### PR TITLE
feat(update): non-blocking auto-update — progress, states, busy-gating

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ const TranscriptionsPage = lazy(() => import('./pages/Transcriptions'));
 const StoriesEditor = lazy(() => import('./components/StoriesEditor'));
 
 import Header from './components/Header';
+import UpdateBadge from './components/UpdateBadge';
 import NavRail from './components/NavRail';
 import ErrorBoundary from './components/ErrorBoundary';
 import FloatingPill from './components/FloatingPill';
@@ -61,6 +62,7 @@ import { saveProject as apiSaveProject, loadProject as apiLoadProject, deletePro
 import { exportAction, exportReveal, exportRecord } from './api/exports';
 
 import { isTauri, doubleClickMaximize, fileToMediaUrl, playBlobAudio, playPing } from './utils/media';
+import { checkForUpdate } from './utils/updater';
 import i18n from './i18n';
 
 function App() {
@@ -393,29 +395,10 @@ function App() {
     if (typeof window === 'undefined') return;
     if (!('__TAURI_INTERNALS__' in window)) return;
     if (import.meta.env.DEV) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const [{ check }, { relaunch }, { ask }] = await Promise.all([
-          import('@tauri-apps/plugin-updater'),
-          import('@tauri-apps/plugin-process'),
-          import('@tauri-apps/plugin-dialog'),
-        ]);
-        const update = await check();
-        if (cancelled || !update) return;
-        const proceed = await ask(
-          `A new version (${update.version}) of OmniVoice Studio is available.\n\nWhat's new:\n${update.body || '— see release notes'}\n\nDownload and install now?`,
-          { title: 'Update available', kind: 'info' },
-        );
-        if (!proceed) return;
-        await update.downloadAndInstall();
-        await relaunch();
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.debug('Updater check failed (non-fatal):', e);
-      }
-    })();
-    return () => { cancelled = true; };
+    // Non-blocking: surface availability into the store. The UpdateBadge lets
+    // the user install + restart when they choose (with a progress bar), so an
+    // update never interrupts in-flight work.
+    checkForUpdate(useAppStore.getState());
   }, []);
 
   // ── DESKTOP NATIVE INTEGRATION ──
