### PR TITLE
feat(audiobook): pronunciation editor + markup reference UI

### DIFF
--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -37,7 +37,7 @@ export interface AudiobookPreview {
 
 /** Render a single chapter to audition it (also warms the resume cache). */
 export async function audiobookPreviewChapter(
-  body: { text: string; chapter_index: number; default_voice?: string | null },
+  body: { text: string; chapter_index: number; default_voice?: string | null; lexicon?: Record<string, string> | null },
 ): Promise<AudiobookPreview> {
   const res = await apiFetch('/audiobook/preview', {
     method: 'POST',
@@ -65,6 +65,7 @@ export interface AudiobookGenerateBody {
   loudness?: 'off' | 'acx' | 'podcast' | null;
   cover_path?: string | null;
   metadata?: AudiobookMetadata | null;
+  lexicon?: Record<string, string> | null;
 }
 
 /**

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -145,7 +145,14 @@
     "cached_note": "Reused {{count}} already-rendered chapter(s).",
     "failed_note": "{{count}} chapter(s) failed — click Create again to retry just those.",
     "import": "Import",
-    "import_failed": "Import failed: {{message}}"
+    "import_failed": "Import failed: {{message}}",
+    "lexicon": "Pronunciation",
+    "lex_word": "Word",
+    "lex_say": "Say it as…",
+    "lex_add": "Add word",
+    "lex_remove": "Remove",
+    "markup_help": "Markup reference",
+    "markup_hint": "# Chapter title · [voice:NAME] switch voice · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell]"
   },
   "launchpad": {
     "greeting": "hello there",

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookMarked, Loader, Download, Image as ImageIcon, X, Play, Upload } from 'lucide-react';
+import { BookMarked, Loader, Download, Image as ImageIcon, X, Play, Upload, Plus } from 'lucide-react';
 
 import {
   audiobookPlan, audiobookGenerate, audiobookUploadCover, audiobookPreviewChapter, audiobookImport,
@@ -38,6 +38,14 @@ export default function AudiobookTab({ profiles = [] }) {
   });
   const [coverFile, setCoverFile] = useState(null);
   const [coverPreview, setCoverPreview] = useState('');
+  // Pronunciation lexicon: editable {word → respelling} rows.
+  const [lex, setLex] = useState([]); // [{ word, say }]
+  const lexDict = () => Object.fromEntries(
+    lex.filter((r) => r.word.trim() && r.say.trim()).map((r) => [r.word.trim(), r.say.trim()]),
+  );
+  const setLexRow = (i, k) => (e) => setLex((rows) => rows.map((r, j) => (j === i ? { ...r, [k]: e.target.value } : r)));
+  const addLexRow = () => setLex((rows) => [...rows, { word: '', say: '' }]);
+  const removeLexRow = (i) => setLex((rows) => rows.filter((_, j) => j !== i));
   const setMetaField = (k) => (e) => setMeta((m) => ({ ...m, [k]: e.target.value }));
 
   const onCoverPick = useCallback((e) => {
@@ -90,13 +98,17 @@ export default function AudiobookTab({ profiles = [] }) {
     setError('');
     setChapterPrev((p) => ({ ...p, [i]: { ...(p[i] || {}), loading: true } }));
     try {
-      const r = await audiobookPreviewChapter({ text, chapter_index: i, default_voice: defaultVoice || null });
+      const lexicon = lexDict();
+      const r = await audiobookPreviewChapter({
+        text, chapter_index: i, default_voice: defaultVoice || null,
+        lexicon: Object.keys(lexicon).length ? lexicon : null,
+      });
       setChapterPrev((p) => ({ ...p, [i]: { url: audioUrl(r.output), loading: false } }));
     } catch (e) {
       setChapterPrev((p) => ({ ...p, [i]: { ...(p[i] || {}), loading: false } }));
       setError(e?.message || String(e));
     }
-  }, [text, defaultVoice]);
+  }, [text, defaultVoice, lex]);
 
   const onCreate = useCallback(async () => {
     setError('');
@@ -114,6 +126,7 @@ export default function AudiobookTab({ profiles = [] }) {
       const metadata = Object.fromEntries(
         Object.entries(meta).filter(([, v]) => v && v.trim()),
       );
+      const lexicon = lexDict();
       const res = await audiobookGenerate({
         text,
         default_voice: defaultVoice || null,
@@ -121,6 +134,7 @@ export default function AudiobookTab({ profiles = [] }) {
         loudness: loudness === 'off' ? null : loudness,
         cover_path,
         metadata: Object.keys(metadata).length ? metadata : null,
+        lexicon: Object.keys(lexicon).length ? lexicon : null,
       });
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
@@ -158,7 +172,7 @@ export default function AudiobookTab({ profiles = [] }) {
     } finally {
       setGenerating(false);
     }
-  }, [text, defaultVoice, format, loudness, coverFile, meta]);
+  }, [text, defaultVoice, format, loudness, coverFile, meta, lex]);
 
   const busy = planLoading || generating || importing;
   const canRun = text.trim().length > 0 && !busy;
@@ -273,6 +287,32 @@ export default function AudiobookTab({ profiles = [] }) {
               </div>
             </div>
           </div>
+
+          {/* Pronunciation lexicon */}
+          <div className="audiobook-tab__field">
+            <label className="field-label">{t('audiobook.lexicon')}</label>
+            {lex.map((row, i) => (
+              <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+                <input className="input-base" placeholder={t('audiobook.lex_word')}
+                  value={row.word} onChange={setLexRow(i, 'word')} aria-label={t('audiobook.lex_word')} style={{ flex: 1, minWidth: 0 }} />
+                <input className="input-base" placeholder={t('audiobook.lex_say')}
+                  value={row.say} onChange={setLexRow(i, 'say')} aria-label={t('audiobook.lex_say')} style={{ flex: 1, minWidth: 0 }} />
+                <button type="button" className="btn" onClick={() => removeLexRow(i)}
+                  aria-label={t('audiobook.lex_remove')} style={{ padding: 4 }}><X size={14} /></button>
+              </div>
+            ))}
+            <button type="button" className="btn" onClick={addLexRow} style={{ alignSelf: 'flex-start' }}>
+              <Plus size={14} /> {t('audiobook.lex_add')}
+            </button>
+          </div>
+
+          {/* Markup quick reference */}
+          <details className="audiobook-tab__field">
+            <summary className="field-label" style={{ cursor: 'pointer' }}>{t('audiobook.markup_help')}</summary>
+            <p className="muted" style={{ fontSize: '0.72rem', lineHeight: 1.6, marginTop: 6 }}>
+              {t('audiobook.markup_hint')}
+            </p>
+          </details>
 
           {error && <div className="error-banner" role="alert">{error}</div>}
 


### PR DESCRIPTION
Makes the **lexicon backend** (#419) and **SSML-lite markup** (#421) usable from the tab — both previously backend-only.

- **Pronunciation editor** in the full-width side pane: add/remove `{word → say it as…}` rows, compiled to a lexicon dict sent with **both** the full render and **per-chapter preview** (so previews match the final output).
- **Markup reference** (collapsible): the script syntax at a glance — `# chapter`, `[voice:]`, `[pause]`, `[slow]`/`[fast]`/`[emphasis]`/`[spell]`.
- `api/audiobook.ts`: `lexicon` field on the generate + preview bodies.

Build clean; 345 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Overview

This PR exposes the lexicon backend and SSML-lite markup features in the UI, making pronunciation customization and syntax reference available to users. The changes integrate a Pronunciation editor and collapsible Markup reference into the AudiobookTab side panel.

## UI Changes

### Layout - Before/After Side Panel

**Before:**
```
┌─ AudiobookTab Side Panel ─────────────┐
│                                       │
│  Default Voice: [dropdown]            │
│                                       │
│  Format: [dropdown]  Loudness: [dd]   │
│                                       │
│  Details (Cover + Metadata):          │
│  [96×96 cover]  [title, author...]    │
│                                       │
│  [Error banner if any]                │
│  [Progress display if generating]     │
└───────────────────────────────────────┘
```

**After:**
```
┌─ AudiobookTab Side Panel ─────────────┐
│                                       │
│  Default Voice: [dropdown]            │
│                                       │
│  Format: [dropdown]  Loudness: [dd]   │
│                                       │
│  Details (Cover + Metadata):          │
│  [96×96 cover]  [title, author...]    │
│                                       │
│  Pronunciation Lexicon:               │
│  [word input] [say input] [×]         │
│  [word input] [say input] [×]         │
│  [+ Add] button                       │
│                                       │
│  ▶ Markup Quick Reference             │
│    (collapsible, shows syntax help)   │
│                                       │
│  [Error banner if any]                │
│  [Progress display if generating]     │
└───────────────────────────────────────┘
```

## Data Flow - Lexicon Integration

```mermaid
graph TD
    A["User adds pronunciation rows<br/>{word, say}"] -->|state: lex| B["lexDict() generates<br/>dictionary"]
    B -->|filter empty rows| C{"Lexicon<br/>empty?"}
    C -->|yes| D["Pass null to API"]
    C -->|no| E["Pass Record&lt;word, say&gt;"]
    D --> F["Preview or Generate"]
    E --> F
    F -->|preview| G["audiobookPreviewChapter<br/>+ lexicon field"]
    F -->|generate| H["audiobookGenerate<br/>+ lexicon field"]
    G --> I["Preview uses same<br/>pronunciation rules<br/>as final output"]
    H --> J["Backend uses lexicon<br/>for TTS synthesis"]
```

## Functional Changes

**API Updates** (`frontend/src/api/audiobook.ts`):
- `audiobookPreviewChapter()`: Added optional `lexicon?: Record<string, string> | null` parameter
- `AudiobookGenerateBody` interface: Added optional `lexicon?: Record<string, string> | null` field

**State Management** (`frontend/src/pages/AudiobookTab.jsx`):
- New state: `lex` (array of `{ word, say }` rows)
- Helper functions:
  - `lexDict()`: Converts rows to dictionary, filtering empty entries
  - `setLexRow(i, k)`: Updates word/say field for row index `i`
  - `addLexRow()`: Appends new empty row
  - `removeLexRow(i)`: Removes row by index
- Updated `onPreviewChapter()` and `onCreate()` to compute and pass lexicon
- Updated hook dependencies to include `lex` state

**UI Components** (`frontend/src/pages/AudiobookTab.jsx`):
- **Pronunciation Lexicon Section**: Displays editable rows with word and say inputs, with remove (×) buttons per row and an "Add" button to append new rows
- **Markup Quick Reference**: Collapsible `<details>` element showing script syntax help: `# chapter`, `[voice:]`, `[pause]`, `[slow]`/`[fast]`/`[emphasis]`/`[spell]`

**Localization** (`frontend/src/i18n/locales/en.json`):
- Updated `import_failed` message template
- Added translation keys: `lexicon`, `lex_word`, `lex_say`, `lex_add`, `lex_remove`, `markup_help`, `markup_hint`

## Testing & Validation
- 345 frontend tests passing
- Build clean
- Lexicon is validated (empty rows filtered out) before API calls
- Pronunciation previews now match final audiobook output due to shared lexicon

<!-- end of auto-generated comment: release notes by coderabbit.ai -->