### PR TITLE
feat(longform): JS canonical port + frontend convergence (#27 slice B)

### DIFF
--- a/frontend/src/test/longformParser.test.js
+++ b/frontend/src/test/longformParser.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseScriptToSpans, roundHalfToEven } from '../utils/longformParser';
+
+// Load the SAME golden corpus the Python suite asserts against. A divergence
+// between the two ports fails one of the two suites against this shared truth.
+// vitest runs with cwd = frontend/, so the repo-root fixture is one level up.
+// (import.meta.url isn't a file: URL under the vitest transform, so use cwd.)
+const CASES = JSON.parse(
+  readFileSync(resolve(process.cwd(), '../tests/fixtures/longform_parser_cases.json'), 'utf-8'));
+
+describe('parseScriptToSpans — cross-impl golden corpus', () => {
+  it('has the same ≥40-case corpus as Python', () => {
+    expect(CASES.length).toBeGreaterThanOrEqual(40);
+  });
+
+  it.each(CASES.map((c) => [c.name, c]))('%s', (_name, c) => {
+    const got = parseScriptToSpans(c.input, {
+      defaultVoice: c.default_voice,
+      defaultSpeed: c.default_speed ?? null,
+    });
+    expect(got).toEqual(c.expected);
+  });
+});
+
+describe('parseScriptToSpans — guards & rounding', () => {
+  it('returns [] for empty / undefined input', () => {
+    expect(parseScriptToSpans('')).toEqual([]);
+    expect(parseScriptToSpans(undefined)).toEqual([]);
+  });
+
+  it('rounds half-to-even like Python (not Math.round half-up)', () => {
+    expect(roundHalfToEven(0.5)).toBe(0);
+    expect(roundHalfToEven(1.5)).toBe(2);
+    expect(roundHalfToEven(2.5)).toBe(2);
+    expect(roundHalfToEven(3.5)).toBe(4);
+    expect(roundHalfToEven(0.4)).toBe(0);
+    expect(roundHalfToEven(0.6)).toBe(1);
+  });
+
+  it('is linear on pathological input (ReDoS guard)', () => {
+    for (const blob of ['[slow]'.repeat(5000), '[pause'.repeat(5000),
+      '[voice:'.repeat(5000), '# \n'.repeat(5000), '[a]'.repeat(5000)]) {
+      const t0 = Date.now();
+      parseScriptToSpans(blob, { defaultVoice: 'v' });
+      expect(Date.now() - t0).toBeLessThan(1000);
+    }
+  });
+});

--- a/frontend/src/test/storyToSpans.test.js
+++ b/frontend/src/test/storyToSpans.test.js
@@ -85,4 +85,54 @@ describe('storyToSpans', () => {
     expect(spans[0]).toEqual({ voice_id: 'p_narr', text: '', pause_ms_after: 1000, speed: null });
     expect(spans[1].text).toBe('Go.');
   });
+
+  // ── §H adapter-specific cases (#27) ──
+
+  it('returns [] for empty / null track lists', () => {
+    expect(storyToSpans([], CAST)).toEqual([]);
+    expect(storyToSpans(null, CAST)).toEqual([]);
+    expect(storyToSpans(undefined, CAST)).toEqual([]);
+  });
+
+  it('honors the canonical pause dialect ([pause], Nms) — never spoken', () => {
+    const tracks = [{ character: 'narrator', text: 'A [pause] B [pause 500ms] C' }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans.map((s) => s.text)).toEqual(['A', 'B', 'C']);
+    expect(spans[0].pause_ms_after).toBe(350);   // bare [pause]
+    expect(spans[1].pause_ms_after).toBe(500);   // [pause 500ms]
+  });
+
+  it('## inside a multi-line track text does NOT re-chapter', () => {
+    const tracks = [{ character: 'narrator', text: 'line one\n# not a chapter\nline two' }];
+    const chapters = storyToSpans(tracks, CAST);
+    expect(chapters).toHaveLength(1);
+    // the embedded `#` stays literal in the span text (single chapter body)
+    expect(chapters[0].spans[0].text).toContain('# not a chapter');
+  });
+
+  it('folds a leading pause across tracks into the previous span', () => {
+    const tracks = [
+      { character: 'narrator', text: 'First.' },
+      { character: 'narrator', text: '[pause 1s] Second.' },
+    ];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans[0]).toEqual({ voice_id: 'p_narr', text: 'First.', pause_ms_after: 1000, speed: null });
+    expect(spans[1].text).toBe('Second.');
+    expect(spans).toHaveLength(2); // no standalone silent span between tracks
+  });
+
+  it('treats per-track speed 0 as null (engine default, not 0×)', () => {
+    const tracks = [{ character: 'narrator', text: 'Hi.', speed: 0 }];
+    expect(storyToSpans(tracks, CAST)[0].spans[0].speed).toBeNull();
+  });
+
+  it('[voice:] reverts to the resolved cast voice, not null', () => {
+    const tracks = [{ character: 'c_fox', text: 'hi [voice:p_bob] there [voice:] back' }];
+    const spans = storyToSpans(tracks, CAST)[0].spans;
+    expect(spans.map((s) => [s.voice_id, s.text])).toEqual([
+      ['p_fox', 'hi'],
+      ['p_bob', 'there'],
+      ['p_fox', 'back'],   // reverts to the cast voice (p_fox), NOT null
+    ]);
+  });
 });

