### PR TITLE
ci(release): reinstate macOS Intel (x86_64) build target on macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,9 +133,28 @@ jobs:
             rust_target: aarch64-apple-darwin
             bundles: "app,dmg,updater"
 
-          # macOS Intel dropped: Apple shipped the last Intel Mac in 2023 and
-          # Rosetta 2 runs the ARM build natively. macos-13 runner backlog
-          # was also blocking every release tag for ~10 min.
+          # macOS Intel (#279): reinstated. The earlier "Rosetta 2 runs the
+          # ARM build" rationale for dropping it was backwards — Rosetta only
+          # translates x86_64→arm64, so Intel Macs (supported through macOS
+          # Sequoia) simply cannot run the aarch64 bundle and had NO
+          # installable artifact. Runner: `macos-15-intel`, GitHub's
+          # designated migration target after macos-13 retired (Dec 2025);
+          # it's a standard (public-repo-free) image supported through
+          # August 2027 — the last x86_64 image Actions will offer. Building
+          # natively (not cross-compiling from the arm64 leg) keeps the
+          # per-TRIPLE uv/ffmpeg sidecar fetches, the DMG installer smoke,
+          # and the ad-hoc signing verification (scripts/
+          # verify-macos-signing.sh, PR #290) all exercising the real
+          # x86_64 artifact on real Intel hardware. The macos-13 queue
+          # backlog that motivated the original drop is contained by
+          # fail-fast:false — a slow Intel leg can delay the release run but
+          # can't fail the other targets.
+          - os: macos-15-intel
+            arch: x86_64-apple-darwin
+            label: "macOS Intel"
+            rust_target: x86_64-apple-darwin
+            bundles: "app,dmg,updater"
+
           # Windows: force MSI bundling via --bundles. NSIS fails at makensis
           # because our PyInstaller payload approaches its ~2 GB stub limit.
           - os: windows-2022
@@ -291,7 +310,10 @@ jobs:
           case "$TRIPLE" in
             aarch64-apple-darwin|x86_64-apple-darwin)
               # evermeet.cx ships each binary as a separate .zip containing
