### PR TITLE
fix(tts): voice clone corrupts from 2nd render — pin cudagraph-compiled inference to one thread (#315)

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -2,6 +2,7 @@ import os
 import time
 import asyncio
 import logging
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 # ── Lazy imports ─────────────────────────────────────────────────────
@@ -338,6 +339,75 @@ def _install_compile_fallback(_model) -> None:
     _model.generate = _generate_with_compile_fallback
 
 
+# ── #315: thread affinity for cudagraph-compiled models ─────────────────────
+# `torch.compile(mode="reduce-overhead")` captures CUDA graphs, and captured
+# graph state is **thread-local** (torch/_inductor/cudagraph_trees keys its
+# tree manager off the capturing thread). The `_gpu_pool` runs up to
+# `_GPU_WORKER_CAP` threads, so render #1 captures the graph on worker A and a
+# later render dispatched to worker B replays against mismatched cudagraph
+# state — silently corrupting the audio (static / slowed playback, no
+# exception, so the #278 eager fallback never fires). Fix: every call into a
+# cudagraph-compiled model executes on ONE dedicated thread; uncompiled
+# models (CPU / MPS / Windows-no-Triton / compile-disabled) keep the full pool.
+
+_TORCH_COMPILE_MODE = "reduce-overhead"
+# Compile modes that enable CUDA graphs under the hood — these need the
+# single-thread affinity below. "default" / "max-autotune-no-cudagraphs"
+# would not.
+_CUDAGRAPH_COMPILE_MODES = frozenset({"reduce-overhead", "max-autotune"})
+
+_compiled_inference_executor: "ThreadPoolExecutor | None" = None
+_compiled_inference_thread_ident: "int | None" = None
+
+
+def _get_compiled_inference_executor() -> ThreadPoolExecutor:
+    """The single-thread executor that owns ALL inference on a compiled model.
+
+    Created lazily the first time a model is compiled with a cudagraph mode;
+    reused across model reloads (idle unload → reload keeps the same thread,
+    which is fine — a fresh compile simply captures its graphs there too).
+    The worker is spun up eagerly so its thread ident is known for the
+    re-entrancy guard in `_install_compile_thread_affinity`.
+    """
+    global _compiled_inference_executor, _compiled_inference_thread_ident
+    if _compiled_inference_executor is None:
+        _compiled_inference_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="compiled-infer",
+        )
+        _compiled_inference_thread_ident = _compiled_inference_executor.submit(
+            threading.get_ident
+        ).result()
+    return _compiled_inference_executor
+
+
+def _install_compile_thread_affinity(_model) -> None:
+    """Pin every ``model.generate`` call to the dedicated compile thread (#315).
+
+    Wraps ``model.generate`` (the single choke point all TTS paths funnel
+    through — generate, archetype previews, dub, stream, batch) so the call
+    body always runs on `_get_compiled_inference_executor()`'s one thread.
+    That makes the thread that *captures* the CUDA graph on the first render
+    and the thread that *replays* it on every later render the same thread,
+    deterministically, regardless of which `_gpu_pool` worker dispatched it.
+
+    Installed AFTER `_install_compile_fallback`, so the call-time order is:
+    caller thread → hop to the dedicated thread → eager-fallback wrapper →
+    real generate (the #278 classification/retry also runs on the dedicated
+    thread, with native tracebacks). The hop is a no-op when already on the
+    dedicated thread — a 1-worker executor submitting to itself would
+    deadlock, so the re-entrancy guard is load-bearing.
+    """
+    executor = _get_compiled_inference_executor()
+    inner_generate = _model.generate
+
+    def _generate_on_compile_thread(*args, **kwargs):
+        if threading.get_ident() == _compiled_inference_thread_ident:
+            return inner_generate(*args, **kwargs)
+        return executor.submit(inner_generate, *args, **kwargs).result()
+
+    _model.generate = _generate_on_compile_thread
+
+
 def _set_loading(sub_stage: str, detail: str = "", error: str | None = None, progress: float | None = None):
     """Update the loading detail dict atomically."""
     _loading_detail["sub_stage"] = sub_stage
@@ -411,7 +481,7 @@ def _load_model_sync():
             if should_torch_compile(device):
                 _set_loading("compiling", "Compiling model (torch.compile)…")
                 try:
-                    _model.llm = torch.compile(_model.llm, mode="reduce-overhead")
+                    _model.llm = torch.compile(_model.llm, mode=_TORCH_COMPILE_MODE)
                 except Exception as compile_exc:
                     # #278: compile is an optimization, never a point of
                     # failure — keep the eager model and remember the failure
