### PR TITLE
feat(longform): pronunciation lexicon — per-render word respelling (PR 8a)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -152,6 +152,8 @@ class AudiobookRequest(BaseModel):
     # Global tags embedded in the output: {title, author, narrator, year,
     # genre, description}. Player-visible (Apple Books / Audible read these).
     metadata: dict | None = None
+    # Optional pronunciation lexicon {word: respelling} applied before synthesis.
+    lexicon: dict | None = None
 
 
 def _resolve_voice(profile_id: str | None) -> dict:
@@ -254,18 +256,21 @@ async def _prepare_synth(default_voice: str | None):
     return info["synth"], info["sample_rate"], resolve, engine_id
 
 
-def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir):
+def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, lexicon=None):
     """Render one chapter, content-addressed so a re-run reuses it (resume).
 
     Returns ``(wav_path, duration_s, was_cached)``. The WAV lives at
     ``cache_dir/<key>.wav`` where ``key`` is :func:`chapter_cache_key` over the
-    chapter's spans + sample rate + engine + each voice's resolved signature, so
-    an unchanged chapter is never re-synthesized. Runs in the GPU-pool executor.
+    chapter's spans + sample rate + engine + each voice's resolved signature
+    (+ the lexicon, so a lexicon edit re-renders), so an unchanged chapter is
+    never re-synthesized. Runs in the GPU-pool executor.
     """
+    import json
     import wave
 
     from services.audio_io import atomic_save_wav
     from services.longform_render import chapter_cache_key
+    from services.pronunciation import normalize_lexicon
 
     spans_tuples = [(s.voice_id, s.text, s.pause_ms_after, getattr(s, "speed", None))
                     for s in chapter.spans]
@@ -275,6 +280,10 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir):
         if k not in sig:
             v = resolve(s.voice_id)
             sig[k] = f"{v.get('ref_audio')}|{v.get('ref_text')}|{v.get('instruct')}|{v.get('seed')}"
+    if lexicon:
+        # Fold the lexicon into the cache key so editing pronunciations
+        # invalidates cached chapters (reserved key can't collide with a voice id).
+        sig["\x00lexicon"] = json.dumps(normalize_lexicon(lexicon), sort_keys=True)
     key = chapter_cache_key(spans_tuples, sample_rate=sr, engine_id=engine_id, voice_sig=sig)
     wav_path = os.path.join(cache_dir, f"{key}.wav")
 
@@ -286,7 +295,7 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir):
         except Exception:
             pass  # corrupt cache entry — fall through and re-render
 
-    audio, dur = synthesize_chapter(chapter.spans, synth, sr)
+    audio, dur = synthesize_chapter(chapter.spans, synth, sr, lexicon=lexicon)
     atomic_save_wav(wav_path, audio, sr)
     return wav_path, dur, False
 
@@ -295,6 +304,7 @@ class AudiobookPreviewRequest(BaseModel):
     text: str
     chapter_index: int = 0
     default_voice: str | None = None
+    lexicon: dict | None = None
 
 
 @router.post("/audiobook/preview")
