### PR TITLE
feat(bootstrap): splash UI with live progress during first-run setup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "flate2",
  "libc",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -3,8 +3,9 @@ use std::io::{self, Read};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use serde::Serialize;
 use tauri::Manager;
 
 // Unique port range (3900-3902) chosen to avoid common conflicts:
@@ -20,6 +21,47 @@ const UV_VERSION: &str = "0.11.7";
 
 pub struct BackendState {
     pub process: Mutex<Option<Child>>,
+}
+
+// ── Bootstrap progress (for the React splash screen) ─────────────────────
+
+#[derive(Clone, Serialize, Debug)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+pub enum BootstrapStage {
+    /// Working out whether we need to bootstrap at all.
+    Checking,
+    /// Fetching the standalone `uv` binary from astral-sh/uv releases.
+    DownloadingUv { percent: Option<u8> },
+    /// Creating the Python 3.11 venv.
+    CreatingVenv,
+    /// Running `uv sync --frozen --no-dev`. Biggest time sink on first run
+    /// (~5-10 min to pull torch + whisperx + faster-whisper + demucs).
+    InstallingDeps,
+    /// Venv ready, spawning uvicorn. Should be <5 s.
+    StartingBackend,
+    /// Backend is listening and healthy. Frontend can leave the splash.
+    Ready,
+    /// Something blew up; message carries the reason.
+    Failed { message: String },
+}
+
+pub struct BootstrapState {
+    pub stage: Arc<Mutex<BootstrapStage>>,
+}
+
+fn set_stage(state: &Arc<Mutex<BootstrapStage>>, stage: BootstrapStage) {
+    if let Ok(mut guard) = state.lock() {
+        *guard = stage;
+    }
+}
+
+#[tauri::command]
+fn bootstrap_status(state: tauri::State<'_, BootstrapState>) -> BootstrapStage {
+    state
+        .stage
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or(BootstrapStage::Checking)
 }
 
 // ── Port probing ──────────────────────────────────────────────────────────
@@ -246,7 +288,17 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
 /// the behaviour of `bun run dev`). Otherwise copy the bundled pyproject.toml
 /// + uv.lock + backend/ from Tauri resources into `app_local_data_dir/project`
 /// and run `uv venv` + `uv sync --frozen --no-dev` there.
-fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<(PathBuf, PathBuf)> {
+fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Option<&Arc<Mutex<BootstrapStage>>>) -> Option<(PathBuf, PathBuf)> {
+    let fail = |progress: Option<&Arc<Mutex<BootstrapStage>>>, msg: &str| {
+        log::error!("{}", msg);
+        if let Some(p) = progress {
+            set_stage(p, BootstrapStage::Failed { message: msg.to_string() });
+        }
+    };
+    if let Some(p) = progress {
+        set_stage(p, BootstrapStage::Checking);
+    }
+
     if let Some(dev_root) = find_dev_project_root() {
         let dev_venv = dev_root.join(".venv");
         let dev_py = venv_python_path(&dev_venv);
@@ -273,28 +325,26 @@ fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<(PathBuf,
     let resource_uvlock = resource_dir.join("uv.lock");
     let resource_backend = resource_dir.join("backend");
     if !resource_pyproject.is_file() || !resource_backend.is_dir() {
-        log::warn!(
+        fail(progress, &format!(
             "Missing bootstrap resources (pyproject={}, backend={})",
-            resource_pyproject.display(),
-            resource_backend.display()
-        );
+            resource_pyproject.display(), resource_backend.display()));
         return None;
     }
 
     log::info!("First-run venv bootstrap in {}", project_dir.display());
     if let Err(e) = fs::create_dir_all(&project_dir) {
-        log::error!("mkdir {} failed: {}", project_dir.display(), e);
+        fail(progress, &format!("mkdir {} failed: {}", project_dir.display(), e));
         return None;
     }
     if let Err(e) = fs::copy(&resource_pyproject, project_dir.join("pyproject.toml")) {
-        log::error!("copy pyproject.toml: {}", e);
+        fail(progress, &format!("copy pyproject.toml: {}", e));
         return None;
     }
     if resource_uvlock.is_file() {
         let _ = fs::copy(&resource_uvlock, project_dir.join("uv.lock"));
     }
     if let Err(e) = copy_dir_recursive(&resource_backend, &backend_dir) {
-        log::error!("copy backend/: {}", e);
+        fail(progress, &format!("copy backend/: {}", e));
         return None;
     }
 
@@ -302,31 +352,42 @@ fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<(PathBuf,
     // standalone binary into `app_data/tools`.
     let uv_path = match Command::new("uv").arg("--version").output() {
         Ok(_) => PathBuf::from("uv"),
-        Err(_) => match install_uv_standalone(&app_data.join("tools")) {
-            Ok(p) => p,
-            Err(e) => {
-                log::error!("uv install failed: {}", e);
-                return None;
+        Err(_) => {
+            if let Some(p) = progress {
+                set_stage(p, BootstrapStage::DownloadingUv { percent: None });
             }
-        },
+            match install_uv_standalone(&app_data.join("tools")) {
+                Ok(p) => p,
+                Err(e) => {
+                    fail(progress, &format!("uv install failed: {}", e));
+                    return None;
+                }
+            }
+        }
     };
     log::info!("Bootstrap uv: {}", uv_path.display());
 
+    if let Some(p) = progress {
+        set_stage(p, BootstrapStage::CreatingVenv);
+    }
     let status = Command::new(&uv_path)
         .args(["venv", "--python", "3.11"])
         .current_dir(&project_dir)
         .status();
     if !matches!(status, Ok(s) if s.success()) {
-        log::error!("uv venv failed: {:?}", status);
+        fail(progress, &format!("uv venv failed: {:?}", status));
         return None;
     }
 
+    if let Some(p) = progress {
+        set_stage(p, BootstrapStage::InstallingDeps);
+    }
     let sync_status = Command::new(&uv_path)
         .args(["sync", "--frozen", "--no-dev"])
         .current_dir(&project_dir)
         .status();
     if !matches!(sync_status, Ok(s) if s.success()) {
-        log::error!("uv sync failed: {:?}", sync_status);
+        fail(progress, &format!("uv sync failed: {:?}", sync_status));
         return None;
     }
 
@@ -359,7 +420,7 @@ fn backend_log_path() -> PathBuf {
 /// Stage the bundled ffmpeg binary and return its absolute path. The path is
 /// exported via `OMNIVOICE_FFMPEG` so the Python backend uses it over a
 /// system install. Returns None if the bundled binary isn't present.
-fn find_bundled_ffmpeg<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<PathBuf> {
+fn find_bundled_ffmpeg<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> Option<PathBuf> {
     let dir = app.path().resource_dir().ok()?;
     let candidates = [
         dir.join("bin/ffmpeg"),
@@ -379,7 +440,7 @@ fn find_bundled_ffmpeg<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<PathBuf
 
 // ── Spawn the backend via the bootstrapped venv Python ────────────────────
 
-fn spawn_backend<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<Child> {
+fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Option<&Arc<Mutex<BootstrapStage>>>) -> Option<Child> {
     let log_path = backend_log_path();
     let err_path = log_path.with_file_name("backend_err.log");
     log::info!(
@@ -388,13 +449,16 @@ fn spawn_backend<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<Child> {
         err_path.display(),
     );
 
-    let (python, backend_dir) = match ensure_venv_ready(app) {
+    let (python, backend_dir) = match ensure_venv_ready(app, progress) {
         Some(x) => x,
         None => {
             log::error!("Venv bootstrap failed — backend not started");
             return None;
         }
     };
+    if let Some(p) = progress {
+        set_stage(p, BootstrapStage::StartingBackend);
+    }
 
     let stdout_file = fs::File::create(&log_path).ok();
     let stderr_file = fs::File::create(&err_path).ok();
@@ -454,6 +518,7 @@ fn spawn_backend<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<Child> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![bootstrap_status])
         .setup(|app| {
             app.handle().plugin(tauri_plugin_dialog::init())?;
             app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
@@ -472,24 +537,37 @@ pub fn run() {
                     .build(),
             )?;
 
-            // ── Port-reuse dance ──
-            // 1. TAURI_SKIP_BACKEND=1 → never spawn (for devs running uvicorn manually).
-            // 2. Port already serving a healthy OmniVoice backend → attach so
-            //    you can keep a manual `uv run uvicorn` running alongside
-            //    `bun run tauri dev`.
-            // 3. Otherwise → spawn (kill orphan first if port held by corpse).
-            //    spawn_backend triggers the first-run venv bootstrap if needed.
-            let skip_spawn = std::env::var("TAURI_SKIP_BACKEND").is_ok();
-            let child = if skip_spawn {
-                log::info!("TAURI_SKIP_BACKEND set — not spawning");
-                None
-            } else if backend_healthy(BACKEND_PORT) {
-                log::info!(
-                    "Port {} already serving OmniVoice backend — attaching",
-                    BACKEND_PORT
-                );
-                None
-            } else {
+            // Bootstrap state is published via the `bootstrap_status` Tauri
+            // command so the React splash can poll it while we work.
+            let bootstrap = BootstrapState {
+                stage: Arc::new(Mutex::new(BootstrapStage::Checking)),
+            };
+            let stage_handle = bootstrap.stage.clone();
+            app.manage(bootstrap);
+            app.manage(BackendState {
+                process: Mutex::new(None),
+            });
+
+            // Spawn the bootstrap + backend launch in a background thread so
+            // setup() returns immediately and the webview can render the
+            // splash screen. Previously this was synchronous, so on first
+            // launch the webview was blank for 5-10 minutes.
+            let app_handle = app.handle().clone();
+            std::thread::spawn(move || {
+                let skip_spawn = std::env::var("TAURI_SKIP_BACKEND").is_ok();
+                if skip_spawn {
+                    log::info!("TAURI_SKIP_BACKEND set — not spawning");
+                    set_stage(&stage_handle, BootstrapStage::Ready);
+                    return;
+                }
+                if backend_healthy(BACKEND_PORT) {
+                    log::info!(
+                        "Port {} already serving OmniVoice backend — attaching",
+                        BACKEND_PORT
+                    );
+                    set_stage(&stage_handle, BootstrapStage::Ready);
+                    return;
+                }
                 if port_in_use(BACKEND_PORT) {
                     log::warn!(
                         "Port {} in use — taking ownership (killing whatever's there)",
@@ -498,11 +576,28 @@ pub fn run() {
                     kill_orphan_on_port(BACKEND_PORT);
                     std::thread::sleep(Duration::from_millis(500));
                 }
-                spawn_backend(app)
-            };
-
-            app.manage(BackendState {
-                process: Mutex::new(child),
+                let child = spawn_backend(&app_handle, Some(&stage_handle));
+                if let Ok(mut guard) = app_handle.state::<BackendState>().process.lock() {
+                    *guard = child;
+                }
+                // Poll the port until the backend actually responds, then flip
+                // the splash to Ready. Bounded wait — if it never comes up we
+                // stop after ~60 s and leave the stage on StartingBackend so
+                // the UI can surface an error.
+                let start = std::time::Instant::now();
+                while start.elapsed() < Duration::from_secs(60) {
+                    if backend_healthy(BACKEND_PORT) {
+                        set_stage(&stage_handle, BootstrapStage::Ready);
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+                set_stage(
+                    &stage_handle,
+                    BootstrapStage::Failed {
+                        message: "Backend did not respond within 60 s".to_string(),
+                    },
+                );
             });
             Ok(())
         })

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ const ProjectsPage = lazy(() => import('./pages/Projects'));
 import Header from './components/Header';
 import NavRail from './components/NavRail';
 import ErrorBoundary from './components/ErrorBoundary';
+import { BootstrapSplash, useBootstrapStage } from './components/BootstrapSplash';
 
 const LazyFallback = () => <div style={{ padding: 12, color: '#6b6657', fontSize: '0.7rem' }}>Loading…</div>;
 
@@ -153,6 +154,12 @@ const playPing = () => {
 };
 
 function App() {
+  // First-run bootstrap: Rust spawns uv sync in a background thread and
+  // publishes progress via the `bootstrap_status` Tauri command. Hook below
+  // polls every 1 s; until `ready`, we render BootstrapSplash instead of the
+  // normal app shell, so the user sees real progress instead of a hung UI.
+  const { stage: bootstrapStage, message: bootstrapMessage } = useBootstrapStage();
+
   // UI navigation state now lives in the Zustand `uiSlice` (Phase 2.2).
   // Mode + uiScale + sidebar-collapsed persist across reloads automatically
   // via the store's `partialize`; active project / voice ids stay transient.
@@ -1956,6 +1963,12 @@ function App() {
         </Suspense>
       </div>
     );
+  }
+
+  // Block the main UI until Rust reports the backend is ready. In dev web
+  // (no Tauri), the hook returns 'ready' immediately so this is a no-op.
+  if (bootstrapStage !== 'ready') {
+    return <BootstrapSplash stage={bootstrapStage} message={bootstrapMessage} />;
   }
 
   return (

--- a/frontend/src/components/BootstrapSplash.css
+++ b/frontend/src/components/BootstrapSplash.css
@@ -1,0 +1,109 @@
+.bootstrap-splash {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: var(--chrome-bg, #141414);
+  color: var(--chrome-fg, #eee);
+  font-family: 'Inter Variable', 'Inter', system-ui, sans-serif;
+  z-index: 9999;
+  padding: 2rem;
+}
+
+.bootstrap-splash__card {
+  width: 100%;
+  max-width: 560px;
+  background: color-mix(in srgb, var(--chrome-fg, #eee) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--chrome-fg, #eee) 10%, transparent);
+  border-radius: 14px;
+  padding: 2rem;
+  text-align: left;
+}
+
+.bootstrap-splash__card h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.bootstrap-splash__status {
+  margin: 0 0 1.25rem;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.bootstrap-splash__bar {
+  height: 4px;
+  width: 100%;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--chrome-fg, #eee) 8%, transparent);
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+}
+
+.bootstrap-splash__bar-fill {
+  height: 100%;
+  background: var(--chrome-accent, #8ec07c);
+  transition: width 0.4s ease;
+}
+
+.bootstrap-splash__steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.bootstrap-splash__steps li {
+  padding-left: 1.5rem;
+  position: relative;
+  opacity: 0.5;
+}
+
+.bootstrap-splash__steps li::before {
+  content: '○';
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.bootstrap-splash__steps li.done {
+  opacity: 0.6;
+}
+
+.bootstrap-splash__steps li.done::before {
+  content: '✓';
+  color: var(--chrome-accent, #8ec07c);
+}
+
+.bootstrap-splash__steps li.active {
+  opacity: 1;
+  font-weight: 500;
+}
+
+.bootstrap-splash__steps li.active::before {
+  content: '●';
+  color: var(--chrome-accent, #8ec07c);
+  animation: bootstrap-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes bootstrap-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.bootstrap-splash__error {
+  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  font-size: 0.8rem;
+  background: color-mix(in srgb, #ef4444 12%, transparent);
+  border: 1px solid color-mix(in srgb, #ef4444 35%, transparent);
+  color: #fca5a5;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -1,0 +1,115 @@
+/**
+ * First-run bootstrap splash.
+ *
+ * The Rust side spawns the venv setup (uv install + `uv sync --frozen`) in a
+ * background thread and publishes progress via the `bootstrap_status` Tauri
+ * command. This component polls that command every 1 s and renders the
+ * current stage until the backend is healthy (stage === 'ready'), then
+ * unmounts and lets the main UI take over.
+ */
+import { useEffect, useState } from 'react';
+import './BootstrapSplash.css';
+
+const STAGE_LABEL = {
+  checking:          'Checking environment…',
+  downloading_uv:    'Downloading uv (Python package manager)…',
+  creating_venv:     'Creating Python virtual environment…',
+  installing_deps:   'Installing dependencies — this is a one-time setup (5-10 min on first run).',
+  starting_backend:  'Starting backend…',
+  ready:             'Ready',
+  failed:            'Setup failed',
+};
+
+const STEPS = ['checking', 'downloading_uv', 'creating_venv', 'installing_deps', 'starting_backend'];
+
+export function BootstrapSplash({ stage, message }) {
+  const label = STAGE_LABEL[stage] || stage;
+  const stepIndex = Math.max(0, STEPS.indexOf(stage));
+  const isFailed = stage === 'failed';
+
+  return (
+    <div className="bootstrap-splash">
+      <div className="bootstrap-splash__card">
+        <h1>OmniVoice Studio</h1>
+        <p className="bootstrap-splash__status">{label}</p>
+        {isFailed ? (
+          <pre className="bootstrap-splash__error">{message || 'Unknown error'}</pre>
+        ) : (
+          <>
+            <div className="bootstrap-splash__bar">
+              <div
+                className="bootstrap-splash__bar-fill"
+                style={{ width: `${((stepIndex + 1) / STEPS.length) * 100}%` }}
+              />
+            </div>
+            <ol className="bootstrap-splash__steps">
+              {STEPS.map((s, i) => (
+                <li
+                  key={s}
+                  className={
+                    i < stepIndex ? 'done' :
+                    i === stepIndex ? 'active' :
+                    'pending'
+                  }
+                >
+                  {STAGE_LABEL[s]}
+                </li>
+              ))}
+            </ol>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Hook: polls the Rust `bootstrap_status` command every pollMs ms. Returns
+ * the current stage (string) + message. In a non-Tauri context (dev web),
+ * returns 'ready' immediately so the splash never mounts.
+ */
+export function useBootstrapStage(pollMs = 1000) {
+  const [state, setState] = useState({ stage: 'checking', message: null });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') { setState({ stage: 'ready', message: null }); return; }
+    if (!('__TAURI_INTERNALS__' in window)) { setState({ stage: 'ready', message: null }); return; }
+    if (import.meta.env.DEV) { setState({ stage: 'ready', message: null }); return; }
+
+    let cancelled = false;
+    let timer = null;
+    const invoke = async () => {
+      try {
+        const { invoke: tauriInvoke } = await import('@tauri-apps/api/core');
+        return tauriInvoke;
+      } catch {
+        return null;
+      }
+    };
+    (async () => {
+      const tauriInvoke = await invoke();
+      if (!tauriInvoke) { setState({ stage: 'ready', message: null }); return; }
+      const tick = async () => {
+        if (cancelled) return;
+        try {
+          const res = await tauriInvoke('bootstrap_status');
+          if (cancelled) return;
+          // Rust returns { stage: 'ready' } or { stage: 'failed', message: '…' } etc.
+          setState({ stage: res.stage || 'ready', message: res.message || null });
+          if (res.stage !== 'ready' && res.stage !== 'failed') {
+            timer = setTimeout(tick, pollMs);
+          }
+        } catch {
+          setState({ stage: 'ready', message: null });
+        }
+      };
+      tick();
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [pollMs]);
+
+  return state;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.2.2"
+version = "0.2.3"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Fixes v0.2.2 upgrade UX where users saw "Failed to load engines: Load failed" while uv sync ran in the background.

- Rust: BootstrapStage enum + state + `bootstrap_status` command. setup() no longer blocks — bootstrap runs on a thread.
- React: BootstrapSplash component + useBootstrapStage hook. Polls every 1s, blocks main UI until backend healthy.
- Version bump 0.2.2 → 0.2.3.