### PR TITLE
feat(dub): per-segment clone references (Wave 3.2)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -367,7 +367,11 @@ _prep_event_helper = dub_pipeline.prep_event  # alias; we keep the module-local 
 
 
 @router.get("/dub/transcribe-stream/{job_id}")
-async def dub_transcribe_stream(job_id: str, num_speakers: Optional[int] = None):
+async def dub_transcribe_stream(
+    job_id: str,
+    num_speakers: Optional[int] = None,
+    per_segment_refs: bool = True,
+):
     """Stream per-chunk segments via SSE, then emit diarized final pass.
 
     Pre-flight checks (missing job, missing audio, ASR not loaded) are emitted
@@ -769,12 +773,41 @@ async def dub_transcribe_stream(job_id: str, num_speakers: Optional[int] = None)
                     clones = done.pop().result()
                     break
                 yield _sse_event("ping", {})
-            if clones:
-                job["speaker_clones"] = clones
-                # Default each segment's profile_id to its speaker's auto-clone,
-                # but only if the user hasn't already assigned something.
+            # Wave 3.2: per-segment clone refs. Cut each long-enough segment's
+            # own reference from the vocals so the dub of each line matches the
+            # prosody of its source line. Short lines fall back to the
+            # per-speaker clone below. Default on; the user can force
+            # per-speaker by disabling it (job["per_segment_refs"]).
+            seg_clones = {}
+            job["per_segment_refs"] = per_segment_refs
+            if per_segment_refs:
+                try:
+                    from services.speaker_clone import extract_segment_refs
+                    seg_ids_for_clone = [s.get("id", i) for i, s in enumerate(final_segs)]
+                    seg_clones = await loop.run_in_executor(
+                        _cpu_pool, lambda: extract_segment_refs(
+                            vocals_for_clone, final_segs,
+                            os.path.dirname(vocals_for_clone),
+                            seg_ids=seg_ids_for_clone,
+                        ),
+                    )
+                    if seg_clones:
+                        job["segment_clones"] = seg_clones
+                except Exception as e:
+                    logger.warning("per-segment clone refs skipped: %s", e)
+
+            if clones or seg_clones:
+                if clones:
+                    job["speaker_clones"] = clones
+                # Default each segment's profile_id to its own per-segment ref
+                # when available, else its speaker's auto-clone — but only if
+                # the user hasn't already assigned something.
                 for s in final_segs:
                     if s.get("profile_id"):
+                        continue
+                    sid = str(s.get("id", ""))
+                    if sid and sid in seg_clones:
+                        s["profile_id"] = f"auto-seg:{sid}"
                         continue
                     spk = s.get("speaker_id") or "Speaker 1"
                     if spk in clones:

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -204,7 +204,17 @@ async def dub_generate(job_id: str, req: DubRequest):
                 # (see services/speaker_clone.py) live at job["speaker_clones"]
                 # keyed by speaker_id. We use the `auto:` prefix so they can't
                 # collide with persistent voice_profiles.id values.
-                if profile_id and profile_id.startswith("auto:"):
+                # Wave 3.2: a per-segment clone ref (cut from this line's own
+                # source audio) takes precedence over the per-speaker clone.
+                if profile_id and profile_id.startswith("auto-seg:"):
+                    sid = profile_id[len("auto-seg:"):]
+                    info = (job.get("segment_clones") or {}).get(sid)
+                    if info:
+                        ref_audio = info.get("ref_audio")
+                        ref_text = info.get("ref_text")
+                    profile_id = None  # prevent the voice_profiles lookup below
+
+                elif profile_id and profile_id.startswith("auto:"):
                     key = profile_id[len("auto:"):]
                     clones = job.get("speaker_clones") or {}
                     # Match by the safe-name key first, fall back to speaker_id.

--- a/backend/services/speaker_clone.py
+++ b/backend/services/speaker_clone.py
@@ -33,6 +33,15 @@ MIN_REF_DURATION_S = 5.0   # below this the clone is thin and unstable
 MAX_REF_DURATION_S = 15.0  # above this is just wasted reference context
 IDEAL_REF_DURATION_S = 8.0  # target window — long enough for prosody, short enough for coverage
 
+# Per-segment clone refs (Wave 3.2): cutting a reference from a single
+# subtitle line gives the dub of that line the prosody/emotion of its source
+# line — but a single line is usually short. We use a lower floor than the
+# per-speaker MIN (5.0): most dialogue lines are 2-6 s, and a 5 s floor would
+# make per-segment refs almost never fire. Below this, the line falls back to
+# the per-speaker reference (which always covers ≥ MIN_REF_DURATION_S). 3.0 s
+# is the empirical floor below which our zero-shot clone gets unstable.
+MIN_SEGMENT_REF_DURATION_S = 3.0
+
 
 def extract_speaker_clones(
     vocals_path: str,
@@ -111,6 +120,74 @@ def extract_speaker_clones(
             ref_path, out[speaker_id]["duration"], len(chosen), "" if len(chosen) == 1 else "s",
         )
 
+    return out
+
+
+def extract_segment_refs(
+    vocals_path: str,
+    segments: list[dict],
+    out_dir: str,
+    *,
+    seg_ids: list | None = None,
+) -> dict[str, dict]:
+    """Per-segment clone references (Wave 3.2 / Spec 4).
+
+    Cut each segment's own slice from the isolated vocals at THAT segment's
+    timestamps, so the dub of each line carries the prosody of its source
+    line — finer-grained than one reference per speaker. Returns a dict keyed
+    by segment id (``seg_ids[i]`` or ``"seg_{i}"``) for segments long enough
+    to clone from:
+
+        {"seg_3": {"ref_audio": "/abs/seg_ref_seg_3.wav",
+                   "ref_text": "the source-language line",
+                   "duration": 4.12}, ...}
+
+    Segments shorter than ``MIN_SEGMENT_REF_DURATION_S`` are omitted — the
+    caller falls back to the per-speaker reference for those (a strict
+    improvement over per-speaker-only, never a regression). Uses the
+    *original* segment timestamps (pre slack-absorption); only the vocals are
+    read, never the raw mix.
+    """
+    if not vocals_path or not os.path.exists(vocals_path) or not segments:
+        return {}
+    try:
+        audio, sr = sf.read(vocals_path, dtype="float32", always_2d=False)
+    except Exception as e:
+        logger.warning("segment_refs: failed to read %s: %s", vocals_path, e)
+        return {}
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+
+    os.makedirs(out_dir, exist_ok=True)
+    out: dict[str, dict] = {}
+    for i, seg in enumerate(segments):
+        seg_id = str(seg_ids[i]) if (seg_ids and i < len(seg_ids)) else f"seg_{i}"
+        start = float(seg.get("start", 0.0))
+        end = float(seg.get("end", 0.0))
+        if end - start < MIN_SEGMENT_REF_DURATION_S:
+            continue
+        s = max(0, int(start * sr))
+        e = min(audio.size, int(end * sr))
+        if e <= s:
+            continue
+        clip = audio[s:e].astype(np.float32, copy=False)
+        ref_path = os.path.join(out_dir, f"seg_ref_{_safe_name(seg_id)}.wav")
+        try:
+            sf.write(ref_path, clip, sr)
+        except Exception as e2:
+            logger.warning("segment_refs: failed to write %s: %s", ref_path, e2)
+            continue
+        # The vocals slice is source-language audio, so the matching
+        # reference transcript is the SOURCE text (text_original), not the
+        # translated `text`. Falls back to text only if no original is kept.
+        ref_text = (seg.get("text_original") or seg.get("text") or "").strip()
+        out[seg_id] = {
+            "ref_audio": ref_path,
+            "ref_text": ref_text,
+            "duration": float(clip.size) / float(sr),
+        }
+    if out:
+        logger.info("segment_refs: wrote %d per-segment reference(s)", len(out))
     return out
 
 

--- a/tests/test_segment_refs.py
+++ b/tests/test_segment_refs.py
@@ -1,0 +1,83 @@
+"""Per-segment clone references (Wave 3.2 / Spec 4).
+
+Pure tests over a synthetic vocals wav — no model, no main import.
+"""
+import os
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from services import speaker_clone
+from services.speaker_clone import (
+    MIN_SEGMENT_REF_DURATION_S,
+    extract_segment_refs,
+)
+
+SR = 16000
+
+
+@pytest.fixture
+def vocals(tmp_path):
+    # 20 s of non-silent audio so every segment slice has content.
+    path = tmp_path / "vocals.wav"
+    sf.write(str(path), np.float32(np.sin(np.linspace(0, 6000, 20 * SR))), SR)
+    return str(path)
+
+
+def test_long_segments_get_their_own_ref(tmp_path, vocals):
+    segs = [
+        {"start": 0.0, "end": 4.0, "text": "primera linea", "text_original": "first line"},
+        {"start": 5.0, "end": 9.5, "text": "segunda", "text_original": "second line"},
+    ]
+    out = extract_segment_refs(vocals, segs, str(tmp_path), seg_ids=["a", "b"])
+    assert set(out) == {"a", "b"}
+    assert os.path.exists(out["a"]["ref_audio"])
+    # Reference transcript is the SOURCE text, not the translation.
+    assert out["a"]["ref_text"] == "first line"
+    assert out["a"]["duration"] == pytest.approx(4.0, abs=0.05)
+    assert out["b"]["duration"] == pytest.approx(4.5, abs=0.05)
+
+
+def test_short_segment_is_omitted_for_fallback(tmp_path, vocals):
+    segs = [
+        {"start": 0.0, "end": 1.5, "text": "x", "text_original": "short"},   # < 3.0 floor
+        {"start": 2.0, "end": 6.0, "text": "y", "text_original": "long enough"},
+    ]
+    out = extract_segment_refs(vocals, segs, str(tmp_path), seg_ids=["s", "l"])
+    assert "s" not in out  # too short → caller falls back to per-speaker ref
+    assert "l" in out
+
+
+def test_default_seg_ids_when_unspecified(tmp_path, vocals):
+    segs = [{"start": 0.0, "end": 4.0, "text": "a", "text_original": "a"}]
+    out = extract_segment_refs(vocals, segs, str(tmp_path))
+    assert "seg_0" in out
+
+
+def test_text_falls_back_to_translation_without_original(tmp_path, vocals):
+    segs = [{"start": 0.0, "end": 4.0, "text": "only translated"}]
+    out = extract_segment_refs(vocals, segs, str(tmp_path), seg_ids=["k"])
+    assert out["k"]["ref_text"] == "only translated"
+
+
+def test_clip_clamped_to_audio_bounds(tmp_path, vocals):
+    # end beyond the 20 s file → clamped, still produced.
+    segs = [{"start": 18.0, "end": 25.0, "text": "t", "text_original": "tail"}]
+    out = extract_segment_refs(vocals, segs, str(tmp_path), seg_ids=["t"])
+    assert out["t"]["duration"] == pytest.approx(2.0, abs=0.05)  # 18→20
+
+
+def test_missing_vocals_returns_empty(tmp_path):
+    assert extract_segment_refs("/no/such.wav", [{"start": 0, "end": 5}], str(tmp_path)) == {}
+    assert extract_segment_refs("", [], str(tmp_path)) == {}
+
+
+def test_floor_boundary(tmp_path, vocals):
+    # exactly at the floor is kept; just under is dropped.
+    segs = [
+        {"start": 0.0, "end": MIN_SEGMENT_REF_DURATION_S, "text_original": "at floor"},
+        {"start": 6.0, "end": 6.0 + MIN_SEGMENT_REF_DURATION_S - 0.1, "text_original": "under"},
+    ]
+    out = extract_segment_refs(vocals, segs, str(tmp_path), seg_ids=["at", "under"])
+    assert "at" in out and "under" not in out


### PR DESCRIPTION
## What

Wave 3.2 of the [parity program](docs/specs/2026-06-12-elevenlabs-parity-program.md) (Spec 4). Cut each dub segment's clone reference from the isolated vocals at **that segment's own timestamps**, so each dubbed line carries the prosody/emotion of its source line — finer-grained than today's one-reference-per-speaker. Reimplemented from the clean-room functional spec (pyvideotrans's per-line idea; no GPL code).

**Our design delta — a quality floor with fallback.** pyvideotrans uses no floor (a 400 ms line → a 400 ms ref). We omit segments shorter than `MIN_SEGMENT_REF_DURATION_S = 3.0` and fall back to the existing per-speaker clone for those — a strict improvement over per-speaker-only, never a regression. (3.0, not the per-speaker 5.0: most dialogue lines fall under 5 s, so a 5 s floor would make per-segment refs almost never fire.)

- **`extract_segment_refs()`** keyed by segment id; reference transcript is the **source** text (`text_original`), since the vocals slice is source-language audio.
- **dub_core** runs extraction at transcribe (`per_segment_refs` query param, default on), stores `job['segment_clones']`, and defaults each unassigned segment's `profile_id` to `auto-seg:{id}` when it has its own ref, else the existing `auto:{speaker}`. `per_segment_refs=false` forces per-speaker for long-form consistency.
- **dub_generate `_gen`** resolves `auto-seg:` ahead of the per-speaker `auto:` path. `profile_id` is already a fingerprint field, so flipping the mode re-dubs automatically.

## Verification
- `uv run pytest tests/test_segment_refs.py` → 7 passed (own-ref for long lines, short-line omission→fallback, source-text transcript, bounds clamping, floor boundary, missing-vocals)
- `py_compile` on the three touched backend modules; CJK gate green; pipeline wiring validated in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Per-Segment Clone References (Wave 3.2)

This PR introduces per-segment clone references for dub generation, enabling finer-grained prosody and emotion matching by using segment-specific reference audio extracted from isolated vocals at each segment's own timestamps, instead of a single reference per speaker.

### Key Implementation Details

**Segment Reference Extraction** (`backend/services/speaker_clone.py`)
- Added `extract_segment_refs()` function that reads Demucs-isolated `vocals.wav` and slices it per segment timestamp
- Writes `seg_ref_*.wav` files only for segments ≥ `MIN_SEGMENT_REF_DURATION_S = 3.0` seconds
- Returns dict keyed by segment id with `ref_audio`, `ref_text` (preferring `text_original`), and `duration`
- Segments shorter than 3.0s are omitted to enable fallback to per-speaker clones

**Transcription Integration** (`backend/api/routers/dub_core.py`)
- Added `per_segment_refs: bool = True` query parameter to `/dub/transcribe-stream/{job_id}`
- Extracts segment references during transcription with opt-out via `per_segment_refs=false`
- Stores segment references in `job["segment_clones"]`
- Sets each segment's `profile_id` to `auto-seg:{segment_id}` when a matching segment ref exists, otherwise falls back to per-speaker `auto:{speaker}`

**Generation Resolution** (`backend/api/routers/dub_generate.py`)
- During per-segment generation flow, `profile_id` values prefixed with `auto-seg:` trigger lookup of per-segment clone reference from `job["segment_clones"][segment_id]`
- Uses the segment-specific `ref_audio`/`ref_text` for generation, then clears `profile_id` to skip the per-speaker `auto:` lookup
- Preserves any pre-existing `profile_id` values

### Behavior Flow

```mermaid
flowchart TD
    A["Transcription with per_segment_refs=true"] --> B["extract_segment_refs from isolated vocals"]
    B --> C{Segment duration >= 3.0s?}
    C -->|Yes| D["Create per-segment clone ref<br/>profile_id = auto-seg:{id}"]
    C -->|No| E["Omit segment from refs"]
    D --> F["Store in job[segment_clones]"]
    E --> G["Fall back to per-speaker"]
    F --> H["Generation Phase"]
    G --> H
    H --> I{Check profile_id prefix}
    I -->|auto-seg:*| J["Resolve from job[segment_clones]<br/>Use segment ref_audio/ref_text"]
    I -->|auto:*| K["Fall back to per-speaker clone"]
    J --> L["Generate dub with segment-specific prosody"]
    K --> L
```

### Testing

New test suite `tests/test_segment_refs.py` (7 tests) validates:
- Long segments receive their own clone references with expected audio presence
- Short segments are properly omitted for fallback behavior
- Reference transcript sourcing from `text_original` with `text` fallback
- Duration calculations with segment boundary clamping
- Default segment ID generation as `seg_{i}` when unspecified
- Missing/empty vocals input handling
- Minimum-duration floor boundary conditions

### Changes Summary

| File | Changes | Effort |
|------|---------|--------|
| `backend/api/routers/dub_core.py` | +38/-5 | Medium |
| `backend/api/routers/dub_generate.py` | +11/-1 | Medium |
| `backend/services/speaker_clone.py` | +77/-0 | Medium |
| `tests/test_segment_refs.py` | +83/-0 | Medium |

### Public API Changes

- `dub_transcribe_stream()` signature: added `per_segment_refs: bool = True` parameter
- `extract_segment_refs()`: new function in `speaker_clone.py` for segment reference extraction
- Module constant: `MIN_SEGMENT_REF_DURATION_S = 3.0` in `speaker_clone.py`

The feature is enabled by default (`per_segment_refs=true`) and can be disabled via query parameter to preserve per-speaker behavior. Since `profile_id` remains a fingerprint field, changing the mode automatically re-dubs affected segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->