### PR TITLE
fix(generate): classify a bad-instruct error as a 400, not a 500 "ran out of memory" (#664)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -178,6 +178,20 @@ def _oom_friendly_reraise(e):
             f"usually a transient glitch. Use the Flush button to reload the model, "
             f"then regenerate. Underlying error: {e}"
         ) from e
+    # #664: a bad voice-design instruct (free-form prose, mixed EN/ZH, or
+    # conflicting tags) raises "Unsupported instruct items …" / "Cannot mix …
+    # in a single instruct" / "Conflicting instruct items …" from omnivoice's
+    # _resolve_instruct. That's a USER-INPUT validation error, not an OOM. Match
+    # on the message signature (NOT the type — a lower layer can wrap the original
+    # ValueError, which is why the route's `except ValueError` guard misses it)
+    # and re-raise as a clean ValueError so the route returns a 400 with the
+    # instruct guidance, instead of a 500 telling the user to Flush for memory
+    # they never ran out of. (Complements the client-side guard in #658/#612.)
+    _low = es.lower()
+    if ("unsupported instruct items" in _low
+            or "conflicting instruct items" in _low
+            or "in a single instruct" in _low):
+        raise ValueError(es) from e
     raise RuntimeError(
         f"TTS engine stopped mid-generation. This usually means it ran out of memory. "
         f"Try the Flush button to reload the model, then regenerate. Underlying error: {e}"

--- a/tests/test_generation_audio_guard.py
+++ b/tests/test_generation_audio_guard.py
@@ -53,3 +53,31 @@ def test_generic_failure_still_uses_oom_hint():
     with pytest.raises(RuntimeError) as ei:
         _oom_friendly_reraise(RuntimeError("CUDA error: out of memory"))
     assert "ran out of memory" in str(ei.value)
+
+
+def test_unsupported_instruct_is_a_validation_error_not_oom():
+    # #664: free-form prose in the instruct field must surface as a 400-mapped
+    # ValueError with the instruct guidance — NOT a 500 "ran out of memory".
+    err = ValueError(
+        "Unsupported instruct items found in Speak with high energy:\n"
+        "  'Speak with high energy' -> 'speak with high energy' (unsupported)\n\n"
+        "Valid English items: male, whisper, ..."
+    )
+    with pytest.raises(ValueError) as ei:
+        _oom_friendly_reraise(err)
+    msg = str(ei.value)
+    assert "Unsupported instruct items" in msg
+    assert "ran out of memory" not in msg
+
+
+def test_instruct_error_wrapped_in_runtimeerror_is_still_validation():
+    # A lower layer can wrap the original ValueError; we must classify on the
+    # message signature, not the type, so the route still returns a clean 400.
+    err = RuntimeError(
+        "model.generate failed: Conflicting instruct items within the same "
+        "category: 'male' vs 'female'."
+    )
+    with pytest.raises(ValueError) as ei:
+        _oom_friendly_reraise(err)
+    assert "Conflicting instruct items" in str(ei.value)
+    assert "ran out of memory" not in str(ei.value)


### PR DESCRIPTION
## What

Closes **#664** — typing free-form prose (*"Speak with high energy … like a podcast host"*) into the voice-design **instruct** field returned a **500** reading *"TTS engine stopped mid-generation. This usually means it ran out of memory. Try the Flush button…"*, with the real cause (*"Unsupported instruct items found…"*) buried underneath. The user is sent to Flush for an OOM that never happened.

## Root cause

`_resolve_instruct` raises on unknown/conflicting instruct items, but by the time the error reaches `_oom_friendly_reraise` it's **no longer a bare `ValueError`** (a lower layer wraps it). So the route's `except ValueError → 400` guard misses it and it falls through to the generic OOM `RuntimeError`. v0.3.7 has had that guard since v0.3.6 yet **still** produced the OOM message — proving the error arrives wrapped, so type-based detection is insufficient.

## Fix

In `_oom_friendly_reraise`, detect the instruct-validation **message signature** (`unsupported instruct items` / `conflicting instruct items` / `in a single instruct`) **regardless of exception type** and re-raise a clean `ValueError` → the route returns a **400 with the instruct guidance**, not a 500 OOM.

Version-independent and complements the client-side guard (#658/#612): also covers **API/MCP callers** and **stored profiles** whose instruct slips through.

## Test

`test_generation_audio_guard.py` — a bare instruct `ValueError` and one wrapped in a `RuntimeError` both reclassify to a `ValueError` without the "ran out of memory" text; the generic OOM path is unchanged.

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Issue
Bad voice-design instruct validation errors (free-form prose, mixed languages, conflicting tags) were incorrectly classified as 500 "ran out of memory" errors instead of 400 bad request errors. When users received validation errors like "Unsupported instruct items found…", they were misdirected to use the Flush button for a non-existent out-of-memory condition.

## Root Cause
`_resolve_instruct` raises `ValueError` on invalid instruct items, but when lower layers wrap this error in `RuntimeError`, the route's `except ValueError` guard misses it. The error falls through to the generic `RuntimeError` handler in `_oom_friendly_reraise`, which produces the misleading 500 response with OOM messaging.

## Solution
Updated `_oom_friendly_reraise` to detect instruct-validation errors by matching message signatures ("unsupported instruct items", "conflicting instruct items", "in a single instruct") regardless of exception type wrapper. Upon detection, it re-raises a clean `ValueError` so the route correctly returns 400 status with instruct guidance.

## Error Handling Flow

```mermaid
graph TD
    A["Exception Raised<br/>from _resolve_instruct"] --> B{"_oom_friendly_reraise<br/>checks type & message"}
    B -->|Instruct error signature<br/>detected| C["Re-raise as clean<br/>ValueError"]
    B -->|ffmpeg/decode error| D["Raise RuntimeError:<br/>unreadable audio"]
    B -->|Permission denied| E["Raise RuntimeError:<br/>binary permission issue"]
    B -->|torch.compile failure| F["Raise RuntimeError:<br/>Triton/Inductor error"]
    B -->|Other RuntimeError| G["Raise RuntimeError:<br/>ran out of memory"]
    C -->|Route handler:<br/>except ValueError| H["Return 400<br/>with instruct guidance"]
    D --> I["Return 500"]
    E --> I
    F --> I
    G --> I
```

## Changes

**backend/api/routers/generation.py** (+14 lines)
- Enhanced `_oom_friendly_reraise` with message-based detection for instruct validation errors
- Checks for patterns: "unsupported instruct items", "conflicting instruct items", "in a single instruct"
- Re-raises detected errors as clean `ValueError` to bypass generic OOM handler

**tests/test_generation_audio_guard.py** (+28 lines)
- `test_unsupported_instruct_is_a_validation_error_not_oom`: Validates direct `ValueError` with unsupported instruct message is re-raised unchanged as `ValueError`
- `test_instruct_error_wrapped_in_runtimeerror_is_still_validation`: Validates that `RuntimeError` wrapping instruct validation messages is converted to `ValueError`

## Impact
- Users receive accurate 400 status with instruct guidance instead of misleading 500 OOM messages
- Covers API/MCP callers and stored profiles in addition to UI
- Version-independent fix based on message signatures rather than exception types
- Existing OOM and other error paths remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->