### PR TITLE
fix(projects): preview finished renders in-app, not via window.open (#532)

### DIFF
--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -8,6 +8,7 @@ import {
 import { apiFetch } from '../api/client';
 import { loadTranscriptions, TRANSCRIPTION_EVENT } from '../utils/transcriptionsStore';
 import { audioUrl } from '../api/generate';
+import { playBlobAudio } from '../utils/media';
 import './Projects.css';
 
 /**
@@ -49,6 +50,26 @@ function fmtDuration(sec) {
   const m = Math.floor(n / 60);
   const s = Math.floor(n % 60);
   return `${m}m ${s}s`;
+}
+
+/**
+ * Preview a finished render (audiobook/story) inside the app.
+ *
+ * Previously the card did `window.open(url, '_blank')`. Under Tauri's WebView2
+ * on Windows that handed the file to a new webview/OS media surface, spawning a
+ * separate black playback window with centered controls that the user couldn't
+ * close without force-quitting the whole app (#532). Fetch the file and route
+ * it through the shared single-playback manager instead — identical, in-app
+ * behavior on macOS/Windows/Linux, and starting another preview stops this one.
+ */
+async function playRenderInApp(url) {
+  try {
+    const resp = await fetch(url, { cache: 'no-store' });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    await playBlobAudio(await resp.blob());
+  } catch (e) {
+    console.error('[Projects] render playback failed:', e);
+  }
 }
 
 function Card({ kind, accent, title, subtitle, trailing, onClick, IconC }) {
@@ -201,7 +222,7 @@ export default function Projects({
         ts: (j.created_at || 0) * 1000,
         accent: '#d3869b',
         Icon: BookMarked,
-        onClick: () => j.output && window.open(audioUrl(j.output), '_blank'),
+        onClick: () => j.output && playRenderInApp(audioUrl(j.output)),
       });
     }
     for (const tr of transcriptions) {

--- a/frontend/src/test/ProjectsAudiobookPlayback.test.jsx
+++ b/frontend/src/test/ProjectsAudiobookPlayback.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+// Regression guard for #532: a finished audiobook/story render must preview
+// IN-APP. The card used to call window.open(url, '_blank'), which under Tauri's
+// WebView2 on Windows spawned a separate, un-closeable black media window. The
+// fix routes the render through the shared in-app playback path (playBlobAudio).
+
+vi.mock('../utils/media', () => ({ playBlobAudio: vi.fn() }));
+vi.mock('../api/generate', () => ({ audioUrl: (f) => `http://test.local/audio/${f}` }));
+vi.mock('../api/client', () => ({
+  apiFetch: vi.fn(async (path) => {
+    if (path === '/longform/jobs') {
+      return {
+        json: async () => ({
+          jobs: [{ job_id: 'jb1', output: 'book.wav', title: 'My Audiobook', type: 'audiobook', created_at: 1 }],
+        }),
+      };
+    }
+    return { json: async () => ({}) };
+  }),
+}));
+
+import Projects from '../pages/Projects';
+import { playBlobAudio } from '../utils/media';
+
+describe('Projects — audiobook playback (#532)', () => {
+  let fetchMock;
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    fetchMock = vi.fn(async () => ({ ok: true, blob: async () => new Blob(['x']) }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+  it('plays the render in-app and never opens a separate window', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<Projects />);
+
+    // The longform job loads via apiFetch('/longform/jobs') in an effect.
+    const card = (await screen.findByText('My Audiobook')).closest('button');
+    expect(card).toBeTruthy();
+
+    fireEvent.click(card);
+
+    await waitFor(() => expect(playBlobAudio).toHaveBeenCalledTimes(1));
+    // In-app fetch of the render file, never a new window/OS media surface.
+    expect(fetchMock).toHaveBeenCalledWith('http://test.local/audio/book.wav', { cache: 'no-store' });
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

After generation, Windows users reported a **separate black playback window with media controls in the center** auto-opening and playing the output — un-closeable without force-quitting the whole app. Two reporters (hieu03099, Cuongnm) on 0.3.6 / Windows 11.

## Root cause

`frontend/src/pages/Projects.jsx` rendered the finished audiobook/story (longform) library card with:

```js
onClick: () => j.output && window.open(audioUrl(j.output), '_blank'),
```

Under Tauri's WebView2 on Windows, `window.open(mediaUrl, '_blank')` hands the file to a new webview / OS media surface — exactly the "separate black window with centered controls" symptom. This is the **only** raw `window.open` on a media URL anywhere in the frontend (`new Audio()` plays inline; `revealItemInDir` opens a file explorer), so it's the single code path that can spawn a separate media window — confirmed by grepping `frontend/src`.

The project even documents this trap in `src/api/external.ts`: *"In a Tauri desktop app `window.open()` is blocked by the webview."*

## Fix

Route the render through the app's shared single-playback manager via `playBlobAudio` (the same path used for generated output):

```js
onClick: () => j.output && playRenderInApp(audioUrl(j.output)),
```

`playRenderInApp` fetches the file and plays it in-app — **identical behavior on macOS/Windows/Linux** (cross-platform parity rule), and because it claims the global playback manager (#316), starting another preview stops this one. No separate window, nothing to force-quit. Matches the issue's "Expected": preview inside the main app.

## Tests

- New `frontend/src/test/ProjectsAudiobookPlayback.test.jsx`: renders Projects with a longform job, clicks the card, asserts it plays in-app (`playBlobAudio` called, render fetched) and **never** calls `window.open`. Fails on the old code, passes on the fix.
- Full frontend suite: **62 files / 544 tests pass** (`bunx vitest run`).
- `typecheck:ci` clean (the CI-gated frontend check).

No version bump, no backend changes, no new user-facing strings (i18n untouched), backward-compatible.

## Note for the owner

The two reporters' exact trigger is still being confirmed over Discord (a separate pending reply asks whether the window is an OS app vs an in-app surface, and whether it fires on every generate). This patch fixes the one code path that can produce the reported "separate window" symptom; if a non-code cause (OS file association) also exists, that's outside the app. Holding as **draft** for your call.

Fixes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a Windows-specific bug where a separate, un-closeable black playback window with media controls auto-opens after audio generation completes. The root cause is `window.open(audioUrl, '_blank')` in the audiobook card click handler, which under Tauri's WebView2 on Windows hands the media file to a separate webview or OS surface instead of playing in-app.

## Changes

**frontend/src/pages/Projects.jsx**
- Added `playRenderInApp(url)` helper function that:
  - Fetches the audio file with `cache: 'no-store'`
  - Converts the response to a blob
  - Routes playback through the app's shared `playBlobAudio` manager
  - Logs any fetch failures to console
- Updated audiobook/story library card click handler from `window.open(audioUrl(...), '_blank')` to `playRenderInApp(audioUrl(j.output))`

**frontend/src/test/ProjectsAudiobookPlayback.test.jsx** *(new)*
- Added regression test for issue `#532` that:
  - Mocks `playBlobAudio` and the audio URL generator
  - Stubs the `/longform/jobs` API to return a finished audiobook job
  - Stubs global `fetch` to return a blob
  - Spies on `window.open`
  - Verifies that clicking the audiobook card invokes `playBlobAudio` exactly once
  - Verifies that `fetch` is called with the audio URL and `{ cache: 'no-store' }` option
  - Asserts that `window.open` is never called

## Behavioral Change

```mermaid
graph TD
    A["User clicks audiobook card"] --> B{"Playback method"}
    B -->|Before| C["window.open audioUrl blank"]
    C --> D["⚠️ Separate OS/webview window opens"]
    D --> E["Black window with unremovable controls"]
    B -->|After| F["playRenderInApp audioUrl"]
    F --> G["Fetch audio as blob"]
    G --> H["playBlobAudio blob"]
    H --> I["✓ In-app waveform player"]
    I --> J["Consistent cross-platform behavior"]
```

## Additional Benefits

- Automatic single-playback enforcement: starting another preview stops the current one (all playback uses the shared manager)
- Identical behavior across macOS, Windows, and Linux
- Backward-compatible; no version bump or API changes required

## Verification

- Full frontend test suite passes (62 files, 544 tests)
- `typecheck:ci` clean
- Regression test confirms in-app playback and prevents `window.open` on media URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->