@@ -321,6 +331,7 @@ async def audiobook_preview(req: AudiobookPreviewRequest) -> dict:
     loop = asyncio.get_running_loop()
     wav_path, dur, was_cached = await loop.run_in_executor(
         _gpu_pool, _render_chapter_cached, chapter, synth, sr, engine_id, resolve, cache_dir,
+        req.lexicon,
     )
     return {
         "output": os.path.relpath(wav_path, OUTPUTS_DIR),  # served via /audio
@@ -339,6 +350,7 @@ async def _render_longform_sse(
     loudness: str | None = None,
     cover_path: str | None = None,
     metadata: dict | None = None,
+    lexicon: dict | None = None,
     job_type: str = "audiobook",
 ):
     """Shared chapterized-render SSE generator for Audiobook *and* Stories.
@@ -401,7 +413,7 @@ async def _render_longform_sse(
             try:
                 wav_path, dur, was_cached = await loop.run_in_executor(
                     _gpu_pool, _render_chapter_cached,
-                    chapter, synth, sr, engine_id, resolve, cache_dir,
+                    chapter, synth, sr, engine_id, resolve, cache_dir, lexicon,
                 )
             except Exception:  # isolate a bad chapter — keep going
                 logger.warning("[%s] chapter %d (%s) failed to render",
@@ -468,7 +480,7 @@ async def audiobook_synthesize(req: AudiobookRequest):
         _render_longform_sse(
             plan, default_voice=req.default_voice, fmt=req.format, bitrate=req.bitrate,
             loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
-            job_type="audiobook",
+            lexicon=req.lexicon, job_type="audiobook",
         ),
         media_type="text/event-stream",
     )
@@ -496,6 +508,7 @@ class LongformRenderRequest(BaseModel):
     loudness: str | None = None
     cover_path: str | None = None
     metadata: dict | None = None
+    lexicon: dict | None = None
 
 
 @router.post("/longform/render")
@@ -522,7 +535,7 @@ async def longform_render(req: LongformRenderRequest):
         _render_longform_sse(
             plan, default_voice=req.default_voice, fmt=req.format, bitrate=req.bitrate,
             loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
-            job_type="story",
+            lexicon=req.lexicon, job_type="story",
         ),
         media_type="text/event-stream",
     )

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -148,24 +148,28 @@ def synthesize_chapter(
     sample_rate: int,
     *,
     crossfade_ms: int = 50,
+    lexicon: Optional[dict] = None,
 ):
     """Render a chapter's spans to one waveform via an injected ``synth``.
 
     ``synth(text, voice_id, speed)`` returns a 1-D float32 audio tensor for a
     span of text in the given voice (``speed`` may be ``None`` for the engine
     default). Long spans are split with the ``chunked_tts`` splitter and
-    crossfaded; inter-span ``pause_ms_after`` becomes silence.
+    crossfaded; inter-span ``pause_ms_after`` becomes silence. ``lexicon`` (when
+    given) respells each span's text before chunking so the engine pronounces
+    tricky words correctly; a ``None``/empty lexicon is a no-op pass-through.
 
     Returns ``(audio_tensor, duration_seconds)``. torch + chunked_tts are
     imported lazily so this module stays import-light for the pure parser path.
     """
     import torch
     from services.chunked_tts import concatenate_audio_chunks, split_text_into_chunks
+    from services.pronunciation import apply_lexicon
 
     parts: list = []
     for span in spans:
         if span.text:
-            chunks = split_text_into_chunks(span.text)
+            chunks = split_text_into_chunks(apply_lexicon(span.text, lexicon))
             rendered = [synth(c, span.voice_id, span.speed) for c in chunks]
             rendered = [r for r in rendered if r is not None and getattr(r, "numel", lambda: 0)()]
             if len(rendered) == 1:

--- a/backend/services/pronunciation.py
+++ b/backend/services/pronunciation.py
@@ -1,0 +1,147 @@
+"""Pronunciation lexicon — per-project word respelling (longform render, PR 8).
+
+A pronunciation lexicon maps a word (or short phrase) to a respelling the TTS
+engine pronounces correctly: ``{"OmniVoice": "Omni Voice", "Dr": "Doctor",
+"GIF": "jiff"}``. The narration pipeline applies it to each span's text just
+before chunking, so the engine never sees the hard-to-say original.
+
+This module is the engine-agnostic, pure core:
+
+  * ``apply_lexicon(text, lexicon)`` — whole-word, case-insensitive replacement
+    of every key with its respelling. Word-boundary aware (``\\b``), so a key
+    ``cat`` never touches ``category``; surrounding punctuation/whitespace is
+    preserved (``"smith,"`` → ``"Smith,"``). Longest key first, so a key
+    ``Dr. Smith`` wins over ``Dr`` on overlapping input.
+  * ``normalize_lexicon(lexicon)`` — drop empty/whitespace keys, coerce values.
+  * ``load_lexicon(path)`` / ``save_lexicon(path, lexicon)`` — JSON round-trip.
+
+ReDoS safety: the matcher is a single anchored-alternation regex built from
+``re.escape``'d keys joined by ``|`` and wrapped in word boundaries
+(``\\b(?:k1|k2|…)\\b``). No nested/overlapping quantifiers, no user-controlled
+quantifier — the keys are literals, so there is no catastrophic backtracking
+(CodeQL py/polynomial-redos clean). Matching is done in one ``re.sub`` pass with
+a callback, so a respelling that happens to contain another key is never
+re-scanned (idempotent against its own output).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+# A "word" character for boundary purposes. We treat the standard regex word
+# class (``\w`` = ``[A-Za-z0-9_]`` plus Unicode letters under ``re.UNICODE``,
+# the default for ``str`` patterns). A key only gets ``\b`` boundaries on a side
+# that actually abuts a word char, so a key like ``Dr.`` (ends in a non-word
+# char) still matches when followed by a space.
+
+
+def normalize_lexicon(lexicon: Optional[dict]) -> dict[str, str]:
+    """Return a clean ``{key: respelling}`` dict.
+
+    Drops entries whose key is empty or whitespace-only; coerces keys/values to
+    stripped strings. A value may be empty (``""``) — that deletes the word
+    (valid: e.g. stripping a stray marker). ``None``/non-dict input → ``{}``.
+    """
+    if not isinstance(lexicon, dict):
+        return {}
+    out: dict[str, str] = {}
+    for k, v in lexicon.items():
+        if k is None:
+            continue
+        key = str(k).strip()
+        if not key:
+            continue
+        out[key] = "" if v is None else str(v)
+    return out
+
+
+def _boundary_prefix(key: str) -> str:
+    """``\\b`` only if the key starts with a word char (else the boundary would
+    never match — e.g. a key opening with punctuation)."""
+    return r"\b" if key[:1].isalnum() or key[:1] == "_" else ""
+
+
+def _boundary_suffix(key: str) -> str:
+    """``\\b`` only if the key ends with a word char."""
+    return r"\b" if key[-1:].isalnum() or key[-1:] == "_" else ""
+
+
+def _compile(lexicon: dict[str, str]) -> tuple[Optional[re.Pattern], dict[str, str]]:
+    """Build the single alternation regex + a casefold→respelling lookup.
+
+    Keys are sorted longest-first so an overlapping longer key (``Dr. Smith``)
+    is tried before a shorter one (``Dr``). Each alternative carries its own
+    word-boundary guards based on its own edge characters, which keeps a
+    punctuation-edged key (``Dr.``) matchable while still protecting a
+    letter-edged key (``cat``) from partial hits inside ``category``.
+    """
+    keys = sorted(lexicon.keys(), key=len, reverse=True)
+    if not keys:
+        return None, {}
+    # casefold (not lower) for robust Unicode case-insensitive lookup.
+    lookup = {k.casefold(): lexicon[k] for k in keys}
+    alts = [f"{_boundary_prefix(k)}{re.escape(k)}{_boundary_suffix(k)}" for k in keys]
+    # No capturing groups, no nested quantifiers — pure literal alternation.
+    pattern = re.compile("(?:" + "|".join(alts) + ")", re.IGNORECASE)
+    return pattern, lookup
+
+
+def apply_lexicon(text: str, lexicon: Optional[dict]) -> str:
+    """Replace whole-word occurrences of each lexicon key with its respelling.
+
+    Case-insensitive match; word-boundary aware (a key never matches inside a
+    longer word); longest key wins on overlap; surrounding punctuation and
+    whitespace are untouched. A single left-to-right ``re.sub`` pass means a
+    respelling is never itself rescanned, so applying twice is idempotent when
+    no key is a substring of another key's output.
+
+    Returns ``text`` unchanged when ``text`` is falsy or the lexicon is empty.
+    """
+    if not text:
+        return text or ""
+    clean = normalize_lexicon(lexicon)
+    pattern, lookup = _compile(clean)
+    if pattern is None:
+        return text
+
+    def _repl(m: re.Match) -> str:
+        return lookup.get(m.group(0).casefold(), m.group(0))
+
+    return pattern.sub(_repl, text)
+
+
+# ── JSON persistence ─────────────────────────────────────────────────────────
+
+def load_lexicon(path) -> dict[str, str]:
+    """Load + normalize a lexicon from a JSON file.
+
+    A missing file, empty file, or non-object JSON yields ``{}`` rather than
+    raising — a project simply has no lexicon yet. Malformed JSON still raises
+    (caller's choice to surface it).
+    """
+    p = Path(path)
+    if not p.is_file():
+        return {}
+    raw = p.read_text(encoding="utf-8").strip()
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    return normalize_lexicon(data)
+
+
+def save_lexicon(path, lexicon: Optional[dict]) -> dict[str, str]:
+    """Normalize + write a lexicon to ``path`` as pretty JSON (utf-8).
+
+    Returns the normalized dict that was written. Parent dirs are created.
+    """
+    clean = normalize_lexicon(lexicon)
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        json.dumps(clean, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return clean

--- a/tests/test_audiobook.py
+++ b/tests/test_audiobook.py
@@ -141,3 +141,18 @@ def test_synthesize_empty_spans_is_silent():
     audio, dur = synthesize_chapter([], lambda t, v, s=None: torch.ones(10), 16000)
     assert audio.shape[-1] == 0
     assert dur == 0.0
+
+
+def test_synthesize_chapter_applies_lexicon():
+    torch = pytest.importorskip("torch")
+    seen = []
+
+    def synth(text, voice_id, speed=None):
+        seen.append(text)
+        return torch.ones(100, dtype=torch.float32)
+
+    plan = parse_audiobook_script("Meet Dr Smith.", default_voice="v")
+    synthesize_chapter(plan.chapters[0].spans, synth, 16000, lexicon={"Dr": "Doctor"})
+    # The engine sees the respelled text, never the original "Dr".
+    assert any("Doctor" in t for t in seen)
+    assert not any("Dr " in t or t.endswith(" Dr") for t in seen)

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -1,0 +1,135 @@
+"""Pronunciation lexicon core (longform render, PR 8).
+
+Pure tests for the whole-word, case-insensitive respelling matcher plus the
+JSON round-trip. No torch, no engine, no GPU.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from services.pronunciation import (
+    apply_lexicon,
+    load_lexicon,
+    normalize_lexicon,
+    save_lexicon,
+)
+
+
+# ── apply_lexicon: whole-word replace ────────────────────────────────────────
+
+def test_whole_word_replace():
+    assert apply_lexicon("I love GIF files", {"GIF": "jiff"}) == "I love jiff files"
+
+
+def test_case_insensitive_match():
+    lex = {"OmniVoice": "Omni Voice"}
+    assert apply_lexicon("omnivoice rocks", lex) == "Omni Voice rocks"
+    assert apply_lexicon("OMNIVOICE rocks", lex) == "Omni Voice rocks"
+    assert apply_lexicon("OmniVoice rocks", lex) == "Omni Voice rocks"
+
+
+def test_no_partial_word_replacement():
+    # "cat" must not touch "category" / "scatter".
+    assert apply_lexicon("category scatter cat", {"cat": "feline"}) == \
+        "category scatter feline"
+
+
+def test_punctuation_adjacency_trailing():
+    # "smith," — trailing comma preserved, word still matched.
+    assert apply_lexicon("Hello smith, hi", {"Smith": "Smyth"}) == "Hello Smyth, hi"
+
+
+def test_punctuation_adjacency_period_key():
+    # Key with an internal/edge period: "Dr." should match before a space.
+    out = apply_lexicon("See Dr. Jones", {"Dr.": "Doctor"})
+    assert out == "See Doctor Jones"
+
+
+def test_longest_match_first():
+    lex = {"Dr": "Doctor", "Dr. Smith": "Doctor Smith the third"}
+    # The longer key must win over the shorter overlapping one.
+    assert apply_lexicon("Call Dr. Smith now", lex) == "Call Doctor Smith the third now"
+
+
+def test_multiple_replacements_in_one_pass():
+    lex = {"GIF": "jiff", "SQL": "sequel"}
+    assert apply_lexicon("GIF and SQL", lex) == "jiff and sequel"
+
+
+def test_empty_text_and_empty_lexicon():
+    assert apply_lexicon("", {"a": "b"}) == ""
+    assert apply_lexicon(None, {"a": "b"}) == ""
+    assert apply_lexicon("unchanged text", {}) == "unchanged text"
+    assert apply_lexicon("unchanged text", None) == "unchanged text"
+
+
+def test_idempotence_when_no_key_in_output():
+    lex = {"GIF": "jiff"}
+    once = apply_lexicon("a GIF here", lex)
+    twice = apply_lexicon(once, lex)
+    assert once == twice == "a jiff here"
+
+
+def test_respelling_not_rescanned_in_single_pass():
+    # If a value contains another key, a single pass must NOT re-expand it.
+    lex = {"NY": "New York", "York": "Yorkshire"}
+    # "NY" -> "New York"; the produced "York" is part of the substituted
+    # text and must not be re-matched within the same pass.
+    assert apply_lexicon("from NY today", lex) == "from New York today"
+
+
+def test_unicode_word_boundary():
+    lex = {"café": "kaffey"}
+    assert apply_lexicon("a café here", lex) == "a kaffey here"
+    # Must not partial-match inside a longer token.
+    assert apply_lexicon("cafés plural", lex) == "cafés plural"
+
+
+def test_value_may_be_empty_to_delete_word():
+    assert apply_lexicon("the [marker] gone", {"[marker]": ""}) == "the  gone"
+
+
+# ── normalize_lexicon ────────────────────────────────────────────────────────
+
+def test_normalize_drops_empty_keys():
+    lex = {"": "x", "  ": "y", "ok": "v", None: "z"}
+    assert normalize_lexicon(lex) == {"ok": "v"}
+
+
+def test_normalize_strips_keys_and_coerces_values():
+    assert normalize_lexicon({"  Dr  ": "Doctor", "n": None}) == {"Dr": "Doctor", "n": ""}
+
+
+def test_normalize_non_dict():
+    assert normalize_lexicon(None) == {}
+    assert normalize_lexicon(["a", "b"]) == {}
+
+
+# ── load / save round-trip ───────────────────────────────────────────────────
+
+def test_save_and_load_round_trip(tmp_path):
+    path = tmp_path / "sub" / "lexicon.json"
+    written = save_lexicon(str(path), {"  GIF ": "jiff", "": "skip"})
+    assert written == {"GIF": "jiff"}
+    assert path.is_file()
+    assert load_lexicon(str(path)) == {"GIF": "jiff"}
+
+
+def test_load_missing_or_empty(tmp_path):
+    assert load_lexicon(str(tmp_path / "nope.json")) == {}
+    empty = tmp_path / "empty.json"
+    empty.write_text("   ", encoding="utf-8")
+    assert load_lexicon(str(empty)) == {}
+
+
+def test_load_non_object_json(tmp_path):
+    p = tmp_path / "arr.json"
+    p.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert load_lexicon(str(p)) == {}
+
+
+def test_load_normalizes(tmp_path):
+    p = tmp_path / "lex.json"
+    p.write_text(json.dumps({"  Dr  ": "Doctor", "": "x"}), encoding="utf-8")
+    assert load_lexicon(str(p)) == {"Dr": "Doctor"}


### PR DESCRIPTION
Lets a render correct hard-to-say words — e.g. `{"GIF":"jiff","Dr":"Doctor","OmniVoice":"Omni Voice"}`. Backend wiring (parallel-built module + integration); the **editor UI folds into the full-width Audiobook redesign** (next PR).

## Changes
- **`services/pronunciation.py`** (built by a worktree agent, 19 tests): `apply_lexicon` — whole-word, case-insensitive, longest-key-first, word-boundary-aware, single **ReDoS-safe** `re.sub` pass; + `normalize_lexicon`/`load_lexicon`/`save_lexicon`.
- **`synthesize_chapter`** gains a `lexicon` kwarg, applied to each span's text **before chunk splitting** (None/empty = no-op → backward compatible).
- **`_render_chapter_cached`** folds the normalized lexicon into the chapter **cache key** (a lexicon edit re-renders); threaded through `_render_longform_sse` and the `/audiobook`, `/audiobook/preview`, `/longform/render` request models.

## Tests
`synthesize_chapter` respells via lexicon (engine never sees the original word); pronunciation module (19); **75 related backend tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pronunciation Lexicon — Per-Render Word Respelling

This PR adds backend support for a per-render pronunciation lexicon that respells whole words before synthesis, enabling correct pronunciation of difficult words (e.g., {"GIF":"jiff","Dr":"Doctor","OmniVoice":"Omni Voice"}).

### New Module: `backend/services/pronunciation.py`
A pure, ReDoS-safe pronunciation lexicon core with five core functions:
- **`normalize_lexicon(lexicon)`**: Sanitizes input dict by trimming keys/values, dropping empty keys, returning `{}` for non-dict inputs
- **`apply_lexicon(text, lexicon)`**: Performs whole-word, case-insensitive respelling via a single `re.sub` pass using an escaped alternation pattern with word-boundary guards; returns input unchanged for falsy text or empty lexicons
- **`load_lexicon(path)`** / **`save_lexicon(path, lexicon)`**: JSON round-trip utilities with error handling and directory creation

### Integration Points
- **`synthesize_chapter(spans, synth, sample_rate, *, crossfade_ms=50, lexicon=None)`**: Now accepts optional lexicon and applies `apply_lexicon(span.text, lexicon)` before chunking each span
- **Request models**: `AudiobookRequest`, `AudiobookPreviewRequest`, and `LongformRenderRequest` all gain optional `lexicon: dict | None` field
- **Rendering pipeline**: Lexicon is threaded through `_render_chapter_cached` (folds normalized lexicon into chapter cache key), `_render_longform_sse`, and `/audiobook`, `/audiobook/preview`, `/longform/render` endpoints

### Mechanism

```
Text Input + Lexicon Dict
    ↓
normalize_lexicon() → sanitized {key: value} mapping
    ↓
_compile() → escape keys, build single alternation Pattern (longest-first)
           → create casefold-based lookup for case-insensitive matching
    ↓
apply_lexicon() → one re.sub() pass with word-boundary awareness
    ↓
Respelled Text → split_text_into_chunks() → synthesis
```

### Cache Invalidation
The normalized lexicon is hashed into the chapter cache key in `_render_chapter_cached`, ensuring lexicon edits automatically invalidate cached chapters and trigger re-renders.

### Tests
- **`test_synthesize_chapter_applies_lexicon`**: Verifies respelling in synthesis pipeline
- **`test_pronunciation.py`** (19 tests): Validates whole-word matching, case-insensitivity, punctuation adjacency, longest-match-first, multiple replacements, Unicode boundaries, empty-value deletion, lexicon normalization, and JSON round-tripping
- **75 related backend tests**: Pass with new feature

### Backward Compatibility
None or empty lexicon is a no-op; existing code paths unchanged.

### Note
Editor UI for managing lexicons is deferred to a future PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->