### PR TITLE
fix(windows): HF cache disk-fallback for WinError 448 (plan-01, closes #117 #118)

### DIFF
--- a/backend/api/routers/setup/models.py
+++ b/backend/api/routers/setup/models.py
@@ -124,6 +124,65 @@ def hf_cache_dir() -> str:
     )
 
 
+def _repo_dir_name(repo_id: str) -> str:
+    """HF cache dir name for a repo: 'k2-fsa/OmniVoice' → 'models--k2-fsa--OmniVoice'."""
+    return "models--" + repo_id.replace("/", "--")
+
+
+def _is_cached_on_disk(repo_id: str) -> bool:
+    """Direct-filesystem fallback for is_cached when scan_cache_dir is unavailable.
+
+    On Windows scan_cache_dir() can raise WinError 448 ('untrusted mount point');
+    we then walk the canonical HF layout <cache>/models--<org>--<name>/snapshots/
+    <rev>/ and treat the repo as cached if any revision directory has files. This
+    stops a present model from being mistaken for missing and re-downloaded
+    (#117/#118).
+    """
+    snaps = os.path.join(hf_cache_dir(), _repo_dir_name(repo_id), "snapshots")
+    try:
+        if not os.path.isdir(snaps):
+            return False
+        for rev in os.listdir(snaps):
+            rev_dir = os.path.join(snaps, rev)
+            if os.path.isdir(rev_dir) and any(os.scandir(rev_dir)):
+                return True
+        return False
+    except OSError:
+        return False
+
+
+def _scan_cache_on_disk() -> dict[str, dict]:
+    """Direct-filesystem equivalent of scan_cache_dir(), for the WinError-448
+    fallback path. Returns {repo_id: {size_on_disk, last_accessed, nb_files}}."""
+    out: dict[str, dict] = {}
+    root = hf_cache_dir()
+    try:
+        names = os.listdir(root)
+    except OSError:
+        return out
+    for name in names:
+        if not name.startswith("models--"):
+            continue
+        repo_id = name[len("models--"):].replace("--", "/")
+        repo_root = os.path.join(root, name)
+        if not os.path.isdir(os.path.join(repo_root, "snapshots")):
+            continue
+        size = 0
+        nb = 0
+        for dirpath, _dirs, files in os.walk(repo_root):
+            for f in files:
+                try:
+                    size += os.path.getsize(os.path.join(dirpath, f))
+                    nb += 1
+                except OSError:
+                    # Skip files we can't stat (broken symlink, permission) —
+                    # the count is best-effort for the UI's "installed" badge.
+                    continue
+        if nb > 0:
+            out[repo_id] = {"size_on_disk": size, "last_accessed": None, "nb_files": nb}
+    return out
+
+
 def is_cached(repo_id: str) -> bool:
     """Best-effort check: does HF have this repo in its cache on disk?"""
     try:
@@ -134,8 +193,11 @@ def is_cached(repo_id: str) -> bool:
                 return True
         return False
     except Exception as e:
-        logger.debug("scan_cache_dir failed: %s", e)
-        return False
+        # scan_cache_dir can raise on Windows (WinError 448 'untrusted mount
+        # point'); fall back to a direct disk check so a cached model isn't
+        # mistaken for missing and re-downloaded in a loop (#117/#118).
+        logger.debug("scan_cache_dir failed (%s); using disk fallback", e)
+        return _is_cached_on_disk(repo_id)
 
 
 # ── Response Cache ─────────────────────────────────────────────────────────
@@ -187,7 +249,10 @@ def list_models():
                 "nb_files": entry.nb_files,
             }
     except Exception as e:
-        logger.warning("scan_cache_dir failed: %s", e)
+        # WinError-448 fallback (#117/#118): use a direct disk scan so installed
+        # models still show as installed instead of offering a re-download.
+        logger.warning("scan_cache_dir failed (%s); using disk fallback", e)
+        cached_by_repo = _scan_cache_on_disk()
 
     out = []
     for m in KNOWN_MODELS:
