### PR TITLE
docs(readme): shorten 'Why OmniVoice Studio?' to 'Why OVS?'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <p>
     <a href="#quickstart">Quickstart</a> ·
     <a href="#features">Features</a> ·
-    <a href="#why-omnivoice-studio">Why OmniVoice Studio?</a> ·
+    <a href="#why-ovs">Why OVS</a> ·
     <a href="#tts-engines">TTS Engines</a> ·
     <a href="#asr-engines">ASR Engines</a> ·
     <a href="#sponsor--donate">Donate</a> ·
@@ -228,7 +228,7 @@ options, see [docs/downloading-models.md](docs/downloading-models.md).
 
 ---
 
-## Why OmniVoice Studio?
+## Why OVS?
 
 ElevenLabs charges **$5–$330/mo** and processes your audio on their servers. OmniVoice Studio runs **on your hardware, with no usage limits.**
 


### PR DESCRIPTION
Shorten the comparison section heading and nav anchor from 'Why OmniVoice Studio?' to 'Why OVS?'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR shortens the "Why OmniVoice Studio?" section heading to "Why OVS?" in the README.md documentation, along with updating the corresponding navigation anchor link.

## Changes
**README.md:**
- Updated the table of contents navigation link to point to `#why-ovs` with display text "Why OVS" (previously implied longer text)
- Renamed the main section heading from `## Why OmniVoice Studio?` to `## Why OVS?`

## Navigation Update
Before:
```
Navigation:
    [Why OmniVoice Studio?] → #... (misaligned anchor)

Section:
    ## Why OmniVoice Studio?
```

After:
```
Navigation:
    [Why OVS] → `#why-ovs`

Section:
    ## Why OVS?
```

This change improves consistency between the navigation link text and the section heading, while maintaining the intended anchor target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->