### PR TITLE
docs: community docs refresh — README, CONTRIBUTING, SECURITY, SUPPORT, Docker/macOS install

### DIFF
--- a/.agents/rules/antigravity-rtk-rules.md
+++ b/.agents/rules/antigravity-rtk-rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Google Antigravity)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 - [ ] 📝 Documentation
 - [ ] 🧪 Tests
 - [ ] 🔧 CI / Build
-- [ ] 🚀 Release prep (RC or final)
+- [ ] 🚀 Release prep
 
 ## Testing
 
@@ -33,17 +33,12 @@
 - [ ] No local machine paths, logs, or personal env details in this PR
 - [ ] Version files are in sync (if version bump): `pyproject.toml`, `package.json`, `tauri.conf.json`, `Cargo.toml`
 - [ ] If this PR changes runtime behavior, the regression fixture at `tests/fixtures/omnivoice_data/` still loads green on the `smoke-matrix` CI job (macOS + Windows + Linux)
-- [ ] If this is part of a release, I've read the "Release cadence" section below and confirmed this PR targets the right RC
 
-## Release cadence (read once per RC)
+## Release cadence
 
-OmniVoice ships every minor on a **two-RC cadence**:
-- `vX.Y.0-rc1` — cut from `main` once all GATE-* requirements pass; clean-VM exercise on 4 OSes (per `REL-01`)
-- 48-hour soak (no new commits to release branch except fix-forward)
-- `vX.Y.0` — promotion if rc1 is clean
-
-If your PR touches install / bootstrap / CI, it MUST land before rc1 cut, not between rc1 and the promotion. During a soak, any merge needs explicit OK from the release captain.
-
-## Screenshots
-
-<!-- If applicable, add screenshots or recordings. -->
+OmniVoice ships **continuous-to-main** — no release candidates, no soak windows.
+Every merged PR is immediately part of the rolling preview (`main`, Docker
+`:latest`, the desktop Preview channel). Versioned releases are tagged from
+`main` when it's ready; `main` then bumps to the next patch automatically.
+Users who want stability pin a release tag / Docker `:stable` / the desktop
+Stable channel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,8 @@ Everything else (new engines, fancy features) is downstream of "the thing instal
 - Docker: `ghcr.io/debpalash/omnivoice-studio:latest` = **main** (rolling preview); `:X.Y.Z` + `:X.Y` + `:stable` = tagged releases. `:latest` is the preview channel by design — stable users pin `:stable` or a version tag.
 - Do not bump minor/major or invent RCs/codenames without the owner asking. No "defer to next version" labels — scope is absorbed or declined, never re-versioned.
 
+**Docs-sync (hard rule, owner-set 2026-06-11):** any change that alters something these docs describe — README.md, CONTRIBUTING.md, SECURITY.md, SUPPORT.md, LICENSE, or `docs/**` (install flows, Docker tag semantics, platform support, versioning/release behavior, review process, supported versions) — must update those docs **in the same PR** as the change. If a doc impact is discovered after merge, the docs fix is the immediate next commit, not backlog. Stale docs are treated as bugs.
+
 **Localization (hard rule):** No hardcoded non-English (CJK) **user-facing text** anywhere in the codebase except the translation layer (`frontend/src/i18n/`). All UI strings go through i18n (`t('...')` keys in `locales/*.json`); native language names live in `i18n/index.ts` (`LANGUAGES`). Functional CJK is allowed and tracked via the allowlist in `tests/test_no_hardcoded_cjk.py` — text-processing regexes, model/engine vocabulary & identifiers (e.g. CosyVoice speaker IDs), localized error matching, demo/eval data, and test fixtures. CI fails on any hardcoded CJK outside the allowlist; to add legitimate functional CJK, extend `_ALLOWED_FILES` there with a justification.
 
 Other conventions not yet established. Will populate as patterns emerge during development.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,69 @@ cd frontend/src-tauri && cargo check
 
 ---
 
