### PR TITLE
feat(studio): Voice Console 10x P4 — contrast, radiogroups, focus rings, reduced motion

### DIFF
--- a/frontend/src/components/FloatingPill.css
+++ b/frontend/src/components/FloatingPill.css
@@ -66,6 +66,10 @@
 @media (prefers-reduced-motion: reduce) {
   .floating-pill { animation: none; opacity: 1; }
   .floating-pill--exiting { animation: none; opacity: 0; }
+  /* 10x P4 (spec §3): pulse/sweep loops die too — the dot and the
+     indeterminate bar hold a static frame. */
+  .floating-pill__dot { animation: none; }
+  .floating-pill__progress-fill--indeterminate { animation: none; transform: none; }
 }
 
 /* ── Stage indicator dot ────────────────────────────────────────────── */

--- a/frontend/src/components/LogsFooter.css
+++ b/frontend/src/components/LogsFooter.css
@@ -452,3 +452,12 @@
   color: var(--color-brand);
   white-space: nowrap;
 }
+
+/* ── Reduced motion (10x P4, spec §3): the heart stops glowing; the
+   refresh spinner holds a static frame. ───────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .logs-footer__donate,
+  .logs-footer__icon-btn .spinner {
+    animation: none;
+  }
+}

--- a/frontend/src/components/WaveformPlayer.css
+++ b/frontend/src/components/WaveformPlayer.css
@@ -79,3 +79,9 @@
   width: 100%;
   height: 34px;
 }
+
+/* ── Reduced motion (10x P4, spec §3): loading spinner holds a static
+   frame instead of rotating. ──────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .wf-player__spin { animation: none; }
+}

--- a/frontend/src/components/WorkspaceVoices.css
+++ b/frontend/src/components/WorkspaceVoices.css
@@ -27,7 +27,8 @@
   font-size: 0.62rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--chrome-fg-dim, #665c54);
+  /* 10x P4 contrast: readable kicker — dim (3.91:1 default theme) → muted. */
+  color: var(--chrome-fg-muted, #a89984);
   margin-bottom: 6px;
 }
 .wv__active-card {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1013,6 +1013,20 @@ a:focus:not(:focus-visible),
 input:focus:not(:focus-visible),
 select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
 
+/* 10x P4 (spec §3 a11y gate): one consistent, fully-opaque ring on the
+   studio's 10x controls — shared rule, not per-component restyles. */
+.identity-line:focus-visible,
+.clone-insert-btn:focus-visible,
+.personality-chip:focus-visible,
+.chip:focus-visible,
+.wh__chip:focus-visible,
+.dub-lang-pill:focus-visible,
+.wf-player__btn:focus-visible,
+.studio-action-bar__overrides:focus-visible {
+  outline: 2px solid var(--chrome-accent);
+  outline-offset: 1px;
+}
+
 /* ═══ LAUNCHPAD — chrome frame + restrained motion ═══ */
 .launchpad {
   flex: 1; display: flex; flex-direction: column; overflow-y: auto;

--- a/frontend/src/pages/CloneDesignTab.css
+++ b/frontend/src/pages/CloneDesignTab.css
@@ -117,8 +117,8 @@
 .studio-action-bar__overrides {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 10px;
+  gap: 4px;     /* 10x P4 8-pt audit: 5 → 4 */
+  padding: 4px 10px;
   font-size: 0.7rem;
   color: var(--chrome-fg-muted);
   background: transparent;
@@ -140,7 +140,7 @@
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 3px 9px;
+  padding: 4px 8px;     /* 10x P4 8-pt audit: 3px 9px → 4px 8px */
   font-size: 0.66rem;
   color: var(--chrome-fg-muted);
   background: var(--chrome-bg);
@@ -188,7 +188,8 @@
   font-size: 0.62rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--chrome-fg-dim, #665c54);
+  /* 10x P4 contrast: readable kicker — dim (3.91:1 default theme) → muted. */
+  color: var(--chrome-fg-muted, #a89984);
   flex: 0 0 auto;
 }
 .identity-line__recipe {
@@ -208,7 +209,8 @@
   font-size: 0.62rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--chrome-fg-dim, #665c54);
+  /* 10x P4 contrast: readable kicker — dim (3.91:1 default theme) → muted. */
+  color: var(--chrome-fg-muted, #a89984);
   margin-bottom: 6px;
 }
 .starting-points__strip {
@@ -298,7 +300,8 @@
 }
 .describe-voice-hint {
   font-size: 0.62rem;
-  color: var(--chrome-fg-dim);
+  /* 10x P4 contrast: readable hint text — dim (3.91:1 default theme) → muted. */
+  color: var(--chrome-fg-muted);
 }
 .describe-voice-feedback {
   font-size: 0.65rem;
@@ -312,7 +315,7 @@
 .clone-sliders-col {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 7px 12px;
+  gap: 8px 12px;     /* 10x P4 8-pt audit: 7 → 8 */
 }
 .clone-cat--chips  { grid-column: 1 / -1; }
 .clone-cat--select { min-width: 0; }
@@ -339,7 +342,8 @@
 .clone-slider-kicker {
   margin-left: 6px;
   font-size: 0.58rem;
-  color: var(--chrome-fg-dim);
+  /* 10x P4 contrast: shows the selected value — readable label, dim → muted. */
+  color: var(--chrome-fg-muted);
   font-weight: 500;
 }
 

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -222,6 +222,25 @@ export default function CloneDesignTab(props) {
       });
   };
 
+  // 10x P4 a11y (spec §3): category chip groups are radiogroups with a
+  // roving tabindex — ArrowLeft/ArrowRight move focus AND selection within
+  // the group, per the WAI-ARIA radio-group pattern.
+  const onChipKeyDown = (e, key, options) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const cur = Math.max(0, options.indexOf(vdStates[key]));
+    const next = (cur + (e.key === 'ArrowRight' ? 1 : -1) + options.length) % options.length;
+    setVdStates({ ...vdStates, [key]: options[next] });
+    e.currentTarget.closest('.chip-group')?.querySelectorAll('[role="radio"]')[next]?.focus();
+  };
+
+  // 10x P4 a11y (spec §3): once a generation has run, the persistent status
+  // region below announces its finish — not just its start.
+  const wasGeneratingRef = useRef(false);
+  useEffect(() => {
+    if (isGenerating) wasGeneratingRef.current = true;
+  }, [isGenerating]);
+
   // Partition personalities into legacy chips vs. new demo cards.
   // `is_demo: true` entries get the rich card grid; the rest keep their
   // existing chip-strip rendering (backward-compatible with v0.2.x users
@@ -528,17 +547,25 @@ export default function CloneDesignTab(props) {
                         {options.map(opt => <option key={opt} value={opt}>{opt}</option>)}
                       </select>
                     ) : (
-                      <div className="chip-group">
-                        {options.map(opt => {
+                      <div className="chip-group" role="radiogroup" aria-label={t(`clone.cat_${key}`)}>
+                        {options.map((opt, i) => {
                           const optTKey = `clone.opt_${opt.replace(/[ -]/g, '_')}`;
                           const optTl = t(optTKey);
                           const optLabel = optTl !== optTKey ? optTl : opt;
+                          const checked = vdStates[key] === opt;
+                          // Roving tabindex: the checked chip is the group's
+                          // single tab stop (first chip if nothing matches).
+                          const roving = checked || (!options.includes(vdStates[key]) && i === 0);
                           return (
                             <button
                               key={opt}
                               type="button"
-                              className={`chip ${vdStates[key] === opt ? 'active' : ''}`}
+                              role="radio"
+                              aria-checked={checked}
+                              tabIndex={roving ? 0 : -1}
+                              className={`chip ${checked ? 'active' : ''}`}
                               onClick={() => setVdStates({ ...vdStates, [key]: opt })}
+                              onKeyDown={e => onChipKeyDown(e, key, options)}
                             >
                               {opt === 'Auto'
                                 ? <span className="chip-auto"><FALLBACK_VOICE_ICON size={11} /> {stripVoiceEmoji(t('clone.opt_Auto'))}</span>
@@ -721,6 +748,18 @@ export default function CloneDesignTab(props) {
             className="clone-footer-cta"
           />
         )}
+        {/* 10x P4 a11y (spec §3): persistent polite live region — screen
+            readers hear generation start AND finish in-workspace, without
+            relying on the FloatingPill. sr-only keeps it out of the
+            action-bar flex flow; static text avoids per-second re-announces
+            from the ticking "Synthesizing… (Ns)" button label. */}
+        <div className="sr-only" role="status" aria-live="polite">
+          {isGenerating
+            ? t('clone.generating_status', { defaultValue: 'Generating audio…' })
+            : wasGeneratingRef.current
+              ? t('clone.generating_done_status', { defaultValue: 'Generation finished' })
+              : null}
+        </div>
     </div>
     </div>
   );

--- a/frontend/src/pages/DubTab.css
+++ b/frontend/src/pages/DubTab.css
@@ -977,3 +977,13 @@
   gap: 6px;
   flex-wrap: wrap;
 }
+
+/* ── Reduced motion (10x P4, spec §3): shimmer/pulse die; the stepper
+   spinner holds a static frame. ───────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .dub-skel-bar,
+  .dub-idle-drop.is-dragging,
+  .dub-stepper__spin {
+    animation: none;
+  }
+}

--- a/frontend/src/ui/themes.css
+++ b/frontend/src/ui/themes.css
@@ -104,7 +104,9 @@
 
   --chrome-bg:           #073642;
   --chrome-fg:           #93a1a1;
-  --chrome-fg-muted:     #657b83;
+  /* 10x P4 contrast: was #657b83 (2.92:1 on --chrome-bg) → #899da4 (4.59:1).
+     Same hue (hsl 196°), lightness raised 45%→59% to clear WCAG AA 4.5:1. */
+  --chrome-fg-muted:     #899da4;
   --chrome-fg-dim:       #586e75;
   --chrome-border:       #073642;
 }


### PR DESCRIPTION
## Summary

P4 craft pass of the Voice Console 10x spec (`docs/specs/voice-console-10x.md`, §3 craft rules / §4 acceptance). Frontend only, no behavior changes to click paths.

### §3 a11y gate
- **Muted text ≥ 4.5:1, verified per theme.** Computed WCAG contrast of `--chrome-fg-muted` / `--chrome-fg-dim` against `--chrome-bg` for the default (Gruvbox) theme and all five `themes.css` overrides. Only **solarized** muted failed (`#657b83` → 2.92:1); raised to `#899da4` (4.59:1) keeping the hue (hsl 196°, lightness 45%→59%). Old→new documented in a comment. Default 6.85:1, midnight 5.71, nord 7.45, rose-pine 5.12, catppuccin 5.65 — all already pass.
- **Dim stays decorative**, but readable labels that were riding it switch to muted: `.identity-line__kicker`, `.starting-points__label`, `.wv__active-kicker`, `.clone-slider-kicker`, `.describe-voice-hint`.
- **Radiogroups + roving tabindex.** The design category chip groups (`.chip-group` over `CATEGORIES`) are now `role="radiogroup"` (aria-label = category name) with `role="radio"` + `aria-checked` chips; the checked chip is the single tab stop and **ArrowLeft/ArrowRight** move focus *and* selection (WAI-ARIA radio pattern). The From-audio/By-design `Segmented` was checked first: it is backed by Radix ToggleGroup `type="single"`, which already renders `role="radio"` items inside a RovingFocusGroup — left as is.
- **Visible `:focus-visible` on every interactive.** One shared rule in `index.css` (`outline: 2px solid var(--chrome-accent); outline-offset: 1px;`) covers `.identity-line`, `.clone-insert-btn`, `.personality-chip`, `.chip`, `.wh__chip`, `.dub-lang-pill`, `.wf-player__btn`, `.studio-action-bar__overrides`. Audited: none of these suppressed outlines without replacement (the global ring at `index.css` FOCUS VISIBLE section was already reaching them).
- **`prefers-reduced-motion` kills shimmer/pulse.** New/extended blocks: DubTab (`dub-skel-shimmer`, `dub-pulse`, `dub-stepper-spin`), LogsFooter (`heart-glow`, `logs-spin`), WaveformPlayer (`wf-spin`), FloatingPill (`pill-dot-pulse`, `pill-progress-sweep`). FirstRunSetup's existing block already covers every `frs-alarm` / `frs-hw-pulse` consumer (incl. SetupWizard's `.swiz-lib__led--busy`) — verified, unchanged. Spinners hold a static frame.
- **Generation status `aria-live="polite"`.** FloatingPill already had `role="status" aria-live="polite"` (verified). The studio action bar gains a persistent sr-only polite status region that announces generation **start and finish** in-workspace — static text, so the ticking "Synthesizing… (Ns)" label can't spam re-announces.

### §3 8-pt rhythm (light audit, CloneDesignTab.css only)
Snapped off-grid values: overrides-button gap 5→4 and padding `5px 10px`→`4px 10px`, insert-button padding `3px 9px`→`4px 8px`, sliders grid gap `7px`→`8px`. Chip text alignment untouched.

### Verification
- `npm run build` ✅
- `npm test` — **312/312 passed** ✅
- Rebased onto `origin/main` after #396 (P3) landed mid-work; P3-introduced selectors (`.identity-line__kicker`, `.wv__active-kicker`) picked up the muted token in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Accessibility & Contrast Enhancement

The solarized dark theme `--chrome-fg-muted` color improved for readability:

```
BEFORE: `#657b83` (contrast 2.92:1) → AFTER: `#899da4` (contrast 4.59:1)
├─ Solarized theme: 4.59:1 ✓ WCAG AA
├─ Default (Gruvbox): 6.85:1 ✓ WCAG AAA
├─ Midnight: 5.71:1 ✓ WCAG AA
├─ Nord: 7.45:1 ✓ WCAG AAA
├─ Rose Pine: 5.12:1 ✓ WCAG AA
└─ Catppuccin: 5.65:1 ✓ WCAG AA

Updated components (dim → muted):
  · .identity-line__kicker
  · .starting-points__label
  · .wv__active-kicker
  · .clone-slider-kicker
  · .describe-voice-hint
```

## Radiogroup Keyboard Navigation

Design category chip groups (`.chip-group`) now implement WAI-ARIA radiogroup pattern with roving tabindex:

```
User presses ArrowLeft/ArrowRight on focused chip
         │
         ▼
onChipKeyDown() handler
         │
         ├─ preventDefault() on arrow key
         │
         ├─ Calculate next index: (current + direction + length) % length
         │
         ├─ Update vdStates[categoryKey] to new selection
         │
         └─ Focus shift to new chip element
         
Markup structure:
  <div class="chip-group" role="radiogroup" aria-label="Category">
    <button role="radio" aria-checked="true" tabIndex="0">Option A</button>
    <button role="radio" aria-checked="false" tabIndex="-1">Option B</button>
    <button role="radio" aria-checked="false" tabIndex="-1">Option C</button>
  </div>
```

## Focus Ring Styling

Applied consistent `:focus-visible` outline across 8 interactive control types:

```
BEFORE (inconsistent/missing):          AFTER (unified 10x P4 spec):
  focus-visible state varies               .identity-line:focus-visible,
  by component                            .clone-insert-btn:focus-visible,
                                          .personality-chip:focus-visible,
                                          .chip:focus-visible,
                                          .wh__chip:focus-visible,
                                          .dub-lang-pill:focus-visible,
                                          .wf-player__btn:focus-visible,
                                          .studio-action-bar__overrides:focus-visible {
                                            outline: 2px solid var(--chrome-accent);
                                            outline-offset: 1px;
                                          }
```

## Reduced Motion Compliance

`@media (prefers-reduced-motion: reduce)` rules added to 5 files, disabling animations and holding static frames:

| Component | Animation Disabled |
|-----------|-------------------|
| FloatingPill | `.floating-pill__dot`, `.floating-pill__progress-fill--indeterminate` |
| LogsFooter | `.logs-footer__donate` (heart), `.logs-footer__icon-btn .spinner` |
| WaveformPlayer | `.wf-player__spin` |
| DubTab | `.dub-skel-bar`, `.dub-idle-drop.is-dragging`, `.dub-stepper__spin` |

## Live Region for Screen Readers

`CloneDesignTab.jsx` adds a persistent `sr-only` polite ARIA live region that announces generation start and completion, plus reference to `wasGeneratingRef` to detect the transition from generating → complete.

## Spacing Adjustments (8pt Rhythm)

`CloneDesignTab.css` grid/gap/padding refinements:
- `studio-action-bar__overrides`: gap and padding adjusted
- `clone-insert-btn`: button padding refined
- `clone-sliders-col`: grid gap increased for vertical spacing

## Verification
- `npm run build` ✅
- `npm test` 312/312 passed ✅

<!-- end of auto-generated comment: release notes by coderabbit.ai -->