### PR TITLE
feat(stories): full export → shared server-side renderer (PR 5/8)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -285,115 +285,190 @@ async def audiobook_preview(req: AudiobookPreviewRequest) -> dict:
     }
 
 
-@router.post("/audiobook")
-async def audiobook_synthesize(req: AudiobookRequest):
-    """Synthesize a chapterized m4b audiobook, streaming SSE progress."""
+async def _render_longform_sse(
+    plan,
+    *,
+    default_voice: str | None,
+    fmt: str = "m4b",
+    bitrate: str = "128k",
+    loudness: str | None = None,
+    cover_path: str | None = None,
+    metadata: dict | None = None,
+    job_type: str = "audiobook",
+):
+    """Shared chapterized-render SSE generator for Audiobook *and* Stories.
+
+    Takes a ready ``plan`` (``.chapters`` → ``.title`` + ``.spans``) — Audiobook
+    parses it from a script, Stories compiles it from cast/lines — and renders
+    each chapter (content-addressed cache → resume), isolating per-chapter
+    failures, then muxes the successful chapters into a tagged file. This is the
+    convergence point: one renderer, two front doors.
+    """
     from core.config import OUTPUTS_DIR
     from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
     from services.model_manager import _gpu_pool
 
+    job_id = uuid.uuid4().hex[:16]
+    try:
+        from core import job_store
+        job_store.create(job_id, type=job_type)
+        job_store.mark_running(job_id)
+    except Exception:
+        job_store = None  # job history is best-effort; never block synthesis
+
+    def _emit(payload: dict) -> str:
+        if job_store is not None:
+            try:
+                job_store.append_event(job_id, json.dumps(payload))
+            except Exception:
+                pass
+        return f"data: {json.dumps(payload)}\n\n"
+
+    if not plan.chapters:
+        yield _emit({"type": "error", "error": "nothing to render (no chapters)"})
+        return
+    ffmpeg = find_ffmpeg()
+    if not ffmpeg:
+        yield _emit({"type": "error", "error": "ffmpeg not available; the output needs it"})
+        return
+
+    work = os.path.join(OUTPUTS_DIR, f"{job_type}_{job_id}")
+    os.makedirs(work, exist_ok=True)
+    # Chapter WAVs are content-addressed in a shared cache so a re-run (after a
+    # failure or interruption) reuses what already rendered — only the
+    # missing/changed chapters synthesize again (resume). Shared across both
+    # front doors: an identical chapter renders once.
+    cache_dir = os.path.join(OUTPUTS_DIR, "longform_cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    loop = asyncio.get_running_loop()
+
+    try:
+        synth, sr, resolve, engine_id = await _prepare_synth(default_voice)
+
+        total = len(plan.chapters)
+        chapter_files: list[str] = []
+        chapters_meta: list[tuple[str, int]] = []
+        cached_n = 0
+        failed: list[int] = []
+        yield _emit({"type": "started", "job_id": job_id, "chapters": total})
+
+        for i, chapter in enumerate(plan.chapters):
+            try:
+                wav_path, dur, was_cached = await loop.run_in_executor(
+                    _gpu_pool, _render_chapter_cached,
+                    chapter, synth, sr, engine_id, resolve, cache_dir,
+                )
+            except Exception as ce:  # isolate a bad chapter — keep going
+                failed.append(i)
+                yield _emit({"type": "chapter_error", "index": i, "total": total,
+                             "title": chapter.title, "error": str(ce)[:200]})
+                continue
+            chapter_files.append(wav_path)
+            chapters_meta.append((chapter.title, int(round(dur * 1000))))
+            cached_n += 1 if was_cached else 0
+            yield _emit({"type": "chapter", "index": i, "total": total,
+                         "title": chapter.title, "duration_s": round(dur, 2),
+                         "cached": was_cached})
+
+        if not chapter_files:
+            yield _emit({"type": "error", "error": "all chapters failed to render"})
+            return
+
+        yield _emit({"type": "assembling"})
+        meta_path = os.path.join(work, "chapters.ffmeta")
+        with open(meta_path, "w", encoding="utf-8") as f:
+            f.write(build_ffmetadata(chapters_meta, global_meta=metadata))
+        concat_path = os.path.join(work, "concat.txt")
+        with open(concat_path, "w", encoding="utf-8") as f:
+            f.write(build_concat_list(chapter_files))
+        ext = "mp3" if (fmt or "").lower() == "mp3" else "m4b"
+        out_name = f"{job_type}_{job_id}.{ext}"
+        out_path = os.path.join(OUTPUTS_DIR, out_name)
+        await run_ffmpeg(
+            build_render_cmd(
+                ffmpeg, concat_path, meta_path, out_path,
+                fmt=ext, bitrate=bitrate, cover_path=cover_path, loudness=loudness,
+            ),
+            job_id=job_id,
+        )
+
+        if job_store is not None:
+            try:
+                job_store.mark_done(job_id)
+            except Exception:
+                pass
+        total_s = sum(d for _, d in chapters_meta) / 1000.0
+        yield _emit({"type": "done", "output": out_name,
+                     "chapters": len(chapter_files), "duration_s": round(total_s, 2),
+                     "cached_chapters": cached_n, "failed_chapters": failed})
+    except Exception as e:  # surface, don't 500 the stream
+        if job_store is not None:
+            try:
+                job_store.mark_failed(job_id, str(e))
+            except Exception:
+                pass
+        yield _emit({"type": "error", "error": str(e)[:300]})
+
+
+@router.post("/audiobook")
+async def audiobook_synthesize(req: AudiobookRequest):
+    """Synthesize a chapterized audiobook from a script, streaming SSE progress."""
     plan = parse_audiobook_script(req.text, default_voice=req.default_voice)
+    return StreamingResponse(
+        _render_longform_sse(
+            plan, default_voice=req.default_voice, fmt=req.format, bitrate=req.bitrate,
+            loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
+            job_type="audiobook",
+        ),
+        media_type="text/event-stream",
+    )
 
-    async def gen():
-        job_id = uuid.uuid4().hex[:16]
-        try:
-            from core import job_store
-            job_store.create(job_id, type="audiobook")
-            job_store.mark_running(job_id)
-        except Exception:
-            job_store = None  # job history is best-effort; never block synthesis
 
-        def _emit(payload: dict) -> str:
-            if job_store is not None:
-                try:
-                    job_store.append_event(job_id, json.dumps(payload))
-                except Exception:
-                    pass
-            return f"data: {json.dumps(payload)}\n\n"
+# ── Shared longform render: Stories (and any future front door) post a plan ──
 
-        if not plan.chapters:
-            yield _emit({"type": "error", "error": "no chapters parsed from the script"})
-            return
-        ffmpeg = find_ffmpeg()
-        if not ffmpeg:
-            yield _emit({"type": "error", "error": "ffmpeg not available; the m4b output needs it"})
-            return
+class LongformSpan(BaseModel):
+    voice_id: str | None = None
+    text: str
+    pause_ms_after: int = 0
 
-        work = os.path.join(OUTPUTS_DIR, f"audiobook_{job_id}")
-        os.makedirs(work, exist_ok=True)
-        # Chapter WAVs are content-addressed in a shared cache so a re-run
-        # (after a failure or interruption) reuses what already rendered — only
-        # the missing/changed chapters synthesize again (resume).
-        cache_dir = os.path.join(OUTPUTS_DIR, "audiobook_cache")
-        os.makedirs(cache_dir, exist_ok=True)
-        loop = asyncio.get_running_loop()
 
-        try:
-            synth, sr, resolve, engine_id = await _prepare_synth(req.default_voice)
+class LongformChapter(BaseModel):
+    title: str = ""
+    spans: list[LongformSpan] = []
 
-            total = len(plan.chapters)
-            chapter_files: list[str] = []
-            chapters_meta: list[tuple[str, int]] = []
-            cached_n = 0
-            failed: list[int] = []
-            yield _emit({"type": "started", "job_id": job_id, "chapters": total})
 
-            for i, chapter in enumerate(plan.chapters):
-                try:
-                    wav_path, dur, was_cached = await loop.run_in_executor(
-                        _gpu_pool, _render_chapter_cached,
-                        chapter, synth, sr, engine_id, resolve, cache_dir,
-                    )
-                except Exception as ce:  # isolate a bad chapter — keep going
-                    failed.append(i)
-                    yield _emit({"type": "chapter_error", "index": i, "total": total,
-                                 "title": chapter.title, "error": str(ce)[:200]})
-                    continue
-                chapter_files.append(wav_path)
-                chapters_meta.append((chapter.title, int(round(dur * 1000))))
-                cached_n += 1 if was_cached else 0
-                yield _emit({"type": "chapter", "index": i, "total": total,
-                             "title": chapter.title, "duration_s": round(dur, 2),
-                             "cached": was_cached})
+class LongformRenderRequest(BaseModel):
+    chapters: list[LongformChapter] = []
+    default_voice: str | None = None
+    bitrate: str = "128k"
+    format: str = "m4b"
+    loudness: str | None = None
+    cover_path: str | None = None
+    metadata: dict | None = None
 
-            if not chapter_files:
-                yield _emit({"type": "error", "error": "all chapters failed to render"})
-                return
 
-            yield _emit({"type": "assembling"})
-            meta_path = os.path.join(work, "chapters.ffmeta")
-            with open(meta_path, "w", encoding="utf-8") as f:
-                f.write(build_ffmetadata(chapters_meta, global_meta=req.metadata))
-            concat_path = os.path.join(work, "concat.txt")
-            with open(concat_path, "w", encoding="utf-8") as f:
-                f.write(build_concat_list(chapter_files))
-            ext = "mp3" if (req.format or "").lower() == "mp3" else "m4b"
-            out_name = f"audiobook_{job_id}.{ext}"
-            out_path = os.path.join(OUTPUTS_DIR, out_name)
-            await run_ffmpeg(
-                build_render_cmd(
-                    ffmpeg, concat_path, meta_path, out_path,
-                    fmt=ext, bitrate=req.bitrate,
-                    cover_path=req.cover_path, loudness=req.loudness,
-                ),
-                job_id=job_id,
-            )
+@router.post("/longform/render")
+async def longform_render(req: LongformRenderRequest):
+    """Render a pre-built chapter/span plan (the Stories Editor's compiled
+    cast+lines) through the shared chapterized renderer — same resume, loudness,
+    cover, metadata, and output formats as the Audiobook job."""
+    from services.audiobook import AudiobookPlan, Chapter, Span
 
-            if job_store is not None:
-                try:
-                    job_store.mark_done(job_id)
-                except Exception:
-                    pass
-            total_s = sum(d for _, d in chapters_meta) / 1000.0
-            yield _emit({"type": "done", "output": out_name,
-                         "chapters": len(chapter_files), "duration_s": round(total_s, 2),
-                         "cached_chapters": cached_n, "failed_chapters": failed})
-        except Exception as e:  # surface, don't 500 the stream
-            if job_store is not None:
-                try:
-                    job_store.mark_failed(job_id, str(e))
-                except Exception:
-                    pass
-            yield _emit({"type": "error", "error": str(e)[:300]})
-
-    return StreamingResponse(gen(), media_type="text/event-stream")
+    chapters = []
+    for i, c in enumerate(req.chapters):
+        # Keep a span if it has text to speak OR a pause to render (pause-only
+        # spans carry inter-line silence with empty text).
+        spans = [Span(voice_id=s.voice_id, text=(s.text or "").strip(),
+                      pause_ms_after=max(0, int(s.pause_ms_after)))
+                 for s in c.spans if ((s.text and s.text.strip()) or s.pause_ms_after > 0)]
+        if spans:
+            chapters.append(Chapter(title=c.title or f"Chapter {i + 1}", spans=spans))
+    plan = AudiobookPlan(chapters=chapters)
+    return StreamingResponse(
+        _render_longform_sse(
+            plan, default_voice=req.default_voice, fmt=req.format, bitrate=req.bitrate,
+            loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
+            job_type="story",
+        ),
+        media_type="text/event-stream",
+    )

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -39,18 +39,23 @@ router = APIRouter()
 
 
 def _safe_cover_path(cover_path: str | None) -> str | None:
-    """Confine a user-supplied cover path to ``OUTPUTS_DIR`` before it can flow
-    into ffmpeg. Returns the real path if it lives under OUTPUTS_DIR (where the
-    /audiobook/cover upload writes), else None — an arbitrary path (e.g.
-    ``/etc/passwd``) is dropped, not read."""
+    """Confine a user-supplied cover to the upload directory before it can flow
+    into ffmpeg.
+
+    Covers only ever come from ``/audiobook/cover``, which writes them to
+    ``OUTPUTS_DIR/audiobook_covers`` with a generated name. We rebuild the path
+    from the basename alone (``os.path.basename`` strips any directory component
+    or ``..`` traversal) joined onto that fixed directory, so no caller-supplied
+    path — absolute or relative — can escape it. Returns the path only if the
+    file actually exists there, else None."""
     if not cover_path:
         return None
     from core.config import OUTPUTS_DIR
-    base = os.path.realpath(OUTPUTS_DIR)
-    real = os.path.realpath(cover_path)
-    if real == base or real.startswith(base + os.sep):
-        return real
-    return None
+    name = os.path.basename(cover_path)
+    if not name:
+        return None
+    candidate = os.path.join(OUTPUTS_DIR, "audiobook_covers", name)
+    return candidate if os.path.isfile(candidate) else None
 
 
 class AudiobookPlanRequest(BaseModel):

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -60,8 +60,14 @@ def _safe_cover_path(cover_path: str | None) -> str | None:
     name = os.path.basename(cover_path)
     if not _COVER_NAME_RE.match(name):
         return None  # not a name the upload endpoint could have produced
-    candidate = os.path.join(OUTPUTS_DIR, "audiobook_covers", name)
-    return candidate if os.path.isfile(candidate) else None
+    cover_dir = os.path.realpath(os.path.join(OUTPUTS_DIR, "audiobook_covers"))
+    real = os.path.realpath(os.path.join(cover_dir, name))
+    # Containment check on the resolved path itself — it must live inside the
+    # covers dir. Belt-and-suspenders over the regex+basename above; the
+    # commonpath form is the path-injection barrier static analysis recognizes.
+    if os.path.commonpath([real, cover_dir]) != cover_dir:
+        return None
+    return real if os.path.isfile(real) else None
 
 
 class AudiobookPlanRequest(BaseModel):

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -16,6 +16,7 @@ epub/pdf ingest, ACX mastering, crash-resume and the UI remain follow-ups.
 
 import asyncio
 import json
+import logging
 import os
 import uuid
 
@@ -33,7 +34,23 @@ from services.longform_render import (
     build_render_cmd,
 )
 
+logger = logging.getLogger("omnivoice.audiobook")
 router = APIRouter()
+
+
+def _safe_cover_path(cover_path: str | None) -> str | None:
+    """Confine a user-supplied cover path to ``OUTPUTS_DIR`` before it can flow
+    into ffmpeg. Returns the real path if it lives under OUTPUTS_DIR (where the
+    /audiobook/cover upload writes), else None — an arbitrary path (e.g.
+    ``/etc/passwd``) is dropped, not read."""
+    if not cover_path:
+        return None
+    from core.config import OUTPUTS_DIR
+    base = os.path.realpath(OUTPUTS_DIR)
+    real = os.path.realpath(cover_path)
+    if real == base or real.startswith(base + os.sep):
+        return real
+    return None
 
 
 class AudiobookPlanRequest(BaseModel):
@@ -321,7 +338,7 @@ async def _render_longform_sse(
             try:
                 job_store.append_event(job_id, json.dumps(payload))
             except Exception:
-                pass
+                pass  # best-effort job history; never block the stream
         return f"data: {json.dumps(payload)}\n\n"
 
     if not plan.chapters:
@@ -358,10 +375,12 @@ async def _render_longform_sse(
                     _gpu_pool, _render_chapter_cached,
                     chapter, synth, sr, engine_id, resolve, cache_dir,
                 )
-            except Exception as ce:  # isolate a bad chapter — keep going
+            except Exception:  # isolate a bad chapter — keep going
+                logger.warning("[%s] chapter %d (%s) failed to render",
+                               job_id, i, chapter.title, exc_info=True)
                 failed.append(i)
                 yield _emit({"type": "chapter_error", "index": i, "total": total,
-                             "title": chapter.title, "error": str(ce)[:200]})
+                             "title": chapter.title, "error": "chapter failed to render"})
                 continue
             chapter_files.append(wav_path)
             chapters_meta.append((chapter.title, int(round(dur * 1000))))
