### PR TITLE
fix: add PYTHONPATH to docker-compose for pre-built images

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - HF_HOME=/app/omnivoice_data/huggingface
       - HF_TOKEN=${HF_TOKEN:-}
       - OMNIVOICE_DATA_DIR=/app/omnivoice_data
+      - PYTHONPATH=/app/backend
       - PYTHONUNBUFFERED=1
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3900/health"]
@@ -63,6 +64,7 @@ services:
       - HF_HOME=/app/omnivoice_data/huggingface
       - HF_TOKEN=${HF_TOKEN:-}
       - OMNIVOICE_DATA_DIR=/app/omnivoice_data
+      - PYTHONPATH=/app/backend
       - PYTHONUNBUFFERED=1
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3900/health"]


### PR DESCRIPTION
## Summary

- Add `PYTHONPATH=/app/backend` to both CPU and GPU service definitions in `deploy/docker-compose.yml`

## Problem

The pre-built GHCR image (`ghcr.io/debpalash/omnivoice-studio:latest`) was published before the `sys.path` fix in `backend/main.py` (lines 8–10) was added. When `docker compose up` starts the container, uvicorn resolves `backend.main:app` successfully, but the module-level import at line 144:

```python
from core.config import (
```

fails with `ModuleNotFoundError: No module named 'core'`, causing the container to crash-loop on startup.

The `Dockerfile` already sets `ENV PYTHONPATH=/app/backend`, but the pre-built image on GHCR predates that line — the environment variable is absent from the published image (confirmed via `docker inspect`).

## Fix

Explicitly set `PYTHONPATH=/app/backend` in `docker-compose.yml` for both `omnivoice` (CPU) and `omnivoice-gpu` services. This works regardless of whether the image was built before or after the `PYTHONPATH`/`sys.path` fixes.

## Test plan

- [x] `docker compose -f deploy/docker-compose.yml up -d` — container starts and reaches `healthy` status
- [x] `docker compose -f deploy/docker-compose.yml --profile gpu up -d` — GPU variant also has the fix
- [x] Verified container no longer crash-loops; `/health` endpoint returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker deployment environment so containerized services correctly locate the application backend at runtime: PYTHONPATH is set for both CPU and GPU service configurations, alongside existing runtime data and model settings, improving consistency of Python module resolution within deployed containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->