### PR TITLE
feat(stories): MP3/M4B export — backend ffmpeg encode + format selector

### DIFF
--- a/backend/api/routers/stories.py
+++ b/backend/api/routers/stories.py
@@ -1,0 +1,79 @@
+"""Stories Editor backend — audio encoding.
+
+The Stories Editor stitches its audiobook client-side (Web Audio → WAV). This
+endpoint optionally transcodes that WAV to a compressed container (MP3/M4B/OGG)
+via ffmpeg, so users can export a small shareable file. Encoding runs through
+`spawn_subprocess` (the Windows-`--reload`-safe helper, #122/#175).
+"""
+import asyncio
+import os
+import re
+import tempfile
+
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from fastapi.responses import Response
+
+from services.ffmpeg_utils import find_ffmpeg, spawn_subprocess
+
+router = APIRouter()
+
+# format -> (ffmpeg audio codec, mime type, file extension). Strict whitelist so
+# the operator-uploaded `format` can never inject arbitrary ffmpeg arguments.
+_FORMATS = {
+    "mp3": ("libmp3lame", "audio/mpeg", "mp3"),
+    "m4b": ("aac", "audio/mp4", "m4b"),
+    "ogg": ("libvorbis", "audio/ogg", "ogg"),
+}
+
+
+@router.post("/stories/encode")
+async def stories_encode(
+    file: UploadFile = File(...),
+    format: str = Form("mp3"),
+    bitrate: str = Form("192k"),
+):
+    """Transcode an uploaded WAV to MP3/M4B/OGG and return the encoded bytes."""
+    fmt = (format or "mp3").lower()
+    if fmt not in _FORMATS:
+        raise HTTPException(status_code=400, detail=f"Unsupported format: {format}")
+    codec, mime, ext = _FORMATS[fmt]
+    if not re.match(r"^\d{2,3}k$", bitrate or ""):
+        bitrate = "192k"
+
+    ffmpeg = find_ffmpeg()
+    if not ffmpeg:
+        raise HTTPException(
+            status_code=501,
+            detail="ffmpeg not available. Install system ffmpeg or re-run the setup.",
+        )
+
+    data = await file.read()
+    in_path = out_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as f:
+            f.write(data)
+            in_path = f.name
+        out_path = f"{in_path[:-4]}.{ext}"
+        proc = await spawn_subprocess(
+            ffmpeg, "-hide_banner", "-loglevel", "error", "-y",
+            "-i", in_path, "-c:a", codec, "-b:a", bitrate, out_path,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0 or not os.path.exists(out_path):
+            detail = (stderr.decode(errors="replace") if stderr else "") or "encode failed"
+            raise HTTPException(status_code=500, detail=detail[:300])
+        with open(out_path, "rb") as fh:
+            encoded = fh.read()
+        return Response(
+            content=encoded,
+            media_type=mime,
+            headers={"Content-Disposition": f'attachment; filename="story.{ext}"'},
+        )
+    finally:
+        for p in (in_path, out_path):
+            if p and os.path.exists(p):
+                try:
+                    os.remove(p)
+                except OSError:
+                    pass

--- a/backend/main.py
+++ b/backend/main.py
@@ -295,6 +295,7 @@ from api.routers import (
     glossary,
     engines,
     tools,
+    stories,
     setup,
     gallery,
     batch,
@@ -620,6 +621,7 @@ app.include_router(projects.router)
 app.include_router(glossary.router)
 app.include_router(engines.router)
 app.include_router(tools.router)
+app.include_router(stories.router)
 app.include_router(setup.router)
 app.include_router(gallery.router)
 app.include_router(batch.router)

--- a/frontend/src/api/stories.ts
+++ b/frontend/src/api/stories.ts
@@ -1,0 +1,15 @@
+import { apiFetch } from './client';
+
+/**
+ * Transcode a client-stitched WAV blob to a compressed format via the backend
+ * ffmpeg endpoint. Same-origin + PIN-aware (apiFetch). Throws on failure so the
+ * caller can fall back to the raw WAV.
+ */
+export async function encodeAudio(wavBlob: Blob, format = 'mp3', bitrate = '192k'): Promise<Blob> {
+  const fd = new FormData();
+  fd.append('file', wavBlob, 'story.wav');
+  fd.append('format', format);
+  fd.append('bitrate', bitrate);
+  const res = await apiFetch('/stories/encode', { method: 'POST', body: fd });
+  return res.blob();
+}

--- a/frontend/src/components/StoriesEditor.css
+++ b/frontend/src/components/StoriesEditor.css
@@ -448,3 +448,14 @@
 }
 .stories-proj__open:hover { color: var(--color-accent); }
 .stories-proj--current { background: rgba(184, 187, 38, 0.08); border-radius: var(--radius-sm); }
+
+/* ── Export format selector ───────────────────────────────────────── */
+.stories-editor__format {
+  background: var(--color-bg-elevated, rgba(0, 0, 0, 0.2));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-fg);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  padding: 3px 6px;
+}

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -19,6 +19,7 @@ import { parseStoryText, hasStoryMarkers, applyInlineVoice, insertToken } from '
 import { parseScript } from '../utils/parseScript';
 import { importToText } from '../utils/importStory';
 import { generateSpeech } from '../api/generate';
