### PR TITLE
feat: add MiniMax provider support (Chat + TTS)

### DIFF
--- a/backend/services/llm_backend.py
+++ b/backend/services/llm_backend.py
@@ -125,6 +125,72 @@ class OpenAICompatBackend(LLMBackend):
 # ── Off — explicit no-LLM path ────────────────────────────────────────────
 
 
+class MiniMaxBackend(LLMBackend):
+    """MiniMax (MiniMax) — OpenAI-compatible chat endpoint.
+
+    Models:
+      • MiniMax-M2.7        — Peak Performance. Ultimate Value.
+      • MiniMax-M2.7-highspeed — Same performance, faster and more agile.
+
+    Config env vars:
+      MINIMAX_API_KEY       — required
+      MINIMAX_BASE_URL      — optional (default https://api.minimax.io/v1)
+      MINIMAX_MODEL         — optional (default MiniMax-M2.7)
+    """
+
+    id = "minimax"
+    display_name = "MiniMax (MiniMax)"
+
+    def __init__(self):
+        self._client = None
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        try:
+            import openai  # noqa: F401
+        except ImportError:
+            return False, "openai package missing (install with `pip install openai`)."
+        if not os.environ.get("MINIMAX_API_KEY"):
+            return False, (
+                "MINIMAX_API_KEY not set. Get one at https://platform.minimax.io "
+                "and export MINIMAX_API_KEY=<key>."
+            )
+        return True, "ready"
+
+    @property
+    def model_name(self) -> str:
+        return os.environ.get("MINIMAX_MODEL", "MiniMax-M2.7")
+
+    def _get_client(self):
+        if self._client is not None:
+            return self._client
+        from openai import OpenAI
+
+        api_key = os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY not set. See `is_available()` for details.")
+        base_url = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+        self._client = OpenAI(api_key=api_key, base_url=base_url)
+        return self._client
+
+    def chat(self, *, system: str, user: str, timeout: Optional[float] = None) -> str:
+        if timeout is None:
+            try:
+                timeout = float(os.environ.get("OMNIVOICE_LLM_TIMEOUT", "45"))
+            except ValueError:
+                timeout = 45.0
+        res = self._get_client().chat.completions.create(
+            model=self.model_name,
+            timeout=timeout,
+            temperature=1.0,  # MiniMax requires (0.0, 1.0], cannot be 0
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        )
+        return (res.choices[0].message.content or "").strip()
+
+
 class OffBackend(LLMBackend):
     id = "off"
     display_name = "Off (no LLM)"
@@ -146,6 +212,7 @@ class OffBackend(LLMBackend):
 
 _REGISTRY: dict[str, type[LLMBackend]] = {
     "openai-compat": OpenAICompatBackend,
+    "minimax":       MiniMaxBackend,
     "off":           OffBackend,
 }
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1109,6 +1109,124 @@ class SherpaOnnxBackend(TTSBackend):
         return wav
 
 
