### PR TITLE
fix(player): WaveformPlayer paused itself on play — idempotent claim + hard listener teardown

### DIFF
--- a/frontend/src/components/WaveformPlayer.jsx
+++ b/frontend/src/components/WaveformPlayer.jsx
@@ -106,18 +106,31 @@ export default function WaveformPlayer({
       return;
     }
     wsRef.current = ws;
+    // Stale-instance guard: a destroy() that throws mid-teardown (observed
+    // under StrictMode double-mount) can leave this instance's media
+    // listeners alive — its handlers must become inert, or its duplicate
+    // 'play' event re-claims the playback slot and stops... ourselves
+    // (the self-pause bug: waveform drew, click silently un-played).
+    let stale = false;
 
     ws.on('ready', () => {
+      if (stale) return;
       setDuration(ws.getDuration());
       setReady(true);
       if (autoPlayRef.current) ws.play().catch(() => {});
     });
-    ws.on('timeupdate', (t) => setCurrentTime(t));
+    ws.on('timeupdate', (t) => { if (!stale) setCurrentTime(t); });
     ws.on('play', () => {
+      if (stale) return;
       setIsPlaying(true);
-      releaseRef.current = claimPlayback(() => { try { ws.pause(); } catch { /* noop */ } }, source);
+      // Idempotent: duplicate 'play' events must not re-claim — claiming
+      // stops the current owner, which would be this very element.
+      if (!releaseRef.current) {
+        releaseRef.current = claimPlayback(() => { try { ws.pause(); } catch { /* noop */ } }, source);
+      }
     });
     ws.on('pause', () => {
+      if (stale) return;
       setIsPlaying(false);
       if (releaseRef.current) { releaseRef.current(); releaseRef.current = null; }
     });
@@ -143,7 +156,11 @@ export default function WaveformPlayer({
     // (No explicit ws.load — `url` in the create options loads via the media el.)
 
     return () => {
+      stale = true;
       if (releaseRef.current) { releaseRef.current(); releaseRef.current = null; }
+      // Detach our handlers BEFORE destroy — if destroy throws mid-teardown
+      // (the swallowed catch below) the listeners must already be gone.
+      try { ws.unAll(); } catch { /* noop */ }
       try { ws.destroy(); } catch { /* already gone */ }
       wsRef.current = null;
     };


### PR DESCRIPTION
Third and root-cause fix for 'history player doesn't play'. Live-debugged in Playwright WebKit with a `pause()` stack hook: duplicate 'play' events (stale instance listeners surviving a throwing `destroy()` under StrictMode) made the second `claimPlayback` stop the current owner — the same element. Fix: claim only when not already owning the slot; per-instance stale guard; `unAll()` before `destroy()` in cleanup.

Verified empirically in WebKit: `paused=false`, `currentTime` advancing, zero stray pause calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes the "history player doesn't play" bug caused by stale event listeners from destroyed WaveformPlayer instances (particularly under React StrictMode double-mount) that triggered duplicate 'play' events, causing the player to claim and immediately stop its own playback (self-pause).

## Changes
The WaveformPlayer component implements three coordinated defensive fixes:

1. **Idempotent playback claiming**: The 'play' handler only initializes `releaseRef.current` (claims the global playback slot) if it's not already set, preventing duplicate 'play' events from re-claiming and stopping the current owner.

2. **Per-instance stale guard**: A `stale` flag marks instances pending teardown. All event handlers (`ready`, `timeupdate`, `play`, `pause`) check this flag and return early, rendering handlers from leaked listeners inert.

3. **Hardened cleanup ordering**: During effect cleanup, the component now:
   - Sets `stale = true` immediately
   - Releases any existing playback claim
   - Calls `ws.unAll()` to detach listeners **before** `ws.destroy()` (preventing listeners from surviving if destroy throws)
   - Destroys the instance while tolerating errors

## Mechanism
```mermaid
graph TD
    A["Component mounts<br/>WaveSurfer instance created<br/>stale = false"] --> B["User clicks play"]
    B --> C{"'play' event<br/>fires"}
    C -->|stale = false| D{"releaseRef.current<br/>already set?"}
    D -->|No| E["Claim playback slot<br/>set releaseRef.current"]
    D -->|Yes| F["Skip claiming<br/>idempotent"]
    E --> G["Player owns slot<br/>plays audio"]
    F --> G
    
    H["Component unmounts"] --> I["Effect cleanup runs"]
    I --> J["Set stale = true"]
    J --> K["Release playback claim<br/>releaseRef = null"]
    K --> L["Call ws.unAll()"]
    L --> M["Call ws.destroy<br/>tolerate errors"]
    
    N["Leaked listener fires<br/>'play' event"] --> O{"stale<br/>flag?"}
    O -->|true| P["Handler gates early<br/>no-op"]
    O -->|false| E
    
    style A fill:`#e1f5e1`
    style G fill:`#e1f5e1`
    style P fill:`#fff4e6`
    style M fill:`#e1f5e1`
```

## Impact
- Player no longer self-pauses after mounting under StrictMode
- Stale listeners can no longer interfere with active instances
- Robust cleanup prevents listener leaks even if WaveSurfer teardown fails
- Verified in WebKit (Tauri macOS): player not paused, currentTime advancing, zero stray pause calls

## Technical Details
- **Lines changed**: +19/-2
- **File modified**: `frontend/src/components/WaveformPlayer.jsx`
- **No exported API changes**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->