### PR TITLE
fix(ui): clone popover/CTA clipping + textarea resize (#481, #476)

### DIFF
--- a/frontend/src/components/WorkspaceHistory.css
+++ b/frontend/src/components/WorkspaceHistory.css
@@ -20,11 +20,34 @@
   overflow: hidden;
 }
 
-@media (max-width: 900px) {
-  .studio-with-history {
-    flex-direction: column;
-    overflow-y: auto;
-  }
+/* On a narrow shell the workspace + history aside stack vertically. Driven by
+   the shell-width class set in App.jsx from `app-container.clientWidth`, NOT a
+   raw `@media (max-width)`: the shell scales via `zoom`, so a viewport media
+   query fires at the wrong threshold whenever --ui-scale ≠ 1 and dropped the
+   action bar (Synthesize CTA) below the fold (#476). `.shell-narrow`/`.shell-mini`
+   track the real scaled layout width on every engine (index.css:294). */
+.shell-narrow .studio-with-history,
+.shell-mini .studio-with-history {
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+/* When stacked, the main column must NOT clip its own overflow — its
+   `overflow:hidden` (needed for the side-by-side scroll panes) otherwise trapped
+   the pinned action bar below the fold of the now-scrolling outer column (#476).
+   Letting it grow naturally hands scrolling to `.studio-with-history`, and the
+   action bar below stays reachable; `position:sticky` keeps the Synthesize CTA
+   pinned to the viewport bottom while the script content scrolls. */
+.shell-narrow .studio-with-history__main,
+.shell-mini .studio-with-history__main {
+  overflow: visible;
+  flex: 0 0 auto;
+}
+.shell-narrow .studio-with-history__main .studio-action-bar,
+.shell-mini .studio-with-history__main .studio-action-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
 }
 
 /* Right column: Saved voices (top) + History (bottom) stacked, each scrolls. */
@@ -115,12 +138,13 @@
   padding: 32px 16px;
 }
 
