### PR TITLE
feat(support): Contact page, Ko-fi/PayPal donate, simpler license

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,7 @@
 # These are supported funding model platforms
+# GitHub Sponsors isn't set up for this account — fund via Ko-fi or PayPal.
 
-github: [debpalash]
-# ko_fi: omnivoice
+ko_fi: debpalash
+custom: ["https://paypal.me/palashCoder"]
+# github: [debpalash]            # not available
 # open_collective: omnivoice-studio
-# custom: ["https://omnivoice.palash.dev/sponsor"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,23 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Added
+
+- **A dedicated Contact page.** Discord, email, GitHub issues, and the project
+  website (palash.dev) as clean one-tap rows, reachable from the footer — so
+  reaching the maker is never more than a click away.
+
+### Changed
+
+- **Donations now go through Ko-fi or PayPal (GitHub Sponsors removed).** GitHub
+  Sponsors isn't available, so the Support page no longer routes there: pick an
+  amount (now $10 / $20 / $50) and then choose Ko-fi or PayPal — PayPal carries
+  the amount straight into checkout. `.github/FUNDING.yml` and the README badges
+  were updated to match.
+- **Simplified the Commercial License page.** Trimmed the six-tile benefit grid
+  and FAQ down to the three things that actually drive the decision (you own the
+  output, no per-minute cost, direct support) plus one clear "request a quote"
+  contact — less wall-of-text, faster to act on.
 
 ## [0.3.7] — 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     <a href="https://github.com/debpalash/OmniVoice-Studio/issues"><img src="https://img.shields.io/github/issues/debpalash/OmniVoice-Studio?style=flat-square&color=ef4444" alt="Issues" /></a>
     <a href="https://discord.gg/bzQavDfVV9"><img src="https://img.shields.io/badge/Discord-Join_Community-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
     <a href="https://ko-fi.com/debpalash"><img src="https://img.shields.io/badge/Ko--fi-Support_Us-FF5E5B?style=flat-square&logo=ko-fi&logoColor=white" alt="Ko-fi" /></a>
-    <a href="https://github.com/sponsors/debpalash"><img src="https://img.shields.io/badge/GitHub-Sponsor-ff69b4?style=flat-square&logo=github&logoColor=white" alt="GitHub Sponsors" /></a>
+    <a href="https://paypal.me/palashCoder"><img src="https://img.shields.io/badge/PayPal-Donate-00457C?style=flat-square&logo=paypal&logoColor=white" alt="PayPal" /></a>
   </p>
 </div>
 
@@ -388,8 +388,6 @@ OmniVoice Studio is built by one developer using Claude Code and AI agents — a
 <a href="https://ko-fi.com/debpalash"><img src="https://img.shields.io/badge/Ko--fi-Support_❤️-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white" alt="Ko-fi" /></a>
 &nbsp;&nbsp;
 <a href="https://paypal.me/palashCoder"><img src="https://img.shields.io/badge/PayPal-Donate-00457C?style=for-the-badge&logo=paypal&logoColor=white" alt="PayPal" /></a>
-&nbsp;&nbsp;
-<a href="https://github.com/sponsors/debpalash"><img src="https://img.shields.io/badge/GitHub-Sponsor-ff69b4?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Sponsors" /></a>
 
 <br/>
 <sub>Every dollar goes directly to agent bills — keeping OmniVoice development continuous.</sub>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ const LogsFooter = lazy(() => import('./components/LogsFooter'));
 const ProjectsPage = lazy(() => import('./pages/Projects'));
 const VoiceGallery = lazy(() => import('./pages/VoiceGallery'));
 const SupportPage = lazy(() => import('./pages/SupportPage'));
+const ContactPage = lazy(() => import('./pages/ContactPage'));
 const TranscriptionsPage = lazy(() => import('./pages/Transcriptions'));
 const StoriesEditor = lazy(() => import('./components/StoriesEditor'));
 const AudiobookTab = lazy(() => import('./pages/AudiobookTab'));
