### PR TITLE
fix: preflight disk check, realtime download progress, fresh bundle build

### DIFF
--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -113,6 +113,30 @@ async def install_model(req: InstallModelRequest):
             if sys.platform == "win32":
                 dl_kwargs["local_dir_use_symlinks"] = False
 
+            # Emit a 'resolving' heartbeat every 2s while snapshot_download
+            # resolves repo metadata (before any tqdm bars appear).
+            import threading
+            import time as _t
+            _resolving = threading.Event()
+
+            def _heartbeat():
+                _step = 0
+                while not _resolving.is_set():
+                    _resolving.wait(2.0)
+                    if _resolving.is_set():
+                        break
+                    _step += 1
+                    hf_progress.emit({
+                        "repo_id": req.repo_id,
+                        "filename": req.repo_id,
+                        "downloaded": 0, "total": 0, "pct": 0.0,
+                        "phase": "resolving",
+                        "step": _step,
+                    })
+
+            hb = threading.Thread(target=_heartbeat, daemon=True)
+            hb.start()
+
             _max_attempts = 5
             _attempt = 0
             while True:
@@ -136,8 +160,9 @@ async def install_model(req: InstallModelRequest):
                         "attempt": _attempt,
                         "error": str(net_err),
                     })
-                    import time as _t
                     _t.sleep(_backoff)
+            # Stop heartbeat once download completes
+            _resolving.set()
             logger.info("model install done: %s", req.repo_id)
             hf_progress.emit({
                 "repo_id": req.repo_id,
@@ -147,6 +172,7 @@ async def install_model(req: InstallModelRequest):
             })
             invalidate_cache()
         except Exception as e:
+            _resolving.set()
             logger.warning("model install failed for %s: %s", req.repo_id, e)
             hf_progress.emit({
                 "repo_id": req.repo_id,

--- a/backend/api/routers/setup/wizard.py
+++ b/backend/api/routers/setup/wizard.py
@@ -27,8 +27,22 @@ MIN_FREE_GB = 10
 
 
 def _disk_free_gb(path: str) -> float:
+    """Return free GB on the volume containing *path*.
+
+    If *path* doesn't exist yet (e.g. after a fresh wipe), walk up to the
+    nearest existing ancestor so ``shutil.disk_usage`` can still probe the
+    correct mount point.
+    """
     try:
-        return _shutil.disk_usage(path).free / (1024 ** 3)
+        from pathlib import Path
+        p = Path(path).resolve()
+        # Walk up until we find a directory that exists
+        while not p.exists():
+            parent = p.parent
+            if parent == p:  # root
+                break
+            p = parent
+        return _shutil.disk_usage(str(p)).free / (1024 ** 3)
     except Exception:
         return 0.0
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -102,6 +102,16 @@ export function ModelStoreTab({ info, modelBadge }) {
   const tableBodyRef = React.useRef(null);
   // Track download speed per repo: { [repo_id]: { lastBytes, lastTime, speed } }
   const speedRef = React.useRef({});
+  // Tick counter — forces re-render every second while a download is active
+  // so speed/ETA displays update smoothly between SSE events.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const hasActive = Object.values(rowState).some(s =>
+      ['install_start', 'active', 'delete_start'].includes(s.phase));
+    if (!hasActive) return;
+    const iv = setInterval(() => setTick(t => t + 1), 1000);
+    return () => clearInterval(iv);
+  }, [rowState]);
 
   // HF token inline — compact input in the toolbar
   const [hfToken, setHfToken] = useState('');
