### PR TITLE
docs(install): clarify macOS Gatekeeper "damaged" workaround (#134)

### DIFF
--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -38,7 +38,7 @@ double-click to mount, drag **OmniVoice Studio.app** into `/Applications`.
 If the first launch shows "app is damaged and can't be opened", that's macOS
 Gatekeeper — see the next section.
 
-## Gatekeeper quarantine
+## App is "damaged" / can't be opened (Gatekeeper)
 
 <a id="gatekeeper-quarantine"></a>
 
@@ -46,20 +46,32 @@ If you see **"OmniVoice Studio.app" is damaged and can't be opened. You should
 move it to the Trash**, the app is **not** damaged — that misleading message is
 macOS Gatekeeper blocking an app it can't verify (issues #134, #72).
 
-**Why:** releases are only notarised when the project's Apple Developer ID
-signing pipeline is configured (see "For maintainers" below). On an unsigned
-build, macOS quarantines any copy downloaded outside the App Store.
+**Why:** the build isn't yet notarised by Apple, so macOS quarantines any copy
+downloaded from the internet outside the App Store and shows the "damaged"
+message. This is expected for open-source unsigned builds — releases are only
+notarised once the project's Apple Developer ID signing pipeline is configured
+(see "For maintainers" below). The workaround below is **safe** because you
+downloaded the app from the official repo / Releases page; if you want
+belt-and-braces, verify the SHA-256 against the `*.dmg.sha256` checksum on the
+release page first.
 
-**Fix (unsigned builds):** after dragging the app into `/Applications`, run:
+**Fix — GUI (no terminal):** in Finder, **right-click** (or Control-click) the
+app → **Open** → click **Open** again in the dialog. Or go to **System Settings
+→ Privacy & Security**, scroll to the security section, and click **"Open
+Anyway"** next to the OmniVoice Studio prompt.
+
+**Fix — Terminal:** after dragging the app into `/Applications`, run:
 
 ```bash
-xattr -cr "/Applications/OmniVoice Studio.app"
+xattr -dr com.apple.quarantine "/Applications/OmniVoice Studio.app"
 ```
 
-That clears the quarantine xattr so Gatekeeper stops blocking the launch — a
-one-time fix per install. Alternatively, right-click the app → **Open** →
-**Open** in the dialog. The app is open source; verify the SHA-256 against the
-`*.dmg.sha256` checksum on the release page first if you want belt-and-braces.
+(Adjust the path if you put the app somewhere other than `/Applications`. The
+broader `xattr -cr "/Applications/OmniVoice Studio.app"` also works — it clears
+*all* extended attributes rather than just the quarantine flag.)
+
+That clears the quarantine attribute so Gatekeeper stops blocking the launch — a
+one-time fix per install.
 
 ### For maintainers — enabling notarised builds
 


### PR DESCRIPTION
## What

Clarifies the macOS Gatekeeper "**'OmniVoice Studio.app' is damaged and can't be opened**" workaround in `docs/install/macos.md`.

The doc already had a Gatekeeper section; this PR:

- Renames the heading to **"App is 'damaged' / can't be opened (Gatekeeper)"** so users searching the exact symptom land on it.
- Spells out both fix paths explicitly:
  - **GUI:** right-click the app -> **Open** -> **Open**, or **System Settings -> Privacy & Security -> "Open Anyway"**.
  - **Terminal:** `xattr -dr com.apple.quarantine "/Applications/OmniVoice Studio.app"` (with the broader `xattr -cr` noted as an alternative).
- Explains **why** macOS shows "damaged" (the build isn't notarised yet, so downloaded copies get quarantined) and **why the workaround is safe** (downloaded from the official repo / Releases page; SHA-256 verifiable against the release checksum).

## Why

Closes the gap for #134 (and #72). The proper fix — Apple Developer ID signing + notarisation — is already wired into `release.yml` and activates once the maintainer adds the documented Apple secrets; until then every macOS user hits this hard block. This gives them an immediate, safe, documented unblock.

Docs-only change. Not closing #134 — proper notarisation is still pending the Apple Developer cert.

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote macOS installation troubleshooting section for the Gatekeeper "app is damaged" issue with improved clarity.
  * Separated remediation into two distinct paths: GUI-based and Terminal-based approaches for better user guidance.
  * Enhanced instructions with clarified optional command variants for resolving security restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->