### PR TITLE
fix(updater): preview channel never offers updates once stable catches up

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "libc",
  "log",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "sysinfo",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -24,6 +24,9 @@ tauri-plugin-log = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-window-state = "2.0.0"
 tauri-plugin-updater = "2"
+# Channel-aware update comparator (preview is a rolling channel; see
+# updater_channel.rs). Same semver crate tauri-plugin-updater uses internally.
+semver = "1"
 tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"

--- a/frontend/src-tauri/src/updater_channel.rs
+++ b/frontend/src-tauri/src/updater_channel.rs
@@ -30,6 +30,22 @@ fn channel_endpoints(channel: &str) -> Vec<tauri::Url> {
     raw.iter().filter_map(|u| u.parse().ok()).collect()
 }
 
+/// Update-availability predicate for a channel.
+///
+/// Stable keeps the plugin's default strict-semver `remote > current`. Preview
+/// builds are versioned as pre-releases of the *current* stable base (e.g.
+/// `0.3.5-41`), and semver orders a pre-release *below* its release — so once
+/// stable catches up, the default comparator tells preview users they are
+/// already up to date forever (#326). Preview is a rolling channel: any
+/// manifest version that differs from the running one is an update.
+fn update_available(channel: &str, current: &semver::Version, remote: &semver::Version) -> bool {
+    if channel == "preview" {
+        remote != current
+    } else {
+        remote > current
+    }
+}
+
 #[derive(Serialize, Clone)]
 pub struct UpdateMeta {
     pub version: String,
@@ -50,8 +66,12 @@ pub async fn check_update(
     app: AppHandle,
     channel: String,
 ) -> Result<Option<UpdateMeta>, String> {
+    let ch = channel.clone();
     let updater = app
         .updater_builder()
+        .version_comparator(move |current, release| {
+            update_available(&ch, &current, &release.version)
+        })
         .endpoints(channel_endpoints(&channel))
         .map_err(|e| format!("updater endpoints: {e}"))?
         .build()
@@ -73,8 +93,12 @@ pub async fn check_update(
 /// side, exactly as the badge flow already does.
 #[tauri::command]
 pub async fn install_update(app: AppHandle, channel: String) -> Result<(), String> {
+    let ch = channel.clone();
     let updater = app
         .updater_builder()
+        .version_comparator(move |current, release| {
+            update_available(&ch, &current, &release.version)
+        })
         .endpoints(channel_endpoints(&channel))
         .map_err(|e| format!("updater endpoints: {e}"))?
         .build()
@@ -163,4 +187,42 @@ pub async fn list_releases(_channel: String) -> Result<Vec<ReleaseInfo>, String>
         }
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::update_available;
+    use semver::Version;
+
+    fn v(s: &str) -> Version {
+        Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn stable_keeps_strict_semver_ordering() {
+        assert!(update_available("stable", &v("0.3.4"), &v("0.3.5")));
+        assert!(!update_available("stable", &v("0.3.5"), &v("0.3.5")));
+        // A pre-release of the running version is NOT an update on stable.
+        assert!(!update_available("stable", &v("0.3.5"), &v("0.3.5-41")));
+        assert!(!update_available("stable", &v("0.3.5"), &v("0.3.4")));
+    }
+
+    #[test]
+    fn preview_offers_rolling_builds_of_the_same_base() {
+        // The #326 regression: stable 0.3.5 user switches to preview while the
+        // rolling manifest advertises a pre-release of the same base version.
+        assert!(update_available("preview", &v("0.3.5"), &v("0.3.5-41")));
+        // Newer rolling build for an existing preview user.
+        assert!(update_available("preview", &v("0.3.5-40"), &v("0.3.5-41")));
+        // Already on the advertised build → up to date.
+        assert!(!update_available("preview", &v("0.3.5-41"), &v("0.3.5-41")));
+        // Plain newer versions still count, e.g. stable-manifest fallback.
+        assert!(update_available("preview", &v("0.3.5-41"), &v("0.3.6")));
+    }
+
+    #[test]
+    fn unknown_channel_behaves_like_stable() {
+        assert!(!update_available("nightly", &v("0.3.5"), &v("0.3.5-41")));
+        assert!(update_available("nightly", &v("0.3.4"), &v("0.3.5")));
+    }
 }


### PR DESCRIPTION
## Problem

A user on stable `0.3.5` who switches the update channel to **preview** is always told they're up to date, even though the rolling `preview` release is days newer (reported on Discord, #326).

Preview builds are versioned as pre-releases of the *current* stable base (the manifest currently advertises `0.3.5-41`), and `tauri-plugin-updater`'s default availability check is a strict semver `remote > current`. In semver, `0.3.5-41 < 0.3.5` — so the moment stable catches up to the preview base version, the preview channel goes permanently silent. It worked before only because `0.3.5-x > 0.3.4`.

## Fix

Install a channel-aware `version_comparator` on the updater builder in `check_update` and `install_update` (`frontend/src-tauri/src/updater_channel.rs`):

- **preview** — rolling channel: any manifest version *different* from the running one is an update.
- **stable** (and anything unknown) — keeps the default strict `remote > current`, so default behavior is byte-for-byte unchanged.

The predicate is factored into `update_available()` with unit tests covering the regression case (stable 0.3.5 → preview 0.3.5-41), rolling upgrades (0.3.5-40 → -41), same-build no-op, and stable's unchanged ordering. Adds `semver = "1"` as a direct dep (already in the tree via tauri itself).

Pure Rust logic — identical on macOS/Windows/Linux; no UI strings, no data-format changes, no version bumps.

## Tests

- `cargo test --lib updater_channel`: **3 passed** (new)
- `cargo check`: clean (one pre-existing warning in setup.rs)
- Backend `uv run pytest tests/ -q`: **729 passed, 21 skipped, 11 xfailed, 3 xpassed**
- `bun run test:frontend`: **36 passed**

Fixes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
