### PR TITLE
fix(docker): runtime API-base override (Settings 'Failed to load engines: Failed to fetch')

### DIFF
--- a/backend/core/spa_inject.py
+++ b/backend/core/spa_inject.py
@@ -1,0 +1,35 @@
+"""Runtime API-base injection for the served SPA (Docker / reverse-proxy).
+
+`VITE_*` vars are inlined at build time, so a prebuilt image cannot take an
+API-base override from `docker run -e`. When `OMNIVOICE_PUBLIC_API_BASE` is set,
+the backend injects it into `index.html` as `window.__OMNIVOICE_API_BASE__`,
+which the SPA's API resolver reads first. These helpers are pure so they can be
+unit-tested without booting the app.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+# Operator-controlled value, but validate to a plain http(s) URL with no
+# whitespace, quotes, or angle brackets so it can never break out of the
+# injected <script> element.
+_URL_RE = re.compile(r"^https?://[^\s<>\"']+$")
+
+
+def is_valid_public_api_base(value: str) -> bool:
+    """True if `value` is a safe http(s) URL we can inject into HTML."""
+    return bool(value) and bool(_URL_RE.match(value))
+
+
+def inject_api_base(html_doc: str, api_base: str) -> str:
+    """Insert `window.__OMNIVOICE_API_BASE__` right after the SPA's <head>.
+
+    `api_base` is JSON-encoded (neutralising quotes); the caller is expected to
+    have validated it via `is_valid_public_api_base` first. Falls back to
+    prepending the snippet if the document has no <head>.
+    """
+    snippet = f"<script>window.__OMNIVOICE_API_BASE__={json.dumps(api_base)};</script>"
+    if "<head>" in html_doc:
+        return html_doc.replace("<head>", "<head>" + snippet, 1)
+    return snippet + html_doc

--- a/backend/main.py
+++ b/backend/main.py
@@ -622,6 +622,37 @@ app.include_router(settings_router.router)  # Phase 1 AUTH-03 endpoints
 
 frontend_path = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
 if os.path.exists(frontend_path):
+    # ── Runtime API-base override (Docker / reverse-proxy deployments) ──────
+    # When OMNIVOICE_PUBLIC_API_BASE is set we inject it into index.html as
+    # `window.__OMNIVOICE_API_BASE__`, which the SPA's API resolver reads first.
+    # Unset (the default) → StaticFiles serves index.html untouched: same-origin,
+    # zero overhead, no behavior change. See core/spa_inject.py.
+    from core.spa_inject import is_valid_public_api_base, inject_api_base
+
+    _public_api_base = os.environ.get("OMNIVOICE_PUBLIC_API_BASE", "").strip().rstrip("/")
+    _index_path = os.path.join(frontend_path, "index.html")
+    if _public_api_base and not is_valid_public_api_base(_public_api_base):
+        logging.getLogger("omnivoice.api").warning(
+            "OMNIVOICE_PUBLIC_API_BASE=%r is not a valid http(s) URL; ignoring.",
+            _public_api_base,
+        )
+        _public_api_base = ""
+
+    if _public_api_base and os.path.isfile(_index_path):
+        from fastapi.responses import HTMLResponse
+
+        def _index_with_api_base() -> "HTMLResponse":
+            with open(_index_path, "r", encoding="utf-8") as _fh:
+                return HTMLResponse(inject_api_base(_fh.read(), _public_api_base))
+
+        @app.get("/", include_in_schema=False)
+        def _index_root():
+            return _index_with_api_base()
+
+        @app.get("/index.html", include_in_schema=False)
+        def _index_html():
+            return _index_with_api_base()
+
     app.mount("/", StaticFiles(directory=frontend_path, html=True), name="frontend")
 else:
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -63,17 +63,26 @@ services:
       - "0.0.0.0:3900:3900"   # ← was 127.0.0.1:3900:3900
 ```
 
-The OmniVoice frontend uses `window.location.host` for its API base when no
-explicit override is set, so opening the UI from `http://<lan-ip>:3900` Just
-Works for both the page load *and* the media-preview requests it kicks off
-afterwards. If you front the app with a reverse proxy and the API and UI
-land on different origins, pin the API base explicitly:
+The OmniVoice frontend defaults to the **same origin** the page was served
+from, so opening the UI from `http://<lan-ip>:3900` Just Works for both the
+page load *and* the API/media requests it makes afterwards.
+
+If you front the app with a **reverse proxy** and the API and UI land on
+different origins, pin the API base explicitly. Use **`OMNIVOICE_PUBLIC_API_BASE`**
+— a *runtime* env var the backend injects into the page, so it works with the
+prebuilt image via `docker run -e` (the older `VITE_OMNIVOICE_API` is inlined at
+*build* time and cannot be set on a prebuilt image):
 
 ```bash
-docker run -e VITE_OMNIVOICE_API=https://api.your-host.example \
+docker run -e OMNIVOICE_PUBLIC_API_BASE=https://api.your-host.example \
   -p 0.0.0.0:3900:3900 \
   ghcr.io/debpalash/omnivoice-studio:latest
 ```
+
+> `OMNIVOICE_PUBLIC_API_BASE` must be a plain `http(s)://…` URL; anything else
+> is ignored and the app falls back to same-origin. If you build from source you
+> may instead bake `VITE_OMNIVOICE_API` at build time, but the runtime var above
+> is simpler and image-agnostic.
 
 > **Security:** OmniVoice ships no authentication. Anything on your LAN with
 > the URL can use the app. Put it behind a reverse proxy with `basic_auth`

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -104,9 +104,11 @@ pane shows 404s for `/media/...`.
 **Cause:** pre-v0.3, the frontend hardcoded `localhost:3900` for media-preview
 URLs, which is wrong when the UI is reached from a different LAN host.
 
-**Fix:** Plan 01-03 ships a fix that derives the media-preview base from
-`window.location.host`. See [docker.md#lan-access](docker.md#lan-access) for the
-override env var (`VITE_OMNIVOICE_API`) when running behind a reverse proxy.
+**Fix:** the frontend derives its API/media base from the page's own origin.
+When running behind a reverse proxy where the UI and API are on different
+origins, set the runtime override `OMNIVOICE_PUBLIC_API_BASE` (works on the
+prebuilt image via `docker run -e`) — see
+[docker.md#lan-access](docker.md#lan-access).
 
 ## 9. Apple Silicon `mlx-whisper` unavailable on Intel mac
 

--- a/frontend/src/api/client.apibase.test.ts
+++ b/frontend/src/api/client.apibase.test.ts
@@ -32,4 +32,20 @@ describe('_resolveApiBase', () => {
     const win = { __TAURI__: {}, location: { origin: 'x', hostname: 'x' } };
     expect(_resolveApiBase({ VITE_API_PORT: '4000' }, win)).toBe('http://127.0.0.1:4000');
   });
+
+  it('runtime window.__OMNIVOICE_API_BASE__ wins over everything (Docker prebuilt-image override)', () => {
+    const win = { __TAURI__: {}, __OMNIVOICE_API_BASE__: 'https://api.example.com/', location: { origin: 'http://x', hostname: 'x' } };
+    // Beats Tauri loopback AND VITE_API_URL; trailing slash stripped.
+    expect(_resolveApiBase({ VITE_API_URL: 'http://10.0.0.5:9' }, win)).toBe('https://api.example.com');
+  });
+
+  it('honors VITE_OMNIVOICE_API (the documented Docker var) and strips trailing slash', () => {
+    const win = { location: { origin: 'http://x', hostname: 'x' } };
+    expect(_resolveApiBase({ VITE_OMNIVOICE_API: 'http://10.0.0.5:9/' }, win)).toBe('http://10.0.0.5:9');
+  });
+
+  it('Tauri via __TAURI_INTERNALS__ → loopback', () => {
+    const win = { __TAURI_INTERNALS__: {}, location: { origin: 'tauri://localhost', hostname: 'localhost' } };
+    expect(_resolveApiBase({}, win)).toBe('http://127.0.0.1:3900');
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,9 +13,18 @@ const viteEnv = import.meta.env ?? {};
 // re-import the module or stub import.meta.env.
 export function _resolveApiBase(env: any, win: any): string {
   const port = env?.VITE_API_PORT || '3900';
-  if (env?.VITE_API_URL) return env.VITE_API_URL;
+  // Explicit override, in precedence order:
+  //   1. window.__OMNIVOICE_API_BASE__ — RUNTIME global the backend injects
+  //      into index.html from OMNIVOICE_PUBLIC_API_BASE. The only override that
+  //      works on a prebuilt Docker image (VITE_* is inlined at build time).
+  //   2. VITE_OMNIVOICE_API — the build-time var documented for Docker/proxy
+  //      deploys and used by utils/apiBase.ts.
+  //   3. VITE_API_URL — legacy alias.
+  const runtime = win && typeof win.__OMNIVOICE_API_BASE__ === 'string' ? win.__OMNIVOICE_API_BASE__ : '';
+  const override = runtime || env?.VITE_OMNIVOICE_API || env?.VITE_API_URL;
+  if (override) return String(override).replace(/\/+$/, '');
   if (!win) return `http://127.0.0.1:${port}`;
-  if (win.__TAURI__) return `http://127.0.0.1:${port}`;
+  if (win.__TAURI__ || win.__TAURI_INTERNALS__) return `http://127.0.0.1:${port}`;
   if (env?.DEV) return `http://${win.location.hostname}:${port}`;
   return win.location.origin;
 }

--- a/frontend/src/utils/apiBase.test.ts
+++ b/frontend/src/utils/apiBase.test.ts
@@ -24,6 +24,7 @@ describe("apiBase.getApiBase", () => {
   });
 
   afterEach(() => {
+    delete (window as Window).__OMNIVOICE_API_BASE__;
     if (originalTauriInternals === undefined) {
       delete (window as Window).__TAURI_INTERNALS__;
     } else {
@@ -61,6 +62,16 @@ describe("apiBase.getApiBase", () => {
     const mod = await import("./apiBase");
     mod._setEnvOverrideForTesting("http://10.0.0.5:3900/");
     expect(mod.getApiBase()).toBe("http://10.0.0.5:3900");
+    mod._setEnvOverrideForTesting(undefined);
+  });
+
+  it("runtime window.__OMNIVOICE_API_BASE__ wins over Tauri + env (Docker prebuilt-image override)", async () => {
+    (window as Window).__TAURI_INTERNALS__ = {};
+    (window as Window).__OMNIVOICE_API_BASE__ = "https://api.example.com/";
+    vi.resetModules();
+    const mod = await import("./apiBase");
+    mod._setEnvOverrideForTesting("http://10.0.0.5:3900");
+    expect(mod.getApiBase()).toBe("https://api.example.com"); // trailing slash stripped
     mod._setEnvOverrideForTesting(undefined);
   });
 

--- a/frontend/src/utils/apiBase.ts
+++ b/frontend/src/utils/apiBase.ts
@@ -27,6 +27,9 @@ declare global {
   interface Window {
     __TAURI_INTERNALS__?: unknown;
     __TAURI__?: unknown;
+    /** Runtime API base injected into index.html by the backend from
+     *  OMNIVOICE_PUBLIC_API_BASE (Docker / reverse-proxy deployments). */
+    __OMNIVOICE_API_BASE__?: string;
   }
 }
 
@@ -63,7 +66,16 @@ function _readEnvOverride(): string | undefined {
 }
 
 export function getApiBase(): string {
-  // 1. Explicit override always wins.
+  // 0. Runtime override injected by the backend (Docker/proxy) wins over
+  //    everything — it's the only knob a prebuilt image can turn at run time.
+  if (typeof window !== "undefined") {
+    const runtime = window.__OMNIVOICE_API_BASE__;
+    if (typeof runtime === "string" && runtime) {
+      return stripTrailingSlash(runtime);
+    }
+  }
+
+  // 1. Explicit build-time override.
   const override = _readEnvOverride();
   if (override) {
     return stripTrailingSlash(override);

--- a/tests/test_spa_inject.py
+++ b/tests/test_spa_inject.py
@@ -1,0 +1,43 @@
+"""Runtime API-base injection helpers (Docker / reverse-proxy deployments).
+
+A prebuilt image can't take a build-time VITE_* override, so the backend
+injects OMNIVOICE_PUBLIC_API_BASE into index.html as a window global. These
+test the pure helpers without booting the app.
+"""
+from __future__ import annotations
+
+from core.spa_inject import inject_api_base, is_valid_public_api_base
+
+
+def test_valid_public_api_base_accepts_http_urls():
+    assert is_valid_public_api_base("https://api.example.com")
+    assert is_valid_public_api_base("http://10.0.0.5:3900")
+    assert is_valid_public_api_base("https://voice.example.com/api")
+
+
+def test_valid_public_api_base_rejects_unsafe_or_empty():
+    assert not is_valid_public_api_base("")
+    assert not is_valid_public_api_base("not a url")
+    assert not is_valid_public_api_base("javascript:alert(1)")
+    # No script breakout possible — angle brackets / quotes are rejected.
+    assert not is_valid_public_api_base('https://x"</script><script>evil()')
+    assert not is_valid_public_api_base("https://x</script>")
+
+
+def test_inject_api_base_into_head():
+    doc = "<html><head><title>x</title></head><body></body></html>"
+    out = inject_api_base(doc, "https://api.example.com")
+    assert '<head><script>window.__OMNIVOICE_API_BASE__="https://api.example.com";</script>' in out
+    assert out.count("<head>") == 1  # injected once, original head preserved
+
+
+def test_inject_api_base_prepends_when_no_head():
+    out = inject_api_base("<body>x</body>", "http://10.0.0.5:3900")
+    assert out.startswith('<script>window.__OMNIVOICE_API_BASE__="http://10.0.0.5:3900";</script>')
+
+
+def test_inject_api_base_json_encodes_value():
+    # json.dumps wraps in double quotes; combined with is_valid_public_api_base
+    # the value can't contain a quote, so the snippet is always well-formed.
+    out = inject_api_base("<head></head>", "https://a/b")
+    assert '="https://a/b";' in out


### PR DESCRIPTION
## Bug
Docker users open the web UI, go to **Settings → Engines**, and get **"Failed to load engines: Failed to fetch"** (a browser `TypeError` — the request never reached a server). Works in the desktop build.

## Root cause
1. **Two divergent API-base resolvers**: `client.ts` (what the Engines tab uses) honored `VITE_API_URL`; `utils/apiBase.ts` (media) honored `VITE_OMNIVOICE_API`. The docs told users to set `VITE_OMNIVOICE_API` — **which the Engines path ignored**.
2. **No working runtime override**: `VITE_*` is inlined at **build** time, so the prebuilt `ghcr.io` image can't take an override from `docker run -e` — leaving reverse-proxy / split-origin deployments with no knob at all. (The standard single-container `localhost:3900` case already works via same-origin; the failure is non-same-origin topologies.)

## Fix
- **Backend** (`core/spa_inject.py` + `main.py`): when `OMNIVOICE_PUBLIC_API_BASE` is set, inject it into `index.html` as `window.__OMNIVOICE_API_BASE__`. The value is validated to a plain `http(s)://` URL (no quotes/angle brackets) so it can't break out of the `<script>`. **Unset (default) → StaticFiles serves `index.html` untouched** — same-origin, zero overhead, no behavior change.
- **Frontend** (`client.ts` + `utils/apiBase.ts`): both resolvers now read the **runtime global first**, then `VITE_OMNIVOICE_API` / `VITE_API_URL`, then fall through to same-origin. `client.ts` also strips trailing slashes and recognizes `__TAURI_INTERNALS__` (parity with the other resolvers).
- **Docs**: `docker.md` + `troubleshooting.md` now document `OMNIVOICE_PUBLIC_API_BASE` — the runtime override that actually works on the prebuilt image.

## Verify
- Backend `pytest tests/test_spa_inject.py` (5) ✓, router smoke (23) ✓.
- Frontend typecheck ✓, resolver tests 16/16 (runtime-global wins; `VITE_OMNIVOICE_API` honored; trailing-slash strip; `__TAURI_INTERNALS__`), full vitest 107/107, build ✓.
- In Docker behind a proxy: `docker run -e OMNIVOICE_PUBLIC_API_BASE=https://api.host …` → Engines tab loads (request targets the configured origin). Standard `localhost:3900` unchanged.

Default same-origin behavior identical on macOS/Windows/Linux; override is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime API base configuration via `OMNIVOICE_PUBLIC_API_BASE` environment variable, allowing dynamic API endpoint setup for Docker deployments without rebuilding the application.

* **Documentation**
  * Updated Docker and troubleshooting guides to explain runtime API base configuration for multi-origin setups, including examples and expected URL format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->