### PR TITLE
feat(settings): Hugging Face mirror (HF_ENDPOINT) for restricted networks (Wave 4.3)

### DIFF
--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -395,3 +395,60 @@ def set_models_dir(body: _ModelsDirBody):
 
     user_env.set_user_env(_MODELS_DIR_ENV, path)
     return {"configured": path, "effective": _effective_models_dir(), "restart_required": True}
+
+
+# ── HF mirror endpoint (parity program Wave 4.3 / §R4 c) ──────────────────
+# Restricted-network users (e.g. behind the Great Firewall) need to point
+# huggingface_hub at a mirror. HF reads HF_ENDPOINT at import time, so a
+# change takes effect on the next backend start — persisted to the durable
+# per-user env so it survives Tauri/Finder launches that don't inherit a
+# shell. Loopback-gated via the router dep.
+
+_HF_ENDPOINT_ENV = "HF_ENDPOINT"
+
+# A few well-known mirrors, surfaced as quick-picks in the UI. hf-mirror.com
+# is the community mirror most-used in China; the official endpoint clears it.
+_HF_MIRROR_PRESETS = [
+    {"label": "Hugging Face (official)", "url": ""},
+    {"label": "hf-mirror.com (community, China)", "url": "https://hf-mirror.com"},
+]
+
+
+class _HFMirrorBody(BaseModel):
+    url: str = Field("", description="HF_ENDPOINT URL; empty string clears it (official endpoint)")
+
+
+@router.get("/hf-mirror")
+def get_hf_mirror():
+    from core import user_env
+
+    configured = user_env.get_user_env(_HF_ENDPOINT_ENV) or ""
+    return {
+        # The value that will apply after restart (persisted), and what's
+        # live in this process (env may differ until then).
+        "configured": configured,
+        "effective": os.environ.get(_HF_ENDPOINT_ENV, ""),
+        "presets": _HF_MIRROR_PRESETS,
+    }
+
+
+@router.put("/hf-mirror")
+def set_hf_mirror(body: _HFMirrorBody):
+    from core import user_env
+
+    url = (body.url or "").strip().rstrip("/")
+    if url and not url.startswith(("http://", "https://")):
+        raise HTTPException(status_code=400, detail="Mirror URL must start with http(s)://")
+    try:
+        if url:
+            user_env.set_user_env(_HF_ENDPOINT_ENV, url)
+            os.environ[_HF_ENDPOINT_ENV] = url  # best-effort for new downloads this session
+        else:
+            user_env.unset_user_env(_HF_ENDPOINT_ENV)
+            os.environ.pop(_HF_ENDPOINT_ENV, None)
+    except Exception:
+        logger.exception("set_hf_mirror failed")
+        raise HTTPException(status_code=500, detail="Failed to persist mirror setting")
+    # HF endpoint is read at import time by huggingface_hub, so the override
+    # is only guaranteed once the backend restarts.
+    return {"configured": url, "restart_required": True, "presets": _HF_MIRROR_PRESETS}

