### PR TITLE
fix(stories): thread per-line speed through the shared renderer (PR 6/8)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -214,11 +214,12 @@ def _build_synth(default_voice: str | None) -> dict:
 
     backend = cls()
 
-    def synth(text, voice_id):
+    def synth(text, voice_id, speed=None):
         v = resolve(voice_id)
         return backend.generate(
             text, language=None, ref_audio=v["ref_audio"],
             ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
+            speed=float(speed) if speed else 1.0,
         )
     return {"mode": "generic", "resolve": resolve, "engine_id": engine_id,
             "synth": synth, "sample_rate": backend.sample_rate}
@@ -234,11 +235,12 @@ async def _prepare_synth(default_voice: str | None):
         model = await info["get_model"]()
         sr = getattr(model, "sampling_rate", 24000)
 
-        def synth(text, voice_id):
+        def synth(text, voice_id, speed=None):
             v = resolve(voice_id)
             return model.generate(
                 text=text, language=None, ref_audio=v["ref_audio"],
                 ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
+                speed=float(speed) if speed else 1.0,
             )[0]
         return synth, sr, resolve, engine_id
     return info["synth"], info["sample_rate"], resolve, engine_id
@@ -257,7 +259,8 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir):
     from services.audio_io import atomic_save_wav
     from services.longform_render import chapter_cache_key
 
-    spans_tuples = [(s.voice_id, s.text, s.pause_ms_after) for s in chapter.spans]
+    spans_tuples = [(s.voice_id, s.text, s.pause_ms_after, getattr(s, "speed", None))
+                    for s in chapter.spans]
     sig: dict = {}
     for s in chapter.spans:
         k = s.voice_id or ""
@@ -469,6 +472,7 @@ class LongformSpan(BaseModel):
     voice_id: str | None = None
     text: str
     pause_ms_after: int = 0
+    speed: float | None = None
 
 
 class LongformChapter(BaseModel):
@@ -498,7 +502,7 @@ async def longform_render(req: LongformRenderRequest):
         # Keep a span if it has text to speak OR a pause to render (pause-only
         # spans carry inter-line silence with empty text).
         spans = [Span(voice_id=s.voice_id, text=(s.text or "").strip(),
-                      pause_ms_after=max(0, int(s.pause_ms_after)))
+                      pause_ms_after=max(0, int(s.pause_ms_after)), speed=s.speed)
                  for s in c.spans if ((s.text and s.text.strip()) or s.pause_ms_after > 0)]
         if spans:
             chapters.append(Chapter(title=c.title or f"Chapter {i + 1}", spans=spans))

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -44,14 +44,20 @@ _VOICE_RE = re.compile(r"\[voice:([^\]\[]*)\]")
 
 @dataclass
 class Span:
-    """One contiguous run of text in a single voice, plus trailing silence."""
+    """One contiguous run of text in a single voice, plus trailing silence.
+
+    ``speed`` (when set) is the per-span rate passed to the engine — Stories'
+    per-line speed slider rides through here so the shared server render honours
+    it the way the old client export did.
+    """
     voice_id: Optional[str]
     text: str
     pause_ms_after: int = 0
+    speed: Optional[float] = None
 
     def to_dict(self) -> dict:
         return {"voice_id": self.voice_id, "text": self.text,
-                "pause_ms_after": self.pause_ms_after}
+                "pause_ms_after": self.pause_ms_after, "speed": self.speed}
 
 
 @dataclass
@@ -138,16 +144,17 @@ def parse_audiobook_script(text: str, *, default_voice: Optional[str] = None) ->
 
 def synthesize_chapter(
     spans: list[Span],
-    synth: Callable[[str, Optional[str]], "object"],
+    synth: Callable[[str, Optional[str], Optional[float]], "object"],
     sample_rate: int,
     *,
     crossfade_ms: int = 50,
 ):
     """Render a chapter's spans to one waveform via an injected ``synth``.
 
-    ``synth(text, voice_id)`` returns a 1-D float32 audio tensor for a span of
-    text in the given voice. Long spans are split with the ``chunked_tts``
-    splitter and crossfaded; inter-span ``pause_ms_after`` becomes silence.
+    ``synth(text, voice_id, speed)`` returns a 1-D float32 audio tensor for a
+    span of text in the given voice (``speed`` may be ``None`` for the engine
+    default). Long spans are split with the ``chunked_tts`` splitter and
+    crossfaded; inter-span ``pause_ms_after`` becomes silence.
 
     Returns ``(audio_tensor, duration_seconds)``. torch + chunked_tts are
     imported lazily so this module stays import-light for the pure parser path.
@@ -159,7 +166,7 @@ def synthesize_chapter(
     for span in spans:
         if span.text:
             chunks = split_text_into_chunks(span.text)
-            rendered = [synth(c, span.voice_id) for c in chunks]
+            rendered = [synth(c, span.voice_id, span.speed) for c in chunks]
             rendered = [r for r in rendered if r is not None and getattr(r, "numel", lambda: 0)()]
             if len(rendered) == 1:
                 parts.append(rendered[0])

--- a/backend/services/longform_render.py
+++ b/backend/services/longform_render.py
@@ -60,7 +60,7 @@ def _escape_meta(value: str) -> str:
 # ── Chapter cache key (resume) ──────────────────────────────────────────────
 
 def chapter_cache_key(
-    spans: Iterable[tuple[Optional[str], str, int]],
+    spans: Iterable[tuple],
     *,
     sample_rate: int,
     engine_id: str,
@@ -68,17 +68,18 @@ def chapter_cache_key(
 ) -> str:
     """Deterministic content hash for a chapter's rendered audio.
 
