### PR TITLE
feat(audiobook): persist metadata/script/prefs via LongformProject store (#31b)

### DIFF
--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -7,6 +7,7 @@ import {
 } from '../api/audiobook';
 import { audioUrl } from '../api/generate';
 import { consumeLongformStream } from '../utils/longformStream';
+import { useAppStore } from '../store';
 import './AudiobookTab.css';
 
 /**
@@ -18,8 +19,17 @@ import './AudiobookTab.css';
  */
 export default function AudiobookTab({ profiles = [] }) {
   const { t } = useTranslation();
-  const [text, setText] = useState('');
-  const [defaultVoice, setDefaultVoice] = useState('');
+  // Persisted via the unified LongformProject store (#31b) — book identity,
+  // script, voice, and output prefs now survive a tab switch / reload (they
+  // used to live in component useState and evaporate).
+  const text = useAppStore((s) => s.script);
+  const setText = useAppStore((s) => s.setScript);
+  const defaultVoice = useAppStore((s) => s.defaultVoice) ?? '';  // select coerces null→''
+  const setOutputPrefs = useAppStore((s) => s.setOutputPrefs);
+  const setProjectMeta = useAppStore((s) => s.setProjectMeta);
+  const setLexiconStore = useAppStore((s) => s.setLexicon);
+  const storeLexicon = useAppStore((s) => s.lexicon);
+  const setDefaultVoice = (v) => setOutputPrefs({ defaultVoice: v || null });
   const [plan, setPlan] = useState(null);
   const [planLoading, setPlanLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
@@ -30,23 +40,44 @@ export default function AudiobookTab({ profiles = [] }) {
   const [chapterPrev, setChapterPrev] = useState({}); // index → {url, loading}
   const abortRef = useRef(false);
 
-  // Output + metadata (embedded in the file; players show these).
-  const [format, setFormat] = useState('m4b');      // 'm4b' | 'mp3'
-  const [loudness, setLoudness] = useState('off');  // 'off' | 'acx' | 'podcast'
-  const [meta, setMeta] = useState({
-    title: '', author: '', narrator: '', year: '', genre: '', description: '',
-  });
+  // Output prefs + metadata (embedded in the file; players show these) — now
+  // store-backed. `meta` is default-filled so every controlled input gets a
+  // defined string (an empty store record never flips a controlled→uncontrolled).
+  const format = useAppStore((s) => s.outputFormat);     // 'm4b' | 'mp3'
+  const setFormat = (v) => setOutputPrefs({ outputFormat: v });
+  const loudness = useAppStore((s) => s.loudness);        // 'off' | 'acx' | 'podcast'
+  const setLoudness = (v) => setOutputPrefs({ loudness: v });
+  const metaStore = useAppStore((s) => s.meta);
+  const meta = { title: '', author: '', narrator: '', year: '', genre: '', description: '', ...metaStore };
+  const setMetaField = (k) => (e) => setProjectMeta({ [k]: e.target.value });
+
+  // Cover stays component-local (a File/blob can't persist to localStorage;
+  // coverRef persistence is a noted follow-up).
   const [coverFile, setCoverFile] = useState(null);
   const [coverPreview, setCoverPreview] = useState('');
-  // Pronunciation lexicon: editable {word → respelling} rows.
+
+  // Pronunciation lexicon: editable {word → respelling} rows. Rows stay LOCAL
+  // (half-typed rows aren't junk-persisted); the filtered dict flushes to the
+  // store so it survives a reload, and hydrates back into rows on mount.
   const [lex, setLex] = useState([]); // [{ word, say }]
+  const lexHydrated = useRef(false);
+  useEffect(() => {
+    if (lexHydrated.current) return;
+    lexHydrated.current = true;
+    const rows = Object.entries(storeLexicon || {}).map(([word, say]) => ({ word, say }));
+    if (rows.length) setLex(rows);
+  }, [storeLexicon]);
   const lexDict = () => Object.fromEntries(
     lex.filter((r) => r.word.trim() && r.say.trim()).map((r) => [r.word.trim(), r.say.trim()]),
   );
+  // Flush the filtered dict to the store whenever rows change (after hydration).
+  useEffect(() => {
+    if (!lexHydrated.current) return;
+    setLexiconStore(lexDict());
+  }, [lex]); // eslint-disable-line react-hooks/exhaustive-deps
   const setLexRow = (i, k) => (e) => setLex((rows) => rows.map((r, j) => (j === i ? { ...r, [k]: e.target.value } : r)));
   const addLexRow = () => setLex((rows) => [...rows, { word: '', say: '' }]);
   const removeLexRow = (i) => setLex((rows) => rows.filter((_, j) => j !== i));
-  const setMetaField = (k) => (e) => setMeta((m) => ({ ...m, [k]: e.target.value }));
 
   const onCoverPick = useCallback((e) => {
     const f = e.target.files?.[0];


### PR DESCRIPTION
Binds Audiobook's script / default voice / output format / loudness / book metadata / lexicon to the unified store (#31a) instead of component `useState` — so they **survive a tab switch / reload** (previously all lost). The headline #31 win.

- `meta` is default-filled (empty record never flips a controlled input to uncontrolled). Lexicon rows stay local (half-typed rows not junk-persisted); the filtered dict flushes to the store + hydrates back on mount. Transient state (plan/generating/progress/output/previews) stays local — correctly not persisted.

**Deferred (noted):** `coverRef` persistence (blob can't go to localStorage); the "Save as named project" + Projects-list card + App `onOpenStory` mode-aware routing (criterion 4). This slice = working-state persistence (criterion 3).

Full vitest green (357); typecheck:ci clean; CJK guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements persistent storage for the Audiobook feature by binding the script, voice, output format, loudness, and book metadata to a unified `LongformProject` store, replacing component-level state. This ensures user input survives tab switches and page reloads, addressing a critical usability gap (`#31`).

### Key Changes in AudiobookTab.jsx

**Persistent State (now store-backed):**
- `text` → `useAppStore` binding to `script`, updated via `setScript()`
- `defaultVoice` → store binding, wrapped via `setOutputPrefs({ defaultVoice })`
- `format` → `outputFormat` binding, wrapped via `setOutputPrefs({ outputFormat })`
- `loudness` → store binding, wrapped via `setOutputPrefs({ loudness })`
- `meta` (title, author, narrator, year, genre, description) → store binding with merge semantics via `setProjectMeta()`

**Default-filled controlled inputs:** All metadata fields are default-filled with empty strings to prevent controlled inputs from becoming uncontrolled when the store object is empty:
```javascript
const meta = { title: '', author: '', narrator: '', year: '', genre: '', description: '', ...metaStore };
```

**Hybrid Lexicon Model (local rows + store dictionary):**
- Editable lexicon rows remain component-local state (no junk persistence of half-typed entries)
- Rows are hydrated once from store on mount via `useEffect`
- Filtered dictionary (non-empty word/say pairs) is flushed to store whenever rows change
- Round-trip preserves user intent without persisting incomplete data

**Transient State (remains component-local):**
- `plan`, `generating`, `progress`, `output`, `chapterPrev` — generation workflow state, not persisted
- `coverFile`, `coverPreview` — temporary blob references; `coverRef` persistence deferred to follow-up

### Data Flow Diagram

```
┌─────────────────────────────────────────────────────┐
│                   AudiobookTab Mount                │
└──────────────────┬──────────────────────────────────┘
                   │
        ┌──────────v──────────┐
        │ Hydrate from Store:  │
        │ • script            │
        │ • defaultVoice      │
        │ • outputFormat      │
        │ • loudness          │
        │ • meta (w/ defaults)│
        │ • lexicon → rows    │
        └──────────┬──────────┘
                   │
        ┌──────────v──────────────────────────┐
        │   User Edits (e.target.value)      │
        │   • Script textarea                │
        │   • Voice/format/loudness selects  │
        │   • Meta input fields              │
        │   • Lexicon word/respelling rows   │
        └──────────┬──────────────────────────┘
                   │
     ┌─────────────v─────────────┐
     │ Flush to Store            │
     │ • setScript()             │
     │ • setOutputPrefs({…})     │ (merge semantics)
     │ • setProjectMeta({…})     │ (merge semantics)
     │ • setLexicon(lexDict())   │ (replace semantics)
     └─────────────┬─────────────┘
                   │
  ┌────────────────v────────────────┐
  │ Persist to localStorage          │
  │ (survives tab switch/reload)     │
  └─────────────────────────────────┘
```

### Implementation Details

**Merge vs. Replace Semantics:**
- `setProjectMeta()` merges partial patches into the `meta` object (editing `title` doesn't clear `author`)
- `setOutputPrefs()` merges three preference fields (`outputFormat`, `loudness`, `defaultVoice`), with special handling for `null` as a valid voice value
- `setLexicon()` replaces the entire dictionary (filtered from local rows)

**All automated tests pass:** 357 vitest tests, type checking clean, CJK character handling validated.

**Deferred to future work:**
- `coverRef` persistence (files/blobs cannot be stored in localStorage)
- "Save as named project" affordance
- Projects list card UI  
- App-level `onOpenStory` mode-aware routing for reopening saved projects

**API compatibility:** All backend request shapes (`audiobookPlan`, `audiobookGenerate`, `audiobookPreviewChapter`) remain unchanged; only the source of field values moves from local state to store.

**No public API signature changes** — all modifications are internal to the component's state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->