### PR TITLE
fix(tts): /generate honors the selected TTS engine (#312)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -59,13 +59,65 @@ def _render_with_pauses(gen_span, segments, sample_rate):
             parts.append(torch.zeros(*shape, dtype=ref.dtype, device=ref.device))
     return torch.cat(parts, dim=-1)
 
+
+def _apply_effect_chain(audio_out, sample_rate, effect_preset, *, skip_mastering=False):
+    """Shared post-DSP for /generate: preset validation → mastering →
+    effect chain → loudness normalization.
+
+    ``skip_mastering`` honors a backend's ``applies_own_mastering`` flag
+    (issue #312): studio engines (e.g. VoxCPM2's native 48 kHz output)
+    opt out of the broadcast Compressor + Reverb chain that's tuned for
+    OmniVoice's 24 kHz clone output. Loudness normalization still runs —
+    it's a benign peak scale. Mirrors ``_run_tts`` in openai_compat.py.
+    """
+    from services.audio_dsp import (
+        EFFECT_PRESETS, apply_mastering, normalize_audio,
+        apply_effects_chain, get_effect_chain,
+    )
+
+    preset = effect_preset or "broadcast"
+    if preset not in EFFECT_PRESETS:
+        raise ValueError(
+            f"Unknown effect preset: {preset!r}. "
+            f"Valid: {list(EFFECT_PRESETS.keys())}"
+        )
+
+    if preset == "raw":
+        # Raw: skip all DSP — return raw model output
+        return audio_out
+
+    if not skip_mastering:
+        audio_out = apply_mastering(audio_out, sample_rate=sample_rate)
+    chain = get_effect_chain(preset)
+    if chain:
+        audio_out = apply_effects_chain(
+            audio_out, sample_rate=sample_rate, chain=chain,
+        )
+    return normalize_audio(audio_out, target_dBFS=-2.0)
+
+
+def _oom_friendly_reraise(e):
+    """Best-effort cache flush + the user-facing OOM hint shared by both
+    inference paths."""
+    import gc
+    import torch
+    gc.collect()
+    if torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+    elif torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    raise RuntimeError(
+        f"TTS engine stopped mid-generation. This usually means it ran out of memory. "
+        f"Try the Flush button to reload the model, then regenerate. Underlying error: {e}"
+    )
+
+
 def _run_inference(
     model, text, language, ref_audio_path, ref_text, instruct, duration,
     num_step, guidance_scale, speed, t_shift, denoise,
     postprocess_output, layer_penalty_factor, position_temperature,
     class_temperature, used_seed, effect_preset="broadcast",
 ):
-    from services.audio_dsp import apply_mastering, normalize_audio, apply_effects_chain, get_effect_chain
     import torch
     try:
         if used_seed is not None:
@@ -108,47 +160,70 @@ def _run_inference(
             )
             audio_out = audios[0]
 
-        # Apply DSP effect preset
-        _effect_preset = effect_preset or "broadcast"
+        # Apply DSP effect preset. The OmniVoice model never masters its own
+        # output, so mastering always runs here (unchanged behavior).
+        return _apply_effect_chain(audio_out, sr, effect_preset)
 
-        # Validate preset ID
-        from services.audio_dsp import EFFECT_PRESETS
-        if _effect_preset not in EFFECT_PRESETS:
-            raise ValueError(
-                f"Unknown effect preset: {_effect_preset!r}. "
-                f"Valid: {list(EFFECT_PRESETS.keys())}"
-            )
-
-        if _effect_preset == "raw":
-            # Raw: skip all DSP — return raw model output
-            return audio_out
-
-        # TODO(#312): this route runs the OmniVoice model directly (not the active
-        # backend), so VoxCPM2 never reaches it. When these routes become
-        # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
-        mastered_audio = apply_mastering(audio_out, sample_rate=sr)
-        _chain = get_effect_chain(_effect_preset)
-        if _chain:
-            mastered_audio = apply_effects_chain(
-                mastered_audio, sample_rate=sr, chain=_chain,
-            )
-
-        return normalize_audio(mastered_audio, target_dBFS=-2.0)
-        
     except ValueError as e:
         # Don't wrap validation errors in OOM message
         raise e
     except Exception as e:
-        import gc
-        gc.collect()
-        if torch.backends.mps.is_available():
-            torch.mps.empty_cache()
-        elif torch.cuda.is_available():
-            torch.cuda.empty_cache()
-        raise RuntimeError(
-            f"TTS engine stopped mid-generation. This usually means it ran out of memory. "
-            f"Try the Flush button to reload the model, then regenerate. Underlying error: {e}"
+        _oom_friendly_reraise(e)
+
+
+def _run_backend_inference(
+    backend, text, language, ref_audio_path, ref_text, instruct, duration,
+    num_step, guidance_scale, speed, denoise, postprocess_output,
+    used_seed, effect_preset="broadcast",
+):
+    """Engine-aware twin of :func:`_run_inference` (issue #312).
+
+    Runs the request through a pluggable ``TTSBackend`` adapter instead of the
+    OmniVoice model directly. The adapter protocol is narrower than the
+    OmniVoice-native surface — engine-specific extras (``t_shift``,
+    ``layer_penalty_factor``, …) only exist on the native path, which is why
+    OmniVoice itself still goes through ``_run_inference``.
+    """
+    import torch
+    try:
+        if used_seed is not None:
+            torch.manual_seed(used_seed)
+
+        if language and language.lower() == "auto":
+            language = None
+
+        gen_kwargs = dict(
+            language=language, ref_audio=ref_audio_path, ref_text=ref_text,
+            instruct=instruct, num_step=num_step, guidance_scale=guidance_scale,
+            speed=speed, denoise=denoise, postprocess_output=postprocess_output,
         )
+        sr = backend.sample_rate
+
+        # Inline [pause Nms] markers (issue #276) work for every engine — the
+        # silence stitching is model-free.
+        from omnivoice.utils.text import parse_pause_markers
+        segments = parse_pause_markers(text)
+        has_pause = len(segments) > 1 or (segments and segments[0][1] > 0)
+
+        if has_pause:
+            def _gen_span(span_text):
+                # Per-span duration is left to the engine; an explicit overall
+                # `duration` can't be meaningfully split across spans.
+                return backend.generate(span_text, duration=None, **gen_kwargs)
+            audio_out = _render_with_pauses(_gen_span, segments, sr)
+        else:
+            audio_out = backend.generate(text, duration=duration, **gen_kwargs)
+
+        return _apply_effect_chain(
+            audio_out, sr, effect_preset,
+            skip_mastering=getattr(backend, "applies_own_mastering", False),
+        )
+
+    except ValueError as e:
+        # Don't wrap validation errors in OOM message
+        raise e
+    except Exception as e:
+        _oom_friendly_reraise(e)
 
 
 @router.post("/generate")
@@ -171,8 +246,51 @@ async def generate_speech(
     profile_id: Optional[str] = Form(None),
     seed: Optional[int] = Form(None),
     effect_preset: str = Form("broadcast"),
+    engine: Optional[str] = Form(None),
 ):
-    _model = await get_model()
+    # ── Engine resolution (issue #312) ──────────────────────────────────────
+    # The request runs on the engine selected in Settings (POST /engines/select,
+    # env var OMNIVOICE_TTS_BACKEND wins), or an explicit per-request `engine`
+    # override — same pattern as /ws/tts's `engine` field and /v1/audio/speech's
+    # `model`. Omitting both keeps the historical default (OmniVoice), so
+    # existing API consumers see no change.
+    from services.tts_backend import (
+        OmniVoiceBackend, _mask_hf_tokens, active_backend_id, get_backend_class,
+    )
+
+    engine_id = engine or active_backend_id()
+    try:
+        backend_cls = get_backend_class(engine_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown TTS engine: {engine_id!r}. "
+                "See GET /engines/tts for the list of valid engine ids."
+            ),
+        )
+
+    _model = None
+    _backend = None
+    if backend_cls is OmniVoiceBackend:
+        # OmniVoice keeps its native path: it carries the full advanced
+        # parameter surface (t_shift, layer/position/class controls) that the
+        # generic adapter protocol doesn't. Byte-identical to the old behavior.
+        _model = await get_model()
+    else:
+        try:
+            ok, msg = backend_cls.is_available()
+        except Exception as exc:
+            ok, msg = False, f"{type(exc).__name__}: {exc}"
+        if not ok:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TTS engine '{engine_id}' is not available: {_mask_hf_tokens(msg)}",
+            )
+        # Reuse the per-process instance cache shared with the engine
+        # health-check route so weights load once, not per request.
+        from api.routers.engines import _get_engine_instance
+        _backend = _get_engine_instance(backend_cls)
 
     ref_audio_path = None
     cleanup_ref = False
