### PR TITLE
fix(ui): gate A/B Compare on having ≥2 profiles to actually compare

### DIFF
--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -111,13 +111,19 @@ export default function Launchpad({
               Built for creators who care how it sounds.
             </p>
           </div>
-          <button
-            onClick={() => setIsCompareModalOpen(true)}
-            className="lp-ab-compare"
-            title="Try two voices side by side"
-          >
-            <Scale size={12} /> {t('launchpad.ab_compare')}
-          </button>
+          {/* A/B Compare is a side-by-side voice diff — only useful when the
+              user has at least two profiles to actually compare. On a fresh
+              install (or for first-time users) the button is just chrome
+              noise that opens an empty modal, so we gate it. */}
+          {profiles.length >= 2 && (
+            <button
+              onClick={() => setIsCompareModalOpen(true)}
+              className="lp-ab-compare"
+              title="Try two voices side by side"
+            >
+              <Scale size={12} /> {t('launchpad.ab_compare')}
+            </button>
+          )}
         </div>
 
       </div>


### PR DESCRIPTION
The "A/B Compare" button rendered in the Launchpad chrome regardless of state — even on a fresh install with zero or one profile, clicking it opens an empty CompareModal.

Gates the render on \`profiles.length >= 2\`. The button appears only when A/B comparison is meaningfully available; until then it's hidden and the header stays clean for the "Make voices that sound like you" hero.

Part of the "calm chrome" pass (#105, #106, this one).

## Test plan
- [x] \`bun run typecheck:ci\` clean
- [ ] Fresh install (0 profiles) → button absent
- [ ] One profile saved → button still absent
- [ ] Two+ profiles → button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The A/B Compare button in the Launchpad now conditionally displays only when there are sufficient profiles (minimum 2) available for comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->