### PR TITLE
Dub: dedicated home (projects/history) + project rename

### DIFF
--- a/backend/api/routers/projects.py
+++ b/backend/api/routers/projects.py
@@ -2,12 +2,17 @@ import uuid
 import time
 import json
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 
 from core.db import db_conn
 from core import event_bus
 from schemas.requests import ProjectSaveRequest
 
 router = APIRouter()
+
+
+class ProjectRenameRequest(BaseModel):
+    name: str
 
 @router.get("/projects")
 async def list_projects():
@@ -58,6 +63,26 @@ async def update_project(project_id: str, req: ProjectSaveRequest):
         )
     event_bus.emit("projects", {"action": "updated", "id": project_id})
     return {"id": project_id, "name": req.name, "updated_at": now}
+
+@router.patch("/projects/{project_id}")
+async def rename_project(project_id: str, req: ProjectRenameRequest):
+    """Lightweight rename — updates only the project name (and updated_at),
+    without re-serialising the whole state blob like PUT does."""
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Project name cannot be empty")
+    now = time.time()
+    with db_conn() as conn:
+        row = conn.execute("SELECT id FROM studio_projects WHERE id=?", (project_id,)).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Project not found")
+        conn.execute(
+            "UPDATE studio_projects SET name=?, updated_at=? WHERE id=?",
+            (name, now, project_id),
+        )
+    event_bus.emit("projects", {"action": "renamed", "id": project_id})
+    return {"id": project_id, "name": name, "updated_at": now}
+
 
 @router.delete("/projects/{project_id}")
 async def delete_project(project_id: str):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -62,7 +62,7 @@ import { LANG_CODES } from './utils/languages';
 import { formatTime } from './utils/format';
 import { API, apiPost } from './api/client';
 import { flushMemory as apiFlushMemory } from './api/system';
-import { saveProject as apiSaveProject, loadProject as apiLoadProject, deleteProject as apiDeleteProject } from './api/projects';
+import { saveProject as apiSaveProject, loadProject as apiLoadProject, deleteProject as apiDeleteProject, renameProject as apiRenameProject } from './api/projects';
 import { exportAction, exportReveal, exportRecord } from './api/exports';
 
 import { isTauri, doubleClickMaximize, fileToMediaUrl, playBlobAudio, playPing } from './utils/media';
@@ -821,6 +821,16 @@ function App() {
     } catch (err) { toast.error(err.message); }
   };
 
