### PR TITLE
fix(ui): hide RAM/CPU/VRAM in header by default; opt in via Settings → Performance

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Globe, Fingerprint, Wand2, Film, FolderOpen, RefreshCw, Settings2, ChevronRight, ChevronDown, Zap, Building2, Library, FileText, Trash2 } from 'lucide-react';
 import { Button, Badge } from '../ui';
 import NotificationPanel from './NotificationPanel';
+import { useAppStore } from '../store';
 
 const VIEW_META = {
   launchpad:  { label: 'Launchpad',       Icon: Globe,       accent: '#f3a5b6', kicker: 'Studio' },
@@ -41,6 +42,10 @@ export default function Header({
   mode, setMode, sysStats, modelStatus, doubleClickMaximize,
   activeProjectName, onFlushMemory,
 }) {
+  // Default OFF — chrome shouldn't double as a resource monitor. Power users
+  // flip this on via Settings → Performance. Idle/Ready/Loading badge +
+  // Flush button stay visible regardless (action-relevant).
+  const showLiveStats = useAppStore(s => s.showHeaderLiveStats);
   const [flushing, setFlushing] = useState(false);
   const [flushOpen, setFlushOpen] = useState(false);
   const [loadedModels, setLoadedModels] = useState([]);
@@ -189,11 +194,15 @@ export default function Header({
         <WaveBars color={view.accent} active={modelStatus === 'ready' || modelStatus === 'loading'} />
         {sysStats && (
           <div className="hq-stats">
-            <span><b className="hq-stats__key">RAM</b> {sysStats.ram.toFixed(1)}/{sysStats.total_ram.toFixed(0)}G</span>
-            <span><b className="hq-stats__key">CPU</b> {sysStats.cpu.toFixed(0)}%</span>
-            <span className="hq-stats__sep" aria-label={`VRAM usage: ${sysStats.vram.toFixed(1)} gigabytes`}>
-              <b className={`hq-stats__key ${sysStats.gpu_active ? 'hq-stats__key--gpu-active' : ''}`}>VRAM</b> {sysStats.vram.toFixed(1)}G
-            </span>
+            {showLiveStats && (
+              <>
+                <span><b className="hq-stats__key">RAM</b> {sysStats.ram.toFixed(1)}/{sysStats.total_ram.toFixed(0)}G</span>
+                <span><b className="hq-stats__key">CPU</b> {sysStats.cpu.toFixed(0)}%</span>
+                <span className="hq-stats__sep" aria-label={`VRAM usage: ${sysStats.vram.toFixed(1)} gigabytes`}>
+                  <b className={`hq-stats__key ${sysStats.gpu_active ? 'hq-stats__key--gpu-active' : ''}`}>VRAM</b> {sysStats.vram.toFixed(1)}G
+                </span>
+              </>
+            )}
             <span className="hq-stats__status-wrap">
               <Badge
                 tone={modelStatus === 'ready' ? 'success' : modelStatus === 'loading' ? 'warn' : 'neutral'}

--- a/frontend/src/components/settings/PerformancePanel.jsx
+++ b/frontend/src/components/settings/PerformancePanel.jsx
@@ -18,6 +18,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Cpu } from 'lucide-react';
 import { apiJson, apiFetch } from '../../api/client';
+import { useAppStore } from '../../store';
 import './PerformancePanel.css';
 
 export default function PerformancePanel() {
@@ -26,6 +27,11 @@ export default function PerformancePanel() {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
+
+  // Header live-metrics toggle (default OFF). Persisted via the Zustand
+  // app store so it survives reload without a separate API round-trip.
+  const showHeaderLiveStats = useAppStore(s => s.showHeaderLiveStats);
+  const setShowHeaderLiveStats = useAppStore(s => s.setShowHeaderLiveStats);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -111,6 +117,24 @@ export default function PerformancePanel() {
         model load on GPUs with &lt;16 GB VRAM. Enabling this sets{' '}
         <code>TORCH_COMPILE_DISABLE=1</code> on engine subprocesses, which
         falls back to eager mode. macOS and Linux are unaffected.
+      </p>
+
+      <label className="perfpanel__row" title="Show RAM / CPU / VRAM live counters in the top bar.">
+        <input
+          type="checkbox"
+          className="perfpanel__checkbox"
+          checked={showHeaderLiveStats}
+          onChange={(e) => setShowHeaderLiveStats(e.target.checked)}
+          data-testid="header-live-stats-toggle"
+        />
+        <span className="perfpanel__label">Show live system metrics in header</span>
+      </label>
+
+      <p className="perfpanel__help">
+        Default off — the header keeps the model-status badge and Flush
+        button always visible because they're action-relevant, but RAM /
+        CPU / VRAM counters are noise on the welcome screen. Turn this on
+        if you want a live resource monitor in the top bar.
       </p>
     </section>
   );

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -59,6 +59,7 @@ export const useAppStore = create<AppStore>()(
         burnSubs:                   s.burnSubs,
         glossaryVisible:            s.glossaryVisible,
         reviewMode:                 s.reviewMode,
+        showHeaderLiveStats:        s.showHeaderLiveStats,
         mode:                       s.mode,
         isSidebarCollapsed:         s.isSidebarCollapsed,
         isSidebarProjectsCollapsed: s.isSidebarProjectsCollapsed,

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -23,11 +23,21 @@ export interface PrefsSlice {
    */
   reviewMode: 'on' | 'off';
 
+  /**
+   * Show RAM/CPU/VRAM live counters in the header. Default OFF — the
+   * "Make voices that sound like you" landing screen shouldn't double as a
+   * resource monitor. Power users can flip this on via Settings →
+   * Performance. The Idle/Ready/Loading status badge + Flush button stay
+   * visible regardless because they're action-relevant.
+   */
+  showHeaderLiveStats: boolean;
+
   setTranslateQuality: (q: TranslateQuality) => void;
   setDualSubs: (on: boolean) => void;
   setBurnSubs: (on: boolean) => void;
   setGlossaryVisible: (on: boolean) => void;
   setReviewMode: (mode: 'on' | 'off') => void;
+  setShowHeaderLiveStats: (on: boolean) => void;
 
   theme: ThemeId;
   setTheme: (id: ThemeId) => void;
@@ -39,12 +49,14 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   burnSubs: false,
   glossaryVisible: true,
   reviewMode: 'on',
+  showHeaderLiveStats: false,
 
-  setTranslateQuality: (q) => set({ translateQuality: q }),
-  setDualSubs:         (on) => set({ dualSubs: on }),
-  setBurnSubs:         (on) => set({ burnSubs: on }),
-  setGlossaryVisible:  (on) => set({ glossaryVisible: on }),
-  setReviewMode:       (mode) => set({ reviewMode: mode }),
+  setTranslateQuality:    (q) => set({ translateQuality: q }),
+  setDualSubs:            (on) => set({ dualSubs: on }),
+  setBurnSubs:            (on) => set({ burnSubs: on }),
+  setGlossaryVisible:     (on) => set({ glossaryVisible: on }),
+  setReviewMode:          (mode) => set({ reviewMode: mode }),
+  setShowHeaderLiveStats: (on) => set({ showHeaderLiveStats: on }),
 
   theme: 'gruvbox',
   setTheme: (id) => {


### PR DESCRIPTION
Continuation of the "calm chrome" pass started in #105. Removes the loudest piece of always-visible telemetry from the welcome screen.

## What was annoying

\`RAM 12.8/16G  CPU 25%  VRAM 3.2G  ●Idle  Flush\` lived in the header beside the OmniVoice brand. A user picking "Voice Clone" doesn't need a resource monitor. Telemetry chrome is the opposite of "a first-run that actually works."

## What's hidden vs kept

| Element | Default visible? | Why |
|---|---|---|
| \`RAM 12.8/16G\` | **Hidden** | Pure observational |
| \`CPU 25%\` | **Hidden** | Pure observational |
| \`VRAM 3.2G\` | **Hidden** | Pure observational |
| \`●Idle\` / \`Loading…\` / \`Ready\` status badge | **Visible** | Action-relevant — user needs to know when model is loading |
| \`Flush\` dropdown | **Visible** | Action — quick access to memory management |

## How to enable

Settings → Performance → "Show live system metrics in header"

Persists via the Zustand store (same path as the existing torch.compile toggle, so the "Performance" panel clusters all perf controls).

## Test plan
- [x] \`bun run typecheck:ci\` clean
- [ ] Launch app → header shows just \`OmniVoice\` brand + bell + wave + status + Flush — no numeric counters
- [ ] Settings → Performance → toggle ON → counters appear
- [ ] Reload → setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Show live system metrics in header" toggle in the Performance settings panel, allowing users to control the display of real-time RAM, CPU, and VRAM statistics in the application header.
  * The visibility preference is automatically saved and persists across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->