### PR TITLE
feat(gallery): multilingual designed-voice archetypes

### DIFF
--- a/backend/core/archetypes.py
+++ b/backend/core/archetypes.py
@@ -308,7 +308,63 @@ def _make_featured():
     return out
 
 
-_FEATURED = _make_featured()
+# ── Featured: multilingual designed voices ────────────────────────────────────
+# The voice-design *timbre* axes (gender/age/pitch) are language-independent, and
+# the spoken language of a designed voice is driven by the preview *text*, not by
+# the instruct — the same neutral instruct renders in any of OmniVoice's 646
+# languages (the exact ``model.generate(text=…, language=…, instruct=…)`` call
+# the Generate tab already makes). So we ship a curated set in the major languages
+# the app already localizes its UI into, giving the gallery more than English +
+# Chinese out of the box.
+#
+# These carry **no accent/dialect token**: accents are English-only and dialects
+# Chinese-only, so a "spanish accent" token doesn't exist in the taxonomy and
+# would crash synthesis (the issue-#89 failure mode). Using only the universal
+# gender/age/pitch axes keeps every instruct inside the validator's vocabulary —
+# ``test_archetypes.py`` enforces this independently.
+#
+# Each ``language`` label must match an entry in ``frontend/src/languages.json``
+# verbatim, because the string flows straight into ``model.generate(language=…)``
+# with no normalization. ("Arabic" is intentionally omitted — it is not in that
+# list.) ``_ML_SAMPLES`` is functional demo/eval text (like ``_ZH_SAMPLE``); the
+# Japanese/Korean lines are covered by this file's ``test_no_hardcoded_cjk.py``
+# allowlist entry.
+_ML_SAMPLES = {
+    "Spanish": "Hola y bienvenido a esta breve demostración de voz. Espero que disfrutes escuchando cómo suena.",
+    "French": "Bonjour et bienvenue dans cette courte démonstration vocale. J'espère que cette voix vous plaira.",
+    "German": "Hallo und willkommen zu dieser kurzen Sprachdemo. Ich hoffe, diese Stimme gefällt dir.",
+    "Italian": "Ciao e benvenuto in questa breve dimostrazione vocale. Spero che questa voce ti piaccia.",
+    "Portuguese": "Olá e bem-vindo a esta breve demonstração de voz. Espero que goste de ouvir como ela soa.",
+    "Russian": "Здравствуйте и добро пожаловать в эту короткую демонстрацию голоса. Надеюсь, вам понравится, как он звучит.",
+    "Hindi": "नमस्ते और इस छोटे से वॉइस डेमो में आपका स्वागत है। मुझे आशा है कि आपको यह आवाज़ पसंद आएगी।",
+    "Japanese": "こんにちは。この短い音声デモへようこそ。この声を気に入っていただけるとうれしいです。",
+    "Korean": "안녕하세요. 이 짧은 음성 데모에 오신 것을 환영합니다. 이 목소리가 마음에 드시길 바랍니다.",
+}
+
+# Three reusable, language-independent roles. (gender, age, pitch, use_case,
+# role, icon) — instruct is built from gender/age/pitch only.
+_ML_ROLES = [
+    ("female", "middle-aged", "low pitch", "narration", "Narrator", "BookOpen"),
+    ("male", "young adult", "moderate pitch", "informative", "Explainer", "GraduationCap"),
+    ("female", "young adult", "moderate pitch", "conversational", "Companion", "MessagesSquare"),
+]
+
+
+def _make_multilingual():
+    out = []
+    for language, script in _ML_SAMPLES.items():
+        lang_slug = language.lower()
+        for gender, age, pitch, uc, role, icon in _ML_ROLES:
+            out.append(_build(
+                gender, age, pitch,
+                use_case=uc, name=f"{language} {role}", icon=icon,
+                language=language, script=script,
+                featured=True, fid=f"ml_{lang_slug}_{role.lower()}",
+            ))
+    return out
+
+
+_FEATURED = _make_featured() + _make_multilingual()
 _FEATURED_KEYS = {(a["instruct"], a["language"]) for a in _FEATURED}
 
 

