### PR TITLE
fix(tts): let studio engines skip the broadcast mastering chain

### DIFF
--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -298,6 +298,9 @@ async def _run_batch_pipeline(job_id: str, job: dict):
                         denoise=True, postprocess_output=True,
                     )
                     audio_out = audios[0]
+                    # TODO(#312): this route runs the OmniVoice model directly (not the active
+                    # backend), so VoxCPM2 never reaches it. When these routes become
+                    # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
                     mastered = apply_mastering(
                         audio_out,
                         sample_rate=sr,

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -265,6 +265,9 @@ async def dub_generate(job_id: str, req: DubRequest):
                     if seg_effect_preset == "raw":
                         return audio_out
 
+                    # TODO(#312): this route runs the OmniVoice model directly (not the active
+                    # backend), so VoxCPM2 never reaches it. When these routes become
+                    # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
                     mastered_audio = apply_mastering(audio_out, sample_rate=sr)
                     effect_chain = get_effect_chain(seg_effect_preset)
                     if effect_chain:
@@ -310,6 +313,9 @@ async def dub_generate(job_id: str, req: DubRequest):
                         if seg_effect_preset == "raw":
                             return audio_out
 
+                        # TODO(#312): this route runs the OmniVoice model directly (not the active
+                        # backend), so VoxCPM2 never reaches it. When these routes become
+                        # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
                         mastered_audio = apply_mastering(audio_out, sample_rate=sr)
                         effect_chain = get_effect_chain(seg_effect_preset)
                         if effect_chain:
@@ -784,6 +790,9 @@ async def preview_segment(job_id: str, req: SegmentPreviewRequest):
             postprocess_output=True,
         )
         audio_out = audios[0]
