### PR TITLE
fix(asr): PyTorch-Whisper fallback works without cuDNN 8 or preload (#255)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -404,12 +404,11 @@ async def dub_transcribe_stream(job_id: str):
             else:
                 from services.asr_backend import get_active_asr_backend
                 try:
+                    # The PyTorch-Whisper backend lazily builds its own pipeline
+                    # when no preloaded `_asr_pipe` is present (issue #255), so it
+                    # no longer needs OMNIVOICE_PRELOAD_TTS_ASR=1 — don't reject it
+                    # here; any load failure surfaces per-chunk with a real cause.
                     _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
-                    if _asr_backend.id == "pytorch-whisper" and getattr(_model, "_asr_pipe", None) is None:
-                        preflight_error = (
-                            "No ASR backend is ready. Install WhisperX/faster-whisper/MLX Whisper "
-                            "or set OMNIVOICE_PRELOAD_TTS_ASR=1 before launch to use the PyTorch fallback."
-                        )
                 except Exception as e:
                     from core.failure import build_failure
                     f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -577,22 +577,32 @@ class PyTorchWhisperBackend(ASRBackend):
     def _ensure_pipe(self):
         if self._pipe is not None:
             return
-        # Fall back to grabbing the TTS model's ASR head.
-        import asyncio
-        from services.model_manager import get_model
-        try:
-            loop = asyncio.get_running_loop()
-            if loop.is_running():
-                raise RuntimeError(
-                    "PyTorchWhisperBackend needs the ASR pipe — pass it via constructor "
-                    "when calling from an async context."
-                )
-            model = loop.run_until_complete(get_model())
-        except RuntimeError:
-            model = asyncio.run(get_model())
-        self._pipe = getattr(model, "_asr_pipe", None)
-        if self._pipe is None:
-            raise RuntimeError("Loaded TTS model has no `_asr_pipe` attribute.")
+        # Build a standalone transformers Whisper pipeline on demand. This runs
+        # on PyTorch's own stack (cuDNN 9 ships with torch), so it works as a
+        # fallback on machines where WhisperX / faster-whisper can't load
+        # cuDNN 8 (the `cudnn_ops_infer64_8.dll` failure, issue #255) — and it
+        # needs neither OMNIVOICE_PRELOAD_TTS_ASR=1 nor a loaded TTS model.
+        # When the TTS model already has an ASR head, dub_core passes it via the
+        # constructor and this path is skipped.
+        import torch
+        from transformers import pipeline as hf_pipeline
+        from services.model_manager import get_best_device
+
+        model_name = os.environ.get(
+            "OMNIVOICE_PYTORCH_ASR_MODEL", "openai/whisper-large-v3-turbo"
+        )
+        device = get_best_device()
+        asr_dtype = torch.float16 if str(device).startswith("cuda") else torch.float32
+        logger.info(
+            "PyTorchWhisperBackend: loading standalone ASR pipeline %s on %s",
+            model_name, device,
+        )
+        self._pipe = hf_pipeline(
+            "automatic-speech-recognition",
+            model=model_name,
+            dtype=asr_dtype,
+            device_map=device,
+        )
 
     def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
         import soundfile as sf

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -121,7 +121,24 @@ falling back to faster-whisper`.
 path and is still fast. If you want the latest CT2 wheels, run `uv sync`
 from a fresh source checkout.
 
-## 10. IndexTTS / CosyVoice / ChatterboxTTS clash
+## 10. Windows: `Could not locate cudnn_ops_infer64_8.dll` during transcription
+
+**Symptom:** on Windows + NVIDIA, transcription/dubbing fails and the backend
+log shows `Could not locate cudnn_ops_infer64_8.dll`. Settings → Models shows
+WhisperX or faster-whisper selected.
+
+**Cause:** WhisperX and faster-whisper run on **CTranslate2**, which needs
+**cuDNN 8**, but PyTorch 2.8 ships cuDNN 9. OmniVoice side-loads a cuDNN-8 copy
+from `.venv\Lib\site-packages\cudnn8_compat\`; if that folder is missing
+(some upgrade paths don't install it), CTranslate2 can't find the DLL.
+
+**Fix:** switch the ASR backend to **PyTorch Whisper** in **Settings → Models**.
+It runs on PyTorch's own stack (cuDNN 9, bundled with torch) and needs no
+cuDNN-8 DLL — it loads its Whisper pipeline on demand (no extra env var). To
+keep using faster-whisper/WhisperX instead, reinstall to restore the bundled
+`cudnn8_compat` libraries.
+
+## 11. IndexTTS / CosyVoice / ChatterboxTTS clash
 
 **Symptom:** installing one of these engines breaks the others — e.g. after
 installing CosyVoice, IndexTTS errors out with import conflicts.

--- a/tests/test_pytorch_whisper_fallback.py
+++ b/tests/test_pytorch_whisper_fallback.py
@@ -1,0 +1,83 @@
+"""PyTorch-Whisper backend must work as a standalone fallback (issue #255).
+
+On machines where WhisperX / faster-whisper can't load cuDNN 8
+(`cudnn_ops_infer64_8.dll` missing), the PyTorch-Whisper backend should build
+its own transformers pipeline on demand — without OMNIVOICE_PRELOAD_TTS_ASR=1
+and without loading the full TTS model.
+"""
+import sys
+import types
+
+import pytest
+
+from services import asr_backend as ab
+
+
+def test_is_available_when_transformers_present():
+    ok, msg = ab.PyTorchWhisperBackend.is_available()
+    assert ok is True
+    assert msg == "ready"
+
+
+def test_reuses_constructor_pipe_without_building(monkeypatch):
+    sentinel = object()
+    be = ab.PyTorchWhisperBackend(asr_pipe=sentinel)
+
+    def _boom(*a, **k):
+        raise AssertionError("must not build a pipeline when one was passed in")
+
+    # transformers.pipeline is imported lazily inside _ensure_pipe.
+    fake_tf = types.ModuleType("transformers")
+    fake_tf.pipeline = _boom
+    monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+
+    be._ensure_pipe()
+    assert be._pipe is sentinel
+
+
+def test_lazy_builds_standalone_pipeline(monkeypatch):
+    """No preloaded pipe → build a standalone transformers ASR pipeline, with no
+    call into the TTS model loader (get_model)."""
+    captured = {}
+
+    def fake_pipeline(task, **kw):
+        captured["task"] = task
+        captured["kw"] = kw
+        return lambda *a, **k: {"chunks": []}
+
+    fake_tf = types.ModuleType("transformers")
+    fake_tf.pipeline = fake_pipeline
+    monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+    monkeypatch.setattr("services.model_manager.get_best_device", lambda: "cpu")
+
+    # Guard: building the standalone pipe must NOT pull in the full TTS model.
+    import services.model_manager as mm
+
+    def _no_get_model(*a, **k):
+        raise AssertionError("standalone ASR build must not call get_model()")
+
+    monkeypatch.setattr(mm, "get_model", _no_get_model, raising=False)
+
+    be = ab.PyTorchWhisperBackend(asr_pipe=None)
+    be._ensure_pipe()
+
+    assert be._pipe is not None
+    assert captured["task"] == "automatic-speech-recognition"
+    assert captured["kw"]["model"]  # a concrete model name was chosen
+
+
+def test_pytorch_asr_model_overridable_via_env(monkeypatch):
+    captured = {}
+
+    def fake_pipeline(task, **kw):
+        captured["kw"] = kw
+        return object()
+
+    fake_tf = types.ModuleType("transformers")
+    fake_tf.pipeline = fake_pipeline
+    monkeypatch.setitem(sys.modules, "transformers", fake_tf)
+    monkeypatch.setattr("services.model_manager.get_best_device", lambda: "cpu")
+    monkeypatch.setenv("OMNIVOICE_PYTORCH_ASR_MODEL", "openai/whisper-small")
+
+    ab.PyTorchWhisperBackend(asr_pipe=None)._ensure_pipe()
+    assert captured["kw"]["model"] == "openai/whisper-small"


### PR DESCRIPTION
## Root cause (confirmed from the reporter's log)

```
Could not locate cudnn_ops_infer64_8.dll. Please make sure it is in your library path!
```

WhisperX & faster-whisper run on **CTranslate2**, which needs **cuDNN 8**, but PyTorch 2.8 ships cuDNN **9**. OmniVoice side-loads a cuDNN-8 copy from `.venv\Lib\site-packages\cudnn8_compat\`; the reporter's venv didn't have it, so the DLL couldn't be found. Their attempt to use the **PyTorch-Whisper** backend instead failed with *"set OMNIVOICE_PRELOAD_TTS_ASR=1"* — it only worked when the TTS model preloaded an ASR head.

## Fix

- **`PyTorchWhisperBackend._ensure_pipe()`** now builds its **own** transformers ASR pipeline on demand — PyTorch's stack (cuDNN 9, bundled with torch), **no CTranslate2 / cuDNN 8**, no full-TTS-model load, no `OMNIVOICE_PRELOAD_TTS_ASR=1`. A constructor-passed pipe (when the TTS model already has one) is still reused. Model overridable via `OMNIVOICE_PYTORCH_ASR_MODEL`.
- **dub_core preflight** no longer hard-rejects `pytorch-whisper` when no pipe is preloaded — it lazy-loads; any failure surfaces per-chunk with the real cause (the #259 path).

Net: a Windows box missing cuDNN 8 can switch ASR backend to **PyTorch Whisper** (Settings → Models) and transcription works.

## Tests
`tests/test_pytorch_whisper_fallback.py` — lazy standalone build, reuse of a passed-in pipe, **asserts no `get_model()` call** (doesn't drag in the TTS model), env override. Full `tests/` suite: **700 passed**.

## Scope / honesty
This is the cross-platform fallback that I can unit-test; I can't run real Whisper inference on the reporter's Windows/CUDA box, so **#255 stays open** until they confirm. Two follow-ups (separate, harder to verify): auto-detect skipping CTranslate2 backends when cuDNN 8 is absent, and making the `cudnn8_compat` install robust on upgrade (so faster-whisper itself works). Docs: troubleshooting entry #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for PyTorch Whisper ASR backend initialization
  * Added Windows troubleshooting guide for cuDNN compatibility issues

* **New Features**
  * PyTorch Whisper backend now supports lazy pipeline initialization
  * Configurable ASR model selection via environment variable

* **Tests**
  * Added comprehensive test coverage for PyTorch Whisper fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->