@@ -341,50 +351,61 @@ export function ModelStoreTab({ info, modelBadge }) {
                   size="xs"
                 />
                 <span className="models-row__progresstext">
-                  {rt.isDeleting
-                    ? 'Removing cached revisions…'
-                    : rt.hasFiles
-                      ? (() => {
-                          const sp = speedRef.current[m.repo_id];
-                          const now = Date.now();
-                          if (sp && rt.totals.downloaded > 0) {
-                            const dt = (now - sp.lastTime) / 1000;
-                            if (dt >= 1) {
-                              sp.speed = Math.max(0, (rt.totals.downloaded - sp.lastBytes) / dt);
-                              sp.lastBytes = rt.totals.downloaded;
-                              sp.lastTime = now;
-                            }
-                          } else {
-                            speedRef.current[m.repo_id] = { lastBytes: rt.totals.downloaded, lastTime: now, speed: 0 };
-                          }
-                          // Prefer backend tqdm rate (available immediately), fall back to client delta
-                          const speed = rt.backendRate > 0 ? rt.backendRate : (sp?.speed || 0);
-                          const remaining = rt.totals.total - rt.totals.downloaded;
-                          const etaSec = speed > 0 ? remaining / speed : 0;
-                          const etaStr = etaSec > 0
-                            ? etaSec < 60 ? `~${Math.ceil(etaSec)}s left`
-                            : etaSec < 3600 ? `~${Math.ceil(etaSec / 60)}m left`
-                            : `~${(etaSec / 3600).toFixed(1)}h left`
-                            : '';
-                          const pctStr = rt.aggPct != null ? `${Math.round(rt.aggPct)}%` : '';
-                          const parts = [
-                            `${fmtBytes(rt.totals.downloaded)} / ${rt.totals.total ? fmtBytes(rt.totals.total) : '?'}`,
-                            pctStr,
-                            speed > 0 ? `${fmtBytes(speed)}/s` : 'measuring speed…',
-                            etaStr || null,
-                          ].filter(Boolean);
-                          const extra = [];
-                          if (rt.fileList.length > 1) {
-                            extra.push(`${rt.totals.done}/${rt.fileList.length} files`);
-                          }
-                          if (rt.activeFilename) {
-                            extra.push(rt.activeFilename.split('/').pop());
-                          }
-                          return extra.length
-                            ? `${parts.join(' · ')}  ⸱  ${extra.join(' · ')}`
-                            : parts.join(' · ');
-                        })()
-                      : rt.phase === 'install_start' ? 'Connecting to HuggingFace…' : 'Preparing download…'}
+                  {(() => {
+                    if (rt.isDeleting) return 'Removing cached revisions…';
+                    if (!rt.hasFiles) return 'Connecting to HuggingFace…';
+
+                    // We have file events — compute speed
+                    const sp = speedRef.current[m.repo_id];
+                    const now = Date.now();
+                    if (sp && rt.totals.downloaded > 0) {
+                      const dt = (now - sp.lastTime) / 1000;
+                      if (dt >= 1) {
+                        sp.speed = Math.max(0, (rt.totals.downloaded - sp.lastBytes) / dt);
+                        sp.lastBytes = rt.totals.downloaded;
+                        sp.lastTime = now;
+                      }
+                    } else {
+                      speedRef.current[m.repo_id] = { lastBytes: rt.totals.downloaded, lastTime: now, speed: 0 };
+                    }
+                    const speed = rt.backendRate > 0 ? rt.backendRate : (sp?.speed || 0);
+
+                    // If total is unknown and nothing downloaded yet → still resolving
+                    if (rt.totals.total === 0 && rt.totals.downloaded === 0) {
+                      const activeFile = rt.activeFilename?.split('/').pop();
+                      return activeFile
+                        ? `Resolving ${rt.fileList.length} file${rt.fileList.length > 1 ? 's' : ''}… · ${activeFile}`
+                        : `Resolving ${rt.fileList.length} file${rt.fileList.length > 1 ? 's' : ''}…`;
+                    }
+
+                    // Build the info line
+                    const remaining = rt.totals.total - rt.totals.downloaded;
+                    const etaSec = speed > 0 && rt.totals.total > 0 ? remaining / speed : 0;
+                    const etaStr = etaSec > 0
+                      ? etaSec < 60 ? `~${Math.ceil(etaSec)}s`
+                      : etaSec < 3600 ? `~${Math.ceil(etaSec / 60)}m`
+                      : `~${(etaSec / 3600).toFixed(1)}h`
+                      : '';
+                    const dlStr = fmtBytes(rt.totals.downloaded) || '0 B';
+                    const totalStr = rt.totals.total > 0 ? fmtBytes(rt.totals.total) : '…';
+                    const pctStr = rt.aggPct != null && rt.aggPct > 0 ? `${Math.round(rt.aggPct)}%` : '';
+                    const speedStr = speed > 0 ? `${fmtBytes(speed)}/s` : '';
+
+                    const parts = [
+                      `${dlStr} / ${totalStr}`,
+                      pctStr,
+                      speedStr || (rt.totals.downloaded > 0 ? 'measuring…' : ''),
+                      etaStr,
+                    ].filter(Boolean);
+
+                    const extra = [];
+                    if (rt.fileList.length > 1) extra.push(`${rt.totals.done}/${rt.fileList.length} files`);
+                    if (rt.activeFilename) extra.push(rt.activeFilename.split('/').pop());
+
+                    return extra.length
+                      ? `${parts.join(' · ')}  ⸱  ${extra.join(' · ')}`
+                      : parts.join(' · ');
+                  })()}
                 </span>
               </div>
             )}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -58,7 +58,8 @@ function Row({ label, value, mono }) {
 }
 
 function fmtBytes(n) {
-  if (!n || n <= 0) return '—';
+  if (n == null || n < 0) return '—';
+  if (n === 0) return '0 B';
   if (n >= 1024 ** 3) return `${(n / 1024 ** 3).toFixed(2)} GB`;
   if (n >= 1024 ** 2) return `${(n / 1024 ** 2).toFixed(1)} MB`;
   return `${Math.round(n / 1024)} KB`;
@@ -157,6 +158,13 @@ export function ModelStoreTab({ info, modelBadge }) {
           // touching per-file accounting.
           if (ev.phase === 'install_start' || ev.phase === 'delete_start') {
             return { ...prev, [ev.repo_id]: { phase: ev.phase, files: {}, error: null } };
+          }
+          // Heartbeat from backend while resolving repo metadata
+          if (ev.phase === 'resolving') {
+            return { ...prev, [ev.repo_id]: { ...cur, phase: 'resolving', resolvingStep: ev.step || 0 } };
+          }
+          if (ev.phase === 'install_retry') {
+            return { ...prev, [ev.repo_id]: { ...cur, phase: 'install_retry', retryAttempt: ev.attempt, error: ev.error } };
           }
           if (ev.phase === 'install_done') {
             return { ...prev, [ev.repo_id]: { ...cur, phase: 'install_done' } };
@@ -295,7 +303,7 @@ export function ModelStoreTab({ info, modelBadge }) {
       .reduce((s, [, f]) => s + f.rate, 0);
     const hasFiles = fileList.length > 0;
     const aggPct = totals.total > 0 ? (totals.downloaded / totals.total) * 100 : null;
-    const showBar = phase === 'install_start' || phase === 'active' || phase === 'delete_start';
+    const showBar = ['install_start', 'resolving', 'install_retry', 'active', 'delete_start'].includes(phase);
     const activeFilename = fileList.find(([, f]) => f.phase !== 'done')?.[0];
     const unsupported = m.supported === false;
 
@@ -353,7 +361,16 @@ export function ModelStoreTab({ info, modelBadge }) {
                 <span className="models-row__progresstext">
                   {(() => {
                     if (rt.isDeleting) return 'Removing cached revisions…';
-                    if (!rt.hasFiles) return 'Connecting to HuggingFace…';
+                    if (!rt.hasFiles) {
+                      if (rt.phase === 'resolving') {
+                        const dots = '.'.repeat((rt.rs?.resolvingStep || 0) % 4);
+                        return `Resolving repo metadata${dots}`;
+                      }
+                      if (rt.phase === 'install_retry') {
+                        return `Retry attempt ${rt.rs?.retryAttempt || '?'} — ${rt.rs?.error || 'reconnecting'}`;
+                      }
+                      return 'Connecting to HuggingFace…';
+                    }
 
                     // We have file events — compute speed
                     const sp = speedRef.current[m.repo_id];

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -94,12 +94,26 @@ if [ "$SKIP_BUILD" = false ]; then
   APP_BUNDLE="${TAURI_DIR}/target/debug/bundle/macos/${APP_NAME}.app"
   [ -d "$APP_BUNDLE" ] && rm -rf "$APP_BUNDLE"
 
-  cd frontend
   # The build creates the .app bundle successfully, but then fails trying
   # to sign the updater artifact (no TAURI_SIGNING_PRIVATE_KEY). The .app
-  # itself is fine — tolerate the exit code.
-  bunx tauri build --debug 2>&1 || true
+  # itself is fine — tolerate ONLY that specific error.
+  BUILD_LOG=$(mktemp)
+  cd frontend
+  set +e
+  bunx tauri build --debug 2>&1 | tee "$BUILD_LOG"
+  BUILD_EXIT=$?
+  set -e
   cd ..
+  if [ $BUILD_EXIT -ne 0 ]; then
+    if grep -qi "TAURI_SIGNING_PRIVATE_KEY\|private key" "$BUILD_LOG"; then
+      echo "⚠️  Updater signing skipped (no TAURI_SIGNING_PRIVATE_KEY) — .app is fine."
+    else
+      echo "❌ Build failed with exit code $BUILD_EXIT"
+      rm -f "$BUILD_LOG"
+      exit $BUILD_EXIT
+    fi
+  fi
+  rm -f "$BUILD_LOG"
 
   if [ -d "${TAURI_DIR}/target/debug/bundle/macos/${APP_NAME}.app" ]; then
     echo "✅ Build complete."

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -88,19 +88,30 @@ fi
 # ── Build debug binary ─────────────────────────────────────────────────────
 if [ "$SKIP_BUILD" = false ]; then
   echo ""
-  echo "🔨 Building debug binary (this takes 1-3 min first time)..."
+  echo "🔨 Building debug bundle (this takes 1-3 min first time)..."
+
+  # Remove stale bundle so we never accidentally launch old code
+  APP_BUNDLE="${TAURI_DIR}/target/debug/bundle/macos/${APP_NAME}.app"
+  [ -d "$APP_BUNDLE" ] && rm -rf "$APP_BUNDLE"
+
   cd frontend
-  # --no-bundle skips DMG/updater so we don't need TAURI_SIGNING_PRIVATE_KEY
-  bunx tauri build --debug --no-bundle 2>&1
+  # The build creates the .app bundle successfully, but then fails trying
+  # to sign the updater artifact (no TAURI_SIGNING_PRIVATE_KEY). The .app
+  # itself is fine — tolerate the exit code.
+  bunx tauri build --debug 2>&1 || true
   cd ..
-  echo "✅ Build complete."
+
+  if [ -d "${TAURI_DIR}/target/debug/bundle/macos/${APP_NAME}.app" ]; then
+    echo "✅ Build complete."
+  else
+    echo "❌ Build failed — no .app bundle produced."
+    exit 1
+  fi
 else
   echo "⏭️  Skipping build (--skip-build)"
 fi
 
 # ── Find and launch the app ────────────────────────────────────────────────
-# --no-bundle produces the raw binary, not the .app bundle
-RAW_BINARY="${TAURI_DIR}/target/debug/app"
 APP_BUNDLE="${TAURI_DIR}/target/debug/bundle/macos/${APP_NAME}.app"
 
 if [ -d "$APP_BUNDLE" ]; then
@@ -108,13 +119,8 @@ if [ -d "$APP_BUNDLE" ]; then
   echo "🚀 Launching ${APP_NAME} (.app bundle)..."
   echo "   Bundle: ${APP_BUNDLE}"
   open "$APP_BUNDLE"
-elif [ -f "$RAW_BINARY" ]; then
-  echo ""
-  echo "🚀 Launching ${APP_NAME} (raw binary)..."
-  echo "   Binary: ${RAW_BINARY}"
-  "$RAW_BINARY" &
 else
-  echo "❌ No binary found. Run without --skip-build first."
+  echo "❌ No bundle found. Run without --skip-build first."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes three issues with the bootstrap/setup wizard experience:

### 1. Disk space check reports 0.0 GB after fresh wipe
`shutil.disk_usage()` throws on non-existent paths. After `desktop-prod` wipes `~/.cache/huggingface`, the preflight reported 0 GB free. Now walks up to the nearest existing ancestor directory to probe the actual volume.

### 2. Download progress lacks realtime speed/ETA
- Backend tqdm hook now includes `rate` (bytes/sec) in every SSE event
- Frontend uses backend rate immediately — no 2s client-side warmup delay
- Shows `Connecting to HuggingFace…` → `Resolving N files…` → `245 MB / 2.4 GB · 10% · 12.5 MB/s · ~3m` at each stage
- 1s tick timer forces re-render so speed/ETA updates between SSE events

### 3. desktop-prod launched stale .app bundle
`--no-bundle` built only the raw binary but the script still found and launched the OLD cached `.app` from a prior build. Now builds the full bundle (tolerating the non-fatal signing error) and deletes the old bundle first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disk free-space check now handles non-existent cache paths by resolving to the nearest existing mount point.
  * Progress text fixes: show "0 B" for zero bytes, only show percentage when >0, and simplify ETA wording.

* **Improvements**
  * Model install/download progress now refreshes every second and shows explicit "Resolving…" and "Retry attempt…" states when applicable.
  * Periodic "resolving" progress updates emitted during initial metadata resolution.

* **Chores**
  * macOS debug build process updated to produce and validate a .app bundle exclusively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->