-/* On narrow windows the right column drops below the definition column. */
-@media (max-width: 900px) {
-  .studio-right {
-    flex-basis: auto;
-    border-left: none;
-    border-top: 1px solid var(--chrome-border);
-    max-height: 60vh;
-  }
+/* On a narrow shell the right column drops below the definition column. Same
+   shell-class trigger as above (not a viewport media query) so it reflows in
+   lockstep with the stacked layout at the scaled width (#476). */
+.shell-narrow .studio-right,
+.shell-mini .studio-right {
+  flex-basis: auto;
+  border-left: none;
+  border-top: 1px solid var(--chrome-border);
+  max-height: 60vh;
 }

--- a/frontend/src/pages/CloneDesignTab.css
+++ b/frontend/src/pages/CloneDesignTab.css
@@ -136,7 +136,10 @@
 .clone-insert-btn {
   position: absolute;
   right: 8px;
-  bottom: 8px;
+  /* Lifted off the textarea's bottom-right resize grip so the ⊕ button no
+     longer covers the drag handle (#481). The popover's `bottom` offset below
+     is anchored to this row, so they move together. */
+  bottom: 30px;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -154,12 +157,17 @@
 .clone-insert-pop {
   position: absolute;
   right: 8px;
-  bottom: 38px;
+  /* Opens upward, clearing the lifted ⊕ button (bottom:30px + its height). */
+  bottom: 60px;
   z-index: 20;
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
-  max-width: 360px;
+  /* Viewport-edge guard (#481): the 14-chip grid can't spill past the window
+     even when the script panel is narrow. The script panel's
+     `.clone-panel--overflow-visible` (applied in the JSX) stops the parent
+     `overflow:auto` from clipping it. */
+  max-width: min(360px, calc(100vw - 16px));
   padding: 8px;
   background: var(--chrome-bg);
   border: 1px solid var(--chrome-border-strong);
@@ -265,7 +273,10 @@
 /* Text input + textarea tweaks */
 .clone-text-area {
   flex: 1;
-  resize: none;
+  /* Re-enable the corner grip (matches base textarea.input-base). The ⊕ Insert
+     button is lifted off the bottom-right so it no longer covers the handle
+     (#481). */
+  resize: vertical;
   min-height: 60px;
   margin-bottom: 6px;
 }

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -266,7 +266,10 @@ export default function CloneDesignTab(props) {
 
       {/* ═══ SCRIPT — what should it say ═══ */}
       <div className="studio-column">
-        <div className="studio-panel">
+        {/* overflow-visible: the ⊕ Insert popover opens above the textarea and
+            must escape the panel's `overflow:auto` box instead of being clipped
+            into its scroll region (#481). */}
+        <div className="studio-panel clone-panel--overflow-visible">
           <div className="label-row label-row--center">
             <Command className="label-icon" size={14} /> {t('clone.script', { defaultValue: 'Script' })}
           </div>

--- a/frontend/src/test/workspaceHistoryReflow.test.js
+++ b/frontend/src/test/workspaceHistoryReflow.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Regression guard for the design-mode "Synthesize Audio" CTA clipping (#476).
+ *
+ * The studio workspace stacks vertically on narrow shells. That reflow MUST be
+ * driven by the shell-width classes (`.shell-narrow` / `.shell-mini`, set in
+ * App.jsx from `app-container.clientWidth`), NOT a raw `@media (max-width)`:
+ * the shell scales via `zoom`, so a viewport media query fires at the wrong
+ * threshold whenever `--ui-scale ≠ 1` and dropped the action bar below the fold
+ * (the same anti-pattern documented in index.css:294). This test fails CI if a
+ * future change reintroduces a `@media (max-width)` in this file or drops the
+ * shell-class reflow / sticky action bar.
+ */
+// Strip /* … */ comments so the guard checks real declarations, not the
+// warning comment that quotes the forbidden `@media (max-width)` pattern.
+const raw = readFileSync(
+  resolve(process.cwd(), 'src/components/WorkspaceHistory.css'),
+  'utf8',
+);
+const css = raw.replace(/\/\*[\s\S]*?\*\//g, '');
+
+describe('workspace narrow-shell reflow (#476 CTA-clipping guard)', () => {
+  it('does NOT use a raw viewport @media (max-width) query', () => {
+    expect(css).not.toMatch(/@media[^{]*max-width/);
+  });
+
+  it('stacks the workspace via the shell-width classes', () => {
+    expect(css).toMatch(/\.shell-narrow\s+\.studio-with-history/);
+    expect(css).toMatch(/\.shell-mini\s+\.studio-with-history/);
+  });
+
+  it('pins the action bar (Synthesize CTA) sticky so it stays on-screen', () => {
+    expect(css).toMatch(/\.studio-action-bar\s*\{[^}]*position:\s*sticky/s);
+  });
+});


### PR DESCRIPTION
## Problem
Two related layout bugs in the Clone/Voice + Design area:

- **#481** — The script editor's **⊕ Insert** token popover (14 chips) opened *offscreen*, clipped into the panel's scroll region; and the script **textarea couldn't be resized** — its corner grip was disabled and physically covered by the ⊕ Insert button.
- **#476** — For an **unsaved design**, the only play/test control is the bottom **"Synthesize Audio"** CTA. On narrow shells it dropped **below the fold** and became unreachable.

## Root cause
- **#481 popover:** `.clone-insert-pop` is `position:absolute` inside `.studio-panel` (`overflow:auto`) → clipped to the panel box. `max-width:360px` let it spill past the viewport edge too.
- **#481 resize:** `.clone-text-area { resize: none }` killed the grip, and `.clone-insert-btn` (`right:8px; bottom:8px`) sat on top of the bottom-right drag handle.
- **#476 CTA:** raw `@media (max-width:900px)` rules flipped `.studio-with-history` to a scrolling column while `.studio-with-history__main { overflow:hidden }` trapped the action bar below the fold. The shell scales via `zoom`, so the **viewport `@media` fires at the wrong threshold** whenever `--ui-scale ≠ 1` (the documented anti-pattern at `index.css:294`).

## Fix
- Apply the existing `.clone-panel--overflow-visible` helper to the script `.studio-panel` so the popover escapes the clip; cap it with `max-width: min(360px, calc(100vw - 16px))` so it stays inside the viewport.
- `resize: vertical` on the textarea (matches base `textarea.input-base`); lift the ⊕ Insert button (and its anchored popover) off the bottom-right grip.
- Replace the raw `@media (max-width:900px)` rules in `WorkspaceHistory.css` with the app's shell-width classes (`.shell-narrow` / `.shell-mini`, set in `App.jsx` from `app-container.clientWidth`), so the reflow tracks the scaled layout width on every engine. When stacked, drop the main column's `overflow:hidden` clip and pin the action bar `position: sticky; bottom: 0` so the Synthesize CTA stays visible.

Pure CSS + one `className` change; no component restructuring. Cross-platform / browser + Tauri consistent (no platform-only behavior). No new user-facing strings.

## Tests
- `bun run typecheck:ci` — clean.
- `bun run test` (vitest) — **506/506 green** (was 503; +3).
- Added `frontend/src/test/workspaceHistoryReflow.test.js` — a permanent regression guard (mirrors `appShellScale.test.js`) asserting the reflow uses the shell-width classes + sticky CTA and never reintroduces a viewport `@media (max-width)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two CSS layout bugs affecting the Clone/Voice + Design interface:

### Bug `#481`: Script Editor Popover and Textarea Issues

The ⊕ Insert token popover (14-chip grid) was opening offscreen and clipping into the script panel's scroll region, while the script textarea resize grip was disabled and covered by the Insert button.

**Before:**
```
┌─────────────────────────────────────┐
│ SCRIPT (panel, overflow:auto)       │◄─ Popover gets clipped here
│ ┌──────────────────────────────────┐│
│ │ Script textarea (resize: none)   ││
│ │ ┌──────────────────────────────┐ ││
│ │ │                              │ ││
│ │ │                              │ ││
│ │ │                     ⊕Insert  │ ││◄─ Covers resize grip
│ │ │                    └──┘      │ ││    (bottom-right corner)
│ │ └──────────────────────────────┘ ││
│ └──────────────────────────────────┘│
└─────────────────────────────────────┘
        ↓ (Popover opens, clipped)
   [chips overflow past viewport]
```

**After:**
```
┌─────────────────────────────────────┐
│ SCRIPT (panel, overflow:visible)    │
│ ┌──────────────────────────────────┐│
│ │ Script textarea (resize:vertical)││
│ │ ┌──────────────────────────────┐ ││
│ │ │                              │◄├─ Resize grip visible
│ │ │                              │░││
│ │ │                    ⊕Insert   │░││◄─ Lifted 30px → 22px gap
│ │ │                   └──┘       │░││
│ │ └────────────────────────────░░┘ ││
│ └──────────────────────────────────┘│
└─────────────────────────────────────┘
        ↑ (Popover opens, max-width guards viewport)
   [chips fit safely within viewport bounds]
```

**Changes:**
- **CloneDesignTab.jsx**: Wrapped script panel in `clone-panel--overflow-visible` to escape popover clipping
- **CloneDesignTab.css**:
  - `.clone-insert-btn`: `bottom: 8px` → `bottom: 30px` (off the resize grip)
  - `.clone-insert-pop`: `bottom: 38px` → `bottom: 60px`; `max-width: 360px` → `max-width: min(360px, calc(100vw - 16px))`
  - `.clone-text-area`: `resize: none` → `resize: vertical` (restore grip)

### Bug `#476`: CTA Visibility on Narrow Shells

The "Synthesize Audio" button dropped below the fold on narrow viewports because the workspace/history stacking was driven by raw `@media (max-width: 900px)` viewport queries. Since the app shell scales via CSS `zoom`, these media queries fire at incorrect thresholds when `--ui-scale ≠ 1`, leaving the action bar trapped in a scrolling overflow region.

**Before (viewport-based):**
```
┌─ Viewport 900px ──────────────────┐
│ ┌─ Workspace (flex, overflow:hidden)
│ │ ┌─ Script (scrolls)          │  Side-by-side at viewport 901px
│ │ │                            │  ↓ Stacks at viewport ≤900px
│ │ └────────────────────────────┤  (but zoom scale breaks threshold)
│ │ ┌─ Synthesize CTA (pinned)   │
│ │ └────────────────────────────┤
│ │       ⬅ scrolls, CTA exits     │
│ └────────────────────────────────┤
│ ┌─ History (right column)        │
│ └────────────────────────────────┘
```

**After (shell-class driven):**
```
┌─ Viewport (zoom-scaled) ──────────────────┐
│ ┌─ Workspace (flex, overflow:visible when stacked)
│ │ ┌─ Script (scrolls)          │
│ │ │                            │
│ │ │                            │
│ │ └────────────────────────────┤
│ │ ┌─ Synthesize CTA (sticky)   │◄─ Pinned to viewport bottom
│ │ └────────────────────────────┤  even when script scrolls
│ │       ⬇ content scrolls, CTA stays
│ └────────────────────────────────┤
│ ┌─ History (stacked below)       │
│ │                                │
│ └────────────────────────────────┘
```

**Changes (WorkspaceHistory.css):**
- Replaced `@media (max-width: 900px)` with `.shell-narrow`/`.shell-mini` class selectors (driven by `App.jsx` from `app-container.clientWidth`)
- `.studio-with-history`: `flex-direction: column; overflow-y: auto`
- `.studio-with-history__main`: when stacked, `overflow: visible` (instead of `hidden`) so scrolling moves to outer container; `flex: 0 0 auto` (natural height)
- `.studio-action-bar`: added `position: sticky; bottom: 0; z-index: 3` to keep CTA visible while content scrolls
- `.studio-right`: similarly class-driven, drops below main column with `max-height: 60vh`

### Testing

Added `workspaceHistoryReflow.test.js` regression guard (38 lines) that verifies:
1. No raw `@media ... max-width` declarations in `WorkspaceHistory.css`
2. Stacking is driven by `.shell-narrow` / `.shell-mini` classes
3. Action bar declares `position: sticky`

All changes are **CSS-only** except one `className` addition in JSX. `typecheck:ci` passes; 506/506 vitest tests green (+3 new).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->