### PR TITLE
fix(version): frozen backend reports real version, not the 0.3.5 fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -733,8 +733,12 @@ jobs:
           mv "$tmp" frontend/package.json
           sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEXT\"/" frontend/src-tauri/Cargo.toml
           sed -i "0,/^version = \"$CURRENT\"/s//version = \"$NEXT\"/" pyproject.toml
+          # backend/core/version.py last-resort literal — the frozen backend
+          # reads metadata, but keep this in lockstep so a metadata-less context
+          # never reports a stale version (the v0.3.6 build that showed "0.3.5").
+          sed -i "0,/_FALLBACK_VERSION = \"$CURRENT\"/s//_FALLBACK_VERSION = \"$NEXT\"/" backend/core/version.py
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add frontend/src-tauri/tauri.conf.json frontend/package.json frontend/src-tauri/Cargo.toml pyproject.toml
+          git add frontend/src-tauri/tauri.conf.json frontend/package.json frontend/src-tauri/Cargo.toml pyproject.toml backend/core/version.py
           git commit -m "chore(version): main -> $NEXT after $GITHUB_REF_NAME release"
           git push origin main

--- a/backend.spec
+++ b/backend.spec
@@ -13,12 +13,18 @@
 # Run:  uv run pyinstaller backend.spec --noconfirm --clean
 import platform
 import sys
-from PyInstaller.utils.hooks import collect_data_files, collect_all, collect_submodules
+from PyInstaller.utils.hooks import collect_data_files, collect_all, collect_submodules, copy_metadata
 
 IS_MAC_ARM = sys.platform == "darwin" and platform.machine() == "arm64"
 
 datas = []
 binaries = []
