### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [0.3.4] — 2026-06-03
+
+### Fixed
+- **Transcription on Windows + NVIDIA failed with `Could not locate
+  cudnn_ops_infer64_8.dll`.** WhisperX/faster-whisper need cuDNN 8 (via
+  CTranslate2); when the side-loaded `cudnn8_compat` libs are missing, the
+  **PyTorch Whisper** backend (Settings → Models) now works as a drop-in
+  fallback — it builds its own transformers pipeline on PyTorch's cuDNN-9
+  stack, with no CTranslate2/cuDNN-8 dependency and no
+  `OMNIVOICE_PRELOAD_TTS_ASR=1` required. (#255)
+
 ## [0.3.3] — 2026-06-03
 
 ### Fixed

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -12,4 +12,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     APP_VERSION = version("omnivoice")
 except PackageNotFoundError:  # non-installed source checkout
-    APP_VERSION = "0.3.3"
+    APP_VERSION = "0.3.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs-next",
  "enigo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.3"
+version = "0.3.4"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.3"
+version = "0.3.4"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Source-available under FSL-1.1-ALv2 (see LICENSE); each release converts to

--- a/uv.lock
+++ b/uv.lock
@@ -3058,7 +3058,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Patch release. Version bumped across all sources + lock files (`uv lock --check` passes).

### Ships
- **#255** — the **PyTorch Whisper** ASR backend now works as a standalone fallback (no cuDNN 8 / CTranslate2, no `OMNIVOICE_PRELOAD_TTS_ASR=1`), unblocking Windows + NVIDIA users hitting `Could not locate cudnn_ops_infer64_8.dll`. Select it in Settings → Models.

### On merge
Tag `v0.3.4` → desktop + docker builds. macOS `SHA256SUMS` now auto-generates (bash-3.2 CI fix). I'll then point the #255 reporter at v0.3.4 (but keep the issue open until they confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.3.4

* **Bug Fixes**
  * Fixed Windows NVIDIA transcription failures: PyTorch Whisper backend now automatically acts as fallback when GPU-acceleration libraries are unavailable, removing the need for manual configuration and environment variable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->