### PR TITLE
feat(longform): TranscriptionPicker + shared reader util (#23 slices 1–2)

### DIFF
--- a/frontend/src/components/TranscriptionPicker.css
+++ b/frontend/src/components/TranscriptionPicker.css
@@ -1,0 +1,29 @@
+.txn-picker__search {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 10px;
+  color: var(--chrome-fg-muted, #999);
+}
+.txn-picker__search > * { flex: 1 1 auto; min-width: 0; }
+.txn-picker__list {
+  display: flex; flex-direction: column; gap: 6px;
+  max-height: 50vh; overflow-y: auto;
+}
+.txn-picker__row {
+  display: flex; flex-direction: column; gap: 4px; width: 100%;
+  text-align: left; padding: 8px 10px; cursor: pointer;
+  border: 1px solid var(--chrome-border, rgba(255,255,255,0.12));
+  border-radius: 6px; background: transparent; color: var(--chrome-fg, #eee);
+}
+.txn-picker__row:hover, .txn-picker__row:focus-visible {
+  border-color: var(--chrome-accent, #fe8019);
+  background: color-mix(in srgb, var(--chrome-accent, #fe8019) 8%, transparent);
+}
+.txn-picker__text { font-size: var(--text-sm, 0.85rem); line-height: 1.35; }
+.txn-picker__meta {
+  display: flex; gap: 10px; flex-wrap: wrap;
+  font-size: 0.7rem; color: var(--chrome-fg-muted, #999);
+}
+.txn-picker__meta span { display: inline-flex; align-items: center; gap: 3px; }
+.txn-picker__empty {
+  display: flex; flex-direction: column; align-items: center; gap: 8px;
+  padding: 28px 12px; color: var(--chrome-fg-muted, #999); text-align: center;
+}

--- a/frontend/src/components/TranscriptionPicker.jsx
+++ b/frontend/src/components/TranscriptionPicker.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Mic, Search, Clock, Languages } from 'lucide-react';
+import { Dialog, Input } from '../ui';
+import { loadTranscriptions, TRANSCRIPTION_EVENT } from '../utils/transcriptionsStore';
+import './TranscriptionPicker.css';
+
+/**
+ * A controlled modal that lets the user seed long-form work from a past
+ * dictation (#23). It does NOT know about Audiobook vs Stories — it only emits
+ * the picked entry via `onPick`. Reads localStorage directly; all text via t().
+ *
+ * @param {{ open: boolean, onClose: () => void, onPick: (entry: object) => void }} props
+ */
+export default function TranscriptionPicker({ open, onClose, onPick }) {
+  const { t } = useTranslation();
+  const [entries, setEntries] = useState([]);
+  const [search, setSearch] = useState('');
+
+  // Read on open; subscribe to live additions only while open.
+  useEffect(() => {
+    if (!open) return undefined;
+    setSearch('');
+    setEntries(loadTranscriptions());
+    const handler = () => setEntries(loadTranscriptions());
+    window.addEventListener(TRANSCRIPTION_EVENT, handler);
+    return () => window.removeEventListener(TRANSCRIPTION_EVENT, handler);
+  }, [open]);
+
+  // Relative time, host-locale absolute fallback; null on unparseable timestamp.
+  const formatTime = (iso) => {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    const diff = Date.now() - d.getTime();
+    if (diff < 60000) return t('transcriptions.just_now');
+    if (diff < 3600000) return t('transcriptions.m_ago', { count: Math.floor(diff / 60000) });
+    if (diff < 86400000) return t('transcriptions.h_ago', { count: Math.floor(diff / 3600000) });
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  };
+
+  // Per-row display normalization; hide empty-text rows entirely.
+  const rows = useMemo(() => entries
+    .map((e, idx) => ({
+      entry: e,
+      key: e?.id ?? idx,
+      text: String(e?.text ?? ''),
+      language: e?.language && e.language !== 'unknown' ? e.language : null,
+      duration: typeof e?.duration_s === 'number' && e.duration_s > 0 ? e.duration_s : null,
+      time: formatTime(e?.timestamp),
+    }))
+    .filter((r) => r.text.trim()), [entries]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const q = search.trim().toLowerCase();
+  const visible = q
+    ? rows.filter((r) => r.text.toLowerCase().includes(q) || (r.language || '').toLowerCase().includes(q))
+    : rows;
+
+  return (
+    <Dialog open={open} onClose={onClose} title={t('transcriptionPicker.title')} size="md">
+      {rows.length > 0 && (
+        <div className="txn-picker__search">
+          <Search size={13} />
+          <Input
+            size="sm"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('transcriptionPicker.search_placeholder')}
+            aria-label={t('transcriptionPicker.search_placeholder')}
+          />
+        </div>
+      )}
+
+      {visible.length === 0 ? (
+        <div className="txn-picker__empty">
+          <Mic size={24} />
+          <p>{rows.length === 0 ? t('transcriptionPicker.empty') : t('transcriptionPicker.empty_search')}</p>
+        </div>
+      ) : (
+        <div className="txn-picker__list" role="list">
+          {visible.map((r) => (
+            <button
+              type="button"
+              key={r.key}
+              className="txn-picker__row"
+              onClick={() => { onPick(r.entry); onClose(); }}
+            >
+              <span className="txn-picker__text">
+                {r.text.length > 120 ? `${r.text.slice(0, 120)}…` : r.text}
+              </span>
+              <span className="txn-picker__meta">
+                {r.time && <span><Clock size={10} /> {r.time}</span>}
+                {r.language && <span><Languages size={10} /> {r.language}</span>}
+                {r.duration && <span>{r.duration.toFixed(1)}s</span>}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </Dialog>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -983,6 +983,12 @@
     "m_ago": "{{count}}m ago",
     "h_ago": "{{count}}h ago"
   },
+  "transcriptionPicker": {
+    "title": "Import from a transcription",
+    "search_placeholder": "Search transcriptions…",
+    "empty": "No transcriptions yet. Record one in the Transcriptions tab.",
+    "empty_search": "No transcriptions match your search."
+  },
   "setup": {
     "welcome": "Welcome",
     "system_check": "System check",

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -6,6 +6,7 @@ import {
   LayoutGrid, List as ListIcon, Clock, FileText, Mic, BookMarked, BookOpen,
 } from 'lucide-react';
 import { apiFetch } from '../api/client';
+import { loadTranscriptions, TRANSCRIPTION_EVENT } from '../utils/transcriptionsStore';
 import { audioUrl } from '../api/generate';
 import './Projects.css';
 
@@ -113,18 +114,12 @@ export default function Projects({
   }, []);
 
   // Load transcriptions from localStorage (same source as TranscriptionsPage)
-  const [transcriptions, setTranscriptions] = useState(() => {
-    try { return JSON.parse(localStorage.getItem('omni_transcriptions') || '[]'); }
-    catch { return []; }
-  });
+  const [transcriptions, setTranscriptions] = useState(loadTranscriptions);
   // Listen for new transcriptions
   React.useEffect(() => {
-    const handler = () => {
-      try { setTranscriptions(JSON.parse(localStorage.getItem('omni_transcriptions') || '[]')); }
-      catch {}
-    };
-    window.addEventListener('omni:transcription-added', handler);
-    return () => window.removeEventListener('omni:transcription-added', handler);
+    const handler = () => setTranscriptions(loadTranscriptions());
+    window.addEventListener(TRANSCRIPTION_EVENT, handler);
+    return () => window.removeEventListener(TRANSCRIPTION_EVENT, handler);
   }, []);
 
   // Normalise every source into a common shape so the filter + search +

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -13,18 +13,13 @@ import { useTranslation } from 'react-i18next';
 import { Mic, Copy, Trash2, Search, Clock, Languages, FileText, Download } from 'lucide-react';
 import { Button } from '../ui';
 import { toast } from 'react-hot-toast';
+import {
+  loadTranscriptions, TRANSCRIPTIONS_KEY, TRANSCRIPTION_EVENT,
+} from '../utils/transcriptionsStore';
 import './Transcriptions.css';
 
-const STORAGE_KEY = 'omni_transcriptions';
-const TXN_EVENT = 'omni:transcription-added';
-
-function loadTranscriptions() {
-  try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]'); }
-  catch { return []; }
-}
-
 function saveTranscriptions(list) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  localStorage.setItem(TRANSCRIPTIONS_KEY, JSON.stringify(list));
 }
 
 export function addTranscription(entry) {
@@ -42,7 +37,7 @@ export function addTranscription(entry) {
   if (list.length > 200) list.length = 200;
   saveTranscriptions(list);
   // Fire custom event for reactive updates
-  window.dispatchEvent(new CustomEvent(TXN_EVENT, { detail: newEntry }));
+  window.dispatchEvent(new CustomEvent(TRANSCRIPTION_EVENT, { detail: newEntry }));
 }
 
 export default function TranscriptionsPage() {
@@ -56,8 +51,8 @@ export default function TranscriptionsPage() {
     const handler = () => {
       setTranscriptions(loadTranscriptions());
     };
-    window.addEventListener(TXN_EVENT, handler);
-    return () => window.removeEventListener(TXN_EVENT, handler);
+    window.addEventListener(TRANSCRIPTION_EVENT, handler);
+    return () => window.removeEventListener(TRANSCRIPTION_EVENT, handler);
   }, []);
 
   const filtered = useMemo(() => {

--- a/frontend/src/test/TranscriptionPicker.test.jsx
+++ b/frontend/src/test/TranscriptionPicker.test.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import TranscriptionPicker from '../components/TranscriptionPicker';
+import { TRANSCRIPTIONS_KEY, TRANSCRIPTION_EVENT } from '../utils/transcriptionsStore';
+
+function seed(entries) {
+  localStorage.setItem(TRANSCRIPTIONS_KEY, JSON.stringify(entries));
+}
+
+describe('TranscriptionPicker', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('renders the empty state when there are no transcriptions', () => {
+    render(<TranscriptionPicker open onClose={vi.fn()} onPick={vi.fn()} />);
+    expect(screen.getByText(/No transcriptions yet/i)).toBeInTheDocument();
+  });
+
+  it('lists entries and hides empty-text rows', () => {
+    seed([
+      { id: 1, text: 'Hello world', language: 'en', duration_s: 3, timestamp: new Date().toISOString() },
+      { id: 2, text: '   ', language: 'en', timestamp: new Date().toISOString() }, // hidden
+    ]);
+    render(<TranscriptionPicker open onClose={vi.fn()} onPick={vi.fn()} />);
+    expect(screen.getByText('Hello world')).toBeInTheDocument();
+    expect(screen.getAllByRole('button').filter((b) => b.className.includes('txn-picker__row'))).toHaveLength(1);
+  });
+
+  it('clicking a row calls onPick with the original entry, then onClose', () => {
+    const entry = { id: 7, text: 'Pick me', timestamp: new Date().toISOString() };
+    seed([entry]);
+    const onPick = vi.fn();
+    const onClose = vi.fn();
+    render(<TranscriptionPicker open onClose={onClose} onPick={onPick} />);
+    fireEvent.click(screen.getByText('Pick me'));
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: 7, text: 'Pick me' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('rows are real buttons (keyboard-activatable)', () => {
+    seed([{ id: 1, text: 'Keyboard ready', timestamp: new Date().toISOString() }]);
+    const onPick = vi.fn();
+    render(<TranscriptionPicker open onClose={vi.fn()} onPick={onPick} />);
+    const row = screen.getByText('Keyboard ready').closest('button');
+    expect(row).toBeInTheDocument();
+    fireEvent.click(row); // a <button> activates on Enter/Space natively → click in jsdom
+    expect(onPick).toHaveBeenCalled();
+  });
+
+  it('search filters by text + shows the search-specific empty state', () => {
+    seed([
+      { id: 1, text: 'alpha cat', timestamp: new Date().toISOString() },
+      { id: 2, text: 'beta dog', timestamp: new Date().toISOString() },
+    ]);
+    render(<TranscriptionPicker open onClose={vi.fn()} onPick={vi.fn()} />);
+    const box = screen.getByPlaceholderText(/Search transcriptions/i);
+    fireEvent.change(box, { target: { value: 'cat' } });
+    expect(screen.getByText('alpha cat')).toBeInTheDocument();
+    expect(screen.queryByText('beta dog')).not.toBeInTheDocument();
+    fireEvent.change(box, { target: { value: 'zzz' } });
+    expect(screen.getByText(/No transcriptions match/i)).toBeInTheDocument();
+  });
+
+  it('omits the time chip for an unparseable timestamp (no "Invalid Date")', () => {
+    seed([{ id: 1, text: 'no time', timestamp: 'not-a-date' }]);
+    render(<TranscriptionPicker open onClose={vi.fn()} onPick={vi.fn()} />);
+    expect(screen.getByText('no time')).toBeInTheDocument();
+    expect(screen.queryByText(/Invalid Date/)).not.toBeInTheDocument();
+  });
+
+  it('refreshes on a transcription-added event while open', () => {
+    render(<TranscriptionPicker open onClose={vi.fn()} onPick={vi.fn()} />);
+    expect(screen.getByText(/No transcriptions yet/i)).toBeInTheDocument();
+    seed([{ id: 9, text: 'live add', timestamp: new Date().toISOString() }]);
+    fireEvent(window, new CustomEvent(TRANSCRIPTION_EVENT));
+    expect(screen.getByText('live add')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/transcriptionsStore.js
+++ b/frontend/src/utils/transcriptionsStore.js
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for the dictation-history localStorage store (#23).
+ * Relocates the key/event consts + the reader that were duplicated across
+ * Transcriptions.jsx and Projects.jsx. No version/rename/rewrite — the storage
+ * contract (key, entry shape, 200-cap) is unchanged; this only de-dups the read.
+ */
+export const TRANSCRIPTIONS_KEY = 'omni_transcriptions';
+export const TRANSCRIPTION_EVENT = 'omni:transcription-added';
+
+/**
+ * Read the transcription history. Never throws; always returns an array
+ * (newest-first, as written). [] on absent/empty/malformed/non-array/blocked.
+ * @returns {Array<object>}
+ */
+export function loadTranscriptions() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(TRANSCRIPTIONS_KEY) || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/frontend/src/utils/transcriptionsStore.test.js
+++ b/frontend/src/utils/transcriptionsStore.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadTranscriptions, TRANSCRIPTIONS_KEY, TRANSCRIPTION_EVENT,
+} from './transcriptionsStore';
+
+describe('transcriptionsStore', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('pins the storage contract literals (backward-compat)', () => {
+    expect(TRANSCRIPTIONS_KEY).toBe('omni_transcriptions');
+    expect(TRANSCRIPTION_EVENT).toBe('omni:transcription-added');
+  });
+
+  it('returns [] for absent / empty / malformed / non-array; the array otherwise', () => {
+    expect(loadTranscriptions()).toEqual([]);                 // absent
+    localStorage.setItem(TRANSCRIPTIONS_KEY, '[{');           // malformed
+    expect(loadTranscriptions()).toEqual([]);
+    localStorage.setItem(TRANSCRIPTIONS_KEY, '"x"');          // non-array
+    expect(loadTranscriptions()).toEqual([]);
+    localStorage.setItem(TRANSCRIPTIONS_KEY, '{}');           // non-array obj
+    expect(loadTranscriptions()).toEqual([]);
+    const arr = [{ id: 1, text: 'hi' }];
+    localStorage.setItem(TRANSCRIPTIONS_KEY, JSON.stringify(arr));
+    expect(loadTranscriptions()).toEqual(arr);                // preserved, no re-sort
+  });
+
+  it('never throws even when localStorage access throws', () => {
+    const orig = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get() { throw new Error('storage disabled'); },
+    });
+    expect(() => loadTranscriptions()).not.toThrow();
+    expect(loadTranscriptions()).toEqual([]);
+    Object.defineProperty(window, 'localStorage', orig);
+  });
+});


### PR DESCRIPTION
Groundwork for "import from a past dictation" — the shared store reader + the reusable picker modal, fully unit/RTL-tested. The two-tab wiring (Audiobook Replace/Append prompt + Stories split-panel routing) is **slice 3, deferred** for visual verification.

**Slice 1 — `utils/transcriptionsStore.js`:** `loadTranscriptions()` (parse + `Array.isArray` guard, `[]` on absent/empty/malformed/non-array/blocked-storage) + `TRANSCRIPTIONS_KEY`/`TRANSCRIPTION_EVENT` consts. Refactored `Transcriptions.jsx` + `Projects.jsx` onto it (behavior-preserving; storage key/shape/200-cap unchanged → no migration).

**Slice 2 — `components/TranscriptionPicker.jsx`:** controlled modal wrapping the shared `ui/Dialog` (Radix focus-trap/ESC/backdrop/ARIA inherited). Reads on open, live-refresh while open, per-row normalization, hides empty-text rows, distinct empty vs empty-search states, `String.includes` search (no RegExp → no ReDoS), keyboard-activatable `<button>` rows, Invalid-Date guard; `onPick` gets the original entry. All strings via `t()`.

**Tests:** util edge matrix (3) + picker RTL (7). Full vitest green; `typecheck:ci` clean; CJK guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces groundwork for an "import from a past dictation" feature through two implementation slices:

### Slice 1: Shared Transcriptions Store Utility

Added `frontend/src/utils/transcriptionsStore.js` to consolidate duplicated localStorage parsing logic. The utility exports:
- `TRANSCRIPTIONS_KEY` and `TRANSCRIPTION_EVENT` constants
- `loadTranscriptions()` function with comprehensive error handling (absent storage, empty values, malformed JSON, non-array values, blocked access) — always returns an empty array rather than throwing

Refactored `Transcriptions.jsx` and `Projects.jsx` to use the shared utility in place of inline storage logic. The refactoring is behavior-preserving, maintains the existing 200-item capacity, and requires no data migration.

**Tests:** 3 edge-case tests cover all error scenarios (absent storage, malformed JSON, non-array values, blocked access).

### Slice 2: Reusable TranscriptionPicker Modal Component

Added `TranscriptionPicker.jsx`, a controlled modal component that:
- Loads and displays stored transcription entries via `loadTranscriptions()`
- Subscribes to `TRANSCRIPTION_EVENT` while open to reflect live updates
- Normalizes display fields (text, optional language, optional duration, formatted timestamp)
- Filters rows with empty/whitespace text
- Supports case-insensitive substring search (using `String.includes` to avoid ReDoS)
- Renders distinct states: list, empty state, or empty-search state
- Keyboard-activatable rows (native `<button>` elements)
- Invalid-Date guards for unparseable timestamps
- All user-facing strings localized via `t()` under the `transcriptionPicker` namespace

Added corresponding CSS (`TranscriptionPicker.css`) and localization strings in `frontend/src/i18n/locales/en.json`.

**Tests:** 7 RTL tests cover empty state, hidden rows, selection with callbacks, keyboard interaction, search filtering, timestamp handling, and live-refresh.

### Component UI

```
┌─────────────────────────────────────────┐
│  📖 Import from past dictation          │
├─────────────────────────────────────────┤
│  🔍 [Search transcriptions...........] │
├─────────────────────────────────────────┤
│  │ Text excerpt [EN] 2m 34s          │
│  │ 5 days ago                        │
│  ├─────────────────────────────────────┤
│  │ Another entry    [FR] 1m 12s       │
│  │ 2 weeks ago                       │
│  ├─────────────────────────────────────┤
│  │ More content...                    │
│  └─────────────────────────────────────┘
│                                         │
│  (empty state: "No transcriptions")    │
│  (no-results: "No results matching...")│
└─────────────────────────────────────────┘
```

### Behavior Flow

```mermaid
graph TD
    A["Modal opens<br/>(open=true)"] -->|Reset search, fetch initial list| B["loadTranscriptions()"]
    B --> C["Subscribe to TRANSCRIPTION_EVENT"]
    C --> D{User action?}
    D -->|Type in search| E["Filter list<br/>case-insensitive<br/>substring match"]
    E --> F["Show filtered results<br/>or empty-search state"]
    D -->|Click row| G["Call onPick<br/>with original entry"]
    G --> H["Close modal<br/>via onClose"]
    D -->|External transcription added| I["TRANSCRIPTION_EVENT fires"]
    I --> J["loadTranscriptions()"]
    J --> F
    D -->|Press ESC or click backdrop| H
    H -->|Modal closes<br/>Unsubscribe from event| K["Reset state"]
```

### Testing

- **Utility tests:** 3 edge-case matrix tests for `loadTranscriptions()` covering error scenarios
- **Component tests:** 7 RTL tests covering functionality, keyboard interaction, search, timestamps, and live-refresh
- All tests pass; type-checking passes; CJK guards pass

### Deferred

Slice 3 (integration wiring with Audiobook and Stories components) is deferred pending visual verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->