### PR TITLE
feat(audiobook): synth job → chapterized m4b, SSE progress (Wave 5)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -1,18 +1,35 @@
 """Audiobook creator endpoints (parity Wave 5).
 
-First cut: a pure *plan preview*. ``POST /audiobook/plan`` parses a
-chapter-delimited script (Markdown ``# H1`` chapters, inline ``[voice:NAME]``
-and ``[pause …]``) into the chapter/span plan the UI renders before kicking off
-synthesis — no TTS, no ffmpeg, no side effects.
+``POST /audiobook/plan`` — pure preview: parse a chapter-delimited script
+(Markdown ``# H1`` chapters, inline ``[voice:NAME]`` / ``[pause …]``) into the
+chapter/span plan, no synthesis.
 
-The streaming synth job (chapters → chapterized m4b via the active TTS backend
-+ ``services.audiobook.build_m4b_cmd``) is the planned follow-up.
+``POST /audiobook`` — the synth job: render each chapter through the active TTS
+backend (reusing ``services.audiobook.synthesize_chapter`` + ``chunked_tts``),
+then mux the chapter WAVs into a chapterized **m4b** (FFMETADATA1 chapters via
+``build_m4b_cmd``). Progress streams as Server-Sent Events, mirroring the dub
+pipeline. ffmpeg-gated — without ffmpeg the job reports an error event and
+stops (the m4b is the only output format).
+
+epub/pdf ingest, ACX mastering, crash-resume and the UI remain follow-ups.
 """
 
+import asyncio
+import json
+import os
+import uuid
+
 from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from services.audiobook import parse_audiobook_script
+from services.audiobook import (
+    build_chapter_ffmetadata,
+    build_concat_list,
+    build_m4b_cmd,
+    parse_audiobook_script,
+    synthesize_chapter,
+)
 
 router = APIRouter()
 
@@ -27,3 +44,188 @@ def audiobook_plan(req: AudiobookPlanRequest) -> dict:
     """Parse a script into a chapter/span plan (pure preview, no synthesis)."""
     plan = parse_audiobook_script(req.text, default_voice=req.default_voice)
     return plan.to_dict()
