### PR TITLE
fix(asr): repoint two 404 ASR model repo IDs in catalog (closes #239)

### DIFF
--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -58,11 +58,11 @@ models:
     size_gb: 0.08
     platforms: [darwin-arm64]
 
-  - repo_id: "Systran/faster-whisper-large-v3-turbo"
+  - repo_id: "deepdml/faster-whisper-large-v3-turbo-ct2"
     label: "Whisper large-v3 Turbo (5× faster, 0.8B)"
     role: ASR
     size_gb: 1.6
-    note: "Best speed/quality tradeoff. 5× faster than large-v3 with minimal WER loss."
+    note: "Best speed/quality tradeoff. 5× faster than large-v3 with minimal WER loss. CTranslate2 build (Systran publishes no turbo repo)."
 
   - repo_id: "Systran/faster-distil-whisper-large-v3"
     label: "Distil-Whisper large-v3 (distilled, fast)"
@@ -110,11 +110,11 @@ models:
     size_gb: 0.12
     note: "Variable-length processing, sub-200ms latency. Great for CPU/edge. Requires moonshine-onnx."
 
-  - repo_id: "UsefulSensors/moonshine-small"
-    label: "Moonshine small (edge-optimized, 300M, ONNX)"
+  - repo_id: "UsefulSensors/moonshine-tiny"
+    label: "Moonshine tiny (edge-optimized, 27M, ONNX)"
     role: ASR
-    size_gb: 0.6
-    note: "Higher accuracy than base, still fast. Requires moonshine-onnx."
+    size_gb: 0.05
+    note: "Smallest/fastest Moonshine, sub-200ms latency. Lower accuracy than base. Requires moonshine-onnx."
 
   # ── Diarisation ───────────────────────────────────────────────────────
 

--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -62,7 +62,7 @@ models:
     label: "Whisper large-v3 Turbo (5× faster, 0.8B)"
     role: ASR
     size_gb: 1.6
-    note: "Best speed/quality tradeoff. 5× faster than large-v3 with minimal WER loss. CTranslate2 build (Systran publishes no turbo repo)."
+    note: "Best speed/quality tradeoff. 5× faster than large-v3 with minimal WER loss. Community CTranslate2 conversion (no official Systran/OpenAI turbo repo) — re-verify availability on catalog audits."
 
   - repo_id: "Systran/faster-distil-whisper-large-v3"
     label: "Distil-Whisper large-v3 (distilled, fast)"

--- a/tests/test_models_catalog.py
+++ b/tests/test_models_catalog.py
@@ -50,6 +50,6 @@ def test_required_fields_present():
 
 
 def test_known_404_repo_ids_absent():
-    ids = {m["repo_id"] for m in _models()}
+    ids = {m.get("repo_id", "") for m in _models()}
     leaked = ids & _KNOWN_BAD
     assert not leaked, f"known-404 repo IDs reintroduced (issue #239): {leaked}"

--- a/tests/test_models_catalog.py
+++ b/tests/test_models_catalog.py
@@ -1,0 +1,55 @@
+"""Regression guard for the bundled model catalog (``backend/config/models.yaml``).
+
+Issue #239: two ASR entries pointed at Hugging Face repo IDs that returned
+HTTP 404 ("Repository Not Found"), so users could not install those ASR models:
+
+* ``UsefulSensors/moonshine-small`` — no such model (Moonshine ships *tiny* /
+  *base*, there is no 300M "small").
+* ``Systran/faster-whisper-large-v3-turbo`` — Systran publishes no turbo repo.
+
+These tests are intentionally **static** (no network) so they run in CI: they
+assert every ``repo_id`` is well-formed and that the known-bad IDs can never be
+reintroduced. They do not verify live HF availability — that would be flaky and
+slow — but they stop the catalog from shipping the exact IDs that broke #239.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+_YAML = Path(__file__).resolve().parents[1] / "backend" / "config" / "models.yaml"
+# org-or-user / repo-name, both segments HF-legal (letters, digits, _, -, .).
+_REPO_RE = re.compile(r"^[A-Za-z0-9][\w.-]*/[\w.-]+$")
+# Repo IDs that returned HTTP 404 on Hugging Face (issue #239). Must never reappear.
+_KNOWN_BAD = {
+    "UsefulSensors/moonshine-small",
+    "Systran/faster-whisper-large-v3-turbo",
+}
+
+
+def _models():
+    data = yaml.safe_load(_YAML.read_text(encoding="utf-8"))
+    return data["models"] if isinstance(data, dict) and "models" in data else data
+
+
+def test_catalog_loads_and_has_entries():
+    models = _models()
+    assert isinstance(models, list) and len(models) > 0
+
+
+def test_every_repo_id_is_well_formed():
+    for m in _models():
+        rid = m.get("repo_id")
+        assert rid and _REPO_RE.match(rid), f"malformed repo_id: {rid!r}"
+
+
+def test_required_fields_present():
+    for m in _models():
+        for field in ("repo_id", "label", "role"):
+            assert m.get(field), f"{m.get('repo_id')!r} missing required field {field!r}"
+
+
+def test_known_404_repo_ids_absent():
+    ids = {m["repo_id"] for m in _models()}
+    leaked = ids & _KNOWN_BAD
+    assert not leaked, f"known-404 repo IDs reintroduced (issue #239): {leaked}"


### PR DESCRIPTION
Closes #239.

## Problem

ASR model installation failed with `404 Client Error — Repository Not Found` for two entries in the bundled catalog (`backend/config/models.yaml`). Per the report (0.3.0 on Linux Mint, HF token valid, `moonshine-base` downloads fine, failures are 404 not 401/403), the repo IDs themselves are wrong:

- `UsefulSensors/moonshine-small` — **no such model.** Moonshine ships **tiny** and **base** only; there is no 300 M "small".
- `Systran/faster-whisper-large-v3-turbo` — **Systran publishes no turbo repo** (only `large-v3`, `medium`, `small`, `base`, `distil`).

## Fix

| Was (404) | Now (200) |
|-----------|-----------|
| `UsefulSensors/moonshine-small` | `UsefulSensors/moonshine-tiny` (27 M, the real smaller Moonshine) |
| `Systran/faster-whisper-large-v3-turbo` | `deepdml/faster-whisper-large-v3-turbo-ct2` (valid CTranslate2 turbo build) |

I audited **all 25** `repo_id`s in the catalog against the HF API — every one resolves `200` after the swap (the two above were the only failures, matching the report).

## Regression test

`tests/test_models_catalog.py` (static, no network → CI-safe): asserts every `repo_id` is well-formed, required fields exist, and the two known-404 IDs can never be reintroduced.

## Notes

- Backward-compatible: the broken IDs were un-installable (404), so no existing install references them; `moonshine-base` and the other ASR engines are untouched.
- `models.yaml` is the single source (`KNOWN_MODELS = _load_models_from_yaml()`), so this one change fixes the wizard, the engine picker, and the download validator.

## Type

- [x] 🐛 Bug fix
- [x] 🧪 Tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated model catalog to replace two models with newer variants and refreshed labels/notes for clarity and availability.

* **Tests**
  * Added automated catalog validation to ensure entries are well-formed, include required fields, and to prevent reintroducing known-broken model entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->