### PR TITLE
fix(ui): app-shell scales via zoom + always fills viewport (permanent black-band fix)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -179,9 +179,7 @@ samp,
 
 #root {
   display: flex;
-  /* Anchor top-left so the zoom-compensated .app-container (which can be wider
-     than the viewport pre-zoom at scale <1) renders from the corner instead of
-     being centered and clipped. At scale 1 it's exactly viewport-sized anyway. */
+  /* Anchor top-left so the full-viewport .app-container renders from the corner. */
   justify-content: flex-start;
   padding: 0;
   width: 100%;
@@ -192,17 +190,24 @@ samp,
 
 /* ═══ LAYOUT ═══ */
 .app-container {
-  /* UI scale is applied as `transform: scale(var(--ui-scale))` (NOT `zoom`).
-     CSS `zoom` is honoured by Chromium (the macOS/Windows webview) but IGNORED
-     by WebKitGTK (the Linux webview) — there the `/scale` sizing below shrank
-     the shell with no matching magnification, leaving black bands on the right
-     and bottom (cross-platform default-parity P0). `transform: scale` scales
-     identically on every engine and doesn't alter how `vw`/`vh` resolve, so
-     `declared (100vw/scale) × scale` always equals the viewport and fills
-     exactly. transform-origin keeps it anchored to the top-left corner. */
-  width: calc(100vw / var(--ui-scale, 1));
-  transform: scale(var(--ui-scale, 1));
-  transform-origin: top left;
+  /* UI scale (#21 black-band fix — PERMANENT): scale via `zoom`, and the shell
+     ALWAYS occupies the full viewport (`100vw`/`100vh`, NOT `calc(…/scale)`).
+     Why this never black-bands on any engine:
+       • Chromium (macOS/Windows): `zoom` magnifies AND fills — standard browser
+         zoom (the same `style={{zoom:uiScale}}` the bootstrap/wizard wrappers
+         already use here).
+       • WebKitGTK (Linux): `zoom` is a no-op → the UI renders at 1.0× but the
+         shell is still a plain `100vw × 100vh` element → it FILLS the window.
+     The previous approach paired `width: calc(100vw/scale)` with `transform:
+     scale(var(--ui-scale))`; on WebKitGTK the transform wasn't magnifying the
+     shrunk shell, so `calc(100vw/1.3)` (the default scale) left ~⅓ of the
+     window black. Dropping the `/scale` shrink makes a missed magnification
+     degrade to "unscaled but full", never to "shrunk + black band".
+     ⚠️ Do NOT reintroduce `width: calc(100vw / var(--ui-scale))` or
+     `transform: scale(var(--ui-scale))` here — a regression test
+     (src/test/appShellScale.test.js) fails CI if either pattern returns. */
+  width: 100vw;
+  zoom: var(--ui-scale, 1);
   max-width: none;
   display: grid;
   /* [rail 48px] [sidebar 180–220] [main 1fr] */
@@ -217,7 +222,7 @@ samp,
      footer's state. Content columns (not the grid) yield to the fixed footer
      via padding-bottom below, so expanding the logs panel never compresses
      the side menubar. */
-  height: calc(100vh / var(--ui-scale, 1));
+  height: 100vh;
   overflow: hidden;
   transition: grid-template-columns var(--transition-smooth);
 }

