### PR TITLE
fix(model): first-run model load/download never hangs forever (Windows demo-voice hang)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -98,6 +98,19 @@ if sys.platform == "win32":
 # wrapper that our patch intercepts. Override-able by the user.
 os.environ.setdefault("HF_HUB_DISABLE_XET", "1")
 
+# ── HF network timeouts ─────────────────────────────────────────────────────
+# Bound HF network ops so a stalled metadata HEAD or a dead download socket
+# RAISES (and surfaces as an error) instead of hanging the model-load worker
+# forever — the root cause of the "demo voice spins forever, no error" report
+# (most often hit on Windows behind a proxy / firewall / antivirus that wedges
+# the multi-GB legacy-LFS transfer). HF_HUB_DOWNLOAD_TIMEOUT is a *per-read*
+# timeout: it resets on every received chunk, so a slow-but-progressing
+# download is never punished — only a genuinely dead socket trips it. Both are
+# user-overridable for unusually slow links. Set before huggingface_hub is
+# imported so its constants pick them up.
+os.environ.setdefault("HF_HUB_ETAG_TIMEOUT", "15")
+os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
+
 
 # Prevent torchaudio from lazy-importing torchcodec (broken on some installs).
 # Proper fix = exclude torchcodec in pyproject.toml; this is a belt-and-braces guard.

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -320,16 +320,69 @@ def _load_model_sync():
     finally:
         unregister_listener(lid)
 
+def _model_load_timeout() -> float:
+    """Overall ceiling (seconds) for a single model load/download attempt.
+
+    Backstop for any hang the HF per-read socket timeouts don't catch
+    (a wedged torch.compile, a deadlock, etc.). Generous by default so a
+    legitimate cold multi-GB download on a slow link still completes;
+    overridable via OMNIVOICE_MODEL_LOAD_TIMEOUT for very slow networks.
+    """
+    try:
+        return max(30.0, float(os.environ.get("OMNIVOICE_MODEL_LOAD_TIMEOUT", "1200")))
+    except (ValueError, TypeError):
+        return 1200.0
+
+
+def _reset_gpu_pool() -> None:
+    """Drop the GPU pool singleton so the next access builds a fresh one.
+
+    Python can't kill the thread stuck in a timed-out load, but abandoning the
+    poisoned single-worker pool means a *retry* gets a clean worker instead of
+    queueing forever behind the wedged one.
+    """
+    global _gpu_pool_singleton
+    pool, _gpu_pool_singleton = _gpu_pool_singleton, None
+    if pool is not None:
+        try:
+            pool.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            pass
+
+
+async def _load_model_with_timeout():
+    """Run the blocking model load on the GPU pool, bounded by a deadline.
+
+    Raises RuntimeError on timeout (and resets the poisoned pool) so callers
+    surface an actionable error instead of hanging indefinitely.
+    """
+    loop = asyncio.get_running_loop()
+    timeout = _model_load_timeout()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(_get_gpu_pool(), _load_model_sync),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError as exc:
+        _set_loading("error", "Model load timed out", error="timeout")
+        _reset_gpu_pool()
+        logger.error("Model load exceeded %ss; resetting GPU pool.", timeout)
+        raise RuntimeError(
+            f"Model loading timed out after {int(timeout)}s — usually a network "
+            "stall downloading the model (proxy, firewall, or antivirus). Check "
+            "your connection or set a Hugging Face mirror in Settings, then retry."
+        ) from exc
+
+
 async def get_model():
     global model, _last_used
     _last_used = time.time()
     if model is not None:
         return model
-    
+
     async with _model_lock:
         if model is None:
-            loop = asyncio.get_running_loop()
-            model = await loop.run_in_executor(_get_gpu_pool(), _load_model_sync)
+            model = await _load_model_with_timeout()
     return model
 
 
@@ -359,8 +412,7 @@ async def preload_model():
         _last_used = time.time()
         async with _model_lock:
             if model is None:
-                loop = asyncio.get_running_loop()
-                model = await loop.run_in_executor(_get_gpu_pool(), _load_model_sync)
+                model = await _load_model_with_timeout()
         logger.info("Preload complete — model ready.")
     except Exception as e:
         logger.warning("Model preload failed (non-fatal): %s", e)

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -77,6 +77,7 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
         return suffix ? `${elapsed} ${suffix}` : elapsed;
       });
     }, 100);
+    let abortTimer = null;
     try {
       const formData = new FormData();
       formData.append("text", text);
@@ -122,7 +123,14 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
         }
       }
 
-      const response = await generateSpeech(formData);
+      // The first /generate may cold-load/download the model. The backend now
+      // bounds that and returns an error rather than hanging; this client-side
+      // abort is a backstop so the UI never spins forever even if the backend
+      // is unreachable. The ceiling sits just above the backend's load timeout
+      // so the backend's descriptive error wins in the normal case.
+      const ac = new AbortController();
+      abortTimer = setTimeout(() => ac.abort(), 21 * 60 * 1000);
+      const response = await generateSpeech(formData, { signal: ac.signal });
       const reader = response.body.getReader();
       const chunks = [];
       let receivedLength = 0;
