### PR TITLE
feat(capture): opt-in LLM refinement on REST /transcribe (dictation parity)

### DIFF
--- a/backend/api/routers/capture.py
+++ b/backend/api/routers/capture.py
@@ -25,12 +25,19 @@ router = APIRouter()
 logger = logging.getLogger("omnivoice.capture")
 
 
+def _truthy(value: Optional[str]) -> bool:
+    """Parse a multipart form flag. Treats '1'/'true'/'yes'/'on'/'auto'
+    (any case) as on; everything else — including None — as off."""
+    return (value or "").strip().lower() in {"1", "true", "yes", "on", "auto"}
+
+
 @router.post("/transcribe")
 async def transcribe_audio(
     audio: UploadFile = File(...),
     language: Optional[str] = Form(None),
     model: Optional[str] = Form(None),
     mode: Optional[str] = Form(None),
+    refine: Optional[str] = Form(None),
 ):
     """Transcribe an audio file to text.
 
@@ -40,10 +47,19 @@ async def transcribe_audio(
         model: Whisper model size (legacy; ignored in dual-mode architecture).
         mode: 'fast' (default) uses MLX Turbo for speed; 'accurate' uses
               WhisperX with forced alignment for word-level timing.
+        refine: Opt-in local-LLM cleanup of the final text (disfluencies,
+              self-corrections, punctuation) — same pipeline the live
+              dictation socket uses. Off by default so MCP/CLI callers don't
+              pay LLM latency unless they ask; honours the user's
+              Settings → Dictation-refinement config and silently passes
+              through when no LLM backend is configured. The raw ``text``
+              is always returned; ``refined_text`` is added only when the
+              LLM actually changed something.
 
     Returns:
         {
             "text": "full transcription",
+            "refined_text": "cleaned text",   # only when refine=true changed it
             "segments": [ {"start": 0.0, "end": 1.5, "text": "..."}, ... ],
             "language": "en",
             "duration_s": 4.2,
@@ -103,12 +119,24 @@ async def transcribe_audio(
 
         detected_lang = result.get("language", language or "unknown")
 
+        # Opt-in Wave 2.1 refinement, mirroring the live-dictation socket
+        # (capture_ws). Off-thread (it's a network call, not GPU); never
+        # raises — maybe_refine swallows failures and a missing LLM into a
+        # None pass-through, so the raw text always stands.
+        refined_text = None
+        if _truthy(refine) and full_text:
+            from services.refinement import maybe_refine
+            refined = await asyncio.to_thread(maybe_refine, full_text)
+            if refined and refined != full_text:
+                refined_text = refined
+
         logger.info(
-            "Capture transcription done: engine=%s, elapsed=%.2fs, duration=%.1fs, mode=%s",
+            "Capture transcription done: engine=%s, elapsed=%.2fs, duration=%.1fs, mode=%s, refined=%s",
             engine_id, elapsed, duration, "accurate" if use_accurate else "fast",
+            refined_text is not None,
         )
 
-        return {
+        response = {
             "text": full_text,
             "segments": [
                 {
@@ -123,6 +151,9 @@ async def transcribe_audio(
             "transcription_time_s": elapsed,
             "engine": engine_id,
         }
+        if refined_text is not None:
+            response["refined_text"] = refined_text
+        return response
     finally:
         try:
             os.unlink(tmp.name)

--- a/tests/test_capture_refine.py
+++ b/tests/test_capture_refine.py
@@ -1,0 +1,124 @@
+"""
+Tests for the opt-in local-LLM refinement on the REST `/transcribe`
+endpoint (the MCP/CLI/file-upload surface).
+
+Contract mirrors the live-dictation socket (capture_ws):
+  * refinement is OFF unless the caller passes a truthy `refine` flag
+    (backward-compatible — existing MCP/CLI callers keep raw-only output);
+  * the raw `text` is ALWAYS present;
+  * `refined_text` appears ONLY when the LLM actually changed the text.
+
+The ASR backend and the refinement call are both stubbed — this tests the
+endpoint's wiring, not transcription or LLM quality. maybe_refine is patched
+**at its source module** (`services.refinement.maybe_refine`) because the
+endpoint imports it lazily inside the handler; patching a bound name would
+miss once the route-shape fixtures purge `services.*` from sys.modules.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+
+class _StubBackend:
+    id = "stub"
+
+    def transcribe(self, _path, **_kw):
+        return {
+            "text": "um so like the meeting is at 3pm you know",
+            "segments": [
+                {"start": 0.0, "end": 2.0,
+                 "text": "um so like the meeting is at 3pm you know"},
+            ],
+            "language": "en",
+        }
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    # Both ASR getters resolve to the same in-process stub so neither mode
+    # touches a model. Patched at source — the handler imports them lazily.
+    monkeypatch.setattr(
+        "services.asr_backend.get_capture_asr_backend", lambda: _StubBackend())
+    monkeypatch.setattr(
+        "services.asr_backend.get_active_asr_backend", lambda: _StubBackend())
+
+    from main import app
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+def _post(client, **data):
+    return client.post(
+        "/transcribe",
+        files={"audio": ("a.wav", b"\x00" * 32000, "audio/wav")},
+        data=data,
+    )
+
+
+def test_no_refine_flag_returns_raw_only(client, monkeypatch):
+    # maybe_refine must never even be called when the flag is absent.
+    called = {"n": 0}
+
+    def _boom(_t):
+        called["n"] += 1
+        return "SHOULD NOT APPEAR"
+
+    monkeypatch.setattr("services.refinement.maybe_refine", _boom)
+
+    r = _post(client)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["text"].startswith("um so like")
+    assert "refined_text" not in body
+    assert called["n"] == 0
+
+
+def test_refine_flag_adds_refined_text_when_changed(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.refinement.maybe_refine",
+        lambda _t: "So the meeting is at 3pm.")
+
+    r = _post(client, refine="true")
+    assert r.status_code == 200
+    body = r.json()
+    # Raw text is preserved verbatim …
+    assert body["text"].startswith("um so like")
+    # … and the cleaned text rides alongside it.
+    assert body["refined_text"] == "So the meeting is at 3pm."
+
+
+def test_refine_noop_omits_refined_text(client, monkeypatch):
+    # maybe_refine returning None (no LLM / off / failure) must leave the
+    # response raw-only — no empty/echoed refined_text key.
+    monkeypatch.setattr("services.refinement.maybe_refine", lambda _t: None)
+
+    r = _post(client, refine="1")
+    assert r.status_code == 200
+    assert "refined_text" not in r.json()
+
+
+def test_refine_identical_result_omits_refined_text(client, monkeypatch):
+    # If the LLM returns the same string, don't add a redundant key.
+    monkeypatch.setattr(
+        "services.refinement.maybe_refine",
+        lambda t: t)
+
+    r = _post(client, refine="yes")
+    assert r.status_code == 200
+    assert "refined_text" not in r.json()
+
+
+@pytest.mark.parametrize("flag,expect_refine", [
+    ("true", True), ("1", True), ("auto", True), ("on", True), ("YES", True),
+    ("false", False), ("0", False), ("off", False), ("", False),
+])
+def test_flag_parsing(client, monkeypatch, flag, expect_refine):
+    monkeypatch.setattr(
+        "services.refinement.maybe_refine", lambda _t: "CLEANED")
+    r = _post(client, refine=flag)
+    assert r.status_code == 200
+    assert ("refined_text" in r.json()) is expect_refine


