### PR TITLE
fix(asr): float16-unsupported GPUs fall back to int8 (#551/#549/#516)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ OmniVoice ships a multi-engine ASR (speech-to-text) backend that powers dictatio
 
 > Whisper-family engines cover ~100 languages; **FunASR / SenseVoice** adds an all-in-one multilingual path with built-in voice-activity detection and inline speaker diarization. Every engine runs on-device — no API keys, no cloud.
 
+> **GPU without efficient float16?** On older NVIDIA GPUs (Maxwell/Pascal, GTX 16xx) or after a CTranslate2/cuDNN mismatch, the CTranslate2 ASR engines (WhisperX, Faster-Whisper) can't run `float16` and OmniVoice automatically retries on `int8` — no config needed. If transcription still fails, pin the compute type with the `ASR_COMPUTE_TYPE` env var (escape hatch): `ASR_COMPUTE_TYPE=int8` (or `float32` for CPU). Set it to `int8` and restart the backend.
+
 ---
 
 ## Architecture

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -436,7 +436,7 @@ async def dub_transcribe_stream(
                     )
                 scene_cuts = job.get("scene_cuts") or []
 
-    async def gen():
+    async def _gen_body():
         if preflight_error:
             yield _sse_event("error", {"detail": preflight_error})
             return
@@ -855,6 +855,25 @@ async def dub_transcribe_stream(
             "speaker_clones": job.get("speaker_clones", {}),
         })
         yield _sse_event("done", {})
