### PR TITLE
fix(scripts): Windows (Git Bash) support in install/run/smoke-test

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,10 +103,17 @@ open_browser() {
 
 # ── Detect platform ────────────────────────────────────────────────────────
 OS="linux"
-if [ "$(uname)" = "Darwin" ]; then
-    OS="macos"
-elif grep -qi microsoft /proc/version 2>/dev/null; then
-    OS="wsl"
+case "$(uname -s)" in
+    Darwin)               OS="macos" ;;
+    MINGW*|MSYS*|CYGWIN*)  OS="windows" ;;
+    *) if grep -qi microsoft /proc/version 2>/dev/null; then OS="wsl"; fi ;;
+esac
+
+if [ "$OS" = "windows" ]; then
+    echo "⚠  This source installer is for macOS / Linux (it installs system deps via brew/apt)."
+    echo "   On Windows: download the OmniVoice Studio installer (.msi) from the Releases page,"
+    echo "   or run this script inside WSL (Windows Subsystem for Linux)."
+    exit 0
 fi
 ARCH=$(uname -m)
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -39,11 +39,11 @@ cd "$SCRIPT_DIR"
 
 # ── Detect platform ────────────────────────────────────────────────────────
 OS="linux"
-if [ "$(uname)" = "Darwin" ]; then
-    OS="macos"
-elif grep -qi microsoft /proc/version 2>/dev/null; then
-    OS="wsl"
-fi
+case "$(uname -s)" in
+    Darwin)               OS="macos" ;;
+    MINGW*|MSYS*|CYGWIN*)  OS="windows" ;;  # Git Bash / MSYS2 — uv run works cross-platform
+    *) if grep -qi microsoft /proc/version 2>/dev/null; then OS="wsl"; fi ;;
+esac
 
 # ── PATH: ensure common shell-installed tools are available ────────────────
 export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
@@ -61,8 +61,9 @@ fi
 
 # ── Log directory (platform-aware) ─────────────────────────────────────────
 case "$OS" in
-    macos) LOG_DIR="$HOME/Library/Application Support/OmniVoice" ;;
-    *)     LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/OmniVoice" ;;
+    macos)   LOG_DIR="$HOME/Library/Application Support/OmniVoice" ;;
+    windows) LOG_DIR="${LOCALAPPDATA:-$HOME/AppData/Local}/OmniVoice" ;;
+    *)       LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/OmniVoice" ;;
 esac
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/omnivoice-run.log"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -69,20 +69,26 @@ trap cleanup EXIT
 # ── Detect platform ───────────────────────────────────────────────────────
 OS="$(uname -s)"
 case "$OS" in
-  Darwin) PLATFORM="macos" ;;
-  Linux)  PLATFORM="linux" ;;
-  *)      echo "❌ Unsupported platform: $OS"; exit 1 ;;
+  Darwin)              PLATFORM="macos" ;;
+  Linux)               PLATFORM="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) PLATFORM="windows" ;;  # Git Bash / MSYS2 / Cygwin
+  *)                   echo "❌ Unsupported platform: $OS"; exit 1 ;;
 esac
 
 if [ "$PLATFORM" = "macos" ]; then
   APP_DATA="$HOME/Library/Application Support/${APP_ID}"
   OV_DATA="$HOME/Library/Application Support/OmniVoice"
+  HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
+elif [ "$PLATFORM" = "windows" ]; then
+  # Git Bash exposes Windows env vars; match backend/core/config.py paths.
+  APP_DATA="${LOCALAPPDATA}/${APP_ID}"
+  OV_DATA="${APPDATA}/OmniVoice"
+  HF_CACHE="${HF_HOME:-${LOCALAPPDATA}/OmniVoice/hf_cache}"
 else
   APP_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/${APP_ID}"
   OV_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/OmniVoice"
+  HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
 fi
-
-HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
 
 # ── Flags ──────────────────────────────────────────────────────────────────
 SKIP_BUILD=false
@@ -138,6 +144,7 @@ fi
 header "Phase 2: Build"
 
 BINARY="${TAURI_DIR}/target/debug/omnivoice-studio"
+[ "$PLATFORM" = "windows" ] && BINARY="${BINARY}.exe"
 
 if [ "$SKIP_BUILD" = false ]; then
     info "Building debug bundle (this takes 1-3 min)..."


### PR DESCRIPTION
Follow-up to #165 (which fixed `desktop-prod.sh`) — Windows-proofs the remaining dev scripts that used the `uname` `Darwin|Linux`-only pattern, so a Git Bash user never hits a cryptic `❌ Unsupported platform: MINGW64_NT-…` or silent Linux misbehavior.

- **`smoke-test.sh`** — add `MINGW*|MSYS*|CYGWIN*` detection + a Windows data-path branch (`%APPDATA%\OmniVoice` / `%LOCALAPPDATA%`, matching `backend/core/config.py`) + `.exe` binary suffix. (Was the last hard-error.)
- **`run.sh`** — Windows detection + `%LOCALAPPDATA%` log dir. The backend launch already uses `uv run`, which is cross-platform, so it now works under Git Bash.
- **`install.sh`** — detect Windows and print a clear "download the `.msi` from Releases, or use WSL" message + exit, instead of silently falling through to the `brew`/`apt` Linux path.

Already fine (verified, untouched): `build-omnivoice-tts.sh` (handles `windows-x86_64`), `record-reference.sh` (clean macOS-only guard).

**Validated:** `bash -n` clean on all three; `MINGW64_NT-10.0-26200` resolves to `windows` in each; the only remaining `Unsupported platform` catch-alls now only fire for genuinely-unknown OSes. Not runtime-tested on Windows (no Windows box here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced platform detection across Windows, macOS, and Linux environments with improved Windows user guidance
  * Fixed cross-platform data directory handling to properly recognize platform-specific locations for application data and cache storage
  * Improved Windows executable detection and environment setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->