### PR TITLE
fix(asr): cross-platform speechbrain lazy-import guard — unblock WhisperX on Windows (#630)

### DIFF
--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -153,6 +153,75 @@ class ASRBackend(ABC):
 # ── WhisperX (cross-platform default — forced-alignment word timing) ────────
 
 
+def _harden_speechbrain_lazy_imports() -> None:
+    """Make speechbrain 1.x's lazy-import guard fire on Windows too (#630/#611/#647).
+
+    speechbrain 1.x exposes optional integrations (``k2_fsa``, ``numba`` losses,
+    ``spacy``/``flair`` nlp) as ``LazyModule`` redirects living in ``sys.modules``.
+    Stray introspection — PyTorch's op-registration machinery, pickling, a
+    ``dir()``/``hasattr`` walk — touches one of these during ``whisperx.load_model``
+    (pyannote → speechbrain), which would *actually* import the optional package.
+    speechbrain guards against that by suppressing the import when the triggering
+    frame is the stdlib ``inspect`` module — but the check is
+    ``filename.endswith("/inspect.py")``, a hardcoded POSIX separator. On Windows
+    the frame filename uses backslashes (``...\\Lib\\inspect.py``), so the guard
+    misses, the redirect imports ``speechbrain.integrations.k2_fsa`` → ``import k2``
+    → k2 isn't installed → ``ImportError: Lazy import of LazyModule(...k2_fsa...)
+    failed``. That bubbles out of WhisperX and aborts transcription with zero
+    segments. WhisperX is the *default* ASR, so this is a Windows-only break of a
+    cross-platform-default feature (P0 parity).
+
+    Fix the whole class — every optional-integration redirect, not just k2 — by
+    re-implementing ``LazyModule.ensure_module`` with an ``os.sep``-agnostic
+    basename check. Idempotent and a no-op on macOS/Linux (basename match is a
+    strict superset of the old forward-slash check) and when speechbrain is
+    absent. A genuine access from real user code with k2 missing still raises
+    ImportError unchanged — only inspect-triggered spurious imports are
+    suppressed, on every platform.
+    """
+    try:
+        from speechbrain.utils import importutils as _iu
+    except Exception:  # speechbrain not installed / import side-effect — nothing to harden
+        return
+    if getattr(_iu.LazyModule, "_omnivoice_xplat_guard", False):
+        return
+    import importlib as _importlib
+    import inspect as _inspect
+    import sys as _sys
+    import warnings as _warnings
+
+    def ensure_module(self, stacklevel):
+        importer_frame = None
+        try:
+            importer_frame = _inspect.getframeinfo(_sys._getframe(stacklevel + 1))
+        except AttributeError:
+            _warnings.warn(
+                "Failed to inspect frame to check if we should ignore importing a "
+                "module lazily (OmniVoice cross-platform guard)."
+            )
+        if importer_frame is not None:
+            # Normalise BOTH separators explicitly (not os.path.basename, which is
+            # host-dependent) so the guard is correct regardless of which os.path
+            # flavour is active. Upstream's `.endswith("/inspect.py")` matched only
+            # POSIX paths — that is the Windows-only bug (#630/#611/#647).
+            base = importer_frame.filename.replace("\\", "/").rsplit("/", 1)[-1]
+            if base == "inspect.py":
+                raise AttributeError()
+        if self.lazy_module is None:
+            try:
+                if self.package is None:
+                    self.lazy_module = _importlib.import_module(self.target)
+                else:
+                    self.lazy_module = _importlib.import_module(f".{self.target}", self.package)
+            except Exception as e:  # noqa: BLE001 — match upstream: wrap as ImportError
+                raise ImportError(f"Lazy import of {repr(self)} failed") from e
+        return self.lazy_module
+
+    _iu.LazyModule.ensure_module = ensure_module
+    _iu.LazyModule._omnivoice_xplat_guard = True
+    logger.debug("speechbrain LazyModule guard hardened for cross-platform inspect.py check")
+
+
 class WhisperXBackend(ASRBackend):
     id = "whisperx"
     display_name = "WhisperX (faster-whisper + wav2vec2 forced alignment)"
@@ -197,6 +266,10 @@ class WhisperXBackend(ASRBackend):
     def _ensure_asr(self):
         if self._asr is not None:
             return
+        # Patch speechbrain's lazy-import guard BEFORE whisperx pulls in pyannote
+        # → speechbrain, or a stray k2_fsa redirect import aborts ASR on Windows
+        # (#630/#611/#647). No-op on macOS/Linux and when speechbrain is absent.
+        _harden_speechbrain_lazy_imports()
         import whisperx
         logger.info(
             "whisperx loading ASR %s on %s (%s)",

--- a/backend/tests/test_asr_speechbrain_lazy_guard.py
+++ b/backend/tests/test_asr_speechbrain_lazy_guard.py
@@ -1,0 +1,84 @@
+"""speechbrain LazyModule cross-platform guard (#630/#611/#647).
+
+speechbrain 1.x suppresses optional-integration imports (k2_fsa, numba, …) that
+are triggered merely by introspection from the stdlib `inspect` module. Its
+guard checked `filename.endswith("/inspect.py")` — a hardcoded POSIX separator —
+so on Windows (backslash paths) the guard MISSED and a stray access to the
+`speechbrain.k2_integration` redirect actually imported the (absent) k2 package,
+raising `ImportError: Lazy import of LazyModule(...k2_fsa...) failed` that aborted
+WhisperX transcription with zero segments.
+
+`_harden_speechbrain_lazy_imports()` re-implements `ensure_module` with an
+`os.path.basename` check so the guard fires on every platform. These tests fake
+the importer frame (both Windows- and POSIX-style `inspect.py` paths, plus a
+real-caller path) so they pin the behaviour regardless of the host OS.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+importutils = pytest.importorskip(
+    "speechbrain.utils.importutils",
+    reason="speechbrain not installed in this environment",
+)
+from services.asr_backend import _harden_speechbrain_lazy_imports  # noqa: E402
+
+
+class _FakeFrameInfo:
+    def __init__(self, filename):
+        self.filename = filename
+
+
+def _bogus_lazy_module():
+    # A LazyModule whose target can never import — so we can observe whether the
+    # inspect.py guard fired (AttributeError) or the import was attempted (ImportError).
+    return importutils.LazyModule(
+        "omnivoice_nonexistent_zzz",
+        "omnivoice_nonexistent_zzz_target",
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    "inspect_path",
+    [
+        r"C:\Python311\Lib\inspect.py",   # Windows — the case the old guard missed
+        "/usr/lib/python3.11/inspect.py",  # POSIX — already worked, must keep working
+    ],
+)
+def test_guard_fires_for_inspect_frame_on_any_separator(monkeypatch, inspect_path):
+    _harden_speechbrain_lazy_imports()
+    lm = _bogus_lazy_module()
+    monkeypatch.setattr(
+        importutils.inspect, "getframeinfo",
+        lambda *_a, **_k: _FakeFrameInfo(inspect_path),
+    )
+    # Guard must treat an inspect.py-triggered access as "attribute absent"
+    # (AttributeError) rather than attempting the doomed import (ImportError).
+    with pytest.raises(AttributeError):
+        lm.ensure_module(0)
+
+
+def test_real_caller_still_surfaces_import_error(monkeypatch):
+    """A genuine access from real user code (not inspect.py) with the target
+    missing must still raise ImportError — we only suppress inspect-triggered
+    spurious imports, never legitimate failures."""
+    _harden_speechbrain_lazy_imports()
+    lm = _bogus_lazy_module()
+    monkeypatch.setattr(
+        importutils.inspect, "getframeinfo",
+        lambda *_a, **_k: _FakeFrameInfo(r"C:\Users\me\app\real_caller.py"),
+    )
+    with pytest.raises(ImportError):
+        lm.ensure_module(0)
+
+
+def test_patch_is_idempotent():
+    _harden_speechbrain_lazy_imports()
+    first = importutils.LazyModule.ensure_module
+    _harden_speechbrain_lazy_imports()
+    assert importutils.LazyModule.ensure_module is first
+    assert getattr(importutils.LazyModule, "_omnivoice_xplat_guard", False) is True


### PR DESCRIPTION
## What

Fixes WhisperX transcription failing **on Windows only** with zero segments —
the largest open inflow cluster: **#630** (carries the real traceback), **#611**, **#647**.

## Root cause

speechbrain 1.x exposes optional integrations (`k2_fsa`, numba losses, spacy/flair nlp) as `LazyModule` redirects in `sys.modules`. Stray introspection during `whisperx.load_model` (pyannote → speechbrain) — PyTorch op-registration, pickling, a `dir()`/`hasattr` walk — touches one. speechbrain *should* suppress an import triggered by the stdlib `inspect` module, but its guard is:

```python
if importer_frame.filename.endswith("/inspect.py"):  # hardcoded POSIX sep
    raise AttributeError()
```

On Windows the frame filename is `...\Lib\inspect.py` (backslashes), so the guard **misses**, the redirect actually imports `speechbrain.integrations.k2_fsa` → `import k2` → k2 isn't installed → `ImportError: Lazy import of LazyModule(...k2_fsa...) failed`. That bubbles out of WhisperX and aborts ASR. macOS/Linux use forward slashes → guard fires → feature works. WhisperX is the **default** ASR, so this is a Windows-only break of a cross-platform default (P0 parity).

## Fix

Re-implement `LazyModule.ensure_module` with a **separator-agnostic** basename check (normalise both `\` and `/`), applied right before whisperx loads. Fixes the whole **class** (every optional-integration redirect, not just k2).

- Idempotent; no-op on macOS/Linux and when speechbrain is absent.
- Genuine missing-dep accesses from real user code still raise `ImportError` — only inspect-triggered spurious imports are suppressed, now on every platform.

## Test

`backend/tests/test_asr_speechbrain_lazy_guard.py` fakes the importer frame with Windows- and POSIX-style `inspect.py` paths plus a real-caller path — pins behaviour on any CI host. Fails before the fix on the Windows-path case (`ImportError`), passes after. Existing ASR tests stay green.

Closes #630
Closes #611
Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes cross-platform ASR transcription failures on Windows by hardening SpeechBrain's lazy-import guard against optional integrations. WhisperX (the default ASR backend) was failing with `ImportError: Lazy import of LazyModule(...speechbrain.integrations.k2_fsa...) failed` when introspection machinery touched optional-integration redirects during model loading. The root cause: SpeechBrain's guard used `filename.endswith("/inspect.py")` with hardcoded POSIX separators, missing Windows backslash paths like `C:\Python311\Lib\inspect.py`, causing spurious imports of uninstalled optional packages.

### Changes

**`backend/services/asr_backend.py` (+73 lines)**
- Adds `_harden_speechbrain_lazy_imports()` helper that re-implements `LazyModule.ensure_module` with separator-agnostic basename checking
- Normalizes both backslash and forward-slash separators explicitly, then checks if basename equals `inspect.py`
- When guard fires (inspect-triggered access), raises `AttributeError` to suppress the spurious import
- Idempotent: no-op on macOS/Linux (basename match is strict superset of old forward-slash check) and when speechbrain is absent
- Genuine missing-dependency accesses from real user code still raise `ImportError` unchanged
- Sets `_omnivoice_xplat_guard` marker to prevent re-patching
- `WhisperXBackend._ensure_asr()` calls this before importing whisperx, ensuring the guard is active during model loading

**`backend/tests/test_asr_speechbrain_lazy_guard.py` (+84 lines)**
- Tests guard correctness across platforms by faking `inspect.getframeinfo().filename` with both Windows (`C:\Python311\Lib\inspect.py`) and POSIX (`/usr/lib/python3.11/inspect.py`) inspect.py paths
- Verifies `LazyModule.ensure_module()` raises `AttributeError` (guard suppressed) rather than `ImportError` (import attempted) for both path styles
- Confirms real-caller paths still surface `ImportError` when target is missing
- Validates patch is idempotent via marker attribute

### New Mechanism

```
BEFORE (Windows):
  Frame filename: C:\Python311\Lib\inspect.py
         ↓
  Old guard: filename.endswith("/inspect.py")  ← hardcoded POSIX /
         ↓
  FAILS (uses \, not /)
         ↓
  Spurious import attempted: import k2  ← NOT INSTALLED
         ↓
  ImportError bubbles up
         ↓
  WhisperX transcription aborts (zero segments)

AFTER (Any Platform):
  Frame filename: (Windows) C:\Python311\Lib\inspect.py
                  (POSIX)   /usr/lib/python3.11/inspect.py
         ↓
  New guard: normalize(filename).rsplit("/", 1)[-1] == "inspect.py"
             (replaces \ with /)
         ↓
  MATCHES on all platforms
         ↓
  Guard raises AttributeError
         ↓
  Spurious import suppressed
         ↓
  WhisperX loads successfully
```

### Impact

- Restores cross-platform parity: WhisperX now works on Windows (was P0 blocker)
- Fixes all three linked issues (`#630`, `#611`, `#647`) which reported "Transcribe stream dropped before emitting any segments" on Windows 10 across multiple application versions (0.3.7–0.3.8-51)
- Addresses the entire class of optional-integration redirects (k2_fsa, numba, spacy, flair), not just k2
- No behavioral change on macOS/Linux; genuine import errors still surface correctly on all platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->