### PR TITLE
chore(review-bots): diagrams + ASCII UI sketches in every PR walkthrough

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,14 @@ reviews:
   profile: chill
   request_changes_workflow: false
   high_level_summary: true
+  # Every walkthrough gets a visual: mermaid sequence diagrams for the
+  # mechanics, plus (via the summary instructions) an ASCII before/after
+  # sketch when the PR touches UI — so each PR is reviewable at a glance.
+  sequence_diagrams: true
+  high_level_summary_instructions: >-
+    If the PR changes UI (JSX/TSX/CSS/Tauri windows), include a compact ASCII
+    before/after sketch of the affected layout or component. If it changes
+    behavior, include a short mermaid flowchart of the new mechanism.
   review_status: true
   poem: false
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,6 +7,12 @@
 language: "en-US"
 early_access: false
 
+# The review voice: a panel of senior domain experts, not a linter.
+tone_instructions: >-
+  Review as a panel of principal engineers: ML inference, audio DSP, desktop
+  systems, product polish. Cite exact lines, name the failure mode, give the
+  concrete fix. No filler praise; raise nits only when they change a decision.
+
 reviews:
   # "chill" keeps the bot from blocking merges — it comments, it does not gate.
   # Hard gating lives in CI (security.yml) and the constitution's human bar.
@@ -47,7 +53,8 @@ reviews:
     - "!**/*.onnx"
     - "!tests/fixtures/**"
 
-  # Encode the project's hard constraints so the bot reviews against them.
+  # One expert lens per subsystem — encode what a passionate senior in each
+  # domain would actually check, beyond what linters and CI already gate.
   path_instructions:
     - path: "**/*.{py,rs,js,jsx,ts,tsx}"
       instructions: >-
@@ -56,18 +63,119 @@ reviews:
         model download, or an explicitly opt-in endpoint. Flag any code that
         persists or logs values matching *TOKEN*/*KEY*/*SECRET* or absolute user
         home paths (/Users/<name>/, C:\\Users\\<name>\\).
+    - path: "backend/services/**/*.py"
+      instructions: >-
+        Review as an ML-inference/audio engineer. Check: thread-safety of model
+        and cache state across the GPU worker pool; device/dtype assumptions
+        that break on one of CUDA/MPS/ROCm/CPU; VRAM lifecycle (load/unload,
+        leaks on the error path); sample-rate, channel-count and tensor-shape
+        assumptions at engine boundaries; blocking calls inside async paths;
+        model download/cache behavior when offline. Engine code must stay
+        backward-compatible with already-installed on-disk model state.
     - path: "backend/**/*.py"
       instructions: >-
         Default features must behave identically on macOS, Windows and Linux.
         Platform-specific implementation is allowed, but a divergent user-visible
         default is a P0 bug — flag it and suggest an opt-in (Settings/env/flag).
         Any DB schema change must go through an alembic migration with an upgrade
-        path; flag direct schema edits. Engine code must stay backward-compatible
-        with already-installed on-disk model state (no forced reinstall).
+        path; flag direct schema edits. The backend serves loopback HTTP: treat
+        every query/path/form param as hostile (path traversal, log injection,
+        CSRF from a browser tab), and never route user-chosen filesystem
+        destinations through HTTP — that authorization belongs in the Tauri
+        process.
+    - path: "frontend/src/**/*.{js,jsx,ts,tsx}"
+      instructions: >-
+        Review as a product-minded senior frontend engineer. Check: stale state
+        and races (async results landing after unmount or after newer requests);
+        every user-visible failure has an actionable, non-technical error
+        message; loading/disabled states during long operations. Every new
+        user-facing string must be an i18n t('...') key present in ALL 21
+        frontend/src/i18n/locales/*.json files — flag hardcoded UI strings and
+        keys missing from any locale.
+    - path: "frontend/src-tauri/**/*.rs"
+      instructions: >-
+        Review as a desktop-systems engineer. Check: every #[tauri::command] is
+        callable from the webview — validate inputs and scope filesystem/process
+        access accordingly; window and webview lifecycle on all three OSes;
+        child-process spawn/exit-code/stderr handling; no unwrap/expect on
+        user-controlled input; platform cfg blocks keep user-visible defaults
+        identical across macOS/Windows/Linux.
+    - path: "tests/**/*.py"
+      instructions: >-
+        Review as a test-infrastructure engineer. Check: the test would fail
+        before the fix and pass after (no tautologies); no sleeps as
+        synchronization; no module-level imports of app modules that go stale
+        under sys.modules pollution (resolve at run time); TestClient instances
+        are function-scoped and not lifespan-bound unless the test needs it;
+        new functional CJK is allowlisted in tests/test_no_hardcoded_cjk.py with
+        a justification.
     - path: ".github/workflows/**"
       instructions: >-
         Pin actions to a major version tag at minimum. Flag any workflow that
         grants write permissions it does not need.
