### PR TITLE
fix(license): declare actual FSL-1.1-ALv2 in pyproject (was Apache-2.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ name = "omnivoice"
 version = "0.3.0"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
-license = "Apache-2.0"
+# Source-available under FSL-1.1-ALv2 (see LICENSE); each release converts to
+# Apache-2.0 two years after publication. Declared as a PEP 639 LicenseRef
+# since FSL isn't an OSI/SPDX-listed identifier.
+license = "LicenseRef-FSL-1.1-ALv2"
 requires-python = ">=3.11"
 authors = [{name = "Han Zhu"}]
 keywords = [


### PR DESCRIPTION
`pyproject.toml` declared `license = "Apache-2.0"`, but the repo's LICENSE is **FSL-1.1-ALv2** (each release converts to Apache-2.0 two years after publication). The Apache-2.0 declaration was inaccurate for the current grant.

Declared as a PEP 639 `LicenseRef-FSL-1.1-ALv2` since FSL isn't an OSI/SPDX-listed identifier. Validated locally: hatchling accepts the expression and `uv build` succeeds, so packaging/CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package license metadata to FSL-1.1-ALv2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->