### PR TITLE
feat(dictation): wire AEC end-to-end in the frontend (Wave 8, opt-in)

### DIFF
--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -95,7 +95,7 @@ the self-inventory missed `scripts/validate-install-docs.py`, the probe-judge +
 | Global-hotkey dictation pill | B+ (#323 fixed) | ✅ (v0.5.0, auto-paste **macOS-only**) | ❌ | ❌ | We're ahead on cross-platform (their gap violates our parity rule) |
 | **LLM transcript refinement (filler-word removal)** | ❌ | ✅ local Qwen3 0.6B–4B | ❌ | ❌ | **Gap.** Action 3 |
 | **Captures library (replay / re-transcribe / refine)** | 🟡 (transcription history page) | ✅ richer (v0.5.0) | ❌ | ❌ | Partial gap — we store, they iterate |
-| Dictation while audio plays (echo cancel) | 🟡 (opt-in server-side NLMS AEC on `/ws/transcribe?aec=1`, backend shipped — Action 8b; frontend far-end wiring pending) | ❌ | ❌ | ✅ NLMS AEC | Ported Patter's NLMS canceller. Action 8 |
+| Dictation while audio plays (echo cancel) | ✅ opt-in (Settings → Capture): server-side NLMS AEC on `/ws/transcribe?aec=1` + AudioWorklet PCM mic + player far-end tap — Action 8 | ❌ | ❌ | ✅ NLMS AEC | Ported Patter's NLMS canceller. Action 8 |
 | **Engines & platform** |
 | TTS engine count | B (6) | ✅ 7 | ✅ **33 channels** (22 ASR, 25 translate) | ✅ 7 (cloud) | pyvideotrans = breadth king (incl. cloud); we + voicebox are local-only by design |
 | Engine plugin protocol | B+ (ABC + registry) | ✅ Protocol + ModelConfig registry, **agent skill for adding engines** | ✅ lazy dataclass plugins | ✅ provider SDK | Everyone converged on the same pattern; their `requires_cuda`-gap lesson is free for us |

--- a/frontend/public/aec-worklet.js
+++ b/frontend/public/aec-worklet.js
@@ -1,0 +1,37 @@
+// AudioWorklet processor for the opt-in dictate-over-playback AEC (parity
+// Action 8). Accumulates mono Float32 input into fixed-size frames and posts
+// them to the main thread, which converts them to tagged int16 PCM. The same
+// processor serves both the microphone capture and the playback-reference tap
+// — only the wiring on the main thread differs.
+//
+// Served as a static asset from /public so the AudioContext can load it via
+// audioWorklet.addModule('/aec-worklet.js') in both dev and the bundled app.
+
+class AecFrameEmitter extends AudioWorkletProcessor {
+  constructor(options) {
+    super();
+    const frame = (options && options.processorOptions && options.processorOptions.frameSize) || 320;
+    this._frameSize = frame;     // 320 samples = 20 ms @ 16 kHz
+    this._buf = new Float32Array(frame);
+    this._n = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    // input[0] is the first (mono) channel; absent when upstream is idle.
+    if (input && input[0]) {
+      const ch = input[0];
+      for (let i = 0; i < ch.length; i++) {
+        this._buf[this._n++] = ch[i];
+        if (this._n >= this._frameSize) {
+          // Copy out — the buffer is reused for the next frame.
+          this.port.postMessage(this._buf.slice(0, this._frameSize));
+          this._n = 0;
+        }
+      }
+    }
+    return true; // keep the processor alive
+  }
+}
+
+registerProcessor('aec-frame-emitter', AecFrameEmitter);

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -57,6 +57,21 @@ export default function CaptureWidget({ onDismiss }) {
   const wsHadFinalRef = useRef(false);
   const fallbackTimerRef = useRef(null);
   const startTimeRef = useRef(0);
+  // Opt-in dictate-over-playback AEC (parity Action 8). When on, we capture
+  // raw PCM via an AudioWorklet and tag mic/far-end frames instead of using
+  // MediaRecorder. All AEC state lives in refs so the default path is inert.
+  const aecModeRef = useRef(false);
+  const aecStopRef = useRef(null);     // async teardown of the mic worklet graph
+  const farEndUnsubRef = useRef(null); // unsubscribe from the far-end bus
+
+  const teardownAec = useCallback(async () => {
+    try { farEndUnsubRef.current?.(); } catch { /* ignore */ }
+    farEndUnsubRef.current = null;
+    const stop = aecStopRef.current;
+    aecStopRef.current = null;
+    try { await stop?.(); } catch { /* ignore */ }
+    aecModeRef.current = false;
+  }, []);
 
   // ── Hold-to-talk: listen for tray-dictate (start) and tray-dictate-stop (release) ──
   useEffect(() => {
@@ -180,11 +195,18 @@ export default function CaptureWidget({ onDismiss }) {
         ? 'audio/webm;codecs=opus'
         : 'audio/webm';
 
+      // Read the opt-in AEC pref at start time (avoids a stale closure).
+      const aecOn = useAppStore.getState().aecEnabled === true;
+      aecModeRef.current = aecOn;
+
       // Open WebSocket BEFORE starting recorder
       try {
         // Scheme + host + remote api key all derive from the API base
         // (Wave 2.3) — window.location lies inside the Tauri webview.
-        const ws = new WebSocket(buildWsUrl('/ws/transcribe'));
+        // AEC mode adds ?aec=1 so the server runs the NLMS canceller and
+        // expects tagged raw-PCM frames.
+        const wsPath = aecOn ? '/ws/transcribe?aec=1&sr=16000' : '/ws/transcribe';
+        const ws = new WebSocket(buildWsUrl(wsPath));
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
           for (const buf of wsPendingRef.current) {
@@ -236,23 +258,50 @@ export default function CaptureWidget({ onDismiss }) {
         wsRef.current = null;
       }
 
-      const recorder = new MediaRecorder(stream, { mimeType });
-      recorder.ondataavailable = (e) => {
-        if (e.data.size > 0) {
-          chunksRef.current.push(e.data);
-          e.data.arrayBuffer().then(buf => {
-            const ws = wsRef.current;
-            if (ws && ws.readyState === WebSocket.OPEN) {
-              ws.send(buf);
-            } else {
-              wsPendingRef.current.push(buf);
-            }
-          });
-        }
-      };
-      recorder.onstop = () => {};
-      recorder.start(250);
-      mediaRecorderRef.current = recorder;
+      if (aecOn) {
+        // AEC path: stream raw PCM. The mic is tagged 0x00; whatever the app
+        // is playing (published to the far-end bus by the audio player) is
+        // tagged 0x01 so the server can cancel the echo. No MediaRecorder and
+        // no WebM POST fallback here — the WS is the only path in this mode.
+        const [{ startMicCapture }, { subscribeFarEnd }, { frameFromFloat, AEC_NEAR, AEC_FAR }] =
+          await Promise.all([
+            import('../utils/aec/micCapture'),
+            import('../utils/aec/farEndBus'),
+            import('../utils/aec/pcm'),
+          ]);
+        const sendTagged = (float32, kind) => {
+          const buf = frameFromFloat(float32, kind);
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            try { ws.send(buf); } catch { /* ignore */ }
+          } else {
+            wsPendingRef.current.push(buf);
+          }
+        };
+        aecStopRef.current = await startMicCapture(
+          stream, (f) => sendTagged(f, AEC_NEAR), { sampleRate: 16000 },
+        );
+        farEndUnsubRef.current = subscribeFarEnd((f) => sendTagged(f, AEC_FAR));
+        mediaRecorderRef.current = null;
+      } else {
+        const recorder = new MediaRecorder(stream, { mimeType });
+        recorder.ondataavailable = (e) => {
+          if (e.data.size > 0) {
+            chunksRef.current.push(e.data);
+            e.data.arrayBuffer().then(buf => {
+              const ws = wsRef.current;
+              if (ws && ws.readyState === WebSocket.OPEN) {
+                ws.send(buf);
+              } else {
+                wsPendingRef.current.push(buf);
+              }
+            });
+          }
+        };
+        recorder.onstop = () => {};
+        recorder.start(250);
+        mediaRecorderRef.current = recorder;
+      }
       startTimeRef.current = Date.now();
       setTrayRecording(true);
       setState('recording');
@@ -271,6 +320,11 @@ export default function CaptureWidget({ onDismiss }) {
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
       mediaRecorderRef.current.stop();
+    }
+    // AEC mode: stop the mic worklet + far-end subscription before EOF so no
+    // stray frames arrive after the end-of-stream signal.
+    if (aecModeRef.current) {
+      teardownAec();
     }
     if (streamRef.current) {
       streamRef.current.getTracks().forEach(t => t.stop());
@@ -300,10 +354,12 @@ export default function CaptureWidget({ onDismiss }) {
     }
     setTrayRecording(false);
     setState('transcribing');
-  }, []);
+  }, [teardownAec]);
 
   const sendForTranscription = useCallback(async () => {
     if (wsHadFinalRef.current) return;
+    // No WebM blob exists on the AEC path — the WS is the only result channel.
+    if (aecModeRef.current) return;
 
     const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
     const formData = new FormData();
@@ -329,6 +385,7 @@ export default function CaptureWidget({ onDismiss }) {
   }, [captureMode, applyResult]);
 
   const dismiss = async () => {
+    if (aecModeRef.current) teardownAec();
     setState('idle');
     setTranscript('');
     setDuration(0);

--- a/frontend/src/components/WaveformPlayer.jsx
+++ b/frontend/src/components/WaveformPlayer.jsx
@@ -19,6 +19,7 @@ import WaveSurfer from 'wavesurfer.js';
 import { Play, Pause, Loader } from 'lucide-react';
 import { claimPlayback } from '../utils/playback';
 import { isTauri, fileToMediaUrl } from '../utils/media';
+import { useAppStore } from '../store';
 import './WaveformPlayer.css';
 
 const fmt = (s) => {
@@ -52,6 +53,35 @@ export default function WaveformPlayer({
   const [isPlaying, setIsPlaying] = useState(false);
   const [duration, setDuration] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
+
+  // Opt-in dictate-over-playback AEC (parity Action 8): while this player is
+  // actually playing AND the pref is on, tap its decoded output as the echo
+  // reference for dictation (published to the far-end bus). Gated on isPlaying
+  // so an AudioContext exists only for the one active player (the global
+  // playback manager stops the others), staying well under the browser's
+  // per-page context cap. When the pref is off the default playback path never
+  // constructs an AudioContext.
+  const aecEnabled = useAppStore((s) => s.aecEnabled);
+  const tapDetachRef = useRef(null);
+  useEffect(() => {
+    let cancelled = false;
+    const el = mediaRef.current || nativeRef.current;
+    if (aecEnabled && isPlaying && el) {
+      import('../utils/aec/playbackTap')
+        .then(({ attachPlaybackTap }) => attachPlaybackTap(el))
+        .then((detach) => {
+          if (cancelled) { try { detach?.(); } catch { /* ignore */ } }
+          else { tapDetachRef.current = detach; }
+        })
+        .catch(() => { /* Web Audio unavailable — dictation still works sans AEC */ });
+    }
+    return () => {
+      cancelled = true;
+      const d = tapDetachRef.current;
+      tapDetachRef.current = null;
+      try { d?.(); } catch { /* ignore */ }
+    };
+  }, [aecEnabled, isPlaying]);
 
   // Resolve Blob/File → playable URL. Strings pass through. In Tauri, blob:
   // URLs don't play in WebKit media elements, so blobs are routed through the

--- a/frontend/src/components/settings/AecPanel.jsx
+++ b/frontend/src/components/settings/AecPanel.jsx
@@ -1,0 +1,47 @@
+/**
+ * Settings → Capture → Echo cancellation panel (parity program Action 8).
+ *
+ * Opt-in toggle for dictate-over-playback AEC. When on, dictation streams raw
+ * PCM through the backend's server-side NLMS canceller (`/ws/transcribe?aec=1`)
+ * and the audio player taps its output as the echo reference, so dictating
+ * while OmniVoice plays audio doesn't transcribe the playback. Off by default —
+ * dictation uses the standard MediaRecorder path and behaves identically on
+ * every platform. The pref is the zustand `aecEnabled` flag (persisted); no
+ * backend round-trip needed.
+ */
+import React from 'react';
+import { Volume2 } from 'lucide-react';
+import { useAppStore } from '../../store';
+import './PerformancePanel.css';
+
+export default function AecPanel() {
+  const aecEnabled = useAppStore((s) => s.aecEnabled);
+  const setAecEnabled = useAppStore((s) => s.setAecEnabled);
+
+  return (
+    <section className="perfpanel" aria-labelledby="aecpanel-heading">
+      <h3 id="aecpanel-heading" className="perfpanel__title">
+        <Volume2 size={14} /> Dictate while audio plays
+      </h3>
+
+      <p className="perfpanel__help">
+        Cancels OmniVoice's own playback out of the microphone so you can
+        dictate while a preview, dub, or video is playing — without the
+        transcript picking up what the app is saying. Adds a small amount of
+        audio processing; leave it off if you never dictate over playback.
+      </p>
+
+      <label className="perfpanel__row" title="Server-side NLMS echo cancellation">
+        <input
+          type="checkbox"
+          className="perfpanel__checkbox"
+          checked={aecEnabled}
+          onChange={(e) => setAecEnabled(e.target.checked)}
+          data-testid="aec-enabled"
+        />
+        <span className="perfpanel__label">Enable echo cancellation for dictation</span>
+        <span className="perfpanel__badge">experimental</span>
+      </label>
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -34,6 +34,7 @@ import ApiKeysPanel from '../components/settings/ApiKeysPanel';
 import LLMEndpointPanel from '../components/settings/LLMEndpointPanel';
 import PerformancePanel from '../components/settings/PerformancePanel';
 import RefinementPanel from '../components/settings/RefinementPanel';
+import AecPanel from '../components/settings/AecPanel';
 import AppearancePanel from '../components/settings/AppearancePanel';
 import StoragePanel from '../components/settings/StoragePanel';
 import HFMirrorPanel from '../components/settings/HFMirrorPanel';
@@ -1338,6 +1339,7 @@ export default function Settings() {
           <DictationDemo />
           <HotkeyTab />
           <RefinementPanel />
+          <AecPanel />
         </>
       )}
 

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -107,6 +107,16 @@ export interface PrefsSlice {
   setTimingStrategy: (s: TimingStrategy) => void;
   setFitOptions: (o: FitOptions | null) => void;
 
+  /**
+   * Opt-in dictate-over-playback echo cancellation (parity Action 8). When
+   * on, dictation streams raw PCM through the server-side NLMS AEC and the
+   * audio player taps its output as the echo reference, so dictating while
+   * OmniVoice plays audio doesn't transcribe the playback. Default OFF — the
+   * standard MediaRecorder dictation path is unchanged when off.
+   */
+  aecEnabled: boolean;
+  setAecEnabled: (on: boolean) => void;
+
   locale: string;
   setLocale: (l: string) => void;
 
@@ -126,6 +136,7 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   showHeaderLiveStats: false,
   timingStrategy: 'concise',
   fitOptions: null,
+  aecEnabled: false,
 
   setTranslateQuality:    (q) => set({ translateQuality: q }),
   setDualSubs:            (on) => set({ dualSubs: on }),
@@ -135,6 +146,7 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   setShowHeaderLiveStats: (on) => set({ showHeaderLiveStats: on }),
   setTimingStrategy:      (s) => set({ timingStrategy: s }),
   setFitOptions:          (o) => set({ fitOptions: o }),
+  setAecEnabled:          (on) => set({ aecEnabled: on }),
 
   locale: typeof navigator !== 'undefined' ? (() => {
     const nav = navigator.language || '';

--- a/frontend/src/test/aecFarEndBus.test.js
+++ b/frontend/src/test/aecFarEndBus.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  publishFarEnd,
+  subscribeFarEnd,
+  farEndListenerCount,
+} from '../utils/aec/farEndBus';
+
+describe('aec/farEndBus', () => {
+  beforeEach(() => {
+    // Drain any leftover subscribers between tests (module singleton).
+    while (farEndListenerCount() > 0) {
+      // subscribe then immediately unsubscribe can't clear others; instead
+      // rely on each test cleaning up its own. This guard just asserts a
+      // clean baseline.
+      break;
+    }
+  });
+
+  it('starts with no listeners and publish is a no-op', () => {
+    expect(farEndListenerCount()).toBe(0);
+    expect(() => publishFarEnd(new Float32Array([0.1]))).not.toThrow();
+  });
+
+  it('delivers frames to subscribers and unsubscribes cleanly', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const unsubA = subscribeFarEnd(a);
+    const unsubB = subscribeFarEnd(b);
+    expect(farEndListenerCount()).toBe(2);
+
+    const frame = new Float32Array([0.5, -0.5]);
+    publishFarEnd(frame);
+    expect(a).toHaveBeenCalledWith(frame);
+    expect(b).toHaveBeenCalledWith(frame);
+
+    unsubA();
+    expect(farEndListenerCount()).toBe(1);
+    publishFarEnd(frame);
+    expect(a).toHaveBeenCalledTimes(1); // no longer receiving
+    expect(b).toHaveBeenCalledTimes(2);
+
+    unsubB();
+    expect(farEndListenerCount()).toBe(0);
+  });
+
+  it('a throwing subscriber does not break delivery to others', () => {
+    const bad = vi.fn(() => { throw new Error('boom'); });
+    const good = vi.fn();
+    const unsubBad = subscribeFarEnd(bad);
+    const unsubGood = subscribeFarEnd(good);
+
+    expect(() => publishFarEnd(new Float32Array([1]))).not.toThrow();
+    expect(good).toHaveBeenCalledTimes(1);
+
+    unsubBad();
+    unsubGood();
+  });
+});

--- a/frontend/src/test/aecPcm.test.js
+++ b/frontend/src/test/aecPcm.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AEC_NEAR,
+  AEC_FAR,
+  floatToInt16,
+  tagFrame,
+  frameFromFloat,
+} from '../utils/aec/pcm';
+
+describe('aec/pcm helpers', () => {
+  it('converts Float32 [-1,1] to clamped Int16', () => {
+    const out = floatToInt16(new Float32Array([0, 1, -1, 0.5, -0.5, 2, -2]));
+    expect(out[0]).toBe(0);
+    expect(out[1]).toBe(32767);   // +1 → 0x7fff
+    expect(out[2]).toBe(-32768);  // -1 → -0x8000
+    // Int16Array assignment truncates toward zero (not rounds).
+    expect(out[3]).toBe(Math.trunc(0.5 * 0x7fff));   // 16383.5 → 16383
+    expect(out[4]).toBe(Math.trunc(-0.5 * 0x8000));  // -16384 exact
+    expect(out[5]).toBe(32767);   // clamped above +1
+    expect(out[6]).toBe(-32768);  // clamped below -1
+  });
+
+  it('tags a frame with a 1-byte prefix + int16 LE payload', () => {
+    const pcm = new Int16Array([1, -2, 258]); // 258 = 0x0102
+    const buf = tagFrame(pcm, AEC_FAR);
+    const view = new DataView(buf);
+    expect(buf.byteLength).toBe(1 + pcm.byteLength);
+    expect(view.getUint8(0)).toBe(AEC_FAR);
+    // Payload is little-endian int16.
+    expect(view.getInt16(1, true)).toBe(1);
+    expect(view.getInt16(3, true)).toBe(-2);
+    expect(view.getInt16(5, true)).toBe(258);
+  });
+
+  it('near and far tags are distinct', () => {
+    expect(AEC_NEAR).toBe(0x00);
+    expect(AEC_FAR).toBe(0x01);
+    expect(AEC_NEAR).not.toBe(AEC_FAR);
+  });
+
+  it('frameFromFloat composes conversion + tagging', () => {
+    const buf = frameFromFloat(new Float32Array([1, -1]), AEC_NEAR);
+    const view = new DataView(buf);
+    expect(view.getUint8(0)).toBe(AEC_NEAR);
+    expect(view.getInt16(1, true)).toBe(32767);
+    expect(view.getInt16(3, true)).toBe(-32768);
+  });
+});

--- a/frontend/src/utils/aec/farEndBus.js
+++ b/frontend/src/utils/aec/farEndBus.js
@@ -1,0 +1,27 @@
+// Decoupled far-end (playback) reference bus for dictate-over-playback AEC
+// (parity Action 8). The audio player publishes Float32 mono frames of what it
+// is currently playing; the dictation capture subscribes and forwards them to
+// the backend as the echo reference. A singleton bus means the player and the
+// capture widget never need to know about each other, and when nothing is
+// subscribed (the common case) publishing is a cheap no-op.
+
+const subscribers = new Set();
+
+/** Publish one Float32 mono frame of current playback. No-op with no listeners. */
+export function publishFarEnd(frame) {
+  if (subscribers.size === 0) return;
+  for (const cb of subscribers) {
+    try { cb(frame); } catch { /* a bad subscriber must not break playback */ }
+  }
+}
+
+/** Subscribe to far-end frames. Returns an unsubscribe function. */
+export function subscribeFarEnd(cb) {
+  subscribers.add(cb);
+  return () => { subscribers.delete(cb); };
+}
+
+/** Number of active subscribers — lets the player skip tapping when nobody listens. */
+export function farEndListenerCount() {
+  return subscribers.size;
+}

--- a/frontend/src/utils/aec/micCapture.js
+++ b/frontend/src/utils/aec/micCapture.js
@@ -1,0 +1,35 @@
+// Microphone PCM capture for the opt-in AEC path (parity Action 8). Routes a
+// getUserMedia stream through an AudioWorklet that emits fixed-size Float32
+// frames; the caller converts/tags/sends them. Only used when AEC is enabled
+// — the default dictation path keeps using MediaRecorder/WebM untouched.
+
+const WORKLET_URL = '/aec-worklet.js';
+
+/**
+ * Start capturing ``stream`` as Float32 mono frames at ``sampleRate``.
+ *
+ * @param {MediaStream} stream      mic stream from getUserMedia
+ * @param {(frame: Float32Array) => void} onFrame  called per frame
+ * @param {{sampleRate?: number, frameSize?: number}} opts
+ * @returns {Promise<() => Promise<void>>}  async stop() that tears down the graph
+ */
+export async function startMicCapture(stream, onFrame, { sampleRate = 16000, frameSize = 320 } = {}) {
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  const ctx = new Ctx({ sampleRate });
+  await ctx.audioWorklet.addModule(WORKLET_URL);
+  const src = ctx.createMediaStreamSource(stream);
+  const node = new AudioWorkletNode(ctx, 'aec-frame-emitter', {
+    processorOptions: { frameSize },
+  });
+  node.port.onmessage = (e) => onFrame(e.data);
+  // Mic → worklet only. Deliberately NOT connected to destination: we tap the
+  // mic, we don't want to play it back through the speakers.
+  src.connect(node);
+
+  return async function stop() {
+    try { node.port.onmessage = null; } catch { /* ignore */ }
+    try { node.disconnect(); } catch { /* ignore */ }
+    try { src.disconnect(); } catch { /* ignore */ }
+    try { await ctx.close(); } catch { /* ignore */ }
+  };
+}

--- a/frontend/src/utils/aec/pcm.js
+++ b/frontend/src/utils/aec/pcm.js
@@ -1,0 +1,45 @@
+// PCM framing helpers for the opt-in dictate-over-playback AEC (parity
+// Action 8). The backend's `/ws/transcribe?aec=1` mode expects raw int16 mono
+// PCM frames, each prefixed with a 1-byte tag so it can tell the microphone
+// from the playback reference it must cancel. These helpers are pure (no Web
+// Audio) so they can be unit-tested without an AudioContext.
+
+export const AEC_NEAR = 0x00; // microphone frame
+export const AEC_FAR = 0x01;  // playback-reference frame
+
+/**
+ * Convert Float32 samples in [-1, 1] to Int16Array (clamped). Mirrors the
+ * encode math in utils/audioTrim.js so the wire format matches the backend's
+ * stdlib-`wave` reader.
+ */
+export function floatToInt16(float32) {
+  const out = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i++) {
+    let s = float32[i];
+    if (s > 1) s = 1;
+    else if (s < -1) s = -1;
+    out[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return out;
+}
+
+/**
+ * Build a tagged binary frame: ``[1-byte kind][int16 LE PCM…]`` as an
+ * ArrayBuffer ready for ``ws.send()``. All OmniVoice target platforms are
+ * little-endian (x86_64 / arm64), matching numpy's native int16 read on the
+ * server, so the Int16Array bytes are copied verbatim.
+ */
+export function tagFrame(int16, kind) {
+  const pcm = int16 instanceof Int16Array ? int16 : new Int16Array(int16);
+  const buf = new ArrayBuffer(1 + pcm.byteLength);
+  new DataView(buf).setUint8(0, kind);
+  new Uint8Array(buf, 1).set(
+    new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength),
+  );
+  return buf;
+}
+
+/** Convenience: Float32 mono frame → tagged ArrayBuffer in one step. */
+export function frameFromFloat(float32, kind) {
+  return tagFrame(floatToInt16(float32), kind);
+}

--- a/frontend/src/utils/aec/playbackTap.js
+++ b/frontend/src/utils/aec/playbackTap.js
@@ -1,0 +1,54 @@
+// Playback-reference tap for the opt-in AEC path (parity Action 8). Routes an
+// <audio>/<video> element's decoded output through a Web Audio graph so the
+// dictation AEC can use it as the far-end echo reference — WITHOUT changing
+// what the user hears. Only ever called when AEC is enabled; the default
+// playback path never constructs an AudioContext.
+//
+// Constraint: createMediaElementSource() may be called at most once per
+// element, and once called the element's audio routes ONLY through the graph.
+// So we (a) memoise the source per element, (b) always reconnect it to
+// destination to keep it audible, and (c) on detach disconnect only the tap
+// node — never the element→destination edge — so toggling AEC or remounting
+// the player never silences playback.
+
+import { publishFarEnd } from './farEndBus';
+
+const WORKLET_URL = '/aec-worklet.js';
+
+// element → { ctx, src } so we never double-tap or double-source an element.
+const tapped = new WeakMap();
+
+/**
+ * Attach (or re-attach) a far-end tap to ``mediaEl``. Returns an async
+ * detach() that stops publishing but keeps the element audible.
+ */
+export async function attachPlaybackTap(mediaEl, { sampleRate = 16000, frameSize = 320 } = {}) {
+  if (!mediaEl) return async () => {};
+
+  let entry = tapped.get(mediaEl);
+  if (!entry) {
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    const ctx = new Ctx({ sampleRate });
+    await ctx.audioWorklet.addModule(WORKLET_URL);
+    const src = ctx.createMediaElementSource(mediaEl);
+    src.connect(ctx.destination); // keep playback audible — set up once, forever
+    entry = { ctx, src };
+    tapped.set(mediaEl, entry);
+  }
+
+  const { ctx, src } = entry;
+  if (ctx.state === 'suspended') {
+    try { await ctx.resume(); } catch { /* gesture may be required; harmless */ }
+  }
+  const node = new AudioWorkletNode(ctx, 'aec-frame-emitter', {
+    processorOptions: { frameSize },
+  });
+  node.port.onmessage = (e) => publishFarEnd(e.data);
+  src.connect(node);
+
+  return async function detach() {
+    try { node.port.onmessage = null; } catch { /* ignore */ }
+    try { node.disconnect(); } catch { /* ignore */ }
+    // Intentionally leave ctx + src→destination intact (see header note).
+  };
+}


### PR DESCRIPTION
## What

Completes **Action 8** (streaming polish): dictate-over-playback echo cancellation now works **end-to-end**. Builds on the backend NLMS canceller (#399). Everything is gated behind a new **off-by-default** `aecEnabled` pref — the standard dictation (MediaRecorder/WebM) and playback paths are byte-identical when off.

## How

- **`utils/aec/`** + **`public/aec-worklet.js`**:
  - `pcm.js` — Float32→int16 + 1-byte frame tagging (pure, unit-tested).
  - `farEndBus.js` — singleton bus: the player publishes what it's playing, the capture subscribes (pure, unit-tested).
  - `micCapture.js` — AudioWorklet captures the mic as raw PCM frames.
  - `playbackTap.js` — routes a player's decoded output through Web Audio to the far-end bus, **keeping it audible** (source always reconnected to destination; MediaElementSource memoised per element).
- **`CaptureWidget`** — when `aecEnabled`, opens `/ws/transcribe?aec=1&sr=16000` and streams tagged PCM (`0x00` mic / `0x01` far-end) instead of MediaRecorder. No POST fallback in AEC mode (the WS is the sole channel).
- **`WaveformPlayer`** — while **actually playing** AND `aecEnabled`, taps its output as the echo reference. Gated on `isPlaying` so only the one active player holds an AudioContext (well under the browser per-page cap).
- **`Settings → Capture`** — `AecPanel` toggle. `prefsSlice` — `aecEnabled` (persisted).

## Verification

⚠️ **Needs in-app testing in the Tauri shell** — jsdom has no Web Audio/AudioWorklet, so the capture/tap paths can't be runtime-verified in CI. The pure framing/encode helpers **are** tested (7 new tests). Full vitest suite (319) + `vite build` green; the worklet ships to `dist/`.

Suggested manual check: enable Settings → Capture → "Dictate while audio plays", play a TTS preview, hold-to-talk and speak — the transcript should contain your words, not the playback.

## Docs

`docs/competitive-analysis.md` Action 8 row updated (🟡 → ✅ opt-in end-to-end) per the docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Implements end-to-end WebSocket-based acoustic echo cancellation (AEC) for dictation-over-playback, gated behind an opt-in `aecEnabled` preference. All existing MediaRecorder/WebM dictation remains byte-identical when AEC is disabled. Includes 7 new unit tests; full Vitest suite (319 tests) and build verification pass.

## Architecture

### New AEC Infrastructure
- **AudioWorklet Processor** (`public/aec-worklet.js`): Accumulates Float32 mono samples into fixed 320-sample frames (20ms @ 16kHz) and posts to main thread
- **PCM utilities** (`utils/aec/pcm.js`): Float32↔Int16 conversion with 1-byte frame tagging (0x00 mic, 0x01 far-end)
- **Far-end bus** (`utils/aec/farEndBus.js`): Singleton pub/sub for playback reference frames with error isolation
- **Microphone capture** (`utils/aec/micCapture.js`): AudioWorklet-based raw PCM streaming from `navigator.mediaDevices.getUserMedia`
- **Playback tap** (`utils/aec/playbackTap.js`): Routes decoded player output as echo reference; memoizes MediaElementAudioSourceNode per element, keeps playback audible via destination connection

### Capture Widget Changes
When `aecEnabled`:
- Opens WebSocket at `/ws/transcribe?aec=1&sr=16000` instead of normal transcription endpoint
- Streams tagged PCM frames over WebSocket (no MediaRecorder, no WebM fallback in AEC mode)
- Dynamically imports and manages AEC lifecycle during recording
- Skips WebM POST transcription entirely; WebSocket becomes sole result channel

### Player Integration
WaveformPlayer attaches playback tap when playing and `aecEnabled` is true; tap is gated on `isPlaying` to limit AudioContext overhead.

### UI Changes

```
Settings → Capture tab
┌─────────────────────────────────────┐
│ [Existing Capture Panels]           │
├─────────────────────────────────────┤
│ ┌───────────────────────────────┐   │
│ │ Dictate while audio plays     │   │
│ │ ✓ Enable echo cancellation    │ ← NEW EXPERIMENTAL AEC TOGGLE
│ │   for dictation              │   │
│ │ (Help text about end-to-end)  │   │
│ └───────────────────────────────┘   │
└─────────────────────────────────────┘
```

### Capture Flow with AEC Enabled

```mermaid
sequenceDiagram
    participant User
    participant CaptureWidget
    participant Worklet as AEC Worklet
    participant Bus as FarEndBus
    participant PlaybackTap
    participant WebSocket as Server/AEC

    User->>CaptureWidget: Start recording
    CaptureWidget->>Worklet: startMicCapture()
    CaptureWidget->>WebSocket: Open ws://host/ws/transcribe?aec=1&sr=16000
    
    PlaybackTap->>Worklet: attachPlaybackTap()
    PlaybackTap->>Bus: subscribeFarEnd()
    
    loop During Playback
        Player->>PlaybackTap: Audio output
        PlaybackTap->>Worklet: Tap decoded audio
        Worklet->>Bus: publishFarEnd(frame_0x01)
        Worklet->>WebSocket: Send tagged frame_0x01
    end
    
    loop Microphone Stream
        Worklet->>Bus: (mic frames go direct to WebSocket)
        Worklet->>WebSocket: Send tagged frame_0x00
    end
    
    WebSocket->>WebSocket: Apply NLMS AEC
    WebSocket-->>CaptureWidget: Transcription result
    
    User->>CaptureWidget: Stop recording
    CaptureWidget->>Worklet: teardownAec()
    CaptureWidget->>WebSocket: Close
```

## State Management
- Added `aecEnabled` boolean preference to `prefsSlice` (defaults to `false`)
- Preference persisted and accessible via `useAppStore().aecEnabled` and `setAecEnabled()`
- Settings panel provides UI toggle with "experimental" badge

## Testing
- 7 new unit tests covering PCM conversion, frame tagging, and far-end bus pub/sub behavior
- Tests verify Float32→Int16 clamping/truncation, tag prefix format, subscriber isolation, and error handling
- All 319 Vitest tests pass; `vite build` includes worklet in dist

## Documentation
Updated `docs/competitive-analysis.md` (Dictation while audio plays row) to reflect opt-in status with server-side NLMS AEC + frontend AudioWorklet plumbing.

## Notes
- Web Audio/AudioWorklet paths cannot be runtime-verified in CI (jsdom limitation); manual in-app testing in Tauri shell required
- AEC mode completely replaces MediaRecorder flow (no parallel recording)
- AudioContext and MediaElementAudioSourceNode are memoized to minimize resource overhead
- Errors during playback tap attachment are silently ignored to prevent capture interruption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->