+import { encodeAudio } from '../api/stories';
 import { exportStoryAudio, exportStems, buildCueSheet } from '../utils/storyExport';
 import { reorder } from '../utils/storyReorder';
 import { effectiveProfile, castMember, nextCastColor } from '../utils/storyCast';
@@ -127,6 +128,7 @@ export default function StoriesEditor({ profiles = [] }) {
   const [expandedLine, setExpandedLine] = useState(null);
   const [projectsOpen, setProjectsOpen] = useState(false);
   const [projectName, setProjectName] = useState('');
+  const [exportFormat, setExportFormat] = useState('wav');
   const trackTextRefs = useRef(new Map());
   const fileInputRef = useRef(null);
   const dragId = useRef(null);
@@ -311,6 +313,21 @@ export default function StoriesEditor({ profiles = [] }) {
     }
   }, [fetchChunkAudio, cast, setTracks]);
 
+  // Deliver a stitched WAV in the chosen format. MP3 routes through the backend
+  // ffmpeg endpoint; if that fails (e.g. no ffmpeg), fall back to the raw WAV.
+  const deliver = useCallback(async (wavBlob, baseName) => {
+    if (exportFormat === 'mp3') {
+      try {
+        download(await encodeAudio(wavBlob, 'mp3'), `${baseName}.mp3`);
+        return;
+      } catch (err) {
+        console.warn('MP3 encode failed; falling back to WAV:', err);
+        toast(t('stories.mp3Fallback'), { icon: '⚠️' });
+      }
+    }
+    download(wavBlob, `${baseName}.wav`);
+  }, [exportFormat, t]);
+
   const generateAll = useCallback(async () => {
     const usable = tracks.filter((tk) => (tk.text || '').trim());
     if (!usable.length || exporting) return;
@@ -323,7 +340,7 @@ export default function StoriesEditor({ profiles = [] }) {
         fetchChunkBlob,
         (d, total) => setExportPct(total ? Math.round((d / total) * 100) : 0),
       );
-      download(blob, 'story.wav');
+      await deliver(blob, 'story');
       if (chapters.length) download(new Blob([buildCueSheet(chapters)], { type: 'text/plain' }), 'story-chapters.txt');
       toast.success(t('stories.exportDone'));
     } catch (err) {
@@ -332,7 +349,7 @@ export default function StoriesEditor({ profiles = [] }) {
     } finally {
       setExporting(false);
     }
-  }, [tracks, cast, fetchChunkBlob, exporting, t]);
+  }, [tracks, cast, fetchChunkBlob, exporting, deliver, t]);
 
   const exportStemsAll = useCallback(async () => {
     const usable = tracks.filter((tk) => (tk.text || '').trim());
@@ -348,7 +365,7 @@ export default function StoriesEditor({ profiles = [] }) {
       );
       for (const s of stems) {
         const name = ((castMember(cast, s.character) || {}).name || s.character).replace(/[^\w-]+/g, '_');
-        download(s.blob, `story-${name}.wav`);
+        await deliver(s.blob, `story-${name}`);
       }
       toast.success(t('stories.stemsDone', { count: stems.length }));
     } catch (err) {
@@ -357,7 +374,7 @@ export default function StoriesEditor({ profiles = [] }) {
     } finally {
       setExporting(false);
     }
-  }, [tracks, cast, fetchChunkBlob, exporting, t]);
+  }, [tracks, cast, fetchChunkBlob, exporting, deliver, t]);
 
   // ── Stats ─────────────────────────────────────────────────────────────────
   const totalChars = tracks.reduce((acc, tk) => acc + tk.text.length, 0);