@@ -146,8 +154,12 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
       setSidebarTab('history');
       playPing();
     } catch (err) {
-      toast.error("Error: " + err.message);
+      const msg = err?.name === 'AbortError'
+        ? 'Generation timed out — the model may still be downloading. Check Settings → Logs, then try again.'
+        : ("Error: " + err.message);
+      toast.error(msg);
     } finally {
+      if (abortTimer) clearTimeout(abortTimer);
       clearInterval(timerRef.current);
       setIsGenerating(false);
     }

--- a/tests/test_model_load_timeout.py
+++ b/tests/test_model_load_timeout.py
@@ -1,0 +1,63 @@
+"""Regression: model load/download must never hang forever (Windows demo-voice
+"runs indefinitely, no audio, no error" report).
+
+`get_model()` wraps the blocking load in an `asyncio.wait_for` deadline; on
+timeout it drops the poisoned GPU pool and raises a clear RuntimeError instead
+of leaving `/generate` (and the UI spinner) wedged forever.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def model_manager(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+
+    import services.model_manager as mm
+
+    monkeypatch.setattr(mm, "model", None)
+    return mm
+
+
+def test_model_load_timeout_respects_env(model_manager, monkeypatch):
+    mm = model_manager
+    monkeypatch.delenv("OMNIVOICE_MODEL_LOAD_TIMEOUT", raising=False)
+    assert mm._model_load_timeout() == 1200.0
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_TIMEOUT", "5000")
+    assert mm._model_load_timeout() == 5000.0
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_TIMEOUT", "not-a-number")
+    assert mm._model_load_timeout() == 1200.0
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_TIMEOUT", "1")  # below the safety floor
+    assert mm._model_load_timeout() == 30.0
+
+
+def test_get_model_times_out_and_resets_pool(model_manager, monkeypatch):
+    mm = model_manager
+    # Isolated lock so we never reuse one bound to a previous test's loop.
+    monkeypatch.setattr(mm, "_model_lock", asyncio.Lock())
+    monkeypatch.setattr(mm, "_model_load_timeout", lambda: 0.3)
+
+    release = threading.Event()
+
+    def _hang():  # simulates a wedged download that never returns
+        release.wait(2.0)
+        return object()
+
+    monkeypatch.setattr(mm, "_load_model_sync", _hang)
+    assert mm._get_gpu_pool() is not None  # a pool exists before the timeout
+
+    try:
+        with pytest.raises(RuntimeError, match="timed out"):
+            asyncio.run(mm.get_model())
+        assert mm.model is None                 # no half-loaded model
+        assert mm._gpu_pool_singleton is None    # poisoned pool was dropped
+        assert not mm._model_lock.locked()       # lock released for a retry
+    finally:
+        release.set()  # let the orphaned worker exit immediately


### PR DESCRIPTION
## Bug
Windows users report: install succeeds, app runs, but **creating the demo voice runs indefinitely** — spinner forever, no audio, no error toast.

## Root cause
The first `/generate` calls `OmniVoice.from_pretrained()`, which downloads the multi-GB weights via the **legacy LFS path** (`HF_HUB_DISABLE_XET=1`, set globally) with **no timeout anywhere**. A stalled socket (corporate proxy / firewall / antivirus inspecting the large transfer) blocks the GPU-pool worker **inside `get_model()`** — *before* the `try/except` that would surface an error — so it neither returns nor raises. The frontend `/generate` fetch (`useTTS.js`) had **no abort/timeout**, so the UI spun forever with no message.

## Fix (platform-agnostic, defense-in-depth)
- **HF socket timeouts** (`backend/main.py`): `HF_HUB_ETAG_TIMEOUT=15` + `HF_HUB_DOWNLOAD_TIMEOUT=30`. The download timeout is **per-read** — it resets on every received chunk, so a slow-but-progressing download is never punished; only a genuinely dead socket trips it (→ raises → surfaces as an error). Set before `huggingface_hub` import.
- **Watchdog + pool reset** (`model_manager.py`): `get_model()`/`preload_model()` load via `_load_model_with_timeout()`, an `asyncio.wait_for` backstop (`OMNIVOICE_MODEL_LOAD_TIMEOUT`, default 1200s) that drops the poisoned single-worker GPU pool and raises a clear, actionable `RuntimeError` so a **retry gets a fresh worker** instead of queueing behind the wedged thread.
- **Frontend abort backstop** (`useTTS.js`): `AbortController` on `/generate` so the UI never spins forever even if the backend is unreachable; friendly timeout toast.
- **Tests**: watchdog raises + resets pool + releases lock; env/floor parsing.

## Verify
Backend `pytest tests/test_model_load_timeout.py` (2) + `test_model_manager_preload.py` (3) pass; frontend typecheck/build clean, vitest 103/103, legacy 36/0. On Windows, simulate a stalled HF download (unreachable proxy) → within the read-timeout the request now fails with a clear toast and the spinner clears, instead of hanging.

Constraints: cross-platform parity (no OS-specific behavior), backward-compatible with already-installed models, local-first preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling to prevent indefinite hangs during model loading and text-to-speech operations.
  * Network operations now fail gracefully with timeout messages instead of freezing the application.
  * Added automatic recovery mechanisms for stalled operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->