### PR TITLE
fix(db): self-heal additive schema columns (consent_audio_path 500)

### DIFF
--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -206,6 +206,52 @@ def _migrate(conn, current: int) -> int:
     return current
 
 
+def _reconcile_additive_columns(conn) -> None:
+    """Make the live schema converge to ``_BASE_SCHEMA`` by ADDing any column the
+    canonical schema declares but an existing table is missing — the belt for
+    when alembic can't run on an upgraded DB.
+
+    ``CREATE TABLE IF NOT EXISTS`` (init_db) never adds columns to a table that
+    already exists, the legacy ``_migrate`` only knows pre-0.3 columns, and
+    ``_run_alembic_upgrade`` swallows failures. So a DB whose ``alembic_version``
+    is stamped at a removed revision (e.g. after running a preview build), or
+    where alembic isn't importable in the bundled interpreter, would otherwise
+    lose every alembic-era additive column forever — the ``no such column:
+    consent_audio_path`` 500 (#552/#547), and the same class for
+    ``kind``/``vd_states``/``is_demo``/.... Additive only: never drops or retypes
+    a column, so it is safe and backward-compatible with existing user data. The
+    canonical names/types/defaults come solely from ``_BASE_SCHEMA`` (developer
+    controlled), so the ALTER is injection-safe.
+    """
+    canon = sqlite3.connect(":memory:")
+    try:
+        canon.executescript(_BASE_SCHEMA)
+        _tables_sql = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        live_tables = {r[0] for r in conn.execute(_tables_sql)}
+        for table in (r[0] for r in canon.execute(_tables_sql)):
+            if table not in live_tables:
+                continue  # whole table missing → init_db's CREATE already made it
+            have = {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+            # (cid, name, type, notnull, dflt_value, pk)
+            for _cid, name, ctype, notnull, dflt, _pk in canon.execute(f"PRAGMA table_info({table})"):
+                if name in have or not _IDENT_RE.match(name):
+                    continue
+                ddl = f'ALTER TABLE "{table}" ADD COLUMN "{name}" {ctype or "TEXT"}'
+                if dflt is not None:
+                    ddl += f" DEFAULT {dflt}"
+                elif notnull:
+                    ddl += " DEFAULT ''"  # SQLite requires a default to ADD a NOT NULL column
+                try:
+                    conn.execute(ddl)
+                    logger.info("schema reconcile: added missing column %s.%s", table, name)
+                except sqlite3.OperationalError as exc:
+                    if "duplicate column" not in str(exc).lower():
+                        logger.warning("schema reconcile ALTER %s.%s failed: %s", table, name, exc)
+        conn.commit()
+    finally:
+        canon.close()
+
+
 def init_db():
     conn = get_db()
     try:
@@ -214,6 +260,11 @@ def init_db():
         new_version = _migrate(conn, version)
         if new_version != version:
             conn.execute(f"PRAGMA user_version = {new_version}")
+        # Converge any alembic-era additive columns that CREATE TABLE IF NOT
+        # EXISTS + the legacy _migrate don't add to a pre-existing table
+        # (consent_audio_path, kind, ...). Runs regardless of whether alembic
+        # below succeeds, so an unrunnable alembic can't leave a 500-ing schema.
+        _reconcile_additive_columns(conn)
         conn.commit()
     finally:
         conn.close()
@@ -227,10 +278,12 @@ def init_db():
 
 def _run_alembic_upgrade() -> None:
     """Best-effort `alembic upgrade head` on startup. Non-fatal: if alembic
-    isn't reachable (e.g. user running a stripped-down install or migrations
-    were already applied out-of-band), log a warning and move on. The
-    _BASE_SCHEMA CREATE TABLE IF NOT EXISTS above guarantees the runtime
-    schema is correct regardless."""
+    isn't reachable (e.g. a stripped-down install) or its version is stamped at
+    a revision no longer in versions/ (e.g. after running a preview build), log
+    a warning and move on. The schema is still kept correct by
+    _reconcile_additive_columns (run in init_db above and again here on failure)
+    — CREATE TABLE IF NOT EXISTS alone does NOT add columns to a pre-existing
+    table, so the reconcile is what actually guarantees additive columns land."""
     try:
         import os
         from alembic import command
@@ -248,6 +301,16 @@ def _run_alembic_upgrade() -> None:
         cfg.set_main_option("sqlalchemy.url", f"sqlite:///{DB_PATH}")
         command.upgrade(cfg, "head")
     except Exception as exc:
-        # Don't block startup on a migration tooling problem. The runtime
-        # schema is already correct via _BASE_SCHEMA.
+        # Don't block startup on a migration tooling problem. Converge the schema
+        # directly so a swallowed failure (alembic not importable, or
+        # alembic_version stamped at a removed revision) still lands the additive
+        # columns instead of 500-ing on `no such column` (#552/#547).
         logger.warning("alembic upgrade head skipped: %s", exc)
+        try:
+            conn = get_db()
+            try:
+                _reconcile_additive_columns(conn)
+            finally:
+                conn.close()
+        except Exception as exc2:  # noqa: BLE001
+            logger.warning("schema reconcile after alembic failure also failed: %s", exc2)

--- a/tests/test_db_schema_reconcile.py
+++ b/tests/test_db_schema_reconcile.py
@@ -1,0 +1,89 @@
+"""The runtime schema must self-heal additive columns even when `alembic
+upgrade head` can't run — the "no such column: consent_audio_path" 500
+(#552/#547) and its whole class (kind/vd_states/is_demo/...).
+
+A DB whose alembic_version is stamped at a revision no longer in versions/
+(common after running a preview/main build) makes alembic raise; the failure is
+swallowed, and CREATE TABLE IF NOT EXISTS never adds columns to a pre-existing
+table — so without reconciliation the new columns never land.
+"""
+import sqlite3
+
+from core.db import _BASE_SCHEMA, _reconcile_additive_columns
+
+
+def _cols(db_path, table="voice_profiles"):
+    with sqlite3.connect(str(db_path)) as conn:
+        return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _base_schema_cols(table="voice_profiles"):
+    canon = sqlite3.connect(":memory:")
+    try:
+        canon.executescript(_BASE_SCHEMA)
+        return {r[1] for r in canon.execute(f"PRAGMA table_info({table})")}
+    finally:
+        canon.close()
+
+
+# A pre-consent / pre-unification voice_profiles — missing every alembic-era
+# additive column.
+_LEGACY_PROFILES = """
+    CREATE TABLE voice_profiles (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        ref_audio_path TEXT,
+        ref_text TEXT DEFAULT '',
+        instruct TEXT DEFAULT '',
+        language TEXT DEFAULT 'Auto',
+        created_at REAL
+    );
+"""
+
+
+def test_init_db_self_heals_missing_columns_when_alembic_fails(tmp_path, monkeypatch):
+    db = tmp_path / "legacy.db"
+    with sqlite3.connect(str(db)) as conn:
+        conn.executescript(_LEGACY_PROFILES)
+        conn.execute("INSERT INTO voice_profiles(id, name) VALUES ('vp-1', 'Alice')")
+        # alembic stamped at a revision that no longer exists → command.upgrade
+        # raises 'Can't locate revision', exercising the swallowed-failure path.
+        conn.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        conn.execute("INSERT INTO alembic_version VALUES ('0003_preview_removed_rev')")
+        conn.commit()
+
+    monkeypatch.setattr("core.db.DB_PATH", str(db))
+    from core.db import init_db
+
+    init_db()  # must NOT raise, and must converge the schema
+
+    cols = _cols(db)
+    for col in ("verified_own_voice", "consent_text", "consent_audio_path",
+                "consent_recorded_at", "kind", "vd_states", "is_demo"):
+        assert col in cols, f"schema reconcile did not add {col} (the #552 symptom)"
+    # the existing row survives
+    with sqlite3.connect(str(db)) as conn:
+        assert conn.execute("SELECT name FROM voice_profiles WHERE id='vp-1'").fetchone()[0] == "Alice"
+
+
+def test_reconcile_converges_voice_profiles_to_base_schema(tmp_path):
+    db = tmp_path / "stripped.db"
+    with sqlite3.connect(str(db)) as conn:
+        conn.executescript(_LEGACY_PROFILES)
+        conn.commit()
+        _reconcile_additive_columns(conn)
+    assert _cols(db) == _base_schema_cols(), "reconcile must match the canonical column set"
+
+
+def test_reconcile_is_idempotent_and_additive_only(tmp_path):
+    db = tmp_path / "twice.db"
+    with sqlite3.connect(str(db)) as conn:
+        conn.executescript(_LEGACY_PROFILES)
+        conn.commit()
+        _reconcile_additive_columns(conn)
+        after_first = _cols(db)
+        _reconcile_additive_columns(conn)  # second run must be a clean no-op
+        after_second = _cols(db)
+    assert after_first == after_second
+    # additive only — the original legacy columns are never dropped
+    assert {"id", "name", "instruct", "language"} <= after_second


### PR DESCRIPTION
## Bug (#552 / #547)

Profile/persona/consent endpoints `500` with **`no such column: consent_audio_path`** (and the same class for `kind`/`vd_states`/`is_demo`) after an in-place upgrade.

The `0003`/`0005` migrations exist and are correctly wired, but **nothing guarantees they apply**:
- `init_db`'s `CREATE TABLE IF NOT EXISTS` is a no-op on a pre-existing table → adds no columns;
- legacy `_migrate` only knows pre-0.3 columns;
- `_run_alembic_upgrade` **swallows every failure** with a bare `except`.

So a DB whose `alembic_version` is stamped at a revision no longer in `versions/` (common after running a preview build), or where `alembic` isn't importable in the bundled interpreter, **silently loses every alembic-era column forever**.

## Fix (whole class, not one column)

`_reconcile_additive_columns(conn)` builds the canonical schema from `_BASE_SCHEMA` in-memory, and `ALTER TABLE ADD COLUMN` any column an existing table is missing. **Additive only** (never drops/retypes); names/types/defaults come solely from `_BASE_SCHEMA` (injection-safe). Called in `init_db` (converges regardless of alembic) **and** in the alembic-failure branch. Corrects the false "_BASE_SCHEMA guarantees the schema regardless" comment.

## Test (fail-before / pass-after)
`init_db` on a legacy `voice_profiles` whose `alembic_version` is a *removed* revision now lands `consent_audio_path`/`kind`/etc. without raising (the exact #552 repro); reconcile converges to the canonical column set; idempotent + additive-only. **21 passed** (incl. the existing 0003/0005 migration tests).

Cross-platform: pure stdlib `sqlite3`; `ADD COLUMN` supported everywhere. Backend-only, no version/lockfile impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

Profile, persona, and consent endpoints return 500 errors with "no such column: consent_audio_path" (and similar for `kind`, `vd_states`, `is_demo`) after in-place upgrades due to database schema misalignment. The root causes are:
- `init_db`'s `CREATE TABLE IF NOT EXISTS` doesn't add columns to pre-existing tables
- Legacy `_migrate` function only handles pre-0.3 columns  
- `_run_alembic_upgrade` silently swallows exceptions with bare `except` clauses
- When `alembic_version` is stamped at a removed revision (common after preview build runs) or when alembic is unavailable, columns never get added

## Solution

Introduces a new `_reconcile_additive_columns(conn)` function that ensures tables converge to `_BASE_SCHEMA` by:
- Building canonical schema in-memory from `_BASE_SCHEMA`
- Comparing live DB tables/columns via `sqlite_master` and `PRAGMA table_info`
- Issuing `ALTER TABLE ... ADD COLUMN` for missing columns only (additive-only, never drops/retypes)
- Using `_BASE_SCHEMA`-derived DDL to prevent injection vulnerabilities
- Computing defaults for non-nullable missing columns to satisfy SQLite requirements

The reconcile function is integrated at two points:
1. **In `init_db()`**: Called after `_migrate` completes to ensure schema convergence regardless of alembic status
2. **In `_run_alembic_upgrade()` exception handler**: Performs additional schema reconcile on failure (with fresh connection) to prevent startup failures from missing additive columns

## Implementation Details

**backend/core/db.py** (+69 lines, -6)
- New `_reconcile_additive_columns()` helper function with identifier/type validation
- `init_db()` now calls reconcile helper after legacy `_migrate` 
- `_run_alembic_upgrade()` exception handling expanded to run reconciliation on upgrade failure
- Solution is idempotent and additive-only, requires only standard library `sqlite3`

**tests/test_db_schema_reconcile.py** (new file, +89 lines)
- Validates `init_db()` doesn't raise and adds expected additive columns to legacy `voice_profiles` table even with failed Alembic due to removed `alembic_version` revision
- Verifies `_reconcile_additive_columns()` transforms legacy schema to match `_BASE_SCHEMA` canonical set
- Tests idempotency—subsequent calls are no-op while preserving legacy columns and rows

## Mechanism Flowchart

```mermaid
graph TD
    A["init_db() called"] --> B["Run _migrate<br/>legacy migrations"]
    B --> C["Call _reconcile_additive_columns"]
    C --> D{"Missing columns<br/>in live DB?"}
    D -->|Yes| E["ALTER TABLE ADD COLUMN<br/>for each missing column"]
    D -->|No| F["No-op"]
    E --> G["Schema converged"]
    F --> G
    
    H["_run_alembic_upgrade()<br/>called"] --> I["Attempt alembic upgrade"]
    I --> J{"Upgrade<br/>successful?"}
    J -->|Yes| K["Return success"]
    J -->|No| L["Exception caught"]
    L --> M["Call _reconcile_additive_columns<br/>with fresh connection"]
    M --> N["Add any missing columns"]
    N --> O["Return best-effort success"]
```

All 21 tests pass including existing migration tests. No version or lockfile changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->