@@ -428,6 +498,19 @@ def _load_model_sync():
                     # archs, #278). Wrap generate so that falls back to eager
                     # instead of failing the generation.
                     _install_compile_fallback(_model)
+                    if _TORCH_COMPILE_MODE in _CUDAGRAPH_COMPILE_MODES:
+                        # #315: reduce-overhead uses CUDA graphs, whose
+                        # captured state is thread-local. Pin all inference to
+                        # one dedicated thread so a later render dispatched to
+                        # a different _gpu_pool worker can't replay a graph it
+                        # didn't capture (static / slowed audio from the 2nd
+                        # render onward).
+                        _install_compile_thread_affinity(_model)
+                        logger.info(
+                            "torch.compile mode %r uses CUDA graphs — compiled-model "
+                            "inference pinned to a single dedicated thread (#315).",
+                            _TORCH_COMPILE_MODE,
+                        )
                     logger.info("torch.compile applied.")
         except Exception as e:
             logger.info("torch.compile skipped: %s", e)

--- a/tests/test_compile_thread_affinity.py
+++ b/tests/test_compile_thread_affinity.py
@@ -1,0 +1,224 @@
+"""#315 — a cudagraph-compiled model must never be driven from multiple threads.
+
+`torch.compile(mode="reduce-overhead")` captures CUDA graphs, and captured
+graph state is thread-local (torch/_inductor/cudagraph_trees keys its tree
+manager off the capturing thread). The `_gpu_pool` ThreadPoolExecutor runs up
+to 4 workers, so render #1 captured the graph on worker A and render #2,
+dispatched to worker B, replayed mismatched cudagraph state — silently
+corrupting the audio (static / slowed playback, no exception, so the #278
+eager fallback never fired).
+
+These tests pin the contract: when the model is compiled with a cudagraph
+mode, every ``model.generate`` call — no matter which pool worker dispatches
+it — executes on ONE dedicated thread. Uncompiled models (CPU / MPS /
+Windows-no-Triton / compile-disabled) are untouched and keep the full pool.
+"""
+from __future__ import annotations
+
+import importlib
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+@pytest.fixture
+def engine_env(monkeypatch):
+    """The *live* services.engine_env, with the session flag isolated
+    (same rationale as tests/test_compile_fallback.py)."""
+    mod = importlib.import_module("services.engine_env")
+    monkeypatch.setattr(mod, "_compile_runtime_failure", None)
+    return mod
+
+
+@pytest.fixture
+def model_manager(engine_env):
+    return importlib.import_module("services.model_manager")
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+class _RecordingModel:
+    """Model whose ``generate`` records the thread it actually executes on."""
+
+    def __init__(self, failures=()):
+        self.eager_llm = object()
+        self.llm = _FakeCompiledLLM(self.eager_llm)
+        self.exec_idents: list[int] = []
+        self._failures = list(failures)
+        self._lock = threading.Lock()
+
+    def generate(self, *args, **kwargs):
+        with self._lock:
+            self.exec_idents.append(threading.get_ident())
+            if self._failures:
+                raise self._failures.pop(0)
+        return ["audio-tensor"]
+
+
+class _FakeCompiledLLM:
+    """Stands in for torch.compile's OptimizedModule (has ``_orig_mod``)."""
+
+    def __init__(self, orig):
+        self._orig_mod = orig
+
+
+def _fx_trace_exc() -> Exception:
+    """The #278 compile-stack failure (message-classified)."""
+    return RuntimeError(
+        "Detected that you are using FX to symbolically trace "
+        "a dynamo-optimized function. This is not supported at the moment."
+    )
+
+
+def _dispatch_from_pool(model, n_calls: int = 8, workers: int = 4):
+    """Simulate `_gpu_pool` multi-thread dispatch: fire n_calls generates from
+    a multi-worker pool (exactly what the routers' run_in_executor does)."""
+    dispatch_idents: set[int] = set()
+    results = []
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="gpu-pool-sim") as pool:
+        def _call(i):
+            dispatch_idents.add(threading.get_ident())
+            return model.generate(text=f"render {i}")
+
+        futures = [pool.submit(_call, i) for i in range(n_calls)]
+        for fut in futures:
+            results.append(fut.result(timeout=30))
+    return dispatch_idents, results
+
+
+# ── the regression: multi-thread dispatch must execute on one thread ────────
+
+
+def test_all_generate_calls_execute_on_one_dedicated_thread(model_manager):
+    model = _RecordingModel()
+    model_manager._install_compile_thread_affinity(model)
+
+    dispatch_idents, results = _dispatch_from_pool(model, n_calls=8, workers=4)
+
+    assert results == [["audio-tensor"]] * 8
+    # The bug: before the fix, exec idents == dispatch idents (up to 4
+    # distinct threads). The contract: exactly ONE executing thread...
+    assert len(set(model.exec_idents)) == 1
+    # ...which is the dedicated compiled-inference thread, not a pool worker.
+    assert set(model.exec_idents) == {model_manager._compiled_inference_thread_ident}
+    assert model_manager._compiled_inference_thread_ident not in dispatch_idents
+
+
+def test_load_model_sync_pins_compiled_model_to_one_thread(
+    monkeypatch, engine_env, model_manager
+):
+    """End-to-end through _load_model_sync: a CUDA load that applies
+    torch.compile(mode="reduce-overhead") must return a model whose generate
+    is single-threaded even when dispatched from a multi-worker pool."""
+    from types import SimpleNamespace
+
+    class _FakeOmniVoiceModel(_RecordingModel):
+        def __init__(self):
+            super().__init__()
+            self.llm = object()  # eager module, pre-compile
+
+    fake_model = _FakeOmniVoiceModel()
+
+    fake_torch = SimpleNamespace(
+        float16="float16",
+        compile=lambda mod, mode: _FakeCompiledLLM(mod),
+    )
+    fake_omnivoice_cls = SimpleNamespace(
+        from_pretrained=lambda *a, **k: fake_model,
+    )
+
+    monkeypatch.setattr(model_manager, "_lazy_torch", lambda: fake_torch)
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: fake_omnivoice_cls)
+    monkeypatch.setattr(model_manager, "get_best_device", lambda: "cuda")
+    monkeypatch.setattr(engine_env, "should_torch_compile", lambda device: True)
+
+    loaded = model_manager._load_model_sync()
+
+    assert loaded is fake_model
+    assert isinstance(loaded.llm, _FakeCompiledLLM)  # compile was applied
+
+    _dispatch_from_pool(loaded, n_calls=6, workers=4)
+    assert len(set(loaded.exec_idents)) == 1
+    assert set(loaded.exec_idents) == {model_manager._compiled_inference_thread_ident}
+
+
+def test_uncompiled_model_keeps_caller_threads(
+    monkeypatch, engine_env, model_manager
+):
+    """No behavior change for CPU/MPS/eager paths: when compile is skipped,
+    generate runs on whichever pool worker dispatched it."""
+    from types import SimpleNamespace
+
+    fake_model = _RecordingModel()
+    fake_torch = SimpleNamespace(float16="float16", compile=None)
+    fake_omnivoice_cls = SimpleNamespace(from_pretrained=lambda *a, **k: fake_model)
+
+    monkeypatch.setattr(model_manager, "_lazy_torch", lambda: fake_torch)
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: fake_omnivoice_cls)
+    monkeypatch.setattr(model_manager, "get_best_device", lambda: "mps")
+    monkeypatch.setattr(engine_env, "should_torch_compile", lambda device: False)
+
+    loaded = model_manager._load_model_sync()
+
+    dispatch_idents, _ = _dispatch_from_pool(loaded, n_calls=6, workers=4)
+    # generate executed directly on the dispatching threads — no hop.
+    assert set(loaded.exec_idents) <= dispatch_idents
+
+
+# ── composition & safety properties ─────────────────────────────────────────
+
+
+def test_composes_with_eager_fallback(engine_env, model_manager):
+    """Production install order: fallback first, then affinity. A #278
+    compile-stack failure must still trigger the one-shot eager retry — and
+    both the failed attempt and the retry run on the dedicated thread."""
+    model = _RecordingModel(failures=[_fx_trace_exc()])
+    model_manager._install_compile_fallback(model)
+    model_manager._install_compile_thread_affinity(model)
+
+    dispatch_idents, results = _dispatch_from_pool(model, n_calls=1, workers=2)
+
+    assert results == [["audio-tensor"]]
+    assert len(model.exec_idents) == 2  # compiled attempt + eager retry
+    assert set(model.exec_idents) == {model_manager._compiled_inference_thread_ident}
+    assert model.llm is model.eager_llm  # fallback swapped the module out
+    assert engine_env._compile_runtime_failure is not None
+
+
+def test_reentrant_generate_does_not_deadlock(model_manager):
+    """generate re-entering model.generate on the dedicated thread must run
+    inline (a 1-worker executor submitting to itself would deadlock)."""
+
+    class _ReentrantModel:
+        def __init__(self):
+            self.exec_idents: list[int] = []
+
+        def generate(self, depth=0):
+            self.exec_idents.append(threading.get_ident())
+            if depth == 0:
+                # After install, self.generate is the affinity wrapper.
+                return self.generate(depth=1)
+            return ["audio-tensor"]
+
+    model = _ReentrantModel()
+    model_manager._install_compile_thread_affinity(model)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        result = pool.submit(model.generate).result(timeout=30)
+
+    assert result == ["audio-tensor"]
+    assert len(model.exec_idents) == 2
+    assert set(model.exec_idents) == {model_manager._compiled_inference_thread_ident}
+
+
+def test_errors_propagate_to_the_calling_thread(model_manager):
+    """Non-compile errors raised on the dedicated thread must surface
+    unchanged to the dispatching caller (future.result re-raises)."""
+    model = _RecordingModel(failures=[ValueError("bad preset")])
+    model_manager._install_compile_thread_affinity(model)
+
+    with pytest.raises(ValueError, match="bad preset"):
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(lambda: model.generate(text="x")).result(timeout=30)


