### PR TITLE
docs(longform): retire hand-sync comment; corpus enforces parity (#27 slice C)

### DIFF
--- a/frontend/src/utils/ssmlLite.js
+++ b/frontend/src/utils/ssmlLite.js
@@ -1,5 +1,11 @@
 /**
- * SSML-LITE (client port) — keep in sync with backend/services/ssml_lite.py.
+ * SSML-LITE (client port) of backend/services/ssml_lite.py.
+ *
+ * Parity is no longer kept by hand: the canonical longform grammar (#27) is
+ * exercised end-to-end by the shared golden corpus in
+ * tests/fixtures/longform_parser_cases.json, asserted byte-for-byte against
+ * BOTH this port (via longformParser.js → storyToSpans) and the Python parser.
+ * A drift between the two SSML impls fails one of those two suites.
  *
  * Splits one narration line into ordered prosody segments so the Stories Editor
  * compiles the same `[slow]/[fast]/[emphasis]/[spell]` markup the Audiobook


### PR DESCRIPTION
**Slice C of #27** — final cleanup. The SSML-lite client port header claimed "keep in sync with `backend/services/ssml_lite.py`" — a manual contract with no test. After #27 the canonical grammar (SSML-lite included, via `longformParser.js → storyToSpans`) is asserted byte-for-byte against the Python parser through the shared golden corpus, so drift now fails CI. Comment updated to point at that enforcement.

Docs-sync: grep confirms **no user-facing doc** documents the marker dialect (only the internal `competitive-analysis.md` planning doc), so no doc update is required for the converged behaviour.

Completes #27 (slices A #465 + B #467 + C). The three parser paths are now one Python source + one mechanically-mirrored JS twin, drift-locked by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the module header documentation in `frontend/src/utils/ssmlLite.js` to reflect the completion of issue `#27` and the establishment of automated enforcement of parser parity.

### Changes

The header comment in `ssmlLite.js` has been updated to remove the previous instruction to "keep in sync by hand" with the Python backend implementation. The new documentation states that parity between the JavaScript client port and `backend/services/ssml_lite.py` is now validated automatically end-to-end through:

- A shared golden corpus located in `tests/fixtures/longform_parser_cases.json`
- Byte-for-byte assertions against both the JavaScript parser (via `longformParser.js → storyToSpans`) and the Python parser
- CI test failures triggered by any divergence between the two implementations

This change reflects the completion of consolidating three separate parser implementations into a single canonical longform grammar enforced across platforms through automated corpus-based validation.

**Lines changed:** +7 / -1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->