### PR TITLE
feat(gallery): calmer, more elegant archetype cards

### DIFF
--- a/frontend/src/pages/VoiceGallery.css
+++ b/frontend/src/pages/VoiceGallery.css
@@ -387,7 +387,7 @@
   border-radius: 13px;
   transition: transform 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease;
 }
-.archetype-card:hover { transform: translateY(-2px); border-color: rgba(255, 255, 255, 0.16); box-shadow: 0 6px 22px rgba(0, 0, 0, 0.4); }
+.archetype-card:hover { transform: translateY(-2px); border-color: rgba(255, 255, 255, 0.13); box-shadow: 0 6px 22px rgba(0, 0, 0, 0.4); }
 .archetype-card.playing { border-color: var(--card-accent, var(--accent)); box-shadow: 0 0 0 1px var(--card-accent, var(--accent)), 0 6px 22px rgba(0, 0, 0, 0.4); }
 
 /* Header: avatar tile + title + favorite */
@@ -404,8 +404,11 @@
 .fav-btn:hover { color: #fabd2f; background: rgba(255, 255, 255, 0.05); }
 .fav-btn.on { color: #fabd2f; }
 
-/* Facet chips (accent chip carries its flag) */
-.archetype-chips { display: flex; flex-wrap: wrap; gap: 5px; }
+/* Facet chips (accent chip carries its flag). Always rendered (even when a
+   voice has no accent/whisper chip) with a reserved min-height so every card
+   shares the same vertical rhythm and the action rows line up across the grid
+   instead of floating at ragged heights. */
+.archetype-chips { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; min-height: 21px; }
 .facet-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 8px; border-radius: 7px; background: rgba(255, 255, 255, 0.05); color: var(--text-secondary); font-size: 0.64rem; line-height: 1.6; }
 .facet-chip.with-flag { padding-left: 5px; }
 
@@ -413,9 +416,29 @@
 .arch-foot { display: flex; align-items: center; gap: 6px; margin-top: auto; }
 .preview-btn { display: inline-flex; align-items: center; gap: 6px; padding: 6px 11px; border: 1px solid rgba(255, 255, 255, 0.09); background: rgba(255, 255, 255, 0.03); color: var(--text-primary); border-radius: 8px; font-size: 0.7rem; cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
 .preview-btn:hover { border-color: var(--card-accent, var(--accent)); color: var(--card-accent, var(--accent)); }
-.use-btn { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 6px 10px; border: none; border-radius: 8px; background: var(--card-accent, var(--accent)); color: #1d2021; font-size: 0.72rem; font-weight: 600; cursor: pointer; transition: filter 0.15s ease; }
-.use-btn:hover { filter: brightness(1.08); }
-.designer-btn { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; flex-shrink: 0; border: 1px solid rgba(255, 255, 255, 0.09); background: rgba(255, 255, 255, 0.03); color: var(--text-secondary); border-radius: 8px; cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+/* Primary action — tonal by default (a low-alpha wash of the card accent with
+   accent-colored text), going solid only on hover/focus. This keeps the grid
+   calm at rest — the eye lands on the voice names, not a field of saturated
+   color blocks — while the CTA still "lights up" on the card you're pointing
+   at. The per-category hue is preserved as identity, just dialed down. */
+.use-btn {
+  flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 6px 10px; border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--card-accent, var(--accent)) 36%, transparent);
+  background: color-mix(in srgb, var(--card-accent, var(--accent)) 13%, transparent);
+  color: var(--card-accent, var(--accent));
+  font-size: 0.72rem; font-weight: 600; cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.use-btn:hover, .use-btn:focus-visible {
+  background: var(--card-accent, var(--accent));
+  border-color: var(--card-accent, var(--accent));
+  color: #1d2021;
+}
+/* Designer/open-in-designer is a tertiary action — keep it quiet at rest and
+   reveal it on card hover/focus so it isn't competing on every tile. */
+.designer-btn { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; flex-shrink: 0; border: 1px solid rgba(255, 255, 255, 0.09); background: rgba(255, 255, 255, 0.03); color: var(--text-secondary); border-radius: 8px; cursor: pointer; opacity: 0.5; transition: opacity 0.15s ease, border-color 0.15s ease, color 0.15s ease; }
+.archetype-card:hover .designer-btn, .designer-btn:focus-visible { opacity: 1; }
 .designer-btn:hover { color: var(--card-accent, var(--accent)); border-color: var(--card-accent, var(--accent)); }
 
 /* Animated "now playing" equalizer */

--- a/frontend/src/pages/VoiceGallery.jsx
+++ b/frontend/src/pages/VoiceGallery.jsx
@@ -377,19 +377,19 @@ function ArchetypeCard({
         </button>
       </div>
 
-      {(accentLabel || a.facets.whisper) && (
-        <div className="archetype-chips">
-          {accentLabel && (
-            <span className="facet-chip with-flag">
-              <AccentFlag accent={a.facets.accent} lang={a.language} size={14} />
-              {accentLabel}
-            </span>
-          )}
-          {a.facets.whisper && (
-            <span className="facet-chip">{t('archetypes.facet_whisper', { defaultValue: 'Whisper' })}</span>
-          )}
-        </div>
-      )}
+      {/* Always render the chip row (even when empty) so every card shares the
+          same height and the action rows align across the grid. */}
+      <div className="archetype-chips">
+        {accentLabel && (
+          <span className="facet-chip with-flag">
+            <AccentFlag accent={a.facets.accent} lang={a.language} size={14} />
+            {accentLabel}
+          </span>
+        )}
+        {a.facets.whisper && (
+          <span className="facet-chip">{t('archetypes.facet_whisper', { defaultValue: 'Whisper' })}</span>
+        )}
+      </div>
 
       <div className="arch-foot">
         <button className="preview-btn" onClick={() => onPreview(a)} title={t('gallery.preview', { defaultValue: 'Preview' })}>


### PR DESCRIPTION
The `Use voice` buttons were solid, fully-saturated per-category color fills — 16 loud, differently-hued blocks at once drew the eye to the buttons instead of the voice names. This is the polish pass we discussed:

- **Tonal primary button** — 13% accent wash + accent-colored text + hairline border at rest, solid accent (dark text) on hover/focus. Keeps each category's hue as identity, kills the patchwork loudness.
- **Reserved chip row** — always rendered with a min-height, so chip-less cards (Captain Crusty, Junior Quacks, The Pixie) no longer leave a ragged void; action rows align across the grid.
- **Hover-reveal the wand** — the designer button sits at 0.5 opacity at rest, full on card hover/focus (tertiary action).
- **Softened card hover border.**

`color-mix()` is used in 17 other frontend files (safe on all WebView targets). Verified: tsc clean, build OK, vitest 167/167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced archetype card hover effects with refined border color transitions.
  * Improved vertical spacing consistency across archetype cards.
  * Redesigned primary action button with updated hover and focus states.
  * Refined secondary action button visibility, appearing on card interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->