### PR TITLE
fix(ui): align Audiobook + Stories controls to the design tokens

### DIFF
--- a/frontend/src/components/StoriesEditor.css
+++ b/frontend/src/components/StoriesEditor.css
@@ -450,12 +450,10 @@
 .stories-proj--current { background: rgba(184, 187, 38, 0.08); border-radius: var(--radius-sm); }
 
 /* ── Export format selector ───────────────────────────────────────── */
+/* Inherits the canonical chrome look from .input-base; only override the
+   toolbar-select sizing (input-base is full-width by default). */
 .stories-editor__format {
-  background: var(--color-bg-elev-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  color: var(--color-fg);
-  font-family: inherit;
+  width: auto;
   font-size: var(--text-xs);
   padding: 3px 6px;
 }

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -480,7 +480,7 @@ export default function StoriesEditor({ profiles = [] }) {
               <Layers size={13} /> {t('stories.stems')}
             </Button>
             <select
-              className="stories-editor__format"
+              className="input-base stories-editor__format"
               value={exportFormat}
               onChange={(e) => setExportFormat(e.target.value)}
               aria-label={t('stories.format')}

--- a/frontend/src/pages/AudiobookTab.css
+++ b/frontend/src/pages/AudiobookTab.css
@@ -23,8 +23,23 @@
   align-items: center;
   gap: 8px;
   margin: 0;
+  font-family: var(--font-serif);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-fg);
 }
