### PR TITLE
chore(lint): remove unused imports + variables (ruff F401/F841)

### DIFF
--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -96,8 +96,6 @@ def _set_progress(job, stage, percent=0, **extra):
 async def _run_batch_pipeline(job_id: str, job: dict):
     """Full batch dub pipeline: extract → transcribe → translate → generate → mix → export."""
     import subprocess
-    import tempfile
-    import soundfile as sf
 
     loop = asyncio.get_running_loop()
     video_path = job["video_path"]

--- a/backend/api/routers/capture.py
+++ b/backend/api/routers/capture.py
@@ -13,13 +13,12 @@ by default, or MLX Whisper on Apple Silicon when configured.
 """
 from __future__ import annotations
 
-import io
 import logging
 import os
 import tempfile
 import time
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, UploadFile
 from typing import Optional
 
 router = APIRouter()

--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -18,7 +18,6 @@ Protocol:
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 import os
 import tempfile
@@ -200,8 +199,6 @@ async def ws_transcribe(websocket: WebSocket):
 
 async def _transcribe_buffer(chunks: list[bytes]) -> str:
     """Quick partial transcription of the current audio buffer."""
-    import soundfile as sf
-    import numpy as np
 
     tmp = _chunks_to_wav(chunks)
     if tmp is None:

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -1,29 +1,23 @@
 import os
-import io
-import sys
 import uuid
-import json
-import time
 import asyncio
 import logging
 import shutil
 import subprocess
 import soundfile as sf
 import torch
-import torchaudio
-from typing import Optional, List
-from fastapi import APIRouter, File, Form, UploadFile, HTTPException, Query
-from fastapi.responses import FileResponse, Response, StreamingResponse, JSONResponse
+from typing import Optional
+from fastapi import APIRouter, File, Form, UploadFile, HTTPException
+from fastapi.responses import FileResponse, StreamingResponse, JSONResponse
 
 from core.db import db_conn
-from core.config import DATA_DIR, DUB_DIR, PREVIEW_DIR, VOICES_DIR
+from core.config import PREVIEW_DIR
 from core.tasks import task_manager
 from core import event_bus
-from schemas.requests import DubRequest, TranslateRequest, DubIngestUrlRequest
-from services.model_manager import get_model, _gpu_pool, _cpu_pool, get_best_device, get_diarization_pipeline, offload_tts_for_asr, restore_tts_after_asr
-from services.audio_dsp import apply_mastering, normalize_audio
+from schemas.requests import DubIngestUrlRequest
+from services.model_manager import get_model, _gpu_pool, _cpu_pool, get_diarization_pipeline, offload_tts_for_asr, restore_tts_after_asr
 from services.audio_io import _safe_soundfile_write
-from services.ffmpeg_utils import find_ffmpeg, _get_semaphore, _spawn_with_retry
+from services.ffmpeg_utils import find_ffmpeg
 from services.segmentation import (
     segment_transcript,
     assign_speakers_from_diarization,
@@ -586,7 +580,6 @@ async def dub_transcribe_stream(job_id: str):
 
             from services.model_manager import (
                 DIARIZATION_ERR_LICENSE,
-                DIARIZATION_ERR_LOAD,
                 DIARIZATION_ERR_NO_TOKEN,
             )
             from core import error_docs_map
@@ -773,8 +766,6 @@ async def dub_transcribe(job_id: str):
     _model = await get_model()
 
     def _transcribe():
-        import re
-        import traceback
         
         asr_audio_target = job.get("vocals_path")
         if not asr_audio_target or not os.path.exists(asr_audio_target):

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -8,7 +8,6 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
 
-from core.db import db_conn
 from core.config import DUB_DIR, dub_seg_path
 from core.tasks import task_manager
 from api.routers.dub_core import _get_job

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -7,7 +7,6 @@ import numpy as np
 import torch
 import torchaudio
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import StreamingResponse
 
 from core.db import db_conn
 from core.config import DUB_DIR, VOICES_DIR, dub_seg_path

--- a/backend/api/routers/gallery.py
+++ b/backend/api/routers/gallery.py
@@ -4,11 +4,10 @@ import uuid
 import time
 import asyncio
 import logging
-import subprocess
 from typing import Optional, List
 from pathlib import Path
 from fastapi import APIRouter, File, Form, UploadFile, HTTPException, Query
-from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from pydantic import BaseModel
 
 from core.db import db_conn

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -14,7 +14,6 @@ from fastapi.responses import StreamingResponse
 from core.db import db_conn
 from core.config import OUTPUTS_DIR, VOICES_DIR
 from services.model_manager import get_model, _gpu_pool
-from services.audio_dsp import apply_mastering, normalize_audio
 from services.audio_io import _safe_torchaudio_save
 from core import event_bus
 

--- a/backend/api/routers/marketplace.py
+++ b/backend/api/routers/marketplace.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 
 from core.config import OUTPUTS_DIR, VOICES_DIR
 from core.db import db_conn

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -24,15 +24,13 @@ import logging
 import os
 import asyncio
 import tempfile
-import time
-import uuid
 from typing import Literal, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
-from services.model_manager import get_model, _gpu_pool
+from services.model_manager import _gpu_pool
 
 logger = logging.getLogger("omnivoice.openai_compat")
 
@@ -116,7 +114,7 @@ _OPENAI_VOICE_ALIASES = {
 
 def _resolve_engine(model_id: str):
     """Map an OpenAI model name to an OmniVoice backend."""
-    from services.tts_backend import get_backend_class, get_active_tts_backend, active_backend_id
+    from services.tts_backend import get_backend_class, get_active_tts_backend
 
     # Accept OpenAI model names as pass-through to the active engine.
     if model_id in ("tts-1", "tts-1-hd"):
@@ -208,7 +206,6 @@ def _encode_audio(wav_tensor, sample_rate: int, fmt: str) -> tuple[bytes, str, s
 
 def _run_tts(backend, text: str, kw: dict):
     """Run TTS inference in the GPU thread pool."""
-    import torch
     from services.audio_dsp import apply_mastering, normalize_audio
     wav = backend.generate(text, **kw)
     sr = backend.sample_rate

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import asdict
-from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field

--- a/backend/api/routers/setup/models.py
+++ b/backend/api/routers/setup/models.py
@@ -14,9 +14,8 @@ import platform as _platform
 import sys
 import time
 from pathlib import Path
-from typing import Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 
 logger = logging.getLogger("omnivoice.setup.models")
 router = APIRouter()

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, File, UploadFile, HTTPException, Query, 
 from core.prefs import set_ as prefs_set, delete as prefs_delete
 from services import network_share
 from services import tailscale as _tailscale
-from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse, LogsResponse, FlushMemoryResponse
+from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse
 from api.dependencies import require_loopback
 from fastapi.responses import FileResponse, StreamingResponse
 import torch
@@ -437,7 +437,7 @@ async def flush_memory(unload_model: bool = False):
     re-loaded lazily on the next generation request.
     """
     import gc
