### PR TITLE
fix: personality preset crash in Design tab (closes #89)

### DIFF
--- a/backend/core/personalities.py
+++ b/backend/core/personalities.py
@@ -1,45 +1,77 @@
 """Built-in voice personality presets.
 
-Each personality is a named set of TTS parameters (instruct text, style
-hints) that users can pick from a strip in Voice Design.  The instruct
-string is treated as a starting point — users can edit it after applying.
+Each personality is a named bundle of TTS-instruct taxonomy tokens (gender,
+age, pitch, accent, dialect, style — see ``omnivoice.utils.voice_design``)
+that users can pick from a strip in the Voice Design tab.
+
+Why taxonomy tokens and not prose
+=================================
+OmniVoice's ``model.generate(instruct=...)`` runs every instruct string
+through ``_resolve_instruct``, which splits on commas and validates each
+item against a fixed vocabulary (e.g. ``male``, ``middle-aged``,
+``moderate pitch``, ``british accent``). Anything outside that vocabulary
+raises ``ValueError`` and surfaces to the user as a generation failure.
+
+Earlier versions of this file shipped prose like
+``"Speak clearly and professionally like a television news presenter"``
+which always failed the validator — clicking *any* personality button in
+the Design tab made the next Synthesize call crash (issue #89). Each
+personality below maps to a comma-separated list of valid taxonomy
+tokens so the picked instruct string is accepted by the model.
+
+The ``description`` field is the human-readable explanation kept for
+parity with the old field and for any future UI tooltips; the frontend
+today only renders ``name`` and ``icon``. ``instruct`` is what flows into
+``setInstruct`` on click.
 """
 
 PERSONALITIES = [
     {
         "id": "narrator",
         "name": "Narrator",
-        "instruct": "Speak as a calm, authoritative documentary narrator with measured pacing",
+        # Calm documentary-narrator vibe: settled adult, mid-low pitch.
+        "instruct": "middle-aged, low pitch",
+        "description": "Calm, authoritative documentary narrator with measured pacing",
         "icon": "📖",
     },
     {
         "id": "casual",
         "name": "Casual",
-        "instruct": "Speak in a relaxed, conversational tone like talking to a friend",
+        # Relaxed, conversational — younger speaker, neutral pitch.
+        "instruct": "young adult, moderate pitch",
+        "description": "Relaxed, conversational tone like talking to a friend",
         "icon": "😊",
     },
     {
         "id": "news_anchor",
         "name": "News Anchor",
-        "instruct": "Speak clearly and professionally like a television news presenter",
+        # Clear, professional broadcaster — adult voice with US accent.
+        "instruct": "middle-aged, moderate pitch, american accent",
+        "description": "Clear, professional television news presenter",
         "icon": "📺",
     },
     {
         "id": "storyteller",
         "name": "Storyteller",
-        "instruct": "Speak with dramatic flair and engaging pacing like reading a bedtime story",
+        # Dramatic bedtime-story flair — British accent reads well here.
+        "instruct": "middle-aged, moderate pitch, british accent",
+        "description": "Dramatic flair and engaging pacing like reading a bedtime story",
         "icon": "🧙",
     },
     {
         "id": "corporate",
         "name": "Corporate",
-        "instruct": "Speak in a polished, professional tone suitable for business presentations",
+        # Polished business-presentation register.
+        "instruct": "middle-aged, moderate pitch",
+        "description": "Polished, professional tone suitable for business presentations",
         "icon": "💼",
     },
     {
         "id": "energetic",
         "name": "Energetic",
-        "instruct": "Speak with high energy and enthusiasm like a podcast host",
+        # High-energy podcast host — younger speaker, higher pitch.
+        "instruct": "young adult, high pitch",
+        "description": "High energy and enthusiasm like a podcast host",
         "icon": "⚡",
     },
 ]

--- a/tests/backend/core/test_personalities.py
+++ b/tests/backend/core/test_personalities.py
@@ -1,0 +1,108 @@
+"""Regression test for issue #89.
+
+Bug: clicking any personality button in the Design tab made the next
+Synthesize call crash with a 400 ValueError. Root cause: the personality
+``instruct`` strings shipped as prose ("Speak clearly and professionally
+like a television news presenter") instead of the comma-separated
+taxonomy tokens OmniVoice's ``_resolve_instruct`` accepts.
+
+This test guards the personalities registry so we never regress: every
+personality's ``instruct`` must pass the validator the same model code
+path runs at synthesis time.
+
+If you add a new personality, ``instruct`` must be a comma-separated
+string of tokens drawn from ``omnivoice.utils.voice_design._INSTRUCT_ALL_VALID``
+(see ``backend/core/personalities.py`` for the full taxonomy list).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# Import directly from core — no torch / model load needed for this check.
+# tests/conftest.py prepends ``backend/`` to ``sys.path`` (the same way the
+# uvicorn launcher does with ``--app-dir backend``), so ``core`` resolves
+# to ``backend/core``.
+from core.personalities import get_personalities, get_personality
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _import_resolver():
+    """Import the same ``_resolve_instruct`` the runtime calls.
+
+    Lives in ``omnivoice.models.omnivoice`` (the upstream model module),
+    which transitively pulls torch. We skip the test if torch isn't
+    available in the current environment — the test still runs on dev
+    machines and in CI where torch is part of the test extras.
+    """
+    pytest.importorskip("torch")
+    pytest.importorskip("omnivoice")
+    from omnivoice.models.omnivoice import _resolve_instruct  # type: ignore[import-not-found]
+
+    return _resolve_instruct
+
+
+# ── Schema sanity ──────────────────────────────────────────────────────────
+
+
+def test_personality_registry_shape():
+    personalities = get_personalities()
+    assert isinstance(personalities, list) and personalities, (
+        "Design tab needs at least one personality to render the strip"
+    )
+    seen_ids: set[str] = set()
+    for p in personalities:
+        # Every personality must expose these fields — the frontend reads
+        # them by name in ``CloneDesignTab.jsx``.
+        for key in ("id", "name", "instruct", "icon"):
+            assert key in p, f"personality {p.get('name')!r} missing {key!r}"
+            assert isinstance(p[key], str), (
+                f"personality {p.get('name')!r} field {key!r} must be a string"
+            )
+        assert p["id"] not in seen_ids, f"duplicate personality id {p['id']!r}"
+        seen_ids.add(p["id"])
+
+
+def test_get_personality_lookup():
+    p = get_personality("narrator")
+    assert p is not None and p["id"] == "narrator"
+    assert get_personality("does_not_exist") is None
+
+
+# ── Issue #89 regression ───────────────────────────────────────────────────
+
+
+def test_every_personality_instruct_is_accepted_by_resolve_instruct():
+    """The exact failing path from issue #89.
+
+    Clicking a personality button sets ``instruct = p.instruct`` on the
+    frontend. The Design tab's Synthesize call sends that string as the
+    ``instruct`` form field, the router forwards it to
+    ``model.generate(instruct=...)``, and the model runs
+    ``_resolve_instruct`` first thing. If any token is rejected, the
+    whole synthesis call raises ``ValueError`` (HTTP 400 to the UI).
+
+    Guarantee: every shipped personality must round-trip through
+    ``_resolve_instruct`` without raising.
+    """
+    resolve_instruct = _import_resolver()
+    for p in get_personalities():
+        try:
+            normalised = resolve_instruct(p["instruct"])
+        except ValueError as exc:
+            pytest.fail(
+                f"Personality {p['id']!r} instruct {p['instruct']!r} was "
+                f"rejected by OmniVoice — this is the exact #89 crash. "
+                f"Fix: replace prose with comma-separated taxonomy tokens "
+                f"from omnivoice.utils.voice_design._INSTRUCT_ALL_VALID. "
+                f"Underlying error: {exc}"
+            )
+        # The normaliser returns either None (for empty) or a non-empty
+        # string. We don't want any personality to silently collapse to
+        # None — that would mean the picked instruct had no effect.
+        assert normalised, (
+            f"Personality {p['id']!r} instruct {p['instruct']!r} normalised "
+            "to nothing — pick at least one taxonomy token."
+        )


### PR DESCRIPTION
## Summary

Selecting any personality preset on the Design tab (e.g. **News Anchor**) made the next *Synthesize Audio* call crash with HTTP 400 from the generate router — the user had to restart the app to recover. Affects all 6 shipped personalities.

This PR ships a minimal data fix to `backend/core/personalities.py` plus a regression test that pins the failing path.

## Reproduction steps (per issue #89)

1. Open the Design tab.
2. Click any personality button — try **News Anchor**.
3. Click **Synthesize Audio**.
4. Observe error toast / generation failure.

Confirmed all 6 prose personality strings raise `ValueError` against the same code path the runtime uses:

```
narrator     -> ValueError (#89)
casual       -> ValueError (#89)
news_anchor  -> ValueError (#89)
storyteller  -> ValueError (#89)
corporate    -> ValueError (#89)
energetic    -> ValueError (#89)
6/6 old personalities crash the model
```

## Root cause

`backend/core/personalities.py` shipped human-readable prose as each personality's `instruct` value, e.g.

> ``"Speak clearly and professionally like a television news presenter"``

OmniVoice's `model.generate(instruct=...)` runs every instruct string through `_resolve_instruct` (`omnivoice/models/omnivoice.py:1351`), which splits on commas and validates each item against a fixed taxonomy defined in `omnivoice/utils/voice_design.py` (gender, age, pitch, accent, dialect, ``whisper``). Prose like *"Speak clearly…"* has zero tokens in that vocabulary, so the model raises:

```
ValueError: Unsupported instruct items found in
Speak clearly and professionally like a television news presenter:
  'Speak clearly and professionally like a television news presenter'
  -> ... (unsupported)
```

The frontend (`CloneDesignTab.jsx` → `applyPersonality`) writes the preset's `instruct` straight into the synth form (`useTTS.js` line 108–110 joins it with the comma-separated `vdStates`), so every personality triggered the crash.

## Fix

Map each personality to a comma-separated bundle of **valid taxonomy tokens** that `_resolve_instruct` accepts. The original prose moves into a new `description` field so design intent isn't lost and future UI tooltips can use it. The frontend doesn't render `description` today (only `name` + `icon`), so this is purely additive.

| Personality | New `instruct` |
|-------------|----------------|
| narrator    | `middle-aged, low pitch` |
| casual      | `young adult, moderate pitch` |
| news_anchor | `middle-aged, moderate pitch, american accent` |
| storyteller | `middle-aged, moderate pitch, british accent` |
| corporate   | `middle-aged, moderate pitch` |
| energetic   | `young adult, high pitch` |

## Regression test

`tests/backend/core/test_personalities.py` runs every personality's `instruct` through the **exact same `_resolve_instruct` the runtime calls**. The test would have failed on all 6 personalities before this commit; after the fix it passes for all of them.

```
tests/backend/core/test_personalities.py::test_personality_registry_shape PASSED
tests/backend/core/test_personalities.py::test_get_personality_lookup PASSED
tests/backend/core/test_personalities.py::test_every_personality_instruct_is_accepted_by_resolve_instruct PASSED
```

Also confirmed the wider `tests/backend/core/` slice still passes (25 passed).

## Cross-platform / data compatibility

- **Cross-platform:** pure-Python data — identical on macOS, Windows, Linux. No platform-specific code.
- **Backward-compat:** `voice_profiles.instruct` column is untouched. No DB migration needed; existing `omnivoice_data/` works unchanged.
- **Engine compatibility:** no engine code touched. Existing IndexTTS / CosyVoice / etc. installs are unaffected.

## Test plan

- [x] Unit: `pytest tests/backend/core/test_personalities.py -v` (3/3 pass)
- [x] Regression: all 6 old prose strings provably fail; all 6 new taxonomy strings provably succeed against `_resolve_instruct`
- [x] No other backend core tests regress (`pytest tests/backend/core/` — 25/25 pass)
- [ ] Manual smoke (deferred to maintainer): click each personality in the Design tab, click Synthesize, expect audio playback instead of an error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced personality presets with description fields and restructured instruction parameters for clarity.

* **Tests**
  * Added comprehensive test suite to validate personality registry structure, data integrity, and voice synthesis compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->