-    ``spans`` is an ordered list of ``(voice_id, text, pause_ms_after)``. Same
-    inputs → same key → reuse the cached chapter WAV on a re-run (resume); any
-    change (text, voice, order, pauses, sample rate, engine, or a voice's
-    resolved signature) → new key → re-render. ``voice_sig`` maps each voice id
-    to a stable signature string (e.g. ``ref_audio|instruct|seed``) so editing
-    the underlying profile also invalidates the cache.
+    ``spans`` is an ordered list of ``(voice_id, text, pause_ms_after[, speed])``
+    (speed optional, defaults to None). Same inputs → same key → reuse the
+    cached chapter WAV on a re-run (resume); any change (text, voice, order,
+    pauses, speed, sample rate, engine, or a voice's resolved signature) → new
+    key → re-render. ``voice_sig`` maps each voice id to a stable signature
+    string (e.g. ``ref_audio|instruct|seed``) so editing the underlying profile
+    also invalidates the cache.
     """
     payload = {
         "sr": int(sample_rate),
         "engine": engine_id or "",
-        "spans": [[v, t, int(p)] for (v, t, p) in spans],
+        "spans": [[s[0], s[1], int(s[2]), (s[3] if len(s) > 3 else None)] for s in spans],
         "voices": {k: voice_sig[k] for k in sorted(voice_sig)} if voice_sig else {},
     }
     raw = json.dumps(payload, sort_keys=True, ensure_ascii=False)

--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -97,7 +97,7 @@ export async function audiobookImport(file: File): Promise<{ text: string; chapt
 }
 
 export interface LongformRenderBody {
-  chapters: Array<{ title?: string; spans: Array<{ voice_id: string | null; text: string; pause_ms_after: number }> }>;
+  chapters: Array<{ title?: string; spans: Array<{ voice_id: string | null; text: string; pause_ms_after: number; speed?: number | null }> }>;
   default_voice?: string | null;
   bitrate?: string;
   format?: 'm4b' | 'mp3';

--- a/frontend/src/test/storyToSpans.test.js
+++ b/frontend/src/test/storyToSpans.test.js
@@ -15,8 +15,8 @@ describe('storyToSpans', () => {
     const chapters = storyToSpans(tracks, CAST);
     expect(chapters).toHaveLength(1);
     expect(chapters[0].spans).toEqual([
-      { voice_id: 'p_narr', text: 'Once upon a time.', pause_ms_after: 0 },
-      { voice_id: 'p_fox', text: 'Hello there.', pause_ms_after: 0 },
+      { voice_id: 'p_narr', text: 'Once upon a time.', pause_ms_after: 0, speed: null },
+      { voice_id: 'p_fox', text: 'Hello there.', pause_ms_after: 0, speed: null },
     ]);
   });
 
@@ -29,7 +29,7 @@ describe('storyToSpans', () => {
     ];
     const chapters = storyToSpans(tracks, CAST);
     expect(chapters.map((c) => c.title)).toEqual(['Chapter One', 'Chapter Two']);
-    expect(chapters[1].spans[0]).toEqual({ voice_id: 'p_fox', text: 'More.', pause_ms_after: 0 });
+    expect(chapters[1].spans[0]).toEqual({ voice_id: 'p_fox', text: 'More.', pause_ms_after: 0, speed: null });
   });
 
   it('honors a per-line voice override', () => {
@@ -37,11 +37,17 @@ describe('storyToSpans', () => {
     expect(storyToSpans(tracks, CAST)[0].spans[0].voice_id).toBe('p_override');
   });
 
+  it('carries the per-line speed onto its spans', () => {
+    const tracks = [{ character: 'narrator', text: 'Slow. [pause 0.2s] down.', speed: 0.8 }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans.every((s) => s.speed === 0.8)).toBe(true);
+  });
+
   it('folds [pause] into the previous span', () => {
     const tracks = [{ character: 'narrator', text: 'Wait. [pause 0.5s] Done.' }];
     const spans = storyToSpans(tracks, CAST)[0].spans;
-    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: 'Wait.', pause_ms_after: 500 });
-    expect(spans[1]).toEqual({ voice_id: 'p_narr', text: 'Done.', pause_ms_after: 0 });
+    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: 'Wait.', pause_ms_after: 500, speed: null });
+    expect(spans[1]).toEqual({ voice_id: 'p_narr', text: 'Done.', pause_ms_after: 0, speed: null });
   });
 
   it('switches voice mid-line on [voice:]', () => {
@@ -65,7 +71,7 @@ describe('storyToSpans', () => {
   it('a leading pause becomes a silent span', () => {
     const tracks = [{ character: 'narrator', text: '[pause 1s] Go.' }];
     const spans = storyToSpans(tracks, CAST)[0].spans;
-    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: '', pause_ms_after: 1000 });
+    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: '', pause_ms_after: 1000, speed: null });
     expect(spans[1].text).toBe('Go.');
   });
 });

--- a/frontend/src/utils/storyToSpans.js
+++ b/frontend/src/utils/storyToSpans.js
@@ -30,14 +30,15 @@ export function storyToSpans(tracks, cast) {
       continue;
     }
     const profileId = effectiveProfile(tk, cast) || null;
+    const speed = tk.speed || null;  // per-line rate rides through to the engine
     for (const seg of parseStoryText(text, profileId)) {
       if (seg.type === 'pause') {
         const ms = Math.round(seg.seconds * 1000);
         const last = cur.spans[cur.spans.length - 1];
         if (last) last.pause_ms_after += ms;
-        else cur.spans.push({ voice_id: profileId, text: '', pause_ms_after: ms });
+        else cur.spans.push({ voice_id: profileId, text: '', pause_ms_after: ms, speed });
       } else if (seg.text) {
-        cur.spans.push({ voice_id: seg.profileId || null, text: seg.text, pause_ms_after: 0 });
+        cur.spans.push({ voice_id: seg.profileId || null, text: seg.text, pause_ms_after: 0, speed });
       }
     }
   }

--- a/tests/test_audiobook.py
+++ b/tests/test_audiobook.py
@@ -124,8 +124,8 @@ def test_synthesize_chapter_stitches_spans_and_silence():
     sr = 16000
     calls = []
 
-    def synth(text, voice_id):
-        calls.append((text, voice_id))
+    def synth(text, voice_id, speed=None):
+        calls.append((text, voice_id, speed))
         return torch.ones(1000, dtype=torch.float32)  # 1000 samples per chunk
 
     plan = parse_audiobook_script("First. [pause 1s] Second.", default_voice="v")
@@ -138,6 +138,6 @@ def test_synthesize_chapter_stitches_spans_and_silence():
 
 def test_synthesize_empty_spans_is_silent():
     torch = pytest.importorskip("torch")
-    audio, dur = synthesize_chapter([], lambda t, v: torch.ones(10), 16000)
+    audio, dur = synthesize_chapter([], lambda t, v, s=None: torch.ones(10), 16000)
     assert audio.shape[-1] == 0
     assert dur == 0.0

--- a/tests/test_longform_render.py
+++ b/tests/test_longform_render.py
@@ -200,6 +200,8 @@ def test_cache_key_deterministic():
     lambda: chapter_cache_key(_SPANS, sample_rate=24000, engine_id="kokoro"),                 # engine
     lambda: chapter_cache_key(_SPANS, sample_rate=24000, engine_id="omnivoice",
                               voice_sig={"narrator": "ref.wav|warm|7"}),                       # voice sig
+    lambda: chapter_cache_key([(None, "Once upon a time.", 350, 0.8), ("narrator", "The end.", 0)],
+                              sample_rate=24000, engine_id="omnivoice"),                       # speed
 ])
 def test_cache_key_changes_on_any_input(mutate):
     base = chapter_cache_key(_SPANS, sample_rate=24000, engine_id="omnivoice")


### PR DESCRIPTION
PR 5 moved Stories' full export to `/longform/render` but **dropped per-line speed** — the old client export sent each line's speed to `/generate`; the converged path silently ignored it. This restores it end-to-end (a real regression fix).

## Changes
- `Span` gains optional **`speed`**; `synthesize_chapter` passes it to the injected synth (signature now `synth(text, voice_id, speed)`); both engine paths (OmniVoice model + generic `TTSBackend`) forward it to `generate(speed=…)`.
- `chapter_cache_key` now folds in speed (a speed change re-renders). Tuples accept an optional 4th element, so existing 3-tuple callers/tests keep working.
- `LongformSpan` + `/longform/render` carry `speed`; `storyToSpans` emits each line's speed onto its spans.

## Emotion note
Per-line tone is already **model-native via inline tags** (`[laughter]` etc.) inserted into the line text, so no separate emotion→instruct plumbing is needed — the dead `emotion` store field stays superseded (documented, not built).

## Tests
`storyToSpans` speed passthrough; `chapter_cache_key` speed sensitivity; synth stubs updated for the 3-arg signature. **65 backend + 334 frontend green; build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Per-Line Speed Propagation Through Audiobook/Stories Synthesis

This PR restores per-line speed support in the Stories audiobook export pipeline, enabling each line's playback speed to flow end-to-end from the frontend UI through the shared backend renderer to the TTS engine.

### Speed Propagation Flowchart

```mermaid
graph TD
    A["Story Line with Speed Slider<br/>(Frontend UI)"] -->|tk.speed| B["storyToSpans<br/>(frontend/src/utils/storyToSpans.js)"]
    B -->|speed in span object| C["LongformRenderBody<br/>(POST /longform/render)"]
    C -->|LongformSpan.speed| D["longform_render endpoint<br/>(backend/api/routers/audiobook.py)"]
    D -->|speed in Span dataclass| E["synthesize_chapter<br/>(backend/services/audiobook.py)"]
    E -->|synth<br/>text, voice_id, speed| F{"Active Engine"}
    F -->|OmniVoice Path| G["model.generate<br/>speed=float"]
    F -->|Generic TTSBackend Path| H["backend.generate<br/>speed=float"]
    G -->|Audio| I["Chapter Cache Key<br/>includes speed"]
    H -->|Audio| I
    I -->|Cache Invalidation| J["Rendered Audio<br/>at specified speed"]
```

### Key Changes

**Backend API (`backend/api/routers/audiobook.py`)**
- `LongformSpan` dataclass gains optional `speed: float | None = None` field
- The `/longform/render` endpoint now passes speed from the request payload into constructed `Span` objects

**Backend Services**
- **`Span` dataclass** (`backend/services/audiobook.py`): Added optional `speed: Optional[float]` field; `to_dict()` now serializes it
- **`synthesize_chapter` function** now accepts injected `synth` with signature `synth(text, voice_id, speed)` (previously `synth(text, voice_id)`), and passes `span.speed` for each chunk
- **Synth builders** (`_build_synth`, `_prepare_synth` in `audiobook.py`): Both OmniVoice (`model.generate`) and generic TTSBackend (`backend.generate`) paths now forward `speed=float(speed)` (defaulting to `1.0` when omitted)
- **Cache key logic** (`chapter_cache_key` in `backend/services/longform_render.py`): Updated to include per-span speed values in cache key tuples, ensuring changes in speed trigger re-rendering; tuple signature now accepts optional 4th element while remaining compatible with existing 3-tuple callers

**Frontend**
- **`LongformRenderBody` interface** (`frontend/src/api/audiobook.ts`): Each chapter span now accepts optional `speed?: number | null` field
- **`storyToSpans` function** (`frontend/src/utils/storyToSpans.js`): Propagates `tk.speed || null` into emitted span objects; when a `[pause]` creates a silent span (no preceding span), it includes the current line's speed; when a `[pause]` extends an existing span, the existing span's speed is unchanged

### Design Rationale

Speed is propagated as optional fields throughout the chain (`null` where not specified), allowing graceful degradation—engines that don't support speed or calls that omit it default to normal playback rate. The existing per-line emotion approach remains model-native via inline tags; the legacy emotion store field is superseded and unused. Chapter caching correctly invalidates when speed changes, maintaining cache correctness across different rendering configurations.

### Testing

- New test case verifies per-line speed is propagated onto all generated spans
- Updated `synthesize_chapter` test stubs to accept the new 3-argument `synth` signature
- Cache key tests extended to validate speed-based invalidation
- 65 backend + 334 frontend tests passing; build clean

<!-- end of auto-generated comment: release notes by coderabbit.ai -->