### PR TITLE
feat(audiobook): text + EPUB import → auto-chapter (PR 4/8)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -53,6 +53,32 @@ def audiobook_plan(req: AudiobookPlanRequest) -> dict:
 _COVER_MAX_BYTES = 8 * 1024 * 1024
 
 
+@router.post("/audiobook/import")
+async def audiobook_import(file: UploadFile = File(...)) -> dict:
+    """Import a ``.txt``/``.md``/``.epub`` into a chapter-delimited script.
+
+    EPUB is parsed in spine order (stdlib only, local); plain text gets ``# ``
+    headings inserted ahead of obvious chapter-title lines. Returns the script
+    text (for the editor) + the resulting chapter count."""
+    from services.longform_import import chapterize_plaintext, epub_to_chapter_script
+
+    name = (file.filename or "").lower()
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="empty file")
+    if name.endswith(".epub"):
+        try:
+            script = epub_to_chapter_script(data)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=f"couldn't parse EPUB: {e}")
+    else:
+        script = chapterize_plaintext(data.decode("utf-8", "ignore"))
+    if not script.strip():
+        raise HTTPException(status_code=400, detail="no text found in the file")
+    plan = parse_audiobook_script(script)
+    return {"text": script, "chapters": plan.chapter_count}
+
+
 @router.post("/audiobook/cover")
 async def audiobook_cover(cover: UploadFile = File(...)) -> dict:
     """Upload a cover image; returns a server-side ``path`` to pass back as

--- a/backend/services/longform_import.py
+++ b/backend/services/longform_import.py
@@ -1,0 +1,168 @@
+"""Import plain text / EPUB into the chapter-delimited script the audiobook
+parser understands.
+
+Both helpers are pure (bytes/str in, script-str out) so they're unit-tested
+without a server. EPUB parsing is **stdlib only** (zipfile + ElementTree +
+html.parser) — no new dependency, no network, consistent with the local-first
+guarantee. The output is the same ``# Heading`` + body grammar
+:func:`services.audiobook.parse_audiobook_script` already consumes, so import is
+just a front door onto the existing pipeline.
+"""
+
+from __future__ import annotations
+
+import io
+import posixpath
+import re
+import zipfile
+from html.parser import HTMLParser
+from xml.etree import ElementTree as ET
+
+# A line that *starts* with a chapter keyword and is short enough to be a title
+# (not a sentence that happens to begin with "Chapter"). Anchored, no ambiguous
+# quantifiers → ReDoS-safe and applied per-line (short input) anyway.
+_CH_RE = re.compile(r"^(?:chapter|part|book|prologue|epilogue|section)\b", re.IGNORECASE)
+# Already-present Markdown H1 — if the text has any, we leave it untouched.
+_H1_RE = re.compile(r"^[ \t]*#[ \t]+\S", re.MULTILINE)
+_CHAPTER_TITLE_MAX = 60
+
+
+def chapterize_plaintext(text: str) -> str:
+    """Insert ``# `` headings ahead of obvious chapter-title lines.
+
+    No-op if the text already has Markdown H1 headings (the user has structured
+    it). Otherwise short standalone lines beginning with a chapter keyword
+    (``Chapter 3``, ``Prologue`` …) become headings; everything else is left
+    verbatim. Text with no detectable breaks falls through as a single chapter.
+    """
+    text = text or ""
+    if _H1_RE.search(text):
+        return text
+    out = []
+    for line in text.split("\n"):
+        s = line.strip()
+        if s and len(s) <= _CHAPTER_TITLE_MAX and _CH_RE.match(s):
+            out.append(f"# {s}")
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+class _TextExtractor(HTMLParser):
+    """Collect visible text from XHTML, dropping script/style and collapsing
+    whitespace. First <h1>/<h2>/<title> seen is kept as the chapter title."""
+
+    _SKIP = {"script", "style", "head"}
+    _BREAK = {"p", "br", "div", "h1", "h2", "h3", "li", "tr"}
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._skip_depth = 0
+        self._in_title = False
+        self.title = ""
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self._SKIP:
+            self._skip_depth += 1
+        if tag in ("h1", "h2", "title") and not self.title:
+            self._in_title = True
+        if tag in self._BREAK:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag):
+        if tag in self._SKIP and self._skip_depth:
+            self._skip_depth -= 1
+        if tag in ("h1", "h2", "title"):
+            self._in_title = False
+
+    def handle_data(self, data):
+        if self._skip_depth:
+            return
+        if self._in_title:
+            # The first heading becomes the chapter's `# Title` (metadata, not
+            # narrated) — capture it but keep it out of the body. Later headings
+            # (title already set) fall through and are narrated as subheadings.
+            if not self.title:
+                self.title = data.strip()
+            return
+        self._parts.append(data)
+
+    def text(self) -> str:
+        raw = "".join(self._parts)
+        # Collapse runs of blank lines / trailing spaces into tidy paragraphs.
+        lines = [ln.strip() for ln in raw.split("\n")]
+        out: list[str] = []
+        for ln in lines:
+            if ln or (out and out[-1]):
+                out.append(ln)
+        return "\n".join(out).strip()
+
+
+def _html_to_title_body(xhtml: str) -> tuple[str, str]:
+    p = _TextExtractor()
+    try:
+        p.feed(xhtml)
+    except Exception:
+        pass
+    return p.title, p.text()
+
+
+_OPF_NS = {"opf": "http://www.idpf.org/2007/opf", "c": "urn:oasis:names:tc:opendocument:xmlns:container"}
+
+
+def _opf_path(zf: zipfile.ZipFile) -> str:
+    container = zf.read("META-INF/container.xml")
+    # The EPUB is a local file the user chose to import (not a remote/untrusted
+    # surface); stdlib ElementTree doesn't expand external entities by default.
+    root = ET.fromstring(container)  # nosec B314
+    rootfile = root.find(".//c:rootfiles/c:rootfile", _OPF_NS)
+    if rootfile is None or not rootfile.get("full-path"):
+        raise ValueError("EPUB container.xml has no rootfile")
+    return rootfile.get("full-path")
+
+
+def epub_to_chapter_script(data: bytes) -> str:
+    """Convert EPUB bytes into a ``# Chapter`` / body script in spine order.
+
+    Reads the OPF manifest + spine (the publisher's reading order), extracts
+    each document's title + visible text, and emits one ``# Title`` block per
+    document with renderable text. Raises ``ValueError`` on a malformed EPUB.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile as e:
+        raise ValueError(f"not a valid EPUB (zip) file: {e}") from e
+
+    opf_path = _opf_path(zf)
+    opf = ET.fromstring(zf.read(opf_path))  # nosec B314 — local user EPUB; see _opf_path
+    base = posixpath.dirname(opf_path)
+
+    manifest: dict[str, str] = {}
+    for item in opf.findall(".//opf:manifest/opf:item", _OPF_NS):
+        iid, href = item.get("id"), item.get("href")
+        if iid and href:
+            manifest[iid] = href
+
+    blocks: list[str] = []
+    names = set(zf.namelist())
+    for ref in opf.findall(".//opf:spine/opf:itemref", _OPF_NS):
+        href = manifest.get(ref.get("idref") or "")
+        if not href:
+            continue
+        full = posixpath.normpath(posixpath.join(base, href)) if base else href
+        if full not in names:
+            continue
+        try:
+            xhtml = zf.read(full).decode("utf-8", "ignore")
+        except KeyError:
+            continue
+        title, body = _html_to_title_body(xhtml)
+        if not body.strip():
+            continue  # nav docs, empty pages
+        title = title or f"Chapter {len(blocks) + 1}"
+        blocks.append(f"# {title}\n\n{body}")
+
+    if not blocks:
+        raise ValueError("no readable chapters found in the EPUB")
+    return "\n\n".join(blocks)

--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -87,3 +87,11 @@ export async function audiobookUploadCover(file: File): Promise<{ path: string }
   const res = await apiFetch('/audiobook/cover', { method: 'POST', body: form });
   return res.json();
 }
