### PR TITLE
ci: bypass bun run for node:test (fixes --experimental-strip-types)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
         working-directory: frontend
         run: bunx tsc --noEmit
 
+      # Invoke node directly (not `bun run test`) because `bun run` auto-aliases
+      # `node` to `bun` in script bodies, and bun doesn't support
+      # --experimental-strip-types.
       - name: Run frontend node:test
         working-directory: frontend
-        run: bun run test
+        run: node --experimental-strip-types --no-warnings --test ../tests/frontend/*.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
+      # Node 22 is needed for --experimental-strip-types so node:test can
+      # import .ts files directly from frontend/src/api/*.
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
 
@@ -74,9 +81,12 @@ jobs:
         working-directory: frontend
         run: bunx tsc --noEmit
 
+      # Invoke node directly (not `bun run test`) because `bun run` auto-aliases
+      # `node` to `bun` in script bodies, and bun doesn't support
+      # --experimental-strip-types.
       - name: Run frontend node:test
         working-directory: frontend
-        run: bun run test
+        run: node --experimental-strip-types --no-warnings --test ../tests/frontend/*.test.mjs
 
   build:
     needs: test


### PR DESCRIPTION
## Summary
- `bun run <script>` auto-aliases `node` → `bun` in script bodies. bun rejects `--experimental-strip-types` → CI step fails with `node: bad option`.
- CI step now calls `node` directly from the setup-node@v4 install, skipping bun's script dispatch.
- `release.yml` test gate was missing `setup-node` entirely — added.

## Test plan
- [ ] CI run on this PR passes the `Run frontend node:test` step
- [ ] After merge, retag `v0.2.0` → release.yml test gate passes → matrix build kicks off

🤖 Generated with [Claude Code](https://claude.com/claude-code)