### PR TITLE
ci: opt JavaScript actions into Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Run all JavaScript actions on Node 24 (GH deprecates Node 20 in Sep 2026).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Tests (backend + frontend)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: write    # needed to attach artifacts + updater manifest to GH Release
 
+env:
+  # Run all JavaScript actions on Node 24 (GH deprecates Node 20 in Sep 2026).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Fast gating job — runs backend pytest + frontend node:test + tsc on a
   # single Linux runner. The matrix build below waits on this via `needs:`


### PR DESCRIPTION
## Summary
Every run currently prints:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5, astral-sh/setup-uv@v3, oven-sh/setup-bun@v1.

Set \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` at workflow level in both \`ci.yml\` and \`release.yml\`. All JavaScript actions run on Node 24 now; the deprecation warning disappears.

Our own test script still pins Node 22 via \`actions/setup-node@v4\` because \`--experimental-strip-types\` isn't available on Node 20.

## Test plan
- [ ] CI on this PR passes
- [ ] Deprecation warning gone from the run summary