--- a/frontend/src/test/appShellScale.test.js
+++ b/frontend/src/test/appShellScale.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * PERMANENT regression guard for the app-shell black-band bug (#21).
+ *
+ * The shell must scale via `zoom` and ALWAYS occupy the full viewport. The old
+ * `width: calc(100vw / var(--ui-scale))` + `transform: scale(var(--ui-scale))`
+ * approach left ~⅓ of the window black on WebKitGTK (the default scale is 1.3,
+ * and the transform wasn't magnifying the shrunk shell). This test fails CI if
+ * either foot-gun pattern is reintroduced, so a future change can't silently
+ * bring the black band back.
+ */
+// vitest runs from the frontend/ package dir. Strip /* … */ comments so the
+// guard checks real declarations, not the warning comment that quotes the
+// forbidden patterns.
+const raw = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
+const css = raw.replace(/\/\*[\s\S]*?\*\//g, '');
+
+describe('app shell scale (black-band regression guard)', () => {
+  it('does NOT shrink the shell with calc(100vw / --ui-scale)', () => {
+    expect(css).not.toMatch(/calc\(\s*100vw\s*\/\s*var\(--ui-scale/);
+    expect(css).not.toMatch(/calc\(\s*100vh\s*\/\s*var\(--ui-scale/);
+  });
+
+  it('does NOT scale the shell via transform: scale(--ui-scale)', () => {
+    expect(css).not.toMatch(/transform:\s*scale\(\s*var\(--ui-scale/);
+  });
+
+  it('scales the shell via zoom and fills the viewport (100vw/100vh)', () => {
+    // .app-container block must use zoom + full-viewport sizing.
+    const block = css.slice(css.indexOf('.app-container {'));
+    expect(block).toMatch(/zoom:\s*var\(--ui-scale/);
+    expect(block).toMatch(/width:\s*100vw/);
+    expect(block).toMatch(/height:\s*100vh/);
+  });
+});


### PR DESCRIPTION
**Fixes the black-band / empty-space responsiveness failure permanently, app-wide.**

## Root cause (confirmed)
`uiScale` **defaults to 1.3**, so the shell's `width: calc(100vw/--ui-scale)` + `transform: scale(--ui-scale)` path runs for **every** user. On WebKitGTK (Linux webview) the `transform` wasn't magnifying the shrunk shell, so `calc(100vw/1.3)` left ~⅓ of the window black — on **every view, by default**. (Setting UI Scale to 100% made it fill, pinning the cause. The earlier #445 fix addressed the responsive *breakpoints* — the wrong layer.)

## Fix
Scale via **`zoom`** and keep the shell at full **`100vw × 100vh`** (drop the `calc(…/scale)` shrink + the `transform`):
- **Chromium (mac/win):** `zoom` magnifies **and** fills — standard browser zoom (same mechanism the bootstrap/wizard wrappers already use).
- **WebKitGTK (Linux):** `zoom` is a no-op → UI renders at 1.0× but the shell is a plain `100vw×100vh` element → **fills, no band.** A missed magnification now degrades to *"unscaled but full"*, never *"shrunk + black band"*. (Trade-off: Linux loses the 1.3× magnify — but it was never actually magnifying there; that was the bug.)

## Permanent / regression-proof
`src/test/appShellScale.test.js` **fails CI** if anyone reintroduces `width: calc(100vw/var(--ui-scale))` or `transform: scale(var(--ui-scale))` on the shell, or drops the `zoom`/`100vw`/`100vh` contract. The rationale + the "do NOT reintroduce" warning live inline in the `.app-container` rule.

Full vitest green (**398**, incl. the 3-case guard); `typecheck:ci` + `vite build` clean.

> Please verify in-app at your default scale (should now fill) and after bumping UI Scale (Chromium scales; Linux stays 1.0× but fills).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixed app shell black-band responsiveness issue

**Problem:** The app shell left a ~⅓ black band or empty space on the viewport, particularly on WebKitGTK (Linux). The root cause was using `width: calc(100vw/var(--ui-scale))` combined with `transform: scale(var(--ui-scale))`. On WebKitGTK, the transform property failed to magnify the shrunk shell, causing the calculated width (e.g., `calc(100vw/1.3)` at default scale) to render as black space.

**Solution:** Replaced the calc + transform approach with CSS `zoom` property while maintaining the shell at full `100vw × 100vh` dimensions.

### Layout Mechanism

```
BEFORE (Broken on WebKitGTK)
┌─────────────────────────────────┐
│ Viewport (100vw × 100vh)        │
├──────────────────┬──────────────┤
│  Shell           │  BLACK BAND  │
│ ~77% of width    │  ~23% empty  │
│ (100vw/1.3)      │              │
│ + transform      │ (transform   │
│   scale(1.3)     │  failed)     │
│   (FAILED)       │              │
└──────────────────┴──────────────┘

AFTER (Fixed)
┌─────────────────────────────────┐
│ Viewport (100vw × 100vh)        │
├─────────────────────────────────┤
│  Shell (100vw × 100vh)          │
│  zoom: var(--ui-scale, 1)       │
│  ✓ Fills entire viewport        │
│  ✓ Works on all engines         │
└─────────────────────────────────┘
```

### Cross-Platform Behavior

```mermaid
graph TD
    A[app-container: width=100vw, zoom=var--ui-scale] --> B{Browser Engine}
    B -->|Chromium<br/>macOS/Windows| C["zoom magnifies UI<br/>AND fills viewport<br/>Result: Scaled UI at full size ✓"]
    B -->|WebKitGTK<br/>Linux| D["zoom is no-op<br/>Shell is still 100vw×100vh<br/>Result: UI at 1.0× fills viewport ✓"]
    C --> E["No black band<br/>UI properly magnified"]
    D --> F["No black band<br/>UI unscaled but complete<br/>Previous magnification<br/>was never working anyway"]
```

### Changes Made

**frontend/src/index.css:**
- Updated `#root` comment to reflect top-left anchoring for full-viewport rendering
- Refactored `.app-container` scaling:
  - **Removed:** `width: calc(100vw/var(--ui-scale))`, `transform: scale(var(--ui-scale))` with associated `transform-origin` logic
  - **Added:** `width: 100vw`, `height: 100vh`, `zoom: var(--ui-scale, 1)`
- Added comprehensive inline documentation explaining the fix and preventing regression
- Lines changed: +20/-15

**frontend/src/test/appShellScale.test.js** (new file):
- Three regression guard test cases:
  1. Verifies `calc(100vw/var(--ui-scale))` is NOT present
  2. Verifies `transform: scale(var(--ui-scale))` is NOT present
  3. Verifies `.app-container` uses `zoom: var(--ui-scale)` with full viewport `100vw` and `100vh`
- Strips CSS comments before testing to avoid false positives from documentation
- Fails CI if prohibited patterns reappear
- Lines added: +38

### Trade-offs & Notes

- **Linux users:** No longer receive 1.3× magnification, but this magnification was not actually rendering before. The current behavior resolves the underlying bug by ensuring the shell fills the viewport even when `zoom` is unsupported.
- **Regression prevention:** Test suite automatically prevents reintroduction of the problematic patterns
- **Verification:** All 398 vitest cases pass including three new guard tests; typecheck and build are clean

<!-- end of auto-generated comment: release notes by coderabbit.ai -->