### PR TITLE
fix(dub): speaker-aware re-split so merged speaker turns separate (#486) — FOR REVIEW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
   contact — less wall-of-text, faster to act on.
 ### Fixed
 
+- **Multi-speaker dubbing: two speakers' turns merged onto one line are now
+  split apart.** Segmentation groups words into sentences *before* diarization
+  runs, so a back-and-forth exchange could land in a single segment; the speaker
+  pass then only *relabelled* that segment with its majority speaker, losing the
+  turn boundary (the second half of #486; the per-speaker voice auto-assign was
+  fixed earlier in #490). A new post-diarization pass re-splits any segment whose
+  words span more than one speaker at the word-level boundary, assigning each
+  piece its own speaker. Single-speaker segments pass through **byte-for-byte
+  unchanged**, so single-speaker dubs and their timing never move, and a lone
+  mis-attributed word (diarization noise) is smoothed rather than causing a
+  spurious split. (#486)
 - **Designed voices saved with a bad style no longer render wrong or crash
   generation.** A designed voice could persist an `instruct` the engine
   validator rejects — either the literal `"[object Object]"` from an old build,

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -23,6 +23,9 @@ from services.segmentation import (
     assign_speakers_from_diarization,
     assign_speakers_from_turns,
     assign_speakers_heuristic,
+    resplit_segments_by_diarization,
+    resplit_segments_by_turns,
+    _words_from_whisper,
     clean_up_segments,
 )
 from services.onset_align import snap_segment_starts
@@ -491,6 +494,9 @@ async def dub_transcribe_stream(
             logger.warning("offload_tts_for_asr failed (continuing): %s", e)
 
         all_segments: list[dict] = []
+        # Words (global-timeline) retained so diarization can re-split a segment
+        # that spans two speakers' turns at the word boundary (#486).
+        all_words: list = []
         detected_lang = None
         next_seg_id = 0
         chunk_errors: list[str] = []
@@ -574,6 +580,12 @@ async def dub_transcribe_stream(
                 detected_lang = part["language"]
             asr_speaker_turns.extend(part.get("speaker_turns") or [])
             chunk_segs = segment_transcript(part, duration=t1, scene_cuts=scene_cuts)
+            # Same word source segment_transcript used (already global-timeline),
+            # kept for the post-diarization speaker re-split (#486).
+            try:
+                all_words.extend(_words_from_whisper(part))
+            except Exception:
+                pass
             # #280: Whisper often stretches a segment's start back over
             # leading music/silence (classic case: speech begins at 0:03,
             # transcript says 0.0 → the dub plays 3 s early). Snap starts
@@ -652,7 +664,10 @@ async def dub_transcribe_stream(
             # use its speaker turns directly and skip pyannote entirely (#182).
             if asr_speaker_turns:
                 logger.info("Using inline ASR diarization (%d turns); skipping pyannote.", len(asr_speaker_turns))
-                return assign_speakers_from_turns(all_segments, asr_speaker_turns), None
+                assigned = assign_speakers_from_turns(all_segments, asr_speaker_turns)
+                # #486: split any segment that spans two speakers' turns at the
+                # word boundary (single-speaker segments pass through unchanged).
+                return resplit_segments_by_turns(assigned, all_words, asr_speaker_turns), None
 
             from services.model_manager import (
                 DIARIZATION_ERR_LICENSE,
@@ -729,7 +744,10 @@ async def dub_transcribe_stream(
                     diar = diar_pipe(asr_audio_target, num_speakers=num_speakers)
                 else:
                     diar = diar_pipe(asr_audio_target)
-                return assign_speakers_from_diarization(all_segments, diar), None
+                assigned = assign_speakers_from_diarization(all_segments, diar)
+                # #486: split any segment that spans two speakers' turns at the
+                # word boundary (single-speaker segments pass through unchanged).
+                return resplit_segments_by_diarization(assigned, all_words, diar), None
             except Exception as e:
                 logger.error(f"Diarization failed: {e}")
                 # Mid-run failure — classify against the same sentinels so a

--- a/backend/services/segmentation.py
+++ b/backend/services/segmentation.py
@@ -542,3 +542,146 @@ def assign_speakers_heuristic(segments: List[dict]) -> List[dict]:
         s["speaker_id"] = f"Speaker {current}"
         last_end = s["end"]
     return segments
+
+
+# ── Speaker-aware re-split (#486) ────────────────────────────────────────────
+#
+# Segmentation runs BEFORE diarization and groups words by sentence/duration
+# only, so one segment can span two speakers' turns. assign_speakers_* then only
+# *relabels* each segment with its majority speaker — the boundary is lost and a
+# two-speaker exchange reads as one line. This pass re-splits such a segment at
+# the word-level speaker boundary, after diarization.
+#
+# Hard invariant (the single-speaker no-regression guarantee): a segment whose
+# words all map to ONE speaker is returned byte-for-byte unchanged — same dict,
+# id, text, start, end — so single-speaker dubs and their timing never move.
+
+def _word_speaker(w: "Word", turns: Sequence[tuple]) -> Optional[str]:
+    """Majority-overlap speaker label for a word; midpoint membership as a
+    fallback; ``None`` when the word has no diarization coverage at all."""
+    acc: dict = {}
+    for ts, te, label in turns:
+        left = max(w.start, ts)
+        right = min(w.end, te)
+        if right > left:
+            acc[label] = acc.get(label, 0.0) + (right - left)
+    if acc:
+        return max(acc.items(), key=lambda kv: kv[1])[0]
+    mid = (w.start + w.end) / 2.0
+    for ts, te, label in turns:
+        if ts <= mid <= te:
+            return label
+    return None
+
+
+def _fill_and_smooth(labels: List[Optional[str]]) -> List[Optional[str]]:
+    """Forward/back-fill gaps (words with no coverage inherit a neighbor) and
+    smooth single-word flips, so one mis-attributed word inside a speaker's run
+    (diarization noise) doesn't trigger a spurious split."""
+    out = list(labels)
+    n = len(out)
+    last = None
+    for i in range(n):
+        if out[i] is None:
+            out[i] = last
+        else:
+            last = out[i]
+    nxt = None
+    for i in range(n - 1, -1, -1):
+        if out[i] is None:
+            out[i] = nxt
+        else:
+            nxt = out[i]
+    for i in range(1, n - 1):
+        if out[i] != out[i - 1] and out[i - 1] == out[i + 1]:
+            out[i] = out[i - 1]
+    return out
+
+
+def _resplit_core(
+    segments: List[dict], words: Sequence["Word"], turns: Sequence[tuple],
+) -> List[dict]:
+    """Split each segment that spans >1 speaker at the word-level boundary.
+
+    ``turns`` is a normalised list of ``(start, end, speaker_label)``. Single-
+    speaker segments are passed through untouched. Pieces keep the segment's
+    outer start/end (preserving any onset-snap) and use word times for interior
+    boundaries, so the pieces exactly cover the original span.
+    """
+    if not turns or not words:
+        return segments
+    ordered = sorted(words, key=lambda w: (w.start, w.end))
+    out: List[dict] = []
+    for seg in segments:
+        s0, s1 = seg["start"], seg["end"]
+        seg_words = [w for w in ordered if min(w.end, s1) - max(w.start, s0) > 1e-6]
+        if len(seg_words) < 2:
+            out.append(seg)
+            continue
+        labels = _fill_and_smooth([_word_speaker(w, turns) for w in seg_words])
+        if len({l for l in labels if l is not None}) <= 1:
+            out.append(seg)  # single speaker (or unknown) → byte-for-byte unchanged
+            continue
+        runs: List[tuple] = []
+        for w, label in zip(seg_words, labels):
+            if runs and runs[-1][0] == label:
+                runs[-1][1].append(w)
+            else:
+                runs.append((label, [w]))
+        n_runs = len(runs)
+        piece_no = 0
+        for k, (label, ws) in enumerate(runs):
+            text = _clean(" ".join(w.text for w in ws))
+            if not text:
+                continue
+            piece = dict(seg)
+            piece["text"] = text
+            piece["start"] = s0 if k == 0 else ws[0].start
+            piece["end"] = s1 if k == n_runs - 1 else ws[-1].end
+            if label:
+                piece["speaker_id"] = label
+            if piece_no > 0:
+                piece["id"] = f"{seg.get('id', 'seg')}-{piece_no}"
+                if "text_original" in piece:
+                    piece["text_original"] = text
+            elif "text_original" in piece:
+                piece["text_original"] = text
+            out.append(piece)
+            piece_no += 1
+    return out
+
+
+def _diar_speaker_label(raw) -> str:
+    """``SPEAKER_00`` → ``Speaker 1`` (mirrors assign_speakers_from_diarization)."""
+    try:
+        return f"Speaker {int(str(raw).split('_')[-1]) + 1}"
+    except (ValueError, AttributeError):
+        return str(raw)
+
+
+def resplit_segments_by_diarization(
+    segments: List[dict], words: Sequence["Word"], diarization,
+) -> List[dict]:
+    """Speaker-aware re-split using a pyannote diarization result (#486)."""
+    turns = [
+        (turn.start, turn.end, _diar_speaker_label(spk))
+        for turn, _, spk in diarization.itertracks(yield_label=True)
+    ]
+    return _resplit_core(segments, words, turns)
+
+
+def resplit_segments_by_turns(
+    segments: List[dict], words: Sequence["Word"], turns: Sequence[dict],
+) -> List[dict]:
+    """Speaker-aware re-split using inline ASR speaker turns (FunASR cam++).
+
+    ``speaker`` is used verbatim (FunASR already labels ``"Speaker N"``), matching
+    :func:`assign_speakers_from_turns`."""
+    norm = [
+        (t["start"], t["end"], t["speaker"])
+        for t in (turns or [])
+        if t.get("speaker") is not None
+        and t.get("start") is not None
+        and t.get("end") is not None
+    ]
+    return _resplit_core(segments, words, norm)

--- a/tests/test_resplit_speaker.py
+++ b/tests/test_resplit_speaker.py
@@ -1,0 +1,166 @@
+"""Speaker-aware re-split after diarization (#486).
+
+Segmentation groups words by sentence before diarization, so one segment can
+span two speakers; assign_speakers_* only relabels it with the majority speaker,
+merging the turn. resplit_segments_* splits such a segment at the word boundary.
+
+The load-bearing guarantee is **no single-speaker regression**: a segment whose
+words all map to one speaker must come back byte-for-byte unchanged (same dict,
+id, text, start, end) so single-speaker dub timing never moves. These tests pin
+that, plus the actual split behaviour and diarization-noise robustness.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+from services.segmentation import (  # noqa: E402
+    Word,
+    resplit_segments_by_turns,
+    resplit_segments_by_diarization,
+    _resplit_core,
+)
+
+
+def _w(start, end, text):
+    return Word(start=start, end=end, text=text)
+
+
+def _seg(start, end, text, sid="Speaker 1", _id="seg1"):
+    return {"start": start, "end": end, "text": text, "speaker_id": sid, "id": _id,
+            "text_original": text}
+
+
+# ── No-regression: single-speaker segments are untouched ─────────────────────
+
+def test_single_speaker_segment_unchanged():
+    seg = _seg(0.0, 4.0, "hello there friends")
+    words = [_w(0.0, 1.0, "hello"), _w(1.0, 2.0, "there"), _w(2.0, 3.5, "friends")]
+    turns = [{"start": 0.0, "end": 4.0, "speaker": "Speaker 1"}]
+    out = resplit_segments_by_turns([dict(seg)], words, turns)
+    assert len(out) == 1
+    assert out[0] == seg  # byte-for-byte identical (text, id, timing all preserved)
+
+
+def test_no_turns_is_identity():
+    seg = _seg(0.0, 4.0, "all one speaker")
+    words = [_w(0.0, 2.0, "all"), _w(2.0, 4.0, "one")]
+    assert resplit_segments_by_turns([seg], words, []) == [seg]
+    assert resplit_segments_by_turns([seg], words, None) == [seg]
+
+
+def test_segment_with_fewer_than_two_words_unchanged():
+    seg = _seg(0.0, 1.0, "hi")
+    words = [_w(0.0, 1.0, "hi")]
+    turns = [{"start": 0.0, "end": 0.5, "speaker": "Speaker 1"},
+             {"start": 0.5, "end": 1.0, "speaker": "Speaker 2"}]
+    assert resplit_segments_by_turns([seg], words, turns) == [seg]
+
+
+# ── The fix: a two-speaker segment splits at the boundary ────────────────────
+
+def test_two_speaker_segment_splits():
+    # "how are you" (Speaker 1, 0-3s) + "i am fine" (Speaker 2, 3-6s) got merged
+    # into one segment; the re-split must separate them.
+    seg = _seg(0.0, 6.0, "how are you i am fine")
+    words = [
+        _w(0.0, 1.0, "how"), _w(1.0, 2.0, "are"), _w(2.0, 3.0, "you"),
+        _w(3.0, 4.0, "i"), _w(4.0, 5.0, "am"), _w(5.0, 6.0, "fine"),
+    ]
+    turns = [
+        {"start": 0.0, "end": 3.0, "speaker": "Speaker 1"},
+        {"start": 3.0, "end": 6.0, "speaker": "Speaker 2"},
+    ]
+    out = resplit_segments_by_turns([seg], words, turns)
+    assert len(out) == 2
+    assert out[0]["text"] == "how are you"
+    assert out[0]["speaker_id"] == "Speaker 1"
+    assert out[1]["text"] == "i am fine"
+    assert out[1]["speaker_id"] == "Speaker 2"
+    # Pieces exactly cover the original span; outer edges preserved.
+    assert out[0]["start"] == 0.0
+    assert out[1]["end"] == 6.0
+    # Interior boundary on a word edge; new piece gets a distinct id.
+    assert out[0]["end"] == 3.0 and out[1]["start"] == 3.0
+    assert out[0]["id"] == "seg1" and out[1]["id"] != "seg1"
+    assert out[1]["text_original"] == "i am fine"
+
+
+def test_three_speaker_runs_split_into_three():
+    seg = _seg(0.0, 6.0, "a b c d e f")
+    words = [_w(i, i + 1, ch) for i, ch in enumerate(["a", "b", "c", "d", "e", "f"])]
+    turns = [
+        {"start": 0.0, "end": 2.0, "speaker": "Speaker 1"},
+        {"start": 2.0, "end": 4.0, "speaker": "Speaker 2"},
+        {"start": 4.0, "end": 6.0, "speaker": "Speaker 1"},
+    ]
+    out = resplit_segments_by_turns([seg], words, turns)
+    assert [s["text"] for s in out] == ["a b", "c d", "e f"]
+    assert [s["speaker_id"] for s in out] == ["Speaker 1", "Speaker 2", "Speaker 1"]
+
+
+# ── Robustness: diarization noise must not over-split ─────────────────────────
+
+def test_single_word_flip_is_smoothed_not_split():
+    # One word mis-attributed to Speaker 2 inside Speaker 1's run → no split.
+    seg = _seg(0.0, 5.0, "one two three four five")
+    words = [_w(i, i + 1, t) for i, t in enumerate(["one", "two", "three", "four", "five"])]
+    turns = [
+        {"start": 0.0, "end": 2.0, "speaker": "Speaker 1"},
+        {"start": 2.0, "end": 3.0, "speaker": "Speaker 2"},   # lone noisy word
+        {"start": 3.0, "end": 5.0, "speaker": "Speaker 1"},
+    ]
+    out = resplit_segments_by_turns([seg], words, turns)
+    assert len(out) == 1
+    assert out[0] == seg
+
+
+def test_only_mixed_segment_splits_others_identity():
+    a = _seg(0.0, 2.0, "solo one", sid="Speaker 1", _id="a")
+    b = _seg(2.0, 8.0, "mixed left mixed right", sid="Speaker 1", _id="b")
+    c = _seg(8.0, 10.0, "solo two", sid="Speaker 2", _id="c")
+    words = [
+        _w(0.0, 1.0, "solo"), _w(1.0, 2.0, "one"),
+        _w(2.0, 3.0, "mixed"), _w(3.0, 4.0, "left"),
+        _w(5.0, 6.0, "mixed"), _w(6.0, 7.0, "right"),
+        _w(8.0, 9.0, "solo"), _w(9.0, 10.0, "two"),
+    ]
+    turns = [
+        {"start": 0.0, "end": 4.0, "speaker": "Speaker 1"},
+        {"start": 4.0, "end": 8.0, "speaker": "Speaker 2"},
+        {"start": 8.0, "end": 10.0, "speaker": "Speaker 2"},
+    ]
+    out = resplit_segments_by_turns([a, b, c], words, turns)
+    # a and c untouched (identity); b split in two.
+    assert out[0] == a
+    assert out[-1] == c
+    mid = [s for s in out if s["id"].startswith("b")]
+    assert len(mid) == 2
+    assert [s["speaker_id"] for s in mid] == ["Speaker 1", "Speaker 2"]
+
+
+# ── pyannote wrapper: label formatting (SPEAKER_00 → Speaker 1) ───────────────
+
+class _FakeTurn:
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+
+class _FakeDiar:
+    def __init__(self, tracks):
+        self._tracks = tracks  # list of (start, end, raw_label)
+
+    def itertracks(self, yield_label=True):
+        for s, e, lab in self._tracks:
+            yield _FakeTurn(s, e), None, lab
+
+
+def test_diarization_wrapper_formats_labels_and_splits():
+    seg = _seg(0.0, 4.0, "left side right side")
+    words = [_w(0.0, 1.0, "left"), _w(1.0, 2.0, "side"),
+             _w(2.0, 3.0, "right"), _w(3.0, 4.0, "side")]
+    diar = _FakeDiar([(0.0, 2.0, "SPEAKER_00"), (2.0, 4.0, "SPEAKER_01")])
+    out = resplit_segments_by_diarization([seg], words, diar)
+    assert [s["speaker_id"] for s in out] == ["Speaker 1", "Speaker 2"]
+    assert [s["text"] for s in out] == ["left side", "right side"]


### PR DESCRIPTION
> ⚠️ **For review — please do not merge without a look.** This touches the core dub-timing / segmentation path you reserved for v0.3.8. It's behind regression tests and built to be conservative, but you should eyeball the re-split heuristics and the single-speaker invariant before it lands.

## What this fixes
The second half of #486 (the per-speaker **voice** auto-assign was fixed in #490). Segmentation groups words into sentences **before** diarization runs, so a back-and-forth exchange can land in one segment; `assign_speakers_*` then only **relabels** that segment with its majority speaker — the turn boundary is lost and two speakers read as one line.

## Approach
A post-diarization pass re-splits any segment whose words span >1 speaker, at the word-level boundary.

- **`segmentation.py`** — `resplit_segments_by_diarization` / `resplit_segments_by_turns` (+ a pure `_resplit_core`), mirroring the existing `assign_speakers_*` label handling.
- **The load-bearing invariant — no single-speaker regression:** a segment whose words all map to one speaker is returned **byte-for-byte unchanged** (same dict, id, text, start, end). So single-speaker dubs and their timing never move. Pieces keep the segment's **outer** start/end (preserving the #280 onset-snap) and use word times only for interior boundaries, so they exactly cover the original span with no gap/overlap.
- **Diarization-noise robustness:** a lone mis-attributed word inside a speaker's run is smoothed (not split), so pyannote jitter doesn't shred a sentence.
- **`dub_core.py`** — accumulate global-timeline words alongside segments; apply the re-split after **both** the pyannote and FunASR-turns assign. The heuristic fallback (no word-speaker data) is untouched.

## Tests / verification
- `tests/test_resplit_speaker.py` (8 cases): single-speaker **identity**, no-turns identity, the actual 2-speaker split, 3-way runs, single-word-flip smoothing, only-mixed-splits-others-identity, and pyannote label formatting (`SPEAKER_00 → Speaker 1`).
- Related dub/segmentation/diarization/redub suite: **139 passed**. Full suite: **1836 passed**, no regressions.

## Risk notes for your review
- Re-split only runs on the **diarized** paths (pyannote / FunASR turns); the silence-gap heuristic fallback is unchanged.
- Word timing is the same chunk-token approximation segmentation already uses (the data hasn't changed; only the boundary logic).
- The smoothing threshold (single-word flip) is conservative — a genuine one-word interjection between two longer turns by a third speaker would be absorbed; tune if you'd rather keep ultra-short interjections.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes merged speaker turns in multi-speaker dubbing (issue `#486`) by introducing a post-diarization re-splitting mechanism. When segmentation groups words into sentences before diarization runs, back-and-forth exchanges between speakers can land in a single segment. Previously, speaker assignment would label such segments with the majority speaker, losing turn boundaries. This fix re-splits mixed-speaker segments at word-level boundaries while preserving single-speaker segment timing byte-for-byte.

## Changes

### Backend Service Layer (`backend/services/segmentation.py`)
Adds speaker-aware re-splitting logic via two new public functions:

- **`resplit_segments_by_diarization(segments, words, diarization)`**: Processes segments after pyannote diarization, extracting speaker labels from diarization tracks (normalizing labels like `SPEAKER_00` → `Speaker 1`).
- **`resplit_segments_by_turns(segments, words, turns)`**: Handles inline ASR diarization turns (e.g., FunASR), extracting speaker info from turn dictionaries.

Both call a shared `_resplit_core` helper that:
- Maps each word to its speaker based on diarization coverage (using midpoint fallback when overlap is absent)
- Smooths isolated mis-attributed words (single-word flips) to prevent noise-driven over-splitting
- Splits segments into contiguous speaker runs at word boundaries
- **Preserves single-speaker segments unchanged** (same dict, text, id, start, end) to prevent timing regressions
- Re-split pieces preserve outer start/end times (maintaining segment onset-snap from issue `#280`) and use word times only for interior boundaries
- New segment pieces are created with incremented id suffixes when a split occurs

### Transcription Pipeline (`backend/api/routers/dub_core.py`)
Integrates re-splitting into the `/dub/transcribe-stream/{job_id}` flow:

- Accumulates global-timeline `all_words` from whisper during per-chunk transcription
- After initial segmentation and speaker assignment:
  - For pyannote diarization: calls `resplit_segments_by_diarization(segments, all_words, diar)` 
  - For ASR turns: calls `resplit_segments_by_turns(segments, all_words, asr_speaker_turns)`

### Documentation (`CHANGELOG.md`)
Adds entry describing the multi-speaker dubbing fix, noting that single-speaker segments remain unchanged and isolated mis-attributed words are smoothed.

### Testing (`tests/test_resplit_speaker.py`)
New test suite with 8 regression tests covering:
- Identity preservation of single-speaker segments (byte-for-byte unchanged)
- Multi-speaker splits at word boundaries with correct speaker attribution
- Segment ID suffixing for split pieces
- Outer start/end time preservation
- Noise handling (isolated mis-attributed words smoothed, not split)
- Multi-segment cases (only mixed segments re-split, others unchanged)
- Pyannote-like label formatting

## Behavior Change

```mermaid
flowchart TD
    A["Transcription Output<br/>+ Segmentation"] --> B["Speaker Assignment<br/>pyannote or ASR turns"]
    B --> C{"Does segment<br/>span multiple<br/>speakers?"}
    C -->|No| D["Return unchanged<br/>timing preserved"]
    C -->|Yes| E["Re-split at<br/>word boundaries"]
    E --> F["Create separate segments<br/>per speaker run"]
    F --> G["Assign speaker_id<br/>to each piece"]
    G --> H["Preserve outer times<br/>use word times<br/>for interior boundaries"]
    D --> I["Final multi-speaker<br/>segments with<br/>turn boundaries"]
    H --> I
```

## Safety & Regression Handling

- **No single-speaker regression invariant**: Segments whose words all map to one speaker are returned byte-for-byte unchanged, ensuring single-speaker dubs and timing never shift
- **Noise robustness**: Lone mis-attributed words are forward/back-filled rather than causing spurious splits
- **Outer time preservation**: Re-split pieces maintain the original segment's start/end times (preserving onset-snap from issue `#280`)

## Testing
Full test suite reports 1,836 passed tests with no regressions. The new 8-test suite validates identity cases, multi-speaker splits, noise handling, and segment preservation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->