### PR TITLE
feat(release): split backend out of installer (download on first run, ~1.8GB → ~50MB)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,3 +230,28 @@ jobs:
           prerelease: false
           updaterJsonPreferNsis: false
           includeUpdaterJson: true
+
+      # The installer above ships WITHOUT the PyInstaller backend because a
+      # single bundled asset (Linux .deb, Windows .msi) overshoots GH
+      # Releases' 2 GB per-asset cap. Package the backend into its own tar.gz
+      # and attach it to the same draft release; the Tauri app downloads and
+      # extracts it from app_local_data_dir on first launch (see lib.rs →
+      # ensure_backend_ready).
+      - name: Package backend tarball
+        shell: bash
+        run: |
+          VER="${GITHUB_REF_NAME#v}"
+          OUT="omnivoice-backend_${VER}_${{ matrix.rust_target }}.tar.gz"
+          tar -czf "$OUT" -C dist omnivoice-backend
+          ls -lah "$OUT"
+          echo "BACKEND_TARBALL=$OUT" >> "$GITHUB_ENV"
+
+      - name: Upload backend tarball to draft release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "$BACKEND_TARBALL" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -28,5 +28,13 @@ tauri-plugin-window-state = "2.0.0"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 
+# First-run backend bootstrap: the PyInstaller backend (~1.5 GB) ships as a
+# separate release asset instead of being bundled into the installer so we
+# stay under GH Releases' 2 GB per-asset cap on Linux/Windows. ureq handles
+# the HTTP GET, flate2 + tar do the extraction of the downloaded tarball.
+ureq = "2"
+tar = "0.4"
+flate2 = "1"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{self, Read};
 use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -7,6 +8,10 @@ use std::time::Duration;
 use tauri::Manager;
 
 const BACKEND_PORT: u16 = 8000;
