### PR TITLE
feat(ui): shared VoiceSelector component + SearchableSelect grouping (#22)

### DIFF
--- a/frontend/src/components/SearchableSelect.jsx
+++ b/frontend/src/components/SearchableSelect.jsx
@@ -32,6 +32,14 @@ export default function SearchableSelect({
   buttonStyle,
   buttonClassName = 'input-base',
   size = 'md',
+  // When true, emit a `.ss-group-label` header each time `option.group` changes
+  // (and `option.groupLabel` is non-empty) while walking the MAIN rows. Default
+  // false so the two pre-existing call sites are unaffected. (#22)
+  renderGroupHeaders = false,
+  // Gate which committed values get recorded as recents. Default records all
+  // (back-compat). VoiceSelector passes a guard so sentinel values
+  // ('' / preset: / auto:) never pollute the recents list. (#22)
+  isRecentable = () => true,
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -120,7 +128,7 @@ export default function SearchableSelect({
   const commit = (o) => {
     const v = getVal(o);
     onChange?.(v);
-    if (recentsKey) {
+    if (recentsKey && isRecentable(v)) {
       const next = [v, ...recents.filter(r => r !== v)].slice(0, 8);
       setRecents(next);
       writeRecents(recentsKey, next);
@@ -181,29 +189,41 @@ export default function SearchableSelect({
               </div>
             )}
 
-            {flatItems.map((it, idx) => {
+            {(() => { let lastGroup; return flatItems.map((it, idx) => {
               const v = getVal(it.o);
               const selected = v === value;
               const highlighted = idx === highlight;
+              // Group header: emitted lazily on the first MAIN row of a new
+              // group whose option carries a non-empty groupLabel (#22). Pinned
+              // recent/popular rows never trigger a header. `lastGroup` advances
+              // only on main rows so a pinned row can't swallow the first header.
+              const showHeader =
+                renderGroupHeaders &&
+                it.kind === 'main' &&
+                it.o && it.o.groupLabel &&
+                it.o.group !== lastGroup;
+              if (it.kind === 'main') lastGroup = it.o?.group;
               return (
-                <div
-                  key={`${it.kind}-${v}-${idx}`}
-                  data-idx={idx}
-                  className={`ss-option ${highlighted ? 'ss-hl' : ''} ${selected ? 'ss-sel' : ''}`}
-                  onMouseEnter={() => setHighlight(idx)}
-                  onMouseDown={(e) => { e.preventDefault(); commit(it.o); }}
-                  role="option"
-                  aria-selected={selected}
-                >
-                  {it.kind === 'recent' && <Clock size={9} className="ss-kind-icon"/>}
-                  {it.kind === 'popular' && <Star size={9} className="ss-kind-icon"/>}
-                  <span className="ss-option-label">
-                    {renderOption ? renderOption(it.o) : getLabel(it.o)}
-                  </span>
-                  {selected && <Check size={10} className="ss-check"/>}
-                </div>
+                <React.Fragment key={`${it.kind}-${v}-${idx}`}>
+                  {showHeader && <div className="ss-group-label">{it.o.groupLabel}</div>}
+                  <div
+                    data-idx={idx}
+                    className={`ss-option ${highlighted ? 'ss-hl' : ''} ${selected ? 'ss-sel' : ''}`}
+                    onMouseEnter={() => setHighlight(idx)}
+                    onMouseDown={(e) => { e.preventDefault(); commit(it.o); }}
+                    role="option"
+                    aria-selected={selected}
+                  >
+                    {it.kind === 'recent' && <Clock size={9} className="ss-kind-icon"/>}
+                    {it.kind === 'popular' && <Star size={9} className="ss-kind-icon"/>}
+                    <span className="ss-option-label">
+                      {renderOption ? renderOption(it.o) : getLabel(it.o)}
+                    </span>
+                    {selected && <Check size={10} className="ss-check"/>}
+                  </div>
+                </React.Fragment>
               );
-            })}
+            }); })()}
 
             {!query && filtered.length > MAX_DISPLAY && (
               <div className="ss-more">{t('common.showing_of', { shown: MAX_DISPLAY, total: filtered.length })}</div>

--- a/frontend/src/components/VoiceSelector.css
+++ b/frontend/src/components/VoiceSelector.css
@@ -1,0 +1,45 @@
+/* Shared voice picker (#22): the SearchableSelect grows to fill, adornment
+   buttons sit to its right. */
+.voice-selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.voice-selector > .ss-wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.voice-selector__adornments {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+.voice-selector__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--chrome-border, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  background: transparent;
+  color: var(--chrome-fg-muted, #999);
+  cursor: pointer;
+}
+.voice-selector__btn:hover:not(:disabled) {
+  color: var(--chrome-fg, #eee);
+  border-color: var(--chrome-border-strong, rgba(255, 255, 255, 0.22));
+}
+.voice-selector__btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.voice-selector__spin {
+  animation: voice-selector-spin 0.8s linear infinite;
+}
+@keyframes voice-selector-spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/components/VoiceSelector.jsx
+++ b/frontend/src/components/VoiceSelector.jsx
@@ -1,0 +1,190 @@
+import React, { useMemo } from 'react';
+import { Play, Loader, ExternalLink, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import SearchableSelect from './SearchableSelect';
+import { PRESETS } from '../utils/constants';
+import './VoiceSelector.css';
+
+/**
+ * Shared voice picker (#22) — one searchable, grouped control used everywhere a
+ * voice is chosen (Stories cast, Audiobook default, Dub segments). A thin,
+ * controlled wrapper over {@link SearchableSelect}: it builds a group-ordered
+ * options array and surfaces optional preview / gallery-jump / create
+ * adornments. It owns NO audio and makes NO API calls — it only emits the
+ * selected value string and hands click events to the parent's callbacks.
+ *
+ * Value contract (identical to what every existing call site already sends to
+ * the backend, so project data stays byte-compatible):
+ *   '' (engine default) | '<profileId>' | 'preset:<id>' | 'auto:<slug>'
+ *
+ * Group order is fixed: default → fromVideo (dub only) → clone → designed →
+ * preset. Clone-vs-designed splits on the runtime `.instruct` string (matching
+ * VoicePreview/DubSegmentRow), NOT `profile.kind`.
+ *
+ * @param {string}   value            controlled value (see contract above)
+ * @param {(v:string)=>void} onChange commits a new value
+ * @param {Array}    [profiles=[]]    voice profiles ({id,name,instruct?})
+ * @param {boolean}  [presets=false]  include the PRESETS character group
+ * @param {Object}   [speakerClones=null] dub from-video speakers ({name: ...})
+ * @param {boolean}  [engineDefault=true] include the '' engine-default row
+ * @param {string}   [defaultLabel]   overrides the '' row label (Stories "↳ Aria")
+ * @param {(v:string)=>void} [onPreview]   render a preview button → calls this
+ * @param {boolean}  [previewLoading=false] show a spinner + disable preview
+ * @param {()=>void} [onJumpToGallery] render a gallery-jump button → calls this
+ * @param {()=>void} [onCreateVoice]  render an inline "create voice" button
+ * @param {string}   [recentsKey='']  persist recents under this key (real ids only)
+ * @param {string}   [placeholder]    trigger placeholder when nothing resolves
+ */
+export default function VoiceSelector({
+  value = '',
+  onChange,
+  profiles = [],
+  presets = false,
+  speakerClones = null,
+  engineDefault = true,
+  defaultLabel,
+  onPreview,
+  previewLoading = false,
+  onJumpToGallery,
+  onCreateVoice,
+  recentsKey = '',
+  placeholder,
+  disabled = false,
+  size = 'md',
+  buttonClassName,
+}) {
+  const { t } = useTranslation();
+
+  const options = useMemo(() => {
+    const list = [];
+
+    // 1. engine-default sentinel — FIRST, no group header (groupLabel '').
+    if (engineDefault) {
+      list.push({
+        value: '',
+        label: defaultLabel || t('voiceSelector.engineDefault'),
+        group: 'default',
+        groupLabel: '',
+      });
+    }
+
+    // 2. fromVideo (dub only) — slug rule byte-identical to DubSegmentRow.
+    const speakers = speakerClones ? Object.keys(speakerClones) : [];
+    for (const spk of speakers) {
+      const slug = (spk || '').toLowerCase().replace(/\s+/g, '_');
+      list.push({
+        value: `auto:${slug}`,
+        label: `🎤 ${spk}`,
+        group: 'fromVideo',
+        groupLabel: t('voiceSelector.fromVideo'),
+      });
+    }
+
+    // 3 & 4. clone vs designed — split on runtime `.instruct` (not .kind).
+    const clones = profiles.filter((p) => !p.instruct);
+    const designed = profiles.filter((p) => !!p.instruct);
+    for (const p of clones) {
+      list.push({
+        value: p.id,
+        label: p.name?.trim() || p.id,
+        group: 'clone',
+        groupLabel: t('voiceSelector.clone'),
+      });
+    }
+    for (const p of designed) {
+      list.push({
+        value: p.id,
+        label: p.name?.trim() || p.id,
+        group: 'designed',
+        groupLabel: t('voiceSelector.designed'),
+      });
+    }
+
+    // 5. presets.
+    if (presets) {
+      for (const p of PRESETS) {
+        list.push({
+          value: `preset:${p.id}`,
+          label: p.name,
+          group: 'preset',
+          groupLabel: t('voiceSelector.presets'),
+        });
+      }
+    }
+
+    // Ghost: a real profile id is selected but the profile is gone (deleted but
+    // still referenced by a track/segment/default). Render a human label so the
+    // trigger isn't the raw id — but DON'T auto-clear (that mutates user data).
+    const isSentinel = !value || value.startsWith('preset:') || value.startsWith('auto:');
+    if (!isSentinel && !list.some((o) => o.value === value)) {
+      list.push({
+        value,
+        label: t('voiceSelector.missingVoice'),
+        group: 'clone',
+        groupLabel: t('voiceSelector.clone'),
+      });
+    }
+
+    return list;
+  }, [profiles, presets, speakerClones, engineDefault, defaultLabel, value, t]);
+
+  // Only real profile ids are worth recording as recents.
+  const isRecentable = (v) => !!v && !v.startsWith('preset:') && !v.startsWith('auto:');
+
+  return (
+    <div className="voice-selector">
+      <SearchableSelect
+        value={value}
+        onChange={onChange}
+        options={options}
+        renderGroupHeaders
+        isRecentable={isRecentable}
+        recentsKey={recentsKey}
+        placeholder={placeholder || t('voiceSelector.engineDefault')}
+        disabled={disabled}
+        size={size}
+        buttonClassName={buttonClassName}
+      />
+      {(onPreview || onJumpToGallery || onCreateVoice) && (
+        <div className="voice-selector__adornments">
+          {onPreview && (
+            <button
+              type="button"
+              className="voice-selector__btn"
+              onClick={() => onPreview(value)}
+              disabled={previewLoading}
+              aria-label={t('voiceSelector.preview')}
+              title={t('voiceSelector.preview')}
+            >
+              {previewLoading
+                ? <Loader size={13} className="voice-selector__spin" />
+                : <Play size={13} />}
+            </button>
+          )}
+          {onJumpToGallery && (
+            <button
+              type="button"
+              className="voice-selector__btn"
+              onClick={() => onJumpToGallery()}
+              aria-label={t('voiceSelector.openGallery')}
+              title={t('voiceSelector.openGallery')}
+            >
+              <ExternalLink size={13} />
+            </button>
+          )}
+          {onCreateVoice && (
+            <button
+              type="button"
+              className="voice-selector__btn"
+              onClick={() => onCreateVoice()}
+              aria-label={t('voiceSelector.createVoice')}
+              title={t('voiceSelector.createVoice')}
+            >
+              <Plus size={13} />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1713,6 +1713,17 @@
     "routingFallback": "Running on CPU — this engine has no GPU path on your machine, so generation will be slower. {{reason}}",
     "routingCaveat": "Using the GPU, but: {{reason}}"
   },
+  "voiceSelector": {
+    "engineDefault": "Engine default",
+    "clone": "Cloned voices",
+    "designed": "Designed voices",
+    "presets": "Presets",
+    "fromVideo": "From video",
+    "missingVoice": "Voice not found (re-pick)",
+    "preview": "Preview voice",
+    "openGallery": "Open in Voice Gallery",
+    "createVoice": "Create a new voice"
+  },
   "sharing": {
     "title": "Sharing & Remote Access",
     "help": "Expose this running OmniVoice instance to your other machines without restarting it. Loopback-only is the default — nothing is shared until you turn it on here.",

--- a/frontend/src/test/VoiceSelector.test.jsx
+++ b/frontend/src/test/VoiceSelector.test.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+
+import VoiceSelector from '../components/VoiceSelector';
+
+const PROFILES = [
+  { id: 'p_clone', name: 'Aria' },               // falsy instruct → clone
+  { id: 'p_design', name: 'Narrator', instruct: 'warm, deep' }, // designed
+];
+
+function open() {
+  // The trigger is the only button until the popup opens.
+  fireEvent.click(screen.getAllByRole('button')[0]);
+}
+
+describe('VoiceSelector', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // jsdom doesn't implement scrollIntoView; SearchableSelect calls it on open.
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('renders engine-default first, then grouped clone/designed options', () => {
+    render(<VoiceSelector value="" onChange={vi.fn()} profiles={PROFILES} />);
+    // trigger shows the engine-default label
+    expect(screen.getByRole('button', { name: /Engine default/ })).toBeInTheDocument();
+    open();
+    expect(screen.getByText('Aria')).toBeInTheDocument();
+    expect(screen.getByText('Narrator')).toBeInTheDocument();
+    // group headers present (designed split from clone)
+    expect(screen.getByText('Cloned voices')).toBeInTheDocument();
+    expect(screen.getByText('Designed voices')).toBeInTheDocument();
+  });
+
+  it('commits the profile id (value contract) on click', () => {
+    const onChange = vi.fn();
+    render(<VoiceSelector value="" onChange={onChange} profiles={PROFILES} />);
+    open();
+    fireEvent.mouseDown(screen.getByText('Aria'));
+    expect(onChange).toHaveBeenCalledWith('p_clone');
+  });
+
+  it('emits preset:<id> values when presets enabled', () => {
+    const onChange = vi.fn();
+    render(<VoiceSelector value="" onChange={onChange} profiles={[]} presets />);
+    open();
+    expect(screen.getByText('Presets')).toBeInTheDocument();
+    // the first preset row commits a preset: value
+    const presetRow = screen.getAllByRole('option').find(
+      (el) => el.textContent && /Authoritative|Preset|🎙/.test(el.textContent),
+    );
+    // fall back to any non-default option if preset names change
+    fireEvent.mouseDown(presetRow || screen.getAllByRole('option')[1]);
+    expect(onChange.mock.calls[0][0]).toMatch(/^preset:/);
+  });
+
+  it('slugs from-video speakers to auto:<slug> (byte-identical to dub)', () => {
+    const onChange = vi.fn();
+    render(
+      <VoiceSelector value="" onChange={onChange} profiles={[]}
+        speakerClones={{ 'Speaker 1': {} }} />,
+    );
+    open();
+    expect(screen.getByText('From video')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByText('🎤 Speaker 1'));
+    expect(onChange).toHaveBeenCalledWith('auto:speaker_1');
+  });
+
+  it('renders a ghost row (does NOT auto-clear) for a deleted-but-referenced voice', () => {
+    const onChange = vi.fn();
+    render(<VoiceSelector value="p_gone" onChange={onChange} profiles={PROFILES} />);
+    // trigger shows a human label, not the raw id
+    expect(screen.getByRole('button', { name: /Voice not found/ })).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();  // value preserved
+  });
+
+  it('does NOT record sentinel values (engine-default) as recents', () => {
+    const onChange = vi.fn();
+    render(<VoiceSelector value="p_clone" onChange={onChange} profiles={PROFILES} recentsKey="vs_test" />);
+    open();
+    // pick engine default ('')
+    fireEvent.mouseDown(screen.getByText('Engine default'));
+    expect(onChange).toHaveBeenCalledWith('');
+    const recents = JSON.parse(window.localStorage.getItem('vs_test') || '[]');
+    expect(recents).not.toContain('');
+  });
+
+  it('DOES record a real profile id as a recent', () => {
+    render(<VoiceSelector value="" onChange={vi.fn()} profiles={PROFILES} recentsKey="vs_test2" />);
+    open();
+    fireEvent.mouseDown(screen.getByText('Aria'));
+    const recents = JSON.parse(window.localStorage.getItem('vs_test2') || '[]');
+    expect(recents).toContain('p_clone');
+  });
+
+  it('renders a preview button only when onPreview is provided, passing the current value', () => {
+    const onPreview = vi.fn();
+    const { rerender } = render(
+      <VoiceSelector value="p_clone" onChange={vi.fn()} profiles={PROFILES} onPreview={onPreview} />,
+    );
+    const previewBtn = screen.getByRole('button', { name: /Preview voice/ });
+    fireEvent.click(previewBtn);
+    expect(onPreview).toHaveBeenCalledWith('p_clone');
+
+    // absent without the prop
+    rerender(<VoiceSelector value="p_clone" onChange={vi.fn()} profiles={PROFILES} />);
+    expect(screen.queryByRole('button', { name: /Preview voice/ })).not.toBeInTheDocument();
+  });
+
+  it('disables the preview button while previewLoading', () => {
+    render(
+      <VoiceSelector value="p_clone" onChange={vi.fn()} profiles={PROFILES}
+        onPreview={vi.fn()} previewLoading />,
+    );
+    expect(screen.getByRole('button', { name: /Preview voice/ })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
A single searchable, **grouped** voice picker to replace the per-tab `<select>`s across Stories / Audiobook / Dub. This slice ships the **component + the two `SearchableSelect` extensions it needs**; the 4 call-site migrations are a deliberate follow-up (component lands first, tested in isolation — matches the spec's PR slicing).

## `SearchableSelect` — two opt-in, backward-compatible props
Both existing call sites are untouched and render identically (defaults preserve old behavior).
- **`renderGroupHeaders`** (default `false`) — emits a `.ss-group-label` header on the first MAIN row of each new `option.group` with a non-empty `groupLabel`. Pinned recent/popular rows never trigger one; empty/filtered-out groups never emit a stray header.
- **`isRecentable`** (default `() => true`) — gates which committed values get recorded as recents.

## `VoiceSelector`
- Group-ordered options (`default → fromVideo → clone → designed → preset`) over the **existing value contract** (`'' | id | preset:<id> | auto:<slug>`) — byte-identical to what every call site already sends, so **project data stays compatible**.
- Clone-vs-designed splits on the runtime `.instruct` string (matching `VoicePreview`), **not** `.kind`.
- Optional **preview / gallery-jump / create** adornments. The component owns no audio and makes no API call — it emits the value string and fires the parent's callbacks.
- A **deleted-but-referenced** voice renders a "Voice not found (re-pick)" ghost row **without auto-clearing** the value (no silent project-data mutation).
- `isRecentable` excludes `''` / `preset:` / `auto:` so only real voices become recents.
- i18n under `voiceSelector.*` (en.json; other locales fall back via `fallbackLng`, the project's established pattern).

## Tests
9 RTL cases — grouping/headers, value contract for id/preset/auto, from-video slug parity, ghost row (no auto-clear), recents guard (sentinels excluded / real ids kept), preview button presence+value+loading. Full frontend vitest green (**362**); `typecheck:ci` clean; CJK guard green.

## Follow-up (next slice)
Migrate the 4 call sites (StoriesEditor cast, AudiobookTab default, DubSegmentRow, etc.) onto `<VoiceSelector>` + thread the `onOpenVoicePreview` closure. Kept separate so a working component merges before touching live pickers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## SearchableSelect: opt-in grouped headers + controllable recents writes

### What changed
**`frontend/src/components/SearchableSelect.jsx`**
- Added **`renderGroupHeaders`** (default `false`): when enabled, inserts a `.ss-group-label` row *only* before the first **MAIN** option of each new `option.group`, using `option.groupLabel` when it’s non-empty. Pinned recent/popular rows do **not** trigger headers and won’t “swallow” the first MAIN header.
- Added **`isRecentable`** (default `() => true`): during commit, recents are written to `localStorage` only when `recentsKey` is set **and** `isRecentable(selectedValue)` returns `true`.

### UI sketch (dropdown list)
```
BEFORE
┌─ ss-pop (pinned recents/popular) ─┐
│  (Clock/Star label row)          │
├─ ss-list ───────────────────────┤
│  Item A                         │
│  Item B                         │
│  Item C                         │
└──────────────────────────────────┘

AFTER (renderGroupHeaders=true)
┌─ ss-pop (pinned recents/popular) ─┐
│  (Clock/Star label row)          │
├─ ss-list ───────────────────────┤
│  Item A                         │
│  ─ GROUP A ─                     │  ← inserted before first MAIN row of group
│  Item B                         │
│  ─ GROUP B ─                     │  ← inserted before first MAIN row of group
│  Item C                         │
└──────────────────────────────────┘
```

### Recents + header mechanisms
```mermaid
flowchart TD
  A[User commits an option] --> B[SearchableSelect commit() => onChange(value)]
  B --> C{recentsKey set AND isRecentable(value)?}
  C -- yes --> D[Write updated recents list to localStorage]
  C -- no --> E[Skip recents write]
  B --> F[Close dropdown]
```

---

## VoiceSelector: shared grouped voice picker (Stories / Audiobook / Dub)

**`frontend/src/components/VoiceSelector.jsx` + `frontend/src/components/VoiceSelector.css`**
- Introduced a new **`VoiceSelector`** component that wraps `SearchableSelect` and emits the existing value contract:
  - `''` (engine default) | `<profileId>` | `preset:<id>` | `auto:<slug>`
- Builds grouped options in fixed order:
  1. engine-default
  2. fromVideo (`auto:<slug>`; slug rules match DubSegmentRow)
  3. clone
  4. designed
  5. presets (optional)
- **Clone vs designed split** is determined by runtime `profile.instruct` presence (**not** `profile.kind`).
- **Ghost row behavior:** if `value` is a real profile id that no longer exists in `profiles`, the dropdown includes a **“Voice not found (re-pick)”**-labeled option, but **does not auto-clear** the incoming `value` (the prop remains controlled).
- **Recents filtering:** only real voice ids are eligible for recents (excludes sentinel values `''`, `preset:*`, `auto:*` via `isRecentable` passed to `SearchableSelect`).
- Optional adornments on the right:
  - Preview button (shows spinner + disabled when `previewLoading=true`)
  - Gallery jump button
  - Create voice button

### UI/layout sketch (component)
```
VoiceSelector (flex row)
┌────────────────────────────────────────────┐
│  SearchableSelect (fills available width) │
│                                            │
│                      [adornments right]   │
│                      [▶] [↗] [+]         │
└────────────────────────────────────────────┘
```

### Options construction + ghost handling
```mermaid
flowchart TD
  A[Build options list] --> B[Add engine-default '' (if enabled)]
  B --> C[Add fromVideo -> auto:<slug> (if speakerClones)]
  C --> D[Split profiles: instruct? => designed else clone]
  D --> E[Add presets if presets=true]
  E --> F{value is sentinel? ('', preset:*, auto:*)}
  F -- yes --> G[No ghost row]
  F -- no --> H{value exists in options?}
  H -- yes --> G
  H -- no --> I[Append ghost option with "Voice not found (re-pick)"]
```

---

## Internationalization
**`frontend/src/i18n/locales/en.json`**
- Added `voiceSelector.*` namespace keys (English), used for group labels and actions (engine default, from video, clone/designed/presets, missing voice, preview, gallery, create).

---

## Testing
**`frontend/src/test/VoiceSelector.test.jsx`**
- Added a Vitest suite covering:
  - group ordering + clone/designed split
  - value contract emissions (`<id>`, `preset:<id>`, `auto:<slug>`)
  - ghost row rendering without auto-clearing
  - recents filtering via `recentsKey` (excludes sentinels)
  - preview button rendering, click, and disabled state when `previewLoading=true`

---

## Migration
- Call-site migrations (StoriesEditor, AudiobookTab, DubSegmentRow) are intentionally deferred to a follow-up PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->