### PR TITLE
fix(settings): About → Version never blank (web/Pinokio build)

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -28,6 +28,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { selectEngine } from '../api/engines';
 import { setupDownloadStreamUrl } from '../api/setup';
 import { getFrontendLogs, clearFrontendLogs } from '../utils/consoleBuffer';
+import { resolveAboutVersion } from '../utils/appVersion';
 import { Tabs, Segmented, Button, Badge, Table, Progress, Select } from '../ui';
 import { useAppStore } from '../store';
 import ApiKeysPanel from '../components/settings/ApiKeysPanel';
@@ -1242,7 +1243,7 @@ export default function Settings() {
     const lines = [
       '### OmniVoice Studio diagnostics',
       '',
-      `- **App version:** ${appVersion || '—'}`,
+      `- **App version:** ${resolveAboutVersion(appVersion, info)}`,
       `- **Tauri runtime:** ${tauriVersion || (isTauri() ? '—' : 'web preview')}`,
       `- **Platform:** ${info?.platform || '—'}`,
       `- **Architecture:** ${nav.userAgentData?.platform || nav.platform || '—'}`,
@@ -1505,7 +1506,7 @@ export default function Settings() {
         <section className="settings-section">
           <h2><Info size={16} color="#8ec07c" /> {t('settings.about')}</h2>
           <Row label={t('about.app')}             value="OmniVoice Studio" />
-          <Row label={t('about.version')}         value={appVersion || info?.app_version || '—'} mono />
+          <Row label={t('about.version')}         value={resolveAboutVersion(appVersion, info)} mono />
           <Row label={t('about.tauri_runtime')}   value={tauriVersion || (isTauri() ? '—' : t('about.web_preview'))} mono />
           <Row label={t('about.platform')}        value={info?.platform || '—'} />
           <Row label={t('about.architecture')}    value={info?.arch || '—'} mono />

--- a/frontend/src/utils/appVersion.js
+++ b/frontend/src/utils/appVersion.js
@@ -1,0 +1,21 @@
+/* global __APP_VERSION__ -- injected by Vite (vite.config define) at build time */
+// The build's own version, always present regardless of Tauri presence or
+// backend liveness — the always-correct source per the version-lockstep rule
+// (it comes from package.json, kept in lockstep with the other version files).
+export const APP_VERSION =
+  (typeof __APP_VERSION__ !== 'undefined' && __APP_VERSION__) || 'unknown';
+
+/**
+ * Resolve the version shown in Settings → About / the diagnostics block. Prefer
+ * the authoritative Tauri-config version, then the live backend's
+ * `/system/info` `app_version`, then the build-time constant — so it is NEVER
+ * blank, even in the web/Pinokio build where Tauri is absent and the backend
+ * may be idle (the About → Version field rendered empty there).
+ *
+ * @param {string|null|undefined} appVersion  Tauri `getVersion()` result
+ * @param {{ app_version?: string }|null|undefined} info  `/system/info` payload
+ * @returns {string}
+ */
+export function resolveAboutVersion(appVersion, info) {
+  return appVersion || info?.app_version || APP_VERSION;
+}

--- a/frontend/src/utils/appVersion.test.js
+++ b/frontend/src/utils/appVersion.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAboutVersion, APP_VERSION } from './appVersion';
+
+describe('resolveAboutVersion (About → Version blank-in-web-build fix)', () => {
+  it('prefers Tauri appVersion, then backend app_version, then the build constant', () => {
+    expect(resolveAboutVersion('1.2.3', { app_version: '9.9.9' })).toBe('1.2.3');
+    expect(resolveAboutVersion(null, { app_version: '9.9.9' })).toBe('9.9.9');
+    expect(resolveAboutVersion('', { app_version: '9.9.9' })).toBe('9.9.9');
+  });
+
+  it('falls back to the build-time version and is NEVER blank/dash (web/Pinokio build)', () => {
+    // Vite injects __APP_VERSION__ at build time (incl. under vitest), so the
+    // constant is always a real version string.
+    expect(APP_VERSION).toBeTruthy();
+    expect(resolveAboutVersion(null, undefined)).toBe(APP_VERSION);
+    expect(resolveAboutVersion(null, null)).toBe(APP_VERSION);
+    expect(resolveAboutVersion(null, {})).toBe(APP_VERSION);
+    expect(resolveAboutVersion(null, undefined)).not.toBe('');
+    expect(resolveAboutVersion(null, undefined)).not.toBe('—');
+  });
+});


### PR DESCRIPTION
In the **web/Pinokio (non-Tauri)** build with the backend idle, Settings → About showed an **empty Version** cell. Both sources were unavailable: `appVersion` is set only inside the `isTauri()`-gated effect, and `info.app_version` comes from `/system/info`, which never resolves while the backend is **IDLE** (`retry: Infinity`).

Fix: `resolveAboutVersion()` falls back to the build-time **`__APP_VERSION__`** (Vite-injected from package.json — always present, version-lockstep-guaranteed). Applied at **both** the About → Version row **and** the diagnostics-copy block (which had no fallback at all). Tauri/live-backend sources still take precedence, so the packaged desktop build is unchanged.

Test (fail-before/pass-after): prefers Tauri → backend → build constant, never blank/dash. **vitest 2 passed**, typecheck clean. Platform-agnostic build constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

The Settings → About Version field displayed as empty in web/Pinokio builds when the backend was idle, due to two unavailable version sources:
1. `appVersion` is only set in Tauri builds (gated by `isTauri()` effect)
2. `info.app_version` from `/system/info` endpoint never resolves while backend is in IDLE state

## Solution

Introduced `resolveAboutVersion()` utility function that adds a build-time constant fallback, ensuring a version is always displayed via the fallback hierarchy:

```
Tauri appVersion
    ↓ (if not available)
Backend app_version (/system/info)
    ↓ (if not available)
Build-time __APP_VERSION__ (from package.json)
```

## Changes Made

**frontend/src/utils/appVersion.js** (new file)
- `APP_VERSION` constant: Vite-injected build-time version with `'unknown'` fallback
- `resolveAboutVersion(appVersion, info)` function: Implements fallback hierarchy

**frontend/src/pages/Settings.jsx**
- Updated About → Version row to use `resolveAboutVersion()`
- Updated diagnostics copy block to use `resolveAboutVersion()` instead of previous `appVersion || '—'` fallback

**frontend/src/utils/appVersion.test.js** (new file)
- Vitest suite verifying fallback chain precedence
- Validates that function never returns blank strings or dashes

## Behavioral Impact

Version resolution now follows a consistent, platform-agnostic approach where build-time constant ensures display availability across macOS, Windows, Linux, Docker, and Pinokio builds. Tauri and live-backend sources maintain precedence, preserving existing behavior for standard builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->