### PR TITLE
fix(test): resolve package.json version reference in the desktop probe spec

### DIFF
--- a/tests/probe/desktop.py
+++ b/tests/probe/desktop.py
@@ -42,7 +42,21 @@ def load_tauri_config(platform: str | None = None) -> dict:
         override_path = _SRC_TAURI / f"tauri.{platform}.conf.json"
         if override_path.exists():
             base = _deep_merge(base, json.loads(override_path.read_text(encoding="utf-8")))
-    return base
+    return _resolve_version(base)
+
+
+def _resolve_version(config: dict) -> dict:
+    """Resolve a package.json `version` reference the way Tauri does.
+
+    package.json is the single source of truth, so tauri.conf.json carries
+    ``"version": "../package.json"`` (a path Tauri reads at build time) rather
+    than a literal. Resolve it here to the effective bundle version so the
+    config-integrity checks see — and assert parity against — the real value."""
+    v = config.get("version")
+    if isinstance(v, str) and v.endswith("package.json"):
+        pkg = json.loads((_SRC_TAURI / v).resolve().read_text(encoding="utf-8"))
+        config = {**config, "version": pkg.get("version", v)}
+    return config
 
 
 def pyproject_version() -> str:


### PR DESCRIPTION
**Hotfix for red main.** #503 made `tauri.conf.json` derive its version (`"version": "../package.json"`), but the L3 desktop probe spec (`tests/probe/specs/desktop_smoke.probe.yaml`) asserts `config.version == pyproject_version` and was reading the literal path string.

`load_tauri_config()` now resolves the package.json reference the way Tauri does, so the integrity check sees the effective bundle version — validating the real thing: resolved bundle version == project version.

Full backend suite locally: **1691 passed, 20 skipped, 11 xfailed, 3 xpassed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix desktop probe integrity check for resolved package.json version

This PR fixes a failing test in the desktop probe specification caused by PR `#503`, which modified `tauri.conf.json` to reference `package.json` for its version using `"version": "../package.json"`. The L3 desktop probe spec includes an integrity check asserting `config.version == pyproject_version`, but was reading the literal path string instead of the resolved version value.

### Changes

**`tests/probe/desktop.py`**
- `load_tauri_config(platform: str | None = None)` now resolves the effective version before returning the config
- Added `_resolve_version(config: dict)` helper function that:
  - Detects when `config["version"]` contains a path string ending with `package.json`
  - Loads the referenced `package.json` from the Tauri source directory
  - Replaces the path reference with the actual version value from the loaded package
  - Returns the config with the resolved literal version string

### Behavior Flow

```mermaid
flowchart TD
    A["load_tauri_config<br/>called"] --> B["Load base<br/>tauri.conf.json"]
    B --> C{Platform<br/>override<br/>exists?}
    C -->|Yes| D["Deep merge with<br/>platform override"]
    C -->|No| E["Use base config"]
    D --> F["Call _resolve_version"]
    E --> F
    F --> G{version ends<br/>with<br/>package.json?}
    G -->|No| H["Return config<br/>unchanged"]
    G -->|Yes| I["Resolve path from<br/>Tauri src dir"]
    I --> J["Load package.json<br/>and extract version"]
    J --> K["Replace version<br/>string with<br/>resolved value"]
    K --> L["Return config<br/>with literal<br/>version"]
    H --> M["Config integrity check"]
    L --> M
    M --> N["Assert config.version<br/>== pyproject_version"]
```

This ensures the probe spec's integrity check now validates the actual resolved bundle version against the project version, confirming both that the bundle version matches the project version and that `package.json` is synchronized with `pyproject.toml`.

**Test Results:** Full backend test suite reports 1691 passed tests, 20 skipped, 11 xfailed, and 3 xpassed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->