### PR TITLE
fix(bootstrap): surface why the backend "never started" (refs #144, #127)

### DIFF
--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::net::{TcpStream, ToSocketAddrs};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -133,6 +133,29 @@ pub fn read_error_log_tail(max_lines: usize) -> String {
     }
 }
 
+/// Human-readable diagnostic for a failed `Command::spawn()` of the backend.
+///
+/// #144 / #127: when the bundled venv Python can't exec (the common Linux/
+/// AppImage failure — missing system lib, stale venv, arch mismatch) the
+/// process "never started" and we previously surfaced "no error output
+/// captured". Writing this to backend_err.log lets read_error_log_tail show the
+/// real OS error + an actionable hint instead.
+fn spawn_failure_diagnostic(python: &Path, err: &std::io::Error) -> String {
+    format!(
+        "Failed to launch the backend process.\n\
+         Tried to run: {}\n\
+         Interpreter present on disk: {}\n\
+         OS error: {}\n\n\
+         On Linux (especially the AppImage) this usually means the bundled venv \
+         Python can't execute — a missing system library or a stale/incomplete \
+         venv. Use \"Clean & Retry\" to rebuild it; if it persists, run the \
+         AppImage from a terminal to see the dynamic-loader error.",
+        python.display(),
+        python.exists(),
+        err,
+    )
+}
+
 // ── Spawn the backend via the bootstrapped venv Python ────────────────────
 
 pub fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Option<&Arc<Mutex<BootstrapStage>>>) -> Option<Child> {
@@ -216,7 +239,12 @@ pub fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Opt
             c
         }
         Err(e) => {
-            log::error!("Failed to spawn backend: {}", e);
+            // #144/#127: surface WHY it never started. Write the diagnostic to
+            // backend_err.log so the bootstrap's read_error_log_tail shows the
+            // real exec error instead of "no error output captured".
+            let diag = spawn_failure_diagnostic(&python, &e);
+            log::error!("{}", diag);
+            let _ = fs::write(&err_path, &diag);
             return None;
         }
     };
@@ -254,4 +282,20 @@ pub fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Opt
     }
 
     Some(child)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn spawn_failure_diagnostic_surfaces_path_error_and_hint() {
+        let err = io::Error::new(io::ErrorKind::NotFound, "No such file or directory");
+        let diag = spawn_failure_diagnostic(Path::new("/no/such/python"), &err);
+        assert!(diag.contains("/no/such/python"), "must name the interpreter path");
+        assert!(diag.contains("No such file or directory"), "must include the OS error");
+        assert!(diag.contains("Interpreter present on disk: false"));
+        assert!(diag.contains("Clean & Retry"), "must give an actionable hint");
+    }
 }

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -141,18 +141,33 @@ pub fn read_error_log_tail(max_lines: usize) -> String {
 /// captured". Writing this to backend_err.log lets read_error_log_tail show the
 /// real OS error + an actionable hint instead.
 fn spawn_failure_diagnostic(python: &Path, err: &std::io::Error) -> String {
+    // Platform-specific tail (cfg! resolves to this build's target OS, i.e. the
+    // OS it runs on) — don't show AppImage/loader wording to macOS/Windows users.
+    let os_hint = if cfg!(target_os = "linux") {
+        "On Linux (especially the AppImage) this usually means the bundled venv \
+         Python can't execute — a missing system library or a stale/incomplete \
+         venv. If it persists, run the app from a terminal to see the \
+         dynamic-loader error."
+    } else if cfg!(target_os = "macos") {
+        "On macOS this usually means the bundled venv Python can't execute (a \
+         stale/incomplete venv, or the interpreter got quarantined)."
+    } else if cfg!(target_os = "windows") {
+        "On Windows this usually means the bundled venv Python is missing or was \
+         blocked (antivirus / SmartScreen), or the venv is stale/incomplete."
+    } else {
+        "This usually means the bundled venv Python can't execute, or the venv is \
+         stale/incomplete."
+    };
     format!(
         "Failed to launch the backend process.\n\
          Tried to run: {}\n\
          Interpreter present on disk: {}\n\
          OS error: {}\n\n\
-         On Linux (especially the AppImage) this usually means the bundled venv \
-         Python can't execute — a missing system library or a stale/incomplete \
-         venv. Use \"Clean & Retry\" to rebuild it; if it persists, run the \
-         AppImage from a terminal to see the dynamic-loader error.",
+         {} Use \"Clean & Retry\" to rebuild the environment.",
         python.display(),
         python.exists(),
         err,
+        os_hint,
     )
 }
 


### PR DESCRIPTION
AppImage users get **"Backend process exited (never started) — no error output captured"** (#144, #127) with nothing actionable.

## Root gap
When `Command::spawn()` of the venv Python fails — the common Linux/AppImage case (the bundled interpreter can't exec: missing system lib, stale venv, arch mismatch) — `spawn_backend` logged the OS error but returned `None` **silently**, so the bootstrap surfaced the useless "no error output captured."

## Fix
On spawn failure, write a diagnostic to `backend_err.log` (which the bootstrap's `read_error_log_tail` already reads): the interpreter path, whether it exists on disk, the **real OS error**, and an actionable hint ("Clean & Retry / run the AppImage from a terminal to see the loader error"). The dead-end becomes the actual launch error.

## Scope / honesty
This makes the failure **diagnosable** — it surfaces *why* the backend won't start. It doesn't blindly guess the specific AppImage root cause (which needs that now-visible error). Once a reporter shares the surfaced message, the underlying cause routes to a targeted fix. Same "errors must be visible" principle as plan-04, applied to the Tauri bootstrap.

## Tests
Pure message builder unit-tested (`spawn_failure_diagnostic`); `cargo test` + `cargo check` clean. (Full AppImage repro isn't possible in CI.)

Refs #144, #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup error diagnostics when the bundled backend fails to launch, providing a human-readable message with interpreter path, OS error text, and platform-specific troubleshooting hints; this diagnostic is logged so existing log-tail mechanisms surface the real execution error.

* **Tests**
  * Added a unit test to verify the diagnostic message includes the interpreter path, OS error text, and actionable hint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->