### PR TITLE
perf(dub): retime batches seek to their window instead of decoding from frame 0

### DIFF
--- a/backend/services/video_retime.py
+++ b/backend/services/video_retime.py
@@ -277,15 +277,33 @@ async def render_retimed_video(
             if abort_check is not None and abort_check():
                 raise RetimeError("export aborted", stage="aborted")
             is_last = bi == len(batches) - 1
+            # #382: seek the input to this batch's window instead of decoding
+            # from frame 0 every time — without this, batch N pays for
+            # decoding everything before it and long exports go O(n²).
+            # `-ss` before `-i` is frame-accurate under re-encode (ffmpeg
+            # decodes from the prior keyframe and discards up to the target);
+            # decoded timestamps then start at ~0, so chunk times are shifted
+            # into window-relative coordinates for the filter graph.
+            win_start = batch[0][0]
+            win_dur = batch[-1][1] - win_start
+            shifted = [(max(0.0, a - win_start), b - win_start, r) for a, b, r in batch]
             graph, label = build_chunk_filter_graph(
-                batch, "[0:v]",
+                shifted, "[0:v]",
                 fps_norm=fps_norm,
                 out_fps=out_fps,
                 tail_pad_s=tail_pad_s if is_last else 0.0,
             )
             slice_path = os.path.join(slices_dir, f"slice_{bi:04d}.mp4")
+            seek_args = (
+                ["-ss", f"{win_start:.4f}"] if win_start > 1e-4 else []
+            )
             cmd = [
-                ffmpeg, "-hide_banner", "-y", "-i", video_path,
+                ffmpeg, "-hide_banner", "-y",
+                *seek_args,
+                # +0.5s read margin: trim's end is exclusive and fps_norm can
+                # shift a frame; reading slightly past the window is cheap.
+                "-t", f"{win_dur + 0.5:.4f}",
+                "-i", video_path,
                 "-filter_complex", graph, "-map", label, "-an",
                 *VIDEO_ENC_ARGS,
                 "-force_key_frames", "0",


### PR DESCRIPTION
Closes #382 (deferred from #350 review). Each retime batch now input-seeks (`-ss` before `-i`, frame-accurate under re-encode) with a bounded read window and window-relative chunk times — long-video exports drop from O(n²) decode cost to O(n).

Validated by the existing real-ffmpeg render suite (40/40), whose duration assertions run with `batch_size=2` and would catch any timestamp-shift error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Performance: Retime Batches Seek to Window Instead of Decoding from Frame 0

### Overview
This PR implements window-based input seeking for Smart Fit video retime batches, reducing O(n²) decode cost to O(n) for long-video exports. Each batch now seeks to its window start using ffmpeg's `-ss` flag (before `-i`) instead of always decoding from frame 0, and limits decoding to a bounded read window.

### Key Changes
**`backend/services/video_retime.py`**
- Added window-based batch processing in `render_retimed_video()`:
  - Calculates batch window (`win_start`, `win_dur`) from chunk boundaries
  - Shifts chunk time coordinates to be window-relative via: `shifted = [(max(0.0, a - win_start), b - win_start, r) for a, b, r in batch]`
  - Applies input seeking when window start is significant: `-ss {win_start}` before `-i {video_path}`
  - Limits read duration to window plus 0.5s guard margin: `-t {win_dur + 0.5}`
- Chunk times are fed into the filter graph as window-relative offsets
- Each batch is encoded with forced keyframe at t=0 to enable lossless concat-demuxer joins
- All other batch encoding logic (filter_complex, output validation, concat-join) remains unchanged

### Behavior
```mermaid
graph TD
    A["Input: Video + Retime Chunks"] --> B{"Chunk Count"}
    B -->|≤ 48 chunks| C["Single-Pass Render"]
    B -->|> 48 chunks| D["Partition into Batches"]
    D --> E["For Each Batch"]
    E --> F["Calculate Window Start/Duration"]
    F --> G["Shift Chunk Times to Window-Relative"]
    G --> H["Seek Input to Window Start<br/>-ss before -i"]
    H --> I["Bounded Read: Window + 0.5s<br/>-t flag"]
    I --> J["Build Filter Graph<br/>split → trim → setpts → concat"]
    J --> K["Encode to Intermediate MP4<br/>Force Keyframe at t=0"]
    K --> L["Next Batch<br/>NEW: Only Decode this Window<br/>OLD: Would Re-decode from Frame 0"]
    L -->|Last Batch| M["Concat Slices Losslessly<br/>-f concat -c copy"]
    M --> N["Output: Retimed Video"]
    C --> N
```

### Performance Impact
- **Before**: Batch N re-decoded all frames before it → O(n²) total decode cost for n chunks
- **After**: Each batch decodes only its window → O(n) total decode cost
- Frame-accurate seeking achieved via ffmpeg's `-ss` before `-i` (decodes from prior keyframe, discards frames up to target)
- 0.5s read margin handles trim's exclusive end boundary and fps normalization frame shifting

### Validation
- Existing real-ffmpeg render suite (40/40 tests) passed
- Duration assertions run with `batch_size=2`, would detect timestamp-shift errors
- VFR guard and CFR normalization logic preserved from prior implementation

### Files Changed
- `backend/services/video_retime.py` (+20/-2 lines): Window-based seeking and bounded read in batch executor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->