### PR TITLE
fix(backend): self-healing GPU pool so a reset can't strand requests (#589/#599)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **"cannot schedule new futures after shutdown" no longer breaks generate/dub
+  after a slow first load.** When a model load timed out, the backend reset its
+  GPU worker pool to recover — but several request handlers had captured the old
+  pool object at import time and kept submitting to it, so every subsequent
+  generate, dub, transcribe, or translate failed with `cannot schedule new
+  futures after shutdown` (a 500, or "Can't reach the local backend" when it
+  took the worker down). The GPU pool is now a single self-healing handle whose
+  worker pool is rebuilt on demand, so a reset can never strand an in-flight or
+  later request. No settings change; the recovery is automatic. (#589 #599)
 
 ## [0.3.7] — 2026-06-20
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -3,7 +3,7 @@ import time
 import asyncio
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, Executor
 
 # ── Lazy imports ─────────────────────────────────────────────────────
 # torch and OmniVoice are heavy (~2-3s import on Apple Silicon).
@@ -47,7 +47,7 @@ logger = logging.getLogger("omnivoice.model")
 _GPU_VRAM_PER_JOB_GB = 5.0
 _GPU_WORKER_CAP = 4
 
-_gpu_pool_singleton: "ThreadPoolExecutor | None" = None
+_gpu_pool_singleton: "_ResilientGpuPool | None" = None
 _cpu_pool = ThreadPoolExecutor(max_workers=CPU_POOL_WORKERS)
 
 
@@ -100,14 +100,82 @@ def _build_gpu_pool() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="gpu-pool")
 
 
-def _get_gpu_pool() -> ThreadPoolExecutor:
-    """Internal accessor. Same singleton as the module-level `_gpu_pool`
-    attribute, but resolvable from inside this module (Python's module
-    `__getattr__` only fires for unresolved lookups from *outside*).
+class _ResilientGpuPool(Executor):
+    """A stable, self-healing wrapper around the GPU `ThreadPoolExecutor`.
+
+    The crash this fixes (#589 #599): `_reset_gpu_pool()` shuts the pool down on
+    a model-load timeout, but consumers that captured the executor *object* at
+    import time (`from services.model_manager import _gpu_pool` at module level —
+    generation, dub_generate, dub_core, dub_translate, openai_compat) kept
+    submitting to the dead pool and got `RuntimeError: cannot schedule new
+    futures after shutdown` on the next generate/dub/translate.
+
+    Making `_gpu_pool` a single long-lived wrapper whose *inner* pool is swapped
+    means those references never go stale: every `submit()` resolves the live
+    pool, and a submit that races a shutdown rebuilds once and retries. Building
+    the inner pool stays lazy so we still size workers after torch's device
+    probe (the reason for the original `__getattr__` indirection).
+    """
+
+    def __init__(self):
+        self._pool: "ThreadPoolExecutor | None" = None
+        self._lock = threading.Lock()
+
+    def _live_pool(self) -> ThreadPoolExecutor:
+        pool = self._pool
+        if pool is None:
+            with self._lock:
+                if self._pool is None:
+                    self._pool = _build_gpu_pool()
+                pool = self._pool
+        return pool
+
+    def submit(self, fn, /, *args, **kwargs):
+        try:
+            return self._live_pool().submit(fn, *args, **kwargs)
+        except RuntimeError as e:
+            # "cannot schedule new futures after shutdown": the inner pool was
+            # reset (or torn down) under us. Rebuild once and retry so a stale
+            # caller self-heals instead of 500-ing. (Interpreter-shutdown races
+            # re-raise on the retry — we don't loop.)
+            if "shutdown" not in str(e).lower():
+                raise
+            with self._lock:
+                self._pool = _build_gpu_pool()
+                pool = self._pool
+            return pool.submit(fn, *args, **kwargs)
+
+    def reset(self) -> None:
+        """Abandon the current worker pool; the next submit builds a fresh one.
+
+        Python can't kill a thread wedged in a timed-out load, but dropping the
+        poisoned pool means a retry gets a clean worker instead of queueing
+        behind the wedged one. The wrapper identity is preserved, so references
+        held by importers stay valid.
+        """
+        with self._lock:
+            pool, self._pool = self._pool, None
+        if pool is not None:
+            try:
+                pool.shutdown(wait=False, cancel_futures=True)
+            except Exception:
+                pass
+
+    def shutdown(self, wait=True, *, cancel_futures=False):
+        with self._lock:
+            pool, self._pool = self._pool, None
+        if pool is not None:
+            pool.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+
+def _get_gpu_pool() -> "_ResilientGpuPool":
+    """Internal accessor for the GPU pool singleton. Same object as the
+    module-level `_gpu_pool` attribute, but resolvable from inside this module
+    (Python's module `__getattr__` only fires for lookups from *outside*).
     """
     global _gpu_pool_singleton
     if _gpu_pool_singleton is None:
-        _gpu_pool_singleton = _build_gpu_pool()
+        _gpu_pool_singleton = _ResilientGpuPool()
     return _gpu_pool_singleton
 
 
@@ -584,19 +652,15 @@ def _model_load_timeout() -> float:
 
 
 def _reset_gpu_pool() -> None:
-    """Drop the GPU pool singleton so the next access builds a fresh one.
+    """Recover from a wedged/timed-out load by abandoning the GPU worker pool.
 
-    Python can't kill the thread stuck in a timed-out load, but abandoning the
-    poisoned single-worker pool means a *retry* gets a clean worker instead of
-    queueing forever behind the wedged one.
+    The resilient wrapper is kept (its identity is shared by every importer);
+    only its inner `ThreadPoolExecutor` is dropped, so the next submit builds a
+    fresh worker. This is what stops stale references from raising "cannot
+    schedule new futures after shutdown" after a reset (#589 #599).
     """
-    global _gpu_pool_singleton
-    pool, _gpu_pool_singleton = _gpu_pool_singleton, None
-    if pool is not None:
-        try:
-            pool.shutdown(wait=False, cancel_futures=True)
-        except Exception:
-            pass
+    if _gpu_pool_singleton is not None:
+        _gpu_pool_singleton.reset()
 
 
 async def _load_model_with_timeout():

--- a/tests/test_gpu_pool_resilient.py
+++ b/tests/test_gpu_pool_resilient.py
@@ -1,0 +1,76 @@
+"""Regression: the GPU pool must survive a reset without breaking long-lived
+references (#589 #599 — "cannot schedule new futures after shutdown").
+
+`_reset_gpu_pool()` fires on a model-load timeout. Before the fix, consumers
+that did a *module-level* `from services.model_manager import _gpu_pool`
+(generation, dub_generate, dub_core, dub_translate, openai_compat) captured the
+ThreadPoolExecutor object once — so after a reset they kept submitting to the
+shut-down pool and every generate/dub 500'd with "cannot schedule new futures
+after shutdown". The resilient wrapper keeps a stable identity and rebuilds its
+inner pool on demand, so those references self-heal.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def mm(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+    import services.model_manager as _mm
+    # Keep the pool tiny + device-probe-free regardless of the host.
+    monkeypatch.setattr(_mm, "_pick_gpu_workers", lambda: 1)
+    # Start from a clean singleton so tests don't share a wrapper.
+    monkeypatch.setattr(_mm, "_gpu_pool_singleton", None)
+    return _mm
+
+
+def test_stale_reference_survives_reset(mm):
+    # Mimic a module-level `from services.model_manager import _gpu_pool`.
+    captured = mm._gpu_pool                      # triggers __getattr__ → wrapper
+    assert captured.submit(lambda: 7).result(timeout=5) == 7
+
+    mm._reset_gpu_pool()                          # the load-timeout recovery path
+
+    # The SAME captured reference must still work — no "cannot schedule new
+    # futures after shutdown".
+    assert captured.submit(lambda: 11).result(timeout=5) == 11
+
+
+def test_reset_keeps_wrapper_identity_drops_inner_pool(mm):
+    pool = mm._get_gpu_pool()
+    pool.submit(lambda: None).result(timeout=5)   # force-build the inner pool
+    assert pool._pool is not None
+
+    mm._reset_gpu_pool()
+    assert mm._get_gpu_pool() is pool             # stable identity
+    assert pool._pool is None                     # inner worker pool dropped
+
+    pool.submit(lambda: None).result(timeout=5)   # rebuilds transparently
+    assert pool._pool is not None
+
+
+def test_submit_after_inner_shutdown_self_heals(mm):
+    pool = mm._get_gpu_pool()
+    # Simulate the exact failure: a stale inner pool that's been shut down.
+    pool.submit(lambda: None).result(timeout=5)
+    pool._pool.shutdown(wait=True)
+    # Without the retry this raises RuntimeError("cannot schedule new futures
+    # after shutdown"); the wrapper rebuilds and succeeds.
+    assert pool.submit(lambda: 42).result(timeout=5) == 42
+
+
+def test_wrapper_usable_with_asyncio_run_in_executor(mm):
+    import asyncio
+
+    pool = mm._get_gpu_pool()
+
+    async def _go():
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(pool, lambda: 5)
+
+    assert asyncio.run(_go()) == 5

--- a/tests/test_model_load_timeout.py
+++ b/tests/test_model_load_timeout.py
@@ -57,7 +57,10 @@ def test_get_model_times_out_and_resets_pool(model_manager, monkeypatch):
         with pytest.raises(RuntimeError, match="timed out"):
             asyncio.run(mm.get_model())
         assert mm.model is None                 # no half-loaded model
-        assert mm._gpu_pool_singleton is None    # poisoned pool was dropped
+        # The resilient wrapper survives (importers hold its identity); only its
+        # inner worker pool is dropped, so a retry builds a fresh worker.
+        assert mm._gpu_pool_singleton is not None
+        assert mm._gpu_pool_singleton._pool is None
         assert not mm._model_lock.locked()       # lock released for a retry
     finally:
         release.set()  # let the orphaned worker exit immediately


### PR DESCRIPTION
## Problem

`cannot schedule new futures after shutdown` — reported on both Windows/CUDA (#589) and macOS/MPS (#599), on the first generate/dub after the app had been open a while.

When a model load times out, `_reset_gpu_pool()` recovers by shutting the GPU `ThreadPoolExecutor` down and rebuilding a fresh one on next access. But five request handlers capture the executor **object** at import time via a *module-level* `from services.model_manager import _gpu_pool`:

- `generation.py`, `dub_generate.py`, `dub_core.py`, `dub_translate.py`, `openai_compat.py`

After a reset those references point at the **dead** pool, so the next `loop.run_in_executor(_gpu_pool, …)` raises `RuntimeError: cannot schedule new futures after shutdown` — surfacing as a 500, or "Can't reach the local backend" when it tore the worker down. (Function-level imports happened to self-heal; module-level ones couldn't.)

## Fix

Make `_gpu_pool` a single long-lived **`_ResilientGpuPool`** (a `concurrent.futures.Executor`) whose **inner** `ThreadPoolExecutor` is swapped rather than the outer handle:

- every `submit()` resolves the live inner pool; a submit that races a shutdown **rebuilds once and retries**, so a stale captured reference self-heals;
- `_reset_gpu_pool()` now drops only the inner pool (fresh worker on retry) while **preserving the wrapper identity** every importer holds;
- inner-pool sizing stays lazy, so we still probe the device after torch's lazy import (the reason for the original `__getattr__` indirection).

This fixes the whole class: all importers — module-level or function-level — share one wrapper that can never go stale.

## Tests
`tests/test_gpu_pool_resilient.py` (new):
- **stale reference survives a reset** (the exact #589/#599 repro),
- wrapper identity stable across reset + inner pool dropped,
- submit after an inner-pool shutdown self-heals,
- usable with `asyncio.run_in_executor`.

Updated `test_model_load_timeout.py` to the new reset semantics (wrapper persists, inner pool dropped). Pool-related suite: **57 passed, 4 skipped**.

Resolves #589, #599. Removes the other major driver of the "Can't reach the local backend" cluster (with the design-instruct fix in #600).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a critical issue where GPU pool resets left stale references in module-level imports, causing `RuntimeError: cannot schedule new futures after shutdown` errors on Windows/CUDA and macOS/MPS after model-load timeouts during operations like dubbing, generation, transcription, and translation.

### Root Cause

When a model load timed out, `_reset_gpu_pool()` shut down the `ThreadPoolExecutor`, but several request handlers (generation, dub_generate, dub_core, dub_translate, openai_compat) had captured the executor object at module import time via `from services.model_manager import _gpu_pool`. These stale references continued submitting tasks to the dead pool, triggering shutdown errors on all subsequent requests.

### Solution

The fix replaces the direct `ThreadPoolExecutor` with a long-lived `_ResilientGpuPool` wrapper (implementing `concurrent.futures.Executor`) that maintains stable identity across resets. Instead of replacing the entire executor on reset, only the inner `ThreadPoolExecutor` is swapped. The wrapper implements self-healing logic:

- **`_live_pool()`**: Returns the inner pool, lazily building it under lock if `None`
- **`submit()`**: Calls `_live_pool().submit()` and catches `RuntimeError` from shutdown — if detected, rebuilds the inner pool once under lock and retries the submission
- **`reset()`**: Shuts down the inner pool and sets it to `None`, preserving wrapper identity so all captured references remain valid

This design allows stale references to self-heal on the next `submit()` call by automatically rebuilding the inner pool. All request handlers—whether using module-level or function-level imports—share a single resilient wrapper that cannot become stale.

### Mechanism Diagram

```
BEFORE (Direct ThreadPoolExecutor):
   Module-level import
   (generation, dub_generate, etc.)
            |
            v
   Captured Executor ref ──> submit() ──> [task queue]
            |
            └─ On timeout → reset()
                    |
                    v
            Executor.shutdown()
                    |
                    v
            ❌ Next submit() fails
            "cannot schedule new futures after shutdown"

AFTER (Resilient Wrapper):
   Module-level import
            |
            v
   Captured _ResilientGpuPool ref (stable identity)
            |
            v
       submit(fn)
            |
         [try]
            |
            v
     _live_pool() returns inner ThreadPoolExecutor
            |
            v
     inner.submit(fn)
            |
            v
     [success OR RuntimeError: "...shutdown..."]
            |
     [if shutdown error detected]
            |
            v
     [lock] Rebuild inner pool
     [retry] submit() on new inner pool
            |
            v
     ✓ Request succeeds (self-healed)

   Separately, on timeout → reset()
            |
            v
     Shutdown current inner pool & set to None
     (Wrapper identity unchanged!)
            |
            v
     ✓ Stale references survive because
       wrapper object is still the same
```

### Changes

**backend/services/model_manager.py** (+82/-18):
- New `_ResilientGpuPool` class wrapping `ThreadPoolExecutor`
- `_gpu_pool_singleton` now typed as `_ResilientGpuPool | None`
- `_get_gpu_pool()` returns the wrapper instance
- `_reset_gpu_pool()` calls `wrapper.reset()` instead of replacing the wrapper
- Lazy pool sizing maintained for device probing after torch's lazy import

**tests/test_gpu_pool_resilient.py** (+76/-0):
- New regression test module with isolated `mm` fixture
- Tests verify: (1) stale references survive reset without "cannot schedule" errors, (2) wrapper identity is preserved while inner pool drops, (3) self-healing on submit after inner-pool shutdown, (4) asyncio compatibility with `run_in_executor`

**tests/test_model_load_timeout.py** (+4/-1):
- Updated `test_get_model_times_out_and_resets_pool` expectations: wrapper persists (`_gpu_pool_singleton is not None`) while inner pool clears (`_gpu_pool_singleton._pool is None`)

**CHANGELOG.md** (+11/-1):
- Entry describing recovery from "cannot schedule new futures after shutdown" using a single self-healing GPU pool handle that rebuilds on demand, with automatic recovery and no settings changes required (references `#589`, `#599`)

### Impact

- Resolves issue `#589` (Windows/CUDA) and `#599`
- No API changes or settings required for users
- Automatic recovery on all subsequent generate/dub/transcribe/translate requests after a model-load timeout
- All request handlers now survive pool resets with transparent self-healing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Closes #589
Closes #599
