### PR TITLE
fix(clone): cap the ⊕ Insert popover height so it can't clip off the top of the window

### DIFF
--- a/frontend/src/pages/CloneDesignTab.css
+++ b/frontend/src/pages/CloneDesignTab.css
@@ -168,6 +168,14 @@
      `.clone-panel--overflow-visible` (applied in the JSX) stops the parent
      `overflow:auto` from clipping it. */
   max-width: min(360px, calc(100vw - 16px));
+  /* Vertical guard: the popover opens upward, and with 15 chips wrapping to
+     several rows it used to grow unbounded and clip off the TOP of the window
+     (the ⊕ button can sit high in a tall script panel). Cap the height to the
+     space above the button and scroll the overflow, so the whole list always
+     stays in view instead of shooting past the app's top edge. */
+  max-height: min(280px, calc(100vh - 120px));
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 8px;
   background: var(--chrome-bg);
   border: 1px solid var(--chrome-border-strong);


### PR DESCRIPTION
On the **Voice Clone** tab, the **⊕ Insert** popover (the 15 expression-token chips like `[dissatisfaction-hnn]`, `[CMU]`) opens upward from the lifted button (`bottom: 60px`) but had **no `max-height`** — so the wrapping chip grid grew unbounded and, when the button sat high in a tall script panel, the popover **shot past the top of the app window** and the first rows were clipped behind the title bar.

```
BEFORE                          AFTER
┌──[clipped above window]──┐
│ [surprise] [CMU] …       │     (popover stays fully in view,
│ [dissatisfaction-hnn] …  │      compact + scrollable, just
└──────────────────────────┘      above the ⊕ button)
══ OmniVoice title bar ═════
   ruth is not.   [+ Insert ▾]    ruth is not.   [+ Insert ▾]
```

## Fix

`max-height: min(280px, calc(100vh - 120px))` + `overflow-y: auto` (+ `overscroll-behavior: contain`) on `.clone-insert-pop`. It's now a compact, scrollable box that always stays within the viewport regardless of script length or button position. The horizontal viewport guard (#481) and the upward anchor are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Voice Clone tab’s `⊕ Insert` popover styling to prevent it from extending past the top of the viewport when opened upward.

**What changed**
- Added a viewport-aware `max-height` to `.clone-insert-pop`
- Enabled internal vertical scrolling with `overflow-y: auto`
- Contained scroll chaining with `overscroll-behavior: contain`

**Result**
- The expression-token chip list stays compact
- The popover remains fully visible within the window
- Existing upward anchoring and horizontal bounds behavior are unchanged

**Layout sketch**

Before:
```text
+-----------------------------+
|  app title bar              |
|                             |
|      [ Insert ]             |
|        ┌───────────────┐    |
|        │ chip chip ... │    |
|        │ chip chip ... │    |
|        │ chip chip ... │    |
|        │ chip chip ... │    |
|        └───────────────┘    |
|        ↑ can clip off top   |
+-----------------------------+
```

After:
```text
+-----------------------------+
|  app title bar              |
|                             |
|      [ Insert ]             |
|        ┌───────────────┐    |
|        │ chip chip ... │    |
|        │ chip chip ... │    |
|        │     scroll    │    |
|        └───────────────┘    |
|        stays in viewport    |
+-----------------------------+
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->