### PR TITLE
fix(dub): ExportModal crash — t-shadowing in .map callbacks (#183)

### DIFF
--- a/frontend/src/components/ExportModal.jsx
+++ b/frontend/src/components/ExportModal.jsx
@@ -222,13 +222,13 @@ export default function ExportModal({
             </div>
           </div>
           <div className="export-modal__track-row">
-            {allTracks.map(t => {
-              const on = exportTracks[t.code] !== false;
+            {allTracks.map(track => {
+              const on = exportTracks[track.code] !== false;
               return (
-                <label key={t.code} className={`export-modal__track ${on ? 'is-on' : ''} ${t.kind === 'original' ? 'is-original' : 'is-dub'}`}>
-                  <input type="checkbox" checked={on} onChange={() => toggleTrack(t.code)} />
-                  <span className="export-modal__track-label">{t.label}</span>
-                  {t.kind === 'dub' && t.code === dubLangCode && <Badge tone="brand" size="xs">{t('exportModal.primary')}</Badge>}
+                <label key={track.code} className={`export-modal__track ${on ? 'is-on' : ''} ${track.kind === 'original' ? 'is-original' : 'is-dub'}`}>
+                  <input type="checkbox" checked={on} onChange={() => toggleTrack(track.code)} />
+                  <span className="export-modal__track-label">{track.label}</span>
+                  {track.kind === 'dub' && track.code === dubLangCode && <Badge tone="brand" size="xs">{t('exportModal.primary')}</Badge>}
                 </label>
               );
             })}
@@ -263,8 +263,8 @@ export default function ExportModal({
               <Field label={t('exportModal.default_audio_track')} hint={t('exportModal.default_audio_hint')}>
                 <select className="input-base input-base--xs" value={defaultTrack} onChange={e => setDefaultTrack(e.target.value)}>
                   {exportTracks['original'] !== false && <option value="original">{t('exportModal.original')}</option>}
-                  {(dubTracks || []).filter(t => exportTracks[t] !== false).map(t => (
-                    <option key={t} value={t}>{t.toUpperCase()} {t('exportModal.dub_suffix')}</option>
+                  {(dubTracks || []).filter(code => exportTracks[code] !== false).map(code => (
+                    <option key={code} value={code}>{code.toUpperCase()} {t('exportModal.dub_suffix')}</option>
                   ))}
                 </select>
               </Field>
@@ -315,7 +315,7 @@ export default function ExportModal({
                 {audioBatch === 'primary' && (
                   <select className="input-base input-base--xs export-modal__mt6"
                     value={audioPrimaryLang} onChange={e => setAudioPrimaryLang(e.target.value)}>
-                    {(dubTracks || []).map(t => <option key={t} value={t}>{t.toUpperCase()}</option>)}
+                    {(dubTracks || []).map(code => <option key={code} value={code}>{code.toUpperCase()}</option>)}
                   </select>
                 )}
               </Field>

--- a/frontend/src/components/ExportModal.test.jsx
+++ b/frontend/src/components/ExportModal.test.jsx
@@ -1,0 +1,47 @@
+// Regression for #183: a dub job's Export modal crashed DubTab's ErrorBoundary
+// with "TypeError: e is not a function" — the i18n sweep added t('…') calls
+// inside `.map(t => …)` callbacks where `t` was the loop variable, shadowing the
+// useTranslation `t`. Rendering with a dub track that equals the primary
+// dubLangCode exercises the exact crashing branch.
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '../i18n';
+import ExportModal from './ExportModal';
+
+const noop = () => {};
+
+function renderModal(extra = {}) {
+  return render(
+    <ExportModal
+      open
+      onClose={noop}
+      jobId="job1"
+      filename="video.mp4"
+      dubTracks={['es', 'fr']}
+      dubLangCode="es"
+      preserveBg={false} setPreserveBg={noop}
+      defaultTrack="original" setDefaultTrack={noop}
+      exportTracks={{}} setExportTracks={noop}
+      dualSubs={false} setDualSubs={noop}
+      burnSubs={false} setBurnSubs={noop}
+      API=""
+      triggerDownload={noop}
+      handleDubDownload={noop}
+      handleDubAudioDownload={noop}
+      handleAudioExport={noop}
+      segmentCount={3}
+      {...extra}
+    />
+  );
+}
+
+describe('ExportModal (regression #183)', () => {
+  it('renders with dub tracks incl. the primary dub without throwing', () => {
+    expect(() => renderModal()).not.toThrow();
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<ExportModal open={false} onClose={noop} dubTracks={[]} exportTracks={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #183.

**Bug:** Opening the **Export** modal on a dub job crashes DubTab's ErrorBoundary with `TypeError: e is not a function` (inside an `Array.map` during render).

**Cause:** the zh-CN i18n sweep (#157) added `t('…')` translation calls *inside* `.map(t => …)` / `.filter(t => …)` callbacks in `ExportModal.jsx` where **`t` is the loop variable** (a track object at the primary-badge line; a lang-code string at the default-track `<option>`), shadowing the `useTranslation` `t`. Calling the shadowed `t` as a function throws — minified to `e is not a function`. It fires the moment the modal opens with a dub track present (matches the report's "on a user action, ~43 min after load").

**Fix:** rename the loop vars (`t` → `track`/`code`) at the three render sites so they stop shadowing the translation fn; user-facing strings still go through `t()`. Harmless non-rendering shadows (useMemo/handlers that never call `t()`) left as-is.

**Test:** new `ExportModal.test.jsx` renders the modal with a dub track equal to `dubLangCode` (the exact crashing branch) and asserts no throw; also that it renders nothing when closed. Full suite **154/154**, typecheck/build/legacy ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash in the Export Modal when exporting dub tracks.

* **Tests**
  * Added regression test for Export Modal to prevent future crashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->