@@ -281,8 +346,10 @@ def recommendations():
         cached_ids = {
             entry.repo_id for entry in info.repos if entry.size_on_disk > 0
         }
-    except Exception:
-        pass
+    except Exception as e:
+        # WinError-448 fallback (#117/#118): recommend based on the disk scan.
+        logger.debug("scan_cache_dir failed (%s); using disk fallback", e)
+        cached_ids = set(_scan_cache_on_disk().keys())
 
     entries = []
     for rid in recommended_ids:

--- a/backend/api/routers/setup/models.py
+++ b/backend/api/routers/setup/models.py
@@ -129,57 +129,83 @@ def _repo_dir_name(repo_id: str) -> str:
     return "models--" + repo_id.replace("/", "--")
 
 
+def _hub_cache_roots() -> list[str]:
+    """Candidate roots that directly contain ``models--*`` dirs.
+
+    HF stores repos under ``$HF_HUB_CACHE`` (== ``$HF_HOME/hub`` by default). When
+    only ``HF_HOME`` (or the ``~/.cache/huggingface`` default) is known, the repos
+    live under the ``hub`` subdir — so we probe both ``<dir>`` (the
+    ``HF_HUB_CACHE``-is-set case, e.g. OmniVoice's Windows short cache) and
+    ``<dir>/hub`` (the ``HF_HOME``-only case). Without this the WinError-448
+    fallback would look one level too high and miss the cache (CodeRabbit #137).
+    """
+    base = hf_cache_dir()
+    roots = [base]
+    hub = os.path.join(base, "hub")
+    if hub not in roots:
+        roots.append(hub)
+    return roots
+
+
 def _is_cached_on_disk(repo_id: str) -> bool:
     """Direct-filesystem fallback for is_cached when scan_cache_dir is unavailable.
 
     On Windows scan_cache_dir() can raise WinError 448 ('untrusted mount point');
-    we then walk the canonical HF layout <cache>/models--<org>--<name>/snapshots/
+    we then walk the canonical HF layout <root>/models--<org>--<name>/snapshots/
     <rev>/ and treat the repo as cached if any revision directory has files. This
     stops a present model from being mistaken for missing and re-downloaded
     (#117/#118).
     """
-    snaps = os.path.join(hf_cache_dir(), _repo_dir_name(repo_id), "snapshots")
-    try:
-        if not os.path.isdir(snaps):
-            return False
-        for rev in os.listdir(snaps):
-            rev_dir = os.path.join(snaps, rev)
-            if os.path.isdir(rev_dir) and any(os.scandir(rev_dir)):
-                return True
-        return False
-    except OSError:
-        return False
+    name = _repo_dir_name(repo_id)
+    for root in _hub_cache_roots():
+        snaps = os.path.join(root, name, "snapshots")
+        try:
+            if not os.path.isdir(snaps):
+                continue
+            for rev in os.listdir(snaps):
+                rev_dir = os.path.join(snaps, rev)
+                if os.path.isdir(rev_dir):
+                    # `with` so the dir handle is closed even when any() short-
+                    # circuits — avoids handle leaks on repeated polls (Greptile).
+                    with os.scandir(rev_dir) as it:
+                        if any(it):
+                            return True
+        except OSError:
+            continue
+    return False
 
 
 def _scan_cache_on_disk() -> dict[str, dict]:
     """Direct-filesystem equivalent of scan_cache_dir(), for the WinError-448
     fallback path. Returns {repo_id: {size_on_disk, last_accessed, nb_files}}."""
     out: dict[str, dict] = {}
-    root = hf_cache_dir()
-    try:
-        names = os.listdir(root)
-    except OSError:
-        return out
-    for name in names:
-        if not name.startswith("models--"):
+    for root in _hub_cache_roots():
+        try:
+            names = os.listdir(root)
+        except OSError:
             continue
