### PR TITLE
test(onboarding): guard demo clip stays un-ignored + bundled (#621)

### DIFF
--- a/tests/test_onboarding_demo.py
+++ b/tests/test_onboarding_demo.py
@@ -34,6 +34,49 @@ def test_demo_clip_is_committed_and_valid():
         assert w.getframerate() > 0
 
 
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_demo_clip_is_not_gitignored():
+    """`.gitignore` has a blanket `*.wav`; the clip survives only via the
+    `!backend/assets/samples/*.wav` allowlist. If that allowlist is ever
+    weakened the file becomes ignored — and any build tool that walks with
+    gitignore semantics (the `ignore` crate, `git archive`, Docker) would drop
+    it from the bundle while it still sits in the repo. Pin that it is NOT
+    ignored so the silent-drop class can't return (#621/#633)."""
+    import shutil
+    import subprocess
+    if shutil.which("git") is None:
+        import pytest
+        pytest.skip("git not available")
+    rel = "backend/assets/samples/demo_voice.wav"
+    # `git check-ignore` exits 0 (and echoes the path) when the path IS ignored.
+    res = subprocess.run(
+        ["git", "check-ignore", rel], cwd=_ROOT,
+        capture_output=True, text=True,
+    )
+    assert res.returncode != 0 and not res.stdout.strip(), (
+        f"{rel} is gitignored — the un-ignore allowlist in .gitignore was lost. "
+        "Restore `!backend/assets/samples/*.wav` or the clip drops from builds."
+    )
+
+
+def test_backend_is_a_bundled_tauri_resource():
+    """The clip ships only because the whole `backend/` tree is a Tauri bundle
+    resource. If that entry is removed, the asset (and the backend) stops
+    shipping. Pin it."""
+    import json
+    conf = os.path.join(_ROOT, "frontend", "src-tauri", "tauri.conf.json")
+    if not os.path.isfile(conf):
+        import pytest
+        pytest.skip("tauri.conf.json not found")
+    resources = json.load(open(conf)).get("bundle", {}).get("resources", []) or []
+    assert any(str(r).rstrip("/").endswith("backend") for r in resources), (
+        "backend/ is no longer a bundle resource in tauri.conf.json — the demo "
+        "clip and the backend source would stop shipping with the app."
+    )
+
+
 def _table_sql():
     return (
         "CREATE TABLE voice_profiles (id TEXT PRIMARY KEY, name TEXT, "


### PR DESCRIPTION
A Windows user's backend log showed `Demo audio not found … demo_voice.wav — skipping onboarding seed`. I verified the locally-built `.app` **does** ship the clip, so that user just has a build predating #633 — **not** a systemic bundling bug.

But the existing onboarding test only checks the file exists in the repo. It misses the two ways the clip could silently drop from **all** builds while still in the repo:
1. The `.gitignore` un-ignore allowlist (`!backend/assets/samples/*.wav`, under a blanket `*.wav`) being weakened — then gitignore-aware build walkers (the `ignore` crate, `git archive`, Docker) skip it.
2. `backend/` being removed from `tauri.conf.json` bundle `resources`.

This pins both (skips cleanly if git/conf absent). **Test-only**, 5 pass. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds regression test coverage to prevent the demo audio clip (`backend/assets/samples/demo_voice.wav`) from being silently omitted during builds. The tests guard against two failure modes discovered when a Windows user's build lacked the demo clip despite it existing in the repository.

### Changes

**`tests/test_onboarding_demo.py`**

Added a module-level `_ROOT` constant to establish the repository root path, along with two new test functions:

1. **`test_demo_clip_is_not_gitignored()`** — Validates that the demo clip is not ignored by `.gitignore` using `git check-ignore`. This detects if the un-ignore allowlist (`!backend/assets/samples/*.wav`) is accidentally weakened or removed, which would cause gitignore-aware build tools (the `ignore` crate, `git archive`, Docker) to silently drop the file from the bundle while it remains in the repository.

2. **`test_backend_is_a_bundled_tauri_resource()`** — Parses `frontend/src-tauri/tauri.conf.json` and asserts that `backend/` is included in the `bundle.resources` configuration. This prevents the scenario where the backend directory is removed from the Tauri bundle config, which would stop the demo clip (and backend source) from shipping.

Both tests include conditional skips when dependencies are unavailable (`git` for the first test, `tauri.conf.json` for the second). The existing onboarding tests remain unchanged.

### Impact

- **Lines changed:** +43/-0 (test-only)
- **Test coverage:** 5 passing tests (2 new + 3 existing)
- **No version bump required**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->