+
+/** Import a .txt/.md/.epub into a chapter-delimited script. */
+export async function audiobookImport(file: File): Promise<{ text: string; chapters: number }> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await apiFetch('/audiobook/import', { method: 'POST', body: form });
+  return res.json();
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -143,7 +143,9 @@
     "meta_description": "Description",
     "preview_chapter": "Preview chapter: {{title}}",
     "cached_note": "Reused {{count}} already-rendered chapter(s).",
-    "failed_note": "{{count}} chapter(s) failed — click Create again to retry just those."
+    "failed_note": "{{count}} chapter(s) failed — click Create again to retry just those.",
+    "import": "Import",
+    "import_failed": "Import failed: {{message}}"
   },
   "launchpad": {
     "greeting": "hello there",

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookMarked, Loader, Download, Image as ImageIcon, X, Play } from 'lucide-react';
+import { BookMarked, Loader, Download, Image as ImageIcon, X, Play, Upload } from 'lucide-react';
 
 import {
-  audiobookPlan, audiobookGenerate, audiobookUploadCover, audiobookPreviewChapter,
+  audiobookPlan, audiobookGenerate, audiobookUploadCover, audiobookPreviewChapter, audiobookImport,
 } from '../api/audiobook';
 import { audioUrl } from '../api/generate';
 import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
