### PR TITLE
feat(studio): consolidate Clone + Design into one Voice workspace (spec P4)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -107,6 +107,10 @@ function App() {
   }, [locale, theme, font]);
   const mode = useAppStore(s => s.mode);
   const setMode = useAppStore(s => s.setMode);
+  // "Define voice" method inside the Voice (studio) workspace — replaces the
+  // old clone/design navigation split (voice-studio-unification P4).
+  const defineMethod = useAppStore(s => s.defineMethod);
+  const setDefineMethod = useAppStore(s => s.setDefineMethod);
   // Breadcrumb every view change — mode names are a closed set, so this is
   // privacy-safe by construction (see utils/breadcrumbs.js).
   useEffect(() => { addBreadcrumb(`view:${mode}`); }, [mode]);
@@ -163,9 +167,9 @@ function App() {
   const hideSidebar = mode === 'launchpad' || mode === 'settings' || mode === 'voice' || mode === 'donate'
     || mode === 'queue' || mode === 'tools' || mode === 'projects' || mode === 'gallery' || mode === 'enterprise' || mode === 'transcriptions'
     || mode === 'stories'
-    // Voice (clone/design) and Dub workspaces moved their saved voices /
+    // Voice (studio) and Dub workspaces moved their saved voices /
     // projects + history into right-side panels; left sidebar dissolved.
-    || mode === 'clone' || mode === 'design' || mode === 'dub';
+    || mode === 'studio' || mode === 'dub';
   const availableSidebarTabs = [];
   // Generate-tab prefs now live in `generateSlice` (Phase 2.2). Persisted
   // knobs survive reloads via the store's `partialize`.
@@ -236,7 +240,7 @@ function App() {
 
   // ═══ PENDING PROFILE HAND-OFF ═══
   // Views like the Gallery hand a freshly-created profile to the synthesis view
-  // via store.pendingProfileId + setMode('clone'). The profile may not be in the
+  // via store.pendingProfileId + setMode('studio'). The profile may not be in the
   // loaded list yet (it arrives via loadProfiles / the realtime `profiles` event),
   // so we wait for it to appear, select it, then clear the hand-off.
   const pendingProfileId = useAppStore(s => s.pendingProfileId);
@@ -841,7 +845,15 @@ function App() {
   };
 
   const restoreHistory = (item) => {
-    if (item.mode) setMode(item.mode);
+    // History `mode` values stay 'clone'/'design' forever — only the
+    // navigation mode id changed. Map them onto the unified 'studio'
+    // workspace + its define method (voice-studio-unification P4).
+    if (item.mode === 'clone' || item.mode === 'design') {
+      setMode('studio');
+      setDefineMethod(item.mode === 'clone' ? 'audio' : 'design');
+    } else if (item.mode) {
+      setMode(item.mode);
+    }
     if (item.text) setText(item.text);
     if (item.language) setLanguage(item.language);
     if (item.profile_id) setSelectedProfile(item.profile_id);
@@ -1154,7 +1166,6 @@ function App() {
           <ErrorBoundary name="clone-design">
           <Suspense fallback={<LazyFallback />}>
             <CloneDesignTab
-              mode={mode}
               textAreaRef={textAreaRef}
               text={text} setText={setText}
               language={language} setLanguage={setLanguage}
@@ -1194,7 +1205,7 @@ function App() {
           </div>
           <div className="studio-right">
             <WorkspaceVoices
-              mode={mode}
+              defineMethod={defineMethod}
               profiles={profiles}
               selectedProfile={selectedProfile}
               previewLoading={previewLoading}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -9,6 +9,9 @@ import { useSysinfo } from '../api/hooks';
 
 const VIEW_META = {
   launchpad:  { labelKey: 'header.label_launchpad',  Icon: Globe,       accent: '#f3a5b6', kickerKey: 'header.kicker_studio' },
+  studio:     { labelKey: 'nav.voice',                Icon: Fingerprint, accent: '#d3869b', kickerKey: 'header.kicker_studio' },
+  // Legacy ids — kept so a not-yet-shimmed persisted 'clone'/'design' mode
+  // still renders a sensible header (voice-studio-unification P4).
   clone:      { labelKey: 'header.label_clone',       Icon: Fingerprint, accent: '#d3869b', kickerKey: 'header.kicker_studio' },
   design:     { labelKey: 'header.label_design',      Icon: Wand2,       accent: '#8ec07c', kickerKey: 'header.kicker_studio' },
   dub:        { labelKey: 'header.label_dub',         Icon: Film,        accent: '#fe8019', kickerKey: 'header.kicker_studio' },

--- a/frontend/src/components/NavRail.jsx
+++ b/frontend/src/components/NavRail.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Globe, Fingerprint, Wand2, Film, FolderOpen, Settings2, ArrowLeftRight,
+  Globe, Fingerprint, Film, FolderOpen, Settings2, ArrowLeftRight,
   Library, FileText, BookOpen,
 } from 'lucide-react';
 
 const ITEM_DEFS = [
   { id: 'launchpad',     Icon: Globe,       tKey: 'launchpad',   accent: '#f3a5b6' },
-  { id: 'clone',         Icon: Fingerprint, tKey: 'clone',       accent: '#d3869b' },
-  { id: 'design',        Icon: Wand2,       tKey: 'design',      accent: '#8ec07c' },
+  { id: 'studio',        Icon: Fingerprint, tKey: 'voice',       accent: '#d3869b' },
   { id: 'dub',           Icon: Film,        tKey: 'dub',         accent: '#fe8019' },
   { id: 'stories',       Icon: BookOpen,    tKey: 'stories',     accent: '#fabd2f' },
   { id: 'gallery',       Icon: Library,     tKey: 'gallery',     accent: '#b8bb26' },

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -81,6 +81,9 @@ export default function Sidebar(props) {
 
   // Phase 2.2 — read UI + dub state straight from the store.
   const mode               = useAppStore(s => s.mode);
+  // Voice ('studio') workspace's define method — scopes which profiles show
+  // ('audio' = reference clones, 'design' = designed voices).
+  const defineMethod       = useAppStore(s => s.defineMethod);
   const isSidebarCollapsed = useAppStore(s => s.isSidebarCollapsed);
   const dubStep            = useAppStore(s => s.dubStep);
   const activeProjectId    = useAppStore(s => s.activeProjectId);
@@ -115,7 +118,7 @@ export default function Sidebar(props) {
   };
 
   const tabCount = {
-    projects: mode === 'dub' ? studioProjects.length : (mode === 'clone' ? profiles.filter(p => !p.instruct).length : profiles.filter(p => !!p.instruct).length),
+    projects: mode === 'dub' ? studioProjects.length : (defineMethod === 'audio' ? profiles.filter(p => !p.instruct).length : profiles.filter(p => !!p.instruct).length),
     history: history.length + dubHistory.length,
     downloads: exportHistory.length,
   };
@@ -195,7 +198,7 @@ export default function Sidebar(props) {
                 className="sidebar__section-title"
                 onClick={() => setIsSidebarProjectsCollapsed(!isSidebarProjectsCollapsed)}
               >
-                <span>{mode === 'dub' ? t('sidebar.dub_projects') : (mode === 'clone' ? t('sidebar.voice_clones') : t('sidebar.designed_voices'))}</span>
+                <span>{mode === 'dub' ? t('sidebar.dub_projects') : (defineMethod === 'audio' ? t('sidebar.voice_clones') : t('sidebar.designed_voices'))}</span>
                 {isSidebarProjectsCollapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}
               </div>
             )}
@@ -247,18 +250,18 @@ export default function Sidebar(props) {
                   </>
                 )}
 
-                {(mode === 'clone' || mode === 'design') && (
+                {mode === 'studio' && (
                   <>
-                    {filteredProfiles.filter(p => mode === "clone" ? !p.instruct : !!p.instruct).length === 0 ? (
+                    {filteredProfiles.filter(p => defineMethod === 'audio' ? !p.instruct : !!p.instruct).length === 0 ? (
                       <EmptyState
-                        icon={mode === 'clone' ? Fingerprint : Wand2}
-                        title={`${mode === 'clone' ? t('sidebar.no_clones') : t('sidebar.no_designs')}`}
-                        hint={mode === 'clone' ? t('sidebar.no_clones_hint') : t('sidebar.no_designs_hint')}
+                        icon={defineMethod === 'audio' ? Fingerprint : Wand2}
+                        title={`${defineMethod === 'audio' ? t('sidebar.no_clones') : t('sidebar.no_designs')}`}
+                        hint={defineMethod === 'audio' ? t('sidebar.no_clones_hint') : t('sidebar.no_designs_hint')}
                       />
                     ) : (
-                      (mode === 'clone' ? filteredProfiles.filter(p => !p.instruct) : filteredProfiles.filter(p => !!p.instruct)).map(proj => {
-                        const accent = proj.is_locked ? '#b8bb26' : (mode === 'clone' ? '#d3869b' : '#8ec07c');
-                        const KindIcon = proj.is_locked ? Lock : (mode === 'clone' ? Fingerprint : Wand2);
+                      (defineMethod === 'audio' ? filteredProfiles.filter(p => !p.instruct) : filteredProfiles.filter(p => !!p.instruct)).map(proj => {
+                        const accent = proj.is_locked ? '#b8bb26' : (defineMethod === 'audio' ? '#d3869b' : '#8ec07c');
+                        const KindIcon = proj.is_locked ? Lock : (defineMethod === 'audio' ? Fingerprint : Wand2);
                         return (
                           <div key={proj.id}
                             className={`history-item ${selectedProfile === proj.id ? 'project-active' : ''}`}
@@ -267,7 +270,7 @@ export default function Sidebar(props) {
                           >
                             <div className="history-row-head">
                               <span className="history-kind" style={{ color: accent, borderColor: `${accent}40` }}>
-                                <KindIcon size={9} /> {proj.is_locked ? t('sidebar.locked') : (mode === 'clone' ? t('sidebar.clone_label') : t('sidebar.design_label'))}
+                                <KindIcon size={9} /> {proj.is_locked ? t('sidebar.locked') : (defineMethod === 'audio' ? t('sidebar.clone_label') : t('sidebar.design_label'))}
                               </span>
                               {proj.is_locked ? <span className="history-meta history-meta--locked">{t('sidebar.consistent')}</span> : null}
                             </div>
@@ -329,7 +332,7 @@ export default function Sidebar(props) {
               </IconTile>
             ))}
 
-            {isSidebarCollapsed && (mode === 'clone' || mode === 'design') && (mode === 'clone' ? filteredProfiles.filter(p => !p.instruct) : filteredProfiles.filter(p => !!p.instruct)).map(proj => (
+            {isSidebarCollapsed && mode === 'studio' && (defineMethod === 'audio' ? filteredProfiles.filter(p => !p.instruct) : filteredProfiles.filter(p => !!p.instruct)).map(proj => (
               <IconTile
                 key={proj.id}
                 title={`Select: ${proj.name}`}
@@ -337,7 +340,7 @@ export default function Sidebar(props) {
                 active={selectedProfile === proj.id}
                 rotSeed={proj.id}
               >
-                {mode === 'clone' ? <Fingerprint size={18} /> : <Wand2 size={18} />}
+                {defineMethod === 'audio' ? <Fingerprint size={18} /> : <Wand2 size={18} />}
                 {proj.is_locked && <Lock size={8} className="sidebar__icon-tile__lock" />}
               </IconTile>
             ))}

--- a/frontend/src/components/WorkspaceVoices.jsx
+++ b/frontend/src/components/WorkspaceVoices.jsx
@@ -4,8 +4,8 @@
  * Relocates the saved-profile list that used to live in the left Sidebar
  * (the "Designed voices" / "Voice clones" section) to the right column, so
  * the Voice workspace can dissolve the left sidebar entirely. Profiles are
- * scoped by define-method: clone mode shows reference-audio profiles
- * (no instruct), design mode shows designed profiles (have instruct).
+ * scoped by define-method: 'audio' shows reference-audio profiles
+ * (no instruct), 'design' shows designed profiles (have instruct).
  *
  * Card markup + actions mirror the former Sidebar section 1:1 (select,
  * preview, open full profile, try-voice, unlock, delete) so behavior is
@@ -19,7 +19,7 @@ import {
 import './WorkspaceVoices.css';
 
 export default function WorkspaceVoices({
-  mode,
+  defineMethod,
   profiles = [],
   selectedProfile,
   previewLoading,
@@ -35,15 +35,15 @@ export default function WorkspaceVoices({
   const qLower = q.trim().toLowerCase();
 
   const items = useMemo(() => {
-    const byMode = profiles.filter(p => (mode === 'clone' ? !p.instruct : !!p.instruct));
-    if (!qLower) return byMode;
-    return byMode.filter(p =>
+    const byMethod = profiles.filter(p => (defineMethod === 'audio' ? !p.instruct : !!p.instruct));
+    if (!qLower) return byMethod;
+    return byMethod.filter(p =>
       (p.name || '').toLowerCase().includes(qLower) ||
       (p.instruct || '').toLowerCase().includes(qLower)
     );
-  }, [profiles, mode, qLower]);
+  }, [profiles, defineMethod, qLower]);
 
-  const title = mode === 'clone' ? t('sidebar.voice_clones') : t('sidebar.designed_voices');
+  const title = defineMethod === 'audio' ? t('sidebar.voice_clones') : t('sidebar.designed_voices');
 
   return (
     <section className={`wv ${items.length === 0 ? 'wv--collapsed' : ''}`}>
@@ -63,13 +63,13 @@ export default function WorkspaceVoices({
       <div className="wv__scroll">
         {items.length === 0 ? (
           <div className="wv__empty">
-            {mode === 'clone'
+            {defineMethod === 'audio'
               ? t('sidebar.no_clones', { defaultValue: 'No voice clones yet' })
               : t('sidebar.no_designs', { defaultValue: 'No designed voices yet' })}
           </div>
         ) : items.map(proj => {
-          const accent = proj.is_locked ? '#b8bb26' : (mode === 'clone' ? '#d3869b' : '#8ec07c');
-          const KindIcon = proj.is_locked ? Lock : (mode === 'clone' ? Fingerprint : Wand2);
+          const accent = proj.is_locked ? '#b8bb26' : (defineMethod === 'audio' ? '#d3869b' : '#8ec07c');
+          const KindIcon = proj.is_locked ? Lock : (defineMethod === 'audio' ? Fingerprint : Wand2);
           return (
             <div
               key={proj.id}
@@ -79,7 +79,7 @@ export default function WorkspaceVoices({
             >
               <div className="history-row-head">
                 <span className="history-kind" style={{ color: accent, borderColor: `${accent}40` }}>
-                  <KindIcon size={9} /> {proj.is_locked ? t('sidebar.locked') : (mode === 'clone' ? t('sidebar.clone_label') : t('sidebar.design_label'))}
+                  <KindIcon size={9} /> {proj.is_locked ? t('sidebar.locked') : (defineMethod === 'audio' ? t('sidebar.clone_label') : t('sidebar.design_label'))}
                 </span>
                 {proj.is_locked ? <span className="history-meta history-meta--locked">{t('sidebar.consistent')}</span> : null}
               </div>

--- a/frontend/src/hooks/useAppData.js
+++ b/frontend/src/hooks/useAppData.js
@@ -18,6 +18,8 @@ import { toast } from 'react-hot-toast';
 export default function useAppData() {
   const mode = useAppStore(s => s.mode);
   const setMode = useAppStore(s => s.setMode);
+  const defineMethod = useAppStore(s => s.defineMethod);
+  const setDefineMethod = useAppStore(s => s.setDefineMethod);
   const uiScale = useAppStore(s => s.uiScale);
   const setUiScale = useAppStore(s => s.setUiScale);
   const setText = useAppStore(s => s.setText);
@@ -134,7 +136,13 @@ export default function useAppData() {
       const saved = JSON.parse(localStorage.getItem('omni_ui') || '{}');
       if (saved.uiScale) setUiScale(saved.uiScale);
       if (saved.text) setText(saved.text);
-      if (saved.mode) setMode(saved.mode);
+      // Legacy shim (voice-studio-unification P4): the old 'clone'/'design'
+      // navigation modes are now one 'studio' workspace; the split lives on
+      // as the defineMethod ('audio'|'design').
+      if (saved.mode === 'clone') { setMode('studio'); setDefineMethod('audio'); }
+      else if (saved.mode === 'design') { setMode('studio'); setDefineMethod('design'); }
+      else if (saved.mode) setMode(saved.mode);
+      if (saved.defineMethod) setDefineMethod(saved.defineMethod);
       if (saved.vdStates) setVdStates(saved.vdStates);
       if (saved.language) setLanguage(saved.language);
       if (saved.isSidebarCollapsed !== undefined) setIsSidebarCollapsed(saved.isSidebarCollapsed);
@@ -164,14 +172,14 @@ export default function useAppData() {
   // ── Persist to localStorage ──
   useEffect(() => {
     localStorage.setItem('omni_ui', JSON.stringify({
-      uiScale, text, mode, vdStates, language,
+      uiScale, text, mode, defineMethod, vdStates, language,
       isSidebarCollapsed, sidebarTab,
       dubJobId, dubFilename, dubDuration, dubSegments,
       dubLang, dubLangCode, dubTracks, dubStep, dubTranscript,
       exportTracks, preserveBg, defaultTrack, exportHistory,
       speed, steps, cfg, denoise, showOverrides
     }));
-  }, [uiScale, text, mode, vdStates, language, isSidebarCollapsed, sidebarTab,
+  }, [uiScale, text, mode, defineMethod, vdStates, language, isSidebarCollapsed, sidebarTab,
     dubJobId, dubFilename, dubDuration, dubSegments, dubLang, dubLangCode,
     dubTracks, dubStep, dubTranscript, exportTracks, preserveBg, defaultTrack,
     exportHistory, speed, steps, cfg, denoise, showOverrides

--- a/frontend/src/hooks/useProfiles.js
+++ b/frontend/src/hooks/useProfiles.js
@@ -27,6 +27,7 @@ export default function useProfiles({ loadHistory, loadProfiles }) {
   const setInstruct = useAppStore(s => s.setInstruct);
   const setLanguage = useAppStore(s => s.setLanguage);
   const setVdStates = useAppStore(s => s.setVdStates);
+  const setDefineMethod = useAppStore(s => s.setDefineMethod);
   const language = useAppStore(s => s.language);
   const mode = useAppStore(s => s.mode);
   const steps = useAppStore(s => s.steps);
@@ -67,6 +68,9 @@ export default function useProfiles({ loadHistory, loadProfiles }) {
     setRefText(profile.ref_text || '');
     setInstruct(profile.instruct || '');
     if (profile.language && profile.language !== 'Auto') setLanguage(profile.language);
+    // The profile's kind picks the "Define voice" method implicitly: design
+    // profiles open the design controls, everything else the audio path.
+    setDefineMethod(profile.kind === 'design' ? 'design' : 'audio');
     // Design profiles (0005) carry their category picks — restore the sliders
     // so selecting one makes it re-editable, not just re-usable.
     if (profile.kind === 'design' && profile.vd_states) {
@@ -75,7 +79,7 @@ export default function useProfiles({ loadHistory, loadProfiles }) {
         if (parsed && typeof parsed === 'object') setVdStates(parsed);
       } catch { /* malformed stored state — sliders keep their current values */ }
     }
-  }, [setRefText, setInstruct, setLanguage, setVdStates]);
+  }, [setRefText, setInstruct, setLanguage, setVdStates, setDefineMethod]);
 
   /** Save the current design (vd_states + instruct) as a reusable profile.
       The backend renders a deterministic identity sample (seed 42). */

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -32,7 +32,10 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
   const postprocess = useAppStore(s => s.postprocess);
   const duration = useAppStore(s => s.duration);
   const vdStates = useAppStore(s => s.vdStates);
-  const mode = useAppStore(s => s.mode);
+  // Which "Define voice" method is active in the Voice (studio) workspace —
+  // 'audio' (reference clip) vs 'design' (described attributes). Replaces the
+  // old clone/design navigation-mode checks (voice-studio-unification P4).
+  const defineMethod = useAppStore(s => s.defineMethod);
   const setSidebarTab = useAppStore(s => s.setSidebarTab);
 
   const [refAudio, setRefAudio] = useState(null);
@@ -70,8 +73,8 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
 
   const handleGenerate = useCallback(async () => {
     if (!text.trim()) return toast.error(t('tts_errors.enter_text'));
-    if (mode === 'clone' && !refAudio && !selectedProfile) return toast.error(t('tts_errors.upload_or_select'));
-    addBreadcrumb(`generate:start (${mode})`);
+    if (defineMethod === 'audio' && !refAudio && !selectedProfile) return toast.error(t('tts_errors.upload_or_select'));
+    addBreadcrumb(`generate:start (${defineMethod})`);
     setIsGenerating(true);
     setGenerationTime(0);
     const st = Date.now();
@@ -98,7 +101,7 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
       formData.append("postprocess_output", postprocess);
       if (duration) formData.append("duration", parseFloat(duration));
 
-      if (mode === 'clone') {
+      if (defineMethod === 'audio') {
         if (selectedProfile) {
           formData.append("profile_id", selectedProfile);
         } else if (refAudio) {
@@ -171,7 +174,7 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
       clearInterval(timerRef.current);
       setIsGenerating(false);
     }
-  }, [text, mode, selectedProfile, refAudio, refText, language, instruct, steps, cfg, speed, denoise, tShift, posTemp, classTemp, layerPenalty, postprocess, duration, vdStates, loadHistory, setSidebarTab]);
+  }, [text, defineMethod, selectedProfile, refAudio, refText, language, instruct, steps, cfg, speed, denoise, tShift, posTemp, classTemp, layerPenalty, postprocess, duration, vdStates, loadHistory, setSidebarTab]);
 
   return {
     refAudio, setRefAudio,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -95,6 +95,7 @@
   },
   "nav": {
     "launchpad": "Launchpad",
+    "voice": "Voice",
     "clone": "Clone",
     "design": "Design",
     "dub": "Dub",

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -13,7 +13,8 @@ import { POPULAR_LANGS, PRESETS, TAGS, CATEGORIES } from '../utils/constants';
 import {
   PRESET_ICONS, PERSONALITY_ICONS, FALLBACK_VOICE_ICON, FALLBACK_PERSONALITY_ICON, stripVoiceEmoji,
 } from '../utils/voiceIcons';
-import { Button, Input, Slider, Progress } from '../ui';
+import { Button, Input, Slider, Progress, Segmented } from '../ui';
+import { useAppStore } from '../store';
 import { API, apiPost } from '../api/client';
 import { mergeDescribedAttrs, buildDesignInstruct } from '../utils/voiceInstruct';
 import { listEngines } from '../api/engines';
@@ -22,7 +23,6 @@ import './CloneDesignTab.css';
 
 export default function CloneDesignTab(props) {
   const {
-    mode,
     textAreaRef,
     text, setText,
     language, setLanguage,
@@ -54,6 +54,11 @@ export default function CloneDesignTab(props) {
   } = props;
 
   const { t } = useTranslation();
+  // "Define voice" method — 'audio' (was the Clone tab) | 'design' (was the
+  // Design tab). Lives in the store so navigation shims / profile selection
+  // can preset it (voice-studio-unification P4).
+  const defineMethod = useAppStore(s => s.defineMethod);
+  const setDefineMethod = useAppStore(s => s.setDefineMethod);
   const [activePersonality, setActivePersonality] = useState('');
 
   // ── "Describe your voice" (#317): free-text → design parameters ──────────
@@ -134,8 +139,8 @@ export default function CloneDesignTab(props) {
   });
   const anyTtsReady = !!(enginesData?.tts?.backends || []).some(b => b.available);
 
-  // Demo coach-mark: when the user enters the Clone tab with the bundled
-  // demo profile (demo0001) freshly selected and the textarea is empty,
+  // Demo coach-mark: when the user is on the "From audio" method with the
+  // bundled demo profile (demo0001) freshly selected and the textarea is empty,
   // prefill a punchy starter prompt and show a one-line coach-mark above
   // the textarea. Both auto-dismiss as soon as the user types anything.
   // Tracked via localStorage so we don't re-prefill on every visit.
@@ -144,7 +149,7 @@ export default function CloneDesignTab(props) {
   const [showDemoCoachmark, setShowDemoCoachmark] = useState(false);
 
   useEffect(() => {
-    if (mode !== 'clone') return;
+    if (defineMethod !== 'audio') return;
     if (selectedProfile !== DEMO_PROFILE_ID) return;
     if (typeof window === 'undefined') return;
     if (localStorage.getItem('omnivoice.demoClonePrompted') === '1') return;
@@ -153,14 +158,14 @@ export default function CloneDesignTab(props) {
     setShowDemoCoachmark(true);
     localStorage.setItem('omnivoice.demoClonePrompted', '1');
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, selectedProfile]);
+  }, [defineMethod, selectedProfile]);
 
   // "Hear demo" fallback: when no TTS engine is ready and the user is on
   // the demo profile, the Synthesize button is swapped for one that plays
   // the pre-rendered demo_clone_output.wav. This guarantees a working
   // "wow moment" on first launch before any model downloads finish.
   const showHearDemo =
-    mode === 'clone' && selectedProfile === DEMO_PROFILE_ID && !anyTtsReady;
+    defineMethod === 'audio' && selectedProfile === DEMO_PROFILE_ID && !anyTtsReady;
   const demoAudioRef = useRef(null);
   const demoReleaseRef = useRef(null);
   const [demoAudioPlaying, setDemoAudioPlaying] = useState(false);
@@ -227,10 +232,10 @@ export default function CloneDesignTab(props) {
               attribute-preset buttons when the user has not yet typed
               anything and no personality is active. As soon as they
               interact, the grid steps aside for the standard form. */}
-          {mode === 'design' && !text && !activePersonality && demoPresets.length > 0 && (
+          {defineMethod === 'design' && !text && !activePersonality && demoPresets.length > 0 && (
             <DemoPresetGrid presets={demoPresets} onUse={applyDemoPreset} />
           )}
-          {mode === 'design' && (text || activePersonality || demoPresets.length === 0) && (
+          {defineMethod === 'design' && (text || activePersonality || demoPresets.length === 0) && (
             <div className="preset-grid">
               {PRESETS.map(p => {
                 const Icon = PRESET_ICONS[p.id] || FALLBACK_VOICE_ICON;
@@ -243,7 +248,7 @@ export default function CloneDesignTab(props) {
               })}
             </div>
           )}
-          {showDemoCoachmark && mode === 'clone' && selectedProfile === DEMO_PROFILE_ID && (
+          {showDemoCoachmark && defineMethod === 'audio' && selectedProfile === DEMO_PROFILE_ID && (
             <div className="clone-coachmark" role="note">
               <span className="clone-coachmark__icon">💡</span>
               <span className="clone-coachmark__msg">
@@ -262,7 +267,7 @@ export default function CloneDesignTab(props) {
           <textarea
             ref={textAreaRef}
             className="input-base clone-text-area"
-            placeholder={mode === 'clone' ? t('clone.prompt_placeholder') : t('clone.design_placeholder')}
+            placeholder={defineMethod === 'audio' ? t('clone.prompt_placeholder') : t('clone.design_placeholder')}
             value={text}
             onChange={e => {
               setText(e.target.value);
@@ -308,10 +313,26 @@ export default function CloneDesignTab(props) {
       {/* ═══ RIGHT COLUMN: voice source + overrides/synth ═══ */}
       <div className="studio-column">
         <div className="studio-panel">
-        {mode === 'clone' ? (
-          <div>
-            <div className="label-row"><Volume2 className="label-icon" size={14} /> {t('clone.voice_source')}</div>
+        <div className="label-row"><Volume2 className="label-icon" size={14} /> {t('clone.voice_source')}</div>
 
+        {/* Define voice — the method toggle that replaced the Clone/Design
+            tab split: 'From audio' (reference clip) vs 'By design' (described
+            attributes). */}
+        <div className="label-row label-row--spread">
+          <span>{t('clone.define_voice', { defaultValue: 'Define voice' })}</span>
+          <Segmented
+            size="sm"
+            value={defineMethod}
+            onChange={setDefineMethod}
+            items={[
+              { value: 'audio', label: t('clone.define_from_audio', { defaultValue: 'From audio' }) },
+              { value: 'design', label: t('clone.define_by_design', { defaultValue: 'By design' }) },
+            ]}
+          />
+        </div>
+
+        {defineMethod === 'audio' ? (
+          <div>
             {/* Saved voices now live in the right-side WorkspaceVoices panel. */}
 
             {!selectedProfile && (

--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -5,6 +5,7 @@ import {
   FileText, HardDrive, Download, ArrowRight,
 } from 'lucide-react';
 import { API } from '../api/client';
+import { useAppStore } from '../store';
 import ReadinessChecklist from '../components/ReadinessChecklist';
 
 function DubThumb({ jobId, fallback }) {
@@ -62,6 +63,10 @@ export default function Launchpad({
   setMode, setIsCompareModalOpen, handleSelectProfile, loadProject,
 }) {
   const { t } = useTranslation();
+  // Clone/Design are no longer separate navigation modes — both cards open
+  // the unified Voice ('studio') workspace preset to the matching method.
+  const setDefineMethod = useAppStore(s => s.setDefineMethod);
+  const openStudio = (method) => { setMode('studio'); setDefineMethod(method); };
   const cloneProfiles = profiles.filter(p => !p.instruct);
   const designProfiles = profiles.filter(p => !!p.instruct);
   const demoProfile = profiles.find(p => p.id === 'demo0001');
@@ -131,10 +136,10 @@ export default function Launchpad({
 
       {/* Action Cards */}
       <div className="lp-actions">
-        <ActionCard hue="#d3869b" Icon={Fingerprint} title={t('launchpad.clone_title')} count={cloneProfiles.length} onClick={() => setMode('clone')}>
+        <ActionCard hue="#d3869b" Icon={Fingerprint} title={t('launchpad.clone_title')} count={cloneProfiles.length} onClick={() => openStudio('audio')}>
           {t('launchpad.clone_desc')}
         </ActionCard>
-        <ActionCard hue="#8ec07c" Icon={Wand2} title={t('launchpad.design_title')} count={designProfiles.length} onClick={() => setMode('design')}>
+        <ActionCard hue="#8ec07c" Icon={Wand2} title={t('launchpad.design_title')} count={designProfiles.length} onClick={() => openStudio('design')}>
           {t('launchpad.design_desc')}
         </ActionCard>
         <ActionCard hue="#fe8019" Icon={Film} title={t('launchpad.dub_title')} count={studioProjects.length} onClick={() => setMode('dub')}>
@@ -191,7 +196,7 @@ export default function Launchpad({
           <span>{t('launchpad.demo_callout')}</span>
           <button
             className="lp-demo-callout__btn"
-            onClick={() => { setMode('clone'); handleSelectProfile(demoProfile); }}
+            onClick={() => { openStudio('audio'); handleSelectProfile(demoProfile); }}
           >
             {t('launchpad.try_it')}
           </button>
@@ -214,7 +219,7 @@ export default function Launchpad({
                         <div className="proj-name">{p.name}</div>
                         <div className="proj-meta">{p.ref_audio_path}</div>
                       </div>
-                      <button className="proj-action" onClick={() => { setMode('clone'); handleSelectProfile(p); }}>{t('launchpad.open')}</button>
+                      <button className="proj-action" onClick={() => { openStudio('audio'); handleSelectProfile(p); }}>{t('launchpad.open')}</button>
                     </div>
                   ))}
                 </div>
@@ -236,7 +241,7 @@ export default function Launchpad({
                         <div className="proj-meta lp-proj-meta--italic">{p.instruct}</div>
                       </div>
                       {p.is_locked && <span className="lp-locked-badge">{t('launchpad.locked')}</span>}
-                      <button className="proj-action" onClick={() => { setMode('design'); handleSelectProfile(p); }}>{t('launchpad.open')}</button>
+                      <button className="proj-action" onClick={() => { openStudio('design'); handleSelectProfile(p); }}>{t('launchpad.open')}</button>
                     </div>
                   ))}
                 </div>

--- a/frontend/src/pages/VoiceGallery.jsx
+++ b/frontend/src/pages/VoiceGallery.jsx
@@ -66,6 +66,7 @@ export default function VoiceGallery() {
   const viewMode = useAppStore((s) => s.galleryViewMode);
   const setViewMode = useAppStore((s) => s.setGalleryViewMode);
   const setMode = useAppStore((s) => s.setMode);
+  const setDefineMethod = useAppStore((s) => s.setDefineMethod);
   const setPendingProfileId = useAppStore((s) => s.setPendingProfileId);
   const setInstruct = useAppStore((s) => s.setInstruct);
   const setVdStates = useAppStore((s) => s.setVdStates);
@@ -201,7 +202,8 @@ export default function VoiceGallery() {
               // Hand the new profile to the synthesis view and jump there so the
               // user lands ready-to-generate instead of hunting for it in the list.
               setPendingProfileId(r.profile_id);
-              setMode('clone');
+              setMode('studio');
+              setDefineMethod('audio');
             } catch (e) {
               flash(t('gallery.use_failed', { defaultValue: 'Could not create that voice — the engine may be loading.' }));
             }
@@ -209,7 +211,8 @@ export default function VoiceGallery() {
           onDesign={(a) => {
             setVdStates({ ...vdStates, ...a.attrs });
             setInstruct('');
-            setMode('design');
+            setMode('studio');
+            setDefineMethod('design');
           }}
         />
       ) : zone === 'community' ? (
@@ -221,7 +224,7 @@ export default function VoiceGallery() {
           toggleFavorite={toggleFavorite}
           onPlayAudio={(url, id) => playUrl(url, id)}
           flash={flash}
-          onDesign={(instruct) => { setVdStates({ ...vdStates }); setInstruct(instruct); setMode('design'); }}
+          onDesign={(instruct) => { setVdStates({ ...vdStates }); setInstruct(instruct); setMode('studio'); setDefineMethod('design'); }}
         />
       ) : (
         <ImportsZone

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -79,6 +79,7 @@ export const useAppStore = create<AppStore>()(
         timingStrategy:             s.timingStrategy,
         fitOptions:                 s.fitOptions,
         mode:                       s.mode,
+        defineMethod:               s.defineMethod,
         isSidebarCollapsed:         s.isSidebarCollapsed,
         isSidebarProjectsCollapsed: s.isSidebarProjectsCollapsed,
         sidebarTab:                 s.sidebarTab,

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -17,6 +17,10 @@ export type AppMode =
   | 'launchpad'
   | 'generate'
   | 'dub'
+  | 'studio'
+  // Legacy navigation ids — consolidated into 'studio' (voice-studio-unification
+  // P4). Kept in the union so persisted UI state / history items that still say
+  // 'clone'/'design' type-check while the restore shims map them to 'studio'.
   | 'clone'
   | 'design'
   | 'stories'
@@ -25,10 +29,19 @@ export type AppMode =
   | 'batch'
   | 'settings';
 
+/**
+ * The Voice workspace's "Define voice" method (was the Clone/Design tab
+ * split): 'audio' = define from reference audio (old Clone tab), 'design' =
+ * define by described attributes (old Design tab).
+ */
+export type DefineMethod = 'audio' | 'design';
+
 export type SidebarTab = 'projects' | 'history' | 'downloads';
 
 export interface UiSlice {
   mode: AppMode;
+  /** Active definition method inside the Voice ('studio') workspace. */
+  defineMethod: DefineMethod;
   activeProjectId: string | null;
   activeProjectName: string;
   activeVoiceId: string | null;
@@ -36,7 +49,7 @@ export interface UiSlice {
   modeBeforeVoice: AppMode | null;
   /**
    * One-shot hand-off for "use this voice in the synthesis view": the Gallery
-   * (or any view) sets a profile id and navigates to `clone`; App.jsx selects
+   * (or any view) sets a profile id and navigates to `studio`; App.jsx selects
    * that profile once it appears in the loaded profiles list, then clears this.
    */
   pendingProfileId: string | null;
@@ -47,6 +60,7 @@ export interface UiSlice {
   uiScale: number;
 
   setMode: (mode: AppMode) => void;
+  setDefineMethod: (method: DefineMethod) => void;
   setActiveProject: (id: string | null, name?: string) => void;
   setActiveVoiceId: (id: string | null) => void;
   setModeBeforeVoice: (mode: AppMode | null) => void;
@@ -65,6 +79,7 @@ export interface UiSlice {
 
 export const createUiSlice: StateCreator<UiSlice, [], [], UiSlice> = (set, get) => ({
   mode: 'launchpad',
+  defineMethod: 'audio',
   activeProjectId: null,
   activeProjectName: '',
   activeVoiceId: null,
@@ -77,6 +92,7 @@ export const createUiSlice: StateCreator<UiSlice, [], [], UiSlice> = (set, get) 
   uiScale: 1.3,
 
   setMode: (mode) => set({ mode }),
+  setDefineMethod: (method) => set({ defineMethod: method }),
   setActiveProject: (id, name = '') => set({ activeProjectId: id, activeProjectName: name }),
   setActiveVoiceId: (id) => set({ activeVoiceId: id }),
   setModeBeforeVoice: (mode) => set({ modeBeforeVoice: mode }),


### PR DESCRIPTION
P4 of `docs/specs/voice-studio-unification.md` §2 — the final visible step of the Clone/Design merge.

- One **`studio`** navigation mode replaces the clone/design pair; NavRail and Header show a single **Voice** entry
- The split lives on as a **Define voice** toggle (From audio / By design) at the top of Voice Source; selecting a saved profile sets the method from its `kind` (P3)
- `defineMethod` persisted; legacy shims map stored `mode:'clone'/'design'` and history-restore targets → `studio` + method
- **History `mode` values are untouched** — only the navigation id changes

Verification: build clean, 312/312 tests, tsc clean, zero `setMode('clone'|'design')` remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR consolidates the separate Clone and Design navigation workspaces into a unified "studio" workspace, preserving the former split as a persistent "Define voice" toggle (`defineMethod`) that selects between audio-based and design-based voice synthesis methods. Navigation consolidation is visible in NavRail/Header (one Voice entry), while method selection is driven by a new `defineMethod` state in the app store rather than navigation mode.

## UI Changes

**NavRail Navigation Before/After:**
```
Before:                          After:
┌──────────────┐                ┌──────────────┐
│ 🔀 Clone     │                │ 🔗 Voice     │
│ ✨ Design    │       →        │              │
│ 🚀 Launchpad │                │ 🚀 Launchpad │
└──────────────┘                └──────────────┘
```

**Voice Workspace Layout Addition:**
```
Voice Workspace (new unified view)
┌───────────────────────────────────────┐
│ [From audio] [By design]  ← DefineMethod toggle
├───────────────────────────────────────┤
│ Audio Mode:                             │
│  • Upload reference audio               │
│  • Transcript input                     │
│  • Profile list (no instruct)           │
│                                         │
│ OR Design Mode:                         │
│  • Description textarea                 │
│  • Personality controls                 │
│  • Profile list (has instruct)          │
└───────────────────────────────────────┘
```

## Behavioral Flow

**Define Method Selection & Persistence:**
```mermaid
graph TD
    A["User opens Studio"] --> B{Source?}
    B -->|From Launchpad Clone| C["setMode='studio' + defineMethod='audio'"]
    B -->|From Launchpad Design| D["setMode='studio' + defineMethod='design'"]
    B -->|From Gallery archetype| E["setMode='studio' + defineMethod='audio'"]
    B -->|From Gallery designer| F["setMode='studio' + defineMethod='design'"]
    B -->|Select saved profile| G["defineMethod from profile.kind"]
    B -->|Toggle UI control| H["User selects From audio/By design"]
    C --> I["Persisted to localStorage"]
    D --> I
    E --> I
    F --> I
    G --> I
    H --> I
    I --> J["On reload: restore both mode='studio' + defineMethod"]
    J --> K["Legacy: clone/design mode migrates to studio + method"]
```

## Key Implementation Changes

### Store & Persistence Layer
- **AppMode type**: Added `'studio'` entry (replacing `'clone'` and `'design'` navigation semantics)
- **DefineMethod type**: New union type `'audio' | 'design'` for voice definition method
- **UiSlice**: Added `defineMethod` state field and `setDefineMethod` action; initializes to `'audio'`
- **Legacy migration**: `useAppData` hook detects `localStorage` entries with `mode: 'clone'/'design'` and remaps to `mode: 'studio'` with corresponding `defineMethod`, preserving history mode values unchanged

### Component Updates
- **CloneDesignTab**: Added "Define voice" segmented control (From audio / By design); removed `mode` prop dependency; all form branching (audio upload vs design description) now uses `defineMethod` from `useAppStore`
- **WorkspaceVoices**: Changed prop from `mode` to `defineMethod`; profile filtering and list title now depend on `defineMethod === 'audio'` (show non-instruct profiles) vs design (show instruct profiles)
- **Sidebar**: Projects UI labeling, profile badges, and profile grid filtering now combine `mode === 'studio'` with `defineMethod` branching
- **useTTS**: Form branch and validation use `defineMethod === 'audio'` instead of `mode === 'clone'`; audio mode requires uploaded audio or selected profile
- **useProfiles**: When profile is selected, automatically calls `setDefineMethod` based on `profile.kind`
- **Launchpad**: Clone/Design action cards and CTA buttons now open studio with paired `setMode('studio')` + `setDefineMethod(method)` calls
- **VoiceGallery**: Archetype use/design handlers set `mode='studio'` with corresponding `defineMethod`

### Header & Navigation
- **Header**: Added `studio` view metadata (label, icon, accent color); inline comments document legacy `clone`/`design` rendering during transition
- **NavRail**: Removed `clone` and `design` items; added single `studio` item with Fingerprint icon and `nav.voice` i18n key

### Internationalization
- Added `nav.voice: "Voice"` translation key in English locale

## Migration Path
Existing users with persisted `clone` or `design` navigation modes are automatically migrated on app load: the legacy shim in `useAppData` detects the old mode values, maps them to `studio` mode with the appropriate `defineMethod`, and saves the new state. History mode values themselves remain unchanged (still record `clone`/`design`), ensuring historical navigation context is preserved.

## Test & Build Status
- Repository builds clean
- 312/312 tests pass
- TypeScript checks pass
- No remaining calls to `setMode('clone'|'design')`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->