### PR TITLE
feat(audiobook): chapterized audiobook core + plan preview (Wave 5)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -1,0 +1,29 @@
+"""Audiobook creator endpoints (parity Wave 5).
+
+First cut: a pure *plan preview*. ``POST /audiobook/plan`` parses a
+chapter-delimited script (Markdown ``# H1`` chapters, inline ``[voice:NAME]``
+and ``[pause …]``) into the chapter/span plan the UI renders before kicking off
+synthesis — no TTS, no ffmpeg, no side effects.
+
+The streaming synth job (chapters → chapterized m4b via the active TTS backend
++ ``services.audiobook.build_m4b_cmd``) is the planned follow-up.
+"""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from services.audiobook import parse_audiobook_script
+
+router = APIRouter()
+
+
+class AudiobookPlanRequest(BaseModel):
+    text: str
+    default_voice: str | None = None
+
+
+@router.post("/audiobook/plan")
+def audiobook_plan(req: AudiobookPlanRequest) -> dict:
+    """Parse a script into a chapter/span plan (pure preview, no synthesis)."""
+    plan = parse_audiobook_script(req.text, default_voice=req.default_voice)
+    return plan.to_dict()

--- a/backend/main.py
+++ b/backend/main.py
@@ -329,6 +329,7 @@ from api.routers import (
     tts_stream,
     marketplace,
     sonitranslate,
+    audiobook,
     settings as settings_router,  # Phase 1 AUTH-03: HF token save/clear/state
 )
 from utils import hf_progress
@@ -764,6 +765,7 @@ app.include_router(openai_compat.router)
 app.include_router(tts_stream.router)
 app.include_router(marketplace.router)
 app.include_router(sonitranslate.router)
+app.include_router(audiobook.router)
 app.include_router(settings_router.router)  # Phase 1 AUTH-03 endpoints
 from api.routers import mcp_bindings as _mcp_bindings_router  # noqa: E402
 app.include_router(_mcp_bindings_router.router)  # Wave 2.2 per-agent voice bindings

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -29,10 +29,14 @@ from typing import Callable, Optional
 from omnivoice.utils.text import parse_pause_markers
 
 # A Markdown H1 (``# Title``) starts a new chapter. Deeper headings stay in the
-# body as ordinary text (narrated, not chapter breaks).
-_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(.+?)[ \t]*$", re.MULTILINE)
-# ``[voice:NAME]`` switches the active narrator for the text that follows.
-_VOICE_RE = re.compile(r"\[voice:\s*([^\]]+?)\s*\]")
+# body as ordinary text (narrated, not chapter breaks). The title is captured
+# greedily and stripped in code — no trailing ``[ \t]*`` quantifier, so the
+# pattern is linear-time on adversarial whitespace (no ReDoS).
+_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(.+)$", re.MULTILINE)
+# ``[voice:NAME]`` switches the active narrator for the text that follows. A
+# single ``[^\]]*`` class (stripped in code) avoids the overlapping ``\s*``
+# quantifiers that make ``\s*(...)\s*`` polynomial-time.
+_VOICE_RE = re.compile(r"\[voice:([^\]]*)\]")
 _BITRATE_RE = re.compile(r"^\d{2,3}k$")
 
 

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -29,10 +29,11 @@ from typing import Callable, Optional
 from omnivoice.utils.text import parse_pause_markers
 
 # A Markdown H1 (``# Title``) starts a new chapter. Deeper headings stay in the
