### PR TITLE
fix(ci): make SHA-256 checksum step bash-3.2 safe (macOS runner)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,7 +540,13 @@ jobs:
 
           # Gather artifact paths per matrix leg's `bundles` (msi/app/dmg/deb/appimage/updater).
           # `find` is portable across all three runners (Git Bash on Windows).
-          mapfile -t ARTIFACTS < <(find "$BUNDLE_DIR" -type f \
+          # NB: macOS runners use /bin/bash 3.2, which has no `mapfile` (a bash 4+
+          # builtin) — using it 127'd this step and dropped the macOS SHA256SUMS
+          # for v0.3.1 and v0.3.2. A `while read` loop is portable to bash 3.2.
+          ARTIFACTS=()
+          while IFS= read -r artifact; do
+            ARTIFACTS+=("$artifact")
+          done < <(find "$BUNDLE_DIR" -type f \
             \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.app.tar.gz.sig" \
                -o -name "*.msi" -o -name "*.msi.sig" \
                -o -name "*.AppImage" -o -name "*.AppImage.sig" \


### PR DESCRIPTION
## Problem

The release workflow's **"Compute SHA-256 checksums"** step used `mapfile -t` (a **bash 4+** builtin), but macOS GitHub runners execute `shell: bash` as **/bin/bash 3.2**, which has no `mapfile`. The macOS leg exited **127** (`mapfile: command not found`), so `SHA256SUMS-macOS Apple Silicon.txt` was never generated/uploaded for **v0.3.1** and **v0.3.2** — I had to regenerate and upload it by hand both times. (The binaries + signatures + `latest.json` always shipped fine; only the macOS checksum file was missing.)

## Fix

Replace `mapfile` with a portable `while IFS= read -r … done < <(find … | sort)` loop, which works on bash 3.2. Verified locally on `GNU bash 3.2.57`: builds the array correctly and handles spaces in bundle filenames. Linux/Windows legs unchanged.

This only runs on `v*` tag pushes, so it can't be exercised by PR CI — but the YAML is valid and the bash was tested against an actual 3.2 shell. The next release's macOS checksum file will upload automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checksum generation for release artifacts that previously failed for certain tagged releases, ensuring reliable artifact validation across all deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->