### PR TITLE
fix: actionable download errors + self-heal a relocated venv (#554/#536/encodings)

### DIFF
--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -39,6 +39,9 @@ _HINTS: dict[str, str] = {
     "PYANNOTE_LICENSE_REQUIRED": "Accept the pyannote model licenses on Hugging Face, then retry.",
     "COMPUTE_TYPE_UNSUPPORTED": "Your GPU doesn't support float16 — OmniVoice retried on int8. If transcription still fails, set OMNIVOICE/ASR_COMPUTE_TYPE=int8 or use CPU.",
     "TRANSFORMERS_IMPORT": "Your transformers install is incomplete. Reinstall it (`uv pip install --reinstall transformers`) or switch ASR to faster-whisper (Settings → Models).",
+    "UNSUPPORTED_VIDEO_URL": "This link isn't a directly downloadable video. Paste a direct video page (e.g. a youtube.com/watch?v=… or douyin.com/video/<id> link), not a share/profile/feed link — or download the file and drop it in directly.",
+    "VIDEO_DOWNLOAD_NETWORK": "The connection to the video server dropped mid-download (often a transient CDN/network blip or a regional rate-limit). Just retry — OmniVoice already cleaned up the partial download. If it keeps failing, check your network/VPN.",
+    "BROKEN_VENV": "The Python backend environment was moved or damaged. OmniVoice rebuilds it automatically on the next launch; if it keeps failing, use Clean & Retry on the setup screen.",
 }
 
 
@@ -68,6 +71,24 @@ def classify(reason: str) -> str:
         "token" in low or "auth" in low or "401" in low or "unauthorized" in low
     ):
         return "HF_AUTH_FAILED"
+    # Video download (#554/#536): a non-downloadable URL shape vs a transient
+    # network drop — both previously surfaced as a bare yt-dlp string with no
+    # next step. UNSUPPORTED first (more specific) so "Unable to download video:
+    # Broken pipe" still classifies as a network blip.
+    if "unsupported url" in low or "no video formats" in low or "is not a valid url" in low:
+        return "UNSUPPORTED_VIDEO_URL"
+    if (
+        "broken pipe" in low
+        or "connection reset" in low
+        or "unable to download video" in low
+        or "remote end closed" in low
+        or "timed out" in low
+    ):
+        return "VIDEO_DOWNLOAD_NETWORK"
+    # A relocated/corrupted venv whose interpreter can't bootstrap its stdlib —
+    # the Rust self-heal rebuilds it; this names the class for the toast.
+    if "no module named 'encodings'" in low:
+        return "BROKEN_VENV"
     return ""
 
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -501,14 +501,20 @@ fn quarantine_broken_venv(venv_dir: &Path) -> bool {
 }
 
 /// Whether a dead backend process looks like it failed because the venv
-/// itself is structurally broken — the CPython venv launcher prints
-/// "No pyvenv.cfg file" and exits with code 106 (`RC_NO_PYVENV_CFG`). Matches
-/// either the message in the captured stderr tail or the exit code in the
-/// `ExitStatus` display ("exit code: 106" on Windows, "exit status: 106" on
-/// Unix). Kept deliberately narrow so ordinary backend crashes never trigger
-/// a venv rebuild.
+/// itself is structurally broken — either the CPython venv launcher's
+/// "No pyvenv.cfg file" + exit 106 (`RC_NO_PYVENV_CFG`), OR a relocated/copied/
+/// restored venv whose interpreter can't bootstrap its own stdlib and aborts
+/// very early with "No module named 'encodings'" (exit 1). Both are
+/// unrunnable-interpreter cases that `uv sync` cannot fix — only a venv rebuild
+/// can — so both route into the rebuild-once self-heal. Matches the message in
+/// the captured stderr tail or the exit code in the `ExitStatus` display
+/// ("exit code: 106" on Windows, "exit status: 106" on Unix). Kept deliberately
+/// narrow (full quoted phrases) so an ordinary backend crash — or an app-level
+/// import error of some 'encodings'-named package — never triggers a rebuild.
 pub fn backend_exit_indicates_broken_venv(exit_info: &str, err_tail: &str) -> bool {
-    err_tail.contains("No pyvenv.cfg file") || exit_info.trim_end().ends_with(": 106")
+    err_tail.contains("No pyvenv.cfg file")
+        || err_tail.contains("No module named 'encodings'")
+        || exit_info.trim_end().ends_with(": 106")
 }
 
 /// Prepare (and on first run, create) the Python venv that will host the
