### PR TITLE
security: add loopback origin check to /system/set-env

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,6 +1,6 @@
 # STATE: OmniVoice Studio v0.3.x Stabilization
 
-**Last updated:** 2026-05-16
+**Last updated:** 2026-05-18 — Completed quick task 260518-ivy: loopback origin check on /system/set-env
 
 ---
 
@@ -75,6 +75,12 @@
 ### Blockers
 
 None.
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260518-ivy | Add loopback origin check to /system/set-env (security fix from PR #66 review) | 2026-05-18 | e1f08a6 | [260518-ivy-add-loopback-origin-check-to-system-set-](./quick/260518-ivy-add-loopback-origin-check-to-system-set-/) |
 
 ---
 

--- a/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-PLAN.md
+++ b/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-PLAN.md
@@ -1,0 +1,268 @@
+---
+phase: quick-260518-ivy
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - backend/api/routers/system.py
+  - tests/test_api.py
+  - .planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md
+autonomous: true
+requirements:
+  - SEC-LOOPBACK-01
+tags:
+  - security
+  - fastapi
+  - backend
+
+must_haves:
+  truths:
+    - "POST /system/set-env from any non-loopback client returns HTTP 403"
+    - "POST /system/set-env from 127.0.0.1 (or ::1, localhost) with an allowed key still mutates os.environ and returns 200"
+    - "All existing allow-list, env-mutation, logging, and return-shape behavior of the endpoint is preserved unchanged"
+    - "Other POST endpoints in backend/api/routers/system.py are NOT modified by this commit"
+    - "A deferred-items file enumerates the remaining unauthenticated POST endpoints in system.py for follow-up triage"
+    - "A single atomic commit lands on main with message: security: add loopback origin check to /system/set-env"
+  artifacts:
+    - path: "backend/api/routers/system.py"
+      provides: "Loopback-only guard on /system/set-env"
+      contains: "request.client.host"
+    - path: "tests/test_api.py"
+      provides: "Regression test(s) for loopback enforcement"
+      contains: "set-env"
+    - path: ".planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md"
+      provides: "Audit list of other unauthenticated POST endpoints in system.py for follow-up"
+      contains: "/system/"
+  key_links:
+    - from: "backend/api/routers/system.py:set_env_var"
+      to: "fastapi.Request.client.host"
+      via: "request parameter injected by FastAPI"
+      pattern: "request\\.client\\.host"
+    - from: "tests/test_api.py"
+      to: "fastapi.testclient.TestClient"
+      via: "client_kwarg={'client': ('127.0.0.1', 50000)} override for happy-path test"
+      pattern: "TestClient\\(.*client=\\("
+---
+
+<objective>
+Close a local-LAN credential-overwrite vulnerability on `POST /system/set-env` (backend/api/routers/system.py:524-552). The backend binds 0.0.0.0:3900 and this endpoint mutates `os.environ` for `HF_TOKEN` and `TRANSLATE_API_KEY` with no auth or origin check, so any LAN host or arbitrary local process can overwrite stored tokens. PR #66 widened the blast radius by persisting tokens to `prefs.json`. This plan adds a loopback-origin allow-list as the first statement of the handler and surfaces (without fixing) the other POST endpoints in the same router for a follow-up triage.
+
+Purpose: Reinforce OmniVoice's local-first guarantee (per CLAUDE.md: "no required cloud calls, accounts, or API keys" — and by extension, no remote mutation of locally-stored credentials). Today the endpoint is reachable from any host on the user's network; after this fix it is only reachable from the same machine.
+
+Output:
+- Hardened `/system/set-env` handler with `Request`-based loopback gate
+- Regression test(s) covering both 403 (non-loopback) and 200 (loopback) paths
+- `260518-ivy-deferred-items.md` enumerating the other unauthenticated POST routes in `system.py` for the next security pass
+- One atomic commit on `main`
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@CLAUDE.md
+@backend/api/routers/system.py
+@tests/test_api.py
+
+<interfaces>
+<!-- Key signatures the executor needs. Extracted from current file at lines 524-552. -->
+<!-- Do not re-explore the codebase for these. -->
+
+Current handler (backend/api/routers/system.py, lines 524-552):
+- Decorator: @router.post("/system/set-env")
+- Signature: async def set_env_var(body: dict):
+- Allow-list (preserve verbatim): ALLOWED_KEYS = {"HF_TOKEN", "TRANSLATE_API_KEY"}
+- Existing import line at top of file (line 7):
+    from fastapi import APIRouter, File, UploadFile, HTTPException, Query
+  -> Add `Request` to this import (do NOT add a second `from fastapi import ...` line).
+
+Other @router.post routes in the same file (for deferred-items audit, lines confirmed via grep):
+- line 108: /model/unload/{model_id}
+- line 318: /system/logs/clear
+- line 341: /system/logs/tauri/clear
+- line 384: /system/flush-memory
+- line 524: /system/set-env   ← THIS task
+- line 555: /clean-audio
+
+TestClient pattern (FastAPI / Starlette):
+- Default TestClient sets request.client.host = "testclient" — this is what makes the 403 test trivially pass.
+- To simulate a loopback origin, construct: TestClient(app, client=("127.0.0.1", 50000))
+- Existing client fixture at tests/test_api.py:71-76 returns `TestClient(app)` — reuse it for the 403 case; build a second loopback client inline for the 200 case.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add loopback-origin guard to /system/set-env and regression tests</name>
+  <files>backend/api/routers/system.py, tests/test_api.py</files>
+  <behavior>
+    Test 1 (403 path, non-loopback origin):
+      - Using the default TestClient fixture (host = "testclient"), POST /system/set-env with body {"key": "HF_TOKEN", "value": "hf_dummy"}.
+      - Expect status_code == 403.
+      - Expect response JSON detail to contain "loopback".
+      - Expect os.environ.get("HF_TOKEN") to be UNCHANGED (the env mutation must not run when the guard rejects).
+
+    Test 2 (200 path, loopback origin):
+      - Construct TestClient(app, client=("127.0.0.1", 50000)).
+      - POST /system/set-env with body {"key": "HF_TOKEN", "value": "hf_loopback_ok"}.
+      - Expect status_code == 200.
+      - Expect response JSON == {"key": "HF_TOKEN", "set": True}.
+      - Expect os.environ["HF_TOKEN"] == "hf_loopback_ok".
+      - Teardown: pop HF_TOKEN from os.environ to keep test isolation (use a try/finally or a monkeypatch fixture if available in the test module).
+
+    Test 3 (optional, only if trivial — skip if it complicates the test):
+      - POST with body {"key": "DISALLOWED", "value": "x"} from loopback origin still returns 400 (existing allow-list still enforced after the guard).
+  </behavior>
+  <action>
+    Implement the security fix and its tests in one task.
+
+    Production change in backend/api/routers/system.py:
+    1. Extend the existing fastapi import at line 7 to include Request — i.e., the line becomes:
+         from fastapi import APIRouter, File, UploadFile, HTTPException, Query, Request
+       Do NOT add a duplicate import line.
+    2. Change the handler signature at line 525 from:
+         async def set_env_var(body: dict):
+       to:
+         async def set_env_var(request: Request, body: dict):
+    3. Insert the loopback check as the FIRST statement of the function body (above the ALLOWED_KEYS line). Use the exact triple from task_specifics — ("127.0.0.1", "::1", "localhost") — and raise HTTPException(status_code=403, detail="set-env requires loopback origin"). Defensive note: request.client may be None in pathological transports; treat that case as non-loopback (also 403). A safe expression is:
+         host = request.client.host if request.client else None
+         if host not in ("127.0.0.1", "::1", "localhost"):
+             raise HTTPException(status_code=403, detail="set-env requires loopback origin")
+    4. Leave the rest of the function body byte-for-byte identical: ALLOWED_KEYS check, value branch / pop branch, logger.info lines, and the return dict.
+
+    Test change in tests/test_api.py:
+    - Append a new test block at the end of the file (do not interleave with existing fixtures). Reuse the existing `client` fixture for Test 1. For Test 2, instantiate a second TestClient inline via the pattern documented in <interfaces>. Wrap the os.environ mutation in try/finally so the test cleans up after itself even on failure.
+    - Use the `_mock_model` session fixture (autouse) implicitly — no additional model mocking is needed for this endpoint.
+    - Name the tests `test_set_env_rejects_non_loopback`, `test_set_env_allows_loopback`, and (if included) `test_set_env_loopback_still_validates_allowlist`.
+
+    Do not modify any other @router.post handler in system.py in this task — those are deferred to Task 2's audit file.
+  </action>
+  <verify>
+    <automated>cd /Users/user4/Desktop/voice-design/OmniVoice &amp;&amp; python -m pytest tests/test_api.py -k "set_env" -x -q</automated>
+  </verify>
+  <done>
+    - backend/api/routers/system.py imports Request from fastapi (single import line, not duplicated).
+    - Handler signature is `async def set_env_var(request: Request, body: dict):`.
+    - First executable statement in the handler body is the loopback guard raising 403 for non-allow-listed hosts.
+    - Existing ALLOWED_KEYS / os.environ / logger / return behavior is unchanged.
+    - `pytest tests/test_api.py -k set_env` passes with at least the two new tests green.
+    - No other endpoint in system.py is touched.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Enumerate other unauthenticated POST endpoints in system.py (deferred-items audit)</name>
+  <files>.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md</files>
+  <action>
+    Create `260518-ivy-deferred-items.md` in this quick task's directory listing every `@router.post(...)` in backend/api/routers/system.py OTHER than `/system/set-env`, with one line each describing what the endpoint does and a one-line risk note. Use the enumeration already verified via grep (do not re-grep; the lines below are authoritative for this commit):
+
+    - `/model/unload/{model_id}` (line 108) — unloads a named model from memory. Risk: a LAN host can force-evict the user's loaded TTS/ASR model, causing a re-load stall on next inference. Severity: low (no data exfil, no credential mutation).
+    - `/system/logs/clear` (line 318) — truncates the backend log file. Risk: a LAN host can destroy diagnostic evidence (anti-forensics). Severity: low–medium.
+    - `/system/logs/tauri/clear` (line 341) — truncates the frontend (Tauri) log file. Risk: same as above. Severity: low–medium.
+    - `/system/flush-memory` (line 384) — forces a GC / VRAM-flush cycle. Risk: a LAN host can trigger repeated flushes to degrade performance. Severity: low.
+    - `/clean-audio` (line 555) — accepts an uploaded WAV and runs demucs. Risk: a LAN host can upload arbitrary audio and consume CPU/GPU/disk on the user's machine. Severity: medium (resource exhaustion + writes to OUTPUTS_DIR).
+
+    Format the file with a short header citing the trigger (PR #66 security review, Task #17 follow-up) and explicit "Out of scope for the 260518-ivy commit — to be triaged in a follow-up quick task or as part of Phase 5 (Opt-in Bug Reporting) security review." Reference Task #18 in our backlog.
+
+    Do NOT modify backend/api/routers/system.py or any test in this task. This is documentation-only.
+  </action>
+  <verify>
+    <automated>test -f /Users/user4/Desktop/voice-design/OmniVoice/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md &amp;&amp; grep -v '^#' /Users/user4/Desktop/voice-design/OmniVoice/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md | grep -c '/system/\|/model/\|/clean-audio' | awk '$1 &gt;= 5 {exit 0} {exit 1}'</automated>
+  </verify>
+  <done>
+    - File exists at the expected path.
+    - Contains exactly the five other POST routes from system.py with one-line descriptions and risk notes.
+    - Explicitly marked as out-of-scope for this commit and referenced to Task #18 / follow-up.
+    - No production code or tests were modified in this task.
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Atomic commit on main</name>
+  <files>.git (commit metadata)</files>
+  <action>
+    Stage exactly the three modified paths:
+      - backend/api/routers/system.py
+      - tests/test_api.py
+      - .planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md
+      - .planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-PLAN.md (this plan — include so the artifact is traceable in git history)
+
+    Verify with `git status` that no other files are staged inadvertently (no edits to other endpoints, no formatter sweeps, no .pyc files).
+
+    Land directly on `main` (per user direction — no feature branch for this security fix). Use a HEREDOC commit message:
+
+    Title: `security: add loopback origin check to /system/set-env`
+    Body:
+      - Reference: surfaced during PR #66 security review.
+      - Closes a local-LAN credential-overwrite vector — the endpoint mutates os.environ for HF_TOKEN / TRANSLATE_API_KEY and the backend binds 0.0.0.0:3900, so any LAN host or local process could overwrite stored tokens. The vector existed pre-PR for in-memory state and was widened by PR #66's prefs.json persistence.
+      - Notes: other POST endpoints in backend/api/routers/system.py share the same gap and are catalogued in `.planning/quick/260518-ivy.../260518-ivy-deferred-items.md` for follow-up (Task #18).
+      - Co-Authored-By trailer for Claude per repo convention.
+
+    Do NOT push to remote unless explicitly requested by the user later. Do NOT amend any prior commit. Do NOT skip hooks (no --no-verify). If a pre-commit hook fails, fix the underlying issue and create a NEW commit (do not amend).
+  </action>
+  <verify>
+    <automated>cd /Users/user4/Desktop/voice-design/OmniVoice &amp;&amp; git log -1 --pretty=%s | grep -q '^security: add loopback origin check to /system/set-env$' &amp;&amp; git log -1 --name-only --pretty=format: | grep -q 'backend/api/routers/system.py' &amp;&amp; git status --porcelain | wc -l | awk '$1 == 0 {exit 0} {exit 1}'</automated>
+  </verify>
+  <done>
+    - HEAD on `main` is a new commit titled exactly `security: add loopback origin check to /system/set-env`.
+    - Commit touches at minimum: backend/api/routers/system.py, tests/test_api.py, the deferred-items file, and this PLAN.md.
+    - `git status` is clean post-commit.
+    - No push to remote.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| LAN host → backend (0.0.0.0:3900) | Untrusted: any device on the user's network can reach the backend |
+| Local process (non-OmniVoice) → backend (loopback) | Semi-trusted: same-machine processes are still distinct security principals from the Tauri frontend, but cannot be distinguished at HTTP layer without OS-level auth (out of scope) |
+| Tauri frontend → backend (loopback) | Trusted within OmniVoice's local-first model |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-ivy-01 | Tampering | POST /system/set-env from LAN host | mitigate | Loopback-only allow-list ("127.0.0.1", "::1", "localhost") on `request.client.host`; non-matching origin → HTTP 403 before any os.environ mutation. |
+| T-ivy-02 | Elevation of Privilege | LAN host overwriting HF_TOKEN with attacker-controlled token, redirecting subsequent HF downloads | mitigate | Same loopback gate. Attacker on LAN can no longer reach the mutation path at all. |
+| T-ivy-03 | Information Disclosure | Logger emits `Set environment variable: HF_TOKEN (length=N)` | accept | Length-only log; no value, no PII. Pre-existing behavior, no regression. |
+| T-ivy-04 | Tampering | Local non-OmniVoice process on loopback still able to call /system/set-env | accept | Out of scope for this quick fix. OS-level UID/process auth would be required; defer to a future hardening pass. Same-machine processes already share write access to $HF_HOME/token under the local-first model. |
+| T-ivy-05 | Spoofing | `X-Forwarded-For` header tricking the guard | mitigate-by-design | Guard reads `request.client.host` (the actual TCP peer), NOT any header. Documented in test rationale. |
+| T-ivy-SC | Tampering | npm/pip installs in this commit | mitigate | No new package installs — `fastapi.Request` is already present in the pinned dependency set. Slopcheck not required for this commit. |
+</threat_model>
+
+<verification>
+Run the new regression tests and confirm no other system.py endpoint behavior shifted:
+
+```bash
+cd /Users/user4/Desktop/voice-design/OmniVoice
+python -m pytest tests/test_api.py -k "set_env" -x -q
+python -m pytest tests/test_router_smoke.py -x -q   # smoke check — should remain green
+git log -1 --stat   # confirm only the four intended paths were touched
+grep -n 'request.client.host' backend/api/routers/system.py   # exactly one match expected, in set_env_var
+```
+
+Manual sanity (optional, can be skipped per yolo mode):
+- Start the backend, then from a second machine on the LAN: `curl -X POST http://<host-ip>:3900/system/set-env -d '{"key":"HF_TOKEN","value":"x"}'` → expect 403.
+- From the same machine: `curl -X POST http://127.0.0.1:3900/system/set-env -d '{"key":"HF_TOKEN","value":"x"}'` → expect 200.
+</verification>
+
+<success_criteria>
+- `/system/set-env` returns 403 for any non-loopback caller and 200 (with env mutation) for loopback callers.
+- All existing allow-list, env-mutation, logging, and return-shape behavior is preserved verbatim for the loopback path.
+- New regression tests in `tests/test_api.py` cover both the 403 and 200 paths and pass.
+- `260518-ivy-deferred-items.md` exists in the quick directory enumerating the other five POST routes in `system.py` with risk notes.
+- Single atomic commit on `main` with title `security: add loopback origin check to /system/set-env`, body referencing PR #66, no other endpoints modified, `git status` clean.
+- Local-first guarantee from CLAUDE.md is reinforced (not weakened): credentials cannot be mutated by anyone other than a same-machine principal.
+</success_criteria>
+
+<output>
+Create `.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-SUMMARY.md` when done summarizing what shipped, the test results, the deferred items, and the commit SHA.
+</output>

--- a/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-SUMMARY.md
+++ b/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-SUMMARY.md
@@ -1,0 +1,132 @@
+---
+phase: quick-260518-ivy
+plan: 01
+subsystem: backend.api.routers.system
+tags:
+  - security
+  - fastapi
+  - backend
+  - loopback
+dependency_graph:
+  requires: []
+  provides:
+    - SEC-LOOPBACK-01
+  affects:
+    - backend/api/routers/system.py
+    - tests/test_api.py
+tech_stack:
+  added: []
+  patterns:
+    - fastapi.Request injection for peer-address gating
+    - TestClient(app, client=("127.0.0.1", 50000)) to simulate loopback in tests
+key_files:
+  created:
+    - .planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md
+  modified:
+    - backend/api/routers/system.py
+    - tests/test_api.py
+decisions:
+  - "Read request.client.host (TCP peer) — not any X-Forwarded-For header — so the guard is not spoofable by clients on a reverse-proxy boundary."
+  - "Treat request.client is None as non-loopback (also 403) — defensive for pathological transports."
+  - "Did NOT add loopback guards to the other five POST endpoints in system.py this commit. Cataloged in deferred-items.md for Task #18 follow-up; the credential-mutation vector was the urgent fix."
+  - "Did NOT factor out a shared loopback dependency / decorator yet — rule-of-three. Will refactor when the second endpoint adopts the same gate."
+  - "Restored an incidental uv.lock drift (setuptools specifier) before committing — out of scope for this security fix."
+metrics:
+  duration: "5m 12s"
+  completed: "2026-05-18T08:15:03Z"
+---
+
+# Quick Task 260518-ivy: Loopback Origin Check on /system/set-env
+
+Hardened `POST /system/set-env` against LAN credential-overwrite by gating the handler on `request.client.host ∈ {"127.0.0.1", "::1", "localhost"}` before any `os.environ` mutation; covered with three regression tests and shipped in a single atomic commit on the worktree branch.
+
+## What shipped
+
+**Production change** (`backend/api/routers/system.py`):
+1. Extended the existing fastapi import on line 7 to include `Request` (no duplicate import line).
+2. Changed the handler signature on line 525 from `async def set_env_var(body: dict):` to `async def set_env_var(request: Request, body: dict):`.
+3. Inserted the loopback gate as the FIRST executable statement of the function body, before `ALLOWED_KEYS`:
+
+   ```python
+   host = request.client.host if request.client else None
+   if host not in ("127.0.0.1", "::1", "localhost"):
+       raise HTTPException(status_code=403, detail="set-env requires loopback origin")
+   ```
+4. Every other line of the handler is byte-for-byte unchanged (ALLOWED_KEYS check, value branch / pop branch, logger.info lines, return dict). Confirmed via `grep -c 'request.client.host' backend/api/routers/system.py` → exactly 1 match.
+
+**Test change** (`tests/test_api.py`, appended below `test_kani_tts_synth_streaming_e2e_explicit_sampling`):
+- `test_set_env_rejects_non_loopback` — uses the existing `client` fixture (default `request.client.host == "testclient"`), POSTs `{"key": "HF_TOKEN", "value": "__set_env_should_not_be_set__"}`, asserts 403, asserts `"loopback" in detail.lower()`, asserts os.environ is unchanged. Wrapped in try/finally to restore any prior `HF_TOKEN` on teardown.
+- `test_set_env_allows_loopback` — builds a fresh `TestClient(app, client=("127.0.0.1", 50000))`, POSTs `{"key": "HF_TOKEN", "value": "hf_loopback_ok"}`, asserts 200, asserts `response.json() == {"key": "HF_TOKEN", "set": True}`, asserts `os.environ["HF_TOKEN"] == "hf_loopback_ok"`. Try/finally restores `HF_TOKEN` to its prior state.
+- `test_set_env_loopback_still_validates_allowlist` — confirms the new guard does NOT bypass the existing allow-list: loopback POST with `{"key": "DISALLOWED", ...}` still returns 400 and `DISALLOWED` is not added to `os.environ`.
+
+**Deferred-items file** (`.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md`):
+Enumerates the other five `@router.post(...)` endpoints in `backend/api/routers/system.py` with one-line descriptions and per-endpoint risk notes, plus a recommended triage step (loopback-only / rate-limit / token-auth) for the Task #18 follow-up:
+- `/model/unload/{model_id}` (line 108) — model eviction DOS, severity low
+- `/system/logs/clear` (line 318) — anti-forensics, severity low–medium
+- `/system/logs/tauri/clear` (line 341) — anti-forensics, severity low–medium
+- `/system/flush-memory` (line 384) — performance degradation DOS, severity low
+- `/clean-audio` (line 555) — resource exhaustion + disk write, severity medium
+
+## Test results
+
+```
+$ uv run python -m pytest tests/test_api.py -k "set_env" -x -q
+...                                                                      [100%]
+3 passed, 28 deselected in 1.36s
+```
+
+Plus the wider router smoke suite as a non-regression check:
+
+```
+$ uv run python -m pytest tests/test_router_smoke.py -x -q
+23 passed, 7 warnings in 106.67s
+```
+
+The seven warnings are pre-existing pydub `DeprecationWarning`s from upstream (`pydub/utils.py` invalid escape sequences and `audioop` removal in Python 3.13) — not introduced by this commit and out of scope per the analysis-paralysis-guard / scope-boundary rules.
+
+## Commit
+
+| Field | Value |
+| ----- | ----- |
+| SHA   | `e1f08a6845e3d1766ce69dce776fa9ef3875f2ae` (`e1f08a6`) |
+| Branch | `worktree-agent-aece56abfce0a911a` (per-agent worktree; not pushed) |
+| Subject | `security: add loopback origin check to /system/set-env` |
+| Files | `backend/api/routers/system.py`, `tests/test_api.py`, `.planning/quick/260518-ivy-.../260518-ivy-deferred-items.md` |
+| Net diff | 93 insertions, 2 deletions across 3 files |
+
+The PLAN.md was already committed in the base commit (`58a1ec0 docs(260518-ivy): pre-dispatch plan for loopback origin check on /system/set-env`), so it's traceable in git history without re-committing — `git status` confirmed clean post-commit. No push to remote.
+
+## Threat model coverage
+
+The plan's `<threat_model>` register lists six threats; this commit closes/handles each as documented:
+
+- **T-ivy-01 (Tampering, LAN host hits /system/set-env)** — MITIGATED by the loopback gate, verified by `test_set_env_rejects_non_loopback`.
+- **T-ivy-02 (Elevation of Privilege, LAN host overwriting HF_TOKEN)** — MITIGATED by the same gate; attacker has no reachable mutation path.
+- **T-ivy-03 (Information Disclosure via length-only log line)** — ACCEPTED; pre-existing behavior, no regression introduced.
+- **T-ivy-04 (Tampering by same-machine non-OmniVoice process)** — ACCEPTED; OS-level UID/process auth is out of scope, documented in deferred-items for a future hardening pass.
+- **T-ivy-05 (Spoofing via X-Forwarded-For)** — MITIGATED-BY-DESIGN; guard reads `request.client.host` (actual TCP peer), never any header.
+- **T-ivy-SC (Supply-chain risk via package install)** — MITIGATED; no new package installs in this commit. `fastapi.Request` was already importable from the existing pinned `fastapi` dep.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. The three tasks ran in order, the production edit matched the `<action>` block byte-for-byte (single-line import extension, signature change, four-line guard insertion above ALLOWED_KEYS), the test names match the plan's prescribed names, the deferred-items file enumerates the five routes the plan listed with the same risk notes, and the commit subject is exactly `security: add loopback origin check to /system/set-env`.
+
+One minor non-deviation observation: running `uv run` during verification incidentally rewrote a `setuptools` specifier line in `uv.lock`. Per the plan's Task 3 instruction ("Verify with `git status` that no other files are staged inadvertently") I reverted `uv.lock` before staging so the commit touches only the four intended paths. This is in-scope cleanup, not a deviation.
+
+## Threat Flags
+
+None introduced beyond those in the plan's threat register. The change strictly reduces attack surface.
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+- `backend/api/routers/system.py`: FOUND, contains `request.client.host` (1 match, in `set_env_var`).
+- `tests/test_api.py`: FOUND, contains `test_set_env_rejects_non_loopback`, `test_set_env_allows_loopback`, `test_set_env_loopback_still_validates_allowlist`.
+- `.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md`: FOUND, enumerates the five other POST routes.
+- Commit `e1f08a6`: FOUND in `git log --oneline`.
+- `pytest tests/test_api.py -k set_env`: 3 passed / 28 deselected.
+- `pytest tests/test_router_smoke.py`: 23 passed (non-regression).
+- `git status` post-commit: clean.

--- a/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md
+++ b/.planning/quick/260518-ivy-add-loopback-origin-check-to-system-set-/260518-ivy-deferred-items.md
@@ -1,0 +1,25 @@
+# Deferred Items — 260518-ivy follow-up
+
+**Trigger:** PR #66 security review surfaced that `backend/api/routers/system.py` binds `0.0.0.0:3900` and several `@router.post(...)` endpoints in this router lack any authentication or origin check. Quick task `260518-ivy` hardened only `/system/set-env` (the credential-mutation vector). The remaining unauthenticated POST endpoints in the same file are catalogued here for a follow-up triage pass.
+
+**Out of scope for the 260518-ivy commit — to be triaged in a follow-up quick task (Task #18 in backlog) or as part of Phase 5 (Opt-in Bug Reporting) security review.**
+
+These endpoints all share the same trust-boundary defect: any LAN host (or arbitrary same-machine process) can reach them because the backend listens on `0.0.0.0:3900`. None of them rotate credentials, but several enable denial-of-service or anti-forensics attacks from a LAN attacker. None are gated by the loopback origin check shipped in this commit; each will need its own analysis (some may legitimately want LAN access — e.g., a future "control OmniVoice from your phone" feature — and others should be loopback-only).
+
+## Other POST endpoints in `backend/api/routers/system.py`
+
+- `/model/unload/{model_id}` (line 108) — unloads a named model from memory. Risk: a LAN host can force-evict the user's loaded TTS/ASR model, causing a re-load stall on next inference. Severity: low (no data exfil, no credential mutation).
+- `/system/logs/clear` (line 318) — truncates the backend log file. Risk: a LAN host can destroy diagnostic evidence (anti-forensics). Severity: low–medium.
+- `/system/logs/tauri/clear` (line 341) — truncates the frontend (Tauri) log file. Risk: same as above. Severity: low–medium.
+- `/system/flush-memory` (line 384) — forces a GC / VRAM-flush cycle. Risk: a LAN host can trigger repeated flushes to degrade performance. Severity: low.
+- `/clean-audio` (line 555) — accepts an uploaded WAV and runs demucs. Risk: a LAN host can upload arbitrary audio and consume CPU/GPU/disk on the user's machine. Severity: medium (resource exhaustion + writes to OUTPUTS_DIR).
+
+## Recommended next step
+
+Open Task #18 to triage the above with one of three dispositions per endpoint:
+
+1. **Loopback-only** — reuse the guard pattern from `set_env_var` (factor into a small dependency / decorator after the third copy).
+2. **Keep open with rate-limiting** — for endpoints that may legitimately be reached from a future LAN-control surface.
+3. **Authenticated** — wait for the local-token scheme planned for the Tauri ↔ backend handshake (separate roadmap item, not in v0.3.x scope).
+
+The router-wide audit should also cover the GET endpoints (e.g. `/system/info`, `/system/logs`) for information-disclosure analogues; those were not enumerated in this commit because they do not mutate state.

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -4,7 +4,7 @@ import uuid
 import psutil
 import asyncio
 import logging
-from fastapi import APIRouter, File, UploadFile, HTTPException, Query
+from fastapi import APIRouter, File, UploadFile, HTTPException, Query, Request
 from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse, LogsResponse, FlushMemoryResponse
 from fastapi.responses import FileResponse, StreamingResponse
 import torch
@@ -522,7 +522,7 @@ def system_notifications():
 
 
 @router.post("/system/set-env")
-async def set_env_var(body: dict):
+async def set_env_var(request: Request, body: dict):
     """Set an environment variable at runtime.
 
     Currently supports:
@@ -532,6 +532,9 @@ async def set_env_var(body: dict):
     The value is set on os.environ for the running process.
     For persistence across restarts, users should set it in their shell profile.
     """
+    host = request.client.host if request.client else None
+    if host not in ("127.0.0.1", "::1", "localhost"):
+        raise HTTPException(status_code=403, detail="set-env requires loopback origin")
     ALLOWED_KEYS = {"HF_TOKEN", "TRANSLATE_API_KEY"}
     key = body.get("key", "")
     value = body.get("value", "")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -535,3 +535,66 @@ class TestStreamingTTS:
             assert res.headers.get("x-audio-duration") is not None
             # Verify it's valid WAV
             assert len(res.content) > 44  # WAV header is 44 bytes minimum
+
+
+# ---------------------------------------------------------------------------
+# /system/set-env loopback-origin guard (260518-ivy security fix)
+# ---------------------------------------------------------------------------
+
+def test_set_env_rejects_non_loopback(client):
+    """Default TestClient sets request.client.host = 'testclient' (non-loopback).
+    The guard must return 403 and must NOT mutate os.environ."""
+    sentinel = "__set_env_should_not_be_set__"
+    # Ensure HF_TOKEN does not currently equal the sentinel
+    original = os.environ.get("HF_TOKEN")
+    os.environ.pop("HF_TOKEN", None)
+    try:
+        res = client.post("/system/set-env", json={"key": "HF_TOKEN", "value": sentinel})
+        assert res.status_code == 403
+        assert "loopback" in res.json().get("detail", "").lower()
+        # Guard must short-circuit before the os.environ mutation
+        assert os.environ.get("HF_TOKEN") != sentinel
+    finally:
+        if original is None:
+            os.environ.pop("HF_TOKEN", None)
+        else:
+            os.environ["HF_TOKEN"] = original
+
+
+def test_set_env_allows_loopback():
+    """A TestClient explicitly constructed with client=('127.0.0.1', ...) must pass
+    the loopback gate, mutate os.environ, and return the documented payload."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    loopback_client = TestClient(app, client=("127.0.0.1", 50000))
+    original = os.environ.get("HF_TOKEN")
+    os.environ.pop("HF_TOKEN", None)
+    try:
+        res = loopback_client.post(
+            "/system/set-env",
+            json={"key": "HF_TOKEN", "value": "hf_loopback_ok"},
+        )
+        assert res.status_code == 200
+        assert res.json() == {"key": "HF_TOKEN", "set": True}
+        assert os.environ.get("HF_TOKEN") == "hf_loopback_ok"
+    finally:
+        if original is None:
+            os.environ.pop("HF_TOKEN", None)
+        else:
+            os.environ["HF_TOKEN"] = original
+
+
+def test_set_env_loopback_still_validates_allowlist():
+    """Even on the loopback path, keys outside the allow-list must return 400 —
+    the new guard must NOT bypass the existing allow-list enforcement."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    loopback_client = TestClient(app, client=("127.0.0.1", 50000))
+    res = loopback_client.post(
+        "/system/set-env",
+        json={"key": "DISALLOWED", "value": "x"},
+    )
+    assert res.status_code == 400
+    assert "DISALLOWED" not in os.environ


### PR DESCRIPTION
## Summary

- Adds a `request.client.host` allow-list check (`127.0.0.1` / `::1` / `localhost`) to `POST /system/set-env` so non-loopback callers receive `403` instead of being able to mutate `os.environ` for `HF_TOKEN` / `TRANSLATE_API_KEY`.
- Surfaced during security review of PR #66 — that PR widens the existing pre-fix window (in-memory state) into disk-persistent secret overwrite via the expanded `PERSISTENT_KEYS` allow-list. This PR closes the underlying vulnerability so PR #66's revision lands onto a clean base.
- Defensive `request.client is None` branch handles ASGI middleware that strips client info (rare but documented in Starlette).

## Scope

| File | Lines | Note |
|---|---|---|
| `backend/api/routers/system.py` | +5 / -1 | `Request` import + signature + 3-line loopback guard |
| `tests/test_api.py` | +63 / -0 | 3 new tests (reject non-loopback / allow loopback / allow-list still validated on loopback) |
| `.planning/quick/260518-ivy-.../` | +planning artifacts | GSD trail: PLAN, SUMMARY, deferred-items |
| `.planning/STATE.md` | +6 / -1 | Quick task entry |

3 of 4 commits are pure planning/process artifacts; the one functional change is `e1f08a6`. CI matrix from #71 should validate cross-platform.

## Test plan

- [x] `uv run python -m pytest tests/test_api.py -k set_env -x -q` → 3 passed
- [x] Non-regression: `uv run python -m pytest tests/test_router_smoke.py` → 23 passed
- [ ] Phase 0 CI matrix green on macOS / Windows / Linux
- [ ] Manual verification: confirm a LAN-bound POST to `http://<lan-ip>:3900/system/set-env` returns `403` (was previously `200` + state mutation)

## Follow-up

`260518-ivy-deferred-items.md` enumerates the 5 sibling `POST` routes in `system.py` that share the same auth/origin gap pattern. Task tracker has these queued for a broader `/system/*` audit (separate PR, not bundled here to keep this surface tight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened `/system/set-env` endpoint with origin validation to prevent LAN-based credential overwrite attacks. Non-loopback requests now return HTTP 403 and are rejected; loopback requests continue to work as expected.

* **Tests**
  * Added test coverage for loopback origin enforcement, non-loopback rejection, and validation of existing allowlist restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->