--- a/frontend/src/utils/longformParser.js
+++ b/frontend/src/utils/longformParser.js
@@ -1,0 +1,161 @@
+/**
+ * Canonical longform marker parser — JS twin of
+ * backend/services/longform_parser.py (#27).
+ *
+ * Byte-for-byte mirror of the Python parser, verified by the shared golden
+ * corpus tests/fixtures/longform_parser_cases.json (asserted in both
+ * tests/test_longform_parser.py and frontend/src/test/longformParser.test.js).
+ * Do not "improve" one side without the other — the corpus will fail.
+ *
+ * Grammar precedence (outer→inner):  # chapter → [voice:] → [pause] → SSML-lite.
+ */
+import { parseSsmlLite, spellOut } from './ssmlLite';
+
+export const PAUSE_DEFAULT_MS = 350;
+export const PAUSE_MAX_MS = 10000;
+
+// H1 only (## … narrate as body); title starts with \S so `# ` (no title) is
+// body. Moved-equivalent of audiobook.py _HEADING_RE. Global+multiline.
+const HEADING_RE = /^[ \t]*#[ \t]+(\S.*)$/gm;
+// [voice:NAME] — content excludes BOTH brackets (mirrors _VOICE_RE).
+const VOICE_RE = /\[voice:([^\]\[]*)\]/g;
+// Pause dialect mirroring omnivoice.utils.text._PAUSE_RE. JS has no atomic
+// group; the unit's own `(?:\s*(ms|s))?` is zero-width when no unit follows, so
+// the trailing `\s*` is the ONLY consumer of trailing whitespace — no two `\s*`
+// overlap on the same run (ReDoS-safe, matches the Python atomic group exactly
+// on the full dialect + NO-MATCH boundary set).
+const PAUSE_RE = /\[\s*pause(?:\s+(\d+(?:\.\d+)?)(?:\s*(ms|s))?)?\s*\]/gi;
+
+/** Round half-to-even (banker's rounding) — matches Python int(round(x)). */
+export function roundHalfToEven(x) {
+  const f = Math.floor(x);
+  const diff = x - f;
+  if (diff < 0.5) return f;
+  if (diff > 0.5) return f + 1;
+  // exact .5 tie → round to the even neighbour
+  return f % 2 === 0 ? f : f + 1;
+}
+
+function _pauseMs(num, unit) {
+  if (num == null) return PAUSE_DEFAULT_MS;
+  const value = parseFloat(num);
+  if (!Number.isFinite(value)) return PAUSE_DEFAULT_MS;
+  const ms = (unit && unit.toLowerCase() === 's') ? value * 1000 : value;
+  const msInt = roundHalfToEven(ms);
+  return Math.max(0, Math.min(msInt, PAUSE_MAX_MS));
+}
+
+/** Mirror of text.py:parse_pause_markers → [[spanText, pauseMsAfter], …]. */
+export function parsePauseMarkers(text) {
+  if (!text || text.indexOf('[') === -1) return [[text, 0]];
+  const segments = [];
+  let last = 0;
+  let pendingText = '';
+  const re = new RegExp(PAUSE_RE.source, PAUSE_RE.flags);
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    pendingText += text.slice(last, m.index);
+    last = re.lastIndex;
+    const pause = _pauseMs(m[1] != null ? m[1] : null, m[2] != null ? m[2] : null);
+    if (pendingText === '' && segments.length) {
+      const [prevText, prevPause] = segments[segments.length - 1];
+      segments[segments.length - 1] = [prevText, Math.min(prevPause + pause, PAUSE_MAX_MS)];
+    } else {
+      segments.push([pendingText, pause]);
+    }
+    pendingText = '';
+    if (re.lastIndex === m.index) re.lastIndex++; // guard against zero-width
+  }
+  const tail = pendingText + text.slice(last);
+  if (tail || !segments.length) segments.push([tail, 0]);
+  return segments;
+}
+
+/** Mirror of the voice-split in _parse_chapter_body → [[voiceId, runText], …]. */
+export function parseVoiceRuns(body, defaultVoice) {
+  const runs = [];
+  let curVoice = defaultVoice;
+  let last = 0;
+  const re = new RegExp(VOICE_RE.source, VOICE_RE.flags);
+  let m;
+  while ((m = re.exec(body)) !== null) {
+    if (m.index > last) runs.push([curVoice, body.slice(last, m.index)]);
+    const id = (m[1] || '').trim();
+    curVoice = id || defaultVoice;
+    last = re.lastIndex;
+    if (re.lastIndex === m.index) re.lastIndex++;
+  }
+  runs.push([curVoice, body.slice(last)]);
+  return runs;
+}
+
+/**
+ * Voice→pause→SSML layering for ONE chapter body (no chapter split). The
+ * storyToSpans adapter calls this per spoken track. Mirrors Python
+ * _parse_chapter_body.
+ */
+export function parseChapterBody(body, { defaultVoice = null, defaultSpeed = null } = {}) {
+  const spans = [];
+  for (const [voice, runText] of parseVoiceRuns(body, defaultVoice)) {
+    for (const [spanText, pauseMs] of parsePauseMarkers(runText)) {
+      const t = (spanText || '').trim();
+      if (!t && pauseMs === 0) continue;
+      const rendered = [];
+      for (const seg of (t ? parseSsmlLite(t) : [])) {
+        const st = (seg.spell ? spellOut(seg.text) : seg.text).trim();
+        if (st) {
+          const sp = seg.speed != null ? seg.speed : defaultSpeed;
+          rendered.push([st, sp]);
+        }
+      }
+      if (!rendered.length) {
+        if (pauseMs > 0) {
+          spans.push({ voice_id: voice, text: '', pause_ms_after: pauseMs, speed: null });
+        }
+        continue;
+      }
+      rendered.forEach(([st, sp], j) => {
+        spans.push({
+          voice_id: voice, text: st,
+          pause_ms_after: j === rendered.length - 1 ? pauseMs : 0,
+          speed: sp,
+        });
+      });
+    }
+  }
+  return spans;
+}
+
+/** Mirror of parse_script_to_spans → [{ title, spans:[{voice_id,text,pause_ms_after,speed}] }]. */
+export function parseScriptToSpans(text, { defaultVoice = null, defaultSpeed = null } = {}) {
+  if (!text) return [];
+  const norm = text.replace(/\r\n?/g, '\n');
+
+  const matches = [];
+  const re = new RegExp(HEADING_RE.source, HEADING_RE.flags);
+  let m;
+  while ((m = re.exec(norm)) !== null) {
+    matches.push({ index: m.index, end: m.index + m[0].length, title: m[1] });
+    if (re.lastIndex === m.index) re.lastIndex++;
+  }
+
+  const raw = [];
+  if (!matches.length) {
+    raw.push([null, norm]);
+  } else {
+    const intro = norm.slice(0, matches[0].index);
+    if (intro.trim()) raw.push([null, intro]);
+    for (let i = 0; i < matches.length; i++) {
+      const end = i + 1 < matches.length ? matches[i + 1].index : norm.length;
+      raw.push([matches[i].title.trim(), norm.slice(matches[i].end, end)]);
+    }
+  }
+
+  const chapters = [];
+  for (const [title, body] of raw) {
+    const spans = parseChapterBody(body, { defaultVoice, defaultSpeed });
+    if (!spans.length) continue;
+    chapters.push({ title: title || `Chapter ${chapters.length + 1}`, spans });
+  }
+  return chapters;
+}

