### PR TITLE
fix(gpu): prevent the 8 GB-card OOM crash behind the "backend unreachable" wave (#567/#570/#571/#580+)

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -35,15 +35,28 @@ from core.config import IDLE_TIMEOUT_SECONDS, CPU_POOL_WORKERS
 logger = logging.getLogger("omnivoice.model")
 
 # Per-TTS-job VRAM headroom estimate. OmniVoice's forward + autoregressive
-# decode peaks around 1.6 GB on a 24 kHz 8-second utterance; we budget 2.5 GB
-# to leave room for the ASR/diarization pipelines that run concurrently in
-# the same process. Tuned empirically — bumps to 3 GB if anyone reports OOM
-# at 16 GB on a multi-segment dub.
-_GPU_VRAM_PER_JOB_GB = 2.5
+# decode peaks around 1.6 GB, but the interactive clone path co-loads WhisperX
+# large-v3 ASR (~3 GB) to transcribe the reference, so a *concurrent* clone job
+# is realistically ~5 GB. The old 2.5 GB budget over-committed: an 8 GB card
+# (~7 GB free) got 2 workers, and two concurrent clone jobs blew past VRAM into
+# a sticky CUDA "illegal memory access" that aborts the whole backend process —
+# the wave of "Can't reach the local backend" crash reports on 8 GB GPUs
+# (#567/#570/#571/#580/#582/#583/#584). Budgeting 5 GB serializes to 1 worker on
+# ≤10 GB cards (no contention → no crash) while 16/24 GB cards still parallelize.
+# Power users override with OMNIVOICE_GPU_WORKERS.
+_GPU_VRAM_PER_JOB_GB = 5.0
 _GPU_WORKER_CAP = 4
 
 _gpu_pool_singleton: "ThreadPoolExecutor | None" = None
 _cpu_pool = ThreadPoolExecutor(max_workers=CPU_POOL_WORKERS)
+
+
+def _workers_for_free_vram(free_gb: float) -> int:
+    """GPU worker count for a given free-VRAM figure: free // per-job budget,
+    floored at 1 and capped at _GPU_WORKER_CAP. Pure so the sizing policy is
+    unit-tested without a GPU (the #567 crash hinged on this returning >1 on
+    8 GB cards)."""
+    return max(1, min(_GPU_WORKER_CAP, int(free_gb // _GPU_VRAM_PER_JOB_GB)))
 
 
 def _pick_gpu_workers() -> int:
@@ -68,7 +81,7 @@ def _pick_gpu_workers() -> int:
         if hasattr(torch, "cuda") and torch.cuda.is_available():
             free_bytes, _total = torch.cuda.mem_get_info()
             free_gb = free_bytes / (1024 ** 3)
-            workers = max(1, min(_GPU_WORKER_CAP, int(free_gb // _GPU_VRAM_PER_JOB_GB)))
+            workers = _workers_for_free_vram(free_gb)
             logger.info(
                 "GPU pool sized to %d worker(s) — %.1f GB free / %.1f GB per job (cap %d)",
                 workers, free_gb, _GPU_VRAM_PER_JOB_GB, _GPU_WORKER_CAP,

--- a/tests/test_gpu_worker_sizing.py
+++ b/tests/test_gpu_worker_sizing.py
@@ -1,0 +1,43 @@
+"""GPU worker-sizing policy (#567 crash prevention).
+
+The "Can't reach the local backend" crash wave on 8 GB GPUs was an OOM/CUDA
+fault from running 2 concurrent clone jobs (TTS + co-loaded WhisperX ASR) when
+the pool was sized to >1 worker on a small card. These pin the sizing policy so
+an 8 GB card serializes to a single worker (no contention → no crash) while
+larger cards still parallelize, all without needing a GPU.
+"""
+from services.model_manager import (
+    _workers_for_free_vram,
+    _GPU_WORKER_CAP,
+    _GPU_VRAM_PER_JOB_GB,
+)
+
+
+def test_eight_gb_card_serializes_to_one_worker():
+    # An 8 GB card reports ~7 GB free when the pool is sized — must be 1 worker
+    # so two concurrent clone jobs can't blow past VRAM (#567/#570/#571/#580+).
+    assert _workers_for_free_vram(7.0) == 1
+    assert _workers_for_free_vram(6.5) == 1
+    # ≤10 GB stays single-worker under the 5 GB/job budget.
+    assert _workers_for_free_vram(9.5) == 1
+
+
+def test_larger_cards_still_parallelize():
+    assert _workers_for_free_vram(11.0) == 2   # 12 GB
+    assert _workers_for_free_vram(15.0) == 3   # 16 GB
+    assert _workers_for_free_vram(23.0) == _GPU_WORKER_CAP  # 24 GB → capped
+
+
+def test_floor_and_cap():
+    # Never zero (a tiny/!-reported free figure still gets one worker)...
+    assert _workers_for_free_vram(0.4) == 1
+    assert _workers_for_free_vram(0.0) == 1
+    # ...and never above the cap, however large the card.
+    assert _workers_for_free_vram(256.0) == _GPU_WORKER_CAP
+
+
+def test_budget_is_conservative_enough_for_the_asr_coload():
+    # Guard the constant itself: the co-loaded WhisperX large-v3 (~3 GB) plus
+    # TTS (~1.6 GB) means a concurrent clone job needs ~5 GB; a regression back
+    # toward 2.5 GB would re-enable the 2-worker-on-8 GB crash.
+    assert _GPU_VRAM_PER_JOB_GB >= 5.0


### PR DESCRIPTION
## What & why

The wave of **"Can't reach the local backend"** reports (#567, #570, #571, #580, #582, #583, #584 — all on **~8 GB NVIDIA cards**, all during **generate bursts**) is the backend **process dying**, not a transport blip.

**Root cause:** the GPU pool was sized at **2.5 GB/job**, so an 8 GB card (~7 GB free) got **2 workers**. The interactive clone path co-loads **WhisperX large-v3 ASR (~3 GB)** alongside TTS (~1.6 GB), so two concurrent clone jobs ≈ **10 GB on an 8 GB card** → a sticky CUDA *"illegal memory access"* that **aborts the whole interpreter** — uncatchable by the per-request OOM guard (which only re-raises a clean `torch.cuda.OutOfMemoryError` as HTTP 500). #571's own log shows the startup banner replaying 6× during a 20-generate burst: the process dying and relaunching.

## The fix

Budget **5 GB/job** (the real TTS+ASR concurrent footprint) instead of 2.5 GB:

| Card | free | before | after |
|------|------|--------|-------|
| 8 GB | ~7 | **2** 💥 | **1** ✅ |
| 12 GB | ~11 | 4 | 2 |
| 16 GB | ~15 | 4 | 3 |
| 24 GB | ~23 | 4 | 4 |

≤10 GB cards now **serialize to one GPU worker** — no concurrent-kernel contention, so the crash can't happen — while bigger cards still parallelize. Overridable via `OMNIVOICE_GPU_WORKERS`.

This **prevents** the crash; the auto-restart supervisor (#572) **recovers** from any other cause — defense in depth. Together they close the cluster.

## Tests
Extracted `_workers_for_free_vram()` (pure); `test_gpu_worker_sizing.py` pins **8 GB → 1 worker**, the larger-card ladder, floor/cap, and a guard on the budget constant so a regression toward 2.5 GB can't silently re-enable the crash. (Math verified locally; runs in CI on 3.11.)

> ⚠️ The fix only reaches users **once released** — every report above is on v0.3.7, which predates the supervisor *and* this fix. Cutting the next tag is the priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## GPU Worker Sizing Policy for OOM Crash Prevention

**Problem**: 8 GB NVIDIA GPUs were experiencing "Can't reach the local backend" crashes during concurrent generation bursts (e.g., clone jobs). The root cause was GPU memory overcommit: with a 2.5 GB per-job budget, an 8 GB card (≈7 GB free) would allocate 2 workers. When two concurrent clone jobs co-loaded TTS (~1.6 GB) and WhisperX ASR (~3 GB), total consumption reached ~10 GB, triggering a sticky CUDA "illegal memory access" error that crashed the entire backend process. The per-request OOM guard couldn't intercept process-level crashes.

**Solution**: Adjusted GPU memory budget from 2.5 GB to 5.0 GB per job to reflect actual concurrent TTS+ASR footprint. This serializes execution on ≤10 GB cards (eliminating concurrent kernel contention) while preserving parallelization on larger systems.

### Behavior Change

```mermaid
flowchart TD
    A["GPU Worker Pool Initialization"] --> B{"Check OMNIVOICE_GPU_WORKERS env var"}
    B -->|Set| C["Use explicit override (clamped 1..16)"]
    B -->|Not set| D["Query CUDA runtime"]
    D --> E{"CUDA/ROCm available?"}
    E -->|Yes| F["Get free VRAM"]
    F --> G["Calculate: free_gb // 5.0 GB per job"]
    G --> H["Floor at 1, cap at 4"]
    H --> I["Create ThreadPoolExecutor with N workers"]
    E -->|No| J{"MPS available?"}
    J -->|Yes| K["Use 1 worker"]
    J -->|No| L["Use 1 worker default"]
    C --> I
    K --> I
    L --> I
```

### Impact on GPU Configurations

| GPU Memory | Old Budget (2.5 GB) | New Budget (5.0 GB) | Change |
|-----------|-----------------|-----------------|--------|
| 8 GB (≈7 GB free) | 2 workers | 1 worker | **Serialized** — prevents crash |
| 12 GB (≈11 GB free) | 4 workers | 2 workers | Reduced contention |
| 16 GB (≈15 GB free) | 4 workers (capped) | 3 workers | Balanced |
| 24 GB (≈23 GB free) | 4 workers (capped) | 4 workers | Unchanged |

### Implementation Details

**`backend/services/model_manager.py`**:
- Added `_GPU_VRAM_PER_JOB_GB = 5.0` constant with comprehensive comment documenting the crash wave (`#567/`#570/#571/#580/#582/#583/#584) and co-load footprint
- Added `_GPU_WORKER_CAP = 4` to enforce maximum parallelization
- Extracted pure function `_workers_for_free_vram(free_gb: float) -> int` that deterministically calculates worker count: `max(1, min(_GPU_WORKER_CAP, int(free_gb // _GPU_VRAM_PER_JOB_GB)))`
- Updated `_pick_gpu_workers()` to call the new helper, replacing inline 2.5 GB calculation
- Added informative logging showing free VRAM, per-job budget, and worker count
- Maintains support for `OMNIVOICE_GPU_WORKERS` override and MPS/CPU fallback

**`tests/test_gpu_worker_sizing.py`** (new file):
- `test_eight_gb_card_serializes_to_one_worker()` — verifies 8 GB cards with 6.5–9.5 GB free report 1 worker
- `test_larger_cards_still_parallelize()` — confirms 12/16/24 GB cards still achieve 2/3/4 workers respectively
- `test_floor_and_cap()` — ensures floor at 1 worker (even for 0 free VRAM) and cap at 4
- `test_budget_is_conservative_enough_for_the_asr_coload()` — regression guard verifying per-job budget ≥ 5.0 GB

Power users can override sizing via `OMNIVOICE_GPU_WORKERS` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->