### PR TITLE
fix(profiles): decouple design-profile save from TTS render (#476)

### DIFF
--- a/backend/api/routers/profiles.py
+++ b/backend/api/routers/profiles.py
@@ -266,10 +266,15 @@ async def get_profile_audio(profile_id: str):
         if rendered is None:
             return Response("No audio available", status_code=404)
         audio_file = rendered
-    # Serve only a direct child of VOICES_DIR — basename() drops any directory
-    # component so a stored/derived name can never escape the voices dir (CWE-22).
-    audio_path = os.path.join(VOICES_DIR, os.path.basename(str(audio_file)))
-    if not os.path.exists(audio_path):
+    # CWE-22: resolve under VOICES_DIR and reject anything that escapes it —
+    # realpath() collapses any `..`, commonpath() confirms containment.
+    base = os.path.realpath(VOICES_DIR)
+    audio_path = os.path.realpath(os.path.join(base, str(audio_file)))
+    try:
+        contained = os.path.commonpath((base, audio_path)) == base
+    except ValueError:  # e.g. different drive on Windows → treat as escape
+        contained = False
+    if not contained or not os.path.exists(audio_path):
         return Response("Audio file missing", status_code=404)
     return FileResponse(audio_path, media_type="audio/wav")
 
@@ -293,9 +298,16 @@ async def _materialize_design_sample(profile_id: str, row) -> Optional[str]:
     from api.routers.archetypes import _render_archetype_wav
 
     audio_filename = f"{profile_id}.wav"
-    # profile_id is regex-validated by the caller; basename() keeps it a direct
-    # child of VOICES_DIR regardless (CWE-22).
-    audio_path = os.path.join(VOICES_DIR, os.path.basename(audio_filename))
+    # CWE-22: resolve under VOICES_DIR and reject any escape before rendering
+    # (realpath collapses `..`, commonpath confirms containment).
+    base = os.path.realpath(VOICES_DIR)
+    audio_path = os.path.realpath(os.path.join(base, audio_filename))
+    try:
+        contained = os.path.commonpath((base, audio_path)) == base
+    except ValueError:
+        contained = False
+    if not contained:
+        raise HTTPException(status_code=400, detail="invalid profile identifier")
     try:
         await _render_archetype_wav(
             {

--- a/backend/api/routers/profiles.py
+++ b/backend/api/routers/profiles.py
@@ -238,6 +238,22 @@ def get_profile_usage(profile_id: str):
     }
 
 
+def _safe_voice_path(filename: str) -> str:
+    """Resolve `filename` strictly inside VOICES_DIR and return the absolute path.
+
+    `filename` is request-influenced (a profile_id-derived name or a DB-stored
+    value), so strip any directory components, restrict to safe characters, and
+    verify realpath containment — raises ValueError on a traversal attempt
+    (CWE-22). Mirrors core.config.dub_seg_path's containment guard.
+    """
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", os.path.basename(str(filename)))
+    base = os.path.realpath(VOICES_DIR)
+    full = os.path.realpath(os.path.join(base, safe))
+    if full != base and not full.startswith(base + os.sep):
+        raise ValueError(f"voice path escapes VOICES_DIR: {filename!r}")
+    return full
+
+
 @router.get("/profiles/{profile_id}/audio")
 async def get_profile_audio(profile_id: str):
     with db_conn() as conn:
@@ -257,7 +273,10 @@ async def get_profile_audio(profile_id: str):
         if rendered is None:
             return Response("No audio available", status_code=404)
         audio_file = rendered
-    audio_path = os.path.join(VOICES_DIR, audio_file)
+    try:
+        audio_path = _safe_voice_path(audio_file)
+    except ValueError:
+        return Response("Audio file missing", status_code=404)
     if not os.path.exists(audio_path):
         return Response("Audio file missing", status_code=404)
     return FileResponse(audio_path, media_type="audio/wav")
@@ -282,7 +301,7 @@ async def _materialize_design_sample(profile_id: str, row) -> Optional[str]:
     from api.routers.archetypes import _render_archetype_wav
 
     audio_filename = f"{profile_id}.wav"
-    audio_path = os.path.join(VOICES_DIR, audio_filename)
+    audio_path = _safe_voice_path(audio_filename)  # contain under VOICES_DIR (CWE-22)
     try:
         await _render_archetype_wav(
             {

--- a/backend/api/routers/profiles.py
+++ b/backend/api/routers/profiles.py
@@ -238,24 +238,17 @@ def get_profile_usage(profile_id: str):
     }
 
 
-def _safe_voice_path(filename: str) -> str:
-    """Resolve `filename` strictly inside VOICES_DIR and return the absolute path.
-
-    `filename` is request-influenced (a profile_id-derived name or a DB-stored
-    value), so strip any directory components, restrict to safe characters, and
-    verify realpath containment — raises ValueError on a traversal attempt
-    (CWE-22). Mirrors core.config.dub_seg_path's containment guard.
-    """
-    safe = re.sub(r"[^A-Za-z0-9._-]", "_", os.path.basename(str(filename)))
-    base = os.path.realpath(VOICES_DIR)
-    full = os.path.realpath(os.path.join(base, safe))
-    if full != base and not full.startswith(base + os.sep):
-        raise ValueError(f"voice path escapes VOICES_DIR: {filename!r}")
-    return full
+# profile_id is a request path param and the audio filename derives from it, so
+# constrain it to the generated-id charset (no separators / `..` possible) before
+# any path use, and read only a *direct child* of VOICES_DIR — os.path.basename()
+# strips any directory component (a path-injection / CWE-22 barrier).
+_PROFILE_ID_RE = re.compile(r"[A-Za-z0-9_-]{1,64}")
 
 
 @router.get("/profiles/{profile_id}/audio")
 async def get_profile_audio(profile_id: str):
+    if not _PROFILE_ID_RE.fullmatch(profile_id or ""):
+        return Response("Profile not found", status_code=404)
     with db_conn() as conn:
         row = conn.execute(
             "SELECT ref_audio_path, locked_audio_path, kind, instruct, language, ref_text "
@@ -273,10 +266,9 @@ async def get_profile_audio(profile_id: str):
         if rendered is None:
             return Response("No audio available", status_code=404)
         audio_file = rendered
-    try:
-        audio_path = _safe_voice_path(audio_file)
-    except ValueError:
-        return Response("Audio file missing", status_code=404)
+    # Serve only a direct child of VOICES_DIR — basename() drops any directory
+    # component so a stored/derived name can never escape the voices dir (CWE-22).
+    audio_path = os.path.join(VOICES_DIR, os.path.basename(str(audio_file)))
     if not os.path.exists(audio_path):
         return Response("Audio file missing", status_code=404)
     return FileResponse(audio_path, media_type="audio/wav")
@@ -301,7 +293,9 @@ async def _materialize_design_sample(profile_id: str, row) -> Optional[str]:
     from api.routers.archetypes import _render_archetype_wav
 
     audio_filename = f"{profile_id}.wav"
-    audio_path = _safe_voice_path(audio_filename)  # contain under VOICES_DIR (CWE-22)
+    # profile_id is regex-validated by the caller; basename() keeps it a direct
+    # child of VOICES_DIR regardless (CWE-22).
+    audio_path = os.path.join(VOICES_DIR, os.path.basename(audio_filename))
     try:
         await _render_archetype_wav(
             {

--- a/backend/api/routers/profiles.py
+++ b/backend/api/routers/profiles.py
@@ -72,8 +72,10 @@ async def create_profile(
                 raise ValueError("not an object")
         except ValueError:
             raise HTTPException(status_code=422, detail="vd_states must be a JSON object")
-        if not instruct.strip():
-            raise HTTPException(status_code=422, detail="design profiles require instruct")
+        # An all-Auto design (every category left on "Auto") yields an empty
+        # instruct — that's still a valid, saveable voice: synthesis falls back
+        # to neutral instruct-only conditioning (see generation.py design path).
+        # Don't gate save on a non-empty instruct.
 
     profile_id = str(uuid.uuid4())[:8]
 
@@ -85,8 +87,15 @@ async def create_profile(
             f.write(await ref_audio.read())
         used_seed = seed
     else:
-        # Render the deterministic identity sample through the one shared TTS
-        # path (archetypes' renderer) — never a second inference code path.
+        # Saving a design profile is a pure persistence operation — it must not
+        # depend on a loaded TTS model (issue #476: on a fresh model-less Docker
+        # image the render forced a full model load + inference that 503'd, so
+        # the save failed). We try the deterministic identity sample opportunist-
+        # ically through the one shared TTS path (archetypes' renderer, never a
+        # second inference code path); if the engine isn't ready it's rendered
+        # lazily on first preview/use. The row carries vd_states + instruct, so
+        # the voice is fully usable without the sample (synthesis falls back to
+        # instruct-only conditioning — see generation.py's design path).
         from pathlib import Path
         from api.routers.archetypes import _render_archetype_wav
         audio_filename = f"{profile_id}.wav"
@@ -100,11 +109,19 @@ async def create_profile(
                 },
                 Path(audio_path),
             )
-        except Exception as e:
-            raise HTTPException(
-                status_code=503,
-                detail=f"could not render the design sample: {e}",
+        except Exception:
+            # Engine unavailable / OOM / inference failure — defer the sample.
+            # Store the row with no ref_audio_path; the identity sample is
+            # rendered on first preview or use. Never let this block the save.
+            import logging
+            logging.getLogger("omnivoice.profiles").info(
+                "Design profile %s saved with sample pending — "
+                "voice engine not ready; will render on first use", profile_id,
             )
+            if os.path.exists(audio_path):  # partial/blank render: don't keep it
+                with __import__("contextlib").suppress(OSError):
+                    os.remove(audio_path)
+            audio_filename = None
         used_seed = seed if seed is not None else _DESIGN_SEED
 
     try:
@@ -222,18 +239,78 @@ def get_profile_usage(profile_id: str):
 
 
 @router.get("/profiles/{profile_id}/audio")
-def get_profile_audio(profile_id: str):
+async def get_profile_audio(profile_id: str):
     with db_conn() as conn:
-        row = conn.execute("SELECT ref_audio_path, locked_audio_path FROM voice_profiles WHERE id=?", (profile_id,)).fetchone()
+        row = conn.execute(
+            "SELECT ref_audio_path, locked_audio_path, kind, instruct, language, ref_text "
+            "FROM voice_profiles WHERE id=?",
+            (profile_id,),
+        ).fetchone()
     if not row:
         return Response("Profile not found", status_code=404)
     audio_file = row["locked_audio_path"] or row["ref_audio_path"]
     if not audio_file:
-        return Response("No audio available", status_code=404)
+        # A design profile saved before the engine was ready (issue #476) has no
+        # identity sample yet. Render it lazily now — the deterministic seed-42
+        # sample is reproducible, so a deferred render matches a save-time one.
+        rendered = await _materialize_design_sample(profile_id, row)
+        if rendered is None:
+            return Response("No audio available", status_code=404)
+        audio_file = rendered
     audio_path = os.path.join(VOICES_DIR, audio_file)
     if not os.path.exists(audio_path):
         return Response("Audio file missing", status_code=404)
     return FileResponse(audio_path, media_type="audio/wav")
+
+
+async def _materialize_design_sample(profile_id: str, row) -> Optional[str]:
+    """Render a design profile's pending identity sample on first request.
+
+    Returns the stored filename on success, or None if this isn't a renderable
+    design row. Raises HTTPException(503) with a precise "model not ready"
+    message if the engine is genuinely unavailable — saving never depends on
+    this, but a user who explicitly asks for the sample gets a clear signal.
+    """
+    try:
+        kind = row["kind"]
+    except (KeyError, IndexError):
+        kind = "clone"
+    if kind != "design":
+        return None
+
+    from pathlib import Path
+    from api.routers.archetypes import _render_archetype_wav
+
+    audio_filename = f"{profile_id}.wav"
+    audio_path = os.path.join(VOICES_DIR, audio_filename)
+    try:
+        await _render_archetype_wav(
+            {
+                "language": row["language"] or "Auto",
+                "sample_script": row["ref_text"] or "",
+                "instruct": row["instruct"] or "",
+            },
+            Path(audio_path),
+        )
+    except Exception as e:
+        with __import__("contextlib").suppress(OSError):
+            if os.path.exists(audio_path):
+                os.remove(audio_path)
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "The voice engine isn't ready yet, so this designed voice's "
+                "preview sample can't be rendered. Finish setup / download a "
+                f"model, then try again. ({e})"
+            ),
+        )
+
+    with db_conn() as conn:
+        conn.execute(
+            "UPDATE voice_profiles SET ref_audio_path=? WHERE id=?",
+            (audio_filename, profile_id),
+        )
+    return audio_filename
 
 @router.post("/profiles/{profile_id}/lock")
 async def lock_profile(

--- a/backend/api/routers/profiles.py
+++ b/backend/api/routers/profiles.py
@@ -266,15 +266,11 @@ async def get_profile_audio(profile_id: str):
         if rendered is None:
             return Response("No audio available", status_code=404)
         audio_file = rendered
-    # CWE-22: resolve under VOICES_DIR and reject anything that escapes it —
-    # realpath() collapses any `..`, commonpath() confirms containment.
-    base = os.path.realpath(VOICES_DIR)
-    audio_path = os.path.realpath(os.path.join(base, str(audio_file)))
-    try:
-        contained = os.path.commonpath((base, audio_path)) == base
-    except ValueError:  # e.g. different drive on Windows → treat as escape
-        contained = False
-    if not contained or not os.path.exists(audio_path):
+    # CWE-22: resolve the DB-stored filename strictly inside VOICES_DIR via the
+    # shared guard — _voices_path() applies the os.path.basename() barrier plus
+    # symlink-resolved containment (same path the consent endpoint trusts).
+    audio_path = _voices_path(str(audio_file))
+    if audio_path is None or not os.path.exists(audio_path):
         return Response("Audio file missing", status_code=404)
     return FileResponse(audio_path, media_type="audio/wav")
 
@@ -298,15 +294,10 @@ async def _materialize_design_sample(profile_id: str, row) -> Optional[str]:
     from api.routers.archetypes import _render_archetype_wav
 
     audio_filename = f"{profile_id}.wav"
-    # CWE-22: resolve under VOICES_DIR and reject any escape before rendering
-    # (realpath collapses `..`, commonpath confirms containment).
-    base = os.path.realpath(VOICES_DIR)
-    audio_path = os.path.realpath(os.path.join(base, audio_filename))
-    try:
-        contained = os.path.commonpath((base, audio_path)) == base
-    except ValueError:
-        contained = False
-    if not contained:
+    # CWE-22: resolve under VOICES_DIR via the shared basename + containment
+    # guard before rendering (rejects any escape).
+    audio_path = _voices_path(audio_filename)
+    if audio_path is None:
         raise HTTPException(status_code=400, detail="invalid profile identifier")
     try:
         await _render_archetype_wav(

--- a/docs/specs/voice-studio-unification.md
+++ b/docs/specs/voice-studio-unification.md
@@ -5,7 +5,7 @@
 Three user-driven decisions (locked):
 1. **Full UI consolidation** — one "Voice" workspace; the saved profile is the hub; "from audio" (clone) and "by design" are two ways to *define* the same profile object.
 2. **History moves right** — left sidebar keeps **Projects + Downloads** only; the per-workspace generation history lives on the right.
-3. **Design voice saves a rendered reference WAV** — on save we synthesize a deterministic sample (seed 42), store it as `ref_audio_path`, *and* persist the design params for re-editing. Same mechanism archetypes already use.
+3. **Design voice saves a rendered reference WAV** — on save we *try* to synthesize a deterministic sample (seed 42) and store it as `ref_audio_path`, *and* persist the design params for re-editing. Same mechanism archetypes already use. **Saving never depends on a loaded TTS model** (issue #476): if the engine isn't ready (e.g. fresh model-less Docker image) the row is persisted with the sample *pending* and the deterministic sample is rendered lazily on first preview/use — the row's `vd_states` + `instruct` already make the voice fully usable (synthesis falls back to instruct-only conditioning).
 
 Not in scope: changing the Dub or Stories workspaces beyond giving them the same right-side history panel; realtime/streaming synthesis; voice-mixing.
 
@@ -219,7 +219,7 @@ GET /history?mode=clone|design&limit=50
 - Make `ref_audio` **optional**. Add `kind` (default `clone`) and `vd_states` (JSON string, optional) form fields.
 - Validation:
   - `kind='clone'` → `ref_audio` required (today's rule).
-  - `kind='design'` → `vd_states` required; **server renders a sample WAV** (reuse the archetype materialization path in `archetypes.py:260-310`: synth `sample_script` at `_PREVIEW_SEED=42`, store as `ref_audio_path`), persist `vd_states` + derived `instruct` + `seed=42`.
+  - `kind='design'` → `vd_states` required; `instruct` is **not** required (an all-Auto design has an empty instruct and is still a valid, saveable voice). The server *opportunistically* renders a sample WAV (reuse the archetype renderer in `archetypes.py`: synth `sample_script` at `_PREVIEW_SEED=42`, store as `ref_audio_path`) and always persists `vd_states` + derived `instruct` + `seed=42`. **The render is non-fatal** (issue #476): if the engine isn't ready the row is saved with `ref_audio_path=NULL` (sample pending) and `GET /profiles/{id}/audio` renders + caches it lazily on first request (returning a precise "model not ready — finish setup / download a model" 503 if the engine is still unavailable).
 - Return `kind` and `vd_states` in the profile payload (and from `GET /profiles`, `GET /profiles/{id}`).
 
 ### `POST /generate` profile resolution (`backend/api/routers/generation.py:310-335`)

--- a/tests/test_profile_design_save_decouple.py
+++ b/tests/test_profile_design_save_decouple.py
@@ -152,18 +152,12 @@ def test_lazy_sample_renders_on_first_audio_request(iso, monkeypatch):
     assert ref, "the lazily-rendered sample should be persisted on the row"
 
 
-def test_safe_voice_path_contains_request_derived_filenames():
-    """#476 hardening / CWE-22 (CodeQL path-injection): the profile-audio path
-    helper must keep every request-derived filename inside VOICES_DIR, so a
-    crafted profile_id (e.g. ``../../etc/passwd``) can't traverse out."""
-    from api.routers import profiles as prof
-    from core.config import VOICES_DIR
-
-    base = os.path.realpath(VOICES_DIR)
-    assert prof._safe_voice_path("a1b2c3d4.wav").startswith(base + os.sep)
-    for evil in ("../../etc/passwd", "..\\..\\win.ini", "/abs/escape.wav", "a/../../b.wav"):
-        got = prof._safe_voice_path(evil)
-        # Contained: dir components are stripped so the file resolves DIRECTLY
-        # inside VOICES_DIR and can never escape. (A literal ".." substring left
-        # in the basename is harmless once separators are neutralised.)
-        assert os.path.dirname(got) == base, (evil, got)
+def test_traversal_profile_id_is_rejected(iso):
+    """#476 hardening / CWE-22 (CodeQL path-injection): a profile_id carrying
+    path separators / `..` / NUL must 404 at the entry guard, never reaching a
+    filesystem read — the audio endpoint only ever serves a direct child of
+    VOICES_DIR."""
+    _, _, prof = iso
+    for evil in ("../../etc/passwd", "..", "a/b", "foo/../bar", "x\x00y", "/abs", ""):
+        resp = asyncio.run(prof.get_profile_audio(evil))
+        assert getattr(resp, "status_code", None) == 404, (evil, resp)

--- a/tests/test_profile_design_save_decouple.py
+++ b/tests/test_profile_design_save_decouple.py
@@ -150,3 +150,20 @@ def test_lazy_sample_renders_on_first_audio_request(iso, monkeypatch):
             "SELECT ref_audio_path FROM voice_profiles WHERE id=?", (pid,)
         ).fetchone()["ref_audio_path"]
     assert ref, "the lazily-rendered sample should be persisted on the row"
+
+
+def test_safe_voice_path_contains_request_derived_filenames():
+    """#476 hardening / CWE-22 (CodeQL path-injection): the profile-audio path
+    helper must keep every request-derived filename inside VOICES_DIR, so a
+    crafted profile_id (e.g. ``../../etc/passwd``) can't traverse out."""
+    from api.routers import profiles as prof
+    from core.config import VOICES_DIR
+
+    base = os.path.realpath(VOICES_DIR)
+    assert prof._safe_voice_path("a1b2c3d4.wav").startswith(base + os.sep)
+    for evil in ("../../etc/passwd", "..\\..\\win.ini", "/abs/escape.wav", "a/../../b.wav"):
+        got = prof._safe_voice_path(evil)
+        # Contained: dir components are stripped so the file resolves DIRECTLY
+        # inside VOICES_DIR and can never escape. (A literal ".." substring left
+        # in the basename is harmless once separators are neutralised.)
+        assert os.path.dirname(got) == base, (evil, got)

--- a/tests/test_profile_design_save_decouple.py
+++ b/tests/test_profile_design_save_decouple.py
@@ -1,0 +1,152 @@
+"""Design-profile save is decoupled from TTS render (issue #476).
+
+On a fresh model-less image (e.g. Docker first-run), saving a *design* voice
+profile used to force a full TTS model load + inference to render an identity
+sample, which 503'd when no model was present — so the save failed. Saving a
+design profile is a pure persistence operation: it must succeed without a
+loaded model. The deterministic identity sample is rendered lazily on first
+preview/use instead.
+
+This module runs torch-free against an isolated data dir and drives the real
+`create_profile` / `get_profile_audio` endpoint coroutines directly. Each test
+uses `asyncio.run(...)` (NOT a shared/`get_event_loop()` loop) and the module
+lives at top-level `tests/` (not `tests/backend/`) to avoid the
+sys.modules-isolation collection-order leak.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+_VD = {"Gender": "female", "Age": "young adult", "Pitch": "high pitch"}
+_VD_AUTO = {"Gender": "Auto", "Age": "Auto", "Pitch": "Auto"}
+
+
+@pytest.fixture()
+def iso(tmp_path, monkeypatch):
+    """Isolated data dir + freshly-reloaded config/db/profiles modules."""
+    monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
+    import core.config as cfg
+    importlib.reload(cfg)
+    import core.db as db
+    importlib.reload(db)
+    from api.routers import profiles as prof
+    importlib.reload(prof)
+    db.init_db()
+    return cfg, db, prof
+
+
+def _model_unavailable(monkeypatch):
+    """Simulate a model-less image: the shared renderer 503s on model load."""
+    async def _boom(a, out_path):
+        raise RuntimeError("503: no TTS model is downloaded yet")
+
+    from api.routers import archetypes as arch
+    monkeypatch.setattr(arch, "_render_archetype_wav", _boom)
+
+
+def test_design_save_creates_row_when_model_unavailable(iso, monkeypatch):
+    """kind=design saves (lazy path) instead of 503-ing when no model exists."""
+    _, db, prof = iso
+    _model_unavailable(monkeypatch)
+
+    result = asyncio.run(
+        prof.create_profile(
+            name="Designed (no model)",
+            ref_audio=None,
+            ref_text="",
+            instruct="female, young adult, high pitch",
+            language="English",
+            seed=None,
+            personality="",
+            kind="design",
+            vd_states=json.dumps(_VD),
+        )
+    )
+    assert result["kind"] == "design"
+
+    with db.db_conn() as conn:
+        row = conn.execute(
+            "SELECT kind, ref_audio_path, instruct, vd_states FROM voice_profiles WHERE id=?",
+            (result["id"],),
+        ).fetchone()
+    assert row is not None, "row must be persisted even with no model"
+    assert row["kind"] == "design"
+    # Sample is pending — no rendered identity wav was forced at save time.
+    assert not row["ref_audio_path"]
+    assert json.loads(row["vd_states"]) == _VD
+
+
+def test_all_auto_design_is_saveable(iso, monkeypatch):
+    """An all-Auto design (empty instruct) saves; it isn't gated on instruct."""
+    _, db, prof = iso
+    _model_unavailable(monkeypatch)
+
+    result = asyncio.run(
+        prof.create_profile(
+            name="All Auto",
+            ref_audio=None,
+            ref_text="",
+            instruct="",
+            language="Auto",
+            seed=None,
+            personality="",
+            kind="design",
+            vd_states=json.dumps(_VD_AUTO),
+        )
+    )
+    assert result["kind"] == "design"
+
+    with db.db_conn() as conn:
+        row = conn.execute(
+            "SELECT kind, instruct FROM voice_profiles WHERE id=?",
+            (result["id"],),
+        ).fetchone()
+    assert row is not None
+    assert row["kind"] == "design"
+    assert (row["instruct"] or "") == ""
+
+
+def test_lazy_sample_renders_on_first_audio_request(iso, monkeypatch):
+    """A pending design sample is materialized on first /audio request."""
+    _, db, prof = iso
+    _model_unavailable(monkeypatch)
+
+    result = asyncio.run(
+        prof.create_profile(
+            name="Lazy Sample",
+            ref_audio=None,
+            ref_text="",
+            instruct="female, calm",
+            language="English",
+            seed=None,
+            personality="",
+            kind="design",
+            vd_states=json.dumps(_VD),
+        )
+    )
+    pid = result["id"]
+
+    # Now the engine becomes available: the next /audio request renders + caches.
+    async def _ok(a, out_path):
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(b"RIFF" + b"\x00" * 2048)
+
+    from api.routers import archetypes as arch
+    monkeypatch.setattr(arch, "_render_archetype_wav", _ok)
+
+    resp = asyncio.run(prof.get_profile_audio(pid))
+    assert getattr(resp, "status_code", 200) == 200
+
+    with db.db_conn() as conn:
+        ref = conn.execute(
+            "SELECT ref_audio_path FROM voice_profiles WHERE id=?", (pid,)
+        ).fetchone()["ref_audio_path"]
+    assert ref, "the lazily-rendered sample should be persisted on the row"

--- a/tests/test_profile_unification.py
+++ b/tests/test_profile_unification.py
@@ -70,13 +70,21 @@ def test_design_requires_vd_states(app_client):
     assert r.status_code == 422
 
 
-def test_design_requires_instruct(app_client):
+def test_design_saveable_without_instruct(app_client, fake_render):
+    """An all-Auto design (empty instruct) is a valid, saveable voice (#476).
+
+    Saving must not gate on a non-empty instruct — synthesis falls back to
+    neutral instruct-only conditioning.
+    """
     client, _ = app_client
     r = client.post(
         "/profiles",
-        data={"name": "D", "kind": "design", "vd_states": json.dumps(_VD)},
+        data={"name": "AllAuto", "kind": "design", "vd_states": json.dumps(_VD)},
     )
-    assert r.status_code == 422
+    assert r.status_code == 200, r.text
+    profile = client.get(f"/profiles/{r.json()['id']}").json()
+    assert profile["kind"] == "design"
+    assert (profile["instruct"] or "") == ""
 
 
 def test_design_rejects_malformed_vd_states(app_client):


### PR DESCRIPTION
## Problem
On a fresh **Docker** image with no TTS model downloaded, saving a **design** voice profile throws an error (sub-bug of #476, "save-profile error").

## Root cause
Saving a design profile was not a pure DB write — it forced a full TTS model load + inference to render a deterministic identity sample:
- `POST /profiles` (`backend/api/routers/profiles.py`) called `_render_archetype_wav(...)`, which does `await get_model()` + `_run_inference`. On a model-less image this raised → caught and re-raised as **HTTP 503 "could not render the design sample: …"**, so the save failed.
- Secondary: an all-Auto design (every category on "Auto") produces an empty `instruct`, which tripped a **422 "design profiles require instruct"** guard.

## Fix
Saving a design profile is now a pure persistence operation that never depends on a loaded model:
- The seed-42 identity-sample render is **attempted opportunistically but is non-fatal**. If the engine isn't ready, the row is persisted with `ref_audio_path=NULL` (sample *pending*). The row's `vd_states` + `instruct` already make the voice fully usable — `generation.py`'s design branch falls back to instruct-only conditioning when there's no ref audio.
- The pending sample is **rendered lazily + cached** on the first `GET /profiles/{id}/audio` request (deterministic seed → a deferred render matches a save-time one). If the engine is *still* unavailable there, that path returns a precise, typed **"model not ready — finish setup / download a model" 503** (only when the user explicitly asks for the sample, never on save).
- The **all-Auto** (empty-instruct) design is now saveable; `vd_states` is still required.

Existing clone and model-present design flows are unchanged.

## Tests
- New `tests/test_profile_design_save_decouple.py` (top-level `tests/`, `asyncio.run()` per test):
  - `kind=design` with the model unavailable **creates the row** (lazy path) instead of 503-ing, with `ref_audio_path` empty.
  - The **all-Auto** design is saveable.
  - The pending sample **materializes on first `/audio` request** and is persisted on the row.
- Updated `tests/test_profile_unification.py`: `test_design_requires_instruct` → `test_design_saveable_without_instruct`.
- Green: new test + `test_profile_unification`, `test_persona_kind`, `test_persona_bundle`, `test_profile_consent`, `test_archetype_blank_guard`, `test_no_hardcoded_cjk` (59 passed).

## Docs-sync
Updated `docs/specs/voice-studio-unification.md` (§Decisions + §`POST /profiles` validation) to describe the non-fatal/lazy render and the no-longer-required instruct.

## Cross-platform
Pure backend logic; identical behavior on macOS/Windows/Linux/Docker. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a design-voice save bug where `POST /profiles` could fail with **503** on fresh Docker images that don’t have a downloaded TTS model, and it makes design save a **persistence-only** operation. It also allows **all-Auto** design profiles (all category picks set to `"Auto"`, producing an **empty `instruct`**) to be saved instead of being rejected with **422**.

## Key Changes

### New behavior for profile save (`POST /profiles`)
For `kind="design"`:
- The server **no longer rejects** design profiles when the computed/derived `instruct` is empty (e.g., all-`Auto` categories).
- `vd_states` remains **required** and is still persisted.
- Identity/sample rendering is now **best-effort and non-fatal**:
  - It attempts to render a deterministic identity sample (seed **42**).
  - If rendering fails (e.g., engine/model unavailable), it:
    - deletes any partial output WAV (if present),
    - persists the profile with `voice_profiles.ref_audio_path = NULL` (sample marked **pending**),
    - proceeds with inserting/storing profile fields (including `instruct` and metadata).
- As a result, design saves succeed even when the TTS engine can’t load yet.

### Lazy sample materialization (`GET /profiles/{profile_id}/audio`)
`GET /profiles/{profile_id}/audio` is now **async** and:
- Validates `profile_id` with `_PROFILE_ID_RE` (`[A-Za-z0-9_-]{1,64}`); invalid IDs return **404**.
- Uses the stored audio path if available:
  - serves `locked_audio_path` first, otherwise `ref_audio_path`.
- If no persisted audio path exists for a design profile:
  - lazily renders a deterministic identity WAV via `_materialize_design_sample(...)`,
  - updates `voice_profiles.ref_audio_path` on success and serves the generated WAV.
  - if rendering fails at request time, it returns **503** (engine not ready).
- Returns **404** if the profile exists but no audio can be produced/located.

### Security hardening (path containment / CodeQL)
- Hardened file path handling to address **CWE-22** path-injection alerts by routing DB-stored filename resolution through the shared **`_voices_path()` guard helper**.
- Both the audio serving path (`get_profile_audio`) and the lazy renderer (`_materialize_design_sample`) now rely on `_voices_path()` (which applies an `os.path.basename()` barrier plus symlink-resolved containment) rather than relying on inline containment checks that CodeQL didn’t treat as sanitizers.
- The request entry regex guard remains as defense-in-depth.

## Behavior Flow

```mermaid
sequenceDiagram
  participant Client
  participant API as POST /profiles
  participant Engine as TTS Engine
  participant DB as voice_profiles
  participant FS as VOICES_DIR

  Client->>API: POST /profiles (kind="design")
  API->>Engine: Best-effort render deterministic identity (seed 42)
  alt Render succeeds
    API->>FS: Write WAV file
    API->>DB: Insert profile with ref_audio_path set
  else Render fails (engine not ready)
    API->>FS: Delete any partial/blank WAV (if any)
    API->>DB: Insert profile with ref_audio_path = NULL (pending)
  end
  API-->>Client: 200 Profile saved (no engine dependency)

  Client->>API: GET /profiles/{profile_id}/audio
  API->>DB: Load ref_audio_path/locked_audio_path
  alt Audio path exists
    API->>FS: Serve file (resolved via _voices_path)
  else Pending design audio
    API->>Engine: Render deterministic identity
    alt Render succeeds
      API->>DB: Update ref_audio_path
      API->>FS: Serve file
    else Render fails
      API-->>Client: 503 (only when user requests audio)
    end
  end
```

## Files Changed

- `backend/api/routers/profiles.py`
  - Updated design profile creation to be saveable with empty `instruct` (all-`Auto`), while keeping `vd_states` required.
  - Decoupled design save from TTS availability: save succeeds even if sample rendering fails; persists `ref_audio_path = NULL` when pending.
  - Added lazy identity rendering via `_materialize_design_sample(...)` and persisted/cache `ref_audio_path` on first audio request.
  - Hardened audio path resolution using the shared `_voices_path()` guard (CodeQL-recognized) and kept the `profile_id` regex entry guard.
- `tests/test_profile_design_save_decouple.py` (new)
  - Covers: model-unavailable save (no save-time 503; `ref_audio_path` stays empty), all-`Auto` design save with empty `instruct`, lazy sample materialization on first audio request, and traversal/path-manipulation `profile_id` rejection (**404**).
- `tests/test_profile_unification.py`
  - Adjusted unified profile tests to remove the “design requires non-empty instruct” assumption and assert saveability when `instruct` is empty.
- `docs/specs/voice-studio-unification.md`
  - Documents non-fatal, lazy identity sample rendering and the defined **503 only on explicit audio request** behavior.

## Test Coverage
All tests pass, including the new decoupling/lazy-render test suite and the updated unification validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->