### PR TITLE
fix: triage batch — timeline box flicker (#373), truncated-model detection (#352), stale history pruning

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -537,9 +537,29 @@ def _safe_output_path(name):
 
 @router.get("/history")
 def list_history():
+    """Newest 50 generations whose audio still exists on disk.
+
+    Rows whose WAV was deleted out-of-band (cleared outputs dir, manual
+    cleanup) used to come back anyway and render dead players that 404 on
+    every fetch; prune them here so the UI never sees them again."""
     with db_conn() as conn:
-        rows = conn.execute("SELECT * FROM generation_history ORDER BY created_at DESC LIMIT 50").fetchall()
-    return [dict(r) for r in rows]
+        rows = conn.execute(
+            "SELECT * FROM generation_history ORDER BY created_at DESC LIMIT 50"
+        ).fetchall()
+        alive, stale_ids = [], []
+        for r in rows:
+            p = _safe_output_path(r["audio_path"]) if r["audio_path"] else None
+            if r["audio_path"] and (not p or not os.path.exists(p)):
+                stale_ids.append(r["id"])
+            else:
+                alive.append(dict(r))
+        if stale_ids:
+            conn.executemany(
+                "DELETE FROM generation_history WHERE id=?",
+                [(i,) for i in stale_ids],
+            )
+            logger.info("pruned %d stale history rows (audio file gone)", len(stale_ids))
+    return alive
 
 @router.delete("/history")
 def clear_history():

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -42,6 +42,41 @@ def _safe_put(queue: asyncio.Queue, event) -> None:
             pass
 
 
+# Minimum size for "this snapshot actually contains model weights". An
+# interrupted snapshot_download can leave config/tokenizer files but no
+# weights; the install then looks complete and synthesis later fails with
+# "does not appear to have a file named pytorch_model.bin or
+# model.safetensors" (#352). 5 MB clears every weight format we ship
+# (safetensors/bin shards, onnx, pt, gguf) without false-positiving on
+# config-only aux repos.
+_MIN_WEIGHT_BYTES = 5 * 1024 * 1024
+
+
+def _validate_snapshot_has_weights(repo_id: str, snapshot_path: str) -> None:
+    """Raise OSError when a finished snapshot has no plausible weight file —
+    surfaces the truncated-download class (#352) at install time, where the
+    retry loop and the UI's re-download path can deal with it, instead of at
+    first synthesis with an opaque transformers error."""
+    try:
+        biggest = 0
+        for root, _dirs, files in os.walk(snapshot_path, followlinks=True):
+            for f in files:
+                try:
+                    biggest = max(biggest, os.path.getsize(os.path.join(root, f)))
+                except OSError:
+                    continue
+                if biggest >= _MIN_WEIGHT_BYTES:
+                    return
+    except OSError:
+        return  # can't inspect — don't block the install on the checker itself
+    raise OSError(
+        f"{repo_id}: download finished but no model weights were found in the "
+        "snapshot (largest file "
+        f"{biggest} bytes). The download was likely interrupted — delete the "
+        "model in Settings → Models and install it again."
+    )
+
+
 @router.get("/setup/download-stream")
 async def setup_download_stream():
     """SSE: forward every HuggingFace download tqdm update as a JSON event."""
@@ -158,7 +193,8 @@ async def install_model(req: InstallModelRequest):
             while True:
                 _attempt += 1
                 try:
-                    snapshot_download(**dl_kwargs)
+                    _snapshot_path = snapshot_download(**dl_kwargs)
+                    _validate_snapshot_has_weights(req.repo_id, _snapshot_path)
                     break
                 except (HfHubHTTPError, LocalEntryNotFoundError, OSError) as net_err:
                     if _attempt >= _max_attempts:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -467,9 +467,23 @@ def _load_model_sync():
             logger.info("Preloading PyTorch Whisper with TTS model.")
         else:
             logger.info("Skipping PyTorch Whisper preload; ASR will load on demand.")
-        _model = OmniVoice.from_pretrained(
-            checkpoint, device_map=device, dtype=torch.float16, load_asr=preload_asr,
-        )
+        try:
+            _model = OmniVoice.from_pretrained(
+                checkpoint, device_map=device, dtype=torch.float16, load_asr=preload_asr,
+            )
+        except OSError as e:
+            # #352: a truncated HF cache surfaces here as "does not appear to
+            # have a file named pytorch_model.bin or model.safetensors".
+            # Translate to an actionable message instead of the raw
+            # transformers error.
+            if "does not appear to have a file named" in str(e):
+                raise RuntimeError(
+                    f"The TTS model cache for {checkpoint} is incomplete "
+                    "(weights missing — usually an interrupted download). "
+                    "Open Settings → Models, delete the OmniVoice TTS model, "
+                    "and install it again."
+                ) from e
+            raise
 
         try:
             # plan-02 (#65): gate on Triton availability (+ user setting), not

--- a/frontend/src/components/SegmentTrack.css
+++ b/frontend/src/components/SegmentTrack.css
@@ -30,7 +30,10 @@
 .seg-track__lane {
   position: relative;
   height: 100%;
-  will-change: transform;
+  /* No `will-change: transform` — the persistent compositor layer it forces
+     made the semi-transparent segment boxes vanish/reappear during playback
+     and drags on some Windows GPU drivers (#373). The lane only translates
+     while scrolling; a permanent layer isn't worth the paint glitch. */
 }
 
 .seg-track__box {

--- a/frontend/src/utils/timeline.js
+++ b/frontend/src/utils/timeline.js
@@ -20,13 +20,13 @@ export const GRID_SNAP_MAX_PX_PER_SEC = 40;
 // Segment box palette — was WaveformTimeline's region palette; lives here so
 // both the track and any legend can share it without circular imports.
 export const REGION_COLORS = [
-  'rgba(211,134,155,0.3)',
-  'rgba(131,165,152,0.3)',
-  'rgba(184,187,38,0.3)',
-  'rgba(250,189,47,0.3)',
-  'rgba(142,192,124,0.3)',
-  'rgba(254,128,25,0.3)',
-  'rgba(104,157,106,0.3)',
+  'rgba(211,134,155,0.45)',
+  'rgba(131,165,152,0.45)',
+  'rgba(184,187,38,0.45)',
+  'rgba(250,189,47,0.45)',
+  'rgba(142,192,124,0.45)',
+  'rgba(254,128,25,0.45)',
+  'rgba(104,157,106,0.45)',
 ];
 
 export const timeToPx = (t, pxPerSec) => t * pxPerSec;


### PR DESCRIPTION
Three small fixes from open-issue triage:

- **#373(1)** — segment boxes vanishing/reappearing during playback & drags: removed `will-change: transform` on the track lane (its persistent compositor layer glitches semi-transparent paints on some Windows GPU drivers) and raised region alpha 0.30 → 0.45. The issue's second half (dialect loop) was fixed in #377.
- **#352** — `k2-fsa/OmniVoice does not appear to have a file named pytorch_model.bin…`: an interrupted `snapshot_download` leaves config files but no weights and the install still reports done. Installs now validate the snapshot contains a plausible weight file (>5 MB) and fail with a re-download hint; the model loader translates the raw transformers error into the same guidance.
- **Stale history** — `GET /history` prunes rows whose audio file no longer exists instead of returning dead players that 404 on every panel mount.

Tests: related backend suites + 312/312 frontend green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses three issues affecting stability and user experience:

1. **`#373` (Timeline rendering flicker)**: Removed `will-change: transform` from the segment track lane that was causing a persistent GPU compositor layer, leading semi-transparent region boxes to vanish/reappear during playback and dragging on some Windows drivers. Region color alpha increased from 0.30 to 0.45 for improved visibility.

2. **`#352` (Truncated model detection)**: Added post-download validation to detect incomplete model snapshots. Installers now verify that completed downloads contain a plausible weights file (>5 MB). Interrupted snapshots that left config files but no weights now fail at install time with a re-download hint, rather than failing later during synthesis with an opaque error.

3. **Stale history pruning**: The `GET /history` endpoint now removes history rows whose audio files no longer exist on disk, preventing dead audio players that return 404 when the UI tries to render them.

---

## Changes by file

### `frontend/src/components/SegmentTrack.css`
Removed `will-change: transform` property that forced a persistent compositor layer:

```
Before:                          After:
.seg-track__lane {               .seg-track__lane {
  will-change: transform;          /* will-change caused semi-transparent
  position: relative;               * segment boxes to vanish/reappear
  ...                               * during playback on some Windows
}                                   * GPU drivers — removed. */
                                   position: relative;
                                   ...
                                 }
```

### `frontend/src/utils/timeline.js`
Increased alpha transparency of region color palette from 0.30 to 0.45 for enhanced visibility:

```
Before:                     After:
rgba(211,134,155,0.30)  →  rgba(211,134,155,0.45)  ▮
rgba(131,165,152,0.30)  →  rgba(131,165,152,0.45)  ▮
(all palette entries updated similarly)
```

### `backend/api/routers/setup/download.py`
Added `_validate_snapshot_has_weights(repo_id, snapshot_path)` function that:
- Scans the completed HF snapshot directory for the largest file
- Raises `OSError` if no file ≥5 MB is found (indicating incomplete download)
- Is called after `snapshot_download()` completes, before proceeding
- Integrates with existing retry loop so truncated snapshots trigger re-attempts

### `backend/services/model_manager.py`
Wrapped `from_pretrained()` call in try/except to catch incomplete cache errors:
- Detects `OSError` with message containing "does not appear to have a file named"
- Translates to user-friendly `RuntimeError` instructing deletion/reinstall in Settings
- Other `OSError` cases are re-raised unchanged

**Model load error handling flow:**
```
from_pretrained()
       ↓
   OSError?
   ↙        ↘
Yes      No → return model
   ↓
Check if "does not appear to have a file"
   ↙        ↘
Yes      No → re-raise
   ↓
Raise RuntimeError with:
"Delete OmniVoice TTS model in Settings
 and retry to re-download"
```

### `backend/api/routers/generation.py`
Refactored `GET /history` to prune dead history entries:

```
Query: SELECT * FROM generation_history (newest 50)
       ↓
For each row:
  Check if audio_path exists on disk AND passes safety validation
       ↙                           ↘
   Safe & exists              Missing or unsafe
       ↓                           ↓
   [alive]                    [stale_ids]
       ↓                           ↓
       └────────────────────────────┘
                      ↓
         DELETE stale rows (batch)
         LOG prune count
                      ↓
         RETURN alive rows only
         (UI never sees 404 players)
```

---

## Code review effort assessment
- **Low**: CSS transparency removal (SegmentTrack.css)
- **Medium**: Region color alpha update (timeline.js), history pruning logic (generation.py), model error translation (model_manager.py)
- **High**: Snapshot validation implementation (download.py requires import addition)

Lines changed: +87/-14 across 5 files. All backend test suites passing; frontend reports 312/312 green.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->