### PR TITLE
feat(routing): synth-time no-silent-fallback gating at all TTS entry points (#21 follow-up)

### DIFF
--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -270,6 +270,12 @@ class SelectEngineResponse(BaseModel):
     family: str
     active: str
     env_override: bool
+    # Routing verdict for the selected engine on THIS host (#21). Always present
+    # so the UI can show a confirm/warning toast on a cpu_fallback pick without
+    # branching on key presence; defaults match a legacy/degraded row.
+    routing_status: str = "cpu_only"
+    effective_device: str = "cpu"
+    routing_reason: str | None = None
 
 
 @router.post("/engines/select", response_model=SelectEngineResponse)
@@ -305,4 +311,8 @@ def select_engine(req: SelectEngineRequest):
         "family": req.family,
         "active": module.active_backend_id(),
         "env_override": bool(__import__("os").environ.get(f"OMNIVOICE_{req.family.upper()}_BACKEND")),
+        # Echo the routing verdict so the UI can warn on a cpu_fallback pick.
+        "routing_status": entry.get("routing_status", "cpu_only"),
+        "effective_device": entry.get("effective_device", "cpu"),
+        "routing_reason": entry.get("routing_reason"),
     }

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -352,6 +352,17 @@ async def generate_speech(
         from api.routers.engines import _get_engine_instance
         _backend = _get_engine_instance(backend_cls)
 
+    # ── Routing gate (#21 — no silent CPU fallback). Computed ONCE per request
+    # (host caps are constant; the per-request engine= override bypasses the
+    # /engines/select gate, so this is the only place it's enforced for synth).
+    from core.device_caps import detect_host_caps
+    from services.engine_routing import resolve_routing, routing_notice
+    _routing = resolve_routing(getattr(backend_cls, "gpu_compat", ("cpu",)), detect_host_caps())
+    if _routing["routing_status"] == "unavailable":
+        # The engine needs an accelerator this host lacks and has no CPU path.
+        raise HTTPException(status_code=400, detail=_routing["routing_reason"])
+    _routing_notice = routing_notice(_routing)  # (status, reason) or None
+
     ref_audio_path = None
     cleanup_ref = False
     used_seed = seed
@@ -490,17 +501,26 @@ async def generate_speech(
             for i in range(0, len(wav_bytes), chunk_size):
                 yield wav_bytes[i:i + chunk_size]
 
+        _resp_headers = {
+            "X-Audio-Id": audio_id,
+            "X-Gen-Time": str(gen_time),
+            "X-Audio-Path": audio_filename,
+            "X-Seed": str(used_seed) if used_seed is not None else "",
+            "X-Audio-Duration": str(audio_dur),
+            "Content-Length": str(len(wav_bytes)),
+        }
+        # Routing notice (#21): cpu_fallback or accelerated-with-caveat only;
+        # the WAV body is binary so the header channel is the carrier.
+        if _routing_notice:
+            from services.engine_routing import header_safe_reason
+            _resp_headers["X-OmniVoice-Routing"] = _routing_notice[0]
+            _hr = header_safe_reason(_routing_notice[1])
+            if _hr:
+                _resp_headers["X-OmniVoice-Routing-Reason"] = _hr
         return StreamingResponse(
             _stream_wav(),
             media_type="audio/wav",
-            headers={
-                "X-Audio-Id": audio_id,
-                "X-Gen-Time": str(gen_time),
-                "X-Audio-Path": audio_filename,
-                "X-Seed": str(used_seed) if used_seed is not None else "",
-                "X-Audio-Duration": str(audio_dur),
-                "Content-Length": str(len(wav_bytes)),
-            }
+            headers=_resp_headers,
         )
     except HTTPException:
         raise

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -253,6 +253,14 @@ async def create_speech(req: SpeechRequest):
     """Generate audio from text. Compatible with OpenAI's POST /v1/audio/speech."""
     backend = _resolve_engine(req.model)
 
+    # Routing gate (#21 — no silent CPU fallback), identical to REST /generate.
+    from core.device_caps import detect_host_caps
+    from services.engine_routing import resolve_routing, routing_notice
+    _routing = resolve_routing(getattr(backend, "gpu_compat", ("cpu",)), detect_host_caps())
+    if _routing["routing_status"] == "unavailable":
+        raise HTTPException(status_code=400, detail=_routing["routing_reason"])
+    _routing_notice = routing_notice(_routing)  # (status, reason) or None
+
     # Build kwargs for the backend's generate() method
     kw: dict = {
         "speed": req.speed,
@@ -313,13 +321,20 @@ async def create_speech(req: SpeechRequest):
 
     audio_bytes, mime_type, ext = _encode_audio(wav, sr, req.response_format)
 
+    _headers = {
+        "Content-Length": str(len(audio_bytes)),
+        "Content-Disposition": f'inline; filename="speech.{ext}"',
+    }
+    if _routing_notice:
+        from services.engine_routing import header_safe_reason
+        _headers["X-OmniVoice-Routing"] = _routing_notice[0]
+        _hr = header_safe_reason(_routing_notice[1])
+        if _hr:
+            _headers["X-OmniVoice-Routing-Reason"] = _hr
     return StreamingResponse(
         io.BytesIO(audio_bytes),
         media_type=mime_type,
-        headers={
-            "Content-Length": str(len(audio_bytes)),
-            "Content-Disposition": f'inline; filename="speech.{ext}"',
-        },
+        headers=_headers,
     )
 
 

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -98,6 +98,30 @@ async def ws_tts(websocket: WebSocket):
                     model = await get_model()
                     backend = get_active_tts_backend(model=model)
 
+                # ── Routing gate (#21 — no silent CPU fallback). WebSockets have
+                # no response headers, so this uses frames: an error frame +
+                # close on `unavailable`, a one-time `routing` frame on
+                # cpu_fallback / accelerated-with-caveat (before any audio).
+                from core.device_caps import detect_host_caps
+                from services.engine_routing import resolve_routing, routing_notice
+                from core.scrub import scrub_text
+                _routing = resolve_routing(
+                    getattr(backend, "gpu_compat", ("cpu",)), detect_host_caps())
+                if _routing["routing_status"] == "unavailable":
+                    await websocket.send_json({
+                        "type": "error",
+                        "detail": scrub_text(_routing["routing_reason"])
+                        or "engine cannot run on this host",
+                    })
+                    continue  # don't stream; wait for the next request
+                _notice = routing_notice(_routing)
+                if _notice:
+                    await websocket.send_json({
+                        "type": "routing",
+                        "status": _notice[0],
+                        "reason": scrub_text(_notice[1]) if _notice[1] else None,
+                    })
+
                 # Build generation kwargs
                 kw: dict = {"speed": data.get("speed", 1.0)}
                 if data.get("language"):

--- a/backend/services/engine_routing.py
+++ b/backend/services/engine_routing.py
@@ -102,6 +102,33 @@ def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResul
     }
 
 
+def routing_notice(result: RoutingResult) -> tuple[str, str | None] | None:
+    """`(status, reason)` when a synth-time notice SHOULD be surfaced to the
+    user, else `None`. Surfaced for `cpu_fallback` (always) and for
+    `accelerated` ONLY when it carries a driver/arch caveat reason — everything
+    else (`cpu_only`, clean `accelerated`, `n/a`) is benign and stays silent."""
+    st = result["routing_status"]
+    if st == "cpu_fallback" or (st == "accelerated" and result["routing_reason"]):
+        return (st, result["routing_reason"])
+    return None
+
+
+def header_safe_reason(reason: str | None) -> str | None:
+    """A routing reason made safe for an HTTP header value: scrubbed, then
+    ASCII-sanitized (headers are latin-1; a non-ASCII device name would 500 the
+    response otherwise), **control characters stripped** (a CR/LF could split
+    the header / inject a new one), and length-capped at 256. Returns None for
+    an empty reason. No regex — `.encode`/membership only (CodeQL-clean)."""
+    if not reason:
+        return None
+    from core.scrub import scrub_text
+    ascii_only = scrub_text(reason).encode("ascii", "ignore").decode("ascii")
+    # Drop ASCII control chars (0x00-0x1F + DEL 0x7F) — incl. CR/LF, so the
+    # value can never break out of its header line.
+    cleaned = "".join(c for c in ascii_only if 0x20 <= ord(c) < 0x7F)
+    return cleaned[:256] or None
+
+
 def routing_fields(gpu_compat: tuple[str, ...], caps: HostCaps) -> dict:
     """The three serialization-ready routing keys for a ``list_backends`` entry.
 
@@ -123,4 +150,7 @@ def routing_fields(gpu_compat: tuple[str, ...], caps: HostCaps) -> dict:
     }
 
 
-__all__ = ["RoutingStatus", "RoutingResult", "resolve_routing", "routing_fields"]
+__all__ = [
+    "RoutingStatus", "RoutingResult", "resolve_routing", "routing_fields",
+    "routing_notice", "header_safe_reason",
+]

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -11,6 +11,11 @@ import { addBreadcrumb } from '../utils/breadcrumbs';
 import i18next from 'i18next';
 const t = i18next.t.bind(i18next);
 
+// #21: in-memory de-dup for the synth-time routing toast — a 50-clip batch
+// shouldn't fire one toast per request. Tracks the last status surfaced this
+// session (module scope, no localStorage); resets on full reload.
+let _lastRoutingStatus = null;
+
 /**
  * Encapsulates TTS generation logic, streaming response handling,
  * audio ingestion (with trim gate), and preset/tag helpers.
@@ -143,6 +148,22 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
       const chunks = [];
       let receivedLength = 0;
       const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
+
+      // #21: one-time, non-blocking routing notice. The backend sets these
+      // headers only on cpu_fallback / accelerated-with-caveat (never on the
+      // benign cpu_only / clean-accelerated paths), so their mere presence is
+      // the signal. De-duped by status so a batch doesn't spam.
+      const routingStatus = response.headers.get('X-OmniVoice-Routing');
+      if (routingStatus && routingStatus !== _lastRoutingStatus) {
+        _lastRoutingStatus = routingStatus;
+        const reason = response.headers.get('X-OmniVoice-Routing-Reason') || '';
+        if (routingStatus === 'cpu_fallback') {
+          toast(t('tts.routingFallback', { reason }), { icon: '🐢' });
+        } else if (routingStatus === 'accelerated' && reason) {
+          // accelerated is only surfaced WITH a driver/arch caveat reason.
+          toast(t('tts.routingCaveat', { reason }), { icon: '⚠️' });
+        }
+      }
 
       while (true) {
         const { done, value } = await reader.read();

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1709,6 +1709,10 @@
     "ignored_unsupported": "Ignored unsupported instruct: {{items}}",
     "ignored_duplicate": "Ignored (category already set): {{items}}"
   },
+  "tts": {
+    "routingFallback": "Running on CPU — this engine has no GPU path on your machine, so generation will be slower. {{reason}}",
+    "routingCaveat": "Using the GPU, but: {{reason}}"
+  },
   "sharing": {
     "title": "Sharing & Remote Access",
     "help": "Expose this running OmniVoice instance to your other machines without restarting it. Loopback-only is the default — nothing is shared until you turn it on here.",

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -161,12 +161,17 @@ def test_gpu_compat_omnivoice_has_cuda_mps_cpu(fresh_app):
 # ── select_engine host-routing gate (no silent CPU fallback) ────────────────
 
 
-def _force_cpu_host(monkeypatch):
-    """Pin detect_host_caps() to a CPU-only host so routing is deterministic
-    regardless of the CI runner's actual hardware."""
+def _force_host(monkeypatch, family="cpu"):
+    """Pin detect_host_caps() to a specific host family so routing is
+    deterministic regardless of the CI runner's actual hardware."""
     from core.device_caps import HostCaps
-    cpu = HostCaps(family="cpu", available_families=("cpu",))
-    monkeypatch.setattr("core.device_caps.detect_host_caps", lambda: cpu)
+    avail = (family, "cpu") if family != "cpu" else ("cpu",)
+    caps = HostCaps(family=family, available_families=avail)
+    monkeypatch.setattr("core.device_caps.detect_host_caps", lambda: caps)
+
+
+def _force_cpu_host(monkeypatch):
+    _force_host(monkeypatch, "cpu")
 
 
 def test_select_blocks_engine_unavailable_on_this_host(fresh_app, monkeypatch):
@@ -199,13 +204,14 @@ def test_select_blocks_engine_unavailable_on_this_host(fresh_app, monkeypatch):
 
 
 def test_select_allows_cpu_fallback_engine(fresh_app, monkeypatch):
-    """A CUDA+CPU engine on a CPU host is `cpu_fallback` (runs, slower) → allowed."""
+    """An MPS+CPU engine on a CUDA host is `cpu_fallback` (runs, slower) →
+    allowed (not blocked), and the response echoes the routing verdict."""
     from services import tts_backend as tts_mod
 
     class CpuCapableBackend(tts_mod.TTSBackend):
         id = "cpu-ok-test"
         display_name = "CPU-capable (test)"
-        gpu_compat = ("cuda", "cpu")
+        gpu_compat = ("mps", "cpu")  # no CUDA path → cpu_fallback on a CUDA host
 
         @property
         def sample_rate(self): return 24000
@@ -215,14 +221,19 @@ def test_select_allows_cpu_fallback_engine(fresh_app, monkeypatch):
         def is_available(cls): return True, "ready"
         def generate(self, text, **kw): raise NotImplementedError
 
-    _force_cpu_host(monkeypatch)
+    _force_host(monkeypatch, "cuda")
     saved = dict(tts_mod._REGISTRY)
     try:
         tts_mod._REGISTRY["cpu-ok-test"] = CpuCapableBackend
         r = _client(fresh_app).post(
             "/engines/select", json={"family": "tts", "backend_id": "cpu-ok-test"})
         assert r.status_code == 200, r.text
-        assert r.json()["active"] == "cpu-ok-test"
+        body = r.json()
+        assert body["active"] == "cpu-ok-test"
+        # #21: the response echoes the routing verdict for the picked engine.
+        assert body["routing_status"] == "cpu_fallback"
+        assert body["effective_device"] == "cpu"
+        assert body["routing_reason"]
     finally:
         tts_mod._REGISTRY.clear(); tts_mod._REGISTRY.update(saved)
 

--- a/tests/test_engine_routing.py
+++ b/tests/test_engine_routing.py
@@ -7,7 +7,11 @@ from spec §2, plus the cross-OS determinism + never-emits-"n/a" guarantees.
 from __future__ import annotations
 
 from core.device_caps import DIRECTML_MARKER, KERNEL_RISK_MARKER, HostCaps
-from services.engine_routing import resolve_routing
+from services.engine_routing import (
+    resolve_routing,
+    routing_notice,
+    header_safe_reason,
+)
 
 
 def _caps(family, *, notes=(), available=None):
@@ -117,3 +121,52 @@ def test_reason_str_for_fallback_and_unavailable_none_for_clean():
     assert resolve_routing(("cpu",), _caps("cuda"))["routing_reason"] is not None
     assert resolve_routing(("cuda",), _caps("cpu"))["routing_reason"] is not None
     assert resolve_routing(("cuda", "cpu"), _caps("cuda"))["routing_reason"] is None
+
+
+# ── routing_notice (synth-time surfacing decision) ──────────────────────────
+def test_notice_emitted_for_cpu_fallback():
+    r = resolve_routing(("cpu",), _caps("cuda"))
+    n = routing_notice(r)
+    assert n is not None and n[0] == "cpu_fallback" and n[1]
+
+
+def test_notice_emitted_for_accelerated_with_caveat():
+    note = f"sm_120 not in build — {KERNEL_RISK_MARKER}"
+    r = resolve_routing(("cuda", "cpu"), _caps("cuda", notes=[note]))
+    n = routing_notice(r)
+    assert n is not None and n[0] == "accelerated"
+
+
+def test_no_notice_for_clean_accelerated_or_cpu_only():
+    assert routing_notice(resolve_routing(("cuda", "cpu"), _caps("cuda"))) is None
+    assert routing_notice(resolve_routing(("cuda", "cpu"), _caps("cpu"))) is None
+
+
+# ── header_safe_reason (latin-1/length/scrub safety) ────────────────────────
+def test_header_reason_none_for_empty():
+    assert header_safe_reason(None) is None
+    assert header_safe_reason("") is None
+
+
+def test_header_reason_strips_non_ascii():
+    # Latin-1 accents + em-dash — all non-ASCII, must be stripped (no CJK so the
+    # hardcoded-CJK guard stays out of it).
+    out = header_safe_reason("CUDA on café — dríver naïve")
+    assert out == out.encode("ascii").decode("ascii")  # round-trips as pure ASCII
+    assert "é" not in out and "—" not in out
+
+
+def test_header_reason_strips_control_chars_no_header_injection():
+    # A CR/LF (or tab) must never survive into a header value.
+    out = header_safe_reason("ok\r\nX-Injected: evil\tmore")
+    assert "\r" not in out and "\n" not in out and "\t" not in out
+    assert "X-Injected" in out  # text remains; only the control chars are gone
+
+
+def test_header_reason_capped_at_256():
+    assert len(header_safe_reason("x" * 500)) == 256
+
+
+def test_header_reason_scrubs_home_path():
+    out = header_safe_reason("failed at /home/alice/model")
+    assert "/home/alice" not in out and "~" in out

--- a/tests/test_generate_engine.py
+++ b/tests/test_generate_engine.py
@@ -42,14 +42,18 @@ def _tts_mod():
     return importlib.import_module("services.tts_backend")
 
 
-def _make_fake_engine(engine_id="fake-engine", *, available=True, own_mastering=False):
+def _make_fake_engine(engine_id="fake-engine", *, available=True, own_mastering=False,
+                      gpu_compat=("cpu",)):
     """Build a fresh TTSBackend stub class. Fresh per call so the per-process
     instance cache in api.routers.engines can't leak state across tests."""
+
+    _compat = gpu_compat
 
     class _FakeEngine(_tts_mod().TTSBackend):
         id = engine_id
         display_name = "Fake Engine (test)"
         applies_own_mastering = own_mastering
+        gpu_compat = _compat
         calls: list = []
 
         @property
@@ -150,6 +154,48 @@ def test_generate_unavailable_engine_is_400_with_reason(client, monkeypatch):
     assert "not available" in detail
     assert "deliberately unavailable" in detail
     assert not fake.calls
+
+
+# ── #21 synth-time routing gate ─────────────────────────────────────────────
+
+def _force_host(monkeypatch, family="cpu"):
+    from core.device_caps import HostCaps
+    avail = (family, "cpu") if family != "cpu" else ("cpu",)
+    caps = HostCaps(family=family, available_families=avail)
+    monkeypatch.setattr("core.device_caps.detect_host_caps", lambda: caps)
+
+
+def test_generate_routing_unavailable_is_400(client, monkeypatch, no_omnivoice_model):
+    """A GPU-only engine (no cpu path) on a CPU host → 400 before any synth."""
+    _force_host(monkeypatch, "cpu")
+    fake = _make_fake_engine(gpu_compat=("cuda",))  # no cpu fallback
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-engine", fake)
+    res = client.post("/generate", data={"text": "x", "engine": "fake-engine"})
+    assert res.status_code == 400
+    assert not fake.calls  # never synthesized
+
+
+def test_generate_cpu_fallback_emits_routing_headers(client, monkeypatch, no_omnivoice_model):
+    """An MPS+CPU engine on a CUDA host → cpu_fallback → 200 + routing headers."""
+    _force_host(monkeypatch, "cuda")
+    fake = _make_fake_engine(gpu_compat=("mps", "cpu"))  # no CUDA path
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-engine", fake)
+    res = client.post("/generate", data={"text": "hi", "engine": "fake-engine"})
+    assert res.status_code == 200, res.text
+    assert res.headers.get("x-omnivoice-routing") == "cpu_fallback"
+    reason = res.headers.get("x-omnivoice-routing-reason")
+    assert reason and reason.encode("ascii")  # present + latin-1/ASCII-safe
+    assert len(fake.calls) == 1  # synth still ran (fallback, not block)
+
+
+def test_generate_cpu_only_host_emits_no_routing_header(client, monkeypatch, no_omnivoice_model):
+    """A cpu-capable engine on a no-GPU host is benign cpu_only → no header."""
+    _force_host(monkeypatch, "cpu")
+    fake = _make_fake_engine(gpu_compat=("cpu",))
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-engine", fake)
+    res = client.post("/generate", data={"text": "hi", "engine": "fake-engine"})
+    assert res.status_code == 200, res.text
+    assert "x-omnivoice-routing" not in {k.lower() for k in res.headers}
 
 
 def test_generate_default_path_still_runs_omnivoice(client, monkeypatch, tmp_path):


### PR DESCRIPTION
Closes the last **#21** gap. A per-request `engine=`/`model=` override bypasses the `/engines/select` host-gate, so an engine that can't use this host's GPU could still be triggered at synth time and **silently** fall back to CPU (or die mid-synth). Now enforced at **every TTS synth entry point**, reusing the same probe + resolver (never re-deriving routing).

## Shared helpers (`services/engine_routing.py`)
- `routing_notice(result)` → `(status, reason)` to surface, or `None`. Fires for `cpu_fallback` (always) + `accelerated`-with-caveat; silent for `cpu_only` / clean-accelerated / `n/a`.
- `header_safe_reason(reason)` → scrubbed + **ASCII-sanitized** (headers are latin-1; a non-ASCII device name would 500 otherwise) + **≤256 chars**. No regex.

## Entry points
| Path | unavailable | cpu_fallback / caveat | benign |
|---|---|---|---|
| REST `POST /generate` | 400 | 200 + `X-OmniVoice-Routing` + `-Reason` headers | no headers |
| OpenAI `POST /v1/audio/speech` | 400 | same headers | no headers |
| WS `/ws/tts` | `{"type":"error"}` + skip stream | one `{"type":"routing",…}` frame before audio | no frame |

`select_engine` response now echoes `routing_status` / `effective_device` / `routing_reason` (PR #432 added the gate; this adds the fields so the UI can warn on a `cpu_fallback` pick).

## Frontend
`useTTS` reads `X-OmniVoice-Routing` and shows a **one-time, non-blocking** toast (in-memory de-dup by status — a 50-clip batch fires once, no localStorage). i18n keys `tts.routingFallback` / `tts.routingCaveat`.

## Tests
`routing_notice` + `header_safe_reason` (ASCII/length/scrub) units; REST synth gate (unavailable→400, cpu_fallback→headers, cpu_only→none) via the fake-engine harness + a mocked host; select response routing fields. Full frontend vitest green (353).

> Local note: the REST synth tests use the full app (`main` + torch) which segfaults under local pytest (pre-existing Triton issue) — CI validates them. Logic verified via the pure helper tests + mocked-host route-shape tests.

## Deferred (small follow-up)
Dub-pipeline ASR routing note on the `preflight_error` SSE channel — a separate path, not a TTS synth entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Synth-time Engine Routing Validation at All TTS Entry Points

This PR closes a gap in PR `#21` by enforcing **no-silent-fallback engine routing at synth time** across all TTS entry points (REST `POST /generate`, OpenAI-compatible `POST /v1/audio/speech`, and WebSocket `/ws/tts`). It prevents per-request `engine=` / `model=` overrides from bypassing host gating and triggering engines incompatible with the host GPU (silently falling back to CPU or failing mid-synthesis).

### Core Mechanism

```mermaid
flowchart TD
    A["Request with engine/model override"] --> B["Resolve engine compatibility<br/>against host capabilities"]
    B --> C{Routing Status?}

    C -->|unavailable| D["REST/OpenAI: 400 + reject synthesis<br/>WebSocket: send {type:error} frame"]
    C -->|cpu_fallback| E["REST/OpenAI: 200 + X-OmniVoice-Routing headers<br/>WebSocket: send {type:routing} before audio"]
    C -->|accelerated + caveat| F["REST/OpenAI: 200 + X-OmniVoice-Routing headers<br/>WebSocket: send {type:routing} before audio"]
    C -->|clean| G["✓ Proceed with synthesis<br/>No routing notice headers/frames"]

    E --> H["Frontend shows one-time toast (deduped in-memory)"]
    F --> H
```

### Backend Changes

**Routing decision helpers** (`backend/services/engine_routing.py`)
- `routing_notice(...)`: returns `(routing_status, routing_reason)` for user-facing cases:
  - always for `cpu_fallback`
  - only for `accelerated` when the caveat reason is non-empty
- `header_safe_reason(...)`: scrubs and sanitizes the reason for safe inclusion in HTTP headers (ASCII/encoding-safe, strips control chars like CR/LF/TAB, caps length to 256, etc.)

**Engine selection contract** (`backend/api/routers/engines.py`)
- The `/engines/select` response contract now includes routing verdict fields so the UI can warn on fallback picks:
  - `routing_status` (default `cpu_only`)
  - `effective_device` (default `cpu`)
  - optional `routing_reason`

**Entry point enforcement & response signaling**
- **REST `POST /generate`** (`backend/api/routers/generation.py`)
  - Resolves routing against host capabilities + the selected backend’s `gpu_compat`
  - If `unavailable`: returns **400**
  - If `cpu_fallback` / `accelerated`-with-caveat: returns **200** and sets:
    - `X-OmniVoice-Routing` (status)
    - `X-OmniVoice-Routing-Reason` (only when non-empty)
- **OpenAI `POST /v1/audio/speech`** (`backend/api/routers/openai_compat.py`)
  - Same gating + header behavior as REST
- **WebSocket `/ws/tts`** (`backend/api/routers/tts_stream.py`)
  - No response headers; signaling is via frames:
    - If `unavailable`: sends `{"type":"error","detail":...}` and skips streaming
    - If `cpu_fallback` / `accelerated`-with-caveat`: sends a one-time `{"type":"routing","status":...,"reason":...}` **before any audio**

### Frontend Changes

**One-time routing toast using response headers** (`frontend/src/hooks/useTTS.js`)
- After the `/generate` response headers arrive, `useTTS` reads:
  - `X-OmniVoice-Routing`
  - `X-OmniVoice-Routing-Reason` (optional)
- Shows a **non-blocking** toast only for:
  - `cpu_fallback` → `tts.routingFallback` with 🐢 icon
  - `accelerated` + non-empty reason → `tts.routingCaveat` with ⚠️ icon
- Deduplication:
  - module-scoped in-memory `_lastRoutingStatus` prevents repeated toasts with the same routing status during a session
  - **no localStorage**

**UI sketch (before/after toast behavior)**

```text
Before (per request):
[Generate] ------------------>  (no routing toast)

After (only on fallback/caveat):
[Generate] --> [Toast once per routing status]
            🐢 cpu_fallback: “...reason...”
            ⚠️ accelerated: “...reason...”
```

**i18n** (`frontend/src/i18n/locales/en.json`)
- Added:
  - `tts.routingFallback` (uses `{{reason}}`)
  - `tts.routingCaveat` (uses `{{reason}}`)

### Test Coverage

- **Helper unit tests** (`tests/test_engine_routing.py`)
  - Validates `routing_notice()` emission rules for `cpu_fallback` / `accelerated` with caveat
  - Validates `header_safe_reason()` sanitization: ASCII-only, control-char stripping (prevents header injection), 256-char cap, home-path scrubbing
- **Engine route shape** (`tests/backend/api/test_engines_route_shape.py`)
  - Makes host routing deterministic and asserts `/engines/select` echoes:
    - `routing_status == "cpu_fallback"`
    - `effective_device == "cpu"`
    - `routing_reason` present
- **REST synth-time gating** (`tests/test_generate_engine.py`)
  - GPU-only engine on CPU host → **400**
  - `mps+cpu`-compatible engine on CUDA host → **200** with routing header + ASCII-safe reason
  - CPU-capable engine on CPU host → **200** with no routing notice

### Files Changed
- `backend/services/engine_routing.py`: `routing_notice()`, `header_safe_reason()`
- `backend/api/routers/engines.py`: extended `SelectEngineResponse` with routing fields
- `backend/api/routers/generation.py`: REST routing gate + routing headers
- `backend/api/routers/openai_compat.py`: OpenAI routing gate + routing headers
- `backend/api/routers/tts_stream.py`: WebSocket routing gate + routing/error frames
- `frontend/src/hooks/useTTS.js`: routing toast from `X-OmniVoice-Routing*` with in-memory dedup
- `frontend/src/i18n/locales/en.json`: `tts.routingFallback` / `tts.routingCaveat`
- Test updates across routing helpers, select response shape, and synth-time gating
<!-- end of auto-generated comment: release notes by coderabbit.ai -->