### PR TITLE
feat(routing): host device probe + routing resolver (#21 PR 1/5)

### DIFF
--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -46,10 +46,11 @@ KERNEL_RISK_MARKER = "may fail at kernel launch"
 # router reads this marker to explain the neutral badge instead of "no GPU".
 DIRECTML_MARKER = "DirectML device present"
 
-# Mirrors ``wizard._MIN_NVIDIA_DRIVER`` — the minimum NVIDIA driver the bundled
-# CUDA 12.8 runtime needs. Duplicated (not imported) to keep this module free of
-# any dependency on the API/router layer.
-_MIN_NVIDIA_DRIVER = 555
+# NOTE: the NVIDIA driver-version check (min R555 for the bundled CUDA runtime)
+# is intentionally NOT done here — it requires shelling to ``nvidia-smi``, which
+# would put a subprocess on the cold-start probe path. That check stays in
+# ``wizard._detect_gpu`` (preflight), which already runs it. The probe only
+# emits the torch-visible SM-arch caveat (cheap, metadata-only).
 
 
 @dataclass(frozen=True)
@@ -95,7 +96,11 @@ def _probe() -> HostCaps:
         )
 
     notes: list[str] = []
-    family: DeviceFamily = "cpu"
+    # Probe EVERY accelerator independently into this list (don't short-circuit
+    # after the first hit) so `available_families` is honest on hybrid hosts
+    # (e.g. an NVIDIA GPU + an Intel iGPU exposed via IPEX). The preferred
+    # `family` is chosen by priority at the end.
+    detected: list[DeviceFamily] = []
     device_name = ""
     vram_gb = 0.0
     driver: str | None = None
@@ -116,7 +121,7 @@ def _probe() -> HostCaps:
             notes.append("CUDA reports available but device_count==0")
         else:
             is_rocm = getattr(torch.version, "hip", None) is not None
-            family = "rocm" if is_rocm else "cuda"
+            detected.append("rocm" if is_rocm else "cuda")
             if is_rocm:
                 driver = getattr(torch.version, "hip", None)
             if count > 1:
@@ -144,51 +149,63 @@ def _probe() -> HostCaps:
                             f"{KERNEL_RISK_MARKER}"
                         )
             except Exception:
+                # Arch metadata unavailable on this torch build — skip the check
+                # (treated as compatible, exactly as check_device_compatibility).
                 pass
 
     # ── Intel XPU via IPEX ───────────────────────────────────────────────
-    if family == "cpu":
-        try:
-            import intel_extension_for_pytorch  # noqa: F401
-            if hasattr(torch, "xpu") and torch.xpu.is_available():
-                family = "xpu"
+    try:
+        import intel_extension_for_pytorch  # noqa: F401
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            detected.append("xpu")
+            if not device_name:
                 try:
                     device_name = torch.xpu.get_device_name(0)
                 except Exception:
+                    # XPU present but unnamed — family classification still holds.
                     pass
-                notes.append("XPU VRAM not queried (unreliable across IPEX versions)")
-        except Exception:
-            pass
+            notes.append("XPU VRAM not queried (unreliable across IPEX versions)")
+    except Exception:
+        # IPEX absent or XPU probe failed — no XPU on this host.
+        pass
 
     # ── Apple Silicon MPS ────────────────────────────────────────────────
-    if family == "cpu":
-        try:
-            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                family = "mps"
-                device_name = device_name or "Apple Silicon (MPS)"
+    try:
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            detected.append("mps")
+            if not device_name:
+                device_name = "Apple Silicon (MPS)"
+            if not vram_gb:
                 try:
                     import psutil
                     vram_gb = float(psutil.virtual_memory().total) / (1024 ** 3) / 2
                 except Exception:
                     notes.append("psutil unavailable; MPS VRAM unknown")
-        except Exception:
-            pass
+    except Exception:
+        # MPS probe raised on a non-Apple/old torch — treat as no MPS.
+        pass
 
     # ── DirectML — Windows GPU, NOT a torch device family ────────────────
-    if family == "cpu":
-        try:
-            import torch_directml
-            if torch_directml.device_count() > 0:
-                notes.append(
-                    f"{DIRECTML_MARKER} (Windows GPU); torch-family probe treats "
-                    f"as non-accelerated"
-                )
-        except Exception:
-            pass
+    try:
+        import torch_directml
+        if torch_directml.device_count() > 0:
+            notes.append(
+                f"{DIRECTML_MARKER} (Windows GPU); torch-family probe treats "
+                f"as non-accelerated"
+            )
+    except Exception:
+        # torch_directml absent (the common case) — no DirectML on this host.
+        pass
 
