### PR TITLE
chore(desktop-prod): add --keep-models for fast fresh-app runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "desktop-prod": "bun scripts/desktop-prod.mjs",
     "desktop-prod:run": "bun scripts/desktop-prod.mjs --skip-build",
     "desktop-prod:upgrade": "bun scripts/desktop-prod.mjs --keep-data",
+    "desktop-prod:keep-models": "bun scripts/desktop-prod.mjs --keep-models",
     "desktop-prod:pill": "bun scripts/desktop-prod.mjs --pill",
     "desktop-prod:run:pill": "bun scripts/desktop-prod.mjs --skip-build --pill",
     "build": "turbo run build",

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -67,19 +67,24 @@ fi
 # ── Flags ──────────────────────────────────────────────────────────────────
 SKIP_BUILD=false
 KEEP_DATA=false
+KEEP_MODELS=false
 PILL_MODE=false
 
 for arg in "$@"; do
   case "$arg" in
-    --skip-build) SKIP_BUILD=true ;;
-    --keep-data)  KEEP_DATA=true ;;
-    --pill)       PILL_MODE=true ;;
+    --skip-build)  SKIP_BUILD=true ;;
+    --keep-data)   KEEP_DATA=true ;;
+    --keep-models) KEEP_MODELS=true ;;
+    --pill)        PILL_MODE=true ;;
     -h|--help)
-      echo "Usage: $0 [--skip-build] [--keep-data] [--pill]"
+      echo "Usage: $0 [--skip-build] [--keep-data] [--keep-models] [--pill]"
       echo ""
-      echo "  --skip-build  Skip cargo build, use last compiled binary"
-      echo "  --keep-data   Don't wipe app data (test upgrade path)"
-      echo "  --pill        Launch in dictation-widget mode (no main window)"
+      echo "  --skip-build   Skip cargo build, use last compiled binary"
+      echo "  --keep-data    Don't wipe app data (test upgrade path)"
+      echo "  --keep-models  Wipe app/backend data for a fresh app, but KEEP the"
+      echo "                 HF model cache — fresh first-run without re-downloading"
+      echo "                 the multi-GB weights. Ignored when --keep-data is set."
+      echo "  --pill         Launch in dictation-widget mode (no main window)"
       exit 0
       ;;
   esac
@@ -109,7 +114,17 @@ if [ "$KEEP_DATA" = false ]; then
   fi
 
   # 2. HF model cache (downloaded .safetensors, tokenizers, etc.)
-  if [ -d "${HF_CACHE}" ]; then
+  #    --keep-models preserves it so a "fresh app" run doesn't re-pull multi-GB
+  #    weights (the model-download is the slow, bandwidth-heavy part of a clean
+  #    run; everything else still resets for an honest first-run emulation).
+  if [ "$KEEP_MODELS" = true ]; then
+    if [ -d "${HF_CACHE}" ]; then
+      HF_SIZE=$(du -sh "${HF_CACHE}" 2>/dev/null | cut -f1)
+      echo "   ◆ HF cache:     ${HF_CACHE} (${HF_SIZE}) — KEPT (--keep-models)"
+    else
+      echo "   ○ HF cache:     (already clean)"
+    fi
+  elif [ -d "${HF_CACHE}" ]; then
     HF_SIZE=$(du -sh "${HF_CACHE}" 2>/dev/null | cut -f1)
     echo "   ✗ HF cache:     ${HF_CACHE} (${HF_SIZE})"
     rm -rf "${HF_CACHE}"


### PR DESCRIPTION
`bun desktop-prod` (clean) wipes **everything** including the HF model cache, so every fresh-install emulation re-downloads the multi-GB weights — slow, bandwidth-heavy, and the exact pain users on flaky networks hit (and we hit testing today).

**`--keep-models`** wipes app/backend data, logs, and webview state for an honest first-run emulation, but **keeps the model cache** so the weights aren't re-pulled. Ignored under `--keep-data` (which keeps everything). Adds a `desktop-prod:keep-models` convenience script.

- `bash -n` clean; `--help` documents it; the wipe block prints `◆ HF cache: … — KEPT (--keep-models)`.
- Scripts-only `package.json` change → no deps, `bun.lock` unaffected. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added a `--keep-models` flag to the `bun desktop-prod` command to accelerate development iteration and fresh-install testing by preserving the Hugging Face model cache during cleanup, avoiding multi-gigabyte re-downloads of model weights.

## Changes

### package.json
- Added new npm script entry `desktop-prod:keep-models` that invokes `bun scripts/desktop-prod.mjs --keep-models`

### scripts/desktop-prod.sh
- Added `KEEP_MODELS` flag variable initialized to `false` (line 70)
- Updated argument parsing to recognize `--keep-models` flag (line 77)
- Extended help documentation (lines 80–86) explaining that `--keep-models` wipes app/backend data for a fresh first-run emulation but preserves the HF model cache; noted that the flag is ignored when `--keep-data` is set
- Modified HF cache cleanup logic (lines 116–133):
  - When `--keep-models` is true and HF cache exists: calculates and displays cache size, outputs status message "◆ HF cache: … — KEPT (--keep-models)", and skips deletion
  - When `--keep-models` is false: maintains existing behavior of removing the HF cache
  - When `--keep-data` is true: no cleanup occurs (existing behavior, `--keep-models` is ignored)

## Behavior Flow

```mermaid
graph TD
    A["Start: bun desktop-prod"] --> B{"--keep-data<br/>set?"}
    B -->|Yes| C["✓ Keep all data<br/>Upgrade test mode"]
    B -->|No| D["🧹 Clean app/backend data<br/>Fresh install simulation"]
    D --> E{"--keep-models<br/>set?"}
    E -->|Yes| F["◆ Keep HF cache<br/>Display size"]
    E -->|No| G["✗ Delete HF cache<br/>Full reset"]
    F --> H["Continue: Clean logs,<br/>webview, build, launch"]
    G --> H
    C --> H
    H --> I["✅ App launched"]
```

## Notes

- No dependencies added; no impact to `bun.lock` or version numbers
- Input validation uses standard bash `-n` checks for directory existence
- Changes are isolated to scripts and package configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->