### PR TITLE
fix(i18n): close coverage gap the translation PR missed (#230 follow-up)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -512,18 +512,18 @@ function App() {
       if (!destPath) return; // User cancelled
 
       await exportAction({ source_filename: sourceIdentifier, destination_path: destPath, mode });
-      toast.success(`Exported: ${fallbackName}`);
+      toast.success(i18n.t('app.toast_exported', { name: fallbackName }));
       loadExportHistory();
     } catch (err) {
       console.error(err);
-      toast.error(`Export failed: ${err?.message || err}`);
+      toast.error(i18n.t('app.toast_export_failed', { message: err?.message || err }));
     }
   };
   const revealInFolder = async (filePath) => {
     try {
       await exportReveal({ path: filePath });
     } catch (err) {
-      toast.error(`Could not open folder: ${err.message}`);
+      toast.error(i18n.t('app.toast_open_folder_failed', { message: err.message }));
     }
   };
   const parseFilenameFromContentDisposition = (header) => {
@@ -549,7 +549,7 @@ function App() {
           filters: [{ name: modeGuess === 'video' ? 'Video' : 'Audio', extensions: [extGuess] }],
         });
         if (!destPath) return; // user cancelled
-        toast.loading(`Saving ${fallbackName}...`, { id: fallbackName });
+        toast.loading(i18n.t('app.toast_saving', { name: fallbackName }), { id: fallbackName });
         const sep = url.includes('?') ? '&' : '?';
         const res = await fetch(`${url}${sep}save_path=${encodeURIComponent(destPath)}`);
         if (!res.ok) {
@@ -557,21 +557,21 @@ function App() {
           throw new Error(err.detail || 'Save failed');
         }
         const data = await res.json();
-        toast.success(`Saved: ${data.path}`, { id: fallbackName });
+        toast.success(i18n.t('app.toast_saved', { path: data.path }), { id: fallbackName });
         try {
           await exportRecord({ filename: data.display_name || fallbackName, destination_path: data.path, mode: modeGuess });
           loadExportHistory();
         } catch (err) { console.warn('exportRecord (Tauri save path) failed:', err); }
       } catch (err) {
         console.error(err);
-        toast.error(`Save error: ${err.message}`, { id: fallbackName });
+        toast.error(i18n.t('app.toast_save_error', { message: err.message }), { id: fallbackName });
       }
       return;
     }
 
     // Browser path: standard blob download.
     try {
-      toast.loading(`Processing ${fallbackName}...`, { id: fallbackName });
+      toast.loading(i18n.t('app.toast_processing', { name: fallbackName }), { id: fallbackName });
       const response = await fetch(url);
       if (!response.ok) throw new Error("Download failed");
       const serverName = parseFilenameFromContentDisposition(response.headers.get('content-disposition'));
@@ -585,14 +585,14 @@ function App() {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(localUrl);
-      toast.success(`Downloaded ${finalName}`, { id: fallbackName });
+      toast.success(i18n.t('app.toast_downloaded', { name: finalName }), { id: fallbackName });
       try {
         await exportRecord({ filename: finalName, destination_path: `~/Downloads/${finalName}`, mode: modeGuess });
         loadExportHistory();
       } catch (err) { console.warn('exportRecord (browser download path) failed:', err); }
     } catch (err) {
       console.error(err);
-      toast.error(`Download error: ${err.message}`, { id: fallbackName });
+      toast.error(i18n.t('app.toast_download_error', { message: err.message }), { id: fallbackName });
     }
   };
   // Pre-flight for audio/video exports. If any segments are at preview
@@ -640,7 +640,7 @@ function App() {
   // ═══ STUDIO PROJECT CRUD ═══
   const saveProject = async () => {
     if (dubStep === 'idle') {
-      toast.error("Please click 'Upload & Transcribe' first so the video is processed on the server before saving.");
+      toast.error(i18n.t('app.toast_upload_first'));
       return;
     }
     const name = activeProjectName || dubFilename || `Project ${new Date().toLocaleString()}`;
@@ -658,10 +658,10 @@ function App() {
     try {
       const data = await apiSaveProject(statePayload, activeProjectId);
       setActiveProject(data.id, name);
-      toast.success(activeProjectId ? 'Project saved' : 'Project created');
+      toast.success(activeProjectId ? i18n.t('app.toast_project_saved') : i18n.t('app.toast_project_created'));
       loadProjects();
     } catch (err) {
-      toast.error('Save failed: ' + err.message);
+      toast.error(i18n.t('app.toast_save_failed', { message: err.message }));
     }
   };
 
@@ -689,7 +689,7 @@ function App() {
       // the last generate.
       setLastGenFingerprints(s.segHashes || {});
       setSpeakerClones(s.speakerClones || {});
-      toast.success(`Opened: ${data.name}`);
+      toast.success(i18n.t('app.toast_opened', { name: data.name }));
     } catch (err) {
       toast.error(err.message);
     }
@@ -704,7 +704,7 @@ function App() {
         setActiveProject(null);
       }
       loadProjects();
-      toast.success('Project deleted');
+      toast.success(i18n.t('app.toast_project_deleted'));
     } catch (err) { toast.error(err.message); }
   };
 
@@ -744,7 +744,7 @@ function App() {
     
     // Switch to studio tab
     setSidebarTab('projects');
-    toast.success('Restored previous generation state');
+    toast.success(i18n.t('app.toast_restored_state'));
   };
 
   const deleteHistory = async (id, type) => {
@@ -757,7 +757,7 @@ function App() {
       } else {
         loadHistory();
       }
-      toast.success('History item deleted');
+      toast.success(i18n.t('app.toast_history_deleted'));
     } catch (err) {
       toast.error(err.message);
     }
@@ -859,8 +859,12 @@ function App() {
         onFlushMemory={async (unloadModel) => {
           try {
             const r = await apiFlushMemory(unloadModel);
-            toast.success(`Flushed — RAM ${r.ram_after}G · VRAM ${r.vram_after}G${r.unloaded_model ? ' · model unloaded' : ''}`);
-          } catch (e) { toast.error('Flush failed: ' + e.message); }
+            toast.success(i18n.t('app.toast_flushed', {
+              ram: r.ram_after,
+              vram: r.vram_after,
+              unloaded: r.unloaded_model ? i18n.t('app.toast_model_unloaded') : '',
+            }));
+          } catch (e) { toast.error(i18n.t('app.toast_flush_failed', { message: e.message })); }
         }}
       />
 

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "تم مسح سجلات الواجهة الخلفية",
     "clear_backend_failed": "فشل في مسح السجلات",
     "copy_failed": "فشل النسخ: {{message}}",
-    "update_check_failed": "فشل التحقق من التحديث: {{message}}"
+    "update_check_failed": "فشل التحقق من التحديث: {{message}}",
+    "save_failed": "فشل الحفظ: {{message}}",
+    "clear_failed": "فشل المسح: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "فشل تعيين القناة: {{message}}",
+    "updater_downloading": "جارٍ التنزيل {{version}}…",
+    "updater_installed": "تم التثبيت - إعادة التشغيل.",
+    "updater_available_title": "التحديث متاح",
+    "updater_available_body": "الإصدار {{version}} متاح.\n\n{{notes}}\n\nتحميل وتثبيت الآن؟",
+    "updater_notes_fallback": "راجع ملاحظات الإصدار على GitHub.",
+    "shortcut_load_failed": "تعذر تحميل الاختصار: {{message}}",
+    "shortcut_set": "تم ضبط اختصار الإملاء على {{shortcut}}",
+    "shortcut_register_failed": "تعذر التسجيل: {{message}}",
+    "shortcut_reset": "إعادة التعيين إلى الوضع الافتراضي",
+    "shortcut_reset_failed": "فشلت إعادة التعيين: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "تم تحديد لغة {{count}}",
     "languages_selected_other": "تم تحديد {{count}} اللغات",
     "more_to_narrow": "+{{count}} المزيد - اكتب للتضييق",