-    available: tuple[DeviceFamily, ...] = (
-        (family, "cpu") if family != "cpu" else ("cpu",)
-    )
+    # Preferred family by priority; cpu when nothing accelerated was detected.
+    family: DeviceFamily = "cpu"
+    for pref in ("cuda", "rocm", "xpu", "mps"):
+        if pref in detected:
+            family = pref  # type: ignore[assignment]
+            break
+    # available_families: every detected accelerator + cpu, deduped, cpu last.
+    available: tuple[DeviceFamily, ...] = tuple(dict.fromkeys([*detected, "cpu"]))
+
     return HostCaps(
         family=family,
         available_families=available,
@@ -242,6 +259,7 @@ def mlx_supported() -> tuple[bool, str]:
         if torch.backends.mps.is_available():
             return (True, "")
     except Exception:
+        # MPS query raised — fall through to the conservative unavailable path.
         pass
     return (
         False,

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -1,0 +1,261 @@
+"""Canonical host compute-capability probe — the single source of truth for
+"what can this machine actually accelerate on."
+
+Every routing decision (the engine compatibility matrix, ``/setup/preflight``,
+``/system/diagnose``, and the synth-time no-silent-fallback gating) reads from
+``detect_host_caps()`` so the probe and the model loader can never disagree.
+
+Design contract (load-bearing):
+  - **Never raises** to a caller. A broken torch / driver crash degrades to a
+    cached CPU-only ``probe_ok=False`` result; every endpoint stays responsive
+    (local-first: the app must work with no GPU and even with a broken torch).
+  - **No network call** — driver/sysctl reads only, no tensor allocation, so it
+    stays kernel-free on cold start.
+  - **No new regex** on any driver/device string (CodeQL py/polynomial-redos):
+    the only string parse is the ``int(driver.split(".")[0])`` shape reused
+    from the wizard, and arch comparison is plain list membership.
+  - Distinguishes **ROCm from CUDA** (unlike the gguf ``hardware_probe``):
+    ROCm-on-HIP presents through ``torch.cuda`` but is reported ``family="rocm"``.
+
+The ``get_best_device()`` loader (``services.model_manager``) delegates its
+*family* decision here while keeping its own DirectML branch and the ROCm
+``HSA_OVERRIDE_GFX_VERSION`` env side-effect — the probe **reads**, the loader
+**writes**. (The gguf ``hardware_probe.detect_capabilities()`` rebase onto this
+module is a deliberate follow-up: it has its own torch-mocked test suite and a
+VRAM-driven quant table that is unaffected by the family rename, so it is kept
+out of this backend-only slice.)
+"""
+from __future__ import annotations
+
+import functools
+import platform as _platform
+import sys
+from dataclasses import dataclass
+from typing import Literal
+
+DeviceFamily = Literal["cuda", "rocm", "mps", "xpu", "cpu"]
+
+# Stable substring stamped onto notes that represent a real kernel-launch risk
+# (arch/driver mismatch) — as opposed to advisory notes (multi-GPU, VRAM query
+# failed, DirectML present). ``engine_routing`` keys the "accelerated, but…"
+# caveat off this marker so advisory notes never downgrade an accelerated badge.
+KERNEL_RISK_MARKER = "may fail at kernel launch"
+
+# Substring marking a DirectML-present (Windows GPU) host. The probe reports
+# such hosts as ``family="cpu"`` (DirectML is not a torch device family); the
+# router reads this marker to explain the neutral badge instead of "no GPU".
+DIRECTML_MARKER = "DirectML device present"
+
+# Mirrors ``wizard._MIN_NVIDIA_DRIVER`` — the minimum NVIDIA driver the bundled
+# CUDA 12.8 runtime needs. Duplicated (not imported) to keep this module free of
+# any dependency on the API/router layer.
+_MIN_NVIDIA_DRIVER = 555
+
+
+@dataclass(frozen=True)
+class HostCaps:
+    """Snapshot of the host's accelerator capability. Immutable + cached."""
+
+    family: DeviceFamily
+    """Best available accelerator family, else ``"cpu"``."""
+
+    available_families: tuple[DeviceFamily, ...]
+    """Everything usable; **always includes** ``"cpu"`` (invariant)."""
+
+    device_name: str = ""
+    """Device 0's name, e.g. ``"NVIDIA RTX 4090"`` / ``"Apple Silicon (MPS)"``."""
+
+    vram_gb: float = 0.0
+    """CUDA/ROCm total VRAM in GB; MPS = system RAM / 2; 0 for cpu/xpu."""
+
+    driver: str | None = None
+    """Raw ROCm HIP version string (``torch.version.hip``) or ``None``. The
+    NVIDIA driver-version check is owned by ``wizard._detect_gpu`` (it already
+    shells to ``nvidia-smi``); the probe stays subprocess-free."""
+
+    notes: tuple[str, ...] = ()
+    """Author-controlled English advisories (never user input). Empty on a
+    clean accelerated host."""
+
+    probe_ok: bool = True
+    """``False`` only when torch could not be imported (degraded CPU-only)."""
+
+
+def _probe() -> HostCaps:
+    """Run the probe once. Enumerates every failure branch from the spec's
+    degradation contract; never raises."""
+    try:
+        import torch
+    except Exception:
+        return HostCaps(
+            family="cpu",
+            available_families=("cpu",),
+            notes=("torch not importable; treating host as CPU-only",),
+            probe_ok=False,
+        )
+
+    notes: list[str] = []
+    family: DeviceFamily = "cpu"
+    device_name = ""
+    vram_gb = 0.0
+    driver: str | None = None
+
+    # ── CUDA / ROCm (both present through torch.cuda) ────────────────────
+    cuda_ok = False
+    try:
+        cuda_ok = bool(torch.cuda.is_available())
+    except Exception as exc:  # broken CUDA init (forked process / driver crash)
+        notes.append(f"CUDA init raised: {type(exc).__name__}")
+
+    if cuda_ok:
+        try:
+            count = int(torch.cuda.device_count())
+        except Exception:
+            count = 0
+        if count == 0:
+            notes.append("CUDA reports available but device_count==0")
+        else:
+            is_rocm = getattr(torch.version, "hip", None) is not None
+            family = "rocm" if is_rocm else "cuda"
+            if is_rocm:
+                driver = getattr(torch.version, "hip", None)
+            if count > 1:
+                notes.append(f"{count} GPUs detected; routing reflects device 0")
+            try:
+                device_name = torch.cuda.get_device_name(0)
+            except Exception:
+                device_name = ""
+            try:
+                _free, total = torch.cuda.mem_get_info()
+                vram_gb = float(total) / (1024 ** 3)
+            except Exception:
+                notes.append("VRAM query failed")
+            # SM-arch mismatch (mirrors model_manager.check_device_compatibility).
+            try:
+                major, minor = torch.cuda.get_device_capability(0)
+                arch_list = getattr(torch.cuda, "_get_arch_list", lambda: [])()
+                if arch_list:
+                    sm_tag = f"sm_{major}{minor}"
+                    compute_tag = f"compute_{major}{minor}"
+                    if sm_tag not in arch_list and compute_tag not in arch_list:
+                        notes.append(
+                            f"{device_name or 'GPU'} ({sm_tag}) not in this torch "
+                            f"build's archs ({', '.join(arch_list)}) — "
+                            f"{KERNEL_RISK_MARKER}"
+                        )
+            except Exception:
+                pass
+
+    # ── Intel XPU via IPEX ───────────────────────────────────────────────
+    if family == "cpu":
+        try:
+            import intel_extension_for_pytorch  # noqa: F401
+            if hasattr(torch, "xpu") and torch.xpu.is_available():
+                family = "xpu"
+                try:
+                    device_name = torch.xpu.get_device_name(0)
+                except Exception:
+                    pass
+                notes.append("XPU VRAM not queried (unreliable across IPEX versions)")
+        except Exception:
+            pass
+
+    # ── Apple Silicon MPS ────────────────────────────────────────────────
+    if family == "cpu":
+        try:
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+                family = "mps"
+                device_name = device_name or "Apple Silicon (MPS)"
+                try:
+                    import psutil
+                    vram_gb = float(psutil.virtual_memory().total) / (1024 ** 3) / 2
+                except Exception:
+                    notes.append("psutil unavailable; MPS VRAM unknown")
+        except Exception:
+            pass
+
+    # ── DirectML — Windows GPU, NOT a torch device family ────────────────
+    if family == "cpu":
+        try:
+            import torch_directml
+            if torch_directml.device_count() > 0:
+                notes.append(
+                    f"{DIRECTML_MARKER} (Windows GPU); torch-family probe treats "
+                    f"as non-accelerated"
+                )
+        except Exception:
+            pass
+
+    available: tuple[DeviceFamily, ...] = (
+        (family, "cpu") if family != "cpu" else ("cpu",)
+    )
+    return HostCaps(
+        family=family,
+        available_families=available,
+        device_name=device_name,
+        vram_gb=vram_gb,
+        driver=driver,
+        notes=tuple(notes),
+        probe_ok=True,
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def detect_host_caps() -> HostCaps:
+    """Cached per-process host capabilities. Never raises, makes no network
+    call, kernel-free on cold start. Host compute capability does not change at
+    runtime in any supported desktop flow (no GPU hot-plug; switching the active
+    engine does not re-probe — routing is recomputed from these same caps), so
+    a single probe per process is correct. ``probe_ok=False`` is cached too."""
+    return _probe()
+
+
+def refresh() -> HostCaps:
+    """Clear the cache and re-probe. **TEST-ONLY** — nothing in the running app
+    calls this (host caps are immutable per process)."""
+    detect_host_caps.cache_clear()
+    return detect_host_caps()
+
+
+def mlx_supported() -> tuple[bool, str]:
+    """``(ok, reason)``. ``ok=True`` **only** on Apple Silicon
+    (``sys.platform == "darwin"`` and ``platform.machine() == "arm64"``) with
+    torch MPS available — the shared gate for MLX-Audio / MLX-Whisper (#390).
+
+    Gates on exact-string equality (no regex → no CodeQL surface). On any
+    non-Apple host it returns ``False`` **before** any package import, so a
+    stray ``mlx_*`` wheel on Linux/Windows never reports available.
+    """
+    if sys.platform != "darwin" or _platform.machine() != "arm64":
+        if sys.platform == "darwin":
+            return (False, "MLX requires Apple Silicon; this Mac is Intel")
+        return (
+            False,
+            f"MLX requires Apple Silicon; this host is "
+            f"{sys.platform}/{_platform.machine()}",
+        )
+    try:
+        import torch
+    except Exception:
+        return (False, "torch not importable; cannot confirm MPS")
+    try:
+        if torch.backends.mps.is_available():
+            return (True, "")
+    except Exception:
+        pass
+    return (
+        False,
+        "Apple Silicon detected but torch MPS unavailable; "
+        "reinstall torch with MPS support",
+    )
+
+
+__all__ = [
+    "DeviceFamily",
+    "HostCaps",
+    "detect_host_caps",
+    "refresh",
+    "mlx_supported",
+    "KERNEL_RISK_MARKER",
+    "DIRECTML_MARKER",
+]

--- a/backend/services/engine_routing.py
+++ b/backend/services/engine_routing.py
@@ -1,0 +1,105 @@
+"""Pure, host-aware routing resolver — maps an engine's declared ``gpu_compat``
+against the cached host capabilities to "where will this engine *actually* run
+on this machine, and is that a problem the user should hear about?"
+
+No model load, no probe (the caller passes the cached ``HostCaps``), no I/O.
+Deterministic and byte-identical for a given ``(gpu_compat, HostCaps)`` across
+macOS/Windows/Linux — that cross-OS determinism is the whole point of the
+no-silent-fallback contract.
+
+Reason strings are author-controlled English (interpolating only family/device
+names) but are **still** scrubbed by the caller (``core.scrub.scrub_text``)
+before serialization, because an interpolated ``device_name`` or probe note can
+carry a home path.
+"""
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from core.device_caps import (
+    DIRECTML_MARKER,
+    KERNEL_RISK_MARKER,
+    HostCaps,
+)
+
+RoutingStatus = Literal["accelerated", "cpu_fallback", "cpu_only", "unavailable", "n/a"]
+
+
+class RoutingResult(TypedDict):
+    effective_device: str          # a DeviceFamily value or "cpu"
+    routing_status: RoutingStatus  # resolve_routing never emits "n/a" (LLM-only)
+    routing_reason: str | None     # raw, pre-scrub
+
+
+def _caveat(caps: HostCaps) -> str | None:
+    """A kernel-risk caveat string for an otherwise-accelerated host, or None.
+    Advisory notes (multi-GPU, VRAM-query-failed, DirectML) never qualify."""
+    for note in caps.notes:
+        if KERNEL_RISK_MARKER in note:
+            return f"{caps.family.upper()} selected, but: {note}"
+    return None
+
+
+def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResult:
+    """Resolve the effective device + status for an engine on this host.
+
+    Rules are evaluated in order; the first match wins (see spec §2)."""
+    targets = tuple(gpu_compat or ())
+    fam = caps.family
+
+    # 1. Empty compat — reserved for LLM (which never calls this). Defensive.
+    if not targets:
+        return {
+            "effective_device": "cpu",
+            "routing_status": "cpu_only",
+            "routing_reason": "engine declares no compute targets",
+        }
+
+    # 2. Host accelerator is one the engine supports → accelerated.
+    if fam != "cpu" and fam in targets:
+        return {
+            "effective_device": fam,
+            "routing_status": "accelerated",
+            "routing_reason": _caveat(caps),
+        }
+
+    # 3. Host has an accelerator the engine lacks, but engine supports cpu
+    #    → the no-silent-fallback signal.
+    if fam != "cpu" and "cpu" in targets:
+        if fam == "rocm" and "cuda" in targets and "rocm" not in targets:
+            reason = "declares CUDA only; ROCm not in its compat set"
+        else:
+            reason = f"engine has no {fam.upper()} path; running on CPU"
+        return {
+            "effective_device": "cpu",
+            "routing_status": "cpu_fallback",
+            "routing_reason": reason,
+        }
+
+    # 4. Genuine CPU-only host (or DirectML, which the probe reports as cpu)
+    #    and engine supports cpu → benign; must not warn or block.
+    if fam == "cpu" and "cpu" in targets:
+        reason = None
+        for note in caps.notes:
+            if DIRECTML_MARKER in note:
+                reason = (
+                    "DirectML GPU present; engine routes via torch CPU path "
+                    "(DirectML acceleration not wired into routing)"
+                )
+                break
+        return {
+            "effective_device": "cpu",
+            "routing_status": "cpu_only",
+            "routing_reason": reason,
+        }
+
+    # 5. Engine needs an accelerator this host lacks and has no cpu path.
+    first = targets[0]
+    return {
+        "effective_device": first,
+        "routing_status": "unavailable",
+        "routing_reason": f"requires {', '.join(targets)}; this host has {fam}",
+    }
+
+
+__all__ = ["RoutingStatus", "RoutingResult", "resolve_routing"]

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -197,12 +197,23 @@ def get_best_device():
     """Detect the best available compute device.
 
     Priority: CUDA/ROCm > Intel XPU > DirectML > MPS > CPU
-    """
-    torch = _lazy_torch()
 
-    # ── NVIDIA CUDA or AMD ROCm ──────────────────────────────────────
-    # ROCm-enabled PyTorch reports through torch.cuda, so this covers both.
-    if torch.cuda.is_available():
+    The *family* decision delegates to ``core.device_caps.detect_host_caps()``
+    (the single source of truth) so the probe and this loader can never
+    disagree. This function keeps the side-effects the probe deliberately
+    avoids: the ROCm ``HSA_OVERRIDE_GFX_VERSION`` env override and the
+    DirectML device-string return (DirectML is not a torch device family, so
+    the probe reports it as ``cpu`` — we still resolve the real device string
+    here for Windows DirectML users). The string contract is unchanged:
+    ``"cuda"`` / ``"xpu"`` / a DirectML device string / ``"mps"`` / ``"cpu"``.
+    """
+    from core.device_caps import detect_host_caps
+
+    torch = _lazy_torch()
+    family = detect_host_caps().family
+
+    # ── NVIDIA CUDA or AMD ROCm (both present through torch.cuda) ─────
+    if family in ("cuda", "rocm"):
         _configure_rocm_if_needed(torch)
         compatible, warning = check_device_compatibility()
         if not compatible:
@@ -210,15 +221,14 @@ def get_best_device():
         return "cuda"
 
     # ── Intel Arc / discrete GPU via IPEX ────────────────────────────
-    try:
-        import intel_extension_for_pytorch  # noqa: F401
-        if hasattr(torch, "xpu") and torch.xpu.is_available():
+    if family == "xpu":
+        try:
             logger.info("Using Intel XPU device: %s", torch.xpu.get_device_name(0))
-            return "xpu"
-    except ImportError:
-        pass
+        except Exception:
+            logger.info("Using Intel XPU device")
+        return "xpu"
 
-    # ── DirectML — universal Windows GPU (AMD, Intel, NVIDIA fallback)
+    # ── DirectML — universal Windows GPU (probe reports this as "cpu") ─
     try:
         import torch_directml
         if torch_directml.device_count() > 0:
@@ -228,7 +238,7 @@ def get_best_device():
         pass
 
     # ── Apple Silicon MPS ────────────────────────────────────────────
-    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+    if family == "mps":
         return "mps"
 
     return "cpu"

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -228,7 +228,16 @@ def get_best_device():
             logger.info("Using Intel XPU device")
         return "xpu"
 
+    # ── Apple Silicon MPS ────────────────────────────────────────────
+    # Checked BEFORE DirectML to mirror the probe's family-priority order
+    # (cuda > rocm > xpu > mps; DirectML is not a torch family) so the loader
+    # and detect_host_caps() never disagree on a host that somehow exposes both.
+    if family == "mps":
+        return "mps"
+
     # ── DirectML — universal Windows GPU (probe reports this as "cpu") ─
+    # Reached only when no torch family was detected (family == "cpu"), which is
+    # exactly the DirectML case — the probe classifies DirectML hosts as cpu.
     try:
         import torch_directml
         if torch_directml.device_count() > 0:
@@ -236,10 +245,6 @@ def get_best_device():
             return str(torch_directml.device(0))
     except ImportError:
         pass
-
-    # ── Apple Silicon MPS ────────────────────────────────────────────
-    if family == "mps":
-        return "mps"
 
     return "cpu"
 

--- a/tests/test_device_caps.py
+++ b/tests/test_device_caps.py
@@ -1,0 +1,226 @@
+"""Unit tests for backend/core/device_caps.py (GPU compatibility matrix, PR 1).
+
+Every host shape is exercised by mocking ``torch`` (and friends) via
+``sys.modules`` and re-probing with ``device_caps.refresh()`` — the probe imports
+torch lazily inside ``_probe()``, so the override lands. Covers the full §1a
+degradation contract: torch-unimportable, CUDA-init-raises, device_count==0,
+multi-GPU, mem_get_info failure, arch mismatch, ROCm vs CUDA, MPS, XPU, DirectML,
+and the cpu-only baseline + caching.
+"""
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+from core import device_caps
+from core.device_caps import DIRECTML_MARKER, KERNEL_RISK_MARKER
+
+
+def _torch_mock(
+    *,
+    cuda_available=False,
+    cuda_raises=False,
+    device_count=1,
+    hip=None,
+    device_name="NVIDIA RTX 4090",
+    total_vram_bytes=24 * 1024 ** 3,
+    mem_raises=False,
+    capability=(8, 9),
+    arch_list=None,
+    mps_available=False,
+    xpu_available=False,
+):
+    """Build a torch-module mock with a controllable accelerator shape."""
+
+    def _is_available():
+        if cuda_raises:
+            raise RuntimeError("CUDA init blew up")
+        return cuda_available
+
+    def _mem_get_info():
+        if mem_raises:
+            raise RuntimeError("mem_get_info refused")
+        return (total_vram_bytes // 2, total_vram_bytes)
+
+    cuda = types.SimpleNamespace(
+        is_available=_is_available,
+        device_count=lambda: device_count,
+        get_device_name=lambda i: device_name,
+        mem_get_info=_mem_get_info,
+        get_device_capability=lambda i: capability,
+        _get_arch_list=lambda: (arch_list if arch_list is not None else []),
+    )
+    version = types.SimpleNamespace()
+    if hip is not None:
+        version.hip = hip
+    backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: mps_available)
+    )
+    xpu = types.SimpleNamespace(
+        is_available=lambda: xpu_available,
+        get_device_name=lambda i: "Intel Arc A770",
+    )
+    return types.SimpleNamespace(
+        cuda=cuda, version=version, backends=backends, xpu=xpu
+    )
+
+
+def _probe_with(modules):
+    with patch.dict("sys.modules", modules):
+        return device_caps.refresh()
+
+
+def test_torch_unimportable_degrades_to_cpu_probe_not_ok():
+    # A sentinel that raises on import is awkward; instead drop torch from
+    # sys.modules and block re-import via a finder is heavy — simplest is to
+    # map "torch" to something whose attribute access is irrelevant because the
+    # import itself must fail. Use a builtins.__import__ shim.
+    real_import = __import__
+
+    def _blocked(name, *a, **k):
+        if name == "torch":
+            raise ImportError("no torch here")
+        return real_import(name, *a, **k)
+
+    with patch("builtins.__import__", _blocked):
+        caps = device_caps.refresh()
+    assert caps.probe_ok is False
+    assert caps.family == "cpu"
+    assert caps.available_families == ("cpu",)
+    assert any("torch not importable" in n for n in caps.notes)
+
+
+def test_cuda_host_clean():
+    caps = _probe_with({"torch": _torch_mock(cuda_available=True)})
+    assert caps.family == "cuda"
+    assert caps.available_families == ("cuda", "cpu")
+    assert caps.device_name == "NVIDIA RTX 4090"
+    assert round(caps.vram_gb) == 24
+    assert caps.driver is None
+    assert caps.notes == ()
+    assert caps.probe_ok is True
+
+
+def test_rocm_distinguished_from_cuda():
+    caps = _probe_with({"torch": _torch_mock(cuda_available=True, hip="6.1.40091")})
+    assert caps.family == "rocm"
+    assert caps.available_families == ("rocm", "cpu")
+    assert caps.driver == "6.1.40091"
+
+
+def test_cuda_available_but_zero_devices_is_not_cuda():
+    caps = _probe_with({"torch": _torch_mock(cuda_available=True, device_count=0)})
+    assert caps.family == "cpu"
+    assert any("device_count==0" in n for n in caps.notes)
+
+
+def test_cuda_init_raises_is_swallowed_probe_stays_ok():
+    caps = _probe_with({"torch": _torch_mock(cuda_raises=True)})
+    assert caps.family == "cpu"
+    assert caps.probe_ok is True
+    assert any("CUDA init raised" in n for n in caps.notes)
+
+
+def test_mem_get_info_failure_keeps_family_zeroes_vram():
+    caps = _probe_with({"torch": _torch_mock(cuda_available=True, mem_raises=True)})
+    assert caps.family == "cuda"
+    assert caps.vram_gb == 0.0
+    assert any("VRAM query failed" in n for n in caps.notes)
+
+
+def test_arch_mismatch_emits_kernel_risk_note():
+    caps = _probe_with({
+        "torch": _torch_mock(
+            cuda_available=True, capability=(12, 0), arch_list=["sm_80", "sm_89"]
+        )
+    })
+    assert caps.family == "cuda"
+    assert any(KERNEL_RISK_MARKER in n for n in caps.notes)
+
+
+def test_arch_in_build_emits_no_note():
+    caps = _probe_with({
+        "torch": _torch_mock(
+            cuda_available=True, capability=(8, 9), arch_list=["sm_80", "sm_89"]
+        )
+    })
+    assert caps.notes == ()
+
+
+def test_multi_gpu_advisory_note():
+    caps = _probe_with({"torch": _torch_mock(cuda_available=True, device_count=3)})
+    assert caps.family == "cuda"
+    assert any("3 GPUs detected" in n for n in caps.notes)
+    # advisory, not a kernel risk
+    assert not any(KERNEL_RISK_MARKER in n for n in caps.notes)
+
+
+def test_mps_host_uses_half_ram():
+    fake_psutil = types.SimpleNamespace(
+        virtual_memory=lambda: types.SimpleNamespace(total=32 * 1024 ** 3)
+    )
+    caps = _probe_with({
+        "torch": _torch_mock(mps_available=True),
+        "psutil": fake_psutil,
+    })
+    assert caps.family == "mps"
+    assert caps.available_families == ("mps", "cpu")
+    assert round(caps.vram_gb) == 16
+    assert caps.device_name == "Apple Silicon (MPS)"
+
+
+def test_xpu_host():
+    caps = _probe_with({
+        "torch": _torch_mock(xpu_available=True),
+        "intel_extension_for_pytorch": types.SimpleNamespace(),
+    })
+    assert caps.family == "xpu"
+    assert caps.available_families == ("xpu", "cpu")
+    assert caps.vram_gb == 0.0
+
+
+def test_directml_present_reports_cpu_with_marker():
+    caps = _probe_with({
+        "torch": _torch_mock(),
+        "torch_directml": types.SimpleNamespace(
+            device_count=lambda: 1, device=lambda i: "privateuseone:0"
+        ),
+    })
+    assert caps.family == "cpu"
+    assert any(DIRECTML_MARKER in n for n in caps.notes)
+
+
+def test_cpu_only_baseline():
+    caps = _probe_with({"torch": _torch_mock()})
+    assert caps.family == "cpu"
+    assert caps.available_families == ("cpu",)
+    assert caps.notes == ()
+    assert caps.probe_ok is True
+
+
+def test_cpu_always_in_available_families_invariant():
+    for mods in (
+        {"torch": _torch_mock(cuda_available=True)},
+        {"torch": _torch_mock(cuda_available=True, hip="6.1")},
+        {"torch": _torch_mock(mps_available=True),
+         "psutil": types.SimpleNamespace(
+             virtual_memory=lambda: types.SimpleNamespace(total=8 * 1024 ** 3))},
+        {"torch": _torch_mock()},
+    ):
+        caps = _probe_with(mods)
+        assert "cpu" in caps.available_families
+
+
+def test_result_is_cached_until_refresh():
+    first = _probe_with({"torch": _torch_mock(cuda_available=True)})
+    # No refresh → same cached object even though the (now-restored) real torch
+    # would probe differently.
+    again = device_caps.detect_host_caps()
+    assert again is first
+    # refresh re-probes against whatever torch is now live.
+    device_caps.refresh()
+
+
+def teardown_module(_module):
+    # Drop any cached mock-derived result so other test modules re-probe clean.
+    device_caps.detect_host_caps.cache_clear()

--- a/tests/test_device_caps.py
+++ b/tests/test_device_caps.py
@@ -190,6 +190,17 @@ def test_directml_present_reports_cpu_with_marker():
     assert any(DIRECTML_MARKER in n for n in caps.notes)
 
 
+def test_hybrid_cuda_plus_xpu_keeps_both_in_available():
+    # NVIDIA GPU + Intel iGPU via IPEX: family is the priority pick (cuda) but
+    # available_families must not drop the secondary accelerator.
+    caps = _probe_with({
+        "torch": _torch_mock(cuda_available=True, xpu_available=True),
+        "intel_extension_for_pytorch": types.SimpleNamespace(),
+    })
+    assert caps.family == "cuda"
+    assert caps.available_families == ("cuda", "xpu", "cpu")
+
+
 def test_cpu_only_baseline():
     caps = _probe_with({"torch": _torch_mock()})
     assert caps.family == "cpu"

--- a/tests/test_engine_routing.py
+++ b/tests/test_engine_routing.py
@@ -1,0 +1,119 @@
+"""Unit tests for backend/services/engine_routing.py (GPU compat matrix, PR 1).
+
+``resolve_routing`` is a pure function over ``(gpu_compat, HostCaps)`` — these
+tests construct ``HostCaps`` directly (no torch) and assert every rule + edge
+from spec §2, plus the cross-OS determinism + never-emits-"n/a" guarantees.
+"""
+from __future__ import annotations
+
+from core.device_caps import DIRECTML_MARKER, KERNEL_RISK_MARKER, HostCaps
+from services.engine_routing import resolve_routing
+
+
+def _caps(family, *, notes=(), available=None):
+    if available is None:
+        available = (family, "cpu") if family != "cpu" else ("cpu",)
+    return HostCaps(family=family, available_families=available, notes=tuple(notes))
+
+
+# ── Rule 2: accelerated ──────────────────────────────────────────────────
+def test_cuda_host_cuda_engine_accelerated():
+    r = resolve_routing(("cuda", "cpu"), _caps("cuda"))
+    assert r == {"effective_device": "cuda", "routing_status": "accelerated",
+                 "routing_reason": None}
+
+
+def test_mps_host_mps_engine_accelerated():
+    r = resolve_routing(("mps", "cpu"), _caps("mps"))
+    assert r["routing_status"] == "accelerated"
+    assert r["effective_device"] == "mps"
+
+
+def test_accelerated_with_kernel_risk_caveat():
+    note = f"GPU (sm_120) not in this torch build's archs — {KERNEL_RISK_MARKER}"
+    r = resolve_routing(("cuda", "cpu"), _caps("cuda", notes=[note]))
+    assert r["routing_status"] == "accelerated"
+    assert r["routing_reason"] is not None
+    assert r["routing_reason"].startswith("CUDA selected, but:")
+    assert KERNEL_RISK_MARKER in r["routing_reason"]
+
+
+def test_accelerated_ignores_advisory_notes():
+    # Multi-GPU / VRAM advisory notes must NOT downgrade the accelerated badge.
+    r = resolve_routing(("cuda", "cpu"),
+                        _caps("cuda", notes=["3 GPUs detected; routing reflects device 0"]))
+    assert r["routing_status"] == "accelerated"
+    assert r["routing_reason"] is None
+
+
+# ── Rule 3: cpu_fallback (the no-silent-fallback signal) ──────────────────
+def test_cuda_host_cpu_only_engine_falls_back():
+    r = resolve_routing(("cpu",), _caps("cuda"))
+    assert r["routing_status"] == "cpu_fallback"
+    assert r["effective_device"] == "cpu"
+    assert "no CUDA path" in r["routing_reason"]
+
+
+def test_rocm_host_cuda_only_engine_falls_back_with_specific_reason():
+    r = resolve_routing(("cuda", "cpu"), _caps("rocm"))
+    assert r["routing_status"] == "cpu_fallback"
+    assert r["routing_reason"] == "declares CUDA only; ROCm not in its compat set"
+
+
+def test_xpu_host_cpu_engine_falls_back():
+    r = resolve_routing(("cuda", "cpu"), _caps("xpu"))
+    assert r["routing_status"] == "cpu_fallback"
+    assert "no XPU path" in r["routing_reason"]
+
+
+# ── Rule 4: cpu_only (benign) ─────────────────────────────────────────────
+def test_cpu_host_cpu_engine_is_neutral():
+    r = resolve_routing(("cuda", "cpu"), _caps("cpu"))
+    assert r == {"effective_device": "cpu", "routing_status": "cpu_only",
+                 "routing_reason": None}
+
+
+def test_directml_host_gets_explanatory_reason_but_stays_neutral():
+    note = f"{DIRECTML_MARKER} (Windows GPU); torch-family probe treats as non-accelerated"
+    r = resolve_routing(("cuda", "cpu"), _caps("cpu", notes=[note]))
+    assert r["routing_status"] == "cpu_only"   # never blocks
+    assert "DirectML" in r["routing_reason"]
+
+
+# ── Rule 5: unavailable ───────────────────────────────────────────────────
+def test_cpu_host_gpu_only_engine_unavailable():
+    r = resolve_routing(("cuda",), _caps("cpu"))
+    assert r["routing_status"] == "unavailable"
+    assert r["effective_device"] == "cuda"
+    assert "requires cuda" in r["routing_reason"]
+    assert "this host has cpu" in r["routing_reason"]
+
+
+def test_xpu_host_gpu_only_no_cpu_unavailable():
+    r = resolve_routing(("cuda", "mps"), _caps("xpu"))
+    assert r["routing_status"] == "unavailable"
+
+
+# ── Rule 1: defensive empty compat ────────────────────────────────────────
+def test_empty_compat_is_defensive_cpu_only():
+    r = resolve_routing((), _caps("cuda"))
+    assert r["routing_status"] == "cpu_only"
+    assert r["effective_device"] == "cpu"
+
+
+# ── Contract guarantees ───────────────────────────────────────────────────
+def test_never_emits_n_a():
+    for fam in ("cuda", "rocm", "mps", "xpu", "cpu"):
+        for compat in ((), ("cpu",), ("cuda",), ("cuda", "cpu"), ("mps", "cpu")):
+            assert resolve_routing(compat, _caps(fam))["routing_status"] != "n/a"
+
+
+def test_deterministic_across_calls():
+    caps = _caps("rocm")
+    assert resolve_routing(("cuda", "cpu"), caps) == resolve_routing(("cuda", "cpu"), caps)
+
+
+def test_reason_str_for_fallback_and_unavailable_none_for_clean():
+    assert resolve_routing(("cpu",), _caps("cuda"))["routing_reason"] is not None
+    assert resolve_routing(("cuda",), _caps("cpu"))["routing_reason"] is not None
+    assert resolve_routing(("cuda", "cpu"), _caps("cuda"))["routing_reason"] is None

--- a/tests/test_mlx_supported.py
+++ b/tests/test_mlx_supported.py
@@ -1,0 +1,78 @@
+"""Unit tests for core.device_caps.mlx_supported() — the shared MLX platform
+gate (#390). Gates strictly on darwin+arm64+torch-MPS; returns the exact pinned
+(ok, reason) tuples for every host so a stray mlx wheel on Linux/Windows/mac-Intel
+never reports available.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+from core import device_caps
+
+
+def _mps_torch(available):
+    return types.SimpleNamespace(
+        backends=types.SimpleNamespace(
+            mps=types.SimpleNamespace(is_available=lambda: available)
+        )
+    )
+
+
+def test_apple_silicon_with_mps_supported():
+    with patch.object(sys, "platform", "darwin"), \
+         patch("platform.machine", return_value="arm64"), \
+         patch.dict("sys.modules", {"torch": _mps_torch(True)}):
+        ok, reason = device_caps.mlx_supported()
+    assert ok is True
+    assert reason == ""
+
+
+def test_apple_silicon_without_mps():
+    with patch.object(sys, "platform", "darwin"), \
+         patch("platform.machine", return_value="arm64"), \
+         patch.dict("sys.modules", {"torch": _mps_torch(False)}):
+        ok, reason = device_caps.mlx_supported()
+    assert ok is False
+    assert "torch MPS unavailable" in reason
+
+
+def test_mac_intel_rejected():
+    with patch.object(sys, "platform", "darwin"), \
+         patch("platform.machine", return_value="x86_64"):
+        ok, reason = device_caps.mlx_supported()
+    assert ok is False
+    assert reason == "MLX requires Apple Silicon; this Mac is Intel"
+
+
+def test_linux_rejected_before_import():
+    with patch.object(sys, "platform", "linux"), \
+         patch("platform.machine", return_value="x86_64"):
+        ok, reason = device_caps.mlx_supported()
+    assert ok is False
+    assert "this host is linux/x86_64" in reason
+
+
+def test_windows_rejected():
+    with patch.object(sys, "platform", "win32"), \
+         patch("platform.machine", return_value="AMD64"):
+        ok, reason = device_caps.mlx_supported()
+    assert ok is False
+    assert "MLX requires Apple Silicon" in reason
+
+
+def test_apple_silicon_torch_unimportable():
+    real_import = __import__
+
+    def _blocked(name, *a, **k):
+        if name == "torch":
+            raise ImportError("no torch")
+        return real_import(name, *a, **k)
+
+    with patch.object(sys, "platform", "darwin"), \
+         patch("platform.machine", return_value="arm64"), \
+         patch("builtins.__import__", _blocked):
+        ok, reason = device_caps.mlx_supported()
+    assert ok is False
+    assert "torch not importable" in reason

--- a/tests/test_routing_redaction.py
+++ b/tests/test_routing_redaction.py
@@ -1,0 +1,46 @@
+"""Token/path-safety contract for routing reasons (GPU compat matrix, PR 1).
+
+``resolve_routing`` returns raw author strings, but any reason that interpolates
+a ``device_name`` or probe note can carry a home path — so the serialization
+layer scrubs it with ``core.scrub.scrub_text``. These tests pin that a reason
+built from a home-path-bearing note comes out clean after scrubbing, and that a
+``None`` reason must NOT be passed through ``scrub_text`` (which would turn it
+into ``""`` instead of JSON ``null``).
+"""
+from __future__ import annotations
+
+from core.device_caps import KERNEL_RISK_MARKER, HostCaps
+from core.scrub import scrub_text
+from services.engine_routing import resolve_routing
+
+
+def _caps(family, *, notes=()):
+    avail = (family, "cpu") if family != "cpu" else ("cpu",)
+    return HostCaps(family=family, available_families=avail, notes=tuple(notes))
+
+
+def test_home_path_in_caveat_reason_is_scrubbed():
+    note = (f"/home/alice/torch GPU (sm_120) not in this build's archs "
+            f"— {KERNEL_RISK_MARKER}")
+    r = resolve_routing(("cuda", "cpu"), _caps("cuda", notes=[note]))
+    raw = r["routing_reason"]
+    assert "/home/alice" in raw           # pre-scrub carries the path
+    clean = scrub_text(raw)
+    assert "/home/alice" not in clean     # post-scrub it is gone
+    assert "~" in clean
+
+
+def test_none_reason_must_not_become_empty_string():
+    r = resolve_routing(("cuda", "cpu"), _caps("cuda"))
+    assert r["routing_reason"] is None
+    # The serialization rule the wiring must follow: scrub only when truthy,
+    # else preserve JSON null. scrub_text(None) would wrongly yield "".
+    serialized = scrub_text(r["routing_reason"]) if r["routing_reason"] else None
+    assert serialized is None
+    assert scrub_text(None) == ""         # documents why the guard is needed
+
+
+def test_fallback_reason_scrubs_clean_and_nonempty():
+    r = resolve_routing(("cpu",), _caps("cuda"))
+    clean = scrub_text(r["routing_reason"])
+    assert clean and "***REDACTED***" not in clean  # no secret to redact here


### PR DESCRIPTION
**Foundational slice of the GPU compatibility matrix (#21).** Backend-only, no API/UI change — the wiring into `/engines`, preflight/diagnose, synth gating, and the matrix UI lands in PRs 2–5. Each slice is independently green and shippable continuous-to-main.

## What's here
- **`core/device_caps.py`** — the single source of truth for "what can this host accelerate on." `detect_host_caps()`:
  - distinguishes **ROCm from CUDA** (the gguf `hardware_probe` collapses both to `cuda`),
  - **never raises**, makes **no network call**, stays kernel-free on cold start, cached per process (local-first: works with no GPU and even with a broken torch),
  - enumerates the full degradation contract: torch-unimportable → `probe_ok=False`, CUDA-init-raises, `device_count==0`, multi-GPU, `mem_get_info` failure, SM-arch mismatch, MPS, XPU, DirectML.
  - Plus the shared **`mlx_supported()`** gate (#390 groundwork) — exact-string `darwin`+`arm64`+torch-MPS check, **no regex** (CodeQL-clean).
- **`services/engine_routing.py`** — pure `resolve_routing(gpu_compat, caps)` → `{effective_device, routing_status, routing_reason}`. Deterministic and **byte-identical across macOS/Windows/Linux**. Covers `accelerated` / `cpu_fallback` (the no-silent-fallback signal) / `cpu_only` / `unavailable`, incl. the ROCm-not-in-set, DirectML-neutral, and XPU edges.
- **`get_best_device()`** now delegates its *family* decision to the probe so loader and probe can never disagree — while keeping the ROCm `HSA_OVERRIDE_GFX_VERSION` env override and the DirectML device-string return (probe reads, loader writes). String contract unchanged.

## Tests
39 new unit tests (`test_device_caps`, `test_engine_routing`, `test_mlx_supported`, `test_routing_redaction`) — every host shape via torch mocking, every routing rule/edge, the mlx gate's pinned tuples, and the reason→`scrub_text` contract. No tracked test referenced `get_best_device` after the mm2 cleanup, so the delegation breaks nothing. CJK guard green; no new regex.

## Deliberately deferred
The gguf `hardware_probe.detect_capabilities()` rebase: it has its own torch-mocked suite and a VRAM-driven quant table unaffected by the ROCm family rename — kept out of this zero-risk slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## GPU Host Capability Probe & Routing Resolver Foundation

### Overview
Backend-only infrastructure adding a canonical, cached host GPU/accelerator probe and a deterministic routing resolver used by engine selection. No API or UI changes.

### Core Changes

backend/core/device_caps.py (+279 lines)
- New immutable HostCaps dataclass and DeviceFamily literal ("cuda","rocm","mps","xpu","cpu").
- detect_host_caps() (LRU-cached, maxsize=1) is the single source of truth for host accelerator capabilities:
  - Defensive: never raises, no network calls, stays kernel-free on cold start; degrades to CPU probe_ok=False on import/init failures.
  - Distinguishes ROCm from CUDA via torch.version.hip.
  - Detects Apple MPS, Intel XPU, and DirectML (DirectML is annotated with DIRECTML_MARKER but family remains "cpu").
  - Reports available_families (now lists all detected accelerators to support hybrid hosts), device name, best-effort vram_mb, driver/hip string, notes including kernel-risk via KERNEL_RISK_MARKER, and probe_ok flags for multiple degradation modes (torch-unimportable, CUDA init raises, device_count==0, mem_get_info failure, SM-arch mismatch, MPS, XPU, DirectML).
- mlx_supported(): strict gate that returns (True,"") only for darwin+arm64 with torch MPS available; on other platforms returns (False, reason) and avoids importing torch on non-Apple hosts.
- Exposes refresh() (TEST-ONLY) to clear the probe cache.

backend/services/engine_routing.py (+105 lines)
- Adds resolve_routing(gpu_compat: tuple[str,...], caps: HostCaps) → RoutingResult (effective_device, routing_status, routing_reason).
- Deterministic, pure function (no I/O), returns one of: accelerated, cpu_fallback, cpu_only, unavailable. Kernel-risk caveat is attached when the host accelerates but has advisory notes.
- Handles DirectML as CPU-neutral (annotated reason) and covers ROCm-not-in-set and XPU edges.
- Designed to be byte-identical across platforms for same inputs.

backend/services/model_manager.py (+29/-14 lines)
- get_best_device() now delegates family decision to detect_host_caps() while preserving existing ROCm HSA_OVERRIDE_GFX_VERSION behavior and DirectML device-string contract.
- Minor ordering change: MPS checked prior to DirectML to align loader with probe family priority.

### Tests (39 new unit tests)
- tests/test_device_caps.py (237 lines): comprehensive torch-mocking tests for CUDA/ROCm/MPS/XPU/DirectML, degradation paths, kernel-risk notes, hybrid hosts, caching, vram and mem_get_info failures.
- tests/test_engine_routing.py (119 lines): host-caps-driven routing rules, accelerated/fallback/unavailable, kernel-risk caveats, determinism and contract checks.
- tests/test_mlx_supported.py (78 lines): mlx_supported() gating across platforms and torch-import scenarios.
- tests/test_routing_redaction.py (46 lines): routing_reason scrubbing and None-preservation behavior.

### Notable Implementation & Design Notes
- available_families now reports all detected accelerators (no short-circuit) and family is chosen by defined priority at the end to support hybrid hosts.
- All empty except blocks annotated for static analysis clarity.
- Driver-version checks removed from probe path (kept in wizard preflight); no subprocess calls during probe.
- Probe is designed to remain safe on CI/unsupported hosts and to surface advisory notes rather than raising.
- DirectML remains neutral (family="cpu") but is reported with an explanatory marker.
- Kernel-risk notes clearly surfaced when architecture/SM mismatches are detected.
- get_best_device() preserves unchanged external string contracts (including DirectML) and ROCm override behavior.

### Routing Logic (summary)
- If host_device ∈ gpu_compat → accelerated (may include kernel-risk caveat)
- Else if "cpu" ∈ gpu_compat → cpu_fallback (with reason)
- Else if engine is cpu-only or gpu_compat empty → cpu_only (neutral; DirectML hosts include explanatory reason)
- Else → unavailable (gpu-only engine on incompatible host)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->