### PR TITLE
fix(ui): compact the top-bar height

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -302,7 +302,7 @@ samp,
   /* Matches the LogsFooter's chrome: flat bg, hairline bottom border,
      no radial glow, no blur, no decorative SVG ribbon. The pulsing
      accent dot + italic logo still carry the brand. */
-  padding: 6px 16px 6px 64px;
+  padding: 3px 16px 3px 64px;
   background: var(--chrome-bg);
   border-bottom: 1px solid var(--chrome-border);
   user-select: none;
@@ -575,7 +575,7 @@ samp,
   50% { transform: scaleY(1.25); opacity: 1; }
 }
 .header-area h1 {
-  font-size: 1.1rem; font-weight: 700;
+  font-size: 1.05rem; font-weight: 700; line-height: 1.15;
   background: linear-gradient(135deg, #fff 0%, #a1a1aa 100%);
   -webkit-background-clip: text; -webkit-text-fill-color: transparent;
   letter-spacing: -0.01em;


### PR DESCRIPTION
Per request (keep the top bar where it is, just make it shorter): `.header-area` vertical padding **6px → 3px** + tighter title (`line-height: 1.15`, `1.05rem`). Reclaims vertical space for content. build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined header layout with adjusted spacing and typography for a more compact appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->