+  const renameProject = async (projectId, nextName) => {
+    const name = (nextName || '').trim();
+    if (!name) return;
+    try {
+      await apiRenameProject(projectId, name);
+      if (activeProjectId === projectId) setActiveProject(projectId, name);
+      loadProjects();
+    } catch (err) { toast.error(err.message); }
+  };
+
   const restoreDubHistory = (item) => {
     try {
       if (!item.job_data) return;
@@ -1108,7 +1118,7 @@ function App() {
           </Suspense>
           </ErrorBoundary>
         ) : mode === 'dub' ? (
-          <div className="studio-with-history">
+          <div className={`studio-with-history ${dubStep === 'idle' ? '' : 'studio-with-history--editing'}`}>
           <div className="studio-with-history__main">
           <ErrorBoundary name="dub">
           <Suspense fallback={<LazyFallback />}>
@@ -1156,6 +1166,10 @@ function App() {
           </Suspense>
           </ErrorBoundary>
           </div>
+          {/* Dub home: the Projects + History landing shows only when no project
+              is being edited. Opening/creating one switches to the full-width
+              editor (dubStep !== 'idle'). */}
+          {dubStep === 'idle' && (
           <div className="studio-right">
             <WorkspaceProjects
               projects={studioProjects}
@@ -1164,6 +1178,7 @@ function App() {
               saveProject={saveProject}
               loadProject={loadProject}
               deleteProject={deleteProject}
+              renameProject={renameProject}
             />
             <WorkspaceHistory
               variant="dub"
@@ -1172,6 +1187,7 @@ function App() {
               deleteHistory={deleteHistory}
             />
           </div>
+          )}
           </div>
         ) : (
           <div className="studio-with-history">

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -14,6 +14,10 @@ export async function loadProject(id: string): Promise<ProjectDetail> {
   return apiJson<ProjectDetail>(`/projects/${id}`);
 }
 
+export async function renameProject(id: string, name: string): Promise<ProjectDetail> {
+  return apiPost<ProjectDetail>(`/projects/${id}`, { name }, { method: 'PATCH' });
+}
+
 export async function deleteProject(id: string): Promise<Response> {
   return apiFetch(`/projects/${id}`, { method: 'DELETE' });
 }

--- a/frontend/src/components/WorkspaceProjects.jsx
+++ b/frontend/src/components/WorkspaceProjects.jsx
@@ -8,7 +8,7 @@
  */
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Search, Film, FolderOpen, Trash2, Save } from 'lucide-react';
+import { Search, Film, FolderOpen, Trash2, Save, Pencil, Check, X } from 'lucide-react';
 import { Button } from '../ui';
 import './WorkspaceVoices.css';
 
@@ -34,10 +34,22 @@ export default function WorkspaceProjects({
   saveProject,
   loadProject,
   deleteProject,
+  renameProject,
 }) {
   const { t } = useTranslation();
   const [q, setQ] = useState('');
   const qLower = q.trim().toLowerCase();
+  // Inline rename: which project id is being edited + the draft name.
+  const [editingId, setEditingId] = useState(null);
+  const [draftName, setDraftName] = useState('');
+
+  const startRename = (proj) => { setEditingId(proj.id); setDraftName(proj.name || ''); };
+  const cancelRename = () => { setEditingId(null); setDraftName(''); };
+  const commitRename = (proj) => {
+    const next = draftName.trim();
+    if (next && next !== proj.name) renameProject?.(proj.id, next);
+    cancelRename();
+  };
 
   const items = useMemo(() => {
     if (!qLower) return projects;
@@ -89,7 +101,22 @@ export default function WorkspaceProjects({
                 {timeAgo(proj.updated_at * 1000)}
               </span>
             </div>
-            <div className="history-title">{proj.name}</div>
+            {editingId === proj.id ? (
+              <input
+                className="input-base wv__rename-input"
+                autoFocus
+                value={draftName}
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => setDraftName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.stopPropagation(); commitRename(proj); }
+                  else if (e.key === 'Escape') { e.stopPropagation(); cancelRename(); }
+                }}
+                onBlur={() => commitRename(proj)}
+              />
+            ) : (
+              <div className="history-title">{proj.name}</div>
+            )}
             <div className="history-subtitle">
               {proj.duration ? `${Math.round(proj.duration)}s` : 'audio'}
               {(() => {
@@ -98,12 +125,30 @@ export default function WorkspaceProjects({
               })()}
             </div>
             <div className="history-actions">
-              <button className="history-action-btn accent" onClick={(e) => { e.stopPropagation(); loadProject(proj.id); }}>
-                <FolderOpen size={10} /> {t('sidebar.open')}
-              </button>
-              <button className="history-action-btn danger history-action-icon" onClick={(e) => { e.stopPropagation(); deleteProject(proj.id); }} title="Delete">
-                <Trash2 size={10} />
-              </button>
+              {editingId === proj.id ? (
+                <>
+                  <button className="history-action-btn accent" onClick={(e) => { e.stopPropagation(); commitRename(proj); }} title={t('sidebar.rename_save', { defaultValue: 'Save name' })}>
+                    <Check size={10} /> {t('common.save', { defaultValue: 'Save' })}
+                  </button>
+                  <button className="history-action-btn history-action-icon" onClick={(e) => { e.stopPropagation(); cancelRename(); }} title={t('common.cancel', { defaultValue: 'Cancel' })}>
+                    <X size={10} />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button className="history-action-btn accent" onClick={(e) => { e.stopPropagation(); loadProject(proj.id); }}>
+                    <FolderOpen size={10} /> {t('sidebar.open')}
+                  </button>
+                  {renameProject && (
+                    <button className="history-action-btn history-action-icon" onClick={(e) => { e.stopPropagation(); startRename(proj); }} title={t('sidebar.rename', { defaultValue: 'Rename' })}>
+                      <Pencil size={10} />
+                    </button>
+                  )}
+                  <button className="history-action-btn danger history-action-icon" onClick={(e) => { e.stopPropagation(); deleteProject(proj.id); }} title="Delete">
+                    <Trash2 size={10} />
+                  </button>
+                </>
+              )}
             </div>
           </div>
         ))}

--- a/frontend/src/components/WorkspaceVoices.css
+++ b/frontend/src/components/WorkspaceVoices.css
@@ -126,3 +126,12 @@
   text-align: center;
   padding: 24px 16px;
 }
+
+/* Inline project rename (WorkspaceProjects) — fills the card row like the title. */
+.wv__rename-input {
+  width: 100%;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  margin: 1px 0;
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1418,6 +1418,8 @@
     "tab_exports": "Exports",
     "save_project": "Save Dub Project",
     "save_new_project": "Save as New Dub Project",
+    "rename": "Rename",
+    "rename_save": "Save name",
     "dub_projects": "Dub Projects",
     "voice_clones": "Voice Clones",
     "designed_voices": "Designed Voices",


### PR DESCRIPTION
## What

Two dub UX changes:

### 1. Dedicated Dub home
The Projects + History rail (`WorkspaceProjects` / `WorkspaceHistory`) used to render beside the editor **at all times**. Now it's a **landing**: shown only when no project is open (`dubStep === 'idle'`). Opening or creating a project switches to a **full-width editor** (the flex layout fills the space once the rail unmounts). The global left Sidebar is already hidden in dub mode (`hideSidebar` includes `'dub'`), so the studio-right rail is the only projects/history surface — no Sidebar change required.

### 2. Project rename
There was no way to rename a saved dub project (you had to delete + re-save, losing the id).
- **backend:** `PATCH /projects/{id}` updates just the `name` (+`updated_at`) — lighter than `PUT` which rewrites the whole state blob. 400 on empty name, 404 on missing.
- **api/handler:** `renameProject(id, name)`; `App.jsx` handler updates the active-project label and refreshes the list.
- **UI:** inline rename on each project card — pencil icon → editable title → Enter/Save commits, Esc cancels.

## Files
- `backend/api/routers/projects.py` — PATCH endpoint
- `frontend/src/api/projects.ts` — `renameProject`
- `frontend/src/App.jsx` — `renameProject` handler + gate `studio-right` to `dubStep==='idle'`
- `frontend/src/components/WorkspaceProjects.jsx` — inline rename UI
- `frontend/src/components/WorkspaceVoices.css`, `i18n/locales/en.json`

## Verification
- Live: `PATCH` create→rename→list shows new name; empty → 400; missing → 404.
- `frontend typecheck:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Dedicated Dub Home Landing + Inline Project Rename

### Overview
This PR introduces a dedicated "Dub home" landing page that displays the Projects and History panels only when idle (no project open). When a project is opened or created, the editor expands to full width and the landing unmounts. Additionally, users can now rename projects inline via a pencil icon that triggers an editable title field.

### UI/Layout Changes

**Before/After: Dub Workspace Layout**

```
BEFORE (current): Projects/History always visible in studio-right
┌─────────────────────────────────────┐
│ Studio (full workspace)             │
│ ┌──────────────┬───────────────────┐│
│ │              │ Projects/History  ││
│ │   Editor     │                   ││
│ │   (or idle)  │   (always shown)  ││
│ │              │                   ││
│ └──────────────┴───────────────────┘│
└─────────────────────────────────────┘

AFTER (new): Projects/History home shown only when dubStep === 'idle'
┌─────────────────────────────────────┐
When IDLE:                              When PROJECT OPEN:
│ Studio                              │ │ Studio                       │
│ ┌────────────────────────────────┐ │ │ ┌──────────────────────────┐ │
│ │ Projects + History (Landing)   │ │ │ │  Full-width Editor       │ │
│ │  [New Project] [Search]        │ │ │ │                          │ │
│ │  ─────────────────────────    │ │ │ │                          │ │
│ │  • Project A                  │ │ │ │                          │ │
│ │  • Project B                  │ │ │ └──────────────────────────┘ │
│ └────────────────────────────────┘ │ └──────────────────────────────┘
└─────────────────────────────────────┘
```

**Inline Project Rename Interaction**

```
Project Card Default:
┌─────────────────────────────────────┐
│ 📹 DUB  •  2h ago                   │
│ ┌─────────────────────────────────┐ │
│ │ My Project Name                 │ │ [✏️]
│ │                                 │ │
│ └─────────────────────────────────┘ │
│ [📂 Open] [🗑️ Delete]               │
└─────────────────────────────────────┘

↓ Click pencil (✏️) to edit:

┌─────────────────────────────────────┐
│ 📹 DUB  •  2h ago                   │
│ ┌─────────────────────────────────┐ │
│ │ ┌───────────────────────────────┤ │ (auto-focused input)
│ │ │ My Project Name (editable)    │ │
│ │ └───────────────────────────────┤ │
│ └─────────────────────────────────┘ │
│ [✔️ Save] [✕ Cancel]                │
└─────────────────────────────────────┘

↓ Press Enter/Save or Esc/Cancel
```

### Behavior Flow: Project Rename Mechanism

```
User clicks pencil icon on project card
           ↓
   Set editingId & draftName
           ↓
   Render inline text input (auto-focused)
           ↓
   User enters new name & presses Enter
           ↓
   commitRename() validates (trim, non-empty)
           ↓
   Call renameProject(projectId, newName)
           ↓
   Frontend API sends PATCH /projects/{id}
           ↓
   Backend validates name, updates DB
           ↓
   ├─→ 400 if empty name (after trim)
   ├─→ 404 if project missing
   └─→ 200 with updated {id, name, updated_at}
           ↓
   Frontend updates activeProject label
   & refreshes project list
           ↓
   Cancel edit mode (editingId = null)
```

### Changes Summary

**Backend (`projects.py`)**
- Added `ProjectRenameRequest` Pydantic model with single `name` field
- New `PATCH /projects/{project_id}` endpoint (`rename_project`) that:
  - Validates name is non-empty after trimming (400 error if not)
  - Checks project exists (404 error if missing)
  - Updates only `name` and `updated_at` in `studio_projects` (lightweight, preserves state blob)
  - Emits `projects` event with action `renamed`

**Frontend API (`api/projects.ts`)**
- New `renameProject(id: string, name: string)` exported function
- Sends `PATCH` to `/projects/{id}` with body `{ name }`

**App.jsx**
- Imports `apiRenameProject`
- New `renameProject(projectId, nextName)` handler that:
  - Trims name and validates
  - Calls backend rename API
  - Updates active project name if applicable
  - Refreshes project list
  - Surfaces errors via toast
- Conditional rendering: "Dub home" (Projects + History landing) shown only when `dubStep === 'idle'`
- Studio wrapper applies `studio-with-history--editing` class when `dubStep !== 'idle'`
- Wires `renameProject` callback to Projects panel

**WorkspaceProjects.jsx**
- Added `renameProject` prop (optional)
- Local state: `editingId` (which project is being edited) and `draftName` (draft rename text)
- New handlers: `startRename()`, `cancelRename()`, `commitRename()`
- Inline rename UI: pencil icon → auto-focused text input → Save (✔️) / Cancel (✕) buttons
- Edit mode replaces open/delete buttons with save/cancel controls (event propagation stopped)

**WorkspaceVoices.css**
- New `.wv__rename-input` class: full-width, adjusted typography (0.78rem), padding (2px 6px), minimal margin

**i18n (en.json)**
- Added `sidebar.rename` and `sidebar.rename_save` translation keys

### Verification
- End-to-end: create project → rename (via pencil) → confirm in list; PATCH endpoint correctly rejects empty names (400) and missing projects (404)
- Frontend typecheck passes (CI clean)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->