### PR TITLE
test(settings): de-flake the at-rest-encryption assertion

### DIFF
--- a/tests/backend/services/test_settings_store.py
+++ b/tests/backend/services/test_settings_store.py
@@ -2,7 +2,8 @@
 
 Behaviors covered:
 - set_hf_token / get_hf_token round-trips the exact same string
-- Raw bytes in the SQLite `settings.value` column do NOT contain `hf_` —
+- Raw bytes in the SQLite `settings.value` column do NOT contain the plaintext
+  token (nor a long chunk of it) and round-trip back via get_hf_token —
   encrypted at rest, not plaintext
 - clear_hf_token followed by get_hf_token returns None
 - First set generates and stores a per-install salt row
@@ -65,9 +66,14 @@ def test_stored_value_is_encrypted_not_plaintext(isolated_db):
         ).fetchone()
     assert row is not None
     raw = row[0]
-    # If the token leaked into storage in plaintext, this catches it.
-    assert "hf_" not in raw
+    # The stored value must not be the plaintext token. Check the full token and
+    # a long leading chunk — but NOT a 3-char prefix like "hf_": the value is
+    # Fernet urlsafe-base64 (alphabet includes '_'), so a random ciphertext
+    # occasionally contains "hf_" by chance, which made that assertion flaky.
     assert SAMPLE_TOKEN not in raw
+    assert SAMPLE_TOKEN[:16] not in raw  # not even a leading chunk leaks
+    # And it must round-trip — proving it's genuinely encrypted, not just absent.
+    assert settings_store.get_hf_token() == SAMPLE_TOKEN
 
 
 def test_clear_removes_token(isolated_db):


### PR DESCRIPTION
`test_stored_value_is_encrypted_not_plaintext` asserted `"hf_" not in raw`, but the stored value is Fernet **URL-safe base64** (alphabet includes `_`), so a random ciphertext occasionally contains the substring `hf_` by chance — a **false failure that bit unrelated PRs** on CI (seen on #467).

### Fix
Replace the weak-and-flaky 3-char-prefix check with stronger, deterministic guarantees:
- full token absent from the raw column (kept);
- a **16-char leading chunk** absent (no partial leak; never collides by chance);
- value **round-trips** via `get_hf_token()` — proves it's genuinely encrypted, not just absent/empty.

Verified non-flaky: target test **passed 8/8** consecutive local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for Flaky Encryption Validation Test

This PR addresses test flakiness in `test_stored_value_is_encrypted_not_plaintext` by strengthening the validation logic that confirms stored HuggingFace tokens are properly encrypted rather than plaintext.

### Problem
The test originally checked that the substring `"hf_"` was absent from the raw SQLite-stored encrypted value. However, because Fernet uses URL-safe base64 encoding (which includes the underscore character in its alphabet), random ciphertext occasionally contains the substring `"hf_"` by pure chance, causing false test failures on unrelated PRs.

### Solution
Replaced the weak 3-character prefix check with three deterministic validation guarantees:

1. **Full token absence** (existing): The complete plaintext token is not present in the raw stored value
2. **Long chunk absence** (new): A 16-character leading chunk of the token is absent, ensuring no partial token leak and making random collision statistically impossible
3. **Round-trip correctness** (existing): The stored value decrypts correctly via `get_hf_token()`, proving the value is genuinely encrypted rather than merely absent

### Changes
- **File**: `tests/backend/services/test_settings_store.py` (lines 59–76)
- Updated comments to explain why the original weak assertion was problematic
- Added new assertion: `assert SAMPLE_TOKEN[:16] not in raw`
- Retained existing checks for full token absence and round-trip correctness

The target test now passes reliably (8+ consecutive local runs confirmed without failure), eliminating the flakiness that impacted unrelated CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->