--- a/frontend/src/utils/storyExport.js
+++ b/frontend/src/utils/storyExport.js
@@ -59,14 +59,17 @@ export function encodeWav(buffer, sampleRate) {
   return ab;
 }
 
-/** A line is a chapter heading if its text starts with a markdown "# ". */
+/** A line is a chapter heading iff it's an H1 with a non-space title (#27:
+ *  narrowed from H1–H6 to match the server's _HEADING_RE — `##`… and `# ` with
+ *  no non-space title narrate as body, not chapter breaks). */
 export function isChapterLine(text) {
-  return /^#{1,6}\s+/.test(String(text || '').trim());
+  return /^#[ \t]+\S/.test(String(text || '').trim());
 }
 
-/** The chapter title — the text after the leading "# ". */
+/** The chapter title — strip only the single leading "# ", remainder verbatim
+ *  (matching the server's raw-title behavior, so `# [voice:x] T` → `[voice:x] T`). */
 export function chapterTitle(text) {
-  return String(text || '').trim().replace(/^#+\s+/, '').trim();
+  return String(text || '').trim().replace(/^#[ \t]+/, '').trim();
 }
 
 /** Format seconds as HH:MM:SS for a chapter cue sheet. */

--- a/frontend/src/utils/storyExport.test.js
+++ b/frontend/src/utils/storyExport.test.js
@@ -42,12 +42,20 @@ describe('encodeWav', () => {
 });
 
 describe('chapter helpers', () => {
-  it('detects + titles markdown chapter lines', () => {
+  it('detects + titles H1 chapter lines (H1-only, #27)', () => {
     expect(isChapterLine('# Chapter One')).toBe(true);
-    expect(isChapterLine('  ## Part 2 ')).toBe(true);
+    expect(isChapterLine('  # Indented')).toBe(true);   // leading space ok
+    // #27 convergence: H2–H6 narrate as body, not chapter breaks.
+    expect(isChapterLine('  ## Part 2 ')).toBe(false);
+    expect(isChapterLine('### Deep')).toBe(false);
+    // `# ` / `#   ` with no non-space title is body (matches server _HEADING_RE).
+    expect(isChapterLine('# ')).toBe(false);
+    expect(isChapterLine('#   ')).toBe(false);
+    expect(isChapterLine('#Title')).toBe(false);        // needs a space
     expect(isChapterLine('Not a chapter')).toBe(false);
     expect(chapterTitle('# Chapter One')).toBe('Chapter One');
-    expect(chapterTitle('## Part 2')).toBe('Part 2');
+    // strip only the single H1 marker; remainder verbatim (raw-title behavior).
+    expect(chapterTitle('# [voice:x] Title')).toBe('[voice:x] Title');
   });
   it('formats timecodes HH:MM:SS', () => {
     expect(formatTimecode(0)).toBe('00:00:00');

--- a/frontend/src/utils/storyToScript.test.js
+++ b/frontend/src/utils/storyToScript.test.js
@@ -41,12 +41,14 @@ describe('storyToScript', () => {
     expect(r.script).toBe('A\n\n[voice:p_b] B');
   });
 
-  it('chapters: single-#, ## downgraded to #, indented un-indented', () => {
+  it('chapters: H1-only (#27) — ## narrates as body, indented # un-indented', () => {
     const r = storyToScript([
       spoken(1, '## Deep'), spoken(2, 'body1'),
       spoken(3, '   # Indented'), spoken(4, 'body2'),
     ], []);
-    expect(r.script).toBe('# Deep\n\nbody1\n\n# Indented\n\nbody2');
+    // #27 convergence: `## Deep` is NOT a heading (H1-only), so it narrates as
+    // body text verbatim; only the indented H1 opens a chapter (un-indented).
+    expect(r.script).toBe('## Deep\n\nbody1\n\n# Indented\n\nbody2');
   });
 
   it('does not double-tag a line that already leads with [voice:sameid]', () => {

--- a/frontend/src/utils/storyToSpans.js
+++ b/frontend/src/utils/storyToSpans.js
@@ -1,7 +1,6 @@
-import { parseStoryText } from './storyTokens';
 import { isChapterLine, chapterTitle } from './storyExport';
 import { effectiveProfile } from './storyCast';
-import { parseSsmlLite, spellOut } from './ssmlLite';
+import { parseChapterBody } from './longformParser';
 
 /**
  * Compile the Stories Editor's cast + ordered lines into the chapter/span plan
@@ -9,14 +8,17 @@ import { parseSsmlLite, spellOut } from './ssmlLite';
  * multi-voice story render on the same server-side pipeline as an audiobook
  * (resume, loudness, cover, chapter markers).
  *
- * Rules:
- *  - a line starting with "# " opens a new chapter (its text is the title)
- *  - every spoken line resolves to its effective voice (per-line override →
- *    cast member's voice) and is split on inline `[voice:]`/`[pause]` markers
- *  - a `[pause]` folds into the previous span's trailing silence, or becomes a
- *    silent span if it leads a chapter
+ * The track→canonical adapter (#27): per-track cast voice + speed are resolved
+ * here, then the track's text runs through the ONE canonical voice→pause→SSML
+ * layering (`parseChapterBody`) — the same code the Python parser uses. The
+ * adapter, not the canonical parser, owns the two track-shaped concerns:
+ *  - a `#`-line *inside* a track's text must NOT re-chapter (we call
+ *    parseChapterBody, which never chapter-splits, not parseScriptToSpans);
+ *  - a track's *leading* pause folds into the previous track's last span
+ *    (cross-track fold) — but a mid-track silent span (from `[voice:x][pause]`)
+ *    is kept, matching the server's single-blob behavior.
  *
- * @returns Array<{ title, spans: [{ voice_id, text, pause_ms_after }] }>
+ * @returns Array<{ title, spans: [{ voice_id, text, pause_ms_after, speed }] }>
  */
 export function storyToSpans(tracks, cast) {
   const chapters = [];
@@ -30,24 +32,19 @@ export function storyToSpans(tracks, cast) {
       cur = { title: chapterTitle(text), spans: [] };
       continue;
     }
-    const profileId = effectiveProfile(tk, cast) || null;
-    const speed = tk.speed || null;  // per-line rate rides through to the engine
-    for (const seg of parseStoryText(text, profileId)) {
-      if (seg.type === 'pause') {
-        const ms = Math.round(seg.seconds * 1000);
-        const last = cur.spans[cur.spans.length - 1];
-        if (last) last.pause_ms_after += ms;
-        else cur.spans.push({ voice_id: profileId, text: '', pause_ms_after: ms, speed });
-      } else if (seg.text) {
-        // Inner layer: SSML-lite prosody within the chunk. Inline [slow]/[fast]
-        // /[emphasis] speed overrides the per-line slider; [spell] spaces it out.
-        const vid = seg.profileId || null;
-        for (const s of parseSsmlLite(seg.text)) {
-          const st = (s.spell ? spellOut(s.text) : s.text).trim();
-          if (st) cur.spans.push({ voice_id: vid, text: st, pause_ms_after: 0, speed: s.speed != null ? s.speed : speed });
-        }
+    const voiceId = effectiveProfile(tk, cast) || null;
+    const speed = tk.speed || null;  // falsy 0 → null (engine default), per spec
+    const spans = parseChapterBody(text, { defaultVoice: voiceId, defaultSpeed: speed });
+    spans.forEach((s, i) => {
+      const prev = cur.spans[cur.spans.length - 1];
+      // Cross-track fold: a track that *leads* with a pause merges that silence
+      // onto the previous span instead of emitting a standalone silent span.
+      if (i === 0 && s.text === '' && s.pause_ms_after > 0 && prev) {
+        prev.pause_ms_after += s.pause_ms_after;
+      } else {
+        cur.spans.push(s);
       }
-    }
+    });
   }
   flush();
   return chapters;

--- a/frontend/src/utils/storyTokens.js
+++ b/frontend/src/utils/storyTokens.js
@@ -17,10 +17,26 @@
  * Whitespace-only chunks between markers are dropped so they don't introduce
  * audible "uhs" from the TTS model.
  */
+import { roundHalfToEven, PAUSE_DEFAULT_MS, PAUSE_MAX_MS } from './longformParser';
 
 // Single pattern that matches either token; the alternation captures the
-// payload in group 1 (pause seconds) or group 2 (voice id).
-const TOKEN_RE = /\[(?:pause\s+(\d+(?:\.\d+)?)\s*s?|voice:\s*([^\]]+))\]/gi;
+// payload in group 1 (pause number), group 2 (pause unit ms|s), group 3 (voice).
+// Widened to the CANONICAL dialect (#27) so the highlight overlay agrees with
+// the render plan: bare [pause], [pause Nms], [pause Ns], [pause N.Ns], and
+// [voice:[^\]\[]*] (empty [voice:] → default; a nested `[` → no match).
+// ReDoS-safe: the unit's `(?:\s*(ms|s))?` is zero-width without a unit, so no
+// two `\s*` overlap on the same whitespace run (mirrors PAUSE_RE).
+const TOKEN_RE = /\[(?:\s*pause(?:\s+(\d+(?:\.\d+)?)(?:\s*(ms|s))?)?\s*|voice:\s*([^\]\[]*))\]/gi;
+
+// Resolve a parsed (number, unit) pause to clamped ms — mirrors text.py:_pause_ms
+// (banker's rounding via the shared roundHalfToEven so highlight == render).
+function _pauseMs(num, unit) {
+  if (num == null) return PAUSE_DEFAULT_MS;
+  const value = parseFloat(num);
+  if (!Number.isFinite(value)) return PAUSE_DEFAULT_MS;
+  const ms = (unit && unit.toLowerCase() === 's') ? value * 1000 : value;
+  return Math.max(0, Math.min(roundHalfToEven(ms), PAUSE_MAX_MS));
+}
 
 export function parseStoryText(text, defaultProfileId = null) {
   const out = [];
@@ -35,16 +51,21 @@ export function parseStoryText(text, defaultProfileId = null) {
       const chunk = text.slice(cursor, match.index).trim();
       if (chunk) out.push({ type: 'chunk', text: chunk, profileId: currentProfile });
     }
-    if (match[1] != null) {
-      const seconds = parseFloat(match[1]);
+    if (match[3] != null) {
+      // voice branch — group 3 is defined even when empty ([voice:] → default)
+      const id = match[3].trim();
+      currentProfile = (id === 'default' || id === '') ? defaultProfileId : id;
+    } else {
+      // pause branch — bare or numbered. ms→seconds; a 0-duration pause is
+      // consumed (not spoken) but shows no overlay (the >0 guard below).
+      const seconds = _pauseMs(match[1] != null ? match[1] : null,
+                              match[2] != null ? match[2] : null) / 1000;
       if (Number.isFinite(seconds) && seconds > 0) {
         out.push({ type: 'pause', seconds });
       }
-    } else if (match[2] != null) {
-      const id = match[2].trim();
-      currentProfile = (id === 'default' || id === '') ? defaultProfileId : id;
     }
     cursor = re.lastIndex;
+    if (re.lastIndex === match.index) re.lastIndex++; // zero-width guard
   }
   if (cursor < text.length) {
     const tail = text.slice(cursor).trim();
@@ -53,9 +74,11 @@ export function parseStoryText(text, defaultProfileId = null) {
   return out;
 }
 
-/** True if `text` contains any inline marker we need to special-case for preview. */
+/** True if `text` contains any inline marker we special-case for preview.
+ *  Widened (#27) to recognize bare [pause] / [pause Nms] so the highlight path
+ *  and the render path agree on which lines carry markers. */
 export function hasStoryMarkers(text) {
-  return /\[(?:pause\s+\d|voice:)/i.test(text || '');
+  return /\[\s*pause\b|\[voice:/i.test(text || '');
 }
 
 /**

--- a/frontend/src/utils/storyTokens.test.js
+++ b/frontend/src/utils/storyTokens.test.js
@@ -16,11 +16,15 @@ describe('parseStoryText', () => {
     ]);
   });
 
-  it('accepts pauses without trailing "s" and with integer seconds', () => {
-    const out = parseStoryText('A [pause 1] B [pause 2s] C', 'n');
+  it('treats a bare number as milliseconds (#27 canonical), "s" as seconds', () => {
+    // #27 convergence to the server dialect: a unitless number is MILLISECONDS
+    // ([pause 1] = 1ms = 0.001s), and "ms"/"s" units are honored. Previously the
+    // client read a bare number as seconds — now both ports agree it's ms.
+    const out = parseStoryText('A [pause 1] B [pause 2s] C [pause 500ms] D', 'n');
     expect(out.filter(e => e.type === 'pause')).toEqual([
-      { type: 'pause', seconds: 1 },
-      { type: 'pause', seconds: 2 },
+      { type: 'pause', seconds: 0.001 },  // 1ms
+      { type: 'pause', seconds: 2 },      // 2s
+      { type: 'pause', seconds: 0.5 },    // 500ms
     ]);
   });
 
@@ -59,10 +63,41 @@ describe('parseStoryText', () => {
   });
 });
 
+// §I — #27 dialect-widening cases (bare/ms pause, empty [voice:], NO-MATCH set)
+describe('parseStoryText — #27 canonical dialect', () => {
+  it('emits bare [pause] as 0.35s (was previously spoken)', () => {
+    expect(parseStoryText('a [pause] b')).toEqual([
+      { type: 'chunk', text: 'a', profileId: null },
+      { type: 'pause', seconds: 0.35 },
+      { type: 'chunk', text: 'b', profileId: null },
+    ]);
+  });
+
+  it('empty [voice:] reverts to the default profile (no longer spoken)', () => {
+    const out = parseStoryText('a [voice:p_x] b [voice:] c', 'p_def');
+    expect(out.map((e) => [e.profileId, e.text])).toEqual([
+      ['p_def', 'a'], ['p_x', 'b'], ['p_def', 'c'],
+    ]);
+  });
+
+  it('does not match NO-MATCH boundary pause forms (spoken literally)', () => {
+    for (const bad of ['[pause .5s]', '[pause -5s]', '[pause1s]', '[pausexyz]']) {
+      const out = parseStoryText(`x ${bad} y`);
+      expect(out.some((e) => e.type === 'pause')).toBe(false);
+      expect(out.map((e) => e.text || '').join(' ')).toContain('pause');
+    }
+  });
+});
+
 describe('hasStoryMarkers', () => {
   it('returns true when either token is present', () => {
     expect(hasStoryMarkers('A [pause 0.5s] B')).toBe(true);
     expect(hasStoryMarkers('[voice:char-0] hello')).toBe(true);
+  });
+  it('recognizes the #27-widened forms (bare/ms pause, empty voice)', () => {
+    expect(hasStoryMarkers('hi [pause] there')).toBe(true);
+    expect(hasStoryMarkers('hi [pause 500ms] there')).toBe(true);
+    expect(hasStoryMarkers('hi [voice:] there')).toBe(true);
   });
   it('returns false for plain prose', () => {
     expect(hasStoryMarkers('Just regular text.')).toBe(false);


### PR DESCRIPTION
**Slice B of #27** — the mechanically-mirrored **JS twin** of the slice-A Python parser, plus the frontend convergence. Builds on #465 (merged).

### Change
- **`frontend/src/utils/longformParser.js`** (new): `parseScriptToSpans` / `parseChapterBody` / `parsePauseMarkers` / `parseVoiceRuns` + `roundHalfToEven` — a byte-for-byte mirror of `backend/services/longform_parser.py`. CRLF/CR→LF normalization, empty-guard, ReDoS-safe pause regex (the unit's `(?:\s*(ms|s))?` is zero-width without a unit → no overlapping `\s*`).
- **`frontend/src/test/longformParser.test.js`** (new): loads the **same** `tests/fixtures/longform_parser_cases.json` the Python suite asserts → drift in either port fails its own suite. **82 cases** + rounding + ReDoS-linearity.
- **`storyToSpans.js`**: reimplemented as the **track→canonical adapter** — per-track cast voice + speed resolved here, text run through `parseChapterBody` (no re-chapter on an embedded `#`), cross-track leading-pause fold; mid-track silent spans kept (matches server blob).
- **`storyTokens.js`**: `TOKEN_RE` widened to the canonical dialect (bare `[pause]`, `Nms`/`Ns`, `[voice:[^\]\[]*]`), **group renumbered** (pause 1+2, voice 3), `parseStoryText` reads the new groups + banker's-rounding ms; `hasStoryMarkers` widened.
- **`storyExport.js`**: `isChapterLine`/`chapterTitle` narrowed to **H1-only + `\S` title** (matches `_HEADING_RE`).

### Convergence (intended, user-visible)
`##`–`######` and `# ` (no title) now narrate as **body**; bare `[pause]`/`[pause 500ms]` become **silence** (not spoken); a unitless `[pause 1]` is now **1 ms** (was 1 s — both ports now agree with the server); `[voice:]` reverts to default; `[voice:[nested]]` spoken literally. Pre-existing tests updated to lock the new truth (`storyExport`, `storyToScript`, `storyTokens`).

### Checks
**Full vitest: 500 passed (56 files).** Cross-impl corpus identical to Python. No wire-shape change; `StoriesEditor` imports unchanged.

Next: docs/cleanup (slice C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR establishes a canonical text parsing implementation across the frontend by introducing a JavaScript port of the Python longform parser. The changes ensure consistent handling of pause markers, voice tags, and chapter detection between frontend and backend, with 500 tests passing across 56 test files.

## Key Additions

**`frontend/src/utils/longformParser.js`** (161 LOC)
- New canonical parser module that mirrors `backend/services/longform_parser.py` byte-for-byte
- Exports functions: `parseScriptToSpans`, `parseChapterBody`, `parsePauseMarkers`, `parseVoiceRuns`, and `roundHalfToEven`
- Features CRLF/CR→LF normalization, empty-guard handling, and ReDoS-safe regex patterns
- Exports constants: `PAUSE_DEFAULT_MS = 350`, `PAUSE_MAX_MS = 10000`

**Test Suites**
- `frontend/src/test/longformParser.test.js`: 82 test cases loaded from shared `tests/fixtures/longform_parser_cases.json` fixture (82 cases, used by Python suite for drift detection)
- Extended `storyToSpans.test.js` and `storyTokens.test.js` with adapter-specific test cases

## Key Modifications

**`storyToSpans.js`**
- Now acts as track-to-canonical adapter
- Resolves per-track voice (from `effectiveProfile`) and speed (from `tk.speed`)
- Processes text through `parseChapterBody` instead of legacy `parseStoryText` pipeline
- Implements cross-track fold: leading silence from subsequent track merges into prior span's trailing pause

**`storyTokens.js`**
- Expanded `TOKEN_RE` to support canonical dialect: bare `[pause]`, `[pause Nms]`, `[pause Ns]`, `[voice:[^\]\[]*]`
- Added `_pauseMs` helper with banker's rounding for milliseconds using `roundHalfToEven`
- Empty voice tags `[voice:]` now revert to default voice instead of being spoken
- Added zero-width regex progress guard

**`storyExport.js`**
- Narrowed chapter detection: only H1 (`#`) headings with non-whitespace titles are chapters
- H2–H6 headings now narrate as body text
- Updated `chapterTitle` to strip only single `#` marker plus spaces/tabs

## Parsing Pipeline

```
Script Text
    ↓ [Normalize CRLF→LF]
    ↓
    ├─→ Per-Chapter:
    │   ├─→ Extract title (H1 only)
    │   ├─→ Parse chapter body:
    │   │   ├─→ Parse voice runs [voice:NAME]
    │   │   ├─→ Split into segments
    │   │   ├─→ Parse pause markers [pause], [pause 500ms], [pause 2s]
    │   │   └─→ Generate spans {voice_id, text, pause_ms_after, speed}
    │   └─→ Chapter {title, spans}
    │
    ├─→ Per-Track (in storyToSpans):
    │   ├─→ Resolve voice from profile
    │   ├─→ Resolve speed (0 → null)
    │   ├─→ Parse via parseChapterBody
    │   └─→ Fold leading silence into prior span
    │
    └─→ Output: Chapters with canonical spans
```

## Behavioral Changes

| Aspect | Before | After |
|--------|--------|-------|
| **Chapter Detection** | H1–H6 headings | H1 (`#`) only with non-whitespace title |
| **Pause Markers** | `[pause:500]`, `[pause 2]` (ambiguous) | Bare `[pause]` (350ms), `[pause 500ms]`, `[pause 2s]` (explicit units) |
| **Unitless Pause Values** | Interpreted as seconds | Interpreted as milliseconds |
| **Empty Voice Tags** | `[voice:]` → `null` (spoken literally) | `[voice:]` → revert to default voice (silent) |
| **Nested Voice Tags** | Ignored or nested | Spoken literally (not parsed) |
| **Cross-Track Leading Pause** | Creates standalone silent span | Folded into previous span's `pause_ms_after` |
| **Rounding** | Truncation | Banker's rounding (half-to-even) for milliseconds |

## Testing

- 82 golden-corpus test cases from shared Python fixture file ensure drift detection
- 500+ total tests passing across 56 test files
- Performance guard: `parseScriptToSpans` completes in <1s on pathological inputs
- No wire-shape changes or StoriesEditor import modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->