-    "no_matches": "لا توجد مباريات"
+    "no_matches": "لا توجد مباريات",
+    "diagnostic_copied": "منقول التشخيص",
+    "copy_failed": "فشل النسخ",
+    "open_docs": "افتح المستندات",
+    "copy_diagnostic": "نسخ التشخيص"
   },
   "glossary": {
     "title": "مسرد",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "جارٍ التحميل…",
-    "trimmed_loaded": "تم تحميل الصوت المقطوع"
+    "trimmed_loaded": "تم تحميل الصوت المقطوع",
+    "toast_exported": "تم التصدير: {{name}}",
+    "toast_export_failed": "فشل التصدير: {{message}}",
+    "toast_open_folder_failed": "لا يمكن فتح المجلد: {{message}}",
+    "toast_saving": "جارٍ حفظ {{name}}...",
+    "toast_saved": "تم الحفظ: {{path}}",
+    "toast_save_error": "خطأ في الحفظ: {{message}}",
+    "toast_processing": "معالجة {{name}}...",
+    "toast_downloaded": "تم التنزيل {{name}}",
+    "toast_download_error": "خطأ في التنزيل: {{message}}",
+    "toast_upload_first": "الرجاء النقر فوق \"تحميل ونسخ\" أولاً حتى تتم معالجة الفيديو على الخادم قبل حفظه.",
+    "toast_save_failed": "فشل الحفظ: {{message}}",
+    "toast_opened": "مفتوح: {{name}}",
+    "toast_project_deleted": "تم حذف المشروع",
+    "toast_restored_state": "تمت استعادة حالة الجيل السابق",
+    "toast_history_deleted": "تم حذف عنصر السجل",
+    "toast_flushed": "متدفق — ذاكرة الوصول العشوائي {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· تم تفريغ النموذج",
+    "toast_flush_failed": "فشل التدفق: {{message}}",
+    "toast_project_saved": "تم حفظ المشروع",
+    "toast_project_created": "تم إنشاء المشروع"
   },
   "update": {
     "available": "يتوفّر التحديث {{version}}",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Backend-Protokolle gelöscht",
     "clear_backend_failed": "Protokolle konnten nicht gelöscht werden",
     "copy_failed": "Kopieren fehlgeschlagen: {{message}}",
-    "update_check_failed": "Update-Prüfung fehlgeschlagen: {{message}}"
+    "update_check_failed": "Update-Prüfung fehlgeschlagen: {{message}}",
+    "save_failed": "Speichern fehlgeschlagen: {{message}}",
+    "clear_failed": "Löschen fehlgeschlagen: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Kanal konnte nicht festgelegt werden: {{message}}",
+    "updater_downloading": "{{version}} wird heruntergeladen…",
+    "updater_installed": "Installiert – Neustart.",
+    "updater_available_title": "Update verfügbar",
+    "updater_available_body": "Version {{version}} ist verfügbar.\n\n{{notes}}\n\nJetzt herunterladen und installieren?",
+    "updater_notes_fallback": "Siehe Versionshinweise auf GitHub.",
+    "shortcut_load_failed": "Verknüpfung konnte nicht geladen werden: {{message}}",
+    "shortcut_set": "Diktatverknüpfung auf {{shortcut}} festgelegt",
+    "shortcut_register_failed": "Konnte nicht registriert werden: {{message}}",
+    "shortcut_reset": "Auf Standard zurücksetzen",
+    "shortcut_reset_failed": "Zurücksetzen fehlgeschlagen: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -632,7 +646,11 @@
     "languages_selected_one": "{{count}} Sprache ausgewählt",
     "languages_selected_other": "{{count}} Sprachen ausgewählt",
     "more_to_narrow": "+{{count}} mehr – zum Eingrenzen eingeben",
-    "no_matches": "Keine Übereinstimmungen"
+    "no_matches": "Keine Übereinstimmungen",
+    "diagnostic_copied": "Diagnose kopiert",
+    "copy_failed": "Das Kopieren ist fehlgeschlagen",
+    "open_docs": "Dokumente öffnen",
+    "copy_diagnostic": "Diagnose kopieren"
   },
   "glossary": {
     "title": "Glossar",
@@ -1505,7 +1523,27 @@
   },
   "app": {
     "loading": "Laden…",
-    "trimmed_loaded": "Zugeschnittenes Audio geladen"
+    "trimmed_loaded": "Zugeschnittenes Audio geladen",
+    "toast_exported": "Exportiert: {{name}}",
+    "toast_export_failed": "Export fehlgeschlagen: {{message}}",
+    "toast_open_folder_failed": "Ordner konnte nicht geöffnet werden: {{message}}",
+    "toast_saving": "Speichern {{name}}...",
+    "toast_saved": "Gespeichert: {{path}}",
+    "toast_save_error": "Speicherfehler: {{message}}",
+    "toast_processing": "Verarbeitung {{name}}...",
+    "toast_downloaded": "Heruntergeladen {{name}}",
+    "toast_download_error": "Download-Fehler: {{message}}",
+    "toast_upload_first": "Bitte klicken Sie zuerst auf „Hochladen und transkribieren“, damit das Video vor dem Speichern auf dem Server verarbeitet wird.",
+    "toast_save_failed": "Speichern fehlgeschlagen: {{message}}",
+    "toast_opened": "Geöffnet: {{name}}",
+    "toast_project_deleted": "Projekt gelöscht",
+    "toast_restored_state": "Wiederhergestellter Zustand der vorherigen Generation",
+    "toast_history_deleted": "Verlaufselement gelöscht",
+    "toast_flushed": "Gespült – RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· Modell entladen",
+    "toast_flush_failed": "Spülung fehlgeschlagen: {{message}}",
+    "toast_project_saved": "Projekt gespeichert",
+    "toast_project_created": "Projekt erstellt"
   },
   "update": {
     "available": "Update {{version}} verfügbar",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -236,7 +236,21 @@
     "backend_logs_cleared": "Backend logs cleared",
     "clear_backend_failed": "Failed to clear logs",
     "copy_failed": "Copy failed: {{message}}",
-    "update_check_failed": "Update check failed: {{message}}"
+    "update_check_failed": "Update check failed: {{message}}",
+    "save_failed": "Save failed: {{message}}",
+    "clear_failed": "Clear failed: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Failed to set channel: {{message}}",
+    "updater_downloading": "Downloading {{version}}…",
+    "updater_installed": "Installed — relaunching.",
+    "updater_available_title": "Update available",
+    "updater_available_body": "Version {{version}} is available.\n\n{{notes}}\n\nDownload and install now?",
+    "updater_notes_fallback": "See release notes on GitHub.",
+    "shortcut_load_failed": "Could not load shortcut: {{message}}",
+    "shortcut_set": "Dictation shortcut set to {{shortcut}}",
+    "shortcut_register_failed": "Couldn't register: {{message}}",
+    "shortcut_reset": "Reset to default",
+    "shortcut_reset_failed": "Reset failed: {{message}}"
   },
   "about": {
     "app": "App",
@@ -316,7 +330,6 @@
     "group_deepl": "DeepL Custom Endpoint",
     "group_microsoft": "Microsoft Translator Custom Endpoint"
   },
