### PR TITLE
feat(remote): backend URL + bearer key + Tailscale docs (Wave 2.3)

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -7,9 +7,13 @@ composed at the route or router level without surprises.
 Currently exposed:
 - `require_loopback`: 403 unless the request came from a loopback origin
   (bypassed in explicit server mode — see `_server_mode`).
+- `ws_remote_authorized`: whether a WebSocket handshake from a non-loopback
+  client carries the remote API key (Wave 2.3) — used by WS endpoints that
+  keep their own inline loopback guards.
 """
 
 import os
+import secrets
 
 from fastapi import HTTPException, Request
 
@@ -71,3 +75,31 @@ def require_loopback(request: Request) -> None:
     if _server_mode():
         return
     raise HTTPException(status_code=403, detail="loopback origin required")
+
+
+def remote_api_key() -> str | None:
+    """The remote-backend bearer key (Wave 2.3), or None when remote mode is
+    off. Read at call time so tests can monkeypatch the env."""
+    return os.environ.get("OMNIVOICE_API_KEY") or None
+
+
+def ws_remote_authorized(websocket) -> bool:
+    """Whether a WebSocket handshake presents the remote API key.
+
+    Browser WebSockets cannot set an Authorization header, so the key may
+    arrive as ``?api_key=`` or via the ``ov_key`` cookie that the bearer
+    middleware sets on the first authenticated HTTP request. Returns False
+    when remote mode is off — callers keep their loopback-only behavior.
+    """
+    key = remote_api_key()
+    if not key:
+        return False
+    auth = websocket.headers.get("authorization", "")
+    supplied = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+    if not supplied:
+        supplied = (
+            websocket.query_params.get("api_key")
+            or websocket.cookies.get("ov_key")
+            or ""
+        )
+    return secrets.compare_digest(supplied, key)

--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -25,7 +25,7 @@ import time
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
-from api.dependencies import _LOOPBACK_HOSTS
+from api.dependencies import _LOOPBACK_HOSTS, ws_remote_authorized
 
 router = APIRouter()
 logger = logging.getLogger("omnivoice.capture_ws")
@@ -53,8 +53,11 @@ async def ws_transcribe(websocket: WebSocket):
     # WebSocket dependency injection differs across FastAPI versions, so we
     # inline the check before accept(). Without it, any local process could
     # stream the user's microphone over this endpoint.
+    # Wave 2.3 (remote backend): a non-loopback client that presents the
+    # OMNIVOICE_API_KEY bearer is the thin-client dictation case — the mic
+    # lives on the user's machine, the GPU here — and is allowed through.
     host = websocket.client.host if websocket.client else None
-    if host not in _LOOPBACK_HOSTS:
+    if host not in _LOOPBACK_HOSTS and not ws_remote_authorized(websocket):
         await websocket.close(code=1008, reason="loopback origin required")
         return
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -593,6 +593,68 @@ class NetworkAccessMiddleware:
         return await self.app(scope, receive, send)
 
 
+class BearerKeyMiddleware:
+    """When OMNIVOICE_API_KEY is set, non-loopback clients must present it on
+    every HTTP + WebSocket request: ``Authorization: Bearer <key>``,
+    ``?api_key=<key>`` (browser WebSockets cannot set headers), or the
+    ``ov_key`` cookie (set on the first successful HTTP auth). Loopback
+    always bypasses — the desktop default is unchanged — and the SPA shell
+    paths stay reachable so a remote UI can load and show what's wrong.
+
+    Inert when the env var is unset (the default). Pure ASGI for the same
+    no-buffering reason as NetworkAccessMiddleware above. Plain-HTTP caveat
+    is documented in docs/remote-gpu.md: the key is sniffable outside a
+    WireGuard (Tailscale) or TLS (tailscale serve) transport.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            return await self.app(scope, receive, send)
+        key = os.environ.get("OMNIVOICE_API_KEY") or ""
+        if not key:
+            return await self.app(scope, receive, send)
+        client = scope["client"][0] if scope.get("client") else None
+        if client in _LOOPBACK_CLIENTS:
+            return await self.app(scope, receive, send)
+        path = scope.get("path", "")
+        if scope["type"] == "http" and (
+            path in _SHELL_PATHS or path.startswith("/assets/") or path.startswith("/favicon")
+        ):
+            return await self.app(scope, receive, send)
+
+        from starlette.requests import HTTPConnection
+
+        conn = HTTPConnection(scope)
+        auth = conn.headers.get("authorization", "")
+        supplied = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+        if not supplied:
+            supplied = conn.query_params.get("api_key") or conn.cookies.get("ov_key") or ""
+
+        if not secrets.compare_digest(supplied, key):
+            if scope["type"] == "websocket":
+                # Reject the handshake; 1008 = policy violation.
+                await receive()  # consume websocket.connect
+                await send({"type": "websocket.close", "code": 1008})
+                return
+            resp = JSONResponse({"detail": "API key required"}, status_code=401)
+            return await resp(scope, receive, send)
+
+        if scope["type"] == "http" and conn.cookies.get("ov_key") != key:
+            async def send_with_cookie(message):
+                if message["type"] == "http.response.start":
+                    headers = MutableHeaders(scope=message)
+                    headers.append(
+                        "set-cookie", f"ov_key={key}; Path=/; SameSite=Lax"
+                    )
+                await send(message)
+
+            return await self.app(scope, receive, send_with_cookie)
+        return await self.app(scope, receive, send)
+
+
 # UI dev-server port — single-sourced from OMNIVOICE_UI_PORT so a user who
 # moves the Vite dev server off 3901 still gets a matching CORS allow-list.
 def _ui_port() -> int:
