### PR TITLE
feat(network): user-configurable backend / LAN-share / UI ports

### DIFF
--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -38,6 +38,21 @@ _is_cuda = torch.cuda.is_available()
 psutil.cpu_percent(interval=None)
 
 
+def _ui_port() -> int:
+    """The Vite UI dev-server port, single-sourced from OMNIVOICE_UI_PORT.
+
+    Mirrors the resolver in main.py (kept local to avoid importing the app
+    module). Falls back to 3901 on a missing or malformed value.
+    """
+    raw = os.environ.get("OMNIVOICE_UI_PORT")
+    if raw is None:
+        return 3901
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 3901
+
+
 def _has_hf_token() -> bool:
     # Phase 1 AUTH-01..06 cascade. Delegates to the 3-source resolver
     # (App → Env → HF-CLI) instead of reading env/HF-CLI directly. This
@@ -171,6 +186,9 @@ def system_info():
             "share_port": network_share.get_state().share_port,
             "lan_addresses": network_share.get_state().lan_addresses,
             "pin_required": bool(network_share.get_state().pin),
+            "backend_port": network_share.backend_port(),
+            "share_port_base": network_share.share_port_base(),
+            "ui_port": _ui_port(),
         }
     except Exception as e:
         logger.exception("system_info failed — returning safe defaults")
@@ -191,6 +209,9 @@ def system_info():
             "share_port": network_share.get_state().share_port,
             "lan_addresses": network_share.get_state().lan_addresses,
             "pin_required": bool(network_share.get_state().pin),
+            "backend_port": network_share.backend_port(),
+            "share_port_base": network_share.share_port_base(),
+            "ui_port": _ui_port(),
             "error": str(e),
         }
 
@@ -555,7 +576,15 @@ PERSISTENT_KEYS = {
     "TRANSLATE_BASE_URL", "TRANSLATE_API_KEY", "TRANSLATE_MODEL",
     "DEEPL_API_KEY", "DEEPL_BASE_URL",
     "MICROSOFT_API_KEY", "MICROSOFT_BASE_URL",
+    # User-configurable network ports. Persisted so they survive restarts;
+    # the Rust sidecar reads OMNIVOICE_PORT at startup and the backend derives
+    # the LAN-share/UI ports from the others.
+    "OMNIVOICE_PORT", "OMNIVOICE_SHARE_PORT", "OMNIVOICE_UI_PORT",
 }
+
+# Keys whose value must be a valid TCP port (1024–65535). Validated before
+# being set so a bad value never reaches uvicorn / the share listener.
+_PORT_KEYS = {"OMNIVOICE_PORT", "OMNIVOICE_SHARE_PORT", "OMNIVOICE_UI_PORT"}
 
 
 @router.post("/system/set-env")
@@ -600,6 +629,22 @@ async def set_env_var(body: dict):
                 raise HTTPException(
                     status_code=400,
                     detail=f"File not found: {value}",
+                )
+        # Port keys must be a numeric string in the unprivileged range so a
+        # typo can't drop the backend onto a privileged port (<1024) or an
+        # out-of-range value uvicorn would reject at bind time.
+        if key in _PORT_KEYS:
+            try:
+                port_n = int(value)
+            except (TypeError, ValueError):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid port for {key}: '{value}' is not a number.",
+                )
+            if not (1024 <= port_n <= 65535):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid port for {key}: must be between 1024 and 65535.",
                 )
         os.environ[key] = value
         logger.info("Set environment variable: %s (length=%d)", key, len(value))

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -44,6 +44,9 @@ class SystemInfoResponse(BaseModel):
     share_port: int | None = None
     lan_addresses: list[str] = []
     pin_required: bool = False
+    backend_port: int = 3900
+    share_port_base: int = 3901
+    ui_port: int = 3901
 
 
 class ModelStatusResponse(BaseModel):

--- a/backend/main.py
+++ b/backend/main.py
@@ -538,9 +538,22 @@ class NetworkAccessMiddleware:
         return await self.app(scope, receive, send)
 
 
