### PR TITLE
feat(ui): density follow-up — tighter studio-panel padding

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2110,7 +2110,7 @@ div[role="dialog"].audio-trimmer {
   background: var(--chrome-bg);
   border: 1px solid var(--chrome-border);
   border-radius: 0;
-  padding: 14px 16px;
+  padding: 10px 12px;
   position: relative;
   overflow: auto;
   display: flex; flex-direction: column;


### PR DESCRIPTION
Continues the compactness pass: `.studio-panel` padding **14px 16px → 10px 12px**, reclaiming space uniformly across the studio panels (left + right columns). Safe global tightening; the larger bar-merge + borders→tints remain a visual-iteration follow-up. build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted padding on studio panels for a more compact visual appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/debpalash/OmniVoice-Studio/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->