### PR TITLE
fix(release): add missing tauri npm script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --no-warnings --test ../tests/frontend/*.test.mjs",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "tauri": "tauri"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",


### PR DESCRIPTION
## Summary
- tauri-action invokes \`npm run tauri build -- --target <triple>\`. Without a \`tauri\` script in frontend/package.json, all matrix builds failed with \`npm error Missing script: \"tauri\"\`.
- Added \`\"tauri\": \"tauri\"\` — forwards to the \`@tauri-apps/cli\` binary already in devDependencies.

## Failing run
https://github.com/debpalash/OmniVoice-Studio/actions/runs/24795169479 (all 4 matrix jobs failed at same step)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, retag v0.2.0 → matrix jobs reach \`tauri build\` and progress past the missing-script error

🤖 Generated with [Claude Code](https://claude.com/claude-code)