### PR TITLE
docs(planning): singing-mode + donate-cta specs

### DIFF
--- a/.planning/decisions/SPIKE-02-singing.md
+++ b/.planning/decisions/SPIKE-02-singing.md
@@ -1,9 +1,16 @@
 # SPIKE-02: Adopt `ModelsLab/omnivoice-singing` as singing variant of the existing engine
 
-**Status:** Proposed (research-supported) — awaiting Phase 2 SubprocessBackend merge
-**Date:** 2026-05-18
+**Status:** ⚠️ **SUPERSEDED (2026-06-14)** by [`specs/006-dubbing-singing-mode/`](../../specs/006-dubbing-singing-mode/spec.md)
+**Date:** 2026-05-18 (superseded 2026-06-14)
 **Decision-makers:** [maintainer]
 **Related:** ROADMAP Phase 4; REQUIREMENTS SING-01..05; `.planning/phases/04-adaptive-specialty-engines-spike-first/04-RESEARCH.md`
+
+> **Superseded:** This chose `ModelsLab/omnivoice-singing` for singing, but that
+> model has **no melody (F0/MIDI) conditioning** — it sings its own melody and
+> cannot follow the *source song* a dub must preserve. SoulX-Singer (arXiv
+> 2602.07803, published after this decision) provides F0/MIDI conditioning and is
+> selected in plan-06. This ADR stays valid only if reframed as an
+> expressive-TTS styling toggle, not melody-matched dubbing.
 
 ## Context
 

