### PR TITLE
fix(synthesize): validate clone-path instruct client-side so non-EN/ZH prose can't 400 (#612)

### DIFF
--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -121,7 +121,22 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
           formData.append("ref_audio", safeBlob, refAudio.name || "audio.wav");
           formData.append("ref_text", refText);
         }
-        if (instruct) formData.append("instruct", instruct);
+        // #612: a clone's free-text style field also passes through the backend
+        // instruct whitelist, so raw prose (e.g. a non-EN/ZH description like the
+        // Vietnamese report) 400s with "Unsupported instruct items". Apply the
+        // SAME validator-safe guard the design path uses: keep valid style tags,
+        // drop the rest, and surface a localized warning toast — never round-trip
+        // a 400. vdStates is empty here (clone has no design sliders).
+        if (instruct) {
+          const { instruct: safeInstruct, unsupported, duplicates } = buildDesignInstruct({}, instruct);
+          if (unsupported.length) {
+            toast(t('tts_errors.ignored_unsupported', { items: unsupported.join(', ') }), { icon: '⚠️' });
+          }
+          if (duplicates.length) {
+            toast(t('tts_errors.ignored_duplicate', { items: duplicates.join(', ') }), { icon: '⚠️' });
+          }
+          if (safeInstruct) formData.append("instruct", safeInstruct);
+        }
       } else {
         // #526: reuse the pinned seed when "keep this seed" is on (stable
         // tweaks), else roll a fresh one. The backend echoes the seed it used

--- a/frontend/src/utils/voiceInstruct.test.js
+++ b/frontend/src/utils/voiceInstruct.test.js
@@ -27,6 +27,22 @@ describe('buildDesignInstruct', () => {
     expect(duplicates).toEqual([]);
   });
 
+  it('clone path (#612): non-EN/ZH free-text yields no instruct, all items flagged unsupported', () => {
+    // The clone synthesize path runs free-text through buildDesignInstruct({}, …)
+    // exactly like this. A Vietnamese description must NOT reach the backend (it
+    // 400s with "Unsupported instruct items"); it drops to "" + a warn bucket so
+    // the UI shows a localized toast and synthesis still proceeds (no style).
+    const { instruct, unsupported } = buildDesignInstruct({}, 'quảng cáo, sôi nổi và thu hút');
+    expect(instruct).toBe('');
+    expect(unsupported).toEqual(['quảng cáo', 'sôi nổi và thu hút']);
+  });
+
+  it('clone path keeps valid style tags while dropping prose in the same field', () => {
+    const { instruct, unsupported } = buildDesignInstruct({}, 'whisper, sôi nổi');
+    expect(instruct).toBe('whisper');
+    expect(unsupported).toEqual(['sôi nổi']);
+  });
+
   it('buckets a valid tag outranked by a dropdown as a duplicate, not unsupported (#114)', () => {
     const { instruct, unsupported, duplicates } = buildDesignInstruct({ Pitch: 'low pitch' }, 'high pitch');
     expect(instruct).toBe('low pitch'); // dropdown wins the category


### PR DESCRIPTION
## What

Closes **#612** — a Vietnamese user typed a free-form description into the voice **style (instruct)** field and got `400: Unsupported instruct items found in quảng cáo, sôi nổi và thu hút`.

The instruct field is a **fixed EN/ZH style-tag vocabulary** (the model's trained tokens — gender/age/pitch/accent/dialect/whisper). The backend `_resolve_instruct` deliberately **raises** on unknown items. The model genuinely **cannot** honor non-EN/ZH instructs, so the only thing to fix is the failure UX.

## Root cause

The **design** path already guarded this (runs free-text through `buildDesignInstruct()` → keeps valid tags, drops the rest, localized warning toast — #115/#114). But the **clone** path (`defineMethod === 'audio'`) appended the **raw** `instruct` string straight to the request:

```js
if (instruct) formData.append("instruct", instruct);   // ← unvalidated
```

So a clone + free-text style in any non-EN/ZH language round-tripped to a 400.

## Fix (chosen approach: localized client-side guard)

Route the clone path's free-text through the **same** `buildDesignInstruct({}, instruct)` guard:
- valid style tags survive (a clone can still ask for `whisper`),
- unsupported items drop with the existing localized `tts_errors.ignored_unsupported` toast,
- synthesis proceeds in the user's language (no style control) instead of a raw 400.

No backend/engine change.

## Test

`voiceInstruct.test.js` — a fully-Vietnamese instruct yields `""` + all items in the unsupported bucket; mixed `whisper, sôi nổi` keeps `whisper` and flags the prose.

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix for clone-path voice instruct validation (`#612`)

**Problem**: When users entered non-English/Chinese prose (e.g., Vietnamese descriptions) in the voice style (instruct) field during clone synthesis, the backend would reject the request with a 400 error ("Unsupported instruct items"). The design path already had proper client-side validation, but the clone path bypassed it.

**Solution**: Apply the same `buildDesignInstruct()` validator guard to the clone path (when `defineMethod === 'audio'`) that was already used for the design path. This filters the raw instruct string to extract only valid style tags (e.g., "whisper"), drops unsupported prose, and displays localized warning toasts instead of returning a 400 error.

### New validation flow:

```mermaid
graph TD
    A["User enters instruct text<br/>(e.g., 'whisper, sôi nổi')"] -->|Clone path| B["buildDesignInstruct{}, instruct"]
    B --> C{"Parse and validate<br/>each item"}
    C -->|Valid tag<br/>e.g., 'whisper'| D["Add to safeInstruct"]
    C -->|Invalid prose<br/>e.g., 'sôi nổi'| E["Add to unsupported bucket"]
    D --> F["Append safeInstruct to request"]
    E --> G["Show warning toast:<br/>tts_errors.ignored_unsupported"]
    F --> H["Send to backend<br/>No 400 error"]
    G --> H
    H --> I["Synthesis proceeds<br/>with valid style or no style"]
```

### Changes

**frontend/src/hooks/useTTS.js** (+16/-1):
- Modified the clone path's instruct handling to call `buildDesignInstruct({}, instruct)` before appending to the request
- Displays localized warning toasts for `unsupported` items and `duplicates`
- Only appends the validated `safeInstruct` to prevent unsupported prose from reaching the backend
- Preserves valid style tags like "whisper" while dropping prose

**frontend/src/utils/voiceInstruct.test.js** (+16/-0):
- Added test case: "clone path (`#612`): non-EN/ZH free-text yields no instruct, all items flagged unsupported" — verifies that a fully Vietnamese instruct ("quảng cáo, sôi nổi và thu hút") results in an empty instruct string with all items marked unsupported
- Added test case: "clone path keeps valid style tags while dropping prose in the same field" — verifies that mixed input ("whisper, sôi nổi") preserves "whisper" while flagging Vietnamese text as unsupported

**No UI or backend changes** — client-side only. Users now see a graceful warning toast instead of a raw 400 error when they mix valid style tags with unsupported prose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->