@@ -51,6 +51,8 @@ export default function AudiobookTab({ profiles = [] }) {
     setCoverPreview('');
   }, [coverPreview]);
 
+  const [importing, setImporting] = useState(false);
+
   const onPreview = useCallback(async () => {
     setError('');
     setPlanLoading(true);
@@ -62,6 +64,23 @@ export default function AudiobookTab({ profiles = [] }) {
       setPlanLoading(false);
     }
   }, [text, defaultVoice]);
+
+  const onImport = useCallback(async (e) => {
+    const f = e.target.files?.[0];
+    e.target.value = ''; // allow re-importing the same file
+    if (!f) return;
+    setError('');
+    setImporting(true);
+    try {
+      const r = await audiobookImport(f);
+      setText(r.text);
+      setPlan(null);
+    } catch (err) {
+      setError(t('audiobook.import_failed', { message: err?.message || String(err) }));
+    } finally {
+      setImporting(false);
+    }
+  }, [t]);
 
   const onPreviewChapter = useCallback(async (i) => {
     setError('');
@@ -137,7 +156,7 @@ export default function AudiobookTab({ profiles = [] }) {
     }
   }, [text, defaultVoice, format, loudness, coverFile, meta]);
 
-  const busy = planLoading || generating;
+  const busy = planLoading || generating || importing;
   const canRun = text.trim().length > 0 && !busy;
 
   return (
@@ -192,6 +211,16 @@ export default function AudiobookTab({ profiles = [] }) {
           <option value="podcast">{t('audiobook.loudness_podcast')}</option>
         </select>
 
+        <label className="btn" style={{ cursor: busy ? 'default' : 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          {importing ? <Loader size={14} className="spin" /> : <Upload size={14} />} {t('audiobook.import')}
+          <input
+            type="file"
+            accept=".txt,.md,.epub"
+            onChange={onImport}
+            disabled={busy}
+            style={{ display: 'none' }}
+          />
+        </label>
         <button className="btn" onClick={onPreview} disabled={!canRun}>
           {planLoading ? <Loader size={14} className="spin" /> : null} {t('audiobook.preview_plan')}
         </button>

--- a/tests/test_longform_import.py
+++ b/tests/test_longform_import.py
@@ -1,0 +1,124 @@
+"""Text / EPUB import → chapter-delimited script.
+
+Pure helpers, tested without a server. The EPUB case builds a minimal valid
+EPUB zip in memory (no fixture file, no new dep).
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+from services.longform_import import chapterize_plaintext, epub_to_chapter_script
+from services.audiobook import parse_audiobook_script
+
+
+# ── plain text ──────────────────────────────────────────────────────────────
+
+def test_plaintext_leaves_existing_h1_untouched():
+    src = "# One\nhello\n\n# Two\nworld"
+    assert chapterize_plaintext(src) == src
+
+
+def test_plaintext_promotes_chapter_lines():
+    src = "Chapter 1\nOnce upon a time.\n\nChapter 2\nThe end."
+    out = chapterize_plaintext(src)
+    assert "# Chapter 1" in out
+    assert "# Chapter 2" in out
+    # And it parses into two chapters.
+    assert len(parse_audiobook_script(out).chapters) == 2
+
+
+def test_plaintext_ignores_sentences_starting_with_keyword():
+    # A long line beginning with "Chapter" is prose, not a heading.
+    src = "Chapter books were her favorite thing in the whole wide world to read."
+    out = chapterize_plaintext(src)
+    assert not out.startswith("# ")
+
+
+def test_plaintext_promotes_prologue_and_part():
+    out = chapterize_plaintext("Prologue\nhi\n\nPart One\nthere")
+    assert "# Prologue" in out and "# Part One" in out
+
+
+def test_plaintext_no_breaks_is_single_chapter():
+    out = chapterize_plaintext("just a flat blob of narration with no headings")
+    assert len(parse_audiobook_script(out).chapters) == 1
+
+
+# ── EPUB ────────────────────────────────────────────────────────────────────
+
+def _make_epub(chapters: list[tuple[str, str]]) -> bytes:
+    """Build a minimal EPUB: container.xml → content.opf (manifest+spine) →
+    one XHTML per chapter."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("mimetype", "application/epub+zip")
+        z.writestr(
+            "META-INF/container.xml",
+            '<?xml version="1.0"?>'
+            '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+            '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+            'media-type="application/oebps-package+xml"/></rootfiles></container>',
+        )
+        items, refs = [], []
+        for i, (title, _body) in enumerate(chapters):
+            items.append(f'<item id="c{i}" href="ch{i}.xhtml" media-type="application/xhtml+xml"/>')
+            refs.append(f'<itemref idref="c{i}"/>')
+        opf = (
+            '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+            f'<manifest>{"".join(items)}</manifest>'
+            f'<spine>{"".join(refs)}</spine></package>'
+        )
+        z.writestr("OEBPS/content.opf", opf)
+        for i, (title, body) in enumerate(chapters):
+            z.writestr(
+                f"OEBPS/ch{i}.xhtml",
+                f"<html><head><title>{title}</title></head><body>"
+                f"<h1>{title}</h1><p>{body}</p></body></html>",
+            )
+    return buf.getvalue()
+
+
+def test_epub_extracts_chapters_in_spine_order():
+    data = _make_epub([("Intro", "Welcome aboard."), ("Finale", "Goodbye now.")])
+    script = epub_to_chapter_script(data)
+    assert "# Intro" in script and "# Finale" in script
+    assert "Welcome aboard." in script and "Goodbye now." in script
+    assert script.index("Intro") < script.index("Finale")
+    plan = parse_audiobook_script(script)
+    assert len(plan.chapters) == 2
+
+
+def test_epub_skips_empty_documents():
+    data = _make_epub([("Real", "Has text."), ("Blank", "")])
+    plan = parse_audiobook_script(epub_to_chapter_script(data))
+    assert len(plan.chapters) == 1
+
+
+def test_epub_strips_html_tags():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("META-INF/container.xml",
+                   '<?xml version="1.0"?><container version="1.0" '
+                   'xmlns="urn:oasis:names:tc:opendocument:xmlns:container"><rootfiles>'
+                   '<rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>'
+                   '</rootfiles></container>')
+        z.writestr("content.opf",
+                   '<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0">'
+                   '<manifest><item id="a" href="a.xhtml" media-type="application/xhtml+xml"/></manifest>'
+                   '<spine><itemref idref="a"/></spine></package>')
+        z.writestr("a.xhtml",
+                   "<html><body><h1>T</h1><p>Hello <b>bold</b> "
+                   "<script>ignore()</script>world.</p></body></html>")
+    script = epub_to_chapter_script(buf.getvalue())
+    assert "ignore()" not in script
+    assert "<b>" not in script
+    assert "Hello" in script and "world." in script
+
+
+def test_epub_bad_zip_raises_valueerror():
+    with pytest.raises(ValueError):
+        epub_to_chapter_script(b"not a zip at all")


### PR DESCRIPTION
PR 4/8 of the [convergence](../blob/main/docs/specs/2026-06-13-stories-audiobook-maturity.md). A front door onto the existing chapter parser: import a file → get a chapter-delimited script in the editor.

## Backend — new `services/longform_import.py` (pure, **stdlib only, no new dep**)
- **`chapterize_plaintext(text)`** — inserts `# ` headings ahead of short standalone chapter-title lines (`Chapter`/`Part`/`Prologue`/…). No-op if the text already has H1s; a long "Chapter books were…" *sentence* stays prose. ReDoS-safe (anchored, per-line).
- **`epub_to_chapter_script(bytes)`** — parses EPUB (`zipfile` + `ElementTree` + `html.parser`) in **spine order** → `# Title` + stripped body per document; skips empty/nav pages; the heading becomes the chapter title (not narrated). `ValueError` on a malformed EPUB. `ET.fromstring` annotated `# nosec B314` (local user file; stdlib doesn't expand external entities).
- **`POST /audiobook/import`** (UploadFile) → `{text, chapters}`.

## Frontend
- An **Import** button (`.txt`/`.md`/`.epub`) that fills the script editor.

## Tests
`tests/test_longform_import.py` (9) — plain-text promotion + prose guard, and an **in-memory synthetic EPUB**: spine order, empty-doc skip, tag/script stripping, bad-zip → ValueError. **64 backend + 326 frontend green; build clean; en.json valid.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a file import frontend for the audiobook editor, converting plain-text, Markdown, or EPUB files into the chapter-delimited script format. The backend uses stdlib-only parsing (zipfile, ElementTree, html.parser) with no new dependencies, maintaining the local-first guarantee.

## Backend Changes

**New module: `backend/services/longform_import.py`** (168 lines)
- `chapterize_plaintext(text)`: Inserts Markdown `# ` headings before standalone lines beginning with chapter keywords (Chapter, Prologue, Part, etc.) if the text has no existing H1 headings. Max line length 60 chars; regex-anchored, ReDoS-safe.
- `epub_to_chapter_script(bytes)`: Parses EPUB via zipfile + ElementTree + HTMLParser (stdlib only). Reads OPF manifest & spine order, extracts each document's first `<h1>`/`<h2>`/`<title>` as the chapter heading (metadata, not narrated), strips and collapses visible text (removing `<script>`, `<style>`, etc.), and emits one `# Title` block per non-empty document in spine order. Raises `ValueError` for malformed EPUBs or missing readable chapters.

**New endpoint: `backend/api/routers/audiobook.py`** `POST /audiobook/import`
- Accepts `.txt`/`.md`/`.epub` via FormData
- Rejects empty files
- Routes to `epub_to_chapter_script` for EPUB; calls `chapterize_plaintext` for text
- Validates non-blank output; raises 400 on parse errors
- Returns `{text: script, chapters: count}` via `parse_audiobook_script`

## Frontend Changes

**New API helper: `frontend/src/api/audiobook.ts`**
- `audiobookImport(file): Promise<{text, chapters}>`

**Updated: `frontend/src/pages/AudiobookTab.jsx`**
- Added `importing` state, `onImport` callback, and Import button with file input
- Disabled when busy (alongside planning/generation)
- Shows spinning loader during upload
- Clears plan on successful import; populates editor with parsed script
- Error messages localized via `audiobook.import_failed`

**Updated: `frontend/src/i18n/locales/en.json`**
- Added `audiobook.import` and `audiobook.import_failed` (with `{{message}}` interpolation)

## UI Layout — Before/After

```
BEFORE                          AFTER
┌─────────────────────┐         ┌─────────────────────┐
│ Audiobook Studio    │         │ Audiobook Studio    │
├─────────────────────┤         ├─────────────────────┤
│ [Script editor      │         │ [Script editor      │
│  textarea]          │         │  textarea]          │
│                     │         │                     │
│ Voice: [▼]          │         │ Voice: [▼]          │
│         [Preview] ▶ │         │ [⬆ Import] [Preview] ▶
│         [Create] ▶  │         │         [Create] ▶
│                     │         │                     │
└─────────────────────┘         └─────────────────────┘
(no import control)              (new Import button
                                  accepts .txt/.md/.epub
                                  with loading spinner)
```

## Import Flow — Mermaid Diagram

```mermaid
graph TD
    A["User selects<br/>.txt/.md/.epub"] -->|File picker| B["onImport callback"]
    B -->|await audiobookImport| C["POST /audiobook/import"]
    C -->|read bytes| D{File type?}
    D -->|.epub| E["epub_to_chapter_script"]
    D -->|.txt/.md| F["chapterize_plaintext"]
    E -->|parse zipfile<br/>OPF spine| G["Extract docs<br/>in spine order"]
    G -->|HTMLParser| H["Title + visible text<br/>per document"]
    F -->|regex check<br/>existing H1?| I["Insert # headings<br/>before chapter keywords"]
    H -->|concatenate| J["Script output"]
    I -->|concatenate| J
    J -->|parse_audiobook_script| K["Compute chapter count"]
    K -->|return| L["{ text, chapters }"]
    L -->|setText| M["Editor populated"]
    L -->|setPlan null| N["Clear preview"]
    M -->|display| O["✓ Ready to preview/create"]
```

## Testing

- **tests/test_longform_import.py** (124 lines, 9 tests): plaintext heading promotion (H1 guard, prose safety, no-break fallback), EPUB spine order & empty-doc skip, tag stripping, bad-zip → ValueError
- CI: 64 backend + 326 frontend tests pass; build clean; `en.json` valid

## Key Design Notes

- **Local-first**: EPUB parsing uses only stdlib (no external libraries), no network calls
- **Reuses existing pipeline**: Output format matches `parse_audiobook_script`, so import is a front door onto the present audiobook editor
- **Security**: User-provided EPUB (local file), ElementTree doesn't expand external entities by default; annotated `# nosec B314`
- **Chapter keywords**: Chapter, Part, Book, Prologue, Epilogue, Section (case-insensitive, ≤60 chars, anchored regex)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->