### PR TITLE
feat(routing): active-engine GPU verdict in preflight + diagnose (#21 PR 4/5)

### DIFF
--- a/backend/api/routers/setup/wizard.py
+++ b/backend/api/routers/setup/wizard.py
@@ -373,6 +373,46 @@ def preflight():
         "status": gpu_status, "detail": gpu_detail, "fix": gpu_fix,
     })
 
+    # ── GPU routing for the ACTIVE TTS engine (#21 — no silent CPU fallback).
+    # Distinct from the hardware "gpu" check above: this asks "will the engine
+    # the user actually selected use that GPU on this host?" Built from the same
+    # canonical probe + resolver the Engine Compatibility Matrix uses.
+    try:
+        from services.tts_backend import gpu_routing_verdict
+        gpu_routing = gpu_routing_verdict()
+    except Exception as exc:  # never break preflight on a routing hiccup
+        logger.warning("preflight gpu_routing failed: %s", exc)
+        gpu_routing = None
+    if gpu_routing:
+        _rs = gpu_routing.get("routing_status")
+        _eng = gpu_routing.get("engine") or "active engine"
+        _dev = gpu_routing.get("effective_device") or "?"
+        _why = gpu_routing.get("routing_reason")
+        if _rs == "accelerated" and not _why:
+            r_status, r_detail, r_fix = "pass", f"{_eng} → {_dev} (accelerated)", None
+        elif _rs == "accelerated":  # driver/arch caveat
+            r_status, r_detail, r_fix = "warn", f"{_eng} → {_dev}: {_why}", (
+                "GPU selected but may fail at kernel launch — update drivers / "
+                "reinstall torch for this GPU architecture.")
+        elif _rs == "cpu_fallback":
+            r_status, r_detail, r_fix = "warn", (
+                f"{_eng} runs on CPU here: {_why or 'no GPU path for this host'}"), (
+                "Pick an engine that supports this host's GPU for a speedup, or "
+                "continue on CPU (slower).")
+        elif _rs == "cpu_only":
+            r_status, r_detail, r_fix = "pass", f"{_eng} → cpu (no accelerator on this host)", None
+        elif _rs == "unavailable":
+            r_status, r_detail, r_fix = "fail", (
+                f"{_eng} can't run on this host: {_why or 'needs a GPU this machine lacks'}"), (
+                "Select an engine with a CPU path in Settings → Engines.")
+        else:  # "none" / unknown
+            r_status, r_detail, r_fix = "warn", "No active TTS engine resolved for routing.", (
+                "Pick an engine in Settings → Engines.")
+        checks.append({
+            "id": "gpu_routing", "label": "Active engine routing",
+            "status": r_status, "detail": r_detail, "fix": r_fix,
+        })
+
     # ── Network
     net_ok = _probe_network()
     checks.append({
@@ -400,9 +440,13 @@ def preflight():
             "gpu_available": gpu["available"],
             "gpu_driver": gpu["driver"],
             "gpu_device_name": gpu["device_name"],
+            # Canonical probe (distinguishes ROCm from CUDA):
+            "gpu_family": (gpu_routing or {}).get("host_family", "cpu"),
+            "vram_gb": (gpu_routing or {}).get("vram_gb", 0.0),
             "ram_gb": round(ram, 1),
             "disk_free_gb": round(free, 1),
         },
+        "gpu_routing": gpu_routing,
     }
 
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -129,8 +129,30 @@ class DeviceInfo(BaseModel):
     gpu_available: bool = False
     gpu_driver: str | None = None
     gpu_device_name: str | None = None
+    # From the canonical device probe (core.device_caps) — distinguishes ROCm
+    # from CUDA, unlike the legacy nvidia-smi-based gpu_vendor/gpu_backend.
+    gpu_family: str = "cpu"
+    vram_gb: float = 0.0
     ram_gb: float = 0.0
     disk_free_gb: float = 0.0
+
+
+class GpuRouting(BaseModel):
+    """Routing verdict for the active TTS engine on THIS host (#21).
+
+    Distinct from the per-engine `routing_*` keys in `/engines`: this is the
+    single verdict for the *currently-selected* engine, surfaced in preflight +
+    diagnose so the user hears about a CPU fallback / unavailable GPU before a
+    slow or failed synth — no silent CPU fallback.
+    """
+    model_config = ConfigDict(extra="allow")
+
+    engine: str | None = None            # active TTS engine id
+    effective_device: str | None = None  # device it will actually use here
+    routing_status: str | None = None    # accelerated|cpu_fallback|cpu_only|unavailable|none
+    routing_reason: str | None = None    # scrubbed; null when none
+    host_family: str = "cpu"             # detect_host_caps().family
+    vram_gb: float = 0.0
 
 
 class PreflightResponse(BaseModel):
