### PR TITLE
fix(ui): move UI scale + theme picker from footer to Settings → Appearance

### DIFF
--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -7,8 +7,6 @@ import toast from 'react-hot-toast';
 import { clearSystemLogs, clearTauriLogs } from '../api/system';
 import { useSystemLogs, useTauriLogs, useClearLogs, useClearTauriLogs } from '../api/hooks';
 import { getFrontendLogs, clearFrontendLogs } from '../utils/consoleBuffer';
-import { Segmented } from '../ui';
-import { useAppStore } from '../store';
 import './LogsFooter.css';
 
 /**
@@ -67,57 +65,11 @@ function SeverityIcon({ level, size = 11 }) {
   return <Info size={size} color="#7c6f64" />;
 }
 
-function UiScaleToggle() {
-  // Sources the zoom factor directly from the store so no prop-drilling
-  // is required. Same three values the Header previously exposed; moved
-  // here so app-wide chrome lives in one place.
-  const uiScale    = useAppStore(s => s.uiScale);
-  const setUiScale = useAppStore(s => s.setUiScale);
-  return (
-    <Segmented
-      className="logs-footer__scale"
-      size="xs"
-      value={uiScale}
-      onChange={setUiScale}
-      items={[
-        { value: 1,   label: 'S', title: 'Small UI scale'  },
-        { value: 1.3, label: 'M', title: 'Medium UI scale' },
-        { value: 1.5, label: 'L', title: 'Large UI scale'  },
-      ]}
-    />
-  );
-}
-
-const THEMES = [
-  { id: 'gruvbox',    label: 'Gruvbox',    dot: '#d3869b' },
-  { id: 'midnight',   label: 'Midnight',   dot: '#8b5cf6' },
-  { id: 'nord',       label: 'Nord',       dot: '#88c0d0' },
-  { id: 'solarized',  label: 'Solarized',  dot: '#268bd2' },
-  { id: 'rose-pine',  label: 'Rosé Pine',  dot: '#ebbcba' },
-  { id: 'catppuccin', label: 'Catppuccin', dot: '#cba6f7' },
-];
-
-function ThemePicker() {
-  const theme    = useAppStore(s => s.theme);
-  const setTheme = useAppStore(s => s.setTheme);
-  return (
-    <div className="logs-footer__themes" role="radiogroup" aria-label="Color theme">
-      {THEMES.map(t => (
-        <button
-          key={t.id}
-          type="button"
-          className={`logs-footer__theme-dot ${theme === t.id ? 'is-active' : ''}`}
-          style={{ '--dot-color': t.dot }}
-          onClick={() => setTheme(t.id)}
-          title={t.label}
-          aria-label={`${t.label} theme`}
-          aria-checked={theme === t.id}
-          role="radio"
-        />
-      ))}
-    </div>
-  );
-}
+// UiScaleToggle and ThemePicker used to live here as always-visible
+// controls in the footer chrome. Moved to Settings → Appearance (see
+// AppearancePanel) so the footer can stay focused on logs. The store
+// fields (uiScale, theme, setUiScale, setTheme) are unchanged; only the
+// rendering moved.
 
 function SourcePill({ source, counts, active, onClick }) {
   const hasErrors = counts.error > 0;
@@ -389,10 +341,9 @@ export default function LogsFooter() {
 
       <div className="logs-footer__bar">
         <div className="logs-footer__left">
-          <UiScaleToggle />
-          <span className="logs-footer__divider" />
-          <ThemePicker />
-          <span className="logs-footer__divider" />
+          {/* UI scale + theme picker moved to Settings → Appearance.
+              Footer is logs-focused now; rarely-used display prefs don't
+              belong in always-visible chrome. */}
           <button
             type="button"
             className="logs-footer__toggle"

