### PR TITLE
feat(stream): sentence-by-sentence /ws/tts via ported chunker (Wave 1.4)

### DIFF
--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -144,13 +144,26 @@ async def ws_tts(websocket: WebSocket):
                     except Exception:
                         kw["voice"] = voice
 
+                # Wave 1.4: split the request into sentences so the first
+                # sentence's audio streams while later sentences are still
+                # synthesizing — this is the time-to-first-audio win. The
+                # chunker handles abbreviations/acronyms/decimals and CJK /
+                # non-Latin terminators; single-sentence requests behave
+                # exactly like the old single-shot path.
+                from services.sentence_chunker import SentenceChunker
+                _chunker = SentenceChunker(language=(data.get("language") or "en"))
+                sentences = _chunker.push(text)
+                sentences.extend(_chunker.flush())
+                if not sentences:
+                    sentences = [text]
+
                 # Run generation in the GPU pool
                 from services.model_manager import _gpu_pool
                 loop = asyncio.get_running_loop()
 
-                def _generate():
+                def _generate(sentence_text):
                     from services.audio_dsp import apply_mastering, normalize_audio
-                    wav = backend.generate(text, **kw)
+                    wav = backend.generate(sentence_text, **kw)
                     sr_actual = backend.sample_rate
                     # Like _run_tts in openai_compat: studio engines (VoxCPM2)
                     # opt out of the broadcast mastering chain. This is the
@@ -161,38 +174,45 @@ async def ws_tts(websocket: WebSocket):
                     wav = normalize_audio(wav, target_dBFS=-2.0)
                     return wav, sr_actual
 
-                wav_tensor, sr = await loop.run_in_executor(_gpu_pool, _generate)
-
-                # Send metadata after generation so sample_rate is real
-                await websocket.send_json({
-                    "type": "start",
-                    "sample_rate": sr,
-                    "channels": 1,
-                    "format": "pcm16",
-                    "engine": backend.id,
-                })
-
-                # Stream PCM16 chunks over the WebSocket
                 import torch
-                # Convert to 16-bit PCM
-                pcm = (wav_tensor * 32767).clamp(-32768, 32767).to(torch.int16)
-                if pcm.ndim == 2:
-                    pcm = pcm[0]  # mono
-                pcm_bytes = pcm.numpy().tobytes()
+                total_samples = 0
+                sr = backend.sample_rate
+                started = False
 
-                total_samples = len(pcm)
-                sent_samples = 0
-                chunk_bytes = CHUNK_SAMPLES * 2  # 2 bytes per int16 sample
+                for sentence in sentences:
+                    wav_tensor, sr = await loop.run_in_executor(
+                        _gpu_pool, _generate, sentence
+                    )
 
-                while sent_samples < total_samples:
-                    end = min(sent_samples + CHUNK_SAMPLES, total_samples)
-                    start_byte = sent_samples * 2
-                    end_byte = end * 2
-                    chunk = pcm_bytes[start_byte:end_byte]
-                    await websocket.send_bytes(chunk)
-                    sent_samples = end
-                    # Yield to event loop between chunks for responsiveness
-                    await asyncio.sleep(0)
+                    if not started:
+                        # Send metadata after the first generation so
+                        # sample_rate is real (lazy-loading engines report
+                        # their true rate only once weights are up).
+                        await websocket.send_json({
+                            "type": "start",
+                            "sample_rate": sr,
+                            "channels": 1,
+                            "format": "pcm16",
+                            "engine": backend.id,
+                        })
+                        started = True
+
+                    # Convert to 16-bit PCM and stream
+                    pcm = (wav_tensor * 32767).clamp(-32768, 32767).to(torch.int16)
+                    if pcm.ndim == 2:
+                        pcm = pcm[0]  # mono
+                    pcm_bytes = pcm.numpy().tobytes()
+
+                    n_samples = len(pcm)
+                    sent_samples = 0
+                    while sent_samples < n_samples:
+                        end = min(sent_samples + CHUNK_SAMPLES, n_samples)
+                        chunk = pcm_bytes[sent_samples * 2: end * 2]
+                        await websocket.send_bytes(chunk)
+                        sent_samples = end
+                        # Yield to event loop between chunks for responsiveness
+                        await asyncio.sleep(0)
+                    total_samples += n_samples
 
                 gen_time = round(time.perf_counter() - t0, 3)
                 duration = round(total_samples / sr, 3)

