### PR TITLE
fix(docker): fix stale :latest tag + add push-to-main trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,30 @@
 # Publish Docker images to GitHub Container Registry (GHCR).
 #
 # Triggers:
-#   - push of a tag matching `v*` (e.g. `v0.2.7`) → pushed as :0.2.7 + :latest
-#   - workflow_dispatch → pushed as :sha-<short> (for testing)
+#   - push of a tag matching `v*` (e.g. `v0.3.0`) → :0.3.0, :0.3, :latest
+#   - push to main branch                          → :main (rolling "edge" build)
+#   - workflow_dispatch                            → :sha-<short> (ad-hoc test build)
+#
+# Tag ↔ image mapping
+#   :latest   — always the most recent versioned release (set on every v* tag push)
+#   :0.3.0    — exact version from the git tag
+#   :0.3      — major.minor floating tag (updated on every patch within the minor)
+#   :main     — latest commit on main; may be ahead of the last tagged release
+#   :sha-xxxx — specific commit SHA; produced by workflow_dispatch
 #
 # Images land at: ghcr.io/debpalash/omnivoice-studio
+#
+# NOTE: the Docker image is the headless web-server build of OmniVoice (FastAPI
+# backend + pre-built React frontend served over HTTP).  The Tauri desktop
+# auto-updater and its update-channel toggle are desktop-only features; they do
+# NOT apply to the Docker image.
 
 name: Docker (GHCR)
 
 on:
   push:
     tags: ['v*']
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -42,9 +56,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extracts semver tags from the git ref:
-      #   v0.2.7 → 0.2.7, latest
-      #   manual dispatch → sha-abc1234
+      # Tag strategy:
+      #   v0.3.0 tag push  → :0.3.0, :0.3, :latest
+      #   main branch push → :main
+      #   workflow_dispatch → :sha-<short>
+      #
+      # Fix for stale :latest (issues #249, #251):
+      #   The previous rule used `enable={{is_default_branch}}`, which evaluates
+      #   to false on tag pushes (detached HEAD) — so :latest was never updated
+      #   when a release tag was pushed. Replaced with `enable=${{ github.ref_type
+      #   == 'tag' }}` so :latest tracks every versioned release exactly.
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -53,8 +74,9 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,9 @@
 # Publish Docker images to GitHub Container Registry (GHCR).
 #
 # Triggers:
-#   - push of a tag matching `v*` (e.g. `v0.3.0`) → :0.3.0, :0.3, :latest
-#   - push to main branch                          → :main (rolling "edge" build)
-#   - workflow_dispatch                            → :sha-<short> (ad-hoc test build)
+#   - push of a tag matching `v*` (e.g. `v0.3.0`) → :0.3.0, :0.3, :latest, :sha-
+#   - push to main branch                          → :main, :sha- (rolling "edge" build)
+#   - workflow_dispatch                            → :sha- only (ad-hoc test build)
 #
 # Tag ↔ image mapping
 #   :latest   — always the most recent versioned release (set on every v* tag push)
@@ -56,26 +56,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Tag strategy:
-      #   v0.3.0 tag push  → :0.3.0, :0.3, :latest
-      #   main branch push → :main
-      #   workflow_dispatch → :sha-<short>
+      # Tag strategy (`:sha-<short>` is emitted on every trigger):
+      #   v0.3.0 tag push   → :0.3.0, :0.3, :latest, :sha-
+      #   main branch push  → :main, :sha-
+      #   workflow_dispatch → :sha- only
       #
       # Fix for stale :latest (issues #249, #251):
       #   The previous rule used `enable={{is_default_branch}}`, which evaluates
       #   to false on tag pushes (detached HEAD) — so :latest was never updated
-      #   when a release tag was pushed. Replaced with `enable=${{ github.ref_type
-      #   == 'tag' }}` so :latest tracks every versioned release exactly.
+      #   when a release tag was pushed. The version / :latest / :main rules are
+      #   gated on `github.event_name == 'push'` so a manual workflow_dispatch can
+      #   only ever produce a throwaway `:sha-` tag (never republish a mutable
+      #   tag), and :latest additionally excludes prerelease tags (those contain a
+      #   `-`, e.g. v1.0.0-rc.1) so a prerelease can't clobber :latest.
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref, '-') }}
+            type=raw,value=main,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-,format=short
 
       - name: Build and push

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -4,6 +4,18 @@ For headless servers, dedicated GPUs, or "I want one command" deployments.
 The docker image bundles the backend; the UI is served over HTTP and you open
 it in a normal browser.
 
