### PR TITLE
Share the longform SSE stream consumer across Stories + Audiobook

### DIFF
--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -23,7 +23,7 @@ import { encodeAudio } from '../api/stories';
 import { longformRender } from '../api/audiobook';
 import { exportStems } from '../utils/storyExport';
 import { storyToSpans } from '../utils/storyToSpans';
-import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
+import { consumeLongformStream } from '../utils/longformStream';
 import { reorder } from '../utils/storyReorder';
 import { effectiveProfile, castMember, nextCastColor } from '../utils/storyCast';
 import './StoriesEditor.css';
@@ -369,27 +369,17 @@ export default function StoriesEditor({ profiles = [] }) {
         chapters,
         format: exportFormat === 'mp3' ? 'mp3' : 'm4b',
       });
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
       let total = 0;
       let output = '';
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const { lines, rest } = splitSSEBuffer(buffer);
-        buffer = rest;
-        for (const line of lines) {
-          const evt = parseSSELine(line);
-          if (!evt) continue;
-          if (evt.type === 'started') total = evt.chapters;
-          else if (evt.type === 'chapter' || evt.type === 'chapter_error') {
-            setExportPct(total ? Math.round(((evt.index + 1) / total) * 100) : 0);
-          } else if (evt.type === 'done') output = evt.output;
-          else if (evt.type === 'error') throw new Error(evt.error || 'render failed');
-        }
-      }
+      let streamErr = null;
+      await consumeLongformStream(res, (evt) => {
+        if (evt.type === 'started') total = evt.chapters;
+        else if (evt.type === 'chapter' || evt.type === 'chapter_error') {
+          setExportPct(total ? Math.round(((evt.index + 1) / total) * 100) : 0);
+        } else if (evt.type === 'done') output = evt.output;
+        else if (evt.type === 'error') streamErr = evt.error || 'render failed';
+      });
+      if (streamErr) throw new Error(streamErr);
       if (!output) throw new Error('no output produced');
       downloadUrl(audioUrl(output), output.split('/').pop());
       toast.success(t('stories.exportDone'));

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -6,7 +6,7 @@ import {
   audiobookPlan, audiobookGenerate, audiobookUploadCover, audiobookPreviewChapter, audiobookImport,
 } from '../api/audiobook';
 import { audioUrl } from '../api/generate';
