### PR TITLE
fix(backend): auto-restart supervisor + client transport-retry (#567/#570/#571)

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.6"
+version = "0.3.8"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -4,15 +4,16 @@ use std::fs;
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tauri::{Emitter, Manager};
 
 use crate::config::get_effective_region;
 use crate::tools::resolve_uv;
-use crate::{BackendState, backend_port};
+use crate::{AppFlags, BackendState, backend_port};
 
 // ── Bootstrap stages ──────────────────────────────────────────────────────
 
@@ -179,6 +180,18 @@ pub fn spawn_backend_and_wait(app: &tauri::AppHandle, stage_handle: &Arc<Mutex<B
         while start.elapsed() < Duration::from_secs(300) {
             if crate::backend::backend_healthy(backend_port()) {
                 set_stage(stage_handle, BootstrapStage::Ready);
+                // #567/#570/#571: once Ready, keep watching the backend child
+                // and respawn it if it dies mid-session, so a crash self-heals
+                // instead of leaving every later request to dead-end on
+                // "Can't reach the local backend". Only one supervisor runs at
+                // a time — Retry can re-enter this function concurrently.
+                if SUPERVISOR_ACTIVE
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    supervise_backend(app, stage_handle);
+                    SUPERVISOR_ACTIVE.store(false, Ordering::SeqCst);
+                }
                 return;
             }
             let process_dead = if let Ok(mut guard) = app.state::<BackendState>().process.lock() {
@@ -241,6 +254,131 @@ pub fn spawn_backend_and_wait(app: &tauri::AppHandle, stage_handle: &Arc<Mutex<B
         };
         set_stage(stage_handle, BootstrapStage::Failed { message: msg });
         return;
+    }
+}
+
+// ── Backend supervisor (auto-restart) ─────────────────────────────────────
+//
+// #567/#570/#571: the backend used to be spawned once and never watched again
+// (`spawn_backend_and_wait` returned the instant it was healthy). When the
+// uvicorn process then died mid-session — a CUDA OOM/context fault under a
+// burst of generations, an antivirus kill, any crash — nothing restarted it,
+// so every later request threw connection-refused and the user was stuck on
+// the "Can't reach the local backend" toast until they restarted the whole
+// app. The supervisor closes that gap: after Ready, it watches the child and
+// respawns it (bounded) so a crash self-heals.
+
+/// Only one supervisor loop may run at a time. The launch-time bootstrap and
+/// the Retry button both call `spawn_backend_and_wait` (and can race), so the
+/// first to reach Ready claims this and the rest fall through.
+static SUPERVISOR_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Give up (surface Failed) if the backend dies this many times within
+/// `RESTART_WINDOW` — a deterministic startup crash must not become a
+/// fork-bomb. The #314 broken-venv self-heal stays the venv-failure path; the
+/// supervisor only handles post-Ready deaths.
+const MAX_RESTARTS: usize = 5;
+const RESTART_WINDOW: Duration = Duration::from_secs(60);
+
+fn app_is_quitting(app: &tauri::AppHandle) -> bool {
+    app.try_state::<AppFlags>()
+        .map(|f| f.quitting.load(Ordering::SeqCst))
+        .unwrap_or(false)
+}
+
+/// Returns `Some(exit description)` if the tracked backend child has exited,
+/// `None` if it is still running (or none is tracked — which we never treat as
+/// a death to respawn, to avoid fighting a deliberate teardown).
+fn backend_child_exit(app: &tauri::AppHandle) -> Option<String> {
+    let state = app.try_state::<BackendState>()?;
+    let mut guard = state.process.lock().ok()?;
+    match guard.as_mut() {
+        Some(child) => match child.try_wait() {
+            Ok(Some(status)) => Some(status.to_string()),
+            Ok(None) => None,
+            Err(e) => Some(format!("try_wait error: {e}")),
+        },
+        None => None,
+    }
+}
+
+/// Drop restart timestamps older than `RESTART_WINDOW` and report whether the
+/// remaining count has hit the cap. Pure so the backoff policy is unit-tested
+/// without spawning real processes.
+fn restart_budget_exhausted(times: &mut Vec<Instant>, now: Instant) -> bool {
+    times.retain(|t| now.duration_since(*t) < RESTART_WINDOW);
+    times.len() >= MAX_RESTARTS
+}
+
+/// After the backend is Ready, watch its process and respawn it on an
+/// unexpected exit. Runs on the (otherwise-returning) bootstrap thread and
+/// stops the instant the app is quitting so it never resurrects the backend
+/// during shutdown. Death is detected only via a *confirmed process exit*
+/// (`try_wait`), never a slow health probe, so a busy-but-alive backend is
+/// never killed.
+fn supervise_backend(app: &tauri::AppHandle, stage_handle: &Arc<Mutex<BootstrapStage>>) {
+    let mut restart_times: Vec<Instant> = Vec::new();
+    loop {
+        std::thread::sleep(Duration::from_secs(2));
+        if app_is_quitting(app) {
+            return;
+        }
+        let exit_info = match backend_child_exit(app) {
+            Some(info) => info,
+            None => continue, // still running
+        };
+        // The exit may have raced with a shutdown that killed the child.
+        if app_is_quitting(app) {
+            return;
+        }
+        if restart_budget_exhausted(&mut restart_times, Instant::now()) {
+            let tail = crate::backend::read_error_log_tail(30);
+            let msg = format!(
+                "The backend kept crashing ({} times in {}s) and couldn't be kept running. \
+                 Use Clean & Retry, or check Settings → Logs → Backend.{}",
+                MAX_RESTARTS,
+                RESTART_WINDOW.as_secs(),
+                if tail.is_empty() { String::new() } else { format!("\n\nLast output:\n{tail}") },
+            );
+            log::error!("Backend supervisor giving up: {msg}");
+            let _ = app.emit("backend-restart-failed", msg.clone());
+            set_stage(stage_handle, BootstrapStage::Failed { message: msg });
+            return;
+        }
+        restart_times.push(Instant::now());
+        log::warn!("Backend process exited unexpectedly ({exit_info}) — restarting it (#567)");
+        emit_log(app, "starting_backend", "Backend stopped unexpectedly — restarting it automatically");
+        // Frontend listens for this to show a "reconnecting" banner (the splash
+        // poll has already stopped post-Ready, so the stage alone won't show).
+        let _ = app.emit("backend-restarting", exit_info.clone());
+        set_stage(stage_handle, BootstrapStage::StartingBackend);
+        // Clear any orphan still holding the port before the respawn.
+        if crate::backend::port_in_use(backend_port()) {
+            crate::backend::kill_orphan_on_port(backend_port());
+            std::thread::sleep(Duration::from_millis(300));
+        }
+        let child = crate::backend::spawn_backend(app, Some(stage_handle));
+        if let Ok(mut guard) = app.state::<BackendState>().process.lock() {
+            *guard = child;
+        }
+        // Wait (bounded) for the respawn to become healthy. If it dies again
+        // immediately, bail early so the next loop counts it toward the cap.
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(120) {
+            if app_is_quitting(app) {
+                return;
+            }
+            if crate::backend::backend_healthy(backend_port()) {
+                set_stage(stage_handle, BootstrapStage::Ready);
+                let _ = app.emit("backend-restored", ());
+                log::info!("Backend restarted and healthy again");
+                break;
+            }
+            if backend_child_exit(app).is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
     }
 }
 
@@ -1050,6 +1188,36 @@ mod tests {
         assert_eq!(envs.get("UV_HTTP_TIMEOUT").map(String::as_str), Some("120"));
         assert_eq!(envs.get("UV_HTTP_CONNECT_TIMEOUT").map(String::as_str), Some("30"));
         assert_eq!(envs.get("UV_HTTP_RETRIES").map(String::as_str), Some("5"));
+    }
+
+    #[test]
+    fn restart_budget_caps_respawns_and_prunes_old_ones() {
+        // Supervisor backoff policy (#567): fewer than MAX_RESTARTS deaths
+        // inside the window keeps restarting; hitting the cap gives up.
+        let t0 = Instant::now();
+        let mut times: Vec<Instant> = (0..MAX_RESTARTS - 1).map(|_| t0).collect();
+        assert!(
+            !restart_budget_exhausted(&mut times, t0),
+            "{} deaths in-window is under the cap",
+            MAX_RESTARTS - 1
+        );
+        times.push(t0);
+        assert!(
+            restart_budget_exhausted(&mut times, t0),
+            "{} deaths in-window must trip the cap",
+            MAX_RESTARTS
+        );
+
+        // Restarts older than the window are pruned and never count toward the
+        // cap, so an app left running for hours never crash-loops on stale
+        // history. (Forward Instant arithmetic — always representable.)
+        let later = t0 + RESTART_WINDOW + Duration::from_secs(1);
+        let mut aged: Vec<Instant> = (0..MAX_RESTARTS).map(|_| t0).collect();
+        assert!(
+            !restart_budget_exhausted(&mut aged, later),
+            "deaths older than the window must be pruned, not counted"
+        );
+        assert!(aged.is_empty(), "stale timestamps should have been dropped");
     }
 
     #[test]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -99,6 +99,12 @@ async function readError(res: Response): Promise<string> {
   }
 }
 
