### PR TITLE
fix(ui): full-width/height Audiobook + Stories layouts (match other tabs)

### DIFF
--- a/frontend/src/components/StoriesEditor.css
+++ b/frontend/src/components/StoriesEditor.css
@@ -462,8 +462,9 @@
 
 /* ── Redesign: grouped toolbar, chapter bars, readable column ──────── */
 
-/* Center the editor at a comfortable reading width (header + script align). */
-.stories-editor { max-width: 1040px; margin-inline: auto; }
+/* Full-bleed like the other studio tabs — fill the content area edge to edge
+   instead of a centered column. */
+.stories-editor { width: 100%; }
 
 /* Toolbar: logical clusters (project · content · output) with thin dividers. */
 .stories-editor__actions { flex-wrap: wrap; }

--- a/frontend/src/pages/AudiobookTab.css
+++ b/frontend/src/pages/AudiobookTab.css
@@ -1,0 +1,82 @@
+/* Audiobook tab — full-bleed, full-height layout (matches the other studio
+   tabs). A two-pane body: the script editor fills the left + grows to the
+   window height; settings + results scroll on the right. Collapses to a single
+   column on narrow widths. */
+.audiobook-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 1.25rem 1.5rem;
+  gap: 12px;
+}
+
+.audiobook-tab__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.audiobook-tab__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+.audiobook-tab__sub { margin: 2px 0 0; }
+.audiobook-tab__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Body fills the remaining height; min-height:0 lets the textarea shrink. */
+.audiobook-tab__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 380px);
+  gap: 16px;
+}
+
+.audiobook-tab__script {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: 6px;
+}
+.audiobook-tab__script textarea {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  resize: none;
+  font-family: var(--font-mono, monospace);
+}
+
+.audiobook-tab__side {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.audiobook-tab__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.audiobook-tab__field select { width: 100%; }
+.audiobook-tab__duo {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+@media (max-width: 900px) {
+  .audiobook-tab__body { grid-template-columns: 1fr; }
+  .audiobook-tab__side { overflow: visible; }
+  .audiobook-tab__script textarea { min-height: 240px; }
+}

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -7,6 +7,7 @@ import {
 } from '../api/audiobook';
 import { audioUrl } from '../api/generate';
 import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
+import './AudiobookTab.css';
 
 /**
  * AudiobookTab — turn a chapter-delimited script into a chapterized m4b.
@@ -163,207 +164,179 @@ export default function AudiobookTab({ profiles = [] }) {
   const canRun = text.trim().length > 0 && !busy;
 
   return (
-    <div className="audiobook-tab" style={{ maxWidth: 860, margin: '0 auto', padding: '1.5rem' }}>
-      <h2 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <BookMarked size={20} /> {t('audiobook.title')}
-      </h2>
-      <p className="muted">{t('audiobook.subtitle')}</p>
-
-      <label className="field-label">{t('audiobook.script')}</label>
-      <textarea
-        className="input-base"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder={t('audiobook.script_placeholder')}
-        rows={14}
-        style={{ width: '100%', fontFamily: 'monospace' }}
-        aria-label={t('audiobook.script')}
-      />
-
-      <div style={{ display: 'flex', gap: 12, alignItems: 'center', margin: '12px 0', flexWrap: 'wrap' }}>
-        <label className="field-label" style={{ margin: 0 }}>{t('audiobook.default_voice')}</label>
-        <select
-          className="input-base"
-          value={defaultVoice}
-          onChange={(e) => setDefaultVoice(e.target.value)}
-          aria-label={t('audiobook.default_voice')}
-        >
-          <option value="">{t('audiobook.engine_default')}</option>
-          {profiles.map((p) => (
-            <option key={p.id} value={p.id}>{p.name}</option>
-          ))}
-        </select>
-
-        <select
-          className="input-base"
-          value={format}
-          onChange={(e) => setFormat(e.target.value)}
-          aria-label={t('audiobook.format')}
-        >
-          <option value="m4b">{t('audiobook.format_m4b')}</option>
-          <option value="mp3">{t('audiobook.format_mp3')}</option>
-        </select>
-        <select
-          className="input-base"
-          value={loudness}
-          onChange={(e) => setLoudness(e.target.value)}
-          aria-label={t('audiobook.loudness')}
-        >
-          <option value="off">{t('audiobook.loudness_off')}</option>
-          <option value="acx">{t('audiobook.loudness_acx')}</option>
-          <option value="podcast">{t('audiobook.loudness_podcast')}</option>
-        </select>
-
-        <label className="btn" style={{ cursor: busy ? 'default' : 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-          {importing ? <Loader size={14} className="spin" /> : <Upload size={14} />} {t('audiobook.import')}
-          <input
-            type="file"
-            accept=".txt,.md,.epub"
-            onChange={onImport}
-            disabled={busy}
-            style={{ display: 'none' }}
-          />
-        </label>
-        <button className="btn" onClick={onPreview} disabled={!canRun}>
-          {planLoading ? <Loader size={14} className="spin" /> : null} {t('audiobook.preview_plan')}
-        </button>
-        <button className="btn btn-primary" onClick={onCreate} disabled={!canRun}>
-          {generating ? <Loader size={14} className="spin" /> : null} {t('audiobook.create')}
-        </button>
+    <div className="audiobook-tab">
+      <div className="audiobook-tab__head">
+        <div>
+          <h2 className="audiobook-tab__title">
+            <BookMarked size={20} /> {t('audiobook.title')}
+          </h2>
+          <p className="muted audiobook-tab__sub">{t('audiobook.subtitle')}</p>
+        </div>
+        <div className="audiobook-tab__actions">
+          <label className="btn" style={{ cursor: busy ? 'default' : 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            {importing ? <Loader size={14} className="spin" /> : <Upload size={14} />} {t('audiobook.import')}
+            <input type="file" accept=".txt,.md,.epub" onChange={onImport} disabled={busy} style={{ display: 'none' }} />
+          </label>
+          <button className="btn" onClick={onPreview} disabled={!canRun}>
+            {planLoading ? <Loader size={14} className="spin" /> : null} {t('audiobook.preview_plan')}
+          </button>
+          <button className="btn btn-primary" onClick={onCreate} disabled={!canRun}>
+            {generating ? <Loader size={14} className="spin" /> : null} {t('audiobook.create')}
+          </button>
+        </div>
       </div>
 
-      <details className="audiobook-meta" style={{ margin: '8px 0 12px' }}>
-        <summary className="field-label" style={{ cursor: 'pointer' }}>
-          {t('audiobook.details')}
-        </summary>
-        <div style={{ display: 'flex', gap: 16, marginTop: 12, flexWrap: 'wrap' }}>
-          {/* Cover picker */}
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <label className="field-label" style={{ margin: 0 }}>{t('audiobook.cover')}</label>
-            <div style={{ position: 'relative', width: 120, height: 120 }}>
-              {coverPreview ? (
-                <>
-                  <img
-                    src={coverPreview}
-                    alt={t('audiobook.cover')}
-                    style={{ width: 120, height: 120, objectFit: 'cover', borderRadius: 6 }}
-                  />
-                  <button
-                    type="button"
-                    className="btn"
-                    onClick={clearCover}
-                    aria-label={t('audiobook.cover_remove')}
-                    style={{ position: 'absolute', top: 4, right: 4, padding: 2 }}
-                  >
-                    <X size={14} />
-                  </button>
-                </>
-              ) : (
-                <label
-                  className="input-base"
-                  style={{
-                    width: 120, height: 120, display: 'flex', flexDirection: 'column',
-                    alignItems: 'center', justifyContent: 'center', gap: 6, cursor: 'pointer',
-                  }}
-                >
-                  <ImageIcon size={22} />
-                  <span style={{ fontSize: '0.7rem' }}>{t('audiobook.cover_add')}</span>
-                  <input
-                    type="file"
-                    accept="image/png,image/jpeg"
-                    onChange={onCoverPick}
-                    style={{ display: 'none' }}
-                  />
-                </label>
-              )}
+      <div className="audiobook-tab__body">
+        {/* Left: script editor fills the height */}
+        <div className="audiobook-tab__script">
+          <label className="field-label">{t('audiobook.script')}</label>
+          <textarea
+            className="input-base"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={t('audiobook.script_placeholder')}
+            aria-label={t('audiobook.script')}
+          />
+        </div>
+
+        {/* Right: settings + results, scrolls independently */}
+        <div className="audiobook-tab__side">
+          <div className="audiobook-tab__field">
+            <label className="field-label">{t('audiobook.default_voice')}</label>
+            <select className="input-base" value={defaultVoice}
+              onChange={(e) => setDefaultVoice(e.target.value)} aria-label={t('audiobook.default_voice')}>
+              <option value="">{t('audiobook.engine_default')}</option>
+              {profiles.map((p) => (<option key={p.id} value={p.id}>{p.name}</option>))}
+            </select>
+          </div>
+
+          <div className="audiobook-tab__duo">
+            <div className="audiobook-tab__field">
+              <label className="field-label">{t('audiobook.format')}</label>
+              <select className="input-base" value={format}
+                onChange={(e) => setFormat(e.target.value)} aria-label={t('audiobook.format')}>
+                <option value="m4b">{t('audiobook.format_m4b')}</option>
+                <option value="mp3">{t('audiobook.format_mp3')}</option>
+              </select>
+            </div>
+            <div className="audiobook-tab__field">
+              <label className="field-label">{t('audiobook.loudness')}</label>
+              <select className="input-base" value={loudness}
+                onChange={(e) => setLoudness(e.target.value)} aria-label={t('audiobook.loudness')}>
+                <option value="off">{t('audiobook.loudness_off')}</option>
+                <option value="acx">{t('audiobook.loudness_acx')}</option>
+                <option value="podcast">{t('audiobook.loudness_podcast')}</option>
+              </select>
             </div>
           </div>
-          {/* Metadata fields */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, flex: 1, minWidth: 280 }}>
-            <input className="input-base" placeholder={t('audiobook.meta_title')}
-              value={meta.title} onChange={setMetaField('title')} aria-label={t('audiobook.meta_title')} />
-            <input className="input-base" placeholder={t('audiobook.meta_author')}
-              value={meta.author} onChange={setMetaField('author')} aria-label={t('audiobook.meta_author')} />
-            <input className="input-base" placeholder={t('audiobook.meta_narrator')}
-              value={meta.narrator} onChange={setMetaField('narrator')} aria-label={t('audiobook.meta_narrator')} />
-            <input className="input-base" placeholder={t('audiobook.meta_year')}
-              value={meta.year} onChange={setMetaField('year')} aria-label={t('audiobook.meta_year')} />
-            <input className="input-base" placeholder={t('audiobook.meta_genre')}
-              value={meta.genre} onChange={setMetaField('genre')} aria-label={t('audiobook.meta_genre')} />
-            <input className="input-base" placeholder={t('audiobook.meta_description')}
-              value={meta.description} onChange={setMetaField('description')} aria-label={t('audiobook.meta_description')}
-              style={{ gridColumn: '1 / -1' }} />
-          </div>
-        </div>
-      </details>
 
