### PR TITLE
feat(longform): canonical Python parser + golden corpus (#27 slice A)

### DIFF
--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -22,25 +22,8 @@ ingestion, the streaming synth job + UI are deferred follow-ups.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 from typing import Callable, Optional
-
-from omnivoice.utils.text import parse_pause_markers
-
-# A Markdown H1 (``# Title``) starts a new chapter. Deeper headings stay in the
-# body as ordinary text (narrated, not chapter breaks). The title capture
-# starts with ``\S`` (a non-space) so the leading ``[ \t]+`` and the title's
-# ``.*`` can't both match the same whitespace run — that overlap is what makes
-# ``[ \t]+(.+)`` polynomial-time on adversarial tabs (ReDoS). Stripped in code.
-_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(\S.*)$", re.MULTILINE)
-# ``[voice:NAME]`` switches the active narrator for the text that follows. The
-# content class excludes BOTH brackets (``[^\]\[]``) so a run of nested
-# ``[voice:`` prefixes can't create overlapping match attempts across
-# ``finditer`` (the source of the polynomial-time ReDoS). A voice name never
-# contains a bracket; the value is stripped in code.
-_VOICE_RE = re.compile(r"\[voice:([^\]\[]*)\]")
-
 
 @dataclass
 class Span:
@@ -90,73 +73,20 @@ class AudiobookPlan:
         }
 
 
-def _parse_spans(body: str, default_voice: Optional[str]) -> list[Span]:
-    """Split a chapter body into voice-tagged, pause-aware spans."""
-    spans: list[Span] = []
-    cur_voice = default_voice
-    runs: list[tuple[Optional[str], str]] = []
-    last = 0
-    for m in _VOICE_RE.finditer(body):
-        if m.start() > last:
-            runs.append((cur_voice, body[last:m.start()]))
-        cur_voice = (m.group(1).strip() or default_voice)
-        last = m.end()
-    runs.append((cur_voice, body[last:]))
-
-    from services.ssml_lite import parse_ssml_lite, spell_out
-
-    for voice, run_text in runs:
-        # Marker precedence (outer → inner): [voice:] (run split above) →
-        # [pause] (shared dialect) → SSML-lite prosody ([slow]/[fast]/[emphasis]
-        # /[spell]) within the text. The trailing pause attaches to the LAST
-        # SSML segment of the run.
-        for span_text, pause_ms in parse_pause_markers(run_text):
-            t = span_text.strip()
-            if not t and pause_ms == 0:
-                continue  # pure whitespace between markers — nothing to render
-            rendered: list[tuple[str, Optional[float]]] = []
-            for seg in (parse_ssml_lite(t) if t else []):
-                st = (spell_out(seg["text"]) if seg["spell"] else seg["text"]).strip()
-                if st:
-                    rendered.append((st, seg["speed"]))
-            if not rendered:
-                # Only-markers / empty text but a real pause → carry the silence.
-                if pause_ms > 0:
-                    spans.append(Span(voice_id=voice, text="", pause_ms_after=pause_ms))
-                continue
-            for j, (st, sp) in enumerate(rendered):
-                spans.append(Span(
-                    voice_id=voice, text=st, speed=sp,
-                    pause_ms_after=pause_ms if j == len(rendered) - 1 else 0,
-                ))
-    return spans
-
-
 def parse_audiobook_script(text: str, *, default_voice: Optional[str] = None) -> AudiobookPlan:
     """Parse a chapter-delimited script into an :class:`AudiobookPlan`.
 
-    ``# Heading`` lines delimit chapters; text before the first heading becomes
-    an untitled lead-in chapter. Chapters with no renderable spans are dropped.
+    Thin wrapper over the canonical :func:`services.longform_parser.
+    parse_script_to_spans` (the single grammar source of truth, #27); wraps its
+    span dicts in the ``Span``/``Chapter``/``AudiobookPlan`` dataclasses so the
+    four router call sites and ``.to_dict()`` shape are unchanged.
     """
-    text = text or ""
-    matches = list(_HEADING_RE.finditer(text))
-    if not matches:
-        raw = [(None, text)]
-    else:
-        raw = []
-        intro = text[:matches[0].start()]
-        if intro.strip():
-            raw.append((None, intro))
-        for i, m in enumerate(matches):
-            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
-            raw.append((m.group(1).strip(), text[m.end():end]))
+    from services.longform_parser import parse_script_to_spans
 
