### PR TITLE
Import .srt subtitles to bypass Whisper (closes #52)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -56,6 +56,83 @@ _kill_job_procs    = dub_pipeline.kill_job_procs
 _get_job           = dub_pipeline.get_job
 _save_job          = dub_pipeline.save_job
 
+@router.post("/dub/import-srt/{job_id}")
+async def dub_import_srt(job_id: str, file: UploadFile = File(...)):
+    """Replace `job["segments"]` with timestamps + text parsed from an SRT
+    file. Used as a fallback when Whisper mis-transcribes — the user can
+    point at their own pre-synced subtitles and skip ASR entirely.
+
+    Returns the new segment list plus counts of any cues we had to skip or
+    re-time (overlap shifts). The caller surfaces these so the user knows
+    if the import wasn't lossless.
+    """
+    job = _get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    try:
+        raw_bytes = await file.read()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Could not read uploaded file: {e}") from e
+    if not raw_bytes:
+        raise HTTPException(status_code=400, detail="Uploaded SRT file is empty.")
+    # Most SRT files are UTF-8 (with or without BOM); fall back to latin-1
+    # so legacy Windows-encoded subs don't blow up the import.
+    try:
+        text = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        text = raw_bytes.decode("latin-1", errors="replace")
+
+    from services.srt_parser import parse_srt
+    result = parse_srt(text)
+    if not result.segments:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No valid cues found in the uploaded file. "
+                f"Skipped {result.skipped_cues} malformed cue(s). "
+                "Expected SubRip (.srt) format: index, then 'HH:MM:SS,ms --> HH:MM:SS,ms', then text, blank line."
+            ),
+        )
+
+    # Clamp cues that run past the source media's known duration. Pipeline
+    # downstream code assumes segment.end <= duration; without this, dub
+    # generation would try to time-stretch into negative slack.
+    duration = float(job.get("duration") or 0.0)
+    clamped = 0
+    if duration > 0:
+        kept = []
+        for seg in result.segments:
+            if seg["start"] >= duration:
+                continue
+            if seg["end"] > duration:
+                seg = {**seg, "end": round(duration, 3)}
+                clamped += 1
+            kept.append(seg)
+        # Re-id after clamp drops.
+        segments = [{**s, "id": i} for i, s in enumerate(kept)]
+    else:
+        segments = result.segments
+
+    job["segments"] = segments
+    # `source_lang` stays whatever the user (or the upload step) set; we
+    # don't try to language-detect off the cue text — that's noisy and the
+    # user usually knows what their .srt is.
+    _save_job(job_id, job)
+    logger.info(
+        "Imported %d cue(s) from .srt for job %s (skipped=%d, overlap_shifted=%d, clamped=%d)",
+        len(segments), job_id, result.skipped_cues, result.dropped_overlaps, clamped,
+    )
+    return {
+        "segments": segments,
+        "stats": {
+            "imported": len(segments),
+            "skipped_malformed": result.skipped_cues,
+            "dropped_overlap": result.dropped_overlaps,
+            "clamped_to_duration": clamped,
+        },
+    }
+
+
 @router.post("/dub/cleanup-segments/{job_id}")
 def dub_cleanup_segments(job_id: str):
     """Re-run merge/stitch passes on a job's existing segments to drop fragments."""

