### PR TITLE
fix(donate): correct progress from $137.50 to actual $10/$200 raised

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ OmniVoice Studio is built by one developer using Claude Code and AI agents — a
 
 **This month's agent bill fund**
 
-<img src="https://img.shields.io/badge/raised_%2410_of_%24200-5%25-FF5E5B?style=for-the-badge" alt="$10 / $200 raised" />
+<img src="https://img.shields.io/badge/raised_%2410_of_%24200-5%25-EAB308?style=for-the-badge" alt="$10 / $200 raised" />
 
 <br/><br/>
 

--- a/frontend/public/donation_progress.json
+++ b/frontend/public/donation_progress.json
@@ -1,7 +1,7 @@
 {
-  "raised": 137.5,
+  "raised": 10,
   "goal": 200,
   "currency": "USD",
-  "sponsorCount": 23,
-  "updated": "2026-06-16"
+  "sponsorCount": 1,
+  "updated": "2026-06-17"
 }

--- a/frontend/src/api/donation.ts
+++ b/frontend/src/api/donation.ts
@@ -30,11 +30,11 @@ export interface DonationProgress {
  * bump both — a test asserts the bundled fallback is well-formed.
  */
 export const BUNDLED_PROGRESS: DonationProgress = {
-  raised: 137.5,
+  raised: 10,
   goal: 200,
   currency: 'USD',
-  sponsorCount: 23,
-  updated: '2026-06-16',
+  sponsorCount: 1,
+  updated: '2026-06-17',
 };
 
 /** Where the runtime-refreshable copy lives (served from `public/`). */


### PR DESCRIPTION
## Problem

The in-app "Fund Claude Max" goal bar showed **\$137.50 / \$200 (23 sponsors)** — fabricated numbers. The real amount is **\$10 / \$200, 1 sponsor**.

## Changes

- `frontend/public/donation_progress.json`: raised `137.5` → `10`, sponsorCount `23` → `1`, updated date
- `frontend/src/api/donation.ts`: BUNDLED_PROGRESS fallback synced to match
- `README.md`: badge color changed from red to yellow (in-progress, not near-goal)

## Test plan

- [x] Existing `GoalBar.test.jsx` asserts `raised > 0 && raised < goal` — still passes with 10
- [ ] Visual check on SupportPage that goal bar shows 5% / \$10 of \$200
- [ ] Visual check that Postcard mini bar shows same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Donation Progress Metrics Correction

This PR corrects inaccurate donation progress metrics displayed throughout the application. The interface was previously showing inflated figures ($137.50 / $200 with 23 sponsors), but the actual amount raised is $10 with 1 sponsor.

### Changes Made

**1. Data File Updates**
- `frontend/public/donation_progress.json`: Corrected raised amount from 137.5 to 10, sponsor count from 23 to 1, and updated timestamp from 2026-06-16 to 2026-06-17
- `frontend/src/api/donation.ts`: Synchronized the bundled offline fallback constant (`BUNDLED_PROGRESS`) with matching values to ensure consistency between the fetched and offline data sources
  
**2. Documentation & Badge Update**
- `README.md`: Updated the "Fund Claude Max" badge color from red (indicating near-goal) to yellow/amber (`EAB308`) to reflect the actual in-progress status of 5% ($10 of $200)

### Visual Impact

The donation progress badge changed from:
```
[raised $137.50 of $200 - 69% (red)] ❌ Misleading - near goal
```
to:
```
[raised $10 of $200 - 5% (yellow/amber)] ✓ Accurate - early stage
```

### Design Consistency

The changes maintain architectural integrity:
- The bundled fallback (`BUNDLED_PROGRESS`) and public JSON file are kept in lockstep, ensuring the goal bar renders correctly both offline and online
- All runtime normalization logic and fetching behavior remains unchanged
- Existing tests continue to pass with the corrected values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->