### PR TITLE
Fix NameError: '_gpu_pool' is not defined in get_model()

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -323,7 +323,7 @@ async def get_model():
     async with _model_lock:
         if model is None:
             loop = asyncio.get_running_loop()
-            model = await loop.run_in_executor(_gpu_pool, _load_model_sync)
+            model = await loop.run_in_executor(_get_gpu_pool(), _load_model_sync)
     return model
 
 


### PR DESCRIPTION
## Summary

- Fix `NameError: name '_gpu_pool' is not defined` when calling `get_model()`
- Use `_get_gpu_pool()` accessor instead of direct `_gpu_pool` reference

## Problem

The `/generate` endpoint fails with:

```
NameError: name '_gpu_pool' is not defined
  File "backend/services/model_manager.py", line 326, in get_model
    model = await loop.run_in_executor(_gpu_pool, _load_model_sync)
```

## Root Cause

`_gpu_pool` is a lazy module attribute only accessible via `__getattr__` (lines 102-108) or the `_get_gpu_pool()` accessor (lines 90-98). Line 326 was accessing it directly, which bypasses the lazy initialization.

Line 357 already correctly uses `_get_gpu_pool()`.

## Fix

```diff
- model = await loop.run_in_executor(_gpu_pool, _load_model_sync)
+ model = await loop.run_in_executor(_get_gpu_pool(), _load_model_sync)
```

## Test Plan

- [x] Verified `/generate` endpoint now works after fix
- [x] Generated audio successfully with voice design instructions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency in background model loading task management to ensure reliable and uniform behavior across different model initialization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->