### PR TITLE
fix(backend): import omnivoice from source when the editable install is missing (#564)

### DIFF
--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -89,6 +89,12 @@ def classify(reason: str) -> str:
     # the Rust self-heal rebuilds it; this names the class for the toast.
     if "no module named 'encodings'" in low:
         return "BROKEN_VENV"
+    # #564: the interpreter starts fine but the backend can't import its OWN
+    # `omnivoice` package (a venv missing the editable install). Same self-heal
+    # class — Clean & Retry / the bootstrap repair rebuilds it. The trailing
+    # quote keeps a legitimately-named `omnivoice_*` helper from matching.
+    if "no module named 'omnivoice'" in low:
+        return "BROKEN_VENV"
     return ""
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,25 @@ _backend_dir = os.path.dirname(os.path.abspath(__file__))
 if _backend_dir not in sys.path:
     sys.path.insert(0, _backend_dir)
 
+# #564: also make the project's OWN `omnivoice` package importable from source.
+# It's normally an editable install, but an interrupted/offline `uv sync` that
+# installed deps but never laid the editable record, an antivirus-quarantined
+# `_editable_impl_omnivoice.pth`, or an upgrade where only the lock-gated drift
+# sync ran can leave that record missing — the backend then boots fine and only
+# fails at the first model call with `No module named 'omnivoice'` (the dub SSE
+# error in #564). The desktop layout always copies `omnivoice/` next to
+# `backend/`, so fall back to importing it from there. Appended (not inserted)
+# so a real site-packages/editable install keeps precedence, and it cannot
+# shadow a legitimately-different `omnivoice`; guarded on the dir existing so
+# it's a no-op in Docker (no sibling `omnivoice/`) and a harmless duplicate in
+# a dev checkout (where the editable install already resolves it).
+_project_root = os.path.dirname(_backend_dir)
+if (
+    os.path.isfile(os.path.join(_project_root, "omnivoice", "__init__.py"))
+    and _project_root not in sys.path
+):
+    sys.path.append(_project_root)
+
 # Triton is unavailable on Windows — disable torch.compile / dynamo / inductor
 # to prevent TritonMissing errors at inference time. Must be set before torch
 # is imported (it is lazily imported in services/model_manager.py). Uses

--- a/tests/test_failure_classify.py
+++ b/tests/test_failure_classify.py
@@ -63,6 +63,18 @@ def test_classify_broken_venv_encodings():
     assert failure.classify("No module named 'encodings_helper'") == ""
 
 
+def test_classify_broken_venv_missing_own_package():
+    # #564: the interpreter starts but the backend can't import its own
+    # 'omnivoice' package (editable install missing) → BROKEN_VENV so the toast
+    # points at the self-heal / Clean & Retry instead of a bare import error.
+    assert failure.classify("ModuleNotFoundError: No module named 'omnivoice'") == (
+        "BROKEN_VENV"
+    )
+    # ...but a legitimately-named 'omnivoice_*' helper package must NOT match
+    # (the trailing quote in the matcher is the guard).
+    assert failure.classify("No module named 'omnivoice_helper'") == ""
+
+
 def test_classify_generic_still_empty():
     # A genuinely unknown reason must still classify to "" (no false hint).
     assert failure.classify("some totally unrelated failure") == ""


### PR DESCRIPTION
## What & why

**#564 "No module named 'omnivoice'"** is the backend failing to import its **own** package at the first model call (the dub SSE error on `dub:upload`). `omnivoice` is an **editable install**, so any of these leaves the venv able to start uvicorn yet unable to import omnivoice:
- an interrupted/offline `uv sync` that installed deps but never laid the editable record,
- an antivirus-quarantined `_editable_impl_omnivoice.pth` (the exact class already seen for `pkg_resources` in #248),
- an upgrade where only the lock-gated #307 drift sync ran.

The backend **boots fine and only fails at runtime**, so the bootstrap health gate and the exit-based broken-venv self-heal (#314/#562) — which only see a process that *won't start* — never catch it.

## The fix (whole class, at the import layer)

`backend/main.py` now also appends the **project root** (parent of `backend/`, where the desktop layout always copies `omnivoice/`) to `sys.path`, guarded on `omnivoice/__init__.py` existing. The backend then resolves `omnivoice` **from source regardless of the editable-install state** — covering every variant above, without a repair sync.

- **Appended** (not inserted) → a real site-packages/editable install keeps precedence; can't shadow a different `omnivoice`.
- **Guarded** → no-op in Docker (no sibling `omnivoice/`), harmless duplicate in a dev checkout.

Also routes `No module named 'omnivoice'` through `failure.classify()` → `BROKEN_VENV` so if it ever still surfaces, the toast points at **Clean & Retry** instead of a bare import error.

## Tests
- `tests/test_failure_classify.py`: new case asserts the classify mapping **and its negative guard** (a legitimately-named `omnivoice_*` helper must not match — the trailing quote is the guard).
- Local: 6 classify tests pass; `main.py`/`failure.py` syntax clean. The CI **smoke-matrix** (boots the FastAPI app in-process on mac/Win/Linux) exercises that `main.py` still imports.

Part of the post-v0.3.7 reliability sweep (Rank 2). Rank 1 (supervisor, #567/#570/#571) merged in #572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

The backend fails at runtime when trying to import its own `omnivoice` package due to a missing or incomplete editable install record. This can occur when:
- An interrupted or offline `uv sync` installs dependencies but doesn't complete the editable install
- Antivirus software quarantines the `_editable_impl_omnivoice.pth` file
- An upgrade where only the lock-gated drift sync ran

Since the backend boots successfully, existing bootstrap health checks never catch this issue—it only fails at the first model call with a bare import error.

## Solution

**Two-part fix:**

### 1. Runtime Fallback (backend/main.py)
Adds a conditional fallback to make the project's own `omnivoice/` package importable directly from source:
- Checks if `omnivoice/__init__.py` exists next to the backend directory
- Appends (not inserts) the project root to `sys.path` if not already present
- Preserves precedence of a properly-installed editable install
- No-op in Docker (no sibling `omnivoice/` directory) and harmless in dev checkouts

### 2. Error Classification (backend/core/failure.py)
Routes "No module named 'omnivoice'" errors through the existing `BROKEN_VENV` taxonomy class, ensuring users see a "Clean & Retry" prompt instead of a bare import error.

## Implementation Details

The fix flow when the backend starts:

```mermaid
graph TD
    A["backend/main.py executes"] --> B{"omnivoice/__init__.py<br/>exists next to backend/?"}
    B -->|No| C["Skip sys.path modification<br/>Docker or similar setup"]
    B -->|Yes| D{"_project_root already<br/>in sys.path?"}
    D -->|Yes| E["Skip append<br/>Already installed properly"]
    D -->|No| F["Append _project_root<br/>to sys.path"]
    F --> G["omnivoice importable<br/>from source"]
    E --> G
    C --> H["Continue with existing<br/>import mechanism"]
    G --> I["Backend runs<br/>without import error"]
    H --> I
```

## Testing

New test case `test_classify_broken_venv_missing_own_package()` validates:
- `ModuleNotFoundError: No module named 'omnivoice'` correctly maps to `BROKEN_VENV`
- `omnivoice_helper` (similarly-named but legitimate) is not misclassified (returns `""`)

This prevents the fix from shadowing legitimate helper packages with similar names.

## Files Changed
- **backend/main.py**: +19 lines (sys.path fallback mechanism)
- **backend/core/failure.py**: +6 lines (error classification mapping)
- **tests/test_failure_classify.py**: +12 lines (test coverage)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->