### PR TITLE
fix(startup): timeout-bound MCP session-manager start to stop M1 startup hang (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
   contact — less wall-of-text, faster to act on.
 ### Fixed
 
+- **Backend no longer hangs on startup (unreachable, no error) on Apple-Silicon Macs.**
+  The MCP session manager could hang on its anyio task group during lifespan
+  startup (observed on M1, #632); because that start was awaited before the server
+  began serving, "Application startup complete" never fired and the whole backend
+  was unreachable. The MCP start is now timeout-bounded (`OMNIVOICE_MCP_START_TIMEOUT_S`,
+  default 30s) — a hang becomes a logged warning and the backend serves normally
+  without MCP, instead of wedging. (#632)
+
 - **Dubbing a URL no longer fails with `[Errno 22] Invalid argument` on Windows.**
   yt-dlp stamps the downloaded file's modified-time with the video's upload
   date; an out-of-range/invalid timestamp makes the `os.utime` call raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -385,6 +385,48 @@ def _env_flag(name: str, default: bool = False) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _mcp_start_timeout_s() -> float:
+    """Seconds to wait for the MCP session manager to start before giving up
+    and serving without it (#632). Overridable via OMNIVOICE_MCP_START_TIMEOUT_S."""
+    raw = os.environ.get("OMNIVOICE_MCP_START_TIMEOUT_S", "")
+    try:
+        v = float(raw)
+        if v > 0:
+            return v
+    except (TypeError, ValueError):
+        pass
+    return 30.0
+
+
+async def _enter_mcp_session_manager(stack, session_manager, *, timeout: float) -> bool:
+    """Best-effort start of the FastMCP Streamable-HTTP session manager.
+
+    Returns True if it mounted. The MCP layer is explicitly best-effort: it must
+    never wedge backend startup. The earlier guard only caught *exceptions*, but
+    on some platforms (observed: Apple-Silicon M1, #632) ``session_manager.run()``
+    can *hang* on its anyio task group — and an awaited hang means
+    "Application startup complete" never fires, so the whole backend is
+    unreachable with no error. Bounding the enter with a timeout converts that
+    hang into a logged warning + a backend that still serves (just without MCP).
+    """
+    if session_manager is None:
+        return False
+    try:
+        await asyncio.wait_for(
+            stack.enter_async_context(session_manager.run()), timeout=timeout
+        )
+        return True
+    except asyncio.TimeoutError:
+        logger.warning(
+            "MCP session manager did not start within %.0fs (#632); serving "
+            "without MCP. Set OMNIVOICE_MCP_START_TIMEOUT_S to adjust.", timeout,
+        )
+        return False
+    except Exception as e:
+        logger.warning("MCP session manager failed to start: %s", e)
+        return False
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup watchdog (#632): a silent hang during startup (e.g. a model-load /
@@ -496,12 +538,10 @@ async def lifespan(app: FastAPI):
     from contextlib import AsyncExitStack
     async with AsyncExitStack() as _mcp_stack:
         _sm = getattr(app.state, "mcp_session_manager", None)
-        if _sm is not None:
-            try:
-                await _mcp_stack.enter_async_context(_sm.run())
-                logger.info("MCP server mounted at /mcp")
-            except Exception as e:
-                logger.warning("MCP session manager failed to start: %s", e)
+        if await _enter_mcp_session_manager(
+            _mcp_stack, _sm, timeout=_mcp_start_timeout_s()
+        ):
+            logger.info("MCP server mounted at /mcp")
         # Startup finished — disarm the hang watchdog before serving (#632).
         if _watchdog_armed:
             try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -398,33 +398,54 @@ def _mcp_start_timeout_s() -> float:
     return 30.0
 
 
-async def _enter_mcp_session_manager(stack, session_manager, *, timeout: float) -> bool:
-    """Best-effort start of the FastMCP Streamable-HTTP session manager.
+async def _serve_mcp(session_manager, ready: "asyncio.Event", stop: "asyncio.Event") -> None:
+    """Own the MCP session manager's full enter→exit lifecycle in ONE task.
 
-    Returns True if it mounted. The MCP layer is explicitly best-effort: it must
-    never wedge backend startup. The earlier guard only caught *exceptions*, but
-    on some platforms (observed: Apple-Silicon M1, #632) ``session_manager.run()``
-    can *hang* on its anyio task group — and an awaited hang means
-    "Application startup complete" never fires, so the whole backend is
-    unreachable with no error. Bounding the enter with a timeout converts that
-    hang into a logged warning + a backend that still serves (just without MCP).
+    FastMCP's ``run()`` opens an anyio task group, and anyio requires the cancel
+    scope to be exited in the *same task* that entered it. So we must NOT enter
+    it via ``wait_for`` (which runs the enter in a throwaway sub-task) or on the
+    lifespan task and exit it elsewhere — either raises "Attempted to exit cancel
+    scope in a different task". This coroutine enters and exits the context
+    itself: it signals ``ready`` once mounted, then idles until ``stop``.
     """
-    if session_manager is None:
-        return False
     try:
-        await asyncio.wait_for(
-            stack.enter_async_context(session_manager.run()), timeout=timeout
-        )
-        return True
+        async with session_manager.run():
+            ready.set()
+            await stop.wait()
+    except Exception as e:
+        logger.warning("MCP session manager stopped: %s", e)
+    finally:
+        ready.set()  # never leave startup blocked on the readiness wait
+
+
+async def _start_mcp_session_manager(session_manager, *, timeout: float):
+    """Start MCP off the startup critical path; wait up to ``timeout`` for it to
+    signal ready. Returns ``(task, stop_event, mounted)``.
+
+    The MCP layer is best-effort and must never wedge backend startup. On some
+    platforms (observed: Apple-Silicon M1, #632) ``run()`` can *hang* on its
+    anyio task group; the old code awaited the enter before serving, so the hang
+    meant "Application startup complete" never fired and the whole backend was
+    unreachable with no error. Now the enter lives in its own task and we only
+    *optionally* wait on a ready signal — a hang becomes a logged warning + a
+    backend that serves normally without MCP.
+    """
+    stop = asyncio.Event()
+    if session_manager is None:
+        return None, stop, False
+    ready = asyncio.Event()
+    task = asyncio.create_task(_serve_mcp(session_manager, ready, stop))
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=timeout)
+        mounted = not task.done()  # ready is also set on failure → not mounted
     except asyncio.TimeoutError:
         logger.warning(
-            "MCP session manager did not start within %.0fs (#632); serving "
-            "without MCP. Set OMNIVOICE_MCP_START_TIMEOUT_S to adjust.", timeout,
+            "MCP session manager did not signal ready within %.0fs (#632); "
+            "serving without waiting. Set OMNIVOICE_MCP_START_TIMEOUT_S to adjust.",
+            timeout,
         )
-        return False
-    except Exception as e:
-        logger.warning("MCP session manager failed to start: %s", e)
-        return False
+        mounted = False
+    return task, stop, mounted
 
 
 @asynccontextmanager
@@ -530,28 +551,37 @@ async def lifespan(app: FastAPI):
         logger.info("Capture ASR preload disabled; dictation ASR will load on first use.")
 
     # ── MCP session manager (Wave 2.2) ────────────────────────────────────
-    # FastMCP's Streamable-HTTP transport needs its session manager running
-    # for the lifetime of the app. It's created lazily by streamable_http_app()
-    # (called in mount_mcp below), so we stack its `run()` context into ours
-    # via AsyncExitStack rather than replacing this lifespan. Best-effort: a
-    # missing/broken MCP layer must never stop the rest of the backend.
-    from contextlib import AsyncExitStack
-    async with AsyncExitStack() as _mcp_stack:
-        _sm = getattr(app.state, "mcp_session_manager", None)
-        if await _enter_mcp_session_manager(
-            _mcp_stack, _sm, timeout=_mcp_start_timeout_s()
-        ):
-            logger.info("MCP server mounted at /mcp")
-        # Startup finished — disarm the hang watchdog before serving (#632).
-        if _watchdog_armed:
-            try:
-                import faulthandler
-                faulthandler.cancel_dump_traceback_later()
-            except Exception:
-                pass
-        yield
+    # FastMCP's Streamable-HTTP transport needs its session manager running for
+    # the lifetime of the app. Run it in its OWN task that owns the full
+    # enter→exit lifecycle (anyio task-affinity, see _serve_mcp) and only wait,
+    # with a timeout, for it to signal ready — so a hang on its anyio group
+    # (observed on M1, #632) can never wedge "Application startup complete".
+    _sm = getattr(app.state, "mcp_session_manager", None)
+    mcp_task, mcp_stop, mcp_mounted = await _start_mcp_session_manager(
+        _sm, timeout=_mcp_start_timeout_s()
+    )
+    if mcp_mounted:
+        logger.info("MCP server mounted at /mcp")
+    # Startup finished — disarm the hang watchdog before serving (#632).
+    if _watchdog_armed:
+        try:
+            import faulthandler
+            faulthandler.cancel_dump_traceback_later()
+        except Exception:
+            pass
+    yield
     # ── Graceful shutdown (SIGTERM from Tauri, Ctrl+C, etc.) ────────────
     logger.info("Shutdown: cleaning up…")
+    # Stop MCP first — signal its task to exit its own anyio context (correct
+    # task-affinity), then bound the wait so a wedged manager can't hang exit.
+    mcp_stop.set()
+    if mcp_task is not None:
+        try:
+            await asyncio.wait_for(mcp_task, timeout=5.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+        except Exception:
+            pass
     idle_task.cancel()
     worker_task.cancel()
     # Wait for tasks to finish their current iteration

--- a/tests/test_mcp_startup_timeout.py
+++ b/tests/test_mcp_startup_timeout.py
@@ -1,0 +1,66 @@
+"""MCP session-manager start must never wedge backend startup (#632).
+
+On Apple-Silicon M1 the FastMCP Streamable-HTTP session manager could *hang* on
+its anyio task group during lifespan startup. Because that enter is awaited
+before `yield`, the hang meant "Application startup complete" never fired and the
+whole backend was unreachable with no error. The start is now timeout-bounded:
+a hang becomes a logged warning + a backend that still serves (without MCP).
+"""
+import asyncio
+import contextlib
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+from main import _enter_mcp_session_manager, _mcp_start_timeout_s  # noqa: E402
+
+
+class _CM:
+    def __init__(self, hang):
+        self.hang = hang
+
+    async def __aenter__(self):
+        if self.hang:
+            await asyncio.sleep(60)  # never completes within the test timeout
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _SM:
+    def __init__(self, hang):
+        self.hang = hang
+
+    def run(self):
+        return _CM(self.hang)
+
+
+def _run(sm, timeout):
+    async def go():
+        async with contextlib.AsyncExitStack() as stack:
+            return await _enter_mcp_session_manager(stack, sm, timeout=timeout)
+    return asyncio.run(go())
+
+
+def test_hang_times_out_and_continues():
+    # The whole point: a hanging manager returns False fast, never raises.
+    assert _run(_SM(hang=True), 0.2) is False
+
+
+def test_healthy_manager_mounts():
+    assert _run(_SM(hang=False), 5.0) is True
+
+
+def test_none_manager_is_noop():
+    assert _run(None, 5.0) is False
+
+
+def test_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_MCP_START_TIMEOUT_S", "12.5")
+    assert _mcp_start_timeout_s() == 12.5
+    monkeypatch.delenv("OMNIVOICE_MCP_START_TIMEOUT_S", raising=False)
+    assert _mcp_start_timeout_s() == 30.0
+    monkeypatch.setenv("OMNIVOICE_MCP_START_TIMEOUT_S", "garbage")
+    assert _mcp_start_timeout_s() == 30.0  # invalid → safe default

--- a/tests/test_mcp_startup_timeout.py
+++ b/tests/test_mcp_startup_timeout.py
@@ -1,26 +1,30 @@
 """MCP session-manager start must never wedge backend startup (#632).
 
 On Apple-Silicon M1 the FastMCP Streamable-HTTP session manager could *hang* on
-its anyio task group during lifespan startup. Because that enter is awaited
+its anyio task group during lifespan startup. Because that enter was awaited
 before `yield`, the hang meant "Application startup complete" never fired and the
-whole backend was unreachable with no error. The start is now timeout-bounded:
-a hang becomes a logged warning + a backend that still serves (without MCP).
+whole backend was unreachable with no error. MCP now runs in its own task (it
+owns the anyio enter→exit itself — task-affinity) and startup only *optionally*
+waits, with a timeout, on a ready signal: a hang → a logged warning + a backend
+that still serves without MCP.
 """
 import asyncio
-import contextlib
 import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
 
-from main import _enter_mcp_session_manager, _mcp_start_timeout_s  # noqa: E402
+from main import _start_mcp_session_manager, _mcp_start_timeout_s  # noqa: E402
 
 
 class _CM:
-    def __init__(self, hang):
+    def __init__(self, hang, raise_on_enter=False):
         self.hang = hang
+        self.raise_on_enter = raise_on_enter
 
     async def __aenter__(self):
+        if self.raise_on_enter:
+            raise RuntimeError("boom")
         if self.hang:
             await asyncio.sleep(60)  # never completes within the test timeout
         return self
@@ -30,31 +34,44 @@ class _CM:
 
 
 class _SM:
-    def __init__(self, hang):
-        self.hang = hang
+    def __init__(self, hang=False, raise_on_enter=False):
+        self._cm = _CM(hang, raise_on_enter)
 
     def run(self):
-        return _CM(self.hang)
+        return self._cm
 
 
-def _run(sm, timeout):
+def _drive(sm, timeout):
+    """Run _start_mcp_session_manager, then clean up the task; return `mounted`."""
     async def go():
-        async with contextlib.AsyncExitStack() as stack:
-            return await _enter_mcp_session_manager(stack, sm, timeout=timeout)
+        task, stop, mounted = await _start_mcp_session_manager(sm, timeout=timeout)
+        stop.set()
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except BaseException:
+                pass
+        return mounted
     return asyncio.run(go())
 
 
-def test_hang_times_out_and_continues():
-    # The whole point: a hanging manager returns False fast, never raises.
-    assert _run(_SM(hang=True), 0.2) is False
+def test_hang_does_not_block_startup():
+    # The crux: a hanging manager returns fast with mounted=False (no raise).
+    assert _drive(_SM(hang=True), 0.2) is False
 
 
 def test_healthy_manager_mounts():
-    assert _run(_SM(hang=False), 5.0) is True
+    assert _drive(_SM(hang=False), 5.0) is True
+
+
+def test_broken_manager_is_not_mounted():
+    # An exception during enter → not mounted, startup still proceeds.
+    assert _drive(_SM(raise_on_enter=True), 5.0) is False
 
 
 def test_none_manager_is_noop():
-    assert _run(None, 5.0) is False
+    assert _drive(None, 5.0) is False
 
 
 def test_timeout_env_override(monkeypatch):


### PR DESCRIPTION
## Diagnosis (from the reporter's thread dump)
The faulthandler dump on M1 showed the asyncio loop **alive but idle** (parked at an `await`), an **idle ThreadPoolExecutor worker**, and a **leaked semaphore** at shutdown — the signature of the **FastMCP Streamable-HTTP session manager hanging on its anyio task group** during lifespan startup.

Because `await _mcp_stack.enter_async_context(_sm.run())` is awaited **before `yield`**, that hang meant *Application startup complete* never fired and the **whole backend was unreachable with no error** — a P0 (a default feature dead on a platform). MCP is mounted by default, so this hit M1 users out of the box.

## Fix
The MCP layer is explicitly *best-effort*, but the old guard only caught **exceptions**, not **hangs**. Bound the start with `asyncio.wait_for` (**OMNIVOICE_MCP_START_TIMEOUT_S, default 30s**): a hang becomes a logged warning and the backend **serves normally without MCP** instead of wedging. Extracted `_enter_mcp_session_manager` + `_mcp_start_timeout_s` (testable).

## Tests
`tests/test_mcp_startup_timeout.py` (4): hanging manager returns False fast (no raise), healthy returns True, None is a no-op, env override + invalid-fallback. No version bump.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## MCP Session Manager Startup Timeout (Issue `#632`)

**Problem:** On Apple Silicon M1 Macs, the FastMCP Streamable-HTTP session manager could *hang indefinitely* during backend lifespan startup, preventing `"Application startup complete"` from firing and leaving the backend unreachable (with no error output).

**Root Cause:** The MCP session manager `run()`/enter lifecycle was awaited without any timeout; the exception handler only handled exceptions, not an indefinite hang.

### New mechanism

```mermaid
flowchart TD
    A["FastAPI lifespan startup"] --> B["Get session_manager from app.state"]
    B --> C["Start MCP in its own task (_serve_mcp)"]
    C --> D["Wait up to timeout for ready signal (asyncio.wait_for)"]
    D -->|ready before timeout| E["mounted = not task.done()"]
    D -->|timeout| F["Log warning; mounted=False"]
    E --> G["If mounted: log 'MCP server mounted at /mcp'"]
    F --> H["Continue startup normally (no MCP mount/wait)"]
    G --> I["App serves"]
    H --> I["App serves"]
    I --> J["Shutdown: set stop event; bounded wait for MCP task"]
```

### Implementation details

**`backend/main.py`:**
- Added `_mcp_start_timeout_s()` to parse `OMNIVOICE_MCP_START_TIMEOUT_S` as a positive float; defaults to **30.0s** on unset/invalid.
- Added `_serve_mcp(session_manager, ready, stop)` which owns the entire **enter→exit** lifecycle inside **one task** (important for anyio task-affinity). It sets `ready` when mounted, and logs a warning if the manager stops/errs.
- Added `_start_mcp_session_manager(session_manager, *, timeout)` which:
  - starts `_serve_mcp` in a background task,
  - waits for `ready.wait()` bounded by `asyncio.wait_for(..., timeout=...)`,
  - on timeout logs a warning and returns `mounted=False` so backend startup continues.
- Updated `lifespan()` to call `_start_mcp_session_manager(...)` and proceed serving regardless of MCP mount/ready failure.
- Shutdown now signals MCP via `mcp_stop.set()` and awaits completion with a short timeout (5s) to avoid wedged shutdown.

### Tests

**`tests/test_mcp_startup_timeout.py`:**
- `test_hang_does_not_block_startup()`: a hanging manager returns quickly with `mounted=False`.
- `test_healthy_manager_mounts()`: a healthy manager yields `mounted=True`.
- `test_broken_manager_is_not_mounted()`: exceptions during enter result in `mounted=False` (no startup failure).
- `test_none_manager_is_noop()`: `None` manager returns `mounted=False`.
- `test_timeout_env_override()`: validates env var override parsing, default fallback to 30.0, and safe fallback on invalid values.

### Changelog

**`CHANGELOG.md`:**
- Added a **Fixed** entry noting the backend no longer hangs on startup on Apple-Silicon Macs; MCP startup is now timeout-bounded and best-effort (`OMNIVOICE_MCP_START_TIMEOUT_S`, default 30s).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->