### PR TITLE
docs(docker): maintain Docker Hub overview in-repo + auto-sync on main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,9 @@
 # (Docker Hub push gated on the DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets;
 # if unset the build still pushes to GHCR.)
 #
+# On main pushes the Docker Hub repository overview is also synced from
+# deploy/dockerhub-overview.md (source of truth for the hub.docker.com page).
+#
 # NOTE: the Docker image is the headless web-server build of OmniVoice (FastAPI
 # backend + pre-built React frontend served over HTTP).  The Tauri desktop
 # auto-updater and its update-channel toggle are desktop-only features; they do
@@ -111,3 +114,16 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Sync the Docker Hub repository overview from deploy/dockerhub-overview.md.
+      # Only on main pushes (the overview tracks the rolling preview) and only
+      # when Docker Hub creds are present, mirroring the push gating above.
+      - name: Update Docker Hub description
+        if: steps.dockerhub.outputs.enabled == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          short-description: "Local ElevenLabs alternative: voice cloning, design & video dubbing in 646 languages. No API keys."
+          readme-filepath: ./deploy/dockerhub-overview.md

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -1,0 +1,129 @@
+# OmniVoice Studio
+
+**The open-source ElevenLabs alternative.** Real-time dictation, zero-shot voice
+cloning, and cinematic video dubbing — fully local, no API keys, no accounts.
+**646 languages.**
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/palashdeb/omnivoice-studio?logo=docker&color=2496ED)](https://hub.docker.com/r/palashdeb/omnivoice-studio)
+[![Image Size](https://img.shields.io/docker/image-size/palashdeb/omnivoice-studio/latest?logo=docker&label=image%20size)](https://hub.docker.com/r/palashdeb/omnivoice-studio/tags)
+[![GitHub Stars](https://img.shields.io/github/stars/debpalash/OmniVoice-Studio?logo=github&color=f59e0b)](https://github.com/debpalash/OmniVoice-Studio)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](https://github.com/debpalash/OmniVoice-Studio/blob/main/LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/bzQavDfVV9)
+
+![OmniVoice Studio — the open-source ElevenLabs alternative](https://raw.githubusercontent.com/debpalash/OmniVoice-Studio/main/.github/assets/social-preview.png)
+
+OmniVoice runs entirely on your own hardware (CUDA / MPS / ROCm / CPU
+auto-detect) — nothing is sent to the cloud. This image is the **headless
+web-server build**: a FastAPI backend serving a pre-built React UI over HTTP, so
+you can run it on a homelab box, a GPU server, or anywhere Docker runs and open
+the UI in a browser.
+
+> The Tauri desktop app's auto-updater and update-channel toggle are
+> **desktop-only** and do not apply to this image — to update, pull a newer tag
+> and recreate the container.
+
+---
+
+## Quick start (CPU)
+
+```bash
+docker run -d --name omnivoice \
+  -p 127.0.0.1:3900:3900 \
+  -v omnivoice-data:/app/omnivoice_data \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  palashdeb/omnivoice-studio:latest
+```
+
+Open <http://localhost:3900>. The first run downloads a few GB of model weights —
+follow `docker logs -f omnivoice` to watch progress.
+
+## Quick start (NVIDIA GPU)
+
+```bash
+docker run -d --name omnivoice --gpus all \
+  -p 127.0.0.1:3900:3900 \
+  -v omnivoice-data:/app/omnivoice_data \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  palashdeb/omnivoice-studio:latest
+```
+
+GPU mode needs the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+on the host. There's also a Compose file in the repo with `cpu` / `gpu` profiles
+— see the [Docker install guide](https://github.com/debpalash/OmniVoice-Studio/blob/main/docs/install/docker.md).
+
+---
+
+## Image tags
+
+| Tag | What you get |
+|-----|--------------|
+| `:latest` | **Rolling preview** — latest commit on `main` (always one patch ahead of the last release). This is the preview channel; pin `:stable` for production. |
+| `:stable` | Most recent versioned release (updated on every `v*` git tag) |
+| `:0.3.6` | Exact release version |
+| `:0.3` | Latest patch within the `0.3` minor |
+| `:main` | Alias of the same rolling `main` build as `:latest` |
+| `:sha-xxxxxxx` | A specific commit (produced by manual workflow dispatch) |
+
+`main` always carries *last release + 1 patch*, so `:latest` (preview)
+version-sorts above `:stable` — upgrades flow naturally. The same images and tags
+are mirrored on GHCR at
+[`ghcr.io/debpalash/omnivoice-studio`](https://github.com/debpalash/OmniVoice-Studio/pkgs/container/omnivoice-studio).
+
+---
+
+## What's inside
+
+- **🎙️ Voice Cloning** — a 3-second clip mirrors any voice, zero-shot, in 646 languages.
+- **🎨 Voice Design** — dial in gender, age, accent, pitch, speed, emotion, and dialect.
+- **🎬 Video Dubbing** — YouTube URL or file → transcribe → translate → re-voice → MP4.
+- **📖 Audiobook & long-form** — script → plan → loudness-normalized M4B with chapters, metadata, and cover art.
+- **🔊 Vocal Isolation** — Demucs splits speech from music and keeps the background.
+- **👥 Speaker Diarization** — Pyannote + WhisperX auto-identify who said what.
+- **📦 Batch Queue** — drop 50 videos and walk away; per-job progress.
+- **🤖 MCP Server** — drive OmniVoice from Claude, Cursor, or any MCP client.
+- **🛡️ AI Watermark** — invisible AudioSeal (Meta) marking that survives compression.
+- **⚡ GPU Auto-Detect** — CUDA · MPS · ROCm · CPU, with auto-offload on ≤8 GB cards.
+- **🧩 Extensible** — subclass `TTSBackend` to add any engine in ~50 lines.
+
+Multiple TTS engines ship out of the box (IndexTTS, CosyVoice, Supertonic-3, and
+more), auto-detected and selectable in Settings.
+
+---
+
+## Volumes worth persisting
+
+| Mount | Purpose |
+|-------|---------|
+| `omnivoice-data:/app/omnivoice_data` | Project DB, user voices, settings, encrypted HF token — survives upgrades |
+| `~/.cache/huggingface:/root/.cache/huggingface` | HF model cache — reuse the host cache to skip multi-GB re-downloads |
+
+---
+
+## Configuration & networking
+
+- The container binds uvicorn to `0.0.0.0` internally; the host-side
+  `127.0.0.1:3900:3900` mapping is what keeps it loopback-only. Change the
+  mapping to `0.0.0.0:3900:3900` for LAN access.
+- Behind a reverse proxy on a different origin, set
+  `-e OMNIVOICE_PUBLIC_API_BASE=https://api.your-host.example` so the UI targets
+  the right API base (works on the prebuilt image; no rebuild needed).
+- The image ships with `OMNIVOICE_SERVER_MODE=1`, which relaxes the desktop-only
+  loopback-origin gate so the admin UI works through Docker's NAT. Set it to `0`
+  if you front the container with your own loopback auth proxy.
+
+> **Security:** OmniVoice ships **no authentication**. Anything that can reach the
+> URL can use the app. Before exposing it beyond localhost, put it behind a
+> reverse proxy with auth (Caddy `basic_auth`, nginx + htpasswd) or a private
+> overlay (Tailscale, ZeroTier).
+
+---
+
+## Links
+
+- **Source & full install docs:** <https://github.com/debpalash/OmniVoice-Studio>
+- **Docker guide:** <https://github.com/debpalash/OmniVoice-Studio/blob/main/docs/install/docker.md>
+- **Troubleshooting:** <https://github.com/debpalash/OmniVoice-Studio/blob/main/docs/install/troubleshooting.md>
+- **Community / support:** [Discord](https://discord.gg/bzQavDfVV9)
+
+OmniVoice Studio is in active beta and licensed under AGPL-3.0.


### PR DESCRIPTION
## What

The Docker Hub overview at [`palashdeb/omnivoice-studio`](https://hub.docker.com/r/palashdeb/omnivoice-studio) was maintained by hand and had gone stale (stuck at the `sha-f86beb0` era — no tag table, no audiobook/long-form, no Supertonic-3, no server-mode networking notes).

This makes the overview a maintained, in-repo artifact:

- **`deploy/dockerhub-overview.md`** — source of truth for the hub.docker.com page.
- **`.github/workflows/docker.yml`** — adds a `peter-evans/dockerhub-description@v4` step after build-and-push that syncs the overview on `main` pushes.

## Gating

The sync step is gated identically to the existing Docker Hub *image* push: only runs `if` `DOCKERHUB_TOKEN` is set **and** it's a push to `main`. Forks and GHCR-only runs are unaffected.

## Overview content

- `:latest` = rolling preview / `:stable` = release tag-semantics table (matches `docs/install/docker.md`)
- Headless web-build clarification (Tauri auto-updater is desktop-only)
- CPU + GPU quick-start using the `palashdeb/...` image name
- Current feature set incl. **Audiobook / long-form M4B**, MCP server, Supertonic-3
- `OMNIVOICE_PUBLIC_API_BASE` / `OMNIVOICE_SERVER_MODE` networking + no-auth security note
- shields badges (pulls, image size, stars, license, Discord)
- short description: 98/100 chars

## Notes for the maintainer

- **Token scope:** the existing `DOCKERHUB_TOKEN` is used today only for image *push*. Updating the description needs a PAT with **read & write** scope — if the current token is push-only the new step will 401 (the image push is unaffected). Regenerate the PAT if so.
- The page won't change until this merges to `main` and the Docker workflow runs; thereafter it re-syncs on every main push.
- Account avatar / per-repo logo are **not** covered here — those are manual Docker Hub UI actions (personal-account avatar = Gravatar; per-repo logo requires an org account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Adds automated Docker Hub repository description syncing and clarifies the headless nature of the Docker image in CI/CD documentation.

## Changes

**Workflow Enhancement (.github/workflows/docker.yml)**
- Added clarifying comments documenting that the Docker image is the **headless web-server build** (FastAPI + React UI over HTTP), not the desktop Tauri app. The Tauri auto-updater and update-channel toggle are desktop-only and do not apply to this image.
- Integrated automated Docker Hub description sync using `peter-evans/dockerhub-description@v4` action:
  - Triggers after successful image build-and-push on pushes to `main`
  - Reads source-of-truth from `deploy/dockerhub-overview.md`
  - Gated by Docker Hub credentials presence (same as image push; unset credentials don't block the workflow)
  - Updates the repository overview and short description on Docker Hub

**New Documentation (deploy/dockerhub-overview.md)**
- Comprehensive Docker Hub overview authored as in-repo source of truth
- Includes Docker pull/image size/stars/license/Discord shields
- CPU and NVIDIA GPU quick-start examples with `docker run` commands
- Image tag documentation: `:latest` (rolling preview), `:stable` (release), `:0.3.x` (versioned), `:main` (alias), `:sha-*` (commit-specific)
- Feature enumeration: voice cloning, voice design, video dubbing, audiobook/long-form M4B, vocal isolation, speaker diarization, batch queue, MCP server, AI watermark, GPU auto-detect, extensibility
- Volume mounting guidance for persistent project data and Hugging Face cache
- Networking/configuration notes: loopback binding, `OMNIVOICE_PUBLIC_API_BASE` for reverse proxy, `OMNIVOICE_SERVER_MODE` behavior
- Explicit security advisory: image ships with **no authentication**; recommends reverse proxy with auth (Caddy basic_auth, nginx + htpasswd) or private overlay (Tailscale, ZeroTier) before exposing beyond localhost
- Links to GitHub repo, Docker install guide, troubleshooting, and Discord community

## Behavior Flow

```mermaid
graph LR
    A[Push to main] --> B{Credentials present?}
    B -->|Yes| C[Build & push image]
    B -->|No| D[Build & push to GHCR only]
    C --> E{Event is push to main?}
    E -->|Yes| F[Sync deploy/dockerhub-overview.md to Docker Hub]
    E -->|No| G[End]
    D --> G
    F --> G
```

## Notes

- Docker Hub token must have read & write permissions (PAT); push-only tokens will cause 401 error on the new sync step but will not block image push
- Account avatar and per-repo logo must be updated manually in Docker Hub UI
- Forks and GHCR-only runs (without Docker Hub credentials) are unaffected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->