### PR TITLE
feat(dub): FunASR cam++ inline diarization (#182 Phase 2)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -27,6 +27,7 @@ from services.ffmpeg_utils import find_ffmpeg, _get_semaphore, _spawn_with_retry
 from services.segmentation import (
     segment_transcript,
     assign_speakers_from_diarization,
+    assign_speakers_from_turns,
     assign_speakers_heuristic,
     clean_up_segments,
 )
@@ -440,6 +441,9 @@ async def dub_transcribe_stream(job_id: str):
         detected_lang = None
         next_seg_id = 0
         chunk_errors: list[str] = []
+        # Speaker turns from an ASR backend that diarizes inline (FunASR cam++).
+        # When present, _diarize() uses them and skips pyannote (Phase 2, #182).
+        asr_speaker_turns: list[dict] = []
 
         for i in range(chunks_n):
             if job.get("aborted"):
@@ -471,7 +475,16 @@ async def dub_transcribe_stream(job_id: str):
                         a0 = (ts[0] if ts[0] is not None else 0.0) + offset
                         a1 = (ts[1] if ts[1] is not None else 0.0) + offset
                         shifted.append({"text": c.get("text", ""), "timestamp": (a0, a1)})
-                    return {"chunks": shifted, "language": r.get("language")}
+                    # Inline-diarization speaker turns (FunASR cam++), offset-shifted
+                    # to the full-audio timeline so _diarize() can use them.
+                    turns = []
+                    for seg in r.get("segments", []) or []:
+                        spk = seg.get("speaker")
+                        s0, s1 = seg.get("start"), seg.get("end")
+                        if spk is None or s0 is None or s1 is None:
+                            continue
+                        turns.append({"start": s0 + offset, "end": s1 + offset, "speaker": spk})
+                    return {"chunks": shifted, "language": r.get("language"), "speaker_turns": turns}
                 except Exception as e:
                     logger.exception("chunk transcribe failed (backend=%s)", _asr_backend.id)
                     return {"chunks": [], "language": None, "error": str(e)}
@@ -506,6 +519,7 @@ async def dub_transcribe_stream(job_id: str):
                 logger.warning("Chunk %d/%d error: %s", i + 1, chunks_n, part["error"])
             if detected_lang is None and part.get("language"):
                 detected_lang = part["language"]
+            asr_speaker_turns.extend(part.get("speaker_turns") or [])
             chunk_segs = segment_transcript(part, duration=t1, scene_cuts=scene_cuts)
             chunk_segs = assign_speakers_heuristic(chunk_segs)
             for s in chunk_segs:
@@ -564,6 +578,12 @@ async def dub_transcribe_stream(job_id: str):
             attach an `error_class` so the front-end's errorDocsMap can
             render a "See docs" deeplink instead of a dead-end toast.
             """
+            # The active ASR backend already diarized inline (FunASR cam++):
+            # use its speaker turns directly and skip pyannote entirely (#182).
+            if asr_speaker_turns:
+                logger.info("Using inline ASR diarization (%d turns); skipping pyannote.", len(asr_speaker_turns))
+                return assign_speakers_from_turns(all_segments, asr_speaker_turns), None
+
             from services.model_manager import (
                 DIARIZATION_ERR_LICENSE,
                 DIARIZATION_ERR_LOAD,

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -854,6 +854,9 @@ class FunASRBackend(ASRBackend):
     def __init__(self):
         self._model_name = os.environ.get("ASR_MODEL_FUNASR", "iic/SenseVoiceSmall")
         self._vad_model = os.environ.get("ASR_FUNASR_VAD", "fsmn-vad")
+        # cam++ speaker model → inline diarization (Phase 2). Set ASR_FUNASR_SPK=""
+        # to disable and fall back to the dub pipeline's pyannote/heuristic path.
+        self._spk_model = os.environ.get("ASR_FUNASR_SPK", "cam++")
         self._model = None
 
     @classmethod
@@ -868,8 +871,11 @@ class FunASRBackend(ASRBackend):
         if self._model is not None:
             return
         from funasr import AutoModel
-        logger.info("FunASR loading %s (vad=%s)", self._model_name, self._vad_model)
-        self._model = AutoModel(model=self._model_name, vad_model=self._vad_model, disable_update=True)
+        kwargs = {"model": self._model_name, "vad_model": self._vad_model, "disable_update": True}
+        if self._spk_model:
+            kwargs["spk_model"] = self._spk_model
+        logger.info("FunASR loading %s (vad=%s, spk=%s)", self._model_name, self._vad_model, self._spk_model or "off")
+        self._model = AutoModel(**kwargs)
 
     def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
         self._ensure_model()

--- a/backend/services/segmentation.py
+++ b/backend/services/segmentation.py
@@ -494,6 +494,44 @@ def assign_speakers_from_diarization(
     return segments
 
 
+def assign_speakers_from_turns(
+    segments: List[dict],
+    turns: List[dict],
+) -> List[dict]:
+    """Assign speaker_id by overlap against a list of ``{start, end, speaker}``
+    turns produced by an ASR backend that diarizes inline (e.g. FunASR's cam++).
+
+    Mirrors :func:`assign_speakers_from_diarization`'s overlap-weighting (winner
+    = most-overlapping speaker; midpoint membership as fallback) without a
+    pyannote object. ``speaker`` is used verbatim — FunASR already labels its
+    speakers ``"Speaker N"``. Falls back to the silence-gap heuristic when no
+    usable turns are supplied.
+    """
+    clean = [
+        t for t in (turns or [])
+        if t.get("speaker") is not None and t.get("start") is not None and t.get("end") is not None
+    ]
+    if not clean:
+        return assign_speakers_heuristic(segments)
+    for s in segments:
+        start, end = s["start"], s["end"]
+        mid = (start + end) / 2.0
+        overlap: dict = {}
+        for t in clean:
+            left = max(start, t["start"])
+            right = min(end, t["end"])
+            if right > left:
+                overlap[t["speaker"]] = overlap.get(t["speaker"], 0.0) + (right - left)
+        if overlap:
+            s["speaker_id"] = max(overlap.items(), key=lambda kv: kv[1])[0]
+        else:
+            for t in clean:
+                if t["start"] <= mid <= t["end"]:
+                    s["speaker_id"] = t["speaker"]
+                    break
+    return segments
+
+
 def assign_speakers_heuristic(segments: List[dict]) -> List[dict]:
     """Two-speaker alternation based on silence gaps."""
     current = 1

--- a/tests/test_assign_speakers_from_turns.py
+++ b/tests/test_assign_speakers_from_turns.py
@@ -1,0 +1,33 @@
+"""assign_speakers_from_turns — inline-ASR diarization (FunASR cam++, #182 Phase 2)."""
+from services.segmentation import assign_speakers_from_turns
+
+
+def test_overlap_winner():
+    segs = [{"start": 0.0, "end": 2.0}, {"start": 2.0, "end": 4.0}]
+    turns = [
+        {"start": 0.0, "end": 2.1, "speaker": "Speaker 1"},
+        {"start": 2.1, "end": 4.0, "speaker": "Speaker 2"},
+    ]
+    out = assign_speakers_from_turns(segs, turns)
+    assert out[0]["speaker_id"] == "Speaker 1"   # 2.0s overlap vs 0
+    assert out[1]["speaker_id"] == "Speaker 2"   # 1.9s overlap vs 0.1
+
+
+def test_assigns_from_containing_turn():
+    segs = [{"start": 5.0, "end": 6.0}]
+    turns = [{"start": 4.0, "end": 7.0, "speaker": "Speaker 3"}]
+    assert assign_speakers_from_turns(segs, turns)[0]["speaker_id"] == "Speaker 3"
+
+
+def test_drops_malformed_turns():
+    segs = [{"start": 0.0, "end": 1.0}]
+    turns = [{"start": 0.0, "end": 1.0}, {"speaker": "X"}, {"start": 0.0, "end": 1.0, "speaker": "Speaker 2"}]
+    assert assign_speakers_from_turns(segs, turns)[0]["speaker_id"] == "Speaker 2"
+
+
+def test_empty_turns_falls_back_to_heuristic():
+    # >1.2s gap → the silence-gap heuristic alternates speakers.
+    segs = [{"start": 0.0, "end": 1.0}, {"start": 5.0, "end": 6.0}]
+    out = assign_speakers_from_turns(segs, [])
+    assert out[0]["speaker_id"] == "Speaker 1"
+    assert out[1]["speaker_id"] == "Speaker 2"


### PR DESCRIPTION
Phase 2 of #182 — the 'all-in-one' diarization. When **FunASR** is the active ASR backend, use its **cam++** per-segment speaker IDs directly and **skip pyannote**.

- `FunASRBackend` loads `spk_model='cam++'` (`ASR_FUNASR_SPK`, set `''` to disable); `transcribe()`/`_normalize_funasr` already surface per-segment speakers.
- `segmentation.assign_speakers_from_turns()` — generalised overlap-weighted speaker assignment from `{start,end,speaker}` turns (mirrors `assign_speakers_from_diarization` without a pyannote object; falls back to the silence-gap heuristic when no turns). Pure + tested.
- `dub_core`: collects offset-shifted speaker turns per chunk; `_diarize()` uses them and skips pyannote when present. **Default WhisperX flow unchanged** (no turns → existing pyannote/heuristic).

4 new tests; router smoke confirms boot. Closes the #182 diarization ask (combined with #191 Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline speaker diarization support for streamed transcriptions, enabling improved speaker identification during chunked audio processing.
  * Enhanced speaker assignment with intelligent overlap detection and fallback mechanisms.

* **Tests**
  * Added comprehensive test coverage for the new speaker assignment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->