### PR DESCRIPTION
Closes #315

## Root cause

`torch.compile(mode="reduce-overhead")` (applied to `model.llm` in `_load_model_sync`) uses **CUDA graphs**, and captured graph state is **thread-local** — `torch/_inductor/cudagraph_trees` keys its tree manager off the thread that captured the graph.

Meanwhile, every render is dispatched via `run_in_executor(_gpu_pool, ...)`, and `_gpu_pool` is a `ThreadPoolExecutor` with up to **4 workers** on CUDA. So:

1. **Render #1** lands on worker A → Dynamo/Inductor compiles and captures the CUDA graph on thread A → output is perfect.
2. **Render #2** lands on worker B → replays against cudagraph state that belongs to thread A → mismatched/stale graph memory → **static noise + slowed playback**.

Crucially this corrupts **silently** — no exception is raised — which is why the #327 eager-fallback wrapper (which classifies Dynamo/Inductor/Triton *exceptions*) never fired. It also explains the exact "works once, then degrades" signature in the report, and matches the reporter's log from the #278 attachment.

## Fix

When the model is compiled with a cudagraph mode (`reduce-overhead` / `max-autotune`), route **all** inference through a single dedicated thread:

- New `_get_compiled_inference_executor()`: a lazy 1-thread `compiled-infer` executor, created when a cudagraph-compiled model loads, reused across idle-unload/reload cycles.
- New `_install_compile_thread_affinity(model)`: wraps `model.generate` — the same single choke point all TTS paths (generate, archetype previews, dub, stream, batch) funnel through, and that #327 already wraps — so every call hops to the dedicated thread. Graph **capture** (first render) and every **replay** (later renders) now deterministically happen on the same thread, regardless of which `_gpu_pool` worker dispatched.
- **Re-entrancy guard** by thread ident: a call already on the dedicated thread runs inline (a 1-worker executor submitting to itself would deadlock).
- Installed **after** `_install_compile_fallback`, so call order is: caller thread → hop → #327 eager-fallback wrapper → real generate. The #278/#327 classification and eager retry also run on the dedicated thread with native tracebacks.
- Compile mode hoisted to `_TORCH_COMPILE_MODE = "reduce-overhead"` with `_CUDAGRAPH_COMPILE_MODES` gating the affinity install, plus an INFO log explaining the pin.

