### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [0.3.2] — 2026-06-03
+
+### Fixed
+- **"Loopback origin required" all over the Docker UI** (and a blank version).
+  The `/system/*` and `/api/settings/*` routes are restricted to a loopback
+  origin, but Docker's NAT makes every request look non-loopback, so the gate
+  403'd the operator out of the admin UI — including `/system/info` (blanking
+  the version) and HF-token entry. The Docker image now runs with
+  `OMNIVOICE_SERVER_MODE=1`, which relaxes the gate for the headless
+  deployment; exposure is governed by the `-p` port mapping plus the optional
+  share PIN. Desktop builds are unaffected — their loopback boundary (and the
+  denial of admin routes to LAN share guests) is unchanged. (#261)
+
 ## [0.3.1] — 2026-06-03
 
 First tagged build of the 0.3 line off `main` — it ships the accumulated

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -12,4 +12,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     APP_VERSION = version("omnivoice")
 except PackageNotFoundError:  # non-installed source checkout
-    APP_VERSION = "0.3.1"
+    APP_VERSION = "0.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs-next",
  "enigo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.1"
+version = "0.3.2"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.1"
+version = "0.3.2"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Source-available under FSL-1.1-ALv2 (see LICENSE); each release converts to

--- a/uv.lock
+++ b/uv.lock
@@ -3058,7 +3058,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Patch release. Version bumped across all sources + lock files (`uv lock --check` passes).

### Ships
- **#261** — "Loopback origin required" 403s broke the Docker admin UI (and re-blanked the version). The image now runs with `OMNIVOICE_SERVER_MODE=1`, relaxing the loopback gate for the headless deployment (exposure governed by port mapping + optional share PIN). Desktop loopback boundary unchanged.

### On merge
Tagging `v0.3.2` triggers `release.yml` (desktop binaries) and `docker.yml` (GHCR `:0.3.2`/`:0.3`/`:latest`). I'll verify the builds and then close #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker UI incorrectly enforcing loopback-origin restriction in headless deployments. Exposure control remains via port mapping and optional share PIN.

* **Chores**
  * Version bumped to 0.3.2 across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->