-
   "capture": {
     "desc": "Global hotkeys only work in the desktop app. The web UI uses an in-page <1>Ctrl+Shift+Space</1> shortcut while the window has focus.",
     "desc_detail": "The hotkey works system-wide while OmniVoice is running — it focuses the window and starts dictation. Avoid combos already claimed by the OS (on macOS, <1>⌘+Space</1> is Spotlight and <2>⌘+⇧+Space</2> cycles input sources). If registration fails, pick a different combo.",
@@ -511,7 +524,11 @@
     "install_already": "{{engine}} was already installed",
     "install_ok": "{{engine}} installed",
     "install_failed": "Install failed: {{message}}",
-    "prep_elapsed": "{{time}} elapsed"
+    "prep_elapsed": "{{time}} elapsed",
+    "diagnostic_copied": "Diagnostic copied",
+    "copy_failed": "Copy failed",
+    "open_docs": "Open docs",
+    "copy_diagnostic": "Copy diagnostic"
   },
   "glossary": {
     "title": "Glossary",
@@ -706,7 +723,6 @@
     "estimate": "{{videos}} video(s) × {{langs}} lang(s) = {{jobs}} job(s)",
     "select_files_langs": "Select files and languages",
     "add_to_queue": "Add to Queue"
-
   },
   "gallery": {
     "title": "Gallery",
@@ -1527,6 +1543,26 @@
   },
   "app": {
     "loading": "Loading…",
-    "trimmed_loaded": "Trimmed audio loaded"
+    "trimmed_loaded": "Trimmed audio loaded",
+    "toast_exported": "Exported: {{name}}",
+    "toast_export_failed": "Export failed: {{message}}",
+    "toast_open_folder_failed": "Could not open folder: {{message}}",
+    "toast_saving": "Saving {{name}}...",
+    "toast_saved": "Saved: {{path}}",
+    "toast_save_error": "Save error: {{message}}",
+    "toast_processing": "Processing {{name}}...",
+    "toast_downloaded": "Downloaded {{name}}",
+    "toast_download_error": "Download error: {{message}}",
+    "toast_upload_first": "Please click 'Upload & Transcribe' first so the video is processed on the server before saving.",
+    "toast_save_failed": "Save failed: {{message}}",
+    "toast_opened": "Opened: {{name}}",
+    "toast_project_deleted": "Project deleted",
+    "toast_restored_state": "Restored previous generation state",
+    "toast_history_deleted": "History item deleted",
+    "toast_flushed": "Flushed — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": " · model unloaded",
+    "toast_flush_failed": "Flush failed: {{message}}",
+    "toast_project_saved": "Project saved",
+    "toast_project_created": "Project created"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Registros de backend borrados",
     "clear_backend_failed": "No se pudieron borrar los registros",
     "copy_failed": "Copia fallida: {{message}}",
-    "update_check_failed": "Error en la verificación de actualización: {{message}}"
+    "update_check_failed": "Error en la verificación de actualización: {{message}}",
+    "save_failed": "Error al guardar: {{message}}",
+    "clear_failed": "Borrado fallido: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "No se pudo configurar el canal: {{message}}",
+    "updater_downloading": "Descargando {{version}}…",
+    "updater_installed": "Instalado - relanzando.",
+    "updater_available_title": "Actualización disponible",
+    "updater_available_body": "La versión {{version}} está disponible.\n\n{{notes}}\n\n¿Descargar e instalar ahora?",
+    "updater_notes_fallback": "Consulte las notas de la versión en GitHub.",
+    "shortcut_load_failed": "No se pudo cargar el acceso directo: {{message}}",
+    "shortcut_set": "Atajo de dictado configurado en {{shortcut}}",
+    "shortcut_register_failed": "No se pudo registrar: {{message}}",
+    "shortcut_reset": "Restablecer los valores predeterminados",
+    "shortcut_reset_failed": "Error al restablecer: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -632,7 +646,11 @@
     "languages_selected_one": "{{count}} idioma seleccionado",
     "languages_selected_other": "{{count}} idiomas seleccionados",
     "more_to_narrow": "+{{count}} más — escribe para limitar",
-    "no_matches": "No hay coincidencias"
+    "no_matches": "No hay coincidencias",
+    "diagnostic_copied": "Diagnóstico copiado",
+    "copy_failed": "Copia fallida",
+    "open_docs": "Documentos abiertos",
+    "copy_diagnostic": "Copiar diagnóstico"
   },
   "glossary": {
     "title": "Glosario",
@@ -1505,7 +1523,27 @@
   },
   "app": {
     "loading": "Cargando…",
-    "trimmed_loaded": "Audio recortado cargado"
+    "trimmed_loaded": "Audio recortado cargado",
+    "toast_exported": "Exportado: {{name}}",
+    "toast_export_failed": "Error al exportar: {{message}}",
+    "toast_open_folder_failed": "No se pudo abrir la carpeta: {{message}}",
+    "toast_saving": "Guardando {{name}}...",
+    "toast_saved": "Guardado: {{path}}",
+    "toast_save_error": "Error al guardar: {{message}}",
+    "toast_processing": "Procesando {{name}}...",
+    "toast_downloaded": "Descargado {{name}}",
+    "toast_download_error": "Error de descarga: {{message}}",
+    "toast_upload_first": "Primero haga clic en \"Cargar y transcribir\" para que el video se procese en el servidor antes de guardarlo.",
+    "toast_save_failed": "Error al guardar: {{message}}",
+    "toast_opened": "Abierto: {{name}}",
+    "toast_project_deleted": "Proyecto eliminado",
+    "toast_restored_state": "Estado de generación anterior restaurado",
+    "toast_history_deleted": "Elemento del historial eliminado",
+    "toast_flushed": "Vaciado — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· modelo descargado",
+    "toast_flush_failed": "Error de descarga: {{message}}",
+    "toast_project_saved": "Proyecto guardado",
+    "toast_project_created": "Proyecto creado"
   },
   "update": {
     "available": "Actualización {{version}} disponible",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Journaux back-end effacés",
     "clear_backend_failed": "Échec de la suppression des journaux",
     "copy_failed": "Échec de la copie : {{message}}",
-    "update_check_failed": "Échec de la vérification de la mise à jour : {{message}}"
+    "update_check_failed": "Échec de la vérification de la mise à jour : {{message}}",
+    "save_failed": "Échec de l'enregistrement : {{message}}",
+    "clear_failed": "Échec de la suppression : {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Échec de la définition du canal : {{message}}",
+    "updater_downloading": "Téléchargement de {{version}}…",
+    "updater_installed": "Installé — relance.",
+    "updater_available_title": "Mise à jour disponible",
+    "updater_available_body": "La version {{version}} est disponible.\n\n{{notes}}\n\nTélécharger et installer maintenant ?",
+    "updater_notes_fallback": "Voir les notes de version sur GitHub.",
+    "shortcut_load_failed": "Impossible de charger le raccourci : {{message}}",
+    "shortcut_set": "Raccourci de dictée défini sur {{shortcut}}",
+    "shortcut_register_failed": "Impossible de s'inscrire : {{message}}",
+    "shortcut_reset": "Réinitialiser aux valeurs par défaut",
+    "shortcut_reset_failed": "Échec de la réinitialisation : {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -632,7 +646,11 @@
     "languages_selected_one": "{{count}} langue sélectionnée",
     "languages_selected_other": "{{count}} langues sélectionnées",
     "more_to_narrow": "+{{count}} plus — tapez pour affiner",
-    "no_matches": "Aucune correspondance"
+    "no_matches": "Aucune correspondance",
+    "diagnostic_copied": "Diagnostic copié",
+    "copy_failed": "Échec de la copie",
+    "open_docs": "Ouvrir des documents",
+    "copy_diagnostic": "Copier le diagnostic"
   },
   "glossary": {
     "title": "Glossaire",
@@ -1505,7 +1523,27 @@
   },
   "app": {
     "loading": "Chargement…",
-    "trimmed_loaded": "Audio découpé chargé"
+    "trimmed_loaded": "Audio découpé chargé",
+    "toast_exported": "Exporté : {{name}}",
+    "toast_export_failed": "Échec de l'exportation : {{message}}",
+    "toast_open_folder_failed": "Impossible d'ouvrir le dossier : {{message}}",
+    "toast_saving": "Sauvegarde de {{name}}...",
+    "toast_saved": "Enregistré : {{path}}",
+    "toast_save_error": "Erreur d'enregistrement : {{message}}",
+    "toast_processing": "Traitement {{name}}...",
+    "toast_downloaded": "Téléchargé {{name}}",
+    "toast_download_error": "Erreur de téléchargement : {{message}}",
+    "toast_upload_first": "Veuillez d'abord cliquer sur « Télécharger et transcrire » afin que la vidéo soit traitée sur le serveur avant de l'enregistrer.",
+    "toast_save_failed": "Échec de l'enregistrement : {{message}}",
+    "toast_opened": "Ouvert : {{name}}",
+    "toast_project_deleted": "Projet supprimé",
+    "toast_restored_state": "État de la génération précédente restauré",
+    "toast_history_deleted": "Élément d'historique supprimé",
+    "toast_flushed": "Vidé — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· modèle déchargé",
+    "toast_flush_failed": "Échec du rinçage : {{message}}",
+    "toast_project_saved": "Projet enregistré",
+    "toast_project_created": "Projet créé"
   },
   "update": {
     "available": "Mise à jour {{version}} disponible",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "बैकएंड लॉग साफ़ किए गए",
     "clear_backend_failed": "लॉग साफ़ करने में विफल",
     "copy_failed": "प्रतिलिपि विफल: {{message}}",
-    "update_check_failed": "अद्यतन जाँच विफल: {{message}}"
+    "update_check_failed": "अद्यतन जाँच विफल: {{message}}",
+    "save_failed": "सहेजना विफल: {{message}}",
+    "clear_failed": "साफ़ विफल: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "चैनल सेट करने में विफल: {{message}}",
+    "updater_downloading": "डाउनलोड हो रहा है {{version}}…",
+    "updater_installed": "इंस्टॉल किया गया - पुनः लॉन्च किया जा रहा है।",
+    "updater_available_title": "अपडेट उपलब्ध है",
+    "updater_available_body": "संस्करण {{version}} उपलब्ध है.\n\n{{notes}}\n\nअभी डाउनलोड करें और इंस्टॉल करें?",
+    "updater_notes_fallback": "GitHub पर रिलीज़ नोट्स देखें।",
+    "shortcut_load_failed": "शॉर्टकट लोड नहीं किया जा सका: {{message}}",
+    "shortcut_set": "डिक्टेशन शॉर्टकट {{shortcut}} पर सेट किया गया",
+    "shortcut_register_failed": "पंजीकरण नहीं हो सका: {{message}}",
+    "shortcut_reset": "डिफ़ॉल्ट पर रीसेट करें",
+    "shortcut_reset_failed": "रीसेट विफल: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} भाषा चयनित",
     "languages_selected_other": "{{count}} भाषाएँ चयनित",
     "more_to_narrow": "+{{count}} अधिक - संकीर्ण करने के लिए टाइप करें",
-    "no_matches": "कोई मेल नहीं"
+    "no_matches": "कोई मेल नहीं",
+    "diagnostic_copied": "डायग्नोस्टिक कॉपी किया गया",
+    "copy_failed": "प्रतिलिपि विफल",
+    "open_docs": "दस्तावेज़ खोलें",
+    "copy_diagnostic": "डायग्नोस्टिक कॉपी करें"
   },
   "glossary": {
     "title": "शब्दावली",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "लोड हो रहा है...",
-    "trimmed_loaded": "ट्रिम किया गया ऑडियो लोड किया गया"
+    "trimmed_loaded": "ट्रिम किया गया ऑडियो लोड किया गया",
+    "toast_exported": "निर्यातित: {{name}}",
+    "toast_export_failed": "निर्यात विफल: {{message}}",
+    "toast_open_folder_failed": "फ़ोल्डर नहीं खुल सका: {{message}}",
+    "toast_saving": "सहेजा जा रहा है {{name}}...",
+    "toast_saved": "सहेजा गया: {{path}}",
+    "toast_save_error": "त्रुटि सहेजें: {{message}}",
+    "toast_processing": "प्रसंस्करण {{name}}...",
+    "toast_downloaded": "डाउनलोड किया गया {{name}}",
+    "toast_download_error": "डाउनलोड त्रुटि: {{message}}",
+    "toast_upload_first": "कृपया पहले 'अपलोड और ट्रांसक्राइब' पर क्लिक करें ताकि वीडियो सहेजने से पहले सर्वर पर संसाधित हो जाए।",
+    "toast_save_failed": "सहेजना विफल: {{message}}",
+    "toast_opened": "खोला गया: {{name}}",
+    "toast_project_deleted": "प्रोजेक्ट हटा दिया गया",
+    "toast_restored_state": "पिछली पीढ़ी की स्थिति बहाल की गई",
+    "toast_history_deleted": "इतिहास आइटम हटा दिया गया",
+    "toast_flushed": "फ्लश - RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· मॉडल उतार दिया गया",
+    "toast_flush_failed": "फ्लश विफल: {{message}}",
+    "toast_project_saved": "प्रोजेक्ट सहेजा गया",
+    "toast_project_created": "प्रोजेक्ट बनाया गया"
   },
   "update": {
     "available": "अपडेट {{version}} उपलब्ध है",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Log backend dihapus",
     "clear_backend_failed": "Gagal menghapus log",
     "copy_failed": "Penyalinan gagal: {{message}}",
-    "update_check_failed": "Pemeriksaan pembaruan gagal: {{message}}"
+    "update_check_failed": "Pemeriksaan pembaruan gagal: {{message}}",
+    "save_failed": "Gagal menyimpan: {{message}}",
+    "clear_failed": "Hapus gagal: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Gagal menyetel saluran: {{message}}",
+    "updater_downloading": "Mengunduh {{version}}…",
+    "updater_installed": "Dipasang — diluncurkan kembali.",
+    "updater_available_title": "Pembaruan tersedia",
+    "updater_available_body": "Versi {{version}} tersedia.\n\n{{notes}}\n\nUnduh dan instal sekarang?",
+    "updater_notes_fallback": "Lihat catatan rilis di GitHub.",
+    "shortcut_load_failed": "Tidak dapat memuat pintasan: {{message}}",
+    "shortcut_set": "Pintasan dikte disetel ke {{shortcut}}",
+    "shortcut_register_failed": "Tidak dapat mendaftar: {{message}}",
+    "shortcut_reset": "Atur ulang ke default",
+    "shortcut_reset_failed": "Penyetelan ulang gagal: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} bahasa dipilih",
     "languages_selected_other": "{{count}} bahasa dipilih",
     "more_to_narrow": "+{{count}} more — ketik untuk mempersempit",
-    "no_matches": "Tidak ada kecocokan"
+    "no_matches": "Tidak ada kecocokan",
+    "diagnostic_copied": "Diagnostik disalin",
+    "copy_failed": "Penyalinan gagal",
+    "open_docs": "Buka dokumen",
+    "copy_diagnostic": "Salin diagnostik"
   },
   "glossary": {
     "title": "Glosarium",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Memuat…",
-    "trimmed_loaded": "Audio yang dipangkas dimuat"
+    "trimmed_loaded": "Audio yang dipangkas dimuat",
+    "toast_exported": "Diekspor: {{name}}",
+    "toast_export_failed": "Ekspor gagal: {{message}}",
+    "toast_open_folder_failed": "Tidak dapat membuka folder: {{message}}",
+    "toast_saving": "Menyimpan {{name}}...",
+    "toast_saved": "Disimpan: {{path}}",
+    "toast_save_error": "Kesalahan penyimpanan: {{message}}",
+    "toast_processing": "Memproses {{name}}...",
+    "toast_downloaded": "Diunduh {{name}}",
+    "toast_download_error": "Kesalahan pengunduhan: {{message}}",
+    "toast_upload_first": "Silakan klik 'Unggah & Transkripsikan' terlebih dahulu agar video diproses di server sebelum disimpan.",
+    "toast_save_failed": "Gagal menyimpan: {{message}}",
+    "toast_opened": "Dibuka: {{name}}",
+    "toast_project_deleted": "Proyek dihapus",
+    "toast_restored_state": "Memulihkan keadaan generasi sebelumnya",
+    "toast_history_deleted": "Item riwayat dihapus",
+    "toast_flushed": "Dibilas — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· model dibongkar",
+    "toast_flush_failed": "Gagal menyiram: {{message}}",
+    "toast_project_saved": "Proyek disimpan",
+    "toast_project_created": "Proyek dibuat"
   },
   "update": {
     "available": "Pembaruan {{version}} tersedia",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Registri di backend cancellati",
     "clear_backend_failed": "Impossibile cancellare i registri",
     "copy_failed": "Copia non riuscita: {{message}}",
-    "update_check_failed": "Controllo aggiornamento non riuscito: {{message}}"
+    "update_check_failed": "Controllo aggiornamento non riuscito: {{message}}",
+    "save_failed": "Salvataggio non riuscito: {{message}}",
+    "clear_failed": "Cancellazione non riuscita: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Impossibile impostare il canale: {{message}}",
+    "updater_downloading": "Download in corso di {{version}}...",
+    "updater_installed": "Installato: riavvio.",
+    "updater_available_title": "Aggiornamento disponibile",
+    "updater_available_body": "La versione {{version}} è disponibile.\n\n{{notes}}\n\nScaricare e installare adesso?",
+    "updater_notes_fallback": "Vedi le note di rilascio su GitHub.",
+    "shortcut_load_failed": "Impossibile caricare il collegamento: {{message}}",
+    "shortcut_set": "Scorciatoia per la dettatura impostata su {{shortcut}}",
+    "shortcut_register_failed": "Impossibile registrarsi: {{message}}",
+    "shortcut_reset": "Ripristina le impostazioni predefinite",
+    "shortcut_reset_failed": "Reimpostazione non riuscita: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} lingua selezionata",
     "languages_selected_other": "{{count}} lingue selezionate",
     "more_to_narrow": "+{{count}} altro: digita per restringere",
-    "no_matches": "Nessuna corrispondenza"
+    "no_matches": "Nessuna corrispondenza",
+    "diagnostic_copied": "Diagnostica copiata",
+    "copy_failed": "Copia non riuscita",
+    "open_docs": "Apri documenti",
+    "copy_diagnostic": "Copia diagnostica"
   },
   "glossary": {
     "title": "Glossario",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Caricamento…",
-    "trimmed_loaded": "Audio tagliato caricato"
+    "trimmed_loaded": "Audio tagliato caricato",
+    "toast_exported": "Esportato: {{name}}",
+    "toast_export_failed": "Esportazione non riuscita: {{message}}",
+    "toast_open_folder_failed": "Impossibile aprire la cartella: {{message}}",
+    "toast_saving": "Salvataggio {{name}}...",
+    "toast_saved": "Salvato: {{path}}",
+    "toast_save_error": "Errore di salvataggio: {{message}}",
+    "toast_processing": "Elaborazione {{name}}...",
+    "toast_downloaded": "Scaricato {{name}}",
+    "toast_download_error": "Errore di download: {{message}}",
+    "toast_upload_first": "Fai prima clic su \"Carica e trascrivi\" in modo che il video venga elaborato sul server prima di essere salvato.",
+    "toast_save_failed": "Salvataggio non riuscito: {{message}}",
+    "toast_opened": "Aperto: {{name}}",
+    "toast_project_deleted": "Progetto eliminato",
+    "toast_restored_state": "Stato della generazione precedente ripristinato",
+    "toast_history_deleted": "Elemento della cronologia eliminato",
+    "toast_flushed": "Scaricato — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· modello scarico",
+    "toast_flush_failed": "Eliminazione non riuscita: {{message}}",
+    "toast_project_saved": "Progetto salvato",
+    "toast_project_created": "Progetto creato"
   },
   "update": {
     "available": "Aggiornamento {{version}} disponibile",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "バックエンドログがクリアされました",
     "clear_backend_failed": "ログのクリアに失敗しました",
     "copy_failed": "コピーに失敗しました: {{message}}",
-    "update_check_failed": "更新チェックに失敗しました: {{message}}"
+    "update_check_failed": "更新チェックに失敗しました: {{message}}",
+    "save_failed": "保存に失敗しました: {{message}}",
+    "clear_failed": "クリアに失敗しました: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "チャネルの設定に失敗しました: {{message}}",
+    "updater_downloading": "{{version}} をダウンロード中…",
+    "updater_installed": "インストール済み — 再起動中。",
+    "updater_available_title": "利用可能なアップデート",
+    "updater_available_body": "バージョン {{version}} が利用可能です。\n\n{{notes}}\n\n今すぐダウンロードしてインストールしますか?",
+    "updater_notes_fallback": "GitHub のリリース ノートを参照してください。",
+    "shortcut_load_failed": "ショートカットを読み込めませんでした: {{message}}",
+    "shortcut_set": "ディクテーションのショートカットが {{shortcut}} に設定されました",
+    "shortcut_register_failed": "登録できませんでした: {{message}}",
+    "shortcut_reset": "デフォルトにリセットする",
+    "shortcut_reset_failed": "リセットに失敗しました: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -632,7 +646,11 @@
     "languages_selected_one": "{{count}} 言語が選択されました",
     "languages_selected_other": "{{count}} 言語が選択されました",
     "more_to_narrow": "+{{count}} 詳細 — 入力して絞り込む",
-    "no_matches": "一致しません"
+    "no_matches": "一致しません",
+    "diagnostic_copied": "診断がコピーされました",
+    "copy_failed": "コピーに失敗しました",
+    "open_docs": "ドキュメントを開く",
+    "copy_diagnostic": "コピー診断"
   },
   "glossary": {
     "title": "用語集",
@@ -1505,7 +1523,27 @@
   },
   "app": {
     "loading": "読み込み中…",
-    "trimmed_loaded": "トリミングされたオーディオがロードされました"
+    "trimmed_loaded": "トリミングされたオーディオがロードされました",
+    "toast_exported": "エクスポート済み: {{name}}",
+    "toast_export_failed": "エクスポートに失敗しました: {{message}}",
+    "toast_open_folder_failed": "フォルダーを開けませんでした: {{message}}",
+    "toast_saving": "{{name}} を保存しています...",
+    "toast_saved": "保存済み: {{path}}",
+    "toast_save_error": "保存エラー: {{message}}",
+    "toast_processing": "{{name}} を処理しています...",
+    "toast_downloaded": "{{name}} をダウンロードしました",
+    "toast_download_error": "ダウンロード エラー: {{message}}",
+    "toast_upload_first": "まず「アップロードと文字起こし」をクリックして、ビデオが保存前にサーバー上で処理されるようにしてください。",
+    "toast_save_failed": "保存に失敗しました: {{message}}",
+    "toast_opened": "オープン済み: {{name}}",
+    "toast_project_deleted": "プロジェクトが削除されました",
+    "toast_restored_state": "前世代の状態を復元",
+    "toast_history_deleted": "履歴項目が削除されました",
+    "toast_flushed": "フラッシュ — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· モデルがアンロードされました",
+    "toast_flush_failed": "フラッシュに失敗しました: {{message}}",
+    "toast_project_saved": "プロジェクトが保存されました",
+    "toast_project_created": "プロジェクトが作成されました"
   },
   "update": {
     "available": "アップデート {{version}} が利用可能です",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "백엔드 로그가 삭제되었습니다.",
     "clear_backend_failed": "로그를 지우지 못했습니다.",
     "copy_failed": "복사 실패: {{message}}",
-    "update_check_failed": "업데이트 확인 실패: {{message}}"
+    "update_check_failed": "업데이트 확인 실패: {{message}}",
+    "save_failed": "저장 실패: {{message}}",
+    "clear_failed": "지우기 실패: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "채널 설정 실패: {{message}}",
+    "updater_downloading": "{{version}} 다운로드 중…",
+    "updater_installed": "설치됨 - 다시 시작하는 중입니다.",
+    "updater_available_title": "업데이트 가능",
+    "updater_available_body": "버전 {{version}}을(를) 사용할 수 있습니다.\n\n{{notes}}\n\n지금 다운로드하여 설치하시겠습니까?",
+    "updater_notes_fallback": "GitHub의 릴리스 노트를 참조하세요.",
+    "shortcut_load_failed": "바로가기를 로드할 수 없습니다: {{message}}",
+    "shortcut_set": "받아쓰기 단축키가 {{shortcut}}로 설정되었습니다.",
+    "shortcut_register_failed": "등록할 수 없습니다: {{message}}",
+    "shortcut_reset": "기본값으로 재설정",
+    "shortcut_reset_failed": "재설정 실패: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} 언어 선택됨",
     "languages_selected_other": "{{count}} 언어 선택됨",
     "more_to_narrow": "+{{count}} 더보기 — 범위를 좁히려면 입력하세요.",
-    "no_matches": "일치하는 항목 없음"
+    "no_matches": "일치하는 항목 없음",
+    "diagnostic_copied": "진단이 복사되었습니다.",
+    "copy_failed": "복사 실패",
+    "open_docs": "문서 열기",
+    "copy_diagnostic": "진단 복사"
   },
   "glossary": {
     "title": "용어집",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "로드 중…",
-    "trimmed_loaded": "잘린 오디오 로드됨"
+    "trimmed_loaded": "잘린 오디오 로드됨",
+    "toast_exported": "내보낸 날짜: {{name}}",
+    "toast_export_failed": "내보내기 실패: {{message}}",
+    "toast_open_folder_failed": "폴더를 열 수 없습니다: {{message}}",
+    "toast_saving": "{{name}} 저장 중...",
+    "toast_saved": "저장됨: {{path}}",
+    "toast_save_error": "저장 오류: {{message}}",
+    "toast_processing": "{{name}} 처리 중...",
+    "toast_downloaded": "{{name}} 다운로드됨",
+    "toast_download_error": "다운로드 오류: {{message}}",
+    "toast_upload_first": "저장하기 전에 동영상이 서버에서 처리되도록 먼저 '업로드 및 스크립트 작성'을 클릭하세요.",
+    "toast_save_failed": "저장 실패: {{message}}",
+    "toast_opened": "열림: {{name}}",
+    "toast_project_deleted": "프로젝트가 삭제되었습니다.",
+    "toast_restored_state": "이전 세대 상태를 복원했습니다.",
+    "toast_history_deleted": "기록 항목이 삭제되었습니다.",
+    "toast_flushed": "플러시 — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· 모델 언로드됨",
+    "toast_flush_failed": "플러시 실패: {{message}}",
+    "toast_project_saved": "프로젝트가 저장되었습니다",
+    "toast_project_created": "프로젝트가 생성되었습니다."
   },
   "update": {
     "available": "업데이트 {{version}} 사용 가능",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Backend-logboeken gewist",
     "clear_backend_failed": "Kan de logboeken niet wissen",
     "copy_failed": "Kopiëren mislukt: {{message}}",
-    "update_check_failed": "Updatecontrole mislukt: {{message}}"
+    "update_check_failed": "Updatecontrole mislukt: {{message}}",
+    "save_failed": "Opslaan mislukt: {{message}}",
+    "clear_failed": "Wissen mislukt: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Kan kanaal niet instellen: {{message}}",
+    "updater_downloading": "{{version}} downloaden…",
+    "updater_installed": "Geïnstalleerd - opnieuw gestart.",
+    "updater_available_title": "Update beschikbaar",
+    "updater_available_body": "Versie {{version}} is beschikbaar.\n\n{{notes}}\n\nNu downloaden en installeren?",
+    "updater_notes_fallback": "Zie release-opmerkingen op GitHub.",
+    "shortcut_load_failed": "Kan snelkoppeling niet laden: {{message}}",
+    "shortcut_set": "Dicteersnelkoppeling ingesteld op {{shortcut}}",
+    "shortcut_register_failed": "Kon niet registreren: {{message}}",
+    "shortcut_reset": "Resetten naar standaard",
+    "shortcut_reset_failed": "Reset mislukt: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} taal geselecteerd",
     "languages_selected_other": "{{count}} talen geselecteerd",
     "more_to_narrow": "+{{count}} meer — typ om te verkleinen",
-    "no_matches": "Geen overeenkomsten"
+    "no_matches": "Geen overeenkomsten",
+    "diagnostic_copied": "Diagnostiek gekopieerd",
+    "copy_failed": "Kopiëren mislukt",
+    "open_docs": "Documenten openen",
+    "copy_diagnostic": "Diagnostiek kopiëren"
   },
   "glossary": {
     "title": "Woordenlijst",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Laden…",
-    "trimmed_loaded": "Bijgesneden audio geladen"
+    "trimmed_loaded": "Bijgesneden audio geladen",
+    "toast_exported": "Geëxporteerd: {{name}}",
+    "toast_export_failed": "Exporteren mislukt: {{message}}",
+    "toast_open_folder_failed": "Kan map niet openen: {{message}}",
+    "toast_saving": "{{name}} opslaan...",
+    "toast_saved": "Opgeslagen: {{path}}",
+    "toast_save_error": "Fout bij opslaan: {{message}}",
+    "toast_processing": "Verwerking {{name}}...",
+    "toast_downloaded": "Gedownload {{name}}",
+    "toast_download_error": "Downloadfout: {{message}}",
+    "toast_upload_first": "Klik eerst op 'Uploaden en transcriberen', zodat de video op de server wordt verwerkt voordat deze wordt opgeslagen.",
+    "toast_save_failed": "Opslaan mislukt: {{message}}",
+    "toast_opened": "Geopend: {{name}}",
+    "toast_project_deleted": "Project verwijderd",
+    "toast_restored_state": "Herstelde staat van de vorige generatie",
+    "toast_history_deleted": "Geschiedenisitem verwijderd",
+    "toast_flushed": "Gespoeld — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· model onbeladen",
+    "toast_flush_failed": "Spoelen mislukt: {{message}}",
+    "toast_project_saved": "Project opgeslagen",
+    "toast_project_created": "Project gemaakt"
   },
   "update": {
     "available": "Update {{version}} beschikbaar",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Dzienniki backendu zostały wyczyszczone",
     "clear_backend_failed": "Nie udało się wyczyścić dzienników",
     "copy_failed": "Kopiowanie nie powiodło się: {{message}}",
-    "update_check_failed": "Sprawdzanie aktualizacji nie powiodło się: {{message}}"
+    "update_check_failed": "Sprawdzanie aktualizacji nie powiodło się: {{message}}",
+    "save_failed": "Zapis nie powiódł się: {{message}}",
+    "clear_failed": "Wyczyszczenie nie powiodło się: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Nie udało się ustawić kanału: {{message}}",
+    "updater_downloading": "Pobieranie {{version}}…",
+    "updater_installed": "Zainstalowano — uruchamiam ponownie.",
+    "updater_available_title": "Dostępna aktualizacja",
+    "updater_available_body": "Dostępna jest wersja {{version}}.\n\n{{notes}}\n\nPobrać i zainstalować teraz?",
+    "updater_notes_fallback": "Zobacz informacje o wersji w serwisie GitHub.",
+    "shortcut_load_failed": "Nie można załadować skrótu: {{message}}",
+    "shortcut_set": "Skrót do dyktowania ustawiony na {{shortcut}}",
+    "shortcut_register_failed": "Nie udało się zarejestrować: {{message}}",
+    "shortcut_reset": "Przywróć ustawienia domyślne",
+    "shortcut_reset_failed": "Resetowanie nie powiodło się: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "Wybrano {{count}} język",
     "languages_selected_other": "Wybrano {{count}} języki",
     "more_to_narrow": "+{{count}} więcej — wpisz, aby zawęzić",
-    "no_matches": "Brak dopasowań"
+    "no_matches": "Brak dopasowań",
+    "diagnostic_copied": "Diagnostyka skopiowana",
+    "copy_failed": "Kopiowanie nie powiodło się",
+    "open_docs": "Otwórz dokumenty",
+    "copy_diagnostic": "Kopiuj diagnostykę"
   },
   "glossary": {
     "title": "Glosariusz",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Ładowanie…",
-    "trimmed_loaded": "Wczytano przycięty dźwięk"
+    "trimmed_loaded": "Wczytano przycięty dźwięk",
+    "toast_exported": "Wyeksportowano: {{name}}",
+    "toast_export_failed": "Eksport nie powiódł się: {{message}}",
+    "toast_open_folder_failed": "Nie można otworzyć folderu: {{message}}",
+    "toast_saving": "Zapisywanie {{name}}...",
+    "toast_saved": "Zapisano: {{path}}",
+    "toast_save_error": "Zapisz błąd: {{message}}",
+    "toast_processing": "Przetwarzanie {{name}}...",
+    "toast_downloaded": "Pobrano {{name}}",
+    "toast_download_error": "Błąd pobierania: {{message}}",
+    "toast_upload_first": "Najpierw kliknij „Prześlij i transkrybuj”, aby wideo zostało przetworzone na serwerze przed zapisaniem.",
+    "toast_save_failed": "Zapis nie powiódł się: {{message}}",
+    "toast_opened": "Otwarto: {{name}}",
+    "toast_project_deleted": "Projekt usunięty",
+    "toast_restored_state": "Przywrócono stan poprzedniej generacji",
+    "toast_history_deleted": "Element historii usunięty",
+    "toast_flushed": "Opróżniony — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· model rozładowany",
+    "toast_flush_failed": "Spłukiwanie nie powiodło się: {{message}}",
+    "toast_project_saved": "Projekt zapisany",
+    "toast_project_created": "Projekt stworzony"
   },
   "update": {
     "available": "Dostępna aktualizacja {{version}}",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Registros de back-end limpos",
     "clear_backend_failed": "Falha ao limpar registros",
     "copy_failed": "Falha na cópia: {{message}}",
-    "update_check_failed": "Falha na verificação de atualização: {{message}}"
+    "update_check_failed": "Falha na verificação de atualização: {{message}}",
+    "save_failed": "Falha ao salvar: {{message}}",
+    "clear_failed": "Falha na limpeza: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Falha ao definir canal: {{message}}",
+    "updater_downloading": "Baixando {{version}}…",
+    "updater_installed": "Instalado – relançando.",
+    "updater_available_title": "Atualização disponível",
+    "updater_available_body": "A versão {{version}} está disponível.\n\n{{notes}}\n\nBaixe e instale agora?",
+    "updater_notes_fallback": "Veja as notas de lançamento no GitHub.",
+    "shortcut_load_failed": "Não foi possível carregar o atalho: {{message}}",
+    "shortcut_set": "Atalho de ditado definido como {{shortcut}}",
+    "shortcut_register_failed": "Não foi possível registrar: {{message}}",
+    "shortcut_reset": "Redefinir para o padrão",
+    "shortcut_reset_failed": "Falha na reinicialização: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} idioma selecionado",
     "languages_selected_other": "{{count}} idiomas selecionados",
     "more_to_narrow": "+{{count}} mais — digite para restringir",
-    "no_matches": "Nenhuma correspondência"
+    "no_matches": "Nenhuma correspondência",
+    "diagnostic_copied": "Diagnóstico copiado",
+    "copy_failed": "Falha na cópia",
+    "open_docs": "Abrir documentos",
+    "copy_diagnostic": "Copiar diagnóstico"
   },
   "glossary": {
     "title": "Glossário",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Carregando…",
-    "trimmed_loaded": "Áudio cortado carregado"
+    "trimmed_loaded": "Áudio cortado carregado",
+    "toast_exported": "Exportado: {{name}}",
+    "toast_export_failed": "Falha na exportação: {{message}}",
+    "toast_open_folder_failed": "Não foi possível abrir a pasta: {{message}}",
+    "toast_saving": "Salvando {{name}}...",
+    "toast_saved": "Salvo: {{path}}",
+    "toast_save_error": "Erro ao salvar: {{message}}",
+    "toast_processing": "Processando {{name}}...",
+    "toast_downloaded": "Baixado {{name}}",
+    "toast_download_error": "Erro de download: {{message}}",
+    "toast_upload_first": "Clique primeiro em 'Carregar e transcrever' para que o vídeo seja processado no servidor antes de salvá-lo.",
+    "toast_save_failed": "Falha ao salvar: {{message}}",
+    "toast_opened": "Aberto: {{name}}",
+    "toast_project_deleted": "Projeto excluído",
+    "toast_restored_state": "Estado restaurado da geração anterior",
+    "toast_history_deleted": "Item do histórico excluído",
+    "toast_flushed": "Liberado — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· modelo descarregado",
+    "toast_flush_failed": "Falha na liberação: {{message}}",
+    "toast_project_saved": "Projeto salvo",
+    "toast_project_created": "Projeto criado"
   },
   "update": {
     "available": "Atualização {{version}} disponível",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Серверные журналы очищены",
     "clear_backend_failed": "Не удалось очистить журналы",
     "copy_failed": "Не удалось скопировать: {{message}}",
-    "update_check_failed": "Проверка обновлений не удалась: {{message}}"
+    "update_check_failed": "Проверка обновлений не удалась: {{message}}",
+    "save_failed": "Не удалось сохранить: {{message}}",
+    "clear_failed": "Очистить не удалось: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Не удалось установить канал: {{message}}.",
+    "updater_downloading": "Загрузка {{version}}…",
+    "updater_installed": "Установил — перезапускаю.",
+    "updater_available_title": "Доступно обновление",
+    "updater_available_body": "Доступна версия {{version}}.\n\n{{notes}}\n\nСкачать и установить сейчас?",
+    "updater_notes_fallback": "См. примечания к выпуску на GitHub.",
+    "shortcut_load_failed": "Не удалось загрузить ярлык: {{message}}.",
+    "shortcut_set": "Ярлык диктовки установлен на {{shortcut}}.",
+    "shortcut_register_failed": "Не удалось зарегистрироваться: {{message}}",
+    "shortcut_reset": "Сбросить настройки по умолчанию",
+    "shortcut_reset_failed": "Сброс не удался: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} выбран язык",
     "languages_selected_other": "Выбрано {{count}} языков",
     "more_to_narrow": "+{{count}} еще — введите текст, чтобы сузить",
-    "no_matches": "Нет совпадений"
+    "no_matches": "Нет совпадений",
+    "diagnostic_copied": "Диагностика скопирована",
+    "copy_failed": "Не удалось скопировать",
+    "open_docs": "Открыть документы",
+    "copy_diagnostic": "Копирование диагностики"
   },
   "glossary": {
     "title": "Глоссарий",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Загрузка…",
-    "trimmed_loaded": "Обрезанный звук загружен."
+    "trimmed_loaded": "Обрезанный звук загружен.",
+    "toast_exported": "Экспортировано: {{name}}",
+    "toast_export_failed": "Не удалось экспортировать: {{message}}",
+    "toast_open_folder_failed": "Не удалось открыть папку: {{message}}",
+    "toast_saving": "Сохранение {{name}}...",
+    "toast_saved": "Сохранено: {{path}}",
+    "toast_save_error": "Ошибка сохранения: {{message}}",
+    "toast_processing": "Обработка {{name}}...",
+    "toast_downloaded": "Скачано {{name}}",
+    "toast_download_error": "Ошибка загрузки: {{message}}",
+    "toast_upload_first": "Сначала нажмите «Загрузить и расшифровать», чтобы видео обработалось на сервере перед сохранением.",
+    "toast_save_failed": "Не удалось сохранить: {{message}}",
+    "toast_opened": "Открыто: {{name}}",
+    "toast_project_deleted": "Проект удален",
+    "toast_restored_state": "Восстановлено состояние предыдущего поколения",
+    "toast_history_deleted": "Элемент истории удален.",
+    "toast_flushed": "Сброшено — ОЗУ {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· модель выгружена",
+    "toast_flush_failed": "Сброс не выполнен: {{message}}",
+    "toast_project_saved": "Проект сохранен.",
+    "toast_project_created": "Проект создан"
   },
   "update": {
     "available": "Доступно обновление {{version}}",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Backend-loggarna rensades",
     "clear_backend_failed": "Det gick inte att rensa loggar",
     "copy_failed": "Kopieringen misslyckades: {{message}}",
-    "update_check_failed": "Uppdateringskontrollen misslyckades: {{message}}"
+    "update_check_failed": "Uppdateringskontrollen misslyckades: {{message}}",
+    "save_failed": "Det gick inte att spara: {{message}}",
+    "clear_failed": "Rensa misslyckades: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Det gick inte att ställa in kanal: {{message}}",
+    "updater_downloading": "Laddar ner {{version}}...",
+    "updater_installed": "Installerad — omstart.",
+    "updater_available_title": "Uppdatering tillgänglig",
+    "updater_available_body": "Version {{version}} är tillgänglig.\n\n{{notes}}\n\nLadda ner och installera nu?",
+    "updater_notes_fallback": "Se release notes på GitHub.",
+    "shortcut_load_failed": "Det gick inte att läsa in genväg: {{message}}",
+    "shortcut_set": "Dikteringsgenväg inställd på {{shortcut}}",
+    "shortcut_register_failed": "Kunde inte registrera: {{message}}",
+    "shortcut_reset": "Återställ till standard",
+    "shortcut_reset_failed": "Återställning misslyckades: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} språk valt",
     "languages_selected_other": "{{count}} språk har valts",
     "more_to_narrow": "+{{count}} mer — skriv för att begränsa",
-    "no_matches": "Inga matchningar"
+    "no_matches": "Inga matchningar",
+    "diagnostic_copied": "Diagnostiken kopierad",
+    "copy_failed": "Kopieringen misslyckades",
+    "open_docs": "Öppna dokument",
+    "copy_diagnostic": "Kopiera diagnostik"
   },
   "glossary": {
     "title": "Ordlista",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Laddar...",
-    "trimmed_loaded": "Trimmat ljud har laddats"
+    "trimmed_loaded": "Trimmat ljud har laddats",
+    "toast_exported": "Exporterad: {{name}}",
+    "toast_export_failed": "Export misslyckades: {{message}}",
+    "toast_open_folder_failed": "Kunde inte öppna mappen: {{message}}",
+    "toast_saving": "Sparar {{name}}...",
+    "toast_saved": "Sparad: {{path}}",
+    "toast_save_error": "Spara fel: {{message}}",
+    "toast_processing": "Bearbetar {{name}}...",
+    "toast_downloaded": "Nedladdat {{name}}",
+    "toast_download_error": "Nedladdningsfel: {{message}}",
+    "toast_upload_first": "Klicka på \"Ladda upp och transkribera\" först så att videon bearbetas på servern innan du sparar.",
+    "toast_save_failed": "Det gick inte att spara: {{message}}",
+    "toast_opened": "Öppnad: {{name}}",
+    "toast_project_deleted": "Projektet raderat",
+    "toast_restored_state": "Återställd föregående generations tillstånd",
+    "toast_history_deleted": "Historikobjektet har tagits bort",
+    "toast_flushed": "Spolat — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· modell avlastad",
+    "toast_flush_failed": "Spolning misslyckades: {{message}}",
+    "toast_project_saved": "Projektet sparat",
+    "toast_project_created": "Projekt skapat"
   },
   "update": {
     "available": "Uppdatering {{version}} tillgänglig",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "ล้างบันทึกแบ็กเอนด์แล้ว",
     "clear_backend_failed": "ไม่สามารถล้างบันทึกได้",
     "copy_failed": "การคัดลอกล้มเหลว: {{message}}",
-    "update_check_failed": "การตรวจสอบการอัปเดตล้มเหลว: {{message}}"
+    "update_check_failed": "การตรวจสอบการอัปเดตล้มเหลว: {{message}}",
+    "save_failed": "บันทึกล้มเหลว: {{message}}",
+    "clear_failed": "การเคลียร์ล้มเหลว: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "ไม่สามารถตั้งค่าช่อง: {{message}}",
+    "updater_downloading": "กำลังดาวน์โหลด {{version}}…",
+    "updater_installed": "ติดตั้งแล้ว — เปิดตัวใหม่",
+    "updater_available_title": "อัปเดตพร้อมใช้งาน",
+    "updater_available_body": "มีเวอร์ชัน {{version}} แล้ว\n\n{{notes}}\n\nดาวน์โหลดและติดตั้งทันที?",
+    "updater_notes_fallback": "ดูบันทึกประจำรุ่นบน GitHub",
+    "shortcut_load_failed": "ไม่สามารถโหลดทางลัด: {{message}}",
+    "shortcut_set": "ทางลัดการเขียนตามคำบอกตั้งค่าเป็น {{shortcut}}",
+    "shortcut_register_failed": "ไม่สามารถลงทะเบียนได้: {{message}}",
+    "shortcut_reset": "รีเซ็ตเป็นค่าเริ่มต้น",
+    "shortcut_reset_failed": "การรีเซ็ตล้มเหลว: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "เลือก {{count}} ภาษาแล้ว",
     "languages_selected_other": "เลือก {{count}} ภาษาแล้ว",
     "more_to_narrow": "+{{count}} เพิ่มเติม — พิมพ์เพื่อจำกัดให้แคบลง",
-    "no_matches": "ไม่มีการแข่งขัน"
+    "no_matches": "ไม่มีการแข่งขัน",
+    "diagnostic_copied": "คัดลอกการวินิจฉัยแล้ว",
+    "copy_failed": "การคัดลอกล้มเหลว",
+    "open_docs": "เปิดเอกสาร",
+    "copy_diagnostic": "คัดลอกการวินิจฉัย"
   },
   "glossary": {
     "title": "อภิธานศัพท์",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "กำลังโหลด...",
-    "trimmed_loaded": "โหลดเสียงที่ตัดแล้ว"
+    "trimmed_loaded": "โหลดเสียงที่ตัดแล้ว",
+    "toast_exported": "ส่งออกแล้ว: {{name}}",
+    "toast_export_failed": "การส่งออกล้มเหลว: {{message}}",
+    "toast_open_folder_failed": "ไม่สามารถเปิดโฟลเดอร์: {{message}}",
+    "toast_saving": "กำลังบันทึก {{name}}...",
+    "toast_saved": "บันทึกแล้ว: {{path}}",
+    "toast_save_error": "บันทึกข้อผิดพลาด: {{message}}",
+    "toast_processing": "กำลังประมวลผล {{name}}...",
+    "toast_downloaded": "ดาวน์โหลดแล้ว {{name}}",
+    "toast_download_error": "ข้อผิดพลาดในการดาวน์โหลด: {{message}}",
+    "toast_upload_first": "โปรดคลิก 'อัปโหลดและถอดเสียง' ก่อน เพื่อให้วิดีโอได้รับการประมวลผลบนเซิร์ฟเวอร์ก่อนบันทึก",
+    "toast_save_failed": "บันทึกล้มเหลว: {{message}}",
+    "toast_opened": "เปิดแล้ว: {{name}}",
+    "toast_project_deleted": "ลบโครงการแล้ว",
+    "toast_restored_state": "คืนค่าสถานะรุ่นก่อนหน้า",
+    "toast_history_deleted": "ลบรายการประวัติแล้ว",
+    "toast_flushed": "ฟลัช — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· โมเดลยกเลิกการโหลดแล้ว",
+    "toast_flush_failed": "การฟลัชล้มเหลว: {{message}}",
+    "toast_project_saved": "บันทึกโครงการแล้ว",
+    "toast_project_created": "สร้างโครงการแล้ว"
   },
   "update": {
     "available": "มีอัปเดต {{version}}",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Arka uç günlükleri temizlendi",
     "clear_backend_failed": "Günlükler temizlenemedi",
     "copy_failed": "Kopyalama başarısız oldu: {{message}}",
-    "update_check_failed": "Güncelleme kontrolü başarısız oldu: {{message}}"
+    "update_check_failed": "Güncelleme kontrolü başarısız oldu: {{message}}",
+    "save_failed": "Kaydetme başarısız oldu: {{message}}",
+    "clear_failed": "Temizleme başarısız oldu: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Kanal ayarlanamadı: {{message}}",
+    "updater_downloading": "{{version}} indiriliyor…",
+    "updater_installed": "Yüklendi - yeniden başlatılıyor.",
+    "updater_available_title": "Güncelleme mevcut",
+    "updater_available_body": "Sürüm {{version}} mevcut.\n\n{{notes}}\n\nŞimdi indirip yüklemek ister misiniz?",
+    "updater_notes_fallback": "GitHub'daki sürüm notlarına bakın.",
+    "shortcut_load_failed": "Kısayol yüklenemedi: {{message}}",
+    "shortcut_set": "Dikte kısayolu {{shortcut}} olarak ayarlandı",
+    "shortcut_register_failed": "Kaydedilemedi: {{message}}",
+    "shortcut_reset": "Varsayılana sıfırla",
+    "shortcut_reset_failed": "Sıfırlama başarısız oldu: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} dil seçildi",
     "languages_selected_other": "{{count}} dil seçildi",
     "more_to_narrow": "+{{count}} daha fazla — daraltmak için yazın",
-    "no_matches": "Eşleşme yok"
+    "no_matches": "Eşleşme yok",
+    "diagnostic_copied": "Teşhis kopyalandı",
+    "copy_failed": "Kopyalama başarısız oldu",
+    "open_docs": "Dokümanları aç",
+    "copy_diagnostic": "Teşhisi kopyala"
   },
   "glossary": {
     "title": "Sözlük",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Yükleniyor…",
-    "trimmed_loaded": "Kırpılmış ses yüklendi"
+    "trimmed_loaded": "Kırpılmış ses yüklendi",
+    "toast_exported": "Dışa aktarıldı: {{name}}",
+    "toast_export_failed": "Dışa aktarma başarısız oldu: {{message}}",
+    "toast_open_folder_failed": "Klasör açılamadı: {{message}}",
+    "toast_saving": "{{name}} kaydediliyor...",
+    "toast_saved": "Kaydedildi: {{path}}",
+    "toast_save_error": "Kaydetme hatası: {{message}}",
+    "toast_processing": "{{name}} işleniyor...",
+    "toast_downloaded": "İndirildi {{name}}",
+    "toast_download_error": "İndirme hatası: {{message}}",
+    "toast_upload_first": "Videonun kaydedilmeden önce sunucuda işlenmesi için lütfen önce 'Yükle ve Metne Yaz'ı tıklayın.",
+    "toast_save_failed": "Kaydetme başarısız oldu: {{message}}",
+    "toast_opened": "Açılış: {{name}}",
+    "toast_project_deleted": "Proje silindi",
+    "toast_restored_state": "Önceki nesil durumu geri yüklendi",
+    "toast_history_deleted": "Geçmiş öğesi silindi",
+    "toast_flushed": "Temizlenmiş — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· model boşaltıldı",
+    "toast_flush_failed": "Temizleme başarısız oldu: {{message}}",
+    "toast_project_saved": "Proje kaydedildi",
+    "toast_project_created": "Proje oluşturuldu"
   },
   "update": {
     "available": "{{version}} güncellemesi mevcut",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Серверні журнали очищено",
     "clear_backend_failed": "Не вдалося очистити журнали",
     "copy_failed": "Помилка копіювання: {{message}}",
-    "update_check_failed": "Не вдалося перевірити оновлення: {{message}}"
+    "update_check_failed": "Не вдалося перевірити оновлення: {{message}}",
+    "save_failed": "Не вдалося зберегти: {{message}}",
+    "clear_failed": "Помилка очищення: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Не вдалося встановити канал: {{message}}",
+    "updater_downloading": "Завантаження {{version}}…",
+    "updater_installed": "Встановлено — перезапуск.",
+    "updater_available_title": "Доступне оновлення",
+    "updater_available_body": "Доступна версія {{version}}.\n\n{{notes}}\n\nЗавантажити та встановити зараз?",
+    "updater_notes_fallback": "Перегляньте примітки до випуску на GitHub.",
+    "shortcut_load_failed": "Не вдалося завантажити ярлик: {{message}}",
+    "shortcut_set": "Ярлик для диктування встановлено на {{shortcut}}",
+    "shortcut_register_failed": "Не вдалося зареєструватися: {{message}}",
+    "shortcut_reset": "Скинути до замовчування",
+    "shortcut_reset_failed": "Помилка скидання: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "Вибрано {{count}} мову",
     "languages_selected_other": "Вибрано {{count}} мов",
     "more_to_narrow": "+{{count}} більше — введіть, щоб звузити",
-    "no_matches": "Немає збігів"
+    "no_matches": "Немає збігів",
+    "diagnostic_copied": "Діагностику скопійовано",
+    "copy_failed": "Помилка копіювання",
+    "open_docs": "Відкрити документи",
+    "copy_diagnostic": "Діагностика копії"
   },
   "glossary": {
     "title": "Глосарій",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Завантаження…",
-    "trimmed_loaded": "Завантажено обрізаний звук"
+    "trimmed_loaded": "Завантажено обрізаний звук",
+    "toast_exported": "Експортовано: {{name}}",
+    "toast_export_failed": "Помилка експорту: {{message}}",
+    "toast_open_folder_failed": "Не вдалося відкрити папку: {{message}}",
+    "toast_saving": "Збереження {{name}}...",
+    "toast_saved": "Збережено: {{path}}",
+    "toast_save_error": "Помилка збереження: {{message}}",
+    "toast_processing": "Обробка {{name}}...",
+    "toast_downloaded": "Завантажено {{name}}",
+    "toast_download_error": "Помилка завантаження: {{message}}",
+    "toast_upload_first": "Будь ласка, спочатку натисніть «Завантажити та транскрибувати», щоб відео було оброблено на сервері перед збереженням.",
+    "toast_save_failed": "Не вдалося зберегти: {{message}}",
+    "toast_opened": "Відкрито: {{name}}",
+    "toast_project_deleted": "Проект видалено",
+    "toast_restored_state": "Відновлено стан попереднього покоління",
+    "toast_history_deleted": "Елемент історії видалено",
+    "toast_flushed": "Очищено — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· модель ненавантажена",
+    "toast_flush_failed": "Помилка очищення: {{message}}",
+    "toast_project_saved": "Проект збережено",
+    "toast_project_created": "Проект створено"
   },
   "update": {
     "available": "Доступне оновлення {{version}}",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "Đã xóa nhật ký phụ trợ",
     "clear_backend_failed": "Không thể xóa nhật ký",
     "copy_failed": "Sao chép không thành công: {{message}}",
-    "update_check_failed": "Kiểm tra cập nhật không thành công: {{message}}"
+    "update_check_failed": "Kiểm tra cập nhật không thành công: {{message}}",
+    "save_failed": "Lưu không thành công: {{message}}",
+    "clear_failed": "Xóa không thành công: {{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "Không đặt được kênh: {{message}}",
+    "updater_downloading": "Đang tải xuống _V_0__…",
+    "updater_installed": "Đã cài đặt - khởi chạy lại.",
+    "updater_available_title": "Đã có bản cập nhật",
+    "updater_available_body": "Đã có phiên bản {{version}}.\n\n{{notes}}\n\nTải xuống và cài đặt ngay bây giờ?",
+    "updater_notes_fallback": "Xem ghi chú phát hành trên GitHub.",
+    "shortcut_load_failed": "Không thể tải phím tắt: {{message}}",
+    "shortcut_set": "Phím tắt đọc chính tả được đặt thành {{shortcut}}",
+    "shortcut_register_failed": "Không thể đăng ký: {{message}}",
+    "shortcut_reset": "Đặt lại về mặc định",
+    "shortcut_reset_failed": "Đặt lại không thành công: {{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "{{count}} ngôn ngữ đã chọn",
     "languages_selected_other": "{{count}} ngôn ngữ đã chọn",
     "more_to_narrow": "+{{count}} thêm — gõ để thu hẹp",
-    "no_matches": "Không có kết quả phù hợp"
+    "no_matches": "Không có kết quả phù hợp",
+    "diagnostic_copied": "Đã sao chép chẩn đoán",
+    "copy_failed": "Sao chép không thành công",
+    "open_docs": "Mở tài liệu",
+    "copy_diagnostic": "Sao chép chẩn đoán"
   },
   "glossary": {
     "title": "Thuật ngữ",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "Đang tải…",
-    "trimmed_loaded": "Đã tải âm thanh đã cắt bớt"
+    "trimmed_loaded": "Đã tải âm thanh đã cắt bớt",
+    "toast_exported": "Đã xuất: {{name}}",
+    "toast_export_failed": "Xuất không thành công: {{message}}",
+    "toast_open_folder_failed": "Không thể mở thư mục: {{message}}",
+    "toast_saving": "Đang lưu {{name}}...",
+    "toast_saved": "Đã lưu: {{path}}",
+    "toast_save_error": "Lỗi lưu: {{message}}",
+    "toast_processing": "Đang xử lý {{name}}...",
+    "toast_downloaded": "Đã tải xuống _V_0__",
+    "toast_download_error": "Lỗi tải xuống: _V_0__",
+    "toast_upload_first": "Vui lòng nhấp vào 'Tải lên & Phiên âm' trước để video được xử lý trên máy chủ trước khi lưu.",
+    "toast_save_failed": "Lưu không thành công: {{message}}",
+    "toast_opened": "Đã mở: {{name}}",
+    "toast_project_deleted": "Dự án đã bị xóa",
+    "toast_restored_state": "Đã khôi phục trạng thái thế hệ trước",
+    "toast_history_deleted": "Mục lịch sử đã bị xóa",
+    "toast_flushed": "Đã xóa — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· dỡ mô hình",
+    "toast_flush_failed": "Xóa không thành công: {{message}}",
+    "toast_project_saved": "Đã lưu dự án",
+    "toast_project_created": "Dự án đã được tạo"
   },
   "update": {
     "available": "Đã có bản cập nhật {{version}}",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -253,7 +253,21 @@
     "backend_logs_cleared": "后台日志清除",
     "clear_backend_failed": "清除日志失败",
     "copy_failed": "复制失败：{{message}}",
-    "update_check_failed": "更新检查失败：{{message}}"
+    "update_check_failed": "更新检查失败：{{message}}",
+    "save_failed": "保存失败：{{message}}",
+    "clear_failed": "清除失败：{{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "无法设置频道：{{message}}",
+    "updater_downloading": "正在下载 {{version}}...",
+    "updater_installed": "已安装 - 重新启动。",
+    "updater_available_title": "可用更新",
+    "updater_available_body": "版本 {{version}} 可用。\n\n{{notes}}\n\n立即下载并安装？",
+    "updater_notes_fallback": "请参阅 GitHub 上的发行说明。",
+    "shortcut_load_failed": "无法加载快捷方式：{{message}}",
+    "shortcut_set": "听写快捷键设置为 {{shortcut}}",
+    "shortcut_register_failed": "无法注册：{{message}}",
+    "shortcut_reset": "重置为默认值",
+    "shortcut_reset_failed": "重置失败：{{message}}"
   },
   "about": {
     "app": "应用",
@@ -601,7 +615,11 @@
     "languages_selected_one": "已选择 {{count}} 语言",
     "languages_selected_other": "已选择 {{count}} 种语言",
     "more_to_narrow": "+{{count}} more — 键入缩小范围",
-    "no_matches": "没有匹配项"
+    "no_matches": "没有匹配项",
+    "diagnostic_copied": "诊断复制",
+    "copy_failed": "复制失败",
+    "open_docs": "打开文档",
+    "copy_diagnostic": "复制诊断"
   },
   "glossary": {
     "title": "术语表",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "加载中...",
-    "trimmed_loaded": "已加载修剪后的音频"
+    "trimmed_loaded": "已加载修剪后的音频",
+    "toast_exported": "导出：{{name}}",
+    "toast_export_failed": "导出失败：{{message}}",
+    "toast_open_folder_failed": "无法打开文件夹：{{message}}",
+    "toast_saving": "正在保存 {{name}}...",
+    "toast_saved": "已保存：{{path}}",
+    "toast_save_error": "保存错误：{{message}}",
+    "toast_processing": "正在处理 {{name}}...",
+    "toast_downloaded": "已下载{{name}}",
+    "toast_download_error": "下载错误：{{message}}",
+    "toast_upload_first": "请先单击“上传和转录”，以便在保存之前在服务器上处理视频。",
+    "toast_save_failed": "保存失败：{{message}}",
+    "toast_opened": "开放时间：{{name}}",
+    "toast_project_deleted": "项目已删除",
+    "toast_restored_state": "恢复了上一代状态",
+    "toast_history_deleted": "历史记录项已删除",
+    "toast_flushed": "刷新 — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· 模型卸载",
+    "toast_flush_failed": "刷新失败：{{message}}",
+    "toast_project_saved": "项目已保存",
+    "toast_project_created": "项目已创建"
   },
   "update": {
     "available": "有可用更新 {{version}}",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -59,7 +59,21 @@
     "backend_logs_cleared": "後台日誌清除",
     "clear_backend_failed": "清除日誌失敗",
     "copy_failed": "複製失敗：{{message}}",
-    "update_check_failed": "更新檢查失敗：{{message}}"
+    "update_check_failed": "更新檢查失敗：{{message}}",
+    "save_failed": "儲存失敗：{{message}}",
+    "clear_failed": "清除失敗：{{message}}",
+    "engine_switched": "{{family}} → {{engine}}",
+    "channel_set_failed": "無法設定頻道：{{message}}",
+    "updater_downloading": "正在下載 {{version}}...",
+    "updater_installed": "已安裝 - 重新啟動。",
+    "updater_available_title": "可用更新",
+    "updater_available_body": "版本 {{version}} 可用。\n\n{{notes}}\n\n立即下載並安裝？",
+    "updater_notes_fallback": "請參閱 GitHub 上的發行說明。",
+    "shortcut_load_failed": "無法載入捷徑：{{message}}",
+    "shortcut_set": "聽寫快捷鍵設定為 {{shortcut}}",
+    "shortcut_register_failed": "無法註冊：{{message}}",
+    "shortcut_reset": "重設為預設值",
+    "shortcut_reset_failed": "重置失敗：{{message}}"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -631,7 +645,11 @@
     "languages_selected_one": "已選擇 {{count}} 語言",
     "languages_selected_other": "已選擇 {{count}} 種語言",
     "more_to_narrow": "+{{count}} more — 鍵入縮小範圍",
-    "no_matches": "沒有匹配項"
+    "no_matches": "沒有匹配項",
+    "diagnostic_copied": "診斷複製",
+    "copy_failed": "複製失敗",
+    "open_docs": "開啟文件",
+    "copy_diagnostic": "複製診斷"
   },
   "glossary": {
     "title": "詞彙表",
@@ -1504,7 +1522,27 @@
   },
   "app": {
     "loading": "加載中...",
-    "trimmed_loaded": "已載入修剪後的音頻"
+    "trimmed_loaded": "已載入修剪後的音頻",
+    "toast_exported": "匯出：{{name}}",
+    "toast_export_failed": "匯出失敗：{{message}}",
+    "toast_open_folder_failed": "無法開啟資料夾：{{message}}",
+    "toast_saving": "正在儲存 {{name}}...",
+    "toast_saved": "已儲存：{{path}}",
+    "toast_save_error": "儲存錯誤：{{message}}",
+    "toast_processing": "正在處理 {{name}}...",
+    "toast_downloaded": "已下載{{name}}",
+    "toast_download_error": "下載錯誤：{{message}}",
+    "toast_upload_first": "請先點擊“上傳和轉錄”，以便在儲存之前在伺服器上處理影片。",
+    "toast_save_failed": "儲存失敗：{{message}}",
+    "toast_opened": "開放時間：{{name}}",
+    "toast_project_deleted": "項目已刪除",
+    "toast_restored_state": "恢復了上一代狀態",
+    "toast_history_deleted": "歷史記錄項目已刪除",
+    "toast_flushed": "刷新 — RAM {{ram}}G · VRAM {{vram}}G{{unloaded}}",
+    "toast_model_unloaded": "· 模型卸載",
+    "toast_flush_failed": "刷新失敗：{{message}}",
+    "toast_project_saved": "項目已儲存",
+    "toast_project_created": "專案已建立"
   },
   "update": {
     "available": "有可用更新 {{version}}",

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -38,14 +38,15 @@ const LazyFallback = () => (
  *  diagnostic block — shown beneath the error badge when the backend sent a
  *  structured failure. */
 function DubFailureNotice({ failure }) {
+  const { t } = useTranslation();
   if (!failure) return null;
   const topic = failure.docsTopic || classifyError(failure.reason);
   const copyDiagnostic = async () => {
     try {
       await copyText(failure.diagnostic || failure.reason);
-      toast.success('Diagnostic copied');
+      toast.success(t('dub.diagnostic_copied'));
     } catch {
-      toast.error('Copy failed');
+      toast.error(t('dub.copy_failed'));
     }
   };
   return (
@@ -54,12 +55,12 @@ function DubFailureNotice({ failure }) {
       <div className="dub-failure-notice__actions">
         {topic && (
           <Button variant="subtle" size="sm" onClick={() => openDocsFor(topic)}>
-            <ExternalLink size={11} /> Open docs
+            <ExternalLink size={11} /> {t('dub.open_docs')}
           </Button>
         )}
         {failure.diagnostic && (
           <Button variant="subtle" size="sm" onClick={copyDiagnostic}>
-            <Copy size={11} /> Copy diagnostic
+            <Copy size={11} /> {t('dub.copy_diagnostic')}
           </Button>
         )}
       </div>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -103,7 +103,7 @@ function GeneralTab() {
         const d = await r.json().catch(() => ({}));
         toast.error(d.detail || t('credentials.save_failed'));
       }
-    } catch (e) { toast.error(`Save failed: ${e.message}`); }
+    } catch (e) { toast.error(t('settings.save_failed', { message: e.message })); }
     finally { setFfmpegSaving(false); }
   };
 
@@ -139,7 +139,7 @@ function GeneralTab() {
         const d = await r.json().catch(() => ({}));
         toast.error(d.detail || t('settings.proxy_save_failed'));
       }
-    } catch (e) { toast.error(`Save failed: ${e.message}`); }
+    } catch (e) { toast.error(t('settings.save_failed', { message: e.message })); }
     finally { setProxySaving(false); }
   };
 