--- a/backend/services/sentence_chunker.py
+++ b/backend/services/sentence_chunker.py
@@ -1,0 +1,571 @@
+"""Sentence chunker for streaming TTS (Wave 1.4 — /ws/tts polish).
+
+Adapted from Patter (https://github.com/PatterAI/Patter), MIT License,
+Copyright (c) 2026 Patter Contributors. Ported behavior-identical (the
+golden parity scenarios ship as fixtures in tests/test_sentence_chunker.py);
+only this header differs.
+
+Accumulates streaming text (LLM tokens or a whole request) and yields
+complete sentences. Regex-based marker replacement handles abbreviations,
+acronyms, decimals, websites, ellipsis, and CJK/non-Latin punctuation —
+the terminator tables below contain functional CJK and are allowlisted in
+tests/test_no_hardcoded_cjk.py. Used by api/routers/tts_stream.py to
+synthesize sentence-by-sentence for low time-to-first-audio.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Default minimum sentence length before emitting.
+# Fragments shorter than this are merged with the next sentence.
+DEFAULT_MIN_SENTENCE_LEN = 20
+
+# Minimum word count for emitting a "short" sentence (one whose total length
+# is below ``min_sentence_len``) as soon as a terminator is seen. Default is
+# 1: a single-word reply ("Yes.", "Done.") flushes immediately on the
+# terminator so TTS can speak it without waiting for ``flush()``. Acronym
+# and decimal guards in ``_maybe_short_flush`` still block dangerous cases
+# ("U.S.", "f(x) = 2."). Bumping this to 2+ keeps single-word utterances
+# buffered until ``flush()`` is called by the caller.
+DEFAULT_MIN_WORDS_FOR_SHORT_FLUSH = 1
+
+# ---------------------------------------------------------------------------
+# Per-language honorific / abbreviation prefixes.
+#
+# Each entry is the ALPHA prefix (no trailing period) — the regex framework
+# in ``_split_sentences`` appends the ``[.]`` itself. We merge all language
+# lists into a single regex alternation so the chunker handles mixed-language
+# text correctly out of the box (this is the behaviour shipped since the
+# SDK introduced sentence chunking; per-language constants are an
+# organisational refactor that also lets callers verify per-language
+# coverage in tests).
+#
+# Single-letter honorifics (French "M.", "A.") are deliberately omitted —
+# they are handled by the existing ``\\s + alphabets + [.] `` rule which
+# preserves any single-letter-period sequence.
+# ---------------------------------------------------------------------------
+
+# English (NLTK Punkt training set + common military/civic).
+HONORIFICS_EN = (
+    "Mr",
+    "St",
+    "Mrs",
+    "Ms",
+    "Dr",
+    "Prof",
+    "Gen",
+    "Sen",
+    "Rep",
+    "Lt",
+    "Cpt",
+    "Capt",
+    "Col",
+    "Cmdr",
+    "Adm",
+)
+
+# Italian. Compound abbreviations like "Sig.ra" / "Dott.ssa" / "Prof.ssa"
+# are handled implicitly: the prefix regex matches the leading word
+# ("Sig", "Dott", "Prof") and the trailing letters after the period are
+# preserved as part of the same token by the marker-replacement pass.
+HONORIFICS_IT = (
+    "Sig",
+    "Sgr",
+    "Dott",
+    "Prof",
+    "Avv",
+    "Ing",
+    "Geom",
+    "Rag",
+    "Arch",
+    "On",
+    "Egr",
+    "Spett",
+    "Gent",
+    "Ill",
+)
+
+# Spanish.
+HONORIFICS_ES = (
+    "Sr",
+    "Sra",
+    "Sres",
+    "Sras",
+    "Srta",
+    "Srtas",
+    "Dr",
+    "Dra",
+    "Dres",
+    "Lic",
+    "Licda",
+    "Ing",
+    "Prof",
+    "Profa",
+    "Arq",
+    "Mtro",
+    "Mtra",
+)
+
+# German.
+HONORIFICS_DE = (
+    "Hr",
+    "Fr",
+    "Frl",
+    "Dr",
+    "Prof",
+    "Dipl",
+    "Mag",
+)
+
+# French.
+HONORIFICS_FR = (
+    "Mme",
+    "Mmes",
+    "Mlle",
+    "Mlles",
+    "MM",
+    "Dr",
+    "Pr",
+    "Mgr",
+    "Me",
+)
+
+# Portuguese (European + Brazilian).
+HONORIFICS_PT = (
+    "Sr",
+    "Sra",
+    "Srs",
+    "Sras",
+    "Srta",
+    "Srtas",
+    "Dr",
+    "Dra",
+    "Eng",
+    "Enga",
+    "Prof",
+    "Profa",
+)
+
+# Mapping for callers who want to know which language ships which list.
+HONORIFICS_BY_LANGUAGE: dict[str, tuple[str, ...]] = {
+    "en": HONORIFICS_EN,
+    "it": HONORIFICS_IT,
+    "es": HONORIFICS_ES,
+    "de": HONORIFICS_DE,
+    "fr": HONORIFICS_FR,
+    "pt": HONORIFICS_PT,
+}
+
+# Union of every language list, sorted longest-first so regex alternation
+# prefers the most specific match (e.g. "Sras" before "Sr").
+HONORIFICS_ALL: tuple[str, ...] = tuple(
+    sorted(
+        {p for prefixes in HONORIFICS_BY_LANGUAGE.values() for p in prefixes},
+        key=lambda s: (-len(s), s),
+    )
+)
+
+# Sentence-terminating characters. Includes Latin (`. ! ?`), full-width CJK
+# (`。 ！ ？`), Japanese half-width (`｡`), full-width semicolon (`；`), full-
+# width period (`．`), and Western ellipsis (`…`). Covers the most common
+# multilingual response shapes.
+_SENTENCE_TERMINATORS = ".!?…;。！？；．｡"
+
+# Unambiguous non-Latin sentence terminators — punctuation that cannot also
+# appear in numbers, abbreviations, or URLs in the script's typical usage,
+# so a buffer ending in one of these can be flushed without a regex pass.
+# Covers Hindi/Devanagari (। ॥), Arabic (؟ ؛ ۔ ؏), Armenian (։ ՜ ՞),
+# Ethiopic (። ፧), Khmer (។ ៕), Burmese (။), Tibetan (༎ ༏), Thai (no
+# terminator — relies on whitespace), and the Japanese half-width set we
+# already have.
+_UNAMBIGUOUS_NON_LATIN_TERMINATORS = "।॥؟؛۔؏։፧።។៕။༎༏"
+
+# Pre-built regex character class covering both Latin/CJK and the
+# non-Latin terminators above. Used by `_split_sentences` to mark `<stop>`.
+_TERMINATOR_REGEX_CLASS = "".join(
+    re.escape(c)
+    for c in sorted(set(_SENTENCE_TERMINATORS + _UNAMBIGUOUS_NON_LATIN_TERMINATORS))
+)
+
+# "Soft" punctuation marks that terminate a clause but not a full sentence.
+# These are candidates for the optional aggressive first-clause flush only.
+# Includes em-dash (U+2014) and en-dash (U+2013); excludes ":" (often used
+# as "Name: …" in LLM output) and ";" (rare in conversational speech).
+_SOFT_TERMINATORS = ",—–"
+
+# Default minimum buffer length before the aggressive first-clause flush is
+# allowed to fire. Below ~40 chars TTS prosody suffers; ElevenLabs internally
+# buffers up to 120 chars by default (``chunk_length_schedule``), so very
+# short fragments are merged regardless of what we send.
+DEFAULT_AGGRESSIVE_FIRST_MIN_LEN = 40
+
+# Currency symbols that, when present near a comma, indicate the comma is a
+# decimal/thousands separator and must not be treated as a clause boundary.
+_CURRENCY_SYMBOLS = "$€£¥₹₩"
+
+# Pre-built regex alternation for honorific prefixes (longest-first so that
+# "Sras" matches before "Sra"). Kept at module scope so we build it once
+# rather than every call to ``_split_sentences``.
+_HONORIFICS_REGEX = "|".join(re.escape(p) for p in HONORIFICS_ALL)
+
+
+def _split_sentences(
+    text: str,
+    *,
+    min_sentence_len: int = DEFAULT_MIN_SENTENCE_LEN,
+) -> list[tuple[str, int, int]]:
+    """Split text into sentences using regex marker replacement.
+
+    Returns a list of (sentence, start_pos, end_pos) tuples.
+    The text must not contain literal ``<prd>`` or ``<stop>`` substrings.
+    """
+    alphabets = r"([A-Za-z])"
+    # Title/honorific prefixes that take a trailing period. Sourced from the
+    # union of every language list in ``HONORIFICS_BY_LANGUAGE`` (en / it /
+    # es / de / fr / pt). The period after these is preserved (treated as
+    # part of the word, not as sentence end).
+    prefixes = rf"({_HONORIFICS_REGEX})[.]"
+    # Suffix-style abbreviations: typically lowercase Italian ones (ecc, art,
+    # pag, …) plus the existing English company-suffix list. English additions
+    # from the NLTK Punkt training set: vs, etc, e.g., i.e., No, Vol, pp, cf, ca, op.
+    suffixes = (
+        r"(Inc|Ltd|Jr|Sr|Co|ecc|cit|cap|sez|art|pag|fig|tab|cfr|vol|ed|"
+        r"vs|etc|No|Vol|pp|cf|ca|op|Mt|Hwy|Rt|Pl|Ave|Blvd|Sq)"
+    )
+    starters = (
+        r"(Mr|Mrs|Ms|Dr|Prof|Capt|Cpt|Lt|He\s|She\s|It\s|They\s|Their\s|"
+        r"Our\s|We\s|But\s|However\s|That\s|This\s|Wherever)"
+    )
+    acronyms = r"([A-Z][.][A-Z][.](?:[A-Z][.])?)"
+    websites = r"[.](com|net|org|io|gov|edu|me)"
+    digits = r"([0-9])"
+    multiple_dots = r"\.{2,}"
+
+    text = text.replace("\n", " ")
+
+    text = re.sub(prefixes, r"\1<prd>", text)
+    text = re.sub(websites, r"<prd>\1", text)
+    text = re.sub(digits + r"[.]" + digits, r"\1<prd>\2", text)
+    text = re.sub(multiple_dots, lambda m: "<prd>" * len(m.group(0)), text)
+
+    if "Ph.D" in text:
+        text = text.replace("Ph.D.", "Ph<prd>D<prd>")
+
+    text = re.sub(r"\s" + alphabets + r"[.] ", r" \1<prd> ", text)
+    text = re.sub(acronyms + r" " + starters, r"\1<stop> \2", text)
+    text = re.sub(
+        alphabets + r"[.]" + alphabets + r"[.]" + alphabets + r"[.]",
+        r"\1<prd>\2<prd>\3<prd>",
+        text,
+    )
+    text = re.sub(alphabets + r"[.]" + alphabets + r"[.]", r"\1<prd>\2<prd>", text)
+    # Preserve the period of the suffix abbreviation when it precedes a starter,
+    # e.g. "Patter Inc. He left" → keep "Inc." in the emitted sentence.
+    text = re.sub(r" " + suffixes + r"[.] " + starters, r" \1.<stop> \2", text)
+    text = re.sub(r" " + suffixes + r"[.]", r" \1<prd>", text)
+    text = re.sub(r" " + alphabets + r"[.]", r" \1<prd>", text)
+
+    # Mark sentence-ending punctuation (Latin + CJK + non-Latin scripts).
+    text = re.sub(rf"([{_TERMINATOR_REGEX_CLASS}])([\"\u201d])", r"\1\2<stop>", text)
+    text = re.sub(rf"([{_TERMINATOR_REGEX_CLASS}])(?![\"\u201d])", r"\1<stop>", text)
+
+    # Restore periods
+    text = text.replace("<prd>", ".")
+
+    splitted = text.split("<stop>")
+    text = text.replace("<stop>", "")
+
+    sentences: list[tuple[str, int, int]] = []
+    buff = ""
+    start_pos = 0
+    end_pos = 0
+
+    for match in splitted:
+        sentence = match.strip()
+        if not sentence:
+            continue
+
+        buff += " " + sentence
+        end_pos += len(match)
+
+        if len(buff) > min_sentence_len:
+            sentences.append((buff.lstrip(), start_pos, end_pos))
+            start_pos = end_pos
+            buff = ""
+
+    if buff:
+        sentences.append((buff.lstrip(), start_pos, len(text) - 1))
+
+    return sentences
+
+
+class SentenceChunker:
+    """Accumulates streaming tokens and yields complete sentences.
+
+    Usage::
+
+        chunker = SentenceChunker()
+        for token in llm_stream:
+            for sentence in chunker.push(token):
+                await tts.synthesize(sentence)
+        for sentence in chunker.flush():
+            await tts.synthesize(sentence)
+    """
+
+    def __init__(
+        self,
+        *,
+        min_sentence_len: int = DEFAULT_MIN_SENTENCE_LEN,
+        min_words_for_short_flush: int = DEFAULT_MIN_WORDS_FOR_SHORT_FLUSH,
+        aggressive_first_flush: bool = False,
+        aggressive_first_min_len: int = DEFAULT_AGGRESSIVE_FIRST_MIN_LEN,
+        language: str = "en",
+    ) -> None:
+        self._buffer = ""
+        self._min_sentence_len = min_sentence_len
+        self._min_words_for_short_flush = min_words_for_short_flush
+        self._aggressive_first_min_len = aggressive_first_min_len
+        self._language = (language or "en").lower()
+        # Italian uses comma as decimal separator (3,14) and dot as thousands
+        # separator (1.000) — both invert the English convention. Aggressive
+        # comma-flush would split decimals, so we hard-disable it for Italian
+        # regardless of caller preference.
+        self._aggressive_first_flush = (
+            aggressive_first_flush and not self._language.startswith("it")
+        )
+        self._is_first_flush = True
+
+    def push(self, token: str) -> list[str]:
+        """Feed a token. Returns zero or more complete sentences.
+
+        Two emission paths:
+
+        * **Standard path** — when the buffer is at least ``min_sentence_len``
+          characters long and the regex tokenizer reports more than one
+          sentence, all but the last (potentially incomplete) sentence are
+          emitted.
+        * **Short-flush path** — when the buffer is shorter than
+          ``min_sentence_len`` but ends with a sentence terminator AND the
+          preceding text has at least ``min_words_for_short_flush`` words
+          (default 1 — single-word replies like ``"Yes."`` flush immediately
+          for low TTS TTFB). Acronym ("U.S.") and decimal ("f(x) = 2.")
+          guards still block dangerous cases. Bump
+          ``min_words_for_short_flush`` to 2+ if you want the legacy
+          behaviour where single-word utterances stay buffered until
+          ``flush()``.
+        """
+        self._buffer += token
+
+        # Aggressive first-clause flush: when enabled, emit the first clause
+        # of the response on a soft punctuation boundary (",", em/en-dash) as
+        # soon as enough characters accumulate. Saves 200-500 ms TTFA on the
+        # first sentence of each turn. Subsequent sentences fall through to
+        # the standard sentence-boundary path.
+        if self._aggressive_first_flush and self._is_first_flush:
+            flushed = self._maybe_aggressive_first_flush()
+            if flushed is not None:
+                self._is_first_flush = False
+                return [flushed]
+
+        if len(self._buffer) < self._min_sentence_len:
+            return self._maybe_short_flush()
+
+        sentences = _split_sentences(
+            self._buffer, min_sentence_len=self._min_sentence_len
+        )
+
+        if len(sentences) <= 1:
+            return []
+
+        # Emit all sentences except the last (which may be incomplete)
+        result: list[str] = []
+        for sent_text, _, _ in sentences[:-1]:
+            if sent_text.strip():
+                result.append(sent_text.strip())
+
+        # Keep the last (potentially incomplete) sentence in the buffer
+        last_text = sentences[-1][0] if sentences else ""
+        self._buffer = last_text
+
+        if result:
+            # A standard-path emission ends the "first flush" window too:
+            # only the aggressive flush cleared the flag, so a comma in
+            # sentence 2+ could still trigger a clause-level flush mid-turn
+            # — choppy prosody, contradicting the documented "first clause
+            # of each turn" contract.
+            self._is_first_flush = False
+
+        return result
+
+    def _maybe_short_flush(self) -> list[str]:
+        """Emit the buffer when it's a short, complete single-sentence utterance.
+
+        A buffer qualifies when **all** of these hold:
+
+        1. Last non-whitespace char is a sentence terminator.
+        2. Word count is at least ``min_words_for_short_flush`` (default 1 —
+           single-word replies like ``"Yes."`` flush immediately).
+        3. The buffer contains exactly one terminator (the trailing one).
+           Multiple terminators mean we may be mid-stream of a longer merged
+           utterance like ``"Hey! Hi! Hello! This is a sentence."`` — let
+           the standard path keep merging.
+        4. The char immediately before the terminator is **not** a digit
+           (avoids decimal mid-stream like ``"f(x) = x * 2."`` flushing
+           before the ``54`` arrives).
+        5. The trailing word is **not** a short ASCII all-caps acronym of
+           1-3 chars (``"U."`` / ``"U.S."`` / ``"USA."``) — those are
+           likely abbreviation periods, not sentence ends.
+        6. The trailing word is **not** a known honorific from any of the
+           per-language ``HONORIFICS_*`` constants (``"Mr."``, ``"Sr."``,
+           ``"Dr."``, ``"Hr."``, ``"Mme."``, ...) — those signal a name
+           continuation, not a sentence end.
+
+        Together these gates preserve the merging behaviour of the standard
+        path while letting genuine short greetings flush immediately for low
+        TTS TTFB.
+        """
+        stripped = self._buffer.rstrip()
+        if not stripped or stripped[-1] not in _SENTENCE_TERMINATORS:
+            return []
+
+        # Only one terminator in the entire buffer (the trailing one).
+        if sum(1 for c in stripped if c in _SENTENCE_TERMINATORS) != 1:
+            return []
+
+        # Word count: ``"Hi there!".split()`` -> 2.
+        word_count = len(stripped.split())
+        if word_count < self._min_words_for_short_flush:
+            return []
+
+        # Don't flush on potential decimals.
+        if len(stripped) >= 2:
+            prev = stripped[-2]
+            if prev.isdigit():
+                return []
+            # Don't flush on short all-caps acronyms ("U.", "US.", "USA.") —
+            # these are likely abbreviation periods, not sentence ends. Only
+            # block if the trailing word is **purely uppercase** AND **at most
+            # 3 chars** (matches U/US/USA/NATO patterns without dots; longer
+            # all-caps words like RAMESH or SPEAKING are real sentences and
+            # must still be allowed to flush).
+            terminator = stripped[-1]
+            last_word = (
+                stripped.rstrip(_SENTENCE_TERMINATORS).split()[-1]
+                if stripped.rstrip(_SENTENCE_TERMINATORS).split()
+                else ""
+            )
+            if (
+                terminator == "."
+                and last_word.isascii()
+                and last_word.isupper()
+                and len(last_word) <= 3
+            ):
+                return []
+            # Don't flush when the trailing token is a known honorific — the
+            # next token will be a name (e.g. "Mr. Theo" / "Sr. García" /
+            # "Hr. Müller"). Only applies to "." since "Hi!" / "Yes?" never
+            # name-continue.
+            if terminator == "." and last_word in HONORIFICS_ALL:
+                return []
+
+        self._buffer = ""
+        return [stripped]
+
+    def _maybe_aggressive_first_flush(self) -> str | None:
+        """Try to flush the first clause of the response on a soft punctuation
+        boundary (comma / em-dash / en-dash) to minimise TTFA.
+
+        Returns the flushed clause text (terminator stripped) or ``None`` if
+        no safe boundary is found. All of these guards must pass:
+
+        1. **Min length** — buffer ≥ ``aggressive_first_min_len`` (default 40).
+        2. **Trailing terminator** — last non-whitespace char in
+           ``_SOFT_TERMINATORS``.
+        3. **Decimal/thousands guard** — refuse if the comma is between two
+           digits (``3,14``) or surrounded by digit-thousands grouping.
+        4. **Currency guard** — refuse if a currency symbol appears in the
+           preceding 8 characters (``€1.000,50``).
+        5. **Balanced delimiter** — refuse if open parens/brackets/braces or
+           unmatched double-quotes still pending (avoids splitting JSON,
+           parenthetical asides, quoted speech).
+        6. **Ellipsis** — refuse if buffer ends with ``...`` or ``…`` (it's an
+           intentional pause, not a clause boundary).
+        7. **Sub-token ambiguity** — only fire when at least one trailing char
+           after the terminator has arrived OR the terminator is followed by
+           whitespace (avoids firing mid-token when next char might extend
+           the number/abbreviation).
+        """
+        rstripped = self._buffer.rstrip()
+        if len(rstripped) < self._aggressive_first_min_len:
+            return None
+
+        last_char = rstripped[-1]
+        if last_char not in _SOFT_TERMINATORS:
+            return None
+
+        pos = len(rstripped) - 1
+
+        # Sub-token ambiguity: require at least one char (whitespace or other)
+        # in the original buffer after the terminator. Without this we may
+        # fire mid-decimal before the next digit arrives.
+        if pos + 1 >= len(self._buffer):
+            return None
+        next_char = self._buffer[pos + 1]
+
+        # Decimal/thousands guard for comma: refuse if surrounded by digits.
+        if last_char == ",":
+            prev_char = rstripped[pos - 1] if pos >= 1 else ""
+            if prev_char.isdigit() and next_char.isdigit():
+                return None
+            # Also refuse for "1,000" thousands separator pattern: digit-comma-
+            # whitespace-or-end is OK only when not in a number context. Be
+            # conservative — if a digit immediately precedes the comma and the
+            # last 4 chars contain another comma in a digit context, skip.
+            tail = rstripped[max(0, pos - 6) : pos]
+            if prev_char.isdigit() and ("," in tail and any(c.isdigit() for c in tail)):
+                return None
+
+        # Currency guard: any currency symbol in the trailing 8 chars before
+        # the terminator suggests a number context.
+        snippet = rstripped[max(0, pos - 8) : pos]
+        if any(c in snippet for c in _CURRENCY_SYMBOLS):
+            return None
+
+        # Balanced delimiter guard.
+        opens = sum(rstripped.count(c) for c in "([{")
+        closes = sum(rstripped.count(c) for c in ")]}")
+        if opens > closes:
+            return None
+        # Odd number of double-quotes ⇒ inside a quoted span; don't split.
+        if rstripped.count('"') % 2 != 0:
+            return None
+
+        # Ellipsis guard.
+        if rstripped.endswith("...") or rstripped.endswith("…"):
+            return None
+
+        # Comma-before-quote guard (orphan fragment).
+        if last_char == "," and next_char == '"':
+            return None
+
+        # All guards passed. Emit the clause and trim the buffer.
+        flushed = rstripped
+        self._buffer = self._buffer[len(rstripped) :].lstrip()
+        return flushed
+
+    def flush(self) -> list[str]:
+        """Flush remaining buffer as final sentence(s). Call at end of stream."""
+        remaining = self._buffer.strip()
+        self._buffer = ""
+        self._is_first_flush = True
+
+        if not remaining:
+            return []
+
+        return [remaining]
+
+    def reset(self) -> None:
+        """Discard buffered text. Call on interrupt."""
+        self._buffer = ""
+        self._is_first_flush = True

--- a/tests/fixtures/sentence_chunker_scenarios.json
+++ b/tests/fixtures/sentence_chunker_scenarios.json
@@ -1,0 +1,389 @@
+{
+  "scenario_id": "sentence_chunker",
+  "description": "Verify Python and TypeScript SentenceChunker emit identical sentences for the same token stream. Each case feeds tokens one at a time, then calls flush(); the concatenation of push() results plus flush() must match expected_sentences exactly in both SDKs. A case may carry a current_behavior field documenting the actual output of the current implementation when it differs from the ideal expected_sentences — the runner accepts current_behavior with an xfail marker so the test does not block CI, and clears it when the regression is fixed. Cases marked regression: true are real bugs to fix; cases marked quirk: true are accepted by-design behavior (e.g., short sentences merged below min_sentence_len).",
+  "default_min_sentence_len": 20,
+  "default_min_words_for_short_flush": 2,
+  "cases": [
+    {
+      "name": "single_short_greeting_two_words",
+      "tokens": ["Hi there!"],
+      "expected_sentences": ["Hi there!"]
+    },
+    {
+      "name": "single_word_buffered_until_flush",
+      "tokens": ["Sì."],
+      "expected_sentences": ["Sì."]
+    },
+    {
+      "name": "two_sentences_period",
+      "tokens": ["This is the first sentence. This is the second sentence."],
+      "expected_sentences": ["This is the first sentence.", "This is the second sentence."]
+    },
+    {
+      "name": "two_sentences_streamed_token_by_token",
+      "tokens": ["This ", "is ", "the ", "first ", "sentence. ", "This ", "is ", "the ", "second ", "sentence."],
+      "expected_sentences": ["This is the first sentence.", "This is the second sentence."],
+      "current_behavior": ["This is the first sentence.", "Thisis the second sentence."],
+      "regression": true,
+      "notes": "When tokens arrive after a sentence-end, the buffer for the next sentence loses the leading space inside the chunker carry. Phase 1 should preserve the inter-sentence space."
+    },
+    {
+      "name": "three_sentences_question_exclamation_period",
+      "tokens": ["Are you sure? Yes I am! That is great."],
+      "expected_sentences": ["Are you sure?", "Yes I am!", "That is great."],
+      "current_behavior": ["Are you sure? Yes I am!", "That is great."],
+      "quirk": true,
+      "notes": "First two sentences are below min_sentence_len=20 and are merged by design. To get individual short sentences emitted, lower min_sentence_len."
+    },
+    {
+      "name": "abbreviation_doctor_smith",
+      "tokens": ["I met Dr. Smith yesterday at the clinic."],
+      "expected_sentences": ["I met Dr. Smith yesterday at the clinic."]
+    },
+    {
+      "name": "abbreviation_mr_mrs_ms",
+      "tokens": ["Mr. Smith and Mrs. Jones met Ms. Davis at noon."],
+      "expected_sentences": ["Mr. Smith and Mrs. Jones met Ms. Davis at noon."]
+    },
+    {
+      "name": "acronym_usa_followed_by_starter",
+      "tokens": ["He moved to the U.S.A. He is happy there."],
+      "expected_sentences": ["He moved to the U.S.A.", "He is happy there."]
+    },
+    {
+      "name": "phd_abbreviation",
+      "tokens": ["She earned her Ph.D. before turning thirty years old."],
+      "expected_sentences": ["She earned her Ph.D. before turning thirty years old."]
+    },
+    {
+      "name": "decimal_english_pi",
+      "tokens": ["The value of pi is 3.14 approximately for our calculations."],
+      "expected_sentences": ["The value of pi is 3.14 approximately for our calculations."]
+    },
+    {
+      "name": "decimal_english_two_periods",
+      "tokens": ["She measured 2.54 cm and then said it was 3.14 m total length."],
+      "expected_sentences": ["She measured 2.54 cm and then said it was 3.14 m total length."]
+    },
+    {
+      "name": "website_dot_com",
+      "tokens": ["Please visit example.com for more information about our pricing."],
+      "expected_sentences": ["Please visit example.com for more information about our pricing."]
+    },
+    {
+      "name": "website_dot_org",
+      "tokens": ["Check wikipedia.org and archive.org for the source documents."],
+      "expected_sentences": ["Check wikipedia.org and archive.org for the source documents."]
+    },
+    {
+      "name": "ellipsis_three_dots",
+      "tokens": ["I was thinking... maybe we should reconsider the entire approach."],
+      "expected_sentences": ["I was thinking... maybe we should reconsider the entire approach."]
+    },
+    {
+      "name": "ellipsis_four_dots",
+      "tokens": ["He paused.... then continued the long story without further hesitation."],
+      "expected_sentences": ["He paused.... then continued the long story without further hesitation."]
+    },
+    {
+      "name": "cjk_japanese_two_sentences",
+      "tokens": ["これはテストです。次の文章があります。"],
+      "expected_sentences": ["これはテストです。", "次の文章があります。"],
+      "current_behavior": ["これはテストです。次の文章があります。"],
+      "quirk": true,
+      "notes": "CJK sentences merged by min_sentence_len; CJK chars are 1 codepoint each so the buffer rarely crosses 20 chars before second sentence is appended."
+    },
+    {
+      "name": "cjk_chinese_question_period",
+      "tokens": ["你好吗？我很好。"],
+      "expected_sentences": ["你好吗？", "我很好。"],
+      "current_behavior": ["你好吗？我很好。"],
+      "quirk": true,
+      "notes": "Same CJK min_sentence_len merging."
+    },
+    {
+      "name": "cjk_full_width_exclamation",
+      "tokens": ["素晴らしい！これは本当に楽しいですね。"],
+      "expected_sentences": ["素晴らしい！", "これは本当に楽しいですね。"],
+      "current_behavior": ["素晴らしい！これは本当に楽しいですね。"],
+      "quirk": true,
+      "notes": "Same CJK min_sentence_len merging."
+    },
+    {
+      "name": "quote_with_punctuation_inside",
+      "tokens": ["She said \"hello.\" Then he replied \"goodbye.\""],
+      "expected_sentences": ["She said \"hello.\"", "Then he replied \"goodbye.\""],
+      "current_behavior": ["She said \"hello.\" Then he replied \"goodbye.\""],
+      "quirk": true,
+      "notes": "First sentence is 17 chars, below min_sentence_len=20, merged with second by design."
+    },
+    {
+      "name": "long_sentence_streamed_char_by_char",
+      "tokens": ["T", "h", "i", "s", " ", "i", "s", " ", "a", " ", "l", "o", "n", "g", " ", "s", "e", "n", "t", "e", "n", "c", "e", "."],
+      "expected_sentences": ["This is a long sentence."]
+    },
+    {
+      "name": "newline_normalized_to_space",
+      "tokens": ["First line.\nSecond line on a new physical row."],
+      "expected_sentences": ["First line.", "Second line on a new physical row."],
+      "current_behavior": ["First line.\nSecond line on a new physical row."],
+      "regression": true,
+      "notes": "_split_sentences replaces \\n with space, but the buffer comparison happens before that. Newline in input prevents normal sentence boundary detection. Phase 1 should normalize newlines on push()."
+    },
+    {
+      "name": "single_word_with_question_mark",
+      "tokens": ["Why?"],
+      "expected_sentences": ["Why?"]
+    },
+    {
+      "name": "two_words_short_flush_question",
+      "tokens": ["Are you?"],
+      "expected_sentences": ["Are you?"]
+    },
+    {
+      "name": "empty_input",
+      "tokens": [""],
+      "expected_sentences": []
+    },
+    {
+      "name": "only_whitespace",
+      "tokens": ["   "],
+      "expected_sentences": []
+    },
+    {
+      "name": "only_punctuation_dot",
+      "tokens": ["."],
+      "expected_sentences": ["."]
+    },
+    {
+      "name": "trailing_whitespace_after_terminator",
+      "tokens": ["Hello world.   "],
+      "expected_sentences": ["Hello world."]
+    },
+    {
+      "name": "five_sentences_streamed_individually",
+      "tokens": [
+        "Sentence one is here. ",
+        "Sentence two follows now. ",
+        "Sentence three arrives. ",
+        "Sentence four lands. ",
+        "Sentence five ends."
+      ],
+      "expected_sentences": [
+        "Sentence one is here.",
+        "Sentence two follows now.",
+        "Sentence three arrives.",
+        "Sentence four lands.",
+        "Sentence five ends."
+      ]
+    },
+    {
+      "name": "abbreviation_inc_followed_by_starter",
+      "tokens": ["He works at Patter Inc. He likes it."],
+      "expected_sentences": ["He works at Patter Inc.", "He likes it."],
+      "current_behavior": ["He works at Patter Inc", "He likes it."],
+      "regression": true,
+      "notes": "The 'Inc.' suffix-followed-by-starter pattern strips the period entirely instead of preserving it. Phase 1 should keep the period in the emitted sentence."
+    },
+    {
+      "name": "abbreviation_jr_followed_by_starter",
+      "tokens": ["I met John Smith Jr. He is twenty years old."],
+      "expected_sentences": ["I met John Smith Jr.", "He is twenty years old."],
+      "current_behavior": ["I met John Smith Jr. He is twenty years old."],
+      "quirk": true,
+      "notes": "First fragment 'I met John Smith Jr.' is 21 chars but the chunker fuses with 'He is twenty years old.' because of buffer merge logic. Acceptable for now."
+    },
+    {
+      "name": "no_punctuation_at_all_kept_until_flush",
+      "tokens": ["This is a sentence with no terminator at the end at all"],
+      "expected_sentences": ["This is a sentence with no terminator at the end at all"]
+    },
+    {
+      "name": "italian_decimal_comma_pi",
+      "tokens": ["Il valore di pi greco è 3,14 circa per i nostri calcoli."],
+      "expected_sentences": ["Il valore di pi greco è 3,14 circa per i nostri calcoli."]
+    },
+    {
+      "name": "italian_decimal_comma_currency",
+      "tokens": ["Il prezzo totale è di euro 1.000,50 spedizione inclusa."],
+      "expected_sentences": ["Il prezzo totale è di euro 1.000,50 spedizione inclusa."]
+    },
+    {
+      "name": "italian_abbreviation_signor",
+      "tokens": ["Ho incontrato il Sig. Rossi alla riunione di stamattina."],
+      "expected_sentences": ["Ho incontrato il Sig. Rossi alla riunione di stamattina."],
+      "current_behavior": ["Ho incontrato il Sig.", "Rossi alla riunione di stamattina."],
+      "regression": true,
+      "notes": "Sig. (Italian Signor) is not in the abbreviation prefix list — the period after Sig is treated as sentence end. Phase 1 should add Italian honorifics: Sig, Sig.ra, Sgr, On, Egr, Spett."
+    },
+    {
+      "name": "italian_abbreviation_dottore",
+      "tokens": ["Il Dott. Bianchi visita ogni martedì pomeriggio in studio."],
+      "expected_sentences": ["Il Dott. Bianchi visita ogni martedì pomeriggio in studio."]
+    },
+    {
+      "name": "italian_abbreviation_dottoressa_inline",
+      "tokens": ["La Dott.ssa Verdi ha confermato la diagnosi clinica al paziente."],
+      "expected_sentences": ["La Dott.ssa Verdi ha confermato la diagnosi clinica al paziente."]
+    },
+    {
+      "name": "italian_abbreviation_avvocato",
+      "tokens": ["L'Avv. Marini ha vinto la causa civile davanti al tribunale."],
+      "expected_sentences": ["L'Avv. Marini ha vinto la causa civile davanti al tribunale."]
+    },
+    {
+      "name": "italian_abbreviation_professor",
+      "tokens": ["Il Prof. Galli insegna fisica all'università di Bologna ogni anno."],
+      "expected_sentences": ["Il Prof. Galli insegna fisica all'università di Bologna ogni anno."]
+    },
+    {
+      "name": "italian_company_spa",
+      "tokens": ["L'azienda S.p.A. ha pubblicato i risultati del bilancio annuale ieri."],
+      "expected_sentences": ["L'azienda S.p.A. ha pubblicato i risultati del bilancio annuale ieri."]
+    },
+    {
+      "name": "italian_company_srl",
+      "tokens": ["La S.r.l. ha sede legale a Milano da molti anni ormai."],
+      "expected_sentences": ["La S.r.l. ha sede legale a Milano da molti anni ormai."]
+    },
+    {
+      "name": "list_with_commas_three_items",
+      "tokens": ["Compra mele, pere, banane e uva al supermercato vicino."],
+      "expected_sentences": ["Compra mele, pere, banane e uva al supermercato vicino."]
+    },
+    {
+      "name": "currency_dollar_thousands",
+      "tokens": ["The total is $1,000,000 for the entire fiscal quarter this year."],
+      "expected_sentences": ["The total is $1,000,000 for the entire fiscal quarter this year."]
+    },
+    {
+      "name": "date_april_28_2026",
+      "tokens": ["The meeting on April 28, 2026 is scheduled for noon sharp."],
+      "expected_sentences": ["The meeting on April 28, 2026 is scheduled for noon sharp."]
+    },
+    {
+      "name": "json_inline",
+      "tokens": ["The payload was {\"a\": 1, \"b\": 2, \"c\": 3} for the test case."],
+      "expected_sentences": ["The payload was {\"a\": 1, \"b\": 2, \"c\": 3} for the test case."]
+    },
+    {
+      "name": "vocative_italian_then_greeting",
+      "tokens": ["Maria, ciao come stai oggi pomeriggio dopo il pranzo?"],
+      "expected_sentences": ["Maria, ciao come stai oggi pomeriggio dopo il pranzo?"]
+    },
+    {
+      "name": "two_italian_sentences_period",
+      "tokens": ["Buongiorno a tutti voi. Oggi parleremo del nostro nuovo prodotto."],
+      "expected_sentences": ["Buongiorno a tutti voi.", "Oggi parleremo del nostro nuovo prodotto."]
+    },
+    {
+      "name": "italian_question_then_answer",
+      "tokens": ["Come ti chiami davvero? Mi chiamo Mario, piacere di conoscerti."],
+      "expected_sentences": ["Come ti chiami davvero?", "Mi chiamo Mario, piacere di conoscerti."]
+    },
+    {
+      "name": "italian_etcetera_abbreviation",
+      "tokens": ["Ho comprato pane, latte, formaggio, ecc. al supermercato sotto casa."],
+      "expected_sentences": ["Ho comprato pane, latte, formaggio, ecc. al supermercato sotto casa."],
+      "current_behavior": ["Ho comprato pane, latte, formaggio, ecc.", "al supermercato sotto casa."],
+      "regression": true,
+      "notes": "ecc. (Italian etcetera) is not in the abbreviation list. Phase 1 should add it together with art. (articolo), pag. (pagina), n. (numero), cit. (citato), ed. (edizione)."
+    },
+    {
+      "name": "italian_two_sentences_with_decimal",
+      "tokens": ["Il numero è 3,14. Il secondo numero è 2,71 invece."],
+      "expected_sentences": ["Il numero è 3,14.", "Il secondo numero è 2,71 invece."],
+      "current_behavior": ["Il numero è 3,14. Il secondo numero è 2,71 invece."],
+      "quirk": true,
+      "notes": "First sentence 'Il numero è 3,14.' is 17 chars, below min_sentence_len=20, fused with second sentence. Lower min_sentence_len to flush both."
+    },
+    {
+      "name": "italian_thousands_separator_dot",
+      "tokens": ["La popolazione è 1.234.567 abitanti totali nella regione metropolitana."],
+      "expected_sentences": ["La popolazione è 1.234.567 abitanti totali nella regione metropolitana."]
+    },
+    {
+      "name": "long_response_three_sentences_with_filler",
+      "tokens": [
+        "Certo, ",
+        "ti aiuto subito con questa richiesta. ",
+        "Per favore, attendi un momento mentre verifico le informazioni necessarie. ",
+        "Grazie per la pazienza."
+      ],
+      "expected_sentences": [
+        "Certo, ti aiuto subito con questa richiesta.",
+        "Per favore, attendi un momento mentre verifico le informazioni necessarie.",
+        "Grazie per la pazienza."
+      ]
+    },
+    {
+      "name": "english_response_with_filler_then_two_sentences",
+      "tokens": [
+        "Sure, ",
+        "let me check that for you. ",
+        "The order shipped yesterday afternoon. ",
+        "It should arrive within three days."
+      ],
+      "expected_sentences": [
+        "Sure, let me check that for you.",
+        "The order shipped yesterday afternoon.",
+        "It should arrive within three days."
+      ]
+    },
+    {
+      "name": "phase7_ramesh_all_caps_name",
+      "tokens": ["I was speaking with RAMESH about the project."],
+      "expected_sentences": ["I was speaking with RAMESH about the project."],
+      "notes": "Phase 7 fix: gate-5 previously blocked any uppercase-preceded period; an all-caps name immediately before the terminator must still register as a real sentence end."
+    },
+    {
+      "name": "phase7_us_two_letter_acronym_preserved",
+      "tokens": ["He moved to the US for work last year."],
+      "expected_sentences": ["He moved to the US for work last year."]
+    },
+    {
+      "name": "phase7_vs_abbreviation_preserved",
+      "tokens": ["Compare option A vs. option B carefully here."],
+      "expected_sentences": ["Compare option A vs. option B carefully here."],
+      "notes": "Phase 7 EN abbrev expansion: vs. now in suffix list."
+    },
+    {
+      "name": "phase7_etc_abbreviation_english",
+      "tokens": ["Buy apples, oranges, etc. before the weekend."],
+      "expected_sentences": ["Buy apples, oranges, etc. before the weekend."],
+      "notes": "Phase 7 EN abbrev expansion: etc. now in suffix list."
+    },
+    {
+      "name": "phase7_general_senator_titles",
+      "tokens": ["Met Gen. Smith and Sen. Davis at the conference."],
+      "expected_sentences": ["Met Gen. Smith and Sen. Davis at the conference."]
+    },
+    {
+      "name": "phase7_hindi_devanagari_danda",
+      "tokens": ["यह हिन्दी का एक वाक्य है। और यह दूसरा वाक्य है।"],
+      "expected_sentences": ["यह हिन्दी का एक वाक्य है।", "और यह दूसरा वाक्य है।"]
+    },
+    {
+      "name": "phase7_arabic_question_mark",
+      "tokens": ["هل أنت بخير؟ نعم، شكراً جزيلاً لك."],
+      "expected_sentences": ["هل أنت بخير؟ نعم، شكراً جزيلاً لك."],
+      "current_behavior": ["هل أنت بخير؟", "نعم، شكراً جزيلاً لك."],
+      "quirk": true,
+      "notes": "Arabic question mark `؟` now triggers split (Phase 7) — first fragment is short (12 chars < 20) so it would normally fuse, but the second clause is long enough to push it past min_sentence_len. Behavior is acceptable; documenting the actual output."
+    },
+    {
+      "name": "phase7_ascii_semicolon_terminator",
+      "tokens": ["First clause ends here; second clause continues onward."],
+      "expected_sentences": ["First clause ends here;", "second clause continues onward."],
+      "current_behavior": ["First clause ends here; second clause continues onward."],
+      "quirk": true,
+      "notes": "ASCII semicolon is now a terminator (Phase 7), but the first fragment is exactly 22 chars and merging logic keeps it together with the rest in the standard path. Acceptable behavior."
+    },
+    {
+      "name": "phase7_ellipsis_unicode_terminator",
+      "tokens": ["I was thinking… maybe we should reconsider."],
+      "expected_sentences": ["I was thinking… maybe we should reconsider."],
+      "notes": "Unicode ellipsis U+2026 now a terminator (Phase 7) but the lookahead pattern keeps it together as a single sentence."
+    }
+  ]
+}

--- a/tests/test_no_hardcoded_cjk.py
+++ b/tests/test_no_hardcoded_cjk.py
@@ -50,6 +50,7 @@ _ALLOWED_FILES = {
     "examples/README.md",                         # multilingual example payloads
     # Text-processing (CJK punctuation inside sentence/clause-splitting regexes)
     "backend/services/segmentation.py",
+    "backend/services/sentence_chunker.py",       # streaming-TTS terminator tables (Patter port, Wave 1.4)
     "backend/services/subtitle_segmenter.py",
     "frontend/src/components/DubSegmentRow.jsx",
     "frontend/src/components/StoriesEditor.jsx",

--- a/tests/test_sentence_chunker.py
+++ b/tests/test_sentence_chunker.py
@@ -1,0 +1,71 @@
+"""Wave 1.4 — sentence chunker golden-parity suite.
+
+Drives all 61 scenarios from Patter's parity corpus (MIT) — copied verbatim
+to tests/fixtures/sentence_chunker_scenarios.json — through our port. Cases
+carrying ``current_behavior`` are accepted as documented xfails (matching
+upstream's runner semantics): the port must reproduce upstream behavior
+exactly, including its documented quirks.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from services.sentence_chunker import SentenceChunker
+
+_SCENARIOS = json.loads(
+    (Path(__file__).parent / "fixtures" / "sentence_chunker_scenarios.json")
+    .read_text(encoding="utf-8")
+)
+
+
+def _run_case(tokens: list[str]) -> list[str]:
+    chunker = SentenceChunker()
+    emitted: list[str] = []
+    for token in tokens:
+        emitted.extend(chunker.push(token))
+    emitted.extend(chunker.flush())
+    return emitted
+
+
+@pytest.mark.parametrize(
+    "case", _SCENARIOS["cases"], ids=[c["name"] for c in _SCENARIOS["cases"]]
+)
+def test_golden_parity(case):
+    got = _run_case(case["tokens"])
+    expected = case["expected_sentences"]
+    current = case.get("current_behavior")
+    if got == expected:
+        return
+    if current is not None and got == current:
+        # Upstream documents this divergence (quirk or known regression);
+        # parity with upstream's ACTUAL behavior is the port contract.
+        return
+    raise AssertionError(
+        f"{case['name']}: got {got!r}\n expected {expected!r}"
+        + (f"\n or documented current {current!r}" if current is not None else "")
+    )
+
+
+# ── OmniVoice integration shape (how /ws/tts drives it) ────────────────────
+
+def test_whole_request_text_splits_to_sentences():
+    chunker = SentenceChunker()
+    out = chunker.push("First thing here today. Second thing follows it. Third!")
+    out.extend(chunker.flush())
+    assert out == ["First thing here today.", "Second thing follows it.", "Third!"]
+
+
+def test_single_sentence_request_stays_whole():
+    chunker = SentenceChunker()
+    out = chunker.push("Just the one sentence without much else going on.")
+    out.extend(chunker.flush())
+    assert out == ["Just the one sentence without much else going on."]
+
+
+def test_italian_language_disables_aggressive_flush():
+    chunker = SentenceChunker(language="it", aggressive_first_flush=True)
+    assert chunker._aggressive_first_flush is False


### PR DESCRIPTION
## What

Wave 1.4 of the [parity program](docs/specs/2026-06-12-elevenlabs-parity-program.md) (Spec 8a) — Patter's sentence chunker (MIT, attribution header), ported behavior-identical.

- **`backend/services/sentence_chunker.py`** — stdlib-only port; abbreviation/honorific tables for 6 languages, acronym + decimal + currency guards, CJK and 8 non-Latin script terminators (file allowlisted in the CJK gate per the documented functional-CJK convention), short-flush for instant single-word replies, opt-in aggressive first-clause flush with the Italian comma-decimal hard-disable.
- **Golden parity:** all **61 upstream scenarios** copied verbatim to `tests/fixtures/` and passing — including upstream's documented quirks (`current_behavior` xfail semantics mirrored), so the port contract is "exactly what Patter does", not "close enough".
- **`/ws/tts`** now synthesizes sentence-by-sentence: the first sentence's PCM streams while later sentences are still generating — the TTFA improvement on multi-sentence input. Single-sentence requests take the identical old path; `start` metadata still waits for the first generation so lazy-loading engines report their true sample rate; per-sentence mastering/normalization unchanged.

## Verification
- `uv run pytest tests/test_sentence_chunker.py tests/test_no_hardcoded_cjk.py` → 65 passed (61 golden + 3 integration + gate)
- WS protocol shape unchanged (start → binary PCM16 frames → done with cumulative totals) — existing clients unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Sentence-by-Sentence WebSocket TTS Streaming with SentenceChunker

## Overview
This PR introduces sentence-level chunking for the `/ws/tts` WebSocket endpoint, enabling time-to-first-audio improvements by streaming the first sentence's audio while subsequent sentences are still generating. A new `SentenceChunker` service module was ported from Patter (MIT-licensed) with attribution, providing regex-based sentence splitting with language-specific honorific/abbreviation support for 6 languages, CJK terminator handling, acronym/decimal/currency guards, and optional aggressive first-clause flushing.

## Behavior Flow

```mermaid
graph TD
    A["WebSocket /ws/tts Request<br/>text + language + generation params"] --> B["SentenceChunker splits text<br/>into sentences"]
    B --> C["Loop: Generate sentence-by-sentence"]
    C --> D["First sentence generated"]
    D --> E["Send 'start' metadata<br/>with sample_rate"]
    E --> F["Convert sentence waveform to PCM16<br/>chunk into CHUNK_SAMPLES frames"]
    F --> G["Stream binary frames to client"]
    G --> H["Later sentences generating<br/>in parallel"]
    H --> I["Next sentence ready"]
    I --> J["Convert + chunk PCM16"]
    J --> G
    K["All sentences processed"] --> L["Send 'done' metadata<br/>cumulative total_samples<br/>+ duration"]
    L --> M["Close WebSocket"]
    style D fill:`#90EE90`
    style E fill:`#87CEEB`
    style G fill:`#FFD700`
```

## Key Changes

### `backend/services/sentence_chunker.py` (+571 lines)
- **New `SentenceChunker` class**: Buffers incoming tokens and emits complete sentences via three paths:
  - Standard boundary detection (sentence-ending punctuation with abbreviation protection)
  - Short-flush for single-word utterances (guards: minimum word count, no mid-decimal splits, honorific suffix blocking)
  - Aggressive first-clause flush on soft punctuation (comma/dashes) with 7+ safety guards including quote/paren balance, ellipsis avoidance, currency context rejection
  
- **Language support**: Honorific prefix lists for EN, FR, DE, IT, ES, PT; combined regex protects 200+ abbreviations/acronyms, decimals, URLs, special sequences (Ph.D., etc.)
- **CJK & non-Latin**: Handles Japanese/Chinese/Korean/Thai/Vietnamese/Arabic/Hebrew/Devanagari terminators
- **Public API**: `push(token) → list[str]`, `flush() → list[str]`, `reset()`
- **Constants**: `DEFAULT_MIN_SENTENCE_LEN`, `DEFAULT_MIN_WORDS_FOR_SHORT_FLUSH`, `DEFAULT_AGGRESSIVE_FIRST_MIN_LEN`, `HONORIFICS_BY_LANGUAGE`

### `backend/api/routers/tts_stream.py` (+53/-33 lines)
- Refactored `ws_tts` to instantiate `SentenceChunker` and loop over generated sentences
- Updated GPU-pool helper to accept `sentence_text` argument instead of full text
- Delayed `"start"` metadata emission until first sentence generation completes (ensures `sample_rate` availability for lazy-loading engines)
- Accumulates `total_samples` across all sentences for correct final duration in `"done"` message
- Maintains existing WebSocket protocol shape: `start` → binary frames → `done`

### Test Coverage
- **`tests/test_sentence_chunker.py`** (+71 lines): Golden-parity suite loading 61 upstream scenarios from `tests/fixtures/sentence_chunker_scenarios.json`; includes integration tests for whole-request splitting and single-sentence preservation; regression test confirms Italian + aggressive-flush disables internal aggressive mode
- **`tests/test_no_hardcoded_cjk.py`** (+1 line): Allowlisted `sentence_chunker.py` in CJK gate per project convention

## Protocol Compatibility
- WebSocket message shape unchanged: clients receive identical `start` and `done` frames
- Backward compatible: single-sentence requests use existing single-shot path
- Sample rate metadata available early (after first sentence generation vs. after full text buffering)

## Verification
- All 65 tests pass: 61 golden parity + 3 integration + 1 gate enforcement
- Upstream parity established with mirrored xfail semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->