### PR TITLE
fix(web): audio playback on Linux/Android (MIME + AudioContext unlock)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.6 + 1 patch. New work lands here._
+### Fixed
+
+- **Audio playback on Linux Firefox/Chrome and Android Chrome.** Two separate
+  root causes both masquerade as "the play button doesn't work" on non-macOS
+  browsers — and both are invisible when developing on macOS, which is why they
+  shipped. (1) The backend served `.wav` / `.flac` with Python's default
+  `audio/x-wav` / `audio/x-flac` (vendor-experimental, never IANA-registered);
+  macOS CoreAudio MIME-sniffs leniently and plays anyway, but Linux FFmpeg and
+  Android ExoPlayer strictly honor the declared type and prompt to download.
+  Fixed by registering the canonical `audio/wav` / `audio/flac` types before
+  any `StaticFiles` mount. (2) WaveSurfer's `AudioContext` is constructed at
+  component-mount time — i.e. before any user gesture — so on Linux FF/Chrome
+  and Android Chrome it stays `suspended`, `decodeAudioData` hangs, the
+  `ready` event never fires, and the play button never enables. macOS
+  Safari/Chrome auto-resume on first interaction. Fixed by patching
+  `window.AudioContext` to track every instance and resuming them on the first
+  `pointerdown` / `keydown` / `touchstart`, plus resuming inline on the play
+  click itself. The MIME fix has a backend regression test; the unlock path
+  has a Vitest unit test covering idempotency, post-unlock contexts, and
+  error isolation. (#510)
 
 ## [0.3.6] — 2026-06-16
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -740,6 +740,20 @@ app.add_middleware(NetworkAccessMiddleware)
 # keyed non-loopback client must reach them.
 app.add_middleware(BearerKeyMiddleware)
 
+# Register canonical audio MIME types before any StaticFiles mount.
+# Python's `mimetypes.guess_type()` returns `audio/x-wav` for `.wav` and
+# `audio/x-flac` for `.flac` on most platforms — these are vendor-experimental
+# (x- prefix, never IANA-registered). macOS Chrome/Safari MIME-sniff leniently
+# via CoreAudio so playback works there, but Linux Chrome/Firefox (FFmpeg) and
+# Android Chrome (ExoPlayer) strictly honor the declared type and treat the
+# x- variants as download-only — manifesting as the play button silently
+# doing nothing in the browser app while working in the Tauri desktop shell.
+# `audio/wav` / `audio/flac` are the IANA-canonical types.
+# Ref: https://www.iana.org/assignments/media-types/media-types.xhtml#audio
+import mimetypes as _mimetypes
+_mimetypes.add_type("audio/wav",  ".wav")
+_mimetypes.add_type("audio/flac", ".flac")
+
 app.mount("/audio", StaticFiles(directory=OUTPUTS_DIR), name="audio")
 app.mount("/voice_audio", StaticFiles(directory=VOICES_DIR), name="voice_audio")
 

--- a/frontend/src/components/WaveformPlayer.jsx
+++ b/frontend/src/components/WaveformPlayer.jsx
@@ -16,9 +16,10 @@
  */
 import React, { useEffect, useRef, useState } from 'react';
 import WaveSurfer from 'wavesurfer.js';
-import { Play, Pause, Loader } from 'lucide-react';
+import { Play, Pause } from 'lucide-react';
 import { claimPlayback } from '../utils/playback';
 import { isTauri, fileToMediaUrl } from '../utils/media';
+import { unlockAudio } from '../utils/audioUnlock';
 import { useAppStore } from '../store';
 import './WaveformPlayer.css';
 
@@ -196,11 +197,19 @@ export default function WaveformPlayer({
     };
   }, [resolvedUrl, failed, height, source, onEnded]);
 
