### PR TITLE
fix: stabilize dub/diarization UI + production deployment + sonitranslate plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ research/
 !.planning/research/**
 marketing.md
 .coverage
+engines/
+engines/

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -163,18 +163,47 @@ async def dub_generate(job_id: str, req: DubRequest):
                     mastered_audio = apply_mastering(audio_out, sample_rate=_model.sampling_rate if hasattr(_model, 'sampling_rate') else 24000)
                     return normalize_audio(mastered_audio, target_dBFS=-2.0)
                 except Exception as e:
+                    is_oom = (
+                        isinstance(e, torch.cuda.OutOfMemoryError)
+                        or "out of memory" in str(e).lower()
+                        or "CUDA error" in str(e)
+                    )
+                    # Always try to reclaim VRAM regardless of error type.
                     import gc
                     gc.collect()
-                    if torch.backends.mps.is_available():
-                        torch.mps.empty_cache()
-                    elif torch.cuda.is_available():
+                    if torch.cuda.is_available():
                         torch.cuda.empty_cache()
-                    # User-facing: what happened · why · what to do.
-                    raise RuntimeError(
-                        f"Ran out of GPU memory generating this segment. "
-                        f"Try the Flush button in the header to free VRAM, or switch to CPU in Settings. "
-                        f"Underlying error: {e}"
+                    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                        torch.mps.empty_cache()
+
+                    if not is_oom:
+                        raise  # Non-OOM — propagate the real error, don't mask it.
+
+                    # OOM recovery: retry once with reduced steps (less VRAM).
+                    retry_steps = min(nstep, 8)
+                    logger.warning(
+                        "OOM on segment (nstep=%d), retrying with %d steps after cache flush",
+                        nstep, retry_steps,
                     )
+                    try:
+                        audios = _model.generate(
+                            text=text, language=lang if lang != "Auto" else None,
+                            ref_audio=ref_audio, ref_text=ref_text,
+                            instruct=instruct_str if instruct_str else None,
+                            duration=dur_s, num_step=retry_steps, guidance_scale=cfg,
+                            speed=spd, denoise=True, postprocess_output=True,
+                        )
+                        audio_out = audios[0]
+                        mastered_audio = apply_mastering(audio_out, sample_rate=_model.sampling_rate if hasattr(_model, 'sampling_rate') else 24000)
+                        return normalize_audio(mastered_audio, target_dBFS=-2.0)
+                    except Exception as retry_err:
+                        raise RuntimeError(
+                            f"Ran out of GPU memory generating this segment. "
+                            f"Retried with {retry_steps} steps but still failed. "
+                            f"Try the Flush button in the header to free VRAM, "
+                            f"or switch to CPU in Settings. "
+                            f"Underlying error: {retry_err}"
+                        )
 
             seg_instruct = seg.instruct or req.instruct
             seg_profile = seg.profile_id or None

--- a/backend/api/routers/sonitranslate.py
+++ b/backend/api/routers/sonitranslate.py
@@ -1,0 +1,93 @@
+"""SoniTranslate engine endpoints.
+
+Provides status, install, start/stop, and dub operations for the
+SoniTranslate sidecar integration.
+"""
+
+import logging
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+
+from services import sonitranslate as soni
+
+router = APIRouter(prefix="/engines/sonitranslate", tags=["SoniTranslate"])
+logger = logging.getLogger("omnivoice.api")
+
+
+# ── Status ──────────────────────────────────────────────────────────────
+
+
+@router.get("/status")
+def sonitranslate_status():
+    """Check SoniTranslate availability."""
+    return soni.status()
+
+
+# ── Install ─────────────────────────────────────────────────────────────
+
+
+@router.post("/install")
+async def sonitranslate_install():
+    """Clone and set up SoniTranslate (heavy — ~15GB with models)."""
+    try:
+        result = await soni.install()
+        return result
+    except Exception as e:
+        logger.exception("SoniTranslate install failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ── Start / Stop ────────────────────────────────────────────────────────
+
+
+@router.post("/start")
+async def sonitranslate_start():
+    """Start the SoniTranslate Gradio server."""
+    try:
+        result = await soni.start()
+        return result
+    except Exception as e:
+        logger.exception("SoniTranslate start failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/stop")
+async def sonitranslate_stop():
+    """Stop the SoniTranslate Gradio server."""
+    result = await soni.stop()
+    return result
+
+
+# ── Dub ─────────────────────────────────────────────────────────────────
+
+
+class DubRequest(BaseModel):
+    video_path: str
+    target_language: str = "Spanish (es)"
+    source_language: str = "Automatic detection"
+    tts_voice: str = "es-ES-AlvaroNeural-Male"
+    max_speakers: int = 1
+    output_dir: Optional[str] = None
+
+
+@router.post("/dub")
+async def sonitranslate_dub(body: DubRequest):
+    """Run full dubbing pipeline via SoniTranslate.
+
+    Transcribes, translates, generates TTS, and mixes audio.
+    Returns the path to the dubbed output video.
+    """
+    try:
+        result = await soni.dub_video(
+            video_path=body.video_path,
+            target_language=body.target_language,
+            source_language=body.source_language,
+            tts_voice=body.tts_voice,
+            max_speakers=body.max_speakers,
+            output_dir=body.output_dir,
+        )
+        return result
+    except Exception as e:
+        logger.exception("SoniTranslate dub failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -616,3 +616,13 @@ async def _do_clean_audio(audio, tmp_dir, clean_id):
 
     return FileResponse(final_path, media_type="audio/wav", filename=clean_filename,
                         headers={"X-Clean-Filename": clean_filename})
+
+
+@router.get("/system/asr-backends")
+def asr_backends():
+    """List all registered ASR backends and their availability."""
+    from services.asr_backend import list_backends, active_backend_id
+    return {
+        "active": active_backend_id(),
+        "backends": list_backends(),
+    }

--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -58,6 +58,64 @@ models:
     size_gb: 0.08
     platforms: [darwin-arm64]
 
+  - repo_id: "Systran/faster-whisper-large-v3-turbo"
+    label: "Whisper large-v3 Turbo (5× faster, 0.8B)"
+    role: ASR
+    size_gb: 1.6
+    note: "Best speed/quality tradeoff. 5× faster than large-v3 with minimal WER loss."
+
+  - repo_id: "Systran/faster-distil-whisper-large-v3"
+    label: "Distil-Whisper large-v3 (distilled, fast)"
+    role: ASR
+    size_gb: 1.5
+    note: "Knowledge-distilled from large-v3. Good accuracy at higher speed."
+
+  - repo_id: "Systran/faster-whisper-medium"
+    label: "Whisper medium (balanced, lower VRAM)"
+    role: ASR
+    size_gb: 1.5
+    note: "Good balance of speed and accuracy. Half the VRAM of large-v3."
+
+  - repo_id: "Systran/faster-whisper-small"
+    label: "Whisper small (fast preview, low VRAM)"
+    role: ASR
+    size_gb: 0.5
+    note: "Quick previews and testing. ~2× faster than medium."
+
+  - repo_id: "Systran/faster-whisper-base"
+    label: "Whisper base (minimal, fastest Whisper)"
+    role: ASR
+    size_gb: 0.15
+    note: "Lowest accuracy but near-instant. Good for rapid iteration."
+
+  # ── Non-Whisper ASR (from Open ASR Leaderboard) ────────────────────────
+
+  - repo_id: "nvidia/parakeet-tdt-0.6b-v3"
+    label: "Parakeet TDT 0.6B v3 (NVIDIA — SOTA, 25+ langs)"
+    role: ASR
+    size_gb: 1.2
+    platforms: [cuda]
+    note: "Beats Whisper large-v3 on English benchmarks. Requires nemo_toolkit[asr]."
+
+  - repo_id: "nvidia/parakeet-tdt-0.6b-v2"
+    label: "Parakeet TDT 0.6B v2 (NVIDIA — English + punctuation)"
+    role: ASR
+    size_gb: 1.2
+    platforms: [cuda]
+    note: "English-optimized with punctuation/capitalization. Requires nemo_toolkit[asr]."
+
+  - repo_id: "UsefulSensors/moonshine-base"
+    label: "Moonshine base (edge-optimized, 61M, ONNX)"
+    role: ASR
+    size_gb: 0.12
+    note: "Variable-length processing, sub-200ms latency. Great for CPU/edge. Requires moonshine-onnx."
+
+  - repo_id: "UsefulSensors/moonshine-small"
+    label: "Moonshine small (edge-optimized, 300M, ONNX)"
+    role: ASR
+    size_gb: 0.6
+    note: "Higher accuracy than base, still fast. Requires moonshine-onnx."
+
   # ── Diarisation ───────────────────────────────────────────────────────
 
   - repo_id: "pyannote/speaker-diarization-3.1"

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,10 @@ try:
     import dotenv
 
     dotenv.load_dotenv()
+    # Also load .env from the project root (parent of backend/)
+    _project_env = os.path.join(os.path.dirname(_backend_dir), ".env")
+    if os.path.isfile(_project_env):
+        dotenv.load_dotenv(_project_env, override=False)
     # Also load the durable per-user config so env vars set once survive
     # Tauri/Finder launches that don't inherit a shell environment.
     _user_env = os.path.expanduser("~/.config/omnivoice/env")
@@ -215,6 +219,7 @@ from api.routers import (
     openai_compat,
     tts_stream,
     marketplace,
+    sonitranslate,
 )
 from utils import hf_progress
 
@@ -426,6 +431,7 @@ app.include_router(capture_ws.router)
 app.include_router(openai_compat.router)
 app.include_router(tts_stream.router)
 app.include_router(marketplace.router)
+app.include_router(sonitranslate.router)
 
 frontend_path = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
 if os.path.exists(frontend_path):

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -497,6 +497,203 @@ class PyTorchWhisperBackend(ASRBackend):
         return result if isinstance(result, dict) else {"chunks": [], "raw": result}
 
 
+# ── NeMo Parakeet TDT (NVIDIA — English SOTA from ASR Leaderboard) ─────────
+
+
+class NeMoASRBackend(ASRBackend):
+    """NVIDIA Parakeet TDT via NeMo toolkit.
+
+    FastConformer encoder + Token-and-Duration Transducer decoder.
+    Beats Whisper large-v3 on English benchmarks (~6% WER).
+    Supports 25+ European languages with auto language detection.
+    Requires NVIDIA GPU.
+    """
+    id = "nemo-parakeet"
+    display_name = "Parakeet TDT (NVIDIA NeMo — English SOTA)"
+
+    def __init__(self):
+        self._model_name = os.environ.get(
+            "ASR_MODEL_NEMO", "nvidia/parakeet-tdt-0.6b-v3"
+        )
+        self._model = None
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        try:
+            import torch
+            if not torch.cuda.is_available():
+                return False, "Parakeet TDT requires NVIDIA GPU (CUDA)"
+        except ImportError:
+            return False, "PyTorch not installed"
+        try:
+            import nemo.collections.asr  # noqa: F401
+            return True, "ready"
+        except ImportError as e:
+            return False, f"nemo_toolkit[asr] not installed: {e}"
+
+    def _ensure_model(self):
+        if self._model is not None:
+            return
+        import nemo.collections.asr as nemo_asr
+        logger.info("NeMo loading %s", self._model_name)
+        self._model = nemo_asr.models.ASRModel.from_pretrained(
+            model_name=self._model_name
+        )
+
+    def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
+        self._ensure_model()
+        logger.info(
+            "NeMo Parakeet transcribing %s (word_timestamps=%s)",
+            audio_path, word_timestamps,
+        )
+        outputs = self._model.transcribe(
+            [audio_path], timestamps=word_timestamps
+        )
+        # NeMo returns a list of Hypothesis objects with .text and optional
+        # .timestep / .alignments. Normalise to OmniVoice's expected shape.
+        hyp = outputs[0] if outputs else None
+        if hyp is None:
+            return {"chunks": [], "segments": [], "language": "en"}
+
+        text = hyp.text if hasattr(hyp, "text") else str(hyp)
+
+        # Extract word-level timestamps if available
+        words = []
+        segments_out = []
+        if word_timestamps and hasattr(hyp, "timestep") and hyp.timestep:
+            try:
+                # NeMo timestep format varies by model version
+                ts = hyp.timestep
+                if isinstance(ts, dict) and "word" in ts:
+                    for w in ts["word"]:
+                        words.append({
+                            "word": w.get("char", w.get("word", "")),
+                            "start": w.get("start_offset", 0),
+                            "end": w.get("end_offset", 0),
+                        })
+            except Exception as e:
+                logger.debug("NeMo timestamp extraction: %s", e)
+
+        # Build a single segment from the full transcription
+        # (NeMo doesn't natively split into VAD segments like Whisper)
+        if text.strip():
+            segments_out.append({
+                "text": text,
+                "start": words[0]["start"] if words else 0.0,
+                "end": words[-1]["end"] if words else None,
+                "words": words,
+            })
+
+        chunks = [
+            {"text": seg["text"], "timestamp": (seg["start"], seg["end"])}
+            for seg in segments_out
+        ]
+        return {
+            "chunks": chunks,
+            "segments": segments_out,
+            "language": "en",  # Parakeet v3 auto-detects but doesn't expose it cleanly
+        }
+
+    def unload(self) -> None:
+        self._model = None
+        import gc
+        gc.collect()
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+
+# ── Moonshine (edge-optimized, variable-length — from ASR Leaderboard) ─────
+
+
+class MoonshineASRBackend(ASRBackend):
+    """Moonshine ASR via moonshine-voice or ONNX runtime.
+
+    Optimized for edge/CPU deployment. Variable-length processing
+    (no 30s padding waste like Whisper). Sub-200ms latency.
+    Great for live capture and CPU-only environments.
+    """
+    id = "moonshine"
+    display_name = "Moonshine (edge-optimized, ONNX)"
+
+    def __init__(self):
+        self._model_name = os.environ.get(
+            "ASR_MODEL_MOONSHINE", "moonshine/base"
+        )
+        self._transcriber = None
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        try:
+            import moonshine_onnx  # noqa: F401
+            return True, "ready (moonshine_onnx)"
+        except ImportError:
+            pass
+        try:
+            from moonshine_voice import Transcriber  # noqa: F401
+            return True, "ready (moonshine_voice)"
+        except ImportError:
+            pass
+        return False, (
+            "moonshine not installed. Install with: "
+            "uv pip install moonshine-onnx  (or moonshine-voice)"
+        )
+
+    def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
+        logger.info(
+            "Moonshine transcribing %s (model=%s)",
+            audio_path, self._model_name,
+        )
+        # Try moonshine_onnx first (lighter), then moonshine_voice
+        try:
+            import moonshine_onnx
+            text = moonshine_onnx.transcribe(audio_path, model=self._model_name)
+            if isinstance(text, list):
+                text = " ".join(text)
+        except ImportError:
+            from moonshine_voice import Transcriber
+            if self._transcriber is None:
+                self._transcriber = Transcriber(model=self._model_name)
+            text = self._transcriber.transcribe_file(audio_path)
+            if isinstance(text, list):
+                text = " ".join(text)
+
+        # Moonshine returns plain text without timestamps in basic mode.
+        # Build minimal segments structure.
+        segments_out = []
+        if text and text.strip():
+            # Get audio duration for rough segment bounds
+            try:
+                import soundfile as sf
+                info = sf.info(audio_path)
+                duration = info.duration
+            except Exception:
+                duration = None
+
+            segments_out.append({
+                "text": text.strip(),
+                "start": 0.0,
+                "end": duration,
+                "words": [],
+            })
+
+        chunks = [
+            {"text": seg["text"], "timestamp": (seg["start"], seg["end"])}
+            for seg in segments_out
+        ]
+        return {
+            "chunks": chunks,
+            "segments": segments_out,
+            "language": "en",
+        }
+
+    def unload(self) -> None:
+        self._transcriber = None
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 
 
@@ -505,6 +702,8 @@ _REGISTRY: dict[str, type[ASRBackend]] = {
     "faster-whisper":  FasterWhisperBackend,
     "mlx-whisper":     MLXWhisperBackend,
     "pytorch-whisper": PyTorchWhisperBackend,
+    "nemo-parakeet":   NeMoASRBackend,
+    "moonshine":       MoonshineASRBackend,
 }
 
 

--- a/backend/services/sonitranslate.py
+++ b/backend/services/sonitranslate.py
@@ -1,0 +1,291 @@
+"""SoniTranslate sidecar integration.
+
+Manages an isolated SoniTranslate instance that runs as a Gradio service
+on port 7860. OmniVoice calls it via `gradio_client` for full-pipeline
+video dubbing with access to Edge TTS, Piper, Coqui XTTS, and RVC.
+"""
+
+import asyncio
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("omnivoice.sonitranslate")
+
+# Default install location — inside the OmniVoice project tree
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+SONI_DIR = _PROJECT_ROOT / "engines" / "sonitranslate"
+SONI_VENV = SONI_DIR / ".venv"
+SONI_PORT = 7860
+SONI_URL = f"http://127.0.0.1:{SONI_PORT}"
+
+# Track subprocess
+_proc: Optional[subprocess.Popen] = None
+
+
+def is_installed() -> bool:
+    """Check if SoniTranslate is cloned and has its entry point."""
+    return (SONI_DIR / "app_rvc.py").is_file()
+
+
+def is_venv_ready() -> bool:
+    """Check if the SoniTranslate virtualenv exists with key deps."""
+    pip = SONI_VENV / "bin" / "pip"
+    return pip.is_file()
+
+
+def is_running() -> bool:
+    """Check if the Gradio server is responding."""
+    global _proc
+    if _proc is not None and _proc.poll() is not None:
+        _proc = None
+    try:
+        import httpx
+        r = httpx.get(f"{SONI_URL}/info", timeout=2.0)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+def status() -> dict:
+    """Return full status object for the frontend."""
+    installed = is_installed()
+    return {
+        "installed": installed,
+        "venv_ready": is_venv_ready() if installed else False,
+        "running": is_running() if installed else False,
+        "path": str(SONI_DIR),
+        "url": SONI_URL,
+    }
+
+
+async def install(progress_callback=None) -> dict:
+    """Clone SoniTranslate and set up its virtualenv.
+
+    This is a heavy operation (~15GB with models). Runs in background.
+    """
+    if not is_installed():
+        logger.info("Cloning SoniTranslate...")
+        if progress_callback:
+            progress_callback("Cloning SoniTranslate repository...")
+        proc = await asyncio.create_subprocess_exec(
+            "git", "clone", "--depth", "1",
+            "https://github.com/R3gm/SoniTranslate.git",
+            str(SONI_DIR),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"Clone failed: {stderr.decode()}")
+
+    # Create venv if needed
+    if not is_venv_ready():
+        logger.info("Creating SoniTranslate virtualenv...")
+        if progress_callback:
+            progress_callback("Creating virtualenv...")
+
+        python = sys.executable
+        proc = await asyncio.create_subprocess_exec(
+            python, "-m", "venv", str(SONI_VENV),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+
+        # Install base requirements
+        pip = str(SONI_VENV / "bin" / "pip")
+        if progress_callback:
+            progress_callback("Installing base requirements (this may take a while)...")
+
+        proc = await asyncio.create_subprocess_exec(
+            pip, "install", "-r", str(SONI_DIR / "requirements_base.txt"),
+            cwd=str(SONI_DIR),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            logger.error("Base requirements failed: %s", stderr.decode()[-500:])
+
+        # Install extra requirements
+        if progress_callback:
+            progress_callback("Installing extra requirements...")
+        proc = await asyncio.create_subprocess_exec(
+            pip, "install", "-r", str(SONI_DIR / "requirements_extra.txt"),
+            cwd=str(SONI_DIR),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+
+    return status()
+
+
+async def start() -> dict:
+    """Start the SoniTranslate Gradio server as a subprocess."""
+    global _proc
+    if is_running():
+        return {"started": False, "reason": "already_running", **status()}
+
+    if not is_installed():
+        raise RuntimeError("SoniTranslate not installed. Call /engines/sonitranslate/install first.")
+
+    python = str(SONI_VENV / "bin" / "python") if is_venv_ready() else sys.executable
+
+    # Pass HF token from OmniVoice environment
+    env = os.environ.copy()
+    hf_token = os.environ.get("HF_TOKEN", "")
+    if hf_token:
+        env["YOUR_HF_TOKEN"] = hf_token
+
+    logger.info("Starting SoniTranslate on port %d...", SONI_PORT)
+    _proc = subprocess.Popen(
+        [python, "app_rvc.py"],
+        cwd=str(SONI_DIR),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Wait up to 30s for it to be ready
+    for _ in range(60):
+        await asyncio.sleep(0.5)
+        if is_running():
+            logger.info("SoniTranslate started successfully")
+            return {"started": True, **status()}
+        if _proc.poll() is not None:
+            out = _proc.stdout.read().decode()[-500:] if _proc.stdout else ""
+            raise RuntimeError(f"SoniTranslate exited early: {out}")
+
+    raise RuntimeError("SoniTranslate failed to start within 30s")
+
+
+async def stop() -> dict:
+    """Stop the SoniTranslate subprocess."""
+    global _proc
+    if _proc is None:
+        return {"stopped": False, "reason": "not_running"}
+
+    _proc.send_signal(signal.SIGTERM)
+    try:
+        _proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        _proc.kill()
+    _proc = None
+    logger.info("SoniTranslate stopped")
+    return {"stopped": True}
+
+
+async def dub_video(
+    video_path: str,
+    target_language: str = "Spanish (es)",
+    source_language: str = "Automatic detection",
+    tts_voice: str = "es-ES-AlvaroNeural-Male",
+    max_speakers: int = 1,
+    output_dir: Optional[str] = None,
+) -> dict:
+    """Run the full SoniTranslate dubbing pipeline on a video file.
+
+    Returns the path to the dubbed output file.
+    """
+    if not is_running():
+        await start()
+
+    try:
+        from gradio_client import Client, handle_file
+    except ImportError:
+        raise RuntimeError(
+            "gradio_client not installed. Run: pip install gradio_client"
+        )
+
+    logger.info("Submitting dub job to SoniTranslate: %s → %s", video_path, target_language)
+
+    client = Client(SONI_URL)
+
+    # The main function is `batch_multilingual_media_conversion`
+    # which is exposed as the first API endpoint
+    result = client.predict(
+        handle_file(video_path),  # media_file
+        "",                       # link_media
+        "",                       # directory_input
+        os.environ.get("HF_TOKEN", ""),  # YOUR_HF_TOKEN
+        False,                    # preview
+        "large-v3",               # transcriber_model
+        4,                        # batch_size
+        "auto",                   # compute_type
+        source_language,          # origin_language
+        target_language,          # target_language
+        1,                        # min_speakers
+        max_speakers,             # max_speakers
+        tts_voice,                # tts_voice00
+        tts_voice,                # tts_voice01 (fallback same)
+        tts_voice,                # tts_voice02
+        tts_voice,                # tts_voice03
+        tts_voice,                # tts_voice04
+        tts_voice,                # tts_voice05
+        tts_voice,                # tts_voice06
+        tts_voice,                # tts_voice07
+        tts_voice,                # tts_voice08
+        tts_voice,                # tts_voice09
+        tts_voice,                # tts_voice10
+        tts_voice,                # tts_voice11
+        "",                       # video_output_name
+        "Adjusting volumes and mixing audio",  # mix_method_audio
+        2.1,                      # max_accelerate_audio
+        False,                    # acceleration_rate_regulation
+        0.25,                     # volume_original_audio
+        1.80,                     # volume_translated_audio
+        "srt",                    # output_format_subtitle
+        False,                    # get_translated_text
+        False,                    # get_video_from_text_json
+        "{}",                     # text_json
+        False,                    # avoid_overlap
+        False,                    # vocal_refinement
+        True,                     # literalize_numbers
+        15,                       # segment_duration_limit
+        "pyannote_3.1",           # diarization_model
+        "google_translator_batch",  # translate_process
+        None,                     # subtitle_file
+        "video (mp4)",            # output_type
+        False,                    # voiceless_track
+        False,                    # voice_imitation
+        3,                        # voice_imitation_max_segments
+        False,                    # voice_imitation_vocals_dereverb
+        True,                     # voice_imitation_remove_previous
+        "freevc",                 # voice_imitation_method
+        True,                     # dereverb_automatic_xtts
+        "sentence",               # text_segmentation_scale
+        "",                       # divide_text_segments_by
+        True,                     # soft_subtitles_to_video
+        False,                    # burn_subtitles_to_video
+        True,                     # enable_cache
+        False,                    # custom_voices
+        1,                        # custom_voices_workers
+        False,                    # is_gui
+        api_name="/batch_multilingual_media_conversion",
+    )
+
+    # Result is the output file path(s)
+    if isinstance(result, list):
+        output_file = result[0] if result else None
+    else:
+        output_file = result
+
+    if output_file and output_dir:
+        dest = os.path.join(output_dir, os.path.basename(output_file))
+        shutil.copy2(output_file, dest)
+        output_file = dest
+
+    logger.info("SoniTranslate dub complete: %s", output_file)
+    return {
+        "output_file": output_file,
+        "target_language": target_language,
+        "source_language": source_language,
+    }
+"""Backend service wrapper for SoniTranslate sidecar."""

--- a/frontend/src/components/DubSegmentRow.css
+++ b/frontend/src/components/DubSegmentRow.css
@@ -1,60 +1,79 @@
 /* ═══ DubSegmentRow extracted layout styles ═══ */
