### PR TITLE
fix(stories): apply global reading speed to preview + stem export

### DIFF
--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -26,7 +26,7 @@ import { exportStems } from '../utils/storyExport';
 import { storyToSpans } from '../utils/storyToSpans';
 import { consumeLongformStream } from '../utils/longformStream';
 import { reorder } from '../utils/storyReorder';
-import { effectiveProfile, castMember, nextCastColor } from '../utils/storyCast';
+import { effectiveProfile, effectiveSpeed, castMember, nextCastColor } from '../utils/storyCast';
 import './StoriesEditor.css';
 
 // Trigger a browser download for a Blob.
@@ -302,7 +302,7 @@ export default function StoriesEditor({ profiles = [] }) {
     const raw = (track.text || '').trim();
     if (!raw) return;
     const pid = effectiveProfile(track, cast);
-    const spd = track.speed || 1.0;
+    const spd = effectiveSpeed(track, globalSpeed);
     setTracks((prev) => prev.map((tk) => (tk.id === track.id ? { ...tk, generating: true } : tk)));
 
     if (!hasStoryMarkers(raw)) {
@@ -349,7 +349,7 @@ export default function StoriesEditor({ profiles = [] }) {
       console.warn('Stories chained preview failed:', err);
       setTracks((prev) => prev.map((tk) => (tk.id === track.id ? { ...tk, generating: false } : tk)));
     }
-  }, [fetchChunkAudio, cast, setTracks]);
+  }, [fetchChunkAudio, cast, globalSpeed, setTracks]);
 
   // Deliver a stitched WAV in the chosen format. MP3 routes through the backend
   // ffmpeg endpoint; if that fails (e.g. no ffmpeg), fall back to the raw WAV.
@@ -416,7 +416,7 @@ export default function StoriesEditor({ profiles = [] }) {
     try {
       const stems = await exportStems(
         usable,
-        (tk) => ({ profileId: effectiveProfile(tk, cast), speed: tk.speed || 1.0 }),
+        (tk) => ({ profileId: effectiveProfile(tk, cast), speed: effectiveSpeed(tk, globalSpeed) }),
         fetchChunkBlob,
         (d, total) => setExportPct(total ? Math.round((d / total) * 100) : 0),
       );
@@ -431,7 +431,7 @@ export default function StoriesEditor({ profiles = [] }) {
     } finally {
       setExporting(false);
     }
-  }, [tracks, cast, fetchChunkBlob, exporting, deliver, t]);
+  }, [tracks, cast, fetchChunkBlob, exporting, deliver, globalSpeed, t]);
 
   // ── Stats ─────────────────────────────────────────────────────────────────
   const totalChars = tracks.reduce((acc, tk) => acc + tk.text.length, 0);

--- a/frontend/src/utils/storyCast.js
+++ b/frontend/src/utils/storyCast.js
@@ -24,6 +24,18 @@ export function effectiveProfile(track, cast) {
   return (member && member.profileId) || null;
 }
 