+
+# Bundle the omnivoice package's .dist-info so importlib.metadata.version()
+# resolves inside the frozen build. Without it the backend can't read its own
+# version and falls back to the literal in backend/core/version.py — which is
+# how a 0.3.6 desktop build shipped reporting "0.3.5" in About + bug reports.
+datas += copy_metadata('omnivoice')
 hiddenimports = [
     # Web stack
     'uvicorn', 'uvicorn.logging', 'uvicorn.loops', 'uvicorn.loops.auto',

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -2,14 +2,43 @@
 
 Read from the installed package metadata (driven by ``pyproject.toml``) so the
 FastAPI/API version and exported-bundle metadata never drift to a stale literal
-again (the prior "0.4.0" / "0.2.7" bug). Falls back to a literal only when
-running from a raw source checkout that was never ``uv sync``'d.
+— the prior "0.4.0" / "0.2.7" bug, and the v0.3.6 desktop build that reported
+"0.3.5" because the *frozen* backend couldn't read its own metadata.
+
+Resolution order:
+  1. installed package metadata — correct in any ``uv sync``'d env and, thanks
+     to ``copy_metadata('omnivoice')`` in ``backend.spec``, in the frozen build;
+  2. ``pyproject.toml`` walked up from this file — correct for a raw source
+     checkout that was never installed;
+  3. ``_FALLBACK_VERSION`` — a last resort, kept in lockstep with the four
+     version files by ``tests/test_app_version.py`` so it can never silently
+     drift again.
 """
 from __future__ import annotations
 
+import re
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+# Last-resort literal. Guarded by
+# tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
+# release.yml's version-bump job, so it stays equal to
+# pyproject/tauri.conf/Cargo/package.json.
+_FALLBACK_VERSION = "0.3.7"
+
+
+def _fallback_version() -> str:
+    """Version for contexts where package metadata is unavailable."""
+    for parent in Path(__file__).resolve().parents:
+        pyproject = parent / "pyproject.toml"
+        if pyproject.is_file():
+            match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', pyproject.read_text())
+            if match:
+                return match.group(1)
+    return _FALLBACK_VERSION
+
 
 try:
     APP_VERSION = version("omnivoice")
-except PackageNotFoundError:  # non-installed source checkout
-    APP_VERSION = "0.3.5"
+except PackageNotFoundError:  # frozen build w/o metadata, or non-installed checkout
+    APP_VERSION = _fallback_version()

--- a/tests/test_app_version.py
+++ b/tests/test_app_version.py
@@ -17,13 +17,17 @@ def test_app_version_matches_installed_package_metadata():
 
 
 def test_all_version_files_in_lockstep():
-    """The FOUR version files must agree: pyproject.toml,
-    frontend/src-tauri/{tauri.conf.json,Cargo.toml}, and frontend/package.json.
+    """The FIVE version sources must agree: pyproject.toml,
+    frontend/src-tauri/{tauri.conf.json,Cargo.toml}, frontend/package.json, and
+    backend/core/version.py's ``_FALLBACK_VERSION``.
 
     package.json drives the runtime ``__APP_VERSION__`` (vite.config.js), which
     shows in the first-run footer and EVERY auto bug report — so a drift ships a
-    v0.3.6 build that calls itself v0.3.5. The release.yml version-bump job was
-    bumping only the first three; package.json drifted unnoticed. Catch it in CI.
+    v0.3.6 build that calls itself v0.3.5. ``_FALLBACK_VERSION`` is what the
+    *frozen* backend reports when package metadata is unavailable — and it being
+    stuck at "0.3.5" is exactly why the v0.3.6 desktop build reported 0.3.5 in
+    About + bug reports. The release.yml version-bump job must bump all five;
+    catch any drift here in CI.
     """
     import json
     from pathlib import Path
@@ -33,10 +37,40 @@ def test_all_version_files_in_lockstep():
     def _toml_version(p: Path) -> str:
         return re.search(r'(?m)^version\s*=\s*"([^"]+)"', p.read_text()).group(1)
 
+    def _named_literal(p: Path, name: str) -> str:
+        return re.search(rf'(?m)^{name}\s*=\s*"([^"]+)"', p.read_text()).group(1)
+
     versions = {
         "pyproject.toml": _toml_version(root / "pyproject.toml"),
         "Cargo.toml": _toml_version(root / "frontend/src-tauri/Cargo.toml"),
         "tauri.conf.json": json.loads((root / "frontend/src-tauri/tauri.conf.json").read_text())["version"],
         "package.json": json.loads((root / "frontend/package.json").read_text())["version"],
+        "core/version.py": _named_literal(root / "backend/core/version.py", "_FALLBACK_VERSION"),
     }
     assert len(set(versions.values())) == 1, f"version files drifted: {versions}"
+
+
+def test_fallback_version_resolves_to_pyproject():
+    """When package metadata is unavailable (frozen build / raw checkout), the
+    version must still resolve to pyproject — never the stale literal that made
+    the v0.3.6 build report "0.3.5"."""
+    from pathlib import Path
+
+    from core.version import _fallback_version
+
+    root = Path(__file__).resolve().parents[1]
+    pyproject = re.search(
+        r'(?m)^version\s*=\s*"([^"]+)"', (root / "pyproject.toml").read_text()
+    ).group(1)
+    assert _fallback_version() == pyproject
+
+
+def test_frozen_build_collects_package_metadata():
+    """backend.spec must copy_metadata('omnivoice') so the frozen backend reads
+    its real version via importlib.metadata instead of the fallback literal."""
+    from pathlib import Path
+
+    spec = (Path(__file__).resolve().parents[1] / "backend.spec").read_text()
+    assert (
+        "copy_metadata('omnivoice')" in spec or 'copy_metadata("omnivoice")' in spec
+    ), "backend.spec must copy_metadata('omnivoice') (frozen-build version reporting)"


### PR DESCRIPTION
## The bug (answering "why is 0.3.5 in a 0.3.6 build?")

`core.version.APP_VERSION` is read by the About panel, `/health`, `/system/info`, diagnostics, bug reports, **and exported persona/marketplace bundle metadata**. It resolves like this:

```python
try:    APP_VERSION = version("omnivoice")   # package metadata
except PackageNotFoundError:
        APP_VERSION = "0.3.5"                 # ← hardcoded fallback
```

In a `uv sync`'d env (CI, dev) the metadata path works → the lockstep test is green → nobody notices. But the **PyInstaller-frozen backend** ships no `omnivoice` `.dist-info`, so it raises `PackageNotFoundError` and reports the hardcoded **`0.3.5`**. The `version-bump` job bumps the 4 version files but never this literal — so every 0.3.x desktop build has reported `0.3.5`.

## Fix (belt-and-suspenders)

| Change | Effect |
|---|---|
| `backend.spec`: `copy_metadata('omnivoice')` | the frozen build can now read its real version via `importlib.metadata` — the **primary** path works there too |
| `version.py`: metadata → **pyproject (walked up)** → named literal | source checkouts resolve correctly; the literal is a true last resort, not the only fallback |
| `tests/test_app_version.py` | `_FALLBACK_VERSION` joins the lockstep (now **5** sources) + a fallback-resolves-to-pyproject test + a test that the spec copies metadata (frozen path can't silently regress) |
| `release.yml` version-bump | also bumps `_FALLBACK_VERSION`, so the 5-way lockstep guard never reddens main after a release |

## Testing

- `uv run pytest tests/test_app_version.py` → **5 passed** (lockstep across 5 sources, fallback→pyproject, spec-collects-metadata).
- Already-shipped binaries can't be retro-fixed, but tonight's preview build and the next stable will report their real version.

> Note: edits `release.yml`'s version-bump job (a different region than #500's preview-trigger edits); merges cleanly, rebase the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Version Resolution Fix for PyInstaller Backend

This PR fixes a bug where the frozen PyInstaller-based backend reports a stale version `0.3.5` regardless of the actual release version. The root cause is that the frozen build doesn't include the package metadata directory, causing `importlib.metadata.version()` to fail and fall back to a hardcoded constant that never gets updated during releases.

### Version Resolution Chain (New Mechanism)

```
APP_VERSION resolution attempts:
│
├─→ importlib.metadata.version("omnivoice")
│   └─ (Works with .dist-info metadata)
│
├─→ _fallback_version()
│   └─ Parses pyproject.toml for version field
│     (Works in source checkouts, frozen builds)
│
└─→ _FALLBACK_VERSION = "0.3.7"
    └─ Last resort, kept in sync by CI
```

### Changes

1. **backend.spec** (+7/-1): Imports `copy_metadata` from PyInstaller hooks and adds `copy_metadata('omnivoice')` to bundle `.dist-info` in frozen builds, enabling metadata lookup at runtime.

2. **backend/core/version.py** (+33/-4): 
   - Introduces `_FALLBACK_VERSION = "0.3.7"` constant (replaces inline `"0.3.5"`)
   - Implements `_fallback_version()` function that searches parent directories for `pyproject.toml` and extracts version via regex
   - Restructures `APP_VERSION` to attempt metadata → pyproject fallback → named constant fallback

3. **.github/workflows/release.yml** (+5/-1): Updates version-bump job to also modify `_FALLBACK_VERSION` in `backend/core/version.py`, keeping all 5 version sources synchronized during releases.

4. **tests/test_app_version.py** (+38/-4):
   - Extends `test_all_version_files_in_lockstep` to verify 5 version sources (previously 4)
   - Adds `test_fallback_version_resolves_to_pyproject()` to validate that pyproject parsing works as intended
   - Adds `test_frozen_build_collects_package_metadata()` to verify `backend.spec` correctly copies metadata

### Impact

- Subsequent builds will report their actual versions
- Existing shipped binaries cannot be retroactively fixed
- The layered approach ensures version reporting works across installed packages, source checkouts, and frozen PyInstaller builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->