### PR TITLE
fix(realtime): probe auth-exempt /health, not gated /model/status

### DIFF
--- a/frontend/src/hooks/useRealtimeEvents.js
+++ b/frontend/src/hooks/useRealtimeEvents.js
@@ -19,7 +19,14 @@ const WS_EVENTS_URL = wsUrl('/ws/events');
 // HTTP health-check URL (derived from same base as WS). We poll this before
 // creating the WebSocket so the first attempt doesn't fail with ECONNREFUSED
 // when the Python backend hasn't finished starting Uvicorn (~14s on cold start).
-const HEALTH_CHECK_URL = `${apiUrl()}/model/status`;
+//
+// Must be the auth-exempt liveness endpoint /health (in backend _SHELL_PATHS),
+// NOT /model/status: this is a raw fetch() that does NOT carry the LAN PIN /
+// remote API-key headers apiFetch attaches. In LAN-share / remote-API mode a
+// gated path returns 401, which would reject this probe forever and the
+// WebSocket would never open. /health is exempt from both gates and returns
+// 200 as soon as Uvicorn is up — exactly the liveness signal this probe needs.
+const HEALTH_CHECK_URL = apiUrl('/health');
 
 /**
  * @param {Object} handlers - Map of event kind → callback

--- a/frontend/src/test/useRealtimeEvents.test.jsx
+++ b/frontend/src/test/useRealtimeEvents.test.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+// The cold-start probe in useRealtimeEvents uses a RAW fetch() that does not
+// carry the LAN PIN / remote API-key headers apiFetch would attach. It must
+// therefore poll the auth-exempt /health endpoint — never a gated path like
+// /model/status, which 401s in LAN-share/remote mode and would wedge the
+// reconnect loop so the WebSocket never opens. This test pins that contract.
+import useRealtimeEvents from '../hooks/useRealtimeEvents';
+
+// Minimal WebSocket stub: records construction and lets us drive onopen.
+class FakeWebSocket {
+  static instances = [];
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0; // CONNECTING
+    this.onopen = null;
+    this.onmessage = null;
+    this.onclose = null;
+    this.onerror = null;
+    FakeWebSocket.instances.push(this);
+  }
+  close() {
+    this.readyState = 3; // CLOSED
+  }
+}
+
+function Harness() {
+  useRealtimeEvents({});
+  return null;
+}
+
+describe('useRealtimeEvents cold-start health probe', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    if (!AbortSignal.timeout) {
+      AbortSignal.timeout = () => new AbortController().signal;
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('probes the auth-exempt /health endpoint, not a gated path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<Harness />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const probedUrl = String(fetchMock.mock.calls[0][0]);
+    expect(probedUrl).toMatch(/\/health$/);
+    // Guard against the #439 regression: the gated path drops auth → 401.
+    expect(probedUrl).not.toContain('/model/status');
+  });
+
+  it('opens the WebSocket once the health probe succeeds', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<Harness />);
+
+    await waitFor(() => expect(FakeWebSocket.instances.length).toBe(1));
+    expect(FakeWebSocket.instances[0].url).toContain('/ws/events');
+  });
+
+  it('does NOT open the WebSocket while the backend is unreachable', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<Harness />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(FakeWebSocket.instances.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

The cold-start health probe added in #439 (`frontend/src/hooks/useRealtimeEvents.js`) breaks realtime sidebar updates in **LAN-share / remote-API mode** (the opt-in non-loopback paths). Default local-desktop (loopback) use is unaffected.

`HEALTH_CHECK_URL` pointed at `/model/status` and was hit with a **raw `fetch()`** — not `apiFetch`, so it carries neither the LAN PIN (`X-OmniVoice-Pin`) nor the remote API key (`Authorization: Bearer …`). `/model/status` is **not** in the backend `_SHELL_PATHS` allowlist (`backend/main.py`: `/`, `/index.html`, `/favicon.ico`, `/health`), so on a non-loopback client `NetworkAccessMiddleware` + `BearerKeyMiddleware` return **401** → `res.ok` false → `.catch` → `scheduleReconnect()` loops forever → `openWebSocket()` is never reached. Before #439, `wsUrl()` appended `?api_key=`, so the WS connected fine in this mode — this is a regression.

## Fix

Probe **`/health`** instead — the auth-exempt liveness endpoint (in `_SHELL_PATHS`) that returns 200 the moment Uvicorn is up, which is exactly the cold-start signal this gate needs. Works identically loopback and remote, no credentials required. `apiUrl('/health')` also avoids a double-slash when the API base carries a trailing slash. One-line change + clarifying comment.

## Tests

New `frontend/src/test/useRealtimeEvents.test.jsx` (3 cases):
- probe targets `/health`, never `/model/status` (this fails on the pre-fix code — verified)
- WebSocket opens after the probe succeeds
- WebSocket does **not** open while the backend is unreachable

`bunx vitest run`: **53 files / 398 tests pass** (incl. the new ones). No backend change, no data/schema/engine impact, no version bump; cross-platform (affects the opt-in LAN/remote path on all OSes equally).

Fixes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Behavioral Change: Cold-Start Health Probe Endpoint

This PR fixes a regression in WebSocket connection initialization where the cold-start health probe targeted an auth-gated endpoint instead of an auth-exempt one.

### Mechanism (New Flow)

```mermaid
graph TD
    A["useRealtimeEvents hook mounts"] --> B["connect() called"]
    B --> C["Fetch HEALTH_CHECK_URL"]
    C --> D{"Response ok?"}
    D -->|Yes| E["Reset retry counter"]
    E --> F["openWebSocket()"]
    F --> G["WebSocket connects to /ws/events"]
    D -->|No| H["Schedule reconnect<br/>with exponential backoff"]
    H --> I["setTimeout → connect()"]
    I --> B
```

**Key change**: The health probe now targets `/health` (auth-exempt, returns 200 as soon as Uvicorn starts) instead of `/model/status` (auth-gated, returns 401 in LAN-share/remote-API modes). This ensures the probe succeeds immediately when the backend is ready, allowing the WebSocket connection to proceed rather than entering an infinite reconnect loop.

## Code Changes

**frontend/src/hooks/useRealtimeEvents.js** (8 additions, 1 deletion):
- Changed `HEALTH_CHECK_URL` from `apiUrl() + '/model/status'` to `apiUrl('/health')`
- Added detailed comments explaining why `/health` is required (auth-exempt liveness endpoint in `_SHELL_PATHS` allowlist)
- Uses `apiUrl('/health')` to prevent double-slash issues when API base has trailing slash
- The probe uses raw `fetch()` without authentication headers, making auth-exempt endpoints essential

**frontend/src/test/useRealtimeEvents.test.jsx** (81 additions, new file):
- Three test cases verify the fix:
  1. **Endpoint contract test**: Confirms probe targets `/health`, never `/model/status` (guards against `#439` regression)
  2. **Success path test**: Verifies WebSocket opens only after successful health probe
  3. **Failure path test**: Confirms WebSocket does not open when health probe fails (backend unreachable), allowing reconnect logic to retry
- Includes `FakeWebSocket` test harness and global stubs for `WebSocket` and `fetch`

## Testing

All 53 files and 398 tests pass via `bunx vitest run`, including the three new test cases covering cold-start scenarios across all modes (loopback, LAN-share, remote-API).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->