### PR TITLE
fix(setup): weight-aware install-state so a truncated model cache isn't read as installed (#622)

### DIFF
--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -21,7 +21,17 @@ from pydantic import BaseModel
 from core import prefs
 from utils import hf_progress
 from utils import download_aggregator
-from .models import KNOWN_MODELS, invalidate_cache
+# Weight-floor scan (MM2-07 / #352) lives in ``models.py`` — the lowest module in
+# the setup import graph — so install-time validation here, the first-run
+# install-state detector (#622), and load-time repair share one set of floors and
+# can't drift apart. ``_MIN_WEIGHT_BYTES``/``_WEIGHT_FLOORS`` re-exported for tests.
+from .models import (  # noqa: F401
+    KNOWN_MODELS,
+    invalidate_cache,
+    snapshot_has_weights,
+    _MIN_WEIGHT_BYTES,
+    _WEIGHT_FLOORS,
+)
 
 logger = logging.getLogger("omnivoice.setup.download")
 router = APIRouter()
@@ -223,51 +233,26 @@ def _safe_put(queue: asyncio.Queue, event) -> None:
 # model.safetensors" (#352). 5 MB clears every weight format we ship
 # (safetensors/bin shards, onnx, pt, gguf) without false-positiving on
 # config-only aux repos.
