### PR TITLE
fix(client): use window.location.hostname for remote/Docker deployments

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,7 +2,13 @@
 // In production Tauri builds, the webview talks to the sidecar on localhost.
 const viteEnv = import.meta.env ?? {};
 const _port = viteEnv.VITE_API_PORT || '3900';
-export const API = viteEnv.VITE_API_URL || `http://127.0.0.1:${_port}`;
+// In Tauri builds the backend is always on localhost; in Docker/remote deployments
+// use window.location.hostname so the browser can reach the server remotely.
+const _host =
+  typeof window !== 'undefined' && window.__TAURI__
+    ? '127.0.0.1'
+    : (typeof window !== 'undefined' ? window.location.hostname : '127.0.0.1');
+export const API = viteEnv.VITE_API_URL || `http://${_host}:${_port}`;
 
 export class ApiError extends Error {
   status?: number;


### PR DESCRIPTION
## Problem

When running OmniVoice Studio in Docker and accessing it from a remote machine (e.g. over Tailscale or LAN), the frontend fails entirely — every API call hits `ERR_CONNECTION_REFUSED` because the client is hardcoded to `127.0.0.1`.

This is tracked in #120.

## Root Cause

`frontend/src/api/client.ts` always builds the API base URL as:
```ts
`http://127.0.0.1:${_port}`
```

This works fine in Tauri desktop builds (where the backend sidecar runs locally), but breaks in any browser-based deployment where the server is on a different host.

## Fix

Detect the Tauri context via `window.__TAURI__` and use `127.0.0.1` only for native desktop builds. For all other cases (Docker, web server), use `window.location.hostname` so the frontend talks to whatever host it was loaded from.

```ts
const _host =
  typeof window !== 'undefined' && window.__TAURI__
    ? '127.0.0.1'
    : (typeof window !== 'undefined' ? window.location.hostname : '127.0.0.1');
export const API = viteEnv.VITE_API_URL || `http://${_host}:${_port}`;
```

- ✅ Tauri desktop: unchanged behaviour (`127.0.0.1`)
- ✅ Docker remote access: uses actual server hostname
- ✅ `VITE_API_URL` env override still takes priority

Fixes #120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API endpoint configuration to properly support remote and hosted deployments, allowing the application to reach the backend from different network locations based on deployment context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->