### PR TITLE
fix(lang): propagate profile/request language into generation + longform (#533/#505/#502)

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -164,6 +164,7 @@ async def audiobook_cover(cover: UploadFile = File(...)) -> dict:
 class AudiobookRequest(BaseModel):
     text: str
     default_voice: str | None = None   # voice profile id; None = engine default
+    language: str | None = None        # None/"Auto" → profile language, else autodetect (#505)
     bitrate: str = "128k"
     format: str = "m4b"                 # "m4b" | "mp3"
     loudness: str | None = None         # None/"off" | "acx" | "podcast" (opt-in)
@@ -215,7 +216,35 @@ def _resolve_voice(profile_id: str | None) -> dict:
     return out
 
 
-def _build_synth(default_voice: str | None) -> dict:
+def _resolve_default_language(language: str | None, default_voice: str | None) -> str | None:
+    """Pick the language to thread into the longform synth callable.
+
+    Priority (mirrors the single-shot /generate path, #533): an explicit
+    non-Auto request ``language`` wins; otherwise the selected profile's stored
+    language drives it; otherwise ``None`` (genuine Auto — the engine
+    autodetects, exactly as before). Hardcoding ``None`` here (#505 B2) let the
+    engine re-autodetect per chunk, so a non-English clone flipped to the wrong
+    language on short/ambiguous chapters.
+    """
+    if language and language != "Auto":
+        return language
+    if default_voice:
+        from core.db import db_conn
+        with db_conn() as conn:
+            row = conn.execute(
+                "SELECT language FROM voice_profiles WHERE id=?", (default_voice,)
+            ).fetchone()
+        if row:
+            try:
+                prof_lang = row["language"]
+            except (KeyError, IndexError):
+                prof_lang = None
+            if prof_lang and prof_lang != "Auto":
+                return prof_lang
+    return None
+
+
+def _build_synth(default_voice: str | None, language: str | None = None) -> dict:
     """Describe how to synthesize for the active TTS engine.
 
     Returns a dict with ``mode``, ``resolve`` (voice-id → resolved refs, cached
@@ -223,6 +252,11 @@ def _build_synth(default_voice: str | None) -> dict:
     ``get_model``; other engines carry a ready ``synth`` + ``sample_rate``.
     :func:`_prepare_synth` turns this into a uniform ``(synth, sr, resolve,
     engine_id)`` once the (async) model is in hand.
+
+    ``language`` (already resolved by :func:`_resolve_default_language`) is
+    threaded into every chunk's ``generate`` so a non-English clone stays in its
+    language instead of re-autodetecting per chunk (#505 B2). ``None`` keeps the
+    engine's autodetect behavior unchanged.
     """
     from services.tts_backend import OmniVoiceBackend, active_backend_id, get_backend_class
 
@@ -239,14 +273,14 @@ def _build_synth(default_voice: str | None) -> dict:
     if cls is OmniVoiceBackend:
         from services.model_manager import get_model
         return {"mode": "omnivoice", "resolve": resolve,
-                "engine_id": engine_id, "get_model": get_model}
+                "engine_id": engine_id, "get_model": get_model, "language": language}
 
     backend = cls()
 
     def synth(text, voice_id, speed=None):
         v = resolve(voice_id)
         return backend.generate(
-            text, language=None, ref_audio=v["ref_audio"],
+            text, language=language, ref_audio=v["ref_audio"],
             ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
             speed=float(speed) if speed else 1.0,
         )
@@ -254,20 +288,22 @@ def _build_synth(default_voice: str | None) -> dict:
             "synth": synth, "sample_rate": backend.sample_rate}
 
 
