### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [0.3.5] — 2026-06-03
+
+### Fixed
+- **Speaker diarization failed on PyTorch ≥ 2.6** (`Weights only load failed …
+  Unsupported global: torch.torch_version.TorchVersion`) even with the pyannote
+  license accepted. PyTorch 2.6 made `torch.load` default to
+  `weights_only=True`, whose secure unpickler rejects the pyannote checkpoint's
+  metadata globals. The diarization loader now registers the same safe-globals
+  allowlist the WhisperX VAD load already uses, so the secure load succeeds.
+  (#270)
+
 ## [0.3.4] — 2026-06-03
 
 ### Fixed

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -12,4 +12,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     APP_VERSION = version("omnivoice")
 except PackageNotFoundError:  # non-installed source checkout
-    APP_VERSION = "0.3.4"
+    APP_VERSION = "0.3.5"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "dirs-next",
  "enigo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.4"
+version = "0.3.5"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.4"
+version = "0.3.5"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Source-available under FSL-1.1-ALv2 (see LICENSE); each release converts to

--- a/uv.lock
+++ b/uv.lock
@@ -3058,7 +3058,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Patch release. Version bumped across all sources + lock files (`uv lock --check` passes).

### Ships
- **#270** — speaker diarization fixed on PyTorch ≥ 2.6: the `weights_only=True` default was rejecting the pyannote checkpoint's `TorchVersion` global. The diarization loader now registers the same safe-globals allowlist the WhisperX VAD load already uses.

### On merge
Tag `v0.3.5` → desktop + docker builds (macOS `SHA256SUMS` auto-generates). I'll point the #270 reporter at v0.3.5 to retry diarization (keeping the issue open until they confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved speaker diarization failures on PyTorch 2.6 and later with secure model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->