+# UI dev-server port — single-sourced from OMNIVOICE_UI_PORT so a user who
+# moves the Vite dev server off 3901 still gets a matching CORS allow-list.
+def _ui_port() -> int:
+    raw = os.environ.get("OMNIVOICE_UI_PORT")
+    if raw is None:
+        return 3901
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 3901
+
+
+_ui = _ui_port()
 _allowed = os.environ.get(
     "OMNIVOICE_ALLOWED_ORIGINS",
-    "http://localhost:3901,http://127.0.0.1:3901,tauri://localhost,http://tauri.localhost",
+    f"http://localhost:{_ui},http://127.0.0.1:{_ui},tauri://localhost,http://tauri.localhost",
 ).split(",")
 
 app.add_middleware(
@@ -634,15 +647,19 @@ if __name__ == "__main__":
     )
     args, _unknown = parser.parse_known_args()
 
+    # Single-sourced from OMNIVOICE_PORT so the bare `python main.py` path and
+    # `--health-check` agree with the Rust sidecar / uvicorn-CLI `--port`.
+    _port = network_share.backend_port()
+
     if args.health_check:
-        HEALTH_URL = "http://127.0.0.1:3900/health"
+        HEALTH_URL = f"http://127.0.0.1:{_port}/health"
         TIMEOUT_S = 60
         INTERVAL_S = 5
 
         def _serve():
             # log_level="warning" silences the per-request access log spam
             # so the smoke output stays readable in GH Actions.
-            uvicorn.run(app, host="127.0.0.1", port=3900, log_level="warning")
+            uvicorn.run(app, host="127.0.0.1", port=_port, log_level="warning")
 
         t = threading.Thread(target=_serve, daemon=True)
         t.start()
@@ -675,4 +692,4 @@ if __name__ == "__main__":
     # set OMNIVOICE_BIND_HOST=0.0.0.0 explicitly (see deploy/docker-compose.yml)
     # — the host-side port mapping is what enforces 127.0.0.1-only there.
     _bind_host = os.environ.get("OMNIVOICE_BIND_HOST", "127.0.0.1")
-    uvicorn.run(app, host=_bind_host, port=3900)
+    uvicorn.run(app, host=_bind_host, port=_port)