+
+    async def gen():
+        # Terminal-event guard (#516): the SSE stream must NEVER close without a
+        # terminal event. Any unanticipated exception in the body (e.g. an ASR
+        # load that escapes the per-chunk handler) previously dropped the
+        # connection, which the frontend can only report as "stream dropped,
+        # likely ASR failed" — hiding the real cause. Emit a structured `error`
+        # (with the actionable hint from build_failure) then `done`, so the user
+        # sees the real failure + a Retry instead of a silent disconnect.
+        try:
+            async for ev in _gen_body():
+                yield ev
+        except Exception as e:  # noqa: BLE001 — last-resort stream finalizer
+            logger.exception("transcribe stream crashed (job=%s)", job_id)
+            from core.failure import build_failure
+            f = build_failure(e, stage="transcribe", include_diagnostic=False)
+            detail = f["reason"] + (f" — {f['hint']}" if f.get("hint") else "")
+            yield _sse_event("error", {"detail": detail, "retryable": True})
+            yield _sse_event("done", {})
 
     return StreamingResponse(
         gen(),

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -37,6 +37,8 @@ _HINTS: dict[str, str] = {
     "APPIMAGE_WEBKIT_WHITESCREEN": "Launch with WEBKIT_DISABLE_DMABUF_RENDERER=1 set.",
     "HF_AUTH_FAILED": "Set a valid HF_TOKEN in Settings → Hugging Face and retry.",
     "PYANNOTE_LICENSE_REQUIRED": "Accept the pyannote model licenses on Hugging Face, then retry.",
+    "COMPUTE_TYPE_UNSUPPORTED": "Your GPU doesn't support float16 — OmniVoice retried on int8. If transcription still fails, set OMNIVOICE/ASR_COMPUTE_TYPE=int8 or use CPU.",
+    "TRANSFORMERS_IMPORT": "Your transformers install is incomplete. Reinstall it (`uv pip install --reinstall transformers`) or switch ASR to faster-whisper (Settings → Models).",
 }
 
 
@@ -55,6 +57,13 @@ def classify(reason: str) -> str:
         return "APPIMAGE_WEBKIT_WHITESCREEN"
     if "pyannote" in low or ("gated" in low and "model" in low) or "accept the" in low:
         return "PYANNOTE_LICENSE_REQUIRED"
+    # ASR robustness (#551 / #549): name the class so the no-segments toast is
+    # actionable. Place before the generic returns so a compute-type/transformers
+    # failure gets its hint rather than falling through to "".
+    if "compute type" in low or "efficient float16" in low:
+        return "COMPUTE_TYPE_UNSUPPORTED"
+    if "could not import module" in low or "autofeatureextractor" in low:
+        return "TRANSFORMERS_IMPORT"
     if ("huggingface" in low or "hf_token" in low or "401" in low or "unauthorized" in low) and (
         "token" in low or "auth" in low or "401" in low or "unauthorized" in low
     ):

--- a/backend/engines/_asr_sidecar/main.py
+++ b/backend/engines/_asr_sidecar/main.py
@@ -50,6 +50,22 @@ def _recv(stream):
     return json.loads(bytes(body).decode("utf-8"))
 
 
+# NOTE: keep this compute_type fallback in lockstep with
+# services/asr_backend.py:_compute_type_candidates / _is_compute_type_error.
+# This sidecar runs in a child proc with a clean import path, so we duplicate a
+# tiny copy rather than cross-importing the heavy services package (#551).
+def _ct_candidates(device):
+    override = os.environ.get("ASR_COMPUTE_TYPE")
+    if override:
+        return [override]
+    return ["float16", "int8_float16", "int8"] if device == "cuda" else ["int8", "float32"]
+
+
+def _is_ct_error(msg):
+    low = msg.lower()
+    return "compute type" in low or "efficient float16" in low
+
+
 def _get_model():
     global _model
     if _model is None:
@@ -60,8 +76,20 @@ def _get_model():
             device = "cuda" if torch.cuda.is_available() else "cpu"
         except Exception:
             device = "cpu"
-        compute = "float16" if device == "cuda" else "int8"
-        _model = WhisperModel(name, device=device, compute_type=compute)
+        # Degrade fp16 → int8 rather than crash on GPUs without efficient fp16
+        # (older Maxwell/Pascal, GTX 16xx, CTranslate2/cuDNN mismatch) (#551).
+        last_err = None
+        for compute in _ct_candidates(device):
+            try:
+                _model = WhisperModel(name, device=device, compute_type=compute)
+                break
+            except (ValueError, RuntimeError) as e:
+                last_err = e
+                if _is_ct_error(str(e)):
+                    continue
+                raise
+        else:
+            raise last_err
     return _model
 
 

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -31,6 +31,23 @@ from abc import ABC, abstractmethod
 logger = logging.getLogger("omnivoice.asr")
 
 
+def _compute_type_candidates(device: str) -> list[str]:
+    """Per-device compute_type fallback chain. int8 is supported by every
+    CTranslate2 CUDA+CPU build; float16/int8_float16 only on GPUs with efficient
+    fp16 — so degrade rather than crash (#551). Honors an ASR_COMPUTE_TYPE env
+    override (power users on exotic hardware can pin int8/float32)."""
+    import os
+    override = os.environ.get("ASR_COMPUTE_TYPE")
+    if override:
+        return [override]
+    return ["float16", "int8_float16", "int8"] if device == "cuda" else ["int8", "float32"]
+
+
+def _is_compute_type_error(msg: str) -> bool:
+    low = msg.lower()
+    return "compute type" in low or "efficient float16" in low
+
+
 def _decode_audio_16k_mono(audio_path: str):
     """Decode `audio_path` to a 16 kHz mono float32 waveform using OmniVoice's
     *validated* ffmpeg, instead of whisperx.load_audio's bare ``"ffmpeg"`` PATH
@@ -189,7 +206,40 @@ class WhisperXBackend(ASRBackend):
                 # vad_method="silero" is the default; keep it so short gaps
                 # get cleaned up before transcription.
             )
-        except RuntimeError as e:
+        except (ValueError, RuntimeError) as e:
+            # #551: GPUs without efficient fp16 (older Maxwell/Pascal, GTX 16xx)
+            # or a CTranslate2/cuDNN binary mismatch raise a *ValueError*
+            # ("Requested float16 compute type, but the target device or backend
+            # do not support efficient float16 computation") at load — not an
+            # OOM, not a RuntimeError. Retry on the SAME device with the next
+            # compute_type candidate (cuda: int8_float16 → int8) before touching
+            # the OOM→CPU path, so we degrade rather than crash every chunk.
+            if _is_compute_type_error(str(e)):
+                candidates = _compute_type_candidates(self._device)
+                try:
+                    nxt = candidates[candidates.index(self._compute_type) + 1:]
+                except ValueError:
+                    nxt = [c for c in candidates if c != self._compute_type]
+                for ct in nxt:
+                    logger.warning(
+                        "whisperx %s unsupported on %s — retrying with %s. Detail: %s",
+                        self._compute_type, self._device, ct, e,
+                    )
+                    self._compute_type = ct
+                    try:
+                        self._asr = whisperx.load_model(
+                            self._model_name,
+                            device=self._device,
+                            compute_type=self._compute_type,
+                        )
+                        return
+                    except (ValueError, RuntimeError) as e2:
+                        if _is_compute_type_error(str(e2)):
+                            e = e2
+                            continue
+                        raise
+                # Exhausted compute-type candidates on this device — re-raise.
+                raise
             # CUDA OOM: a resident TTS model + the GPU worker pool can starve
             # VRAM on small (e.g. 8 GB laptop) GPUs, so loading large-v3 on
             # CUDA dies here — which previously surfaced as a bare 500 from
@@ -462,6 +512,10 @@ class FasterWhisperBackend(ASRBackend):
             "ASR_MODEL_FASTER", "Systran/faster-whisper-large-v3"
         )
         self._model = None  # lazy — first transcribe() loads weights
+        # Set by _ensure_model() to the device/compute_type that actually loaded
+        # (after the #551 compute_type / #255 OOM→CPU fallback chain).
+        self._device: str | None = None
+        self._compute_type: str | None = None
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:
@@ -490,9 +544,58 @@ class FasterWhisperBackend(ASRBackend):
             "faster-whisper loading %s on %s (%s)",
             self._model_name, device, compute_type,
         )
-        self._model = WhisperModel(
-            self._model_name, device=device, compute_type=compute_type
-        )
+        # Try the per-device compute_type chain (cuda: float16 → int8_float16 →
+        # int8; cpu: int8 → float32). A GPU without efficient fp16 (older
+        # Maxwell/Pascal, GTX 16xx, or a CTranslate2/cuDNN mismatch) raises a
+        # *ValueError* at construction (#551) — degrade to the next candidate
+        # instead of failing every chunk. A genuine CUDA OOM falls back to CPU
+        # (slower, same model/accuracy), preserving the existing #255 behaviour.
+        candidates = _compute_type_candidates(device)
+        if compute_type in candidates:
+            candidates = candidates[candidates.index(compute_type):]
+        last_err: Exception | None = None
+        while True:
+            for ct in candidates:
+                try:
+                    self._model = WhisperModel(
+                        self._model_name, device=device, compute_type=ct
+                    )
+                    self._device, self._compute_type = device, ct
+                    return
+                except (ValueError, RuntimeError) as e:
+                    last_err = e
+                    if _is_compute_type_error(str(e)):
+                        logger.warning(
+                            "faster-whisper %s unsupported on %s — trying next "
+                            "compute_type. Detail: %s", ct, device, e,
+                        )
+                        continue
+                    if device == "cuda" and "out of memory" in str(e).lower():
+                        # Stop scanning GPU candidates; fall back to CPU below.
+                        break
+                    raise
+            # Exhausted candidates for this device. If we were on CUDA and the
+            # last failure was an OOM, retry on CPU with its candidates (#255).
+            if device == "cuda" and last_err is not None and (
+                "out of memory" in str(last_err).lower()
+            ):
+                logger.warning(
+                    "faster-whisper CUDA OOM loading %s — retrying on CPU "
+                    "(slower). Free VRAM (Flush the TTS model) for GPU-speed "
+                    "ASR. Detail: %s", self._model_name, last_err,
+                )
+                try:
+                    import torch
+                    torch.cuda.empty_cache()
+                except Exception:  # noqa: BLE001 — cache clear is best-effort
+                    pass
+                device = "cpu"
+                candidates = _compute_type_candidates(device)
+                compute_type = candidates[0]
+                continue
+            # All candidates exhausted (and no OOM→CPU retry available) — surface
+            # the last error.
+            raise last_err
 
     def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
         self._ensure_model()
@@ -681,12 +784,25 @@ class PyTorchWhisperBackend(ASRBackend):
             "PyTorchWhisperBackend: loading standalone ASR pipeline %s on %s",
             model_name, device,
         )
-        self._pipe = hf_pipeline(
-            "automatic-speech-recognition",
-            model=model_name,
-            dtype=asr_dtype,
-            device_map=device,
-        )
+        try:
+            self._pipe = hf_pipeline(
+                "automatic-speech-recognition",
+                model=model_name,
+                dtype=asr_dtype,
+                device_map=device,
+            )
+        except Exception as e:
+            # #549: an incomplete transformers install fails to build the ASR
+            # pipeline (e.g. "Could not import module 'AutoFeatureExtractor'").
+            # The raw error is opaque; re-raise with an actionable next step so
+            # the toast tells the user how to recover instead of "no segments".
+            raise RuntimeError(
+                "transformers ASR pipeline failed to import (AutoFeatureExtractor) "
+                "— your transformers install is incomplete; reinstall with "
+                "`uv pip install --reinstall transformers`, or use faster-whisper "
+                "(OmniVoice's default ASR) which avoids the transformers pipeline. "
+                f"Underlying: {e}"
+            ) from e
 
     def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
         import soundfile as sf

--- a/backend/tests/test_asr_oom_fallback.py
+++ b/backend/tests/test_asr_oom_fallback.py
@@ -25,7 +25,17 @@ sys.modules["core.config"] = _config
 
 whisperx = pytest.importorskip("whisperx")
 
-from services.asr_backend import WhisperXBackend  # noqa: E402
+from services.asr_backend import (  # noqa: E402
+    WhisperXBackend,
+    _is_compute_type_error,
+)
+
+# The exact ValueError CTranslate2 raises at model construction on a GPU
+# without efficient fp16 (older Maxwell/Pascal, GTX 16xx) or a cuDNN mismatch.
+_FP16_ERR = (
+    "Requested float16 compute type, but the target device or backend do not "
+    "support efficient float16 computation"
+)
 
 
 def test_cuda_oom_falls_back_to_cpu(monkeypatch):
@@ -52,8 +62,13 @@ def test_cuda_oom_falls_back_to_cpu(monkeypatch):
 
 
 def test_non_oom_runtime_error_still_raises(monkeypatch):
+    msg = "some other failure"
+    # A generic non-OOM, non-compute-type RuntimeError must still propagate —
+    # the new compute_type fallback must NOT swallow it.
+    assert _is_compute_type_error(msg) is False
+
     def fake_load_model(name, device, compute_type, **kw):
-        raise RuntimeError("some other failure")  # not an OOM → must propagate
+        raise RuntimeError(msg)  # not an OOM, not compute-type → must propagate
 
     monkeypatch.setattr(whisperx, "load_model", fake_load_model)
 
@@ -62,3 +77,63 @@ def test_non_oom_runtime_error_still_raises(monkeypatch):
     be._allow_vad_pickle_globals = lambda: None
     with pytest.raises(RuntimeError, match="some other failure"):
         be._ensure_asr()
+
+
+def test_float16_unsupported_falls_back_to_int8(monkeypatch):
+    """#551: a GPU without efficient fp16 raises a ValueError at load for both
+    float16 AND int8_float16; the backend must degrade to int8 on the SAME
+    device (cuda) without raising — not fall to CPU and not crash."""
+    calls = []
+
+    def fake_load_model(name, device, compute_type, **kw):
+        calls.append((device, compute_type))
+        if device == "cuda" and compute_type in ("float16", "int8_float16"):
+            raise ValueError(_FP16_ERR)
+        return object()  # cuda int8 succeeds
+
+    monkeypatch.setattr(whisperx, "load_model", fake_load_model)
+
+    be = WhisperXBackend()
+    be._device, be._compute_type = "cuda", "float16"
+    be._allow_vad_pickle_globals = lambda: None
+
+    be._ensure_asr()
+
+    assert be._asr is not None                       # recovered, no raise
+    assert be._device == "cuda" and be._compute_type == "int8"  # same device, int8
+    assert calls == [("cuda", "float16"), ("cuda", "int8_float16"), ("cuda", "int8")]
+
+
+def test_faster_whisper_float16_unsupported_falls_back_to_int8(monkeypatch):
+    """Mirror for FasterWhisperBackend: float16 + int8_float16 raise the fp16
+    ValueError, int8 succeeds → loads on (cuda, int8) without raising."""
+    import services.asr_backend as asr_backend
+    from services.asr_backend import FasterWhisperBackend
+
+    calls = []
+
+    class FakeWhisperModel:
+        def __init__(self, name, device, compute_type, **kw):
+            calls.append((device, compute_type))
+            if device == "cuda" and compute_type in ("float16", "int8_float16"):
+                raise ValueError(_FP16_ERR)
+            # cuda int8 succeeds
+
+    fake_fw = types.ModuleType("faster_whisper")
+    fake_fw.WhisperModel = FakeWhisperModel
+    monkeypatch.setitem(sys.modules, "faster_whisper", fake_fw)
+
+    # Force the CUDA starting point regardless of the CI host's hardware by
+    # making torch.cuda.is_available() return True inside _ensure_model.
+    fake_torch = types.ModuleType("torch")
+    fake_torch.cuda = types.SimpleNamespace(
+        is_available=lambda: True, empty_cache=lambda: None
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    be = FasterWhisperBackend()
+    be._ensure_model()
+
+    assert be._model is not None                     # recovered, no raise
+    assert be._device == "cuda" and be._compute_type == "int8"
+    assert calls == [("cuda", "float16"), ("cuda", "int8_float16"), ("cuda", "int8")]

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -146,6 +146,72 @@ def test_transcribe_stream_surfaces_model_load_failure(tmp_path, monkeypatch):
     assert "CUDA driver init failed: simulated" in body, body
 
 
+def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeypatch):
+    """Regression #516: an unanticipated exception INSIDE the stream body (one
+    that escapes the per-chunk handler, e.g. segmentation blowing up) must still
+    end the stream with a terminal `error` then `done` — never a silent
+    disconnect (which the UI can only report as "stream dropped, likely ASR
+    failed", hiding the real cause)."""
+    import asyncio
+    import numpy as np
+    from api.routers import dub_core as dc
+
+    job_id = "t_bodycrash"
+    audio = tmp_path / "a.wav"
+    _make_wav(audio, seconds=1.0)
+    dc._dub_jobs[job_id] = {
+        "audio_path": str(audio), "vocals_path": None, "scene_cuts": [],
+    }
+
+    # Model + ASR backend load fine (preflight passes), so the failure happens
+    # mid-body where the terminal-event guard is the only safety net.
+    fake_model = MagicMock()
+    fake_model._asr_pipe = MagicMock()
+
+    async def _ok_model():
+        return fake_model
+
+    class _FakeASR:
+        id = "fake"
+        def transcribe(self, path, *, word_timestamps=True):
+            return {"chunks": [{"text": "hi", "timestamp": (0.0, 0.5)}],
+                    "segments": [], "language": "en"}
+        def unload(self):
+            pass
+
+    monkeypatch.setattr(dc, "get_model", _ok_model)
+    monkeypatch.setattr(
+        "services.asr_backend.get_active_asr_backend",
+        lambda *a, **k: _FakeASR(),
+    )
+    # Make the post-chunk segmentation (outside the per-chunk try/except) blow
+    # up — the exact class of "unanticipated escape" the guard must catch.
+    def _boom_segment(*a, **k):
+        raise RuntimeError("segmentation exploded: simulated")
+    monkeypatch.setattr(dc, "segment_transcript", _boom_segment)
+    # Don't touch the GPU/TTS during the test.
+    monkeypatch.setattr(dc, "offload_tts_for_asr", lambda *a, **k: None)
+
+    async def _collect():
+        resp = await dc.dub_transcribe_stream(job_id)
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk))
+        return "".join(parts)
+
+    try:
+        body = asyncio.run(_collect())
+    finally:
+        dc._dub_jobs.pop(job_id, None)
+
+    # The stream must end with a terminal error followed by done.
+    assert "event: error" in body, body
+    assert "segmentation exploded: simulated" in body, body
+    err_idx = body.rfind("event: error")
+    done_idx = body.rfind("event: done")
+    assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"
+
+
 @pytest.mark.xfail(
     reason="dub_core._transcribe was refactored to route through "
            "services.asr_backend.get_active_asr_backend; the MagicMock fixture "

--- a/tests/test_failure_classify.py
+++ b/tests/test_failure_classify.py
@@ -1,0 +1,39 @@
+"""ASR-robustness failure classification (#551 / #549).
+
+The dub/transcribe "no segments" toast is only actionable if `classify()` names
+the failure class so `build_failure()` can attach a hint. These assert the two
+new taxonomy classes added for the ASR-robustness fix map to a non-empty hint.
+"""
+from core import failure
+
+
+def test_classify_compute_type_unsupported():
+    # The exact CTranslate2 message on a GPU without efficient fp16 (#551).
+    reason = (
+        "Requested float16 compute type, but the target device or backend do "
+        "not support efficient float16 computation"
+    )
+    assert failure.classify(reason) == "COMPUTE_TYPE_UNSUPPORTED"
+    evt = failure.build_failure(reason, stage="transcribe", include_diagnostic=False)
+    assert evt["docs_topic"] == "COMPUTE_TYPE_UNSUPPORTED"
+    assert evt["hint"], "compute-type failure must carry an actionable hint"
+
+
+def test_classify_transformers_import():
+    # The transformers ASR-pipeline import failure (#549).
+    assert failure.classify("Could not import module 'AutoFeatureExtractor'") == (
+        "TRANSFORMERS_IMPORT"
+    )
+    # Substring match on the bare class name too (case-insensitive).
+    assert failure.classify("AutoFeatureExtractor failed to load") == "TRANSFORMERS_IMPORT"
+    evt = failure.build_failure(
+        "Could not import module 'AutoFeatureExtractor'",
+        stage="transcribe",
+        include_diagnostic=False,
+    )
+    assert evt["hint"], "transformers-import failure must carry an actionable hint"
+
+
+def test_classify_generic_still_empty():
+    # A genuinely unknown reason must still classify to "" (no false hint).
+    assert failure.classify("some totally unrelated failure") == ""


### PR DESCRIPTION
## #551 — the core bug
Both CTranslate2 ASR backends request `compute_type="float16"` on CUDA with **no fallback**. On GPUs without efficient fp16 (older Maxwell/Pascal, GTX 16xx) or a CTranslate2/cuDNN binary mismatch, model construction raises a **ValueError** that escaped the OOM-only `except RuntimeError` — so every chunk failed → *"Transcription produced no segments"*.

Add a per-device **compute_type fallback chain** (cuda: `float16 → int8_float16 → int8`; cpu: `int8 → float32`) to **both** backends (`WhisperXBackend._ensure_asr`, `FasterWhisperBackend._ensure_model`) **and** the ASR sidecar — *alongside* the existing OOM→CPU path, with an `ASR_COMPUTE_TYPE` override (README-documented).

## Folded into the same ASR-robustness pass
- **#549** — `_ensure_pipe` re-raises an actionable error (reinstall transformers / use faster-whisper) instead of bare *"Could not import module 'AutoFeatureExtractor'"*.
- **#516** — the `/dub/transcribe` SSE generator can now **never close without a terminal event**: any escape yields a structured `error` (+ hint) then `done`, turning "stream dropped" into the real cause + Retry.
- `failure.py` — `COMPUTE_TYPE_UNSUPPORTED` + `TRANSFORMERS_IMPORT` classes so the toast is actionable.

## Tests (fail-before/pass-after)
float16-unsupported → int8 for WhisperX + FasterWhisper; a generic non-OOM RuntimeError still raises; the two new `classify()` classes; the SSE stream always terminates `error→done`. **7 + 1 passed**, 17 in the failure suite (no regression).

Cross-platform: macOS has no CUDA (the new cuda chain is never entered); Windows/Linux CUDA users with cuDNN mismatches or older GPUs are the beneficiaries; the `ASR_COMPUTE_TYPE` escape hatch is opt-in (no divergent default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# ASR Robustness: Compute-Type Fallback & Terminal Event Guarantee

## Overview

This PR fixes critical ASR failures on GPUs lacking efficient float16 support or experiencing CTranslate2/cuDNN mismatches (issue `#551`). The core fix implements a per-device compute-type fallback mechanism across both WhisperX and FasterWhisper backends, ensuring graceful degradation instead of catastrophic failure. Concurrently addresses actionable error messaging (`#549`) and stream termination guarantees (`#516`).

## Compute-Type Fallback Mechanism

```mermaid
flowchart TD
    A["ASR Model Load Request<br/>(GPU: float16)"] --> B{Load Succeeds?}
    B -->|Yes| C["✓ Model Ready"]
    B -->|No| D{Compute-Type Error?<br/>float16/efficient fp16}
    D -->|No| E["Re-raise<br/>(OOM or other)"]
    D -->|Yes| F["Try Next Candidate"]
    F --> G{"Device Type?"}
    G -->|CUDA| H["Next: int8_float16"]
    G -->|CPU| I["Next: float32"]
    H --> B
    I --> B
    F --> J{All Candidates<br/>Exhausted?}
    J -->|Yes| K["Re-raise Last Error"]
    J -->|No| L["Continue Fallback"]
    L --> B
    E --> M["ASR Fails"]
    K --> M
    C --> N["Transcription Proceeds"]
```

**Fallback chains:**
- **CUDA**: `float16 → int8_float16 → int8`
- **CPU**: `int8 → float32`
- **Override**: `ASR_COMPUTE_TYPE` environment variable pins compute type (e.g., `ASR_COMPUTE_TYPE=int8`)

## Key Changes

### Backend Model Loading (WhisperX & FasterWhisper)
- `WhisperXBackend._ensure_asr` and `FasterWhisperBackend._ensure_model` now detect compute-type errors and iterate through device-specific candidate chains
- Maintains existing CUDA OOM → CPU fallback behavior alongside new per-device compute-type degradation
- Errors distinguishable via `_is_compute_type_error()` which matches "compute type" or "efficient float16" substrings

### ASR Sidecar (faster-whisper)
- `backend/engines/_asr_sidecar/main.py` adds `_ct_candidates(device)` helper to generate compute-type candidates
- Model construction wraps `WhisperModel` initialization in loop that retries on compute-type errors
- Respects `ASR_COMPUTE_TYPE` override from environment

### PyTorch Whisper Backend Error Messaging
- `PyTorchWhisperBackend._ensure_pipe` wraps transformers pipeline construction with error handling
- Incomplete transformers installs (missing `AutoFeatureExtractor`) now raise actionable `RuntimeError` suggesting reinstall or backend switch

### SSE Stream Termination Guarantee
- `dub_transcribe_stream` refactored: streaming loop moved to inner `_gen_body()` async generator
- Outer `gen()` wrapper catches all exceptions and guarantees terminal event sequence: `error` (with reason/hint) → `done`
- Eliminates silent stream disconnections on mid-stream exceptions (e.g., post-chunk segmentation failures)

### Failure Classification & Hints
New entries in `backend/core/failure.py`:
- **`COMPUTE_TYPE_UNSUPPORTED`**: "Your GPU doesn't support float16 — OmniVoice retried on int8. If transcription still fails, set ASR_COMPUTE_TYPE=int8 or use CPU."
- **`TRANSFORMERS_IMPORT`**: "Your transformers install is incomplete. Reinstall it or switch ASR to faster-whisper."

Both enable toast notifications with recovery guidance.

## Testing

**New Tests**
- `test_float16_unsupported_falls_back_to_int8`: Validates WhisperX fallback sequence (float16 → int8_float16 → int8 on CUDA)
- `test_faster_whisper_float16_unsupported_falls_back_to_int8`: Mirrors behavior for FasterWhisper
- `test_transcribe_stream_never_closes_without_terminal_event`: Ensures SSE stream always closes with terminal events
- `test_failure_classify.py`: Validates COMPUTE_TYPE_UNSUPPORTED and TRANSFORMERS_IMPORT classification and hint generation

**Test Suite**: All 17 ASR failure tests pass; no regressions.

## Documentation
README updated with GPU troubleshooting note explaining automatic fallback to int8 on compute-type mismatch, and documents `ASR_COMPUTE_TYPE` environment variable escape hatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->