### PR TITLE
feat(persona): /personas export·import·inspect router + wiring (#29 slice B)

### DIFF
--- a/backend/api/routers/personas.py
+++ b/backend/api/routers/personas.py
@@ -1,0 +1,327 @@
+"""HTTP layer for the `.ovsvoice` portable persona format (#29 / parity §R3 G1).
+
+Thin router over `services.persona_bundle`:
+
+    POST /personas/export/{profile_id}   → stream a downloadable .ovsvoice
+    POST /personas/import                → create a profile from a bundle
+    POST /personas/inspect               → read a bundle's manifest, no writes
+
+Mirrors the legacy `.omnivoice` endpoints (`marketplace.py`) and reuses the
+same path-confinement (`_voices_path`) + consent floor. `.ovsvoice` is additive;
+`.omnivoice` import stays a compatible legacy reader.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+import time
+import uuid
+
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi.responses import StreamingResponse
+
+from core import event_bus
+from core.config import VOICES_DIR  # noqa: F401 — re-exported for tests/monkeypatch
+from core.db import db_conn
+from core.version import APP_VERSION
+from services import persona_bundle as pb
+
+router = APIRouter()
+logger = logging.getLogger("omnivoice.personas")
+
+
+def _safe_name(name: str, profile_id: str) -> str:
+    """Sanitised download filename stem (marketplace idiom); empty → persona_<id>."""
+    cleaned = "".join(
+        c if c.isalnum() or c in "-_ " else "" for c in (name or "")
+    ).strip().replace(" ", "_")[:40]
+    return cleaned or f"persona_{profile_id}"
+
+
+# ── Export ────────────────────────────────────────────────────────────────
+
+
+@router.post("/personas/export/{profile_id}")
+async def export_persona(
+    profile_id: str,
+    license_spdx: str = Query(pb.DEFAULT_LICENSE),
+    tags: str = Query(""),
+    include_reference: bool = Query(True),
+):
+    """Build + stream a `.ovsvoice` bundle for a profile."""
+    with db_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM voice_profiles WHERE id = ?", (profile_id,)
+        ).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Voice profile not found")
+    profile = dict(row)
+
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+    try:
+        loop = asyncio.get_running_loop()
+        content = await loop.run_in_executor(
+            None,
+            functools.partial(
+                pb.build_persona_bundle,
+                profile,
+                license_spdx=license_spdx,
+                tags=tag_list,
+                include_reference=include_reference,
+                engine_id=os.environ.get("OMNIVOICE_MODEL", ""),
+                omnivoice_version=APP_VERSION,
+            ),
+        )
+    except pb.NoPreviewSource:
+        raise HTTPException(
+            status_code=503,
+            detail="This profile has no readable reference or locked audio to "
+                   "build a preview from — re-create or re-import it.",
+        )
+    except Exception:
+        logger.exception("persona export failed for %s", profile_id)
+        raise HTTPException(
+            status_code=503,
+            detail="Could not build the persona bundle — see Settings → Logs.",
+        )
+
+    filename = f"{_safe_name(profile.get('name'), profile_id)}.ovsvoice"
+    from io import BytesIO
+    return StreamingResponse(
+        BytesIO(content),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(content)),
+        },
+    )
+
+
+# ── Import ────────────────────────────────────────────────────────────────
+
+
+def _voices_dest(filename: str) -> str:
+    """Resolve an output filename inside VOICES_DIR; 400 on escape (belt+braces —
+    the name is always server-generated `{profile_id}…`)."""
+    from api.routers.profiles import _voices_path
+    path = _voices_path(filename)
+    if path is None:
+        raise HTTPException(status_code=400, detail="Invalid profile id")
+    return path
+
+
+def _consent_verified(parsed: pb.ParsedPersona, consent_path: str | None) -> bool:
+    """B12-B16: trust verified-own-voice ONLY with a real recording (≥ floor) AND
+    non-empty consent_text AND a consent.json present. The manifest flag alone
+    can't forge it."""
+    if not parsed.consent or not consent_path:
+        return False
+    if os.path.getsize(consent_path) < pb._MIN_CONSENT_AUDIO_BYTES:
+        return False
+    return bool((parsed.consent.get("consent_text") or "").strip())
+
+
+@router.post("/personas/import")
+async def import_persona(file: UploadFile = File(...)):
+    """Create a new voice profile from a `.ovsvoice` (or legacy `.omnivoice`) bundle."""
+    name = (file.filename or "").lower()
+    if not name.endswith(".ovsvoice") and not name.endswith(".omnivoice"):
+        raise HTTPException(status_code=400, detail="File must be a .ovsvoice or .omnivoice bundle")
+
+    content = await file.read()
+    try:
+        parsed = pb.parse_persona_bundle(content)
+    except pb.BundleError as e:
+        raise HTTPException(status_code=e.status, detail=e.detail)
+
+    persona = parsed.manifest.get("persona") or {}
+    written: list[str] = []
+
+    def _gen_id() -> str:
+        return str(uuid.uuid4())[:8]
+
+    profile_id = _gen_id()
+    try:
+        # ── Audio members → server-named files (never the member name). ──
+        ref_filename = None
+        locked_filename = None
+        if "ref_audio" in parsed.members:
+            ref_filename = f"{profile_id}{parsed.member_ext('ref_audio')}"
+            dest = _voices_dest(ref_filename)
+            parsed.extract_member("ref_audio", dest); written.append(dest)
+        if "locked_audio" in parsed.members:
+            locked_filename = f"{profile_id}_locked{parsed.member_ext('locked_audio')}"
+            dest = _voices_dest(locked_filename)
+            parsed.extract_member("locked_audio", dest); written.append(dest)
+        # Preview-only bundle (A12/B8): use the preview as the usable ref clip.
+        if ref_filename is None and locked_filename is None and "preview" in parsed.members:
+            ref_filename = f"{profile_id}{parsed.member_ext('preview')}"
+            dest = _voices_dest(ref_filename)
+            parsed.extract_member("preview", dest); written.append(dest)
+        if ref_filename is None and locked_filename is None:
+            raise HTTPException(status_code=400, detail="bundle has no usable audio")
+
+        # ── Consent recording (optional) ──
+        consent_filename = None
+        consent_path = None
+        if "consent_audio" in parsed.members:
+            consent_filename = f"{profile_id}_consent{parsed.member_ext('consent_audio')}"
+            consent_path = _voices_dest(consent_filename)
+            parsed.extract_member("consent_audio", consent_path); written.append(consent_path)
+
+        verified = _consent_verified(parsed, consent_path)
+        consent_text = ((parsed.consent or {}).get("consent_text") or "").strip()
+        recorded_at = None
+        if verified:
+            try:
+                recorded_at = float(parsed.consent.get("recorded_at"))
+            except (TypeError, ValueError):
+                recorded_at = time.time()
+
+        is_locked = bool(persona.get("is_locked") and locked_filename)
+        ref_for_db = ref_filename or locked_filename  # at least one is set
+
+        def _insert(pid: str):
+            with db_conn() as conn:
+                conn.execute(
+                    """INSERT INTO voice_profiles
+                       (id, name, ref_audio_path, ref_text, instruct, language,
+                        seed, personality, is_locked, locked_audio_path, created_at,
+                        kind, vd_states,
+                        verified_own_voice, consent_text, consent_audio_path, consent_recorded_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        pid,
+                        persona.get("name") or "Imported Voice",
+                        ref_for_db,
+                        persona.get("ref_text", ""),
+                        persona.get("instruct", ""),
+                        persona.get("language", "Auto"),
+                        persona.get("seed"),
+                        persona.get("personality", ""),
+                        1 if is_locked else 0,
+                        locked_filename or "",
+                        time.time(),
+                        persona.get("kind") or "clone",
+                        persona.get("vd_states"),
+                        1 if verified else 0,
+                        # Keep the attestation text so the user can re-attest locally,
+                        # even when imported unverified.
+                        consent_text,
+                        consent_filename if verified else "",
+                        recorded_at if verified else None,
+                    ),
+                )
+
+        import sqlite3
+        try:
+            _insert(profile_id)
+        except sqlite3.IntegrityError:
+            profile_id = _gen_id()  # one retry on id collision (B20)
+            # rename the on-disk files to the new id so they still match the row
+            written = _rename_for_new_id(written, profile_id)
+            ref_for_db = _retarget(ref_for_db, profile_id)
+            locked_filename = _retarget(locked_filename, profile_id)
+            consent_filename = _retarget(consent_filename, profile_id)
+            _insert(profile_id)
+
+    except HTTPException:
+        _cleanup(written)
+        raise
+    except Exception:
+        _cleanup(written)
+        logger.exception("persona import failed")
+        raise HTTPException(status_code=500, detail="Import failed; no files were kept.")
+
+    event_bus.emit("profiles", {"action": "created", "id": profile_id})
+    logger.info("Imported persona %r as %s (verified=%s)", persona.get("name"), profile_id, verified)
+
+    return {
+        "success": True,
+        "profile_id": profile_id,
+        "name": persona.get("name") or "Imported Voice",
+        "kind": persona.get("kind") or "clone",
+        "verified_own_voice": verified,
+        "preview_only": parsed.preview_only,
+        "license_spdx": parsed.license_spdx,
+        "watermarked_preview": parsed.watermarked_preview,
+        "source_bundle": file.filename,
+        "schema_version_ahead": parsed.schema_version_ahead,
+    }
+
+
+def _cleanup(paths: list[str]) -> None:
+    for p in paths:
+        try:
+            if p and os.path.exists(p):
+                os.remove(p)
+        except OSError:
+            pass
+
+
+def _rename_for_new_id(written: list[str], new_id: str) -> list[str]:
+    """After an id-collision retry, rename each written file to carry the new id
+    (filenames are `{old_id}…`; swap the leading 8-char stem)."""
+    out = []
+    for p in written:
+        d, base = os.path.split(p)
+        # base looks like {id}{ext} | {id}_locked{ext} | {id}_consent{ext}
+        new_base = new_id + base[8:]
+        new_path = os.path.join(d, new_base)
+        try:
+            os.replace(p, new_path)
+            out.append(new_path)
+        except OSError:
+            out.append(p)
+    return out
+
+
+def _retarget(filename: str | None, new_id: str) -> str | None:
+    return new_id + filename[8:] if filename else filename
+
+
+# ── Inspect (no-write preview) ──────────────────────────────────────────────
+
+
+@router.post("/personas/inspect")
+async def inspect_persona(file: UploadFile = File(...)):
+    """Read a bundle's manifest + consent summary WITHOUT writing any file or row."""
+    name = (file.filename or "").lower()
+    if not name.endswith(".ovsvoice") and not name.endswith(".omnivoice"):
+        raise HTTPException(status_code=400, detail="File must be a .ovsvoice or .omnivoice bundle")
+    content = await file.read()
+    try:
+        parsed = pb.parse_persona_bundle(content)
+    except pb.BundleError as e:
+        raise HTTPException(status_code=e.status, detail=e.detail)
+
+    persona = parsed.manifest.get("persona") or {}
+    consent_summary = None
+    if parsed.consent:
+        has_recording = "consent_audio" in parsed.members
+        consent_summary = {
+            "verified_claimed": bool(parsed.consent.get("verified_own_voice")),
+            "method": parsed.consent.get("method", ""),
+            "has_recording": has_recording,
+            # would_verify mirrors import's gate, minus the byte-floor check
+            # (inspect never extracts to measure size — advisory only).
+            "would_verify": has_recording and bool((parsed.consent.get("consent_text") or "").strip()),
+        }
+
+    return {
+        "format": "omnivoice-legacy" if parsed.is_legacy else pb.OVSVOICE_FORMAT,
+        "schema_version": parsed.manifest.get("schema_version", pb.OVSVOICE_SCHEMA_VERSION),
+        "name": persona.get("name") or "Imported Voice",
+        "kind": persona.get("kind") or "clone",
+        "language": persona.get("language", "Auto"),
+        "personality": persona.get("personality", ""),
+        "is_locked": bool(persona.get("is_locked")),
+        "license_spdx": parsed.license_spdx,
+        "tags": parsed.manifest.get("tags") or [],
+        "preview_only": parsed.preview_only,
+        "watermarked_preview": parsed.watermarked_preview,
+        "consent": consent_summary,
+        "schema_version_ahead": parsed.schema_version_ahead,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -328,6 +328,7 @@ from api.routers import (
     openai_compat,
     tts_stream,
     marketplace,
+    personas,
     sonitranslate,
     audiobook,
     longform_jobs,
@@ -789,6 +790,7 @@ app.include_router(capture_ws.router)
 app.include_router(openai_compat.router)
 app.include_router(tts_stream.router)
 app.include_router(marketplace.router)
+app.include_router(personas.router)
 app.include_router(sonitranslate.router)
 app.include_router(audiobook.router)
 app.include_router(longform_jobs.router)

--- a/backend/services/persona_bundle.py
+++ b/backend/services/persona_bundle.py
@@ -9,7 +9,13 @@ pack/unpack (which lazily import torchaudio/watermark) layer on top of these.
 """
 from __future__ import annotations
 
+import io
+import json
+import os
+import re
 import time
+import zipfile
+from dataclasses import dataclass
 from typing import Optional
 
 # ── Format constants ─────────────────────────────────────────────────────────
@@ -18,6 +24,15 @@ OVSVOICE_SCHEMA_VERSION = 1
 MAX_BUNDLE_BYTES = 100 * 1024 * 1024          # 100 MB (mirrors marketplace cap)
 _MIN_CONSENT_AUDIO_BYTES = 1000               # the consent-recording floor
 DEFAULT_LICENSE = "LicenseRef-OmniVoice-Personal"
+PREVIEW_MAX_SECONDS = 8.0                      # preview length cap (A6)
+PREVIEW_SAMPLE_RATE = 24_000                  # preview rate; mono, 16-bit PCM (A8)
+
+# Audio member prefixes the importer recognises. The ZIP member NAME is never
+# used to build an output path (zip-slip safe, B10) — only its extension, and
+# only after the linear allowlist below.
+_AUDIO_MEMBER_PREFIXES = ("ref_audio", "locked_audio", "consent_audio", "preview")
+# Reused verbatim from profiles.py:306 — single linear quantifier, no ReDoS.
+_MEMBER_EXT_RE = re.compile(r"^\.[A-Za-z0-9]{1,8}$")
 
 # Membership allowlist for SPDX validation — a fixed-string set + the
 # ``LicenseRef-`` prefix. NO regex over the (user-supplied) SPDX string, so this
@@ -35,6 +50,19 @@ class BundleError(Exception):
         super().__init__(detail)
         self.status = status
         self.detail = detail
+
+
+class NoPreviewSource(Exception):
+    """No readable source clip exists to build a preview from (A2/A3/A4/A5/A12).
+    The router maps this to HTTP 503."""
+
+
+def _safe_member_ext(member_name: str) -> str:
+    """The extension for a ZIP member, allowlisted to ``^\\.[A-Za-z0-9]{1,8}$``
+    (else ``.wav``). Used ONLY to choose the output extension — never the path
+    (B11). Linear regex, no ReDoS."""
+    ext = os.path.splitext(member_name)[1]
+    return ext if _MEMBER_EXT_RE.match(ext) else ".wav"
 
 
 def normalize_spdx(spdx: Optional[str]) -> str:
@@ -119,8 +147,290 @@ def build_consent_json(profile: dict, *, has_recording: bool) -> Optional[dict]:
     }
 
 
+def _legacy_metadata(profile: dict, omnivoice_version: str) -> dict:
+    """A ``metadata.json`` payload shaped like marketplace ``_bundle_metadata`` so
+    an OLDER OmniVoice (which only reads metadata.json) can still import the ref
+    audio from a ``.ovsvoice`` bundle."""
+    return {
+        "bundle_version": 1,
+        "profile_name": profile.get("name") or "",
+        "ref_text": profile.get("ref_text") or "",
+        "instruct": profile.get("instruct") or "",
+        "language": profile.get("language") or "Auto",
+        "personality": profile.get("personality") or "",
+        "seed": profile.get("seed"),
+        "kind": profile.get("kind") or "clone",
+        "vd_states": profile.get("vd_states"),
+        "is_locked": bool(profile.get("is_locked")),
+        "omnivoice_version": omnivoice_version or "",
+    }
+
+
+def _resolve_voice_file(filename: Optional[str]) -> Optional[str]:
+    """Resolve a DB-stored audio filename strictly inside VOICES_DIR, returning
+    an absolute path only if the file actually exists. None on missing/escape —
+    mirrors profiles._voices_path (basename + realpath confinement, E1)."""
+    if not filename or os.path.basename(filename) != filename:
+        return None
+    from core.config import VOICES_DIR
+    root = os.path.realpath(VOICES_DIR)
+    path = os.path.realpath(os.path.join(root, filename))
+    if not path.startswith(root + os.sep):
+        return None
+    return path if os.path.isfile(path) else None
+
+
+def _generate_preview(profile: dict, embed_fn) -> tuple[bytes, bool, float]:
+    """Load the profile's source clip, downmix→mono, resample→24 kHz, trim ≤8 s,
+    watermark (forced), and return ``(wav_bytes, watermarked, duration_s)``.
+
+    Source precedence is locked-over-ref (profiles.py:230). Raises
+    :class:`NoPreviewSource` when neither clip is readable (A2-A5). All heavy
+    imports (torch/torchaudio/watermark) are lazy so the module stays model-free
+    at collection time (avoids the known local torch/Triton segfault)."""
+    import torch  # noqa: F401  (torchaudio needs it loaded)
+    import torchaudio
+    from services.audio_io import _safe_torchaudio_save
+    from services.watermark import _check_available
+
+    candidates = [profile.get("locked_audio_path"), profile.get("ref_audio_path")]
+    wav = None
+    for name in candidates:
+        path = _resolve_voice_file(name)
+        if not path:
+            continue
+        try:
+            waveform, sr = torchaudio.load(path)
+        except Exception:  # noqa: BLE001 — try the next candidate (A4)
+            continue
+        if waveform.numel() == 0:  # empty/zero-length (A5)
+            continue
+        if waveform.shape[0] > 1:  # downmix to mono (A7)
+            waveform = waveform.mean(dim=0, keepdim=True)
+        if sr != PREVIEW_SAMPLE_RATE:  # resample (A8)
+            waveform = torchaudio.functional.resample(waveform, sr, PREVIEW_SAMPLE_RATE)
+        cap = int(PREVIEW_SAMPLE_RATE * PREVIEW_MAX_SECONDS)
+        waveform = waveform[:, :cap]  # trim, shorter used whole (A6)
+        wav = waveform
+        break
+
+    if wav is None or wav.numel() == 0:
+        raise NoPreviewSource("no readable reference or locked audio for a preview")
+
+    # Forced watermark — bypasses the user pref but still no-ops without AudioSeal.
+    fn = embed_fn or _default_embed
+    wav = fn(wav, PREVIEW_SAMPLE_RATE)
+    watermarked = bool(_check_available())  # best-effort honesty (A11)
+
+    duration_s = round(wav.shape[-1] / PREVIEW_SAMPLE_RATE, 3)
+    buf = io.BytesIO()
+    _safe_torchaudio_save(buf, wav, PREVIEW_SAMPLE_RATE, format="wav", bits_per_sample=16)
+    return buf.getvalue(), watermarked, duration_s
+
+
+def _default_embed(wav, sample_rate):
+    """Default preview watermarker: services.watermark.embed_watermark(force=True)."""
+    from services.watermark import embed_watermark
+    return embed_watermark(wav, sample_rate, force=True)
+
+
+def build_persona_bundle(
+    profile: dict,
+    *,
+    license_spdx: str = DEFAULT_LICENSE,
+    tags: Optional[list[str]] = None,
+    custom_license_text: Optional[str] = None,
+    include_reference: bool = True,
+    engine_id: str = "",
+    omnivoice_version: str = "",
+    embed_fn=None,
+) -> bytes:
+    """Assemble a ``.ovsvoice`` ZIP in memory and return its bytes.
+
+    Always writes a watermarked ``preview.wav`` + ``manifest.json`` +
+    (legacy-shaped) ``metadata.json``. Writes ``consent.json`` when there's
+    something to attest, the raw ``ref_audio``/``locked_audio`` members unless
+    ``include_reference=False`` (privacy / preview-only, A12), and
+    ``consent_audio`` when a recording exists. Raises :class:`NoPreviewSource`
+    (router → 503) when no source clip is readable."""
+    preview_bytes, watermarked, duration_s = _generate_preview(profile, embed_fn)
+
+    members: dict = {"ref_audio": None, "locked_audio": None, "consent_audio": None}
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        if include_reference:
+            ref_path = _resolve_voice_file(profile.get("ref_audio_path"))
+            if ref_path:
+                name = f"ref_audio{os.path.splitext(ref_path)[1] or '.wav'}"
+                zf.write(ref_path, name)
+                members["ref_audio"] = name
+            locked_path = _resolve_voice_file(profile.get("locked_audio_path"))
+            if locked_path:
+                name = f"locked_audio{os.path.splitext(locked_path)[1] or '.wav'}"
+                zf.write(locked_path, name)
+                members["locked_audio"] = name
+
+        # Consent recording travels only when it exists and clears the floor.
+        consent_path = _resolve_voice_file(profile.get("consent_audio_path"))
+        has_recording = False
+        if consent_path and os.path.getsize(consent_path) >= _MIN_CONSENT_AUDIO_BYTES:
+            name = f"consent_audio{os.path.splitext(consent_path)[1] or '.wav'}"
+            zf.write(consent_path, name)
+            members["consent_audio"] = name
+            has_recording = True
+
+        zf.writestr("preview.wav", preview_bytes)
+
+        preview_block = {
+            "file": "preview.wav", "watermarked": watermarked,
+            "duration_s": duration_s, "sample_rate": PREVIEW_SAMPLE_RATE,
+        }
+        manifest = build_manifest(
+            profile, license_spdx=license_spdx, tags=tags or [],
+            engine_id=engine_id, custom_license_text=custom_license_text,
+            preview=preview_block, members=members,
+            omnivoice_version=omnivoice_version,
+        )
+        zf.writestr("manifest.json", json.dumps(manifest, ensure_ascii=False, indent=2))
+        zf.writestr("metadata.json",
+                    json.dumps(_legacy_metadata(profile, omnivoice_version),
+                               ensure_ascii=False, indent=2))
+        consent = build_consent_json(profile, has_recording=has_recording)
+        if consent is not None:
+            zf.writestr("consent.json", json.dumps(consent, ensure_ascii=False, indent=2))
+
+    return buf.getvalue()
+
+
+@dataclass
+class ParsedPersona:
+    manifest: dict                 # parsed manifest.json OR synthesized from metadata.json
+    consent: Optional[dict]        # parsed consent.json, or None
+    is_legacy: bool                # only metadata.json was found (B6/B23)
+    schema_version_ahead: bool     # manifest.schema_version > OVSVOICE_SCHEMA_VERSION (B7)
+    license_spdx: str              # normalized (B21)
+    preview_only: bool             # only preview.wav, no ref/locked member (A12/B8)
+    members: dict                  # {prefix: member_name} for audio members present
+    watermarked_preview: bool      # manifest.preview.watermarked (False for legacy)
+    _zip: zipfile.ZipFile          # open handle; router extracts via extract_member()
+
+    def member_ext(self, prefix: str) -> str:
+        name = self.members.get(prefix)
+        return _safe_member_ext(name) if name else ".wav"
+
+    def extract_member(self, prefix: str, dest_path: str) -> bool:
+        """Stream the audio member named by ``prefix`` to ``dest_path`` (a path
+        the CALLER derived from a server-generated id — never from the member
+        name). Returns False when the member is absent. Last-wins on dup (B9)."""
+        name = self.members.get(prefix)
+        if not name:
+            return False
+        import shutil
+        with self._zip.open(name) as src, open(dest_path, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        return True
+
+
+def parse_persona_bundle(content: bytes) -> ParsedPersona:
+    """Validate the ZIP and read manifest/consent WITHOUT touching the DB or
+    writing files. Raises :class:`BundleError` (400|413) for B1-B11. The caller
+    must use the returned ``ParsedPersona`` while the process holds ``content``
+    (the open ZIP reads from the in-memory bytes)."""
+    if len(content) > MAX_BUNDLE_BYTES:
+        raise BundleError(413, f"Bundle too large. Max is {MAX_BUNDLE_BYTES} bytes.")
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile:
+        raise BundleError(400, "not a valid ZIP bundle")
+
+    names = [n for n in zf.namelist() if not n.endswith("/")]
+
+    # Manifest selection: prefer manifest.json, fall back to legacy metadata.json.
+    manifest: dict = {}
+    is_legacy = False
+    if "manifest.json" in names:
+        try:
+            manifest = json.loads(zf.read("manifest.json"))
+        except (ValueError, UnicodeDecodeError):
+            raise BundleError(400, "manifest is not valid JSON")
+        if not isinstance(manifest, dict):
+            raise BundleError(400, "manifest is not valid JSON")
+        # A bundle whose format is neither ovsvoice nor absent → still read
+        # leniently (B6); we only branch on schema_version below.
+    elif "metadata.json" in names:
+        is_legacy = True
+        try:
+            legacy = json.loads(zf.read("metadata.json"))
+        except (ValueError, UnicodeDecodeError):
+            raise BundleError(400, "manifest is not valid JSON")
+        if not isinstance(legacy, dict):
+            raise BundleError(400, "manifest is not valid JSON")
+        manifest = {
+            "format": "omnivoice-legacy",
+            "schema_version": OVSVOICE_SCHEMA_VERSION,
+            "persona": {
+                "name": legacy.get("profile_name") or legacy.get("name") or "Imported Voice",
+                "kind": legacy.get("kind") or "clone",
+                "language": legacy.get("language") or "Auto",
+                "personality": legacy.get("personality") or "",
+                "instruct": legacy.get("instruct") or "",
+                "ref_text": legacy.get("ref_text") or "",
+                "seed": legacy.get("seed"),
+                "is_locked": bool(legacy.get("is_locked")),
+                "vd_states": legacy.get("vd_states"),
+            },
+            "license": {"spdx": DEFAULT_LICENSE, "custom_text": None},
+            "tags": [],
+            "preview": None,
+            "members": {},
+        }
+    else:
+        raise BundleError(400, "bundle is missing a manifest")
+
+    # Audio members by prefix (last-wins on duplicates, B9). The member NAME is
+    # retained only to read bytes + pick an extension — never to build a path.
+    members: dict = {}
+    for name in names:
+        for prefix in _AUDIO_MEMBER_PREFIXES:
+            if os.path.basename(name).startswith(prefix):
+                members[prefix] = name
+    has_audio = any(p in members for p in ("ref_audio", "locked_audio", "preview"))
+    if not has_audio:
+        raise BundleError(400, "bundle has no audio member")
+
+    consent = None
+    if "consent.json" in names:
+        try:
+            parsed = json.loads(zf.read("consent.json"))
+            if isinstance(parsed, dict):
+                consent = parsed
+        except (ValueError, UnicodeDecodeError):
+            consent = None  # advisory only — a bad consent.json never 400s
+
+    schema_version = manifest.get("schema_version", OVSVOICE_SCHEMA_VERSION)
+    try:
+        ahead = int(schema_version) > OVSVOICE_SCHEMA_VERSION
+    except (TypeError, ValueError):
+        ahead = False
+
+    preview_block = manifest.get("preview") or {}
+    watermarked_preview = bool(preview_block.get("watermarked")) if isinstance(preview_block, dict) else False
+    license_spdx = normalize_spdx((manifest.get("license") or {}).get("spdx"))
+    preview_only = ("preview" in members
+                    and "ref_audio" not in members and "locked_audio" not in members)
+
+    return ParsedPersona(
+        manifest=manifest, consent=consent, is_legacy=is_legacy,
+        schema_version_ahead=ahead, license_spdx=license_spdx,
+        preview_only=preview_only, members=members,
+        watermarked_preview=watermarked_preview, _zip=zf,
+    )
+
+
 __all__ = [
     "OVSVOICE_FORMAT", "OVSVOICE_SCHEMA_VERSION", "MAX_BUNDLE_BYTES",
-    "DEFAULT_LICENSE", "BundleError", "normalize_spdx", "build_manifest",
-    "build_consent_json",
+    "PREVIEW_MAX_SECONDS", "PREVIEW_SAMPLE_RATE", "DEFAULT_LICENSE",
+    "BundleError", "NoPreviewSource", "ParsedPersona",
+    "normalize_spdx", "build_manifest", "build_consent_json",
+    "build_persona_bundle", "parse_persona_bundle",
 ]

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -97,6 +97,8 @@ def embed_watermark(
     waveform: torch.Tensor,
     sample_rate: int,
     message: Optional[list[int]] = None,
+    *,
+    force: bool = False,
 ) -> torch.Tensor:
     """
     Embed an imperceptible watermark into the audio waveform.
@@ -105,11 +107,17 @@ def embed_watermark(
         waveform: Audio tensor of shape (channels, samples) or (1, channels, samples)
         sample_rate: Sample rate of the audio
         message: Optional 16-bit message (list of 0/1). Defaults to OMNI_MESSAGE.
+        force: Keyword-only. When True, bypass the user's invisible-watermark
+            preference (``is_enabled()``) and embed regardless — used by the
+            persona-preview path, which mandates a watermark at package time.
+            It does NOT bypass availability: when AudioSeal isn't installed the
+            call still no-ops and returns the input unchanged. Existing
+            positional call sites default to ``force=False`` (unchanged).
 
     Returns:
         Watermarked waveform (same shape as input).
     """
-    if not is_enabled() or not _check_available():
+    if (not force and not is_enabled()) or not _check_available():
         return waveform
 
     try:

--- a/backend/tests/test_personas_api.py
+++ b/backend/tests/test_personas_api.py
@@ -1,0 +1,223 @@
+"""API contract tests for the persona router (``api.routers.personas``).
+
+Torch-free by construction: bundles are hand-crafted ZIPs (manifest + raw audio
+bytes), so the import/inspect paths (parse → file-copy → DB insert) run without
+the model. The export path's preview generation needs torchaudio and is covered
+by the service-layer round-trip in ``tests/test_persona_bundle.py`` + CI; here we
+only assert export's 404 (which fails before any audio work).
+
+Follows the config-stub pattern of ``test_archetypes_api.py`` / ``test_community.py``
+so it mounts ONLY the persona router on a bare FastAPI app (no ``main`` import,
+no torch at collection).
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+_TMP = tempfile.mkdtemp(prefix="omnivoice_personas_test_")
+_VOICES = Path(_TMP) / "voices"
+_VOICES.mkdir(parents=True, exist_ok=True)
+_config = types.ModuleType("core.config")
+_config.DATA_DIR = _TMP
+_config.VOICES_DIR = str(_VOICES)
+_config.OUTPUTS_DIR = str(Path(_TMP) / "outputs")
+_config.DB_PATH = str(Path(_TMP) / "omnivoice.db")
+sys.modules["core.config"] = _config
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from core.db import db_conn, init_db  # noqa: E402
+from services.persona_bundle import build_manifest, DEFAULT_LICENSE  # noqa: E402
+from api.routers import personas as personas_router  # noqa: E402
+
+init_db()
+
+
+@pytest.fixture(scope="module")
+def client():
+    app = FastAPI()
+    app.include_router(personas_router.router)
+    return TestClient(app)
+
+
+# ── bundle builders (no torch) ───────────────────────────────────────────────
+
+def _ovsvoice(*, manifest_over=None, ref=b"R" * 200, locked=None, preview=b"P" * 200,
+              consent_audio=None, consent_json=None) -> bytes:
+    profile = {"name": "Aria", "kind": "clone", "seed": 7, "vd_states": None}
+    members = {"ref_audio": "ref_audio.wav" if ref else None,
+               "locked_audio": "locked_audio.wav" if locked else None,
+               "consent_audio": "consent_audio.wav" if consent_audio else None}
+    manifest = build_manifest(profile, license_spdx="CC-BY-4.0", tags=["x"],
+                              preview={"file": "preview.wav", "watermarked": True,
+                                       "duration_s": 6.0, "sample_rate": 24000},
+                              members=members)
+    if manifest_over:
+        manifest.update(manifest_over)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        if ref:
+            zf.writestr("ref_audio.wav", ref)
+        if locked:
+            zf.writestr("locked_audio.wav", locked)
+        if preview:
+            zf.writestr("preview.wav", preview)
+        if consent_audio:
+            zf.writestr("consent_audio.wav", consent_audio)
+        if consent_json is not None:
+            zf.writestr("consent.json", json.dumps(consent_json))
+    return buf.getvalue()
+
+
+def _legacy_omnivoice() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("metadata.json", json.dumps(
+            {"profile_name": "Old Voice", "kind": "clone", "language": "English"}))
+        zf.writestr("ref_audio.wav", b"R" * 200)
+    return buf.getvalue()
+
+
+def _upload(content: bytes, filename="x.ovsvoice"):
+    return {"file": (filename, content, "application/zip")}
+
+
+# ── export ───────────────────────────────────────────────────────────────────
+
+def test_export_404_when_profile_missing(client):
+    r = client.post("/personas/export/nope")
+    assert r.status_code == 404
+
+
+# ── import ───────────────────────────────────────────────────────────────────
+
+def test_import_rejects_bad_extension(client):
+    r = client.post("/personas/import", files=_upload(b"x", filename="evil.txt"))
+    assert r.status_code == 400
+
+
+def test_import_rejects_non_zip(client):
+    r = client.post("/personas/import", files=_upload(b"not a zip"))
+    assert r.status_code == 400
+
+
+def test_import_missing_manifest_400(client):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("ref_audio.wav", b"R" * 200)
+    r = client.post("/personas/import", files=_upload(buf.getvalue()))
+    assert r.status_code == 400
+
+
+def test_import_roundtrip_creates_profile(client):
+    r = client.post("/personas/import", files=_upload(_ovsvoice(), filename="Aria.ovsvoice"))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] and body["name"] == "Aria" and body["kind"] == "clone"
+    assert body["verified_own_voice"] is False
+    assert body["license_spdx"] == "CC-BY-4.0"
+    assert body["source_bundle"] == "Aria.ovsvoice"
+    pid = body["profile_id"]
+    with db_conn() as conn:
+        row = conn.execute("SELECT * FROM voice_profiles WHERE id=?", (pid,)).fetchone()
+    assert row is not None and row["name"] == "Aria" and row["seed"] == 7
+    # the ref file landed under a server-derived name, inside VOICES_DIR
+    assert os.path.isfile(os.path.join(_config.VOICES_DIR, row["ref_audio_path"]))
+    assert row["ref_audio_path"].startswith(pid)
+
+
+def test_import_case_insensitive_extension(client):
+    r = client.post("/personas/import", files=_upload(_ovsvoice(), filename="A.OVSVOICE"))
+    assert r.status_code == 200
+
+
+def test_import_forgery_guard_unverified(client):
+    # consent.json claims verified, but NO consent_audio member → unverified (B12).
+    bundle = _ovsvoice(consent_json={"verified_own_voice": True, "method": "self-recorded-statement",
+                                     "consent_text": "I consent.", "recorded_at": 1.0})
+    body = client.post("/personas/import", files=_upload(bundle)).json()
+    assert body["verified_own_voice"] is False
+
+
+def test_import_verified_with_recording(client):
+    bundle = _ovsvoice(
+        consent_audio=b"C" * 2000,  # >= 1000-byte floor
+        consent_json={"verified_own_voice": True, "method": "self-recorded-statement",
+                      "consent_text": "I consent to my voice.", "recorded_at": 123.0})
+    body = client.post("/personas/import", files=_upload(bundle)).json()
+    assert body["verified_own_voice"] is True
+    with db_conn() as conn:
+        row = conn.execute("SELECT * FROM voice_profiles WHERE id=?",
+                           (body["profile_id"],)).fetchone()
+    assert row["verified_own_voice"] == 1
+    assert row["consent_audio_path"].startswith(body["profile_id"])
+    assert row["consent_recorded_at"] == 123.0
+
+
+def test_import_short_recording_is_unverified(client):
+    bundle = _ovsvoice(
+        consent_audio=b"C" * 50,  # below floor
+        consent_json={"verified_own_voice": True, "consent_text": "ok", "recorded_at": 1.0})
+    body = client.post("/personas/import", files=_upload(bundle)).json()
+    assert body["verified_own_voice"] is False
+
+
+def test_import_preview_only(client):
+    bundle = _ovsvoice(ref=None, locked=None, manifest_over={
+        "members": {"ref_audio": None, "locked_audio": None, "consent_audio": None}})
+    body = client.post("/personas/import", files=_upload(bundle)).json()
+    assert body["preview_only"] is True
+    with db_conn() as conn:
+        row = conn.execute("SELECT * FROM voice_profiles WHERE id=?",
+                           (body["profile_id"],)).fetchone()
+    # the preview became the usable ref clip
+    assert os.path.isfile(os.path.join(_config.VOICES_DIR, row["ref_audio_path"]))
+
+
+def test_import_legacy_omnivoice(client):
+    body = client.post("/personas/import",
+                       files=_upload(_legacy_omnivoice(), filename="old.omnivoice")).json()
+    assert body["name"] == "Old Voice" and body["kind"] == "clone"
+    assert body["verified_own_voice"] is False
+    assert body["watermarked_preview"] is False
+    assert body["license_spdx"] == DEFAULT_LICENSE
+
+
+# ── inspect (no DB write, no file) ───────────────────────────────────────────
+
+def test_inspect_no_write(client):
+    before = set(os.listdir(_config.VOICES_DIR))
+    with db_conn() as conn:
+        n_before = conn.execute("SELECT COUNT(*) c FROM voice_profiles").fetchone()["c"]
+    r = client.post("/personas/inspect", files=_upload(_ovsvoice()))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["format"] == "ovsvoice" and body["name"] == "Aria"
+    assert body["license_spdx"] == "CC-BY-4.0"
+    after = set(os.listdir(_config.VOICES_DIR))
+    with db_conn() as conn:
+        n_after = conn.execute("SELECT COUNT(*) c FROM voice_profiles").fetchone()["c"]
+    assert before == after and n_before == n_after  # nothing written
+
+
+def test_inspect_consent_summary(client):
+    bundle = _ovsvoice(consent_audio=b"C" * 2000, consent_json={
+        "verified_own_voice": True, "method": "self-recorded-statement",
+        "consent_text": "yes", "recorded_at": 1.0})
+    body = client.post("/personas/inspect", files=_upload(bundle)).json()
+    assert body["consent"]["verified_claimed"] is True
+    assert body["consent"]["has_recording"] is True
+    assert body["consent"]["would_verify"] is True

--- a/tests/test_persona_bundle.py
+++ b/tests/test_persona_bundle.py
@@ -6,13 +6,24 @@ separate slice (and run on CI for the torch-coupled paths).
 """
 from __future__ import annotations
 
+import io
+import json
+import zipfile
+
+import pytest
+
 from services.persona_bundle import (
     DEFAULT_LICENSE,
+    MAX_BUNDLE_BYTES,
     OVSVOICE_FORMAT,
     OVSVOICE_SCHEMA_VERSION,
+    BundleError,
+    NoPreviewSource,
     build_consent_json,
     build_manifest,
+    build_persona_bundle,
     normalize_spdx,
+    parse_persona_bundle,
 )
 
 _PROFILE = {
@@ -104,3 +115,201 @@ def test_consent_recorded_at_coerced_when_missing_or_bad():
     c = build_consent_json({"kind": "clone", "consent_text": "ok", "consent_recorded_at": "nope"},
                            has_recording=True)
     assert isinstance(c["recorded_at"], float)  # coerced to now, not a crash
+
+
+# ── parse_persona_bundle: pure ZIP validation (no torch) ─────────────────────
+
+def _zip(members: dict) -> bytes:
+    """members: {arcname: bytes|str}."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, body in members.items():
+            zf.writestr(name, body if isinstance(body, (bytes, bytearray)) else str(body))
+    return buf.getvalue()
+
+
+def _manifest_bytes(**over) -> str:
+    base = build_manifest(_PROFILE, license_spdx="CC-BY-4.0", tags=["narration"],
+                          preview={"file": "preview.wav", "watermarked": True,
+                                   "duration_s": 6.2, "sample_rate": 24000},
+                          members={"ref_audio": "ref_audio.wav", "locked_audio": None,
+                                   "consent_audio": None})
+    base.update(over)
+    return json.dumps(base)
+
+
+def test_parse_prefers_manifest_and_normalizes():
+    content = _zip({"manifest.json": _manifest_bytes(),
+                    "ref_audio.wav": b"\x00" * 100, "preview.wav": b"\x00" * 100})
+    parsed = parse_persona_bundle(content)
+    assert parsed.is_legacy is False
+    assert parsed.manifest["format"] == OVSVOICE_FORMAT
+    assert parsed.license_spdx == "CC-BY-4.0"
+    assert parsed.watermarked_preview is True
+    assert parsed.preview_only is False
+    assert parsed.members.get("ref_audio") == "ref_audio.wav"
+
+
+def test_parse_legacy_metadata_only():
+    legacy = {"profile_name": "Old Voice", "kind": "clone", "language": "English"}
+    content = _zip({"metadata.json": json.dumps(legacy), "ref_audio.wav": b"\x00" * 100})
+    parsed = parse_persona_bundle(content)
+    assert parsed.is_legacy is True
+    assert parsed.manifest["persona"]["name"] == "Old Voice"
+    assert parsed.license_spdx == DEFAULT_LICENSE
+    assert parsed.watermarked_preview is False
+
+
+def test_parse_preview_only_bundle():
+    content = _zip({"manifest.json": _manifest_bytes(members={"ref_audio": None}),
+                    "preview.wav": b"\x00" * 100})
+    parsed = parse_persona_bundle(content)
+    assert parsed.preview_only is True
+
+
+def test_parse_future_schema_version_flagged():
+    content = _zip({"manifest.json": _manifest_bytes(schema_version=99),
+                    "ref_audio.wav": b"\x00" * 100})
+    parsed = parse_persona_bundle(content)
+    assert parsed.schema_version_ahead is True
+
+
+def test_parse_missing_manifest_400():
+    with pytest.raises(BundleError) as e:
+        parse_persona_bundle(_zip({"ref_audio.wav": b"\x00" * 100}))
+    assert e.value.status == 400
+
+
+def test_parse_no_audio_member_400():
+    with pytest.raises(BundleError) as e:
+        parse_persona_bundle(_zip({"manifest.json": _manifest_bytes()}))
+    assert e.value.status == 400
+
+
+def test_parse_malformed_manifest_json_400():
+    with pytest.raises(BundleError) as e:
+        parse_persona_bundle(_zip({"manifest.json": "{not json",
+                                   "ref_audio.wav": b"\x00" * 100}))
+    assert e.value.status == 400
+
+
+def test_parse_not_a_zip_400():
+    with pytest.raises(BundleError) as e:
+        parse_persona_bundle(b"definitely not a zip")
+    assert e.value.status == 400
+
+
+def test_parse_oversize_413():
+    # Header check fires before ZIP parsing — a non-zip blob over the cap is 413.
+    with pytest.raises(BundleError) as e:
+        parse_persona_bundle(b"\x00" * (MAX_BUNDLE_BYTES + 1))
+    assert e.value.status == 413
+
+
+def test_parse_bad_consent_json_is_advisory_not_fatal():
+    content = _zip({"manifest.json": _manifest_bytes(), "ref_audio.wav": b"\x00" * 100,
+                    "consent.json": "{broken"})
+    parsed = parse_persona_bundle(content)
+    assert parsed.consent is None  # ignored, not a 400
+
+
+def test_parse_bad_spdx_in_manifest_normalized():
+    content = _zip({"manifest.json": _manifest_bytes(license={"spdx": "haha; rm -rf", "custom_text": None}),
+                    "ref_audio.wav": b"\x00" * 100})
+    assert parse_persona_bundle(content).license_spdx == DEFAULT_LICENSE
+
+
+def test_parse_last_wins_on_duplicate_members():
+    content = _zip({"manifest.json": _manifest_bytes(),
+                    "ref_audio.wav": b"\x00" * 100, "ref_audio_2.wav": b"\x11" * 100})
+    parsed = parse_persona_bundle(content)
+    # Whichever sorts last in the namelist wins; either is a valid prefix match.
+    assert parsed.members["ref_audio"].startswith("ref_audio")
+
+
+# ── build_persona_bundle round-trip (torchaudio; runs on CI, often local) ────
+
+def _write_wav(path, *, seconds=1.0, sr=16000, channels=1):
+    import numpy as np
+    import soundfile as sf
+    n = int(seconds * sr)
+    data = (0.1 * np.sin(2 * np.pi * 220 * np.arange(n) / sr)).astype("float32")
+    if channels > 1:
+        data = np.stack([data] * channels, axis=1)
+    sf.write(str(path), data, sr)
+
+
+@pytest.fixture
+def voices_dir(tmp_path, monkeypatch):
+    import core.config as cfg
+    d = tmp_path / "voices"
+    d.mkdir()
+    monkeypatch.setattr(cfg, "VOICES_DIR", str(d))
+    return d
+
+
+def _identity_embed(wav, sr):
+    return wav  # avoid loading AudioSeal in unit tests
+
+
+def test_build_roundtrip_identity_fields(voices_dir):
+    _write_wav(voices_dir / "abc.wav")
+    profile = {**_PROFILE, "kind": "clone", "ref_audio_path": "abc.wav"}
+    content = build_persona_bundle(profile, license_spdx="CC-BY-4.0", tags=["x"],
+                                   embed_fn=_identity_embed)
+    parsed = parse_persona_bundle(content)
+    p = parsed.manifest["persona"]
+    assert p["name"] == "Aria Narration" and p["seed"] == 42
+    assert parsed.manifest["preview"]["sample_rate"] == 24000
+    assert isinstance(parsed.manifest["preview"]["duration_s"], float)
+    # legacy-reader compat: a metadata.json sibling is always written.
+    with zipfile.ZipFile(io.BytesIO(content)) as zf:
+        assert "metadata.json" in zf.namelist()
+        assert "preview.wav" in zf.namelist()
+        assert any(n.startswith("ref_audio") for n in zf.namelist())
+
+
+def test_build_no_source_raises_no_preview_source(voices_dir):
+    profile = {**_PROFILE, "kind": "clone", "ref_audio_path": None, "locked_audio_path": None}
+    with pytest.raises(NoPreviewSource):
+        build_persona_bundle(profile, embed_fn=_identity_embed)
+
+
+def test_build_missing_file_raises_no_preview_source(voices_dir):
+    profile = {**_PROFILE, "ref_audio_path": "gone.wav"}
+    with pytest.raises(NoPreviewSource):
+        build_persona_bundle(profile, embed_fn=_identity_embed)
+
+
+def test_build_include_reference_false_is_preview_only(voices_dir):
+    _write_wav(voices_dir / "abc.wav")
+    profile = {**_PROFILE, "kind": "clone", "ref_audio_path": "abc.wav"}
+    content = build_persona_bundle(profile, include_reference=False, embed_fn=_identity_embed)
+    with zipfile.ZipFile(io.BytesIO(content)) as zf:
+        names = zf.namelist()
+        assert "preview.wav" in names
+        assert not any(n.startswith("ref_audio") for n in names)
+    assert parse_persona_bundle(content).preview_only is True
+
+
+def test_build_stereo_offrate_source_downmixed_resampled(voices_dir):
+    _write_wav(voices_dir / "st.wav", sr=48000, channels=2, seconds=12.0)
+    profile = {**_PROFILE, "kind": "clone", "ref_audio_path": "st.wav"}
+    content = build_persona_bundle(profile, embed_fn=_identity_embed)
+    parsed = parse_persona_bundle(content)
+    assert parsed.manifest["preview"]["sample_rate"] == 24000
+    assert parsed.manifest["preview"]["duration_s"] <= 8.0  # trimmed to cap
+
+
+# ── embed_watermark(force=) unit (D1-D3) ─────────────────────────────────────
+
+def test_embed_watermark_force_keyword(monkeypatch):
+    import torch
+    from services import watermark
+    monkeypatch.setattr(watermark, "_check_available", lambda: False)  # AudioSeal absent
+    wav = torch.zeros(1, 100)
+    # force=True still no-ops without AudioSeal (D3) — returns input unchanged.
+    out = watermark.embed_watermark(wav, 24000, force=True)
+    assert out is wav
+    # default force=False also unchanged for existing positional callers (D1).
+    assert watermark.embed_watermark(wav, 24000) is wav


### PR DESCRIPTION
**Slice B** of `.ovsvoice` (#29) — the HTTP layer over the slice-A service. **Stacked on #460** (base `feat/persona-bundle-core`); rebases to main after #460 merges.

### Endpoints (`api/routers/personas.py`, wired in `main.py`)
- **`POST /personas/export/{id}`** → builds the bundle off the event loop (`run_in_executor`) and streams it (`application/zip`, `.ovsvoice` filename, empty→`persona_<id>`). 404 missing profile; `NoPreviewSource`→**503**; other build error→503 generic (no raw exc text).
- **`POST /personas/import`** → parse (`BundleError`→its status); extract audio members to **server-named** files (`{id}{ext}` etc., never the member name → zip-slip safe via `profiles._voices_path`); **17-column INSERT** (legacy 13 + 4 consent); `event_bus` emit post-commit. Verified-own-voice granted **only** with a real recording ≥ floor **and** non-empty `consent_text` **and** `consent.json` present (forgery guard B12–B16). **Rollback**: all written files deleted on any failure; id-collision retries once. Accepts legacy `.omnivoice` (case-insensitive).
- **`POST /personas/inspect`** → manifest + consent summary, **no DB row, no file** extracted.

### Tests
`backend/tests/test_personas_api.py` — 13 cases via the config-stub pattern (mounts only the router, **no `main`/torch import**): export 404; import bad-ext / non-zip / missing-manifest → 400; round-trip (row + file under server name, inside `VOICES_DIR`); case-insensitive ext; forgery→unverified; verified-with-recording; short-recording→unverified; preview-only→ref; legacy `.omnivoice`; inspect no-write + consent summary. **13 passed locally.** CJK green.

Next: frontend (C), docs (D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)