-        repo_id = name[len("models--"):].replace("--", "/")
-        repo_root = os.path.join(root, name)
-        if not os.path.isdir(os.path.join(repo_root, "snapshots")):
-            continue
-        size = 0
-        nb = 0
-        for dirpath, _dirs, files in os.walk(repo_root):
-            for f in files:
-                try:
-                    size += os.path.getsize(os.path.join(dirpath, f))
-                    nb += 1
-                except OSError:
-                    # Skip files we can't stat (broken symlink, permission) —
-                    # the count is best-effort for the UI's "installed" badge.
-                    continue
-        if nb > 0:
-            out[repo_id] = {"size_on_disk": size, "last_accessed": None, "nb_files": nb}
+        for name in names:
+            if not name.startswith("models--"):
+                continue
+            repo_id = name[len("models--"):].replace("--", "/")
+            if repo_id in out:
+                continue  # first root wins (HF_HUB_CACHE before the /hub probe)
+            repo_root = os.path.join(root, name)
+            if not os.path.isdir(os.path.join(repo_root, "snapshots")):
+                continue
+            size = 0
+            nb = 0
+            for dirpath, _dirs, files in os.walk(repo_root):
+                for f in files:
+                    try:
+                        size += os.path.getsize(os.path.join(dirpath, f))
+                        nb += 1
+                    except OSError:
+                        # Skip files we can't stat (broken symlink, permission) —
+                        # the count is best-effort for the UI's "installed" badge.
+                        continue
+            if nb > 0:
+                out[repo_id] = {"size_on_disk": size, "last_accessed": None, "nb_files": nb}
     return out
 
 