-import { splitSSEBuffer, parseSSELine } from '../utils/sseParse';
+import { consumeLongformStream } from '../utils/longformStream';
 import './AudiobookTab.css';
 
 /**
@@ -136,37 +136,25 @@ export default function AudiobookTab({ profiles = [] }) {
         metadata: Object.keys(metadata).length ? metadata : null,
         lexicon: Object.keys(lexicon).length ? lexicon : null,
       });
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-      while (!abortRef.current) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const { lines, rest } = splitSSEBuffer(buffer);
-        buffer = rest;
-        for (const line of lines) {
-          const evt = parseSSELine(line);
-          if (!evt) continue;
-          if (evt.type === 'started') {
-            setProgress({ current: 0, total: evt.chapters });
-          } else if (evt.type === 'chapter') {
-            setProgress({ current: evt.index + 1, total: evt.total, title: evt.title });
-          } else if (evt.type === 'assembling') {
-            setProgress((p) => ({ ...(p || {}), assembling: true }));
-          } else if (evt.type === 'chapter_error') {
-            setProgress({ current: evt.index + 1, total: evt.total, title: evt.title });
-          } else if (evt.type === 'done') {
-            setOutput(evt.output);
-            setDone({
-              cached_chapters: evt.cached_chapters || 0,
-              failed_chapters: evt.failed_chapters || [],
-            });
-          } else if (evt.type === 'error') {
-            setError(evt.error || 'synthesis failed');
-          }
+      await consumeLongformStream(res, (evt) => {
+        if (evt.type === 'started') {
+          setProgress({ current: 0, total: evt.chapters });
+        } else if (evt.type === 'chapter') {
+          setProgress({ current: evt.index + 1, total: evt.total, title: evt.title });
+        } else if (evt.type === 'assembling') {
+          setProgress((p) => ({ ...(p || {}), assembling: true }));
+        } else if (evt.type === 'chapter_error') {
+          setProgress({ current: evt.index + 1, total: evt.total, title: evt.title });
+        } else if (evt.type === 'done') {
+          setOutput(evt.output);
+          setDone({
+            cached_chapters: evt.cached_chapters || 0,
+            failed_chapters: evt.failed_chapters || [],
+          });
+        } else if (evt.type === 'error') {
+          setError(evt.error || 'synthesis failed');
         }
-      }
+      }, { isAborted: () => abortRef.current });
     } catch (e) {
       setError(e?.message || String(e));
     } finally {

--- a/frontend/src/test/longformStream.test.js
+++ b/frontend/src/test/longformStream.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { consumeLongformStream } from '../utils/longformStream';
+
+// Build a fake fetch Response whose body streams the given chunks of text.
+function streamResponse(chunks) {
+  const enc = new TextEncoder();
+  let i = 0;
+  return {
+    body: {
+      getReader() {
+        return {
+          read() {
+            if (i < chunks.length) return Promise.resolve({ done: false, value: enc.encode(chunks[i++]) });
+            return Promise.resolve({ done: true, value: undefined });
+          },
+        };
+      },
+    },
+  };
+}
+
+function sse(obj) {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+describe('consumeLongformStream', () => {
+  it('parses every event across chunk boundaries, in order', async () => {
+    // Split one event across two reads to exercise the buffer.
+    const full = sse({ type: 'started', chapters: 2 })
+      + sse({ type: 'chapter', index: 0, total: 2, title: 'One' })
+      + sse({ type: 'chapter', index: 1, total: 2, title: 'Two' })
+      + sse({ type: 'done', output: 'book.m4b' });
+    const mid = Math.floor(full.length / 2);
+    const res = streamResponse([full.slice(0, mid), full.slice(mid)]);
+
+    const events = [];
+    await consumeLongformStream(res, (e) => events.push(e));
+
+    expect(events.map((e) => e.type)).toEqual(['started', 'chapter', 'chapter', 'done']);
+    expect(events[0].chapters).toBe(2);
+    expect(events.at(-1).output).toBe('book.m4b');
+  });
+
+  it('stops early when isAborted() returns true', async () => {
+    const res = streamResponse([sse({ type: 'started', chapters: 5 }), sse({ type: 'chapter', index: 0 })]);
+    const events = [];
+    let aborted = false;
+    await consumeLongformStream(res, (e) => { events.push(e); aborted = true; }, { isAborted: () => aborted });
+    // First read delivers the 'started' event, then isAborted() trips before the next read.
+    expect(events.length).toBe(1);
+  });
+
+  it('throws when the response has no body', async () => {
+    await expect(consumeLongformStream({}, () => {})).rejects.toThrow(/no response stream/);
+  });
+});

--- a/frontend/src/utils/longformStream.js
+++ b/frontend/src/utils/longformStream.js
@@ -1,0 +1,43 @@
+/**
+ * Shared consumer for the longform render SSE stream (Stories + Audiobook).
+ *
+ * Both editors compile to a chapter/span plan and stream progress from the same
+ * server-side renderer (`_render_longform_sse`), emitting the same event shapes:
+ *   { type: 'started', chapters }
+ *   { type: 'chapter' | 'chapter_error', index, total, title }
+ *   { type: 'assembling' }
+ *   { type: 'done', output, cached_chapters?, failed_chapters? }
+ *   { type: 'error', error }
+ *
+ * This factors out the identical read/decode/split/parse loop that lived in
+ * both StoriesEditor and AudiobookTab — so a protocol change lives in one place
+ * and each editor only supplies its own per-event state handling.
+ */
+import { splitSSEBuffer, parseSSELine } from './sseParse';
+
+/**
+ * Read `res.body` as an SSE stream and invoke `onEvent(evt)` for every parsed
+ * event. Returns when the stream ends or `isAborted()` becomes true.
+ *
+ * @param {Response} res        fetch Response whose body is the SSE stream
+ * @param {(evt: object) => void} onEvent  called once per parsed event
+ * @param {{ isAborted?: () => boolean }} [opts]
+ */
+export async function consumeLongformStream(res, onEvent, { isAborted } = {}) {
+  if (!res || !res.body) throw new Error('no response stream');
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    if (isAborted && isAborted()) break;
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const { lines, rest } = splitSSEBuffer(buffer);
+    buffer = rest;
+    for (const line of lines) {
+      const evt = parseSSELine(line);
+      if (evt) onEvent(evt);
+    }
+  }
+}


### PR DESCRIPTION
## What

