### PR TITLE
fix(transcribe): surface the real ASR-load failure instead of generic "stream dropped" (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,25 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-_Nothing yet — `main` is at v0.3.7 + 1 patch. New work lands here._
+### Fixed
+
+- **"Transcribe stream dropped … Likely ASR backend failed to load" now shows
+  the *real* reason.** When transcription failed to load its ASR model (the
+  reported case was WhisperX on Windows — typically a faster-whisper /
+  CTranslate2-cuDNN mismatch, a missing model download, or the torch-2.6
+  weights-only VAD regression), the UI dead-ended on a generic "stream dropped"
+  message with no actionable cause. Two root causes: (1) WhisperX loads lazily
+  *inside* transcription, so the load failure was buried in per-chunk errors and
+  retried on every chunk; the transcribe pre-flight now eagerly loads the ASR
+  model (new `ASRBackend.ensure_loaded()`), surfacing the genuine cause once, up
+  front, as a structured error. (2) Pre-flight and audio-load errors closed the
+  SSE stream with a bare `error` and no terminal `done`, so the browser's native
+  EventSource connection-drop could race and win against the structured error —
+  discarding the real cause and falling back to the generic message; every
+  terminal error now emits `done`, and the frontend latches the structured cause
+  so a connection drop can't overwrite it. Net: WhisperX load failures are
+  diagnosable instead of a silent dead-end. Fail-before/pass-after regression
+  test included. (#578)
 
 ## [0.3.7] — 2026-06-20
 

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -425,10 +425,22 @@ async def dub_transcribe_stream(
                 try:
                     # The PyTorch-Whisper backend lazily builds its own pipeline
                     # when no preloaded `_asr_pipe` is present (issue #255), so it
-                    # no longer needs OMNIVOICE_PRELOAD_TTS_ASR=1 — don't reject it
-                    # here; any load failure surfaces per-chunk with a real cause.
+                    # no longer needs OMNIVOICE_PRELOAD_TTS_ASR=1.
                     _asr_backend = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
+                    # Eagerly load the model HERE so a real load failure (e.g.
+                    # WhisperX: missing weights, CTranslate2/cuDNN mismatch, the
+                    # torch-2.6 weights-only VAD regression) surfaces once, with
+                    # its actual cause, as a clean preflight `error` event —
+                    # instead of being buried in N cryptic per-chunk failures
+                    # and retried on every chunk (#578). Run in a thread so the
+                    # (blocking) load doesn't stall the event loop.
+                    _ensure_loaded = getattr(_asr_backend, "ensure_loaded", None)
+                    if callable(_ensure_loaded):
+                        await asyncio.get_running_loop().run_in_executor(
+                            _gpu_pool, _ensure_loaded
+                        )
                 except Exception as e:
+                    logger.exception("transcribe preflight: ASR load failed (job=%s)", job_id)
                     from core.failure import build_failure
                     f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
                     preflight_error = "ASR backend initialization failed: " + f["reason"] + (
@@ -438,7 +450,14 @@ async def dub_transcribe_stream(
 
     async def _gen_body():
         if preflight_error:
-            yield _sse_event("error", {"detail": preflight_error})
+            # Always follow a terminal `error` with `done` so the stream closes
+            # via a named event, not a raw connection drop. A bare error+close
+            # races the browser's native EventSource error (which carries no
+            # `data`); if that native error wins, the client falls back to the
+            # misleading generic "stream dropped … ASR backend failed" message
+            # and the real cause (in `detail`) is lost (#578).
+            yield _sse_event("error", {"detail": preflight_error, "retryable": True})
+            yield _sse_event("done", {})
             return
         import math
         import tempfile
@@ -453,7 +472,9 @@ async def dub_transcribe_stream(
         try:
             audio_np, sr = await loop.run_in_executor(_cpu_pool, _load)
         except Exception as e:
-            yield _sse_event("error", {"detail": f"audio load failed: {e}"})
+            # Terminal error → always emit `done` (see preflight note, #578).
+            yield _sse_event("error", {"detail": f"audio load failed: {e}", "retryable": True})
+            yield _sse_event("done", {})
             return
 
         total = float(len(audio_np)) / float(sr) if sr else 0.0

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -129,6 +129,22 @@ class ASRBackend(ABC):
         that already speak the shape plug in with zero adapter work.
         """
 
+    def ensure_loaded(self) -> None:
+        """Eagerly load the model weights, raising the real cause on failure.
+
+        Backends load lazily inside ``transcribe()`` by default, so a load
+        failure (missing weights, CUDA/cuDNN mismatch, torch-2.6 weights-only
+        VAD regression, import error) first surfaces buried in per-chunk
+        errors — and is retried on *every* chunk. The transcribe preflight
+        calls this so the genuine cause is surfaced once, up front, as a clean
+        terminal error event instead of N cryptic per-chunk failures (#578).
+
+        Default is a no-op; backends that hold a heavy model override it to
+        trigger their lazy loader. It MUST raise the underlying exception (not
+        swallow it) so the caller can classify and surface it.
+        """
+        pass
+
     def unload(self) -> None:
         """Release the model from memory."""
         pass
@@ -170,6 +186,13 @@ class WhisperXBackend(ASRBackend):
             return True, "ready"
         except ImportError as e:
             return False, f"whisperx not installed: {e}"
+
+    def ensure_loaded(self) -> None:
+        # Surface a whisperx/CTranslate2/torch load failure at preflight (once,
+        # with the real cause) instead of buried per-chunk and retried N times
+        # (#578). Re-raises whatever `_ensure_asr` raises after its fp16→int8
+        # and OOM→CPU fallbacks are exhausted.
+        self._ensure_asr()
 
     def _ensure_asr(self):
         if self._asr is not None:

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -80,6 +80,13 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     const numSpeakers = useAppStore.getState().dubNumSpeakers;
     const evt = new EventSource(transcribeStreamUrl(jobId, numSpeakers));
     let gotFinal = false;
+    // Latch the real cause from a named `error` event. EventSource also fires
+    // its *native* error (no `data`) on any connection close, which can race
+    // and win against the backend's structured `error` event — if it did, we
+    // used to throw away the real cause and show the generic "stream dropped …
+    // ASR backend failed" message (#578). Holding the detail here lets the
+    // native-close handler surface the real cause instead.
+    let lastErrorDetail = null;
     const close = () => { try { evt.close(); } catch {} };
     const onAbortSignal = () => { close(); reject(Object.assign(new Error('aborted'), { name: 'AbortError' })); };
     ctrl.signal.addEventListener('abort', onAbortSignal, { once: true });
@@ -125,7 +132,18 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     evt.addEventListener('done', () => { close(); ctrl.signal.removeEventListener('abort', onAbortSignal); resolve(); });
     evt.addEventListener('aborted', () => { close(); ctrl.signal.removeEventListener('abort', onAbortSignal); reject(Object.assign(new Error('aborted'), { name: 'AbortError' })); });
     evt.addEventListener('error', (e) => {
-      try { const m = e.data ? JSON.parse(e.data) : null; if (m && m.detail) { close(); reject(new Error(m.detail)); return; } } catch {}
+      // A named `error` event carries the real cause in `data.detail`. Latch
+      // it AND reject with it. The backend now always follows it with `done`,
+      // but we reject eagerly here so the cause survives even if the native
+      // connection-drop error arrives first/concurrently (#578).
+      try {
+        const m = e.data ? JSON.parse(e.data) : null;
+        if (m && m.detail) { lastErrorDetail = m.detail; close(); reject(new Error(m.detail)); return; }
+      } catch { /* malformed error payload — fall through */ }
+      // No fresh detail on this event (native EventSource connection error).
+      // If we already saw a structured error, surface its cause, not the
+      // generic message.
+      if (lastErrorDetail) { close(); reject(new Error(lastErrorDetail)); return; }
       if (gotFinal) { close(); resolve(); return; }
       close();
       reject(new Error('Transcribe stream dropped before emitting any segments. Likely ASR backend failed to load — check backend log + Settings → Models.'));

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -173,6 +173,8 @@ def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeyp
 
     class _FakeASR:
         id = "fake"
+        def ensure_loaded(self):  # preflight eager-load (no-op for the fake)
+            pass
         def transcribe(self, path, *, word_timestamps=True):
             return {"chunks": [{"text": "hi", "timestamp": (0.0, 0.5)}],
                     "segments": [], "language": "en"}
@@ -210,6 +212,79 @@ def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeyp
     err_idx = body.rfind("event: error")
     done_idx = body.rfind("event: done")
     assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"
+
+
+def test_transcribe_stream_surfaces_asr_load_failure_at_preflight(tmp_path, monkeypatch):
+    """Regression #578: the reported failure mode is the *ASR model* failing to
+    load (WhisperX: faster-whisper weights / CTranslate2-cuDNN mismatch / the
+    torch-2.6 weights-only VAD regression), not the TTS model. Because WhisperX
+    loads lazily inside ``transcribe()``, that failure used to be buried in N
+    per-chunk errors (and the bare error event raced the browser's native
+    connection-drop, so the UI showed the misleading generic "stream dropped …
+    ASR backend failed to load").
+
+    The preflight now eagerly calls ``backend.ensure_loaded()`` so the *real*
+    cause surfaces once, as a structured ``error`` event, ALWAYS followed by a
+    terminal ``done`` (so the stream closes via a named event, never a raw
+    drop the client can only render generically).
+    """
+    import asyncio
+    from api.routers import dub_core as dc
+
+    job_id = "t_asrload"
+    audio = tmp_path / "a.wav"
+    _make_wav(audio, seconds=1.0)
+    dc._dub_jobs[job_id] = {
+        "audio_path": str(audio), "vocals_path": None, "scene_cuts": [],
+    }
+
+    # TTS model loads fine; the *ASR backend* fails to load — the #578 case.
+    fake_model = MagicMock()
+    fake_model._asr_pipe = None
+
+    async def _ok_model():
+        return fake_model
+
+    class _BoomASR:
+        id = "whisperx"
+        def ensure_loaded(self):
+            raise RuntimeError(
+                "Could not load library libcudnn_ops_infer.so.8: simulated"
+            )
+        def transcribe(self, path, *, word_timestamps=True):  # pragma: no cover
+            raise AssertionError("transcribe must not run when load fails")
+        def unload(self):
+            pass
+
+    monkeypatch.setattr(dc, "get_model", _ok_model)
+    monkeypatch.setattr(
+        "services.asr_backend.get_active_asr_backend",
+        lambda *a, **k: _BoomASR(),
+    )
+
+    async def _collect():
+        resp = await dc.dub_transcribe_stream(job_id)
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk))
+        return "".join(parts)
+
+    try:
+        body = asyncio.run(_collect())
+    finally:
+        dc._dub_jobs.pop(job_id, None)
+
+    # Real cause surfaced as a structured error, not the generic "stream dropped".
+    assert "event: error" in body, body
+    assert "ASR backend initialization failed" in body, body
+    assert "libcudnn_ops_infer.so.8: simulated" in body, body
+    assert "stream dropped" not in body, body
+    # And it must be followed by a terminal `done` so the client closes via a
+    # named event — never a bare error+connection-drop (which races the
+    # browser's native EventSource error and loses the real cause).
+    err_idx = body.find("event: error")
+    done_idx = body.find("event: done")
+    assert done_idx > err_idx >= 0, f"error must be followed by terminal done: {body}"
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Root cause

A user selected **WhisperX** and transcription failed after a few seconds with the generic, dead-end message:

> Transcribe stream dropped before emitting any segments. Likely ASR backend failed to load — check backend log + Settings → Models.

That message is the frontend's *fallback* — it only fires when the SSE stream closes without delivering a structured cause. Two independent reasons the real cause was lost:

1. **WhisperX loads its model lazily inside `transcribe()`**, not at pre-flight. So an actual load failure (faster-whisper weights, a CTranslate2/cuDNN mismatch, the torch-2.6 `weights_only` VAD regression, a missing first-run download) was buried in per-chunk errors *and* re-attempted on every chunk. The pre-flight `get_active_asr_backend()` only *constructs* the backend object — it never validates that the model can load.

2. **Terminal `error` events weren't always followed by `done`.** The pre-flight-error and audio-load-error paths emitted a bare `error` then closed the connection. The browser's EventSource *also* fires a native `error` event (with no `data`) on any connection close — that native event can race and win against the named `error` event, so the frontend discarded the real `detail` and showed the generic message.

## Fix

- **`ASRBackend.ensure_loaded()`** (new): default no-op; `WhisperXBackend` overrides it to trigger its lazy loader (re-raising after its existing fp16→int8 and OOM→CPU fallbacks are exhausted). The transcribe pre-flight now calls it in the executor, so a genuine ASR-load failure surfaces **once, up front**, as a structured `error` event with the actual cause — not buried per-chunk.
- **Every terminal `error` now emits `done`** (pre-flight + audio-load paths), so the stream always closes via a named event, never a raw connection drop that races the browser's native error.
- **Frontend latches the structured cause** (`lastErrorDetail`): if a native connection-drop error fires after a named `error` event was received, it surfaces the real cause instead of the generic "stream dropped" message.

The class fix is the invariant *"a terminal SSE error is always (a) the real cause and (b) followed by `done`, and the client never overwrites a known cause with the generic fallback."*

## Test

`tests/test_dub_transcribe.py::test_transcribe_stream_surfaces_asr_load_failure_at_preflight` drives the stream's async generator with an ASR backend whose `ensure_loaded()` raises a cuDNN-style error, and asserts the body contains the real cause (`ASR backend initialization failed: … libcudnn… simulated`), does **not** contain `stream dropped`, and ends with a terminal `done` after the `error`.

**Fail-before verified**: with the pre-flight `ensure_loaded` call removed, the test fails (`transcribe` runs and the cause never surfaces). **Pass-after**: green. The existing #516 fake backend was updated to the new `ensure_loaded()` contract.

## Gates

- `uv run python -m pytest tests/test_dub_transcribe.py tests/test_pytorch_whisper_fallback.py tests/test_diarization_weights_only.py` → **9 passed, 8 xfailed, 3 xpassed**
- `node --check` on the edited hook → syntax OK

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes ASR transcription failures by surfacing the real underlying cause of WhisperX/ASR initialization problems instead of showing a generic fallback like “Transcribe stream dropped … Likely ASR backend failed to load.” It addresses (1) lazy WhisperX model loading that delayed and obscured failures, and (2) an SSE event-order race where connection-drop errors could override the structured error payload.

## Key Changes

### Backend (Error Generation / Stream Semantics)
- **New `ASRBackend.ensure_loaded()` hook (default no-op)** in `backend/services/asr_backend.py`, allowing backends to eagerly validate model readiness during transcription preflight.
- **`WhisperXBackend.ensure_loaded()` override** to trigger its internal `_ensure_asr()` so model/load failures surface immediately during preflight rather than later during chunk transcription.
- **Router preflight calls `ensure_loaded()`** in `backend/api/routers/dub_core.py` (via the executor), so ASR initialization failures are emitted once as a structured SSE `error` event.
- **Terminal SSE handling hardened** in `dub_core.py`: all terminal error paths now emit **`error` immediately followed by `done`**, preventing browser EventSource connection-drop races from replacing the structured failure cause. The audio-load failure path also follows the same `error` → `done` pattern and is marked `retryable: True`.

### Frontend (Error Detail Preservation)
- **Structured error latching in `useDubWorkflow`** (`frontend/src/hooks/useDubWorkflow.js`):
  - Initializes a `lastErrorDetail` latch when the SSE opens.
  - Parses SSE `error` event data for `detail` and rejects/terminates using that structured reason.
  - If a native connection-drop error arrives without `detail`, the handler uses the previously latched structured cause instead of falling back to the generic “stream dropped” message.

### Testing
- Updated the existing fake ASR backend used in stream-body-crash coverage to include an `ensure_loaded()` no-op so it satisfies the new preflight contract.
- Added **`test_transcribe_stream_surfaces_asr_load_failure_at_preflight`** in `tests/test_dub_transcribe.py`:
  - Mocks an ASR backend whose `ensure_loaded()` raises `RuntimeError`.
  - Asserts the SSE stream includes an `event: error` with the real initialization failure text (and that “stream dropped” is absent).
  - Asserts the stream ends with a terminal `event: done` after the error.

### Documentation
- **`CHANGELOG.md`**: Added an “Unreleased” **Fixed** entry documenting that transcription preflight now eagerly loads the ASR model via `ASRBackend.ensure_loaded()` and that SSE now emits terminal `done` alongside errors to avoid connection-drop races.

## Error Handling Flow (New)
```mermaid
flowchart TD
  A[SSE stream opened] --> B[Transcription preflight starts]
  B --> C[Router calls ASRBackend.ensure_loaded() in executor]
  C -->|Success| D[Proceed with transcription streaming]
  C -->|Load/Init Error| E[Emit SSE error (structured detail)]
  E --> F[Emit SSE done (terminal close)]
  D --> G[Transcribe / stream segments]
  G -->|Any terminal error| H[Emit SSE error]
  H --> I[Emit SSE done]

  E --> J[Frontend receives SSE error]
  J --> K[Latch structured detail (lastErrorDetail)]
  F --> L[Stream ends]

  G -. native connection-drop race .-> M[Frontend error handler invoked]
  M --> N[If no detail, use latched lastErrorDetail]
  N --> O[Avoid generic "stream dropped" fallback]
```

## Files Modified
- `CHANGELOG.md`
- `backend/api/routers/dub_core.py`
- `backend/services/asr_backend.py`
- `frontend/src/hooks/useDubWorkflow.js`
- `tests/test_dub_transcribe.py`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->