### PR TITLE
feat(macos): wire Developer-ID signing + notarization; fix "app is damaged" docs (#134, #72)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,6 +353,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # macOS Developer-ID code-signing + notarization (#134 / #72).
+          # tauri-action signs + notarizes the .app/.dmg ONLY when these are
+          # non-empty; with the secrets unset they resolve to empty strings and
+          # the build stays unsigned (today's behavior — users clear quarantine
+          # via `xattr -cr`, see docs/install/macos.md). To enable, add the repo
+          # secrets documented in docs/install/macos.md → "For maintainers".
+          # No-op on the Windows/Linux matrix legs.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # GH runners disable FUSE, so linuxdeploy's AppImage can't mount
           # itself at bundle time. This env tells linuxdeploy to extract-and-run
           # instead, which works without FUSE.

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -42,19 +42,43 @@ Gatekeeper — see the next section.
 
 <a id="gatekeeper-quarantine"></a>
 
-OmniVoice Studio is currently **not notarised** — the developer-ID signing +
-notarisation pipeline is tracked for v0.4. Until then, macOS quarantines any
-copy you downloaded outside the App Store. After dragging the app into
-`/Applications`, run:
+If you see **"OmniVoice Studio.app" is damaged and can't be opened. You should
+move it to the Trash**, the app is **not** damaged — that misleading message is
+macOS Gatekeeper blocking an app it can't verify (issues #134, #72).
+
+**Why:** releases are only notarised when the project's Apple Developer ID
+signing pipeline is configured (see "For maintainers" below). On an unsigned
+build, macOS quarantines any copy downloaded outside the App Store.
+
+**Fix (unsigned builds):** after dragging the app into `/Applications`, run:
 
 ```bash
 xattr -cr "/Applications/OmniVoice Studio.app"
 ```
 
-That clears the quarantine xattr so Gatekeeper stops blocking the launch. It's
-a one-time fix per install. The app itself is open source — verify the SHA-256
-against the `*.dmg.sha256` checksum on the release page before clearing the
-attribute if you want belt-and-braces.
+That clears the quarantine xattr so Gatekeeper stops blocking the launch — a
+one-time fix per install. Alternatively, right-click the app → **Open** →
+**Open** in the dialog. The app is open source; verify the SHA-256 against the
+`*.dmg.sha256` checksum on the release page first if you want belt-and-braces.
+
+### For maintainers — enabling notarised builds
+
+The release workflow (`.github/workflows/release.yml`) is already wired to
+code-sign + notarise the macOS bundle; it activates automatically once these
+repository **secrets** are set (it skips signing — producing today's unsigned
+build — when they're absent):
+
+| Secret | What |
+|--------|------|
+| `APPLE_CERTIFICATE` | Developer ID Application cert, exported as a base64-encoded `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | password for that `.p12` |
+| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Your Name (TEAMID)` |
+| `APPLE_ID` | Apple ID email used for notarisation |
+| `APPLE_PASSWORD` | an **app-specific password** for that Apple ID |
+| `APPLE_TEAM_ID` | your 10-char Apple Developer Team ID |
+
+Requires a paid Apple Developer account ($99/yr). Once set, downloaded DMGs open
+without the quarantine step.
 
 ## Apple Silicon vs Intel
 


### PR DESCRIPTION
Addresses the macOS **"OmniVoice Studio.app is damaged and can't be opened"** reports (#134, #72) — which is Gatekeeper blocking an unsigned/un-notarised app, not actual corruption.

## Two parts
1. **`release.yml`** — pass `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID` to `tauri-action`. It code-signs + notarizes the macOS bundle **only when these repo secrets are set**, and is a **no-op** (today's unsigned build) when they're absent. → safe to merge now; it *activates* the moment you add an Apple Developer ID cert.
2. **`docs/install/macos.md`** — clarify the "damaged" message is Gatekeeper (not corruption), give the immediate `xattr -cr` + right-click→**Open** workarounds, and add a **"For maintainers"** table of the exact secrets to configure. Removed a stale "tracked for v0.4" line (versioning rule — everything's on v0.3.0). The in-app error→docs deeplink (`GATEKEEPER_QUARANTINE`) already points at the `#gatekeeper-quarantine` anchor.

## What you need to do to get signed builds
Add the 6 repo secrets listed in `docs/install/macos.md → For maintainers` (needs a paid Apple Developer account, \$99/yr). Until then, users on the unsigned build clear quarantine with `xattr -cr`.

## Verification note
The signing path can't be exercised in CI without a real Apple cert; this PR wires it + degrades gracefully. The next tagged release with the secrets present is the real test. `release.yml` YAML validated.

Refs #134, #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled macOS application signing and notarization for improved security, resolving Gatekeeper compatibility issues that display "damaged" application warnings.

* **Documentation**
  * Enhanced macOS installation guide with improved guidance for Gatekeeper security warnings, providing clear explanations of quarantine behavior and two practical workarounds: using the xattr command or the right-click open method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->