### PR TITLE
feat: add CosyVoice 3 TTS backend, engine platform matrix, CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,201 @@
+# Contributing to OmniVoice Studio
+
+Thanks for your interest in improving OmniVoice Studio! This guide covers everything you need to get started.
+
+## Quick Links
+
+| | |
+|---|---|
+| 💬 **Chat** | [Discord](https://discord.gg/aRRdVj3de7) |
+| 🐛 **Bugs** | [GitHub Issues](https://github.com/debpalash/OmniVoice-Studio/issues) |
+| 🏷️ **Good First Issues** | [Filtered list](https://github.com/debpalash/OmniVoice-Studio/labels/good%20first%20issue) |
+| 📋 **Roadmap** | [README → Roadmap](README.md#roadmap) |
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+- [Git](https://git-scm.com/)
+- [Bun](https://bun.sh/) (frontend package manager)
+- [uv](https://docs.astral.sh/uv/) (Python environment manager)
+- [ffmpeg](https://ffmpeg.org/) (audio/video processing)
+- Python 3.10+ (managed automatically by `uv`)
+
+### Clone & Run
+
+```bash
+git clone https://github.com/debpalash/OmniVoice-Studio.git
+cd OmniVoice-Studio
+bun install
+bun run dev
+```
+
+This starts both services:
+
+| Service | URL | What it does |
+|---------|-----|---|
+| **Backend** | `localhost:3900` | FastAPI server — TTS, ASR, diarization, dubbing pipeline |
+| **Frontend** | `localhost:3901` | React + Vite UI |
+
+### Desktop App (Tauri)
+
+```bash
+bun run desktop
+```
+
+Requires [Rust](https://rustup.rs/) and platform-specific Tauri dependencies — see the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/).
+
+---
+
+## Project Structure
+
+```
+OmniVoice-Studio/
+├── backend/                 # Python FastAPI server
+│   ├── api/                 # Route handlers
+│   ├── core/                # Config, prefs, constants
+│   └── services/            # TTS engines, ASR, dubbing, audio DSP
+│       └── tts_backend.py   # ← Multi-engine TTS registry
+├── frontend/                # React + Vite
+│   ├── src/
+│   │   ├── components/      # UI components
+│   │   ├── hooks/           # Custom React hooks
+│   │   ├── stores/          # Zustand state slices
+│   │   └── utils/           # Shared utilities
+│   └── src-tauri/           # Rust/Tauri desktop shell
+├── deploy/                  # Docker, CI configs
+├── docs/                    # Screenshots, MCP config
+└── scripts/                 # Build & release scripts
+```
+
+---
+
+## How to Contribute
+
+### Bug Reports
+
+Open an [issue](https://github.com/debpalash/OmniVoice-Studio/issues/new) with:
+
+1. **What happened** vs **what you expected**
+2. **Steps to reproduce**
+3. **OS, GPU, and Python version** (find in Settings → Logs)
+4. **Error logs** (Settings → Logs → copy relevant lines)
+
+### Pull Requests
+
+1. **Fork** the repo and create a branch from `main`
+2. **Keep PRs focused** — one feature or fix per PR
+3. **Run tests** before pushing:
+   ```bash
+   # Backend tests
+   uv run pytest backend/ -x -q
+
+   # Frontend build check
+   cd frontend && npx vite build --mode development
+   ```
+4. **Write a clear PR title** — it becomes the squash-merge commit message
+5. **Don't include** local machine stats, file paths, or private system info in PR descriptions
+
+### Adding a New TTS Engine
+
+OmniVoice's TTS backend is a plugin registry. Adding a new engine takes ~50 lines:
+
+1. Open `backend/services/tts_backend.py`
+2. Create a class extending `TTSBackend`:
+
+```python
+class MyEngineBackend(TTSBackend):
+    id = "my-engine"
+    display_name = "My Engine (description)"
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        try:
+            import my_engine  # noqa: F401
+            return True, "ready"
+        except ImportError:
+            return False, "my_engine not installed. pip install my-engine"
+
+    @property
+    def sample_rate(self) -> int:
+        return 24000
+
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["en", "zh"]
+
+    def generate(self, text: str, **kw) -> torch.Tensor:
+        # ... call your engine, return [1, num_samples] tensor
+```
+
+3. Register it in `_REGISTRY` at the bottom of the file
+4. That's it — it auto-appears in Settings → TTS Engine
+
+---
+
+## Code Style
+
+### Python (Backend)
+
+- **Formatter**: We don't enforce one globally — match the style of the file you're editing
+- **Logging**: Use `logger.warning()` / `logger.error()`, never bare `print()`
+- **Exceptions**: Avoid bare `except: pass` — catch specific exceptions
+- **Type hints**: Use them for public API functions and class methods
+
+### JavaScript/React (Frontend)
+
+- **Components**: Functional components with hooks
+- **State**: Zustand stores in `src/stores/`, organized by slice
+- **CSS**: Vanilla CSS in component-level files — no Tailwind
+- **Naming**: `PascalCase` for components, `camelCase` for hooks and utils
+
+### Rust (Tauri)
+
+- **Format**: `cargo fmt` before committing
+- **Modules**: One concern per file (`bootstrap.rs`, `tools.rs`, `config.rs`, `commands.rs`)
+
+---
+
+## Commit Messages
+
+Write clear, concise messages. The PR title becomes the squash-merge commit.
+
+```
+good: fix: prevent CUDA OOM during concurrent transcription + TTS
+good: feat: add CosyVoice 3 TTS backend adapter
+good: docs: add platform compatibility matrix to README
+
+bad:  fixed stuff
+bad:  update
+bad:  WIP
+```
+
+---
+
+## Testing
+
+```bash
+# Run all backend tests
+uv run pytest backend/ -x -q
+
+# Run a specific test file
+uv run pytest backend/tests/test_api.py -x -q
+
+# Frontend build validation (no test suite yet)
+cd frontend && npx vite build --mode development
+
+# Tauri shell check (requires Rust)
+cd frontend/src-tauri && cargo check
+```
+
+---
+
+## Need Help?
+
+- **Stuck on setup?** Ask in [Discord #help](https://discord.gg/aRRdVj3de7)
+- **Not sure where to start?** Check [good first issues](https://github.com/debpalash/OmniVoice-Studio/labels/good%20first%20issue)
+- **Want to discuss a big change?** Open a [discussion](https://github.com/debpalash/OmniVoice-Studio/discussions) or Discord thread before coding
+
+Thank you for contributing! 🎙️

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Personal, educational, internal-team, and non-commercial use is free under <a hr
 <details>
 <summary><b>Can I add my own TTS engine?</b></summary>
 <br/>
-Yes. OmniVoice ships a <b>Plugin SDK</b> — subclass <code>TTSBackend</code> in <code>backend/services/tts_backend.py</code> to add any engine in ~50 lines. Six engines are built in: OmniVoice, CosyVoice, MLX-Audio (14+ sub-engines), VoxCPM2, MOSS-TTS-Nano, and KittenTTS. See the <a href="#tts-engines">TTS Engines</a> section for details.
+Yes. OmniVoice uses a <b>built-in backend registry</b>. To add an engine in ~50 lines, subclass <code>TTSBackend</code> in <code>backend/services/tts_backend.py</code> and add it to the <code>_REGISTRY</code> dictionary at the bottom. Six engines are built in: OmniVoice, CosyVoice, MLX-Audio (14+ sub-engines), VoxCPM2, MOSS-TTS-Nano, and KittenTTS. See the <a href="#tts-engines">TTS Engines</a> section for details.
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -263,6 +263,21 @@ chmod +x OmniVoice.Studio_*.AppImage
 > [!TIP]
 > On GPUs with **≤8 GB VRAM**, OmniVoice automatically offloads TTS to CPU during transcription — no config needed. A dedicated GPU is not required; the entire pipeline runs on CPU (just slower).
 
+### TTS Engines
+
+OmniVoice ships a multi-engine TTS backend. The default engine (OmniVoice) is always available; additional engines are opt-in and auto-detected. Switch engines in **Settings → TTS Engine** or via the `OMNIVOICE_TTS_BACKEND` env var.
+
+| Engine | Languages | Clone | Instruct | Linux | macOS ARM | Windows | License |
+|--------|:---------:|:-----:|:--------:|:-----:|:---------:|:-------:|:-------:|
+| **OmniVoice** (default) | 600+ | ✅ | ✅ | ✅ CUDA/CPU | ✅ MPS | ✅ CUDA/CPU | Built-in |
+| **CosyVoice 3** | 9 + 18 dialects | ✅ | ✅ | ✅ CUDA/CPU | ✅ MPS | ✅ CUDA/CPU | Apache-2.0 |
+| **MLX-Audio** (Kokoro, Qwen3-TTS, CSM, Dia, …) | Multi | Varies | Varies | ❌ | ✅ Native | ❌ | Varies |
+| **VoxCPM2** | 30 | ✅ | ✅ | ✅ CUDA/CPU | ✅ MPS | ✅ CUDA/CPU | Apache-2.0 |
+| **MOSS-TTS-Nano** | 20 | ✅ | ❌ | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
+| **KittenTTS** | English | ❌ | ❌ | ✅ CPU | ✅ CPU | ✅ CPU | MIT |
+
+> **CUDA** = GPU-accelerated · **MPS** = Apple Silicon Metal · **CPU** = runs everywhere, slower for large models · KittenTTS and MOSS-TTS-Nano run realtime on CPU · MLX-Audio is Apple Silicon only.
+
 ---
 
 ## Architecture
@@ -317,6 +332,16 @@ chmod +x OmniVoice.Studio_*.AppImage
 
 ---
 
+## Contributing
+
+We welcome contributions of all kinds — bug fixes, new TTS engine adapters, UI improvements, docs, and translations.
+
+- 📖 Read the **[Contributing Guide](CONTRIBUTING.md)** for setup, code style, and PR workflow
+- 🐛 Browse [good first issues](https://github.com/debpalash/OmniVoice-Studio/labels/good%20first%20issue)
+- 💬 Join our [Discord](https://discord.gg/aRRdVj3de7) to discuss ideas or ask for help
+
+---
+
 ## FAQ
 
 <details>
@@ -352,7 +377,7 @@ Personal, educational, internal-team, and non-commercial use is free under <a hr
 <details>
 <summary><b>Can I add my own TTS engine?</b></summary>
 <br/>
-Not yet — a Plugin SDK is on the <a href="#roadmap">roadmap</a>. The architecture is modular, so integration is straightforward for contributors.
+Yes. OmniVoice ships a <b>Plugin SDK</b> — subclass <code>TTSBackend</code> in <code>backend/services/tts_backend.py</code> to add any engine in ~50 lines. Six engines are built in: OmniVoice, CosyVoice, MLX-Audio (14+ sub-engines), VoxCPM2, MOSS-TTS-Nano, and KittenTTS. See the <a href="#tts-engines">TTS Engines</a> section for details.
 </details>
 
 ---
@@ -366,12 +391,6 @@ OmniVoice Studio is source-available under the [**Functional Source License (FSL
 **Business / enterprise** users building a competing product or service on top of OmniVoice Studio need a commercial license. **Pricing tiers coming soon.** For inquiries in the meantime, reach out at **OmniVoice@palash.dev**.
 
 See [`LICENSE`](LICENSE) for the full terms.
-
----
-
-## Contributing
-
-Issues and PRs welcome. See the [roadmap](#roadmap) for areas where help is most needed. Join our [Discord](https://discord.gg/aRRdVj3de7) to discuss ideas, get help, or find what to work on.
 
 ---
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -178,10 +178,9 @@ class VoxCPM2Backend(TTSBackend):
         except ImportError:
             return False, (
                 "voxcpm package not installed. Install with `pip install voxcpm` "
-                "(requires CUDA 12+ and ~8 GB VRAM)."
+                "(requires Python ≥3.10, PyTorch ≥2.5). CUDA ≥12 recommended "
+                "for full speed; MPS (Apple Silicon) and CPU also supported."
             )
-        if not torch.cuda.is_available():
-            return False, "VoxCPM2 requires a CUDA GPU (CUDA 12+)."
         return True, "ready"
 
     @property
@@ -533,16 +532,149 @@ class MLXAudioBackend(TTSBackend):
         return wav
 
 
+# ── CosyVoice adapter (Alibaba FunAudioLLM, Apache-2.0) ────────────────────
+
+
+class CosyVoiceBackend(TTSBackend):
+    """FunAudioLLM CosyVoice — multilingual zero-shot TTS (9 langs + 18 dialects).
+
+    Supports v1 (300M), v2 (0.5B), and v3 (0.5B, latest). Installation is
+    non-trivial (git clone --recursive + SoX) so we ship as an optional
+    scaffold: ``is_available()`` reports the missing install cleanly.
+
+    Set ``OMNIVOICE_COSYVOICE_MODEL`` to the pretrained model directory path
+    (e.g. ``pretrained_models/Fun-CosyVoice3-0.5B``). The directory must
+    contain the CosyVoice checkpoint files.
+
+    Install:
+        git clone --recursive https://github.com/FunAudioLLM/CosyVoice.git
+        cd CosyVoice && pip install -r requirements.txt
+        # Ubuntu: sudo apt-get install sox libsox-dev
+        # macOS:  brew install sox
+    """
+
+    id = "cosyvoice"
+    display_name = "CosyVoice 3 (9 langs, zero-shot, instruct, Apache-2.0)"
+
+    # CosyVoice language tags used for cross-lingual synthesis.
+    LANG_TAGS = {
+        "zh": "<|zh|>", "en": "<|en|>", "ja": "<|ja|>",
+        "ko": "<|ko|>", "yue": "<|yue|>", "de": "<|de|>",
+        "es": "<|es|>", "fr": "<|fr|>", "it": "<|it|>",
+        "ru": "<|ru|>",
+    }
+
+    def __init__(self):
+        self._model = None
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        try:
+            from cosyvoice.cli.cosyvoice import AutoModel  # noqa: F401
+            return True, "ready"
+        except ImportError:
+            return False, (
+                "cosyvoice package not installed. Install from "
+                "https://github.com/FunAudioLLM/CosyVoice "
+                "(git clone --recursive + pip install -r requirements.txt + SoX). "
+                "Then set OMNIVOICE_COSYVOICE_MODEL to your model directory."
+            )
+
+    @property
+    def sample_rate(self) -> int:
+        if self._model is not None:
+            return self._model.sample_rate
+        return 24000  # v3 default
+
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["zh", "en", "ja", "ko", "yue", "de", "es", "fr", "it", "ru"]
+
+    def _ensure_loaded(self):
+        if self._model is not None:
+            return
+        ok, msg = self.is_available()
+        if not ok:
+            raise RuntimeError(f"CosyVoice unavailable: {msg}")
+        from cosyvoice.cli.cosyvoice import AutoModel  # type: ignore[import-not-found]
+        model_dir = os.environ.get(
+            "OMNIVOICE_COSYVOICE_MODEL",
+            "pretrained_models/Fun-CosyVoice3-0.5B",
+        )
+        logger.info("Loading CosyVoice from %s", model_dir)
+        self._model = AutoModel(model_dir=model_dir)
+
+    def generate(self, text: str, **kw) -> torch.Tensor:
+        import numpy as np
+        self._ensure_loaded()
+
+        ref_audio = kw.get("ref_audio")
+        ref_text = kw.get("ref_text")
+        instruct = kw.get("instruct")
+        language = kw.get("language")
+
+        # Pick the right inference method based on what the caller provides:
+        # 1. instruct + ref_audio → inference_instruct2 (emotion/dialect/speed)
+        # 2. ref_audio + ref_text → inference_zero_shot (voice cloning)
+        # 3. ref_audio only → inference_cross_lingual (with lang tag)
+        # 4. nothing → inference_sft (built-in speakers, v1/SFT model only)
+        pieces = []
+        if instruct and ref_audio:
+            # Instruct mode: "用四川话说<|endofprompt|>"
+            if not instruct.endswith("<|endofprompt|>"):
+                instruct = f"{instruct}<|endofprompt|>"
+            results = self._model.inference_instruct2(
+                text, instruct, ref_audio, stream=False,
+            )
+        elif ref_audio and ref_text:
+            results = self._model.inference_zero_shot(
+                text, ref_text, ref_audio, stream=False,
+            )
+        elif ref_audio:
+            # Cross-lingual: prefix text with language tag if available.
+            lang_tag = ""
+            if language:
+                lang_key = language[:2].lower() if len(language) > 2 else language.lower()
+                lang_tag = self.LANG_TAGS.get(lang_key, "")
+            results = self._model.inference_cross_lingual(
+                f"{lang_tag}{text}", ref_audio, stream=False,
+            )
+        else:
+            # No ref audio — try SFT with first available speaker.
+            spks = self._model.list_available_spks()
+            spk = spks[0] if spks else "中文女"
+            results = self._model.inference_sft(text, spk, stream=False)
+
+        for chunk in results:
+            wav = chunk.get("tts_speech")
+            if wav is None:
+                continue
+            if isinstance(wav, np.ndarray):
+                wav = torch.from_numpy(wav).float()
+            if not isinstance(wav, torch.Tensor):
+                wav = torch.tensor(wav, dtype=torch.float32)
+            pieces.append(wav)
+
+        if not pieces:
+            raise RuntimeError("CosyVoice produced no audio")
+        wav = torch.cat(pieces, dim=-1)
+        if wav.ndim == 1:
+            wav = wav.unsqueeze(0)
+        return wav
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 
 
 _REGISTRY: dict[str, type[TTSBackend]] = {
     "omnivoice":     OmniVoiceBackend,
+    "cosyvoice":     CosyVoiceBackend,
     "kittentts":     KittenTTSBackend,
     "mlx-audio":     MLXAudioBackend,
     "voxcpm2":       VoxCPM2Backend,
     "moss-tts-nano": MossTTSNanoBackend,
 }
+
 
 
 def list_backends() -> list[dict]:

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -634,8 +634,9 @@ class CosyVoiceBackend(TTSBackend):
             # Cross-lingual: prefix text with language tag if available.
             lang_tag = ""
             if language:
-                lang_key = language[:2].lower() if len(language) > 2 else language.lower()
-                lang_tag = self.LANG_TAGS.get(lang_key, "")
+                full_lang = language.lower()
+                lang_key = full_lang[:2] if len(full_lang) > 2 else full_lang
+                lang_tag = self.LANG_TAGS.get(full_lang) or self.LANG_TAGS.get(lang_key, "")
             results = self._model.inference_cross_lingual(
                 f"{lang_tag}{text}", ref_audio, stream=False,
             )


### PR DESCRIPTION
## What changed

### CosyVoice 3 Backend (`tts_backend.py`)
- New `CosyVoiceBackend` adapter — 6th engine in the registry
- Supports v1/v2/v3 via `OMNIVOICE_COSYVOICE_MODEL` env var
- Smart method dispatch: `inference_zero_shot` (voice cloning), `inference_instruct2` (emotion/dialect), `inference_cross_lingual` (lang tags), `inference_sft` (built-in speakers)
- 9 languages + 18 Chinese dialects, Apache-2.0

### VoxCPM2 Fix
- Removed incorrect hard CUDA gate from `is_available()`
- VoxCPM2 supports MPS (Apple Silicon) and CPU fallback per their docs

### README
- Added unified TTS Engines table (features + platform compat in one table)
- Updated FAQ — Plugin SDK entry now reflects the 6 built-in engines
- Moved Contributing section above FAQ

### CONTRIBUTING.md (new)
- Dev setup, project structure map, PR workflow
- TTS engine plugin tutorial with copy-paste template
- Code style conventions (Python/React/Rust)
- Testing commands

## How to verify
```bash
# Syntax + import + interface validation
uv run python -c "
import sys; sys.path.insert(0, 'backend')
from services.tts_backend import list_backends
for b in list_backends(): print(b['id'], b['available'])
"

# Backend tests
uv run pytest backend/ -x -q

# Frontend build
cd frontend && npx vite build --mode development
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CosyVoice as a selectable TTS engine.

* **Improvements**
  * VoxCPM2 now usable without CUDA — CPU and MPS runtimes supported; clearer environment guidance.
  * TTS engines can be switched via app Settings or environment configuration.

* **Documentation**
  * Full CONTRIBUTING guide with setup, workflow, style, and testing instructions.
  * README updated with TTS engine matrix and Plugin SDK details for adding engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->