### PR TITLE
feat(routing): wire effective-device into /engines + select gate (#21 PR 3/5)

### DIFF
--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -266,11 +266,20 @@ class SelectEngineRequest(BaseModel):
     backend_id: str
 
 
-@router.post("/engines/select")
+class SelectEngineResponse(BaseModel):
+    family: str
+    active: str
+    env_override: bool
+
+
+@router.post("/engines/select", response_model=SelectEngineResponse)
 def select_engine(req: SelectEngineRequest):
-    """Persist a family's engine pick to prefs.json. Refuses unknown backends
-    + refuses backends whose deps aren't installed (so the UI can't silently
-    brick a pipeline by picking an unavailable engine)."""
+    """Persist a family's engine pick to prefs.json. Refuses unknown backends,
+    backends whose deps aren't installed, AND backends that cannot run on THIS
+    host's hardware (routing_status == "unavailable") — so the UI can't silently
+    brick a pipeline by picking an engine that needs a GPU this machine lacks.
+    A `cpu_fallback` pick is allowed (it runs, just slower) — only a hard
+    `unavailable` is blocked. LLM is never routing-gated (its status is "n/a")."""
     family = _FAMILIES.get(req.family)
     if not family:
         raise HTTPException(400, f"Unknown family: {req.family}. Expected one of tts/asr/llm.")
@@ -278,9 +287,19 @@ def select_engine(req: SelectEngineRequest):
     available = {b["id"]: b for b in module.list_backends()}
     if req.backend_id not in available:
         raise HTTPException(400, f"Unknown {req.family} backend: {req.backend_id!r}")
-    if not available[req.backend_id]["available"]:
-        reason = available[req.backend_id].get("reason") or "unavailable"
+    entry = available[req.backend_id]
+    if not entry["available"]:
+        reason = entry.get("reason") or "unavailable"
         raise HTTPException(400, f"Backend {req.backend_id} not ready: {reason}")
+    # Host-routing gate (no silent CPU fallback). `.get` is defensive so an
+    # older/legacy payload without routing keys still selects cleanly.
+    if entry.get("routing_status") == "unavailable":
+        why = entry.get("routing_reason") or "requires a GPU this host doesn't have"
+        raise HTTPException(
+            400,
+            f"Backend {req.backend_id} can't run on this machine: {why}. "
+            f"Pick an engine with a CPU path, or one that supports this host's GPU.",
+        )
     prefs.set_(pref_key, req.backend_id)
     return {
         "family": req.family,

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -1018,15 +1018,66 @@ _REGISTRY: dict[str, type[ASRBackend]] = _LazyASRRegistry({
 })
 
 
+# Short install hints surfaced as tooltips on the Settings → Engines UI
+# (parity with tts_backend._INSTALL_HINTS).
+_INSTALL_HINTS: dict[str, str] = {
+    "whisperx":        "pip install whisperx  (CTranslate2 + wav2vec2 alignment; CUDA or CPU)",
+    "faster-whisper":  "pip install faster-whisper  (CTranslate2; cross-platform, CUDA or CPU)",
+    "mlx-whisper":     "pip install mlx-whisper  (Apple Silicon only)",
+    "pytorch-whisper": "Bundled with transformers — no extra install (CUDA/MPS/CPU)",
+    "nemo-parakeet":   "pip install nemo_toolkit[asr]  (NVIDIA Parakeet; CUDA or CPU)",
+    "moonshine":       "pip install useful-moonshine  (edge/CPU-optimized ASR)",
+    "funasr":          "pip install funasr  (SenseVoiceSmall + FSMN-VAD; CUDA or CPU)",
+}
+
+# Most-recent failure per backend, so a transient probe error survives between
+# Settings refreshes (parity with tts_backend._LAST_ERRORS).
+_LAST_ERRORS: dict[str, str] = {}
+
+
 def list_backends() -> list[dict]:
-    out = []
+    """Enumerate every ASR backend with the **same 11-key shape as TTS** so the
+    Engine Compatibility Matrix renders all families uniformly.
+
+    Per-entry: id, display_name, available, reason (scrubbed), install_hint,
+    last_error, isolation_mode, gpu_compat, effective_device, routing_status,
+    routing_reason. A backend whose ``is_available()`` raises is reported
+    ``available: false`` (never a 500), exactly like TTS.
+    """
+    from core.device_caps import detect_host_caps
+    from core.scrub import scrub_text
+    from services.engine_routing import routing_fields
+    caps = detect_host_caps()
+
+    out: list[dict] = []
     for bid, cls in _REGISTRY.items():
-        ok, msg = cls.is_available()
+        try:
+            ok, msg = cls.is_available()
+        except Exception as exc:
+            ok = False
+            msg = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "asr list_backends: %s.is_available() raised — degrading "
+                "gracefully so the picker still renders: %s", bid, msg,
+            )
+        if ok:
+            _LAST_ERRORS.pop(bid, None)
+        else:
+            _LAST_ERRORS[bid] = scrub_text(msg)
+        isolation = "subprocess" if getattr(cls, "_is_subprocess_isolated", False) else "in-process"
+        gpu_compat = getattr(cls, "gpu_compat", ("cpu",))
         out.append({
             "id": bid,
             "display_name": cls.display_name,
             "available": ok,
-            "reason": None if ok else msg,
+            # ASR previously emitted `reason` UNMASKED — scrub it now (closes a
+            # pre-existing token-leak gap, matching TTS's redaction guarantee).
+            "reason": None if ok else scrub_text(msg),
+            "install_hint": _INSTALL_HINTS.get(bid),
+            "last_error": _LAST_ERRORS.get(bid),
+            "isolation_mode": isolation,
+            "gpu_compat": list(gpu_compat),
+            **routing_fields(gpu_compat, caps),
         })
     return out
 

--- a/backend/services/engine_routing.py
+++ b/backend/services/engine_routing.py
@@ -102,4 +102,25 @@ def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResul
     }
 
 