@@ -164,7 +164,7 @@ function GeneralTab() {
       setProxySaved(false);
       toast.success(t('settings.proxy_cleared'));
       queryClient.invalidateQueries({ queryKey: queryKeys.systemInfo });
-    } catch (e) { toast.error(`Clear failed: ${e.message}`); }
+    } catch (e) { toast.error(t('settings.clear_failed', { message: e.message })); }
     finally { setProxySaving(false); }
   };
 
@@ -350,7 +350,7 @@ export function ModelStoreTab({ info, modelBadge }) {
         const d = await res.json().catch(() => ({}));
         toast.error(d.detail || t('models.hf_token_save_failed'));
       }
-    } catch (e) { toast.error(`Save failed: ${e.message}`); }
+    } catch (e) { toast.error(t('settings.save_failed', { message: e.message })); }
     finally { setHfSaving(false); }
   };
   const hfTokenSet = hfSaved || info?.has_hf_token;
@@ -1010,7 +1010,7 @@ export function EnginesTab() {
   const onSelect = useCallback(async (family, backendId) => {
     try {
       const r = await selectEngine(family, backendId);
-      toast.success(`${family.toUpperCase()} → ${r.active}`);
+      toast.success(t('settings.engine_switched', { family: family.toUpperCase(), engine: r.active }));
     } catch (e) {
       toast.error(e.message || t('engines.switch_failed'));
     }
@@ -1097,7 +1097,7 @@ export default function Settings() {
       await invoke('set_update_channel', { channel: next });
       toast.success(t('about.channel_set', { channel: t(`about.channel_${next}`) }));
     } catch (e) {
-      toast.error(`Failed to set channel: ${e?.message || e}`);
+      toast.error(t('settings.channel_set_failed', { message: e?.message || e }));
     }
   }, [t]);
 
@@ -1165,14 +1165,17 @@ export default function Settings() {
         return;
       }
       const proceed = await ask(
-        `Version ${update.version} is available.\n\n${update.notes || 'See release notes on GitHub.'}\n\nDownload and install now?`,
-        { title: 'Update available', kind: 'info' },
+        t('settings.updater_available_body', {
+          version: update.version,
+          notes: update.notes || t('settings.updater_notes_fallback'),
+        }),
+        { title: t('settings.updater_available_title'), kind: 'info' },
       );
       if (!proceed) { setUpdateState('idle'); return; }
       setUpdateState('downloading');
-      const tid = toast.loading(`Downloading ${update.version}…`);
+      const tid = toast.loading(t('settings.updater_downloading', { version: update.version }));
       await invoke('install_update', { channel });
-      toast.success('Installed — relaunching.', { id: tid });
+      toast.success(t('settings.updater_installed'), { id: tid });
       await relaunch();
     } catch (e) {
       setUpdateState('error');
@@ -1536,7 +1539,7 @@ function HotkeyTab() {
         const v = await invoke('get_dictation_shortcut');
         setCurrent(v || '');
       } catch (e) {
-        toast.error(`Could not load shortcut: ${e?.message || e}`);
+        toast.error(t('settings.shortcut_load_failed', { message: e?.message || e }));
       }
     })();
   }, [tauri]);
