### PR TITLE
fix(desktop-prod): clean backend data dir for actual fresh-install emulation

### DIFF
--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -28,13 +28,23 @@ case "$OS" in
 esac
 
 # ── Platform-specific paths ───────────────────────────────────────────────
+# Two directories matter for fresh-install simulation:
+#   APP_DATA     — Tauri's bundle dir (keyed by APP_ID); holds the post-install
+#                  Python venv + webview state.
+#   BACKEND_DATA — Where backend/core/config.py::get_app_data_dir() writes:
+#                  SQLite db, voice profiles, generation outputs, logs. This is
+#                  NOT under APP_ID — it's a separate hardcoded name. Cleaning
+#                  only APP_DATA leaves all user data behind, defeating the
+#                  fresh-emulation promise.
 if [ "$PLATFORM" = "macos" ]; then
   APP_DATA="$HOME/Library/Application Support/${APP_ID}"
+  BACKEND_DATA="$HOME/Library/Application Support/OmniVoice"
   TAURI_LOGS="$HOME/Library/Logs/${APP_ID}"
   WEBKIT_DATA="$HOME/Library/WebKit/${APP_ID}"
 else
-  # Linux: XDG conventions
+  # Linux: backend uses ~/.omnivoice (not XDG — see backend/core/config.py).
   APP_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/${APP_ID}"
+  BACKEND_DATA="$HOME/.omnivoice"
   TAURI_LOGS="${XDG_DATA_HOME:-$HOME/.local/share}/${APP_ID}/logs"
   WEBKIT_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/${APP_ID}/webview"
 fi
@@ -68,12 +78,22 @@ if [ "$KEEP_DATA" = false ]; then
   echo "🧹 Cleaning all OmniVoice data for fresh prod emulation..."
   echo ""
 
-  # 1. App data (venv, config, bundled backend)
+  # 1. App data (Tauri bundle dir: post-install venv + webview state)
   if [ -d "${APP_DATA}" ]; then
     echo "   ✗ App data:     ${APP_DATA}"
     rm -rf "${APP_DATA}"
   else
     echo "   ○ App data:     (already clean)"
+  fi
+
+  # 1b. Backend data (SQLite db, voice profiles, outputs, logs)
+  #     — separate dir hardcoded in backend/core/config.py, NOT under APP_ID.
+  if [ -d "${BACKEND_DATA}" ]; then
+    BD_SIZE=$(du -sh "${BACKEND_DATA}" 2>/dev/null | cut -f1)
+    echo "   ✗ Backend data: ${BACKEND_DATA} (${BD_SIZE})"
+    rm -rf "${BACKEND_DATA}"
+  else
+    echo "   ○ Backend data: (already clean)"
   fi
 
   # 2. HF model cache (downloaded .safetensors, tokenizers, etc.)


### PR DESCRIPTION
## Problem

\`scripts/desktop-prod.sh\` claims "🧹 Cleaning all OmniVoice data for fresh prod emulation" but cleans the wrong directory.

- **Tauri APP_ID dir** (\`~/Library/Application Support/com.debpalash.omnivoice-studio/\`) — what the script cleans.
- **Backend data dir** (\`~/Library/Application Support/OmniVoice/\`) — where \`backend/core/config.py::get_app_data_dir()\` actually writes: SQLite db, voice profiles, dub jobs, generation outputs, logs.

These are separate hardcoded paths. The script's cleanup never touches the backend dir, so developers running \`bun desktop-prod\` think they're testing a clean install path but are actually testing on accumulated state.

## Surfaced

Running \`bun desktop-prod\` for the first time today on a clean tree: the .app launched, Settings showed a pre-existing voice profile ("palish") from a prior session despite the script's "fresh emulation" claim.

## Fix

Add a \`BACKEND_DATA\` variable and a \`1b\` cleanup step targeting the backend's actual data dir. Per platform (matches \`backend/core/config.py\`):

| OS      | Backend data dir                              |
|---------|-----------------------------------------------|
| macOS   | \`~/Library/Application Support/OmniVoice\`     |
| Linux   | \`~/.omnivoice\`                                |
| Windows | \`%APPDATA%/OmniVoice\` (not in this .sh script) |

## Test plan
- [x] \`bash -n scripts/desktop-prod.sh\` — syntax OK
- [ ] \`bun desktop-prod\` cleans both dirs and confirms backend boots with zero pre-existing profiles
- [ ] Linux verification: AppImage path uses \`~/.omnivoice\` cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved fresh install process to separately manage and clean backend data (databases, profiles, logs) and application data, with enhanced logging of disk usage during cleanup operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->