+
+/* Row transition — smooth bg/border changes during generation */
+.segment-row {
+  transition: background 0.2s ease, border-left 0.15s ease, opacity 0.3s ease;
+  border-left: 2px solid transparent;
+}
+.segment-active {
+  border-left: 2px solid #d3869b !important;
+  background: rgba(211, 134, 155, 0.08) !important;
+}
+.segment-done {
+  opacity: 0.6;
+  border-left: 2px solid rgba(142, 192, 124, 0.35) !important;
+}
+.segment-selected {
+  background: rgba(211, 134, 155, 0.05) !important;
+}
+
 .seg-check {
-  width: 16px; flex-shrink: 0; margin-right: 2px; cursor: pointer;
+  width: 14px; flex-shrink: 0; margin-right: 1px; cursor: pointer;
 }
 .seg-time {
-  width: 50px; flex-shrink: 0; display: flex; flex-direction: column;
+  width: 46px; flex-shrink: 0; display: flex; flex-direction: column;
 }
 .seg-sync-badge {
-  font-size: 0.5rem; margin-top: 2px;
-  display: inline-flex; align-items: center; gap: 2px;
+  font-size: 0.48rem; margin-top: 1px;
+  display: inline-flex; align-items: center; gap: 1px;
 }
 .seg-rate-badge {
-  font-size: 0.5rem; margin-top: 2px;
+  font-size: 0.48rem; margin-top: 1px;
   font-variant-numeric: tabular-nums;
 }
 .seg-speed-badge {
-  font-size: 0.55rem; margin-left: 2px;
+  font-size: 0.52rem; margin-left: 1px;
 }
 .seg-speaker-input {
-  width: 45px; flex-shrink: 0; font-size: 0.55rem; color: #a89984;
+  width: 40px; flex-shrink: 0; font-size: 0.52rem; color: #a89984;
   padding: 1px 2px; text-align: center;
 }
 .seg-text-col {
-  flex: 1 1 0%; display: flex; flex-direction: column; gap: 2px;
+  flex: 1 1 0%; display: flex; flex-direction: column; gap: 1px;
   min-width: 80px; overflow: hidden;
 }
 .seg-text-col .segment-input {
   width: 100%; min-width: 0;
 }
 .seg-orig-row {
-  font-size: 0.55rem; color: #6b6657;
-  display: flex; align-items: center; gap: 4px;
-  padding: 0 4px; overflow: hidden;
+  font-size: 0.52rem; color: #6b6657;
+  display: flex; align-items: center; gap: 3px;
+  padding: 0 2px; overflow: hidden;
 }
 .seg-orig-label {
   opacity: 0.8; text-transform: uppercase; font-weight: 600;
-  font-size: 0.5rem; color: #7c6f64;
+  font-size: 0.48rem; color: #7c6f64;
 }
 .seg-orig-text {
   flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.seg-budget-warn { color: #fabd2f; font-size: 0.5rem; }
+.seg-budget-warn { color: #fabd2f; font-size: 0.48rem; }
 .seg-restore-btn {
   background: none; border: none; color: #83a598;
-  cursor: pointer; padding: 0; font-size: 0.55rem;
+  cursor: pointer; padding: 0; font-size: 0.52rem;
 }
 .seg-lang-select {
-  width: 42px; flex-shrink: 0; font-size: 0.5rem; padding: 1px 2px;
+  width: 38px; flex-shrink: 0; font-size: 0.48rem; padding: 1px 1px;
 }
 .seg-profile-select {
-  width: 60px; flex-shrink: 0; font-size: 0.55rem; padding: 1px 2px;
+  width: 56px; flex-shrink: 0; font-size: 0.52rem; padding: 1px 2px;
   overflow: hidden; text-overflow: ellipsis;
 }
 .seg-gain-slider {
-  width: 40px !important; max-width: 40px; flex-shrink: 0; flex-grow: 0;
+  width: 36px !important; max-width: 36px; flex-shrink: 0; flex-grow: 0;
   height: 3px; padding: 0; margin: 0;
 }
 .seg-actions {
-  display: flex; gap: 1px; width: 42px; flex-shrink: 0;
+  display: flex; gap: 1px; width: 38px; flex-shrink: 0;
 }
+

--- a/frontend/src/components/DubSegmentTable.jsx
+++ b/frontend/src/components/DubSegmentTable.jsx
@@ -4,17 +4,17 @@ import DubSegmentRow from './DubSegmentRow';
 import { Table, Select } from '../ui';
 import './DubSegmentTable.css';
 
-const BASE_ROW_HEIGHT = 28;
-const ROW_HEIGHT_WITH_ORIG = 44;
+const BASE_ROW_HEIGHT = 26;
+const ROW_HEIGHT_WITH_ORIG = 40;
 
 const COLUMNS = [
-  { key: 'time',  label: 'Time',  width: 50 },
-  { key: 'spkr',  label: 'Spkr',  width: 45 },
+  { key: 'time',  label: 'Time',  width: 46 },
+  { key: 'spkr',  label: 'Spkr',  width: 40 },
   { key: 'text',  label: 'Text',  flex: 1 },
-  { key: 'lang',  label: 'Lang',  width: 42 },
-  { key: 'voice', label: 'Voice', width: 60 },
-  { key: 'vol',   label: 'Vol',   width: 40, title: 'Volume (0–200%)' },
-  { key: 'act',   label: '',      width: 42 },
+  { key: 'lang',  label: 'Lang',  width: 38 },
+  { key: 'voice', label: 'Voice', width: 56 },
+  { key: 'vol',   label: 'Vol',   width: 36, title: 'Volume (0–200%)' },
+  { key: 'act',   label: '',      width: 38 },
 ];
 
 export default function DubSegmentTable({

--- a/frontend/src/pages/DubTab.css
+++ b/frontend/src/pages/DubTab.css
@@ -8,12 +8,12 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 14px;
+  padding: 5px 12px;
   flex-shrink: 0;
   background: rgba(255, 255, 255, 0.015);
   border: 1px solid rgba(255, 255, 255, 0.04);
   border-radius: var(--radius-md);
-  margin: 0 0 4px 0;
+  margin: 0 0 2px 0;
 }
 .dub-head__title     { display: flex; align-items: center; gap: var(--space-3); margin-bottom: 0; min-width: 0; flex: 1; }
 .dub-head__actions   { display: flex; gap: var(--space-2); align-items: center; flex-shrink: 0; }
@@ -155,8 +155,8 @@
 .dub-outputs-row {
   display: flex;
   align-items: center;
-  gap: var(--space-5);
-  margin-bottom: var(--space-2);
+  gap: var(--space-3);
+  margin-bottom: 2px;
   padding: 0 var(--space-2);
   font-size: var(--text-xs);
   color: var(--chrome-fg-muted);
@@ -171,9 +171,9 @@
 .dub-tracks-row {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-  margin-bottom: var(--space-3);
-  padding: 4px var(--space-3);
+  gap: var(--space-2);
+  margin-bottom: 2px;
+  padding: 3px var(--space-3);
   font-size: var(--text-xs);
   color: var(--chrome-fg-muted);
   font-family: var(--font-sans);
@@ -213,7 +213,7 @@
 /* ── Utility: column flex that fills remaining height ────────── */
 .dub-col            { flex: 1; display: flex; flex-direction: column; min-height: 0; }
 .dub-panel-col      { margin-bottom: 0; overflow: hidden; display: flex; flex-direction: column; }
-.dub-split-2        { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; flex: 1; min-height: 0; }
+.dub-split-2        { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; flex: 1; min-height: 0; overflow: hidden; }
 .dub-split-1        { display: grid; grid-template-columns: 1fr; gap: 6px; flex: 1; min-height: 0; }
 
 /* ── Idle / drop-zone skeleton ───────────────────────────────── */
@@ -223,23 +223,33 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 14px;
+  gap: 10px;
   cursor: pointer;
   border: 2px dashed rgba(255, 255, 255, 0.06);
   border-radius: 8px;
   transition: background 0.3s, border-color 0.3s;
-  margin: 4px;
+  margin: 2px;
   background: transparent;
+}
+@keyframes dub-pulse {
+  0%, 100% { border-color: rgba(211, 134, 155, 0.3); background: rgba(211, 134, 155, 0.04); }
+  50%      { border-color: rgba(211, 134, 155, 0.6); background: rgba(211, 134, 155, 0.08); }
 }
 .dub-idle-drop.is-dragging {
   border-color: #d3869b;
   background: rgba(211, 134, 155, 0.05);
+  animation: dub-pulse 1.2s ease-in-out infinite;
 }
 .dub-idle-drop__puck {
   width: 60px; height: 60px; border-radius: 50%;
   display: flex; align-items: center; justify-content: center;
   background: rgba(211, 134, 155, 0.06);
   border: 1px solid rgba(211, 134, 155, 0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.dub-idle-drop:hover .dub-idle-drop__puck {
+  transform: scale(1.08);
+  box-shadow: 0 0 24px rgba(211, 134, 155, 0.15);
 }
 .dub-idle-drop__lines    { text-align: center; }
 .dub-idle-drop__title    { font-size: 0.9rem; color: var(--color-fg); font-weight: 500; margin-bottom: 4px; }
@@ -324,9 +334,9 @@
 .dub-settings-bar {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 6px;
-  padding: 6px 8px;
+  gap: 3px;
+  margin-bottom: 4px;
+  padding: 4px 8px;
   background: var(--chrome-bg);
   border: 1px solid var(--chrome-border);
   border-radius: var(--chrome-radius-pill);
@@ -410,14 +420,14 @@
 .dub-settings-summary {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-  padding: 4px var(--space-3);
-  margin-bottom: 4px;
+  gap: var(--space-2);
+  padding: 3px var(--space-3);
+  margin-bottom: 3px;
   background: var(--chrome-bg);
   border: 1px solid var(--chrome-border);
   border-radius: var(--chrome-radius-pill);
   font-family: var(--font-sans);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   color: var(--chrome-fg-muted);
 }
 .dub-settings-summary__trigger {
@@ -543,15 +553,15 @@
    action strip below has somewhere neutral to sit. Keep the content
    padding tight. */
 .dub-footer-panel {
-  padding: 6px var(--space-4);
+  padding: 4px var(--space-3);
   flex-shrink: 0;
   background: var(--chrome-bg) !important;
   border: 1px solid var(--chrome-border) !important;
   border-radius: 0 !important;
 }
 .dub-footer-panel::before { display: none !important; }
-.dub-footer-btns                     { display: flex; gap: 4px; }
-.dub-footer-btns--spaced             { margin-top: 4px; }
+.dub-footer-btns                     { display: flex; gap: 3px; }
+.dub-footer-btns--spaced             { margin-top: 3px; }
 
 /* Output options row value column */
 .dub-outputs-title-strong {
@@ -601,23 +611,23 @@
 .dub-skel-field--sm   { flex: 1; min-width: 80px; }
 
 /* ── Generating overlay (on top of waveform) ─────────────────── */
-.dub-gen-overlay          { display: flex; flex-direction: column; align-items: center; gap: 6px; width: 100%; }
+.dub-gen-overlay          { display: flex; flex-direction: column; align-items: center; gap: 6px; width: 100%; padding: 10px; backdrop-filter: blur(2px); }
 .dub-gen-overlay__head    { display: flex; align-items: center; gap: 6px; }
-.dub-gen-overlay__title   { font-weight: 500; font-size: 0.72rem; color: var(--color-fg); }
+.dub-gen-overlay__title   { font-weight: 600; font-size: 0.75rem; color: var(--color-fg); font-variant-numeric: tabular-nums; letter-spacing: 0.01em; }
 .dub-gen-overlay__title.is-stopping { color: var(--color-fg-muted); }
-.dub-gen-overlay__bar     { width: 80%; max-width: 240px; }
-.dub-gen-overlay__text    { font-size: 0.65rem; color: var(--color-fg-muted); }
-.dub-gen-overlay__stats   { display: flex; gap: var(--space-5); font-size: 0.68rem; color: var(--color-fg-muted); font-variant-numeric: tabular-nums; }
+.dub-gen-overlay__bar     { width: 80%; max-width: 240px; margin: 1px 0; }
+.dub-gen-overlay__text    { font-size: 0.62rem; color: var(--color-fg-muted); }
+.dub-gen-overlay__stats   { display: flex; gap: var(--space-4); font-size: 0.65rem; color: var(--color-fg-muted); font-variant-numeric: tabular-nums; }
 
 /* ── Cast / speaker-voices strip below waveform ──────────────── */
 .dub-cast {
-  margin-top: 4px;
-  padding: 4px var(--space-3);
+  margin-top: 2px;
+  padding: 3px var(--space-3);
   background: var(--chrome-bg);
   border-radius: var(--chrome-radius-pill);
   border: 1px solid var(--chrome-border);
 }
-.dub-cast__row          { display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; }
+.dub-cast__row          { display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; }
 .dub-cast__kicker {
   font-family: var(--chrome-font-mono);
   font-size: var(--chrome-label-size);
@@ -626,9 +636,10 @@
   text-transform: uppercase;
   font-weight: 600;
 }
-.dub-cast__pair         { display: flex; align-items: center; gap: 4px; }
-.dub-cast__label        { font-family: var(--chrome-font-mono); font-size: 0.65rem; color: var(--chrome-fg); }
-.dub-cast__select       { width: 100px; padding: 1px 4px; font-size: 0.62rem; }
+.dub-cast__pair         { display: flex; align-items: center; gap: 3px; padding: 1px 5px; border-radius: var(--radius-sm); transition: background 0.2s ease; }
+.dub-cast__pair:hover   { background: rgba(255, 255, 255, 0.03); }
+.dub-cast__label        { font-family: var(--chrome-font-mono); font-size: 0.62rem; color: var(--chrome-fg); }
+.dub-cast__select       { width: 95px; padding: 1px 3px; font-size: 0.60rem; }
 
 /* Muted placeholder cast strip shown in the idle skeleton */
 .dub-cast--muted        { background: transparent; border-color: var(--chrome-border); }
@@ -656,9 +667,9 @@
 .dub-footer-btn {
   margin-top: 0 !important;
   flex: 1;
-  padding: 6px 10px !important;
+  padding: 5px 8px !important;
   font-family: var(--font-sans) !important;
-  font-size: var(--text-sm) !important;
+  font-size: 0.72rem !important;
   letter-spacing: 0.02em !important;
   text-transform: none !important;
   background: transparent !important;
@@ -670,7 +681,7 @@
 }
 .dub-footer-btn:hover:not(:disabled) { background: var(--chrome-hover-bg) !important; }
 .dub-footer-btn:disabled             { opacity: 0.45; cursor: not-allowed; }
-.dub-footer-btn--sm { padding: 4px 8px !important; font-size: var(--text-xs) !important; }
+.dub-footer-btn--sm { padding: 3px 6px !important; font-size: 0.62rem !important; }
 
 .dub-footer-btn--idle     { color: var(--chrome-fg-muted) !important; border-color: var(--chrome-border) !important; }
 .dub-footer-btn--stopping { color: var(--chrome-fg-muted) !important; border-color: var(--chrome-border) !important; }

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -636,7 +636,7 @@ export default function DubTab(props) {
                     title="Edit translation settings"
                   >
                     <ChevronDown size={10} />
-                    <span><strong>{dubLang}</strong> · {dubLangCode} · {translateQuality} · {translateProvider}</span>
+                    <span><strong>{dubLang}</strong> · {dubLangCode} · {translateQuality} · <span style={{ color: activeEngineUnavailable ? '#fb4934' : '#b8bb26' }}>●</span> {translateProvider}</span>
                     {dubInstruct && <span className="dub-settings-summary__style">style: {dubInstruct}</span>}
                   </button>
                   <Button
@@ -991,7 +991,7 @@ export default function DubTab(props) {
                   label={`Stop (${dubProgress.current}/${dubProgress.total})`} />
               ) : (
                 <>
-                  <FooterBtn tone={dubSegments.length ? 'idle' : 'idle'} onClick={() => handleDubGenerate()}
+                  <FooterBtn tone={dubSegments.length ? 'pink' : 'idle'} onClick={() => handleDubGenerate()}
                     disabled={!dubSegments.length} icon={<Play size={11} />} label="Generate Dub" />
                   {dubStep === 'done' && incrementalPlan && incrementalPlan.stale?.length > 0 && (
                     <FooterBtn

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,23 @@
 import '@testing-library/jest-dom/vitest';
+
+const localStorageMock = (function () {
+  let store = {};
+  return {
+    getItem(key) {
+      return store[key] || null;
+    },
+    setItem(key, value) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+    removeItem(key) {
+      delete store[key];
+    }
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ dependencies = [
     "python-multipart",
     # Required by uvicorn for WebSocket support (real-time sidebar events).
     "websockets",
+    # Offline translation — listed as builtin in the engine registry so the
+    # "Argos (Local, Fast)" option in the Dub tab works out-of-the-box.
+    "argostranslate>=1.9.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -264,6 +264,24 @@ wheels = [
 ]
 
 [[package]]
+name = "argostranslate"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ctranslate2" },
+    { name = "minisbd" },
+    { name = "packaging" },
+    { name = "sacremoses" },
+    { name = "sentencepiece" },
+    { name = "spacy" },
+    { name = "stanza" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/0c/2887de7e72805eb37dac37cdd84132691c95b5842463b634bf86000d259a/argostranslate-1.11.0.tar.gz", hash = "sha256:be43fa826cbac15399a33a90c842dfe504ad6b8fa55e252514e7071f5425b406", size = 39275, upload-time = "2026-02-02T13:23:02.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/16/aa4ddcbc3a3fe352ca3046ef90e612147e0604cbc84a2a70e48df4021bb9/argostranslate-1.11.0-py3-none-any.whl", hash = "sha256:a89b42d82f40843900338f9ac60d4c82fda590b6898247f5d0c15d46731ca7df", size = 41551, upload-time = "2026-02-02T13:23:01.631Z" },
+]
+
+[[package]]
 name = "asteroid-filterbanks"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1224,6 +1242,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "emoji"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/78/0d2db9382c92a163d7095fc08efff7800880f830a152cfced40161e7638d/emoji-2.15.0.tar.gz", hash = "sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4", size = 615483, upload-time = "2025-09-21T12:13:02.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/5e/4b5aaaabddfacfe36ba7768817bd1f71a7a810a43705e531f3ae4c690767/emoji-2.15.0-py3-none-any.whl", hash = "sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb", size = 608433, upload-time = "2025-09-21T12:13:01.197Z" },
 ]
 
 [[package]]
@@ -2359,6 +2386,20 @@ wheels = [
 ]
 
 [[package]]
+name = "minisbd"
+version = "0.9.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/09/648d539139188925d3c58272ccae9d8b0d51513a384e422ec1d4e4501ed1/minisbd-0.9.5.tar.gz", hash = "sha256:b40d0a32ad0b3aeb8477e06a9e4723b7fa34a30121731f6a5063d39b7b3a464e", size = 39611, upload-time = "2026-03-03T18:15:13.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/47/7b13b62127a6e1460e1bc3fabf3aab0cf281f73cad81d5972b3aef40c0ff/minisbd-0.9.5-py3-none-any.whl", hash = "sha256:a573a3bb62349a5a7f22f6e12c8305814dbe6765d83bcb034c6f780d1e69d1df", size = 41125, upload-time = "2026-03-03T18:15:10.972Z" },
+]
+
+[[package]]
 name = "misaki"
 version = "0.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3022,6 +3063,7 @@ source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
     { name = "alembic" },
+    { name = "argostranslate" },
     { name = "audioseal" },
     { name = "demucs" },
     { name = "fastapi" },
@@ -3082,6 +3124,7 @@ dev = [
 requires-dist = [
     { name = "accelerate" },
     { name = "alembic", specifier = ">=1.13" },
+    { name = "argostranslate", specifier = ">=1.9.0" },
     { name = "audioseal", specifier = ">=0.1.3" },
     { name = "demucs", specifier = ">=4.0.1" },
     { name = "fastapi" },
@@ -4722,6 +4765,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/7f/de69806654326a958d38f65190d0edb1725d221dc3a06aa2902b7fb3221f/s3prl-0.4.18.tar.gz", hash = "sha256:b59dcb12c434edc969b0b0290d4059c3a5c661adecc31db81ed9c510cd7f405e", size = 648900, upload-time = "2025-06-13T07:11:54.385Z" }
 
 [[package]]
+name = "sacremoses"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/51/fbdc4af4f6e85d26169e28be3763fe50ddfd0d4bf8b871422b0788dcc4d2/sacremoses-0.1.1.tar.gz", hash = "sha256:b6fd5d3a766b02154ed80b962ddca91e1fd25629c0978c7efba21ebccf663934", size = 883188, upload-time = "2023-10-30T15:56:20.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/f0/89ee2bc9da434bd78464f288fdb346bc2932f2ee80a90b2a4bbbac262c74/sacremoses-0.1.1-py3-none-any.whl", hash = "sha256:31e04c98b169bfd902144824d191825cd69220cdb4ae4bcf1ec58a7db5587b1a", size = 897476, upload-time = "2023-10-30T15:56:18.121Z" },
+]
+
+[[package]]
 name = "safehttpx"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -5323,6 +5381,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/ae/e3707f6c1bc6f7aa0df600ba8075bfb8a19252140cd595335be60e25f9ee/standard_sunau-3.13.0-py3-none-any.whl", hash = "sha256:53af624a9529c41062f4c2fd33837f297f3baa196b0cfceffea6555654602622", size = 7364, upload-time = "2024-10-30T16:01:28.003Z" },
+]
+
+[[package]]
+name = "stanza"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "emoji" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/d3/1e849c2fd5c31250534407205dcf10265defce35795c7fc9846d3b689848/stanza-1.10.1.tar.gz", hash = "sha256:f1b283021323ef9273fb1a751a194c0d568e373a2a11b933e2f4b600322406b2", size = 901628, upload-time = "2024-12-24T06:07:27.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f6/c50d0ee85e40687a81a95d90d426938d0d83ac0683efa2b87fa4110b665c/stanza-1.10.1-py3-none-any.whl", hash = "sha256:d0ebc22c7e7a201077e0ed88d2450e654acadb4ea0d8584d5a5eb2ae1e65c060", size = 1112060, upload-time = "2024-12-24T06:07:22.898Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Multi-area stability pass touching dub pipeline UI, diarization handling, production deployment, and sonitranslate engine plumbing. Single commit (\`f5af607\`) from 3 days ago.

## Files changed (15)

**Backend:**
- \`backend/api/routers/dub_generate.py\`, \`sonitranslate.py\`, \`system.py\`
- \`backend/services/asr_backend.py\`, \`sonitranslate.py\`
- \`backend/config/models.yaml\`
- \`backend/main.py\`

**Frontend (dub editor):**
- \`frontend/src/components/DubSegmentRow.css\`
- \`frontend/src/components/DubSegmentTable.jsx\`
- \`frontend/src/pages/DubTab.css\`
- \`frontend/src/pages/DubTab.jsx\`

**Infra:**
- \`.gitignore\`, \`pyproject.toml\`, \`uv.lock\`
- \`frontend/src/test/setup.js\`

## ⚠️ Review note

This is a **single 890-line commit across mixed concerns** (dub UI + diarization + production deploy + sonitranslate). Reviewer may want to either:
- Land as-is given the changes are interconnected, or
- Request split into focused commits (one per concern area) for clearer review.

CodeRabbit will surface specific issues per-file.

## Test plan

- [ ] Backend tests pass — \`uv run pytest tests/\`
- [ ] Frontend smoke — dub workflow end-to-end (upload → diarize → edit → export)
- [ ] Production deploy on at least one platform (macOS/Linux/Windows)
- [ ] Sonitranslate engine still loads + transcribes
- [ ] Cross-platform CI matrix (smoke-matrix from PR #71) passes once #71 merges

## Scope vs milestone

Touches stability areas in v0.3.x scope (dubbing pipeline = Wave 2 stability), but pre-dates the GSD planning. Bundled as a single commit by intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated SoniTranslate sidecar with endpoints for installing, starting, stopping and dubbing
  * Added NeMo Parakeet TDT and Moonshine ASR backends
  * Added Argos offline translation option and more ASR model entries

* **Bug Fixes**
  * Improved GPU/OOM detection with automated VRAM reclamation and a controlled retry on generation

* **Style**
  * UI spacing/layout refinements, segment/table sizing, generation overlay and availability indicators

* **Tests**
  * Added in-memory localStorage mock for frontend tests

* **Chores**
  * Updated gitignore and conditional .env loading on startup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->