### PR TITLE
chore(i18n): backfill 36 studio-overhaul keys into en.json + all 20 locales

### DIFF
--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -74,7 +74,16 @@
     "shortcut_set": "تم ضبط اختصار الإملاء على {{shortcut}}",
     "shortcut_register_failed": "تعذر التسجيل: {{message}}",
     "shortcut_reset": "إعادة التعيين إلى الوضع الافتراضي",
-    "shortcut_reset_failed": "فشلت إعادة التعيين: {{message}}"
+    "shortcut_reset_failed": "فشلت إعادة التعيين: {{message}}",
+    "cancel": "إلغاء",
+    "hf_token_also_clear": "امسح أيضًا",
+    "hf_token_clear_btn": "مسح الرمز",
+    "hf_token_clear_confirm": "هل تريد مسح رمز HuggingFace المحفوظ من التطبيق؟",
+    "hf_token_clear_dialog": "مسح الرمز",
+    "hf_token_input": "رمز HuggingFace",
+    "hf_token_sources": "مصادر رمز HF",
+    "hf_token_test_now": "اختبر الآن",
+    "hf_token_test_now_title": "إعادة تشغيل whoami لكل مصدر"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "مثال: a warm elderly British storyteller, slightly raspy",
     "describe_hint": "وصفك (بالإنجليزية) يضبط عناصر التحكم أدناه — ويمكنك تعديلها يدويًا لاحقًا.",
     "describe_unmatched": "تعذّر التعيين: {{items}}",
-    "describe_no_match": "لم يتم التعرف على سمات صوتية بعد — جرّب كلمات مثل deep أو elderly أو British."
+    "describe_no_match": "لم يتم التعرف على سمات صوتية بعد — جرّب كلمات مثل deep أو elderly أو British.",
+    "define_by_design": "بالتصميم",
+    "define_from_audio": "من الصوت",
+    "define_voice": "تحديد الصوت",
+    "save_design_as_profile": "حفظ التصميم كملف تعريف صوتي"
   },
   "about": {
     "app": "التطبيق",
@@ -692,7 +705,14 @@
     "dialect_title": "اللهجة الإقليمية والمفردات للترجمة (مثل الأرجنتين ← “vos sos” بدلاً من “tú eres”). تُطبَّق بواسطة محركات LLM ‏(OpenAI/Ollama) وجودة Cinematic.",
     "num_speakers_label": "المتحدثون",
     "num_speakers_auto": "تلقائي",
-    "num_speakers_help": "كم عدد المتحدثين في هذا الفيديو؟ اتركه فارغًا للاكتشاف التلقائي. حدّد رقمًا إذا دمج الاكتشاف التلقائي عدة متحدثين في متحدث واحد."
+    "num_speakers_help": "كم عدد المتحدثين في هذا الفيديو؟ اتركه فارغًا للاكتشاف التلقائي. حدّد رقمًا إذا دمج الاكتشاف التلقائي عدة متحدثين في متحدث واحد.",
+    "advanced": "متقدم",
+    "cinematic_needs_llm_hint": "تحتاج الجودة السينمائية إلى LLM. قم بتكوينه في الإعدادات → بيانات الاعتماد → نقطة نهاية LLM ‏(يعمل Ollama محليًا، دون الحاجة إلى مفتاح).",
+    "generate_dub_multi": "إنشاء {{count}} دبلجات",
+    "pipeline": "مسار الدبلجة",
+    "preview_language": "لغة المعاينة",
+    "target_language": "الدبلجة إلى",
+    "transcript_after_extract": "يظهر النص بعد الاستخراج."
   },
   "glossary": {
     "title": "مسرد",
@@ -955,7 +975,15 @@
     "save_failed": "لا يمكن حفظ الملف الشخصي.",
     "confirm_delete": "هل تريد حذف \"{{name}}\"؟",
     "trim_load_failed": "تعذر تحميل الصوت للاقتطاع.",
-    "delete": "حذف"
+    "delete": "حذف",
+    "community_empty": "لم يتم تحميل أصوات المجتمع بعد — اتصل بالإنترنت وأعد الفتح، أو كن أول من يرسل صوتًا.",
+    "community_explainer": "إعدادات مسبقة مصممة وأصوات مسجلة يشاركها المجتمع، تُحمَّل من omnivoice-gallery.",
+    "no_designer": "صوت مسجل — استخدم \"استخدم الصوت\" بدلًا من ذلك.",
+    "no_preview": "لا توجد معاينة — أضفه عبر \"استخدم الصوت\" لسماعه.",
+    "submit_failed": "تعذر فتح نموذج الإرسال.",
+    "submit_preset": "إرسال إعداد مسبق",
+    "submit_voice": "إرسال صوت",
+    "zone_community": "المجتمع"
   },
   "transcriptions": {
     "title": "النسخ",
@@ -1337,7 +1365,8 @@
     "dub_label": "يصفه",
     "save_label": "حفظ",
     "lock_identity": "قفل الهوية الصوتية",
-    "in_folder": "في {{folder}}"
+    "in_folder": "في {{folder}}",
+    "search": "بحث…"
   },
   "trimmer": {
     "title": "تقليم الصوت المرجعي",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "جارٍ الحفظ…",
     "hf_token_saved": "تم حفظ رمز Hugging Face",
     "hf_token_error": "تعذّر حفظ الرمز — أعد المحاولة أو عيّنه لاحقًا في الإعدادات → بيانات الاعتماد."
+  },
+  "history": {
+    "dub_title": "سجل الدبلجة",
+    "empty": "لا شيء هنا بعد — ستظهر مخرجاتك على اليمين.",
+    "empty_dub": "ستظهر دبلجاتك هنا.",
+    "title": "السجل"
+  },
+  "recording": {
+    "cleaned_loaded": "تم تنظيف التسجيل وتحميله!",
+    "loaded_raw": "تم تحميل التسجيل (خام — إزالة الضوضاء غير متاحة)",
+    "too_short": "التسجيل قصير جدًا"
   }
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Diktatverknüpfung auf {{shortcut}} festgelegt",
     "shortcut_register_failed": "Konnte nicht registriert werden: {{message}}",
     "shortcut_reset": "Auf Standard zurücksetzen",
-    "shortcut_reset_failed": "Zurücksetzen fehlgeschlagen: {{message}}"
+    "shortcut_reset_failed": "Zurücksetzen fehlgeschlagen: {{message}}",
+    "cancel": "Abbrechen",
+    "hf_token_also_clear": "Ebenfalls löschen",
+    "hf_token_clear_btn": "Token löschen",
+    "hf_token_clear_confirm": "Das HuggingFace-Token aus der App-Quelle löschen?",
+    "hf_token_clear_dialog": "Token löschen",
+    "hf_token_input": "HuggingFace-Token",
+    "hf_token_sources": "HF-Token-Quellen",
+    "hf_token_test_now": "Jetzt testen",
+    "hf_token_test_now_title": "whoami für jede Quelle erneut ausführen"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -320,7 +329,11 @@
     "describe_placeholder": "z. B. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Deine Beschreibung (auf Englisch) stellt die Regler unten ein — du kannst sie danach weiter anpassen.",
     "describe_unmatched": "Nicht zuordenbar: {{items}}",