+> **Image ↔ version mapping**
+>
+> | Tag | What you get |
+> |-----|--------------|
+> | `:latest` | Most recent versioned release (updated on every `v*` git tag) |
+> | `:0.3.0` | Exact release version |
+> | `:0.3` | Latest patch within the 0.3 minor |
+> | `:main` | Latest commit on `main` — may be ahead of the last release |
+> | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |
+>
+> **Note on the update-channel toggle:** The update-channel UI (Settings → About → Update channel) is part of the Tauri desktop app's built-in auto-updater. It does **not** apply to the Docker image — the Docker image is the headless web-server build. To update your Docker deployment, pull the new image tag and recreate the container (`docker compose pull && docker compose up -d`).
+
 ## Pull and run (CPU)
 
 ```bash
@@ -100,6 +112,10 @@ Two paths are worth persisting across container restarts:
 
 ## Troubleshooting
 
+- **Container reports 0.2.7 but image is tagged 0.3.x:** This was a workflow bug
+  (fixes #249, #251) — the `:latest` tag was not being updated on release tag
+  pushes. Pull the image again after the fix is merged: `docker pull ghcr.io/debpalash/omnivoice-studio:latest`.
+- **Checking which version is running:** `docker exec omnivoice python -c "import importlib.metadata; print(importlib.metadata.version('omnivoice-studio'))"` or visit the `/health` endpoint which includes the version field.
 - **Media-preview 404 in LAN mode:** see the [LAN access](#lan-access) section
   above — the `window.location.host` fix shipped in v0.3.
 - **GPU not detected:** verify `docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi` succeeds first.


### PR DESCRIPTION
## Root cause

Two bugs in `.github/workflows/docker.yml` combined to produce a stale Docker image — the `:latest` tag pointing to v0.2.7 code even after the codebase moved to v0.3.0 (issues #249, #251).

### Bug 1 — `:latest` was never updated on release tag pushes

The metadata-action rule was:
```yaml
type=raw,value=latest,enable={{is_default_branch}}
```

`{{is_default_branch}}` is a docker/metadata-action template variable that evaluates to `false` on tag-triggered runs — because a `push: tags:` event runs in a detached-HEAD context, not on the default branch. So every time a `v*` tag was pushed, `:latest` was **silently skipped**. The last time `:latest` was correctly set was the `v0.2.7` tag push when the workflow presumably had different (or no) `is_default_branch` logic.

**Fix:** Replace with `enable=${{ github.ref_type == 'tag' }}` — a GitHub Actions expression that is true whenever the trigger is a tag push. This is the canonical pattern from docker/metadata-action's own docs.

### Bug 2 — No trigger for main-branch pushes

Between releases, there was no mechanism to publish an up-to-date edge image. This meant users who pulled `:latest` between release tags always got the old one.

**Fix:** Added `push: branches: [main]` trigger, which publishes a `:main` rolling tag on every merge to main. Tag pushes still produce `:X.Y.Z`, `:X.Y`, and `:latest`.

## Changes

- **`.github/workflows/docker.yml`** — fix `:latest` rule; add `push: branches: [main]`; add `:main` rolling tag; update comments to document the full tag → image mapping; note that the update-channel toggle is desktop-only.
- **`docs/install/docker.md`** — add a tag ↔ version mapping table at the top; add a note clarifying that the update-channel UI applies to the Tauri desktop app only (not the Docker/headless build); add a troubleshooting entry for the version mismatch.

## What was NOT changed

- The Dockerfile (`deploy/Dockerfile`) is correct — it builds from the current repo code via `COPY pyproject.toml uv.lock` + `uv pip install .`. No hardcoded version or remote download.
- No Python/backend/frontend code touched.

## Verification

- YAML linted and parsed (PyYAML): triggers are `push.tags: ['v*']`, `push.branches: ['main']`, and `workflow_dispatch` — all correct.
- `docker build` not run locally (Docker not available in this environment); the Dockerfile has been correct all along and is unchanged.
- The workflow correctly builds from the checked-out repo tree, so pushing a `v0.3.0` tag after merge will produce an image that reports version 0.3.0.

Closes #251
Addresses #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Image ↔ version mapping and clarified that Docker is a headless build; updating requires pulling a tag and recreating the container.
  * Added troubleshooting steps, including how to determine the running version (health endpoint or in-container command) and guidance after a prior tagging fix.

* **Chores**
  * Adjusted Docker image tagging and publish behavior so :latest and branch/raw tags are emitted only in the intended push scenarios, reducing incorrect tag releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->