@@ -139,6 +161,9 @@ class PreflightResponse(BaseModel):
     has_warnings: bool = False
     checks: list[PreflightCheck] = Field(default_factory=list)
     device: DeviceInfo
+    # Explicit field (PreflightResponse has no extra="allow") so the verdict
+    # survives serialization instead of being silently dropped.
+    gpu_routing: GpuRouting | None = None
 
 
 class InstallModelRequest(BaseModel):

--- a/backend/core/diagnose.py
+++ b/backend/core/diagnose.py
@@ -4,7 +4,7 @@ One pass over everything a working install needs: Python, compute device,
 ffmpeg, HF token, disk, data-dir permissions, RAM, TTS engines, and (when
 requested) network reachability of the HuggingFace hub. Surfaced two ways:
 
-  - ``GET /system/diagnose`` (Settings > About → "Run self-check")
+  - ``GET /system/diagnose`` (Settings > About -> "Run self-check")
   - ``python main.py --diagnose`` for headless installs / issue triage
 
 Every ``detail``/``hint`` string is passed through ``core.scrub`` before it
@@ -194,6 +194,49 @@ def _check_engines() -> dict:
     return _check("engines", "TTS engines", OK, detail)
 
 
+def _check_gpu_routing() -> dict:
+    """Routing verdict for the active TTS engine on THIS host (#21).
+
+    Surfaces a CPU fallback / unavailable-GPU *before* a slow or failed synth —
+    the no-silent-fallback contract. `cpu_only` on a no-GPU machine is the
+    expected normal state and stays OK (never noise-warns)."""
+    try:
+        from services.tts_backend import gpu_routing_verdict
+        v = gpu_routing_verdict()
+    except Exception as e:
+        return _check("gpu_routing", "GPU routing", WARN, f"could not resolve: {e}")
+
+    status = v.get("routing_status")
+    engine = v.get("engine") or "active engine"
+    dev = v.get("effective_device") or "?"
+    reason = v.get("routing_reason")
+    host = v.get("host_family", "cpu")
+
+    if status == "accelerated":
+        if reason:  # driver/arch caveat — accelerated but at risk
+            return _check("gpu_routing", "GPU routing", WARN,
+                          f"{engine} -> {dev}: {reason}",
+                          "The GPU is selected but may fail at kernel launch — "
+                          "update drivers / reinstall torch for this GPU arch.")
+        return _check("gpu_routing", "GPU routing", OK, f"{engine} -> {dev} (accelerated)")
+    if status == "cpu_fallback":
+        return _check("gpu_routing", "GPU routing", WARN,
+                      f"{engine} runs on CPU: {reason or 'no GPU path for this host'}",
+                      "Pick an engine that supports this host's GPU for a big speedup, "
+                      "or continue on CPU (slower).")
+    if status == "cpu_only":
+        return _check("gpu_routing", "GPU routing", OK,
+                      f"{engine} -> cpu (no accelerator on this host)")
+    if status == "unavailable":
+        return _check("gpu_routing", "GPU routing", FAIL,
+                      f"{engine} can't run on this host: {reason or f'needs a GPU; host is {host}'}",
+                      "Select an engine with a CPU path in Settings -> Engines.")
+    # status == "none" / unknown — no active engine resolved.
+    return _check("gpu_routing", "GPU routing", WARN,
+                  "No active TTS engine resolved for routing.",
+                  "Pick an engine in Settings -> Engines.")
+
+
 _DEEP_TIMEOUT_S = 180
 
 
@@ -298,6 +341,7 @@ def run_diagnostics(include_network: bool = True, deep: bool = False) -> dict:
         _check_data_dir(),
         _check_ram(),
         _check_engines(),
+        _check_gpu_routing(),
     ]
     if include_network:
         checks.append(_check_network())

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1260,6 +1260,60 @@ def get_backend_class(backend_id: str) -> type[TTSBackend]:
     return _REGISTRY[backend_id]
 
 
