### PR TITLE
fix(release): resolve AppImage path before cd in Linux smoke (exit 127)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,6 +461,10 @@ jobs:
           set -euo pipefail
           # Use the AppImage — single-file, no installer needed.
           APPIMAGE=$(find frontend/src-tauri/target/${{ matrix.rust_target }}/release/bundle/appimage -name "*.AppImage" | head -1)
+          # Resolve to an absolute path BEFORE the cd below — `--appimage-extract`
+          # always writes ./squashfs-root into the CWD, so we cd into a temp dir,
+          # at which point a relative AppImage path would no longer resolve.
+          APPIMAGE=$(realpath "$APPIMAGE")
           echo "Smoke-testing AppImage: $APPIMAGE"
           chmod +x "$APPIMAGE"
           # GH runners have no FUSE — extract before running (mirrors APPIMAGE_EXTRACT_AND_RUN=1 used at build time).


### PR DESCRIPTION
The Linux installer-smoke ran for the first time (now that Linux builds AppImage-only) and failed with exit 127: it does `cd "$EXTRACT_DIR"` and then runs `"$APPIMAGE"`, but `$APPIMAGE` was a **relative** path — after the cd it no longer resolves (`--appimage-extract` writes ./squashfs-root into CWD, so the cd is required).

Fix: `realpath` the AppImage before the cd. The AppImage itself **built and published fine** (it's already on the `preview` release) — only the smoke check broke.

Context: the macOS leg's repeat codesign failure on this run was the buggy `&& '' ||` skip expression from #215 (empty string is falsy in GH expressions, so it fell through to the secret); **#217 already fixed that** with the opt-in `MACOS_SIGNING_ENABLED` gate. A fresh preview build (after this) should be green on all three platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue in the Linux installer smoke test that could cause verification failures during release builds. The AppImage path is now properly resolved to ensure all installer checks run correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->