### PR TITLE
feat(persona): .ovsvoice manifest + SPDX + consent core (#29, pure nucleus)

### DIFF
--- a/backend/services/persona_bundle.py
+++ b/backend/services/persona_bundle.py
@@ -1,0 +1,126 @@
+"""`.ovsvoice` persona-bundle format (#29 / parity §R3 G1).
+
+A portable ZIP that packages a voice profile's identity + an optional reference
+clip + a consent attestation + an SPDX license tag + a watermarked preview.
+
+This module owns the **pure, model-free** core: the format constants, SPDX
+normalization, and the manifest/consent builders. The audio preview + ZIP
+pack/unpack (which lazily import torchaudio/watermark) layer on top of these.
+"""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+# ── Format constants ─────────────────────────────────────────────────────────
+OVSVOICE_FORMAT = "ovsvoice"
+OVSVOICE_SCHEMA_VERSION = 1
+MAX_BUNDLE_BYTES = 100 * 1024 * 1024          # 100 MB (mirrors marketplace cap)
+_MIN_CONSENT_AUDIO_BYTES = 1000               # the consent-recording floor
+DEFAULT_LICENSE = "LicenseRef-OmniVoice-Personal"
+
+# Membership allowlist for SPDX validation — a fixed-string set + the
+# ``LicenseRef-`` prefix. NO regex over the (user-supplied) SPDX string, so this
+# carries no CodeQL py/polynomial-redos surface.
+_SPDX_ALLOWLIST: frozenset[str] = frozenset({
+    "CC0-1.0", "CC-BY-4.0", "CC-BY-SA-4.0", "CC-BY-NC-4.0", "CC-BY-NC-SA-4.0",
+    "CC-BY-ND-4.0", "MIT", "Apache-2.0", "LicenseRef-OmniVoice-Personal",
+})
+
+
+class BundleError(Exception):
+    """A bundle build/parse failure carrying the HTTP status the router maps to."""
+
+    def __init__(self, status: int, detail: str):
+        super().__init__(detail)
+        self.status = status
+        self.detail = detail
+
+
+def normalize_spdx(spdx: Optional[str]) -> str:
+    """Return a safe SPDX id: the value if it's allowlisted or a ``LicenseRef-``
+    custom id, else :data:`DEFAULT_LICENSE`. Never raises, never 400s — a junk
+    id (incl. shell-injection attempts) normalizes to the default. Membership /
+    fixed-prefix only — no regex (CodeQL-clean)."""
+    if not spdx or not isinstance(spdx, str):
+        return DEFAULT_LICENSE
+    s = spdx.strip()
+    if s in _SPDX_ALLOWLIST or s.startswith("LicenseRef-"):
+        return s
+    return DEFAULT_LICENSE
+
+
+def build_manifest(
+    profile: dict,
+    *,
+    license_spdx: str,
+    tags: list[str],
+    engine_id: str = "",
+    custom_license_text: Optional[str] = None,
+    preview: Optional[dict] = None,
+    members: Optional[dict] = None,
+    omnivoice_version: str = "",
+) -> dict:
+    """Build the ``manifest.json`` object for a profile row. Mirrors the legacy
+    ``_bundle_metadata`` persona fields, adds the format discriminator, license
+    (normalized — never raises on a bad id, A19), tags, preview + members blocks.
+    Pure: no I/O, no model."""
+    return {
+        "format": OVSVOICE_FORMAT,
+        "schema_version": OVSVOICE_SCHEMA_VERSION,
+        "omnivoice_version": omnivoice_version or "",
+        "exported_at": time.time(),
+        "persona": {
+            "name": profile.get("name") or "",
+            "kind": profile.get("kind") or "clone",
+            "language": profile.get("language") or "Auto",
+            "personality": profile.get("personality") or "",
+            "instruct": profile.get("instruct") or "",
+            "ref_text": profile.get("ref_text") or "",
+            "seed": profile.get("seed"),                 # int or None (A16)
+            "is_locked": bool(profile.get("is_locked")),
+            "vd_states": profile.get("vd_states"),        # JSON string or None (A15) — never re-parsed
+        },
+        "engine": {"id": engine_id or "", "design_params": None},
+        "license": {"spdx": normalize_spdx(license_spdx), "custom_text": custom_license_text or None},
+        "tags": list(tags or []),
+        "preview": preview,                              # set by the audio step; None for legacy/no-preview
+        "members": members or {"ref_audio": None, "locked_audio": None, "consent_audio": None},
+    }
+
+
+def build_consent_json(profile: dict, *, has_recording: bool) -> Optional[dict]:
+    """The optional ``consent.json`` for a profile, or None when there's nothing
+    to attest. A ``design`` persona attests as designed-synthetic by definition;
+    a verified clone attests as a self-recorded statement. Import treats these
+    fields as ADVISORY — real verification needs the actual consent_audio member
+    (see the import rules), so this can't forge verified-own-voice."""
+    kind = profile.get("kind") or "clone"
+    consent_text = (profile.get("consent_text") or "").strip()
+    verified = bool(profile.get("verified_own_voice"))
+    if kind == "design":
+        method = "designed-synthetic"
+        verified = True
+    elif verified or consent_text or has_recording:
+        method = "self-recorded-statement"
+    else:
+        return None  # nothing to attest
+    recorded_at = profile.get("consent_recorded_at")
+    try:
+        recorded_at = float(recorded_at)
+    except (TypeError, ValueError):
+        recorded_at = time.time()
+    return {
+        "verified_own_voice": verified,
+        "method": method,
+        "consent_text": consent_text,
+        "recorded_at": recorded_at,
+        "has_recording": bool(has_recording),
+    }
+
+
+__all__ = [
+    "OVSVOICE_FORMAT", "OVSVOICE_SCHEMA_VERSION", "MAX_BUNDLE_BYTES",
+    "DEFAULT_LICENSE", "BundleError", "normalize_spdx", "build_manifest",
+    "build_consent_json",
+]

--- a/tests/test_persona_bundle.py
+++ b/tests/test_persona_bundle.py
@@ -1,0 +1,106 @@
+"""Pure-core tests for the .ovsvoice persona bundle (#29 / parity §R3 G1).
+
+Covers the model-free nucleus: SPDX normalization, manifest schema/fields, and
+the consent attestation builder. The audio preview + ZIP pack/unpack are a
+separate slice (and run on CI for the torch-coupled paths).
+"""
+from __future__ import annotations
+
+from services.persona_bundle import (
+    DEFAULT_LICENSE,
+    OVSVOICE_FORMAT,
+    OVSVOICE_SCHEMA_VERSION,
+    build_consent_json,
+    build_manifest,
+    normalize_spdx,
+)
+
+_PROFILE = {
+    "name": "Aria Narration", "kind": "design", "language": "English",
+    "personality": "warm-narrator", "instruct": "female, middle-aged, low pitch",
+    "ref_text": "Hello.", "seed": 42, "is_locked": False,
+    "vd_states": '{"gender":"female"}',
+}
+
+
+# ── SPDX normalization ──────────────────────────────────────────────────────
+
+def test_spdx_allowlisted_kept():
+    for ok in ("CC-BY-4.0", "MIT", "Apache-2.0", "CC0-1.0", "LicenseRef-OmniVoice-Personal"):
+        assert normalize_spdx(ok) == ok
+
+
+def test_spdx_custom_licenseref_prefix_kept():
+    assert normalize_spdx("LicenseRef-MyStudio-Terms") == "LicenseRef-MyStudio-Terms"
+
+
+def test_spdx_junk_and_injection_normalize_to_default():
+    for bad in (None, "", "   ", "GPL-3.0-only", "haha; rm -rf /", "<script>", 123):
+        assert normalize_spdx(bad) == DEFAULT_LICENSE  # never raises, never the raw junk
+
+
+def test_spdx_is_stripped():
+    assert normalize_spdx("  MIT  ") == "MIT"
+
+
+# ── manifest ────────────────────────────────────────────────────────────────
+
+def test_manifest_format_discriminator_and_schema():
+    m = build_manifest(_PROFILE, license_spdx="CC-BY-4.0", tags=["narration"])
+    assert m["format"] == OVSVOICE_FORMAT
+    assert m["schema_version"] == OVSVOICE_SCHEMA_VERSION
+    assert isinstance(m["exported_at"], float)
+
+
+def test_manifest_persona_fields_mirror_profile():
+    m = build_manifest(_PROFILE, license_spdx="CC-BY-4.0", tags=[])
+    p = m["persona"]
+    assert p["name"] == "Aria Narration" and p["kind"] == "design"
+    assert p["seed"] == 42 and p["is_locked"] is False
+    assert p["vd_states"] == '{"gender":"female"}'  # JSON string, NOT re-parsed
+
+
+def test_manifest_seed_and_vd_states_none_passthrough():
+    m = build_manifest({"name": "X", "seed": None, "vd_states": None},
+                       license_spdx="MIT", tags=[])
+    assert m["persona"]["seed"] is None
+    assert m["persona"]["vd_states"] is None
+
+
+def test_manifest_normalizes_bad_license_never_raises():
+    m = build_manifest(_PROFILE, license_spdx="bogus-license", tags=[])
+    assert m["license"]["spdx"] == DEFAULT_LICENSE
+
+
+def test_manifest_tags_and_members_defaults():
+    m = build_manifest(_PROFILE, license_spdx="MIT", tags=["a", "b"])
+    assert m["tags"] == ["a", "b"]
+    assert m["members"] == {"ref_audio": None, "locked_audio": None, "consent_audio": None}
+    assert m["preview"] is None
+
+
+# ── consent.json ────────────────────────────────────────────────────────────
+
+def test_consent_design_is_designed_synthetic_verified():
+    c = build_consent_json(_PROFILE, has_recording=False)
+    assert c["method"] == "designed-synthetic"
+    assert c["verified_own_voice"] is True
+
+
+def test_consent_clone_self_recorded_when_attested():
+    prof = {"kind": "clone", "verified_own_voice": 1, "consent_text": "I consent.",
+            "consent_recorded_at": 1749790000.0}
+    c = build_consent_json(prof, has_recording=True)
+    assert c["method"] == "self-recorded-statement"
+    assert c["has_recording"] is True and c["consent_text"] == "I consent."
+    assert c["recorded_at"] == 1749790000.0
+
+
+def test_consent_none_when_nothing_to_attest():
+    assert build_consent_json({"kind": "clone"}, has_recording=False) is None
+
+
+def test_consent_recorded_at_coerced_when_missing_or_bad():
+    c = build_consent_json({"kind": "clone", "consent_text": "ok", "consent_recorded_at": "nope"},
+                           has_recording=True)
+    assert isinstance(c["recorded_at"], float)  # coerced to now, not a crash


### PR DESCRIPTION
The **model-free nucleus** of the portable `.ovsvoice` persona-bundle format (parity §R3 G1): format constants, SPDX normalization, and the manifest/consent builders — all pure (no torch, no I/O), fully locally testable. The audio preview + ZIP pack/unpack + watermark `force=` param + router + frontend are follow-on slices of #29.

- **`normalize_spdx()`** — allowlist membership + `LicenseRef-` prefix; junk/None/injection → `DEFAULT_LICENSE`, never raises/400s. No regex over the SPDX string (CodeQL-clean).
- **`build_manifest()`** — mirrors the legacy `_bundle_metadata` persona fields + format discriminator + normalized license + tags + engine/preview/members. `seed`/`vd_states` pass through None-safe (`vd_states` is a JSON string, never re-parsed). `BundleError(status, detail)` for the router to map.
- **`build_consent_json()`** — designed-synthetic for `kind='design'`, self-recorded for an attested clone, `None` when nothing to attest. **Advisory by design** — real verification needs the actual consent-audio member, so verified-own-voice can't be forged by hand-editing a manifest.

**Tests:** 14 (SPDX allowlist/prefix/junk/strip; manifest schema + field mirror + None-passthrough + bad-license-normalized; consent design/clone/none/coerce). Backend pytest + CJK guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## `.ovsvoice` Persona-Bundle Format: Model-Free Core Implementation

Introduces the pure, dependency-free nucleus of the `.ovsvoice` persona-bundle format—a portable ZIP packaging voice profiles with optional reference clips, consent attestations, SPDX licensing, and watermarked previews. This PR implements three core functions:

### `normalize_spdx(spdx: Optional[str]) -> str`
Validates and normalizes SPDX license identifiers using **allowlist membership** (no regex, CodeQL-clean). Preserves:
- Allowlisted identifiers: `CC0-1.0`, `CC-BY-4.0`, `CC-BY-SA-4.0`, `CC-BY-NC-4.0`, `CC-BY-NC-SA-4.0`, `CC-BY-ND-4.0`, `MIT`, `Apache-2.0`, `LicenseRef-OmniVoice-Personal`
- Custom `LicenseRef-*` prefixes (user-defined)

Maps invalid, null, or injection-attack inputs (e.g., `None`, `""`, `"GPL-3.0-only"`, `"<script>"`) to `DEFAULT_LICENSE` without raising exceptions.

### `build_manifest(profile: dict, **kwargs) -> dict`
Constructs the `manifest.json` structure by:
- Setting format discriminator (`OVSVOICE_FORMAT`, schema version `1`, timestamp)
- Mirroring profile fields: persona name/kind/language/personality/instruct/ref_text + derivable state (`seed`, `vd_states` as JSON strings, `is_locked`)
- Applying normalized SPDX license + optional custom text
- Inserting tags, engine/preview/members blocks with safe defaults
- Safely passing through `seed` and `vd_states` (stored as-is without re-parsing) even when `None`

Raises `BundleError` with HTTP status codes for router-level error handling.

### `build_consent_json(profile: dict, *, has_recording: bool) -> Optional[dict]`
Generates optional consent attestations using **advisory-by-design** semantics:

```
                                    ┌─────────────────────┐
                                    │ kind == "design"?   │
                                    └──────────┬──────────┘
                              Yes              │              No
                         ┌────────────────────┘ └─────────────────┐
                         │                                        │
                ┌────────▼────────┐                     ┌─────────▼─────────┐
                │ designed-       │                     │ verified_own_voice│
                │ synthetic       │                     │ OR consent_text   │
                │ (verified=True) │                     │ OR has_recording? │
                └────────────────┘                      └─────────┬─────────┘
                                                           Yes│ No│
                                                     ┌────────┘  └─────────┐
                                                     │                     │
                                            ┌────────▼────────┐  ┌────────▼──┐
                                            │ self-recorded-  │  │   None    │
                                            │ statement       │  │(nothing   │
                                            │ (attested flow) │  │ to attest)│
                                            └─────────────────┘  └───────────┘
```

For design personas: forced `method="designed-synthetic"`, `verified_own_voice=True` (synthetic by definition).
For clones: `method="self-recorded-statement"` when verified, has consent text, or has recording; otherwise returns `None`.
Coerces `consent_recorded_at` to float timestamp, falling back to `time.time()` on missing/invalid input.

**Advisory behavior:** consent records prevent forgery through manifest hand-editing; actual verification requires the consent-audio member file.

### Coverage
**14 test cases** validating:
- SPDX: allowlist preservation, LicenseRef prefix handling, junk/injection normalization, whitespace stripping
- Manifest: format/schema/exported_at types, persona field passthrough, seed/vd_states None-safety, license normalization, tag/member/preview defaults
- Consent: designed-synthetic vs. self-recorded selection, None-return for unattested clones, recorded_at coercion

**Exports:** `OVSVOICE_FORMAT`, `OVSVOICE_SCHEMA_VERSION`, `MAX_BUNDLE_BYTES` (100 MB), `DEFAULT_LICENSE`, `BundleError`, `normalize_spdx`, `build_manifest`, `build_consent_json`

**File metrics:** `+126/-0` (backend module) + `+106/-0` (pytest tests)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->