### PR TITLE
fix(tts): auto-repair incomplete model cache instead of dead-ending (#581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **An interrupted model download now self-repairs instead of dead-ending.**
+  When the OmniVoice TTS cache was missing weight shards (the usual aftermath of
+  an interrupted first download), the next synthesize failed with a 500 and a
+  "delete the model and install it again" instruction — a manual dead-end. The
+  backend now detects the truncated-cache error on load, re-fetches just the
+  missing files via `snapshot_download` (already-present blobs are skipped, so a
+  near-complete cache repairs in seconds and a healthy cache is never touched),
+  and retries the load automatically. Offline mode (`HF_HUB_OFFLINE`) is
+  respected — repair never makes a network call the user opted out of — and if
+  the re-fetch still can't fix it, the actionable delete-and-reinstall message
+  is preserved as the fallback. (#581)
 
 ## [0.3.7] — 2026-06-20
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -462,6 +462,71 @@ def should_preload_tts_asr() -> bool:
     return _env_flag("OMNIVOICE_PRELOAD_TTS_ASR")
 
 
+def _is_incomplete_cache_error(exc: BaseException) -> bool:
+    """True when `exc` is the truncated-HF-cache class (#352 / #581).
+
+    transformers raises an OSError whose message contains "does not appear to
+    have a file named …" when the on-disk snapshot has config/tokenizer files
+    but no weight shard — the signature of an interrupted download. We match on
+    that phrase (stable across transformers 4.x/5.x) rather than the error type,
+    since the same OSError type covers unrelated I/O failures."""
+    return "does not appear to have a file named" in str(exc)
+
+
+def _hf_offline() -> bool:
+    """Respect HF's offline switches so repair never makes a network call the
+    user opted out of. `snapshot_download` would itself raise offline, but
+    checking up front lets us skip straight to the actionable message."""
+    return _env_flag("HF_HUB_OFFLINE") or _env_flag("TRANSFORMERS_OFFLINE")
+
+
+def _repair_model_cache(checkpoint: str) -> bool:
+    """Re-fetch a checkpoint's missing files in place and report success.
+
+    An interrupted download leaves the cache missing only some files;
+    `snapshot_download` resumes/fills exactly those (already-present, correctly
+    sized blobs are skipped by hash, so a near-complete cache repairs in
+    seconds and a complete one would no-op). Returns False — leaving the caller
+    to surface the actionable delete-and-reinstall message — when repair is
+    impossible (offline) or the re-fetch itself fails (no network, gated repo,
+    full disk). Never raises; repair is best-effort."""
+    if _hf_offline():
+        logger.warning(
+            "Model cache for %s is incomplete but HF offline mode is set — "
+            "cannot auto-repair.", checkpoint,
+        )
+        return False
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception as imp_err:  # pragma: no cover - huggingface_hub is a hard dep
+        logger.warning("Cannot import snapshot_download to repair cache: %s", imp_err)
+        return False
+    logger.info("Auto-repairing incomplete model cache for %s …", checkpoint)
+    dl_kwargs: dict = {"repo_id": checkpoint}
+    endpoint = os.environ.get("HF_ENDPOINT")
+    if endpoint:
+        dl_kwargs["endpoint"] = endpoint
+    if os.name == "nt":
+        # Match the install path (download.py): avoid symlinks on Windows.
+        dl_kwargs["local_dir_use_symlinks"] = False
+    try:
+        snapshot_download(**dl_kwargs)
+    except TypeError:
+        # Older/newer huggingface_hub may not accept local_dir_use_symlinks
+        # on a cache-only call — retry without the optional knob.
+        dl_kwargs.pop("local_dir_use_symlinks", None)
+        try:
+            snapshot_download(**dl_kwargs)
+        except Exception as e:
+            logger.warning("Auto-repair of %s failed: %s", checkpoint, e)
+            return False
+    except Exception as e:
+        logger.warning("Auto-repair of %s failed: %s", checkpoint, e)
+        return False
+    logger.info("Auto-repair of %s completed; retrying model load.", checkpoint)
+    return True
+
+
 def _load_model_sync():
     global model
     from utils.hf_progress import register_listener, unregister_listener
@@ -496,23 +561,43 @@ def _load_model_sync():
             logger.info("Preloading PyTorch Whisper with TTS model.")
         else:
             logger.info("Skipping PyTorch Whisper preload; ASR will load on demand.")
-        try:
-            _model = OmniVoice.from_pretrained(
+        def _load():
+            return OmniVoice.from_pretrained(
                 checkpoint, device_map=device, dtype=torch.float16, load_asr=preload_asr,
             )
+
+        try:
+            _model = _load()
         except OSError as e:
-            # #352: a truncated HF cache surfaces here as "does not appear to
-            # have a file named pytorch_model.bin or model.safetensors".
-            # Translate to an actionable message instead of the raw
-            # transformers error.
-            if "does not appear to have a file named" in str(e):
+            # #352 / #581: a truncated HF cache surfaces here as "does not
+            # appear to have a file named pytorch_model.bin or
+            # model.safetensors". Instead of dead-ending the user with a
+            # manual delete-and-reinstall instruction, try to self-repair: an
+            # interrupted download leaves the cache missing only some files,
+            # and snapshot_download() resumes/fills exactly those (a complete
+            # cache never reaches this branch, so the fast path is untouched).
+            if not _is_incomplete_cache_error(e):
+                raise
+            _set_loading("loading_weights", "Repairing incomplete model cache…")
+            if not _repair_model_cache(checkpoint):
                 raise RuntimeError(
                     f"The TTS model cache for {checkpoint} is incomplete "
                     "(weights missing — usually an interrupted download). "
                     "Open Settings → Models, delete the OmniVoice TTS model, "
                     "and install it again."
                 ) from e
-            raise
+            _set_loading("loading_weights", f"Loading TTS weights on {device}…")
+            try:
+                _model = _load()
+            except OSError as e2:
+                # Repair ran but the cache is still unusable (e.g. the repo
+                # genuinely lacks weights, or the disk is corrupt). Fall back
+                # to the actionable message rather than the raw error.
+                raise RuntimeError(
+                    f"The TTS model cache for {checkpoint} is incomplete and "
+                    "could not be auto-repaired. Open Settings → Models, delete "
+                    "the OmniVoice TTS model, and install it again."
+                ) from e2
 
         try:
             # plan-02 (#65): gate on Triton availability (+ user setting), not

--- a/tests/test_model_cache_repair.py
+++ b/tests/test_model_cache_repair.py
@@ -1,0 +1,149 @@
+"""Regression tests for #581: an incomplete/corrupt TTS model cache must
+self-repair (re-fetch the missing files) instead of dead-ending the user with
+a manual delete-and-reinstall instruction.
+
+The old behavior raised a RuntimeError on the *first* truncated-cache OSError.
+The fix makes `_load_model_sync` attempt an in-place `snapshot_download` repair
+and retry the load once before surfacing the actionable message — so these
+tests fail before the fix (no repair is attempted; load_asr default path raises
+RuntimeError) and pass after.
+"""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def model_manager(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+
+    import services.model_manager as mm
+
+    monkeypatch.setattr(mm, "_torch", None)
+    monkeypatch.setattr(mm, "_OmniVoice", None)
+    monkeypatch.setattr(mm, "model", None)
+    monkeypatch.setenv("OMNIVOICE_MODEL", "test/checkpoint")
+    monkeypatch.delenv("OMNIVOICE_PRELOAD_TTS_ASR", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    monkeypatch.setattr(mm, "_lazy_torch", lambda: SimpleNamespace(float16="float16"))
+    monkeypatch.setattr(mm, "get_best_device", lambda: "cpu")
+    return mm
+
+
+_TRUNCATED = OSError(
+    "test/checkpoint does not appear to have a file named pytorch_model.bin "
+    "or model.safetensors"
+)
+
+
+def test_incomplete_cache_error_detection(model_manager):
+    assert model_manager._is_incomplete_cache_error(_TRUNCATED) is True
+    # An unrelated OSError must NOT be classified as an incomplete cache.
+    assert model_manager._is_incomplete_cache_error(OSError("disk full")) is False
+
+
+def test_complete_cache_does_not_trigger_repair(model_manager, monkeypatch):
+    """Fast path: a complete cache loads on the first try with no repair call."""
+    repair_calls = []
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache",
+        lambda checkpoint: repair_calls.append(checkpoint) or True,
+    )
+
+    class GoodOmniVoice:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: GoodOmniVoice)
+
+    loaded = model_manager._load_model_sync()
+    assert loaded.llm is not None
+    assert repair_calls == []  # repair never attempted on a healthy cache
+
+
+def test_incomplete_cache_self_repairs_and_retries(model_manager, monkeypatch):
+    """The core #581 fix: the first load hits a truncated cache, repair runs,
+    and the retried load succeeds — no RuntimeError surfaces to the user."""
+    repair_calls = []
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache",
+        lambda checkpoint: repair_calls.append(checkpoint) or True,
+    )
+
+    class FlakyOmniVoice:
+        attempts = 0
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            cls.attempts += 1
+            if cls.attempts == 1:
+                raise _TRUNCATED
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: FlakyOmniVoice)
+
+    loaded = model_manager._load_model_sync()
+    assert loaded.llm is not None
+    assert repair_calls == ["test/checkpoint"]
+    assert FlakyOmniVoice.attempts == 2  # load, repair, reload
+
+
+def test_repair_failure_surfaces_actionable_message(model_manager, monkeypatch):
+    """If repair can't fix the cache, the user still gets the actionable
+    delete-and-reinstall message (not a raw transformers OSError)."""
+    monkeypatch.setattr(model_manager, "_repair_model_cache", lambda checkpoint: False)
+
+    class BrokenOmniVoice:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise _TRUNCATED
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: BrokenOmniVoice)
+
+    with pytest.raises(RuntimeError, match="incomplete"):
+        model_manager._load_model_sync()
+
+
+def test_repair_skipped_in_offline_mode(model_manager, monkeypatch):
+    """Offline mode must not trigger a network re-fetch the user opted out of."""
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    called = []
+    monkeypatch.setattr(
+        "huggingface_hub.snapshot_download",
+        lambda *a, **k: called.append((a, k)),
+    )
+    assert model_manager._repair_model_cache("test/checkpoint") is False
+    assert called == []  # no download attempted offline
+
+
+def test_repair_invokes_snapshot_download(model_manager, monkeypatch):
+    """Repair re-fetches the repo via snapshot_download (resume/fill missing)."""
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return "/cache/test/checkpoint"
+
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    assert model_manager._repair_model_cache("test/checkpoint") is True
+    assert calls and calls[0]["repo_id"] == "test/checkpoint"
+
+
+def test_repair_returns_false_when_download_fails(model_manager, monkeypatch):
+    """A failed re-fetch (no network, gated repo) returns False, never raises."""
+    import huggingface_hub
+
+    def boom(**kwargs):
+        raise OSError("network down")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", boom)
+    assert model_manager._repair_model_cache("test/checkpoint") is False


