### PR TITLE
fix(design): heal validator-rejecting instruct on design voices (#594/#571/#596)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **Designed voices saved with a bad style no longer render wrong or crash
+  generation.** A designed voice could persist an `instruct` the engine
+  validator rejects — either the literal `"[object Object]"` from an old build,
+  or freeform prose typed into the style field — which made every generation or
+  dub that used the voice fail with `Unsupported instruct items found in …`
+  (surfacing to users as a 400/500 and, when it tore down mid-render, "Can't
+  reach the local backend"). The previous fix only *blanked* `"[object Object]"`,
+  which silently dropped the design — so an Indonesian **female** voice came out
+  **male**. Now the stored instruct is sanitized down to valid tags at every
+  seam (save, edit, and when a profile drives Generate or Dub), and when the
+  stored value is unusable the tags are **rebuilt from the design's saved
+  category picks (`vd_states`)** so the intended gender/age/pitch/accent survive.
+  A migration (0007) heals existing poisoned profiles in place — no reinstall,
+  no manual fix. (#550 #571 #594 #596)
 
 ## [0.3.7] — 2026-06-20
 

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -28,6 +28,7 @@ from services.incremental import segment_fingerprint, fit_fingerprint
 from services.fit_planner import FitParams, plan_fit
 from services.watermark import embed_watermark
 from api.routers.dub_core import _get_job, _save_job
+from omnivoice.utils.voice_design import heal_design_instruct
 
 logger = logging.getLogger("omnivoice.dub")
 
@@ -258,7 +259,11 @@ async def dub_generate(job_id: str, req: DubRequest):
                             used_seed = row["seed"]
                             
                         if not instruct_str:
-                            instruct_str = row["instruct"]
+                            try:
+                                _vd = row["vd_states"]
+                            except (KeyError, IndexError):
+                                _vd = None
+                            instruct_str = heal_design_instruct(row["instruct"], _vd)
 
                 if used_seed is not None:
                     torch.manual_seed(used_seed)

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -17,9 +17,25 @@ from core.config import OUTPUTS_DIR, VOICES_DIR
 from services.model_manager import get_model, _gpu_pool
 from services.audio_io import _safe_torchaudio_save
 from core import event_bus
+from omnivoice.utils.voice_design import heal_design_instruct
 
 router = APIRouter()
 logger = logging.getLogger("omnivoice.generate")
+
+
+def _profile_instruct(row):
+    """Validator-safe instruct for a stored profile row.
+
+    Sanitizes the persisted instruct (dropping the ``"[object Object]"``
+    sentinel / freeform prose that older builds saved) and, for a design row,
+    rebuilds the tags from ``vd_states`` when the stored value is unusable — so
+    a poisoned/legacy profile never 400-s generation (#550 #571 #594 #596).
+    """
+    try:
+        vd = row["vd_states"]
+    except (KeyError, IndexError):
+        vd = None
+    return heal_design_instruct(row["instruct"], vd)
 
 
 def _render_with_pauses(gen_span, segments, sample_rate):
@@ -410,7 +426,7 @@ async def generate_speech(
                 if not ref_text:
                     ref_text = row["ref_text"]
                 if not instruct:
-                    instruct = row["instruct"]
+                    instruct = _profile_instruct(row)
                 if used_seed is None and row["seed"] is not None:
                     used_seed = row["seed"]
             elif profile_kind == "design":
@@ -420,14 +436,14 @@ async def generate_speech(
                 if ref_audio_path and not ref_text and row["ref_text"]:
                     ref_text = row["ref_text"]
                 if not instruct:
-                    instruct = row["instruct"]
+                    instruct = _profile_instruct(row)
                 if used_seed is None and row["seed"] is not None:
                     used_seed = row["seed"]
             elif row["instruct"] and not row["is_locked"] and not row["ref_audio_path"]:
                 # Legacy design-shaped row (pre-0004 archetype materialization
                 # failure path): instruct-only conditioning.
                 if not instruct:
-                    instruct = row["instruct"]
+                    instruct = _profile_instruct(row)
                 if used_seed is None and row["seed"] is not None:
                     used_seed = row["seed"]
             else:

--- a/backend/api/routers/profiles.py
+++ b/backend/api/routers/profiles.py
@@ -12,6 +12,7 @@ from core.db import db_conn
 from core.config import VOICES_DIR, OUTPUTS_DIR
 from core import event_bus
 from core.personalities import get_personalities
+from omnivoice.utils.voice_design import heal_design_instruct, sanitize_instruct
 
 router = APIRouter()
 
@@ -76,6 +77,13 @@ async def create_profile(
         # instruct — that's still a valid, saveable voice: synthesis falls back
         # to neutral instruct-only conditioning (see generation.py design path).
         # Don't gate save on a non-empty instruct.
+        #
+        # Defence-in-depth against the "[object Object]" / freeform-prose poison
+        # (#550 #571 #594 #596): never persist an instruct the engine validator
+        # would reject. Sanitize the submitted instruct and, if it's unusable,
+        # rebuild the tags from vd_states — so the row is always generation-safe
+        # regardless of which frontend build saved it.
+        instruct = heal_design_instruct(instruct, parsed)
 
     profile_id = str(uuid.uuid4())[:8]
 
@@ -167,6 +175,10 @@ def update_profile(profile_id: str, patch: ProfileUpdate):
             continue
         if col == "name" and not val.strip():
             raise HTTPException(status_code=400, detail="A voice profile needs a name.")
+        if col == "instruct":
+            # Never let an edit persist a validator-rejecting instruct (prose /
+            # "[object Object]"); keep only whitelist tags (#550 #571 #594 #596).
+            val = sanitize_instruct(val)
         fields.append(f"{col} = ?")
         params.append(val.strip() if col in ("name", "language") else val)
     if not fields:

--- a/backend/migrations/versions/0007_rebuild_poisoned_design_instruct.py
+++ b/backend/migrations/versions/0007_rebuild_poisoned_design_instruct.py
@@ -1,0 +1,118 @@
+"""Rebuild design-profile instructs poisoned with prose / "[object Object]".
+
+Revision ID: 0007_rebuild_poisoned_design_instruct
+Revises: 0006_strip_object_object_instruct
+Create Date: 2026-06-22 00:00:00.000000
+
+Migration 0006 *blanked* the literal ``"[object Object]"`` sentinel. That stops
+the 400 on use, but it also throws away the designed voice: a row that read
+``"[object Object]"`` (or freeform prose like "A gentle, quiet male voice…")
+becomes ``instruct=''`` and then renders with the engine's neutral default —
+which is why an Indonesian *female* designed voice came out *male* (#594), and
+why prose-poisoned designs still 400 (#571 #596).
+
+This migration heals it properly: for every design profile it recomputes a
+validator-safe instruct, preferring any whitelist tags already in the stored
+value and otherwise rebuilding the tags from ``vd_states`` (the authoritative
+category→pick map the Voice Design picker persists). Non-design rows simply get
+their instruct sanitized (poison dropped). Idempotent — a healthy row is left
+byte-for-byte unchanged, so re-running is a no-op.
+
+Self-contained by design: alembic migrations must not import evolving app code
+(``omnivoice`` would also drag in torch at startup), so the tag whitelist is a
+frozen snapshot of ``omnivoice.utils.voice_design._INSTRUCT_ALL_VALID``.
+``tests/test_migration_0007_instruct_rebuild.py`` asserts the snapshot stays in
+sync with the canonical set.
+"""
+import json
+import re
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect
+
+revision: str = "0007_rebuild_poisoned_design_instruct"
+down_revision: Union[str, None] = "0006_strip_object_object_instruct"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Frozen snapshot of the design-instruct whitelist + mutually-exclusive
+# categories (omnivoice/utils/voice_design.py). Kept self-contained so the
+# migration's behaviour is pinned to the data it heals, not to future vocab
+# edits. Parity is guarded by the migration test.
+_CATEGORIES = [
+    {"male", "女", "female", "男"},
+    {"child", "teenager", "young adult", "middle-aged", "elderly",
+     "儿童", "少年", "青年", "中年", "老年"},
+    {"very low pitch", "low pitch", "moderate pitch", "high pitch", "very high pitch",
+     "极低音调", "低音调", "中音调", "高音调", "极高音调"},
+    {"whisper", "耳语"},
+    {"american accent", "british accent", "australian accent", "chinese accent",
+     "canadian accent", "indian accent", "korean accent", "portuguese accent",
+     "russian accent", "japanese accent"},
+    {"河南话", "陕西话", "四川话", "贵州话", "云南话", "桂林话",
+     "济南话", "石家庄话", "甘肃话", "宁夏话", "青岛话", "东北话"},
+]
+_ALL_VALID = set().union(*_CATEGORIES)
+
+
+def _valid_from_items(items) -> str:
+    """One whitelist tag per category, first-seen order; everything else dropped."""
+    seen = set()
+    out = []
+    for raw in items:
+        tag = str(raw if raw is not None else "").strip().lower()
+        if not tag or tag not in _ALL_VALID:
+            continue
+        ci = next((i for i, c in enumerate(_CATEGORIES) if tag in c), -1)
+        if ci in seen:
+            continue
+        seen.add(ci)
+        out.append(tag)
+    return ", ".join(out)
+
+
+def _heal(instruct, vd_states, is_design) -> str:
+    healed = _valid_from_items(re.split(r"\s*[,，]\s*", str(instruct or "").strip()))
+    if healed or not is_design:
+        return healed
+    # Stored instruct was all-poison — recover the design from vd_states.
+    if not vd_states:
+        return ""
+    try:
+        vd = json.loads(vd_states)
+    except (ValueError, TypeError):
+        return ""
+    return _valid_from_items(vd.values()) if isinstance(vd, dict) else ""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "voice_profiles" not in insp.get_table_names():
+        return
+    cols = {c["name"] for c in insp.get_columns("voice_profiles")}
+    has_kind = "kind" in cols
+    has_vd = "vd_states" in cols
+
+    select = "SELECT id, instruct"
+    select += ", kind" if has_kind else ""
+    select += ", vd_states" if has_vd else ""
+    select += " FROM voice_profiles"
+
+    for row in bind.exec_driver_sql(select).mappings().all():
+        instruct = row["instruct"] or ""
+        is_design = (row["kind"] == "design") if has_kind else bool(instruct)
+        vd = row["vd_states"] if has_vd else None
+        healed = _heal(instruct, vd, is_design)
+        if healed != instruct:
+            bind.exec_driver_sql(
+                "UPDATE voice_profiles SET instruct = ? WHERE id = ?",
+                (healed, row["id"]),
+            )
+
+
+def downgrade() -> None:
+    # Irreversible heal — the original poisoned value isn't worth restoring.
+    pass

--- a/omnivoice/utils/voice_design.py
+++ b/omnivoice/utils/voice_design.py
@@ -64,3 +64,87 @@ _INSTRUCT_ALL_VALID = (
 
 _INSTRUCT_VALID_EN = frozenset(i for i in _INSTRUCT_ALL_VALID if not _ZH_RE.search(i))
 _INSTRUCT_VALID_ZH = frozenset(i for i in _INSTRUCT_ALL_VALID if _ZH_RE.search(i))
+
+
+def _instruct_category_index(tag):
+    """Index of the mutually-exclusive category ``tag`` belongs to, else -1."""
+    for i, cat in enumerate(_INSTRUCT_MUTUALLY_EXCLUSIVE):
+        if tag in cat:
+            return i
+    return -1
+
+
+def _valid_instruct_from_items(items):
+    """Keep only known design tags, one per category, in first-seen order.
+
+    Drops the ``"[object Object]"`` sentinel, freeform prose, ``"Auto"``, and any
+    token outside the whitelist. Lowercases and de-duplicates by category so a
+    pair like ``male, female`` collapses to the first pick. Returns ``""`` when
+    nothing valid remains.
+    """
+    seen = set()
+    out = []
+    for raw in items:
+        tag = str(raw if raw is not None else "").strip().lower()
+        if not tag or tag not in _INSTRUCT_ALL_VALID:
+            continue
+        ci = _instruct_category_index(tag)
+        if ci in seen:
+            continue
+        seen.add(ci)
+        out.append(tag)
+    return ", ".join(out)
+
+
+def sanitize_instruct(raw):
+    """Return a validator-safe instruct from a possibly-poisoned stored value.
+
+    Unlike :func:`_resolve_instruct` (which *raises* on unknown items so the
+    Generate tab can surface typos), this is the forgiving path for *stored*
+    design-profile instructs: it silently drops the ``"[object Object]"``
+    sentinel and freeform prose, keeping only whitelist tags. This stops a
+    poisoned/legacy profile from 400-ing every generation that uses it
+    (#550 #571 #594 #596).
+    """
+    if not raw:
+        return ""
+    return _valid_instruct_from_items(re.split(r"\s*[,，]\s*", str(raw).strip()))
+
+
+def instruct_from_vd_states(vd_states):
+    """Rebuild a validator-safe instruct from a design profile's ``vd_states``.
+
+    ``vd_states`` is the authoritative category→pick map the Voice Design picker
+    persists (``"Auto"`` means a category was left unset). It's the source of
+    truth used to *recover* a designed voice's tags when the stored instruct was
+    poisoned (object-coerced or replaced by prose) — so the designed gender/age/
+    pitch/accent survive instead of silently defaulting (#594).
+
+    Accepts a dict or a JSON string. Returns ``""`` when unparseable/empty.
+    """
+    if not vd_states:
+        return ""
+    if isinstance(vd_states, str):
+        import json
+        try:
+            vd_states = json.loads(vd_states)
+        except (ValueError, TypeError):
+            return ""
+    if not isinstance(vd_states, dict):
+        return ""
+    return _valid_instruct_from_items(vd_states.values())
+
+
+def heal_design_instruct(instruct, vd_states=None):
+    """Best-effort validator-safe instruct for a stored profile.
+
+    Prefers the sanitized stored value (so any hand-typed valid tags survive);
+    falls back to rebuilding from ``vd_states`` when the stored value sanitizes
+    to nothing — the #594 case where ``"[object Object]"`` (or prose) must still
+    yield the designed attributes, not a silent default. A clone profile (no
+    ``vd_states``) simply gets its instruct sanitized.
+    """
+    healed = sanitize_instruct(instruct)
+    if healed:
+        return healed
+    return instruct_from_vd_states(vd_states)

--- a/tests/test_migration_0007_instruct_rebuild.py
+++ b/tests/test_migration_0007_instruct_rebuild.py
@@ -1,0 +1,111 @@
+"""Migration 0007 rebuilds design-profile instructs that 0006 only blanked.
+
+0006 clears the literal "[object Object]" sentinel (losing the designed voice);
+0007 recovers the tags from vd_states so a designed female voice stays female
+(#594) and prose-poisoned designs (#571 #596) stop 400-ing. Drives the real
+alembic chain on a temp SQLite DB, mirroring tests/test_migration_0006_instruct.py.
+"""
+import importlib.util
+import os
+import sqlite3
+
+# Pre-0003 voice_profiles shape the alembic chain upgrades (matches the 0006 test).
+_BASE_PROFILES = """
+    CREATE TABLE voice_profiles (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        ref_audio_path TEXT,
+        ref_text TEXT DEFAULT '',
+        instruct TEXT DEFAULT '',
+        language TEXT DEFAULT 'Auto',
+        locked_audio_path TEXT DEFAULT '',
+        seed INTEGER DEFAULT NULL,
+        is_locked INTEGER DEFAULT 0,
+        personality TEXT DEFAULT '',
+        description TEXT DEFAULT '',
+        is_demo INTEGER DEFAULT 0,
+        created_at REAL
+    );
+"""
+
+
+def _repo_root() -> str:
+    root = os.path.abspath(os.path.dirname(__file__))
+    while root and root != "/" and not os.path.isfile(os.path.join(root, "alembic.ini")):
+        root = os.path.dirname(root)
+    assert os.path.isfile(os.path.join(root, "alembic.ini")), "alembic.ini not found"
+    return root
+
+
+def _run_alembic_upgrade(db_path: str, target: str = "head") -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config(os.path.join(_repo_root(), "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    command.upgrade(cfg, target)
+
+
+def _load_migration_module():
+    path = os.path.join(
+        _repo_root(), "backend", "migrations", "versions",
+        "0007_rebuild_poisoned_design_instruct.py",
+    )
+    spec = importlib.util.spec_from_file_location("_mig0007", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_frozen_whitelist_matches_canonical():
+    """The migration's self-contained tag snapshot must not drift from the
+    canonical whitelist — else it would heal against a stale vocabulary."""
+    from omnivoice.utils.voice_design import _INSTRUCT_ALL_VALID
+
+    mod = _load_migration_module()
+    assert mod._ALL_VALID == set(_INSTRUCT_ALL_VALID)
+
+
+def test_migration_0007_rebuilds_and_sanitizes(tmp_path):
+    db = tmp_path / "poisoned.db"
+    with sqlite3.connect(str(db)) as conn:
+        conn.executescript(_BASE_PROFILES)
+    conn.close()
+
+    # Bring the schema up to where kind + vd_states exist, then seed rows.
+    _run_alembic_upgrade(str(db), target="0005_unified_profiles")
+
+    with sqlite3.connect(str(db)) as conn:
+        rows = [
+            # design, object-coerced: 0006 blanks it, 0007 rebuilds from vd_states.
+            ("d-obj", "Obj", "design", "[object Object]",
+             '{"gender":"female","age":"young adult","pitch":"high pitch"}'),
+            # design, prose-poisoned (#596): 0006 leaves it, 0007 rebuilds.
+            ("d-prose", "Prose", "design", "A gentle, quiet, and calm male voice",
+             '{"gender":"female"}'),
+            # design, already healthy: must be left untouched.
+            ("d-ok", "Ok", "design", "female, high pitch",
+             '{"gender":"female","pitch":"high pitch"}'),
+            # clone, poisoned, no vd_states: sanitized to '' (no rebuild source).
+            ("c-bad", "CloneBad", "clone", "[object Object]", None),
+        ]
+        conn.executemany(
+            "INSERT INTO voice_profiles(id, name, kind, instruct, vd_states) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+    conn.close()
+
+    _run_alembic_upgrade(str(db), target="head")
+
+    with sqlite3.connect(str(db)) as conn:
+        got = dict(conn.execute("SELECT id, instruct FROM voice_profiles").fetchall())
+    conn.close()
+
+    assert got["d-obj"] == "female, young adult, high pitch", \
+        "0007 must recover the designed tags from vd_states after 0006 blanks the sentinel"
+    assert got["d-prose"] == "female", \
+        "prose poison must be dropped and the design recovered from vd_states (no 'male' leak)"
+    assert got["d-ok"] == "female, high pitch", "healthy instruct must be untouched"
+    assert got["c-bad"] == "", "clone poison sanitizes to empty (no vd_states to rebuild from)"

--- a/tests/test_no_hardcoded_cjk.py
+++ b/tests/test_no_hardcoded_cjk.py
@@ -69,6 +69,7 @@ _ALLOWED_FILES = {
     "omnivoice/models/omnivoice.py",              # instruct-mode vocabulary
     "omnivoice/utils/duration.py",
     "omnivoice/utils/voice_design.py",            # EN/CJK attribute maps
+    "backend/migrations/versions/0007_rebuild_poisoned_design_instruct.py",  # frozen CJK dialect-tag snapshot for the instruct heal (#564)
     # Localized error matching (classify OS errors reported in Chinese, #72)
     "frontend/src/utils/errorDocsMap.ts",
     # WER evaluation data

--- a/tests/test_profile_unification.py
+++ b/tests/test_profile_unification.py
@@ -71,20 +71,51 @@ def test_design_requires_vd_states(app_client):
 
 
 def test_design_saveable_without_instruct(app_client, fake_render):
-    """An all-Auto design (empty instruct) is a valid, saveable voice (#476).
+    """An all-Auto design (no picks → empty instruct) is still saveable (#476).
 
     Saving must not gate on a non-empty instruct — synthesis falls back to
     neutral instruct-only conditioning.
     """
     client, _ = app_client
+    all_auto = {"Gender": "Auto", "Age": "Auto", "Pitch": "Auto"}
     r = client.post(
         "/profiles",
-        data={"name": "AllAuto", "kind": "design", "vd_states": json.dumps(_VD)},
+        data={"name": "AllAuto", "kind": "design", "vd_states": json.dumps(all_auto)},
     )
     assert r.status_code == 200, r.text
     profile = client.get(f"/profiles/{r.json()['id']}").json()
     assert profile["kind"] == "design"
     assert (profile["instruct"] or "") == ""
+
+
+def test_design_derives_instruct_from_picks_when_unset(app_client, fake_render):
+    """A design saved with category picks but no explicit instruct must persist
+    a matching instruct derived from vd_states — otherwise the designed voice
+    renders neutral/wrong-gender (#594). Guards the save-time heal."""
+    client, _ = app_client
+    r = client.post(
+        "/profiles",
+        data={"name": "Designed", "kind": "design", "vd_states": json.dumps(_VD)},
+    )
+    assert r.status_code == 200, r.text
+    profile = client.get(f"/profiles/{r.json()['id']}").json()
+    assert profile["instruct"] == "female, young adult, high pitch"
+
+
+def test_design_save_drops_object_object_instruct(app_client, fake_render):
+    """The "[object Object]" poison can never be persisted — it's sanitized and
+    the design is rebuilt from vd_states at save time (#550 #571 #594)."""
+    client, _ = app_client
+    r = client.post(
+        "/profiles",
+        data={
+            "name": "Poisoned", "kind": "design",
+            "vd_states": json.dumps(_VD), "instruct": "[object Object]",
+        },
+    )
+    assert r.status_code == 200, r.text
+    profile = client.get(f"/profiles/{r.json()['id']}").json()
+    assert profile["instruct"] == "female, young adult, high pitch"
 
 
 def test_design_rejects_malformed_vd_states(app_client):

--- a/tests/test_voice_design_instruct_heal.py
+++ b/tests/test_voice_design_instruct_heal.py
@@ -1,0 +1,95 @@
+"""Unit tests for the design-instruct sanitizer/healer (#550 #571 #594 #596).
+
+These guard the forgiving path used for *stored* design-profile instructs:
+unlike ``_resolve_instruct`` (which raises so the Generate tab can flag typos),
+``sanitize_instruct`` / ``heal_design_instruct`` must never raise and must
+strip poison ("[object Object]", freeform prose) down to whitelist tags,
+recovering a design from ``vd_states`` when the stored value is unusable.
+"""
+import json
+
+import pytest
+
+from omnivoice.utils.voice_design import (
+    sanitize_instruct,
+    instruct_from_vd_states,
+    heal_design_instruct,
+)
+
+
+def test_sanitize_drops_object_object_sentinel():
+    assert sanitize_instruct("[object Object]") == ""
+
+
+def test_sanitize_drops_freeform_prose():
+    prose = "A gentle, quiet, and calm male voice is suitable for podcast content"
+    # Comma-split phrases are never standalone whitelist tags, so the whole
+    # prose is dropped — crucially, the "male" buried in a phrase does NOT leak
+    # as a gender tag (that's what makes #594's female recover correctly).
+    assert sanitize_instruct(prose) == ""
+
+
+def test_sanitize_extracts_only_standalone_tags_from_mixed_input():
+    # A real standalone tag among prose items survives; the prose item doesn't.
+    assert sanitize_instruct("female, calm soothing narrator, high pitch") == (
+        "female, high pitch"
+    )
+
+
+def test_sanitize_keeps_valid_tags_unchanged():
+    assert sanitize_instruct("female, high pitch, british accent") == (
+        "female, high pitch, british accent"
+    )
+
+
+def test_sanitize_dedupes_by_category():
+    # male+female are the same (gender) category — first wins.
+    assert sanitize_instruct("male, female") == "male"
+    assert sanitize_instruct("high pitch, low pitch") == "high pitch"
+
+
+def test_sanitize_normalises_case_and_blank_items():
+    assert sanitize_instruct("  FEMALE , , british accent ") == "female, british accent"
+
+
+@pytest.mark.parametrize("bad", [None, "", "   ", "[object Object]"])
+def test_sanitize_handles_empty_and_poison(bad):
+    assert sanitize_instruct(bad) == ""
+
+
+def test_instruct_from_vd_states_dict_drops_auto():
+    vd = {"gender": "female", "age": "Auto", "pitch": "high pitch", "accent": "british accent"}
+    assert instruct_from_vd_states(vd) == "female, high pitch, british accent"
+
+
+def test_instruct_from_vd_states_json_string():
+    vd = json.dumps({"gender": "male", "pitch": "low pitch"})
+    assert instruct_from_vd_states(vd) == "male, low pitch"
+
+
+@pytest.mark.parametrize("bad", [None, "", "not json", "[1,2,3]"])
+def test_instruct_from_vd_states_unparseable(bad):
+    assert instruct_from_vd_states(bad) == ""
+
+
+def test_heal_recovers_gender_from_vd_states_when_poisoned():
+    # The #594 case: a designed FEMALE voice whose instruct got object-coerced
+    # must render female again, not the engine's male default.
+    vd = json.dumps({"gender": "female", "age": "young adult", "pitch": "high pitch"})
+    assert heal_design_instruct("[object Object]", vd) == "female, young adult, high pitch"
+
+
+def test_heal_recovers_from_vd_states_when_prose():
+    vd = json.dumps({"gender": "female"})
+    assert heal_design_instruct("A calm soothing narrator", vd) == "female"
+
+
+def test_heal_prefers_valid_stored_tags_over_vd_states():
+    # A hand-typed valid tag not present in vd_states must survive.
+    vd = json.dumps({"gender": "female"})
+    assert heal_design_instruct("male, british accent", vd) == "male, british accent"
+
+
+def test_heal_clone_profile_without_vd_states_just_sanitizes():
+    assert heal_design_instruct("[object Object]", None) == ""
+    assert heal_design_instruct("female", None) == "female"


### PR DESCRIPTION
## Problem

A designed voice could persist an `instruct` the engine validator rejects:
- the literal **`"[object Object]"`** from a pre-fix build (#550), or
- **freeform prose** typed into the style field (e.g. *"A gentle, quiet, and calm male voice…"*).

Every Generate/Dub that used the voice then failed with `Unsupported instruct items found in …` — surfacing as a 400/500 and, when it tore the worker down mid-render, as **"Can't reach the local backend."** Migration 0006 only *blanked* `"[object Object]"`, which **silently discarded the design** → an Indonesian **female** voice rendered **male** (#594).

## Fix — heal the whole class at every seam, rebuild from the source of truth

The design's saved **`vd_states`** (category picks) is authoritative. When the stored instruct is unusable, rebuild the tags from it instead of dropping them.

- **`omnivoice/utils/voice_design.py`** — `sanitize_instruct` / `instruct_from_vd_states` / `heal_design_instruct`: forgiving (never raise), strip poison/prose to whitelist tags, rebuild from `vd_states` when needed. (Distinct from `_resolve_instruct`, which still raises so the Generate tab can flag typos.)
- **Save** (`profiles.py` POST) sanitize + rebuild; **Edit** (PUT) sanitize → no poisoned instruct can be persisted again.
- **Read** (`generation.py`, `dub_generate.py`) heal whenever a profile drives synthesis → legacy poisoned rows resolve to valid tags instead of 400-ing.
- **Migration 0007** heals existing rows in place (recovers gender/age/pitch from `vd_states`); self-contained (frozen vocab snapshot) so it never drags torch into startup; supersedes 0006's blanking. Backward-compatible — no reinstall, no manual fix.

## Tests
- `test_voice_design_instruct_heal.py` — unit coverage (object/prose/dedupe/recover-from-vd_states).
- `test_migration_0007_instruct_rebuild.py` — drives the real **0006 → 0007** chain on the post-0005 schema, plus a **parity guard** so the frozen snapshot can't drift from the canonical whitelist.
- `test_profile_unification.py` — 2 new API-level guards; corrected one existing test that had encoded the #594 behaviour.

Related suite: **75 passed, 1 skipped**.

Resolves #571, #594, #596. Removes a major driver of the "Can't reach backend" reports (#567/#570/#580/#582–585/#588/#591/#592/#597) — those will be re-triaged after the executor-shutdown fix (Cluster B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### High-level summary
This PR fixes generation/dubbing failures caused by persisted, validator-incompatible `instruct` values in designed voices. It prevents invalid/sentinel `instruct` content (e.g., `"[object Object]"` and freeform prose) from being saved, and “heals” legacy/poisoned rows at read-time by rebuilding `instruct` deterministically from the voice design’s authoritative `vd_states` category picks.

### New/updated behavior
```mermaid
flowchart TD
  A[Save/Edit design profile] --> B[sanitize_instruct + instruct_from_vd_states]
  B --> C[Persist validator-safe instruct tags]

  D[Generate/Dub read paths] --> E[_profile_instruct(row)]
  E --> F[heal_design_instruct(instruct, vd_states)]
  F --> G[Use healed instruct_str for synthesis]

  H[Legacy DB rows] --> I[Migration 0007 rebuild_poisoned_design_instruct]
  I --> J[Rebuild poisoned instruct from frozen whitelist + vd_states]
  J --> K[DB rows healed to validator-safe tags]
```

### Key code changes
- **`omnivoice/utils/voice_design.py`**
  - Added `sanitize_instruct`, `instruct_from_vd_states`, and `heal_design_instruct` to:
    - drop sentinel `"[object Object]"`, freeform prose, and non-whitelisted tokens
    - normalize and dedupe tags per mutually-exclusive category
    - rebuild missing/poisoned `instruct` from `vd_states`
    - never raise on bad input (returns `""` when healing/rebuilding isn’t possible)
- **`backend/api/routers/profiles.py`**
  - On **design profile create**, derives/sanitizes `instruct` from `vd_states` before persisting.
  - On **profile update (PUT)**, sanitizes incoming `instruct` before writing.
- **`backend/api/routers/generation.py`**
  - Introduced `_profile_instruct(row)` to sanitize/heal stored profile `instruct` during `/generate` profile loading using `vd_states`.
- **`backend/api/routers/dub_generate.py`**
  - Uses `heal_design_instruct` when building `instruct_str` for dub segment TTS, preferring healed `vd_states`-derived tags when needed.
- **Migration `backend/migrations/versions/0007_rebuild_poisoned_design_instruct.py`**
  - Heals existing `voice_profiles.instruct` values in-place (superseding the 0006 failure mode where poisoned values ended up blank).
  - Uses a frozen whitelist snapshot (`_ALL_VALID`) to rebuild deterministic, validator-safe tags from `vd_states` (and is implemented as an irreversible/no-op `downgrade()`).

### Tests added/updated
- **`tests/test_voice_design_instruct_heal.py`**: unit coverage for non-raising sanitization, prose/sentinel dropping, rebuild from `vd_states`, dedupe/category rules, and `heal_design_instruct` preference/fallback behavior.
- **`tests/test_profile_unification.py`**: verifies design saves derive `instruct` from `vd_states` and drop `"[object Object]"` during persistence.
- **`tests/test_migration_0007_instruct_rebuild.py`**: migration chain integration test (0006→0007) plus a frozen-whitelist parity guard against the canonical whitelist in `omnivoice.utils.voice_design`.
- **`tests/test_no_hardcoded_cjk.py`**: allowlists the new migration file to avoid false-positive i18n hardcoding checks.

### Outcome
- Designed voice `instruct` is now validator-safe and consistently derived/healed across save/edit, generation, and dubbing.
- Legacy “poisoned” profile rows are repaired automatically (via migration and read-time healing), removing a major driver of “Unsupported instruct items found in …” and related backend reach errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Closes #571
Closes #594
Closes #596
