### PR TITLE
fix(dub): auto-assign per-speaker voices in multi-speaker dubbing (#486)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -799,19 +799,35 @@ async def dub_transcribe_stream(
             if clones or seg_clones:
                 if clones:
                     job["speaker_clones"] = clones
-                # Default each segment's profile_id to its own per-segment ref
-                # when available, else its speaker's auto-clone — but only if
-                # the user hasn't already assigned something.
+                # Default each segment's profile_id to its detected speaker's
+                # auto-clone — but only if the user hasn't already assigned
+                # something. (#486)
+                #
+                # We prefer the UI-visible `auto:{speaker}` id over the
+                # per-segment `auto-seg:{id}` id even when a per-segment ref
+                # exists, because the dub editor's Voice dropdown only renders
+                # `auto:` options ("From Video → Speaker N"). An `auto-seg:`
+                # value matches no <option>, so the row silently read
+                # "Default" while the speaker was actually bound — exactly the
+                # reported bug. The per-segment ref is NOT lost: dub_generate's
+                # `auto:` branch transparently prefers this segment's own
+                # per-segment ref (job["segment_clones"][seg_id]) when present,
+                # so a row shown as "Speaker 1" still clones from its own line
+                # when that line is long enough.
                 for s in final_segs:
                     if s.get("profile_id"):
-                        continue
-                    sid = str(s.get("id", ""))
-                    if sid and sid in seg_clones:
-                        s["profile_id"] = f"auto-seg:{sid}"
                         continue
                     spk = s.get("speaker_id") or "Speaker 1"
                     if spk in clones:
                         s["profile_id"] = auto_profile_id(spk)
+                        continue
+                    # No per-speaker clone for this speaker (too little usable
+                    # audio overall) but this single line was long enough for
+                    # its own ref — fall back to the per-segment id. The editor
+                    # can't render it, but generation still clones correctly.
+                    sid = str(s.get("id", ""))
+                    if sid and sid in seg_clones:
+                        s["profile_id"] = f"auto-seg:{sid}"
         except Exception as e:
             logger.warning("speaker_clone extraction skipped: %s", e)
 

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -215,17 +215,31 @@ async def dub_generate(job_id: str, req: DubRequest):
                     profile_id = None  # prevent the voice_profiles lookup below
 
                 elif profile_id and profile_id.startswith("auto:"):
-                    key = profile_id[len("auto:"):]
-                    clones = job.get("speaker_clones") or {}
-                    # Match by the safe-name key first, fall back to speaker_id.
-                    auto = None
-                    for spk, info in clones.items():
-                        if spk.lower().replace(" ", "_") == key or spk == key:
-                            auto = info
-                            break
-                    if auto:
-                        ref_audio = auto.get("ref_audio")
-                        ref_text = auto.get("ref_text")
+                    # #486: an `auto:{speaker}` binding still prefers THIS
+                    # segment's own per-segment ref when one exists (cut from
+                    # this line's source audio → matches its prosody), falling
+                    # back to the per-speaker clone otherwise. This keeps the
+                    # Wave 3.2 per-segment-ref quality win while letting every
+                    # segment carry the UI-visible `auto:` id the dub editor's
+                    # Voice dropdown can actually render ("From Video →
+                    # Speaker N"). `seg_id` is closed over from the per-segment
+                    # loop below.
+                    seg_ref = (job.get("segment_clones") or {}).get(str(seg_id))
+                    if seg_ref:
+                        ref_audio = seg_ref.get("ref_audio")
+                        ref_text = seg_ref.get("ref_text")
+                    else:
+                        key = profile_id[len("auto:"):]
+                        clones = job.get("speaker_clones") or {}
+                        # Match by the safe-name key first, fall back to speaker_id.
+                        auto = None
+                        for spk, info in clones.items():
+                            if spk.lower().replace(" ", "_") == key or spk == key:
+                                auto = info
+                                break
+                        if auto:
+                            ref_audio = auto.get("ref_audio")
+                            ref_text = auto.get("ref_text")
                     profile_id = None  # prevent the voice_profiles lookup below
 
                 if profile_id:

--- a/tests/test_dub_multispeaker_voice_486.py
+++ b/tests/test_dub_multispeaker_voice_486.py
@@ -1,0 +1,221 @@
+"""Multi-speaker dub: per-speaker voice auto-assignment (#486).
+
+Two regressions are covered, both hermetic (fake model, no DB, no ffmpeg,
+WAVs under tmp_path):
+
+1. Segment → speaker-clone *binding* (the assignment loop that ran in
+   dub_core after diarization). Before the fix, the default-on per-segment
+   ref path stamped each long line with `auto-seg:{id}` — a profile id the
+   dub editor's Voice <select> can't render, so every such row silently read
+   "Default" even though a speaker clone existed. The fix binds segments to
+   the UI-visible `auto:{speaker}` whenever that speaker has a clone, and only
+   falls back to `auto-seg:` when the speaker has no per-speaker clone at all.
+
+2. Generate-time *resolution* (api.routers.dub_generate `_gen`). An
+   `auto:{speaker}` binding must still prefer THIS segment's own per-segment
+   ref (cut from its source line → matches its prosody) when one exists, and
+   fall back to the per-speaker clone otherwise. That keeps the Wave 3.2
+   per-segment-ref quality win while every segment carries the renderable
+   `auto:` id.
+"""
+from __future__ import annotations
+
+import os
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import asyncio
+import json
+
+import pytest
+import torch
+
+from schemas.requests import DubRequest
+
+
+SR = 24000
+
+
+# ── Part 1: the assignment loop (extracted to match dub_core's logic) ──────
+#
+# dub_core.py assigns each segment's default profile_id inside the transcribe
+# stream coroutine, which needs the full ASR/diarization stack to reach. The
+# loop itself is pure dict-munging, so we replicate it verbatim here and assert
+# the contract. If dub_core's loop drifts from this, the test below that hits
+# the real generate path still guards the user-visible behaviour.
+
+def _assign_default_profiles(final_segs, clones, seg_clones):
+    """Mirror of dub_core.py's post-diarization assignment loop (#486)."""
+    from services.speaker_clone import auto_profile_id
+
+    for s in final_segs:
+        if s.get("profile_id"):
+            continue
+        spk = s.get("speaker_id") or "Speaker 1"
+        if spk in clones:
+            s["profile_id"] = auto_profile_id(spk)
+            continue
+        sid = str(s.get("id", ""))
+        if sid and sid in seg_clones:
+            s["profile_id"] = f"auto-seg:{sid}"
+    return final_segs
+
+
+def test_segments_bind_to_speaker_clone_not_auto_seg():
+    """Long lines with a per-segment ref still get the UI-visible auto:{spk}."""
+    clones = {
+        "Speaker 1": {"ref_audio": "/v/spk1.wav", "ref_text": "one"},
+        "Speaker 2": {"ref_audio": "/v/spk2.wav", "ref_text": "two"},
+    }
+    # Both lines are long enough to have their own per-segment ref.
+    seg_clones = {
+        "s0": {"ref_audio": "/v/seg0.wav", "ref_text": "line0"},
+        "s1": {"ref_audio": "/v/seg1.wav", "ref_text": "line1"},
+    }
+    segs = [
+        {"id": "s0", "speaker_id": "Speaker 1"},
+        {"id": "s1", "speaker_id": "Speaker 2"},
+    ]
+    _assign_default_profiles(segs, clones, seg_clones)
+    # The bug: these would have been "auto-seg:s0"/"auto-seg:s1" → render as
+    # "Default" in the editor. The fix: the renderable per-speaker id.
+    assert segs[0]["profile_id"] == "auto:speaker_1"
+    assert segs[1]["profile_id"] == "auto:speaker_2"
+
+
+def test_manual_override_is_never_clobbered():
+    clones = {"Speaker 1": {"ref_audio": "/v/spk1.wav", "ref_text": "one"}}
+    seg_clones = {"s0": {"ref_audio": "/v/seg0.wav", "ref_text": "l0"}}
+    segs = [{"id": "s0", "speaker_id": "Speaker 1", "profile_id": "my-saved-voice"}]
+    _assign_default_profiles(segs, clones, seg_clones)
+    assert segs[0]["profile_id"] == "my-saved-voice"
+
+
+def test_seg_ref_fallback_when_speaker_has_no_clone():
+    """A speaker with no per-speaker clone but a single long line still binds
+    to its own per-segment ref (renders as Default, but generation works)."""
+    clones = {}  # no speaker reached the per-speaker MIN duration
+    seg_clones = {"s0": {"ref_audio": "/v/seg0.wav", "ref_text": "l0"}}
+    segs = [{"id": "s0", "speaker_id": "Speaker 7"}]
+    _assign_default_profiles(segs, clones, seg_clones)
+    assert segs[0]["profile_id"] == "auto-seg:s0"
+
+
+def test_no_clones_leaves_default():
+    segs = [{"id": "s0", "speaker_id": "Speaker 1"}]
+    _assign_default_profiles(segs, {}, {})
+    assert "profile_id" not in segs[0] or not segs[0]["profile_id"]
+
+
+# ── Part 2: generate-time resolution through the real dub_generate path ─────
+
+
+class _RefCapturingModel:
+    """Records the (ref_audio, ref_text) it was asked to clone from, per call,
+    so the test can assert which reference the resolver picked."""
+
+    sampling_rate = SR
+
+    def __init__(self):
+        self.refs: list[tuple] = []
+
+    def generate(self, text=None, ref_audio=None, ref_text=None, **kwargs):
+        self.refs.append((ref_audio, ref_text))
+        # 0.5 s of audio per segment — short enough to always "fit".
+        return [torch.full((1, int(0.5 * SR)), 0.1)]
+
+
+@pytest.fixture
+def patched_generate(monkeypatch, tmp_path):
+    import api.routers.dub_generate as dg
+
+    model = _RefCapturingModel()
+
+    async def _fake_get_model():
+        return model
+
+    job = {
+        "duration": 6.0,
+        "dubbed_tracks": {},
+        "speaker_clones": {
+            "Speaker 1": {"ref_audio": "/v/spk1.wav", "ref_text": "spk1 ref"},
+            "Speaker 2": {"ref_audio": "/v/spk2.wav", "ref_text": "spk2 ref"},
+        },
+        # Only seg id "0" has its own per-segment ref; "1" must fall back.
+        "segment_clones": {
+            "0": {"ref_audio": "/v/seg0.wav", "ref_text": "seg0 ref"},
+        },
+    }
+    job_dir = tmp_path / "jobX"
+    job_dir.mkdir()
+
+    monkeypatch.setattr(dg, "get_model", _fake_get_model)
+    monkeypatch.setattr(dg, "_get_job", lambda job_id: job)
+    monkeypatch.setattr(dg, "_save_job", lambda job_id, j: None)
+    monkeypatch.setattr(dg, "DUB_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        dg, "dub_seg_path",
+        lambda job_id, seg_id: str(job_dir / f"seg_{seg_id}.wav"),
+    )
+    monkeypatch.setattr(dg, "rvc_is_enabled", lambda: False)
+    monkeypatch.setattr(dg, "embed_watermark", lambda wav, sr: wav)
+    monkeypatch.setattr(dg, "apply_mastering", lambda a, sample_rate=None: a)
+    monkeypatch.setattr(dg, "get_effect_chain", lambda preset: None)
+    monkeypatch.setattr(dg, "apply_effects_chain", lambda a, **k: a)
+    monkeypatch.setattr(dg, "normalize_audio", lambda a, target_dBFS=None: a)
+
+    events: list[str] = []
+
+    class _StubTaskManager:
+        def is_cancelled(self, task_id):
+            return False
+
+        async def add_task(self, task_id, task_type, func, *args, **kwargs):
+            async for evt in func(*args):
+                events.append(evt)
+
+    monkeypatch.setattr(dg, "task_manager", _StubTaskManager())
+
+    def run(body: dict):
+        events.clear()
+        req = DubRequest(**body)
+        asyncio.run(dg.dub_generate("jobX", req))
+        return model
+
+    return run
+
+
+def test_auto_speaker_prefers_per_segment_ref_then_falls_back(patched_generate):
+    """seg0 has its own per-segment ref → use it; seg1 has none → per-speaker."""
+    body = {
+        "segments": [
+            {"start": 0.0, "end": 3.0, "text": "hola", "profile_id": "auto:speaker_1"},
+            {"start": 3.0, "end": 6.0, "text": "buenas", "profile_id": "auto:speaker_2"},
+        ],
+        "segment_ids": ["0", "1"],
+        "language": "Auto",
+        "language_code": "es",
+        "num_step": 4,
+        "timing_strategy": "concise",
+    }
+    model = patched_generate(body)
+    assert len(model.refs) == 2
+    # seg0: per-segment ref wins over Speaker 1's per-speaker clone.
+    assert model.refs[0] == ("/v/seg0.wav", "seg0 ref")
+    # seg1: no per-segment ref → Speaker 2's per-speaker clone.
+    assert model.refs[1] == ("/v/spk2.wav", "spk2 ref")
+
+
+def test_auto_speaker_uses_per_speaker_clone_when_no_segment_refs(patched_generate):
+    """With no segment_clones at all, auto:{speaker} resolves to per-speaker."""
+    body = {
+        "segments": [
+            {"start": 0.0, "end": 3.0, "text": "hola", "profile_id": "auto:speaker_1"},
+        ],
+        "segment_ids": ["99"],  # id not in segment_clones
+        "language": "Auto",
+        "language_code": "es",
+        "num_step": 4,
+        "timing_strategy": "concise",
+    }
+    model = patched_generate(body)
+    assert model.refs[0] == ("/v/spk1.wav", "spk1 ref")


### PR DESCRIPTION
## Problem
Dubbing a multi-speaker video: diarization detects both speakers and per-speaker clones get created (the Voice dropdown shows **From Video → Speaker 1 / Speaker 2**), but most segments are left on **Default** voice instead of being auto-bound to their detected speaker's clone. A row correctly labelled `Speaker 1` reads Voice = `Default`. Inconsistent across runs — short lines sometimes show the cloned voice, long lines don't. (Sub-bug 1 of #486.)

## Root cause
After diarization, `backend/api/routers/dub_core.py` defaults each segment's `profile_id`. With per-segment refs on (the default), every line ≥3s was stamped `auto-seg:{id}`. The dub editor's Voice `<select>` (and the Cast panel) in `DubSegmentRow.jsx` / `DubTab.jsx` only render `auto:{speaker}` options ("From Video → Speaker N") — an `auto-seg:` value matches **no** `<option>`, so the row silently falls back to displaying "Default". Short lines (<3s) had no per-segment ref and fell through to `auto:{speaker}`, which *does* render — exactly the "sometimes it's picked" inconsistency. The frontend has zero handling of the `auto-seg:` prefix.

## Fix
- `dub_core.py`: bind every segment to the UI-visible `auto:{speaker}` whenever its detected speaker has a clone. Only fall back to `auto-seg:{id}` when the speaker has **no** per-speaker clone at all (rare: too little usable audio overall, but a single long line still has its own ref).
- `dub_generate.py`: the per-segment-ref quality win is preserved transparently — the `auto:` resolution branch now prefers THIS segment's own per-segment ref (`segment_clones[seg_id]`) when present, else the per-speaker clone. So a row shown as "Speaker 1" still clones from its own line's source audio when long enough.

Backward-compatible: manual overrides and the no-clone path are untouched; existing jobs that already persisted `auto-seg:` ids still resolve via the retained `auto-seg:` branch. No schema change, no version bump, no user-facing strings (no i18n/docs impact).

### Sub-bug 2 (speaker turns merged onto one line) — investigated, not fixed here
Root cause is clear but the fix is **not** low-risk, so it's documented rather than shipped: segmentation runs **before** diarization (`segment_transcript` → `_build_segments_from_words` groups words by sentence/duration only), and `assign_speakers_from_diarization` only **relabels** existing segments by majority overlap — it never **re-splits** a segment that spans two speakers. When the merge/stitch passes run, every segment still carries the placeholder `speaker_id="Speaker 1"`, so the "never merge across a speaker boundary" rule is a no-op. A correct fix needs diarization turns fed back as split boundaries (or a speaker-aware re-split pass), which touches the broadcast-grade segmentation rules and risks regressing single-speaker timing. Left for a dedicated change.

## Tests
`tests/test_dub_multispeaker_voice_486.py` (top-level, `asyncio.run`):
- assignment binds to `auto:{speaker}` (not `auto-seg:`) when a speaker clone exists
- never clobbers a manual override
- falls back to `auto-seg:` only when the speaker has no clone; leaves Default when no clones exist
- generate-time resolution prefers the per-segment ref, then the per-speaker clone

Green alongside `test_segment_refs`, `test_smart_fit_generate`, `test_redub_incremental`, `test_assign_speakers_*`, `test_segmentation`, `test_dub_transcribe`, `test_dub_timing_strategy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes automatic voice assignment in multi-speaker dubbing workflows where segments were inconsistently bound to the "Default" voice despite having detected speaker clones available.

### The Problem

When diarization detects multiple speakers and creates per-speaker voice clones:
- Segments longer than 3 seconds received `auto-seg:{segment_id}` as their `profile_id` (per-segment reference)
- The dub editor's Voice dropdown only renders speaker-level options: `auto:{speaker}` ("From Video → Speaker N")
- Since `auto-seg:` doesn't match any rendered `<option>`, the UI silently fell back to "Default"
- Shorter segments correctly used `auto:{speaker}`, which renders properly
- **Result**: unpredictable "sometimes picked" behavior—long lines showed "Default" while short lines showed the cloned voice

### The Fix

Two coordinated changes restore correct behavior while preserving per-segment voice quality:

#### 1. **Segment Binding** (`dub_core.py`)
After diarization completes, the assignment loop now:
- For each segment without a manual `profile_id` override:
  - If the segment's detected speaker has a per-speaker clone → bind to `auto:{speaker}` (UI-visible)
  - Else if the segment has a per-segment reference → bind to `auto-seg:{segment_id}` (fallback)
  - Else → leave unset

This ensures every segment carries a renderable `auto:{speaker}` binding when its speaker has a clone.

#### 2. **Generate-Time Resolution** (`dub_generate.py`)
When an `auto:{speaker}` binding is encountered during voice synthesis:
- **First**: check `job["segment_clones"][segment_id]` for a per-segment reference
  - If present, use it (this segment's own audio → better prosody match)
- **Second**: fall back to the per-speaker clone in `job["speaker_clones"]`
  - If present, use it

This preserves the Wave 3.2 per-segment-reference quality advantage while keeping the UI-visible binding stable.

### Resolution Flow

```
┌─────────────────────────────────────────────────────────────────┐
│ BINDING (dub_core.py after diarization)                         │
├─────────────────────────────────────────────────────────────────┤
│                                                                 │
│  For each segment s:                                           │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Has manual profile_id? ──Yes──> Skip (preserve override)  │ │
│  └─────────────────────────────────────────────────────────┘ │
│        │ No                                                    │
│        ↓                                                       │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Speaker in speaker_clones? ──Yes──> Bind to auto:{spk}   │ │
│  │                                                            │ │
│  │            (UI-visible, renders in Voice dropdown)        │ │
│  └─────────────────────────────────────────────────────────┘ │
│        │ No                                                    │
│        ↓                                                       │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Segment in segment_clones? ──Yes──> Bind to auto-seg:{id}│ │
│  │                                                            │ │
│  │     (Fallback: editor can't render, but generation works) │ │
│  └─────────────────────────────────────────────────────────┘ │
│        │ No                                                    │
│        ↓                                                       │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Leave unset (no clone available)                           │ │
│  └─────────────────────────────────────────────────────────┘ │
│                                                                 │
└─────────────────────────────────────────────────────────────────┘
                                ↓
┌─────────────────────────────────────────────────────────────────┐
│ RESOLUTION (dub_generate.py during synthesis)                   │
├─────────────────────────────────────────────────────────────────┤
│                                                                 │
│  For profile_id = "auto:{speaker}":                            │
│                                                                 │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Check segment_clones[segment_id]? ──Present──> Use it    │ │
│  │                                                            │ │
│  │      (This segment's own audio: best prosody match)      │ │
│  └─────────────────────────────────────────────────────────┘ │
│        │ Not present                                          │
│        ↓                                                       │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Check speaker_clones[speaker]? ──Present──> Use it       │ │
│  │                                                            │ │
│  │             (Per-speaker clone: fallback)                │ │
│  └─────────────────────────────────────────────────────────┘ │
│        │ Not present                                          │
│        ↓                                                       │
│  ┌───────────────────────────────────────────────────────────┐ │
│  │ Generate without voice reference (no clone available)     │ │
│  └─────────────────────────────────────────────────────────┘ │
│                                                                 │
└─────────────────────────────────────────────────────────────────┘
```

### Backward Compatibility

- Manual voice overrides are never touched
- Existing jobs with persisted `auto-seg:` IDs continue to resolve correctly in generation
- No-clone paths and fallback logic remain unchanged
- All existing multi-speaker and single-speaker workflows unaffected

### Testing

New test suite (`tests/test_dub_multispeaker_voice_486.py`) validates:
- Long segments with per-segment refs bind to `auto:{speaker}` (not `auto-seg:`)
- Manual `profile_id` overrides are preserved
- Speakers without per-speaker clones fall back to per-segment refs
- No clones → profile_id remains unset (default behavior)
- Generate-time resolution prefers per-segment ref, then per-speaker clone
- Integration tests through the real `dub_generate` path with patched model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->