### PR TITLE
fix: dub OOM fallback, watermark on /generate, Settings responsiveness (#241 follow-up)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -164,6 +164,16 @@ async def generate_speech(
             postprocess_output, layer_penalty_factor, position_temperature,
             class_temperature, used_seed, effect_preset,
         )
+        # Invisible AudioSeal provenance watermark on the final audio. Embedding
+        # was previously only wired into the dub pipeline (dub_generate.py), so
+        # plain TTS came out unmarked despite the setting being on. embed_watermark
+        # self-gates on the user's watermark setting + AudioSeal availability and
+        # passes the audio through unchanged on any failure, so it never breaks
+        # generation.
+        from services.watermark import embed_watermark
+        audio_tensor = await loop.run_in_executor(
+            _gpu_pool, embed_watermark, audio_tensor, _model.sampling_rate
+        )
         gen_time = round(time.time() - start_time, 2)
 
         audio_id = str(uuid.uuid4())[:8]

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -115,13 +115,40 @@ class WhisperXBackend(ASRBackend):
         # ships a checkpoint with a new pickle class, the load fails loudly
         # and we extend `_allow_vad_pickle_globals()`.
         self._allow_vad_pickle_globals()
-        self._asr = whisperx.load_model(
-            self._model_name,
-            device=self._device,
-            compute_type=self._compute_type,
-            # vad_method="silero" is the default; keep it so short gaps
-            # get cleaned up before transcription.
-        )
+        try:
+            self._asr = whisperx.load_model(
+                self._model_name,
+                device=self._device,
+                compute_type=self._compute_type,
+                # vad_method="silero" is the default; keep it so short gaps
+                # get cleaned up before transcription.
+            )
+        except RuntimeError as e:
+            # CUDA OOM: a resident TTS model + the GPU worker pool can starve
+            # VRAM on small (e.g. 8 GB laptop) GPUs, so loading large-v3 on
+            # CUDA dies here — which previously surfaced as a bare 500 from
+            # /dub/transcribe with no guidance. Fall back to CPU (slower, but
+            # dubbing still works and keeps the same model/accuracy) instead.
+            # Only triggers on a CUDA OOM, so the MPS/CPU paths are untouched.
+            if self._device == "cuda" and "out of memory" in str(e).lower():
+                logger.warning(
+                    "whisperx CUDA OOM loading %s — retrying on CPU (slower). "
+                    "Free VRAM (Flush the TTS model) for GPU-speed ASR. Detail: %s",
+                    self._model_name, e,
+                )
+                try:
+                    import torch
+                    torch.cuda.empty_cache()
+                except Exception:  # noqa: BLE001 — cache clear is best-effort
+                    pass
+                self._device, self._compute_type = "cpu", "int8"
+                self._asr = whisperx.load_model(
+                    self._model_name,
+                    device=self._device,
+                    compute_type=self._compute_type,
+                )
+            else:
+                raise
 
     @staticmethod
     def _allow_vad_pickle_globals():

