### PR TITLE
fix(setup): live download progress from the backend aggregate (fixes 0.0 MB / 1 KB/s)

### DIFF
--- a/frontend/src/components/WizardLibrary.jsx
+++ b/frontend/src/components/WizardLibrary.jsx
@@ -57,8 +57,22 @@ export function isPlatformPick(model, platformTags) {
   );
 }
 
-/** Aggregate one repo's SSE file events: percent + ETA + live rate + remaining.
- * Exported (pure) so the speed/remaining math is unit-testable. */
+/** Overall progress from the backend's authoritative `aggregate` SSE event.
+ * This is the TRUSTWORTHY source: under parallel/segmented fetch the per-file
+ * tqdm events are unreliable (big weight shards may report total/rate as 0),
+ * so summing them on the frontend gave wrong numbers — e.g. "8% · 1 KB/s ·
+ * 0.0 MB left". The backend computes one windowed rate + ETA + bytes_done /
+ * total_bytes (seeded by the dry-run preflight), which is what we render. Pure
+ * + exported for unit tests. Returns null until totals are known. */
+export function progressFromAgg(agg) {
+  if (!agg || !(agg.totalBytes > 0)) return null;
+  const pct = Math.min(100, Math.round((agg.bytesDone / agg.totalBytes) * 100));
+  const remaining = agg.totalBytes > agg.bytesDone ? agg.totalBytes - agg.bytesDone : null;
+  return { pct, remaining, rate: agg.rate || 0, etaSec: agg.etaSeconds ?? null };
+}
+
+/** Fallback: aggregate one repo's per-file SSE events when the authoritative
+ * `aggregate` event hasn't arrived yet. Exported (pure) for unit tests. */
 export function aggregate(files) {
   let done = 0;
   let total = 0;
@@ -177,6 +191,20 @@ export default function WizardLibrary() {
             delete next[ev.repo_id];
             return next;
           }
+          // Authoritative overall progress (download_aggregator): one windowed
+          // rate + ETA + bytes_done/total_bytes for the whole repo. Preferred
+          // over summing per-file events, which is unreliable under parallel/
+          // segmented fetch (the source of the "8% · 1 KB/s · 0.0 MB left" bug).
+          if (ev.phase === 'aggregate') {
+            return { ...prev, [ev.repo_id]: { ...cur, agg: {
+              bytesDone: ev.bytes_done || 0,
+              totalBytes: ev.total_bytes || 0,
+              rate: ev.rate || 0,
+              etaSeconds: ev.eta_seconds ?? null,
+              filesDone: ev.files_done || 0,
+              filesTotal: ev.files_total || 0,
+            } } };
+          }
           if (!ev.filename) return prev;
           const files = { ...cur.files, [ev.filename]: { downloaded: ev.downloaded || 0, total: ev.total || 0, rate: ev.rate || 0 } };
           return { ...prev, [ev.repo_id]: { ...cur, files } };
@@ -219,9 +247,11 @@ export default function WizardLibrary() {
 
   const modelRow = (m, chip, chipTone, note) => {
     const p = progress[m.repo_id];
-    const { pct, etaSec, rate, remaining } = p
-      ? aggregate(p.files)
-      : { pct: null, etaSec: null, rate: 0, remaining: null };
+    // Prefer the backend's authoritative aggregate; fall back to per-file sums
+    // only until that event arrives (then to nulls when nothing's streaming).
+    const { pct, etaSec, rate, remaining } =
+      progressFromAgg(p?.agg) ||
+      (p ? aggregate(p.files) : { pct: null, etaSec: null, rate: 0, remaining: null });
     const downloading = !!p;
     // Live telemetry line: "5.2 MB/s · 700 MB left · ~3m". Each part only shows
     // once the SSE stream has the data, so early on it degrades to "downloading…".

--- a/frontend/src/test/wizardLibraryAggregate.test.js
+++ b/frontend/src/test/wizardLibraryAggregate.test.js
@@ -1,5 +1,37 @@
 import { describe, it, expect } from 'vitest';
-import { aggregate, fmtBytes, fmtRate } from '../components/WizardLibrary.jsx';
+import { aggregate, progressFromAgg, fmtBytes, fmtRate } from '../components/WizardLibrary.jsx';
+
+describe('progressFromAgg — backend authoritative aggregate event', () => {
+  it('computes pct + remaining + rate + ETA from real totals (not the buggy per-file sum)', () => {
+    // 8% of 2.4 GB must show ~2.2 GB left — NOT "0.0 MB left" (#657 follow-up bug).
+    const TOTAL = 2.4 * 1024 * 1024 * 1024;   // 2.4 GiB, matching the "2.4 GB" label
+    const agg = {
+      bytesDone: 0.08 * TOTAL,
+      totalBytes: TOTAL,
+      rate: 5.2 * 1024 * 1024,  // 5.2 MB/s
+      etaSeconds: 405,
+    };
+    const r = progressFromAgg(agg);
+    expect(r.pct).toBe(8);
+    expect(r.remaining).toBeCloseTo(0.92 * TOTAL, 0);
+    expect(fmtBytes(r.remaining)).toBe('2.2 GB');     // not 0.0 MB
+    expect(fmtRate(r.rate)).toBe('5.2 MB/s');          // not 1 KB/s
+    expect(r.etaSec).toBe(405);
+  });
+
+  it('returns null until totals are known (so the row falls back / shows downloading…)', () => {
+    expect(progressFromAgg(null)).toBeNull();
+    expect(progressFromAgg({ bytesDone: 100, totalBytes: 0 })).toBeNull();
+    expect(progressFromAgg({ bytesDone: 100 })).toBeNull();
+  });
+
+  it('caps pct at 100 and treats no-remaining as null', () => {
+    const r = progressFromAgg({ bytesDone: 2_576_980_377, totalBytes: 2_576_980_377, rate: 0, etaSeconds: null });
+    expect(r.pct).toBe(100);
+    expect(r.remaining).toBeNull();
+    expect(r.etaSec).toBeNull();
+  });
+});
 
 describe('aggregate — download telemetry from SSE file events', () => {
   it('sums bytes, computes pct, remaining, rate and ETA', () => {


### PR DESCRIPTION
The first-run download line showed **wrong numbers** — e.g. `8% · 1 KB/s · 0.0 MB left` on a 2.4 GB model that just started:

```
BEFORE                                  AFTER
2.4 GB  8% · 1 KB/s · 0.0 MB left        2.4 GB  8% · 5.2 MB/s · 2.2 GB left · ~7m
2.9 GB 14% · 1 KB/s · 0.0 MB left        2.9 GB 14% · 6.1 MB/s · 2.5 GB left · ~6m
```

## Root cause

The #657 display **summed the per-file tqdm SSE events on the frontend**. Under parallel/segmented fetch the big weight shards report `total`/`rate` as 0, so the sum was garbage (tiny total → "0.0 MB left", a couple small files → "1 KB/s"). It also wasn't updating live.

The backend already solves this: `download_aggregator` emits a throttled **`phase:"aggregate"`** event with one **windowed rate + ETA + bytes_done/total_bytes** (+ files done/total), seeded by the dry-run preflight totals — *exactly because summing per-file on the client is unreliable*. But `WizardLibrary` dropped that event (`if (!ev.filename) return prev`) and never consumed it.

## Fix

Capture the `aggregate` event into per-repo state and render from it (new pure `progressFromAgg`), falling back to the per-file sum only until the first aggregate arrives. Real, live values now, landing on 100%.

(Pairs with #669: the segmented downloader feeds real bytes to the aggregator, so the rate/ETA are accurate.)

## Test

`wizardLibraryAggregate.test.js` — `progressFromAgg` yields correct pct/remaining/rate/ETA from real totals (**2.2 GB left, 5.2 MB/s** — not 0.0 MB / 1 KB/s), returns null until totals are known, caps pct at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Switched `WizardLibrary` download progress to prefer the backend’s authoritative `aggregate` SSE events instead of summing per-file updates.
- Added `progressFromAgg(agg)` to compute percent, remaining bytes, rate, and ETA from aggregate progress windows.
- Stored aggregate progress per repo and kept a fallback to per-file aggregation until the first aggregate event arrives.
- Added tests covering aggregate-derived progress, unknown totals, and 100% capping.

## UI flow
```mermaid
flowchart TD
  A[SSE download event] --> B{phase === aggregate?}
  B -- yes --> C[Store agg in repo state]
  B -- no --> D[Update per-file progress]
  C --> E[Render progressFromAgg(agg)]
  D --> F{agg available yet?}
  F -- no --> G[Render summed per-file progress]
  F -- yes --> E
```

## Component behavior
```text
Before:
[per-file SSE events] -> [sum bytes on frontend] -> [progress line]

After:
[per-file SSE events] ----+
                          +-> [repo state]
[aggregate SSE event] ----+       |
                                  +-> [progressFromAgg] -> [correct progress line]
                                         ^
                                         |
                               fallback until agg arrives
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->