@@ -1204,6 +1210,18 @@ mod tests {
         assert!(!backend_exit_indicates_broken_venv("exit status: 1060", ""));
         assert!(!backend_exit_indicates_broken_venv("signal: 6 (SIGABRT)", ""));
         assert!(!backend_exit_indicates_broken_venv("never started", ""));
+        // A relocated/copied venv whose interpreter can't bootstrap its stdlib
+        // aborts with this exact phrase (exit 1, not 106) — must rebuild.
+        assert!(backend_exit_indicates_broken_venv(
+            "exit status: 1",
+            "ModuleNotFoundError: No module named 'encodings'"
+        ));
+        // ...but an app-level import of an 'encodings'-prefixed package must NOT
+        // (the full quoted phrase guards against this).
+        assert!(!backend_exit_indicates_broken_venv(
+            "exit status: 1",
+            "ModuleNotFoundError: No module named 'encodings_helper'"
+        ));
     }
 
     /// #248: verify that the setuptools repair install uses the correct specifier.

--- a/tests/test_failure_classify.py
+++ b/tests/test_failure_classify.py
@@ -34,6 +34,35 @@ def test_classify_transformers_import():
     assert evt["hint"], "transformers-import failure must carry an actionable hint"
 
 
+def test_classify_video_download_classes():
+    # #554: a non-downloadable link shape → actionable "paste a direct video URL".
+    assert failure.classify("Unsupported URL: https://www.douyin.com/discover") == (
+        "UNSUPPORTED_VIDEO_URL"
+    )
+    # #536: a transient mid-download drop → "just retry".
+    assert failure.classify("Unable to download video: [Errno 32] Broken pipe") == (
+        "VIDEO_DOWNLOAD_NETWORK"
+    )
+    assert failure.classify("Connection reset by peer") == "VIDEO_DOWNLOAD_NETWORK"
+    for cls, reason in (
+        ("UNSUPPORTED_VIDEO_URL", "Unsupported URL: x"),
+        ("VIDEO_DOWNLOAD_NETWORK", "Unable to download video: Broken pipe"),
+    ):
+        evt = failure.build_failure(reason, stage="download", include_diagnostic=False)
+        assert evt["docs_topic"] == cls
+        assert evt["hint"], f"{cls} must carry an actionable hint"
+
+
+def test_classify_broken_venv_encodings():
+    # The relocated/corrupted-venv stdlib-bootstrap failure → BROKEN_VENV (the
+    # Rust self-heal rebuilds it; this names the class for the toast).
+    assert failure.classify("ModuleNotFoundError: No module named 'encodings'") == (
+        "BROKEN_VENV"
+    )
+    # ...but an app-level import of an 'encodings'-prefixed package must NOT.
+    assert failure.classify("No module named 'encodings_helper'") == ""
+
+
 def test_classify_generic_still_empty():
     # A genuinely unknown reason must still classify to "" (no false hint).
     assert failure.classify("some totally unrelated failure") == ""


### PR DESCRIPTION
Two robustness fixes sharing the failure taxonomy.

### Video downloads (#554 / #536)
yt-dlp's raw error surfaced with no next step. `classify()` now names:
- **UNSUPPORTED_VIDEO_URL** — `Unsupported URL` (a share/profile/feed link, not a direct video page) → hint: paste a direct video page or drop a file.
- **VIDEO_DOWNLOAD_NETWORK** — `Broken pipe`/`Connection reset`/`Unable to download video` → hint: transient blip, just retry (the partial download is already cleaned up).

