### PR TITLE
fix(layout): rail-right + hidden sidebar left a phantom 48px gap

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -249,6 +249,12 @@ samp,
 .app-container.rail-right > .history-panel { grid-column: 1; }
 .app-container.rail-right > .main-content { grid-column: 2; }
 .app-container.rail-right.sidebar-hidden > .main-content { grid-column: 1; }
+/* sidebar-hidden collapses the template to 2 columns — the rail must move to
+   column 2, or it overflows into a phantom column and leaves the reserved
+   48px slot as a dead black gap beside it. */
+.app-container.rail-right.sidebar-hidden > .nav-rail { grid-column: 2; }
+/* …and the same off-by-one under sidebar-collapsed's 3-column template. */
+.app-container.rail-right.sidebar-collapsed > .history-panel { grid-column: 1; }
 .app-container > .nav-rail {
   grid-column: 1;
   grid-row: 2;


### PR DESCRIPTION
Flipping the nav rail to the right broke the grid: the sidebar-hidden template has 2 columns but the rail was still assigned `grid-column: 3`, overflowing into a phantom column and leaving the reserved 48px slot as a dead black band. Rail now maps to column 2 in that combo. Verified in WebKit (rail/main/footer edges meet exactly at 1400px and the screenshot is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Layout Grid Fix for Rail-Right + Sidebar-Hidden

This CSS update fixes a layout bug where the navigation rail in right-side mode (`rail-right`) was placed in a non-existent grid column when the sidebar was hidden, creating a 48px phantom gap.

### The Problem

When `rail-right` + `sidebar-hidden` are both applied, the grid template collapses to just 2 columns:
```css
grid-template-columns: minmax(0, 1fr) 48px;
```

However, the nav-rail was still assigned `grid-column: 3`, which doesn't exist in a 2-column layout. This forced the browser to create an implicit third column, leaving a 48px black band visible on the screen.

### The Solution

Two new CSS rules add specific grid-column assignments for these layout combinations:

**Rail-right + Sidebar-hidden:** Map `.nav-rail` to column 2 (line 255)
```css
.app-container.rail-right.sidebar-hidden > .nav-rail { grid-column: 2; }
```

**Rail-right + Sidebar-collapsed:** Ensure `.history-panel` stays in column 1 (line 257)
```css
.app-container.rail-right.sidebar-collapsed > .history-panel { grid-column: 1; }
```

### Layout Diagram

**Before (Bug):**
```
┌────────────────────────────────┬──────┬──────────┐
│      Main Content              │ Rail │ (phantom)│
│      (column 1)                │ col3 │  gap     │
└────────────────────────────────┴──────┴──────────┘
                                        ↑
                                   48px black
                                   deadzone
```

**After (Fixed):**
```
┌──────────────────────────────────────┬──────┐
│      Main Content (column 1)         │ Rail │
│                                      │ col2 │
└──────────────────────────────────────┴──────┘
```

The footer edges now align cleanly with the rail at viewport width 1400px with no overflow or gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->