### PR TITLE
docs(persona): document the .ovsvoice portable format (#29 slice D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+### Added
+- **Portable personas (`.ovsvoice`).** Export any voice as a self-contained,
+  fully-local persona bundle — identity, optional reference clip, consent
+  attestation, SPDX license, and a watermarked preview — and import it back into
+  another OmniVoice install. A privacy toggle ships a **preview-only** bundle so
+  no raw recording of your voice has to travel. Verified-own-voice status can't
+  be forged by hand-editing a bundle (real recording + consent text + attestation
+  required). Legacy `.omnivoice` files still import. See
+  [docs/persona-format.md](docs/persona-format.md). (#29)
+
 ## [0.3.5] — 2026-06-03
 
 ### Fixed

--- a/docs/persona-format.md
+++ b/docs/persona-format.md
@@ -1,0 +1,67 @@
+# Portable personas — the `.ovsvoice` format
+
+A **`.ovsvoice`** file is a portable voice persona: a single ZIP that packages a
+voice profile's identity, an optional reference clip, a consent attestation, an
+SPDX license tag, and a **watermarked preview**. You can export one from any
+voice and import it back into another OmniVoice install — fully local, no
+account, no upload to anyone.
+
+It supersedes the older `.omnivoice` share bundle. OmniVoice still imports
+`.omnivoice` files (they just carry no consent / license / preview).
+
+## Export
+
+**Voices → open a voice → Export persona.**
+
+- The **"Include voice clip"** checkbox controls privacy:
+  - **On (default):** the bundle carries your raw reference/locked audio, so the
+    imported persona clones with full fidelity.
+  - **Off:** a **preview-only** bundle — only the watermarked preview travels, no
+    raw recording of your voice leaves the machine. The imported persona is still
+    usable (the preview becomes its reference clip).
+- A short **preview** is always generated and, when AudioSeal is installed,
+  **watermarked** so the audio can be attributed back to OmniVoice. Behaviour is
+  identical on macOS, Windows, and Linux; without AudioSeal the preview is still
+  written, just flagged un-watermarked.
+- The file downloads as `<voice name>.ovsvoice`.
+
+## Import
+
+**Voices → My Imports → the package button (next to Upload).** Pick a
+`.ovsvoice` (or legacy `.omnivoice`) file; the persona appears in your voice
+list.
+
+### Consent & verification
+
+A persona's **verified-own-voice** status can't be forged by hand-editing the
+bundle. On import, OmniVoice marks a persona verified **only** when all three
+hold: a real consent recording is present (above the minimum length), the
+consent statement text is non-empty, and a `consent.json` attestation is
+included. Otherwise it imports **unverified** — still usable for local
+synthesis; verification is only required for agentic features and community
+sharing, never for plain local generation. You can always re-attest locally
+afterwards.
+
+## What's inside (`.ovsvoice` = ZIP)
+
+| Member | Purpose | Presence |
+|--------|---------|----------|
+| `manifest.json` | format + schema version, persona identity, engine/design params, license, tags, preview metadata | required |
+| `metadata.json` | legacy-shaped copy so older OmniVoice can still read the ref audio | always written |
+| `preview.wav` | watermarked preview (24 kHz mono) | required |
+| `consent.json` | attestation: method, statement text, verified flag, timestamp | optional |
+| `ref_audio.*` / `locked_audio.*` | the reference / locked clip | omitted when "Include voice clip" is off |
+| `consent_audio.*` | the recorded consent statement | optional |
+
+The manifest's `license.spdx` is validated against an allowlist (plus
+`LicenseRef-` custom ids); anything unrecognised normalises to
+`LicenseRef-OmniVoice-Personal`. The license is **metadata only** — OmniVoice
+does not enforce it.
+
+## Privacy & local-first
+
+Export and import are **100% local** — building a bundle reads your local
+database and files and writes a ZIP on the same machine; importing reads a local
+file. No network call is made on any export/import/inspect path, and the feature
+works fully offline. (The only adjacent network use is AudioSeal's optional
+one-time model download for watermarking, which degrades to a no-op offline.)


### PR DESCRIPTION
Final slice of `.ovsvoice` (#29) — docs-sync. (Supersedes #463, auto-closed when its stacked base branch was deleted during the cascade merge; rebased onto main.)

- **`docs/persona-format.md`** (new): export (privacy/include-reference, watermarked preview), import (the consent **non-forgeability** rule), the ZIP-layout table, SPDX-license semantics (metadata only), and the local-first / zero-network guarantee; notes legacy `.omnivoice` compatibility.
- **`CHANGELOG.md`**: `[Unreleased] → Added` entry for portable personas.

Docs-only; CJK guard green. Slices A–C already merged (#460/#461/#462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This documentation-only pull request documents the `.ovsvoice` portable persona format, completing the final documentation slice for feature `#29`. It supersedes `#463` (which was auto-closed when its stacked base branch was deleted) and is rebased onto main.

## Changes

### New Documentation (`docs/persona-format.md`)
Added comprehensive specification of the `.ovsvoice` portable format covering:
- **Export functionality**: privacy considerations, include-reference settings, and watermarked preview generation
- **Import functionality**: consent requirements and non-forgeability verification rules
- **ZIP-layout specification**: structural details of the portable bundle format
- **SPDX-license semantics**: clarification that licensing applies to metadata only
- **Local-first and zero-network guarantees**: architectural properties of the format
- **Legacy compatibility**: notes on `.omnivoice` format import support

### CHANGELOG Update
Added entry under `[Unreleased] → Added` documenting portable personas feature, including:
- Self-contained export bundles (identity, optional reference clip, consent attestation, SPDX license, watermarked preview)
- Privacy-preserving import with preview-only toggle to avoid sending raw voice recordings
- Non-forgeability guarantee for verified-own-voice status
- Backward compatibility with legacy `.omnivoice` files
- Reference to `docs/persona-format.md`

## Notes
This completes the documentation requirements for the portable persona feature, with slices A–C already merged in pull requests `#460`, `#461`, and `#462`. The changes pass CJK character validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->