yt-dlp is on a current pin — this is graceful classification, **not** a dependency bump.

### "No module named 'encodings'" (relocated venv)
A moved/copied/restored venv whose interpreter can't bootstrap its stdlib aborts with this phrase (**exit 1, not 106**), slipping **both** #314 self-heal matchers → the user saw it forever. Widen `backend_exit_indicates_broken_venv` to match the full quoted phrase, routing it into the existing **rebuild-once** self-heal. Narrow enough that an app-level import of an `encodings`-prefixed package can't trigger a rebuild. Plus a `BROKEN_VENV` hint for when the rebuild itself can't run.

### Tests
`classify()` maps the 3 new classes (each with a hint; a generic reason still `""`); the `encodings_helper` negative guard holds; the Rust matcher test gains the encodings positive + negative cases. **5 pytest passed**; the Rust matcher is compiled by CI's Tauri shell check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses two robustness issues through a unified error classification framework:

### Video Download Errors (`#554/`#536)

yt-dlp raw errors now map to actionable classifications:
- **UNSUPPORTED_VIDEO_URL**: Detects URL shape issues ("unsupported url", "no video formats", "is not a valid url") → guides users to paste direct video pages or drop files
- **VIDEO_DOWNLOAD_NETWORK**: Detects transient network drops ("broken pipe", "connection reset", "unable to download video", "remote end closed", "timed out") → advises retry with note that partial downloads are cleaned up

### Relocated/Corrupted Virtual Environment (`#314` extension)

When a venv is moved or copied, the Python interpreter may fail to bootstrap its standard library with `ModuleNotFoundError: No module named 'encodings'` (exit code 1). This error previously bypassed existing self-heal matchers. The fix:
- Widens `backend_exit_indicates_broken_venv()` matcher to catch the full quoted phrase `"No module named 'encodings'"`
- Routes into the existing rebuild-once self-heal mechanism
- Constrains matching narrowly (`'encodings'` not `'encodings_helper'`) to prevent false positives on app-level imports
- Adds `BROKEN_VENV` hint explaining automatic rebuild on next launch

### Changes

**backend/core/failure.py** (+21 lines):
- Extends `_HINTS` dict with entries for `UNSUPPORTED_VIDEO_URL`, `VIDEO_DOWNLOAD_NETWORK`, `BROKEN_VENV`
- Expands `classify()` with substring checks for video and venv errors

**frontend/src-tauri/src/bootstrap.rs** (+25/-7 lines):
- Updates `backend_exit_indicates_broken_venv()` to detect encodings bootstrap failure
- Adds positive/negative test cases (encodings vs encodings_helper)

**tests/test_failure_classify.py** (+29 lines):
- Tests video download classifications and hint generation
- Tests BROKEN_VENV classification with negative guard validation

### Mechanism Flow

```mermaid
graph TD
    A["Backend Error Occurs"] --> B{"Classify Error"}
    B -->|Video URL patterns| C["UNSUPPORTED_VIDEO_URL<br/>Hint: Paste direct link"]
    B -->|Network patterns| D["VIDEO_DOWNLOAD_NETWORK<br/>Hint: Retry, partial downloads cleaned"]
    B -->|Encodings bootstrap| E["BROKEN_VENV<br/>Hint: Will rebuild on next launch"]
    B -->|Unknown| F["Empty classification<br/>No hint shown"]
    
    E --> G{"backend_exit_indicates_broken_venv()<br/>matches stderr?"}
    G -->|Yes| H["Quarantine broken venv"]
    H --> I["Set stage: Checking<br/>Trigger rebuild"]
    G -->|No| F
```

No dependency changes; yt-dlp remains on its current pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->