### PR TITLE
fix(bootstrap): mirror cascade + system-Python fallback for blocked networks (plan-03, closes #60)

### DIFF
--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -132,3 +132,24 @@ engines per OmniVoice copy. See [docs/engines/cosyvoice.md](../engines/cosyvoice
 for the dedicated CosyVoice path.
 
 **Linked issue:** [#55](https://github.com/debpalash/OmniVoice-Studio/issues/55)
+
+## First-run setup fails on a restricted network (GitHub/PyPI blocked)
+
+On networks that block or can't resolve **GitHub**, the first-run bootstrap may
+fail to download the managed Python (`uv venv ... failed`, often a DNS error).
+OmniVoice now tries, in order: the default GitHub host → a gh-proxy mirror → your
+**system Python** (if 3.11+ is installed). If all three fail:
+
+1. **Install Python 3.11+** from <https://www.python.org/downloads/> (on Windows,
+   tick *"Add Python to PATH"*), then relaunch — OmniVoice will use it.
+2. **Point at a reachable mirror** for the Python download:
+   - `UV_PYTHON_INSTALL_MIRROR=https://gh-proxy.com/https://github.com/astral-sh/python-build-standalone/releases/download`
+3. **Point at a PyPI mirror** for the dependency install (`uv sync`):
+   - China: `UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple` (or `https://mirrors.aliyun.com/pypi/simple`)
+   - Fully-blocked networks (e.g. some regions): use a VPN — there is no
+     government-blessed PyPI mirror to rely on.
+4. The bootstrap already raises the network budget for you
+   (`UV_HTTP_TIMEOUT=120`, `UV_HTTP_CONNECT_TIMEOUT=30`, `UV_HTTP_RETRIES=5`);
+   you can raise them further in the environment if a mirror is very slow.
+
+**Linked issues:** [#130](https://github.com/debpalash/OmniVoice-Studio/issues/130), [#60](https://github.com/debpalash/OmniVoice-Studio/issues/60), [#57](https://github.com/debpalash/OmniVoice-Studio/issues/57)

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -492,9 +492,14 @@ pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress:
         ),
     ];
     if system_python_ge_311() {
+        // No `--python 3.11` pin here: that would force uv to find a 3.11.x
+        // interpreter exactly, so a machine with only 3.12/3.13 would fail the
+        // fallback despite being compatible (Greptile #140). `only-system` plus
+        // the project's `requires-python = ">=3.11"` lets uv resolve any
+        // compatible system interpreter.
         venv_attempts.push((
             "system-python",
-            vec!["venv", "--python", "3.11"],
+            vec!["venv"],
             vec![("UV_PYTHON_PREFERENCE", "only-system")],
         ));
     }

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -260,6 +260,61 @@ pub fn find_dev_project_root() -> Option<PathBuf> {
     None
 }
 
+// ── plan-03 (#130): restricted-network bootstrap resilience ────────────────
+
+/// gh-proxy mirror for python-build-standalone, used as a fallback when the
+/// default GitHub releases host is blocked/unresolvable (#60). Points
+/// UV_PYTHON_INSTALL_MIRROR at the releases-download base behind the proxy.
+const PY_INSTALL_MIRROR: &str =
+    "https://gh-proxy.com/https://github.com/astral-sh/python-build-standalone/releases/download";
+
+/// Shown when every managed-Python strategy AND the system-Python fallback fail
+/// — actionable remediation instead of a raw `uv` exit code (#130 step 5).
+const BOOTSTRAP_REMEDIATION: &str =
+    "First-run setup couldn't download Python — your network may be blocking GitHub. \
+Fix: install Python 3.11+ from https://www.python.org/downloads/ (tick \"Add to PATH\"), \
+then relaunch — OmniVoice will use your system Python. Advanced: set \
+UV_PYTHON_INSTALL_MIRROR to a reachable mirror (see docs/install/troubleshooting.md).";
+
+/// Longer timeouts + more retries so a slow/flaky mirror or PyPI doesn't kill
+/// the first-run install on its first hiccup (#130 step 2).
+fn apply_uv_http_env(cmd: &mut Command) {
+    cmd.env("UV_HTTP_TIMEOUT", "120")
+        .env("UV_HTTP_CONNECT_TIMEOUT", "30")
+        .env("UV_HTTP_RETRIES", "5");
+}
+
+/// Parse a `python --version` line ("Python 3.11.7") into (major, minor).
+fn parse_py_version(s: &str) -> Option<(u32, u32)> {
+    let rest = s.trim().strip_prefix("Python ")?;
+    let mut parts = rest.split('.');
+    let major: u32 = parts.next()?.trim().parse().ok()?;
+    let minor: u32 = parts.next()?.trim().parse().ok()?;
+    Some((major, minor))
+}
+
+/// True if a system Python >= 3.11 is on PATH — the prerequisite for the
+/// `UV_PYTHON_PREFERENCE=only-system` fallback when all download mirrors fail.
+fn system_python_ge_311() -> bool {
+    for exe in ["python3", "python"] {
+        if let Ok(out) = Command::new(exe).arg("--version").output() {
+            if out.status.success() {
+                let text = format!(
+                    "{}{}",
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr),
+                );
+                if let Some((maj, min)) = parse_py_version(&text) {
+                    if maj == 3 && min >= 11 {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Prepare (and on first run, create) the Python venv that will host the
 /// backend process. Returns (venv_python, backend_source_dir).
 pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Option<&Arc<Mutex<BootstrapStage>>>) -> Option<(PathBuf, PathBuf)> {
@@ -424,12 +479,44 @@ pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress:
     if let Some(p) = progress {
         set_stage(p, BootstrapStage::CreatingVenv);
     }
-    let mut venv_cmd = Command::new(&uv_path);
-    venv_cmd.env_remove("PYTHONHOME").env_remove("PYTHONPATH").env_remove("LD_LIBRARY_PATH");
-    venv_cmd.args(["venv", "--python", "3.11", "--managed-python"]).current_dir(&project_dir);
-    let status = run_streaming(app, "creating_venv", &mut venv_cmd);
-    if !matches!(status, Ok(ref s) if s.success()) {
-        fail(progress, &format!("uv venv failed: {:?}", status));
+    // plan-03 (#130): mirror cascade + system-Python fallback so first-run
+    // survives a GitHub-blocked network. Try in order: (1) default GitHub host,
+    // (2) gh-proxy mirror, (3) system Python (only if >= 3.11) — each with
+    // longer timeouts/retries. Stop at the first that succeeds.
+    let mut venv_attempts: Vec<(&str, Vec<&str>, Vec<(&str, &str)>)> = vec![
+        ("default", vec!["venv", "--python", "3.11", "--managed-python"], vec![]),
+        (
+            "gh-proxy mirror",
+            vec!["venv", "--python", "3.11", "--managed-python"],
+            vec![("UV_PYTHON_INSTALL_MIRROR", PY_INSTALL_MIRROR)],
+        ),
+    ];
+    if system_python_ge_311() {
+        venv_attempts.push((
+            "system-python",
+            vec!["venv", "--python", "3.11"],
+            vec![("UV_PYTHON_PREFERENCE", "only-system")],
+        ));
+    }
+
+    let mut venv_ok = false;
+    for (label, args, envs) in &venv_attempts {
+        let mut venv_cmd = Command::new(&uv_path);
+        venv_cmd.env_remove("PYTHONHOME").env_remove("PYTHONPATH").env_remove("LD_LIBRARY_PATH");
+        apply_uv_http_env(&mut venv_cmd);
+        for &(k, v) in envs {
+            venv_cmd.env(k, v);
+        }
+        venv_cmd.args(args.iter()).current_dir(&project_dir);
+        log::info!("uv venv attempt ({})", label);
+        if matches!(run_streaming(app, "creating_venv", &mut venv_cmd), Ok(ref s) if s.success()) {
+            venv_ok = true;
+            break;
+        }
+        log::warn!("uv venv attempt ({}) failed; trying next strategy", label);
+    }
+    if !venv_ok {
+        fail(progress, BOOTSTRAP_REMEDIATION);
         return None;
     }
 
@@ -438,6 +525,7 @@ pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress:
     }
     let mut sync_cmd = Command::new(&uv_path);
     sync_cmd.env_remove("PYTHONHOME").env_remove("PYTHONPATH").env_remove("LD_LIBRARY_PATH");
+    apply_uv_http_env(&mut sync_cmd);
     let has_lockfile = project_dir.join("uv.lock").is_file();
     if has_lockfile {
         sync_cmd
@@ -455,9 +543,46 @@ pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress:
     }
     let sync_status = run_streaming(app, "installing_deps", &mut sync_cmd);
     if !matches!(sync_status, Ok(ref s) if s.success()) {
-        fail(progress, &format!("uv sync failed: {:?}", sync_status));
+        fail(
+            progress,
+            "Dependency install (uv sync) failed — often a network drop or a \
+partial cache. \"Clean & Retry\" rebuilds the environment from scratch. If your \
+network blocks PyPI, set UV_DEFAULT_INDEX to a mirror (see \
+docs/install/troubleshooting.md).",
+        );
         return None;
     }
 
     Some((venv_py, backend_dir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn parse_py_version_handles_real_and_garbage() {
+        assert_eq!(parse_py_version("Python 3.11.7"), Some((3, 11)));
+        assert_eq!(parse_py_version("Python 3.11"), Some((3, 11)));
+        assert_eq!(parse_py_version("Python 3.12.2\n"), Some((3, 12)));
+        assert_eq!(parse_py_version("Python 3.10.6"), Some((3, 10)));
+        assert_eq!(parse_py_version("garbage"), None);
+        assert_eq!(parse_py_version(""), None);
+    }
+
+    #[test]
+    fn apply_uv_http_env_sets_timeouts_and_retries() {
+        let mut cmd = Command::new("uv");
+        apply_uv_http_env(&mut cmd);
+        let envs: HashMap<String, String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                v.map(|v| (k.to_string_lossy().into_owned(), v.to_string_lossy().into_owned()))
+            })
+            .collect();
+        assert_eq!(envs.get("UV_HTTP_TIMEOUT").map(String::as_str), Some("120"));
+        assert_eq!(envs.get("UV_HTTP_CONNECT_TIMEOUT").map(String::as_str), Some("30"));
+        assert_eq!(envs.get("UV_HTTP_RETRIES").map(String::as_str), Some("5"));
+    }
 }

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -45,6 +45,7 @@ function detectHints(message, logs) {
   if (/ffmpeg/i.test(all) && /download|timeout/i.test(all)) hints.push('ffmpeg download failed. This is non-fatal — retry or install ffmpeg manually.');
   if (/port.*in use|address.*in use/i.test(all)) hints.push('Port 3900 is already in use. Close other instances of OmniVoice or apps using that port.');
   if (/no error output/i.test(all))      hints.push('Backend crashed silently. "Clean & Retry" often fixes corrupt venv issues.');
+  if (/blocking GitHub|couldn't download Python|python-build-standalone|dns error/i.test(all)) hints.push('Your network may block GitHub. Install Python 3.11+ from python.org (Add to PATH) and relaunch, or set UV_PYTHON_INSTALL_MIRROR — see docs/install/troubleshooting.md.');
   if (hints.length === 0)                hints.push('Try "Retry" first. If it fails again, "Clean & Retry" will rebuild the environment from scratch.');
   return hints;
 }

--- a/specs/004-installer-network-resilience/plan.md
+++ b/specs/004-installer-network-resilience/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan: Installer Bootstrap Network Resilience (plan-03)
+
+**Branch**: `004-installer-network-resilience` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Make first-run survive a GitHub-blocked network. The bootstrap is **Rust**
+(`frontend/src-tauri/src/bootstrap.rs` spawns `uv venv`/`uv sync`; `tools.rs`
+installs uv). Add an env-var cascade (mirror + timeouts/retries) on those
+commands, a system-Python ≥3.11 `only-system` fallback, and actionable error
+strings for the BootstrapSplash UI.
+
+## Change sites (Rust)
+
+1. `bootstrap.rs` ~L427 (`uv venv`) and ~L439 (`uv sync`) — apply a shared
+   `apply_uv_network_env(cmd, region)` helper: `UV_PYTHON_INSTALL_MIRROR`
+   (gh-proxy cascade), `UV_HTTP_TIMEOUT=120`, `UV_HTTP_CONNECT_TIMEOUT=30`,
+   `UV_HTTP_RETRIES=5`; keep/extend the region `UV_INDEX_URL`.
+2. `bootstrap.rs` — on `uv venv` failure, detect a system Python ≥3.11
+   (`detect_system_python()`); if present, retry the venv with
+   `UV_PYTHON_PREFERENCE=only-system`.
+3. `bootstrap.rs` `fail()` sites (L432/L458) — emit an actionable message
+   (install python.org Python ≥3.11; documented env vars) that
+   `BootstrapSplash.detectHints()` already surfaces.
+4. `tools.rs` uv installer curl — add `--connect-timeout`/`--retry`.
+5. `docs/install/*.md` — document the env vars + China index + VPN note (keeps
+   the docs-drift validator honest).
+
+## Testable slice (Rust `#[cfg(test)]`)
+
+- `apply_uv_network_env` sets the expected vars (assert on a built Command's env).
+- `detect_system_python` version parsing: "Python 3.11.x" → eligible;
+  "Python 3.10.x"/garbage → not.
+- Remediation-message builder contains the key steps.
+
+## Verification gap (must flag on the PR)
+
+The restricted-network end-to-end paths (mirror install, only-system fallback)
+need a real Tauri build on a GitHub-blocked network — **not reproducible in the
+dev harness**. `cargo check`/`cargo test` (the Tauri shell-check CI job) cover
+compile + the unit slice only. CodeRabbit/Greptile + CodeQL give weaker coverage
+on Rust than Python. So this PR carries a "manual verification required" note.
+
+## Out of scope
+Windows venv completeness (#129, shipped). HF cache (#128, shipped).

--- a/specs/004-installer-network-resilience/spec.md
+++ b/specs/004-installer-network-resilience/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: Installer Bootstrap Network Resilience
+
+**Feature Branch**: `004-installer-network-resilience` | **Created**: 2026-05-29
+**Status**: Draft | **Input**: plan-03 (#130); children #60, #57, #127
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — First-run works on a GitHub-blocked network (Priority: P1)
+
+A user on a network that blocks/can't resolve GitHub launches OmniVoice. Today
+the Tauri bootstrap runs `uv venv --managed-python`, which downloads
+python-build-standalone from GitHub with no mirror and a short retry budget, so
+it dies with a DNS/tunnel error and the install is dead-on-arrival (#60). After
+this change the bootstrap sets a mirror cascade + longer timeouts/retries and,
+if all mirrors fail but a compatible system Python ≥3.11 is present, falls back
+to `UV_PYTHON_PREFERENCE=only-system`. If everything fails, it shows exact
+remediation steps, not a raw `uv` exit code.
+
+**Why this priority**: A dead first-run is the worst possible outcome — the user
+never gets to use the app. This is the core of the cluster.
+
+**Acceptance Scenarios** (from #130 test matrix):
+1. **Given** GitHub blocked + a mirror reachable + no system Python, **When**
+   bootstrap runs, **Then** the managed Python installs via the mirror.
+2. **Given** GitHub + mirrors blocked + system Python ≥3.11 present, **When**
+   bootstrap runs, **Then** it falls back to the system Python and succeeds.
+3. **Given** GitHub + mirrors blocked + no system Python, **When** bootstrap
+   fails, **Then** the UI shows actionable remediation (install python.org
+   Python ≥3.11; set the documented env vars) — not a raw stack trace.
+
+### Edge Cases
+- A mirror resolves but serves a corrupt/partial archive → uv's retry +
+  next-mirror cascade covers it; total failure → remediation path.
+- System Python present but <3.11 → not used; remediation names the version.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The bootstrap MUST set, on the `uv venv`/`uv sync` commands:
+  `UV_PYTHON_INSTALL_MIRROR` (gh-proxy cascade), `UV_HTTP_TIMEOUT=120`,
+  `UV_HTTP_CONNECT_TIMEOUT=30`, `UV_HTTP_RETRIES=5`.
+- **FR-002**: When the managed-Python install fails AND a system Python ≥3.11 is
+  detected, the bootstrap MUST retry with `UV_PYTHON_PREFERENCE=only-system`.
+- **FR-003**: On total failure, the user-facing error MUST contain actionable
+  remediation (install python.org Python ≥3.11; documented env vars), feeding
+  the existing BootstrapSplash hint system.
+- **FR-004**: The PyPI index mirror MUST be configurable per region (extend the
+  existing China `UV_INDEX_URL` to a documented cascade); VPN documented for
+  fully-blocked networks.
+- **FR-005**: Behaviour on an unrestricted network MUST be unchanged (mirrors are
+  fallbacks; the default GitHub path still works).
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: On a GitHub-blocked-but-mirror-reachable network, first-run install
+  succeeds (manual/integration verification on a restricted network).
+- **SC-002**: With mirrors blocked + system Python ≥3.11, install succeeds via
+  the only-system fallback.
+- **SC-003**: With everything blocked, the UI shows remediation steps, never a
+  raw uv exit code.
+- **SC-004**: No regression on an unrestricted network.
+
+## Assumptions
+
+- Bootstrap is Rust (`frontend/src-tauri/src/bootstrap.rs` spawns `uv`); the
+  env-var cascade + system-Python detection are added there, plus actionable
+  error strings consumed by `BootstrapSplash.jsx`.
+- Windows venv dependency completeness (#129/plan-02) and HF cache (#128/plan-01)
+  are out of scope (already shipped).
+
+## Verification reality (important)
+
+The failure paths depend on real network conditions and a Tauri build, which
+**cannot be exercised in the dev test harness**. Unit-testable pieces (the
+env-var builder, system-Python version parsing) get Rust `#[cfg(test)]` tests;
+the end-to-end restricted-network behaviour needs **manual verification on a
+GitHub-blocked network** (or a CI job that simulates it). This is called out so
+the PR isn't merged on a false sense of automated coverage.

--- a/specs/004-installer-network-resilience/tasks.md
+++ b/specs/004-installer-network-resilience/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Installer Bootstrap Network Resilience (plan-03)
+
+**Branch**: `004-installer-network-resilience` | Closes #60. Addresses #130/#57/#127.
+**Note:** ~90% Rust; network-failure E2E needs manual verification on a restricted network.
+
+## Phase 1: Bootstrap resilience (Rust)
+- [x] T001 `bootstrap.rs` helpers: `apply_uv_http_env` (timeout/connect/retries),
+  `parse_py_version`, `system_python_ge_311`, `PY_INSTALL_MIRROR`,
+  `BOOTSTRAP_REMEDIATION`.
+- [x] T002 `uv venv` cascade: default → gh-proxy mirror → system-Python
+  (only-system, if ≥3.11), each with the http env. Actionable failure message.
+- [x] T003 `uv sync`: apply http env; actionable failure message (mirror hint).
+- [x] T004 Rust `#[cfg(test)]`: parse_py_version (real + garbage), apply_uv_http_env
+  sets the three vars. `cargo test` → 2 passed; crate compiles.
+
+## Phase 2: User-facing remediation + docs
+- [x] T005 `BootstrapSplash.detectHints`: GitHub-blocked / can't-download-Python
+  hint pointing at python.org + UV_PYTHON_INSTALL_MIRROR + docs.
+- [x] T006 `docs/install/troubleshooting.md`: restricted-network section
+  (mirror env vars, China index, VPN note) — referenced by the remediation text.
+
+## Phase 3: Verify
+- [x] T007 `cargo test` green; `bun run build` clean; docs-drift validator passes.
+- [ ] T008 **Manual**: verify mirror install + only-system fallback on a real
+  GitHub-blocked network (cannot be reproduced in the dev/CI harness).
+
+## Out of scope
+- uv installer curl timeout in tools.rs (smaller follow-up).
+- Per-region mirror cascade beyond gh-proxy + China index (follow-up).


### PR DESCRIPTION
**plan-03** — Closes #60. Addresses #130, #57, #127.

First-run bootstrap downloaded managed Python from GitHub with **no mirror** and a short retry budget — a GitHub-blocked/unresolvable network killed the install dead-on-arrival (#60: `uv venv failed`, DNS error).

## Fix (`frontend/src-tauri/src/bootstrap.rs`)
- **`apply_uv_http_env()`** — `UV_HTTP_TIMEOUT=120` / `UV_HTTP_CONNECT_TIMEOUT=30` / `UV_HTTP_RETRIES=5` on both `uv venv` and `uv sync` (step 2).
- **`uv venv` cascade** (step 1+3): default GitHub → **gh-proxy mirror** (`UV_PYTHON_INSTALL_MIRROR`) → **system Python** (`UV_PYTHON_PREFERENCE=only-system`, only when a system Python ≥3.11 is detected). First success wins.
- **Actionable failures** (step 5): "install python.org Python 3.11+ / set a mirror / Clean & Retry" instead of a raw `uv` exit code.
- **Frontend**: a `BootstrapSplash` hint for the GitHub-blocked case.
- **Docs** (step 4): `troubleshooting.md` restricted-network section — mirror env vars, China PyPI index, honest VPN note — referenced by the remediation text.

## Cross-platform parity
Mirrors/fallbacks only kick in **after** the default path fails, so an unrestricted network is unchanged.

## Tests
Rust `#[cfg(test)]`: `parse_py_version` (real + garbage), `apply_uv_http_env` sets the three vars — **`cargo test`: 2 passed, crate compiles**. Docs-drift validator + frontend build green.

## ⚠️ Verification reality — please read
This is ~90% Rust in the Tauri bootstrap. The **restricted-network E2E paths** (mirror install, only-system fallback) depend on real network conditions + a packaged Tauri build and **cannot be reproduced in the dev/CI harness** — `cargo` + the unit tests cover compile + the pure helpers only. **Recommend a manual smoke on a GitHub-blocked network** (or a VM with GitHub firewalled) before relying on it in the wild. Also note: CodeRabbit/Greptile/CodeQL give weaker coverage on Rust than on the Python PRs.

Spec/plan/tasks in `specs/004-installer-network-resilience/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-run setup now copes with restricted networks using mirror cascades, system-Python fallback, and extended network timeouts/retries.

* **Bug Fixes**
  * Improved bootstrap failure detection and clearer, actionable remediation messages and hints for network-related issues.

* **Documentation**
  * Added a troubleshooting guide and a resilience spec/plan describing installer behavior on blocked networks.

* **Tests**
  * Added unit tests for version parsing and network-environment handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->