Stories Editor and Audiobook are two authoring front-ends over **one** server-side renderer (`_render_longform_sse`) — they emit the same chapter-progress SSE events. Both editors had hand-rolled the **identical** stream loop (`getReader` → decode → `splitSSEBuffer` → `parseSSELine`).

This extracts that loop into `utils/longformStream.consumeLongformStream(res, onEvent, { isAborted })`:
- One place owns the SSE protocol (a protocol change is now a single edit).
- Each editor keeps only its own per-event state handling — Stories tracks export %, Audiobook tracks `{current, total, title, assembling, done, ...}`.
- Behaviour unchanged; Audiobook keeps its mid-stream abort via `isAborted: () => abortRef.current`.

The rest of the two editors stay distinct **on purpose** — cast/multi-voice dialogue vs manuscript/EPUB authoring — per `docs/specs/2026-06-13-stories-audiobook-maturity.md` ("two authoring frontends over the same job"). The markup help / cast panel / metadata fields are genuinely different UIs, so there's nothing else low-risk to fold without changing UX.

## Files
- `frontend/src/utils/longformStream.js` (new) — shared consumer
- `frontend/src/components/StoriesEditor.jsx`, `frontend/src/pages/AudiobookTab.jsx` — use it; drop the duplicated loop + `sseParse` import
- `frontend/src/test/longformStream.test.js` (new)

## Verification
- New test covers chunk-boundary parsing, `isAborted` early-stop, no-body error.
- Full vitest: **348 passed**; `typecheck:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Share the longform SSE stream consumer across Stories + Audiobook

## Overview
This PR extracts the identical Server-Sent Events (SSE) stream handling logic that was duplicated in Stories Editor and Audiobook into a shared utility function `consumeLongformStream`. Protocol changes now live in a single place, while each editor retains its own per-event state handling and behavior remains unchanged.

## Changes

### New shared utility
- **frontend/src/utils/longformStream.js**: Introduces `consumeLongformStream(res, onEvent, { isAborted })` that reads SSE data from a fetch Response body, incrementally decodes it, buffers text, splits into SSE lines, parses events, and invokes the `onEvent` callback. Supports early termination via optional `isAborted()` predicate.

### Updated components
- **StoriesEditor.jsx**: Replaces manual buffer/line parsing with `consumeLongformStream` call. The export flow now delegates SSE protocol handling to the shared utility while maintaining its own `exportPct` progress tracking based on `started`/`chapter`/`chapter_error` events.
- **AudiobookTab.jsx**: Switches to `consumeLongformStream` for streaming lifecycle. Wires the component's `abortRef` to the `isAborted` option, enabling mid-stream abort support. Consolidates event handling into the callback.

### Test coverage
- **frontend/src/test/longformStream.test.js**: Verifies the shared consumer correctly parses SSE events across chunk boundaries, respects the `isAborted` predicate for early termination, and rejects when Response lacks a body stream.

## Stream consumption flow

```
┌─────────────────────────────────────────────────────────────┐
│ consumeLongformStream(res, onEvent, { isAborted })          │
└────────────────────────┬────────────────────────────────────┘
                         │
                    ┌────▼─────┐
                    │ Check     │
                    │isAborted()│
                    └────┬─────┘
                         │ true
                      ┌──┴─────────────┐
                      │ Exit (abort)   │
                      └────────────────┘
                      
                      (false or skipped)
                         │
                    ┌────▼──────────────────┐
                    │ reader.read() from    │
                    │ res.body stream       │
                    └────┬──────────────────┘
                         │
               ┌─────────┴─────────┐
          done=true            done=false
          (stream end)         (has data)
               │                   │
            Exit                   │
                                   ▼
                            ┌──────────────────┐
                            │ Decode chunk &   │
                            │ buffer += text   │
                            └────┬─────────────┘
                                 │
                            ┌────▼─────────────────┐
                            │ splitSSEBuffer()     │
                            │ → {lines, rest}      │
                            └────┬─────────────────┘
                                 │
                            ┌────▼───────────────┐
                            │ For each line:     │
                            │ parseSSELine()     │
                            │ → event obj        │
                            └────┬──────────────┘
                                 │
                            ┌────▼─────────────────┐
                            │ onEvent(evt)        │
                            │ (caller's handler)  │
                            └────┬────────────────┘
                                 │
                            (loop back to
                             isAborted check)
```

**Lines changed**: +43 (new shared utility), +10/-20 (Stories), +19/-31 (Audiobook), +56 (tests)  
**Test status**: All 348 vitest tests pass; typecheck clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->