### Why this design (vs. downgrading the compile mode)

Pinning preserves `reduce-overhead`'s CUDA-graph speedup *and* keeps the full `_gpu_pool` throughput for everything else that runs on it (ASR/transcription chunks, diarization, RVC, NLLB translation, watermarking, non-default engine backends). Compiled-LLM inference is effectively GPU-serialized anyway, so a single driver thread costs nothing. Downgrading to a non-cudagraph mode would have thrown away the optimization for every multi-worker CUDA user.

### What doesn't change

- CPU / MPS / Windows-no-Triton / compile-disabled / arch-gated paths: `should_torch_compile()` gates exactly as before → no wrapper installed → generate runs on pool workers as today.
- The #327 eager fallback and session-wide compile disable are untouched and verified composed.

## Tests

New `tests/test_compile_thread_affinity.py` (6 tests, fail-before/pass-after verified):

- `test_all_generate_calls_execute_on_one_dedicated_thread` — 8 renders dispatched from a 4-worker pool (simulating `_gpu_pool`); asserts every `generate` body executed on exactly one thread, the dedicated one, never a dispatcher. **Fails before the fix** (executes on up to 4 distinct pool threads).
- `test_load_model_sync_pins_compiled_model_to_one_thread` — end-to-end through `_load_model_sync` with stubbed torch/OmniVoice on a CUDA+compile path.
- `test_uncompiled_model_keeps_caller_threads` — eager path unchanged (passes before and after, by design).
- `test_composes_with_eager_fallback` — a #278 compile-stack failure still triggers the one-shot eager retry, both attempts on the dedicated thread.
- `test_reentrant_generate_does_not_deadlock` — re-entrancy guard.
- `test_errors_propagate_to_the_calling_thread` — exceptions surface unchanged to the dispatching caller.

