### PR TITLE
fix(dub): surface real ASR/model-load failures instead of dropping the stream (#255)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -384,24 +384,39 @@ async def dub_transcribe_stream(job_id: str):
     if not job:
         preflight_error = "Job not found. It may have been cleaned up or was never created."
     else:
-        _model = await get_model()
-        asr_audio_target = job.get("vocals_path")
-        if not asr_audio_target or not os.path.exists(asr_audio_target):
-            asr_audio_target = job.get("audio_path")
-        if not asr_audio_target or not os.path.exists(asr_audio_target):
-            preflight_error = "No audio available for transcription."
-        else:
-            from services.asr_backend import get_active_asr_backend
-            try:
-                _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
-                if _asr_backend.id == "pytorch-whisper" and getattr(_model, "_asr_pipe", None) is None:
-                    preflight_error = (
-                        "No ASR backend is ready. Install WhisperX/faster-whisper/MLX Whisper "
-                        "or set OMNIVOICE_PRELOAD_TTS_ASR=1 before launch to use the PyTorch fallback."
+        # Guard the model load: if it raises, the SSE stream would otherwise die
+        # before emitting any event, and the UI shows a misleading generic
+        # "stream dropped" message instead of the real cause (issue #255).
+        try:
+            _model = await get_model()
+        except Exception as e:
+            logger.exception("transcribe preflight: model load failed (job=%s)", job_id)
+            from core.failure import build_failure
+            f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
+            preflight_error = f["reason"] + (f" — {f['hint']}" if f.get("hint") else "")
+            _model = None
+        if _model is not None:
+            asr_audio_target = job.get("vocals_path")
+            if not asr_audio_target or not os.path.exists(asr_audio_target):
+                asr_audio_target = job.get("audio_path")
+            if not asr_audio_target or not os.path.exists(asr_audio_target):
+                preflight_error = "No audio available for transcription."
+            else:
+                from services.asr_backend import get_active_asr_backend
+                try:
+                    _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
+                    if _asr_backend.id == "pytorch-whisper" and getattr(_model, "_asr_pipe", None) is None:
+                        preflight_error = (
+                            "No ASR backend is ready. Install WhisperX/faster-whisper/MLX Whisper "
+                            "or set OMNIVOICE_PRELOAD_TTS_ASR=1 before launch to use the PyTorch fallback."
+                        )
+                except Exception as e:
+                    from core.failure import build_failure
+                    f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
+                    preflight_error = "ASR backend initialization failed: " + f["reason"] + (
+                        f" — {f['hint']}" if f.get("hint") else ""
                     )
-            except Exception as e:
-                preflight_error = f"ASR backend initialization failed: {e}"
-            scene_cuts = job.get("scene_cuts") or []
+                scene_cuts = job.get("scene_cuts") or []
 
     async def gen():
         if preflight_error:
@@ -429,7 +444,12 @@ async def dub_transcribe_stream(job_id: str):
 
         # Free VRAM: move TTS model to CPU so WhisperX + VAD can fit.
         # Only offloads when free GPU memory is < 4 GB (e.g. laptop GPUs).
-        await loop.run_in_executor(_cpu_pool, offload_tts_for_asr)
+        # Non-fatal: an offload failure must not drop the stream (#255) —
+        # transcription can still proceed (it just has less headroom).
+        try:
+            await loop.run_in_executor(_cpu_pool, offload_tts_for_asr)
+        except Exception as e:
+            logger.warning("offload_tts_for_asr failed (continuing): %s", e)
 
         all_segments: list[dict] = []
         detected_lang = None
@@ -540,15 +560,23 @@ async def dub_transcribe_stream(job_id: str):
         # whisperx's VAD load, or an unsupported audio format.
         if not all_segments:
             # Deduplicate while preserving order so one root cause doesn't
-            # repeat N times in the UI toast.
+            # repeat N times in the UI toast. Sanitize each message so home
+            # paths / tokens from a backend traceback never leak (#255).
+            from core.failure import sanitize, build_failure
             seen = set()
             uniq: list[str] = []
             for msg in chunk_errors:
-                if msg and msg not in seen:
-                    seen.add(msg)
-                    uniq.append(msg)
+                s = sanitize(msg)
+                if s and s not in seen:
+                    seen.add(s)
+                    uniq.append(s)
             if uniq:
                 detail = "Transcription produced no segments. " + " | ".join(uniq[:3])
+                # Add the actionable hint for a recognized failure class
+                # (e.g. pkg_resources missing → install setuptools).
+                hint = build_failure(" ".join(uniq), stage="transcribe", include_diagnostic=False).get("hint")
+                if hint:
+                    detail += f" — {hint}"
             else:
                 detail = (
                     "Transcription produced no segments. The audio may be silent, "

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -109,6 +109,24 @@ def _seed_job(dc_module, tmp_path: Path, duration: float, scene_cuts=None) -> st
 # Tests
 # ---------------------------------------------------------------------------
 
+def test_transcribe_stream_surfaces_model_load_failure(app_client):
+    """Regression #255: when the model fails to load, the SSE transcribe stream
+    must emit a structured `error` event carrying the real cause — not silently
+    drop the connection (the UI renders a dropped stream as a misleading generic
+    "Transcribe stream dropped … Likely ASR backend failed to load")."""
+    client, dc, tmp = app_client
+    job_id = _seed_job(dc, tmp, duration=4.0)
+
+    async def _boom():
+        raise RuntimeError("CUDA driver init failed: simulated")
+
+    dc.get_model = _boom  # the fixture reloads dc fresh per test
+
+    body = client.get(f"/dub/transcribe-stream/{job_id}").text
+    assert "event: error" in body, body
+    assert "CUDA driver init failed: simulated" in body, body
+
+
 @pytest.mark.xfail(
     reason="dub_core._transcribe was refactored to route through "
            "services.asr_backend.get_active_asr_backend; the MagicMock fixture "

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -109,20 +109,39 @@ def _seed_job(dc_module, tmp_path: Path, duration: float, scene_cuts=None) -> st
 # Tests
 # ---------------------------------------------------------------------------
 
-def test_transcribe_stream_surfaces_model_load_failure(app_client):
+def test_transcribe_stream_surfaces_model_load_failure(tmp_path, monkeypatch):
     """Regression #255: when the model fails to load, the SSE transcribe stream
     must emit a structured `error` event carrying the real cause — not silently
     drop the connection (the UI renders a dropped stream as a misleading generic
-    "Transcribe stream dropped … Likely ASR backend failed to load")."""
-    client, dc, tmp = app_client
-    job_id = _seed_job(dc, tmp, duration=4.0)
+    "Transcribe stream dropped … Likely ASR backend failed to load").
+
+    Drives the route's async generator directly (no TestClient/lifespan) — the
+    preflight-error path yields a single event with no executor/Queue, so it
+    stays isolated from the app event loop.
+    """
+    import asyncio
+    from api.routers import dub_core as dc
+
+    job_id = "t_modelfail"
+    dc._dub_jobs[job_id] = {"audio_path": str(tmp_path / "a.wav"), "vocals_path": None}
 
     async def _boom():
         raise RuntimeError("CUDA driver init failed: simulated")
 
-    dc.get_model = _boom  # the fixture reloads dc fresh per test
+    monkeypatch.setattr(dc, "get_model", _boom)
 
-    body = client.get(f"/dub/transcribe-stream/{job_id}").text
+    async def _collect():
+        resp = await dc.dub_transcribe_stream(job_id)
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk))
+        return "".join(parts)
+
+    try:
+        body = asyncio.run(_collect())
+    finally:
+        dc._dub_jobs.pop(job_id, None)
+
     assert "event: error" in body, body
     assert "CUDA driver init failed: simulated" in body, body
 


### PR DESCRIPTION
## Problem

Issue #255 — on Windows the transcribe step fails with a **misleading** message:

> Transcribe stream dropped before emitting any segments. Likely ASR backend failed to load — check backend log + Settings → Models.

That string is the **frontend's generic fallback** (`useDubWorkflow.js`), shown only when the SSE `transcribe-stream` closes **without** a structured `error` event. The per-chunk transcribe was already wrapped (so `pkg_resources` / load errors *inside* a chunk surface as real messages), but two calls in the stream generator were **not** guarded — if either raised, the connection dropped with no event, and the user never saw the real cause.

## Changes (`backend/api/routers/dub_core.py`)

- **`get_model()` preflight** is now wrapped. On failure it emits a structured `error` event built via `core.failure.build_failure` — a **sanitized** reason (no home paths / tokens) plus the actionable hint (e.g. the `pkg_resources` → "install setuptools" hint, deep-linkable via the existing docs taxonomy).
- **`offload_tts_for_asr()`** is now **non-fatal** — an offload hiccup logs a warning and transcription continues, instead of dropping the stream.
- The **empty-segments guard** sanitizes each chunk error and appends the recognized-failure-class hint.

## Test

`tests/test_dub_transcribe.py::test_transcribe_stream_surfaces_model_load_failure` — a raising `get_model()` must yield a structured `error` SSE event carrying the real message (not a dropped connection). Local: 49 related tests pass.

## Why this doesn't `close` #255

I can't reproduce the reporter's Windows-CUDA environment, so this is a **diagnostics fix**, not a claimed root-cause fix. After this lands, the reporter will see the *actual* failure (most likely a faster-whisper/CTranslate2 **cuDNN 8** load error — `backend/main.py` already side-loads `cudnn8_compat/` libs, so a `.venv` missing those would fail natively). I've asked on the issue for the surfaced message / backend log to confirm and follow up.

Cross-platform: pure error-path hardening; the happy path and all backends are unchanged. No schema/DB/on-disk changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transcription streaming now reports model-loading and backend init failures with structured, user-facing error details and hints instead of failing silently.
  * GPU offload for TTS-before-ASR is non-fatal: offload issues are logged as warnings and no longer abort transcription.
  * Chunk-level transcription errors are sanitized, deduplicated, and surfaced with actionable hints when possible.

* **Tests**
  * Added regression test to assert proper error reporting when model load fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->