### PR TITLE
Fix README and make dev script cross-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ OmniVoice Studio is a local, full-stack application built for fast, high-quality
 
 1. Make sure `ffmpeg` is installed on your system.
 2. Install [Bun](https://bun.sh/) if you don't have it.
-3. Clone and run:
+3. Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you don't have it.
+4. Clone and run:
 
 ```bash
-git clone https://github.com/k2-fsa/OmniVoice.git
-cd OmniVoice
+git clone https://github.com/debpalash/OmniVoice-Studio.git
+cd OmniVoice-Studio
+uv sync
 bun install
 bun dev
 ```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "turbo run dev //#dev:api",
     "build": "turbo run build",
     "start": "turbo run start",
-    "dev:api": ".venv/bin/uvicorn api:app --host 0.0.0.0 --port 8000 --reload"
+    "dev:api": "uv run uvicorn api:app --host 0.0.0.0 --port 8000 --reload"
   },
   "workspaces": [
     "frontend"


### PR DESCRIPTION
This PR improves setup instructions and fixes a cross-platform issue in the development workflow.

Changes:
- fixed incorrect clone URL and setup steps in README
- clarified backend and frontend startup process
- updated dev:api script to use `uv run` instead of OS-specific path

Reason:
The previous setup instructions could lead to confusion, and the dev script
was not working on Windows due to a hardcoded POSIX path.