+
+  # Non-gating pre-merge audits of the project's hard rules (warning mode —
+  # the human owner is the gate, these make the checklist visible per-PR).
+  pre_merge_checks:
+    title:
+      mode: warning
+      requirements: >-
+        Conventional-commit style with scope, e.g. "fix(dub): …", and the issue
+        reference in title or body. Never propose a version bump.
+    issue_assessment:
+      mode: warning
+    custom_checks:
+      - name: "Cross-platform default parity"
+        mode: warning
+        instructions: >-
+          If the PR changes any default-mode (out-of-the-box) behavior, verify
+          it behaves identically on macOS, Windows and Linux, or is moved behind
+          an explicit opt-in (Settings toggle, env var, or CLI flag). A
+          platform-divergent default is a P0 per CLAUDE.md — fail this check
+          and say which platform diverges.
+      - name: "i18n completeness (21 locales)"
+        mode: warning
+        instructions: >-
+          For every new or changed t('...') key in frontend code, verify the
+          key exists in all 21 files under frontend/src/i18n/locales/. List any
+          locale files missing the key. Also flag hardcoded user-facing strings
+          that bypass i18n entirely.
+      - name: "Local-first guarantee"
+        mode: warning
+        instructions: >-
+          Verify the PR adds no required cloud calls, accounts, API keys or
+          telemetry. Outbound traffic is only allowed to GitHub Issues (opt-in
+          bug reporting) and HuggingFace model downloads. The app must remain
+          fully functional offline and with reporting disabled.
+      - name: "Backward compatibility"
+        mode: warning
+        instructions: >-
+          Verify existing omnivoice_data/ (voices, projects, settings) and
+          already-installed engine model state keep working without manual
+          migration. Any DB schema change must ship an alembic migration with
+          an upgrade path. Flag anything that would force users to reinstall an
+          engine or re-download model weights.
+
+  finishing_touches:
+    docstrings:
+      enabled: true
+    unit_tests:
+      enabled: true
+
+# Feed the bot the project constitution and docs, and let it accumulate
+# learnings from review conversations ("@coderabbitai always/never …").
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "CLAUDE.md"
+      - "docs/**/*.md"
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  pull_requests:
+    scope: auto
 
 chat:
   auto_reply: true