+
+// GH Releases uploader repo. Used to construct the tarball download URL for
+// the first-run bootstrap when the installer ships without a bundled backend.
+const BACKEND_RELEASE_REPO: &str = "debpalash/OmniVoice-Studio";
 
 pub struct BackendState {
     pub process: Mutex<Option<Child>>,
@@ -105,22 +110,144 @@ fn kill_orphan_on_port(_port: u16) {}
 
 // ── Backend path resolution ───────────────────────────────────────────────
 
-/// Look for a frozen PyInstaller bundle shipped as a Tauri resource.
-/// In a packaged .app: `Contents/Resources/backend/omnivoice-backend/omnivoice-backend`.
+/// Look for a frozen PyInstaller bundle in three places, in priority order:
+///   1. Tauri resource dir (legacy path: backend bundled into the installer).
+///   2. Per-user app data dir (new path: backend downloaded on first run).
+///   3. Dev fallback (`../../dist/omnivoice-backend/`) — PyInstaller local run.
 fn find_bundled_backend<R: tauri::Runtime>(app: &tauri::App<R>) -> Option<PathBuf> {
-    let resource_dir = app.path().resource_dir().ok()?;
-    let candidates = [
-        resource_dir.join("backend/omnivoice-backend/omnivoice-backend"),
-        resource_dir.join("backend/omnivoice-backend"),
-        resource_dir.join("omnivoice-backend"),
-    ];
-    for c in &candidates {
-        if c.is_file() {
-            return Some(c.clone());
+    let exe_name = backend_exe_name();
+    let mut roots: Vec<PathBuf> = Vec::new();
+    if let Ok(d) = app.path().resource_dir() {
+        roots.push(d);
+    }
+    if let Ok(d) = app.path().app_local_data_dir() {
+        roots.push(d);
+    }
+    roots.push(PathBuf::from("../../dist"));
+    for root in roots {
+        let candidates = [
+            root.join(format!("backend/omnivoice-backend/{}", exe_name)),
+            root.join("backend/omnivoice-backend").join(&exe_name),
+            root.join("omnivoice-backend").join(&exe_name),
+            root.join(format!("omnivoice-backend/{}", exe_name)),
+        ];
+        for c in &candidates {
+            if c.is_file() {
+                return Some(c.clone());
+            }
         }
     }
     None
 }
+
+fn backend_exe_name() -> String {
+    if cfg!(windows) {
+        "omnivoice-backend.exe".into()
+    } else {
+        "omnivoice-backend".into()
+    }
+}
+
+// ── First-run backend bootstrap (download + extract) ──────────────────────
+
+/// Triple that matches the release-asset naming used by release.yml — see
+/// the `package-backend-tarball` step. Kept in lock-step with that
+/// matrix.rust_target value.
+fn release_asset_triple() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Some("aarch64-apple-darwin"),
+        ("macos", "x86_64") => Some("x86_64-apple-darwin"),
+        ("linux", "x86_64") => Some("x86_64-unknown-linux-gnu"),
+        ("windows", "x86_64") => Some("x86_64-pc-windows-msvc"),
+        _ => None,
+    }
+}
+
+fn backend_download_url() -> Option<String> {
+    let triple = release_asset_triple()?;
+    let version = env!("CARGO_PKG_VERSION");
+    Some(format!(
+        "https://github.com/{}/releases/download/v{}/omnivoice-backend_{}_{}.tar.gz",
+        BACKEND_RELEASE_REPO, version, version, triple
+    ))
+}
+
+/// Download the backend tarball and extract it under the per-user app-local
+/// data dir. Blocks the caller. Returns the path where the backend was
+/// extracted (parent of the omnivoice-backend directory) on success.
+fn download_and_extract_backend<R: tauri::Runtime>(app: &tauri::App<R>) -> io::Result<PathBuf> {
+    let url = backend_download_url()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "no release asset for this platform"))?;
+    let dest_root = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+    fs::create_dir_all(&dest_root)?;
+
+    log::info!("Fetching backend tarball: {}", url);
+    let resp = ureq::get(&url)
+        .timeout(Duration::from_secs(60 * 30))
+        .call()
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("download: {}", e)))?;
+    if resp.status() != 200 {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("download HTTP {} from {}", resp.status(), url),
+        ));
+    }
+
+    let mut reader = resp.into_reader();
+    let gz = flate2::read::GzDecoder::new(LogReader::new(&mut reader));
+    let mut archive = tar::Archive::new(gz);
+    archive.unpack(&dest_root)?;
+    log::info!("Backend extracted under {}", dest_root.display());
+    Ok(dest_root)
+}
+
+/// Wraps a Read impl and logs progress every ~64 MB. Gives the user some
+/// feedback in the tauri log while the download runs.
+struct LogReader<'a, R: Read> {
+    inner: &'a mut R,
+    so_far: u64,
+    next_log: u64,
+}
+
+impl<'a, R: Read> LogReader<'a, R> {
+    fn new(inner: &'a mut R) -> Self {
+        Self { inner, so_far: 0, next_log: 64 * 1024 * 1024 }
+    }
+}
+
+impl<'a, R: Read> Read for LogReader<'a, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.so_far += n as u64;
+        if self.so_far >= self.next_log {
+            log::info!("Backend download: {} MB received", self.so_far / (1024 * 1024));
+            self.next_log += 64 * 1024 * 1024;
+        }
+        Ok(n)
+    }
+}
+
+fn ensure_backend_ready<R: tauri::Runtime>(app: &tauri::App<R>) -> bool {
+    if find_bundled_backend(app).is_some() {
+        return true;
+    }
+    if release_asset_triple().is_none() {
+        log::warn!("No release asset known for this platform; skipping auto-download.");
+        return false;
+    }
+    log::info!("Backend not found locally — starting first-run download.");
+    match download_and_extract_backend(app) {
+        Ok(_) => find_bundled_backend(app).is_some(),
+        Err(e) => {
+            log::error!("Backend auto-download failed: {}", e);
+            false
+        }
+    }
+}
+
 
 /// Dev-mode fallback: running from the source tree (`bun run dev`).
 /// Locate `backend/main.py` so we can launch via `uv run uvicorn`.
