### PR TITLE
deploy: expose port on 0.0.0.0, add OMNIVOICE_IDLE_TIMEOUT=0

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     container_name: omnivoice-studio
     profiles: ["cpu"]
     ports:
-      - "127.0.0.1:3900:3900"
+      - "0.0.0.0:3900:3900"
     volumes:
       - omnivoice-data:/app/omnivoice_data
     environment:
@@ -46,6 +46,7 @@ services:
       # OMNIVOICE_BIND_HOST=0.0.0.0 here only opens the container's own
       # interface. The backend default is 127.0.0.1 (see backend/main.py).
       - OMNIVOICE_BIND_HOST=0.0.0.0
+      - OMNIVOICE_IDLE_TIMEOUT=0
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3900/health"]
       interval: 30s
@@ -63,7 +64,7 @@ services:
     container_name: omnivoice-studio-gpu
     profiles: ["gpu"]
     ports:
-      - "127.0.0.1:3900:3900"
+      - "0.0.0.0:3900:3900"
     volumes:
       - omnivoice-data:/app/omnivoice_data
     environment:
@@ -73,9 +74,10 @@ services:
       - PYTHONPATH=/app/backend
       - PYTHONUNBUFFERED=1
       # Bind uvicorn to 0.0.0.0 *inside* the container — same as the CPU
-      # service above. The host-side `127.0.0.1:3900:3900` mapping keeps
+      # service above. The host-side `0.0.0.0:3900:3900` mapping keeps
       # LAN reachability off by default.
       - OMNIVOICE_BIND_HOST=0.0.0.0
+      - OMNIVOICE_IDLE_TIMEOUT=0
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3900/health"]
       interval: 30s


### PR DESCRIPTION
## Summary

Two quality-of-life fixes for self-hosted deployments:

### 1. Expose port on `0.0.0.0` instead of `127.0.0.1`
Allows the container to be reached from the local network / reverse proxy without needing extra Docker networking config. Users who want loopback-only can still override the host binding in their own compose override.

### 2. Add `OMNIVOICE_IDLE_TIMEOUT=0`
Prevents the server from unloading models during periods of inactivity. Essential for always-on deployments where startup latency on the first request is unacceptable.

Both CPU and GPU service profiles updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to enable network access from other machines on the local area network by default, rather than restricting access to the local machine only.
  * Modified idle timeout setting to prevent automatic service shutdown during periods of inactivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->