### PR TITLE
Model-management v2 cleanup: unload contract + lifecycle facade (mm2)

### DIFF
--- a/.planning/quick/260613-mm2-clean-model-management-v2/260613-mm2-SUMMARY.md
+++ b/.planning/quick/260613-mm2-clean-model-management-v2/260613-mm2-SUMMARY.md
@@ -1,0 +1,32 @@
+# SUMMARY — model-management v2 cleanup (mm2)
+
+**Date:** 2026-06-13 · **Scope:** all 3 tiers (MM2-01..09). Backend-only; no frontend, no on-disk model-state change, no new deps.
+
+## Tier 1 — correctness
+- **MM2-01 (VRAM leak on engine switch):** `get_active_tts_backend()` now caches one instance per configured backend id and calls the outgoing engine's `unload()` before switching. Added `reset_active_backend()` for shutdown/tests. The `model=` OmniVoice fast-path still returns a fresh view over the shared singleton (no double-load) but a switch *away from* another engine still releases it. `tts_backend.py`.
+- **MM2-02 (per-engine unload()):** `OmniVoiceBackend.unload()` drops the local ref + the shared `model_manager.model` singleton + `free_vram()` (idempotent, preload-safe, best-effort — no async lock from the sync path). `SubprocessBackend.unload()` routes to `unload_sidecar(self.id)` (busy sidecars skipped) and is inherited by every subprocess engine.
+- **MM2-03 (honest ASR row):** `/model/loaded` ASR row now reports the pipe's actual device and carries a `note: "released with the TTS model"` so the disabled unload button is explained rather than silent.
+
+## Tier 2 — single lifecycle surface
+- **MM2-04 (`services/model_lifecycle.py`):** new facade owns `list_loaded()` / `unload(id)` / `unload_all()` / `free_vram()` across in-process TTS+ASR, diarization, and sidecars. `system.py` `/model/loaded` + `/model/unload` are now thin delegations; **response shapes preserved exactly** (`{models,count}`, `{unloaded,success,...}`, 400 on unknown id) — frontend untouched.
+- **MM2-05 (unified idle config):** removed the duplicated `_IDLE_TIMEOUT_SECONDS`; the in-process idle timeout and the sidecar idle timeout both resolve per-tick via `prefs.resolve(... env=...)` (env wins, settings can tune without restart). New keys: `idle_timeout_seconds` (`OMNIVOICE_IDLE_TIMEOUT_S`), `sidecar_idle_timeout_seconds` (`OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S`). `<=0` still disables sidecar reaping.
+
+## Tier 3 — robustness & observability
+- **MM2-06 (bounded cooldowns):** `_install_cooldowns` is swept (TTL 1h) on each install check and cleared on success — can no longer grow unbounded.
+- **MM2-07 (per-role weight floor):** `_validate_snapshot_has_weights` uses per-extension floors (tensor formats keep 5 MB; `.onnx` floor 64 KB) **OR** the original ≥5 MB catch — strictly more lenient, so a small-but-complete ONNX model is no longer false-flagged as truncated while a 0/KB partial is still rejected (#352 intact).
+- **MM2-08 (sidecar VRAM self-report):** the parent can't see a child's VRAM, so the GPU sidecar (`engines/indextts`) now reports `vram_mb` in its `pong` (CUDA/MPS-aware, 0 on CPU); the parent stashes the last-known figure and `list_live_sidecars()` surfaces it. CPU/absent sidecars honestly report 0.
+- **MM2-09 (cache-fallback logging):** the `is_cached` `scan_cache_dir → on-disk` fallback now logs at WARNING with the exception type (was DEBUG/invisible) — the #117/#118 WinError-448 path is triagable from logs.
+
+## Out of scope (as planned, not done)
+GPU-pool per-engine sizing (`_GPU_VRAM_PER_JOB_GB`) and torch.compile tuning — perf, not cleanup; risk regressing #278/#315.
+
+## Verification
+- New `tests/test_mm2_lifecycle.py` — 15 tests (reuse/switch-unload/reset/idempotent-unload, facade list/unload/unknown/sidecars shapes + honest ASR, env-wins idle config, cooldown sweep, per-role weight floor ×3).
+- Affected existing: `test_engines.py`, `test_subprocess_reaper.py`, `test_model_load_timeout.py`, `test_model_manager_preload.py` — green (no regressions).
+- **Full suite: 1379 passed, 0 failed.** Live: facade endpoints return preserved shapes; engine switch calls the previous engine's `unload()` exactly once.
+
+## Test placement note
+MM2 tests live at top-level `tests/` (not `tests/backend/`) on purpose: adding files under `tests/backend/` reorders collection and can expose a pre-existing `sys.modules`-isolation leak in other backend fixtures (the issue debugged in the FDL PR). Top-level placement keeps `tests/backend/` order identical.
+
+## Docs-sync
+The new idle-timeout settings keys are internal env/prefs knobs with no UI surface, so no README/docs change is required by the docs-sync rule. If a future Settings panel exposes them, document there.

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -29,6 +29,17 @@ router = APIRouter()
 # Cooldown: prevent rapid re-install after a failure. Maps repo_id → last_fail_time.
 _install_cooldowns: dict[str, float] = {}
 _COOLDOWN_SECS = 60.0
+# Evict cooldown entries older than this so the dict can't grow unbounded across
+# a long-lived process (MM2-06). Anything past the cooldown window is dead state.
+_COOLDOWN_TTL_SECS = 3600.0
+
+
+def _sweep_cooldowns(now: float) -> None:
+    """Drop cooldown entries older than the TTL (MM2-06). Keeps the dict bounded
+    — without this it accumulated one entry per ever-failed repo forever."""
+    stale = [k for k, t in _install_cooldowns.items() if (now - t) > _COOLDOWN_TTL_SECS]
+    for k in stale:
+        _install_cooldowns.pop(k, None)
 
 # Repo_ids the user asked to cancel (FDL-11). Checked between retry attempts.
 # Note: a single in-flight snapshot_download/Xet fetch is not interruptible
@@ -214,22 +225,47 @@ def _safe_put(queue: asyncio.Queue, event) -> None:
 # config-only aux repos.
 _MIN_WEIGHT_BYTES = 5 * 1024 * 1024
 
+# Per-role weight-file floors (MM2-07). A valid model has at least one
+# recognized weight file at or above its extension's floor. ONNX graphs are
+# legitimately small (a complete model can be well under 5 MB), so a single
+# 5 MB rule false-positives on them as "truncated" (#352 over-trigger); give
+# .onnx a lower floor while still rejecting a 0/KB partial. Tensor formats keep
+# the original 5 MB floor.
+_WEIGHT_FLOORS = {
+    ".safetensors": _MIN_WEIGHT_BYTES,
+    ".bin": _MIN_WEIGHT_BYTES,
+    ".ckpt": _MIN_WEIGHT_BYTES,
+    ".pt": _MIN_WEIGHT_BYTES,
+    ".pth": _MIN_WEIGHT_BYTES,
+    ".gguf": _MIN_WEIGHT_BYTES,
+    ".onnx": 64 * 1024,   # a real ONNX graph is ≥ tens of KB; a truncated one is bytes
+}
+
 
 def _validate_snapshot_has_weights(repo_id: str, snapshot_path: str) -> None:
     """Raise OSError when a finished snapshot has no plausible weight file —
     surfaces the truncated-download class (#352) at install time, where the
     retry loop and the UI's re-download path can deal with it, instead of at
-    first synthesis with an opaque transformers error."""
+    first synthesis with an opaque transformers error.
+
+    A snapshot is valid if it contains a recognized weight file meeting its
+    per-extension floor (MM2-07) OR any file ≥ the global 5 MB floor (the
+    original lenient catch — kept so this is never stricter than before)."""
     try:
         biggest = 0
         for root, _dirs, files in os.walk(snapshot_path, followlinks=True):
             for f in files:
                 try:
-                    biggest = max(biggest, os.path.getsize(os.path.join(root, f)))
+                    size = os.path.getsize(os.path.join(root, f))
                 except OSError:
                     continue
-                if biggest >= _MIN_WEIGHT_BYTES:
-                    return
+                biggest = max(biggest, size)
+                ext = os.path.splitext(f)[1].lower()
+                floor = _WEIGHT_FLOORS.get(ext)
+                if floor is not None and size >= floor:
+                    return  # a recognized weight file of plausible size
+                if size >= _MIN_WEIGHT_BYTES:
+                    return  # original lenient catch (non-standard weight names)
     except OSError:
         return  # can't inspect — don't block the install on the checker itself
     raise OSError(
@@ -296,6 +332,7 @@ async def install_model(req: InstallModelRequest):
         )
     # Cooldown guard — don't retry if the same model just failed.
     import time as _time_check
+    _sweep_cooldowns(_time_check.time())  # bound the dict (MM2-06)
     last_fail = _install_cooldowns.get(req.repo_id)
     if last_fail and (_time_check.time() - last_fail) < _COOLDOWN_SECS:
         remaining = int(_COOLDOWN_SECS - (_time_check.time() - last_fail))
@@ -462,6 +499,7 @@ async def install_model(req: InstallModelRequest):
                 "downloaded": 0, "total": 0, "pct": 1.0,
                 "phase": "install_done",
             })
+            _install_cooldowns.pop(req.repo_id, None)  # success clears any cooldown (MM2-06)
             invalidate_cache()
         except _InstallCancelled:
             _resolving.set()

--- a/backend/api/routers/setup/models.py
+++ b/backend/api/routers/setup/models.py
@@ -220,8 +220,12 @@ def is_cached(repo_id: str) -> bool:
     except Exception as e:
         # scan_cache_dir can raise on Windows (WinError 448 'untrusted mount
         # point'); fall back to a direct disk check so a cached model isn't
-        # mistaken for missing and re-downloaded in a loop (#117/#118).
-        logger.debug("scan_cache_dir failed (%s); using disk fallback", e)
+        # mistaken for missing and re-downloaded in a loop (#117/#118). Logged
+        # at WARNING with the exception type (MM2-09) so this fallback isn't
+        # invisible when triaging a Windows cache report — it previously logged
+        # at DEBUG and never showed at the default level.
+        logger.warning("is_cached: scan_cache_dir failed (%s: %s); using on-disk fallback for %s",
+                       type(e).__name__, e, repo_id)
         return _is_cached_on_disk(repo_id)
 
 

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -174,118 +174,23 @@ def model_status():
 
 @router.get("/model/loaded")
 def loaded_models():
-    """Return details about all currently loaded models for the flush dropdown.
-
-    Returns a list of models with name, type, device, and estimated VRAM usage.
-    """
-    import services.model_manager as mm
-
-    models = []
-
-    # 1. TTS model (OmniVoice)
-    if mm.model is not None:
-        device = "unknown"
-        vram_mb = 0
-        try:
-            device = str(next(mm.model.parameters()).device) if hasattr(mm.model, 'parameters') else get_best_device()
-        except Exception:
-            device = get_best_device()
-        try:
-            torch = mm._lazy_torch()
-            if torch.cuda.is_available():
-                vram_mb = torch.cuda.memory_allocated() / (1024 ** 2)
-            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                driver = getattr(torch.mps, "driver_allocated_memory", None)
-                if driver:
-                    vram_mb = driver() / (1024 ** 2)
-        except Exception:
-            pass
-        models.append({
-            "id": "tts",
-            "name": "OmniVoice TTS",
-            "checkpoint": os.environ.get("OMNIVOICE_MODEL", "k2-fsa/OmniVoice"),
-            "device": device,
-            "vram_mb": round(vram_mb, 1),
-            "unloadable": True,
-        })
-
-    # 2. ASR model (WhisperX)
-    if mm.model is not None and hasattr(mm.model, '_asr_pipe') and mm.model._asr_pipe is not None:
-        models.append({
-            "id": "asr",
-            "name": "WhisperX ASR",
-            "checkpoint": os.environ.get("ASR_MODEL", "Systran/faster-whisper-large-v3"),
-            "device": "cpu",
-            "vram_mb": 0,
-            "unloadable": False,  # tied to TTS model lifecycle
-        })
-
-    # 3. Diarization pipeline
-    if mm._diar_pipeline is not None:
-        models.append({
-            "id": "diarization",
-            "name": "Pyannote Diarization",
-            "checkpoint": "pyannote/speaker-diarization-3.1",
-            "device": get_best_device(),
-            "vram_mb": 0,
-            "unloadable": True,
-        })
-
-    # 4. Subprocess engine sidecars (IndexTTS/CosyVoice/etc.) — each holds a
-    #    process and, on GPU, VRAM, until idle-reaped. Surface them as
-    #    unloadable rows so a multi-engine user can free VRAM on demand instead
-    #    of waiting for the idle reaper. VRAM isn't measurable from the parent
-    #    process, so it's reported as 0 with a sidecar-tagged name.
-    try:
-        from services.subprocess_backend import list_live_sidecars
-        for s in list_live_sidecars():
-            models.append({
-                "id": f"sidecar:{s['id']}",
-                "name": f"{s['id']} (sidecar)",
-                "checkpoint": s["id"],
-                "device": get_best_device(),
-                "vram_mb": 0,
-                "unloadable": True,
-            })
-    except Exception:
-        pass  # never let sidecar enumeration break the loaded-models panel
-
-    return {"models": models, "count": len(models)}
+    """List all currently loaded models for the flush dropdown (MM2-04).
+    Thin delegation to the model_lifecycle facade — shape unchanged:
+    ``{models, count}``."""
+    from services import model_lifecycle
+    return model_lifecycle.list_loaded()
 
 
 @router.post("/model/unload/{model_id}")
 async def unload_model(model_id: str):
-    """Unload a specific model by ID."""
-    import services.model_manager as mm
-
-    # Subprocess engine sidecars: ``sidecar:<engine_id>`` frees one, ``sidecars``
-    # frees them all. Busy sidecars (mid-synth) are skipped, not interrupted.
-    if model_id == "sidecars" or model_id.startswith("sidecar:"):
-        from services.subprocess_backend import unload_all_sidecars, unload_sidecar
-        if model_id == "sidecars":
-            n = unload_all_sidecars()
-        else:
-            n = unload_sidecar(model_id.split(":", 1)[1])
-        return {"unloaded": model_id, "success": n > 0, "count": n,
-                **({} if n > 0 else {"reason": "not running or busy"})}
-
-    if model_id == "tts":
-        async with mm._model_lock:
-            if mm.model is not None:
-                mm.model = None
-                mm.free_vram()
-                return {"unloaded": "tts", "success": True}
-        return {"unloaded": "tts", "success": False, "reason": "not loaded"}
-
-    elif model_id == "diarization":
-        if mm._diar_pipeline is not None:
-            mm._diar_pipeline = None
-            mm.free_vram()
-            return {"unloaded": "diarization", "success": True}
-        return {"unloaded": "diarization", "success": False, "reason": "not loaded"}
-
-    else:
-        raise HTTPException(status_code=400, detail=f"Unknown model id: {model_id}")
+    """Unload a specific model by id (MM2-04). Delegates to model_lifecycle;
+    an unknown id maps to HTTP 400. ``tts`` | ``diarization`` |
+    ``sidecar:<id>`` | ``sidecars``."""
+    from services import model_lifecycle
+    try:
+        return await model_lifecycle.unload(model_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get("/system/info", response_model=SystemInfoResponse)

--- a/backend/engines/indextts/main.py
+++ b/backend/engines/indextts/main.py
@@ -74,6 +74,24 @@ import traceback
 # Mirrors backend/services/subprocess_backend.py::MAX_FRAME_BYTES.
 MAX_FRAME_BYTES = 64 * 1024 * 1024
 
+
+def _measure_vram_mb() -> float:
+    """This sidecar's own GPU memory in MB, for the loaded-models panel
+    (MM2-08). The parent can't see a child's VRAM, so we self-report it in the
+    pong. Degrades to 0 on CPU / when torch isn't loaded yet — never raises."""
+    try:
+        import torch  # already a dep inside the indextts venv
+        if torch.cuda.is_available():
+            return round(torch.cuda.memory_allocated() / (1024 ** 2), 1)
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            drv = getattr(torch.mps, "driver_allocated_memory", None)
+            if drv:
+                return round(drv() / (1024 ** 2), 1)
+    except Exception:
+        pass
+    return 0.0
+
 # Sample rate IndexTTS-2 emits natively. Advertised in the ready frame so
 # the parent doesn't have to import IndexTTS just to learn the rate.
 INDEXTTS_SAMPLE_RATE = 24000
@@ -282,7 +300,7 @@ def main() -> int:
         op = msg.get("op") if isinstance(msg, dict) else None
         try:
             if op == "ping":
-                _send(stdout, {"op": "pong"})
+                _send(stdout, {"op": "pong", "vram_mb": _measure_vram_mb()})
             elif op == "synthesize":
                 _handle_synthesize(msg, stdout)
             elif op == "shutdown":

--- a/backend/services/model_lifecycle.py
+++ b/backend/services/model_lifecycle.py
@@ -1,0 +1,158 @@
+"""Single lifecycle surface for loaded models (MM2-04).
+
+Before this, ``GET /model/loaded`` and ``POST /model/unload`` each hand-rolled
+enumeration/dispatch across three worlds — the in-process TTS+ASR model
+(``model_manager``), the diarization pipeline, and subprocess sidecars
+(``subprocess_backend``). This module owns that logic so the routers are thin
+delegations and there's one place to reason about model lifecycle.
+
+Response shapes are preserved exactly — the frontend (hooks.ts model status +
+the flush dropdown) depends on ``{models, count}`` and
+``{unloaded, success, ...}``.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import services.model_manager as mm
+from services.model_manager import get_best_device
+
+
+def _tts_vram_mb() -> float:
+    """Best-effort allocated VRAM for the in-process model. Accurate on CUDA,
+    sparse on MPS, 0 elsewhere — degrade gracefully, never raise."""
+    try:
+        torch = mm._lazy_torch()
+        if torch.cuda.is_available():
+            return torch.cuda.memory_allocated() / (1024 ** 2)
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            driver = getattr(torch.mps, "driver_allocated_memory", None)
+            if driver:
+                return driver() / (1024 ** 2)
+    except Exception:
+        pass
+    return 0.0
+
+
+def _asr_device() -> str:
+    """Where the ASR pipe actually lives, rather than a hardcoded 'cpu'."""
+    pipe = getattr(mm.model, "_asr_pipe", None)
+    for attr in ("device",):
+        dev = getattr(pipe, attr, None)
+        if dev is not None:
+            return str(dev)
+    return "cpu"
+
+
+def list_loaded() -> dict:
+    """Enumerate every currently-loaded model. Shape: ``{"models": [...],
+    "count": n}`` with per-model id/name/checkpoint/device/vram_mb/unloadable
+    (+ optional ``note``)."""
+    models: list[dict] = []
+
+    # 1. In-process TTS model (OmniVoice)
+    if mm.model is not None:
+        try:
+            device = str(next(mm.model.parameters()).device) if hasattr(mm.model, "parameters") else get_best_device()
+        except Exception:
+            device = get_best_device()
+        models.append({
+            "id": "tts",
+            "name": "OmniVoice TTS",
+            "checkpoint": os.environ.get("OMNIVOICE_MODEL", "k2-fsa/OmniVoice"),
+            "device": device,
+            "vram_mb": round(_tts_vram_mb(), 1),
+            "unloadable": True,
+        })
+
+    # 2. ASR (WhisperX) — co-loaded with and released alongside the TTS model.
+    #    Honest reporting (MM2-03): the device is read from the pipe, and the
+    #    dead "unload" button is explained by a note rather than left silent.
+    if mm.model is not None and getattr(mm.model, "_asr_pipe", None) is not None:
+        models.append({
+            "id": "asr",
+            "name": "WhisperX ASR",
+            "checkpoint": os.environ.get("ASR_MODEL", "Systran/faster-whisper-large-v3"),
+            "device": _asr_device(),
+            "vram_mb": 0,
+            "unloadable": False,
+            "note": "released with the TTS model",
+        })
+
+    # 3. Diarization pipeline
+    if mm._diar_pipeline is not None:
+        models.append({
+            "id": "diarization",
+            "name": "Pyannote Diarization",
+            "checkpoint": "pyannote/speaker-diarization-3.1",
+            "device": get_best_device(),
+            "vram_mb": 0,
+            "unloadable": True,
+        })
+
+    # 4. Subprocess engine sidecars — each holds a process (and on GPU, VRAM)
+    #    until idle-reaped. VRAM is reported by the child itself when available
+    #    (MM2-08); 0 means CPU-only or not-yet-measured. Enumeration must never
+    #    break the panel.
+    try:
+        from services.subprocess_backend import list_live_sidecars
+        for s in list_live_sidecars():
+            models.append({
+                "id": f"sidecar:{s['id']}",
+                "name": f"{s['id']} (sidecar)",
+                "checkpoint": s["id"],
+                "device": get_best_device(),
+                "vram_mb": round(float(s.get("vram_mb") or 0), 1),
+                "unloadable": True,
+            })
+    except Exception:
+        pass
+
+    return {"models": models, "count": len(models)}
+
+
+async def unload(model_id: str) -> dict:
+    """Unload one model by id. Preserves the original per-id response shapes.
+
+    ``tts`` | ``diarization`` | ``sidecar:<id>`` | ``sidecars``. Raises
+    ValueError for an unknown id (router maps to HTTP 400)."""
+    if model_id == "sidecars" or model_id.startswith("sidecar:"):
+        from services.subprocess_backend import unload_all_sidecars, unload_sidecar
+        n = unload_all_sidecars() if model_id == "sidecars" else unload_sidecar(model_id.split(":", 1)[1])
+        return {"unloaded": model_id, "success": n > 0, "count": n,
+                **({} if n > 0 else {"reason": "not running or busy"})}
+
+    if model_id == "tts":
+        async with mm._model_lock:
+            if mm.model is not None:
+                mm.model = None
+                mm.free_vram()
+                return {"unloaded": "tts", "success": True}
+        return {"unloaded": "tts", "success": False, "reason": "not loaded"}
+
+    if model_id == "diarization":
+        if mm._diar_pipeline is not None:
+            mm._diar_pipeline = None
+            mm.free_vram()
+            return {"unloaded": "diarization", "success": True}
+        return {"unloaded": "diarization", "success": False, "reason": "not loaded"}
+
+    raise ValueError(f"Unknown model id: {model_id}")
+
+
+async def unload_all() -> dict:
+    """Release every releasable model — in-process TTS + diarization + all
+    sidecars. Convenience for app shutdown / a global flush."""
+    results = {}
+    for mid in ("tts", "diarization", "sidecars"):
+        try:
+            results[mid] = await unload(mid)
+        except Exception as exc:  # noqa: BLE001
+            results[mid] = {"unloaded": mid, "success": False, "reason": str(exc)}
+    return {"unloaded_all": True, "results": results}
+
+
+def free_vram() -> None:
+    """One import surface for callers that just want to drop GPU caches."""
+    mm.free_vram()

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -111,7 +111,8 @@ def __getattr__(name: str):
 model = None  # type: ignore
 _model_lock = asyncio.Lock()
 _last_used = time.time()
-_IDLE_TIMEOUT_SECONDS = IDLE_TIMEOUT_SECONDS
+# Idle timeout is resolved per-tick in _resolve_idle_timeout() (MM2-05) from
+# prefs/env/core.config — no module-level duplicate of IDLE_TIMEOUT_SECONDS.
 
 # ── Loading sub-stage tracker ────────────────────────────────────────
 # Updated by _load_model_sync() so get_model_status() can report
@@ -664,13 +665,28 @@ def get_model_status():
             result["error"] = err
     return result
 
+def _resolve_idle_timeout() -> float:
+    """In-process model idle timeout in seconds (MM2-05): prefs store → env →
+    core.config default, env winning. Resolved per-tick so a settings change
+    takes effect without a restart."""
+    try:
+        from core import prefs
+        return float(prefs.resolve(
+            "idle_timeout_seconds",
+            env="OMNIVOICE_IDLE_TIMEOUT_S",
+            default=IDLE_TIMEOUT_SECONDS,
+        ))
+    except (TypeError, ValueError, ImportError):
+        return float(IDLE_TIMEOUT_SECONDS)
+
+
 async def idle_worker():
     global model
     torch = _lazy_torch()
     while True:
         await asyncio.sleep(30)
         async with _model_lock:
-            if model is not None and time.time() - _last_used > _IDLE_TIMEOUT_SECONDS:
+            if model is not None and time.time() - _last_used > _resolve_idle_timeout():
                 logger.info("Idle timeout reached. Unloading OmniVoice model to free VRAM.")
                 model = None
                 free_vram()

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -103,9 +103,27 @@ RECV_TIMEOUT_S = 60.0
 # op because the reaper only acts while holding the per-backend lock acquired
 # NON-blockingly — if an op holds it, the reaper skips that backend this round.
 #
-# Tunable via OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S (seconds; <= 0 disables).
+# Default idle timeout. The live value is resolved per-tick via
+# _resolve_sidecar_idle_timeout() (MM2-05) so the Settings store can tune it
+# without a restart; the env var still wins. Kept as a module constant for the
+# import-time default and for tests that monkeypatch it.
 SIDECAR_IDLE_TIMEOUT_S = float(os.environ.get("OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S", "300"))
 _REAPER_INTERVAL_S = 30.0
+
+
+def _resolve_sidecar_idle_timeout() -> float:
+    """Idle-reap timeout in seconds (MM2-05): prefs store → env → default, with
+    env winning. ``<= 0`` disables reaping. Resolved lazily so a settings change
+    takes effect without a restart."""
+    from core import prefs
+    try:
+        return float(prefs.resolve(
+            "sidecar_idle_timeout_seconds",
+            env="OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S",
+            default=SIDECAR_IDLE_TIMEOUT_S,
+        ))
+    except (TypeError, ValueError):
+        return SIDECAR_IDLE_TIMEOUT_S
 
 #: Weak registry of live SubprocessBackend instances the reaper scans. Weak so
 #: discarded backends (the fresh-per-call instances) don't leak — once GC'd and
@@ -120,7 +138,7 @@ def reap_idle_sidecars(timeout_s: float | None = None) -> int:
     reaped. A non-positive timeout disables reaping (returns 0). Safe to call
     from any thread — it never touches a backend that is mid-op (it acquires
     the backend lock non-blockingly and skips on contention)."""
-    timeout = SIDECAR_IDLE_TIMEOUT_S if timeout_s is None else timeout_s
+    timeout = _resolve_sidecar_idle_timeout() if timeout_s is None else timeout_s
     if timeout <= 0:
         return 0
     reaped = 0
@@ -192,6 +210,7 @@ def list_live_sidecars() -> list[dict]:
             "id": b.id,
             "pid": proc.pid,
             "idle_seconds": round(b.idle_seconds(), 1),
+            "vram_mb": round(getattr(b, "_vram_mb", 0.0), 1),  # MM2-08; 0 = CPU/unmeasured
         })
     return out
 