-    "describe_no_match": "Noch keine Stimmmerkmale erkannt — versuche Wörter wie deep, elderly oder British."
+    "describe_no_match": "Noch keine Stimmmerkmale erkannt — versuche Wörter wie deep, elderly oder British.",
+    "define_by_design": "Per Design",
+    "define_from_audio": "Aus Audio",
+    "define_voice": "Stimme definieren",
+    "save_design_as_profile": "Design als Profil speichern"
   },
   "about": {
     "app": "App",
@@ -693,7 +706,14 @@
     "dialect_title": "Regionaler Dialekt und Wortschatz für die Übersetzung (z. B. Argentinien → „vos sos“ statt „tú eres“). Wird von LLM-Engines (OpenAI/Ollama) und der Cinematic-Qualität angewendet.",
     "num_speakers_label": "Sprecher",
     "num_speakers_auto": "Automatisch",
-    "num_speakers_help": "Wie viele Sprecher sind in diesem Video? Leer lassen für automatische Erkennung. Eine Zahl angeben, falls die Erkennung mehrere Sprecher zu einem zusammenfasst."
+    "num_speakers_help": "Wie viele Sprecher sind in diesem Video? Leer lassen für automatische Erkennung. Eine Zahl angeben, falls die Erkennung mehrere Sprecher zu einem zusammenfasst.",
+    "advanced": "Erweitert",
+    "cinematic_needs_llm_hint": "Filmisch benötigt ein LLM. Konfigurieren Sie eines unter Einstellungen → Anmeldedaten → LLM-Endpunkt (Ollama läuft lokal, kein Schlüssel nötig).",
+    "generate_dub_multi": "{{count}} Dubs generieren",
+    "pipeline": "Dubbing-Pipeline",
+    "preview_language": "Vorschausprache",
+    "target_language": "Dubben in",
+    "transcript_after_extract": "Das Transkript erscheint nach der Extraktion."
   },
   "glossary": {
     "title": "Glossar",
@@ -956,7 +976,15 @@
     "save_failed": "Profil konnte nicht gespeichert werden.",
     "confirm_delete": "„{{name}}“ löschen?",
     "trim_load_failed": "Audio zum Zuschneiden konnte nicht geladen werden.",
-    "delete": "Löschen"
+    "delete": "Löschen",
+    "community_empty": "Noch keine Community-Stimmen geladen — stellen Sie eine Internetverbindung her und öffnen Sie erneut, oder reichen Sie als Erste(r) eine ein.",
+    "community_explainer": "Gestaltete Voreinstellungen und aufgenommene Stimmen aus der Community, geladen aus der omnivoice-gallery.",
+    "no_designer": "Aufgenommene Stimme — verwenden Sie stattdessen „Benutzen Sie die Stimme“.",
+    "no_preview": "Keine Vorschau — fügen Sie sie mit „Benutzen Sie die Stimme“ hinzu, um sie anzuhören.",
+    "submit_failed": "Das Einreichungsformular konnte nicht geöffnet werden.",
+    "submit_preset": "Voreinstellung einreichen",
+    "submit_voice": "Stimme einreichen",
+    "zone_community": "Community"
   },
   "transcriptions": {
     "title": "Transkriptionen",
@@ -1338,7 +1366,8 @@
     "dub_label": "Dub",
     "save_label": "Speichern",
     "lock_identity": "Sprachidentität sperren",
-    "in_folder": "in {{folder}}"
+    "in_folder": "in {{folder}}",
+    "search": "Suchen…"
   },
   "trimmer": {
     "title": "Referenzaudio zuschneiden",
@@ -1730,5 +1759,16 @@
     "hf_token_saving": "speichert…",
     "hf_token_saved": "Hugging-Face-Token gespeichert",
     "hf_token_error": "Token konnte nicht gespeichert werden — erneut versuchen oder später in Einstellungen → Zugangsdaten setzen."
+  },
+  "history": {
+    "dub_title": "Dub-Verlauf",
+    "empty": "Hier ist noch nichts — Ihre Generierungen erscheinen rechts.",
+    "empty_dub": "Ihre Dubs erscheinen hier.",
+    "title": "Verlauf"
+  },
+  "recording": {
+    "cleaned_loaded": "Aufnahme bereinigt & geladen!",
+    "loaded_raw": "Aufnahme geladen (roh — Entrauschen nicht verfügbar)",
+    "too_short": "Aufnahme zu kurz"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -212,7 +212,11 @@
     "opt_high_pitch": "high pitch",
     "opt_very_high_pitch": "very high pitch",
     "opt_whisper": "whisper",
-    "style_placeholder": "e.g. whisper"
+    "style_placeholder": "e.g. whisper",
+    "define_by_design": "By design",
+    "define_from_audio": "From audio",
+    "define_voice": "Define voice",
+    "save_design_as_profile": "Save design as profile"
   },
   "settings": {
     "title": "Settings",
@@ -275,7 +279,16 @@
     "shortcut_set": "Dictation shortcut set to {{shortcut}}",
     "shortcut_register_failed": "Couldn't register: {{message}}",
     "shortcut_reset": "Reset to default",
-    "shortcut_reset_failed": "Reset failed: {{message}}"
+    "shortcut_reset_failed": "Reset failed: {{message}}",
+    "cancel": "Cancel",
+    "hf_token_also_clear": "Also clear",
+    "hf_token_clear_btn": "Clear token",
+    "hf_token_clear_confirm": "Clear the App-source HuggingFace token?",
+    "hf_token_clear_dialog": "Clear token",
+    "hf_token_input": "HuggingFace token",
+    "hf_token_sources": "HF token sources",
+    "hf_token_test_now": "Test now",
+    "hf_token_test_now_title": "Re-run whoami for every source"
   },
   "about": {
     "app": "App",
@@ -600,7 +613,14 @@
     "diagnostic_copied": "Diagnostic copied",
     "copy_failed": "Copy failed",
     "open_docs": "Open docs",
-    "copy_diagnostic": "Copy diagnostic"
+    "copy_diagnostic": "Copy diagnostic",
+    "advanced": "Advanced",
+    "cinematic_needs_llm_hint": "Cinematic needs an LLM. Configure one in Settings → Credentials → LLM endpoint (Ollama runs locally, no key needed).",
+    "generate_dub_multi": "Generate {{count}} dubs",
+    "pipeline": "Dubbing pipeline",
+    "preview_language": "Preview language",
+    "target_language": "Dub into",
+    "transcript_after_extract": "Transcript appears after extraction."
   },
   "glossary": {
     "title": "Glossary",
@@ -857,7 +877,15 @@
     "save_failed": "Could not save profile.",
     "confirm_delete": "Delete \"{{name}}\"?",
     "trim_load_failed": "Could not load audio for trimming.",
-    "delete": "Delete"
+    "delete": "Delete",
+    "community_empty": "No community voices loaded yet — connect to the internet and reopen, or be the first to submit one.",
+    "community_explainer": "Designed presets and recorded voices shared by the community, loaded from the omnivoice-gallery.",
+    "no_designer": "Recorded voice — use \"Use voice\" instead.",
+    "no_preview": "No preview — add it with \"Use voice\" to hear it.",
+    "submit_failed": "Could not open the submission form.",
+    "submit_preset": "Submit a preset",
+    "submit_voice": "Submit a voice",
+    "zone_community": "Community"
   },
   "archetypes": {
     "featured": "Featured",
@@ -1362,7 +1390,8 @@
     "dub_label": "Dub",
     "save_label": "Save",
     "lock_identity": "Lock voice identity",
-    "in_folder": "in {{folder}}"
+    "in_folder": "in {{folder}}",
+    "search": "Search…"
   },
   "logs": {
     "no_tauri_log": "No Tauri log on disk yet — launch via the desktop build to produce one",
@@ -1761,5 +1790,16 @@
     "hf_token_saving": "saving…",
     "hf_token_saved": "Hugging Face token saved",
     "hf_token_error": "Could not save the token — try again or set it later in Settings → Credentials."
+  },
+  "history": {
+    "dub_title": "Dub history",
+    "empty": "Nothing here yet — your generations will appear on the right.",
+    "empty_dub": "Your dubs will appear here.",
+    "title": "History"
+  },
+  "recording": {
+    "cleaned_loaded": "Recording cleaned & loaded!",
+    "loaded_raw": "Recording loaded (raw — denoising unavailable)",
+    "too_short": "Recording too short"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Atajo de dictado configurado en {{shortcut}}",
     "shortcut_register_failed": "No se pudo registrar: {{message}}",
     "shortcut_reset": "Restablecer los valores predeterminados",
-    "shortcut_reset_failed": "Error al restablecer: {{message}}"
+    "shortcut_reset_failed": "Error al restablecer: {{message}}",
+    "cancel": "Cancelar",
+    "hf_token_also_clear": "Borrar también",
+    "hf_token_clear_btn": "Borrar token",
+    "hf_token_clear_confirm": "¿Borrar el token de HuggingFace guardado por la aplicación?",
+    "hf_token_clear_dialog": "Borrar token",
+    "hf_token_input": "Token de HuggingFace",
+    "hf_token_sources": "Fuentes del token HF",
+    "hf_token_test_now": "Probar ahora",
+    "hf_token_test_now_title": "Volver a ejecutar whoami para cada fuente"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -320,7 +329,11 @@
     "describe_placeholder": "p. ej. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Tu descripción (en inglés) ajusta los controles de abajo; puedes afinarlos después.",
     "describe_unmatched": "No se pudo asignar: {{items}}",
-    "describe_no_match": "Aún no se reconocen rasgos de voz; prueba palabras como deep, elderly o British."
+    "describe_no_match": "Aún no se reconocen rasgos de voz; prueba palabras como deep, elderly o British.",
+    "define_by_design": "Por diseño",
+    "define_from_audio": "Desde audio",
+    "define_voice": "Definir voz",
+    "save_design_as_profile": "Guardar diseño como perfil"
   },
   "about": {
     "app": "Aplicación",
@@ -693,7 +706,14 @@
     "dialect_title": "Dialecto regional y vocabulario para la traducción (p. ej. Argentina → “vos sos” en lugar de “tú eres”). Lo aplican los motores LLM (OpenAI/Ollama) y la calidad Cinematic.",
     "num_speakers_label": "Hablantes",
     "num_speakers_auto": "Automático",
-    "num_speakers_help": "¿Cuántos hablantes hay en este vídeo? Déjalo vacío para detectarlo automáticamente. Indica un número si la detección automática fusiona varios hablantes en uno."
+    "num_speakers_help": "¿Cuántos hablantes hay en este vídeo? Déjalo vacío para detectarlo automáticamente. Indica un número si la detección automática fusiona varios hablantes en uno.",
+    "advanced": "Avanzado",
+    "cinematic_needs_llm_hint": "La calidad cinemática necesita un LLM. Configúralo en Configuración → Credenciales → URL base del LLM (Ollama funciona en local, no necesita clave).",
+    "generate_dub_multi": "Generar {{count}} doblajes",
+    "pipeline": "Flujo de doblaje",
+    "preview_language": "Idioma de vista previa",
+    "target_language": "Doblar a",
+    "transcript_after_extract": "La transcripción aparecerá tras la extracción."
   },
   "glossary": {
     "title": "Glosario",
@@ -956,7 +976,15 @@
     "save_failed": "No se pudo guardar el perfil.",
     "confirm_delete": "¿Eliminar \"{{name}}\"?",
     "trim_load_failed": "No se pudo cargar el audio para recortar.",
-    "delete": "Eliminar"
+    "delete": "Eliminar",
+    "community_empty": "Aún no se han cargado voces de la comunidad: conéctate a internet y vuelve a abrir, o sé el primero en enviar una.",
+    "community_explainer": "Preajustes diseñados y voces grabadas compartidos por la comunidad, cargados desde la omnivoice-gallery.",
+    "no_designer": "Voz grabada — usa \"Usar voz\" en su lugar.",
+    "no_preview": "Sin vista previa — añádela con \"Usar voz\" para escucharla.",
+    "submit_failed": "No se pudo abrir el formulario de envío.",
+    "submit_preset": "Enviar un preajuste",
+    "submit_voice": "Enviar una voz",
+    "zone_community": "Comunidad"
   },
   "transcriptions": {
     "title": "Transcripciones",
@@ -1338,7 +1366,8 @@
     "dub_label": "Doblar",
     "save_label": "Guardar",
     "lock_identity": "Bloquear identidad de voz",
-    "in_folder": "en {{folder}}"
+    "in_folder": "en {{folder}}",
+    "search": "Buscar…"
   },
   "trimmer": {
     "title": "Recortar audio de referencia",
@@ -1730,5 +1759,16 @@
     "hf_token_saving": "guardando…",
     "hf_token_saved": "Token de Hugging Face guardado",
     "hf_token_error": "No se pudo guardar el token — reintenta o configúralo luego en Ajustes → Credenciales."
+  },
+  "history": {
+    "dub_title": "Historial de doblajes",
+    "empty": "Aún no hay nada: tus generaciones aparecerán a la derecha.",
+    "empty_dub": "Tus doblajes aparecerán aquí.",
+    "title": "Historial"
+  },
+  "recording": {
+    "cleaned_loaded": "¡Grabación limpiada y cargada!",
+    "loaded_raw": "Grabación cargada (sin procesar — eliminación de ruido no disponible)",
+    "too_short": "Grabación demasiado corta"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Raccourci de dictée défini sur {{shortcut}}",
     "shortcut_register_failed": "Impossible de s'inscrire : {{message}}",
     "shortcut_reset": "Réinitialiser aux valeurs par défaut",
-    "shortcut_reset_failed": "Échec de la réinitialisation : {{message}}"
+    "shortcut_reset_failed": "Échec de la réinitialisation : {{message}}",
+    "cancel": "Annuler",
+    "hf_token_also_clear": "Effacer aussi",
+    "hf_token_clear_btn": "Effacer le jeton",
+    "hf_token_clear_confirm": "Effacer le jeton HuggingFace de la source App ?",
+    "hf_token_clear_dialog": "Effacer le jeton",
+    "hf_token_input": "Jeton HuggingFace",
+    "hf_token_sources": "Sources du jeton HF",
+    "hf_token_test_now": "Tester maintenant",
+    "hf_token_test_now_title": "Relancer whoami pour chaque source"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -320,7 +329,11 @@
     "describe_placeholder": "p. ex. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Votre description (en anglais) règle les contrôles ci-dessous — vous pouvez encore les ajuster après.",
     "describe_unmatched": "Impossible d'associer : {{items}}",
-    "describe_no_match": "Aucun trait vocal reconnu pour l'instant — essayez des mots comme deep, elderly ou British."
+    "describe_no_match": "Aucun trait vocal reconnu pour l'instant — essayez des mots comme deep, elderly ou British.",
+    "define_by_design": "Par conception",
+    "define_from_audio": "À partir de l'audio",
+    "define_voice": "Définir la voix",
+    "save_design_as_profile": "Enregistrer la conception en tant que profil"
   },
   "about": {
     "app": "Application",
@@ -693,7 +706,14 @@
     "dialect_title": "Dialecte régional et vocabulaire pour la traduction (p. ex. Argentine → « vos sos » au lieu de « tú eres »). Appliqué par les moteurs LLM (OpenAI/Ollama) et la qualité Cinematic.",
     "num_speakers_label": "Locuteurs",
     "num_speakers_auto": "Auto",
-    "num_speakers_help": "Combien de locuteurs dans cette vidéo ? Laissez vide pour la détection automatique. Indiquez un nombre si la détection fusionne plusieurs locuteurs en un seul."
+    "num_speakers_help": "Combien de locuteurs dans cette vidéo ? Laissez vide pour la détection automatique. Indiquez un nombre si la détection fusionne plusieurs locuteurs en un seul.",
+    "advanced": "Avancé",
+    "cinematic_needs_llm_hint": "Cinématique nécessite un LLM. Configurez-en un dans Paramètres → Identifiants → point de terminaison LLM (Ollama fonctionne localement, aucune clé requise).",
+    "generate_dub_multi": "Générer {{count}} doublages",
+    "pipeline": "Pipeline de doublage",
+    "preview_language": "Langue d'aperçu",
+    "target_language": "Doubler en",
+    "transcript_after_extract": "La transcription apparaît après l'extraction."
   },
   "glossary": {
     "title": "Glossaire",
@@ -956,7 +976,15 @@
     "save_failed": "Impossible d'enregistrer le profil.",
     "confirm_delete": "Supprimer « {{name}} » ?",
     "trim_load_failed": "Impossible de charger l'audio pour le découpage.",
-    "delete": "Supprimer"
+    "delete": "Supprimer",
+    "community_empty": "Aucune voix communautaire chargée pour l'instant — connectez-vous à internet et rouvrez, ou soyez le premier à en soumettre une.",
+    "community_explainer": "Préréglages conçus et voix enregistrées partagés par la communauté, chargés depuis l'omnivoice-gallery.",
+    "no_designer": "Voix enregistrée — utilisez plutôt « Utiliser la voix ».",
+    "no_preview": "Aucun aperçu — ajoutez-la avec « Utiliser la voix » pour l'entendre.",
+    "submit_failed": "Impossible d'ouvrir le formulaire de soumission.",
+    "submit_preset": "Soumettre un préréglage",
+    "submit_voice": "Soumettre une voix",
+    "zone_community": "Communauté"
   },
   "transcriptions": {
     "title": "Transcriptions",
@@ -1338,7 +1366,8 @@
     "dub_label": "Doublage",
     "save_label": "Enregistrer",
     "lock_identity": "Verrouiller l'identité vocale",
-    "in_folder": "en {{folder}}"
+    "in_folder": "en {{folder}}",
+    "search": "Rechercher…"
   },
   "trimmer": {
     "title": "Couper l'audio de référence",
@@ -1730,5 +1759,16 @@
     "hf_token_saving": "enregistrement…",
     "hf_token_saved": "Jeton Hugging Face enregistré",
     "hf_token_error": "Impossible d’enregistrer le jeton — réessayez ou configurez-le plus tard dans Réglages → Identifiants."
+  },
+  "history": {
+    "dub_title": "Historique des doublages",
+    "empty": "Rien ici pour l'instant — vos générations apparaîtront à droite.",
+    "empty_dub": "Vos doublages apparaîtront ici.",
+    "title": "Historique"
+  },
+  "recording": {
+    "cleaned_loaded": "Enregistrement nettoyé et chargé !",
+    "loaded_raw": "Enregistrement chargé (brut — débruitage indisponible)",
+    "too_short": "Enregistrement trop court"
   }
 }

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -74,7 +74,16 @@
     "shortcut_set": "डिक्टेशन शॉर्टकट {{shortcut}} पर सेट किया गया",
     "shortcut_register_failed": "पंजीकरण नहीं हो सका: {{message}}",
     "shortcut_reset": "डिफ़ॉल्ट पर रीसेट करें",
-    "shortcut_reset_failed": "रीसेट विफल: {{message}}"
+    "shortcut_reset_failed": "रीसेट विफल: {{message}}",
+    "cancel": "रद्द करें",
+    "hf_token_also_clear": "साथ ही साफ़ करें",
+    "hf_token_clear_btn": "टोकन साफ़ करें",
+    "hf_token_clear_confirm": "ऐप-स्रोत HuggingFace टोकन साफ़ करें?",
+    "hf_token_clear_dialog": "टोकन साफ़ करें",
+    "hf_token_input": "HuggingFace टोकन",
+    "hf_token_sources": "HF टोकन स्रोत",
+    "hf_token_test_now": "अभी परीक्षण करें",
+    "hf_token_test_now_title": "हर स्रोत के लिए whoami फिर से चलाएँ"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "उदा. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "आपका विवरण (अंग्रेज़ी में) नीचे के नियंत्रण सेट करता है — आप बाद में इन्हें बदल सकते हैं।",
     "describe_unmatched": "मैप नहीं हो सका: {{items}}",
