### PR TITLE
feat(setup): faster downloads by default + prominent, encouraged HF-token entry

### DIFF
--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -130,11 +130,15 @@ def compute_plan(plan_files) -> dict:
 
 
 def _segmented_enabled() -> bool:
-    """Opt-in IDM-style accelerator (FDL-09), default OFF. Most useful when Xet
-    is inactive (the app's default): the legacy-LFS path is single-stream, so
-    this restores parallel speed AND gives real live byte progress."""
+    """IDM-style multi-connection accelerator (FDL-09), default **ON**. The app
+    forces the legacy-LFS path (HF_HUB_DISABLE_XET=1) for clear progress, but that
+    path is single-stream and slow — this restores parallel byte-range speed AND
+    real live progress, and falls back to snapshot_download on any error so it
+    can never compromise a correct install. Default-on so first-run downloads are
+    fast out of the box (pairs with an HF token for higher rate limits); set
+    OMNIVOICE_SEGMENTED_DOWNLOAD=0 to force the single-stream path."""
     return _truthy(prefs.resolve(
-        "segmented_downloader", env="OMNIVOICE_SEGMENTED_DOWNLOAD", default=False,
+        "segmented_downloader", env="OMNIVOICE_SEGMENTED_DOWNLOAD", default=True,
     ))
 
 
@@ -434,10 +438,11 @@ async def install_model(req: InstallModelRequest):
                     raise _InstallCancelled()
                 _attempt += 1
                 try:
-                    # Opt-in segmented accelerator (FDL-09): parallel byte-range
-                    # fetch with real live progress, for the legacy-LFS path.
-                    # Any failure falls through to snapshot_download — the
-                    # accelerator can never compromise a correct install.
+                    # Segmented accelerator (FDL-09, default ON): parallel
+                    # byte-range fetch with real live progress, for the
+                    # legacy-LFS path. Any failure falls through to
+                    # snapshot_download — the accelerator can never compromise a
+                    # correct install.
                     _snapshot_path = None
                     if _attempt == 1 and _segmented_enabled() and not _xet_active():
                         try:

--- a/docs/downloading-models.md
+++ b/docs/downloading-models.md
@@ -14,6 +14,15 @@ download UI couldn't show real bytes/speed. Until a proper Xet progress hook
 lands, the app forces the **classic LFS path**, which streams through the
 standard progress reporter and gives accurate downloaded/remaining/speed.
 
+To keep that path **fast** despite Xet being off, the app runs a built-in
+**multi-connection (segmented) downloader on by default** — it fetches each file
+over parallel byte-ranges (IDM/uGet style), so the legacy-LFS path is no longer
+single-stream. It reports real live speed/ETA and **falls back to the normal
+download on any error**, so it can never compromise a correct install. Adding a
+free Hugging Face token (first-run setup, or Settings → Credentials) makes this
+faster still — authenticated downloads get higher rate limits and fewer stalls.
+To force the old single-stream path, set `OMNIVOICE_SEGMENTED_DOWNLOAD=0`.
+
 State is reported at **Settings → About** / `GET /system/info`:
 
 - `fast_download.xet_installed` — `hf_xet` present (true)
@@ -54,12 +63,13 @@ When a download starts you'll see, in order:
 
 ## Advanced / opt-in tuning
 
-All of these default **off** and apply to every platform identically. Set them
-as environment variables (or via **Settings → API keys / environment**).
+These apply to every platform identically. Set them as environment variables (or
+via **Settings → API keys / environment**). The segmented accelerator is **on by
+default** (set its var to `0` to disable); the rest default **off**.
 
 | Setting | Env var | Effect |
 |---|---|---|
-| Segmented accelerator | `OMNIVOICE_SEGMENTED_DOWNLOAD=1` | Multi-connection downloader (parallel byte-ranges) for the legacy-LFS path — restores parallel speed **and** shows live byte speed/ETA. Falls back to the normal download on any error; files land in the standard cache. Best paired with Xet disabled (the default). |
+| Segmented accelerator | `OMNIVOICE_SEGMENTED_DOWNLOAD=0` | **On by default** (see above). Set to `0` to force the old single-stream legacy-LFS download instead of the parallel byte-range one. |
 | Max parallel files | `OMNIVOICE_DOWNLOAD_MAX_WORKERS` (default 8) | Files fetched at once. Xet already parallelises *within* a file, so raising this rarely helps and uses more memory. |
 | High-performance mode | `HF_XET_HIGH_PERFORMANCE=1` | Maximum throughput. Needs lots of RAM and bandwidth — can **hurt** low-RAM machines. Leave off unless you have headroom. |
 | Spinning-disk (HDD) | `HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY=1` | Sequential writes; avoids parallel-write thrash on HDDs. Leave off on SSD/NVMe. |