@@ -219,7 +238,7 @@ def _reaper_loop() -> None:
 def _ensure_reaper_running() -> None:
     """Start the daemon reaper thread once, lazily, on first sidecar spawn."""
     global _reaper_started
-    if _reaper_started or SIDECAR_IDLE_TIMEOUT_S <= 0:
+    if _reaper_started or _resolve_sidecar_idle_timeout() <= 0:
         return
     with _reaper_lock:
         if _reaper_started:
@@ -262,6 +281,10 @@ class SubprocessBackend(TTSBackend):
         # (parity Action 13). Registered in the weak live-backend set so the
         # reaper can find this instance's sidecar.
         self._last_used = time.monotonic()
+        # Last-known GPU memory the sidecar self-reported in a pong (MM2-08).
+        # 0 = CPU-only or not yet measured. The parent can't measure a child's
+        # VRAM, so this is the only source of a real figure.
+        self._vram_mb = 0.0
         _LIVE_BACKENDS.add(self)
         # Idempotent atexit shutdown (Pitfall 6 layer 1). If the interpreter
         # exits without an explicit shutdown call, this still tears down the
@@ -275,6 +298,16 @@ class SubprocessBackend(TTSBackend):
     def idle_seconds(self) -> float:
         """Seconds since the last sidecar activity (spawn or frame I/O)."""
         return time.monotonic() - self._last_used