@@ -1571,11 +1574,11 @@ function HotkeyTab() {
       const saved = await invoke('set_dictation_shortcut', { accelerator: pending });
       setCurrent(saved);
       setPending('');
-      toast.success(`Dictation shortcut set to ${saved}`);
+      toast.success(t('settings.shortcut_set', { shortcut: saved }));
     } catch (e) {
       // Common cause: the OS or another app already owns the combo. Surface
       // the raw error so the user can pick something else.
-      toast.error(`Couldn't register: ${e?.message || e}`);
+      toast.error(t('settings.shortcut_register_failed', { message: e?.message || e }));
     } finally {
       setSaving(false);
     }
@@ -1590,9 +1593,9 @@ function HotkeyTab() {
       });
       setCurrent(saved);
       setPending('');
-      toast.success('Reset to default');
+      toast.success(t('settings.shortcut_reset'));
     } catch (e) {
-      toast.error(`Reset failed: ${e?.message || e}`);
+      toast.error(t('settings.shortcut_reset_failed', { message: e?.message || e }));
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
You flagged that #230 wasn't actually clean. I verified the dangerous part first — **zero regressions** (the only shared-key value change from the merge was my intentional `engines.unavailable` casing fix). The real residual was the **"full i18n coverage" overclaim**: #230 was based on a stale snapshot, so strings added to main *after* it — the updater/channel dialog, dictation shortcut, and a batch of export/save/project toasts — were still hardcoded English.

This extracts the remaining **user-facing imperative strings** (toasts + the update `ask()` dialog) plus the adjacent JSX labels in `DubFailureNotice`:

- **App.jsx** (17): export/save/download/project/flush toasts → `i18n.t('app.toast_*')` (reused the already-imported configured `i18n` instance instead of plumbing a hook through 17 handlers).
- **Settings.jsx** (14): save/clear failures, engine-switch, channel, updater download/install + the "Update available" dialog, dictation-shortcut set/register/reset.
- **DubTab.jsx**: added `useTranslation` to `DubFailureNotice`; its 2 toasts + "Open docs"/"Copy diagnostic" labels.

**38 new keys** in en.json, backfilled across all 21 locales.

Verified: 21 locales at parity, tsc clean, build OK, vitest 167/167, CJK guard.

**Scope note:** this covers imperative strings (toast/ask) in these 3 files. A full codebase audit of *all* JSX text/placeholders is a larger separate sweep — happy to do it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Internationalization**
  * Added comprehensive language support for 15+ languages including Arabic, German, Spanish, French, Hindi, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Portuguese, Russian, Swedish, Turkish, Ukrainian, Vietnamese, and Chinese variants. All notifications and messages for file operations, project management, and system actions now appear in your selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->