### PR TITLE
Cross-platform bug bash: docker, diarization, VRAM concurrency, dub editor UX, Stories tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ docker run -d --name omnivoice --gpus all \
 
 ```bash
 # CPU
-docker compose -f deploy/docker-compose.yml up -d
+docker compose -f deploy/docker-compose.yml --profile cpu up -d
 
-# GPU
+# GPU (NVIDIA)
 docker compose -f deploy/docker-compose.yml --profile gpu up -d
 ```
 

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -528,23 +528,55 @@ async def dub_transcribe_stream(job_id: str):
             return
 
         def _diarize():
+            """Returns (segments, warning_or_None).
+
+            Warning is set when we silently fell back to the silence-gap
+            heuristic (no HF_TOKEN, model unavailable, or pyannote raised).
+            The heuristic only detects speaker turns from >1.2s silences,
+            so a rapid-fire man↔woman exchange will read as one speaker.
+            """
             diar_pipe = get_diarization_pipeline()
+            if not diar_pipe:
+                if not os.environ.get("HF_TOKEN"):
+                    reason = (
+                        "Speaker diarization is disabled because no HF_TOKEN is set. "
+                        "To detect multiple speakers, set HF_TOKEN and accept the "
+                        "pyannote/speaker-diarization-3.1 license at huggingface.co. "
+                        "Falling back to a silence-gap heuristic — turns with no audible "
+                        "pause between them will be merged into one speaker."
+                    )
+                else:
+                    reason = (
+                        "Speaker diarization model failed to load — see backend logs for "
+                        "the underlying error (often: pyannote license not accepted on "
+                        "Hugging Face, or download blocked by network). Falling back to "
+                        "a silence-gap heuristic; rapid speaker turns may be merged."
+                    )
+                return assign_speakers_heuristic(all_segments), reason
             try:
-                if diar_pipe:
-                    diar = diar_pipe(asr_audio_target)
-                    return assign_speakers_from_diarization(all_segments, diar)
+                diar = diar_pipe(asr_audio_target)
+                return assign_speakers_from_diarization(all_segments, diar), None
             except Exception as e:
                 logger.error(f"Diarization failed: {e}")
-            return assign_speakers_heuristic(all_segments)
+                return (
+                    assign_speakers_heuristic(all_segments),
+                    f"Speaker diarization crashed mid-run ({type(e).__name__}); "
+                    "falling back to a silence-gap heuristic. Rapid speaker turns "
+                    "may be merged."
+                )
 
         fut_diar = loop.run_in_executor(_gpu_pool, _diarize)
         final_segs = None
+        diar_warning = None
         while True:
             done, pending = await asyncio.wait([fut_diar], timeout=5.0)
             if done:
-                final_segs = done.pop().result()
+                final_segs, diar_warning = done.pop().result()
                 break
             yield _sse_event("ping", {})
+        if diar_warning:
+            logger.warning("diarization fallback: %s", diar_warning)
+            yield _sse_event("warning", {"detail": diar_warning, "source": "diarization"})
 
         job["segments"] = final_segs
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -34,8 +34,79 @@ from core.config import IDLE_TIMEOUT_SECONDS, CPU_POOL_WORKERS
 
 logger = logging.getLogger("omnivoice.model")
 
-_gpu_pool = ThreadPoolExecutor(max_workers=1)
+# Per-TTS-job VRAM headroom estimate. OmniVoice's forward + autoregressive
+# decode peaks around 1.6 GB on a 24 kHz 8-second utterance; we budget 2.5 GB
+# to leave room for the ASR/diarization pipelines that run concurrently in
+# the same process. Tuned empirically — bumps to 3 GB if anyone reports OOM
+# at 16 GB on a multi-segment dub.
+_GPU_VRAM_PER_JOB_GB = 2.5
+_GPU_WORKER_CAP = 4
+
+_gpu_pool_singleton: "ThreadPoolExecutor | None" = None
 _cpu_pool = ThreadPoolExecutor(max_workers=CPU_POOL_WORKERS)
