### PR TITLE
feat(studio): Voice Console 10x P3 — identity recipe line, Active-voice card, empty-state verbs

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1208,6 +1208,7 @@ function App() {
               defineMethod={defineMethod}
               profiles={profiles}
               selectedProfile={selectedProfile}
+              setSelectedProfile={setSelectedProfile}
               previewLoading={previewLoading}
               handleSelectProfile={handleSelectProfile}
               handleDeleteProfile={handleDeleteProfile}

--- a/frontend/src/components/WorkspaceVoices.css
+++ b/frontend/src/components/WorkspaceVoices.css
@@ -16,6 +16,60 @@
   flex: 0 0 auto;
 }
 
+/* ── Active voice card (10x §2) — identity always visible ─────── */
+.wv__active {
+  flex: 0 0 auto;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--chrome-border);
+}
+.wv__active-kicker {
+  font-family: var(--chrome-font-mono, var(--font-mono));
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--chrome-fg-dim, #665c54);
+  margin-bottom: 6px;
+}
+.wv__active-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--chrome-accent-border, rgba(211, 134, 155, 0.35));
+  background: var(--chrome-accent-bg, rgba(211, 134, 155, 0.08));
+  border-radius: 10px;
+}
+.wv__active-row { display: flex; align-items: center; gap: 8px; justify-content: space-between; }
+.wv__active-name { font-size: 0.8rem; font-weight: 600; color: var(--chrome-fg); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wv__active-recipe {
+  font-size: 0.68rem;
+  color: var(--chrome-fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.wv__active-actions { display: flex; gap: 6px; }
+.wv__active-empty {
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: var(--chrome-fg-muted);
+  padding: 8px 10px;
+  border: 1px dashed var(--chrome-border);
+  border-radius: 10px;
+}
+
+.wv__empty-cta {
+  display: block;
+  margin: 8px auto 0;
+  padding: 4px 10px;
+  font-size: 0.66rem;
+  color: var(--chrome-fg-muted);
+  background: transparent;
+  border: 1px dashed var(--chrome-border);
+  border-radius: var(--chrome-radius-pill, 999px);
+  cursor: default;
+}
+
 .wv__head {
   flex: 0 0 auto;
   display: flex;

--- a/frontend/src/components/WorkspaceVoices.jsx
+++ b/frontend/src/components/WorkspaceVoices.jsx
@@ -14,14 +14,18 @@
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  Search, Fingerprint, Wand2, Lock, Unlock, Play, Loader, Check, Volume2, Trash2,
+  Search, Fingerprint, Wand2, Lock, Unlock, Play, Loader, Check, Volume2, Trash2, Plus,
 } from 'lucide-react';
+import WaveformPlayer from './WaveformPlayer';
+import { API } from '../api/client';
+import { useAppStore } from '../store';
 import './WorkspaceVoices.css';
 
 export default function WorkspaceVoices({
   defineMethod,
   profiles = [],
   selectedProfile,
+  setSelectedProfile,
   previewLoading,
   handleSelectProfile,
   handleDeleteProfile,
@@ -31,8 +35,13 @@ export default function WorkspaceVoices({
   onOpenVoicePreview,
 }) {
   const { t } = useTranslation();
+  const setDefineMethod = useAppStore(s => s.setDefineMethod);
   const [q, setQ] = useState('');
   const qLower = q.trim().toLowerCase();
+
+  // ACTIVE VOICE card (10x §2): always answer "who speaks when I press
+  // Synthesize". Recipe = instruct (designed) or "your reference clip".
+  const active = profiles.find(p => p.id === selectedProfile) || null;
 
   const items = useMemo(() => {
     const byMethod = profiles.filter(p => (defineMethod === 'audio' ? !p.instruct : !!p.instruct));
@@ -47,6 +56,41 @@ export default function WorkspaceVoices({
 
   return (
     <section className={`wv ${items.length === 0 ? 'wv--collapsed' : ''}`}>
+      {/* ── ACTIVE VOICE ─────────────────────────────────────────────── */}
+      <div className="wv__active">
+        <div className="wv__active-kicker">{t('voices.active', { defaultValue: 'Active voice' })}</div>
+        {active ? (
+          <div className="wv__active-card">
+            <div className="wv__active-row">
+              <span className="wv__active-name">{active.name}</span>
+              <span className="history-kind" style={{ color: active.instruct ? '#8ec07c' : '#d3869b', borderColor: active.instruct ? '#8ec07c40' : '#d3869b40' }}>
+                {active.instruct ? t('sidebar.design_label') : t('sidebar.clone_label')}
+              </span>
+            </div>
+            <div className="wv__active-recipe">
+              {active.instruct || t('voices.active_clone_recipe', { defaultValue: 'Cloned from your reference clip' })}
+            </div>
+            {active.ref_audio_path ? (
+              <WaveformPlayer
+                src={`${API}/profiles/${active.id}/audio`}
+                source="profile-sample"
+                height={26}
+                compact
+              />
+            ) : null}
+            <div className="wv__active-actions">
+              <button type="button" className="history-action-btn" onClick={() => setSelectedProfile?.(null)}>
+                <Plus size={10} /> {t('voices.new', { defaultValue: 'New voice' })}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="wv__active-empty">
+            {t('voices.none_selected', { defaultValue: 'No voice selected — describe one, drop audio, or pick below.' })}
+          </div>
+        )}
+      </div>
+
       <div className="wv__head">
         <span className="wv__title">{title}</span>
         <div className="wv__search">
@@ -66,6 +110,16 @@ export default function WorkspaceVoices({
             {defineMethod === 'audio'
               ? t('sidebar.no_clones', { defaultValue: 'No voice clones yet' })
               : t('sidebar.no_designs', { defaultValue: 'No designed voices yet' })}
+            {/* Empty states carry verbs (10x §2). */}
+            <button
+              type="button"
+              className="wv__empty-cta"
+              onClick={() => setDefineMethod(defineMethod === 'audio' ? 'audio' : 'design')}
+            >
+              {defineMethod === 'audio'
+                ? t('voices.cta_clone', { defaultValue: 'Drop a 3s clip in Voice ← to clone one' })
+                : t('voices.cta_design', { defaultValue: 'Describe one in Voice ← to design it' })}
+            </button>
           </div>
         ) : items.map(proj => {
           const accent = proj.is_locked ? '#b8bb26' : (defineMethod === 'audio' ? '#d3869b' : '#8ec07c');

--- a/frontend/src/pages/CloneDesignTab.css
+++ b/frontend/src/pages/CloneDesignTab.css
@@ -167,6 +167,40 @@
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
+/* ── Identity recipe line (collapsed category summary) ───────── */
+.identity-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin: 4px 0 8px;
+  padding: 6px 10px;
+  background: var(--chrome-hover-bg, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--chrome-border);
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--dur-fast);
+}
+.identity-line:hover { border-color: var(--chrome-border-strong); }
+.identity-line__kicker {
+  font-family: var(--chrome-font-mono, var(--font-mono));
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--chrome-fg-dim, #665c54);
+  flex: 0 0 auto;
+}
+.identity-line__recipe {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.74rem;
+  color: var(--chrome-fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* ── Starting points: ONE preset lane, edge-faded scroll ─────── */
 .starting-points { margin: 8px 0 12px; }
 .starting-points__label {
@@ -213,7 +247,9 @@
   min-height: 0;
   position: relative;
 }
-.clone-split-grid > .studio-column:first-child { flex: 1 0 auto; z-index: 2; }
+/* Natural stacking — forcing the script column to grow left a void between
+   SCRIPT and VOICE; the pinned action bar owns the bottom edge anyway. */
+.clone-split-grid > .studio-column:first-child { flex: 0 0 auto; z-index: 2; }
 .clone-split-grid > .studio-column:last-child  { z-index: 1; }
 .clone-panel--overflow-visible { overflow: visible; position: relative; z-index: 10; }
 

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -62,6 +62,15 @@ export default function CloneDesignTab(props) {
   const [activePersonality, setActivePersonality] = useState('');
   const [insertOpen, setInsertOpen] = useState(false);
 
+  // Identity recipe line (10x §1.5): the non-Auto category picks as one
+  // readable string. All-Auto (nothing chosen yet) starts the chips expanded.
+  const identityPicks = Object.values(vdStates || {}).filter(v => v && v !== 'Auto');
+  const identityRecipe = identityPicks.length
+    ? identityPicks.join(' · ')
+    : t('clone.identity_auto', { defaultValue: 'Auto — the model decides' });
+  const [identityOpen, setIdentityOpen] = useState(() =>
+    !Object.values(vdStates || {}).some(v => v && v !== 'Auto'));
+
   // ── "Describe your voice" (#317): free-text → design parameters ──────────
   // Debounced call to the local deterministic mapper (POST /design/describe);
   // the result overwrites the category controls live, and the user can still
@@ -479,6 +488,21 @@ export default function CloneDesignTab(props) {
                 })}
               </div>
             </div>
+            {/* Identity recipe (10x §1.5): once any category is set, the
+                chip groups collapse to one quiet line — the current voice
+                recipe — and the describe box rewrites it live. All-Auto
+                (first run) starts expanded. */}
+            <button
+              type="button"
+              className="identity-line"
+              onClick={() => setIdentityOpen(o => !o)}
+              aria-expanded={identityOpen}
+            >
+              <span className="identity-line__kicker">{t('clone.identity', { defaultValue: 'Identity' })}</span>
+              <span className="identity-line__recipe">{identityRecipe}</span>
+              {identityOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+            </button>
+            {identityOpen && (
             <div className="clone-sliders-col">
               {Object.entries(CATEGORIES).map(([key, options]) => {
                 const many = options.length > 6;
@@ -528,6 +552,7 @@ export default function CloneDesignTab(props) {
                 );
               })}
             </div>
+            )}
 
             {/* Save the current design as a reusable profile (0005): the
                 backend renders a deterministic identity sample (seed 42)


### PR DESCRIPTION
Phase 3 of `docs/specs/voice-console-10x.md`: category chips collapse behind a live **Identity** recipe line; the right rail leads with an **ACTIVE VOICE** card (name · kind badge · recipe · identity sample · ＋New) so it's always clear who speaks on Synthesize; empty states carry verbs. Verified live in WebKit; 312/312 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Implementation of Voice Console 10x Phase 3

Implements Phase 3 per `docs/specs/voice-console-10x.md` §1.5 & §2, introducing:

### 1. Identity Recipe Line (Category Chip Collapsing)
The CloneDesignTab now renders a collapsible "identity recipe" button above category controls. Non-Auto category selections are summarized as a single human-readable line (e.g., "male · elderly · …"); All-Auto defaults to expanded. Toggling the line collapses/expands the chip controls.

**Layout shift:**
```
Before:
┌─────────────────────┐
│ Category Sliders:   │
│ ☐ Gender:  [Slider]│
│ ☐ Age:     [Slider]│
│ ☐ ...              │
└─────────────────────┘

After (collapsed):
┌─────────────────────┐
│ 🔽 Identity: male ··│  (clickable line)
│    Age: elderly ... │
└─────────────────────┘

After (expanded):
┌─────────────────────┐
│ 🔼 Identity: male ··│  (clickable line)
│    Age: elderly ... │
│ Category Sliders:   │
│ ☐ Gender:  [Slider]│
│ ☐ Age:     [Slider]│
└─────────────────────┘
```

### 2. Active Voice Card (Right Rail Pinning)
WorkspaceVoices now displays a prominent "ACTIVE VOICE" panel above the saved-voices list, always showing who will speak on Synthesize:

```
Right Rail Before:
┌──────────────────────────┐
│ Saved Voices             │
│ [Search box]             │
│ • Profile 1              │
│ • Profile 2              │
└──────────────────────────┘

Right Rail After:
┌──────────────────────────┐
│ ACTIVE VOICE             │
│ ┌──────────────────────┐ │
│ │ My Voice    [Design] │ │
│ │ English instructions │ │
│ │ [Waveform player]    │ │
│ │ [+ New voice      ]  │ │
│ └──────────────────────┘ │
│                          │
│ Saved Voices             │
│ [Search box]             │
│ • Profile 1              │
│ • Profile 2              │
└──────────────────────────┘
```

Active card shows:
- Profile name (truncated)
- Kind badge: "Clone" (pink) | "Design" (green)
- Recipe text: either instruct (designed profiles) or "Cloned from your reference clip"
- Optional waveform preview from `ref_audio_path`
- "+ New voice" action (clears selection)

Empty state: "No voice selected — describe one, drop audio, or pick below."

### 3. Enhanced Empty States
- When no profiles exist in the selected method (audio/design), a CTA button toggles `defineMethod` with instructional text: "Describe one in Voice ←"

### 4. Column Layout Adjustment
Changed `.clone-split-grid > .studio-column:first-child` flex sizing from `flex: 1 0 auto` to `flex: 0 0 auto`, allowing the script/voice columns to stack naturally without void space during horizontal scrolling.

### Code Changes
- **WorkspaceVoices.jsx**: Now accepts `setSelectedProfile` prop; derives `active` profile from selectedProfile; implements search filtering (`q`/`qLower`) on name and instruct text
- **WorkspaceVoices.css**: +54 lines for `.wv__active*` and `.wv__active-empty` selectors (card, row, recipe, actions, empty states)
- **CloneDesignTab.jsx**: +25 lines deriving `identityRecipe` string and `identityOpen` state; conditionally renders category chips only when expanded
- **CloneDesignTab.css**: +37 lines for `.identity-line`, `.identity-line__kicker`, `.identity-line__recipe`; +1 line flex rule change
- **App.jsx**: Passes `setSelectedProfile` to WorkspaceVoices

**Test coverage**: 312/312 passing; verified in WebKit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->