--- a/frontend/src/components/settings/AppearancePanel.css
+++ b/frontend/src/components/settings/AppearancePanel.css
@@ -1,0 +1,71 @@
+/* Settings → Appearance panel.
+   Mirrors the layout of PerformancePanel (Wave 2 INST-12) so all the
+   per-section Settings sub-panels read consistently. */
+
+.appearance-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.appearance-panel__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 0.02em;
+}
+
+.appearance-panel__row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.appearance-panel__label {
+  min-width: 100px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.appearance-panel__themes {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.appearance-panel__theme-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  background: var(--dot-color, #888);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.appearance-panel__theme-dot:hover {
+  transform: scale(1.1);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.appearance-panel__theme-dot.is-active {
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+}
+
+.appearance-panel__help {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.5);
+}

--- a/frontend/src/components/settings/AppearancePanel.jsx
+++ b/frontend/src/components/settings/AppearancePanel.jsx
@@ -1,0 +1,76 @@
+/**
+ * Settings → Appearance panel.
+ *
+ * Houses the UI scale (S/M/L) and color-theme picker that used to live in
+ * the always-visible LogsFooter chrome. Moved here because they're
+ * rarely-used preferences that don't need to compete with logs / error
+ * counts on every screen — Settings is where appearance config belongs.
+ */
+import React from 'react';
+import { Palette } from 'lucide-react';
+import { Segmented } from '../../ui';
+import { useAppStore } from '../../store';
+import './AppearancePanel.css';
+
+const THEMES = [
+  { id: 'gruvbox',    label: 'Gruvbox',    dot: '#d3869b' },
+  { id: 'midnight',   label: 'Midnight',   dot: '#8b5cf6' },
+  { id: 'nord',       label: 'Nord',       dot: '#88c0d0' },
+  { id: 'solarized',  label: 'Solarized',  dot: '#268bd2' },
+  { id: 'rose-pine',  label: 'Rosé Pine',  dot: '#ebbcba' },
+  { id: 'catppuccin', label: 'Catppuccin', dot: '#cba6f7' },
+];
+
+export default function AppearancePanel() {
+  const uiScale    = useAppStore(s => s.uiScale);
+  const setUiScale = useAppStore(s => s.setUiScale);
+  const theme      = useAppStore(s => s.theme);
+  const setTheme   = useAppStore(s => s.setTheme);
+
+  return (
+    <section className="appearance-panel" aria-labelledby="appearance-panel-heading">
+      <h3 id="appearance-panel-heading" className="appearance-panel__title">
+        <Palette size={14} /> Appearance
+      </h3>
+
+      <div className="appearance-panel__row">
+        <span className="appearance-panel__label">UI scale</span>
+        <Segmented
+          size="xs"
+          value={uiScale}
+          onChange={setUiScale}
+          items={[
+            { value: 1,   label: 'S', title: 'Small UI scale'  },
+            { value: 1.3, label: 'M', title: 'Medium UI scale' },
+            { value: 1.5, label: 'L', title: 'Large UI scale'  },
+          ]}
+        />
+      </div>
+
+      <div className="appearance-panel__row">
+        <span className="appearance-panel__label">Color theme</span>
+        <div className="appearance-panel__themes" role="radiogroup" aria-label="Color theme">
+          {THEMES.map(t => (
+            <button
+              key={t.id}
+              type="button"
+              className={`appearance-panel__theme-dot ${theme === t.id ? 'is-active' : ''}`}
+              style={{ '--dot-color': t.dot }}
+              onClick={() => setTheme(t.id)}
+              title={t.label}
+              aria-label={`${t.label} theme`}
+              aria-checked={theme === t.id}
+              role="radio"
+            />
+          ))}
+        </div>
+      </div>
+
+      <p className="appearance-panel__help">
+        These controls used to live in the bottom logs bar — moved here so
+        the footer can stay focused on logs. Changes apply instantly and
+        persist across launches.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -24,6 +24,7 @@ import { Tabs, Segmented, Button, Badge, Panel, Table, Progress } from '../ui';
 import { useAppStore } from '../store';
 import ApiKeysPanel from '../components/settings/ApiKeysPanel';
 import PerformancePanel from '../components/settings/PerformancePanel';
+import AppearancePanel from '../components/settings/AppearancePanel';
 import EngineCompatibilityMatrix from '../components/EngineCompatibilityMatrix';
 import './Settings.css';
 
@@ -1417,6 +1418,10 @@ function CredentialsTab({ info }) {
           (#65). Toggle is rendered disabled on macOS/Linux with an
           explainer; backend ignores the flag on non-Windows. */}
       <PerformancePanel />
+
+      {/* UI scale + color theme — moved out of the LogsFooter chrome so
+          the footer can focus on logs. Rarely-used prefs belong here. */}
+      <AppearancePanel />
 
       <p className="settings-prose">
         Other API keys and tokens are set <strong>for this session only</strong>.


### PR DESCRIPTION
Final piece of the "calm chrome" pass (#105, #106, #107, this one).

## What moved

The LogsFooter bar carried two always-visible appearance controls in its left edge:
- \`S M L\` UI-scale toggle
- 6 color theme dots (Gruvbox / Midnight / Nord / Solarized / Rosé Pine / Catppuccin)

Both belong in Settings — rarely-used display preferences shouldn't live in always-visible chrome competing with logs / error counts. Moved into a new \`AppearancePanel\` rendered as a Settings section, alongside the existing \`ApiKeysPanel\` and \`PerformancePanel\`.

## State preservation

Store fields (\`uiScale\`, \`theme\`, \`setUiScale\`, \`setTheme\`) are unchanged. They still persist via the same Zustand persist whitelist; only the rendering location moved. Users who toggled to L-scale or Catppuccin keep their prefs across the move.

## User-visible effect

Footer left edge now starts with the collapse chevron + "Logs" title + source pills. No S/M/L. No color dots. A user who wants to change either opens Settings.

## Files

- **New:** \`frontend/src/components/settings/AppearancePanel.{jsx,css}\`
- **Modified:** \`Settings.jsx\` — wires the panel in
- **Modified:** \`LogsFooter.jsx\` — drops the inline \`UiScaleToggle\` / \`ThemePicker\` components + their renders + imports

## Test plan
- [x] \`bun run typecheck:ci\` clean
- [ ] Launch app → footer left edge has only \`▲ Logs ⌬ Backend  Frontend  Tauri\` — no S/M/L, no color dots
- [ ] Open Settings → see new "Appearance" section with both controls
- [ ] Click L → instant scale change → reload → still L (state preserved)
- [ ] Click Catppuccin dot → instant theme change → reload → still Catppuccin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appearance settings panel introduced in Settings, centralizing UI scale controls (Small/Medium/Large) and theme color selection with instant application. Consolidates appearance customization options into dedicated interface for improved navigation and streamlined logs footer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->