### PR TITLE
fix(dub): Timing strategy options never rendered — wrong prop name on Segmented (#313)

### DIFF
--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -942,7 +942,7 @@ export default function DubTab(props) {
                   <Segmented
                     value={timingStrategy}
                     onChange={setTimingStrategy}
-                    options={[
+                    items={[
                       { value: 'concise',       label: 'Concise',        title: 'Translator trims text to fit at natural rate. Overflows surface in the row badge so you can shorten the segment.' },
                       { value: 'stretch_video', label: 'Stretch Video',  title: 'Audio plays at natural rate; each segment of the video is stretched (per-segment ffmpeg setpts) to fit. Total video duration grows. Requires a re-encode pass.' },
                       { value: 'strict_slot',   label: 'Strict slot',    title: 'Legacy: compress audio to fit the original timing. Can sound rushed/chipmunky on high-density target languages.' },


### PR DESCRIPTION
## Problem

Fixes #313 (Discord report: dubbing to Korean, wanted to stretch the video to match the audio — the TIMING row showed one dead empty radio and nothing was clickable).

`DubTab.jsx` passed `options={[...]}` to `<Segmented>`, but the component's prop is `items` (default `[]`) — so the toggle group rendered zero options. Broken since the control was introduced in 8b00dc1; all other `Segmented` call sites use `items=`.

## Fix

One word: `options=` → `items=`. The three strategies (Concise / Stretch Video / Strict slot) now render and are selectable; the store default `'concise'` highlights correctly and `useDubWorkflow` already forwards `timing_strategy` to the backend.

## Verification

- eslint: identical 3 pre-existing findings before/after — nothing introduced.
- Store value set (`prefsSlice.ts:105` default `'concise'`) matches an option value, so the active state renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Timing setting control configuration for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->