+// Backoff (ms) for retrying a *transport-level* failure — the backend briefly
+// down while the auto-restart supervisor brings it back (#567/#570/#571). One
+// short cascade (~2.9 s total) so a restart window becomes invisible, yet a
+// genuinely-down backend still surfaces the actionable error promptly.
+const TRANSPORT_RETRY_BACKOFF_MS = [400, 900, 1600];
+
 export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Response> {
   const pin = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('ov_pin') : null;
   const key = _apiKey();
@@ -111,30 +117,44 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
   const finalOpts: RequestInit = Object.keys(extra).length
     ? { ...opts, headers: { ...(opts.headers as Record<string, string> || {}), ...extra } }
     : opts;
-  let res: Response;
-  try {
-    res = await fetch(apiUrl(path), finalOpts);
-  } catch (e) {
-    // A thrown fetch (TypeError "Failed to fetch" / "NetworkError") means the
-    // request never reached the backend — it's still starting up, crashed, or
-    // the dev server dropped. Surface that as an actionable ApiError instead of
-    // the raw browser string (issues #438/#454/#466). status:0 lets callers
-    // distinguish a transport failure from an HTTP error.
-    throw new ApiError(
-      "Can't reach the local OmniVoice backend — it may still be starting up, or it stopped. " +
-      "Wait a few seconds and try again; if it persists, restart the app (or check Settings → Logs → Backend).",
-      { status: 0, detail: String((e as Error)?.message || e) },
-    );
-  }
-  if (!res.ok) {
-    // 401 from the LAN PIN middleware on a remote device → surface the gate.
-    if (res.status === 401 && typeof window !== 'undefined') {
-      window.dispatchEvent(new Event('ov:pin-required'));
+  const signal = finalOpts.signal as AbortSignal | null | undefined;
+  let lastDetail = '';
+  for (let attempt = 0; ; attempt++) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    let res: Response;
+    try {
+      res = await fetch(apiUrl(path), finalOpts);
+    } catch (e) {
+      // A thrown fetch (TypeError "Failed to fetch" / "NetworkError") means the
+      // request never reached the backend — it's still starting up, crashed, or
+      // the dev server dropped. The auto-restart supervisor revives it within a
+      // few seconds, so retry a bounded few times with backoff before surfacing
+      // the actionable ApiError, making a brief restart window invisible
+      // (issues #438/#454/#466/#567). Never retry a deliberate abort. status:0
+      // lets callers distinguish a transport failure from an HTTP error.
+      if (signal?.aborted || (e as Error)?.name === 'AbortError') throw e;
+      lastDetail = String((e as Error)?.message || e);
+      if (attempt < TRANSPORT_RETRY_BACKOFF_MS.length) {
+        await new Promise((r) => setTimeout(r, TRANSPORT_RETRY_BACKOFF_MS[attempt]));
+        continue;
+      }
+      throw new ApiError(
+        "Can't reach the local OmniVoice backend — it may still be starting up, or it stopped. " +
+        "Wait a few seconds and try again; if it persists, restart the app (or check Settings → Logs → Backend).",
+        { status: 0, detail: lastDetail },
+      );
     }
-    const detail = await readError(res);
-    throw new ApiError(`${res.status} ${res.statusText}: ${detail}`, { status: res.status, detail });
+    if (!res.ok) {
+      // 401 from the LAN PIN middleware on a remote device → surface the gate.
+      // An HTTP error means the backend *did* respond — never retry it.
+      if (res.status === 401 && typeof window !== 'undefined') {
+        window.dispatchEvent(new Event('ov:pin-required'));
+      }
+      const detail = await readError(res);
+      throw new ApiError(`${res.status} ${res.statusText}: ${detail}`, { status: res.status, detail });
+    }
+    return res;
   }
-  return res;
 }
 
 export async function apiJson<T = unknown>(path: string, opts: RequestInit = {}): Promise<T> {

--- a/frontend/src/test/client.retry.test.ts
+++ b/frontend/src/test/client.retry.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { apiFetch, ApiError } from '../api/client';
+
+// #567/#570/#571: when the backend dies mid-session, the auto-restart
+// supervisor revives it within a few seconds. apiFetch must ride out that
+// brief window by retrying a *transport* failure (a thrown fetch) a bounded
+// few times — but never retry an HTTP error (the backend responded) or a
+// deliberate abort, and still surface the actionable error if it stays down.
+describe('apiFetch transport-retry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('retries a transient transport failure, then succeeds', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p = apiFetch('/health');
+    await vi.advanceTimersByTimeAsync(500); // first backoff is 400ms
+    const res = await p;
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry an HTTP error response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('nope', { status: 500, statusText: 'Server Error' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(apiFetch('/x')).rejects.toBeInstanceOf(ApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call fetch once the signal is already aborted', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+    const ac = new AbortController();
+    ac.abort();
+
+    await expect(apiFetch('/x', { signal: ac.signal })).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('gives up after the bounded retries with a status:0 ApiError', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p = apiFetch('/x');
+    const assertion = expect(p).rejects.toMatchObject({ status: 0 });
+    await vi.advanceTimersByTimeAsync(400 + 900 + 1600 + 100);
+    await assertion;
+    // initial attempt + 3 bounded retries
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## What & why

The **"Can't reach the local OmniVoice backend"** cluster (#567, #570, #571 — three Windows reports right after v0.3.7) is **not a v0.3.7 regression**. It's a long-standing supervision gap (dates to v0.3.0/#38): the backend was spawned **once** and never watched again — `spawn_backend_and_wait` returned the instant it was healthy. When uvicorn then died mid-session (a CUDA OOM/context fault under a burst of generations — **#571's log shows the startup banner replaying 6× during a 20-generate burst** — an AV kill, any crash), nothing restarted it, so every later request threw connection-refused and the user was **stuck on the toast until a full app restart**.

## The fix (two layers, both default-mode + platform-neutral)

**1. Backend auto-restart supervisor** (`bootstrap.rs`)
- After `Ready`, the bootstrap thread (which used to just `return`) keeps watching the child and respawns it on a **confirmed process exit** (`try_wait` — never a slow health probe, so a busy-but-alive backend is never killed).
- **Bounded** to 5 restarts / 60s → then `Failed` (no fork-bomb on a deterministic crash). The #314 broken-venv self-heal stays the venv-failure path.
- **Strictly gated on `AppFlags.quitting`** — verified every quit path (`quit_app`, all tray actions) sets it before exit, so the supervisor never resurrects the backend during shutdown.
- **Single-supervisor guard** (`compare_exchange`) so concurrent `Retry` can't spawn duplicate loops.
- Emits `backend-restarting` / `backend-restored` events (the splash poll stops post-`Ready`, so the stage alone can't drive a reconnect UI).

**2. Client transport-retry** (`client.ts`)
- A **thrown** fetch (backend briefly down while it respawns) is retried a bounded few times with backoff (~2.9s total) before surfacing the actionable `ApiError` — making the restart window invisible. HTTP errors and deliberate aborts are **never** retried. Covers the `generate` path (`generateSpeech` → `apiFetch`).

Together these resolve the whole cluster **regardless of the exact crash trigger** (the keystone insight: fix *recovery*, which works for any cause).

## Tests
- **Rust**: backoff-policy unit test (cap + window-pruning).
- **Vitest** (4 cases): retry-then-succeed, no-retry-on-HTTP-error, no-retry-on-abort, bounded give-up.
- Full suites green locally: `cargo check` ✓, `cargo test` ✓, `typecheck:ci` ✓, 553 vitest tests ✓.

## Notes
- Also corrects a stale `Cargo.lock` (`omnivoice-studio` 0.3.6 → 0.3.8 — pre-existing drift cargo auto-fixes on check).
- Follow-ups in the v0.3.8 line (separate PRs): #564 `import omnivoice` health-gate, #569 torch CUDA mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Backend Auto-Restart Supervisor & Client Transport Retry

## Overview
This PR fixes a long-standing supervision gap where the backend process crashed mid-session and was never monitored or restarted. Users encountering "Can't reach the local OmniVoice backend" errors (issues `#567`, `#570`, `#571`) now benefit from two complementary recovery mechanisms:

1. **Backend auto-restart supervisor** — automatically restarts the backend upon unexpected exit
2. **Client transport-retry** — retries transient connection failures while the backend is restarting

## Backend Supervisor Flow
```
Backend Marked Ready
        ↓
[SUPERVISOR_ACTIVE guard] → only one supervisor runs
        ↓
Loop: Check process every 2 seconds
        ↓
    Is quitting? → YES → Exit supervisor
        ↓ NO
    Process dead (try_wait)? → NO → Continue loop
        ↓ YES
    Is quitting (race check)? → YES → Exit
        ↓ NO
    Restart budget exhausted? → YES → Emit "backend-restart-failed", set stage Failed
        ↓ NO
    Log warning & emit "backend-restarting"
        ↓
    Kill orphan process on port (if any)
        ↓
    Spawn backend, clear old timestamps, push new restart time
        ↓
    Wait up to 120s for backend to become healthy
        ↓
    If healthy → Emit "backend-restored", set stage Ready
    If dead again → Count restart, loop back to budget check
```

**Restart Rate Cap**: 5 restarts per 60-second window. Timestamps older than 60s are pruned automatically. Deterministic startup crashes won't fork-bomb.

## Client Retry Flow
```
apiFetch(/path, opts)
        ↓
Check: signal.aborted? → YES → Throw AbortError (no fetch)
        ↓ NO
Attempt = 0, Backoff = [400ms, 900ms, 1600ms]
        ↓
Call fetch(url, opts)
        ↓
    ┌─────── Fetch throws (e.g. connection refused) ───────┐
    │                                                        │
    │  Check: signal.aborted or is AbortError? → YES → Rethrow
    │         │ NO
    │  Attempt < 3 retries? → YES → Sleep, attempt++, retry
    │         │ NO
    │  Throw ApiError(status: 0, detail: lastError)
    │
    └─── Fetch succeeds (got Response) ─────┐
         Response.ok? → YES → Return Response
         Response.ok? → NO  → Emit 401 PIN event (if browser), throw ApiError with HTTP status
```

## Key Implementation Details

### `bootstrap.rs` (+170 lines)
- **`SUPERVISOR_ACTIVE`**: Static `AtomicBool` guard prevents duplicate supervisors (using `compare_exchange`)
- **`supervise_backend()`**: Main loop monitoring the tracked child process:
  - Polls every 2 seconds via `try_wait()` (safe check for actual exit, never kills a busy process)
  - Respawns with port-orphan cleanup before launch
  - Waits up to 120s for health probe (500ms intervals)
  - Emits `backend-restarting` (exit reason) and `backend-restored` (success) events
  - Stops immediately on `AppFlags.quitting` to avoid resurrection during shutdown
- **`restart_budget_exhausted()`**: Pure function that prunes timestamps outside `RESTART_WINDOW` and checks cap (unit-tested)
- **Constants**: `MAX_RESTARTS = 5`, `RESTART_WINDOW = 60s`
- **Error tail**: On failure, reads backend stderr tail (30 lines) and includes it in the `backend-restart-failed` event payload

### `client.ts` (+42 lines)
- **`TRANSPORT_RETRY_BACKOFF_MS = [400, 900, 1600]`**: Total ~2.9s window before surfacing error
- **Retry loop**:
  - Iterates up to 3 times on thrown `fetch` (connection refused, network errors)
  - Checks `signal.aborted` before each fetch to honor cancellations
  - **Never retries**: HTTP responses (`!res.ok`), deliberate aborts
  - Returns `ApiError` with `status: 0` on transport exhaustion (distinguishes from HTTP errors)
  - Maintains 401 PIN-gate dispatch for browser LAN-share mode

### `client.retry.test.ts` (+66 lines)
Four Vitest cases covering:
1. **Transient then succeed**: Fetch throws once, then succeeds on retry
2. **No retry on HTTP error**: 500 response returns immediately (no backoff)
3. **No retry when aborted**: Pre-aborted signal never calls fetch
4. **Bounded give-up**: After 3 retries exhausted, `status: 0` ApiError with message

## Platform & Mode
- Platform-neutral (Linux, macOS, Windows)
- Enabled in default mode (no feature flag)
- Also includes a `Cargo.lock` version correction (0.3.6 → 0.3.8)

## User Experience
- Brief backend crash (uvicorn CUDA OOM, antivirus kill, etc.) becomes invisible to the user (~3s recovery)
- UI shows `backend-restarting` banner during respawn (if dashboard listens to event)
- If restart cap exceeded, `backend-restart-failed` event + "Clean & Retry" guidance
- Transient network errors during respawn are automatically masked

<!-- end of auto-generated comment: release notes by coderabbit.ai -->