### PR TITLE
fix(longform): correctness + robustness fixes from adversarial review

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -85,6 +85,12 @@ def audiobook_plan(req: AudiobookPlanRequest) -> dict:
 #: Cover size cap mirrors longform_render's guard (8 MB — a book cover, not a
 #: payload). Kept in sync intentionally; the render builder re-validates too.
 _COVER_MAX_BYTES = 8 * 1024 * 1024
+#: Import upload cap — a generous ceiling for a .txt/.md/.epub manuscript that
+#: still stops a memory-exhaustion upload (the whole file is read into RAM).
+_IMPORT_MAX_BYTES = 64 * 1024 * 1024
+#: Upper bound on chapters in a single /longform/render plan — far above any real
+#: book, but stops a pathological request from allocating/holding the job forever.
+_MAX_CHAPTERS = 10_000
 
 
 @router.post("/audiobook/import")
@@ -100,6 +106,8 @@ async def audiobook_import(file: UploadFile = File(...)) -> dict:
     data = await file.read()
     if not data:
         raise HTTPException(status_code=400, detail="empty file")
+    if len(data) > _IMPORT_MAX_BYTES:
+        raise HTTPException(status_code=400, detail="file too large (max 64 MB)")
     if name.endswith(".epub"):
         try:
             script = epub_to_chapter_script(data)
@@ -266,7 +274,7 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir):
         k = s.voice_id or ""
         if k not in sig:
             v = resolve(s.voice_id)
-            sig[k] = f"{v.get('ref_audio')}|{v.get('instruct')}|{v.get('seed')}"
+            sig[k] = f"{v.get('ref_audio')}|{v.get('ref_text')}|{v.get('instruct')}|{v.get('seed')}"
     key = chapter_cache_key(spans_tuples, sample_rate=sr, engine_id=engine_id, voice_sig=sig)
     wav_path = os.path.join(cache_dir, f"{key}.wav")
 
@@ -307,7 +315,7 @@ async def audiobook_preview(req: AudiobookPreviewRequest) -> dict:
         raise HTTPException(status_code=400, detail=f"chapter_index out of range (0..{n - 1})")
 
     chapter = plan.chapters[req.chapter_index]
-    cache_dir = os.path.join(OUTPUTS_DIR, "audiobook_cache")
+    cache_dir = os.path.join(OUTPUTS_DIR, "longform_cache")  # shared with _render_longform_sse
     os.makedirs(cache_dir, exist_ok=True)
     synth, sr, resolve, engine_id = await _prepare_synth(req.default_voice)
     loop = asyncio.get_running_loop()
