### PR TITLE
fix(tts): NFC-normalize text + dense-script-aware chunking (#502/#505)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -320,6 +320,15 @@ async def generate_speech(
     max_chunk_chars: int = Form(800, ge=0),
     crossfade_ms: int = Form(50, ge=0, le=1000),
 ):
+    # #502: NFC-normalize the input text so decomposed (NFD) diacritics — common
+    # in pasted Vietnamese and other Latin-with-marks text — are composed to the
+    # single codepoints the tokenizer/model expect, instead of base-letter +
+    # combining-mark sequences that render as distorted/garbled speech. NFC is a
+    # no-op for already-composed text; mirrors the duration estimator
+    # (utils/duration.py) so the estimate and the synthesis see the same text.
+    import unicodedata
+    text = unicodedata.normalize("NFC", text)
+
     # ── Engine resolution (issue #312) ──────────────────────────────────────
     # The request runs on the engine selected in Settings (POST /engines/select,
     # env var OMNIVOICE_TTS_BACKEND wins), or an explicit per-request `engine`

--- a/backend/services/chunked_tts.py
+++ b/backend/services/chunked_tts.py
@@ -42,6 +42,46 @@ _ABBREVIATIONS = frozenset({
 # [pause 300ms] markers). The splitter must never cut inside one.
 _BRACKET_TAG_RE = re.compile(r"\[[^\]]*\]")
 
+# Dense scripts (CJK ideographs, kana, Hangul) where ~1 character = 1 syllable,
+# so an N-char chunk is far more *speech* than N Latin chars. Counted by code
+# point (see _dense_char_count) so there are no literal CJK chars in source.
+def _dense_char_count(text: str) -> int:
+    """Number of CJK / kana / Hangul characters in *text* (dense scripts)."""
+    n = 0
+    for ch in text:
+        o = ord(ch)
+        if (0x3040 <= o <= 0x30FF or 0x3400 <= o <= 0x4DBF
+                or 0x4E00 <= o <= 0x9FFF or 0xAC00 <= o <= 0xD7AF
+                or 0xF900 <= o <= 0xFAFF):
+            n += 1
+    return n
+
+# A chunk that is predominantly dense-script (>= this fraction) gets the smaller
+# limit; below it, the text is mostly spaced/Latin and the full limit applies.
+_DENSE_FRACTION_THRESHOLD = 0.3
+# Speech-per-char multiplier for dense scripts vs Latin (~1 ideograph ≈ 2.5
+# Latin chars of audio). Used to scale the char limit down.
+_DENSE_SPEECH_FACTOR = 2.5
+
+
+def _effective_max_chars(text: str, max_chars: int) -> int:
+    """Scale *max_chars* down for dense-script text (#505).
+
+    Long-form (5+ min) generation degrades — repeated / skipped / mispronounced
+    words — when a single chunk's acoustic sequence gets too long. With CJK /
+    kana / Hangul, ~1 char = 1 syllable, so an 800-char chunk is ~4-5 minutes of
+    audio in one shot, well past the model's reliable range. When a chunk is
+    predominantly dense-script, cap it to ``max_chars / _DENSE_SPEECH_FACTOR``
+    (floored) so each chunk's spoken length stays bounded. Latin / spaced text
+    is unchanged. ``max_chars <= 0`` (chunking disabled) is left untouched.
+    """
+    if max_chars <= 0 or not text:
+        return max_chars
+    dense = _dense_char_count(text)
+    if dense and dense / len(text) >= _DENSE_FRACTION_THRESHOLD:
+        return max(120, min(max_chars, round(max_chars / _DENSE_SPEECH_FACTOR)))
+    return max_chars
+
 
 def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) -> List[str]:
     """Split *text* at natural boundaries into chunks of at most *max_chars*.
@@ -54,6 +94,9 @@ def split_text_into_chunks(text: str, max_chars: int = DEFAULT_MAX_CHUNK_CHARS) 
     text = text.strip()
     if not text:
         return []
+    # #505: dense-script text packs far more speech per char, so cap the chunk
+    # smaller to keep each chunk's spoken length in the model's reliable range.
+    max_chars = _effective_max_chars(text, max_chars)
     if max_chars <= 0 or len(text) <= max_chars:
         return [text]
 

--- a/tests/test_chunked_tts_dense_script.py
+++ b/tests/test_chunked_tts_dense_script.py
@@ -1,0 +1,51 @@
+"""Dense-script chunk sizing (#505).
+
+Long-form (5+ min) generation degrades (repeated/skipped/mispronounced) when a
+single chunk's acoustic sequence runs too long. CJK/kana/Hangul pack ~1 char =
+1 syllable, so an 800-char chunk is minutes of audio in one shot. The chunker
+caps dense-script chunks smaller. CJK is built from code points so the test
+file carries no literal CJK.
+"""
+from services.chunked_tts import (
+    _dense_char_count,
+    _effective_max_chars,
+    split_text_into_chunks,
+    DEFAULT_MAX_CHUNK_CHARS,
+)
+
+_CJK = "".join(chr(0x4E00 + i) for i in range(50))   # 50 CJK ideographs
+_KANA = "".join(chr(0x3042 + i) for i in range(20))  # hiragana
+_HANGUL = chr(0xAC00)
+
+
+def test_dense_char_count():
+    assert _dense_char_count(_CJK) == 50
+    assert _dense_char_count(_KANA) == 20
+    assert _dense_char_count("hi " + _HANGUL) == 1
+    assert _dense_char_count("plain english, no dense script.") == 0
+
+
+def test_effective_max_chars_shrinks_only_for_dense_text():
+    # Predominantly CJK → scaled down by the speech factor (2.5).
+    assert _effective_max_chars(_CJK, 800) == round(800 / 2.5)  # 320
+    # Mostly Latin → unchanged.
+    assert _effective_max_chars("a normal english sentence. " * 40, 800) == 800
+    # Chunking disabled (0) is left untouched.
+    assert _effective_max_chars(_CJK, 0) == 0
+    # Never collapses below the floor.
+    assert _effective_max_chars(_CJK, 100) >= 120 or _effective_max_chars(_CJK, 100) == 100
+
+
+def test_dense_text_is_split_below_the_raw_limit():
+    # 400 CJK chars: by raw count that's under the 800 default (one chunk), but
+    # the effective limit (320) forces a split — the #505 fix.
+    dense = "".join(chr(0x4E00 + (i % 100)) for i in range(400))
+    chunks = split_text_into_chunks(dense, DEFAULT_MAX_CHUNK_CHARS)
+    assert len(chunks) >= 2, "dense 400-char text must split below the raw 800 limit"
+    assert all(len(c) <= round(800 / 2.5) for c in chunks)
+
+
+def test_latin_chunking_is_unchanged():
+    # A 400-char English paragraph stays a single chunk under the 800 default.
+    latin = "This is a normal English sentence that carries on. " * 8  # ~408 chars
+    assert len(split_text_into_chunks(latin, DEFAULT_MAX_CHUNK_CHARS)) == 1


### PR DESCRIPTION
## What & why — two defensive long-form / non-Latin quality fixes

### #502 — Vietnamese clone output distorted/unintelligible
The `/generate` text path **never NFC-normalized** its input. Pasted **decomposed (NFD)** Vietnamese — a base letter + a separate combining diacritic instead of the single composed codepoint — reached the tokenizer/model as *two* characters and rendered as garbled speech. Now the endpoint NFC-normalizes the input text (a no-op for already-composed text), **mirroring the duration estimator** so the estimate and the synthesis see the same text.

### #505 — long-form (5+ min) degrades: repeated/skipped/mispronounced
The chunker split purely by **character count** (800). But CJK/kana/Hangul pack **~1 char = 1 syllable**, so an 800-char chunk is **~4–5 minutes of audio in one shot** — past the model's reliable range, exactly where it starts repeating/skipping. Now a predominantly-dense chunk is capped to `max_chars / 2.5` so each chunk's *spoken* length stays bounded; **Latin/spaced text is unchanged**. Dense-script detection is by **code point** (no literal CJK in source — the no-literal-CJK gate stays clean).

## Tests
`test_chunked_tts_dense_script.py`: `_dense_char_count`, `_effective_max_chars` (shrink-when-dense / unchanged-for-Latin / disabled-passthrough / floor), and that a 400-CJK-char string now **splits** (was one chunk) while a Latin paragraph still doesn't. All green locally.

## Note
#502's exact distortion still wants a **user sample** to fully confirm root cause; the NFC fix is correct regardless and is the approved defensive change.

Last fix in the post-v0.3.7 sweep before cutting v0.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Vietnamese Text Normalization (Issue `#502`)

The `/generate` endpoint now applies Unicode NFC (Canonical Decomposition, followed by Canonical Composition) normalization to incoming text. This ensures that decomposed diacritics (e.g., Vietnamese text with separate combining characters) are converted to composed codepoints before downstream processing, making the input consistent with duration estimation and preventing tokenizer garbling.

## Dense-Script-Aware Text Chunking (Issue `#505`)

Long-form synthesis (5+ minutes) now uses density-aware chunk sizing. CJK ideographs, kana, and Hangul pack ~1 character = 1 syllable, making an 800-character chunk represent 4–5 minutes of audio—exceeding reliable model processing. The fix detects predominantly dense-script text (≥30% CJK/kana/Hangul by code point analysis) and scales the per-chunk character limit down by 2.5× to keep acoustic sequence length bounded, while Latin and spaced text remain at the original 800-character limit.

**Mechanism flowchart:**

```mermaid
graph TD
    A["Input text"] --> B["Count dense characters<br/>CJK/kana/Hangul"]
    B --> C{"Dense fraction<br/>≥ 30%?"}
    C -->|Yes| D["Scale max_chars<br/>max_chars / 2.5<br/>floor: 120"]
    C -->|No| E["Keep max_chars<br/>unchanged"]
    D --> F["Split at natural boundaries<br/>sentence/clause/whitespace"]
    E --> F
    F --> G["Return chunks<br/>with bounded duration"]
```

## Test Coverage

New test module `tests/test_chunked_tts_dense_script.py` validates:
- Dense character counting for CJK, kana, and Hangul (returning zero for plain Latin)
- Effective max-char scaling for dense text, unchanged for Latin, and preserved for disabled chunking (max_chars ≤ 0) with a 120-character floor
- A 400-character CJK string splits across multiple chunks despite being under the raw 800-character limit
- A 400-character Latin paragraph remains a single chunk

<!-- end of auto-generated comment: release notes by coderabbit.ai -->