-    "describe_no_match": "अभी कोई आवाज़ विशेषता पहचानी नहीं गई — deep, elderly या British जैसे शब्द आज़माएँ।"
+    "describe_no_match": "अभी कोई आवाज़ विशेषता पहचानी नहीं गई — deep, elderly या British जैसे शब्द आज़माएँ।",
+    "define_by_design": "डिज़ाइन से",
+    "define_from_audio": "ऑडियो से",
+    "define_voice": "आवाज़ परिभाषित करें",
+    "save_design_as_profile": "डिज़ाइन को प्रोफ़ाइल के रूप में सहेजें"
   },
   "about": {
     "app": "ऐप",
@@ -692,7 +705,14 @@
     "dialect_title": "अनुवाद के लिए क्षेत्रीय बोली और शब्दावली (जैसे अर्जेंटीना → “vos sos”, “tú eres” की जगह)। LLM इंजन (OpenAI/Ollama) और Cinematic गुणवत्ता द्वारा लागू।",
     "num_speakers_label": "वक्ता",
     "num_speakers_auto": "स्वतः",
-    "num_speakers_help": "इस वीडियो में कितने वक्ता हैं? स्वतः पहचान के लिए खाली छोड़ें। यदि स्वतः पहचान कई वक्ताओं को एक में मिला देती है तो संख्या निर्धारित करें।"
+    "num_speakers_help": "इस वीडियो में कितने वक्ता हैं? स्वतः पहचान के लिए खाली छोड़ें। यदि स्वतः पहचान कई वक्ताओं को एक में मिला देती है तो संख्या निर्धारित करें।",
+    "advanced": "उन्नत",
+    "cinematic_needs_llm_hint": "सिनेमाई के लिए एलएलएम चाहिए। इसे सेटिंग्स → क्रेडेंशियल → एलएलएम एंडपॉइंट में कॉन्फ़िगर करें (Ollama लोकली चलता है, किसी कुंजी की ज़रूरत नहीं)।",
+    "generate_dub_multi": "{{count}} डब उत्पन्न करें",
+    "pipeline": "डबिंग पाइपलाइन",
+    "preview_language": "पूर्वावलोकन भाषा",
+    "target_language": "इसमें डब करें",
+    "transcript_after_extract": "निकालने के बाद प्रतिलिपि दिखाई देगी।"
   },
   "glossary": {
     "title": "शब्दावली",
@@ -955,7 +975,15 @@
     "save_failed": "प्रोफ़ाइल सहेजी नहीं जा सकी.",
     "confirm_delete": "\"{{name}}\" हटाएं?",
     "trim_load_failed": "ट्रिमिंग के लिए ऑडियो लोड नहीं किया जा सका.",
-    "delete": "हटाएँ"
+    "delete": "हटाएँ",
+    "community_empty": "अभी तक कोई सामुदायिक आवाज़ें लोड नहीं हुईं — इंटरनेट से कनेक्ट करके फिर से खोलें, या सबसे पहले एक सबमिट करें।",
+    "community_explainer": "समुदाय द्वारा साझा किए गए डिज़ाइन प्रीसेट और रिकॉर्ड की गई आवाज़ें, omnivoice-gallery से लोड की गईं।",
+    "no_designer": "रिकॉर्ड की गई आवाज़ — इसके बजाय \"आवाज का प्रयोग करें\" इस्तेमाल करें।",
+    "no_preview": "कोई पूर्वावलोकन नहीं — इसे सुनने के लिए \"आवाज का प्रयोग करें\" से जोड़ें।",
+    "submit_failed": "सबमिशन फ़ॉर्म नहीं खोला जा सका।",
+    "submit_preset": "प्रीसेट सबमिट करें",
+    "submit_voice": "आवाज़ सबमिट करें",
+    "zone_community": "समुदाय"
   },
   "transcriptions": {
     "title": "प्रतिलेखन",
@@ -1337,7 +1365,8 @@
     "dub_label": "डब",
     "save_label": "सहेजें",
     "lock_identity": "आवाज की पहचान लॉक करें",
-    "in_folder": "{{folder}} में"
+    "in_folder": "{{folder}} में",
+    "search": "खोजें…"
   },
   "trimmer": {
     "title": "संदर्भ ऑडियो ट्रिम करें",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "सहेजा जा रहा है…",
     "hf_token_saved": "Hugging Face टोकन सहेजा गया",
     "hf_token_error": "टोकन सहेजा नहीं जा सका — फिर कोशिश करें या बाद में सेटिंग्स → क्रेडेंशियल्स में सेट करें।"
+  },
+  "history": {
+    "dub_title": "डब इतिहास",
+    "empty": "अभी यहाँ कुछ नहीं — आपकी पीढ़ियाँ दाईं ओर दिखाई देंगी।",
+    "empty_dub": "आपके डब यहाँ दिखाई देंगे।",
+    "title": "इतिहास"
+  },
+  "recording": {
+    "cleaned_loaded": "रिकॉर्डिंग साफ़ करके लोड हो गई!",
+    "loaded_raw": "रिकॉर्डिंग लोड हुई (रॉ — डेनोइज़िंग अनुपलब्ध)",
+    "too_short": "रिकॉर्डिंग बहुत छोटी है"
   }
 }

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Pintasan dikte disetel ke {{shortcut}}",
     "shortcut_register_failed": "Tidak dapat mendaftar: {{message}}",
     "shortcut_reset": "Atur ulang ke default",
-    "shortcut_reset_failed": "Penyetelan ulang gagal: {{message}}"
+    "shortcut_reset_failed": "Penyetelan ulang gagal: {{message}}",
+    "cancel": "Batalkan",
+    "hf_token_also_clear": "Hapus juga",
+    "hf_token_clear_btn": "Hapus token",
+    "hf_token_clear_confirm": "Hapus token HuggingFace dari sumber Aplikasi?",
+    "hf_token_clear_dialog": "Hapus token",
+    "hf_token_input": "Token HuggingFace",
+    "hf_token_sources": "Sumber token HF",
+    "hf_token_test_now": "Uji sekarang",
+    "hf_token_test_now_title": "Jalankan ulang whoami untuk setiap sumber"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "mis. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Deskripsi Anda (dalam bahasa Inggris) mengatur kontrol di bawah — Anda tetap bisa menyetelnya setelahnya.",
     "describe_unmatched": "Tidak dapat dipetakan: {{items}}",
-    "describe_no_match": "Belum ada ciri suara yang dikenali — coba kata seperti deep, elderly, atau British."
+    "describe_no_match": "Belum ada ciri suara yang dikenali — coba kata seperti deep, elderly, atau British.",
+    "define_by_design": "Lewat desain",
+    "define_from_audio": "Dari audio",
+    "define_voice": "Tentukan suara",
+    "save_design_as_profile": "Simpan desain sebagai profil"
   },
   "about": {
     "app": "Aplikasi",
@@ -692,7 +705,14 @@
     "dialect_title": "Dialek regional dan kosakata untuk terjemahan (mis. Argentina → “vos sos” alih-alih “tú eres”). Diterapkan oleh mesin LLM (OpenAI/Ollama) dan kualitas Cinematic.",
     "num_speakers_label": "Pembicara",
     "num_speakers_auto": "Otomatis",
-    "num_speakers_help": "Berapa banyak pembicara dalam video ini? Biarkan kosong untuk deteksi otomatis. Tetapkan angka jika deteksi otomatis menggabungkan beberapa pembicara menjadi satu."
+    "num_speakers_help": "Berapa banyak pembicara dalam video ini? Biarkan kosong untuk deteksi otomatis. Tetapkan angka jika deteksi otomatis menggabungkan beberapa pembicara menjadi satu.",
+    "advanced": "Lanjutan",
+    "cinematic_needs_llm_hint": "Sinematik memerlukan LLM. Konfigurasikan di Pengaturan → Kredensial → titik akhir LLM (Ollama berjalan secara lokal, tanpa kunci).",
+    "generate_dub_multi": "Hasilkan {{count}} dub",
+    "pipeline": "Alur sulih suara",
+    "preview_language": "Bahasa pratinjau",
+    "target_language": "Sulih suara ke",
+    "transcript_after_extract": "Transkrip muncul setelah ekstraksi."
   },
   "glossary": {
     "title": "Glosarium",
@@ -955,7 +975,15 @@
     "save_failed": "Tidak dapat menyimpan profil.",
     "confirm_delete": "Hapus \"{{name}}\"?",
     "trim_load_failed": "Tidak dapat memuat audio untuk pemangkasan.",
-    "delete": "Hapus"
+    "delete": "Hapus",
+    "community_empty": "Belum ada suara komunitas yang dimuat — sambungkan ke internet lalu buka kembali, atau jadilah yang pertama mengirimkannya.",
+    "community_explainer": "Preset desain dan suara rekaman yang dibagikan komunitas, dimuat dari omnivoice-gallery.",
+    "no_designer": "Suara rekaman — gunakan \"Gunakan suara\" sebagai gantinya.",
+    "no_preview": "Tidak ada pratinjau — tambahkan dengan \"Gunakan suara\" untuk mendengarnya.",
+    "submit_failed": "Tidak dapat membuka formulir pengiriman.",
+    "submit_preset": "Kirim preset",
+    "submit_voice": "Kirim suara",
+    "zone_community": "Komunitas"
   },
   "transcriptions": {
     "title": "Transkripsi",
@@ -1337,7 +1365,8 @@
     "dub_label": "sulih suara",
     "save_label": "Simpan",
     "lock_identity": "Kunci identitas suara",
-    "in_folder": "di {{folder}}"
+    "in_folder": "di {{folder}}",
+    "search": "Cari…"
   },
   "trimmer": {
     "title": "Pangkas audio referensi",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "menyimpan…",
     "hf_token_saved": "Token Hugging Face tersimpan",
     "hf_token_error": "Gagal menyimpan token — coba lagi atau atur nanti di Pengaturan → Kredensial."
+  },
+  "history": {
+    "dub_title": "Riwayat sulih suara",
+    "empty": "Belum ada apa pun di sini — hasil generasi Anda akan muncul di sebelah kanan.",
+    "empty_dub": "Sulih suara Anda akan muncul di sini.",
+    "title": "Riwayat"
+  },
+  "recording": {
+    "cleaned_loaded": "Rekaman dibersihkan & dimuat!",
+    "loaded_raw": "Rekaman dimuat (mentah — penghilang derau tidak tersedia)",
+    "too_short": "Rekaman terlalu pendek"
   }
 }

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Scorciatoia per la dettatura impostata su {{shortcut}}",
     "shortcut_register_failed": "Impossibile registrarsi: {{message}}",
     "shortcut_reset": "Ripristina le impostazioni predefinite",
-    "shortcut_reset_failed": "Reimpostazione non riuscita: {{message}}"
+    "shortcut_reset_failed": "Reimpostazione non riuscita: {{message}}",
+    "cancel": "Annulla",
+    "hf_token_also_clear": "Cancella anche",
+    "hf_token_clear_btn": "Cancella token",
+    "hf_token_clear_confirm": "Cancellare il token HuggingFace della sorgente App?",
+    "hf_token_clear_dialog": "Cancella token",
+    "hf_token_input": "Token HuggingFace",
+    "hf_token_sources": "Sorgenti del token HF",
+    "hf_token_test_now": "Testa ora",
+    "hf_token_test_now_title": "Riesegui whoami per ogni sorgente"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "es. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "La tua descrizione (in inglese) imposta i controlli qui sotto — puoi comunque regolarli dopo.",
     "describe_unmatched": "Impossibile mappare: {{items}}",
