### PR TITLE
feat(settings): remote LLM endpoint UI — Ollama/vLLM/LM Studio (Wave 2.4)

### DIFF
--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -161,6 +161,80 @@ def set_dictation_refinement(body: _RefinementBody):
     return _refinement_state()
 
 
+# ── LLM endpoint (parity program Wave 2.4 / §R2 rung 4) ───────────────────
+# Focused configuration for the OpenAI-compatible LLM endpoint that powers
+# cinematic translate, glossary auto-extract, and dictation refinement.
+# Persistence rides the existing TRANSLATE_BASE_URL / TRANSLATE_API_KEY /
+# TRANSLATE_MODEL env vars (already in system.py PERSISTENT_KEYS, restored
+# at startup) so the resolution path in llm_backend/translator is unchanged.
+
+
+class _LLMEndpointBody(BaseModel):
+    base_url: str | None = None
+    model: str | None = None
+    api_key: str | None = None  # None = leave unchanged; "" = clear
+
+
+def _mask(secret: str | None) -> str | None:
+    if not secret:
+        return None
+    return f"…{secret[-4:]}" if len(secret) > 4 else "set"
+
+
+def _llm_endpoint_state():
+    from services.llm_backend import OpenAICompatBackend
+
+    ok, reason = OpenAICompatBackend.is_available()
+    return {
+        "base_url": os.environ.get("TRANSLATE_BASE_URL", ""),
+        "model": os.environ.get("TRANSLATE_MODEL", ""),
+        "api_key_masked": _mask(
+            os.environ.get("TRANSLATE_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        ),
+        "available": ok,
+        "reason": None if ok else reason,
+    }
+
+
+@router.get("/llm-endpoint")
+def get_llm_endpoint():
+    """Current OpenAI-compatible LLM endpoint config + live availability."""
+    return _llm_endpoint_state()
+
+
+@router.put("/llm-endpoint")
+def set_llm_endpoint(body: _LLMEndpointBody):
+    """Persist base URL / model / API key for the OpenAI-compatible endpoint.
+
+    Reuses the env-var persistence path (prefs.json, restored at startup):
+    base_url -> TRANSLATE_BASE_URL, model -> TRANSLATE_MODEL,
+    api_key -> TRANSLATE_API_KEY. A None field is left unchanged; an empty
+    string clears it. Ollama ignores the key; vLLM / LM Studio require it.
+    """
+    from core.prefs import set_ as prefs_set, delete as prefs_delete
+
+    mapping = {
+        "TRANSLATE_BASE_URL": body.base_url,
+        "TRANSLATE_MODEL": body.model,
+        "TRANSLATE_API_KEY": body.api_key,
+    }
+    for env_key, val in mapping.items():
+        if val is None:
+            continue  # untouched
+        val = val.strip()
+        if val:
+            os.environ[env_key] = val
+            prefs_set(f"env.{env_key}", val)
+        else:
+            os.environ.pop(env_key, None)
+            prefs_delete(f"env.{env_key}")
+    # get_active_llm_backend() builds a fresh backend (and its OpenAI client
+    # reads env at construction) on every call, so there's no singleton to
+    # invalidate — the next translate/refine picks up the new values.
+    return _llm_endpoint_state()
+>>>>>>> 323f0d3 (feat(settings): remote LLM endpoint UI — Ollama/vLLM/LM Studio (Wave 2.4))
+
+
 # ── License acceptance (Phase 3 Plan 03-01 / TTS-05) ──────────────────────
 # Frontend ``SupertonicLicenseDialog`` flips the engine-license bit via this
 # endpoint. The handler is loopback-gated (router-level dep) and the

--- a/frontend/src/components/settings/LLMEndpointPanel.jsx
+++ b/frontend/src/components/settings/LLMEndpointPanel.jsx
@@ -1,0 +1,125 @@
+/**
+ * Settings → Credentials → LLM endpoint panel (parity program Wave 2.4).
+ *
+ * Configure the OpenAI-compatible LLM that powers cinematic translate,
+ * glossary auto-extract, and dictation refinement (Wave 2.1). Works with
+ * Ollama (no key), LM Studio, vLLM, or hosted OpenAI-compatible servers.
+ *
+ * Endpoints (loopback-only):
+ *   GET /api/settings/llm-endpoint
+ *     → {base_url, model, api_key_masked, available, reason}
+ *   PUT /api/settings/llm-endpoint  body: {base_url?, model?, api_key?}
+ *     (null field = unchanged; "" = clear). Persists via the existing
+ *     TRANSLATE_* env vars, restored on restart.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Brain, CheckCircle2, XCircle } from 'lucide-react';
+import { apiJson, apiFetch } from '../../api/client';
+import './PerformancePanel.css';
+
+const PRESETS = [
+  ['Ollama', 'http://localhost:11434/v1', 'llama3.1'],
+  ['LM Studio', 'http://localhost:1234/v1', 'local-model'],
+  ['vLLM', 'http://localhost:8000/v1', ''],
+  ['OpenAI', 'https://api.openai.com/v1', 'gpt-4o-mini'],
+];
+
+export default function LLMEndpointPanel() {
+  const [state, setState] = useState(null);
+  const [baseUrl, setBaseUrl] = useState('');
+  const [model, setModel] = useState('');
+  const [apiKey, setApiKey] = useState(''); // '' until user types; we never echo the stored key
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const data = await apiJson('/api/settings/llm-endpoint');
+      setState(data);
+      setBaseUrl(data.base_url || '');
+      setModel(data.model || '');
+    } catch (e) {
+      setError(e?.message || 'Failed to load LLM endpoint settings');
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const onSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const body = { base_url: baseUrl.trim(), model: model.trim() };
+      // Only send the key when the user typed one — an untouched field
+      // leaves the stored value alone (null = unchanged on the backend).
+      if (apiKey) body.api_key = apiKey;
+      const res = await apiFetch('/api/settings/llm-endpoint', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      setState(await res.json());
+      setApiKey('');
+    } catch (e) {
+      setError(e?.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const applyPreset = ([, url, m]) => { setBaseUrl(url); setModel(m); };
+
+  if (!state) return null;
+
+  return (
+    <section className="perfpanel" aria-labelledby="llmendpoint-heading">
+      <h3 id="llmendpoint-heading" className="perfpanel__title">
+        <Brain size={14} /> LLM endpoint
+      </h3>
+      <p className="perfpanel__help">
+        Powers cinematic translation, glossary auto-extract, and dictation
+        refinement. Any OpenAI-compatible server: Ollama, LM Studio, vLLM, or
+        a hosted API. Stays opt-in — features only call it when you enable them.
+      </p>
+
+      <div className="perfpanel__row" style={{ flexWrap: 'wrap', gap: 6 }}>
+        {PRESETS.map((p) => (
+          <button type="button" key={p[0]} onClick={() => applyPreset(p)} data-testid={`llm-preset-${p[0]}`}>
+            {p[0]}
+          </button>
+        ))}
+      </div>
+
+      <label className="perfpanel__row">
+        <span className="perfpanel__label">Base URL</span>
+        <input type="text" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)}
+          placeholder="http://localhost:11434/v1" style={{ flex: 1 }} data-testid="llm-base-url" />
+      </label>
+      <label className="perfpanel__row">
+        <span className="perfpanel__label">Model</span>
+        <input type="text" value={model} onChange={(e) => setModel(e.target.value)}
+          placeholder="llama3.1" style={{ flex: 1 }} data-testid="llm-model" />
+      </label>
+      <label className="perfpanel__row">
+        <span className="perfpanel__label">API key</span>
+        <input type="password" value={apiKey} onChange={(e) => setApiKey(e.target.value)}
+          placeholder={state.api_key_masked ? `stored (${state.api_key_masked}) — type to replace` : 'optional (Ollama needs none)'}
+          style={{ flex: 1 }} data-testid="llm-api-key" />
+      </label>
+
+      {error && <div className="perfpanel__error" role="alert">{error}</div>}
+
+      <div className="perfpanel__row">
+        <button type="button" onClick={onSave} disabled={saving} data-testid="llm-save">
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <span className="perfpanel__badge" role="status">
+          {state.available
+            ? <><CheckCircle2 size={11} /> reachable</>
+            : <><XCircle size={11} /> {state.reason || 'not configured'}</>}
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -31,6 +31,7 @@ import { getFrontendLogs, clearFrontendLogs } from '../utils/consoleBuffer';
 import { Tabs, Segmented, Button, Badge, Table, Progress, Select } from '../ui';
 import { useAppStore } from '../store';
 import ApiKeysPanel from '../components/settings/ApiKeysPanel';
+import LLMEndpointPanel from '../components/settings/LLMEndpointPanel';
 import PerformancePanel from '../components/settings/PerformancePanel';
 import RefinementPanel from '../components/settings/RefinementPanel';
 import AppearancePanel from '../components/settings/AppearancePanel';
@@ -1800,6 +1801,9 @@ function CredentialsTab({ info }) {
       {/* Wave 2 AUTH-03 panel — 3-source cascade with Active badge,
           encrypted-at-rest App-source storage, and live whoami status. */}
       <ApiKeysPanel />
+
+      {/* Wave 2.4 — OpenAI-compatible LLM endpoint (Ollama/LM Studio/vLLM). */}
+      <LLMEndpointPanel />
 
       <p className="settings-prose">
         <Trans i18nKey="credentials.desc" components={{ 1: <strong /> }} />

--- a/tests/test_llm_endpoint_settings.py
+++ b/tests/test_llm_endpoint_settings.py
@@ -1,0 +1,89 @@
+"""LLM endpoint settings (Wave 2.4) — GET/PUT /api/settings/llm-endpoint.
+
+Persistence rides the TRANSLATE_* env vars; these tests assert the read
+shape, masking, and the set/unchanged/clear semantics, with prefs writes
+stubbed so nothing touches the real prefs.json.
+"""
+import os
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import importlib
+
+import pytest
+
+# `openai` is an optional (translator-path) dependency. is_available() short-
+# circuits to False without it, so availability assertions are guarded.
+_HAS_OPENAI = importlib.util.find_spec("openai") is not None
+
+
+@pytest.fixture
+def settings_mod(monkeypatch):
+    # Stub prefs persistence so PUT doesn't write the developer's prefs.json.
+    import core.prefs as prefs
+    monkeypatch.setattr(prefs, "set_", lambda *a, **k: None)
+    monkeypatch.setattr(prefs, "delete", lambda *a, **k: None)
+    for k in ("TRANSLATE_BASE_URL", "TRANSLATE_MODEL", "TRANSLATE_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    return importlib.import_module("api.routers.settings")
+
+
+def test_get_empty_state(settings_mod):
+    state = settings_mod.get_llm_endpoint()
+    assert state["base_url"] == ""
+    assert state["model"] == ""
+    assert state["api_key_masked"] is None
+    assert state["available"] is False
+    assert state["reason"]
+
+
+def test_put_sets_and_masks(settings_mod):
+    body = settings_mod._LLMEndpointBody(
+        base_url="http://localhost:11434/v1", model="llama3.1", api_key="sk-secret-1234"
+    )
+    state = settings_mod.set_llm_endpoint(body)
+    assert os.environ["TRANSLATE_BASE_URL"] == "http://localhost:11434/v1"
+    assert os.environ["TRANSLATE_MODEL"] == "llama3.1"
+    assert os.environ["TRANSLATE_API_KEY"] == "sk-secret-1234"
+    assert state["api_key_masked"] == "…1234"
+    if _HAS_OPENAI:
+        assert state["available"] is True  # base_url + key → ready
+
+
+def test_put_none_field_leaves_unchanged(settings_mod):
+    settings_mod.set_llm_endpoint(
+        settings_mod._LLMEndpointBody(base_url="http://x/v1", model="m", api_key="key123456")
+    )
+    # api_key omitted (None) — must not clear it.
+    settings_mod.set_llm_endpoint(
+        settings_mod._LLMEndpointBody(base_url="http://y/v1", model="m2")
+    )
+    assert os.environ["TRANSLATE_BASE_URL"] == "http://y/v1"
+    assert os.environ["TRANSLATE_API_KEY"] == "key123456"
+
+
+def test_put_empty_string_clears(settings_mod):
+    settings_mod.set_llm_endpoint(
+        settings_mod._LLMEndpointBody(base_url="http://x/v1", api_key="key123456")
+    )
+    settings_mod.set_llm_endpoint(settings_mod._LLMEndpointBody(api_key=""))
+    assert "TRANSLATE_API_KEY" not in os.environ
+
+
+def test_local_base_url_is_available_without_key(settings_mod):
+    # A local base_url makes the backend usable even with no key (Ollama):
+    # is_available()'s api_key falls back to "local" when a base_url is set.
+    state = settings_mod.set_llm_endpoint(
+        settings_mod._LLMEndpointBody(base_url="http://localhost:11434/v1", model="llama3.1")
+    )
+    assert state["api_key_masked"] is None
+    if _HAS_OPENAI:
+        assert state["available"] is True
+
+
+def test_short_key_masks_to_set(settings_mod):
+    state = settings_mod.set_llm_endpoint(
+        settings_mod._LLMEndpointBody(base_url="http://x/v1", api_key="abc")
+    )
+    assert state["api_key_masked"] == "set"


### PR DESCRIPTION
## What

Wave 2.4 of the [parity program](docs/specs/2026-06-12-elevenlabs-parity-program.md) (§R2 rung 4) — a focused Settings panel for the OpenAI-compatible LLM endpoint behind cinematic translate, glossary auto-extract, and dictation refinement (2.1).

- **Persistence reuses what already exists:** the `TRANSLATE_BASE_URL` / `TRANSLATE_MODEL` / `TRANSLATE_API_KEY` env vars are already persistent (system.py `PERSISTENT_KEYS`, restored at startup) and already what `llm_backend`/`translator` read — so this is purely a UI + read/write surface, no resolution-path change. vLLM is a verified OpenAI-compat drop-in; Ollama ignores the key, vLLM/LM Studio require it.
- **`GET/PUT /api/settings/llm-endpoint`** (loopback-gated): read returns base URL, model, **masked** key (last-4, never echoed), and live availability + reason. PUT semantics: a `null` field is left unchanged, an empty string clears it — so a base-url-only save can't accidentally wipe the stored key.
- **Credentials-tab panel:** one-click presets (Ollama / LM Studio / vLLM / OpenAI), base URL + model + optional key fields, reachable/not status badge.

## Verification
- `uv run pytest tests/test_llm_endpoint_settings.py` → 6 passed (read shape, set+mask, null-unchanged, empty-clears, local-url-no-key, short-key masking; availability guarded on `openai` presence)
- `bun run typecheck:ci` clean; `bunx vitest run` 312 passed; CJK gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## LLM Endpoint Settings (Wave 2.4)

This PR adds a focused settings panel and loopback-gated API for configuring an OpenAI‑compatible LLM endpoint used by cinematic translate, glossary auto-extract, and dictation refinement.

### Backend API (/api/settings/llm-endpoint)
- GET: returns current snapshot:
  - base_url, model
  - api_key_masked: None or masked preview (last-4 prefixed with ellipsis; short keys shown as "set")
  - available (bool) and reason (nullable) from OpenAICompatBackend.is_available()
- PUT: accepts optional base_url, model, api_key with smart semantics:
  - null → leave unchanged
  - empty/whitespace string → clear (remove env var + prefs entry)
  - non-empty → save to os.environ and persist (env.<KEY> in prefs)
- Raw API keys are never returned. TRANSLATE_* env vars reused (TRANSLATE_BASE_URL, TRANSLATE_MODEL, TRANSLATE_API_KEY); fallback to OPENAI_API_KEY for masked preview if TRANSLATE_API_KEY absent.

### Frontend UI (Credentials tab)
- New LLMEndpointPanel component:
  - Preset buttons: Ollama / LM Studio / vLLM / OpenAI
  - Inputs: Base URL, Model, API key (typed key only sent to PUT; otherwise omitted)
  - Reachability badge showing available/reason
  - Clears local API key input after successful save; shows load/save errors
- Panel placed in Credentials tab immediately after API Keys panel.

ASCII layout (Credentials tab) — before/after
Before:
┌─ Credentials Tab ───────────────────────────────┐
│ ┌─ API Keys Panel ────────────────────────────┐ │
│ │ [OpenAI key...] [Anthropic key...] etc.     │ │
│ └─────────────────────────────────────────────┘ │
└─────────────────────────────────────────────────┘

After:
┌─ Credentials Tab ───────────────────────────────┐
│ ┌─ API Keys Panel ────────────────────────────┐ │
│ │ [OpenAI key...] [Anthropic key...] etc.     │ │
│ └─────────────────────────────────────────────┘ │
│ ┌─ LLM endpoint (new) ────────────────────────┐ │
│ │ [Ollama] [LM Studio] [vLLM] [OpenAI]        │ │
│ │ Base URL: [......................]         │ │
│ │ Model:    [......................]         │ │
│ │ API key:  [••••••••••••] (stored: …abcd)    │ │
│ │ [Save]                ● reachable / reason  │ │
│ └─────────────────────────────────────────────┘ │
└─────────────────────────────────────────────────┘

Save behavior flow (mermaid)
graph TD
    A[Component mounts or user clicks Save] --> B{Did user type api_key?}
    B -->|Yes| C[Build request with base_url, model, api_key]
    B -->|No| D[Build request with base_url, model (omit api_key)]
    C --> E[PUT /api/settings/llm-endpoint]
    D --> E
    E --> F[Backend persists to env vars + prefs]
    F --> G[Return masked config + availability]
    G --> H[UI updates state; clear local api_key field]

Key save detail: Omitting api_key in the PUT triggers backend None semantics (leave unchanged) — prevents accidental key wiping when changing base URL/model only.

### Tests
- Added pytest module with 6 tests (all passing):
  - initial empty GET (available=False)
  - PUT sets values and masks API key (last-4 or "set")
  - PUT with None leaves field unchanged
  - PUT with empty string clears field
  - Localhost base_url considered available without key
  - Short keys mask to literal "set"

### Files changed & sizes
- backend/api/routers/settings.py — modified (approx. 398 lines)
- frontend/src/components/settings/LLMEndpointPanel.jsx — added (125 lines)
- frontend/src/pages/Settings.jsx — modified (approx. 1850 lines)
- tests/test_llm_endpoint_settings.py — added (89 lines)

### Notes
- No new persistence mechanism: uses existing PERSISTENT_KEYS and prefs syncing.
- vLLM treated as OpenAI-compatible drop-in; Ollama ignores API key; vLLM and LM Studio require it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->