@@ -496,6 +504,9 @@ async def longform_render(req: LongformRenderRequest):
     cast+lines) through the shared chapterized renderer — same resume, loudness,
     cover, metadata, and output formats as the Audiobook job."""
     from services.audiobook import AudiobookPlan, Chapter, Span
+
+    if len(req.chapters) > _MAX_CHAPTERS:
+        raise HTTPException(status_code=422, detail=f"too many chapters (max {_MAX_CHAPTERS})")
 
     chapters = []
     for i, c in enumerate(req.chapters):

--- a/backend/services/longform_import.py
+++ b/backend/services/longform_import.py
@@ -126,12 +126,19 @@ def _opf_path(zf: zipfile.ZipFile) -> str:
     return rootfile.get("full-path")
 
 
-def epub_to_chapter_script(data: bytes) -> str:
+def epub_to_chapter_script(
+    data: bytes,
+    *,
+    max_entry_bytes: int = _EPUB_MAX_ENTRY_BYTES,
+    max_total_bytes: int = _EPUB_MAX_TOTAL_BYTES,
+) -> str:
     """Convert EPUB bytes into a ``# Chapter`` / body script in spine order.
 
     Reads the OPF manifest + spine (the publisher's reading order), extracts
     each document's title + visible text, and emits one ``# Title`` block per
-    document with renderable text. Raises ``ValueError`` on a malformed EPUB.
+    document with renderable text. ``max_entry_bytes`` / ``max_total_bytes``
+    bound the *uncompressed* bytes read (zip-bomb guard). Raises ``ValueError``
+    on a malformed EPUB.
     """
     try:
         zf = zipfile.ZipFile(io.BytesIO(data))
@@ -165,9 +172,9 @@ def epub_to_chapter_script(data: bytes) -> str:
             info = zf.getinfo(full)
         except KeyError:
             continue
-        if info.file_size > _EPUB_MAX_ENTRY_BYTES:
+        if info.file_size > max_entry_bytes:
             continue
-        if total + info.file_size > _EPUB_MAX_TOTAL_BYTES:
+        if total + info.file_size > max_total_bytes:
             break
         try:
             raw = zf.read(full)

--- a/backend/services/longform_import.py
+++ b/backend/services/longform_import.py
@@ -25,6 +25,10 @@ _CH_RE = re.compile(r"^(?:chapter|part|book|prologue|epilogue|section)\b", re.IG
 # Already-present Markdown H1 — if the text has any, we leave it untouched.
 _H1_RE = re.compile(r"^[ \t]*#[ \t]+\S", re.MULTILINE)
 _CHAPTER_TITLE_MAX = 60
+# Zip-bomb / OOM guards for EPUB ingestion: per-entry and cumulative caps on
+# *uncompressed* bytes read from the archive.
+_EPUB_MAX_ENTRY_BYTES = 25 * 1024 * 1024
+_EPUB_MAX_TOTAL_BYTES = 300 * 1024 * 1024
 
 
 def chapterize_plaintext(text: str) -> str:
@@ -146,6 +150,7 @@ def epub_to_chapter_script(data: bytes) -> str:
 
     blocks: list[str] = []
     names = set(zf.namelist())
+    total = 0  # cumulative uncompressed bytes read — zip-bomb guard
     for ref in opf.findall(".//opf:spine/opf:itemref", _OPF_NS):
         href = manifest.get(ref.get("idref") or "")
         if not href:
@@ -153,11 +158,23 @@ def epub_to_chapter_script(data: bytes) -> str:
         full = posixpath.normpath(posixpath.join(base, href)) if base else href
         if full not in names:
             continue
+        # Bound decompression: skip an absurdly large entry, and stop once the
+        # cumulative uncompressed size crosses the ceiling (defends against a
+        # zip bomb / a maliciously huge chapter exhausting memory).
         try:
-            xhtml = zf.read(full).decode("utf-8", "ignore")
+            info = zf.getinfo(full)
         except KeyError:
             continue
-        title, body = _html_to_title_body(xhtml)
+        if info.file_size > _EPUB_MAX_ENTRY_BYTES:
+            continue
+        if total + info.file_size > _EPUB_MAX_TOTAL_BYTES:
+            break
+        try:
+            raw = zf.read(full)
+        except KeyError:
+            continue
+        total += len(raw)
+        title, body = _html_to_title_body(raw.decode("utf-8", "ignore"))
         if not body.strip():
             continue  # nav docs, empty pages
         title = title or f"Chapter {len(blocks) + 1}"

--- a/backend/services/longform_render.py
+++ b/backend/services/longform_render.py
@@ -205,18 +205,23 @@ def build_render_cmd(
     if not _BITRATE_RE.match(bitrate or ""):
         bitrate = "128k"
     is_mp3 = (fmt or "").lower() == "mp3"
-    have_cover = validate_cover_image(cover_path)
+    # Cover art is embedded for M4B only. The MP3 muxer rejects an
+    # ``attached_pic`` video stream via ``-c:v copy`` (produces a corrupt file
+    # across ffmpeg versions), and a reliable cross-version ID3 APIC path is
+    # finicky — so for MP3 we skip the cover rather than ship a broken file.
+    # M4B is the cover-bearing audiobook format anyway.
+    embed_cover = validate_cover_image(cover_path) and not is_mp3
 
     cmd = [
         ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
         "-f", "concat", "-safe", "0", "-i", str(concat_list_path),
         "-i", str(metadata_path),
     ]
-    if have_cover:
+    if embed_cover:
         cmd += ["-i", str(cover_path)]
 
     cmd += ["-map", "0:a", "-map_metadata", "1"]
-    if have_cover:
+    if embed_cover:
         cmd += ["-map", "2:v", "-disposition:v", "attached_pic"]
 
     filt = build_loudnorm_filter(loudness)
@@ -224,13 +229,10 @@ def build_render_cmd(
         cmd += ["-af", filt]
 
     if is_mp3:
-        cmd += ["-c:a", "libmp3lame", "-b:a", bitrate]
-        if have_cover:
-            cmd += ["-c:v", "copy", "-id3v2_version", "3"]
-        cmd += ["-f", "mp3", str(out_path)]
+        cmd += ["-c:a", "libmp3lame", "-b:a", bitrate, "-f", "mp3", str(out_path)]
     else:  # m4b — AAC in an mp4 container
         cmd += ["-c:a", "aac", "-b:a", bitrate]
-        if have_cover:
+        if embed_cover:
             cmd += ["-c:v", "copy"]
         cmd += ["-movflags", "+faststart", "-f", "mp4", str(out_path)]
     return cmd

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -261,7 +261,10 @@ export default function StoriesEditor({ profiles = [] }) {
   const insertPauseInto = useCallback((trackId) => insertTokenInto(trackId, '[pause 0.5s]'), [insertTokenInto]);
 
   const addTrack = useCallback(() => setTracks((prev) => [...prev, makeTrack()]), [setTracks]);
-  const removeTrack = useCallback((id) => setTracks((prev) => prev.filter((tk) => tk.id !== id)), [setTracks]);
+  const removeTrack = useCallback((id) => setTracks((prev) => prev.filter((tk) => {
+    if (tk.id === id && tk.audioUrl) URL.revokeObjectURL(tk.audioUrl);  // free the preview blob
+    return tk.id !== id;
+  })), [setTracks]);
   const updateTrack = useCallback((id, field, value) => {
     setTracks((prev) => prev.map((tk) => (tk.id === id ? { ...tk, [field]: value } : tk)));
   }, [setTracks]);

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookMarked, Loader, Download, Image as ImageIcon, X, Play, Upload } from 'lucide-react';
 
@@ -50,6 +50,9 @@ export default function AudiobookTab({ profiles = [] }) {
     if (coverPreview) URL.revokeObjectURL(coverPreview);
     setCoverPreview('');
   }, [coverPreview]);
+  // Revoke the cover blob URL when it's replaced or the tab unmounts (React
+  // doesn't reclaim object URLs on its own).
+  useEffect(() => () => { if (coverPreview) URL.revokeObjectURL(coverPreview); }, [coverPreview]);
 
   const [importing, setImporting] = useState(false);
 

--- a/tests/test_audiobook_preview.py
+++ b/tests/test_audiobook_preview.py
@@ -46,9 +46,10 @@ def test_render_chapter_cache_hit_skips_synth(tmp_path):
     chapter = Chapter(title="C1", spans=[Span(voice_id=None, text="hi", pause_ms_after=0)])
     resolve = lambda _vid: {"ref_audio": None, "instruct": None, "seed": None}  # noqa: E731
 
-    # Pre-seed the cache at the exact key this chapter will hash to.
-    sig = {"": "None|None|None"}
-    key = chapter_cache_key([(None, "hi", 0)], sample_rate=sr, engine_id="eng", voice_sig=sig)
+    # Pre-seed the cache at the exact key this chapter will hash to. The voice
+    # signature is ref_audio|ref_text|instruct|seed (all None here).
+    sig = {"": "None|None|None|None"}
+    key = chapter_cache_key([(None, "hi", 0, None)], sample_rate=sr, engine_id="eng", voice_sig=sig)
     _write_wav(tmp_path / f"{key}.wav", sr=sr, frames=sr // 2)  # 0.5 s
 
     def boom(*_a, **_k):

--- a/tests/test_longform_import.py
+++ b/tests/test_longform_import.py
@@ -122,3 +122,23 @@ def test_epub_strips_html_tags():
 def test_epub_bad_zip_raises_valueerror():
     with pytest.raises(ValueError):
         epub_to_chapter_script(b"not a zip at all")
+
+
+def test_epub_total_size_cap_truncates(monkeypatch):
+    import services.longform_import as li
+    # Tiny total cap → only the first chapter's bytes fit; the rest are skipped
+    # (zip-bomb / OOM guard). Each synthetic chapter body is ~?; cap below two.
+    # Cap sits between one and two chapter docs (~1.1 KB uncompressed each), so
+    # the first is read and the rest are skipped.
+    monkeypatch.setattr(li, "_EPUB_MAX_TOTAL_BYTES", 1500)
+    data = _make_epub([("One", "x" * 1000), ("Two", "y" * 1000), ("Three", "z" * 1000)])
+    plan = parse_audiobook_script(epub_to_chapter_script(data))
+    assert 1 <= len(plan.chapters) < 3  # capped before reading all three
+
+
+def test_epub_oversize_entry_skipped(monkeypatch):
+    import services.longform_import as li
+    monkeypatch.setattr(li, "_EPUB_MAX_ENTRY_BYTES", 50)  # smaller than any chapter doc
+    data = _make_epub([("Big", "x" * 500)])
+    with pytest.raises(ValueError):  # all entries skipped → no readable chapters
+        epub_to_chapter_script(data)

--- a/tests/test_longform_import.py
+++ b/tests/test_longform_import.py
@@ -124,21 +124,16 @@ def test_epub_bad_zip_raises_valueerror():
         epub_to_chapter_script(b"not a zip at all")
 
 
-def test_epub_total_size_cap_truncates(monkeypatch):
-    import services.longform_import as li
-    # Tiny total cap → only the first chapter's bytes fit; the rest are skipped
-    # (zip-bomb / OOM guard). Each synthetic chapter body is ~?; cap below two.
+def test_epub_total_size_cap_truncates():
     # Cap sits between one and two chapter docs (~1.1 KB uncompressed each), so
-    # the first is read and the rest are skipped.
-    monkeypatch.setattr(li, "_EPUB_MAX_TOTAL_BYTES", 1500)
+    # the first is read and the rest skipped. Caps passed directly (no
+    # monkeypatch) so the bound holds regardless of module import path.
     data = _make_epub([("One", "x" * 1000), ("Two", "y" * 1000), ("Three", "z" * 1000)])
-    plan = parse_audiobook_script(epub_to_chapter_script(data))
+    plan = parse_audiobook_script(epub_to_chapter_script(data, max_total_bytes=1500))
     assert 1 <= len(plan.chapters) < 3  # capped before reading all three
 
 
-def test_epub_oversize_entry_skipped(monkeypatch):
-    import services.longform_import as li
-    monkeypatch.setattr(li, "_EPUB_MAX_ENTRY_BYTES", 50)  # smaller than any chapter doc
+def test_epub_oversize_entry_skipped():
     data = _make_epub([("Big", "x" * 500)])
-    with pytest.raises(ValueError):  # all entries skipped → no readable chapters
-        epub_to_chapter_script(data)
+    with pytest.raises(ValueError):  # the one entry exceeds the cap → all skipped
+        epub_to_chapter_script(data, max_entry_bytes=50)

--- a/tests/test_longform_limits.py
+++ b/tests/test_longform_limits.py
@@ -1,0 +1,40 @@
+"""Input bounds on the longform endpoints (review findings #4/#5).
+
+Direct handler calls (no main/torch import). Caps are monkeypatched small so the
+tests stay cheap.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+import api.routers.audiobook as ab
+from api.routers.audiobook import (
+    LongformChapter,
+    LongformRenderRequest,
+    LongformSpan,
+    audiobook_import,
+    longform_render,
+)
+
+
+def test_import_rejects_oversize(monkeypatch):
+    monkeypatch.setattr(ab, "_IMPORT_MAX_BYTES", 10)
+    up = UploadFile(io.BytesIO(b"x" * 50), filename="big.txt")
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(audiobook_import(up))
+    assert ei.value.status_code == 400
+
+
+def test_longform_render_rejects_too_many_chapters(monkeypatch):
+    monkeypatch.setattr(ab, "_MAX_CHAPTERS", 1)
+    req = LongformRenderRequest(chapters=[
+        LongformChapter(title="A", spans=[LongformSpan(text="hi")]),
+        LongformChapter(title="B", spans=[LongformSpan(text="yo")]),
+    ])
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(longform_render(req))
+    assert ei.value.status_code == 422

--- a/tests/test_longform_render.py
+++ b/tests/test_longform_render.py
@@ -177,6 +177,18 @@ def test_render_cmd_drops_invalid_cover(tmp_path):
     assert "attached_pic" not in cmd  # silently dropped, render still proceeds
 
 
+def test_render_cmd_mp3_never_embeds_cover(tmp_path):
+    # A valid cover must NOT be wired into an MP3 (the attached_pic + -c:v copy
+    # combo produces a corrupt mp3); m4b is the cover-bearing format.
+    cover = tmp_path / "cover.jpg"
+    cover.write_bytes(b"\xff\xd8\xff" + b"x" * 50)
+    cmd = build_render_cmd("ffmpeg", "c", "m", "o.mp3", fmt="mp3", cover_path=str(cover))
+    assert "libmp3lame" in cmd
+    assert "attached_pic" not in cmd
+    assert str(cover) not in cmd
+    assert "-c:v" not in cmd
+
+
 # ── chapter cache key (resume) ──────────────────────────────────────────────
 
 _SPANS = [(None, "Once upon a time.", 350), ("narrator", "The end.", 0)]


### PR DESCRIPTION
Fixes the confirmed findings from a multi-agent adversarial review of the convergence (PRs #408–#416). The review ran 5 reviewers + per-finding verification and surfaced 10 real issues; this PR lands the HIGH ones + quick robustness/leak fixes.

## HIGH — correctness / output
- **MP3 + cover = corrupt file.** `-map 2:v -c:v copy` is invalid for the mp3 muxer. Cover art is now embedded for **M4B only**; mp3 skips it (m4b is the cover-bearing audiobook format).
- **Cache key omitted `ref_text`** → editing only a profile's `ref_text` served stale cached audio. `ref_text` is now part of the chapter cache's voice signature.
- **Preview/render cache-dir mismatch.** Preview wrote `audiobook_cache/` but `_render_longform_sse` reads `longform_cache/` (a rename missed in PR 5) → cache-warming silently broke. Unified to `longform_cache/`.

## Robustness — DoS / OOM guards
- `/audiobook/import` caps the upload at **64 MB**; `epub_to_chapter_script` bounds per-entry (**25 MB**) and cumulative (**300 MB**) uncompressed reads (zip-bomb guard).
- `/longform/render` rejects **> 10,000 chapters** (422).

## Frontend leaks
- `StoriesEditor.removeTrack` revokes the line's preview blob URL.
- `AudiobookTab` revokes the cover blob URL on replace/unmount.

## Deferred fast-follows (also from the review)
- Render-cache **disk eviction** (LRU/age/size) — caches grow unbounded today.
- Restore the **standalone chapter cue-sheet** export (needs chapter times in the `done` event; the m4b already embeds chapters).

## Tests
mp3-drops-cover, epub entry/total caps, import + chapter-count limits; updated the cache-hit test for the 4-field voice sig. **70 backend + 334 frontend green; build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR updates EPUB ingestion to accept explicit per-entry and total uncompressed-byte caps (zip-bomb/OOM guards) and adjusts tests to pass those caps as arguments rather than monkeypatching module constants.

## EPUB ingestion: configurable zip-bomb protections

- Function signature change:
  - epub_to_chapter_script(data: bytes) → epub_to_chapter_script(data: bytes, *, max_entry_bytes: int = _EPUB_MAX_ENTRY_BYTES, max_total_bytes: int = _EPUB_MAX_TOTAL_BYTES) -> str
  - New kwargs bound the *uncompressed* bytes read from each Zip entry and cumulatively across the archive.

- Runtime behavior:
  - Skip spine entries whose ZipInfo.file_size > max_entry_bytes.
  - Stop processing further spine items once total uncompressed bytes + next entry’s file_size > max_total_bytes.
  - Raises ValueError for malformed EPUBs or when no readable chapters remain.

- Module-level defaults remain (_EPUB_MAX_ENTRY_BYTES, _EPUB_MAX_TOTAL_BYTES) but tests (and callers) can override per-call.

## Tests

- tests/test_longform_import.py:
  - test_epub_total_size_cap_truncates now calls epub_to_chapter_script(..., max_total_bytes=1500) instead of monkeypatching module constants.
  - test_epub_oversize_entry_skipped now calls epub_to_chapter_script(..., max_entry_bytes=50) and asserts ValueError.
  - Avoids import-path monkeypatch fragility by passing caps directly.

## Notes / Impact

- Provides safer, deterministic EPUB parsing for hostile or malformed archives.
- Backwards-compatible for callers that omit the new kwargs (defaults preserved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->