### PR TITLE
fix(dub): auto-assign per-speaker cloned voices to segments (#486)

### DIFF
--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -6,7 +6,7 @@ import {
   transcribeStreamUrl, dubImportSrt,
 } from '../api/dub';
 import { dialectMatchesLang } from '../api/dialects';
-import { segmentGenInputs } from '../utils/segments';
+import { segmentGenInputs, applySpeakerCloneDefaults } from '../utils/segments';
 import { apiPost } from '../api/client';
 import { API } from '../api/client';
 import { playPing, isTauri } from '../utils/media';
@@ -100,11 +100,14 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
       try {
         const m = JSON.parse(e.data);
         gotFinal = true;
-        setDubSegments((m.segments || []).map((s, i) => ({
+        const normalized = (m.segments || []).map((s, i) => ({
           ...s,
           id: s.id != null ? String(s.id) : String(i),
           text_original: s.text_original || s.text || '',
-        })));
+        }));
+        // #486: bind each segment to its detected speaker's clone up front, so
+        // a 2-speaker dub doesn't land every row on "Default".
+        setDubSegments(applySpeakerCloneDefaults(normalized, m.speaker_clones));
         setDubTranscript(m.full_transcript || '');
         if (m.speaker_clones && typeof m.speaker_clones === 'object') {
           setSpeakerClones(m.speaker_clones);

--- a/frontend/src/test/segments.speakerClone.test.js
+++ b/frontend/src/test/segments.speakerClone.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { applySpeakerCloneDefaults, autoProfileId } from '../utils/segments';
+
+// #486: multi-speaker dub must auto-bind each segment to its detected
+// speaker's cloned voice instead of leaving every row on "Default".
+describe('applySpeakerCloneDefaults (#486)', () => {
+  const clones = { 'Speaker 1': { duration: 4.2 }, 'Speaker 2': { duration: 3.1 } };
+
+  it('assigns the auto: clone id to segments whose speaker was cloned', () => {
+    const segs = [
+      { id: '0', speaker_id: 'Speaker 1', profile_id: '' },
+      { id: '1', speaker_id: 'Speaker 2', profile_id: '' },
+    ];
+    const out = applySpeakerCloneDefaults(segs, clones);
+    expect(out[0].profile_id).toBe('auto:speaker_1');
+    expect(out[1].profile_id).toBe('auto:speaker_2');
+    expect(autoProfileId('Speaker 2')).toBe('auto:speaker_2');
+  });
+
+  it('never clobbers a profile_id the user already chose', () => {
+    const segs = [{ id: '0', speaker_id: 'Speaker 1', profile_id: 'preset:narrator' }];
+    expect(applySpeakerCloneDefaults(segs, clones)[0].profile_id).toBe('preset:narrator');
+  });
+
+  it('leaves a segment on Default when its speaker has no clone', () => {
+    const segs = [{ id: '0', speaker_id: 'Speaker 9', profile_id: '' }];
+    expect(applySpeakerCloneDefaults(segs, clones)[0].profile_id).toBe('');
+  });
+
+  it('is a no-op when there are no clones', () => {
+    const segs = [{ id: '0', speaker_id: 'Speaker 1', profile_id: '' }];
+    expect(applySpeakerCloneDefaults(segs, {})[0].profile_id).toBe('');
+    expect(applySpeakerCloneDefaults(segs, null)).toEqual(segs);
+  });
+});

--- a/frontend/src/utils/segments.js
+++ b/frontend/src/utils/segments.js
@@ -34,3 +34,27 @@ export function segmentGenInputs(s) {
     effect_preset: s.effect_preset || undefined,
   };
 }
+
+/** The `auto:<safe>` profile id for a diarized speaker. Mirrors the backend's
+ *  clone-resolution key (`speaker_id.lower().replace(" ", "_")`) and the
+ *  Voice-dropdown option value in DubTab, so the three always agree. */
+export function autoProfileId(speakerId) {
+  return `auto:${(speakerId || '').toLowerCase().replace(/\s+/g, '_')}`;
+}
+
+/**
+ * #486: auto-assign each diarized segment to its detected speaker's cloned
+ * voice instead of leaving it on "Default". When the backend cloned a speaker
+ * from the video (`speakerClones[speaker_id]` present) and the segment has no
+ * voice chosen yet, default its `profile_id` to that speaker's `auto:` clone.
+ * The user can still override per-speaker or per-segment afterwards — we only
+ * fill an *empty* profile_id, never clobber an explicit choice.
+ */
+export function applySpeakerCloneDefaults(segments, speakerClones) {
+  const clones = (speakerClones && typeof speakerClones === 'object') ? speakerClones : {};
+  if (!Array.isArray(segments) || !Object.keys(clones).length) return segments || [];
+  return segments.map((s) => {
+    if (!s || s.profile_id || !s.speaker_id || !clones[s.speaker_id]) return s;
+    return { ...s, profile_id: autoProfileId(s.speaker_id) };
+  });
+}


### PR DESCRIPTION
## What & why

**#486** (reported on Discord with screenshots): multi-speaker dubbing diarizes the speakers and clones each from the video (the Voice dropdown shows **From Video → Speaker 1 / Speaker 2**), but **every segment was left on "Default"** — a row correctly *labelled* `Speaker 1` had its Voice column reading `Default`, so the user had to set the voice on every segment by hand.

**Root cause:** the clone→segment binding never happened. The transcribe `final` handler (`useDubWorkflow.js`) stored `speaker_clones` but set the segments without filling their `profile_id`.

## The fix

New pure helper `applySpeakerCloneDefaults(segments, speakerClones)` binds each segment to its detected speaker's clone up front:
- Sets `profile_id = autoProfileId(speaker_id)` (`auto:<safe>`) when a clone exists for that speaker.
- `autoProfileId()` mirrors **both** the backend clone-resolution key (`speaker_id.lower().replace(" ","_")`, dub_generate.py) **and** the DubTab dropdown option value (DubTab.jsx:889) — so all three agree and the auto-selected option renders correctly.
- **Only fills an empty `profile_id`** — an explicit per-speaker/per-segment choice is never clobbered.

## Tests
`segments.speakerClone.test.js` (4 cases): assign-when-cloned, never-clobber-explicit, no-clone-stays-Default, no-op-without-clones. Full vitest suite + `typecheck:ci` green.

## Scope note
The issue's **second** symptom — different speakers' turns merged onto one line — is a separate **diarization/segment-grouping** concern (speaker-turn re-split). It's tracked as a follow-up; this PR fixes the per-speaker voice assignment (the primary complaint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Multi-Speaker Dubbing Auto-Voice Assignment Fix

## Overview
This PR fixes a critical issue in multi-speaker dubbing workflows where auto-cloned speaker voices were not being assigned to their corresponding segments. When users dubbed multi-speaker videos, the system would diarize speakers and clone each one, but all segments remained set to "Default," requiring manual reassignment.

## Root Cause
The transcribe `final` handler in `useDubWorkflow.js` stored the `speaker_clones` metadata but created segments without populating their `profile_id` field.

## Solution

### New Helper Functions (`frontend/src/utils/segments.js`)
Two new exported utilities manage auto-assigned voice profiles for diarized speakers:

- **`autoProfileId(speakerId)`**: Normalizes a speaker ID into the backend-compatible `auto:<safe>` form (lowercased, whitespace collapsed to underscores). This format aligns with the backend clone-resolution key and DubTab dropdown option values.

- **`applySpeakerCloneDefaults(segments, speakerClones)`**: Binds each segment to its detected speaker's cloned voice at initialization by:
  - Setting `profile_id = autoProfileId(speaker_id)` when a clone exists for that speaker
  - Only filling empty `profile_id` values, preserving explicit per-speaker or per-segment voice selections
  - Returning an empty array when no valid clones are provided

### Integration (`frontend/src/hooks/useDubWorkflow.js`)
The transcription SSE "final" event handler now:
1. Normalizes the segment list (id, text_original, speaker_id)
2. Passes normalized segments through `applySpeakerCloneDefaults(normalized, m.speaker_clones)`
3. Stores segments with speaker-clone bindings applied upfront

### Behavior Flow

```mermaid
graph TD
    A["SSE: final Event<br/>(Transcription Complete)"] --> B["Normalize Segments<br/>(id, text_original, speaker_id)"]
    B --> C["applySpeakerCloneDefaults<br/>(segments, speaker_clones)"]
    C --> D{Clone exists for<br/>this speaker?}
    D -->|Yes & profile_id empty| E["Set profile_id =<br/>auto:speaker_id"]
    D -->|No| F["Leave profile_id empty<br/>(Default)"]
    D -->|User already chose| G["Preserve user's<br/>profile_id"]
    E --> H["Store Segments<br/>with Auto-Bindings"]
    F --> H
    G --> H
    H --> I["UI Displays Voices<br/>Pre-assigned to Speakers"]
    I --> J{User satisfied?}
    J -->|Yes| K["Ready to Generate"]
    J -->|No| L["User can override<br/>per-speaker/segment"]
    L --> K
```

## Testing
- **4 unit test cases** (`frontend/src/test/segments.speakerClone.test.js`):
  - Auto-assignment when speaker clones exist
  - Preservation of explicit user voice selections
  - Default behavior when no clone is available
  - Correct no-op operation without clones (including null clones)
- Full vitest suite and `typecheck:ci` pass successfully

## Changes Summary
| File | Changes |
|------|---------|
| `frontend/src/utils/segments.js` | +24 LOC: New `autoProfileId()` and `applySpeakerCloneDefaults()` functions |
| `frontend/src/hooks/useDubWorkflow.js` | +6/-3 LOC: Import and apply `applySpeakerCloneDefaults()` in SSE "final" handler |
| `frontend/src/test/segments.speakerClone.test.js` | +35 LOC: Four test cases validating auto-assignment behavior |

## Related Issue
A secondary concern—different speakers' turns merging onto one line—is identified as a separate diarization/segment-grouping concern and tracked as a follow-up item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->