### PR TITLE
fix: actionable errors for non-executable engine binary (#437) + unreachable backend (#438/#454/#466)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -116,6 +116,17 @@ def _oom_friendly_reraise(e):
             f"Disable torch.compile in Settings → Performance, use the Flush "
             f"button to reload the model, then regenerate. Underlying error: {e}"
         ) from e
+    # #437: a Permission-denied / exec failure (e.g. a bundled engine binary
+    # that lost its +x bit) is NOT an OOM — don't send the user to the Flush
+    # button; tell them what's actually wrong.
+    es = str(e)
+    if isinstance(e, PermissionError) or "Permission denied" in es or "Errno 13" in es:
+        raise RuntimeError(
+            f"A required engine binary couldn't be executed (permission denied). "
+            f"This usually means a bundled binary lost its execute bit — reinstall, "
+            f"or run `chmod +x` on the engine binary named in the error. "
+            f"Underlying error: {e}"
+        ) from e
     raise RuntimeError(
         f"TTS engine stopped mid-generation. This usually means it ran out of memory. "
         f"Try the Flush button to reload the model, then regenerate. Underlying error: {e}"

--- a/backend/engines/omnivoice_gguf/backend.py
+++ b/backend/engines/omnivoice_gguf/backend.py
@@ -353,6 +353,21 @@ def _make_backend_class():
                         f"This clears the quarantine on the .app and its "
                         f"bundled binaries. See docs/install/macos.md."
                     )
+                # Execute bit (issue #437). A `git clone` / zip extract on POSIX
+                # can drop +x, which only surfaces at spawn time as
+                # "[Errno 13] Permission denied" — and the generic synth handler
+                # then mislabels it as out-of-memory. Self-heal here, AFTER the
+                # SHA check has confirmed this is the right file (so we never
+                # chmod a foreign binary). No-op on Windows.
+                if os.name == "posix" and not os.access(bin_path, os.X_OK):
+                    try:
+                        bin_path.chmod(bin_path.stat().st_mode | 0o111)
+                    except OSError:
+                        return False, (
+                            f"GGUF binary {bin_path.name} isn't executable and "
+                            f"couldn't be made so — run `chmod +x {bin_path}` "
+                            f"and retry."
+                        )
                 return True, "ready"
             except Exception as exc:
                 return False, f"{type(exc).__name__}: {exc}"

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -21,4 +21,16 @@ describe('apiFetch PIN header', () => {
     await apiFetch('/system/info');
     expect((seen.headers || {})['X-OmniVoice-Pin']).toBeUndefined();
   });
