### PR TITLE
feat(stories): Pro Studio Phase 3 — per-line tone tags + speed

### DIFF
--- a/frontend/src/components/StoriesEditor.css
+++ b/frontend/src/components/StoriesEditor.css
@@ -379,5 +379,53 @@
 }
 
 /* ── Drag-to-reorder ──────────────────────────────────────────────── */
-.stories-track { cursor: grab; }
+.stories-track { cursor: grab; flex-wrap: wrap; }
 .stories-track--dragover { box-shadow: inset 0 2px 0 0 var(--color-accent, #b8bb26); }
+
+/* ── Per-line tone/speed drawer ───────────────────────────────────── */
+.stories-track__btn--on { color: var(--color-accent); background: rgba(255, 255, 255, 0.06); }
+.stories-track__drawer {
+  flex-basis: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border);
+}
+.stories-track__tones { display: flex; flex-wrap: wrap; gap: 4px; }
+.stories-track__tone {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: var(--color-bg-elevated, rgba(0, 0, 0, 0.2));
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-fg);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  padding: 3px 9px;
+  cursor: pointer;
+}
+.stories-track__tone:hover { border-color: var(--color-accent); color: var(--color-accent); }
+.stories-track__speed {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-xs);
+  color: var(--color-fg-subtle);
+}
+.stories-track__speed input[type="range"] { width: 120px; }
+.stories-track__speed-val { font-family: var(--font-mono); color: var(--color-fg); min-width: 44px; }
+.stories-track__reset {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-fg-subtle);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.stories-track__reset:hover { color: var(--color-fg); }

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -10,12 +10,12 @@
  * Spec: docs/superpowers/specs/2026-05-30-stories-editor-studio-design.md
  */
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon, Users, X, Upload, Sparkles } from 'lucide-react';
+import { Plus, Play, Trash2, GripVertical, BookOpen, Mic, Download, Scissors, Pause as PauseIcon, Users, X, Upload, Sparkles, SlidersHorizontal } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Menu } from '../ui';
 import { useAppStore } from '../store';
-import { parseStoryText, hasStoryMarkers, applyInlineVoice } from '../utils/storyTokens';
+import { parseStoryText, hasStoryMarkers, applyInlineVoice, insertToken } from '../utils/storyTokens';
 import { parseScript } from '../utils/parseScript';
 import { importToText } from '../utils/importStory';
 import { generateSpeech } from '../api/generate';
@@ -63,6 +63,17 @@ function genCastId() {
   return `c_${rnd}`;
 }
 
+// Curated inline emotion/sound tags (a subset of utils/constants TAGS) for the
+// per-line tone drawer. Inserting a tag is the model-native way to direct tone.
+const STORY_TONES = [
+  { tag: '[laughter]', icon: '😄', key: 'laugh' },
+  { tag: '[sigh]', icon: '😮‍💨', key: 'sigh' },
+  { tag: '[question-en]', icon: '❓', key: 'question' },
+  { tag: '[surprise-wa]', icon: '😲', key: 'surprise' },
+  { tag: '[confirmation-en]', icon: '✅', key: 'confirm' },
+  { tag: '[dissatisfaction-hnn]', icon: '😒', key: 'dissatisfaction' },
+];
+
 export default function StoriesEditor({ profiles = [] }) {
   const { t } = useTranslation();
 
@@ -95,6 +106,7 @@ export default function StoriesEditor({ profiles = [] }) {
   const [splitMax, setSplitMax] = useState(180);
   const [exporting, setExporting] = useState(false);
   const [exportPct, setExportPct] = useState(0);
+  const [expandedLine, setExpandedLine] = useState(null);
   const trackTextRefs = useRef(new Map());
   const fileInputRef = useRef(null);
   const dragId = useRef(null);
@@ -179,23 +191,12 @@ export default function StoriesEditor({ profiles = [] }) {
     }));
   }, [setTracks]);
 
