### PR TITLE
fix(ui): calmer launchpad — hide readiness when green, drop duplicate notif pill

### DIFF
--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ChevronUp, ChevronDown, RefreshCw, Trash2, Copy, Bug, X,
-  AlertTriangle, AlertCircle, Info, FileText, Heart, Bell,
+  AlertTriangle, AlertCircle, Info, FileText, Heart,
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { clearSystemLogs, clearTauriLogs } from '../api/system';
@@ -23,7 +23,9 @@ const SOURCES = [
   { id: 'backend',  label: 'Backend',  icon: FileText },
   { id: 'frontend', label: 'Frontend', icon: FileText },
   { id: 'tauri',    label: 'Tauri',    icon: FileText },
-  { id: 'notifications', label: 'Notifications', icon: Bell },
+  // Notifications used to live here as a 4th pill but that duplicated the
+  // header's bell+badge (single source of truth for notifications). The
+  // footer is logs-only now; bell handles notifications.
 ];
 
 const LS_HEIGHT = 'omnivoice.logs.height';

--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -240,7 +240,11 @@ export default function Launchpad({
               {t('launchpad.empty_hint')}
             </p>
           </div>
-          <ReadinessChecklist showWhenAllPass />
+          {/* No `showWhenAllPass` — let the component self-hide when every
+              check is pass-or-warn. Surfacing "everything is fine" on the
+              welcome screen is noise; only show when there's an actual
+              issue to address. */}
+          <ReadinessChecklist />
         </div>
       )}
 


### PR DESCRIPTION
Two small surfaces of "annoying chrome on the welcome screen":

## 1. System Readiness card stayed visible even when all-green

\`ReadinessChecklist\` already has self-hide logic for "every check passes or warns" — but \`Launchpad.jsx\` was passing \`showWhenAllPass\` which defeated it. The card was on every launch surfacing healthy-system diagnostics (FFmpeg path, yt-dlp version, "configure TRANSLATE_BASE_URL" optional config tip).

**Fix:** drop the prop. The compact "All systems ready" pill still appears once you have projects, so the affordance isn't gone — just quieter.

## 2. Footer "Notifications" pill duplicated the header bell

\`SOURCES\` in \`LogsFooter.jsx\` declared a 4th source (\`notifications\`) that rendered a duplicate pill in the always-visible footer. The header bell + badge is the canonical surface. Removed the entry + the now-unused \`Bell\` import.

## User-visible effect

On a healthy install, the Launchpad shows just the hero text + 3 capability cards. No "✅ System Readiness" panel. No "Notifications (1)" footer pill. The bell stays as the single notifications surface; the readiness card resurfaces when something actually needs attention.

## Test plan
- [x] \`bun run typecheck:ci\` clean
- [ ] Manual launch: confirm Launchpad is cleaner with no projects + all-green readiness
- [ ] Trigger a real warning (e.g., backend down) and confirm the readiness card resurfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated notification indicators to display exclusively from the header, eliminating duplicate notifications across different sections of the application interface
  * Updated the readiness checklist in the Launchpad view to dynamically display only when there are actionable items or unresolved issues that require user attention

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->