-__all__ = ["RoutingStatus", "RoutingResult", "resolve_routing"]
+def routing_fields(gpu_compat: tuple[str, ...], caps: HostCaps) -> dict:
+    """The three serialization-ready routing keys for a ``list_backends`` entry.
+
+    Resolves routing and applies the redaction contract: ``routing_reason`` is
+    scrubbed via ``core.scrub.scrub_text`` only when truthy, so a ``None`` reason
+    serializes as JSON ``null`` (NOT ``""`` — ``scrub_text(None)`` would coerce
+    to ``""``). Used by tts/asr ``list_backends`` so the scrub rule lives in one
+    place. (LLM emits its own literal ``network``/``n/a``/``null`` fields and
+    does NOT call this.)
+    """
+    from core.scrub import scrub_text
+
+    r = resolve_routing(tuple(gpu_compat or ()), caps)
+    reason = r["routing_reason"]
+    return {
+        "effective_device": r["effective_device"],
+        "routing_status": r["routing_status"],
+        "routing_reason": scrub_text(reason) if reason else None,
+    }
+
+
+__all__ = ["RoutingStatus", "RoutingResult", "resolve_routing", "routing_fields"]

--- a/backend/services/llm_backend.py
+++ b/backend/services/llm_backend.py
@@ -37,6 +37,12 @@ logger = logging.getLogger("omnivoice.llm")
 class LLMBackend(ABC):
     id: str = "base"
     display_name: str = "Base LLM"
+    # LLM backends call out over the network (OpenAI/Ollama/LM Studio) or are a
+    # no-op — none run a model on the user's GPU. So `gpu_compat` is empty and
+    # list_backends() labels the family `effective_device:"network"` /
+    # routing_status:"n/a" rather than asserting a false GPU claim. Routing is
+    # never gated for LLM (see engines.select_engine + diagnose).
+    gpu_compat: tuple[str, ...] = ()
 
     @classmethod
     @abstractmethod
@@ -166,15 +172,53 @@ _REGISTRY: dict[str, type[LLMBackend]] = {
 }
 
 
+# Most-recent failure per backend (parity with tts/asr list_backends).
+_LAST_ERRORS: dict[str, str] = {}
+
+_INSTALL_HINTS: dict[str, str] = {
+    "openai-compat": "Set TRANSLATE_BASE_URL (+ TRANSLATE_API_KEY) — OpenAI, "
+                     "Ollama (http://localhost:11434/v1), or any compatible host.",
+}
+
+
 def list_backends() -> list[dict]:
-    out = []
+    """Same 11-key shape as tts/asr so the matrix renders families uniformly.
+
+    LLM is NOT a GPU family: every entry carries literal
+    ``effective_device:"network"`` / ``routing_status:"n/a"`` /
+    ``routing_reason:null`` (NOT via resolve_routing — that would be a false
+    GPU claim). ``effective_device:"network"`` is a label, not a probe: nothing
+    here touches the network (local-first).
+    """
+    from core.scrub import scrub_text
+
+    out: list[dict] = []
     for bid, cls in _REGISTRY.items():
