### PR TITLE
chore(version): bring frontend/package.json into lockstep (0.3.6) — pre-v0.3.6 gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -725,10 +725,16 @@ jobs:
           tmp=$(mktemp)
           jq --arg v "$NEXT" '.version = $v' frontend/src-tauri/tauri.conf.json > "$tmp"
           mv "$tmp" frontend/src-tauri/tauri.conf.json
+          # frontend/package.json drives __APP_VERSION__ (vite.config.js) — the
+          # first-run footer + every auto bug report. Keep it in lockstep too,
+          # set absolutely (jq) so any prior drift self-heals. (#248-sweep finding)
+          tmp=$(mktemp)
+          jq --arg v "$NEXT" '.version = $v' frontend/package.json > "$tmp"
+          mv "$tmp" frontend/package.json
           sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEXT\"/" frontend/src-tauri/Cargo.toml
           sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEXT\"/" pyproject.toml
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add frontend/src-tauri/tauri.conf.json frontend/src-tauri/Cargo.toml pyproject.toml
+          git add frontend/src-tauri/tauri.conf.json frontend/package.json frontend/src-tauri/Cargo.toml pyproject.toml
           git commit -m "chore(version): main -> $NEXT after $GITHUB_REF_NAME release"
           git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ Everything else (new engines, fancy features) is downstream of "the thing instal
 <!-- GSD:conventions-start source:CONVENTIONS.md -->
 ## Conventions
 
-**Versioning (hard rule, owner-set 2026-06-11):** main is always **latest release + 1 patch**. The moment `vX.Y.Z` is released, main's version files (`frontend/src-tauri/tauri.conf.json`, `frontend/src-tauri/Cargo.toml`, `pyproject.toml` — keep all three in lockstep) bump to `X.Y.(Z+1)`. Consequences:
+**Versioning (hard rule, owner-set 2026-06-11):** main is always **latest release + 1 patch**. The moment `vX.Y.Z` is released, main's version files (`frontend/src-tauri/tauri.conf.json`, `frontend/src-tauri/Cargo.toml`, `pyproject.toml`, **and `frontend/package.json`** — keep all **four** in lockstep; `package.json` drives the runtime `__APP_VERSION__` via vite, shown in the first-run footer + every auto bug report, so a drift ships a build that misreports its own version — guarded by `tests/test_app_version.py::test_all_version_files_in_lockstep`) bump to `X.Y.(Z+1)`. Consequences:
 - Every PR and preview build identifies as the **next** version. Preview builds stamp `X.Y.(Z+1)-N` (run number), which semver-sorts **above** the last stable `X.Y.Z` — the updater ordering is natural, no comparator tricks needed.
 - Releasing = tag `vX.Y.(Z+1)` from main (version files already match), then immediately bump main to `X.Y.(Z+2)`. The post-release bump is automated by the `version-bump` job in release.yml; if it fails, do it manually in the same day.
 - Docker: `ghcr.io/debpalash/omnivoice-studio:latest` = **main** (rolling preview); `:X.Y.Z` + `:X.Y` + `:stable` = tagged releases. `:latest` is the preview channel by design — stable users pin `:stable` or a version tag.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnivoice-studio",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/tests/test_app_version.py
+++ b/tests/test_app_version.py
@@ -14,3 +14,29 @@ def test_app_version_matches_installed_package_metadata():
     # In any synced env the package is installed; APP_VERSION must equal it
     # (i.e. it's read from pyproject, not hardcoded).
     assert APP_VERSION == version("omnivoice")
+
+
+def test_all_version_files_in_lockstep():
+    """The FOUR version files must agree: pyproject.toml,
+    frontend/src-tauri/{tauri.conf.json,Cargo.toml}, and frontend/package.json.
+
+    package.json drives the runtime ``__APP_VERSION__`` (vite.config.js), which
+    shows in the first-run footer and EVERY auto bug report — so a drift ships a
+    v0.3.6 build that calls itself v0.3.5. The release.yml version-bump job was
+    bumping only the first three; package.json drifted unnoticed. Catch it in CI.
+    """
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+
+    def _toml_version(p: Path) -> str:
+        return re.search(r'(?m)^version\s*=\s*"([^"]+)"', p.read_text()).group(1)
+
+    versions = {
+        "pyproject.toml": _toml_version(root / "pyproject.toml"),
+        "Cargo.toml": _toml_version(root / "frontend/src-tauri/Cargo.toml"),
+        "tauri.conf.json": json.loads((root / "frontend/src-tauri/tauri.conf.json").read_text())["version"],
+        "package.json": json.loads((root / "frontend/package.json").read_text())["version"],
+    }
+    assert len(set(versions.values())) == 1, f"version files drifted: {versions}"


### PR DESCRIPTION
## Problem (pre-v0.3.6 release-sweep finding)
`frontend/package.json` was stuck at **0.3.5** while `tauri.conf.json` / `Cargo.toml` / `pyproject.toml` were all `0.3.6`. Since `__APP_VERSION__` is injected from `package.json` (`vite.config.js`), a **v0.3.6 build identified itself as "v0.3.5"** in the first-run footer *and* in every auto bug report — undercutting the bug-reporting feature.

**Root cause:** the `release.yml` version-bump job bumped only the trio, never `package.json`, and no test guarded the lockstep — so it drifted silently across releases.

## Fix (4 parts — fixes the class, not the instance)
1. `frontend/package.json` 0.3.5 → **0.3.6**. (`bun install --frozen-lockfile` still passes — the version *field* doesn't affect the lock graph.)
2. **`release.yml` version-bump job** now also bumps `package.json` (set absolutely via `jq`, so any prior drift self-heals on the next release).
3. **`tests/test_app_version.py::test_all_version_files_in_lockstep`** — fails CI if the four files ever diverge again.
4. **CLAUDE.md** versioning rule updated to **four** lockstep files (docs-sync).

## Verify
All four files = 0.3.6; the lockstep guard (3 tests) passes; release.yml is valid YAML.

This is the one pre-tag gate from the v0.3.6 test sweep. Once merged green, v0.3.6 is ready to cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Version Synchronization Fix

Fixes a silent version drift issue where `frontend/package.json` (0.3.5) had fallen behind `pyproject.toml`, `Cargo.toml`, and `tauri.conf.json` (all 0.3.6). Since `__APP_VERSION__` is injected from `package.json` via `vite.config.js`, the app was self-reporting as v0.3.5 despite being released as v0.3.6, compromising the bug-reporting feature which relies on accurate version identification.

## Changes

**frontend/package.json**
- Version bumped from 0.3.5 → 0.3.6

**.github/workflows/release.yml**  
- `version-bump` job now updates `frontend/package.json` alongside the three other config files during releases
- Uses `jq` to set the version field absolutely, so any future drift self-heals on the next release
- Includes inline comment referencing the bug that triggered this fix

**tests/test_app_version.py**
- New test `test_all_version_files_in_lockstep()` validates that four version sources remain synchronized:
  - `pyproject.toml`
  - `frontend/src-tauri/Cargo.toml`
  - `frontend/src-tauri/tauri.conf.json`
  - `frontend/package.json`
- Reads from both TOML and JSON formats; fails CI if any diverge
- Prevents regression of this issue across future releases

**CLAUDE.md**
- Updated versioning convention documentation to reflect that all four files must remain in lockstep
- Added reference to the regression test guard

## Verification

All four version files confirmed at 0.3.6; lockstep enforcement test added to CI; `release.yml` remains valid YAML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->