### PR TITLE
fix: setuptools pin, Linux/Russia troubleshooting (#58, #56, #60)

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,248 @@
+<!-- refreshed: 2026-05-16 -->
+# Architecture
+
+**Analysis Date:** 2026-05-16
+
+## System Overview
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│              Desktop Shell  (Tauri v2 + Rust)                          │
+│  `frontend/src-tauri/src/main.rs` → `lib.rs`                          │
+│                                                                        │
+│  bootstrap.rs   tools.rs   backend.rs   commands.rs   config.rs       │
+│  (venv + uv)  (sidecar)  (spawn uvicorn) (IPC cmds) (region/hotkey)  │
+└──────────────────────┬─────────────────────────────────────────────────┘
+                       │ spawns subprocess  /  IPC invoke
+                       ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│              React 18 SPA  (Vite + JSX)                                │
+│  `frontend/src/main.jsx` → `main-app.jsx` → `App.jsx`                 │
+│                                                                        │
+│  pages/          components/         hooks/           store/           │
+│  (full views)   (shared UI)       (data logic)   (Zustand slices)     │
+│                                                                        │
+│  api/client.ts → fetch → http://127.0.0.1:3900                        │
+│  hooks/useRealtimeEvents.js → ws://127.0.0.1:3900/ws/events           │
+└──────────────────────┬─────────────────────────────────────────────────┘
+                       │ HTTP REST + WebSocket
+                       ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│              FastAPI Backend  (Python 3.11 / uvicorn)                  │
+│  `backend/main.py`  — app factory, lifespan, 22 routers               │
+│                                                                        │
+│  api/routers/      services/          core/                           │
+│  (HTTP handlers)  (ML + pipeline)  (db, config, tasks, event_bus)     │
+└──────────────────────┬─────────────────────────────────────────────────┘
+                       │ Python import
+                       ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│              OmniVoice Model Package                                   │
+│  `omnivoice/models/omnivoice.py`  (lazy-loaded on first generate)     │
+└──────────────────────┬─────────────────────────────────────────────────┘
+                       │
+                       ▼
+┌───────────────────────────────────────────────────────────────────────┐
+│  SQLite  (`omnivoice.db` in platform data dir)                        │
+│  + file system outputs (outputs/, voices/, dub_jobs/, preview/)       │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Responsibilities
+
+| Component | Responsibility | Key Files |
+|-----------|----------------|-----------|
+| Tauri shell | Desktop window management, sidecar bootstrap, IPC commands | `frontend/src-tauri/src/lib.rs`, `bootstrap.rs`, `backend.rs` |
+| React SPA | All UI rendering, client-side state, API calls | `frontend/src/App.jsx`, `frontend/src/main-app.jsx` |
+| Zustand store | Persistent + transient app state, slice composition | `frontend/src/store/index.ts` |
+| API layer | Typed wrappers around every backend endpoint | `frontend/src/api/client.ts`, `frontend/src/api/*.ts` |
+| FastAPI app | HTTP routing, middleware, lifespan startup/shutdown | `backend/main.py` |
+| Routers | Thin HTTP handlers (one file per domain) | `backend/api/routers/*.py` |
+| Services | ML inference, dubbing pipeline, DSP, ASR, translation | `backend/services/*.py` |
+| Core | DB init/migrations, config, task queue, event bus, job store | `backend/core/*.py` |
+| Model package | TTS model weights + inference class | `omnivoice/models/omnivoice.py` |
+| MCP server | AI-agent tool interface (stdio or SSE) | `backend/mcp_server.py` |
+| Plugin SDK | Abstract base + registry for third-party TTS engines | `backend/services/plugin_sdk.py` |
+
+## Pattern Overview
+
+**Overall:** Layered monolith with an async task queue — a single FastAPI process owns all ML inference, routing, and persistence. The desktop shell is a thin Tauri wrapper that spawns the Python backend as a subprocess sidecar.
+
+**Key Characteristics:**
+- No microservices; all backend logic in one Python process on port 3900
+- React SPA deployed as static files served by the same FastAPI process (`/`) in production; Vite dev server in development
+- ML inference always offloaded to a single-threaded `ThreadPoolExecutor` (`_gpu_pool`) to avoid GIL contention with FastAPI's async event loop
+- Real-time UI updates driven by a WebSocket event bus (`/ws/events`) instead of polling
+- SQLite with WAL mode for all persistence; no ORM — raw `sqlite3` with a context-managed `db_conn()` helper
+
+## Layers
+
+**Desktop Shell (Rust/Tauri):**
+- Purpose: OS integration — window, tray icon, single-instance, global shortcut
+- Location: `frontend/src-tauri/src/`
+- Contains: Bootstrap state machine, subprocess management, Tauri IPC commands
+- Depends on: Python backend (HTTP health probe), `uv`, `ffmpeg`/`ffprobe` sidecars
+- Used by: End user on macOS/Windows/Linux desktop
+
+**React Frontend:**
+- Purpose: Full application UI
+- Location: `frontend/src/`
+- Contains: Pages, components, custom hooks, Zustand slices, typed API wrappers
+- Depends on: Backend REST API (HTTP), backend WebSocket (`/ws/events`)
+- Used by: Tauri webview in desktop mode; any browser in server/web mode
+
+**FastAPI Routers:**
+- Purpose: HTTP boundary — validate requests, delegate to services, return responses
+- Location: `backend/api/routers/`
+- Contains: 22 routers covering generation, dubbing, profiles, projects, setup, capture, etc.
+- Depends on: Services, Core
+- Used by: Frontend API layer, MCP server, external OpenAI-compat clients
+
+**Services:**
+- Purpose: ML inference and media pipeline — the "heavy" business logic
+- Location: `backend/services/`
+- Contains: `model_manager.py` (TTS loading/idle), `tts_backend.py`, `asr_backend.py`, `dub_pipeline.py`, `speaker_clone.py`, `translation_engines.py`, `audio_dsp.py`, `ffmpeg_utils.py`, etc.
+- Depends on: Core config, OmniVoice model package, external ML libs
+- Used by: Routers
+
+**Core:**
+- Purpose: Shared infrastructure with no ML dependencies
+- Location: `backend/core/`
+- Contains: `db.py` (SQLite init + migrations), `config.py` (paths), `event_bus.py` (WebSocket pub/sub), `tasks.py` (async task manager + SSE), `job_store.py` (SQLite job metadata), `prefs.py` (user prefs JSON), `onboarding.py`, `personalities.py`
+- Depends on: Nothing outside stdlib and `core.config`
+- Used by: Services, Routers
+
+**OmniVoice Model Package:**
+- Purpose: TTS model definition and inference
+- Location: `omnivoice/` (top-level package, separate from `backend/`)
+- Contains: `models/omnivoice.py` — the `OmniVoice` class
+- Depends on: PyTorch, torchaudio
+- Used by: `backend/services/model_manager.py` (lazy-loaded)
+
+## Data Flow
+
+### TTS Generation Request
+
+1. User submits form in `frontend/src/pages/CloneDesignTab.jsx`
+2. `frontend/src/api/generate.ts` calls `apiPost('/generate', formData)`
+3. `backend/api/routers/generation.py` → `POST /generate` handler validates form fields
+4. Handler calls `await get_model()` from `backend/services/model_manager.py` — loads TTS if not in memory
+5. `loop.run_in_executor(_gpu_pool, _run_inference, ...)` offloads PyTorch to the GPU thread pool
+6. `_run_inference` calls `model.generate(...)` from `omnivoice/models/omnivoice.py`
+7. Result passes through `services/audio_dsp.py` (`apply_mastering`, `normalize_audio`)
+8. Audio written to `OUTPUTS_DIR`; metadata inserted into `generation_history` via `core/db.py`
+9. `core/event_bus.emit("generation_history")` → broadcasts to all WebSocket listeners
+10. HTTP response streams WAV bytes back to frontend (`StreamingResponse`)
+11. `frontend/src/hooks/useRealtimeEvents.js` receives the `generation_history` event → TanStack Query cache invalidated → sidebar refreshes
+
+### Dubbing Pipeline
+
+1. User uploads video in `frontend/src/pages/DubTab.jsx`
+2. `POST /dub/ingest` → `backend/api/routers/dub_core.py` streams SSE progress events
+3. `services/dub_pipeline.py` manages job state + file paths under `DUB_DIR`
+4. Pipeline stages: ffmpeg extract audio → ASR (`services/asr_backend.py`) → translate (`services/translation_engines.py`) → re-synthesize per segment (`services/tts_backend.py`) → ffmpeg re-compose
+5. Each stage emits SSE events the frontend consumes via `EventSource`
+6. Final export via `POST /dub/export` → `backend/api/routers/dub_export.py`
+
+### Desktop Bootstrap Sequence
+
+1. Tauri `run()` in `frontend/src-tauri/src/lib.rs` — app builds, window opens
+2. `BootstrapSplash` React component renders, polling `bootstrap_status` Tauri IPC command
+3. `backend.rs` calls `bootstrap::ensure_venv_ready()` — checks for `.venv`, runs `uv sync --frozen` if absent
+4. On venv ready, `backend.rs` spawns `uvicorn backend.main:app --port 3900`
+5. `backend.rs` probes `GET /system/info` until healthy (max 60 s)
+6. Bootstrap stage transitions to `Ready` → splash removed → main App renders
+7. `backend/main.py` lifespan: `init_db()` → sweep orphans → `preload_model()` task started
+
+**State Management:**
+- Frontend: Zustand (`frontend/src/store/`) — slices for prefs, UI, dub, generate, pill, glossary. Persisted subset to `localStorage` under key `omnivoice.app`
+- Backend: SQLite for durable state; in-memory `dict` for active job runtime state; `prefs.json` for user preferences
+
+## Key Abstractions
+
+**TaskManager (`backend/core/tasks.py`):**
+- Purpose: In-memory async task dispatcher with SQLite-backed metadata
+- Pattern: Each long job (dub ingest, batch TTS) gets a UUID, stored in `jobs` table; SSE listeners fan out progress events; `?after_seq=N` allows reconnect and replay
+
+**EventBus (`backend/core/event_bus.py`):**
+- Purpose: Push-based sidebar reactivity — fire-and-forget pub/sub to all connected WebSocket clients
+- Pattern: `emit(kind, payload)` is safe from both sync and async; frontend treats events as cache invalidation signals (not data payloads)
+
+**TTSPlugin / PluginSDK (`backend/services/plugin_sdk.py`):**
+- Purpose: Extension point for third-party TTS engines
+- Pattern: Subclass `TTSPlugin`, decorate with `@register_plugin` or add to `PLUGINS` dict; engine appears in Settings engine picker
+
+**AppStore (`frontend/src/store/index.ts`):**
+- Purpose: Single Zustand root store composed from typed slices
+- Pattern: `useAppStore(s => s.field)` at call sites; never create sibling stores; `partialize` controls which fields survive reload
+
+## Entry Points
+
+**Backend (HTTP server):**
+- Location: `backend/main.py`
+- Triggers: `uvicorn backend.main:app` (spawned by Tauri) or direct invocation
+- Responsibilities: FastAPI app factory, lifespan startup (DB init, task workers, model preload), CORS, static file mounts, 22 router registrations
+
+**Desktop app:**
+- Location: `frontend/src-tauri/src/main.rs` → `lib.rs:run()`
+- Triggers: User launches OmniVoice.app / .exe
+- Responsibilities: Tauri window setup, single-instance enforcement, bootstrap state machine, backend subprocess lifecycle, system tray, global dictation shortcut
+
+**Frontend SPA:**
+- Location: `frontend/src/main.jsx` → `main-app.jsx:bootstrapApp()`
+- Triggers: Tauri webview load or browser navigation
+- Responsibilities: React root render, QueryClient setup, font + i18n init, widget vs. main app branching (`?window=widget`)
+
+**MCP Server:**
+- Location: `backend/mcp_server.py`
+- Triggers: `python -m backend.mcp_server` (stdio for Claude Desktop) or `--sse` flag
+- Responsibilities: Expose TTS generation + voice profile listing as AI-agent tools
+
+## Architectural Constraints
+
+- **Threading:** FastAPI runs on a single asyncio event loop. All PyTorch/ML work runs in `_gpu_pool` (single-worker `ThreadPoolExecutor` in `backend/services/model_manager.py`) to serialize GPU access. CPU-bound work uses `_cpu_pool` (up to 8 workers).
+- **Global state:** `model_manager.py` holds `model` (TTS model singleton), `_gpu_pool`, `_cpu_pool`, `_loading_detail` as module-level singletons. `dub_pipeline.py` holds `_dub_jobs` and `_active_procs` module-level dicts. `event_bus.py` holds `_listeners` module-level list.
+- **Circular imports:** `backend/main.py` imports from `core.*` and `services.*`; routers import from both layers. Avoid importing `api.*` from `services.*` or `core.*`.
+- **Port:** Backend always binds to port 3900 (overridable via `OMNIVOICE_PORT`). Frontend hardcodes this default in `frontend/src/api/client.ts`.
+- **Data dir:** All user data (DB, audio outputs, voice references) lives under a platform-specific directory resolved by `backend/core/config.py:get_app_data_dir()`. Never write to the project root at runtime.
+
+## Anti-Patterns
+
+### Importing API routers from services or core
+
+**What happens:** A service or core module imports from `api/routers/`.
+**Why it's wrong:** Creates a circular dependency chain; routers already import services/core.
+**Do this instead:** Services emit to `core.event_bus` or return data to the router; the router shapes the HTTP response.
+
+### Writing ML inference directly in router handlers
+
+**What happens:** PyTorch calls or heavy I/O inside an `async def` route without `run_in_executor`.
+**Why it's wrong:** Blocks the asyncio event loop; all other requests hang for the duration of inference.
+**Do this instead:** Wrap the synchronous work in `await loop.run_in_executor(_gpu_pool, fn, *args)` as in `backend/api/routers/generation.py`.
+
+### Creating sibling Zustand stores in the frontend
+
+**What happens:** A new feature calls `create<SomeSlice>()` at module level instead of adding a slice to the root store.
+**Why it's wrong:** Breaks the single-store contract; persisted state becomes fragmented across multiple `localStorage` keys.
+**Do this instead:** Create a new slice file under `frontend/src/store/`, export `createXxxSlice`, import and spread it in `frontend/src/store/index.ts`.
+
+## Error Handling
+
+**Strategy:** FastAPI global exception handler in `backend/main.py` catches unhandled exceptions, writes to `CRASH_LOG_PATH`, attaches CORS headers, and returns `500` JSON. Client disconnects are caught separately and return `499`.
+
+**Patterns:**
+- Routers raise `HTTPException` for known bad inputs (400, 404)
+- Services raise `RuntimeError` for ML failures (OOM, engine crash), which bubble to the global handler
+- Frontend: `apiFetch` in `frontend/src/api/client.ts` throws `ApiError` on non-2xx responses; components use `react-hot-toast` for user-visible errors
+
+## Cross-Cutting Concerns
+
+**Logging:** Python `logging` with rotating file handler at `LOG_PATH` (2 MB, 3 backups). JSON format opt-in via `OMNIVOICE_JSON_LOGS=1`. Log level via `OMNIVOICE_LOG_LEVEL`. Logger namespace convention: `omnivoice.<module>` (e.g., `omnivoice.api`, `omnivoice.model`, `omnivoice.db`).
+
+**Validation:** Pydantic handled by FastAPI on request bodies where schema files exist (`backend/schemas/`). File path inputs use `os.path.realpath` + prefix checks to prevent traversal.
+
+**Authentication:** None — single-user local application. CORS restricted to `tauri://localhost` + `localhost:3901` by default (overridable via `OMNIVOICE_ALLOWED_ORIGINS`).
+
+---
+
+*Architecture analysis: 2026-05-16*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,154 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-05-16
+
+## Naming Patterns
+
+**Files (Python backend):**
+- Modules use `snake_case`: `dub_pipeline.py`, `job_queue.py`, `tts_backend.py`
+- Router files are prefixed by domain: `dub_core.py`, `dub_generate.py`, `dub_export.py`, `dub_translate.py`
+- Private/internal module helpers are prefixed with `_`: `_get_semaphore`, `_spawn_with_retry`, `_clamp`
+
+**Files (Frontend):**
+- React components use `PascalCase`: `Button.jsx`, `Dialog.jsx`, `CastingView.jsx`
+- Hooks use `camelCase` with `use` prefix: `useTTS.js`, `useDubWorkflow.js`, `useSegmentEditing.js`
+- API modules use `camelCase` or `kebab-case` context nouns: `client.ts`, `dub.ts`, `profiles.ts`
+- Utility modules use `camelCase`: `format.js`, `media.js`, `constants.js`
+
+**Functions (Python):**
+- Public functions: `snake_case` — `compute_file_hash`, `safe_job_dir`, `parse_srt`
+- Private/internal helpers: leading underscore `_snake_case` — `_ts_to_seconds`, `_transcribe_chunk`, `_load`
+- Async functions follow same convention; no `async_` prefix — `ingest_pipeline`, `run_proc`
+
+**Functions (Frontend JS/TS):**
+- Regular functions and hooks: `camelCase` — `apiUrl`, `apiFetch`, `apiJson`, `apiPost`
+- React components: `PascalCase` — `Button`, `WaveformTimeline`, `BootstrapSplash`
+
+**Variables (Python):**
+- Module-level constants: `SCREAMING_SNAKE_CASE` — `DATA_DIR`, `DUB_DIR`, `TRANSCRIBE_CHUNK_S`, `CPU_POOL_WORKERS`
+- Module-level private state: leading underscore `_snake_case` — `_dub_jobs`, `_active_procs`, `_listeners`, `_crash_log_lock`
+- Local variables: `snake_case`
+
+**Types/Classes (Python):**
+- Classes: `PascalCase` — `JobQueue`, `JobState`, `DubSegment`, `ExportRequest`, `SrtParseResult`
+- Enums: `PascalCase` with `SCREAMING_SNAKE_CASE` members — `class JobState(str, enum.Enum): QUEUED = "queued"`
+- Pydantic models: `PascalCase` — `DubRequest`, `DubSegment`, `RevealRequest`
+- Dataclasses: `PascalCase` — `Job`
+
+**Types/Interfaces (TypeScript):**
+- Interfaces: `PascalCase` — `EngineBackend`, `SystemInfo`, `EngineFamilyResponse`
+- Type aliases: `PascalCase` — `EngineFamily`
+- Error classes: `PascalCase` — `ApiError`
+
+## Code Style
+
+**Formatting (Python):**
+- Ruff is configured (`.ruff_cache/` present, version 0.15.11)
+- `from __future__ import annotations` used in 38 of 75 Python files in `backend/` — use it in all new files that use type hints
+- No trailing commas rule enforced; inline comments used heavily for context
+- Long docstrings at module top describe purpose and section breakdown
+
+**Formatting (Frontend):**
+- No Prettier config detected — formatting is not strictly enforced beyond ESLint
+- Tailwind CSS 4.x via `@tailwindcss/vite` plugin; utility classes inline in JSX
+
+**Linting:**
+- Python: Ruff (`.ruff_cache/` confirms active use). Suppressions use `# noqa: <CODE>` inline
+  - Common suppressions: `# noqa: F401` (side-effect imports), `# noqa: BLE001` (broad exception catch), `# noqa: E402` (module-level import order)
+  - `# type: ignore[<category>]` used for optional third-party deps that may not be installed
+- Frontend: ESLint 10.x configured in `frontend/eslint.config.js`
+  - Applies `eslint/js.recommended`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`
+  - Rule override: `'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }]` — uppercase constants are exempt
+  - TypeScript: `tsc --noEmit --checkJs false` in CI (JS errors pre-existing; only `.ts` files block CI)
+
+## Import Organization
+
+**Python order (per `backend/services/dub_pipeline.py` pattern):**
+1. `from __future__ import annotations`
+2. Standard library imports (alphabetical within group): `asyncio`, `hashlib`, `json`, `logging`, `os`, …
+3. `from typing import …`
+4. Third-party packages: `import soundfile as sf`
+5. Internal project imports: `from core.config import …`, `from fastapi import …`, `from services.… import …`
+
+**Python internal import note:**
+- Lazy imports inside functions are used for optional heavy dependencies to avoid import errors when the dep is not installed (e.g., `import whisperx`, `import mlx_audio`). Guarded with `# noqa: F401` + `try/except ImportError`.
+
+**Frontend order (per `frontend/src/App.jsx` and hook files):**
+1. React and framework imports: `import React, { useState, … } from 'react'`
+2. CSS imports: `import './index.css'`
+3. Internal store: `import { useAppStore } from './store'`
+4. Internal components: `import Button from './components/Button'`
+5. Internal hooks: `import useTTS from './hooks/useTTS'`
+6. Internal API: `import { apiJson } from './api/client'`
+7. Internal utils: `import { formatTime } from './utils/format'`
+8. Third-party libs: `import { toast } from 'react-hot-toast'`
+
+**Path Aliases:**
+- No `@/` path alias configured in Vite. All imports use relative paths.
+
+## Error Handling
+
+**Python backend patterns:**
+- Route handlers raise `fastapi.HTTPException` with explicit `status_code` and `detail` string: `raise HTTPException(status_code=404, detail="Job not found")`
+- Service-layer functions raise Python exceptions (`ValueError`, `RuntimeError`, `OSError`) — routers catch and convert to `HTTPException`
+- `from e` chaining used on re-raises: `raise HTTPException(status_code=400, ...) from e`
+- Broad `except Exception as e:` used only in entry-point/recovery paths, suppressed with `# noqa: BLE001`
+- `logger.error(...)` / `logger.warning(...)` called before or after raising in service code
+
+**Frontend patterns:**
+- `ApiError` class (`frontend/src/api/client.ts`) carries `.status` and `.detail`; thrown by `apiFetch` on non-2xx
+- Error detail extracted from JSON `{ detail }` or `{ error }` field first, then raw text, then `statusText`
+- `toast.error(...)` used in React components for user-visible errors (via `react-hot-toast`)
+
+## Logging
+
+**Framework:** Python `logging` module; logger names follow `"omnivoice.<module>"` pattern
+
+**Logger declaration (always module-level):**
+```python
+logger = logging.getLogger("omnivoice.dub")   # in dub_generate.py
+logger = logging.getLogger("omnivoice.jobs")  # in job_queue.py, job_store.py
+logger = logging.getLogger("omnivoice.db")    # in core/db.py
+```
+
+**Patterns:**
+- `logger.info(...)` for normal milestones (cache hit, job start/end)
+- `logger.warning(...)` for recoverable failures (demucs fallback, subprocess kill error)
+- `logger.error(...)` for data integrity failures (DB decode error, persist failure)
+- Use `%s` lazy-format, not f-strings in logger calls: `logger.warning("msg %s: %s", job_id, e)`
+
+## Comments
+
+**When to Comment:**
+- Module-level docstrings required for services and routers — describe responsibility, what's included, what stays elsewhere
+- Section dividers used with em-dash box comments: `# ── Section Name ──────────────────────────────────────────────────────────`
+- Inline comments explain non-obvious business logic, pinned dependency reasons, and platform constraints
+- Pinned dependency rationale always documented inline in `pyproject.toml`
+
+**Docstrings:**
+- Module: multi-line triple-quote with description, sub-sections where applicable
+- Classes: single-line triple-quote on the class body line: `"""Single-lane serial async worker with cancellation and introspection."""`
+- Functions: single-line triple-quote when purpose is non-obvious: `"""SHA-256 digest of a file, streamed in 256 KB chunks."""`
+- No NumPy/Google-style parameter docs observed — prose-style only
+
+## Function Design
+
+**Size:** No strict line limit; complex service functions (ingest pipeline, dub pipeline) are long but heavily sectioned with inline comments. Aim for single responsibility.
+
+**Parameters:** Type-annotated in all new code. Optional parameters use `Optional[T] = None` or `T | None = None` (Python 3.11 style). Pydantic `BaseModel` used for HTTP request bodies.
+
+**Return Values:** Type-annotated in all new code. Return `Optional[str]`/`Optional[dict]` for functions that can return `None` rather than raising.
+
+## Module Design
+
+**Exports:**
+- Python: no explicit `__all__` observed; consumers import by name. Private helpers use `_` prefix.
+- Frontend: named exports preferred for utilities and API functions. Default export used for React components and hooks.
+
+**Barrel Files:**
+- Python: `backend/api/routers/setup/__init__.py` re-exports from submodules with `# noqa: F401`
+- Frontend: `frontend/src/store/index.js` (implied by `import { useAppStore } from '../store'`)
+
+---
+
+*Convention analysis: 2026-05-16*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,248 @@
+# External Integrations
+
+**Analysis Date:** 2026-05-16
+
+## APIs & External Services
+
+**LLM / AI Inference (Translation & Glossary):**
+- OpenAI-compatible endpoints — cinematic translation, glossary auto-extraction, TTS translation
+  - SDK/Client: `openai` Python package (lazy import in `backend/services/llm_backend.py`)
+  - Auth: `TRANSLATE_API_KEY` env var (falls back to `OPENAI_API_KEY`)
+  - Base URL: `TRANSLATE_BASE_URL` env var (defaults to OpenAI; override for Ollama `http://localhost:11434/v1`, LM Studio, Together, Anyscale, DeepSeek, Qwen, OpenRouter)
+  - Model: `TRANSLATE_MODEL` env var (default `gpt-4o-mini`)
+  - Timeout: `OMNIVOICE_LLM_TIMEOUT` env var (default 45 seconds)
+  - Backend selection: `OMNIVOICE_LLM_BACKEND` env var or user preference in `core/prefs`
+  - Implementation: `backend/services/llm_backend.py`, `backend/services/translator.py`
+
+**HuggingFace Hub:**
+- Purpose: model weight downloads (OmniVoice, WhisperX, NLLB-200, pyannote, mlx-community models)
+  - Auth: `HF_TOKEN` env var (required for gated models like pyannote speaker diarization)
+  - Cache: `HF_HOME` / `HF_HUB_CACHE` env vars (or `OMNIVOICE_CACHE_DIR`)
+  - Windows cache path override: `%LOCALAPPDATA%\OmniVoice\hf_cache` (auto-set in `backend/core/config.py`)
+  - Xet disabled by default (`HF_HUB_DISABLE_XET=1`) to keep tqdm progress hooks working
+  - HTTP client: `httpx` (shared pool in `backend/api/http_client.py`); HuggingFace Hub SDK uses its own session
+
+**YouTube / URL Video Download:**
+- `yt-dlp ≥2024.12.13` — downloads video from YouTube URLs for dubbing workflow
+  - No API key required for public videos
+  - Used in: `backend/api/routers/dub_core.py`, `backend/services/dub_pipeline.py`
+
+## Translation Providers
+
+The translation engine registry (`backend/services/translation_engines.py`) is the single source of truth. Engines are installed/uninstalled at runtime via `uv pip` or `python -m pip`.
+
+**Offline (no API key):**
+- `argos` — Argos Translate (`argostranslate` package); pure-CPU, ~50 MB language packs downloaded per language pair
+- `nllb` — Meta NLLB-200 (`transformers` package, already a core dep); ~2.4 GB HF model download
+
+**Online (no API key):**
+- `google` — Google Translate via `deep_translator` package; free web endpoint, rate-limited
+- `mymemory` — MyMemory via `deep_translator`; crowdsourced, 5K chars/day anonymous free tier
+
+**Online (API key required):**
+- `deepl` — DeepL via `deep_translator`; 500K chars/month free tier
+  - Auth: `DEEPL_API_KEY` env var
+- `microsoft` — Azure Cognitive Services Translator via `deep_translator`; 2M chars/month free tier
+  - Auth: `MICROSOFT_API_KEY` env var
+- `openai` — Any OpenAI-compatible endpoint via `openai` package (GPT-4/5, Claude via OpenRouter, Gemini, DeepSeek, Qwen, Ollama, LM Studio)
+  - Auth: `TRANSLATE_API_KEY` + `TRANSLATE_BASE_URL` + `TRANSLATE_MODEL`
+
+## Data Storage
+
+**Databases:**
+- SQLite — sole persistent data store
+  - DB file: `{DATA_DIR}/omnivoice.db` (path resolved in `backend/core/config.py`)
+  - Client: Python stdlib `sqlite3` — WAL mode + foreign keys enforced on every connection
+  - Connection factory: `backend/core/db.py` (`get_db()`, `db_conn()` context manager)
+  - Schema: `backend/core/db.py` (`_BASE_SCHEMA`)
+  - Migrations: in-band in `init_db()` via `PRAGMA user_version` (4 versions as of analysis date)
+  - Tables: `voice_profiles`, `generation_history`, `dub_history`, `studio_projects`, `export_history`, `glossary_terms`, `jobs`, `job_events`
+  - Alembic: configured in `alembic.ini` / `backend/migrations/` — used for formal migration authoring; URL set programmatically from `core.config.DB_PATH`
+
+**File Storage:**
+- Local filesystem only — all user data stored under `DATA_DIR`
+  - `{DATA_DIR}/voices/` — reference audio for voice profiles
+  - `{DATA_DIR}/outputs/` — generated audio files (served as `/audio` static mount)
+  - `{DATA_DIR}/dub_jobs/` — dubbing job artifacts
+  - `{DATA_DIR}/preview/` — preview audio clips
+  - `{DATA_DIR}/outputs/marketplace/` — locally published `.omnivoice` voice bundles
+  - Voice profiles exported as `.omnivoice` ZIP bundles (metadata.json + audio, `backend/api/routers/marketplace.py`)
+- Docker: `/app/omnivoice_data` volume (`deploy/docker-compose.yml`)
+
+**Caching:**
+- HuggingFace Hub cache: `{HF_HOME}` / `{HF_HUB_CACHE}` (models, tokenizers)
+- PyTorch hub cache: `{TORCH_HOME}`
+- No Redis or in-memory external cache — job event replay uses `job_events` SQLite table
+
+## Authentication & Identity
+
+**Auth Provider:** None — OmniVoice ships with no built-in authentication layer.
+- The Docker Compose config explicitly warns to put OmniVoice behind a reverse proxy with auth if exposed externally (`deploy/docker-compose.yml`, comments)
+- Default port binding: `127.0.0.1:3900` (localhost only)
+- CORS: restricted to `localhost:3901`, `127.0.0.1:3901`, `tauri://localhost`, `http://tauri.localhost` by default; override with `OMNIVOICE_ALLOWED_ORIGINS`
+
+## AI Model Integrations
+
+**TTS Backends** (registry in `backend/services/tts_backend.py`):
+- `omnivoice` (default) — OmniVoice zero-shot diffusion model, 600+ languages, 24 kHz
+- `kittentts` — KittenML KittenTTS, English-only, ONNX, 8 preset voices, CPU realtime
+- `mlx-audio` — Blaizzy/mlx-audio, mac-ARM only; wraps Kokoro, CSM, Dia, Qwen3-TTS, Chatterbox, MeloTTS, OuteTTS, Spark, Higgs-Audio; model via `OMNIVOICE_MLX_AUDIO_MODEL`
+- `cosyvoice` — CosyVoice 2 (optional install)
+- `indextts2` — IndexTTS 2 (optional install)
+- `gpt-sovits` — GPT-SoVITS (optional install)
+- `sherpa-onnx` — Sherpa-ONNX (optional install)
+- `voxcpm2` — VoxCPM2 (stub, install hint on call)
+- `moss-tts-nano` — Moss TTS Nano (optional install)
+- Backend selection: `OMNIVOICE_TTS_BACKEND` env var or `OMNIVOICE_MLX_AUDIO_MODEL`
+
+**ASR Backends** (registry in `backend/services/asr_backend.py`):
+- `whisperx` (default cross-platform) — WhisperX + faster-whisper + wav2vec2 forced alignment; model via `ASR_MODEL_WHISPERX` env var (default `large-v3`); CUDA float16 or CPU int8
+- `faster-whisper` — CTranslate2 standalone fallback
+- `mlx-whisper` — Apple Silicon only; preloaded at startup for low-latency dictation
+- `pytorch-whisper` — last-resort fallback using `_asr_pipe`
+- Backend selection: `OMNIVOICE_ASR_BACKEND` env var (default: auto-detect)
+- Capture ASR: separate backend for real-time dictation, preloaded at app startup in `backend/main.py`
+
+**Speaker Diarization:**
+- `pyannote.audio` Pipeline — gated HuggingFace model; requires `HF_TOKEN`
+  - Implementation: `backend/services/model_manager.py` (~line 391)
+
+**Audio Watermarking:**
+- AudioSeal (Meta) — invisible neural watermarks in generated speech; 16-bit message payload ("OM" ASCII marker)
+  - Implementation: `backend/services/watermark.py`
+
+**Voice Conversion:**
+- RVC (Retrieval-based Voice Conversion) — optional; `rvc_python` package; no-ops unless enabled
+  - Implementation: `backend/services/rvc.py`
+
+**Audio Source Separation:**
+- Demucs ≥4.0.1 — vocal/music separation for dubbing ingestion
+
+**Audio DSP:**
+- Pedalboard ≥0.9.14 — compressor, reverb, highpass filter, EQ; used in `backend/services/audio_dsp.py`
+
+## Real-Time Communication
+
+**WebSocket:**
+- Streaming ASR endpoint — `/capture_ws` — streams PCM/WebM audio from browser, returns partial + final transcription JSON
+  - Router: `backend/api/routers/capture_ws.py`
+  - Protocol: binary audio frames in, JSON messages out (`{"type": "partial"|"final"|"error", ...}`)
+
+**Server-Sent Events (SSE):**
+- Task/job progress streaming — clients connect with `EventSource` and receive durable SSE events
+  - Router: `backend/api/routers/events.py`
+  - Durable replay: events persisted to `job_events` SQLite table; reconnect with `?after_seq=N`
+  - Event bus: `backend/core/event_bus.py` fans events to all connected WebSocket listener queues
+  - HF Hub download progress also forwarded to SSE via `backend/utils/hf_progress.py` tqdm patch
+
+## OpenAI-Compatible API
+
+OmniVoice exposes an OpenAI drop-in TTS/STT API so any tool speaking the OpenAI protocol can use OmniVoice as a local backend:
+- `POST /v1/audio/speech` — TTS (text → wav/mp3/opus/flac)
+- `POST /v1/audio/transcriptions` — STT (audio file → text/json)
+- `GET  /v1/audio/voices` — list voice profiles (OmniVoice extension)
+- Router: `backend/api/routers/openai_compat.py`
+
+## MCP (Model Context Protocol)
+
+OmniVoice exposes voice synthesis as AI-agent tools via an MCP server:
+- Standalone: `python -m backend.mcp_server`
+- Transport: stdio (Claude Desktop) or SSE (`--sse` flag, remote agents)
+- SDK: `mcp[cli]` package (lazy import, not a core dependency)
+- Tools: `generate_speech`, `list_voices`, `list_languages`, `list_personalities`
+- Resources: `voice://{profile_id}`, `history://recent`
+- Implementation: `backend/mcp_server.py`
+
+## FFmpeg
+
+- Used extensively for audio/video processing, format conversion, muxing, and export
+- Resolution order in `backend/services/ffmpeg_utils.py`: bundled Tauri binary → `imageio_ffmpeg` → system PATH
+- Bundled in Tauri desktop packages as external binary (`frontend/src-tauri/tauri.conf.json` `externalBin`)
+- System install on Docker (`apt-get install ffmpeg` in `deploy/Dockerfile`)
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None (no Sentry, Datadog, or similar)
+
+**Crash Logging:**
+- Local crash log at `{DATA_DIR}/crash_log.txt` — written on unhandled FastAPI exceptions (`backend/main.py`)
+
+**Runtime Logs:**
+- Rolling file log at `{DATA_DIR}/omnivoice.log` — `RotatingFileHandler`, 2 MB max, 3 backups; readable from Settings UI
+- JSON log format optional via `OMNIVOICE_JSON_LOGS=1`
+- Log level: `OMNIVOICE_LOG_LEVEL` env var (default `INFO`)
+
+## CI/CD & Deployment
+
+**CI Pipeline:**
+- GitHub Actions — `.github/workflows/ci.yml`
+  - Triggers: PR to main, push to main
+  - Jobs: pytest (backend), pytest (backend/tests isolated), Vitest (frontend), TypeScript typecheck, Tauri `cargo check` (macOS/Windows/Linux matrix)
+  - Runner: ubuntu-22.04 (tests), macOS-14/Windows-2022/ubuntu-22.04 (Tauri check)
+
+**Docker CI/CD:**
+- GitHub Actions — `.github/workflows/docker.yml`
+  - Triggers: semver tag push (`v*`), `workflow_dispatch`
+  - Registry: `ghcr.io` (GitHub Container Registry)
+  - Image: `ghcr.io/debpalash/omnivoice-studio:latest` + semver tags
+  - Cache: GitHub Actions cache (`type=gha`)
+
+**Desktop Release:**
+- GitHub Actions — `.github/workflows/release.yml`
+  - Triggers: semver tag push (`v*`), `workflow_dispatch`
+  - Produces: platform-signed Tauri bundles (`.dmg`/`.app`, `.msi`, `.deb`/`.AppImage`)
+  - Signing: `TAURI_SIGNING_PRIVATE_KEY` GitHub secret
+  - Updater: publishes `latest.json` to GitHub Releases; Tauri updater plugin polls on client boot
+
+**Hosting:**
+- Docker: self-hosted (pull from GHCR or build from source)
+- Desktop: self-updating binaries distributed via GitHub Releases
+
+## Webhooks & Callbacks
+
+**Incoming:** None
+
+**Outgoing:**
+- HuggingFace Hub API — model weight downloads (via HF Hub SDK + httpx)
+- OpenAI-compatible endpoints — LLM translation and glossary calls (user-configured, opt-in)
+- GitHub Releases — Tauri auto-updater polls `latest.json` for desktop update checks
+- yt-dlp — HTTP requests to YouTube/URLs for video download
+
+## Environment Configuration
+
+**Required env vars (for gated features):**
+- `HF_TOKEN` — HuggingFace access token; required for pyannote speaker diarization and other gated models
+- `TRANSLATE_API_KEY` / `OPENAI_API_KEY` — LLM API key; required for AI translation and glossary features
+- `TRANSLATE_BASE_URL` — LLM base URL; required when using non-OpenAI endpoints (Ollama, LM Studio, etc.)
+- `DEEPL_API_KEY` — required for DeepL translation engine
+- `MICROSOFT_API_KEY` — required for Microsoft Azure Translator engine
+
+**Optional env vars:**
+- `OMNIVOICE_DATA_DIR` — override platform data directory
+- `OMNIVOICE_CACHE_DIR` — override HF/Torch cache directory
+- `OMNIVOICE_TTS_BACKEND` — select TTS engine (default: `omnivoice`)
+- `OMNIVOICE_ASR_BACKEND` — select ASR engine (default: auto-detect)
+- `OMNIVOICE_LLM_BACKEND` — select LLM backend (default: auto-detect)
+- `OMNIVOICE_MLX_AUDIO_MODEL` — mlx-audio model key or HF repo ID
+- `ASR_MODEL_WHISPERX` — WhisperX model size (default: `large-v3`)
+- `TRANSLATE_MODEL` — LLM model name (default: `gpt-4o-mini`)
+- `OMNIVOICE_IDLE_TIMEOUT` — VRAM idle timeout in seconds (default: `900`)
+- `OMNIVOICE_CPU_POOL` — CPU thread pool size (default: `min(8, cpu_count)`)
+- `OMNIVOICE_LLM_TIMEOUT` — LLM call timeout in seconds (default: `45`)
+- `OMNIVOICE_ALLOWED_ORIGINS` — comma-separated CORS origins
+- `OMNIVOICE_LOG_LEVEL` — log level (default: `INFO`)
+- `OMNIVOICE_JSON_LOGS` — set to `1` for JSON log format
+- `OMNIVOICE_DISABLE_FILE_LOG` — suppress rolling file log
+- `OMNIVOICE_FROZEN` — mark process as frozen (Tauri/PyInstaller bundle)
+- `HSA_OVERRIDE_GFX_VERSION` — AMD ROCm GFX version override (auto-set for known consumer GPUs)
+
+**Secrets location:**
+- `.env` file at repo root (loaded by `python-dotenv` in `backend/main.py`)
+- Persistent user config: `~/.config/omnivoice/env` (survives desktop launcher restarts)
+- Docker: environment section in `deploy/docker-compose.yml` referencing host env vars
+- CI: GitHub Actions secrets (`TAURI_SIGNING_PRIVATE_KEY`, `GITHUB_TOKEN` for GHCR)
+
+---
+
+*Integration audit: 2026-05-16*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,152 @@
+# Technology Stack
+
+**Analysis Date:** 2026-05-16
+
+## Languages
+
+**Primary:**
+- Python 3.11 — entire backend, ML models, API server, CLI tools
+- TypeScript/JavaScript (JSX) — React frontend (`frontend/src/`)
+- Rust — Tauri desktop shell (`frontend/src-tauri/`)
+
+**Secondary:**
+- Shell (Bash/Zsh) — build scripts (`scripts/`)
+
+## Runtime
+
+**Environment:**
+- Python 3.11 (pinned via `.python-version`)
+- Node.js 22 (required for `--experimental-strip-types` in tests)
+- Rust stable (minimum 1.77.2 per `frontend/src-tauri/Cargo.toml`)
+
+**Package Manager:**
+- Python: `uv` (Astral) — lockfile at `uv.lock` (present)
+- JavaScript: `bun` 1.3.11 — lockfile at `bun.lock` (present)
+- Rust: `cargo` — lockfile at `frontend/src-tauri/Cargo.lock` (present)
+
+## Frameworks
+
+**Core:**
+- FastAPI — REST API server (`backend/main.py`), port 3900
+- Uvicorn — ASGI server for FastAPI
+- React 19 — frontend UI (`frontend/src/`)
+- Tauri 2.11.0 — cross-platform desktop shell wrapping React + Python backend (`frontend/src-tauri/`)
+
+**ML / AI:**
+- PyTorch 2.8.0 (CUDA 12.8 on Linux/Windows, CPU/MPS on macOS) — deep learning runtime
+- Torchaudio 2.8.0 — audio I/O and transforms
+- HuggingFace Transformers ≥5.3.0 — model hub integration and NLLB-200 translation
+- WhisperX ≥3.1.0 — cross-platform ASR with wav2vec2 forced alignment
+- Faster-Whisper ≥1.0.0 — CTranslate2-based Whisper fallback
+- mlx-whisper ≥0.2.1 — Apple Silicon ASR (mac-ARM only)
+- mlx-audio ≥0.3.0 — Apple Silicon multi-engine TTS (mac-ARM only; Kokoro, CSM, Dia, Qwen3-TTS, Chatterbox, MeloTTS, OuteTTS, Spark, Higgs-Audio)
+- pyannote-audio ≥3.3.2,<4.0 — speaker diarization for dubbing
+- Demucs ≥4.0.1 — audio source separation (vocals/music split)
+- Pedalboard ≥0.9.14 — audio effects (DSP post-processing)
+- AudioSeal ≥0.1.3 — invisible neural watermarking (Meta)
+- KittenTTS 0.8.1 — lightweight English ONNX TTS (25-80 MB, 8 preset voices)
+- Accelerate — HuggingFace distributed training/inference accelerator
+- Pydub — audio format conversion
+- Soundfile — audio file I/O (libsndfile)
+
+**Frontend UI:**
+- Tailwind CSS 4 — utility-first styling (Vite plugin)
+- Radix UI — accessible headless component primitives (Dialog, Dropdown, Tabs, Slider, Select, Popover, etc.)
+- Zustand 5 — frontend state management (`frontend/src/store/`)
+- TanStack Query 5 — server state, caching, data fetching
+- TanStack Table 8 — headless table primitives
+- TanStack Virtual 3 — list virtualisation
+- wavesurfer.js 7 — waveform visualisation in audio editor
+- i18next 26 + react-i18next — internationalisation
+- Lucide React — icon set
+- react-hot-toast — toast notifications
+- react-window 2 — virtualised list rendering
+
+**Build / Dev:**
+- Vite 8 — frontend bundler (port 3901 in dev)
+- Vitest 4 — frontend unit test runner
+- Turbo 2 — monorepo task orchestration (`turbo.json`)
+- Tauri CLI 2.11.0 — desktop build toolchain
+- PyInstaller ≥6.19.0 — Python backend freezing for desktop distribution (`backend.spec`)
+- hatchling — Python package build backend (`pyproject.toml`)
+- Alembic 1.13 — DB schema migrations (`alembic.ini`, `backend/migrations/`)
+- Ruff — Python linting (`.ruff_cache/` present)
+- ESLint 10 — JavaScript/JSX linting (`frontend/eslint.config.js`)
+- Playwright 1.59 — end-to-end browser tests
+
+**Testing:**
+- pytest ≥9.0.3 — Python unit/integration tests (`tests/`, `backend/tests/`)
+- pytest-asyncio ≥1.3.0 — async test support
+- pytest-cov ≥6.0 — coverage reporting
+- Vitest — React component/unit tests (`frontend/src/**/*.test.*`)
+- Node test runner — legacy frontend API tests (`tests/frontend/*.test.mjs`)
+
+## Key Dependencies
+
+**Critical:**
+- `torch==2.8.0` / `torchaudio==2.8.0` — constrained version; Linux/Windows pull from PyTorch CUDA 12.8 index (`https://download.pytorch.org/whl/cu128`)
+- `whisperx>=3.1.0` — ASR default; pins `pyannote-audio<4.0` for compatibility
+- `pyannote-audio>=3.3.2,<4.0` — speaker diarization; must stay <4.0 until whisperx releases a compatible build
+- `kittentts @ https://github.com/KittenML/KittenTTS/releases/download/0.8.1/kittentts-0.8.1-py3-none-any.whl` — not on PyPI, installed via GitHub Releases URL
+- `scalar-fastapi` — replaces default FastAPI `/docs` with Scalar interactive docs
+
+**Infrastructure:**
+- `fastapi` + `uvicorn` + `python-multipart` + `websockets` — API server stack
+- `alembic` — schema migration management (SQLite via `sqlite3` stdlib)
+- `imageio-ffmpeg ≥0.6.0` — bundled FFmpeg binary fallback
+- `yt-dlp ≥2024.12.13` — YouTube/URL video download for dubbing
+- `psutil ≥7.2.2` — system metrics
+- `gradio` + `gradio_client` — optional legacy demo UI
+
+## Configuration
+
+**Environment:**
+- `.env` file at repo root (loaded by `python-dotenv` in `backend/main.py`)
+- Per-user persistent config: `~/.config/omnivoice/env` (survives Tauri/Finder launches)
+- `OMNIVOICE_DATA_DIR` — overrides default platform data directory
+- `OMNIVOICE_CACHE_DIR` — redirect HF/Torch cache (sets `HF_HOME`, `HF_HUB_CACHE`, `TORCH_HOME`)
+- `OMNIVOICE_IDLE_TIMEOUT` — seconds before model unloads from VRAM (default 900)
+- `OMNIVOICE_CPU_POOL` — thread pool workers (default: min(8, cpu_count))
+- `OMNIVOICE_LOG_LEVEL` — logging level (default `INFO`)
+- `OMNIVOICE_JSON_LOGS=1` — switch to JSON-per-line log format
+- `OMNIVOICE_DISABLE_FILE_LOG` — suppress rolling file log (useful in CI)
+- `OMNIVOICE_ALLOWED_ORIGINS` — comma-separated CORS origins (default: localhost:3901, tauri://localhost)
+- `HF_HUB_DISABLE_XET=1` — force LFS over Xet (set by default in `backend/main.py`)
+- `HF_HUB_DISABLE_SYMLINKS` / `HF_HUB_DISABLE_SYMLINKS_WARNING` — Windows symlink workaround
+
+**Platform Data Directories (auto-resolved in `backend/core/config.py`):**
+- macOS: `~/Library/Application Support/OmniVoice/`
+- Windows: `%APPDATA%\OmniVoice\`
+- Linux: `~/.omnivoice/`
+
+**Build:**
+- `pyproject.toml` — Python packaging, dependency declarations, pytest config
+- `uv.lock` — pinned Python dependency tree
+- `package.json` — root monorepo scripts and dev tooling
+- `frontend/package.json` — React/Tauri frontend
+- `turbo.json` — task graph for build/dev/desktop targets
+- `backend.spec` — PyInstaller spec for frozen backend binary
+- `frontend/src-tauri/tauri.conf.json` + `tauri.macos.conf.json` / `tauri.linux.conf.json` / `tauri.windows.conf.json` — platform-specific Tauri config
+- `alembic.ini` — Alembic migration config (DB URL set programmatically in `backend/migrations/env.py`)
+
+## Platform Requirements
+
+**Development:**
+- Python 3.11
+- `uv` (Python dependency management)
+- Bun 1.3.11 (JavaScript package management)
+- Rust stable ≥1.77.2 (for `tauri dev` / `cargo check`)
+- FFmpeg (system install or bundled via `imageio-ffmpeg`)
+- CUDA 12.8 toolkit (optional, Linux/Windows GPU acceleration)
+
+**Production:**
+- Docker: `pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime` base image (`deploy/Dockerfile`)
+- Docker Compose CPU and GPU profiles (`deploy/docker-compose.yml`)
+- Container registry: `ghcr.io/debpalash/omnivoice-studio` (GitHub Container Registry)
+- Desktop: self-updating Tauri bundles — `.dmg`/`.app` (macOS), `.msi` (Windows), `.deb`/`.AppImage` (Linux)
+- Updater endpoint: `https://github.com/debpalash/OmniVoice-Studio/releases/latest/download/latest.json`
+- macOS minimum version: 12.0
+
+---
+
+*Stack analysis: 2026-05-16*

--- a/README.md
+++ b/README.md
@@ -174,6 +174,30 @@ chmod +x OmniVoice.Studio_*.AppImage
 ```
 </details>
 
+<details>
+<summary><b>Linux — White screen on Fedora 44 / Ubuntu 24.04</b></summary>
+<br/>
+
+Some newer distros ship a WebKit/GTK version with compositing issues. Try:
+
+```bash
+WEBKIT_DISABLE_COMPOSITING_MODE=1 ./OmniVoice.Studio_*.AppImage
+```
+
+If that doesn't help, use the `.deb` package or run from source instead.
+</details>
+
+<details>
+<summary><b>Installation fails behind a firewall / in Russia</b></summary>
+<br/>
+
+The desktop app downloads Python from GitHub during first launch. If your network blocks GitHub:
+
+1. Install Python 3.11 manually from [python.org](https://python.org/downloads/)
+2. Set `UV_PYTHON_PREFERENCE=system` before launching, or run from source with `bun run dev`
+3. For PyPI mirrors: set `UV_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/`
+</details>
+
 ---
 
 ### 🐳 Option 2 — Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ dependencies = [
     "webdataset",
     "numpy",
     "soundfile",
-    "setuptools",
+    # pkg_resources is used by whisperx/faster-whisper at runtime.
+    # On Python 3.12+ it's no longer bundled by default — pin a modern
+    # setuptools to guarantee it's present (fixes #58).
+    "setuptools>=75.0",
     "psutil>=7.2.2",
     # Pinned to 3.x — pyannote 4.x removed `use_auth_token` from `Inference`
     # which whisperx 3.4.2 still passes, blowing up `whisperx.load_model()`


### PR DESCRIPTION
## Wave 1 Quick Wins

### Changes
- **Pin `setuptools>=75.0`** in `pyproject.toml` — ensures `pkg_resources` is available on Python 3.12+ where it's no longer bundled by default. Fixes the `No module named 'pkg_resources'` error during transcription.
- **Linux white-screen workaround** — documents `WEBKIT_DISABLE_COMPOSITING_MODE=1` for Fedora 44 and Ubuntu 24.04.
- **Russia/CIS install guide** — documents `UV_PYTHON_PREFERENCE=system` and PyPI mirror options for users behind firewalls that block GitHub CDN.

### Issues Addressed
- Closes #58 (`pkg_resources` missing)
- Addresses #56 (Linux white screen — documented workaround)
- Addresses #60, #57 (install failures behind firewalls — documented workaround)

### Also in this batch
- Merged PR #53 (SRT import, closes #52)
- Merged PR #61 (Lazy ASR loading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation for system design and component interactions.
  * Added coding conventions guide for Python and frontend development standards.
  * Added integrations and runtime configuration reference covering external services and setup.
  * Added technology stack documentation detailing frameworks and dependencies.
  * Enhanced Linux setup instructions with troubleshooting for white screen and firewall issues.

* **Chores**
  * Updated setuptools dependency version requirement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->