### PR TITLE
fix(gguf): forward speech generation controls

### DIFF
--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -82,6 +82,33 @@ class SpeechRequest(BaseModel):
         "E.g. 'young female, warm tone, slight British accent'.",
     )
     instruct: Optional[str] = Field(default=None, description="Style instruction for the TTS engine.")
+    duration: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description="OmniVoice extension: target output duration in seconds.",
+    )
+    seed: Optional[int] = Field(
+        default=None,
+        description="OmniVoice extension: deterministic sampling seed.",
+    )
+    denoise: bool = Field(
+        default=True,
+        description="OmniVoice extension: prepend denoise control when supported.",
+    )
+    preprocess_prompt: bool = Field(
+        default=True,
+        description="OmniVoice extension: trim/preprocess reference prompt when supported.",
+    )
+    chunk_duration: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="OmniVoice GGUF extension: long-form internal chunk duration.",
+    )
+    chunk_threshold: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="OmniVoice GGUF extension: long-form internal chunk threshold.",
+    )
 
 
 class TranscriptionResponse(BaseModel):
@@ -222,7 +249,17 @@ async def create_speech(req: SpeechRequest):
     # Build kwargs for the backend's generate() method
     kw: dict = {
         "speed": req.speed,
+        "denoise": req.denoise,
+        "preprocess_prompt": req.preprocess_prompt,
     }
+    if req.duration is not None:
+        kw["duration"] = req.duration
+    if req.seed is not None:
+        kw["seed"] = req.seed
+    if req.chunk_duration is not None:
+        kw["chunk_duration"] = req.chunk_duration
+    if req.chunk_threshold is not None:
+        kw["chunk_threshold"] = req.chunk_threshold
     if req.language:
         kw["language"] = req.language
     if req.instruct:
@@ -251,6 +288,8 @@ async def create_speech(req: SpeechRequest):
                     kw["ref_text"] = row["ref_text"]
                 if row["instruct"] and not req.instruct:
                     kw["instruct"] = row["instruct"]
+                if req.seed is None and row["seed"] is not None:
+                    kw["seed"] = row["seed"]
             else:
                 # Not a profile ID — forward as engine preset name
                 kw["voice"] = voice

--- a/backend/engines/omnivoice_gguf/backend.py
+++ b/backend/engines/omnivoice_gguf/backend.py
@@ -493,6 +493,12 @@ def _make_backend_class():
               * ``ref_audio`` (str/Path) — speaker reference WAV for cloning.
               * ``ref_text`` (str) — transcript of ``ref_audio``.
               * ``language`` (str) — ISO code or omnivoice-tts lang label.