--- a/backend/tests/test_asr_oom_fallback.py
+++ b/backend/tests/test_asr_oom_fallback.py
@@ -1,0 +1,64 @@
+"""WhisperX CUDA-OOM → CPU fallback (api/services parity for small GPUs).
+
+On an 8 GB laptop GPU with the TTS model resident, whisperx's CTranslate2
+load of large-v3 dies with `RuntimeError: CUDA failed with error out of
+memory`, which previously surfaced as a bare 500 from /dub/transcribe. The
+backend now retries on CPU (slower, same model/accuracy). This test forces the
+OOM deterministically (no GPU needed) and asserts the device switch.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+_config = types.ModuleType("core.config")
+_config.DATA_DIR = tempfile.mkdtemp(prefix="omnivoice_asr_oom_")
+_config.VOICES_DIR = _config.DATA_DIR
+_config.OUTPUTS_DIR = _config.DATA_DIR
+sys.modules["core.config"] = _config
+
+whisperx = pytest.importorskip("whisperx")
+
+from services.asr_backend import WhisperXBackend  # noqa: E402
+
+
+def test_cuda_oom_falls_back_to_cpu(monkeypatch):
+    calls = []
+
+    def fake_load_model(name, device, compute_type, **kw):
+        calls.append((device, compute_type))
+        if device == "cuda":
+            raise RuntimeError("CUDA failed with error out of memory")
+        return object()  # CPU load succeeds
+
+    monkeypatch.setattr(whisperx, "load_model", fake_load_model)
+
+    be = WhisperXBackend()
+    # Force the CUDA starting point regardless of the CI host's hardware.
+    be._device, be._compute_type = "cuda", "float16"
+    be._allow_vad_pickle_globals = lambda: None  # skip torch pickle allowlist
+
+    be._ensure_asr()
+
+    assert be._asr is not None                      # didn't raise — recovered
+    assert be._device == "cpu" and be._compute_type == "int8"
+    assert [d for d, _ in calls] == ["cuda", "cpu"]  # tried CUDA, then CPU
+
+
+def test_non_oom_runtime_error_still_raises(monkeypatch):
+    def fake_load_model(name, device, compute_type, **kw):
+        raise RuntimeError("some other failure")  # not an OOM → must propagate
+
+    monkeypatch.setattr(whisperx, "load_model", fake_load_model)
+
+    be = WhisperXBackend()
+    be._device, be._compute_type = "cuda", "float16"
+    be._allow_vad_pickle_globals = lambda: None
+    with pytest.raises(RuntimeError, match="some other failure"):
+        be._ensure_asr()

--- a/frontend/src/components/EngineCompatibilityMatrix.css
+++ b/frontend/src/components/EngineCompatibilityMatrix.css
@@ -38,7 +38,24 @@
 
 .engine-matrix__table {
   width: 100%;
+  /* Responsive: the fixed-width columns (status/gpu/isolation/actions) +
+     the flexible name column need ~840px. On a narrow Settings pane they used
+     to collapse and OVERLAP (name text under the badges). Instead keep the
+     table's shape and let it scroll horizontally — the data-table treatment
+     used elsewhere — so every column stays legible at any width. */
+  overflow-x: auto;
 }
+
+/* Header + body share one min-width so columns stay aligned while scrolling. */
+.engine-matrix__table .ui-table-header,
+.engine-matrix__body {
+  min-width: 840px;
+}
+
+/* Fixed-width cells must not shrink below their column width (that shrink was
+   what caused the overlap); the name column keeps a sane floor and still grows. */
+.engine-matrix__cell { flex-shrink: 0; }
+.engine-matrix__cell--name { min-width: 200px; }
 
 .engine-matrix__body {
   display: flex;

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -49,20 +49,47 @@
 /* We're migrating to the ui/ Tabs primitive — keep a thin class so the old
    .settings-tabs gradient-above space stays; the Tabs primitive itself
    carries visual styling. */
-.settings-tabs-ui { margin-bottom: var(--space-5); }
+/* The .settings-content bridge owns the gap below the bar (see below). */
+.settings-tabs-ui { margin-bottom: 0; }
 
 /* The settings sub-nav has 10 tabs (General…Privacy). The base .ui-tabs is a
    non-wrapping inline-flex row, so on a narrow Settings pane the later tabs
    (Credentials/Logs/About/Privacy) overflow and clip out of view. Scope a wrap
    to this nav only (the shared primitive is unchanged) so every tab stays
    reachable — the pill bar grows to 2 rows instead of running off-screen.
-   `.ui-tabs.settings-tabs-ui` outranks `.ui-tabs` so the display/flex overrides
-   take regardless of stylesheet order. */
+   `.ui-tabs.settings-tabs-ui` outranks `.ui-tabs` so the overrides take
+   regardless of stylesheet order. */
 .ui-tabs.settings-tabs-ui {
   display: flex;
   flex-wrap: wrap;
   max-width: 100%;
   row-gap: 3px;
+}
+
+/* Active tab adopts its own semantic accent (TAB_DEFS) instead of the global
+   pink, so that colour can be echoed on the content edge below as the visual
+   "connection". --ui-tab-accent is set per-trigger by the Tabs primitive.
+   Scoped to the settings nav only. */
+.ui-tabs.settings-tabs-ui .ui-tabs__tab.is-active {
+  background: color-mix(in srgb, var(--ui-tab-accent) 14%, transparent);
+  color: var(--ui-tab-accent);
+  border-color: color-mix(in srgb, var(--ui-tab-accent) 42%, transparent);
+}
+.ui-tabs.settings-tabs-ui .ui-tabs__tab.is-active .ui-tabs__icon {
+  color: var(--ui-tab-accent);
+}
+
+/* Tab → content connection. The panel opens with a hairline painted in the
+   active tab's accent (threaded in as --settings-accent by Settings.jsx), so
+   the coloured active tab above and the coloured content edge below read as a
+   single unit — subtle (a 1px rule blended toward the chrome border), not a
+   slab, and wrap-proof (colour carries the meaning, not position). The margin
+   + padding give the panel deliberate breathing room under the bar. */
+.settings-content {
+  margin-top: var(--space-4);
+  padding-top: var(--space-5);
+  border-top: 1px solid color-mix(in srgb, var(--settings-accent) 32%, var(--chrome-border) 68%);
+  transition: border-color var(--dur-fast, 120ms) var(--ease-out, ease);
 }
 
 /* ── Engines tab ─────────────────────────────────────────────── */

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -51,6 +51,20 @@
    carries visual styling. */
 .settings-tabs-ui { margin-bottom: var(--space-5); }
 
+/* The settings sub-nav has 10 tabs (General…Privacy). The base .ui-tabs is a
+   non-wrapping inline-flex row, so on a narrow Settings pane the later tabs
+   (Credentials/Logs/About/Privacy) overflow and clip out of view. Scope a wrap
+   to this nav only (the shared primitive is unchanged) so every tab stays
+   reachable — the pill bar grows to 2 rows instead of running off-screen.
+   `.ui-tabs.settings-tabs-ui` outranks `.ui-tabs` so the display/flex overrides
+   take regardless of stylesheet order. */
+.ui-tabs.settings-tabs-ui {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 100%;
+  row-gap: 3px;
+}
+
 /* ── Engines tab ─────────────────────────────────────────────── */
 .engines-family            { margin-bottom: var(--space-5); }
 .engines-family__active {

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -64,6 +64,12 @@
   flex-wrap: wrap;
   max-width: 100%;
   row-gap: 3px;
+  /* Border-connect: the bar opens at the bottom into the content panel — flat
+     bottom corners + no bottom border so the panel below reads as one
+     continuous outlined container attached to the tabs. */
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: 0;
 }
 
 /* Active tab adopts its own semantic accent (TAB_DEFS) instead of the global
@@ -86,11 +92,24 @@
    slab, and wrap-proof (colour carries the meaning, not position). The margin
    + padding give the panel deliberate breathing room under the bar. */
 .settings-content {
-  margin-top: var(--space-4);
-  padding-top: var(--space-5);
-  border-top: 1px solid color-mix(in srgb, var(--settings-accent) 32%, var(--chrome-border) 68%);
+  /* Attached directly under the bar (no gap) as a 3-sided panel with an open
+     top — the bar + panel form one outlined container, split where the tabs
+     sit. The border is tinted by the active tab's accent so the active tab and
+     its panel read as connected by a shared border. */
+  margin-top: 0;
+  padding: var(--space-5) var(--space-5) var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--settings-accent) 38%, var(--chrome-border) 62%);
+  /* Stronger top: a 2px full-accent edge at the seam with the bar, so the
+     active tab's colour visibly "feeds" into the panel it opens. Top corners
+     stay square to butt against the bar above; bottom corners round off. */
+  border-top: 2px solid var(--settings-accent);
+  border-bottom-left-radius: var(--chrome-radius-pill);
+  border-bottom-right-radius: var(--chrome-radius-pill);
   transition: border-color var(--dur-fast, 120ms) var(--ease-out, ease);
 }
+/* The bar's accent already cues the active tab; inside the connected panel the
+   first card sits flush to the panel's inner padding (no extra top margin). */
+.settings-content > :first-child { margin-top: 0; }
 
 /* ── Engines tab ─────────────────────────────────────────────── */
 .engines-family            { margin-bottom: var(--space-5); }

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1248,8 +1248,13 @@ export default function Settings() {
   : status?.status === 'loading' ? <Badge tone="warn"><RefreshCw size={11} className="spinner" /> {t('models.loading_badge')}</Badge>
                                  : <Badge tone="warn">{t('models.idle_badge')}</Badge>;
 
+  // The active tab's accent (from TAB_DEFS) threads down to the content edge as
+  // --settings-accent, so the coloured active tab and the content panel read as
+  // one connected unit (see .settings-content in Settings.css).
+  const activeAccent = TAB_DEFS.find((d) => d.id === activeTab)?.accent || 'var(--chrome-accent)';
+
   return (
-    <div className="settings-page">
+    <div className="settings-page" style={{ '--settings-accent': activeAccent }}>
       <Tabs
         items={TAB_DEFS.map(def => ({ ...def, label: t(`settings.${def.id}`) }))}
         value={activeTab}
@@ -1257,6 +1262,7 @@ export default function Settings() {
         className="settings-tabs-ui"
       />
 
+      <div className="settings-content">
       {activeTab === 'general' && (
         <>
           <GeneralTab />
@@ -1459,6 +1465,7 @@ export default function Settings() {
           />
         </section>
       )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Follow-up to #241 (squash-merged with only its first 4 commits). The remaining 6 fixes, rebased onto current `main` so this is a clean delta (no overlap with #240/#236). Supersedes the stale #243. All found/verified on Arch/CachyOS x64 (CUDA RTX 4070 Laptop).

## Backend
- **`fix(dub)` whisperx CUDA OOM → CPU fallback** — on an 8 GB laptop GPU with the TTS model resident, whisperx's large-v3 CUDA load OOMs and `/dub/transcribe` returned a bare **500**. Now catches the CUDA OOM and retries on CPU (same model/accuracy, slower). Verified 500 → 200 with a correct transcript; unit test (`test_asr_oom_fallback.py`) forces the OOM and asserts the cuda→cpu switch, and that a non-OOM error still propagates. Only triggers on CUDA OOM (MPS/CPU paths untouched).
- **`fix(watermark)` embed on `/generate`** — `embed_watermark` was wired only into the dub pipeline, so plain TTS came out unmarked despite invisible watermarking being on. Embed it on the generate path too; self-gates on the setting + AudioSeal availability and passes audio through on failure. Verified: detector on a fresh clip went `is_watermarked:false → true`, confidence 1.0, message OMNI.

## Settings UI (responsiveness + design)
- **`fix(settings)` tab wrap** — the 10-tab sub-nav (General…Privacy) clipped out of view on a narrow pane. Scoped `flex-wrap` to the settings nav only; wraps to 2–3 rows, all tabs reachable. Shared `.ui-tabs` primitive untouched.
- **`feat(settings)` accent connect → border-connect** — the active tab carries its own semantic accent (TAB_DEFS) threaded down as `--settings-accent`; the content panel border-connects to the bar (opens at the bottom into a 3-sided accent-framed panel with a 2px accent top edge at the seam). Wrap-proof.
- **`fix(engines)` matrix responsive** — the Engine Compatibility Matrix's fixed-width columns collapsed and **overlapped** on a narrow pane. Now a horizontal-scroll table with a shared header/body min-width and non-shrinking cells; fills normally when wide.

## Verification
- E2E **15/15** (UI smoke across all views + gallery); backend suites green (incl. the new ASR-OOM test).
- Clean build on this machine: `vite build` ✅, `tauri build --no-bundle` release ✅ (2m09s). Clean install: `uv sync --locked` resolves 270 pkgs ✅; the shipped backend boots from its bundled-uv venv on CUDA ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AudioSeal watermarking to generated speech output.
  * Implemented automatic fallback to CPU processing for speech recognition when GPU memory runs out.
  * Added accent color theming to Settings page tabs.

* **Improvements**
  * Enhanced responsive scrolling behavior for engine compatibility matrix on narrow screens.
  * Refined Settings page tab layout and styling.

* **Tests**
  * Added tests for GPU memory fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->