### PR TITLE
fix(onboarding): hide DictationDemo when sample assets are absent

### DIFF
--- a/frontend/src/components/DictationDemo.jsx
+++ b/frontend/src/components/DictationDemo.jsx
@@ -61,7 +61,22 @@ export default function DictationDemo({ embedded = false }) {
   const [hotkeyState, setHotkeyState] = useState('unknown'); // unknown | registered | verified
   const [playingId, setPlayingId] = useState(null);
   const [transcripts, setTranscripts] = useState({}); // {scriptId: {state, text, error}}
+  // null = probing, true/false once the demo assets are confirmed present.
+  // The sample WAVs are rendered by scripts/build_demos.sh and may be absent
+  // (e.g. source checkout without a render step). When absent we hide the demo
+  // rather than show cards that fail on click (#119/#124 follow-up).
+  const [assetsAvailable, setAssetsAvailable] = useState(null);
   const audioRef = useRef(null);
+
+  // Probe whether the bundled dictation samples actually exist; hide the whole
+  // demo if not, mirroring DubbingDemo's missing-manifest behavior.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${API}${SCRIPTS[0].wav}`, { method: 'HEAD' })
+      .then((r) => { if (!cancelled) setAssetsAvailable(r.ok); })
+      .catch(() => { if (!cancelled) setAssetsAvailable(false); });
+    return () => { cancelled = true; };
+  }, []);
 
   // Read the registered hotkey on mount.
   useEffect(() => {
@@ -178,6 +193,9 @@ export default function DictationDemo({ embedded = false }) {
         );
     }
   })();
+
+  // No bundled samples on disk → don't render a demo that can't work.
+  if (assetsAvailable === false) return null;
 
   return (
     <section className={`dictation-demo ${embedded ? 'dictation-demo--embedded' : ''}`}>

--- a/frontend/src/test/DictationDemo.test.jsx
+++ b/frontend/src/test/DictationDemo.test.jsx
@@ -34,6 +34,16 @@ describe('DictationDemo', () => {
     expect(screen.getByText(/No hotkey registered/i)).toBeInTheDocument();
   });
 
+  it('hides the demo when the sample assets are missing (HEAD 404)', async () => {
+    // The mount probe HEAD-checks the first sample; a 404 means no rendered
+    // assets on disk → the whole demo should disappear rather than show cards
+    // that fail on click.
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 404 }));
+    const { container } = render(withI18n(<DictationDemo />));
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    expect(screen.queryByText(/Schedule a meeting with Pat/)).not.toBeInTheDocument();
+  });
+
   it('POSTs the bundled WAV to /transcribe when Replay is clicked', async () => {
     const wavBlob = new Blob([new Uint8Array([0, 0, 0, 0])], { type: 'audio/wav' });
     // Make the recognized text deliberately different from the on-card


### PR DESCRIPTION
Follow-up to #119/#133 onboarding demos.

## Problem
`DubbingDemo` and `DemoPresetGrid` already hide themselves when their assets / `is_demo` profiles are missing. `DictationDemo` didn't — it always rendered its three hardcoded cards, which then fail on click without the bundled sample WAVs (`/demo_audio/dictation/*.wav`, rendered by `scripts/build_demos.sh` and absent in a plain source checkout).

## Fix
Mount-time `HEAD` probe of the first sample; if it's not present, the component returns `null` (hides the whole demo), mirroring `DubbingDemo`'s missing-manifest behavior. With assets present, behavior is unchanged.

## Test
`DictationDemo.test.jsx`: HEAD 404 → demo renders nothing (existing 3 tests still pass).

No default-behavior change (when assets ship, the demo shows as before), no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The dictation demo now automatically hides itself when required audio demonstration assets are unavailable, preventing users from encountering incomplete demo experiences or attempting to use non-functional demo features.

* **Tests**
  * Added test coverage to validate that the demo properly hides itself when the necessary audio demonstration assets cannot be accessed or located on startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->