### PR TITLE
fix(release): Linux AppImage FUSE + Windows NSIS→MSI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,12 +176,17 @@ jobs:
       # tauri-action handles: bundle, sign updater payload with the
       # TAURI_SIGNING_PRIVATE_KEY secret, attach to release, update
       # latest.json with per-platform download URLs & signatures.
+      #
+      # APPIMAGE_EXTRACT_AND_RUN=1: GH Actions runners disable FUSE, so the
+      # linuxdeploy AppImage can't mount itself. Setting this env var tells
+      # AppImages to extract-and-run instead, which works without FUSE.
       - name: Build + release (Tauri)
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPIMAGE_EXTRACT_AND_RUN: 1
         with:
           projectPath: frontend
           args: --target ${{ matrix.rust_target }}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app", "nsis", "appimage", "deb"],
+    "targets": ["dmg", "app", "msi", "appimage", "deb"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
Run 24796154889 results:
- macOS arm64 ✅ built
- macOS Intel (still queued — macos-13 runner backlog)
- Linux x64 ❌ \`failed to run linuxdeploy\` — FUSE disabled on runners
- Windows x64 ❌ \`Internal compiler error #12345: error mmapping file (1843463346, 33554432)\` — NSIS 2 GB stub limit; our backend bundle is ~1.7 GB

## Fixes
- **Linux**: \`APPIMAGE_EXTRACT_AND_RUN=1\` env var — AppImages extract-and-run instead of FUSE-mount.
- **Windows**: tauri.conf.json bundle target \`nsis\` → \`msi\`. WiX MSI uses cabinet archives that cope with >2 GB payloads. Tauri auto-downloads WiX 3.11 when it sees the \`msi\` target.

## Test plan
- [ ] CI on this PR passes
- [ ] After merge + retag v0.2.0, Linux + Windows matrix jobs complete; draft release has .AppImage, .deb, .msi, .dmg, .app

🤖 Generated with [Claude Code](https://claude.com/claude-code)