### PR TITLE
fix(dub): video retry after URL ingest, responsive layout, icon-only toolbar

### DIFF
--- a/frontend/src/components/DubSegmentTable.css
+++ b/frontend/src/components/DubSegmentTable.css
@@ -9,6 +9,26 @@
   --seg-grid-cols: 18px 64px 70px minmax(0, 1fr) 44px 60px 40px 44px;
 }
 
+/* Narrow windows: shrink the fixed rails so the text column keeps real
+   width instead of being squeezed to nothing — the table reflows with the
+   window instead of overflowing it. */
+@media (max-width: 1100px) {
+  .segment-table {
+    --seg-grid-cols: 16px 54px 56px minmax(0, 1fr) 38px 52px 34px 38px;
+  }
+}
+
+@media (max-width: 760px) {
+  .segment-table {
+    --seg-grid-cols: 14px 48px minmax(0, 1fr) 34px 48px 34px;
+  }
+  /* Speaker + gain rails collapse entirely below tablet width. */
+  .dub-segment-table__header > :nth-child(3),
+  .segment-row > :nth-child(3),
+  .dub-segment-table__header > :nth-child(7),
+  .segment-row > :nth-child(7) { display: none; }
+}
+
 .dub-segment-table__header,
 .segment-table .segment-row {
   display: grid !important;

--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -96,6 +96,7 @@ function WaveformTimeline({
 
     // ── 1. Create the video element imperatively (stable, no React re-renders) ──
     let videoEl = null;
+    let videoRetryTimer = null;
     if (videoSrc && videoContainerRef.current) {
       // Remove prior children + detach listeners explicitly to avoid leaks.
       const c = videoContainerRef.current;
@@ -135,14 +136,27 @@ function WaveformTimeline({
       // project save and reload). In either case the rest of the
       // pipeline can't do anything useful, so flip into the
       // user-facing error fallback instead of staring at a black box.
+      // Right after a URL ingest the server file may not be finalized yet
+      // (yt-dlp still remuxing) — the first load then fails with code 2
+      // (network) or 4 (non-media 404 body) and the preview used to stay a
+      // black box until the project was reloaded. Retry with backoff before
+      // declaring the source dead; code 3 (decode) is terminal immediately.
+      let videoRetries = 0;
       videoEl.addEventListener('error', () => {
         const code = videoEl.error?.code;
+        if ((code === 2 || code === 4) && videoRetries < 6) {
+          videoRetries += 1;
+          videoRetryTimer = setTimeout(() => {
+            try { videoEl.src = videoSrc; videoEl.load(); } catch (_) { /* ignore */ }
+          }, 1000 * videoRetries);
+          return;
+        }
         if (code === 3 || code === 4) {
           console.warn('[WaveformTimeline] video element rejected source', videoSrc, 'code', code);
           setSourceMissing(code === 4);
           setLoadError(true);
         }
-      }, { once: true });
+      });
       videoContainerRef.current.appendChild(videoEl);
     }
 
@@ -325,6 +339,7 @@ function WaveformTimeline({
     wsRef.current = ws;
 
     return () => {
+      if (videoRetryTimer) clearTimeout(videoRetryTimer);
       // Gracefully stop before destroy to avoid WaveSurfer's internal
       // fetch progress handler logging "AbortError: Fetch is aborted".
       try { ws.pause(); } catch (_) {}

--- a/frontend/src/pages/DubTab.css
+++ b/frontend/src/pages/DubTab.css
@@ -102,7 +102,7 @@
 .dub-prep-overlay__note {
   font-size: var(--text-xs);
   color: var(--color-fg-subtle);
-  max-width: 320px;
+  max-width: min(320px, 90vw);
   text-align: center;
 }
 .dub-prep-overlay__detail {
@@ -112,7 +112,7 @@
   letter-spacing: 0.02em;
 }
 .dub-prep-bar {
-  width: 240px;
+  width: min(240px, 85vw);
   height: 4px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.06);
@@ -431,12 +431,12 @@
   margin-left: 2px;
 }
 /* Size fields so they share the row proportionally */
-.dub-settings-field--lang    { flex: 1 1 100px; min-width: 90px; }
-.dub-settings-field--iso     { flex: 0 0 72px; }
-.dub-settings-field--engine  { flex: 1.4 1 130px; min-width: 110px; }
-.dub-settings-field--quality { flex: 0 0 auto; min-width: 100px; }
+.dub-settings-field--lang    { flex: 1 1 100px; min-width: 70px; }
+.dub-settings-field--iso     { flex: 0 1 72px; min-width: 52px; }
+.dub-settings-field--engine  { flex: 1.4 1 130px; min-width: 90px; }
+.dub-settings-field--quality { flex: 0 1 auto; min-width: 80px; }
 .dub-settings-field--quality > *:last-child { width: 100%; }
-.dub-settings-field--style   { flex: 1 1 90px; min-width: 80px; }
+.dub-settings-field--style   { flex: 1 1 90px; min-width: 64px; }
 @media (max-width: 960px) {
   .dub-settings-bar__fields { flex-direction: column; }
   .dub-settings-field--lang,
@@ -625,8 +625,8 @@
 /* Bulk-select row controls */
 .dub-bulk-select               { font-size: 0.62rem; padding: 2px 4px; }
 .dub-bulk-select--flex         { flex: 1; }
-.dub-bulk-select--voice        { min-width: 100px; }
-.dub-bulk-select--lang         { width: 90px; }
+.dub-bulk-select--voice        { min-width: 72px; flex: 1 1 100px; }
+.dub-bulk-select--lang         { width: auto; min-width: 64px; flex: 0 1 90px; }
 .dub-bulk-row__clear           { margin-left: auto; }
 
 /* Footer banner gapping */

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -8,7 +8,7 @@ import {
   ExternalLink, Copy,
 } from 'lucide-react';
 // lucide-react exports DownloadIcon as "Download"; alias here to match App.jsx naming.
-import { Download as Download } from 'lucide-react';
+import { Download as Download, RotateCcw } from 'lucide-react';
 import SearchableSelect from '../components/SearchableSelect';
 import WaveformTimeline from '../components/WaveformTimeline';
 import CheckpointBanner from '../components/CheckpointBanner';
@@ -296,8 +296,8 @@ export default function DubTab(props) {
               )}
             </div>
             <div className="dub-head__actions">
-              <Button variant="subtle" size="sm" disabled leading={<Save size={9} />}>{t('dub.save')}</Button>
-              <Button variant="ghost"  size="sm" disabled>{t('dub.reset')}</Button>
+              <Button variant="subtle" size="sm" disabled title={t('dub.save')} aria-label={t('dub.save')}><Save size={12} /></Button>
+              <Button variant="ghost" size="sm" disabled title={t('dub.reset')} aria-label={t('dub.reset')}><RotateCcw size={12} /></Button>
             </div>
           </div>
 
@@ -605,8 +605,12 @@ export default function DubTab(props) {
               )}
             </div>
             <div className="dub-head__actions">
-              <Button variant="subtle" size="sm" onClick={saveProject} leading={<Save size={9} />}>{t('dub.save')}</Button>
-              <Button variant="danger" size="sm" onClick={resetDub}>{t('dub.reset')}</Button>
+              {/* Icon-only secondary actions (tooltips carry the labels);
+                  Generate Dub keeps its label as the primary verb. */}
+              <Button variant="subtle" size="sm" onClick={saveProject}
+                title={t('dub.save')} aria-label={t('dub.save')}><Save size={12} /></Button>
+              <Button variant="danger" size="sm" onClick={resetDub}
+                title={t('dub.reset')} aria-label={t('dub.reset')}><RotateCcw size={12} /></Button>
               {/* Primary actions live on the header bar (compact) — moved up from the footer. */}
               <div className="dub-head__primary">
                 {dubStep === 'stopping' ? (
@@ -629,7 +633,8 @@ export default function DubTab(props) {
                 <FooterBtn sm tone={dubStep === 'done' ? 'green' : 'idle'}
                   disabled={dubStep !== 'done' && !dubSegments.length}
                   onClick={() => setExportOpen(true)}
-                  icon={<Download size={11} />} label={t('dub.export_btn')} />
+                  icon={<Download size={12} />}
+                  title={t('dub.export_btn')} aria-label={t('dub.export_btn')} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Three dub-editor reports: (1) dark video after YouTube ingest — first load raced yt-dlp finalization and the once-only error handler declared the source dead; now retries with backoff before failing. (2) Responsive pass: min-width:0 shrink traps fixed, settings fields/bulk selects get shrink room, segment-table rails narrow at 1100px and collapse speaker+gain below 760px. (3) Save/Reset/Export icon-only with tooltips + aria-labels; Generate Dub keeps its label. Vitest 196/196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video preview ingest now automatically retries on transient network failures with incremental backoff, improving reliability on unstable connections.

* **Style**
  * Enhanced responsive design for mobile and tablet viewports with improved layout spacing and control visibility on smaller screens.
  * Editor header controls now use compact icon-only buttons with accessible tooltips for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->