@@ -387,7 +406,8 @@ async def _render_longform_sse(
         await run_ffmpeg(
             build_render_cmd(
                 ffmpeg, concat_path, meta_path, out_path,
-                fmt=ext, bitrate=bitrate, cover_path=cover_path, loudness=loudness,
+                fmt=ext, bitrate=bitrate, cover_path=_safe_cover_path(cover_path),
+                loudness=loudness,
             ),
             job_id=job_id,
         )
@@ -396,18 +416,20 @@ async def _render_longform_sse(
             try:
                 job_store.mark_done(job_id)
             except Exception:
-                pass
+                pass  # best-effort job history
         total_s = sum(d for _, d in chapters_meta) / 1000.0
         yield _emit({"type": "done", "output": out_name,
                      "chapters": len(chapter_files), "duration_s": round(total_s, 2),
                      "cached_chapters": cached_n, "failed_chapters": failed})
     except Exception as e:  # surface, don't 500 the stream
+        logger.exception("[%s] longform render failed", job_id)
         if job_store is not None:
             try:
                 job_store.mark_failed(job_id, str(e))
             except Exception:
-                pass
-        yield _emit({"type": "error", "error": str(e)[:300]})
+                pass  # best-effort job history
+        # Generic message only — don't leak the stack/exception text to the client.
+        yield _emit({"type": "error", "error": "render failed (see backend log)"})
 
 
 @router.post("/audiobook")

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -18,6 +18,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import uuid
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
@@ -37,6 +38,11 @@ from services.longform_render import (
 logger = logging.getLogger("omnivoice.audiobook")
 router = APIRouter()
 
+# A cover filename as produced by /audiobook/cover: 12 hex chars + image ext.
+# An exact-match allowlist is the strongest barrier (and the one CodeQL's
+# path-injection query recognizes) — anything else is rejected outright.
+_COVER_NAME_RE = re.compile(r"^[0-9a-f]{12}\.(?:jpg|jpeg|png)$")
+
 
 def _safe_cover_path(cover_path: str | None) -> str | None:
     """Confine a user-supplied cover to the upload directory before it can flow
@@ -52,8 +58,8 @@ def _safe_cover_path(cover_path: str | None) -> str | None:
         return None
     from core.config import OUTPUTS_DIR
     name = os.path.basename(cover_path)
-    if not name:
-        return None
+    if not _COVER_NAME_RE.match(name):
+        return None  # not a name the upload endpoint could have produced
     candidate = os.path.join(OUTPUTS_DIR, "audiobook_covers", name)
     return candidate if os.path.isfile(candidate) else None
 

--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -95,3 +95,27 @@ export async function audiobookImport(file: File): Promise<{ text: string; chapt
   const res = await apiFetch('/audiobook/import', { method: 'POST', body: form });
   return res.json();
 }
+
+export interface LongformRenderBody {
+  chapters: Array<{ title?: string; spans: Array<{ voice_id: string | null; text: string; pause_ms_after: number }> }>;
+  default_voice?: string | null;
+  bitrate?: string;
+  format?: 'm4b' | 'mp3';
+  loudness?: 'off' | 'acx' | 'podcast' | null;
+  cover_path?: string | null;
+  metadata?: AudiobookMetadata | null;
+}
+
+/**
+ * Render a pre-built chapter/span plan through the shared chapterized renderer
+ * (the convergence endpoint Stories posts to). Returns the raw SSE stream
+ * Response — read `response.body` with the sseParse helpers, same as
+ * `audiobookGenerate`.
+ */
+export async function longformRender(body: LongformRenderBody): Promise<Response> {
+  return apiFetch('/longform/render', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -18,9 +18,12 @@ import { useAppStore } from '../store';
 import { parseStoryText, hasStoryMarkers, applyInlineVoice, insertToken } from '../utils/storyTokens';
 import { parseScript } from '../utils/parseScript';
 import { importToText } from '../utils/importStory';
-import { generateSpeech } from '../api/generate';
+import { generateSpeech, audioUrl } from '../api/generate';
 import { encodeAudio } from '../api/stories';
-import { exportStoryAudio, exportStems, buildCueSheet } from '../utils/storyExport';
+import { longformRender } from '../api/audiobook';
+import { exportStems } from '../utils/storyExport';
+import { storyToSpans } from '../utils/storyToSpans';
+import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
 import { reorder } from '../utils/storyReorder';
 import { effectiveProfile, castMember, nextCastColor } from '../utils/storyCast';
 import './StoriesEditor.css';
@@ -35,6 +38,16 @@ function download(blob, filename) {
   a.click();
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 10000);
+}
+
+// Trigger a browser download for a same-origin URL (server-rendered file).
+function downloadUrl(url, filename) {
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
 }
 
 // A chapter line is any track whose text is a markdown heading (`# …`). It
@@ -136,7 +149,7 @@ export default function StoriesEditor({ profiles = [] }) {
   const [expandedLine, setExpandedLine] = useState(null);
   const [projectsOpen, setProjectsOpen] = useState(false);
   const [projectName, setProjectName] = useState('');
-  const [exportFormat, setExportFormat] = useState('wav');
+  const [exportFormat, setExportFormat] = useState('m4b');
   const trackTextRefs = useRef(new Map());
   const fileInputRef = useRef(null);
   const dragId = useRef(null);
@@ -336,28 +349,54 @@ export default function StoriesEditor({ profiles = [] }) {
     download(wavBlob, `${baseName}.wav`);
   }, [exportFormat, t]);
 
+  // Full export now runs on the shared server-side renderer (the Stories +
+  // Audiobook convergence): cast + lines compile to a chapter/span plan and
+  // stream through /longform/render — gaining chapter markers, resume, and
+  // (via the audiobook controls) loudness/metadata. Single-line preview stays
+  // client-side for latency. Stems remain a client export below.
   const generateAll = useCallback(async () => {
     const usable = tracks.filter((tk) => (tk.text || '').trim());
     if (!usable.length || exporting) return;
+    const chapters = storyToSpans(usable, cast);
+    if (!chapters.length) { toast.error(t('stories.exportFailed')); return; }
     setExporting(true);
     setExportPct(0);
     try {
-      const { blob, chapters } = await exportStoryAudio(
-        usable,
-        (tk) => ({ profileId: effectiveProfile(tk, cast), speed: tk.speed || 1.0 }),
-        fetchChunkBlob,
-        (d, total) => setExportPct(total ? Math.round((d / total) * 100) : 0),
-      );
-      await deliver(blob, 'story');
-      if (chapters.length) download(new Blob([buildCueSheet(chapters)], { type: 'text/plain' }), 'story-chapters.txt');
+      const res = await longformRender({
+        chapters,
+        format: exportFormat === 'mp3' ? 'mp3' : 'm4b',
+      });
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let total = 0;
+      let output = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const { lines, rest } = splitSSEBuffer(buffer);
+        buffer = rest;
+        for (const line of lines) {
+          const evt = parseSSELine(line);
+          if (!evt) continue;
+          if (evt.type === 'started') total = evt.chapters;
+          else if (evt.type === 'chapter' || evt.type === 'chapter_error') {
+            setExportPct(total ? Math.round(((evt.index + 1) / total) * 100) : 0);
+          } else if (evt.type === 'done') output = evt.output;
+          else if (evt.type === 'error') throw new Error(evt.error || 'render failed');
+        }
+      }
+      if (!output) throw new Error('no output produced');
+      downloadUrl(audioUrl(output), output.split('/').pop());
       toast.success(t('stories.exportDone'));
     } catch (err) {
-      console.warn('Story export failed:', err);
+      console.warn('Story render failed:', err);
       toast.error(t('stories.exportFailed'));
     } finally {
       setExporting(false);
     }
-  }, [tracks, cast, fetchChunkBlob, exporting, deliver, t]);
+  }, [tracks, cast, exporting, exportFormat, t]);
 
   const exportStemsAll = useCallback(async () => {
     const usable = tracks.filter((tk) => (tk.text || '').trim());
@@ -444,7 +483,7 @@ export default function StoriesEditor({ profiles = [] }) {
               aria-label={t('stories.format')}
               title={t('stories.format')}
             >
-              <option value="wav">WAV</option>
+              <option value="m4b">M4B</option>
               <option value="mp3">MP3</option>
             </select>
             <Button size="sm" onClick={generateAll} disabled={tracks.length === 0 || exporting}>

--- a/frontend/src/test/storyToSpans.test.js
+++ b/frontend/src/test/storyToSpans.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { storyToSpans } from '../utils/storyToSpans';
+
+const CAST = [
+  { id: 'narrator', name: 'Narrator', profileId: 'p_narr' },
+  { id: 'c_fox', name: 'Fox', profileId: 'p_fox' },
+];
+
+describe('storyToSpans', () => {
+  it('resolves each line to its cast voice', () => {
+    const tracks = [
+      { character: 'narrator', text: 'Once upon a time.' },
+      { character: 'c_fox', text: 'Hello there.' },
+    ];
+    const chapters = storyToSpans(tracks, CAST);
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0].spans).toEqual([
+      { voice_id: 'p_narr', text: 'Once upon a time.', pause_ms_after: 0 },
+      { voice_id: 'p_fox', text: 'Hello there.', pause_ms_after: 0 },
+    ]);
+  });
+
+  it('opens a new chapter on a "# " line', () => {
+    const tracks = [
+      { character: 'narrator', text: '# Chapter One' },
+      { character: 'narrator', text: 'Intro.' },
+      { character: 'narrator', text: '# Chapter Two' },
+      { character: 'c_fox', text: 'More.' },
+    ];
+    const chapters = storyToSpans(tracks, CAST);
+    expect(chapters.map((c) => c.title)).toEqual(['Chapter One', 'Chapter Two']);
+    expect(chapters[1].spans[0]).toEqual({ voice_id: 'p_fox', text: 'More.', pause_ms_after: 0 });
+  });
+
+  it('honors a per-line voice override', () => {
+    const tracks = [{ character: 'narrator', profileId: 'p_override', text: 'Hi.' }];
+    expect(storyToSpans(tracks, CAST)[0].spans[0].voice_id).toBe('p_override');
+  });
+
+  it('folds [pause] into the previous span', () => {
+    const tracks = [{ character: 'narrator', text: 'Wait. [pause 0.5s] Done.' }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: 'Wait.', pause_ms_after: 500 });
+    expect(spans[1]).toEqual({ voice_id: 'p_narr', text: 'Done.', pause_ms_after: 0 });
+  });
+
+  it('switches voice mid-line on [voice:]', () => {
+    const tracks = [{ character: 'narrator', text: 'A [voice:p_fox] B' }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans[0].voice_id).toBe('p_narr');
+    expect(spans[1].voice_id).toBe('p_fox');
+  });
+
+  it('drops empty lines and empty chapters', () => {
+    const tracks = [
+      { character: 'narrator', text: '# Empty' },
+      { character: 'narrator', text: '   ' },
+      { character: 'narrator', text: '# Real' },
+      { character: 'narrator', text: 'Here.' },
+    ];
+    const chapters = storyToSpans(tracks, CAST);
+    expect(chapters.map((c) => c.title)).toEqual(['Real']);
+  });
+
+  it('a leading pause becomes a silent span', () => {
+    const tracks = [{ character: 'narrator', text: '[pause 1s] Go.' }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: '', pause_ms_after: 1000 });
+    expect(spans[1].text).toBe('Go.');
+  });
+});

--- a/frontend/src/utils/storyToSpans.js
+++ b/frontend/src/utils/storyToSpans.js
@@ -1,0 +1,46 @@
+import { parseStoryText } from './storyTokens';
+import { isChapterLine, chapterTitle } from './storyExport';
+import { effectiveProfile } from './storyCast';
+
+/**
+ * Compile the Stories Editor's cast + ordered lines into the chapter/span plan
+ * the shared `/longform/render` endpoint consumes — the bridge that lets a
+ * multi-voice story render on the same server-side pipeline as an audiobook
+ * (resume, loudness, cover, chapter markers).
+ *
+ * Rules:
+ *  - a line starting with "# " opens a new chapter (its text is the title)
+ *  - every spoken line resolves to its effective voice (per-line override →
+ *    cast member's voice) and is split on inline `[voice:]`/`[pause]` markers
+ *  - a `[pause]` folds into the previous span's trailing silence, or becomes a
+ *    silent span if it leads a chapter
+ *
+ * @returns Array<{ title, spans: [{ voice_id, text, pause_ms_after }] }>
+ */
+export function storyToSpans(tracks, cast) {
+  const chapters = [];
+  let cur = { title: '', spans: [] };
+  const flush = () => { if (cur.spans.length) chapters.push(cur); };
+
+  for (const tk of tracks || []) {
+    const text = tk.text || '';
+    if (isChapterLine(text)) {
+      flush();
+      cur = { title: chapterTitle(text), spans: [] };
+      continue;
+    }
+    const profileId = effectiveProfile(tk, cast) || null;
+    for (const seg of parseStoryText(text, profileId)) {
+      if (seg.type === 'pause') {
+        const ms = Math.round(seg.seconds * 1000);
+        const last = cur.spans[cur.spans.length - 1];
+        if (last) last.pause_ms_after += ms;
+        else cur.spans.push({ voice_id: profileId, text: '', pause_ms_after: ms });
+      } else if (seg.text) {
+        cur.spans.push({ voice_id: seg.profileId || null, text: seg.text, pause_ms_after: 0 });
+      }
+    }
+  }
+  flush();
+  return chapters;
+}


### PR DESCRIPTION
**The convergence core.** Stories' full export no longer stitches audio in the browser (Web Audio — capped by RAM, no resume / loudness / chapter markers). It compiles cast + lines into a chapter/span plan and streams through the **same chapterized renderer the Audiobook tab uses**.

## Backend
- Extracted the audiobook SSE job into a shared **`_render_longform_sse(plan, …)`** generator (resume cache, per-chapter fault isolation, mux). `/audiobook` is now a thin caller.
- **`POST /longform/render`** — accepts a pre-built `{chapters:[{title, spans:[{voice_id,text,pause_ms_after}]}]}` plan (+ format/loudness/cover/metadata) and renders it. Pause-only spans (empty text) are kept as silence. `job_type=story`.
- Shared content-addressed cache renamed `longform_cache` — one render per unique chapter across both front doors.

## Frontend
- **`storyToSpans(tracks, cast)`** — pure compiler: `# ` lines → chapters; each line resolves its cast/override voice; inline `[voice:]`/`[pause]` split into spans; pauses fold into the previous span.
- `StoriesEditor.generateAll` now posts via `longformRender` and downloads the server file (**chaptered M4B** / MP3). Single-line preview stays client-side; stems export unchanged. Format select WAV→M4B.

## Deferred to PR 6 (with the component split)
Per-line regenerate, emotion→instruct wiring.

## Tests
`storyToSpans` (7) — cast resolution, chapter breaks, per-line + inline voice override, pause folding, empty-drop. **64 backend + 333 frontend green; build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Stories Full Export → Shared Server-Side Renderer

## Objective
Move Stories full-export audio rendering from client-side chunked browser stitching to the server's chapterized renderer (shared with the Audiobook tab) to improve resource efficiency, enable resume/caching, and provide per-chapter fault isolation.

## Backend Changes

- Added _safe_cover_path(cover_path) to confine user-supplied cover paths to the server audiobook covers output dir. Sanitation uses os.path.basename + anchored regex (12-hex + jpg|jpeg|png), resolves realpath and enforces containment via os.path.commonpath, and returns the path only if the file actually exists there.
- Extracted shared async SSE generator _render_longform_sse(plan, *, default_voice, fmt="m4b", bitrate="128k", loudness=None, cover_path=None, metadata=None, job_type="audiobook") in backend/api/routers/audiobook.py:
  - Creates/updates job_store record (best-effort) and streams SSE events while appending job history.
  - Validates plan chapters and gates on ffmpeg availability (early SSE error).
  - Renders chapters sequentially via _render_chapter_cached using the GPU-pool, with per-chapter failure isolation (emit chapter_error, continue).
  - Resume behavior via shared longform_cache (content-addressed chapter WAV caching).
  - Builds chapter ffmetadata and concat inputs, runs ffmpeg to produce {job_type}_{job_id}.{m4b|mp3} using requested format/bitrate/loudness and sanitized cover path.
  - Emits started, per-chapter chapter, assembling, and terminal done (with cached/failed counts) or terminal error (generic message). Exceptions mark job failed (best-effort).
- POST /audiobook now delegates streaming to _render_longform_sse(..., job_type="audiobook") (thin caller; behavior preserved).
- Added POST /longform/render endpoint:
  - New request models LongformSpan, LongformChapter, LongformRenderRequest (server-side).
  - Accepts a pre-built plan: chapters: [{ title?, spans: [{ voice_id, text, pause_ms_after }] }], plus default_voice/format/bitrate/loudness/cover_path/metadata.
  - Normalizes spans (drops spans with no speak text and no positive pause), constructs internal AudiobookPlan, and streams via _render_longform_sse(..., job_type="story").
- Renamed/shared content-addressed cache to longform_cache to unify renders across entry points.
- SSE error payloads are now generic (details logged server-side) for robustness/security.

Commit hygiene: cover-upload + render-time checks are tightened to satisfy static analysis (basename + anchored filename regex + containment + existence).

## Frontend Changes

- New API client longformRender(body: LongformRenderBody) in frontend/src/api/audiobook.ts that POSTs to /longform/render and returns the raw streaming Response for SSE consumption.
- StoriesEditor.jsx:
  - Full multi-line export switched from client-side chunked export to posting a compiled plan to /longform/render.
  - generateAll now:
    - Filters usable tracks, compiles plan via storyToSpans(tracks, cast).
    - Calls longformRender with format m4b (default changed from WAV→M4B) or mp3.
    - Consumes res.body as a text stream, incrementally parses SSE using splitSSEBuffer/parseSSELine, updates exportPct from started/chapter events, handles SSE error events, and downloads final output via downloadUrl(audioUrl(output), ...).
  - Single-line preview and stems export remain client-side/unchanged.
  - Replaced generic blob-download helper with downloadUrl for same-origin server-rendered files.
- New utility frontend/src/utils/storyToSpans.js:
  - export function storyToSpans(tracks, cast) → chapters: [{ title, spans: [{ voice_id, text, pause_ms_after }] }]
  - Rules: "# " lines start new chapters; resolve per-line effective profile (per-line override → cast member), parse inline [voice:] and [pause], split into spans, fold pauses into previous span (or create leading silent span), drop empty lines and empty chapters.
- Tests:
  - frontend/src/test/storyToSpans.test.js: 7 Vitest unit tests covering cast resolution, chapter breaks, per-line voice overrides, pause folding, voice switching mid-line, empty-line/chapter dropping, and leading-pause silent spans.

## Tests & CI
- storyToSpans covered by 7 unit tests.
- CI reported: 64 backend + 333 frontend tests green; build clean (per PR summary).

## UI change — compact before/after sketch (StoriesEditor export area)

Before:
+----------------------------------+
| [Export] [Format: WAV] [Stems]   |
| (client-side chunked stitching)  |
+----------------------------------+

After:
+----------------------------------+
| [Export] [Format: M4B ▾] [Stems] |
| (POST compiled plan → /longform) |
| SSE progress: 0% ───── 100%      |
+----------------------------------+

## Architecture Flow (new)

flowchart LR
  A[StoriesEditor tracks] -->|storyToSpans| B[Chapter/Span Plan]
  B -->|POST /longform/render| C[Server _render_longform_sse]
  C -->|per-chapter cached synth| D[GPU synth / longform_cache]
  D -->|chapter WAVs| E[FFmpeg concat & mux]
  E -->|output M4B/MP3| F[Stored output (audioUrl)]
  C -->|SSE events| G[Client SSE stream -> progress UI]
  G -->|on done| H[downloadUrl(audioUrl(...))]

## Impact
- Resource efficiency: GPU synthesis and caching moved to server; browser freed during export.
- Fault isolation & resumability: per-chapter failures don't block whole job; cached chapters enable resume.
- Unified pipeline: Audiobook and Stories share renderer, cache, job tracking, and ffmpeg muxing.
- Deferred work: per-line regenerate and emotion→instruct wiring remain for subsequent PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->