+# ── MiniMax TTS adapter (cloud API, hex-encoded audio) ────────────────────
+
+
+class MiniMaxTTSBackend(TTSBackend):
+    """MiniMax TTS — cloud-based text-to-speech via the MiniMax API.
+
+    Models: speech-2.8-hd (default, highest quality), speech-2.8-turbo (fast).
+    Endpoint: POST https://api.minimax.io/v1/t2a_v2
+    Audio: hex-encoded MP3, decoded to PCM tensor.
+
+    Config env vars:
+      MINIMAX_API_KEY       — required (shared with MiniMax Chat)
+      MINIMAX_BASE_URL      — optional (default https://api.minimax.io)
+      MINIMAX_TTS_MODEL     — optional (default speech-2.8-hd)
+    """
+
+    id = "minimax"
+    display_name = "MiniMax TTS (cloud, speech-2.8-hd / turbo)"
+
+    # MiniMax voices — a curated subset of the system voice list.
+    VOICES = [
+        "English_Graceful_Lady",
+        "English_Insightful_Speaker",
+        "English_radiant_girl",
+        "English_Persuasive_Man",
+        "English_Lucky_Robot",
+        "English_expressive_narrator",
+    ]
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        if not os.environ.get("MINIMAX_API_KEY"):
+            return False, (
+                "MINIMAX_API_KEY not set. Get one at https://platform.minimax.io "
+                "and export MINIMAX_API_KEY=<key>."
+            )
+        return True, "ready"
+
+    @property
+    def sample_rate(self) -> int:
+        return 32000
+
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["multi"]
+
+    def generate(self, text: str, **kw) -> torch.Tensor:
+        import io
+        import json
+        import urllib.request
+
+        api_key = os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            raise RuntimeError("MINIMAX_API_KEY not set. See `is_available()` for details.")
+
+        base_url = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io")
+        base_url = base_url.rstrip("/")
+        model = os.environ.get("MINIMAX_TTS_MODEL", "speech-2.8-hd")
+        voice = kw.get("voice", self.VOICES[0])
+        speed = float(kw.get("speed", 1.0))
+
+        payload = json.dumps({
+            "model": model,
+            "text": text,
+            "stream": False,
+            "voice_setting": {
+                "voice_id": voice,
+                "speed": speed,
+                "vol": 1,
+                "pitch": 0,
+            },
+            "audio_setting": {
+                "sample_rate": self.sample_rate,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1,
+            },
+        }).encode()
+
+        req = urllib.request.Request(
+            f"{base_url}/v1/t2a_v2",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                result = json.loads(resp.read())
+        except Exception as e:
+            raise RuntimeError(f"MiniMax TTS API call failed: {e}")
+
+        status_code = result.get("base_resp", {}).get("status_code", -1)
+        if status_code != 0:
+            msg = result.get("base_resp", {}).get("status_msg", "unknown error")
+            raise RuntimeError(f"MiniMax TTS error ({status_code}): {msg}")
+
+        hex_audio = result.get("data", {}).get("audio", "")
+        if not hex_audio:
+            raise RuntimeError("MiniMax TTS returned empty audio data.")
+
+        # MiniMax returns hex-encoded audio (not base64).
+        audio_bytes = bytes.fromhex(hex_audio)
+
+        import torchaudio
+        wav, sr = torchaudio.load(io.BytesIO(audio_bytes))
+        if sr != self.sample_rate:
+            wav = torchaudio.functional.resample(wav, sr, self.sample_rate)
+        if wav.ndim == 1:
+            wav = wav.unsqueeze(0)
+        elif wav.ndim == 2 and wav.shape[0] > 1:
+            wav = wav.mean(dim=0, keepdim=True)
+        return wav
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 
 
@@ -1122,6 +1240,7 @@ _REGISTRY: dict[str, type[TTSBackend]] = {
     "indextts2":     IndexTTS2Backend,
     "gpt-sovits":    GPTSoVITSBackend,
     "sherpa-onnx":   SherpaOnnxBackend,
+    "minimax":       MiniMaxTTSBackend,
 }
 
 
@@ -1138,6 +1257,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "indextts2":     "git clone index-tts/index-tts && uv pip install -e .  (NOT uv sync --all-extras)",
     "gpt-sovits":    "External API server — start api_v2.py on port 9880",
     "sherpa-onnx":   "pip install sherpa-onnx  (universal ONNX runtime, WASM-ready)",
+    "minimax":       "Cloud API — set MINIMAX_API_KEY (get key at https://platform.minimax.io)",
 }
 
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -99,7 +99,7 @@ def test_asr_env_override(monkeypatch):
 def test_llm_registry_includes_off():
     rows = llm_backend.list_backends()
     ids = {r["id"] for r in rows}
-    assert ids == {"openai-compat", "off"}
+    assert {"openai-compat", "off", "minimax"}.issubset(ids)
 
 
 def test_llm_off_chat_raises_actionable(monkeypatch):
@@ -131,3 +131,83 @@ def test_llm_auto_selects_openai_compat_when_configured(monkeypatch):
     except ImportError:
         pytest.skip("openai package not available in this environment")
     assert llm_backend.active_backend_id() == "openai-compat"