-    from services.model_manager import free_vram, model as _current_model
+    from services.model_manager import free_vram
 
     freed_model = False
     if unload_model:

--- a/backend/api/routers/tools.py
+++ b/backend/api/routers/tools.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from services import director, speech_rate, incremental
-from services.ffmpeg_utils import find_ffmpeg, find_ffprobe, spawn_subprocess
+from services.ffmpeg_utils import find_ffprobe, spawn_subprocess
 
 logger = logging.getLogger("omnivoice.tools")
 router = APIRouter()

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -18,7 +18,6 @@ The chunked delivery targets <100ms time-to-first-audio (TTFA) on warm models.
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 import os
 import time
@@ -150,7 +149,6 @@ async def ws_tts(websocket: WebSocket):
                 loop = asyncio.get_running_loop()
 
                 def _generate():
-                    import torch
                     from services.audio_dsp import apply_mastering, normalize_audio
                     wav = backend.generate(text, **kw)
                     sr_actual = backend.sample_rate

--- a/backend/main.py
+++ b/backend/main.py
@@ -117,8 +117,6 @@ os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
 os.environ.setdefault("TORCHAUDIO_USE_TORCHCODEC", "0")
 sys.modules.setdefault("torchcodec", None)
 
-import soundfile as sf
-import torch
 import torchaudio
 import warnings
 import logging

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -27,7 +27,6 @@ import logging
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Optional
 
 logger = logging.getLogger("omnivoice.asr")
 
@@ -293,7 +292,7 @@ class WhisperXBackend(ASRBackend):
         audio = whisperx.load_audio(audio_path)
         try:
             result = self._asr.transcribe(audio)
-        except IndexError as e:
+        except IndexError:
             # WhisperX pipeline crashes with IndexError if VAD produces 0 segments
             logger.info("whisperx transcribe threw IndexError (likely 0 VAD segments). Returning empty result.")
             result = {"segments": [], "language": "en"}

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -44,7 +44,7 @@ from core.config import DUB_DIR
 from fastapi import HTTPException
 from services.ffmpeg_utils import find_ffmpeg, find_ffprobe, _get_semaphore, _spawn_with_retry
 from services.model_manager import get_best_device