@@ -397,6 +414,16 @@ export default function StoriesEditor({ profiles = [] }) {
           <Button size="sm" variant="ghost" onClick={exportStemsAll} disabled={tracks.length === 0 || exporting} aria-label={t('stories.stems')}>
             <Layers size={13} /> {t('stories.stems')}
           </Button>
+          <select
+            className="stories-editor__format"
+            value={exportFormat}
+            onChange={(e) => setExportFormat(e.target.value)}
+            aria-label={t('stories.format')}
+            title={t('stories.format')}
+          >
+            <option value="wav">WAV</option>
+            <option value="mp3">MP3</option>
+          </select>
           <Button size="sm" onClick={generateAll} disabled={tracks.length === 0 || exporting}>
             <Download size={13} /> {exporting ? `${exportPct}%` : t('stories.generateAll')}
           </Button>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -22,6 +22,8 @@
     "chapterN": "Chapter {{n}}",
     "stems": "Stems",
     "stemsDone": "Exported {{count}} character stem(s)",
+    "format": "Export format",
+    "mp3Fallback": "MP3 encode unavailable — downloaded WAV instead.",
     "projects": "Projects",
     "newStory": "New story",
     "save": "Save",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -22,6 +22,8 @@
     "chapterN": "第 {{n}} 章",
     "stems": "分轨",
     "stemsDone": "已导出 {{count}} 个角色分轨",
+    "format": "导出格式",
+    "mp3Fallback": "MP3 编码不可用 — 已改为下载 WAV。",
     "projects": "项目",
     "newStory": "新建故事",
     "save": "保存",

--- a/tests/test_stories_encode.py
+++ b/tests/test_stories_encode.py
@@ -1,0 +1,56 @@
+"""Stories audio-encode endpoint (/stories/encode)."""
+from __future__ import annotations
+
+import io
+import struct
+import wave
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routers import stories
+from services.ffmpeg_utils import find_ffmpeg
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(stories.router)
+    return app
+
+
+def _wav_bytes(sec=0.1, sr=8000):
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        w.writeframes(b"".join(struct.pack("<h", 0) for _ in range(int(sr * sec))))
+    return buf.getvalue()
+
+
+def test_rejects_unknown_format():
+    c = TestClient(_app())
+    r = c.post("/stories/encode", files={"file": ("s.wav", _wav_bytes(), "audio/wav")}, data={"format": "exe"})
+    assert r.status_code == 400
+
+
+def test_501_when_ffmpeg_missing(monkeypatch):
+    monkeypatch.setattr(stories, "find_ffmpeg", lambda: None)
+    c = TestClient(_app())
+    r = c.post("/stories/encode", files={"file": ("s.wav", _wav_bytes(), "audio/wav")}, data={"format": "mp3"})
+    assert r.status_code == 501
+
+
+def test_encodes_mp3_when_ffmpeg_present():
+    if not find_ffmpeg():
+        pytest.skip("ffmpeg not available in this environment")
+    c = TestClient(_app())
+    r = c.post(
+        "/stories/encode",
+        files={"file": ("s.wav", _wav_bytes(0.2), "audio/wav")},
+        data={"format": "mp3", "bitrate": "96k"},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "audio/mpeg"
+    assert len(r.content) > 0


### PR DESCRIPTION
The last optional piece of the pro-studio Stories Editor: compressed export.

- **Format selector** (WAV / MP3) on the toolbar. WAV stays fully client-side; **MP3** routes the client-stitched WAV through a new **`POST /stories/encode`** (ffmpeg via the Windows-`--reload`-safe `spawn_subprocess`, #175).
- **Hardened:** strict format whitelist (`mp3`/`m4b`/`ogg` → fixed codec) + bitrate regex, so the uploaded `format` can't inject ffmpeg args; temp files always cleaned up.
- Both the **audiobook** and **per-character stems** honor the format; MP3 **falls back to WAV** with a toast if ffmpeg is missing.
- `frontend/src/api/stories.ts` `encodeAudio()` (apiFetch — same-origin + PIN).
- **Tests:** format-whitelist → 400, ffmpeg-missing → 501, real MP3 encode (skips if ffmpeg absent). Backend **26** (incl. router smoke — app boots with the new router); frontend **152/152**, typecheck/build/CJK ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audio export format selector—users can now choose between WAV and MP3 formats when exporting stories.
  * MP3 export gracefully falls back to WAV download if encoding is unavailable.

* **Localization**
  * Added English and Simplified Chinese translations for the new export format feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->