### PR TITLE
fix(smoke): force-override OMNIVOICE_DATA_DIR + purge cached backend modules

### DIFF
--- a/tests/smoke/test_boot_smoke.py
+++ b/tests/smoke/test_boot_smoke.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 
@@ -43,17 +44,21 @@ if not FIXTURE_SRC.exists():
 _FIXTURE_COPY = Path(tempfile.mkdtemp(prefix="omnivoice-smoke-"))
 shutil.copytree(FIXTURE_SRC, _FIXTURE_COPY, dirs_exist_ok=True)
 
-# Point backend.core.config.get_app_data_dir() at the COPY before any
-# import that pulls in core.config (which caches DB_PATH at module import).
-os.environ.setdefault("OMNIVOICE_DATA_DIR", str(_FIXTURE_COPY))
+# Point backend.core.config.get_app_data_dir() at the COPY. Force-override
+# (not setdefault) — earlier tests in a full-suite run may have set it to
+# their own temp dir, and core.config caches DB_PATH at first import.
+os.environ["OMNIVOICE_DATA_DIR"] = str(_FIXTURE_COPY)
 
 
 @pytest.fixture(scope="module")
 def client():
-    # Lazy import — env must be set before `core.config` is touched.
-    # `client=("127.0.0.1", 50000)` makes `request.client.host` resolve to
-    # a loopback address — the system router is now gated by a router-level
-    # `require_loopback` dependency, and the smoke test hits `/system/info`.
+    # Purge any cached backend modules from earlier tests in the suite —
+    # `core.config` reads OMNIVOICE_DATA_DIR at import time and caches DB_PATH,
+    # so a prior import with a different value would survive the env-var
+    # override above. Same pattern as tests/backend/services/conftest.py.
+    for mod in list(sys.modules):
+        if mod == "main" or mod == "core" or mod.startswith("core.") or mod.startswith("api.") or mod.startswith("services."):
+            sys.modules.pop(mod, None)
     from fastapi.testclient import TestClient
     from main import app
     return TestClient(app, client=("127.0.0.1", 50000))


### PR DESCRIPTION
## Summary

The smoke test used `os.environ.setdefault()` to point at the frozen fixture, which silently skipped when a prior test in the suite had already set the env var. Combined with `core.config` caching `DB_PATH` at module import time, this left smoke tests pointed at the wrong DB once Wave 1's services tests pre-imported `main` with their own temp state.

- Exposed by Wave 2's additional tests (PR #94) pushing collection order past the tipping point.
- Underlying pollution existed since Wave 1 merged — Wave 3 CI passed only by collection-order luck.
- Fix mirrors the `sys.modules` purge pattern that `tests/backend/services/conftest.py` already uses.

## Test plan
- [x] `pytest tests/smoke/` → 4 passed (no regression vs Phase 0 smoke matrix)
- [x] `pytest tests/backend/services tests/smoke/` → 31 passed (used to fail at the smoke step)
- [x] `pytest tests/ -q --ignore=tests/manual` → 292 passed, 6 skipped, 12 xfailed, 1 xpassed, 0 failures
- [x] Cross-platform: change is OS-agnostic (no path / env-var conventions changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved smoke test reliability to ensure proper test isolation and prevent data contamination between test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->