-    "describe_no_match": "Nessun tratto vocale riconosciuto — prova parole come deep, elderly o British."
+    "describe_no_match": "Nessun tratto vocale riconosciuto — prova parole come deep, elderly o British.",
+    "define_by_design": "Tramite progettazione",
+    "define_from_audio": "Da audio",
+    "define_voice": "Definisci la voce",
+    "save_design_as_profile": "Salva il progetto come profilo"
   },
   "about": {
     "app": "App",
@@ -692,7 +705,14 @@
     "dialect_title": "Dialetto regionale e lessico per la traduzione (es. Argentina → “vos sos” invece di “tú eres”). Applicato dai motori LLM (OpenAI/Ollama) e dalla qualità Cinematic.",
     "num_speakers_label": "Parlanti",
     "num_speakers_auto": "Auto",
-    "num_speakers_help": "Quanti parlanti ci sono in questo video? Lascia vuoto per il rilevamento automatico. Imposta un numero se il rilevamento unisce più parlanti in uno."
+    "num_speakers_help": "Quanti parlanti ci sono in questo video? Lascia vuoto per il rilevamento automatico. Imposta un numero se il rilevamento unisce più parlanti in uno.",
+    "advanced": "Avanzate",
+    "cinematic_needs_llm_hint": "Cinematografico richiede un LLM. Configurane uno in Impostazioni → Credenziali → endpoint LLM (Ollama funziona in locale, nessuna chiave necessaria).",
+    "generate_dub_multi": "Genera {{count}} doppiaggi",
+    "pipeline": "Pipeline di doppiaggio",
+    "preview_language": "Lingua di anteprima",
+    "target_language": "Doppia in",
+    "transcript_after_extract": "La trascrizione appare dopo l'estrazione."
   },
   "glossary": {
     "title": "Glossario",
@@ -955,7 +975,15 @@
     "save_failed": "Impossibile salvare il profilo.",
     "confirm_delete": "Eliminare \"{{name}}\"?",
     "trim_load_failed": "Impossibile caricare l'audio per il ritaglio.",
-    "delete": "Elimina"
+    "delete": "Elimina",
+    "community_empty": "Nessuna voce della community caricata — connettiti a internet e riapri, oppure sii il primo a inviarne una.",
+    "community_explainer": "Preimpostazioni progettate e voci registrate condivise dalla community, caricate dalla omnivoice-gallery.",
+    "no_designer": "Voce registrata — usa invece \"Usa la voce\".",
+    "no_preview": "Nessuna anteprima — aggiungila con \"Usa la voce\" per ascoltarla.",
+    "submit_failed": "Impossibile aprire il modulo di invio.",
+    "submit_preset": "Invia una preimpostazione",
+    "submit_voice": "Invia una voce",
+    "zone_community": "Community"
   },
   "transcriptions": {
     "title": "Trascrizioni",
@@ -1337,7 +1365,8 @@
     "dub_label": "Duplicare",
     "save_label": "Salva",
     "lock_identity": "Blocca l'identità vocale",
-    "in_folder": "tra {{folder}}"
+    "in_folder": "tra {{folder}}",
+    "search": "Cerca…"
   },
   "trimmer": {
     "title": "Taglia l'audio di riferimento",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "salvataggio…",
     "hf_token_saved": "Token Hugging Face salvato",
     "hf_token_error": "Impossibile salvare il token — riprova o impostalo dopo in Impostazioni → Credenziali."
+  },
+  "history": {
+    "dub_title": "Cronologia doppiaggi",
+    "empty": "Ancora niente qui — le tue generazioni appariranno sulla destra.",
+    "empty_dub": "I tuoi doppiaggi appariranno qui.",
+    "title": "Cronologia"
+  },
+  "recording": {
+    "cleaned_loaded": "Registrazione pulita e caricata!",
+    "loaded_raw": "Registrazione caricata (grezza — eliminazione del rumore non disponibile)",
+    "too_short": "Registrazione troppo breve"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -74,7 +74,16 @@
     "shortcut_set": "ディクテーションのショートカットが {{shortcut}} に設定されました",
     "shortcut_register_failed": "登録できませんでした: {{message}}",
     "shortcut_reset": "デフォルトにリセットする",
-    "shortcut_reset_failed": "リセットに失敗しました: {{message}}"
+    "shortcut_reset_failed": "リセットに失敗しました: {{message}}",
+    "cancel": "キャンセル",
+    "hf_token_also_clear": "あわせてクリア",
+    "hf_token_clear_btn": "トークンをクリア",
+    "hf_token_clear_confirm": "アプリに保存された HuggingFace トークンをクリアしますか?",
+    "hf_token_clear_dialog": "トークンをクリア",
+    "hf_token_input": "HuggingFace トークン",
+    "hf_token_sources": "HF トークンのソース",
+    "hf_token_test_now": "今すぐテスト",
+    "hf_token_test_now_title": "すべてのソースで whoami を再実行します"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -320,7 +329,11 @@
     "describe_placeholder": "例: a warm elderly British storyteller, slightly raspy",
     "describe_hint": "説明（英語）が下のコントロールを設定します。後から微調整もできます。",
     "describe_unmatched": "対応付けできません: {{items}}",
-    "describe_no_match": "まだ声の特徴を認識できていません。deep、elderly、British などの単語を試してください。"
+    "describe_no_match": "まだ声の特徴を認識できていません。deep、elderly、British などの単語を試してください。",
+    "define_by_design": "デザインで",
+    "define_from_audio": "音声から",
+    "define_voice": "音声の定義",
+    "save_design_as_profile": "デザインをプロファイルとして保存"
   },
   "about": {
     "app": "アプリ",
@@ -693,7 +706,14 @@
     "dialect_title": "翻訳に使う地域の方言と語彙（例: アルゼンチン → “tú eres” ではなく “vos sos”）。LLM エンジン（OpenAI/Ollama）と Cinematic 品質で適用されます。",
     "num_speakers_label": "話者",
     "num_speakers_auto": "自動",
-    "num_speakers_help": "この動画の話者は何人ですか？空欄で自動検出します。自動検出が複数の話者を1人にまとめてしまう場合は人数を指定してください。"
+    "num_speakers_help": "この動画の話者は何人ですか？空欄で自動検出します。自動検出が複数の話者を1人にまとめてしまう場合は人数を指定してください。",
+    "advanced": "詳細設定",
+    "cinematic_needs_llm_hint": "映画的品質には LLM が必要です。設定 → 資格情報 → LLM エンドポイントで設定してください（Ollama はローカルで動作し、キーは不要です）。",
+    "generate_dub_multi": "{{count}} 件のダブを生成",
+    "pipeline": "ダビングパイプライン",
+    "preview_language": "プレビュー言語",
+    "target_language": "吹き替え先",
+    "transcript_after_extract": "文字起こしは抽出後に表示されます。"
   },
   "glossary": {
     "title": "用語集",
@@ -956,7 +976,15 @@
     "save_failed": "プロフィールを保存できませんでした。",
     "confirm_delete": "「{{name}}」を削除しますか?",
     "trim_load_failed": "トリミングするオーディオをロードできませんでした。",
-    "delete": "削除"
+    "delete": "削除",
+    "community_empty": "コミュニティの音声はまだ読み込まれていません — インターネットに接続して開き直すか、最初の投稿者になりましょう。",
+    "community_explainer": "コミュニティが共有したデザイン済みプリセットと録音音声です。omnivoice-gallery から読み込まれます。",
+    "no_designer": "録音された音声です — 代わりに「音声を使用する」をお使いください。",
+    "no_preview": "プレビューはありません — 「音声を使用する」で追加すると聞けます。",
+    "submit_failed": "投稿フォームを開けませんでした。",
+    "submit_preset": "プリセットを投稿",
+    "submit_voice": "音声を投稿",
+    "zone_community": "コミュニティ"
   },
   "transcriptions": {
     "title": "転写",
@@ -1338,7 +1366,8 @@
     "dub_label": "ダブ",
     "save_label": "保存",
     "lock_identity": "音声 ID をロックする",
-    "in_folder": "{{folder}} に"
+    "in_folder": "{{folder}} に",
+    "search": "検索…"
   },
   "trimmer": {
     "title": "リファレンスオーディオをトリミングする",
@@ -1730,5 +1759,16 @@
     "hf_token_saving": "保存中…",
     "hf_token_saved": "Hugging Face トークンを保存しました",
     "hf_token_error": "トークンを保存できませんでした。再試行するか、後で設定 → 認証情報から設定してください。"
+  },
+  "history": {
+    "dub_title": "ダブ履歴",
+    "empty": "まだ何もありません — 生成結果が右側に表示されます。",
+    "empty_dub": "ダブはここに表示されます。",
+    "title": "履歴"
+  },
+  "recording": {
+    "cleaned_loaded": "録音をクリーンアップして読み込みました！",
+    "loaded_raw": "録音を読み込みました（未処理 — ノイズ除去は利用できません）",
+    "too_short": "録音が短すぎます"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -74,7 +74,16 @@
     "shortcut_set": "받아쓰기 단축키가 {{shortcut}}로 설정되었습니다.",
     "shortcut_register_failed": "등록할 수 없습니다: {{message}}",
     "shortcut_reset": "기본값으로 재설정",
-    "shortcut_reset_failed": "재설정 실패: {{message}}"
+    "shortcut_reset_failed": "재설정 실패: {{message}}",
+    "cancel": "취소",
+    "hf_token_also_clear": "함께 지우기",
+    "hf_token_clear_btn": "토큰 지우기",
+    "hf_token_clear_confirm": "앱 소스 HuggingFace 토큰을 지우시겠습니까?",
+    "hf_token_clear_dialog": "토큰 지우기",
+    "hf_token_input": "HuggingFace 토큰",
+    "hf_token_sources": "HF 토큰 소스",
+    "hf_token_test_now": "지금 테스트",
+    "hf_token_test_now_title": "모든 소스에 대해 whoami 다시 실행"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "예: a warm elderly British storyteller, slightly raspy",
     "describe_hint": "설명(영어)이 아래 컨트롤을 설정합니다. 이후에 직접 조정할 수도 있습니다.",
     "describe_unmatched": "매핑할 수 없음: {{items}}",
-    "describe_no_match": "아직 인식된 목소리 특징이 없습니다. deep, elderly, British 같은 단어를 사용해 보세요."
+    "describe_no_match": "아직 인식된 목소리 특징이 없습니다. deep, elderly, British 같은 단어를 사용해 보세요.",
+    "define_by_design": "디자인으로",
+    "define_from_audio": "오디오에서",
+    "define_voice": "음성 정의",
+    "save_design_as_profile": "디자인을 프로필로 저장"
   },
   "about": {
     "app": "앱",
@@ -692,7 +705,14 @@
     "dialect_title": "번역에 적용할 지역 방언과 어휘 (예: 아르헨티나 → “tú eres” 대신 “vos sos”). LLM 엔진(OpenAI/Ollama)과 Cinematic 품질에서 적용됩니다.",
     "num_speakers_label": "화자",
     "num_speakers_auto": "자동",
-    "num_speakers_help": "이 영상에 화자가 몇 명인가요? 비워 두면 자동 감지합니다. 자동 감지가 여러 화자를 한 명으로 합치는 경우 숫자를 지정하세요."
+    "num_speakers_help": "이 영상에 화자가 몇 명인가요? 비워 두면 자동 감지합니다. 자동 감지가 여러 화자를 한 명으로 합치는 경우 숫자를 지정하세요.",
+    "advanced": "고급",
+    "cinematic_needs_llm_hint": "시네마틱에는 LLM이 필요합니다. 설정 → 자격 증명 → LLM 엔드포인트에서 구성하세요 (Ollama는 로컬에서 실행되며 키가 필요 없습니다).",
+    "generate_dub_multi": "더빙 {{count}}개 생성",
+    "pipeline": "더빙 파이프라인",
+    "preview_language": "미리보기 언어",
+    "target_language": "더빙할 언어",
+    "transcript_after_extract": "추출이 끝나면 대본이 표시됩니다."
   },
   "glossary": {
     "title": "용어집",
@@ -955,7 +975,15 @@
     "save_failed": "프로필을 저장할 수 없습니다.",
     "confirm_delete": "'{{name}}'을 삭제하시겠습니까?",
     "trim_load_failed": "다듬기 위해 오디오를 로드할 수 없습니다.",
-    "delete": "삭제"
+    "delete": "삭제",
+    "community_empty": "아직 로드된 커뮤니티 음성이 없습니다 — 인터넷에 연결한 뒤 다시 열거나, 첫 번째로 제출해 보세요.",
+    "community_explainer": "커뮤니티가 공유한 디자인 프리셋과 녹음 음성으로, omnivoice-gallery에서 로드됩니다.",
+    "no_designer": "녹음된 음성입니다 — 대신 \"음성 사용\"을 이용하세요.",
+    "no_preview": "미리보기 없음 — \"음성 사용\"으로 추가하면 들을 수 있습니다.",
+    "submit_failed": "제출 양식을 열 수 없습니다.",
+    "submit_preset": "프리셋 제출",
+    "submit_voice": "음성 제출",
+    "zone_community": "커뮤니티"
   },
   "transcriptions": {
     "title": "전사",
@@ -1337,7 +1365,8 @@
     "dub_label": "더빙",
     "save_label": "저장",
     "lock_identity": "음성 신원 잠금",
-    "in_folder": "{{folder}}에서"
+    "in_folder": "{{folder}}에서",
+    "search": "검색…"
   },
   "trimmer": {
     "title": "참조 오디오 다듬기",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "저장 중…",
     "hf_token_saved": "Hugging Face 토큰 저장됨",
     "hf_token_error": "토큰을 저장하지 못했습니다 — 다시 시도하거나 나중에 설정 → 자격 증명에서 설정하세요."
+  },
+  "history": {
+    "dub_title": "더빙 기록",
+    "empty": "아직 아무것도 없습니다 — 생성 결과가 오른쪽에 표시됩니다.",
+    "empty_dub": "더빙 결과가 여기에 표시됩니다.",
+    "title": "기록"
+  },
+  "recording": {
+    "cleaned_loaded": "녹음이 정리되어 로드되었습니다!",
+    "loaded_raw": "녹음이 로드되었습니다 (원본 — 노이즈 제거 사용 불가)",
+    "too_short": "녹음이 너무 짧습니다"
   }
 }

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Dicteersnelkoppeling ingesteld op {{shortcut}}",
     "shortcut_register_failed": "Kon niet registreren: {{message}}",
     "shortcut_reset": "Resetten naar standaard",
-    "shortcut_reset_failed": "Reset mislukt: {{message}}"
+    "shortcut_reset_failed": "Reset mislukt: {{message}}",
+    "cancel": "Annuleer",
+    "hf_token_also_clear": "Ook wissen",
+    "hf_token_clear_btn": "Token wissen",
+    "hf_token_clear_confirm": "De HuggingFace-token uit de app-bron wissen?",
+    "hf_token_clear_dialog": "Token wissen",
+    "hf_token_input": "HuggingFace-token",
+    "hf_token_sources": "HF-tokenbronnen",
+    "hf_token_test_now": "Nu testen",
+    "hf_token_test_now_title": "Voer whoami opnieuw uit voor elke bron"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "bijv. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Je beschrijving (in het Engels) stelt de regelaars hieronder in — je kunt ze daarna bijstellen.",
     "describe_unmatched": "Kon niet toewijzen: {{items}}",
-    "describe_no_match": "Nog geen stemkenmerken herkend — probeer woorden als deep, elderly of British."
+    "describe_no_match": "Nog geen stemkenmerken herkend — probeer woorden als deep, elderly of British.",
+    "define_by_design": "Via ontwerp",
+    "define_from_audio": "Vanuit audio",
+    "define_voice": "Stem definiëren",
+    "save_design_as_profile": "Ontwerp opslaan als profiel"
   },
   "about": {
     "app": "App",
@@ -692,7 +705,14 @@
     "dialect_title": "Regionaal dialect en vocabulaire voor de vertaling (bijv. Argentinië → “vos sos” in plaats van “tú eres”). Toegepast door LLM-engines (OpenAI/Ollama) en Cinematic-kwaliteit.",
     "num_speakers_label": "Sprekers",
     "num_speakers_auto": "Automatisch",
-    "num_speakers_help": "Hoeveel sprekers zijn er in deze video? Laat leeg voor automatische detectie. Stel een aantal in als de detectie meerdere sprekers samenvoegt tot één."
+    "num_speakers_help": "Hoeveel sprekers zijn er in deze video? Laat leeg voor automatische detectie. Stel een aantal in als de detectie meerdere sprekers samenvoegt tot één.",
+    "advanced": "Geavanceerd",
+    "cinematic_needs_llm_hint": "Filmisch heeft een LLM nodig. Stel er een in via Instellingen → Inloggegevens → LLM-eindpunt (Ollama draait lokaal, geen sleutel nodig).",
+    "generate_dub_multi": "{{count}} dubs genereren",
+    "pipeline": "Dubbing-pipeline",
+    "preview_language": "Voorbeeldtaal",
+    "target_language": "Dubben naar",
+    "transcript_after_extract": "Het afschrift verschijnt na extractie."
   },
   "glossary": {
     "title": "Woordenlijst",
@@ -955,7 +975,15 @@
     "save_failed": "Kan profiel niet opslaan.",
     "confirm_delete": "\"{{name}}\" verwijderen?",
     "trim_load_failed": "Kan audio voor bijsnijden niet laden.",
-    "delete": "Verwijderen"
+    "delete": "Verwijderen",
+    "community_empty": "Nog geen community-stemmen geladen — maak verbinding met internet en open opnieuw, of wees de eerste die er een indient.",
+    "community_explainer": "Ontworpen presets en opgenomen stemmen gedeeld door de community, geladen vanuit de omnivoice-gallery.",
+    "no_designer": "Opgenomen stem — gebruik in plaats daarvan \"Gebruik stem\".",
+    "no_preview": "Geen voorbeeld — voeg de stem toe met \"Gebruik stem\" om hem te horen.",
+    "submit_failed": "Het indieningsformulier kon niet worden geopend.",
+    "submit_preset": "Preset indienen",
+    "submit_voice": "Stem indienen",
+    "zone_community": "Community"
   },
   "transcriptions": {
     "title": "Transcripties",
@@ -1337,7 +1365,8 @@
     "dub_label": "Dub",
     "save_label": "Opslaan",
     "lock_identity": "Stemidentiteit vergrendelen",
-    "in_folder": "in {{folder}}"
+    "in_folder": "in {{folder}}",
+    "search": "Zoeken…"
   },
   "trimmer": {
     "title": "Referentie-audio trimmen",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "opslaan…",
     "hf_token_saved": "Hugging Face-token opgeslagen",
     "hf_token_error": "Token kon niet worden opgeslagen — probeer opnieuw of stel het later in via Instellingen → Inloggegevens."
+  },
+  "history": {
+    "dub_title": "Dubgeschiedenis",
+    "empty": "Hier is nog niets — je generaties verschijnen rechts.",
+    "empty_dub": "Je dubs verschijnen hier.",
+    "title": "Geschiedenis"
+  },
+  "recording": {
+    "cleaned_loaded": "Opname opgeschoond en geladen!",
+    "loaded_raw": "Opname geladen (ruw — ruisonderdrukking niet beschikbaar)",
+    "too_short": "Opname te kort"
   }
 }

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Skrót do dyktowania ustawiony na {{shortcut}}",
     "shortcut_register_failed": "Nie udało się zarejestrować: {{message}}",
     "shortcut_reset": "Przywróć ustawienia domyślne",
