### PR TITLE
fix(logs): import useAppStore in LogsFooter (donate + notif nav crashed)

### DIFF
--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -8,6 +8,7 @@ import toast from 'react-hot-toast';
 import { clearSystemLogs, clearTauriLogs } from '../api/system';
 import { useSystemLogs, useTauriLogs, useClearLogs, useClearTauriLogs } from '../api/hooks';
 import { getFrontendLogs, clearFrontendLogs } from '../utils/consoleBuffer';
+import { useAppStore } from '../store';
 import NetworkToggle from './NetworkToggle';
 import './LogsFooter.css';
 


### PR DESCRIPTION
`LogsFooter.jsx` calls `useAppStore.getState().setMode(...)` in four handlers — the **donate** button and **notification action** targets (~L405/447/880/922) — but never imported `useAppStore`. Clicking any of them threw the `ReferenceError: Can't find variable: useAppStore` you saw in the console; the click handler died.

One-line fix: add the canonical `import { useAppStore } from '../store'` (same pattern every other component uses).

Verified: `tsc` clean, build OK (LogsFooter chunk emits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed footer action buttons that were previously non-functional due to a missing internal dependency. The Donate button and notification navigation features are now operational and working as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->