### PR TITLE
macOS: ad-hoc sign so users open without Terminal + signing/notarization verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,6 +477,35 @@ jobs:
           echo "OK — bundle has shell + uv + backend resources"
           hdiutil detach "$MOUNT" || true
 
+      # ── Signing / Gatekeeper / notarization verification ──────────────
+      # Runs codesign --verify, spctl (Gatekeeper), nested-binary, and
+      # stapler checks against the built .app (see docs/macos-signing-verification.md).
+      # STRICT (--require-signed) only on the opt-in signed stable path — same
+      # condition as "Configure Apple signing" above — so a failed or missing
+      # signature/notarization FAILS the job and STOPS the release instead of
+      # publishing an unsigned artifact. On every other (unsigned dev/preview)
+      # path it runs report-only and never breaks the build.
+      - name: Verify macOS signing
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          STRICT: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && vars.MACOS_SIGNING_ENABLED == 'true') && '1' || '0' }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -uo pipefail
+          APP=$(find "frontend/src-tauri/target/${{ matrix.rust_target }}/release/bundle/macos" -maxdepth 1 -name '*.app' | head -1)
+          [ -n "$APP" ] || { echo "FAIL — no .app found to verify"; exit 1; }
+          MODE=""
+          if [ "$STRICT" = "1" ]; then
+            MODE="--require-signed"
+            echo "Signed stable release → STRICT verification (release stops on failure)."
+          else
+            echo "Unsigned dev/preview path → report-only verification."
+          fi
+          bash scripts/verify-macos-signing.sh "$APP" $MODE
+
       - name: Installer smoke (Windows)
         if: runner.os == 'Windows'
         timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,12 @@ jobs:
           # only on the opt-in stable path, leaving them ABSENT (not "") on
           # preview/unsigned paths so Tauri's bundler skips cert import. A static
           # env: here would always set them to "" and break the mac build.
