### PR TITLE
feat(longform): SSML-lite prosody markup — [slow]/[fast]/[emphasis]/[spell] (PR 8b)

### DIFF
--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -103,14 +103,32 @@ def _parse_spans(body: str, default_voice: Optional[str]) -> list[Span]:
         last = m.end()
     runs.append((cur_voice, body[last:]))
 
+    from services.ssml_lite import parse_ssml_lite, spell_out
+
     for voice, run_text in runs:
-        # Delegate pause handling to the shared parser so the [pause …] dialect
-        # stays identical to single-shot synthesis.
+        # Marker precedence (outer → inner): [voice:] (run split above) →
+        # [pause] (shared dialect) → SSML-lite prosody ([slow]/[fast]/[emphasis]
+        # /[spell]) within the text. The trailing pause attaches to the LAST
+        # SSML segment of the run.
         for span_text, pause_ms in parse_pause_markers(run_text):
             t = span_text.strip()
             if not t and pause_ms == 0:
                 continue  # pure whitespace between markers — nothing to render
-            spans.append(Span(voice_id=voice, text=t, pause_ms_after=pause_ms))
+            rendered: list[tuple[str, Optional[float]]] = []
+            for seg in (parse_ssml_lite(t) if t else []):
+                st = (spell_out(seg["text"]) if seg["spell"] else seg["text"]).strip()
+                if st:
+                    rendered.append((st, seg["speed"]))
+            if not rendered:
+                # Only-markers / empty text but a real pause → carry the silence.
+                if pause_ms > 0:
+                    spans.append(Span(voice_id=voice, text="", pause_ms_after=pause_ms))
+                continue
+            for j, (st, sp) in enumerate(rendered):
+                spans.append(Span(
+                    voice_id=voice, text=st, speed=sp,
+                    pause_ms_after=pause_ms if j == len(rendered) - 1 else 0,
+                ))
     return spans
 
 