-    "shortcut_reset_failed": "Resetowanie nie powiodło się: {{message}}"
+    "shortcut_reset_failed": "Resetowanie nie powiodło się: {{message}}",
+    "cancel": "Anuluj",
+    "hf_token_also_clear": "Wyczyść również",
+    "hf_token_clear_btn": "Wyczyść token",
+    "hf_token_clear_confirm": "Wyczyścić token HuggingFace ze źródła „Aplikacja”?",
+    "hf_token_clear_dialog": "Wyczyść token",
+    "hf_token_input": "Token HuggingFace",
+    "hf_token_sources": "Źródła tokenu HF",
+    "hf_token_test_now": "Testuj teraz",
+    "hf_token_test_now_title": "Uruchom ponownie whoami dla każdego źródła"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "np. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Twój opis (po angielsku) ustawia poniższe kontrolki — możesz je potem doprecyzować.",
     "describe_unmatched": "Nie udało się dopasować: {{items}}",
-    "describe_no_match": "Nie rozpoznano jeszcze cech głosu — spróbuj słów takich jak deep, elderly lub British."
+    "describe_no_match": "Nie rozpoznano jeszcze cech głosu — spróbuj słów takich jak deep, elderly lub British.",
+    "define_by_design": "Według projektu",
+    "define_from_audio": "Z audio",
+    "define_voice": "Zdefiniuj głos",
+    "save_design_as_profile": "Zapisz projekt jako profil"
   },
   "about": {
     "app": "Aplikacja",
@@ -692,7 +705,14 @@
     "dialect_title": "Regionalny dialekt i słownictwo tłumaczenia (np. Argentyna → „vos sos” zamiast „tú eres”). Stosowane przez silniki LLM (OpenAI/Ollama) i jakość Cinematic.",
     "num_speakers_label": "Mówcy",
     "num_speakers_auto": "Automatycznie",
-    "num_speakers_help": "Ilu mówców jest w tym wideo? Pozostaw puste, aby wykryć automatycznie. Podaj liczbę, jeśli automatyczne wykrywanie łączy kilku mówców w jednego."
+    "num_speakers_help": "Ilu mówców jest w tym wideo? Pozostaw puste, aby wykryć automatycznie. Podaj liczbę, jeśli automatyczne wykrywanie łączy kilku mówców w jednego.",
+    "advanced": "Zaawansowane",
+    "cinematic_needs_llm_hint": "Tryb Filmowy wymaga LLM. Skonfiguruj go w Ustawienia → Dane uwierzytelniające → Punkt końcowy LLM (Ollama działa lokalnie, bez klucza).",
+    "generate_dub_multi": "Wygeneruj dubbingi ({{count}})",
+    "pipeline": "Proces dubbingu",
+    "preview_language": "Język podglądu",
+    "target_language": "Dubbinguj na",
+    "transcript_after_extract": "Transkrypcja pojawi się po ekstrakcji."
   },
   "glossary": {
     "title": "Glosariusz",
@@ -955,7 +975,15 @@
     "save_failed": "Nie udało się zapisać profilu.",
     "confirm_delete": "Usunąć „{{name}}”?",
     "trim_load_failed": "Nie można wczytać dźwięku do przycięcia.",
-    "delete": "Usuń"
+    "delete": "Usuń",
+    "community_empty": "Nie załadowano jeszcze głosów społeczności — połącz się z internetem i otwórz ponownie albo prześlij pierwszy.",
+    "community_explainer": "Zaprojektowane ustawienia wstępne i nagrane głosy udostępnione przez społeczność, ładowane z omnivoice-gallery.",
+    "no_designer": "Nagrany głos — użyj zamiast tego opcji „Użyj głosu”.",
+    "no_preview": "Brak podglądu — dodaj go opcją „Użyj głosu”, aby odsłuchać.",
+    "submit_failed": "Nie udało się otworzyć formularza zgłoszenia.",
+    "submit_preset": "Prześlij ustawienie wstępne",
+    "submit_voice": "Prześlij głos",
+    "zone_community": "Społeczność"
   },
   "transcriptions": {
     "title": "Transkrypcje",
@@ -1337,7 +1365,8 @@
     "dub_label": "Dub",
     "save_label": "Zapisz",
     "lock_identity": "Zablokuj tożsamość głosową",
-    "in_folder": "w {{folder}}"
+    "in_folder": "w {{folder}}",
+    "search": "Szukaj…"
   },
   "trimmer": {
     "title": "Przytnij dźwięk referencyjny",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "zapisywanie…",
     "hf_token_saved": "Token Hugging Face zapisany",
     "hf_token_error": "Nie udało się zapisać tokenu — spróbuj ponownie lub ustaw go później w Ustawieniach → Dane logowania."
+  },
+  "history": {
+    "dub_title": "Historia dubbingu",
+    "empty": "Nic tu jeszcze nie ma — Twoje generacje pojawią się po prawej stronie.",
+    "empty_dub": "Tutaj pojawią się Twoje dubbingi.",
+    "title": "Historia"
+  },
+  "recording": {
+    "cleaned_loaded": "Nagranie oczyszczone i załadowane!",
+    "loaded_raw": "Nagranie załadowane (surowe — odszumianie niedostępne)",
+    "too_short": "Nagranie zbyt krótkie"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Atalho de ditado definido como {{shortcut}}",
     "shortcut_register_failed": "Não foi possível registrar: {{message}}",
     "shortcut_reset": "Redefinir para o padrão",
-    "shortcut_reset_failed": "Falha na reinicialização: {{message}}"
+    "shortcut_reset_failed": "Falha na reinicialização: {{message}}",
+    "cancel": "Cancelar",
+    "hf_token_also_clear": "Limpar também",
+    "hf_token_clear_btn": "Limpar token",
+    "hf_token_clear_confirm": "Limpar o token HuggingFace da fonte App?",
+    "hf_token_clear_dialog": "Limpar token",
+    "hf_token_input": "Token HuggingFace",
+    "hf_token_sources": "Fontes do token HF",
+    "hf_token_test_now": "Testar agora",
+    "hf_token_test_now_title": "Reexecutar whoami para cada fonte"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "ex.: a warm elderly British storyteller, slightly raspy",
     "describe_hint": "A sua descrição (em inglês) define os controlos abaixo — pode afiná-los depois.",
     "describe_unmatched": "Não foi possível mapear: {{items}}",
-    "describe_no_match": "Ainda não foram reconhecidos traços de voz — experimente palavras como deep, elderly ou British."
+    "describe_no_match": "Ainda não foram reconhecidos traços de voz — experimente palavras como deep, elderly ou British.",
+    "define_by_design": "Por design",
+    "define_from_audio": "A partir de áudio",
+    "define_voice": "Definir voz",
+    "save_design_as_profile": "Salvar design como perfil"
   },
   "about": {
     "app": "Aplicativo",
@@ -692,7 +705,14 @@
     "dialect_title": "Dialeto regional e vocabulário para a tradução (ex.: Argentina → “vos sos” em vez de “tú eres”). Aplicado pelos motores LLM (OpenAI/Ollama) e pela qualidade Cinematic.",
     "num_speakers_label": "Falantes",
     "num_speakers_auto": "Automático",
-    "num_speakers_help": "Quantos falantes há neste vídeo? Deixe em branco para detecção automática. Defina um número se a detecção automática mesclar vários falantes em um."
+    "num_speakers_help": "Quantos falantes há neste vídeo? Deixe em branco para detecção automática. Defina um número se a detecção automática mesclar vários falantes em um.",
+    "advanced": "Avançado",
+    "cinematic_needs_llm_hint": "O Cinematográfico precisa de um LLM. Configure um em Configurações → Credenciais → endpoint do LLM (o Ollama roda localmente, sem precisar de chave).",
+    "generate_dub_multi": "Gerar {{count}} dublagens",
+    "pipeline": "Pipeline de dublagem",
+    "preview_language": "Idioma da visualização",
+    "target_language": "Dublar para",
+    "transcript_after_extract": "A transcrição aparece após a extração."
   },
   "glossary": {
     "title": "Glossário",
@@ -955,7 +975,15 @@
     "save_failed": "Não foi possível salvar o perfil.",
     "confirm_delete": "Excluir \"{{name}}\"?",
     "trim_load_failed": "Não foi possível carregar o áudio para corte.",
-    "delete": "Excluir"
+    "delete": "Excluir",
+    "community_empty": "Nenhuma voz da comunidade carregada ainda — conecte-se à internet e reabra, ou seja o primeiro a enviar uma.",
+    "community_explainer": "Predefinições projetadas e vozes gravadas compartilhadas pela comunidade, carregadas da omnivoice-gallery.",
+    "no_designer": "Voz gravada — use \"Usar voz\" em vez disso.",
+    "no_preview": "Sem visualização — adicione-a com \"Usar voz\" para ouvi-la.",
+    "submit_failed": "Não foi possível abrir o formulário de envio.",
+    "submit_preset": "Enviar uma predefinição",
+    "submit_voice": "Enviar uma voz",
+    "zone_community": "Comunidade"
   },
   "transcriptions": {
     "title": "Transcrições",
@@ -1337,7 +1365,8 @@
     "dub_label": "Duplicar",
     "save_label": "Salvar",
     "lock_identity": "Bloquear identidade de voz",
-    "in_folder": "em {{folder}}"
+    "in_folder": "em {{folder}}",
+    "search": "Pesquisar…"
   },
   "trimmer": {
     "title": "Cortar áudio de referência",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "salvando…",
     "hf_token_saved": "Token do Hugging Face salvo",
     "hf_token_error": "Não foi possível salvar o token — tente de novo ou configure depois em Configurações → Credenciais."
+  },
+  "history": {
+    "dub_title": "Histórico de dublagens",
+    "empty": "Nada por aqui ainda — suas gerações aparecerão à direita.",
+    "empty_dub": "Suas dublagens aparecerão aqui.",
+    "title": "Histórico"
+  },
+  "recording": {
+    "cleaned_loaded": "Gravação limpa e carregada!",
+    "loaded_raw": "Gravação carregada (bruta — remoção de ruído indisponível)",
+    "too_short": "Gravação muito curta"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Ярлык диктовки установлен на {{shortcut}}.",
     "shortcut_register_failed": "Не удалось зарегистрироваться: {{message}}",
     "shortcut_reset": "Сбросить настройки по умолчанию",
-    "shortcut_reset_failed": "Сброс не удался: {{message}}"
+    "shortcut_reset_failed": "Сброс не удался: {{message}}",
+    "cancel": "Отмена",
+    "hf_token_also_clear": "Также очистить",
+    "hf_token_clear_btn": "Очистить токен",
+    "hf_token_clear_confirm": "Очистить токен HuggingFace, заданный в приложении?",
+    "hf_token_clear_dialog": "Очистить токен",
+    "hf_token_input": "Токен HuggingFace",
+    "hf_token_sources": "Источники токена HF",
+    "hf_token_test_now": "Проверить сейчас",
+    "hf_token_test_now_title": "Повторно выполнить whoami для каждого источника"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "напр. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Ваше описание (на английском) задаёт настройки ниже — их можно подправить вручную.",
     "describe_unmatched": "Не удалось сопоставить: {{items}}",
-    "describe_no_match": "Голосовые черты пока не распознаны — попробуйте слова deep, elderly или British."
+    "describe_no_match": "Голосовые черты пока не распознаны — попробуйте слова deep, elderly или British.",
+    "define_by_design": "По дизайну",
+    "define_from_audio": "Из аудио",
+    "define_voice": "Задать голос",
+    "save_design_as_profile": "Сохранить дизайн как профиль"
   },
   "about": {
     "app": "Приложение",
@@ -692,7 +705,14 @@
     "dialect_title": "Региональный диалект и лексика перевода (напр. Аргентина → “vos sos” вместо “tú eres”). Применяется движками LLM (OpenAI/Ollama) и качеством Cinematic.",
     "num_speakers_label": "Говорящие",
     "num_speakers_auto": "Авто",
-    "num_speakers_help": "Сколько говорящих в этом видео? Оставьте пустым для автоопределения. Укажите число, если автоопределение объединяет нескольких говорящих в одного."
+    "num_speakers_help": "Сколько говорящих в этом видео? Оставьте пустым для автоопределения. Укажите число, если автоопределение объединяет нескольких говорящих в одного.",
+    "advanced": "Дополнительно",
+    "cinematic_needs_llm_hint": "Для кинематографического качества нужен LLM. Настройте его в Настройки → Ключи → Базовый URL-адрес LLM (Ollama работает локально, ключ не нужен).",
+    "generate_dub_multi": "Создать дубляжей: {{count}}",
+    "pipeline": "Конвейер дубляжа",
+    "preview_language": "Язык предпросмотра",
+    "target_language": "Дублировать на",
+    "transcript_after_extract": "Стенограмма появится после извлечения."
   },
   "glossary": {
     "title": "Глоссарий",
@@ -955,7 +975,15 @@
     "save_failed": "Не удалось сохранить профиль.",
     "confirm_delete": "Удалить \"{{name}}\"?",
     "trim_load_failed": "Не удалось загрузить аудио для обрезки.",
-    "delete": "Удалить"
+    "delete": "Удалить",
+    "community_empty": "Голоса сообщества ещё не загружены — подключитесь к интернету и откройте снова, или станьте первым, кто поделится своим.",
+    "community_explainer": "Созданные пресеты и записанные голоса, которыми поделилось сообщество; загружаются из omnivoice-gallery.",
+    "no_designer": "Записанный голос — используйте «Использовать голос».",
+    "no_preview": "Нет предпросмотра — добавьте через «Использовать голос», чтобы услышать его.",
+    "submit_failed": "Не удалось открыть форму отправки.",
+    "submit_preset": "Отправить пресет",
+    "submit_voice": "Отправить голос",
+    "zone_community": "Сообщество"
   },
   "transcriptions": {
     "title": "Транскрипции",
@@ -1337,7 +1365,8 @@
     "dub_label": "Дублировать",
     "save_label": "Сохранять",
     "lock_identity": "Заблокировать голосовую идентификацию",
-    "in_folder": "в {{folder}}"
+    "in_folder": "в {{folder}}",
+    "search": "Поиск…"
   },
   "trimmer": {
     "title": "Обрезать эталонный звук",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "сохранение…",
     "hf_token_saved": "Токен Hugging Face сохранён",
     "hf_token_error": "Не удалось сохранить токен — повторите или задайте позже в Настройках → Учётные данные."
+  },
+  "history": {
+    "dub_title": "История дубляжа",
+    "empty": "Пока пусто — ваши генерации появятся справа.",
+    "empty_dub": "Ваши дубляжи появятся здесь.",
+    "title": "История"
+  },
+  "recording": {
+    "cleaned_loaded": "Запись очищена и загружена!",
+    "loaded_raw": "Запись загружена (без обработки — шумоподавление недоступно)",
+    "too_short": "Запись слишком короткая"
   }
 }

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Dikteringsgenväg inställd på {{shortcut}}",
     "shortcut_register_failed": "Kunde inte registrera: {{message}}",
     "shortcut_reset": "Återställ till standard",