+
+    def unload(self) -> None:
+        """Release this engine's sidecar (MM2-02). Routes to the same
+        force-reap path the manual /model/unload endpoint uses, so a busy
+        sidecar (mid-synth) is skipped, not interrupted. Idempotent: a no-op
+        when no sidecar is running. Inherited by every subprocess engine."""
+        try:
+            unload_sidecar(self.id)
+        except Exception:
+            pass
 
     # ── subclass contract ──────────────────────────────────────────────────
 
@@ -435,6 +468,14 @@ class SubprocessBackend(TTSBackend):
                 self._send({"op": "ping"})
                 reply = self._recv_with_timeout(RECV_TIMEOUT_S)
             if reply and reply.get("op") == "pong":
+                # Sidecars may self-report their GPU memory (MM2-08) — the parent
+                # can't measure a child's VRAM. Stash the last-known figure so
+                # list_live_sidecars() can surface a real number instead of 0.
+                if "vram_mb" in reply:
+                    try:
+                        self._vram_mb = float(reply["vram_mb"] or 0)
+                    except (TypeError, ValueError):
+                        pass
                 return True, "pong"
             return False, f"unexpected reply: {reply!r}"
         except Exception as exc:

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -232,6 +232,22 @@ class OmniVoiceBackend(TTSBackend):
         )
         return audios[0]
 
