### PR TITLE
fix(engines): pin uv pip install to the running interpreter (#529/#527)

### DIFF
--- a/backend/services/translation_engines.py
+++ b/backend/services/translation_engines.py
@@ -177,6 +177,16 @@ async def run_pip(args: list[str], timeout: float = 600.0) -> tuple[int, str]:
     """
     base = _installer_cmd()
     using_uv = base[:1] == ["uv"]
+    # Pin `uv pip` to the interpreter the backend ACTUALLY runs under. The desktop
+    # spawns `<venv>/bin/python -m uvicorn` WITHOUT exporting VIRTUAL_ENV, so bare
+    # `uv pip install` finds no venv and 500s with "No virtual environment found"
+    # (#529/#527) — and the `--system` branch below never fires, because the
+    # running interpreter genuinely IS in a venv (uv just can't auto-discover it).
+    # `--python sys.executable` targets the same interpreter _probe()/is_installed()
+    # import from, and takes precedence when both flags are present, so the Docker
+    # `--system` path is unaffected.
+    if using_uv and args and args[0] in ("install", "uninstall") and "--python" not in args:
+        args = [args[0], "--python", sys.executable, *args[1:]]
     if using_uv and not _in_virtualenv() and args and args[0] in ("install", "uninstall") and "--system" not in args:
         args = [args[0], "--system", *args[1:]]
     cmd = base + args

--- a/tests/test_translation_engine_install.py
+++ b/tests/test_translation_engine_install.py
@@ -1,0 +1,45 @@
+"""The engine Install chip must target the interpreter the backend runs under.
+
+#529/#527: the desktop spawns `<venv>/bin/python -m uvicorn` WITHOUT exporting
+VIRTUAL_ENV, so bare `uv pip install` finds no venv and 500s with "No virtual
+environment found". run_pip must pass `--python sys.executable`.
+"""
+import asyncio
+import sys
+
+from services import translation_engines as te
+
+
+class _FakeProc:
+    returncode = 0
+
+    async def communicate(self):
+        return (b"ok", b"")
+
+
+def _run_capturing(monkeypatch, args):
+    """Force the uv branch + capture the spawned argv; return (rc, argv)."""
+    captured = {}
+    monkeypatch.setattr(te.shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    async def fake_exec(*argv, **kwargs):
+        captured["argv"] = list(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(te.asyncio, "create_subprocess_exec", fake_exec)
+    rc, _out = asyncio.run(te.run_pip(args))
+    return rc, captured.get("argv", [])
+
+
+def test_run_pip_pins_uv_install_to_sys_executable(monkeypatch):
+    rc, argv = _run_capturing(monkeypatch, ["install", "deep_translator"])
+    assert rc == 0
+    assert argv[:3] == ["uv", "pip", "install"], argv
+    assert "--python" in argv, argv
+    assert argv[argv.index("--python") + 1] == sys.executable
+
+
+def test_run_pip_pins_uv_uninstall_to_sys_executable(monkeypatch):
+    _rc, argv = _run_capturing(monkeypatch, ["uninstall", "deep_translator"])
+    assert "--python" in argv, argv
+    assert argv[argv.index("--python") + 1] == sys.executable


### PR DESCRIPTION
**#529 / #527** — the engine Install chip 500s with *No virtual environment found*.

`run_pip` uses bare `uv pip install`, which finds its target venv from `VIRTUAL_ENV` / a `.venv` in CWD — **not** the running interpreter. The desktop spawns `<venv>/bin/python -m uvicorn` without `VIRTUAL_ENV`, so uv finds nothing. The `--system` fallback is dead code here (gated on `_in_virtualenv()==False`, but the interpreter genuinely *is* in a venv — just not auto-discoverable).

Fix: pass **`--python sys.executable`** for uv install/uninstall — targets the same interpreter `_probe()`/`is_installed()` import from (whole class: spawned-venv/system/conda). Takes precedence when both flags present, so the Docker `--system` path is untouched.

Test (fail-before/pass-after): `run_pip`'s spawned argv includes `--python <sys.executable>` after install **and** uninstall. **2 passed.** Cross-platform: `sys.executable` is correct on mac/win/linux (incl. the Windows thread fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fixes engine installation failures ("No virtual environment found" 500 errors) in the Install chip for modules like deep_translator, openai, and argostranslate. The root cause is that the desktop spawns `<venv>/bin/python -m uvicorn` without exporting the `VIRTUAL_ENV` environment variable, causing `uv pip install` to fail when it cannot auto-discover the virtual environment.

## Root Cause

The `_in_virtualenv()` heuristic used to gate the `--system` fallback answers the wrong question. The interpreter genuinely is running in a virtual environment, but `uv` cannot auto-discover it when `VIRTUAL_ENV` is not exported. This leaves the `--system` fallback gated on a condition that never triggers, even though `uv` needs explicit environment targeting.

## Solution

Adds `--python sys.executable` flag to both `uv pip install` and `uv pip uninstall` commands, explicitly targeting the same interpreter that the `_probe()` and `is_installed()` methods use to import packages. This approach works across all scenarios: spawned venvs, system interpreters, and conda environments. When both `--python` and `--system` flags are present, `--python` takes precedence, leaving the Docker `--system` path unchanged.

## New Behavior

```mermaid
flowchart TD
    A["Backend spawned from venv<br/>without VIRTUAL_ENV set"] --> B["run_pip called<br/>with install/uninstall"]
    B --> C{Using uv?<br/>AND<br/>install/uninstall op?<br/>AND<br/>no --python flag?}
    C -->|Yes| D["Inject: --python sys.executable"]
    C -->|No| E["Use args as-is"]
    D --> F["Execute uv pip with<br/>explicit interpreter"]
    E --> F
    F --> G["Success: targets backend's<br/>running interpreter"]
```

## Changes

**backend/services/translation_engines.py** (+10 lines)
- `run_pip()` now injects `--python sys.executable` into `uv pip install` and `uv pip uninstall` commands when the flag is not already present
- Ensures `uv` targets the interpreter the backend actually runs under rather than attempting auto-discovery

**tests/test_translation_engine_install.py** (+45 lines)
- Added helper `_run_capturing()` that monkeypatches `shutil.which` to force the `uv` branch and captures spawned command arguments
- `test_run_pip_pins_uv_install_to_sys_executable`: Verifies `--python <sys.executable>` is injected for install operations
- `test_run_pip_pins_uv_uninstall_to_sys_executable`: Verifies `--python <sys.executable>` is injected for uninstall operations
- Both tests validate cross-platform compatibility (macOS, Windows with thread fallback, Linux)

## Testing

All tests pass, confirming that `run_pip`'s spawned argv includes `--python <sys.executable>` for both install and uninstall operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->