### PR TITLE
fix(mcp): drop unsupported FastMCP kwargs (mcp SDK >= 1.10)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -48,8 +48,7 @@ def create_mcp_server():
     FastMCP = _ensure_mcp()
     mcp = FastMCP(
         "OmniVoice Studio",
-        version="0.3.0",
-        description=(
+        instructions=(
             "AI-agent interface for OmniVoice Studio — voice cloning, "
             "voice design, and video dubbing in 646 languages."
         ),


### PR DESCRIPTION
## Summary

`backend/mcp_server.py` passes `version=` and `description=` to `FastMCP()`, but neither kwarg exists on `mcp >= 1.10` — the protocol version is managed internally and `description` was renamed to `instructions`.

**Symptom on a fresh install** (`uv sync && pip install 'mcp[cli]'`):

```
TypeError: FastMCP.__init__() got an unexpected keyword argument 'version'
```

Three-line diff in `backend/mcp_server.py`:

```diff
     mcp = FastMCP(
         "OmniVoice Studio",
-        version="0.3.0",
-        description=(
+        instructions=(
             "AI-agent interface for OmniVoice Studio — voice cloning, "
             "voice design, and video dubbing in 646 languages."
         ),
```

## Test plan

- [x] `python -m backend.mcp_server` no longer raises `TypeError`
- [x] `FastMCP.list_tools()` returns the 5 expected tools (`generate_speech`, `list_voices`, `list_personalities`, `list_languages`, `check_health`)
- [x] End-to-end `generate_speech` returns base64 WAV — verified at 16 diffusion steps (4.2 s of audio, ~24 s server-side on Apple Silicon MPS)
- [x] `uv run pytest backend/ -x -q` — 45 passed

## What this is NOT

- Not adding `mcp[cli]` to `pyproject.toml`. Left as an opt-in install for users wiring the MCP server.
- Not touching `docs/mcp.json` — kept as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server configuration to use a unified instructions parameter for managing AI agent interface text, replacing the previous separate version and description fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->