+        # TODO(#312): this route runs the OmniVoice model directly (not the active
+        # backend), so VoxCPM2 never reaches it. When these routes become
+        # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
         mastered = apply_mastering(
             audio_out,
             sample_rate=getattr(_model, "sampling_rate", 24000),

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -123,6 +123,9 @@ def _run_inference(
             # Raw: skip all DSP — return raw model output
             return audio_out
 
+        # TODO(#312): this route runs the OmniVoice model directly (not the active
+        # backend), so VoxCPM2 never reaches it. When these routes become
+        # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
         mastered_audio = apply_mastering(audio_out, sample_rate=sr)
         _chain = get_effect_chain(_effect_preset)
         if _chain:

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -209,7 +209,14 @@ def _run_tts(backend, text: str, kw: dict):
     from services.audio_dsp import apply_mastering, normalize_audio
     wav = backend.generate(text, **kw)
     sr = backend.sample_rate
-    wav = apply_mastering(wav, sample_rate=sr)
+    # Engines that already emit mastered, studio-grade audio (e.g. VoxCPM2's
+    # native 48 kHz) opt out of apply_mastering via `applies_own_mastering`.
+    # That chain's Compressor + 8% Reverb is tuned for OmniVoice's 24 kHz clone
+    # output; applied to a studio engine it adds an audible level pump and a
+    # reverb tail that degrade the very output we want clean. Loudness
+    # normalisation still runs — it's a benign peak scale, not dynamics.
+    if not getattr(backend, "applies_own_mastering", False):
+        wav = apply_mastering(wav, sample_rate=sr)
     wav = normalize_audio(wav, target_dBFS=-2.0)
     return wav, sr
 

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -152,7 +152,12 @@ async def ws_tts(websocket: WebSocket):
                     from services.audio_dsp import apply_mastering, normalize_audio
                     wav = backend.generate(text, **kw)
                     sr_actual = backend.sample_rate
-                    wav = apply_mastering(wav, sample_rate=sr_actual)
+                    # Like _run_tts in openai_compat: studio engines (VoxCPM2)
+                    # opt out of the broadcast mastering chain. This is the
+                    # other route that runs the active backend, so it needs the
+                    # same guard. Loudness normalisation still runs.
+                    if not getattr(backend, "applies_own_mastering", False):
+                        wav = apply_mastering(wav, sample_rate=sr_actual)
                     wav = normalize_audio(wav, target_dBFS=-2.0)
                     return wav, sr_actual
 

--- a/backend/services/batched_tts.py
+++ b/backend/services/batched_tts.py
@@ -151,6 +151,9 @@ async def generate_segments_batched(
                     # Raw: skip all DSP — return raw model output
                     return audio_out
 
+                # TODO(#312): this route runs the OmniVoice model directly (not the active
+                # backend), so VoxCPM2 never reaches it. When these routes become
+                # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
                 mastered = apply_mastering(audio_out, sample_rate=sr)
                 effect_chain = get_effect_chain(seg_effect_preset)
                 if effect_chain:

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -87,6 +87,13 @@ class TTSBackend(ABC):
     #: (e.g. "young female, warm tone, British accent") without reference audio.
     supports_voice_design: bool = False
 
+    #: Whether this engine already emits mastered, studio-grade audio and should
+    #: therefore skip the shared apply_mastering() chain (Compressor + Reverb,
+    #: tuned for OmniVoice's 24 kHz output). Studio engines like VoxCPM2 (native
+    #: 48 kHz) set this True so their clean output isn't pumped/reverbed. Loudness
+    #: normalisation is applied regardless — it's a benign peak scale.
+    applies_own_mastering: bool = False
+
     #: GPU/accelerator targets the engine can run on. Surfaced via the
     #: Engine Compatibility Matrix (Plan 02-04 / ENGINE-06) so users can
     #: tell at a glance which engines will use their hardware. Defaults to
@@ -246,6 +253,7 @@ class VoxCPM2Backend(TTSBackend):
     id = "voxcpm2"
     display_name = "VoxCPM2 (30 langs, studio 48 kHz, voice design)"
     supports_voice_design = True
+    applies_own_mastering = True  # native 48 kHz studio output — skip apply_mastering()
     gpu_compat = ("cuda", "mps", "cpu")
 
     def __init__(self):


### PR DESCRIPTION
## Problem

`_run_tts()` in the OpenAI-compatible `/v1/audio/speech` route applies `apply_mastering()` to **every** engine's output. That chain — `HighpassFilter(60Hz)` + `Compressor(threshold=-15, ratio=1.5)` + `Reverb(wet=0.08)` — is tuned for OmniVoice's 24 kHz clone output, where it adds broadcast polish.

Applied to **VoxCPM2**, whose native output is already studio-grade 48 kHz, the same chain is *degradation*, not polish: the compressor introduces an audible level pump and the reverb adds a tail. Cloning the same reference through VoxCPM2 directly (raw) vs. through `/v1/audio/speech` makes the difference clearly audible.

## Fix

Add an opt-out class flag on the backend base:

```python
class TTSBackend(ABC):
    applies_own_mastering: bool = False   # default: unchanged for all engines
```

Set it on the one engine that emits mastered studio output:

```python
class VoxCPM2Backend(TTSBackend):
    applies_own_mastering = True
```

`_run_tts()` skips `apply_mastering()` when the active backend declares it. **Loudness normalisation (`normalize_audio`) still runs for every engine** — that's a benign peak scale, not dynamics processing, so output levels stay consistent.

## Compatibility

Default is `False`, so behaviour is **unchanged for every existing engine** except VoxCPM2. No API/schema change. Other studio-grade engines (e.g. future 48 kHz backends) can opt in by setting the same flag.

## How to reproduce the original issue

1. Install VoxCPM2 (`pip install voxcpm`), select it as the active TTS engine.
2. Create a voice profile, then `POST /v1/audio/speech` with `voice=<profile_id>`, `response_format=wav`.
3. Compare against raw `VoxCPM.generate(...)` output of the same text/reference — the API version has a level pump + reverb tail that the raw output doesn't.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio-grade TTS engines can opt out of shared mastering to preserve native quality; streaming still applies loudness normalization for consistent volume.
* **Bug Fixes**
  * Avoids redundant mastering that could degrade audio or waste processing, improving output fidelity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->