### PR TITLE
fix(bootstrap): gate venv on omnivoice import + source fallback (#564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **`No module named 'omnivoice'` on installs whose venv lost its editable
+  record.** An interrupted or offline `uv sync` (common during an in-place
+  upgrade) could install all dependencies yet never lay the editable install of
+  the project's own `omnivoice` package — or an antivirus quarantine could
+  remove it. The venv still started uvicorn, so the bootstrap's health gate
+  passed it through, and the app only failed at the first generate/dub with
+  `No module named 'omnivoice'`. The bootstrap now also verifies `omnivoice` is
+  importable (via a cheap `find_spec`, no torch load) and forces a repair
+  `uv sync` that re-lays the editable install when it isn't; the backend also
+  resolves `omnivoice` from its bundled source tree at runtime as a safety net.
+  No reinstall needed — relaunch and it self-repairs. (#564)
 
 ## [0.3.7] — 2026-06-20
 

--- a/backend/core/omnivoice_path.py
+++ b/backend/core/omnivoice_path.py
@@ -1,0 +1,77 @@
+"""Resolve the project's own ``omnivoice`` package from source when the venv's
+editable install is missing (#564).
+
+``omnivoice`` is normally an editable install in the backend venv. An interrupted
+or offline ``uv sync`` can install dependencies yet never lay the editable record
+(``_editable_impl_omnivoice.pth``), or an antivirus quarantine can remove it —
+leaving a venv that starts uvicorn but cannot ``import omnivoice``, so it boots
+fine and only fails at the first model call (``No module named 'omnivoice'``).
+
+The desktop layout always copies ``omnivoice/`` next to ``backend/``, so we fall
+back to importing it from there. The bootstrap now also gates on omnivoice being
+importable (re-syncing to re-lay the editable install), but this keeps the
+backend resilient even when that repair hasn't run yet.
+"""
+import os
+import sys
+
+
+def find_omnivoice_source_root(candidates):
+    """Return the first candidate dir holding ``omnivoice/__init__.py``, else None."""
+    for root in candidates:
+        if root and os.path.isfile(os.path.join(root, "omnivoice", "__init__.py")):
+            return root
+    return None
+
+
+def _candidate_roots(backend_dir):
+    """Source roots to probe, most-specific first.
+
+    ``OMNIVOICE_PROJECT_ROOT`` lets the launcher point at the staged project dir
+    explicitly; otherwise the desktop layout puts ``omnivoice/`` beside
+    ``backend/`` (parent of ``backend_dir``).
+    """
+    roots = []
+    env = os.environ.get("OMNIVOICE_PROJECT_ROOT")
+    if env:
+        roots.append(env)
+    roots.append(os.path.dirname(os.path.abspath(backend_dir)))
+    return roots
+
+
+def _already_importable():
+    import importlib.util
+    try:
+        return importlib.util.find_spec("omnivoice") is not None
+    except (ImportError, ValueError):
+        # A half-laid spec (e.g. a stale .pth pointing at a deleted dir) raises
+        # rather than returning None — treat it as "not importable" so we fall
+        # back to the on-disk source.
+        return False
+
+
+def ensure_omnivoice_importable(backend_dir, logger=None):
+    """Make ``import omnivoice`` work, falling back to the sibling source tree.
+
+    No-op when the editable/site-packages install already resolves it. Otherwise
+    appends the first source root containing ``omnivoice/`` to ``sys.path``
+    (appended, never inserted, so a real install keeps precedence). Returns the
+    root that was added, or ``None`` if none was needed or found.
+    """
+    if _already_importable():
+        return None
+    root = find_omnivoice_source_root(_candidate_roots(backend_dir))
+    if root and root not in sys.path:
+        sys.path.append(root)
+        if logger:
+            logger.warning(
+                "omnivoice not importable from the venv (missing/broken editable "
+                "install) — resolving it from source at %s (#564)", root,
+            )
+    elif logger and root is None:
+        logger.error(
+            "omnivoice is not importable and no source tree was found next to "
+            "%s — the install is incomplete; relaunch to let the bootstrap "
+            "repair the venv (#564)", backend_dir,
+        )
+    return root

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,24 +9,15 @@ _backend_dir = os.path.dirname(os.path.abspath(__file__))
 if _backend_dir not in sys.path:
     sys.path.insert(0, _backend_dir)
 
-# #564: also make the project's OWN `omnivoice` package importable from source.
-# It's normally an editable install, but an interrupted/offline `uv sync` that
-# installed deps but never laid the editable record, an antivirus-quarantined
-# `_editable_impl_omnivoice.pth`, or an upgrade where only the lock-gated drift
-# sync ran can leave that record missing — the backend then boots fine and only
-# fails at the first model call with `No module named 'omnivoice'` (the dub SSE
-# error in #564). The desktop layout always copies `omnivoice/` next to
-# `backend/`, so fall back to importing it from there. Appended (not inserted)
-# so a real site-packages/editable install keeps precedence, and it cannot
-# shadow a legitimately-different `omnivoice`; guarded on the dir existing so
-# it's a no-op in Docker (no sibling `omnivoice/`) and a harmless duplicate in
-# a dev checkout (where the editable install already resolves it).
-_project_root = os.path.dirname(_backend_dir)
-if (
-    os.path.isfile(os.path.join(_project_root, "omnivoice", "__init__.py"))
-    and _project_root not in sys.path
-):
-    sys.path.append(_project_root)
+# #564: also make the project's OWN `omnivoice` package importable from source
+# when the venv's editable install is missing/broken (interrupted/offline
+# `uv sync`, antivirus-quarantined `_editable_impl_omnivoice.pth`, …). Without
+# this the backend boots fine and only fails at the first model call with
+# `No module named 'omnivoice'`. The bootstrap now gates on omnivoice being
+# importable too (re-syncing to re-lay the editable install); this is the
+# runtime safety net. See core/omnivoice_path.py for the full rationale.
+from core.omnivoice_path import ensure_omnivoice_importable
+ensure_omnivoice_importable(_backend_dir)
 
 # Triton is unavailable on Windows — disable torch.compile / dynamo / inductor
 # to prevent TritonMissing errors at inference time. Must be set before torch

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -25,7 +25,16 @@ def _lazy_torch():
 def _lazy_omnivoice():
     global _OmniVoice
     if _OmniVoice is None:
-        from omnivoice.models.omnivoice import OmniVoice as _OV
+        try:
+            from omnivoice.models.omnivoice import OmniVoice as _OV
+        except ModuleNotFoundError:
+            # The venv's editable install is missing/broken (#564). main.py wires
+            # the source fallback at startup, but resolve it here too so the
+            # model-load path self-heals and logs the paths it searched.
+            from core.omnivoice_path import ensure_omnivoice_importable
+            _backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            ensure_omnivoice_importable(_backend_dir, logger)
+            from omnivoice.models.omnivoice import OmniVoice as _OV
         _OmniVoice = _OV
     return _OmniVoice
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -771,7 +771,33 @@ manually, then relaunch.",
         } else {
             false
         };
-        if matches!(uvicorn_check, Ok(ref s) if s.success()) && pkg_resources_ok {
+        // #564: a venv can pass the uvicorn + pkg_resources gates yet still be
+        // unable to import its OWN `omnivoice` package — an interrupted/offline
+        // `uv sync` installed deps but never laid the editable record, or an
+        // antivirus quarantine removed `_editable_impl_omnivoice.pth`. The
+        // backend then boots fine and only fails at the first model call with
+        // "No module named 'omnivoice'". Verify it here so we force a repair
+        // sync (which re-lays the editable install) instead of handing back a
+        // broken venv. `find_spec` resolves the package WITHOUT importing it, so
+        // this stays cheap — a real `import omnivoice` would pull in torch.
+        let omnivoice_ok = if matches!(uvicorn_check, Ok(ref s) if s.success()) {
+            let mut ov_check = Command::new(&venv_py);
+            scrub_python_env(&mut ov_check);
+            matches!(
+                ov_check
+                    .args([
+                        "-c",
+                        "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('omnivoice') else 1)",
+                    ])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status(),
+                Ok(ref s) if s.success()
+            )
+        } else {
+            false
+        };
+        if matches!(uvicorn_check, Ok(ref s) if s.success()) && pkg_resources_ok && omnivoice_ok {
             // Always sync source dirs from bundle so code fixes land on
             // existing installs without requiring a full clean+reinstall.
             let resource_dir = app.path().resource_dir().ok();
@@ -847,13 +873,17 @@ the existing venv; newly added dependencies may be missing (#307)",
             return Some((venv_py, backend_dir));
         }
         if matches!(uvicorn_check, Ok(ref s) if s.success()) {
-            // uvicorn is fine but pkg_resources is missing (#248): setuptools>=80 was
-            // installed before the <80 pin landed (issue #224). Force a repair sync
-            // to downgrade setuptools to a version that ships pkg_resources.
+            // uvicorn is fine but pkg_resources (#248) and/or the omnivoice
+            // editable install (#564) is missing. pkg_resources: setuptools>=80
+            // (installed before the <80 pin in #224) dropped the bundled module.
+            // omnivoice: an interrupted/offline sync never laid the editable
+            // record. Either way a repair `uv sync` re-pins setuptools AND
+            // re-lays the editable install, so force it rather than hand back a
+            // venv that crashes at the first model call.
             log::warn!(
-                "Venv at {} is missing pkg_resources (setuptools>=80 pre-dates the <80 pin) \
-— re-running uv sync to repair (#248)",
-                venv_dir.display()
+                "Venv at {} starts uvicorn but failed a runtime-import gate \
+(pkg_resources_ok={}, omnivoice_ok={}) — re-running uv sync to repair (#248 #564)",
+                venv_dir.display(), pkg_resources_ok, omnivoice_ok
             );
         } else {
             log::warn!(

--- a/tests/test_omnivoice_path.py
+++ b/tests/test_omnivoice_path.py
@@ -1,0 +1,81 @@
+"""Regression: the backend must resolve its own `omnivoice` package from source
+when the venv's editable install is missing (#564).
+
+`No module named 'omnivoice'` is a venv that starts uvicorn but never laid (or
+lost) the editable record. The bootstrap now gates on it, and this source
+fallback is the runtime safety net. These tests cover the pure path-resolution
+logic without disturbing the real (installed) omnivoice.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+from core.omnivoice_path import (  # noqa: E402
+    find_omnivoice_source_root,
+    ensure_omnivoice_importable,
+    _candidate_roots,
+)
+
+
+def _make_source_root(tmp_path):
+    root = tmp_path / "project"
+    (root / "omnivoice").mkdir(parents=True)
+    (root / "omnivoice" / "__init__.py").write_text("")
+    return root
+
+
+def test_find_source_root_picks_dir_with_package(tmp_path):
+    root = _make_source_root(tmp_path)
+    other = tmp_path / "empty"
+    other.mkdir()
+    assert find_omnivoice_source_root([str(other), str(root)]) == str(root)
+
+
+def test_find_source_root_none_when_absent(tmp_path):
+    assert find_omnivoice_source_root([str(tmp_path), None, str(tmp_path / "nope")]) is None
+
+
+def test_candidate_roots_prefers_env_then_backend_parent(tmp_path, monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_PROJECT_ROOT", "/explicit/root")
+    backend_dir = str(tmp_path / "project" / "backend")
+    roots = _candidate_roots(backend_dir)
+    assert roots[0] == "/explicit/root"
+    assert roots[1] == os.path.join(str(tmp_path), "project")  # parent of backend/
+
+
+def test_candidate_roots_without_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_PROJECT_ROOT", raising=False)
+    backend_dir = str(tmp_path / "project" / "backend")
+    assert _candidate_roots(backend_dir) == [os.path.join(str(tmp_path), "project")]
+
+
+def test_ensure_noop_when_already_importable(monkeypatch):
+    # omnivoice IS installed in the test venv → find_spec resolves → no fallback.
+    before = list(sys.path)
+    assert ensure_omnivoice_importable("/anywhere") is None
+    assert sys.path == before
+
+
+def test_ensure_appends_source_root_when_not_importable(tmp_path, monkeypatch):
+    root = _make_source_root(tmp_path)
+    backend_dir = str(root / "backend")
+    # Simulate the missing editable install.
+    monkeypatch.setattr("core.omnivoice_path._already_importable", lambda: False)
+    monkeypatch.delenv("OMNIVOICE_PROJECT_ROOT", raising=False)
+    monkeypatch.setattr(sys, "path", list(sys.path))  # isolate mutation
+
+    added = ensure_omnivoice_importable(backend_dir)
+    assert added == str(root)
+    assert str(root) in sys.path
+    # Appended (not inserted) so a real install keeps precedence.
+    assert sys.path[-1] == str(root)
+
+
+def test_ensure_returns_none_when_no_source_found(tmp_path, monkeypatch):
+    monkeypatch.setattr("core.omnivoice_path._already_importable", lambda: False)
+    monkeypatch.delenv("OMNIVOICE_PROJECT_ROOT", raising=False)
+    backend_dir = str(tmp_path / "no-sibling" / "backend")
+    assert ensure_omnivoice_importable(backend_dir) is None

--- a/tests/test_omnivoice_path.py
+++ b/tests/test_omnivoice_path.py
@@ -52,22 +52,34 @@ def test_candidate_roots_without_env(tmp_path, monkeypatch):
     assert _candidate_roots(backend_dir) == [os.path.join(str(tmp_path), "project")]
 
 
-def test_ensure_noop_when_already_importable(monkeypatch):
+# NB: patch + call through the LIVE module object (`op`), never the names bound
+# at this file's import time. Other suites `importlib.reload(core.*)`, which can
+# leave the top-level-imported `ensure_omnivoice_importable` closed over a stale
+# module whose `_already_importable` a string-form monkeypatch wouldn't touch —
+# the #603 CI flake. Resolving both from sys.modules keeps them consistent.
+def _live():
+    import importlib
+    return importlib.import_module("core.omnivoice_path")
+
+
+def test_ensure_noop_when_already_importable():
+    op = _live()
     # omnivoice IS installed in the test venv → find_spec resolves → no fallback.
     before = list(sys.path)
-    assert ensure_omnivoice_importable("/anywhere") is None
+    assert op.ensure_omnivoice_importable("/anywhere") is None
     assert sys.path == before
 
 
 def test_ensure_appends_source_root_when_not_importable(tmp_path, monkeypatch):
+    op = _live()
     root = _make_source_root(tmp_path)
     backend_dir = str(root / "backend")
-    # Simulate the missing editable install.
-    monkeypatch.setattr("core.omnivoice_path._already_importable", lambda: False)
+    # Simulate the missing editable install (patch on the live module object).
+    monkeypatch.setattr(op, "_already_importable", lambda: False)
     monkeypatch.delenv("OMNIVOICE_PROJECT_ROOT", raising=False)
     monkeypatch.setattr(sys, "path", list(sys.path))  # isolate mutation
 
-    added = ensure_omnivoice_importable(backend_dir)
+    added = op.ensure_omnivoice_importable(backend_dir)
     assert added == str(root)
     assert str(root) in sys.path
     # Appended (not inserted) so a real install keeps precedence.
@@ -75,7 +87,8 @@ def test_ensure_appends_source_root_when_not_importable(tmp_path, monkeypatch):
 
 
 def test_ensure_returns_none_when_no_source_found(tmp_path, monkeypatch):
-    monkeypatch.setattr("core.omnivoice_path._already_importable", lambda: False)
+    op = _live()
+    monkeypatch.setattr(op, "_already_importable", lambda: False)
     monkeypatch.delenv("OMNIVOICE_PROJECT_ROOT", raising=False)
     backend_dir = str(tmp_path / "no-sibling" / "backend")
-    assert ensure_omnivoice_importable(backend_dir) is None
+    assert op.ensure_omnivoice_importable(backend_dir) is None


### PR DESCRIPTION
## Problem

`No module named 'omnivoice'` (#564) — reporter installed via MSI, auto-updated 0.2.2 → 0.3.8-49, and it **persisted after #573**. The attached `backend.log` shows the backend booting fine (config loaded, MCP mounted, alembic run) and failing only at `Importing PyTorch & OmniVoice runtime…` → `Model loading failed: No module named 'omnivoice'`.

Root cause: the venv's **editable install of the project's own `omnivoice` package was lost** — an interrupted/offline `uv sync` during the in-place upgrade installed deps but never laid `_editable_impl_omnivoice.pth` (the user's home path is also non-ASCII, `C:\Users\АСУ\`, a known aggravator). The bootstrap health gate only checked `import uvicorn` + `import pkg_resources`, so it passed the broken venv through, and the app failed only at the first generate/dub. #573's `main.py` source fallback couldn't help because the *editable record*, not the source tree, was missing.

## Fix — close the gate, harden the runtime

- **`bootstrap.rs`** — add an `omnivoice` check beside the uvicorn/pkg_resources gates, via `importlib.util.find_spec` (**resolves without importing**, so no torch load / no startup-time cost). When it fails, fall through to the existing repair `uv sync`, which **re-lays the editable install**. Mirrors the #248 `pkg_resources` pattern line-for-line.
- **`core/omnivoice_path.py`** (new) — `ensure_omnivoice_importable()`: no-ops when the install resolves; otherwise appends the sibling source root to `sys.path` (appended, never inserted, so a real install keeps precedence); precise error when neither is found.
- **`main.py`** — replace the inline #573 block with the helper.
- **`model_manager._lazy_omnivoice`** — self-heal on `ModuleNotFoundError` at the actual import site so the model-load path recovers and logs the roots it searched.

## Tests / verification
- `tests/test_omnivoice_path.py` (new, 7 cases): source-root resolution, env-override precedence, append-not-insert, no-op-when-installed, no-source-found.
- `cargo check` passes for the Rust change (only a pre-existing unrelated `setup.rs` warning).
- Backend imports clean.

The Rust gate runs on Windows/macOS/Linux installs; I can't exercise the Windows installer path on this machine, but the check mirrors the proven `pkg_resources` gate and `find_spec` keeps it cheap.

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary

## Problem
MSI installs with auto-update can lose the venv’s editable install metadata for the `omnivoice` package (e.g., incomplete/offline `uv sync`, and especially when user home paths contain non-ASCII characters). The failure previously wasn’t detected until the first model generation call, not during startup.

## Solution

### Bootstrap Health Gate (frontend/src-tauri/src/bootstrap.rs)
`ensure_venv_ready` now includes a third runtime-import gate: in addition to checking `uvicorn` and `pkg_resources`, it validates that `omnivoice` is discoverable via `importlib.util.find_spec('omnivoice')` (without importing). If any gate fails, the existing repair branch runs `uv sync` to re-lay the editable install.

**Runtime flow:**
```mermaid
graph TD
    A["ensure_venv_ready<br/>(venv startup)"] --> B{"uvicorn<br/>importable?"}
    B -->|No| C["Repair: uv sync"]
    B -->|Yes| D{"pkg_resources<br/>working?"}
    D -->|No| C
    D -->|Yes| E{"omnivoice<br/>locatable via find_spec?"}
    E -->|No| C
    E -->|Yes| F["Venv ready<br/>proceed"]
    C --> G["Restart venv"]
```

### Importability Helper (backend/core/omnivoice_path.py – new)
Adds centralized recovery logic to make the backend’s bundled `omnivoice` source importable when the editable install is missing/broken:

- `find_omnivoice_source_root(candidates)`: finds the first candidate directory containing `omnivoice/__init__.py`.
- `ensure_omnivoice_importable(backend_dir, logger=None)`:
  - no-ops if `omnivoice` is already importable
  - otherwise discovers a local source root (preferring `OMNIVOICE_PROJECT_ROOT`, otherwise using the backend’s parent directory)
  - appends the discovered root to `sys.path` (**append-only, not inserted**) to preserve install precedence
  - emits precise diagnostics when it can’t find a valid source root

### Backend Startup (backend/main.py)
Replaces the previous inline fallback (from earlier fix `#573`) with a single call to `ensure_omnivoice_importable(_backend_dir)`.

### Runtime Self-Healing (backend/services/model_manager.py)
`_lazy_omnivoice()` wraps the initial `OmniVoice` import in `try/except ModuleNotFoundError`. On failure it calls `ensure_omnivoice_importable()` and retries the import; when repair fails, it logs the searched roots.

**Runtime recovery flow:**
```mermaid
graph TD
    A["Model load<br/>_lazy_omnivoice"] --> B["Try import<br/>OmniVoice"]
    B -->|Success| C["Use OmniVoice"]
    B -->|ModuleNotFoundError| D["ensure_omnivoice_importable<br/>with logger"]
    D -->|Found source| E["Append to sys.path (append-only)"]
    D -->|Not found| F["Log incomplete install + searched roots"]
    E --> G["Retry import<br/>OmniVoice"]
    F --> G
    G -->|Success| C
```

## Test Coverage
Adds regression tests in `tests/test_omnivoice_path.py` (7 total) covering:
- source-root discovery via `omnivoice/__init__.py`
- `OMNIVOICE_PROJECT_ROOT` precedence vs backend-parent fallback
- append-not-insert behavior for `sys.path`
- no-op when `omnivoice` is already importable
- behavior when no valid source root exists
- live-module safety for monkeypatching via a `_live()` helper
<!-- end of auto-generated comment: release notes by coderabbit.ai -->