### PR TITLE
feat(settings): configurable models directory (#64)

### DIFF
--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -13,6 +13,7 @@ The state endpoint duplicates `/system/hf-token/state` (which lives on
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import asdict
 from typing import Optional
 
@@ -194,3 +195,82 @@ def get_license_acceptance(engine_id: str) -> dict:
         logger.exception("get_license_accepted failed for %s", eid)
         raise HTTPException(status_code=500, detail="Failed to read license acceptance")
     return {"engine_id": eid, "accepted": bool(accepted)}
+
+
+# ── Storage: configurable models directory (#64) ──────────────────────────
+# Where HuggingFace / Torch download model weights. Persisted durably to the
+# per-user env file so main.py maps it to HF_HOME / HF_HUB_CACHE / TORCH_HOME
+# at startup. Takes effect on the next backend restart (a storage-location
+# change can't safely move an in-use cache mid-process).
+_MODELS_DIR_ENV = "OMNIVOICE_CACHE_DIR"
+_MODELS_DIR_KEY = "storage.models_dir"
+
+
+def _default_models_dir() -> str:
+    return os.path.expanduser("~/.cache/huggingface")
+
+
+def _effective_models_dir() -> str:
+    return (
+        os.environ.get("HF_HUB_CACHE")
+        or os.environ.get("HUGGINGFACE_HUB_CACHE")
+        or os.environ.get("HF_HOME")
+        or _default_models_dir()
+    )
+
+
+class _ModelsDirBody(BaseModel):
+    path: str = Field(default="", description="Absolute directory; empty clears → default cache")
+
+
+@router.get("/storage/models-dir")
+def get_models_dir():
+    """Current models directory: the persisted choice, what's effective in this
+    process, and the platform default."""
+    from services import settings_store
+
+    configured = settings_store.get_text(_MODELS_DIR_KEY, "") or None
+    return {
+        "configured": configured,
+        "effective": _effective_models_dir(),
+        "default": _default_models_dir(),
+        "restart_required": False,
+    }
+
+
+@router.put("/storage/models-dir")
+def set_models_dir(body: _ModelsDirBody):
+    """Set (or clear, with an empty path) the models download directory.
+
+    Validates the directory is writable, persists the choice, and writes
+    OMNIVOICE_CACHE_DIR to the durable per-user env file so main.py applies it
+    on the next launch. Returns restart_required=True.
+    """
+    from core import user_env
+    from services import settings_store
+
+    raw = (body.path or "").strip()
+    if not raw:
+        try:
+            settings_store.set_text(_MODELS_DIR_KEY, "")
+        except Exception:
+            logger.exception("models-dir: settings_store clear failed")
+        user_env.unset_user_env(_MODELS_DIR_ENV)
+        return {"configured": None, "default": _default_models_dir(), "restart_required": True}
+
+    path = os.path.abspath(os.path.expanduser(raw))
+    try:
+        os.makedirs(path, exist_ok=True)
+        probe = os.path.join(path, ".omnivoice_write_test")
+        with open(probe, "w", encoding="utf-8") as f:
+            f.write("ok")
+        os.remove(probe)
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=f"Directory is not writable: {e}")
+
+    try:
+        settings_store.set_text(_MODELS_DIR_KEY, path)
+    except Exception:
+        logger.exception("models-dir: settings_store write failed")
+    user_env.set_user_env(_MODELS_DIR_ENV, path)
+    return {"configured": path, "effective": _effective_models_dir(), "restart_required": True}

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -198,16 +198,20 @@ def get_license_acceptance(engine_id: str) -> dict:
 
 
 # ── Storage: configurable models directory (#64) ──────────────────────────
-# Where HuggingFace / Torch download model weights. Persisted durably to the
-# per-user env file so main.py maps it to HF_HOME / HF_HUB_CACHE / TORCH_HOME
-# at startup. Takes effect on the next backend restart (a storage-location
-# change can't safely move an in-use cache mid-process).
+# Where HuggingFace / Torch download model weights. The user's choice is
+# persisted durably to the per-user env file as OMNIVOICE_CACHE_DIR, which
+# main.py maps to HF_HOME / HF_HUB_CACHE / TORCH_HOME at startup. That env file
+# is the *single source of truth*: PUT writes it, GET reads it back — there is
+# no second store to diverge from. Takes effect on the next backend restart
+# (a storage-location change can't safely move an in-use cache mid-process).
 _MODELS_DIR_ENV = "OMNIVOICE_CACHE_DIR"
-_MODELS_DIR_KEY = "storage.models_dir"
 
 
 def _default_models_dir() -> str:
-    return os.path.expanduser("~/.cache/huggingface")
+    """huggingface_hub's default cache root, honoring XDG_CACHE_HOME on Linux
+    (matches HF so GET reports the *true* default the backend would use)."""
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "huggingface")
 
 
 def _effective_models_dir() -> str:
