### PR TITLE
feat(update): dismiss button for the failed-update pill

### DIFF
--- a/frontend/src/components/UpdateBadge.css
+++ b/frontend/src/components/UpdateBadge.css
@@ -65,3 +65,12 @@
   color: #fb4934;
 }
 .update-badge__btn--error:hover { background: rgba(251, 73, 52, 0.22); }
+.update-badge__error { display: inline-flex; align-items: center; gap: 4px; }
+.update-badge__dismiss {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; padding: 0;
+  background: rgba(251, 73, 52, 0.14); border: 1px solid rgba(251, 73, 52, 0.5);
+  color: #fb4934; border-radius: 999px; cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+.update-badge__dismiss:hover { background: rgba(251, 73, 52, 0.22); }

--- a/frontend/src/components/UpdateBadge.jsx
+++ b/frontend/src/components/UpdateBadge.jsx
@@ -5,7 +5,7 @@
 // is running. A failed install surfaces a retry instead of vanishing silently.
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Download, Loader, RotateCw, AlertTriangle, ChevronDown } from 'lucide-react';
+import { Download, Loader, RotateCw, AlertTriangle, ChevronDown, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useAppStore } from '../store';
 import { installUpdate } from '../utils/updater';
@@ -18,6 +18,7 @@ export default function UpdateBadge() {
   const notes = useAppStore((s) => s.updateNotes);
   const progress = useAppStore((s) => s.updateProgress);
   const error = useAppStore((s) => s.updateError);
+  const dismissUpdate = useAppStore((s) => s.dismissUpdate);
   const dubStep = useAppStore((s) => s.dubStep);
   const [notesOpen, setNotesOpen] = useState(false);
 
@@ -62,14 +63,25 @@ export default function UpdateBadge() {
         </button>
       )}
       {status === 'error' && (
-        <button
-          type="button"
-          className="update-badge__btn update-badge__btn--error"
-          onClick={onInstall}
-          title={error || t('update.failed')}
-        >
-          <AlertTriangle size={12} /> {t('update.failed')} · {t('update.retry')}
-        </button>
+        <div className="update-badge__error">
+          <button
+            type="button"
+            className="update-badge__btn update-badge__btn--error"
+            onClick={onInstall}
+            title={error || t('update.failed')}
+          >
+            <AlertTriangle size={12} /> {t('update.failed')} · {t('update.retry')}
+          </button>
+          <button
+            type="button"
+            className="update-badge__dismiss"
+            onClick={dismissUpdate}
+            title={t('update.dismiss')}
+            aria-label={t('update.dismiss')}
+          >
+            <X size={12} />
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -8,7 +8,8 @@
     "busy": "Finish your dub first — then install the update.",
     "whats_new": "What's new",
     "failed": "Update failed",
-    "retry": "Retry"
+    "retry": "Retry",
+    "dismiss": "Dismiss"
   },
   "stories": {
     "title": "Stories Editor",

--- a/frontend/src/store/updaterSlice.test.ts
+++ b/frontend/src/store/updaterSlice.test.ts
@@ -52,4 +52,14 @@ describe('updaterSlice', () => {
     expect(get().updateStatus).toBe('idle');
     expect(get().updateProgress).toBe(0);
   });
+
+  it('dismiss clears the error pill back to idle', () => {
+    const { get } = harness();
+    get().setUpdateError('boom');
+    expect(get().updateStatus).toBe('error');
+    get().dismissUpdate();
+    expect(get().updateStatus).toBe('idle');
+    expect(get().updateError).toBeNull();
+    expect(get().updateProgress).toBe(0);
+  });
 });

--- a/frontend/src/store/updaterSlice.ts
+++ b/frontend/src/store/updaterSlice.ts
@@ -3,7 +3,7 @@ import type { StateCreator } from 'zustand';
 /**
  * Auto-update state machine (Tauri updater). Transient — never persisted.
  * idle → checking → available → downloading(progress) → ready → (relaunch)
- *                 ↘ idle (up to date)        ↘ error
+ *                 ↘ idle (up to date)        ↘ error → idle (retry/dismiss)
  */
 export type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error';
 
@@ -19,6 +19,8 @@ export interface UpdaterSlice {
   setUpdateProgress: (pct: number) => void;
   setUpdateReady: () => void;
   setUpdateError: (msg: string) => void;
+  /** Clear a failed/finished update surface (the badge's dismiss ×). */
+  dismissUpdate: () => void;
 }
 
 export const createUpdaterSlice: StateCreator<UpdaterSlice, [], [], UpdaterSlice> = (set) => ({
@@ -34,4 +36,5 @@ export const createUpdaterSlice: StateCreator<UpdaterSlice, [], [], UpdaterSlice
   setUpdateProgress: (pct) => set({ updateStatus: 'downloading', updateProgress: Math.max(0, Math.min(100, Math.round(pct))) }),
   setUpdateReady: () => set({ updateStatus: 'ready', updateProgress: 100 }),
   setUpdateError: (msg) => set({ updateStatus: 'error', updateError: msg }),
+  dismissUpdate: () => set({ updateStatus: 'idle', updateError: null, updateProgress: 0 }),
 });


### PR DESCRIPTION
## What

Adds a **×** to dismiss the failed-update pill in the auto-updater badge.

## Why

#216 correctly stopped the 6-hourly periodic re-check from silently clobbering a `Update failed · Retry` badge — but that left **no way to clear it** except retrying the install or restarting the app. A transient install failure (offline blip, mirror hiccup) now pins a red error pill indefinitely. This adds the dismiss affordance, mirroring `FloatingPill`'s × — so the badge stays until the user *acts* (retry **or** dismiss), exactly as intended.

This is the follow-up to the "dismissible + guard" decision; the guard half shipped in #216, this is the dismissible half.

## Changes

- `updaterSlice.ts` — `dismissUpdate()` → back to `idle`, clears `updateError` + progress.
- `UpdateBadge.jsx` — × button on the `error` state (i18n `update.dismiss`).
- `UpdateBadge.css` — styles for the error container + dismiss button.
- `updaterSlice.test.ts` — dismiss returns to idle and clears the error.
- `en.json` — `update.dismiss` ("Dismiss"); other locales fall back to `en` until backfilled.

## Verification

- ✅ `vitest` 10/10 (`updaterSlice.test.ts` incl. new dismiss test + the merged `updater.test.js` guard tests)
- ✅ `typecheck:ci` clean · `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to dismiss failed update notifications. When an update fails, users can now dismiss the error notification and clear the message without attempting another installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->