### PR TITLE
fix(player): WaveformPlayer click did nothing — media element never got a src

### DIFF
--- a/frontend/src/components/WaveformPlayer.jsx
+++ b/frontend/src/components/WaveformPlayer.jsx
@@ -94,8 +94,11 @@ export default function WaveformPlayer({
         // create a detached one: Tauri's WebKit decodes (peaks render) but
         // won't actually output sound for detached/blob-backed media — the
         // same reason WaveformTimeline passes its <video> element.
+        // NOTE: the element's `src` is set in JSX, NOT via the `url` option —
+        // with an external `media`, wavesurfer only fetches `url` for peaks
+        // and never assigns it to the element, leaving play() with nothing
+        // to play (waveform drew, click did nothing).
         media:         mediaRef.current,
-        url:           resolvedUrl,
       });
     } catch (initErr) {
       console.warn('WaveformPlayer: WaveSurfer init failed, native fallback:', initErr);
@@ -146,7 +149,12 @@ export default function WaveformPlayer({
     };
   }, [resolvedUrl, failed, height, source, onEnded]);
 
-  const togglePlay = () => { try { wsRef.current?.playPause(); } catch { /* noop */ } };
+  const togglePlay = () => {
+    // playPause is async — a swallowed rejection here is exactly how the
+    // "click does nothing" bug hid; log it so playback failures are visible.
+    Promise.resolve(wsRef.current?.playPause())
+      .catch((e) => console.warn('WaveformPlayer: play failed:', e));
+  };
 
   if (!resolvedUrl) return null;
 
@@ -180,7 +188,7 @@ export default function WaveformPlayer({
   return (
     <div className={`wf-player ${compact ? 'wf-player--compact' : ''} ${className}`}>
       {/* Hidden but DOM-attached playback element (see WaveSurfer `media`). */}
-      <audio ref={mediaRef} preload="metadata" style={{ display: 'none' }} />
+      <audio ref={mediaRef} src={resolvedUrl} preload="metadata" style={{ display: 'none' }} />
       <button
         type="button"
         className="wf-player__btn"


### PR DESCRIPTION
With an external `media`, wavesurfer v7 only fetches `url` for peak decoding and never assigns it to the element — waveform rendered, play() had nothing to play. Fix: set `src` on the in-DOM `<audio>` via JSX (the proven WaveformTimeline pattern) and drop the `url` option; also log swallowed `playPause()` rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: WaveformPlayer click did nothing — media element never got a src

### Problem
WaveformPlayer's waveform rendered correctly but clicking play had no effect. The root cause: when WaveSurfer v7 uses an external `media` element with the `url` option, it only fetches the URL for peak decoding and never assigns that URL to the media element itself. Result: the waveform drew, but the `<audio>` element had no `src`, so `play()` had nothing to play.

### Solution
**Set the media element's `src` via JSX instead of relying on WaveSurfer's `url` option:**
- Removed the `url` option from WaveSurfer's create config
- Explicitly set `src={resolvedUrl}` on the hidden in-DOM `<audio>` element via JSX (mirrors WaveformTimeline pattern)
- Added detailed inline comments documenting why the `src` must be set this way

**Surface playback failures instead of silently swallowing them:**
- Wrapped `wsRef.current?.playPause()` in `Promise.resolve()` with `.catch()` logging
- Now reports playback rejections to console instead of hiding them

### Behavioral Flow
```mermaid
flowchart TD
    A["User clicks play button<br/>(togglePlay)"] --> B["Promise.resolve<br/>playPause call"]
    B --> C{playPause<br/>succeeds?}
    C -->|Yes| D["Media element<br/>plays audio<br/>(now has src!)"]
    C -->|No| E["Log rejection<br/>to console"]
    E --> F["Error visible<br/>for debugging"]
    D --> G["Audio outputs"]
    style D fill:`#90EE90`
    style F fill:`#FFB6C1`
```

**Before:** Click → `playPause()` rejects silently → nothing plays → no error indication  
**After:** Click → `playPause()` succeeds (media has `src` now) → audio plays; or rejection logged for visibility

### Code Changes
- **File:** `frontend/src/components/WaveformPlayer.jsx`
- **Lines changed:** +11 / -3
- **Key modifications:**
  1. Removed `url` option from WaveSurfer.create() config
  2. Added `src={resolvedUrl}` to the hidden `<audio>` JSX element
  3. Updated `togglePlay()` to wrap playPause in Promise and log rejections
  4. Added inline documentation explaining the media element pattern

### API & Props
No changes to exported component signature—`WaveformPlayer` props and external interface remain identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->