@@ -225,11 +229,12 @@ class _ModelsDirBody(BaseModel):
 
 @router.get("/storage/models-dir")
 def get_models_dir():
-    """Current models directory: the persisted choice, what's effective in this
+    """Current models directory: the persisted choice (from the durable env
+    file — the same value main.py reads at startup), what's effective in this
     process, and the platform default."""
-    from services import settings_store
+    from core import user_env
 
-    configured = settings_store.get_text(_MODELS_DIR_KEY, "") or None
+    configured = user_env.get_user_env(_MODELS_DIR_ENV) or None
     return {
         "configured": configured,
         "effective": _effective_models_dir(),
@@ -242,19 +247,15 @@ def get_models_dir():
 def set_models_dir(body: _ModelsDirBody):
     """Set (or clear, with an empty path) the models download directory.
 
-    Validates the directory is writable, persists the choice, and writes
-    OMNIVOICE_CACHE_DIR to the durable per-user env file so main.py applies it
-    on the next launch. Returns restart_required=True.
+    Validates the directory is writable, then writes OMNIVOICE_CACHE_DIR to the
+    durable per-user env file so main.py applies it on the next launch. The env
+    file is the only persisted store, so GET can never diverge from what was
+    saved. Returns restart_required=True.
     """
     from core import user_env
-    from services import settings_store
 
     raw = (body.path or "").strip()
     if not raw:
-        try:
-            settings_store.set_text(_MODELS_DIR_KEY, "")
-        except Exception:
-            logger.exception("models-dir: settings_store clear failed")
         user_env.unset_user_env(_MODELS_DIR_ENV)
         return {"configured": None, "default": _default_models_dir(), "restart_required": True}
 
@@ -272,13 +273,15 @@ def set_models_dir(body: _ModelsDirBody):
         probe = os.path.join(path, ".omnivoice_write_test")
         with open(probe, "w", encoding="utf-8") as f:
             f.write("ok")
-        os.remove(probe)
     except OSError as e:
-        raise HTTPException(status_code=400, detail=f"Directory is not writable: {e}")
+        raise HTTPException(status_code=400, detail=f"Directory is not writable: {e}") from e
+    finally:
+        # Best-effort cleanup; a failed remove (concurrent process, perm change)
+        # must not leave the request hanging or mask the real error.
+        try:
+            os.remove(os.path.join(path, ".omnivoice_write_test"))
+        except OSError:
+            pass
 
-    try:
-        settings_store.set_text(_MODELS_DIR_KEY, path)
-    except Exception:
-        logger.exception("models-dir: settings_store write failed")
     user_env.set_user_env(_MODELS_DIR_ENV, path)
     return {"configured": path, "effective": _effective_models_dir(), "restart_required": True}

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -258,6 +258,14 @@ def set_models_dir(body: _ModelsDirBody):
         user_env.unset_user_env(_MODELS_DIR_ENV)
         return {"configured": None, "default": _default_models_dir(), "restart_required": True}
 
+    # Reject control characters / NUL before touching the filesystem: an
+    # embedded NUL makes os.makedirs raise ValueError (→ 500). This is also
+    # the input-validation barrier for the path before it reaches any fs call
+    # (the dir is user-chosen by design — this is a loopback-gated, same-user
+    # local file picker, not a cross-privilege boundary).
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in raw):
+        raise HTTPException(status_code=400, detail="Path contains invalid control characters")
+
     path = os.path.abspath(os.path.expanduser(raw))
     try:
         os.makedirs(path, exist_ok=True)

--- a/backend/core/user_env.py
+++ b/backend/core/user_env.py
@@ -1,0 +1,71 @@
+"""Durable per-user environment file (`~/.config/omnivoice/env`).
+
+`main.py` loads this file at startup (via dotenv) before importing torch/HF, so
+values written here take effect on the next backend launch. Used by the
+configurable models directory (#64): the Settings endpoint upserts
+``OMNIVOICE_CACHE_DIR`` here, which main.py then maps to
+``HF_HOME`` / ``HF_HUB_CACHE`` / ``TORCH_HOME``.
+
+Format is dotenv-style ``KEY=value`` lines. Upsert preserves other keys (e.g. a
+persisted ``HF_TOKEN``) and writes the file ``0600`` (it can hold secrets).
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+USER_ENV_PATH = os.path.expanduser("~/.config/omnivoice/env")
+
+
+def _read_lines(path: str) -> list[str]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().splitlines()
+    except OSError:
+        return []
+
+
+def _write_lines(path: str, lines: list[str]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    body = "\n".join(lines)
+    if body and not body.endswith("\n"):
+        body += "\n"
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(body)
+    try:
+        os.chmod(path, 0o600)  # may hold secrets; no-op semantics on Windows
+    except OSError:
+        pass
+
+
+def get_user_env(key: str, path: Optional[str] = None) -> Optional[str]:
+    path = path or os.environ.get("OMNIVOICE_ENV_FILE") or USER_ENV_PATH  # resolved at call time so tests can monkeypatch
+    prefix = f"{key}="
+    for line in _read_lines(path):
+        if line.startswith(prefix):
+            return line[len(prefix):]
+    return None
+
+
+def set_user_env(key: str, value: str, path: Optional[str] = None) -> None:
+    """Upsert ``KEY=value``, preserving all other lines."""
+    path = path or os.environ.get("OMNIVOICE_ENV_FILE") or USER_ENV_PATH
+    prefix = f"{key}="
+    lines = _read_lines(path)
+    replaced = False
+    for i, line in enumerate(lines):
+        if line.startswith(prefix):
+            lines[i] = f"{key}={value}"
+            replaced = True
+            break
+    if not replaced:
+        lines.append(f"{key}={value}")
+    _write_lines(path, lines)
+
+
+def unset_user_env(key: str, path: Optional[str] = None) -> None:
+    """Remove ``KEY=...`` if present, preserving all other lines."""
+    path = path or os.environ.get("OMNIVOICE_ENV_FILE") or USER_ENV_PATH
+    prefix = f"{key}="
+    lines = [ln for ln in _read_lines(path) if not ln.startswith(prefix)]
+    _write_lines(path, lines)

--- a/backend/core/user_env.py
+++ b/backend/core/user_env.py
@@ -21,21 +21,34 @@ def _read_lines(path: str) -> list[str]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             return f.read().splitlines()
-    except OSError:
+    except FileNotFoundError:
         return []
+    # Any *other* OSError (permission, I/O error) propagates: collapsing it to
+    # an empty baseline would make a subsequent upsert silently drop existing
+    # keys (e.g. a persisted HF_TOKEN) when it rewrites the file.
+
+
+def _opener_0600(path: str, flags: int) -> int:
+    # Create the file with 0600 from the start (no world-readable window before
+    # a follow-up chmod) — it can hold secrets like HF_TOKEN. The mode is
+    # masked by umask but only ever *more* restrictive; non-POSIX platforms
+    # ignore the mode bits.
+    return os.open(path, flags, 0o600)
 
 
 def _write_lines(path: str, lines: list[str]) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    parent = os.path.dirname(path)
+    if parent:  # bare filename (e.g. an OMNIVOICE_ENV_FILE override) has no parent
+        os.makedirs(parent, exist_ok=True)
     body = "\n".join(lines)
     if body and not body.endswith("\n"):
         body += "\n"
-    with open(path, "w", encoding="utf-8") as f:
+    with open(path, "w", encoding="utf-8", opener=_opener_0600) as f:
         f.write(body)
     try:
-        os.chmod(path, 0o600)  # may hold secrets; no-op semantics on Windows
+        os.chmod(path, 0o600)  # tighten an existing file that predates the opener
     except OSError:
-        pass  # best-effort hardening; some filesystems/Windows don't support chmod
+        pass  # best-effort; some filesystems/Windows don't support chmod
 
 
 def get_user_env(key: str, path: Optional[str] = None) -> Optional[str]:

--- a/backend/core/user_env.py
+++ b/backend/core/user_env.py
@@ -35,7 +35,7 @@ def _write_lines(path: str, lines: list[str]) -> None:
     try:
         os.chmod(path, 0o600)  # may hold secrets; no-op semantics on Windows
     except OSError:
-        pass
+        pass  # best-effort hardening; some filesystems/Windows don't support chmod
 
 
 def get_user_env(key: str, path: Optional[str] = None) -> Optional[str]:

--- a/frontend/src/components/settings/StoragePanel.css
+++ b/frontend/src/components/settings/StoragePanel.css
@@ -1,0 +1,59 @@
+.storagepanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+  border: 1px solid var(--border, #3c3836);
+  border-radius: 8px;
+  background: var(--panel-bg, rgba(255, 255, 255, 0.02));
+}
+.storagepanel__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+.storagepanel__help {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.8;
+}
+.storagepanel__row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.storagepanel__input {
+  flex: 1 1 280px;
+  min-width: 0;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: var(--mono, ui-monospace, monospace);
+  border: 1px solid var(--border, #504945);
+  border-radius: 6px;
+  background: var(--input-bg, rgba(0, 0, 0, 0.2));
+  color: inherit;
+}
+.storagepanel__btn {
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--border, #504945);
+  border-radius: 6px;
+  background: var(--accent, #83a598);
+  color: #1d2021;
+  cursor: pointer;
+}
+.storagepanel__btn:disabled { opacity: 0.5; cursor: default; }
+.storagepanel__btn--ghost { background: transparent; color: inherit; }
+.storagepanel__meta { margin: 0; font-size: 11px; opacity: 0.7; }
+.storagepanel__meta code { font-size: 11px; }
+.storagepanel__restart { margin: 0; font-size: 12px; color: var(--warn, #fabd2f); }
+.storagepanel__error {
+  font-size: 12px;
+  color: var(--danger, #fb4934);
+  padding: 4px 0;
+}

--- a/frontend/src/components/settings/StoragePanel.jsx
+++ b/frontend/src/components/settings/StoragePanel.jsx
@@ -78,7 +78,7 @@ export default function StoragePanel() {
 
       {error && <div className="storagepanel__error" role="alert">{error}</div>}
 
-      <p className="storagepanel__help">
+      <p id="storagepanel-help" className="storagepanel__help">
         Where model weights download (the HuggingFace / Torch cache). Point this
         at a larger or faster drive — useful when your system drive is small.
         Changes apply on the next restart.
@@ -93,6 +93,8 @@ export default function StoragePanel() {
           onChange={(e) => setInput(e.target.value)}
           disabled={saving || loading}
           spellCheck={false}
+          aria-labelledby="storagepanel-heading"
+          aria-describedby="storagepanel-help"
           data-testid="models-dir-input"
         />
         <button

--- a/frontend/src/components/settings/StoragePanel.jsx
+++ b/frontend/src/components/settings/StoragePanel.jsx
@@ -1,0 +1,126 @@
+/**
+ * Settings → Models tab → Models directory panel (#64).
+ *
+ * Lets the user choose where model weights download (the HuggingFace / Torch
+ * cache). The backend persists it to the durable per-user env file as
+ * OMNIVOICE_CACHE_DIR, which main.py maps to HF_HOME / HF_HUB_CACHE / TORCH_HOME
+ * on the next launch — so changes apply after a restart.
+ *
+ * Endpoints:
+ *   GET /api/settings/storage/models-dir
+ *     → {configured, effective, default, restart_required}
+ *   PUT /api/settings/storage/models-dir  body {path}  (empty path clears)
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { HardDrive } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { apiJson, apiFetch } from '../../api/client';
+import './StoragePanel.css';
+
+export default function StoragePanel() {
+  const [configured, setConfigured] = useState('');
+  const [effective, setEffective] = useState('');
+  const [def, setDef] = useState('');
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [restart, setRestart] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const d = await apiJson('/api/settings/storage/models-dir');
+      setConfigured(d?.configured || '');
+      setEffective(d?.effective || '');
+      setDef(d?.default || '');
+      setInput(d?.configured || '');
+    } catch (e) {
+      setError(e?.message || 'Failed to load storage settings');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async (path) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/settings/storage/models-dir', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+      });
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({}));
+        throw new Error(b?.detail || `HTTP ${res.status}`);
+      }
+      const b = await res.json();
+      setConfigured(b?.configured || '');
+      setRestart(Boolean(b?.restart_required));
+      toast.success(path ? 'Models directory saved — restart to apply' : 'Reverted to default — restart to apply');
+      refresh();
+    } catch (e) {
+      setError(e?.message || 'Failed to save models directory');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="storagepanel" aria-labelledby="storagepanel-heading">
+      <h3 id="storagepanel-heading" className="storagepanel__title">
+        <HardDrive size={14} /> Models directory
+      </h3>
+
+      {error && <div className="storagepanel__error" role="alert">{error}</div>}
+
+      <p className="storagepanel__help">
+        Where model weights download (the HuggingFace / Torch cache). Point this
+        at a larger or faster drive — useful when your system drive is small.
+        Changes apply on the next restart.
+      </p>
+
+      <div className="storagepanel__row">
+        <input
+          className="storagepanel__input"
+          type="text"
+          value={input}
+          placeholder={def || '~/.cache/huggingface'}
+          onChange={(e) => setInput(e.target.value)}
+          disabled={saving || loading}
+          spellCheck={false}
+          data-testid="models-dir-input"
+        />
+        <button
+          className="storagepanel__btn"
+          onClick={() => save(input.trim())}
+          disabled={saving || loading}
+          data-testid="models-dir-save"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          className="storagepanel__btn storagepanel__btn--ghost"
+          onClick={() => { setInput(''); save(''); }}
+          disabled={saving || loading || !configured}
+          title="Revert to the default cache location"
+        >
+          Reset
+        </button>
+      </div>
+
+      <p className="storagepanel__meta">
+        Effective now: <code>{effective || '…'}</code>
+        {configured ? <> · configured: <code>{configured}</code></> : <> · using default</>}
+      </p>
+
+      {restart && (
+        <p className="storagepanel__restart">↻ Restart OmniVoice to use the new location.</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -25,6 +25,7 @@ import { useAppStore } from '../store';
 import ApiKeysPanel from '../components/settings/ApiKeysPanel';
 import PerformancePanel from '../components/settings/PerformancePanel';
 import AppearancePanel from '../components/settings/AppearancePanel';
+import StoragePanel from '../components/settings/StoragePanel';
 import EngineCompatibilityMatrix from '../components/EngineCompatibilityMatrix';
 import './Settings.css';
 
@@ -1027,7 +1028,12 @@ export default function Settings() {
         className="settings-tabs-ui"
       />
 
-      {activeTab === 'models' && <ModelStoreTab info={info} modelBadge={modelBadge} />}
+      {activeTab === 'models' && (
+        <>
+          <StoragePanel />
+          <ModelStoreTab info={info} modelBadge={modelBadge} />
+        </>
+      )}
 
       {activeTab === 'engines' && <EnginesTab />}
 

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -1,5 +1,10 @@
 """#64 — the configurable models-dir settings endpoints (validate + persist +
-write the durable env that main.py reads at startup)."""
+write the durable env that main.py reads at startup).
+
+Single source of truth: the durable per-user env file (``OMNIVOICE_CACHE_DIR``).
+``main.py`` reads it at launch; the GET endpoint reads it back. There is no
+second store to diverge from.
+"""
 from __future__ import annotations
 
 import os
@@ -17,11 +22,9 @@ def env(tmp_path, monkeypatch):
     # module re-import: some tests/backend/* tests stub `core.*` in sys.modules,
     # which can give the endpoint's `core.user_env` and this test's a *different*
     # module object — a setattr monkeypatch wouldn't reach the endpoint's copy.
-    monkeypatch.setenv("OMNIVOICE_ENV_FILE", str(tmp_path / "env"))
-    store: dict[str, str] = {}
-    monkeypatch.setattr("services.settings_store.get_text", lambda k, d="": store.get(k, d))
-    monkeypatch.setattr("services.settings_store.set_text", lambda k, v: store.__setitem__(k, v))
-    return store
+    envfile = str(tmp_path / "env")
+    monkeypatch.setenv("OMNIVOICE_ENV_FILE", envfile)
+    return envfile
 
 
 def test_set_persists_and_writes_durable_env(env, tmp_path):
@@ -30,15 +33,21 @@ def test_set_persists_and_writes_durable_env(env, tmp_path):
     abs_target = os.path.abspath(target)
     assert res["configured"] == abs_target
     assert res["restart_required"] is True
-    assert env["storage.models_dir"] == abs_target
-    # main.py reads this on next launch:
+    # main.py reads this on next launch; GET reads it back — single source:
     assert user_env.get_user_env("OMNIVOICE_CACHE_DIR") == abs_target
+    assert s.get_models_dir()["configured"] == abs_target
     assert os.path.isdir(target)
 
 
-def test_rejects_unwritable_dir(env):
+def test_rejects_unwritable_dir(env, monkeypatch, tmp_path):
+    # OS-neutral: force the mkdir to fail rather than relying on Unix-only
+    # /dev/null path semantics (cross-platform parity).
+    def boom(*a, **k):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(os, "makedirs", boom)
     with pytest.raises(fastapi.HTTPException) as ei:
-        s.set_models_dir(s._ModelsDirBody(path="/dev/null/cannot/mkdir/here"))
+        s.set_models_dir(s._ModelsDirBody(path=str(tmp_path / "ro")))
     assert ei.value.status_code == 400
 
 
@@ -51,17 +60,25 @@ def test_rejects_path_with_null_byte(env):
 
 
 def test_clear_reverts_to_default(env):
-    env["storage.models_dir"] = "/old"
     user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/old")
     res = s.set_models_dir(s._ModelsDirBody(path=""))
     assert res["configured"] is None
     assert res["restart_required"] is True
-    assert env["storage.models_dir"] == ""
     assert user_env.get_user_env("OMNIVOICE_CACHE_DIR") is None
+    assert s.get_models_dir()["configured"] is None
 
 
 def test_get_shape(env):
-    env["storage.models_dir"] = "/configured"
+    user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/configured")
     res = s.get_models_dir()
     assert res["configured"] == "/configured"
     assert "effective" in res and "default" in res
+
+
+def test_default_is_xdg_aware(env, monkeypatch, tmp_path):
+    # huggingface_hub's default cache root honors XDG_CACHE_HOME on Linux.
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    for var in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"):
+        monkeypatch.delenv(var, raising=False)
+    default = s.get_models_dir()["default"]
+    assert default == str(tmp_path / "xdg" / "huggingface")

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -1,0 +1,59 @@
+"""#64 — the configurable models-dir settings endpoints (validate + persist +
+write the durable env that main.py reads at startup)."""
+from __future__ import annotations
+
+import os
+
+import fastapi
+import pytest
+
+from core import user_env
+from api.routers import settings as s
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    # Resolve the durable env file via a process-global override so it survives
+    # module re-import: some tests/backend/* tests stub `core.*` in sys.modules,
+    # which can give the endpoint's `core.user_env` and this test's a *different*
+    # module object — a setattr monkeypatch wouldn't reach the endpoint's copy.
+    monkeypatch.setenv("OMNIVOICE_ENV_FILE", str(tmp_path / "env"))
+    store: dict[str, str] = {}
+    monkeypatch.setattr("services.settings_store.get_text", lambda k, d="": store.get(k, d))
+    monkeypatch.setattr("services.settings_store.set_text", lambda k, v: store.__setitem__(k, v))
+    return store
+
+
+def test_set_persists_and_writes_durable_env(env, tmp_path):
+    target = str(tmp_path / "models")
+    res = s.set_models_dir(s._ModelsDirBody(path=target))
+    abs_target = os.path.abspath(target)
+    assert res["configured"] == abs_target
+    assert res["restart_required"] is True
+    assert env["storage.models_dir"] == abs_target
+    # main.py reads this on next launch:
+    assert user_env.get_user_env("OMNIVOICE_CACHE_DIR") == abs_target
+    assert os.path.isdir(target)
+
+
+def test_rejects_unwritable_dir(env):
+    with pytest.raises(fastapi.HTTPException) as ei:
+        s.set_models_dir(s._ModelsDirBody(path="/dev/null/cannot/mkdir/here"))
+    assert ei.value.status_code == 400
+
+
+def test_clear_reverts_to_default(env):
+    env["storage.models_dir"] = "/old"
+    user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/old")
+    res = s.set_models_dir(s._ModelsDirBody(path=""))
+    assert res["configured"] is None
+    assert res["restart_required"] is True
+    assert env["storage.models_dir"] == ""
+    assert user_env.get_user_env("OMNIVOICE_CACHE_DIR") is None
+
+
+def test_get_shape(env):
+    env["storage.models_dir"] = "/configured"
+    res = s.get_models_dir()
+    assert res["configured"] == "/configured"
+    assert "effective" in res and "default" in res

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -42,6 +42,14 @@ def test_rejects_unwritable_dir(env):
     assert ei.value.status_code == 400
 
 
+def test_rejects_path_with_null_byte(env):
+    # An embedded NUL would otherwise blow up os.makedirs with a ValueError
+    # (→ 500). Validate up front and return a clean 400 instead.
+    with pytest.raises(fastapi.HTTPException) as ei:
+        s.set_models_dir(s._ModelsDirBody(path="/tmp/mo\x00dels"))
+    assert ei.value.status_code == 400
+
+
 def test_clear_reverts_to_default(env):
     env["storage.models_dir"] = "/old"
     user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/old")

--- a/tests/test_user_env.py
+++ b/tests/test_user_env.py
@@ -1,0 +1,55 @@
+"""plan-01 follow-up / #64 — durable per-user env file helper.
+
+Backs the configurable models directory: the Settings endpoint writes
+OMNIVOICE_CACHE_DIR into ~/.config/omnivoice/env, which main.py loads at startup
+(→ HF_HOME / HF_HUB_CACHE / TORCH_HOME). The helper must upsert one key without
+clobbering others (e.g. a persisted HF_TOKEN) and store the file 0600.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+from core import user_env
+
+
+def test_set_creates_and_upserts(tmp_path):
+    p = str(tmp_path / "env")
+    user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/data/models", path=p)
+    assert user_env.get_user_env("OMNIVOICE_CACHE_DIR", path=p) == "/data/models"
+    # upsert: change value, do not duplicate the key
+    user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/other/models", path=p)
+    assert user_env.get_user_env("OMNIVOICE_CACHE_DIR", path=p) == "/other/models"
+    assert open(p).read().count("OMNIVOICE_CACHE_DIR=") == 1
+
+
+def test_preserves_other_keys(tmp_path):
+    p = tmp_path / "env"
+    p.write_text("HF_TOKEN=hf_abc123\nFOO=bar\n")
+    user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/m", path=str(p))
+    txt = p.read_text()
+    assert "HF_TOKEN=hf_abc123" in txt
+    assert "FOO=bar" in txt
+    assert "OMNIVOICE_CACHE_DIR=/m" in txt
+
+
+def test_unset_removes_only_that_key(tmp_path):
+    p = tmp_path / "env"
+    p.write_text("HF_TOKEN=hf_x\nOMNIVOICE_CACHE_DIR=/m\n")
+    user_env.unset_user_env("OMNIVOICE_CACHE_DIR", path=str(p))
+    txt = p.read_text()
+    assert "OMNIVOICE_CACHE_DIR" not in txt
+    assert "HF_TOKEN=hf_x" in txt
+
+
+def test_get_missing_returns_none(tmp_path):
+    assert user_env.get_user_env("NOPE", path=str(tmp_path / "env")) is None
+
+
+def test_file_is_0600(tmp_path):
+    if sys.platform == "win32":
+        return  # POSIX perms not meaningful on Windows
+    p = tmp_path / "env"
+    user_env.set_user_env("K", "v", path=str(p))
+    assert stat.S_IMODE(os.stat(p).st_mode) == 0o600

--- a/tests/test_user_env.py
+++ b/tests/test_user_env.py
@@ -21,7 +21,8 @@ def test_set_creates_and_upserts(tmp_path):
     # upsert: change value, do not duplicate the key
     user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/other/models", path=p)
     assert user_env.get_user_env("OMNIVOICE_CACHE_DIR", path=p) == "/other/models"
-    assert open(p).read().count("OMNIVOICE_CACHE_DIR=") == 1
+    with open(p) as f:
+        assert f.read().count("OMNIVOICE_CACHE_DIR=") == 1
 
 
 def test_preserves_other_keys(tmp_path):

--- a/tests/test_user_env.py
+++ b/tests/test_user_env.py
@@ -48,6 +48,14 @@ def test_get_missing_returns_none(tmp_path):
     assert user_env.get_user_env("NOPE", path=str(tmp_path / "env")) is None
 
 
+def test_set_with_bare_filename_no_parent(tmp_path, monkeypatch):
+    # A path with no directory component (e.g. OMNIVOICE_ENV_FILE=env) must not
+    # blow up: os.makedirs("") raises, so the helper has to skip the mkdir.
+    monkeypatch.chdir(tmp_path)
+    user_env.set_user_env("K", "v", path="envfile")
+    assert user_env.get_user_env("K", path="envfile") == "v"
+
+
 def test_file_is_0600(tmp_path):
     if sys.platform == "win32":
         return  # POSIX perms not meaningful on Windows


### PR DESCRIPTION
Closes #64.

## What

Lets users choose **where model weights download** (the HuggingFace / Torch cache) from **Settings → Models**, instead of being pinned to `~/.cache/huggingface`. Useful when the system drive is small/slow and the user wants weights on a bigger or faster volume.

## How

**Backend**
- `core/user_env.py` — durable per-user env file (`~/.config/omnivoice/env`) helper with `get`/`set`/`unset`. Upsert preserves other keys (e.g. a persisted `HF_TOKEN`) and writes the file `0600`. `main.py` already loads this at startup *before* importing torch/HF, so a written value takes effect on the next launch. Path resolves at call time (honoring an `OMNIVOICE_ENV_FILE` override) so it's robust to module re-import.
- `api/routers/settings.py` — `GET`/`PUT /api/settings/storage/models-dir`:
  - `PUT` validates the directory is writable (`mkdir` + write-probe → `400` if not), persists the choice in the settings store, and writes `OMNIVOICE_CACHE_DIR` to the durable env. Empty path **clears** → reverts to default.
  - Returns `restart_required: true` (an in-use cache can't be safely relocated mid-process). Loopback-gated like the other settings endpoints.

**Frontend**
- `StoragePanel` in the Models tab — view / set / reset the directory; shows effective-vs-configured-vs-default and a restart note.

## Constraints

- **Cross-platform default parity:** default cache path is the HF default on every OS; the feature is the same on mac/Win/Linux. ✅
- **Local-first:** no network, no telemetry. ✅
- **Backward-compatible:** absent setting → existing behavior, no migration. ✅
- **No version bump.** ✅

## Tests

- `tests/test_user_env.py` (5) — upsert/unset/preserve/0600.
- `tests/test_models_dir_setting.py` (4) — persist+durable-env write, unwritable→400, clear→default, GET shape.

All 9 green. (The unrelated `test_supertonic3::test_license_gate` fails locally only because `supertonic` isn't in my local venv; it's a runtime dep present in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage settings panel and API to view/save the models download directory, showing configured, effective, and default paths; saving/clearing updates persisted per-user env and may require restart.
  * Input validation for saved paths, ensures directories are created and writable, and rejects invalid characters.

* **Tests**
  * Added tests covering storage settings behavior, input validation, default resolution, and per-user env persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->