+          # Unsigned paths still get a VALID ad-hoc seal from tauri.conf.json
+          # (bundle.macOS.signingIdentity = "-"), so a downloaded build shows the
+          # GUI-bypassable "unidentified developer" prompt (right-click → Open /
+          # Settings → "Open Anyway") instead of the un-bypassable "damaged"
+          # error. On the signed path APPLE_SIGNING_IDENTITY (env) overrides the
+          # "-" default; once notarized, Gatekeeper accepts it with no prompt.
           # GH runners disable FUSE, so linuxdeploy's AppImage can't mount
           # itself at bundle time. This env tells linuxdeploy to extract-and-run
           # instead, which works without FUSE.

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -35,30 +35,36 @@ Download the latest DMG from the
 [Releases page](https://github.com/debpalash/OmniVoice-Studio/releases/latest),
 double-click to mount, drag **OmniVoice Studio.app** into `/Applications`.
 
-If the first launch shows "app is damaged and can't be opened", that's macOS
-Gatekeeper — see the next section.
+If the first launch is blocked by macOS Gatekeeper ("OmniVoice Studio cannot be
+opened because the developer cannot be verified"), see the next section — it
+opens with one right-click, no Terminal.
 
 ## App is "damaged" / can't be opened (Gatekeeper)
 
 <a id="gatekeeper-quarantine"></a>
 
-If you see **"OmniVoice Studio.app" is damaged and can't be opened. You should
-move it to the Trash**, the app is **not** damaged — that misleading message is
-macOS Gatekeeper blocking an app it can't verify (issues #134, #72).
+On first launch you'll see **"OmniVoice Studio cannot be opened because the
+developer cannot be verified"** — macOS Gatekeeper blocking an app it can't trace
+to a paid Apple Developer account (issues #134, #72).
 
-**Why:** the build isn't yet notarised by Apple, so macOS quarantines any copy
-downloaded from the internet outside the App Store and shows the "damaged"
-message. This is expected for open-source unsigned builds — releases are only
-notarised once the project's Apple Developer ID signing pipeline is configured
-(see "For maintainers" below). The workaround below is **safe** because you
-downloaded the app from the official repo / Releases page; if you want
-belt-and-braces, verify the SHA-256 against the `*.dmg.sha256` checksum on the
-release page first.
+**Why:** the build is **ad-hoc code-signed** (a valid signature, free) but not
+yet **notarised** by Apple, so macOS quarantines any copy downloaded from the
+internet and asks you to confirm the first launch. This is expected for
+open-source builds — releases are notarised (warning-free) only once the
+project's Apple Developer ID pipeline is funded (see "For maintainers" below).
+Confirming is **safe** because you downloaded from the official repo / Releases
+page; for belt-and-braces, verify the SHA-256 against the `*.dmg.sha256` checksum
+on the release page first.
 
-**Fix — GUI (no terminal):** in Finder, **right-click** (or Control-click) the
-app → **Open** → click **Open** again in the dialog. Or go to **System Settings
-→ Privacy & Security**, scroll to the security section, and click **"Open
-Anyway"** next to the OmniVoice Studio prompt.
+**Fix — GUI, no Terminal (do this):** in Finder, **right-click** (or
+Control-click) **OmniVoice Studio.app** → **Open** → click **Open** again in the
+dialog. (On macOS 15 Sequoia: double-click once, then go to **System Settings →
+Privacy & Security**, scroll down, and click **"Open Anyway"**.) This is a
+one-time confirmation per install; afterwards it launches by double-click.
+
+> If you instead see the harsher **"app is damaged and can't be opened. Move to
+> Trash"** with no Open option, the download was corrupted or it's a pre-signing
+> build — re-download the latest release, or use the Terminal fallback below.
 
 **Fix — Terminal:** after dragging the app into `/Applications`, run:
 

--- a/docs/macos-signing-verification.md
+++ b/docs/macos-signing-verification.md
@@ -1,0 +1,120 @@
+# macOS Build, Signing & Notarization — Requirements & Verification
+
+The canonical checklist for producing and verifying the OmniVoice Studio macOS
+desktop bundle. It pairs with two helper scripts and the release workflow:
+
+- **`scripts/verify-macos-signing.sh`** — runs every verification command below
+  and reports PASS / WARN / FAIL. Strict mode (`--require-signed`) fails on any
+  unsigned/un-notarized component.
+- **`scripts/macos-dev-unquarantine.sh`** — local-dev-only quarantine stripper.
+- **`.github/workflows/release.yml`** — builds, optionally signs (opt-in), and
+  runs `verify-macos-signing.sh` on the macOS leg.
+
+> **Current state of this repo:** Apple Developer ID signing is **opt-in and OFF
+> by default** (see the *Configure Apple signing* step in `release.yml`). Default
+> stable + all preview builds ship **unsigned**; users clear quarantine manually
+> (see [`docs/install/macos.md`](install/macos.md#gatekeeper-quarantine), issues
+> #134/#72). Turning on signed releases means fixing the Apple secrets and setting
+> the repo variable `MACOS_SIGNING_ENABLED = true` — at which point the
+> verification below switches to **strict** automatically and gates the release.
+
+---
+
+## Requirements
+
+When modifying or releasing this Tauri application:
+
+1. **Produce a valid macOS `.app` bundle** via the current Tauri release process
+   (`tauri-apps/tauri-action` in `release.yml`; locally, `bun desktop-prod`).
+2. **Verify the app launches** on the latest supported macOS version.
+3. **Signature integrity** — before release, run:
+   ```bash
+   codesign --verify --deep --strict --verbose=4 "<APP_PATH>"
+   ```
+4. **Gatekeeper acceptance**:
+   ```bash
+   spctl -a -vv "<APP_PATH>"
+   ```
+5. **No unsigned nested components** — no unsigned binaries, frameworks, helper
+   apps, or dynamic libraries may exist inside the bundle.
+6. **Sign nested before root** — every nested component is signed *before* the
+   root application bundle.
+7. **Production releases:**
+   - Use an **Apple Developer ID** certificate.
+   - **Notarize** the application.
+   - **Staple** the notarization ticket (`xcrun stapler staple`).
+   - macOS 15 (Sequoia) also rejects a DMG that *wraps* a signed `.app` but isn't
+     itself notarized — **re-notarize + staple the DMG**, then re-upload it (see
+     `docs/DESKTOP_RELEASE.md`, Phase E).
+8. **Validate downloaded builds do NOT trigger:**
+   - "App is damaged and can't be opened"
+   - "Move to Trash"
+   - any Gatekeeper rejection message
+9. **Test both scenarios:** fresh download, and existing-user upgrade
+   (`bun desktop-prod` = fresh; `bun desktop-prod:upgrade` = rebuild keeping data).
+10. **Fail closed** — if signing or notarization fails, **stop the release and
+    report the exact error** rather than producing an unsigned artifact. The
+    strict-mode verification step in `release.yml` enforces this on the signed path.
+
+### Required verification commands
+
+```bash
+codesign --verify --deep --strict --verbose=4 "OmniVoice Studio.app"
+spctl -a -vv "OmniVoice Studio.app"
+xcrun notarytool history          # needs Apple credentials / keychain profile
+```
+
+A release is considered **successful only when all verification checks pass.**
+
+---
+
+## How to verify
+
+```bash
+# Auto-discover the most recent built .app and report status (dev default):
+scripts/verify-macos-signing.sh
+
+# Verify a specific bundle or DMG:
+scripts/verify-macos-signing.sh "path/to/OmniVoice Studio.app"
+scripts/verify-macos-signing.sh ~/Downloads/OmniVoice*.dmg
+
+# Production gate — fail on ANY unsigned/un-notarized component:
+scripts/verify-macos-signing.sh "OmniVoice Studio.app" --require-signed
+```
+
+The script runs checks 3–8 plus stapler/notarytool, and exits non-zero in strict
+mode if anything fails — the machine-checkable form of requirement #10.
+
+`xcrun notarytool history` is included when credentials are present in the
+environment (`NOTARYTOOL_KEYCHAIN_PROFILE`, or `APPLE_ID` + `APPLE_PASSWORD` +
+`APPLE_TEAM_ID`); otherwise it is skipped with a note.
+
+---
+
+## Local development
+
+For **local test artifacts only**, you may remove the quarantine attribute so an
+unsigned dev build launches without the right-click → Open dance:
+
+```bash
+scripts/macos-dev-unquarantine.sh "path/to/OmniVoice Studio.app"
+```
+
+> ⚠️ This is a **development convenience only** and is **never a substitute** for
+> proper Developer ID signing + notarization of production releases. Shipped
+> artifacts must be signed and notarized so end users never need it.
+
+---
+
+## Enabling signed + notarized stable releases
+
+1. Obtain an Apple Developer ID (~$99/yr) and a Developer ID Application cert.
+2. Add the secrets used by `release.yml`: `APPLE_CERTIFICATE`,
+   `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`,
+   `APPLE_PASSWORD`, `APPLE_TEAM_ID`.
+3. Set repo variable **`MACOS_SIGNING_ENABLED = true`**.
+4. Tag a `v*` release. The build then signs, notarizes, and the *Verify macOS
+   signing* step runs in **strict** mode — a failure stops the release (req #10).
+5. Confirm the DMG itself is notarized + stapled (macOS 15 requirement, #7).
+
+See `docs/DESKTOP_RELEASE.md` (Phase E) for the full pipeline rationale.

--- a/docs/macos-signing-verification.md
+++ b/docs/macos-signing-verification.md
@@ -10,13 +10,28 @@ desktop bundle. It pairs with two helper scripts and the release workflow:
 - **`.github/workflows/release.yml`** — builds, optionally signs (opt-in), and
   runs `verify-macos-signing.sh` on the macOS leg.
 
-> **Current state of this repo:** Apple Developer ID signing is **opt-in and OFF
-> by default** (see the *Configure Apple signing* step in `release.yml`). Default
-> stable + all preview builds ship **unsigned**; users clear quarantine manually
-> (see [`docs/install/macos.md`](install/macos.md#gatekeeper-quarantine), issues
-> #134/#72). Turning on signed releases means fixing the Apple secrets and setting
-> the repo variable `MACOS_SIGNING_ENABLED = true` — at which point the
+> **Current state of this repo:** Apple Developer ID signing + notarization is
+> **opt-in and OFF by default** (see the *Configure Apple signing* step in
+> `release.yml`). Default stable + all preview builds are **ad-hoc signed** —
+> `tauri.conf.json > bundle > macOS > signingIdentity = "-"` gives the bundle a
+> *valid* seal (free, no Apple account), so a downloaded copy shows the
+> **GUI-bypassable "unidentified developer"** prompt (right-click → Open) instead
+> of the un-bypassable **"app is damaged"** error a broken/missing seal produces.
+> It is **not** notarized, so users still confirm the first launch once (see
+> [`docs/install/macos.md`](install/macos.md#gatekeeper-quarantine), issues
+> #134/#72). For a warning-free double-click, enable signing: fix the Apple
+> secrets, set the repo variable `MACOS_SIGNING_ENABLED = true` (the env-set
+> `APPLE_SIGNING_IDENTITY` overrides the `"-"` default) — at which point the
 > verification below switches to **strict** automatically and gates the release.
+
+### Signing tiers at a glance
+
+| Tier | Cost | What the user sees | Terminal? |
+|------|------|--------------------|-----------|
+| **Unsigned / broken seal** | free | "app is damaged" — **no GUI bypass** | yes (`xattr`) |
+| **Ad-hoc signed** (current default) | free | "unidentified developer" → right-click → Open / "Open Anyway" | **no** |
+| **Developer ID, not notarized** | $99/yr | "unidentified developer" → right-click → Open | no |
+| **Developer ID + notarized + stapled** | $99/yr | nothing — clean double-click | no |
 
 ---
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -73,7 +73,8 @@
       "binaries/ffprobe"
     ],
     "macOS": {
-      "minimumSystemVersion": "12.0"
+      "minimumSystemVersion": "12.0",
+      "signingIdentity": "-"
     }
   },
   "plugins": {

--- a/scripts/macos-dev-unquarantine.sh
+++ b/scripts/macos-dev-unquarantine.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────
+# macos-dev-unquarantine.sh — strip com.apple.quarantine from a LOCAL TEST
+# artifact so you can launch an unsigned dev/preview build without the
+# right-click → Open dance.
+#
+#   ⚠️  LOCAL DEVELOPMENT CONVENIENCE ONLY.
+#   This is NEVER a substitute for proper Developer ID signing + notarization
+#   of production releases. Real users must receive a signed, notarized build
+#   (see docs/macos-signing-verification.md) — do not ship artifacts and tell
+#   users to run this. Production signing is gated separately in release.yml.
+#
+# Usage:
+#   scripts/macos-dev-unquarantine.sh "path/to/OmniVoice Studio.app"
+#   scripts/macos-dev-unquarantine.sh ~/Downloads/OmniVoice*.dmg
+#   scripts/macos-dev-unquarantine.sh        # auto-discover newest built .app
+# ──────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "macos-dev-unquarantine: not macOS — nothing to do."
+  exit 0
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="${1:-}"
+
+if [ -z "$TARGET" ]; then
+  TARGET="$(find "$REPO_ROOT/frontend/src-tauri/target" -type d -name '*.app' -path '*/bundle/macos/*' 2>/dev/null | grep -E '/release/' | head -1)"
+  [ -z "$TARGET" ] && TARGET="$(find "$REPO_ROOT/frontend/src-tauri/target" -type d -name '*.app' -path '*/bundle/macos/*' 2>/dev/null | head -1)"
+  [ -z "$TARGET" ] && { echo "ERROR: no built .app found — pass an explicit path." >&2; exit 2; }
+fi
+
+[ -e "$TARGET" ] || { echo "ERROR: path does not exist: $TARGET" >&2; exit 2; }
+
+echo "⚠️  DEV-ONLY: stripping com.apple.quarantine from:"
+echo "    $TARGET"
+echo "    (not a substitute for signing + notarization — see docs/macos-signing-verification.md)"
+
+xattr -dr com.apple.quarantine "$TARGET" 2>/dev/null || true
+
+if xattr -pr com.apple.quarantine "$TARGET" >/dev/null 2>&1; then
+  echo "✗ quarantine attribute still present — try: sudo xattr -dr com.apple.quarantine \"$TARGET\""
+  exit 1
+fi
+echo "✓ quarantine cleared — the unsigned build will now launch locally."

--- a/scripts/verify-macos-signing.sh
+++ b/scripts/verify-macos-signing.sh
@@ -87,6 +87,13 @@ resolve_app() {
 
 APP="$(resolve_app "$TARGET")"
 
+# Detect an ad-hoc signature: a VALID seal but not Developer-ID / not notarized.
+# This is the free default (tauri.conf.json bundle.macOS.signingIdentity "-") —
+# it makes a downloaded copy show the GUI-bypassable "unidentified developer"
+# prompt instead of the un-bypassable "damaged" error.
+IS_ADHOC=0
+if codesign -dvv "$APP" 2>&1 | grep -q 'Signature=adhoc'; then IS_ADHOC=1; fi
+
 # ── Result accounting ─────────────────────────────────────────────────────
 FAILS=0
 WARNS=0
@@ -116,7 +123,20 @@ if [ $CS_RC -eq 0 ]; then ok "signature valid (deep, strict)"; else problem "cod
 echo "[2/6] spctl -a -vv --type execute  (Gatekeeper)"
 SPCTL_OUT="$(spctl --assess -a -vv --type execute "$APP" 2>&1)"; SPCTL_RC=$?
 printf '%s\n' "$SPCTL_OUT" | sed 's/^/      /'
-if [ $SPCTL_RC -eq 0 ]; then ok "Gatekeeper accepts the bundle"; else problem "Gatekeeper rejected the bundle (rc=$SPCTL_RC) — users would see \"app is damaged\" / \"Move to Trash\""; fi
+if [ $SPCTL_RC -eq 0 ]; then
+  ok "Gatekeeper accepts the bundle (signed + notarized)"
+elif [ "$IS_ADHOC" = 1 ] && [ $CS_RC -eq 0 ]; then
+  if [ "$REQUIRE_SIGNED" = 1 ]; then
+    echo "  ✗ FAIL: ad-hoc only, not notarized — Gatekeeper won't auto-accept a production release"; FAILS=$((FAILS+1))
+  else
+    echo "  ⓘ ad-hoc signed (valid seal, not notarized): a downloaded copy shows the"
+    echo "      \"unidentified developer\" prompt — users open it WITHOUT Terminal via"
+    echo "      right-click → Open, or Settings → Privacy & Security → \"Open Anyway\"."
+    echo "      Notarize (paid Apple ID) for a warning-free double-click."
+  fi
+else
+  problem "Gatekeeper rejected (rc=$SPCTL_RC) and the signature is invalid/missing — users would see \"app is damaged\" / \"Move to Trash\" with NO GUI bypass"
+fi
 
 # ── 3. No unsigned nested components ──────────────────────────────────────
 # Tauri/Apple require every nested Mach-O (helpers, frameworks, dylibs,
@@ -177,7 +197,13 @@ if [ "$FAILS" -gt 0 ]; then
   hr; exit 1
 elif [ "$WARNS" -gt 0 ]; then
   echo "RESULT: PASS (report-only) — $WARNS warning(s)."
-  echo "Bundle is unsigned/un-notarized, which is expected for dev/preview builds."
+  if [ "$IS_ADHOC" = 1 ]; then
+    echo "Bundle is ad-hoc signed: users can open it WITHOUT Terminal (right-click → Open"
+    echo "/ Settings → \"Open Anyway\"). Not notarized — sign + notarize (paid Apple ID)"
+    echo "for a warning-free double-click."
+  else
+    echo "Bundle is unsigned/un-notarized, which is expected for dev/preview builds."
+  fi
   echo "For a production release run with --require-signed after enabling Apple signing."
   hr; exit 0
 else

--- a/scripts/verify-macos-signing.sh
+++ b/scripts/verify-macos-signing.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────
+# verify-macos-signing.sh — Gatekeeper / code-signing / notarization checks
+#
+# Implements the verification half of docs/macos-signing-verification.md.
+# Runs the canonical Apple checks against a built bundle and reports a clear
+# PASS / WARN / FAIL summary:
+#
+#   codesign --verify --deep --strict --verbose=4   (signature integrity)
+#   spctl -a -vv --type execute                      (Gatekeeper acceptance)
+#   per-nested-component codesign -v                 (no unsigned binaries)
+#   xcrun stapler validate                           (notarization ticket)
+#   xcrun notarytool history                         (notarization log, opt-in)
+#
+# Two modes:
+#   • default (report-only) — for unsigned dev / preview builds. Missing
+#     signature/notarization is reported as WARN, exit 0. This is the repo's
+#     normal state: Apple signing is OPT-IN and OFF by default (see release.yml
+#     "Configure Apple signing"); unsigned bundles are expected there.
+#   • --require-signed (strict) — for production. ANY unsigned component,
+#     Gatekeeper rejection, or missing notarization ticket is a FAIL (exit 1),
+#     so a broken release stops instead of shipping an unsigned artifact.
+#
+# Usage:
+#   scripts/verify-macos-signing.sh [APP_OR_DMG_PATH] [--require-signed]
+#
+#   # auto-discover the most recent built .app under the Tauri target dir:
+#   scripts/verify-macos-signing.sh
+#   # strict gate against a specific bundle:
+#   scripts/verify-macos-signing.sh "path/to/OmniVoice Studio.app" --require-signed
+#   # verify a DMG (mounts read-only, finds the .app inside, detaches):
+#   scripts/verify-macos-signing.sh "OmniVoice Studio_0.3.5_aarch64.dmg"
+#
+# Env equivalents: REQUIRE_SIGNED=1
+# ──────────────────────────────────────────────────────────────────────────
+set -uo pipefail
+
+# ── macOS only ────────────────────────────────────────────────────────────
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "verify-macos-signing: not macOS (uname=$(uname -s)) — nothing to verify; skipping."
+  exit 0
+fi
+
+# ── Parse args ────────────────────────────────────────────────────────────
+TARGET=""
+REQUIRE_SIGNED="${REQUIRE_SIGNED:-0}"
+for a in "$@"; do
+  case "$a" in
+    --require-signed) REQUIRE_SIGNED=1 ;;
+    --report-only)    REQUIRE_SIGNED=0 ;;
+    -h|--help)        sed -n '2,40p' "$0"; exit 0 ;;
+    *)                TARGET="$a" ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MOUNT=""               # set if we attach a DMG, detached on exit
+cleanup() { [ -n "$MOUNT" ] && hdiutil detach "$MOUNT" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# ── Resolve a .app bundle to verify ───────────────────────────────────────
+resolve_app() {
+  local t="$1"
+  if [ -z "$t" ]; then
+    # Auto-discover: prefer release bundles, fall back to debug. Newest first.
+    t="$(find "$REPO_ROOT/frontend/src-tauri/target" \
+          -type d -name '*.app' -path '*/bundle/macos/*' 2>/dev/null \
+          | grep -E '/release/' | head -1)"
+    [ -z "$t" ] && t="$(find "$REPO_ROOT/frontend/src-tauri/target" \
+          -type d -name '*.app' -path '*/bundle/macos/*' 2>/dev/null | head -1)"
+    [ -z "$t" ] && { echo "ERROR: no .app found under frontend/src-tauri/target/**/bundle/macos/. Build first (bun desktop-prod) or pass an explicit path." >&2; exit 2; }
+    echo "$t"; return
+  fi
+  case "$t" in
+    *.dmg)
+      MOUNT="$(hdiutil attach -nobrowse -readonly "$t" | tail -1 | grep -oE '/Volumes/.*$')"
+      [ -z "$MOUNT" ] && { echo "ERROR: failed to mount DMG: $t" >&2; exit 2; }
+      local app; app="$(find "$MOUNT" -maxdepth 2 -name '*.app' | head -1)"
+      [ -z "$app" ] && { echo "ERROR: no .app inside DMG: $t" >&2; exit 2; }
+      echo "$app"; return ;;
+    *.app)
+      [ -d "$t" ] || { echo "ERROR: not a directory: $t" >&2; exit 2; }
+      echo "$t"; return ;;
+    *) echo "ERROR: unsupported target (want .app or .dmg): $t" >&2; exit 2 ;;
+  esac
+}
+
+APP="$(resolve_app "$TARGET")"
+
+# ── Result accounting ─────────────────────────────────────────────────────
+FAILS=0
+WARNS=0
+hr() { printf '%s\n' "────────────────────────────────────────────────────────────"; }
+# Demote a problem to WARN in report-only mode, FAIL in strict mode.
+problem() { # problem <message>
+  if [ "$REQUIRE_SIGNED" = "1" ]; then echo "  ✗ FAIL: $1"; FAILS=$((FAILS+1));
+  else echo "  ⚠ WARN: $1"; WARNS=$((WARNS+1)); fi
+}
+ok() { echo "  ✓ $1"; }
+
+echo
+hr
+echo "macOS signing verification"
+echo "  bundle : $APP"
+echo "  mode   : $([ "$REQUIRE_SIGNED" = 1 ] && echo 'REQUIRE-SIGNED (strict, production)' || echo 'report-only (dev/preview; unsigned OK)')"
+hr
+
+# ── 1. codesign --verify --deep --strict --verbose=4 ──────────────────────
+echo "[1/6] codesign --verify --deep --strict --verbose=4"
+CS_OUT="$(codesign --verify --deep --strict --verbose=4 "$APP" 2>&1)"; CS_RC=$?
+printf '%s\n' "$CS_OUT" | sed 's/^/      /'
+if [ $CS_RC -eq 0 ]; then ok "signature valid (deep, strict)"; else problem "codesign verification failed (rc=$CS_RC) — bundle is unsigned or signature is broken"; fi
+
+# ── 2. spctl Gatekeeper assessment ────────────────────────────────────────
+# Surfaces the exact "damaged" / "Move to Trash" / rejection text users hit.
+echo "[2/6] spctl -a -vv --type execute  (Gatekeeper)"
+SPCTL_OUT="$(spctl --assess -a -vv --type execute "$APP" 2>&1)"; SPCTL_RC=$?
+printf '%s\n' "$SPCTL_OUT" | sed 's/^/      /'
+if [ $SPCTL_RC -eq 0 ]; then ok "Gatekeeper accepts the bundle"; else problem "Gatekeeper rejected the bundle (rc=$SPCTL_RC) — users would see \"app is damaged\" / \"Move to Trash\""; fi
+
+# ── 3. No unsigned nested components ──────────────────────────────────────
+# Tauri/Apple require every nested Mach-O (helpers, frameworks, dylibs,
+# external sidecars) to be signed before the root bundle. Walk them all.
+echo "[3/6] nested components — every Mach-O must be signed"
+NESTED_BAD=0; NESTED_TOTAL=0
+while IFS= read -r f; do
+  # Only Mach-O files (skip scripts, data, resources).
+  file -b "$f" 2>/dev/null | grep -q 'Mach-O' || continue
+  NESTED_TOTAL=$((NESTED_TOTAL+1))
+  if ! codesign -v "$f" >/dev/null 2>&1; then
+    NESTED_BAD=$((NESTED_BAD+1))
+    echo "      unsigned: ${f#"$APP"/}"
+  fi
+done < <(find "$APP/Contents" -type f 2>/dev/null)
+if [ "$NESTED_TOTAL" -eq 0 ]; then
+  echo "      (no Mach-O files found to check)"
+elif [ "$NESTED_BAD" -eq 0 ]; then
+  ok "all $NESTED_TOTAL nested Mach-O components are signed"
+else
+  problem "$NESTED_BAD of $NESTED_TOTAL nested Mach-O components are unsigned (sign nested before the root bundle)"
+fi
+
+# ── 4. Notarization ticket stapled ────────────────────────────────────────
+echo "[4/6] xcrun stapler validate  (notarization ticket)"
+if command -v xcrun >/dev/null 2>&1; then
+  STAP_OUT="$(xcrun stapler validate "$APP" 2>&1)"; STAP_RC=$?
+  printf '%s\n' "$STAP_OUT" | sed 's/^/      /'
+  if [ $STAP_RC -eq 0 ]; then ok "notarization ticket is stapled"; else problem "no stapled notarization ticket (rc=$STAP_RC) — notarize + staple before release"; fi
+else
+  echo "      xcrun not available — skipping"
+fi
+
+# ── 5. Notarization history (opt-in; needs credentials) ───────────────────
+echo "[5/6] xcrun notarytool history  (audit log, opt-in)"
+if command -v xcrun >/dev/null 2>&1 && [ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]; then
+  xcrun notarytool history --keychain-profile "$NOTARYTOOL_KEYCHAIN_PROFILE" 2>&1 | head -20 | sed 's/^/      /' || true
+elif command -v xcrun >/dev/null 2>&1 && [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
+  xcrun notarytool history --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" 2>&1 | head -20 | sed 's/^/      /' || true
+else
+  echo "      no notarization credentials in env (NOTARYTOOL_KEYCHAIN_PROFILE or APPLE_ID/APPLE_PASSWORD/APPLE_TEAM_ID) — skipping audit log"
+fi
+
+# ── 6. Quarantine attribute (informational) ───────────────────────────────
+echo "[6/6] quarantine attribute (com.apple.quarantine)"
+if xattr -p com.apple.quarantine "$APP" >/dev/null 2>&1; then
+  echo "      present — a downloaded copy would be gated by Gatekeeper until notarized"
+  echo "      (local dev only: scripts/macos-dev-unquarantine.sh strips it — never a substitute for notarization)"
+else
+  ok "no quarantine attribute on this copy"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+hr
+if [ "$FAILS" -gt 0 ]; then
+  echo "RESULT: FAIL — $FAILS blocking issue(s), $WARNS warning(s)."
+  echo "Release must stop. See docs/macos-signing-verification.md for remediation."
+  hr; exit 1
+elif [ "$WARNS" -gt 0 ]; then
+  echo "RESULT: PASS (report-only) — $WARNS warning(s)."
+  echo "Bundle is unsigned/un-notarized, which is expected for dev/preview builds."
+  echo "For a production release run with --require-signed after enabling Apple signing."
+  hr; exit 0
+else
+  echo "RESULT: PASS — signed, Gatekeeper-accepted, notarized. Ready to ship."
+  hr; exit 0
+fi


### PR DESCRIPTION
## Summary

Two related changes for the macOS desktop bundle:

1. **Ad-hoc sign the bundle at build time (free, no Apple account)** so a downloaded copy shows the *bypassable* "Apple could not verify…" Gatekeeper prompt instead of the **un-bypassable "app is damaged"** error — users open it with a GUI **"Open Anyway"**, no Terminal `xattr` needed.
2. **Add macOS signing / Gatekeeper / notarization verification** (`scripts/verify-macos-signing.sh`) and wire it into `release.yml` so signing failures are caught (and, on the opt-in signed path, **stop the release**).

## Why

"App is damaged and can't be opened" is caused by a **broken/incomplete code-signature seal** (`codesign --verify` failed: *"code has no resources but signature indicates they must be present"*) on the quarantined download. On modern macOS that variant has **no GUI bypass**, forcing end users into the Terminal — a non-starter for most.

Giving the bundle a **valid ad-hoc signature** (`tauri.conf.json` → `bundle.macOS.signingIdentity = "-"`) flips the failure mode to the **"unidentified developer / could not verify"** prompt, which clears via right-click → Open or **Settings → Privacy & Security → "Open Anyway"** — no Terminal. Notarization (paid Apple ID) is still the only way to remove the prompt entirely; that path is unchanged and opt-in.

## Verified

- Through a real `tauri build`: the produced `.app` is `flags=adhoc,runtime`, `Signature=adhoc`, and **passes `codesign --verify --deep --strict`**.
- On a copy with the real `com.apple.quarantine` attribute applied: the seal **survives** (`codesign --verify` rc=0).
- Manually on macOS 15: double-click now yields **"Apple could not verify … is free of malware"** (Move to Trash / Done) — the bypassable dialog — **not** "is damaged".
- `verify-macos-signing.sh`: report-only PASS on the ad-hoc build; `--require-signed` correctly FAILS it (production must be notarized). `release.yml` parses as valid YAML.

## Changes

- `frontend/src-tauri/tauri.conf.json` — `signingIdentity: "-"` (ad-hoc default; env `APPLE_SIGNING_IDENTITY` overrides on the signed path).
- `scripts/verify-macos-signing.sh` — codesign/spctl/nested-binary/stapler/notarytool checks; report-only vs `--require-signed`.
- `scripts/macos-dev-unquarantine.sh` — local-dev-only quarantine stripper (never a substitute for notarization).
- `.github/workflows/release.yml` — "Verify macOS signing" step (report-only by default; strict on the opt-in signed stable path).
- `docs/macos-signing-verification.md` — 10-point requirements + how-to-verify + signing-tiers table.
- `docs/install/macos.md` — Gatekeeper section now leads with the GUI "Open Anyway" path; `xattr` kept as fallback.

## Notes / out of scope

- This is a **one-time confirmation**, not a clean double-click — only notarization removes the prompt.
- macOS 15 Sequoia routes first-launch through Settings → "Open Anyway" (Apple removed the right-click→Open shortcut for un-notarized apps).
- DMG re-notarization (macOS-15 requirement) is documented but not implemented — it lives on the credential-blocked signed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved macOS installation guide with enhanced Gatekeeper troubleshooting steps for first-time app launch issues
  * Added comprehensive macOS code signing and notarization verification documentation detailing validation procedures and requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->