### PR TITLE
fix(dub): retry transient broken-pipe on URL download (#579, #598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **Dubbing a YouTube URL no longer dies on a transient "Broken pipe."**
+  Pasting a video link could fail outright with `download: Unable to download
+  video: [Errno 32] Broken pipe` — a broken pipe raised while the write side of
+  a pipe closes mid-stream (a killed ffmpeg merge child, a CDN reset during
+  muxing). yt-dlp's own per-fragment retries don't cover that case, so a single
+  transient blip aborted the whole ingest. The URL download now retries up to
+  twice on broken-pipe / network-drop failures, wiping the partial download
+  between attempts, and only surfaces the (already-actionable) "connection
+  dropped — just retry" hint after the retries are exhausted. Unsupported links
+  still fail fast with their own hint — no wasted retries. (#579, #598)
 
 ## [0.3.7] — 2026-06-20
 

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -435,6 +435,46 @@ def _ensure_browser_playable_mp4(video_path: str) -> str:
     return video_path
 
 
+# Bounded retry for transient download failures (#579/#598). yt-dlp's own
+# `retries`/`fragment_retries` cover per-fragment HTTP flakes, but a broken
+# pipe ([Errno 32]) raised while the write side of a pipe closes mid-stream
+# (a killed ffmpeg merge child, a CDN reset during muxing) aborts the whole
+# `extract_info` call and is NOT covered by them — so a single transient blip
+# failed the entire ingest with a raw "Broken pipe". We add a small download-
+# level retry on top, cleaning up the partial download between attempts so a
+# half-written `original.*` can't poison the next try.
+_YT_DOWNLOAD_RETRIES = 2  # total attempts = 1 + retries = 3
+
+
+def _is_transient_download_error(exc: BaseException) -> bool:
+    """True when a download failure is worth retrying (broken pipe / net drop).
+
+    Reuses the single failure taxonomy (`VIDEO_DOWNLOAD_NETWORK`) rather than a
+    parallel keyword list, so "what counts as transient" stays single-sourced
+    with the error-hint classification. ``BrokenPipeError``/``ConnectionError``
+    are matched by class too, since a bare instance may be wrapped or re-raised
+    with a stripped message that no longer contains "broken pipe".
+    """
+    if isinstance(exc, (BrokenPipeError, ConnectionError)):
+        return True
+    return failure.classify(str(exc)) == "VIDEO_DOWNLOAD_NETWORK"
+
+
+def _cleanup_partial_download(job_dir: str) -> None:
+    """Remove any half-written `original.*` files before a retry.
+
+    A partial download left on disk would otherwise be picked up as a "finished"
+    file by the post-download codec probe, or collide with the next attempt's
+    output. Best-effort — never raises on the failure path.
+    """
+    import glob
+    for stale in glob.glob(os.path.join(job_dir, "original.*")):
+        try:
+            os.remove(stale)
+        except OSError:
+            pass
+
+
 def yt_download_sync(
     url: str,
     job_dir: str,
@@ -493,15 +533,36 @@ def yt_download_sync(
     }
     if progress_hook is not None:
         ydl_opts["progress_hooks"] = [progress_hook]
-    with yt_dlp.YoutubeDL(ydl_opts) as ydl:
-        info = ydl.extract_info(url, download=True)
-        path = ydl.prepare_filename(info)
-        root, _ = os.path.splitext(path)
-        mp4 = root + ".mp4"
-        if os.path.exists(mp4):
-            video_path = mp4
-        else:
-            video_path = path
+
+    # Download with a bounded retry on transient/broken-pipe-class failures
+    # (#579/#598). A broken pipe mid-mux isn't recoverable inside yt-dlp's own
+    # fragment retries, but a fresh `extract_info` usually succeeds. Between
+    # attempts we wipe the partial `original.*` so a half-written file can't be
+    # mistaken for a finished download.
+    info = None
+    path = None
+    for attempt in range(_YT_DOWNLOAD_RETRIES + 1):
+        try:
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                info = ydl.extract_info(url, download=True)
+                path = ydl.prepare_filename(info)
+            break
+        except Exception as exc:
+            _cleanup_partial_download(job_dir)
+            if attempt < _YT_DOWNLOAD_RETRIES and _is_transient_download_error(exc):
+                logger.warning(
+                    "Transient download failure for %s (attempt %d/%d): %s — retrying",
+                    url, attempt + 1, _YT_DOWNLOAD_RETRIES + 1, exc,
+                )
+                time.sleep(2 * (attempt + 1))  # brief, increasing backoff
+                continue
+            raise
+    root, _ = os.path.splitext(path)
+    mp4 = root + ".mp4"
+    if os.path.exists(mp4):
+        video_path = mp4
+    else:
+        video_path = path
     # Browser-playability guard: WKWebView (Tauri on macOS) refuses to
     # decode VP9/AV1 video and Opus audio even when they're wrapped in an
     # mp4 container, and refuses .webm/.mkv outright. We probe the actual

--- a/tests/test_dub_download_retry.py
+++ b/tests/test_dub_download_retry.py
@@ -1,0 +1,146 @@
+"""Download-retry on transient broken-pipe failures (#579 / #598).
+
+`download: Unable to download video: [Errno 32] Broken pipe` was a hard failure:
+yt-dlp's own per-fragment retries don't cover a broken pipe raised while the
+write side of a pipe closes mid-mux (a killed ffmpeg child / a CDN reset during
+muxing), so a single transient blip aborted the whole ingest with a raw
+"Broken pipe" string.
+
+These assert the fix:
+  * `_is_transient_download_error` classifies broken-pipe / network-drop
+    failures as retryable, reusing the single `VIDEO_DOWNLOAD_NETWORK` taxonomy.
+  * `yt_download_sync` retries a transient failure and recovers on a later
+    attempt, cleaning up the partial download in between.
+  * a non-transient failure (unsupported URL) is NOT retried — the existing
+    unsupported-link vs network-drop hinting must not regress.
+
+RED before the fix (no retry loop existed → first transient error propagated).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from services import dub_pipeline as dp
+from core import failure
+
+
+# ── unit: retryability classification ───────────────────────────────────────
+
+def test_broken_pipe_is_transient():
+    # The exact message from #579/#598.
+    exc = OSError("[Errno 32] Broken pipe")
+    assert dp._is_transient_download_error(exc) is True
+    # A yt-dlp DownloadError-style wrap with the same suffix.
+    assert dp._is_transient_download_error(
+        RuntimeError("Unable to download video: [Errno 32] Broken pipe")
+    ) is True
+    # BrokenPipeError matched by class even with a stripped message.
+    assert dp._is_transient_download_error(BrokenPipeError()) is True
+    assert dp._is_transient_download_error(ConnectionResetError()) is True
+
+
+def test_unsupported_url_is_not_transient():
+    # Must classify as UNSUPPORTED (more specific) and therefore NOT retry —
+    # otherwise we'd waste 3 attempts on a link that can never download.
+    exc = RuntimeError("Unsupported URL: https://www.douyin.com/discover")
+    assert failure.classify(str(exc)) == "UNSUPPORTED_VIDEO_URL"
+    assert dp._is_transient_download_error(exc) is False
+
+
+def test_generic_error_is_not_transient():
+    assert dp._is_transient_download_error(RuntimeError("totally unrelated")) is False
+
+
+# ── integration: yt_download_sync retry/recovery ────────────────────────────
+
+class _FakeYDL:
+    """Minimal yt_dlp.YoutubeDL stand-in driven by a shared call counter."""
+
+    # class-level state so each constructed instance shares the script
+    behaviors: list = []
+    calls: list = []
+    job_dir: str = ""
+
+    def __init__(self, opts):
+        self.opts = opts
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def extract_info(self, url, download=True):
+        idx = len(_FakeYDL.calls)
+        _FakeYDL.calls.append(url)
+        behavior = _FakeYDL.behaviors[idx]
+        # Simulate a partial download being written before the failure, so the
+        # cleanup path has something to remove.
+        with open(os.path.join(_FakeYDL.job_dir, "original.part"), "w") as f:
+            f.write("partial")
+        if isinstance(behavior, BaseException):
+            raise behavior
+        # Success: yt-dlp renames its `.part` to the final file. Mirror that so
+        # the test asserts on real post-success state.
+        out = os.path.join(_FakeYDL.job_dir, "original.mp4")
+        os.replace(os.path.join(_FakeYDL.job_dir, "original.part"), out)
+        return {"title": "Clip", "_filename": out}
+
+    def prepare_filename(self, info):
+        return os.path.join(_FakeYDL.job_dir, "original.mp4")
+
+
+@pytest.fixture
+def _patched_ytdlp(monkeypatch, tmp_path):
+    import yt_dlp
+
+    _FakeYDL.calls = []
+    _FakeYDL.job_dir = str(tmp_path)
+    monkeypatch.setattr(yt_dlp, "YoutubeDL", _FakeYDL)
+    # No real codec transcode / browser-playability probe in tests.
+    monkeypatch.setattr(dp, "_ensure_browser_playable_mp4", lambda p: p)
+    # Skip the real backoff sleep so the test is instant.
+    monkeypatch.setattr(dp.time, "sleep", lambda *_a, **_k: None)
+    return tmp_path
+
+
+def test_retries_then_recovers_on_broken_pipe(_patched_ytdlp):
+    job_dir = str(_patched_ytdlp)
+    # Fail twice with a broken pipe, then succeed.
+    _FakeYDL.behaviors = [
+        OSError("[Errno 32] Broken pipe"),
+        OSError("[Errno 32] Broken pipe"),
+        None,
+    ]
+    video_path, title, subs = dp.yt_download_sync("https://example.com/v", job_dir)
+    assert len(_FakeYDL.calls) == 3, "should retry twice then succeed"
+    assert os.path.basename(video_path) == "original.mp4"
+    assert title == "Clip"
+    # The partial file from the failed attempts must have been cleaned up.
+    assert not os.path.exists(os.path.join(job_dir, "original.part"))
+
+
+def test_gives_up_after_bounded_retries(_patched_ytdlp):
+    job_dir = str(_patched_ytdlp)
+    # Always broken pipe — exhaust the bounded retries, then surface the error.
+    _FakeYDL.behaviors = [OSError("[Errno 32] Broken pipe")] * 10
+    with pytest.raises(OSError) as ei:
+        dp.yt_download_sync("https://example.com/v", job_dir)
+    assert "broken pipe" in str(ei.value).lower()
+    # Bounded: exactly 1 + _YT_DOWNLOAD_RETRIES attempts, not infinite.
+    assert len(_FakeYDL.calls) == dp._YT_DOWNLOAD_RETRIES + 1
+    # The classified failure still carries the actionable network hint.
+    evt = failure.build_failure(ei.value, stage="download", include_diagnostic=False)
+    assert evt["docs_topic"] == "VIDEO_DOWNLOAD_NETWORK"
+    assert evt["hint"]
+
+
+def test_does_not_retry_unsupported_url(_patched_ytdlp):
+    job_dir = str(_patched_ytdlp)
+    # A non-downloadable link must fail fast (no wasted retries).
+    _FakeYDL.behaviors = [RuntimeError("Unsupported URL: https://x/feed")] * 10
+    with pytest.raises(RuntimeError):
+        dp.yt_download_sync("https://x/feed", job_dir)
+    assert len(_FakeYDL.calls) == 1, "unsupported URL must not be retried"


### PR DESCRIPTION
## Problem

Pasting a video URL into the dubber could fail outright with:

```
download: Unable to download video: [Errno 32] Broken pipe
```

Reported twice (#579, #598) — both on macOS / Apple Silicon, both just pasting a YouTube link.

## Root cause

A broken pipe (`[Errno 32]`) is raised when the **write side of a pipe closes mid-stream** — a killed ffmpeg merge child, or a CDN reset during muxing. It aborts the whole `yt_dlp.YoutubeDL.extract_info(...)` call and is **not** covered by yt-dlp's own `retries`/`fragment_retries` (those only cover per-fragment HTTP flakes). So a single transient blip killed the entire ingest.

The failure was already *classified* as `VIDEO_DOWNLOAD_NETWORK` (#554/#536) and carried a "connection dropped — just retry" hint — but nothing actually retried. The user had to manually re-paste the link.

## Fix

`backend/services/dub_pipeline.py` — wrap the download in `yt_download_sync` in a **bounded retry** (1 + 2 = 3 attempts):

- Retries **only** on transient/broken-pipe-class failures, decided by `_is_transient_download_error()`, which reuses the single `failure.classify() == "VIDEO_DOWNLOAD_NETWORK"` taxonomy (plus the `BrokenPipeError` / `ConnectionError` classes for bare/stripped-message instances) rather than inventing a parallel keyword list.
- Wipes any partial `original.*` between attempts (`_cleanup_partial_download`) so a half-written download can't be mistaken for a finished file or collide with the next attempt.
- Brief increasing backoff between attempts.
- After retries are exhausted, the existing actionable `VIDEO_DOWNLOAD_NETWORK` hint is surfaced (unchanged).

**No regression to the existing taxonomy:** unsupported links classify as `UNSUPPORTED_VIDEO_URL` (checked first in `classify()`), so they are **not** transient and fail fast with their own "paste a direct video URL" hint — no wasted retries.

## Test

`tests/test_dub_download_retry.py` (fails before — no retry loop / helper existed; passes after):

- `_is_transient_download_error` classifies broken-pipe / connection-reset as retryable, unsupported-URL / generic as not.
- `yt_download_sync` retries twice then recovers on a transient broken pipe, cleaning up the partial download.
- Bounded give-up: exactly `1 + _YT_DOWNLOAD_RETRIES` attempts (not infinite), and the surfaced error still classifies to `VIDEO_DOWNLOAD_NETWORK` with a hint.
- Unsupported URL is **not** retried (1 attempt).

## Gates

`uv run python -m pytest tests/test_dub_download_retry.py tests/test_failure_classify.py tests/test_failure_helper.py tests/test_dub_error_transparency.py tests/test_dub_pipeline_state.py tests/test_dub_subtitles_309.py` → **46 passed**.

CHANGELOG `## [Unreleased] → ### Fixed` entry added.

Closes #579
Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a critical bug where pasting YouTube URLs into the dubber application fails with `[Errno 32] Broken pipe` errors. The solution adds a bounded retry mechanism (3 total attempts with 1 initial + 2 retries) to the video download operation to recover from transient network failures, while preserving fast-fail behavior for unsupported URLs.

## Problem Statement

Issues `#579` and `#598` reported broken pipe failures when ingesting YouTube links on macOS with Apple Silicon hardware. The root cause is that transient failures during the `yt_dlp.YoutubeDL.extract_info()` call fall outside yt-dlp's per-fragment retry mechanism, causing immediate failure with no recovery attempt. The error was already classified in the failure taxonomy as `VIDEO_DOWNLOAD_NETWORK` with a "just retry" hint, but no actual retry logic existed.

## New Mechanism

```mermaid
graph TD
    A["Start yt_download_sync"] --> B["Attempt download"]
    B --> C{"Download succeeds?"}
    C -->|Yes| D["Extract final video path"]
    C -->|No| E{"Transient error?"}
    E -->|No| F["Re-raise immediately"]
    E -->|Yes| G{"Retries remaining?"}
    G -->|No| H["Emit failure event with<br/>VIDEO_DOWNLOAD_NETWORK diagnostic"]
    G -->|Yes| I["Clean up partial original.* files"]
    I --> J["Wait with increasing backoff"]
    J --> B
    D --> K["Return video path"]
    F --> L["Fail fast"]
    H --> L
```

## Changes

**CHANGELOG.md**
- Updates [Unreleased] → Fixed section with entry describing the retry behavior for transient broken-pipe errors during YouTube ingestion, with referenced issue numbers

**backend/services/dub_pipeline.py** (+70/-9 lines)
- Adds `VIDEO_DOWNLOAD_MAX_RETRIES` constant for bounded retry limit
- Implements `_is_transient_download_error()` to classify broken-pipe/connection-reset failures and unrelated transient errors as retryable, while rejecting unsupported URLs
- Adds `_cleanup_partial_downloads()` helper to remove half-written `original.*` files between attempts
- Wraps `yt_dlp.YoutubeDL(...).extract_info(..., download=True)` in a retry loop with increasing backoff
- Extracts final `video_path` from yt-dlp's prepared filename, preferring `.mp4` variants
- Surfaces existing `VIDEO_DOWNLOAD_NETWORK` diagnostic hint after retries exhausted

**tests/test_dub_download_retry.py** (+146 lines)
- New test module validating:
  - `_is_transient_download_error()` correctly classifies broken-pipe/connection-reset variants as transient and rejects unrelated errors and "Unsupported URL"
  - `yt_download_sync` successfully retries transient failures and recovers on later attempts, cleaning up `.part` files between attempts
  - `yt_download_sync` respects retry bounds, emitting failure events with `VIDEO_DOWNLOAD_NETWORK` diagnostic when exhausted
  - Unsupported URLs fail fast without wasted retries (single attempt only)
- Uses minimal `_FakeYDL` stub with deterministic state management and monkeypatches `yt_dlp.YoutubeDL` and `time.sleep` for instant, controlled testing

## Testing

All tests pass (46 total). The retry mechanism reuses the existing failure taxonomy rather than introducing parallel error classification, ensuring consistency with prior diagnostic work from issues `#554/`#536.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->