### PR TITLE
fix(diarization): use_auth_token->token shim for pyannote on HF Hub 1.x (#167)

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -515,6 +515,45 @@ def _classify_diarization_error(exc: BaseException) -> str:
     return DIARIZATION_ERR_LOAD
 
 
+def _ensure_pyannote_hf_token_compat():
+    """pyannote-audio 3.x calls huggingface_hub.hf_hub_download / snapshot_download
+    with the ``use_auth_token`` kwarg, which huggingface_hub 1.x removed (only
+    ``token`` remains) — raising ``hf_hub_download() got an unexpected keyword
+    argument 'use_auth_token'`` and breaking diarization (#167).
+
+    Wrap those functions to translate the deprecated kwarg. We patch
+    huggingface_hub itself BEFORE pyannote is imported, so pyannote's
+    ``from huggingface_hub import hf_hub_download`` binds the wrapped fn; we
+    also patch any already-imported pyannote submodule that bound it directly.
+    Idempotent (guarded by an attribute marker).
+    """
+    import functools
+    import sys as _sys
+    import huggingface_hub as _hf
+
+    def _wrap(orig):
+        if orig is None or getattr(orig, "_ov_uat_shim", False):
+            return orig
+
+        @functools.wraps(orig)
+        def _wrapped(*args, **kwargs):
+            if "use_auth_token" in kwargs:
+                kwargs.setdefault("token", kwargs.pop("use_auth_token"))
+            return orig(*args, **kwargs)
+
+        _wrapped._ov_uat_shim = True
+        return _wrapped
+
+    for _name in ("hf_hub_download", "snapshot_download"):
+        if hasattr(_hf, _name):
+            setattr(_hf, _name, _wrap(getattr(_hf, _name)))
+    for _modname, _mod in list(_sys.modules.items()):
+        if _modname.startswith("pyannote.") and _mod is not None:
+            for _name in ("hf_hub_download", "snapshot_download"):
+                if hasattr(_mod, _name):
+                    setattr(_mod, _name, _wrap(getattr(_mod, _name)))
+
+
 def get_diarization_pipeline(return_error: bool = False):
     """Load (or return the cached) pyannote speaker-diarization-3.1 pipeline.
 
@@ -542,6 +581,7 @@ def get_diarization_pipeline(return_error: bool = False):
     hf_token = resolved.token
     try:
         torch = _lazy_torch()
+        _ensure_pyannote_hf_token_compat()  # #167: use_auth_token -> token
         from pyannote.audio import Pipeline
         logger.info("Loading Pyannote Diarization Pipeline...")
         _diar_pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=hf_token)

--- a/tests/test_pyannote_hf_compat.py
+++ b/tests/test_pyannote_hf_compat.py
@@ -51,12 +51,11 @@ def test_pyannote_binds_the_shim():
     """The real proof: after the shim, pyannote's own `hf_hub_download`
     reference translates `use_auth_token` rather than raising."""
     _ensure_pyannote_hf_token_compat()
-    try:
-        from pyannote.audio.core import pipeline as _pp
-    except Exception as e:  # pragma: no cover - pyannote/torch not importable
-        pytest.skip(f"pyannote not importable: {e}")
-    # _ensure also patches already-imported pyannote modules, so the reference
-    # pyannote calls at pipeline.py:102 is the wrapped one.
+    # importorskip imports the module (or skips) — and since the shim patched
+    # huggingface_hub first, pyannote's `from huggingface_hub import
+    # hf_hub_download` (pipeline.py:34) binds the wrapped fn. (Also avoids the
+    # CodeQL "possibly-uninitialized local" false positive from a try/skip.)
+    _pp = pytest.importorskip("pyannote.audio.core.pipeline")
     assert getattr(_pp.hf_hub_download, "_ov_uat_shim", False), (
         "pyannote.audio.core.pipeline.hf_hub_download is not the use_auth_token shim"
     )

--- a/tests/test_pyannote_hf_compat.py
+++ b/tests/test_pyannote_hf_compat.py
@@ -1,0 +1,62 @@
+"""#167 — pyannote-audio 3.x passes the removed `use_auth_token` kwarg to
+huggingface_hub.hf_hub_download (HF Hub 1.x only accepts `token`), breaking
+diarization. Verify the compat shim translates the kwarg and that pyannote
+actually binds the wrapped function."""
+import pytest
+
+from services.model_manager import _ensure_pyannote_hf_token_compat
+
+
+def test_shim_translates_use_auth_token_to_token(monkeypatch):
+    import huggingface_hub
+
+    seen = {}
+
+    def fake(*args, token=None, **kwargs):
+        # Mimic HF Hub 1.x: `use_auth_token` is no longer accepted.
+        if "use_auth_token" in kwargs:
+            raise TypeError(
+                "hf_hub_download() got an unexpected keyword argument 'use_auth_token'"
+            )
+        seen["token"] = token
+        return "downloaded"
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake, raising=False)
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake, raising=False)
+
+    _ensure_pyannote_hf_token_compat()
+
+    # The wrapped fn must translate the dead kwarg instead of raising.
+    result = huggingface_hub.hf_hub_download(repo_id="r", filename="f", use_auth_token="secret")
+    assert result == "downloaded"
+    assert seen["token"] == "secret"
+
+
+def test_shim_is_idempotent(monkeypatch):
+    import huggingface_hub
+
+    def fake(*args, token=None, **kwargs):
+        return token
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake, raising=False)
+    _ensure_pyannote_hf_token_compat()
+    once = huggingface_hub.hf_hub_download
+    _ensure_pyannote_hf_token_compat()
+    twice = huggingface_hub.hf_hub_download
+    assert once is twice  # not re-wrapped
+    assert getattr(twice, "_ov_uat_shim", False) is True
+
+
+def test_pyannote_binds_the_shim():
+    """The real proof: after the shim, pyannote's own `hf_hub_download`
+    reference translates `use_auth_token` rather than raising."""
+    _ensure_pyannote_hf_token_compat()
+    try:
+        from pyannote.audio.core import pipeline as _pp
+    except Exception as e:  # pragma: no cover - pyannote/torch not importable
+        pytest.skip(f"pyannote not importable: {e}")
+    # _ensure also patches already-imported pyannote modules, so the reference
+    # pyannote calls at pipeline.py:102 is the wrapped one.
+    assert getattr(_pp.hf_hub_download, "_ov_uat_shim", False), (
+        "pyannote.audio.core.pipeline.hf_hub_download is not the use_auth_token shim"
+    )


### PR DESCRIPTION
Fixes #167. pyannote-audio 3.x (`core/pipeline.py:102`) calls `hf_hub_download(..., use_auth_token=...)`; huggingface_hub 1.x removed that kwarg (only `token`), so diarization died with `unexpected keyword argument 'use_auth_token'`. We can't drop to HF Hub <1 (transformers≥5.3 + our token persistence need 1.x) nor jump to pyannote 4.x (whisperx 3.4.2 still passes `use_auth_token` to pyannote's `Inference` — already noted in pyproject). So: a small shim wraps `hf_hub_download`/`snapshot_download` to translate `use_auth_token`→`token`, applied before pyannote's `from huggingface_hub import …` binds it. Tested with the installed pyannote 3.4.0 + HF Hub 1.7.2 — incl. a real check that pyannote's bound reference is the shim. 3 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented diarization pipeline failures by adding a compatibility shim that makes older/newer Hugging Face Hub parameter names work together.

* **Tests**
  * Added tests verifying the compatibility shim translates legacy parameters to the newer form, is idempotent, and binds correctly when related modules are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->