### PR TITLE
refactor(settings): move Performance toggles to the General tab

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1261,7 +1261,12 @@ export default function Settings() {
         className="settings-tabs-ui"
       />
 
-      {activeTab === 'general' && <GeneralTab />}
+      {activeTab === 'general' && (
+        <>
+          <GeneralTab />
+          <PerformancePanel />
+        </>
+      )}
 
       {activeTab === 'models' && (
         <>
@@ -1689,11 +1694,6 @@ function CredentialsTab({ info }) {
       {/* Wave 2 AUTH-03 panel — 3-source cascade with Active badge,
           encrypted-at-rest App-source storage, and live whoami status. */}
       <ApiKeysPanel />
-
-      {/* Wave 2 INST-12 panel — Windows torch.compile OOM workaround
-          (#65). Toggle is rendered disabled on macOS/Linux with an
-          explainer; backend ignores the flag on non-Windows. */}
-      <PerformancePanel />
 
       <p className="settings-prose">
         <Trans i18nKey="credentials.desc" components={{ 1: <strong /> }} />


### PR DESCRIPTION
Moves the two Performance toggles — **Disable torch.compile (Windows)** and **Show live system metrics in header** — out of the **Credentials** tab (where they were oddly nested under the API keys) and into the **General** tab, where users look for app-level settings.

Pure relocation: `PerformancePanel` itself is unchanged; it's removed from `CredentialsTab` and rendered after `GeneralTab` in the general view. The torch.compile toggle stays Windows-gated (shows "not applicable" on mac/Linux) and the header-metrics toggle stays default-off.

Verified: `tsc` clean, `bun run build` ✓, **vitest 167/167**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance metrics now accessible from the general settings tab
  * Dedicated API keys management panel in the credentials section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->