### PR TITLE
fix(network): remote LAN-share UI actually works (same-origin API + safe clipboard)

### DIFF
--- a/frontend/src/api/client.apibase.test.ts
+++ b/frontend/src/api/client.apibase.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { _resolveApiBase } from './client';
+
+describe('_resolveApiBase', () => {
+  it('served (non-Tauri, non-dev) → SAME ORIGIN (fixes remote LAN-share CORS)', () => {
+    // A device opening the share URL: SPA served from :5050 must talk to :5050,
+    // not a hardcoded :3900 (cross-origin + loopback-only).
+    const win = { location: { origin: 'http://100.64.0.48:5050', hostname: '100.64.0.48' } };
+    expect(_resolveApiBase({ DEV: false }, win)).toBe('http://100.64.0.48:5050');
+  });
+
+  it('Tauri webview → local sidecar (127.0.0.1)', () => {
+    const win = { __TAURI__: {}, location: { origin: 'tauri://localhost', hostname: 'localhost' } };
+    expect(_resolveApiBase({}, win)).toBe('http://127.0.0.1:3900');
+  });
+
+  it('vite dev → backend on :3900 (SPA :3901 → API :3900, CORS-allowed)', () => {
+    const win = { location: { origin: 'http://localhost:3901', hostname: 'localhost' } };
+    expect(_resolveApiBase({ DEV: true }, win)).toBe('http://localhost:3900');
+  });
+
+  it('VITE_API_URL overrides everything', () => {
+    const win = { __TAURI__: {}, location: { origin: 'http://x', hostname: 'x' } };
+    expect(_resolveApiBase({ VITE_API_URL: 'http://10.0.0.5:9' }, win)).toBe('http://10.0.0.5:9');
+  });
+
+  it('no window (SSR) → loopback', () => {
+    expect(_resolveApiBase({}, undefined)).toBe('http://127.0.0.1:3900');
+  });
+
+  it('honors VITE_API_PORT', () => {
+    const win = { __TAURI__: {}, location: { origin: 'x', hostname: 'x' } };
+    expect(_resolveApiBase({ VITE_API_PORT: '4000' }, win)).toBe('http://127.0.0.1:4000');
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,14 +1,25 @@
-// Backend base URL. Configurable via VITE_API_URL or VITE_API_PORT env vars.
-// In production Tauri builds, the webview talks to the sidecar on localhost.
+// Backend base URL.
+//   • VITE_API_URL                → explicit override (any deploy).
+//   • Tauri webview               → the local sidecar (127.0.0.1:<port>).
+//   • Vite dev server (import.meta.env.DEV) → backend on :<port> (the dev
+//     SPA runs on :3901 and the backend on :3900; CORS allows the dev origin).
+//   • Anything else (served BY the backend itself — the LAN-share listener,
+//     Docker, or a prod build) → SAME ORIGIN. That server serves both the SPA
+//     and the API, so a remote device on http://<host>:<share-port> must hit
+//     that same origin — NOT a hardcoded :3900, which is cross-origin (CORS)
+//     and loopback-only/unreachable from another machine.
 const viteEnv = import.meta.env ?? {};
-const _port = viteEnv.VITE_API_PORT || '3900';
-// In Tauri builds the backend is always on localhost; in Docker/remote deployments
-// use window.location.hostname so the browser can reach the server remotely.
-const _host =
-  typeof window !== 'undefined' && window.__TAURI__
-    ? '127.0.0.1'
-    : (typeof window !== 'undefined' ? window.location.hostname : '127.0.0.1');
-export const API = viteEnv.VITE_API_URL || `http://${_host}:${_port}`;
+// Pure + exported for unit testing — takes env + window so tests don't need to
+// re-import the module or stub import.meta.env.
+export function _resolveApiBase(env: any, win: any): string {
+  const port = env?.VITE_API_PORT || '3900';
+  if (env?.VITE_API_URL) return env.VITE_API_URL;
+  if (!win) return `http://127.0.0.1:${port}`;
+  if (win.__TAURI__) return `http://127.0.0.1:${port}`;
+  if (env?.DEV) return `http://${win.location.hostname}:${port}`;
+  return win.location.origin;
+}
+export const API = _resolveApiBase(viteEnv, typeof window !== 'undefined' ? window : undefined);
 
 // Capture a QR-supplied PIN once on load. When LAN sharing is on, the host's
 // QR code links to `http://<lan-ip>:<port>/?pin=<pin>`; stash it in

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -9,6 +9,7 @@
  *      min dependency install.
  */
 import { useEffect, useRef, useState } from 'react';
+import { copyText } from "../utils/copyText";
 import './BootstrapSplash.css';
 
 // Vite injects package.json version at build time.
@@ -195,7 +196,7 @@ export function BootstrapSplash({ stage, message }) {
     const full = isFailed && message
       ? `ERROR: ${message}\n\n--- Bootstrap Logs ---\n${logText}`
       : logText;
-    navigator.clipboard.writeText(full).then(() => {
+    copyText(full).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }).catch(() => {});

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { copyText } from "../utils/copyText";
 import { X, Loader } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { useAppStore } from '../store';
@@ -117,7 +118,7 @@ export default function CaptureWidget({ onDismiss }) {
 
     if (data.text) {
       try {
-        await navigator.clipboard.writeText(data.text);
+        await copyText(data.text);
         try {
           const { invoke } = await import('@tauri-apps/api/core');
           await invoke('simulate_paste');

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { copyText } from "../utils/copyText";
 import {
   ChevronUp, ChevronDown, RefreshCw, Trash2, Copy, Bug, X,
   AlertTriangle, AlertCircle, Info, FileText, Heart,
@@ -293,7 +294,7 @@ export default function LogsFooter() {
   const onCopy = async () => {
     try {
       const raw = (lines[active] || []).join('\n');
-      await navigator.clipboard.writeText(raw);
+      await copyText(raw);
       toast.success(`Copied ${active} log`);
     } catch (e) {
       toast.error(`Copy failed: ${e?.message || e}`);
@@ -319,7 +320,7 @@ export default function LogsFooter() {
         l.slice(-80).join('\n');
     }).join('\n\n');
     try {
-      await navigator.clipboard.writeText(header + body);
+      await copyText(header + body);
       toast.success('Diagnostic report copied — paste it into a GitHub issue.');
     } catch (e) {
       toast.error(`Report failed: ${e?.message || e}`);

--- a/frontend/src/components/NetworkToggle.jsx
+++ b/frontend/src/components/NetworkToggle.jsx
@@ -1,5 +1,6 @@
 // frontend/src/components/NetworkToggle.jsx
 import { useEffect, useState, useCallback } from 'react';
+import { copyText } from "../utils/copyText";
 import QRCode from 'qrcode';
 import { Wifi, WifiOff, Copy, ExternalLink } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -47,7 +48,7 @@ export default function NetworkToggle() {
     finally { setBusy(false); }
   };
 
-  const copy = (text) => { navigator.clipboard?.writeText(text); toast.success('Copied'); };
+  const copy = (text) => { copyText(text); toast.success('Copied'); };
 
   return (
     <div className="net-toggle">

--- a/frontend/src/components/settings/SharingPanel.jsx
+++ b/frontend/src/components/settings/SharingPanel.jsx
@@ -17,6 +17,7 @@
  *   POST /system/tailscale/disable  → {ok}
  */
 import React, { useCallback, useEffect, useState } from 'react';
+import { copyText } from "../../utils/copyText";
 import QRCode from 'qrcode';
 import { Wifi, Globe, Copy, ExternalLink } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -150,7 +151,7 @@ export default function SharingPanel() {
     }
   };
 
-  const copy = (text) => { navigator.clipboard?.writeText(text); toast.success('Copied'); };
+  const copy = (text) => { copyText(text); toast.success('Copied'); };
 
   const installed = !!status?.installed;
   const running = !!status?.running;

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -1,4 +1,5 @@
 import React, { Suspense, lazy, useState, useEffect, useCallback, useRef } from 'react';
+import { copyText } from "../utils/copyText";
 import { useTranslation } from 'react-i18next';
 import {
   PanelLeftOpen, PanelLeftClose, Film, Save, UploadCloud, Sparkles, Loader, Square,
@@ -41,7 +42,7 @@ function DubFailureNotice({ failure }) {
   const topic = failure.docsTopic || classifyError(failure.reason);
   const copyDiagnostic = async () => {
     try {
-      await navigator.clipboard.writeText(failure.diagnostic || failure.reason);
+      await copyText(failure.diagnostic || failure.reason);
       toast.success('Diagnostic copied');
     } catch {
       toast.error('Copy failed');

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { copyText } from "../utils/copyText";
 import { useTranslation } from 'react-i18next';
 import {
   Search, FolderOpen, Film, Fingerprint, Wand2, Music, Download,
@@ -169,7 +170,7 @@ export default function Projects({
         accent: '#83a598',
         Icon: FileText,
         onClick: () => {
-          navigator.clipboard.writeText(tr.text || '');
+          copyText(tr.text || '');
         },
       });
     }

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import { copyText } from "../utils/copyText";
 import { isTauri as _isTauri } from '../utils/media';
 import {
   flexRender,
@@ -1115,7 +1116,7 @@ export default function Settings() {
     ];
     const text = lines.join('\n');
     try {
-      await navigator.clipboard.writeText(text);
+      await copyText(text);
       toast.success('Diagnostics copied — paste into your issue report.');
     } catch (e) {
       toast.error('Copy failed: ' + (e?.message || e));

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -8,6 +8,7 @@
  * page updates in realtime without requiring a shared store.
  */
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import { copyText } from "../utils/copyText";
 import { useTranslation } from 'react-i18next';
 import { Mic, Copy, Trash2, Search, Clock, Languages, FileText, Download } from 'lucide-react';
 import { Button } from '../ui';
@@ -74,7 +75,7 @@ export default function TranscriptionsPage() {
   );
 
   const copyText = useCallback((text) => {
-    navigator.clipboard.writeText(text).then(
+    copyText(text).then(
       () => toast.success(t('transcriptions.copied')),
       () => toast.error(t('transcriptions.copy_failed'))
     );

--- a/frontend/src/utils/copyText.js
+++ b/frontend/src/utils/copyText.js
@@ -1,0 +1,38 @@
+/**
+ * Copy text to the clipboard, resilient to non-secure (plain-HTTP) contexts.
+ *
+ * The async Clipboard API (`navigator.clipboard`) is only available in secure
+ * contexts (https / localhost). On a LAN-shared instance opened over plain
+ * `http://<ip>:<port>`, `navigator.clipboard` is `undefined`, so a bare
+ * `navigator.clipboard.writeText(...)` throws
+ * "Cannot read properties of undefined (reading 'writeText')". Fall back to a
+ * hidden-textarea + `execCommand('copy')`, which works in non-secure contexts.
+ *
+ * @param {string} text
+ * @returns {Promise<boolean>} whether the copy succeeded
+ */
+export async function copyText(text) {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* secure-context call failed (permissions, focus) — fall through */
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '-1000px';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/utils/copyText.test.js
+++ b/frontend/src/utils/copyText.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { copyText } from './copyText';
+
+describe('copyText', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    try { Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true }); } catch { /* noop */ }
+  });
+
+  it('uses navigator.clipboard.writeText in a secure context', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    const ok = await copyText('hello');
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(ok).toBe(true);
+  });
+
+  it('falls back to execCommand over plain HTTP (no navigator.clipboard) — never throws', async () => {
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    const exec = vi.fn(() => true);
+    document.execCommand = exec;  // jsdom doesn't pre-define it; assign a mock
+    const ok = await copyText('hello');   // must NOT throw "Cannot read properties of undefined"
+    expect(exec).toHaveBeenCalledWith('copy');
+    expect(ok).toBe(true);
+  });
+});


### PR DESCRIPTION
Opening the LAN-share URL on another device showed a wall of CORS errors + a clipboard crash. Two compounding remote-only bugs:

1. **Same-origin API** — the SPA served by the share listener on `:5050` had its API client hardcoded to `:3900`, which is cross-origin (CORS-blocked) *and* loopback-only/unreachable from another machine. The share listener serves the same app+API, so the remote SPA must use **its own origin**. `_resolveApiBase`: Tauri→127.0.0.1; vite-dev→:3900 (CORS-allowed); else (share listener / Docker / prod build)→`window.location.origin`. +6 unit tests.
2. **Safe clipboard** — `navigator.clipboard` is secure-context-only; over plain HTTP it's `undefined`, so unguarded `writeText(...)` threw and crashed copy buttons. New `copyText` util (clipboard API → hidden-textarea/`execCommand` fallback), routed through all 9 call sites. +2 tests.

**Verified:** typecheck:ci ✓, test:legacy ✓, vitest 103/103 ✓, build ✓. This is the fix that makes the (real, already-working backend) sharing usable end-to-end from a phone/second machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced clipboard functionality with improved fallback support for better compatibility across different environments and browser contexts.

* **Tests**
  * Added comprehensive test coverage for API base URL resolution.
  * Added test coverage for clipboard operation reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->