### PR TITLE
fix(about): show server CPU arch, not the client browser's platform (#262)

### DIFF
--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 import uuid
 import psutil
 import asyncio
@@ -181,6 +182,7 @@ def system_info():
             "device": get_best_device(),
             "python": sys.version.split()[0],
             "platform": sys.platform,
+            "arch": platform.machine(),
             "ffmpeg_ok": bool(_ffmpeg),
             "ffmpeg_path": _ffmpeg or "",
             "proxy_url": os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy") or "",
@@ -207,6 +209,7 @@ def system_info():
             "device": "cpu",
             "python": sys.version.split()[0],
             "platform": sys.platform,
+            "arch": platform.machine(),
             "proxy_url": "",
             "share_enabled": network_share.get_state().enabled,
             "share_port": network_share.get_state().share_port,

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -37,6 +37,7 @@ class SystemInfoResponse(BaseModel):
     device: str = "cpu"
     python: str = ""
     platform: str = ""
+    arch: str = ""
     error: str | None = None
     ffmpeg_ok: bool = False
     ffmpeg_path: str = ""

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -60,6 +60,7 @@ export interface SystemInfo {
   app_version?: string;
   python?: string;
   platform?: string;
+  arch?: string;
   device?: string;
   data_dir?: string;
   outputs_dir?: string;

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1355,7 +1355,7 @@ export default function Settings() {
           <Row label={t('about.version')}         value={appVersion || info?.app_version || '—'} mono />
           <Row label={t('about.tauri_runtime')}   value={tauriVersion || (isTauri() ? '—' : t('about.web_preview'))} mono />
           <Row label={t('about.platform')}        value={info?.platform || '—'} />
-          <Row label={t('about.architecture')}    value={typeof navigator !== 'undefined' ? (navigator.userAgentData?.platform || navigator.platform || '—') : '—'} mono />
+          <Row label={t('about.architecture')}    value={info?.arch || '—'} mono />
           <Row label={t('about.python')}          value={info?.python || '—'} mono />
           <Row label={t('about.compute_device')}  value={info?.device || '—'} mono />
           <Row label={t('about.gpu_active')}      value={hw?.gpu_active

--- a/tests/test_router_smoke.py
+++ b/tests/test_router_smoke.py
@@ -37,6 +37,10 @@ def test_system_info_smoke(client):
     # running version from here so it shows the real version, not a dash (#249).
     from core.version import APP_VERSION
     assert body["app_version"] == APP_VERSION
+    # Settings → About → Architecture must reflect the SERVER's machine, not the
+    # client browser's navigator.platform (which showed "Win32" in Docker, #262).
+    import platform as _pf
+    assert body["arch"] == _pf.machine()
 
 
 def test_health_exposes_version(client):


### PR DESCRIPTION
## Problem

Issue #262 — Settings → About on Docker showed **incorrect architecture** ("Win32") plus blank version/GPU/RAM/VRAM.

Two distinct causes:
1. **Blank version / GPU / RAM / VRAM** — the `/system/info` and `/sysinfo` routes were 403ing in Docker (the loopback gate). **Already fixed in v0.3.2 (#261)** — pull `:latest`.
2. **Wrong architecture** (this PR) — the "Architecture" row rendered `navigator.platform`, i.e. the **client browser's** OS. In a Docker/web deployment that's the remote machine (e.g. "Win32" when browsing from Windows), not the container.

## Fix

Expose the **server's** `platform.machine()` as `arch` on `/system/info` (+ schema + TS type), and render `info.arch` in the Architecture row. Correct for both the desktop app (local backend → the desktop's arch) and Docker (→ the container's arch, e.g. `x86_64`/`aarch64`).

## Tests
`test_router_smoke.py` now asserts `/system/info.arch == platform.machine()`. Local: backend ✅, `typecheck:ci` ✅, `bun run build` ✅. No DB/schema changes.

Addresses #262 (the architecture half; the blank-fields half shipped in v0.3.2). Will verify + close after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System information now displays server-reported architecture in the About section, providing accurate system details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->