+
+  it('turns a thrown fetch into an actionable ApiError (backend unreachable)', async () => {
+    // Backend down / still starting → fetch() rejects with a TypeError.
+    globalThis.fetch = vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))) as any;
+    const { apiFetch, ApiError } = await import('./client');
+    let err: any;
+    try { await apiFetch('/system/info'); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(0);                       // transport failure, not HTTP
+    expect(String(err.message)).toMatch(/reach the local OmniVoice backend/i);
+    expect(String(err.detail)).toMatch(/Failed to fetch/);
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -111,7 +111,21 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
   const finalOpts: RequestInit = Object.keys(extra).length
     ? { ...opts, headers: { ...(opts.headers as Record<string, string> || {}), ...extra } }
     : opts;
-  const res = await fetch(apiUrl(path), finalOpts);
+  let res: Response;
+  try {
+    res = await fetch(apiUrl(path), finalOpts);
+  } catch (e) {
+    // A thrown fetch (TypeError "Failed to fetch" / "NetworkError") means the
+    // request never reached the backend — it's still starting up, crashed, or
+    // the dev server dropped. Surface that as an actionable ApiError instead of
+    // the raw browser string (issues #438/#454/#466). status:0 lets callers
+    // distinguish a transport failure from an HTTP error.
+    throw new ApiError(
+      "Can't reach the local OmniVoice backend — it may still be starting up, or it stopped. " +
+      "Wait a few seconds and try again; if it persists, restart the app (or check Settings → Logs → Backend).",
+      { status: 0, detail: String((e as Error)?.message || e) },
+    );
+  }
   if (!res.ok) {
     // 401 from the LAN PIN middleware on a remote device → surface the gate.
     if (res.status === 401 && typeof window !== 'undefined') {


### PR DESCRIPTION
Two reliability bugs from open issues — both first-run papercuts where the error told the user the **wrong** thing.

### #437 — `Permission denied: bin/omnivoice-tts-linux-x86_64`
A `git clone` / zip extract on POSIX can drop the bundled binary's execute bit. It only surfaced at spawn time, and the generic synth handler **mislabeled it as "ran out of memory"** and told the user to flush the model.
- `omnivoice_gguf.is_available()` **self-heals**: after the SHA check confirms the binary is the right file, it adds `+x` (best-effort) on POSIX; if it can't, it returns a clear *"isn't executable — run `chmod +x`"* message. No-op on Windows.
- `generation.py` classifies `PermissionError`/EACCES as its own case (*"a bundled binary lost its execute bit — reinstall or chmod +x"*) — never again masquerading as OOM.

### #438 / #454 / #466 — bare "Failed to fetch" / "NetworkError"
When the local backend is still starting, crashed, or the dev server dropped, `fetch()` throws a `TypeError` that propagated raw to the user.
- `client.ts` `apiFetch` now catches it and raises an `ApiError` with an actionable message (*"Can't reach the local OmniVoice backend — it may still be starting up… restart the app or check Settings → Logs"*), `status:0` to mark a transport failure vs an HTTP error.

### Tests
`client.test.ts` +1 (thrown fetch → `ApiError` status 0 + actionable text) — 3 pass. CJK green.

Closes #437, #438, #454, #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix first-run reliability bugs with misleading error messages

## Overview
This PR addresses two critical first-run reliability issues where errors were misreported to users, causing confusion and incorrect troubleshooting attempts:

1. **Issue `#437`**: Non-executable engine binary reported as "out of memory" on POSIX systems  
2. **Issues `#438`, `#454`, `#466`**: Unreachable backend fetch errors propagating as generic "Failed to fetch"

The fixes implement self-healing for missing execute permissions and proper error classification for transport-layer failures.

## Changes

### Backend Error Classification (generation.py)
Enhanced `_oom_friendly_reraise()` to detect and properly classify permission-related failures:
- After torch.compile/Triton checks, detects `PermissionError`, "Permission denied" string, or "Errno 13" in exception messages
- Raises a clear `RuntimeError` with actionable message: "A required engine binary couldn't be executed (permission denied). This usually means a bundled binary lost its execute bit — reinstall, or run `chmod +x` on the engine binary named in the error."
- Separates permission failures from legitimate out-of-memory conditions
- Prevents misleading OOM diagnostics when the real issue is missing execute permissions (+11/-0 lines)

### Self-Healing Execute Bit (omnivoice_gguf/backend.py)
`OmniVoiceGGUFBackend.is_available()` now implements POSIX execute-bit remediation:
- After SHA256 validation confirms the binary is correct, checks if the bundled binary is user-executable on POSIX systems
- On POSIX: if not executable, automatically attempts `chmod +x` via `bin_path.chmod(bin_path.stat().st_mode | 0o111)`
- If chmod succeeds silently, availability check passes; if it fails, returns `(False, reason)` with guidance: "GGUF binary {name} isn't executable and couldn't be made so — run `chmod +x {path}` and retry."
- Windows systems are unaffected (checks only run on `os.name == "posix"`, no executable bit concept)
- Self-healing is non-destructive and only applies after checksum verification to never chmod a foreign binary (+15/-0 lines)

### Transport Error Handling (client.ts)
`apiFetch()` now properly catches and classifies network failures:
- Wraps `fetch(apiUrl(path), finalOpts)` in try/catch to intercept transport-layer failures
- When fetch throws `TypeError` (backend unreachable, still starting, or dev server down), catches and re-raises as `ApiError` with `status: 0` (transport failure indicator)
- Provides user-friendly message: "Can't reach the local OmniVoice backend — it may still be starting up, or it stopped. Wait a few seconds and try again; if it persists, restart the app (or check Settings → Logs → Backend)."
- Includes original error details in the `detail` field (`String((e as Error)?.message || e)`) for debugging
- Uses `status: 0` to allow callers to distinguish transport failures from HTTP errors (status > 0) (+15/-1 lines)

### Test Coverage (client.test.ts)
Added new Vitest case `turns a thrown fetch into an actionable ApiError (backend unreachable)`:
- Simulates `globalThis.fetch` rejecting with `TypeError('Failed to fetch')`
- Verifies `apiFetch` throws `ApiError` with `status: 0` (transport failure, not HTTP)
- Validates error message matches `/reach the local OmniVoice backend/i`
- Validates error detail includes "Failed to fetch"
- All 3 existing tests (PIN header attachment and omission) continue to pass (+12/-0 lines)

## Behavior Flows

**Permission Denied Recovery (POSIX Only):**
```
git clone/zip extract → binary at bin/omnivoice-tts-linux-x86_64
    ↓
file permissions drop +x bit during extraction
    ↓
is_available() called during app start
    ├─ SHA256 check → PASSES (correct binary)
    ├─ os.name == "posix" → TRUE
    ├─ os.access(bin_path, os.X_OK) → FALSE
    ├─ chmod +x attempted → SUCCESS
    └─ Returns (True, "ready") ✓
    ↓
User runs generation (first time)
    └─ Binary spawns and executes normally
```

**Failed chmod Self-Healing:**
```
is_available() on filesystem with no chmod permission
    ├─ SHA256 check → PASSES
    ├─ chmod +x attempted → OSError raised
    └─ Catches OSError, returns:
       (False, "GGUF binary {name} isn't executable and 
               couldn't be made so — run `chmod +x {path}` and retry.")
    ↓
User sees clear guidance in UI (not OOM error)
```

**Unreachable Backend Handling:**
```
User clicks Generate/Play
    ↓
apiFetch('/synthesis/...') called
    ├─ fetch() → Network error (backend down/starting)
    │   └─ Throws TypeError("Failed to fetch" | "NetworkError")
    │       ↓
    │       try/catch catches TypeError
    │       ↓
    │       throw ApiError(
    │         message: "Can't reach the local OmniVoice backend...",
    │         status: 0,
    │         detail: "TypeError: Failed to fetch"
    │       ) ✓
    │
    └─ fetch() → HTTP Response received
        └─ res.ok check → normal error handling with status > 0
```

## Testing
- All 3 existing client tests pass (PIN header attachment/omission)
- 1 new test added covering fetch transport-error scenario
- Backend self-healing applies automatically on first run without user intervention
- Both POSIX and Windows environments handled correctly

## Impact
- **Issue `#437` users**: No longer see misleading "out of memory" errors when the real issue is missing execute permissions. Clear guidance surfaces on first run.
- **Issues `#438/`#454/#466 users**: Backend startup delays no longer show generic "Failed to fetch" or raw browser errors. Actionable message guides users to wait/restart/check logs.
- **First-run UX**: Self-healing reduces friction—many permission issues auto-resolve on app start without manual intervention
- **Error classification**: Transport failures (`status: 0`) now clearly distinguished from HTTP errors (`status > 0`), enabling more targeted debugging and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->