### PR TITLE
docs: official Docker Hub image palashdeb/omnivoice-studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Per-OS install guides — pick yours and follow it end-to-end:
 - **macOS** — [docs/install/macos.md](docs/install/macos.md)
 - **Windows** — [docs/install/windows.md](docs/install/windows.md)
 - **Linux** — [docs/install/linux.md](docs/install/linux.md)
-- **Docker** — [docs/install/docker.md](docs/install/docker.md)
+- **Docker** — [docs/install/docker.md](docs/install/docker.md) · [Docker Hub: `palashdeb/omnivoice-studio`](https://hub.docker.com/r/palashdeb/omnivoice-studio)
 
 Stuck? Run the built-in self-check first — **Settings → About → "Run
 self-check"** in the app, or `uv run python backend/main.py --diagnose` from

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -4,6 +4,9 @@ For headless servers, dedicated GPUs, or "I want one command" deployments.
 The docker image bundles the backend; the UI is served over HTTP and you open
 it in a normal browser.
 
+**Official images:** [`ghcr.io/debpalash/omnivoice-studio`](https://github.com/debpalash/OmniVoice-Studio/pkgs/container/omnivoice-studio)
+and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palashdeb/omnivoice-studio) — same images, same tags.
+
 > **Image ↔ version mapping**
 >
 > | Tag | What you get |


### PR DESCRIPTION
Links the published [Docker Hub repo](https://hub.docker.com/r/palashdeb/omnivoice-studio) as an official image alongside GHCR (README install list + docker.md header). Same images, same tags. Follows the publish workflow added in #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation: Official Docker Hub Image Reference

This PR adds explicit references to the official OmniVoice Studio Docker Hub repository (`palashdeb/omnivoice-studio`) to improve discoverability alongside the existing GHCR image registry.

### Changes Made

**README.md**
- Added a Docker Hub link (`palashdeb/omnivoice-studio`) next to the Docker installation guide reference in the quickstart install list

**docs/install/docker.md**
- Added an "Official images" header section listing both GHCR (`ghcr.io/debpalash/omnivoice-studio`) and Docker Hub (`palashdeb/omnivoice-studio`) registries
- Clarified that both registries use identical images and tags

### Impact
- Provides clearer visibility of the official Docker image on both major registries (GHCR and Docker Hub)
- No functional changes; purely informational documentation updates
- Aligns with the publish workflow introduced in PR `#375`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->