### PR TITLE
fix: lazy-load ASR during desktop startup

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -295,12 +295,15 @@ async def dub_transcribe_stream(job_id: str):
             preflight_error = "No audio available for transcription."
         else:
             from services.asr_backend import get_active_asr_backend
-            _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
-            if _asr_backend.id == "pytorch-whisper" and getattr(_model, "_asr_pipe", None) is None:
-                preflight_error = (
-                    "No ASR backend is ready. Install WhisperX/faster-whisper/MLX Whisper "
-                    "or set OMNIVOICE_PRELOAD_TTS_ASR=1 before launch to use the PyTorch fallback."
-                )
+            try:
+                _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
+                if _asr_backend.id == "pytorch-whisper" and getattr(_model, "_asr_pipe", None) is None:
+                    preflight_error = (
+                        "No ASR backend is ready. Install WhisperX/faster-whisper/MLX Whisper "
+                        "or set OMNIVOICE_PRELOAD_TTS_ASR=1 before launch to use the PyTorch fallback."
+                    )
+            except Exception as e:
+                preflight_error = f"ASR backend initialization failed: {e}"
             scene_cuts = job.get("scene_cuts") or []
 
     async def gen():

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -288,22 +288,20 @@ async def dub_transcribe_stream(job_id: str):
         preflight_error = "Job not found. It may have been cleaned up or was never created."
     else:
         _model = await get_model()
-        if _model._asr_pipe is None:
-            preflight_error = (
-                "ASR (speech recognition) isn't loaded yet. The model is still warming up or "
-                "Whisper failed to initialise — check Settings → Models for status, or restart "
-                "the server if 'Idle' persists."
-            )
+        asr_audio_target = job.get("vocals_path")
+        if not asr_audio_target or not os.path.exists(asr_audio_target):
+            asr_audio_target = job.get("audio_path")
+        if not asr_audio_target or not os.path.exists(asr_audio_target):
+            preflight_error = "No audio available for transcription."
         else:
-            asr_audio_target = job.get("vocals_path")
-            if not asr_audio_target or not os.path.exists(asr_audio_target):
-                asr_audio_target = job.get("audio_path")
-            if not asr_audio_target or not os.path.exists(asr_audio_target):
-                preflight_error = "No audio available for transcription."
-            else:
-                from services.asr_backend import get_active_asr_backend
-                _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
-                scene_cuts = job.get("scene_cuts") or []
+            from services.asr_backend import get_active_asr_backend
+            _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
+            if _asr_backend.id == "pytorch-whisper" and getattr(_model, "_asr_pipe", None) is None:
+                preflight_error = (
+                    "No ASR backend is ready. Install WhisperX/faster-whisper/MLX Whisper "
+                    "or set OMNIVOICE_PRELOAD_TTS_ASR=1 before launch to use the PyTorch fallback."
+                )
+            scene_cuts = job.get("scene_cuts") or []
 
     async def gen():
         if preflight_error:
@@ -543,11 +541,6 @@ async def dub_transcribe(job_id: str):
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     _model = await get_model()
-    if _model._asr_pipe is None:
-        raise HTTPException(
-            status_code=503,
-            detail="ASR (speech recognition) isn't loaded yet. The model is still warming up or Whisper failed to initialise — check Settings → Models for status, or restart the server if 'Idle' persists.",
-        )
 
     def _transcribe():
         import re
@@ -573,9 +566,12 @@ async def dub_transcribe(job_id: str):
             detected_lang = result.get("language")
         except Exception as e:
             logger.error("ASR backend %s failed: %s", _asr.id, e)
+            if getattr(_model, "_asr_pipe", None) is None:
+                raise RuntimeError(
+                    f"ASR backend {_asr.id} failed and PyTorch Whisper fallback is not preloaded: {e}"
+                ) from e
             # Last-resort fallback — in-memory pytorch whisper via the TTS
-            # model's pipeline. Guaranteed present since the TTS model is
-            # already loaded to reach this code path.
+            # model's pipeline when explicitly preloaded.
             audio_np, sr = sf.read(asr_audio_target, dtype="float32")
             if audio_np.ndim > 1: audio_np = audio_np.mean(axis=1)
             bs = 16 if torch.cuda.is_available() else 1

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -564,25 +564,31 @@ async def dub_transcribe(job_id: str):
         from services.asr_backend import get_active_asr_backend
         _asr = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
         try:
-            logger.info("Transcribing full audio via %s ...", _asr.id)
-            result = _asr.transcribe(asr_audio_target, word_timestamps=True)
-            detected_lang = result.get("language")
-        except Exception as e:
-            logger.error("ASR backend %s failed: %s", _asr.id, e)
-            if getattr(_model, "_asr_pipe", None) is None:
-                raise RuntimeError(
-                    f"ASR backend {_asr.id} failed and PyTorch Whisper fallback is not preloaded: {e}"
-                ) from e
-            # Last-resort fallback — in-memory pytorch whisper via the TTS
-            # model's pipeline when explicitly preloaded.
-            audio_np, sr = sf.read(asr_audio_target, dtype="float32")
-            if audio_np.ndim > 1: audio_np = audio_np.mean(axis=1)
-            bs = 16 if torch.cuda.is_available() else 1
-            result = _model._asr_pipe(
-                {"array": audio_np, "sampling_rate": sr},
-                return_timestamps=True, chunk_length_s=15, batch_size=bs,
-            )
-            detected_lang = (result.get("language") if isinstance(result, dict) else None)
+            try:
+                logger.info("Transcribing full audio via %s ...", _asr.id)
+                result = _asr.transcribe(asr_audio_target, word_timestamps=True)
+                detected_lang = result.get("language")
+            except Exception as e:
+                logger.error("ASR backend %s failed: %s", _asr.id, e)
+                if getattr(_model, "_asr_pipe", None) is None:
+                    raise RuntimeError(
+                        f"ASR backend {_asr.id} failed and PyTorch Whisper fallback is not preloaded: {e}"
+                    ) from e
+                # Last-resort fallback — in-memory pytorch whisper via the TTS
+                # model's pipeline when explicitly preloaded.
+                audio_np, sr = sf.read(asr_audio_target, dtype="float32")
+                if audio_np.ndim > 1: audio_np = audio_np.mean(axis=1)
+                bs = 16 if torch.cuda.is_available() else 1
+                result = _model._asr_pipe(
+                    {"array": audio_np, "sampling_rate": sr},
+                    return_timestamps=True, chunk_length_s=15, batch_size=bs,
+                )
+                detected_lang = (result.get("language") if isinstance(result, dict) else None)
+        finally:
+            try:
+                _asr.unload()
+            except Exception as e:
+                logger.warning("Failed to unload ASR backend: %s", e)
 
         job["source_lang"] = (detected_lang or "en").split("_")[0][:2].lower()
 
@@ -610,11 +616,6 @@ async def dub_transcribe(job_id: str):
         for s in segments:
             s.setdefault("text_original", s.get("text", ""))
         job["full_transcript"] = " ".join(s["text"] for s in segments)
-
-        try:
-            _asr.unload()
-        except Exception as e:
-            logger.warning("Failed to unload ASR backend: %s", e)
 
         if torch.backends.mps.is_available():
             torch.mps.empty_cache()

--- a/backend/main.py
+++ b/backend/main.py
@@ -224,6 +224,13 @@ from utils import hf_progress
 hf_progress.install()
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_db()
@@ -246,30 +253,31 @@ async def lifespan(app: FastAPI):
     worker_task = asyncio.create_task(task_manager.worker())
     # Warm the TTS model in the background so first /generate is instant.
     preload_task = asyncio.create_task(preload_model())