+    def unload(self) -> None:
+        """Release the OmniVoice model (MM2-02). OmniVoice shares the singleton
+        owned by ``model_manager``, so dropping our local ref isn't enough — we
+        clear the shared one and free GPU memory too. Idempotent and safe before
+        the first generate(). Best-effort: assignment is GIL-atomic, so we don't
+        take the async ``_model_lock`` from this sync path; the registry wraps
+        this call in try/except so a race can never block an engine switch."""
+        self._model = None
+        try:
+            import services.model_manager as mm
+            if mm.model is not None:
+                mm.model = None
+                mm.free_vram()
+        except Exception:
+            pass
+
 
 # ── VoxCPM2 adapter (optional, scaffolded) ──────────────────────────────────
 
@@ -1232,14 +1248,65 @@ def active_backend_id() -> str:
     return prefs.resolve("tts_backend", env="OMNIVOICE_TTS_BACKEND", default="omnivoice")
 
 
+# Cached active backend instance + its id (MM2-01). Without this, every call
+# built a fresh instance and the previous engine's VRAM/sidecar leaked until GC
+# — measurable when switching engines on an 8 GB MPS Mac (root cause behind the
+# #278 comment thread). We now keep one instance per configured backend id and
+# call the outgoing engine's unload() before switching.
+_active_instance: "TTSBackend | None" = None
+_active_instance_id: "str | None" = None
+
+
+def reset_active_backend() -> None:
+    """Unload + clear the cached active backend. For app shutdown and tests.
+    Idempotent and best-effort — a raising unload() never propagates."""
+    global _active_instance, _active_instance_id
+    inst = _active_instance
+    _active_instance = None
+    _active_instance_id = None
+    if inst is not None:
+        try:
+            inst.unload()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("reset_active_backend: %s.unload() raised: %s",
+                           type(inst).__name__, exc)
+
+
 def get_active_tts_backend(*, model=None) -> TTSBackend:
-    """Instantiate the configured backend. Pass `model=` for OmniVoice to
-    reuse an already-loaded model from `model_manager`.
+    """Return the configured backend, reusing a cached instance and releasing
+    the previous engine on a switch (MM2-01).
+
+    Rule: the cache tracks the configured backend id. Switching id always
+    unload()s the outgoing instance first. For OmniVoice with an explicit
+    ``model=`` (caller already holds a loaded model), we return a fresh view
+    over the shared singleton rather than caching it — but a switch *away from*
+    a different engine still triggers that engine's unload().
     """
-    cls = get_backend_class(active_backend_id())
-    if cls is OmniVoiceBackend:
+    global _active_instance, _active_instance_id
+    bid = active_backend_id()
+
+    # Switching engines: release the outgoing one first. Best-effort so a bad
+    # unload() can never block the switch.
+    if _active_instance is not None and _active_instance_id != bid:
+        try:
+            _active_instance.unload()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("engine switch: %s.unload() raised: %s",
+                           type(_active_instance).__name__, exc)
+        _active_instance = None
+        _active_instance_id = None
+
+    cls = get_backend_class(bid)
+    if cls is OmniVoiceBackend and model is not None:
+        # Per-call view over the already-loaded shared singleton; don't cache it
+        # (the model lifecycle is owned by model_manager), but the switch above
+        # already released any *different* previous engine.
         return OmniVoiceBackend(model=model)
-    return cls()
+
+    if _active_instance is None or _active_instance_id != bid:
+        _active_instance = OmniVoiceBackend(model=model) if cls is OmniVoiceBackend else cls()
+        _active_instance_id = bid
+    return _active_instance
 
 
 # ── PEP 562 lazy attribute re-export ───────────────────────────────────────

--- a/tests/test_mm2_lifecycle.py
+++ b/tests/test_mm2_lifecycle.py
@@ -1,0 +1,163 @@
+"""MM2 model-management cleanup — unload contract, lifecycle facade, config,
+cooldown bounding, per-role weight validation, sidecar VRAM surfacing.
+
+Top-level (not under tests/backend/) on purpose: adding files there reorders
+collection and can expose a pre-existing sys.modules-isolation leak in other
+backend fixtures (see tests/test_fdl_*).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+import services.tts_backend as tb
+import services.model_lifecycle as ml
+import services.model_manager as mm
+import services.subprocess_backend as sb
+import api.routers.setup.download as dl
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── MM2-01 / MM2-02: registry reuse + unload-on-switch ──────────────────────
+
+def _fake_backend(calls):
+    class Fake(tb.TTSBackend):
+        id = "fake-mm2"
+        display_name = "Fake"
+        @property
+        def sample_rate(self): return 24000
+        @property
+        def supported_languages(self): return ["multi"]
+        @classmethod
+        def is_available(cls): return True, "ok"
+        def generate(self, *a, **k): ...
+        def unload(self): calls["unload"] += 1
+    return Fake
+
+
+def test_active_instance_reused_for_same_id(monkeypatch):
+    tb.reset_active_backend()
+    monkeypatch.setattr(tb, "active_backend_id", lambda: "omnivoice")
+    a = tb.get_active_tts_backend()
+    b = tb.get_active_tts_backend()
+    assert a is b
+    tb.reset_active_backend()
+
+
+def test_switch_unloads_previous_engine(monkeypatch):
+    calls = {"unload": 0}
+    tb._REGISTRY["fake-mm2"] = _fake_backend(calls)
+    tb.reset_active_backend()
+    monkeypatch.setattr(tb, "active_backend_id", lambda: "fake-mm2")
+    tb.get_active_tts_backend()
+    monkeypatch.setattr(tb, "active_backend_id", lambda: "omnivoice")
+    tb.get_active_tts_backend()
+    assert calls["unload"] == 1
+    tb.reset_active_backend()
+    tb._REGISTRY.pop("fake-mm2", None)
+
+
+def test_reset_active_backend_is_idempotent_and_unloads():
+    calls = {"unload": 0}
+    tb._active_instance = _fake_backend(calls)()
+    tb._active_instance_id = "fake-mm2"
+    tb.reset_active_backend()
+    tb.reset_active_backend()  # second call no-ops
+    assert calls["unload"] == 1
+    assert tb._active_instance is None
+
+
+def test_omnivoice_unload_idempotent_and_preload_safe():
+    b = tb.OmniVoiceBackend()
+    b.unload()
+    b.unload()  # twice, and before any generate() — must not raise
+
+
+# ── MM2-04 / MM2-03: lifecycle facade + honest ASR ──────────────────────────
+
+def test_list_loaded_empty(monkeypatch):
+    monkeypatch.setattr(mm, "model", None)
+    monkeypatch.setattr(mm, "_diar_pipeline", None)
+    out = ml.list_loaded()
+    assert out == {"models": [], "count": 0} or out["count"] == 0
+
+
+def test_list_loaded_asr_row_is_honest(monkeypatch):
+    class _Model:
+        _asr_pipe = object()
+        def parameters(self): raise StopIteration
+    monkeypatch.setattr(mm, "model", _Model())
+    monkeypatch.setattr(mm, "_diar_pipeline", None)
+    rows = {m["id"]: m for m in ml.list_loaded()["models"]}
+    assert "asr" in rows
+    asr = rows["asr"]
+    assert asr["unloadable"] is False
+    assert asr.get("note")  # explains the disabled unload button
+
+
+def test_facade_unload_unknown_raises():
+    with pytest.raises(ValueError):
+        _run(ml.unload("bogus"))
+
+
+def test_facade_unload_tts_not_loaded(monkeypatch):
+    monkeypatch.setattr(mm, "model", None)
+    r = _run(ml.unload("tts"))
+    assert r == {"unloaded": "tts", "success": False, "reason": "not loaded"}
+
+
+def test_facade_unload_sidecars_none_running():
+    r = _run(ml.unload("sidecars"))
+    assert r["unloaded"] == "sidecars"
+    assert r["success"] is False and r["count"] == 0
+
+
+# ── MM2-05: unified idle config (env wins) ──────────────────────────────────
+
+def test_idle_timeout_env_wins(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_IDLE_TIMEOUT_S", "123")
+    assert mm._resolve_idle_timeout() == 123.0
+
+
+def test_sidecar_idle_timeout_env_wins(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S", "0")
+    assert sb._resolve_sidecar_idle_timeout() == 0.0  # <=0 disables reaping
+
+
+# ── MM2-06: bounded cooldowns ───────────────────────────────────────────────
+
+def test_cooldown_sweep_evicts_stale():
+    now = 1_000_000.0
+    dl._install_cooldowns.clear()
+    dl._install_cooldowns["old/repo"] = now - dl._COOLDOWN_TTL_SECS - 10
+    dl._install_cooldowns["fresh/repo"] = now - 5
+    dl._sweep_cooldowns(now)
+    assert "old/repo" not in dl._install_cooldowns
+    assert "fresh/repo" in dl._install_cooldowns
+    dl._install_cooldowns.clear()
+
+
+# ── MM2-07: per-role weight validation ──────────────────────────────────────
+
+def test_small_onnx_is_not_flagged_as_truncated(tmp_path):
+    # A complete-but-small ONNX model (> 64 KB, < 5 MB) must pass.
+    (tmp_path / "model.onnx").write_bytes(b"\0" * (128 * 1024))
+    dl._validate_snapshot_has_weights("x/onnx", str(tmp_path))  # must not raise
+
+
+def test_truncated_snapshot_still_rejected(tmp_path):
+    # Only tiny config/tokenizer files, no plausible weight → reject (#352).
+    (tmp_path / "config.json").write_bytes(b"{}")
+    (tmp_path / "tokenizer.json").write_bytes(b"x" * 2048)
+    with pytest.raises(OSError):
+        dl._validate_snapshot_has_weights("x/truncated", str(tmp_path))
+
+
+def test_large_tensor_weight_passes(tmp_path):
+    (tmp_path / "model.safetensors").write_bytes(b"\0" * (6 * 1024 * 1024))
+    dl._validate_snapshot_has_weights("x/big", str(tmp_path))  # must not raise


### PR DESCRIPTION
## What

One coherent lifecycle surface over the in-process model, diarization, and subprocess sidecars; fixes the engine-switch VRAM leak; tightens download robustness. **Backend-only, response shapes preserved, no new deps, no on-disk model-state change.**

## Tier 1 — correctness
- **MM2-01 — VRAM leak on engine switch (the real bug):** `get_active_tts_backend()` cached nothing and never tore down the previous engine. Now it caches one instance per backend id and calls the outgoing engine's `unload()` on switch. Adds `reset_active_backend()`.
- **MM2-02 — `unload()` contract:** `OmniVoiceBackend.unload()` releases the shared `model_manager` singleton + `free_vram()`; `SubprocessBackend.unload()` → `unload_sidecar(self.id)` (busy sidecars skipped), inherited by all sidecar engines. Idempotent + safe before first generate().
- **MM2-03 — honest ASR row:** `/model/loaded` reports the ASR pipe's real device + a `note` explaining the disabled unload button.

## Tier 2 — single lifecycle surface
- **MM2-04 — `services/model_lifecycle.py`:** owns `list_loaded` / `unload` / `unload_all` / `free_vram`. `system.py` routers become thin delegations; **`{models,count}` / `{unloaded,success,...}` / 400-on-unknown shapes preserved** (frontend untouched).
- **MM2-05 — unified idle config:** in-process + sidecar idle timeouts resolve via `prefs.resolve` (env wins, no restart); removed the duplicated constant.

## Tier 3 — robustness & observability
- **MM2-06:** `_install_cooldowns` swept (1h TTL) + cleared on success → bounded.
- **MM2-07:** per-extension weight floors (`.onnx` 64 KB, tensors 5 MB) **OR** the original ≥5 MB catch — small complete ONNX no longer false-flagged; #352 truncation still caught.
- **MM2-08:** the `indextts` GPU sidecar self-reports `vram_mb` in its `pong`; parent surfaces it in `list_live_sidecars` (0 = CPU/unmeasured).
- **MM2-09:** `is_cached`'s `scan_cache_dir → on-disk` fallback now logs WARNING with the exception type (was DEBUG/invisible) — #117/#118 triagable.

## Out of scope (as planned)
GPU-pool sizing + torch.compile tuning — perf, not cleanup; risk regressing #278/#315.

## Tests
`tests/test_mm2_lifecycle.py` (15): reuse/switch-unload/reset/idempotent, facade shapes + honest ASR, env-wins idle config, cooldown sweep, per-role weight floor. **Full suite: 1379 passed, 0 failed.** Tests placed top-level to avoid the `tests/backend/` collection-order leak debugged in #424.

Plan/summary under `.planning/quick/260613-mm2-clean-model-management-v2/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## VRAM Caching & Unload Mechanism

```mermaid
flowchart TD
    A["Engine Switch Requested<br/>(new backend id)"] --> B{"Backend id<br/>changed?"}
    B -->|Yes| C["Call unload()<br/>on outgoing engine"]
    C --> D["Drop model_manager ref<br/>Call free_vram"]
    D --> E["Cache new backend<br/>by id"]
    B -->|No| E
    E --> F["Return cached<br/>instance"]
    
    style C fill:`#f9f`,color:`#000`
    style D fill:`#f9f`,color:`#000`
```

## Summary

This backend-only change introduces a unified lifecycle surface for in-process models, diarization, and subprocess sidecars while fixing a VRAM leak when switching engines.

**Tier 1 — VRAM Leak Fix:**
- `get_active_tts_backend()` now caches one instance per backend id and explicitly calls `unload()` on the outgoing engine when switching IDs
- `OmniVoiceBackend.unload()` releases the shared `model_manager` singleton and calls `free_vram()`; `SubprocessBackend.unload()` delegates to `unload_sidecar()`, skipping busy sidecars
- Added `reset_active_backend()` for app shutdown/tests
- `/model/loaded` reports the ASR pipeline's actual device and adds a `note` indicating unload is disabled for ASR

**Tier 2 — Lifecycle Facade:**
- New `services/model_lifecycle.py` module owns `list_loaded()`, `unload()`, `unload_all()`, and `free_vram()` functions
- System routers delegate thinly while preserving existing response shapes (`{models, count}`)
- Unified idle timeout configuration via `prefs.resolve` (environment wins over defaults); removed duplicated constants

**Tier 3 — Robustness & Observability:**
- Bounded install cooldowns with 1-hour TTL and sweep-on-check pattern
- Per-extension weight floors (`.onnx` 64 KB, tensors 5 MB) to reduce false "truncated" detection
- GPU sidecar reports `vram_mb` in pong messages; parent surfaces it (0 = CPU/unmeasured)
- `is_cached()` logs WARNING with exception type on disk-fallback instead of DEBUG

**Testing:**
- 15 new test cases in `tests/test_mm2_lifecycle.py` covering: backend reuse/switch-unload/reset idempotency, facade operations, ASR reporting, environment-override idle config, cooldown eviction, and weight validation heuristics
- Full test suite: 1379 passed, 0 failed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->