### PR TITLE
fix(windows): port-conflict kill + Triton/torch.compile disable (salvaged from #85)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,16 @@
 import os
 import sys
 
+# Triton is unavailable on Windows — disable torch.compile / dynamo / inductor
+# to prevent TritonMissing errors at inference time. Must be set before torch
+# is imported (it is lazily imported in services/model_manager.py). Uses
+# setdefault so an explicit user-set value is never overridden, and is guarded
+# to win32 so cross-platform default behavior is unchanged.
+if sys.platform == "win32":
+    os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
+    os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
+    os.environ.setdefault("TORCHINDUCTOR_DISABLE", "1")
+
 # Ensure `backend/` is on sys.path so bare imports like `from core.config`
 # work regardless of how uvicorn is invoked:
 #   - `uvicorn main:app`           (cwd = backend/)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,14 @@
 import os
 import sys
 
+# Ensure `backend/` is on sys.path so bare imports like `from core.config`
+# work regardless of how uvicorn is invoked:
+#   - `uvicorn main:app`           (cwd = backend/)
+#   - `uvicorn backend.main:app`   (cwd = /app, Docker)
+_backend_dir = os.path.dirname(os.path.abspath(__file__))
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+
 # Triton is unavailable on Windows — disable torch.compile / dynamo / inductor
 # to prevent TritonMissing errors at inference time. Must be set before torch
 # is imported (it is lazily imported in services/model_manager.py). Uses
@@ -10,14 +18,6 @@ if sys.platform == "win32":
     os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
     os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
     os.environ.setdefault("TORCHINDUCTOR_DISABLE", "1")
-
-# Ensure `backend/` is on sys.path so bare imports like `from core.config`
-# work regardless of how uvicorn is invoked:
-#   - `uvicorn main:app`           (cwd = backend/)
-#   - `uvicorn backend.main:app`   (cwd = /app, Docker)
-_backend_dir = os.path.dirname(os.path.abspath(__file__))
-if _backend_dir not in sys.path:
-    sys.path.insert(0, _backend_dir)
 
 try:
     import dotenv

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -97,7 +97,38 @@ pub fn kill_orphan_on_port(port: u16) {
 }
 
 #[cfg(not(unix))]
-pub fn kill_orphan_on_port(_port: u16) {}
+pub fn kill_orphan_on_port(port: u16) {
+    // `netstat -ano` lists listening sockets with their owning PID.
+    // Parse the output to find the process listening on exactly `port`.
+    let out = match Command::new("netstat").args(["-ano", "-p", "TCP"]).output() {
+        Ok(o) => o,
+        Err(_) => return,
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Match the local address ending in ":PORT" exactly to avoid false
+    // positives (e.g. :3900 must not match port 39000).
+    let port_suffix = format!(":{}", port);
+    for line in stdout.lines() {
+        if !line.to_uppercase().contains("LISTENING") {
+            continue;
+        }
+        // Local address is the second whitespace-delimited field.
+        // Format: "  TCP    0.0.0.0:3900           0.0.0.0:0   LISTENING   1234"
+        let local_addr = line.split_whitespace().nth(1).unwrap_or("");
+        if !local_addr.ends_with(&port_suffix) {
+            continue;
+        }
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if let Some(pid_str) = parts.last() {
+            if let Ok(pid) = pid_str.parse::<u32>() {
+                log::warn!("Killing orphan process {} on port {} (Windows)", pid, port);
+                let _ = Command::new("taskkill")
+                    .args(["/PID", &pid.to_string(), "/F"])
+                    .output();
+            }
+        }
+    }
+}
 
 // ── Log paths ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Salvages the two safe, valuable Windows fixes from community PR #85 (author: @caaaaaleb), without the parts that would regress all users. The original PR bundled good Windows fixes with a dangerous default-behavior change plus a large amount of unrelated churn, so we are declining it as-is and landing the good parts cleanly here. **Full credit to @caaaaaleb** (co-authored on the commit).

## What was salvaged

1. **`frontend/src-tauri/src/backend.rs` — real Windows `kill_orphan_on_port`.**
   The `#[cfg(not(unix))]` branch was a no-op (`pub fn kill_orphan_on_port(_port: u16) {}`). It now parses `netstat -ano -p TCP` for the `LISTENING` socket on exactly `port` (suffix-matched on `":PORT"` to avoid e.g. `:3900` matching port `39000`) and kills the owning PID via `taskkill /PID <pid> /F`. Behind `#[cfg(not(unix))]`; the unix branch is untouched and the signature now matches it (`pub fn kill_orphan_on_port(port: u16)`).

2. **`backend/main.py` — Windows Triton disable block.**
   On `sys.platform == "win32"`, defaults `TORCH_COMPILE_DISABLE` / `TORCHDYNAMO_DISABLE` / `TORCHINDUCTOR_DISABLE` to `"1"` before torch is imported. Triton has no Windows wheel, so this prevents `TritonMissing`/dynamo errors. Uses `os.environ.setdefault` (never overrides an explicit user value) and is `win32`-guarded — cross-platform default behavior is unchanged.

## What was intentionally NOT salvaged (why we declined #85 as-is)

- **The forced offline mode** — `os.environ["HF_HUB_OFFLINE"] = "1"` in `main.py` and the `local_files_only=True` / `HF_HUB_OFFLINE` save-restore in `model_manager.py`. This **breaks first-run model downloads for every user** — downloading models on first use is the core value prop. Offline mode must stay **opt-in**, only when the user sets `HF_HUB_OFFLINE` themselves. Existing download behavior is left untouched.
- **The `model_manager.py` torch.compile / `_get_gpu_pool` changes** — already present on `main` in a superior form: the `should_torch_compile()` gating (plan-02 / #65, which gates on Triton availability and falls back to eager) and the existing `_get_gpu_pool()` lazy pool. Applying #85's cruder `TORCH_COMPILE_DISABLE` env check would be a regression, so `model_manager.py` is not touched.
- **The 512-line README rewrite**, the ~50 frontend `.jsx` formatting-only diffs, and the `personalities.py` `attrs` additions — all out of scope for a Windows-fix salvage.

## Verification

- `cargo check` (host/macOS, unix build): passes clean.
- The Windows MSVC target isn't fully cross-linkable on this host (a transitive C dep, `ring`, needs the Windows SDK), so the exact `#[cfg(not(unix))]` `kill_orphan_on_port` body was type-checked in isolation against `x86_64-pc-windows-msvc`: compiles clean.
- `python -c "import ast; ast.parse(...)"` on `backend/main.py` and `backend/services/model_manager.py`: both parse OK.

Refs #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows startup to avoid platform-specific inference errors by adjusting startup environment settings.
  * Enhanced Windows process cleanup to detect and reliably terminate orphaned backend processes holding ports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->