### PR TITLE
fix(dub): async-ify _pitch_preserving_stretch (Greptile P1 from #133)

### DIFF
--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -1,7 +1,6 @@
 import os
 import json
 import logging
-import subprocess
 import time
 import asyncio
 import numpy as np
@@ -62,11 +61,16 @@ def _atempo_chain(ratio: float) -> str:
     return ",".join(stages)
 
 
-def _pitch_preserving_stretch(
+async def _pitch_preserving_stretch(
     wav: torch.Tensor, target_samples: int, sr: int,
 ) -> torch.Tensor:
     """Time-stretch a (1, samples) tensor to `target_samples` while
     preserving pitch, by piping the audio through `ffmpeg atempo`.
+
+    Async so it never blocks the event loop: it's awaited from the `_stream`
+    generator, and each ffmpeg call is ~50-100 ms — a synchronous
+    ``subprocess.run`` here froze health-checks / SSE / every concurrent
+    request for the whole multi-segment job.
 
     Returns a (1, target_samples) tensor on the same device as input.
     Raises RuntimeError when ffmpeg fails — callers should fall back to
@@ -79,24 +83,24 @@ def _pitch_preserving_stretch(
     ratio = wl / target_samples
     filter_str = _atempo_chain(ratio)
 
-    # Mono float32 via stdin → ffmpeg → stdout. One subprocess per
-    # segment is ~50-100 ms overhead, dwarfed by TTS generation.
+    # Mono float32 via stdin → ffmpeg → stdout. One subprocess per segment,
+    # run off the event loop so concurrent requests stay responsive.
     arr = wav.detach().cpu().to(torch.float32).numpy().reshape(-1).astype(np.float32, copy=False)
-    proc = subprocess.run(
-        [
-            find_ffmpeg(), "-hide_banner", "-loglevel", "error", "-y",
-            "-f", "f32le", "-ar", str(sr), "-ac", "1", "-i", "pipe:0",
-            "-af", filter_str,
-            "-f", "f32le", "-ar", str(sr), "-ac", "1", "pipe:1",
-        ],
-        input=arr.tobytes(),
-        capture_output=True,
+    proc = await asyncio.create_subprocess_exec(
+        find_ffmpeg(), "-hide_banner", "-loglevel", "error", "-y",
+        "-f", "f32le", "-ar", str(sr), "-ac", "1", "-i", "pipe:0",
+        "-af", filter_str,
+        "-f", "f32le", "-ar", str(sr), "-ac", "1", "pipe:1",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
     )
-    if proc.returncode != 0 or not proc.stdout:
+    stdout, stderr = await proc.communicate(input=arr.tobytes())
+    if proc.returncode != 0 or not stdout:
         raise RuntimeError(
-            (proc.stderr.decode(errors="replace") or "atempo failed")[:200]
+            (stderr.decode(errors="replace") or "atempo failed")[:200]
         )
-    out_arr = np.frombuffer(proc.stdout, dtype=np.float32)
+    out_arr = np.frombuffer(stdout, dtype=np.float32)
     # atempo rarely lands exactly on the integer sample count, so
     # pad/trim to the requested slot length.
     if len(out_arr) < target_samples:
@@ -595,7 +599,7 @@ async def dub_generate(job_id: str, req: DubRequest):
                         capped_ratio = min(ratio, MAX_STRETCH_RATIO)
                         capped_target = int(wl / capped_ratio)
                         try:
-                            adjusted = _pitch_preserving_stretch(
+                            adjusted = await _pitch_preserving_stretch(
                                 adjusted, capped_target, sr,
                             )
                             if adjusted.shape[-1] > slot_samples:

--- a/tests/test_pitch_stretch_async.py
+++ b/tests/test_pitch_stretch_async.py
@@ -1,0 +1,31 @@
+"""`_pitch_preserving_stretch` must be async so it doesn't block the event
+loop (Greptile P1 on PR #133's dub-timing path). It's awaited from the
+`_stream` async generator; each ffmpeg invocation is ~50-100ms and on a
+multi-segment job that froze health-checks / SSE / every concurrent request.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import torch
+
+from api.routers.dub_generate import _pitch_preserving_stretch
+
+
+def test_stretch_is_a_coroutine_and_hits_target_length():
+    sr = 16000
+    wav = torch.zeros((1, sr), dtype=torch.float32)  # 1s of silence
+    target = sr // 2                                  # compress to 0.5s
+    coro = _pitch_preserving_stretch(wav, target, sr)
+    assert asyncio.iscoroutine(coro), "must be async so it can't block the loop"
+    out = asyncio.run(coro)
+    assert out.shape == (1, target)
+    assert out.dtype == torch.float32
+
+
+def test_stretch_noop_when_already_target_length():
+    sr = 16000
+    wav = torch.zeros((1, sr), dtype=torch.float32)
+    out = asyncio.run(_pitch_preserving_stretch(wav, sr, sr))
+    assert out.shape[-1] == sr


### PR DESCRIPTION
Addresses the Greptile P1 flagged on #133.

## Problem
`_pitch_preserving_stretch` ran a blocking `subprocess.run()` **inside the `_stream` async generator** (directly on the event loop, not in an executor). Each ffmpeg `atempo` invocation is ~50-100 ms, so a 100-segment `time_stretch` dub job froze the event loop for seconds — health-check polls, status SSE streams, and every concurrent API request stalled.

## Fix
- `_pitch_preserving_stretch` → `async def`, using `asyncio.create_subprocess_exec` + `await proc.communicate(input=…)` (mirrors `run_proc_streaming_stderr` in `dub_pipeline.py`).
- `await` the single call site in `_stream`.
- Dropped the now-unused `import subprocess`.

Behavior is otherwise identical (same ffmpeg command, same pad/trim, same RuntimeError-on-failure contract).

## Tests
`tests/test_pitch_stretch_async.py` — asserts it returns a coroutine (can't block the loop), hits the target length via real ffmpeg, and the no-op (already-target-length) path. 15 pass with the existing timing-strategy suite.

No default-behavior change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Improved audio pitch-preservation functionality to eliminate blocking during audio processing operations, resulting in smoother and more responsive application behavior when handling audio files.

* **Tests**
  * Added comprehensive tests for audio stretching to ensure reliable operation and correct output characteristics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->