### PR TITLE
feat(dub): move Generate Dub + Export to the header bar

### DIFF
--- a/frontend/src/pages/DubTab.css
+++ b/frontend/src/pages/DubTab.css
@@ -17,6 +17,9 @@
 }
 .dub-head__title     { display: flex; align-items: center; gap: var(--space-3); margin-bottom: 0; min-width: 0; flex: 1; }
 .dub-head__actions   { display: flex; gap: var(--space-2); align-items: center; flex-shrink: 0; }
+/* Primary actions (Generate/Export/Stop) relocated onto the header bar; a thin
+   divider separates them from Save/Reset and sm FooterBtns keep it compact. */
+.dub-head__primary   { display: flex; gap: var(--space-2); align-items: center; padding-left: var(--space-2); border-left: 1px solid var(--color-border, #3a3a3a); }
 .dub-head__filename  { font-weight: var(--weight-semibold); font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--color-fg); }
 .dub-head__meta      { color: var(--color-fg-muted); font-weight: 400; white-space: nowrap; font-size: 0.72rem; }
 .dub-head__project   { color: #b8bb26; margin-left: var(--space-3); white-space: nowrap; font-size: 0.72rem; }

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -587,6 +587,30 @@ export default function DubTab(props) {
             <div className="dub-head__actions">
               <Button variant="subtle" size="sm" onClick={saveProject} leading={<Save size={9} />}>{t('dub.save')}</Button>
               <Button variant="danger" size="sm" onClick={resetDub}>{t('dub.reset')}</Button>
+              {/* Primary actions live on the header bar (compact) — moved up from the footer. */}
+              <div className="dub-head__primary">
+                {dubStep === 'stopping' ? (
+                  <FooterBtn sm tone="stopping" disabled icon={<Loader className="spinner" size={9} />} label={t('dub.stopping')} />
+                ) : dubStep === 'generating' ? (
+                  <FooterBtn sm tone="danger" onClick={handleDubStop} icon={<Square size={9} />}
+                    label={t('dub.stop_progress', { current: dubProgress.current, total: dubProgress.total })} />
+                ) : (
+                  <>
+                    <FooterBtn sm tone={dubSegments.length ? 'pink' : 'idle'} onClick={() => handleDubGenerate()}
+                      disabled={!dubSegments.length} icon={<Play size={11} />} label={t('dub.generate_dub')} />
+                    {dubStep === 'done' && incrementalPlan && incrementalPlan.stale?.length > 0 && (
+                      <FooterBtn sm tone="pink"
+                        onClick={() => handleDubGenerate({ regenOnly: incrementalPlan.stale, preview: true })}
+                        icon={<Play size={11} />}
+                        label={t('dub.regen_changed', { count: incrementalPlan.stale.length })} />
+                    )}
+                  </>
+                )}
+                <FooterBtn sm tone={dubStep === 'done' ? 'green' : 'idle'}
+                  disabled={dubStep !== 'done' && !dubSegments.length}
+                  onClick={() => setExportOpen(true)}
+                  icon={<Download size={11} />} label={t('dub.export_btn')} />
+              </div>
             </div>
           </div>
 
@@ -1084,34 +1108,7 @@ export default function DubTab(props) {
                 </div>
               );
             })()}
-            <div className="dub-footer-btns">
-              {dubStep === 'stopping' ? (
-                <FooterBtn tone="stopping" disabled icon={<Loader className="spinner" size={9} />} label={t('dub.stopping')} />
-              ) : dubStep === 'generating' ? (
-                <FooterBtn tone="danger" onClick={handleDubStop} icon={<Square size={9} />}
-                  label={t('dub.stop_progress', { current: dubProgress.current, total: dubProgress.total })} />
-              ) : (
-                <>
-                  <FooterBtn tone={dubSegments.length ? 'pink' : 'idle'} onClick={() => handleDubGenerate()}
-                    disabled={!dubSegments.length} icon={<Play size={11} />} label={t('dub.generate_dub')} />
-                  {dubStep === 'done' && incrementalPlan && incrementalPlan.stale?.length > 0 && (
-                    <FooterBtn
-                      tone="pink"
-                      onClick={() => handleDubGenerate({ regenOnly: incrementalPlan.stale, preview: true })}
-                      icon={<Play size={11} />}
-                      label={t('dub.regen_changed', { count: incrementalPlan.stale.length })}
-                    />
-                  )}
-                </>
-              )}
-              <FooterBtn
-                tone={dubStep === 'done' ? 'green' : 'idle'}
-                disabled={dubStep !== 'done' && !dubSegments.length}
-                onClick={() => setExportOpen(true)}
-                icon={<Download size={11} />}
-                label={t('dub.export_btn')}
-              />
-            </div>
+            {/* Generate / Export / Stop actions moved to the header bar (dub-head__primary). */}
           </div>
         </div>
       )}


### PR DESCRIPTION
Relocates the primary-action cluster (**Generate Dub** / Stop / Stopping / Regen-changed + **Export**) from the footer button bar up to the **header bar** next to Save/Reset, as compact `sm` FooterBtns behind a thin divider. The footer keeps just the output settings. Tighter layout, primary CTA next to the file/Save/Reset context. typecheck/build/vitest 154/154 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized primary action controls (Generate, Export, Stop) from footer to header bar with updated visual styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->