### PR TITLE
fix(voice): stop poisoning design profiles with "[object Object]" instruct

### DIFF
--- a/backend/migrations/versions/0006_strip_object_object_instruct.py
+++ b/backend/migrations/versions/0006_strip_object_object_instruct.py
@@ -1,0 +1,36 @@
+"""Heal voice_profiles.instruct poisoned with the "[object Object]" sentinel.
+
+Revision ID: 0006_strip_object_object_instruct
+Revises: 0005_unified_profiles
+Create Date: 2026-06-20 00:00:00.000000
+
+A pre-fix Voice Studio build ("Save design as profile") passed the
+``buildDesignInstruct()`` *object* straight to FormData, which string-coerced it
+to the literal ``"[object Object]"`` and persisted that into
+``voice_profiles.instruct`` (#550 #545 #542 #537 #530 #525). On first
+preview/use that value fails the engine instruct validator with a 400. The
+frontend + backend fixes stop any NEW poisoned rows; this migration heals the
+ones already saved on the buggy build (the local-first backward-compat rule —
+existing project data must keep working without manual migration).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "0006_strip_object_object_instruct"
+down_revision: Union[str, None] = "0005_unified_profiles"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if "voice_profiles" in inspect(bind).get_table_names():
+        # Idempotent: only touches rows whose instruct is literally the sentinel.
+        op.execute("UPDATE voice_profiles SET instruct='' WHERE instruct='[object Object]'")
+
+
+def downgrade() -> None:
+    # Irreversible heal — the original garbage sentinel is not worth restoring.
+    pass

--- a/frontend/src/hooks/useProfiles.js
+++ b/frontend/src/hooks/useProfiles.js
@@ -5,6 +5,7 @@ import { createProfile, deleteProfile as apiDeleteProfile, lockProfile, unlockPr
 import { generateSpeech, audioUrlWithCacheBust } from '../api/generate';
 import { playBlobAudio } from '../utils/media';
 import { PRESETS } from '../utils/constants';
+import { instructToFormValue } from '../utils/voiceInstruct';
 import { askConfirm } from '../utils/dialog';
 import { toast } from 'react-hot-toast';
 import { evaluateDonationPrompt } from '../components/donate/evaluateDonationPrompt';
@@ -93,7 +94,11 @@ export default function useProfiles({ loadHistory, loadProfiles }) {
     fd.append('name', profileName);
     fd.append('kind', 'design');
     fd.append('vd_states', JSON.stringify(vdStates || {}));
-    fd.append('instruct', instruct || '');
+    // Defensive: instruct must be the STRING. buildDesignInstruct() returns an
+    // object — appending it coerced to "[object Object]", poisoning the profile
+    // (#550 et al). instructToFormValue extracts .instruct if an object slips
+    // through, so the field is never garbage.
+    fd.append('instruct', instructToFormValue(instruct));
     fd.append('language', language || 'Auto');
     try {
       await createProfile(fd);

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -606,7 +606,7 @@ export default function CloneDesignTab(props) {
                     onChange={e => setProfileName(e.target.value)}
                   />
                   <Button variant="subtle" size="sm"
-                    onClick={() => handleSaveDesignProfile(vdStates, buildDesignInstruct(vdStates, instruct), language)}>
+                    onClick={() => handleSaveDesignProfile(vdStates, buildDesignInstruct(vdStates, instruct).instruct, language)}>
                     {t('clone.save')}
                   </Button>
                   <Button variant="ghost" size="sm" onClick={() => setShowSaveProfile(false)}>{t('clone.cancel')}</Button>

--- a/frontend/src/utils/voiceInstruct.js
+++ b/frontend/src/utils/voiceInstruct.js
@@ -67,6 +67,22 @@ export function buildDesignInstruct(vdStates = {}, freeText = '') {
 }
 
 /**
+ * Coerce an instruct value to the STRING that belongs in the FormData/payload.
+ * `buildDesignInstruct()` returns `{ instruct, unsupported, duplicates }`, and
+ * passing that object to `FormData.append` string-coerced it to the literal
+ * `"[object Object]"`, poisoning saved design profiles (#550 #545 #542 #537
+ * #530 #525). Always run instruct through this before sending it.
+ *
+ * @param {string | { instruct?: string } | null | undefined} instruct
+ * @returns {string}
+ */
+export function instructToFormValue(instruct) {
+  if (typeof instruct === 'string') return instruct;
+  if (instruct && typeof instruct === 'object') return String(instruct.instruct ?? '');
+  return '';
+}
+
+/**
  * Project the backend's "describe your voice" result (#317) onto a fresh
  * vdStates object. The description drives the *whole* parameter set — matched
  * categories get their token, everything else resets to 'Auto' — so retyping

--- a/frontend/src/utils/voiceInstruct.test.js
+++ b/frontend/src/utils/voiceInstruct.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildDesignInstruct } from './voiceInstruct';
+import { buildDesignInstruct, instructToFormValue } from './voiceInstruct';
 
 // plan-05 (#132): the Voice Design payload must be a validator-safe instruct —
 // one valid tag per category, no unsupported free-text — so Synthesize stops
@@ -55,5 +55,23 @@ describe('buildDesignInstruct', () => {
     const { instruct, unsupported } = buildDesignInstruct({ Gender: 'nonbinary' }, '');
     expect(instruct).toBe('');
     expect(unsupported).toEqual([]);
+  });
+});
+
+describe('instructToFormValue (#550 [object Object] guard)', () => {
+  it('extracts the string from a buildDesignInstruct() object, never "[object Object]"', () => {
+    const built = buildDesignInstruct({ Gender: 'male' }, '');
+    // the bug: appending the raw object to FormData string-coerces to this
+    expect(String(built)).toBe('[object Object]');
+    expect(typeof instructToFormValue(built)).toBe('string');
+    expect(instructToFormValue(built)).toBe('male');
+    expect(instructToFormValue(built)).not.toBe('[object Object]');
+  });
+
+  it('passes a plain string through and coerces null/garbage to ""', () => {
+    expect(instructToFormValue('male, high pitch')).toBe('male, high pitch');
+    expect(instructToFormValue(null)).toBe('');
+    expect(instructToFormValue(undefined)).toBe('');
+    expect(instructToFormValue({})).toBe('');
   });
 });

--- a/omnivoice/models/omnivoice.py
+++ b/omnivoice/models/omnivoice.py
@@ -1412,7 +1412,11 @@ def _resolve_instruct(
 
     # Split on both half-width and full-width commas
     raw_items = re.split(r"\s*[,，]\s*", instruct_str)
-    raw_items = [x for x in raw_items if x]
+    # Tolerate the "[object Object]" sentinel a buggy frontend build could have
+    # persisted into voice_profiles.instruct (#550 et al): drop it instead of
+    # 400-ing the whole generation. The 0006 migration heals stored values; this
+    # guards any that slip through (e.g. generation_history rows).
+    raw_items = [x for x in raw_items if x and x.strip().lower() != "[object object]"]
 
     # Validate each item
     unknown = []

--- a/tests/backend/core/test_personalities.py
+++ b/tests/backend/core/test_personalities.py
@@ -106,3 +106,19 @@ def test_every_personality_instruct_is_accepted_by_resolve_instruct():
             f"Personality {p['id']!r} instruct {p['instruct']!r} normalised "
             "to nothing — pick at least one taxonomy token."
         )
+
+
+def test_resolve_instruct_tolerates_object_object_sentinel():
+    """A pre-fix Voice Studio build persisted the literal "[object Object]" into
+    voice_profiles.instruct (#550 et al). _resolve_instruct must DROP that
+    sentinel and not 400 the whole generation, while still rejecting a genuine
+    unsupported token."""
+    resolve_instruct = _import_resolver()
+    # sentinel alone → treated as empty (no ValueError); returns falsy
+    assert not resolve_instruct("[object Object]")
+    assert not resolve_instruct("[OBJECT object]")  # case-insensitive
+    # sentinel mixed with a valid token → the valid token survives, no raise
+    assert resolve_instruct("male, [object Object]") == "male"
+    # a real unsupported token must STILL raise (the #114/#115 user feedback)
+    with pytest.raises(ValueError):
+        resolve_instruct("frobnicate")

--- a/tests/test_migration_0006_instruct.py
+++ b/tests/test_migration_0006_instruct.py
@@ -1,0 +1,59 @@
+"""Migration 0006 heals voice_profiles.instruct poisoned with the
+"[object Object]" sentinel (#550 #545 #542 #537 #530 #525). Drives alembic on a
+temp SQLite DB, mirroring tests/test_profile_consent.py's migration harness."""
+import os
+import sqlite3
+
+# A pre-0003 voice_profiles — the shape the alembic chain expects to upgrade
+# (matches tests/test_profile_consent.py::_PRE_CONSENT_PROFILES).
+_BASE_PROFILES = """
+    CREATE TABLE voice_profiles (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        ref_audio_path TEXT,
+        ref_text TEXT DEFAULT '',
+        instruct TEXT DEFAULT '',
+        language TEXT DEFAULT 'Auto',
+        locked_audio_path TEXT DEFAULT '',
+        seed INTEGER DEFAULT NULL,
+        is_locked INTEGER DEFAULT 0,
+        personality TEXT DEFAULT '',
+        description TEXT DEFAULT '',
+        is_demo INTEGER DEFAULT 0,
+        created_at REAL
+    );
+"""
+
+
+def _run_alembic_upgrade(db_path: str, target: str = "head") -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    root = os.path.abspath(os.path.dirname(__file__))
+    while root and root != "/" and not os.path.isfile(os.path.join(root, "alembic.ini")):
+        root = os.path.dirname(root)
+    assert os.path.isfile(os.path.join(root, "alembic.ini")), "alembic.ini not found"
+    cfg = Config(os.path.join(root, "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    command.upgrade(cfg, target)
+
+
+def test_migration_0006_heals_object_object_instruct(tmp_path):
+    db = tmp_path / "poisoned.db"
+    with sqlite3.connect(str(db)) as conn:
+        conn.executescript(_BASE_PROFILES)
+        # a poisoned row (the #550 bug) + a healthy row that must be untouched
+        conn.execute(
+            "INSERT INTO voice_profiles(id, name, instruct) VALUES ('vp-bad', 'Bad', '[object Object]')"
+        )
+        conn.execute(
+            "INSERT INTO voice_profiles(id, name, instruct) VALUES ('vp-ok', 'Ok', 'male, high pitch')"
+        )
+        conn.commit()
+
+    _run_alembic_upgrade(str(db))
+
+    with sqlite3.connect(str(db)) as conn:
+        rows = dict(conn.execute("SELECT id, instruct FROM voice_profiles").fetchall())
+    assert rows["vp-bad"] == "", "0006 must clear the [object Object] sentinel"
+    assert rows["vp-ok"] == "male, high pitch", "0006 must not touch healthy instruct values"


### PR DESCRIPTION
## Bug (#550 #545 #542 #537 #530 #525)

Voice Studio **"Save design as profile"** passed `buildDesignInstruct()`'s **return object** `{instruct, unsupported, duplicates}` straight to `FormData.append`, which string-coerces an object to the literal **`"[object Object]"`**. That was persisted into `voice_profiles.instruct` and `400`'d on first preview/use: *"Unsupported instruct items found in [object Object]"*. Six independent reports.

## Fix (whole class + heal existing data)

| Layer | Change |
|---|---|
| **Source** | `CloneDesignTab.jsx:609` passes `.instruct` (the string), not the object |
| **Defense** | `useProfiles.js` appends via new `instructToFormValue()` — extracts `.instruct` if an object slips through again |
| **Engine** | `_resolve_instruct` drops the `"[object Object]"` sentinel instead of raising (a *real* unsupported token still raises — keeps #114/#115 feedback) |
| **Data heal** | alembic **0006** clears the sentinel from already-saved profiles (idempotent, table-guarded — the backward-compatible-data rule) |

## Tests (fail-before / pass-after)
- Frontend (`voiceInstruct.test.js`): `instructToFormValue(buildDesignInstruct(...))` is a string `'male'`, **never** `'[object Object]'`. → **9 passed**, typecheck clean.
- Backend (`test_personalities.py`): `_resolve_instruct('[object Object]')` → falsy (no raise); `'male, [object Object]'` → `'male'`; `'frobnicate'` → still raises.
- Migration (`test_migration_0006_instruct.py`): a poisoned row heals to `''`, a healthy row is untouched. → **backend 5 passed**.

Cross-platform: pure JS/Python string handling — identical on mac/win/linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bug Fix: Voice Studio "Save Design as Profile" Persisting "[object Object]"

### Problem
The "Save design as profile" feature was persisting the literal string `"[object Object]"` to the database instead of the actual voice instruction string. This occurred because `buildDesignInstruct()` returns an object `{instruct, unsupported, duplicates}`, but the entire object was being passed to `FormData.append()`, which string-coerced it to the sentinel value. Saved profiles subsequently failed on first use with: `400 "Unsupported instruct items found in [object Object]"`.

### Solution
A four-layer fix prevents future occurrences and heals existing poisoned data:

#### **Frontend Layer**
- **`CloneDesignTab.jsx`**: Extract only `.instruct` string property from `buildDesignInstruct()` result before passing to save handler
- **`voiceInstruct.js`**: New `instructToFormValue()` helper normalizes instruct inputs—returns strings unchanged, extracts `.instruct` from objects, coerces null/undefined to empty string
- **`useProfiles.js`**: Defense layer applies `instructToFormValue()` transformation when appending instruct to FormData

#### **Backend Layer**
- **`omnivoice.py`**: Drop `"[object Object]"` sentinel during instruct parsing (case-insensitive, whitespace-tolerant) before validation, allowing graceful degradation while still raising on genuinely unsupported tokens
- **`test_personalities.py`**: Regression test verifies sentinel is tolerated, valid tokens alongside sentinel still work, and real bad tokens still raise errors

#### **Data Healing**
- **Migration `0006_strip_object_object_instruct.py`**: Idempotent SQL UPDATE clears sentinel from poisoned `voice_profiles.instruct` rows. Downgrade is no-op (fix is irreversible)
- **`test_migration_0006_instruct.py`**: Verifies poisoned rows are healed while healthy rows remain unchanged

### Data Flow (Bug → Fix)

```mermaid
graph LR
    BUILD["buildDesignInstruct()"]
    
    subgraph BUG ["❌ BEFORE (Bug)"]
        BUILD -->|entire object| SAVE1["handleSaveDesignProfile"]
        SAVE1 -->|FormData.append<br/>auto string-coerce| SENTINEL["'[object Object]'"]
        SENTINEL -->|persisted| DB1["voice_profiles.instruct"]
        DB1 -->|on load| ERROR["400 error<br/>Unsupported instruct items<br/>found in [object Object]"]
    end
    
    subgraph FIX ["✅ AFTER (Fixed)"]
        BUILD -->|extract .instruct| EXTRACT["'...actual string...'"]
        EXTRACT -->|defense layer<br/>instructToFormValue| SAFE["safe string<br/>guaranteed"]
        SAFE -->|FormData.append| VALUE["'actual instruction value'"]
        VALUE -->|persisted| DB2["voice_profiles.instruct"]
        DB2 -->|on load| SUCCESS["Validation succeeds<br/>profile works"]
    end
    
    DB1 -->|migration 0006<br/>idempotent UPDATE| HEAL["Clear sentinel<br/>from poisoned rows"]
```

### Test Coverage
- Frontend unit tests verify `instructToFormValue()` never produces `"[object Object]"`
- Backend regression tests confirm sentinel is gracefully dropped while real bad tokens (e.g., `"frobnicate"`) still raise errors to preserve user feedback for issues `#114/`#115
- Migration tests validate poisoned rows are healed while healthy rows remain unchanged
- All tests pass with clean typechecking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->