### PR TITLE
fix(ui): UI scale via transform:scale, not zoom — fixes WebKitGTK black bands

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -959,7 +959,7 @@ function App() {
         hideSidebar ? 'sidebar-hidden' : '',
         navRailSide === 'right' ? 'rail-right' : '',
       ].filter(Boolean).join(' ')}
-      style={{ zoom: uiScale, '--ui-scale': uiScale }}
+      style={{ '--ui-scale': uiScale }}
     >
       {pendingTrimFile && (
         <ErrorBoundary name="audio-trimmer">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -192,11 +192,17 @@ samp,
 
 /* ═══ LAYOUT ═══ */
 .app-container {
-  /* UI scale is applied as `zoom: var(--ui-scale)`. zoom renders from the
-     top-left, so a 100%-wide box shrinks below 100% at scale <1 (leaving an
-     empty margin) and overflows at >1. Size the box to 1/scale of the viewport
-     so `declared × zoom` always equals the viewport and it fills exactly. */
+  /* UI scale is applied as `transform: scale(var(--ui-scale))` (NOT `zoom`).
+     CSS `zoom` is honoured by Chromium (the macOS/Windows webview) but IGNORED
+     by WebKitGTK (the Linux webview) — there the `/scale` sizing below shrank
+     the shell with no matching magnification, leaving black bands on the right
+     and bottom (cross-platform default-parity P0). `transform: scale` scales
+     identically on every engine and doesn't alter how `vw`/`vh` resolve, so
+     `declared (100vw/scale) × scale` always equals the viewport and fills
+     exactly. transform-origin keeps it anchored to the top-left corner. */
   width: calc(100vw / var(--ui-scale, 1));
+  transform: scale(var(--ui-scale, 1));
+  transform-origin: top left;
   max-width: none;
   display: grid;
   /* [rail 48px] [sidebar 180–220] [main 1fr] */


### PR DESCRIPTION
## Bug

At the default **uiScale of 1.3**, the entire app shell rendered at ~77% of the window on **Linux**, leaving black bands on the right and bottom (reported via screenshots on the Audiobook + Projects tabs — it's **global**, not tab-specific).

## Root cause

UI scale was applied as CSS **`zoom`**, with the shell sized to `100vw/scale × 100vh/scale` so `declared × zoom` would equal the viewport. But **`zoom` is honoured by Chromium (mac/Windows webview) and ignored by WebKitGTK (Linux webview)** — so on Linux the `/scale` shrink landed with no magnification → `1/1.3 ≈ 77%` fill.

Per the project's strict rule, a **default** that breaks on a platform is a P0.

## Fix

Swap `zoom` → **`transform: scale(var(--ui-scale))`** + `transform-origin: top left`. `transform: scale` magnifies identically on every engine and doesn't alter `vw`/`vh` resolution, so `(100vw/scale) × scale` fills the viewport exactly. Inline `zoom` dropped; the `--ui-scale` CSS var is still set for the transform to read.

- `frontend/src/index.css` — `.app-container`: add `transform: scale(...)` + `transform-origin`.
- `frontend/src/App.jsx` — main container inline style: `zoom` → just `--ui-scale`.

## Verification (real WebKitGTK webview)

Launched the Tauri **debug build** against the live frontend; confirmed this window's persisted `localStorage uiScale = 1.3` (the exact failing scale). **Result: shell fills edge-to-edge** — header, content, and logs footer all reach the window edges; no black bands.

Scope note: the first-run splash/wizard wrappers still use `zoom` (transient screens, render fine at 1× on Linux); converting them is a minor separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fix UI scaling on WebKitGTK (Linux webview) by replacing CSS `zoom` with `transform: scale()`. On WebKitGTK, `zoom` is ignored, causing the app shell to render at ~77% of the window at the default `uiScale = 1.3`, leaving black bands on the right and bottom. `transform: scale()` behaves consistently across all engines (Chromium on macOS/Windows, WebKitGTK on Linux).

## Changes

**frontend/src/index.css**
- `.app-container`: Replace inline `zoom` mechanism with `transform: scale(var(--ui-scale, 1))` and `transform-origin: top left`
- Keep existing width formula `calc(100vw / var(--ui-scale, 1))` unchanged
- Add explanatory comments detailing the cross-engine differences: `zoom` is honored by Chromium but ignored by WebKitGTK; `transform: scale` scales identically on all engines and doesn't alter viewport unit resolution

**frontend/src/App.jsx**
- `.app-container` (main shell): Remove inline `zoom: uiScale` style property
- Retain `style={{ '--ui-scale': uiScale }}` to feed the CSS variable to the transform

Note: Bootstrap splash and setup wizard wrappers (`style={{ zoom: uiScale }}`) remain unchanged; converting them is deferred to a separate follow-up.

## Behavior

### Before (WebKitGTK broken)
```
Viewport (1280×800)                          Rendered output (WebKitGTK)
┌──────────────────────────┐                 ┌────────────────────┐
│ Header                   │                 │ Header      (77%)   │█ (black band)
│                          │                 │                    │█
│ Content area             │                 │ Content      (77%) │█
│                          │                 │                    │█
│ Logs Footer              │                 │ Logs Footer  (77%) │█
└──────────────────────────┘                 └────────────────────┘█
                                             ████████████████████████
```
At uiScale = 1.3: shell sized to (100vw÷1.3) × (100vh÷1.3) ≈ 77%, then `zoom: 1.3` applied — but ignored on WebKitGTK, leaving shell at 77%.

### After (all engines consistent)
```
Viewport (1280×800)
┌──────────────────────────┐
│ Header                   │ ← rendered at 1.3× scale, fills viewport
│                          │
│ Content area             │ ← transform: scale(1.3) applied from top-left
│                          │
│ Logs Footer              │ ← no black bands, edge-to-edge
└──────────────────────────┘
```
Shell sized to (100vw÷1.3) × (100vh÷1.3), then scaled up 1.3× from top-left corner → fills viewport exactly on all engines.

## Verification

Tested on WebKitGTK webview (Tauri debug build, localStorage uiScale = 1.3): shell now fills edge-to-edge with header, content, and logs footer reaching window edges; no black bands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->