### PR TITLE
feat(settings): dedicated Appearance tab + global font selection

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback, Suspense, lazy } from 'react';
 import './index.css';
-import { useAppStore } from './store';
+import { useAppStore, FONT_STACKS } from './store';
 import SearchableSelect from './components/SearchableSelect';
 import DirectionDialog from './components/DirectionDialog';
 
@@ -78,8 +78,9 @@ function App() {
   const theme = useAppStore(s => s.theme);
 
   const locale = useAppStore(s => s.locale);
+  const font = useAppStore(s => s.font);
 
-  // Hydrate the theme & locale so persisted preferences take effect after
+  // Hydrate the theme, locale & font so persisted preferences take effect after
   // zustand persist rehydrates (async from localStorage) and when the user
   // changes them at runtime.
   useEffect(() => {
@@ -91,7 +92,12 @@ function App() {
     if (locale) {
       i18n.changeLanguage(locale);
     }
-  }, [locale, theme]);
+    // Re-apply the global font the same way setFont does, so a persisted
+    // non-default font takes effect on launch.
+    const fontStack = FONT_STACKS[font];
+    if (fontStack) document.documentElement.style.setProperty('--font-sans', fontStack);
+    else document.documentElement.style.removeProperty('--font-sans');
+  }, [locale, theme, font]);
   const mode = useAppStore(s => s.mode);
   const setMode = useAppStore(s => s.setMode);
   const [navRailSide, setNavRailSide] = useState(() => {

--- a/frontend/src/components/settings/AppearancePanel.jsx
+++ b/frontend/src/components/settings/AppearancePanel.jsx
@@ -8,8 +8,8 @@
  */
 import React from 'react';
 import { Palette } from 'lucide-react';
-import { Segmented } from '../../ui';
-import { useAppStore } from '../../store';
+import { Segmented, Select } from '../../ui';
+import { useAppStore, FONT_OPTIONS } from '../../store';
 import './AppearancePanel.css';
 
 const THEMES = [
@@ -26,6 +26,8 @@ export default function AppearancePanel() {
   const setUiScale = useAppStore(s => s.setUiScale);
   const theme      = useAppStore(s => s.theme);
   const setTheme   = useAppStore(s => s.setTheme);
+  const font       = useAppStore(s => s.font);
+  const setFont    = useAppStore(s => s.setFont);
 
   return (
     <section className="appearance-panel" aria-labelledby="appearance-panel-heading">
@@ -64,6 +66,21 @@ export default function AppearancePanel() {
             />
           ))}
         </div>
+      </div>
+
+      <div className="appearance-panel__row">
+        <span className="appearance-panel__label">Font</span>
+        <Select
+          size="xs"
+          value={font}
+          onChange={(e) => setFont(e.target.value)}
+          data-testid="appearance-font-select"
+          aria-label="Font"
+        >
+          {FONT_OPTIONS.map(f => (
+            <option key={f.id} value={f.id}>{f.label}</option>
+          ))}
+        </Select>
       </div>
 
       <p className="appearance-panel__help">

--- a/frontend/src/components/settings/AppearancePanel.test.jsx
+++ b/frontend/src/components/settings/AppearancePanel.test.jsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import AppearancePanel from './AppearancePanel';
+import { useAppStore, FONT_OPTIONS } from '../../store';
+
+describe('AppearancePanel — global font selection', () => {
+  beforeEach(() => {
+    // Deterministic start: reset font to default and clear any DOM override.
+    useAppStore.getState().setFont('default');
+    document.documentElement.style.removeProperty('--font-sans');
+  });
+
+  it('renders the font select with all FONT_OPTIONS', () => {
+    render(<AppearancePanel />);
+    const select = screen.getByTestId('appearance-font-select');
+    expect(select).toBeInTheDocument();
+
+    for (const opt of FONT_OPTIONS) {
+      expect(screen.getByRole('option', { name: opt.label })).toBeInTheDocument();
+    }
+    // Defaults to the persisted 'default' font.
+    expect(select.value).toBe('default');
+  });
+
+  it('selecting a non-default font updates the store and sets --font-sans', () => {
+    render(<AppearancePanel />);
+    const select = screen.getByTestId('appearance-font-select');
+
+    fireEvent.change(select, { target: { value: 'serif' } });
+
+    // Store reflects the selection.
+    expect(useAppStore.getState().font).toBe('serif');
+    // The select shows the new value.
+    expect(select.value).toBe('serif');
+    // The global font override is applied on the document root.
+    expect(document.documentElement.style.getPropertyValue('--font-sans')).toMatch(/Georgia/);
+  });
+
+  it('switching back to default removes the --font-sans override', () => {
+    render(<AppearancePanel />);
+    const select = screen.getByTestId('appearance-font-select');
+
+    fireEvent.change(select, { target: { value: 'mono' } });
+    expect(document.documentElement.style.getPropertyValue('--font-sans')).not.toBe('');
+
+    fireEvent.change(select, { target: { value: 'default' } });
+    expect(useAppStore.getState().font).toBe('default');
+    expect(document.documentElement.style.getPropertyValue('--font-sans')).toBe('');
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -134,6 +134,7 @@
     "engines": "Engines",
     "capture": "Capture",
     "sharing": "Sharing",
+    "appearance": "Appearance",
     "credentials": "Credentials",
     "proxy": "Proxy",
     "proxy_desc": "HTTP/SOCKS5 proxy for downloads (yt-dlp, HuggingFace). Supports http://, https://, socks5://. Restart required if changed after backend start.",

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -11,7 +11,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   Cpu, FileText, Info, ShieldCheck, RefreshCw, Trash2, ExternalLink,
   CheckCircle, AlertCircle, Plug, Download, Copy, Building2, KeyRound,
-  Keyboard, Wifi,
+  Keyboard, Wifi, Palette,
 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { openExternal } from '../api/external';
@@ -41,6 +41,7 @@ const TAB_DEFS = [
   { id: 'engines',     icon: Plug,         accent: '#d3869b' },
   { id: 'capture',     icon: Keyboard,     accent: '#83a598' },
   { id: 'sharing',     icon: Wifi,         accent: '#83a598' },
+  { id: 'appearance',  icon: Palette,      accent: '#d3869b' },
   { id: 'credentials', icon: KeyRound,     accent: '#fe8019' },
   { id: 'logs',        icon: FileText,     accent: '#fabd2f' },
   { id: 'about',       icon: Info,         accent: '#8ec07c' },
@@ -1256,6 +1257,8 @@ export default function Settings() {
 
       {activeTab === 'sharing' && <SharingPanel />}
 
+      {activeTab === 'appearance' && <AppearancePanel />}
+
       {activeTab === 'credentials' && <CredentialsTab info={info} />}
 
       {activeTab === 'logs' && (
@@ -1644,10 +1647,6 @@ function CredentialsTab({ info }) {
           (#65). Toggle is rendered disabled on macOS/Linux with an
           explainer; backend ignores the flag on non-Windows. */}
       <PerformancePanel />
-
-      {/* UI scale + color theme — moved out of the LogsFooter chrome so
-          the footer can focus on logs. Rarely-used prefs belong here. */}
-      <AppearancePanel />
 
       <p className="settings-prose">
         <Trans i18nKey="credentials.desc" components={{ 1: <strong /> }} />

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -17,8 +17,12 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-import type { PrefsSlice } from './prefsSlice';
-import { createPrefsSlice } from './prefsSlice';
+import type { PrefsSlice, FontId } from './prefsSlice';
+import { createPrefsSlice, FONT_OPTIONS, FONT_STACKS } from './prefsSlice';
+
+// Re-export font preference tables so panels can import from the store root.
+export type { FontId };
+export { FONT_OPTIONS, FONT_STACKS };
 import type { GlossarySlice } from './glossarySlice';
 import { createGlossarySlice } from './glossarySlice';
 import type { UiSlice } from './uiSlice';
@@ -68,6 +72,7 @@ export const useAppStore = create<AppStore>()(
         uiScale:                    s.uiScale,
         locale:                     s.locale,
         theme:                      s.theme,
+        font:                       s.font,
         // Generate-tab prefs — users expect their synthesis knobs to stick.
         language:      s.language,
         speed:         s.speed,

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -12,6 +12,33 @@ export type TranslateQuality = 'fast' | 'cinematic';
 export type ThemeId = 'gruvbox' | 'midnight' | 'nord' | 'solarized' | 'rose-pine' | 'catppuccin';
 
 /**
+ * Global UI font. Applied app-wide by overriding the `--font-sans` CSS custom
+ * property on `document.documentElement` (the whole UI uses
+ * `font-family: var(--font-sans)`). `default` removes the override so the CSS
+ * `:root` Inter stack takes over. All stacks are SYSTEM-SAFE — no web-font
+ * downloads, so this works identically offline across macOS/Windows/Linux.
+ */
+export type FontId = 'default' | 'system' | 'serif' | 'mono' | 'rounded' | 'readable';
+
+export const FONT_OPTIONS: { id: FontId; label: string }[] = [
+  { id: 'default',  label: 'Inter (default)' },
+  { id: 'system',   label: 'System' },
+  { id: 'serif',    label: 'Serif' },
+  { id: 'mono',     label: 'Monospace' },
+  { id: 'rounded',  label: 'Rounded' },
+  { id: 'readable', label: 'Readable' },
+];
+
+export const FONT_STACKS: Record<FontId, string | null> = {
+  default:  null, // use the CSS :root --font-sans (Inter)
+  system:   '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  serif:    'Georgia, "Times New Roman", serif',
+  mono:     'ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace',
+  rounded:  '"SF Pro Rounded", "Nunito", "Quicksand", system-ui, sans-serif',
+  readable: '"Atkinson Hyperlegible", Verdana, system-ui, sans-serif',
+};
+
+/**
  * Dub timing strategy — replaces audio time-compression with two cleaner
  * alternatives. `concise` trims the translation up-front so it fits at
  * natural rate (overflows surfaced for manual edit); `stretch_video`
@@ -63,6 +90,9 @@ export interface PrefsSlice {
 
   theme: ThemeId;
   setTheme: (id: ThemeId) => void;
+
+  font: FontId;
+  setFont: (id: FontId) => void;
 }
 
 export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (set) => ({
@@ -94,5 +124,13 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
     } else {
       document.documentElement.setAttribute('data-theme', id);
     }
+  },
+
+  font: 'default',
+  setFont: (id) => {
+    set({ font: id });
+    const stack = FONT_STACKS[id];
+    if (stack) document.documentElement.style.setProperty('--font-sans', stack);
+    else document.documentElement.style.removeProperty('--font-sans');
   },
 });


### PR DESCRIPTION
Two requested Settings changes:

1. **Appearance is its own tab** — moved the UI-scale + color-theme panel out of the Credentials tab into a dedicated **Appearance** tab (`Palette` icon).
2. **Global font selection** — a new persisted preference in the Appearance panel. Picks from system-safe stacks (Inter default / System / Serif / Monospace / Rounded / Readable) and applies app-wide by overriding the `--font-sans` CSS variable on the root (the same var the whole UI's `font-family` already uses — mirrors how `setTheme` sets `data-theme`). Persisted via zustand + re-applied on launch in `App.jsx`'s rehydrate effect.

No web-font downloads (all stacks fall back to system fonts). **Verified:** typecheck:ci ✓, test:legacy 36 ✓, vitest 94/94 (incl. new AppearancePanel test) ✓, build ✓, CJK guard ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated Appearance tab in Settings for visual customization.
  * Added font selection feature allowing users to choose their preferred font from available options.
  * Font preferences are automatically saved and restored on app reload.

* **Tests**
  * Added test suite for font selection functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->