### PR TITLE
ci: rust cache for Tauri builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,15 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
+      # Cache ~/.cargo/registry + {target}/ per rust_target. Cargo dep
+      # compile is the long pole of the build — cold is ~5-7 min, warm
+      # drops to ~1-2 min.
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: frontend/src-tauri -> target
+          key: ${{ matrix.rust_target }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
 


### PR DESCRIPTION
Adds Swatinem/rust-cache@v2 to release.yml. Cold matrix build stays ~5-7 min per platform; warm builds (same rust_target) drop to ~1-2 min.