-_MIN_WEIGHT_BYTES = 5 * 1024 * 1024
-
-# Per-role weight-file floors (MM2-07). A valid model has at least one
-# recognized weight file at or above its extension's floor. ONNX graphs are
-# legitimately small (a complete model can be well under 5 MB), so a single
-# 5 MB rule false-positives on them as "truncated" (#352 over-trigger); give
-# .onnx a lower floor while still rejecting a 0/KB partial. Tensor formats keep
-# the original 5 MB floor.
-_WEIGHT_FLOORS = {
-    ".safetensors": _MIN_WEIGHT_BYTES,
-    ".bin": _MIN_WEIGHT_BYTES,
-    ".ckpt": _MIN_WEIGHT_BYTES,
-    ".pt": _MIN_WEIGHT_BYTES,
-    ".pth": _MIN_WEIGHT_BYTES,
-    ".gguf": _MIN_WEIGHT_BYTES,
-    ".onnx": 64 * 1024,   # a real ONNX graph is ≥ tens of KB; a truncated one is bytes
-}
-
-
 def _validate_snapshot_has_weights(repo_id: str, snapshot_path: str) -> None:
     """Raise OSError when a finished snapshot has no plausible weight file —
     surfaces the truncated-download class (#352) at install time, where the
     retry loop and the UI's re-download path can deal with it, instead of at
     first synthesis with an opaque transformers error.
 
-    A snapshot is valid if it contains a recognized weight file meeting its
-    per-extension floor (MM2-07) OR any file ≥ the global 5 MB floor (the
-    original lenient catch — kept so this is never stricter than before)."""
+    Delegates the weight check to ``models.snapshot_has_weights`` (single source of
+    the floors); only the install-time error message lives here."""
+    if snapshot_has_weights(snapshot_path):
+        return
+    biggest = 0
     try:
-        biggest = 0
         for root, _dirs, files in os.walk(snapshot_path, followlinks=True):
             for f in files:
                 try:
-                    size = os.path.getsize(os.path.join(root, f))
+                    biggest = max(biggest, os.path.getsize(os.path.join(root, f)))
                 except OSError:
                     continue
-                biggest = max(biggest, size)
-                ext = os.path.splitext(f)[1].lower()
-                floor = _WEIGHT_FLOORS.get(ext)
-                if floor is not None and size >= floor:
-                    return  # a recognized weight file of plausible size
-                if size >= _MIN_WEIGHT_BYTES:
-                    return  # original lenient catch (non-standard weight names)
     except OSError:
-        return  # can't inspect — don't block the install on the checker itself
+        pass
     raise OSError(
         f"{repo_id}: download finished but no model weights were found in the "
         "snapshot (largest file "

--- a/backend/api/routers/setup/models.py
+++ b/backend/api/routers/setup/models.py
@@ -146,6 +146,94 @@ def _hub_cache_roots() -> list[str]:
     return roots
 
 
+# ── Weight-presence (truncated-cache) detection ─────────────────────────────
+# A cache that downloaded config/tokenizer files but not the weight shard still
+# occupies bytes on disk, so a size-only "installed" check (#352/#581/#606) reads
+# it as installed and the first-run wizard hides the re-download button, stranding
+# the user (#622). These helpers tell a *complete* snapshot from a truncated one by
+# checking for a plausible weight file — the same class `download.py` guards at
+# install time and `model_manager.py` repairs at load time. Shared here (the lowest
+# module in the setup import graph; `download.py` imports from this module) so the
+# floors live in exactly one place and can't drift between the three call sites.
+
+_MIN_WEIGHT_BYTES = 5 * 1024 * 1024  # tensor formats: a real shard is ≥ a few MB
+
+# Per-extension floors. ONNX graphs are legitimately small (a complete model can be
+# well under 5 MB), so they get a lower floor that still rejects a bytes-only partial.
+_WEIGHT_FLOORS = {
+    ".safetensors": _MIN_WEIGHT_BYTES,
+    ".bin": _MIN_WEIGHT_BYTES,
+    ".ckpt": _MIN_WEIGHT_BYTES,
+    ".pt": _MIN_WEIGHT_BYTES,
+    ".pth": _MIN_WEIGHT_BYTES,
+    ".gguf": _MIN_WEIGHT_BYTES,
+    ".onnx": 64 * 1024,
+}
+
+
+def snapshot_has_weights(snapshot_path: str) -> bool:
+    """True when a finished snapshot dir holds a plausible weight file.
+
+    A snapshot is complete if it contains a recognized weight file meeting its
+    per-extension floor OR any file ≥ the global 5 MB floor (the lenient catch for
+    non-standard weight names). Returns True when the path can't be inspected — an
+    un-walkable dir must never be reported as truncated, only a confirmed weight-less
+    one. `getsize` follows symlinks, so HF's snapshot→blob links resolve correctly;
+    a broken link (missing blob) raises OSError and is skipped, i.e. counts as absent.
+    """
+    try:
+        for root, _dirs, files in os.walk(snapshot_path, followlinks=True):
+            for f in files:
+                try:
+                    size = os.path.getsize(os.path.join(root, f))
+                except OSError:
+                    continue
+                ext = os.path.splitext(f)[1].lower()
+                floor = _WEIGHT_FLOORS.get(ext)
+                if floor is not None and size >= floor:
+                    return True
+                if size >= _MIN_WEIGHT_BYTES:
+                    return True
+    except OSError:
+        return True  # can't inspect — don't mislabel as truncated
+    return False
+
+
+def _snapshot_dirs(repo_id: str) -> list[str]:
+    """Existing snapshot revision dirs for a repo across the candidate cache roots."""
+    name = _repo_dir_name(repo_id)
+    dirs: list[str] = []
+    for root in _hub_cache_roots():
+        snaps = os.path.join(root, name, "snapshots")
+        try:
+            for rev in os.listdir(snaps):
+                rev_dir = os.path.join(snaps, rev)
+                if os.path.isdir(rev_dir):
+                    dirs.append(rev_dir)
+        except OSError:
+            continue
+    return dirs
+
+
+def cache_is_complete(model: dict) -> bool:
+    """True when this model's on-disk cache is usable (not a truncated download).
+
+    Config-only repos (``config_only: true`` in models.yaml — e.g. pyannote's
+    diarisation pipeline, whose real weights live in referenced sub-repos) carry no
+    weight file of their own, so the weight check would false-positive them as
+    incomplete (#622 caveat). They're exempt: cache presence alone means complete.
+    A weight-bearing repo is complete only if at least one of its snapshots has
+    weights; if no snapshot dir is found on disk we can't prove truncation, so we
+    don't downgrade (the size-based caller already decided it's cached).
+    """
+    if model.get("config_only"):
+        return True
+    dirs = _snapshot_dirs(model["repo_id"])
+    if not dirs:
+        return True
+    return any(snapshot_has_weights(d) for d in dirs)
+
+
 def _is_cached_on_disk(repo_id: str) -> bool:
     """Direct-filesystem fallback for is_cached when scan_cache_dir is unavailable.
 