-  const insertPauseInto = useCallback((trackId) => {
+  const insertTokenInto = useCallback((trackId, token) => {
     const el = trackTextRefs.current.get(trackId);
-    const token = '[pause 0.5s]';
-    setTracks((prev) => prev.map((tk) => {
-      if (tk.id !== trackId) return tk;
-      const pos = el?.selectionStart;
-      if (pos != null && pos >= 0 && pos <= tk.text.length) {
-        const before = tk.text.slice(0, pos);
-        const after = tk.text.slice(pos);
-        const left = before.length && !/\s$/.test(before) ? `${before} ` : before;
-        const right = after.length && !/^\s/.test(after) ? ` ${after}` : after;
-        return { ...tk, text: `${left}${token}${right}` };
-      }
-      const sep = tk.text.length && !/\s$/.test(tk.text) ? ' ' : '';
-      return { ...tk, text: `${tk.text}${sep}${token}` };
-    }));
+    const caret = el ? el.selectionStart : null;
+    setTracks((prev) => prev.map((tk) => (tk.id === trackId ? { ...tk, text: insertToken(tk.text, caret, token) } : tk)));
   }, [setTracks]);
+  const insertPauseInto = useCallback((trackId) => insertTokenInto(trackId, '[pause 0.5s]'), [insertTokenInto]);
 
   const addTrack = useCallback(() => setTracks((prev) => [...prev, makeTrack()]), [setTracks]);
   const removeTrack = useCallback((id) => setTracks((prev) => prev.filter((tk) => tk.id !== id)), [setTracks]);
@@ -204,17 +205,17 @@ export default function StoriesEditor({ profiles = [] }) {
   }, [setTracks]);
 
   // ── Synthesis (preview + export share one fetch) ─────────────────────────
-  const fetchChunkBlob = useCallback(async (text, profileId) => {
+  const fetchChunkBlob = useCallback(async (text, profileId, speed = 1.0) => {
     const fd = new FormData();
     fd.append('text', text);
-    fd.append('speed', '1.0');
+    fd.append('speed', String(speed || 1.0));
     if (profileId) fd.append('profile_id', profileId);
     const res = await generateSpeech(fd); // apiFetch: same-origin + PIN-aware
     return res.blob();
   }, []);
 
-  const fetchChunkAudio = useCallback(async (text, profileId) => {
-    const blob = await fetchChunkBlob(text, profileId);
+  const fetchChunkAudio = useCallback(async (text, profileId, speed = 1.0) => {
+    const blob = await fetchChunkBlob(text, profileId, speed);
     return URL.createObjectURL(blob);
   }, [fetchChunkBlob]);
 
@@ -222,11 +223,12 @@ export default function StoriesEditor({ profiles = [] }) {
     const raw = (track.text || '').trim();
     if (!raw) return;
     const pid = effectiveProfile(track, cast);
+    const spd = track.speed || 1.0;
     setTracks((prev) => prev.map((tk) => (tk.id === track.id ? { ...tk, generating: true } : tk)));
 
     if (!hasStoryMarkers(raw)) {
       try {
-        const url = await fetchChunkAudio(raw, pid);
+        const url = await fetchChunkAudio(raw, pid, spd);
         setTracks((prev) => prev.map((tk) => (tk.id === track.id ? { ...tk, audioUrl: url, generating: false } : tk)));
         const audio = new Audio(url);
         audio.play().catch(() => {});
@@ -240,7 +242,7 @@ export default function StoriesEditor({ profiles = [] }) {
     const parsed = parseStoryText(raw, pid);
     try {
       const audioUrls = await Promise.all(
-        parsed.map((seg) => (seg.type === 'chunk' ? fetchChunkAudio(seg.text, seg.profileId) : Promise.resolve(null))),
+        parsed.map((seg) => (seg.type === 'chunk' ? fetchChunkAudio(seg.text, seg.profileId, spd) : Promise.resolve(null))),
       );
       let cursor = 0;
       const finish = () => {
@@ -278,7 +280,7 @@ export default function StoriesEditor({ profiles = [] }) {
     try {
       const blob = await exportStoryAudio(
         usable,
-        (tk) => effectiveProfile(tk, cast),
+        (tk) => ({ profileId: effectiveProfile(tk, cast), speed: tk.speed || 1.0 }),
         fetchChunkBlob,
         (d, total) => setExportPct(total ? Math.round((d / total) * 100) : 0),
       );
@@ -499,6 +501,9 @@ export default function StoriesEditor({ profiles = [] }) {
                       <Users size={12} />
                     </button>
                   </Menu>
+                  <button className={`stories-track__btn ${expandedLine === track.id ? 'stories-track__btn--on' : ''}`} onClick={(e) => { e.stopPropagation(); setExpandedLine((id) => (id === track.id ? null : track.id)); }} title={t('stories.tune')} aria-label={t('stories.tune')}>
+                    <SlidersHorizontal size={12} />
+                  </button>
                   <button className="stories-track__btn" onClick={(e) => { e.stopPropagation(); insertPauseInto(track.id); }} title={t('stories.insertPause')} aria-label={t('stories.insertPause')}>
                     <PauseIcon size={12} />
                   </button>
@@ -509,6 +514,30 @@ export default function StoriesEditor({ profiles = [] }) {
                     <Trash2 size={12} />
                   </button>
                 </div>
+
+                {expandedLine === track.id && (
+                  <div className="stories-track__drawer" onClick={(e) => e.stopPropagation()}>
+                    <div className="stories-track__tones">
+                      {STORY_TONES.map((tn) => (
+                        <button key={tn.tag} type="button" className="stories-track__tone" onClick={() => insertTokenInto(track.id, tn.tag)} title={tn.tag}>
+                          <span aria-hidden="true">{tn.icon}</span> {t(`stories.tones.${tn.key}`)}
+                        </button>
+                      ))}
+                    </div>
+                    <label className="stories-track__speed">
+                      <span>{t('stories.speed')}</span>
+                      <input
+                        type="range" min="0.5" max="2" step="0.05" value={track.speed || 1}
+                        onChange={(e) => updateTrack(track.id, 'speed', parseFloat(e.target.value))}
+                        aria-label={t('stories.speed')}
+                      />
+                      <span className="stories-track__speed-val">{(track.speed || 1).toFixed(2)}×</span>
+                      {track.speed != null && (
+                        <button type="button" className="stories-track__reset" onClick={() => updateTrack(track.id, 'speed', null)}>{t('stories.reset')}</button>
+                      )}
+                    </label>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -37,6 +37,17 @@
     "insertPause": "Insert a [pause 0.5s] break",
     "preview": "Preview this line",
     "removeLine": "Remove line",
+    "tune": "Tone & speed",
+    "speed": "Speed",
+    "reset": "Reset",
+    "tones": {
+      "laugh": "Laugh",
+      "sigh": "Sigh",
+      "question": "Question",
+      "surprise": "Surprise",
+      "confirm": "Confirm",
+      "dissatisfaction": "Hmph"
+    },
     "lines": "{{count}} lines",
     "characters": "{{count}} characters",
     "minutes": "~{{count}} min",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -37,6 +37,17 @@
     "insertPause": "插入 [pause 0.5s] 停顿",
     "preview": "试听这句",
     "removeLine": "移除台词",
+    "tune": "语气与语速",
+    "speed": "语速",
+    "reset": "重置",
+    "tones": {
+      "laugh": "笑",
+      "sigh": "叹气",
+      "question": "疑问",
+      "surprise": "惊讶",
+      "confirm": "确认",
+      "dissatisfaction": "不满"
+    },
     "lines": "{{count}} 句",
     "characters": "{{count}} 个角色",
     "minutes": "约 {{count}} 分钟",

--- a/frontend/src/utils/storyExport.js
+++ b/frontend/src/utils/storyExport.js
@@ -61,20 +61,22 @@ export function encodeWav(buffer, sampleRate) {
 
 /**
  * Render an ordered track list to one WAV blob.
- * @param tracks          [{ text, character, profileId }]
- * @param resolveProfile  (track) => profileId|null   // applies cast fallback
- * @param fetchChunkBlob  (text, profileId) => Promise<Blob>   // /generate WAV
+ * @param tracks          [{ text, character, profileId, speed }]
+ * @param resolveOpts     (track) => { profileId, speed }   // applies cast fallback
+ * @param fetchChunkBlob  (text, profileId, speed) => Promise<Blob>   // /generate WAV
  * @param onProgress      (done, total) => void
  * @returns Blob (audio/wav)
  */
-export async function exportStoryAudio(tracks, resolveProfile, fetchChunkBlob, onProgress) {
+export async function exportStoryAudio(tracks, resolveOpts, fetchChunkBlob, onProgress) {
   const Ctx = window.AudioContext || window.webkitAudioContext;
   const ctx = new Ctx();
   try {
     const segments = [];
     for (const tk of tracks) {
-      const pid = resolveProfile(tk);
-      for (const seg of parseStoryText(tk.text || '', pid)) segments.push(seg);
+      const opts = resolveOpts(tk) || {};
+      for (const seg of parseStoryText(tk.text || '', opts.profileId)) {
+        segments.push(seg.type === 'chunk' ? { ...seg, speed: opts.speed } : seg);
+      }
     }
     const chunkCount = segments.filter((s) => s.type === 'chunk').length;
     let done = 0;
@@ -84,7 +86,7 @@ export async function exportStoryAudio(tracks, resolveProfile, fetchChunkBlob, o
         buffers.push(silenceBuffer(seg.seconds, ctx.sampleRate));
         continue;
       }
-      const blob = await fetchChunkBlob(seg.text, seg.profileId);
+      const blob = await fetchChunkBlob(seg.text, seg.profileId, seg.speed);
       const decoded = await ctx.decodeAudioData(await blob.arrayBuffer());
       buffers.push(decoded); // decodeAudioData resamples to ctx.sampleRate → safe to concat
       onProgress?.(++done, chunkCount);

--- a/frontend/src/utils/storyTokens.js
+++ b/frontend/src/utils/storyTokens.js
@@ -76,3 +76,21 @@ export function applyInlineVoice(text, selectionStart, selectionEnd, voiceId) {
   }
   return `${before}[voice:${voiceId}]${middle}[voice:default]${after}`;
 }
+
+/**
+ * Insert `token` (e.g. `[pause 0.5s]` or `[laughter]`) at `caret`, padding with
+ * spaces so it survives a re-split and never glues onto a word. With a null/
+ * out-of-range caret it appends to the end. Pure — the caller updates state.
+ */
+export function insertToken(text, caret, token) {
+  const t = String(text || '');
+  if (caret == null || caret < 0 || caret > t.length) {
+    const sep = t.length && !/\s$/.test(t) ? ' ' : '';
+    return `${t}${sep}${token}`;
+  }
+  const before = t.slice(0, caret);
+  const after = t.slice(caret);
+  const left = before.length && !/\s$/.test(before) ? `${before} ` : before;
+  const right = after.length && !/^\s/.test(after) ? ` ${after}` : after;
+  return `${left}${token}${right}`;
+}

--- a/frontend/src/utils/storyTokens.test.js
+++ b/frontend/src/utils/storyTokens.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseStoryText, hasStoryMarkers, applyInlineVoice } from './storyTokens';
+import { parseStoryText, hasStoryMarkers, applyInlineVoice, insertToken } from './storyTokens';
 
 describe('parseStoryText', () => {
   it('returns a single chunk with the default voice when no markers are present', () => {
@@ -82,5 +82,20 @@ describe('applyInlineVoice', () => {
   it('clamps out-of-range indices to the text length', () => {
     const result = applyInlineVoice('xy', 99, 99, 'c');
     expect(result).toBe('xy[voice:c]');
+  });
+});
+
+describe('insertToken', () => {
+  it('inserts at the caret, padding with spaces', () => {
+    expect(insertToken('hello world', 5, '[laughter]')).toBe('hello [laughter] world');
+  });
+  it('appends to the end when the caret is null', () => {
+    expect(insertToken('hello', null, '[pause 0.5s]')).toBe('hello [pause 0.5s]');
+  });
+  it('does not add a leading space at the start of the text', () => {
+    expect(insertToken('hi', 0, '[sigh]')).toBe('[sigh] hi');
+  });
+  it('handles empty text', () => {
+    expect(insertToken('', null, '[laughter]')).toBe('[laughter]');
   });
 });


### PR DESCRIPTION
Phase 3: **studio depth per line**, revealed only when you click the tune button (progressive disclosure).

- **Tone chips** insert OmniVoice's *native* inline emotion/sound tags (`[laughter]`, `[sigh]`, `[question-en]`, `[surprise-wa]`, `[confirmation-en]`, `[dissatisfaction-hnn]`) at the cursor. (The `instruct` param only whitelists gender/age/pitch/style/accent and *rejects* free emotion words — issues #114/#115 — so tags are the correct mechanism.)
- **Per-line speed slider** (0.5–2.0×) threaded into `/generate` for both preview and the audiobook export, with reset-to-default.
- Refactor: pure **`insertToken`** in storyTokens (shared by pause + tones); `exportStoryAudio` resolves per-track `{profileId, speed}`.
- i18n (en + zh-CN); **4 new unit tests**. Full suite **143/143**, typecheck/build/CJK ✓.

Next: Phase 4 (pro output — per-character stems, chapters, MP3 — + named projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Per-line tone insertion (laugh, sigh, question, surprise, confirm, dissatisfaction)
  - Per-track speed adjustment with reset control

* **Style**
  - Improved story editor layout flexibility

* **Internationalization**
  - Added English and Chinese translations for tone and speed controls

* **Tests**
  - Added test coverage for token insertion functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->