-    "shortcut_reset_failed": "Återställning misslyckades: {{message}}"
+    "shortcut_reset_failed": "Återställning misslyckades: {{message}}",
+    "cancel": "Avbryt",
+    "hf_token_also_clear": "Rensa också",
+    "hf_token_clear_btn": "Rensa token",
+    "hf_token_clear_confirm": "Rensa HuggingFace-token från App-källan?",
+    "hf_token_clear_dialog": "Rensa token",
+    "hf_token_input": "HuggingFace-token",
+    "hf_token_sources": "HF-tokenkällor",
+    "hf_token_test_now": "Testa nu",
+    "hf_token_test_now_title": "Kör whoami igen för varje källa"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "t.ex. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Din beskrivning (på engelska) ställer in kontrollerna nedan — du kan finjustera dem efteråt.",
     "describe_unmatched": "Kunde inte mappa: {{items}}",
-    "describe_no_match": "Inga röstdrag har känts igen ännu — prova ord som deep, elderly eller British."
+    "describe_no_match": "Inga röstdrag har känts igen ännu — prova ord som deep, elderly eller British.",
+    "define_by_design": "Via design",
+    "define_from_audio": "Från ljud",
+    "define_voice": "Definiera röst",
+    "save_design_as_profile": "Spara design som profil"
   },
   "about": {
     "app": "App",
@@ -692,7 +705,14 @@
     "dialect_title": "Regional dialekt och ordförråd för översättningen (t.ex. Argentina → ”vos sos” i stället för ”tú eres”). Tillämpas av LLM-motorer (OpenAI/Ollama) och Cinematic-kvalitet.",
     "num_speakers_label": "Talare",
     "num_speakers_auto": "Auto",
-    "num_speakers_help": "Hur många talare finns i videon? Lämna tomt för automatisk identifiering. Ange ett antal om identifieringen slår ihop flera talare till en."
+    "num_speakers_help": "Hur många talare finns i videon? Lämna tomt för automatisk identifiering. Ange ett antal om identifieringen slår ihop flera talare till en.",
+    "advanced": "Avancerat",
+    "cinematic_needs_llm_hint": "Filmisk kvalitet behöver en LLM. Konfigurera en i Inställningar → Autentisering → LLM-slutpunkt (Ollama körs lokalt, ingen nyckel behövs).",
+    "generate_dub_multi": "Generera {{count}} dubbar",
+    "pipeline": "Dubbningspipeline",
+    "preview_language": "Förhandsgranskningsspråk",
+    "target_language": "Dubba till",
+    "transcript_after_extract": "Avskriften visas efter extraktionen."
   },
   "glossary": {
     "title": "Ordlista",
@@ -955,7 +975,15 @@
     "save_failed": "Det gick inte att spara profilen.",
     "confirm_delete": "Ta bort \"{{name}}\"?",
     "trim_load_failed": "Det gick inte att ladda ljudet för trimning.",
-    "delete": "Ta bort"
+    "delete": "Ta bort",
+    "community_empty": "Inga communityröster har laddats ännu — anslut till internet och öppna igen, eller bli först med att skicka in en.",
+    "community_explainer": "Designade förinställningar och inspelade röster som delas av communityn, laddade från omnivoice-gallery.",
+    "no_designer": "Inspelad röst — använd \"Använd röst\" i stället.",
+    "no_preview": "Ingen förhandsgranskning — lägg till den med \"Använd röst\" för att höra den.",
+    "submit_failed": "Det gick inte att öppna inskickningsformuläret.",
+    "submit_preset": "Skicka in en förinställning",
+    "submit_voice": "Skicka in en röst",
+    "zone_community": "Community"
   },
   "transcriptions": {
     "title": "Transkriptioner",
@@ -1337,7 +1365,8 @@
     "dub_label": "Dub",
     "save_label": "Spara",
     "lock_identity": "Lås röstidentitet",
-    "in_folder": "i {{folder}}"
+    "in_folder": "i {{folder}}",
+    "search": "Sök…"
   },
   "trimmer": {
     "title": "Trimma referensljud",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "sparar…",
     "hf_token_saved": "Hugging Face-token sparad",
     "hf_token_error": "Kunde inte spara token — försök igen eller ange den senare i Inställningar → Uppgifter."
+  },
+  "history": {
+    "dub_title": "Dubbhistorik",
+    "empty": "Inget här ännu — dina generationer visas till höger.",
+    "empty_dub": "Dina dubbar visas här.",
+    "title": "Historik"
+  },
+  "recording": {
+    "cleaned_loaded": "Inspelningen rensad och laddad!",
+    "loaded_raw": "Inspelningen laddad (rå — brusreducering otillgänglig)",
+    "too_short": "Inspelningen är för kort"
   }
 }

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -74,7 +74,16 @@
     "shortcut_set": "ทางลัดการเขียนตามคำบอกตั้งค่าเป็น {{shortcut}}",
     "shortcut_register_failed": "ไม่สามารถลงทะเบียนได้: {{message}}",
     "shortcut_reset": "รีเซ็ตเป็นค่าเริ่มต้น",
-    "shortcut_reset_failed": "การรีเซ็ตล้มเหลว: {{message}}"
+    "shortcut_reset_failed": "การรีเซ็ตล้มเหลว: {{message}}",
+    "cancel": "ยกเลิก",
+    "hf_token_also_clear": "ล้างด้วย",
+    "hf_token_clear_btn": "ล้างโทเค็น",
+    "hf_token_clear_confirm": "ล้างโทเค็น HuggingFace ที่ตั้งจากแอปหรือไม่",
+    "hf_token_clear_dialog": "ล้างโทเค็น",
+    "hf_token_input": "โทเค็น HuggingFace",
+    "hf_token_sources": "แหล่งที่มาของโทเค็น HF",
+    "hf_token_test_now": "ทดสอบตอนนี้",
+    "hf_token_test_now_title": "รัน whoami ใหม่สำหรับทุกแหล่งที่มา"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "เช่น a warm elderly British storyteller, slightly raspy",
     "describe_hint": "คำอธิบายของคุณ (ภาษาอังกฤษ) จะตั้งค่าตัวควบคุมด้านล่าง และคุณยังปรับเองได้ภายหลัง",
     "describe_unmatched": "จับคู่ไม่ได้: {{items}}",
-    "describe_no_match": "ยังไม่พบลักษณะเสียง ลองใช้คำอย่าง deep, elderly หรือ British"
+    "describe_no_match": "ยังไม่พบลักษณะเสียง ลองใช้คำอย่าง deep, elderly หรือ British",
+    "define_by_design": "โดยการออกแบบ",
+    "define_from_audio": "จากเสียง",
+    "define_voice": "กำหนดเสียง",
+    "save_design_as_profile": "บันทึกการออกแบบเป็นโปรไฟล์"
   },
   "about": {
     "app": "แอพ",
@@ -692,7 +705,14 @@
     "dialect_title": "สำเนียงถิ่นและคำศัพท์เฉพาะภูมิภาคสำหรับการแปล (เช่น อาร์เจนตินา → “vos sos” แทน “tú eres”) ใช้โดยเอนจิน LLM (OpenAI/Ollama) และคุณภาพ Cinematic",
     "num_speakers_label": "ผู้พูด",
     "num_speakers_auto": "อัตโนมัติ",
-    "num_speakers_help": "วิดีโอนี้มีผู้พูดกี่คน? เว้นว่างเพื่อตรวจหาอัตโนมัติ ระบุจำนวนหากการตรวจหาอัตโนมัติรวมผู้พูดหลายคนเป็นคนเดียว"
+    "num_speakers_help": "วิดีโอนี้มีผู้พูดกี่คน? เว้นว่างเพื่อตรวจหาอัตโนมัติ ระบุจำนวนหากการตรวจหาอัตโนมัติรวมผู้พูดหลายคนเป็นคนเดียว",
+    "advanced": "ขั้นสูง",
+    "cinematic_needs_llm_hint": "คุณภาพระดับภาพยนตร์ต้องใช้ LLM ตั้งค่าได้ที่ การตั้งค่า → สิทธิ์การใช้งาน → ปลายทาง LLM (Ollama ทำงานในเครื่อง ไม่ต้องใช้คีย์)",
+    "generate_dub_multi": "สร้างพากย์ {{count}} รายการ",
+    "pipeline": "ไปป์ไลน์การพากย์",
+    "preview_language": "ภาษาตัวอย่าง",
+    "target_language": "พากย์เป็น",
+    "transcript_after_extract": "ทรานสคริปต์จะปรากฏหลังการแยกเสียง"
   },
   "glossary": {
     "title": "อภิธานศัพท์",
@@ -955,7 +975,15 @@
     "save_failed": "ไม่สามารถบันทึกโปรไฟล์ได้",
     "confirm_delete": "ลบ \"{{name}}\" หรือไม่",
     "trim_load_failed": "ไม่สามารถโหลดเสียงเพื่อตัดแต่งได้",
-    "delete": "ลบ"
+    "delete": "ลบ",
+    "community_empty": "ยังไม่มีเสียงจากชุมชน — เชื่อมต่ออินเทอร์เน็ตแล้วเปิดใหม่ หรือเป็นคนแรกที่ส่งเสียงเข้ามา",
+    "community_explainer": "พรีเซ็ตที่ออกแบบไว้และเสียงที่บันทึกไว้ซึ่งแชร์โดยชุมชน โหลดจาก omnivoice-gallery",
+    "no_designer": "เสียงที่บันทึกไว้ — ใช้ \"ใช้เสียง\" แทน",
+    "no_preview": "ไม่มีตัวอย่าง — เพิ่มด้วย \"ใช้เสียง\" เพื่อฟัง",
+    "submit_failed": "ไม่สามารถเปิดแบบฟอร์มส่งได้",
+    "submit_preset": "ส่งพรีเซ็ต",
+    "submit_voice": "ส่งเสียง",
+    "zone_community": "ชุมชน"
   },
   "transcriptions": {
     "title": "การถอดเสียง",
@@ -1337,7 +1365,8 @@
     "dub_label": "พากย์",
     "save_label": "บันทึก",
     "lock_identity": "ล็อคตัวตนของเสียง",
-    "in_folder": "ใน {{folder}}"
+    "in_folder": "ใน {{folder}}",
+    "search": "ค้นหา…"
   },
   "trimmer": {
     "title": "ตัดเสียงอ้างอิง",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "กำลังบันทึก…",
     "hf_token_saved": "บันทึกโทเคน Hugging Face แล้ว",
     "hf_token_error": "บันทึกโทเคนไม่สำเร็จ — ลองใหม่ หรือไปตั้งค่าภายหลังที่ การตั้งค่า → ข้อมูลรับรอง"
+  },
+  "history": {
+    "dub_title": "ประวัติการพากย์",
+    "empty": "ยังไม่มีอะไรที่นี่ — ผลงานที่สร้างจะปรากฏทางด้านขวา",
+    "empty_dub": "เสียงพากย์ของคุณจะปรากฏที่นี่",
+    "title": "ประวัติ"
+  },
+  "recording": {
+    "cleaned_loaded": "ทำความสะอาดและโหลดการบันทึกแล้ว!",
+    "loaded_raw": "โหลดการบันทึกแล้ว (ดิบ — ใช้การลดเสียงรบกวนไม่ได้)",
+    "too_short": "การบันทึกสั้นเกินไป"
   }
 }

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Dikte kısayolu {{shortcut}} olarak ayarlandı",
     "shortcut_register_failed": "Kaydedilemedi: {{message}}",
     "shortcut_reset": "Varsayılana sıfırla",
