### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [0.3.1] — 2026-06-03
+
+First tagged build of the 0.3 line off `main` — it ships the accumulated
+`[0.3.0]` work below plus the fixes here. (The `[0.3.0]` milestone heading is
+kept for the qualitative "actually useful" release.)
+
+### Fixed
+- **Voice-clone / export download crashed in the Docker & browser build** with
+  `TypeError: Cannot read properties of undefined (reading 'invoke')`. The
+  export button called the Tauri save dialog unconditionally; outside the
+  desktop shell it now falls back to a standard browser download of the file
+  served at `/audio/<path>`. (#256)
+- **Docker container showed no version** (a dash) in Settings → About, and the
+  desktop-only update-channel toggle appeared in the web build. The running
+  version is now read from the backend (`/system/info` `app_version`, `/health`
+  `version`); the updater UI is hidden outside Tauri. Also corrected the
+  version-check command in the Docker docs (`omnivoice`, not
+  `omnivoice-studio`). (#249)
+- **Transcription failures were masked** by a generic "Transcribe stream
+  dropped" message. The transcribe SSE stream now surfaces the real, sanitized
+  cause (with an actionable hint) instead of silently dropping when model load
+  or VRAM offload fails. (#255)
+
 ## [0.3.0] — Unreleased
 
 ### Added

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -12,4 +12,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     APP_VERSION = version("omnivoice")
 except PackageNotFoundError:  # non-installed source checkout
-    APP_VERSION = "0.3.0"
+    APP_VERSION = "0.3.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs-next",
  "enigo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.0"
+version = "0.3.1"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.0"
+version = "0.3.1"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Source-available under FSL-1.1-ALv2 (see LICENSE); each release converts to

--- a/uv.lock
+++ b/uv.lock
@@ -3058,7 +3058,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
First tagged build of the **0.3 line** off `main`. Version bumped across all sources (pyproject, frontend `package.json`, `tauri.conf.json`, `Cargo.toml` + `Cargo.lock`, `uv.lock`, and the source-checkout fallback in `core/version.py`); `uv lock --check` passes so the release's `--frozen` installs hold.

The `[0.3.0]` CHANGELOG heading is intentionally **left in place** as the qualitative "actually useful" milestone — `v0.3.1` is the first shipped increment.

### Ships
- **#256** — browser/Docker file-export crash (`invoke` undefined)
- **#249** — running version surfaced in the web/Docker UI; desktop-only updater UI hidden
- **#255** — transcribe stream now surfaces the real ASR/model-load failure instead of dropping

### On merge
Tagging `v0.3.1` triggers `release.yml` (desktop binaries, macOS/Windows/Linux) and `docker.yml` (GHCR `:0.3.1`, `:0.3`, `:latest`) — which also repopulates the stale `:latest` from #249/#252 with an image that correctly reports `0.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.3.1

* **Bug Fixes**
  * Fixed export/download crash in Docker and browser environments
  * Corrected version display and removed desktop-specific UI elements from non-desktop builds
  * Improved transcription error messages to display actual error causes instead of generic fallback messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->