### PR TITLE
feat(ui): Engine Compatibility Matrix routing display (#21 PR 5/5)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -12,13 +12,18 @@
 // ── Engines (Phase 3 / 4.6 / Plan 02-04) ─────────────────────────────────
 export type EngineFamily = 'tts' | 'asr' | 'llm';
 
-// `isolation_mode`, `last_error`, `install_hint`, `gpu_compat` arrived
-// in Plan 02-04 alongside the Engine Compatibility Matrix. They're
-// optional in this type because the asr / llm registries don't emit them
-// today (only the TTS registry has been migrated to the extended shape).
-// The matrix UI gates them with `??` / `?.length` so the simpler payload
-// still renders without errors.
-export type GPUTarget = 'cuda' | 'mps' | 'rocm' | 'cpu';
+// `isolation_mode`, `last_error`, `install_hint`, `gpu_compat` arrived in Plan
+// 02-04 alongside the Engine Compatibility Matrix. As of #21 ALL three
+// registries (tts / asr / llm) emit the full shape, plus the routing trio
+// (`effective_device` / `routing_status` / `routing_reason`). They stay
+// optional so the matrix still renders a legacy/older payload that omits them
+// (it gates with `??` / `?.length` and suppresses the routing badge).
+export type GPUTarget = 'cuda' | 'mps' | 'rocm' | 'xpu' | 'cpu';
+// Where an engine actually runs on THIS host. `network` is LLM-only (remote).
+export type EffectiveDevice = GPUTarget | 'network';
+// `n/a` is LLM-only; resolve_routing only ever returns the first four.
+export type RoutingStatus =
+  | 'accelerated' | 'cpu_fallback' | 'cpu_only' | 'unavailable' | 'n/a';
 
 export interface EngineBackend {
   id: string;
@@ -29,6 +34,10 @@ export interface EngineBackend {
   last_error?: string | null;
   isolation_mode?: 'in-process' | 'subprocess';
   gpu_compat?: GPUTarget[];
+  // Routing (#21) — the device this engine uses on this machine + why.
+  effective_device?: EffectiveDevice;
+  routing_status?: RoutingStatus;
+  routing_reason?: string | null;
 }
 
 export interface EngineFamilyResponse {

--- a/frontend/src/components/EngineCompatibilityMatrix.css
+++ b/frontend/src/components/EngineCompatibilityMatrix.css
@@ -223,8 +223,22 @@
   border-color: color-mix(in srgb, #ed1c24 45%, transparent);
   background: color-mix(in srgb, #ed1c24 10%, transparent);
 }
+.engine-matrix__chip--xpu {
+  color: #0071c5;
+  border-color: color-mix(in srgb, #0071c5 45%, transparent);
+  background: color-mix(in srgb, #0071c5 10%, transparent);
+}
 .engine-matrix__chip--cpu {
   /* keep default muted tone for CPU */
+}
+
+/* The device this engine will actually use on THIS host (#21). A ring +
+   brighter foreground so it reads as "selected here" at a glance. */
+.engine-matrix__chip.is-effective {
+  box-shadow: 0 0 0 1px var(--chrome-accent, #fe8019);
+  border-color: var(--chrome-accent, #fe8019);
+  color: var(--chrome-fg, #eee);
+  font-weight: 700;
 }
 
 .engine-matrix__result {

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -71,7 +71,19 @@ const GPU_LABEL = {
   cuda: 'CUDA',
   mps: 'MPS',
   rocm: 'ROCm',
+  xpu: 'XPU',
   cpu: 'CPU',
+};
+
+// routing_status → badge tone + i18n key (#21). `unavailable` is intentionally
+// absent: the availability badge already conveys it, so the routing badge is
+// suppressed there. Any status not in this map (or a legacy payload with no
+// routing_status at all) falls back to a neutral "Unknown" badge / no badge.
+const ROUTING_BADGE = {
+  accelerated:  { tone: 'success', k: 'engines.routingAccelerated' },
+  cpu_fallback: { tone: 'warn',    k: 'engines.routingCpuFallback' },
+  cpu_only:     { tone: 'neutral', k: 'engines.routingCpuOnly' },
+  'n/a':        { tone: 'neutral', k: 'engines.routingRemote' },
 };
 
 const TEST_COOLDOWN_MS = 5000;
@@ -89,6 +101,11 @@ function normalizeEntry(entry) {
     gpu_compat: Array.isArray(entry.gpu_compat) && entry.gpu_compat.length > 0
       ? entry.gpu_compat
       : ['cpu'],
+    // Routing (#21) — may be absent on a legacy/older backend payload, in
+    // which case the matrix renders exactly as before (no routing badge).
+    effective_device: entry.effective_device || null,
+    routing_status: entry.routing_status || null,
+    routing_reason: entry.routing_reason || null,
   };
 }
 
@@ -307,14 +324,45 @@ export default function EngineCompatibilityMatrix({
                     : <Badge tone="warn" size="xs"><AlertTriangle size={10} /> {t('engines.unavailable')}</Badge>}
                 </div>
 
-                {/* GPU compat chips */}
+                {/* GPU compat chips + routing badge (the device this engine
+                    will actually use on THIS machine). LLM (routing 'n/a')
+                    shows a single "Remote" badge instead of device chips. */}
                 <div role="cell" className="engine-matrix__cell engine-matrix__cell--gpu" style={{ width: 170 }}>
                   <div className="engine-matrix__chips">
-                    {b.gpu_compat.map((g) => (
-                      <span key={g} className={`engine-matrix__chip engine-matrix__chip--${g}`}>
-                        {GPU_LABEL[g] || g.toUpperCase()}
-                      </span>
-                    ))}
+                    {b.routing_status === 'n/a' ? (
+                      <Badge tone="neutral" size="xs">{t('engines.routingRemote')}</Badge>
+                    ) : (
+                      <>
+                        {b.gpu_compat.map((g) => {
+                          const isEffective = b.routing_status
+                            && b.routing_status !== 'unavailable'
+                            && g === b.effective_device;
+                          return (
+                            <span
+                              key={g}
+                              className={`engine-matrix__chip engine-matrix__chip--${g}${isEffective ? ' is-effective' : ''}`}
+                              title={isEffective
+                                ? t('engines.routingEffectiveChip', { device: GPU_LABEL[g] || g })
+                                : undefined}
+                            >
+                              {GPU_LABEL[g] || g.toUpperCase()}
+                            </span>
+                          );
+                        })}
+                        {/* Routing badge: known status → toned badge; unknown
+                            status → neutral fallback; suppressed when the row is
+                            unavailable (availability badge covers it) or legacy
+                            (no routing_status → no badge). */}
+                        {b.routing_status && b.available && b.routing_status !== 'unavailable' && (
+                          ROUTING_BADGE[b.routing_status]
+                            ? <Badge tone={ROUTING_BADGE[b.routing_status].tone} size="xs"
+                                     title={b.routing_reason || undefined}>
+                                {t(ROUTING_BADGE[b.routing_status].k)}
+                              </Badge>
+                            : <Badge tone="neutral" size="xs">{t('engines.routingUnknown')}</Badge>
+                        )}
+                      </>
+                    )}
                   </div>
                 </div>
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1253,7 +1253,14 @@
     "failed": "failed",
     "acceptLicense": "Accept license",
     "noBackends": "No backends registered.",
-    "switch_failed": "Failed to switch engine"
+    "switch_failed": "Failed to switch engine",
+    "routingAccelerated": "GPU active",
+    "routingCpuFallback": "CPU fallback",
+    "routingCpuOnly": "CPU",
+    "routingRemote": "Remote",
+    "routingUnknown": "Unknown",
+    "routingEffectiveChip": "Runs on {{device}} on this machine",
+    "routingCaveatTitle": "GPU selected, but: {{reason}}"
   },
   "errors": {
     "title": "This tab hit a snag.",

--- a/frontend/src/test/EngineCompatibilityMatrix.test.jsx
+++ b/frontend/src/test/EngineCompatibilityMatrix.test.jsx
@@ -224,6 +224,84 @@ describe('EngineCompatibilityMatrix', () => {
     resolveHealth({ id: 'indextts2', ok: true, message: 'pong', latency_ms: 50 });
   });
 
+  // ── #21 routing display ────────────────────────────────────────────────
+  function routingResponse() {
+    const base = (over) => ({
+      display_name: over.id, available: true, reason: null, install_hint: null,
+      last_error: null, isolation_mode: 'in-process', ...over,
+    });
+    return {
+      tts: {
+        active: 'accel',
+        backends: [
+          base({ id: 'accel', display_name: 'Accel TTS', gpu_compat: ['cuda', 'mps', 'cpu'],
+                 effective_device: 'cuda', routing_status: 'accelerated', routing_reason: null }),
+          base({ id: 'fallback', display_name: 'Fallback TTS', gpu_compat: ['cuda', 'cpu'],
+                 effective_device: 'cpu', routing_status: 'cpu_fallback',
+                 routing_reason: 'engine has no CUDA path; running on CPU' }),
+          base({ id: 'gone', display_name: 'Unavail TTS', available: false, reason: 'needs cuda',
+                 gpu_compat: ['cuda'], effective_device: 'cuda',
+                 routing_status: 'unavailable', routing_reason: 'requires cuda; this host has cpu' }),
+          // Legacy payload: no routing_* keys → render exactly as before.
+          base({ id: 'legacy', display_name: 'Legacy TTS', gpu_compat: ['cpu'] }),
+        ],
+      },
+      asr: { active: '', backends: [] },
+      llm: {
+        active: 'off',
+        backends: [base({ id: 'off', display_name: 'Off LLM', gpu_compat: [],
+                          effective_device: 'network', routing_status: 'n/a', routing_reason: null })],
+      },
+    };
+  }
+
+  it('highlights the effective device chip + shows an "accelerated" badge', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(routingResponse());
+    render(<EngineCompatibilityMatrix family="tts" apiListEngines={apiListEngines} apiGetEngineHealth={vi.fn()} />);
+    await waitFor(() => screen.getByText('Accel TTS'));
+    const row = screen.getByText('Accel TTS').closest('[role="row"]');
+    expect(within(row).getByText('GPU active')).toBeInTheDocument();
+    // the CUDA chip (effective_device) carries the highlight class
+    expect(within(row).getByText('CUDA').classList.contains('is-effective')).toBe(true);
+    // a non-effective chip does not
+    expect(within(row).getByText('MPS').classList.contains('is-effective')).toBe(false);
+  });
+
+  it('shows a "CPU fallback" badge for a cpu_fallback engine', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(routingResponse());
+    render(<EngineCompatibilityMatrix family="tts" apiListEngines={apiListEngines} apiGetEngineHealth={vi.fn()} />);
+    await waitFor(() => screen.getByText('Fallback TTS'));
+    const row = screen.getByText('Fallback TTS').closest('[role="row"]');
+    expect(within(row).getByText('CPU fallback')).toBeInTheDocument();
+  });
+
+  it('suppresses the routing badge for an unavailable engine', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(routingResponse());
+    render(<EngineCompatibilityMatrix family="tts" apiListEngines={apiListEngines} apiGetEngineHealth={vi.fn()} />);
+    await waitFor(() => screen.getByText('Unavail TTS'));
+    const row = screen.getByText('Unavail TTS').closest('[role="row"]');
+    expect(within(row).queryByText('GPU active')).not.toBeInTheDocument();
+    expect(within(row).queryByText('CPU fallback')).not.toBeInTheDocument();
+  });
+
+  it('renders a legacy (no-routing) payload with no routing badge', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(routingResponse());
+    render(<EngineCompatibilityMatrix family="tts" apiListEngines={apiListEngines} apiGetEngineHealth={vi.fn()} />);
+    await waitFor(() => screen.getByText('Legacy TTS'));
+    const row = screen.getByText('Legacy TTS').closest('[role="row"]');
+    expect(within(row).getByText('CPU')).toBeInTheDocument();             // chip still renders
+    expect(within(row).queryByText('GPU active')).not.toBeInTheDocument(); // no routing badge
+    expect(within(row).queryByText('CPU fallback')).not.toBeInTheDocument();
+  });
+
+  it('shows a "Remote" badge (not device chips) for LLM rows', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(routingResponse());
+    render(<EngineCompatibilityMatrix family="llm" apiListEngines={apiListEngines} apiGetEngineHealth={vi.fn()} />);
+    await waitFor(() => screen.getByText('Off LLM'));
+    const row = screen.getByText('Off LLM').closest('[role="row"]');
+    expect(within(row).getByText('Remote')).toBeInTheDocument();
+  });
+
   it('renders a failure marker when the health route returns ok=false', async () => {
     const apiListEngines = vi.fn().mockResolvedValue(makeEnginesResponse());
     const apiGetEngineHealth = vi.fn().mockResolvedValue({


### PR DESCRIPTION
**Stacked on #433 (→ #432 → #431 → main).** The user-facing payoff: surfaces the `/engines` routing data (#432) in the matrix so users see the device each engine will actually use on **this** machine. Auto-retargets as the stack merges.

## What changed
- The chip matching `effective_device` is **highlighted** (accent ring + bold) with a "Runs on X on this machine" tooltip.
- A status-toned **routing badge**: `accelerated`→success **GPU active**, `cpu_fallback`→warn **CPU fallback** (reason in tooltip), `cpu_only`→neutral **CPU**.
  - **Suppressed** for unavailable rows (the availability badge already conveys it) and for **legacy payloads** with no `routing_status` (renders exactly as before).
  - Unknown/future status → neutral **Unknown** fallback.
- **LLM rows** (`routing_status: "n/a"`) render a single neutral **Remote** badge instead of device chips — no false GPU claim.
- `types.ts`: `EngineBackend` gains `effective_device` / `routing_status` / `routing_reason`; `GPUTarget` gains `xpu`; new `EffectiveDevice` + `RoutingStatus` unions. Corrected the stale "only TTS migrated" comment (all three families now emit the full shape).
- i18n keys in `en.json` (other locales fall back to `en` via `fallbackLng` until translated — there is no key-parity gate). `xpu` chip color in the matrix CSS.

## Tests
5 new RTL cases (accelerated highlight+badge, cpu_fallback badge, unavailable suppression, legacy no-badge, LLM Remote). Full frontend vitest green (**350**); `typecheck:ci` clean.

## Note
This completes #21's UI. The synth-time routing headers/WS-frames remain a documented follow-up (see #433) — selection is hard-gated (#432) and the matrix + preflight/diagnose now surface routing everywhere a user looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Engine Compatibility Matrix Routing Display

This PR surfaces `/engines` routing metadata in the Engine Compatibility Matrix UI, enabling users to see which device each engine will actually use on the current machine.

## Type & API Changes

**frontend/src/api/types.ts**
- Added `EffectiveDevice` type (GPUTarget | 'network')
- Added `RoutingStatus` type (`'accelerated' | 'cpu_fallback' | 'cpu_only' | 'unavailable' | 'n/a'`)
- Extended `GPUTarget` union to include `'xpu'` (alongside cuda, mps, rocm, cpu)
- Updated `EngineBackend` interface with three optional routing fields:
  - `effective_device?: EffectiveDevice` — the device this engine uses on this machine
  - `routing_status?: RoutingStatus` — why/how it was routed
  - `routing_reason?: string | null` — fallback reason (e.g. "no CUDA drivers")
- Fields are optional for backward compatibility with legacy payloads

## UI Rendering Logic

**frontend/src/components/EngineCompatibilityMatrix.jsx**

The GPU compatibility cell now intelligently displays routing information:

```
┌─ GPU Cell Rendering Logic ─────────────────────────────┐
│                                                         │
│  routing_status = 'n/a' (LLM)?                         │
│  ├─ YES → Single neutral "Remote" badge               │
│  └─ NO → GPU chips + routing badge                    │
│          ├─ Chip matching effective_device            │
│          │  └─ Adds .is-effective class (ring+bold)   │
│          │     + tooltip: "Runs on X on this machine" │
│          └─ Routing badge (if available & not 'n/a')  │
│             ├─ 'accelerated' → ✓ success "GPU active" │
│             ├─ 'cpu_fallback' → ⚠ warn "CPU fallback"│
│             ├─ 'cpu_only' → ○ neutral "CPU"           │
│             ├─ unknown status → neutral "Unknown"     │
│             └─ Suppressed for unavailable rows or     │
│                legacy payloads (no routing_status)    │
└─────────────────────────────────────────────────────────┘
```

### Before/After Layout

**Before:** GPU compatibility shown as static chip list
```
┌──────────────────────┐
│ CUDA  MPS  ROCm  CPU │
└──────────────────────┘
```

**After:** GPU compatibility with routing highlight & status badge
```
┌────────────────────────────────────────┐
│ ◯─CUDA──  MPS  ROCm  CPU               │  (CUDA has accent ring,
│ GPU active                             │   bold text, tooltip)
│                                        │
│ (or for unavailable/legacy:)           │
│ CUDA  MPS  ROCm  CPU                   │  (no badge, chip styling)
│                                        │
│ (or for LLM rows:)                     │
│ Remote                                 │  (single neutral badge)
└────────────────────────────────────────┘
```

## Visual Styling

**frontend/src/components/EngineCompatibilityMatrix.css**
- New `.engine-matrix__chip--xpu` — blue chip (color-mix with `#0071c5`)
- New `.engine-matrix__chip.is-effective` — accent ring (box-shadow), brighter foreground, bold font-weight

## Localization

**frontend/src/i18n/locales/en.json**
Added 6 new locale keys under `engines`:
- `routingAccelerated`: "GPU active"
- `routingCpuFallback`: "CPU fallback"
- `routingCpuOnly`: "CPU"
- `routingRemote`: "Remote"
- `routingUnknown`: "Unknown"
- `routingEffectiveChip`: "Runs on {{device}} on this machine"

Other locales fall back to English via `fallbackLng`.

## Tests

**frontend/src/test/EngineCompatibilityMatrix.test.jsx**
- New fixture: `routingResponse()` — mocks engines with routing metadata
- 5 new RTL test cases:
  1. TTS with `routing_status: 'accelerated'` → chip highlighted + GPU active badge
  2. TTS with `routing_status: 'cpu_fallback'` → CPU fallback badge with tooltip
  3. Unavailable engine → routing badge suppressed (availability badge takes precedence)
  4. Legacy payload (no `routing_status`) → no routing badge
  5. LLM row → renders single "Remote" badge instead of device chips

Frontend vitest suite: **350 tests passing**; typecheck:ci passes.

## Dependencies

Stacked on PRs `#433` (and transitively `#432` → `#431` → main). Synth-time routing headers and WebSocket frame routing remain a documented follow-up (see `#433`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->