### PR TITLE
chore(version): main = latest release + 1, Docker :latest = preview, :stable = releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,11 +5,13 @@
 #   - push to main branch                          → :main, :sha- (rolling "edge" build)
 #   - workflow_dispatch                            → :sha- only (ad-hoc test build)
 #
-# Tag ↔ image mapping
-#   :latest   — always the most recent versioned release (set on every v* tag push)
-#   :0.3.0    — exact version from the git tag
+# Tag ↔ image mapping (versioning hard rule, owner-set 2026-06-11:
+# :latest IS the preview channel; stable users pin :stable or a version tag)
+#   :latest   — rolling preview: latest commit on main (always last release + 1 dev)
+#   :main     — alias of the same rolling main build (kept for back-compat)
+#   :stable   — most recent versioned release (set on every v* tag push)
+#   :0.3.6    — exact version from the git tag
 #   :0.3      — major.minor floating tag (updated on every patch within the minor)
-#   :main     — latest commit on main; may be ahead of the last tagged release
 #   :sha-xxxx — specific commit SHA; produced by workflow_dispatch
 #
 # Images land at: ghcr.io/debpalash/omnivoice-studio
@@ -57,18 +59,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Tag strategy (`:sha-<short>` is emitted on every trigger):
-      #   v0.3.0 tag push   → :0.3.0, :0.3, :latest, :sha-
-      #   main branch push  → :main, :sha-
+      #   v0.3.6 tag push   → :0.3.6, :0.3, :stable, :sha-
+      #   main branch push  → :latest, :main, :sha-
       #   workflow_dispatch → :sha- only
       #
-      # Fix for stale :latest (issues #249, #251):
-      #   The previous rule used `enable={{is_default_branch}}`, which evaluates
-      #   to false on tag pushes (detached HEAD) — so :latest was never updated
-      #   when a release tag was pushed. The version / :latest / :main rules are
-      #   gated on `github.event_name == 'push'` so a manual workflow_dispatch can
-      #   only ever produce a throwaway `:sha-` tag (never republish a mutable
-      #   tag), and :latest additionally excludes prerelease tags (those contain a
-      #   `-`, e.g. v1.0.0-rc.1) so a prerelease can't clobber :latest.
+      # All mutable-tag rules stay gated on `github.event_name == 'push'` so a
+      # manual workflow_dispatch can only ever produce a throwaway `:sha-` tag
+      # (the stale-:latest fix from #249/#251). :stable excludes prerelease
+      # tags (those contain a `-`) so a prerelease can't clobber it.
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -77,7 +75,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref, '-') }}
+            type=raw,value=stable,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref, '-') }}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=raw,value=main,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-,format=short
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,11 +398,12 @@ jobs:
       # always reported the static 0.3.0 never looked "newer", so no update was
       # ever delivered). Ephemeral, CI-only — never committed. Tauri reads the
       # bundle + updater version from tauri.conf.json, so rewriting it here
-      # stamps the artifacts + latest.json. `0.3.0-preview.N` is a prerelease of
-      # the current target, so previews converge to stable when 0.3.0 ships
-      # (0.3.0 > 0.3.0-preview.N). NOTE: the Windows MSI ProductVersion strips
-      # the prerelease (→ 0.3.0), a wrinkle to verify for win preview→preview
-      # upgrades; mac/linux replace the bundle wholesale and are unaffected.
+      # stamps the artifacts + latest.json. Under the versioning hard rule
+      # (owner-set 2026-06-11) main is always last-release + 1, so BASE-N is a
+      # prerelease of the NEXT version and semver-sorts ABOVE the last stable
+      # (0.3.6-N > 0.3.5) — preview users naturally upgrade past stable, and
+      # the Windows MSI ProductVersion (which strips the prerelease → 0.3.6)
+      # is also correctly above the last stable.
       - name: Stamp preview version
         if: github.event_name == 'workflow_dispatch' && inputs.publish_preview
         shell: bash
@@ -637,3 +638,40 @@ jobs:
           } > /tmp/preview-notes.md
           gh release edit preview --repo "$REPO" --notes-file /tmp/preview-notes.md
           echo "Applied auto-generated release notes + contributors to the preview release."
+
+  # ── Post-release version bump (versioning hard rule, owner-set 2026-06-11) ──
+  # main is always last-release + 1 patch. The moment a stable v* tag is
+  # released, bump the three version sources on main to the next patch so every
+  # PR and preview build identifies as the next version. Pushes directly to
+  # main with the workflow token (a metadata-only commit; CI runs on PRs).
+  version-bump:
+    if: github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref, '-')
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Bump main to released version + 1 patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASED="${GITHUB_REF_NAME#v}"
+          IFS=. read -r MAJ MIN PAT <<< "$RELEASED"
+          NEXT="$MAJ.$MIN.$((PAT + 1))"
+          CURRENT=$(jq -r .version frontend/src-tauri/tauri.conf.json)
+          if [ "$(printf '%s\n' "$NEXT" "$CURRENT" | sort -V | tail -1)" = "$CURRENT" ] && [ "$NEXT" != "$CURRENT" ]; then
+            echo "main is already at $CURRENT (>= $NEXT) — nothing to bump"; exit 0
+          fi
+          tmp=$(mktemp)
+          jq --arg v "$NEXT" '.version = $v' frontend/src-tauri/tauri.conf.json > "$tmp"
+          mv "$tmp" frontend/src-tauri/tauri.conf.json
+          sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEXT\"/" frontend/src-tauri/Cargo.toml
+          sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEXT\"/" pyproject.toml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/src-tauri/tauri.conf.json frontend/src-tauri/Cargo.toml pyproject.toml
+          git commit -m "chore(version): main -> $NEXT after $GITHUB_REF_NAME release"
+          git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,11 @@ Everything else (new engines, fancy features) is downstream of "the thing instal
 <!-- GSD:conventions-start source:CONVENTIONS.md -->
 ## Conventions
 
