### PR TITLE
fix(bootstrap): always try only-system fallback (drop too-strict gate, refs #130)

### DIFF
--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -284,37 +284,6 @@ fn apply_uv_http_env(cmd: &mut Command) {
         .env("UV_HTTP_RETRIES", "5");
 }
 
-/// Parse a `python --version` line ("Python 3.11.7") into (major, minor).
-fn parse_py_version(s: &str) -> Option<(u32, u32)> {
-    let rest = s.trim().strip_prefix("Python ")?;
-    let mut parts = rest.split('.');
-    let major: u32 = parts.next()?.trim().parse().ok()?;
-    let minor: u32 = parts.next()?.trim().parse().ok()?;
-    Some((major, minor))
-}
-
-/// True if a system Python >= 3.11 is on PATH — the prerequisite for the
-/// `UV_PYTHON_PREFERENCE=only-system` fallback when all download mirrors fail.
-fn system_python_ge_311() -> bool {
-    for exe in ["python3", "python"] {
-        if let Ok(out) = Command::new(exe).arg("--version").output() {
-            if out.status.success() {
-                let text = format!(
-                    "{}{}",
-                    String::from_utf8_lossy(&out.stdout),
-                    String::from_utf8_lossy(&out.stderr),
-                );
-                if let Some((maj, min)) = parse_py_version(&text) {
-                    if maj == 3 && min >= 11 {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    false
-}
-
 /// Prepare (and on first run, create) the Python venv that will host the
 /// backend process. Returns (venv_python, backend_source_dir).
 pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Option<&Arc<Mutex<BootstrapStage>>>) -> Option<(PathBuf, PathBuf)> {
@@ -491,18 +460,18 @@ pub fn ensure_venv_ready<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress:
             vec![("UV_PYTHON_INSTALL_MIRROR", PY_INSTALL_MIRROR)],
         ),
     ];
-    if system_python_ge_311() {
-        // No `--python 3.11` pin here: that would force uv to find a 3.11.x
-        // interpreter exactly, so a machine with only 3.12/3.13 would fail the
-        // fallback despite being compatible (Greptile #140). `only-system` plus
-        // the project's `requires-python = ">=3.11"` lets uv resolve any
-        // compatible system interpreter.
-        venv_attempts.push((
-            "system-python",
-            vec!["venv"],
-            vec![("UV_PYTHON_PREFERENCE", "only-system")],
-        ));
-    }
+    // Always try the system Python as the LAST resort (mirrors blocked too).
+    // No `--python 3.11` pin and no pre-gate: uv's own interpreter discovery is
+    // the authority — with `only-system` + the project's `requires-python =
+    // ">=3.11"` it resolves any compatible system interpreter (3.12/3.13/3.14…),
+    // or fails fast → the remediation message. A pre-gate that only probed
+    // `python3`/`python` was stricter than uv (e.g. it missed a Homebrew 3.14
+    // when `python3` was the macOS 3.9), wrongly skipping this fallback.
+    venv_attempts.push((
+        "system-python",
+        vec!["venv"],
+        vec![("UV_PYTHON_PREFERENCE", "only-system")],
+    ));
 
     let mut venv_ok = false;
     for (label, args, envs) in &venv_attempts {
@@ -565,16 +534,6 @@ docs/install/troubleshooting.md).",
 mod tests {
     use super::*;
     use std::collections::HashMap;
-
-    #[test]
-    fn parse_py_version_handles_real_and_garbage() {
-        assert_eq!(parse_py_version("Python 3.11.7"), Some((3, 11)));
-        assert_eq!(parse_py_version("Python 3.11"), Some((3, 11)));
-        assert_eq!(parse_py_version("Python 3.12.2\n"), Some((3, 12)));
-        assert_eq!(parse_py_version("Python 3.10.6"), Some((3, 10)));
-        assert_eq!(parse_py_version("garbage"), None);
-        assert_eq!(parse_py_version(""), None);
-    }
 
     #[test]
     fn apply_uv_http_env_sets_timeouts_and_retries() {


### PR DESCRIPTION
Follow-up from **verifying #140** by driving the real `uv` binary.

**Finding:** `system_python_ge_311()` was stricter than uv's own interpreter discovery — it probed only `python3`/`python`. On this Mac, `python3` is the system 3.9.6 (no `python`), so the gate returned **false** and the `only-system` fallback was **skipped** — even though `UV_PYTHON_PREFERENCE=only-system uv venv` immediately resolves the Homebrew **CPython 3.14.5**. So in the exact worst case the fallback exists for (GitHub **and** mirror blocked), a user with a perfectly good system Python could be sent to the remediation screen.

**Fix:** drop the pre-gate (and the now-unused `parse_py_version`/`system_python_ge_311` helpers + the parse test); always add the system-python attempt as the last cascade step. uv's discovery is the authority — with `requires-python = ">=3.11"` it resolves any compatible system interpreter (3.12/3.13/3.14…) or fails fast → remediation.

**Verified live (real uv 0.11.14):** `only-system uv venv` built a venv from system CPython 3.14.5 on a host with no 3.11.x. `cargo test` + `cargo check` clean.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved bootstrap virtual environment creation with more reliable system Python fallback strategy. The setup process now consistently attempts system Python as a final option, leveraging built-in dependency version constraints for compatibility validation instead of pre-checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->