### PR TITLE
fix(dub): key per-segment WAVs by stable id, not list index (#185)

### DIFF
--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
 
 from core.db import db_conn
-from core.config import DUB_DIR
+from core.config import DUB_DIR, dub_seg_path
 from core.tasks import task_manager
 from api.routers.dub_core import _get_job
 from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
@@ -712,7 +712,15 @@ async def dub_preview_segment(job_id: str, segment_index: int):
     job = _get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    seg_path = os.path.join(DUB_DIR, job_id, f"seg_{segment_index}.wav")
+    # Resolve the stable-id-named WAV via the render manifest; fall back to the
+    # legacy index name for jobs rendered before id-based naming (#185).
+    order = job.get("seg_order") or []
+    seg_id = order[segment_index] if 0 <= segment_index < len(order) else segment_index
+    seg_path = dub_seg_path(job_id, seg_id)
+    if not os.path.exists(seg_path):
+        _legacy = os.path.join(DUB_DIR, job_id, f"seg_{segment_index}.wav")
+        if os.path.exists(_legacy):
+            seg_path = _legacy
     if not os.path.exists(seg_path):
         raise HTTPException(status_code=404, detail="Segment not generated yet")
     return FileResponse(seg_path, media_type="audio/wav")
@@ -873,9 +881,15 @@ async def dub_export_segments_zip(job_id: str):
         raise HTTPException(status_code=400, detail="No segments available")
 
     zip_buffer = io.BytesIO()
+    order = job.get("seg_order") or []
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         for i, seg in enumerate(segments):
-            seg_path = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+            seg_id = order[i] if i < len(order) else i
+            seg_path = dub_seg_path(job_id, seg_id)
+            if not os.path.exists(seg_path):
+                _legacy = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+                if os.path.exists(_legacy):
+                    seg_path = _legacy
             if os.path.exists(seg_path):
                 speaker = seg.get("speaker_id", "Speaker1").replace(" ", "")
                 start_str = f"{seg['start']:.2f}"

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -723,6 +723,11 @@ async def dub_preview_segment(job_id: str, segment_index: int):
             seg_path = _legacy
     if not os.path.exists(seg_path):
         raise HTTPException(status_code=404, detail="Segment not generated yet")
+    # Containment guard at the sink (dub_seg_path already validates; re-assert
+    # here so static analysis sees the barrier dominate the file read).
+    seg_path = os.path.realpath(seg_path)
+    if not seg_path.startswith(os.path.realpath(DUB_DIR) + os.sep):
+        raise HTTPException(status_code=400, detail="Invalid segment path")
     return FileResponse(seg_path, media_type="audio/wav")
 
 
@@ -890,7 +895,9 @@ async def dub_export_segments_zip(job_id: str):
                 _legacy = dub_seg_path(job_id, i)
                 if os.path.exists(_legacy):
                     seg_path = _legacy
-            if os.path.exists(seg_path):
+            # Containment guard at the sink (see preview endpoint).
+            seg_path = os.path.realpath(seg_path)
+            if seg_path.startswith(os.path.realpath(DUB_DIR) + os.sep) and os.path.exists(seg_path):
                 speaker = seg.get("speaker_id", "Speaker1").replace(" ", "")
                 start_str = f"{seg['start']:.2f}"
                 end_str = f"{seg['end']:.2f}"

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -713,21 +713,20 @@ async def dub_preview_segment(job_id: str, segment_index: int):
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
     # Resolve the stable-id-named WAV via the render manifest; fall back to the
-    # legacy index name for jobs rendered before id-based naming (#185).
+    # legacy index name for jobs rendered before id-based naming (#185). Each
+    # candidate is realpath-normalised and containment-checked BEFORE any
+    # filesystem access, so the guard dominates every path sink.
     order = job.get("seg_order") or []
     seg_id = order[segment_index] if 0 <= segment_index < len(order) else segment_index
-    seg_path = dub_seg_path(job_id, seg_id)
-    if not os.path.exists(seg_path):
-        _legacy = dub_seg_path(job_id, segment_index)
-        if os.path.exists(_legacy):
-            seg_path = _legacy
-    if not os.path.exists(seg_path):
+    base = os.path.realpath(DUB_DIR)
+    seg_path = None
+    for _sid in (seg_id, segment_index):
+        cand = os.path.realpath(dub_seg_path(job_id, _sid))
+        if cand.startswith(base + os.sep) and os.path.exists(cand):
+            seg_path = cand
+            break
+    if not seg_path:
         raise HTTPException(status_code=404, detail="Segment not generated yet")
-    # Containment guard at the sink (dub_seg_path already validates; re-assert
-    # here so static analysis sees the barrier dominate the file read).
-    seg_path = os.path.realpath(seg_path)
-    if not seg_path.startswith(os.path.realpath(DUB_DIR) + os.sep):
-        raise HTTPException(status_code=400, detail="Invalid segment path")
     return FileResponse(seg_path, media_type="audio/wav")
 
 
@@ -887,17 +886,18 @@ async def dub_export_segments_zip(job_id: str):
 
     zip_buffer = io.BytesIO()
     order = job.get("seg_order") or []
+    base = os.path.realpath(DUB_DIR)
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         for i, seg in enumerate(segments):
             seg_id = order[i] if i < len(order) else i
-            seg_path = dub_seg_path(job_id, seg_id)
-            if not os.path.exists(seg_path):
-                _legacy = dub_seg_path(job_id, i)
-                if os.path.exists(_legacy):
-                    seg_path = _legacy
-            # Containment guard at the sink (see preview endpoint).
-            seg_path = os.path.realpath(seg_path)
-            if seg_path.startswith(os.path.realpath(DUB_DIR) + os.sep) and os.path.exists(seg_path):
+            # realpath + containment guard before any filesystem access.
+            seg_path = None
+            for _sid in (seg_id, i):
+                cand = os.path.realpath(dub_seg_path(job_id, _sid))
+                if cand.startswith(base + os.sep) and os.path.exists(cand):
+                    seg_path = cand
+                    break
+            if seg_path:
                 speaker = seg.get("speaker_id", "Speaker1").replace(" ", "")
                 start_str = f"{seg['start']:.2f}"
                 end_str = f"{seg['end']:.2f}"

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -718,7 +718,7 @@ async def dub_preview_segment(job_id: str, segment_index: int):
     seg_id = order[segment_index] if 0 <= segment_index < len(order) else segment_index
     seg_path = dub_seg_path(job_id, seg_id)
     if not os.path.exists(seg_path):
-        _legacy = os.path.join(DUB_DIR, job_id, f"seg_{segment_index}.wav")
+        _legacy = dub_seg_path(job_id, segment_index)
         if os.path.exists(_legacy):
             seg_path = _legacy
     if not os.path.exists(seg_path):
@@ -887,7 +887,7 @@ async def dub_export_segments_zip(job_id: str):
             seg_id = order[i] if i < len(order) else i
             seg_path = dub_seg_path(job_id, seg_id)
             if not os.path.exists(seg_path):
-                _legacy = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+                _legacy = dub_seg_path(job_id, i)
                 if os.path.exists(_legacy):
                     seg_path = _legacy
             if os.path.exists(seg_path):

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
 from core.db import db_conn
-from core.config import DUB_DIR, VOICES_DIR
+from core.config import DUB_DIR, VOICES_DIR, dub_seg_path
 from core.tasks import task_manager
 from schemas.requests import DubRequest
 from services.model_manager import get_model, _gpu_pool
@@ -135,6 +135,10 @@ async def dub_generate(job_id: str, req: DubRequest):
         # `seg_i.wav` on disk and slot into the final mix unchanged.
         regen_only = set(req.regen_only or []) if req.regen_only is not None else None
         seg_ids = req.segment_ids or []
+        # Manifest: stable segment id per current index. Per-segment WAVs are
+        # named by stable id (dub_seg_path) so regen reuses the right audio after
+        # reorder; index-keyed readers (preview/export) resolve via this manifest.
+        job["seg_order"] = [seg_ids[k] if k < len(seg_ids) else f"seg_{k}" for k in range(len(req.segments))]
 
         # Deferred disk writes: collect (index, tensor, sr, seg_id, fingerprint,
         # num_step) tuples during the hot loop and batch-flush after all TTS
@@ -168,7 +172,12 @@ async def dub_generate(job_id: str, req: DubRequest):
             # Partial regen: if this segment isn't in the allow-list, reuse its
             # previously-rendered WAV so the final mix still covers the timeline.
             if regen_only is not None and seg_id not in regen_only:
-                seg_wav_path = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+                seg_wav_path = dub_seg_path(job_id, seg_id)
+                if not os.path.exists(seg_wav_path):
+                    # Back-compat: jobs rendered before id-named files used seg_{index}.wav.
+                    _legacy = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+                    if os.path.exists(_legacy):
+                        seg_wav_path = _legacy
                 if os.path.exists(seg_wav_path):
                     try:
                         _t_cache_0 = time.perf_counter()
@@ -428,7 +437,7 @@ async def dub_generate(job_id: str, req: DubRequest):
                 # RVC needs the WAV on disk, so write it immediately only
                 # when RVC is active (uncommon path).
                 if rvc_is_enabled():
-                    seg_wav_path = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+                    seg_wav_path = dub_seg_path(job_id, seg_id)
                     atomic_save_wav(seg_wav_path, audio_tensor, _model.sampling_rate)
                     try:
                         await loop.run_in_executor(_gpu_pool, apply_rvc, seg_wav_path)
@@ -464,7 +473,7 @@ async def dub_generate(job_id: str, req: DubRequest):
         hashes = job.setdefault("seg_hashes", {})
         quality_map = job.setdefault("seg_num_step", {})
         for (_si, _wav, _sr, _sid, _fp, _nstep) in _pending_seg_writes:
-            seg_wav_path = os.path.join(DUB_DIR, job_id, f"seg_{_si}.wav")
+            seg_wav_path = dub_seg_path(job_id, _sid)
             try:
                 # Apply invisible watermark before writing to disk
                 _wav = embed_watermark(_wav, _sr)

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -175,7 +175,7 @@ async def dub_generate(job_id: str, req: DubRequest):
                 seg_wav_path = dub_seg_path(job_id, seg_id)
                 if not os.path.exists(seg_wav_path):
                     # Back-compat: jobs rendered before id-named files used seg_{index}.wav.
-                    _legacy = os.path.join(DUB_DIR, job_id, f"seg_{i}.wav")
+                    _legacy = dub_seg_path(job_id, i)
                     if os.path.exists(_legacy):
                         seg_wav_path = _legacy
                 if os.path.exists(seg_wav_path):

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 def get_app_data_dir():
@@ -48,6 +49,18 @@ VOICES_DIR = os.path.join(DATA_DIR, "voices")       # Reference audio for profil
 OUTPUTS_DIR = os.path.join(DATA_DIR, "outputs")      # Generated audio files
 DUB_DIR = os.path.join(DATA_DIR, "dub_jobs")
 DB_PATH = os.path.join(DATA_DIR, "omnivoice.db")
+
+
+def dub_seg_path(job_id, seg_id):
+    """Per-segment dub WAV path keyed by the STABLE segment id (not its list
+    index), so partial regeneration reuses the right audio after a
+    delete/merge/split shifts positions (#185). The id is sanitised to a bare
+    filename (no path separators) — defends against traversal via crafted ids.
+    Note: a numeric index `i` sanitises to `seg_{i}.wav`, i.e. the legacy
+    index-based name, so old jobs keep resolving via the same helper.
+    """
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", str(seg_id))
+    return os.path.join(DUB_DIR, job_id, f"seg_{safe}.wav")
 PREVIEW_DIR = os.path.join(DATA_DIR, "preview")
 CRASH_LOG_PATH = os.path.join(DATA_DIR, "crash_log.txt")   # only written on unhandled exceptions
 LOG_PATH = os.path.join(DATA_DIR, "omnivoice.log")          # rolling runtime log — what the Settings UI reads

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -54,13 +54,21 @@ DB_PATH = os.path.join(DATA_DIR, "omnivoice.db")
 def dub_seg_path(job_id, seg_id):
     """Per-segment dub WAV path keyed by the STABLE segment id (not its list
     index), so partial regeneration reuses the right audio after a
-    delete/merge/split shifts positions (#185). The id is sanitised to a bare
-    filename (no path separators) — defends against traversal via crafted ids.
-    Note: a numeric index `i` sanitises to `seg_{i}.wav`, i.e. the legacy
-    index-based name, so old jobs keep resolving via the same helper.
+    delete/merge/split shifts positions (#185). A numeric index `i` sanitises to
+    `seg_{i}.wav`, i.e. the legacy index-based name, so old jobs keep resolving
+    via the same helper.
+
+    Both `job_id` and `seg_id` come from the request, so the result is sanitised
+    (separators stripped) AND verified to stay inside DUB_DIR via realpath
+    containment — raises ValueError on any attempt to escape the dub directory.
     """
-    safe = re.sub(r"[^A-Za-z0-9._-]", "_", str(seg_id))
-    return os.path.join(DUB_DIR, job_id, f"seg_{safe}.wav")
+    safe_job = re.sub(r"[^A-Za-z0-9._-]", "_", str(job_id))
+    safe_seg = re.sub(r"[^A-Za-z0-9._-]", "_", str(seg_id))
+    base = os.path.realpath(DUB_DIR)
+    full = os.path.realpath(os.path.join(base, safe_job, f"seg_{safe_seg}.wav"))
+    if full != base and not full.startswith(base + os.sep):
+        raise ValueError(f"dub segment path escapes DUB_DIR: {job_id!r}/{seg_id!r}")
+    return full
 PREVIEW_DIR = os.path.join(DATA_DIR, "preview")
 CRASH_LOG_PATH = os.path.join(DATA_DIR, "crash_log.txt")   # only written on unhandled exceptions
 LOG_PATH = os.path.join(DATA_DIR, "omnivoice.log")          # rolling runtime log — what the Settings UI reads

--- a/tests/test_dub_seg_path.py
+++ b/tests/test_dub_seg_path.py
@@ -6,6 +6,8 @@ constant can differ from the instance dub_seg_path closes over.
 """
 import os
 
+import pytest
+
 from core.config import dub_seg_path
 
 
@@ -25,3 +27,10 @@ def test_sanitises_against_path_traversal():
     assert os.path.basename(p) == "seg_.._.._etc_passwd.wav"  # slashes neutralised
     assert os.path.basename(os.path.dirname(p)) == "job1"      # stays in the job dir
     assert os.path.basename(dub_seg_path("job1", "a b/c")) == "seg_a_b_c.wav"
+
+
+def test_rejects_parent_dir_job_id():
+    # A bare ".." component survives sanitisation (dots are allowed) but the
+    # realpath containment guard rejects it.
+    with pytest.raises(ValueError):
+        dub_seg_path("..", "5")

--- a/tests/test_dub_seg_path.py
+++ b/tests/test_dub_seg_path.py
@@ -1,0 +1,27 @@
+"""dub_seg_path — stable-id-keyed per-segment WAV path (#185).
+
+Assert on the filename + job dir (invariants), not the absolute DUB_DIR — other
+tests reload core.config against a fixture data dir, so the module-level DUB_DIR
+constant can differ from the instance dub_seg_path closes over.
+"""
+import os
+
+from core.config import dub_seg_path
+
+
+def test_keys_by_stable_id():
+    assert os.path.basename(dub_seg_path("job1", "5")) == "seg_5.wav"
+    # A bare numeric index sanitises to the legacy seg_{i}.wav name, so old jobs
+    # keep resolving through the same helper.
+    assert os.path.basename(dub_seg_path("job1", 5)) == "seg_5.wav"
+    # A stable id that is NOT the current index maps to its own file (the fix).
+    assert os.path.basename(dub_seg_path("job1", "abc-12")) == "seg_abc-12.wav"
+    # Lives under the job's own directory.
+    assert os.path.basename(os.path.dirname(dub_seg_path("job1", "5"))) == "job1"
+
+
+def test_sanitises_against_path_traversal():
+    p = dub_seg_path("job1", "../../etc/passwd")
+    assert os.path.basename(p) == "seg_.._.._etc_passwd.wav"  # slashes neutralised
+    assert os.path.basename(os.path.dirname(p)) == "job1"      # stays in the job dir
+    assert os.path.basename(dub_seg_path("job1", "a b/c")) == "seg_a_b_c.wav"


### PR DESCRIPTION
Closes #185.

**Bug:** partial dub regeneration reloaded/wrote `seg_{i}.wav` **by list index**, but the regen allow-list (`regen_only`) and fingerprints are keyed by **stable id**. After a delete/merge/split (ids preserved, positions shifted), unchanged segments reused a *different* segment's audio → **silently corrupted** dub output on the default in-UI incremental path.

**Fix (stable-id naming + manifest, back-compatible):**
- `core.config.dub_seg_path(job_id, seg_id)` — per-segment path keyed by **stable id**, sanitized to a bare filename (defends against path traversal via crafted ids). A numeric index sanitizes to the legacy `seg_{i}.wav`, so old jobs resolve through the same helper.
- `dub_generate` — write/reload per-segment WAVs by `seg_id` (deferred write, RVC write, regen reload) with a legacy `seg_{i}.wav` fallback; persist a `job['seg_order']` manifest (index → stable id).
- `dub_export` — preview + stems-zip resolve the file via `seg_order` → stable id (legacy fallback), so they keep finding the right audio.
- Test: id-naming, legacy-index equivalence, traversal sanitization.

**Verify:** `tests/test_dub_seg_path.py` + full backend suite (122 passed in-session, router smoke confirms the app boots). Back-compatible with in-flight jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Segments use stable identifiers for consistent preview, export, and partial regeneration.

* **Bug Fixes**
  * Preview now resolves segments via job-specific ordering and returns 404 if not found.
  * ZIP export skips missing segments; per-segment files are saved/loaded by stable IDs with legacy fallbacks.
  * Path construction is validated to prevent directory-escape.

* **Tests**
  * Added tests for stable-id mapping, legacy fallback, and path-sanitization/security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->