### PR TITLE
feat(release): add Linux AppImage bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,13 +127,16 @@ jobs:
             rust_target: x86_64-pc-windows-msvc
             bundles: "msi,updater"
 
-          # Linux: ship .deb only. AppImage bundling (linuxdeploy) is
-          # unreliable on GH Actions runners even with APPIMAGE_EXTRACT_AND_RUN.
+          # Linux: ship .deb + .AppImage. AppImage is universal (no distro
+          # package-manager dep), runs on any glibc-2.31+ host. Now viable
+          # because the thin uv-venv installer is ~10 MB (vs the prior ~2 GB
+          # PyInstaller payload that exceeded linuxdeploy limits). FUSE
+          # unavailability on GH runners handled via APPIMAGE_EXTRACT_AND_RUN=1.
           - os: ubuntu-22.04
             arch: x86_64-unknown-linux-gnu
             label: "Linux x64"
             rust_target: x86_64-unknown-linux-gnu
-            bundles: "deb,updater"
+            bundles: "deb,appimage,updater"
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.label }}
@@ -204,6 +207,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # GH runners disable FUSE, so linuxdeploy's AppImage can't mount
+          # itself at bundle time. This env tells linuxdeploy to extract-and-run
+          # instead, which works without FUSE.
+          APPIMAGE_EXTRACT_AND_RUN: 1
         with:
           projectPath: frontend
           args: --target ${{ matrix.rust_target }} --bundles ${{ matrix.bundles }}

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app", "msi", "deb"],
+    "targets": ["dmg", "app", "msi", "deb", "appimage"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
AppImage back on the matrix. Was broken before because linuxdeploy couldn't FUSE-mount on GH runners + the 2 GB PyInstaller payload tripped its internal limits. Now viable: thin uv-venv installer + `APPIMAGE_EXTRACT_AND_RUN=1` bypass.

Linux bundles: deb + appimage + updater.