### PR TITLE
feat(dictation): opt-in NLMS AEC for dictate-over-playback (Wave 8b)

### DIFF
--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -8,6 +8,12 @@ live dictation feedback.
 Protocol:
     → Client sends binary audio frames (16-bit PCM or WebM/Opus blobs)
     ← Server sends JSON messages:
+
+    Opt-in AEC mode (``?aec=1[&sr=16000]``, parity Action 8b): for dictating
+    while the app plays audio. Frames must be raw int16 mono PCM, each tagged
+    with a 1-byte prefix — 0x00 = microphone, 0x01 = playback reference. The
+    server runs an NLMS echo canceller, cleaning the mic against the reference
+    before transcription. Without the param the protocol is unchanged.
         {"type": "partial", "text": "Hello wor..."}      — interim result
         {"type": "final",   "text": "Hello world.",       — committed result
          "segments": [...], "language": "en",
@@ -44,6 +50,56 @@ MIN_BUFFER_BYTES = 64000  # ~2s of 16-bit mono 16kHz — needs enough WebM frame
 # to transcribe whatever the user recorded, even short utterances.
 MIN_FINAL_BUFFER_BYTES = 4000  # ~125ms of 16-bit mono 16kHz
 
+# ── Dictate-over-playback AEC (parity Action 8b, opt-in) ──────────────────
+# Activated by the ``?aec=1`` query param. When OFF (the default), the
+# protocol and behaviour are byte-for-byte unchanged. When ON, the client
+# streams raw int16 mono PCM frames tagged with a 1-byte type prefix so the
+# server can tell mic audio from the playback reference it must cancel:
+_AEC_NEAR = 0x00  # microphone frame (clean it, then buffer for ASR)
+_AEC_FAR = 0x01   # playback reference frame (feed the echo model only)
+
+
+def _demux_aec_frame(data: bytes) -> tuple[str, bytes]:
+    """Split a prefixed AEC binary frame into ``(kind, pcm)``.
+
+    ``kind`` is ``"near"`` (mic) or ``"far"`` (playback reference). An empty
+    or prefix-only frame yields an empty payload. Unknown prefixes are treated
+    as ``"near"`` so a malformed tag degrades to plain dictation rather than
+    dropping audio.
+    """
+    if not data:
+        return "near", b""
+    kind = "far" if data[0] == _AEC_FAR else "near"
+    return kind, data[1:]
+
+
+def _pcm16_to_wav(pcm: bytes, sample_rate: int) -> str | None:
+    """Write raw int16 mono PCM to a temp WAV via stdlib ``wave`` (no ffmpeg).
+
+    Used on the AEC path, where frames are already decoded PCM — the cleaned
+    samples have no container, so the ffmpeg-sniffing ``_chunks_to_wav`` would
+    misdetect them. Returns the temp path, or ``None`` for a too-short buffer.
+    """
+    if not pcm or len(pcm) < 100:
+        return None
+    import wave
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+    tmp.close()
+    try:
+        with wave.open(tmp.name, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)  # int16
+            wf.setframerate(sample_rate)
+            wf.writeframes(pcm)
+        return tmp.name
+    except Exception as e:
+        logger.debug("PCM->WAV failed: %s", e)
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        return None
+
 
 @router.websocket("/ws/transcribe")
 async def ws_transcribe(websocket: WebSocket):
@@ -62,6 +118,23 @@ async def ws_transcribe(websocket: WebSocket):
         return
 
     await websocket.accept()
+
+    # Opt-in dictate-over-playback AEC (parity Action 8b). Default OFF →
+    # identical legacy behaviour. When on, frames are 1-byte-tagged raw PCM
+    # and the cleaned mic stream is muxed via stdlib wave (not ffmpeg).
+    aec = None
+    pcm_sr: int | None = None
+    if websocket.query_params.get("aec") in ("1", "true", "on"):
+        try:
+            pcm_sr = int(websocket.query_params.get("sr", "16000"))
+            from services.aec import NlmsEchoCanceller
+            aec = NlmsEchoCanceller(sample_rate=pcm_sr)
+            logger.info("AEC enabled for dictation session (sr=%d)", pcm_sr)
+        except Exception as e:
+            # Bad sr or import failure → fall back to plain dictation.
+            logger.warning("AEC requested but disabled: %s", e)
+            aec = None
+            pcm_sr = None
 
     audio_chunks: list[bytes] = []
     total_bytes = 0
@@ -100,6 +173,16 @@ async def ws_transcribe(websocket: WebSocket):
                         # Empty binary frame also acts as EOF — connection stays open.
                         running = False
                         break
+                    if aec is not None:
+                        # Tagged PCM: route the playback reference into the echo
+                        # model and clean the mic before it reaches the buffer.
+                        kind, payload = _demux_aec_frame(data)
+                        if kind == "far":
+                            aec.push_far_end(payload)
+                            continue
+                        if not payload:
+                            continue
+                        data = aec.process_near_end(payload)
                     audio_chunks.append(data)
                     total_bytes += len(data)
                     last_audio_time = time.monotonic()
@@ -146,7 +229,7 @@ async def ws_transcribe(websocket: WebSocket):
 
             # Transcribe current buffer
             try:
-                text = await _transcribe_buffer(audio_chunks[:])
+                text = await _transcribe_buffer(audio_chunks[:], pcm_sr=pcm_sr)
                 if text and text != partial_text:
                     partial_text = text
                     await _safe_send({
@@ -176,7 +259,7 @@ async def ws_transcribe(websocket: WebSocket):
     # Final transcription on complete buffer — skip if client already gone.
     if total_bytes > MIN_FINAL_BUFFER_BYTES:
         try:
-            result = await _transcribe_buffer_full(audio_chunks)
+            result = await _transcribe_buffer_full(audio_chunks, pcm_sr=pcm_sr)
             # Wave 2.1: optional local-LLM refinement of the final text.
             # Off-thread (network call, not GPU); pass-through on any
             # failure or when no LLM backend is configured. The raw text
@@ -209,10 +292,10 @@ async def ws_transcribe(websocket: WebSocket):
             pass
 
 
-async def _transcribe_buffer(chunks: list[bytes]) -> str:
+async def _transcribe_buffer(chunks: list[bytes], *, pcm_sr: int | None = None) -> str:
     """Quick partial transcription of the current audio buffer."""
 
-    tmp = _chunks_to_wav(chunks)
+    tmp = _pcm16_to_wav(b"".join(chunks), pcm_sr) if pcm_sr else _chunks_to_wav(chunks)
     if tmp is None:
         return ""
 
@@ -235,9 +318,9 @@ async def _transcribe_buffer(chunks: list[bytes]) -> str:
             pass
 
 
-async def _transcribe_buffer_full(chunks: list[bytes]) -> dict:
+async def _transcribe_buffer_full(chunks: list[bytes], *, pcm_sr: int | None = None) -> dict:
     """Full transcription with timing info for the final result."""
-    tmp = _chunks_to_wav(chunks)
+    tmp = _pcm16_to_wav(b"".join(chunks), pcm_sr) if pcm_sr else _chunks_to_wav(chunks)
     if tmp is None:
         return {"text": "", "segments": [], "language": "unknown",
                 "duration_s": 0, "transcription_time_s": 0, "engine": "none"}

--- a/backend/services/aec.py
+++ b/backend/services/aec.py
@@ -1,0 +1,281 @@
+"""Acoustic echo cancellation for dictate-over-playback (parity Action 8b).
+
+When the user dictates while OmniVoice is *playing* audio (a TTS preview, a
+dub render, a video), the loudspeaker signal leaks back into the microphone.
+The streaming ASR on ``/ws/transcribe`` then transcribes that bleed as if it
+were speech — the "it typed back what the app just said" symptom. A browser's
+``getUserMedia({echoCancellation:true})`` would help, but its quality and even
+its availability differ per platform/webview, which would make a *default*
+feature behave differently on macOS/Windows/Linux — against the project's
+cross-platform-parity rule. A server-side canceller behaves identically
+everywhere, so it is the local-first, platform-neutral choice.
+
+This is an NLMS (normalised least-mean-squares) time-domain adaptive filter
+with a Geigel double-talk detector. It is a clean-room-grade *port* of
+Patter's ``getpatter/audio/aec.py`` (MIT) — see docs/competitive-analysis.md,
+Action 8. It is NOT production-grade DSP (WebRTC AEC3 / Speex AEC are); it is
+a dependency-free, good-enough canceller that removes the steady-state echo
+the ASR would otherwise hallucinate on.
+
+Wiring (one instance per ``/ws/transcribe`` session — NOT thread-safe)::
+
+    aec = NlmsEchoCanceller(sample_rate=16000)
+    # Far-end: every PCM chunk the client is about to play through speakers.
+    aec.push_far_end(playback_pcm_bytes)
+    # Near-end: the mic PCM, cleaned before it reaches the ASR buffer.
+    cleaned = aec.process_near_end(mic_pcm_bytes)
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Final
+
+import numpy as np
+
+logger = logging.getLogger("omnivoice.aec")
+
+
+_DEFAULT_FILTER_TAPS: Final[int] = 512
+"""Adaptive-filter length in samples. 512 taps @ 16 kHz = 32 ms, covering a
+typical near-field laptop/desktop echo path. Longer tails (large rooms) can
+pass ``filter_taps=1024``+ at proportionally more CPU per frame; 512 converges
+in ~0.5 s with the warm-up ramp and is the sweet spot for dictation."""
+
+_DEFAULT_STEP_SIZE: Final[float] = 0.1
+"""Steady-state NLMS step size. Larger = faster channel tracking but less
+stable; 0.1 is the textbook value for narrowband voice."""
+
+_DEFAULT_WARMUP_STEP_SIZE: Final[float] = 0.5
+"""Aggressive step used during the warm-up window so the filter reaches a
+usable echo estimate within ~0.5 s instead of several seconds. The Geigel
+double-talk detector still gates updates, so the bigger step does not learn
+the user's own voice as echo."""
+
+_DEFAULT_WARMUP_SECONDS: Final[float] = 0.5
+"""Length of the warm-up window. After this many seconds of processed
+near-end audio the step decays from ``warmup_step_size`` to ``step_size``."""
+
+_DEFAULT_LEAKAGE: Final[float] = 0.9999
+"""Per-iteration weight leakage (slightly < 1) so the filter slowly forgets
+stale taps when the echo path drifts (the user moves the mic)."""
+
+_DOUBLE_TALK_RHO: Final[float] = 0.6
+"""Geigel double-talk threshold. When ``max(|near|) > rho * max(|far|)`` the
+near-end carries energy the far-end cannot explain (the user is talking) →
+freeze adaptation so the filter does not model the user's voice as echo."""
+
+_FAR_END_BUFFER_SECONDS: Final[float] = 0.5
+"""How much past far-end (playback) audio to retain. The echo arrives at the
+mic tens of ms after playback; the filter needs that much look-back to align.
+500 ms is generous headroom."""
+
+
+class NlmsEchoCanceller:
+    """Time-domain NLMS adaptive filter with Geigel double-talk detection.
+
+    Operates on narrowband mono PCM at 16 kHz (the rate the dictation path
+    resamples to) or 8 kHz. Not thread-safe — each ``/ws/transcribe`` session
+    owns its own instance.
+    """
+
+    # Far-end staleness window (seconds): once the most recent far-end push
+    # is older than this, ``process_near_end`` passes the mic through instead
+    # of cancelling against a frozen reference (which would superimpose the
+    # same stale ~50 ms waveform on every mic frame as an audible buzz).
+    _FAR_STALE_S: float = 0.25
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        *,
+        filter_taps: int = _DEFAULT_FILTER_TAPS,
+        step_size: float = _DEFAULT_STEP_SIZE,
+        warmup_step_size: float = _DEFAULT_WARMUP_STEP_SIZE,
+        warmup_seconds: float = _DEFAULT_WARMUP_SECONDS,
+        leakage: float = _DEFAULT_LEAKAGE,
+        double_talk_rho: float = _DOUBLE_TALK_RHO,
+    ) -> None:
+        if sample_rate not in (8000, 16000):
+            raise ValueError(
+                "NlmsEchoCanceller supports 8000 Hz or 16000 Hz only; "
+                f"got {sample_rate}."
+            )
+        if filter_taps < 64:
+            raise ValueError(
+                f"filter_taps must be >= 64 to model a meaningful echo path; "
+                f"got {filter_taps}."
+            )
+        if not 0 < step_size <= 1:
+            raise ValueError(f"step_size must be in (0, 1]; got {step_size}.")
+        if not 0 < warmup_step_size <= 1:
+            raise ValueError(
+                f"warmup_step_size must be in (0, 1]; got {warmup_step_size}."
+            )
+        if warmup_seconds < 0:
+            raise ValueError(f"warmup_seconds must be >= 0; got {warmup_seconds}.")
+        if not 0 < leakage <= 1:
+            raise ValueError(f"leakage must be in (0, 1]; got {leakage}.")
+
+        self._sample_rate = sample_rate
+        self._taps = filter_taps
+        self._step = float(step_size)
+        self._warmup_step = float(warmup_step_size)
+        self._warmup_samples = int(warmup_seconds * sample_rate)
+        self._leakage = float(leakage)
+        self._rho = float(double_talk_rho)
+        # Counts near-end samples processed so the step can taper from
+        # warmup_step to step over the first warmup_samples. Counted from the
+        # first process_near_end call so the window aligns with playback start.
+        self._processed_samples: int = 0
+        self._last_far_push_monotonic: float | None = None
+
+        # Filter coefficients (zeros — adapts to the channel within ~0.5–2 s).
+        self._w = np.zeros(filter_taps, dtype=np.float32)
+
+        # Far-end ring buffer holding >= filter_taps samples of playback
+        # history, with headroom so push/process can interleave freely.
+        max_buf_samples = max(
+            filter_taps * 2,
+            int(sample_rate * _FAR_END_BUFFER_SECONDS),
+        )
+        self._far_buf = np.zeros(max_buf_samples, dtype=np.float32)
+        self._far_write_idx = 0  # next write position (head)
+        self._far_filled = 0  # samples written so far (capped at len(far_buf))
+
+        # Diagnostics only — never read in the hot path.
+        self.frames_processed: int = 0
+        self.double_talk_frames: int = 0
+
+    # ── Public API ──────────────────────────────────────────────────────────
+
+    def push_far_end(self, pcm_bytes: bytes) -> None:
+        """Append far-end (playback) audio to the reference ring buffer.
+
+        Accepts raw int16 little-endian mono PCM at the configured rate.
+        """
+        if not pcm_bytes:
+            return
+        self._last_far_push_monotonic = time.monotonic()
+        samples = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        n = samples.shape[0]
+        buf_len = self._far_buf.shape[0]
+        if n >= buf_len:
+            # More than the buffer holds — keep only the newest buf_len.
+            self._far_buf[:] = samples[-buf_len:]
+            self._far_write_idx = 0
+            self._far_filled = buf_len
+            return
+        end = self._far_write_idx + n
+        if end <= buf_len:
+            self._far_buf[self._far_write_idx:end] = samples
+        else:
+            head = buf_len - self._far_write_idx
+            self._far_buf[self._far_write_idx:] = samples[:head]
+            self._far_buf[: n - head] = samples[head:]
+        self._far_write_idx = (self._far_write_idx + n) % buf_len
+        self._far_filled = min(self._far_filled + n, buf_len)
+
+    def process_near_end(self, pcm_bytes: bytes) -> bytes:
+        """Subtract the estimated echo from the near-end (mic) signal.
+
+        Returns int16 little-endian mono PCM with the estimated echo removed.
+        Passes the frame through unchanged when there is nothing worth
+        cancelling: no playback has been primed, or the far-end reference is
+        stale (the app went silent).
+        """
+        if not pcm_bytes:
+            return pcm_bytes
+
+        # Not enough far-end history to fill the filter window yet — passing
+        # through avoids emitting garbage on the first frames.
+        if self._far_filled < self._taps:
+            return pcm_bytes
+
+        # Far-end reference is stale (app stopped playing): the ring only
+        # advances on push_far_end, so the "most recent" window is frozen at
+        # the tail of the last playback. Convolving against it would buzz.
+        last_push = self._last_far_push_monotonic
+        if last_push is None or (time.monotonic() - last_push) > self._FAR_STALE_S:
+            return pcm_bytes
+
+        near = np.frombuffer(pcm_bytes, dtype=np.int16).astype(np.float32) / 32768.0
+        cleaned = self._block_nlms(near)
+        out = np.clip(cleaned * 32768.0, -32768.0, 32767.0).astype(np.int16)
+        self.frames_processed += 1
+        return out.tobytes()
+
+    def reset(self) -> None:
+        """Clear filter coefficients and far-end history (e.g. on a new turn)."""
+        self._w.fill(0)
+        self._far_buf.fill(0)
+        self._far_write_idx = 0
+        self._far_filled = 0
+        self._processed_samples = 0
+        self._last_far_push_monotonic = None
+        self.frames_processed = 0
+        self.double_talk_frames = 0
+
+    # ── Internals ───────────────────────────────────────────────────────────
+
+    def _far_window(self, length: int) -> np.ndarray:
+        """Most recent ``length`` far-end samples, oldest first / newest last."""
+        buf_len = self._far_buf.shape[0]
+        if length > self._far_filled:
+            length = self._far_filled
+        end = self._far_write_idx  # newest sample is at (end - 1) mod buf_len
+        if end >= length:
+            return self._far_buf[end - length: end]
+        head = self._far_buf[buf_len - (length - end):]
+        tail = self._far_buf[:end]
+        return np.concatenate((head, tail))
+
+    def _block_nlms(self, near: np.ndarray) -> np.ndarray:
+        """Sample-by-sample NLMS over one frame of near-end samples.
+
+        Classical NLMS depends on the weights adapted at the previous sample,
+        so the inner loop is sequential. Each sample is O(taps); numpy keeps a
+        320-sample / 512-tap frame well under a millisecond on commodity CPUs.
+        """
+        taps = self._taps
+        far_window = self._far_window(taps + near.shape[0] - 1)
+        if far_window.shape[0] < taps + near.shape[0] - 1:
+            # Still warming up — left-pad with zeros so indices line up.
+            pad = np.zeros(
+                taps + near.shape[0] - 1 - far_window.shape[0], dtype=np.float32
+            )
+            far_window = np.concatenate((pad, far_window))
+
+        # Geigel double-talk detector (frame-wise).
+        far_max = float(np.max(np.abs(far_window))) if far_window.size else 0.0
+        near_max = float(np.max(np.abs(near)))
+        # Freeze adaptation when the far reference is effectively silent
+        # (<= -60 dBFS): adapting against a fade-out tail with near-zero norm
+        # blows the weights up against user speech when playback resumes.
+        if far_max <= 1e-3:
+            return near
+        double_talk = near_max > self._rho * far_max
+        if double_talk:
+            self.double_talk_frames += 1
+
+        out = np.empty_like(near)
+        w = self._w
+        leakage = self._leakage
+        # Constant step within the frame keeps the inner loop branch-free.
+        if self._processed_samples < self._warmup_samples:
+            step = self._warmup_step
+        else:
+            step = self._step
+        for i in range(near.shape[0]):
+            x = far_window[i: i + taps]
+            y_est = float(np.dot(w, x))
+            e = float(near[i] - y_est)
+            out[i] = e
+            if not double_talk:
+                # NLMS update with leakage. +1e-6 guards divide-by-zero.
+                norm = float(np.dot(x, x)) + 1e-6
+                w *= leakage
+                w += (step * e / norm) * x
+        self._processed_samples += near.shape[0]
+        return out

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -95,7 +95,7 @@ the self-inventory missed `scripts/validate-install-docs.py`, the probe-judge +
 | Global-hotkey dictation pill | B+ (#323 fixed) | ✅ (v0.5.0, auto-paste **macOS-only**) | ❌ | ❌ | We're ahead on cross-platform (their gap violates our parity rule) |
 | **LLM transcript refinement (filler-word removal)** | ❌ | ✅ local Qwen3 0.6B–4B | ❌ | ❌ | **Gap.** Action 3 |
 | **Captures library (replay / re-transcribe / refine)** | 🟡 (transcription history page) | ✅ richer (v0.5.0) | ❌ | ❌ | Partial gap — we store, they iterate |
-| Dictation while audio plays (echo cancel) | ❌ | ❌ | ❌ | ✅ NLMS AEC | Patter's AEC is portable. Action 8 |
+| Dictation while audio plays (echo cancel) | 🟡 (opt-in server-side NLMS AEC on `/ws/transcribe?aec=1`, backend shipped — Action 8b; frontend far-end wiring pending) | ❌ | ❌ | ✅ NLMS AEC | Ported Patter's NLMS canceller. Action 8 |
 | **Engines & platform** |
 | TTS engine count | B (6) | ✅ 7 | ✅ **33 channels** (22 ASR, 25 translate) | ✅ 7 (cloud) | pyvideotrans = breadth king (incl. cloud); we + voicebox are local-only by design |
 | Engine plugin protocol | B+ (ABC + registry) | ✅ Protocol + ModelConfig registry, **agent skill for adding engines** | ✅ lazy dataclass plugins | ✅ provider SDK | Everyone converged on the same pattern; their `requires_cuda`-gap lesson is free for us |

--- a/tests/backend/api/routers/test_capture_ws_aec.py
+++ b/tests/backend/api/routers/test_capture_ws_aec.py
@@ -1,0 +1,65 @@
+"""Capture-WS AEC framing helpers (parity Action 8b).
+
+Unit-tests the pure helpers the ``/ws/transcribe`` AEC path relies on — frame
+demux and PCM→WAV muxing — without standing up the WebSocket or the ASR stack
+(which pulls torch and segfaults on some dev boxes). The wire integration is
+covered indirectly: these are the only AEC-specific branches in the handler.
+"""
+from __future__ import annotations
+
+import os
+import wave
+
+from api.routers.capture_ws import (
+    _AEC_FAR,
+    _AEC_NEAR,
+    _demux_aec_frame,
+    _pcm16_to_wav,
+)
+
+
+def test_demux_near_frame():
+    kind, payload = _demux_aec_frame(bytes([_AEC_NEAR]) + b"abcd")
+    assert kind == "near"
+    assert payload == b"abcd"
+
+
+def test_demux_far_frame():
+    kind, payload = _demux_aec_frame(bytes([_AEC_FAR]) + b"xyz")
+    assert kind == "far"
+    assert payload == b"xyz"
+
+
+def test_demux_empty_frame():
+    assert _demux_aec_frame(b"") == ("near", b"")
+
+
+def test_demux_prefix_only_frame():
+    # A bare far-tag with no payload is valid (kind set, payload empty).
+    assert _demux_aec_frame(bytes([_AEC_FAR])) == ("far", b"")
+
+
+def test_demux_unknown_prefix_degrades_to_near():
+    # Any non-0x01 tag is treated as mic audio so a bad tag never drops audio.
+    kind, payload = _demux_aec_frame(b"\x07hello")
+    assert kind == "near"
+    assert payload == b"hello"
+
+
+def test_pcm16_to_wav_roundtrip():
+    pcm = (b"\x01\x02" * 2000)  # 2000 int16 samples
+    path = _pcm16_to_wav(pcm, 16000)
+    assert path is not None
+    try:
+        with wave.open(path, "rb") as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getframerate() == 16000
+            assert wf.readframes(wf.getnframes()) == pcm
+    finally:
+        os.unlink(path)
+
+
+def test_pcm16_to_wav_rejects_tiny_buffer():
+    assert _pcm16_to_wav(b"\x00\x01", 16000) is None
+    assert _pcm16_to_wav(b"", 16000) is None

--- a/tests/backend/services/test_aec.py
+++ b/tests/backend/services/test_aec.py
@@ -1,0 +1,159 @@
+"""NLMS echo canceller (parity Action 8b).
+
+Validates the ported ``NlmsEchoCanceller`` against synthetic far-end +
+echo-contaminated near-end signals: the steady-state echo must attenuate, the
+user's own speech (double-talk) must survive, and cold/stale references must
+pass through untouched. Pure-numpy — no torch, no ASR stack.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from services.aec import NlmsEchoCanceller
+
+SR = 16000
+FRAME = 320  # 20 ms @ 16 kHz
+
+
+def _pcm(x: np.ndarray) -> bytes:
+    """float32 [-1, 1] → int16 LE PCM bytes."""
+    return np.clip(x * 32768.0, -32768.0, 32767.0).astype(np.int16).tobytes()
+
+
+def _f32(pcm: bytes) -> np.ndarray:
+    return np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+
+
+def _rms(x: np.ndarray) -> float:
+    return float(np.sqrt(np.mean(x ** 2))) if x.size else 0.0
+
+
+def _tone(freq: float, n: int, *, amp: float = 0.5, phase: float = 0.0) -> np.ndarray:
+    t = np.arange(n, dtype=np.float32) / SR
+    return amp * np.sin(2 * np.pi * freq * t + phase).astype(np.float32)
+
+
+# ── Construction / validation ────────────────────────────────────────────────
+
+def test_rejects_unsupported_sample_rate():
+    with pytest.raises(ValueError):
+        NlmsEchoCanceller(sample_rate=44100)
+
+
+@pytest.mark.parametrize("kw", [
+    {"filter_taps": 32},
+    {"step_size": 0},
+    {"step_size": 1.5},
+    {"warmup_step_size": 0},
+    {"leakage": 0},
+    {"leakage": 2},
+    {"warmup_seconds": -1},
+])
+def test_rejects_bad_params(kw):
+    with pytest.raises(ValueError):
+        NlmsEchoCanceller(sample_rate=SR, **kw)
+
+
+# ── Pass-through guards ──────────────────────────────────────────────────────
+
+def test_passthrough_before_any_far_end():
+    """No playback primed → mic returns byte-identical."""
+    aec = NlmsEchoCanceller(sample_rate=SR)
+    mic = _pcm(_tone(300, FRAME))
+    assert aec.process_near_end(mic) == mic
+
+
+def test_passthrough_when_far_end_stale(monkeypatch):
+    """Far reference older than the staleness window → no cancellation."""
+    aec = NlmsEchoCanceller(sample_rate=SR)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr("services.aec.time.monotonic", lambda: clock["t"])
+    # Prime far-end so the ring is full, then let the clock jump forward.
+    for _ in range(4):
+        aec.push_far_end(_pcm(_tone(440, FRAME)))
+    clock["t"] += 1.0  # > _FAR_STALE_S (0.25 s)
+    mic = _pcm(_tone(300, FRAME))
+    assert aec.process_near_end(mic) == mic
+
+
+def test_empty_frames_are_noops():
+    aec = NlmsEchoCanceller(sample_rate=SR)
+    aec.push_far_end(b"")
+    assert aec.process_near_end(b"") == b""
+
+
+# ── Core behaviour ───────────────────────────────────────────────────────────
+
+def test_attenuates_steady_state_echo(monkeypatch):
+    """With the mic carrying a scaled, delayed copy of the playback signal and
+    no local speech, the residual after convergence is far quieter than the
+    echo it removed."""
+    aec = NlmsEchoCanceller(sample_rate=SR)
+    clock = {"t": 0.0}
+    monkeypatch.setattr("services.aec.time.monotonic", lambda: clock["t"])
+
+    echo_gain = 0.6
+    delay = 80  # samples (5 ms) — within the 512-tap window
+    prev_tail = np.zeros(delay, dtype=np.float32)
+
+    residual_rms = []
+    for k in range(200):
+        clock["t"] += FRAME / SR
+        far = _tone(500, FRAME, amp=0.5, phase=k)  # vary phase so it's not periodic-identical
+        # Echo = delayed, attenuated far-end (mic hears only the echo here).
+        src = np.concatenate((prev_tail, far))
+        echo = echo_gain * src[:FRAME]
+        prev_tail = far[-delay:]
+
+        aec.push_far_end(_pcm(far))
+        out = _f32(aec.process_near_end(_pcm(echo)))
+        residual_rms.append(_rms(out))
+
+    early = np.mean(residual_rms[5:15])   # just after warm-up starts
+    late = np.mean(residual_rms[-20:])    # converged
+    assert late < early                    # it is learning the echo path
+    assert late < 0.10 * echo_gain * 0.5   # residual well below the echo level
+
+
+def test_double_talk_preserves_user_speech(monkeypatch):
+    """When the user speaks over playback, the Geigel detector freezes
+    adaptation so the user's voice is not modelled as echo and survives."""
+    aec = NlmsEchoCanceller(sample_rate=SR)
+    clock = {"t": 0.0}
+    monkeypatch.setattr("services.aec.time.monotonic", lambda: clock["t"])
+
+    # Converge the filter on echo-only frames first.
+    echo_gain = 0.5
+    for k in range(60):
+        clock["t"] += FRAME / SR
+        far = _tone(500, FRAME, amp=0.5, phase=k)
+        aec.push_far_end(_pcm(far))
+        aec.process_near_end(_pcm(echo_gain * far))
+
+    # Now the user talks (distinct frequency, loud) over the same playback.
+    user = _tone(180, FRAME, amp=0.6)
+    clock["t"] += FRAME / SR
+    far = _tone(500, FRAME, amp=0.5, phase=999)
+    aec.push_far_end(_pcm(far))
+    out = _f32(aec.process_near_end(_pcm(echo_gain * far + user)))
+
+    assert aec.double_talk_frames >= 1       # detector fired
+    assert _rms(out) > 0.5 * _rms(user)      # user energy is largely retained
+
+
+def test_reset_clears_state(monkeypatch):
+    aec = NlmsEchoCanceller(sample_rate=SR)
+    clock = {"t": 0.0}
+    monkeypatch.setattr("services.aec.time.monotonic", lambda: clock["t"])
+    for k in range(10):
+        clock["t"] += FRAME / SR
+        aec.push_far_end(_pcm(_tone(440, FRAME, phase=k)))
+        aec.process_near_end(_pcm(_tone(300, FRAME)))
+    aec.reset()
+    assert aec.frames_processed == 0
+    assert aec._far_filled == 0
+    assert not np.any(aec._w)
+    # After reset, a cold mic frame passes straight through again.
+    mic = _pcm(_tone(300, FRAME))
+    assert aec.process_near_end(mic) == mic

--- a/tests/test_capture_ws.py
+++ b/tests/test_capture_ws.py
@@ -28,10 +28,10 @@ def client(monkeypatch):
     # Stub the heavy transcription helpers so the test stays in-process.
     from api.routers import capture_ws as cw
 
-    async def fake_partial(_chunks):
+    async def fake_partial(_chunks, **_kw):
         return "hello"
 
-    async def fake_full(_chunks):
+    async def fake_full(_chunks, **_kw):
         return {
             "text": "hello world",
             "segments": [{"start": 0.0, "end": 1.0, "text": "hello world"}],


### PR DESCRIPTION
## What

Adds **server-side acoustic echo cancellation** so dictation works while OmniVoice is playing audio (TTS preview, dub render, video). Today the loudspeaker signal leaks into the mic and the streaming ASR on `/ws/transcribe` transcribes that bleed — the "it typed back what the app just said" symptom.

This is parity **Action 8b** (the AEC half of the streaming-polish kit; the sentence chunker shipped in #357/#358).

## Why server-side

A browser's `getUserMedia({echoCancellation:true})` exists, but its quality and availability differ per platform/webview — a *default* feature can't behave differently across macOS/Windows/Linux (CLAUDE.md cross-platform-parity rule). A server-side canceller behaves identically everywhere and keeps us local-first.

## How

- **`backend/services/aec.py`** — ports Patter's `NlmsEchoCanceller` (MIT, see `docs/competitive-analysis.md` Action 8): time-domain NLMS adaptive filter + Geigel double-talk detector, warm-up step ramp, far-end staleness pass-through. Pure numpy (already pinned — **no new deps**).
- **`/ws/transcribe`** — opt-in `?aec=1[&sr=16000]`. Frames become raw int16 mono PCM tagged with a 1-byte prefix (`0x00` mic, `0x01` playback reference). The mic is cleaned against the reference before buffering; cleaned PCM is muxed via stdlib `wave` (not ffmpeg). **Without the param the protocol and behaviour are byte-for-byte unchanged.**

## Scope

Backend ships **dark** (opt-in, no client yet) — same backend-first pattern as the crash-isolated ASR wave (#393). **Frontend far-end streaming is a follow-up PR.**

## Tests

`tests/backend/services/test_aec.py` + `tests/backend/api/routers/test_capture_ws_aec.py` — echo attenuation, double-talk preservation, cold/stale pass-through, param validation, framing helpers. All pure numpy/stdlib (skip the torch ASR stack). 21 passing locally.

## Docs

`docs/competitive-analysis.md` matrix row updated (❌ → 🟡 opt-in, Action 8b backend shipped) per the docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Acoustic Echo Cancellation for Dictation-over-Playback

### What
Implements an opt-in server-side NLMS (Normalized Least Mean Squares) acoustic echo canceller so dictation can work while OmniVoice plays audio (TTS preview, dub render, video). Prevents loudspeaker output leaking into the microphone and being transcribed by the streaming ASR on /ws/transcribe.

### Why
Browser getUserMedia({echoCancellation:true}) quality and availability vary across platforms/webviews. A server-side canceller yields consistent cross-platform behavior, follows the local-first approach, and satisfies CLAUDE.md parity rules.

### How

#### New AEC Processing Pipeline
```mermaid
graph LR
    WS["WebSocket /ws/transcribe<br/>?aec=1&sr=16000"] --> DEMUX["Demux Frame<br/>1-byte prefix tag (0x00 mic, 0x01 playback)"]
    DEMUX -->|0x00 near-end| NE["Near-end<br/>Microphone PCM"]
    DEMUX -->|0x01 far-end| FE["Far-end<br/>Playback Reference PCM"]
    FE --> AEC["NlmsEchoCanceller<br/>push_far_end"]
    AEC --> BUFFER["Ring Buffer<br/>Far-end History"]
    NE --> CANCEL["process_near_end<br/>Adaptive Filter"]
    BUFFER --> CANCEL
    CANCEL --> CLEAN["Cleaned PCM<br/>Echo Attenuated"]
    CLEAN --> WAV["Convert to WAV<br/>stdlib wave"]
    WAV --> ASR["ASR Transcription<br/>Streaming"]
```

#### Key Implementation Details
- backend/services/aec.py — New NlmsEchoCanceller class (pure NumPy, ~281 lines):
  - Time-domain NLMS adaptive filter with configurable taps, step size, and leakage
  - Geigel double-talk detector (freezes adaptation when user speaks)
  - Warm-up ramp (aggressive step for initial convergence)
  - Far-end ring buffer and far-end staleness guard (bypass when playback is stale)
  - Public API: push_far_end(pcm_bytes), process_near_end(pcm_bytes), reset()
  - Diagnostic counters: frames_processed, double_talk_frames
  - Supports 8000 or 16000 Hz only; validates params

- backend/api/routers/capture_ws.py — WebSocket handler updates (net +89/-6):
  - Opt-in via query param ?aec=1 (also accepts true/on); optional sr param (defaults 16000)
  - Expects raw int16 mono PCM frames prefixed with a 1-byte tag: 0x00 = mic (near), 0x01 = playback (far)
  - _demux_aec_frame(data) -> (kind, payload) added; unknown prefixes degrade to "near"
  - _pcm16_to_wav(pcm, sample_rate) added — writes cleaned PCM to a temp WAV via stdlib wave (used instead of ffmpeg on AEC path)
  - _transcribe_buffer(...) and _transcribe_buffer_full(...) now accept optional pcm_sr to choose WAV path for AEC-cleaned PCM; handler behavior otherwise unchanged when ?aec absent
  - Mic frames are cleaned by aec.process_near_end before buffering; playback frames are fed to aec.push_far_end

- Frame format: raw int16 LE mono PCM, 1-byte prefix per frame (0x00 mic, 0x01 playback)

- Scope: Backend-only, opt-in (dark) feature; frontend far-end streaming wiring to follow

### Tests
- tests/backend/services/test_aec.py (NumPy-only, 159 lines): validates construction/param rejection, passthrough before far-end priming and when far-end is stale, attenuation of steady-state echo, double-talk preservation, reset behavior. Uses synthetic tones to assert RMS reductions and detector firing.
- tests/backend/api/routers/test_capture_ws_aec.py (65 lines): unit-tests _demux_aec_frame and _pcm16_to_wav with edge cases (empty frames, prefix-only, unknown prefix, tiny buffers) and WAV roundtrip.
- tests/test_capture_ws.py: updated fixture stubs to accept extra pcm_sr kwarg introduced for the AEC PCM path (prevents TypeError in tests).
- Local run: 21 tests pass locally.

### Docs
- docs/competitive-analysis.md: updated matrix to mark "Dictation while audio plays (echo cancel)" as backend opt-in NLMS AEC shipped (Action 8b), frontend wiring pending.

### Commits / Notes
- Commit adjusted test capture_ws stubs to accept the new optional pcm_sr kwarg so existing WS tests continue to exercise the EOF/final message flow.
- Feature is opt-in and backward-compatible: when ?aec is not provided the protocol and behaviour are byte-for-byte unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->