### PR TITLE
fix(update): keep error/retry pill across periodic re-check (#214 follow-up)

### DIFF
--- a/frontend/src/components/UpdateBadge.css
+++ b/frontend/src/components/UpdateBadge.css
@@ -56,7 +56,7 @@
   background: var(--chrome-bg, #1d2021); border: 1px solid var(--chrome-border, #3a3a3a);
   border-radius: 8px; padding: 8px 10px;
   font-size: 11px; line-height: 1.45; color: #d5c4a1;
-  white-space: pre-wrap; word-break: break-word;
+  white-space: pre-wrap; overflow-wrap: break-word;
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
 }
 .update-badge__btn--error {

--- a/frontend/src/components/UpdateBadge.jsx
+++ b/frontend/src/components/UpdateBadge.jsx
@@ -42,11 +42,12 @@ export default function UpdateBadge() {
               className={`update-badge__more ${notesOpen ? 'is-open' : ''}`}
               onClick={() => setNotesOpen((v) => !v)}
               aria-expanded={notesOpen}
+              aria-controls="update-badge-notes"
             >
               <ChevronDown size={12} /> {t('update.whats_new')}
             </button>
           )}
-          {notesOpen && notes && <div className="update-badge__notes">{notes}</div>}
+          {notesOpen && notes && <div id="update-badge-notes" className="update-badge__notes">{notes}</div>}
         </div>
       )}
       {status === 'downloading' && (

--- a/frontend/src/components/UpdateBadge.jsx
+++ b/frontend/src/components/UpdateBadge.jsx
@@ -47,7 +47,7 @@ export default function UpdateBadge() {
               <ChevronDown size={12} /> {t('update.whats_new')}
             </button>
           )}
-          {notesOpen && notes && <div id="update-badge-notes" className="update-badge__notes">{notes}</div>}
+          {notes && <div id="update-badge-notes" className="update-badge__notes" hidden={!notesOpen}>{notes}</div>}
         </div>
       )}
       {status === 'downloading' && (

--- a/frontend/src/utils/updater.js
+++ b/frontend/src/utils/updater.js
@@ -33,8 +33,18 @@ async function currentChannel() {
 export async function checkForUpdate(store) {
   if (!isTauri()) return;
   // A periodic re-check must not interrupt an in-progress download or a
-  // ready-to-restart state (it would reset the badge mid-flight).
-  if (store.updateStatus === 'downloading' || store.updateStatus === 'ready') return;
+  // ready-to-restart state (it would reset the badge mid-flight), nor wipe a
+  // surfaced error — `setUpdateChecking()` clears `updateError` and hides the
+  // pill, so a 6h tick would silently erase the "failed · retry" prompt the
+  // user still needs to act on. Retry is user-initiated (it goes through
+  // installUpdate → downloading), so skipping the auto re-check here is safe.
+  if (
+    store.updateStatus === 'downloading' ||
+    store.updateStatus === 'ready' ||
+    store.updateStatus === 'error'
+  ) {
+    return;
+  }
   try {
     store.setUpdateChecking();
     const { invoke } = await import('@tauri-apps/api/core');

--- a/frontend/src/utils/updater.test.js
+++ b/frontend/src/utils/updater.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkForUpdate } from './updater';
+
+// Stub the Tauri core so checkForUpdate's "proceed" path resolves cleanly in
+// jsdom without a real Tauri runtime. The guarded (early-return) cases never
+// reach these imports.
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (cmd) => (cmd === 'get_update_channel' ? 'stable' : null)),
+}));
+
+function makeStore(status) {
+  return {
+    updateStatus: status,
+    setUpdateChecking: vi.fn(),
+    setUpdateAvailable: vi.fn(),
+    setUpdateIdle: vi.fn(),
+  };
+}
+
+describe('checkForUpdate periodic re-check guard', () => {
+  beforeEach(() => { window.__TAURI_INTERNALS__ = {}; });
+  afterEach(() => { delete window.__TAURI_INTERNALS__; });
+
+  // Regression for #214: a 6h re-check while one of these states is showing
+  // must NOT call setUpdateChecking() — that clears updateError and hides the
+  // badge, silently wiping the "failed · retry" prompt (the 'error' case) or
+  // resetting an in-flight job ('downloading' / 'ready').
+  it.each(['error', 'downloading', 'ready'])(
+    'no-ops while status is %s (leaves the badge intact)',
+    async (status) => {
+      const store = makeStore(status);
+      await checkForUpdate(store);
+      expect(store.setUpdateChecking).not.toHaveBeenCalled();
+    },
+  );
+
+  it('proceeds from idle (boot / periodic check actually runs)', async () => {
+    const store = makeStore('idle');
+    await checkForUpdate(store);
+    expect(store.setUpdateChecking).toHaveBeenCalledTimes(1);
+    expect(store.setUpdateIdle).toHaveBeenCalled(); // mocked check_update → no update
+  });
+});


### PR DESCRIPTION
Follow-up to #214 (already merged) — fixes the one real bug its review surfaced, plus the two cosmetic nits the bots flagged but that landed unresolved.

## The bug (greptile P1, was unresolved)

#214's 6h periodic re-check guard skipped only `downloading`/`ready`, **not `error`**:

```js
if (store.updateStatus === 'downloading' || store.updateStatus === 'ready') return;
```

`setUpdateChecking()` sets `{ updateStatus: 'checking', updateError: null }` and `UpdateBadge` renders `null` for `checking`. So when the badge was showing **"Update failed · Retry"**, the next 6h tick cleared the error and hid the pill — silently erasing the prompt the user still needed to act on. That directly defeats #214's own "surface errors / retry instead of vanishing" goal.

## Changes

- **`utils/updater.js`** — also short-circuit the re-check on `'error'`. Retry stays user-initiated (`installUpdate` → `downloading`), so auto re-checking in the error state isn't needed.
- **`utils/updater.test.js`** (new) — regression test: the guard no-ops on `error`/`downloading`/`ready` and proceeds from `idle`.
- **`components/UpdateBadge.jsx`** — add `aria-controls` + a matching panel `id` to the "What's new" disclosure (greptile P2 a11y).
- **`components/UpdateBadge.css`** — `word-break: break-word` → `overflow-wrap: break-word` (CodeRabbit; the former value is deprecated).

## Verification (local)

- `bun run test` → **vitest 166/166** (4 new)
- `bun run typecheck:ci` → clean (exit 0)
- `bun run build` → OK (only the pre-existing >500 kB chunk warning)
- `pytest tests/test_no_hardcoded_cjk.py` → pass

## Type

- [x] 🐛 Bug fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text wrapping in release notes so long lines break cleanly.
  * Prevented the update checker from resetting or interfering while an update is in progress or in an error state.

* **Improvements**
  * Enhanced accessibility and keyboard/screen-reader behavior of the "What's new" release-notes toggle and visibility handling.

* **Tests**
  * Added tests covering the periodic update re-check guard to ensure stable updater behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->