@@ -205,7 +206,7 @@ function App() {
   const openVoiceProfile = useAppStore(s => s.openVoiceProfile);
   const closeVoiceProfile = useAppStore(s => s.closeVoiceProfile);
   const hideSidebar = mode === 'launchpad' || mode === 'settings' || mode === 'voice' || mode === 'donate'
-    || mode === 'queue' || mode === 'tools' || mode === 'projects' || mode === 'gallery' || mode === 'enterprise' || mode === 'transcriptions'
+    || mode === 'queue' || mode === 'tools' || mode === 'projects' || mode === 'gallery' || mode === 'enterprise' || mode === 'contact' || mode === 'transcriptions'
     || mode === 'stories' || mode === 'audiobook'
     // Voice (studio) and Dub workspaces moved their saved voices /
     // projects + history into right-side panels; left sidebar dissolved.
@@ -1141,6 +1142,12 @@ function App() {
           <ErrorBoundary name="enterprise">
             <Suspense fallback={<LazyFallback />}>
               <SupportPage initialView="license" onBack={() => setMode('launchpad')} />
+            </Suspense>
+          </ErrorBoundary>
+        ) : mode === 'contact' ? (
+          <ErrorBoundary name="contact">
+            <Suspense fallback={<LazyFallback />}>
+              <ContactPage onBack={() => setMode('launchpad')} />
             </Suspense>
           </ErrorBoundary>
         ) : mode === 'launchpad' ? (

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { copyText } from "../utils/copyText";
 import {
   ChevronUp, ChevronDown, RefreshCw, Trash2, Copy, Bug, X,
-  AlertTriangle, AlertCircle, Info, FileText, Heart,
+  AlertTriangle, AlertCircle, Info, FileText, Heart, Mail,
 } from 'lucide-react';
 
 import toast from 'react-hot-toast';
@@ -421,6 +421,15 @@ export default function LogsFooter() {
             aria-label={t('logs.join_discord_aria')}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.947 2.418-2.157 2.418z"/></svg>
+          </button>
+          <button
+            type="button"
+            className="logs-footer__discord"
+            onClick={() => useAppStore.getState().setMode?.('contact')}
+            title={t('logs.contact', { defaultValue: 'Contact' })}
+            aria-label={t('logs.contact_aria', { defaultValue: 'Open the contact page' })}
+          >
+            <Mail size={14} />
           </button>
           <button
             type="button"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1066,6 +1066,8 @@
     "suggested_title": "Pick an amount",
     "most_common": "most common",
     "custom": "Custom",
+    "choose_method": "Choose how to give",
+    "choose_method_amount": "Continue with ${{amount}}",
     "goal": {
       "title": "Fund Claude Max",
       "of": "of",
@@ -1093,6 +1095,8 @@
     "desc": "Professional licensing and technical support for commercial users.",
     "back": "Back to Studio",
     "badge": "Commercial License",
+    "hero_simple": "OmniVoice Studio is free and open-source under the AGPL-3.0 — including for commercial and internal business use. You only need a commercial license to embed it in a closed-source product without AGPL’s copyleft obligations.",
+    "contact_lead": "Pricing is quoted per deployment so it fits your team and workload. Tell me your use case and I’ll get you a quote.",
     "hero_title": "Ship AI voices in production",
     "hero_desc": "OmniVoice Studio is free and open-source software under the GNU Affero General Public License v3 (AGPL-3.0) — free to use, including for commercial and internal business use. A commercial license is needed only if you want to embed OmniVoice Studio in a closed-source or proprietary product or service without AGPL-3.0's copyleft obligations.",
     "hero_note": "Use, self-hosting, and commercial use are all free under the AGPL-3.0 — including at scale. AGPL is a network-copyleft license: if you modify OmniVoice and offer that modified version to others over a network, you must share your modified source under the same terms. A commercial license lifts those copyleft obligations for proprietary, closed-source deployments. Pricing tiers are coming soon — get in touch in the meantime.",
@@ -1546,6 +1550,8 @@
     "join_discord_aria": "Join our Discord community",
     "support_project": "Support this project",
     "support_project_aria": "Support this project",
+    "contact": "Contact",
+    "contact_aria": "Open the contact page",
     "empty_frontend_short": "No frontend console output yet.",
     "empty_lines": "No lines.",
     "all_clear": "✅ All clear — no issues detected",
@@ -1860,6 +1866,18 @@
     "other_ways": "Other ways to help",
     "star_github": "Star on GitHub",
     "join_discord": "Join Discord"
+  },
+  "contact": {
+    "hero_title": "Get in touch",
+    "hero_desc": "Questions, bugs, licensing, or just to say hi — here’s how to reach me.",
+    "discord": "Discord",
+    "discord_desc": "Chat with the community and get help fast.",
+    "email": "Email",
+    "email_desc": "Licensing, partnerships, or anything private.",
+    "issues": "GitHub Issues",
+    "issues_desc": "Report a bug or request a feature.",
+    "website": "Website",
+    "website_desc": "More about the project and the maker."
   },
   "firstrun": {
     "loading": "Preparing setup…",

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ArrowLeft, ExternalLink, MessageCircle, Mail, Bug, Globe,
+} from 'lucide-react';
+import { Button } from '../ui';
+import { openExternal } from '../api/external';
+import './DonatePage.css';
+import './SupportPage.css';
+
+// All outward contact channels in one place (#contact). Values are the same
+// ones used across the app (donate/license footers) so there's a single source.
+const DISCORD_URL = 'https://discord.gg/bzQavDfVV9';
+const EMAIL = 'OmniVoice@palash.dev';
+const ISSUES_URL = 'https://github.com/debpalash/OmniVoice-Studio/issues';
+const WEBSITE_URL = 'https://palash.dev';
+
+const CHANNELS = [
+  {
+    id: 'discord',
+    icon: MessageCircle,
+    hue: '#5865F2',
+    labelKey: 'contact.discord',
+    labelDefault: 'Discord',
+    descKey: 'contact.discord_desc',
+    descDefault: 'Chat with the community and get help fast.',
+    value: 'discord.gg/bzQavDfVV9',
+    url: DISCORD_URL,
+  },
+  {
+    id: 'email',
+    icon: Mail,
+    hue: '#d3869b',
+    labelKey: 'contact.email',
+    labelDefault: 'Email',
+    descKey: 'contact.email_desc',
+    descDefault: 'Licensing, partnerships, or anything private.',
+    value: EMAIL,
+    url: `mailto:${EMAIL}`,
+  },
+  {
+    id: 'issues',
+    icon: Bug,
+    hue: '#8ec07c',
+    labelKey: 'contact.issues',
+    labelDefault: 'GitHub Issues',
+    descKey: 'contact.issues_desc',
+    descDefault: 'Report a bug or request a feature.',
+    value: 'github.com/debpalash/OmniVoice-Studio',
+    url: ISSUES_URL,
+  },
+  {
+    id: 'website',
+    icon: Globe,
+    hue: '#83a598',
+    labelKey: 'contact.website',
+    labelDefault: 'Website',
+    descKey: 'contact.website_desc',
+    descDefault: 'More about the project and the maker.',
+    value: 'palash.dev',
+    url: WEBSITE_URL,
+  },
+];
+
+/**
+ * ContactPage — a standalone "reach me" page: Discord, email, GitHub issues,
+ * and website as clean, single-tap rows. Reached via `mode === 'contact'`.
+ */
+export default function ContactPage({ onBack }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="support-page donate-page">
+      <div className="lp-aurora" aria-hidden="true">
+        <span className="lp-aurora__blob lp-aurora__blob--pink" />
+        <span className="lp-aurora__blob lp-aurora__blob--green" />
+        <span className="lp-aurora__blob lp-aurora__blob--amber" />
+      </div>
+
+      <div className="support-page__topbar">
+        <Button variant="subtle" size="sm" onClick={onBack} leading={<ArrowLeft size={14} />}>
+          {t('donate.back')}
+        </Button>
+        <span className="support-page__spacer" aria-hidden="true" />
+      </div>
+
+      <div className="support-page__content donate-page__content support-page__content--support">
+        <div className="support-view">
+          <div className="donate-hero">
+            <div className="donate-hero__icon-wrap">
+              <MessageCircle size={24} className="donate-hero__heart" />
+            </div>
+            <h2 className="donate-hero__title">
+              {t('contact.hero_title', { defaultValue: 'Get in touch' })}
+              <span className="lp-hero__sweep" aria-hidden="true" />
+            </h2>
+            <p className="donate-hero__subtitle">
+              {t('contact.hero_desc', { defaultValue: 'Questions, bugs, licensing, or just to say hi — here’s how to reach me.' })}
+            </p>
+          </div>
+
+          <section className="donate-section">
+            <div className="donate-grid support-methods">
+              {CHANNELS.map((c, i) => {
+                const Icon = c.icon;
+                return (
+                  <button
+                    key={c.id}
+                    type="button"
+                    className="donate-card donate-card--link lp-glow-card"
+                    style={{ '--anim-i': i, '--card-hue': c.hue }}
+                    onClick={() => openExternal(c.url)}
+                  >
+                    <span className="donate-card__glow" aria-hidden="true" />
+                    <div className="donate-card__icon"><Icon size={20} /></div>
+                    <div className="donate-card__body">
+                      <div className="donate-card__label">{t(c.labelKey, { defaultValue: c.labelDefault })}</div>
+                      <div className="donate-card__desc">{t(c.descKey, { defaultValue: c.descDefault })}</div>
+                      <div className="contact-card__value">{c.value}</div>
+                    </div>
+                    <div className="donate-card__arrow"><ExternalLink size={14} /></div>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SupportPage.css
+++ b/frontend/src/pages/SupportPage.css
@@ -157,3 +157,14 @@
   .support-toggle__opt svg { transition: none; }
   .support-view { animation: none; }
 }
+
+/* Contact page — the small monospace channel value under each card's
+   description (e.g. "discord.gg/…", "palash.dev"). */
+.contact-card__value {
+  margin-top: 4px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11px;
+  color: var(--text-muted, #928374);
+  opacity: 0.85;
+  word-break: break-all;
+}

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Heart, ExternalLink, ArrowLeft, Building2,
-  Shield, Zap, Users, Headphones, Code, Globe, Mail,
+  Shield, Zap, Users, Headphones, Mail,
   Star, MessageCircle,
 } from 'lucide-react';
 import { Button } from '../ui';
@@ -13,29 +13,38 @@ import './DonatePage.css';
 import './EnterprisePage.css';
 import './SupportPage.css';
 
-const SPONSOR_URL = 'https://github.com/sponsors/debpalash';
-// Suggested amounts — middle option ($5) is flagged "most common".
-// None is pre-selected (no dark-pattern default-charge nudge).
+// GitHub Sponsors isn't available, so donations go through Ko-fi or PayPal and
+// the supporter picks which — no default-charge nudge, none pre-selected.
+const KOFI_URL = 'https://ko-fi.com/debpalash';
+const PAYPAL_URL = 'https://paypal.me/palashCoder';
+// Suggested amounts — ladder starts at $10; middle ($20) is "most common".
 const SUGGESTED_AMOUNTS = [
-  { value: 3,  label: '$3' },
-  { value: 5,  label: '$5', common: true },
   { value: 10, label: '$10' },
+  { value: 20, label: '$20', common: true },
+  { value: 50, label: '$50' },
 ];
 
 const METHODS = [
-  { id: 'github', label: 'GitHub Sponsors', descriptionKey: 'donate.github_desc', url: 'https://github.com/debpalash', icon: '🐙' },
-  { id: 'kofi', label: 'Ko-fi', descriptionKey: 'donate.coffee_desc', url: 'https://ko-fi.com/debpalash', icon: '☕' },
-  { id: 'paypal', label: 'PayPal', descriptionKey: 'donate.paypal_desc', url: 'https://paypal.me/palashCoder', icon: '💳' },
+  { id: 'kofi', label: 'Ko-fi', descriptionKey: 'donate.coffee_desc', url: KOFI_URL, icon: '☕' },
+  { id: 'paypal', label: 'PayPal', descriptionKey: 'donate.paypal_desc', url: PAYPAL_URL, icon: '💳' },
 ];
 
-function LinkCard({ method, style }) {
+// PayPal.me carries the chosen amount straight into the checkout; Ko-fi opens
+// its tip page (no reliable preset-amount URL). A non-numeric/"custom" amount
+// falls back to the bare link.
+function methodUrl(method, amount) {
+  if (method.id === 'paypal' && typeof amount === 'number') return `${PAYPAL_URL}/${amount}`;
+  return method.url;
+}
+
+function LinkCard({ method, amount, style }) {
   const { t } = useTranslation();
   return (
     <button
       type="button"
       className="donate-card donate-card--link lp-glow-card"
       style={style}
-      onClick={() => openExternal(method.url)}
+      onClick={() => openExternal(methodUrl(method, amount))}
     >
       <span className="donate-card__glow" aria-hidden="true" />
       <div className="donate-card__icon">{method.icon}</div>
@@ -89,7 +98,9 @@ function SupportView() {
         </div>
       </section>
 
-      {/* ── Suggested amounts (none pre-selected; middle is "most common") ── */}
+      {/* ── Step 1: pick an amount (none pre-selected; middle is "most common"). ──
+          Selecting only *records* the amount — the supporter then chooses
+          Ko-fi or PayPal below, and PayPal carries the amount through. */}
       <section className="donate-section">
         <div className="donate-section__title"><span>{t('donate.suggested_title', { defaultValue: 'Pick an amount' })}</span></div>
         <div className="donate-amounts" role="group" aria-label={t('donate.suggested_title', { defaultValue: 'Pick an amount' })}>
@@ -99,7 +110,7 @@ function SupportView() {
               type="button"
               className={`donate-amount ${amount === a.value ? 'is-selected' : ''} ${a.common ? 'donate-amount--common' : ''}`}
               aria-pressed={amount === a.value}
-              onClick={() => { setAmount(a.value); openExternal(SPONSOR_URL); }}
+              onClick={() => setAmount(amount === a.value ? null : a.value)}
             >
               <span className="donate-amount__value">{a.label}</span>
               {a.common && (
@@ -113,18 +124,26 @@ function SupportView() {
             type="button"
             className={`donate-amount donate-amount--custom ${amount === 'custom' ? 'is-selected' : ''}`}
             aria-pressed={amount === 'custom'}
-            onClick={() => { setAmount('custom'); openExternal(SPONSOR_URL); }}
+            onClick={() => setAmount(amount === 'custom' ? null : 'custom')}
           >
             <span className="donate-amount__value">{t('donate.custom', { defaultValue: 'Custom' })}</span>
           </button>
         </div>
       </section>
 
+      {/* ── Step 2: pick where (Ko-fi or PayPal). GitHub Sponsors isn't
+          available; the supporter chooses, and PayPal carries the amount. ── */}
       <section className="donate-section">
-        <div className="donate-section__title"><span>{t('donate.platforms')}</span></div>
+        <div className="donate-section__title">
+          <span>
+            {typeof amount === 'number'
+              ? t('donate.choose_method_amount', { defaultValue: 'Continue with ${{amount}}', amount })
+              : t('donate.choose_method', { defaultValue: 'Choose how to give' })}
+          </span>
+        </div>
         <div className="donate-grid support-methods">
           {METHODS.map((m, i) => (
-            <LinkCard key={m.id} method={m} style={{ '--anim-i': i, '--card-hue': '#d3869b' }} />
+            <LinkCard key={m.id} method={m} amount={typeof amount === 'number' ? amount : null} style={{ '--anim-i': i, '--card-hue': '#d3869b' }} />
           ))}
         </div>
       </section>
@@ -157,15 +176,20 @@ function SupportView() {
 }
 
 /* ── Commercial License panel ─────────────────────────────────────────── */
+const LICENSE_EMAIL = 'OmniVoice@palash.dev';
+const LICENSE_MAILTO =
+  'mailto:OmniVoice@palash.dev?subject=OmniVoice Commercial License Inquiry'
+  + '&body=Hi Palash,%0A%0AI%27d like to talk about a commercial license for OmniVoice Studio.%0A%0AOrganization:%0ATeam size:%0AUse case:%0A';
+
 function LicenseView() {
   const { t } = useTranslation();
+  // The three reasons that actually drive a commercial-license decision — the
+  // full benefit grid + FAQ was noise; what matters is "you own it", "no
+  // per-minute cost", "direct support". Everything else is one email away.
   const WHY_ITEMS = [
     { icon: Shield, label: t('enterprise.benefit_ip'), desc: t('enterprise.benefit_ip_desc') },
     { icon: Zap, label: t('enterprise.benefit_cost'), desc: t('enterprise.benefit_cost_desc') },
-    { icon: Users, label: t('enterprise.benefit_team'), desc: t('enterprise.benefit_team_desc') },
     { icon: Headphones, label: t('enterprise.benefit_support'), desc: t('enterprise.benefit_support_desc') },
-    { icon: Code, label: t('enterprise.benefit_source'), desc: t('enterprise.benefit_source_desc') },
-    { icon: Globe, label: t('enterprise.benefit_lang'), desc: t('enterprise.benefit_lang_desc') },
   ];
   return (
     <div className="support-view">
@@ -175,12 +199,12 @@ function LicenseView() {
           {t('enterprise.hero_title')}
           <span className="lp-hero__sweep" aria-hidden="true" />
         </h2>
-        <p className="ent-hero__subtitle">{t('enterprise.hero_desc')}</p>
-        <p className="ent-hero__subtitle">{t('enterprise.hero_note')}</p>
+        <p className="ent-hero__subtitle">{t('enterprise.hero_simple', {
+          defaultValue: 'OmniVoice Studio is free and open-source under the AGPL-3.0 — including for commercial and internal business use. You only need a commercial license to embed it in a closed-source product without AGPL’s copyleft obligations.',
+        })}</p>
       </div>
 
       <section className="ent-why">
-        <div className="ent-section-title"><span>{t('enterprise.why_title')}</span></div>
         <div className="ent-why__grid">
           {WHY_ITEMS.map(({ icon: Icon, label, desc }) => (
             <div key={label} className="ent-why__card">
@@ -192,64 +216,33 @@ function LicenseView() {
         </div>
       </section>
 
+      {/* One clear next step: pricing is quoted per deployment, so the action
+          is simply "tell me about your use case". */}
       <section className="ent-tiers-section">
-        <div className="ent-section-title"><span>{t('enterprise.pricing_title')}</span></div>
         <div className="ent-coming-soon">
-          <p>
-            <strong>{t('enterprise.pricing_desc')}</strong>{' '}
-            {t('enterprise.pricing_detail')}
-          </p>
+          <p>{t('enterprise.contact_lead', {
+            defaultValue: 'Pricing is quoted per deployment so it fits your team and workload. Tell me your use case and I’ll get you a quote.',
+          })}</p>
           <button
             type="button"
             className="ent-coming-soon__cta"
-            onClick={() => openExternal('mailto:OmniVoice@palash.dev?subject=OmniVoice Commercial License Inquiry&body=Hi Palash,%0A%0AI%27d like to talk about a commercial license for OmniVoice Studio.%0A%0AOrganization:%0ATeam size:%0AUse case:%0A')}
+            onClick={() => openExternal(LICENSE_MAILTO)}
           >
             <Mail size={13} />
             {t('enterprise.request_quote')}
           </button>
+          <p className="ent-cta-footer__sub">
+            <button
+              type="button"
+              className="ent-cta-footer__link"
+              onClick={() => openExternal(LICENSE_MAILTO)}
+              title={LICENSE_EMAIL}
+            >
+              {LICENSE_EMAIL}
+            </button>
+          </p>
         </div>
       </section>
-
-      <section className="ent-faq">
-        <div className="ent-section-title"><span>{t('enterprise.faq_title')}</span></div>
-        <div className="ent-faq__list">
-          <details className="ent-faq__item">
-            <summary>{t('enterprise_faq.q_internal_tools')}</summary>
-            <p>{t('enterprise_faq.a_internal_tools')}</p>
-          </details>
-          <details className="ent-faq__item">
-            <summary>{t('enterprise_faq.q_try_before')}</summary>
-            <p>{t('enterprise_faq.a_try_before')}</p>
-          </details>
-          <details className="ent-faq__item">
-            <summary>{t('enterprise_faq.q_watermark')}</summary>
-            <p>{t('enterprise_faq.a_watermark')}</p>
-          </details>
-        </div>
-      </section>
-
-      <div className="ent-cta-footer">
-        <p>
-          <button
-            type="button"
-            className="ent-cta-footer__link"
-            onClick={() => openExternal('mailto:OmniVoice@palash.dev')}
-            title="OmniVoice@palash.dev"
-          >
-            {t('enterprise.footer_email')}
-          </button>
-        </p>
-        <p className="ent-cta-footer__sub">
-          <button
-            type="button"
-            className="ent-cta-footer__link"
-            onClick={() => openExternal('https://discord.gg/bzQavDfVV9')}
-            title="discord.gg/bzQavDfVV9"
-          >
-            {t('enterprise.footer_discord')}
-          </button>
-        </p>
-      </div>
     </div>
   );
 }

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -27,6 +27,7 @@ export type AppMode =
   | 'voice'
   | 'tools'
   | 'batch'
+  | 'contact'
   | 'settings';
 
 /**


### PR DESCRIPTION
GitHub Sponsors isn't available for this account, so this routes donations to **Ko-fi / PayPal**, adds a standalone **Contact** page, and trims the **commercial-license** page to the essentials.

## Donate (Support tab)
- **Removed GitHub Sponsors** entirely (it wasn't reachable). Pick an amount — now **$10 / $20 / $50** ($20 "most common") — then choose **Ko-fi** or **PayPal**. PayPal.me carries the chosen amount straight into checkout; "Custom" / no-amount falls back to the bare links.
- Updated `.github/FUNDING.yml` (→ `ko_fi` + `custom` PayPal) and the README funding badges so the repo's Sponsor button and docs match (docs-sync rule).

## Contact page (new)
- New `mode: 'contact'` + `ContactPage.jsx`: **Discord, email, GitHub issues, website (palash.dev)** as clean one-tap rows, reachable from a new **footer button**. Routed in `App.jsx`, sidebar hidden like the other full pages.

## Commercial License (License tab)
- Cut the six-tile benefit grid + three-item FAQ down to the **three deciding factors** (you own the output · no per-minute cost · direct support) and **one clear "request a quote"** email CTA. Much less wall-of-text.

## i18n / quality
- All new copy goes through i18n (`en.json`: `donate.choose_method*`, `enterprise.hero_simple` / `contact_lead`, `contact.*`, `logs.contact*`).
- `vite build` green; **vitest 561 passed**; `en.json` validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### Donation system redesign (GitHub Sponsors → Ko-fi + PayPal)

**Before → After (UI + routing):**
```
BEFORE: GitHub Sponsors preset tiers + external routing
  [Donate tiers...] → opens GitHub Sponsors

AFTER: Amount → method cards → external checkout
  Step 1 (amount buttons):  [$10] [$20 (most common)] [$50] [Custom]
                         (no amount selected = amount = null)
  Step 2 (method cards):   [Ko-fi] [PayPal]
                         • PayPal uses chosen numeric amount
                         • Custom / no amount fall back to bare links
```

**New behavior (routing logic):**
```mermaid
flowchart TD
  A[User clicks an amount button] --> B{Selected amount is numeric?}
  B -->|Yes (10/20/50)| C[Store amount as number]
  B -->|No (Custom or none)| D[Store amount as non-number or null]

  C --> E[User clicks Ko-fi card]
  D --> E
  E --> F[Open Ko-fi base link (always)]

  C --> G[User clicks PayPal card]
  D --> G
  G --> H{Selected amount is numeric?}
  H -->|Yes| I[Open PayPal.me /{amount}]
  H -->|No| J[Open bare PayPal.me link]
```

**Implementation notes (verified from code):**
- Suggested amounts: **$10 / $20 (most common) / $50**, plus **Custom**; initial state is **no amount pre-selected**.
- UI records the selection; external navigation happens only when the user clicks **Ko-fi** or **PayPal**.
- PayPal checkout URL is constructed as `${PAYPAL_URL}/${amount}` only when the stored amount is a number; otherwise it opens the base PayPal.me URL.

### New standalone Contact page (full-page mode)

**Before → After (layout + navigation):**
```
BEFORE: no dedicated Contact route
  [Footer buttons...]

AFTER: dedicated "Contact" full-page mode (sidebar hidden)
  [◀ Back]
  [Discord] [Email] [GitHub Issues] [Website]
  (each row is one-tap, opens external links)
```

- Added `frontend/src/pages/ContactPage.jsx` as a standalone page rendering Discord, email (`mailto:`), GitHub issues, and website as clean one-tap rows via `openExternal`.
- Footer now includes a **Mail/Contact** button that navigates to `mode = 'contact'`.
- `App.jsx` includes a `mode === 'contact'` render branch and hides the sidebar for this mode (same treatment as other full-page modes).

### Commercial license page streamlined

**Before → After (content presentation):**
```
BEFORE:
  - larger benefit grid
  - multi-item FAQ
  - more tier/pricing messaging

AFTER:
  - 3 decision-factor tiles (IP ownership, no per-minute cost, direct support)
  - single “request a quote” email CTA (mailto link)
```

- `frontend/src/pages/SupportPage.jsx` consolidates the commercial-license presentation into:
  - a simplified **3-item** “why” section, and
  - a single CTA that opens a prefilled `mailto:` inquiry (`LICENSE_MAILTO`)—replacing the prior longer tier/FAQ style UI.

### i18n + funding/metadata updates

- Updated `frontend/src/i18n/locales/en.json` with new/updated copy for:
  - donation UI (`donate.choose_method*`, including the continue-with amount variant, plus labels like “most common” and “Custom”),
  - commercial licensing (`enterprise.hero_simple`, `contact_lead`, `enterprise.request_quote`),
  - contact page (`contact.*`) and logs footer (`logs.contact*`).
- Updated `.github/FUNDING.yml` to route funding through **Ko-fi** and a **custom PayPal** link (GitHub Sponsors left commented as unavailable).
- Synced `README.md` donation/sponsor badges from GitHub Sponsors to **Ko-fi**/**PayPal**.
- Added `CHANGELOG.md` entries under **[Unreleased]** for the Contact page, donation routing, and commercial license streamlining.

### Build validation

- `vite build` passes
- all 561 vitest tests pass
- `en.json` validation succeeds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->