-        ok, msg = cls.is_available()
+        try:
+            ok, msg = cls.is_available()
+        except Exception as exc:
+            ok = False
+            msg = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "llm list_backends: %s.is_available() raised — degrading "
+                "gracefully so the picker still renders: %s", bid, msg,
+            )
+        if ok:
+            _LAST_ERRORS.pop(bid, None)
+        else:
+            _LAST_ERRORS[bid] = scrub_text(msg)
         out.append({
             "id": bid,
             "display_name": cls.display_name,
             "available": ok,
-            "reason": None if ok else msg,
+            "reason": None if ok else scrub_text(msg),
+            "install_hint": _INSTALL_HINTS.get(bid),
+            "last_error": _LAST_ERRORS.get(bid),
+            "isolation_mode": "in-process",
+            "gpu_compat": list(getattr(cls, "gpu_compat", ())),
+            "effective_device": "network",
+            "routing_status": "n/a",
+            "routing_reason": None,
         })
     return out
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1184,7 +1184,10 @@ def list_backends() -> list[dict]:
           "install_hint":   Optional[str],
           "last_error":     Optional[str],          # cached most-recent failure
           "isolation_mode": "in-process" | "subprocess",
-          "gpu_compat":     list[str],              # subset of {cuda, mps, rocm, cpu}
+          "gpu_compat":     list[str],              # subset of {cuda, rocm, mps, xpu, cpu}
+          "effective_device": str,                  # device this engine uses on THIS host
+          "routing_status": "accelerated" | "cpu_fallback" | "cpu_only" | "unavailable",
+          "routing_reason": Optional[str],          # scrubbed; null when none
         }
 
     Guarantees (ENGINE-05): a backend whose `is_available()` raises does
@@ -1204,6 +1207,12 @@ def list_backends() -> list[dict]:
     # class object that no longer == the one this test's subclasses closed
     # over. The marker attribute is set on SubprocessBackend itself, so
     # subclasses inherit it through any re-import path.
+    # Routing is host-aware but the host caps are constant per process, so probe
+    # ONCE here and resolve each engine's effective device against the same caps.
+    from core.device_caps import detect_host_caps
+    from services.engine_routing import routing_fields
+    caps = detect_host_caps()
+
     out: list[dict] = []
     for bid, cls in _REGISTRY.items():
         try:
@@ -1229,6 +1238,7 @@ def list_backends() -> list[dict]:
             isolation = "subprocess"
         else:
             isolation = "in-process"
+        gpu_compat = getattr(cls, "gpu_compat", ("cpu",))
         out.append({
             "id": bid,
             "display_name": cls.display_name,
@@ -1237,7 +1247,9 @@ def list_backends() -> list[dict]:
             "install_hint": _INSTALL_HINTS.get(bid),
             "last_error": _LAST_ERRORS.get(bid),
             "isolation_mode": isolation,
-            "gpu_compat": list(getattr(cls, "gpu_compat", ("cpu",))),
+            "gpu_compat": list(gpu_compat),
+            # effective_device / routing_status / routing_reason (scrubbed):
+            **routing_fields(gpu_compat, caps),
         })
     return out
 

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -75,22 +75,60 @@ def _client(app, host="127.0.0.1"):
 # ── /engines response shape (gpu_compat, isolation_mode, last_error) ──────
 
 
+# The full 11-key shape every family now shares (TTS + ASR + LLM parity).
+_REQUIRED_KEYS = {
+    "id", "display_name", "available", "reason",
+    "install_hint", "last_error", "isolation_mode", "gpu_compat",
+    "effective_device", "routing_status", "routing_reason",
+}
+_TTS_ASR_STATUSES = {"accelerated", "cpu_fallback", "cpu_only", "unavailable"}
+_VALID_FAMILIES = {"cuda", "rocm", "mps", "xpu", "cpu"}
+
+
 def test_engines_response_includes_new_fields(fresh_app):
     client = _client(fresh_app)
     r = client.get("/engines")
     assert r.status_code == 200
     body = r.json()
 
-    required = {
-        "id", "display_name", "available", "reason",
-        "install_hint", "last_error", "isolation_mode", "gpu_compat",
-    }
     for entry in body["tts"]["backends"]:
-        missing = required - entry.keys()
+        missing = _REQUIRED_KEYS - entry.keys()
         assert not missing, f"entry {entry.get('id')!r} missing keys: {missing}"
         assert isinstance(entry["gpu_compat"], list)
         assert all(isinstance(x, str) for x in entry["gpu_compat"])
         assert entry["isolation_mode"] in {"in-process", "subprocess"}
+
+
+def test_all_families_share_the_11_key_shape(fresh_app):
+    client = _client(fresh_app)
+    body = client.get("/engines").json()
+    for fam in ("tts", "asr", "llm"):
+        for entry in body[fam]["backends"]:
+            missing = _REQUIRED_KEYS - entry.keys()
+            assert not missing, f"{fam} entry {entry.get('id')!r} missing: {missing}"
+
+
+def test_tts_asr_routing_keys_are_well_formed(fresh_app):
+    client = _client(fresh_app)
+    body = client.get("/engines").json()
+    for fam in ("tts", "asr"):
+        for entry in body[fam]["backends"]:
+            assert entry["routing_status"] in _TTS_ASR_STATUSES
+            assert entry["effective_device"] in _VALID_FAMILIES
+            # routing_reason is a scrubbed str or JSON null — never the empty
+            # string (the None-vs-"" serialization contract).
+            assert entry["routing_reason"] is None or isinstance(entry["routing_reason"], str)
+            assert entry["routing_reason"] != ""
+
+
+def test_llm_entries_are_network_n_a(fresh_app):
+    client = _client(fresh_app)
+    body = client.get("/engines").json()
+    for entry in body["llm"]["backends"]:
+        assert entry["effective_device"] == "network"
+        assert entry["routing_status"] == "n/a"
+        assert entry["routing_reason"] is None
+        assert entry["gpu_compat"] == []
 
 
 def test_indextts2_entry_has_subprocess_isolation_mode(fresh_app):
@@ -118,6 +156,84 @@ def test_gpu_compat_omnivoice_has_cuda_mps_cpu(fresh_app):
     r = client.get("/engines")
     by_id = {b["id"]: b for b in r.json()["tts"]["backends"]}
     assert set(by_id["omnivoice"]["gpu_compat"]) == {"cuda", "mps", "cpu"}
+
+
+# ── select_engine host-routing gate (no silent CPU fallback) ────────────────
+
+
+def _force_cpu_host(monkeypatch):
+    """Pin detect_host_caps() to a CPU-only host so routing is deterministic
+    regardless of the CI runner's actual hardware."""
+    from core.device_caps import HostCaps
+    cpu = HostCaps(family="cpu", available_families=("cpu",))
+    monkeypatch.setattr("core.device_caps.detect_host_caps", lambda: cpu)
+
+
+def test_select_blocks_engine_unavailable_on_this_host(fresh_app, monkeypatch):
+    """A CUDA-only engine (no cpu path) on a CPU host is `unavailable` → 400."""
+    from services import tts_backend as tts_mod
+
+    class CudaOnlyBackend(tts_mod.TTSBackend):
+        id = "cuda-only-test"
+        display_name = "CUDA-only (test)"
+        gpu_compat = ("cuda",)  # no cpu fallback
+
+        @property
+        def sample_rate(self): return 24000
+        @property
+        def supported_languages(self): return ["en"]
+        @classmethod
+        def is_available(cls): return True, "ready"   # deps fine; host is the problem
+        def generate(self, text, **kw): raise NotImplementedError
+
+    _force_cpu_host(monkeypatch)
+    saved = dict(tts_mod._REGISTRY)
+    try:
+        tts_mod._REGISTRY["cuda-only-test"] = CudaOnlyBackend
+        r = _client(fresh_app).post(
+            "/engines/select", json={"family": "tts", "backend_id": "cuda-only-test"})
+        assert r.status_code == 400
+        assert "can't run on this machine" in r.json()["detail"]
+    finally:
+        tts_mod._REGISTRY.clear(); tts_mod._REGISTRY.update(saved)
+
+
+def test_select_allows_cpu_fallback_engine(fresh_app, monkeypatch):
+    """A CUDA+CPU engine on a CPU host is `cpu_fallback` (runs, slower) → allowed."""
+    from services import tts_backend as tts_mod
+
+    class CpuCapableBackend(tts_mod.TTSBackend):
+        id = "cpu-ok-test"
+        display_name = "CPU-capable (test)"
+        gpu_compat = ("cuda", "cpu")
+
+        @property
+        def sample_rate(self): return 24000
+        @property
+        def supported_languages(self): return ["en"]
+        @classmethod
+        def is_available(cls): return True, "ready"
+        def generate(self, text, **kw): raise NotImplementedError
+
+    _force_cpu_host(monkeypatch)
+    saved = dict(tts_mod._REGISTRY)
+    try:
+        tts_mod._REGISTRY["cpu-ok-test"] = CpuCapableBackend
+        r = _client(fresh_app).post(
+            "/engines/select", json={"family": "tts", "backend_id": "cpu-ok-test"})
+        assert r.status_code == 200, r.text
+        assert r.json()["active"] == "cpu-ok-test"
+    finally:
+        tts_mod._REGISTRY.clear(); tts_mod._REGISTRY.update(saved)
+
+
+def test_select_llm_never_routing_gated(fresh_app, monkeypatch):
+    """LLM entries are routing_status 'n/a' — the host gate must never fire."""
+    _force_cpu_host(monkeypatch)
+    # 'off' is always available and has no GPU claim.
+    r = _client(fresh_app).post(
+        "/engines/select", json={"family": "llm", "backend_id": "off"})
+    assert r.status_code == 200, r.text
 
 
 # ── /engines/{id}/health round-trip ────────────────────────────────────────