-      {error && <div className="error-banner" role="alert">{error}</div>}
-
-      {generating && progress && (
-        <div className="audiobook-progress" role="status" aria-live="polite">
-          {progress.assembling
-            ? t('audiobook.assembling')
-            : t('audiobook.synthesizing', {
-                current: progress.current, total: progress.total,
-                title: progress.title || '',
-              })}
-        </div>
-      )}
-
-      {output && (
-        <div className="audiobook-done" style={{ margin: '16px 0' }}>
-          <div style={{ marginBottom: 8 }}>✅ {t('audiobook.ready')}</div>
-          {done && done.failed_chapters.length > 0 && (
-            <div className="muted" style={{ marginBottom: 8 }}>
-              {t('audiobook.failed_note', { count: done.failed_chapters.length })}
-            </div>
-          )}
-          {done && done.cached_chapters > 0 && (
-            <div className="muted" style={{ marginBottom: 8 }}>
-              {t('audiobook.cached_note', { count: done.cached_chapters })}
-            </div>
-          )}
-          <audio controls src={audioUrl(output)} style={{ width: '100%' }} />
-          <div style={{ marginTop: 8 }}>
-            <a className="btn" href={audioUrl(output)} download={output}>
-              <Download size={14} /> {t('audiobook.download')}
-            </a>
-          </div>
-        </div>
-      )}
-
-      {plan && (
-        <div className="audiobook-plan" style={{ marginTop: 16 }}>
-          <h3>{t('audiobook.plan_heading', { count: plan.chapter_count })}</h3>
-          <ol>
-            {plan.chapters.map((c, i) => {
-              const prev = chapterPrev[i] || {};
-              return (
-                <li key={i} style={{ marginBottom: 8 }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <button
-                      className="btn"
-                      onClick={() => onPreviewChapter(i)}
-                      disabled={prev.loading || busy}
-                      aria-label={t('audiobook.preview_chapter', { title: c.title })}
-                      style={{ padding: '2px 6px' }}
-                    >
-                      {prev.loading ? <Loader size={12} className="spin" /> : <Play size={12} />}
+          {/* Cover + metadata */}
+          <div className="audiobook-tab__field">
+            <label className="field-label">{t('audiobook.details')}</label>
+            <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+              <div style={{ position: 'relative', width: 96, height: 96, flexShrink: 0 }}>
+                {coverPreview ? (
+                  <>
+                    <img src={coverPreview} alt={t('audiobook.cover')}
+                      style={{ width: 96, height: 96, objectFit: 'cover', borderRadius: 6 }} />
+                    <button type="button" className="btn" onClick={clearCover}
+                      aria-label={t('audiobook.cover_remove')}
+                      style={{ position: 'absolute', top: 4, right: 4, padding: 2 }}>
+                      <X size={14} />
                     </button>
-                    <strong>{c.title}</strong>{' '}
-                    <span className="muted">
-                      {t('audiobook.chapter_meta', { spans: c.spans.length, chars: c.char_count })}
-                    </span>
-                  </div>
-                  {prev.url && (
-                    <audio controls src={prev.url} style={{ width: '100%', marginTop: 4 }} />
-                  )}
-                </li>
-              );
-            })}
-          </ol>
+                  </>
+                ) : (
+                  <label className="input-base" style={{
+                    width: 96, height: 96, display: 'flex', flexDirection: 'column',
+                    alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer',
+                  }}>
+                    <ImageIcon size={20} />
+                    <span style={{ fontSize: '0.65rem' }}>{t('audiobook.cover_add')}</span>
+                    <input type="file" accept="image/png,image/jpeg" onChange={onCoverPick} style={{ display: 'none' }} />
+                  </label>
+                )}
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, flex: 1, minWidth: 0 }}>
+                <input className="input-base" placeholder={t('audiobook.meta_title')}
+                  value={meta.title} onChange={setMetaField('title')} aria-label={t('audiobook.meta_title')} />
+                <input className="input-base" placeholder={t('audiobook.meta_author')}
+                  value={meta.author} onChange={setMetaField('author')} aria-label={t('audiobook.meta_author')} />
+                <input className="input-base" placeholder={t('audiobook.meta_narrator')}
+                  value={meta.narrator} onChange={setMetaField('narrator')} aria-label={t('audiobook.meta_narrator')} />
+                <input className="input-base" placeholder={t('audiobook.meta_year')}
+                  value={meta.year} onChange={setMetaField('year')} aria-label={t('audiobook.meta_year')} />
+                <input className="input-base" placeholder={t('audiobook.meta_genre')}
+                  value={meta.genre} onChange={setMetaField('genre')} aria-label={t('audiobook.meta_genre')} />
+                <input className="input-base" placeholder={t('audiobook.meta_description')}
+                  value={meta.description} onChange={setMetaField('description')}
+                  aria-label={t('audiobook.meta_description')} style={{ gridColumn: '1 / -1' }} />
+              </div>
+            </div>
+          </div>
+
+          {error && <div className="error-banner" role="alert">{error}</div>}
+
+          {generating && progress && (
+            <div className="audiobook-progress" role="status" aria-live="polite">
+              {progress.assembling
+                ? t('audiobook.assembling')
+                : t('audiobook.synthesizing', {
+                    current: progress.current, total: progress.total, title: progress.title || '',
+                  })}
+            </div>
+          )}
+
+          {output && (
+            <div className="audiobook-done">
+              <div style={{ marginBottom: 8 }}>✅ {t('audiobook.ready')}</div>
+              {done && done.failed_chapters.length > 0 && (
+                <div className="muted" style={{ marginBottom: 8 }}>
+                  {t('audiobook.failed_note', { count: done.failed_chapters.length })}
+                </div>
+              )}
+              {done && done.cached_chapters > 0 && (
+                <div className="muted" style={{ marginBottom: 8 }}>
+                  {t('audiobook.cached_note', { count: done.cached_chapters })}
+                </div>
+              )}
+              <audio controls src={audioUrl(output)} style={{ width: '100%' }} />
+              <div style={{ marginTop: 8 }}>
+                <a className="btn" href={audioUrl(output)} download={output}>
+                  <Download size={14} /> {t('audiobook.download')}
+                </a>
+              </div>
+            </div>
+          )}
+
+          {plan && (
+            <div className="audiobook-plan">
+              <h3>{t('audiobook.plan_heading', { count: plan.chapter_count })}</h3>
+              <ol style={{ paddingLeft: 18, margin: 0 }}>
+                {plan.chapters.map((c, i) => {
+                  const prev = chapterPrev[i] || {};
+                  return (
+                    <li key={i} style={{ marginBottom: 8 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                        <button className="btn" onClick={() => onPreviewChapter(i)}
+                          disabled={prev.loading || busy}
+                          aria-label={t('audiobook.preview_chapter', { title: c.title })}
+                          style={{ padding: '2px 6px' }}>
+                          {prev.loading ? <Loader size={12} className="spin" /> : <Play size={12} />}
+                        </button>
+                        <strong>{c.title}</strong>{' '}
+                        <span className="muted">
+                          {t('audiobook.chapter_meta', { spans: c.spans.length, chars: c.char_count })}
+                        </span>
+                      </div>
+                      {prev.url && (<audio controls src={prev.url} style={{ width: '100%', marginTop: 4 }} />)}
+                    </li>
+                  );
+                })}
+              </ol>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Both tabs rendered as **narrow centered columns** (Audiobook `maxWidth:860`, Stories `max-width:1040; margin:auto`) while the rest of the studio is full-bleed — so they looked under-sized vs every other tab.

## Changes
- **AudiobookTab** — rebuilt into a **full-height two-pane layout** (new `AudiobookTab.css`):
  - Header with the action buttons (Import / Preview plan / Create)
  - **Left:** the script editor, which grows to fill the window height
  - **Right:** a settings + results pane (voice / format / loudness, cover & metadata, progress / output / chapter plan) that scrolls independently
  - Collapses to a single column under 900 px. Removed the inline 860 px cap.
- **StoriesEditor** — dropped the `max-width:1040px; margin-inline:auto` cap → fills edge-to-edge like the dub / projects / transcripts tabs.

## Verify
Build clean; 334 frontend tests green. (Tried a live WebKitGTK screenshot but the window opened behind the active session on COSMIC — the layout is standard flex/grid and builds cleanly; easy to eyeball on reload.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Layout Refactoring: Full-Width Audiobook & Stories Tabs

### Overview
Rebuilt the AudiobookTab and StoriesEditor layouts to be full-bleed (edge-to-edge) and match the visual consistency of other studio tabs (dub, projects, transcripts), instead of rendering as narrow centered columns.

### AudiobookTab Layout Transformation

**Before:** Centered column with inline `maxWidth: 860px`  
**After:** Full-height two-pane responsive layout

```
═══════════════════════════════════════════════════════════════════
                    BEFORE (Narrow Centered)
───────────────────────────────────────────────────────────────────
│                                                                   │
│                        [Title]                                   │
│                                                                   │
│                    ╔═════════════╗                               │
│                    ║ Script Area ║ (single column,               │
│                    ║ 860px max)  ║  max 860px wide)              │
│                    ║             ║                               │
│                    ╚═════════════╝                               │
│                                                                   │
│                                                                   │
════════════════════════════════════════════════════════════════════


═══════════════════════════════════════════════════════════════════
                    AFTER (Full-Width Two-Pane)
───────────────────────────────────────────────────────────────────
│ [Title] ← Icon        [Import] [Preview plan] [Create] → Buttons │
├─────────────────────────────────────────────────────────────────┤
│                                                                   │
│ ╔──────────────────────────────┐  ╔──────────────────────────╗  │
│ │                              │  │ Voice    [────────────]  │  │
│ │   Script Editor              │  │ Format   [m4b  ↓]       │  │
│ │   (left pane, flex: 1,       │  │ Loudness [off  ↓]       │  │
│ │   grows to fill height)      │  │                          │  │
│ │                              │  │ Cover & Metadata:        │  │
│ │                              │  │ Title    [──────────]    │  │
│ │                              │  │ Author   [──────────]    │  │
│ │                              │  │ Narrator [──────────]    │  │
│ │                              │  │ Year     [──────────]    │  │
│ │                              │  │ Genre    [──────────]    │  │
│ │                              │  │ Desc     [──────────]    │  │
│ │                              │  │                          │  │
│ │                              │  │ Progress / Output /      │  │
│ │                              │  │ Chapter Plan             │  │
│ │                              │  │                          │  │
│ │                              │  │ (right pane scrolls      │  │
│ │                              │  │ independently; 300–380px)│  │
│ ╚──────────────────────────────┘  ╚──────────────────────────╝  │
│                                                                   │
└─────────────────────────────────────────────────────────────────┘

Responsive: Collapses to single-column below 900px viewport width
```

### StoriesEditor Constraint Removal

**Before:**  
```css
.stories-editor {
  max-width: 1040px;
  margin-inline: auto;  /* centered column */
}
```

**After:**  
```css
.stories-editor {
  width: 100%;  /* full-bleed */
}
```

### Implementation Details

**AudiobookTab.css (new file, 82 lines)**
- `.audiobook-tab`: Flex column container, 100% height, padding 1.25rem 1.5rem
- `.audiobook-tab__head`: Header with title icon and action buttons (Import / Preview / Create)
- `.audiobook-tab__body`: Two-column grid (`minmax(0, 1fr)` | `minmax(300px, 380px)`)
  - Left column: Script editor with flex textarea that shrinks below minimum height
  - Right column: Settings/results panel with independent `overflow-y: auto` scrolling
- `@media (max-width: 900px)`: Single-column layout; textarea `min-height: 240px`

**AudiobookTab.jsx (±27 lines)**
- Imported new `AudiobookTab.css`
- Refactored DOM structure from inline styles + `<details>`/`<summary>` to semantic BEM classes (`audiobook-tab__*`)
- Moved controls (Import/Preview/Create), cover/metadata inputs, progress/output/chapter list into the two-pane grid structure
- Styling driven by CSS classes instead of inline `style` props

**StoriesEditor.css (3 lines modified)**
- Removed `max-width: 1040px; margin-inline: auto;` centered-column constraint
- Set `width: 100%;` to fill available editor area edge-to-edge

### Verification
- Project builds without errors
- 334 frontend tests passed
- Layout is responsive (flex/grid foundation) and visually consistent with other studio tabs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->