### PR TITLE
chore: set version to 0.3.0 across all sources (+ drop v0.4 references)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [0.2.7] — Unreleased
+## [0.3.0] — Unreleased
 
 ### Added
 - **Frameless dictation widget.** Global dictation upgraded from an in-app FAB to a true OS-level floating widget that hovers over any application. Transparent, decorations-free, always-on-top secondary Tauri window activated by `⌘+⇧+Space`. Auto-hides 2.5 s after a successful paste.

--- a/backend/api/routers/marketplace.py
+++ b/backend/api/routers/marketplace.py
@@ -38,6 +38,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from core.config import OUTPUTS_DIR, VOICES_DIR
 from core.db import db_conn
 from core import event_bus
+from core.version import APP_VERSION
 
 logger = logging.getLogger("omnivoice.marketplace")
 
@@ -85,7 +86,7 @@ def export_profile(profile_id: str):
             "is_locked": bool(profile.get("is_locked")),
             "created_at": profile.get("created_at"),
             "exported_at": time.time(),
-            "omnivoice_version": "0.3.0",
+            "omnivoice_version": APP_VERSION,
         }
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 
@@ -263,7 +264,7 @@ def publish_to_marketplace(
             "is_locked": bool(profile.get("is_locked")),
             "tags": [t.strip() for t in tags.split(",") if t.strip()],
             "published_at": time.time(),
-            "omnivoice_version": "0.3.0",
+            "omnivoice_version": APP_VERSION,
         }
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 

--- a/backend/api/routers/marketplace.py
+++ b/backend/api/routers/marketplace.py
@@ -85,7 +85,7 @@ def export_profile(profile_id: str):
             "is_locked": bool(profile.get("is_locked")),
             "created_at": profile.get("created_at"),
             "exported_at": time.time(),
-            "omnivoice_version": "0.4.0",
+            "omnivoice_version": "0.2.7",
         }
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 
@@ -263,7 +263,7 @@ def publish_to_marketplace(
             "is_locked": bool(profile.get("is_locked")),
             "tags": [t.strip() for t in tags.split(",") if t.strip()],
             "published_at": time.time(),
-            "omnivoice_version": "0.4.0",
+            "omnivoice_version": "0.2.7",
         }
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 

--- a/backend/api/routers/marketplace.py
+++ b/backend/api/routers/marketplace.py
@@ -85,7 +85,7 @@ def export_profile(profile_id: str):
             "is_locked": bool(profile.get("is_locked")),
             "created_at": profile.get("created_at"),
             "exported_at": time.time(),
-            "omnivoice_version": "0.2.7",
+            "omnivoice_version": "0.3.0",
         }
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 
@@ -263,7 +263,7 @@ def publish_to_marketplace(
             "is_locked": bool(profile.get("is_locked")),
             "tags": [t.strip() for t in tags.split(",") if t.strip()],
             "published_at": time.time(),
-            "omnivoice_version": "0.2.7",
+            "omnivoice_version": "0.3.0",
         }
         zf.writestr("metadata.json", json.dumps(metadata, indent=2))
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -1,0 +1,15 @@
+"""Single source of truth for the app version at runtime.
+
+Read from the installed package metadata (driven by ``pyproject.toml``) so the
+FastAPI/API version and exported-bundle metadata never drift to a stale literal
+again (the prior "0.4.0" / "0.2.7" bug). Falls back to a literal only when
+running from a raw source checkout that was never ``uv sync``'d.
+"""
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    APP_VERSION = version("omnivoice")
+except PackageNotFoundError:  # non-installed source checkout
+    APP_VERSION = "0.3.0"

--- a/backend/engines/indextts/bootstrap.py
+++ b/backend/engines/indextts/bootstrap.py
@@ -34,8 +34,8 @@ Threat model (Plan 02-03 frontmatter):
     T-02-09 — supply chain (uv pip install -e):
         Bootstrap installs from a user-controlled local directory
         (``OMNIVOICE_INDEXTTS_DIR``). The user already trusts that
