### PR TITLE
fix(audiobook): import 500 — add AudiobookPlan.chapter_count (#543)

### DIFF
--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -65,10 +65,14 @@ class AudiobookPlan:
     def char_count(self) -> int:
         return sum(c.char_count for c in self.chapters)
 
+    @property
+    def chapter_count(self) -> int:
+        return len(self.chapters)
+
     def to_dict(self) -> dict:
         return {
             "chapters": [c.to_dict() for c in self.chapters],
-            "chapter_count": len(self.chapters),
+            "chapter_count": self.chapter_count,
             "char_count": self.char_count,
         }
 

--- a/tests/test_audiobook.py
+++ b/tests/test_audiobook.py
@@ -76,6 +76,15 @@ def test_plan_to_dict_shape():
     assert d["chapters"][0]["spans"][0]["text"] == "Hi there."
 
 
+def test_plan_chapter_count_property():
+    # Regression for #543: the /audiobook/import endpoint reads plan.chapter_count
+    # directly (not via to_dict), so the attribute must exist and stay in lockstep
+    # with the serialized key.
+    plan = parse_audiobook_script("# A\nHi.\n# B\nBye.")
+    assert plan.chapter_count == 2
+    assert plan.chapter_count == plan.to_dict()["chapter_count"]
+
+
 # ── FFMETADATA ───────────────────────────────────────────────────────────────
 
 def test_ffmetadata_cumulative_offsets():

--- a/tests/test_longform_import.py
+++ b/tests/test_longform_import.py
@@ -5,10 +5,12 @@ EPUB zip in memory (no fixture file, no new dep).
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import zipfile
 
 import pytest
+from fastapi import UploadFile
 
 from services.longform_import import (
     chapterize_plaintext,
@@ -16,6 +18,7 @@ from services.longform_import import (
     pdf_to_chapter_script,
 )
 from services.audiobook import parse_audiobook_script
+from api.routers.audiobook import audiobook_import
 
 
 # ── PDF fixture builder ───────────────────────────────────────────────────
@@ -219,3 +222,28 @@ def test_pdf_too_many_pages_guard():
     data = _make_pdf(["Chapter 1", "Hi."])
     with pytest.raises(ValueError, match="too many pages"):
         pdf_to_chapter_script(data, max_pages=0)
+
+
+# ── import endpoint ────────────────────────────────────────────────────────
+# Calls the handler directly (no TestClient → no main+torch import), mirroring
+# tests/test_audiobook_cover.py.
+
+def _upload(name: str, data: bytes) -> UploadFile:
+    return UploadFile(io.BytesIO(data), filename=name)
+
+
+def test_import_endpoint_returns_chapter_count():
+    # Regression for #543: parsing succeeded but the endpoint then read
+    # plan.chapter_count, which didn't exist → 500 AttributeError. Covers the
+    # whole class — every import format hits this same return path.
+    pdf = _make_pdf(["Chapter 1", "Once upon a time.", "Chapter 2", "The end."])
+    for name, data in [
+        ("book.pdf", pdf),
+        ("book.md", b"# One\nhello\n\n# Two\nworld"),
+        ("book.txt", b"just a flat blob of narration with no headings"),
+    ]:
+        res = asyncio.run(audiobook_import(_upload(name, data)))
+        assert isinstance(res["chapters"], int) and res["chapters"] >= 1
+        assert res["text"].strip()
+    # The two-chapter inputs parse to exactly two chapters.
+    assert asyncio.run(audiobook_import(_upload("book.pdf", pdf)))["chapters"] == 2


### PR DESCRIPTION
## What

`POST /audiobook/import` (Audiobook tab → Import) returned a 500:

```
Import failed: 500 Internal Server Error: 'AudiobookPlan' object has no attribute 'chapter_count'
```

The file *parsed* fine — the crash was the very next line, `plan.chapter_count`, accessing an attribute that didn't exist on `AudiobookPlan` (it only had `char_count` as a property and emitted `chapter_count` from `to_dict()`). Because the crash is in the shared post-parse return path, it broke **every** import format — `.txt`, `.md`, `.epub`, `.pdf` — not just the PDF the reporter hit.

## Fix

Add a `chapter_count` property to `AudiobookPlan` mirroring the existing `char_count`, and have `to_dict()` derive its `chapter_count` key from the property so the attribute and the serialized key can't drift again. No API/schema/data change; backward compatible.

## Tests

- `tests/test_audiobook.py::test_plan_chapter_count_property` — unit cover of the property + lockstep with `to_dict()`.
- `tests/test_longform_import.py::test_import_endpoint_returns_chapter_count` — calls the `audiobook_import` handler directly (pdf/md/txt), reproducing the user's exact path. Both fail-before with `AttributeError`, pass-after.

Full backend suite green locally: `uv run pytest tests/ -q` → **1694 passed, 20 skipped, 11 xfailed, 3 xpassed**.

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes issue `#543` where the `POST /audiobook/import` endpoint crashed with `'AudiobookPlan' object has no attribute 'chapter_count'` when importing any supported document format (.txt, .md, .epub, .pdf).

## Root Cause
The endpoint handler calls `plan.chapter_count` after successfully parsing the input file, but `AudiobookPlan` lacked this attribute. While `to_dict()` emitted a `"chapter_count"` key, it computed the value inline rather than deriving it from a property, leaving the class without the attribute when accessed directly.

## Changes

### backend/services/audiobook.py
- Added `@property chapter_count(self) -> int` to `AudiobookPlan` that returns `len(self.chapters)`, mirroring the existing `char_count` property pattern
- Refactored `to_dict()` to derive the `"chapter_count"` key from the new property instead of computing it inline, ensuring attribute-serialization consistency and preventing future drift
- No API, schema, or data changes introduced; output format remains unchanged

### tests/test_audiobook.py
- Added `test_plan_chapter_count_property` unit test verifying the property exists and stays synchronized with the serialized output for a two-chapter test case

### tests/test_longform_import.py
- Added "import endpoint" regression test block with helper `_upload()` function
- New test `test_import_endpoint_returns_chapter_count` directly invokes the `audiobook_import` handler via `asyncio.run()` with in-memory `UploadFile` objects
- Covers all three supported import formats: PDF, Markdown, and plain text
- Verifies endpoint returns integer `chapters` count and non-empty `text` field
- Validates two-chapter inputs produce exactly two chapters in output

## Mechanism Flow
```mermaid
graph LR
    A["File Upload<br/>(PDF/MD/TXT)"] --> B["Parse to<br/>AudiobookPlan"]
    B --> C["Access<br/>plan.chapter_count"]
    C --> D["Property returns<br/>len(chapters)"]
    D --> E["Return response<br/>with chapters field"]
    E --> F["✓ 200 Success"]
    
    style C fill:`#90EE90`
    style D fill:`#90EE90`
    style F fill:`#90EE90`
```

## Testing
- Full backend test suite passes: 1694 passed, 20 skipped, 11 xfailed, 3 xpassed
- Both test cases fail with `AttributeError` on unfixed code and pass after fix
- Backward compatible; no breaking changes to API or data model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->