### PR TITLE
fix: improve ffmpeg detection on Windows, increase yt-dlp timeout, add proxy setting

### DIFF
--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -518,7 +518,7 @@ async def set_env_var(body: dict):
     The value is set on os.environ for the running process.
     For persistence across restarts, users should set it in their shell profile.
     """
-    ALLOWED_KEYS = {"HF_TOKEN", "TRANSLATE_API_KEY"}
+    ALLOWED_KEYS = {"HF_TOKEN", "TRANSLATE_API_KEY", "HTTP_PROXY", "HTTPS_PROXY"}
     key = body.get("key", "")
     value = body.get("value", "")
 

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -308,7 +308,9 @@ def yt_download_sync(
         "quiet": True,
         "no_warnings": True,
         "restrictfilenames": True,
-        "socket_timeout": 30,
+        "socket_timeout": 120,
+        "retries": 3,
+        "fragment_retries": 3,
     }
     if fetch_subs:
         ydl_opts.update({
@@ -454,11 +456,13 @@ async def ingest_pipeline(
                 "-ar", "16000", "-ac", "1", audio_path, "-y",
             ])
             if p.returncode != 0:
-                raise Exception(stderr.decode(errors="replace")[:500])
+                msg = (stderr.decode(errors="replace") or f"ffmpeg returned exit code {p.returncode}").strip()[:500]
+                raise Exception(msg)
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            yield prep_event("error", stage="extract", error=str(e)[:300])
+            msg = str(e) or f"{type(e).__name__} during audio extraction"
+            yield prep_event("error", stage="extract", error=msg[:300])
             return
 
         try:

--- a/backend/services/ffmpeg_utils.py
+++ b/backend/services/ffmpeg_utils.py
@@ -44,7 +44,15 @@ def find_ffmpeg():
     except Exception as e:
         logger.debug("imageio_ffmpeg unavailable: %s", e)
     # 3. Well-known system paths + PATH lookup
-    for path in ["/opt/homebrew/bin/ffmpeg", "/usr/local/bin/ffmpeg", "ffmpeg"]:
+    common = [
+        "/opt/homebrew/bin/ffmpeg",
+        "/usr/local/bin/ffmpeg",
+        "C:\\ffmpeg\\bin\\ffmpeg.exe",
+        "C:\\Program Files\\ffmpeg\\bin\\ffmpeg.exe",
+        "D:\\ffmpeg\\bin\\ffmpeg.exe",
+        "ffmpeg",
+    ]
+    for path in common:
         if shutil.which(path):
             return path
     logger.warning("ffmpeg not found in env, imageio, or system PATH")


### PR DESCRIPTION
## Summary

Three backend fixes for download/extraction reliability:

### 1. FFmpeg detection on Windows
`find_ffmpeg()` only checked macOS well-known paths. Added `D:\ffmpeg\bin\ffmpeg.exe`, `C:\ffmpeg\bin\ffmpeg.exe`, and `C:\Program Files\ffmpeg\bin\ffmpeg.exe` so Windows users with standalone ffmpeg installs are detected even when PATH is not inherited by the backend subprocess.

### 2. yt-dlp download timeout
Increased `socket_timeout` from 30s → 120s and added `retries: 3` / `fragment_retries: 3` for flaky connections.

### 3. Error message improvement
Audio extraction errors no longer show as empty string `""` — when ffmpeg stderr is empty, the exit code is used; when the exception has no message, the exception type is shown instead.

### 4. Proxy support
Added `HTTP_PROXY` / `HTTPS_PROXY` to the allowed env-var keys in `/system/set-env` so users can set a download proxy for yt-dlp and HuggingFace.

## Test plan
- [ ] Backend starts without ffmpeg-related errors on Windows
- [ ] YouTube URL import does not timeout on slow connections
- [ ] POST /system/set-env with key=HTTP_PROXY succeeds

SummerSec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring HTTP and HTTPS proxy settings

* **Bug Fixes**
  * Enhanced network resilience with improved timeout and retry logic for downloads
  * Improved error messages for audio extraction failures
  * Expanded ffmpeg detection across macOS, Windows, and Linux systems

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->