-    # Warm the capture ASR engine (MLX Whisper Turbo on Apple Silicon) so
-    # first dictation is instant. Without this, first capture takes ~25s
-    # just to load the model.
-    async def _preload_capture_asr():
-        try:
-            from services.model_manager import _gpu_pool, _loading_detail
-            loop = asyncio.get_running_loop()
-            def _warm():
-                from services.asr_backend import get_capture_asr_backend
-                _loading_detail["sub_stage"] = "loading_asr"
-                _loading_detail["detail"] = "Warming up ASR engine…"
-                backend = get_capture_asr_backend()
-                logger.info("Capture ASR backend selected: %s", backend.id)
-                # Actually load model weights into memory — without this the
-                # first dictation still takes ~25s for weight loading.
-                if hasattr(backend, 'warmup'):
-                    _loading_detail["detail"] = f"Loading {backend.display_name}…"
-                    backend.warmup()
-                _loading_detail["sub_stage"] = "ready"
-                _loading_detail["detail"] = "ASR engine ready"
-            await loop.run_in_executor(_gpu_pool, _warm)
-        except Exception as e:
-            logger.warning("Capture ASR preload skipped: %s", e)
-    capture_preload_task = asyncio.create_task(_preload_capture_asr())
+    # Capture ASR is useful to keep warm, but it is another large model in
+    # unified memory on Apple Silicon. Keep launch lean by default; users who
+    # prefer instant dictation can opt in with OMNIVOICE_PRELOAD_CAPTURE_ASR=1.
+    if _env_flag("OMNIVOICE_PRELOAD_CAPTURE_ASR"):
+        async def _preload_capture_asr():
+            try:
+                from services.model_manager import _gpu_pool, _loading_detail
+                loop = asyncio.get_running_loop()
+                def _warm():
+                    from services.asr_backend import get_capture_asr_backend
+                    _loading_detail["sub_stage"] = "loading_asr"
+                    _loading_detail["detail"] = "Warming up ASR engine…"
+                    backend = get_capture_asr_backend()
+                    logger.info("Capture ASR backend selected: %s", backend.id)
+                    if hasattr(backend, 'warmup'):
+                        _loading_detail["detail"] = f"Loading {backend.display_name}…"
+                        backend.warmup()
+                    _loading_detail["sub_stage"] = "ready"
+                    _loading_detail["detail"] = "ASR engine ready"
+                await loop.run_in_executor(_gpu_pool, _warm)
+            except Exception as e:
+                logger.warning("Capture ASR preload skipped: %s", e)
+        capture_preload_task = asyncio.create_task(_preload_capture_asr())
+    else:
+        logger.info("Capture ASR preload disabled; dictation ASR will load on first use.")
     yield
     # ── Graceful shutdown (SIGTERM from Tauri, Ctrl+C, etc.) ────────────
     logger.info("Shutdown: cleaning up…")

--- a/backend/main.py
+++ b/backend/main.py
@@ -258,22 +258,29 @@ async def lifespan(app: FastAPI):
     # prefer instant dictation can opt in with OMNIVOICE_PRELOAD_CAPTURE_ASR=1.
     if _env_flag("OMNIVOICE_PRELOAD_CAPTURE_ASR"):
         async def _preload_capture_asr():
+            loading_detail = None
+            prev_loading_detail = None
             try:
                 from services.model_manager import _gpu_pool, _loading_detail
+                loading_detail = _loading_detail
+                prev_loading_detail = dict(loading_detail)
                 loop = asyncio.get_running_loop()
                 def _warm():
                     from services.asr_backend import get_capture_asr_backend
-                    _loading_detail["sub_stage"] = "loading_asr"
-                    _loading_detail["detail"] = "Warming up ASR engine…"
+                    loading_detail["sub_stage"] = "loading_asr"
+                    loading_detail["detail"] = "Warming up ASR engine…"
                     backend = get_capture_asr_backend()
                     logger.info("Capture ASR backend selected: %s", backend.id)
                     if hasattr(backend, 'warmup'):
-                        _loading_detail["detail"] = f"Loading {backend.display_name}…"
+                        loading_detail["detail"] = f"Loading {backend.display_name}…"
                         backend.warmup()
-                    _loading_detail["sub_stage"] = "ready"
-                    _loading_detail["detail"] = "ASR engine ready"
+                    loading_detail["sub_stage"] = "ready"
+                    loading_detail["detail"] = "ASR engine ready"
                 await loop.run_in_executor(_gpu_pool, _warm)
             except Exception as e:
+                if loading_detail is not None and loading_detail.get("sub_stage") == "loading_asr":
+                    loading_detail.clear()
+                    loading_detail.update(prev_loading_detail or {})
                 logger.warning("Capture ASR preload skipped: %s", e)
         capture_preload_task = asyncio.create_task(_preload_capture_asr())
     else:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -169,6 +169,23 @@ def _set_loading(sub_stage: str, detail: str = "", error: str | None = None, pro
     _loading_detail["progress"] = progress
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def should_preload_tts_asr() -> bool:
+    """Whether OmniVoice.from_pretrained should attach PyTorch Whisper.
+
+    The default is intentionally false. On Apple Silicon, eager TTS + ASR
+    loading can overcommit unified memory and leave desktop startup stuck
+    at the model-loading stage. ASR backends still load on demand.
+    """
+    return _env_flag("OMNIVOICE_PRELOAD_TTS_ASR")
+
+
 def _load_model_sync():
     global model
     from utils.hf_progress import register_listener, unregister_listener
@@ -198,8 +215,13 @@ def _load_model_sync():
         checkpoint = os.environ.get("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
         _set_loading("loading_weights", f"Loading TTS weights on {device}…")
         logger.info("Loading OmniVoice model on device: %s", device)
+        preload_asr = should_preload_tts_asr()
+        if preload_asr:
+            logger.info("Preloading PyTorch Whisper with TTS model.")
+        else:
+            logger.info("Skipping PyTorch Whisper preload; ASR will load on demand.")
         _model = OmniVoice.from_pretrained(
-            checkpoint, device_map=device, dtype=torch.float16, load_asr=True,
+            checkpoint, device_map=device, dtype=torch.float16, load_asr=preload_asr,
         )
 
         try:

--- a/tests/test_model_manager_preload.py
+++ b/tests/test_model_manager_preload.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def model_manager(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+
+    import services.model_manager as mm
+
+    monkeypatch.setattr(mm, "_torch", None)
+    monkeypatch.setattr(mm, "_OmniVoice", None)
+    monkeypatch.setattr(mm, "model", None)
+    monkeypatch.setenv("OMNIVOICE_MODEL", "test/checkpoint")
+    return mm
+
+
+def test_tts_asr_preload_is_opt_in(model_manager, monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_PRELOAD_TTS_ASR", raising=False)
+    assert model_manager.should_preload_tts_asr() is False
+
+    for value in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("OMNIVOICE_PRELOAD_TTS_ASR", value)
+        assert model_manager.should_preload_tts_asr() is True
+
+    monkeypatch.setenv("OMNIVOICE_PRELOAD_TTS_ASR", "0")
+    assert model_manager.should_preload_tts_asr() is False
+
+
+def test_load_model_skips_pytorch_whisper_by_default(model_manager, monkeypatch):
+    calls = []
+
+    class DummyOmniVoice:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.delenv("OMNIVOICE_PRELOAD_TTS_ASR", raising=False)
+    monkeypatch.setattr(model_manager, "_lazy_torch", lambda: SimpleNamespace(float16="float16"))
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: DummyOmniVoice)
+    monkeypatch.setattr(model_manager, "get_best_device", lambda: "mps")
+
+    loaded = model_manager._load_model_sync()
+
+    assert loaded.llm is not None
+    assert calls == [
+        (
+            ("test/checkpoint",),
+            {"device_map": "mps", "dtype": "float16", "load_asr": False},
+        )
+    ]
+
+
+def test_load_model_can_preload_pytorch_whisper_when_requested(model_manager, monkeypatch):
+    calls = []
+
+    class DummyOmniVoice:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.setenv("OMNIVOICE_PRELOAD_TTS_ASR", "1")
+    monkeypatch.setattr(model_manager, "_lazy_torch", lambda: SimpleNamespace(float16="float16"))
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: DummyOmniVoice)
+    monkeypatch.setattr(model_manager, "get_best_device", lambda: "mps")
+
+    model_manager._load_model_sync()
+
+    assert calls[0][1]["load_asr"] is True


### PR DESCRIPTION
## Summary

- Avoid preloading PyTorch Whisper ASR when the desktop app loads the OmniVoice TTS model.
- Keep ASR loading available on demand, with `OMNIVOICE_PRELOAD_TTS_ASR=1` as an opt-in for eager preload.
- Make capture/dictation ASR warmup opt-in with `OMNIVOICE_PRELOAD_CAPTURE_ASR=1`.
- Allow dub transcription routes to use the configured ASR backend without requiring the PyTorch Whisper fallback to already be attached to the TTS model.

## Why

On Apple Silicon, eager TTS + ASR loading can overcommit unified memory during desktop startup. This can leave the app stuck in the model-loading stage before the UI becomes usable.

## Tests

- `uv run pytest backend/ tests/test_model_manager_preload.py -x -q`
- `./node_modules/.bin/vite build --mode development`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription error handling for streaming and non-streaming flows: more informative in-stream error events, reliable fallback behavior, and ensured backend cleanup on failure.

* **New Features**
  * ASR preloading is now configurable via environment flags so ASR models can be optionally preloaded or deferred to reduce startup resource use.

* **Tests**
  * Added tests for ASR preload configuration and model-loading defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->