### PR TITLE
fix(release): MSI-legal preview version stamp (numeric pre-release identifier)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,7 +410,11 @@ jobs:
           set -euo pipefail
           CONF=frontend/src-tauri/tauri.conf.json
           BASE=$(jq -r .version "$CONF")
-          PREVIEW_VERSION="${BASE}-preview.${{ github.run_number }}"
+          # MSI/WiX requires the semver pre-release identifier to be numeric-only
+          # (and <= 65535). "preview.N" hard-fails the Windows bundler, so the
+          # preview stamp is BASE-N — still sorts below the stable BASE for the
+          # updater, still unique per run.
+          PREVIEW_VERSION="${BASE}-${{ github.run_number }}"
           tmp=$(mktemp)
           jq --arg v "$PREVIEW_VERSION" '.version = $v' "$CONF" > "$tmp"
           mv "$tmp" "$CONF"


### PR DESCRIPTION
Windows preview bundling fails in WiX: `optional pre-release identifier in app version must be numeric-only and cannot be greater than 65535 for msi target` — the stamp was `BASE-preview.N`. This drops the word: `BASE-N` is still a semver prerelease (sorts below stable for the updater), unique per run, and MSI-legal. Failed run: 27096586578 (mac+Linux built fine; publish skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview version formatting in build workflows to ensure compatibility with Windows installer requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->