### PR TITLE
fix(net): Windows preview playback — 127.0.0.1 loopback + quieter decode-fallback log

### DIFF
--- a/frontend/src/utils/apiBase.test.ts
+++ b/frontend/src/utils/apiBase.test.ts
@@ -3,7 +3,7 @@
  *
  * Covers the four-branch resolver:
  *   1. VITE_OMNIVOICE_API override always wins.
- *   2. Tauri webview context → localhost:3900.
+ *   2. Tauri webview context → 127.0.0.1:3900 (IPv4; not "localhost" — Windows IPv6).
  *   3. Plain browser context → window.location.hostname:3900.
  *   4. SSR / no-window fallback → localhost:3900.
  */
@@ -75,10 +75,13 @@ describe("apiBase.getApiBase", () => {
     mod._setEnvOverrideForTesting(undefined);
   });
 
-  it("returns localhost:3900 in Tauri context", async () => {
+  it("returns 127.0.0.1:3900 (NOT localhost) in Tauri context — Windows IPv6 fix", async () => {
+    // The backend binds IPv4 127.0.0.1 only; "localhost" can resolve to ::1 on
+    // Windows and miss it, causing "Can't reach the local backend" on the media/
+    // preview path. Must be the numeric IPv4 address (matches api/client.ts).
     (window as Window).__TAURI_INTERNALS__ = {};
     const { getApiBase } = await import("./apiBase");
-    expect(getApiBase()).toBe("http://localhost:3900");
+    expect(getApiBase()).toBe("http://127.0.0.1:3900");
   });
 
   it("returns window.location.hostname:3900 in plain browser context (LAN IP)", async () => {

--- a/frontend/src/utils/apiBase.ts
+++ b/frontend/src/utils/apiBase.ts
@@ -10,9 +10,11 @@
  *      Always wins. Set in `.env.local` or the docker-compose env.
  *
  *   2. Tauri webview (the shipped desktop app):
- *      Backend always listens on 127.0.0.1:3900 on the same machine.
- *      Even when Tauri's webview origin is `tauri://localhost`, plain
- *      `http://localhost:3900` reaches the backend.
+ *      Backend always listens on IPv4 127.0.0.1:3900 on the same machine, so we
+ *      target the numeric `http://127.0.0.1:3900` — NOT `localhost`, which on
+ *      Windows can resolve to ::1 (IPv6) first and miss the IPv4-only backend.
+ *      (api/client.ts already does this; this util is kept in lockstep.)
+ *      Tauri's webview origin (`tauri://localhost`) is unaffected.
  *
  *   3. Plain browser (Docker LAN, port-forward, dev server on a NAS):
  *      The browser was served from some host — likely a LAN IP. We must
@@ -81,9 +83,18 @@ export function getApiBase(): string {
     return stripTrailingSlash(override);
   }
 
-  // 2. Tauri webview → loopback.
+  // 2. Tauri webview → loopback. Use the literal IPv4 127.0.0.1, NOT "localhost".
+  //    The backend binds IPv4 127.0.0.1 only (backend/main.py), but on Windows
+  //    "localhost" frequently resolves to ::1 (IPv6) first — so
+  //    http://localhost:3900 hits an address nothing is listening on and the
+  //    request fails with "Can't reach the local backend". The main API client
+  //    (api/client.ts) already resolves Tauri → 127.0.0.1; this util lagged on
+  //    "localhost", so its one consumer — utils/media.js's preview/blob upload
+  //    (the audiobook/video preview path, #653) — still broke on Windows. Align
+  //    the two resolvers. The numeric address skips name resolution and is
+  //    correct on macOS/Linux too (the backend is always on this machine).
   if (isTauriContext()) {
-    return `http://localhost:${BACKEND_PORT}`;
+    return `http://127.0.0.1:${BACKEND_PORT}`;
   }
 
   // 3. Plain browser → follow the page's own origin/host.

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -78,15 +78,20 @@ export const playBlobAudio = async (blob) => {
       src.start(0);
       src.onended = () => { ctx.close(); release(); };
     } catch (e) {
-      console.error('playBlobAudio decode error:', e);
+      // Expected & recovered on WebView2 (Windows): decodeAudioData decodes the
+      // WHOLE file into one PCM AudioBuffer and chokes on long-form audiobook/
+      // story renders (.m4b / AAC) — a `warn`, not a red ERROR, since the
+      // streaming fallback below recovers it. (The scary "decode error" line
+      // users saw in Logs → Frontend was this expected branch, logged at error
+      // level even when playback succeeded.)
+      console.warn('playBlobAudio: Web Audio decode failed, falling back to streamed playback:', e?.message || e);
       ctx.close();
-      // Fallback (#653): decodeAudioData decodes the WHOLE file into one PCM
-      // AudioBuffer — it chokes on long-form audiobook/story renders (.m4b / AAC)
-      // on WebView2. And a blob: URL won't play in an <audio> element under
-      // Tauri's WebKit (see fileToMediaUrl above), so the old createObjectURL
-      // fallback silently played nothing. Instead, upload to the backend preview
-      // endpoint (ffmpeg-extracts a streamable WAV) and play the HTTP URL — the
-      // same path video previews already use. Streams; no whole-file decode.
+      // Fallback (#653): a blob: URL won't play in an <audio> element under
+      // Tauri's WebKit (see fileToMediaUrl above), so upload to the backend
+      // preview endpoint (ffmpeg-extracts a streamable WAV) and play the HTTP
+      // URL — the same path video previews already use. Streams; no whole-file
+      // decode. NOTE: _PREVIEW_API must be 127.0.0.1 (not localhost) or this
+      // fetch misses the IPv4 backend on Windows (see utils/apiBase.ts).
       try {
         const form = new FormData();
         form.append('video', blob, 'preview.audio');
@@ -99,7 +104,8 @@ export const playBlobAudio = async (blob) => {
         a.onended = () => { release(); };
         await a.play().catch((err) => { release(); throw err; });
       } catch (e2) {
-        console.error('playBlobAudio fallback error:', e2);
+        // Real failure — both decode AND the streamed fallback failed.
+        console.error('playBlobAudio: streamed fallback also failed:', e2?.message || e2);
       }
     }
   } else {


### PR DESCRIPTION
## What

Fixes the **`playBlobAudio decode error: EncodingError: Unable to decode audio data`** that Windows users still see in **Logs → Frontend** (cloned-voice / audiobook preview), even after #653. Two coupled fixes:

### 1. `apiBase` → `127.0.0.1`, not `localhost` (Tauri)

The backend binds **IPv4 `127.0.0.1` only**. On Windows, `localhost` often resolves to **`::1` (IPv6)** first → requests miss the backend. The main client (`api/client.ts`) already resolved Tauri → `127.0.0.1` (since #174), but `utils/apiBase.ts` lagged on `localhost` — and its **one consumer is `utils/media.js`'s preview upload, the #653 fallback**. So #653's streamed fallback fetched `http://localhost:3900/preview/upload` and **failed on Windows**, leaving preview playback broken even after #653 shipped. Aligning the two resolvers makes the fallback reach the backend.

### 2. Quieter, accurate logging in `playBlobAudio`

The Web Audio `decodeAudioData` path is **expected** to fail for long-form / AAC renders on WebView2 and is **recovered** by the streamed fallback — yet it logged at **error** level, so users saw a red "decode error" even when playback succeeded. Downgraded that branch to `console.warn` ("falling back to streamed playback"); reserved `error` for the real failure (decode **and** fallback failed). With fix #1, the fallback now completes on Windows.

## Tests

- `apiBase.test.ts` asserts the Tauri context resolves to `http://127.0.0.1:3900`.
- Existing `playBlobAudioFallback.test.js` (#653) still green (fetch hits `/preview/upload`, plays the HTTP URL, never `blob:`).

Completes #653 on Windows · relates to #602 (reachability umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Network Resolution Fix: Use IPv4 Loopback in Tauri Webview

This PR fixes a Windows-specific reachability issue in `frontend/src/utils/apiBase.ts` where the Tauri webview resolver used `http://localhost:3900`. On Windows, `localhost` can resolve to the IPv6 loopback (`::1`) first, while the backend listens on IPv4 only (`127.0.0.1`), causing “Can’t reach the local backend” and breaking the audiobook/video preview path.

### What changed

- **`frontend/src/utils/apiBase.ts`**
  - Updated `getApiBase()` for the **Tauri webview** context to return the literal IPv4 loopback:
    - from `http://localhost:3900`
    - to `http://127.0.0.1:3900`
  - Expanded comments to document the IPv4-vs-IPv6 `localhost` resolution problem on Windows and why this resolver must match the main API client behavior.
- **`frontend/src/utils/apiBase.test.ts`**
  - Added/updated an assertion that in Tauri context `getApiBase()` returns exactly `http://127.0.0.1:3900` (not `localhost`).

### Resolver precedence (new mechanism)

```mermaid
flowchart TD
  A[Start getApiBase()] --> B{window.__OMNIVOICE_API_BASE__?}
  B -- string & non-empty --> C[Return stripTrailingSlash(runtime override)]
  B -- otherwise --> D{VITE_OMNIVOICE_API override?}
  D -- set --> E[Return stripTrailingSlash(VITE_OMNIVOICE_API)]
  D -- otherwise --> F{isTauriContext()?}
  F -- yes --> G[Return http://127.0.0.1:BACKEND_PORT]
  F -- no --> H{window.location exists?}
  H -- yes --> I[Return ${protocol}//${hostname}:${BACKEND_PORT}]
  H -- no --> J[SSR/jsdom fallback: return http://localhost:BACKEND_PORT]
```

### Related consumer impact

`utils/media.js` (preview/blob upload + playback) benefits because `_PREVIEW_API` is sourced from `apiBase.ts`, so Tauri preview requests hit the IPv4 backend reliably.

### Logging fix in media playback

- **`frontend/src/utils/media.js`**
  - In `playBlobAudio`, when `decodeAudioData` fails, the first failure is now logged as a **`console.warn`** with the error message included.
  - If the streamed fallback also fails, the log message was refined to **`streamed fallback also failed`** and includes `e2?.message`.

### Related issues

- `#653` (Windows preview)
- `#602` (reachability umbrella)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->