-    "shortcut_reset_failed": "Sıfırlama başarısız oldu: {{message}}"
+    "shortcut_reset_failed": "Sıfırlama başarısız oldu: {{message}}",
+    "cancel": "İptal",
+    "hf_token_also_clear": "Ayrıca temizle",
+    "hf_token_clear_btn": "Belirteci temizle",
+    "hf_token_clear_confirm": "Uygulama kaynaklı HuggingFace belirteci temizlensin mi?",
+    "hf_token_clear_dialog": "Belirteci temizle",
+    "hf_token_input": "HuggingFace belirteci",
+    "hf_token_sources": "HF belirteç kaynakları",
+    "hf_token_test_now": "Şimdi test et",
+    "hf_token_test_now_title": "Her kaynak için whoami'yi yeniden çalıştır"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "örn. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Açıklamanız (İngilizce) aşağıdaki denetimleri ayarlar — sonradan ince ayar yapabilirsiniz.",
     "describe_unmatched": "Eşlenemedi: {{items}}",
-    "describe_no_match": "Henüz ses özelliği tanınmadı — deep, elderly veya British gibi kelimeler deneyin."
+    "describe_no_match": "Henüz ses özelliği tanınmadı — deep, elderly veya British gibi kelimeler deneyin.",
+    "define_by_design": "Tasarımla",
+    "define_from_audio": "Sesten",
+    "define_voice": "Sesi tanımla",
+    "save_design_as_profile": "Tasarımı profil olarak kaydet"
   },
   "about": {
     "app": "Uygulama",
@@ -692,7 +705,14 @@
     "dialect_title": "Çeviri için bölgesel lehçe ve söz varlığı (örn. Arjantin → “tú eres” yerine “vos sos”). LLM motorları (OpenAI/Ollama) ve Cinematic kalitesi tarafından uygulanır.",
     "num_speakers_label": "Konuşmacılar",
     "num_speakers_auto": "Otomatik",
-    "num_speakers_help": "Bu videoda kaç konuşmacı var? Otomatik algılama için boş bırakın. Otomatik algılama birden çok konuşmacıyı tek kişide birleştiriyorsa bir sayı girin."
+    "num_speakers_help": "Bu videoda kaç konuşmacı var? Otomatik algılama için boş bırakın. Otomatik algılama birden çok konuşmacıyı tek kişide birleştiriyorsa bir sayı girin.",
+    "advanced": "Gelişmiş",
+    "cinematic_needs_llm_hint": "Sinematik için bir LLM gerekir. Ayarlar → Kimlik Bilgileri → LLM uç noktası bölümünden yapılandırın (Ollama yerel çalışır, anahtar gerekmez).",
+    "generate_dub_multi": "{{count}} dublaj oluştur",
+    "pipeline": "Dublaj hattı",
+    "preview_language": "Önizleme dili",
+    "target_language": "Dublaj dili",
+    "transcript_after_extract": "Transkript, çıkarma işleminden sonra görünür."
   },
   "glossary": {
     "title": "Sözlük",
@@ -955,7 +975,15 @@
     "save_failed": "Profil kaydedilemedi.",
     "confirm_delete": "\"{{name}}\" silinsin mi?",
     "trim_load_failed": "Kırpma için ses yüklenemedi.",
-    "delete": "Sil"
+    "delete": "Sil",
+    "community_empty": "Henüz topluluk sesi yüklenmedi — internete bağlanıp yeniden açın veya ilk gönderen siz olun.",
+    "community_explainer": "Topluluk tarafından paylaşılan tasarlanmış ön ayarlar ve kayıtlı sesler; omnivoice-gallery'den yüklenir.",
+    "no_designer": "Kayıtlı ses — bunun yerine \"Sesi kullan\"ı kullanın.",
+    "no_preview": "Önizleme yok — duymak için \"Sesi kullan\" ile ekleyin.",
+    "submit_failed": "Gönderim formu açılamadı.",
+    "submit_preset": "Ön ayar gönder",
+    "submit_voice": "Ses gönder",
+    "zone_community": "Topluluk"
   },
   "transcriptions": {
     "title": "Transkripsiyonlar",
@@ -1337,7 +1365,8 @@
     "dub_label": "Dublaj",
     "save_label": "Kaydet",
     "lock_identity": "Ses kimliğini kilitle",
-    "in_folder": "{{folder}}'da"
+    "in_folder": "{{folder}}'da",
+    "search": "Ara…"
   },
   "trimmer": {
     "title": "Referans sesini kırp",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "kaydediliyor…",
     "hf_token_saved": "Hugging Face belirteci kaydedildi",
     "hf_token_error": "Belirteç kaydedilemedi — yeniden deneyin veya sonra Ayarlar → Kimlik bilgileri bölümünden ayarlayın."
+  },
+  "history": {
+    "dub_title": "Dublaj geçmişi",
+    "empty": "Burada henüz bir şey yok — oluşturduklarınız sağda görünecek.",
+    "empty_dub": "Dublajlarınız burada görünecek.",
+    "title": "Geçmiş"
+  },
+  "recording": {
+    "cleaned_loaded": "Kayıt temizlendi ve yüklendi!",
+    "loaded_raw": "Kayıt yüklendi (ham — gürültü giderme kullanılamıyor)",
+    "too_short": "Kayıt çok kısa"
   }
 }

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Ярлик для диктування встановлено на {{shortcut}}",
     "shortcut_register_failed": "Не вдалося зареєструватися: {{message}}",
     "shortcut_reset": "Скинути до замовчування",
-    "shortcut_reset_failed": "Помилка скидання: {{message}}"
+    "shortcut_reset_failed": "Помилка скидання: {{message}}",
+    "cancel": "Скасувати",
+    "hf_token_also_clear": "Також очистити",
+    "hf_token_clear_btn": "Очистити токен",
+    "hf_token_clear_confirm": "Очистити токен HuggingFace із джерела App?",
+    "hf_token_clear_dialog": "Очистити токен",
+    "hf_token_input": "Токен HuggingFace",
+    "hf_token_sources": "Джерела токена HF",
+    "hf_token_test_now": "Перевірити зараз",
+    "hf_token_test_now_title": "Повторно виконати whoami для кожного джерела"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "напр. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Ваш опис (англійською) налаштовує елементи нижче — їх можна підлаштувати вручну.",
     "describe_unmatched": "Не вдалося зіставити: {{items}}",
-    "describe_no_match": "Голосові риси ще не розпізнано — спробуйте слова deep, elderly або British."
+    "describe_no_match": "Голосові риси ще не розпізнано — спробуйте слова deep, elderly або British.",
+    "define_by_design": "За дизайном",
+    "define_from_audio": "З аудіо",
+    "define_voice": "Визначити голос",
+    "save_design_as_profile": "Зберегти дизайн як профіль"
   },
   "about": {
     "app": "додаток",
@@ -692,7 +705,14 @@
     "dialect_title": "Регіональний діалект і лексика перекладу (напр. Аргентина → “vos sos” замість “tú eres”). Застосовується рушіями LLM (OpenAI/Ollama) та якістю Cinematic.",
     "num_speakers_label": "Мовці",
     "num_speakers_auto": "Авто",
-    "num_speakers_help": "Скільки мовців у цьому відео? Залиште порожнім для автовизначення. Вкажіть число, якщо автовизначення об'єднує кількох мовців в одного."
+    "num_speakers_help": "Скільки мовців у цьому відео? Залиште порожнім для автовизначення. Вкажіть число, якщо автовизначення об'єднує кількох мовців в одного.",
+    "advanced": "Розширені",
+    "cinematic_needs_llm_hint": "Для кінематографічної якості потрібен LLM. Налаштуйте його в Налаштування → Облікові дані → LLM endpoint (Ollama працює локально, ключ не потрібен).",
+    "generate_dub_multi": "Згенерувати {{count}} дублів",
+    "pipeline": "Конвеєр дубляжу",
+    "preview_language": "Мова попереднього перегляду",
+    "target_language": "Дублювати мовою",
+    "transcript_after_extract": "Стенограма з’явиться після вилучення."
   },
   "glossary": {
     "title": "Глосарій",
@@ -955,7 +975,15 @@
     "save_failed": "Не вдалося зберегти профіль.",
     "confirm_delete": "Видалити \"{{name}}\"?",
     "trim_load_failed": "Не вдалося завантажити аудіо для обрізання.",
-    "delete": "Видалити"
+    "delete": "Видалити",
+    "community_empty": "Голоси спільноти ще не завантажено — підключіться до інтернету й відкрийте знову, або станьте першим, хто надішле свій.",
+    "community_explainer": "Розроблені пресети та записані голоси, якими поділилася спільнота, завантажені з omnivoice-gallery.",
+    "no_designer": "Записаний голос — натомість скористайтеся \"Використовуйте голос\".",
+    "no_preview": "Немає попереднього перегляду — додайте його через \"Використовуйте голос\", щоб почути.",
+    "submit_failed": "Не вдалося відкрити форму подання.",
+    "submit_preset": "Надіслати пресет",
+    "submit_voice": "Надіслати голос",
+    "zone_community": "Спільнота"
   },
   "transcriptions": {
     "title": "транскрипції",
@@ -1337,7 +1365,8 @@
     "dub_label": "Dub",
     "save_label": "зберегти",
     "lock_identity": "Блокування голосової ідентифікації",
-    "in_folder": "в {{folder}}"
+    "in_folder": "в {{folder}}",
+    "search": "Пошук…"
   },
   "trimmer": {
     "title": "Обрізати контрольне аудіо",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "збереження…",
     "hf_token_saved": "Токен Hugging Face збережено",
     "hf_token_error": "Не вдалося зберегти токен — повторіть або задайте пізніше в Налаштування → Облікові дані."
+  },
+  "history": {
+    "dub_title": "Історія дубляжу",
+    "empty": "Тут поки порожньо — ваші генерації з’являться праворуч.",
+    "empty_dub": "Ваші дублі з’являться тут.",
+    "title": "Історія"
+  },
+  "recording": {
+    "cleaned_loaded": "Запис очищено та завантажено!",
+    "loaded_raw": "Запис завантажено (необроблений — усунення шуму недоступне)",
+    "too_short": "Запис надто короткий"
   }
 }

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -74,7 +74,16 @@
     "shortcut_set": "Phím tắt đọc chính tả được đặt thành {{shortcut}}",
     "shortcut_register_failed": "Không thể đăng ký: {{message}}",
     "shortcut_reset": "Đặt lại về mặc định",
-    "shortcut_reset_failed": "Đặt lại không thành công: {{message}}"
+    "shortcut_reset_failed": "Đặt lại không thành công: {{message}}",
+    "cancel": "Hủy",
+    "hf_token_also_clear": "Đồng thời xóa",
+    "hf_token_clear_btn": "Xóa token",
+    "hf_token_clear_confirm": "Xóa token HuggingFace từ nguồn Ứng dụng?",
+    "hf_token_clear_dialog": "Xóa token",
+    "hf_token_input": "Token HuggingFace",
+    "hf_token_sources": "Nguồn token HF",
+    "hf_token_test_now": "Kiểm tra ngay",
+    "hf_token_test_now_title": "Chạy lại whoami cho mọi nguồn"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "vd. a warm elderly British storyteller, slightly raspy",
     "describe_hint": "Mô tả của bạn (bằng tiếng Anh) sẽ thiết lập các điều khiển bên dưới — bạn vẫn có thể tinh chỉnh sau.",
     "describe_unmatched": "Không thể ánh xạ: {{items}}",
