### PR TITLE
fix(ui): dub play button + designer script resize on Windows (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **Dubbing: the PLAY button on the dubbed-video preview did nothing.** Same
+  autoplay-policy trap that #510 fixed for the standalone audio player, but the
+  dub editor's timeline player was missed. WaveSurfer builds its `AudioContext`
+  at mount — before any user gesture — so on Windows WebView2 (and Linux
+  Firefox/Chrome, Android Chrome) it stays `"suspended"`; `playPause()` then
+  resolves with no sound and the preview just sits there. Every playback entry
+  point in the dub timeline (the toolbar Play button and the per-segment "play
+  this slot") now resumes the context via the shared `unlockAudio()` on the
+  click before starting playback, and swallowed play() rejections are logged
+  instead of hidden. A source-contract regression test pins the invariant so a
+  future refactor can't quietly reintroduce a silent play path. macOS is
+  unaffected (its context was never blocked). (#595)
+- **Voice design: the script text field couldn't be expanded.** The Script
+  textarea was a `flex: 1` item inside a flex column, so flex-grow recomputed
+  its height on every reflow and snapped the user's drag back — `resize:
+  vertical` is silently ignored on a flex-grown item in Chromium/WebView2. The
+  field now owns its own height (starts taller, and the corner grip grows it
+  reliably on every platform). (#595)
 
 ## [0.3.7] — 2026-06-20
 

--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -5,6 +5,7 @@ import TimelinePlugin from 'wavesurfer.js/dist/plugins/timeline.esm.js';
 import { Play, Pause, ZoomIn, ZoomOut, SkipBack, Loader, Keyboard, AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
+import { unlockAudio } from '../utils/audioUnlock';
 import SegmentTrack from './SegmentTrack';
 import './WaveformErrorBoundary.css';
 
@@ -489,7 +490,10 @@ function WaveformTimeline({
   // timeupdate watcher wired in the init effect. Used by the SegmentTrack
   // ("play this slot") on whatever media the player currently holds, so it
   // respects the original/dubbed preview toggle for free.
-  const playRange = useCallback((start, end) => {
+  const playRange = useCallback(async (start, end) => {
+    // Same autoplay-policy unlock as togglePlay (#595): resume the suspended
+    // AudioContext on this user gesture before kicking off playback.
+    try { await unlockAudio(); } catch { /* ignore */ }
     playRangeEndRef.current = end;
     const ws = wsRef.current;
     if (ws) {
@@ -517,14 +521,22 @@ function WaveformTimeline({
     }
   }, []);
 
-  const togglePlay = useCallback(() => {
+  const togglePlay = useCallback(async () => {
+    // Browser autoplay policy (Linux FF/Chrome, Windows WebView2, Android
+    // Chrome): WaveSurfer's AudioContext is constructed at mount — before any
+    // user gesture — and stays "suspended", so playPause() resolves without a
+    // sound and the dub video preview just sits there (#595, same class as
+    // #510 already fixed in WaveformPlayer). This click IS the gesture —
+    // explicitly resume before play. No-op on macOS where it never blocked.
+    try { await unlockAudio(); } catch { /* play() will surface real errors */ }
     if (wsRef.current) {
-      wsRef.current.playPause();
+      try { await wsRef.current.playPause(); }
+      catch (e) { console.warn('WaveformTimeline: play failed:', e); }
     } else if (mediaElRef.current) {
       // Fallback: control the native media element directly
       const el = mediaElRef.current;
       if (el.paused) {
-        el.play().catch(() => {});
+        el.play().catch((e) => console.warn('WaveformTimeline: play failed:', e));
       } else {
         el.pause();
       }

--- a/frontend/src/components/WaveformTimeline.unlock.test.js
+++ b/frontend/src/components/WaveformTimeline.unlock.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+// Regression guard for #595 — the dubbed-video PLAY button did nothing.
+//
+// WaveSurfer constructs its AudioContext at mount (before any user gesture), so
+// on Windows WebView2 / Linux FF / Android Chrome it stays "suspended" and
+// playPause() resolves silently with no sound. WaveformPlayer was already fixed
+// for this in #510 by awaiting unlockAudio() on the click; WaveformTimeline (the
+// dub editor's player) was missed — that's this bug.
+//
+// Driving WaveSurfer + a real AudioContext through jsdom is brittle, so this is
+// a source-level contract guard: every playback entry point in WaveformTimeline
+// must resume the AudioContext via unlockAudio() before it kicks off playback.
+// It fails-before (no import / no await) and passes-after the fix, and pins the
+// invariant so a future refactor can't quietly reintroduce a silent play path.
+
+// Vitest runs with cwd = frontend/, so resolve the component from there.
+const src = readFileSync(
+  path.resolve(process.cwd(), 'src/components/WaveformTimeline.jsx'),
+  'utf8',
+);
+
+describe('WaveformTimeline autoplay-unlock wiring (#595)', () => {
+  it('imports the shared unlockAudio helper', () => {
+    expect(src).toMatch(/import\s*\{\s*unlockAudio\s*\}\s*from\s*['"]\.\.\/utils\/audioUnlock['"]/);
+  });
+
+  it('awaits unlockAudio() before playing in every playback entry point', () => {
+    // Each playback handler must resume the context first. Grab the body of
+    // each handler and assert the unlock await precedes the play/playPause call.
+    const handlers = {
+      togglePlay: /const togglePlay = useCallback\(async \(\) => \{([\s\S]*?)\}, \[\]\);/.exec(src)?.[1],
+      playRange: /const playRange = useCallback\(async \(start, end\) => \{([\s\S]*?)\}, \[\]\);/.exec(src)?.[1],
+    };
+    for (const [name, body] of Object.entries(handlers)) {
+      expect(body, `${name} handler not found`).toBeTruthy();
+      const unlockAt = body.indexOf('await unlockAudio()');
+      expect(unlockAt, `${name} must await unlockAudio()`).toBeGreaterThanOrEqual(0);
+      const playAt = body.search(/\.play(Pause)?\(/);
+      expect(playAt, `${name} must call play`).toBeGreaterThanOrEqual(0);
+      expect(unlockAt, `${name} must unlock before play`).toBeLessThan(playAt);
+    }
+  });
+});

--- a/frontend/src/pages/CloneDesignTab.css
+++ b/frontend/src/pages/CloneDesignTab.css
@@ -272,12 +272,16 @@
 
 /* Text input + textarea tweaks */
 .clone-text-area {
-  flex: 1;
-  /* Re-enable the corner grip (matches base textarea.input-base). The ⊕ Insert
-     button is lifted off the bottom-right so it no longer covers the handle
-     (#481). */
+  /* #595: the script field "couldn't be expanded". It was `flex: 1` inside a
+     flex column, so flex-grow recomputed its height on every reflow and
+     snapped the user's drag back — `resize: vertical` is silently ignored on a
+     flex-grown item in Chromium/WebView2 (Windows). Drop flex-grow (`flex: 0 1
+     auto`) so the textarea owns its height: it starts at min-height and the
+     corner grip now grows it reliably on every platform. The ⊕ Insert button is
+     lifted off the bottom-right so it doesn't cover the grip (#481). */
+  flex: 0 1 auto;
   resize: vertical;
-  min-height: 60px;
+  min-height: 160px;
   margin-bottom: 6px;
 }
 .clone-auto-extract-btn { border-color: #b8bb26; color: #b8bb26; }


### PR DESCRIPTION
Fixes both UI bugs from #595 (reported on v0.3.7, Windows/CUDA), with screenshots showing a blank dubbed-video preview and a script field that won't grow.

## Bug 1 — PLAY on the dubbed-video preview does nothing

**Root cause.** The dub editor's player (`WaveformTimeline`) drives WaveSurfer, which constructs its `AudioContext` at component-mount — *before* any user gesture. Under Windows WebView2 (and Linux Firefox/Chrome, Android Chrome) that context stays `"suspended"`, so `playPause()` resolves with no sound and the preview just sits there as a blank box. This is the exact autoplay-policy trap **#510** already fixed for the standalone `WaveformPlayer` (it `await unlockAudio()` on the click) — but the dub timeline player was never given the same treatment. macOS auto-resumes on first interaction, which is why it only reproduced cross-platform.

**Fix.** Both playback entry points in `WaveformTimeline` — the toolbar `togglePlay` and the per-segment `playRange` ("play this slot") — now `await unlockAudio()` (the shared, already-tested helper from #510) on the user gesture before starting playback. Swallowed `play()` rejections are now logged instead of hidden (that silent-catch is exactly how "click does nothing" stayed invisible).

## Bug 2 — designer Script text field can't be expanded

**Root cause.** `.clone-text-area` was a `flex: 1` item inside `.clone-script-wrap` (a flex column). Flex-grow recomputes the textarea's height on every reflow, so dragging the corner grip is immediately snapped back — `resize: vertical` is silently ignored on a flex-grown item in Chromium/WebView2. The grip appeared dead.

**Fix.** Drop flex-grow (`flex: 0 1 auto`) so the textarea owns its own height: it starts taller (`min-height: 160px`) and the corner grip now grows it reliably on every platform. Pure CSS — no testable JS logic, so no unit test for this one (a layout/resize gesture isn't meaningfully exercisable in jsdom).

I checked the other raw textareas (`StoriesEditor`, `AudiobookTab`, `VoicePreview`) for the same `flex:1`+`resize` class of bug — none share it (they use plain `min-height`, or deliberately `resize: none`), so the fix is correctly scoped.

## Test

`frontend/src/components/WaveformTimeline.unlock.test.js` — a source-contract regression guard asserting every playback entry point awaits `unlockAudio()` *before* it calls play. Verified fail-before (removing the await fails it) / pass-after. It pins the invariant so a future refactor can't quietly reintroduce a silent play path.

## Gates

- `bun run build` — passes
- `bunx vitest run` — **563 tests, all pass** (67 files)
- `bun install --frozen-lockfile` — passes (no dependency/lockfile change)

No new user-facing strings introduced (i18n rule respected); CHANGELOG `## [Unreleased]` updated in house style.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes two critical UI bugs affecting Windows users on version 0.3.7:

1. **Play button non-functional on dubbed-video preview** — WaveSurfer's AudioContext remains suspended on Windows WebView2, Linux Firefox/Chrome, and Android Chrome, blocking playback. The fix adds `await unlockAudio()` calls at both playback entry points before starting audio.

2. **Designer script text field cannot be expanded** — The textarea had `flex: 1` applied, causing the flex container to recalculate height on every reflow and block manual resizing. The fix removes flex-grow and increases min-height to restore resize functionality.

## Changes

### WaveformTimeline.jsx — Autoplay Policy Handling

The component now respects browser autoplay policies by awaiting an audio-unlock helper before starting playback:

```mermaid
graph TD
    A["User clicks Play or\nTriggered playRange"] --> B{togglePlay or<br/>playRange called}
    B -->|async| C["await unlockAudio()"]
    C --> D{Resume AudioContext}
    D -->|Success| E["Call playPause() or<br/>play()"]
    D -->|Fail| F["Log error, continue"]
    E --> G["Audio playback begins"]
    F --> G
```

**Key changes:**
- `togglePlay()` and `playRange()` are now `async` functions
- Both await `unlockAudio()` before invoking playback
- Play failures are now logged via `console.warn` instead of being silently swallowed

### CloneDesignTab.css — Text Area Resize Fix

**Before:**
```
┌─────────────────────────────┐
│  Clone Design Tab           │
├─────────────────────────────┤
│  Script text field:         │
│  ┌───────────────────────┐  │
│  │ [text grows to fill]  │  │
│  │ [flex: 1 prevents     │  │
│  │  manual resize]       │  │
│  └───────────────────────┘  │
│                 ↑ dragging blocked
│  [Insert button below]      │
└─────────────────────────────┘
```

**After:**
```
┌─────────────────────────────┐
│  Clone Design Tab           │
├─────────────────────────────┤
│  Script text field:         │
│  ┌───────────────────────┐  │
│  │ min-height: 160px     │  │
│  │ flex: 0 1 auto        │  │
│  │ [manual resize works] │  │
│  │                       │  │
│  └───────────────────────┘  │ ← drag to resize
│  [Insert button below]      │
└─────────────────────────────┘
```

**CSS updates:**
- Changed `flex: 1` to `flex: 0 1 auto` (removes flex-grow)
- Increased `min-height` from `60px` to `160px`
- `resize: vertical` now functions reliably

### Test Coverage

A regression test (`WaveformTimeline.unlock.test.js`) was added to ensure:
- The `unlockAudio` helper is imported from the correct path
- Both playback entry points (`togglePlay` and `playRange`) are async
- Both await `unlockAudio()` before calling play/playPause
- Test uses regex inspection to verify function body ordering

### Documentation

CHANGELOG.md updated with two entries under `### Fixed`:
1. Dubbed-video preview now properly resumes audio context on play
2. Voice design script text field now resizes reliably

**Test results:** All 563 tests pass. No dependency changes. No exports modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->