### PR TITLE
fix(ui): fill the shell on WebKitGTK so Generate/Settings buttons aren't clipped (#523/#524)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback, Suspense, lazy } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback, Suspense, lazy } from 'react';
 import './index.css';
 import { useAppStore, FONT_STACKS } from './store';
 import SearchableSelect from './components/SearchableSelect';
@@ -86,12 +86,12 @@ function App() {
 
   // Responsive shell breakpoints driven off the app-container's OWN width, not
   // the viewport. The shell is sized `width: calc(100vw / --ui-scale)` then
-  // `transform: scale(--ui-scale)` (the WebKitGTK fix, #407), so the grid lays
-  // out against `100vw/scale` — which `el.clientWidth` reports (transforms don't
-  // change the layout box). Viewport `@media` queries fire on raw `100vw` and so
-  // collapse at the wrong threshold whenever the UI scale ≠ 1, cramming the
-  // content into a sliver. ResizeObserver fires on both window resize and scale
-  // change (the calc width changes), so this stays correct on every engine.
+  // `zoom: --ui-scale` (#504; the WebKitGTK no-op case is handled by the
+  // data-zoom-layout probe below), so the grid lays out against `100vw/scale` —
+  // which `el.clientWidth` reports. Viewport `@media` queries fire on raw
+  // `100vw` and so collapse at the wrong threshold whenever the UI scale ≠ 1,
+  // cramming the content into a sliver. ResizeObserver fires on both window
+  // resize and scale change (the calc width changes), so this stays correct.
   const shellRef = useRef(null);
   const [shellWidth, setShellWidth] = useState(Infinity);
   useEffect(() => {
@@ -101,6 +101,25 @@ function App() {
     ro.observe(el);
     setShellWidth(el.clientWidth);
     return () => ro.disconnect();
+  }, []);
+
+  // Engine capability probe (#523/#524): does this WebView honor `zoom` as a
+  // LAYOUT transform? Chromium (WebView2 / macOS WebKit) and modern WebKitGTK
+  // do; older WebKitGTK (Linux) treats it as a no-op. The .app-container sizing
+  // branches on the result (index.css) so the shell fills the window on BOTH —
+  // no black band on WebKitGTK, no clipped Generate/Settings CTAs on Chromium.
+  // Measuring a real zoomed element is robust where @supports(zoom)/UA-sniffing
+  // aren't (both report "supported" on WebKitGTK even when zoom doesn't lay out).
+  useLayoutEffect(() => {
+    let honored = true;
+    try {
+      const probe = document.createElement('div');
+      probe.style.cssText = 'position:absolute;left:-9999px;top:0;width:100px;height:100px;zoom:2';
+      document.body.appendChild(probe);
+      honored = Math.round(probe.getBoundingClientRect().width) >= 150;
+      probe.remove();
+    } catch { honored = true; }  // safe default: the existing zoom path
+    document.documentElement.dataset.zoomLayout = honored ? 'on' : 'off';
   }, []);
   const shellSizeClass = shellWidth <= 600 ? 'shell-mini' : shellWidth <= 1100 ? 'shell-narrow' : '';
   const theme = useAppStore(s => s.theme);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -196,9 +196,12 @@ samp,
      black bands:
        • Chromium (macOS/Windows): `zoom` magnifies the shrunk layout box back
          to exactly `100vw × 100vh`, so content fits with no clipping.
-       • WebKitGTK (Linux): `zoom` is a no-op → the layout box stays shrunk to
-         `100vw/scale × 100vh/scale` and FILLS the window (no black bands), just
-         rendered slightly smaller.
+       • Older WebKitGTK (Linux): `zoom` is a layout no-op, so the shrunk
+         `100vw/scale` box would leave a black band on the right/bottom AND push
+         the bottom Generate/Settings CTAs off-screen (#523/#524). The App.jsx
+         zoom-layout probe sets `data-zoom-layout=off` on those engines, and the
+         override below renders the shell at 1.0 filling the window (no band, no
+         clip). Newer WebKitGTK that honors zoom keeps the scaled path.
      The old `transform: scale(var(--ui-scale))` approach is what caused black
      bands on WebKitGTK because the transform didn't magnify the shrunk shell.
      ⚠️ Do NOT replace `zoom` with `transform: scale(var(--ui-scale))` — a
@@ -223,6 +226,16 @@ samp,
      the side menubar. */
   overflow: hidden;
   transition: grid-template-columns var(--transition-smooth);
+}
+/* Older WebKitGTK (Linux), where the App.jsx probe found `zoom` is a layout
+   no-op → html[data-zoom-layout=off]: the calc(100vw/scale) box can't be
+   magnified back, so it leaves a black band and clips the bottom Generate/
+   Settings CTAs (#523/#524). Fill the viewport at 1.0 instead — no band, no
+   clip. The probe leaves the zoom path in place on engines that honor zoom. */
+html[data-zoom-layout='off'] .app-container {
+  width: 100vw;
+  height: 100vh;
+  zoom: 1;
 }
 /* Keep scrollable content clear of the fixed footer. The footer writes its
    current height (pre-zoom px — same coordinate space as these children) to

--- a/frontend/src/test/appShellScale.test.js
+++ b/frontend/src/test/appShellScale.test.js
@@ -37,4 +37,13 @@ describe('app shell scale (black-band + clipping regression guard)', () => {
     expect(block).toMatch(/width:\s*calc\(\s*100vw\s*\/\s*var\(--ui-scale/);
     expect(block).toMatch(/height:\s*calc\(\s*100vh\s*\/\s*var\(--ui-scale/);
   });
+
+  it('falls back to 100vw/100vh where zoom is a layout no-op (WebKitGTK, #523/#524)', () => {
+    // The App.jsx zoom-layout probe sets data-zoom-layout=off on engines that
+    // treat zoom as a layout no-op; this override must then fill the window at
+    // 1.0 so the shell never leaves a black band or clips the bottom CTAs.
+    expect(css).toMatch(
+      /\[data-zoom-layout=['"]?off['"]?\][^{]*\.app-container\s*\{[^}]*width:\s*100vw[^}]*height:\s*100vh/,
+    );
+  });
 });


### PR DESCRIPTION
## Bug (#523 / #524 + Discord "where is the Generate button / clone button disappeared")

On **0.3.6/0.3.7 with the backend UP**, the primary action buttons (the Synthesize/Generate CTA at the bottom of Voice/Design, the NavRail **Settings** footer) are **off-screen** for some users. Not a state gate — the CTA is always rendered. It's a **UI-scale clipping** bug.

The #504 zoom fix sizes `.app-container` as `calc(100vw/scale)` magnified back by `zoom`. That round-trips to the viewport on Chromium, but **older WebKitGTK (Linux) treats `zoom` as a layout no-op**, so the box stays shrunk to `77vw` at the default scale 1.3 → ~23% black band + the bottom-pinned CTAs pushed off-screen. The old comment's *"FILLS the window (no black bands)"* claim was false — #504 traded a Chromium clip for a Linux black-band.

## Fix — detect the engine, don't bet on it

No static rule satisfies both engines, so probe at runtime:
- **App.jsx**: measure a real `zoom:2` element; if its rect isn't magnified → `html[data-zoom-layout=off]`. Robust where `@supports(zoom)`/UA-sniffing lie, and self-corrects on future WebKitGTK that honors zoom.
- **index.css**: `[data-zoom-layout=off] .app-container` → `100vw/100vh` at zoom 1 (fills, no clip). Chromium keeps the scaled path.
- **appShellScale.test.js**: guards **both** branches so a future simplification can't silently re-break one engine.

## Validation
- `vitest` 4 passed (incl. the new fallback-branch guard); `typecheck:ci` clean.
- ⚠️ **CI e2e is chromium-only** — the WebKitGTK fallback path **must be eyeballed on a real Linux AppImage build before the v0.3.7 tag**. (Tracked for the validation phase.)

Cross-platform-parity P0: UI scale ships in default mode, so it must behave identically on mac/win/linux — this restores that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a UI-scale clipping bug affecting versions 0.3.6/0.3.7 where the Synthesize/Generate button and NavRail Settings footer are rendered off-screen on older WebKitGTK installations (Linux AppImage/deb builds). The root cause is that WebKitGTK treats the `zoom` CSS property as a layout no-op, while the app-container sizing introduced in PR `#504` relies on `zoom` to magnify a shrunk layout box back to viewport size. On affected engines, this leaves the container at ~77vw (about a 23% black band on the right) and pushes bottom-pinned CTAs off-screen.

### Changes

**App.jsx** (+26/-7): Adds a `useLayoutEffect` zoom-layout capability probe that creates an off-screen test element with `zoom: 2`, measures if its `getBoundingClientRect().width` is ≥150px (indicating zoom magnifies layout), and writes the result to `document.documentElement.dataset.zoomLayout` as `'on'` or `'off'`.

**index.css** (+16/-3): Adds fallback CSS rule `html[data-zoom-layout='off'] .app-container` that forces `width: 100vw`, `height: 100vh`, and `zoom: 1` on engines where zoom doesn't affect layout, eliminating the black band. Chromium continues using the zoom-based scaling path via the normal `.app-container` rule.

**appShellScale.test.js** (+9/-0): Extends the regression guard suite with a new assertion verifying that the fallback rule properly overrides app-container sizing on WebKitGTK (`data-zoom-layout=off`).

### Visual Impact

**Layout Before/After (at 1.3× default scale):**

```
CHROMIUM (unchanged)          WEBKITGTK BEFORE           WEBKITGTK AFTER
┌──────────────────┐          ┌──────────────┐███████    ┌──────────────────┐
│                  │          │              │███████    │                  │
│                  │          │              │███████    │                  │
│   MAIN CONTENT   │          │ MAIN CONTENT │███████    │   MAIN CONTENT   │
│                  │          │              │███████    │                  │
├──────────────────┤          ├──────────────┤███████    ├──────────────────┤
│[Generate] [More] │          │[Generate]OFF │███████    │[Generate] [More] │
└──────────────────┘          └──────────────┘███████    └──────────────────┘
   100% viewport                  77% viewport           100% viewport
   All buttons fit                 Black band             All buttons fit
                                   Buttons clipped
```

### Detection Mechanism

```
App startup
    │
    ├─ useLayoutEffect hook runs
    │
    ├─ Create test element: <div zoom:2 width:100px>
    │
    ├─ Measure element's rendered width
    │  │
    │  ├─ Width ≥150px? YES ────┐
    │  │                        │
    │  └─ Width <150px? ─────┐  │
    │                       │  │
    │  Set data-zoom-layout │  │
    │                       │  │
    │                  'off'│  │'on'
    │                       │  │
    ├─ CSS applies fallback │  │
    │   100vw/100vh path    │  │
    │   (WebKitGTK)         │  │
    │                       │  │
    └───────────────────────┴──┴─ Normal zoom-scaled
                                   path (Chromium)
                                   
    Result: UI fills viewport
            on BOTH engines
```

### Key Improvements

- **Robust detection**: Measures actual rendered geometry rather than relying on `@supports(zoom)` or UA-sniffing, both of which incorrectly report zoom support on WebKitGTK even when it doesn't affect layout
- **No visual regressions**: Chromium continues using the zoom-based scaling approach; only WebKitGTK-detected engines use the fallback path
- **Future-proof**: If WebKitGTK later implements `zoom` layout support, the probe automatically selects the correct path at runtime
- **Guarded against regressions**: Test assertions prevent future commits from accidentally reintroducing `transform: scale()` or removing the fallback CSS rule

### Testing & Validation Notes

- 4 vitest cases passing (including new WebKitGTK fallback check)
- typecheck passes cleanly
- CI e2e testing is Chromium-only; **manual validation required on actual Linux AppImage/deb builds before v0.3.7 release** to confirm the WebKitGTK fallback path renders correctly (full viewport, no black band, buttons accessible)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->