### PR TITLE
test: scrub brand name from whisper segmentation fixture

### DIFF
--- a/tests/fixtures/whisper_screenshot.json
+++ b/tests/fixtures/whisper_screenshot.json
@@ -1,13 +1,13 @@
 {
   "language": "en",
-  "text": "Most hiring team much time on the Same screening same shortlisting and again. So we built Yupc You can create in templates yourse Then you schedule intervie The AI then runs the interview while it After that, you ge stru c tured report with Try Yupcha if",
+  "text": "Most hiring team much time on the Same screening same shortlisting and again. So we built Acme You can create in templates yourse Then you schedule intervie The AI then runs the interview while it After that, you ge stru c tured report with Try Acme if",
   "chunks": [
     {"text": "Most hiring team", "timestamp": [0.0, 1.2]},
     {"text": "much time on the", "timestamp": [1.2, 2.1]},
     {"text": "Same screening", "timestamp": [2.1, 3.0]},
     {"text": "same shortlisting", "timestamp": [3.0, 4.4]},
     {"text": "and again.", "timestamp": [4.4, 5.2]},
-    {"text": "So we built Yupc", "timestamp": [5.2, 6.6]},
+    {"text": "So we built Acme", "timestamp": [5.2, 6.6]},
     {"text": "You can create in", "timestamp": [6.6, 7.9]},
     {"text": "templates yourse", "timestamp": [7.9, 9.0]},
     {"text": "Then you", "timestamp": [9.0, 9.7]},
@@ -19,6 +19,6 @@
     {"text": "stru", "timestamp": [15.1, 15.3]},
     {"text": "c", "timestamp": [15.3, 15.4]},
     {"text": "tured report with", "timestamp": [15.4, 16.7]},
-    {"text": "Try Yupcha if", "timestamp": [16.7, 17.9]}
+    {"text": "Try Acme if", "timestamp": [16.7, 17.9]}
   ]
 }

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -121,7 +121,7 @@ class TestSegmentTranscript:
             ("Same screening", 2.1, 3.0),
             ("same shortlisting", 3.0, 4.4),
             ("and again.", 4.4, 5.2),
-            ("So we built Yupc", 5.2, 6.6),
+            ("So we built Acme", 5.2, 6.6),
             ("You can create in", 6.6, 7.9),
             ("templates yourse", 7.9, 9.0),
             ("Then you", 9.0, 9.7),
@@ -133,7 +133,7 @@ class TestSegmentTranscript:
             ("stru", 15.1, 15.3),
             ("c", 15.3, 15.4),
             ("tured report with", 15.4, 16.7),
-            ("Try Yupcha if", 16.7, 17.9),
+            ("Try Acme if", 16.7, 17.9),
         )
         segs = segment_transcript(result, duration=18.0)
 


### PR DESCRIPTION
The `whisper_screenshot` transcription fixture (`tests/fixtures/whisper_screenshot.json`) and its segmentation test referenced a real product/brand name in the sample transcript. Swapped it for the neutral placeholder `Acme` (fixture `text` + chunks + the expected-segment assertions in `test_segmentation.py`), keeping the consolidation behavior the test validates identical. `git grep` confirms no trace remains in any tracked file; `test_segmentation.py` stays green (26 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mock data in segmentation tests to use different sample text values. No functional changes to test logic or assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->