### PR TITLE
fix(ui): scale-aware shell breakpoints (cramped/black layout at narrow widths)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -83,6 +83,26 @@ function App() {
   // via the store's `partialize`; active project / voice ids stay transient.
   const uiScale = useAppStore(s => s.uiScale);
   const setUiScale = useAppStore(s => s.setUiScale);
+
+  // Responsive shell breakpoints driven off the app-container's OWN width, not
+  // the viewport. The shell is sized `width: calc(100vw / --ui-scale)` then
+  // `transform: scale(--ui-scale)` (the WebKitGTK fix, #407), so the grid lays
+  // out against `100vw/scale` — which `el.clientWidth` reports (transforms don't
+  // change the layout box). Viewport `@media` queries fire on raw `100vw` and so
+  // collapse at the wrong threshold whenever the UI scale ≠ 1, cramming the
+  // content into a sliver. ResizeObserver fires on both window resize and scale
+  // change (the calc width changes), so this stays correct on every engine.
+  const shellRef = useRef(null);
+  const [shellWidth, setShellWidth] = useState(Infinity);
+  useEffect(() => {
+    const el = shellRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    const ro = new ResizeObserver(() => setShellWidth(el.clientWidth));
+    ro.observe(el);
+    setShellWidth(el.clientWidth);
+    return () => ro.disconnect();
+  }, []);
+  const shellSizeClass = shellWidth <= 600 ? 'shell-mini' : shellWidth <= 1100 ? 'shell-narrow' : '';
   const theme = useAppStore(s => s.theme);
 
   const locale = useAppStore(s => s.locale);
@@ -967,11 +987,13 @@ function App() {
 
   return (
     <div
+      ref={shellRef}
       className={[
         'app-container',
         isSidebarCollapsed ? 'sidebar-collapsed' : '',
         hideSidebar ? 'sidebar-hidden' : '',
         navRailSide === 'right' ? 'rail-right' : '',
+        shellSizeClass,
       ].filter(Boolean).join(' ')}
       style={{ '--ui-scale': uiScale }}
     >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -286,21 +286,29 @@ samp,
 .app-container > .main-content > * { position: relative; z-index: 1; }
 .app-container > div { min-width: 0; }
 
-/* ≤1100: auto-collapse sidebar, keep nav + main */
-@media (max-width: 1100px) {
-  .app-container { grid-template-columns: 48px minmax(0, 1fr) !important; }
-  .app-container > .history-panel { display: none !important; }
-  .app-container > .main-content { grid-column: 2 !important; }
-  .app-container.rail-right { grid-template-columns: minmax(0, 1fr) 48px !important; }
-  .app-container.rail-right > .main-content { grid-column: 1 !important; }
-}
+/* Responsive collapse driven by the shell's OWN width (`shell-narrow`/`shell-mini`
+   set in App.jsx from app-container.clientWidth = 100vw/--ui-scale), NOT a
+   viewport @media query. A `@media (max-width)` fires on raw 100vw and so
+   collapses at the wrong threshold whenever --ui-scale ≠ 1 (the layout box is
+   100vw/scale), which crammed the content into a left sliver with a black band.
+   These class rules respond to the actual scaled layout width on every engine. */
 
-/* ≤600: hide nav rail too, full-width main */
-@media (max-width: 600px) {
-  .app-container { grid-template-columns: minmax(0, 1fr) !important; }
-  .app-container > .nav-rail { display: none; }
-  .app-container > .main-content { grid-column: 1 !important; }
-}
+/* ≤1100 effective: auto-collapse the projects/history panel, keep nav + main */
+.app-container.shell-narrow,
+.app-container.shell-mini { grid-template-columns: 48px minmax(0, 1fr) !important; }
+.app-container.shell-narrow > .history-panel,
+.app-container.shell-mini > .history-panel { display: none !important; }
+.app-container.shell-narrow > .main-content,
+.app-container.shell-mini > .main-content { grid-column: 2 !important; }
+.app-container.shell-narrow.rail-right,
+.app-container.shell-mini.rail-right { grid-template-columns: minmax(0, 1fr) 48px !important; }
+.app-container.shell-narrow.rail-right > .main-content,
+.app-container.shell-mini.rail-right > .main-content { grid-column: 1 !important; }
+
+/* ≤600 effective: hide the nav rail too, full-width main */
+.app-container.shell-mini { grid-template-columns: minmax(0, 1fr) !important; }
+.app-container.shell-mini > .nav-rail { display: none; }
+.app-container.shell-mini > .main-content { grid-column: 1 !important; }
 
 /* ═══ PANELS — flat chrome ═══ */
 .glass-panel {


### PR DESCRIPTION
**Fixes the responsiveness bug** (content jammed into a left ~110px sliver, black band filling the rest) seen at a narrow window.

## Root cause
The shell is `width: calc(100vw / --ui-scale)` + `transform: scale(--ui-scale)` (the #407 WebKitGTK fix), so its grid lays out against `100vw / scale`. But the responsive collapse used **viewport `@media (max-width)`** queries — they fire on raw `100vw`, so at any `--ui-scale ≠ 1` they trip at the wrong threshold. In a narrow window the 3-col grid was kept, the sidebar's `min 180px` crushed `main` → 0, and content jammed into a sliver with a black band.

## Fix
Drive the breakpoints off the shell's **own** width: a `ResizeObserver` on `.app-container` reads `el.clientWidth` (= the pre-transform layout width = `100vw/scale`; transforms don't change the layout box) and toggles `shell-narrow` (≤1100) / `shell-mini` (≤600). The `@media` queries become equivalent `.app-container.shell-*` rules. Correct on every engine + every UI scale; observer fires on both window resize and scale change.

vitest green (357); typecheck:ci clean; `vite build` clean.

> ⚠️ **Needs a visual check** in the running app — I can't verify layout rendering from here. Please confirm at a couple of window sizes × UI scales (esp. a narrow/zoomed window like the report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix responsive layout breakpoints for non-1.0 UI scale settings

**Problem**
The app shell uses `width: calc(100vw / --ui-scale)` with `transform: scale(--ui-scale)` (a fix for WebKitGTK from issue `#407`). The layout grid calculates against `100vw / scale`, but responsive breakpoint logic used viewport-based `@media (max-width)` queries that fire against the raw `100vw` value. When `--ui-scale ≠ 1`, these media queries trigger at incorrect thresholds, causing the 3-column grid to remain active in narrow windows. The sidebar's `min-width: 180px` then compresses the main content column toward zero, jamming the app content into a ~110px left sliver with a black band filling the rest.

**Solution**
Implemented a `ResizeObserver` on the `.app-container` element that reads its `clientWidth` (the pre-transform layout width, equal to `100vw/scale`). This observer toggles two CSS classes:
- `shell-narrow` when width ≤ 1100px (hides history panel, keeps nav + main)
- `shell-mini` when width ≤ 600px (hides nav rail too, full-width main)

CSS media queries were replaced with equivalent `.app-container.shell-narrow/shell-mini` class selectors. This approach is correct across all engines and UI scales, with the observer firing whenever the window resizes or the UI scale changes (which alters the calculated width).

### Layout Behavior Comparison

**Before (broken at narrow widths with UI scale ≠ 1):**
```
Wide window (1200px+):          Narrow window (700px) at scale 0.75:
┌─────────────────────┐        ┌─────────────────────┐
│ 48px │ 180px │ main │        │48px│180px│  main   │ ← content jammed
│ rail │sidebar│ area │        │rail│ sb  │~110px   │   into sliver!
├─────────────────────┤  `@media` │───┴─────┴─────────│   ignores scale
│                     │  fires  │                   │   calc width
│     Main Content    │  at     │    BLACK BAND     │   (700px actual,
│                     │  100vw  │   (remaining      │    not 700/0.75)
│                     │         │    space)         │
└─────────────────────┘        └─────────────────────┘
```

**After (correct at all widths and scales):**
```
Width > 1100px               Width 600–1100px         Width ≤ 600px
(shell-narrow: false)        (shell-narrow: true)     (shell-mini: true)
┌──────────────────────┐    ┌──────────────────┐     ┌──────────────┐
│48px│180px│   main   │    │48px│   main     │     │   main      │
│rail│ sb  │   area   │    │rail│   area     │     │   area      │
├──────────────────────┤    ├──────────────────┤     ├──────────────┤
│                      │    │ History panel    │     │              │
│   3-column grid      │    │    hidden        │     │  Full width  │
│   (default layout)   │    │                  │     │  (rail & sb  │
│                      │    │  2-column grid   │     │  hidden)     │
│                      │    │                  │     │              │
└──────────────────────┘    └──────────────────┘     └──────────────┘

ResizeObserver reads app-container.clientWidth (always = 100vw/--ui-scale)
→ Responsive breakpoints now scale-aware and engine-independent ✓
```

### Responsive Mechanism Flowchart

```mermaid
graph TD
    A["Window resize or<br/>UI scale change"] -->|triggers| B["ResizeObserver<br/>callback"]
    B --> C["Read app-container<br/>clientWidth<br/>(= 100vw / --ui-scale)"]
    C --> D{"Check<br/>breakpoints"}
    D -->|≤ 600px| E["Set class:<br/>shell-mini"]
    D -->|600–1100px| F["Set class:<br/>shell-narrow"]
    D -->|> 1100px| G["Clear shell<br/>size classes"]
    E --> H["CSS applies<br/>shell-mini rules"]
    F --> I["CSS applies<br/>shell-narrow rules"]
    G --> J["CSS applies<br/>default rules"]
    H --> K["Layout updates:<br/>grid columns,<br/>visibility"]
    I --> K
    J --> K
    K --> L["Content renders<br/>correctly at all<br/>scales & widths"]
```

### Files Changed
- **frontend/src/App.jsx** (+22 lines): Added `shellRef`, `shellWidth` state, and `ResizeObserver` hook that computes `shellSizeClass` and attaches it to the `.app-container` element
- **frontend/src/index.css** (+23 lines, −15 lines): Replaced `@media (max-width: 1100px)` and `@media (max-width: 600px)` blocks with equivalent `.app-container.shell-narrow` and `.app-container.shell-mini` class selectors; includes handling for `rail-right` layout variant

### Testing
- vitest reports 357 passing tests
- Type checking passes
- Build completes cleanly
- Visual verification at various window sizes and UI scale settings recommended

<!-- end of auto-generated comment: release notes by coderabbit.ai -->