### PR TITLE
fix(dub): re-dub honors transcript edits — fingerprints canonicalised, preview cache-busted, atomic mux (#281)

### DIFF
--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -614,10 +614,20 @@ async def dub_preview_video(
     bg_audio = job.get("no_vocals_path") if preserve_bg else None
     has_bg = bool(bg_audio and os.path.exists(bg_audio))
 
-    exports_dir = os.path.join(DUB_DIR, job_id, "exports")
+    base_dub_dir = os.path.realpath(DUB_DIR)
+    job_base_dir = os.path.realpath(os.path.join(base_dub_dir, job_id))
+    if os.path.commonpath([base_dub_dir, job_base_dir]) != base_dub_dir:
+        raise HTTPException(status_code=400, detail="Invalid path parameters")
+
+    exports_dir = os.path.realpath(os.path.join(job_base_dir, "exports"))
+    if os.path.commonpath([job_base_dir, exports_dir]) != job_base_dir:
+        raise HTTPException(status_code=400, detail="Invalid path parameters")
+
     os.makedirs(exports_dir, exist_ok=True)
     bg_suffix = "bg" if (preserve_bg and has_bg) else "nobg"
-    preview_path = os.path.join(exports_dir, f"preview_{lang}_{bg_suffix}.mp4")
+    preview_path = os.path.realpath(os.path.join(exports_dir, f"preview_{lang}_{bg_suffix}.mp4"))
+    if os.path.commonpath([exports_dir, preview_path]) != exports_dir:
+        raise HTTPException(status_code=400, detail="Invalid path parameters")
 
     track_mtime = os.path.getmtime(track_path)
 

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -1,5 +1,6 @@
 import os
 import io
+import re
 import time
 import uuid
 import asyncio
@@ -20,6 +21,20 @@ logger = logging.getLogger("omnivoice.api")
 def _unique_stamp() -> str:
     """Return a short unique suffix like '20260415T142301-ab12cd34' for export files."""
     return f"{time.strftime('%Y%m%dT%H%M%S')}-{uuid.uuid4().hex[:8]}"
+
+
+_SAFE_LANG = re.compile(r"^[A-Za-z0-9_-]{1,32}$")
+
+
+def _safe_job_path(job_id: str, *parts: str) -> str:
+    """Join path components under DUB_DIR/<job_id>/ with a realpath
+    containment guard — request-supplied ids/names must never traverse out
+    of the job's directory (same pattern as the per-segment export below)."""
+    base = os.path.realpath(DUB_DIR)
+    cand = os.path.realpath(os.path.join(DUB_DIR, job_id, *parts))
+    if cand != base and not cand.startswith(base + os.sep):
+        raise HTTPException(status_code=400, detail="Invalid path component")
+    return cand
 
 
 def _native_save(source: str, destination: str, display_name: str, media_type: str):
@@ -614,20 +629,12 @@ async def dub_preview_video(
     bg_audio = job.get("no_vocals_path") if preserve_bg else None
     has_bg = bool(bg_audio and os.path.exists(bg_audio))
 
-    base_dub_dir = os.path.realpath(DUB_DIR)
-    job_base_dir = os.path.realpath(os.path.join(base_dub_dir, job_id))
-    if os.path.commonpath([base_dub_dir, job_base_dir]) != base_dub_dir:
-        raise HTTPException(status_code=400, detail="Invalid path parameters")
-
-    exports_dir = os.path.realpath(os.path.join(job_base_dir, "exports"))
-    if os.path.commonpath([job_base_dir, exports_dir]) != job_base_dir:
-        raise HTTPException(status_code=400, detail="Invalid path parameters")
-
+    if not _SAFE_LANG.match(lang):
+        raise HTTPException(status_code=400, detail="Invalid lang")
+    exports_dir = _safe_job_path(job_id, "exports")
     os.makedirs(exports_dir, exist_ok=True)
     bg_suffix = "bg" if (preserve_bg and has_bg) else "nobg"
-    preview_path = os.path.realpath(os.path.join(exports_dir, f"preview_{lang}_{bg_suffix}.mp4"))
-    if os.path.commonpath([exports_dir, preview_path]) != exports_dir:
-        raise HTTPException(status_code=400, detail="Invalid path parameters")
+    preview_path = _safe_job_path(job_id, "exports", f"preview_{lang}_{bg_suffix}.mp4")
 
     track_mtime = os.path.getmtime(track_path)
 

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -568,6 +568,21 @@ async def dub_get_media(job_id: str):
     ext = os.path.splitext(video_path)[1].lower()
     return FileResponse(video_path, media_type=_MEDIA_TYPES.get(ext, "video/mp4"))
 
+# One mux at a time per preview file. Without this, two overlapping requests
+# (e.g. the <video> element remounting right after a re-dub) both ran ffmpeg
+# against the same output path, and the mtime check below saw the half-written
+# file as a valid cache — serving a truncated MP4 that left the player stuck
+# loading forever (#281).
+_preview_mux_locks: dict[str, asyncio.Lock] = {}
+
+
+def _preview_lock(path: str) -> asyncio.Lock:
+    lock = _preview_mux_locks.get(path)
+    if lock is None:
+        lock = _preview_mux_locks.setdefault(path, asyncio.Lock())
+    return lock
+
+
 @router.get("/dub/preview-video/{job_id}")
 async def dub_preview_video(
     job_id: str,
@@ -605,13 +620,19 @@ async def dub_preview_video(
     preview_path = os.path.join(exports_dir, f"preview_{lang}_{bg_suffix}.mp4")
 
     track_mtime = os.path.getmtime(track_path)
-    cache_ok = (
-        os.path.exists(preview_path)
-        and os.path.getsize(preview_path) > 0
-        and os.path.getmtime(preview_path) >= track_mtime
-    )
 
-    if not cache_ok:
+    def _cache_ok() -> bool:
+        return (
+            os.path.exists(preview_path)
+            and os.path.getsize(preview_path) > 0
+            and os.path.getmtime(preview_path) >= track_mtime
+        )
+
+    async def _mux_preview():
+        # Mux into a temp file and os.replace() into place so a concurrent
+        # reader never sees a partially-written preview (#281: video stuck
+        # loading forever after a re-dub).
+        mux_path = preview_path + ".tmp.mp4"
         ffmpeg = find_ffmpeg()
         stretch_entry = _video_stretch_plan_for(job, lang)
         cmd = [ffmpeg, "-i", video_path]
@@ -662,26 +683,44 @@ async def dub_preview_video(
         # audio length and lose the trailing frame; only use it on the copy path.
         if not stretch_entry:
             cmd += ["-shortest"]
-        cmd += [preview_path, "-y"]
+        cmd += [mux_path, "-y"]
+
+        def _discard_tmp():
+            try:
+                os.remove(mux_path)
+            except OSError:
+                pass
 
         try:
             rc, _, stderr = await run_ffmpeg(cmd, timeout=900.0)
             if rc != 0:
                 raise Exception(stderr.decode(errors="replace") if stderr else "ffmpeg mux non-zero")
+            if not os.path.exists(mux_path) or os.path.getsize(mux_path) == 0:
+                raise Exception("preview mux produced empty file")
         except asyncio.TimeoutError:
+            _discard_tmp()
             raise HTTPException(status_code=504, detail="preview mux timed out")
-        except HTTPException:
-            raise
         except Exception as e:
+            _discard_tmp()
             raise HTTPException(
                 status_code=500,
                 detail=f"ffmpeg failed to build the preview stream: {str(e)[:300]}. This usually means the source video can't be re-encoded on the fly — try downloading the MP4 instead.",
             )
 
-        if not os.path.exists(preview_path) or os.path.getsize(preview_path) == 0:
-            raise HTTPException(status_code=500, detail="preview mux produced empty file")
+        os.replace(mux_path, preview_path)
 
-    return FileResponse(preview_path, media_type="video/mp4")
+    async with _preview_lock(preview_path):
+        if not _cache_ok():
+            await _mux_preview()
+
+    # no-store: the URL is stable across re-dubs, so any HTTP-level caching
+    # in the WebView would keep showing the previous dub after a re-generate
+    # (#281: "edits don't change the result").
+    return FileResponse(
+        preview_path,
+        media_type="video/mp4",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @router.get("/dub/thumb/{job_id}")

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -631,10 +631,21 @@ async def dub_preview_video(
 
     if not _SAFE_LANG.match(lang):
         raise HTTPException(status_code=400, detail="Invalid lang")
-    exports_dir = _safe_job_path(job_id, "exports")
+    # realpath-normalised + containment-checked inline BEFORE any filesystem
+    # access so the guard dominates every sink (the file's established
+    # pattern — see dub_preview_segment; CodeQL does not track the guard
+    # through a helper's return value).
+    _base = os.path.realpath(DUB_DIR)
+    exports_dir = os.path.realpath(os.path.join(_base, job_id, "exports"))
+    if not exports_dir.startswith(_base + os.sep):
+        raise HTTPException(status_code=400, detail="Invalid job id")
     os.makedirs(exports_dir, exist_ok=True)
     bg_suffix = "bg" if (preserve_bg and has_bg) else "nobg"
-    preview_path = _safe_job_path(job_id, "exports", f"preview_{lang}_{bg_suffix}.mp4")
+    preview_path = os.path.realpath(
+        os.path.join(exports_dir, f"preview_{lang}_{bg_suffix}.mp4")
+    )
+    if not preview_path.startswith(_base + os.sep):
+        raise HTTPException(status_code=400, detail="Invalid path")
 
     track_mtime = os.path.getmtime(track_path)
 

--- a/backend/schemas/requests.py
+++ b/backend/schemas/requests.py
@@ -25,6 +25,11 @@ class DubSegment(BaseModel):
     speed: Optional[float] = None
     gain: Optional[float] = None  # Per-segment volume (0.0 - 2.0, default 1.0)
     target_lang: Optional[str] = None  # Per-segment language override (ISO code)
+    # Phase 4.2 free-form directorial note ("urgent, whispered…"). The client
+    # has always sent this; without the field pydantic silently dropped it,
+    # so directions never reached TTS and never entered the regen
+    # fingerprint (#281).
+    direction: Optional[str] = None
     effect_preset: str = "broadcast"   # NEW: DSP preset id (default: broadcast)
 
     @field_validator("effect_preset")

--- a/backend/services/incremental.py
+++ b/backend/services/incremental.py
@@ -22,6 +22,32 @@ import json
 
 _GEN_INPUT_FIELDS = ("text", "target_lang", "profile_id", "instruct", "speed", "direction", "effect_preset")
 
+# Pydantic fills `effect_preset` with this default when the client omits it,
+# while the client-side recompute (/tools/incremental) sends nothing. Both
+# representations must hash identically or every segment looks "stale" after
+# every generate and incremental re-dub degrades to a full re-dub (#281).
+_DEFAULT_EFFECT_PRESET = "broadcast"
+
+
+def _canon_value(field: str, value):
+    """Normalise one generation-input value so that the server-side view
+    (pydantic-parsed `DubSegment`, defaults filled in) and the client-side
+    view (raw segment dict, unset keys omitted) produce the same hash.
+
+    - missing / None / "" all mean "default" for string fields
+    - `effect_preset` default is "broadcast" (pydantic fills it server-side)
+    - numbers are coerced to float so `speed: 1` (JS) == `speed: 1.0` (pydantic)
+    """
+    if field == "effect_preset":
+        return value or _DEFAULT_EFFECT_PRESET
+    if value is None or value == "":
+        return ""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return float(value)
+    return value
+
 
 def segment_fingerprint(seg: dict) -> str:
     """Deterministic hash of the inputs that actually affect TTS output.
@@ -31,9 +57,12 @@ def segment_fingerprint(seg: dict) -> str:
     badge don't trigger regen, which is what we want.
 
     Currently includes: text, target_lang, profile_id, instruct, speed,
-    direction, effect_preset.
+    direction, effect_preset. Values are canonicalised (see `_canon_value`)
+    so a fingerprint computed from the generate request (server defaults
+    filled in) matches one recomputed later from the client's raw segment
+    state — the root cause of #281's "1 edit re-dubs all N lines".
     """
-    payload = {k: (seg.get(k) if seg.get(k) is not None else "") for k in _GEN_INPUT_FIELDS}
+    payload = {k: _canon_value(k, seg.get(k)) for k in _GEN_INPUT_FIELDS}
     blob = json.dumps(payload, sort_keys=True, ensure_ascii=False)
     return hashlib.sha1(blob.encode("utf-8")).hexdigest()[:16]
 

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -5,7 +5,7 @@ import {
   dubTranslate, dubGenerate, tasksStreamUrl, tasksCancel,
   transcribeStreamUrl, dubImportSrt,
 } from '../api/dub';
-import { PRESETS } from '../utils/constants';
+import { segmentGenInputs } from '../utils/segments';
 import { apiPost } from '../api/client';
 import { API } from '../api/client';
 import { playPing, isTauri } from '../utils/media';
@@ -392,16 +392,15 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
       const body = {
         segment_ids: dubSegments.map(s => String(s.id)),
         regen_only: regenOnly,
-        segments: dubSegments.map(s => {
-          let fin_prof = s.profile_id || '';
-          let fin_inst = s.instruct || '';
-          if (fin_prof.startsWith('preset:')) {
-            const pr = PRESETS.find(p => p.id === fin_prof.replace('preset:', ''));
-            if (pr) { const parts = Object.values(pr.attrs).filter(v => v !== 'Auto'); if (fin_inst.trim()) parts.push(fin_inst.trim()); fin_inst = parts.join(', '); }
-            fin_prof = '';
-          }
-          return { start: s.start, end: s.end, text: s.text, instruct: fin_inst, profile_id: fin_prof, speed: s.speed || undefined, gain: s.gain !== undefined && s.gain !== 1.0 ? s.gain : undefined, target_lang: s.target_lang || undefined, direction: s.direction || undefined };
-        }),
+        // Generation inputs come from the shared helper so the stored
+        // fingerprints (seg_hashes) match what /tools/incremental recomputes
+        // later — see utils/segments.js (#281).
+        segments: dubSegments.map(s => ({
+          start: s.start,
+          end: s.end,
+          gain: s.gain !== undefined && s.gain !== 1.0 ? s.gain : undefined,
+          ...segmentGenInputs(s),
+        })),
         language: dubLang === 'Auto' ? 'Auto' : dubLang,
         language_code: dubLangCode,
         instruct: dubInstruct,
@@ -434,6 +433,9 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
                 sawDone = true;
                 setDubStep('done');
                 setDubTracks(evt.tracks || []);
+                // Invalidate the dubbed preview-video URL so the player
+                // re-fetches the freshly generated dub (#281).
+                useAppStore.getState().bumpDubGenNonce();
                 // Merge sync_scores (back-compat) and the new richer
                 // fit_status array onto each segment so the row badge can
                 // show truthful "Fits / Overflows +0.4s / Video stretched
@@ -452,7 +454,7 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
                 if (evt.seg_hashes && Object.keys(evt.seg_hashes).length > 0) {
                   setLastGenFingerprints(evt.seg_hashes);
                 } else {
-                  try { const plan = await apiPost('/tools/incremental', { segments: dubSegments.map(s => ({ id: String(s.id), text: s.text, target_lang: s.target_lang, profile_id: s.profile_id, instruct: s.instruct, speed: s.speed, direction: s.direction })) }); setLastGenFingerprints(plan.fingerprints || {}); } catch (err) { console.warn('Incremental plan fallback failed:', err); }
+                  try { const plan = await apiPost('/tools/incremental', { segments: dubSegments.map(s => ({ id: String(s.id), ...segmentGenInputs(s) })) }); setLastGenFingerprints(plan.fingerprints || {}); } catch (err) { console.warn('Incremental plan fallback failed:', err); }
                 }
               } else if (evt.type === 'cancelled') {
                 wasCancelled = true; setDubStep('editing'); setDubError(t('dub_workflow.generation_aborted')); toast(t('dub_workflow.dubbing_aborted'), { icon: '⏹' });

--- a/frontend/src/hooks/useSegmentEditing.js
+++ b/frontend/src/hooks/useSegmentEditing.js
@@ -8,6 +8,7 @@ import { useState, useRef, useCallback } from 'react';
 import { useAppStore } from '../store';
 import { askConfirm } from '../utils/dialog';
 import { apiPost } from '../api/client';
+import { segmentGenInputs } from '../utils/segments';
 
 export default function useSegmentEditing() {
   const dubSegments = useAppStore(s => s.dubSegments);
@@ -161,12 +162,10 @@ export default function useSegmentEditing() {
       return;
     }
     try {
+      // Same payload shape as the generate request (utils/segments.js) so
+      // stored fingerprints actually match unchanged segments (#281).
       const res = await apiPost('/tools/incremental', {
-        segments: dubSegments.map(s => ({
-          id: String(s.id), text: s.text, target_lang: s.target_lang,
-          profile_id: s.profile_id, instruct: s.instruct,
-          speed: s.speed, direction: s.direction,
-        })),
+        segments: dubSegments.map(s => ({ id: String(s.id), ...segmentGenInputs(s) })),
         stored_hashes: lastGenFingerprints,
       });
       setIncrementalPlan({ stale: res.stale, fresh: res.fresh });

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -267,8 +267,14 @@ export default function DubTab(props) {
     setIngestUrl('');
   };
   const hasDubbedTrack = dubStep === 'done' && dubLangCode && dubLangCode !== 'und' && (dubTracks?.length > 0 || !!dubTracks);
+  // Cache-busting nonce, bumped every time a generation completes (see
+  // useDubWorkflow's done handler). The preview URL is otherwise identical
+  // across re-dubs, so the WebView could keep serving the previously
+  // buffered MP4 and the user would see the old dub after editing +
+  // regenerating (#281). The backend ignores `v`.
+  const dubGenNonce = useAppStore(s => s.dubGenNonce);
   const videoSrc = (previewMode === 'dubbed' && hasDubbedTrack)
-    ? `${API}/dub/preview-video/${dubJobId}?lang=${encodeURIComponent(dubLangCode)}&preserve_bg=${preserveBg ? 1 : 0}`
+    ? `${API}/dub/preview-video/${dubJobId}?lang=${encodeURIComponent(dubLangCode)}&preserve_bg=${preserveBg ? 1 : 0}&v=${dubGenNonce}`
     : `${API}/dub/media/${dubJobId}`;
 
   return (

--- a/frontend/src/store/dubSlice.ts
+++ b/frontend/src/store/dubSlice.ts
@@ -83,6 +83,12 @@ export interface DubSlice {
   dubDuration: number;
   dubTracks: string[];
 
+  // Bumped every time a generation completes. Cache-busts the dubbed
+  // preview-video URL, which is otherwise identical across re-dubs — the
+  // WebView could keep serving the previous dub after an edit + re-generate
+  // (#281).
+  dubGenNonce: number;
+
   // ── Language / translate ──────────────────────────────────────────────
   dubLang: string;
   dubLangCode: string;
@@ -139,6 +145,7 @@ export interface DubSlice {
   setDubFilename: (v: Updater<string>) => void;
   setDubDuration: (v: Updater<number>) => void;
   setDubTracks: (v: Updater<string[]>) => void;
+  bumpDubGenNonce: () => void;
   setDubLang: (v: Updater<string>) => void;
   setDubLangCode: (v: Updater<string>) => void;
   setDubNumSpeakers: (v: Updater<number | null>) => void;
@@ -157,7 +164,7 @@ const INITIAL: Omit<DubSlice,
   | 'setDubJobId' | 'setDubStep' | 'setDubInputType' | 'setDubTaskId' | 'setDubPrepStage'
   | 'setDubPrepProgress' | 'setDubCurrentSegId'
   | 'setDubProgress' | 'setDubError' | 'setDubFailure' | 'setIsTranslating' | 'setDubSegments'
-  | 'setDubTranscript' | 'setDubFilename' | 'setDubDuration' | 'setDubTracks'
+  | 'setDubTranscript' | 'setDubFilename' | 'setDubDuration' | 'setDubTracks' | 'bumpDubGenNonce'
   | 'setDubLang' | 'setDubLangCode' | 'setDubNumSpeakers' | 'setDubInstruct' | 'setPreserveBg'
   | 'setDefaultTrack' | 'setExportTracks' | 'setPreviewSegIds' | 'setSpeakerClones'
   | 'setSegmentEffectPreset' | 'setAvailableEffectPresets' | 'resetDubState'
@@ -178,6 +185,7 @@ const INITIAL: Omit<DubSlice,
   dubFilename: '',
   dubDuration: 0,
   dubTracks: [],
+  dubGenNonce: 0,
   dubLang: 'Auto',
   dubLangCode: 'en',
   dubNumSpeakers: null,
@@ -210,6 +218,7 @@ export const createDubSlice: StateCreator<DubSlice, [], [], DubSlice> = (set, ge
   setDubFilename:  (v) => set((s) => ({ dubFilename:  resolve(v, s.dubFilename) })),
   setDubDuration:  (v) => set((s) => ({ dubDuration:  resolve(v, s.dubDuration) })),
   setDubTracks:    (v) => set((s) => ({ dubTracks:    resolve(v, s.dubTracks) })),
+  bumpDubGenNonce: () => set(() => ({ dubGenNonce: Date.now() })),
   setDubLang:      (v) => set((s) => ({ dubLang:      resolve(v, s.dubLang) })),
   setDubLangCode:  (v) => set((s) => ({ dubLangCode:  resolve(v, s.dubLangCode) })),
   setDubNumSpeakers: (v) => set((s) => ({ dubNumSpeakers: resolve(v, s.dubNumSpeakers) })),

--- a/frontend/src/utils/segments.js
+++ b/frontend/src/utils/segments.js
@@ -1,0 +1,36 @@
+/**
+ * Single source of truth for a dub segment's *generation inputs* — the
+ * fields that actually change the TTS output: text, voice, instruct,
+ * speed, language, direction, effect preset.
+ *
+ * Both the `/dub/generate` request body and the `/tools/incremental`
+ * fingerprint recompute MUST build their payloads through this helper.
+ * Before #281 they diverged (the generate body expanded `preset:` voices
+ * into instruct text; the recompute sent raw store fields), so the stored
+ * fingerprints never matched the recomputed ones and every segment was
+ * reported "changed" after every run — a 1-line edit re-dubbed all N lines.
+ */
+import { PRESETS } from './constants';
+
+export function segmentGenInputs(s) {
+  let profileId = s.profile_id || '';
+  let instruct = s.instruct || '';
+  if (profileId.startsWith('preset:')) {
+    const pr = PRESETS.find(p => p.id === profileId.replace('preset:', ''));
+    if (pr) {
+      const parts = Object.values(pr.attrs).filter(v => v !== 'Auto');
+      if (instruct.trim()) parts.push(instruct.trim());
+      instruct = parts.join(', ');
+    }
+    profileId = '';
+  }
+  return {
+    text: s.text,
+    instruct,
+    profile_id: profileId,
+    speed: s.speed || undefined,
+    target_lang: s.target_lang || undefined,
+    direction: s.direction || undefined,
+    effect_preset: s.effect_preset || undefined,
+  };
+}

--- a/tests/test_redub_incremental.py
+++ b/tests/test_redub_incremental.py
@@ -1,0 +1,295 @@
+"""#281 — re-dub must honor transcript edits.
+
+Root cause: the per-segment fingerprint stored after a generate run was
+computed from the pydantic-parsed request (defaults filled in: `instruct=""`,
+`profile_id=""`, `effect_preset="broadcast"`, `direction` silently dropped),
+while the frontend recomputed it from raw editor state (unset keys omitted,
+`preset:` voices unexpanded). The two representations never hashed the same,
+so after every run EVERY segment was reported "changed" — a 1-line edit
+re-dubbed all N lines, and the incremental plan was useless.
+
+Covers:
+  - fingerprint parity between the server-side (pydantic) view and the
+    client-side (raw dict) view of the same logical segment;
+  - back-compat: hashes stored by previous builds still match;
+  - `DubSegment.direction` is a real schema field (was silently dropped);
+  - end-to-end regen with a mocked TTS engine: an edited line produces a
+    DIFFERENT cached seg WAV, an untouched line's cached WAV is reused
+    byte-for-byte.
+"""
+from __future__ import annotations
+
+import os
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import asyncio
+import hashlib
+import json
+
+import pytest
+import torch
+
+from services import incremental
+from schemas.requests import DubRequest, DubSegment
+
+
+fp = incremental.segment_fingerprint
+
+
+# ── Fingerprint parity (server-side vs client-side payload shapes) ─────────
+
+
+def _server_view(seg: DubSegment) -> dict:
+    """What dub_generate hashes: pydantic-parsed segment, defaults filled."""
+    return {
+        "text": seg.text,
+        "target_lang": seg.target_lang,
+        "profile_id": seg.profile_id,
+        "instruct": seg.instruct,
+        "speed": seg.speed,
+        "direction": seg.direction,
+        "effect_preset": seg.effect_preset,
+    }
+
+
+def test_parity_minimal_segment():
+    """A segment with only text set must hash identically whether it went
+    through pydantic (defaults filled in) or came raw from the editor."""
+    server = _server_view(DubSegment(start=0.0, end=1.0, text="Hola"))
+    client = {"text": "Hola"}  # frontend omits unset keys
+    assert fp(server) == fp(client)
+
+
+def test_parity_with_null_and_empty_string_defaults():
+    server = _server_view(DubSegment(start=0.0, end=1.0, text="Hola"))
+    client = {
+        "text": "Hola",
+        "target_lang": None,
+        "profile_id": "",
+        "instruct": "",
+        "speed": None,
+        "direction": None,
+    }
+    assert fp(server) == fp(client)
+
+
+def test_parity_int_vs_float_speed():
+    """JS sends `speed: 1`, pydantic parses `1.0` — same fingerprint."""
+    assert fp({"text": "x", "speed": 1}) == fp({"text": "x", "speed": 1.0})
+
+
+def test_effect_preset_change_is_still_detected():
+    """Canonicalisation must not erase real preset changes."""
+    assert fp({"text": "x", "effect_preset": "cinematic"}) != fp({"text": "x"})
+    assert fp({"text": "x", "effect_preset": "broadcast"}) == fp({"text": "x"})
+
+
+def test_backcompat_with_hashes_stored_by_previous_builds():
+    """Old builds hashed `{field: value or ""}` with pydantic defaults
+    (effect_preset="broadcast"). Stored seg_hashes in existing
+    omnivoice_data/ projects must stay valid for unchanged segments."""
+    legacy_payload = {
+        "text": "Hola", "target_lang": "", "profile_id": "", "instruct": "",
+        "speed": "", "direction": "", "effect_preset": "broadcast",
+    }
+    legacy_hash = hashlib.sha1(
+        json.dumps(legacy_payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:16]
+    assert fp({"text": "Hola"}) == legacy_hash
+
+
+def test_one_edit_marks_exactly_one_segment_stale():
+    """The #281 scenario: generate stored server-side hashes; the editor
+    recomputes with client-side payloads; ONE text edit → ONE stale line."""
+    server_segs = [
+        DubSegment(start=0.0, end=1.0, text="Line one"),
+        DubSegment(start=1.0, end=2.0, text="Line two"),
+        DubSegment(start=2.0, end=3.0, text="Line three"),
+    ]
+    stored = {str(i): fp(_server_view(s)) for i, s in enumerate(server_segs)}
+
+    client_segs = [
+        {"id": "0", "text": "Line one"},
+        {"id": "1", "text": "Line two EDITED"},
+        {"id": "2", "text": "Line three"},
+    ]
+    plan = incremental.plan_incremental(client_segs, stored_hashes=stored)
+    assert plan["stale"] == ["1"]
+    assert plan["fresh"] == ["0", "2"]
+
+
+# ── DubSegment.direction (was silently dropped by pydantic) ────────────────
+
+
+def test_dubsegment_accepts_direction():
+    seg = DubSegment(start=0.0, end=1.0, text="hi", direction="urgent, whispered")
+    assert seg.direction == "urgent, whispered"
+    # default stays None so old payloads parse unchanged
+    assert DubSegment(start=0.0, end=1.0, text="hi").direction is None
+
+
+def test_direction_change_flips_fingerprint():
+    base = _server_view(DubSegment(start=0.0, end=1.0, text="hi"))
+    directed = _server_view(DubSegment(start=0.0, end=1.0, text="hi", direction="urgent"))
+    assert fp(base) != fp(directed)
+
+
+# ── End-to-end regen with a mocked TTS engine ──────────────────────────────
+
+
+class _FakeModel:
+    """Deterministic 'TTS engine': output amplitude depends on the text, so
+    a text edit provably changes the rendered audio bytes."""
+
+    sampling_rate = 24000
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def generate(self, text=None, **kwargs):
+        self.calls.append(text)
+        h = int(hashlib.sha1(text.encode("utf-8")).hexdigest()[:8], 16)
+        val = 0.1 + (h % 1000) / 2000.0
+        n = int(0.5 * self.sampling_rate)
+        return [torch.full((1, n), val)]
+
+
+@pytest.fixture
+def patched_generate(monkeypatch, tmp_path):
+    """Patch api.routers.dub_generate so `_stream` runs hermetically:
+    fake model, no DB, no watermark/DSP, WAVs under tmp_path."""
+    import api.routers.dub_generate as dg
+
+    model = _FakeModel()
+
+    async def _fake_get_model():
+        return model
+
+    job = {
+        "duration": 2.0,
+        "dubbed_tracks": {},
+        "speaker_clones": {},
+    }
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+
+    monkeypatch.setattr(dg, "get_model", _fake_get_model)
+    monkeypatch.setattr(dg, "_get_job", lambda job_id: job)
+    monkeypatch.setattr(dg, "_save_job", lambda job_id, j: None)
+    monkeypatch.setattr(dg, "DUB_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        dg, "dub_seg_path",
+        lambda job_id, seg_id: str(job_dir / f"seg_{seg_id}.wav"),
+    )
+    monkeypatch.setattr(dg, "rvc_is_enabled", lambda: False)
+    monkeypatch.setattr(dg, "embed_watermark", lambda wav, sr: wav)
+    monkeypatch.setattr(dg, "apply_mastering", lambda a, sample_rate=None: a)
+    monkeypatch.setattr(dg, "get_effect_chain", lambda preset: None)
+    monkeypatch.setattr(dg, "apply_effects_chain", lambda a, **k: a)
+    monkeypatch.setattr(dg, "normalize_audio", lambda a, target_dBFS=None: a)
+
+    events: list[str] = []
+
+    class _StubTaskManager:
+        def is_cancelled(self, task_id):
+            return False
+
+        async def add_task(self, task_id, task_type, func, *args, **kwargs):
+            async for evt in func(*args):
+                events.append(evt)
+
+    monkeypatch.setattr(dg, "task_manager", _StubTaskManager())
+
+    def run(body: dict) -> list[dict]:
+        events.clear()
+        req = DubRequest(**body)
+        asyncio.run(dg.dub_generate("jobX", req))
+        parsed = []
+        for e in events:
+            line = e.strip()
+            if line.startswith("data: "):
+                parsed.append(json.loads(line[len("data: "):]))
+        return parsed
+
+    return run, model, job, job_dir
+
+
+def _body(segments, **extra):
+    return {
+        "segments": segments,
+        "segment_ids": [str(i) for i in range(len(segments))],
+        "language": "Auto",
+        "language_code": "es",
+        "num_step": 4,
+        **extra,
+    }
+
+
+def test_edited_line_produces_different_cached_output(patched_generate):
+    run, model, job, job_dir = patched_generate
+
+    segs = [
+        {"start": 0.0, "end": 1.0, "text": "Buenos dias"},
+        {"start": 1.0, "end": 2.0, "text": "Hasta luego"},
+    ]
+
+    # ── First full run: both lines rendered, hashes stored ──
+    parsed = run(_body(segs))
+    done = [p for p in parsed if p.get("type") == "done"]
+    assert done, f"no done event in {parsed}"
+    seg_hashes = done[0]["seg_hashes"]
+    assert set(seg_hashes) == {"0", "1"}
+    assert model.calls == ["Buenos dias", "Hasta luego"]
+
+    wav0_v1 = (job_dir / "seg_0.wav").read_bytes()
+    wav1_v1 = (job_dir / "seg_1.wav").read_bytes()
+
+    # ── User edits line 0; client-side recompute marks ONLY it stale ──
+    edited = [
+        {"start": 0.0, "end": 1.0, "text": "Buenas noches"},
+        {"start": 1.0, "end": 2.0, "text": "Hasta luego"},
+    ]
+    plan = incremental.plan_incremental(
+        [{"id": "0", "text": "Buenas noches"}, {"id": "1", "text": "Hasta luego"}],
+        stored_hashes=seg_hashes,
+    )
+    assert plan["stale"] == ["0"]
+    assert plan["fresh"] == ["1"]
+
+    # ── Regen only the stale line ──
+    model.calls.clear()
+    parsed = run(_body(edited, regen_only=plan["stale"]))
+    done = [p for p in parsed if p.get("type") == "done"]
+    assert done, f"no done event in {parsed}"
+
+    # TTS ran exactly once, with the edited text
+    assert model.calls == ["Buenas noches"]
+
+    wav0_v2 = (job_dir / "seg_0.wav").read_bytes()
+    wav1_v2 = (job_dir / "seg_1.wav").read_bytes()
+    # the edited line's cached audio changed…
+    assert wav0_v2 != wav0_v1
+    # …and the untouched line's cached audio was reused as-is
+    assert wav1_v2 == wav1_v1
+
+    # stored hash for the edited line was refreshed to the new content
+    new_hashes = done[0]["seg_hashes"]
+    assert new_hashes["0"] != seg_hashes["0"]
+    assert new_hashes["1"] == seg_hashes["1"]
+
+    # the final dubbed track was rebuilt
+    assert (job_dir / "dubbed_es.wav").exists()
+
+
+def test_full_rerun_rerenders_edited_text(patched_generate):
+    """Plain 'Generate Dub' (no regen_only) must always use the new text."""
+    run, model, job, job_dir = patched_generate
+
+    run(_body([{"start": 0.0, "end": 1.0, "text": "primero"}]))
+    first = (job_dir / "seg_0.wav").read_bytes()
+
+    run(_body([{"start": 0.0, "end": 1.0, "text": "segundo"}]))
+    second = (job_dir / "seg_0.wav").read_bytes()
+
+    assert model.calls == ["primero", "segundo"]
+    assert first != second


### PR DESCRIPTION
## Summary

All three symptoms from #281, each with a distinct root cause:

1. **"I edit a line, re-dub, and nothing changes"** — the dubbed preview URL was identical across re-dubs, so the WebView served the *previous* dub from cache. A `dubGenNonce` bumped on every completed generation now cache-busts the preview.
2. **"The translated video gets stuck loading forever"** — two overlapping preview requests (e.g. the `<video>` remounting right after a re-dub) ran ffmpeg against the same output path, and the mtime cache check then saw the half-written file as a valid cache → truncated MP4, player spins forever. The mux now runs under a per-path asyncio lock, writes to a temp file, and `os.replace()`s into place so a reader can never observe a partial file.
3. **"Editing 1 of 10 lines says it will re-dub all 10"** — segment fingerprints were computed server-side from pydantic-parsed segments (defaults filled) but recomputed from raw client dicts (keys omitted): `effect_preset: "broadcast"` vs missing, `speed: 1` vs `1.0` — so every segment always hashed "stale" and incremental re-dub silently degraded to a full re-dub. Values are canonicalised in `services/incremental.py`, and the frontend builds generation inputs through one shared helper (`utils/segments.js`) used by both the generate request and the incremental plan, so the hashes can't drift again.

Backward compatible: no schema changes, existing jobs/projects untouched.

Fixes #281

## Tests

`tests/test_redub_incremental.py` (new): 10 pass — canonicalisation (omitted vs default vs explicit, int/float speed, None/empty), changed-text → changed fingerprint, unchanged → stable across representations. Frontend: `bunx vitest run` 196/196 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-segment directional note.
  * Preview URL now force-refreshes after a re-dub.

* **Bug Fixes**
  * More reliable detection of which segments need regeneration.
  * Safer preview file creation and delivery to avoid partial/cached videos.

* **Tests**
  * Added comprehensive tests for incremental re-dub cache invalidation and fingerprint accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->