### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [0.3.3] — 2026-06-03
+
+### Fixed
+- **Settings → About showed the wrong architecture in the Docker/web build.**
+  The "Architecture" row rendered the *client browser's* platform
+  (`navigator.platform` → e.g. "Win32"); it now reports the **server's** CPU
+  architecture from the backend (`platform.machine()`), correct for both the
+  desktop app and Docker. The blank version/GPU/RAM/VRAM in the same report
+  were the loopback-gate 403s already fixed in v0.3.2. (#262)
+
+### CI
+- The release SHA-256 checksum step no longer uses `mapfile` (a bash 4+
+  builtin) — it broke on the macOS runner's bash 3.2 and dropped the macOS
+  `SHA256SUMS` for v0.3.1/v0.3.2. Now portable to bash 3.2.
+
 ## [0.3.2] — 2026-06-03
 
 ### Fixed

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -12,4 +12,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     APP_VERSION = version("omnivoice")
 except PackageNotFoundError:  # non-installed source checkout
-    APP_VERSION = "0.3.2"
+    APP_VERSION = "0.3.3"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "dirs-next",
  "enigo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.2"
+version = "0.3.3"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.2"
+version = "0.3.3"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Source-available under FSL-1.1-ALv2 (see LICENSE); each release converts to

--- a/uv.lock
+++ b/uv.lock
@@ -3058,7 +3058,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Patch release. Version bumped across all sources + lock files (`uv lock --check` passes).

### Ships
- **#262** — Settings → About → Architecture now reports the **server's** CPU arch (was the client browser's `navigator.platform`, e.g. "Win32", in Docker). The blank version/GPU/RAM/VRAM in that report were already fixed in v0.3.2 (#261).
- First release exercising the **bash-3.2 checksum CI fix** (#265) — the macOS `SHA256SUMS` file should now upload automatically (it was dropped in v0.3.1/v0.3.2 and patched by hand).

### On merge
Tag `v0.3.3` → desktop + docker builds. I'll confirm the macOS checksum auto-uploads this time, then close #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Settings → About "Architecture" row to correctly display backend server CPU architecture in Docker and web builds.
  * Improved CI release process compatibility with macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->