### PR TITLE
test(probe): whole-app coverage — dubbing, i18n, engines, security, migration, dictation, design

### DIFF
--- a/tests/probe/README.md
+++ b/tests/probe/README.md
@@ -19,6 +19,31 @@ JUDGE  (deterministic code + metrics)    ◀──renders the verdict
   `advisory` lane. Letting an agent both *act* and *judge* produces false passes
   (green tests on broken software), which is worse than no test.
 
+## Feature coverage (specs)
+
+Beyond the layer skeleton, the suite covers these features — one `*.probe.yaml`
+spec each, run against the real app where possible (a single subprocess boot is
+shared across the backend-touching specs):
+
+| Spec | Layer | Verifies |
+|------|-------|----------|
+| `first_run` | env | fresh-dir boot: health + DB init + endpoints |
+| `migration` | env | alembic UPGRADE on existing `omnivoice_data` fixture (backward-compat) |
+| `engines` | engine | TTS/ASR registry: active engine available, every unavailable engine explains why (11 TTS / 7 ASR backends) |
+| `security` | security | system routes reject non-loopback origins (403) |
+| `dictation` | dictation | streaming-ASR WebSocket `/ws/transcribe` registered + accepts loopback handshake |
+| `tts_smoke` / `voice_clone` / `voice_design` | media | audio-correctness ladder (decode/duration/not-silent/clipping/WER) + speaker-sim (clone) |
+| `dub_export` | dubbing | segment duration-ratio, SRT/VTT well-formed, export-archive contents, output language-ID (advisory) |
+| `i18n_parity` | i18n | locale files valid JSON (gate); orphan-keys + coverage (advisory) |
+| `desktop_smoke` | desktop | Tauri config integrity (version parity, dev/build wiring, bundled bins, CSP) |
+| `launchpad` | web | UI render via Playwright Driver (FakePage offline) |
+| `coverage_critic` | meta | every declared layer still has a spec (drift gate) + API-surface inventory (advisory) |
+
+> The i18n orphan-key check **surfaced a real bug**: all 20 non-`en` locales carry
+> `gallery.cat_*` (and some `bootstrap.lines`) keys absent from the `en`
+> reference. It's reported in the advisory lane (non-blocking) rather than gating,
+> since the fix is a product change.
+
 ## Layers
 
 | Layer | Module | Status | What it does |

--- a/tests/probe/_boot_runner.py
+++ b/tests/probe/_boot_runner.py
@@ -1,10 +1,18 @@
-"""Out-of-process first-run boot, executed by env.capture_first_run().
+"""Out-of-process backend probe, executed by env.capture_first_run().
 
 Runs in its OWN process so it never mutates the parent test session's module
 table or environment (in-process booting purges/re-imports the backend, which
 corrupts DB_PATH for other tests — see env.py). Boots the FastAPI app against a
