### PR TITLE
fix(release): macOS smoke — preserve space in DMG mount path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -439,7 +439,9 @@ jobs:
           set -euo pipefail
           DMG=$(find frontend/src-tauri/target/${{ matrix.rust_target }}/release/bundle/dmg -name "*.dmg" | head -1)
           echo "Smoke-testing DMG: $DMG"
-          MOUNT=$(hdiutil attach -nobrowse -readonly "$DMG" | tail -1 | awk '{print $3}')
+          # Grab the full mount path — the volume name has a space ("OmniVoice
+          # Studio"), so `awk '{print $3}'` would truncate it to /Volumes/OmniVoice.
+          MOUNT=$(hdiutil attach -nobrowse -readonly "$DMG" | tail -1 | grep -oE '/Volumes/.*$')
           APP=$(find "$MOUNT" -maxdepth 2 -name "*.app" | head -1)
           fail() { echo "FAIL — $1"; find "$APP/Contents" -maxdepth 4 -type f 2>/dev/null | head -40; hdiutil detach "$MOUNT" || true; exit 1; }
           [ -n "$APP" ] || { echo "FAIL — no .app inside DMG"; hdiutil detach "$MOUNT" || true; exit 1; }


### PR DESCRIPTION
Preview build #4: **macOS now builds + publishes** (dmg + app.tar.gz + sig are on the `preview` release) — the signing-absent fix (#220) worked, and all three platforms now upload artifacts. 🎉

The macOS leg's remaining failure was the **structural smoke**, not the build: `MOUNT=$(hdiutil attach … | awk '{print $3}')` truncated the mount path at the space — the volume mounts at `/Volumes/OmniVoice Studio` (with a space), so `awk $3` gave `/Volumes/OmniVoice` → `find: /Volumes/OmniVoice: No such file or directory`.

Fix: grab the full `/Volumes/...$` path with `grep -oE`. (Pre-existing bug, only reachable now that mac builds.)

After this, build #5 should be **green on all three legs → the `preview-notes` job finally fires** (auto What's Changed + Contributors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the macOS release workflow where volume names containing spaces could cause problems during the automated build and testing process. The installation path parsing has been enhanced to correctly handle special characters, ensuring the release process runs reliably and completes without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->