### PR TITLE
fix(win): SoniTranslate venv paths cross-platform — Scripts/ on Windows (#186)

### DIFF
--- a/backend/services/sonitranslate.py
+++ b/backend/services/sonitranslate.py
@@ -9,7 +9,6 @@ import asyncio
 import logging
 import os
 import shutil
-import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -30,6 +29,15 @@ SONI_URL = f"http://127.0.0.1:{SONI_PORT}"
 _proc: Optional[subprocess.Popen] = None
 
 
+def _venv_bin(name: str):
+    """Path to an executable inside the SoniTranslate venv, cross-platform.
+    Windows venvs put executables in Scripts\\ (with a .exe suffix); POSIX uses
+    bin/. (Matches engines/indextts/bootstrap.py's _venv_python_path.)"""
+    if sys.platform == "win32":
+        return SONI_VENV / "Scripts" / f"{name}.exe"
+    return SONI_VENV / "bin" / name
+
+
 def is_installed() -> bool:
     """Check if SoniTranslate is cloned and has its entry point."""
     return (SONI_DIR / "app_rvc.py").is_file()
@@ -37,7 +45,7 @@ def is_installed() -> bool:
 
 def is_venv_ready() -> bool:
     """Check if the SoniTranslate virtualenv exists with key deps."""
-    pip = SONI_VENV / "bin" / "pip"
+    pip = _venv_bin("pip")
     return pip.is_file()
 
 
@@ -101,7 +109,7 @@ async def install(progress_callback=None) -> dict:
         await proc.communicate()
 
         # Install base requirements
-        pip = str(SONI_VENV / "bin" / "pip")
+        pip = str(_venv_bin("pip"))
         if progress_callback:
             progress_callback("Installing base requirements (this may take a while)...")
 
@@ -138,7 +146,7 @@ async def start() -> dict:
     if not is_installed():
         raise RuntimeError("SoniTranslate not installed. Call /engines/sonitranslate/install first.")
 
-    python = str(SONI_VENV / "bin" / "python") if is_venv_ready() else sys.executable
+    python = str(_venv_bin("python")) if is_venv_ready() else sys.executable
 
     # Phase 1 AUTH-01/AUTH-04 + INST-12: env built via the shared
     # `engine_env.build_engine_env()` helper. It resolves HF_TOKEN +
@@ -187,7 +195,7 @@ async def stop() -> dict:
     if _proc is None:
         return {"stopped": False, "reason": "not_running"}
 
-    _proc.send_signal(signal.SIGTERM)
+    _proc.terminate()  # cross-platform (SIGTERM on POSIX, TerminateProcess on Windows)
     try:
         _proc.wait(timeout=5)
     except subprocess.TimeoutExpired:

--- a/tests/test_sonitranslate_venv.py
+++ b/tests/test_sonitranslate_venv.py
@@ -1,0 +1,16 @@
+"""SoniTranslate venv binary paths must be cross-platform (#186)."""
+from services import sonitranslate as s
+
+
+def test_venv_bin_windows(monkeypatch):
+    monkeypatch.setattr(s.sys, "platform", "win32")
+    p = s._venv_bin("pip")
+    assert p.name == "pip.exe"
+    assert p.parent.name == "Scripts"
+
+
+def test_venv_bin_posix(monkeypatch):
+    monkeypatch.setattr(s.sys, "platform", "linux")
+    p = s._venv_bin("python")
+    assert p.name == "python"
+    assert p.parent.name == "bin"


### PR DESCRIPTION
Closes #186.

**Bug:** `sonitranslate.py` hardcoded `SONI_VENV/"bin"/{pip,python}` (POSIX). On Windows, `python -m venv` creates `Scripts\` (with `.exe`), so `is_venv_ready()` was always `False` (install loops), and `start()` fell back to the app's own interpreter → SoniTranslate never came up → `RuntimeError("…failed to start within 30s")`.

**Fix:** add `_venv_bin(name)` → `Scripts/{name}.exe` on win32 else `bin/{name}` (mirrors the existing `engines/indextts/bootstrap.py` pattern); use it for the `is_venv_ready`/`install`/`start` pip+python paths. Also `stop()` now uses `_proc.terminate()` (cross-platform) instead of `send_signal(SIGTERM)`, and drops the now-unused `signal` import.

**Test:** `_venv_bin` returns `Scripts/pip.exe` on win32 and `bin/python` on posix. Router smoke confirms the app still boots.

(Opt-in/experimental engine — Windows-only impact — but now functional there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cross-platform compatibility for virtual environment path handling, improving reliability on Windows and Linux systems.

* **Tests**
  * Added unit tests to verify cross-platform virtual environment binary path resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->