### PR TITLE
fix(settings): make in-app models dir authoritative over launcher env (#480)

### DIFF
--- a/backend/core/user_env.py
+++ b/backend/core/user_env.py
@@ -82,3 +82,28 @@ def unset_user_env(key: str, path: Optional[str] = None) -> None:
     prefix = f"{key}="
     lines = [ln for ln in _read_lines(path) if not ln.startswith(prefix)]
     _write_lines(path, lines)
+
+
+def load_into_environ(path: Optional[str] = None) -> bool:
+    """Load the durable per-user env file into ``os.environ``, **overriding**
+    any value a launcher already injected. Returns True if a file was loaded.
+
+    This file is the in-app Settings source of truth. The desktop launcher
+    (Tauri) injects defaults like ``OMNIVOICE_CACHE_DIR`` (and ``HF_ENDPOINT``)
+    from its *own* config into the backend's environment *before* startup, so
+    loading this file with ``override=False`` meant a models directory the user
+    changed in Settings was silently ignored on every launch — the effective
+    location stayed on the old one no matter how many restarts (#480). Both keys
+    this file can hold are the user's explicit Settings choice and should beat
+    the launcher's default, so we override. Restores this file's documented
+    "values written here take effect on the next backend launch" contract.
+    """
+    path = path or os.environ.get("OMNIVOICE_ENV_FILE") or USER_ENV_PATH
+    if not os.path.isfile(path):
+        return False
+    try:
+        import dotenv
+    except ImportError:
+        return False
+    dotenv.load_dotenv(path, override=True)
+    return True

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,11 +43,13 @@ try:
     _project_env = os.path.join(os.path.dirname(_backend_dir), ".env")
     if os.path.isfile(_project_env):
         dotenv.load_dotenv(_project_env, override=False)
-    # Also load the durable per-user config so env vars set once survive
-    # Tauri/Finder launches that don't inherit a shell environment.
-    _user_env = os.path.expanduser("~/.config/omnivoice/env")
-    if os.path.isfile(_user_env):
-        dotenv.load_dotenv(_user_env, override=False)
+    # Load the durable per-user config (the in-app Settings source of truth) so
+    # env vars set once survive Tauri/Finder launches that don't inherit a shell
+    # environment. This OVERRIDES launcher-injected defaults: the desktop app
+    # injects a stale OMNIVOICE_CACHE_DIR from its own config before startup, so
+    # without override a models dir changed in Settings was ignored forever (#480).
+    from core.user_env import load_into_environ as _load_user_env
+    _load_user_env()
 except ImportError:
     pass
 

--- a/tests/test_user_env_authoritative.py
+++ b/tests/test_user_env_authoritative.py
@@ -1,0 +1,50 @@
+"""Regression tests for #480 — the durable per-user env file (in-app Settings
+source of truth) must OVERRIDE a value the desktop launcher pre-injected, so a
+models directory changed in Settings actually takes effect after restart.
+
+Pure unit tests (no Tauri / no real launch); top-level ``tests/`` + runtime
+module import to avoid the sys.modules-isolation collection-order leak.
+"""
+from __future__ import annotations
+
+import os
+
+
+def _user_env():
+    from core import user_env
+    return user_env
+
+
+def test_user_env_overrides_preinjected_value(tmp_path, monkeypatch):
+    """A value in the per-user env file must beat one a launcher (Tauri) already
+    injected into the environment — the core of #480."""
+    envfile = tmp_path / "env"
+    envfile.write_text("OMNIVOICE_CACHE_DIR=/new/models/dir\n")
+    monkeypatch.setenv("OMNIVOICE_ENV_FILE", str(envfile))
+    # simulate Tauri injecting the OLD value before the backend loads the file
+    monkeypatch.setenv("OMNIVOICE_CACHE_DIR", "/old/models/dir")
+
+    loaded = _user_env().load_into_environ()
+
+    assert loaded is True
+    assert os.environ["OMNIVOICE_CACHE_DIR"] == "/new/models/dir"
+
+
+def test_user_env_sets_value_absent_from_environ(tmp_path, monkeypatch):
+    """When nothing was pre-injected, the file value is applied as-is."""
+    envfile = tmp_path / "env"
+    envfile.write_text("OMNIVOICE_CACHE_DIR=/chosen/dir\n")
+    monkeypatch.setenv("OMNIVOICE_ENV_FILE", str(envfile))
+    monkeypatch.delenv("OMNIVOICE_CACHE_DIR", raising=False)
+
+    assert _user_env().load_into_environ() is True
+    assert os.environ["OMNIVOICE_CACHE_DIR"] == "/chosen/dir"
+
+
+def test_user_env_missing_file_is_noop(tmp_path, monkeypatch):
+    """No file -> no-op, and a pre-injected value is left untouched."""
+    monkeypatch.setenv("OMNIVOICE_ENV_FILE", str(tmp_path / "does-not-exist"))
+    monkeypatch.setenv("OMNIVOICE_CACHE_DIR", "/old")
+
+    assert _user_env().load_into_environ() is False
+    assert os.environ["OMNIVOICE_CACHE_DIR"] == "/old"


### PR DESCRIPTION
## Problem
Changing the **model download location** in Settings had no effect (#480): after the prompted restart, new downloads still went to the old folder, and "Effective location" stayed stuck on it "no matter how many times I restart."

## Root cause
Two stores hold the models dir. Settings writes the new path to the durable per-user env file (`~/.config/omnivoice/env`, `OMNIVOICE_CACHE_DIR`), but the **desktop launcher injects the OLD value** from its own Tauri config into the backend env *before* startup — and `main.py` loaded the per-user file with **`override=False`**, so the launcher's stale value always won. `main.py` then maps `OMNIVOICE_CACHE_DIR` → `HF_HOME`/`HF_HUB_CACHE`/`TORCH_HOME`, and `_effective_models_dir()` reads that live env, so the UI faithfully reported the old path as if the save failed.

## Fix
Load the per-user env file with **override** so it beats launcher-injected defaults — restoring this file's documented *"values written here take effect on the next backend launch"* contract. Centralized as `user_env.load_into_environ()` (the file is the in-app Settings source of truth) and called from `main.py`.

- Both keys this file can hold (`OMNIVOICE_CACHE_DIR`, `HF_ENDPOINT`) are the user's explicit Settings choice and *should* beat the launcher default — so the override is correct for both (also fixes the same latent bug for a Settings-set HF mirror). `HF_TOKEN` isn't launcher-injected, so unchanged.
- One restart still applies it (HF cache env is read at import) — the PUT already returns `restart_required: True`.

## Tests
`tests/test_user_env_authoritative.py` (3, pure unit): per-user file value overrides a pre-injected (Tauri) value; applies when nothing pre-injected; missing file is a no-op. Top-level `tests/` + runtime import to dodge the sys.modules-isolation leak. Full user_env/settings/storage suite: 49 passed.

## Follow-up (separate PR)
Add a Tauri `set_models_dir` command so the launcher's `config.json` stays in sync with Settings — covers the reset-to-default edge and keeps the two stores from diverging at the source. Not needed for the reported bug (the override fix makes the Settings choice win regardless).

## Notes
No new deps. Cross-platform (`~/.config/omnivoice/env` + HF env mapping are platform-neutral; CLI/source users without a launcher are unaffected — the file simply wins over nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fixes issue `#480` where changing the model download location in in-app Settings had no effect after restart. The root cause was that the desktop launcher's pre-injected environment values were overriding user settings stored in the durable per-user config file. The fix ensures user-configured values take precedence.

## Problem

The in-app Settings writes new model directory paths to `~/.config/omnivoice/env` (via `OMNIVOICE_CACHE_DIR`), but `main.py` was loading this file with `override=False`, causing launcher-injected defaults to always win. Since `main.py` maps `OMNIVOICE_CACHE_DIR` to HF cache environment variables that control downloads, the UI reported the old path, making it appear the change had failed.

## Solution

**backend/core/user_env.py** — Added `load_into_environ(path: Optional[str] = None) -> bool` function that:
- Loads the durable per-user env file into `os.environ` using `dotenv.load_dotenv(..., override=True)`
- Resolves the effective path at call time (respects `OMNIVOICE_ENV_FILE` or defaults to `~/.config/omnivoice/env`)
- Returns `False` if file doesn't exist or `python-dotenv` cannot be imported; `True` on success
- Explicitly overwrites launcher-injected values, restoring the documented contract that "values written here take effect on the next backend launch"

**backend/main.py** — Updated startup bootstrap to call `load_into_environ()` after loading the project `.env` file, ensuring user-changed model/cache settings persist across Tauri/Finder launches.

**tests/test_user_env_authoritative.py** — Added three regression tests for `#480` verifying:
- Per-user env file values override pre-injected launcher environment variables
- File values are applied when the target env var is absent
- Missing files are handled gracefully as no-ops without altering pre-injected values

## Behavior Change

```
OLD FLOW (Broken):
┌─────────────────────────────────────────┐
│ 1. Launcher injects OMNIVOICE_CACHE_DIR │
│    (stale value from Tauri config)      │
└────────────┬────────────────────────────┘
             │
             ▼
┌─────────────────────────────────────────┐
│ 2. main.py calls load_dotenv(...,       │
│    override=False)                      │
│    Per-user file IGNORED                │
└────────────┬────────────────────────────┘
             │
             ▼
┌─────────────────────────────────────────┐
│ 3. Effective location still shows       │
│    OLD path (launcher value wins)       │
└─────────────────────────────────────────┘

NEW FLOW (Fixed):
┌─────────────────────────────────────────┐
│ 1. Launcher injects OMNIVOICE_CACHE_DIR │
│    (stale value from Tauri config)      │
└────────────┬────────────────────────────┘
             │
             ▼
┌─────────────────────────────────────────┐
│ 2. main.py calls load_into_environ()    │
│    with override=True                   │
│    Per-user file OVERRIDES launcher     │
└────────────┬────────────────────────────┘
             │
             ▼
┌─────────────────────────────────────────┐
│ 3. Effective location shows NEW path    │
│    (user Settings choice wins)          │
└─────────────────────────────────────────┘
```

## Scope

- **Lines added:** 82
- **Lines removed:** 5
- **Files modified:** 3 (2 implementation, 1 test)
- **Breaking changes:** None
- **Requires restart:** Yes (one backend restart applies the change since HF cache variables are read at import time)

## Notes

Both keys the per-user file can hold (`OMNIVOICE_CACHE_DIR` and `HF_ENDPOINT`) represent the user's explicit Settings choices and should override launcher defaults. The `HF_TOKEN` variable is not launcher-injected, so it remains unchanged. A follow-up PR will add a Tauri command to keep the launcher's config in sync, though this is not required for the reported bug fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->