### PR TITLE
ci(security): don't cancel main scans — merge trains painted history red

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,9 +32,13 @@ env:
 permissions:
   contents: read
 
+# PR branches: a new push cancels the superseded scan (no wasted runners).
+# main: every commit keeps its own group, so nothing is cancelled — a merge
+# train used to leave a permanent red ✗ ("cancelled") on every intermediate
+# commit in the history view even though nothing failed.
 concurrency:
-  group: security-${{ github.ref }}
-  cancel-in-progress: true
+  group: security-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'branch' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # ── Secret scanning (gating) ─────────────────────────────────────────────


### PR DESCRIPTION
## What

`security.yml`'s concurrency group cancelled the previous commit's still-running scan on **every push to main**. During today's 14-PR merge train that left a permanent red ✗ ("cancelled") on every intermediate commit in [the history view](https://github.com/debpalash/OmniVoice-Studio/commits/main/) — alarming, but nothing actually failed.

- **main**: each commit now gets its own concurrency group (`…-{sha}`) and `cancel-in-progress` is off — every merged commit keeps a completed scan.
- **PR branches**: unchanged — a new push still cancels the superseded scan.

Cost: a merge train runs N short Security scans in parallel instead of 1. Benefit: main's history reflects reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## GitHub Actions concurrency policy refined for main-branch history

Updated the `concurrency` configuration in `.github/workflows/security.yml` to prevent merge-train commits from appearing as "cancelled" in git history.

### Changes
- **Concurrency group**: Modified from a simple `security-${{ github.ref }}` to a conditional group that appends `github.sha` when on main (`security-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || 'branch' }}`), ensuring each main commit retains its own execution context.
- **Cancel in progress**: Switched from always-enabled (`true`) to conditionally enabled based on branch (`${{ github.ref != 'refs/heads/main' }}`), cancelling only on PR/feature branches.

### Behavior
- **PR branches**: No change — new pushes continue to cancel in-progress scans, conserving runner resources.
- **Main branch**: Each commit now maintains its own concurrency group, preventing the security scan status from being retroactively marked as "cancelled" when later commits are merged. This ensures merge trains display completed scan results in the commit history rather than permanent cancellation indicators.

### Trade-off
Accepts slightly higher concurrent execution on merge trains (N parallel security scans instead of cascading cancellations) in exchange for cleaner historical record of security scan completion states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->