### PR TITLE
fix(mlx): harden import guards against PyInstaller dylib failures (Wave 4.4)

### DIFF
--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -511,8 +511,13 @@ class MLXWhisperBackend(ASRBackend):
                 return False, "Apple Silicon (MPS) not available."
             import mlx_whisper  # noqa: F401
             return True, "ready"
-        except ImportError as e:
-            return False, f"mlx-whisper not installed: {e}"
+        # Catch OSError/RuntimeError too, not just ImportError: in a
+        # PyInstaller bundle mlx's native dylib/metallib can fail to load
+        # even when the package imports, raising OSError/RuntimeError. We must
+        # report unavailable (so the picker falls back) rather than crash the
+        # registry scan (Wave 4.4).
+        except (ImportError, OSError, RuntimeError) as e:
+            return False, f"mlx-whisper unavailable: {e}"
 
     def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
         import mlx_whisper

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -580,9 +580,12 @@ class MLXAudioBackend(TTSBackend):
         try:
             import mlx_audio  # noqa: F401
             return True, "ready"
-        except ImportError as e:
+        # OSError/RuntimeError too: in a PyInstaller bundle mlx's native
+        # dylib/metallib can fail to load even when the package imports —
+        # report unavailable instead of crashing the registry scan (Wave 4.4).
+        except (ImportError, OSError, RuntimeError) as e:
             return False, (
-                f"mlx-audio not installed: {e}. "
+                f"mlx-audio unavailable: {e}. "
                 "This backend is Apple Silicon only — available on mac-ARM dev "
                 "installs; not shipped on Linux/Windows/mac-Intel."
             )

--- a/tests/backend/services/test_mlx_import_guard.py
+++ b/tests/backend/services/test_mlx_import_guard.py
@@ -1,0 +1,47 @@
+"""MLX import-guard hardening (Wave 4.4).
+
+A PyInstaller-bundled mlx whose native dylib/metallib fails to load raises
+OSError/RuntimeError on import — not ImportError. is_available() must report
+unavailable instead of letting that propagate and crash the registry scan.
+"""
+import builtins
+
+import pytest
+
+
+def _block_import(monkeypatch, name, exc):
+    real = builtins.__import__
+
+    def fake(n, *a, **k):
+        if n == name:
+            raise exc
+        return real(n, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake)
+
+
+@pytest.mark.parametrize("exc", [OSError("dlopen metallib failed"),
+                                 RuntimeError("metal device init failed"),
+                                 ImportError("No module named mlx_whisper")])
+def test_mlx_whisper_unavailable_not_crash(monkeypatch, exc):
+    import torch
+    if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
+        # is_available short-circuits on non-MPS before importing mlx; force
+        # the MPS branch so the import guard is what we're exercising.
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True, raising=False)
+    from services.asr_backend import MLXWhisperBackend
+    _block_import(monkeypatch, "mlx_whisper", exc)
+    ok, msg = MLXWhisperBackend.is_available()
+    assert ok is False
+    assert "mlx-whisper" in msg
+
+
+@pytest.mark.parametrize("exc", [OSError("dlopen failed"),
+                                 RuntimeError("metal init failed"),
+                                 ImportError("no mlx_audio")])
+def test_mlx_audio_unavailable_not_crash(monkeypatch, exc):
+    from services.tts_backend import MLXAudioBackend
+    _block_import(monkeypatch, "mlx_audio", exc)
+    ok, msg = MLXAudioBackend.is_available()
+    assert ok is False
+    assert "mlx-audio" in msg


### PR DESCRIPTION
## What

Wave 4.4 (Spec 6 remaining slice). `MLXWhisperBackend` / `MLXAudioBackend` `is_available()` caught only `ImportError` — but in a PyInstaller bundle mlx's native dylib/metallib can fail to load *even when the package imports*, raising `OSError`/`RuntimeError`. That would propagate and crash the registry scan instead of reporting the backend unavailable. Broadened both to `(ImportError, OSError, RuntimeError)` so the engine picker falls back cleanly.

The capture ASR path already routes through MLX Turbo on Apple Silicon (`get_capture_asr_backend`), so this guard is the genuinely-remaining part of the MLX item.

## Verification
- `uv run pytest tests/backend/services/test_mlx_import_guard.py` → 6 passed (OSError / RuntimeError / ImportError × both backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Hardens the import guards in MLX-based backends (`MLXWhisperBackend` and `MLXAudioBackend`) to handle additional failure modes beyond missing Python packages. In PyInstaller bundles, native dylibs or metallibs may fail to load even when the Python package successfully imports, raising `OSError` or `RuntimeError`. Previously these exceptions propagated uncaught, crashing the backend registry scan. Now they are properly caught and converted to unavailable status, allowing clean fallback to alternative backends.

## Changes

### backend/services/asr_backend.py
- `MLXWhisperBackend.is_available()` now catches `(ImportError, OSError, RuntimeError)` instead of just `ImportError`
- Exception details are included in the unavailable reason message to aid debugging
- Lines changed: +7/-2

### backend/services/tts_backend.py
- `MLXAudioBackend.is_available()` expands caught exception types to include `OSError` and `RuntimeError`
- Captured exception is now included in the "mlx-audio unavailable" response
- Lines changed: +5/-2

### tests/backend/services/test_mlx_import_guard.py (new file)
- Adds regression test suite with 6 test cases covering both backends
- `_block_import()` helper monkeypatches `builtins.__import__` to simulate import failures
- `test_mlx_whisper_unavailable_not_crash()` verifies graceful handling of `OSError`, `RuntimeError`, and `ImportError` when importing `mlx_whisper`
- `test_mlx_audio_unavailable_not_crash()` verifies graceful handling of the same exception types when importing `mlx_audio`
- Lines changed: +47/-0

## Behavior Flow

```mermaid
graph TD
    A["is_available() called"] --> B["Try import mlx library"]
    B -->|Success| C["Return True<br/>Backend available"]
    B -->|ImportError| D["Catch exception"]
    B -->|OSError| D
    B -->|RuntimeError| D
    D --> E["Log failure reason<br/>with exception detail"]
    E --> F["Return False<br/>Backend unavailable"]
    F --> G["Registry falls back<br/>to next backend"]
```

## Verification
All 6 tests pass as confirmed by `uv run pytest tests/backend/services/test_mlx_import_guard.py`, ensuring both backends correctly report unavailability across all three exception types without crashing the backend registry scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->