@@ -286,9 +374,15 @@ def list_models():
     out = []
     for m in KNOWN_MODELS:
         cached = cached_by_repo.get(m["repo_id"])
+        on_disk = cached is not None and cached["size_on_disk"] > 0
+        # A size-positive cache can still be a truncated download (config landed,
+        # weight shard didn't). Treat that as not-installed + incomplete so the
+        # wizard re-offers the download instead of stranding the user (#622).
+        incomplete = on_disk and not cache_is_complete(m)
         out.append({
             **m,
-            "installed": cached is not None and cached["size_on_disk"] > 0,
+            "installed": on_disk and not incomplete,
+            "incomplete": incomplete,
             "size_on_disk_bytes": cached["size_on_disk"] if cached else 0,
             "nb_files": cached["nb_files"] if cached else 0,
             "supported": _model_supported(m),
@@ -383,6 +477,9 @@ def recommendations():
     entries = []
     for rid in recommended_ids:
         meta = known_by_id.get(rid, {})
+        # Mirror /models: a truncated cache (weights missing) is not installed, so
+        # the wizard counts it toward the remaining download instead of "all set".
+        installed = rid in cached_ids and cache_is_complete(meta or {"repo_id": rid})
         entries.append({
             "repo_id": rid,
             "label": meta.get("label", rid),
@@ -390,7 +487,7 @@ def recommendations():
             "size_gb": meta.get("size_gb", 0),
             "required": bool(meta.get("required", False)),
             "note": meta.get("note"),
-            "installed": rid in cached_ids,
+            "installed": installed,
         })
 
     to_download_gb = sum(e["size_gb"] for e in entries if not e["installed"])

--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -14,6 +14,10 @@
 #   required   (optional) — true if the app needs this model to function
 #   platforms  (optional) — restrict to specific OS+arch tags (e.g. darwin-arm64, cuda)
 #   note       (optional) — shown in the UI as a tooltip/footnote
+#   config_only (optional) — true for pipeline repos that ship no weight file of
+#                            their own (weights live in referenced sub-repos). Such
+#                            a cache is legitimately tiny, so the truncated-download
+#                            (weights-missing) detector must NOT flag it incomplete.
 # ─────────────────────────────────────────────────────────────────────────
 
 models:
@@ -122,6 +126,7 @@ models:
     label: "pyannote speaker diarisation (multi-speaker videos)"
     role: Diarisation
     size_gb: 0.8
+    config_only: true  # pipeline repo; real weights live in referenced sub-repos
     note: "Needs an HF_TOKEN with license accepted."
 
   # ── Optional TTS ──────────────────────────────────────────────────────

--- a/tests/test_mm2_lifecycle.py
+++ b/tests/test_mm2_lifecycle.py
@@ -161,3 +161,78 @@ def test_truncated_snapshot_still_rejected(tmp_path):
 def test_large_tensor_weight_passes(tmp_path):
     (tmp_path / "model.safetensors").write_bytes(b"\0" * (6 * 1024 * 1024))
     dl._validate_snapshot_has_weights("x/big", str(tmp_path))  # must not raise
+
+
+# ── #622: install-state detector is weight-aware (truncated cache ≠ installed) ─
+
+import api.routers.setup.models as models  # noqa: E402
+
+
+def _make_snapshot(cache_root, repo_id, files):
+    """Build a minimal HF-style snapshots/<rev>/ dir and return its cache root."""
+    name = "models--" + repo_id.replace("/", "--")
+    rev = cache_root / name / "snapshots" / "abc123"
+    rev.mkdir(parents=True)
+    for fname, data in files.items():
+        (rev / fname).write_bytes(data)
+    return rev
+
+
+def test_snapshot_has_weights_distinguishes_truncated(tmp_path):
+    full = tmp_path / "full"; full.mkdir()
+    (full / "config.json").write_bytes(b"{}")
+    (full / "model.safetensors").write_bytes(b"\0" * (6 * 1024 * 1024))
+    assert models.snapshot_has_weights(str(full)) is True
+
+    trunc = tmp_path / "trunc"; trunc.mkdir()
+    (trunc / "config.json").write_bytes(b"{}")
+    (trunc / "tokenizer.json").write_bytes(b"x" * 4096)
+    assert models.snapshot_has_weights(str(trunc)) is False
+
+
+def test_cache_is_complete_flags_truncated_weight_repo(tmp_path, monkeypatch):
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    # Weight-bearing repo with config only (interrupted download) → incomplete.
+    _make_snapshot(tmp_path, "k2-fsa/OmniVoice", {"config.json": b"{}"})
+    assert models.cache_is_complete({"repo_id": "k2-fsa/OmniVoice"}) is False
+    # Same repo once the shard lands → complete.
+    _make_snapshot(
+        tmp_path / "ok", "k2-fsa/OmniVoice",
+        {"config.json": b"{}", "model.safetensors": b"\0" * (6 * 1024 * 1024)},
+    )
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "ok"))
+    assert models.cache_is_complete({"repo_id": "k2-fsa/OmniVoice"}) is True
+
+
+def test_cache_is_complete_exempts_config_only_repo(tmp_path, monkeypatch):
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    # pyannote pipeline ships no weight of its own — a tiny cache is legit, not
+    # truncated; the config_only hint must keep it from being flagged incomplete.
+    _make_snapshot(tmp_path, "pyannote/speaker-diarization-3.1", {"config.yaml": b"x"})
+    assert models.cache_is_complete(
+        {"repo_id": "pyannote/speaker-diarization-3.1", "config_only": True}
+    ) is True
+
+
+def test_list_models_downgrades_truncated_cache(tmp_path, monkeypatch):
+    """A size-positive but weight-less cache must report installed=False so the
+    first-run wizard re-offers the download instead of stranding the user (#622)."""
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    _make_snapshot(tmp_path, "k2-fsa/OmniVoice", {"config.json": b"{}"})
+
+    class _Repo:
+        def __init__(self, rid, size):
+            self.repo_id, self.size_on_disk = rid, size
+            self.last_accessed, self.nb_files = 0, 1
+
+    class _Info:
+        repos = [_Repo("k2-fsa/OmniVoice", 4096)]  # size > 0 (config landed)
+
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "scan_cache_dir", lambda: _Info())
+    models.invalidate_cache()
+    out = models.list_models()
+    row = next(m for m in out["models"] if m["repo_id"] == "k2-fsa/OmniVoice")
+    assert row["installed"] is False
+    assert row["incomplete"] is True
+    models.invalidate_cache()