--- a/frontend/src/components/settings/HFMirrorPanel.jsx
+++ b/frontend/src/components/settings/HFMirrorPanel.jsx
@@ -1,0 +1,94 @@
+/**
+ * Settings → Models tab → Hugging Face mirror panel (Wave 4.3).
+ *
+ * Restricted-network users (e.g. behind the Great Firewall) point
+ * huggingface_hub at a mirror via HF_ENDPOINT. HF reads it at import time, so
+ * the change applies after a restart. Persisted to the durable per-user env.
+ *
+ * Endpoints (loopback-only):
+ *   GET /api/settings/hf-mirror → {configured, effective, presets}
+ *   PUT /api/settings/hf-mirror  body {url}  (empty url clears → official)
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Globe } from 'lucide-react';
+import { apiJson, apiFetch } from '../../api/client';
+import './PerformancePanel.css';
+
+export default function HFMirrorPanel() {
+  const [state, setState] = useState(null);
+  const [url, setUrl] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [restart, setRestart] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const d = await apiJson('/api/settings/hf-mirror');
+      setState(d);
+      setUrl(d?.configured || '');
+    } catch (e) {
+      setError(e?.message || 'Failed to load mirror setting');
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const save = async (value) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/settings/hf-mirror', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: value }),
+      });
+      const d = await res.json();
+      setUrl(d.configured || '');
+      setRestart(Boolean(d.restart_required));
+      refresh();
+    } catch (e) {
+      setError(e?.message || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!state) return null;
+
+  return (
+    <section className="perfpanel" aria-labelledby="hfmirror-heading">
+      <h3 id="hfmirror-heading" className="perfpanel__title">
+        <Globe size={14} /> Hugging Face mirror
+      </h3>
+      <p className="perfpanel__help">
+        On a restricted network, route model downloads through a mirror.
+        Applies after a restart. Leave empty for the official endpoint.
+      </p>
+
+      {error && <div className="perfpanel__error" role="alert">{error}</div>}
+
+      <div className="perfpanel__row" style={{ flexWrap: 'wrap', gap: 6 }}>
+        {state.presets.map((p) => (
+          <button key={p.label} type="button" onClick={() => save(p.url)}
+            disabled={saving} data-testid={`hf-preset-${p.url || 'official'}`}>
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      <label className="perfpanel__row">
+        <span className="perfpanel__label">HF_ENDPOINT</span>
+        <input type="text" value={url} onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://hf-mirror.com" style={{ flex: 1 }} data-testid="hf-mirror-url" />
+        <button type="button" onClick={() => save(url)} disabled={saving} data-testid="hf-mirror-save">
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </label>
+
+      {restart && (
+        <p className="perfpanel__help">Restart the app for the mirror change to take effect.</p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -36,6 +36,7 @@ import PerformancePanel from '../components/settings/PerformancePanel';
 import RefinementPanel from '../components/settings/RefinementPanel';
 import AppearancePanel from '../components/settings/AppearancePanel';
 import StoragePanel from '../components/settings/StoragePanel';
+import HFMirrorPanel from '../components/settings/HFMirrorPanel';
 import SharingPanel from '../components/settings/SharingPanel';
 import RemoteBackendPanel from '../components/settings/RemoteBackendPanel';
 import MCPBindingsPanel from '../components/settings/MCPBindingsPanel';
@@ -1325,6 +1326,7 @@ export default function Settings() {
       {activeTab === 'models' && (
         <>
           <StoragePanel />
+          <HFMirrorPanel />
           <ModelStoreTab info={info} modelBadge={modelBadge} />
         </>
       )}

--- a/tests/test_hf_mirror_settings.py
+++ b/tests/test_hf_mirror_settings.py
@@ -1,0 +1,45 @@
+"""HF mirror (HF_ENDPOINT) setting — Wave 4.3. Pure, prefs stubbed."""
+import os
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def settings_mod(monkeypatch):
+    store = {}
+    import core.user_env as ue
+    monkeypatch.setattr(ue, "get_user_env", lambda k, path=None: store.get(k))
+    monkeypatch.setattr(ue, "set_user_env", lambda k, v, path=None: store.__setitem__(k, v))
+    monkeypatch.setattr(ue, "unset_user_env", lambda k, path=None: store.pop(k, None))
+    monkeypatch.delenv("HF_ENDPOINT", raising=False)
+    return importlib.import_module("api.routers.settings")
+
+
+def test_get_default_empty(settings_mod):
+    st = settings_mod.get_hf_mirror()
+    assert st["configured"] == "" and st["effective"] == ""
+    assert any(p["url"] == "https://hf-mirror.com" for p in st["presets"])
+
+
+def test_set_and_clear(settings_mod):
+    st = settings_mod.set_hf_mirror(settings_mod._HFMirrorBody(url="https://hf-mirror.com/"))
+    assert st["configured"] == "https://hf-mirror.com"  # trailing slash trimmed
+    assert st["restart_required"] is True
+    assert os.environ["HF_ENDPOINT"] == "https://hf-mirror.com"
+    assert settings_mod.get_hf_mirror()["configured"] == "https://hf-mirror.com"
+
+    settings_mod.set_hf_mirror(settings_mod._HFMirrorBody(url=""))
+    assert settings_mod.get_hf_mirror()["configured"] == ""
+    assert "HF_ENDPOINT" not in os.environ
+
+
+def test_rejects_non_http(settings_mod):
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        settings_mod.set_hf_mirror(settings_mod._HFMirrorBody(url="hf-mirror.com"))
+    assert ei.value.status_code == 400


### PR DESCRIPTION
## What

Wave 4.3 slice (§R4 c). The model manager already lists (`GET /models`) and deletes (`DELETE /models/{id}`) cached models with a Settings UI — this adds the genuinely-missing high-value piece: an in-app **HF mirror** setting so users on restricted networks (e.g. behind the Great Firewall) route downloads through `hf-mirror.com` or any `HF_ENDPOINT`.

- `GET/PUT /api/settings/hf-mirror` (loopback-gated): presets (official + hf-mirror.com), http(s) validation, empty clears to official. Persisted to the durable per-user env (survives Tauri/Finder launches that don't inherit a shell). HF reads `HF_ENDPOINT` at import, so the override applies on restart — surfaced in the UI.
- Models-tab `HFMirrorPanel` with quick-picks + free-text field + restart note.

Skipped `hf cache verify` — version-fragile across `huggingface_hub` releases and low value vs the mirror (which the China/Russia network research flagged as the real gap).

## Verification
- `uv run pytest tests/test_hf_mirror_settings.py` → 3 passed (default, set+trim+clear, non-http rejection)
- `bun run typecheck:ci` clean; `bunx vitest run` 312 passed; CJK gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds Hugging Face mirror support (HF_ENDPOINT configuration) for users on restricted networks, enabling downloads through hf-mirror.com or custom endpoints. 

**Backend**: New `/api/settings/hf-mirror` GET/PUT endpoints handle mirror configuration persistence and validation. GET returns the current configured and effective HF_ENDPOINT values plus preset options. PUT validates and persists the URL (HTTP/HTTPS only), updates the process environment, and flags `restart_required: True` since `huggingface_hub` reads the variable at import time.

**Frontend**: HFMirrorPanel component in the Models settings tab loads the mirror config on mount, displays preset quick-pick buttons, supports free-text URL input, and shows a restart-required message after changes.

**Persistence**: Settings are stored in per-user environment storage that survives app restarts.

**Tests**: Three test cases verify default behavior, set/trim/clear operations, and HTTP validation.

### UI Changes

```
Settings → Models Tab (Before)
┌─────────────────────────────────────┐
│ StoragePanel                        │
├─────────────────────────────────────┤
│ ModelStoreTab                       │
└─────────────────────────────────────┘

Settings → Models Tab (After)
┌─────────────────────────────────────┐
│ StoragePanel                        │
├─────────────────────────────────────┤
│ HFMirrorPanel (NEW)                 │
│ ┌─────────────────────────────────┐ │
│ │ HF Mirror Endpoint              │ │
│ │ [Official]  [HF-Mirror.com]     │ │
│ │ [Custom URL input field...]     │ │
│ │ ⚠ Restart required              │ │
│ └─────────────────────────────────┘ │
├─────────────────────────────────────┤
│ ModelStoreTab                       │
└─────────────────────────────────────┘
```

### Behavior Flow

```mermaid
flowchart TD
    A["User opens Settings → Models"] -->|Mount| B["HFMirrorPanel loads<br/>GET /api/settings/hf-mirror"]
    B --> C{"Response<br/>received"}
    C -->|Success| D["Display current mirror URL<br/>Show preset buttons"]
    C -->|Error| E["Show error alert"]
    
    D --> F{"User action"}
    F -->|Click preset| G["Save preset URL<br/>PUT /api/settings/hf-mirror"]
    F -->|Enter custom URL| G
    F -->|Clear| H["PUT with empty URL"]
    
    G --> I{"Validation"}
    I -->|Invalid| J["Show error<br/>400 Bad Request"]
    I -->|Valid| K["Persist to user env<br/>Update os.environ"]
    
    H --> K
    K --> L["Response: restart_required"]
    L --> M["Show restart message<br/>Component re-renders"]
```

### Files Changed
- **backend/api/routers/settings.py**: +57 lines (GET/PUT HF mirror endpoints with validation)
- **frontend/src/components/settings/HFMirrorPanel.jsx**: +94 lines (new React component with preset selection)
- **frontend/src/pages/Settings.jsx**: +2 lines (import and render HFMirrorPanel)
- **tests/test_hf_mirror_settings.py**: +45 lines (4 test cases: defaults, set+trim, clear, validation)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->