### PR TITLE
fix(settings): remove stray rebase conflict marker

### DIFF
--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -232,7 +232,6 @@ def set_llm_endpoint(body: _LLMEndpointBody):
     # reads env at construction) on every call, so there's no singleton to
     # invalidate — the next translate/refine picks up the new values.
     return _llm_endpoint_state()
->>>>>>> 323f0d3 (feat(settings): remote LLM endpoint UI — Ollama/vLLM/LM Studio (Wave 2.4))
 
 
 # ── License acceptance (Phase 3 Plan 03-01 / TTS-05) ──────────────────────


### PR DESCRIPTION
Hotfix: the #365 rebase left a `>>>>>>> 323f0d3` conflict marker at the end of the LLM-endpoint block in `backend/api/routers/settings.py`, which makes the module fail to import. This strips it.

`python -c 'import ast; ast.parse(...)'` parses clean; `tests/test_llm_endpoint_settings.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Removes a stray rebase conflict marker (`>>>>>>> 323f0d3`) that was accidentally left in `backend/api/routers/settings.py` after a rebase operation. The conflict marker at the end of the LLM-endpoint block was preventing the module from parsing correctly.

## Changes

- **backend/api/routers/settings.py**: Removed 1 line containing the stray conflict marker, allowing the file to parse successfully

## Validation

The fix has been verified to:
- Parse cleanly with Python's AST parser
- Pass the existing test suite (`tests/test_llm_endpoint_settings.py`)

The change is purely a syntax fix with no impact on functionality or the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->