### PR TITLE
fix(frontend): browser/Docker fallback for file export (closes #256)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,6 +60,7 @@ import { saveProject as apiSaveProject, loadProject as apiLoadProject, deletePro
 import { exportAction, exportReveal, exportRecord } from './api/exports';
 
 import { isTauri, doubleClickMaximize, fileToMediaUrl, playBlobAudio, playPing } from './utils/media';
+import { browserDownload } from './utils/download';
 import { checkForUpdate, fetchAppVersion } from './utils/updater';
 import { syncChannel } from './utils/channelControl';
 import i18n from './i18n';
@@ -506,6 +507,25 @@ function App() {
 
   const handleNativeExport = async (e, sourceIdentifier, fallbackName, mode) => {
     if (e) { e.preventDefault(); e.stopPropagation(); }
+    // Browser / Docker web build: there is no Tauri shell, so the native save
+    // dialog is unavailable — invoking it throws "Cannot read properties of
+    // undefined (reading 'invoke')" (issue #256). Fall back to a plain HTTP
+    // blob download of the file already served at /audio/<path>.
+    if (!isTauri) {
+      const niceName = (fallbackName || sourceIdentifier || 'audio').split('/').pop();
+      try {
+        const finalName = await browserDownload(`${API}/audio/${sourceIdentifier}`, niceName);
+        toast.success(i18n.t('app.toast_downloaded', { name: finalName }));
+        try {
+          await exportRecord({ filename: finalName, destination_path: `~/Downloads/${finalName}`, mode });
+          loadExportHistory();
+        } catch (err) { console.warn('exportRecord (browser export path) failed:', err); }
+      } catch (err) {
+        console.error(err);
+        toast.error(i18n.t('app.toast_export_failed', { message: err?.message || err }));
+      }
+      return;
+    }
     try {
       const { save } = await import('@tauri-apps/plugin-dialog');
       const ext = fallbackName.includes('.') ? fallbackName.split('.').pop() : 'wav';
@@ -527,14 +547,6 @@ function App() {
       toast.error(i18n.t('app.toast_open_folder_failed', { message: err.message }));
     }
   };
-  const parseFilenameFromContentDisposition = (header) => {
-    if (!header) return null;
-    const utf8 = header.match(/filename\*=(?:UTF-8|utf-8)''([^;]+)/i);
-    if (utf8) { try { return decodeURIComponent(utf8[1].trim().replace(/^"|"$/g, '')); } catch { /* ignore */ } }
-    const plain = header.match(/filename="?([^";]+)"?/i);
-    return plain ? plain[1].trim() : null;
-  };
-
   const triggerDownload = async (url, fallbackName) => {
     const extGuess = (fallbackName.includes('.') ? fallbackName.split('.').pop() : 'bin').toLowerCase();
     const modeGuess = ['mp4','mov','mkv','webm'].includes(extGuess)
@@ -573,19 +585,7 @@ function App() {
     // Browser path: standard blob download.
     try {
       toast.loading(i18n.t('app.toast_processing', { name: fallbackName }), { id: fallbackName });
-      const response = await fetch(url);
-      if (!response.ok) throw new Error("Download failed");
-      const serverName = parseFilenameFromContentDisposition(response.headers.get('content-disposition'));
-      const finalName = serverName || fallbackName || 'download';
-      const blob = await response.blob();
-      const localUrl = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = localUrl;
-      a.download = finalName;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(localUrl);
+      const finalName = await browserDownload(url, fallbackName);
       toast.success(i18n.t('app.toast_downloaded', { name: finalName }), { id: fallbackName });
       try {
         await exportRecord({ filename: finalName, destination_path: `~/Downloads/${finalName}`, mode: modeGuess });

--- a/frontend/src/utils/download.js
+++ b/frontend/src/utils/download.js
@@ -1,0 +1,57 @@
+// Shared browser-download helpers.
+//
+// Used by every "save this file" path that runs outside the Tauri desktop
+// shell (browser dev mode + the Docker web-server build). In Tauri we use the
+// native save dialog instead; calling that dialog when no Tauri runtime is
+// present throws "Cannot read properties of undefined (reading 'invoke')"
+// (issue #256), so callers must guard on isTauri and route here otherwise.
+
+/**
+ * Parse a download filename out of a Content-Disposition header.
+ * Returns null when the header is absent or unparseable.
+ */
+export function parseFilenameFromContentDisposition(header) {
+  if (!header) return null;
+  const utf8 = header.match(/filename\*=(?:UTF-8|utf-8)''([^;]+)/i);
+  if (utf8) {
+    try {
+      return decodeURIComponent(utf8[1].trim().replace(/^"|"$/g, ''));
+    } catch {
+      /* fall through to the plain match */
+    }
+  }
+  const plain = header.match(/filename="?([^";]+)"?/i);
+  return plain ? plain[1].trim() : null;
+}
+
+/**
+ * Fetch `url` and trigger a standard browser blob download via a temporary
+ * <a download> element. Prefers the server-provided Content-Disposition
+ * filename, falling back to `fallbackName`. Returns the filename used.
+ *
+ * `deps` lets tests inject fetch/document/url without a real DOM + network.
+ */
+export async function browserDownload(url, fallbackName, deps = {}) {
+  const _fetch = deps.fetch ?? globalThis.fetch;
+  const doc = deps.document ?? globalThis.document;
+  const urlApi = deps.url ?? globalThis.URL;
+
+  const response = await _fetch(url);
+  if (!response.ok) throw new Error('Download failed');
+
+  const serverName = parseFilenameFromContentDisposition(
+    response.headers?.get?.('content-disposition'),
+  );
+  const finalName = serverName || fallbackName || 'download';
+
+  const blob = await response.blob();
+  const localUrl = urlApi.createObjectURL(blob);
+  const a = doc.createElement('a');
+  a.href = localUrl;
+  a.download = finalName;
+  doc.body.appendChild(a);
+  a.click();
+  doc.body.removeChild(a);
+  urlApi.revokeObjectURL(localUrl);
+  return finalName;
+}

--- a/frontend/src/utils/download.test.js
+++ b/frontend/src/utils/download.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseFilenameFromContentDisposition, browserDownload } from './download';
+
+describe('parseFilenameFromContentDisposition', () => {
+  it('returns null for missing/empty headers', () => {
+    expect(parseFilenameFromContentDisposition(null)).toBe(null);
+    expect(parseFilenameFromContentDisposition('')).toBe(null);
+    expect(parseFilenameFromContentDisposition('inline')).toBe(null);
+  });
+
+  it('parses a plain filename', () => {
+    expect(parseFilenameFromContentDisposition('attachment; filename="clip.wav"')).toBe('clip.wav');
+    expect(parseFilenameFromContentDisposition('attachment; filename=clip.wav')).toBe('clip.wav');
+  });
+
+  it('prefers and decodes the RFC 5987 UTF-8 form', () => {
+    expect(parseFilenameFromContentDisposition("attachment; filename*=UTF-8''my%20clip.wav")).toBe('my clip.wav');
+  });
+});
+
+describe('browserDownload', () => {
+  function makeDeps({ ok = true, disposition = null } = {}) {
+    const anchor = { href: '', download: '', click: vi.fn() };
+    const body = { appendChild: vi.fn(), removeChild: vi.fn() };
+    const fetch = vi.fn(async () => ({
+      ok,
+      headers: { get: () => disposition },
+      blob: async () => new Blob(['data']),
+    }));
+    const document = { createElement: vi.fn(() => anchor), body };
+    const url = { createObjectURL: vi.fn(() => 'blob:local'), revokeObjectURL: vi.fn() };
+    return { deps: { fetch, document, url }, anchor, body, fetch, url };
+  }
+
+  it('downloads via a temporary <a> using the fallback name', async () => {
+    const { deps, anchor, url } = makeDeps();
+    const name = await browserDownload('http://x/audio/foo.wav', 'foo.wav', deps);
+    expect(name).toBe('foo.wav');
+    expect(anchor.download).toBe('foo.wav');
+    expect(anchor.href).toBe('blob:local');
+    expect(anchor.click).toHaveBeenCalledOnce();
+    expect(url.revokeObjectURL).toHaveBeenCalledWith('blob:local');
+  });
+
+  it('prefers the server-provided Content-Disposition filename', async () => {
+    const { deps, anchor } = makeDeps({ disposition: 'attachment; filename="server.mp3"' });
+    const name = await browserDownload('http://x/audio/foo.wav', 'foo.wav', deps);
+    expect(name).toBe('server.mp3');
+    expect(anchor.download).toBe('server.mp3');
+  });
+
+  it('throws when the response is not ok (so callers can surface an error toast)', async () => {
+    const { deps } = makeDeps({ ok: false });
+    await expect(browserDownload('http://x/missing', 'foo.wav', deps)).rejects.toThrow('Download failed');
+  });
+
+  // Regression for #256: in the Docker/browser build there is no Tauri shell,
+  // so the download path must never call the native save dialog (which throws
+  // "Cannot read properties of undefined (reading 'invoke')"). This helper is
+  // pure HTTP + DOM and works without any Tauri runtime present.
+  it('works with no Tauri globals defined', async () => {
+    expect(typeof window === 'undefined' || window.__TAURI_INTERNALS__).toBeFalsy();
+    const { deps } = makeDeps();
+    await expect(browserDownload('http://x/audio/foo.wav', 'foo.wav', deps)).resolves.toBe('foo.wav');
+  });
+});


### PR DESCRIPTION
## Problem

Issue #256 — in the **Docker** web build, downloading a freshly cloned voice (or any export-history item) crashes the UI:

```
TypeError: Cannot read properties of undefined (reading 'invoke')
```

`handleNativeExport` (export-history download button) called the Tauri `save` dialog **unconditionally**. The Docker image is the headless web-server build — there is no Tauri shell — so the dialog plugin's internal `invoke()` dereferences an undefined `window.__TAURI_INTERNALS__` and throws. `triggerDownload` already guarded on `isTauri`; `handleNativeExport` did not.

## Fix

- New shared helper `frontend/src/utils/download.js`:
  - `browserDownload(url, fallbackName)` — plain HTTP-blob download via a temporary `<a download>`, prefers the server `Content-Disposition` filename. Deps are injectable for testing.
  - `parseFilenameFromContentDisposition()` — moved out of `App.jsx` (was a local dup).
- `handleNativeExport` now guards on `isTauri`. Outside Tauri it streams the file already served at `/audio/<path>` and records it in export history — no native dialog, no crash.
- `triggerDownload`'s browser branch reuses `browserDownload` instead of duplicating the blob logic.

## Tests

- `frontend/src/utils/download.test.js` — Content-Disposition parsing + the no-Tauri download path (regression guard for #256).
- Full suite: **192/192 pass**; `typecheck:ci` ✅; `bun run build` ✅.

## Cross-platform / constraints

Default behavior is identical on macOS/Windows/Linux desktop (still uses the native save dialog via the unchanged `isTauri` branch); the new branch only affects the browser/Docker context, where the native dialog was never reachable anyway. No backend or on-disk state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download and export functionality with better filename handling from server responses.
  * Enhanced fallback behavior for downloads when server-provided filenames are unavailable.

* **Tests**
  * Added comprehensive test coverage for download utilities and filename extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->