--- a/specs/002-windows-model-storage/plan.md
+++ b/specs/002-windows-model-storage/plan.md
@@ -1,0 +1,46 @@
+# Implementation Plan: Windows Model Storage & HF Cache (plan-01)
+
+**Branch**: `002-windows-model-storage` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Close the Windows `WinError 448` re-download loop (#117/#118). Much of plan-01's
+fix-sequence already ships (symlink-disable env in `main.py`,
+`local_dir_use_symlinks=False` in `setup/download.py`, `OMNIVOICE_CACHE_DIR` →
+`HF_HOME`/`HF_HUB_CACHE` override, `os.environ.copy()` subprocess forwarding).
+The unfixed defect is fix-sequence **step 2**: the three `scan_cache_dir()` call
+sites in `setup/models.py` swallow the WinError and report "not cached", so the
+app re-downloads. This PR makes them fall back to a direct filesystem scan.
+
+## Constitution Check
+
+| Principle | Status |
+|-----------|--------|
+| I. Local-First | ✅ no network/telemetry added |
+| II. First-Run Works | ✅ (implements) — removes the Windows first-run loop |
+| III. Cross-Platform Parity | ✅ fallback only triggers when scan_cache_dir raises (Windows); mac/Linux unchanged |
+| IV. Backward-Compatible | ✅ no schema/data change; honours existing cache env |
+| V. Root-Cause + Regression Tests | ✅ cluster master; ships fail-before/pass-after tests |
+
+## Change sites (`backend/api/routers/setup/models.py`)
+
+1. `_repo_dir_name(repo_id)` — `org/name` → `models--org--name`.
+2. `_is_cached_on_disk(repo_id)` — walks `<cache>/models--…/snapshots/<rev>/`,
+   cached iff a revision dir has files. The `is_cached()` fallback.
+3. `_scan_cache_on_disk()` — filesystem equivalent of `scan_cache_dir()` returning
+   `{repo_id: {size_on_disk, last_accessed, nb_files}}`. The `list_models()` /
+   `recommendations()` fallback.
+4. Wire the fallback into the `except` of `is_cached()`, `list_models()`,
+   `recommendations()`.
+
+## Out of scope (remaining cluster item)
+
+Configurable models directory UI (#64, fix-sequence step 3-4) — the env plumbing
+exists; a Settings field + persistence + startup read is the follow-up that
+closes #64 within the v0.3.0 line.
+
+## Tests
+
+`tests/test_hf_cache_fallback.py` — scan_cache_dir forced to raise: cached repo
+detected, uncached repo not, empty snapshot not counted, disk scan reports
+size/files. Fail-before/pass-after.

--- a/specs/002-windows-model-storage/spec.md
+++ b/specs/002-windows-model-storage/spec.md
@@ -1,0 +1,71 @@
+# Feature Specification: Windows Model Storage & HF Cache
+
+**Feature Branch**: `002-windows-model-storage` | **Created**: 2026-05-29
+**Status**: Draft | **Input**: plan-01 (#128); children #117, #118, #64
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Cached models are recognised on Windows (Priority: P1)
+
+A Windows user who already has models on disk (or just finished downloading)
+opens OmniVoice. Today, HuggingFace's `scan_cache_dir()` raises `WinError 448
+"untrusted mount point"` → the app concludes no models exist → re-downloads in a
+5× loop and gives up, leaving the app unusable (#117, #118). After this change,
+when `scan_cache_dir()` fails the app falls back to a direct filesystem check of
+the canonical HF cache layout, so present models are recognised and not
+re-downloaded.
+
+**Why this priority**: This is the crash/loop that makes the app unusable on
+Windows — the top first-run blocker. It delivers value on its own.
+
+**Independent Test**: Force `scan_cache_dir()` to raise; with a populated cache
+on disk, `is_cached()` / the models list still report the model installed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a populated HF cache and `scan_cache_dir()` raising `WinError 448`,
+   **When** the app checks model state, **Then** the cached model is reported
+   installed (no re-download offered).
+2. **Given** an empty/partial cache and `scan_cache_dir()` raising, **When**
+   checked, **Then** the model is correctly reported not-installed.
+3. **Given** macOS/Linux where `scan_cache_dir()` works, **When** checked,
+   **Then** behaviour is unchanged (no regression).
+
+### Edge Cases
+
+- A `models--…/snapshots/<rev>/` directory that exists but is **empty** (an
+  interrupted download) must NOT count as cached.
+- The cache directory itself being unreadable → report not-cached, never crash.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: When `scan_cache_dir()` raises, the system MUST fall back to a
+  direct filesystem scan of `<cache>/models--<org>--<name>/snapshots/<rev>/` to
+  determine whether a repo is cached.
+- **FR-002**: The model-list and recommendation endpoints MUST use the same
+  fallback so installed models render as installed during a `scan_cache_dir`
+  failure.
+- **FR-003**: A repo with no files under any snapshot revision MUST be reported
+  not-cached.
+- **FR-004**: Behaviour on platforms where `scan_cache_dir()` succeeds MUST be
+  unchanged.
+- **FR-005**: The cache directory resolution MUST honour `HF_HUB_CACHE` /
+  `HUGGINGFACE_HUB_CACHE` / `HF_HOME` (already implemented) so a relocated/
+  configurable models directory is respected by the fallback too.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: With `scan_cache_dir()` forced to raise, a populated repo is
+  detected as cached 100% of the time (regression-tested).
+- **SC-002**: 0 re-download loops triggered for an already-present model on the
+  WinError-448 path.
+- **SC-003**: No regression on macOS/Linux model detection.
+
+## Assumptions
+
+- Symlink-disable env (`HF_HUB_DISABLE_SYMLINKS=1`) and `local_dir_use_symlinks=
+  False` on Windows are already set (`main.py`, `setup/download.py`) — this spec
+  covers the remaining `scan_cache_dir` failure path (fix-sequence step 2).
+- The configurable models directory (#64, fix-sequence step 3-4) builds on the
+  existing `OMNIVOICE_CACHE_DIR` / `HF_HOME` plumbing and is tracked as the
+  remaining cluster item; this PR closes the crash children #117/#118.

--- a/specs/002-windows-model-storage/tasks.md
+++ b/specs/002-windows-model-storage/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Windows Model Storage & HF Cache (plan-01)
+
+**Branch**: `002-windows-model-storage` | Closes #117, #118 (crash). Addresses #128; #64 follow-up.
+**TDD**: tests written and confirmed RED before the fix.
+
+## Phase 1: Regression tests (RED)
+
+- [x] T001 `tests/test_hf_cache_fallback.py`: scan_cache_dir forced to raise →
+  (a) populated repo detected as cached, (b) uncached repo not, (c) empty
+  snapshot not counted, (d) disk scan reports size/files. Confirmed RED.
+
+## Phase 2: Disk fallback (GREEN)
+
+- [x] T002 `setup/models.py`: add `_repo_dir_name`, `_is_cached_on_disk`,
+  `_scan_cache_on_disk`.
+- [x] T003 Wire fallback into the `except` of `is_cached`, `list_models`,
+  `recommendations`. Tests GREEN (4/4).
+
+## Phase 3: Verify
+
+- [x] T004 No regression on the non-Windows path (fallback only on raise).
+- [ ] T005 Full backend suite green before PR.
+
+## Out of scope (tracked)
+
+- [ ] #64 configurable models directory: Settings field + persistence + startup
+  read on top of the existing `OMNIVOICE_CACHE_DIR`/`HF_HOME` plumbing.

--- a/tests/test_hf_cache_fallback.py
+++ b/tests/test_hf_cache_fallback.py
@@ -8,8 +8,6 @@ assert a direct-filesystem fallback still recognises a cached repo.
 """
 from __future__ import annotations
 
-import os
-
 from api.routers.setup import models
 
 
@@ -48,6 +46,23 @@ def test_disk_scan_reports_size_and_files(tmp_path, monkeypatch):
     assert repo in found
     assert found[repo]["nb_files"] >= 1
     assert found[repo]["size_on_disk"] >= 2048
+
+
+def test_hf_home_only_finds_repo_under_hub_subdir(tmp_path, monkeypatch):
+    # When only HF_HOME is set, HF stores repos under $HF_HOME/hub/models--…
+    # The fallback must probe the /hub subdir, not just the root (CodeRabbit #137).
+    repo_id = "k2-fsa/OmniVoice"
+    name = "models--" + repo_id.replace("/", "--")
+    snap = tmp_path / "hub" / name / "snapshots" / "rev1"
+    snap.mkdir(parents=True)
+    (snap / "model.bin").write_bytes(b"x" * 1024)
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    monkeypatch.setenv("HF_HOME", str(tmp_path))
+    monkeypatch.setattr("huggingface_hub.scan_cache_dir", _raise_winerror)
+    models.invalidate_cache()
+    assert models.is_cached(repo_id) is True
+    assert repo_id in models._scan_cache_on_disk()
 
 
 def test_empty_snapshot_dir_not_counted_as_cached(tmp_path, monkeypatch):

--- a/tests/test_hf_cache_fallback.py
+++ b/tests/test_hf_cache_fallback.py
@@ -1,0 +1,59 @@
+"""plan-01 (#128) — HF cache detection must survive scan_cache_dir failures.
+
+On Windows, huggingface_hub's ``scan_cache_dir()`` can raise
+``OSError WinError 448 'untrusted mount point'``. The old code caught that and
+returned "not cached", so the app re-downloaded models it already had — looping
+5× and giving up (#117/#118). These tests force ``scan_cache_dir`` to raise and
+assert a direct-filesystem fallback still recognises a cached repo.
+"""
+from __future__ import annotations
+
+import os
+
+from api.routers.setup import models
+
+
+def _make_fake_cache(tmp_path, repo_id="k2-fsa/OmniVoice"):
+    """Create the canonical HF cache layout for repo_id under tmp_path."""
+    name = "models--" + repo_id.replace("/", "--")
+    snap = tmp_path / name / "snapshots" / "abc123def456"
+    snap.mkdir(parents=True)
+    (snap / "model.bin").write_bytes(b"x" * 2048)
+    return repo_id
+
+
+def _raise_winerror(*a, **k):
+    raise OSError(22, "[WinError 448] The specified network resource is no longer available")
+
+
+def test_is_cached_falls_back_to_disk_when_scan_raises(tmp_path, monkeypatch):
+    repo = _make_fake_cache(tmp_path)
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setattr("huggingface_hub.scan_cache_dir", _raise_winerror)
+    models.invalidate_cache()
+    assert models.is_cached(repo) is True
+
+
+def test_is_cached_false_for_uncached_repo_when_scan_raises(tmp_path, monkeypatch):
+    _make_fake_cache(tmp_path)  # a different repo is present
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setattr("huggingface_hub.scan_cache_dir", _raise_winerror)
+    assert models.is_cached("not-here/model") is False
+
+
+def test_disk_scan_reports_size_and_files(tmp_path, monkeypatch):
+    repo = _make_fake_cache(tmp_path)
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    found = models._scan_cache_on_disk()
+    assert repo in found
+    assert found[repo]["nb_files"] >= 1
+    assert found[repo]["size_on_disk"] >= 2048
+
+
+def test_empty_snapshot_dir_not_counted_as_cached(tmp_path, monkeypatch):
+    # A repo dir with an empty snapshots/<rev>/ (interrupted download) is NOT cached.
+    name = "models--org--half"
+    (tmp_path / name / "snapshots" / "rev0").mkdir(parents=True)
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setattr("huggingface_hub.scan_cache_dir", _raise_winerror)
+    assert models.is_cached("org/half") is False


### PR DESCRIPTION
**plan-01 fix-sequence step 2** — Closes #117, #118. Addresses #128.

On Windows, `huggingface_hub.scan_cache_dir()` raises `WinError 448 "untrusted mount point"`. The three call sites in `setup/models.py` swallowed it and reported **"not cached"**, so the app re-downloaded models it already had — looping 5× and giving up, leaving the app unusable (#117/#118).

## Fix
A direct-filesystem fallback over the canonical HF layout `<cache>/models--<org>--<name>/snapshots/<rev>/`:
- `_is_cached_on_disk()` / `_scan_cache_on_disk()` — honour `HF_HUB_CACHE`/`HF_HOME`, so a relocated models dir works too
- `is_cached()` / `list_models()` / `recommendations()` fall back to it when `scan_cache_dir()` raises
- an **empty** snapshot dir (interrupted download) is correctly *not* counted

The symlink-disable env (`HF_HUB_DISABLE_SYMLINKS=1`) and `local_dir_use_symlinks=False` (steps 1) already shipped in `main.py`/`setup/download.py`; this closes the remaining failure path.

## Cross-platform parity
The fallback only triggers when `scan_cache_dir()` raises — macOS/Linux behaviour is unchanged.

## Tests (TDD, fail-before/pass-after — Constitution V)
`tests/test_hf_cache_fallback.py` (4): cached repo detected when scan raises, uncached not, empty snapshot not counted, disk scan reports size/files. Targeted regression set (model/cache/setup): 23 passed, 0 failed.

## Remaining cluster item
**#64** (configurable models directory) builds on the existing `OMNIVOICE_CACHE_DIR`/`HF_HOME` plumbing — a Settings field + startup read — tracked as the follow-up within the v0.3.0 line.

Spec/plan/tasks in `specs/002-windows-model-storage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model cache detection on Windows with a filesystem fallback to avoid unnecessary re-downloads when standard cache inspection fails.

* **Tests**
  * Added regression tests covering cached/uncached models, empty snapshot handling, and alternate cache-root scenarios.

* **Documentation**
  * Added spec, plan, and task docs describing the Windows cache-fallback behavior and verification plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->