### PR TITLE
feat(stories): tagged-script [Name] parsing → auto multi-voice cast (#487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Added
 
+- **Tagged scripts auto-cast into a multi-voice podcast/audiobook.** Paste a
+  `[Alice] … [Bob] …` script into Stories and hit Auto-cast: it now recognizes
+  the `[Name]` tag format (alongside the existing `NAME:` screenplay and quoted
+  prose), builds the cast, and assigns a voice per character automatically.
+  Editing one line only re-synthesizes that line on export (the chapter cache
+  is content-addressed), and inline markers like `[pause]` / `[voice:…]` are
+  never mistaken for speakers. (#487)
 - **A dedicated Contact page.** Discord, email, GitHub issues, and the project
   website (palash.dev) as clean one-tap rows, reachable from the footer — so
   reaching the maker is never more than a click away.

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -37,7 +37,7 @@
     "pasteSplit": "Paste & Split",
     "import": "Import",
     "autocast": "Auto-cast",
-    "autocastHint": "Detect who's speaking and assign voices automatically",
+    "autocastHint": "Detect who's speaking — tagged ([Name]), screenplay (NAME:), or quoted prose — and assign voices automatically",
     "autocastEmpty": "Nothing to auto-cast — paste or import a story first.",
     "autocastDone": "Auto-cast {{lines}} lines across {{voices}} voice(s)",
     "importFailed": "Couldn't read that file.",

--- a/frontend/src/utils/parseScript.js
+++ b/frontend/src/utils/parseScript.js
@@ -1,14 +1,16 @@
 /**
  * parseScript — turn pasted prose or a screenplay into attributed lines.
  *
- * Two formats are recognised, paragraph by paragraph:
+ * Three formats are recognised:
+ *   0. Tagged script: `[Alice] dialogue` / `[Bob] dialogue` (podcast/audiobook
+ *      style, #487) — auto-detected and parsed by `parseTaggedScript`.
  *   1. Screenplay:  `NAME: dialogue`            → { speaker: NAME, text }
  *   2. Prose:       narration with "quoted" bits → narration goes to the
  *                   Narrator; each quote is attributed to a nearby dialogue
  *                   tag ("said the fox" / "the fox asked").
  *
  * Returns an ordered array of { speaker, text }. Pure + testable; the caller
- * maps speakers → cast members. Speaker "Narrator" is the default fallback.
+ * maps speakers → cast members (autoCast). Speaker "Narrator" is the default.
  */
 
 const TAG_VERBS =
@@ -39,10 +41,75 @@ function attributionName(before, after) {
   return hit ? hit[1] : null;
 }
 
+// ── Tagged-script format: `[Name] dialogue` (#487) ──────────────────────────
+//
+// Inline markers like [pause], [pause 500ms], [voice:ID], [fast], [spell] must
+// NOT be mistaken for speaker tags. A speaker tag is a `[...]` at line start
+// whose bracket content has no `:` (rules out [voice:…]) and whose first word
+// isn't a reserved marker keyword. Everything the parser emits keeps the same
+// { speaker, text } shape as parseScript, so autoCast works unchanged.
+const _RESERVED_MARKERS = new Set([
+  'pause', 'voice', 'fast', 'slow', 'spell', 'laughter', 'sigh', 'breath',
+  'whisper', 'emphasis', 'em', 'break',
+]);
+const _SPEAKER_TAG = /^\s*\[([^\]:]+)\]\s*(.*)$/;
+
+function _isSpeakerTag(name) {
+  const trimmed = String(name || '').trim();
+  if (!trimmed) return false;
+  const first = trimmed.toLowerCase().replace(/^\//, '').split(/\s+/)[0];
+  return !_RESERVED_MARKERS.has(first);
+}
+
+/** True when the text uses `[Name]` speaker tags (so parseScript routes here). */
+export function hasSpeakerTags(text) {
+  return String(text || '')
+    .split(/\r?\n/)
+    .some((line) => {
+      const m = line.match(_SPEAKER_TAG);
+      return !!(m && _isSpeakerTag(m[1]));
+    });
+}
+
+/**
+ * Parse a `[Name] …` tagged script into ordered { speaker, text } lines.
+ * A speaker's block runs until the next `[Name]` tag (multi-line dialogue is
+ * joined). Any prose before the first tag is attributed to the Narrator.
+ */
+export function parseTaggedScript(text) {
+  const out = [];
+  const src = String(text || '').replace(/\r\n/g, '\n').trim();
+  if (!src) return out;
+
+  let cur = { speaker: 'Narrator', parts: [] };
+  const flush = () => {
+    const t = cur.parts.join('\n').trim();
+    if (t) out.push({ speaker: cur.speaker, text: t });
+    cur = { speaker: cur.speaker, parts: [] };
+  };
+
+  for (const line of src.split('\n')) {
+    const m = line.match(_SPEAKER_TAG);
+    if (m && _isSpeakerTag(m[1])) {
+      flush();
+      cur.speaker = normalizeSpeaker(m[1]);
+      if (m[2] && m[2].trim()) cur.parts.push(m[2].trim());
+    } else if (line.trim()) {
+      cur.parts.push(line.trim());
+    }
+  }
+  flush();
+  return out;
+}
+
 export function parseScript(text) {
   const out = [];
   const src = String(text || '').replace(/\r\n/g, '\n').trim();
   if (!src) return out;
+
+  // Tagged scripts (`[Alice] …`) are unambiguous — handle them first so a
+  // pasted podcast/audiobook script auto-casts without any format toggle (#487).
+  if (hasSpeakerTags(src)) return parseTaggedScript(src);
 
   const paras = src
     .split(/\n\s*\n/)

--- a/frontend/src/utils/parseScript.test.js
+++ b/frontend/src/utils/parseScript.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { parseScript, normalizeSpeaker } from './parseScript';
+import {
+  parseScript, normalizeSpeaker, parseTaggedScript, hasSpeakerTags,
+} from './parseScript';
 
 const L = '“'; // “
 const R = '”'; // ”
@@ -53,5 +55,61 @@ describe('parseScript — prose', () => {
   it('returns [] for empty input', () => {
     expect(parseScript('')).toEqual([]);
     expect(parseScript('   ')).toEqual([]);
+  });
+});
+
+describe('parseTaggedScript — [Name] tagged scripts (#487)', () => {
+  it('parses [Name] dialogue lines', () => {
+    const r = parseTaggedScript('[Alice] Hello there.\n[Bob] Hi, Alice!');
+    expect(r).toEqual([
+      { speaker: 'Alice', text: 'Hello there.' },
+      { speaker: 'Bob', text: 'Hi, Alice!' },
+    ]);
+  });
+
+  it('joins multi-line dialogue under one tag until the next tag', () => {
+    const r = parseTaggedScript('[Alice] First line.\nStill Alice.\n[Bob] Now Bob.');
+    expect(r).toEqual([
+      { speaker: 'Alice', text: 'First line.\nStill Alice.' },
+      { speaker: 'Bob', text: 'Now Bob.' },
+    ]);
+  });
+
+  it('attributes prose before the first tag to the Narrator', () => {
+    const r = parseTaggedScript('Intro narration.\n[Alice] My line.');
+    expect(r).toEqual([
+      { speaker: 'Narrator', text: 'Intro narration.' },
+      { speaker: 'Alice', text: 'My line.' },
+    ]);
+  });
+
+  it('normalizes tag names and supports a tag on its own line', () => {
+    const r = parseTaggedScript('[the FOX]\nWhere are we going?');
+    expect(r).toEqual([{ speaker: 'Fox', text: 'Where are we going?' }]);
+  });
+
+  it('does NOT treat inline markers as speakers', () => {
+    // [pause]/[voice:…]/[fast] are synthesis markers, not character tags — they
+    // stay inside the (Narrator) text, never become a cast member.
+    const r = parseTaggedScript('[Alice] Wait [pause 500ms] for it [voice:default].');
+    expect(r).toEqual([
+      { speaker: 'Alice', text: 'Wait [pause 500ms] for it [voice:default].' },
+    ]);
+    expect(hasSpeakerTags('Just narration [pause] here.\n[voice:x] more')).toBe(false);
+  });
+
+  it('hasSpeakerTags detects only real speaker tags', () => {
+    expect(hasSpeakerTags('[Alice] hi')).toBe(true);
+    expect(hasSpeakerTags('FOX: hi')).toBe(false);
+    expect(hasSpeakerTags('plain prose')).toBe(false);
+    expect(hasSpeakerTags('[fast] zoom [/fast]')).toBe(false);
+  });
+
+  it('parseScript auto-routes tagged scripts so autoCast just works', () => {
+    const r = parseScript('[Alice] Hello.\n[Bob] Hi!');
+    expect(r).toEqual([
+      { speaker: 'Alice', text: 'Hello.' },
+      { speaker: 'Bob', text: 'Hi!' },
+    ]);
   });
 });


### PR DESCRIPTION
Paste a `[Alice] … [Bob] …` script into **Stories**, hit **Auto-cast**, and it builds the cast and assigns a voice per character automatically — the tagged-script → multi-voice podcast/audiobook ask in #487.

## Why it's small
The Stories pipeline already does the heavy lifting: `autoCast()` (cast-building + round-robin voice assignment) → `storyToSpans()` → `/longform/render` with a **content-addressed per-chapter cache**. The only missing piece was recognizing the `[Name]` tag format. So this is a focused parser change, no pipeline rework.

## What changed (`frontend/src/utils/parseScript.js`)
- **`parseTaggedScript`** — `[Name] dialogue`, multi-line blocks join until the next tag, prose before the first tag → Narrator.
- **Inline markers are safe** — `[pause]`, `[pause 500ms]`, `[voice:ID]`, `[fast]`, `[spell]` are *not* treated as speakers (no-colon + reserved-keyword guard), so synthesis markers stay in the text and never spawn a phantom cast member.
- **`parseScript` auto-routes** tagged scripts → the existing **Auto-cast button works unchanged** (no new UI/toggle).
- **Single-line re-render** is already provided by the content-addressed chapter cache — editing one line changes only that chapter's cache key, so export re-synthesizes just the edited line.
- `autocastHint` now advertises all three formats (`[Name]`, `NAME:`, quoted prose).

## Tests / verification
- `parseScript.test.js` extended with 7 tagged-script cases (multi-line blocks, Narrator prose, name normalization, marker-not-speaker guard, `hasSpeakerTags`, auto-route) — **16 passed**.
- `bun run build` green; `featureCoverage` + `storyToSpans` still green (36 passed total).

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR implements automated multi-voice casting for tagged scripts in Stories audiobooks and podcasts. Users can now paste scripts with character tags (`[Name] dialogue`), and the Auto-cast button automatically assigns a unique voice to each character. The feature leverages the existing Stories pipeline and content-addressed chapter caching for efficient per-line re-rendering.

## Key Changes

### parseScript.js (+69/-2 lines)
Added two new exported functions to support the tagged-script format (`[Name] dialogue`):

- **`hasSpeakerTags(text)`** — Detects whether text contains valid speaker tags by checking for `[...]` patterns at line start, excluding reserved synthesis markers (`[pause]`, `[voice:ID]`, `[fast]`, etc. identified by presence of `:` or reserved keyword)
- **`parseTaggedScript(text)`** — Parses tagged scripts into `{ speaker, text }` entries:
  - Groups consecutive lines under the same speaker tag (multi-line dialogue joined)
  - Attributes prose before the first tag to `Narrator`
  - Normalizes speaker names (title case, drops "the", punctuation)
  - Preserves inline synthesis markers as text content

Modified **`parseScript(text)`** to auto-detect and route:
- If tagged speakers detected → delegates to `parseTaggedScript`
- Otherwise → falls back to existing screenplay (`NAME: dialogue`) and prose-with-quoted-dialogue parsing

### i18n/locales/en.json
Updated `stories.autocastHint` to document all three supported formats: **tagged scripts (`[Name]`), screenplay (`NAME:`), and quoted prose**.

### CHANGELOG.md
Documented the feature: auto-casting tagged scripts into multi-voice chapters with per-line re-synthesis via content-addressed cache, guarded against misidentifying inline markers as speakers.

### parseScript.test.js (+59/-1 lines)
Added 7 new test cases for `parseTaggedScript` covering:
- Single-line tagged dialogue
- Multi-line dialogue blocks
- Narrator attribution for pre-tag prose
- Name normalization with tags on own lines
- Inline marker preservation (not treated as tags)
- Validation that `hasSpeakerTags` detects only real speaker tags
- Auto-routing confirmation in `parseScript`

All 16 parseScript tests and 36 total feature tests pass.

## Flow Diagram

```mermaid
flowchart TD
    A["User pastes script in Stories editor"] --> B["Click Auto-cast button"]
    B --> C["parseScript invoked"]
    C --> D{hasSpeakerTags detects<br/>[Name] tags?}
    D -->|Yes| E["parseTaggedScript processes<br/>- Groups multi-line blocks<br/>- Normalizes names<br/>- Preserves [pause], [voice:...] as text"]
    D -->|No| F["Fall back to existing parsers<br/>- Screenplay NAME: format<br/>- Prose with quoted dialogue"]
    E --> G["Output: speaker, text pairs"]
    F --> G
    G --> H["autoCast maps speakers to voices<br/>and builds cast"]
    H --> I["Content-addressed cache<br/>generates chapter with voices"]
    I --> J["Single-line edits trigger<br/>only that line's re-render"]
```

## Highlights

- **Preserves inline synthesis markers**: Lines like `[Alice] Wait [pause 500ms]` correctly treat `[Alice]` as speaker and `[pause 500ms]` as dialogue content via colon/reserved-keyword checks
- **Multi-line blocks**: Consecutive lines without a new `[Name]` tag are joined as a single speaker's dialogue
- **Narrator handling**: Prose before the first character tag becomes Narrator lines
- **No UI changes required**: Existing Auto-cast button automatically detects and routes tagged scripts
- **Efficient re-rendering**: Leverages content-addressed caching to re-synthesize only edited lines in the chapter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->