### PR TITLE
ci(docker): also publish to Docker Hub palashdeb/omnivoice-studio

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,9 @@
 #   :0.3      — major.minor floating tag (updated on every patch within the minor)
 #   :sha-xxxx — specific commit SHA; produced by workflow_dispatch
 #
-# Images land at: ghcr.io/debpalash/omnivoice-studio
+# Images land at: ghcr.io/debpalash/omnivoice-studio AND docker.io/palashdeb/omnivoice-studio
+# (Docker Hub push gated on the DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets;
+# if unset the build still pushes to GHCR.)
 #
 # NOTE: the Docker image is the headless web-server build of OmniVoice (FastAPI
 # backend + pre-built React frontend served over HTTP).  The Tauri desktop
@@ -36,6 +38,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DOCKERHUB_IMAGE: palashdeb/omnivoice-studio
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
@@ -58,6 +61,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Docker Hub login — only when the secret is present, so forks / runs
+      # without the credential still publish to GHCR.
+      - name: Check Docker Hub credentials
+        id: dockerhub
+        run: echo "enabled=${{ secrets.DOCKERHUB_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Tag strategy (`:sha-<short>` is emitted on every trigger):
       #   v0.3.6 tag push   → :0.3.6, :0.3, :stable, :sha-
       #   main branch push  → :latest, :main, :sha-
@@ -71,7 +87,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Same tag set applied to both registries. The Docker Hub line is
+          # blank when the secret is unset, so metadata-action emits GHCR-only
+          # tags in that case.
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ steps.dockerhub.outputs.enabled == 'true' && env.DOCKERHUB_IMAGE || '' }}
           tags: |
             type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' }}

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -32,6 +32,12 @@ docker run -d --name omnivoice \
   ghcr.io/debpalash/omnivoice-studio:latest
 ```
 
+> **Docker Hub mirror:** the same images are published to
+> `palashdeb/omnivoice-studio` on Docker Hub with identical tags — swap the
+> image for `palashdeb/omnivoice-studio:latest` if you prefer Docker Hub.
+> Tag semantics (`:latest` = rolling main preview, `:stable`/`:X.Y.Z` =
+> releases) are the same on both registries.
+
 Open [http://localhost:3900](http://localhost:3900). The first run downloads
 ~2.4 GB of model weights — follow `docker logs -f omnivoice` to watch.
 


### PR DESCRIPTION
Publishes the same images (same tags: `:latest` rolling main, `:stable`/`:X.Y.Z` releases, `:sha-`) to **docker.io/palashdeb/omnivoice-studio** alongside GHCR, for every main push and `v*` tag.

- Gated on `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets — if unset, the build publishes to GHCR only (forks unaffected).
- metadata-action gets both image names, so one tag set covers both registries.
- Docs-sync: `docs/install/docker.md` gains a Docker Hub mirror note.

**Action needed:** add repo secrets `DOCKERHUB_USERNAME` (`palashdeb`) and `DOCKERHUB_TOKEN` (a Docker Hub access token) for the push to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### `.github/workflows/docker.yml`
Added conditional Docker Hub publishing alongside existing GHCR publishing:
- Detects presence of `DOCKERHUB_TOKEN` secret
- Performs Docker Hub login only when credentials are available
- Updates `docker/metadata-action` to conditionally include Docker Hub image targets
- Maintains existing build, push, and tagging behavior (semver/major-minor/stable/latest/main/sha-)

**Publishing flow:**

```mermaid
graph TD
    A["Trigger: Push/Release"] --> B{DOCKERHUB_TOKEN<br/>secret exists?}
    B -->|Yes| C["Log into Docker Hub"]
    B -->|No| D["Skip Docker Hub login"]
    C --> E["Include Docker Hub tags:<br/>palashdeb/omnivoice-studio"]
    D --> F["Include GHCR tags only:<br/>ghcr.io/debpalash/omnivoice-studio"]
    E --> G["Build & push to both registries"]
    F --> H["Build & push to GHCR only"]
    G --> I["Complete"]
    H --> I
```

This design allows forks and repositories without Docker Hub secrets to continue working unaffected, pushing only to GHCR.

### `docs/install/docker.md`
Added documentation note explaining the Docker Hub mirror:
- Clarifies that `palashdeb/omnivoice-studio` on Docker Hub carries identical images and tag semantics
- Users can swap the image reference from GHCR to Docker Hub without changing version behavior
- Tag semantics remain consistent across both registries (`:latest` = rolling main, `:stable`/`:X.Y.Z` = releases)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->