### PR TITLE
feat(dub): audio-only dubbing mode (#119)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -253,14 +253,32 @@ _prep_event       = dub_pipeline.prep_event
 _ingest_gen       = dub_pipeline.ingest_pipeline
 
 
+#: Recognised audio extensions for audio-only dubbing (#119). When the client
+#: declares input_type=audio we refuse anything that isn't a known audio
+#: container so a mislabelled video can't slip past the video-skipping branch.
+_AUDIO_EXTS = {".wav", ".mp3", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma"}
+
+
 @router.post("/dub/upload")
-async def dub_upload(video: UploadFile = File(...), job_id: Optional[str] = Form(None)):
-    """Accept video upload, write to disk, queue background prep task.
+async def dub_upload(
+    video: UploadFile = File(...),
+    job_id: Optional[str] = Form(None),
+    input_type: str = Form("video"),
+):
+    """Accept a media upload, write to disk, queue background prep task.
+
+    `input_type` is "video" (default) or "audio". Audio-only jobs (#119) skip
+    scene detection, thumbnailing, and the final video mux — the transcribe →
+    translate → TTS core is identical.
 
     Returns 202 with {job_id, task_id, filename}. Client should open SSE on
-    /tasks/stream/{task_id} to monitor extract/demucs/scene stages and wait for
-    the 'ready' event before starting transcription.
+    /tasks/stream/{task_id} to monitor extract/demucs stages and wait for the
+    'ready' event before starting transcription.
     """
+    input_type = (input_type or "video").lower()
+    if input_type not in ("video", "audio"):
+        raise HTTPException(status_code=400, detail="input_type must be 'video' or 'audio'")
+
     job_id = job_id or str(uuid.uuid4())[:8]
     job_dir = _safe_job_dir(job_id)
     if job_dir is None:
@@ -268,9 +286,15 @@ async def dub_upload(video: UploadFile = File(...), job_id: Optional[str] = Form
             status_code=400,
             detail="Invalid job_id. Must be alphanumeric + hyphens/underscores only, ≤64 chars. Generate a fresh job_id or omit it to auto-create one.",
         )
+    ext = os.path.splitext(video.filename or "video.mp4")[1]
+    if input_type == "audio" and ext.lower() not in _AUDIO_EXTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Audio-only dubbing needs an audio file ({', '.join(sorted(_AUDIO_EXTS))}); got '{ext or 'no extension'}'.",
+        )
+
     os.makedirs(job_dir, exist_ok=True)
 
-    ext = os.path.splitext(video.filename or "video.mp4")[1]
     video_path = os.path.join(job_dir, f"original{ext}")
     with open(video_path, "wb") as f:
         f.write(await video.read())
@@ -280,7 +304,7 @@ async def dub_upload(video: UploadFile = File(...), job_id: Optional[str] = Form
     await task_manager.add_task(
         task_id, "prep",
         _ingest_gen, job_id, job_dir,
-        {"kind": "file", "path": video_path}, filename,
+        {"kind": "file", "path": video_path, "input_type": input_type}, filename,
     )
     return JSONResponse(
         status_code=202,

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -4,6 +4,7 @@ import time
 import uuid
 import asyncio
 import logging
+from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
 
@@ -264,6 +265,42 @@ def _video_stretch_plan_for(job: dict, lang_code: str) -> dict | None:
     return entry
 
 
+#: Audio export formats → ffmpeg codec args. Unknown formats fall back to
+#: AAC/m4a so a bad request can never produce a broken command.
+_AUDIO_FORMAT_CODECS: dict[str, list[str]] = {
+    "wav": ["-c:a", "pcm_s16le"],
+    "m4a": ["-c:a", "aac", "-b:a", "192k"],
+    "mp3": ["-c:a", "libmp3lame", "-q:a", "2"],
+    "flac": ["-c:a", "flac"],
+}
+
+
+def _build_audio_export_cmd(
+    ffmpeg: str,
+    track_path: str,
+    bg_path: Optional[str],
+    out_path: str,
+    fmt: str,
+) -> list[str]:
+    """Build the ffmpeg command for an audio-only dub export (#119).
+
+    No video input, stream-map, or codec — just the dubbed track, optionally
+    mixed with the separated background (``no_vocals``), written to ``out_path``
+    in the requested ``fmt``. Unknown formats fall back to AAC.
+    """
+    codec = _AUDIO_FORMAT_CODECS.get((fmt or "").lower(), _AUDIO_FORMAT_CODECS["m4a"])
+    cmd = [ffmpeg, "-y", "-i", track_path]
+    if bg_path:
+        # Mix the dubbed voice over the original background bed (same weights
+        # as the video mux path) so ambience/music is preserved.
+        cmd += ["-i", bg_path, "-filter_complex",
+                "[0:a][1:a]amix=inputs=2:duration=longest:dropout_transition=2:weights=1.2 0.8[aout]",
+                "-map", "[aout]"]
+    cmd += codec
+    cmd.append(out_path)
+    return cmd
+
+
 @router.get("/dub/download/{job_id}")
 @router.get("/dub/download/{job_id}/{filename}")
 async def dub_download(
@@ -274,6 +311,7 @@ async def dub_download(
     save_path: str = Query("", description="Absolute destination path. If set, mux output is copied there and JSON returned instead of FileResponse."),
     burn_subs: bool = Query(False, description="Burn subtitles into the video stream (forces re-encode). Uses dual-subtitle layout when dual=1."),
     dual: bool = Query(False, description="When burn_subs=1, render translated on top of italicised original."),
+    out_format: str = Query("m4a", description="Audio-only jobs (#119): output container — wav, m4a, mp3, or flac. Ignored for video jobs."),
 ):
     job = _get_job(job_id)
     if not job:
@@ -300,6 +338,52 @@ async def dub_download(
     os.makedirs(exports_dir, exist_ok=True)
     output_path = os.path.join(exports_dir, f"dubbed_video_{stamp}.mp4")
     ffmpeg = find_ffmpeg()
+
+    # ── Audio-only dubbing (#119) ─────────────────────────────────────────
+    # No source video to mux into — export the dubbed track (optionally mixed
+    # with the separated background) straight to an audio container.
+    if (job.get("input_type") or "video").lower() == "audio":
+        if default_track and default_track != "original" and default_track in filtered_tracks:
+            lang_code, track_info = default_track, filtered_tracks[default_track]
+        elif filtered_tracks:
+            lang_code, track_info = next(iter(filtered_tracks.items()))
+        else:
+            raise HTTPException(status_code=400, detail="No dubbed track selected for audio export")
+
+        fmt = (out_format or "m4a").lower()
+        if fmt not in _AUDIO_FORMAT_CODECS:
+            fmt = "m4a"
+        out_path = os.path.join(exports_dir, f"dubbed_audio_{lang_code}_{stamp}.{fmt}")
+        bg = job.get("no_vocals_path") if preserve_bg else None
+        bg = bg if (bg and os.path.exists(bg)) else None
+        cmd = _build_audio_export_cmd(ffmpeg, track_info["path"], bg, out_path, fmt)
+        try:
+            rc, _, stderr = await run_ffmpeg(cmd, timeout=1800.0)
+            if rc != 0:
+                raise Exception(stderr.decode(errors="replace") if stderr else "ffmpeg audio export non-zero")
+        except asyncio.TimeoutError:
+            raise HTTPException(status_code=504, detail="ffmpeg audio export timed out")
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"ffmpeg failed to export dubbed audio: {e}. Verify ffmpeg is installed (`ffmpeg -version`) and the dubbed track exists.",
+            )
+        if not os.path.exists(out_path) or os.path.getsize(out_path) == 0:
+            raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
+        logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
+
+        base_name = os.path.splitext(job.get("filename", "output"))[0]
+        safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
+        dl_name = f"dubbed_{safe_name}_{lang_code}_{stamp}.{fmt}"
+        media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
+        if save_path:
+            return _native_save(out_path, save_path, dl_name, media_type=media_type)
+        return FileResponse(
+            out_path, media_type=media_type,
+            headers={"Content-Disposition": f'attachment; filename="{dl_name}"'},
+        )
 
     # Determine whether this export should drive video through a per-segment
     # stretch graph (Mode B). Stretch is keyed off the default_track's plan

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -353,7 +353,12 @@ async def dub_download(
         fmt = (out_format or "m4a").lower()
         if fmt not in _AUDIO_FORMAT_CODECS:
             fmt = "m4a"
-        out_path = os.path.join(exports_dir, f"dubbed_audio_{lang_code}_{stamp}.{fmt}")
+        # lang_code is already constrained to an existing track key, but
+        # allowlist-sanitize it before it reaches the output path so a path
+        # component can never carry separators/traversal (same pattern as
+        # safe_name below).
+        safe_lang = "".join(c for c in lang_code if c.isalnum() or c in "-_") or "track"
+        out_path = os.path.join(exports_dir, f"dubbed_audio_{safe_lang}_{stamp}.{fmt}")
         bg = job.get("no_vocals_path") if preserve_bg else None
         bg = bg if (bg and os.path.exists(bg)) else None
         cmd = _build_audio_export_cmd(ffmpeg, track_info["path"], bg, out_path, fmt)
@@ -376,7 +381,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{lang_code}_{stamp}.{fmt}"
+        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         if save_path:
             return _native_save(out_path, save_path, dl_name, media_type=media_type)

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -858,6 +858,10 @@ async def ingest_pipeline(
             # prep SSE contract the frontend waits on is unchanged.
             thumb_path = os.path.join(job_dir, "thumb.jpg")
             if input_type == "audio":
+                # No scenes/thumbnail in audio — emit the start/done pair anyway
+                # so the prep SSE stage sequence stays symmetric with the video
+                # path (the frontend's stage tracker expects both).
+                yield prep_event("scene_start")
                 yield prep_event("scene_done", count=0)
                 thumb_path = None
             else:

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -636,6 +636,9 @@ async def ingest_pipeline(
     demucs_start, demucs_done, scene_start, scene_done, ready, error, cancelled.
     """
     youtube_subs_by_lang: dict[str, list[dict]] = {}
+    # Audio-only jobs (#119) skip scene detection + thumbnailing below; the
+    # transcribe → translate → TTS core is identical.
+    input_type = (source.get("input_type") or "video").lower()
     try:
         if source.get("kind") == "url":
             url = source["url"]
@@ -776,6 +779,7 @@ async def ingest_pipeline(
                 "dubbed_tracks": {},
                 "scene_cuts": scene_cuts,
                 "youtube_subs": youtube_subs_by_lang or None,
+                "input_type": input_type,
             }
             put_job(job_id, full_job)
             save_job(job_id, full_job, filename, dur, content_hash)
@@ -799,6 +803,7 @@ async def ingest_pipeline(
                 "dubbed_tracks": {},
                 "scene_cuts": [],
                 "youtube_subs": youtube_subs_by_lang or None,
+                "input_type": input_type,
             }
             put_job(job_id, partial)
             save_job(job_id, partial, filename, dur, content_hash)
@@ -848,39 +853,46 @@ async def ingest_pipeline(
             yield prep_event("demucs_done",
                              has_bg=bool(no_vocals_path and os.path.exists(no_vocals_path)))
 
-            yield prep_event("scene_start")
-            try:
-                p, _, stderr_scene = await run_proc([
-                    ffmpeg, "-i", video_path, "-filter:v",
-                    "select='gt(scene,0.3)',showinfo", "-f", "null", "-",
-                ], timeout=600.0)
-                matches = re.finditer(r"pts_time:([\d\.]+)", stderr_scene.decode(errors="replace"))
-                scene_cuts = [float(m.group(1)) for m in matches]
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning("Scene detection failed for %s: %s", job_id, e)
-                yield prep_event("warning", **failure.build_failure(e, stage="scene", include_diagnostic=False))
-            yield prep_event("scene_done", count=len(scene_cuts))
-
+            # Audio-only jobs (#119) have no video to scan or thumbnail. Skip
+            # both ffmpeg passes but still emit scene_done (count=0) so the
+            # prep SSE contract the frontend waits on is unchanged.
             thumb_path = os.path.join(job_dir, "thumb.jpg")
-            offset = max(0.5, min(1.5, dur * 0.1)) if dur else 1.0
-            try:
-                await run_proc([
-                    ffmpeg, "-y", "-ss", f"{offset:.2f}", "-i", video_path,
-                    "-vframes", "1", "-vf", "scale=320:-2",
-                    "-q:v", "4", thumb_path,
-                ], timeout=30.0)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                logger.warning("Thumbnail extraction failed for %s: %s", job_id, e)
-                yield prep_event("warning", **failure.build_failure(e, stage="thumbnail", include_diagnostic=False))
+            if input_type == "audio":
+                yield prep_event("scene_done", count=0)
+                thumb_path = None
+            else:
+                yield prep_event("scene_start")
+                try:
+                    p, _, stderr_scene = await run_proc([
+                        ffmpeg, "-i", video_path, "-filter:v",
+                        "select='gt(scene,0.3)',showinfo", "-f", "null", "-",
+                    ], timeout=600.0)
+                    matches = re.finditer(r"pts_time:([\d\.]+)", stderr_scene.decode(errors="replace"))
+                    scene_cuts = [float(m.group(1)) for m in matches]
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning("Scene detection failed for %s: %s", job_id, e)
+                    yield prep_event("warning", **failure.build_failure(e, stage="scene", include_diagnostic=False))
+                yield prep_event("scene_done", count=len(scene_cuts))
+
+                offset = max(0.5, min(1.5, dur * 0.1)) if dur else 1.0
+                try:
+                    await run_proc([
+                        ffmpeg, "-y", "-ss", f"{offset:.2f}", "-i", video_path,
+                        "-vframes", "1", "-vf", "scale=320:-2",
+                        "-q:v", "4", thumb_path,
+                    ], timeout=30.0)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.warning("Thumbnail extraction failed for %s: %s", job_id, e)
+                    yield prep_event("warning", **failure.build_failure(e, stage="thumbnail", include_diagnostic=False))
 
             _dub_jobs[job_id].update({
                 "vocals_path": vocals_path,
                 "no_vocals_path": no_vocals_path,
-                "thumb_path": thumb_path if os.path.exists(thumb_path) else None,
+                "thumb_path": thumb_path if (thumb_path and os.path.exists(thumb_path)) else None,
                 "scene_cuts": scene_cuts,
             })
             save_job(job_id, _dub_jobs[job_id], filename, dur, content_hash)

--- a/frontend/src/api/dub.ts
+++ b/frontend/src/api/dub.ts
@@ -4,11 +4,12 @@ import type { DubHistoryResponse, DubTranslateResponse } from './types';
 export async function dubUpload(
   file: File | Blob,
   jobId: string,
-  { signal }: { signal?: AbortSignal } = {},
+  { signal, inputType = 'video' }: { signal?: AbortSignal; inputType?: 'video' | 'audio' } = {},
 ): Promise<unknown> {
   const fd = new FormData();
   fd.append('video', file);
   fd.append('job_id', jobId);
+  fd.append('input_type', inputType);  // #119: audio-only dubbing
   return apiPost('/dub/upload', fd, { signal });
 }
 

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -205,9 +205,9 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     const clientJobId = Math.random().toString(36).slice(2, 10);
     dubClientJobIdRef.current = clientJobId;
     setDubJobId(clientJobId);
-    useAppStore.getState().showPill('loading-model', 'Preparing video…', { cancellable: true });
+    const inputType = useAppStore.getState().dubInputType || 'video';  // #119
+    useAppStore.getState().showPill('loading-model', inputType === 'audio' ? 'Preparing audio…' : 'Preparing video…', { cancellable: true });
     try {
-      const inputType = useAppStore.getState().dubInputType || 'video';  // #119
       const data = await dubUpload(dubVideoFile, clientJobId, { signal: ctrl.signal, inputType });
       setDubJobId(data.job_id); if (data.filename) setDubFilename(data.filename);
       setDubTaskId(data.task_id); setDubPrepStage('extract');

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -207,7 +207,8 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     setDubJobId(clientJobId);
     useAppStore.getState().showPill('loading-model', 'Preparing video…', { cancellable: true });
     try {
-      const data = await dubUpload(dubVideoFile, clientJobId, { signal: ctrl.signal });
+      const inputType = useAppStore.getState().dubInputType || 'video';  // #119
+      const data = await dubUpload(dubVideoFile, clientJobId, { signal: ctrl.signal, inputType });
       setDubJobId(data.job_id); if (data.filename) setDubFilename(data.filename);
       setDubTaskId(data.task_id); setDubPrepStage('extract');
       useAppStore.getState().showPill('loading-model', 'Extracting audio & scenes…', { cancellable: true });

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -411,7 +411,7 @@ export default function DubTab(props) {
                     e.preventDefault();
                     e.currentTarget.classList.remove('is-dragging');
                     const file = e.dataTransfer.files[0];
-                    if (file && (file.type.startsWith('video/') || file.type.startsWith('audio/') || /\.(mp3|wav|flac|m4a|ogg)$/i.test(file.name))) {
+                    if (file && (file.type.startsWith('video/') || file.type.startsWith('audio/') || /\.(mp3|wav|flac|m4a|aac|ogg|opus|wma)$/i.test(file.name))) {
                       setDubVideoFile(file);
                       // #119: an audio file → audio-only dubbing (skip video work, output audio).
                       setDubInputType(file.type.startsWith('audio/') || /\.(mp3|wav|flac|m4a|aac|ogg|opus|wma)$/i.test(file.name) ? 'audio' : 'video');
@@ -466,7 +466,7 @@ export default function DubTab(props) {
                 </>
               )}
 
-              <input type="file" accept="video/*,audio/*,.mp3,.wav,.m4a,.flac,.ogg" id="video-upload" className="dub-hidden-file"
+              <input type="file" accept="video/*,audio/*,.mp3,.wav,.m4a,.aac,.flac,.ogg,.opus,.wma" id="video-upload" className="dub-hidden-file"
                 onChange={e => {
                   const file = e.target.files[0];
                   if (!file) return;

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -93,7 +93,6 @@ export default function DubTab(props) {
   const dubJobId          = useAppStore(s => s.dubJobId);
   const dubStep           = useAppStore(s => s.dubStep);
   const setDubStep        = useAppStore(s => s.setDubStep);
-  const dubInputType      = useAppStore(s => s.dubInputType);
   const setDubInputType   = useAppStore(s => s.setDubInputType);
   const dubPrepStage      = useAppStore(s => s.dubPrepStage);
   const dubPrepProgress   = useAppStore(s => s.dubPrepProgress);

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -93,6 +93,8 @@ export default function DubTab(props) {
   const dubJobId          = useAppStore(s => s.dubJobId);
   const dubStep           = useAppStore(s => s.dubStep);
   const setDubStep        = useAppStore(s => s.setDubStep);
+  const dubInputType      = useAppStore(s => s.dubInputType);
+  const setDubInputType   = useAppStore(s => s.setDubInputType);
   const dubPrepStage      = useAppStore(s => s.dubPrepStage);
   const dubPrepProgress   = useAppStore(s => s.dubPrepProgress);
   const dubFilename       = useAppStore(s => s.dubFilename);
@@ -411,6 +413,8 @@ export default function DubTab(props) {
                     const file = e.dataTransfer.files[0];
                     if (file && (file.type.startsWith('video/') || file.type.startsWith('audio/') || /\.(mp3|wav|flac|m4a|ogg)$/i.test(file.name))) {
                       setDubVideoFile(file);
+                      // #119: an audio file → audio-only dubbing (skip video work, output audio).
+                      setDubInputType(file.type.startsWith('audio/') || /\.(mp3|wav|flac|m4a|aac|ogg|opus|wma)$/i.test(file.name) ? 'audio' : 'video');
                       setDubStep('idle');
                       fileToMediaUrl(file, null).then(urls => setDubLocalBlobUrl(urls));
                     }
@@ -467,6 +471,8 @@ export default function DubTab(props) {
                   const file = e.target.files[0];
                   if (!file) return;
                   setDubVideoFile(file);
+                  // #119: an audio file → audio-only dubbing (skip video work, output audio).
+                  setDubInputType(file.type.startsWith('audio/') || /\.(mp3|wav|flac|m4a|aac|ogg|opus|wma)$/i.test(file.name) ? 'audio' : 'video');
                   setDubStep('idle');
                   setDubLocalBlobUrl(prev => { fileToMediaUrl(file, prev).then(urls => setDubLocalBlobUrl(urls)); return prev; });
                 }} />

--- a/frontend/src/store/dubSlice.ts
+++ b/frontend/src/store/dubSlice.ts
@@ -114,9 +114,13 @@ export interface DubSlice {
   availableEffectPresets: EffectPreset[];
   setAvailableEffectPresets: (presets: EffectPreset[]) => void;
 
+  /** #119: 'video' (default) or 'audio' — audio-only jobs skip video work. */
+  dubInputType: 'video' | 'audio';
+
   // ── Setters (React-style; accept value or updater fn) ─────────────────
   setDubJobId: (v: Updater<string | null>) => void;
   setDubStep: (v: Updater<DubStep>) => void;
+  setDubInputType: (v: Updater<'video' | 'audio'>) => void;
   setDubTaskId: (v: Updater<string | null>) => void;
   setDubPrepStage: (v: Updater<DubPrepStage>) => void;
   setDubPrepProgress: (v: Updater<DubPrepProgress>) => void;
@@ -144,7 +148,7 @@ export interface DubSlice {
 }
 
 const INITIAL: Omit<DubSlice,
-  | 'setDubJobId' | 'setDubStep' | 'setDubTaskId' | 'setDubPrepStage'
+  | 'setDubJobId' | 'setDubStep' | 'setDubInputType' | 'setDubTaskId' | 'setDubPrepStage'
   | 'setDubPrepProgress' | 'setDubCurrentSegId'
   | 'setDubProgress' | 'setDubError' | 'setDubFailure' | 'setIsTranslating' | 'setDubSegments'
   | 'setDubTranscript' | 'setDubFilename' | 'setDubDuration' | 'setDubTracks'
@@ -154,6 +158,7 @@ const INITIAL: Omit<DubSlice,
 > = {
   dubJobId: null,
   dubStep: 'idle',
+  dubInputType: 'video',
   dubTaskId: null,
   dubPrepStage: null,
   dubPrepProgress: { percent: null, speedBps: null, etaS: null, stageStartedAt: null },
@@ -184,6 +189,7 @@ export const createDubSlice: StateCreator<DubSlice, [], [], DubSlice> = (set, ge
 
   setDubJobId:     (v) => set((s) => ({ dubJobId:     resolve(v, s.dubJobId) })),
   setDubStep:      (v) => set((s) => ({ dubStep:      resolve(v, s.dubStep) })),
+  setDubInputType: (v) => set((s) => ({ dubInputType: resolve(v, s.dubInputType) })),
   setDubTaskId:    (v) => set((s) => ({ dubTaskId:    resolve(v, s.dubTaskId) })),
   setDubPrepStage: (v) => set((s) => ({ dubPrepStage: resolve(v, s.dubPrepStage) })),
   setDubPrepProgress: (v) => set((s) => ({ dubPrepProgress: resolve(v, s.dubPrepProgress) })),

--- a/tests/test_dub_audio_export.py
+++ b/tests/test_dub_audio_export.py
@@ -1,0 +1,52 @@
+"""#119 — audio-only dubbing export.
+
+The audio-only branch of /dub/download builds a simple ffmpeg command that
+muxes the dubbed track (optionally mixed with the separated background) into an
+audio container — no video input, no video codec/stream-map/subtitle pass.
+"""
+from __future__ import annotations
+
+from api.routers.dub_export import _build_audio_export_cmd
+
+
+def _flat(cmd):
+    return " ".join(cmd)
+
+
+def test_wav_track_only_no_video():
+    cmd = _build_audio_export_cmd("ffmpeg", "/j/dubbed_de.wav", None, "/j/out.wav", "wav")
+    s = _flat(cmd)
+    # the dubbed track is the only input; never the source media / a video map
+    assert cmd.count("-i") == 1
+    assert "/j/dubbed_de.wav" in s
+    assert "-map" not in s or "0:v" not in s  # no video stream mapping
+    assert "-c:v" not in s                    # no video codec
+    assert "pcm_s16le" in s                   # wav → PCM
+    assert cmd[-1] == "/j/out.wav"
+
+
+def test_m4a_uses_aac():
+    cmd = _build_audio_export_cmd("ffmpeg", "/j/dubbed_de.wav", None, "/j/out.m4a", "m4a")
+    s = _flat(cmd)
+    assert "aac" in s
+    assert "-c:v" not in s
+
+
+def test_mp3_uses_lame():
+    cmd = _build_audio_export_cmd("ffmpeg", "/j/dubbed_de.wav", None, "/j/out.mp3", "mp3")
+    assert "libmp3lame" in _flat(cmd)
+
+
+def test_background_mix_adds_amix_and_second_input():
+    cmd = _build_audio_export_cmd("ffmpeg", "/j/dubbed_de.wav", "/j/no_vocals.wav", "/j/out.m4a", "m4a")
+    s = _flat(cmd)
+    assert cmd.count("-i") == 2              # track + background
+    assert "/j/no_vocals.wav" in s
+    assert "amix" in s                       # mixed, not just concatenated
+    assert "-filter_complex" in s
+
+
+def test_unknown_format_falls_back_to_aac_m4a():
+    # Defensive: an unexpected format string must not produce a broken command.
+    cmd = _build_audio_export_cmd("ffmpeg", "/j/dubbed_de.wav", None, "/j/out.bin", "weird")
+    assert "aac" in _flat(cmd)

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -142,3 +142,48 @@ class TestDubExportUniqueness:
 
         assert res.status_code == 500
         assert "no output file" in res.json()["detail"]
+
+
+class TestAudioOnlyDubbing:
+    """#119 — audio-only jobs export an audio file (no video mux)."""
+
+    def test_audio_only_export_produces_audio_file(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, job_dir = _seed_job_with_tracks(dc, tmp)
+        dc._dub_jobs[job_id]["input_type"] = "audio"
+        exports_dir = job_dir / "exports"
+
+        with patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)):
+            r = client.get(
+                f"/dub/download/{job_id}",
+                params={"preserve_bg": False, "out_format": "m4a", "default_track": "es"},
+            )
+
+        assert r.status_code == 200, r.text
+        audio_files = sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        assert len(audio_files) == 1, [f.name for f in audio_files]
+        # The video-mux path must NOT have run for an audio job.
+        assert not list(exports_dir.glob("dubbed_video_*.mp4"))
+        assert r.headers.get("content-type", "").startswith("audio/")
+
+    def test_audio_only_export_defaults_unknown_format_to_m4a(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, job_dir = _seed_job_with_tracks(dc, tmp)
+        dc._dub_jobs[job_id]["input_type"] = "audio"
+        exports_dir = job_dir / "exports"
+
+        with patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)):
+            r = client.get(f"/dub/download/{job_id}", params={"preserve_bg": False, "out_format": "weird"})
+
+        assert r.status_code == 200, r.text
+        assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+
+    def test_upload_rejects_video_ext_when_audio_mode(self, app_client):
+        client, dc, dx, tmp = app_client
+        r = client.post(
+            "/dub/upload",
+            files={"video": ("clip.mp4", b"\x00" * 16, "video/mp4")},
+            data={"input_type": "audio"},
+        )
+        assert r.status_code == 400
+        assert "audio file" in r.json()["detail"].lower()


### PR DESCRIPTION
Closes #119.

## What

Adds an **audio→audio dubbing** path: upload an audio file, pick source/target language, get **dubbed audio** out — no video processing, no mandatory video output. The transcribe → translate → TTS core is identical; only the video-coupled stages are skipped.

## How

**Backend**
- `dub_core` `/dub/upload`: new `input_type` form field (`"video"` default | `"audio"`). Audio mode validates the upload is a known audio container (`.wav/.mp3/.m4a/.aac/.flac/.ogg/.opus/.wma`, else `400`) and threads `input_type` into the ingest source dict.
- `dub_pipeline` ingest: for audio input, skip the scene-detect + thumbnail ffmpeg passes (still emits `scene_done` `count=0` so the prep SSE contract the frontend waits on is unchanged). `input_type` is persisted on the job. Audio extraction (`-vn`) and Demucs are already audio-generic — reused as-is.
- `dub_export` `/dub/download`: for audio jobs, branch to a focused audio-only export (`_build_audio_export_cmd`) — no video input/stream-map/codec/subtitle/stretch. Outputs `dubbed_audio_{lang}_{stamp}.{wav|m4a|mp3|flac}` via a new `out_format` query (default `m4a`), optionally mixed with the separated background (`no_vocals`). Unknown formats fall back to AAC.

**Frontend**
- `dubSlice`: `dubInputType` state + setter (default `'video'`).
- `DubTab`: auto-selects audio-only mode when an audio file is dropped/picked (the drop zone already accepted audio).
- `dub.ts` / `useDubWorkflow`: pass `input_type` on upload.

## Constraints
- Cross-platform default parity: pure ffmpeg/Python branch, identical on mac/Win/Linux. ✅
- Local-first: no network. ✅
- Backward-compatible: `input_type` defaults to `video`; existing video jobs and on-disk job state are untouched (absent field → video). ✅
- No version bump.

## Tests (11)
- `test_dub_audio_export.py`: `_build_audio_export_cmd` format/mix matrix (wav→pcm, m4a→aac, mp3→lame, bg→amix, unknown→aac).
- `test_dub_export_unique.py::TestAudioOnlyDubbing`: end-to-end audio-only export produces an audio file (asserts **no** `dubbed_video_*.mp4` is created), unknown-format→m4a fallback, and upload rejects a video extension in audio mode.

All green (80 dub-suite tests pass, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio-only dubbing: upload and process standalone audio files
  * Choose audio export format (wav, m4a, mp3, flac)
  * Optionally preserve/mix separated background with dubbed audio

* **Improvements**
  * UI shows "Preparing audio…" vs "Preparing video…" based on file detection
  * Faster audio-only processing by skipping video-specific steps (no scenes/thumbnails)
  * Upload validation rejects mismatched audio/video file types

* **Tests**
  * Added coverage for audio-only export, mixing, format selection, and upload validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->