+
+
+def _pick_gpu_workers() -> int:
+    """Pick a sensible GPU worker count from the runtime environment.
+
+    Resolution order:
+      1. OMNIVOICE_GPU_WORKERS env var (explicit user override, clamped 1..16).
+      2. CUDA / ROCm: free VRAM // per-job budget, capped at 4.
+      3. MPS / CPU / unknown: 1.
+
+    Designed to fail safe — any exception → 1 worker, never propagated.
+    """
+    override = os.environ.get("OMNIVOICE_GPU_WORKERS")
+    if override:
+        try:
+            n = int(override)
+            return max(1, min(16, n))
+        except ValueError:
+            logger.warning("OMNIVOICE_GPU_WORKERS=%r is not an integer; ignoring", override)
+    try:
+        torch = _lazy_torch()
+        if hasattr(torch, "cuda") and torch.cuda.is_available():
+            free_bytes, _total = torch.cuda.mem_get_info()
+            free_gb = free_bytes / (1024 ** 3)
+            workers = max(1, min(_GPU_WORKER_CAP, int(free_gb // _GPU_VRAM_PER_JOB_GB)))
+            logger.info(
+                "GPU pool sized to %d worker(s) — %.1f GB free / %.1f GB per job (cap %d)",
+                workers, free_gb, _GPU_VRAM_PER_JOB_GB, _GPU_WORKER_CAP,
+            )
+            return workers
+        if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            logger.info("GPU pool: MPS detected, using 1 worker (shared system memory)")
+            return 1
+    except Exception as e:
+        logger.warning("GPU worker probe failed (%s); defaulting to 1", e)
+    return 1
+
+
+def _build_gpu_pool() -> ThreadPoolExecutor:
+    workers = _pick_gpu_workers()
+    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="gpu-pool")
+
+
+def _get_gpu_pool() -> ThreadPoolExecutor:
+    """Internal accessor. Same singleton as the module-level `_gpu_pool`
+    attribute, but resolvable from inside this module (Python's module
+    `__getattr__` only fires for unresolved lookups from *outside*).
+    """
+    global _gpu_pool_singleton
+    if _gpu_pool_singleton is None:
+        _gpu_pool_singleton = _build_gpu_pool()
+    return _gpu_pool_singleton
+
+
+def __getattr__(name: str):
+    """Lazy module attribute — initialises `_gpu_pool` on first access so we
+    can probe the device after torch finishes its lazy import. Without this
+    we'd be forced to commit to max_workers=1 at module import time, before
+    knowing whether CUDA is even available.
+    """
+    if name == "_gpu_pool":
+        return _get_gpu_pool()
+    raise AttributeError(f"module 'services.model_manager' has no attribute {name!r}")
 
 model = None  # type: ignore
 _model_lock = asyncio.Lock()
@@ -283,7 +354,7 @@ async def preload_model():
         async with _model_lock:
             if model is None:
                 loop = asyncio.get_running_loop()
-                model = await loop.run_in_executor(_gpu_pool, _load_model_sync)
+                model = await loop.run_in_executor(_get_gpu_pool(), _load_model_sync)
         logger.info("Preload complete — model ready.")
     except Exception as e:
         logger.warning("Model preload failed (non-fatal): %s", e)

--- a/backend/services/translation_engines.py
+++ b/backend/services/translation_engines.py
@@ -144,11 +144,16 @@ def is_installed(engine_id: str) -> bool:
     return ok
 
 
+def _in_virtualenv() -> bool:
+    """True if the current interpreter is inside a venv/virtualenv."""
+    return getattr(sys, "base_prefix", sys.prefix) != sys.prefix or hasattr(sys, "real_prefix")
+
+
 def _installer_cmd() -> list[str]:
     """Prefer `uv pip` (the dev install's default), fall back to `python -m pip`.
 
-    Using `python -m pip` ensures we target the same interpreter the server
-    is running under — avoids the classic "pip installed into the wrong venv"
+    `python -m pip` ensures we target the same interpreter the server is
+    running under — avoids the classic "pip installed into the wrong venv"
     footgun.
     """
     if shutil.which("uv"):
@@ -161,8 +166,19 @@ async def run_pip(args: list[str], timeout: float = 600.0) -> tuple[int, str]:
 
     Combines stdout + stderr so the UI can surface a useful tail on failure
     (pip's "ERROR: ..." lines go to stderr).
+
+    When using `uv pip` and running outside a venv (e.g. inside the Docker
+    image where Python runs as system), inject `--system` after the
+    install/uninstall subcommand. Without it, uv refuses to write to system
+    Python with: "No virtual environment found; run `uv venv` to create an
+    environment, or pass `--system`...". The `UV_SYSTEM_PYTHON` env var only
+    affects `uv venv`, not `uv pip install`.
     """
-    cmd = _installer_cmd() + args
+    base = _installer_cmd()
+    using_uv = base[:1] == ["uv"]
+    if using_uv and not _in_virtualenv() and args and args[0] in ("install", "uninstall") and "--system" not in args:
+        args = [args[0], "--system", *args[1:]]
+    cmd = base + args
     logger.info("pip: %s", " ".join(cmd))
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,8 +2,11 @@
 #  OmniVoice Studio — Docker Compose
 #
 #  Quick start:
-#    docker compose -f deploy/docker-compose.yml up                 # CPU mode
+#    docker compose -f deploy/docker-compose.yml --profile cpu up   # CPU mode
 #    docker compose -f deploy/docker-compose.yml --profile gpu up   # GPU mode
+#
+#  Both services bind to port 3900, so they MUST be opt-in via profiles —
+#  otherwise `compose up` would race them and one would fail to bind.
 #
 #  First run downloads ~4 GB of models. Progress is shown in logs.
 #  Open http://localhost:3900 once the health check passes.
@@ -26,6 +29,7 @@ services:
       context: ..
       dockerfile: deploy/Dockerfile
     container_name: omnivoice-studio
+    profiles: ["cpu"]
     ports:
       - "127.0.0.1:3900:3900"
     volumes:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ const VoiceGallery = lazy(() => import('./pages/VoiceGallery'));
 const DonatePage = lazy(() => import('./pages/DonatePage'));
 const EnterprisePage = lazy(() => import('./pages/EnterprisePage'));
 const TranscriptionsPage = lazy(() => import('./pages/Transcriptions'));
+const StoriesEditor = lazy(() => import('./components/StoriesEditor'));
 
 import Header from './components/Header';
 import NavRail from './components/NavRail';
@@ -130,7 +131,8 @@ function App() {
   const openVoiceProfile = useAppStore(s => s.openVoiceProfile);
   const closeVoiceProfile = useAppStore(s => s.closeVoiceProfile);
   const hideSidebar = mode === 'launchpad' || mode === 'settings' || mode === 'voice' || mode === 'donate'
-    || mode === 'queue' || mode === 'tools' || mode === 'projects' || mode === 'gallery' || mode === 'enterprise' || mode === 'transcriptions';
+    || mode === 'queue' || mode === 'tools' || mode === 'projects' || mode === 'gallery' || mode === 'enterprise' || mode === 'transcriptions'
+    || mode === 'stories';
   const availableSidebarTabs = mode === 'dub'
     ? ['projects', 'history', 'downloads']
     : (mode === 'clone' || mode === 'design')
@@ -913,6 +915,12 @@ function App() {
           <ErrorBoundary name="transcriptions">
             <Suspense fallback={<LazyFallback />}>
               <TranscriptionsPage />
+            </Suspense>
+          </ErrorBoundary>
+        ) : mode === 'stories' ? (
+          <ErrorBoundary name="stories">
+            <Suspense fallback={<LazyFallback />}>
+              <StoriesEditor profiles={profiles} />
             </Suspense>
           </ErrorBoundary>
         ) : mode === 'donate' ? (

--- a/frontend/src/components/DubSegmentRow.jsx
+++ b/frontend/src/components/DubSegmentRow.jsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useRef } from 'react';
 import {
   CheckCircle, AlertCircle, Circle, Trash2, Loader, Headphones, Scissors, Merge,
   MoreHorizontal, Sparkles,
@@ -10,16 +10,53 @@ import { Menu, Button, Badge } from '../ui';
 import './DubSegmentRow.css';
 
 const CHAR_BUDGET_RATIO = 1.3;
+const SENTENCE_END = /[.!?。！？]/;
 
 function rowClass(isActive, isDone, selected) {
   return `segment-row${isActive ? ' segment-active' : ''}${isDone ? ' segment-done' : ''}${selected ? ' segment-selected' : ''}`;
 }
 
+// Best split point for the Scissors menu when the user hasn't placed a cursor —
+// prefer the sentence boundary nearest the middle, then a whitespace boundary,
+// then the literal midpoint as a last resort.
+function bestSplitPoint(text) {
+  const mid = Math.floor(text.length / 2);
+  let best = -1, bestDist = Infinity;
+  for (let i = 0; i < text.length; i++) {
+    if (SENTENCE_END.test(text[i])) {
+      const d = Math.abs(i + 1 - mid);
+      if (d < bestDist) { best = i + 1; bestDist = d; }
+    }
+  }
+  if (best > 0 && best < text.length) return best;
+  for (let r = 0; r < text.length; r++) {
+    for (const i of [mid - r, mid + r]) {
+      if (i > 0 && i < text.length && /\s/.test(text[i])) return i;
+    }
+  }
+  return mid;
+}
+
+// Accept "m:ss[.s]" or raw seconds; return null on garbage so the field can revert.
+function parseTime(s) {
+  const m = /^\s*(\d+):([0-5]?\d(?:\.\d+)?)\s*$/.exec(s);
+  if (m) return parseInt(m[1], 10) * 60 + parseFloat(m[2]);
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : null;
+}
+
 function DubSegmentRow({
   seg, idx, style, disabled, isActive, isDone, previewLoading, selected,
   profiles, speakerClones, onEditField, onDelete, onRestore, onPreview, onSelect, onSplit, onMerge, canMerge,
-  onDirect,
+  onDirect, onSeek,
 }) {
+  const textInputRef = useRef(null);
+  // Remember where the caret was inside the text field even after it loses
+  // focus — Radix's menu trigger steals focus, so by the time the Scissors
+  // item fires, selectionStart on the input would otherwise read as null.
+  const lastCursorRef = useRef(null);
+  const speakerOptions = speakerClones ? Object.keys(speakerClones) : [];
+  const speakerListId = `seg-speakers-${seg.id}`;
   const syncColor = seg.sync_ratio === undefined ? null
     : (seg.sync_ratio >= 0.95 && seg.sync_ratio <= 1.05) ? '#b8bb26'
     : seg.sync_ratio > 1.25 ? '#fb4934'
@@ -44,8 +81,22 @@ function DubSegmentRow({
     }
   };
 
+  const captureCursor = (e) => {
+    const pos = e.target.selectionStart;
+    if (pos != null) lastCursorRef.current = pos;
+  };
+
+  // Row click → seek the player to this segment. We don't fire when the click
+  // originates in an interactive element (input, button, the actions cluster)
+  // so per-field editing keeps working.
+  const handleRowClick = (e) => {
+    if (!onSeek) return;
+    if (e.target.closest('input, button, select, textarea, label, [data-noseek]')) return;
+    onSeek(seg.start);
+  };
+
   return (
-    <div style={style} className={rowClass(isActive, isDone, selected)}>
+    <div style={style} className={rowClass(isActive, isDone, selected)} onClick={handleRowClick}>
       <input
         type="checkbox"
         checked={!!selected}
@@ -57,8 +108,34 @@ function DubSegmentRow({
         title="Select segment (shift+click for range)"
       />
       <span className="segment-time seg-time">
-        <span>
-          {formatTime(seg.start)}–{formatTime(seg.end)}
+        <span className="seg-time-row">
+          <input
+            type="text"
+            className="seg-time-input"
+            defaultValue={formatTime(seg.start)}
+            key={`start-${seg.id}-${seg.start}`}
+            disabled={disabled}
+            title="Click to edit start time (m:ss.s). Enter to commit, Esc to cancel."
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') e.target.blur();
+              if (e.key === 'Escape') { e.target.value = formatTime(seg.start); e.target.blur(); }
+            }}
+            onBlur={(e) => {
+              const v = parseTime(e.target.value);
+              if (v == null || v < 0 || v >= seg.end) {
+                e.target.value = formatTime(seg.start);
+                return;
+              }
+              if (Math.abs(v - seg.start) > 1e-3) {
+                onEditField(seg.id, 'start', +v.toFixed(3));
+              } else {
+                e.target.value = formatTime(seg.start);
+              }
+            }}
+          />
+          <span className="seg-time-sep">–</span>
+          <span className="seg-time-end">{formatTime(seg.end)}</span>
           {seg.speed && seg.speed !== 1.0 && (
             <span className="seg-speed-badge" style={{ color: seg.speed > 1 ? '#d3869b' : '#8ec07c' }}>
               {seg.speed.toFixed(2)}x
@@ -89,16 +166,30 @@ function DubSegmentRow({
         className="input-base seg-speaker-input"
         value={seg.speaker_id || ''}
         onChange={(e) => onEditField(seg.id, 'speaker_id', e.target.value)}
+        onClick={(e) => e.stopPropagation()}
         disabled={disabled}
-        title="Speaker ID"
+        list={speakerOptions.length ? speakerListId : undefined}
+        placeholder={speakerOptions.length ? 'Pick…' : ''}
+        title={speakerOptions.length
+          ? 'Speaker — pick from detected, or type a custom name'
+          : 'Speaker — type a name (no diarization clones detected)'}
       />
+      {speakerOptions.length > 0 && (
+        <datalist id={speakerListId}>
+          {speakerOptions.map(spk => <option key={spk} value={spk} />)}
+        </datalist>
+      )}
 
       <span className="seg-text-col">
         <input
+          ref={textInputRef}
           className="input-base segment-input"
           value={seg.text}
           onChange={(e) => onEditField(seg.id, 'text', e.target.value)}
           onKeyDown={handleTextKeyDown}
+          onKeyUp={captureCursor}
+          onSelect={captureCursor}
+          onClick={(e) => { e.stopPropagation(); captureCursor(e); }}
           disabled={disabled}
           title={seg.translate_error
             ? `Translation error: ${seg.translate_error}`
@@ -209,7 +300,20 @@ function DubSegmentRow({
               label: 'Split at cursor',
               icon: Scissors,
               shortcut: '⌘D',
-              onSelect: () => onSplit(seg.id, Math.floor(seg.text.length / 2)),
+              onSelect: () => {
+                // Prefer the live cursor if the text input still has focus,
+                // otherwise fall back to the last remembered position, then
+                // to a sentence-boundary heuristic. Splitting at the literal
+                // midpoint (the old behaviour) felt random to users.
+                let pos = textInputRef.current?.selectionStart;
+                if (pos == null || pos <= 0 || pos >= seg.text.length) {
+                  pos = lastCursorRef.current;
+                }
+                if (pos == null || pos <= 0 || pos >= seg.text.length) {
+                  pos = bestSplitPoint(seg.text);
+                }
+                onSplit(seg.id, pos);
+              },
             },
             {
               id: 'merge',
@@ -248,6 +352,7 @@ export default memo(DubSegmentRow, (prev, next) => (
   prev.isDone === next.isDone &&
   prev.previewLoading === next.previewLoading &&
   prev.onDirect === next.onDirect &&
+  prev.onSeek === next.onSeek &&
   prev.selected === next.selected &&
   prev.canMerge === next.canMerge &&
   prev.profiles === next.profiles &&

--- a/frontend/src/components/DubSegmentTable.jsx
+++ b/frontend/src/components/DubSegmentTable.jsx
@@ -20,7 +20,7 @@ const COLUMNS = [
 export default function DubSegmentTable({
   segments, profiles, speakerClones, dubStep, dubProgress, previewLoadingId,
   selectedIds, onSelect, onSelectAll, onClearSelection,
-  onEditField, onDelete, onRestore, onPreview, onSplit, onMerge, onDirect,
+  onEditField, onDelete, onRestore, onPreview, onSplit, onMerge, onDirect, onSeek,
 }) {
   const disabled = dubStep === 'generating' || dubStep === 'stopping';
   const [query, setQuery] = useState('');
@@ -67,12 +67,12 @@ export default function DubSegmentTable({
 
   const rowProps = useMemo(() => ({
     filtered, profiles, speakerClones, disabled, dubStep, dubProgress, previewLoadingId,
-    selectedIds, onSelect, onEditField, onDelete, onRestore, onPreview, onSplit, onMerge, onDirect,
+    selectedIds, onSelect, onEditField, onDelete, onRestore, onPreview, onSplit, onMerge, onDirect, onSeek,
     segments,
   }), [filtered, profiles, speakerClones, disabled, dubStep, dubProgress, previewLoadingId,
-      selectedIds, onSelect, onEditField, onDelete, onRestore, onPreview, onSplit, onMerge, onDirect, segments]);
+      selectedIds, onSelect, onEditField, onDelete, onRestore, onPreview, onSplit, onMerge, onDirect, onSeek, segments]);
 
-  const Row = useCallback(({ index, style, filtered: fl, profiles: profs, speakerClones: clones, disabled: dis, dubProgress: prog, dubStep: step, previewLoadingId: previewId, selectedIds: sel, onSelect: pick, onEditField: edit, onDelete: del, onRestore: rest, onPreview: prev, onSplit: split, onMerge: merge, onDirect: direct, segments: segs }) => {
+  const Row = useCallback(({ index, style, filtered: fl, profiles: profs, speakerClones: clones, disabled: dis, dubProgress: prog, dubStep: step, previewLoadingId: previewId, selectedIds: sel, onSelect: pick, onEditField: edit, onDelete: del, onRestore: rest, onPreview: prev, onSplit: split, onMerge: merge, onDirect: direct, onSeek: seek, segments: segs }) => {
     const seg = fl[index];
     if (!seg) return null;
     const absoluteIndex = segs.indexOf(seg);
@@ -89,7 +89,7 @@ export default function DubSegmentTable({
         profiles={profs}
         speakerClones={clones}
         onEditField={edit} onDelete={del} onRestore={rest} onPreview={prev}
-        onSelect={pick} onSplit={split} onMerge={merge} onDirect={direct}
+        onSelect={pick} onSplit={split} onMerge={merge} onDirect={direct} onSeek={seek}
       />
     );
   }, []);

--- a/frontend/src/components/NavRail.jsx
+++ b/frontend/src/components/NavRail.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Globe, Fingerprint, Wand2, Film, FolderOpen, Settings2, ArrowLeftRight,
-  Library, FileText,
+  Library, FileText, BookOpen,
 } from 'lucide-react';
 
 const ITEMS = [
@@ -9,6 +9,7 @@ const ITEMS = [
   { id: 'clone',     label: 'Clone',     Icon: Fingerprint, accent: '#d3869b' },
   { id: 'design',    label: 'Design',    Icon: Wand2,       accent: '#8ec07c' },
   { id: 'dub',       label: 'Dub',       Icon: Film,        accent: '#fe8019' },
+  { id: 'stories',   label: 'Stories',   Icon: BookOpen,    accent: '#fabd2f' },
   { id: 'gallery',   label: 'Gallery',   Icon: Library,     accent: '#b8bb26' },
   { id: 'transcriptions', label: 'Transcripts', Icon: FileText, accent: '#d3869b' },
   { id: 'projects',  label: 'OmniDrive',  Icon: FolderOpen,  accent: '#83a598' },

--- a/frontend/src/components/StoriesEditor.css
+++ b/frontend/src/components/StoriesEditor.css
@@ -245,3 +245,57 @@
 .stories-track__voice-dot[data-char="char-3"]    { background: #fabd2f; }
 .stories-track__voice-dot[data-char="char-4"]    { background: #fe8019; }
 .stories-track__voice-dot[data-char="char-5"]    { background: #8ec07c; }
+
+
+/* ── Paste & auto-split panel ────────────────────────────────────── */
+
+.stories-editor__split-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  margin: 8px 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+}
+.stories-editor__split-text {
+  width: 100%;
+  min-height: 96px;
+  padding: 8px 10px;
+  background: var(--color-bg-elevated, rgba(0,0,0,0.2));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  resize: vertical;
+}
+.stories-editor__split-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.stories-editor__split-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+}
+.stories-editor__split-num {
+  width: 64px;
+  padding: 4px 6px;
+  background: var(--color-bg-elevated, rgba(0,0,0,0.2));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+.stories-editor__split-hint {
+  flex: 1;
+  font-size: var(--text-xs);
+  color: var(--color-fg-subtle);
+}

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -13,10 +13,41 @@
  *     onGenerate={(tracks) => ...}
  *   />
  */
-import React, { useState, useCallback } from 'react';
-import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download } from 'lucide-react';
+import React, { useState, useCallback, useRef } from 'react';
+import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon } from 'lucide-react';
 import { Button } from '@/ui';
 import './StoriesEditor.css';
+
+// Sentence-aware splitter for the "Paste & auto-split" panel. Walks the
+// text and breaks at the closest sentence boundary that keeps each chunk
+// under `maxChars`. Falls back to whitespace, then to the hard cap.
+function splitIntoChunks(text, maxChars) {
+  const out = [];
+  const clean = String(text || '').replace(/\r\n/g, '\n').trim();
+  if (!clean) return out;
+  const max = Math.max(40, Math.min(2000, maxChars | 0));
+  let i = 0;
+  while (i < clean.length) {
+    const remain = clean.length - i;
+    if (remain <= max) { out.push(clean.slice(i).trim()); break; }
+    const window = clean.slice(i, i + max);
+    // Prefer a sentence break inside the window, scanning from the end.
+    let cut = -1;
+    for (let j = window.length - 1; j > Math.floor(max * 0.4); j--) {
+      if (/[.!?。！？]/.test(window[j])) { cut = j + 1; break; }
+    }
+    if (cut < 0) {
+      // Fall back to last whitespace in the window.
+      for (let j = window.length - 1; j > Math.floor(max * 0.4); j--) {
+        if (/\s/.test(window[j])) { cut = j; break; }
+      }
+    }
+    if (cut < 0) cut = max;
+    out.push(clean.slice(i, i + cut).trim());
+    i += cut;
+  }
+  return out.filter(Boolean);
+}
 
 const CHARACTERS = [
   { id: 'narrator', label: 'Narrator', color: 'var(--color-accent)' },
@@ -50,6 +81,41 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
   ]);
 
   const [activeTrack, setActiveTrack] = useState(null);
+
+  // Paste & auto-split — paste a long passage, pick a chunk size, hit Split,
+  // and each chunk becomes its own track (assigned to Narrator by default).
+  const [splitOpen, setSplitOpen] = useState(false);
+  const [splitText, setSplitText] = useState('');
+  const [splitMax, setSplitMax] = useState(180);
+  const trackTextRefs = useRef(new Map());
+
+  const applySplit = useCallback(() => {
+    const chunks = splitIntoChunks(splitText, splitMax);
+    if (!chunks.length) return;
+    setTracks(prev => [...prev, ...chunks.map(t => makeTrack('narrator', t))]);
+    setSplitText('');
+    setSplitOpen(false);
+  }, [splitText, splitMax]);
+
+  const insertPauseInto = useCallback((trackId) => {
+    const el = trackTextRefs.current.get(trackId);
+    const token = '[pause 0.5s]';
+    setTracks(prev => prev.map(t => {
+      if (t.id !== trackId) return t;
+      const pos = el?.selectionStart;
+      if (pos != null && pos >= 0 && pos <= t.text.length) {
+        const before = t.text.slice(0, pos);
+        const after = t.text.slice(pos);
+        // Insert with surrounding spaces if the neighbours are non-whitespace,
+        // so the token survives a future re-split.
+        const left = before.length && !/\s$/.test(before) ? `${before} ` : before;
+        const right = after.length && !/^\s/.test(after) ? ` ${after}` : after;
+        return { ...t, text: `${left}${token}${right}` };
+      }
+      const sep = t.text.length && !/\s$/.test(t.text) ? ' ' : '';
+      return { ...t, text: `${t.text}${sep}${token}` };
+    }));
+  }, []);
 
   const addTrack = useCallback(() => {
     setTracks(prev => [...prev, makeTrack()]);
@@ -131,6 +197,9 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
           </p>
         </div>
         <div className="stories-editor__actions">
+          <Button size="sm" variant="ghost" onClick={() => setSplitOpen(v => !v)} aria-label="Paste & split">
+            <Scissors size={13} /> Paste & Split
+          </Button>
           <Button size="sm" variant="ghost" onClick={addTrack} aria-label="Add track">
             <Plus size={13} /> Add Line
           </Button>
@@ -139,6 +208,42 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
           </Button>
         </div>
       </div>
+
+      {splitOpen && (
+        <div className="stories-editor__split-panel" role="region" aria-label="Paste long text and auto-split">
+          <textarea
+            className="stories-editor__split-text"
+            placeholder="Paste a long passage. We'll split it into segments at sentence boundaries."
+            value={splitText}
+            onChange={(e) => setSplitText(e.target.value)}
+            rows={6}
+            aria-label="Long-form text input"
+          />
+          <div className="stories-editor__split-controls">
+            <label className="stories-editor__split-label">
+              Max chars per segment
+              <input
+                type="number"
+                min={60}
+                max={1000}
+                step={10}
+                value={splitMax}
+                onChange={(e) => setSplitMax(parseInt(e.target.value, 10) || 180)}
+                className="stories-editor__split-num"
+              />
+            </label>
+            <span className="stories-editor__split-hint">
+              {splitText
+                ? `~${splitIntoChunks(splitText, splitMax).length} segment(s) at ${splitMax} chars`
+                : 'Paste text above'}
+            </span>
+            <Button size="sm" variant="ghost" onClick={() => { setSplitText(''); setSplitOpen(false); }}>Cancel</Button>
+            <Button size="sm" onClick={applySplit} disabled={!splitText.trim()}>
+              <Scissors size={13} /> Split into tracks
+            </Button>
+          </div>
+        </div>
+      )}
 
       {/* Tracks */}
       {tracks.length === 0 ? (
@@ -175,9 +280,13 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
                 {/* Text */}
                 <textarea
                   className="stories-track__text"
+                  ref={(el) => {
+                    if (el) trackTextRefs.current.set(track.id, el);
+                    else trackTextRefs.current.delete(track.id);
+                  }}
                   value={track.text}
                   onChange={(e) => updateTrack(track.id, 'text', e.target.value)}
-                  placeholder="Enter dialogue or narration..."
+                  placeholder="Enter dialogue or narration… use [pause 0.5s] to insert a silent break"
                   rows={1}
                   aria-label={`${char.label} text`}
                 />
@@ -216,6 +325,14 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
 
                 {/* Actions */}
                 <div className="stories-track__actions">
+                  <button
+                    className="stories-track__btn"
+                    onClick={(e) => { e.stopPropagation(); insertPauseInto(track.id); }}
+                    title="Insert a [pause 0.5s] break at the cursor"
+                    aria-label="Insert pause"
+                  >
+                    <PauseIcon size={12} />
+                  </button>
                   <button
                     className="stories-track__btn"
                     onClick={(e) => { e.stopPropagation(); previewTrack(track); }}

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -15,7 +15,7 @@
  */
 import React, { useState, useCallback, useRef } from 'react';
 import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon, Users } from 'lucide-react';
-import { Button, Menu } from '@/ui';
+import { Button, Menu } from '../ui';
 import { parseStoryText, hasStoryMarkers, applyInlineVoice } from '../utils/storyTokens';
 import './StoriesEditor.css';
 

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -14,8 +14,9 @@
  *   />
  */
 import React, { useState, useCallback, useRef } from 'react';
-import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon } from 'lucide-react';
-import { Button } from '@/ui';
+import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon, Users } from 'lucide-react';
+import { Button, Menu } from '@/ui';
+import { parseStoryText, hasStoryMarkers, applyInlineVoice } from '../utils/storyTokens';
 import './StoriesEditor.css';
 
 // Sentence-aware splitter for the "Paste & auto-split" panel. Walks the
@@ -97,6 +98,18 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
     setSplitOpen(false);
   }, [splitText, splitMax]);
 
+  const setVoiceForSelection = useCallback((trackId, voiceId) => {
+    const el = trackTextRefs.current.get(trackId);
+    const start = el?.selectionStart;
+    const end = el?.selectionEnd;
+    setTracks(prev => prev.map(t => {
+      if (t.id !== trackId) return t;
+      const safeStart = start != null ? start : t.text.length;
+      const safeEnd = end != null ? end : safeStart;
+      return { ...t, text: applyInlineVoice(t.text, safeStart, safeEnd, voiceId) };
+    }));
+  }, []);
+
   const insertPauseInto = useCallback((trackId) => {
     const el = trackTextRefs.current.get(trackId);
     const token = '[pause 0.5s]';
@@ -131,44 +144,79 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
     );
   }, []);
 
-  const previewTrack = useCallback(async (track) => {
-    if (!track.text.trim()) return;
-    setTracks(prev =>
-      prev.map(t => t.id === track.id ? { ...t, generating: true } : t)
-    );
+  const fetchChunkAudio = useCallback(async (text, profileId) => {
+    const res = await fetch('/api/dub/preview-segment/__stories__', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, profile_id: profileId || null, speed: 1.0 }),
+    });
+    if (!res.ok) throw new Error(`Preview HTTP ${res.status}`);
+    const blob = await res.blob();
+    return URL.createObjectURL(blob);
+  }, []);
 
-    try {
-      const body = {
-        text: track.text,
-        profile_id: track.profileId || null,
-        speed: 1.0,
-      };
-      // Use the preview-segment endpoint for quick generation
-      const res = await fetch(`/api/dub/preview-segment/__stories__`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      if (res.ok) {
-        const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        setTracks(prev =>
-          prev.map(t => t.id === track.id ? { ...t, audioUrl: url, generating: false } : t)
-        );
-        // Auto-play
+  const previewTrack = useCallback(async (track) => {
+    const raw = (track.text || '').trim();
+    if (!raw) return;
+    setTracks(prev => prev.map(t => t.id === track.id ? { ...t, generating: true } : t));
+
+    // Simple path — no inline markers, keep the original single-shot behaviour
+    // so the user gets a reusable audioUrl on the track for replay.
+    if (!hasStoryMarkers(raw)) {
+      try {
+        const url = await fetchChunkAudio(raw, track.profileId);
+        setTracks(prev => prev.map(t => t.id === track.id ? { ...t, audioUrl: url, generating: false } : t));
         const audio = new Audio(url);
         audio.play().catch(() => {});
-      } else {
-        setTracks(prev =>
-          prev.map(t => t.id === track.id ? { ...t, generating: false } : t)
-        );
+      } catch (err) {
+        console.warn('Stories preview failed:', err);
+        setTracks(prev => prev.map(t => t.id === track.id ? { ...t, generating: false } : t));
       }
-    } catch {
-      setTracks(prev =>
-        prev.map(t => t.id === track.id ? { ...t, generating: false } : t)
-      );
+      return;
     }
-  }, []);
+
+    // Marker path — split into chunks + pauses, fetch chunks in parallel,
+    // play them in order with timed silences. We don't store a single
+    // audioUrl on the track in this path because there isn't one; pressing
+    // preview again regenerates (cheap enough for short stories).
+    const parsed = parseStoryText(raw, track.profileId);
+    try {
+      const audioUrls = await Promise.all(
+        parsed.map(seg => seg.type === 'chunk' ? fetchChunkAudio(seg.text, seg.profileId) : Promise.resolve(null))
+      );
+      let cursor = 0;
+      const finish = () => {
+        // Release any URLs we didn't get to (e.g. an error mid-playback).
+        for (let i = cursor; i < audioUrls.length; i++) {
+          if (audioUrls[i]) URL.revokeObjectURL(audioUrls[i]);
+        }
+        setTracks(prev => prev.map(t => t.id === track.id ? { ...t, generating: false, audioUrl: null } : t));
+      };
+      const step = () => {
+        while (cursor < parsed.length) {
+          const seg = parsed[cursor];
+          const url = audioUrls[cursor];
+          cursor++;
+          if (seg.type === 'pause') {
+            setTimeout(step, seg.seconds * 1000);
+            return;
+          }
+          if (seg.type === 'chunk' && url) {
+            const audio = new Audio(url);
+            audio.onended = () => { URL.revokeObjectURL(url); step(); };
+            audio.onerror = () => { URL.revokeObjectURL(url); step(); };
+            audio.play().catch(() => { URL.revokeObjectURL(url); step(); });
+            return;
+          }
+        }
+        finish();
+      };
+      step();
+    } catch (err) {
+      console.warn('Stories chained preview failed:', err);
+      setTracks(prev => prev.map(t => t.id === track.id ? { ...t, generating: false } : t));
+    }
+  }, [fetchChunkAudio]);
 
   const generateAll = useCallback(() => {
     if (onGenerate) {
@@ -325,6 +373,29 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
 
                 {/* Actions */}
                 <div className="stories-track__actions">
+                  <Menu
+                    placement="bottom-end"
+                    items={[
+                      ...(profiles.length === 0
+                        ? [{ id: 'noprof', label: 'No voice profiles installed', disabled: true }]
+                        : profiles.map(p => ({
+                            id: `voice-${p.id}`,
+                            label: p.name,
+                            onSelect: () => setVoiceForSelection(track.id, p.id),
+                          }))),
+                      'separator',
+                      { id: 'voice-default', label: 'Reset to track default', onSelect: () => setVoiceForSelection(track.id, 'default') },
+                    ]}
+                  >
+                    <button
+                      className="stories-track__btn"
+                      onClick={(e) => e.stopPropagation()}
+                      title="Switch voice for the highlighted text (or insert a switch at the cursor)"
+                      aria-label="Set inline voice"
+                    >
+                      <Users size={12} />
+                    </button>
+                  </Menu>
                   <button
                     className="stories-track__btn"
                     onClick={(e) => { e.stopPropagation(); insertPauseInto(track.id); }}

--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
 import WaveSurfer from 'wavesurfer.js';
 import RegionsPlugin from 'wavesurfer.js/dist/plugins/regions.esm.js';
 import MinimapPlugin from 'wavesurfer.js/dist/plugins/minimap.esm.js';
@@ -27,14 +27,14 @@ const REGION_COLORS = [
  *   disabled       – locks drag/resize of regions
  *   overlayContent – React node rendered as a translucent overlay on the waveform
  */
-export default function WaveformTimeline({
+function WaveformTimeline({
   audioSrc,
   videoSrc,
   segments = [],
   onSegmentsChange,
   disabled = false,
   overlayContent,
-}) {
+}, ref) {
   const waveContainerRef = useRef(null);  // div WaveSurfer draws into
   const videoContainerRef = useRef(null); // div we imperatively append the <video> into
   const wsRef         = useRef(null);
@@ -327,6 +327,43 @@ export default function WaveformTimeline({
     });
   }, [fingerprint, ready, disabled, segments]);
 
+  // Imperative seek + scroll hooks — used by the transcript table to jump the
+  // player to a clicked row, and by the mouse-wheel handler below.
+  useImperativeHandle(ref, () => ({
+    seekTo(time) {
+      const ws = wsRef.current;
+      if (ws && ready) {
+        try {
+          const d = ws.getDuration?.() || duration || 0;
+          const t = Math.max(0, Math.min(time, d || time));
+          if (typeof ws.setTime === 'function') ws.setTime(t);
+          else if (typeof ws.seekTo === 'function' && d > 0) ws.seekTo(t / d);
+        } catch (err) { console.warn('WaveSurfer seek failed:', err); }
+        return;
+      }
+      const el = mediaElRef.current;
+      if (el && Number.isFinite(time)) {
+        try { el.currentTime = Math.max(0, time); } catch (err) { console.warn('media seek failed:', err); }
+      }
+    },
+  }), [ready, duration]);
+
+  // Horizontal mouse-wheel → scroll the waveform. WaveSurfer doesn't bind this
+  // by default; users expect to spin the wheel over a long timeline. We also
+  // honour vertical wheel (most mice) as horizontal motion.
+  const onWaveWheel = useCallback((e) => {
+    const ws = wsRef.current;
+    if (!ws || !ready) return;
+    const wrap = ws.getWrapper?.();
+    if (!wrap) return;
+    // Don't fight the page when ctrl/cmd is held — that pinches zoom in browsers.
+    if (e.ctrlKey || e.metaKey) return;
+    const dx = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+    if (!dx) return;
+    e.preventDefault();
+    wrap.scrollLeft += dx;
+  }, [ready]);
+
   const togglePlay = useCallback(() => {
     if (wsRef.current) {
       wsRef.current.playPause();
@@ -399,6 +436,7 @@ export default function WaveformTimeline({
           <div
             ref={waveContainerRef}
             className="waveform-container wfm-wave-inner"
+            onWheel={onWaveWheel}
           />
 
           {/* Loading shimmer */}
@@ -439,3 +477,5 @@ export default function WaveformTimeline({
     </div>
   );
 }
+
+export default forwardRef(WaveformTimeline);

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -96,6 +96,14 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
         }
       } catch (err) { console.warn('Transcribe SSE handler failed:', err); }
     });
+    evt.addEventListener('warning', (e) => {
+      try {
+        const m = JSON.parse(e.data);
+        if (m && m.detail) {
+          toast(m.detail, { icon: '⚠️', duration: 8000 });
+        }
+      } catch { /* malformed warning event */ }
+    });
     evt.addEventListener('done', () => { close(); ctrl.signal.removeEventListener('abort', onAbortSignal); resolve(); });
     evt.addEventListener('aborted', () => { close(); ctrl.signal.removeEventListener('abort', onAbortSignal); reject(Object.assign(new Error('aborted'), { name: 'AbortError' })); });
     evt.addEventListener('error', (e) => {

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy, useState, useEffect, useCallback } from 'react';
+import React, { Suspense, lazy, useState, useEffect, useCallback, useRef } from 'react';
 import {
   PanelLeftOpen, PanelLeftClose, Film, Save, UploadCloud, Sparkles, Loader, Square,
   FileText, Play, DownloadIcon, Volume2, Link2,
@@ -90,6 +90,12 @@ export default function DubTab(props) {
   const setBurnSubs         = useAppStore(s => s.setBurnSubs);
 
   const showIdleSkeleton = !(dubJobId && (dubStep === 'editing' || dubStep === 'generating' || dubStep === 'done'));
+  // Imperative handle to the post-job waveform so the transcript table can
+  // seek the player when the user clicks a row.
+  const waveformRef = useRef(null);
+  const seekWaveform = useCallback((time) => {
+    waveformRef.current?.seekTo?.(time);
+  }, []);
   const [ingestUrl, setIngestUrl] = useState('');
   const [previewMode, setPreviewMode] = useState('original'); // 'original' | 'dubbed'
   const [exportOpen, setExportOpen] = useState(false);
@@ -543,6 +549,7 @@ export default function DubTab(props) {
               )}
               <WaveformTimeline
                 key={videoSrc}
+                ref={waveformRef}
                 audioSrc={`${API}/dub/audio/${dubJobId}`}
                 videoSrc={videoSrc}
                 segments={dubSegments}
@@ -907,6 +914,7 @@ export default function DubTab(props) {
                   onDirect={onDirectSegment}
                   onSplit={segmentSplit}
                   onMerge={segmentMerge}
+                  onSeek={seekWaveform}
                 />
               </Suspense>
             </div>

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -19,6 +19,7 @@ export type AppMode =
   | 'dub'
   | 'clone'
   | 'design'
+  | 'stories'
   | 'voice'
   | 'tools'
   | 'batch'

--- a/frontend/src/ui/Menu.css
+++ b/frontend/src/ui/Menu.css
@@ -1,7 +1,9 @@
 /* ── Menu primitive ─────────────────────────────────────────────── */
 
 .ui-menu {
-  position: fixed;
+  /* Position is set by Radix via inline styles — declaring `position` here
+   * (especially `fixed`) fights its anchored placement and can cause the
+   * popover to render against the viewport edge instead of the trigger. */
   z-index: var(--z-overlay);
   min-width: 160px;
   max-width: 320px;

--- a/frontend/src/ui/Menu.jsx
+++ b/frontend/src/ui/Menu.jsx
@@ -56,6 +56,8 @@ export default function Menu({
           side={side}
           align={align}
           sideOffset={4}
+          avoidCollisions
+          collisionPadding={8}
           className={`ui-menu ui-menu--below ui-menu--${align}`}
           style={width ? { width } : undefined}
         >

--- a/frontend/src/ui/index.js
+++ b/frontend/src/ui/index.js
@@ -2,7 +2,8 @@
 //  OmniVoice design-system barrel
 //
 //  Import from here, not the individual files:
-//    import { Button, Panel, Field, Input, Select, Dialog, Slider, Badge } from '@/ui';
+//    import { Button, Panel, Field, Input, Select, Dialog, Slider, Badge } from '../ui';
+//  (No '@/' alias is configured in vite.config.js — use a relative path.)
 //
 //  Tokens are imported once here so any file that reaches for a primitive
 //  also pulls in the full token scale.

--- a/frontend/src/utils/storyTokens.js
+++ b/frontend/src/utils/storyTokens.js
@@ -1,0 +1,78 @@
+/**
+ * Story-track text tokenizer.
+ *
+ * A Stories track is plain text plus two kinds of inline markers:
+ *
+ *   [pause 0.5s]            — emit `seconds` of silence
+ *   [voice:<profile-id>]    — switch the active voice to `<profile-id>`
+ *   [voice:default]         — revert to the track's default voice
+ *
+ * Markers are flat, never nested; the active voice persists until the next
+ * voice marker or the end of the track. `parseStoryText` walks the text and
+ * emits a sequence of events the preview/export pipeline can consume:
+ *
+ *   { type: 'chunk', text, profileId }   — speak `text` in `profileId`
+ *   { type: 'pause', seconds }           — insert silence
+ *
+ * Whitespace-only chunks between markers are dropped so they don't introduce
+ * audible "uhs" from the TTS model.
+ */
+
+// Single pattern that matches either token; the alternation captures the
+// payload in group 1 (pause seconds) or group 2 (voice id).
+const TOKEN_RE = /\[(?:pause\s+(\d+(?:\.\d+)?)\s*s?|voice:\s*([^\]]+))\]/gi;
+
+export function parseStoryText(text, defaultProfileId = null) {
+  const out = [];
+  if (!text) return out;
+  let currentProfile = defaultProfileId;
+  let cursor = 0;
+  // Use a fresh regex per call so concurrent callers don't share lastIndex state.
+  const re = new RegExp(TOKEN_RE.source, TOKEN_RE.flags);
+  let match;
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > cursor) {
+      const chunk = text.slice(cursor, match.index).trim();
+      if (chunk) out.push({ type: 'chunk', text: chunk, profileId: currentProfile });
+    }
+    if (match[1] != null) {
+      const seconds = parseFloat(match[1]);
+      if (Number.isFinite(seconds) && seconds > 0) {
+        out.push({ type: 'pause', seconds });
+      }
+    } else if (match[2] != null) {
+      const id = match[2].trim();
+      currentProfile = (id === 'default' || id === '') ? defaultProfileId : id;
+    }
+    cursor = re.lastIndex;
+  }
+  if (cursor < text.length) {
+    const tail = text.slice(cursor).trim();
+    if (tail) out.push({ type: 'chunk', text: tail, profileId: currentProfile });
+  }
+  return out;
+}
+
+/** True if `text` contains any inline marker we need to special-case for preview. */
+export function hasStoryMarkers(text) {
+  return /\[(?:pause\s+\d|voice:)/i.test(text || '');
+}
+
+/**
+ * Wrap a selection with an inline voice switch.
+ * - With a non-empty selection: `before [voice:X]selected[voice:default] after`
+ * - With a collapsed caret: inserts `[voice:X]` at the caret (caller-controlled).
+ *
+ * Returns the new text — the caller is responsible for state updates.
+ */
+export function applyInlineVoice(text, selectionStart, selectionEnd, voiceId) {
+  const s = Math.max(0, Math.min(selectionStart ?? 0, text.length));
+  const e = Math.max(s, Math.min(selectionEnd ?? s, text.length));
+  const before = text.slice(0, s);
+  const middle = text.slice(s, e);
+  const after = text.slice(e);
+  if (!middle) {
+    return `${before}[voice:${voiceId}]${after}`;
+  }
+  return `${before}[voice:${voiceId}]${middle}[voice:default]${after}`;
+}

--- a/frontend/src/utils/storyTokens.test.js
+++ b/frontend/src/utils/storyTokens.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { parseStoryText, hasStoryMarkers, applyInlineVoice } from './storyTokens';
+
+describe('parseStoryText', () => {
+  it('returns a single chunk with the default voice when no markers are present', () => {
+    const out = parseStoryText('Hello world.', 'narrator');
+    expect(out).toEqual([{ type: 'chunk', text: 'Hello world.', profileId: 'narrator' }]);
+  });
+
+  it('parses a pause token into an explicit pause event', () => {
+    const out = parseStoryText('Hello [pause 0.5s] world.', 'narrator');
+    expect(out).toEqual([
+      { type: 'chunk', text: 'Hello', profileId: 'narrator' },
+      { type: 'pause', seconds: 0.5 },
+      { type: 'chunk', text: 'world.', profileId: 'narrator' },
+    ]);
+  });
+
+  it('accepts pauses without trailing "s" and with integer seconds', () => {
+    const out = parseStoryText('A [pause 1] B [pause 2s] C', 'n');
+    expect(out.filter(e => e.type === 'pause')).toEqual([
+      { type: 'pause', seconds: 1 },
+      { type: 'pause', seconds: 2 },
+    ]);
+  });
+
+  it('switches voice on a voice marker and carries it forward', () => {
+    const out = parseStoryText('Default [voice:char-0] switched [pause 0.3s] still switched', 'narrator');
+    expect(out).toEqual([
+      { type: 'chunk', text: 'Default', profileId: 'narrator' },
+      { type: 'chunk', text: 'switched', profileId: 'char-0' },
+      { type: 'pause', seconds: 0.3 },
+      { type: 'chunk', text: 'still switched', profileId: 'char-0' },
+    ]);
+  });
+
+  it('reverts to the track default on [voice:default]', () => {
+    const out = parseStoryText('[voice:char-0]A[voice:default]B', 'narrator');
+    expect(out).toEqual([
+      { type: 'chunk', text: 'A', profileId: 'char-0' },
+      { type: 'chunk', text: 'B', profileId: 'narrator' },
+    ]);
+  });
+
+  it('drops whitespace-only chunks between markers', () => {
+    const out = parseStoryText('A   [pause 0.2s]   B', 'n');
+    // Only the trimmed "A" and "B" survive; the spaces between aren't spoken.
+    expect(out.filter(e => e.type === 'chunk').map(e => e.text)).toEqual(['A', 'B']);
+  });
+
+  it('ignores pauses with zero or negative seconds', () => {
+    const out = parseStoryText('A [pause 0s] B', 'n');
+    expect(out.some(e => e.type === 'pause')).toBe(false);
+  });
+
+  it('returns an empty list for empty input', () => {
+    expect(parseStoryText('', 'n')).toEqual([]);
+    expect(parseStoryText(null, 'n')).toEqual([]);
+  });
+});
+
+describe('hasStoryMarkers', () => {
+  it('returns true when either token is present', () => {
+    expect(hasStoryMarkers('A [pause 0.5s] B')).toBe(true);
+    expect(hasStoryMarkers('[voice:char-0] hello')).toBe(true);
+  });
+  it('returns false for plain prose', () => {
+    expect(hasStoryMarkers('Just regular text.')).toBe(false);
+    expect(hasStoryMarkers('Square [brackets] are fine.')).toBe(false);
+  });
+});
+
+describe('applyInlineVoice', () => {
+  it('wraps a non-empty selection with switch + default markers', () => {
+    const result = applyInlineVoice('Hello brave new world', 6, 11, 'char-0');
+    expect(result).toBe('Hello [voice:char-0]brave[voice:default] new world');
+  });
+  it('inserts a switch marker at the caret when the selection is collapsed', () => {
+    const result = applyInlineVoice('AB', 1, 1, 'char-1');
+    expect(result).toBe('A[voice:char-1]B');
+  });
+  it('clamps out-of-range indices to the text length', () => {
+    const result = applyInlineVoice('xy', 99, 99, 'c');
+    expect(result).toBe('xy[voice:c]');
+  });
+});


### PR DESCRIPTION
## Summary

Bundle of user-reported fixes + the deferred UX work, all written to be
platform/device-agnostic (CUDA, MPS, ROCm, CPU; Tauri, browser; macOS,
Windows, Linux). Five commits.

## Cross-platform bug fixes ([375ea4e](https://github.com/debpalash/OmniVoice-Studio/commit/375ea4e))

A user running OmniVoice through Pinokio on Windows hit three real bugs:

1. **\`docker compose --profile gpu up\` port-conflicts on 3900.** The CPU + GPU services both bind to the same host port. The Linux contributor's \`profiles: ["cpu"]\` fix had been reverted in #49 on CodeRabbit's advice — that was the wrong call. Restoring the profile + updating header comment + README to \`--profile cpu up\`.
2. **Argos / pip install from the UI fails in Docker** with \`No virtual environment found; run \\\`uv venv\\\`...\`. The Dockerfile sets \`UV_SYSTEM_PYTHON=1\` but that env var governs \`uv venv\`, not \`uv pip install\`. Added an \`_in_virtualenv()\` runtime check; \`run_pip\` now injects \`--system\` automatically when on system Python (Docker, bare metal). Inside a real venv it stays off.
3. **Speaker diarization silently falls back** to the silence-gap heuristic when pyannote isn't available (missing HF_TOKEN, license not accepted, network blocked). User reported a man↔woman exchange detected as one speaker. \`_diarize()\` now returns \`(segments, warning)\`; \`dub_core\` yields a \`warning\` SSE event; \`useDubWorkflow\` renders it as an 8-second toast so users know to set \`HF_TOKEN\`.

## Dub editor UX ([d5df454](https://github.com/debpalash/OmniVoice-Studio/commit/d5df454))

Per the annotated screenshots:

- **Start time is editable.** Accepts \`m:ss.s\` or raw seconds. Esc reverts, Enter commits; rejects values that would overlap the end.
- **Click a transcript row → seek the waveform/video.** \`WaveformTimeline\` now \`forwardRef\`s a \`seekTo(time)\` method; \`DubTab\` holds the ref and passes a callback into the segment table. Clicks inside inputs/buttons are filtered so per-cell editing keeps working.
- **Speaker is datalist-backed.** Pulls from detected speaker clones; falls back to free text. Custom names still allowed.
- **Scissors menu splits at cursor.** Was hardcoded to \`text.length / 2\` — felt random. Now uses the live caret if focused, the last remembered caret position otherwise, and a sentence-boundary heuristic as a final fallback.
- **Mouse-wheel scrolls the waveform.** Vertical wheel also accepted as horizontal motion. Ctrl/Cmd is left alone for browser pinch-zoom.
- **Menu popover no longer clips.** Added \`avoidCollisions\` + \`collisionPadding=8\` to Radix \`Content\`; removed \`position: fixed\` from \`.ui-menu\` (it was fighting Radix's anchored positioning).

## VRAM-aware GPU pool ([73dbe18](https://github.com/debpalash/OmniVoice-Studio/commit/73dbe18))

Why a 16 GB 5060ti dubbed a 2-minute video in 10–12 minutes: \`_gpu_pool = ThreadPoolExecutor(max_workers=1)\` — hardcoded since introduction. Every TTS forward serialized through one thread.

- CUDA / ROCm: \`workers = clamp(1, free_GB // 2.5, 4)\`. The 2.5 GB/job budget leaves room for the concurrent ASR + diarization pipelines. On a 16 GB card with ~14 GB free, picks 4 workers — about 4× the throughput on multi-segment dubs.
- MPS (Apple Silicon): 1 worker (shared system RAM).
- CPU / unknown / probe failure: 1 worker.
- \`OMNIVOICE_GPU_WORKERS\` env var overrides everything (clamped 1..16).

Module \`__getattr__\` keeps the public \`_gpu_pool\` symbol working for every existing caller — they just now get the lazily-sized pool.

## Stories tab — wire-up + UX ([f6bbc7a](https://github.com/debpalash/OmniVoice-Studio/commit/f6bbc7a))

The 264-line \`StoriesEditor\` component existed but was mounted nowhere. Wired it up + added the requested affordances:

- **NavRail** entry "Stories" with BookOpen icon.
- **App.jsx** lazy-loads on \`mode === 'stories'\`. \`AppMode\` extended.
- **Paste & Split** panel — paste a long passage, pick a max-chars cap, hit Split. Walks the text and breaks at the nearest sentence boundary (or whitespace, or hard cap) so each chunk stays under the limit. Live preview counter.
- **Insert pause** button per track inserts \`[pause 0.5s]\` at the caret.

## Stories — pauses + inline voice now functional ([edd3a1d](https://github.com/debpalash/OmniVoice-Studio/commit/edd3a1d))

Closes the "Out of scope" footnote from f6bbc7a.

- \`frontend/src/utils/storyTokens.js\` — a single tokenizer that walks a track and emits \`{type:'chunk',text,profileId}\` and \`{type:'pause',seconds}\` events. Voice switches are stateful (carry forward) until the next \`[voice:X]\` or end. \`[voice:default]\` reverts to the track's default profile. Whitespace-only chunks are dropped so the model doesn't say "uh" between markers.
- \`StoriesEditor.previewTrack\` — for plain text we keep the old single-shot path so \`track.audioUrl\` survives for replay. For marker-bearing text we fetch each chunk's audio in parallel, then chain \`HTMLAudioElement\` playback — \`ended\` triggers the next chunk; pauses use \`setTimeout\`. Object URLs are revoked after each chunk plays (and on early exit) so we don't leak.
- **Inline voice picker** — a Users-icon button per track opens a menu of installed profiles. Highlighting text + selecting wraps it with \`[voice:X]…[voice:default]\`. An empty selection inserts a switch at the caret. "Reset to track default" emits \`[voice:default]\`.
- 13 new vitest cases on the tokenizer covering plain text, pauses with and without trailing \`s\`, voice carry-forward, default reversion, whitespace handling, malformed pauses, and selection wrapping at edges. **Vitest is now 24/24** (was 11).

## Test plan

- [x] \`uv run pytest tests/\` → **214 passed**, 3 skipped, 10 xfailed, 3 xpassed
- [x] \`uv run pytest backend/tests/\` → **23 passed**
- [x] \`bun run test\` (vitest) → **24/24 passed** (13 new cases)
- [x] \`bunx tsc --noEmit --checkJs false\` clean
- [ ] Manual: \`docker compose --profile gpu up\` on a CUDA box, no port conflict
- [ ] Manual: install Argos from the UI inside the Docker image
- [ ] Manual: dub without HF_TOKEN → warning toast surfaces
- [ ] Manual: dub on GPU > 5 GB free → log says "GPU pool sized to N worker(s)"
- [ ] Manual: click transcript row, confirm waveform jumps to the segment
- [ ] Manual: edit a segment's start time, confirm waveform region moves
- [ ] Manual: open Stories tab, Paste & Split a paragraph
- [ ] Manual: insert \`[pause 0.5s]\` token, hit preview — audible silence at the right spot
- [ ] Manual: highlight text + Users-icon → pick a different voice, hit preview — voice switches mid-track

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stories editor (Paste & Split), Stories view/nav, pause-insert and narrator-track splitting; per-track preview handling
  * Click-to-seek table rows and programmatic waveform seeking (imperative seek API); waveform mouse-wheel horizontal scroll
  * Inline-editable segment start-times with validation

* **Bug Fixes**
  * Diarization now surfaces client-visible warnings on fallbacks/failures
  * Improved text-splitting using caret position; menu collision/position handling

* **Performance**
  * GPU worker pool now auto-sizes based on available VRAM

* **Documentation**
  * Docker Compose docs updated for explicit CPU/GPU profiles

* **Tests**
  * Unit tests for story-token parsing and utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->