### PR TITLE
fix(engines): MLX platform gate (#390) + ASR gpu_compat + IndexTTS2 (#21 PR 2/5)

### DIFF
--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -79,6 +79,11 @@ class IndexTTS2Backend(SubprocessBackend):
     display_name = "IndexTTS2 (emotion control, duration control, zero-shot)"
     supports_voice_design = False  # requires ref audio for timbre
     _DEFAULT_SAMPLE_RATE = 24000
+    # Explicit so IndexTTS2 stops advertising the inherited CPU-only default:
+    # the sidecar runs the IndexTTS PyTorch model on CUDA when present, else
+    # CPU. ROCm left unclaimed (the sidecar's own venv would need a ROCm torch);
+    # a ROCm host honestly resolves to cpu_fallback.
+    gpu_compat = ("cuda", "cpu")
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -37,6 +37,15 @@ logger = logging.getLogger("omnivoice.asr")
 class ASRBackend(ABC):
     id: str = "base"
     display_name: str = "Base ASR"
+    # Accelerator families this backend can use, in preference order; always
+    # includes a fallback. Subset of {cuda, rocm, mps, xpu, cpu}. Mirrors the
+    # TTSBackend.gpu_compat contract so engine_routing.resolve_routing() can
+    # surface the effective device per host (no silent CPU fallback). The
+    # conservative default is CPU-only; subclasses declare what they really run
+    # on. (ROCm is intentionally NOT claimed yet for any ASR engine — see the
+    # per-engine notes; an unverified `rocm` claim would route ROCm hosts to a
+    # broken GPU path, strictly worse than the honest `cpu_fallback`.)
+    gpu_compat: tuple[str, ...] = ("cpu",)
 
     @classmethod
     @abstractmethod
@@ -61,6 +70,10 @@ class ASRBackend(ABC):
 class WhisperXBackend(ASRBackend):
     id = "whisperx"
     display_name = "WhisperX (faster-whisper + wav2vec2 forced alignment)"
+    # CTranslate2 backend: CUDA fp16 or CPU int8 (see _pick_device). ROCm not
+    # claimed — CTranslate2 has no upstream HIP build, so a ROCm host honestly
+    # gets cpu_fallback rather than a false GPU promise.
+    gpu_compat = ("cuda", "cpu")
 
     def __init__(self):
         self._model_name = os.environ.get("ASR_MODEL_WHISPERX", "large-v3")
@@ -382,6 +395,8 @@ class WhisperXBackend(ASRBackend):
 class FasterWhisperBackend(ASRBackend):
     id = "faster-whisper"
     display_name = "Faster-Whisper (CTranslate2 — Linux/Windows/macOS)"
+    # CTranslate2: CUDA or CPU (no upstream ROCm/HIP build — see WhisperX note).
+    gpu_compat = ("cuda", "cpu")
 
     def __init__(self):
         # Defaulting to the CTranslate2-converted large-v3 repo. Matches
@@ -497,6 +512,7 @@ _MLX_MODEL_TURBO = "mlx-community/whisper-large-v3-turbo"
 class MLXWhisperBackend(ASRBackend):
     id = "mlx-whisper"
     display_name = "MLX Whisper (Apple Silicon CoreML)"
+    gpu_compat = ("mps", "cpu")
 
     def __init__(self, model_name: str | None = None):
         self._model_name = model_name or os.environ.get(
@@ -505,10 +521,14 @@ class MLXWhisperBackend(ASRBackend):
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:
+        # #390: shared platform gate FIRST — one rule for MLX-Audio + MLX-Whisper.
+        # Returns False on Linux/Windows/mac-Intel before any package import, so
+        # a stray mlx-whisper wheel never reports available or advertises `mps`.
+        from core.device_caps import mlx_supported
+        ok, why = mlx_supported()
+        if not ok:
+            return False, why
         try:
-            import torch
-            if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
-                return False, "Apple Silicon (MPS) not available."
             import mlx_whisper  # noqa: F401
             return True, "ready"
         # Catch OSError/RuntimeError too, not just ImportError: in a
@@ -566,6 +586,9 @@ class MLXWhisperBackend(ASRBackend):
 class PyTorchWhisperBackend(ASRBackend):
     id = "pytorch-whisper"
     display_name = "PyTorch Whisper (CUDA / CPU via transformers pipeline)"
+    # Pure transformers pipeline → runs wherever torch does (CUDA, MPS, CPU).
+    # ROCm-via-HIP would also work but is left unclaimed pending verification.
+    gpu_compat = ("cuda", "mps", "cpu")
 
     def __init__(self, asr_pipe=None):
         # Reuses the `_asr_pipe` attached to the TTS model when available.
@@ -638,6 +661,11 @@ class NeMoASRBackend(ASRBackend):
     Requires NVIDIA GPU.
     """
     id = "nemo-parakeet"
+    # CUDA-only: is_available() hard-fails without a GPU ("Parakeet TDT requires
+    # NVIDIA GPU (CUDA)"), so declaring a CPU path would be a false claim. On a
+    # CPU host this correctly resolves to routing_status="unavailable", matching
+    # is_available()=False (the matrix suppresses the routing badge there).
+    gpu_compat = ("cuda",)
     display_name = "Parakeet TDT (NVIDIA NeMo — English SOTA)"
 
     def __init__(self):
@@ -746,6 +774,7 @@ class MoonshineASRBackend(ASRBackend):
     Great for live capture and CPU-only environments.
     """
     id = "moonshine"
+    gpu_compat = ("cpu",)  # edge/CPU-optimized by design
     display_name = "Moonshine (edge-optimized, ONNX)"
 
     def __init__(self):
@@ -890,6 +919,7 @@ class FunASRBackend(ASRBackend):
     #182); WhisperX remains the cross-platform default.
     """
     id = "funasr"
+    gpu_compat = ("cuda", "cpu")  # FunASR: CUDA or CPU
     display_name = "FunASR (SenseVoice — 50+ languages, all-in-one)"
 
     def __init__(self):

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -593,6 +593,13 @@ class MLXAudioBackend(TTSBackend):
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:
+        # #390: gate on the shared platform check FIRST, before importing the
+        # package. A stray mlx-audio wheel on Linux/Windows/mac-Intel must never
+        # report available (and must never advertise a usable `mps` route).
+        from core.device_caps import mlx_supported
+        ok, why = mlx_supported()
+        if not ok:
+            return False, why
         try:
             import mlx_audio  # noqa: F401
             return True, "ready"

--- a/tests/backend/services/test_mlx_import_guard.py
+++ b/tests/backend/services/test_mlx_import_guard.py
@@ -24,11 +24,10 @@ def _block_import(monkeypatch, name, exc):
                                  RuntimeError("metal device init failed"),
                                  ImportError("No module named mlx_whisper")])
 def test_mlx_whisper_unavailable_not_crash(monkeypatch, exc):
-    import torch
-    if not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
-        # is_available short-circuits on non-MPS before importing mlx; force
-        # the MPS branch so the import guard is what we're exercising.
-        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True, raising=False)
+    # #390: is_available now gates on the shared mlx_supported() platform check
+    # BEFORE importing the package. Force the gate open so this test exercises
+    # the import-guard branch (its actual subject) rather than the platform gate.
+    monkeypatch.setattr("core.device_caps.mlx_supported", lambda: (True, ""))
     from services.asr_backend import MLXWhisperBackend
     _block_import(monkeypatch, "mlx_whisper", exc)
     ok, msg = MLXWhisperBackend.is_available()
@@ -40,8 +39,24 @@ def test_mlx_whisper_unavailable_not_crash(monkeypatch, exc):
                                  RuntimeError("metal init failed"),
                                  ImportError("no mlx_audio")])
 def test_mlx_audio_unavailable_not_crash(monkeypatch, exc):
+    # #390: force the platform gate open (see whisper test above) so the
+    # OSError/RuntimeError import-guard is the code path under test.
+    monkeypatch.setattr("core.device_caps.mlx_supported", lambda: (True, ""))
     from services.tts_backend import MLXAudioBackend
     _block_import(monkeypatch, "mlx_audio", exc)
     ok, msg = MLXAudioBackend.is_available()
     assert ok is False
     assert "mlx-audio" in msg
+
+
+def test_mlx_whisper_unavailable_off_apple_platform(monkeypatch):
+    # The #390 fix itself: on a non-Apple host the platform gate reports
+    # unavailable before any package import (so a stray wheel can't advertise it).
+    monkeypatch.setattr(
+        "core.device_caps.mlx_supported",
+        lambda: (False, "MLX requires Apple Silicon; this host is linux/x86_64"),
+    )
+    from services.asr_backend import MLXWhisperBackend
+    ok, msg = MLXWhisperBackend.is_available()
+    assert ok is False
+    assert "Apple Silicon" in msg

--- a/tests/test_asr_gpu_compat.py
+++ b/tests/test_asr_gpu_compat.py
@@ -1,0 +1,69 @@
+"""ASR backends now carry an explicit ``gpu_compat`` (mirroring TTSBackend) so
+engine_routing can surface the effective device per host. Verifies the ABC
+default and every subclass's declared tuple, plus the IndexTTS2 fix.
+
+Backend classes are resolved at RUNTIME (inside each test, via the registry)
+rather than imported at module scope — other suites purge ``services.*`` from
+``sys.modules`` for DB isolation, which would otherwise leave this module
+holding stale class objects depending on collection/run order.
+"""
+from __future__ import annotations
+
+import pytest
+
+# id → declared gpu_compat. NeMo is CUDA-only (its is_available() hard-fails
+# without a GPU), so it legitimately has no cpu path.
+_EXPECTED = {
+    "whisperx": ("cuda", "cpu"),
+    "faster-whisper": ("cuda", "cpu"),
+    "mlx-whisper": ("mps", "cpu"),
+    "pytorch-whisper": ("cuda", "mps", "cpu"),
+    "nemo-parakeet": ("cuda",),
+    "moonshine": ("cpu",),
+    "funasr": ("cuda", "cpu"),
+}
+
+# Engines that legitimately have NO cpu path (hard GPU gate in is_available).
+_GPU_ONLY = {"nemo-parakeet"}
+
+_VALID = {"cuda", "rocm", "mps", "xpu", "cpu"}
+
+
+def _cls(engine_id):
+    from services.asr_backend import _REGISTRY
+    return _REGISTRY[engine_id]
+
+
+def test_abc_default_is_cpu_only():
+    from services.asr_backend import ASRBackend
+    assert ASRBackend.gpu_compat == ("cpu",)
+
+
+@pytest.mark.parametrize("engine_id,expected", list(_EXPECTED.items()))
+def test_subclass_gpu_compat(engine_id, expected):
+    assert _cls(engine_id).gpu_compat == expected
+
+
+@pytest.mark.parametrize("engine_id", list(_EXPECTED))
+def test_compat_values_are_valid(engine_id):
+    compat = _cls(engine_id).gpu_compat
+    assert compat, "gpu_compat must be non-empty"
+    assert set(compat) <= _VALID
+    # Every engine has a cpu path EXCEPT the known hard-GPU-gated ones.
+    if engine_id not in _GPU_ONLY:
+        assert "cpu" in compat
+    else:
+        assert "cpu" not in compat  # would be a false claim — is_available gates on CUDA
+
+
+def test_no_asr_engine_falsely_claims_rocm():
+    # ROCm is intentionally unclaimed until verified per engine (see ABC note).
+    for engine_id in _EXPECTED:
+        assert "rocm" not in _cls(engine_id).gpu_compat
+
+
+def test_indextts2_overrides_cpu_only_default():
+    from engines.indextts import IndexTTS2Backend
+    assert IndexTTS2Backend.gpu_compat == ("cuda", "cpu")
+    # must NOT be the inherited TTSBackend default
+    assert IndexTTS2Backend.gpu_compat != ("cpu",)

--- a/tests/test_mlx_gate_390.py
+++ b/tests/test_mlx_gate_390.py
@@ -1,0 +1,50 @@
+"""#390 regression: MLX-Audio and MLX-Whisper must report unavailable (and never
+advertise a usable `mps` route) on non-Apple-Silicon hosts, even with the
+package importable. Both backends now route through the shared
+``core.device_caps.mlx_supported()`` gate BEFORE importing the package.
+
+Backend classes are resolved at RUNTIME (other suites purge ``services.*`` from
+``sys.modules``; importing the classes at module scope risks stale references
+depending on test order).
+"""
+from __future__ import annotations
+
+import pytest
+
+_MLX_BACKENDS = [
+    ("services.tts_backend", "MLXAudioBackend"),
+    ("services.asr_backend", "MLXWhisperBackend"),
+]
+
+
+def _resolve(module_path, cls_name):
+    import importlib
+    return getattr(importlib.import_module(module_path), cls_name)
+
+
+@pytest.mark.parametrize("module_path,cls_name", _MLX_BACKENDS)
+def test_gate_blocks_when_mlx_unsupported(module_path, cls_name, monkeypatch):
+    monkeypatch.setattr(
+        "core.device_caps.mlx_supported",
+        lambda: (False, "MLX requires Apple Silicon; this host is linux/x86_64"),
+    )
+    ok, why = _resolve(module_path, cls_name).is_available()
+    assert ok is False
+    assert "Apple Silicon" in why
+
+
+@pytest.mark.parametrize("module_path,cls_name", _MLX_BACKENDS)
+def test_gate_passthrough_when_supported(module_path, cls_name, monkeypatch):
+    # When the platform gate passes, is_available proceeds to the package import.
+    monkeypatch.setattr("core.device_caps.mlx_supported", lambda: (True, ""))
+    ok, why = _resolve(module_path, cls_name).is_available()
+    # Proof the gate didn't short-circuit: control reached the package-import
+    # branch — so it's either genuinely available, or it reports the *package*
+    # error ("… unavailable"), never the platform-gate string.
+    assert ok or "unavailable" in why
+    assert not why.startswith("MLX requires Apple Silicon")
+
+
+@pytest.mark.parametrize("module_path,cls_name", _MLX_BACKENDS)
+def test_mlx_backends_declare_mps_cpu(module_path, cls_name):
+    assert _resolve(module_path, cls_name).gpu_compat == ("mps", "cpu")


### PR DESCRIPTION
**Stacked on #430 (PR 1/5).** Builds on the canonical device probe. Backend-only; the routing keys get wired into `/engines` in PR 3.

> Review note: base is `feat/gpu-compat-probe` (PR 1). GitHub will auto-retarget this to `main` once #430 merges. The diff-of-interest is the top commit.

## Closes #390 — MLX falsely available off Apple Silicon
`MLXAudioBackend` / `MLXWhisperBackend` now call the shared `core.device_caps.mlx_supported()` gate **first**, before importing the package. On Linux/Windows/mac-Intel they report unavailable and **never advertise a usable `mps` route**, even with a stray `mlx_*` wheel installed. The ASR backend's ad-hoc inline MPS check is replaced by the one shared rule. The Wave-4.4 `OSError`/`RuntimeError` import-guard is preserved (it now lives behind the gate; its test forces the gate open so the guard stays the path under test).

## ASR `gpu_compat`
`ASRBackend` ABC gains `gpu_compat: tuple[str,...] = ("cpu",)` mirroring `TTSBackend`, and each subclass declares its real targets:

| engine | gpu_compat |
|---|---|
| whisperx, faster-whisper | `(cuda, cpu)` |
| mlx-whisper | `(mps, cpu)` |
| pytorch-whisper | `(cuda, mps, cpu)` |
| nemo-parakeet, funasr | `(cuda, cpu)` |
| moonshine | `(cpu,)` |

Inert until PR 3 serializes them into `list_backends()`.

## IndexTTS2
Declares `gpu_compat = ("cuda","cpu")` so it stops advertising the inherited CPU-only default.

## Why no ROCm claims yet
ROCm is **deliberately unclaimed** for every ASR engine and IndexTTS2: CTranslate2 has no upstream HIP build, and an unverified `rocm` claim would route ROCm hosts to a **broken GPU path** — strictly worse than the honest `cpu_fallback` the resolver already emits (`"declares CUDA only; ROCm not in its compat set"`). The per-engine TTS ROCm audit is a tracked follow-up that verifies each path before claiming it. A test asserts no ASR engine claims `rocm`.

## Tests
MLX gate regression (both backends, on/off Apple), ASR `gpu_compat` tuples + no-false-rocm invariant, IndexTTS2 override. Existing MLX import-guard test updated for the new gate ordering (same-PR, since the behavior intentionally changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR hardens MLX backend availability checks with a shared platform gate (core.device_caps.mlx_supported()) and adds explicit GPU compatibility metadata for ASR and IndexTTS2 backends. Backend-only change; routing/serialization of gpu_compat is deferred to a subsequent PR.

### Key changes

1. MLX platform gating and import-guard
- MLXWhisperBackend and MLXAudioBackend call core.device_caps.mlx_supported() before importing mlx packages and short-circuit as unavailable on unsupported platforms (Linux/Windows/mac-Intel), preventing a stray mlx wheel from advertising an mps route.
- The existing import-guard for native load failures is preserved and broadened to catch ImportError, OSError, RuntimeError; failures now return unavailable with an explanatory message instead of propagating.
- Tests force the gate open to exercise the import-guard branch.

2. ASR gpu_compat metadata
- ASRBackend (ABC) adds gpu_compat: tuple[str, ...] = ("cpu",) (conservative default).
- Subclasses now declare supported accelerator families:
  - whisperx, faster-whisper: ("cuda", "cpu")
  - mlx-whisper: ("mps", "cpu")
  - pytorch-whisper: ("cuda", "mps", "cpu")
  - nemo-parakeet: ("cuda",)
  - funasr: ("cuda", "cpu")
  - moonshine: ("cpu",)
- ROCm is intentionally not claimed by ASR engines in this PR to avoid routing ROCm hosts to unverified GPU paths.

3. IndexTTS2 override
- IndexTTS2Backend now declares gpu_compat = ("cuda", "cpu") (overrides inherited CPU-only default), indicating the sidecar prefers CUDA when available otherwise CPU.

### Tests added / updated
- tests/test_mlx_gate_390.py — MLX gate regression: both backends, gate on/off, and gpu_compat assertion for MLX backends.
- tests/test_asr_gpu_compat.py — validates ASRBackend.gpu_compat default and subclass declarations, enforces allowed device set, requires cpu fallback except for GPU-only engines, asserts no engine claims rocm, and verifies IndexTTS2 override.
- tests/backend/services/test_mlx_import_guard.py — updated to force the platform gate and verify import-guard behavior covering ImportError/OSError/RuntimeError for both MLX backends.

### MLX backend availability flow (mermaid)

graph TD
  A[is_available() called] --> B{core.device_caps.mlx_supported()}
  B -- not ok --> C[return (False, "MLX requires Apple Silicon...")]
  B -- ok --> D[attempt import mlx_whisper / mlx_audio]
  D -- success --> E[return (True, "ready")]
  D -- ImportError/OSError/RuntimeError --> F[return (False, "<mlx-*-unavailable>: <detail>")]

### Scope
- Backend-only changes; no UI modifications.
- Declarations (gpu_compat) are metadata only in this PR; routing serialization occurs in a later stacked PR.

### Files touched (high-level)
- backend/services/asr_backend.py — ASRBackend.gpu_compat + subclass gpu_compat declarations; MLXWhisperBackend gates on mlx_supported() before imports.
- backend/services/tts_backend.py — MLXAudioBackend gates on mlx_supported() before imports.
- backend/engines/indextts/__init__.py — IndexTTS2Backend.gpu_compat = ("cuda", "cpu").
- tests/test_mlx_gate_390.py — new MLX gate regression tests.
- tests/test_asr_gpu_compat.py — new ASR gpu_compat validation tests.
- tests/backend/services/test_mlx_import_guard.py — updated MLX import-guard tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->