+
+
+# ── MiniMax (minimax) ──────────────────────────────────────────────────────
+
+
+def test_llm_registry_includes_minimax():
+    rows = llm_backend.list_backends()
+    ids = {r["id"] for r in rows}
+    assert "minimax" in ids
+
+
+def test_llm_minimax_unavailable_without_key(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    ok, msg = llm_backend.MiniMaxBackend.is_available()
+    assert not ok
+    assert "MINIMAX_API_KEY" in msg or "openai" in msg
+
+
+def test_llm_minimax_available_with_key(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    try:
+        import openai  # noqa: F401
+    except ImportError:
+        pytest.skip("openai package not available in this environment")
+    ok, _ = llm_backend.MiniMaxBackend.is_available()
+    assert ok
+
+
+def test_llm_minimax_default_model():
+    be = llm_backend.MiniMaxBackend()
+    assert be.model_name == "MiniMax-M2.7"
+
+
+def test_llm_minimax_custom_model(monkeypatch):
+    monkeypatch.setenv("MINIMAX_MODEL", "MiniMax-M2.7-highspeed")
+    be = llm_backend.MiniMaxBackend()
+    assert be.model_name == "MiniMax-M2.7-highspeed"
+
+
+def test_llm_minimax_env_override_selects(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_LLM_BACKEND", "minimax")
+    assert llm_backend.active_backend_id() == "minimax"
+
+
+def test_tts_minimax_unavailable_without_key(monkeypatch):
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    ok, msg = tts_backend.MiniMaxTTSBackend.is_available()
+    assert not ok
+    assert "MINIMAX_API_KEY" in msg
+
+
+def test_tts_minimax_available_with_key(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+    ok, _ = tts_backend.MiniMaxTTSBackend.is_available()
+    assert ok
+
+
+def test_tts_minimax_sample_rate():
+    assert tts_backend.MiniMaxTTSBackend().sample_rate == 32000
+
+
+def test_tts_minimax_voices():
+    assert len(tts_backend.MiniMaxTTSBackend.VOICES) == 6
+    assert "English_Graceful_Lady" in tts_backend.MiniMaxTTSBackend.VOICES
+
+
+def test_tts_minimax_languages():
+    langs = tts_backend.MiniMaxTTSBackend().supported_languages
+    assert "multi" in langs
+
+
+def test_tts_minimax_env_override_selects(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_TTS_BACKEND", "minimax")
+    assert tts_backend.active_backend_id() == "minimax"
+
+
+def test_tts_minimax_in_registry():
+    rows = tts_backend.list_backends()
+    ids = {r["id"] for r in rows}
+    assert "minimax" in ids


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as a new provider for both **Chat (LLM)** and **TTS** capabilities:

- **Chat Model**: `MiniMaxBackend` — OpenAI-compatible adapter using models `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`. Follows the same registry pattern as the existing `OpenAICompatBackend`.
- **TTS**: `MiniMaxTTSBackend` — cloud-based text-to-speech via MiniMax's T2A API (`speech-2.8-hd`, `speech-2.8-turbo`). Supports 6 English voices, hex-encoded audio decoding, and auto-appears in Settings → Engines.
- **Shared API key**: Both adapters use `MINIMAX_API_KEY` (get one at [platform.minimax.io](https://platform.minimax.io))
- **Tests**: 12 new unit tests covering registration, availability, config, and env var overrides — all passing

### Environment Variables

| Variable | Required | Purpose |
|----------|----------|---------|
| `MINIMAX_API_KEY` | Yes | API key for both Chat and TTS |
| `MINIMAX_BASE_URL` | No | Override default base URL |
| `MINIMAX_MODEL` | No | Override default Chat model (default: `MiniMax-M2.7`) |
| `MINIMAX_TTS_MODEL` | No | Override default TTS model (default: `speech-2.8-hd`) |

### API Documentation

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- TTS: https://platform.minimax.io/docs/api-reference/speech-t2a-http

## Test Plan

- [x] Unit tests pass (`uv run pytest tests/test_engines.py` — 26 passed, 2 skipped)
- [x] Integration test: Chat API returns valid response with `MiniMax-M2.7`
- [x] Integration test: TTS API returns valid hex-encoded MP3 audio (27KB for short text)
- [x] Existing tests unaffected (only 1 assertion updated to include new provider in registry check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported language model provider. Configure with `MINIMAX_API_KEY` environment variable.
  * Added MiniMax as a supported text-to-speech provider. Configure with `MINIMAX_API_KEY` and optional `MINIMAX_BASE_URL` and `MINIMAX_MODEL` variables.
  * Both backends are now discoverable and selectable in application settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->