Targeted validation:

```
$ .venv/bin/python -m pytest tests/test_compile_thread_affinity.py tests/test_compile_fallback.py tests/test_torch_compile_gate.py -q
27 passed in 0.88s
```

Pre-fix (model_manager.py stashed): 5 failed, 1 passed — the one pass being the uncompiled-path no-change test. Import sanity of `services.model_manager` / `services.engine_env` verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem
When TTS models are compiled with `torch.compile(mode="reduce-overhead")`, CUDA graphs capture and maintain thread-local state. The existing GPU worker pool dispatches inference across multiple threads via `ThreadPoolExecutor`. When graph captures occur on one worker thread and replays occur on another, state mismatches corrupt audio output (static noise, slowed playback) from the second render onward.

## Solution
Pin all inference for cudagraph-compiled models to a single dedicated thread, preventing cross-thread replay of thread-local CUDA graph state. A lazy singleton executor manages this dedicated inference thread across model load/unload cycles.

## How It Works

```mermaid
graph TD
    A["GPU Worker Pool<br/>(ThreadPoolExecutor)"] -->|invoke generate| B{"Is model<br/>cudagraph-compiled?"}
    B -->|No| C["Run on caller thread<br/>(existing behavior)"]
    B -->|Yes| D["Dedicated Inference Executor<br/>(single thread)"]
    D -->|already on<br/>inference thread?| E{"Re-entrancy<br/>check"}
    E -->|Yes| F["Run inline<br/>(avoid deadlock)"]
    E -->|No| G["Queue to executor<br/>and await"]
    F -->|return| H["Result"]
    G -->|return| H
    C -->|return| H
```

## Changes

**backend/services/model_manager.py (+84/-1)**
- Added module-level constants `_TORCH_COMPILE_MODE = "reduce-overhead"` and `_CUDAGRAPH_COMPILE_MODES` to gate thread affinity by compile mode
- Added `_get_compiled_inference_executor()` lazy factory that creates and reuses a single-thread executor named `"compiled-infer"`
- Added `_install_compile_thread_affinity(model)` that wraps `model.generate` to:
  - Route all generate calls through the dedicated thread executor
  - Include a re-entrancy guard to run inline if already executing on the dedicated thread
  - Install after the existing eager-fallback wrapper so compile-failure classification runs on the dedicated thread with native tracebacks
- Added `threading` import for thread identity tracking
- Hoisted compile mode from inline string to constant for consistency

Non-cudagraph paths (CPU, MPS, Windows-no-Triton, compile-disabled, architecture-gated) remain unchanged and continue using the existing worker pool.

**tests/test_compile_thread_affinity.py (+224/-0)**
New comprehensive test suite covering:
- Multi-worker dispatch validates all generate calls execute on the dedicated thread (test_all_generate_calls_execute_on_one_dedicated_thread)
- Lazy executor creation and pinning on model load (test_load_model_sync_pins_compiled_model_to_one_thread)
- Uncompiled models retain caller thread behavior (test_uncompiled_model_keeps_caller_threads)
- Integration with eager-fallback path: compile failures trigger retry on dedicated thread with proper swapback (test_composes_with_eager_fallback)
- Re-entrancy guard prevents deadlock when generate calls itself recursively (test_reentrant_generate_does_not_deadlock)
- Non-compile exceptions propagate correctly from dedicated thread to caller (test_errors_propagate_to_the_calling_thread)

Includes helper classes `_RecordingModel`, `_FakeCompiledLLM`, and helper function `_dispatch_from_pool()` to simulate multi-worker scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->