### PR TITLE
fix(bootstrap): force-reinstall setuptools so pkg_resources repair works (#248)

### DIFF
--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -32,7 +32,7 @@ _REDACTED_VALUE = "***REDACTED***"
 # One-line "what to do" per docs-taxonomy key. Keys mirror error_docs_map's
 # taxonomy; the docs URL itself stays owned by error_docs_map.
 _HINTS: dict[str, str] = {
-    "PKG_RESOURCES_MISSING": "Install setuptools in the backend environment (provides pkg_resources).",
+    "PKG_RESOURCES_MISSING": "Run `uv pip install --reinstall 'setuptools>=75,<80'` in the backend venv (a plain install is skipped when setuptools' metadata is present but its pkg_resources files were removed by antivirus). Restart after.",
     "GATEKEEPER_QUARANTINE": "Clear the macOS quarantine flag (xattr -cr the app), then reopen.",
     "APPIMAGE_WEBKIT_WHITESCREEN": "Launch with WEBKIT_DISABLE_DMABUF_RENDERER=1 set.",
     "HF_AUTH_FAILED": "Set a valid HF_TOKEN in Settings → Hugging Face and retry.",

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -39,14 +39,27 @@ Before digging through the entries below, let the app diagnose itself:
 "Setting up models" step.
 
 **Cause:** WhisperX (and a couple of its transitive deps) still imports
-`pkg_resources`, which was removed from `setuptools >= 70`. Older `uv sync`
-runs would resolve `setuptools` to a version that no longer ships it.
+`pkg_resources`, which `setuptools >= 80` dropped. `pyproject.toml` pins
+`setuptools>=75,<80` so it stays present — but the venv can still lose it two
+other ways: **(a)** antivirus (commonly Windows Defender) quarantines
+`pkg_resources`' files, or **(b)** a partial/interrupted extract. In both cases
+setuptools' *metadata* remains, so `uv`/`pip` report it "already satisfied" and
+a plain install **no-ops** — the files are never restored.
 
-**Fix:** pull the latest `main`. `pyproject.toml` now pins
-`setuptools>=70,<81` and the WhisperX dep is patched to import from
-`importlib.metadata` first.
+**Fix:** in the backend venv, **force a reinstall** (a plain install won't work
+for the reasons above):
 
-**Linked issue:** [#58](https://github.com/debpalash/OmniVoice-Studio/issues/58)
+```
+uv pip install --reinstall 'setuptools>=75,<80'
+```
+
+then restart. If it recurs, your antivirus is removing the files again — add the
+backend **`.venv`** folder to its exclusions (Windows Security → Virus & threat
+protection → Exclusions). The app's auto-repair now uses `--reinstall` too, so a
+fresh install heals itself.
+
+**Linked issues:** [#58](https://github.com/debpalash/OmniVoice-Studio/issues/58),
+[#248](https://github.com/debpalash/OmniVoice-Studio/issues/248)
 
 ## 2. HF 401 / pyannote license not accepted
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -733,12 +733,16 @@ the existing venv; newly added dependencies may be missing (#307)",
             if !pr_ok {
                 log::warn!("pkg_resources still missing after repair sync — installing setuptools<80 directly (#248)");
                 emit_log(app, "installing_deps",
-                    "Repairing pkg_resources: installing setuptools<80 (#248)");
+                    "Repairing pkg_resources: force-reinstalling setuptools<80 (#248)");
                 let mut st_cmd = Command::new(&uv_path);
                 scrub_python_env(&mut st_cmd);
                 apply_uv_http_env(&mut st_cmd);
                 st_cmd
-                    .args(["pip", "install", "setuptools>=75,<80"])
+                    // --reinstall: when the venv has setuptools's *metadata* but its
+                // pkg_resources files were removed (antivirus quarantine, partial
+                // extract), a plain `pip install` sees it "already satisfied" and
+                // no-ops — only a forced reinstall re-extracts pkg_resources (#248).
+                .args(["pip", "install", "--reinstall", "setuptools>=75,<80"])
                     .current_dir(&project_dir);
                 match run_streaming(app, "installing_deps", &mut st_cmd) {
                     Ok(ref s) if s.success() => {
@@ -767,9 +771,12 @@ the existing venv; newly added dependencies may be missing (#307)",
                     fail(
                         progress,
                         "pkg_resources is missing from the backend venv and the automatic \
-                         setuptools repair did not restore it. Open a terminal and run \
-                         `uv pip install 'setuptools>=75,<80'` in the backend venv, then \
-                         restart. (#248)",
+                         setuptools repair did not restore it — its files were likely removed \
+                         by antivirus or left by a partial install (the metadata is still there, \
+                         so a plain reinstall is skipped). Open a terminal in the backend venv \
+                         and run `uv pip install --reinstall 'setuptools>=75,<80'`, then restart. \
+                         If it recurs, add the backend `.venv` folder to your antivirus \
+                         exclusions. (#248)",
                     );
                     return None;
                 }
@@ -955,12 +962,16 @@ docs/install/troubleshooting.md).",
         if !pr_ok {
             log::warn!("pkg_resources not importable after uv sync — installing setuptools<80 (#248)");
             emit_log(app, "installing_deps",
-                "pkg_resources missing (setuptools>=80) — installing setuptools<80 to fix (#248)");
+                "pkg_resources missing — force-reinstalling setuptools<80 to fix (#248)");
             let mut st_cmd = Command::new(&uv_path);
             scrub_python_env(&mut st_cmd);
             apply_uv_http_env(&mut st_cmd);
             st_cmd
-                .args(["pip", "install", "setuptools>=75,<80"])
+                // --reinstall: when the venv has setuptools's *metadata* but its
+                // pkg_resources files were removed (antivirus quarantine, partial
+                // extract), a plain `pip install` sees it "already satisfied" and
+                // no-ops — only a forced reinstall re-extracts pkg_resources (#248).
+                .args(["pip", "install", "--reinstall", "setuptools>=75,<80"])
                 .current_dir(&project_dir);
             match run_streaming(app, "installing_deps", &mut st_cmd) {
                 Ok(ref s) if s.success() => {


### PR DESCRIPTION
## Problem
Windows users hit a setup dead-end (reported on Discord, Win11 + RTX 5070 Ti):
> pkg_resources is missing from the backend venv and the automatic setuptools repair did not restore it…

The logs show the repair *ran* but **"Checked 1 package in 5 ms"** — a no-op.

## Root cause
`bootstrap.rs` repaired with `uv pip install setuptools>=75,<80`. When setuptools' **metadata** is present but its `pkg_resources` **files were removed** (Windows Defender quarantine of `pkg_resources/`, or a partial extract on a restricted network), `uv`/`pip` see it "already satisfied" and **no-op** — the files are never restored, the post-check fails, and the user is stuck. The error message even told them to run the *same* no-op command, so the suggested manual fix also failed.

## Fix
- Both repair sites (`bootstrap.rs:~741` and `~963`) now use **`--reinstall`** (the flag already used for the ROCm torch repair at `:406`), force-re-extracting `pkg_resources` regardless of metadata.
- The `fail()` message + `failure.py` `PKG_RESOURCES_MISSING` hint now say `uv pip install --reinstall 'setuptools>=75,<80'` + add an **antivirus-exclusion** note.
- `docs/install/troubleshooting.md#pkg_resources-missing` rewritten with the real cause (metadata-present / files-missing) and AV guidance; links #248.

A fresh install now self-heals; the manual fallback actually works.

## Verification
`cargo check` clean (0 errors). Python parse OK. Docs-sync: troubleshooting updated in this PR. No version bump.

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

Windows users encountered `ModuleNotFoundError: No module named 'pkg_resources'` during dubbing operations. The root cause was setuptools metadata existing in the virtual environment while the actual `pkg_resources` files were missing—typically due to Windows Defender quarantine or partial extraction on restricted networks. The automatic repair mechanism would run but as a no-op, since package managers treat setuptools as "already satisfied" when metadata is present, leaving files unrestored.

## Solution

The fix implements a forced reinstall strategy by adding the `--reinstall` flag to the setuptools repair commands. This ensures `pkg_resources` files are re-extracted regardless of metadata presence, aligning with existing ROCm torch repair logic already present in the codebase.

## Changes Made

**backend/core/failure.py** (+1/-1)
- Updated `PKG_RESOURCES_MISSING` hint to recommend `uv pip install --reinstall 'setuptools>=75,<80'`

**docs/install/troubleshooting.md** (+21/-8)
- Rewrote the `pkg_resources` troubleshooting section explaining the metadata-vs-files mismatch root cause
- Added specific failure modes and antivirus quarantine guidance
- Updated fix instructions to use the forced reinstall approach
- Added `.venv` antivirus exclusion recommendations

**frontend/src-tauri/src/bootstrap.rs** (+18/-7)
- Added `--reinstall` flag to both setuptools repair command sites (~741 and ~963)
- Updated error messages and log text to reflect the new repair strategy
- Expanded user-facing failure text with terminal command guidance and antivirus-exclusion wording

## Repair Flow

```mermaid
flowchart TD
    A["pkg_resources import check"] --> B{Import successful?}
    B -->|Yes| C["Continue"]
    B -->|No| D["Run: uv pip install --reinstall setuptools>=75,<80"]
    D --> E{Import successful?}
    E -->|Yes| C
    E -->|No| F["Display error with antivirus + manual fix guidance"]
    F --> G["Suggest: uv pip install --reinstall 'setuptools>=75,<80'<br/>and add .venv to antivirus exclusions"]
```

References and closes issue `#248`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->