### PR TITLE
docs(readme): add ASR Engines table (surfaces SenseVoice/FunASR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@ OmniVoice ships a multi-engine ASR (speech-to-text) backend that powers dictatio
 |--------|-------------------------|:---------:|----------|
 | **WhisperX** (default) | `whisperx` | ~100 | Dubbing & subtitles — word-level timing via wav2vec2 forced alignment |
 | **Faster-Whisper** | `faster-whisper` | ~100 | Fast transcription on Linux / macOS / Windows (CTranslate2) |
-| **MLX Whisper** | `mlx-whisper` | ~100 | Native Apple Silicon speed (CoreML) |
+| **MLX Whisper** | `mlx-whisper` | ~100 | Native Apple Silicon speed (Apple MLX / Metal) |
 | **PyTorch Whisper** | `pytorch-whisper` | ~100 | CUDA / CPU fallback via 🤗 Transformers |
-| **Parakeet TDT** | `nemo-parakeet` | English | English SOTA accuracy (NVIDIA NeMo) |
+| **Parakeet TDT** | `nemo-parakeet` | English + 25 EU | SOTA English accuracy, auto language detection (NVIDIA NeMo, GPU only) |
 | **Moonshine** | `moonshine` | English | Edge / low-latency, ONNX |
 | **FunASR** | `funasr` | 50+ | All-in-one multilingual — built-in VAD + inline speaker diarization (SenseVoice) |
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     <a href="#features">Features</a> ·
     <a href="#why-omnivoice-studio">Why OmniVoice Studio?</a> ·
     <a href="#tts-engines">TTS Engines</a> ·
+    <a href="#asr-engines">ASR Engines</a> ·
     <a href="#contributing">Contributing</a> ·
     <a href="https://discord.gg/bzQavDfVV9">Discord</a> ·
     <a href="README_CN.md"><strong>简体中文</strong></a>
@@ -236,6 +237,22 @@ OmniVoice ships a multi-engine TTS backend. The default engine (OmniVoice) is al
 | **KittenTTS** | English | ❌ | ❌ | ✅ CPU | ✅ CPU | ✅ CPU | MIT |
 
 > **CUDA** = GPU-accelerated · **MPS** = Apple Silicon Metal · **CPU** = runs everywhere, slower for large models · KittenTTS and MOSS-TTS-Nano run realtime on CPU · MLX-Audio is Apple Silicon only.
+
+### ASR Engines
+
+OmniVoice ships a multi-engine ASR (speech-to-text) backend that powers dictation, video dubbing, and subtitle generation — all fully local. **WhisperX** is the cross-platform default; the rest are opt-in and auto-detected. Switch in **Settings → ASR Engine** or via the `OMNIVOICE_ASR_BACKEND` env var.
+
+| Engine | `OMNIVOICE_ASR_BACKEND` | Languages | Best for |
+|--------|-------------------------|:---------:|----------|
+| **WhisperX** (default) | `whisperx` | ~100 | Dubbing & subtitles — word-level timing via wav2vec2 forced alignment |
+| **Faster-Whisper** | `faster-whisper` | ~100 | Fast transcription on Linux / macOS / Windows (CTranslate2) |
+| **MLX Whisper** | `mlx-whisper` | ~100 | Native Apple Silicon speed (CoreML) |
+| **PyTorch Whisper** | `pytorch-whisper` | ~100 | CUDA / CPU fallback via 🤗 Transformers |
+| **Parakeet TDT** | `nemo-parakeet` | English | English SOTA accuracy (NVIDIA NeMo) |
+| **Moonshine** | `moonshine` | English | Edge / low-latency, ONNX |
+| **FunASR** | `funasr` | 50+ | All-in-one multilingual — built-in VAD + inline speaker diarization (SenseVoice) |
+
+> Whisper-family engines cover ~100 languages; **FunASR / SenseVoice** adds an all-in-one multilingual path with built-in voice-activity detection and inline speaker diarization. Every engine runs on-device — no API keys, no cloud.
 
 ---
 


### PR DESCRIPTION
## Summary

The README has a **TTS Engines** table but never documented the **ASR (speech-to-text) backends** — even though 7 ship today in `backend/services/asr_backend.py`. That gap is why we keep getting "please add SenseVoice/FunASR" requests (#206, #208) for engines that already exist.

This adds an **ASR Engines** section right after TTS Engines, mirroring its format, plus a nav anchor.

## Changes

- New `### ASR Engines` table in `README.md`, grounded in the actual engine `id`s and `display_name`s in `asr_backend.py`: WhisperX (default), Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet TDT (NeMo), Moonshine, and **FunASR / SenseVoice**.
- Each row lists its `OMNIVOICE_ASR_BACKEND` value and what it's best for.
- Added `#asr-engines` to the top nav.

## Why

Two recent feature requests (#206, #208) asked for SenseVoice/FunASR ASR — both already implemented (`FunASRBackend`, `iic/SenseVoiceSmall`, FSMN-VAD, cam++ diarization). Surfacing the engine list in the README should reduce duplicate "is this supported?" issues.

## Type

- [x] 📝 Documentation

## Testing

- Docs-only change; no runtime behavior touched.
- Table values cross-checked against `id` / `display_name` in `backend/services/asr_backend.py` and the `OMNIVOICE_ASR_BACKEND` override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "ASR Engines" section to README describing on-device ASR backends for dictation, dubbing, and subtitles
  * Guidance for switching ASR engine via Settings or environment configuration
  * Table of supported ASR engines (e.g., WhisperX, Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet TDT, Moonshine, FunASR) with use cases
  * Notes on language coverage and FunASR/SenseVoice role
<!-- end of auto-generated comment: release notes by coderabbit.ai -->