+/**
+ * Resolve the reading speed a track should use: per-line override → the global
+ * Stories speed (#415) → null (the /generate engine default of 1.0×). Mirrors
+ * the span-speed resolution in storyToSpans (`tk.speed || gspeed || null`) so
+ * preview, stem export, and longform export all agree on one speed. A global
+ * of 1 counts as "at rest" → null, matching the export path.
+ */
+export function effectiveSpeed(track, globalSpeed) {
+  if (track && track.speed) return track.speed;
+  return (globalSpeed && globalSpeed !== 1) ? globalSpeed : null;
+}
+
 /** Find a cast member by id (falls back to the first member). */
 export function castMember(cast, id) {
   return (cast || []).find((c) => c.id === id) || (cast || [])[0] || null;

--- a/frontend/src/utils/storyCast.test.js
+++ b/frontend/src/utils/storyCast.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { nextCastColor, effectiveProfile, castMember, CAST_COLORS } from './storyCast';
+import { nextCastColor, effectiveProfile, effectiveSpeed, castMember, CAST_COLORS } from './storyCast';
 
 describe('nextCastColor', () => {
   it('returns the first unused palette color', () => {
@@ -24,6 +24,24 @@ describe('effectiveProfile', () => {
   });
   it('returns null when neither is set', () => {
     expect(effectiveProfile({ character: 'owl', profileId: null }, cast)).toBeNull();
+  });
+});
+
+describe('effectiveSpeed', () => {
+  it('prefers a per-line speed override over the global', () => {
+    expect(effectiveSpeed({ speed: 1.25 }, 0.7)).toBe(1.25);
+  });
+  it('applies the global speed when the track has none (#508)', () => {
+    // Regression: preview + stem export must follow the global, not 1.0.
+    expect(effectiveSpeed({ speed: null }, 0.7)).toBe(0.7);
+    expect(effectiveSpeed({}, 0.7)).toBe(0.7);
+  });
+  it('treats a global of 1 as at-rest → null (engine default)', () => {
+    expect(effectiveSpeed({ speed: null }, 1)).toBeNull();
+  });
+  it('returns null when neither override nor a non-default global is set', () => {
+    expect(effectiveSpeed({ speed: null }, null)).toBeNull();
+    expect(effectiveSpeed({}, undefined)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Problem
`#415` (PR #472) added a global reading-speed control to the Stories editor, but it only reached the **full longform export** path (`generateAll` → `storyToSpans`). The two other generation paths hardcoded the speed fallback and ignored `globalSpeed`:

- `previewTrack` (per-segment preview/playback): `const spd = track.speed || 1.0;`
- `exportStemsAll` (stem export): `speed: tk.speed || 1.0`

So with the global set to e.g. 0.70×, per-segment generated audio still played at 1.00×. Reported on Discord (Japanese long-form user) — the global speed "looks like it isn't being applied."

## Fix
Add a pure, testable `effectiveSpeed(track, globalSpeed)` helper in `storyCast.js` that mirrors the existing `effectiveProfile` shape and the `storyToSpans` precedence (`tk.speed || gspeed || null`): **per-line override → global → engine default (null = 1.0×)**. A global of `1` counts as "at rest" → `null`, matching the export path exactly. Use it at both call sites and add `globalSpeed` to the two `useCallback` deps arrays.

Now preview, stem export, and longform export all resolve speed identically.

## Why this is safe
- Pure frontend logic; no backend/schema/engine change, no new deps, no version bump.
- Cross-platform identical (pure JS).
- Backward-compatible: when the global is at rest (1), behavior is unchanged (`track.speed || 1.0` ≡ `effectiveSpeed → null → String(null||1.0)`).
- No hardcoded CJK.

## Tests
- New `effectiveSpeed` regression cases in `frontend/src/utils/storyCast.test.js` (override wins, global applied when no override (#508), global=1 → null, no-global → null). Fails before the fix (old path returned 1.0), passes after.
- `bunx vitest run` — **60 files / 537 tests pass**.
- `bun run typecheck:ci` — clean.

Fixes #508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a bug where the global reading speed setting was not being applied to per-segment preview playback and stem export paths in the Stories editor. Only the full longform export was correctly honoring the global speed setting.

## Root Cause
Two generation paths in `StoriesEditor.jsx` (`previewTrack` and `exportStems`) resolved speed using hardcoded fallbacks (`track.speed || 1.0`) that ignored the `globalSpeed` parameter, while the full export path (`storyToSpans()`) correctly implemented speed precedence through PR `#472`.

## Solution

### Speed Resolution Logic
```mermaid
graph TD
    A["effectiveSpeed(track, globalSpeed)"] --> B{Track has speed override?}
    B -->|Yes| C["Return track.speed"]
    B -->|No| D{Global speed != 1?}
    D -->|Yes| E["Return globalSpeed"]
    D -->|No| F["Return null (engine default)"]
    C --> G[Resolved Speed]
    E --> G
    F --> G
```

### Changes

**`frontend/src/utils/storyCast.js`** — New utility function
- Added `effectiveSpeed(track, globalSpeed)` that implements correct speed precedence:
  - Per-line override (`track.speed`) takes highest priority
  - Global speed used if no per-line override and `globalSpeed !== 1`
  - Returns `null` otherwise to preserve engine default (1.0×)
- Treats global speed of `1` as "at-rest" to avoid overriding engine defaults unnecessarily

**`frontend/src/components/StoriesEditor.jsx`** — Integration
- Updated `previewTrack` function (line 305) to use `effectiveSpeed(track, globalSpeed)` instead of `track.speed || 1.0`
- Updated `exportStems` call (line 419) to map each track's speed via `effectiveSpeed(tk, globalSpeed)`
- Added `globalSpeed` to relevant `useCallback` dependency arrays to ensure callbacks re-bind when global speed changes
- Extended imports to include `effectiveSpeed`

**`frontend/src/utils/storyCast.test.js`** — Test coverage
- Added 4 test cases covering:
  - Per-line overrides take precedence over global
  - Global speed is applied when track has no override (regression test for `#508`)
  - Global speed of `1` is treated as "at-rest" returning `null`
  - Correct null handling when neither override nor non-default global exists

## Impact
- All three generation paths (preview, stem export, full export) now resolve speed identically
- Backward-compatible with no backend, schema, or engine changes
- Frontend-only fix ensuring consistent behavior across all export/preview scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->