@@ -310,6 +437,14 @@ pub fn run() {
             //    `bun run tauri dev`.
             // 4. Otherwise → spawn (kill orphan first if port held by corpse).
             let skip_spawn = std::env::var("TAURI_SKIP_BACKEND").is_ok();
+            if !skip_spawn {
+                // First-run bootstrap: the installer ships without the
+                // PyInstaller backend so it fits under GH Releases' 2 GB
+                // per-asset cap. Download + extract it into the per-user
+                // app data dir if we don't have it yet. Blocking — the
+                // webview stays on the initial loader until this resolves.
+                let _ = ensure_backend_ready(app);
+            }
             let has_bundled = find_bundled_backend(app).is_some();
             let child = if skip_spawn {
                 log::info!("TAURI_SKIP_BACKEND set — not spawning");

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -44,9 +44,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": {
-      "../../dist/omnivoice-backend": "backend/omnivoice-backend"
-    },
+    "resources": {},
     "macOS": {
       "minimumSystemVersion": "12.0"
     }


### PR DESCRIPTION
## Summary

Splits the PyInstaller backend out of the Tauri installer so the installer drops from ~1.8 GB to ~50 MB. Backend is downloaded + extracted on first launch from a separate GitHub Release asset.

Originally branched 3 weeks ago (Apr 23) — opening now after stabilization milestone planning surfaced installer size as a recurring user-friction point.

## Why

GitHub Releases enforces a 2 GB per-asset cap. Linux `.deb` and Windows MSI both overshot this when shipping PyInstaller's frozen backend (~1.8 GB after CPU-torch slim) bundled inside the installer. NSIS and WiX both failed during their own size-bounded packaging steps too. The macOS DMG snuck under via HFS compression but the cross-platform parity broke.

## Changes

- **Tauri installer ships WITHOUT the PyInstaller backend** — `tauri.conf.json` `bundle.resources` is now empty for the backend path. Installer drops from ~1.8 GB to ~50 MB.
- **CI packages backend separately** — `release.yml` adds a step after `tauri-action` that tarballs the frozen backend as \`omnivoice-backend_<version>_<triple>.tar.gz\` and uploads it to the same draft release via `gh release upload`. Each tarball is gz-compressed, comfortably under 2 GB.
- **First-launch downloader** — new `ensure_backend_ready()` in `frontend/src-tauri/src/lib.rs` checks three locations in order:
  1. Resource dir (legacy install path, for compat)
  2. `app_local_data_dir` (new home for downloaded backend)
  3. Dev-mode `dist/` fallback

  If none match, it downloads the platform-version-matching tarball from the GH Release and extracts into `app_local_data_dir`. Blocking on first run, no-op thereafter.
- **`find_bundled_backend` + `backend_exe_name`** are now platform-aware — append \`.exe\` on Windows, scan all three roots.
- New Rust deps: \`ureq\` (HTTP), \`tar\` + \`flate2\` (archive extract). No tokio — ureq is synchronous, matches existing `setup()` flow.

## ⚠️ Known: rebase needed

Branch is 93 commits behind main. **Conflicts expected in:**
- \`frontend/src-tauri/src/lib.rs\` — pill-mode widget creation (Phase 0 work) was added to this file after this branch was created
- \`frontend/src-tauri/tauri.conf.json\` — widget window config + bundle resources both touched

Auto-merges cleanly:
- \`.github/workflows/release.yml\`
- \`frontend/src-tauri/Cargo.toml\`

Reviewer should rebase against latest main in the GitHub UI or locally — resolve the lib.rs conflicts carefully to preserve both the split-backend logic and the new \`WebviewWindowBuilder\` widget creation from \`b479f9b\`.

## Test plan

- [ ] Rebase against main; resolve conflicts in lib.rs + tauri.conf.json
- [ ] Verify pill-mode widget still creates after rebase (\`bun desktop-prod:pill\`)
- [ ] Verify backend download on first launch with a fresh data dir
- [ ] Tag a test release; confirm installer + backend tarball both attach + installer size dropped to ~50MB
- [ ] Linux .deb under 2 GB; Windows MSI under 2 GB; macOS DMG still works

## Relation to milestone

Not in original v0.3.x stabilization scope per PROJECT.md, but solves a real install-friction concern. Decision: defer to v0.4 unless installer-size complaints land soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically downloads and provisions the backend on first run if not already present, with fallback location detection.

* **Chores**
  * Updated release and packaging process to distribute backend artifacts separately from the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->