### PR DESCRIPTION
## What & why

Fixes #622. A first-run user whose model download was interrupted *after* the config/tokenizer files landed but *before* the weight shard got stranded on the **Models & Engines** page with no way out:

- `GET /models` computed `installed` purely from cache **size** (`cached["size_on_disk"] > 0`), so a size-positive-but-weight-less snapshot reported `installed: true`.
- The first-run `WizardLibrary` shows the install/re-download action only when `!m.installed`, so the button was hidden.
- The repair surface (delete / re-download) lives in **Settings → Models**, which is unreachable while the wizard gates the user on the download page → stranded.

This is the same truncated-download class that `download.py` already guards at **install** time (#352) and `model_manager.py` repairs at **load** time (#581/#606) — the install-state detector just had the same blind spot.

## The fix (whole class, not just the symptom)

- Moved the boolean weight-floor scan into `models.py` (the lowest module in the setup import graph) as `snapshot_has_weights()` + `cache_is_complete()`. **One source of the floors** — `download.py`'s install-time validator now delegates to it, so the install-time / install-state / load-time checks can't drift apart.
- `list_models()` and `recommendations()` downgrade a truncated cache to `installed: false` (and `/models` carries an explicit `incomplete: true`). The existing wizard install action re-appears automatically — no frontend change needed.
- **`config_only` repos exempt:** `pyannote/speaker-diarization-3.1` is a pipeline repo whose real weights live in referenced sub-repos, so its own cache is legitimately tiny. It gets a new `config_only: true` hint in `models.yaml` (documented field) and is never flagged incomplete — avoids the false-positive the issue's caveat calls out.

## Tests

Added to `tests/test_mm2_lifecycle.py` (fail-before / pass-after):
- `snapshot_has_weights` distinguishes a truncated snapshot from a complete one
- `cache_is_complete` flags a truncated weight repo and exempts a `config_only` repo
- `list_models` downgrades a size-positive-but-weight-less cache to `installed: false` / `incomplete: true`

Full backend suite green locally: **1832 passed, 20 skipped, 11 xfailed, 3 xpassed**. No version bump, no hardcoded CJK, backend-only, pure-filesystem (cross-platform), backward-compatible (only corrects `installed` + adds `incomplete`).

Fixes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem Statement

This PR fixes an issue where incomplete model caches (containing config/tokenizer files but missing weight files) were incorrectly reported as installed, stranding first-run users on the download page with no recovery path (Issue `#622`).

The root cause: `GET /models` determines installation status solely by checking if `size_on_disk > 0`, so a truncated cache appeared installed despite missing weights. Since the wizard only offers install/re-download actions when `!m.installed`, users with interrupted downloads were locked on the download page, with the recovery surface (Settings → Models) remaining unreachable.

## Solution

### Core Changes

**1. Centralized weight-detection logic** (`models.py`)
- Added `snapshot_has_weights(snapshot_path)` to walk snapshot directories and identify plausible weight files using extension-based size floors (5MB global fallback)
- Added `cache_is_complete(repo_id, snapshot_path)` to determine if a cached repo has all required weights or is legitimately config-only
- Imported and re-exported weight validation constants (`_MIN_WEIGHT_BYTES`, `_WEIGHT_FLOORS`) for single source of truth

**2. Updated API endpoints**
- `/models` now derives `installed` from both cache presence AND weight completeness check
- Adds explicit `incomplete` boolean field marking cases where cache exists but weights are missing
- `/setup/recommendations` applies the new `cache_is_complete()` check to avoid mis-reporting truncated caches as installed

**3. Unified install-time validation** (`download.py`)
- Refactored `_validate_snapshot_has_weights()` to delegate core weight detection to `models.snapshot_has_weights()`
- Ensures consistency across all three check-points: install-time (download.py), install-state (models.py), and load-time repairs

**4. Config-only repo exemption** (`models.yaml`)
- Introduced optional `config_only` field for pipeline-style repos with no standalone weights
- Marked `pyannote/speaker-diarization-3.1` with `config_only: true` to prevent false-positive incomplete flags

### Behavior Change Flowchart

```
┌─────────────────────────────────────────────────────────┐
│ Cache Existence Check                                   │
│ (size_on_disk > 0)                                      │
└────────────────────┬────────────────────────────────────┘
                     │
         ┌───────────┴───────────┐
         │                       │
      NO │                       │ YES
         │                       │
         ▼                       ▼
    installed:              Check if config_only=true
    false              ┌─────────┴───────────┐
                       │                     │
                    YES│                     │NO
                       │                     │
                       ▼                     ▼
                   installed:         snapshot_has_weights()?
                   true              ┌──────────┴──────────┐
                   incomplete:        │                    │
                   false           YES│                    │NO
                                      │                    │
                                      ▼                    ▼
                                  installed:          installed:
                                  true                false
                                  incomplete:         incomplete:
                                  false               true
```

## Test Coverage

- Added regression tests in `tests/test_mm2_lifecycle.py` covering:
  - `snapshot_has_weights()` returns `True` with weights, `False` when truncated
  - `cache_is_complete()` correctly identifies incomplete vs. complete caches
  - Config-only exemptions prevent false-positive incomplete flags
  - `list_models()` downgrades truncated caches to `installed: false` with `incomplete: true`
- Full backend test suite: 1832 passed, 20 skipped, 11 xfailed, 3 xpassed

## Technical Details

- **Backend-only, cross-platform fix:** Pure filesystem operations, no frontend changes required
- **Backward-compatible:** Existing behavior for complete caches unchanged
- **User recovery path:** Incomplete caches now display `installed: false`, allowing the wizard's install/re-download action to appear

## Files Changed

- `backend/api/routers/setup/models.py` (+99/-2): Weight detection and endpoint updates
- `backend/api/routers/setup/download.py` (+18/-33): Refactored to delegate to centralized weight check
- `backend/config/models.yaml` (+5/-0): Added `config_only` field for `pyannote/speaker-diarization-3.1`
- `tests/test_mm2_lifecycle.py` (+75/-0): Regression tests for weight-aware install state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->