### PR TITLE
docs(readme): nav links above badges, download badges to Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
   <p>Real-time dictation, zero-shot voice cloning, and cinematic video dubbing — all on your desktop.<br/>Open-source, no API keys, fully local. <b>646 languages.</b></p>
 
   <p>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/stargazers"><img src="https://img.shields.io/github/stars/debpalash/OmniVoice-Studio?style=flat-square&color=f59e0b" alt="Stars" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/github/v/release/debpalash/OmniVoice-Studio?style=flat-square&color=10b981" alt="Release" /></a>
-    <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/issues"><img src="https://img.shields.io/github/issues/debpalash/OmniVoice-Studio?style=flat-square&color=ef4444" alt="Issues" /></a>
-    <a href="https://discord.gg/bzQavDfVV9"><img src="https://img.shields.io/badge/Discord-Join_Community-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
-    <a href="https://ko-fi.com/debpalash"><img src="https://img.shields.io/badge/Ko--fi-Support_Us-FF5E5B?style=flat-square&logo=ko-fi&logoColor=white" alt="Ko-fi" /></a>
-    <a href="https://github.com/sponsors/debpalash"><img src="https://img.shields.io/badge/GitHub-Sponsor-ff69b4?style=flat-square&logo=github&logoColor=white" alt="GitHub Sponsors" /></a>
-  </p>
-
-  <p>
     <a href="#quickstart">Quickstart</a> ·
     <a href="#features">Features</a> ·
     <a href="#why-ovs">Why OVS</a> ·
@@ -27,14 +17,13 @@
   </p>
 
   <p>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/macOS-DMG_(Apple_Silicon)-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS DMG" /></a>
-    <!-- Pre-built macOS bundle is Apple Silicon. Intel Macs: build from source (docs/install/macos.md); a pre-built Intel target is tracked in #279. -->
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Windows-MSI_(x64)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows MSI" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Linux-AppImage_(x64)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux AppImage" /></a>
-    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Debian-.deb-A81D33?style=for-the-badge&logo=debian&logoColor=white" alt="Download Debian .deb" /></a>
-  </p>
-  <p>
-    <sub><b>macOS:</b> first launch needs a one-time approval — right-click → <b>Open</b> (or System Settings → Privacy &amp; Security → <b>"Open Anyway"</b> on macOS 15). No Terminal needed. <a href="docs/install/macos.md#gatekeeper-quarantine">Why?</a></sub>
+    <a href="https://github.com/debpalash/OmniVoice-Studio/stargazers"><img src="https://img.shields.io/github/stars/debpalash/OmniVoice-Studio?style=flat-square&color=f59e0b" alt="Stars" /></a>
+    <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/github/v/release/debpalash/OmniVoice-Studio?style=flat-square&color=10b981" alt="Release" /></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License" /></a>
+    <a href="https://github.com/debpalash/OmniVoice-Studio/issues"><img src="https://img.shields.io/github/issues/debpalash/OmniVoice-Studio?style=flat-square&color=ef4444" alt="Issues" /></a>
+    <a href="https://discord.gg/bzQavDfVV9"><img src="https://img.shields.io/badge/Discord-Join_Community-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
+    <a href="https://ko-fi.com/debpalash"><img src="https://img.shields.io/badge/Ko--fi-Support_Us-FF5E5B?style=flat-square&logo=ko-fi&logoColor=white" alt="Ko-fi" /></a>
+    <a href="https://github.com/sponsors/debpalash"><img src="https://img.shields.io/badge/GitHub-Sponsor-ff69b4?style=flat-square&logo=github&logoColor=white" alt="GitHub Sponsors" /></a>
   </p>
 </div>
 
@@ -155,6 +144,15 @@
 ---
 
 ## Quickstart
+
+<div align="center">
+  <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/macOS-DMG_(Apple_Silicon)-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS DMG" /></a>
+  <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Windows-MSI_(x64)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows MSI" /></a>
+  <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Linux-AppImage_(x64)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux AppImage" /></a>
+  <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Debian-.deb-A81D33?style=for-the-badge&logo=debian&logoColor=white" alt="Download Debian .deb" /></a>
+  <br/>
+  <sub><b>macOS:</b> first launch needs a one-time approval — right-click → <b>Open</b> (or System Settings → Privacy &amp; Security → <b>"Open Anyway"</b> on macOS 15). No Terminal needed. <a href="docs/install/macos.md#gatekeeper-quarantine">Why?</a></sub>
+</div>
 
 Per-OS install guides — pick yours and follow it end-to-end:
 


### PR DESCRIPTION
Rearranges the README header so nav links come first (above badges), and moves the platform download badges into the Quickstart section where they're actionably placed next to install instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## README Header and Quickstart Reorganization

This PR restructures the OmniVoice-Studio README header to improve information hierarchy and align download badges with installation workflows.

### Layout Changes

**Before:**
```
┌─────────────────────────────────────────┐
│         OmniVoice Studio Logo           │
│         [Tagline & Description]         │
│                                         │
│  [Download Badges - Platform Links]     │
│  macOS · Windows · Linux · Debian       │
│                                         │
│  [Social/Badge Links]                   │
│  [Stars] [Release] [License] [Issues]   │
│  [Discord] [Ko-fi] [Sponsors]           │
│                                         │
│  [Social Preview Image]                 │
└─────────────────────────────────────────┘

## Quickstart
[Installation instructions...]
```

**After:**
```
┌─────────────────────────────────────────┐
│         OmniVoice Studio Logo           │
│         [Tagline & Description]         │
│                                         │
│  [Navigation Links]                     │
│  Quickstart · Features · Why OVS · ...  │
│  TTS Engines · ASR Engines · Discord    │
│                                         │
│  [Social/Badge Links]                   │
│  [Stars] [Release] [License] [Issues]   │
│  [Discord] [Ko-fi] [Sponsors]           │
│                                         │
│  [Social Preview Image]                 │
└─────────────────────────────────────────┘

## Quickstart

[Download Badges - Platform Links]
┌──────────────────────────────────────┐
│ macOS DMG   Windows MSI  Linux AppImage│
│             Debian .deb                │
│  [macOS Gatekeeper approval note]      │
└──────────────────────────────────────┘

[Installation instructions...]
```

### Key Changes

**Header reorganization:**
- Navigation links (Quickstart, Features, Why OVS, TTS/ASR Engines, Donate, Contributing, Discord, 简体中文) positioned immediately after the tagline for improved scannability
- Social/platform badges (Stars, Release, License, Issues, Discord, Ko-fi, Sponsors) repositioned below navigation links while maintaining header visibility

**Quickstart section enhancement:**
- Platform-specific download badges (macOS Apple Silicon DMG, Windows x64 MSI, Linux AppImage, Debian .deb) relocated from header area to Quickstart section
- macOS Gatekeeper approval guidance and link added directly below download badges with actionable instructions
- Badges positioned immediately before per-OS installation guide list for improved context and user workflow

**Lines changed:** +16/-18  
**Complexity:** Documentation only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->