--- a/backend/services/network_share.py
+++ b/backend/services/network_share.py
@@ -6,6 +6,7 @@ are untouched (no restart). Disabling stops it, closing the 0.0.0.0 socket.
 Loopback-only by default: nothing binds 0.0.0.0 until enable() is called.
 """
 import asyncio
+import os
 import secrets
 import socket
 from dataclasses import dataclass, field
@@ -14,7 +15,42 @@ from typing import Optional
 import psutil
 import uvicorn
 
-BACKEND_PORT = 3900  # must match backend/main.py uvicorn.run(port=...)
+_DEFAULT_BACKEND_PORT = 3900  # must match backend/main.py uvicorn.run(port=...)
+
+
+def backend_port() -> int:
+    """The port the main backend listens on.
+
+    Single source of truth is the ``OMNIVOICE_PORT`` env var (read by the Rust
+    sidecar at startup and passed through to uvicorn's ``--port``). LAN-share
+    and Tailscale derive their target ports from this so a user who runs the
+    backend on a custom port gets a consistent share/proxy port. Falls back to
+    the default on a missing or malformed value — never throws.
+    """
+    raw = os.environ.get("OMNIVOICE_PORT")
+    if raw is None:
+        return _DEFAULT_BACKEND_PORT
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_BACKEND_PORT
+
+
+def share_port_base() -> int:
+    """The first port LAN sharing tries to bind on 0.0.0.0.
+
+    Defaults to ``backend_port() + 1`` (e.g. 3901 for the default 3900), but
+    can be overridden with ``OMNIVOICE_SHARE_PORT``. ``enable()`` probes
+    upward from here for a free port. Falls back to the default on a missing
+    or malformed value — never throws.
+    """
+    raw = os.environ.get("OMNIVOICE_SHARE_PORT")
+    if raw is None:
+        return backend_port() + 1
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return backend_port() + 1
 
 
 @dataclass
@@ -67,7 +103,7 @@ async def enable(app) -> ShareState:
     global _server, _task, _state
     if _state.enabled:
         return _state
-    port = _find_free_port(BACKEND_PORT + 1)
+    port = _find_free_port(share_port_base())
     pin = _gen_pin()
     config = uvicorn.Config(app, host="0.0.0.0", port=port, log_level="warning")
     server = uvicorn.Server(config)

--- a/backend/services/tailscale.py
+++ b/backend/services/tailscale.py
@@ -12,7 +12,7 @@ import json
 import shutil
 import subprocess
 
-from services.network_share import BACKEND_PORT
+from services import network_share
 
 _ADMIN_DNS = "https://login.tailscale.com/admin/dns"
 
@@ -58,7 +58,9 @@ def _run(args):
         return {"ok": False, "error": str(e)}
 
 
-def serve_enable(port: int = BACKEND_PORT) -> dict:
+def serve_enable(port: int | None = None) -> dict:
+    if port is None:
+        port = network_share.backend_port()
     cli = _cli()
     if not cli:
         return {"ok": False, "error": "Tailscale CLI not found. Install Tailscale and sign in first."}

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -229,6 +229,11 @@ pub fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Opt
     let err_log_file = fs::File::create(&err_path).ok();
 
     let mut env: Vec<(String, String)> = vec![("PYTHONUNBUFFERED".into(), "1".into())];
+    // Pin the child's OMNIVOICE_PORT to the value Rust resolved so Python's
+    // network_share.backend_port() always agrees with the uvicorn --port we
+    // pass below — otherwise a user-set OMNIVOICE_PORT would change the
+    // LAN-share/Tailscale target while the listener stayed on the Rust port.
+    env.push(("OMNIVOICE_PORT".into(), backend_port().to_string()));
     if cfg!(target_os = "windows") {
         env.push(("TORCHDYNAMO_DISABLE".into(), "1".into()));
         env.push(("HF_HUB_DISABLE_SYMLINKS_WARNING".into(), "1".into()));

--- a/frontend/src/components/settings/SharingPanel.css
+++ b/frontend/src/components/settings/SharingPanel.css
@@ -106,3 +106,22 @@
   line-height: 1.4;
   opacity: 0.7;
 }
+.sharingpanel__envname {
+  padding: 2px 6px;
+  font-size: 11px;
+  font-family: var(--mono, ui-monospace, monospace);
+  border: 1px solid var(--border, #504945);
+  border-radius: 4px;
+  background: var(--input-bg, rgba(0, 0, 0, 0.2));
+  opacity: 0.85;
+}
+.sharingpanel__portinput {
+  width: 100px;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: var(--mono, ui-monospace, monospace);
+  border: 1px solid var(--border, #504945);
+  border-radius: 6px;
+  background: var(--input-bg, rgba(0, 0, 0, 0.2));
+  color: inherit;
+}

--- a/frontend/src/components/settings/SharingPanel.jsx
+++ b/frontend/src/components/settings/SharingPanel.jsx
@@ -34,6 +34,47 @@ export default function SharingPanel() {
   const [url, setUrl] = useState('');
   const [note, setNote] = useState('');
   const [qr, setQr] = useState('');
+  // Port configuration (read from /system/info; LAN-share port is editable).
+  const [ports, setPorts] = useState(null);
+  const [sharePortInput, setSharePortInput] = useState('');
+  const [savingPort, setSavingPort] = useState(false);
+
+  // Fetch the resolved port config once on mount; cancel-safe.
+  useEffect(() => {
+    const ctrl = { aborted: false };
+    (async () => {
+      try {
+        const info = await apiJson('/system/info');
+        if (ctrl.aborted) return;
+        setPorts(info);
+        if (info?.share_port_base != null) {
+          setSharePortInput(String(info.share_port_base));
+        }
+      } catch {
+        // Loopback-only; if unreachable just hide the ports subsection.
+        if (!ctrl.aborted) setPorts(null);
+      }
+    })();
+    return () => { ctrl.aborted = true; };
+  }, []);
+
+  const saveSharePort = async () => {
+    const n = Number(sharePortInput);
+    if (!Number.isInteger(n) || n < 1024 || n > 65535) {
+      toast.error('Enter a port between 1024 and 65535');
+      return;
+    }
+    setSavingPort(true);
+    try {
+      await apiPost('/system/set-env', { key: 'OMNIVOICE_SHARE_PORT', value: String(n) });
+      setPorts((p) => (p ? { ...p, share_port_base: n } : p));
+      toast.success('LAN-share port saved — applies next time you enable sharing');
+    } catch (e) {
+      toast.error(`Could not save port: ${e.message}`);
+    } finally {
+      setSavingPort(false);
+    }
+  };
 
   const refresh = useCallback(async (signal) => {
     setLoading(true);
@@ -137,6 +178,59 @@ export default function SharingPanel() {
         </p>
         <NetworkToggle />
       </div>
+
+      {/* ── Ports ────────────────────────────────────────────────────── */}
+      {ports && (
+        <div className="sharingpanel__section" data-testid="sharing-ports">
+          <h4 className="sharingpanel__subtitle">
+            <Globe size={12} /> Ports
+          </h4>
+          <p className="sharingpanel__subhelp">
+            These are set via environment variables read at startup. Change the
+            backend or UI port by setting the variable and restarting OmniVoice.
+          </p>
+
+          <div className="sharingpanel__row">
+            <span>Backend port</span>
+            <code className="sharingpanel__addr" data-testid="port-backend">{ports.backend_port}</code>
+            <code className="sharingpanel__envname">OMNIVOICE_PORT</code>
+          </div>
+
+          <div className="sharingpanel__row">
+            <span>UI port</span>
+            <code className="sharingpanel__addr" data-testid="port-ui">{ports.ui_port}</code>
+            <code className="sharingpanel__envname">OMNIVOICE_UI_PORT</code>
+          </div>
+
+          <div className="sharingpanel__row">
+            <label htmlFor="share-port-input">LAN-share port</label>
+            <input
+              id="share-port-input"
+              type="number"
+              min={1024}
+              max={65535}
+              value={sharePortInput}
+              onChange={(e) => setSharePortInput(e.target.value)}
+              className="sharingpanel__portinput"
+              data-testid="port-share-input"
+            />
+            <code className="sharingpanel__envname">OMNIVOICE_SHARE_PORT</code>
+            <button
+              type="button"
+              className="sharingpanel__btn"
+              onClick={saveSharePort}
+              disabled={savingPort}
+              data-testid="port-share-save"
+            >
+              {savingPort ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+          <p className="sharingpanel__note">
+            Backend and UI ports apply on restart. The LAN-share port applies
+            next time you enable sharing.
+          </p>
+        </div>
+      )}
 
       {/* ── Tailscale ────────────────────────────────────────────────── */}
       <div className="sharingpanel__section" data-testid="sharing-tailscale">

--- a/frontend/src/components/settings/SharingPanel.test.jsx
+++ b/frontend/src/components/settings/SharingPanel.test.jsx
@@ -10,11 +10,30 @@ describe('SharingPanel', () => {
   it('shows Tailscale "not detected" when CLI absent', async () => {
     global.fetch = vi.fn((url) => {
       if (String(url).includes('tailscale/status')) return Promise.resolve({ ok: true, json: async () => ({ installed: false }) });
+      if (String(url).includes('/system/info')) return Promise.resolve({ ok: true, json: async () => ({ backend_port: 3900, share_port_base: 3901, ui_port: 3901 }) });
       return Promise.resolve({ ok: true, json: async () => ({ enabled: false }) });
     });
     render(<SharingPanel />);
     // Both the explanatory copy and the install button surface the phrase, so
     // assert at least one node renders rather than requiring a unique match.
     await waitFor(() => expect(screen.getAllByText(/not detected|install tailscale/i).length).toBeGreaterThan(0));
+  });
+
+  it('renders the ports subsection with values from /system/info', async () => {
+    global.fetch = vi.fn((url) => {
+      if (String(url).includes('tailscale/status')) return Promise.resolve({ ok: true, json: async () => ({ installed: false }) });
+      if (String(url).includes('/system/info')) return Promise.resolve({ ok: true, json: async () => ({ backend_port: 4000, share_port_base: 4001, ui_port: 4100 }) });
+      return Promise.resolve({ ok: true, json: async () => ({ enabled: false }) });
+    });
+    render(<SharingPanel />);
+    await waitFor(() => expect(screen.getByTestId('sharing-ports')).toBeInTheDocument());
+    expect(screen.getByTestId('port-backend')).toHaveTextContent('4000');
+    expect(screen.getByTestId('port-ui')).toHaveTextContent('4100');
+    // LAN-share port is an editable input pre-filled with share_port_base.
+    expect(screen.getByTestId('port-share-input')).toHaveValue(4001);
+    // Env-var names are surfaced for the user.
+    expect(screen.getByText('OMNIVOICE_PORT')).toBeInTheDocument();
+    expect(screen.getByText('OMNIVOICE_SHARE_PORT')).toBeInTheDocument();
+    expect(screen.getByText('OMNIVOICE_UI_PORT')).toBeInTheDocument();
   });
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3901,
+    port: Number(process.env.OMNIVOICE_UI_PORT) || 3901,
     strictPort: true,
     host: false,
     watch: {

--- a/tests/test_network_share.py
+++ b/tests/test_network_share.py
@@ -26,6 +26,40 @@ def test_gen_pin_is_six_digits():
     assert pin.isdigit() and len(pin) == 6
 
 
+# ── Configurable ports (issue: user-configurable network ports) ──────────────
+
+def test_backend_port_defaults_to_3900(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_PORT", raising=False)
+    assert ns.backend_port() == 3900
+
+
+def test_backend_port_honors_env(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_PORT", "4000")
+    assert ns.backend_port() == 4000
+
+
+def test_backend_port_bad_env_falls_back(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_PORT", "not-a-number")
+    assert ns.backend_port() == 3900
+
+
+def test_share_port_base_defaults_to_backend_plus_one(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_SHARE_PORT", raising=False)
+    monkeypatch.setenv("OMNIVOICE_PORT", "4000")
+    assert ns.share_port_base() == 4001
+
+
+def test_share_port_base_honors_env(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SHARE_PORT", "5500")
+    assert ns.share_port_base() == 5500
+
+
+def test_share_port_base_bad_env_falls_back(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_PORT", raising=False)
+    monkeypatch.setenv("OMNIVOICE_SHARE_PORT", "garbage")
+    assert ns.share_port_base() == 3901
+
+
 from fastapi.testclient import TestClient
 
 
@@ -52,3 +86,38 @@ def test_system_info_has_sharing_fields():
     body = c.get("/system/info").json()
     for k in ("share_enabled", "share_port", "lan_addresses", "pin_required"):
         assert k in body
+
+
+def test_system_info_has_port_fields():
+    c = _loopback_client()
+    body = c.get("/system/info").json()
+    for k in ("backend_port", "share_port_base", "ui_port"):
+        assert k in body
+    # Defaults when no env override is set.
+    assert isinstance(body["backend_port"], int)
+    assert isinstance(body["share_port_base"], int)
+    assert isinstance(body["ui_port"], int)
+
+
+def test_set_env_share_port_rejects_non_numeric():
+    c = _loopback_client()
+    r = c.post("/system/set-env", json={"key": "OMNIVOICE_SHARE_PORT", "value": "abc"})
+    assert r.status_code == 400
+
+
+def test_set_env_share_port_rejects_out_of_range():
+    c = _loopback_client()
+    r = c.post("/system/set-env", json={"key": "OMNIVOICE_SHARE_PORT", "value": "80"})
+    assert r.status_code == 400
+    r = c.post("/system/set-env", json={"key": "OMNIVOICE_SHARE_PORT", "value": "70000"})
+    assert r.status_code == 400
+
+
+def test_set_env_share_port_accepts_valid(monkeypatch):
+    c = _loopback_client()
+    r = c.post("/system/set-env", json={"key": "OMNIVOICE_SHARE_PORT", "value": "5050"})
+    assert r.status_code == 200
+    assert r.json()["set"] is True
+    # Clean up the process-level env mutation so other tests aren't affected.
+    import os
+    os.environ.pop("OMNIVOICE_SHARE_PORT", None)

--- a/tests/test_tailscale_service.py
+++ b/tests/test_tailscale_service.py
@@ -81,3 +81,25 @@ def test_serve_enable_falls_back_to_http_when_https_fails():
          patch("services.tailscale.subprocess.run", side_effect=_runner(payload, https_ok=False, http_ok=True)):
         r = ts.serve_enable(3900)
     assert r["ok"] and r["scheme"] == "http"
+
+
+def test_serve_enable_proxies_configured_backend_port(monkeypatch):
+    """When OMNIVOICE_PORT is set and serve_enable() is called with no explicit
+    port, the proxy target must use the configured backend port (not 3900)."""
+    monkeypatch.setenv("OMNIVOICE_PORT", "4000")
+    payload = {**_RUNNING, "CertDomains": None}
+    captured = {}
+
+    def run(args, **kw):
+        if "status" in args and "--json" in args:
+            return MagicMock(returncode=0, stdout=json.dumps(payload))
+        if "--http=80" in args:
+            captured["target"] = args[-1]
+            return MagicMock(returncode=0, stdout="", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("services.tailscale.shutil.which", return_value="/usr/bin/tailscale"), \
+         patch("services.tailscale.subprocess.run", side_effect=run):
+        r = ts.serve_enable()  # no explicit port → defaults to backend_port()
+    assert r["ok"]
+    assert captured["target"] == "http://127.0.0.1:4000"


### PR DESCRIPTION
Lets users adapt OmniVoice to their own networks instead of hardcoded 3900/3901. Env vars are the source of truth (the ports are read at startup by the Rust sidecar before any in-app config loads); Settings shows them and makes the runtime LAN-share port editable.

## What changed
- **`OMNIVOICE_PORT`** (backend) was already read by the Rust sidecar; now Python honors it too. Fixes the core bug: `network_share.py` hardcoded `3900`, so a custom backend port left **LAN-share + Tailscale still proxying `:3900`**. `network_share.backend_port()` / `share_port_base()` are now env-driven.
- **`OMNIVOICE_SHARE_PORT`** (default `backend+1`) — the LAN-share listener base; editable in Settings (persists via the existing prefs mechanism, applies on next enable).
- **`OMNIVOICE_UI_PORT`** (default `3901`) — Vite dev port + CORS origins.
- **Rust↔Python agreement made deterministic:** `backend.rs` now pushes `OMNIVOICE_PORT` onto the spawned child's env, so Python's `backend_port()` always equals the `--port` Rust used — the listener and the LAN-share/Tailscale target can never diverge.
- `/system/info` exposes `backend_port` / `share_port_base` / `ui_port`; Settings → Sharing has a **Ports** subsection (displays backend/UI ports + env-var names + "restart to apply"; LAN-share port editable). set-env validates port keys (numeric, 1024–65535).

## Verification (full CI-equivalent, all green locally)
Backend 32 passed · `cargo check` ✓ · `typecheck:ci` ✓ · `test:legacy` 36 ✓ · vitest 91 ✓ · build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LAN-share port settings in the Sharing Panel UI
  * System info now displays backend, UI, and LAN-share port values
  * Port configuration validates inputs (must be a valid TCP port: 1024–65535)

* **Tests**
  * Extended test coverage for port configuration behavior and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->