+def active_routing() -> dict | None:
+    """Routing verdict for the currently-active TTS engine, or ``None`` if it
+    can't be determined (no engine / probe failure).
+
+    Derived from :func:`list_backends` so the verdict is byte-identical to what
+    the Engine Compatibility Matrix shows for the same engine. Consumed by
+    ``/setup/preflight`` and ``/system/diagnose`` to surface a GPU-routing
+    verdict for the active engine (no silent CPU fallback). Never raises.
+    """
+    try:
+        active = active_backend_id()
+        for b in list_backends():
+            if b.get("id") == active:
+                return {
+                    "engine": active,
+                    "available": b.get("available"),
+                    "effective_device": b.get("effective_device"),
+                    "routing_status": b.get("routing_status"),
+                    "routing_reason": b.get("routing_reason"),
+                }
+    except Exception:
+        # Routing is advisory — never let a probe/registry hiccup break the
+        # caller (preflight/diagnose must stay responsive — local-first).
+        return None
+    return None
+
+
+def gpu_routing_verdict() -> dict:
+    """The GpuRouting payload (see api.schemas.GpuRouting) for the active TTS
+    engine + this host's compute summary. Used by ``/setup/preflight`` and
+    ``/system/diagnose``. Never raises — degrades to a host-only verdict with
+    ``routing_status:"none"`` if the active engine can't be resolved."""
+    from core.device_caps import detect_host_caps
+    try:
+        caps = detect_host_caps()
+        host_family, vram_gb = caps.family, round(caps.vram_gb, 1)
+    except Exception:
+        host_family, vram_gb = "cpu", 0.0
+    r = active_routing()
+    if not r:
+        return {
+            "engine": None, "effective_device": None,
+            "routing_status": "none", "routing_reason": None,
+            "host_family": host_family, "vram_gb": vram_gb,
+        }
+    return {
+        "engine": r.get("engine"),
+        "effective_device": r.get("effective_device"),
+        "routing_status": r.get("routing_status"),
+        "routing_reason": r.get("routing_reason"),
+        "host_family": host_family, "vram_gb": vram_gb,
+    }
+
+
 def active_backend_id() -> str:
     # Env var > persisted UI choice > default. Env wins so power-users can
     # pin a backend without the Settings picker silently undoing it.