--- a/specs/006-dubbing-singing-mode/plan.md
+++ b/specs/006-dubbing-singing-mode/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan: Dubbing Singing / Music Mode (plan-06)
+
+**Branch**: `006-dubbing-singing-mode` | **Date**: 2026-06-14 | **Spec**: [spec.md](./spec.md)
+**Decision**: **v1 = Option A (SVS-only)** — integrate **Soul-AILab/SoulX-Singer
+(SVS, PyTorch)** as a `SubprocessBackend` sidecar; reuse Demucs stems for
+F0-conditioned, melody-matched cross-language dub vocals. **SVC = Phase 5
+fast-follow** (same sidecar, `--component svc`). Per-segment auto-routing deferred.
+See spec "v1 scope decision" for the pros/cons/goals matrix.
+
+## Summary
+
+Singing dubbing needs melody preservation, which requires F0/MIDI conditioning —
+only SoulX-Singer provides it. The pipeline already produces the inputs we need
+(Demucs `vocals.wav` + `no_vocals.wav`) and throws them away. The work is: (1)
+de-risk SoulX inference quality + VRAM in a spike, (2) wrap it as a sidecar, (3)
+extract F0 from the existing vocal stem and mix output over the existing
+instrumental stem, (4) expose an opt-in `tts_mode: "singing"` and route to it
+(closing the hard-coded-`_model` TODO #312).
+
+## Constitution Check
+
+| Principle | Status |
+|-----------|--------|
+| I. Local-First | ✅ weights from HF, runs locally, no telemetry; license-gated download (SING-R5) |
+| II. First-Run Works | ✅ default speech dub unchanged; singing is additive opt-in |
+| III. Cross-Platform Parity | ✅ PyTorch CUDA/MPS/CPU; F0 extraction stdlib/torch — identical on all 3 OSes (SING-R6). EN/CN-only coverage is an explicit gated mode, not a divergent default (SING-R3) |
+| IV. Backward-Compatible | ✅ new sidecar engine; no change to existing engines, models, or `omnivoice_data/`; no schema change |
+| V. Root-Cause + Regression Tests | ✅ F0-extraction + mix-back + mode-routing unit tests; sidecar smoke test |
+| Versioning | ✅ ships under v0.3.x rolling main |
+| Docs-sync | ✅ `docs/dubbing.md` + engine card copy updated in the same PR that ships the mode |
+
+## Architecture — reuse the stems we already pay for
+
+```
+dub_pipeline.py:798  Demucs ─┬─ vocals.wav  ──► F0 extract (SoulX Preprocess) ──┐
+                             │                                                   ▼
+                             │                 translated lyrics ──► SoulX-Singer SVS sidecar ──► vocal.wav
+                             └─ no_vocals.wav ──────────────────────────────────────────────────┐
+                                                                                          mix ◄──┘
+                                                                                           │
+                                                                                  dubbed sung track
+```
+
+Today both stems are produced and discarded. Singing mode keeps them: F0 from the
+vocal stem conditions the synth; the instrumental stem is the bed.
+
+## Phases
+
+### Phase 1 — Spike (GATING; do before any integration)
+De-risk the model before writing engine code.
+- Pull SVS weights (`model.pt`, 2.7 GB) + `SoulX-Singer-Preprocess` repo.
+- Run `example/infer.sh` on one clip: translated lyrics + an F0 contour extracted
+  from a real dub `vocals.wav`. Confirm: output follows the melody, intelligible,
+  acceptable artifacts.
+- **Answer the alignment question (SING-R7):** does SVS auto-align free lyric text
+  to the F0 contour, or does it require per-note aligned lyrics? This determines
+  whether Phase 3 needs the syllable-budget pass — it is the single highest-risk
+  unknown in the whole feature.
+- Record **VRAM headroom** + latency on CUDA / MPS / CPU.
+- **Flip spec Status → Accepted (or descope) based on the result.** A poor F0-match
+  here kills the feature cheaply.
+
+### Phase 2 — Sidecar scaffold
+- New `backend/engines/soulx/` — `__init__.py` (`SoulXSingerBackend(SubprocessBackend)`,
+  implements `venv_python()` + `sidecar_script()`) + `main.py` (stdlib-only at
+  import; length-prefixed JSON IPC; lazy model load on first `synthesize` to stay
+  inside the 30 s spawn window — per `subprocess_backend.py:59-150`).
+- **Inference wrapper:** call SoulX's own inference modules using the param shape
+  documented by `ailuntx/SoulX-Singer-MLX`'s `scripts/inference_mlx_bridge.py`
+  (`--component svs|svc`, `--control melody`, `--device`, F0 `.npy` I/O) — that
+  CLI is the reference contract; we do **not** depend on the `mlx` pip package
+  (Apple-only). Device resolves to MPS on Apple, CUDA/CPU elsewhere (SING-R6).
+- Own py3.10 venv (SoulX pins conda py3.10); zero parent-dep leakage (SING-R4).
+- Register in `_LAZY_REGISTRY` (`tts_backend.py:1065`) + install hint
+  (`tts_backend.py:1159`). Set `sample_rate=24000`, `supported_languages=["en","zh"]`,
+  `gpu_compat=("cuda","mps","cpu")`.
+- Model manifest: add SoulX-Singer (+ Preprocess) to `config/models.yaml`
+  (`required: false`, license-gated per SING-R5).
+
+### Phase 3 — F0 + singable lyrics + mix-back in the dub pipeline
+- In `dub_pipeline.py`, surface `vocals.wav`/`no_vocals.wav` paths to the generator
+  (currently dropped after Demucs, ~L823).
+- Extract F0 from `vocals.wav` via the SoulX Preprocess models; pass as a sidecar
+  `synthesize` param (SING-R1).
+- **Singable-lyrics step (SING-R7 — the make-or-break):** the translated lyrics
+  must align to the source melody's syllable/note count, or words won't slot onto
+  notes. v1 approach depends on what Phase 1 finds:
+  - **If SoulX-SVS auto-aligns** free lyric text to the F0 contour → feed
+    translated text directly; no extra work.
+  - **If SoulX needs per-note aligned lyrics** → v1 ships a **best-effort
+    syllable-budget pass** (constrain/pad the MT output toward the source syllable
+    count) and labels output "experimental"; full singable-translation (rhyme,
+    meter) is explicitly deferred. **Do not ship pretending generic MT is singable.**
+- Mix synthesized vocal over `no_vocals.wav` instead of discarding it (SING-R2).
+- **Video:** no new work — the resulting audio track flows through the existing
+  dub video remux (`dub_export.py`); singing mode only swaps the audio.
+
+### Phase 4 — Opt-in mode + routing (closes TODO #312)
+- `schemas/requests.py`: add `tts_mode: Optional[str] = "speech"` to `DubRequest`.
+- `dub_generate.py:198-260`: when `tts_mode=="singing"`, route to the SoulX sidecar
+  via `get_active_tts_backend()`-style selection instead of the hard-coded `_model`
+  singleton (this is exactly the TODO #312 cleanup).
+- `frontend/src/pages/DubTab.jsx`: add a mode toggle (mirror the existing
+  translation-engine picker at ~L232-259). Gate visibility / show EN-CN-only +
+  license note. All strings via i18n (`locales/*.json`).
+
+### Phase 5 — SVC fast-follow (post-v1, no rework)
+- Same sidecar, `synthesize(component="svc")`; download `model-svc.pt` (2.7 GB,
+  opt-in). Adds: same-language "convert the singer's voice" for all 646 langs
+  (G2/G4/G5) and an optional SVS→SVC polish pass. No engine/architecture change —
+  only a `component` param + a second gated weight in `config/models.yaml`.
+
+## Cost / effort
+
+| Item | Cost |
+|---|---|
+| User disk (opt-in) | ~5.3 GB SVS + Preprocess repo |
+| Parent deps added | 0 (sidecar-isolated) |
+| VRAM | measured in Phase 1; budget ~4–6 GB w/ CPU fallback |
+| Dev surface | 1 new engine dir, `config/models.yaml` entry, `dub_pipeline.py` stem-reuse, `DubRequest` field, `dub_generate.py` route, DubTab toggle + i18n keys, `docs/dubbing.md` |
+| Risk concentration | Phase 1 (F0-match quality) and Demucs vocal-stem cleanliness |
+
+## Tests
+
+- `tests/test_soulx_sidecar.py` (top-level — avoids the `tests/backend/`
+  sys.modules-isolation collection leak): sidecar handshake (ready/ping/synthesize/
+  shutdown), F0-param passthrough, EN/CN language gating, `unload()` idempotency.
+  Use `asyncio.run()` per test, not `get_event_loop()`.
+- F0-extraction + mix-back unit tests (deterministic fixture vocal stem).
+- Mode-routing test: `tts_mode="speech"` unchanged; `"singing"` hits the sidecar.
+- Frontend vitest: DubTab mode toggle gating + i18n.
+- Gate is `typecheck:ci` (`tsc --noEmit --checkJs false`), full backend + frontend
+  suites green before merge.
+
+## Open questions (resolve in Phase 1)
+
+1. Does SoulX accept an externally-extracted F0 directly, or does its Preprocess
+   pipeline require the *source* audio (forcing us to feed it the vocal stem)?
+2. VRAM ceiling on 4–6 GB GPUs — is CPU fallback latency tolerable for a dub job?
+3. ~~SVC scope~~ **RESOLVED** — v1 = SVS-only (Option A); SVC is Phase 5. See spec
+   "v1 scope decision".
+
+## Out of scope (carried from spec)
+
+Per-segment singing/speech auto-routing; MLX Mac accelerator; `omnivoice-singing`
+`[singing]`-tag expressive-TTS toggle. (SVC is **not** out of scope — it's Phase 5.)

--- a/specs/006-dubbing-singing-mode/spec.md
+++ b/specs/006-dubbing-singing-mode/spec.md
@@ -1,0 +1,192 @@
+# Feature Specification: Dubbing Singing / Music Mode
+
+**Feature Branch**: `006-dubbing-singing-mode` | **Created**: 2026-06-14
+**Status**: Investigation complete — model selected, awaiting spike (Phase 1) sign-off
+**Input**: User request "music/singing mode for dubbing"; supersedes [`.planning/decisions/SPIKE-02-singing.md`](../../.planning/decisions/SPIKE-02-singing.md)
+**Related**: ROADMAP Phase 4 (specialty engines); TODO #312 (`dub_generate.py` engine-awareness)
+
+## Problem
+
+When OmniVoice dubs sung/musical source content, the pipeline routes the vocal
+through a **speech** TTS engine — it produces flat spoken output over what was a
+song. This is one of the loudest complaints on music-adjacent dubs. The pipeline
+already runs Demucs (`backend/services/dub_pipeline.py:798`) and produces a
+`vocals.wav` (sung performance) + `no_vocals.wav` (instrumental) — **then discards
+both** and re-synthesizes from scratch, throwing away the melody the user wants
+preserved.
+
+The hard requirement for *singing dubbing* (vs. generic "expressive TTS") is
+**melody preservation**: the translated lyrics must follow the original song's
+pitch/rhythm. That requires an engine that accepts an **F0 contour or MIDI** as a
+conditioning input. Generic singing-styled TTS that sings its *own* random melody
+does not solve dubbing.
+
+## Candidate evaluation
+
+Three HuggingFace repos were cloned (metadata-only) and evaluated against the dub
+pipeline on 2026-06-14.
+
+| Criterion | **A. Soul-AILab/SoulX-Singer** | **B. mlx-community/SoulX-Singer** | **C. ModelsLab/omnivoice-singing** |
+|---|---|---|---|
+| Type | Zero-shot **SVS (synth) + SVC (conversion)** | MLX repack of A | Expressive **TTS** w/ `[singing]` tag |
+| **Melody conditioning** | ✅ **F0 contour + MIDI** (required for dubbing) | ✅ same weights | ❌ **none** — style tag only |
+| Architecture | Flow-matching DiT, 22 layers / 1024-hidden, 128-mel, 24 kHz (`config.yaml`) | bf16/8/4-bit safetensors, 11+11 shards | Qwen3-0.6B + HiggsAudioV2 codec, 24 kHz |
+| Languages | EN + CN | EN + CN | 11 langs |
+| License | **Apache-2.0, clean** (weights + code) | Apache-2.0 (inherits A) | Apache-2.0 code, **trained on CC BY-NC-SA / CC BY-NC data → non-commercial taint propagates** |
+| Cross-platform | ✅ CUDA / MPS / CPU (PyTorch) | ❌ **Apple-Silicon only**; "not pure MLX" — still needs a PyTorch bridge | ✅ CUDA / MPS / CPU |
+| Packaging | raw `model.pt` (2.7 GB) + `model-svc.pt` (2.7 GB) + separate `SoulX-Singer-Preprocess` repo; conda py3.10; inference is `bash example/infer.sh` (no pip pkg, no library API) | safetensors shards + external bridge repo | drop-in `OmniVoice.from_pretrained()`, 2.3 GB + 0.77 GB codec |
+| Download | ~5.3 GB + Preprocess repo | ~2.6 GB (bf16) | ~3.1 GB |
+| Sample rate | 24 kHz (matches our default) | 24 kHz | 24 kHz |
+
+### Verdict
+
+- **A. SoulX-Singer (PyTorch) — SELECTED.** The only candidate that can
+  follow the source melody (F0/MIDI input), the only one with a clean Apache-2.0
+  that is safe to ship default-eligible, cross-platform, 24 kHz = matches our
+  pipeline. Inference is script-shaped with its own conda deps + a second
+  Preprocess repo, so it must run as a **subprocess sidecar** (the
+  `backend/engines/indextts` pattern), not in-process.
+- **B. MLX repack — DECLINED as a runtime, ADOPTED as the reference CLI.** The
+  weights pip-install `mlx` (Apple-only) and the repo is "not a pure MLX runtime"
+  (compute still bridges to PyTorch), so it is no faster today and can't be our
+  cross-platform engine. **But** its bridge entrypoint
+  [`ailuntx/SoulX-Singer-MLX`](https://github.com/ailuntx/SoulX-Singer-MLX)
+  `scripts/inference_mlx_bridge.py` is a clean argv CLI — `--component svs|svc`,
+  `--control melody`, `--device mps|cpu|cuda`, explicit F0 `.npy` I/O, bundled
+  Whisper for transcription-free prep — far better-shaped for a sidecar than the
+  original repo's opaque `bash example/infer.sh`. **Plan-06 wraps SoulX's own
+  inference modules using the param shape this bridge documents**, on Apple
+  through MPS and on Win/Linux through PyTorch CUDA/CPU, with no hard `mlx`
+  dependency.
+- **C. omnivoice-singing — DECLINED** (deep-verified 2026-06-14, repo cloned).
+  Disqualified for dubbing on four concrete points:
+  1. **No melody control of any kind.** `[singing]` is plain text the LM reads —
+     0 added/special tokens, and no pitch/F0/melody/note dimension anywhere in
+     `config.json` or the codec config. It generates its *own* melody; it cannot
+     follow the source song (fails SING-R1).
+  2. **Codec can't do music by design.** Model card: HiggsAudioV2 tokenizer is
+     "speech-domain tuned… Music / drum content is **not supported by design**."
+  3. **Light EN-only nursery finetune.** `[singing]` = GTSinger English only,
+     6,755 clips / ~8 h, eval loss ~4.74–4.88, "nursery-style melodic vocals."
+  4. **Non-commercial taint on the singing capability itself.** Apache-2.0 code,
+     but `[singing]` derives from GTSinger **CC BY-NC-SA 4.0 (research use)** and
+     emotion tags from RAVDESS/Expresso (CC BY-NC) — "downstream users must
+     comply." Shipping it into a commercially-used tool is a license landmine.
+
+  Its one strength is being a true drop-in (`OmniVoice.from_pretrained`, same arch
+  as our base, 0 new deps) — but that serves a *different* feature (an expressive
+  + nursery-singing **standalone-TTS toggle**), not music dubbing. **This reverses
+  SPIKE-02**, which chose C on 2026-05-18 before SoulX-Singer existed — see
+  Supersession note below.
+
+## SVS vs SVC — two capabilities, one model family
+
+SoulX ships two checkpoints with different dub roles. They are **not**
+interchangeable:
+
+| | **SVS** (`model.pt`, synthesis) | **SVC** (`model-svc.pt`, conversion) |
+|---|---|---|
+| Operation | translated lyrics + source F0 → new sung vocal | source vocal → re-timbred vocal (audio→audio) |
+| Translates language? | ✅ yes — the dubbing path | ❌ no — keeps source lyrics/language |
+| Inputs | lyrics (transcribe→translate) + F0 + ref voice | source audio + F0 `.npy`; **transcription-free, no MIDI** |
+| Language coverage | EN / CN only | **language-agnostic** (works for any of 646) |
+| Dub role | **cross-language song dubbing** (the core ask) | restyle/clone the singer; same-language; polish SVS output |
+
+**Implication:** only **SVS** satisfies "dub a song into another language"
+(SING-R1). **SVC** is a distinct, adjacent capability — it removes the EN/CN limit
+and the transcription brittleness, but it cannot change the lyrics' language. Two
+ways it pays off: (1) a same-language "convert the singer's voice" feature, and
+(2) an **SVS→SVC chain** where SVC unifies/cleans the SVS output timbre.
+
+## v1 scope decision
+
+Goals tracked: **G1** cross-language song dub (the literal ask) · **G2** all-646
+language coverage · **G3** melody preserved · **G4** timbre/voice control · **G5**
+robustness (transcription-free, no brittle ASR+MT) · **G6** small download/compute
+· **G7** fast ship / small dev surface.
+
+| Option | Pros | Cons | Goals achieved |
+|---|---|---|---|
+| **A. SVS-only** ✅ *recommended* | Matches the literal "dub a song into another language" ask; smallest scope; one checkpoint (~5.3 GB); SVC drops in later with **no rework** (sidecar already exposes `--component svc`) | EN/CN only; depends on transcribe→translate→F0 chain quality | **G1, G3, G7** (partial G6) |
+| **B. SVS + SVC chain** | Best output quality (SVC timbre-unifies the SVS vocal); both capabilities in one release | ~2× download (~10 GB) + 2× compute; slowest; largest surface; gated on *both* models passing the spike | **G1, G3, G4** (fails G6, G7) |
+| **C. SVC-first** | All-646 coverage now; transcription-free + robust; ships a usable "restyle the singer" feature fast | **Does not translate** → fails the core dub ask; "singing *dub* mode" that can't change language is self-contradictory | **G2, G3, G4, G5** (fails **G1**, G7) |
+
+No option hits every goal; **G1 (cross-language dub) is the original request and only
+A and B deliver it.** None of the three is foreclosed by another — the sidecar's
+`--component` switch makes A→B→C additive, not mutually exclusive.
+
+**Decision: ship Option A (SVS-only) as v1** — the smallest change that satisfies the
+literal ask (G1). **SVC becomes Phase 5**, a fast-follow adding G2/G4/G5 with no
+architecture change. Option C is rejected as v1 because a singing *dub* mode that
+can't change language contradicts the feature's intent.
+
+## Requirements
+
+- **SING-R1 (melody preservation):** Dubbed sung segments MUST follow the source
+  song's pitch/rhythm, derived from an F0 contour extracted from the Demucs
+  `vocals.wav` stem.
+- **SING-R2 (instrumental preservation):** The Demucs `no_vocals.wav` stem MUST
+  be mixed back under the synthesized vocal, untouched.
+- **SING-R3 (explicit opt-in mode):** Singing mode is a per-dub mode
+  (`tts_mode: "singing"`), never a silent default. SoulX is EN/CN-only, so the
+  language coverage diverges from the 646-lang speech default — it MUST be gated
+  + labeled, satisfying the "platform/feature parity or opt-in" rule.
+- **SING-R4 (sidecar isolation):** The engine runs as a `SubprocessBackend`
+  sidecar in its own py3.10 venv; zero new deps leak into the parent env.
+- **SING-R5 (license gating):** First-use download surfaces the SoulX Apache-2.0
+  license + model-card link and gates the ~5.3 GB download behind acceptance.
+- **SING-R6 (cross-platform):** Engine + F0 extraction work identically on
+  macOS / Windows / Linux (PyTorch CUDA/MPS/CPU). No platform-only behavior in
+  the default path.
+- **SING-R7 (singable lyrics):** Translated lyrics MUST align to the source
+  melody's syllable/note budget before synthesis. v1 ships at minimum a
+  best-effort syllable-budget pass; if SoulX-SVS auto-aligns free text (Phase 1
+  finding) this is a no-op. Output that relies on raw MT MUST be labeled
+  experimental. Full singable translation (rhyme/meter) is deferred.
+
+## Pros / Cons (selected approach)
+
+**Pros**
+- Solves the actual complaint: sung source → sung output that matches the tune.
+- Reuses ~70% of existing infra — Demucs stems are already produced and discarded.
+- Clean Apache-2.0; no commercial-use landmine.
+- Sidecar isolation = no risk to the parent env or other engines.
+- 24 kHz parity with the existing dub mixing path.
+
+**Cons / risks**
+- EN/CN only → mode is gated, not universal (acceptable; it's opt-in).
+- No pip package — sidecar wraps the repo's `infer.sh`-shaped scripts; more glue
+  than a library engine.
+- Two model artifacts (SVS 2.7 GB + optional SVC 2.7 GB) + Preprocess repo =
+  larger download than other engines.
+- F0-extraction quality on noisy/poly vocals bounds output quality; Demucs
+  bleed-through is the upstream risk.
+
+## Cost summary
+
+| | Estimate |
+|---|---|
+| Disk (user, first use) | ~5.3 GB SVS weights + Preprocess repo (gated, opt-in) |
+| VRAM | TBD by Phase 1 spike (flow-matching DiT @ 1024-hidden; budget ~4–6 GB, CPU fallback expected) |
+| New parent deps | **0** (isolated in sidecar venv) |
+| Dev effort | ~Phases 1–4 below; spike is the gating de-risk |
+
+## Out of scope
+
+- Per-*segment* singing/speech auto-routing (defer; mode applies per-dub job in v1).
+- SVC path is **deferred to Phase 5**, not cut — v1 ships SVS only.
+- The MLX runtime (option B) as an engine; its bridge CLI is still used as the
+  reference param shape.
+- **Lip-sync to video.** The singer's mouth won't match the dubbed audio (standard
+  dub limitation, more visible in close-ups). No visual re-sync in scope.
+- Full singable translation (rhyme, meter, prosody) — v1 is syllable-budget only.
+- A general "expressive TTS" `[singing]`-tag toggle (option C) — separate feature.
+
+## Supersession note
+
+This spec **supersedes `.planning/decisions/SPIKE-02-singing.md`** (Proposed,
+2026-05-18), which selected `ModelsLab/omnivoice-singing`. That decision predated
+SoulX-Singer (arXiv 2602.07803) and optimized for "zero new deps / ≤30-line
+subclass" — but the chosen model has **no melody conditioning**, so it cannot
+satisfy SING-R1 (the core of *dubbing* singing). SPIKE-02 remains valid only if
+the goal is reframed as expressive-TTS styling rather than melody-matched dubbing.

--- a/specs/007-donate-cta/plan.md
+++ b/specs/007-donate-cta/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Donate CTA — "Fund Claude Max" (plan-07)
+
+**Branch**: `007-donate-cta` | **Date**: 2026-06-16 | **Spec**: [spec.md](./spec.md)
+**Decision pending**: goal-number source A/B/C (rec **B** — committed `donation_progress.json` + best-effort fetch).
+
+## Constitution check
+| Principle | Status |
+|---|---|
+| Local-first | ✅ no telemetry; progress JSON is read-only fetch w/ bundled offline fallback |
+| First-run works | ✅ additive; postcard suppressed for first 3 successes + setup/errors |
+| Cross-platform parity | ✅ pure React/CSS/emoji/inline-SVG, no native deps; identical mac/Win/Linux |
+| Backward-compatible | ✅ extends `SupportPage`; zustand `persist` version bump + safe-default `migrate` |
+| i18n hard rule | ✅ every string a `t()` key in `i18n/locales/*.json` (26 locales) |
+| Docs-sync | ✅ FUNDING/README funding copy updated in the same PR if it changes |
+
+## Phasing (risk-ordered — ship Phase 1 alone first)
+1. **Goal bar + `donation_progress.json`** (self-contained, zero-risk) — the honest dated bar on `SupportPage`. Delivers value immediately, no triggers/state.
+2. **PIP mascot + postcard + `donationSlice`** — the mascot component, the `react-hot-toast` postcard, the frequency state machine, wired to the **success** branch of `completePill` + clone-save.
+3. **Milestones + nav-rail "Support" pill** — 1st clone / 10th dub / sustained; the quiet pill.
+4. **Discord** — `/donate` + `/donate top` + the one pinned #announcements post.
+
+## Phase 1 — goal bar (do first)
+- New `frontend/public/donation_progress.json` (or `config/`): `{ "raised": <real>, "goal": 200, "currency": "USD", "sponsorCount": <real>, "updated": "2026-06-16" }`. Owner edits this when sponsorship moves. **Open the bar at the real baseline (endowed progress), never a faked seed.**
+- `SupportPage.jsx`: add a `DonationGoal` section above the payment cards — reads the bundled JSON, optionally `fetch()`es a fresher public copy (graceful catch → bundled). `--goal-pct = raised/goal`. Mini variant accepts a prop for the postcard.
+- CSS (reuse `.dub-prep-bar` fill + existing `shimmer`/tokens; from the art spec):
+```css
+.goal__track{position:relative;height:8px;border-radius:999px;background:var(--color-bg-elev-2);overflow:visible}
+.goal__fill{height:100%;border-radius:999px;width:var(--goal-pct,0%);
+  background:linear-gradient(90deg,rgba(211,134,155,.75),rgba(211,134,155,1));
+  box-shadow:0 0 10px -1px var(--color-brand-glow);transition:width 1.1s var(--ease-spring);position:relative}
+.goal__pip{position:absolute;right:-10px;top:50%;transform:translateY(-60%);width:22px;height:22px}
+.goal__fill::after{content:"";position:absolute;inset:0;border-radius:inherit;
+  background:linear-gradient(90deg,transparent,rgba(255,255,255,.28),transparent);background-size:200% 100%;
+  animation:shimmer 1.4s var(--ease-out) .6s 1 both}
+@media (prefers-reduced-motion:reduce){.goal__fill{transition:none}.goal__fill::after{display:none}}
+```
+
+## Phase 2 — PIP, postcard, state machine
+**`Pip.jsx`** (inline SVG, `currentColor` → `--chrome-accent`; idle `pipBob`/`pipWave`, reduced-motion off):
+```jsx
+<svg viewBox="0 0 24 24" className="pip" aria-hidden="true">
+  <ellipse cx="12" cy="13" rx="8.5" ry="8" fill="currentColor" opacity="0.9"/>
+  <path d="M18 6 q3 -2 4 1" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" className="pip__wave"/>
+  <circle cx="8" cy="14.5" r="1.4" fill="#fb4934" opacity="0.18"/><circle cx="16" cy="14.5" r="1.4" fill="#fb4934" opacity="0.18"/>
+  <circle cx="9.3" cy="12" r="1.15" fill="#0f1011"/><circle cx="14.7" cy="12" r="1.15" fill="#0f1011"/>
+  <circle cx="9.0" cy="11.6" r="0.35" fill="#fff" opacity="0.9"/>  {/* the one sparkle */}
+  <path d="M10.6 14.6 q1.4 1.4 2.8 0" fill="none" stroke="#0f1011" strokeWidth="0.9" strokeLinecap="round"/>
+</svg>
+```
+**`donationSlice.ts`** (composed in `store/index.ts`, added to `partialize` — persist all **except** `shownThisSession`):
+```ts
+interface DonationState { optedOut:boolean; successCount:number; lastShownAt:number|null;
+  lastDismissedAt:number|null; lastClickThroughAt:number|null; donatedAt:number|null;
+  milestonesFired:string[]; shownThisSession:boolean }
+const D={d:864e5}; // ms/day
+shouldShow = s => !s.optedOut && !s.shownThisSession && s.successCount>=3
+  && now-(s.lastShownAt??0)>=7*D.d && now-(s.lastDismissedAt??0)>=14*D.d
+  && now-(s.lastClickThroughAt??0)>=30*D.d && now-(s.donatedAt??0)>=75*D.d;
+```
+Transitions: each success → `successCount++` then evaluate; show → `lastShownAt=now,shownThisSession=true`; dismiss → `lastDismissedAt=now`; CTA → `lastClickThroughAt=now`; "don't ask again" → `optedOut=true` (terminal, re-enable only in Settings); "I've donated" → `donatedAt=now`.
+
+**Trigger**: one shared `evaluateDonationPrompt(ctx)` called right after each **success** `completePill(...)` (`pillSlice.ts`; sites `useDubWorkflow.js:497/232/263`, longform `done`, clone-save resolve in `useProfiles.js`). **Never** off `toastErrorWithReport`/error paths.
+
+**`Postcard.jsx`** — rendered via `react-hot-toast` custom toast (non-blocking, no backdrop). Key CSS from the art spec: `.postcard` fixed `bottom:calc(var(--logs-footer-height,28px)+12px) right:16px; z-index:var(--z-toast)`, dashed-perforation `::before`, dot-grain `::after`, vertical dashed split, stamp corner with `stampThunk`, `postcardIn` spring entrance, `.is-leaving` exit, all under a `prefers-reduced-motion` guard. Mini goal bar inside reuses `--goal-pct` so it fills on slide-in.
+
+## Phase 3 — milestones + pill
+Milestone eval in the same evaluator (id ∉ `milestonesFired`, passes `shouldShow`). Nav-rail `.donate-pill` (`🩷 Support`, warms to accent on hover) → `setMode('donate')`.
+
+## Phase 4 — Discord (bot at `~/.config/omnivoice-bot/`)
+- **`/donate` command** — add to the bot's command set (TRIAGE.md / daemon command map + `discord.sh`): replies with one embed — goal bar (text: `$X/$200 ▓▓▓▓░░ 42% → Claude Max`), the Sponsors/Ko-fi/PayPal links, a warm line. Reads the same `donation_progress.json`.
+- **`/donate top`** — top supporters leaderboard from GitHub Sponsors (names + tier, opt-in/public only).
+- **#announcements** — ONE crafted pinned post calling for support to fund the Claude subscription; edit-in-place refresh only on milestones (quality over quantity — never re-post). Respect the `discord.sh postjson` guard (this is a normal post, not a draft/digest).
+
+## Copy → i18n keys
+`donate.postcard.{title,body,cta,dismiss,never}`, `donate.goal.{label,funds,met,updated}`, `donate.button.{label,tip}`, `donate.milestone.{first_clone,tenth_dub,sustained}`, `donate.page.{hero,body,thanks}`. English source from the copy deck (A/B/C variants captured in the spec; lead variants chosen there).
+
+## Tests
+- `donationSlice` unit (vitest): `shouldShow` truth table — first-3 grace, all cooldowns, opted-out terminal, success-only; transitions. Top-level placement, no real timers (inject `now`).
+- Postcard never renders on the error path (gate test).
+- `DonationGoal` renders bar from JSON + offline fallback + `goal met` state.
+- typecheck:ci clean; vitest green. **Verify the full CI matrix incl. Docker `--frozen-lockfile`** (new files don't touch package.json, so bun.lock unaffected — but confirm, per the "keep main green" rule).
+
+## Open decision before build
+Goal-number source: **A / B / C** (rec **B**). Then start Phase 1.

--- a/specs/007-donate-cta/spec.md
+++ b/specs/007-donate-cta/spec.md
@@ -1,0 +1,55 @@
+# Feature Specification: Donate CTA — "Fund Claude Max" (kawaii postcard)
+
+**Feature Branch**: `007-donate-cta` | **Created**: 2026-06-16
+**Status**: Designed (3-agent synthesis: copy + art + conversion) — awaiting goal-number-source decision, then build
+**Input**: Owner request — cute/arthouse, effective, non-annoying donate experience with a $200/mo goal; Discord surface
+**Extends**: the existing donate page (`SupportPage.jsx`, `mode==='donate'`), `LogsFooter` `DonateHeart`, `.github/FUNDING.yml`
+
+## Goal & framing
+**$200/mo — "Fund Claude Max."** Transparent on purpose: *OmniVoice is built with Claude; $200/month covers the Max subscription that writes the releases. 100% local, no investors, no ads — just this.* Donations are **optional; the app is free-forever, full-featured, never degraded** (the ask is reciprocity, never ransom).
+
+## North star
+**Maximally effective, never annoying** — for a technical, privacy-minded, anti-dark-pattern audience. **Quality over quantity:** one perfectly-timed, beautiful, dismissible ask beats a dozen. Every surface gets depth, not spam.
+
+## Mascot — PIP
+A single **sound-sprite**: a sound-wave droplet with two dot eyes, one ‿ smile, one wave-arc "sprout," and *one* eye-sparkle (not the two-sparkle kawaii cliché). Inline SVG, `currentColor` → `--chrome-accent`; one slow idle (`pipBob`/`pipWave`, ~4.2s), frozen under `prefers-reduced-motion`. PIP is a **mark** (like the existing `.hq-view-dot`), not a chatty assistant. PIP "mails" the postcard and "surfs" the goal bar. One creature, one accent, one slow motion = arthouse restraint.
+
+## Surfaces (6)
+1. **Export-finished postcard** ⭐ *primary* — a real postcard (stamp corner, dashed perforation, paper-grain, PIP) that **slides up bottom-right above the LogsFooter**. A **non-blocking toast** (`react-hot-toast`, **never** `Dialog.jsx` — a modal over a fresh export is itself a dark pattern), auto-dismiss ~12 s (pause on hover). Fires **only on success completion** — `completePill(...)` success branch (`pillSlice.ts`, from `useDubWorkflow.js:497/232/263` + the longform SSE `done`) and the clone-save resolve. Shows artifact context ("Your dub's ready 🎉"), the **mini goal bar** (fills *in front of you* on slide-in — the single most delightful beat), `Chip in ❤️`, `Maybe later`, and a quiet `Don't ask again`. Free secondary micro-ask: `⭐ Star on GitHub`.
+2. **Goal progress bar** — page (in `SupportPage`) + mini (postcard), same `--goal-pct` data. `$X of $200 · Claude Max`, %, **`updated {date}`**. PIP perched at the fill edge, `.dub-prep-bar` fill gradient, **one** shimmer pass (a payoff, not a casino), faint ruler ticks. At/over goal → celebrate and **retire the ask** ("🎉 funded this month — thank you"). Monthly reset re-opens the gradient (no invented urgency).
+3. **Persistent pull surfaces** — keep the footer `DonateHeart` (seasonal); optionally add one quiet `Support` pill in the nav-rail. **Never suppressed** (opting out of *nags* ≠ losing the *ability* to give).
+4. **Milestone nudges** — 1st clone, 10th dub, 30-day sustained use — each **once ever**, celebratory copy variant, same cooldowns/opt-out.
+5. **Donate page (`SupportPage`)** — add the goal bar + **social proof** ("Join N supporters" — count, not amounts) + **suggested amounts** ($3/$5/$10/Custom, middle marked "most common", **none pre-selected**) above the existing Sponsors / Ko-fi / PayPal cards.
+6. **Discord** — a `/donate` command (one goal card: bar + links + warm line), `/donate top` (a **top-supporters leaderboard**, social proof from GitHub Sponsors), and **one** crafted, pinned **#announcements** post — refreshed only on real milestones, **never a recurring nag**.
+
+## The non-annoyance contract (frequency state machine)
+A new persisted `donationSlice` (zustand `persist` `partialize` allowlist, `version` bump + pass-through `migrate`). The postcard shows **only if ALL hold**:
+- `!optedOut` · `!shownThisSession` · `successCount ≥ 3` (grace for new users)
+- `now − lastShownAt ≥ 7d` · `now − lastDismissedAt ≥ 14d` · `now − lastClickThroughAt ≥ 30d` · `now − donatedAt ≥ 75d`
+- artifact `status === success` (**never** on error / in-progress / setup / first-run)
+
+Effect: a heavy daily user sees the postcard **≤ ~once/week**, always after a win, mutable forever in one click. Milestones respect the same cooldown + opt-out.
+
+## Anti-pattern checklist (each avoided = a trust deposit)
+No guilt/confirm-shaming (dismiss is neutral) · non-blocking (toast, never steals focus/covers the artifact) · no fake urgency/countdowns · nothing pre-selected/pre-checked · **no fabricated numbers** (real, dated `raised`/`sponsorCount`) · dismiss as legible as the CTA · symmetric opt-out (one click off; re-enable in Settings) · **zero telemetry** (progress JSON is a read-only fetch with offline fallback; nothing about the user is sent — upholds the local-first constraint).
+
+## Goal-number source — the ONE open decision
+| | Live? | Local-first? | Effort |
+|---|---|---|---|
+| A. Baked value (bump per release) | stale | ✅ offline | trivial |
+| **B. Best-effort fetch of committed `donation_progress.json`** ⭐ | live-ish | ✅ optional + degrades | small |
+| C. GitHub Sponsors GraphQL API | real-time | ❌ token; amounts often private | high |
+
+**Recommend B:** ship a committed `donation_progress.json` `{ raised, goal: 200, currency, sponsorCount, updated }`; `SupportPage` reads it, optionally fetches a fresher copy at runtime, falls back to the bundled value offline. **Honest + dated; never fabricate motion.** Endowed-progress = open the bar at the *real* current baseline (recurring sponsors), not a faked head-start.
+
+## Copy direction
+Warm, lightly kawaii, **honest**, never needy. One ❤️ per surface. Recommended leads (full A/B/C deck → i18n keys): postcard *"Your {artifact}'s ready. ❤️ / OmniVoice is built with Claude — if it saved you a trip to the cloud, a tip toward the Claude Max fund means a lot."*; goal *"$X of $200 — Claude Max fund"*; button *"Donate ❤️"*. Free-forever, never "unlock/premium/pro," never "support us or lose features."
+
+## Success metrics
+Effective: postcard click-through ≥ 8–12%; donate-page→Sponsors ≥ 25–30%; bar funded ≥ 80–100%/mo; star micro-ask ≥ 15%; **"don't ask again" < 5%**. Annoying-alarm: opt-out > ~10%, "nag/begging" mentions on Discord/issues, uninstall correlated with exposure → soften/roll back to footer-heart-only. Measure locally + via the owner's GitHub Sponsors dashboard (no per-user tracking).
+
+## Constraints
+Local-first (no telemetry, offline-safe) · i18n hard rule (every string `t()`, 26 locales) · cross-platform · docs-sync (update FUNDING/README if funding text changes, same PR) · backward-compatible (extends `SupportPage` + a persist version bump with safe-default migrate).
+
+## Out of scope (v1)
+Automated over-goal stretch-goal rotation; real A/B infra; per-amount/per-user tracking (telemetry-free by design); the dub-toolbar redesign (separate, already diagnosed).


### PR DESCRIPTION
Persists the planning artifacts from this cycle: `specs/006-dubbing-singing-mode/` (SoulX-Singer SVS plan; supersedes SPIKE-02) and `specs/007-donate-cta/` (the donate experience — goal bar, kawaii postcard, conversion strategy, frequency state machine, Discord surface). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed feature specifications and phased implementation plans for two upcoming capabilities: singing/music dubbing with melody preservation, and a donation request interface with progress tracking and celebration milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->