+---
+
+## What code review looks like
+
+Every PR is reviewed by two AI reviewers before a human looks at it:
+
+- **CodeRabbit** posts a walkthrough (with a sequence diagram, and an ASCII
+  before/after sketch for UI changes), inline findings, and warning-mode
+  pre-merge checks against the project's hard rules.
+- **Greptile** reviews with the same project rubrics and learns from 👍/👎
+  reactions on its comments — react to train it.
+
+Both are advisory, not gating: CI and the maintainer's approval decide. Don't
+be surprised by detailed bot comments minutes after you open a PR — address
+what's right, push back (in a reply) on what's wrong.
+
+**Commit & PR conventions:** conventional-commit style with a scope
+(`fix(dub): …`, `feat(setup): …`) and link the issue (`Closes #N` / `Refs #N`)
+in the title or body.
+
+## Quality gates your PR must pass
+
+- **Cross-platform parity (hard rule):** anything that ships in default mode
+  must behave identically on macOS, Windows, and Linux. Platform-specific
+  *implementation* is fine; platform-divergent *default behavior* is a P0.
+  Platform-only features go behind an explicit opt-in (Settings toggle, env
+  var, or CLI flag).
+- **i18n — all 21 locales (hard rule):** every user-facing string goes through
+  `t('...')` and the key must exist in **all 21** files under
+  `frontend/src/i18n/locales/`. Translate; don't copy English into non-English
+  locales. CI fails on hardcoded CJK outside the allowlist in
+  `tests/test_no_hardcoded_cjk.py` (extend `_ALLOWED_FILES` with a
+  justification for legitimate functional CJK).
+- **DB schema changes** go through an alembic migration with a tested upgrade
+  path — existing `omnivoice_data/` must keep working with no manual steps.
+- **Engine back-compat:** already-installed engines (model weights on disk)
+  must not require reinstall or re-download.
+- **Local-first:** no new outbound calls except GitHub Issues (opt-in
+  reporting) and HuggingFace model downloads. Never log or persist secrets or
+  absolute home paths.
+- **Security posture:** the backend serves loopback HTTP — treat every
+  query/path/form parameter as hostile. User-chosen filesystem destinations
+  are authorized in the Tauri process (save dialog), never via HTTP params.
+
+## Contribution licensing
+
+OmniVoice Studio is **AGPL-3.0-only**, and the maintainer also offers a
+**commercial license** (see [LICENSE](LICENSE)). By submitting a contribution
+you agree that:
+
+1. you have the right to submit it (your own work, or compatibly licensed);
+2. it is licensed to the project under **AGPL-3.0**; and
+3. you grant the project maintainer a perpetual, worldwide, non-exclusive
+   right to also distribute your contribution under the project's commercial
+   license terms.
+
+This inbound grant is what keeps the dual-license model viable. If you can't
+agree to (3) for a particular contribution, say so in the PR and we'll discuss
+before merging. Adding a `Signed-off-by:` line (DCO) to your commits is
+appreciated but not required.
+
+---
+
 ## Need Help?
 
 - **Stuck on setup?** Ask in [Discord #help](https://discord.gg/bzQavDfVV9)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@
   </p>
 
   <p>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/download/v0.2.7/OmniVoice.Studio_0.2.7_aarch64.dmg"><img src="https://img.shields.io/badge/macOS-DMG_(Apple_Silicon)-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS DMG" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/download/v0.2.7/OmniVoice.Studio_0.2.7_x64_en-US.msi"><img src="https://img.shields.io/badge/Windows-MSI_(x64)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows MSI" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/download/v0.2.7/OmniVoice.Studio_0.2.7_amd64.AppImage"><img src="https://img.shields.io/badge/Linux-AppImage_(x64)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux AppImage" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/download/v0.2.7/OmniVoice.Studio_0.2.7_amd64.deb"><img src="https://img.shields.io/badge/Debian-.deb-A81D33?style=for-the-badge&logo=debian&logoColor=white" alt="Download Debian .deb" /></a>
+    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/macOS-DMG_(Apple_Silicon)-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS DMG" /></a>
+    <!-- Pre-built macOS bundle is Apple Silicon. Intel Macs: build from source (docs/install/macos.md); a pre-built Intel target is tracked in #279. -->
+    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Windows-MSI_(x64)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows MSI" /></a>
+    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Linux-AppImage_(x64)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux AppImage" /></a>
+    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Debian-.deb-A81D33?style=for-the-badge&logo=debian&logoColor=white" alt="Download Debian .deb" /></a>
   </p>
   <p>
     <sub><b>macOS:</b> first launch needs a one-time approval — right-click → <b>Open</b> (or System Settings → Privacy &amp; Security → <b>"Open Anyway"</b> on macOS 15). No Terminal needed. <a href="docs/install/macos.md#gatekeeper-quarantine">Why?</a></sub>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,11 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-|---------|--------------------|
-| 0.2.x   | ✅ Current release |
-| < 0.2   | ❌ No longer supported |
+| Version | Supported |
+|---------|-----------|
+| 0.3.x (latest release + `main` previews) | ✅ Current — all fixes land here |
+| 0.2.7 | ⚠️ Legacy stable — security fixes only, upgrade recommended |
+| < 0.2.7 | ❌ No longer supported |
 
 ## Reporting a Vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,23 @@
+# Support
+
+## Where to get help
+
+| Channel | Best for |
+|---|---|
+| [Discord](https://discord.gg/bzQavDfVV9) — `#help` | Setup problems, quick questions, sharing results |
+| [GitHub Issues](https://github.com/debpalash/OmniVoice-Studio/issues) | Bugs and feature requests — use the templates; attach the diagnostic bundle (Settings → About → "Save diagnostic bundle") |
+| [GitHub Discussions](https://github.com/debpalash/OmniVoice-Studio/discussions) | Design questions, ideas, show & tell |
+| Security issues | **Never a public issue** — see [SECURITY.md](SECURITY.md) for private reporting |
+
+## Before filing a bug
+
+1. Update to the latest release (or `main` if you follow previews) — fixes ship continuously.
+2. Run the in-app self-check: **Settings → About → Run self-check**.
+3. Search existing issues; add a 👍 + your details to an existing one rather than opening a duplicate.
+
+## Response expectations
+
+This is an open-source project maintained with the help of an automated triage
+bot: issues are typically triaged within hours and every report gets a human-
+approved response. Reproducible reports with a diagnostic bundle get fixed
+fastest.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -8,11 +8,15 @@ it in a normal browser.
 >
 > | Tag | What you get |
 > |-----|--------------|
-> | `:latest` | Most recent versioned release (updated on every `v*` git tag) |
-> | `:0.3.0` | Exact release version |
+> | `:latest` | **Rolling preview** — latest commit on `main` (always one patch ahead of the last release). This is the preview channel; pin `:stable` for production. |
+> | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
+> | `:0.3.6` | Exact release version |
 > | `:0.3` | Latest patch within the 0.3 minor |
-> | `:main` | Latest commit on `main` — may be ahead of the last release |
+> | `:main` | Alias of the same rolling `main` build as `:latest` |
 > | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |
+>
+> Versioning rule: `main` always carries *last release + 1 patch*, so `:latest`
+> (preview) version-sorts above `:stable` — upgrades flow naturally.
 >
 > **Note on the update-channel toggle:** The update-channel UI (Settings → About → Update channel) is part of the Tauri desktop app's built-in auto-updater. It does **not** apply to the Docker image — the Docker image is the headless web-server build. To update your Docker deployment, pull the new image tag and recreate the container (`docker compose pull && docker compose up -d`).
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -3,6 +3,11 @@
 This page is self-contained: follow it top to bottom and you'll end up with a
 working OmniVoice Studio install on macOS (Apple Silicon or Intel).
 
+> **Intel Macs:** the pre-built `.app`/DMG currently ships **Apple Silicon
+> only** — on Intel, install **from source** (works fully; ASR falls back to
+> CTranslate2). A pre-built Intel bundle is tracked in
+> [#279](https://github.com/debpalash/OmniVoice-Studio/issues/279).
+
 ## Prerequisites
 
 - **macOS 12 (Monterey) or newer** — Apple Silicon or Intel.


### PR DESCRIPTION
## What

Grounded in a full audit of every community/governance doc against the current project state. Highlights:

- **README** — download badges were frozen at **v0.2.7** (4 patches stale); now evergreen via `releases/latest`. Honest Intel-Mac note (pre-built = Apple Silicon; source works on Intel; pre-built Intel tracked in #279).
- **CONTRIBUTING** — the big gap. New sections: what CodeRabbit/Greptile review looks like (and that it's advisory, not gating), conventional-commit + issue-link conventions, all the hard quality gates (cross-platform default parity, 21-locale i18n + CJK allowlist, alembic migrations, engine back-compat, local-first, loopback security posture), and a **contribution-licensing grant** — contributors license inbound under AGPL-3.0 *and* grant commercial-license redistribution rights, which is what keeps the dual-license model legally viable.
- **SECURITY** — supported versions said `0.2.x = current`; now 0.3.x current + 0.2.7 legacy/security-only.
- **docs/install/docker.md** — tag table contradicted `docker.yml` after #338; now documents `:latest` = rolling main **preview**, new `:stable` for production pinning, and the main-is-release+1 versioning rule.
- **PR template** — still instructed contributors on the **abolished two-RC/48h-soak ceremony**; now documents continuous-to-main.
- **SUPPORT.md** — new: channels, before-you-file checklist (self-check + diagnostic bundle), response expectations.
- **docs/install/macos.md** — Intel claim qualified to match shipping reality.

LICENSE and CODE_OF_CONDUCT audited clean — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation refresh for version 0.3.x release and community contribution standards

This PR updates multiple top-level docs to reflect the 0.3.x/main continuous release model, clarify installation and Docker tag semantics, and establish contributor guidance, quality gates, and contributor-licensing terms.

### README.md
- Download badges now point to /releases/latest (no longer hardcoded to v0.2.7).
- Inline clarification that shipped pre-built macOS bundles are Apple Silicon–only; Intel users should build from source; Intel pre-built tracking referenced in issue `#279`.

### CONTRIBUTING.md
- Adds AI reviewer guidance (CodeRabbit, Greptile) noting their feedback is advisory and non-gating.
- Adds detailed "Quality gates your PR must pass" covering:
  - Cross-platform default parity
  - 21-locale i18n baseline with CJK allowlist
  - Alembic DB migration expectations
  - Engine backward-compatibility
  - Local-first constraints
  - Loopback/security posture requirements
- Adds contribution-licensing clause: inbound contributions licensed AGPL-3.0 with a contributor grant that allows the maintainer to offer a commercial redistribution license (preserves the project’s dual-license model). DCO/Signed-off-by guidance included.

### SECURITY.md
- Updates supported-versions guidance: 0.3.x as current/main-preview (security fixes land here), 0.2.7 marked legacy/security-only, and versions < 0.2.7 unsupported.

### .github/pull_request_template.md
- Replaces RC/48h-soak-specific release prep with a generic "Release prep".
- Documents continuous-to-main workflow (no RCs/soak windows); stability via pinned release tags or the :stable channel.

### SUPPORT.md
- Adds "Where to get help" (Discord `#help`, GitHub Issues with diagnostic bundle requirement, GitHub Discussions) and private security reporting per SECURITY.md.
- Adds a before-you-file checklist (update to latest/main, run in-app self-check, gather diagnostic bundle, search existing issues) and response expectations/triage timelines.

### docs/install/docker.md
- Documents :latest/:main as rolling preview (last release + 1 patch), introduces :stable for production pinning.
- Documents exact tag options (:0.3.6, :0.3) and :sha-xxxxxxx behavior.
- Notes Tauri update-channel toggle doesn't apply to Docker images—updates require pulling a new tag and recreating the container.
- Aligns wording with docker.yml (post-#338).

### docs/install/macos.md
- Clarifies macOS .app/DMG behavior: pre-built bundles are Apple Silicon–only; Intel users should build from source (ASR uses CTranslate2 fallback). References issue `#279`.

### CLAUDE.md / docs-sync rule
- Adds a codified docs-sync hard rule: any change affecting documented behavior/visibility must update corresponding docs in the same PR; post-merge docs fixes must be the immediate next commit and stale docs are treated as bugs.

### Other
- README, SECURITY, SUPPORT, CONTRIBUTING, Docker and macOS install docs, PR template, and a new agents rule file updated.
- LICENSE and CODE_OF_CONDUCT audited and unchanged.
- Co-Authored-By: Claude Fable 5.

Mermaid flowchart — new continuous-to-main release mechanism:
```mermaid
flowchart LR
  Dev[Develop / Feature PRs] -->|Merge to main| Main[main (continuous)]
  Main -->|Automated preview build| Preview[:latest / :main (rolling preview)]
  Main -->|Tag release| Release[Release tag (e.g. 0.3.6)]
  Release -->|Create stable channel| Stable[:stable (production pin)]
  Users -->|Pin to stable| Stable
  Users -->|Use previews| Preview
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->