### PR TITLE
docs(changelog): add non-English language fixes to v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ design, dubbing, transcription, install, and the Linux UI.
 - **A relocated, copied, or restored backend venv ("No module named
   'encodings'") now self-heals** (rebuilds once) instead of failing on every
   launch.
+- **Non-English voices drifted to English / the wrong language.** A voice
+  profile's stored language wasn't propagated into generation (a German
+  archetype previewed in German but generated in English), the audiobook/longform
+  synth hardcoded `language=None` (a non-English clone could flip language
+  mid-render), and the duration estimator under-allocated frames for decomposed
+  (NFD) diacritic text. The profile/request language is now threaded through both
+  the single-shot and longform paths, and text is NFC-normalized. (#533, #505, #502)
 - The **"Can't reach the local backend" startup-crash wave** (pkg_resources
   #248, `scalar_fastapi` #307, exit-106 broken venv) was fixed in v0.3.6 — this
   release carries those fixes, so updating from v0.3.5/older resolves them.


### PR DESCRIPTION
Adds #533/#505/#502 (the non-English language fixes from #565) to the v0.3.7 CHANGELOG so the release body is complete. Docs-only. Merge before tagging v0.3.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Update: Non-English Language Fixes for v0.3.7 CHANGELOG

This PR adds a documentation entry to the v0.3.7 CHANGELOG describing fixes for non-English voice profile language drift issues. The new entry documents three related bugs (issues `#533`, `#505`, and `#502`) that were previously merged but were missing from the release notes.

### Changes Made

- Added a new item to the **0.3.7 "Fixed"** section in `CHANGELOG.md` (7 lines added)
- Documents the bug where voice profiles in non-English languages drifted to English or the wrong language during generation
- Describes the fix: threading profile/request language through both single-shot and longform generation paths, plus NFC-normalization of text
- References issues `#533`, `#505`, and `#502`

### Context

This is a documentation-only change intended to ensure the v0.3.7 release notes are complete and accurate before the version tag is created. The actual fixes were already merged in PR `#565`; this PR simply documents them in the CHANGELOG.

**Estimated review effort:** Low

<!-- end of auto-generated comment: release notes by coderabbit.ai -->