+
+
+class AudiobookRequest(BaseModel):
+    text: str
+    default_voice: str | None = None   # voice profile id; None = engine default
+    bitrate: str = "128k"
+
+
+def _resolve_voice(profile_id: str | None) -> dict:
+    """Map a voice-profile id to (ref_audio, ref_text, instruct, seed).
+
+    Compact form of the resolver in generation.py — covers locked, design and
+    clone profiles. Returns all-None for the engine default (no profile).
+    """
+    out = {"ref_audio": None, "ref_text": None, "instruct": None, "seed": None}
+    if not profile_id:
+        return out
+    from core.config import VOICES_DIR
+    from core.db import db_conn
+
+    with db_conn() as conn:
+        row = conn.execute("SELECT * FROM voice_profiles WHERE id=?", (profile_id,)).fetchone()
+    if not row:
+        return out
+    try:
+        kind = row["kind"] or "clone"
+    except (KeyError, IndexError):
+        kind = "clone"
+    if row["is_locked"] and row["locked_audio_path"]:
+        out["ref_audio"] = os.path.join(VOICES_DIR, row["locked_audio_path"])
+        out["ref_text"] = row["ref_text"]
+        out["instruct"] = row["instruct"]
+    elif kind == "design":
+        out["ref_audio"] = os.path.join(VOICES_DIR, row["ref_audio_path"]) if row["ref_audio_path"] else None
+        out["ref_text"] = row["ref_text"] if out["ref_audio"] else None
+        out["instruct"] = row["instruct"]
+    else:
+        out["ref_audio"] = os.path.join(VOICES_DIR, row["ref_audio_path"]) if row["ref_audio_path"] else None
+        out["ref_text"] = row["ref_text"]
+        out["instruct"] = row["instruct"]
+    try:
+        if row["seed"] is not None:
+            out["seed"] = row["seed"]
+    except (KeyError, IndexError):
+        pass
+    return out
+
+
+def _build_synth(default_voice: str | None):
+    """Return ``(synth, sample_rate)`` bound to the active TTS engine.
+
+    ``synth(text, voice_id)`` renders one span of text (already pause- and
+    chapter-split) in the given voice and returns a 1-D audio tensor. Voice
+    resolutions are cached per id. The default OmniVoice model takes the native
+    path; other engines go through the generic ``TTSBackend`` adapter.
+    """
+    from services.tts_backend import OmniVoiceBackend, active_backend_id, get_backend_class
+
+    cache: dict = {}
+
+    def resolve(voice_id):
+        key = voice_id or default_voice
+        if key not in cache:
+            cache[key] = _resolve_voice(key)
+        return cache[key]
+
+    cls = get_backend_class(active_backend_id())
+    if cls is OmniVoiceBackend:
+        from services.model_manager import get_model
+        # get_model() is async; the caller resolves it before threading.
+        return ("omnivoice", resolve, get_model)
+
+    backend = cls()
+
+    def synth(text, voice_id):
+        v = resolve(voice_id)
+        return backend.generate(
+            text, language=None, ref_audio=v["ref_audio"],
+            ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
+        )
+    return ("generic", synth, backend.sample_rate)
+
+
+@router.post("/audiobook")
+async def audiobook_synthesize(req: AudiobookRequest):
+    """Synthesize a chapterized m4b audiobook, streaming SSE progress."""
+    from core.config import OUTPUTS_DIR
+    from services.audio_io import atomic_save_wav
+    from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
+    from services.model_manager import _gpu_pool
+
+    plan = parse_audiobook_script(req.text, default_voice=req.default_voice)
+
+    async def gen():
+        job_id = uuid.uuid4().hex[:16]
+        try:
+            from core import job_store
+            job_store.create(job_id, type="audiobook")
+            job_store.mark_running(job_id)
+        except Exception:
+            job_store = None  # job history is best-effort; never block synthesis
+
+        def _emit(payload: dict) -> str:
+            if job_store is not None:
+                try:
+                    job_store.append_event(job_id, json.dumps(payload))
+                except Exception:
+                    pass
+            return f"data: {json.dumps(payload)}\n\n"
+
+        if not plan.chapters:
+            yield _emit({"type": "error", "error": "no chapters parsed from the script"})
+            return
+        ffmpeg = find_ffmpeg()
+        if not ffmpeg:
+            yield _emit({"type": "error", "error": "ffmpeg not available; the m4b output needs it"})
+            return
+
+        work = os.path.join(OUTPUTS_DIR, f"audiobook_{job_id}")
+        os.makedirs(work, exist_ok=True)
+        loop = asyncio.get_running_loop()
+
+        try:
+            mode, a, b = _build_synth(req.default_voice)
+            if mode == "omnivoice":
+                resolve, get_model = a, b
+                model = await get_model()
+                sr = getattr(model, "sampling_rate", 24000)
+
+                def synth(text, voice_id):
+                    v = resolve(voice_id)
+                    return model.generate(
+                        text=text, language=None, ref_audio=v["ref_audio"],
+                        ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
+                    )[0]
+            else:
+                synth, sr = a, b
+
+            total = len(plan.chapters)
+            chapter_files: list[str] = []
+            chapters_meta: list[tuple[str, int]] = []
+            yield _emit({"type": "started", "job_id": job_id, "chapters": total})
+
+            for i, chapter in enumerate(plan.chapters):
+                audio, dur = await loop.run_in_executor(
+                    _gpu_pool, synthesize_chapter, chapter.spans, synth, sr,
+                )
+                wav_path = os.path.join(work, f"chapter_{i:03d}.wav")
+                atomic_save_wav(wav_path, audio, sr)
+                chapter_files.append(wav_path)
+                chapters_meta.append((chapter.title, int(round(dur * 1000))))
+                yield _emit({"type": "chapter", "index": i, "total": total,
+                             "title": chapter.title, "duration_s": round(dur, 2)})
+
+            yield _emit({"type": "assembling"})
+            meta_path = os.path.join(work, "chapters.ffmeta")
+            with open(meta_path, "w", encoding="utf-8") as f:
+                f.write(build_chapter_ffmetadata(chapters_meta))
+            concat_path = os.path.join(work, "concat.txt")
+            with open(concat_path, "w", encoding="utf-8") as f:
+                f.write(build_concat_list(chapter_files))
+            out_name = f"audiobook_{job_id}.m4b"
+            out_path = os.path.join(OUTPUTS_DIR, out_name)
+            await run_ffmpeg(
+                build_m4b_cmd(ffmpeg, concat_path, meta_path, out_path, bitrate=req.bitrate),
+                job_id=job_id,
+            )
+
+            if job_store is not None:
+                try:
+                    job_store.mark_done(job_id)
+                except Exception:
+                    pass
+            total_s = sum(d for _, d in chapters_meta) / 1000.0
+            yield _emit({"type": "done", "output": out_name,
+                         "chapters": total, "duration_s": round(total_s, 2)})
+        except Exception as e:  # surface, don't 500 the stream
+            if job_store is not None:
+                try:
+                    job_store.mark_failed(job_id, str(e))
+                except Exception:
+                    pass
+            yield _emit({"type": "error", "error": str(e)[:300]})
+
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -204,6 +204,20 @@ def build_chapter_ffmetadata(chapters: list[tuple[str, int]]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def build_concat_list(wav_paths: list[str]) -> str:
+    """Build an ffmpeg concat-demuxer list for the chapter WAVs.
+
+    Each line is ``file '<path>'`` with single quotes escaped the ffmpeg way
+    (``'`` → ``'\\''``), so paths with spaces/quotes can't break the list or
+    inject arguments.
+    """
+    lines = []
+    for p in wav_paths:
+        safe = str(p).replace("'", "'\\''")
+        lines.append(f"file '{safe}'")
+    return "\n".join(lines) + "\n"
+
+
 def build_m4b_cmd(
     ffmpeg: str,
     concat_list_path: str,

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -1067,13 +1067,15 @@ path, mTLS/OAuth (overkill vs bearer + WireGuard), a second thin-client binary.
 
 ### R3 — Audiobook/stories creator + persona gallery
 
-> **Status (2026-06-13):** first cut shipped — `backend/services/audiobook.py`
+> **Status (2026-06-13):** backend shipped — `backend/services/audiobook.py`
 > parses a chapter-delimited script (Markdown `# H1` chapters + inline
 > `[voice:NAME]`; `[pause …]` delegated to the shared `parse_pause_markers`)
-> into a chapter/span plan, with pure FFMETADATA1 + faststart-m4b argv builders
-> and a stub-testable synth orchestration. `POST /audiobook/plan` returns the
-> plan. Deferred: the streaming synth job + chapterized-m4b run, epub/pdf/docx
-> ingest, ACX `loudnorm` mastering, crash-resume, and the UI.
+> into a chapter/span plan, renders each chapter through the active TTS engine
+> (`synthesize_chapter` + `chunked_tts`), and muxes a chapterized **m4b**
+> (FFMETADATA1 chapters). `POST /audiobook/plan` previews the plan;
+> `POST /audiobook` runs the synth job streaming SSE progress (ffmpeg-gated).
+> Deferred: epub/pdf/docx ingest, ACX `loudnorm` mastering, crash-resume, and
+> the UI.
 
 **The production bar** (verified against [ebook2audiobook](https://github.com/DrewThomasson/ebook2audiobook),
 audiblez, epub2tts, abogen, Pandrator): broad ingest (epub/mobi/pdf/docx + OCR for

--- a/tests/test_audiobook.py
+++ b/tests/test_audiobook.py
@@ -10,6 +10,7 @@ import pytest
 from services.audiobook import (
     AudiobookPlan,
     build_chapter_ffmetadata,
+    build_concat_list,
     build_m4b_cmd,
     parse_audiobook_script,
     synthesize_chapter,
@@ -106,6 +107,14 @@ def test_m4b_cmd_shape():
 def test_m4b_cmd_rejects_bad_bitrate():
     cmd = build_m4b_cmd("ffmpeg", "l", "m", "o", bitrate="; rm -rf /")
     assert cmd[cmd.index("-b:a") + 1] == "128k"   # falls back, no injection
+
+
+def test_concat_list_format_and_escaping():
+    out = build_concat_list(["/a/ch0.wav", "/weird/it's here.wav"])
+    lines = out.strip().split("\n")
+    assert lines[0] == "file '/a/ch0.wav'"
+    # Single quote escaped the ffmpeg way: ' -> '\''
+    assert lines[1] == r"file '/weird/it'\''s here.wav'"
 
 
 # ── Orchestration (stub synth) ───────────────────────────────────────────────


### PR DESCRIPTION
## What

Completes the **audiobook backend** (parity §R3). `POST /audiobook` renders each chapter through the active TTS engine, then muxes a chapterized **m4b**, streaming SSE progress — building directly on the parser + builders from #402.

## How

- **Synthesis**: each chapter → `services.audiobook.synthesize_chapter` (reuses `chunked_tts` split/crossfade + the shared `[pause …]` stitching) on the GPU pool. Per-chapter WAVs via `atomic_save_wav`.
- **Mux**: `build_chapter_ffmetadata` (FFMETADATA1 `[CHAPTER]` table) + new **`build_concat_list`** (concat-demuxer list, single-quote-escaped — no arg injection) + `build_m4b_cmd`, run via `run_ffmpeg`. **ffmpeg-gated**: emits an `error` event and stops if ffmpeg is absent (m4b is the only output).
- **Progress**: SSE `started` / `chapter` / `assembling` / `done` / `error`, recorded to `job_store` (best-effort).
- **Voice**: a compact resolver (locked/design/clone, mirroring `generation.py`) cached per id; OmniVoice native-model path + generic `TTSBackend` path.

## Verification

The reusable building blocks (parser, `synthesize_chapter`, FFMETADATA + m4b argv + concat-list) are **unit-tested** (15 tests, no model/ffmpeg execution). The new router glue (real TTS + ffmpeg + DB + SSE) can't be runtime-exercised in CI — it's thin and **import-checked** by the main-import endpoint tests. Like prior backend-first PRs, the live path wants a quick in-app check.

## Deferred (follow-ups)

epub/pdf/docx ingest (new dep), ACX `loudnorm` mastering, crash-resume, and the UI. `docs/competitive-analysis.md` §R3 updated per the docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Audiobook Synthesis Pipeline with SSE Progress (Wave 5)

**New Endpoint:** `POST /audiobook` renders each chapter of a Markdown script via the active TTS backend and produces a chapterized m4b with streaming Server-Sent Events progress.

### Synthesis Flowchart

```mermaid
flowchart TD
    A["Parse script into<br/>chapters/spans"] --> B{ffmpeg<br/>available?}
    B -->|No| C["Emit error SSE<br/>event"]
    B -->|Yes| D["Resolve voice profile<br/>to engine inputs"]
    D --> E["Emit 'started' SSE<br/>job_id, chapters"]
    E --> F["For each chapter:<br/>dispatch to GPU pool"]
    F --> G["synthesize_chapter:<br/>split text, render spans,<br/>apply crossfade/pause"]
    G --> H["atomic_save_wav<br/>chapter_NNN.wav"]
    H --> I["Emit 'chapter' SSE<br/>index, title, duration"]
    I --> J{More<br/>chapters?}
    J -->|Yes| F
    J -->|No| K["Emit 'assembling' SSE"]
    K --> L["Build FFMETADATA1<br/>chapter table"]
    L --> M["Build ffmpeg<br/>concat list<br/>+ quote escaping"]
    M --> N["run_ffmpeg mux<br/>to m4b"]
    N --> O["Emit 'done' SSE<br/>output name, duration"]
    O --> P["best-effort job_store<br/>record"]
    G -.->|Exception| Q["Emit 'error' SSE<br/>truncated message"]
    Q --> P
```

### Key Implementation Details

**Voice Resolution** (`_resolve_voice`): Maps voice-profile IDs to TTS engine inputs (ref_audio, ref_text, instruct, seed), supporting locked, design, and clone profile kinds. Returns all-None for engine defaults.

**Synth Binding** (`_build_synth`): Dispatches on backend type:
- **OmniVoiceBackend**: Returns `(resolve, get_model)` tuple; model is fetched asynchronously before threading to avoid GPU contention
- **Generic TTSBackend**: Returns direct `synth(text, voice_id)` callable with sample_rate

**Per-Chapter Rendering** (`synthesize_chapter`): 
- Splits long text spans via `chunked_tts` 
- Renders each chunk in specified voice via injected `synth` callback
- Crossfades chunks (default 50ms) and inserts inter-span pauses as silence
- Executed on `_gpu_pool` executor to avoid blocking async loop

**Chapter Muxing**:
- `build_chapter_ffmetadata`: FFMETADATA1 table for chapters
- `build_concat_list`: ffmpeg concat-demuxer list with single-quote escaping (`'` → `'\\''`) for safe path handling
- `build_m4b_cmd`: constructs ffmpeg argv; bitrate defaults to 128k

**Progress Streaming**:
- SSE events (`started`, `chapter`, `assembling`, `done`, `error`) emitted as `data: JSON\n\n`
- Job store records events best-effort (non-blocking; synthesis continues if job_store unavailable)
- ffmpeg absence gated with early error event (m4b is sole output format)

### API Changes

**New Model:** `AudiobookRequest` with fields `text`, `default_voice` (optional), `bitrate` (default "128k")

**New Function:** `async def audiobook_synthesize` returning `StreamingResponse` with event-stream media type

### Service Additions

**New Helper:** `build_concat_list(wav_paths)` → ffmpeg concat-list string with proper quote escaping

### Test Coverage

15 unit tests validate parser, chapter synthesis, FFMETADATA/concat-list/m4b argv builders, and quote escaping. Router glue import-checked in CI; live runtime path requires in-app verification.

### Deferred

- Ingest: epub/pdf/docx parsing
- Mastering: ACX loudness normalization
- Resilience: crash-resume
- UI: frontend audiobook creator

<!-- end of auto-generated comment: release notes by coderabbit.ai -->