-# body as ordinary text (narrated, not chapter breaks). The title is captured
-# greedily and stripped in code — no trailing ``[ \t]*`` quantifier, so the
-# pattern is linear-time on adversarial whitespace (no ReDoS).
-_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(.+)$", re.MULTILINE)
+# body as ordinary text (narrated, not chapter breaks). The title capture
+# starts with ``\S`` (a non-space) so the leading ``[ \t]+`` and the title's
+# ``.*`` can't both match the same whitespace run — that overlap is what makes
+# ``[ \t]+(.+)`` polynomial-time on adversarial tabs (ReDoS). Stripped in code.
+_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(\S.*)$", re.MULTILINE)
 # ``[voice:NAME]`` switches the active narrator for the text that follows. A
 # single ``[^\]]*`` class (stripped in code) avoids the overlapping ``\s*``
 # quantifiers that make ``\s*(...)\s*`` polynomial-time.

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -1,0 +1,221 @@
+"""Audiobook creator — chapterized long-form narration (parity Wave 5).
+
+Turns a chapter-delimited script into a chapterized audiobook. This module is
+the engine-agnostic core:
+
+  * ``parse_audiobook_script`` — pure parser: Markdown ``# H1`` headings become
+    chapters; inline ``[voice:NAME]`` switches the narrator; ``[pause …]`` is
+    delegated to the existing :func:`omnivoice.utils.text.parse_pause_markers`
+    so audiobooks and single-shot synthesis share one pause dialect.
+  * ``synthesize_chapter`` — orchestration: renders a chapter's spans through an
+    injected ``synth(text, voice_id) -> tensor`` callable (reusing the
+    ``chunked_tts`` splitter + crossfade), stitching the inter-span silences.
+    Injecting the synth keeps this unit-testable with a stub backend (no torch
+    model, no GPU).
+  * ``build_chapter_ffmetadata`` / ``build_m4b_cmd`` — pure builders for the
+    ffmpeg chapterized-m4b mux (FFMETADATA1 ``[CHAPTER]`` blocks + concat-demux
+    argv). The actual ffmpeg run lives in the (impure) caller.
+
+Scope (first cut): plain chapter-delimited text/Markdown input. epub/pdf
+ingestion, the streaming synth job + UI are deferred follow-ups.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from omnivoice.utils.text import parse_pause_markers
+
+# A Markdown H1 (``# Title``) starts a new chapter. Deeper headings stay in the
+# body as ordinary text (narrated, not chapter breaks).
+_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(.+?)[ \t]*$", re.MULTILINE)
+# ``[voice:NAME]`` switches the active narrator for the text that follows.
+_VOICE_RE = re.compile(r"\[voice:\s*([^\]]+?)\s*\]")
+_BITRATE_RE = re.compile(r"^\d{2,3}k$")
+
+
+@dataclass
+class Span:
+    """One contiguous run of text in a single voice, plus trailing silence."""
+    voice_id: Optional[str]
+    text: str
+    pause_ms_after: int = 0
+
+    def to_dict(self) -> dict:
+        return {"voice_id": self.voice_id, "text": self.text,
+                "pause_ms_after": self.pause_ms_after}
+
+
+@dataclass
+class Chapter:
+    title: str
+    spans: list[Span] = field(default_factory=list)
+
+    @property
+    def char_count(self) -> int:
+        return sum(len(s.text) for s in self.spans)
+
+    def to_dict(self) -> dict:
+        return {"title": self.title, "char_count": self.char_count,
+                "spans": [s.to_dict() for s in self.spans]}
+
+
+@dataclass
+class AudiobookPlan:
+    chapters: list[Chapter] = field(default_factory=list)
+
+    @property
+    def char_count(self) -> int:
+        return sum(c.char_count for c in self.chapters)
+
+    def to_dict(self) -> dict:
+        return {
+            "chapters": [c.to_dict() for c in self.chapters],
+            "chapter_count": len(self.chapters),
+            "char_count": self.char_count,
+        }
+
+
+def _parse_spans(body: str, default_voice: Optional[str]) -> list[Span]:
+    """Split a chapter body into voice-tagged, pause-aware spans."""
+    spans: list[Span] = []
+    cur_voice = default_voice
+    runs: list[tuple[Optional[str], str]] = []
+    last = 0
+    for m in _VOICE_RE.finditer(body):
+        if m.start() > last:
+            runs.append((cur_voice, body[last:m.start()]))
+        cur_voice = (m.group(1).strip() or default_voice)
+        last = m.end()
+    runs.append((cur_voice, body[last:]))
+
+    for voice, run_text in runs:
+        # Delegate pause handling to the shared parser so the [pause …] dialect
+        # stays identical to single-shot synthesis.
+        for span_text, pause_ms in parse_pause_markers(run_text):
+            t = span_text.strip()
+            if not t and pause_ms == 0:
+                continue  # pure whitespace between markers — nothing to render
+            spans.append(Span(voice_id=voice, text=t, pause_ms_after=pause_ms))
+    return spans
+
+
+def parse_audiobook_script(text: str, *, default_voice: Optional[str] = None) -> AudiobookPlan:
+    """Parse a chapter-delimited script into an :class:`AudiobookPlan`.
+
+    ``# Heading`` lines delimit chapters; text before the first heading becomes
+    an untitled lead-in chapter. Chapters with no renderable spans are dropped.
+    """
+    text = text or ""
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        raw = [(None, text)]
+    else:
+        raw = []
+        intro = text[:matches[0].start()]
+        if intro.strip():
+            raw.append((None, intro))
+        for i, m in enumerate(matches):
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            raw.append((m.group(1).strip(), text[m.end():end]))
+
+    chapters: list[Chapter] = []
+    for title, body in raw:
+        spans = _parse_spans(body, default_voice)
+        if not spans:
+            continue
+        chapters.append(Chapter(title=title or f"Chapter {len(chapters) + 1}", spans=spans))
+    return AudiobookPlan(chapters=chapters)
+
+
+def synthesize_chapter(
+    spans: list[Span],
+    synth: Callable[[str, Optional[str]], "object"],
+    sample_rate: int,
+    *,
+    crossfade_ms: int = 50,
+):
+    """Render a chapter's spans to one waveform via an injected ``synth``.
+
+    ``synth(text, voice_id)`` returns a 1-D float32 audio tensor for a span of
+    text in the given voice. Long spans are split with the ``chunked_tts``
+    splitter and crossfaded; inter-span ``pause_ms_after`` becomes silence.
+
+    Returns ``(audio_tensor, duration_seconds)``. torch + chunked_tts are
+    imported lazily so this module stays import-light for the pure parser path.
+    """
+    import torch
+    from services.chunked_tts import concatenate_audio_chunks, split_text_into_chunks
+
+    parts: list = []
+    for span in spans:
+        if span.text:
+            chunks = split_text_into_chunks(span.text)
+            rendered = [synth(c, span.voice_id) for c in chunks]
+            rendered = [r for r in rendered if r is not None and getattr(r, "numel", lambda: 0)()]
+            if len(rendered) == 1:
+                parts.append(rendered[0])
+            elif rendered:
+                parts.append(concatenate_audio_chunks(rendered, sample_rate, crossfade_ms=crossfade_ms))
+        if span.pause_ms_after > 0:
+            n = int(sample_rate * span.pause_ms_after / 1000.0)
+            if n > 0:
+                parts.append(torch.zeros(n, dtype=torch.float32))
+
+    if not parts:
+        return torch.zeros(0, dtype=torch.float32), 0.0
+    # Hard-concat spans + silences (crossfading silence would bleed the gap).
+    audio = parts[0] if len(parts) == 1 else concatenate_audio_chunks(parts, sample_rate, crossfade_ms=0)
+    return audio, audio.shape[-1] / float(sample_rate)
+
+
+def _escape_meta(value: str) -> str:
+    """Escape an FFMETADATA value (``=``, ``;``, ``#``, ``\\``, newline)."""
+    return re.sub(r"([=;#\\\n])", r"\\\1", value or "")
+
+
+def build_chapter_ffmetadata(chapters: list[tuple[str, int]]) -> str:
+    """Build an FFMETADATA1 document with one ``[CHAPTER]`` per (title, ms).
+
+    ``chapters`` is ordered ``(title, duration_ms)`` pairs; START/END are the
+    cumulative millisecond offsets ffmpeg writes into the m4b chapter table.
+    """
+    lines = [";FFMETADATA1"]
+    start = 0
+    for title, dur_ms in chapters:
+        end = start + max(0, int(dur_ms))
+        lines += [
+            "[CHAPTER]",
+            "TIMEBASE=1/1000",
+            f"START={start}",
+            f"END={end}",
+            f"title={_escape_meta(title)}",
+        ]
+        start = end
+    return "\n".join(lines) + "\n"
+
+
+def build_m4b_cmd(
+    ffmpeg: str,
+    concat_list_path: str,
+    metadata_path: str,
+    out_path: str,
+    *,
+    bitrate: str = "128k",
+) -> list[str]:
+    """Pure argv for muxing chapter WAVs + FFMETADATA into a faststart m4b.
+
+    Input 0 is the concat-demuxer list of chapter WAVs; input 1 is the
+    FFMETADATA file (``-map_metadata 1`` pulls the chapter table from it).
+    """
+    if not _BITRATE_RE.match(bitrate or ""):
+        bitrate = "128k"
+    return [
+        ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
+        "-f", "concat", "-safe", "0", "-i", str(concat_list_path),
+        "-i", str(metadata_path), "-map_metadata", "1",
+        "-c:a", "aac", "-b:a", bitrate,
+        "-movflags", "+faststart", "-f", "mp4", str(out_path),
+    ]

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -34,10 +34,12 @@ from omnivoice.utils.text import parse_pause_markers
 # ``.*`` can't both match the same whitespace run — that overlap is what makes
 # ``[ \t]+(.+)`` polynomial-time on adversarial tabs (ReDoS). Stripped in code.
 _HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(\S.*)$", re.MULTILINE)
-# ``[voice:NAME]`` switches the active narrator for the text that follows. A
-# single ``[^\]]*`` class (stripped in code) avoids the overlapping ``\s*``
-# quantifiers that make ``\s*(...)\s*`` polynomial-time.
-_VOICE_RE = re.compile(r"\[voice:([^\]]*)\]")
+# ``[voice:NAME]`` switches the active narrator for the text that follows. The
+# content class excludes BOTH brackets (``[^\]\[]``) so a run of nested
+# ``[voice:`` prefixes can't create overlapping match attempts across
+# ``finditer`` (the source of the polynomial-time ReDoS). A voice name never
+# contains a bracket; the value is stripped in code.
+_VOICE_RE = re.compile(r"\[voice:([^\]\[]*)\]")
 _BITRATE_RE = re.compile(r"^\d{2,3}k$")
 
 

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -1067,6 +1067,14 @@ path, mTLS/OAuth (overkill vs bearer + WireGuard), a second thin-client binary.
 
 ### R3 — Audiobook/stories creator + persona gallery
 
+> **Status (2026-06-13):** first cut shipped — `backend/services/audiobook.py`
+> parses a chapter-delimited script (Markdown `# H1` chapters + inline
+> `[voice:NAME]`; `[pause …]` delegated to the shared `parse_pause_markers`)
+> into a chapter/span plan, with pure FFMETADATA1 + faststart-m4b argv builders
+> and a stub-testable synth orchestration. `POST /audiobook/plan` returns the
+> plan. Deferred: the streaming synth job + chapterized-m4b run, epub/pdf/docx
+> ingest, ACX `loudnorm` mastering, crash-resume, and the UI.
+
 **The production bar** (verified against [ebook2audiobook](https://github.com/DrewThomasson/ebook2audiobook),
 audiblez, epub2tts, abogen, Pandrator): broad ingest (epub/mobi/pdf/docx + OCR for
 image PDFs), chapter detection (TOC-driven for epub — even the 19.2k★ leader's

--- a/omnivoice/utils/text.py
+++ b/omnivoice/utils/text.py
@@ -225,8 +225,13 @@ def add_punctuation(text: str):
 # A bare `[pause]` uses PAUSE_DEFAULT_MS.
 PAUSE_DEFAULT_MS = 350
 PAUSE_MAX_MS = 10_000
+# The numeric spec is an atomic group ``(?>…)`` so the engine can't backtrack
+# its leading ``\s+`` against the trailing ``\s*`` — that overlap made the
+# pattern polynomial-time on adversarial whitespace (ReDoS). Atomic groups are
+# behavior-preserving here (no valid ``[pause …]`` needs to backtrack into the
+# spec) and require Python ≥3.11, which the project already mandates.
 _PAUSE_RE = re.compile(
-    r"\[\s*pause(?:\s+(\d+(?:\.\d+)?)\s*(ms|s)?)?\s*\]",
+    r"\[\s*pause(?>\s+(\d+(?:\.\d+)?)\s*(ms|s)?)?\s*\]",
     re.IGNORECASE,
 )
 

--- a/tests/test_audiobook.py
+++ b/tests/test_audiobook.py
@@ -1,0 +1,134 @@
+"""Audiobook creator core (parity Wave 5).
+
+Pure tests for the parser + ffmpeg builders, plus a stub-backend test of the
+synthesis orchestration (torch, but no model / GPU / main import).
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.audiobook import (
+    AudiobookPlan,
+    build_chapter_ffmetadata,
+    build_m4b_cmd,
+    parse_audiobook_script,
+    synthesize_chapter,
+)
+
+
+# ── Parser ───────────────────────────────────────────────────────────────────
+
+def test_no_headings_single_chapter():
+    plan = parse_audiobook_script("Hello world. This is a test.")
+    assert isinstance(plan, AudiobookPlan)
+    assert len(plan.chapters) == 1
+    assert plan.chapters[0].title == "Chapter 1"
+    assert plan.chapters[0].spans[0].text == "Hello world. This is a test."
+
+
+def test_h1_headings_become_chapters():
+    plan = parse_audiobook_script("# Prologue\nOnce upon a time.\n# Chapter One\nThe end.")
+    assert [c.title for c in plan.chapters] == ["Prologue", "Chapter One"]
+    assert plan.chapters[0].spans[0].text == "Once upon a time."
+    assert plan.chapters[1].spans[0].text == "The end."
+
+
+def test_intro_before_first_heading_is_untitled_chapter():
+    plan = parse_audiobook_script("Front matter.\n# Real Chapter\nBody.")
+    assert plan.chapters[0].title == "Chapter 1"      # synthesised title
+    assert plan.chapters[0].spans[0].text == "Front matter."
+    assert plan.chapters[1].title == "Real Chapter"
+
+
+def test_voice_tag_switches_narrator():
+    plan = parse_audiobook_script("Narrator speaks. [voice:alice]Alice speaks.", default_voice="narrator")
+    spans = plan.chapters[0].spans
+    assert spans[0].voice_id == "narrator"
+    assert spans[0].text == "Narrator speaks."
+    assert spans[1].voice_id == "alice"
+    assert spans[1].text == "Alice speaks."
+
+
+def test_default_voice_applied_without_tag():
+    plan = parse_audiobook_script("Just text.", default_voice="bob")
+    assert plan.chapters[0].spans[0].voice_id == "bob"
+
+
+def test_pause_marker_delegated():
+    plan = parse_audiobook_script("Before. [pause 500ms] After.")
+    spans = plan.chapters[0].spans
+    assert spans[0].text == "Before."
+    assert spans[0].pause_ms_after == 500
+    assert spans[1].text == "After."
+    assert spans[1].pause_ms_after == 0
+
+
+def test_empty_chapters_dropped():
+    plan = parse_audiobook_script("# Empty\n   \n# Real\nWords.")
+    assert [c.title for c in plan.chapters] == ["Real"]
+
+
+def test_plan_to_dict_shape():
+    d = parse_audiobook_script("# A\nHi there.").to_dict()
+    assert d["chapter_count"] == 1
+    assert d["char_count"] == len("Hi there.")
+    assert d["chapters"][0]["spans"][0]["text"] == "Hi there."
+
+
+# ── FFMETADATA ───────────────────────────────────────────────────────────────
+
+def test_ffmetadata_cumulative_offsets():
+    meta = build_chapter_ffmetadata([("Intro", 1000), ("Chapter 1", 2500)])
+    assert meta.startswith(";FFMETADATA1\n")
+    assert "TIMEBASE=1/1000" in meta
+    # First chapter 0..1000, second 1000..3500.
+    assert "START=0\nEND=1000\ntitle=Intro" in meta
+    assert "START=1000\nEND=3500\ntitle=Chapter 1" in meta
+
+
+def test_ffmetadata_escapes_special_chars():
+    meta = build_chapter_ffmetadata([("A=B; C#1", 100)])
+    assert r"title=A\=B\; C\#1" in meta
+
+
+# ── m4b argv ─────────────────────────────────────────────────────────────────
+
+def test_m4b_cmd_shape():
+    cmd = build_m4b_cmd("ffmpeg", "list.txt", "meta.txt", "out.m4b", bitrate="192k")
+    assert cmd[0] == "ffmpeg"
+    assert "-f" in cmd and "concat" in cmd
+    assert cmd[cmd.index("-map_metadata") + 1] == "1"
+    assert cmd[cmd.index("-b:a") + 1] == "192k"
+    assert "+faststart" in cmd
+    assert cmd[-1] == "out.m4b"
+
+
+def test_m4b_cmd_rejects_bad_bitrate():
+    cmd = build_m4b_cmd("ffmpeg", "l", "m", "o", bitrate="; rm -rf /")
+    assert cmd[cmd.index("-b:a") + 1] == "128k"   # falls back, no injection
+
+
+# ── Orchestration (stub synth) ───────────────────────────────────────────────
+
+def test_synthesize_chapter_stitches_spans_and_silence():
+    torch = pytest.importorskip("torch")
+    sr = 16000
+    calls = []
+
+    def synth(text, voice_id):
+        calls.append((text, voice_id))
+        return torch.ones(1000, dtype=torch.float32)  # 1000 samples per chunk
+
+    plan = parse_audiobook_script("First. [pause 1s] Second.", default_voice="v")
+    audio, dur = synthesize_chapter(plan.chapters[0].spans, synth, sr)
+    # Two text spans (1000 each) + 1 s silence (16000) = 18000 samples.
+    assert audio.shape[-1] == 1000 + sr + 1000
+    assert dur == pytest.approx((2000 + sr) / sr)
+    assert [c[1] for c in calls] == ["v", "v"]  # voice threaded to synth
+
+
+def test_synthesize_empty_spans_is_silent():
+    torch = pytest.importorskip("torch")
+    audio, dur = synthesize_chapter([], lambda t, v: torch.ones(10), 16000)
+    assert audio.shape[-1] == 0
+    assert dur == 0.0


### PR DESCRIPTION
## What

First cut of the **long-form audiobook vertical** (parity §R3 — the ebook2audiobook-class feature we don't yet serve). Engine-agnostic, backend-first.

`backend/services/audiobook.py`:
- **`parse_audiobook_script`** — pure parser. Markdown `# H1` headings → chapters; inline `[voice:NAME]` switches the narrator; `[pause …]` is **delegated to the shared `omnivoice.utils.text.parse_pause_markers`** so audiobooks and single-shot synthesis keep one pause dialect. Returns a chapter/span plan.
- **`synthesize_chapter`** — orchestration via an injected `synth(text, voice) -> tensor` callable (reuses `chunked_tts` split + crossfade, stitches inter-span silence). Injecting the synth keeps it **unit-testable with a stub backend** — no model, no GPU.
- **`build_chapter_ffmetadata`** + **`build_m4b_cmd`** — pure FFMETADATA1 `[CHAPTER]` builder + faststart-m4b concat-demux argv (bitrate-validated, no shell injection).

`POST /audiobook/plan` returns the parsed plan (no TTS, no ffmpeg, no side effects) — the preview the UI will render before synthesis.

## Scope / deferred

This PR is the **reusable core + plan preview**. Deferred follow-ups: the streaming synth job (chapters → chapterized m4b via the active backend + `build_m4b_cmd`), epub/pdf/docx ingest (new dep), ACX `loudnorm` mastering, crash-resume, and the UI.

## Tests

`tests/test_audiobook.py` — 14 tests: parser (chapters, voice switching, pause delegation, untitled intro, empty-chapter drop, `to_dict`), FFMETADATA cumulative offsets + escaping, m4b argv + bitrate guard, and stub-synth orchestration (span+silence stitching, voice threading). All pure / stub — no model, no ffmpeg execution. docs §R3 status updated per the docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Audiobook Core Engine & Plan Preview

This PR introduces a backend-first, engine-agnostic chapterized audiobook workflow with a pure preview endpoint and ReDoS-hardened pause/voice regexes.

### Architecture & Flow

```mermaid
graph LR
    A["Markdown Script<br/>(H1 chapters, voice tags, pauses)"] -->|parse_audiobook_script| B["AudiobookPlan<br/>(chapters → spans)"]
    B -->|POST /audiobook/plan| C["Preview Response<br/>(no side effects)"]
    B -->|synthesize_chapter| D["Audio Tensors<br/>(stitched spans + silence)"]
    B -->|build_chapter_ffmetadata| E["FFMETADATA1 File<br/>(chapter boundaries)"]
    B -->|build_m4b_cmd| F["ffmpeg argv<br/>(mux, bitrate, faststart)"]
    D --> G["m4b Output<br/>(deferred: streaming synth job)"]
    E --> G
    F --> G
```

### Core Components

- New backend router: POST /audiobook/plan — preview-only endpoint that returns a serialized AudiobookPlan (no synthesis, ffmpeg, or side effects).
- New service: backend/services/audiobook.py
  - Data models: Span (voice_id, text, pause_ms_after), Chapter (title, spans, char_count), AudiobookPlan (chapters, char_count) with to_dict serializers.
  - parse_audiobook_script(text, *, default_voice=None) → AudiobookPlan
    - Splits Markdown H1 headings into chapters, collects intro as untitled chapter, supports inline [voice:NAME] switches, delegates [pause …] parsing to omnivoice.utils.text.parse_pause_markers, and drops empty chapters.
  - synthesize_chapter(spans, synth, sample_rate, *, crossfade_ms=50)
    - Orchestrates rendering using an injected synth(text, voice) → tensor callable, reuses chunked_tts chunking/crossfade logic, and appends per-span silence. Designed for unit testing with stubs (no model/GPU).
  - build_chapter_ffmetadata(chapters) → FFMETADATA1 text with cumulative START/END offsets and safe escaping.
  - build_m4b_cmd(ffmpeg, concat_list_path, metadata_path, out_path, *, bitrate="128k") → argv list; validates/normalizes bitrate and avoids shell injection.

### Security / Regex Hardening

- Fixed potential ReDoS risks in pause/voice regexes: made patterns linear-time and non-overlapping (tightened captures, excluded brackets from voice-tag content, used atomic group in pause regex). Changes are behavior-preserving and covered by tests.

### API

- POST /audiobook/plan
  - Request model: AudiobookPlanRequest { text: str, default_voice: Optional[str] }
  - Response: AudiobookPlan.to_dict() — read-only plan preview (chapters → spans). No synthesis/ffmpeg/I/O.

### Tests

- Added tests/tests_audiobook.py (14 tests) covering:
  - Parser: headings → chapters, intro untitled chapter, voice tag switching, default voice, pause marker delegation, empty-chapter drop, to_dict shape.
  - FFMETADATA: cumulative offsets and escaping.
  - m4b argv: command shape and bitrate sanitization/fallback.
  - synth orchestration: span chunking/crossfade, appended silence, and silent output for empty spans.
- All tests use stubs; no model or ffmpeg execution.
- Pause regex/backtracking fix also validated by existing pause tests.

### Documentation

- docs/competitive-analysis.md updated with feature status and deferred scope.

### Deferred / Out of Scope

Streaming synth job (chapterized m4b generation), epub/pdf/docx ingest, ACX loudness mastering, crash-resume, and UI work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->