--- a/backend/services/srt_parser.py
+++ b/backend/services/srt_parser.py
@@ -1,0 +1,120 @@
+"""SRT (SubRip subtitle) parser.
+
+Lenient by design — many "SRT" files in the wild are slightly off-spec
+(missing index numbers, blank-line variants, BOM, `.` instead of `,` in
+the milliseconds separator). We accept what we can, drop what we can't,
+and report counts so the caller can warn the user.
+
+Returns a list of segments compatible with the dub-pipeline shape used
+elsewhere in the backend:
+
+    {
+        "id": int,
+        "start": float,             # seconds
+        "end": float,               # seconds
+        "text": str,
+        "text_original": str,       # same as `text` on import; mutable later
+        "speaker_id": "Speaker 1",  # filler — no diarization on raw .srt
+    }
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# Captures: HH MM SS sep(`,` or `.`) ms (1-3 digits)
+_TS = r"(\d{1,2}):([0-5]?\d):([0-5]?\d)[,.](\d{1,3})"
+# Whole timing line: `00:00:01,000 --> 00:00:04,500` plus optional trailing
+# cue style hints (X1: Y1: ... ) we just throw away.
+_TIMING_RE = re.compile(rf"^\s*{_TS}\s*-->\s*{_TS}.*$", re.MULTILINE)
+
+
+def _ts_to_seconds(h: str, m: str, s: str, ms: str) -> float:
+    # Pad ms to 3 digits so "5" -> 0.005, "50" -> 0.050.
+    ms_padded = (ms + "000")[:3]
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms_padded) / 1000.0
+
+
+@dataclass
+class SrtParseResult:
+    segments: list[dict]
+    skipped_cues: int            # malformed cues we couldn't recover
+    dropped_overlaps: int        # cues that overlapped a kept one
+
+
+def parse_srt(content: str) -> SrtParseResult:
+    """Parse SRT text and return cleaned, non-overlapping segments.
+
+    - Skips cues with non-positive duration or unparseable timestamps.
+    - When two cues overlap, keeps the earlier one and shifts the later
+      one's `start` forward to the earlier's `end` (rather than dropping
+      it outright — overlapping is common in captions and the user's
+      intent is usually "both lines should play, in order"). If the
+      adjustment leaves the later cue with zero/negative duration it
+      gets dropped and `dropped_overlaps` increments.
+    """
+    if not content:
+        return SrtParseResult([], 0, 0)
+
+    # Strip BOM and normalise line endings; many editors save SRTs as CRLF.
+    text = content.lstrip("﻿").replace("\r\n", "\n").replace("\r", "\n")
+
+    raw: list[dict] = []
+    skipped = 0
+    # Find every timing line, slice the cue text from there to the next
+    # timing line (or end of file). This is robust to missing index
+    # numbers and to spec deviations in the blank-line separator.
+    matches = list(_TIMING_RE.finditer(text))
+    for i, m in enumerate(matches):
+        try:
+            start = _ts_to_seconds(m.group(1), m.group(2), m.group(3), m.group(4))
+            end = _ts_to_seconds(m.group(5), m.group(6), m.group(7), m.group(8))
+        except (ValueError, IndexError):
+            skipped += 1
+            continue
+        if end <= start:
+            skipped += 1
+            continue
+        body_start = m.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[body_start:body_end].strip("\n")
+        # Drop the trailing index number of the NEXT cue (which got eaten
+        # into our body) by trimming trailing digit-only lines.
+        lines = body.split("\n")
+        while lines and lines[-1].strip().isdigit():
+            lines.pop()
+        cue_text = "\n".join(line.strip() for line in lines if line.strip())
+        if not cue_text:
+            skipped += 1
+            continue
+        raw.append({"start": start, "end": end, "text": cue_text})
+
+    raw.sort(key=lambda r: r["start"])
+
+    # De-overlap pass.
+    out: list[dict] = []
+    dropped = 0
+    last_end = 0.0
+    for r in raw:
+        s, e = r["start"], r["end"]
+        if s < last_end:
+            s = last_end
+        if e <= s:
+            dropped += 1
+            continue
+        out.append({"start": s, "end": e, "text": r["text"]})
+        last_end = e
+
+    segments = [
+        {
+            "id": i,
+            "start": round(seg["start"], 3),
+            "end": round(seg["end"], 3),
+            "text": seg["text"],
+            "text_original": seg["text"],
+            "speaker_id": "Speaker 1",
+        }
+        for i, seg in enumerate(out)
+    ]
+    return SrtParseResult(segments=segments, skipped_cues=skipped, dropped_overlaps=dropped)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -295,6 +295,7 @@ function App() {
     handleDubAbort, handleDubRetryTranscribe,
     handleDubStop, handleDubGenerate,
     handleCleanupSegments, handleTranslateAll,
+    handleDubImportSrt,
   } = useDubWorkflow({ loadProjects, loadProfiles, loadDubHistory, setLastGenFingerprints });
 
   const [dubVideoFile, setDubVideoFile] = useState(null);
@@ -969,6 +970,7 @@ function App() {
               incrementalPlan={incrementalPlan}
               handleTranslateAll={handleTranslateAll}
               handleCleanupSegments={handleCleanupSegments}
+              handleDubImportSrt={handleDubImportSrt}
               triggerDownload={triggerDownload}
               fileToMediaUrl={fileToMediaUrl}
               editSegments={editSegments}

--- a/frontend/src/api/dub.ts
+++ b/frontend/src/api/dub.ts
@@ -50,6 +50,29 @@ export async function dubCleanupSegments(jobId: string): Promise<unknown> {
   return apiPost(`/dub/cleanup-segments/${jobId}`);
 }
 
+export interface DubImportSrtResponse {
+  segments: Array<{
+    id: number;
+    start: number;
+    end: number;
+    text: string;
+    text_original: string;
+    speaker_id: string;
+  }>;
+  stats: {
+    imported: number;
+    skipped_malformed: number;
+    dropped_overlap: number;
+    clamped_to_duration: number;
+  };
+}
+
+export async function dubImportSrt(jobId: string, file: File | Blob): Promise<DubImportSrtResponse> {
+  const fd = new FormData();
+  fd.append('file', file);
+  return apiPost<DubImportSrtResponse>(`/dub/import-srt/${jobId}`, fd);
+}
+
 export async function dubTranslate(body: Record<string, unknown>): Promise<DubTranslateResponse> {
   return apiPost<DubTranslateResponse>('/dub/translate', body);
 }

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -3,7 +3,7 @@ import { useAppStore } from '../store';
 import {
   dubUpload, dubIngestUrl, dubAbort as apiDubAbort, dubCleanupSegments,
   dubTranslate, dubGenerate, tasksStreamUrl, tasksCancel,
-  transcribeStreamUrl,
+  transcribeStreamUrl, dubImportSrt,
 } from '../api/dub';
 import { PRESETS } from '../utils/constants';
 import { apiPost } from '../api/client';
@@ -231,6 +231,35 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     } finally { dubAbortCtrlRef.current = null; }
   }, [dubJobId, setDubError, setDubSegments, setDubStep, _waitForTranscribe, loadProjects]);
 
+  const handleDubImportSrt = useCallback(async (file) => {
+    if (!dubJobId) {
+      toast.error('Upload or ingest a video first — there is no job to attach subtitles to.');
+      return;
+    }
+    if (!file) return;
+    try {
+      setDubError('');
+      const res = await dubImportSrt(dubJobId, file);
+      const segs = (res && res.segments) || [];
+      setDubSegments(segs.map(s => ({
+        ...s,
+        id: s.id != null ? String(s.id) : String(Math.random()),
+      })));
+      setDubStep('editing');
+      const stats = res?.stats || {};
+      const noteParts = [`Imported ${stats.imported ?? segs.length} cue(s) from ${file.name || '.srt'}`];
+      if (stats.skipped_malformed) noteParts.push(`${stats.skipped_malformed} skipped (malformed)`);
+      if (stats.dropped_overlap) noteParts.push(`${stats.dropped_overlap} dropped (overlap)`);
+      if (stats.clamped_to_duration) noteParts.push(`${stats.clamped_to_duration} clamped to media length`);
+      toast.success(noteParts.join(' · '), { duration: 6000 });
+      loadProjects();
+    } catch (err) {
+      const msg = err?.message || 'SRT import failed';
+      setDubError(msg);
+      toast.error(msg);
+    }
+  }, [dubJobId, setDubError, setDubSegments, setDubStep, loadProjects]);
+
   const handleCleanupSegments = useCallback(async () => {
     if (!dubJobId || !dubSegments.length) return;
     const before = dubSegments.length;
@@ -387,5 +416,6 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     handleDubAbort, handleDubRetryTranscribe,
     handleDubStop, handleDubGenerate,
     handleCleanupSegments, handleTranslateAll,
+    handleDubImportSrt,
   };
 }

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -41,7 +41,7 @@ export default function DubTab(props) {
     segmentPreviewLoading,
     selectedSegIds,
     setDubVideoFile, setDubLocalBlobUrl,
-    handleDubAbort, handleDubUpload, handleDubIngestUrl, handleDubRetryTranscribe, handleDubStop, handleDubGenerate,
+    handleDubAbort, handleDubUpload, handleDubIngestUrl, handleDubRetryTranscribe, handleDubStop, handleDubGenerate, handleDubImportSrt,
     handleDubDownload, handleDubAudioDownload, handleAudioExport,
     speakerClones = {},
     handleSegmentPreview, onDirectSegment, handleTranslateAll, handleCleanupSegments,
@@ -258,6 +258,27 @@ export default function DubTab(props) {
                   Retry transcription
                 </Button>
               )}
+              {handleDubImportSrt && (
+                <label
+                  htmlFor="srt-import-banner-input"
+                  className="dub-idle-upload-label"
+                  title="Upload your own .srt to bypass ASR"
+                  style={{ cursor: 'pointer' }}
+                >
+                  <FileText size={11} /> Import .srt instead
+                  <input
+                    id="srt-import-banner-input"
+                    type="file"
+                    accept=".srt,text/srt,text/plain"
+                    hidden
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) handleDubImportSrt(f);
+                      e.target.value = '';
+                    }}
+                  />
+                </label>
+              )}
             </div>
           )}
 
@@ -289,6 +310,27 @@ export default function DubTab(props) {
                     <label htmlFor="video-upload" className="dub-idle-upload-label">
                       <Film size={13} /> Change file
                     </label>
+                    {dubJobId && handleDubImportSrt && (
+                      <label
+                        htmlFor="srt-import-input"
+                        className="dub-idle-upload-label"
+                        title="Use your own .srt subtitles instead of running Whisper transcription"
+                        style={{ cursor: 'pointer' }}
+                      >
+                        <FileText size={13} /> Import .srt
+                        <input
+                          id="srt-import-input"
+                          type="file"
+                          accept=".srt,text/srt,text/plain"
+                          hidden
+                          onChange={(e) => {
+                            const f = e.target.files?.[0];
+                            if (f) handleDubImportSrt(f);
+                            e.target.value = '';
+                          }}
+                        />
+                      </label>
+                    )}
                     <button className="btn-primary dub-change-row__cta"
                       onClick={handleDubUpload}
                       disabled={dubStep === 'uploading' || dubStep === 'transcribing'}>

--- a/tests/test_srt_parser.py
+++ b/tests/test_srt_parser.py
@@ -1,0 +1,161 @@
+"""Unit tests for the SRT parser used by /dub/import-srt."""
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from services.srt_parser import parse_srt  # noqa: E402
+
+
+def test_parses_a_well_formed_srt_file():
+    srt = """1
+00:00:01,000 --> 00:00:04,500
+Hello world.
+
+2
+00:00:05,250 --> 00:00:08,000
+Second line here.
+"""
+    result = parse_srt(srt)
+    assert result.skipped_cues == 0
+    assert result.dropped_overlaps == 0
+    assert len(result.segments) == 2
+    assert result.segments[0]["start"] == 1.0
+    assert result.segments[0]["end"] == 4.5
+    assert result.segments[0]["text"] == "Hello world."
+    assert result.segments[1]["start"] == 5.25
+    assert result.segments[1]["text"] == "Second line here."
+
+
+def test_joins_multi_line_cues_with_newline():
+    srt = """1
+00:00:01,000 --> 00:00:04,000
+Line one
+Line two
+"""
+    result = parse_srt(srt)
+    assert result.segments[0]["text"] == "Line one\nLine two"
+
+
+def test_accepts_dot_as_milliseconds_separator():
+    # WebVTT-style timestamps inside an SRT file are common in the wild.
+    srt = """1
+00:00:01.500 --> 00:00:03.250
+Dotty.
+"""
+    result = parse_srt(srt)
+    assert result.segments[0]["start"] == 1.5
+    assert result.segments[0]["end"] == 3.25
+
+
+def test_handles_utf8_bom_at_start_of_file():
+    srt = "﻿1\n00:00:01,000 --> 00:00:02,000\nBOM cue.\n"
+    result = parse_srt(srt)
+    assert len(result.segments) == 1
+    assert result.segments[0]["text"] == "BOM cue."
+
+
+def test_handles_crlf_line_endings():
+    srt = "1\r\n00:00:01,000 --> 00:00:02,000\r\nWindows.\r\n\r\n"
+    result = parse_srt(srt)
+    assert len(result.segments) == 1
+
+
+def test_skips_cue_with_non_positive_duration():
+    srt = """1
+00:00:05,000 --> 00:00:05,000
+Zero duration.
+
+2
+00:00:06,000 --> 00:00:05,500
+End before start.
+
+3
+00:00:07,000 --> 00:00:08,000
+Good cue.
+"""
+    result = parse_srt(srt)
+    assert result.skipped_cues == 2
+    assert len(result.segments) == 1
+    assert result.segments[0]["text"] == "Good cue."
+
+
+def test_skips_cue_with_only_whitespace_body():
+    srt = """1
+00:00:01,000 --> 00:00:02,000
+
+
+2
+00:00:03,000 --> 00:00:04,000
+Real text.
+"""
+    result = parse_srt(srt)
+    assert result.skipped_cues == 1
+    assert len(result.segments) == 1
+
+
+def test_shifts_overlapping_cue_to_keep_both():
+    # Cue 2 starts inside cue 1; we expect cue 2's start to be pushed
+    # forward to cue 1's end so both still play, in order.
+    srt = """1
+00:00:01,000 --> 00:00:05,000
+First.
+
+2
+00:00:03,000 --> 00:00:07,000
+Second.
+"""
+    result = parse_srt(srt)
+    assert len(result.segments) == 2
+    assert result.segments[1]["start"] == 5.0
+    assert result.segments[1]["end"] == 7.0
+    assert result.dropped_overlaps == 0
+
+
+def test_drops_overlap_that_would_have_negative_duration():
+    srt = """1
+00:00:01,000 --> 00:00:10,000
+First.
+
+2
+00:00:03,000 --> 00:00:08,000
+Second entirely inside first.
+"""
+    result = parse_srt(srt)
+    assert len(result.segments) == 1
+    assert result.dropped_overlaps == 1
+
+
+def test_parses_missing_index_numbers():
+    # No "1", "2" lines — just timings + text. This happens with some
+    # subtitle editors that strip indices.
+    srt = """00:00:01,000 --> 00:00:02,000
+First.
+
+00:00:03,000 --> 00:00:04,000
+Second.
+"""
+    result = parse_srt(srt)
+    assert len(result.segments) == 2
+
+
+def test_returns_empty_result_for_empty_input():
+    assert parse_srt("").segments == []
+    assert parse_srt("").skipped_cues == 0
+
+
+def test_segments_get_sequential_ids_and_required_fields():
+    srt = """1
+00:00:01,000 --> 00:00:02,000
+A
+
+2
+00:00:03,000 --> 00:00:04,000
+B
+"""
+    result = parse_srt(srt)
+    for i, seg in enumerate(result.segments):
+        assert seg["id"] == i
+        assert seg["text"] == seg["text_original"]
+        assert seg["speaker_id"] == "Speaker 1"


### PR DESCRIPTION
Closes #52.

## Summary

Users who already have correct, pre-synced subtitles can now skip ASR entirely. Upload a video as normal → hit **Import .srt** instead of **Upload & Transcribe** → cues populate the dub segment list directly → translate / dub / export from there.

@eternal1104 reported this as a Whisper-accuracy escape hatch (background noise, accents, etc.). The fix is small because the dub pipeline already operates on a \`segments\` array — an .srt file is literally that data in a different format.

## Backend

- **\`backend/services/srt_parser.py\`** — lenient SubRip parser. Tolerates BOM, CRLF, missing index numbers, dot-vs-comma ms separator, and overlap (shifts the later cue's start to the earlier's end rather than dropping). Skips cues with non-positive duration or empty bodies; reports per-bucket counts so the UI can warn the user when an import wasn't lossless.
- **\`POST /dub/import-srt/{job_id}\`** — accepts the .srt file, parses it, clamps cues that run past the source media's duration, replaces \`job["segments"]\`, persists. Decodes UTF-8 with BOM first, falls back to latin-1 for legacy Windows subs so we don't 500 on Notepad output.

## Frontend

- **\`dubImportSrt\`** helper in \`api/dub.ts\` + a typed response shape.
- **\`handleDubImportSrt\`** in \`useDubWorkflow.js\` — sets segments, flips \`dubStep\` to \`'editing'\`, shows a toast with per-bucket counts: \`Imported 42 cue(s) from foo.srt · 1 skipped (malformed) · 2 clamped to media length\`.
- **DubTab.jsx**: an "Import .srt" button next to "Upload & Transcribe" once a job exists, *and* a smaller "Import .srt instead" affordance in the transcription-failure banner — the exact recovery path the reporter described.

## Tests

12 new pytest cases on the parser cover:
- well-formed input, multi-line cues
- dot-as-separator (WebVTT-style)
- UTF-8 BOM, CRLF line endings
- malformed cues (non-positive duration, empty body)
- overlap shift, overlap-becomes-zero drop
- missing index numbers (some editors strip them)
- empty input
- output shape (sequential ids, speaker filler)

## Test plan

- [x] \`uv run pytest tests/\` → **226 passed** (was 214 — 12 new), 3 skipped, 10 xfailed, 3 xpassed
- [x] \`uv run pytest backend/tests/\` → 23 passed
- [x] \`bun run test\` (vitest) → 11/11
- [x] \`bunx tsc --noEmit --checkJs false\` clean
- [ ] Manual: upload a video, click Import .srt with a well-formed file → segments populate, segment table editable
- [ ] Manual: try importing a malformed SRT → error message names the problem
- [ ] Manual: import an SRT longer than the media → toast notes clamped count
- [ ] Manual: trigger a transcription failure, use "Import .srt instead" banner button → recovers cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now import SRT subtitle files directly into existing dub jobs
  * The system automatically handles various SRT format variations, encoding issues, and overlapping segments
  * Import results display summary statistics: imported cues, skipped entries, dropped overlaps, and clamped segments
  * Added SRT upload options in the dub workflow interface

* **Tests**
  * Added comprehensive test coverage for SRT file parsing and import functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->