-              # a single x86_64 Mach-O executable (runs via Rosetta on arm64).
+              # a single x86_64 Mach-O executable — natively correct on the
+              # Intel leg, and runs via Rosetta 2 on the arm64 leg. Both
+              # darwin TRIPLEs therefore bundle the same payload; only the
+              # sidecar filename suffix differs.
               for TOOL in ffmpeg ffprobe; do
                 if [ "$TOOL" = "ffmpeg" ]; then
                   URL="https://evermeet.cx/ffmpeg/getrelease/zip"

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -35,6 +35,19 @@ Download the latest DMG from the
 [Releases page](https://github.com/debpalash/OmniVoice-Studio/releases/latest),
 double-click to mount, drag **OmniVoice Studio.app** into `/Applications`.
 
+Pick the DMG that matches your Mac (check **Apple menu → About This Mac → Chip/Processor**):
+
+| Mac | DMG to download |
+|-----|-----------------|
+| Apple Silicon (M1/M2/M3/M4…) | `OmniVoice.Studio_<version>_aarch64.dmg` |
+| Intel | `OmniVoice.Studio_<version>_x64.dmg` |
+
+The architectures are **not** interchangeable: an Intel Mac cannot run the
+`aarch64` build (Rosetta 2 only translates the other direction — it lets Apple
+Silicon run Intel apps, never the reverse). If a release predates the Intel
+build target and has no `x64` DMG, use the
+[install-from-source path](#install-from-source) above instead.
+
 If the first launch is blocked by macOS Gatekeeper ("OmniVoice Studio cannot be
 opened because the developer cannot be verified"), see the next section — it
 opens with one right-click, no Terminal.


### PR DESCRIPTION
Refs #279 — leave the issue open until a release actually ships the `x64` DMG.

## Problem

The release matrix builds macOS only for `aarch64-apple-darwin`, so Intel Mac users (reporter: macOS 15.7.3 on an Intel MacBook Pro) have **no installable artifact at all**. The old matrix comment justified dropping Intel with "Rosetta 2 runs the ARM build natively" — that's backwards: Rosetta 2 only translates x86_64→arm64 (Apple Silicon running Intel apps), never the reverse. An Intel Mac cannot launch the aarch64 bundle.

## Runner decision: native `macos-15-intel` (not cross-compile)

GitHub retired the Intel `macos-13` image on Dec 4, 2025, but ships **`macos-15-intel`** as the designated x86_64 migration target — a *standard* (free for public repos) image, supported through **August 2027**, explicitly "the last available x86_64 image from Actions". Sources:
- [GitHub Changelog: macOS 13 runner image is closing down](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- [actions/runner-images#13045 — macOS 15 Intel image announcement](https://github.com/actions/runner-images/issues/13045)

Native build chosen over cross-compiling (`rustup target add x86_64-apple-darwin` on the arm64 runner) because:
1. **Every per-arch step exercises the real artifact on real Intel hardware** — the DMG installer smoke (mount + bundle-completeness checks) and the PR #290 signing verification (`codesign --verify`, `spctl`, nested-binary scan) run against the actual x86_64 app on the architecture users will run it on. Cross-compiling would reduce those to structural-only checks on a foreign arch.
2. **Zero changes to the sidecar fetch scripts** — both `Bundle uv` and `Bundle ffmpeg` case statements already key on `$TRIPLE` and already carry `x86_64-apple-darwin` branches.
3. The macos-13 **queue-backlog** concern that motivated the original drop is contained by `fail-fast: false`: a slow Intel leg can delay a release run, never fail the other three targets.

When `macos-15-intel` retires (Aug 2027), the leg either moves to cross-compile or Intel support sunsets — decision for then.

## Signing path (PR #290 parity)

The Intel leg flows through the identical signing pipeline with **no condition changes** — all macOS signing steps gate on `runner.os == 'macOS'`, which now matches both legs:
- **Ad-hoc seal**: `tauri.conf.json` → `bundle.macOS.signingIdentity: "-"` is target-agnostic; Intel DMGs get the same valid ad-hoc signature (GUI-bypassable Gatekeeper prompt, not the un-bypassable "damaged" error).
- **Opt-in Apple signing**: "Configure Apple signing" (stable tag + `MACOS_SIGNING_ENABLED`) exports `APPLE_*` for both darwin legs.
- **Verification**: "Verify macOS signing" runs `scripts/verify-macos-signing.sh` against the x86_64 `.app` — report-only on preview, `--require-signed` strict on the signed stable path — natively on Intel hardware.

## Arch-dependent pieces audited (complete list)

| Piece | Location | Finding |
|---|---|---|
| `uv` sidecar download | release.yml "Bundle uv" | `case` already has `x86_64-apple-darwin` → `uv-x86_64-apple-darwin.tar.gz`; asset verified present for pinned `0.11.7` (HTTP 200). No change. |
| ffmpeg/ffprobe sidecars | release.yml "Bundle ffmpeg + ffprobe" | `case` already matches `x86_64-apple-darwin`; evermeet.cx binaries are **x86_64 Mach-O** — natively correct on Intel (they were the Rosetta-translated ones on arm64). Comment updated. |
| `bundle.externalBin` | `frontend/src-tauri/tauri.conf.json` | Target-agnostic `binaries/uv|ffmpeg|ffprobe`; tauri-bundler resolves `-x86_64-apple-darwin` suffix from `--target`. No change. |
| Runtime sidecar resolution | `frontend/src-tauri/src/tools.rs:find_bundled_sidecar` | Already maps `("macos","x86_64") → "x86_64-apple-darwin"`. No change. |
| Runtime `uv` fallback | `tools.rs:install_uv_standalone` | astral.sh `install.sh` self-detects arch. No change. |
| Runtime ffmpeg fallback | `tools.rs:install_ffmpeg_standalone` | Checks both `/usr/local/bin/brew` (Intel) and `/opt/homebrew/bin/brew`; evermeet fallback is x86_64. No change. |
| Dev placeholder sidecars | `frontend/src-tauri/build.rs` | Uses cargo `TARGET` env — follows `--target x86_64-apple-darwin` automatically. No change. |
| Python bootstrap | `bootstrap.rs` (uv-managed CPython) | uv selects the host-arch python-build-standalone build. No change. |
| GGUF engine binary | `backend/engines/omnivoice_gguf/backend.py` | Already returns `darwin-x86_64` on Intel. No change. |
| Updater manifest | tauri-action `includeUpdaterJson: true` | Each matrix leg merges its platform key into the release's `latest.json`; the Intel leg contributes **`darwin-x86_64`** alongside `darwin-aarch64` (same merge mechanism that already combines the 3 existing legs). `updater_channel.rs` only picks endpoints/versions — platform-key selection is inside `tauri-plugin-updater`, keyed on the running build's target, so Intel installs self-update on both Stable and Preview channels with no Rust changes. Note: the known tauri-action concurrent-merge race grows from 3 to 4 legs; same accepted exposure as today. |
| Smoke + checksums | release.yml smoke/`SHA256SUMS-<label>.txt` | Keyed on `matrix.rust_target`/`matrix.label` — Intel leg gets its own paths and `SHA256SUMS-macOS Intel.txt`. No change. |
| DMG asset naming | tauri-bundler | `…_x64.dmg` vs `…_aarch64.dmg` — no release-asset collision. |
| `minimumSystemVersion: 12.0` | tauri.conf.json | Deployment target unchanged; building on the macOS 15 image still targets 12.0+. Reporter is on 15.7.3. |

## Files changed

- `.github/workflows/release.yml` — new `macos-15-intel` matrix leg (`x86_64-apple-darwin`, `app,dmg,updater`), corrected the stale "Intel dropped / Rosetta" comment, clarified the darwin ffmpeg comment.
- `docs/install/macos.md` — arch table (which DMG to download), explicit "not interchangeable" note, from-source fallback for releases predating the Intel artifact.

## Validation

CI macOS builds can't run locally; validated by:
1. **YAML parse** (`yaml.safe_load`) — matrix renders 4 legs with the expected keys.
2. **`bash -n` on every `run:` block** in the workflow (with `${{ }}` expressions stubbed) — all pass.
3. **Upstream asset check** — `uv-x86_64-apple-darwin.tar.gz` exists for the pinned `UV_VERSION=0.11.7` (HTTP 200).
4. **Careful diff review** against every arch-dependent step (table above).

### How to test the build matrix without releasing

The workflow already has a no-release-impact dispatch path: **Actions → Desktop Release → Run workflow** on this branch with `publish_preview: false` (the default). That runs the full 4-leg matrix — including the Intel leg's bundle, DMG smoke, and signing verification — and lands in a **draft** release named after the branch (no tag, stable `latest.json` untouched). Delete the draft afterwards. Once merged, the next preview dispatch (`publish_preview: true`) ships the first installable Intel artifact; close #279 only after a release carries `…_x64.dmg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Reinstates native macOS Intel (x86_64) build target in the release workflow to produce installable Intel-compatible DMG artifacts, addressing issue `#279` where Intel Mac users lacked installation support.

## Changes

### Workflow Updates (`.github/workflows/release.yml`)
- Adds `macos-15-intel` matrix leg to build `x86_64-apple-darwin` target alongside existing aarch64 (Apple Silicon) builds
- Uses GitHub-hosted `macos-15-intel` runner (supported through August 2027) for native Intel compilation
- Produces x86_64 app, DMG, and updater artifacts with full signing, smoke tests, and verification on real Intel hardware
- Updates ffmpeg/ffprobe bundling comment to clarify both Darwin targets share x86_64 Mach-O payload, differing only in sidecar filename suffix

### Documentation Updates (`docs/install/macos.md`)
- Adds DMG selection table with exact filenames for Apple Silicon vs. Intel architectures
- Includes explicit warning that Intel and Apple Silicon builds are not interchangeable
- Directs Intel users to install from source when x64 DMG unavailable for older releases

## Validation
The PR audits all architecture-dependent components (uv sidecar, ffmpeg/ffprobe, bundling, runtime resolution, fallbacks, build scripts, Python bootstrap, GGUF engine binary, updater manifests, smoke tests, DMG naming, minimum system versions) and reports no required application code changes. The signing pipeline remains unchanged, continuing to gate on `runner.os == 'macOS'` for ad-hoc sealing and optional Apple signing.

The workflow can be tested via repository dispatch with `publish_preview: false` to run the 4-leg matrix (2 macOS architectures + 2 other targets) and produce a draft release without affecting stable `latest.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->