### PR DESCRIPTION
## Root cause

An interrupted first download leaves the HuggingFace cache holding the small files (config, tokenizer) but missing the weight shard. `OmniVoice.from_pretrained` then raises an `OSError` — *"does not appear to have a file named pytorch_model.bin or model.safetensors"* — and `backend/services/model_manager.py::_load_model_sync` translated that into a `RuntimeError` (surfaced as the 500 in #581) that just told the user to **delete the model and reinstall it manually**. That's a dead-end: the data needed to fix it (which files are missing) is known, and `snapshot_download` already knows how to resume/fill exactly those.

Notably, the install path (`api/routers/setup/download.py`) already validates weights and retries — but a cache truncated *before* that validation, or by an external interruption, only ever fails later at load time, where there was no recovery.

## The fix

In `_load_model_sync`, when the load fails with the truncated-cache `OSError`:

1. Detect it via `_is_incomplete_cache_error` (matches the stable transformers message, not the broad `OSError` type — unrelated I/O errors still propagate).
2. Call `_repair_model_cache(checkpoint)` → `snapshot_download(repo_id=…)`, which **re-fetches only the missing files** (already-present, correctly-sized blobs are skipped by hash). A complete cache never reaches this branch, so the **fast path is untouched** and there's no needless re-download.
3. Retry the load once. On success the user never sees an error.
4. If repair is impossible or still fails, the **actionable delete-and-reinstall message is preserved** as the fallback.

**Offline-safe / local-first:** `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` short-circuit repair (no network call the user opted out of) and fall straight through to the actionable message. **Backward-compatible:** operates on the existing on-disk cache in place; respects `HF_ENDPOINT` mirrors and the Windows no-symlink convention used by the install path. Repair is best-effort and never raises.

## Test

`tests/test_model_cache_repair.py` (7 cases), driving `_load_model_sync` with a dummy `OmniVoice` the same way the existing preload test does:

- completeness-error classification (truncated vs. unrelated `OSError`)
- **fast path**: healthy cache loads with zero repair calls
- **self-repair + retry**: first load raises truncated, repair runs, retried load succeeds, no error surfaces
- repair-failure → actionable `RuntimeError` fallback
- offline mode skips the network re-fetch
- repair invokes `snapshot_download` with the right `repo_id`
- a failed re-fetch returns `False` (never raises)

Fail-before / pass-after confirmed: on `main` the suite fails (`_repair_model_cache` doesn't exist); with the fix all 7 pass.

## Gates

- `pytest tests/test_model_cache_repair.py tests/test_model_manager_preload.py` → **10 passed**
- `pytest tests/test_model_load_timeout.py tests/test_fdl_download_preflight.py tests/test_setup_preflight.py tests/test_models_catalog.py` → **32 passed, 5 skipped**

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes issue `#581` where interrupted OmniVoice TTS model downloads result in incomplete HuggingFace caches that prevent the model from loading. Rather than immediately failing with a 500 error instructing users to manually delete and reinstall the model, the system now automatically detects and repairs the corrupted cache by re-fetching only missing weight files.

## Changes

**CHANGELOG.md**
- Added entry documenting that interrupted OmniVoice downloads now self-repair on the next synthesis request
- Notes automatic detection of truncated cache state, re-fetching of missing weight shards, automatic retry, and fallback to manual delete-reinstall guidance if repair fails

**backend/services/model_manager.py**
- Added `_is_incomplete_cache_error()` function that detects the specific transformers OSError message indicating missing weight files (rather than broad OSError types)
- Added `_is_offline_mode()` function that checks `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE` environment variables
- Added `_repair_model_cache()` function that invokes `huggingface_hub.snapshot_download` to re-fetch missing files, skipping already-present correctly-sized blobs by hash
- Refactored `_load_model_sync()` to wrap the OmniVoice load with expanded OSError handling: on incomplete-cache error detection, sets status to "repairing", attempts repair, retries load once, and falls back to actionable error message if repair fails or is disabled (offline mode)

**tests/test_model_cache_repair.py** (new file)
- 7 regression test cases covering: error classification, healthy cache fast path (no repair), truncated cache auto-repair with retry, repair failure fallback, offline mode behavior, correct `repo_id` invocation, and graceful failure handling

## Behavioral Flow

```mermaid
flowchart TD
    A["Load OmniVoice model"] --> B["Attempt from_pretrained"]
    B --> C{Load successful?}
    C -->|Yes| D["Return model"]
    C -->|No - other error| E["Raise original error"]
    C -->|No - incomplete cache| F["Check offline mode"]
    F -->|Offline enabled| G["Return repair failed"]
    F -->|Online allowed| H["Call snapshot_download<br/>to re-fetch missing files"]
    H --> I{Repair successful?}
    I -->|No| G["Return repair failed"]
    I -->|Yes| J["Retry from_pretrained"]
    J --> K{Retry successful?}
    K -->|Yes| D["Return model"]
    K -->|No| L["Raise actionable<br/>delete-and-reinstall error"]
    G --> L
```

All existing tests remain unaffected. The fast path (already-complete cache) incurs no overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->