### PR TITLE
fix: resolve Tauri _up_ resource paths for Windows/Linux MSI bootstrap

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "flate2",
  "libc",

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -418,9 +418,28 @@ fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Opt
     }
 
     let resource_dir = app.path().resource_dir().ok()?;
-    let resource_pyproject = resource_dir.join("pyproject.toml");
-    let resource_uvlock = resource_dir.join("uv.lock");
-    let resource_backend = resource_dir.join("backend");
+
+    // Tauri v2 replaces `../` with `_up_/` in bundled resource paths. So
+    // `../../pyproject.toml` from tauri.conf.json becomes
+    // `$RESOURCE/_up_/_up_/pyproject.toml` on Windows MSI and Linux deb.
+    // macOS .app bundles flatten resources into Contents/Resources/ directly.
+    // Try both layouts so the bootstrap works across all platforms.
+    let flat = resource_dir.clone();
+    let up2  = resource_dir.join("_up_").join("_up_");
+
+    let (resource_pyproject, resource_uvlock, resource_backend) = if flat.join("pyproject.toml").is_file() {
+        (flat.join("pyproject.toml"), flat.join("uv.lock"), flat.join("backend"))
+    } else if up2.join("pyproject.toml").is_file() {
+        (up2.join("pyproject.toml"), up2.join("uv.lock"), up2.join("backend"))
+    } else {
+        fail(progress, &format!(
+            "Missing bootstrap resources — checked flat={} and _up_={}\n  pyproject.toml: flat={}, up2={}",
+            flat.display(), up2.display(),
+            flat.join("pyproject.toml").display(),
+            up2.join("pyproject.toml").display()));
+        return None;
+    };
+
     if !resource_pyproject.is_file() || !resource_backend.is_dir() {
         fail(progress, &format!(
             "Missing bootstrap resources (pyproject={}, backend={})",


### PR DESCRIPTION
## Fixes #28 — v0.2.4 first launch failed on Windows

**Root cause:** Tauri v2 replaces `../` with `_up_/` when bundling resources into MSI/deb installers. The `../../pyproject.toml` config path becomes `$RESOURCE/_up_/_up_/pyproject.toml` at runtime, but the Rust bootstrap only checked the flat `$RESOURCE/pyproject.toml`.

This worked on macOS (`.app` bundles flatten into `Contents/Resources/`) but failed on Windows MSI and Linux deb.

**Fix:** Try both the flat path and the `_up_/_up_/` prefixed path, with diagnostic logging if neither is found.

### Changed
- `frontend/src-tauri/src/lib.rs` — `ensure_venv_ready()` now probes both `$RESOURCE/pyproject.toml` and `$RESOURCE/_up_/_up_/pyproject.toml`

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced bootstrap resource detection to reliably identify and load bundled Python dependencies across different application directory structures.
  * Improved error diagnostics to provide clearer information when required initialization resources cannot be located.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->