### PR TITLE
fix(install): actionable torch-wheel-download failure + local-wheel recovery (#569)

### DIFF
--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -192,6 +192,46 @@ for the dedicated CosyVoice path.
 
 **Linked issue:** [#55](https://github.com/debpalash/OmniVoice-Studio/issues/55)
 
+## 12. CUDA PyTorch wheel download fails on first run
+
+**Symptom:** first-run setup stops at **Installing dependencies** with a failure
+that mentions `torch` and a `download.pytorch.org` (or `download-r2.pytorch.org`)
+URL — e.g. `Failed to download torch==2.8.0+cu128 …win_amd64.whl`. The app then
+won't launch.
+
+**Cause:** on Windows/Linux NVIDIA machines, OmniVoice installs the CUDA PyTorch
+build (`torch` + `torchaudio`) from PyTorch's own index. That CUDA wheel is
+large (~2.5 GB), so a flaky or restricted network drops it partway. This is a
+download/network problem, **not** a bug in OmniVoice — but the CUDA wheels come
+from a *named, explicit* index that a PyPI mirror (`UV_DEFAULT_INDEX`) cannot
+redirect, so the generic mirror trick doesn't help here.
+
+**Fix, in order:**
+
+1. **Clean & Retry.** Large downloads frequently succeed on a second attempt —
+   OmniVoice already retries each request 5× with long timeouts, and a fresh
+   attempt restarts cleanly.
+2. **Use a VPN** if your network throttles or blocks the PyTorch CDN.
+3. **Provide the wheels manually (offline path).** Download the two wheels that
+   match your machine from a source you *can* reach (the official
+   [pytorch.org](https://pytorch.org/get-started/locally/) wheel index or a
+   regional mirror), then drop them in the wheel folder and **Clean & Retry** —
+   OmniVoice will install from your local copies instead of the network:
+   - Folder: **`<env dir>/wheels`** (the exact path is printed in the error
+     message and in the setup log; `<env dir>` is your chosen install/storage
+     location).
+   - Files: the `torch` **and** `torchaudio` wheels for your exact Python/OS/CUDA
+     — e.g. `torch-2.8.0+cu128-cp311-cp311-win_amd64.whl` and the matching
+     `torchaudio-2.8.0+cu128-cp311-cp311-win_amd64.whl`. They must match the
+     pinned versions (shown in the failing URL).
+   - On retry, OmniVoice re-resolves the install using those local wheels; the
+     rest of the (small) dependencies still come from PyPI/your mirror.
+
+If you don't have an NVIDIA GPU, you don't need the CUDA build at all — a CPU /
+Apple-Silicon install skips this index entirely.
+
+**Linked issue:** [#569](https://github.com/debpalash/OmniVoice-Studio/issues/569)
+
 ## First-run setup fails on a restricted network (GitHub/PyPI blocked)
 
 On networks that block or can't resolve **GitHub**, the first-run bootstrap may

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -531,6 +531,31 @@ fn apply_uv_http_env(cmd: &mut Command) {
         .env("UV_HTTP_RETRIES", "5");
 }
 
+/// `<env_root>/wheels` — a local wheel-drop dir uv installs from via
+/// `--find-links`. When a huge wheel can't be pulled on a restricted network
+/// (the ~2.5 GB cu128 torch wheel from download.pytorch.org — #569), the user
+/// downloads the matching wheel, drops it here, and a retry picks it up.
+/// Created so the path always exists to name in the error/docs. It lives under
+/// `env_root` (not `project/`), so it survives Clean & Retry.
+fn wheels_drop_dir<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> PathBuf {
+    let dir = crate::setup::env_root(app).join("wheels");
+    let _ = fs::create_dir_all(&dir);
+    dir
+}
+
+/// True when a `uv sync` failure tail looks like the CUDA torch wheel download
+/// failing (#569). Lets us give torch-specific guidance instead of the generic
+/// "set a PyPI mirror" advice — which can't redirect the explicit, *named*
+/// pytorch-cuda index anyway (uv 0.11 rejects index-name override values, and
+/// `--frozen` pins the exact download.pytorch.org wheel URLs).
+fn sync_failure_is_torch_download(tail: &str) -> bool {
+    let low = tail.to_lowercase();
+    low.contains("download.pytorch.org")
+        || low.contains("download-r2.pytorch.org")
+        || low.contains("pytorch.org/whl")
+        || (low.contains("torch") && (low.contains("failed to download") || low.contains("failed to fetch")))
+}
+
 /// Default PyTorch ROCm wheel index for the opt-in AMD path (#124). ROCm 6.2 is
 /// the current stable wheel set; overridable via OMNIVOICE_TORCH_INDEX.
 const ROCM_TORCH_INDEX: &str = "https://download.pytorch.org/whl/rocm6.2";
@@ -1055,9 +1080,13 @@ the existing venv; newly added dependencies may be missing (#307)",
     if let Some(p) = progress {
         set_stage(p, BootstrapStage::InstallingDeps);
     }
+    let wheels_dir = wheels_drop_dir(app);
     let mut sync_cmd = Command::new(&uv_path);
     scrub_python_env(&mut sync_cmd); // #144: don't inherit AppImage's bundled Python
     apply_uv_http_env(&mut sync_cmd);
+    // #569: let uv install from locally-dropped wheels. (--frozen ignores
+    // find-links, but the non-frozen torch-recovery retry below honors it.)
+    sync_cmd.env("UV_FIND_LINKS", &wheels_dir);
     let has_lockfile = project_dir.join("uv.lock").is_file();
     if has_lockfile {
         sync_cmd
@@ -1075,15 +1104,59 @@ the existing venv; newly added dependencies may be missing (#307)",
     } else if get_effective_region(app) == "china" {
         sync_cmd.env("UV_INDEX_URL", "https://mirrors.aliyun.com/pypi/simple/");
     }
-    let sync_status = run_streaming(app, "installing_deps", &mut sync_cmd);
-    if !matches!(sync_status, Ok(ref s) if s.success()) {
-        fail(
-            progress,
-            "Dependency install (uv sync) failed — often a network drop or a \
-partial cache. \"Clean & Retry\" rebuilds the environment from scratch. If your \
-network blocks PyPI, set UV_DEFAULT_INDEX to a mirror (see \
-docs/install/troubleshooting.md).",
-        );
+    let mut sync_ok = matches!(run_streaming(app, "installing_deps", &mut sync_cmd), Ok(ref s) if s.success());
+
+    // #569: the big cu128 torch wheel (~2.5 GB) is the most common first-run
+    // download failure on restricted networks. If the frozen sync failed on it
+    // AND the user has dropped wheels in the local drop dir, retry NON-frozen
+    // with --find-links so uv re-resolves using the local wheels (verified: a
+    // non-frozen find-links sync installs from a local wheel offline; --frozen
+    // does not). Best-effort: if it can't satisfy from the wheels, it fails
+    // identically to before and the actionable error below still fires.
+    if !sync_ok && has_lockfile {
+        let tail = crate::backend::read_error_log_tail(40);
+        let have_local_wheels = fs::read_dir(&wheels_dir)
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false);
+        if have_local_wheels && sync_failure_is_torch_download(&tail) {
+            log::warn!(
+                "Frozen sync failed on a torch download; retrying non-frozen with local wheels in {} (#569)",
+                wheels_dir.display()
+            );
+            emit_log(app, "installing_deps", "Retrying the install with the wheels you provided locally…");
+            let mut retry = Command::new(&uv_path);
+            scrub_python_env(&mut retry);
+            apply_uv_http_env(&mut retry);
+            retry.env("UV_FIND_LINKS", &wheels_dir);
+            if let Some(pypi) = custom_mirrors.pypi_index.as_deref() {
+                retry.env("UV_INDEX_URL", pypi);
+            } else if get_effective_region(app) == "china" {
+                retry.env("UV_INDEX_URL", "https://mirrors.aliyun.com/pypi/simple/");
+            }
+            retry.args(["sync", "--no-dev", "--verbose"]).current_dir(&project_dir);
+            sync_ok = matches!(run_streaming(app, "installing_deps", &mut retry), Ok(ref s) if s.success());
+        }
+    }
+
+    if !sync_ok {
+        let tail = crate::backend::read_error_log_tail(40);
+        let msg = if sync_failure_is_torch_download(&tail) {
+            format!(
+                "Couldn't download the CUDA PyTorch package (a ~2.5 GB wheel from download.pytorch.org). \
+This is almost always a dropped or restricted network, not a bug. What to try, in order: \
+(1) \"Clean & Retry\" — large downloads often succeed on a second attempt. \
+(2) Connect through a VPN if your network blocks the PyTorch CDN. \
+(3) Manually download the matching torch and torchaudio wheels (see the link in your error log / \
+pytorch.org), drop them in {}, then \"Clean & Retry\" — the install will use them locally. \
+Details: docs/install/troubleshooting.md (#569).",
+                wheels_dir.display()
+            )
+        } else {
+            "Dependency install (uv sync) failed — often a network drop or a partial cache. \
+\"Clean & Retry\" rebuilds the environment from scratch. If your network blocks PyPI, set a PyPI \
+mirror in Settings → region/mirrors (see docs/install/troubleshooting.md).".to_string()
+        };
+        fail(progress, &msg);
         return None;
     }
 
@@ -1218,6 +1291,24 @@ mod tests {
             "deaths older than the window must be pruned, not counted"
         );
         assert!(aged.is_empty(), "stale timestamps should have been dropped");
+    }
+
+    #[test]
+    fn torch_download_failure_is_detected_for_targeted_help() {
+        // #569: the cu128 torch wheel host (and a torch-named download/fetch
+        // failure) get torch-specific guidance + the local-wheel retry.
+        assert!(sync_failure_is_torch_download(
+            "× Failed to download `torch==2.8.0+cu128`\n  https://download.pytorch.org/whl/cu128/torch-2.8.0%2Bcu128-cp311-cp311-win_amd64.whl"
+        ));
+        assert!(sync_failure_is_torch_download(
+            "error sending request for url (https://download-r2.pytorch.org/whl/cu128/torch-2.8.0.whl)"
+        ));
+        assert!(sync_failure_is_torch_download("Failed to fetch torch wheel"));
+        // An unrelated PyPI failure must NOT be mistaken for the torch case.
+        assert!(!sync_failure_is_torch_download(
+            "Failed to download `numpy==2.0.0` from https://pypi.org/simple"
+        ));
+        assert!(!sync_failure_is_torch_download("some unrelated venv error"));
     }
 
     #[test]


### PR DESCRIPTION
## What & why

**#569**: on a restricted network, first-run setup fails downloading the **~2.5 GB cu128 PyTorch wheel** from `download.pytorch.org`, and the app won't launch. Two problems:
1. The error told users to *"set `UV_DEFAULT_INDEX` to a mirror"* — which **cannot** redirect torch, because torch comes from a **named, explicit** uv index. I verified in uv 0.11.14 that **both** override mechanisms fail: `--index name=url` ("index names are not supported as values") and `UV_INDEX_<NAME>_URL` (ignored), and `--frozen` pins the exact `download.pytorch.org` wheel URLs.
2. There was **no way to supply a manually-downloaded wheel**.

## The fix (verified mechanisms only)

- **Torch-aware error.** Detect a torch/pytorch-host `uv sync` failure (`sync_failure_is_torch_download`) and emit correct, ordered guidance — Clean & Retry → VPN → drop the wheel locally — instead of the wrong mirror advice.
- **Local wheel-drop recovery.** New `<env_root>/wheels` dir (survives Clean & Retry) wired via `UV_FIND_LINKS`. On a frozen-sync torch-download failure **with wheels present**, retry **non-frozen** with find-links so uv re-resolves from the local wheels.
  - **Empirically verified**: a non-frozen find-links sync installs from a local wheel **fully offline**; a `--frozen` sync **ignores** find-links (it pins the exact URL). The non-frozen retry is the *only* mechanism that can consume a dropped wheel.
  - **Best-effort & safe**: if local wheels can't satisfy, it fails identically to before and the actionable error still fires. No happy-path impact (default unset → byte-identical behavior).
- **Docs (docs-sync).** `docs/install/troubleshooting.md` → new "#12 CUDA PyTorch wheel download fails" entry.

## Deliberately NOT shipped
An **automatic mirror redirect** for the cu128 index — uv provides no working override for a named explicit index, so it couldn't be verified. Shipping an unverified auto-mechanism would risk a broken "fix"; the offline wheel path is the reliable, tested escape hatch.

## Tests
- `torch_download_failure_is_detected_for_targeted_help`: host/keyword detection + negative guard.
- Local: 14 bootstrap Rust tests pass; `cargo check` clean.

Post-v0.3.7 reliability sweep, Rank 3. (Rank 1 #572 merged; Rank 2 #573.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds first-run setup resilience for restricted networks where the ~2.5 GB CUDA PyTorch wheel cannot be downloaded from `download.pytorch.org`.

### Problem Addressed
On Windows/Linux with NVIDIA GPUs, OmniVoice first-run setup fails when downloading the CUDA PyTorch build from PyTorch's named explicit index. Previous error guidance incorrectly instructed users to "set `UV_DEFAULT_INDEX` to a mirror," but this mechanism cannot redirect wheels from named indexes (uv 0.11.14 rejects such redirects and `--frozen` pins exact PyTorch URLs).

### Solution Implemented

**Torch-Aware Error Detection & Guidance**
- Detects torch/pytorch wheel download failures by matching against `download.pytorch.org`, `download-r2.pytorch.org`, or torch-specific error patterns
- Replaces generic mirror advice with actionable three-step guidance: Clean & Retry → Try VPN → Provide wheels manually

**Local Wheel-Drop Recovery**
- Creates a persistent `<env_root>/wheels` directory (survives Clean & Retry) for manually-downloaded wheels
- Wires this directory via `UV_FIND_LINKS` environment variable
- Implements a two-stage retry mechanism:
  1. **First attempt**: frozen sync (default behavior, strict dependency pinning)
  2. **If frozen sync fails** with torch pattern detected + local wheels present: **retry with non-frozen sync** that honors find-links, allowing uv to resolve and install torch/torchaudio from locally-provided wheels

**Documentation**
- Adds troubleshooting entry `#12` explaining the CUDA PyTorch wheel download issue
- Provides the offline wheel-drop path and explains why PyPI mirrors cannot fix this named index issue

### Behavior Flow Diagram

```
First-Run Install → Set UV_FIND_LINKS to <env_root>/wheels
                            ↓
                   Run uv sync --frozen
                            ↓
                   ┌────────┴────────┐
                   ✓                  ✗ (Failed)
                   ↓                  ↓
            Continue Setup    Check Error Tail
                              ↓
                         Torch failure?  Local wheels present?
                              ↓
                         ✓    ✗
                         ↓    ↓
                  Retry with    Show generic
                  non-frozen    error message
                  + find-links
                         ↓
                    ┌────┴────┐
                    ✓         ✗
                    ↓         ↓
                Continue   Show torch-specific
                Setup      guidance with wheel
                           drop path
```

### Changes

**`docs/install/troubleshooting.md`** (+40 lines)
- Added section "12. CUDA PyTorch wheel download fails on first run"
- Explains the root cause and three-step remediation path
- Documents the wheel folder location and required files

**`frontend/src-tauri/src/bootstrap.rs`** (+100/-9 lines)
- Added `wheels_drop_dir()`: creates and returns `<env_root>/wheels` directory
- Added `sync_failure_is_torch_download()`: detects CUDA wheel failures by matching PyTorch hosts and error patterns
- Modified `ensure_venv_ready()` first-run path to:
  - Set `UV_FIND_LINKS` environment variable pointing to wheels directory
  - Implement non-frozen sync retry when frozen sync fails with torch failure pattern + local wheels present
  - Generate torch-specific error messages vs. generic dependency failures
- Added unit test `torch_download_failure_is_detected_for_targeted_help()` with positive and negative test cases
- 14 existing bootstrap Rust tests passing

### Key Design Decisions
- Does **not** implement automatic PyTorch mirror redirects because uv provides no verified working mechanism for named explicit indexes
- Offline wheel path is the reliable, tested fallback
- Non-frozen retry only executes when specific conditions are met (torch failure detected + local wheels present) to maintain strict pinning by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->