### PR TITLE
fix(ci): make Docker Hub description sync non-fatal

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,8 +118,17 @@ jobs:
       # Sync the Docker Hub repository overview from deploy/dockerhub-overview.md.
       # Only on main pushes (the overview tracks the rolling preview) and only
       # when Docker Hub creds are present, mirroring the push gating above.
+      #
+      # continue-on-error: the overview text is cosmetic, and the description
+      # PATCH 403s unless DOCKERHUB_TOKEN carries description-edit scope (many
+      # fine-grained Docker Hub tokens that can push still can't edit the
+      # description). The image build+push is what matters — a creds-scope
+      # mismatch on this cosmetic step must not fail the whole Docker run. To
+      # actually sync the overview, use a token with read/write (incl.
+      # description) scope, or the account password.
       - name: Update Docker Hub description
         if: steps.dockerhub.outputs.enabled == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Problem

The **Docker (GHCR)** workflow on `main` reds-out at the **"Update Docker Hub description"** step with `##[error]Forbidden` — even though *build + push succeed*. `DOCKERHUB_TOKEN` can push images but lacks the scope to PATCH the repo description (a common limitation of fine-grained Docker Hub tokens). The cosmetic overview sync (added with `deploy/dockerhub-overview.md`) was failing the whole run.

[Failing job](https://github.com/debpalash/OmniVoice-Studio/actions/runs/27462388337/job/81178480569) — build+push ✅, description PATCH → 403.

## Fix

`continue-on-error: true` on that step. The image is what matters; a creds-scope mismatch on a cosmetic description sync must not fail the build.

To actually sync the overview later: give `DOCKERHUB_TOKEN` read/write (incl. description) scope, or use the account password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR makes the "Update Docker Hub description" step in the Docker workflow non-fatal by adding `continue-on-error: true`. The step can fail with HTTP 403 when the DOCKERHUB_TOKEN lacks permission to update repository metadata (a common limitation of fine-grained tokens that only have push scope). The change prevents such credential-scope mismatches from failing the entire Docker build-and-push workflow, as the actual image build and push operations are what matter.

Added comments document the token scope limitation and note that syncing the description properly would require either a token with full read/write (description) scope or the account password.

**Changed files:** `.github/workflows/docker.yml`

**Mechanism change:**

```mermaid
flowchart TD
    A[Docker build/push] --> B{Success?}
    B -->|Yes| C[Update Docker Hub description]
    C --> D{Success?}
    
    subgraph Old["❌ Old behavior"]
        D1{Success?}
        D1 -->|No| E1["❌ FAIL entire job"]
        D1 -->|Yes| F1["✅ Complete"]
    end
    
    subgraph New["✅ New behavior"]
        D -->|No| E["⚠️ Log error, continue"]
        E --> F["✅ Complete (job passes)"]
        D -->|Yes| F
    end
```

The step only runs when Docker Hub credentials are enabled and the workflow is triggered by a push to `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->