### PR DESCRIPTION
Closes the last gap in the **WisprFlow-grade dictation** roadmap item (discussion #346): the live-dictation socket (`capture_ws`) already runs the final transcript through the configured local LLM (Wave 2.1 — disfluency / self-correction / punctuation cleanup via `services.refinement.maybe_refine`), but the REST `/transcribe` endpoint — the **MCP / CLI / file-upload** surface — only did the always-on hallucination-loop collapse. Agentic and batch callers couldn't get the cleaned output.

### Change
Opt-in `refine` form flag on `POST /transcribe`, running the identical pipeline off-thread:
- **OFF by default** → existing MCP/CLI callers keep raw-only output, no LLM latency (backward-compatible).
- Honours **Settings → Dictation-refinement** config; silently passes through when no LLM is configured (**cross-platform default parity** — identical no-op everywhere without an LLM).
- Raw `text` always returned; `refined_text` added **only when the LLM changed it** — same contract the socket emits.

### Tests
`tests/test_capture_refine.py` — 13 cases: flag-off never calls the LLM, `refined_text` on change, no-op/identical omission, flag parsing (`true/1/auto/on/yes` on; `false/0/off/""` off). `maybe_refine` patched at source (handler imports it lazily — bound-name patch would miss after the route-shape fixtures purge `services.*`). **13 passed locally.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Introduces an opt-in LLM refinement feature to the REST `/transcribe` endpoint, enabling parity with the live-dictation socket's capabilities. The feature bridges the gap between the socket handler (which already refines transcripts) and REST callers (MCP, CLI, file-upload).

## Key Changes

**`backend/api/routers/capture.py`** (+33/-2)
- Added `refine` optional form parameter to `POST /transcribe`
- Implemented `_truthy()` helper to parse flag values (`true/1/yes/on/auto` → enabled; `false/0/off/""` → disabled)
- Conditionally invokes the existing `maybe_refine` LLM pipeline when flag is truthy
- Response contract updated to always return `text` and `segments`; `refined_text` field added only when refinement is enabled and produces a modified result
- Updated logging to report refinement outcomes

**`tests/test_capture_refine.py`** (+124/-0)
- New comprehensive test suite with 13 test cases validating refinement behavior
- Uses `_StubBackend` to provide deterministic ASR output for reproducible testing
- Monkeypatches ASR backend getters to prevent real model invocations
- Test coverage includes:
  - Absence of refinement calls when flag is omitted
  - `refined_text` presence when LLM modifies output
  - `refined_text` omission when LLM returns identical or no-op results
  - Flag parsing semantics across multiple truthy/falsy values

## Behavior Flow

```mermaid
flowchart TD
    A["POST /transcribe received<br/>(with optional refine param)"] --> B{Refine flag<br/>present & truthy?}
    B -->|No/Falsy| C["Return: text + segments only"]
    B -->|Yes/Truthy| D{LLM configured?}
    D -->|No| C
    D -->|Yes| E["Run maybe_refine pipeline<br/>(disfluency correction,<br/>self-correction,<br/>punctuation cleanup)"]
    E --> F{Output changed<br/>from original?}
    F -->|No/Identical| G["Return: text + segments<br/>(refined_text omitted)"]
    F -->|Yes/Modified| H["Return: text + segments<br/>+ refined_text"]
    C --> I["Response sent to client"]
    G --> I
    H --> I
```

## Design Principles

- **Backward compatible**: Feature is opt-in (defaults OFF), with no impact on existing callers
- **Configuration-aware**: Respects user's Settings → Dictation-refinement configuration
- **Silent fallback**: Gracefully handles cases where no LLM is configured
- **Off-thread processing**: Refinement runs asynchronously to minimize latency impact
- **Minimal response bloat**: `refined_text` field only included when necessary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->