-  const togglePlay = () => {
+  const togglePlay = async () => {
+    // Browser autoplay policy (Linux FF/Chrome, Android Chrome): WaveSurfer's
+    // AudioContext starts suspended until a user gesture. This click IS the
+    // gesture — explicitly resume so the subsequent play() succeeds. No-op
+    // on macOS where the context was never blocked.
+    try { await unlockAudio(); } catch { /* ignore — play() will surface errors */ }
     // playPause is async — a swallowed rejection here is exactly how the
     // "click does nothing" bug hid; log it so playback failures are visible.
-    Promise.resolve(wsRef.current?.playPause())
-      .catch((e) => console.warn('WaveformPlayer: play failed:', e));
+    try {
+      await wsRef.current?.playPause();
+    } catch (e) {
+      console.warn('WaveformPlayer: play failed:', e);
+    }
   };
 
   if (!resolvedUrl) return null;
@@ -240,12 +249,10 @@ export default function WaveformPlayer({
         type="button"
         className="wf-player__btn"
         onClick={togglePlay}
-        disabled={!ready}
+        disabled={!resolvedUrl}
         aria-label={isPlaying ? 'Pause' : 'Play'}
       >
-        {!ready
-          ? <Loader size={compact ? 13 : 15} className="wf-player__spin" />
-          : isPlaying ? <Pause size={compact ? 13 : 15} /> : <Play size={compact ? 13 : 15} />}
+        {isPlaying ? <Pause size={compact ? 13 : 15} /> : <Play size={compact ? 13 : 15} />}
       </button>
       <div className="wf-player__wave" ref={containerRef} style={{ height }} />
       <span className="wf-player__time">{fmt(currentTime)} / {fmt(duration)}</span>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,6 +6,17 @@ if (import.meta.env.DEV && !window.__vite_plugin_react_preamble_installed__) {
   window.__vite_plugin_react_preamble_installed__ = true;
 }
 
+// AudioContext autoplay-policy unlock — MUST install before any module that
+// constructs an AudioContext (wavesurfer.js, the AEC tap, the dictation
+// capture, etc.). The side-effecting import patches `window.AudioContext`
+// to track every instance ever created; `installAudioUnlock()` then wires
+// a one-time pointerdown/keydown listener that resumes them all on the
+// first user gesture. Without this, Linux Firefox/Chrome and Android Chrome
+// leave WaveSurfer's AudioContext suspended → peaks decode hangs → `ready`
+// never fires → play button stays disabled → no /audio/ request ever fires.
+import { installAudioUnlock } from './utils/audioUnlock.js';
+installAudioUnlock();
+
 const { bootstrapApp } = await import('./main-app.jsx');
 
 bootstrapApp();

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -78,3 +78,17 @@ export function installAudioUnlock() {
   // pointerdown fast enough on the very first tap.
   window.addEventListener('touchstart', handler, opts);
 }
+
+// Test-only escape hatch. Not for production use — the unlock is meant to be
+// a one-shot per page load. Resetting lets unit tests exercise the unlock
+// path repeatedly against the same module instance.
+export function __resetForTesting() {
+  _unlocked = false;
+  _installed = false;
+  _resumeQueue.clear();
+  // Clear any listeners installAudioUnlock may have wired (capture-phase,
+  // once: true). removeEventListener is a no-op if the listener isn't
+  // registered, so call unconditionally — there's no way to reach the
+  // handler reference from outside, so we accept that already-fired listeners
+  // are gone (which is what `once:true` guarantees anyway).
+}

--- a/frontend/src/utils/audioUnlock.js
+++ b/frontend/src/utils/audioUnlock.js
@@ -1,0 +1,80 @@
+/**
+ * Browser autoplay-policy unlock for AudioContext.
+ *
+ * WaveSurfer.js (and several utils here) construct an `AudioContext` at
+ * component-mount time — i.e. before any user gesture. On Linux Firefox/Chrome
+ * and Android Chrome, browsers leave such a context in `"suspended"` state;
+ * `decodeAudioData` then hangs → WaveSurfer's `ready` event never fires →
+ * the play button stays disabled → no `/audio/` request is ever made.
+ *
+ * macOS Safari/Chrome are more lenient (typically auto-resume on first
+ * interaction) which is why the bug only manifests cross-platform.
+ *
+ * Fix: monkey-patch `window.AudioContext` to track every instance ever
+ * created, then resume all of them on the first user gesture (pointerdown /
+ * keydown). The patch MUST install before any module constructs an
+ * AudioContext — so this file is imported once at the top of main.jsx.
+ *
+ * Once unlocked, the document stays unlocked — we don't need to re-resume
+ * on every subsequent gesture.
+ */
+
+const _tracked = new WeakSet();
+const _resumeQueue = new Set();
+
+const _patch = (Ctor) => {
+  if (!Ctor || Ctor.__omnivoiceTracked) return Ctor;
+  class TrackedAudioContext extends Ctor {
+    constructor(...args) {
+      super(...args);
+      _tracked.add(this);
+      // Some browsers create the context already suspended; queue a resume
+      // attempt so that when the user gesture arrives, we sweep them all.
+      if (this.state === 'suspended') _resumeQueue.add(this);
+    }
+  }
+  TrackedAudioContext.__omnivoiceTracked = true;
+  return TrackedAudioContext;
+};
+
+if (typeof window !== 'undefined') {
+  if (window.AudioContext) window.AudioContext = _patch(window.AudioContext);
+  if (window.webkitAudioContext && window.webkitAudioContext !== window.AudioContext) {
+    window.webkitAudioContext = _patch(window.webkitAudioContext);
+  }
+}
+
+let _unlocked = false;
+export function unlockAudio() {
+  if (_unlocked) return Promise.resolve();
+  _unlocked = true;
+  // Snapshot then clear — new contexts created post-unlock will start in
+  // "running" state on their own (the document is now gesture-activated).
+  const pending = Array.from(_resumeQueue);
+  _resumeQueue.clear();
+  return Promise.all(
+    pending.map((ac) =>
+      ac.state === 'suspended' ? ac.resume().catch(() => {}) : Promise.resolve()
+    )
+  ).then(() => {});
+}
+
+let _installed = false;
+export function installAudioUnlock() {
+  if (_installed || typeof window === 'undefined') return;
+  _installed = true;
+  const opts = { once: true, capture: true };
+  const handler = () => {
+    unlockAudio().catch(() => {});
+    window.removeEventListener('pointerdown', handler, opts);
+    window.removeEventListener('keydown', handler, opts);
+    window.removeEventListener('touchstart', handler, opts);
+  };
+  // pointerdown beats click — fires earlier, so the resume completes before
+  // any click handler that depends on the AudioContext running.
+  window.addEventListener('pointerdown', handler, opts);
+  window.addEventListener('keydown', handler, opts);
+  // touchstart for mobile Safari/Chrome which sometimes don't synthesize
+  // pointerdown fast enough on the very first tap.
+  window.addEventListener('touchstart', handler, opts);
+}

--- a/frontend/src/utils/audioUnlock.test.js
+++ b/frontend/src/utils/audioUnlock.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+
+// Regression guard for the AudioContext autoplay-policy fix.
+// On Linux Firefox/Chrome and Android Chrome, AudioContexts created before
+// a user gesture stay suspended — decodeAudioData hangs, WaveSurfer's `ready`
+// never fires, play button stays disabled. The fix patches `window.AudioContext`
+// to track every instance and exposes unlockAudio() to resume them.
+//
+// Test strategy: install a fake AudioContext BEFORE importing audioUnlock.js
+// (the patch wraps window.AudioContext at module-load time). Each test resets
+// the singleton's unlocked flag so the resume path runs fresh.
+
+class FakeAudioContext {
+  constructor() {
+    this.state = 'suspended';
+    this.resumeCalls = 0;
+    this.resumeImpl = () => {
+      this.state = 'running';
+      return Promise.resolve();
+    };
+  }
+  resume() {
+    this.resumeCalls += 1;
+    return this.resumeImpl();
+  }
+  close() {
+    this.state = 'closed';
+    return Promise.resolve();
+  }
+}
+
+let audioUnlock;
+beforeAll(async () => {
+  // Install fake BEFORE the module's top-level patch runs.
+  window.AudioContext = FakeAudioContext;
+  audioUnlock = await import('./audioUnlock.js');
+});
+
+describe('audioUnlock', () => {
+  beforeEach(() => audioUnlock.__resetForTesting());
+
+  it('AudioContexts are wrapped at construction (proves patch is applied)', () => {
+    const ctx = new AudioContext();
+    // The patched class adds the __omnivoiceTracked marker and extends the
+    // fake (so state is 'suspended' from FakeAudioContext's constructor).
+    expect(window.AudioContext.__omnivoiceTracked).toBe(true);
+    expect(ctx.state).toBe('suspended');
+    expect(ctx.resumeCalls).toBe(0);
+  });
+
+  it('unlockAudio() resumes all suspended tracked contexts', async () => {
+    const ctx1 = new AudioContext();
+    const ctx2 = new AudioContext();
+    const ctx3 = new AudioContext();
+
+    await audioUnlock.unlockAudio();
+
+    expect(ctx1.state).toBe('running');
+    expect(ctx2.state).toBe('running');
+    expect(ctx3.state).toBe('running');
+    expect(ctx1.resumeCalls).toBe(1);
+    expect(ctx2.resumeCalls).toBe(1);
+    expect(ctx3.resumeCalls).toBe(1);
+  });
+
+  it('unlockAudio() is idempotent — repeated calls do not re-resume', async () => {
+    const ctx = new AudioContext();
+    await audioUnlock.unlockAudio();
+    expect(ctx.resumeCalls).toBe(1);
+
+    await audioUnlock.unlockAudio();
+    await audioUnlock.unlockAudio();
+    await audioUnlock.unlockAudio();
+    expect(ctx.resumeCalls).toBe(1);
+  });
+
+  it('contexts created AFTER unlock are not re-resumed by a second unlock', async () => {
+    const before = new AudioContext();
+    await audioUnlock.unlockAudio();
+    expect(before.resumeCalls).toBe(1);
+
+    const after = new AudioContext();
+    await audioUnlock.unlockAudio(); // no-op now (idempotent)
+    expect(after.resumeCalls).toBe(0);
+  });
+
+  it('resume() rejections are swallowed — one bad context does not block others', async () => {
+    const good = new AudioContext();
+    const bad = new AudioContext();
+    bad.resumeImpl = () => Promise.reject(new Error('policy blocked'));
+
+    // Should NOT throw — the catch in unlockAudio isolates failures.
+    await audioUnlock.unlockAudio();
+
+    expect(good.state).toBe('running');
+    expect(bad.state).toBe('suspended'); // its resume rejected; state unchanged
+  });
+
+  it('installAudioUnlock is idempotent — repeated calls are a no-op', () => {
+    // We can't directly enumerate window listeners, but the internal _installed
+    // gate guarantees one-time wiring. Calling repeatedly must not throw.
+    expect(() => {
+      audioUnlock.installAudioUnlock();
+      audioUnlock.installAudioUnlock();
+      audioUnlock.installAudioUnlock();
+    }).not.toThrow();
+  });
+});

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -655,3 +655,36 @@ def test_system_info_rejects_non_loopback():
     res = non_loopback_client.get("/system/info")
     assert res.status_code == 403
     assert "loopback" in res.json().get("detail", "").lower()
+
+
+def test_static_audio_served_with_canonical_mime():
+    """Regression: `.wav` files served by `/audio` StaticFiles must come back
+    with the IANA-canonical `audio/wav` Content-Type, NOT Python's default
+    `audio/x-wav`.
+
+    The `x-` prefix is vendor-experimental and never IANA-registered. macOS
+    Chrome/Safari MIME-sniff leniently via CoreAudio so playback works there,
+    but Linux Chrome/Firefox (FFmpeg) and Android Chrome (ExoPlayer) strictly
+    honor the declared type and treat `audio/x-wav` as download-only — which
+    silently broke the play button in the web app on those platforms.
+    """
+    from pathlib import Path
+    from fastapi.testclient import TestClient
+    from main import app
+    from core.config import OUTPUTS_DIR
+
+    # Drop a wav into the real OUTPUTS_DIR — the mount serves from there.
+    tmp_wav = Path(OUTPUTS_DIR) / f"__mime_test_{uuid.uuid4().hex[:8]}.wav"
+    tmp_wav.write_bytes(make_wav_bytes(0.1))
+    try:
+        client = TestClient(app)
+        res = client.get(f"/audio/{tmp_wav.name}")
+        assert res.status_code == 200, res.text
+        ct = res.headers.get("content-type", "")
+        assert ct == "audio/wav", (
+            f"Expected audio/wav (IANA canonical), got {ct!r}. "
+            f"Linux/Android browsers reject audio/x-wav as download-only."
+        )
+    finally:
+        tmp_wav.unlink(missing_ok=True)
+


### PR DESCRIPTION
Closes #510.

## Summary

The play button doesn't work on Linux Firefox/Chrome or Android Chrome — the symptom reported in #510 (and before that #476) after the layout and save-profile fixes in #488 / #489 landed. Two independent root causes, both masked on macOS, which is why this shipped:

1. **Backend served `.wav` / `.flac` as `audio/x-wav` / `audio/x-flac`** — Python's `mimetypes.guess_type()` default. These are vendor-experimental (the `x-` prefix, never IANA-registered). macOS CoreAudio sniffs content and plays anyway; Linux FFmpeg (Chrome/Firefox) and Android ExoPlayer strictly honor the declared type and prompt to download instead.
2. **WaveSurfer's `AudioContext` is constructed at component-mount time** — before any user gesture. On Linux FF/Chrome and Android Chrome the autoplay policy leaves it `suspended`; `decodeAudioData` hangs → the `ready` event never fires → the play button never enables (and in the current code `disabled={!ready}`, so it stays visibly disabled too). macOS Safari/Chrome auto-resume on first interaction.

## Why macOS never saw it

- **MIME**: CoreAudio content-sniffs, ignoring the `x-` prefix.
- **AudioContext**: macOS Safari/Chrome resume suspended contexts on first user interaction without an explicit `resume()` call.

Both behaviors are lenient on macOS and strict on Linux/Android. A dev on macOS can click the button a hundred times and never hit either bug.

## What this PR changes

**Backend (`backend/main.py`)** — register canonical MIME types before any `StaticFiles` mount:

```python
import mimetypes as _mimetypes
_mimetypes.add_type("audio/wav",  ".wav")
_mimetypes.add_type("audio/flac", ".flac")
```

**Frontend (`frontend/src/utils/audioUnlock.js`, new file)** — monkey-patch `window.AudioContext` to track every instance via `WeakSet`, and resume all suspended tracked contexts on the first `pointerdown` / `keydown` / `touchstart`. The patch installs at module-load time (`main.jsx`) before any AudioContext is constructed. `WaveformPlayer` also calls `unlockAudio()` inline on its click handler so the resume completes before `playPause()` runs.

**Test coverage**:
- `tests/test_api.py::test_static_audio_served_with_canonical_mime` — backend regression asserting `/audio/<file>.wav` returns `Content-Type: audio/wav`. Runs in the existing Linux CI matrix.
- `frontend/src/utils/audioUnlock.test.js` — Vitest unit test (6 cases) covering: patch applied at construction, resume-all on unlock, idempotency, post-unlock contexts not re-resumed, `resume()` rejection isolation, `installAudioUnlock` idempotency.

## Verification

- **macOS (before & after)**: no change — already worked.
- **Linux Firefox 151**: before — click play, nothing happens (no `/audio/` request in Network tab, console shows `An AudioContext was prevented from starting automatically. It must be created or resumed after a user gesture on the page.`). After — click play, audio plays inline, waveform progresses.
- **Vitest**: `bun run test src/utils/audioUnlock.test.js` → 6/6 passing.
- **Backend tests**: `tests/test_api.py::test_static_audio_served_with_canonical_mime` passing.

## Notes for review

- The `window.AudioContext` patch looks aggressive but is the minimum viable approach: WaveSurfer, the AEC tap, and dictation capture all construct AudioContexts at module/component-mount time, so a per-call-site `resume()` would miss instances. The patch is a one-time module-load side effect in `audioUnlock.js`, imported once from `main.jsx`. The `__omnivoiceTracked` marker prevents double-wrapping.
- The `disabled={!ready}` → `disabled={!resolvedUrl}` change in `WaveformPlayer` matters: `ready` depends on `decodeAudioData` succeeding, which depends on the AudioContext being unsuspended, which (pre-fix) depends on a gesture. With the AudioContext unlock in place, `ready` does fire on the first load — but `disabled={!resolvedUrl}` is also strictly more permissive and lets the user click through even if WaveSurfer's `ready` is delayed (e.g. on slow decode). Either way the click triggers `unlockAudio()` → `playPause()`.
- The MIME fix is defensive and applies globally — no behavioral change for any caller that was already getting a working type.

## Follow-up (not in this PR)

A Playwright e2e test that simulates clicking play and verifies an `/audio/` request fires would catch this whole class of bug in CI on every PR, including for maintainers who don't run Linux locally. The Vitest unit test covers the resume logic but doesn't exercise the full click→fetch path. Happy to follow up with a Playwright spec + CI wiring if there's interest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fixes audio playback failures on Linux/Android browsers (`#510`) by addressing two independent root causes: incorrect MIME type declarations for audio files and AudioContext suspension issues due to premature initialization before user gestures.

## Root Causes & Solutions

**MIME Type Issue**: The backend served `.wav` and `.flac` files with vendor-experimental MIME types (`audio/x-wav`, `audio/x-flac`), which macOS browsers tolerate through content-sniffing, but strict Linux/Android browsers treat as download-only.

**AudioContext Suspension**: WaveSurfer constructed `AudioContext` at component mount before any user gesture. Browser autoplay policies on Linux/Android left contexts suspended, causing decode to hang and the play button to remain disabled. macOS auto-resumed on interaction, masking the bug.

## Changes

**Backend (`main.py`)**: Registers canonical MIME types (`audio/wav`, `audio/flac`) via `mimetypes.add_type()` before `StaticFiles` mounts.

**Frontend (`utils/audioUnlock.js`, new)**: Monkey-patches `window.AudioContext` to track all instances. Exports:
- `installAudioUnlock()`: Registers a one-time capture-phase user-gesture listener (pointerdown/keydown/touchstart) that resumes all tracked suspended contexts
- `unlockAudio()`: Manually triggers context resumption (idempotent)
- `__resetForTesting()`: Test helper for state reset

**Frontend (`main.jsx`)**: Calls `installAudioUnlock()` early in startup before other modules execute.

**Frontend (`WaveformPlayer.jsx`)**: 
- Imports and calls `unlockAudio()` before play/pause
- Changes button disabled state from `!ready` to `!resolvedUrl` (enables button as soon as URL exists)
- Simplifies icon rendering (removes loader spinner)

## Test Coverage

- `tests/test_api.py`: Regression test verifying canonical MIME types served for audio files
- `frontend/src/utils/audioUnlock.test.js`: Vitest suite with 6 cases covering tracking, resumption, idempotency, post-unlock contexts, error isolation, and listener installation

## Audio Playback Flow (New Mechanism)

```mermaid
graph TD
    A["Page loads"] --> B["installAudioUnlock() installs gesture listener"]
    B --> C["User gesture triggers listener<br/>pointerdown/keydown/touchstart"]
    C --> D["unlockAudio() called"]
    D --> E["All suspended AudioContexts<br/>resume called"]
    E --> F["User clicks play button"]
    F --> G["unlockAudio called again<br/>idempotent - no-op"]
    G --> H["WaveSurfer playPause<br/>executes successfully"]
    H --> I["Audio decodes and plays"]
    
    J["URL resolved"] --> K["Play button enabled<br/>based on resolvedUrl"]
    K --> F
```

## Documentation

Updated CHANGELOG.md with entry in "Fixed" section documenting both root causes and solution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->