@@ -861,6 +844,7 @@ function App() {
       <FloatingPill />
 
 
+      <UpdateBadge />
       <Header
         mode={mode} setMode={setMode}
         sysStats={sysStats} modelStatus={modelStatus}

--- a/frontend/src/components/UpdateBadge.css
+++ b/frontend/src/components/UpdateBadge.css
@@ -1,0 +1,42 @@
+.update-badge {
+  position: fixed;
+  top: 38px;
+  right: 12px;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+}
+.update-badge__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(184, 187, 38, 0.14);
+  border: 1px solid rgba(184, 187, 38, 0.45);
+  color: #b8bb26;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+.update-badge__btn:hover { background: rgba(184, 187, 38, 0.22); }
+.update-badge__btn--ready {
+  background: rgba(131, 165, 152, 0.18);
+  border-color: rgba(131, 165, 152, 0.5);
+  color: #8ec07c;
+}
+.update-badge__progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--chrome-bg, #1d2021);
+  border: 1px solid var(--chrome-border, #3a3a3a);
+  color: #ebdbb2;
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+.update-badge__bar { width: 60px; height: 3px; background: rgba(255, 255, 255, 0.12); border-radius: 2px; overflow: hidden; }
+.update-badge__bar span { display: block; height: 100%; background: #b8bb26; }

--- a/frontend/src/components/UpdateBadge.jsx
+++ b/frontend/src/components/UpdateBadge.jsx
@@ -1,0 +1,47 @@
+// Non-blocking auto-update surface: a small pill that appears when an update is
+// available / downloading / ready. Replaces the old blocking ask() dialog so an
+// update never interrupts in-flight work — the user installs when they choose,
+// and the action is gated while a dub job is running.
+import { useTranslation } from 'react-i18next';
+import { Download, Loader, RotateCw } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { useAppStore } from '../store';
+import { installUpdate } from '../utils/updater';
+import './UpdateBadge.css';
+
+export default function UpdateBadge() {
+  const { t } = useTranslation();
+  const status = useAppStore((s) => s.updateStatus);
+  const version = useAppStore((s) => s.updateVersion);
+  const progress = useAppStore((s) => s.updateProgress);
+  const dubStep = useAppStore((s) => s.dubStep);
+
+  if (status === 'idle' || status === 'checking' || status === 'error') return null;
+
+  const busy = dubStep === 'generating';
+  const onInstall = () => {
+    if (busy) { toast(t('update.busy'), { icon: '⏳' }); return; }
+    installUpdate(useAppStore.getState());
+  };
+
+  return (
+    <div className="update-badge" role="status">
+      {status === 'available' && (
+        <button type="button" className="update-badge__btn" onClick={onInstall} title={t('update.install_hint')}>
+          <Download size={12} /> {t('update.available', { version: version || '' })} · {t('update.install')}
+        </button>
+      )}
+      {status === 'downloading' && (
+        <span className="update-badge__progress">
+          <Loader size={12} className="spinner" /> {t('update.downloading', { pct: Math.round(progress) })}
+          <span className="update-badge__bar"><span style={{ width: `${progress}%` }} /></span>
+        </span>
+      )}
+      {status === 'ready' && (
+        <button type="button" className="update-badge__btn update-badge__btn--ready" onClick={onInstall}>
+          <RotateCw size={12} /> {t('update.restart')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,4 +1,12 @@
 {
+  "update": {
+    "available": "Update {{version}} available",
+    "install": "Install & Restart",
+    "install_hint": "Download the update and restart into the new version",
+    "downloading": "Updating… {{pct}}%",
+    "restart": "Restart to update",
+    "busy": "Finish your dub first — then install the update."
+  },
   "stories": {
     "title": "Stories Editor",
     "subtitle": "Multi-track audiobook with per-character voices",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1,4 +1,12 @@
 {
+  "update": {
+    "available": "有可用更新 {{version}}",
+    "install": "安装并重启",
+    "install_hint": "下载更新并重启到新版本",
+    "downloading": "更新中… {{pct}}%",
+    "restart": "重启以更新",
+    "busy": "请先完成配音，再安装更新。"
+  },
   "stories": {
     "title": "故事编辑器",
     "subtitle": "多轨有声书，为每个角色分配语音",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -35,8 +35,10 @@ import type { PillSlice } from './pillSlice';
 import { createPillSlice } from './pillSlice';
 import type { StoriesSlice } from './storiesSlice';
 import { createStoriesSlice } from './storiesSlice';
+import type { UpdaterSlice } from './updaterSlice';
+import { createUpdaterSlice } from './updaterSlice';
 
-export type AppStore = PrefsSlice & GlossarySlice & UiSlice & DubSlice & GenerateSlice & PillSlice & StoriesSlice;
+export type AppStore = PrefsSlice & GlossarySlice & UiSlice & DubSlice & GenerateSlice & PillSlice & StoriesSlice & UpdaterSlice;
 
 /**
  * `useAppStore` — single root store. Don't create siblings. Slices compose here.
@@ -55,6 +57,7 @@ export const useAppStore = create<AppStore>()(
       ...createGenerateSlice(set, get, api),
       ...createPillSlice(set, get, api),
       ...createStoriesSlice(set, get, api),
+      ...createUpdaterSlice(set, get, api),  // transient — not in partialize
     }),
     {
       name: 'omnivoice.app',

--- a/frontend/src/store/updaterSlice.test.ts
+++ b/frontend/src/store/updaterSlice.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { createUpdaterSlice } from './updaterSlice';
+
+function harness() {
+  let state: any = {};
+  const set = (p: any) => { state = { ...state, ...(typeof p === 'function' ? p(state) : p) }; };
+  state = createUpdaterSlice(set as any, (() => state) as any, {} as any);
+  return { get: () => state };
+}
+
+describe('updaterSlice', () => {
+  it('starts idle', () => {
+    const { get } = harness();
+    expect(get().updateStatus).toBe('idle');
+    expect(get().updateProgress).toBe(0);
+  });
+
+  it('available carries version + notes', () => {
+    const { get } = harness();
+    get().setUpdateAvailable('0.3.1', 'release notes');
+    expect(get().updateStatus).toBe('available');
+    expect(get().updateVersion).toBe('0.3.1');
+    expect(get().updateNotes).toBe('release notes');
+  });
+
+  it('progress sets downloading and clamps 0–100', () => {
+    const { get } = harness();
+    get().setUpdateProgress(150);
+    expect(get().updateStatus).toBe('downloading');
+    expect(get().updateProgress).toBe(100);
+    get().setUpdateProgress(-5);
+    expect(get().updateProgress).toBe(0);
+  });
+
+  it('ready pins 100; error sets status + message', () => {
+    const { get } = harness();
+    get().setUpdateReady();
+    expect(get().updateStatus).toBe('ready');
+    expect(get().updateProgress).toBe(100);
+    get().setUpdateError('boom');
+    expect(get().updateStatus).toBe('error');
+    expect(get().updateError).toBe('boom');
+  });
+
+  it('checking clears error; idle resets progress', () => {
+    const { get } = harness();
+    get().setUpdateError('x');
+    get().setUpdateChecking();
+    expect(get().updateStatus).toBe('checking');
+    expect(get().updateError).toBeNull();
+    get().setUpdateIdle();
+    expect(get().updateStatus).toBe('idle');
+    expect(get().updateProgress).toBe(0);
+  });
+});

--- a/frontend/src/store/updaterSlice.ts
+++ b/frontend/src/store/updaterSlice.ts
@@ -1,0 +1,37 @@
+import type { StateCreator } from 'zustand';
+
+/**
+ * Auto-update state machine (Tauri updater). Transient — never persisted.
+ * idle → checking → available → downloading(progress) → ready → (relaunch)
+ *                 ↘ idle (up to date)        ↘ error
+ */
+export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error';
+
+export interface UpdaterSlice {
+  updateStatus: UpdateStatus;
+  updateVersion: string | null;
+  updateNotes: string | null;
+  updateProgress: number; // 0–100
+  updateError: string | null;
+  setUpdateChecking: () => void;
+  setUpdateAvailable: (version: string, notes: string | null) => void;
+  setUpdateIdle: () => void;
+  setUpdateProgress: (pct: number) => void;
+  setUpdateReady: () => void;
+  setUpdateError: (msg: string) => void;
+}
+
+export const createUpdaterSlice: StateCreator<UpdaterSlice, [], [], UpdaterSlice> = (set) => ({
+  updateStatus: 'idle',
+  updateVersion: null,
+  updateNotes: null,
+  updateProgress: 0,
+  updateError: null,
+  setUpdateChecking: () => set({ updateStatus: 'checking', updateError: null }),
+  setUpdateAvailable: (version, notes) =>
+    set({ updateStatus: 'available', updateVersion: version, updateNotes: notes, updateError: null }),
+  setUpdateIdle: () => set({ updateStatus: 'idle', updateProgress: 0 }),
+  setUpdateProgress: (pct) => set({ updateStatus: 'downloading', updateProgress: Math.max(0, Math.min(100, Math.round(pct))) }),
+  setUpdateReady: () => set({ updateStatus: 'ready', updateProgress: 100 }),
+  setUpdateError: (msg) => set({ updateStatus: 'error', updateError: msg }),
+});

--- a/frontend/src/utils/updater.js
+++ b/frontend/src/utils/updater.js
@@ -1,0 +1,58 @@
+/**
+ * Tauri auto-update flow with progress + safety.
+ *
+ * - checkForUpdate(): non-blocking; on launch, surfaces availability into the
+ *   store (no auto-install — the user picks when via the UpdateBadge).
+ * - installUpdate(): downloads with a progress callback → store, then relaunches.
+ *   Download is safe anytime; only the relaunch ends the session, and the badge
+ *   gates the action while a job is running so in-flight work isn't lost.
+ *
+ * Both no-op outside a packaged Tauri build.
+ */
+export function isTauri() {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+export async function checkForUpdate(store) {
+  if (!isTauri()) return;
+  try {
+    store.setUpdateChecking();
+    const { check } = await import('@tauri-apps/plugin-updater');
+    const update = await check();
+    if (update) store.setUpdateAvailable(update.version, update.body || null);
+    else store.setUpdateIdle();
+  } catch (e) {
+    // Endpoint 404s until the first signed release — non-fatal noise.
+    console.debug('Update check failed (non-fatal):', e);
+    store.setUpdateIdle();
+  }
+}
+
+export async function installUpdate(store) {
+  if (!isTauri()) return;
+  try {
+    const [{ check }, { relaunch }] = await Promise.all([
+      import('@tauri-apps/plugin-updater'),
+      import('@tauri-apps/plugin-process'),
+    ]);
+    const update = await check();
+    if (!update) { store.setUpdateIdle(); return; }
+    let total = 0;
+    let got = 0;
+    store.setUpdateProgress(0);
+    await update.downloadAndInstall((ev) => {
+      if (ev.event === 'Started') total = ev.data?.contentLength || 0;
+      else if (ev.event === 'Progress') {
+        got += ev.data?.chunkLength || 0;
+        if (total > 0) store.setUpdateProgress(Math.min(99, (got / total) * 100));
+      } else if (ev.event === 'Finished') {
+        store.setUpdateReady();
+      }
+    });
+    store.setUpdateReady();
+    await relaunch();
+  } catch (e) {
+    console.warn('Update install failed:', e);
+    store.setUpdateError((e && e.message) || 'Update failed');
+  }
+}


### PR DESCRIPTION
Completes the auto-update plan's core (Phase 1). Replaces the blocking `ask()` dialog with a **state-driven, progress-visible** flow that **never interrupts in-flight work**.

- **`updaterSlice`** — `idle→checking→available→downloading(pct)→ready/error` state machine (transient). 5 reducer tests.
- **`utils/updater`** — `checkForUpdate()` (launch, non-blocking → store) + `installUpdate()` (`downloadAndInstall` with a Started/Progress/Finished → **progress** callback, then `relaunch`). No-ops outside packaged Tauri.
- **`UpdateBadge`** — a non-intrusive pill: *'Update vX available · Install & Restart'* → progress bar → *'Restart to update'*. **Install is gated while a dub job is generating** (toast) so a relaunch can't lose work.
- **Data safety is structural:** user data lives outside the bundle; alembic migrates on next backend start; the bundled backend updates atomically with the shell.
- i18n (en + zh-CN). Builds on the existing signed `tauri-plugin-updater`.

Full suite **159/159**, typecheck/build/CJK ✓. Preview/main-channel (a `release.yml` `latest-preview.json` + channel toggle) is the noted follow-up; this is the stable-channel core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notification badge displaying update availability and download progress in the top-right corner
  * Users can now check for, download, and install app updates with a visual progress indicator
  * Non-blocking update workflow allows continued app usage while downloading
  * Added English and Chinese localization for update-related prompts and messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->