### PR TITLE
feat(stories): global reading-speed control (#415)

### DIFF
--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -150,6 +150,19 @@ export default function StoriesEditor({ profiles = [] }) {
   const [projectsOpen, setProjectsOpen] = useState(false);
   const [projectName, setProjectName] = useState('');
   const [exportFormat, setExportFormat] = useState('m4b');
+  // Global reading speed (#415): one speed for every line without its own
+  // per-track override. UI preference → persisted in localStorage (survives
+  // restarts; not part of the project state, so no slice migration).
+  const [globalSpeed, setGlobalSpeedState] = useState(() => {
+    try {
+      const v = parseFloat(localStorage.getItem('ov_stories_global_speed'));
+      return Number.isFinite(v) && v >= 0.5 && v <= 2 ? v : 1;
+    } catch { return 1; }
+  });
+  const setGlobalSpeed = useCallback((v) => {
+    setGlobalSpeedState(v);
+    try { localStorage.setItem('ov_stories_global_speed', String(v)); } catch { /* noop */ }
+  }, []);
   const trackTextRefs = useRef(new Map());
   const fileInputRef = useRef(null);
   const dragId = useRef(null);
@@ -360,7 +373,7 @@ export default function StoriesEditor({ profiles = [] }) {
   const generateAll = useCallback(async () => {
     const usable = tracks.filter((tk) => (tk.text || '').trim());
     if (!usable.length || exporting) return;
-    const chapters = storyToSpans(usable, cast);
+    const chapters = storyToSpans(usable, cast, globalSpeed);
     if (!chapters.length) { toast.error(t('stories.exportFailed')); return; }
     setExporting(true);
     setExportPct(0);
@@ -389,7 +402,7 @@ export default function StoriesEditor({ profiles = [] }) {
     } finally {
       setExporting(false);
     }
-  }, [tracks, cast, exporting, exportFormat, t]);
+  }, [tracks, cast, exporting, exportFormat, globalSpeed, t]);
 
   const exportStemsAll = useCallback(async () => {
     const usable = tracks.filter((tk) => (tk.text || '').trim());
@@ -460,6 +473,25 @@ export default function StoriesEditor({ profiles = [] }) {
             <Button size="sm" variant="ghost" onClick={addChapter} aria-label={t('stories.addChapter')}>
               <Bookmark size={13} /> {t('stories.addChapter')}
             </Button>
+          </div>
+
+          <span className="stories-editor__divider" aria-hidden="true" />
+
+          {/* Global reading speed (#415) — one speed for every line that has no
+              per-line override. */}
+          <div className="stories-editor__group">
+            <label className="stories-editor__speed" title={t('stories.global_speed_hint', { defaultValue: 'Reading speed for all lines without their own speed override' })}>
+              <span>{t('stories.global_speed', { defaultValue: 'Speed' })}</span>
+              <input
+                type="range" min="0.5" max="2" step="0.05" value={globalSpeed}
+                onChange={(e) => setGlobalSpeed(parseFloat(e.target.value))}
+                aria-label={t('stories.global_speed', { defaultValue: 'Global reading speed' })}
+              />
+              <span className="stories-editor__speed-val">{globalSpeed.toFixed(2)}×</span>
+              {globalSpeed !== 1 && (
+                <button type="button" className="stories-track__reset" onClick={() => setGlobalSpeed(1)}>{t('stories.reset')}</button>
+              )}
+            </label>
           </div>
 
           <span className="stories-editor__divider" aria-hidden="true" />

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -77,6 +77,8 @@
     "removeLine": "Remove line",
     "tune": "Tone & speed",
     "speed": "Speed",
+    "global_speed": "Speed",
+    "global_speed_hint": "Reading speed for all lines without their own speed override",
     "reset": "Reset",
     "tones": {
       "laugh": "Laugh",

--- a/frontend/src/test/storyToSpans.test.js
+++ b/frontend/src/test/storyToSpans.test.js
@@ -126,6 +126,25 @@ describe('storyToSpans', () => {
     expect(storyToSpans(tracks, CAST)[0].spans[0].speed).toBeNull();
   });
 
+  // ── #415 global speed ──
+
+  it('applies a global speed to lines without a per-track override', () => {
+    const tracks = [
+      { character: 'narrator', text: 'one' },                 // no per-track speed
+      { character: 'narrator', text: 'two', speed: 1.5 },     // per-track override
+    ];
+    const spans = storyToSpans(tracks, CAST, 0.8)[0].spans;
+    expect(spans.find((s) => s.text === 'one').speed).toBe(0.8);   // inherits global
+    expect(spans.find((s) => s.text === 'two').speed).toBe(1.5);   // override wins
+  });
+
+  it('treats global speed 1.0× (and null) as no override', () => {
+    const tracks = [{ character: 'narrator', text: 'hi' }];
+    expect(storyToSpans(tracks, CAST, 1)[0].spans[0].speed).toBeNull();
+    expect(storyToSpans(tracks, CAST, null)[0].spans[0].speed).toBeNull();
+    expect(storyToSpans(tracks, CAST)[0].spans[0].speed).toBeNull(); // default arg
+  });
+
   it('[voice:] reverts to the resolved cast voice, not null', () => {
     const tracks = [{ character: 'c_fox', text: 'hi [voice:p_bob] there [voice:] back' }];
     const spans = storyToSpans(tracks, CAST)[0].spans;

--- a/frontend/src/utils/storyToSpans.js
+++ b/frontend/src/utils/storyToSpans.js
@@ -18,12 +18,19 @@ import { parseChapterBody } from './longformParser';
  *    (cross-track fold) — but a mid-track silent span (from `[voice:x][pause]`)
  *    is kept, matching the server's single-blob behavior.
  *
+ * ``globalSpeed`` (#415) is one reading speed applied to every track that has no
+ * per-track speed of its own — a per-track slider still overrides it. Pass null
+ * (or 1.0×, the engine default) to leave every track at the engine default.
+ *
  * @returns Array<{ title, spans: [{ voice_id, text, pause_ms_after, speed }] }>
  */
-export function storyToSpans(tracks, cast) {
+export function storyToSpans(tracks, cast, globalSpeed = null) {
   const chapters = [];
   let cur = { title: '', spans: [] };
   const flush = () => { if (cur.spans.length) chapters.push(cur); };
+  // 1.0× is the engine default → treat it as "no global override" so we don't
+  // stamp an explicit speed on every span when the control is at rest.
+  const gspeed = (globalSpeed && globalSpeed !== 1) ? globalSpeed : null;
 
   for (const tk of tracks || []) {
     const text = tk.text || '';
@@ -33,7 +40,9 @@ export function storyToSpans(tracks, cast) {
       continue;
     }
     const voiceId = effectiveProfile(tk, cast) || null;
-    const speed = tk.speed || null;  // falsy 0 → null (engine default), per spec
+    // Per-track speed wins; otherwise the global speed; else engine default.
+    // (falsy 0 → fall through to global/null, per the #27 zero-is-default rule.)
+    const speed = tk.speed || gspeed || null;
     const spans = parseChapterBody(text, { defaultVoice: voiceId, defaultSpeed: speed });
     spans.forEach((s, i) => {
       const prev = cur.spans[cur.spans.length - 1];


### PR DESCRIPTION
Closes **#415**. The Stories editor only had a **per-track** speed slider — long scripts had no way to set one speed for the whole thing.

### Change
- **`storyToSpans(tracks, cast, globalSpeed)`**: per-track speed wins, else the global speed, else engine default. **1.0× (and null) = "no override"** so a resting control never stamps an explicit speed on every span. Builds on the #27 `default_speed` plumbing already in the canonical parser.
- **StoriesEditor**: a global-speed slider in the toolbar (0.5–2.0×, with reset), **persisted to localStorage** (UI preference — no project-state/slice migration).
- **i18n**: `stories.global_speed` / `global_speed_hint`.

### Tests
`storyToSpans.test.js` +2 (global applies to un-overridden lines, per-track override wins; 1.0×/null/default-arg → no override). **120 pass**; `en.json` valid; CJK green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

This PR implements a global reading-speed control feature for the Stories editor (closes `#415`), complementing the existing per-track speed overrides. Previously, speed adjustment required manual configuration for each segment; this feature allows users to set one baseline reading speed across the entire script.

### Key Changes

**1. Speed Resolution Hierarchy (`storyToSpans.js`)**
- Function signature updated: `storyToSpans(tracks, cast, globalSpeed = null)`
- Speed priority: **per-track speed > global speed > engine default (null)**
- Values of `1.0×` and `null` are treated as "no override" to avoid stamping explicit speeds on spans when the control is at rest

**2. UI Enhancement (`StoriesEditor.jsx`)**
- Added global speed control in the toolbar: range slider (0.5× to 2.0×) with step 0.05×
- Reset button appears when speed ≠ 1.0× to restore default state
- Settings persisted in `localStorage` as UI preference only (survives restarts; not part of project state)
- Integrated into `generateAll()` callback to pass `globalSpeed` to `storyToSpans()`

**3. Localization (`en.json`)**
- Added `stories.global_speed`: "Speed"
- Added `stories.global_speed_hint`: "Reading speed for all lines without their own speed override"

**4. Tests (`storyToSpans.test.js`)**
- Two new test cases covering global speed application to un-overridden tracks
- Per-track override priority verification
- Null/1.0×/default argument handling

### UI Layout Update

```
Before (toolbar section):
┌─────────────────────────────┐
│ [+] [▶] [🎭] [📁] [🎛️]     │
│ Line controls               │
└─────────────────────────────┘

After (with global speed control):
┌─────────────────────────────────────────────────┐
│ [+] [▶] [🎭] [📁] [🎛️]                          │
│ Line controls                                   │
├─────────────────────────────────────────────────┤
│ Speed: [0.5 ■─────●───── 2.0] 1.35× [↺ reset] │
│ (Reading speed for all lines without override) │
└─────────────────────────────────────────────────┘
```

### Speed Resolution Flowchart

```mermaid
flowchart TD
    A["Track requires speed resolution"] --> B["Check per-track speed<br/>(tk.speed)"]
    B -->|Found & > 0| C["Use per-track speed<br/>(highest priority)"]
    B -->|Not set/null| D["Check global speed<br/>(globalSpeed param)"]
    D -->|Found & ≠ 1.0×| E["Use global speed"]
    D -->|null or 1.0×| F["Use engine default<br/>(null)"]
    C --> G["Pass to parseChapterBody<br/>as defaultSpeed"]
    E --> G
    F --> G
    
    style C fill:`#90EE90`
    style E fill:`#87CEEB`
    style F fill:`#FFB6C1`
    style G fill:`#FFE4B5`
```

### Files Modified
- `frontend/src/components/StoriesEditor.jsx`: +34 lines (toolbar UI, state management, export callback)
- `frontend/src/utils/storyToSpans.js`: +11 lines (function signature, speed resolution logic)
- `frontend/src/test/storyToSpans.test.js`: +19 lines (global speed test coverage)
- `frontend/src/i18n/locales/en.json`: +2 lines (localization keys)

All 120 existing tests pass; CJK language support verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->