-**Versioning (hard rule):** Everything ships on `v0.3.0`. Never mention, suggest, or label anything with a version bump — no v0.4, no RCs, no "defer to next version", no future-version labels — unless the user explicitly asks to bump. Zero unprompted version chatter.
+**Versioning (hard rule, owner-set 2026-06-11):** main is always **latest release + 1 patch**. The moment `vX.Y.Z` is released, main's version files (`frontend/src-tauri/tauri.conf.json`, `frontend/src-tauri/Cargo.toml`, `pyproject.toml` — keep all three in lockstep) bump to `X.Y.(Z+1)`. Consequences:
+- Every PR and preview build identifies as the **next** version. Preview builds stamp `X.Y.(Z+1)-N` (run number), which semver-sorts **above** the last stable `X.Y.Z` — the updater ordering is natural, no comparator tricks needed.
+- Releasing = tag `vX.Y.(Z+1)` from main (version files already match), then immediately bump main to `X.Y.(Z+2)`. The post-release bump is automated by the `version-bump` job in release.yml; if it fails, do it manually in the same day.
+- Docker: `ghcr.io/debpalash/omnivoice-studio:latest` = **main** (rolling preview); `:X.Y.Z` + `:X.Y` + `:stable` = tagged releases. `:latest` is the preview channel by design — stable users pin `:stable` or a version tag.
+- Do not bump minor/major or invent RCs/codenames without the owner asking. No "defer to next version" labels — scope is absorbed or declined, never re-versioned.
 
 **Localization (hard rule):** No hardcoded non-English (CJK) **user-facing text** anywhere in the codebase except the translation layer (`frontend/src/i18n/`). All UI strings go through i18n (`t('...')` keys in `locales/*.json`); native language names live in `i18n/index.ts` (`LANGUAGES`). Functional CJK is allowed and tracked via the allowlist in `tests/test_no_hardcoded_cjk.py` — text-processing regexes, model/engine vocabulary & identifiers (e.g. CosyVoice speaker IDs), localized error matching, demo/eval data, and test fixtures. CI fails on any hardcoded CJK outside the allowlist; to add legitimate functional CJK, extend `_ALLOWED_FILES` there with a justification.
 

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.5"
+version = "0.3.6"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "OmniVoice Studio",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "identifier": "com.debpalash.omnivoice-studio",
   "build": {
     "frontendDist": "../dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.5"
+version = "0.3.6"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see


### PR DESCRIPTION
## What (versioning hard rule, owner-set 2026-06-11)

- **main always carries last release + 1 patch.** Bumped 0.3.5 → **0.3.6** across all three version sources (`tauri.conf.json`, `Cargo.toml` + lock, `pyproject.toml`) — every PR and preview build now identifies as the next version.
- **Preview ordering becomes natural.** Preview builds stamp `BASE-N`; with main at 0.3.6 that's `0.3.6-N` which semver-sorts **above** stable 0.3.5 — preview users always upgrade past the last release without comparator tricks, and the Windows MSI ProductVersion wrinkle (prerelease stripped) is also correct now. Complements #335's cross-channel comparator.
- **Docker retag** (`docker.yml`): `:latest` = rolling **main preview**; `:stable` (new) + `:X.Y.Z` + `:X.Y` = tagged releases. `workflow_dispatch` still emits only throwaway `:sha-` tags (keeps the #249/#251 stale-tag fix).
- **Auto-bump job** (`release.yml` → `version-bump`): on every stable `v*` tag push, bumps main to the next patch automatically (idempotent — skips if main is already ahead).
- **Rule codified in CLAUDE.md**, replacing the obsolete "everything ships on v0.3.0" rule.

## Release flow after this PR

1. main says 0.3.6 → tag `v0.3.6` (version files already match)
2. release builds stable installers + `:0.3.6`/`:0.3`/`:stable` Docker images
3. `version-bump` job pushes main → 0.3.7
4. every main push publishes Docker `:latest` (preview) + `:main`

> Note for Docker users: `:latest` now means **preview channel**. Stable deployments should pin `:stable` or a version tag. Worth a line in the next release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 0.3.6.
  * Refined release automation workflows to streamline stable release publishing and version management.

* **Documentation**
  * Updated versioning conventions clarifying how release versions and preview builds are tracked and tagged.
  * Revised Docker image tagging guidance to distinguish between rolling preview releases and stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->