### PR TITLE
fix(audiobook): play long-form preview via streaming HTTP, not decodeAudioData (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
   contact — less wall-of-text, faster to act on.
 ### Fixed
 
+- **In-app preview of finished audiobooks/stories now plays on Windows.**
+  The preview decoded the entire render into one in-memory PCM buffer via Web
+  Audio `decodeAudioData`, which fails on long-form `.m4b`/AAC under WebView2
+  (`EncodingError: Unable to decode audio data`), and the blob-URL fallback can't
+  play in a Tauri `<audio>` element — so nothing played. The fallback now uploads
+  to the preview endpoint (ffmpeg-extracts a streamable WAV) and plays the HTTP
+  URL, the same path video previews use. Short TTS previews are unchanged. (#653)
+
 - **First-run setup splash no longer shows a raw `bootstrap.lines` key in English.**
   The log-line counter string was present in 4 locales but missing from the `en`
   reference, so English (and 16 other locales falling back to it) rendered the

--- a/frontend/src/test/playBlobAudioFallback.test.js
+++ b/frontend/src/test/playBlobAudioFallback.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #653: in Tauri, decodeAudioData chokes on long-form audiobook/story renders
+// (.m4b / AAC) and a blob: URL won't play in an <audio> element. The fallback
+// must upload to /preview/upload and play the returned HTTP URL — NOT a blob:.
+vi.mock('../utils/apiBase', () => ({
+  API_BASE: 'http://127.0.0.1:3900',
+  isTauriContext: () => true,
+}));
+vi.mock('../utils/playback', () => ({ claimPlayback: () => () => {} }));
+
+// Imported after the mocks so media.js picks up isTauri = true at module load.
+const { playBlobAudio } = await import('../utils/media');
+
+describe('playBlobAudio fallback (#653 — long-form m4b on Tauri/WebView2)', () => {
+  let audioSrcs;
+
+  beforeEach(() => {
+    audioSrcs = [];
+    // AudioContext whose decodeAudioData fails like WebView2 on a big m4b.
+    global.AudioContext = class {
+      state = 'running';
+      destination = {};
+      async resume() {}
+      async decodeAudioData() { throw new DOMException('Unable to decode audio data', 'EncodingError'); }
+      createBufferSource() { return { connect() {}, start() {}, stop() {} }; }
+      close() {}
+    };
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ url: '/preview/x.audio', audioUrl: '/preview/x.wav' }),
+    }));
+    global.Audio = class {
+      constructor(url) { this.src = url; audioSrcs.push(url); }
+      play() { return Promise.resolve(); }
+      pause() {}
+    };
+  });
+
+  it('uploads to /preview/upload and plays the HTTP audioUrl (never a blob: URL)', async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3, 4])], { type: 'audio/mp4' });
+    await playBlobAudio(blob);
+
+    // Uploaded to the preview endpoint…
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, opts] = global.fetch.mock.calls[0];
+    expect(calledUrl).toBe('http://127.0.0.1:3900/preview/upload');
+    expect(opts.method).toBe('POST');
+
+    // …and played the HTTP URL, not a blob:.
+    expect(audioSrcs).toContain('http://127.0.0.1:3900/preview/x.wav');
+    expect(audioSrcs.some((u) => u.startsWith('blob:'))).toBe(false);
+  });
+});

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -80,15 +80,23 @@ export const playBlobAudio = async (blob) => {
     } catch (e) {
       console.error('playBlobAudio decode error:', e);
       ctx.close();
-      // Fallback: try the standard Audio() path even in Tauri
+      // Fallback (#653): decodeAudioData decodes the WHOLE file into one PCM
+      // AudioBuffer — it chokes on long-form audiobook/story renders (.m4b / AAC)
+      // on WebView2. And a blob: URL won't play in an <audio> element under
+      // Tauri's WebKit (see fileToMediaUrl above), so the old createObjectURL
+      // fallback silently played nothing. Instead, upload to the backend preview
+      // endpoint (ffmpeg-extracts a streamable WAV) and play the HTTP URL — the
+      // same path video previews already use. Streams; no whole-file decode.
       try {
-        const url = URL.createObjectURL(blob);
+        const form = new FormData();
+        form.append('video', blob, 'preview.audio');
+        const res = await fetch(`${_PREVIEW_API}/preview/upload`, { method: 'POST', body: form });
+        if (!res.ok) throw new Error(`preview upload failed: ${res.status}`);
+        const data = await res.json();
+        const url = `${_PREVIEW_API}${data.audioUrl || data.url}`;
         const a = new Audio(url);
-        const release = claimPlayback(() => {
-          a.pause();
-          URL.revokeObjectURL(url);
-        }, 'output');
-        a.onended = () => { URL.revokeObjectURL(url); release(); };
+        const release = claimPlayback(() => { a.pause(); }, 'output');
+        a.onended = () => { release(); };
         await a.play().catch((err) => { release(); throw err; });
       } catch (e2) {
         console.error('playBlobAudio fallback error:', e2);


### PR DESCRIPTION
## Problem
In-app preview of a finished **audiobook/story** does nothing on Windows (reported by moth_and_flame on Discord). Frontend logs:
```
ERROR playBlobAudio decode error: EncodingError: Unable to decode audio data
```
`playBlobAudio` (Tauri path) calls Web Audio `decodeAudioData`, which decodes the **entire render into one in-memory PCM buffer** — it fails on long-form **`.m4b`/AAC** under WebView2. The catch-block fallback then used a **blob: URL**, which the file's own `fileToMediaUrl` already documents as **not playable in a Tauri `<audio>` element** — so it silently played nothing (no fallback-error line, no audio).

## Fix
The fallback now uploads the blob to **`/preview/upload`** (ffmpeg-extracts a streamable WAV server-side) and plays the returned **HTTP URL** via `<audio>` — the exact path video previews already use. Streams instead of whole-file decode, so it also fixes hour-long renders regardless of platform. **Short WAV TTS previews keep the fast `decodeAudioData` path.**

## Tests / safety
- `playBlobAudioFallback.test.js`: pins that on a `decodeAudioData` failure the fallback hits `/preview/upload` and plays an **HTTP URL, never `blob:`**. Build green. No version bump.

## Note
This fixes the **preview path** (the most likely cause — short clips work via the same fn, so the render itself is probably fine). If a Windows tester finds the downloaded `.m4b` is itself corrupt, that's a separate render bug — please confirm on the issue.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes in-app preview playback for finished audiobooks on Windows (WebView2 / Tauri). When users click to preview a completed audiobook render in the Projects view, the preview now plays successfully instead of failing silently with "EncodingError: Unable to decode audio data."

## Root Cause
The `playBlobAudio` function in `frontend/src/utils/media.js` attempted to decode entire audiobook renders (`.m4b` / AAC-in-MP4 format) into a single in-memory PCM AudioBuffer via Web Audio's `decodeAudioData`. This approach fails under WebView2 for long-form files. The previous catch-block fallback tried to play a `blob:` URL via an `<audio>` element, but Tauri's `<audio>` implementation does not support `blob:` URLs, resulting in silent failure and no audio playback.

## Solution
When `decodeAudioData` fails (indicating a long-form or unsupported audio format), the new fallback uploads the blob to the backend `/preview/upload` endpoint. The server extracts a streamable WAV file via ffmpeg and returns an HTTP URL, which is then played via the `<audio>` element. This matches the existing pattern used for video previews. Short WAV TTS previews continue using the fast `decodeAudioData` path.

### Playback Flow
```mermaid
flowchart TD
    A["playBlobAudio invoked with blob"] --> B["Attempt decodeAudioData"]
    B -->|Success| C["Play via AudioContext<br/>(fast path)"]
    B -->|Failure| D["Upload blob to<br/>/preview/upload"]
    D -->|Success| E["Receive HTTP audioUrl<br/>from backend"]
    E --> F["Create Audio element<br/>with HTTP URL"]
    F --> G["Play via &lt;audio&gt; element<br/>(streaming)"]
    C -->|Error| H["Log decode error"]
    D -->|Error| I["Log fallback error"]
```

## Changes

**CHANGELOG.md**
- Added entry documenting the Windows audiobook preview fix

**frontend/src/utils/media.js**
- Modified Tauri fallback in `playBlobAudio`:
  - Removed blob URL creation and revocation logic
  - Added `/preview/upload` endpoint request with the audio blob
  - Changed playback to use returned HTTP URL via `<audio>` element
  - Updated error logging to distinguish fallback errors
  - `claimPlayback` now only manages the playback lock (no object URL revocation)

**frontend/src/test/playBlobAudioFallback.test.js** (new)
- Added Vitest test suite for the Tauri fallback path
- Verifies that when `decodeAudioData` fails, the function:
  - POSTs the blob to `/preview/upload` endpoint
  - Plays the returned HTTP URL (not a `blob:` URL)
  - Properly handles the fallback recovery mechanism
- Mocks Tauri context, `AudioContext.decodeAudioData`, and `fetch` to simulate the failure scenario

## Impact
- **Windows users**: Audiobook/story previews now play successfully
- **All platforms**: Hour-long renders now benefit from streaming rather than full in-memory decoding
- **Short TTS previews**: Unaffected; continue using fast `decodeAudioData` path
- **Regression testing**: New test ensures the fallback mechanism does not revert to unsupported `blob:` URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->