--- a/backend/core/archetypes.py
+++ b/backend/core/archetypes.py
@@ -8,10 +8,10 @@ taxonomy. Each archetype carries an ``instruct`` string (e.g.
 
 Two tiers (the "hybrid" gallery model):
 
-* **Featured** — ~24 hand-curated archetypes spanning the seven use-case
-  categories. Pre-rendered preview WAVs are produced by
-  ``scripts/render_demos_omnivoice.py``; until a WAV exists the API renders one
-  on demand.
+* **Featured** — ~51 hand-curated archetypes (24 English across the seven
+  use-case categories + 27 multilingual designed voices in nine more languages).
+  Pre-rendered preview WAVs are produced by ``scripts/render_demos_omnivoice.py``;
+  until a WAV exists the API renders one on demand.
 * **Generated** — the full combinatorial space of gender × age × pitch ×
   accent (English) and gender × age × pitch × dialect (Chinese), pruned of
   physically-implausible combinations (no "child + very low pitch"). This is
@@ -351,6 +351,12 @@ _ML_ROLES = [
 
 
 def _make_multilingual():
+    """Build the featured archetypes for the non-EN/ZH languages.
+
+    Cross-products ``_ML_SAMPLES`` (one localized preview script per language)
+    with ``_ML_ROLES`` (the reusable, language-independent timbre roles), so each
+    language gets the same curated set of neutral-instruct designed voices.
+    """
     out = []
     for language, script in _ML_SAMPLES.items():
         lang_slug = language.lower()

--- a/backend/tests/test_archetypes.py
+++ b/backend/tests/test_archetypes.py
@@ -172,6 +172,38 @@ def test_filter_by_accent():
     assert all("british accent" in a["instruct"] for a in res)
 
 
+# ── (h2) Multilingual designed voices ship beyond English + Chinese ───────────
+_ML_LANGS = {
+    "Spanish", "French", "German", "Italian", "Portuguese",
+    "Russian", "Hindi", "Japanese", "Korean",
+}
+
+
+def test_multilingual_featured_languages_present():
+    featured_langs = {a["language"] for a in archetypes.list_archetypes(featured=True)}
+    missing = _ML_LANGS - featured_langs
+    assert not missing, f"missing curated multilingual languages: {missing}"
+
+
+def test_multilingual_archetypes_are_neutral_timbre_with_valid_tokens():
+    # A designed voice's spoken language is the preview text, not the instruct —
+    # so these carry no English-accent / Chinese-dialect token, only the
+    # universal gender/age/pitch axes that exist in every language.
+    for lang in _ML_LANGS:
+        res = archetypes.list_archetypes(lang=lang)
+        assert res, f"no archetypes for language {lang!r}"
+        for a in res:
+            assert a["language"] == lang
+            assert a["sample_script"].strip(), f"{a['id']} missing sample_script"
+            toks = set(_tokens(a["instruct"]))
+            assert toks, f"{a['id']} has empty instruct"
+            assert all(t in _VALID_TOKENS for t in toks), (
+                f"{a['id']} emits invalid token (instruct={a['instruct']!r})"
+            )
+            assert not (toks & _ACCENTS), f"{a['id']} should carry no English accent"
+            assert not (toks & _DIALECTS), f"{a['id']} should carry no Chinese dialect"
+
+
 # ── (i) Lookup by id ──────────────────────────────────────────────────────────
 def test_get_archetype_roundtrip():
     sample = ALL[0]

--- a/frontend/src/pages/VoiceGallery.jsx
+++ b/frontend/src/pages/VoiceGallery.jsx
@@ -218,9 +218,21 @@ function ArchetypesZone({
     return out;
   }, [filters]);
 
+  // The Featured strip shows only when nothing is filtered; in that case Browse
+  // excludes featured to avoid duplicating it. Once any filter is active the
+  // Featured strip is hidden (see below), so Browse must include featured too —
+  // otherwise the curated multilingual languages (Spanish/French/…), which have
+  // *only* featured archetypes, would filter down to an empty list.
+  const showFeatured = !hasActiveFilters(filters) && !favOnly;
+
   const categoriesQ = useArchetypeCategories();
   const featuredQ = useArchetypes({ featured: true, limit: 100 });
-  const browseQ = useArchetypes({ ...cleanFilters, featured: false, limit: BROWSE_PAGE, offset });
+  const browseQ = useArchetypes({
+    ...cleanFilters,
+    ...(showFeatured ? { featured: false } : {}),
+    limit: BROWSE_PAGE,
+    offset,
+  });
 
   const categories = categoriesQ.data || [];
   const featured = featuredQ.data?.items || [];
@@ -292,7 +304,7 @@ function ArchetypesZone({
         </div>
       </div>
 
-      {!hasActiveFilters(filters) && !favOnly && (
+      {showFeatured && (
         <section className="archetype-section">
           <div className="content-header"><div className="content-title">{t('archetypes.featured', { defaultValue: 'Featured' })}</div></div>
           <div className={`archetype-grid ${viewMode}`}>

--- a/frontend/src/pages/VoiceGallery.jsx
+++ b/frontend/src/pages/VoiceGallery.jsx
@@ -39,7 +39,13 @@ const FACETS = {
     'indian accent', 'chinese accent', 'japanese accent', 'korean accent',
     'portuguese accent', 'russian accent',
   ],
-  lang: ['English', 'Chinese'],
+  // English + Chinese come from the generated catalog; the rest are curated
+  // multilingual designed voices. Values must match the archetype `language`
+  // field (a languages.json entry) exactly — that drives the backend filter.
+  lang: [
+    'English', 'Chinese', 'Spanish', 'French', 'German', 'Italian',
+    'Portuguese', 'Russian', 'Hindi', 'Japanese', 'Korean',
+  ],
 };
 
 const titleCase = (s) => (s ? String(s).replace(/\b\w/g, (c) => c.toUpperCase()) : s);

--- a/tests/test_no_hardcoded_cjk.py
+++ b/tests/test_no_hardcoded_cjk.py
@@ -58,7 +58,7 @@ _ALLOWED_FILES = {
     # Model / engine vocabulary & identifiers (the model/engine requires these)
     "backend/services/tts_backend.py",            # CosyVoice speaker IDs
     "backend/core/personalities.py",              # Chinese-dialect showcase preset
-    "backend/core/archetypes.py",                 # Chinese-dialect preview sample text
+    "backend/core/archetypes.py",                 # Chinese-dialect + JA/KO multilingual preview sample text
     "frontend/src/utils/constants.js",            # Chinese-dialect picker names
     "omnivoice/models/omnivoice.py",              # instruct-mode vocabulary
     "omnivoice/utils/duration.py",


### PR DESCRIPTION
## What

Ships curated **designed voices in 9 more languages** — Spanish, French, German, Italian, Portuguese, Russian, Hindi, Japanese, Korean — so the Voice Gallery offers more than English + Chinese out of the box. 27 new featured archetypes across three reusable roles (Narrator / Explainer / Companion); the catalog now spans **11 languages**.

## How it stays safe

Voice-design *timbre* (gender / age / pitch) is language-independent, and a designed voice's spoken language is driven by the preview **text**, not the instruct. So each new archetype reuses a neutral instruct + a localized sample script + a `language` value matching `frontend/src/languages.json` — byte-for-byte the same `model.generate(text, language, instruct)` call the Generate tab already makes daily.

They carry **no accent/dialect token**: accents are English-only and dialects Chinese-only in the model's vocabulary, so an invented `"spanish accent"` would crash synthesis (the issue-#89 mode). Using only the universal gender/age/pitch axes keeps every instruct inside the validator's vocabulary — `test_archetypes.py` enforces this independently. (`Arabic` is intentionally omitted — it isn't in `languages.json`, so the model wouldn't recognize the string.)

## Changes

- `backend/core/archetypes.py` — `_ML_SAMPLES` + `_ML_ROLES` + `_make_multilingual()`.
- `frontend/src/pages/VoiceGallery.jsx` — extend the language facet filter.
- `backend/tests/test_archetypes.py` — assert the 9 languages are present, neutral-timbre, valid-token.
- `tests/test_no_hardcoded_cjk.py` — note JA/KO sample text in the existing (already-allowlisted) entry for `archetypes.py`.

## Verification

- ✅ `pytest backend/tests/test_archetypes.py tests/test_no_hardcoded_cjk.py` → 18 passed (incl. 2 new tests; CJK test confirms the JA/KO sample text is correctly allowlisted).
- ✅ `pytest backend/tests/test_community.py backend/tests/test_archetypes_api.py` → 23 passed.
- ✅ `vite build` → clean.
- ✅ Catalog: 1,126 archetypes, 51 featured, 11 languages.

## Note on preview audio

The test suite runs without the TTS model by design, so preview *audio quality* in the 9 new languages hasn't been ear-checked headlessly. The render path is identical to the existing Generate+Design flow, so this is low-risk, but a quick manual spot-check of a Spanish/Japanese preview is worth doing before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded language support in the voice gallery: Spanish, French, German, Italian, Portuguese, Russian, Hindi, Japanese, and Korean added to the curated languages (alongside English and Chinese).
  * Curated multilingual voice archetypes added for improved selection and per-language previews.
  * Gallery behavior refined so featured multilingual voices remain available during language filtering unless explicitly hidden.

* **Tests**
  * Added tests to validate multilingual voice presence and token composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->