+              * ``instruct`` (str) — style instruction.
+              * ``duration`` (float) — target duration in seconds.
+              * ``seed`` (int) — deterministic sampling seed.
+              * ``denoise`` (bool) — omit denoise token when false.
+              * ``preprocess_prompt`` (bool) — skip prompt preprocessing when false.
+              * ``chunk_duration`` / ``chunk_threshold`` (float) — binary long-form controls.
             """
             import soundfile as sf  # local import keeps module import cheap
             import torch
@@ -503,15 +509,32 @@ def _make_backend_class():
             fd, out_str = tempfile.mkstemp(prefix="omnivoice-gguf-", suffix=".wav")
             os.close(fd)
             out_path = Path(out_str)
+            ref_text_path: Optional[Path] = None
 
             try:
+                ref_text = kw.get("ref_text")
+                if kw.get("ref_audio") and ref_text:
+                    text_fd, text_str = tempfile.mkstemp(
+                        prefix="omnivoice-gguf-ref-", suffix=".txt"
+                    )
+                    os.close(text_fd)
+                    ref_text_path = Path(text_str)
+                    ref_text_path.write_text(str(ref_text), encoding="utf-8")
+
                 argv = self._build_argv(
                     base=base_path,
                     tokenizer=tok_path,
                     out_path=out_path,
                     ref_audio=kw.get("ref_audio"),
-                    ref_text=kw.get("ref_text"),
+                    ref_text=str(ref_text_path) if ref_text_path else None,
                     language=kw.get("language"),
+                    instruct=kw.get("instruct"),
+                    duration=kw.get("duration"),
+                    seed=kw.get("seed"),
+                    denoise=kw.get("denoise", True),
+                    preprocess_prompt=kw.get("preprocess_prompt", True),
+                    chunk_duration=kw.get("chunk_duration"),
+                    chunk_threshold=kw.get("chunk_threshold"),
                 )
                 self._run_subprocess(argv, stdin_text=text)
                 wav, sr = sf.read(str(out_path))
@@ -520,6 +543,11 @@ def _make_backend_class():
                     out_path.unlink()
                 except OSError:
                     pass
+                if ref_text_path is not None:
+                    try:
+                        ref_text_path.unlink()
+                    except OSError:
+                        pass
 
             # soundfile returns (n,) for mono or (n, c) for multichannel.
             # OmniVoice/Higgs Audio v2 is mono → (n,). Wrap to (1, n).
@@ -544,6 +572,13 @@ def _make_backend_class():
             ref_audio: Optional[str],
             ref_text: Optional[str],
             language: Optional[str],
+            instruct: Optional[str] = None,
+            duration: Optional[float] = None,
+            seed: Optional[int] = None,
+            denoise: bool = True,
+            preprocess_prompt: bool = True,
+            chunk_duration: Optional[float] = None,
+            chunk_threshold: Optional[float] = None,
         ) -> list[str]:
             """Compose argv from typed Path objects only (T-04-02)."""
             argv: list[str] = [
@@ -555,6 +590,20 @@ def _make_backend_class():
             lang = _iso_to_omnivoice_lang(language)
             if lang:
                 argv += ["--lang", lang]
+            if instruct:
+                argv += ["--instruct", str(instruct)]
+            if duration is not None:
+                argv += ["--duration", str(float(duration))]
+            if seed is not None:
+                argv += ["--seed", str(int(seed))]
+            if denoise is False:
+                argv += ["--no-denoise"]
+            if preprocess_prompt is False:
+                argv += ["--no-preprocess-prompt"]
+            if chunk_duration is not None:
+                argv += ["--chunk-duration", str(float(chunk_duration))]
+            if chunk_threshold is not None:
+                argv += ["--chunk-threshold", str(float(chunk_threshold))]
             if ref_audio:
                 # Two-stage validation (defense in depth):
                 #   (a) Reject anything outside the project's voices /
@@ -588,11 +637,8 @@ def _make_backend_class():
                     )
                 argv += ["--ref-wav", str(ref_path)]
                 if ref_text:
-                    # ref_text is free-form text; pass via stdin would
-                    # collide with the synthesis prompt, so the only safe
-                    # channel is argv. The binary treats this as a quoted
-                    # string at the OS layer (Popen escapes argv per
-                    # platform); we don't pre-escape.
+                    # The C++ runtime expects a transcript file path.
+                    # generate() creates this file in the system temp dir.
                     argv += ["--ref-text", str(ref_text)]
             return argv
 

--- a/tests/backend/engines/test_omnivoice_gguf.py
+++ b/tests/backend/engines/test_omnivoice_gguf.py
@@ -251,6 +251,108 @@ def test_generate_returns_tensor_from_stub_wav(monkeypatch, tmp_path):
     assert captured["stdin"] == "hello world"
 
 
+def test_generate_forwards_control_arguments(monkeypatch, tmp_path):
+    """The GGUF binary exposes quality/prosody controls; the adapter must not
+    silently drop them."""
+    from engines.omnivoice_gguf import backend as gguf_backend
+
+    cls = gguf_backend._make_backend_class()
+    backend = cls()
+
+    fake_base = tmp_path / "omnivoice-base-Q8_0.gguf"
+    fake_tok = tmp_path / "omnivoice-tokenizer-Q8_0.gguf"
+    fake_base.write_bytes(b"x")
+    fake_tok.write_bytes(b"x")
+    monkeypatch.setattr(
+        backend,
+        "_resolve_quant_paths",
+        lambda: (fake_base, fake_tok, {"base": "omnivoice-base-Q8_0.gguf",
+                                       "tokenizer": "omnivoice-tokenizer-Q8_0.gguf"}),
+    )
+    monkeypatch.setattr(
+        gguf_backend, "_binary_path", lambda slug=None: tmp_path / "fake-omnivoice-tts",
+    )
+
+    captured: dict = {}
+
+    def _stub_run(argv, *, input=None, text=None, capture_output=None,
+                  timeout=None, check=None, **_kw):
+        for i, a in enumerate(argv):
+            if a == "-o":
+                _write_3s_wav(Path(argv[i + 1]))
+                break
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _stub_run)
+
+    backend.generate(
+        "hello world",
+        instruct="calm narrator",
+        duration=3.2,
+        seed=1234,
+        denoise=False,
+        preprocess_prompt=False,
+        chunk_duration=0,
+        chunk_threshold=999,
+    )
+
+    argv = captured["argv"]
+    assert argv[argv.index("--instruct") + 1] == "calm narrator"
+    assert argv[argv.index("--duration") + 1] == "3.2"
+    assert argv[argv.index("--seed") + 1] == "1234"
+    assert "--no-denoise" in argv
+    assert "--no-preprocess-prompt" in argv
+    assert argv[argv.index("--chunk-duration") + 1] == "0.0"
+    assert argv[argv.index("--chunk-threshold") + 1] == "999.0"
+
+
+def test_generate_passes_ref_text_as_temporary_file(monkeypatch, tmp_path):
+    from engines.omnivoice_gguf import backend as gguf_backend
+
+    cls = gguf_backend._make_backend_class()
+    backend = cls()
+    fake_base = tmp_path / "omnivoice-base-Q8_0.gguf"
+    fake_tok = tmp_path / "omnivoice-tokenizer-Q8_0.gguf"
+    fake_ref = tmp_path / "reference.wav"
+    fake_base.write_bytes(b"x")
+    fake_tok.write_bytes(b"x")
+    fake_ref.write_bytes(b"x")
+    monkeypatch.setattr(
+        backend,
+        "_resolve_quant_paths",
+        lambda: (fake_base, fake_tok, {"base": fake_base.name,
+                                       "tokenizer": fake_tok.name}),
+    )
+    monkeypatch.setattr(
+        gguf_backend, "_binary_path", lambda slug=None: tmp_path / "fake-omnivoice-tts",
+    )
+
+    captured: dict = {}
+
+    def _stub_run(argv, *, input=None, text=None, capture_output=None,
+                  timeout=None, check=None, **_kw):
+        ref_text_path = Path(argv[argv.index("--ref-text") + 1])
+        captured["ref_text_path"] = ref_text_path
+        captured["ref_text"] = ref_text_path.read_text(encoding="utf-8")
+        for i, arg in enumerate(argv):
+            if arg == "-o":
+                _write_3s_wav(Path(argv[i + 1]))
+                break
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _stub_run)
+
+    backend.generate(
+        "hello world",
+        ref_audio=str(fake_ref),
+        ref_text="reference transcript",
+    )
+
+    assert captured["ref_text"] == "reference transcript"
+    assert not captured["ref_text_path"].exists()
+
+
 def test_generate_blocks_freeform_ref_audio(monkeypatch, tmp_path):
     """T-04-02 — ref_audio path that doesn't exist is rejected before
     spawning the subprocess."""


### PR DESCRIPTION
## Summary

- forward GGUF prosody and deterministic generation controls from the OpenAI-compatible speech endpoint
- pass reference transcripts through a temporary UTF-8 file as required by the C++ runtime
- use a profile seed when the request does not provide one

## Supported controls

- `instruct`
- `duration`
- `seed`
- `denoise`
- `preprocess_prompt`
- `chunk_duration`
- `chunk_threshold`

## Tests

- `15 passed` in `tests/backend/engines/test_omnivoice_gguf.py`
- includes control forwarding and reference transcript lifecycle coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended audio synthesis API with advanced controls: timing (`duration`), reproducibility (`seed`), denoising, prompt preprocessing, and long-form audio chunking parameters.
  * Voice profiles now automatically apply stored seed values when not explicitly specified.
  * Enhanced reference text handling for voice synthesis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->