### PR TITLE
fix(stories): preview 404 — route through job-less /generate

### DIFF
--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -17,6 +17,7 @@ import React, { useState, useCallback, useRef } from 'react';
 import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon, Users } from 'lucide-react';
 import { Button, Menu } from '../ui';
 import { parseStoryText, hasStoryMarkers, applyInlineVoice } from '../utils/storyTokens';
+import { generateSpeech } from '../api/generate';
 import './StoriesEditor.css';
 
 // Sentence-aware splitter for the "Paste & auto-split" panel. Walks the
@@ -145,11 +146,15 @@ export default function StoriesEditor({ profiles = [], onGenerate }) {
   }, []);
 
   const fetchChunkAudio = useCallback(async (text, profileId) => {
-    const res = await fetch('/api/dub/preview-segment/__stories__', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, profile_id: profileId || null, speed: 1.0 }),
-    });
+    // Route through the standalone /generate endpoint (job-less TTS) via the
+    // shared api client — same-origin + PIN-aware. The old
+    // /api/dub/preview-segment/__stories__ path 404'd: that route needs a real
+    // dub job, and the bare relative URL skipped the API base entirely (#122-adjacent).
+    const fd = new FormData();
+    fd.append('text', text);
+    fd.append('speed', '1.0');
+    if (profileId) fd.append('profile_id', profileId);
+    const res = await generateSpeech(fd);
     if (!res.ok) throw new Error(`Preview HTTP ${res.status}`);
     const blob = await res.blob();
     return URL.createObjectURL(blob);


### PR DESCRIPTION
The Stories Editor's per-line **Preview** failed with `Preview HTTP 404` (seen live in dev: `Failed to load resource: 404 (__stories__)`).

**Cause:** it POSTed to a bare relative `/api/dub/preview-segment/__stories__` — that dub route requires a real dub job (`__stories__` → 404), and the relative URL also skipped the API base + PIN header.

**Fix:** route preview through the standalone job-less `/generate` endpoint via the shared `generateSpeech` client (same-origin + PIN-aware). Both the simple and `[pause]`/`[voice:]` marker-chained preview paths now work.

Verify: typecheck ✓, build ✓, vitest 107/107. This is Task 1 of `docs/superpowers/plans/2026-05-30-stories-editor.md`; the rest of the "full polish" plan (export, persistence, cast, drag-reorder, i18n) is still available to execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of speech preview generation by switching to the standardized audio generation API client.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->