### PR TITLE
fix(dub): reset stale dub session gracefully instead of erroring "Job not found" (#660)

### DIFF
--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -18,6 +18,26 @@ import i18next from 'i18next';
 const t = i18next.t.bind(i18next);
 
 /**
+ * True when a dub error means the job no longer exists on the backend — a
+ * persisted `dubJobId` outlived the backend's in-memory job store (the backend
+ * restarted, or the job was cleaned up). The backend reports this as
+ * "Job not found. It may have been cleaned up or was never created." (dub_core)
+ * or "This dub session has expired or was never created…" (dub_generate). That
+ * is an EXPECTED stale-session state on resume/retry, not a bug — so the UI
+ * should reset to a clean slate and invite a fresh upload rather than fire an
+ * error toast with a "report a bug" prompt (#660). Exported + pure for testing.
+ */
+export function isExpiredDubJobError(err) {
+  const m = (err && err.message ? String(err.message) : '').toLowerCase();
+  return (
+    m.includes('job not found') ||
+    m.includes('session has expired') ||
+    m.includes('was never created') ||
+    m.includes('cleaned up')
+  );
+}
+
+/**
  * Encapsulates the entire dub pipeline workflow:
  *   upload → prep → transcribe → translate → generate → export
  *
@@ -64,6 +84,19 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
 
   const dubAbortCtrlRef = useRef(null);
   const dubClientJobIdRef = useRef(null);
+
+  // Reset a stale dub session (the persisted job is gone server-side, #660):
+  // clear the dead id/state, drop any pill, and prompt a fresh upload with a
+  // calm info toast — never a bug-report prompt, since this is expected.
+  const _resetStaleDubSession = useCallback(() => {
+    setDubJobId(''); setDubTaskId(''); setDubSegments([]); setDubError('');
+    setDubStep('idle'); setTranscribeStart(null);
+    try { useAppStore.getState().dismissPill(); } catch { /* no pill */ }
+    toast(
+      t('dub_workflow.session_expired', 'This dub session expired or was cleaned up — re-upload your video to start a new one.'),
+      { icon: 'ℹ️', duration: 7000 },
+    );
+  }, [setDubJobId, setDubTaskId, setDubSegments, setDubError, setDubStep]);
 
   // Timer for transcribe elapsed
   useEffect(() => {
@@ -311,9 +344,10 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     } catch (err) {
       setTranscribeStart(null);
       if (err.name === 'AbortError') { toast(t('dub_workflow.retry_cancelled')); setDubStep('idle'); }
+      else if (isExpiredDubJobError(err)) { _resetStaleDubSession(); }
       else { setDubError(err.message); setDubStep('idle'); toastErrorWithReport(t('dub_workflow.transcription_failed', { message: err.message }), err); }
     } finally { dubAbortCtrlRef.current = null; }
-  }, [dubJobId, setDubError, setDubSegments, setDubStep, _waitForTranscribe, loadProjects]);
+  }, [dubJobId, setDubError, setDubSegments, setDubStep, _waitForTranscribe, loadProjects, _resetStaleDubSession]);
 
   const handleDubImportSrt = useCallback(async (file) => {
     if (!dubJobId) {
@@ -338,11 +372,12 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
       toast.success(noteParts.join(' · '), { duration: 6000 });
       loadProjects();
     } catch (err) {
+      if (isExpiredDubJobError(err)) { _resetStaleDubSession(); return; }
       const msg = err?.message || t('dub_workflow.srt_import_failed');
       setDubError(msg);
       toast.error(msg);
     }
-  }, [dubJobId, setDubError, setDubSegments, setDubStep, loadProjects]);
+  }, [dubJobId, setDubError, setDubSegments, setDubStep, loadProjects, _resetStaleDubSession]);
 
   const handleCleanupSegments = useCallback(async () => {
     if (!dubJobId || !dubSegments.length) return;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1729,6 +1729,7 @@
     "ingest_cancelled": "Ingest cancelled",
     "ingest_failed": "URL ingest failed: {{message}}",
     "retry_cancelled": "Retry cancelled",
+    "session_expired": "This dub session expired or was cleaned up — re-upload your video to start a new one.",
     "transcription_failed": "Transcription failed: {{message}}",
     "import_srt_no_job": "Upload or ingest a video first — there is no job to attach subtitles to.",
     "imported_cues": "Imported {{count}} cue(s) from {{file}}",

--- a/frontend/src/test/dubExpiredJobError.test.js
+++ b/frontend/src/test/dubExpiredJobError.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { isExpiredDubJobError } from '../hooks/useDubWorkflow.js';
+
+describe('isExpiredDubJobError (#660 — stale dub session)', () => {
+  it('matches the backend dub_core preflight message', () => {
+    expect(isExpiredDubJobError(new Error(
+      'Job not found. It may have been cleaned up or was never created.'
+    ))).toBe(true);
+  });
+
+  it('matches the dub_generate expired-session message', () => {
+    expect(isExpiredDubJobError(new Error(
+      'This dub session has expired or was never created. Re-upload the video to start a new one.'
+    ))).toBe(true);
+  });
+
+  it('matches a bare 404 "Job not found"', () => {
+    expect(isExpiredDubJobError(new Error('Job not found'))).toBe(true);
+  });
+
+  it('does NOT match unrelated transcription failures (those stay reportable)', () => {
+    expect(isExpiredDubJobError(new Error(
+      'Transcribe stream dropped before emitting any segments.'
+    ))).toBe(false);
+    expect(isExpiredDubJobError(new Error('CUDA out of memory'))).toBe(false);
+    expect(isExpiredDubJobError(new Error('aborted'))).toBe(false);
+  });
+
+  it('is null/shape safe', () => {
+    expect(isExpiredDubJobError(null)).toBe(false);
+    expect(isExpiredDubJobError(undefined)).toBe(false);
+    expect(isExpiredDubJobError({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Closes **#660** — a Windows user reopened the **Dub** tab (the only logged action was `view:dub`) and got a hard error toast: *"Job not found. It may have been cleaned up or was never created."* — **with a "report a bug" prompt**.

## Root cause

`dubJobId` is persisted client-side, but dub jobs live in the backend's **in-memory** store. After a backend restart (or once a job is cleaned up), resuming/retrying that job 404s. The frontend surfaced this **expected stale-session** state via `toastErrorWithReport` — i.e. it asked the user to file a bug for a session that simply expired.

## Fix (whole class)

- New pure, exported `isExpiredDubJobError(err)` — matches the `dub_core` preflight message, the `dub_generate` expired-session message, and a bare 404 `"Job not found"`.
- `_resetStaleDubSession()` — clears the dead job id/state, drops any pill, and shows a **calm info toast** inviting a fresh upload.
- Wired into the two handlers that operate on a **pre-existing** job: **retry-transcribe** (the #660 path) and **SRT import**.
- The fresh **upload/ingest** paths intentionally still report real errors — a *just-created* job going missing is a genuine bug.

## Test

`dubExpiredJobError.test.js` — pins the predicate against both backend messages + a bare 404, and asserts unrelated failures (stream dropped, CUDA OOM, abort) stay reportable.

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes issue `#660` by gracefully handling expired dub job sessions rather than surfacing them as reportable bugs. When the backend restarts or cleans up in-memory dub jobs, a user reopening the Dub tab would previously see a hard error toast with a "report a bug" prompt. The fix detects this stale-session condition and resets the workflow with a calm informational message instead.

### Changes Overview

**frontend/src/hooks/useDubWorkflow.js** (+37/-2)
- Added exported `isExpiredDubJobError(err)` predicate that matches backend job-not-found and session-expired messages, plus bare 404 responses
- Added `_resetStaleDubSession()` helper that clears persisted job ID/state, dismisses any UI pill, and shows an informational toast
- Updated `handleDubRetryTranscribe` catch block to route stale-session errors to the reset helper instead of generic error handling
- Updated `handleDubImportSrt` catch block to route stale-session errors to the reset helper; non-stale errors continue to set error state and show error toast

**frontend/src/i18n/locales/en.json** (+1/-0)
- Added i18n string `dub_workflow.session_expired`: "This dub session expired or was cleaned up — re-upload your video to start a new one."

**frontend/src/test/dubExpiredJobError.test.js** (new file, +34/-0)
- Test suite validates `isExpiredDubJobError` against backend preflight messages, expired-session messages, and bare 404 responses
- Confirms unrelated errors (stream dropped, CUDA OOM, aborted) remain reportable
- Validates null/shape safety

### Error Handling Flow

```mermaid
flowchart TD
    A["User reopens Dub tab after backend restart"] --> B["Retry/Resume job action triggered"]
    B --> C["Backend returns error"]
    C --> D{Is it a stale-session error?}
    D -->|Yes: Job not found/cleaned up| E["_resetStaleDubSession<br/>• Clear jobId from storage<br/>• Reset UI state<br/>• Show info toast"]
    D -->|No: Real error| F["Show error toast<br/>with bug report prompt"]
    E --> G["User can re-upload video<br/>to start fresh session"]
    F --> H["User reports bug"]
```

### UI Change

**Before:** Hard error with alarm tone
```
┌─────────────────────────────────────────┐
│ ❌ Transcription failed: Job not found.  │
│    It may have been cleaned up or was   │
│    never created.                       │
│                                         │
│  [Report a Bug]              [Dismiss]  │
└─────────────────────────────────────────┘
```

**After:** Calm informational message with action
```
┌─────────────────────────────────────────┐
│ ℹ️  This dub session expired or was      │
│    cleaned up — re-upload your video to │
│    start a new one.                     │
│                                         │
│                              [Dismiss]  │
└─────────────────────────────────────────┘
[User can now re-upload fresh video]
```

### Design Rationale

- **Stale-session errors (404, cleaned up)** → Graceful reset with info toast, no bug reporting
  - These are expected in normal operation when backend restarts or jobs age out
  - User action: re-upload video to start a new session
  
- **Fresh upload/ingest paths** → Preserved error reporting
  - A newly created job going missing would indicate a genuine backend defect
  - Maintains accountability for production issues
  
- **Retry/resume paths** → Stale-session detection enabled
  - These operations work with pre-existing jobs that may have expired
  - Expected failure mode that should not alarm users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->