### PR TITLE
fix(asr): bound whole-file transcription so a stall isn't reported as "can't reach backend"

### DIFF
--- a/backend/api/routers/capture.py
+++ b/backend/api/routers/capture.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import time
 
-from fastapi import APIRouter, File, Form, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from typing import Optional
 
 router = APIRouter()
@@ -96,9 +96,17 @@ async def transcribe_audio(
             return result, backend.id
 
         from services.model_manager import _gpu_pool
-        loop = asyncio.get_running_loop()
+        from services.asr_backend import ASRTimeoutError, run_transcribe_guarded
         t0 = time.perf_counter()
-        result, engine_id = await loop.run_in_executor(_gpu_pool, _run)
+        try:
+            result, engine_id = await run_transcribe_guarded(
+                _gpu_pool, _run, what="Dictation",
+            )
+        except ASRTimeoutError as e:
+            # Backend is alive — ASR couldn't finish. 504 with guidance, not a
+            # silent hang the UI reads as "can't reach the local backend".
+            logger.warning("Capture transcription timed out: %s", e)
+            raise HTTPException(status_code=504, detail=str(e))
         elapsed = round(time.perf_counter() - t0, 2)
 
         # Normalize result shape

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -1187,8 +1187,14 @@ async def dub_qc_pass(job_id: str, lang: str = Query(None), drift_threshold: flo
 
     try:
         from services.model_manager import _get_gpu_pool
-        loop = asyncio.get_running_loop()
-        recognized, engine_id = await loop.run_in_executor(_get_gpu_pool(), _recognize)
+        from services.asr_backend import ASRTimeoutError, run_transcribe_guarded
+        recognized, engine_id = await run_transcribe_guarded(
+            _get_gpu_pool(), _recognize, what="QC",
+        )
+    except ASRTimeoutError as e:
+        # Backend is alive; ASR just couldn't finish in time. 504, not 500/connection.
+        logger.warning("dub QC ASR pass timed out for %s: %s", job_id, e)
+        raise HTTPException(status_code=504, detail=str(e))
     except Exception as e:
         logger.exception("dub QC ASR pass failed for %s", job_id)
         raise HTTPException(status_code=500, detail=f"QC transcription failed: {e}")

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -384,12 +384,15 @@ async def create_transcription(
     try:
         backend = get_active_asr_backend()
 
-        # Run transcription in the thread pool to avoid blocking the event loop
-        loop = asyncio.get_running_loop()
+        # Run transcription in the thread pool to avoid blocking the event loop,
+        # bounded so a stuck/starved ASR returns a 504 with guidance instead of
+        # hanging the request forever (see run_transcribe_guarded).
+        from services.asr_backend import run_transcribe_guarded
         word_ts = response_format == "verbose_json"
-        result = await loop.run_in_executor(
+        result = await run_transcribe_guarded(
             _gpu_pool,
             lambda: backend.transcribe(tmp_path, word_timestamps=word_ts),
+            what="OpenAI",
         )
 
         # Extract the full text from segments
@@ -456,6 +459,12 @@ async def create_transcription(
         # Default: json
         return TranscriptionResponse(text=full_text)
 
+    except HTTPException:
+        raise
+    except TimeoutError as e:
+        # ASRTimeoutError (subclass): backend alive, ASR too heavy for compute.
+        logger.warning("OpenAI transcription timed out: %s", e)
+        raise HTTPException(status_code=504, detail=str(e))
     except Exception as e:
         logger.exception("OpenAI transcription failed: %s", e)
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -23,12 +23,59 @@ faster-whisper because it's available on every platform we ship to).
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
 from abc import ABC, abstractmethod
 
 logger = logging.getLogger("omnivoice.asr")
+
+# A single ASR transcribe must never block a request indefinitely. The chunked
+# dub pipeline already bounds each chunk (OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S);
+# the *whole-file* paths (dub QC re-transcribe, dictation, OpenAI-compat) ran
+# unbounded, so a slow/stuck transcribe — e.g. large-v3 on a VRAM-starved GPU
+# where the resident TTS model contends for memory — hung the request *and* tied
+# up a GPU-pool worker, surfacing in the UI as the misleading "can't reach the
+# local backend" (TamKieu / Vietnam report). Bound them so a hang becomes a fast,
+# actionable error instead. Generous default (whole-file large-v3 on CPU is slow
+# but valid); override with the env var for very long single files.
+ASR_TRANSCRIBE_TIMEOUT_S = float(os.environ.get("OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S", "300.0"))
+
+
+class ASRTimeoutError(TimeoutError):
+    """Raised when a whole-file transcribe exceeds ASR_TRANSCRIBE_TIMEOUT_S.
+
+    Carries a user-actionable message: the backend is alive (this is not a
+    connection failure) — the ASR model is too heavy for the available compute.
+    """
+
+
+async def run_transcribe_guarded(executor, fn, *, what: str = "ASR",
+                                 timeout: float = ASR_TRANSCRIBE_TIMEOUT_S):
+    """Run a blocking transcribe ``fn`` in ``executor`` with a hard wall-clock
+    bound. On timeout, raise :class:`ASRTimeoutError` with guidance instead of
+    letting the request hang forever.
+
+    NOTE: ``run_in_executor`` cannot cancel the underlying thread, so the worker
+    stays busy after a timeout — the message tells the user to restart and
+    reduce ASR load, which is the only real remedy for a starved GPU.
+    """
+    loop = asyncio.get_running_loop()
+    fut = loop.run_in_executor(executor, fn)
+    try:
+        return await asyncio.wait_for(fut, timeout=timeout)
+    except asyncio.TimeoutError:
+        raise ASRTimeoutError(
+            f"{what} transcription exceeded {timeout:.0f}s and was abandoned — "
+            "the backend is running, but the ASR model is too heavy for the "
+            "available compute. Most often the GPU is VRAM-starved: the resident "
+            "TTS model and a large ASR model (large-v3) contend for memory. "
+            "Fixes: Flush the TTS model to free VRAM, pick a smaller ASR model "
+            "in Settings → Models, or set ASR to CPU. Then restart the app to "
+            "clear the stuck worker. (Raise OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S "
+            "for very long single files.)"
+        )
 
 
 def _compute_type_candidates(device: str) -> list[str]:

--- a/backend/tests/test_asr_transcribe_timeout.py
+++ b/backend/tests/test_asr_transcribe_timeout.py
@@ -1,0 +1,69 @@
+"""Whole-file ASR transcribe must be wall-clock bounded (TamKieu / Vietnam report).
+
+The chunked dub pipeline already bounds each chunk, but the whole-file paths
+(dub QC re-transcribe, dictation, OpenAI-compat) ran unbounded — a slow/stuck
+transcribe (e.g. large-v3 on a VRAM-starved GPU) hung the request *and* held a
+GPU-pool worker, surfacing in the UI as the misleading "can't reach the local
+backend". `run_transcribe_guarded` bounds them and raises `ASRTimeoutError` with
+actionable guidance. These tests pin the timeout path, the pass-through path, and
+that the error message tells the user what to do.
+"""
+import asyncio
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from services.asr_backend import (  # noqa: E402
+    ASRTimeoutError,
+    ASR_TRANSCRIBE_TIMEOUT_S,
+    run_transcribe_guarded,
+)
+from concurrent.futures import ThreadPoolExecutor  # noqa: E402
+
+
+def test_default_timeout_is_env_overridable(monkeypatch):
+    # The constant is read at import; just assert it's a sane positive default.
+    assert ASR_TRANSCRIBE_TIMEOUT_S > 0
+
+
+def test_slow_transcribe_raises_actionable_timeout():
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def _hang():
+        time.sleep(5)  # would block far past our tiny timeout
+        return "never"
+
+    async def _go():
+        with pytest.raises(ASRTimeoutError) as ei:
+            await run_transcribe_guarded(pool, _hang, what="QC", timeout=0.2)
+        msg = str(ei.value)
+        # Message must reassure (backend alive) + give concrete remedies.
+        assert "backend is running" in msg
+        assert "Settings → Models" in msg
+        assert "CPU" in msg
+
+    asyncio.run(_go())
+    pool.shutdown(wait=False)
+
+
+def test_fast_transcribe_passes_through():
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def _quick():
+        return {"segments": [{"text": "hi"}]}, "whisperx"
+
+    async def _go():
+        out = await run_transcribe_guarded(pool, _quick, what="Dictation", timeout=5.0)
+        assert out == ({"segments": [{"text": "hi"}]}, "whisperx")
+
+    asyncio.run(_go())
+    pool.shutdown(wait=True)
+
+
+def test_timeout_error_is_a_timeouterror_subclass():
+    # Routers that catch broad TimeoutError (openai_compat) must also catch ours.
+    assert issubclass(ASRTimeoutError, TimeoutError)

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -286,6 +286,42 @@ files land where the app looks.)
 
 **Linked issue:** [#622](https://github.com/debpalash/OmniVoice-Studio/issues/622)
 
+## 14. "Can't reach the local backend" *during* transcription / dubbing
+
+**Symptom:** the app worked at startup (you reached the main menu and the model
+loaded), but the moment you **dub a video, transcribe, or dictate**, it spins for
+a long time and then shows **"Can't reach the local backend."** The backend log
+ends right after a line like `whisperx transcribing …tmpXXXX.wav` with nothing
+after it — i.e. the backend is **alive**, the *transcription* is what stalled.
+
+**Cause:** this is **not** a connection, download, or "network mirror" problem —
+the backend started fine. The ASR model (WhisperX/faster-whisper **large-v3**) is
+too heavy for the available compute and the transcribe call runs for minutes,
+which the UI surfaces as an unreachable backend. The usual trigger is **VRAM
+starvation on NVIDIA**: the resident TTS model and a large ASR model contend for
+memory on an 8 GB-class GPU (the log shows e.g. `GPU pool sized … 7.0 GB free`).
+CPU-only machines hit the same wall on long clips.
+
+> There is **no "Network → Restricted/Global mirror" toggle** in Settings — that
+> control (the footer/Sharing **Network** button) is for **LAN sharing**, not
+> downloads. If someone pointed you there for this error, it was the wrong knob.
+
+**Fix — reduce ASR load (any one of these):**
+
+1. **Pick a smaller ASR model / engine** in **Settings → Models** — e.g.
+   faster-whisper **medium** or **small**, instead of large-v3. Biggest win on
+   low-VRAM GPUs.
+2. **Free VRAM**: **Flush the TTS model** before dubbing so ASR isn't competing
+   for memory, or
+3. **Run ASR on CPU** (slower but reliable) if your GPU is small.
+4. **Test with a 10-second clip** first — if that returns quickly, it confirms a
+   compute/VRAM limit rather than a true hang.
+
+Newer builds **bound** whole-file transcription: instead of hanging, it now fails
+after a timeout with this exact guidance. Tune the bound with
+`OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S` (seconds; default 300) — **raise** it for
+very long single files, **lower** it to fail faster on a small machine.
+
 ## First-run setup fails on a restricted network (GitHub/PyPI blocked)
 
 On networks that block or can't resolve **GitHub**, the first-run bootstrap may


### PR DESCRIPTION
## What

A Windows/CUDA user (Vietnam) got **"Can't reach the local backend"** — but **only** when dubbing/transcribing. Their log proves the backend started fine (model loaded, preload complete, 25 models) and ends right after `whisperx transcribing …tmp.wav`. The backend was **alive**; the *transcription* stalled — large-v3 ASR contending with the resident TTS model for VRAM on an 8 GB-class GPU (`GPU pool sized … 7.0 GB free`) — which the UI surfaces as an unreachable backend.

## Root cause (class, not instance)

The chunked dub pipeline already bounds each chunk (`OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S`), but the **whole-file** transcribe paths ran **unbounded**:
- dub QC re-transcribe (`dub_export`)
- dictation (`capture`)
- OpenAI-compat `/audio/transcriptions`

A slow/stuck transcribe on any of these hung the request **and** held a GPU-pool worker — indistinguishable from a dead backend.

## Fix

`run_transcribe_guarded()` in `services/asr_backend.py` — a shared `asyncio.wait_for` wrapper raising `ASRTimeoutError` (a `TimeoutError` subclass) with an env-tunable bound (`OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S`, default 300 s). On timeout the request returns **504 with actionable guidance** (backend is alive; free VRAM / pick a smaller ASR model / use CPU; restart to clear the stuck worker) instead of hanging forever. Wired into all three whole-file paths.

## Docs (same PR, per docs-sync rule)

New troubleshooting **§14** — explains it's ASR weight/VRAM pressure, **not** a network/mirror problem, and corrects the misconception that a *"Network → Restricted/Global mirror"* Settings toggle exists (the **Network** control is **LAN sharing**). Serves the **#602 / #585 / #567** "can't reach backend" cluster.

## Test

`backend/tests/test_asr_transcribe_timeout.py` — slow fn raises `ASRTimeoutError` with the actionable message; fast fn passes through; subclass-of-`TimeoutError` so `openai_compat`'s broad catch still maps to 504.

Relates to #602 #585 #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **backend/api/routers/capture.py**: ## AI-generated summary of changes
- **backend/api/routers/dub_export.py**: ## AI-generated summary of changes
- **backend/api/routers/openai_compat.py**: ## AI-generated summary of changes
- **backend/services/asr_backend.py**: ## AI-generated summary of changes
- **backend/tests/test_asr_transcribe_timeout.py**: ## AI-generated summary of changes
- **docs/install/troubleshooting.md**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->