### PR TITLE
fix(dub): skip yt-dlp mtime stamp to avoid [Errno 22] on Windows (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
   contact — less wall-of-text, faster to act on.
 ### Fixed
 
+- **Dubbing a URL no longer fails with `[Errno 22] Invalid argument` on Windows.**
+  yt-dlp stamps the downloaded file's modified-time with the video's upload
+  date; an out-of-range/invalid timestamp makes the `os.utime` call raise
+  `[Errno 22]` and aborts the whole URL ingest. OmniVoice downloads to a throwaway
+  file and never uses its mtime, so it now skips the stamp entirely
+  (`updatetime=False`). (#642)
+
 - **Dubbing a YouTube link that 403s now retries with a different player
   client.** Some videos serve their formats signature-protected to the default
   player client, so the media download fails with `HTTP Error 403: Forbidden`

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -534,6 +534,12 @@ def yt_download_sync(
         "quiet": True,
         "no_warnings": True,
         "restrictfilenames": True,
+        # Don't stamp the downloaded file's mtime with the video's upload date
+        # (#642): on Windows an out-of-range/invalid timestamp makes the os.utime
+        # call raise `[Errno 22] Invalid argument`, failing the whole ingest. We
+        # download to a throwaway `original.*` and never use its mtime, so skip
+        # it entirely (equivalent to yt-dlp's --no-mtime).
+        "updatetime": False,
         "socket_timeout": 30,
         # Resilience against YouTube CDN flakes: a single empty fragment
         # (commonly the very last one — "Did not get any data blocks")

--- a/tests/test_dub_download_mtime.py
+++ b/tests/test_dub_download_mtime.py
@@ -1,0 +1,46 @@
+"""yt-dlp must not stamp the download's mtime (#642).
+
+On Windows, yt-dlp stamping the temp file with the video's upload date can raise
+`[Errno 22] Invalid argument` from os.utime on an out-of-range timestamp, failing
+the whole URL ingest. We download to a throwaway file and never use its mtime, so
+`updatetime` must be False.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+from services import dub_pipeline  # noqa: E402
+
+
+def test_download_opts_disable_mtime(tmp_path, monkeypatch):
+    import yt_dlp
+
+    captured = {}
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            captured.update(opts)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            raise RuntimeError("stop after capturing opts")
+
+        def prepare_filename(self, info):
+            return "unused"
+
+    monkeypatch.setattr(yt_dlp, "YoutubeDL", _FakeYDL)
+    with pytest.raises(Exception):
+        dub_pipeline.yt_download_sync("https://youtu.be/abc", str(tmp_path))
+
+    assert captured.get("updatetime") is False, (
+        "yt-dlp must set updatetime=False so a bad upload-date timestamp can't "
+        "raise [Errno 22] on Windows (#642)"
+    )


### PR DESCRIPTION
## Problem
Dubbing a URL fails on Windows with `download: Unable to download video: [Errno 22] Invalid argument` (#642). yt-dlp stamps the downloaded file's modified-time with the video's **upload date**; an out-of-range/invalid timestamp makes the `os.utime` call raise `[Errno 22]` on Windows, aborting the whole ingest. (Distinct from the broken-pipe #605 and 403 #625 download fixes.)

## Fix
We download to a throwaway `original.*` and never use its mtime, so set **`updatetime=False`** (yt-dlp's `--no-mtime`) — no stamp, no `os.utime`, no `[Errno 22]`. One-line, can't regress anything (we don't read the file's mtime).

## Test
`tests/test_dub_download_mtime.py` — mocks `YoutubeDL` and asserts `updatetime is False` in the opts. Related download suite (403 + retry) still green: 10 passed. No version bump.

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Windows URL Dubbing Failure Fix

**Issue:** Dubbing a URL failed on Windows with `[Errno 22] Invalid argument`. The root cause was that yt-dlp stamps downloaded files with the video's upload date; when the timestamp is out-of-range or invalid on Windows, the `os.utime` call raises `[Errno 22]` and aborts the entire ingest process.

**Solution:** Set `updatetime=False` in yt-dlp's options (equivalent to the `--no-mtime` flag) to skip mtime stamping entirely. Since OmniVoice downloads to a temporary `original.*` file and never reads its mtime, disabling this operation has zero regression risk.

### Changes

**CHANGELOG.md**
- Added entry under `[Unreleased] → Fixed` documenting that dubbing a URL no longer fails with `[Errno 22] Invalid argument` on Windows, explaining the root cause and fix.

**backend/services/dub_pipeline.py**
- Modified `yt_download_sync()` function's yt-dlp options dictionary to include `"updatetime": False`
- Added explanatory comments noting the Windows `os.utime` failure on out-of-range timestamps and that the downloaded file is temporary and never has its mtime read

**tests/test_dub_download_mtime.py** (new file)
- Added regression test that mocks `yt_dlp.YoutubeDL` and verifies `updatetime=False` is set in the options
- Test confirms the fix prevents the Windows failure mode by asserting the option is properly configured during URL ingest

<!-- end of auto-generated comment: release notes by coderabbit.ai -->