### PR TITLE
fix(voice-design): validator-safe instruct builder (plan-05, closes #114 #115)

### DIFF
--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -109,9 +109,12 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
         // category; drop unsupported free-text) so Synthesize stops failing
         // with "Unsupported instruct items" (#115) / "conflicting items within
         // the same category" (#114).
-        const { instruct: finalInstruct, dropped } = buildDesignInstruct(vdStates, instruct);
-        if (dropped.length) {
-          toast(`Ignored instruct not in the supported set: ${dropped.join(', ')}`, { icon: '⚠️' });
+        const { instruct: finalInstruct, unsupported, duplicates } = buildDesignInstruct(vdStates, instruct);
+        if (unsupported.length) {
+          toast(`Ignored unsupported instruct: ${unsupported.join(', ')}`, { icon: '⚠️' });
+        }
+        if (duplicates.length) {
+          toast(`Ignored (category already set): ${duplicates.join(', ')}`, { icon: '⚠️' });
         }
         if (finalInstruct) formData.append("instruct", finalInstruct);
         if (selectedProfile) {

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -4,6 +4,7 @@ import { generateSpeech, audioUrlWithCacheBust } from '../api/generate';
 import { playBlobAudio, playPing } from '../utils/media';
 import { probeAudioDuration } from '../utils/format';
 import { CLONE_MAX_SECONDS, PRESETS } from '../utils/constants';
+import { buildDesignInstruct } from '../utils/voiceInstruct';
 import { toast } from 'react-hot-toast';
 
 /**
@@ -104,9 +105,14 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
       } else {
         const designSeed = Math.floor(Math.random() * 2147483647);
         formData.append("seed", designSeed);
-        const parts = Object.values(vdStates).filter(v => v !== 'Auto');
-        if (instruct.trim()) parts.push(instruct.trim());
-        const finalInstruct = parts.join(', ');
+        // plan-05 (#132): build a validator-safe instruct (one valid tag per
+        // category; drop unsupported free-text) so Synthesize stops failing
+        // with "Unsupported instruct items" (#115) / "conflicting items within
+        // the same category" (#114).
+        const { instruct: finalInstruct, dropped } = buildDesignInstruct(vdStates, instruct);
+        if (dropped.length) {
+          toast(`Ignored instruct not in the supported set: ${dropped.join(', ')}`, { icon: '⚠️' });
+        }
         if (finalInstruct) formData.append("instruct", finalInstruct);
         if (selectedProfile) {
           formData.append("profile_id", selectedProfile);

--- a/frontend/src/utils/voiceInstruct.js
+++ b/frontend/src/utils/voiceInstruct.js
@@ -20,39 +20,46 @@ const TAG_TO_CATEGORY = (() => {
  *
  * - Dropdowns contribute one valid tag per category (they win their category).
  * - Free-text items are accepted only if they're a known tag whose category is
- *   still open; unknown/prose items and category-duplicates are dropped and
- *   returned in `dropped` so the caller can warn the user.
+ *   still open. The rest are returned split into two buckets so the caller can
+ *   show an accurate message:
+ *     - `unsupported`: not a known tag (free-text prose) — the #115 case;
+ *     - `duplicates`:  a valid tag whose category was already set (e.g. a
+ *       dropdown's `low pitch` outranks a typed `high pitch`) — the #114 case.
  *
- * This closes #114 (≤1 item per category — no "conflicting" error) and #115
- * (no unsupported free-text reaches the whitelist validator).
- *
- * @returns {{ instruct: string, dropped: string[] }}
+ * @returns {{ instruct: string, unsupported: string[], duplicates: string[] }}
  */
 export function buildDesignInstruct(vdStates = {}, freeText = '') {
   const byCategory = {};
+  const unsupported = [];
+  const duplicates = [];
 
-  const add = (value, dropped) => {
+  // Dropdowns first — they win their category.
+  for (const value of Object.values(vdStates || {})) {
     const item = String(value ?? '').trim();
-    if (!item || item === 'Auto') return;
-    const key = item.toLowerCase();
-    const cat = TAG_TO_CATEGORY[key];
+    if (!item || item === 'Auto') continue;
+    const cat = TAG_TO_CATEGORY[item.toLowerCase()];
     if (!cat) {
-      if (dropped) dropped.push(item); // unknown / free-text prose
-      return;
+      // A dropdown value that isn't in CATEGORIES means the option list and the
+      // whitelist have drifted — silently dropping it would hide a real bug.
+      console.warn(`buildDesignInstruct: unknown dropdown value "${item}" (not in CATEGORIES)`);
+      continue;
     }
-    if (cat in byCategory) {
-      if (dropped) dropped.push(item); // category already filled
-      return;
+    if (!(cat in byCategory)) byCategory[cat] = item.toLowerCase();
+  }
+
+  // Free-text field — accept valid tags in open categories; bucket the rest.
+  for (const raw of String(freeText || '').split(/[,，]/)) {
+    const item = raw.trim();
+    if (!item) continue;
+    const cat = TAG_TO_CATEGORY[item.toLowerCase()];
+    if (!cat) {
+      unsupported.push(item);
+    } else if (cat in byCategory) {
+      duplicates.push(item);
+    } else {
+      byCategory[cat] = item.toLowerCase();
     }
-    byCategory[cat] = key; // canonical (CATEGORIES values are lowercase)
-  };
+  }
 
-  // Dropdowns first — they win their category (not tracked as "dropped").
-  for (const v of Object.values(vdStates || {})) add(v, null);
-
-  // Free-text field — accept valid tags in open categories; collect the rest.
-  const dropped = [];
-  for (const raw of String(freeText || '').split(/[,，]/)) add(raw, dropped);
-
-  return { instruct: Object.values(byCategory).join(', '), dropped };
+  return { instruct: Object.values(byCategory).join(', '), unsupported, duplicates };
 }

--- a/frontend/src/utils/voiceInstruct.js
+++ b/frontend/src/utils/voiceInstruct.js
@@ -1,0 +1,58 @@
+import { CATEGORIES } from './constants';
+
+// Lowercased tag -> its category name. The engine validator
+// (omnivoice/models/omnivoice.py::_resolve_instruct) accepts ONLY these
+// whitelist tags, one per category — so the Voice Design payload must be built
+// from them, not raw free text.
+const TAG_TO_CATEGORY = (() => {
+  const map = {};
+  for (const [cat, values] of Object.entries(CATEGORIES)) {
+    for (const v of values) {
+      if (v !== 'Auto') map[v.toLowerCase()] = cat;
+    }
+  }
+  return map;
+})();
+
+/**
+ * Build a validator-safe Voice Design instruct from the category dropdown
+ * selections (`vdStates`) plus the optional free-text field.
+ *
+ * - Dropdowns contribute one valid tag per category (they win their category).
+ * - Free-text items are accepted only if they're a known tag whose category is
+ *   still open; unknown/prose items and category-duplicates are dropped and
+ *   returned in `dropped` so the caller can warn the user.
+ *
+ * This closes #114 (≤1 item per category — no "conflicting" error) and #115
+ * (no unsupported free-text reaches the whitelist validator).
+ *
+ * @returns {{ instruct: string, dropped: string[] }}
+ */
+export function buildDesignInstruct(vdStates = {}, freeText = '') {
+  const byCategory = {};
+
+  const add = (value, dropped) => {
+    const item = String(value ?? '').trim();
+    if (!item || item === 'Auto') return;
+    const key = item.toLowerCase();
+    const cat = TAG_TO_CATEGORY[key];
+    if (!cat) {
+      if (dropped) dropped.push(item); // unknown / free-text prose
+      return;
+    }
+    if (cat in byCategory) {
+      if (dropped) dropped.push(item); // category already filled
+      return;
+    }
+    byCategory[cat] = key; // canonical (CATEGORIES values are lowercase)
+  };
+
+  // Dropdowns first — they win their category (not tracked as "dropped").
+  for (const v of Object.values(vdStates || {})) add(v, null);
+
+  // Free-text field — accept valid tags in open categories; collect the rest.
+  const dropped = [];
+  for (const raw of String(freeText || '').split(/[,，]/)) add(raw, dropped);
+
+  return { instruct: Object.values(byCategory).join(', '), dropped };
+}

--- a/frontend/src/utils/voiceInstruct.test.js
+++ b/frontend/src/utils/voiceInstruct.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildDesignInstruct } from './voiceInstruct';
+
+// plan-05 (#132): the Voice Design payload must be a validator-safe instruct —
+// one valid tag per category, no unsupported free-text — so Synthesize stops
+// failing with "Unsupported instruct items" (#115) / "conflicting items within
+// the same category" (#114).
+
+describe('buildDesignInstruct', () => {
+  it('keeps one valid tag per category from the dropdowns', () => {
+    const { instruct, dropped } = buildDesignInstruct(
+      { Gender: 'male', Age: 'middle-aged', Pitch: 'low pitch', Style: 'Auto',
+        EnglishAccent: 'british accent', ChineseDialect: 'Auto' },
+      '',
+    );
+    expect(instruct.split(', ').sort())
+      .toEqual(['british accent', 'low pitch', 'male', 'middle-aged'].sort());
+    expect(dropped).toEqual([]);
+  });
+
+  it('drops free-text prose as unsupported and reports it (#115)', () => {
+    const { instruct, dropped } = buildDesignInstruct(
+      { Gender: 'male' }, 'Speak as a calm documentary narrator');
+    expect(instruct).toBe('male');
+    expect(dropped).toContain('Speak as a calm documentary narrator');
+  });
+
+  it('drops a free-text tag whose category a dropdown already set (no #114 conflict)', () => {
+    const { instruct, dropped } = buildDesignInstruct({ Pitch: 'low pitch' }, 'high pitch');
+    expect(instruct).toBe('low pitch'); // dropdown wins the category
+    expect(dropped).toContain('high pitch');
+  });
+
+  it('accepts a valid free-text tag when its category is open', () => {
+    const { instruct } = buildDesignInstruct({ Gender: 'male' }, 'whisper');
+    expect(instruct.split(', ').sort()).toEqual(['male', 'whisper'].sort());
+  });
+
+  it('normalises casing and full-width commas in free-text', () => {
+    const { instruct } = buildDesignInstruct({}, 'MALE，WHISPER');
+    expect(instruct.split(', ').sort()).toEqual(['male', 'whisper'].sort());
+  });
+
+  it('ignores Auto and empty input', () => {
+    expect(buildDesignInstruct({ Gender: 'Auto', Age: 'Auto' }, '').instruct).toBe('');
+    expect(buildDesignInstruct({}, '').instruct).toBe('');
+  });
+});

--- a/frontend/src/utils/voiceInstruct.test.js
+++ b/frontend/src/utils/voiceInstruct.test.js
@@ -8,27 +8,30 @@ import { buildDesignInstruct } from './voiceInstruct';
 
 describe('buildDesignInstruct', () => {
   it('keeps one valid tag per category from the dropdowns', () => {
-    const { instruct, dropped } = buildDesignInstruct(
+    const { instruct, unsupported, duplicates } = buildDesignInstruct(
       { Gender: 'male', Age: 'middle-aged', Pitch: 'low pitch', Style: 'Auto',
         EnglishAccent: 'british accent', ChineseDialect: 'Auto' },
       '',
     );
     expect(instruct.split(', ').sort())
       .toEqual(['british accent', 'low pitch', 'male', 'middle-aged'].sort());
-    expect(dropped).toEqual([]);
+    expect(unsupported).toEqual([]);
+    expect(duplicates).toEqual([]);
   });
 
-  it('drops free-text prose as unsupported and reports it (#115)', () => {
-    const { instruct, dropped } = buildDesignInstruct(
+  it('buckets free-text prose as unsupported, not a duplicate (#115)', () => {
+    const { instruct, unsupported, duplicates } = buildDesignInstruct(
       { Gender: 'male' }, 'Speak as a calm documentary narrator');
     expect(instruct).toBe('male');
-    expect(dropped).toContain('Speak as a calm documentary narrator');
+    expect(unsupported).toContain('Speak as a calm documentary narrator');
+    expect(duplicates).toEqual([]);
   });
 
-  it('drops a free-text tag whose category a dropdown already set (no #114 conflict)', () => {
-    const { instruct, dropped } = buildDesignInstruct({ Pitch: 'low pitch' }, 'high pitch');
+  it('buckets a valid tag outranked by a dropdown as a duplicate, not unsupported (#114)', () => {
+    const { instruct, unsupported, duplicates } = buildDesignInstruct({ Pitch: 'low pitch' }, 'high pitch');
     expect(instruct).toBe('low pitch'); // dropdown wins the category
-    expect(dropped).toContain('high pitch');
+    expect(duplicates).toContain('high pitch');
+    expect(unsupported).toEqual([]);
   });
 
   it('accepts a valid free-text tag when its category is open', () => {
@@ -44,5 +47,13 @@ describe('buildDesignInstruct', () => {
   it('ignores Auto and empty input', () => {
     expect(buildDesignInstruct({ Gender: 'Auto', Age: 'Auto' }, '').instruct).toBe('');
     expect(buildDesignInstruct({}, '').instruct).toBe('');
+  });
+
+  it('does not count an unknown dropdown value as unsupported free-text', () => {
+    // CATEGORIES↔dropdown drift: warned in dev, excluded from instruct, NOT a
+    // free-text "unsupported" item.
+    const { instruct, unsupported } = buildDesignInstruct({ Gender: 'nonbinary' }, '');
+    expect(instruct).toBe('');
+    expect(unsupported).toEqual([]);
   });
 });

--- a/specs/005-voice-design-validator/plan.md
+++ b/specs/005-voice-design-validator/plan.md
@@ -1,0 +1,50 @@
+# Implementation Plan: Voice Design Instruct Validator (plan-05)
+
+**Branch**: `005-voice-design-validator` | **Date**: 2026-05-29 | **Spec**: [spec.md](./spec.md)
+**Decision**: Option **A — frontend guard** (preserve the engine's whitelist contract; no vendored-engine change).
+
+## Summary
+
+The engine validator is whitelist-strict by design. The #114/#115 failures came
+from the Voice Design payload merging the free-text instruct field with the
+category dropdowns (`useTTS.js`), producing unsupported items (#115) or two
+items in one category (#114). Fix: build a validator-safe instruct on the
+frontend — one valid tag per category, drop unsupported free-text (with a
+warning) — before sending.
+
+## Constitution Check
+
+| Principle | Status |
+|-----------|--------|
+| I. Local-First | ✅ no network/telemetry |
+| II. First-Run Works | ✅ Synthesize stops failing on presets/free-text |
+| III. Cross-Platform Parity | ✅ pure JS, identical on all platforms |
+| IV. Backward-Compatible | ✅ no engine/model change; whitelist contract preserved |
+| V. Root-Cause + Regression Tests | ✅ vitest unit tests for the builder (fail-before/pass-after) |
+
+## Change sites
+
+1. `frontend/src/utils/voiceInstruct.js` (new) — `buildDesignInstruct(vdStates,
+   freeText)`: dropdowns win their category; free-text accepted only as a known
+   tag in an open category; unknown/duplicate items returned in `dropped`.
+   `TAG_TO_CATEGORY` is derived from `CATEGORIES` (single source of truth).
+2. `frontend/src/hooks/useTTS.js` — design mode uses `buildDesignInstruct`
+   instead of the raw `Object.values(vdStates) + instruct` merge; toasts the
+   dropped items so the user knows what was ignored.
+
+## Tests
+
+`frontend/src/utils/voiceInstruct.test.js` (6, vitest): one-per-category from
+dropdowns, prose dropped (#115), category-duplicate dropped (#114), valid
+free-text accepted, casing/full-width-comma normalisation, Auto/empty. Full
+frontend suite 72 passed; typecheck + build green.
+
+## Out of scope / notes
+
+- Did not touch `_resolve_instruct` (vendored engine) — option B/C declined to
+  preserve the whitelist contract and avoid silently altering user input.
+- Could not reproduce #115's "non-English language injects free-text" claim
+  (language is a separate param); the reproducible path — free-text field mixed
+  with dropdowns — is fixed. If a non-English repro surfaces, revisit.
+- The accent-vs-dialect cross-category rule (a separate validator check) is left
+  to the engine's existing clear message; the builder enforces ≤1 per category.

--- a/specs/005-voice-design-validator/spec.md
+++ b/specs/005-voice-design-validator/spec.md
@@ -1,0 +1,38 @@
+# Feature Specification: Voice Design Instruct Validator
+
+**Feature Branch**: `005-voice-design-validator` | **Created**: 2026-05-29
+**Status**: Investigation — fix approach pending decision | **Input**: plan-05 (#132); children #114, #115
+
+## Investigation findings
+
+- The server validator `omnivoice/models/omnivoice.py::_resolve_instruct` is
+  **whitelist-strict by design**: it splits the instruct on commas, validates
+  each item against `_INSTRUCT_ALL_VALID` (from `omnivoice/utils/voice_design.py`),
+  unifies EN/ZH, enforces one-item-per-category, and returns a canonical tag
+  string the engine consumes. Free-text prose cannot be "passed through" — the
+  engine uses the resolved tags, not arbitrary text.
+- The presets DO emit valid tags: `backend/core/personalities.py` (post-#89) and
+  `frontend/src/utils/constants.js` `PRESETS[].attrs` are all valid category
+  values.
+- **Root cause of #114/#115 is the assembly, not the presets.** In
+  `frontend/src/hooks/useTTS.js` (~L105-110) the design payload is built as:
+  `parts = Object.values(vdStates).filter(v => v !== 'Auto'); if (instruct.trim())
+  parts.push(instruct.trim()); finalInstruct = parts.join(', ')`. So:
+  - typing prose in the free-text **instruct** field → "Unsupported instruct
+    items" (#115);
+  - typing/selecting a tag whose category a dropdown already set → two items in
+    one category → "conflicting instruct items within the same category" (#114).
+- Could not fully reproduce the "presets generate free-text on non-English" claim
+  in #115: language is sent as a **separate** param, not injected into instruct.
+  The reproducible failure is the free-text-field-mixed-with-dropdowns path.
+
+## Decision required (product call, possibly vendored-engine-touching)
+
+| Option | What | Risk |
+|--------|------|------|
+| **A. Frontend guard** | In `useTTS.js`, don't merge the free-text instruct field with the category dropdowns when in design mode; or pre-validate/convert it; ensure one-per-category before sending. No engine change. | Low — UI-only; preserves the engine's whitelist contract. |
+| **B. Tolerant validator** | In `_resolve_instruct`, dedupe a category to the last item (instead of hard-failing) and drop unknown items with a warning. | Med — silently alters user input; touches vendored engine; backward-compat review needed. |
+| **C. Per-engine free-text** | Capability flag; engines that accept natural-language instruct skip the whitelist. | High — needs an engine capability matrix + per-engine handling; biggest change. |
+
+## Out of scope
+General pipeline error transparency (→ plan-04, shipped).

--- a/specs/005-voice-design-validator/tasks.md
+++ b/specs/005-voice-design-validator/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Voice Design Instruct Validator (plan-05)
+
+**Branch**: `005-voice-design-validator` | Closes #114, #115. Addresses #132.
+**Decision**: Option A (frontend guard). **TDD (vitest).**
+
+## Phase 1: Validator-safe instruct builder (RED→GREEN)
+- [x] T001 `frontend/src/utils/voiceInstruct.test.js`: one-per-category, prose
+  dropped (#115), category-duplicate dropped (#114), valid free-text accepted,
+  casing/full-width-comma, Auto/empty. RED.
+- [x] T002 `frontend/src/utils/voiceInstruct.js` `buildDesignInstruct()` —
+  TAG_TO_CATEGORY from CATEGORIES; dropdowns win; drop unknown/duplicate. GREEN (6/6).
+
+## Phase 2: Wire it in
+- [x] T003 `useTTS.js` design mode uses `buildDesignInstruct`; toasts dropped items.
+
+## Phase 3: Verify
+- [x] T004 Full frontend vitest 72 passed; typecheck:ci + build green.
+
+## Out of scope
+- Engine validator `_resolve_instruct` untouched (whitelist contract preserved).
+- Non-English-language free-text injection: not reproduced (language is a
+  separate param); revisit if a repro surfaces.


### PR DESCRIPTION
**plan-05** — Closes #114, #115. Addresses #132.

Voice Design Synthesize failed with **"Unsupported instruct items"** (#115) or **"conflicting instruct items within the same category"** (#114).

## Root cause (investigated, not guessed)
The engine validator (`omnivoice/models/omnivoice.py::_resolve_instruct`) is **whitelist-strict by design** — it maps tags to canonical form the engine consumes, so free-text can't be passed through. The presets already emit valid tags. The failures came from the **frontend assembly** in `useTTS.js`: it merged the free-text instruct field with the category dropdowns —
- typed prose → "unsupported" (#115)
- a tag whose category a dropdown already set → two-in-a-category → "conflicting" (#114)

## Fix — option A (frontend guard, your call)
- **`frontend/src/utils/voiceInstruct.js`** `buildDesignInstruct(vdStates, freeText)`: dropdowns win their category; free-text accepted only as a known tag in an *open* category; unknown/duplicate items are dropped and returned so the UI can warn. `TAG_TO_CATEGORY` is derived from `CATEGORIES` (single source of truth).
- **`useTTS.js`** design mode uses it instead of the raw merge; toasts the dropped items so the user sees what was ignored.

**Engine validator untouched** — the whitelist contract is preserved, no vendored-engine change, no audio-quality risk.

## Tests (TDD, vitest — Constitution V)
`voiceInstruct.test.js` (6): one-per-category, prose dropped (#115), category-duplicate dropped (#114), valid free-text accepted, casing/full-width-comma, Auto/empty. **Full frontend suite: 72 passed**; typecheck + build green.

## Notes
- Declined option B (relax the engine validator) / C (per-engine free-text) to preserve the whitelist contract and avoid silently altering user input.
- Could **not reproduce** #115's "non-English language injects free-text" claim — language is sent as a *separate* param, not into instruct. The reproducible path (free-text + dropdowns) is fixed; if a non-English repro surfaces, we'll revisit.

Spec/plan/tasks in `specs/005-voice-design-validator/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validator-safe handling of voice-design inputs: dropdown choices are preferred, at most one tag per category is accepted, and unsupported or duplicate free-text items are dropped and surfaced as warnings. Finalized instruct is now used for speech requests.

* **Tests**
  * Added comprehensive tests covering dropdown vs free-text merging, normalization, unsupported items, and duplicates.

* **Documentation**
  * Added spec and plan documents describing the validator approach and rollout steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->