### PR TITLE
fix(translate): guess source language from text instead of defaulting to "en"

### DIFF
--- a/backend/api/routers/dub_translate.py
+++ b/backend/api/routers/dub_translate.py
@@ -168,15 +168,38 @@ def _dialect_flags(req, applied: bool) -> dict:
     return {"dialect": req.dialect, "dialect_applied": bool(applied)}
 
 
+def _guess_lang_from_text(segments) -> str | None:
+    """Best-effort source language from segment text, by script.
+
+    Used only as a last resort when neither the request nor the job carries a
+    detected language. Without this, the bare "en" fallback below forces
+    en -> en on non-English audio (e.g. Korean), which has no Argos package and
+    fails every segment even though ASR detected the language correctly.
+    """
+    text = " ".join((getattr(s, "text", "") or "") for s in (segments or [])[:8])
+    has = lambda lo, hi: any(lo <= ord(c) <= hi for c in text)
+    if has(0x3040, 0x30FF):
+        return "ja"  # Hiragana/Katakana — check before CJK (Japanese uses Kanji too)
+    if has(0xAC00, 0xD7A3) or has(0x1100, 0x11FF):
+        return "ko"  # Hangul
+    if has(0x4E00, 0x9FFF):
+        return "zh"  # CJK ideographs
+    if has(0x0400, 0x04FF):
+        return "ru"  # Cyrillic
+    if has(0x0600, 0x06FF):
+        return "ar"  # Arabic
+    return None
+
+
 def _resolve_source_lang(req: TranslateRequest) -> str:
-    """Pick source language: explicit request > job.source_lang > 'en' fallback."""
+    """Pick source language: explicit request > job.source_lang > text guess > 'en'."""
     if getattr(req, "source_lang", None):
         return req.source_lang
     if getattr(req, "job_id", None):
         job = _get_job(req.job_id)
         if job and job.get("source_lang"):
             return job["source_lang"]
-    return "en"
+    return _guess_lang_from_text(getattr(req, "segments", None)) or "en"
 
 
 def _unload_nllb():


### PR DESCRIPTION
## Problem
Dubbing a non-English video (e.g. Korean → English) fails for every segment with:

`No Argos package available for en -> en`

even though WhisperX detected the source correctly (`Detected language: ko (0.98)`).

## Cause
In `backend/api/routers/dub_translate.py`, `_resolve_source_lang()` falls back to `"en"` when neither the request nor the job carries a source language. So source = `en`, target = `en` → `en -> en` → no Argos package → all segments fail.

## Fix
Add a last-resort, script-based source-language guess (`ko`/`ja`/`zh`/`ru`/`ar`) from the segment text, used **only** when no language is otherwise available. Latin-only text still falls through to `"en"`, so existing behaviour is unchanged.

Tested locally: `ko`/`ja`/`zh`/`ru` detected correctly; English (Latin) text still resolves to `"en"`.

> Note: the deeper fix is to propagate the ASR-detected language all the way to the translate request. This PR is a safe, minimal defensive fallback that stops the silent `"en"` default from breaking non-English dubbing.

Fixes #477


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a critical bug in non-English video dubbing where translation requests fail with "No Argos package available for en -> en" by implementing script-based fallback source language detection.

### Root Cause

The `_resolve_source_lang()` function silently defaults to "en" when neither the request nor the job object provides a source language, even though WhisperX correctly detects the actual source language. This causes en→en translation attempts, which fail because Argos has no language model for identical source and target language pairs.

### Solution

- Added `_guess_lang_from_text()` function that inspects the first 8 segment texts to detect non-Latin scripts
- Detects Japanese (Hiragana/Katakana), Korean (Hangul), Chinese (CJK ideographs), Russian (Cyrillic), and Arabic scripts
- Returns appropriate language codes (ja, ko, zh, ru, ar) or None if text contains only Latin characters
- Updated `_resolve_source_lang()` to use the guess as a fallback instead of unconditionally defaulting to "en"

### New Behavior

```
┌─────────────────────────────┐
│ Resolve Source Language     │
└──────────────┬──────────────┘
               │
        ┌──────▼──────┐
        │ req.source_ │
        │   lang set? │
        └──────┬──────┘
              yes│                no
                 │                 │
           ┌─────▼────────┐    ┌────▼──────────┐
           │ Return it    │    │ Check job.    │
           └──────────────┘    │ source_lang   │
                               └────┬──────────┘
                                   yes│    no
                                      │     │
                              ┌──────▼─┐ ┌─▼──────────────┐
                              │Return│ │ Guess from     │
                              │it    │ │ segment text   │
                              └──────┘ │ (non-Latin)    │
                                       └────┬───────────┘
                                           yes│    no
                                              │     │
                                     ┌────────▼─┐ ┌─▼───┐
                                     │Return    │ │Ret. │
                                     │code      │ │"en" │
                                     │(ja,ko...)│ └─────┘
                                     └──────────┘
```

This approach eliminates the silent failure mode while maintaining backward compatibility: English content still defaults to "en", and non-English dubbing workflows now correctly detect their source language from segment text, enabling proper translation pairs (e.g., ko→en, ja→en).

### Files Changed

- `backend/api/routers/dub_translate.py`: +25/-2 lines
  - New `_guess_lang_from_text()` function (lines 171-191)
  - Updated `_resolve_source_lang()` to use script-based detection fallback (line 202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->