### PR TITLE
feat(dictation): collapse Whisper hallucination loops in final transcripts (Wave 1.1)

### DIFF
--- a/backend/api/routers/capture.py
+++ b/backend/api/routers/capture.py
@@ -91,6 +91,11 @@ async def transcribe_audio(
         if not full_text and segments:
             full_text = " ".join(s.get("text", "") for s in segments).strip()
 
+        # Wave 1.1: strip Whisper hallucination loops from the final text.
+        # Segments keep the raw recognition so their timings stay truthful.
+        from services.refinement import collapse_repetitive_artifacts
+        full_text = collapse_repetitive_artifacts(full_text)
+
         # Calculate audio duration from segments if available
         duration = 0.0
         if segments:

--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -245,6 +245,12 @@ async def _transcribe_buffer_full(chunks: list[bytes]) -> dict:
             if not full_text and segments:
                 full_text = " ".join(s.get("text", "") for s in segments).strip()
 
+            # Wave 1.1: strip Whisper hallucination loops from the final
+            # text (the string that gets auto-pasted). Segments keep the
+            # raw recognition so their timings stay truthful.
+            from services.refinement import collapse_repetitive_artifacts
+            full_text = collapse_repetitive_artifacts(full_text)
+
             duration = max((s.get("end", 0) for s in segments), default=0.0)
 
             return {

--- a/backend/services/refinement.py
+++ b/backend/services/refinement.py
@@ -1,0 +1,103 @@
+"""Dictation transcript refinement — deterministic pre-pass (Wave 1.1).
+
+Adapted from voicebox (https://github.com/jamiepine/voicebox), MIT License,
+Copyright (c) voicebox contributors.
+
+This module currently ships phase 1 of Spec 3 (docs/competitive-analysis.md):
+``collapse_repetitive_artifacts()``, a deterministic filter that strips the
+classic Whisper hallucination loops ("thanks for watching" repeated forever)
+from FINAL transcripts before they reach the user. It needs no LLM and runs
+identically on every platform. Phase 2 (optional local-LLM filler-word
+removal via services.llm_backend) lands with parity program Wave 2.1 and
+will live here too.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A token (or unit) must repeat at least this many times consecutively to be
+# treated as an STT artifact. Rhetorical repetition ("no, no, no, no, no" —
+# five repeats) stays below the threshold and survives.
+_REPETITION_RUN_THRESHOLD = 6
+
+# Upper bound on the repeating unit the character-level pass looks for.
+# Long enough for multi-word loop phrases, short enough to keep the
+# non-greedy regex cheap on long transcripts.
+_MAX_REPETITION_UNIT_CHARS = 60
+
+
+def _token_key(word: str) -> str:
+    """Normalize a token for repetition comparison — strip surrounding
+    punctuation and lowercase so "URL", "url," and "URL." all compare
+    equal inside a loop."""
+    return re.sub(r"[^\w]", "", word).lower()
+
+
+def collapse_repetitive_artifacts(text: str, min_run: int = _REPETITION_RUN_THRESHOLD) -> str:
+    """Strip STT-artifact loops. Two passes handle the full space:
+
+    1. Word-level: any token repeated ``min_run``+ times consecutively
+       (with surrounding punctuation stripped for comparison). Catches
+       single-word loops like "URL URL URL..." and punctuated variants.
+    2. Character-level: any substring 2-60 chars long that repeats
+       ``min_run``+ times immediately after itself. Catches multi-word
+       loops ("thanks for watching" x 6) that the word-level pass misses
+       (no consecutive identical tokens) and loops in no-space scripts
+       where ``text.split()`` yields a single unsplit token.
+
+    Both passes preserve rhetorical repetition: five "no"s or three
+    "yeah"s stay in the transcript because they don't cross the threshold.
+    """
+    if not text:
+        return text
+    collapsed = _collapse_word_runs(text, min_run)
+    collapsed = _collapse_character_runs(collapsed, min_run)
+    return collapsed
+
+
+def _collapse_word_runs(text: str, min_run: int) -> str:
+    words = text.split()
+    if len(words) < min_run:
+        return text
+
+    out: list[str] = []
+    i = 0
+    while i < len(words):
+        key = _token_key(words[i])
+        j = i
+        # Empty keys (all-punctuation tokens) shouldn't count as a match.
+        if key:
+            while j < len(words) and _token_key(words[j]) == key:
+                j += 1
+        else:
+            j = i + 1
+        run_len = j - i
+        if run_len >= min_run:
+            # Drop the whole run — the surrounding prose still carries
+            # the speaker's thought, and a 6-token repeat almost always
+            # means the speech-to-text model glitched.
+            pass
+        else:
+            out.extend(words[i:j])
+        i = j
+
+    return " ".join(out)
+
+
+def _collapse_character_runs(text: str, min_run: int) -> str:
+    # Non-greedy unit so the shortest repeating substring wins. Lower
+    # bound of 2 chars avoids stripping emphasized single-letter runs
+    # ("wooooooow", "hmmmmm") that aren't hallucinations. re.DOTALL so a
+    # newline inside a looped unit (rare) doesn't break the match.
+    pattern = re.compile(
+        r"(.{2," + str(_MAX_REPETITION_UNIT_CHARS) + r"}?)\1{" + str(min_run - 1) + r",}",
+        flags=re.DOTALL,
+    )
+    result = pattern.sub("", text)
+    if result == text:
+        return text
+    # Stripping a run leaves double whitespace where the loop used to
+    # bridge surrounding context; normalize only when we actually modified
+    # the text so untouched transcripts keep their original whitespace.
+    return re.sub(r"\s+", " ", result).strip()

--- a/tests/backend/services/test_refinement_collapse.py
+++ b/tests/backend/services/test_refinement_collapse.py
@@ -1,0 +1,81 @@
+"""collapse_repetitive_artifacts — Wave 1.1 (Spec 3 phase 1).
+
+Fixture patterns mirror voicebox's test corpus (MIT) with Latin-only strings
+(the repo CJK gate forbids literal CJK in test files; the character-level
+pass is script-agnostic, so a no-space Latin token exercises the same path).
+"""
+
+import pytest
+
+from services.refinement import collapse_repetitive_artifacts
+
+
+def test_word_level_loop_is_dropped():
+    text = "send it to the URL URL URL URL URL URL please"
+    assert collapse_repetitive_artifacts(text) == "send it to the please"
+
+
+def test_punctuated_word_loop_is_dropped():
+    text = "open the file. URL, URL, URL, URL, URL, URL. then close it"
+    out = collapse_repetitive_artifacts(text)
+    assert "URL" not in out
+    assert "open the file." in out and "then close it" in out
+
+
+def test_multiword_phrase_loop_is_dropped():
+    loop = "thanks for watching " * 6
+    text = f"that's all for today {loop}goodbye"
+    out = collapse_repetitive_artifacts(text)
+    assert "thanks for watching" not in out
+    assert "that's all for today" in out and "goodbye" in out
+
+
+def test_nospace_token_loop_is_dropped():
+    # A single token formed by a unit repeated 6x with no separators —
+    # the word-level pass can't split it; the character pass catches it.
+    text = "done " + "lala" * 6 + " bye"
+    out = collapse_repetitive_artifacts(text)
+    assert "lala" not in out
+    assert out.startswith("done") and out.endswith("bye")
+
+
+def test_rhetorical_repetition_survives():
+    text = "no, no, no, no, no — that's not what I meant"
+    assert collapse_repetitive_artifacts(text) == text
+
+
+def test_triple_yeah_survives():
+    text = "yeah yeah yeah let's do it"
+    assert collapse_repetitive_artifacts(text) == text
+
+
+def test_emphasized_single_letter_runs_survive():
+    # Character pass lower bound is 2 chars — stretched words stay.
+    text = "wooooooow that was hmmmmm interesting"
+    assert collapse_repetitive_artifacts(text) == text
+
+
+def test_clean_text_content_unchanged():
+    # The word-level pass rejoins tokens with single spaces (whitespace is
+    # normalized even when nothing is dropped); the words themselves and
+    # their order must be untouched.
+    text = "a perfectly  normal sentence\nwith odd   spacing"
+    assert collapse_repetitive_artifacts(text).split() == text.split()
+
+
+def test_empty_and_none_safe():
+    assert collapse_repetitive_artifacts("") == ""
+
+
+def test_case_and_punct_insensitive_word_match():
+    text = "ok URL url, URL. url URL url done"
+    out = collapse_repetitive_artifacts(text)
+    assert "url" not in out.lower().replace("ok", "").replace("done", "")
+    assert out == "ok done"
+
+
+@pytest.mark.parametrize("repeats,survives", [(5, True), (6, False)])
+def test_threshold_boundary(repeats, survives):
+    text = ("ping " * repeats).strip()
+    out = collapse_repetitive_artifacts(text)
+    assert (out == text) is survives


### PR DESCRIPTION
## What

Wave 1.1 of the [parity program](docs/specs/2026-06-12-elevenlabs-parity-program.md) (Spec 3 phase 1) — the deterministic half of dictation refinement, ported from voicebox (MIT, attribution header).

- **`backend/services/refinement.py`** — `collapse_repetitive_artifacts()`: word-level pass (token repeated ≥6×, compared punctuation-stripped/lowercased) + character-level pass (any 2–60-char unit repeating ≥6×, which catches multi-word phrase loops and no-space scripts). Rhetorical repetition below the threshold survives ("no, no, no, no, no" stays).
- Applied to the **final** transcript text in `/ws/transcribe` (`capture_ws.py`) and `POST /transcribe` (`capture.py`) — the string that gets auto-pasted. Segment texts keep raw recognition so their timings stay truthful. Partials untouched.
- No LLM, no settings, no platform divergence — this fixes the classic "thanks for watching" loop for every user out of the box. The optional LLM phase (filler-word removal via `llm_backend`) lands with Wave 2.1 in this same module.
- 12 unit tests incl. threshold boundary (5 survives / 6 dropped), punctuated/no-space variants, and emphasized-word ("wooooooow") preservation. Fixtures are Latin-only per the CJK gate; the character pass is script-agnostic.

## Verification
- `uv run pytest tests/backend/services/test_refinement_collapse.py tests/test_capture_ws.py backend/tests/test_capture_ws.py` → all green
- CJK gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dictation Transcript Hallucination Loop Collapse (Wave 1.1)

Implements deterministic, platform-identical pre-processing to remove repetitive Whisper hallucination loops from final dictation transcripts. The implementation is adapted from voicebox (MIT license) and represents Phase 1 of Spec 3 from the parity program.

### New Mechanism

```mermaid
graph TD
    A["ASR Output<br/>(segments + full_text)"] --> B["Extract full_text<br/>(final transcript)"]
    B --> C["Word-Level Pass<br/>Remove tokens repeated ≥6×<br/>(after punct-strip/lowercase)"]
    C --> D["Character-Level Pass<br/>Remove substrings 2–60 chars<br/>repeated ≥6×"]
    D --> E["Normalize Whitespace<br/>(if modified)"]
    E --> F["Return to User<br/>(cleaned final text)"]
    G["Segments + Timings<br/>(unchanged)"] -.->|preserved| F
    style C fill:`#e1f5ff`
    style D fill:`#e1f5ff`
    style G fill:`#f3e5f5`
```

### Changes

**`backend/services/refinement.py`** (+103 lines)
- New public function `collapse_repetitive_artifacts(text: str, min_run: int = 6) -> str`
- Word-level collapse: removes any token repeated ≥6 times consecutively (after normalization)
- Character-level collapse: removes any 2–60 character substring repeated ≥6 times immediately
- Preserves rhetorical repetition below threshold (e.g., "no, no, no, no, no")
- Deterministic, no LLM required, consistent across all platforms

**`backend/api/routers/capture.py`** (+5 lines)
- `transcribe_audio` applies `collapse_repetitive_artifacts()` to final transcript before returning

**`backend/api/routers/capture_ws.py`** (+6 lines)
- `ws_transcribe` applies `collapse_repetitive_artifacts()` in `_transcribe_buffer_full` before returning final text to client

**`tests/backend/services/test_refinement_collapse.py`** (+81 lines)
- 12 unit tests covering:
  - Threshold boundary (5 repeats survives / 6 removed)
  - Punctuated word loops and no-space token variants
  - Rhetorical repetition preservation
  - Emphasized single-letter runs (e.g., "ahhhhhhh")
  - Case and punctuation-insensitive matching
  - Whitespace normalization
  - Empty input safety

### Design Notes

- **Scope**: Applied only to final transcript string returned in `/ws/transcribe` and `POST /transcribe`
- **Segment preservation**: Segment texts retain raw recognition output; timings are unchanged
- **No runtime settings**: Threshold fixed at 6 repetitions; no user-configurable options
- **Future**: Optional LLM-based filler-word removal planned for Wave 2.1 in same module
- **Testing gate**: CJK testing gate applied; fixtures Latin-only per spec

<!-- end of auto-generated comment: release notes by coderabbit.ai -->