### PR TITLE
fix(bootstrap): stall watchdog so a stuck backend isn't a buttonless dead-end (#474)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,10 +42,21 @@ This starts both services:
 ### Desktop App (Tauri)
 
 ```bash
-bun run desktop
+bun run desktop          # dev: hot-reload Tauri shell + backend
+bun run desktop-prod     # production: builds, bundles the backend, then launches
 ```
 
+Both run `uv sync` first (so the Python backend env is set up) and start the
+backend automatically — you do **not** start it separately. Use the exact script
+names: there is no `desktop=prod` (note the **hyphen** in `desktop-prod`).
+`desktop-prod` is Windows-aware (auto-detects bash/git; see `scripts/desktop-prod.mjs`).
+
 Requires [Rust](https://rustup.rs/) and platform-specific Tauri dependencies — see the [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/).
+
+If the app opens but stays on the **setup splash with no buttons**, the Python
+backend didn't finish starting — the splash surfaces the stall reason, a log
+panel, and a **Retry** button (and Settings → Logs → Backend has the full trace).
+The most common from-source cause is `uv` or Python not being on your PATH.
 
 ---
 

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -76,6 +76,7 @@ function detectHints(message, logs) {
   if (/ffmpeg/i.test(all) && /download|timeout/i.test(all)) hints.push('bootstrap.hint_ffmpeg');
   if (/port.*in use|address.*in use/i.test(all)) hints.push('bootstrap.hint_port');
   if (/no error output/i.test(all))      hints.push('bootstrap.hint_silent_crash');
+  if (/seems stuck at|never reported ready/i.test(all)) hints.push('bootstrap.hint_stuck');
   if (/blocking GitHub|couldn't download Python|python-build-standalone|dns error/i.test(all)) hints.push('bootstrap.hint_github_blocked');
   if (hints.length === 0)                hints.push('bootstrap.hint_default');
   return hints;
@@ -513,6 +514,17 @@ export function useBootstrapStage(pollMs = 1000) {
     let cancelled = false;
     let timer = null;
     let misses = 0;
+    // Stall watchdog (#474): if the backend hangs in a non-terminal stage and
+    // never reports `ready` (e.g. a failed Python-backend spawn on a from-source
+    // build), the poll loop would otherwise spin forever and trap the user on a
+    // buttonless splash. Track when the (stage,message) last changed; if it
+    // stays put past the stage's budget, flip to `failed` so the existing
+    // hints + Retry + logs surface instead of an info-less infinite spinner.
+    // installing_deps legitimately runs 5–10 min, so it gets a long leash; any
+    // (stage,message) change resets the clock so a live install never trips it.
+    let lastChangeTs = Date.now();
+    let lastKey = '';
+    const stallBudgetMs = (stage) => (stage === 'installing_deps' ? 20 * 60 * 1000 : 120 * 1000);
     const invoke = async () => {
       try {
         const { invoke: tauriInvoke } = await import('@tauri-apps/api/core');
@@ -530,10 +542,28 @@ export function useBootstrapStage(pollMs = 1000) {
           const res = await tauriInvoke('bootstrap_status');
           if (cancelled) return;
           misses = 0;
+          const stage = res.stage || 'ready';
+          const message = res.message || null;
+          // Reset the stall clock whenever something actually changes.
+          const key = `${stage}|${message || ''}`;
+          if (key !== lastKey) { lastKey = key; lastChangeTs = Date.now(); }
           // Rust returns { stage: 'ready' } or { stage: 'failed', message: '…' } etc.
-          setState({ stage: res.stage || 'ready', message: res.message || null });
-          if (res.stage !== 'ready' && res.stage !== 'failed') {
+          if (stage !== 'ready' && stage !== 'failed') {
+            if (Date.now() - lastChangeTs > stallBudgetMs(stage)) {
+              // Stuck — surface it as a failure so Retry/logs/hints appear.
+              setState({
+                stage: 'failed',
+                message: (message ? message + '\n\n' : '') +
+                  `Setup seems stuck at "${stage}" — the backend never reported ready. ` +
+                  `Check the log below, then Retry. If you're running from source, make sure ` +
+                  `\`uv sync\` completed and uv/Python are on your PATH.`,
+              });
+              return;  // stop polling — failed is terminal
+            }
+            setState({ stage, message });
             timer = setTimeout(tick, pollMs);
+          } else {
+            setState({ stage, message });
           }
         } catch {
           // A transient IPC hiccup (e.g. the very first poll racing webview

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1223,6 +1223,7 @@
     "hint_port": "Port 3900 is already in use. Close other instances of OmniVoice or apps using that port.",
     "hint_silent_crash": "Backend crashed silently. \"Clean & Retry\" often fixes corrupt venv issues.",
     "hint_github_blocked": "Your network may block GitHub. Install Python 3.11+ from python.org (Add to PATH) and relaunch, or set UV_PYTHON_INSTALL_MIRROR — see docs/install/troubleshooting.md.",
+    "hint_stuck": "The backend didn't finish starting. From source, run `uv sync` first and make sure `uv` and Python are on your PATH, then Retry. Check the log below (or Settings → Logs → Backend) for the exact stall point.",
     "hint_default": "Try \"Retry\" first. If it fails again, \"Clean & Retry\" will rebuild the environment from scratch."
   },
   "direction": {


### PR DESCRIPTION
Addresses **#474** ("no start button, no settings button" on a from-source Windows build).

### Diagnosis
The entire main UI is gated behind `bootstrapStage === 'ready'` (`App.jsx`): until the Python backend reports ready, only the **BootstrapSplash** renders. On the reporter's build the backend never reaches ready, so they're parked on the splash — which has no Settings/Start/Clone/Extract buttons. **Not a code regression** — every startup-imported router (`personas`, `audiobook`, `tts_backend`, …) imports cleanly; the backend simply isn't starting in their env (likely `uv`/Python not on PATH; the command `bun run desktop=prod` is also a typo for **`bun run desktop-prod`**).

### Fix (the real product bug — fits "first-run that just works")
- **`useBootstrapStage` stall watchdog:** if a non-terminal stage sits past its budget without any `(stage,message)` change, flip to the existing **`failed`** state — which already shows actionable hints + the live log panel + **Retry**/**Clean-&-Retry**. `installing_deps` gets a 20-min leash (it legitimately runs 5–10 min); everything else 120 s; any change resets the clock, so a live install never trips it. → a stuck backend is no longer an info-less, buttonless infinite spinner.
- **`bootstrap.hint_stuck`** + `detectHints` pattern: tells the user to run `uv sync`, check uv/Python on PATH, and read the log.
- **`CONTRIBUTING.md`:** documents `bun run desktop-prod` (the typo'd command), notes both desktop scripts auto-run `uv sync` + start the backend, and adds a "stuck on the setup splash" pointer.

### Checks
No backend change. Frontend suite **503 passed**; `en.json` valid; CJK green. (Pre-existing eslint notes in the file — `__APP_VERSION__` vite global etc. — are untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes issue `#474` where Windows from-source builds become stuck on the bootstrap splash screen indefinitely with no clickable buttons when the Python backend fails to start.

### Root Cause
The main UI is gated behind `bootstrapStage === 'ready'`. If the Python backend fails to initialize (typically due to missing `uv`/Python on PATH), users remain on the BootstrapSplash with no way to proceed or access logs.

### Solution
Implemented a stall watchdog in the `useBootstrapStage` hook that detects when a bootstrap stage hangs and transitions to the existing `failed` state, which surfaces actionable hints, a live log panel, and Retry/Clean-&-Retry buttons.

**Watchdog mechanism:**

```mermaid
graph TD
    A[Poll bootstrap_status] --> B{Stage changed?}
    B -->|Yes| C[Reset stall clock<br/>Update state]
    B -->|No| D{Exceeded time budget?}
    D -->|No, stage not terminal| E[Continue polling]
    D -->|Yes| F[Transition to failed state<br/>with diagnostic message]
    F --> G[Display hints + logs + Retry]
    E --> A
    C --> A
    
    H["Time budgets:<br/>installing_deps: 20 min<br/>other stages: 120 sec"]
    style H fill:`#f0f0f0`
```

**UI change (failed state now reachable earlier):**

```
BEFORE (stuck on spinner):           AFTER (failed state + actionable hints):
┌────────────────────────────┐      ┌────────────────────────────┐
│ ╭─  OmniVoice Studio      │      │ ╭─  OmniVoice Studio      │
│ ├─  Setup  Install  Models│      │ ├─  Setup  Install  Models│
│ │  Starting backend…     │      │ │  Setup failed           │
│ │  ░░░░░░░░░░░░░░░░░░░░  │      │ │                        │
│ │  (stuck, no buttons)   │      │ │  Setup seems stuck at   │
│ │                        │      │ │  "starting_backend"...  │
│ │                        │      │ │                        │
│ │                        │      │ │  💡 What to try:       │
│ │                        │      │ │  • Run `uv sync` first  │
│ │                        │      │ │  • Check PATH for uv    │
│ │                        │      │ │  • See logs below       │
│ │                        │      │ │                        │
│ │                        │      │ │  [Clean & Retry] [Retry]
│ │  Activity (collapsed)  │      │ │  Activity (expanded)   │
│ │  ▸ Show logs           │      │ │  ▾ Hide logs           │
│ └────────────────────────┘      │ │  [backend init log...] │
                                  │ └────────────────────────┘
```

### Changes

**frontend/src/components/BootstrapSplash.jsx** (+32 lines)
- Added stall watchdog to `useBootstrapStage` hook: tracks `(stage, message)` change time with per-stage budgets (`installing_deps`: 20 min, others: 120 sec)
- When budget exceeded, forces transition to `failed` state with diagnostic message referencing `uv sync` and PATH
- Enhanced `detectHints()` to match "seems stuck" / "never reported ready" patterns and suggest `bootstrap.hint_stuck`
- Any state change resets the stall clock to prevent false positives during active operations
- Polling stops once hook reaches terminal `failed` state

**frontend/src/i18n/locales/en.json** (+1 line)
- Added `bootstrap.hint_stuck`: "The backend didn't finish starting. From source, run `uv sync` first and make sure `uv` and Python are on your PATH, then Retry. Check the log below (or Settings → Logs → Backend) for the exact stall point."

**CONTRIBUTING.md** (+12 lines, -1 line)
- Documented correct desktop commands: `bun run desktop` (dev) and `bun run desktop-prod` (production)—corrects reporter's typo of `desktop=prod`
- Clarified that both scripts auto-run `uv sync` first and start the backend automatically (no separate backend startup needed)
- Added troubleshooting note: if app opens but stays on splash with no buttons, the Python backend stalled—check for `uv`/Python on PATH and review logs (Settings → Logs → Backend)

### Testing
- No backend changes; frontend test suite: 503 passed
- Localization validated for CJK and en.json
- Bootstrap flow unchanged for successful runs; stall detection only activates on hangs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->