### PR TITLE
fix(diarization): register torch safe-globals before pyannote load (#270)

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -633,6 +633,18 @@ def get_diarization_pipeline(return_error: bool = False):
     try:
         torch = _lazy_torch()
         _ensure_pyannote_hf_token_compat()  # #167: use_auth_token -> token
+        # PyTorch 2.6 flipped torch.load's default to weights_only=True, whose
+        # secure unpickler rejects the pyannote checkpoint's metadata globals
+        # (torch_version.TorchVersion, omegaconf nodes, …) — surfacing as
+        # "Weights only load failed / Unsupported global" and breaking
+        # diarization on torch>=2.6 even after the license is accepted (#270).
+        # Reuse the exact allowlist the WhisperX VAD load registers so the
+        # secure load path succeeds; it is idempotent and per-process.
+        try:
+            from services.asr_backend import WhisperXBackend
+            WhisperXBackend._allow_vad_pickle_globals()
+        except Exception as _glob_e:
+            logger.debug("pyannote safe-globals allowlist skipped: %s", _glob_e)
         from pyannote.audio import Pipeline
         logger.info("Loading Pyannote Diarization Pipeline...")
         _diar_pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1", use_auth_token=hf_token)

--- a/tests/test_diarization_weights_only.py
+++ b/tests/test_diarization_weights_only.py
@@ -1,0 +1,65 @@
+"""Diarization must register torch safe-globals before loading (issue #270).
+
+PyTorch 2.6+ defaults `torch.load` to `weights_only=True`, whose secure
+unpickler rejects the pyannote checkpoint's metadata globals
+(`torch_version.TorchVersion`, omegaconf nodes, …). `get_diarization_pipeline`
+must register the same allowlist the WhisperX VAD load uses, before calling
+`Pipeline.from_pretrained`, or diarization breaks even with the license
+accepted.
+"""
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def reset_diar(monkeypatch):
+    import services.model_manager as mm
+    monkeypatch.setattr(mm, "_diar_pipeline", None, raising=False)
+    yield mm
+    monkeypatch.setattr(mm, "_diar_pipeline", None, raising=False)
+
+
+def test_loads_pyannote_after_registering_safe_globals(reset_diar, monkeypatch):
+    mm = reset_diar
+    order = []
+
+    # Token present (App source).
+    monkeypatch.setattr(
+        "services.token_resolver.resolve",
+        lambda: types.SimpleNamespace(token="hf_test", source="app", user="u"),
+    )
+
+    # Spy on the shared allowlister; must run BEFORE from_pretrained.
+    from services import asr_backend as ab
+    monkeypatch.setattr(
+        ab.WhisperXBackend, "_allow_vad_pickle_globals",
+        staticmethod(lambda: order.append("allow")),
+    )
+
+    fake_pipe = object()
+
+    def _from_pretrained(*a, **k):
+        order.append("load")
+        return fake_pipe
+
+    fake_mod = types.ModuleType("pyannote.audio")
+    fake_mod.Pipeline = types.SimpleNamespace(from_pretrained=_from_pretrained)
+    monkeypatch.setitem(sys.modules, "pyannote.audio", fake_mod)
+
+    # CPU device → no .to() call on the fake pipe.
+    monkeypatch.setattr(mm, "get_best_device", lambda: "cpu")
+
+    result = mm.get_diarization_pipeline()
+
+    assert result is fake_pipe
+    assert order == ["allow", "load"], f"allowlist must precede load, got {order}"
+
+
+def test_no_token_short_circuits_without_loading(reset_diar, monkeypatch):
+    mm = reset_diar
+    monkeypatch.setattr("services.token_resolver.resolve", lambda: None)
+    pipe, err = mm.get_diarization_pipeline(return_error=True)
+    assert pipe is None
+    assert err == mm.DIARIZATION_ERR_NO_TOKEN


### PR DESCRIPTION
## Problem

Issue #270 — diarization fails on Windows + NVIDIA (v0.3.4) **with the pyannote license already accepted**:

```
Failed to load Pyannote pipeline: Weights only load failed ...
WeightsUnpickler error: Unsupported global: GLOBAL torch.torch_version.TorchVersion was not an allowed global by default.
```

PyTorch 2.6 flipped `torch.load`'s default to `weights_only=True`; its secure unpickler rejects the pyannote checkpoint's metadata globals. So this isn't a license problem — it's a torch-version incompatibility that hits **every** torch≥2.6 user (the project pins torch 2.8).

## Fix

The WhisperX VAD load already solved this with `WhisperXBackend._allow_vad_pickle_globals()` (allowlists `TorchVersion`, omegaconf nodes, pyannote metadata classes, builtins, numpy, pathlib, …). `get_diarization_pipeline` simply never called it. This PR calls that same allowlister before `Pipeline.from_pretrained` — **reuse, not duplication**; idempotent and per-process.

Verified locally on torch 2.8: the call registers `TorchVersion` (83 globals total) into `torch.serialization.get_safe_globals()` — the exact global the error names.

## Safety
- Graceful fallback (silence-gap heuristic) preserved if anything else fails — no regression.
- Cross-platform (the torch 2.6 change affects all platforms; reproducible).

## Tests
`tests/test_diarization_weights_only.py` — allowlist runs **before** the load; no-token short-circuit. Existing diarization classification tests still pass (16 total).

Addresses #270 (will confirm with the reporter on the next release before resolving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with PyTorch 2.6+ for diarization pipeline loading to prevent checkpoint loading failures.

* **Tests**
  * Added tests to verify diarization pipeline behavior with PyTorch 2.6+ weights-only semantics and token resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->