--- a/greptile.json
+++ b/greptile.json
@@ -1,6 +1,20 @@
 {
-  "$comment": "Greptile per-repo config — https://www.greptile.com/docs/code-review-bot/greptile-json. The Greptile GitHub App is installed; this file tunes its reviews. Dashboard settings are the org-wide fallback.",
-  "instructions": "OmniVoice is a fully-local desktop app (no cloud, no API keys, no telemetry) — flag any new outbound network call that is not GitHub Issues or a HuggingFace model download. Default features must behave identically on macOS, Windows and Linux; a divergent user-visible default is a P0. In every review summary, make the change visual: if the PR touches UI (JSX/TSX/CSS or Tauri window config), include a compact ASCII before/after mockup of the affected layout or component; if it changes behavior or data flow, include a sequence/flow diagram of the new mechanism. Keep diagrams small and strictly faithful to the diff.",
+  "$comment": "Greptile per-repo config — https://www.greptile.com/docs/code-review-bot/greptile-json. The Greptile GitHub App is installed; this file tunes its reviews. Dashboard settings are the org-wide fallback. Greptile also learns from 👍/👎 reactions on its comments — react to train it.",
+  "instructions": "Review as a panel of passionate senior domain experts (ML inference, audio DSP, desktop systems, product polish): cite exact lines, name the concrete failure mode, propose the fix — no filler praise. OmniVoice is a fully-local desktop app (no cloud, no API keys, no telemetry): flag any new outbound network call that is not GitHub Issues or a HuggingFace model download. In every review summary, make the change visual: if the PR touches UI (JSX/TSX/CSS or Tauri window config), include a compact ASCII before/after mockup of the affected layout or component; if it changes behavior or data flow, include a sequence/flow diagram of the new mechanism. Keep diagrams small and strictly faithful to the diff.",
+  "commentTypes": ["logic", "syntax", "info"],
+  "strictness": 2,
+  "customContext": {
+    "files": ["CLAUDE.md"],
+    "rules": [
+      "Default features must behave identically on macOS, Windows and Linux; a platform-divergent default is a P0 — platform-only behavior must sit behind explicit opt-in (Settings toggle, env var, or CLI flag).",
+      "Every new user-facing string must be an i18n t('...') key present in all 21 frontend/src/i18n/locales/*.json files; hardcoded CJK outside the allowlist in tests/test_no_hardcoded_cjk.py fails CI.",
+      "Existing omnivoice_data/ and already-installed engine model state must keep working without manual migration; DB schema changes go through alembic with an upgrade path.",
+      "Never propose version bumps, release candidates, or deferrals to a future version — everything ships on the current line.",
+      "The backend serves loopback HTTP: treat every query/path/form parameter as hostile (path traversal, log injection, CSRF from a browser tab); user-chosen filesystem destinations are authorized in the Tauri process, never via HTTP params.",
+      "Every #[tauri::command] is callable from the webview: validate inputs and scope filesystem/process access; no unwrap/expect on user-controlled input.",
+      "Model/engine code must be thread-safe across the GPU worker pool and correct on all of CUDA, MPS, ROCm and CPU; check VRAM lifecycle on error paths and offline behavior of model downloads."
+    ]
+  },
   "sequenceDiagramSection": {
     "included": true,
     "collapsible": true,

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,14 @@
+{
+  "$comment": "Greptile per-repo config — https://www.greptile.com/docs/code-review-bot/greptile-json. The Greptile GitHub App is installed; this file tunes its reviews. Dashboard settings are the org-wide fallback.",
+  "instructions": "OmniVoice is a fully-local desktop app (no cloud, no API keys, no telemetry) — flag any new outbound network call that is not GitHub Issues or a HuggingFace model download. Default features must behave identically on macOS, Windows and Linux; a divergent user-visible default is a P0. In every review summary, make the change visual: if the PR touches UI (JSX/TSX/CSS or Tauri window config), include a compact ASCII before/after mockup of the affected layout or component; if it changes behavior or data flow, include a sequence/flow diagram of the new mechanism. Keep diagrams small and strictly faithful to the diff.",
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": true
+  },
+  "summarySection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": true
+  }
+}


### PR DESCRIPTION
## What

Make every PR visually reviewable at a glance — both review bots now explain each PR mechanically **and** visually:

- **CodeRabbit** (`.coderabbit.yaml`): `sequence_diagrams: true` made explicit, and new `high_level_summary_instructions` — UI changes get a compact ASCII before/after sketch of the affected layout/component; behavior changes get a short mermaid flowchart.
- **Greptile** (new `greptile.json`): turns on the `sequenceDiagramSection` and `summarySection` (open by default), with matching instructions for ASCII UI mockups and flow diagrams — plus the project's hard rules (local-first, no telemetry, cross-platform default parity) so Greptile reviews against them the same way CodeRabbit already does.

## Why

PR descriptions tell you what changed; a sketch of the layout before/after or a flow of the new mechanism tells you what it *does*. 

Config-only — no app code touched. Takes effect on the next PR each bot reviews after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced repository review configuration: richer visual summaries and sequence diagrams, collapsible review sections, and more detailed review voice/tone.
  * Added robust pre-merge checklists enforcing cross-platform parity, i18n completeness (21 locales), local-first/no-telemetry constraints, and migration/backward-compatibility expectations.
  * Tightened review rules for platform consistency, security/input validation, and automated capture of learnings and docs/tests guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