--- a/frontend/src/components/WizardLibrary.jsx
+++ b/frontend/src/components/WizardLibrary.jsx
@@ -20,6 +20,7 @@ import { toast } from 'react-hot-toast';
 import { useModels, useInstallModel } from '../api/hooks';
 import { setupDownloadStreamUrl } from '../api/setup';
 import { listEngines, selectEngine } from '../api/engines';
+import { openExternal } from '../api/external';
 
 const fmtGB = (gb) => (gb == null ? '' : `${gb.toFixed(gb < 10 ? 1 : 0)} GB`);
 
@@ -305,43 +306,62 @@ export default function WizardLibrary() {
           {t('firstrun.resume_note', 'Interrupted downloads resume automatically — closing the app is safe.')}
         </p>
       )}
-      <details className="frs__advanced swiz-lib__hf">
-        <summary>
-          {hfState === 'saved'
-            ? `✓ ${t('firstrun.hf_token_saved', 'Hugging Face token saved')}`
-            : t('firstrun.hf_token_title', 'Hugging Face token (optional)')}
-        </summary>
-        <div className="swiz-lib__hf-body">
-          <p className="frs__trust">
-            {t('firstrun.hf_token_hint', 'Unlocks gated models — e.g. speaker diarization for multi-speaker dubbing (pyannote). Free account token; stays on this machine.')}
-          </p>
-          <div className="swiz-lib__hf-row">
-            <input
-              className="frs-input"
-              type="password"
-              placeholder="hf_…"
-              value={hfToken}
-              autoComplete="off"
-              onChange={(e) => { setHfToken(e.target.value); if (hfState !== 'idle') setHfState('idle'); }}
-              onKeyDown={(e) => { if (e.key === 'Enter') saveHfToken(); }}
-              aria-label={t('firstrun.hf_token_title', 'Hugging Face token (optional)')}
-            />
+      {/* Prominent, always-visible (no longer a collapsed "advanced" fold that
+          nobody opened) and positioned right above Continue. A free token gives
+          authenticated downloads — faster, higher rate limits, fewer stalls — so
+          first-run setup finishes quicker. Encouraged, not hidden (#657 → owner
+          follow-up). */}
+      <div className={`swiz-lib__hfcard ${hfState === 'saved' ? 'is-saved' : ''}`}>
+        <div className="swiz-lib__hfcard-main">
+          <span className="swiz-lib__hfcard-icon" aria-hidden="true">⚡</span>
+          <div className="swiz-lib__hfcard-text">
+            <div className="swiz-lib__hfcard-title">
+              {hfState === 'saved'
+                ? `✓ ${t('firstrun.hf_token_saved_fast', 'Hugging Face token saved — downloads are now faster')}`
+                : t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
+            </div>
+            <p className="swiz-lib__hfcard-hint">
+              {t('firstrun.hf_token_hint', 'A free account token gives authenticated downloads (faster, higher rate limits, fewer stalls) and unlocks gated models like speaker diarization for multi-speaker dubbing (pyannote). Stays on this machine.')}
+            </p>
+          </div>
+        </div>
+        {hfState !== 'saved' && (
+          <>
+            <div className="swiz-lib__hf-row">
+              <input
+                className="frs-input"
+                type="password"
+                placeholder="hf_…"
+                value={hfToken}
+                autoComplete="off"
+                onChange={(e) => { setHfToken(e.target.value); if (hfState !== 'idle') setHfState('idle'); }}
+                onKeyDown={(e) => { if (e.key === 'Enter') saveHfToken(); }}
+                aria-label={t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
+              />
+              <button
+                type="button"
+                className="frs-btn frs-btn--primary swiz-lib__hfcard-save"
+                disabled={!hfToken.trim() || hfState === 'saving'}
+                onClick={saveHfToken}
+              >
+                {hfState === 'saving'
+                  ? t('firstrun.hf_token_saving', 'saving…')
+                  : t('firstrun.hf_token_save', 'Save')}
+              </button>
+            </div>
             <button
               type="button"
-              className="frs-btn frs-btn--quiet"
-              disabled={!hfToken.trim() || hfState === 'saving'}
-              onClick={saveHfToken}
+              className="swiz-lib__hfcard-link"
+              onClick={() => openExternal('https://huggingface.co/settings/tokens')}
             >
-              {hfState === 'saving'
-                ? t('firstrun.hf_token_saving', 'saving…')
-                : t('firstrun.hf_token_save', 'Save')}
+              {t('firstrun.hf_token_get', "Don't have a token? Get one free →")}
             </button>
-          </div>
-          {hfState === 'error' && (
-            <p className="frs__blocker">{t('firstrun.hf_token_error', 'Could not save the token — try again or set it later in Settings → Credentials.')}</p>
-          )}
-        </div>
-      </details>
+          </>
+        )}
+        {hfState === 'error' && (
+          <p className="frs__blocker">{t('firstrun.hf_token_error', 'Could not save the token — try again or set it later in Settings → Credentials.')}</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1955,9 +1955,12 @@
     "first_sound_done": "That voice? Generated seconds ago, locally. Welcome in.",
     "hf_token_title": "Hugging Face token — faster, more reliable downloads (optional)",
     "hf_token_hint": "A free account token gives authenticated downloads (faster, higher rate limits, fewer stalls) and unlocks gated models like speaker diarization for multi-speaker dubbing (pyannote). Stays on this machine.",
+    "hf_token_card_title": "Add a free Hugging Face token for faster downloads",
+    "hf_token_get": "Don't have a token? Get one free →",
     "hf_token_save": "Save",
     "hf_token_saving": "saving…",
     "hf_token_saved": "Hugging Face token saved",
+    "hf_token_saved_fast": "Hugging Face token saved — downloads are now faster",
     "hf_token_error": "Could not save the token — try again or set it later in Settings → Credentials."
   },
   "history": {

--- a/frontend/src/pages/SetupWizard.css
+++ b/frontend/src/pages/SetupWizard.css
@@ -171,8 +171,38 @@
 
 .swiz-lib__more { align-self: flex-start; }
 
-/* Optional HF token — quiet disclosure at the bottom of the library. */
-.swiz-lib__hf { margin-top: 0.3rem; }
-.swiz-lib__hf-body { display: flex; flex-direction: column; gap: 0.45rem; margin-top: 0.45rem; max-width: 460px; }
+/* HF token — prominent card just above Continue (was a quiet fold). A free
+   token = authenticated, faster downloads, so we surface + encourage it. */
+.swiz-lib__hfcard {
+  margin-top: 0.9rem;
+  padding: 0.8rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  max-width: 560px;
+  border: 1px solid color-mix(in srgb, var(--frs-accent, #d3869b) 38%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--frs-accent, #d3869b) 8%, transparent);
+}
+.swiz-lib__hfcard.is-saved {
+  border-color: color-mix(in srgb, var(--frs-ok, #b8bb26) 45%, transparent);
+  background: color-mix(in srgb, var(--frs-ok, #b8bb26) 9%, transparent);
+}
+.swiz-lib__hfcard-main { display: flex; gap: 0.6rem; align-items: flex-start; }
+.swiz-lib__hfcard-icon { font-size: 1.1rem; line-height: 1.3; }
+.swiz-lib__hfcard-text { display: flex; flex-direction: column; gap: 0.2rem; }
+.swiz-lib__hfcard-title { font-weight: 600; font-size: 0.92rem; }
+.swiz-lib__hfcard-hint { margin: 0; font-size: 0.78rem; opacity: 0.66; line-height: 1.4; }
+.swiz-lib__hfcard-save { white-space: nowrap; }
+.swiz-lib__hfcard-link {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.78rem;
+  color: var(--frs-accent, #d3869b);
+  cursor: pointer;
+  text-decoration: underline;
+}
 .swiz-lib__hf-row { display: flex; gap: 0.45rem; }
 .swiz-lib__hf-row .frs-input { flex: 1; }

--- a/tests/test_segmented_download_default.py
+++ b/tests/test_segmented_download_default.py
@@ -1,0 +1,30 @@
+"""FDL-09: the segmented (multi-connection) downloader is ON by default.
+
+The app forces the legacy-LFS path (HF_HUB_DISABLE_XET=1) for clear progress,
+which is single-stream and slow. The segmented accelerator restores parallel
+byte-range speed with a safe fallback to snapshot_download — so it ships ON by
+default for fast first-run downloads. This pins the default so it can't silently
+regress to opt-in, and that the env override still disables it.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+from api.routers.setup.download import _segmented_enabled  # noqa: E402
+
+
+def test_segmented_is_on_by_default(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_SEGMENTED_DOWNLOAD", raising=False)
+    assert _segmented_enabled() is True
+
+
+def test_env_override_can_disable(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SEGMENTED_DOWNLOAD", "0")
+    assert _segmented_enabled() is False
+
+
+def test_env_override_truthy_keeps_it_on(monkeypatch):
+    for val in ("1", "true", "on", "yes"):
+        monkeypatch.setenv("OMNIVOICE_SEGMENTED_DOWNLOAD", val)
+        assert _segmented_enabled() is True


### PR DESCRIPTION
Addresses owner feedback: **surface + encourage the HF token near Continue**, and **make the slow downloader faster**.

## 1. Faster downloads — segmented accelerator ON by default

The app forces the legacy-LFS path (`HF_HUB_DISABLE_XET=1`) for clear progress, but that path is **single-stream and slow** — the root of "downloads are very slow." The built-in **multi-connection segmented downloader** (parallel byte-ranges, IDM/uGet style, live speed/ETA) was already implemented and unit-tested, just defaulted **OFF**. Flipping it **ON**:

- Engages only when Xet is inactive (the app default).
- **Falls back to `snapshot_download` on any error** — "can never compromise a correct install."
- Pure-httpx, cross-platform, **auth-safe** (token never forwarded to a CDN host).
- Disable with `OMNIVOICE_SEGMENTED_DOWNLOAD=0`.

## 2. HF token — prominent, encouraged, near Continue

Was a collapsed "advanced" fold almost nobody opened. Now a **prominent always-visible card** right above the Continue button:

```
┌────────────────────────────────────────────────┐
│ ⚡ Add a free Hugging Face token for faster       │
│    downloads                                     │
│    Authenticated downloads — higher rate limits, │
│    fewer stalls. Stays on this machine.          │
│    [ hf_………………………  ] [ Save ]                    │
│    Don't have a token? Get one free →            │
└────────────────────────────────────────────────┘
            [  ← Back ]      [  Continue  ]
```

A token raises rate limits, so it **pairs with #1** to keep the parallel fetch from getting throttled. One-click link to `huggingface.co/settings/tokens`.

## Docs & tests

- `docs/downloading-models.md`: legacy-LFS section documents the default-on accelerator + HF-token speed tip; tuning table now shows `OMNIVOICE_SEGMENTED_DOWNLOAD=0` as the disable knob (docs-sync).
- `test_segmented_download_default.py`: pins default ON + env override disables; existing FDL-08 behavior tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Made segmented model downloads the default for first-run setup, with `OMNIVOICE_SEGMENTED_DOWNLOAD=0` to opt out and a fallback to `snapshot_download` on errors.
- Surfaced the Hugging Face token prompt as a prominent always-visible card above Continue, added a token creation link, and emphasized faster downloads with authentication.
- Updated docs and added tests to cover the new default-on segmented download behavior.

### UI sketch
Before:
```text
[resume note]
[collapsed "advanced" details]
  token input / save
[Continue]
```

After:
```text
[resume note]
[Hugging Face token card]
  title + hint + token input/save
  get token link
  error (if any)
[Continue]
```

### Behavior flow
```mermaid
flowchart TD
  A[Setup starts] --> B{OMNIVOICE_SEGMENTED_DOWNLOAD=0?}
  B -- yes --> C[Use snapshot_download]
  B -- no --> D{Segmented downloader enabled?}
  D --> E[Try segmented multi-connection download]
  E -- success --> F[Done]
  E -- error --> C
  C --> F
</mermaid>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->