### PR TITLE
fix: poll backend HTTP before WebSocket connect to avoid startup ECONNREFUSED

### DIFF
--- a/frontend/src/hooks/useRealtimeEvents.js
+++ b/frontend/src/hooks/useRealtimeEvents.js
@@ -12,9 +12,14 @@
  *   { kind: "ping" }  // keepalive, ignored
  */
 import { useEffect, useRef, useCallback } from 'react';
-import { wsUrl } from '../api/client';
+import { wsUrl, apiUrl } from '../api/client';
 
 const WS_EVENTS_URL = wsUrl('/ws/events');
+
+// HTTP health-check URL (derived from same base as WS). We poll this before
+// creating the WebSocket so the first attempt doesn't fail with ECONNREFUSED
+// when the Python backend hasn't finished starting Uvicorn (~14s on cold start).
+const HEALTH_CHECK_URL = `${apiUrl()}/model/status`;
 
 /**
  * @param {Object} handlers - Map of event kind → callback
@@ -33,10 +38,40 @@ export default function useRealtimeEvents(handlers) {
   // Keep handlers ref current without causing reconnects
   useEffect(() => { handlersRef.current = handlers; });
 
+  const scheduleReconnect = useCallback(() => {
+    if (!mountedRef.current) return;
+    const delay = Math.min(2000 * Math.pow(2, retryCountRef.current), 60_000);
+    retryCountRef.current++;
+    reconnectTimerRef.current = setTimeout(connect, delay);
+  }, []);
+
   const connect = useCallback(() => {
     if (!mountedRef.current) return;
     // Don't double-connect
     if (wsRef.current && wsRef.current.readyState <= 1) return;
+
+    // ── Phase 1: Wait for backend HTTP to be reachable ────────────────
+    // Background: the Python backend takes ~14s to import torch/fastapi/etc
+    // before Uvicorn starts. The frontend mounts faster, so the first
+    // WebSocket attempt always fails with code 1006. Polling HTTP first
+    // eliminates that noise and prevents the false "reconnecting" log.
+    fetch(HEALTH_CHECK_URL, { signal: AbortSignal.timeout(2000) })
+      .then(res => {
+        if (!res.ok) throw new Error(`health check returned ${res.status}`);
+        // Backend is up — proceed to Phase 2
+        if (!mountedRef.current) return;
+        if (wsRef.current && wsRef.current.readyState <= 1) return;
+        retryCountRef.current = 0; // reset backoff — health passed
+        openWebSocket();
+      })
+      .catch(() => {
+        // Backend not ready yet — schedule reconnect (no error log)
+        scheduleReconnect();
+      });
+  }, [scheduleReconnect]);
+
+  function openWebSocket() {
+    if (!mountedRef.current) return;
 
     try {
       const ws = new WebSocket(WS_EVENTS_URL);
@@ -84,7 +119,7 @@ export default function useRealtimeEvents(handlers) {
       retryCountRef.current++;
       reconnectTimerRef.current = setTimeout(connect, delay);
     }
-  }, []);
+  }
 
   useEffect(() => {
     mountedRef.current = true;


### PR DESCRIPTION
## Problem

The frontend mounts faster than the Python backend. `useRealtimeEvents` calls `new WebSocket(...)` immediately on mount, but the backend takes ~14s to import torch/fastapi/etc before Uvicorn starts. The WebSocket connection always fails with `code=1006` (ECONNREFUSED), triggering an unnecessary exponential-backoff reconnect before eventually succeeding.

The startup log shows:
```
[ws/events] closed (code=1006), reconnecting in 2000ms
[ws/events] closed (code=1006), reconnecting in 4000ms
[ws/events] closed (code=1006), reconnecting in 8000ms
[ws/events] connected  (after 18s)
```

No data is lost (the backend hasn't started emitting events yet), but the red log is noisy and misleading.

## Fix

Poll `/model/status` via HTTP `fetch` **before** creating the WebSocket. Once the backend responds 200, proceed to `openWebSocket()`. If the health check fails, schedule a reconnect with the same exponential backoff -- but without the noisy "closed (code=1006)" log.

`/model/status` is chosen because:
1. It's already polled by the TanStack Query hooks (in `useModelStatus`)
2. It always returns 200 once Uvicorn is running, even before models are loaded
3. It shares the same API base as the WS URL

## Changes

- `frontend/src/hooks/useRealtimeEvents.js` -- extracted `openWebSocket()` from `connect()`, added health-check phase before WS creation

## Testing

Tested manually: on cold start, the frontend now waits silently for the backend to respond before connecting the WS. No more `code=1006` log noise. The existing exponential-backoff reconnect still protects against legitimate disconnects at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a timing issue where the frontend WebSocket connection fails on cold start due to the Python backend taking ~14 seconds to initialize before Uvicorn starts serving requests. The frontend mounts faster and attempts an immediate WebSocket connection, resulting in error code 1006 (ECONNREFUSED) and noisy exponential-backoff reconnection logs appearing every 2-4 seconds.

### Changes

**File: `frontend/src/hooks/useRealtimeEvents.js`**

The hook now implements a two-phase connection strategy:

1. **Health Check Phase**: Before creating the WebSocket, the hook polls the `/model/status` HTTP endpoint (selected because it's already used by existing `useModelStatus` queries and returns 200 once Uvicorn is running)
2. **WebSocket Phase**: Only after the health check succeeds does the hook proceed to open the WebSocket connection

Key refactorings:
- Added `HEALTH_CHECK_URL` constant derived from the same API base as the WebSocket URL
- Extracted `scheduleReconnect()` helper to compute exponential backoff delays (2s, 4s, 8s, 16s, max 60s)
- Modified `connect()` to perform the health check first via a timed fetch (2-second abort timeout), then either reset the backoff counter and open the WebSocket on success, or schedule a reconnect on failure
- Extracted `openWebSocket()` as a separate function containing all WebSocket setup logic (onopen, onmessage, onclose, onerror handlers)

### Behavior Flow

```mermaid
graph TD
    A["Component mounts"] --> B["connect()"]
    B --> C["Fetch health check from /model/status<br/>Timeout: 2 seconds"]
    C -->|Success<br/>Response 200| D["Reset backoff counter"]
    D --> E["openWebSocket()"]
    E --> F["WebSocket connected<br/>Listen for events"]
    C -->|Failure| G["scheduleReconnect()"]
    G -->|Exponential backoff| H["Wait: 2s × 2^retries<br/>Max 60s"]
    H --> B
    F -->|WebSocket closes| I["scheduleReconnect()"]
    I --> H
```

### Benefits

- **Silent startup**: Frontend waits without misleading error logs while backend initializes
- **Preserved error handling**: Legitimate runtime disconnections still use exponential backoff
- **No data loss**: Backend hasn't emitted events during initial startup anyway
- **Backward compatible**: No changes to exported APIs or event handler signatures

Lines changed: +37/-2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->