### PR TITLE
fix(longform): evict oldest chapters from the render cache (review fast-follow)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -33,6 +33,7 @@ from services.longform_render import (
     build_concat_list,
     build_ffmetadata,
     build_render_cmd,
+    prune_cache_dir,
 )
 
 logger = logging.getLogger("omnivoice.audiobook")
@@ -397,6 +398,7 @@ async def _render_longform_sse(
     # front doors: an identical chapter renders once.
     cache_dir = os.path.join(OUTPUTS_DIR, "longform_cache")
     os.makedirs(cache_dir, exist_ok=True)
+    prune_cache_dir(cache_dir)  # bound disk before this job adds its chapters
     loop = asyncio.get_running_loop()
 
     try:

--- a/backend/services/longform_render.py
+++ b/backend/services/longform_render.py
@@ -28,12 +28,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
 
 _BITRATE_RE = re.compile(r"^\d{2,3}k$")
+#: Default ceiling for the content-addressed chapter cache. Above this, the
+#: oldest cached chapter WAVs are evicted (LRU by mtime). Override via
+#: OMNIVOICE_LONGFORM_CACHE_MAX_GB.
+_CACHE_MAX_BYTES = int(float(os.environ.get("OMNIVOICE_LONGFORM_CACHE_MAX_GB", "2")) * 1024 ** 3)
 _COVER_EXTS = {".jpg", ".jpeg", ".png"}
 _COVER_MAX_BYTES = 8 * 1024 * 1024  # 8 MB — a book cover, not a payload
 
@@ -55,6 +60,48 @@ _GLOBAL_TAG_KEYS: list[tuple[str, str]] = [
 def _escape_meta(value: str) -> str:
     """Escape an FFMETADATA value (``=``, ``;``, ``#``, ``\\``, newline)."""
     return re.sub(r"([=;#\\\n])", r"\\\1", value or "")
+
+
+def prune_cache_dir(cache_dir: str, max_bytes: int = _CACHE_MAX_BYTES) -> tuple[int, int]:
+    """Evict the oldest files in ``cache_dir`` until the total size is within
+    ``max_bytes`` (LRU by mtime). The content-addressed chapter cache otherwise
+    grows without bound — uncompressed WAVs accumulate across every render.
+
+    Best-effort: returns ``(remaining_bytes, removed_count)`` and never raises
+    (a missing dir / unstattable file is just skipped). Call it *before* writing
+    a job's chapters so the fresh ones are never the eviction target.
+    """
+    try:
+        names = os.listdir(cache_dir)
+    except OSError:
+        return (0, 0)
+    entries: list[tuple[float, int, str]] = []
+    total = 0
+    for name in names:
+        p = os.path.join(cache_dir, name)
+        try:
+            if not os.path.isfile(p):
+                continue
+            size = os.path.getsize(p)
+            mtime = os.path.getmtime(p)
+        except OSError:
+            continue
+        entries.append((mtime, size, p))
+        total += size
+    if total <= max_bytes:
+        return (total, 0)
+    entries.sort()  # oldest first
+    removed = 0
+    for _mtime, size, p in entries:
+        if total <= max_bytes:
+            break
+        try:
+            os.remove(p)
+            total -= size
+            removed += 1
+        except OSError:
+            continue
+    return (total, removed)
 
 
 # ── Chapter cache key (resume) ──────────────────────────────────────────────

--- a/tests/test_longform_render.py
+++ b/tests/test_longform_render.py
@@ -15,6 +15,7 @@ from services.longform_render import (
     build_loudnorm_filter,
     build_render_cmd,
     chapter_cache_key,
+    prune_cache_dir,
     validate_cover_image,
 )
 
@@ -226,3 +227,34 @@ def test_cache_key_voice_sig_order_irrelevant():
     b = chapter_cache_key(_SPANS, sample_rate=24000, engine_id="omnivoice",
                           voice_sig={"b": "2", "a": "1"})
     assert a == b
+
+
+# ── cache eviction ──────────────────────────────────────────────────────────
+
+def _seed(tmp_path, name, size, age_s):
+    import os, time
+    p = tmp_path / name
+    p.write_bytes(b"\0" * size)
+    t = time.time() - age_s
+    os.utime(p, (t, t))
+    return p
+
+
+def test_prune_cache_under_cap_is_noop(tmp_path):
+    _seed(tmp_path, "a.wav", 100, 10)
+    remaining, removed = prune_cache_dir(str(tmp_path), max_bytes=1000)
+    assert removed == 0 and remaining == 100
+
+
+def test_prune_cache_evicts_oldest_first(tmp_path):
+    old = _seed(tmp_path, "old.wav", 600, age_s=100)   # oldest
+    new = _seed(tmp_path, "new.wav", 600, age_s=1)      # newest
+    remaining, removed = prune_cache_dir(str(tmp_path), max_bytes=1000)
+    assert removed == 1
+    assert not old.exists()      # oldest evicted
+    assert new.exists()          # newest kept
+    assert remaining <= 1000
+
+
+def test_prune_cache_missing_dir_is_safe(tmp_path):
+    assert prune_cache_dir(str(tmp_path / "nope")) == (0, 0)


### PR DESCRIPTION
Closes the last HIGH-value review fast-follow: the content-addressed `longform_cache/` accumulated uncompressed chapter WAVs across every render with **no bound**.

- **`prune_cache_dir(dir, max_bytes)`** — LRU-by-mtime eviction down to a **2 GB** ceiling (override via `OMNIVOICE_LONGFORM_CACHE_MAX_GB`). Best-effort, never raises (missing dir / unstattable file just skipped).
- Called at the **start** of each render job, *before* its chapters are written, so the fresh chapters are never the eviction target.

## Tests
under-cap no-op · evicts-oldest-keeps-newest · missing-dir safe. **38 green.**

> Deferred (intentionally): the standalone chapter cue-sheet `.txt` (the other review fast-follow) — the m4b already embeds chapter markers, so it's low-value; left as a future nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a cache-pruning mechanism for the longform audio renderer to prevent unbounded accumulation of uncompressed chapter WAV files. A new `prune_cache_dir()` function is added to bound the cached chapter storage at 2 GB (configurable via `OMNIVOICE_LONGFORM_CACHE_MAX_GB`), and is invoked at the start of each render job before synthesizing/muxing chapters.

## Changes

**backend/services/longform_render.py**  
Added:
- `_CACHE_MAX_BYTES`: environment-configurable cache size limit derived from `OMNIVOICE_LONGFORM_CACHE_MAX_GB`
- `prune_cache_dir(cache_dir: str, max_bytes: int = _CACHE_MAX_BYTES) -> tuple[int, int]`: best-effort cache eviction function that lists files, computes total directory size, evicts oldest files by mtime until within the cap, and returns (remaining_bytes, removed_count). Safely skips missing directories or unreadable files without raising exceptions.

**backend/api/routers/audiobook.py**  
Integrated `prune_cache_dir` into `_render_longform_sse` to prune the cache immediately after creating the `longform_cache` directory, ensuring newly-written chapter files are not eviction targets.

**tests/test_longform_render.py**  
New test suite covering:
- Under-cap scenario: no-op when cache size is below the limit
- Over-cap scenario: evicts oldest files first while preserving newer files
- Missing directory: safely returns (0, 0) without raising

## Behavior Flow

```mermaid
graph TD
    A["Render job starts"] --> B["Create/ensure longform_cache directory"]
    B --> C["Call prune_cache_dir"]
    C --> D["List files in cache"]
    D --> E{"Total size > max_bytes?"}
    E -->|No| F["Return remaining_bytes, 0"]
    E -->|Yes| G["Sort files by mtime<br/>oldest first"]
    G --> H["Delete oldest files<br/>until size <= max_bytes"]
    H --> I["Return remaining_bytes,<br/>removed_count"]
    F --> J["Proceed with render job<br/>synthesize/mux chapters"]
    I --> J
    style C fill:`#4a90e2`
    style E fill:`#f5a623`
```

## Notes

- All 38 tests pass
- Function is defensive: skips unreadable entries and missing directories without failure
- Pruning happens before render writes, so newly-created chapters are safe from eviction
- Deferred for future work: handling of standalone chapter cue-sheet `.txt` files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->