### PR TITLE
perf(omnivoice): cache voice-clone prompt embeddings (#427)

### DIFF
--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from typing import Optional
 
 import torch
@@ -159,6 +161,63 @@ class TTSBackend(ABC):
 # ── OmniVoice adapter (the current default) ─────────────────────────────────
 
 
+# ── Voice-clone prompt cache (#427) ──────────────────────────────────────────
+# Every cloned generation re-encodes the reference audio from scratch — a fixed
+# per-request latency that compounds on batch/long-form workloads reusing one
+# voice. The OmniVoice model exposes create_voice_clone_prompt(ref) →
+# VoiceClonePrompt + generate(voice_clone_prompt=) to do that encoding ONCE.
+# We cache the prompt (bounded LRU, keyed by ref path + mtime + ref_text) so
+# repeated generations with the same voice skip the encode. Bounded because a
+# VoiceClonePrompt holds tensors (VRAM). Thread-safe (generation runs in a GPU
+# thread pool). Best-effort: any miss/error falls back to the inline ref path,
+# so output is never affected — this is a pure latency optimization.
+_PROMPT_CACHE_MAX = 8
+_prompt_cache: "OrderedDict[tuple, object]" = OrderedDict()
+_prompt_cache_lock = threading.Lock()
+
+
+def _clone_prompt_key(ref_audio: str, ref_text):
+    try:
+        mtime = os.path.getmtime(ref_audio)
+    except OSError:
+        mtime = 0.0
+    return (os.path.abspath(ref_audio), mtime, ref_text or "")
+
+
+def _get_clone_prompt(model, ref_audio: str, ref_text):
+    """Return a cached/precomputed ``VoiceClonePrompt`` for (ref_audio, ref_text),
+    or ``None`` to fall back to the inline ref path. Never raises."""
+    try:
+        key = _clone_prompt_key(ref_audio, ref_text)
+    except Exception:
+        return None
+    with _prompt_cache_lock:
+        hit = _prompt_cache.get(key)
+        if hit is not None:
+            _prompt_cache.move_to_end(key)
+            return hit
+    try:
+        # Encode outside the lock (slow); default preprocess matches the inline
+        # ref_audio path's preprocessing.
+        prompt = model.create_voice_clone_prompt(ref_audio, ref_text=ref_text)
+    except Exception as e:  # noqa: BLE001 — fall back, never break synthesis
+        logger.warning("voice-clone prompt precompute failed; using inline ref: %s", e)
+        return None
+    with _prompt_cache_lock:
+        _prompt_cache[key] = prompt
+        _prompt_cache.move_to_end(key)
+        while len(_prompt_cache) > _PROMPT_CACHE_MAX:
+            _prompt_cache.popitem(last=False)
+    return prompt
+
+
+def clear_clone_prompt_cache() -> None:
+    """Drop all cached voice-clone prompts (frees their tensors). Called on model
+    unload so a flush/engine-switch doesn't strand VRAM."""
+    with _prompt_cache_lock:
+        _prompt_cache.clear()
+
+
 class OmniVoiceBackend(TTSBackend):
     """Wraps `omnivoice.models.omnivoice.OmniVoice`. Zero behaviour change.
 
@@ -217,11 +276,11 @@ class OmniVoiceBackend(TTSBackend):
     def generate(self, text, **kw) -> torch.Tensor:
         self._ensure_loaded()
         language = kw.get("language")
-        audios = self._model.generate(
+        ref_audio = kw.get("ref_audio")
+        ref_text = kw.get("ref_text")
+        gen_kw = dict(
             text=text,
             language=language if language and language != "Auto" else None,
-            ref_audio=kw.get("ref_audio"),
-            ref_text=kw.get("ref_text"),
             instruct=kw.get("instruct"),
             duration=kw.get("duration"),
             num_step=kw.get("num_step", 16),
@@ -230,6 +289,22 @@ class OmniVoiceBackend(TTSBackend):
             denoise=kw.get("denoise", True),
             postprocess_output=kw.get("postprocess_output", True),
         )
+        # #427: when cloning from a reference file, reuse a cached voice-clone
+        # prompt so the reference isn't re-encoded every call. Any failure in the
+        # prompt path falls back to the inline ref — output is identical either
+        # way (the model documents the two as equivalent); this only saves the
+        # repeated encode. The design/instruct path (no ref_audio) is untouched.
+        audios = None
+        if ref_audio:
+            prompt = _get_clone_prompt(self._model, ref_audio, ref_text)
+            if prompt is not None:
+                try:
+                    audios = self._model.generate(voice_clone_prompt=prompt, **gen_kw)
+                except Exception as e:  # noqa: BLE001 — fall back to the inline ref
+                    logger.warning("voice_clone_prompt generate failed; retrying inline ref: %s", e)
+                    audios = None
+        if audios is None:
+            audios = self._model.generate(ref_audio=ref_audio, ref_text=ref_text, **gen_kw)
         return audios[0]
 
     def unload(self) -> None:
@@ -240,6 +315,7 @@ class OmniVoiceBackend(TTSBackend):
         take the async ``_model_lock`` from this sync path; the registry wraps
         this call in try/except so a race can never block an engine switch."""
         self._model = None
+        clear_clone_prompt_cache()  # #427: drop cached prompts so VRAM is freed
         try:
             import services.model_manager as mm
             if mm.model is not None:

--- a/tests/test_clone_prompt_cache.py
+++ b/tests/test_clone_prompt_cache.py
@@ -1,0 +1,88 @@
+"""Voice-clone prompt cache (#427) — the bounded-LRU reference-encode cache.
+
+Pure cache logic: the model is a stub whose create_voice_clone_prompt counts
+calls, so we assert the reference is encoded ONCE per (path, mtime, ref_text)
+and that misses/errors fall back cleanly. (No real model / torch math here.)
+"""
+from __future__ import annotations
+
+import pytest
+
+from services import tts_backend as tb
+
+
+class _StubModel:
+    def __init__(self, *, fail=False):
+        self.calls = 0
+        self.fail = fail
+
+    def create_voice_clone_prompt(self, ref_audio, ref_text=None):
+        self.calls += 1
+        if self.fail:
+            raise RuntimeError("encode boom")
+        return f"PROMPT::{ref_audio}::{ref_text}"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    tb.clear_clone_prompt_cache()
+    yield
+    tb.clear_clone_prompt_cache()
+
+
+def _wav(tmp_path, name="ref.wav", data=b"\x00" * 100):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return str(p)
+
+
+def test_encodes_once_then_hits_cache(tmp_path):
+    m = _StubModel()
+    ref = _wav(tmp_path)
+    first = tb._get_clone_prompt(m, ref, "hello")
+    second = tb._get_clone_prompt(m, ref, "hello")
+    assert first == second
+    assert m.calls == 1   # second call was a cache hit — no re-encode
+
+
+def test_different_ref_text_re_encodes(tmp_path):
+    m = _StubModel()
+    ref = _wav(tmp_path)
+    tb._get_clone_prompt(m, ref, "hello")
+    tb._get_clone_prompt(m, ref, "different")
+    assert m.calls == 2
+
+
+def test_mtime_change_invalidates(tmp_path):
+    m = _StubModel()
+    ref = _wav(tmp_path)
+    tb._get_clone_prompt(m, ref, "hi")
+    # Rewrite with a different mtime → key changes → re-encode.
+    import os
+    os.utime(ref, (1, 1))
+    tb._get_clone_prompt(m, ref, "hi")
+    assert m.calls == 2
+
+
+def test_lru_eviction_bounds_cache(tmp_path):
+    m = _StubModel()
+    # Fill past the cap with distinct refs.
+    for i in range(tb._PROMPT_CACHE_MAX + 3):
+        tb._get_clone_prompt(m, _wav(tmp_path, f"r{i}.wav"), "t")
+    assert len(tb._prompt_cache) == tb._PROMPT_CACHE_MAX
+    assert m.calls == tb._PROMPT_CACHE_MAX + 3
+
+
+def test_encode_failure_returns_none_and_does_not_cache(tmp_path):
+    m = _StubModel(fail=True)
+    ref = _wav(tmp_path)
+    assert tb._get_clone_prompt(m, ref, "x") is None   # caller falls back to inline ref
+    assert len(tb._prompt_cache) == 0
+
+
+def test_clear_empties_cache(tmp_path):
+    m = _StubModel()
+    tb._get_clone_prompt(m, _wav(tmp_path), "x")
+    assert len(tb._prompt_cache) == 1
+    tb.clear_clone_prompt_cache()
+    assert len(tb._prompt_cache) == 0


### PR DESCRIPTION
Closes **#427**. Every cloned generation re-encoded the reference audio from scratch — a fixed per-request latency that compounds on batch / long-form / dataset workloads reusing one saved voice.

The OmniVoice model already exposes the fast path (`create_voice_clone_prompt` → `VoiceClonePrompt`, `generate(voice_clone_prompt=)`); the Studio backend just wasn't using it.

### Change — `OmniVoiceBackend.generate`
- Builds a `VoiceClonePrompt` **once per reference** and caches it (**bounded LRU, max 8**, keyed by ref path + mtime + ref_text; **thread-safe** — generation runs in a GPU thread pool), then passes `voice_clone_prompt=` to skip the re-encode.
- **Falls back to the inline `ref_audio`/`ref_text` path on ANY miss or error**, so output is identical either way (the model documents the two as equivalent) — this is **purely a latency optimization, never a behaviour change**.
- The design/instruct path (no `ref_audio`) is untouched. `unload()` clears the cache so a flush / engine-switch frees the prompt tensors.

### Tests
`tests/test_clone_prompt_cache.py` — 6 cases (encode-once-then-hit, ref_text + mtime invalidation, LRU eviction at cap, encode-failure → `None` fallback, clear). **6 passed.** CJK green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Voice-Clone Prompt Caching for OmniVoice Backend

Implements LRU caching of OmniVoice voice-clone prompt embeddings to eliminate per-generation reference audio encoding latency. Previously, every cloned voice generation re-encoded the reference audio from scratch, introducing fixed latency that compounds in batch, long-form, or multi-speaker workloads reusing the same saved voice.

### Changes

**backend/services/tts_backend.py** (+79/-3)
- Adds `_prompt_cache`: bounded LRU cache (max 8 entries) storing `VoiceClonePrompt` objects
- Implements `_get_clone_prompt(model, ref_audio, ref_text)`: thread-safe cache accessor that:
  - Keys cache by (absolute reference path, file modification time, reference text)
  - Returns cached prompt on hit, avoiding re-encoding
  - Computes and caches new prompt on miss via `model.create_voice_clone_prompt()`
  - Returns `None` on encoding failure, allowing graceful fallback
  - Enforces LRU eviction when cache reaches capacity
- Adds `clear_clone_prompt_cache()`: clears all cached prompts when `unload()` is called, freeing cached prompt tensors during engine switches or flushes
- Modifies `OmniVoiceBackend.generate()` to use cached prompts via the fast path (`voice_clone_prompt=` parameter) instead of inline `ref_audio`/`ref_text` on each call
- Maintains identical output behavior: falls back to inline generation path on any cache miss or error
- Design/instruct synthesis path (non-reference-audio) remains unchanged

**tests/test_clone_prompt_cache.py** (+88/-0)
Pure test suite validating cache behavior with stub model:
- `test_encodes_once_then_hits_cache`: reference encoded once, second call uses cached prompt
- `test_different_ref_text_re_encodes`: different `ref_text` invalidates cache entry and re-encodes
- `test_mtime_change_invalidates`: file modification time change invalidates cache entry
- `test_lru_eviction_bounds_cache`: cache respects 8-entry maximum with LRU eviction
- `test_encode_failure_returns_none_and_does_not_cache`: encoding errors return `None` and do not populate cache
- `test_clear_empties_cache`: `clear_clone_prompt_cache()` fully empties cache

### Mechanism

```
generate(ref_audio=..., ref_text=...)
       │
       ├─► Is ref_audio provided?
       │    │
       │    ├─YES─► _get_clone_prompt(model, ref_audio, ref_text)
       │    │       │
       │    │       ├─► Compute cache key: (abs_path, mtime, ref_text)
       │    │       │
       │    │       ├─► Cache hit?
       │    │       │    ├─YES─► Return cached VoiceClonePrompt ✓
       │    │       │    └─NO──► Create via create_voice_clone_prompt()
       │    │       │            ├─► Success? Cache & return prompt
       │    │       │            └─► Failure? Return None, log error
       │    │       │
       │    │       └─► Use voice_clone_prompt= parameter (fast path)
       │    │
       │    └─NO──► Use inline ref_audio/ref_text (original path)
       │
       └─► Synthesis (unchanged)
```

### Benefits

- **Latency elimination**: Per-request encoding overhead deferred to first-use-time
- **Batch acceleration**: Batch, long-form, and dataset workloads with repeated voices benefit directly
- **Memory efficiency**: Bounded cache prevents unbounded growth; entries evicted on demand
- **Reliability**: Transparent fallback ensures identical output on any cache issue
- **VRAM management**: Cache cleared on engine unload/switch, freeing tensors immediately

### Testing

All six test cases passed. Tests verify correct cache invalidation on `ref_text` and mtime changes, LRU capacity enforcement, graceful error handling, and cache clearing without behavioral changes to synthesis output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->