-async def _prepare_synth(default_voice: str | None):
+async def _prepare_synth(default_voice: str | None, language: str | None = None):
     """Resolve :func:`_build_synth` into ``(synth, sample_rate, resolve,
     engine_id)`` — awaiting the OmniVoice model load when needed. Shared by the
-    full job and the per-chapter preview."""
-    info = _build_synth(default_voice)
+    full job and the per-chapter preview. ``language`` is threaded into every
+    chunk so a non-English clone holds its language (#505 B2)."""
+    info = _build_synth(default_voice, language=language)
     resolve, engine_id = info["resolve"], info["engine_id"]
     if info["mode"] == "omnivoice":
+        lang = info["language"]
         model = await info["get_model"]()
         sr = getattr(model, "sampling_rate", 24000)
 
         def synth(text, voice_id, speed=None):
             v = resolve(voice_id)
             return model.generate(
-                text=text, language=None, ref_audio=v["ref_audio"],
+                text=text, language=lang, ref_audio=v["ref_audio"],
                 ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
                 speed=float(speed) if speed else 1.0,
             )[0]
@@ -323,6 +359,7 @@ class AudiobookPreviewRequest(BaseModel):
     text: str
     chapter_index: int = 0
     default_voice: str | None = None
+    language: str | None = None   # None/"Auto" → profile language, else autodetect
     lexicon: dict | None = None
 
 
@@ -346,7 +383,10 @@ async def audiobook_preview(req: AudiobookPreviewRequest) -> dict:
     chapter = plan.chapters[req.chapter_index]
     cache_dir = os.path.join(OUTPUTS_DIR, "longform_cache")  # shared with _render_longform_sse
     os.makedirs(cache_dir, exist_ok=True)
-    synth, sr, resolve, engine_id = await _prepare_synth(req.default_voice)
+    synth, sr, resolve, engine_id = await _prepare_synth(
+        req.default_voice,
+        language=_resolve_default_language(req.language, req.default_voice),
+    )
     loop = asyncio.get_running_loop()
     wav_path, dur, was_cached = await loop.run_in_executor(
         _gpu_pool, _render_chapter_cached, chapter, synth, sr, engine_id, resolve, cache_dir,
@@ -364,6 +404,7 @@ async def _render_longform_sse(
     plan,
     *,
     default_voice: str | None,
+    language: str | None = None,
     fmt: str = "m4b",
     bitrate: str = "128k",
     loudness: str | None = None,
@@ -412,7 +453,8 @@ async def _render_longform_sse(
                 for c in plan.chapters
             ],
             params={
-                "default_voice": default_voice, "fmt": fmt, "bitrate": bitrate,
+                "default_voice": default_voice, "language": language,
+                "fmt": fmt, "bitrate": bitrate,
                 "loudness": loudness, "cover_path": cover_path,
                 "metadata": metadata, "lexicon": lexicon,
             },
@@ -453,7 +495,9 @@ async def _render_longform_sse(
     loop = asyncio.get_running_loop()
 
     try:
-        synth, sr, resolve, engine_id = await _prepare_synth(default_voice)
+        synth, sr, resolve, engine_id = await _prepare_synth(
+            default_voice, language=_resolve_default_language(language, default_voice)
+        )
 
         total = len(plan.chapters)
         chapter_files: list[str] = []
@@ -557,7 +601,8 @@ async def audiobook_synthesize(req: AudiobookRequest):
     plan = parse_audiobook_script(req.text, default_voice=req.default_voice)
     return StreamingResponse(
         _render_longform_sse(
-            plan, default_voice=req.default_voice, fmt=req.format, bitrate=req.bitrate,
+            plan, default_voice=req.default_voice, language=req.language,
+            fmt=req.format, bitrate=req.bitrate,
             loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
             lexicon=req.lexicon, job_type="audiobook",
         ),
@@ -582,6 +627,7 @@ class LongformChapter(BaseModel):
 class LongformRenderRequest(BaseModel):
     chapters: list[LongformChapter] = []
     default_voice: str | None = None
+    language: str | None = None        # None/"Auto" → profile language, else autodetect (#505)
     bitrate: str = "128k"
     format: str = "m4b"
     loudness: str | None = None
@@ -612,7 +658,8 @@ async def longform_render(req: LongformRenderRequest):
     plan = AudiobookPlan(chapters=chapters)
     return StreamingResponse(
         _render_longform_sse(
-            plan, default_voice=req.default_voice, fmt=req.format, bitrate=req.bitrate,
+            plan, default_voice=req.default_voice, language=req.language,
+            fmt=req.format, bitrate=req.bitrate,
             loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
             lexicon=req.lexicon, job_type="story",
         ),
@@ -702,7 +749,7 @@ async def resume_longform(job_id: str):
     # never names a work dir / output file (defence-in-depth path-injection).
     return StreamingResponse(
         _render_longform_sse(
-            plan, default_voice=p.get("default_voice"),
+            plan, default_voice=p.get("default_voice"), language=p.get("language"),
             fmt=p.get("fmt", "m4b"), bitrate=p.get("bitrate", "128k"),
             loudness=p.get("loudness"), cover_path=p.get("cover_path"),
             metadata=p.get("metadata"), lexicon=p.get("lexicon"),

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -430,6 +430,20 @@ async def generate_speech(
                     used_seed = row["seed"]
             if language == "Auto":
                 language = None
+            # #533: a profile's stored language must drive generation when the
+            # request didn't pin one. Without this the German (etc.) archetype
+            # generates with language=None and the model drifts to English —
+            # even though the archetype PREVIEW renders correctly (archetypes.py
+            # passes the language). An EXPLICIT non-Auto request language still
+            # wins; we only fill the gap. `row` is a sqlite3.Row, so guard the
+            # column lookup for pre-language DBs mid-upgrade.
+            if language is None:
+                try:
+                    prof_lang = row["language"]
+                except (KeyError, IndexError):
+                    prof_lang = None
+                if prof_lang and prof_lang != "Auto":
+                    language = prof_lang
     elif ref_audio is not None:
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as f:

--- a/omnivoice/utils/duration.py
+++ b/omnivoice/utils/duration.py
@@ -202,7 +202,16 @@ class RuleDurationEstimator:
         return self.weights["default"]
 
     def calculate_total_weight(self, text):
-        """Sums up the normalized weights for a string."""
+        """Sums up the normalized weights for a string.
+
+        Text is NFC-normalized first so decomposed (NFD) input — a base letter
+        followed by a combining tone/diacritic mark (common for Vietnamese and
+        any diacritic script) — collapses onto its precomposed form. Combining
+        marks (U+0300–036F) weigh 0.0, so NFD text under-allocated frames and
+        produced rushed/garbled audio (#502); NFC composition is a no-op for
+        already-precomposed text.
+        """
+        text = unicodedata.normalize("NFC", text)
         return sum(self._get_char_weight(c) for c in text)
 
     def estimate_duration(

--- a/tests/test_duration_nfc.py
+++ b/tests/test_duration_nfc.py
@@ -1,0 +1,84 @@
+"""Issue #502 (partial) — the duration estimator must be Unicode-normalization
+-form independent.
+
+``RuleDurationEstimator`` weights combining marks (U+0300–036F, category Mn) at
+0.0. Decomposed (NFD) text — a base letter followed by combining tone/diacritic
+marks, the canonical on-disk form for Vietnamese and many diacritic scripts —
+therefore mis-allocates frames versus the precomposed (NFC) form of the *same*
+text, producing rushed/garbled audio for the affected syllables.
+
+The fix NFC-normalizes at the estimator's text entry point
+(``calculate_total_weight``), so NFC and NFD inputs always yield the *same*
+estimate. These tests fail before the fix (NFD diverges) and pass after.
+"""
+import unicodedata
+
+import pytest
+
+from omnivoice.utils.duration import RuleDurationEstimator
+
+
+def _raw_weight(est, text):
+    """Pre-fix weighting: sum per-char weights WITHOUT NFC normalization.
+
+    Calls the lru_cache-wrapped ``_get_char_weight`` via ``__wrapped__`` so the
+    fix's normalization step is bypassed — this reproduces the *old*
+    ``calculate_total_weight`` behavior to prove the bug existed.
+    """
+    return sum(est._get_char_weight.__wrapped__(est, c) for c in text)
+
+
+# A single Korean Hangul syllable: precomposed (1 syllable block, weight 2.5)
+# vs decomposed (lead/vowel/tail jamo). This is the clearest member of the
+# normalization-divergence *class* — the bug is not Vietnamese-specific.
+_KOREAN = "한"  # 한
+# A Vietnamese phrase exercising stacked tone + vowel-quality marks — the
+# issue's named script. Stays stable across forms once normalized.
+_VIETNAMESE = "Tiếng Việt nặng hỏi ngã sắc huyền"
+
+
+def test_combining_marks_weigh_zero():
+    """Guards the precondition the bug rests on: combining marks contribute 0.0,
+    so NFD text that splits a syllable into base+marks loses that weight."""
+    est = RuleDurationEstimator()
+    for cp in (0x0300, 0x0301, 0x0302, 0x0303, 0x0309, 0x0323):  # Vietnamese tone marks
+        assert est._get_char_weight(chr(cp)) == 0.0
+
+
+def test_nfd_diverges_from_nfc_before_normalization():
+    """Fail-before guard: the OLD (un-normalized) weighting gives NFD a
+    different weight than NFC, which is exactly the defect."""
+    est = RuleDurationEstimator()
+    nfc = unicodedata.normalize("NFC", _KOREAN)
+    nfd = unicodedata.normalize("NFD", _KOREAN)
+    assert nfc != nfd  # the syllable really does have distinct forms
+    assert _raw_weight(est, nfc) != _raw_weight(est, nfd)
+
+
+@pytest.mark.parametrize("sample", [_KOREAN, _VIETNAMESE, "한국어 문장입니다"])
+def test_calculate_total_weight_is_normalization_independent(sample):
+    """After the fix, NFC and NFD inputs weigh identically (the fix normalizes
+    to NFC first). Non-zero, so the estimate stays meaningful."""
+    est = RuleDurationEstimator()
+    nfc = unicodedata.normalize("NFC", sample)
+    nfd = unicodedata.normalize("NFD", sample)
+    w_nfc = est.calculate_total_weight(nfc)
+    w_nfd = est.calculate_total_weight(nfd)
+    assert w_nfc == w_nfd
+    assert w_nfc > 0
+
+
+@pytest.mark.parametrize("sample", [_KOREAN, _VIETNAMESE])
+def test_estimate_duration_is_normalization_independent(sample):
+    """End-to-end: the public estimate is identical for NFC vs NFD input.
+
+    Before the fix the Hangul case diverges ~3x (NFD over-counts as jamo);
+    after the fix both forms produce the same, correct estimate."""
+    est = RuleDurationEstimator()
+    ref_text, ref_dur = "Hello, world.", 1.5
+    nfc = unicodedata.normalize("NFC", sample)
+    nfd = unicodedata.normalize("NFD", sample)
+    est_nfc = est.estimate_duration(nfc, ref_text, ref_dur)
+    est_nfd = est.estimate_duration(nfd, ref_text, ref_dur)
+    assert est_nfc == est_nfd
+    assert est_nfc > 0

--- a/tests/test_longform_e2e.py
+++ b/tests/test_longform_e2e.py
@@ -39,7 +39,7 @@ def _resolve(_voice_id):
 def _stub_build_synth(*, fail_on=None):
     """Return a drop-in for `audiobook._build_synth` whose `synth` emits 0.1s of
     silence per span. `fail_on(text)` → raise, to exercise per-chapter faults."""
-    def _factory(default_voice=None):
+    def _factory(default_voice=None, language=None):
         def synth(text, voice_id, speed=None):
             if fail_on is not None and fail_on(text):
                 raise RuntimeError("stub synth deliberately failed")

--- a/tests/test_profile_language_propagation.py
+++ b/tests/test_profile_language_propagation.py
@@ -1,0 +1,200 @@
+"""Non-English correctness: a voice profile's stored language must drive
+generation, and the longform path must not hardcode language=None.
+
+  * #533 — POST /generate with a profile_id but no request language must thread
+    the *profile's* language into the engine (German archetype → German output,
+    not English). An explicit non-Auto request language still wins.
+  * #505 (B2) — the audiobook/longform synth callable hardcoded language=None,
+    so each chunk re-autodetected and a non-English clone drifted. The synth
+    must now carry the resolved language.
+
+The engine layer is stubbed (no real model loads), matching
+``tests/test_generate_engine.py``.
+"""
+import importlib
+import os
+import uuid
+
+import pytest
+import torch
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+
+def _tts_mod():
+    return importlib.import_module("services.tts_backend")
+
+
+def _make_fake_engine(engine_id="fake-lang-engine", gpu_compat=("cpu",)):
+    _compat = gpu_compat
+
+    class _FakeEngine(_tts_mod().TTSBackend):
+        id = engine_id
+        display_name = "Fake Lang Engine (test)"
+        applies_own_mastering = False
+        gpu_compat = _compat
+        calls: list = []
+
+        @property
+        def sample_rate(self) -> int:
+            return 24000
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return ["multi"]
+
+        @classmethod
+        def is_available(cls):
+            return True, "ready"
+
+        def generate(self, text, **kw) -> torch.Tensor:
+            type(self).calls.append((text, kw))
+            return torch.zeros(1, 24000)
+
+    return _FakeEngine
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+@pytest.fixture()
+def _init_db():
+    from core.db import init_db
+
+    init_db()
+
+
+@pytest.fixture()
+def german_profile(_init_db):
+    """Insert a clone profile whose stored language is 'German', then remove it.
+
+    No ref_audio_path on disk → the resolver leaves ref_audio None, so the
+    engine still runs (the test asserts on the threaded `language`, not audio)."""
+    from core.db import db_conn
+
+    pid = f"vp-de-{uuid.uuid4().hex[:8]}"
+    with db_conn() as conn:
+        conn.execute(
+            "INSERT INTO voice_profiles (id, name, language, kind, created_at) "
+            "VALUES (?,?,?,?,?)",
+            (pid, "German Narrator", "German", "clone", 0.0),
+        )
+    yield pid
+    with db_conn() as conn:
+        # A successful /generate inserts a generation_history row FK-referencing
+        # the profile — clear dependents before the profile itself.
+        conn.execute("DELETE FROM generation_history WHERE profile_id=?", (pid,))
+        conn.execute("DELETE FROM voice_profiles WHERE id=?", (pid,))
+
+
+# ── #533: profile language drives /generate ──────────────────────────────────
+
+
+def test_generate_uses_profile_language_when_request_unset(client, monkeypatch, german_profile):
+    """Request omits language → the profile's stored 'German' reaches the engine
+    (not None). Before the fix generation.py never read row['language']."""
+    fake = _make_fake_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, fake.id, fake)
+    fake.calls.clear()
+
+    res = client.post("/generate", data={
+        "text": "Guten Tag", "profile_id": german_profile, "engine": fake.id,
+    })
+
+    assert res.status_code == 200, res.text
+    assert len(fake.calls) == 1
+    _, kw = fake.calls[0]
+    # The engine receives the profile's language string; the model's
+    # _resolve_language maps 'German' → 'de'. Critically: NOT None.
+    assert kw.get("language") == "German"
+
+
+def test_generate_explicit_language_overrides_profile(client, monkeypatch, german_profile):
+    """An explicit non-Auto request language wins over the profile language."""
+    fake = _make_fake_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, fake.id, fake)
+    fake.calls.clear()
+
+    res = client.post("/generate", data={
+        "text": "Hello", "profile_id": german_profile, "engine": fake.id,
+        "language": "en",
+    })
+
+    assert res.status_code == 200, res.text
+    assert len(fake.calls) == 1
+    _, kw = fake.calls[0]
+    assert kw.get("language") == "en"  # request wins, not 'German'
+
+
+def test_generate_explicit_auto_falls_back_to_profile(client, monkeypatch, german_profile):
+    """Explicit 'Auto' is request-unset → profile language still wins."""
+    fake = _make_fake_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, fake.id, fake)
+    fake.calls.clear()
+
+    res = client.post("/generate", data={
+        "text": "Guten Tag", "profile_id": german_profile, "engine": fake.id,
+        "language": "Auto",
+    })
+
+    assert res.status_code == 200, res.text
+    _, kw = fake.calls[0]
+    assert kw.get("language") == "German"
+
+
+# ── #505 (B2): longform synth carries the language, never hardcoded None ──────
+
+
+def test_resolve_default_language_request_wins():
+    from api.routers.audiobook import _resolve_default_language
+
+    assert _resolve_default_language("ja", None) == "ja"
+    assert _resolve_default_language("ja", "anything") == "ja"
+
+
+def test_resolve_default_language_falls_back_to_profile(german_profile):
+    from api.routers.audiobook import _resolve_default_language
+
+    # No request language → the profile's stored language drives it.
+    assert _resolve_default_language(None, german_profile) == "German"
+    assert _resolve_default_language("Auto", german_profile) == "German"
+
+
+def test_resolve_default_language_none_when_nothing(_init_db):
+    from api.routers.audiobook import _resolve_default_language
+
+    assert _resolve_default_language(None, None) is None
+    assert _resolve_default_language("Auto", None) is None
+
+
+def test_build_synth_threads_language_into_generic_engine(monkeypatch):
+    """The generic-engine synth callable must pass the resolved language to
+    backend.generate — before the fix it hardcoded language=None (#505 B2)."""
+    import api.routers.audiobook as ab
+
+    captured = {}
+
+    class _Backend:
+        sample_rate = 24000
+
+        def generate(self, text, **kw):
+            captured["language"] = kw.get("language")
+            return torch.zeros(1, 24000)
+
+    monkeypatch.setattr(ab, "_resolve_voice",
+                        lambda pid: {"ref_audio": None, "ref_text": None,
+                                     "instruct": None, "seed": None})
+    monkeypatch.setattr("services.tts_backend.active_backend_id", lambda: "fake")
+    # _Backend is not OmniVoiceBackend → _build_synth takes the generic path.
+    monkeypatch.setattr("services.tts_backend.get_backend_class", lambda eid: _Backend)
+
+    info = ab._build_synth(default_voice="vp1", language="ja")
+    assert info["mode"] == "generic"
+    info["synth"]("こんにちは", "vp1")
+    assert captured["language"] == "ja"  # NOT None


### PR DESCRIPTION
Non-English voices drifted to English / wrong-language because the language wasn't reaching the model. Three related fixes (root-caused via triage):

- **#533** — `generate_speech()` never read a resolved profile's `language` (and collapsed `Auto→None`), so a German archetype previewed in German but **generated in English** on the user's own call (and via Docker/API). Falls back to the profile's stored language when the request didn't pin one; explicit request language still wins. (Frontend already sets the dropdown on profile-select — this is the authoritative backend fix.)
- **#505 (B2)** — the audiobook/longform synth **hardcoded `language=None`**, so the engine re-autodetected per chunk and a non-English clone flipped language mid-render. `_resolve_default_language` (request → profile → autodetect) is now threaded through `_build_synth`/`_prepare_synth`/`_render_longform_sse`, the three longform request models, the preview path, and the resume manifest. Auto/unset behavior unchanged.
- **#502 (partial)** — the duration estimator weights combining marks (U+0300–036F) at `0.0`, so **NFD** text under-allocated frames → rushed audio. NFC-normalize at the estimator entry (fixes the whole diacritic-script class; no-op for precomposed). The residual "distorted" core still needs the reporter's `fail.wav` — tracked separately.

### Tests (fail-before/pass-after)
profile language reaches the engine (German→`de`); longform synth gets the resolved language (→`ja`) not `None`; NFD vs NFC duration parity (Korean Hangul diverges ~3× pre-fix). **tests/ 1740 passed · backend/tests/ 114 passed.**

Cross-platform: pure routing/Python; identical mac/win/linux. No schema/DB change (the longform `language` field is optional, backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Language Propagation & Duration Estimator Fixes

This PR fixes three language propagation issues in the voice generation and synthesis system, plus one duration estimation bug affecting diacritic-heavy scripts.

### Issue `#533`: Profile Language Not Propagating to Generation
The `/generate` route now reads the `language` field from a resolved voice profile when the request doesn't explicitly specify a language. After handling `"Auto"` conversion, if the request language is `None`, the code checks the voice profile's stored language field (with a guard for databases still mid-upgrade). This prevents German and other non-English archetypes from defaulting to English generation.

### Issue `#505` (B2): Longform Synthesis Re-autodetecting Language Per Chunk
The audiobook and longform synthesis pipeline now threads a consistent language through all chunk/chapter renders instead of hardcoding `language=None`. 

**Key additions:**
- `_resolve_default_language(language, default_voice)` helper implements language precedence: explicit non-Auto request → profile's stored language → `None` (engine autodetect)
- Three request models gain optional `language` field: `AudiobookRequest`, `AudiobookPreviewRequest`, `LongformRenderRequest`
- `_build_synth()` and `_prepare_synth()` accept and thread resolved language into backend generation
- Resume manifest persists `language` in stored params, ensuring resumed jobs maintain the same language behavior

The language resolution hierarchy:

```mermaid
graph TD
    A["Request Language Provided?"] -->|Non-Auto| B["Use Request Language"]
    A -->|None or Auto| C["Profile Language Available?"]
    C -->|Non-Auto| D["Use Profile Language"]
    C -->|None or Auto| E["Return None - Engine Autodetects"]
    B --> F["Generate with Resolved Language"]
    D --> F
    E --> F
```

### Issue `#502`: Duration Estimator Under-weighting Decomposed Text
The `calculate_total_weight()` function in `omnivoice/utils/duration.py` now applies NFC normalization at its entry point. Previously, combining diacritical marks (Unicode U+0300–036F) were assigned zero weight, causing decomposed (NFD) text to under-allocate audio frames and produce rushed/garbled output. NFC normalization collapses precomposed characters onto their base form, ensuring consistent duration estimates regardless of input normalization. This has no impact on already-precomposed text.

### Test Coverage
- **200 lines** in `test_profile_language_propagation.py`: Validates language propagation from voice profile through `/generate` endpoint and longform rendering, with tests for request language override and profile fallback behavior
- **84 lines** in `test_duration_nfc.py`: Verifies NFC vs NFD duration parity across Korean Hangul, Vietnamese, and other diacritic-heavy scripts
- **1 line** in `test_longform_e2e.py`: Updates test stub to accept `language` parameter

### Backward Compatibility
- All `language` fields are optional and default to `None`
- Auto/unset behavior unchanged (engine continues to autodetect when no explicit language is provided)
- No database schema changes required
- Pure Python routing changes with cross-platform compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->