-.audiobook-tab__sub { margin: 2px 0 0; }
+.audiobook-tab__sub { margin: 2px 0 0; color: var(--color-fg-muted); font-size: var(--text-sm); }
+
+/* Field/section labels — chrome mono uppercase, matching the rest of the app's
+   form labels (the bare .field-label class has no global rule). */
+.audiobook-tab .field-label {
+  font-family: var(--chrome-font-mono);
+  font-size: var(--chrome-label-size);
+  font-weight: 600;
+  letter-spacing: var(--chrome-label-track);
+  text-transform: uppercase;
+  color: var(--chrome-fg-muted);
+}
 .audiobook-tab__actions {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -187,14 +187,14 @@ export default function AudiobookTab({ profiles = [] }) {
           <p className="muted audiobook-tab__sub">{t('audiobook.subtitle')}</p>
         </div>
         <div className="audiobook-tab__actions">
-          <label className="btn" style={{ cursor: busy ? 'default' : 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <label className="ui-btn ui-btn--subtle" style={{ cursor: busy ? 'default' : 'pointer', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
             {importing ? <Loader size={14} className="spin" /> : <Upload size={14} />} {t('audiobook.import')}
             <input type="file" accept=".txt,.md,.epub" onChange={onImport} disabled={busy} style={{ display: 'none' }} />
           </label>
-          <button className="btn" onClick={onPreview} disabled={!canRun}>
+          <button className="ui-btn ui-btn--subtle" onClick={onPreview} disabled={!canRun}>
             {planLoading ? <Loader size={14} className="spin" /> : null} {t('audiobook.preview_plan')}
           </button>
-          <button className="btn btn-primary" onClick={onCreate} disabled={!canRun}>
+          <button className="ui-btn ui-btn--primary" onClick={onCreate} disabled={!canRun}>
             {generating ? <Loader size={14} className="spin" /> : null} {t('audiobook.create')}
           </button>
         </div>
@@ -253,14 +253,14 @@ export default function AudiobookTab({ profiles = [] }) {
                   <>
                     <img src={coverPreview} alt={t('audiobook.cover')}
                       style={{ width: 96, height: 96, objectFit: 'cover', borderRadius: 6 }} />
-                    <button type="button" className="btn" onClick={clearCover}
+                    <button type="button" className="ui-btn ui-btn--icon" onClick={clearCover}
                       aria-label={t('audiobook.cover_remove')}
-                      style={{ position: 'absolute', top: 4, right: 4, padding: 2 }}>
+                      style={{ position: 'absolute', top: 4, right: 4 }}>
                       <X size={14} />
                     </button>
                   </>
                 ) : (
-                  <label className="input-base" style={{
+                  <label className="ui-btn ui-btn--subtle" style={{
                     width: 96, height: 96, display: 'flex', flexDirection: 'column',
                     alignItems: 'center', justifyContent: 'center', gap: 4, cursor: 'pointer',
                   }}>
@@ -297,11 +297,11 @@ export default function AudiobookTab({ profiles = [] }) {
                   value={row.word} onChange={setLexRow(i, 'word')} aria-label={t('audiobook.lex_word')} style={{ flex: 1, minWidth: 0 }} />
                 <input className="input-base" placeholder={t('audiobook.lex_say')}
                   value={row.say} onChange={setLexRow(i, 'say')} aria-label={t('audiobook.lex_say')} style={{ flex: 1, minWidth: 0 }} />
-                <button type="button" className="btn" onClick={() => removeLexRow(i)}
-                  aria-label={t('audiobook.lex_remove')} style={{ padding: 4 }}><X size={14} /></button>
+                <button type="button" className="ui-btn ui-btn--icon" onClick={() => removeLexRow(i)}
+                  aria-label={t('audiobook.lex_remove')}><X size={14} /></button>
               </div>
             ))}
-            <button type="button" className="btn" onClick={addLexRow} style={{ alignSelf: 'flex-start' }}>
+            <button type="button" className="ui-btn ui-btn--subtle" onClick={addLexRow} style={{ alignSelf: 'flex-start' }}>
               <Plus size={14} /> {t('audiobook.lex_add')}
             </button>
           </div>
@@ -341,7 +341,7 @@ export default function AudiobookTab({ profiles = [] }) {
               )}
               <audio controls src={audioUrl(output)} style={{ width: '100%' }} />
               <div style={{ marginTop: 8 }}>
-                <a className="btn" href={audioUrl(output)} download={output}>
+                <a className="ui-btn ui-btn--subtle" href={audioUrl(output)} download={output}>
                   <Download size={14} /> {t('audiobook.download')}
                 </a>
               </div>
@@ -357,10 +357,9 @@ export default function AudiobookTab({ profiles = [] }) {
                   return (
                     <li key={i} style={{ marginBottom: 8 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                        <button className="btn" onClick={() => onPreviewChapter(i)}
+                        <button className="ui-btn ui-btn--icon" onClick={() => onPreviewChapter(i)}
                           disabled={prev.loading || busy}
-                          aria-label={t('audiobook.preview_chapter', { title: c.title })}
-                          style={{ padding: '2px 6px' }}>
+                          aria-label={t('audiobook.preview_chapter', { title: c.title })}>
                           {prev.loading ? <Loader size={12} className="spin" /> : <Play size={12} />}
                         </button>
                         <strong>{c.title}</strong>{' '}


### PR DESCRIPTION
The hand-written Audiobook + Stories tabs used a bare **`.btn` class that has no CSS rule** → bright white browser-default buttons, plus an **unstyled `.field-label`**. (Every other tab uses the `Button`/`ui-btn` system, which is why only these looked off.) Root-caused via a design-token audit workflow; classes/tokens verified to exist before applying.

## AudiobookTab
- Import / Preview plan / Add word / Add cover / Download → **`ui-btn ui-btn--subtle`**; Create → **`ui-btn ui-btn--primary`**; cover-remove / lexicon-remove / chapter-play → **`ui-btn ui-btn--icon`** (the app's themed variants from `ui/Button.css`).
- `AudiobookTab.css`: define `.audiobook-tab .field-label` (chrome mono/uppercase via `--chrome-*` tokens) + header serif title / muted subtitle (`--font-serif`, `--text-xl`, `--color-fg`/`-muted`). Selects/inputs already used `.input-base` (canonical) — left as-is.

## StoriesEditor
- Format `<select>` → **`.input-base`** (canonical chrome select + dropdown arrow); trimmed the bespoke `.stories-editor__format` rule to just toolbar sizing.

Build clean; 345 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR aligns the Audiobook and Stories editor UI controls with the app's canonical design-token-based system, replacing hand-written button and label styles with established component classes.

### Root Cause
The Audiobook and Stories tabs were using custom `.btn` and bespoke CSS rules instead of the app's standard `ui-btn` component classes and design tokens used elsewhere. The `.field-label` element had no global styling, requiring scoped overrides.

### Changes

#### AudiobookTab
**Button styling refactor:**
- Import / Preview plan / Add word / Add cover / Download → `ui-btn ui-btn--subtle`
- Create button → `ui-btn ui-btn--primary`
- Icon buttons (cover remove, lexicon remove, chapter play) → `ui-btn ui-btn--icon`

**CSS enhancements:**
- `.audiobook-tab__title`: Added serif font family, theme-driven size/weight/color (var(--font-serif), var(--text-xl), var(--color-fg))
- `.audiobook-tab__sub`: Expanded to include muted text color and small font size
- `.audiobook-tab .field-label`: New scoped rule for chrome-mono label appearance (mono font, uppercase, letter-spacing, muted color)

**Before/After layout sketch:**
```
BEFORE:                          AFTER:
┌─────────────────────────────┐ ┌─────────────────────────────┐
│ 📖 Audiobook (plain font)   │ │ 𝐀𝐮𝐝𝐢𝐨𝐛𝐨𝐨𝐤 (serif font)      │
│ subtitle (unstyled)         │ │ subtitle (muted color)      │
│ [plain btn] [plain btn]     │ │ [styled btn] [primary btn]  │
├─────────────────────────────┤ ├─────────────────────────────┤
│ Editor  │  Settings         │ │ Editor  │  Settings         │
│         │  FIELD LABEL      │ │         │  FIELD LABEL ★    │
│         │  (no styling)     │ │         │  (mono, uppercase) │
│         │  input            │ │         │  input             │
└─────────────────────────────┘ └─────────────────────────────┘
★ = now styled with chrome design tokens
```

#### StoriesEditor
**Format selector refactoring:**
- Changed `.stories-editor__format select` to apply `input-base` class for canonical chrome styling
- CSS simplified to inherit from `.input-base` base rule; width override changed from full bespoke styling to `width: auto` only
- Maintains dropdown arrow and border treatment via design tokens

**Example:**
```jsx
// Before: custom styling in CSS
<select className="stories-editor__format">

// After: inherits canonical input chrome
<select className="input-base stories-editor__format">
```

### Build Status
- Clean build; 345 frontend tests passing
- No behavioral changes; all callbacks and disabled states preserved
- Generated with Claude Code

### Impact
Establishes consistent use of `ui-btn` variants and design tokens across all editor tabs, reducing CSS duplication and improving maintainability. Labels and inputs now follow the app's canonical chrome styling system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->