@@ -230,13 +348,25 @@ async def generate_speech(
     start_time = time.time()
     try:
         loop = asyncio.get_running_loop()
-        audio_tensor = await loop.run_in_executor(
-            _gpu_pool, _run_inference,
-            _model, text, language, ref_audio_path, ref_text, instruct, duration,
-            num_step, guidance_scale, speed, t_shift, denoise,
-            postprocess_output, layer_penalty_factor, position_temperature,
-            class_temperature, used_seed, effect_preset,
-        )
+        if _backend is not None:
+            audio_tensor = await loop.run_in_executor(
+                _gpu_pool, _run_backend_inference,
+                _backend, text, language, ref_audio_path, ref_text, instruct,
+                duration, num_step, guidance_scale, speed, denoise,
+                postprocess_output, used_seed, effect_preset,
+            )
+            # Read after generation: engines with lazy model loading report
+            # their real rate only once weights are up.
+            sample_rate = _backend.sample_rate
+        else:
+            audio_tensor = await loop.run_in_executor(
+                _gpu_pool, _run_inference,
+                _model, text, language, ref_audio_path, ref_text, instruct, duration,
+                num_step, guidance_scale, speed, t_shift, denoise,
+                postprocess_output, layer_penalty_factor, position_temperature,
+                class_temperature, used_seed, effect_preset,
+            )
+            sample_rate = _model.sampling_rate
         # Invisible AudioSeal provenance watermark on the final audio. Embedding
         # was previously only wired into the dub pipeline (dub_generate.py), so
         # plain TTS came out unmarked despite the setting being on. embed_watermark
@@ -245,16 +375,16 @@ async def generate_speech(
         # generation.
         from services.watermark import embed_watermark
         audio_tensor = await loop.run_in_executor(
-            _gpu_pool, embed_watermark, audio_tensor, _model.sampling_rate
+            _gpu_pool, embed_watermark, audio_tensor, sample_rate
         )
         gen_time = round(time.time() - start_time, 2)
 
         audio_id = str(uuid.uuid4())[:8]
         audio_filename = f"{audio_id}.wav"
         audio_path = os.path.join(OUTPUTS_DIR, audio_filename)
-        _safe_torchaudio_save(audio_path, audio_tensor, _model.sampling_rate)
+        _safe_torchaudio_save(audio_path, audio_tensor, sample_rate)
 
-        audio_dur = round(audio_tensor.shape[-1] / _model.sampling_rate, 2)
+        audio_dur = round(audio_tensor.shape[-1] / sample_rate, 2)
 
         with db_conn() as conn:
             conn.execute(
@@ -266,7 +396,7 @@ async def generate_speech(
         event_bus.emit("generation_history", {"action": "created", "id": audio_id})
 
         buffer = io.BytesIO()
-        _safe_torchaudio_save(buffer, audio_tensor, _model.sampling_rate, format="wav")
+        _safe_torchaudio_save(buffer, audio_tensor, sample_rate, format="wav")
         buffer.seek(0)
         wav_bytes = buffer.read()
 

--- a/tests/test_generate_engine.py
+++ b/tests/test_generate_engine.py
@@ -21,19 +21,32 @@ import os
 os.environ.setdefault("OMNIVOICE_MODEL", "test")
 os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
 
+import importlib
+
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
-from services import tts_backend
+
+def _tts_mod():
+    """Resolve services.tts_backend at RUN time, not import time.
+
+    Pytest imports every test module during collection, but tests/backend/**
+    (which runs before tests/test_*.py) stubs modules in sys.modules and
+    re-imports the services tree — so a module-level ``from services import
+    tts_backend`` binding here can be a stale pre-pollution copy that the app's
+    request-time imports no longer see. Resolving through sys.modules inside
+    each test keeps the patches and the routes on the same module object.
+    """
+    return importlib.import_module("services.tts_backend")
 
 
 def _make_fake_engine(engine_id="fake-engine", *, available=True, own_mastering=False):
     """Build a fresh TTSBackend stub class. Fresh per call so the per-process
     instance cache in api.routers.engines can't leak state across tests."""
 
-    class _FakeEngine(tts_backend.TTSBackend):
+    class _FakeEngine(_tts_mod().TTSBackend):
         id = engine_id
         display_name = "Fake Engine (test)"
         applies_own_mastering = own_mastering
@@ -60,13 +73,18 @@ def _make_fake_engine(engine_id="fake-engine", *, available=True, own_mastering=
     return _FakeEngine
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def client():
+    # Function-scoped, NOT context-managed — running the app lifespan here
+    # (module-scoped `with TestClient(app)`) bound event_bus queues to this
+    # module's event loop and broke teardown when the full suite mixes it
+    # with the non-lifespan TestClients every other test file uses
+    # (test_api.py pattern). Loopback client addr: required by the
+    # router-level require_loopback dependency.
     from fastapi.testclient import TestClient
     from main import app
 
-    with TestClient(app, client=("127.0.0.1", 50000)) as c:
-        yield c
+    return TestClient(app, client=("127.0.0.1", 50000))
 
 
 @pytest.fixture()
@@ -85,7 +103,7 @@ def no_omnivoice_model(monkeypatch):
 def test_generate_honors_settings_selected_engine(client, monkeypatch, no_omnivoice_model):
     """Engine selected via Settings (env/prefs resolution) runs the request."""
     fake = _make_fake_engine()
-    monkeypatch.setitem(tts_backend._REGISTRY, "fake-engine", fake)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-engine", fake)
     # Env var is the top of the same resolution chain prefs.json feeds
     # (active_backend_id: env > prefs > default).
     monkeypatch.setenv("OMNIVOICE_TTS_BACKEND", "fake-engine")
@@ -106,7 +124,7 @@ def test_generate_honors_settings_selected_engine(client, monkeypatch, no_omnivo
 def test_generate_engine_param_overrides_selection(client, monkeypatch, no_omnivoice_model):
     """Explicit per-request `engine` form field wins, like /ws/tts's `engine`."""
     fake = _make_fake_engine()
-    monkeypatch.setitem(tts_backend._REGISTRY, "fake-engine", fake)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-engine", fake)
     monkeypatch.delenv("OMNIVOICE_TTS_BACKEND", raising=False)
 
     res = client.post("/generate", data={"text": "Override me", "engine": "fake-engine"})
@@ -125,7 +143,7 @@ def test_generate_unknown_engine_is_400(client, monkeypatch):
 
 def test_generate_unavailable_engine_is_400_with_reason(client, monkeypatch):
     fake = _make_fake_engine(available=False)
-    monkeypatch.setitem(tts_backend._REGISTRY, "fake-engine", fake)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-engine", fake)
     res = client.post("/generate", data={"text": "x", "engine": "fake-engine"})
     assert res.status_code == 400
     detail = res.json()["detail"]
@@ -162,15 +180,15 @@ def test_generate_respects_applies_own_mastering(client, monkeypatch, no_omnivoi
     """Studio engines (applies_own_mastering=True) skip apply_mastering;
     regular engines still get the broadcast chain — parity with
     /v1/audio/speech and /ws/tts."""
-    from services import audio_dsp
+    audio_dsp = importlib.import_module("services.audio_dsp")  # run-time resolve, see _tts_mod
 
     mastering = MagicMock(side_effect=lambda t, sample_rate=24000: t)
     monkeypatch.setattr(audio_dsp, "apply_mastering", mastering)
 
     studio = _make_fake_engine("fake-studio", own_mastering=True)
     plain = _make_fake_engine("fake-plain", own_mastering=False)
-    monkeypatch.setitem(tts_backend._REGISTRY, "fake-studio", studio)
-    monkeypatch.setitem(tts_backend._REGISTRY, "fake-plain", plain)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-studio", studio)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-plain", plain)
 
     res = client.post("/generate", data={"text": "studio", "engine": "fake-studio"})
     assert res.status_code == 200, res.text

--- a/tests/test_generate_engine.py
+++ b/tests/test_generate_engine.py
@@ -1,0 +1,181 @@
+"""Issue #312 — POST /generate must honor the selected TTS engine.
+
+Before the fix, /generate always ran the OmniVoice model via
+`services.model_manager.get_model()` and ignored both the Settings engine
+selection (POST /engines/select → prefs / OMNIVOICE_TTS_BACKEND) and any
+per-request override. These tests prove:
+
+  1. The Settings-selected engine is the one that generates.
+  2. An explicit per-request `engine` form field overrides the selection
+     (same pattern as /ws/tts's `engine` and /v1/audio/speech's `model`).
+  3. Unknown / unavailable engines fail with an actionable 400.
+  4. The default path (no selection, no override) still runs OmniVoice —
+     backward compatible for existing API consumers.
+  5. Engines with `applies_own_mastering=True` skip the broadcast mastering
+     chain, mirroring /v1/audio/speech and /ws/tts.
+
+The engine layer is stubbed (no real model loads), matching test_api.py.
+"""
+import os
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from services import tts_backend
+
+
+def _make_fake_engine(engine_id="fake-engine", *, available=True, own_mastering=False):
+    """Build a fresh TTSBackend stub class. Fresh per call so the per-process
+    instance cache in api.routers.engines can't leak state across tests."""
+
+    class _FakeEngine(tts_backend.TTSBackend):
+        id = engine_id
+        display_name = "Fake Engine (test)"
+        applies_own_mastering = own_mastering
+        calls: list = []
+
+        @property
+        def sample_rate(self) -> int:
+            return 24000
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return ["multi"]
+
+        @classmethod
+        def is_available(cls):
+            if available:
+                return True, "ready"
+            return False, "fake engine deliberately unavailable (test)"
+
+        def generate(self, text, **kw) -> torch.Tensor:
+            type(self).calls.append((text, kw))
+            return torch.zeros(1, 24000)
+
+    return _FakeEngine
+
+
+@pytest.fixture(scope="module")
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+
+    with TestClient(app, client=("127.0.0.1", 50000)) as c:
+        yield c
+
+
+@pytest.fixture()
+def no_omnivoice_model(monkeypatch):
+    """Fail loudly if /generate falls back to the OmniVoice model path."""
+
+    async def _boom():
+        raise AssertionError(
+            "get_model() was called — /generate ignored the selected engine (#312)"
+        )
+
+    import api.routers.generation as gen_mod
+    monkeypatch.setattr(gen_mod, "get_model", _boom)
+
+
+def test_generate_honors_settings_selected_engine(client, monkeypatch, no_omnivoice_model):
+    """Engine selected via Settings (env/prefs resolution) runs the request."""
+    fake = _make_fake_engine()
+    monkeypatch.setitem(tts_backend._REGISTRY, "fake-engine", fake)
+    # Env var is the top of the same resolution chain prefs.json feeds
+    # (active_backend_id: env > prefs > default).
+    monkeypatch.setenv("OMNIVOICE_TTS_BACKEND", "fake-engine")
+
+    res = client.post("/generate", data={"text": "Hello engine", "language": "Auto", "seed": "42"})
+
+    assert res.status_code == 200, res.text
+    assert res.headers.get("content-type") == "audio/wav"
+    assert res.headers.get("x-audio-id")
+    assert len(res.content) > 44  # valid WAV payload
+    assert len(fake.calls) == 1
+    text, kw = fake.calls[0]
+    assert text == "Hello engine"
+    # "Auto" must reach the adapter as None (engines don't know the sentinel).
+    assert kw.get("language") is None
+
+
+def test_generate_engine_param_overrides_selection(client, monkeypatch, no_omnivoice_model):
+    """Explicit per-request `engine` form field wins, like /ws/tts's `engine`."""
+    fake = _make_fake_engine()
+    monkeypatch.setitem(tts_backend._REGISTRY, "fake-engine", fake)
+    monkeypatch.delenv("OMNIVOICE_TTS_BACKEND", raising=False)
+
+    res = client.post("/generate", data={"text": "Override me", "engine": "fake-engine"})
+
+    assert res.status_code == 200, res.text
+    assert len(fake.calls) == 1
+    assert fake.calls[0][0] == "Override me"
+
+
+def test_generate_unknown_engine_is_400(client, monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_TTS_BACKEND", raising=False)
+    res = client.post("/generate", data={"text": "x", "engine": "not-a-real-engine"})
+    assert res.status_code == 400
+    assert "Unknown TTS engine" in res.json()["detail"]
+
+
+def test_generate_unavailable_engine_is_400_with_reason(client, monkeypatch):
+    fake = _make_fake_engine(available=False)
+    monkeypatch.setitem(tts_backend._REGISTRY, "fake-engine", fake)
+    res = client.post("/generate", data={"text": "x", "engine": "fake-engine"})
+    assert res.status_code == 400
+    detail = res.json()["detail"]
+    assert "not available" in detail
+    assert "deliberately unavailable" in detail
+    assert not fake.calls
+
+
+def test_generate_default_path_still_runs_omnivoice(client, monkeypatch, tmp_path):
+    """No selection + no override → the OmniVoice model path, unchanged."""
+    # Neutralize any persisted Settings pick so the default resolution applies.
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    monkeypatch.delenv("OMNIVOICE_TTS_BACKEND", raising=False)
+
+    mock_model = MagicMock()
+    mock_model.sampling_rate = 24000
+    mock_model.generate.return_value = [torch.zeros(1, 24000)]
+
+    async def _get():
+        return mock_model
+
+    import api.routers.generation as gen_mod
+    monkeypatch.setattr(gen_mod, "get_model", _get)
+
+    res = client.post("/generate", data={"text": "Default path"})
+
+    assert res.status_code == 200, res.text
+    assert mock_model.generate.called
+    assert res.headers.get("x-audio-id")
+
+
+def test_generate_respects_applies_own_mastering(client, monkeypatch, no_omnivoice_model):
+    """Studio engines (applies_own_mastering=True) skip apply_mastering;
+    regular engines still get the broadcast chain — parity with
+    /v1/audio/speech and /ws/tts."""
+    from services import audio_dsp
+
+    mastering = MagicMock(side_effect=lambda t, sample_rate=24000: t)
+    monkeypatch.setattr(audio_dsp, "apply_mastering", mastering)
+
+    studio = _make_fake_engine("fake-studio", own_mastering=True)
+    plain = _make_fake_engine("fake-plain", own_mastering=False)
+    monkeypatch.setitem(tts_backend._REGISTRY, "fake-studio", studio)
+    monkeypatch.setitem(tts_backend._REGISTRY, "fake-plain", plain)
+
+    res = client.post("/generate", data={"text": "studio", "engine": "fake-studio"})
+    assert res.status_code == 200, res.text
+    assert mastering.call_count == 0
+
+    res = client.post("/generate", data={"text": "plain", "engine": "fake-plain"})
+    assert res.status_code == 200, res.text
+    assert mastering.call_count == 1


### PR DESCRIPTION
## Summary

`POST /generate` always ran the OmniVoice model directly via `get_model()`, silently ignoring the engine selected in Settings (and answering issue #312's question: no, it wasn't intended). It now:

- resolves the active backend per request: explicit `engine` form field > `OMNIVOICE_TTS_BACKEND` env > Settings selection > OmniVoice default — the same pattern `/ws/tts` (`engine`) and `/v1/audio/speech` (`model`) already use
- keeps the OmniVoice default path **byte-identical** (native path with the full advanced parameter surface: `t_shift`, layer/position/class controls) — existing API consumers see zero change
- reuses the per-process engine instance cache shared with the health-check route, so weights load once
- keeps inline `[pause Nms]` markers (#276) working on every engine (silence stitching is model-free)
- honors `applies_own_mastering` so studio engines skip the broadcast mastering chain (closing the TODO left by 5d602c8), while loudness normalization still applies
- unknown/unavailable engines return an actionable 400 listing valid ids

Fixes #312

## Tests

`tests/test_generate_engine.py` (new, 6 tests, engine layer stubbed as in test_api.py): Settings-selected engine generates; per-request `engine` overrides; unknown → 400; unavailable → 400; default path unchanged; own-mastering engines skip the chain. Full file passes locally; CI runs the complete suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request TTS engine override and engine-aware inference path.
  * Language normalization (e.g., "auto" → undetermined) and consistent sample-rate handling.
  * Shared audio effect chain with optional raw passthrough and conditional mastering when engines apply their own mastering.

* **Bug Fixes**
  * Clearer errors for unknown or unavailable engines and improved out-of-memory error handling.

* **Tests**
  * Added tests covering engine selection, overrides, availability errors, and mastering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->