--- a/tests/backend/services/test_tts_backend_registry.py
+++ b/tests/backend/services/test_tts_backend_registry.py
@@ -144,10 +144,13 @@ def test_list_backends_shape(registry_sandbox):
     """Every entry must contain exactly the documented keys — no more, no less."""
     out = list_backends()
     # `gpu_compat` joined the documented shape in Plan 02-04 alongside the
-    # Engine Compatibility Matrix UI (ENGINE-06).
+    # Engine Compatibility Matrix UI (ENGINE-06). The three routing keys
+    # (effective_device / routing_status / routing_reason) joined in #21 so the
+    # matrix can show the device each engine actually uses on THIS host.
     required = {
         "id", "display_name", "available", "reason",
         "install_hint", "last_error", "isolation_mode", "gpu_compat",
+        "effective_device", "routing_status", "routing_reason",
     }
     for entry in out:
         assert set(entry.keys()) == required, (

--- a/tests/test_no_hardcoded_cjk.py
+++ b/tests/test_no_hardcoded_cjk.py
@@ -37,7 +37,11 @@ _SKIP_EXT = {
 }
 
 # The translation layer: locale JSON + native language names (LANGUAGES).
-_ALLOWED_PREFIXES = ("frontend/src/i18n/",)
+# Plus design-spec docs under docs/specs/, which legitimately quote functional
+# CJK (test-fixture descriptions, model/engine identifiers like CosyVoice
+# speaker IDs, multilingual sample text) — they are documentation, not shipped
+# UI strings, so they belong on the same footing as the allowlisted docs below.
+_ALLOWED_PREFIXES = ("frontend/src/i18n/", "docs/specs/")
 
 # Functional / data / documentation files where CJK is intentional and required.
 _ALLOWED_FILES = {


### PR DESCRIPTION
**Stacked on #431 (→ #430).** Surfaces the PR-1 probe/resolver through the engine registries so the matrix UI (PR 5) and the no-silent-fallback gates can consume it. GitHub will auto-retarget to `main` as the stack merges.

## `/engines` now reports the effective device per host
- **`engine_routing.routing_fields()`** — shared helper for the 3 serialization-ready keys, centralizing the scrub rule: `routing_reason` runs through `core.scrub.scrub_text` **only when truthy**, so a `None` reason stays JSON `null` (never coerced to `""`).
- **TTS/ASR `list_backends()`** gain `effective_device` / `routing_status` / `routing_reason`, computed from a **single** `detect_host_caps()` call per request. **ASR is brought to full TTS parity** — it now also carries `install_hint` / `last_error` / `isolation_mode` and a **scrubbed `reason`** (closing a pre-existing ASR token-leak gap), and gains the same `is_available()`-raises resilience (degrade to `available:false`, never 500). Identical **11-key shape** across families.
- **LLM `list_backends()`** reaches 11-key parity but emits literal `effective_device:"network"` / `routing_status:"n/a"` / `routing_reason:null` (NOT via `resolve_routing` — LLM runs no local GPU model). `"network"` is a label, not a probe — nothing here touches the network (local-first).

## `select_engine` host-routing gate
Refuses a pick whose `routing_status == "unavailable"` on this host (400, actionable detail), while **allowing `cpu_fallback`** (it runs, just slower). LLM is never gated. Defensive `.get` so legacy payloads still select. New typed `SelectEngineResponse`.

## Tests
11-key shape across all 3 families; well-formed tts/asr routing keys (+ the None-not-`""` contract); LLM network/n/a labels; select gate (block `unavailable` / allow `cpu_fallback` / never-gate LLM). Updated the registry exact-shape test for the 3 new keys. The existing HF-token-leak test still passes (TTS `reason` keeps `_mask_hf_tokens`; only `routing_reason` uses `scrub_text`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR wires effective-device routing information into engine listing and selection so the Settings matrix UI and the select gate can surface and enforce host-hardware routing constraints.

### Core Changes

- backend/services/engine_routing.py
  - Added routing_fields(gpu_compat, caps) which calls resolve_routing(...) and applies the redaction contract: routing_reason is scrubbed via core.scrub.scrub_text only when truthy so None remains JSON null.
  - Exported routing_fields in __all__.

- backend/services/tts_backend.py, asr_backend.py, llm_backend.py
  - list_backends() now produces a standardized 11-key entry shape for TTS/ASR/LLM:
    - id, display_name, available, reason, install_hint, last_error, isolation_mode, gpu_compat, effective_device, routing_status, routing_reason
  - TTS/ASR call detect_host_caps() once per request and compute routing_fields(gpu_compat, caps) per entry.
  - ASR brought to parity with TTS (adds install_hint, last_error, isolation_mode) and now scrubs reasons via scrub_text (closes prior ASR token-leak gap).
  - LLM list emits literal labels: effective_device:"network", routing_status:"n/a", routing_reason:null (no probe/network calls).
  - Per-backend is_available() exceptions are handled gracefully: backends degrade to available:false with scrubbed last_error and routing_status:"unavailable" instead of raising 500. Modules maintain _LAST_ERRORS caches.

- backend/api/routers/engines.py
  - Added SelectEngineResponse(BaseModel) and annotated POST /engines/select with response_model.
  - Selection logic now enforces a host-routing gate: if the chosen backend row has routing_status == "unavailable" the endpoint returns HTTP 400 with an actionable message; cpu_fallback is allowed; LLM family (routing_status "n/a") is never gated. Uses defensive entry.get("routing_status", "cpu_only") to support legacy payloads.

### Behavior / API Effects

- All three families present an identical 11-key shape (TTS/ASR compute routing per host; LLM labeled network-only).
- routing_reason is always either a non-empty scrubbed string or JSON null (never empty string), preserving the scrub_text(None) → "" contract by guarding: scrub_text(reason) if reason else None.
- No new network calls; detect_host_caps() is local-only and called once per list_backends() invocation.
- Selection: attempting to select an engine that is routing-unavailable on the host returns 400 with an explanatory routing_reason; selecting cpu_fallback is permitted. LLM selections skip the gate.

### Tests

- Expanded tests assert the 11-key shape across tts/asr/llm, scrubbing/null contract for routing_reason, LLM network/n/a/null labels, and _LAST_ERRORS handling.
- New tests for /engines/select verify host-routing gate behavior: CUDA-only engine blocked (HTTP 400) on forced-CPU host; CUDA+CPU engine allowed (HTTP 200); LLM selection never gated.
- Existing HF-token-leak test remains passing; new routing redaction tests ensure token/path/secret redaction.

### Small UI sketch (engine matrix before → after)

Before:
[GPU chips]  Engine Name         Available
[cuda][mps][cpu]  OmniVoice         ✓

After:
[GPU chips]  Engine Name         Available  Effective  Status
[cuda][mps][cpu]  OmniVoice         ✓         [cuda]     accelerated
[network]         OpenAI-Compat     off       [network]  n/a

(The UI highlights the effective_device chip and shows a small status badge with title=routing_reason.)

### Selection Flow (new host-routing gate)

mermaid
graph TD
  A[POST /engines/select] --> B[Validate family & backend_id exist]
  B --> C[Fetch backend row from list_backends()]
  C --> D{available == true?}
  D -- no --> E[400 existing "not ready" message]
  D -- yes --> F{routing_status == "unavailable"?}
  F -- yes --> G[400 "cannot run on this host: <routing_reason>"]
  F -- no --> H[Persist active backend, return SelectEngineResponse (200)]
<!-- end of auto-generated comment: release notes by coderabbit.ai -->