### PR TITLE
fix: stale-chunk preload recovery (#380) + unsupported-GPU-arch notification (#284)

### DIFF
--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -574,6 +574,21 @@ async def flush_memory(unload_model: bool = False):
 
 # ── Actionable notifications ──────────────────────────────────────────────
 
+_GPU_ARCH_WARNING: "list[str | None]" = []  # [-1] = computed result
+
+
+def _gpu_arch_warning_cached() -> "str | None":
+    """check_device_compatibility() once per process (it lazy-imports torch —
+    too heavy for the 30s notifications poll)."""
+    if not _GPU_ARCH_WARNING:
+        try:
+            from services.model_manager import check_device_compatibility
+            compatible, warning = check_device_compatibility()
+            _GPU_ARCH_WARNING.append(None if compatible else warning)
+        except Exception:
+            _GPU_ARCH_WARNING.append(None)
+    return _GPU_ARCH_WARNING[-1]
+
 
 @router.get("/system/notifications")
 def system_notifications():
@@ -603,6 +618,20 @@ def system_notifications():
                 "type": "navigate",
                 "target": "settings",
             },
+        })
+
+    # 1b. GPU compute capability unsupported by this torch build (#284) —
+    # the model "runs" but emits pure noise, the worst silent failure mode
+    # (RTX 50-series Blackwell sm_120 on pre-cu128 wheels). The loader logs
+    # this, but a log line never reached the affected users — surface it in
+    # the panel. Checked once per process: it lazy-imports torch.
+    gpu_warn = _gpu_arch_warning_cached()
+    if gpu_warn:
+        notes.append({
+            "id": "gpu-arch-unsupported",
+            "level": "error",
+            "title": "GPU not supported by this PyTorch build",
+            "message": gpu_warn + " Until then, output will be noise/garbage.",
         })
 
     # 2. Missing ffmpeg

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -31,3 +31,15 @@ window.addEventListener('mousedown', (e) => {
   e.preventDefault();
   doubleClickMaximize();
 });
+
+// #380: after an app update, a still-open window can hold an index.html whose
+// lazy chunks reference old hashed assets that no longer exist on disk —
+// vite surfaces that as "Unable to preload CSS for /assets/…". The documented
+// recovery is a one-time reload to pick up the fresh manifest. The session
+// flag prevents a reload loop if the asset is genuinely missing.
+window.addEventListener('vite:preloadError', (event) => {
+  if (sessionStorage.getItem('omnivoice.preloadErrorReloaded') === '1') return;
+  sessionStorage.setItem('omnivoice.preloadErrorReloaded', '1');
+  event.preventDefault();
+  window.location.reload();
+});


### PR DESCRIPTION
Fixes #380 — one-time reload on `vite:preloadError` (stale hashed assets after an update), loop-guarded.

Addresses #284 — the existing compute-capability check only logged; affected users (RTX 50-series on pre-cu128 torch) saw silent noise output instead. The warning now lands in the notification panel as an actionable error with the pip command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Summary

## Overview
This PR resolves two critical issues: (`#380`) recovering from stale CSS/asset preload errors after updates, and (`#284`) surfacing unsupported GPU architecture warnings as actionable errors in the notification panel instead of silent synthesis failures.

## Changes

### Frontend: Preload Error Recovery (`frontend/src/main.jsx`, lines 35–45)

Added automatic recovery from stale asset preload failures:
- Implemented `vite:preloadError` event listener that intercepts Vite's preload errors for missing/outdated assets  
- Triggers a one-time full page reload to fetch fresh manifest and assets
- Guards against reload loops using `sessionStorage` flag (`omnivoice.preloadErrorReloaded`)

### Backend: GPU Compatibility Notification (`backend/api/routers/system.py`)

Added a caching mechanism to surface GPU compute capability warnings as actionable errors:
- Introduced module-level cache `_GPU_ARCH_WARNING` to store GPU compatibility status once per process
- Created `_gpu_arch_warning_cached()` helper that lazy-imports `check_device_compatibility()` and detects when GPU compute capability is unsupported for the current PyTorch build
- Updated `/system/notifications` endpoint to include GPU architecture warnings as error notifications with remediation instructions

**Impact**: Users with incompatible GPUs (e.g., RTX 50-series on pre-cu128 PyTorch) now see a clear, actionable error in the notifications panel with the pip command to upgrade PyTorch, instead of silent synthesis failures or log-only warnings.

---

## Notification Panel UI Change

```
BEFORE (GPU warning only in logs):
┌─────────────────────────────────────┐
│ Notifications                    (x) │
│                                     │
│ (empty — no visible warnings)       │
└─────────────────────────────────────┘
[User sees silent synthesis failures]

AFTER (GPU warning as actionable notification):
┌─────────────────────────────────────┐
│ Notifications                    (x) │
├─────────────────────────────────────┤
│ ⚠️  GPU not supported by this      │
│     PyTorch build                   │
│                                     │
│     Your RTX 50-series GPU          │
│     requires PyTorch >= X.X with    │
│     CUDA compute capability Y+      │
│                                     │
│     Fix: pip install --upgrade      │
│     torch>=X.X torchvision>=Y.Y    │
│                                     │
│     [Dismiss]                       │
└─────────────────────────────────────┘
```

---

## Behavior Flowchart

```mermaid
graph TD
    A["Vite preload error<br/>unable to load hashed asset"] --> B{"sessionStorage flag<br/>'omnivoice.<br/>preloadErrorReloaded'<br/>set?"}
    B -->|No<br/>First error| C["Set flag to '1'"]
    C --> D["Prevent default<br/>error handling"]
    D --> E["window.location.reload"]
    E --> F["Fresh manifest &<br/>assets from<br/>updated build"]
    B -->|Yes<br/>Subsequent error| G["Skip reload<br/>Avoid infinite loop"]
    
    H["System init:<br/>check GPU device"] --> I{"GPU compute<br/>capability<br/>compatible with<br/>PyTorch?"}
    I -->|Yes| J["Cache: None<br/>No notification"]
    I -->|No| K["Cache: warning message<br/>with pip command"]
    K --> L["/system/notifications<br/>polled every 30s"]
    L --> M["GPU error notification<br/>displayed in panel"]
```

---

## Code Changes Summary

- **Lines added**: +41 across both files  
  - Backend: +29 (GPU cache + notification logic)
  - Frontend: +12 (preload error handler)
- **Files modified**: 2 (1 backend, 1 frontend)
- **Breaking changes**: None
- **New public APIs**: None
- **Caching**: GPU check cached once per process (lazy-loaded) to avoid repeated expensive compatibility checks during 30s notification polls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->