--- a/tests/test_gpu_routing_verdict.py
+++ b/tests/test_gpu_routing_verdict.py
@@ -1,0 +1,86 @@
+"""Active-engine GPU routing verdict (#21 PR 4) — the no-silent-fallback
+surface for preflight + diagnose.
+
+Covers `tts_backend.gpu_routing_verdict()` (built from active_routing + the host
+probe) and `diagnose._check_gpu_routing()`'s status mapping. Both are exercised
+with mocks so no torch / full app import is needed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.device_caps import HostCaps
+from core.diagnose import OK, WARN, FAIL
+
+
+# ── gpu_routing_verdict ─────────────────────────────────────────────────────
+
+def test_verdict_uses_active_routing_and_host(monkeypatch):
+    from services import tts_backend as tb
+    monkeypatch.setattr(tb, "active_routing", lambda: {
+        "engine": "omnivoice", "available": True,
+        "effective_device": "cpu", "routing_status": "cpu_fallback",
+        "routing_reason": "engine has no CUDA path; running on CPU",
+    })
+    monkeypatch.setattr(
+        "core.device_caps.detect_host_caps",
+        lambda: HostCaps(family="cuda", available_families=("cuda", "cpu"), vram_gb=24.0),
+    )
+    v = tb.gpu_routing_verdict()
+    assert v["engine"] == "omnivoice"
+    assert v["routing_status"] == "cpu_fallback"
+    assert v["host_family"] == "cuda"
+    assert v["vram_gb"] == 24.0
+
+
+def test_verdict_degrades_when_no_active_engine(monkeypatch):
+    from services import tts_backend as tb
+    monkeypatch.setattr(tb, "active_routing", lambda: None)
+    monkeypatch.setattr(
+        "core.device_caps.detect_host_caps",
+        lambda: HostCaps(family="cpu", available_families=("cpu",)),
+    )
+    v = tb.gpu_routing_verdict()
+    assert v["engine"] is None
+    assert v["routing_status"] == "none"
+    assert v["host_family"] == "cpu"
+
+
+# ── diagnose._check_gpu_routing status mapping ──────────────────────────────
+
+@pytest.mark.parametrize("verdict,expected_status", [
+    ({"engine": "e", "effective_device": "cuda", "routing_status": "accelerated",
+      "routing_reason": None, "host_family": "cuda", "vram_gb": 24.0}, OK),
+    ({"engine": "e", "effective_device": "cuda", "routing_status": "accelerated",
+      "routing_reason": "CUDA selected, but: may fail at kernel launch",
+      "host_family": "cuda", "vram_gb": 24.0}, WARN),
+    ({"engine": "e", "effective_device": "cpu", "routing_status": "cpu_fallback",
+      "routing_reason": "engine has no CUDA path; running on CPU",
+      "host_family": "cuda", "vram_gb": 24.0}, WARN),
+    ({"engine": "e", "effective_device": "cpu", "routing_status": "cpu_only",
+      "routing_reason": None, "host_family": "cpu", "vram_gb": 0.0}, OK),
+    ({"engine": "e", "effective_device": "cuda", "routing_status": "unavailable",
+      "routing_reason": "requires cuda; this host has cpu",
+      "host_family": "cpu", "vram_gb": 0.0}, FAIL),
+    ({"engine": None, "effective_device": None, "routing_status": "none",
+      "routing_reason": None, "host_family": "cpu", "vram_gb": 0.0}, WARN),
+])
+def test_diagnose_routing_status_mapping(monkeypatch, verdict, expected_status):
+    import core.diagnose as diag
+    monkeypatch.setattr("services.tts_backend.gpu_routing_verdict", lambda: verdict)
+    check = diag._check_gpu_routing()
+    assert check["id"] == "gpu_routing"
+    assert check["status"] == expected_status
+    if expected_status in (WARN, FAIL):
+        assert check["hint"], "actionable hint required on warn/fail"
+
+
+def test_diagnose_routing_never_raises(monkeypatch):
+    import core.diagnose as diag
+
+    def _boom():
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr("services.tts_backend.gpu_routing_verdict", _boom)
+    check = diag._check_gpu_routing()
+    assert check["status"] == WARN  # degrades, doesn't propagate

--- a/tests/test_setup_preflight.py
+++ b/tests/test_setup_preflight.py
@@ -63,6 +63,24 @@ def test_preflight_device_summary(client):
     }
     assert d["gpu_backend"] in {"cuda", "rocm", "mps", "cpu"}
     assert d["gpu_vendor"] in {"nvidia", "amd", "apple", "intel", "unknown", "none"}
+    # #21: canonical-probe family + VRAM joined the device summary.
+    assert d["gpu_family"] in {"cuda", "rocm", "mps", "xpu", "cpu"}
+    assert isinstance(d["vram_gb"], (int, float))
+
+
+def test_preflight_includes_active_engine_routing(client):
+    """#21: preflight surfaces a routing verdict for the active TTS engine
+    (no silent CPU fallback) — both a `gpu_routing` object and a check entry."""
+    body = client.get("/setup/preflight").json()
+    assert "gpu_routing" in body
+    gr = body["gpu_routing"]
+    if gr is not None:
+        assert gr["routing_status"] in {
+            "accelerated", "cpu_fallback", "cpu_only", "unavailable", "none",
+        }
+        assert "host_family" in gr
+        ids = {c["id"] for c in body["checks"]}
+        assert "gpu_routing" in ids
 
 
 # ── Aggregation logic ────────────────────────────────────────────────────


### PR DESCRIPTION
**Stacked on #432 (→ #431 → main).** Surfaces a routing verdict for the **currently-selected** TTS engine in the two system-health surfaces, so a CPU fallback / unavailable-GPU is heard about **before** a slow or failed synth. Read-only; auto-retargets as the stack merges.

## What's here
- **`tts_backend.active_routing()` + `gpu_routing_verdict()`** — the active engine's routing, derived from `list_backends()` (byte-identical to the matrix) plus the host compute summary (family + VRAM from the canonical probe). Never raise.
- **`/system/diagnose`** gains a `gpu_routing` check: `accelerated`→ok, caveat/`cpu_fallback`→warn (+ actionable hint), `cpu_only`→ok (a no-GPU host is the expected normal state — never noise-warns), `unavailable`→fail, no-engine→warn. ASCII-safe details (the text dump enforces ASCII).
- **`/setup/preflight`** gains an "Active engine routing" check + an explicit `gpu_routing` object on `PreflightResponse` (a real field — the response has no `extra="allow"`, so it would otherwise be silently dropped). `device` gains `gpu_family` (ROCm-vs-CUDA aware) + `vram_gb`. New `GpuRouting` schema.

## Tests
`gpu_routing_verdict` (host + active-engine + degraded paths), diagnose status mapping across **all 6 states** + never-raises, preflight `gpu_routing` object + check + `device.gpu_family`. Existing diagnose/preflight tests stay green (checks are additive; the diagnose report's top-level key set is unchanged).

## Deferred (documented)
Synth-time routing **headers / WS-frames** at the 3 synth entry points. Selection is already **hard-gated** in #432 (`select_engine`), and the matrix (PR 5) + this preflight/diagnose verdict surface the situation — the synth-time signal is incremental belt-and-suspenders for the env-var-pinned edge, best validated interactively. Tracked as a #21 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR surfaces a GPU routing verdict for the currently-selected TTS engine in two system-health endpoints (`/setup/preflight` and `/system/diagnose`), ensuring users are informed of CPU fallback or unavailable-GPU conditions *before* attempting synthesis.

### Key additions

**New routing functions** (`backend/services/tts_backend.py`):
- `active_routing()` — retrieves the active engine's routing metadata from `list_backends()`; returns `None` on failure (never raises)
- `gpu_routing_verdict()` — composes the full verdict combining the active engine routing with host GPU capabilities (`host_family`, `vram_gb`) detected via `detect_host_caps()`; degrades gracefully to CPU-only if probe fails

**Schema extensions** (`backend/api/schemas.py`):
- New `GpuRouting` model capturing engine, routing verdict (`routing_status`), effective device, and host capabilities
- `DeviceInfo` enhanced with `gpu_family` and `vram_gb` (distinguished from legacy nvidia-smi fields)
- `PreflightResponse` now includes optional `gpu_routing` field

**Preflight changes** (`backend/api/routers/setup/wizard.py`):
- Adds "Active engine routing" check to preflight response `checks` list
- Maps verdict to `pass`/`warn`/`fail` with actionable hints:
  - `accelerated` (no caveat) → pass
  - `accelerated` + caveat or `cpu_fallback` → warn (suggests driver/arch updates)
  - `cpu_only` → okay (skips noise for non-GPU hosts)
  - `unavailable` → fail (GPU selected but not functional)
  - unresolved → warn (no engine selected)
- Populates device section's `gpu_family` and `vram_gb` from verdict
- Wraps call in exception handler to prevent endpoint failure

**Diagnose changes** (`backend/core/diagnose.py`):
- New `_check_gpu_routing()` function applies same verdict-to-status mapping as preflight
- Appended to diagnostics report alongside existing checks
- Ensures verdicts map to actionable hints and never raise

**Test coverage** (`tests/test_gpu_routing_verdict.py` + `tests/test_setup_preflight.py`):
- Unit tests for `gpu_routing_verdict()` composition and degradation
- Parametrized status mapping tests across all six routing states
- Robustness tests confirming exception handling never breaks endpoints
- Preflight assertions for presence and structure of `gpu_routing` object and `device.gpu_family`

### Routing verdict flow

```mermaid
graph TD
    A["User selected TTS engine"] --> B["active_routing()"]
    B --> C["Query list_backends<br/>for active engine"]
    C --> D{Engine found?}
    D -->|Yes| E["Extract routing_status<br/>effective_device<br/>routing_reason"]
    D -->|No| F["Return None"]
    
    E --> G["gpu_routing_verdict()"]
    F --> G
    
    G --> H["detect_host_caps()"]
    H --> I["Determine host_family<br/>& vram_gb"]
    I --> J["Merge engine routing<br/>+ host capabilities"]
    
    J --> K{routing_status?}
    K -->|accelerated| L["Preflight: PASS<br/>Diagnose: OK"]
    K -->|accelerated-caveat| M["Preflight: WARN<br/>Diagnose: WARN<br/>Hint: Update drivers"]
    K -->|cpu_fallback| M
    K -->|cpu_only| N["Preflight: PASS<br/>Diagnose: OK<br/>Normal for CPU-only hosts"]
    K -->|unavailable| O["Preflight: FAIL<br/>Diagnose: FAIL<br/>Hint: Select CPU engine"]
    K -->|none| P["Preflight: WARN<br/>Diagnose: WARN<br/>Hint: Pick an engine"]
```

### Changes summary

| File | Changes | Impact |
|------|---------|--------|
| `tts_backend.py` | +54 lines | Two new public functions for routing verdict composition |
| `schemas.py` | +25 lines | New `GpuRouting` model; `DeviceInfo` and `PreflightResponse` extended |
| `wizard.py` (preflight) | +44 lines | GPU routing check added; device section enhanced; response includes verdict |
| `diagnose.py` | +45 lines | New `_check_gpu_routing()` check appended to diagnostics report |
| `test_gpu_routing_verdict.py` | +86 lines | Focused unit tests for verdict composition and status mapping |
| `test_setup_preflight.py` | +18 lines | Assertion that preflight includes `gpu_routing` object |

### Notes

- All new code is non-breaking; existing endpoint signatures and checks remain unchanged
- Routing detection failures never break endpoints (logged as warnings, checks skipped or degraded)
- CPU-only verdict on non-GPU hosts is expected and non-disruptive (returns OK status)
- Synth-time routing headers/WebSocket frames deferred to follow-up `#21` work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->