-    "describe_no_match": "Chưa nhận ra đặc điểm giọng nói nào — hãy thử các từ như deep, elderly hoặc British."
+    "describe_no_match": "Chưa nhận ra đặc điểm giọng nói nào — hãy thử các từ như deep, elderly hoặc British.",
+    "define_by_design": "Theo thiết kế",
+    "define_from_audio": "Từ âm thanh",
+    "define_voice": "Xác định giọng nói",
+    "save_design_as_profile": "Lưu thiết kế dưới dạng hồ sơ"
   },
   "about": {
     "app": "ứng dụng",
@@ -692,7 +705,14 @@
     "dialect_title": "Phương ngữ và từ vựng vùng miền cho bản dịch (vd. Argentina → “vos sos” thay vì “tú eres”). Áp dụng bởi các engine LLM (OpenAI/Ollama) và chất lượng Cinematic.",
     "num_speakers_label": "Người nói",
     "num_speakers_auto": "Tự động",
-    "num_speakers_help": "Video này có bao nhiêu người nói? Để trống để tự động phát hiện. Đặt một con số nếu tính năng tự động gộp nhiều người nói thành một."
+    "num_speakers_help": "Video này có bao nhiêu người nói? Để trống để tự động phát hiện. Đặt một con số nếu tính năng tự động gộp nhiều người nói thành một.",
+    "advanced": "Nâng cao",
+    "cinematic_needs_llm_hint": "Điện ảnh cần có LLM. Cấu hình trong Cài đặt → Xác thực → Điểm cuối LLM (Ollama chạy cục bộ, không cần khóa).",
+    "generate_dub_multi": "Tạo {{count}} bản lồng tiếng",
+    "pipeline": "Quy trình lồng tiếng",
+    "preview_language": "Ngôn ngữ xem trước",
+    "target_language": "Lồng tiếng sang",
+    "transcript_after_extract": "Bản chép lời sẽ xuất hiện sau khi trích xuất."
   },
   "glossary": {
     "title": "Thuật ngữ",
@@ -955,7 +975,15 @@
     "save_failed": "Không thể lưu hồ sơ.",
     "confirm_delete": "Xóa \"{{name}}\"?",
     "trim_load_failed": "Không thể tải âm thanh để cắt.",
-    "delete": "Xóa"
+    "delete": "Xóa",
+    "community_empty": "Chưa tải được giọng nói cộng đồng nào — hãy kết nối internet rồi mở lại, hoặc trở thành người đầu tiên gửi một giọng nói.",
+    "community_explainer": "Các cài đặt trước được thiết kế và giọng nói ghi âm do cộng đồng chia sẻ, được tải từ omnivoice-gallery.",
+    "no_designer": "Giọng nói ghi âm — hãy dùng \"Sử dụng giọng nói\" thay thế.",
+    "no_preview": "Không có bản xem trước — thêm bằng \"Sử dụng giọng nói\" để nghe thử.",
+    "submit_failed": "Không thể mở biểu mẫu gửi.",
+    "submit_preset": "Gửi cài đặt trước",
+    "submit_voice": "Gửi giọng nói",
+    "zone_community": "Cộng đồng"
   },
   "transcriptions": {
     "title": "Phiên âm",
@@ -1337,7 +1365,8 @@
     "dub_label": "lồng tiếng",
     "save_label": "Lưu",
     "lock_identity": "Khóa nhận dạng giọng nói",
-    "in_folder": "trong {{folder}}"
+    "in_folder": "trong {{folder}}",
+    "search": "Tìm kiếm…"
   },
   "trimmer": {
     "title": "Cắt âm thanh tham chiếu",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "đang lưu…",
     "hf_token_saved": "Đã lưu token Hugging Face",
     "hf_token_error": "Không thể lưu token — thử lại hoặc đặt sau trong Cài đặt → Thông tin xác thực."
+  },
+  "history": {
+    "dub_title": "Lịch sử lồng tiếng",
+    "empty": "Chưa có gì ở đây — các bản tạo của bạn sẽ xuất hiện ở bên phải.",
+    "empty_dub": "Các bản lồng tiếng của bạn sẽ xuất hiện tại đây.",
+    "title": "Lịch sử"
+  },
+  "recording": {
+    "cleaned_loaded": "Đã làm sạch và tải bản ghi âm!",
+    "loaded_raw": "Đã tải bản ghi âm (thô — không có khử nhiễu)",
+    "too_short": "Bản ghi âm quá ngắn"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -216,7 +216,11 @@
     "describe_placeholder": "例如：中年男性，低音调，四川话",
     "describe_hint": "你的描述会自动设置下方的控件，之后仍可手动微调。（也支持英文描述）",
     "describe_unmatched": "无法识别：{{items}}",
-    "describe_no_match": "尚未识别出声音特征——试试 deep、elderly、British 或「中年」「低音调」等词。"
+    "describe_no_match": "尚未识别出声音特征——试试 deep、elderly、British 或「中年」「低音调」等词。",
+    "define_by_design": "通过设计",
+    "define_from_audio": "从音频",
+    "define_voice": "定义声音",
+    "save_design_as_profile": "将设计保存为声音配置"
   },
   "settings": {
     "title": "设置",
@@ -279,7 +283,16 @@
     "shortcut_set": "听写快捷键设置为 {{shortcut}}",
     "shortcut_register_failed": "无法注册：{{message}}",
     "shortcut_reset": "重置为默认值",
-    "shortcut_reset_failed": "重置失败：{{message}}"
+    "shortcut_reset_failed": "重置失败：{{message}}",
+    "cancel": "取消",
+    "hf_token_also_clear": "同时清除",
+    "hf_token_clear_btn": "清除令牌",
+    "hf_token_clear_confirm": "清除“应用”来源的 HuggingFace 令牌？",
+    "hf_token_clear_dialog": "清除令牌",
+    "hf_token_input": "HuggingFace 令牌",
+    "hf_token_sources": "HF 令牌来源",
+    "hf_token_test_now": "立即测试",
+    "hf_token_test_now_title": "对每个来源重新运行 whoami"
   },
   "about": {
     "app": "应用",
@@ -652,7 +665,14 @@
     "dialect_title": "翻译所用的地区方言与词汇（例如 阿根廷 → “vos sos” 而非 “tú eres”）。由 LLM 引擎（OpenAI/Ollama）和 Cinematic 质量应用。",
     "num_speakers_label": "说话人",
     "num_speakers_auto": "自动",
-    "num_speakers_help": "这段视频中有几位说话人？留空则自动检测。如果自动检测将多位说话人合并为一人，请手动指定人数。"
+    "num_speakers_help": "这段视频中有几位说话人？留空则自动检测。如果自动检测将多位说话人合并为一人，请手动指定人数。",
+    "advanced": "高级",
+    "cinematic_needs_llm_hint": "精译需要 LLM。请在 设置 → 凭证 → LLM 端点 中配置（Ollama 在本地运行，无需密钥）。",
+    "generate_dub_multi": "生成 {{count}} 个配音",
+    "pipeline": "配音流程",
+    "preview_language": "预览语言",
+    "target_language": "配音为",
+    "transcript_after_extract": "提取完成后将显示转录文本。"
   },
   "glossary": {
     "title": "术语表",
@@ -915,7 +935,15 @@
     "save_failed": "Could not save profile.",
     "confirm_delete": "Delete \"{{name}}\"?",
     "trim_load_failed": "Could not load audio for trimming.",
-    "delete": "删除"
+    "delete": "删除",
+    "community_empty": "尚未加载社区声音——请联网后重新打开，或成为第一位提交者。",
+    "community_explainer": "由社区分享的设计预设与录制声音，加载自 omnivoice-gallery。",
+    "no_designer": "录制声音——请改用“Use voice”。",
+    "no_preview": "暂无试听——通过“Use voice”添加后即可收听。",
+    "submit_failed": "无法打开提交表单。",
+    "submit_preset": "提交预设",
+    "submit_voice": "提交声音",
+    "zone_community": "社区"
   },
   "transcriptions": {
     "title": "转录记录",
@@ -1337,7 +1365,8 @@
     "dub_label": "配音",
     "save_label": "保存",
     "lock_identity": "锁定语音身份",
-    "in_folder": "在 {{folder}} 中"
+    "in_folder": "在 {{folder}} 中",
+    "search": "搜索…"
   },
   "trimmer": {
     "title": "修剪参考音频",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "保存中…",
     "hf_token_saved": "Hugging Face 令牌已保存",
     "hf_token_error": "令牌保存失败——请重试，或稍后在设置 → 凭据中设置。"
+  },
+  "history": {
+    "dub_title": "配音历史",
+    "empty": "这里还没有内容——你的生成结果将显示在右侧。",
+    "empty_dub": "你的配音将显示在这里。",
+    "title": "历史"
+  },
+  "recording": {
+    "cleaned_loaded": "录音已清理并加载！",
+    "loaded_raw": "录音已加载（原始音频——降噪不可用）",
+    "too_short": "录音太短"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -74,7 +74,16 @@
     "shortcut_set": "聽寫快捷鍵設定為 {{shortcut}}",
     "shortcut_register_failed": "無法註冊：{{message}}",
     "shortcut_reset": "重設為預設值",
-    "shortcut_reset_failed": "重置失敗：{{message}}"
+    "shortcut_reset_failed": "重置失敗：{{message}}",
+    "cancel": "取消",
+    "hf_token_also_clear": "一併清除",
+    "hf_token_clear_btn": "清除代幣",
+    "hf_token_clear_confirm": "確定要清除 App 來源的 HuggingFace 代幣嗎？",
+    "hf_token_clear_dialog": "清除代幣",
+    "hf_token_input": "HuggingFace 代幣",
+    "hf_token_sources": "HF 代幣來源",
+    "hf_token_test_now": "立即測試",
+    "hf_token_test_now_title": "對每個來源重新執行 whoami"
   },
   "bootstrap": {
     "title": "OmniVoice Studio",
@@ -319,7 +328,11 @@
     "describe_placeholder": "例如：a warm elderly British storyteller, slightly raspy",
     "describe_hint": "你的描述（英文）會自動設定下方的控制項，之後仍可手動微調。",
     "describe_unmatched": "無法辨識：{{items}}",
-    "describe_no_match": "尚未辨識出聲音特徵——試試 deep、elderly 或 British 等詞。"
+    "describe_no_match": "尚未辨識出聲音特徵——試試 deep、elderly 或 British 等詞。",
+    "define_by_design": "以設計",
+    "define_from_audio": "從音訊",
+    "define_voice": "定義聲音",
+    "save_design_as_profile": "將設計另存為語音設定檔"
   },
   "about": {
     "app": "應用程式",
@@ -692,7 +705,14 @@
     "dialect_title": "翻譯所用的地區方言與詞彙（例如 阿根廷 → “vos sos” 而非 “tú eres”）。由 LLM 引擎（OpenAI/Ollama）與 Cinematic 品質套用。",
     "num_speakers_label": "說話者",
     "num_speakers_auto": "自動",
-    "num_speakers_help": "這段影片中有幾位說話者？留空則自動偵測。若自動偵測將多位說話者合併為一人，請手動指定人數。"
+    "num_speakers_help": "這段影片中有幾位說話者？留空則自動偵測。若自動偵測將多位說話者合併為一人，請手動指定人數。",
+    "advanced": "進階",
+    "cinematic_needs_llm_hint": "電影品質需要 LLM。請在 設定 → 金鑰憑證 → LLM 端點 中設定（Ollama 可在本機執行，無需金鑰）。",
+    "generate_dub_multi": "生成 {{count}} 個配音",
+    "pipeline": "配音流程",
+    "preview_language": "預覽語言",
+    "target_language": "配音成",
+    "transcript_after_extract": "擷取完成後將顯示逐字稿。"
   },
   "glossary": {
     "title": "詞彙表",
@@ -955,7 +975,15 @@
     "save_failed": "無法儲存個人資料。",
     "confirm_delete": "刪除“{{name}}”？",
     "trim_load_failed": "無法載入音訊進行修剪。",
-    "delete": "刪除"
+    "delete": "刪除",
+    "community_empty": "尚未載入任何社群語音 — 請連上網路後重新開啟，或成為第一個投稿的人。",
+    "community_explainer": "由社群分享的設計預設與錄製語音，從 omnivoice-gallery 載入。",
+    "no_designer": "錄製的語音 — 請改用「使用語音」。",
+    "no_preview": "沒有預覽 — 透過「使用語音」加入後即可試聽。",
+    "submit_failed": "無法開啟投稿表單。",
+    "submit_preset": "投稿預設",
+    "submit_voice": "投稿語音",
+    "zone_community": "社群"
   },
   "transcriptions": {
     "title": "轉錄",
@@ -1337,7 +1365,8 @@
     "dub_label": "配音",
     "save_label": "儲存",
     "lock_identity": "鎖定語音身份",
-    "in_folder": "在 {{folder}} 中"
+    "in_folder": "在 {{folder}} 中",
+    "search": "搜尋…"
   },
   "trimmer": {
     "title": "修剪參考音訊",
@@ -1729,5 +1758,16 @@
     "hf_token_saving": "儲存中…",
     "hf_token_saved": "Hugging Face 權杖已儲存",
     "hf_token_error": "權杖儲存失敗——請重試，或稍後在設定 → 憑證中設定。"
+  },
+  "history": {
+    "dub_title": "配音歷史",
+    "empty": "這裡還沒有任何內容 — 你的生成結果將顯示在右側。",
+    "empty_dub": "你的配音將顯示在這裡。",
+    "title": "歷史"
+  },
+  "recording": {
+    "cleaned_loaded": "錄音已清理並載入！",
+    "loaded_raw": "錄音已載入（原始 — 無法降噪）",
+    "too_short": "錄音太短"
   }
 }


### PR DESCRIPTION
Closes #383. The 36 `defaultValue`-only keys from the studio-overhaul PRs are now canonical in `en.json` and translated in every locale (zh-CN/zh-TW/es/fr/de/ja/pt/it/ru/ko/hi/tr/pl/nl/sv/th/vi/id/uk/ar) — 20 parallel translation passes preserving `{{placeholders}}`, product names, and each file's existing terminology. All 21 files parse; CJK gate + 312/312 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## i18n Backfill: Studio-Overhaul Keys Canonicalization

This PR canonicalizes 36 `defaultValue`-only keys introduced by studio-overhaul PRs across all 21 locale files (en.json + 20 locales: zh-CN, zh-TW, es, fr, de, ja, pt, it, ru, ko, hi, tr, pl, nl, sv, th, vi, id, uk, ar).

### Changes Summary

**36 new keys added across all 21 locales, organized by feature area:**

- **Settings (10 keys)**: HuggingFace token management workflow (`cancel`, `hf_token_also_clear`, `hf_token_clear_btn`, `hf_token_clear_confirm`, `hf_token_clear_dialog`, `hf_token_input`, `hf_token_sources`, `hf_token_test_now`, `hf_token_test_now_title`); shortcut error messaging (`shortcut_reset_failed`)

- **Voice Clone/Design (5 keys)**: Voice definition modes (`define_by_design`, `define_from_audio`, `define_voice`); trait recognition fallback (`describe_no_match`); profile saving (`save_design_as_profile`)

- **Dubbing Workflow (8 keys)**: Advanced controls (`advanced`, `num_speakers_help`); cinematic quality requirement hint (`cinematic_needs_llm_hint`); pipeline configuration (`pipeline`); multi-dub generation (`generate_dub_multi`); language selection (`preview_language`, `target_language`); transcript timing (`transcript_after_extract`)

- **Gallery/Community (8 keys)**: Community zone label (`zone_community`); empty/loading states (`community_empty`, `community_explainer`); missing content guidance (`no_designer`, `no_preview`); submission errors/actions (`submit_failed`, `submit_preset`, `submit_voice`); content management (`delete`)

- **Sidebar (2 keys)**: Folder context (`in_folder`); search feature (`search`)

- **New Top-Level Sections (7 keys)**:
  - `history`: Dub timeline UI labels (`dub_title`, `empty`, `empty_dub`, `title`)
  - `recording`: Recording status messaging (`cleaned_loaded`, `loaded_raw`, `too_short`)

### Quality Assurance

- ✅ All 21 locale files validated for JSON syntax
- ✅ Placeholders (e.g., `{{count}}`, `{{folder}}`) preserved in translations
- ✅ Product names and terminology consistent with each locale's glossary
- ✅ CJK gate tests passing
- ✅ 312/312 frontend tests green
- ✅ File sizes consistent (1,772–1,804 lines each, ~37K lines total)

**Closes:** `#383`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->