### PR TITLE
fix(ui): larger collapsed-sidebar icons (Projects/History/Exports)

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -106,7 +106,7 @@ export default function Sidebar(props) {
             style={{ '--sidebar-tab-accent': accent }}
             title={`${tabLabel[id]} (${tabCount[id]})`}
           >
-            <Icon size={13} />
+            <Icon size={isSidebarCollapsed ? 18 : 13} />
             {tabCount[id] > 0 && <span className="sidebar__tab-badge">{tabCount[id]}</span>}
           </button>
         ))}


### PR DESCRIPTION
When the sidebar is collapsed, the Projects/History/Exports tab icons were rendered at `size=13` — too small as the sole affordance. Bumped to **18 when collapsed** (expanded tab bar keeps 13). typecheck/build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar tab icons now intelligently adjust their size based on sidebar state—expanding when collapsed and shrinking when expanded for improved visual clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->