### PR TITLE
feat(audiobook): use shared VoiceSelector for default-voice picker (#22 migration 1/N)

### DIFF
--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -8,6 +8,7 @@ import {
 import { audioUrl } from '../api/generate';
 import { consumeLongformStream } from '../utils/longformStream';
 import { useAppStore } from '../store';
+import VoiceSelector from '../components/VoiceSelector';
 import './AudiobookTab.css';
 
 /**
@@ -236,11 +237,12 @@ export default function AudiobookTab({ profiles = [] }) {
         <div className="audiobook-tab__side">
           <div className="audiobook-tab__field">
             <label className="field-label">{t('audiobook.default_voice')}</label>
-            <select className="input-base" value={defaultVoice}
-              onChange={(e) => setDefaultVoice(e.target.value)} aria-label={t('audiobook.default_voice')}>
-              <option value="">{t('audiobook.engine_default')}</option>
-              {profiles.map((p) => (<option key={p.id} value={p.id}>{p.name}</option>))}
-            </select>
+            <VoiceSelector
+              value={defaultVoice}
+              onChange={setDefaultVoice}
+              profiles={profiles}
+              defaultLabel={t('audiobook.engine_default')}
+            />
           </div>
 
           <div className="audiobook-tab__duo">


### PR DESCRIPTION
First #22 call-site migration: the Audiobook default-voice `<select>` → shared `<VoiceSelector>` (searchable + clone/designed grouping). **Value contract unchanged** (`''` engine default | profileId), already store-bound (#31b) → no behavior/data change. `defaultLabel` preserves the engine-default row label.

Stories cast / per-line track / Dub segment pickers deferred — intricate live layouts (custom select CSS, row composition) best migrated with visual verification, not blind-swapped.

vitest green (357); typecheck:ci clean; `vite build` clean. *(Picker rendering is best eyeballed in-app, but the value wiring is unchanged + covered by the VoiceSelector unit tests.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Migrates the Audiobook default-voice picker from a standard `<select>` element to the shared `<VoiceSelector>` component, introducing enhanced functionality while preserving the existing value contract and behavior.

### UI Changes

**Before:** Simple `<select>` dropdown listing "engine default" and one `<option>` per profile.

```
┌──────────────────────────────┐
│ [Default ▼]                  │
│ └─ Default                   │
│ └─ Profile 1                 │
│ └─ Profile 2                 │
└──────────────────────────────┘
```

**After:** `VoiceSelector` component with searchability, grouping (clone/designed), and optional adornments.

```
┌──────────────────────────────┐
│ [Searchable trigger] [🔍]    │
│ ┌─────────────────────────────┐
│ │ (search box)                │
│ ├─────────────────────────────┤
│ │ Default                     │ ← default group
│ ├─────────────────────────────┤
│ │ CLONE VOICES                │
│ │  ✓ Clone 1                  │
│ │    Clone 2                  │
│ ├─────────────────────────────┤
│ │ DESIGNED VOICES             │
│ │    Designed 1               │
│ │    Designed 2               │
│ └─────────────────────────────┘
```

### Changes

**AudiobookTab.jsx (lines 238–246):**
- Replaced `<select>` element with `<VoiceSelector>` component
- Wired to existing store bindings: `defaultVoice` (value), `setDefaultVoice` (handler)
- Passed `profiles` array and localized `defaultLabel` (`t('audiobook.engine_default')`)
- Value contract remains unchanged: empty string (`''`) for engine default, or `profileId` for user-selected voices

### Behavioral Stability

- Value binding unchanged; data storage unaffected (store-backed per `#31b`)
- Component renders with searchability and grouping (clone/designed splits on `.instruct` presence)
- Existing unit tests for `VoiceSelector` cover the value wiring
- Visual rendering best validated through in-app inspection

### Scope

This PR is intentionally limited to the Audiobook default-voice call-site. Other voice picker implementations—Stories cast picker, per-line track picker, and Dub segment picker—are deferred to follow-up migrations due to their complex live layouts, custom CSS, and intricate row composition that require visual verification during migration.

Test results: vitest 357/357 pass, TypeScript clean, production build successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->