### PR TITLE
fix(version): surface running version in web/Docker UI + hide desktop-only updater (#249)

### DIFF
--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -15,6 +15,7 @@ import torch
 import shutil
 
 from core.config import OUTPUTS_DIR, DATA_DIR, CRASH_LOG_PATH, LOG_PATH, IDLE_TIMEOUT_SECONDS
+from core.version import APP_VERSION
 from services.model_manager import get_model_status, get_best_device
 from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
 
@@ -168,6 +169,7 @@ def system_info():
     try:
         _ffmpeg = find_ffmpeg()
         return {
+            "app_version": APP_VERSION,
             "data_dir": DATA_DIR,
             "outputs_dir": OUTPUTS_DIR,
             "crash_log_path": CRASH_LOG_PATH,
@@ -193,6 +195,7 @@ def system_info():
     except Exception as e:
         logger.exception("system_info failed — returning safe defaults")
         return {
+            "app_version": APP_VERSION,
             "data_dir": DATA_DIR,
             "outputs_dir": OUTPUTS_DIR,
             "crash_log_path": str(CRASH_LOG_PATH),

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -25,6 +25,7 @@ class SystemInfoResponse(BaseModel):
     """GET /system/info"""
     model_config = ConfigDict(extra="allow")
 
+    app_version: str = ""
     data_dir: str
     outputs_dir: str
     crash_log_path: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -606,7 +606,7 @@ def health():
     elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         device = "mps"
 
-    return {"status": "ok", "device": device}
+    return {"status": "ok", "device": device, "version": APP_VERSION}
 
 
 app.include_router(system.router)

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -115,7 +115,9 @@ Two paths are worth persisting across container restarts:
 - **Container reports 0.2.7 but image is tagged 0.3.x:** This was a workflow bug
   (fixes #249, #251) — the `:latest` tag was not being updated on release tag
   pushes. Pull the image again after the fix is merged: `docker pull ghcr.io/debpalash/omnivoice-studio:latest`.
-- **Checking which version is running:** `docker exec omnivoice python -c "import importlib.metadata; print(importlib.metadata.version('omnivoice-studio'))"` or visit the `/health` endpoint which includes the version field.
+  The running version is now shown in **Settings → About → Version** (read live
+  from the backend), so the web UI no longer displays a dash in Docker.
+- **Checking which version is running:** `docker exec omnivoice python -c "import importlib.metadata; print(importlib.metadata.version('omnivoice'))"`, or hit the `/health` endpoint — it returns `{"status": "ok", "device": ..., "version": "0.3.x"}`.
 - **Media-preview 404 in LAN mode:** see the [LAN access](#lan-access) section
   above — the `window.location.host` fix shipped in v0.3.
 - **GPU not detected:** verify `docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi` succeeds first.

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1352,7 +1352,7 @@ export default function Settings() {
         <section className="settings-section">
           <h2><Info size={16} color="#8ec07c" /> {t('settings.about')}</h2>
           <Row label={t('about.app')}             value="OmniVoice Studio" />
-          <Row label={t('about.version')}         value={appVersion || '—'} mono />
+          <Row label={t('about.version')}         value={appVersion || info?.app_version || '—'} mono />
           <Row label={t('about.tauri_runtime')}   value={tauriVersion || (isTauri() ? '—' : t('about.web_preview'))} mono />
           <Row label={t('about.platform')}        value={info?.platform || '—'} />
           <Row label={t('about.architecture')}    value={typeof navigator !== 'undefined' ? (navigator.userAgentData?.platform || navigator.platform || '—') : '—'} mono />
@@ -1371,41 +1371,49 @@ export default function Settings() {
           <Row label={t('about.data_dir')}        value={info?.data_dir || '—'} mono />
           <Row label={t('about.outputs')}         value={info?.outputs_dir || '—'} mono />
           <Row label={t('about.crash_log')}       value={info?.crash_log_path || '—'} mono />
-          <Row
-            label={t('about.update_channel')}
-            value={
-              <Segmented
-                size="xs"
-                value={updateChannel}
-                onChange={changeChannel}
-                items={[
-                  { value: 'stable',  label: t('about.channel_stable') },
-                  { value: 'preview', label: t('about.channel_preview') },
-                ]}
+          {/* Auto-updater + channel toggle are desktop-only (Tauri). The Docker
+              web build updates by pulling a new image tag, so hide these rows
+              there to avoid a non-functional control (issue #249). */}
+          {isTauri() && (
+            <>
+              <Row
+                label={t('about.update_channel')}
+                value={
+                  <Segmented
+                    size="xs"
+                    value={updateChannel}
+                    onChange={changeChannel}
+                    items={[
+                      { value: 'stable',  label: t('about.channel_stable') },
+                      { value: 'preview', label: t('about.channel_preview') },
+                    ]}
+                  />
+                }
               />
-            }
-          />
-          <Row
-            label={t('about.update_endpoint')}
-            value={updateChannel === 'preview'
-              ? 'releases/download/preview/latest.json'
-              : 'releases/latest/download/latest.json'}
-            mono
-          />
-          {updateChannel === 'preview' && (
-            <p className="settings-muted">{t('about.channel_preview_hint')}</p>
+              <Row
+                label={t('about.update_endpoint')}
+                value={updateChannel === 'preview'
+                  ? 'releases/download/preview/latest.json'
+                  : 'releases/latest/download/latest.json'}
+                mono
+              />
+              {updateChannel === 'preview' && (
+                <p className="settings-muted">{t('about.channel_preview_hint')}</p>
+              )}
+            </>
           )}
           <div className="settings-link-row">
-            <Button
-              variant="primary"
-              size="md"
-              leading={<Download size={12} />}
-              onClick={checkForUpdates}
-              loading={updateState === 'checking' || updateState === 'downloading'}
-              disabled={!isTauri()}
-            >
-              {updateState === 'downloading' ? t('about.downloading') : t('about.check_updates')}
-            </Button>
+            {isTauri() && (
+              <Button
+                variant="primary"
+                size="md"
+                leading={<Download size={12} />}
+                onClick={checkForUpdates}
+                loading={updateState === 'checking' || updateState === 'downloading'}
+              >
+                {updateState === 'downloading' ? t('about.downloading') : t('about.check_updates')}
+              </Button>
+            )}
             <Button
               variant="subtle"
               size="md"

--- a/tests/test_router_smoke.py
+++ b/tests/test_router_smoke.py
@@ -33,6 +33,18 @@ def test_system_info_smoke(client):
     body = r.json()
     assert "data_dir" in body
     assert "device" in body
+    # The Docker/web build has no Tauri getVersion(); Settings → About reads the
+    # running version from here so it shows the real version, not a dash (#249).
+    from core.version import APP_VERSION
+    assert body["app_version"] == APP_VERSION
+
+
+def test_health_exposes_version(client):
+    """`/health` is the zero-auth way to confirm the running version (#249)."""
+    from core.version import APP_VERSION
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["version"] == APP_VERSION
 
 
 def test_system_logs_smoke(client):


### PR DESCRIPTION
## Problem

Issue #249 — in the **Docker** web build:
1. **Settings → About → Version showed a dash (`—`)** instead of a version. The version came from Tauri's `getVersion()`, which is `null` outside the desktop shell, so users couldn't tell which version was running (compounded by the now-fixed stale `:latest` tag, #252).
2. The **update-channel toggle / "Check for updates"** were shown even though the auto-updater is desktop-only (Docker updates by pulling a new image tag).

## Changes

**Backend — expose the single-source `APP_VERSION` over HTTP** (it already drives the FastAPI/OpenAPI version, but no plain endpoint returned it):
- `/system/info` → adds `app_version` (used by the About tab).
- `/health` → adds `version` (zero-auth, model-free; makes the docs' long-standing "/health includes the version field" claim actually true).

**Frontend (`Settings.jsx`):**
- Version row falls back to `info.app_version` when Tauri `getVersion()` is unavailable → Docker now shows the real `0.3.x`.
- Update-channel toggle, update-endpoint row, and "Check for updates" button are now gated on `isTauri()` (hidden in the web/Docker build), consistent with the existing docker.md note that the updater is desktop-only.

**Docs (`docs/install/docker.md`):**
- Fixed the version-check command — the package name is `omnivoice`, not `omnivoice-studio` (the old command would raise `PackageNotFoundError`).
- Documented the new `/health` `version` field and the in-UI version row.

## Tests

`tests/test_router_smoke.py` now asserts `/system/info.app_version` and `/health.version` both equal `APP_VERSION`. Local: backend smoke ✅, frontend `typecheck:ci` ✅, `build` ✅, updater tests ✅.

## Notes / constraints

- The stale `:latest` Docker tag itself was fixed in #252; cutting a `v0.3.x` release repopulates `:latest`/`:0.3` with an image that reports the correct version.
- Cross-platform: desktop behavior is unchanged (Tauri `getVersion()` still wins, updater UI still shows). The hidden-in-web rows are a platform-only (desktop) feature kept behind the `isTauri()` gate per PROJECT.md's default-features rule. No DB/schema or on-disk changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application version now displayed in Settings → About section
  * Version information exposed through API endpoints

* **Documentation**
  * Updated Docker installation guide with current version display details

* **Tests**
  * Added tests verifying version information accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->