-        directory's contents (it's their own clone). Accepted for v0.3;
-        revisit in v0.4 with hash-pinned indextts requirements.
+        directory's contents (it's their own clone). Accepted for now; a
+        later hardening pass can hash-pin the indextts requirements.
 """
 from __future__ import annotations
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -363,7 +363,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="OmniVoice Studio API",
-    version="0.4.0",
+    version="0.2.7",
     lifespan=lifespan,
     docs_url=None,       # Disabled — replaced by Scalar at /docs
     redoc_url=None,      # Disabled — Scalar covers this

--- a/backend/main.py
+++ b/backend/main.py
@@ -361,9 +361,11 @@ async def lifespan(app: FastAPI):
     logger.info("Shutdown: done.")
 
 
+from core.version import APP_VERSION  # single source of truth (pyproject metadata)
+
 app = FastAPI(
     title="OmniVoice Studio API",
-    version="0.3.0",
+    version=APP_VERSION,
     lifespan=lifespan,
     docs_url=None,       # Disabled — replaced by Scalar at /docs
     redoc_url=None,      # Disabled — Scalar covers this

--- a/backend/main.py
+++ b/backend/main.py
@@ -363,7 +363,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="OmniVoice Studio API",
-    version="0.2.7",
+    version="0.3.0",
     lifespan=lifespan,
     docs_url=None,       # Disabled — replaced by Scalar at /docs
     redoc_url=None,      # Disabled — Scalar covers this

--- a/backend/services/_secret_key.py
+++ b/backend/services/_secret_key.py
@@ -14,7 +14,7 @@ machine will produce a Fernet that can't decrypt the existing token row
 logging a warning and returning None, after which the resolver falls
 through to env / HF-CLI naturally — see Open Question #5 in 01-RESEARCH.md.
 
-We do not use OS keyring (Capability 1 / Keyring deferred to v0.4 per
+We do not use OS keyring (Capability 1 / Keyring deferred — see
 STATE Key Decision #5).
 """
 from __future__ import annotations

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -47,8 +47,9 @@ before the token works for downloads.
 
 **Symptom:** "OmniVoice Studio.app is damaged and can't be opened."
 
-**Cause:** the app is not yet notarised (tracked for v0.4) — macOS quarantines
-every download.
+**Cause:** the app is not yet notarised (signing is wired in `release.yml` and
+activates once the maintainer adds the Apple cert secrets) — until then macOS
+quarantines every download.
 
 **Fix:** see [macos.md#gatekeeper-quarantine](macos.md#gatekeeper-quarantine).
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.2.7",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.2.7"
+version = "0.3.0"
 dependencies = [
  "dirs-next",
  "enigo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.2.7"
+version = "0.3.0"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/src/utils/errorDocsMap.ts
+++ b/frontend/src/utils/errorDocsMap.ts
@@ -7,8 +7,8 @@
 // canonical Python-side resolver is `backend/core/links.py`
 // (`PROJECT_REPO_BLOB_MAIN`). The TS half runs in the browser and can't
 // read `pyproject.toml`, so it gets a hand-maintained mirror. Centralising
-// the URL on the TS side is a v0.4 concern — the milestone accepts the
-// drift risk and relies on the keys-sync test + threat-model T-02-01
+// the URL on the TS side is a deferred hardening item — for now we accept the
+// drift risk and rely on the keys-sync test + threat-model T-02-01
 // to bound the blast radius.
 
 import { openExternal } from '../api/external';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.2.7"
+version = "0.3.0"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_app_version.py
+++ b/tests/test_app_version.py
@@ -1,0 +1,16 @@
+"""The runtime app version must come from package metadata, not a stale literal
+(prevents the recurring "0.4.0"/"0.2.7" drift — Greptile #145)."""
+import re
+from importlib.metadata import version
+
+from core.version import APP_VERSION
+
+
+def test_app_version_is_semver():
+    assert re.match(r"^\d+\.\d+\.\d+", APP_VERSION), APP_VERSION
+
+
+def test_app_version_matches_installed_package_metadata():
+    # In any synced env the package is installed; APP_VERSION must equal it
+    # (i.e. it's read from pyproject, not hardcoded).
+    assert APP_VERSION == version("omnivoice")

--- a/uv.lock
+++ b/uv.lock
@@ -3058,7 +3058,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.2.7"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
The current/upcoming version is **v0.3.0** (0.2.7 is the prior stable). Two parts:

### 1. Version → 0.3.0 everywhere (consistency)
The app even reported a phantom **`0.4.0`** in `main.py`/marketplace metadata. Now every source reads `0.3.0`:
- `pyproject.toml`, `frontend/src-tauri/Cargo.toml`, `frontend/src-tauri/tauri.conf.json`, `frontend/package.json`
- `backend/main.py` (FastAPI version) + `marketplace.py` export metadata
- `CHANGELOG.md`: `[0.2.7] — Unreleased` → `[0.3.0] — Unreleased`
- **`uv.lock` + `Cargo.lock` reconciled** (1 line each) so `uv sync --frozen` / `cargo --frozen` in the bootstrap + CI still hold. `uv lock --check` passes.

This is the **in-code dev version**; the git *tag* still happens later per the release cadence (when you call it "actually useful").

### 2. Drop stray v0.4 references
Reworded the v0.4 deferral comments in `errorDocsMap.ts`, `indextts/bootstrap.py`, `_secret_key.py`, and the `troubleshooting.md` notarization line — no forbidden version chatter left in live code.

Verified: no `v0.4` in live code; backend parses; frontend typecheck OK; lockfiles consistent.

_Out of scope:_ ~90 historical `v0.4` notes under `.planning/` (superseded phase records) — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped application and bundle version metadata to 0.3.0 across the project and unified runtime version sourcing.

* **Documentation**
  * Revised supply-chain/hardening timeline notes and clarified macOS Gatekeeper notarization troubleshooting.

* **Tests**
  * Added assertions ensuring the runtime app version is a valid semantic version and matches the packaged version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->