### PR TITLE
docs: model-source support policy — verifiable public sources only (#310)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,11 +10,12 @@
 
 ## Model supply chain
 
-Only load models from sources you trust. OmniVoice's supported model sources
-are public Hugging Face repos and official project releases; the loaders avoid
-code-executing formats where possible, but a model *archive* from an untrusted
-private source can carry anything (bundled executables, modified configs).
-Treat privately distributed model files like any other untrusted download.
+OmniVoice supports models from **public, verifiable sources only** (Hugging
+Face repos, official project releases). Privately sold or gated model files
+are not supported: an archive from a private source can carry anything
+(bundled executables, modified configs), and nobody else can verify or
+reproduce it. Treat any privately distributed model file as an untrusted
+download, and never run executables bundled with model archives.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,14 @@
 | 0.2.7 | ⚠️ Legacy stable — security fixes only, upgrade recommended |
 | < 0.2.7 | ❌ No longer supported |
 
+## Model supply chain
+
+Only load models from sources you trust. OmniVoice's supported model sources
+are public Hugging Face repos and official project releases; the loaders avoid
+code-executing formats where possible, but a model *archive* from an untrusted
+private source can carry anything (bundled executables, modified configs).
+Treat privately distributed model files like any other untrusted download.
+
 ## Reporting a Vulnerability
 
 **Please do not open a public issue for security vulnerabilities.**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,6 +9,17 @@
 | [GitHub Discussions](https://github.com/debpalash/OmniVoice-Studio/discussions) | Design questions, ideas, show & tell |
 | Security issues | **Never a public issue** — see [SECURITY.md](SECURITY.md) for private reporting |
 
+## Model sources we support
+
+OmniVoice loads local models, and you're free to point it at any model folder
+you trust. **Official support, however, covers only models from verifiable
+public sources** — Hugging Face repos and official project releases with a
+published license and checksums. Privately distributed, paywalled, or
+otherwise unverifiable model files are **use-at-your-own-risk**: we can't
+reproduce or debug problems with a model we can't download, and we can't vouch
+for what's in a private archive. If you do load one, extract only the model
+files themselves (weights, config, tokenizer) — never run bundled executables.
+
 ## Before filing a bug
 
 1. Update to the latest release (or `main` if you follow previews) — fixes ship continuously.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,14 +11,16 @@
 
 ## Model sources we support
 
-OmniVoice loads local models, and you're free to point it at any model folder
-you trust. **Official support, however, covers only models from verifiable
-public sources** — Hugging Face repos and official project releases with a
-published license and checksums. Privately distributed, paywalled, or
-otherwise unverifiable model files are **use-at-your-own-risk**: we can't
-reproduce or debug problems with a model we can't download, and we can't vouch
-for what's in a private archive. If you do load one, extract only the model
-files themselves (weights, config, tokenizer) — never run bundled executables.
+OmniVoice is built on the idea that everything it runs is **open and available
+to everyone**: free, public models with verifiable sources and licenses
+(Hugging Face repos, official project releases), so the whole community can
+use, test, and debug the same thing.
+
+**We do not support privately sold, paywalled, or gated model files.** A model
+delivered privately can't be verified, reproduced, or shared — it doesn't fit
+the project's goals, and issues involving such models will be politely closed.
+As a general safety rule, never run executables bundled inside any model
+archive.
 
 ## Before filing a bug
 


### PR DESCRIPTION
## What

Codifies the owner's decision from #310: OmniVoice keeps its local-first loading mechanism (point `ASR_MODEL_FASTER` etc. at any folder you trust), but **official support covers only models from verifiable public sources** — HF repos and official releases with published licenses/checksums. Privately distributed or paywalled model files (like the "Whisper XXL Pro" sold via private channel in #310) are use-at-your-own-risk, with a never-run-bundled-executables warning.

- `SUPPORT.md`: new "Model sources we support" section
- `SECURITY.md`: matching "Model supply chain" note

Refs #310. Shipped with the policy per the docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Model source support policy documentation

Codifies the decision from issue `#310`: OmniVoice retains its local-first model-loading mechanism (environment variables like ASR_MODEL_FASTER can point at any trusted folder), but official support is limited to verifiable public sources (Hugging Face repos and official releases that publish license and checksum information). Privately distributed or paywalled model files are explicitly unsupported and treated as use-at-your-own-risk; the docs warn to never run bundled executables from such sources. The change is marked shipped per the docs-sync rule.

### Changes

**SUPPORT.md** (+13 lines)
- Adds a "Model sources we support" section specifying official support for free, public models with verifiable sources and licenses (e.g., Hugging Face repos, official project releases with license/checksum).
- States privately sold/paywalled/gated/unverifiable model files are not supported; issues involving them will be closed.
- Adds a safety rule: do not run executables bundled in model archives — extract only model assets (weights, config, tokenizer) from trusted sources.

**SECURITY.md** (+9 lines)
- Adds a "Model supply chain" subsection clarifying OmniVoice supports models only from public, verifiable sources.
- Warns privately distributed or gated model archives may include bundled executables or modified configurations and should be treated as untrusted.

### Commit
Single commit: "docs: firm up model-source policy — open, public, verifiable only; no private/paid models" (co-authored). Marked as shipped.

### Rationale
Balances flexibility (local-first loading remains) with security and supportability: official documentation and support endorse only open, verifiable model sources with published license and integrity metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->