### PR TITLE
feat(dub): density pass — tighter segment rows

### DIFF
--- a/frontend/src/components/DubSegmentTable.css
+++ b/frontend/src/components/DubSegmentTable.css
@@ -18,7 +18,7 @@
 }
 
 .dub-segment-table__header {
-  padding: 4px 6px !important;
+  padding: 3px 6px !important;
   /* Header cells normally carry explicit widths from Table.jsx — neutralise
      them so the grid template wins. */
 }
@@ -32,8 +32,8 @@
 }
 
 .segment-table .segment-row {
-  padding: 4px 6px;
-  min-height: 30px;
+  padding: 3px 6px;
+  min-height: 27px;
 }
 
 .dub-segment-table__body { flex: 1; min-height: 0; }


### PR DESCRIPTION
Safe slice of the compactness review: segment-row `min-height` 30→27 and `padding` 4→3px (header + rows), shaving per-row vertical space without clipping the two-line translated+ORIG content. Higher-impact wins (collapse the stacked TRANSCRIPT/GLOSSARY/translations-ready bars + borders→tints) are a visual follow-up. build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined dub segment table layout with reduced padding and row heights for a more compact appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->