-    chapters: list[Chapter] = []
-    for title, body in raw:
-        spans = _parse_spans(body, default_voice)
-        if not spans:
-            continue
-        chapters.append(Chapter(title=title or f"Chapter {len(chapters) + 1}", spans=spans))
+    chapters = [
+        Chapter(title=c["title"], spans=[Span(**s) for s in c["spans"]])
+        for c in parse_script_to_spans(text, default_voice=default_voice)
+    ]
     return AudiobookPlan(chapters=chapters)
 
 

--- a/backend/services/longform_parser.py
+++ b/backend/services/longform_parser.py
@@ -1,0 +1,143 @@
+"""Canonical longform marker parser (#27) — the single source of grammar truth.
+
+The longform marker dialect (``# heading``, ``[voice:NAME]``, ``[pause …]``,
+``[slow]/[fast]/[emphasis]/[spell]``) was parsed by three independent code
+paths that disagreed (client/server/regex-level). This module is the one
+canonical Python parser; ``frontend/src/utils/longformParser.js`` is its
+mechanically-mirrored JS twin, and ``tests/fixtures/longform_parser_cases.json``
+is the shared golden corpus asserted byte-for-byte against both.
+
+Pure text→plan, import-light (no torch). Grammar precedence (outer→inner):
+
+    # chapter  →  [voice:]  →  [pause]  →  SSML-lite  →  [spell]
+
+It reuses the existing pause dialect (``omnivoice.utils.text.parse_pause_markers``)
+and SSML-lite (``services.ssml_lite``) verbatim so those modules stay the single
+home of their sub-grammars.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from omnivoice.utils.text import parse_pause_markers
+
+# A Markdown H1 (``# Title``) starts a new chapter. Deeper headings (``##``…)
+# stay in the body as ordinary text. The title capture starts with ``\S`` (a
+# non-space) so the leading ``[ \t]+`` and the title's ``.*`` can't both match
+# the same whitespace run — that overlap is what makes ``[ \t]+(.+)``
+# polynomial-time on adversarial tabs (ReDoS). Moved verbatim from
+# audiobook.py (already CodeQL-cleared). Stripped in code.
+_HEADING_RE = re.compile(r"^[ \t]*#[ \t]+(\S.*)$", re.MULTILINE)
+# ``[voice:NAME]`` switches the active narrator. The content class excludes BOTH
+# brackets (``[^\]\[]``) so nested ``[voice:`` prefixes can't create overlapping
+# match attempts across ``finditer`` (the ReDoS source). A voice name never
+# contains a bracket; the value is stripped in code. Empty → default voice.
+_VOICE_RE = re.compile(r"\[voice:([^\]\[]*)\]")
+
+
+def _normalize(text: Optional[str]) -> str:
+    """Coerce None→'' and normalize CRLF/CR→LF so ``$`` (re.MULTILINE) and span
+    text never carry a stray ``\\r`` on Windows-authored scripts — a
+    cross-platform default-behaviour divergence the JS twin mirrors exactly."""
+    if not text:
+        return ""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _parse_chapter_body(
+    body: str,
+    *,
+    default_voice: Optional[str] = None,
+    default_speed: Optional[float] = None,
+) -> list[dict]:
+    """Voice→pause→SSML layering for ONE chapter body (no chapter split).
+
+    Returns a list of span dicts ``{voice_id, text, pause_ms_after, speed}``.
+    A ``#`` inside ``body`` is NOT treated as a heading here — that is the
+    caller's (chapter-split) concern. The JS twin (``parseChapterBody``) is what
+    ``storyToSpans`` calls per spoken track."""
+    spans: list[dict] = []
+    cur_voice = default_voice
+    runs: list[tuple[Optional[str], str]] = []
+    last = 0
+    for m in _VOICE_RE.finditer(body):
+        if m.start() > last:
+            runs.append((cur_voice, body[last:m.start()]))
+        cur_voice = (m.group(1).strip() or default_voice)
+        last = m.end()
+    runs.append((cur_voice, body[last:]))
+
+    from services.ssml_lite import parse_ssml_lite, spell_out
+
+    for voice, run_text in runs:
+        for span_text, pause_ms in parse_pause_markers(run_text):
+            t = span_text.strip()
+            if not t and pause_ms == 0:
+                continue  # pure whitespace between markers — nothing to render
+            rendered: list[tuple[str, Optional[float]]] = []
+            for seg in (parse_ssml_lite(t) if t else []):
+                st = (spell_out(seg["text"]) if seg["spell"] else seg["text"]).strip()
+                if st:
+                    # Inline SSML speed overrides the per-line default; a plain
+                    # segment inherits default_speed.
+                    sp = seg["speed"] if seg["speed"] is not None else default_speed
+                    rendered.append((st, sp))
+            if not rendered:
+                # Only-markers / empty text but a real pause → carry the silence.
+                if pause_ms > 0:
+                    spans.append({"voice_id": voice, "text": "",
+                                  "pause_ms_after": pause_ms, "speed": None})
+                continue
+            for j, (st, sp) in enumerate(rendered):
+                spans.append({
+                    "voice_id": voice, "text": st,
+                    "pause_ms_after": pause_ms if j == len(rendered) - 1 else 0,
+                    "speed": sp,
+                })
+    return spans
+
+
+def parse_script_to_spans(
+    text: Optional[str],
+    *,
+    default_voice: Optional[str] = None,
+    default_speed: Optional[float] = None,
+) -> list[dict]:
+    """Parse a chapter-delimited script into ``[{"title", "spans": [...]}, …]``.
+
+    span dict == ``{"voice_id": str|None, "text": str, "pause_ms_after": int,
+    "speed": float|None}`` (key order matches ``Span.to_dict()``).
+
+    Contract:
+      * None / "" / whitespace-only input → ``[]``.
+      * CRLF/CR normalized to LF at entry (cross-platform parity).
+      * H1 (``# <non-space>…``) opens a chapter; ``##``…``######`` and ``# ``
+        (no ``\\S`` title) are body.
+      * Each chapter body resets the active voice to ``default_voice``.
+      * A span is dropped iff its text is empty AND pause_ms_after == 0.
+      * Chapters with no surviving spans are dropped; untitled bodies are
+        numbered ``Chapter {kept_so_far + 1}`` (post-drop numbering).
+    """
+    text = _normalize(text)
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        raw = [(None, text)]
+    else:
+        raw = []
+        intro = text[:matches[0].start()]
+        if intro.strip():
+            raw.append((None, intro))
+        for i, m in enumerate(matches):
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+            raw.append((m.group(1).strip(), text[m.end():end]))
+
+    chapters: list[dict] = []
+    for title, body in raw:
+        spans = _parse_chapter_body(body, default_voice=default_voice,
+                                    default_speed=default_speed)
+        if not spans:
+            continue
+        chapters.append({"title": title or f"Chapter {len(chapters) + 1}",
+                         "spans": spans})
+    return chapters

--- a/tests/fixtures/longform_parser_cases.json
+++ b/tests/fixtures/longform_parser_cases.json
@@ -1,0 +1,1477 @@
+[
+  {
+    "name": "empty",
+    "input": "",
+    "default_voice": "v1",
+    "expected": []
+  },
+  {
+    "name": "whitespace_only",
+    "input": "   \n\t  ",
+    "default_voice": "v1",
+    "expected": []
+  },
+  {
+    "name": "no_headings_leadin",
+    "input": "just narration here",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "just narration here",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "headings_only_no_body",
+    "input": "# A\n# B",
+    "default_voice": "v1",
+    "expected": []
+  },
+  {
+    "name": "leadin_then_heading",
+    "input": "intro\n# One\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "intro",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      },
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "blank_leadin_then_heading",
+    "input": "\n# One\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "numbering_post_drop",
+    "input": "intro\n# \nmore\n# Real\nx",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "intro\n# \nmore",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      },
+      {
+        "title": "Real",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "x",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "h1_opens_chapter",
+    "input": "# Title\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Title",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "h2_is_body_not_chapter",
+    "input": "# One\nintro\n## Still One\nmore",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "intro\n## Still One\nmore",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "h3_h6_are_body",
+    "input": "# One\n### deep\n#### deeper\nx",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "### deep\n#### deeper\nx",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "hash_no_space_is_body",
+    "input": "# One\n#Title body",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "#Title body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "hash_alone_is_body",
+    "input": "# One\n#\nmore",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "#\nmore",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "hash_space_no_title_is_body",
+    "input": "# One\n# \nmore",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "# \nmore",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "leading_space_heading",
+    "input": "   # Title\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Title",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "tab_separator_heading",
+    "input": "#\tTitle\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Title",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "trailing_ws_title_stripped",
+    "input": "#   Title   \nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Title",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "heading_not_at_line_start",
+    "input": "text # not a heading",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "text # not a heading",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "heading_with_markers_in_title",
+    "input": "# [voice:x] Title\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "[voice:x] Title",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "chapter_all_markers_pause_kept",
+    "input": "# H\n[pause]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "H",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "",
+            "pause_ms_after": 350,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "chapter_all_markers_voice_dropped",
+    "input": "# H\n[voice:]",
+    "default_voice": "v1",
+    "expected": []
+  },
+  {
+    "name": "voice_switch",
+    "input": "[voice:p_fox] hello",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "p_fox",
+            "text": "hello",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_adjacent",
+    "input": "[voice:a][voice:b] hi",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "b",
+            "text": "hi",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_empty_reverts_default",
+    "input": "a [voice:] b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 0,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_whitespace_reverts_default",
+    "input": "a [voice:   ] b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 0,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_nested_bracket_literal",
+    "input": "say [voice:[nested]] now",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "say [voice:[nested]] now",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_space_in_id",
+    "input": "[voice:a b] hi",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "a b",
+            "text": "hi",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_resets_at_chapter",
+    "input": "# A\n[voice:x] hi\n# B\nbye",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "A",
+        "spans": [
+          {
+            "voice_id": "x",
+            "text": "hi",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      },
+      {
+        "title": "B",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "bye",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_before_text",
+    "input": "# A\n[voice:x]\nbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "A",
+        "spans": [
+          {
+            "voice_id": "x",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_unclosed_literal",
+    "input": "[voice:x hello",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "[voice:x hello",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "voice_midline_switch_back",
+    "input": "hi [voice:p_bob] there [voice:] back",
+    "default_voice": "p_alice",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "p_alice",
+            "text": "hi",
+            "pause_ms_after": 0,
+            "speed": null
+          },
+          {
+            "voice_id": "p_bob",
+            "text": "there",
+            "pause_ms_after": 0,
+            "speed": null
+          },
+          {
+            "voice_id": "p_alice",
+            "text": "back",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_bare",
+    "input": "a[pause]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 350,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_500ms",
+    "input": "a[pause 500ms]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 500,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_1s",
+    "input": "a[pause 1s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 1000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_1_5s",
+    "input": "a[pause 1.5s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 1500,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_half_ms_rounds_even_0",
+    "input": "a[pause 0.5]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 0,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_one_half_ms_rounds_even_2",
+    "input": "a[pause 1.5]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 2,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_0s",
+    "input": "a[pause 0s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 0,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_ws_tolerance",
+    "input": "a[ pause  3  ms ]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 3,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_case_insensitive",
+    "input": "a[PAUSE 2S]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 2000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_clamp_99s",
+    "input": "a[pause 99s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 10000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_clamp_10_5s",
+    "input": "a[pause 10.5s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 10000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_negative",
+    "input": "a[pause -5s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause -5s]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_leading_dot",
+    "input": "a[pause .5s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause .5s]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_double_dot",
+    "input": "a[pause 1.2.3s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause 1.2.3s]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_no_space",
+    "input": "a[pause1s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause1s]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_xyz",
+    "input": "a[pausexyz]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pausexyz]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_unknown_unit",
+    "input": "a[pause 5x]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause 5x]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_trailing_junk",
+    "input": "a[pause 5sx]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause 5sx]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_nomatch_two_units",
+    "input": "a[pause 5ms s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a[pause 5ms s]b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_adjacent_sum",
+    "input": "a[pause 1s][pause 2s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 3000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_adjacent_sum_clamp",
+    "input": "a[pause 8s][pause 8s]b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a",
+            "pause_ms_after": 10000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_leading_silent_span",
+    "input": "[pause 1s]hi",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "",
+            "pause_ms_after": 1000,
+            "speed": null
+          },
+          {
+            "voice_id": "v1",
+            "text": "hi",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_trailing_rides_span",
+    "input": "hi[pause 1s]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "hi",
+            "pause_ms_after": 1000,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "pause_standalone",
+    "input": "[pause 1s]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "",
+            "pause_ms_after": 1000,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "literal_bracket_preserved",
+    "input": "a [ b",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "a [ b",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_slow",
+    "input": "[slow]x[/slow]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "x",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_fast",
+    "input": "[fast]y[/fast]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "y",
+            "pause_ms_after": 0,
+            "speed": 1.15
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_emphasis",
+    "input": "[emphasis]z[/emphasis]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "z",
+            "pause_ms_after": 0,
+            "speed": 0.92
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_spell",
+    "input": "[spell]USA[/spell]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "U S A",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_nesting_innermost",
+    "input": "[slow][fast]x[/fast]y[/slow]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "x",
+            "pause_ms_after": 0,
+            "speed": 1.15
+          },
+          {
+            "voice_id": "v1",
+            "text": "y",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_slow_spell_compose",
+    "input": "[slow][spell]A[/spell][/slow]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "A",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_unclosed_to_eol",
+    "input": "[slow]rest of line",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "rest of line",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_stray_close",
+    "input": "[/slow]x",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "x",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_only_markers_no_span",
+    "input": "[slow][/slow]",
+    "default_voice": "v1",
+    "expected": []
+  },
+  {
+    "name": "ssml_spell_go_usa",
+    "input": "[spell]go USA[/spell]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "g o U S A",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_whitespace_only_dropped",
+    "input": "[slow]   [/slow]",
+    "default_voice": "v1",
+    "expected": []
+  },
+  {
+    "name": "ssml_adjacent_identical_merge",
+    "input": "[slow]a[/slow][slow]b[/slow]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "ab",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_case_insensitive",
+    "input": "[SLOW]x[/SLOW]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "x",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ssml_unknown_tag_literal",
+    "input": "[whisper]x[/whisper]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "[whisper]x[/whisper]",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "speed_default_rides_plain",
+    "input": "plain text",
+    "default_voice": "v1",
+    "default_speed": 0.9,
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "plain text",
+            "pause_ms_after": 0,
+            "speed": 0.9
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "speed_inline_overrides_default",
+    "input": "[fast]quick[/fast]",
+    "default_voice": "v1",
+    "default_speed": 0.9,
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "quick",
+            "pause_ms_after": 0,
+            "speed": 1.15
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "speed_default_none_is_null",
+    "input": "plain",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "plain",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "crlf_normalized",
+    "input": "# One\r\nbody\r\n",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "cr_only_normalized",
+    "input": "# One\rbody",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "body",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "combined_all_layers",
+    "input": "[voice:x] a [pause 300ms] [slow]b[/slow]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "x",
+            "text": "a",
+            "pause_ms_after": 300,
+            "speed": null
+          },
+          {
+            "voice_id": "x",
+            "text": "b",
+            "pause_ms_after": 0,
+            "speed": 0.85
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "internal_newline_preserved",
+    "input": "# One\nline a\nline b\n## still one\nline c",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "One",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "line a\nline b\n## still one\nline c",
+            "pause_ms_after": 0,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "recon_silent_span_kept",
+    "input": "[pause 500ms]",
+    "default_voice": "v1",
+    "expected": [
+      {
+        "title": "Chapter 1",
+        "spans": [
+          {
+            "voice_id": "v1",
+            "text": "",
+            "pause_ms_after": 500,
+            "speed": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "recon_whitespace_dropped",
+    "input": "   ",
+    "default_voice": "v1",
+    "expected": []
+  }
+]

--- a/tests/test_longform_parser.py
+++ b/tests/test_longform_parser.py
@@ -1,0 +1,48 @@
+"""Canonical longform parser (#27) — pytest side of the cross-impl golden corpus.
+
+This suite and ``frontend/src/test/longformParser.test.js`` load the SAME JSON
+(`tests/fixtures/longform_parser_cases.json`) and assert both impls produce it
+byte-for-byte. A divergence cannot pass both suites — the side that drifts fails
+its own assertion against the shared truth.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from services.longform_parser import parse_script_to_spans
+
+_FIXTURE = pathlib.Path(__file__).parent / "fixtures" / "longform_parser_cases.json"
+_CASES = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[c["name"] for c in _CASES])
+def test_corpus(case):
+    got = parse_script_to_spans(
+        case["input"],
+        default_voice=case["default_voice"],
+        default_speed=case.get("default_speed"),
+    )
+    assert got == case["expected"]
+
+
+def test_none_input_returns_empty():
+    # The wrapper coerces, but the parser itself must not raise on None.
+    assert parse_script_to_spans(None) == []
+
+
+def test_corpus_has_enough_cases():
+    # The spec mandates ≥40 cases covering §A–I.
+    assert len(_CASES) >= 40
+
+
+def test_pathological_inputs_are_linear():
+    # ReDoS guard: adversarial repeats must finish fast (mirrors the JS suite).
+    import time
+    for blob in ("[slow]" * 5000, "[pause" * 5000, "[voice:" * 5000,
+                 "# \n" * 5000, "[a]" * 5000):
+        t0 = time.perf_counter()
+        parse_script_to_spans(blob, default_voice="v")
+        assert time.perf_counter() - t0 < 1.0


### PR DESCRIPTION
**Slice A of #27** — kill the client/server/regex parser drift. The marker dialect (`# heading` / `[voice:]` / `[pause]` / SSML-lite) was parsed by **three** disagreeing code paths. This lands the single canonical **Python** parser + the shared golden corpus; the JS port + cross-impl test follow in slice B, frontend convergence + docs after.

### Change
- **`backend/services/longform_parser.py`** (new): `parse_script_to_spans(text, *, default_voice, default_speed)` + `_parse_chapter_body` (the reusable voice→pause→SSML layering the JS twin mirrors). H1/voice regexes **moved verbatim** from `audiobook.py` (already CodeQL-cleared); reuses `parse_pause_markers` + `ssml_lite` unchanged. Coerces `None→""`, normalizes **CRLF/CR→LF** at entry (cross-platform parity), adds `default_speed` plumbing (inline SSML speed overrides per-line default).
- **`audiobook.py`**: `parse_audiobook_script` is now a thin wrapper — `Span`/`Chapter`/`AudiobookPlan` return type + `.to_dict()` shape **unchanged**, 4 router call sites untouched. Deleted `_parse_spans`/`_HEADING_RE`/`_VOICE_RE` + dead imports.
- **`tests/fixtures/longform_parser_cases.json`**: **78-case** golden corpus (≥40 required) — H1-only chapters, full pause dialect incl. NO-MATCH boundary, banker's-rounding ties (`[pause 0.5]`→0, `[pause 1.5]`→2), `[voice:]`→default, `[voice:[nested]]` literal, SSML nesting/spell/unknown-tag, speed override, CRLF, combined precedence. **Generated from actual parser output** (the truth the JS port must match).
- **`tests/test_longform_parser.py`**: parametrized over the corpus + None-input + ReDoS-linearity (5000× repeats < 1 s).

### Checks
**130 passed** locally (corpus + `test_audiobook` + `test_pause_markers` + `test_ssml_lite`). CJK green. No wire-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Longform Script Parser Canonicalization (Issue `#27`, Slice A)

## Problem
Three independent code paths parsed the longform script dialect (`# heading`, `[voice:]`, `[pause]`, SSML-lite) with disagreeing results, causing inconsistencies between client and server for pause unit handling, empty voice tags, and H1-only chapter detection.

## Solution
Introduce **`backend/services/longform_parser.py`** as the canonical parser, establishing a single source of truth. The JavaScript twin (`frontend/src/utils/longformParser.js`) and all cross-implementation tests will mechanically mirror this module.

### Parsing Mechanism

```
┌─────────────────────────────────────────────────────────────┐
│ Input Text (None→"", CRLF/CR→LF normalization)             │
└──────────────────────┬──────────────────────────────────────┘
                       │
                       ▼
        ┌──────────────────────────────┐
        │ Split by H1 (# HEADING)      │ ← _HEADING_RE (ReDoS-safe)
        └──────────────────┬───────────┘
                           │
          ┌────────────────┴────────────────┐
          ▼                                 ▼
     [Intro]                        [Chapter 1] [Chapter 2] …
          │                                 │
          └─────────────────────────────────┴─→ _parse_chapter_body() ×N
                                                      │
                                    ┌─────────────────┴─────────────────┐
                                    ▼                                   ▼
                          Process [voice:NAME]                (Reset voice per chapter)
                          (switches narrator)
                                    │
                                    ▼
                          parse_pause_markers()
                          ([pause …] dialect)
                                    │
                                    ▼
                          parse_ssml_lite()
                          + spell_out() optional
                                    │
                                    ▼
                    {voice_id, text, pause_ms_after, speed}
                    (inline SSML speed overrides default)
                                    │
                                    ▼
        ┌───────────────────────────────────────────────────┐
        │ Filter: drop empty-text + zero-pause spans        │
        │ Drop chapters with no surviving spans             │
        │ Auto-number untitled chapters (post-drop)         │
        └───────────────────────┬───────────────────────────┘
                                ▼
                    [{title, spans: [...]}, …]
```

## Changes

### `backend/services/longform_parser.py` (new, +143 lines)
- **`parse_script_to_spans(text, *, default_voice, default_speed) → list[dict]`**: Public entry point enforcing the contract: returns `[]` for empty/whitespace-only input, normalizes CRLF/CR to LF for cross-platform parity, and coerces `None` to `""`.
- **`_parse_chapter_body(body, *, default_voice, default_speed) → list[dict]`**: Per-chapter parser implementing the grammar layers (voice → pause → SSML → spell). Reuses existing `parse_pause_markers` and `parse_ssml_lite` functions unchanged.
- **H1/voice regexes**: Moved verbatim from `audiobook.py` (already CodeQL-cleared). `_HEADING_RE` uses non-overlapping `\S` anchor to avoid ReDoS; `_VOICE_RE` uses bracket-exclusion class `[^\]\[]` to prevent nested match attempts.
- **Speed override plumbing**: Inline SSML `speed` attributes override the per-line `default_speed` for granular control (Stories' per-line speed slider flows through here).

### `backend/services/audiobook.py` (+10/−80 lines)
- **`parse_audiobook_script`** becomes a thin wrapper: delegates all parsing to `parse_script_to_spans`, then wraps result dicts in `Span`/`Chapter`/`AudiobookPlan` dataclasses.
- **Deleted**: `_parse_spans`, `_HEADING_RE`, `_VOICE_RE`, dead imports.
- **Unchanged**: Public signature, `.to_dict()` shape, all four router call sites (`synthesize_chapter`, `build_chapter_ffmetadata`, `build_m4b_cmd` return types and docstrings).

### `tests/fixtures/longform_parser_cases.json` (78 cases, +1476 lines)
Golden corpus exceeding the ≥40-case requirement, covering:
- Empty/whitespace-only input
- H1-only chapters (dropped post-filter)
- Full pause dialect with NO-MATCH boundaries
- Banker's-rounding ties in pause arithmetic
- Voice coercion and default-voice fallback
- SSML nesting, `spell` attribute, unknown-tag handling
- Speed overrides (inline vs. per-line default)
- CRLF/CR normalization cross-platform parity
- Combined precedence scenarios
- Numbering post-drop behavior

Corpus was generated from actual parser output; establishes the byte-for-byte truth the JavaScript port must match.

### `tests/test_longform_parser.py` (+48 lines)
- **`test_corpus`**: Parametrized over 78 cases from the shared fixture; asserts `parse_script_to_spans(...)` returns output byte-for-byte equal to expected JSON.
- **`test_none_input_returns_empty`**: Validates `None` coercion in the normalizer.
- **`test_corpus_has_enough_cases`**: Enforces ≥40 case coverage per spec.
- **`test_pathological_inputs_are_linear`**: ReDoS guard running 5000× adversarial repeats (`[slow]` × 5000, `[pause` × 5000, etc.); asserts parsing completes in <1.0s.

## Impact
- **Wire shape**: No changes; `parse_audiobook_script` return type and `.to_dict()` schema unchanged. All four router call sites transparent.
- **Grammar authority**: Longform marker dialect now has one canonical Python parser; JavaScript twin mirrors it mechanically; shared fixture establishes byte-for-byte truth across implementations.
- **Test results**: 130 tests pass locally. Follow-up Slice B will port the parser to JavaScript and add cross-implementation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->