### PR TITLE
fix(release): force per-platform bundles via --bundles CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,21 +98,29 @@ jobs:
             arch: aarch64-apple-darwin
             label: "macOS Apple Silicon"
             rust_target: aarch64-apple-darwin
+            bundles: "app,dmg,updater"
 
           - os: macos-13
             arch: x86_64-apple-darwin
             label: "macOS Intel"
             rust_target: x86_64-apple-darwin
+            bundles: "app,dmg,updater"
 
+          # Windows: force MSI bundling via --bundles. NSIS fails at makensis
+          # because our PyInstaller payload approaches its ~2 GB stub limit.
           - os: windows-2022
             arch: x86_64-pc-windows-msvc
             label: "Windows x64"
             rust_target: x86_64-pc-windows-msvc
+            bundles: "msi,updater"
 
+          # Linux: ship .deb only. AppImage bundling (linuxdeploy) is
+          # unreliable on GH Actions runners even with APPIMAGE_EXTRACT_AND_RUN.
           - os: ubuntu-22.04
             arch: x86_64-unknown-linux-gnu
             label: "Linux x64"
             rust_target: x86_64-unknown-linux-gnu
+            bundles: "deb,updater"
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.label }}
@@ -189,7 +197,7 @@ jobs:
           APPIMAGE_EXTRACT_AND_RUN: 1
         with:
           projectPath: frontend
-          args: --target ${{ matrix.rust_target }}
+          args: --target ${{ matrix.rust_target }} --bundles ${{ matrix.bundles }}
           tagName: ${{ github.ref_name }}
           releaseName: "OmniVoice Studio ${{ github.ref_name }}"
           releaseBody: "Auto-generated release. See commit log for changes."

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app", "msi", "appimage", "deb"],
+    "targets": ["dmg", "app", "msi", "deb"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
Run 24797827082 showed:
- macOS arm64 ✅
- macOS Intel: queued (runner backlog)
- Linux: ❌ \`failed to run linuxdeploy\` (APPIMAGE_EXTRACT_AND_RUN didn't help)
- Windows: ❌ NSIS still ran despite tauri.conf.json bundling only \`msi\` — tauri seems to ignore the config filter

## Fixes
Pass \`--bundles\` explicitly per-platform from the matrix:
- macOS: \`app,dmg,updater\`
- Windows: \`msi,updater\` (avoids NSIS's ~2 GB stub limit)
- Linux: \`deb,updater\` (drops unreliable AppImage/linuxdeploy)

Also removed \`appimage\` from tauri.conf.json's \`bundle.targets\` to keep config + CLI consistent.

## Test plan
- [ ] CI on this PR passes
- [ ] After merge + retag v0.2.0: all 4 matrix jobs complete, draft release has .app, .dmg, .msi, .deb

🤖 Generated with [Claude Code](https://claude.com/claude-code)