### PR TITLE
feat(tts): unlimited-length generation — sentence-boundary chunking + crossfade (Wave 1.2)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -127,6 +127,7 @@ def _run_inference(
     num_step, guidance_scale, speed, t_shift, denoise,
     postprocess_output, layer_penalty_factor, position_temperature,
     class_temperature, used_seed, effect_preset="broadcast",
+    max_chunk_chars=None, crossfade_ms=None,
 ):
     import torch
     try:
@@ -161,14 +162,41 @@ def _run_inference(
                 )[0]
             audio_out = _render_with_pauses(_gen_span, segments, sr)
         else:
-            audios = model.generate(
-                text=text, language=language, ref_audio=ref_audio_path,
-                ref_text=ref_text, instruct=instruct, duration=duration,
-                num_step=num_step, guidance_scale=guidance_scale, speed=speed,
-                denoise=denoise, postprocess_output=postprocess_output,
-                **kwargs
+            # Wave 1.2: long text is split at sentence boundaries and the
+            # per-chunk audio crossfaded — removes the length ceiling. Short
+            # text takes the single-shot path below unchanged. [pause] inputs
+            # keep the dedicated stitcher above (spans are already short).
+            from services.chunked_tts import (
+                DEFAULT_CROSSFADE_MS, DEFAULT_MAX_CHUNK_CHARS,
+                concatenate_audio_chunks, split_text_into_chunks,
             )
-            audio_out = audios[0]
+            _max_chars = DEFAULT_MAX_CHUNK_CHARS if max_chunk_chars is None else max_chunk_chars
+            _xfade_ms = DEFAULT_CROSSFADE_MS if crossfade_ms is None else crossfade_ms
+            text_chunks = split_text_into_chunks(text, _max_chars)
+            if len(text_chunks) > 1:
+                parts = []
+                for i, chunk_text in enumerate(text_chunks):
+                    # Vary the seed per chunk (deterministically) to avoid
+                    # correlated RNG artifacts across chunk boundaries.
+                    if used_seed is not None:
+                        torch.manual_seed(used_seed + i)
+                    parts.append(model.generate(
+                        text=chunk_text, language=language, ref_audio=ref_audio_path,
+                        ref_text=ref_text, instruct=instruct, duration=None,
+                        num_step=num_step, guidance_scale=guidance_scale, speed=speed,
+                        denoise=denoise, postprocess_output=postprocess_output,
+                        **kwargs
+                    )[0])
+                audio_out = concatenate_audio_chunks(parts, sr, _xfade_ms)
+            else:
+                audios = model.generate(
+                    text=text, language=language, ref_audio=ref_audio_path,
+                    ref_text=ref_text, instruct=instruct, duration=duration,
+                    num_step=num_step, guidance_scale=guidance_scale, speed=speed,
+                    denoise=denoise, postprocess_output=postprocess_output,
+                    **kwargs
+                )
+                audio_out = audios[0]
 
         # Apply DSP effect preset. The OmniVoice model never masters its own
         # output, so mastering always runs here (unchanged behavior).
@@ -185,6 +213,7 @@ def _run_backend_inference(
     backend, text, language, ref_audio_path, ref_text, instruct, duration,
     num_step, guidance_scale, speed, denoise, postprocess_output,
     used_seed, effect_preset="broadcast",
+    max_chunk_chars=None, crossfade_ms=None,
 ):
     """Engine-aware twin of :func:`_run_inference` (issue #312).
 
@@ -222,7 +251,24 @@ def _run_backend_inference(
                 return backend.generate(span_text, duration=None, **gen_kwargs)
             audio_out = _render_with_pauses(_gen_span, segments, sr)
         else:
-            audio_out = backend.generate(text, duration=duration, **gen_kwargs)
+            # Wave 1.2: sentence-boundary chunking for long text (see
+            # _run_inference for the rationale; behavior is identical here).
+            from services.chunked_tts import (
+                DEFAULT_CROSSFADE_MS, DEFAULT_MAX_CHUNK_CHARS,
+                concatenate_audio_chunks, split_text_into_chunks,
+            )
+            _max_chars = DEFAULT_MAX_CHUNK_CHARS if max_chunk_chars is None else max_chunk_chars
+            _xfade_ms = DEFAULT_CROSSFADE_MS if crossfade_ms is None else crossfade_ms
+            text_chunks = split_text_into_chunks(text, _max_chars)
+            if len(text_chunks) > 1:
+                parts = []
+                for i, chunk_text in enumerate(text_chunks):
+                    if used_seed is not None:
+                        torch.manual_seed(used_seed + i)
+                    parts.append(backend.generate(chunk_text, duration=None, **gen_kwargs))
+                audio_out = concatenate_audio_chunks(parts, sr, _xfade_ms)
+            else:
+                audio_out = backend.generate(text, duration=duration, **gen_kwargs)
 
         return _apply_effect_chain(
             audio_out, sr, effect_preset,
@@ -257,6 +303,10 @@ async def generate_speech(
     seed: Optional[int] = Form(None),
     effect_preset: str = Form("broadcast"),
     engine: Optional[str] = Form(None),
+    # Wave 1.2 — unlimited-length generation: long text is split at sentence
+    # boundaries and crossfaded. 0 disables chunking (whole text to engine).
+    max_chunk_chars: int = Form(800, ge=0),
+    crossfade_ms: int = Form(50, ge=0, le=1000),
 ):
     # ── Engine resolution (issue #312) ──────────────────────────────────────
     # The request runs on the engine selected in Settings (POST /engines/select,
@@ -364,6 +414,7 @@ async def generate_speech(
                 _backend, text, language, ref_audio_path, ref_text, instruct,
                 duration, num_step, guidance_scale, speed, denoise,
                 postprocess_output, used_seed, effect_preset,
+                max_chunk_chars, crossfade_ms,
             )
             # Read after generation: engines with lazy model loading report
             # their real rate only once weights are up.
@@ -375,6 +426,7 @@ async def generate_speech(
                 num_step, guidance_scale, speed, t_shift, denoise,
                 postprocess_output, layer_penalty_factor, position_temperature,
                 class_temperature, used_seed, effect_preset,
+                max_chunk_chars, crossfade_ms,
             )
             sample_rate = _model.sampling_rate
         # Invisible AudioSeal provenance watermark on the final audio. Embedding

--- a/backend/services/chunked_tts.py
+++ b/backend/services/chunked_tts.py
@@ -1,0 +1,174 @@
+"""Chunked TTS generation utilities (Wave 1.2 — unlimited-length generation).
+
+Adapted from voicebox (https://github.com/jamiepine/voicebox), MIT License,
+Copyright (c) voicebox contributors. The concatenation half is reworked for
+torch tensors (our inference helpers pass raw model output — possibly
+multi-channel — to the effect chain), and the sample rate comes from the
+engine's declared rate rather than the first chunk (fixes a latent upstream
+bug where a mid-run rate change was silently ignored).
+
+Splits long text into sentence-boundary chunks and joins the per-chunk audio
+with a short crossfade. Pure functions — the generation loop itself lives in
+``api/routers/generation.py`` next to the existing ``[pause]`` span stitcher,
+so this module stays unit-testable without a model.
+
+Short text (<= max_chunk_chars) never reaches this module's concat path; the
+callers keep their unchanged single-shot fast path.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import List
+
+logger = logging.getLogger("omnivoice.chunked_tts")
+
+# Default chunk size in characters. 0 disables chunking entirely.
+DEFAULT_MAX_CHUNK_CHARS = 800
+
+# Default crossfade between chunks. 0 = hard cut.
+DEFAULT_CROSSFADE_MS = 50
+
+# Common abbreviations that should NOT be treated as sentence endings.
+# Lowercase for case-insensitive matching.
+_ABBREVIATIONS = frozenset({
+    "mr", "mrs", "ms", "dr", "prof", "sr", "jr", "st", "ave", "blvd",
+    "inc", "ltd", "corp", "dept", "est", "approx", "vs", "etc",
+    "e.g", "i.e", "a.m", "p.m", "u.s", "u.s.a", "u.k",
+})
+
+# Inline bracket tags (paralinguistic tags like [laugh]; our own
+# [pause 300ms] markers). The splitter must never cut inside one.
+_BRACKET_TAG_RE = re.compile(r"\[[^\]]*\]")
+
+
+def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) -> List[str]:
+    """Split *text* at natural boundaries into chunks of at most *max_chars*.
+
+    Priority: sentence-end (``.!?`` not after an abbreviation/decimal and not
+    inside brackets, plus fullwidth equivalents) -> clause boundary
+    (``;:,`` / em dash) -> whitespace -> hard cut that avoids splitting a
+    ``[tag]``.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    if max_chars <= 0 or len(text) <= max_chars:
+        return [text]
+
+    chunks: List[str] = []
+    remaining = text
+
+    while remaining:
+        remaining = remaining.lstrip()
+        if not remaining:
+            break
+        if len(remaining) <= max_chars:
+            chunks.append(remaining)
+            break
+
+        segment = remaining[:max_chars]
+
+        split_pos = _find_last_sentence_end(segment)
+        if split_pos == -1:
+            split_pos = _find_last_clause_boundary(segment)
+        if split_pos == -1:
+            split_pos = segment.rfind(" ")
+        if split_pos == -1:
+            split_pos = _safe_hard_cut(segment, max_chars)
+
+        chunk = remaining[: split_pos + 1].strip()
+        if chunk:
+            chunks.append(chunk)
+        remaining = remaining[split_pos + 1:]
+
+    return chunks
+
+
+def _find_last_sentence_end(text: str) -> int:
+    """Index of the last sentence-ending punctuation, or -1.
+
+    Skips periods after common abbreviations and decimals, anything inside
+    a bracket tag, and also recognizes fullwidth sentence punctuation
+    (ideographic full stop / fullwidth ! and ?) for no-space scripts.
+    """
+    best = -1
+    for m in re.finditer(r"[.!?](?:\s|$)", text):
+        pos = m.start()
+        if text[pos] == ".":
+            word_start = pos - 1
+            while word_start >= 0 and text[word_start].isalpha():
+                word_start -= 1
+            word = text[word_start + 1: pos].lower()
+            if word in _ABBREVIATIONS:
+                continue
+            if word_start >= 0 and text[word_start].isdigit():
+                continue
+        if _inside_bracket_tag(text, pos):
+            continue
+        best = pos
+    # Fullwidth sentence enders (ideographic full stop, fullwidth !, ?)
+    # written as escapes to keep the repo's no-literal-CJK gate clean.
+    for m in re.finditer("[\u3002\uff01\uff1f]", text):
+        if m.start() > best:
+            best = m.start()
+    return best
+
+
+def _find_last_clause_boundary(text: str) -> int:
+    best = -1
+    for m in re.finditer(r"[;:,—](?:\s|$)", text):
+        if _inside_bracket_tag(text, m.start()):
+            continue
+        best = m.start()
+    return best
+
+
+def _inside_bracket_tag(text: str, pos: int) -> bool:
+    for m in _BRACKET_TAG_RE.finditer(text):
+        if m.start() < pos < m.end():
+            return True
+    return False
+
+
+def _safe_hard_cut(segment: str, max_chars: int) -> int:
+    cut = max_chars - 1
+    for m in _BRACKET_TAG_RE.finditer(segment):
+        if m.start() < cut < m.end():
+            return m.start() - 1 if m.start() > 0 else cut
+    return cut
+
+
+def concatenate_audio_chunks(chunks: list, sample_rate: int,
+                             crossfade_ms: int = DEFAULT_CROSSFADE_MS):
+    """Join per-chunk waveforms with a linear crossfade on the sample axis.
+
+    ``chunks`` are torch tensors as returned by the engine (1-D, or N-D with
+    samples on the last axis — matching what ``_render_with_pauses`` handles).
+    Crossfade overlap is clamped to the shorter neighbor; ``crossfade_ms=0``
+    is a hard concat.
+    """
+    import torch
+
+    chunks = [c for c in chunks if c is not None and c.shape[-1] > 0]
+    if not chunks:
+        return torch.zeros(1, dtype=torch.float32)
+    if len(chunks) == 1:
+        return chunks[0]
+
+    crossfade_samples = int(sample_rate * crossfade_ms / 1000)
+    result = chunks[0]
+
+    for chunk in chunks[1:]:
+        chunk = chunk.to(device=result.device, dtype=result.dtype)
+        overlap = min(crossfade_samples, result.shape[-1], chunk.shape[-1])
+        if overlap > 0:
+            fade_out = torch.linspace(1.0, 0.0, overlap, dtype=result.dtype, device=result.device)
+            fade_in = torch.linspace(0.0, 1.0, overlap, dtype=result.dtype, device=result.device)
+            blended = result[..., -overlap:] * fade_out + chunk[..., :overlap] * fade_in
+            result = torch.cat([result[..., :-overlap], blended, chunk[..., overlap:]], dim=-1)
+        else:
+            result = torch.cat([result, chunk], dim=-1)
+
+    return result

--- a/tests/test_chunked_tts.py
+++ b/tests/test_chunked_tts.py
@@ -1,0 +1,215 @@
+"""Wave 1.2 — chunked long-form TTS (unlimited-length generation).
+
+Unit tests for the splitter/concat (no model) + endpoint tests proving
+/generate chunks long text per-sentence through the engine adapter and
+keeps the single-shot path for short text. Engine stubbing mirrors
+tests/test_generate_engine.py.
+"""
+import os
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import importlib
+
+import pytest
+import torch
+
+from services.chunked_tts import (
+    concatenate_audio_chunks,
+    split_text_into_chunks,
+)
+
+
+# ── Splitter ────────────────────────────────────────────────────────────────
+
+def test_short_text_is_single_chunk():
+    assert split_text_into_chunks("Hello world.", 800) == ["Hello world."]
+
+
+def test_long_text_splits_at_sentence_boundaries():
+    text = "First sentence here. " * 60  # ~1260 chars
+    chunks = split_text_into_chunks(text.strip(), 800)
+    assert len(chunks) > 1
+    assert all(len(c) <= 800 for c in chunks)
+    # Every chunk ends on the sentence boundary, not mid-word.
+    assert all(c.endswith(".") for c in chunks)
+
+
+def test_abbreviations_do_not_split():
+    # Real sentence ends are present, so the splitter must choose those —
+    # never the period of an abbreviation (which it should skip entirely).
+    text = ("Dr. Smith met Mr. Jones at the old lab. They talked there all day. " * 20).strip()
+    chunks = split_text_into_chunks(text, 200)
+    assert len(chunks) > 1
+    for c in chunks:
+        assert c.endswith(("lab.", "day.")), f"chunk ended off-sentence: {c[-12:]!r}"
+
+
+def test_decimals_do_not_split():
+    text = ("The value rose to 3.14159 which pleased everyone greatly today " * 16).strip()
+    for c in split_text_into_chunks(text, 150):
+        assert not c.endswith("3."), "split inside a decimal"
+
+
+def test_bracket_tags_are_atomic():
+    text = ("She paused [laugh] and went on speaking calmly " * 30).strip()
+    for c in split_text_into_chunks(text, 120):
+        assert c.count("[") == c.count("]"), f"tag split across chunks: {c!r}"
+
+
+def test_clause_fallback_when_no_sentence_end():
+    text = ("alpha beta gamma, delta epsilon zeta, " * 40).strip()
+    chunks = split_text_into_chunks(text, 200)
+    assert len(chunks) > 1
+    assert all(len(c) <= 200 for c in chunks)
+
+
+def test_hard_cut_when_no_boundaries():
+    text = "x" * 2000
+    chunks = split_text_into_chunks(text, 800)
+    assert len(chunks) == 3
+    assert "".join(chunks) == text
+
+
+def test_zero_max_chars_disables_chunking():
+    text = "word " * 500
+    assert split_text_into_chunks(text.strip(), 0) == [text.strip()]
+
+
+def test_empty_text():
+    assert split_text_into_chunks("   ", 800) == []
+
+
+# ── Concat ──────────────────────────────────────────────────────────────────
+
+def test_crossfade_length_math():
+    sr = 24000
+    a = torch.ones(sr)            # 1 s
+    b = torch.ones(sr)            # 1 s
+    out = concatenate_audio_chunks([a, b], sr, crossfade_ms=50)
+    overlap = int(sr * 50 / 1000)
+    assert out.shape[-1] == 2 * sr - overlap
+
+
+def test_hard_cut_concat():
+    sr = 24000
+    a, b = torch.ones(100), torch.ones(200)
+    out = concatenate_audio_chunks([a, b], sr, crossfade_ms=0)
+    assert out.shape[-1] == 300
+
+
+def test_crossfade_is_smooth_at_seam():
+    sr = 1000
+    a = torch.ones(500)
+    b = torch.zeros(500)
+    out = concatenate_audio_chunks([a, b], sr, crossfade_ms=100)  # 100 samples
+    seam = out[400:500]
+    # Linear blend from 1.0 toward 0.0 across the overlap — monotone, no step.
+    assert seam[0] == pytest.approx(1.0, abs=1e-5)
+    assert seam[-1] == pytest.approx(0.0, abs=1e-2)
+    assert torch.all(seam[:-1] >= seam[1:] - 1e-6)
+
+
+def test_multichannel_chunks_concat_on_last_axis():
+    sr = 24000
+    a, b = torch.ones(2, 1000), torch.ones(2, 1000)
+    out = concatenate_audio_chunks([a, b], sr, crossfade_ms=10)
+    assert out.shape[0] == 2
+    assert out.shape[-1] == 2000 - int(sr * 10 / 1000)
+
+
+def test_overlap_clamped_to_short_chunk():
+    sr = 24000
+    a, b = torch.ones(10), torch.ones(5000)
+    out = concatenate_audio_chunks([a, b], sr, crossfade_ms=50)  # 1200 > len(a)
+    assert out.shape[-1] == 5000  # overlap clamped to 10
+
+
+def test_single_and_empty_chunk_lists():
+    sr = 24000
+    only = torch.ones(123)
+    assert concatenate_audio_chunks([only], sr).shape[-1] == 123
+    assert concatenate_audio_chunks([], sr).shape[-1] == 1  # silent guard
+
+
+# ── Endpoint integration (stubbed engine, pattern from test_generate_engine) ─
+
+def _tts_mod():
+    return importlib.import_module("services.tts_backend")
+
+
+def _make_fake_engine(engine_id="fake-chunk-engine"):
+    class _FakeEngine(_tts_mod().TTSBackend):
+        id = engine_id
+        display_name = "Fake Chunk Engine (test)"
+        calls: list = []
+
+        @property
+        def sample_rate(self) -> int:
+            return 24000
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return ["multi"]
+
+        @classmethod
+        def is_available(cls):
+            return True, "ready"
+
+        def generate(self, text, **kw) -> torch.Tensor:
+            type(self).calls.append((text, kw))
+            return torch.zeros(1, 4800)  # 200 ms per chunk
+
+    return _FakeEngine
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+def test_long_text_is_chunked_through_engine(client, monkeypatch):
+    fake = _make_fake_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-chunk-engine", fake)
+
+    long_text = ("This is a complete sentence for the chunker. " * 40).strip()  # ~1840 chars
+    res = client.post("/generate", data={
+        "text": long_text, "engine": "fake-chunk-engine", "seed": "7",
+    })
+
+    assert res.status_code == 200, res.text
+    assert len(fake.calls) >= 2, "long text should fan out into multiple engine calls"
+    rejoined = " ".join(t for t, _ in fake.calls)
+    assert rejoined.split() == long_text.split()  # no words lost or reordered
+    # Chunked calls must not carry the un-splittable overall duration.
+    assert all(kw.get("duration") is None for _, kw in fake.calls)
+
+
+def test_short_text_stays_single_shot(client, monkeypatch):
+    fake = _make_fake_engine("fake-single-engine")
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-single-engine", fake)
+
+    res = client.post("/generate", data={
+        "text": "Just one short line.", "engine": "fake-single-engine",
+    })
+
+    assert res.status_code == 200, res.text
+    assert len(fake.calls) == 1
+
+
+def test_chunking_disabled_with_zero(client, monkeypatch):
+    fake = _make_fake_engine("fake-nochunk-engine")
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-nochunk-engine", fake)
+
+    long_text = ("Another complete sentence goes here. " * 40).strip()
+    res = client.post("/generate", data={
+        "text": long_text, "engine": "fake-nochunk-engine", "max_chunk_chars": "0",
+    })
+
+    assert res.status_code == 200, res.text
+    assert len(fake.calls) == 1
+    assert fake.calls[0][0] == long_text


### PR DESCRIPTION
## What

Wave 1.2 of the [parity program](docs/specs/2026-06-12-elevenlabs-parity-program.md) — the **unlimited-length generation** item from discussion #346, ported from voicebox (MIT, attribution header) with two deliberate deltas:
- concat reworked for **torch tensors** (multi-channel safe, last-axis crossfade) to match what our inference helpers feed the effect chain
- sample rate from the engine's declared rate, not the first chunk (fixes a latent upstream bug)

**Behavior:** text > `max_chunk_chars` (default 800) splits at sentence boundaries — abbreviation/decimal-aware, `[tag]`s atomic, fullwidth sentence enders recognized (unicode escapes; CJK gate stays clean) — each chunk generates with deterministic per-chunk seed variation (`seed+i`), then a linear crossfade join (default 50 ms, `0` = hard cut). Effect chain + AudioSeal watermark run **once** on the joined audio. Both inference paths covered (OmniVoice-native + engine adapter), integrated beside the existing `[pause]` stitcher. Short text keeps the unchanged single-shot fast path; `max_chunk_chars=0` disables chunking.

**API:** two new optional `/generate` form params — `max_chunk_chars` (≥0, default 800), `crossfade_ms` (0–1000, default 50). Existing consumers see no change for typical inputs.

## Verification
- 15 model-free unit tests green locally (split priorities, abbreviation/decimal/tag guards, crossfade math incl. multichannel + overlap clamping, seam monotonicity)
- 3 stubbed-engine endpoint tests (long text fans out with **no words lost or reordered** + per-chunk `duration=None`; short text exactly one engine call; `max_chunk_chars=0` single-shot) — **validated in CI**: this dev machine has a pre-existing torch/Triton segfault on any `main`-importing test (main's own `test_generate_engine.py` crashes locally too; all green in CI)
- CJK gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Wave 1.2: Unlimited-Length TTS with Sentence-Boundary Chunking and Crossfade

This PR implements the second iteration of unlimited-length text-to-speech generation, enabling processing of arbitrarily long input by splitting text at intelligent sentence boundaries and seamlessly joining the resulting audio chunks with a linear crossfade effect.

## Mechanism

```mermaid
graph TD
    A["Input: text, max_chunk_chars, crossfade_ms"] --> B{Pause markers present?}
    B -->|Yes| C["Render per-span audio<br/>Stitch silence between"]
    B -->|No| D["split_text_into_chunks<br/>at sentence boundaries"]
    D --> E{Single chunk?}
    E -->|Yes| F["Direct generation<br/>Single-shot path"]
    E -->|No| G["Generate each chunk<br/>with seed+i variation"]
    G --> H["concatenate_audio_chunks<br/>with linear crossfade"]
    F --> I["Apply DSP effects & watermark<br/>Return audio stream"]
    C --> I
    H --> I
```

## Key Changes

**New Endpoint Parameters** (`POST /generate`)
- `max_chunk_chars`: Integer ≥0 (default 800) — maximum characters per chunk; 0 disables chunking
- `crossfade_ms`: Integer 0–1000 (default 50) — linear crossfade duration in milliseconds between chunks

**New Module** (`backend/services/chunked_tts.py`)
- `split_text_into_chunks(text, max_chars)` — Intelligently splits long text with:
  - Sentence-ending punctuation awareness (`.!?` + fullwidth CJK equivalents)
  - Abbreviation protection (e.g., "Dr.", "U.S.A.")
  - Decimal number handling (e.g., "3.14")
  - Bracket-tag atomicity (preserves inline tags like `[pause 300ms]`)
  - Fallback to clause boundaries (`;:,—`) and whitespace when no sentence end found
  
- `concatenate_audio_chunks(chunks, sample_rate, crossfade_ms)` — Joins audio tensors with:
  - Linear overlap crossfade on the last (sample) axis
  - Multi-channel support (operates on final dimension)
  - Hard concatenation when `crossfade_ms=0`
  - Overlap clamping per adjacent chunk lengths

**Updated Inference Paths**
- Both `_run_inference` (OmniVoice-native) and `_run_backend_inference` (engine adapter) now:
  - Accept `max_chunk_chars` and `crossfade_ms` parameters
  - Skip chunking if pause markers are detected (existing behavior preserved)
  - Use deterministic per-chunk seeding (`used_seed + chunk_index`)
  - Fall back to single-shot generation for short text or when chunking is disabled

## Backwards Compatibility

- Existing consumers see no change for typical inputs (max_chunk_chars default of 800 is permissive)
- Pause-marker behavior unchanged
- DSP effects and watermarking applied once to final joined audio
- Streaming response structure preserved

## Test Coverage

- **18 unit and integration tests** validating:
  - Short/long text handling and sentence boundary detection
  - Abbreviation/decimal/CJK/bracket-tag edge cases
  - Crossfade math, monotonicity, and multi-channel correctness
  - Hard-cut concatenation and overlap clamping
  - Endpoint behavior with stubbed engine (long text → multiple calls; short text → single call)
  - Chunking disabled when `max_chunk_chars=0`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->