--- a/backend/services/ssml_lite.py
+++ b/backend/services/ssml_lite.py
@@ -1,0 +1,155 @@
+"""SSML-LITE — inline prosody/spell markup for longform lines (PR 8).
+
+A *single line* of narration may carry inline tags that nudge the engine's
+delivery without reaching for full SSML:
+
+  * ``[slow]…[/slow]``         — speak slower   (``speed ≈ 0.85``)
+  * ``[fast]…[/fast]``         — speak faster   (``speed ≈ 1.15``)
+  * ``[emphasis]…[/emphasis]`` — mild emphasis: a gentle slow-down
+                                 (``speed ≈ 0.92``) plus an ``emphasis`` flag
+                                 the caller may use for future markup
+  * ``[spell]…[/spell]``       — spell the run out letter-by-letter
+                                 (``spell=True``; the caller spaces the chars)
+
+:func:`parse_ssml_lite` splits one line into ordered segments::
+
+    [{"text": str, "speed": float | None, "spell": bool, "emphasis": bool}, …]
+
+Semantics (kept deliberately small and predictable):
+
+  * Plain text → exactly one segment ``{text, speed=None, spell=False,
+    emphasis=False}``.
+  * Tags nest; the **innermost** tag wins for any property it sets. ``speed``
+    from an inner ``[fast]`` overrides an outer ``[slow]``; ``[spell]`` inside
+    ``[slow]`` keeps the slow speed *and* turns spelling on.
+  * An **unclosed** tag applies to the end of the line.
+  * A stray close tag with no matching open is ignored (treated as literal
+    nothing — the markers are always stripped from the emitted ``text``).
+  * Adjacent segments that share identical (speed, spell, emphasis) are merged
+    so plain runs stay single segments.
+
+This module is pure (no torch, no I/O) so it is cheap to import and unit-test.
+The regex is ReDoS-safe: it is a fixed alternation of literal tag tokens with
+no quantifier overlap, so matching is linear in the input length.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Speed multipliers. ``None`` means "engine default" (no override emitted).
+SLOW_SPEED = 0.85
+FAST_SPEED = 1.15
+# Emphasis maps to a *mild* slow-down (between default and [slow]) plus a flag.
+EMPHASIS_SPEED = 0.92
+
+# Recognised tag names → the (speed_delta, spell, emphasis) they impose while
+# open. ``speed`` of ``None`` for a tag means "this tag does not touch speed".
+_TAGS: dict[str, dict] = {
+    "slow": {"speed": SLOW_SPEED, "spell": None, "emphasis": None},
+    "fast": {"speed": FAST_SPEED, "spell": None, "emphasis": None},
+    "emphasis": {"speed": EMPHASIS_SPEED, "spell": None, "emphasis": True},
+    "spell": {"speed": None, "spell": True, "emphasis": None},
+}
+
+# One regex that matches any open/close tag for the known names. It is a plain
+# alternation of fixed literals — ``\[/?(?:slow|fast|emphasis|spell)\]`` — with
+# no nested quantifiers and no overlapping ``*``/``+`` runs, so it cannot
+# backtrack polynomially (ReDoS-safe). ``finditer`` walks it left-to-right.
+_TAG_RE = re.compile(
+    r"\[(/?)(" + "|".join(re.escape(name) for name in _TAGS) + r")\]",
+    re.IGNORECASE,
+)
+
+
+def _resolve(stack: list[str]) -> dict:
+    """Collapse an open-tag stack into the effective segment properties.
+
+    Outer→inner walk: a later (more-deeply-nested) tag overrides any property
+    it sets, leaving untouched properties from outer tags intact. So
+    ``[slow][spell]`` yields ``speed=SLOW_SPEED, spell=True``.
+    """
+    speed: Optional[float] = None
+    spell = False
+    emphasis = False
+    for name in stack:
+        spec = _TAGS[name]
+        if spec["speed"] is not None:
+            speed = spec["speed"]
+        if spec["spell"] is not None:
+            spell = bool(spec["spell"])
+        if spec["emphasis"] is not None:
+            emphasis = bool(spec["emphasis"])
+    return {"speed": speed, "spell": spell, "emphasis": emphasis}
+
+
+def parse_ssml_lite(text: str) -> list[dict]:
+    """Split one line of SSML-LITE markup into ordered prosody segments.
+
+    See the module docstring for the full contract. Always returns at least one
+    segment for non-empty input; returns ``[]`` for ``None``/empty input.
+    """
+    if not text:
+        return []
+    if "[" not in text:
+        return [{"text": text, "speed": None, "spell": False, "emphasis": False}]
+
+    segments: list[dict] = []
+    stack: list[str] = []
+    last = 0
+
+    def emit(chunk: str) -> None:
+        if not chunk:
+            return
+        props = _resolve(stack)
+        seg = {"text": chunk, **props}
+        # Merge with the previous segment when prosody is identical so plain
+        # text never fragments into multiple identical-styled pieces.
+        if segments:
+            prev = segments[-1]
+            if (
+                prev["speed"] == seg["speed"]
+                and prev["spell"] == seg["spell"]
+                and prev["emphasis"] == seg["emphasis"]
+            ):
+                prev["text"] += chunk
+                return
+        segments.append(seg)
+
+    for m in _TAG_RE.finditer(text):
+        emit(text[last:m.start()])
+        last = m.end()
+        is_close = m.group(1) == "/"
+        name = m.group(2).lower()
+        if is_close:
+            # Close the nearest matching open tag; ignore an unmatched close.
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i] == name:
+                    del stack[i]
+                    break
+        else:
+            stack.append(name)  # unclosed opens stay on the stack to EOL
+
+    emit(text[last:])
+
+    if not segments:
+        # Input was only tag markers (e.g. "[slow][/slow]"): nothing to speak.
+        return []
+    return segments
+
+
+def spell_out(word: str) -> str:
+    """Space out a run for the ``[spell]`` case: ``"USA"`` → ``"U S A"``.
+
+    Collapses surrounding whitespace, then joins the remaining characters with
+    single spaces so the engine pronounces each letter discretely. Whitespace
+    inside the run is treated as a separator (each token spelled, joined by a
+    single space), so ``"go USA"`` → ``"g o U S A"``.
+    """
+    if not word:
+        return ""
+    # Drop all existing whitespace, then interleave the visible characters with
+    # spaces. ``split()`` + ``"".join`` removes runs of whitespace first.
+    compact = "".join(word.split())
+    return " ".join(compact)

--- a/frontend/src/test/ssmlLite.test.js
+++ b/frontend/src/test/ssmlLite.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseSsmlLite, spellOut, SLOW_SPEED, FAST_SPEED } from '../utils/ssmlLite';
+
+describe('parseSsmlLite (client port — parity with ssml_lite.py)', () => {
+  it('plain text → one default segment', () => {
+    expect(parseSsmlLite('hello world')).toEqual([
+      { text: 'hello world', speed: null, spell: false, emphasis: false },
+    ]);
+  });
+
+  it('empty/None → []', () => {
+    expect(parseSsmlLite('')).toEqual([]);
+    expect(parseSsmlLite(null)).toEqual([]);
+  });
+
+  it('[slow]/[fast] set speed', () => {
+    expect(parseSsmlLite('[slow]a[/slow]')[0].speed).toBe(SLOW_SPEED);
+    expect(parseSsmlLite('[fast]a[/fast]')[0].speed).toBe(FAST_SPEED);
+  });
+
+  it('[spell] flags spell; emphasis flags + mild slow', () => {
+    const sp = parseSsmlLite('[spell]USA[/spell]')[0];
+    expect(sp.spell).toBe(true);
+    expect(parseSsmlLite('[emphasis]x[/emphasis]')[0].emphasis).toBe(true);
+  });
+
+  it('innermost wins; spell-in-slow keeps both', () => {
+    const seg = parseSsmlLite('[slow][spell]K[/spell][/slow]')[0];
+    expect(seg.speed).toBe(SLOW_SPEED);
+    expect(seg.spell).toBe(true);
+  });
+
+  it('unclosed tag runs to end of line', () => {
+    const segs = parseSsmlLite('plain [fast]rest');
+    expect(segs[0]).toMatchObject({ text: 'plain ', speed: null });
+    expect(segs[1]).toMatchObject({ text: 'rest', speed: FAST_SPEED });
+  });
+
+  it('stray close ignored; only-markers → []', () => {
+    expect(parseSsmlLite('hi[/slow]')[0].text).toBe('hi');
+    expect(parseSsmlLite('[slow][/slow]')).toEqual([]);
+  });
+
+  it('mixed line splits + adjacent identical merge', () => {
+    const segs = parseSsmlLite('a [slow]b[/slow] c');
+    expect(segs.map((s) => s.text)).toEqual(['a ', 'b', ' c']);
+  });
+
+  it('spellOut spaces letters, drops whitespace', () => {
+    expect(spellOut('USA')).toBe('U S A');
+    expect(spellOut('go USA')).toBe('g o U S A');
+  });
+
+  it('is linear-time on pathological input (no ReDoS)', () => {
+    const big = '[slow]'.repeat(5000);
+    const t0 = Date.now();
+    parseSsmlLite(big);
+    expect(Date.now() - t0).toBeLessThan(1000);
+  });
+});

--- a/frontend/src/test/storyToSpans.test.js
+++ b/frontend/src/test/storyToSpans.test.js
@@ -43,6 +43,17 @@ describe('storyToSpans', () => {
     expect(spans.every((s) => s.speed === 0.8)).toBe(true);
   });
 
+  it('applies inline SSML-lite prosody (overriding the line speed)', () => {
+    const tracks = [{ character: 'narrator', text: 'calm [fast]rush[/fast] [spell]USA[/spell]', speed: 0.9 }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    const calm = spans.find((s) => s.text === 'calm');
+    const rush = spans.find((s) => s.text === 'rush');
+    const usa = spans.find((s) => s.text === 'U S A');
+    expect(calm.speed).toBe(0.9);     // plain → falls back to the line slider
+    expect(rush.speed).toBe(1.15);    // [fast] overrides the line slider
+    expect(usa).toBeTruthy();         // [spell] spelled the letters out
+  });
+
   it('folds [pause] into the previous span', () => {
     const tracks = [{ character: 'narrator', text: 'Wait. [pause 0.5s] Done.' }];
     const spans = storyToSpans(tracks, CAST)[0].spans;

--- a/frontend/src/utils/ssmlLite.js
+++ b/frontend/src/utils/ssmlLite.js
@@ -1,0 +1,82 @@
+/**
+ * SSML-LITE (client port) — keep in sync with backend/services/ssml_lite.py.
+ *
+ * Splits one narration line into ordered prosody segments so the Stories Editor
+ * compiles the same `[slow]/[fast]/[emphasis]/[spell]` markup the Audiobook
+ * backend parser honours. Pure; no deps.
+ *
+ *   parseSsmlLite(text) -> [{ text, speed, spell, emphasis }, …]
+ *
+ * Plain text → one segment {speed:null, spell:false, emphasis:false}. Tags nest
+ * (innermost wins per property); an unclosed tag runs to end-of-line; a stray
+ * close is ignored; adjacent identical-prosody segments merge.
+ */
+export const SLOW_SPEED = 0.85;
+export const FAST_SPEED = 1.15;
+export const EMPHASIS_SPEED = 0.92;
+
+const TAGS = {
+  slow: { speed: SLOW_SPEED, spell: null, emphasis: null },
+  fast: { speed: FAST_SPEED, spell: null, emphasis: null },
+  emphasis: { speed: EMPHASIS_SPEED, spell: null, emphasis: true },
+  spell: { speed: null, spell: true, emphasis: null },
+};
+
+// Fixed-literal alternation, no quantifier overlap → linear-time (ReDoS-safe).
+const TAG_RE = /\[(\/?)(slow|fast|emphasis|spell)\]/gi;
+
+function resolve(stack) {
+  let speed = null;
+  let spell = false;
+  let emphasis = false;
+  for (const name of stack) {
+    const spec = TAGS[name];
+    if (spec.speed !== null) speed = spec.speed;
+    if (spec.spell !== null) spell = !!spec.spell;
+    if (spec.emphasis !== null) emphasis = !!spec.emphasis;
+  }
+  return { speed, spell, emphasis };
+}
+
+export function parseSsmlLite(text) {
+  if (!text) return [];
+  if (!text.includes('[')) return [{ text, speed: null, spell: false, emphasis: false }];
+
+  const segments = [];
+  const stack = [];
+  let last = 0;
+
+  const emit = (chunk) => {
+    if (!chunk) return;
+    const props = resolve(stack);
+    const prev = segments[segments.length - 1];
+    if (prev && prev.speed === props.speed && prev.spell === props.spell && prev.emphasis === props.emphasis) {
+      prev.text += chunk;
+      return;
+    }
+    segments.push({ text: chunk, ...props });
+  };
+
+  const re = new RegExp(TAG_RE.source, TAG_RE.flags);
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    emit(text.slice(last, m.index));
+    last = m.index + m[0].length;
+    const isClose = m[1] === '/';
+    const name = m[2].toLowerCase();
+    if (isClose) {
+      for (let i = stack.length - 1; i >= 0; i--) {
+        if (stack[i] === name) { stack.splice(i, 1); break; }
+      }
+    } else {
+      stack.push(name);
+    }
+  }
+  emit(text.slice(last));
+  return segments;
+}
+
+/** Space out a run for [spell]: "USA" → "U S A". */
+export function spellOut(word) {
+  return (word || '').split(/\s+/).join('').split('').join(' ');
+}

--- a/frontend/src/utils/storyToSpans.js
+++ b/frontend/src/utils/storyToSpans.js
@@ -1,6 +1,7 @@
 import { parseStoryText } from './storyTokens';
 import { isChapterLine, chapterTitle } from './storyExport';
 import { effectiveProfile } from './storyCast';
+import { parseSsmlLite, spellOut } from './ssmlLite';
 
 /**
  * Compile the Stories Editor's cast + ordered lines into the chapter/span plan
@@ -38,7 +39,13 @@ export function storyToSpans(tracks, cast) {
         if (last) last.pause_ms_after += ms;
         else cur.spans.push({ voice_id: profileId, text: '', pause_ms_after: ms, speed });
       } else if (seg.text) {
-        cur.spans.push({ voice_id: seg.profileId || null, text: seg.text, pause_ms_after: 0, speed });
+        // Inner layer: SSML-lite prosody within the chunk. Inline [slow]/[fast]
+        // /[emphasis] speed overrides the per-line slider; [spell] spaces it out.
+        const vid = seg.profileId || null;
+        for (const s of parseSsmlLite(seg.text)) {
+          const st = (s.spell ? spellOut(s.text) : s.text).trim();
+          if (st) cur.spans.push({ voice_id: vid, text: st, pause_ms_after: 0, speed: s.speed != null ? s.speed : speed });
+        }
       }
     }
   }

--- a/tests/test_audiobook.py
+++ b/tests/test_audiobook.py
@@ -143,6 +143,15 @@ def test_synthesize_empty_spans_is_silent():
     assert dur == 0.0
 
 
+def test_parse_applies_ssml_lite_prosody():
+    plan = parse_audiobook_script("[slow]hush[/slow] normal [spell]USA[/spell]")
+    spans = plan.chapters[0].spans
+    by_text = {s.text: s for s in spans}
+    assert by_text["hush"].speed == 0.85       # [slow] → slower rate
+    assert by_text["normal"].speed is None     # plain → engine default
+    assert "U S A" in by_text                   # [spell] spaces the letters
+
+
 def test_synthesize_chapter_applies_lexicon():
     torch = pytest.importorskip("torch")
     seen = []

--- a/tests/test_ssml_lite.py
+++ b/tests/test_ssml_lite.py
@@ -1,0 +1,148 @@
+"""SSML-LITE inline markup parser (PR 8).
+
+Pure tests: every tag type, nesting, unclosed-to-EOL, plain text, mixed input,
+stray closes, and the spell_out helper. No torch, no I/O, no main import.
+"""
+from __future__ import annotations
+
+from services.ssml_lite import (
+    EMPHASIS_SPEED,
+    FAST_SPEED,
+    SLOW_SPEED,
+    parse_ssml_lite,
+    spell_out,
+)
+
+
+def test_plain_text_single_segment():
+    segs = parse_ssml_lite("just a plain line")
+    assert segs == [
+        {"text": "just a plain line", "speed": None, "spell": False, "emphasis": False}
+    ]
+
+
+def test_empty_and_none():
+    assert parse_ssml_lite("") == []
+    assert parse_ssml_lite(None) == []
+
+
+def test_slow_tag():
+    segs = parse_ssml_lite("a [slow]b[/slow] c")
+    assert [s["text"] for s in segs] == ["a ", "b", " c"]
+    assert segs[0]["speed"] is None
+    assert segs[1]["speed"] == SLOW_SPEED
+    assert segs[2]["speed"] is None
+
+
+def test_fast_tag():
+    segs = parse_ssml_lite("[fast]zoom[/fast]")
+    assert len(segs) == 1
+    assert segs[0]["text"] == "zoom"
+    assert segs[0]["speed"] == FAST_SPEED
+    assert segs[0]["spell"] is False
+
+
+def test_emphasis_tag_sets_speed_and_flag():
+    segs = parse_ssml_lite("[emphasis]wow[/emphasis]")
+    assert segs[0]["speed"] == EMPHASIS_SPEED
+    assert segs[0]["emphasis"] is True
+    assert segs[0]["spell"] is False
+
+
+def test_spell_tag_sets_flag_not_speed():
+    segs = parse_ssml_lite("call [spell]NASA[/spell] now")
+    middle = segs[1]
+    assert middle["text"] == "NASA"
+    assert middle["spell"] is True
+    assert middle["speed"] is None
+
+
+def test_nesting_innermost_speed_wins():
+    # [fast] nested inside [slow] -> fast wins inside the inner run.
+    segs = parse_ssml_lite("[slow]a[fast]b[/fast]c[/slow]")
+    by_text = {s["text"]: s for s in segs}
+    assert by_text["a"]["speed"] == SLOW_SPEED
+    assert by_text["b"]["speed"] == FAST_SPEED
+    assert by_text["c"]["speed"] == SLOW_SPEED
+
+
+def test_nesting_spell_inside_slow_keeps_both():
+    segs = parse_ssml_lite("[slow]x[spell]Y[/spell]z[/slow]")
+    by_text = {s["text"]: s for s in segs}
+    assert by_text["Y"]["speed"] == SLOW_SPEED  # outer slow still applies
+    assert by_text["Y"]["spell"] is True
+    assert by_text["x"]["spell"] is False
+    assert by_text["z"]["spell"] is False
+
+
+def test_unclosed_applies_to_eol():
+    segs = parse_ssml_lite("start [slow]rest of line")
+    assert segs[0]["text"] == "start "
+    assert segs[0]["speed"] is None
+    assert segs[1]["text"] == "rest of line"
+    assert segs[1]["speed"] == SLOW_SPEED
+
+
+def test_unclosed_nested_both_to_eol():
+    segs = parse_ssml_lite("[slow]a[spell]b")
+    by_text = {s["text"]: s for s in segs}
+    assert by_text["a"]["speed"] == SLOW_SPEED and by_text["a"]["spell"] is False
+    assert by_text["b"]["speed"] == SLOW_SPEED and by_text["b"]["spell"] is True
+
+
+def test_stray_close_ignored():
+    segs = parse_ssml_lite("hello[/slow]world")
+    # Markers stripped; the two plain runs merge into one segment.
+    assert segs == [
+        {"text": "helloworld", "speed": None, "spell": False, "emphasis": False}
+    ]
+
+
+def test_only_markers_yields_no_segments():
+    assert parse_ssml_lite("[slow][/slow]") == []
+
+
+def test_mixed_tags_in_one_line():
+    segs = parse_ssml_lite("Say [slow]hi[/slow] then [fast]bye[/fast]!")
+    texts = [s["text"] for s in segs]
+    assert texts == ["Say ", "hi", " then ", "bye", "!"]
+    assert segs[1]["speed"] == SLOW_SPEED
+    assert segs[3]["speed"] == FAST_SPEED
+    assert segs[0]["speed"] is None and segs[4]["speed"] is None
+
+
+def test_adjacent_plain_runs_merge():
+    # Open+immediate-close around nothing, surrounded by text -> single seg.
+    segs = parse_ssml_lite("foo[slow][/slow]bar")
+    assert segs == [
+        {"text": "foobar", "speed": None, "spell": False, "emphasis": False}
+    ]
+
+
+def test_case_insensitive_tags():
+    segs = parse_ssml_lite("[SLOW]x[/Slow]")
+    assert segs[0]["speed"] == SLOW_SPEED
+
+
+def test_spell_out_basic():
+    assert spell_out("USA") == "U S A"
+    assert spell_out("a") == "a"
+
+
+def test_spell_out_strips_and_joins_whitespace():
+    assert spell_out("  hi  ") == "h i"
+    assert spell_out("go USA") == "g o U S A"
+    assert spell_out("") == ""
+
+
+def test_redos_safe_on_adversarial_input():
+    # Many bracket-like fragments must not blow up (linear-time guarantee).
+    import time
+
+    payload = "[slow]" * 5000 + "x"
+    t0 = time.perf_counter()
+    segs = parse_ssml_lite(payload)
+    assert time.perf_counter() - t0 < 1.0
+    # All 5000 opens unclosed -> the single 'x' run is slow.
+    assert segs[-1]["text"] == "x"
+    assert segs[-1]["speed"] == SLOW_SPEED


### PR DESCRIPTION
Inline delivery hints within a narration line, wired into **both** front doors so Audiobook and Stories behave identically.

- `[slow]…[/slow]` (≈0.85×) · `[fast]…[/fast]` (≈1.15×) · `[emphasis]…[/emphasis]` (mild slow + flag) · `[spell]…[/spell]` (letter-by-letter)

## Changes
- **`services/ssml_lite.py`** (worktree-built, 18 tests): `parse_ssml_lite` → `{text, speed, spell, emphasis}` segments — nesting (innermost wins), unclosed-to-EOL, stray-close ignored, adjacent-merge; **ReDoS-safe** literal alternation. + `spell_out`.
- **`_parse_spans`** (audiobook script path): applies SSML-lite as the **innermost** layer — precedence `[voice:]` → `[pause]` → SSML. Each segment → a `Span` with its `speed` (threaded to the renderer) and spelled-out text for `[spell]`; the trailing pause attaches to the run's last segment.
- **`frontend/src/utils/ssmlLite.js`**: client port (kept in sync) + `storyToSpans` applies it per chunk — inline speed **overrides** the per-line slider, falls back to it otherwise.

## Tests
`parse_ssml_lite` (18 py + 10 js incl. a linear-time ReDoS guard), script-level prosody parse, Stories SSML compile (override + spell). **70 backend + 345 frontend green; build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## SSML-Lite Prosody Markup Processing

This PR introduces an SSML-lite inline prosody markup system for narration lines, allowing fine-grained control over speech speed, emphasis, and character-by-character spelling. The feature is implemented consistently across both backend (Python) and frontend (JavaScript), with comprehensive test coverage.

### Supported Tags
- `[slow]…[/slow]`: Reduces speed to ~0.85×
- `[fast]…[/fast]`: Increases speed to ~1.15×
- `[emphasis]…[/emphasis]`: Applies mild slow (0.85×) with emphasis flag
- `[spell]…[/spell]`: Letter-by-letter output with spaces between characters

### Key Changes

**Backend (`backend/services/ssml_lite.py`)**
- New module implementing SSML-lite parser producing ordered segment list with `{text, speed, spell, emphasis}` properties
- Supports nested tags with "innermost wins" semantics for each property
- Unclosed tags apply through end-of-line; stray closing tags are ignored
- Adjacent segments with matching `(speed, spell, emphasis)` are automatically merged
- ReDoS-safe regex using fixed literal alternation for tag detection
- `spell_out()` function formats words into space-separated characters
- 18 Python unit tests validating parsing, nesting, edge cases, and performance

**Backend Script Integration (`backend/services/audiobook.py`)**
- Modified `_parse_spans` to post-process pause-delimited segments through SSML-lite parser
- Per-subsegment speed values are threaded through to the renderer
- Spelled segments properly expanded; trailing pause only applied to final subsegment
- Pure-whitespace segments and pause-only segments correctly handled

**Frontend (`frontend/src/utils/ssmlLite.js`)**
- Client-side parser mirroring backend behavior for consistency
- Same tag syntax and nesting semantics
- Exports constants and functions matching backend module
- 10 JavaScript tests including ReDoS guard for performance

**Frontend Integration (`frontend/src/utils/storyToSpans.js`)**
- Now applies SSML-lite parsing to each non-pause segment
- Inline speed from tags overrides per-line speed slider when present
- Falls back to per-line speed otherwise
- Properly expands spelled content and trims output

### Processing Flow

```mermaid
flowchart TD
    A["Input Text with SSML-lite Tags<br/>e.g., 'Say it [fast]quickly[/fast]!'"] -->|parse_ssml_lite| B["Segment List<br/>{text, speed, spell, emphasis}"]
    B -->|Audiobook Script| C["Span Objects with<br/>Speed & Spelling Applied"]
    B -->|Frontend storyToSpans| D["UI Spans with<br/>Inline Speed Override"]
    C -->|Renderer| E["Audio Output<br/>Speed/Emphasis/Spelling Applied"]
    D -->|Playback| E
```

### Test Coverage
- **Backend**: 18 tests for `parse_ssml_lite` covering defaults, empty input, speed tags, spell/emphasis flags, nesting precedence, unclosed tags, stray closes, adjacent merging, and ReDoS adversarial cases
- **Frontend**: 10 tests for client-side parser plus `spellOut` formatting; separate integration test for `storyToSpans` with override and spell scenarios
- **Integration**: New test `test_parse_applies_ssml_lite_prosody` verifies end-to-end audiobook script parsing with SSML-lite markup

### Testing Results
- 70 backend tests green
- 345 frontend tests green  
- Build clean

<!-- end of auto-generated comment: release notes by coderabbit.ai -->