### PR TITLE
style(setup): stable scaffold — zero layout shift across the first-run journey

### DIFF
--- a/frontend/src/components/FirstRunSetup.css
+++ b/frontend/src/components/FirstRunSetup.css
@@ -46,11 +46,16 @@
   position: relative;
   width: 100%;
   max-width: 1240px;
-  margin: auto 0;            /* vertical centering when content is short */
+  /* Top-anchored: the waveform opens the page right under the titlebar —
+     vertical centering left a dead zone above it on tall windows. */
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
   min-width: 0;
+  /* Fill the viewport (minus the shell's padding) so the sticky footer's
+     margin-top:auto hugs the bottom even when content is short. */
+  min-height: calc(100dvh - 5.4rem);
 }
 
 .frs__loading {
@@ -100,6 +105,7 @@
   line-height: 1.5;
   opacity: 0.72;
   max-width: 62ch;
+  min-height: 3em;            /* two lines reserved — stage swaps don't shift */
 }
 
 .frs__mast-meta {
@@ -294,18 +300,17 @@
 
 /* Verbosity diet: the description unfolds (smoothly) only on the selected
    card — collapsed cards keep it as a tooltip. */
-.frs-opt__desc {
+/* Descriptions live in a fixed per-group caption slot (two reserved lines)
+   so selecting an option NEVER shifts the layout — text swaps in place.
+   .frs-opt__desc remains visible only for legacy embeds (wizard cards). */
+.frs-opt__desc { font-size: 0.7rem; line-height: 1.45; opacity: 0.7; }
+
+.frs__opt-caption {
+  margin: 0;
   font-size: 0.7rem;
   line-height: 1.45;
-  max-height: 0;
-  opacity: 0;
-  overflow: hidden;
-  transition: max-height 260ms cubic-bezier(0.22, 1, 0.36, 1), opacity 260ms ease;
-}
-
-.frs-opt.is-active .frs-opt__desc {
-  max-height: 4.5em;
-  opacity: 0.6;
+  opacity: 0.68;
+  min-height: 2.9em;          /* exactly two lines reserved */
 }
 
 /* ── Detected hardware readout (Compute panel) ─────────────────────────── */
@@ -547,10 +552,18 @@
 /* ── Footer: gate + armed button ───────────────────────────────────────── */
 
 .frs__foot {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
   padding-top: 0.6rem;
+  padding-bottom: 0.5rem;
+  margin-top: auto;          /* hug the bottom when content is short */
+  background: var(--frs-bg);
+  /* soft top fade so scrolled content slips under, not against, the bar */
+  box-shadow: 0 -14px 14px -8px var(--frs-bg);
 }
 
 .frs__foot-row {

--- a/frontend/src/components/FirstRunSetup.jsx
+++ b/frontend/src/components/FirstRunSetup.jsx
@@ -180,7 +180,7 @@ function OptionCard({ active, disabled, onSelect, name, desc, badge, compact }) 
       tabIndex={active ? 0 : -1}
       className={`frs-opt ${compact ? 'frs-opt--compact' : ''} ${active ? 'is-active' : ''}`}
       disabled={disabled}
-      title={active ? undefined : desc}
+      title={desc}
       onClick={() => !disabled && onSelect()}
     >
       <span className="frs-opt__led" aria-hidden="true" />
@@ -188,9 +188,14 @@ function OptionCard({ active, disabled, onSelect, name, desc, badge, compact }) 
         <span className="frs-opt__name">{name}</span>
         {badge && <span className="frs-opt__badge">{badge}</span>}
       </span>
-      <span className="frs-opt__desc">{desc}</span>
     </button>
   );
+}
+
+/** Fixed caption slot under a radio group: two reserved lines, the active
+ *  option's description swaps in — the layout never shifts on selection. */
+function GroupCaption({ text }) {
+  return <p className="frs__opt-caption" aria-live="polite">{text}</p>;
 }
 
 export default function FirstRunSetup() {
@@ -443,6 +448,9 @@ export default function FirstRunSetup() {
                     : t('firstrun.mode_portable_unavailable', 'Unavailable: the folder next to the app is not writable.')}
                 />
               </div>
+              <GroupCaption text={portable
+                ? t('firstrun.mode_portable_desc', 'Everything lives in one folder next to the app — move it to another disk or machine as a unit.')
+                : t('firstrun.mode_installed_desc', 'Uses standard system folders. Recommended for most users.')} />
             </Panel>
 
             <Panel title={t('firstrun.storage_title', 'Storage')} delay={2}>
@@ -527,6 +535,9 @@ export default function FirstRunSetup() {
                   />
                 )}
               </div>
+              <GroupCaption text={plan.torchVariant === 'rocm'
+                ? t('firstrun.compute_rocm_desc', 'Installs PyTorch ROCm wheels for AMD graphics cards on Linux. Leave on Auto if unsure.')
+                : t('firstrun.compute_auto_desc', 'Picks the best backend on this machine at runtime — CUDA on NVIDIA, MPS on Apple Silicon, CPU otherwise.')} />
             </Panel>
 
             <Panel title={t('firstrun.channel_label', 'Update channel')} delay={3}>
@@ -551,6 +562,9 @@ export default function FirstRunSetup() {
                   desc={t('firstrun.channel_preview_desc', 'Rolling builds from the latest main — new engines and fixes first, occasional rough edges.')}
                 />
               </div>
+              <GroupCaption text={plan.updateChannel === 'preview'
+                ? t('firstrun.channel_preview_desc', 'Rolling builds from the latest main — new engines and fixes first, occasional rough edges.')
+                : t('firstrun.channel_stable_desc', 'Tested releases only — updates arrive after community validation.')} />
             </Panel>
           </div>
         </div>


### PR DESCRIPTION
Top-anchored deck (no more centering dead-zone / reflow between acts), sticky footer (plate + totals + armed action always visible), and reserved space for all variable text: 2-line subtitle slot, and option descriptions moved from inside the cards to a fixed per-group caption slot — selecting an option swaps text in place instead of pushing the page around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the first-run setup layout to anchor at the top of the screen with improved spacing.
  * Changed option descriptions from expand/collapse animations to fixed two-line captions that update based on selection.
  * Made the footer sticky at the bottom with a fade effect to improve usability when scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->