-fresh data dir, probes the first-run endpoints, and writes the captured context
-as JSON to the output path. Not a test module (underscore-prefixed).
+data dir and captures, in a single boot, everything the L5/engine/security/
+coverage probes need:
+
+  - first-run endpoints (health / system info / model status): status/body/latency
+  - DB creation on first boot
+  - TTS + ASR engine matrices (/engines/tts, /engines/asr)
+  - loopback-rejection of a system endpoint from a non-loopback origin
+  - the OpenAPI path inventory (for the Coverage Critic)
+
+Writes the captured context as JSON to the output path. Not a test module.
 
 argv: <data_dir> <output_json_path>
 """
@@ -15,20 +23,19 @@ import os
 import sys
 import time
 
-# First-run endpoints a brand-new user implicitly hits (GET, loopback-safe).
 ENDPOINTS = [("/health", "health"), ("/system/info", "sysinfo"), ("/model/status", "model")]
 
 
 def main() -> int:
     data_dir, out_path = sys.argv[1], sys.argv[2]
-    os.environ["OMNIVOICE_MODEL"] = "test"  # short-circuit the 2.4 GB model load
+    os.environ["OMNIVOICE_MODEL"] = "test"
     os.environ["OMNIVOICE_DISABLE_FILE_LOG"] = "1"
     os.environ["OMNIVOICE_DATA_DIR"] = data_dir
 
     repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     backend = os.path.join(repo_root, "backend")
     if backend not in sys.path:
-        sys.path.insert(0, backend)  # mirror tests/conftest.py (--app-dir backend)
+        sys.path.insert(0, backend)
 
     from fastapi.testclient import TestClient
     from main import app
@@ -45,6 +52,43 @@ def main() -> int:
             except Exception:  # noqa: BLE001
                 ctx[f"{prefix}_body"] = None
 
+        # Engine matrices (loopback-gated routers → use the loopback client).
+        for fam in ("tts", "asr"):
+            r = client.get(f"/engines/{fam}")
+            ctx[f"engines_{fam}_status"] = r.status_code
+            try:
+                ctx[f"engines_{fam}"] = r.json()
+            except Exception:  # noqa: BLE001
+                ctx[f"engines_{fam}"] = None
+
+        # Loopback security: a non-loopback origin must be rejected on system
+        # routes. Use a bare client (no `with`) so we don't re-enter the app
+        # lifespan — re-entry rebinds the module-level task queue to a new event
+        # loop and crashes. The require_loopback dependency only inspects
+        # request.client.host, which doesn't need lifespan state.
+        nl = TestClient(app)  # default client host 'testclient' = non-loopback
+        ctx["loopback_reject_status"] = nl.get("/system/info").status_code
+
+        # Dictation: handshake-only connect to the streaming-ASR WebSocket
+        # (confirms the endpoint is wired + accepts loopback, without loading an
+        # ASR model). Immediately closing triggers the server's disconnect path.
+        try:
+            with client.websocket_connect("/ws/transcribe"):
+                ctx["ws_transcribe_connected"] = True
+        except Exception as exc:  # noqa: BLE001
+            ctx["ws_transcribe_connected"] = False
+            ctx["ws_transcribe_error"] = str(exc)[:200]
+
+    # OpenAPI inventory (no client/lifespan needed). WebSocket routes aren't in
+    # the OpenAPI schema, so enumerate them from the route table separately.
+    try:
+        ctx["openapi_paths"] = sorted(app.openapi().get("paths", {}).keys())
+    except Exception:  # noqa: BLE001
+        ctx["openapi_paths"] = []
+    ctx["ws_routes"] = sorted(
+        getattr(r, "path", "") for r in app.routes if "WebSocket" in type(r).__name__
+    )
+
     ctx["data_dir"] = data_dir
     ctx["db_path"] = ""
     for pat in ("*.sqlite3", "*.sqlite", "*.db"):
@@ -52,6 +96,7 @@ def main() -> int:
         if hits:
             ctx["db_path"] = hits[0]
             break
+    ctx["db_created"] = bool(ctx["db_path"])
 
     with open(out_path, "w", encoding="utf-8") as fh:
         json.dump(ctx, fh)

--- a/tests/probe/_boot_runner.py
+++ b/tests/probe/_boot_runner.py
@@ -26,6 +26,14 @@ import time
 ENDPOINTS = [("/health", "health"), ("/system/info", "sysinfo"), ("/model/status", "model")]
 
 
+def _db_files(data_dir: str) -> set:
+    """Return the set of DB file paths currently present under data_dir."""
+    found = set()
+    for pat in ("*.sqlite3", "*.sqlite", "*.db"):
+        found.update(glob.glob(os.path.join(data_dir, "**", pat), recursive=True))
+    return found
+
+
 def main() -> int:
     data_dir, out_path = sys.argv[1], sys.argv[2]
     os.environ["OMNIVOICE_MODEL"] = "test"
@@ -36,6 +44,11 @@ def main() -> int:
     backend = os.path.join(repo_root, "backend")
     if backend not in sys.path:
         sys.path.insert(0, backend)
+
+    # Snapshot DB files that already exist BEFORE boot so we can detect
+    # creation (not just presence) — a pre-existing file does not mean this
+    # boot created it (e.g. seeded migration fixture already has a DB).
+    pre_boot_db_files = _db_files(data_dir)
 
     from fastapi.testclient import TestClient
     from main import app
@@ -77,7 +90,10 @@ def main() -> int:
                 ctx["ws_transcribe_connected"] = True
         except Exception as exc:  # noqa: BLE001
             ctx["ws_transcribe_connected"] = False
-            ctx["ws_transcribe_error"] = str(exc)[:200]
+            # Store only the exception type — not the raw message — to avoid
+            # leaking absolute home paths or secret-like substrings that may
+            # appear in WebSocket handshake error text.
+            ctx["ws_transcribe_error"] = type(exc).__name__
 
     # OpenAPI inventory (no client/lifespan needed). WebSocket routes aren't in
     # the OpenAPI schema, so enumerate them from the route table separately.
@@ -90,13 +106,14 @@ def main() -> int:
     )
 
     ctx["data_dir"] = data_dir
-    ctx["db_path"] = ""
-    for pat in ("*.sqlite3", "*.sqlite", "*.db"):
-        hits = glob.glob(os.path.join(data_dir, "**", pat), recursive=True)
-        if hits:
-            ctx["db_path"] = hits[0]
-            break
-    ctx["db_created"] = bool(ctx["db_path"])
+    post_boot_db_files = _db_files(data_dir)
+    new_db_files = post_boot_db_files - pre_boot_db_files
+    # db_path: any DB file present after boot (for reference by other judges)
+    all_db = sorted(post_boot_db_files)
+    ctx["db_path"] = all_db[0] if all_db else ""
+    # db_created: True only when this boot actually CREATED a new DB file
+    # (not just found a pre-existing one — e.g. the migration seeded fixture).
+    ctx["db_created"] = bool(new_db_files)
 
     with open(out_path, "w", encoding="utf-8") as fh:
         json.dump(ctx, fh)

--- a/tests/probe/conftest.py
+++ b/tests/probe/conftest.py
@@ -49,6 +49,18 @@ def probe_report(request: pytest.FixtureRequest) -> ProbeRecorder:
     return request.config._probe_recorder  # type: ignore[attr-defined]
 
 
+@pytest.fixture(scope="session")
+def boot_capture() -> dict:
+    """Boot the backend ONCE (fresh data dir, subprocess-isolated) and share the
+    rich capture — first-run endpoints, engine/ASR matrices, loopback-reject
+    status, and the OpenAPI inventory — across the engine/security/coverage
+    probes so the suite pays for only one boot."""
+    from . import env
+
+    with env.fresh_data_dir() as data_dir:
+        return env.capture_first_run(data_dir)
+
+
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     recorder: ProbeRecorder | None = getattr(session.config, "_probe_recorder", None)
     if not recorder or not recorder.outcomes:

--- a/tests/probe/env.py
+++ b/tests/probe/env.py
@@ -49,6 +49,25 @@ def fresh_data_dir(tmp_path: str | os.PathLike | None = None):
             shutil.rmtree(created, ignore_errors=True)
 
 
+@contextlib.contextmanager
+def seeded_data_dir():
+    """Yield a temp data dir pre-populated with the checked-in regression fixture
+    (tests/fixtures/omnivoice_data) — for testing the alembic UPGRADE path on
+    existing user data, not a clean first run."""
+    import shutil
+    import tempfile
+
+    fixture = _REPO_ROOT / "tests" / "fixtures" / "omnivoice_data"
+    if not fixture.exists():
+        raise RuntimeError(f"regression fixture missing at {fixture}")
+    tmp = tempfile.mkdtemp(prefix="probe-seeded-")
+    try:
+        shutil.copytree(fixture, tmp, dirs_exist_ok=True)
+        yield Path(tmp)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
 def capture_first_run(data_dir: str | os.PathLike, timeout: float = 180.0) -> dict:
     """Boot the backend against ``data_dir`` in a subprocess and return the
     captured first-run context (endpoint status/body/latency + on-disk

--- a/tests/probe/judges/coverage.py
+++ b/tests/probe/judges/coverage.py
@@ -1,0 +1,56 @@
+"""Coverage Critic — the drift defense. Enumerates the app's API surface and the
+probe spec set, gates that every declared layer still has a spec, and reports
+(advisory) the API areas no spec touches — so a green dashboard can't hide a
+coverage gap.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+
+from ..spec import JudgeResult
+
+
+def scan_specs(specs_dir: str) -> list[dict]:
+    """Index the probe specs: [{feature, layer, file}, ...]."""
+    import yaml
+
+    out = []
+    for path in sorted(glob.glob(os.path.join(specs_dir, "*.probe.yaml"))):
+        doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
+        out.append({"feature": doc.get("feature"), "layer": doc.get("layer"),
+                    "file": os.path.basename(path)})
+    return out
+
+
+def api_prefixes(openapi_paths: list) -> list[str]:
+    """Top-level path segment for each route ('/engines/tts' → 'engines')."""
+    return sorted({(p.strip("/").split("/")[0] or "root") for p in (openapi_paths or [])})
+
+
+def layers_have_specs(specs: list, required: list) -> JudgeResult:
+    """Gate: every declared layer still has at least one spec (guards against
+    silently dropping a layer's coverage)."""
+    have = {s.get("layer") for s in (specs or [])}
+    missing = [layer for layer in required if layer not in have]
+    return JudgeResult(
+        name="layers_have_specs",
+        passed=not missing,
+        measured=sorted(have),
+        detail=f"all required layers have specs: {required}" if not missing
+        else f"layers with NO spec: {missing}",
+    )
+
+
+def coverage_report(openapi_paths: list, specs: list) -> JudgeResult:
+    """Advisory: a one-line inventory of API surface vs probe specs."""
+    prefixes = api_prefixes(openapi_paths)
+    layers = sorted({s.get("layer") for s in (specs or [])})
+    return JudgeResult(
+        name="coverage_report",
+        passed=True,
+        measured=len(openapi_paths or []),
+        detail=f"{len(openapi_paths or [])} API routes / {len(prefixes)} prefixes; "
+        f"{len(specs or [])} specs across layers {layers}",
+    )

--- a/tests/probe/judges/coverage.py
+++ b/tests/probe/judges/coverage.py
@@ -18,7 +18,8 @@ def scan_specs(specs_dir: str) -> list[dict]:
 
     out = []
     for path in sorted(glob.glob(os.path.join(specs_dir, "*.probe.yaml"))):
-        doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
+        with open(path, encoding="utf-8") as fh:
+            doc = yaml.safe_load(fh) or {}
         out.append({"feature": doc.get("feature"), "layer": doc.get("layer"),
                     "file": os.path.basename(path)})
     return out

--- a/tests/probe/judges/dictation.py
+++ b/tests/probe/judges/dictation.py
@@ -1,0 +1,32 @@
+"""Dictation judges — the streaming-ASR (real-time capture) WebSocket contract.
+
+Model-free: verifies the endpoint is registered and accepts a loopback handshake.
+Driving real partial/final transcription needs an ASR model and is left to an
+enable-on-demand live test.
+"""
+
+from __future__ import annotations
+
+from ..spec import JudgeResult
+
+
+def ws_endpoint_registered(ws_routes: list, path: str) -> JudgeResult:
+    routes = list(ws_routes or [])
+    ok = path in routes
+    return JudgeResult(
+        name="ws_endpoint_registered",
+        passed=ok,
+        measured=path,
+        detail=f"WebSocket {path!r} registered" if ok else f"{path!r} not in WS routes {routes}",
+    )
+
+
+def ws_handshake_ok(connected: bool) -> JudgeResult:
+    ok = bool(connected)
+    return JudgeResult(
+        name="ws_handshake_ok",
+        passed=ok,
+        measured=ok,
+        detail="dictation WS accepted a loopback handshake" if ok
+        else "dictation WS refused the loopback handshake",
+    )

--- a/tests/probe/judges/dubbing.py
+++ b/tests/probe/judges/dubbing.py
@@ -1,0 +1,105 @@
+"""L4 dubbing judges — verify the dubbing pipeline's structural correctness.
+
+Dubbing adds timing + cross-modal constraints on top of TTS. The reliably
+automatable checks (per the research) are: per-segment duration ratio (the core
+dubbing problem — the dub overruns/underruns the source because languages differ
+in information density), output language identification, and export-format
+structural validity. Translation *quality* is not an audio problem and stays out
+of scope. These judges are deterministic; language-ID is pluggable and skips
+without a detector.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Protocol
+
+from ..spec import JudgeResult
+
+
+def _seg_durations(seg: dict) -> tuple[float, float]:
+    """(source, dubbed) durations from a segment dict, computing source from
+    start/end when not given explicitly."""
+    src = seg.get("source")
+    if src is None and "start" in seg and "end" in seg:
+        src = float(seg["end"]) - float(seg["start"])
+    return float(src or 0.0), float(seg.get("dubbed", 0.0))
+
+
+def segments_duration_ratio(segments: list, min_ratio: float = 0.5, max_ratio: float = 1.6) -> JudgeResult:
+    """Each dubbed segment's duration must stay within [min,max]× its source —
+    catches dub tracks that drift badly out of sync with the original."""
+    outliers = []
+    for i, seg in enumerate(segments or []):
+        src, dub = _seg_durations(seg)
+        if src <= 0:
+            continue
+        ratio = dub / src
+        if not (min_ratio <= ratio <= max_ratio):
+            outliers.append(f"#{i}={ratio:.2f}")
+    ok = not outliers
+    return JudgeResult(
+        name="segments_duration_ratio",
+        passed=ok,
+        measured=len(outliers),
+        detail=f"all {len(segments or [])} segments within [{min_ratio}, {max_ratio}]×"
+        if ok else f"out-of-band ratios: {', '.join(outliers)}",
+    )
+
+
+_SRT_TS = re.compile(r"\d{2}:\d{2}:\d{2},\d{3}\s*-->\s*\d{2}:\d{2}:\d{2},\d{3}")
+_VTT_TS = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{3}\s*-->\s*\d{2}:\d{2}:\d{2}\.\d{3}")
+
+
+def srt_well_formed(text: str) -> JudgeResult:
+    has_index = bool(re.search(r"(?m)^\s*\d+\s*$", text or ""))
+    cues = len(_SRT_TS.findall(text or ""))
+    ok = has_index and cues > 0
+    return JudgeResult(
+        name="srt_well_formed",
+        passed=ok,
+        measured=cues,
+        detail=f"{cues} SRT cue(s) with HH:MM:SS,mmm timing" if ok else "no valid SRT cues/index",
+    )
+
+
+def vtt_well_formed(text: str) -> JudgeResult:
+    starts = (text or "").lstrip().startswith("WEBVTT")
+    cues = len(_VTT_TS.findall(text or ""))
+    ok = starts and cues > 0
+    return JudgeResult(
+        name="vtt_well_formed",
+        passed=ok,
+        measured=cues,
+        detail=f"WEBVTT + {cues} cue(s) with HH:MM:SS.mmm timing" if ok else "missing WEBVTT header or cues",
+    )
+
+
+def archive_has(names: list, patterns: list) -> JudgeResult:
+    """Every pattern must match at least one entry name in the export archive."""
+    names = list(names or [])
+    missing = [p for p in patterns if not any(p in n for n in names)]
+    return JudgeResult(
+        name="archive_has",
+        passed=not missing,
+        measured=len(names),
+        detail=f"archive has entries matching {patterns}" if not missing
+        else f"archive missing patterns {missing} (have {names[:6]}...)",
+    )
+
+
+class LangDetector(Protocol):
+    def detect(self, path: str) -> str: ...
+
+
+def output_language_is(audio: str, expected: str, detector: LangDetector | None = None) -> JudgeResult:
+    """Confirm the dubbed track is actually in the target language. Pluggable
+    (Whisper detect_language); SKIPS without a detector. Note: language-ID errs
+    on heavily-accented or very short speech — use whole segments."""
+    if detector is None:
+        return JudgeResult(name="output_language_is", passed=None,
+                           detail="skipped: no language detector wired (inject a Whisper detect_language backend)")
+    got = detector.detect(audio)
+    ok = got == expected
+    return JudgeResult(name="output_language_is", passed=ok, measured=got,
+                       detail=f"detected {got!r} (expected {expected!r})")

--- a/tests/probe/judges/dubbing.py
+++ b/tests/probe/judges/dubbing.py
@@ -28,21 +28,35 @@ def _seg_durations(seg: dict) -> tuple[float, float]:
 
 def segments_duration_ratio(segments: list, min_ratio: float = 0.5, max_ratio: float = 1.6) -> JudgeResult:
     """Each dubbed segment's duration must stay within [min,max]× its source —
-    catches dub tracks that drift badly out of sync with the original."""
+    catches dub tracks that drift badly out of sync with the original.
+
+    Fails when zero segments are validated (all durations missing/zero/negative)
+    because a vacuously-true pass would hide an empty or corrupt segment list.
+    """
     outliers = []
+    validated = 0
     for i, seg in enumerate(segments or []):
         src, dub = _seg_durations(seg)
         if src <= 0:
             continue
+        validated += 1
         ratio = dub / src
         if not (min_ratio <= ratio <= max_ratio):
             outliers.append(f"#{i}={ratio:.2f}")
+    if validated == 0:
+        return JudgeResult(
+            name="segments_duration_ratio",
+            passed=False,
+            measured=0,
+            detail=f"no segments with valid (>0) source duration in {len(segments or [])} segment(s) — "
+            "nothing was actually validated",
+        )
     ok = not outliers
     return JudgeResult(
         name="segments_duration_ratio",
         passed=ok,
         measured=len(outliers),
-        detail=f"all {len(segments or [])} segments within [{min_ratio}, {max_ratio}]×"
+        detail=f"all {validated} segment(s) within [{min_ratio}, {max_ratio}]×"
         if ok else f"out-of-band ratios: {', '.join(outliers)}",
     )
 

--- a/tests/probe/judges/dubbing.py
+++ b/tests/probe/judges/dubbing.py
@@ -56,7 +56,7 @@ def segments_duration_ratio(segments: list, min_ratio: float = 0.5, max_ratio: f
         name="segments_duration_ratio",
         passed=ok,
         measured=len(outliers),
-        detail=f"all {validated} segment(s) within [{min_ratio}, {max_ratio}]×"
+        detail=f"all {validated} segment(s) within [{min_ratio}, {max_ratio}]x"
         if ok else f"out-of-band ratios: {', '.join(outliers)}",
     )
 

--- a/tests/probe/judges/engine.py
+++ b/tests/probe/judges/engine.py
@@ -1,0 +1,66 @@
+"""Engine-matrix judges — verify the TTS/ASR backend registry (the engine
+compatibility hard constraint). Operate on a ``/engines/{family}`` payload
+(``{active, backends:[{id, available, reason}, ...]}``) captured from the app.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..spec import JudgeResult
+
+
+def _backends(payload: Any) -> list:
+    return list((payload or {}).get("backends") or [])
+
+
+def engines_present(payload: dict, min_count: int = 1) -> JudgeResult:
+    n = len(_backends(payload))
+    return JudgeResult(
+        name="engines_present",
+        passed=n >= int(min_count),
+        measured=n,
+        detail=f"{n} backend(s) registered (min {min_count})",
+    )
+
+
+def active_engine_available(payload: dict) -> JudgeResult:
+    """The default/active engine must actually be available — otherwise the app
+    boots pointing at an engine that can't synthesize."""
+    active = (payload or {}).get("active")
+    match = next((b for b in _backends(payload) if b.get("id") == active), None)
+    ok = bool(match) and bool(match.get("available"))
+    return JudgeResult(
+        name="active_engine_available",
+        passed=ok,
+        measured=active,
+        detail=f"active engine {active!r} available" if ok
+        else f"active engine {active!r} is NOT available/registered",
+    )
+
+
+def engine_available(payload: dict, engine_id: str) -> JudgeResult:
+    b = next((b for b in _backends(payload) if b.get("id") == engine_id), None)
+    ok = bool(b) and bool(b.get("available"))
+    return JudgeResult(
+        name="engine_available",
+        passed=ok,
+        measured=engine_id,
+        detail=f"{engine_id!r} available" if ok else f"{engine_id!r} unavailable/missing",
+    )
+
+
+def unavailable_engines_explained(payload: dict) -> JudgeResult:
+    """Every unavailable engine must carry a non-empty ``reason`` — that's how the
+    user learns what to install. A silent unavailable engine is a UX bug."""
+    silent = [
+        b.get("id") for b in _backends(payload)
+        if not b.get("available") and not (b.get("reason") or "").strip()
+    ]
+    return JudgeResult(
+        name="unavailable_engines_explained",
+        passed=not silent,
+        measured=len(silent),
+        detail="every unavailable engine explains why" if not silent
+        else f"unavailable engines with no reason: {silent}",
+    )

--- a/tests/probe/judges/i18n.py
+++ b/tests/probe/judges/i18n.py
@@ -1,0 +1,94 @@
+"""i18n judges — enforce the localization hard rule structurally.
+
+Localization is a CLAUDE.md hard rule: all user-facing text goes through the i18n
+layer. These judges check the locale files for *structural* correctness:
+  - every locale file is valid JSON (blocking)
+  - no locale has ORPHAN keys absent from the reference locale — those are dead
+    or mistyped keys that will silently fall back and never render (blocking)
+  - translation coverage per locale (advisory — incomplete translations fall back
+    to the reference and are tolerated, so this reports a trend, never gates)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..spec import JudgeResult
+
+
+def _flatten(obj: dict, prefix: str = "") -> dict:
+    out: dict = {}
+    for k, v in obj.items():
+        key = f"{prefix}{k}"
+        if isinstance(v, dict):
+            out.update(_flatten(v, key + "."))
+        else:
+            out[key] = v
+    return out
+
+
+def _load_locales(locales_dir: str) -> tuple[dict[str, dict], list[str]]:
+    """Return ({locale_name: flattened_keys}, [bad_files])."""
+    locales, bad = {}, []
+    for path in sorted(Path(locales_dir).glob("*.json")):
+        try:
+            locales[path.stem] = _flatten(json.loads(path.read_text(encoding="utf-8")))
+        except Exception:  # noqa: BLE001
+            bad.append(path.name)
+    return locales, bad
+
+
+def locale_valid_json(locales_dir: str) -> JudgeResult:
+    locales, bad = _load_locales(locales_dir)
+    return JudgeResult(
+        name="locale_valid_json",
+        passed=not bad,
+        measured=len(locales),
+        detail=f"{len(locales)} locale files parse" if not bad else f"invalid JSON: {bad}",
+    )
+
+
+def locale_no_orphan_keys(locales_dir: str, reference: str = "en") -> JudgeResult:
+    locales, _ = _load_locales(locales_dir)
+    ref = set(locales.get(reference, {}))
+    if not ref:
+        return JudgeResult(name="locale_no_orphan_keys", passed=False,
+                           detail=f"reference locale {reference!r} not found/empty")
+    offenders = {}
+    for name, keys in locales.items():
+        if name == reference:
+            continue
+        orphans = set(keys) - ref
+        if orphans:
+            offenders[name] = sorted(orphans)[:5]
+    ok = not offenders
+    return JudgeResult(
+        name="locale_no_orphan_keys",
+        passed=ok,
+        measured=len(offenders),
+        detail=f"no orphan keys across {len(locales)} locales"
+        if ok else f"orphan keys (absent from {reference}): {offenders}",
+    )
+
+
+def locale_coverage(locales_dir: str, reference: str = "en", min_pct: float = 0.0) -> JudgeResult:
+    """Advisory: lowest translation coverage across locales. Never gates —
+    untranslated keys fall back to the reference."""
+    locales, _ = _load_locales(locales_dir)
+    ref = set(locales.get(reference, {}))
+    if not ref:
+        return JudgeResult(name="locale_coverage", passed=None, detail="no reference locale")
+    worst, worst_name = 1.0, reference
+    for name, keys in locales.items():
+        if name == reference:
+            continue
+        pct = len(set(keys) & ref) / len(ref)
+        if pct < worst:
+            worst, worst_name = pct, name
+    return JudgeResult(
+        name="locale_coverage",
+        passed=worst >= min_pct,
+        measured=round(worst, 3),
+        detail=f"lowest coverage: {worst_name} at {worst:.0%} of {len(ref)} reference keys",
+    )

--- a/tests/probe/judges/i18n.py
+++ b/tests/probe/judges/i18n.py
@@ -4,7 +4,7 @@ Localization is a CLAUDE.md hard rule: all user-facing text goes through the i18
 layer. These judges check the locale files for *structural* correctness:
   - every locale file is valid JSON (blocking)
   - no locale has ORPHAN keys absent from the reference locale — those are dead
-    or mistyped keys that will silently fall back and never render (blocking)
+    or mistyped keys that will silently fall back and never render (advisory)
   - translation coverage per locale (advisory — incomplete translations fall back
     to the reference and are tolerated, so this reports a trend, never gates)
 """
@@ -41,6 +41,16 @@ def _load_locales(locales_dir: str) -> tuple[dict[str, dict], list[str]]:
 
 def locale_valid_json(locales_dir: str) -> JudgeResult:
     locales, bad = _load_locales(locales_dir)
+    if not locales and not bad:
+        # No locale files found at all — the directory is empty or missing.
+        # Treat as a hard failure so a missing/empty locales dir can't silently
+        # pass a blocking gate.
+        return JudgeResult(
+            name="locale_valid_json",
+            passed=False,
+            measured=0,
+            detail=f"no locale JSON files found in {locales_dir!r}",
+        )
     return JudgeResult(
         name="locale_valid_json",
         passed=not bad,

--- a/tests/probe/spec.py
+++ b/tests/probe/spec.py
@@ -60,7 +60,7 @@ class Spec:
 def _build_registry() -> dict[str, Callable[..., JudgeResult]]:
     """Map YAML judge keys → judge callables. Imported lazily to avoid the
     spec ⇄ judges circular import (judges import JudgeResult from here)."""
-    from .judges import audio, desktop, http, speaker, transcription
+    from .judges import audio, coverage, desktop, dictation, dubbing, engine, http, i18n, speaker, transcription
     from .judges import web as web_judges
 
     return {
@@ -89,6 +89,27 @@ def _build_registry() -> dict[str, Callable[..., JudgeResult]]:
         "config_eq": desktop.config_eq,
         "config_contains": desktop.config_contains,
         "csp_allows": desktop.csp_allows,
+        # L4 dubbing
+        "segments_duration_ratio": dubbing.segments_duration_ratio,
+        "srt_well_formed": dubbing.srt_well_formed,
+        "vtt_well_formed": dubbing.vtt_well_formed,
+        "archive_has": dubbing.archive_has,
+        "output_language_is": dubbing.output_language_is,
+        # i18n / localization
+        "locale_valid_json": i18n.locale_valid_json,
+        "locale_no_orphan_keys": i18n.locale_no_orphan_keys,
+        "locale_coverage": i18n.locale_coverage,
+        # engine matrix
+        "engines_present": engine.engines_present,
+        "active_engine_available": engine.active_engine_available,
+        "engine_available": engine.engine_available,
+        "unavailable_engines_explained": engine.unavailable_engines_explained,
+        # coverage critic
+        "layers_have_specs": coverage.layers_have_specs,
+        "coverage_report": coverage.coverage_report,
+        # dictation (streaming-ASR WebSocket)
+        "ws_endpoint_registered": dictation.ws_endpoint_registered,
+        "ws_handshake_ok": dictation.ws_handshake_ok,
     }
 
 

--- a/tests/probe/specs/coverage_critic.probe.yaml
+++ b/tests/probe/specs/coverage_critic.probe.yaml
@@ -10,6 +10,6 @@ judge:
   checks:
     - layers_have_specs:
         specs: $.specs
-        required: ["media", "env", "desktop", "web", "dubbing", "i18n", "engine", "security"]
+        required: ["media", "env", "desktop", "web", "dubbing", "i18n", "engine", "security", "meta"]
 advisory:
   - coverage_report: { openapi_paths: $.openapi_paths, specs: $.specs }

--- a/tests/probe/specs/coverage_critic.probe.yaml
+++ b/tests/probe/specs/coverage_critic.probe.yaml
@@ -1,0 +1,15 @@
+# Coverage Critic spec — drift defense across the probe suite.
+# Actor: enumerate the OpenAPI surface + the probe spec set (test supplies them).
+feature: coverage-critic
+layer: meta
+steps:
+  - actor: meta
+    inspect: openapi paths + probe specs
+    capture: { openapi_paths: $.openapi_paths, specs: $.specs }
+judge:
+  checks:
+    - layers_have_specs:
+        specs: $.specs
+        required: ["media", "env", "desktop", "web", "dubbing", "i18n", "engine", "security"]
+advisory:
+  - coverage_report: { openapi_paths: $.openapi_paths, specs: $.specs }

--- a/tests/probe/specs/dictation.probe.yaml
+++ b/tests/probe/specs/dictation.probe.yaml
@@ -1,0 +1,14 @@
+# Dictation spec — streaming-ASR (real-time capture) WebSocket contract.
+# Actor: handshake-only connect to /ws/transcribe (captured in the shared boot).
+# Driving real partial/final transcription needs an ASR model → enable-on-demand.
+feature: dictation
+layer: dictation
+steps:
+  - actor: ws
+    connect: /ws/transcribe
+    capture: { ws_routes: $.ws_routes, ws_transcribe_connected: $.ws_transcribe_connected }
+judge:
+  checks:
+    - ws_endpoint_registered: { ws_routes: $.ws_routes, path: "/ws/transcribe" }
+    - ws_handshake_ok: { connected: $.ws_transcribe_connected }
+advisory: []

--- a/tests/probe/specs/dub_export.probe.yaml
+++ b/tests/probe/specs/dub_export.probe.yaml
@@ -1,0 +1,29 @@
+# L4 dubbing spec — pipeline timing + export structural correctness.
+#
+# Actor: run a dub job and export. The test supplies segments + SRT/VTT/ZIP names
+# (offline, synthetic); a real run plugs the live pipeline outputs into the same
+# context keys. Translation *quality* is out of scope (not an audio problem).
+
+feature: dubbing-export
+layer: dubbing
+
+steps:
+  - actor: api
+    call: dub job → export
+    capture:
+      segments: $.segments       # [{source, dubbed}, ...] durations in seconds
+      srt: $.srt
+      vtt: $.vtt
+      zip_names: $.zip_names
+
+judge:
+  checks:
+    # Core dubbing constraint: dubbed segments stay near source duration.
+    - segments_duration_ratio: { segments: $.segments, min_ratio: 0.5, max_ratio: 1.6 }
+    - srt_well_formed: { text: $.srt }
+    - vtt_well_formed: { text: $.vtt }
+    - archive_has: { names: $.zip_names, patterns: ["vocals", "background"] }
+
+advisory:
+  # Confirm the dubbed track is in the target language — skips without a detector.
+  - output_language_is: { audio: $.dub_audio, expected: en }

--- a/tests/probe/specs/dub_export.probe.yaml
+++ b/tests/probe/specs/dub_export.probe.yaml
@@ -15,6 +15,7 @@ steps:
       srt: $.srt
       vtt: $.vtt
       zip_names: $.zip_names
+      dub_audio: $.dub_audio     # dubbed audio track path (for language-ID advisory)
 
 judge:
   checks:

--- a/tests/probe/specs/engines.probe.yaml
+++ b/tests/probe/specs/engines.probe.yaml
@@ -1,0 +1,19 @@
+# Engine-matrix spec — TTS/ASR backend registry (engine-compatibility constraint).
+# Actor: GET /engines/tts and /engines/asr (captured in the shared boot).
+feature: engine-matrix
+layer: engine
+steps:
+  - actor: api
+    call: GET /engines/tts ; GET /engines/asr
+    capture: { engines_tts: $.engines_tts, engines_asr: $.engines_asr }
+judge:
+  checks:
+    - engines_present: { payload: $.engines_tts, min_count: 1 }
+    - engines_present: { payload: $.engines_asr, min_count: 1 }
+    # The default engine must actually be usable out of the box.
+    - active_engine_available: { payload: $.engines_tts }
+    - active_engine_available: { payload: $.engines_asr }
+    # Every unavailable engine must tell the user how to install it.
+    - unavailable_engines_explained: { payload: $.engines_tts }
+    - unavailable_engines_explained: { payload: $.engines_asr }
+advisory: []

--- a/tests/probe/specs/i18n_parity.probe.yaml
+++ b/tests/probe/specs/i18n_parity.probe.yaml
@@ -1,0 +1,24 @@
+# i18n spec — localization structural integrity (CLAUDE.md hard rule).
+#
+# Actor: read frontend/src/i18n/locales/*.json. The test supplies locales_dir.
+#
+# Gates only on valid JSON. Orphan-key detection and coverage are ADVISORY: the
+# repo currently has real orphan keys (non-en locales carry gallery.cat_* and
+# bootstrap.lines keys absent from en) — surfaced here without blocking the suite,
+# since fixing the en locale is a product change, not a harness change.
+
+feature: localization
+layer: i18n
+
+steps:
+  - actor: fs
+    read: frontend/src/i18n/locales/*.json
+    capture: { locales_dir: $.locales_dir }
+
+judge:
+  checks:
+    - locale_valid_json: { locales_dir: $.locales_dir }
+
+advisory:
+  - locale_no_orphan_keys: { locales_dir: $.locales_dir, reference: en }
+  - locale_coverage: { locales_dir: $.locales_dir, reference: en }

--- a/tests/probe/specs/migration.probe.yaml
+++ b/tests/probe/specs/migration.probe.yaml
@@ -5,9 +5,15 @@ layer: env
 steps:
   - actor: env
     probe: boot against seeded omnivoice_data
-    capture: { health_status: $.health_status, health_body: $.health_body }
+    capture:
+      health_status: $.health_status
+      health_body: $.health_body
+      db_path: $.db_path        # path to the migrated DB file (data integrity)
 judge:
   checks:
     - status_eq: { actual: $.health_status, expected: 200 }
     - json_field_eq: { obj: $.health_body, key: status, value: ok }
+    # Data-integrity: the existing DB file must still be present after migration
+    # (guards against a migration that drops/recreates the DB and loses user data).
+    - path_exists: { target: $.db_path }
 advisory: []

--- a/tests/probe/specs/migration.probe.yaml
+++ b/tests/probe/specs/migration.probe.yaml
@@ -1,0 +1,13 @@
+# DB-migration spec — alembic UPGRADE on existing user data (backward-compat).
+# Actor: boot against a copy of the checked-in omnivoice_data fixture.
+feature: db-migration
+layer: env
+steps:
+  - actor: env
+    probe: boot against seeded omnivoice_data
+    capture: { health_status: $.health_status, health_body: $.health_body }
+judge:
+  checks:
+    - status_eq: { actual: $.health_status, expected: 200 }
+    - json_field_eq: { obj: $.health_body, key: status, value: ok }
+advisory: []

--- a/tests/probe/specs/security.probe.yaml
+++ b/tests/probe/specs/security.probe.yaml
@@ -1,0 +1,12 @@
+# Security spec — loopback gating of system routes (P0 security surface).
+# Actor: a non-loopback origin GETs /system/info (captured in the shared boot).
+feature: loopback-security
+layer: security
+steps:
+  - actor: api
+    call: GET /system/info from a non-loopback origin
+    capture: { loopback_reject_status: $.loopback_reject_status }
+judge:
+  checks:
+    - status_eq: { actual: $.loopback_reject_status, expected: 403 }
+advisory: []

--- a/tests/probe/specs/voice_design.probe.yaml
+++ b/tests/probe/specs/voice_design.probe.yaml
@@ -1,0 +1,22 @@
+# L4 voice-design spec — synthesize from gender/age/accent/pitch/style params.
+# Verification reuses the audio-correctness ladder (design quality stays human-
+# judgment-only). The test supplies the generated audio; a live run plugs in the
+# real /generate (design) output.
+feature: voice-design
+layer: media
+steps:
+  - actor: api
+    call: POST /generate (voice design params)
+    body: { gender: female, age: adult, accent: us, pitch: 1.0, style: calm, text: "Designing a brand new voice." }
+    capture: { audio: $.output_path }
+judge:
+  subject: $.audio
+  checks:
+    - artifact_exists
+    - decodes
+    - no_nan
+    - not_clipping: { peak_ceiling: 0.999 }
+    - duration_between: [0.8, 6.0]
+    - not_silent: { rms_floor_db: -45 }
+    - asr_wer_below: { expected: "Designing a brand new voice.", max: 0.2 }
+advisory: []

--- a/tests/probe/test_probe_asr_e2e.py
+++ b/tests/probe/test_probe_asr_e2e.py
@@ -1,0 +1,38 @@
+"""Real ASR round-trip — enable-on-demand end-to-end.
+
+The true round-trip (TTS speech → Whisper transcript → WER) needs a real TTS
+model producing intelligible speech, so it can't run offline. Gated on
+PROBE_E2E=1 plus a real speech sample at PROBE_ASR_SAMPLE (and optional expected
+text at PROBE_ASR_TEXT). Without those it skips. The non-gated test confirms the
+default ASR backend wires up (no model load).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from .judges import transcription as T
+
+
+def test_faster_whisper_backend_wires_up():
+    """Constructs the default real transcriber without loading a model — proves
+    the round-trip ASR path is importable and conforms to the Transcriber API."""
+    tr = T.FasterWhisperTranscriber(model_size="tiny")
+    assert hasattr(tr, "transcribe") and callable(tr.transcribe)
+    assert tr._model is None  # lazy — no model loaded yet
+
+
+@pytest.mark.skipif(os.environ.get("PROBE_E2E") != "1", reason="real ASR is enable-on-demand (PROBE_E2E=1)")
+def test_real_round_trip_asr():
+    sample = os.environ.get("PROBE_ASR_SAMPLE")
+    if not sample or not os.path.exists(sample):
+        pytest.skip("set PROBE_ASR_SAMPLE=/path/to/speech.wav to run the real round-trip")
+    tr = T.FasterWhisperTranscriber(model_size=os.environ.get("PROBE_ASR_MODEL", "tiny"))
+    heard = tr.transcribe(sample)
+    assert heard.strip(), "ASR returned empty transcript on real speech"
+    expected = os.environ.get("PROBE_ASR_TEXT")
+    if expected:
+        wer = T.word_error_rate(expected, heard)
+        assert wer <= float(os.environ.get("PROBE_ASR_MAX_WER", "0.3")), f"WER={wer:.3f}; heard {heard!r}"

--- a/tests/probe/test_probe_asr_e2e.py
+++ b/tests/probe/test_probe_asr_e2e.py
@@ -27,7 +27,7 @@ def test_faster_whisper_backend_wires_up():
 @pytest.mark.skipif(os.environ.get("PROBE_E2E") != "1", reason="real ASR is enable-on-demand (PROBE_E2E=1)")
 def test_real_round_trip_asr():
     sample = os.environ.get("PROBE_ASR_SAMPLE")
-    if not sample or not os.path.exists(sample):
+    if not sample or not os.path.isfile(sample):
         pytest.skip("set PROBE_ASR_SAMPLE=/path/to/speech.wav to run the real round-trip")
     tr = T.FasterWhisperTranscriber(model_size=os.environ.get("PROBE_ASR_MODEL", "tiny"))
     heard = tr.transcribe(sample)

--- a/tests/probe/test_probe_coverage.py
+++ b/tests/probe/test_probe_coverage.py
@@ -1,0 +1,32 @@
+"""Coverage Critic — enumerate the OpenAPI surface + probe specs, gate that every
+declared layer still has a spec, and report (advisory) the API inventory."""
+
+from __future__ import annotations
+
+import os
+
+from . import spec as probe_spec
+from .judges import coverage as C
+
+_SPECS_DIR = os.path.join(os.path.dirname(__file__), "specs")
+_SPEC = os.path.join(_SPECS_DIR, "coverage_critic.probe.yaml")
+
+
+def test_coverage_critic(probe_report, boot_capture):
+    specs = C.scan_specs(_SPECS_DIR)
+    spec = probe_spec.load_spec(_SPEC)
+    ctx = {"openapi_paths": boot_capture["openapi_paths"], "specs": specs}
+    results = probe_spec.run_judges(spec, ctx)
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
+    # The critic actually enumerated a real surface.
+    assert len(boot_capture["openapi_paths"]) > 100
+    assert len(specs) >= 10
+
+
+def test_layers_have_specs_detects_gap():
+    specs = [{"layer": "media"}, {"layer": "env"}]
+    ok = C.layers_have_specs(specs, ["media", "env"])
+    assert ok.passed is True
+    gap = C.layers_have_specs(specs, ["media", "env", "desktop"])
+    assert gap.passed is False and "desktop" in gap.detail

--- a/tests/probe/test_probe_design.py
+++ b/tests/probe/test_probe_design.py
@@ -1,0 +1,36 @@
+"""Voice design — the design output runs the same audio-correctness ladder as
+TTS (design *quality* stays human-judgment-only). Offline: synthetic audio +
+FakeTranscriber; a live run plugs in the real /generate design output."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from . import spec as probe_spec
+from .judges.transcription import FakeTranscriber
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "voice_design.probe.yaml")
+_TEXT = "Designing a brand new voice."
+
+
+@pytest.fixture
+def designed_audio(tmp_path):
+    t = np.linspace(0, 1.8, int(24000 * 1.8), endpoint=False)
+    path = str(tmp_path / "design.wav")
+    sf.write(path, (0.35 * np.sin(2 * np.pi * 200 * t)).astype(np.float32), 24000, subtype="FLOAT")
+    return path
+
+
+def test_voice_design_verdict(probe_report, designed_audio):
+    spec = probe_spec.load_spec(_SPEC)
+    results = probe_spec.run_judges(
+        spec,
+        context={"audio": designed_audio},
+        backends={"transcriber": FakeTranscriber(fixed=_TEXT)},
+    )
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)

--- a/tests/probe/test_probe_dictation.py
+++ b/tests/probe/test_probe_dictation.py
@@ -1,0 +1,30 @@
+"""Dictation — streaming-ASR WebSocket contract, verified against the real
+backend (shared boot): endpoint registered + loopback handshake accepted."""
+
+from __future__ import annotations
+
+import os
+
+from . import spec as probe_spec
+from .judges import dictation as D
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "dictation.probe.yaml")
+
+
+def test_dictation_ws_contract(probe_report, boot_capture):
+    spec = probe_spec.load_spec(_SPEC)
+    ctx = {
+        "ws_routes": boot_capture.get("ws_routes", []),
+        "ws_transcribe_connected": boot_capture.get("ws_transcribe_connected", False),
+    }
+    results = probe_spec.run_judges(spec, ctx)
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
+    assert "/ws/transcribe" in boot_capture.get("ws_routes", [])
+
+
+def test_dictation_judges_synthetic():
+    assert D.ws_endpoint_registered(["/ws/transcribe"], "/ws/transcribe").passed is True
+    assert D.ws_endpoint_registered([], "/ws/transcribe").passed is False
+    assert D.ws_handshake_ok(True).passed is True
+    assert D.ws_handshake_ok(False).passed is False

--- a/tests/probe/test_probe_dubbing.py
+++ b/tests/probe/test_probe_dubbing.py
@@ -1,0 +1,61 @@
+"""L4 dubbing — offline tests of timing + export-format judges, and the dub
+spec wired against synthetic pipeline outputs."""
+
+from __future__ import annotations
+
+import os
+
+from . import spec as probe_spec
+from .judges import dubbing as D
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "dub_export.probe.yaml")
+
+_SRT = "1\n00:00:00,000 --> 00:00:01,000\nHello world\n\n2\n00:00:01,000 --> 00:00:02,000\nGoodbye\n"
+_VTT = "WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello world\n"
+
+
+def test_segments_duration_ratio():
+    ok = [{"source": 1.0, "dubbed": 1.1}, {"start": 0.0, "end": 2.0, "dubbed": 2.3}]
+    assert D.segments_duration_ratio(ok, max_ratio=1.6).passed is True
+    bad = [{"source": 1.0, "dubbed": 3.0}]  # 3.0× → way over
+    assert D.segments_duration_ratio(bad, max_ratio=1.6).passed is False
+
+
+def test_srt_vtt_well_formed():
+    assert D.srt_well_formed(_SRT).passed is True
+    assert D.srt_well_formed("not subtitles").passed is False
+    assert D.vtt_well_formed(_VTT).passed is True
+    assert D.vtt_well_formed(_SRT).passed is False  # SRT comma timing != VTT
+
+
+def test_archive_has():
+    names = ["001_vocals.wav", "002_no_vocals_background.wav"]
+    assert D.archive_has(names, ["vocals", "background"]).passed is True
+    assert D.archive_has(names, ["music"]).passed is False
+
+
+def test_output_language_skips_without_detector():
+    assert D.output_language_is("x.wav", "en").skipped is True
+
+
+def test_output_language_with_detector():
+    class FakeDet:
+        def detect(self, path):
+            return "en"
+
+    assert D.output_language_is("x.wav", "en", detector=FakeDet()).passed is True
+    assert D.output_language_is("x.wav", "fr", detector=FakeDet()).passed is False
+
+
+def test_dub_spec_verdict(probe_report):
+    spec = probe_spec.load_spec(_SPEC)
+    ctx = {
+        "segments": [{"source": 1.0, "dubbed": 1.05}, {"source": 2.0, "dubbed": 2.4}],
+        "srt": _SRT,
+        "vtt": _VTT,
+        "zip_names": ["001_vocals.wav", "002_no_vocals_background.wav"],
+        "dub_audio": "dubbed_en.wav",  # advisory langid skips (no detector)
+    }
+    results = probe_spec.run_judges(spec, ctx)
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)

--- a/tests/probe/test_probe_engines.py
+++ b/tests/probe/test_probe_engines.py
@@ -1,0 +1,37 @@
+"""Engine matrix — TTS/ASR registry verified against the real running backend
+(shared boot), plus offline judge unit tests."""
+
+from __future__ import annotations
+
+import os
+
+from . import spec as probe_spec
+from .judges import engine as E
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "engines.probe.yaml")
+
+
+def test_engine_matrix(probe_report, boot_capture):
+    spec = probe_spec.load_spec(_SPEC)
+    ctx = {"engines_tts": boot_capture["engines_tts"], "engines_asr": boot_capture["engines_asr"]}
+    results = probe_spec.run_judges(spec, ctx)
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
+    # Real-world sanity: the shipped defaults are available out of the box.
+    assert E.active_engine_available(boot_capture["engines_tts"]).passed is True
+    assert E.engine_available(boot_capture["engines_asr"], "whisperx").passed is True
+
+
+def test_unavailable_engines_explained_synthetic():
+    payload = {"active": "a", "backends": [
+        {"id": "a", "available": True},
+        {"id": "b", "available": False, "reason": "pip install b"},
+    ]}
+    assert E.unavailable_engines_explained(payload).passed is True
+    silent = {"backends": [{"id": "c", "available": False, "reason": ""}]}
+    assert E.unavailable_engines_explained(silent).passed is False
+
+
+def test_active_engine_unavailable_fails():
+    payload = {"active": "ghost", "backends": [{"id": "real", "available": True}]}
+    assert E.active_engine_available(payload).passed is False

--- a/tests/probe/test_probe_i18n.py
+++ b/tests/probe/test_probe_i18n.py
@@ -1,0 +1,59 @@
+"""i18n — locale judges (synthetic) + the localization spec against the real
+locale files. Orphan-key + coverage findings are advisory (reported, not gating).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from . import spec as probe_spec
+from .judges import i18n as I
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "i18n_parity.probe.yaml")
+_LOCALES = str(Path(__file__).resolve().parents[2] / "frontend" / "src" / "i18n" / "locales")
+
+
+def _write_locales(tmp_path, mapping):
+    for name, obj in mapping.items():
+        (tmp_path / f"{name}.json").write_text(json.dumps(obj), encoding="utf-8")
+    return str(tmp_path)
+
+
+def test_valid_json_and_orphans_synthetic(tmp_path):
+    d = _write_locales(tmp_path, {
+        "en": {"a": 1, "b": {"c": 2}},
+        "fr": {"a": 1, "b": {"c": 2}},            # clean
+        "de": {"a": 1, "b": {"c": 2}, "x": 9},    # orphan key 'x'
+    })
+    assert I.locale_valid_json(d).passed is True
+    res = I.locale_no_orphan_keys(d, "en")
+    assert res.passed is False and "de" in res.detail
+
+
+def test_invalid_json_fails(tmp_path):
+    (tmp_path / "en.json").write_text('{"a":1}', encoding="utf-8")
+    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+    assert I.locale_valid_json(str(tmp_path)).passed is False
+
+
+def test_coverage_reports_lowest(tmp_path):
+    d = _write_locales(tmp_path, {
+        "en": {"a": 1, "b": 2, "c": 3, "d": 4},
+        "fr": {"a": 1, "b": 2},  # 50%
+    })
+    res = I.locale_coverage(d, "en")
+    assert res.measured == 0.5 and "fr" in res.detail
+
+
+def test_real_locales_spec(probe_report):
+    """Blocking: all real locale files are valid JSON. Orphan-key/coverage run as
+    advisory — the suite stays green while the report surfaces the real finding
+    (non-en locales carry gallery.cat_*/bootstrap.lines keys absent from en)."""
+    spec = probe_spec.load_spec(_SPEC)
+    results = probe_spec.run_judges(spec, {"locales_dir": _LOCALES})
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == []
+    # The advisory orphan-key finding is present (proof the suite surfaces it).
+    assert any(r.name == "locale_no_orphan_keys" and r.advisory for r in results)

--- a/tests/probe/test_probe_i18n.py
+++ b/tests/probe/test_probe_i18n.py
@@ -56,4 +56,4 @@ def test_real_locales_spec(probe_report):
     probe_report.record(spec, results)
     assert probe_spec.blocking_failures(results) == []
     # The advisory orphan-key finding is present (proof the suite surfaces it).
-    assert any(r.name == "locale_no_orphan_keys" and r.advisory for r in results)
+    assert any(r.name == "locale_no_orphan_keys" and r.advisory and r.passed is False for r in results)

--- a/tests/probe/test_probe_migration.py
+++ b/tests/probe/test_probe_migration.py
@@ -16,7 +16,9 @@ def test_migration_upgrades_existing_data(probe_report):
     spec = probe_spec.load_spec(_SPEC)
     with env.seeded_data_dir() as data_dir:
         context = env.capture_first_run(data_dir)
-    results = probe_spec.run_judges(spec, context)
+        # Run judges INSIDE the with-block: the migration spec's path_exists check
+        # must see the seeded DB before the temp data dir is torn down on exit.
+        results = probe_spec.run_judges(spec, context)
     probe_report.record(spec, results)
     assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
     # Data integrity: the existing DB file must still be present after migration

--- a/tests/probe/test_probe_migration.py
+++ b/tests/probe/test_probe_migration.py
@@ -16,9 +16,10 @@ def test_migration_upgrades_existing_data(probe_report):
     spec = probe_spec.load_spec(_SPEC)
     with env.seeded_data_dir() as data_dir:
         context = env.capture_first_run(data_dir)
-        db_ok = context["db_created"]
     results = probe_spec.run_judges(spec, context)
     probe_report.record(spec, results)
     assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
-    # Migrations ran cleanly on existing data and the DB is intact.
-    assert db_ok
+    # Data integrity: the existing DB file must still be present after migration
+    # (db_path is set even for pre-existing files; db_created would be False here
+    # since the seeded fixture already has a DB — we want presence, not creation).
+    assert context["db_path"], "DB file not found after migration — data may have been lost"

--- a/tests/probe/test_probe_migration.py
+++ b/tests/probe/test_probe_migration.py
@@ -1,0 +1,24 @@
+"""DB migration — boot against a copy of the checked-in omnivoice_data fixture so
+alembic runs its UPGRADE path on existing user data (backward-compat constraint).
+Subprocess-isolated; the model load is short-circuited."""
+
+from __future__ import annotations
+
+import os
+
+from . import env
+from . import spec as probe_spec
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "migration.probe.yaml")
+
+
+def test_migration_upgrades_existing_data(probe_report):
+    spec = probe_spec.load_spec(_SPEC)
+    with env.seeded_data_dir() as data_dir:
+        context = env.capture_first_run(data_dir)
+        db_ok = context["db_created"]
+    results = probe_spec.run_judges(spec, context)
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
+    # Migrations ran cleanly on existing data and the DB is intact.
+    assert db_ok

--- a/tests/probe/test_probe_security.py
+++ b/tests/probe/test_probe_security.py
@@ -1,0 +1,19 @@
+"""Loopback security — system routes must reject non-loopback origins (P0).
+Verified against the real backend via the shared boot."""
+
+from __future__ import annotations
+
+import os
+
+from . import spec as probe_spec
+
+_SPEC = os.path.join(os.path.dirname(__file__), "specs", "security.probe.yaml")
+
+
+def test_loopback_rejection(probe_report, boot_capture):
+    spec = probe_spec.load_spec(_SPEC)
+    ctx = {"loopback_reject_status": boot_capture["loopback_reject_status"]}
+    results = probe_spec.run_judges(spec, ctx)
+    probe_report.record(spec, results)
+    assert probe_spec.blocking_failures(results) == [], "\n".join(str(r) for r in results)
+    assert boot_capture["loopback_reject_status"] == 403  # not 200 — origin was rejected


### PR DESCRIPTION
## What

Expands the `probe` harness from one happy-path spec per layer to **whole-app feature coverage** — web, backend, dictation, clone, design — keeping the Actor/Judge split (no LLM on the verdict path) and **offline-by-default + enable-on-demand** for heavy paths. A single subprocess boot is shared across all backend-touching specs.

## New feature specs

| Spec | Verifies | Runs for real here? |
|------|----------|---------------------|
| **dubbing** (`dub_export`) | per-segment duration ratio (core dubbing constraint), SRT/VTT well-formed, export-archive contents; output language-ID (advisory) | ✅ offline (synthetic) |
| **i18n** (`i18n_parity`) | locale files valid JSON (gate); orphan-keys + coverage (advisory) | ✅ against real locales |
| **engine matrix** (`engines`) | active TTS/ASR engine available + every unavailable engine explains how to install it (**11 TTS / 7 ASR** backends) | ✅ real backend |
| **security** | system routes reject non-loopback origins (403) | ✅ real backend |
| **migration** | alembic **UPGRADE** on the seeded `omnivoice_data` fixture (backward-compat) | ✅ real backend |
| **dictation** | streaming-ASR WebSocket `/ws/transcribe` registered + accepts loopback handshake | ✅ real backend |
| **voice design** | design output runs the audio-correctness ladder | ✅ offline (synthetic) |
| **coverage-critic** | every declared layer still has a spec (drift gate) + API-surface inventory (advisory) | ✅ real (156 routes) |
| **real ASR round-trip** | TTS→Whisper→WER | enable-on-demand (`PROBE_E2E=1`) |

## 🐞 Real bug surfaced

The i18n orphan-key check found that **all 20 non-`en` locales carry `gallery.cat_*` (and some `bootstrap.lines`) keys that are absent from the `en` reference** — so those gallery-category labels don't render for English users. It's reported in the **advisory lane (non-blocking)**, since the fix is a product change, not a harness change. Worth a follow-up to add the missing keys to `en.json`.

## Design

- One **shared subprocess boot** (`boot_capture` session fixture) captures first-run endpoints, engine/ASR matrices, loopback-reject, OpenAPI inventory, and the dictation WS handshake — so the suite pays for ~one boot, not one per spec. Subprocess isolation keeps it from contaminating the rest of the test session.
- Heavy/live paths skip cleanly: real ASR (`PROBE_E2E=1`), live browser, Docker.

## Verification

- `uv run pytest tests/probe` → **74 passed, 5 skipped**.
- Full repo → **687 passed, 13 skipped, 13 xfailed, 0 failures**; no contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive probe framework for dubbing, voice-design, streaming ASR/dictation, engine matrices, i18n parity, DB migration checks, and loopback-security; new judges for engines, dubbing/export, subtitles, dictation handshakes, and locale coverage.

* **Documentation**
  * README: added "Feature coverage (specs)" section and noted an i18n missing-key surfaced as an advisory.

* **Tests**
  * Numerous probe tests added (E2E and synthetic) exercising the new probes and judges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->