### PR TITLE
fix(history): real 2-line title clamp + de-noised display + click-to-expand

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -237,14 +237,23 @@
 .history-meta--locked    { color: #b8bb26; font-style: italic; }
 .history-subtitle--italic { font-style: italic; }
 
-/* Generated-history title clamp */
+/* Generated-history title clamp — real line-clamp with an ellipsis, not a
+   max-height guillotine that sliced the third line mid-glyph. Click toggles
+   the full text (see WorkspaceHistory). */
 .history-title--clamp {
   white-space: normal;
   font-weight: 500;
   font-size: 0.74rem;
   line-height: 1.3;
-  max-height: 3em;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
+  cursor: pointer;
+}
+.history-title--expanded {
+  -webkit-line-clamp: unset;
+  max-height: none;
 }
 .history-subtitle--seed {
   font-family: var(--font-mono);

--- a/frontend/src/components/WorkspaceHistory.jsx
+++ b/frontend/src/components/WorkspaceHistory.jsx
@@ -28,6 +28,17 @@ const FILTERS = [
 ];
 
 /**
+ * Row title for display: drop leading [laughter]/[question-en]-style control
+ * tokens — they're synthesis instructions, not content, and they were eating
+ * the two visible lines. The untouched original stays in the hover tooltip
+ * and in restore/save flows.
+ */
+const displayTitle = (text) => {
+  const stripped = (text || '').replace(/^(\s*\[[^\]]{1,30}\]\s*)+/, '').trim();
+  return stripped || text || '';
+};
+
+/**
  * Defer mounting <WaveformPlayer> (and its audio fetch + waveform decode)
  * until the row scrolls into view — the server returns up to 50 history rows,
  * which would otherwise fire 50 simultaneous fetches on panel mount.
@@ -62,6 +73,7 @@ export default function WorkspaceHistory({
 }) {
   const { t } = useTranslation();
   const [filter, setFilter] = useState('all');
+  const [expanded, setExpanded] = useState(null); // row id with un-clamped title
 
   // Voice workspace = clone + design generations (dub lives in its own workspace).
   const items = useMemo(() => {
@@ -153,8 +165,12 @@ export default function WorkspaceHistory({
                   {item.generation_time ? `${item.generation_time}s` : ''}
                 </span>
               </div>
-              <div className="history-title history-title--clamp" title={item.text}>
-                {item.text}
+              <div
+                className={`history-title history-title--clamp ${expanded === item.id ? 'history-title--expanded' : ''}`}
+                title={item.text}
+                onClick={() => setExpanded(e => (e === item.id ? null : item.id))}
+              >
+                {displayTitle(item.text)}
               </div>
               {item.seed != null && String(item.seed) !== ''
                 ? <div className="history-subtitle history-subtitle--seed">seed {item.seed}</div>


### PR DESCRIPTION
The history row's prompt was clipped with `max-height: 3em` — the third line rendered half-sliced glyphs. Now: true `-webkit-line-clamp: 2` with ellipsis; leading `[laughter]`-style control tokens stripped from the display title (they're synthesis instructions, not content — full text remains in the tooltip/restore); clicking the title expands/collapses the full prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Improves history item title display in the sidebar by implementing proper 2-line clamping with automatic ellipsis, stripping control tokens from the visible text, and adding click-to-expand behavior for the full title.

## Changes

### CSS Improvements (`Sidebar.css`)
**Before/After Title Display:**
```
BEFORE (max-height guillotine):         AFTER (proper 2-line clamp):
┌─────────────────────────┐             ┌─────────────────────────┐
│ [laughter] A very long  │             │ A very long title that  │
│ title text that spans   │             │ spans multiple lines...  │
│ m...                    │ ← cut mid   │ ← clean ellipsis        │
└─────────────────────────┘             └─────────────────────────┘
                                             [Click to expand ↓]
                                        ┌─────────────────────────┐
                                        │ A very long title text  │
                                        │ that spans multiple      │
                                        │ lines with all the full  │
                                        │ content displayed here   │
                                        └─────────────────────────┘
```

- Replaced `max-height: 3em` truncation with `-webkit-line-clamp: 2` on `.history-title--clamp`
- Added `-webkit-box` display and `-webkit-box-orient: vertical` for proper multi-line clamping
- Marked title as clickable with `cursor: pointer`
- Added new `.history-title--expanded` class to remove the clamp and restore full height for expanded state

### JavaScript Behavior (`WorkspaceHistory.jsx`)
**Click-to-Expand State Flow:**
```
┌─ User clicks title
│
├─ Check current expanded state
│
├─ If collapsed → Expand
│  ├─ Store item.id in expanded state
│  ├─ Apply history-title--expanded class
│  └─ Display full displayTitle(text)
│
└─ If expanded → Collapse
   ├─ Clear expanded state (set to null)
   ├─ Remove history-title--expanded class
   └─ Clamp to 2 lines with ellipsis
```

- Introduced `displayTitle()` helper function that strips leading bracketed control tokens (e.g., `[laughter]`, `[pause]`) from display text via regex `/^(\s*\[[^\]]{1,30}\]\s*)+/`
- Added local `expanded` state to track which history row ID has an un-clamped title
- Made title text clickable: clicking toggles the expanded state for that item
- Title div applies `.history-title--expanded` class conditionally based on expanded state
- Full original text (including control tokens) preserved in `title` attribute for tooltip display and restore flows
- Rendered title uses `displayTitle(item.text)` for cleaner display while maintaining full text context

## Result
History item titles now display cleanly with a proper 2-line hard limit and trailing ellipsis, control tokens are hidden from view but remain in tooltips, and users can click any title to toggle the full expanded text—providing better signal-to-noise ratio while preserving access to complete information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->