-from core.db import db_conn, get_db
+from core.db import db_conn
 from core import event_bus
 from core import failure
 

--- a/backend/services/ffmpeg_utils.py
+++ b/backend/services/ffmpeg_utils.py
@@ -201,7 +201,7 @@ async def _spawn_with_retry(cmd, **kwargs):
                 delay *= 2
                 continue
             raise
-        except Exception as e:
+        except Exception:
             raise
     raise last_err if last_err else RuntimeError("spawn failed")
 

--- a/backend/services/gpu_sandbox.py
+++ b/backend/services/gpu_sandbox.py
@@ -26,13 +26,11 @@ Architecture:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import multiprocessing
 import os
 import sys
 import tempfile
-import time
 
 logger = logging.getLogger("omnivoice.sandbox")
 
@@ -43,7 +41,6 @@ def _worker(conn, request: dict):
         # Prevent CUDA from inheriting contexts from parent
         os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
 
-        import torch
         import torchaudio
 
         # Add backend to path

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -2,7 +2,6 @@ import os
 import time
 import asyncio
 import logging
-from typing import Optional
 from concurrent.futures import ThreadPoolExecutor
 
 # ── Lazy imports ─────────────────────────────────────────────────────

--- a/backend/services/segmentation.py
+++ b/backend/services/segmentation.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Sequence
 
 

--- a/backend/services/speaker_clone.py
+++ b/backend/services/speaker_clone.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
 
 import numpy as np
 import soundfile as sf

--- a/backend/services/translator.py
+++ b/backend/services/translator.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from typing import Any, Iterable, Optional
+from typing import Iterable, Optional
 
 logger = logging.getLogger("omnivoice.translator")
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -864,7 +864,6 @@ class GPTSoVITSBackend(TTSBackend):
     def generate(self, text: str, **kw) -> torch.Tensor:
         import urllib.request
         import urllib.parse
-        import json
 
         ref_audio = kw.get("ref_audio")
         ref_text = kw.get("ref_text", "")

--- a/backend/services/video_context.py
+++ b/backend/services/video_context.py
@@ -27,7 +27,6 @@ import logging
 import os
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
 
 logger = logging.getLogger("omnivoice.video_context")
 

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -22,9 +22,7 @@ from __future__ import annotations
 
 import logging
 import math
-import struct
 import torch
-import numpy as np
 from typing import Optional
 
 from core.prefs import resolve

--- a/backend/tests/test_capture_ws.py
+++ b/backend/tests/test_capture_ws.py
@@ -6,7 +6,6 @@ skip in CI — it's integration-tested via the browser.
 """
 import os
 import sys
-import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 

--- a/backend/tests/test_tts_backend_lifecycle.py
+++ b/backend/tests/test_tts_backend_lifecycle.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import inspect
 import os
 import sys
-from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
Autofixes the dead code behind the CodeQL **`py/unused-import`** and **`py/unused-local-variable`** note-level alerts — **actually removing** it rather than dismissing it (these aren't false positives; the code really did have unused imports/vars).

- **68 safe fixes** via `ruff check --select F401,F841 --fix` across 29 backend files — dead stdlib/symbol imports (`io`, `sys`, `json`, `torch`, `typing.Optional`, `fastapi.HTTPException`, …) and unused locals.
- **Only ruff's *safe* fixes applied.** The 9 "unsafe" fixes and the `audio_dsp.py` `numpy` availability-probe import were left untouched (no `--unsafe-fixes`).
- Reviewed the removal list first: all dead symbol/stdlib imports — **no registration/side-effect imports**.

**Not touched (deliberately):**
- `py/empty-except` (109) — needs per-site judgement (what to log/re-raise), not safely autofixable.
- frontend `js/unused-local-variable` — eslint's `no-unused-vars` has no autofix.
- the loopback-low-risk `path-injection`/`log-injection`/`stack-trace-exposure` alerts — real patterns, left **visible** (dismissing would hide future regressions).

**Verified:** full `tests/` suite **unchanged at 601 passed** — the import removals broke nothing. (The 2 `test_supertonic3` failures are pre-existing on `main`: local `.venv` engine/license state, green in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized internal code by removing unused imports and dependencies across backend services and API modules.
  * Cleaned up exception handling for improved code consistency.
  * No user-facing functionality or API behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->