### PR TITLE
fix(tauri): inject-apprun path relative to frontend/ (where beforeBundleCommand runs)

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
     "devUrl": "http://localhost:3901",
     "beforeDevCommand": "bun run dev",
     "beforeBuildCommand": "bun run build",
-    "beforeBundleCommand": "bash ../../scripts/inject-apprun.sh"
+    "beforeBundleCommand": "bash ../scripts/inject-apprun.sh"
   },
   "app": {
     "macOSPrivateApi": true,


### PR DESCRIPTION
## Summary

`bun desktop-prod` was failing on every developer machine at the bundle step with:

\`\`\`
Running beforeBundleCommand \`bash ../../scripts/inject-apprun.sh\`
bash: ../../scripts/inject-apprun.sh: No such file or directory
beforeBundleCommand failed with exit code 127
Build failed with exit code 1
\`\`\`

Root cause: Tauri's \`beforeBundleCommand\` runs from the directory containing the frontend \`package.json\` (\`frontend/\`), **not** from \`frontend/src-tauri/\`. The Phase 1 Wave 3 work used the wrong relative prefix — \`../../scripts/inject-apprun.sh\` resolved one level above the project root, so the script was never found.

Fix: drop one \`../\`. The script itself was correct (uses absolute paths internally), so on macOS it cleanly exits with "no AppDir staging found (skipping — not an AppImage build)" once the path resolves.

## Test plan
- [x] \`bun desktop-prod\` end-to-end on macOS — reaches "✅ Build complete" and launches the .app bundle
- [x] \`inject-apprun.sh\` invoked correctly from \`frontend/\`: outputs "no AppDir staging found (skipping)" on non-AppImage builds
- [ ] AppImage build on Linux — to be verified by release.yml on the next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings.

---

**Note:** This is an internal maintenance update with no direct impact on end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->