### PR TITLE
feat(audiobook): Audiobook tab — script → plan → m4b (Wave 5 UI)

### DIFF
--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -1074,8 +1074,9 @@ path, mTLS/OAuth (overkill vs bearer + WireGuard), a second thin-client binary.
 > (`synthesize_chapter` + `chunked_tts`), and muxes a chapterized **m4b**
 > (FFMETADATA1 chapters). `POST /audiobook/plan` previews the plan;
 > `POST /audiobook` runs the synth job streaming SSE progress (ffmpeg-gated).
-> Deferred: epub/pdf/docx ingest, ACX `loudnorm` mastering, crash-resume, and
-> the UI.
+> A dedicated **Audiobook** tab (script editor → plan preview → streamed synth
+> → m4b player/download) ships in the frontend. Deferred: epub/pdf/docx ingest,
+> ACX `loudnorm` mastering, and crash-resume.
 
 **The production bar** (verified against [ebook2audiobook](https://github.com/DrewThomasson/ebook2audiobook),
 audiblez, epub2tts, abogen, Pandrator): broad ingest (epub/mobi/pdf/docx + OCR for

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ const VoiceGallery = lazy(() => import('./pages/VoiceGallery'));
 const SupportPage = lazy(() => import('./pages/SupportPage'));
 const TranscriptionsPage = lazy(() => import('./pages/Transcriptions'));
 const StoriesEditor = lazy(() => import('./components/StoriesEditor'));
+const AudiobookTab = lazy(() => import('./pages/AudiobookTab'));
 
 import Header from './components/Header';
 import NavRail from './components/NavRail';
@@ -166,7 +167,7 @@ function App() {
   const closeVoiceProfile = useAppStore(s => s.closeVoiceProfile);
   const hideSidebar = mode === 'launchpad' || mode === 'settings' || mode === 'voice' || mode === 'donate'
     || mode === 'queue' || mode === 'tools' || mode === 'projects' || mode === 'gallery' || mode === 'enterprise' || mode === 'transcriptions'
-    || mode === 'stories'
+    || mode === 'stories' || mode === 'audiobook'
     // Voice (studio) and Dub workspaces moved their saved voices /
     // projects + history into right-side panels; left sidebar dissolved.
     || mode === 'studio' || mode === 'dub';
@@ -1065,6 +1066,12 @@ function App() {
           <ErrorBoundary name="stories">
             <Suspense fallback={<LazyFallback />}>
               <StoriesEditor profiles={profiles} />
+            </Suspense>
+          </ErrorBoundary>
+        ) : mode === 'audiobook' ? (
+          <ErrorBoundary name="audiobook">
+            <Suspense fallback={<LazyFallback />}>
+              <AudiobookTab profiles={profiles} />
             </Suspense>
           </ErrorBoundary>
         ) : mode === 'donate' ? (

--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -1,0 +1,44 @@
+import { apiFetch } from './client';
+
+export interface AudiobookSpan {
+  voice_id: string | null;
+  text: string;
+  pause_ms_after: number;
+}
+export interface AudiobookChapter {
+  title: string;
+  char_count: number;
+  spans: AudiobookSpan[];
+}
+export interface AudiobookPlan {
+  chapters: AudiobookChapter[];
+  chapter_count: number;
+  char_count: number;
+}
+
+/** Parse a script into a chapter/span plan (pure preview, no synthesis). */
+export async function audiobookPlan(
+  body: { text: string; default_voice?: string | null },
+): Promise<AudiobookPlan> {
+  const res = await apiFetch('/audiobook/plan', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+/**
+ * Start the synth job. Returns the raw streaming Response; the caller reads
+ * `response.body` with a reader + the sseParse helpers. (apiFetch throws on a
+ * non-2xx status, so a returned Response is always a live stream.)
+ */
+export async function audiobookGenerate(
+  body: { text: string; default_voice?: string | null; bitrate?: string },
+): Promise<Response> {
+  return apiFetch('/audiobook', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/components/NavRail.jsx
+++ b/frontend/src/components/NavRail.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Globe, Fingerprint, Film, FolderOpen, Settings2, ArrowLeftRight,
-  Library, FileText, BookOpen,
+  Library, FileText, BookOpen, BookMarked,
 } from 'lucide-react';
 
 const ITEM_DEFS = [
@@ -10,6 +10,7 @@ const ITEM_DEFS = [
   { id: 'studio',        Icon: Fingerprint, tKey: 'voice',       accent: '#d3869b' },
   { id: 'dub',           Icon: Film,        tKey: 'dub',         accent: '#fe8019' },
   { id: 'stories',       Icon: BookOpen,    tKey: 'stories',     accent: '#fabd2f' },
+  { id: 'audiobook',     Icon: BookMarked,  tKey: 'audiobook',   accent: '#8ec07c' },
   { id: 'gallery',       Icon: Library,     tKey: 'gallery',     accent: '#b8bb26' },
   { id: 'transcriptions',Icon: FileText,    tKey: 'transcripts', accent: '#d3869b' },
   { id: 'projects',      Icon: FolderOpen,  tKey: 'omnidrive',   accent: '#83a598' },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -104,9 +104,26 @@
     "omnidrive": "OmniDrive",
     "settings": "Settings",
     "stories": "Stories",
+    "audiobook": "Audiobook",
     "move_rail_right": "Move rail to the right",
     "move_rail_left": "Move rail to the left",
     "flip_rail": "Flip rail side"
+  },
+  "audiobook": {
+    "title": "Audiobook",
+    "subtitle": "Turn a chapter-delimited script into a chapterized m4b audiobook.",
+    "script": "Script",
+    "script_placeholder": "# Chapter One\nOnce upon a time… [pause 500ms] the end.\n\n# Chapter Two\n[voice:narrator] And so it continued.",
+    "default_voice": "Default voice",
+    "engine_default": "Engine default",
+    "preview_plan": "Preview plan",
+    "create": "Create audiobook",
+    "plan_heading": "Plan — {{count}} chapter(s)",
+    "chapter_meta": "{{spans}} span(s) · {{chars}} chars",
+    "synthesizing": "Synthesizing chapter {{current}} of {{total}} {{title}}",
+    "assembling": "Assembling the m4b…",
+    "ready": "Audiobook ready",
+    "download": "Download m4b"
   },
   "launchpad": {
     "greeting": "hello there",

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -1,0 +1,165 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BookMarked, Loader, Download } from 'lucide-react';
+
+import { audiobookPlan, audiobookGenerate } from '../api/audiobook';
+import { audioUrl } from '../api/generate';
+import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
+
+/**
+ * AudiobookTab — turn a chapter-delimited script into a chapterized m4b.
+ *
+ * Markdown `# H1` headings delimit chapters; inline `[voice:NAME]` and
+ * `[pause …]` are honoured by the backend parser. "Preview plan" shows the
+ * parsed chapters; "Create" streams synthesis progress and offers the m4b.
+ */
+export default function AudiobookTab({ profiles = [] }) {
+  const { t } = useTranslation();
+  const [text, setText] = useState('');
+  const [defaultVoice, setDefaultVoice] = useState('');
+  const [plan, setPlan] = useState(null);
+  const [planLoading, setPlanLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [progress, setProgress] = useState(null); // {current,total,title,assembling}
+  const [output, setOutput] = useState('');
+  const [error, setError] = useState('');
+  const abortRef = useRef(false);
+
+  const onPreview = useCallback(async () => {
+    setError('');
+    setPlanLoading(true);
+    try {
+      setPlan(await audiobookPlan({ text, default_voice: defaultVoice || null }));
+    } catch (e) {
+      setError(e?.message || String(e));
+    } finally {
+      setPlanLoading(false);
+    }
+  }, [text, defaultVoice]);
+
+  const onCreate = useCallback(async () => {
+    setError('');
+    setOutput('');
+    setProgress({ current: 0, total: 0 });
+    setGenerating(true);
+    abortRef.current = false;
+    try {
+      const res = await audiobookGenerate({ text, default_voice: defaultVoice || null });
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (!abortRef.current) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const { lines, rest } = splitSSEBuffer(buffer);
+        buffer = rest;
+        for (const line of lines) {
+          const evt = parseSSELine(line);
+          if (!evt) continue;
+          if (evt.type === 'started') {
+            setProgress({ current: 0, total: evt.chapters });
+          } else if (evt.type === 'chapter') {
+            setProgress({ current: evt.index + 1, total: evt.total, title: evt.title });
+          } else if (evt.type === 'assembling') {
+            setProgress((p) => ({ ...(p || {}), assembling: true }));
+          } else if (evt.type === 'done') {
+            setOutput(evt.output);
+          } else if (evt.type === 'error') {
+            setError(evt.error || 'synthesis failed');
+          }
+        }
+      }
+    } catch (e) {
+      setError(e?.message || String(e));
+    } finally {
+      setGenerating(false);
+    }
+  }, [text, defaultVoice]);
+
+  const busy = planLoading || generating;
+  const canRun = text.trim().length > 0 && !busy;
+
+  return (
+    <div className="audiobook-tab" style={{ maxWidth: 860, margin: '0 auto', padding: '1.5rem' }}>
+      <h2 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <BookMarked size={20} /> {t('audiobook.title')}
+      </h2>
+      <p className="muted">{t('audiobook.subtitle')}</p>
+
+      <label className="field-label">{t('audiobook.script')}</label>
+      <textarea
+        className="input-base"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={t('audiobook.script_placeholder')}
+        rows={14}
+        style={{ width: '100%', fontFamily: 'monospace' }}
+        aria-label={t('audiobook.script')}
+      />
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center', margin: '12px 0', flexWrap: 'wrap' }}>
+        <label className="field-label" style={{ margin: 0 }}>{t('audiobook.default_voice')}</label>
+        <select
+          className="input-base"
+          value={defaultVoice}
+          onChange={(e) => setDefaultVoice(e.target.value)}
+          aria-label={t('audiobook.default_voice')}
+        >
+          <option value="">{t('audiobook.engine_default')}</option>
+          {profiles.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+
+        <button className="btn" onClick={onPreview} disabled={!canRun}>
+          {planLoading ? <Loader size={14} className="spin" /> : null} {t('audiobook.preview_plan')}
+        </button>
+        <button className="btn btn-primary" onClick={onCreate} disabled={!canRun}>
+          {generating ? <Loader size={14} className="spin" /> : null} {t('audiobook.create')}
+        </button>
+      </div>
+
+      {error && <div className="error-banner" role="alert">{error}</div>}
+
+      {generating && progress && (
+        <div className="audiobook-progress" role="status" aria-live="polite">
+          {progress.assembling
+            ? t('audiobook.assembling')
+            : t('audiobook.synthesizing', {
+                current: progress.current, total: progress.total,
+                title: progress.title || '',
+              })}
+        </div>
+      )}
+
+      {output && (
+        <div className="audiobook-done" style={{ margin: '16px 0' }}>
+          <div style={{ marginBottom: 8 }}>✅ {t('audiobook.ready')}</div>
+          <audio controls src={audioUrl(output)} style={{ width: '100%' }} />
+          <div style={{ marginTop: 8 }}>
+            <a className="btn" href={audioUrl(output)} download={output}>
+              <Download size={14} /> {t('audiobook.download')}
+            </a>
+          </div>
+        </div>
+      )}
+
+      {plan && (
+        <div className="audiobook-plan" style={{ marginTop: 16 }}>
+          <h3>{t('audiobook.plan_heading', { count: plan.chapter_count })}</h3>
+          <ol>
+            {plan.chapters.map((c, i) => (
+              <li key={i} style={{ marginBottom: 4 }}>
+                <strong>{c.title}</strong>{' '}
+                <span className="muted">
+                  {t('audiobook.chapter_meta', { spans: c.spans.length, chars: c.char_count })}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/test/sseParse.test.js
+++ b/frontend/src/test/sseParse.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
+
+describe('splitSSEBuffer', () => {
+  it('returns complete lines and keeps the trailing partial as rest', () => {
+    const { lines, rest } = splitSSEBuffer('a\nb\nc-partial');
+    expect(lines).toEqual(['a', 'b']);
+    expect(rest).toBe('c-partial');
+  });
+
+  it('a trailing newline yields an empty rest', () => {
+    const { lines, rest } = splitSSEBuffer('x\ny\n');
+    expect(lines).toEqual(['x', 'y']);
+    expect(rest).toBe('');
+  });
+
+  it('handles an empty buffer', () => {
+    expect(splitSSEBuffer('')).toEqual({ lines: [], rest: '' });
+  });
+});
+
+describe('parseSSELine', () => {
+  it('parses a data line (with the conventional space)', () => {
+    expect(parseSSELine('data: {"type":"chapter","index":0}')).toEqual({ type: 'chapter', index: 0 });
+  });
+
+  it('parses a data line without the space', () => {
+    expect(parseSSELine('data:{"type":"done"}')).toEqual({ type: 'done' });
+  });
+
+  it('ignores non-data lines and blanks', () => {
+    expect(parseSSELine('')).toBeNull();
+    expect(parseSSELine(':keepalive')).toBeNull();
+    expect(parseSSELine('event: ping')).toBeNull();
+    expect(parseSSELine('data: ')).toBeNull();
+  });
+
+  it('returns null on malformed JSON rather than throwing', () => {
+    expect(parseSSELine('data: {not json')).toBeNull();
+  });
+});

--- a/frontend/src/utils/sseParse.js
+++ b/frontend/src/utils/sseParse.js
@@ -1,0 +1,38 @@
+// Minimal helpers for reading a POST Server-Sent-Events stream via
+// fetch() + response.body.getReader() (EventSource is GET-only, so it can't
+// be used for our POST /audiobook stream). Pure + unit-tested so the
+// buffer/line handling — the easy thing to get subtly wrong — is verified.
+
+/**
+ * Split an accumulated decoded-text buffer into complete lines plus the
+ * trailing (possibly incomplete) remainder. Feed the remainder back in with
+ * the next chunk.
+ *
+ * @param {string} buffer
+ * @returns {{ lines: string[], rest: string }}
+ */
+export function splitSSEBuffer(buffer) {
+  const parts = (buffer || '').split('\n');
+  const rest = parts.pop() ?? '';   // last part has no trailing newline yet
+  return { lines: parts, rest };
+}
+
+/**
+ * Parse one SSE line into its JSON event object, or null when the line isn't
+ * a (well-formed) ``data:`` line. Tolerates ``data:`` with or without the
+ * conventional trailing space, blank lines, and malformed JSON (returns null
+ * rather than throwing, so one bad frame can't kill the read loop).
+ *
+ * @param {string} line
+ * @returns {object | null}
+ */
+export function parseSSELine(line) {
+  if (typeof line !== 'string' || !line.startsWith('data:')) return null;
+  const payload = line.slice(5).trim();   // after 'data:'
+  if (!payload) return null;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

The **Audiobook UI** for the backend shipped in #402/#403 — a dedicated tab that takes the audiobook vertical end-to-end for users.

- **`pages/AudiobookTab.jsx`** — script textarea + default-voice picker (reuses the app's `profiles`), **Preview plan** (`POST /audiobook/plan` → chapter list) and **Create** (`POST /audiobook` → reads the SSE stream → per-chapter progress + "assembling" → an `<audio>` player + m4b download via the `/audio` static mount).
- **`api/audiobook.ts`** — typed `audiobookPlan()` + `audiobookGenerate()` (returns the raw streaming `Response`).
- **`utils/sseParse.js`** — pure `splitSSEBuffer` / `parseSSELine` helpers for reading a **POST** event-stream (EventSource is GET-only). The buffer/line handling is the easy thing to get subtly wrong, so it's **unit-tested**.
- **NavRail + App.jsx** wiring (lazy tab, `hideSidebar`); i18n keys in `en.json`.

## Verification

All strings go through i18n (CJK gate green). **7 new SSE-parser tests**; full vitest **326** + `vite build` green. The page itself runs in the Tauri webview so it can't be runtime-exercised in CI — like the AEC UI, it wants a quick in-app pass (open the **Audiobook** tab, paste a `# Chapter`-delimited script, Preview, Create, confirm the m4b plays/downloads).

## Notes

`docs/competitive-analysis.md` §R3 updated. Deferred (follow-ups): epub/pdf/docx ingest, ACX `loudnorm` mastering, crash-resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Audiobook Tab — Script → Plan → M4B (Wave 5 UI)

This PR introduces a complete frontend Audiobook UI workflow that connects end-to-end with the audiobook backend. Users can paste a chapter-delimited script, preview the parsed plan, trigger synthesis, monitor per-chapter progress, and download the resulting m4b file.

### UI Layout

```
┌──────────────────────────────────────────────────────────┐
│ 📖 Audiobook                                              │
│ Turn a chapter-delimited script into a chapterized m4b  │
│                                                           │
│ Script                                                   │
│ ┌──────────────────────────────────────────────────────┐ │
│ │ # Chapter One                                        │ │
│ │ Once upon a time… [pause 500ms] the end.           │ │
│ │                                                      │ │
│ │ # Chapter Two                                        │ │
│ │ [voice:narrator] And so it continued.              │ │
│ └──────────────────────────────────────────────────────┘ │
│                                                           │
│ Default voice  [Engine default ▼] [Preview] [Create ◆]  │
│                                                           │
│ 📊 Synthesizing chapter 2 of 3 "Chapter Two"            │
│    (→ Assembling the m4b…)                              │
│                                                           │
│ ✅ Audiobook ready                                        │
│    [▶️ Audio player with controls] [⬇️ Download m4b]     │
│                                                           │
│ Plan — 2 chapter(s)                                      │
│  1. Chapter One    1 span(s) · 42 chars                 │
│  2. Chapter Two    1 span(s) · 28 chars                 │
└──────────────────────────────────────────────────────────┘
```

### Generation Workflow

```mermaid
flowchart LR
    A["Script input +<br/>Default voice"] -->|Preview Plan| B["POST /audiobook/plan"]
    B -->|JSON response| C["Show parsed chapters<br/>titles, span counts,<br/>char counts"]
    A -->|Create| D["POST /audiobook"]
    D -->|SSE stream| E["Parse SSE events"]
    E -->|started| F["Show total chapters"]
    E -->|chapter| G["Update progress<br/>current/total/title"]
    E -->|assembling| H["Flag assembling state"]
    E -->|done| I["Set output m4b path"]
    E -->|error| J["Surface error"]
    I --> K["Render audio player<br/>+ download link"]
    H --> K
```

### Key Changes

**pages/AudiobookTab.jsx** — New 165-line component with:
- Script textarea (markdown `# H1` chapter delimiters, inline `[voice:NAME]` and `[pause …]` tags)
- Default voice dropdown (populated from app profiles)
- "Preview plan" button → calls `audiobookPlan()` → displays parsed chapters with metadata
- "Create" button → calls `audiobookGenerate()` → reads SSE stream with `ReadableStream.getReader()`, increments progress on chapter events, flags assembling state, renders audio player + download link
- Progress indicator showing synthesis status and chapter title
- Error banner for failed requests

**api/audiobook.ts** — New typed API layer with:
- `AudiobookSpan`, `AudiobookChapter`, `AudiobookPlan` TypeScript interfaces
- `audiobookPlan(body)` — POST to `/audiobook/plan`, returns parsed JSON plan
- `audiobookGenerate(body)` — POST to `/audiobook`, returns raw streaming `Response` for caller to parse

**utils/sseParse.js** — New utility helpers for parsing POST SSE streams (EventSource is GET-only):
- `splitSSEBuffer(buffer)` — splits accumulated text into newline-delimited lines + remainder
- `parseSSELine(line)` — parses `data:` lines into JSON objects, returns `null` for malformed/non-data lines

**test/sseParse.test.js** — 7 new Vitest tests validating buffer splitting and line parsing edge cases (trailing partials, blank lines, malformed JSON)

**App.jsx** — Lazy-loads `AudiobookTab` component; renders in dedicated branch when `mode === 'audiobook'` with sidebar hidden

**NavRail.jsx** — Adds `BookMarked` icon import; new navigation item with key `nav.audiobook`

**i18n/locales/en.json** — 17 new translation keys:
- `nav.audiobook` (navigation label)
- `audiobook.*` group: title, subtitle, script, placeholders, button labels, progress messages, download label

**docs/competitive-analysis.md** — Updated §R3 (Audiobook/stories creator) status to reflect frontend completion with dedicated tab (deferred items: epub/pdf/docx ingest, ACX loudnorm mastering, crash-resume)

### Verification

- All user-facing strings via i18n (CJK compatibility gate passed)
- 7 new SSE parser unit tests
- Vitest: 326 tests passing
- Vite build: succeeds
- Manual verification required: open Audiobook tab in Tauri webview, paste script, Preview → Create → confirm playback/download

<!-- end of auto-generated comment: release notes by coderabbit.ai -->