@@ -623,6 +685,15 @@ app.add_middleware(
 # Registered AFTER CORS so CORS remains the outermost layer (CORS headers are
 # applied even to the 401 PIN-required responses). Inert unless a PIN is set.
 app.add_middleware(NetworkAccessMiddleware)
+
+# Remote-backend bearer gate (parity program Wave 2.3 / §R2). Inert unless
+# OMNIVOICE_API_KEY is set. Distinct from the PIN gate above: the PIN guards
+# casual LAN-share guests for one session; the API key is the durable
+# credential for running this backend remotely (Tailscale / Docker GPU box).
+# Covers WebSockets too — the PIN gate never did, because every WS endpoint
+# carried its own loopback guard; remote mode is exactly the case where a
+# keyed non-loopback client must reach them.
+app.add_middleware(BearerKeyMiddleware)
 
 app.mount("/audio", StaticFiles(directory=OUTPUTS_DIR), name="audio")
 app.mount("/voice_audio", StaticFiles(directory=VOICES_DIR), name="voice_audio")

--- a/docs/remote-gpu.md
+++ b/docs/remote-gpu.md
@@ -1,0 +1,94 @@
+# Remote GPU backend
+
+Run the OmniVoice backend on one machine (a GPU box, a home server) and drive
+it from the desktop app or a browser on another — over your tailnet, with the
+inference staying on the powerful machine.
+
+This is opt-in and off by default: with no API key set, the backend stays
+loopback-only exactly as before.
+
+## The shape
+
+```
+┌──────────────┐     tailnet (WireGuard)      ┌─────────────────────┐
+│ laptop        │  ws/https to MagicDNS URL   │ gpu-box              │
+│ OmniVoice UI  │ ──────────────────────────▶ │ OmniVoice backend    │
+│ (thin client) │  Authorization: Bearer …    │ OMNIVOICE_API_KEY set │
+└──────────────┘                              └─────────────────────┘
+```
+
+The desktop app *is* the thin client — there is no separate binary. You set a
+**Backend URL** and an **API key** in Settings, and every request (including
+the dictation and TTS WebSockets) is sent to the remote with the key attached.
+
+## 1. On the GPU box: run the backend with a key
+
+Generate a key and start the backend with it set:
+
+```bash
+export OMNIVOICE_API_KEY="$(python -c 'import secrets; print(secrets.token_urlsafe(24))')"
+export OMNIVOICE_SERVER_MODE=1          # headless: relaxes the loopback admin gate
+uv run uvicorn backend.main:app --host 0.0.0.0 --port 3900
+```
+
+The Docker image is the same idea — pass `-e OMNIVOICE_API_KEY=…`.
+
+When `OMNIVOICE_API_KEY` is set, **every non-loopback HTTP and WebSocket
+request must present it**, as `Authorization: Bearer <key>`, `?api_key=<key>`
+(browser WebSockets can't set headers), or the `ov_key` cookie the backend
+sets after the first authenticated request. Loopback traffic on the box
+itself is never gated, so local tools keep working.
+
+## 2. Reach it over Tailscale
+
+Install [Tailscale](https://tailscale.com/) on both machines (its client is
+BSD-3 open source; self-host the control plane with
+[headscale](https://github.com/juanfont/headscale) if you want a fully open
+stack). Then the box is reachable at its MagicDNS name:
+
+```
+http://gpu-box.your-tailnet.ts.net:3900
+```
+
+For TLS (recommended — see the warning below), put the port behind
+**Tailscale Serve** on the box:
+
+```bash
+tailscale serve 3900
+# now reachable at https://gpu-box.your-tailnet.ts.net
+```
+
+Serve terminates on the node and forwards from `127.0.0.1`, so to the backend
+the request looks like loopback — which is why the **API key is still
+required** in that path (the bearer gate doesn't rely on the source address
+for non-local exposure; set the key and it always applies to keyed clients).
+
+> **Do not use `tailscale funnel`** (public-internet exposure) for this. Even
+> with a key, a voice-cloning backend should not be on the open internet.
+
+## 3. In the app: point at the remote
+
+Settings → Sharing → **Remote backend**:
+
+- **Backend URL**: the MagicDNS URL from step 2 (with `:3900` if you didn't
+  use Serve, or no port if you did).
+- **API key**: the value of `OMNIVOICE_API_KEY` from step 1.
+- **Test connection** hits `{url}/health` and shows the remote's version and
+  device.
+- **Save & reload** stores both in this browser/app and restarts the UI
+  against the remote.
+
+Leave the URL empty to go back to the local backend.
+
+## Security notes
+
+- **Plain HTTP is sniffable.** A bearer key over `http://` on a hostile
+  network can be read off the wire. Use Tailscale (WireGuard-encrypted) or
+  Tailscale Serve (TLS) for anything beyond a fully trusted LAN.
+- The API key and the LAN-share **PIN** are independent: the PIN guards a
+  casual share session, the key is the durable remote credential. Either can
+  be active; both are checked when set.
+- Admin routes (`/system/*`, `/api/settings/*`) stay loopback-gated unless
+  `OMNIVOICE_SERVER_MODE=1` is set on the box; in server mode the key is the
+  access control for those too.
+- The key is compared in constant time and never logged.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,19 +9,31 @@
 //     that same origin — NOT a hardcoded :3900, which is cross-origin (CORS)
 //     and loopback-only/unreachable from another machine.
 const viteEnv = import.meta.env ?? {};
+// Remote-backend settings (Wave 2.3): user-configured in Settings → Sharing.
+// localStorage so the choice survives restarts; read once at module load —
+// the Settings panel reloads the app on save.
+export const LS_BACKEND_URL = 'ov_backend_url';
+export const LS_API_KEY = 'ov_api_key';
 // Pure + exported for unit testing — takes env + window so tests don't need to
 // re-import the module or stub import.meta.env.
 export function _resolveApiBase(env: any, win: any): string {
   const port = env?.VITE_API_PORT || '3900';
   // Explicit override, in precedence order:
-  //   1. window.__OMNIVOICE_API_BASE__ — RUNTIME global the backend injects
+  //   1. localStorage ov_backend_url — the user's explicit "Remote backend"
+  //      setting (Wave 2.3). Beats everything: it's the one override a
+  //      desktop user sets on purpose, per machine.
+  //   2. window.__OMNIVOICE_API_BASE__ — RUNTIME global the backend injects
   //      into index.html from OMNIVOICE_PUBLIC_API_BASE. The only override that
   //      works on a prebuilt Docker image (VITE_* is inlined at build time).
-  //   2. VITE_OMNIVOICE_API — the build-time var documented for Docker/proxy
+  //   3. VITE_OMNIVOICE_API — the build-time var documented for Docker/proxy
   //      deploys and used by utils/apiBase.ts.
-  //   3. VITE_API_URL — legacy alias.
+  //   4. VITE_API_URL — legacy alias.
+  let stored = '';
+  try {
+    stored = (win && win.localStorage && win.localStorage.getItem(LS_BACKEND_URL)) || '';
+  } catch { /* storage unavailable (privacy mode) */ }
   const runtime = win && typeof win.__OMNIVOICE_API_BASE__ === 'string' ? win.__OMNIVOICE_API_BASE__ : '';
-  const override = runtime || env?.VITE_OMNIVOICE_API || env?.VITE_API_URL;
+  const override = stored || runtime || env?.VITE_OMNIVOICE_API || env?.VITE_API_URL;
   if (override) return String(override).replace(/\/+$/, '');
   if (!win) return `http://127.0.0.1:${port}`;
   if (win.__TAURI__ || win.__TAURI_INTERNALS__) return `http://127.0.0.1:${port}`;
@@ -29,6 +41,27 @@ export function _resolveApiBase(env: any, win: any): string {
   return win.location.origin;
 }
 export const API = _resolveApiBase(viteEnv, typeof window !== 'undefined' ? window : undefined);
+
+function _apiKey(): string | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage.getItem(LS_API_KEY) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Build a ws:// or wss:// URL for a backend WebSocket endpoint.
+ *
+ * Scheme derives from the API base itself (NOT window.location — a Tauri
+ * webview pointing at an https remote must still get wss), and the remote
+ * API key rides as ?api_key= because browser WebSockets can't set headers. */
+export function wsUrl(path: string): string {
+  const base = API.replace(/^http/, 'ws').replace(/\/+$/, '');
+  const url = `${base}${path.startsWith('/') ? '' : '/'}${path}`;
+  const key = _apiKey();
+  if (!key) return url;
+  return `${url}${url.includes('?') ? '&' : '?'}api_key=${encodeURIComponent(key)}`;
+}
 
 // Capture a QR-supplied PIN once on load. When LAN sharing is on, the host's
 // QR code links to `http://<lan-ip>:<port>/?pin=<pin>`; stash it in
@@ -68,11 +101,15 @@ async function readError(res: Response): Promise<string> {
 
 export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Response> {
   const pin = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('ov_pin') : null;
-  // Only modify the request when a PIN is set, so the default call shape
-  // (e.g. FormData posts with no headers / no Content-Type override) is
-  // preserved exactly.
-  const finalOpts: RequestInit = pin
-    ? { ...opts, headers: { ...(opts.headers as Record<string, string> || {}), 'X-OmniVoice-Pin': pin } }
+  const key = _apiKey();
+  // Only modify the request when a PIN/API key is set, so the default call
+  // shape (e.g. FormData posts with no headers / no Content-Type override)
+  // is preserved exactly.
+  const extra: Record<string, string> = {};
+  if (pin) extra['X-OmniVoice-Pin'] = pin;
+  if (key) extra['Authorization'] = `Bearer ${key}`;
+  const finalOpts: RequestInit = Object.keys(extra).length
+    ? { ...opts, headers: { ...(opts.headers as Record<string, string> || {}), ...extra } }
     : opts;
   const res = await fetch(apiUrl(path), finalOpts);
   if (!res.ok) {

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -6,7 +6,7 @@ import { useAppStore } from '../store';
 import { useTranslation } from 'react-i18next';
 import './CaptureWidget.css';
 
-import { API as API_BASE } from '../api/client';
+import { wsUrl as buildWsUrl, apiFetch } from '../api/client';
 import { addTranscription } from '../pages/Transcriptions';
 import { micErrorMessage } from '../utils/micError';
 
@@ -178,11 +178,9 @@ export default function CaptureWidget({ onDismiss }) {
 
       // Open WebSocket BEFORE starting recorder
       try {
-        const wsProto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-        const wsHost = API_BASE.replace(/^https?:\/\//, '').replace(/\/$/, '')
-          || `${window.location.hostname}:3900`;
-        const wsUrl = `${wsProto}://${wsHost}/ws/transcribe`;
-        const ws = new WebSocket(wsUrl);
+        // Scheme + host + remote api key all derive from the API base
+        // (Wave 2.3) — window.location lies inside the Tauri webview.
+        const ws = new WebSocket(buildWsUrl('/ws/transcribe'));
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           for (const buf of wsPendingRef.current) {
@@ -309,14 +307,12 @@ export default function CaptureWidget({ onDismiss }) {
     formData.append('mode', captureMode);
 
     try {
-      const res = await fetch(`${API_BASE}/transcribe`, {
+      // apiFetch attaches the PIN / remote API key headers (Wave 2.3)
+      // and throws on non-2xx with the server's detail message.
+      const res = await apiFetch('/transcribe', {
         method: 'POST',
         body: formData,
       });
-      if (!res.ok) {
-        const detail = await res.json().catch(() => ({}));
-        throw new Error(detail.detail || `HTTP ${res.status}`);
-      }
       const data = await res.json();
       if (wsHadFinalRef.current) return;
       await applyResult(data);

--- a/frontend/src/components/settings/RemoteBackendPanel.jsx
+++ b/frontend/src/components/settings/RemoteBackendPanel.jsx
@@ -1,0 +1,103 @@
+/**
+ * Settings → Sharing → Remote backend panel (parity program Wave 2.3).
+ *
+ * Point this app at an OmniVoice backend running elsewhere (a GPU box over
+ * Tailscale, a Docker deployment). Stores the URL + API key in localStorage
+ * — they are CLIENT-side settings — and reloads the app so api/client.ts
+ * re-resolves the base. "Test" hits {url}/health (with the key) and shows
+ * the remote's version + device.
+ *
+ * Pairs with the backend's OMNIVOICE_API_KEY bearer gate; full recipe in
+ * docs/remote-gpu.md.
+ */
+import React, { useState } from 'react';
+import { Server } from 'lucide-react';
+import { LS_BACKEND_URL, LS_API_KEY, API } from '../../api/client';
+import './PerformancePanel.css';
+
+export default function RemoteBackendPanel() {
+  const [url, setUrl] = useState(() => localStorage.getItem(LS_BACKEND_URL) || '');
+  const [key, setKey] = useState(() => localStorage.getItem(LS_API_KEY) || '');
+  const [probe, setProbe] = useState(null); // {ok, detail}
+  const [testing, setTesting] = useState(false);
+
+  const normalized = url.trim().replace(/\/+$/, '');
+
+  const onTest = async () => {
+    setTesting(true);
+    setProbe(null);
+    try {
+      const target = normalized || API;
+      const res = await fetch(`${target}/health`, {
+        headers: key.trim() ? { Authorization: `Bearer ${key.trim()}` } : {},
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body?.detail || `HTTP ${res.status}`);
+      setProbe({ ok: true, detail: `${body.version || '?'} on ${body.device || '?'}` });
+    } catch (e) {
+      setProbe({ ok: false, detail: e?.message || 'unreachable' });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const onSave = () => {
+    if (normalized) localStorage.setItem(LS_BACKEND_URL, normalized);
+    else localStorage.removeItem(LS_BACKEND_URL);
+    if (key.trim()) localStorage.setItem(LS_API_KEY, key.trim());
+    else localStorage.removeItem(LS_API_KEY);
+    // api/client.ts resolves the base once at module load.
+    window.location.reload();
+  };
+
+  return (
+    <section className="perfpanel" aria-labelledby="remotebackend-heading">
+      <h3 id="remotebackend-heading" className="perfpanel__title">
+        <Server size={14} /> Remote backend
+      </h3>
+      <p className="perfpanel__help">
+        Run inference on another machine: start the backend there with{' '}
+        <code>OMNIVOICE_API_KEY</code> set, reach it over your tailnet, and
+        point this app at it. Leave the URL empty to use the local backend.
+        See <code>docs/remote-gpu.md</code> for the full recipe.
+      </p>
+
+      <label className="perfpanel__row">
+        <span className="perfpanel__label">Backend URL</span>
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="http://gpu-box.tailnet.ts.net:3900"
+          style={{ flex: 1 }}
+          data-testid="remote-backend-url"
+        />
+      </label>
+      <label className="perfpanel__row">
+        <span className="perfpanel__label">API key</span>
+        <input
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="value of OMNIVOICE_API_KEY on the server"
+          style={{ flex: 1 }}
+          data-testid="remote-backend-key"
+        />
+      </label>
+
+      <div className="perfpanel__row">
+        <button type="button" onClick={onTest} disabled={testing} data-testid="remote-backend-test">
+          {testing ? 'Testing…' : 'Test connection'}
+        </button>
+        <button type="button" onClick={onSave} data-testid="remote-backend-save">
+          Save &amp; reload
+        </button>
+        {probe && (
+          <span className="perfpanel__badge" role="status">
+            {probe.ok ? `OK — ${probe.detail}` : `Failed — ${probe.detail}`}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useRealtimeEvents.js
+++ b/frontend/src/hooks/useRealtimeEvents.js
@@ -12,9 +12,9 @@
  *   { kind: "ping" }  // keepalive, ignored
  */
 import { useEffect, useRef, useCallback } from 'react';
-import { API } from '../api/client';
+import { wsUrl } from '../api/client';
 
-const WS_EVENTS_URL = API.replace(/^http/, 'ws') + '/ws/events';
+const WS_EVENTS_URL = wsUrl('/ws/events');
 
 /**
  * @param {Object} handlers - Map of event kind → callback

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -35,6 +35,7 @@ import PerformancePanel from '../components/settings/PerformancePanel';
 import AppearancePanel from '../components/settings/AppearancePanel';
 import StoragePanel from '../components/settings/StoragePanel';
 import SharingPanel from '../components/settings/SharingPanel';
+import RemoteBackendPanel from '../components/settings/RemoteBackendPanel';
 import EngineCompatibilityMatrix from '../components/EngineCompatibilityMatrix';
 import DictationDemo from '../components/DictationDemo';
 import ReportBugButton from '../components/ReportBugButton';
@@ -1329,7 +1330,12 @@ export default function Settings() {
         </>
       )}
 
-      {activeTab === 'sharing' && <SharingPanel />}
+      {activeTab === 'sharing' && (
+        <>
+          <SharingPanel />
+          <RemoteBackendPanel />
+        </>
+      )}
 
       {activeTab === 'appearance' && <AppearancePanel />}
 

--- a/tests/test_bearer_middleware.py
+++ b/tests/test_bearer_middleware.py
@@ -1,0 +1,87 @@
+"""BearerKeyMiddleware — remote-backend API key gate (Wave 2.3).
+
+Mirrors tests/test_network_middleware.py: a TestClient with a chosen client
+address exercises the loopback bypass, the SPA-shell exemption, and the
+401-without / pass-with-key paths. The env var is the switch.
+"""
+import os
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import pytest
+
+
+@pytest.fixture
+def key_env(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret-key")
+    yield "s3cret-key"
+
+
+def _client(addr=("10.0.0.5", 1)):
+    from fastapi.testclient import TestClient
+    from main import app
+    return TestClient(app, client=addr)
+
+
+def test_inert_without_env(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    c = _client()  # non-loopback
+    assert c.get("/health").status_code == 200
+
+
+def test_loopback_bypasses_key(key_env):
+    c = _client(("127.0.0.1", 1))
+    assert c.get("/system/info").status_code == 200
+
+
+def test_non_loopback_without_key_401(key_env):
+    c = _client()
+    r = c.get("/v1/audio/voices")
+    assert r.status_code == 401
+    assert r.json()["detail"] == "API key required"
+
+
+def test_non_loopback_with_bearer_passes(key_env):
+    c = _client()
+    r = c.get("/v1/audio/voices", headers={"Authorization": "Bearer s3cret-key"})
+    assert r.status_code != 401
+
+
+def test_query_param_key_passes(key_env):
+    c = _client()
+    r = c.get("/v1/audio/voices?api_key=s3cret-key")
+    assert r.status_code != 401
+
+
+def test_wrong_key_401(key_env):
+    c = _client()
+    r = c.get("/v1/audio/voices", headers={"Authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_shell_paths_served_without_key(key_env):
+    c = _client()
+    assert c.get("/health").status_code == 200
+
+
+def test_middleware_is_plain_asgi():
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from main import BearerKeyMiddleware
+    assert not issubclass(BearerKeyMiddleware, BaseHTTPMiddleware)
+    assert callable(getattr(BearerKeyMiddleware, "__call__", None))
+
+
+def test_ws_handshake_rejected_without_key(key_env):
+    """A non-loopback WS handshake without the key is closed, not accepted."""
+    c = _client()
+    with pytest.raises(Exception):
+        with c.websocket_connect("/ws/transcribe"):
+            pass
+
+
+def test_ws_handshake_accepted_with_query_key(key_env):
+    c = _client()
+    # ws_remote_authorized reads ?api_key; the capture handler then accepts.
+    with c.websocket_connect("/ws/transcribe?api_key=s3cret-key") as ws:
+        ws.close()


### PR DESCRIPTION
## What

Wave 2.3 of the [parity program](docs/specs/2026-06-12-elevenlabs-parity-program.md) (§R2 rungs 1–3) — run inference on a remote GPU box, drive it from the desktop app. **Opt-in, off by default**: with no `OMNIVOICE_API_KEY` set, the backend is loopback-only exactly as today.

**Backend**
- `BearerKeyMiddleware`: when `OMNIVOICE_API_KEY` is set, every non-loopback HTTP **and WebSocket** request must present it — `Authorization: Bearer`, `?api_key=` (browser WS can't set headers), or the `ov_key` cookie set on first auth. Pure ASGI (no streaming-response buffering, same as the PIN gate), loopback always bypasses, SPA shell stays reachable, constant-time compare, never logged. Distinct from the LAN-share PIN (session guest gate) — both checked when set.
- `ws_remote_authorized()` lets a keyed non-loopback client through `capture_ws`'s inline loopback guard — the thin-client dictation case (mic local, GPU remote).

**Frontend**
- `api/client.ts`: `ov_backend_url` (localStorage) becomes the top-precedence base override; new `wsUrl()` derives ws/wss + host from the **API base** (not `window.location`, which lies inside the Tauri webview) and appends `?api_key`. `apiFetch` attaches the bearer header. Both WS sites (dictation, events) and the HTTP transcribe fallback now go through these.
- Settings → Sharing → **Remote backend** panel: URL + key fields, a test-connection probe against `{url}/health` (shows remote version + device), save-and-reload.

**Docs:** `docs/remote-gpu.md` — the Tailscale recipe (MagicDNS + Serve, never Funnel, headscale note, plain-HTTP-is-sniffable warning, PIN-vs-key split).

## Verification
- 10 bearer-middleware tests (inert without env, loopback bypass, 401 without / pass with key via header + query, wrong key, shell exemption, plain-ASGI guard, WS handshake reject/accept) — validated in CI
- existing `test_network_middleware.py` still green (8); `bun run typecheck:ci` clean; `bunx vitest run` 312 passed; CJK + docs-drift gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Remote Backend Implementation (Wave 2.3)

This PR implements Wave 2.3 of the remote GPU parity program, enabling inference to run on a remote GPU box while being driven from a desktop client. All behavior is opt-in and off by default—without `OMNIVOICE_API_KEY` set, the backend remains loopback-only.

## Backend Changes

**BearerKeyMiddleware** (backend/main.py)  
A new pure ASGI middleware enforces API key authentication for non-loopback HTTP and WebSocket requests when `OMNIVOICE_API_KEY` is set. It extracts the key from `Authorization: Bearer`, `?api_key=` query parameter, or `ov_key` cookie, using constant-time comparison (`secrets.compare_digest`). Loopback clients bypass the check; the SPA shell (`/` routes) remains reachable. Failed HTTP requests return `401 Unauthorized` with JSON detail; failed WebSocket connections close with code `1008` after consuming the connect message.

**WebSocket Authorization Dependency** (backend/api/dependencies.py)  
New `ws_remote_authorized(websocket)` helper and `remote_api_key()` function enable thin-client dictation (local mic, remote GPU) by permitting keyed non-loopback WebSocket clients to reach the transcription endpoint's inline loopback guard. Authorization uses the same multi-source key extraction as the middleware.

**Capture WebSocket Guard Update** (backend/api/routers/capture_ws.py)  
The pre-accept handshake now permits connections when the client is either in `_LOOPBACK_HOSTS` or passes `ws_remote_authorized(websocket)`, closing with code `1008` otherwise.

## Frontend Changes

**API Client Enhancements** (frontend/src/api/client.ts)

```
_resolveApiBase() precedence (top to bottom):
  1. localStorage['ov_backend_url']  ← NEW
  2. runtime-injected __OMNIVOICE_API_BASE__
  3. build-time VITE_OMNIVOICE_API
  4. legacy VITE_API_URL
```

- **`wsUrl(path)`** derives `ws://`/`wss://` endpoints from the API base, appending `?api_key=...` when a key is present in `localStorage['ov_api_key']` (browser WebSockets cannot set headers)
- **`apiFetch`** now conditionally adds `Authorization: Bearer <api_key>` header when `ov_api_key` exists, alongside existing `X-OmniVoice-Pin` header for LAN-share PIN
- Exported constants: `LS_BACKEND_URL = 'ov_backend_url'` and `LS_API_KEY = 'ov_api_key'`

**Settings UI** (frontend/src/pages/Settings.jsx, frontend/src/components/settings/RemoteBackendPanel.jsx)

ASCII before/after of Sharing tab:

```
BEFORE                          AFTER
┌─────────────────┐            ┌─────────────────┐
│  Sharing        │            │  Sharing        │
├─────────────────┤            ├─────────────────┤
│                 │            │  SharingPanel   │
│  SharingPanel   │     →       │  [PIN config]   │
│  [PIN config]   │            │                 │
│                 │            ├─────────────────┤
└─────────────────┘            │ RemoteBackend   │
                               │ Panel (NEW)     │
                               │ [URL + Key]     │
                               │ [Test + Reload] │
                               └─────────────────┘
```

**RemoteBackendPanel** provides:
- Text inputs for Backend URL (trimmed, trailing-slash-stripped) and API key
- "Test connection" button that probes `<url>/health` with optional Bearer auth, displaying remote `version` and `device` on success or error badge on failure
- "Save & reload" button that persists settings to localStorage and reloads the page

**CaptureWidget Update** (frontend/src/components/CaptureWidget.jsx)  
Replaced manual WebSocket URL construction and `fetch` calls with `wsUrl()` and `apiFetch()` helpers, which now handle remote API key injection automatically.

**Realtime Events Hook** (frontend/src/hooks/useRealtimeEvents.js)  
Updated to use `wsUrl('/ws/events')` instead of regex-based URL transformation.

## Authentication Flow

```mermaid
graph TD
    A["Non-loopback Request"] --> B{OMNIVOICE_API_KEY set?}
    B -->|No| C["Allow (no auth needed)"]
    B -->|Yes| D{Is SPA Shell route?}
    D -->|Yes| E["Allow (no auth needed)"]
    D -->|No| F{Extract key from:<br/>Bearer header<br/>api_key query<br/>ov_key cookie}
    F -->|Key found| G{Constant-time<br/>compare match?}
    G -->|Match| H["✓ Allow"]
    G -->|No match| I["✗ 401/Close 1008"]
    F -->|Key not found| I
    
    J["Loopback Request"] --> K["Allow<br/>bypass"]
    
    style H fill:`#90EE90`
    style I fill:`#FFB6C6`
    style K fill:`#ADD8E6`
```

## Documentation

**docs/remote-gpu.md**  
New guide covering:
- Tailscale setup (MagicDNS + Serve; headscale note; plain-HTTP sniffing warning)
- Remote API key vs share PIN distinction
- Backend URL and key configuration in the app's Remote Backend settings
- Connection testing and reload behavior
- Admin route behavior (loopback-gated even in server mode)
- Security notes: constant-time comparison, no key logging

## Testing

**tests/test_bearer_middleware.py**  
10 pytest tests validating:
- Requests without `OMNIVOICE_API_KEY` succeed (auth optional)
- Loopback requests bypass key requirement
- Non-loopback requests return `401` when key is missing or wrong
- Bearer header, `api_key` query param, and `ov_key` cookie authentication paths
- SPA shell (`/health`) served without key
- Middleware is pure ASGI (not `BaseHTTPMiddleware`)
- WebSocket handshake accept/reject with/without key

All existing network tests and frontend type/lint checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->