### PR TITLE
docs(troubleshooting): stuck-download / incomplete-cache recovery (#622)

### DIFF
--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -232,6 +232,60 @@ Apple-Silicon install skips this index entirely.
 
 **Linked issue:** [#569](https://github.com/debpalash/OmniVoice-Studio/issues/569)
 
+## 13. Stuck on the download page / incomplete model cache ("only `refs/`")
+
+**Symptom:** the setup screen never finishes the model download and you can't
+reach the main app. Looking in the HF cache, a model folder
+(`models--k2-fsa--OmniVoice`, `models--Systran--faster-whisper-large-v3`) has
+`refs/` and maybe `config.json` but **no weight files** (`blobs/` empty or tiny).
+
+**Cause:** the download started but the large weight shards never finished —
+almost always the connection **dropping, throttling, or being blocked** mid-pull
+(corporate/school proxy, VPN, antivirus quarantining the multi-GB file, or a
+region where `huggingface.co` is slow/blocked). The app retries and verifies
+weights, but a connection that *trickles* rather than dies can stall for a long
+time.
+
+**Fix — force a clean re-download:**
+
+1. **Fully quit OmniVoice.** Check Task Manager (Windows) / Activity Monitor
+   (macOS) and end any leftover `omnivoice` / `python` process — a half-running
+   one keeps the cache locked.
+2. **Delete the incomplete model folder(s) entirely** from the HF cache (the
+   whole `models--…` folder, not just `refs/`). Leave other models alone:
+   - `models--k2-fsa--OmniVoice`
+   - `models--Systran--faster-whisper-large-v3`
+3. **Relaunch** — the download page re-pulls from scratch.
+
+**If it stalls again at the same spot**, the download is being blocked — try, in
+order:
+
+- **Antivirus/firewall** — temporarily disable it for the download (large model
+  files are a common false-positive quarantine), then re-enable.
+- **Connection** — use a stable, direct connection; pause any VPN; avoid
+  corporate/school networks.
+- **Region mirror** — if `huggingface.co` is slow/blocked where you are, set a
+  mirror **before** launching and relaunch:
+  - macOS/Linux: `export HF_ENDPOINT=https://hf-mirror.com`
+  - Windows (PowerShell): `[Environment]::SetEnvironmentVariable("HF_ENDPOINT","https://hf-mirror.com","User")`
+
+**Manual fallback** (if downloads keep failing), pull the weights yourself into
+the same cache, then relaunch:
+
+```bash
+pip install -U "huggingface_hub[cli]"
+huggingface-cli download k2-fsa/OmniVoice
+huggingface-cli download Systran/faster-whisper-large-v3
+```
+
+(If OmniVoice uses a custom models directory, set `HF_HOME` to it first so the
+files land where the app looks.)
+
+> Newer builds detect an incomplete cache and re-offer the download instead of
+> stranding you on this page — update once the fix is in your channel.
+
+**Linked issue:** [#622](https://github.com/debpalash/OmniVoice-Studio/issues/622)
+
 ## First-run setup fails on a restricted network (GitHub/PyPI blocked)
 
 On networks that block or can't resolve **GitHub**, the first-run bootstrap may


### PR DESCRIPTION
Adds **section 13** to `docs/install/troubleshooting.md` for the recurring *"stuck on the download page, model folder has only `refs/`"* case (#622): quit + delete the incomplete `models--*` folder(s) + relaunch; antivirus/VPN/region-mirror (`HF_ENDPOINT`) escalation; `huggingface-cli` manual fallback. Linkable from support replies. Docs-only — no version bump, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation: Added Troubleshooting Section for Stuck Downloads and Incomplete Model Cache

Added a new section 13 to `docs/install/troubleshooting.md` addressing a recurring user issue where downloads become stuck, leaving incomplete model folders containing only the `refs/` directory without actual model weights.

### Problem Addressed
Users encounter a state where Hugging Face model cache folders exist but contain only `refs/` subdirectories with missing or empty weight blobs, typically caused by interrupted, blocked, or stalled large shard downloads.

### Solution Provided
The new section provides a tiered recovery workflow:

**Primary Recovery Steps:**
1. Quit the application
2. Delete the incomplete `models--*` folder(s)
3. Relaunch the application to re-download

**Escalation Troubleshooting:**
- Antivirus software or firewall blocking downloads
- VPN or network connectivity issues
- Region-specific access limitations (addressable via `HF_ENDPOINT` environment variable for alternative mirrors)

**Manual Fallback:**
- Instructions for using `huggingface-cli download` tool after installing `huggingface_hub[cli]`
- Optional `HF_HOME` configuration for custom model directories
- Note that newer builds auto-detect incomplete caches and offer re-downloads

The documentation is designed to be easily linkable from support responses, enabling user self-service resolution before manual intervention is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->