### PR TITLE
fix(model): actionable "reinstall transformers" hint on a corrupted-install model-load error

### DIFF
--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -65,7 +65,24 @@ def classify(reason: str) -> str:
     # failure gets its hint rather than falling through to "".
     if "compute type" in low or "efficient float16" in low:
         return "COMPUTE_TYPE_UNSUPPORTED"
-    if "could not import module" in low or "autofeatureextractor" in low:
+    if (
+        "could not import module" in low
+        or "autofeatureextractor" in low
+        # A corrupted/incomplete transformers install: a model load lazily
+        # resolves a module file that's MISSING from site-packages (an
+        # interrupted `uv sync`, antivirus removal, or a partial update), e.g.
+        # `[Errno 2] No such file or directory:
+        #  '.../site-packages/transformers/models/qwen3/modeling_qwen3.py'`.
+        # That's a FileNotFoundError, not an ImportError, so the matches above
+        # miss it and the user got a useless "try restarting". Substring-match
+        # the package + the missing-file signal (separately, so it works on both
+        # POSIX `/` and Windows `\` paths).
+        or (
+            ("no such file" in low or "errno 2" in low)
+            and "transformers" in low
+            and "site-packages" in low
+        )
+    ):
         return "TRANSFORMERS_IMPORT"
     if ("huggingface" in low or "hf_token" in low or "401" in low or "unauthorized" in low) and (
         "token" in low or "auth" in low or "401" in low or "unauthorized" in low

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -724,9 +724,19 @@ def _load_model_sync():
         logger.info("OmniVoice model loaded successfully.")
         return _model
     except Exception as exc:
-        err_msg = str(exc)
+        # Surface an ACTIONABLE, sanitized error in /model/status (it's shown in
+        # the first-run System Check). build_failure classifies the cause and
+        # attaches a fix hint — e.g. a corrupted transformers install
+        # ([Errno 2] … modeling_*.py) now says "reinstall transformers" instead
+        # of an unhelpful raw path + "try restarting" — and strips the home dir.
+        try:
+            from core.failure import build_failure
+            _f = build_failure(exc, stage="model-load", include_diagnostic=False)
+            err_msg = _f["reason"] + (f" — {_f['hint']}" if _f.get("hint") else "")
+        except Exception:  # never let failure-formatting mask the real error
+            err_msg = str(exc)
         _set_loading("error", "Model loading failed", error=err_msg)
-        logger.error("Model loading failed: %s", err_msg)
+        logger.error("Model loading failed: %s", str(exc))
         raise
     finally:
         unregister_listener(lid)

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -61,6 +61,29 @@ fresh install heals itself.
 **Linked issues:** [#58](https://github.com/debpalash/OmniVoice-Studio/issues/58),
 [#248](https://github.com/debpalash/OmniVoice-Studio/issues/248)
 
+### 1a. Model load fails: `[Errno 2] No such file or directory: '…/transformers/…/modeling_*.py'`
+
+**Symptom:** the System Check / model load fails with e.g.
+`[Errno 2] No such file or directory:
+'…/site-packages/transformers/models/qwen3/modeling_qwen3.py'`.
+
+**Cause:** same class as §1 — a **corrupted/incomplete `transformers` install**.
+A model load lazily resolves a module file that's **missing from `site-packages`**
+(an interrupted `uv sync`, antivirus quarantine, or a partial update). The
+package's metadata is intact, so a plain install no-ops and never restores the
+file. Restarting does **not** help (the file is still gone).
+
+**Fix:** force-reinstall transformers in the backend venv, then restart:
+
+```
+uv pip install --reinstall transformers
+```
+
+Or, as a quick workaround, switch ASR to **faster-whisper** in
+**Settings → Models**. If it recurs, add the backend **`.venv`** to your
+antivirus exclusions (see §1). Newer builds classify this error and show the
+reinstall hint directly instead of a bare path + "try restarting".
+
 ## 2. HF 401 / pyannote license not accepted
 
 **Symptom:** dubbing fails with `HfHubHTTPError: 401 Client Error: Unauthorized

--- a/tests/test_failure_classify.py
+++ b/tests/test_failure_classify.py
@@ -34,6 +34,28 @@ def test_classify_transformers_import():
     assert evt["hint"], "transformers-import failure must carry an actionable hint"
 
 
+def test_classify_corrupted_transformers_file():
+    # A missing transformers module file (interrupted uv sync / AV / partial
+    # update) surfaces as FileNotFoundError, not ImportError — it must still
+    # classify as TRANSFORMERS_IMPORT so the user gets "reinstall", not "restart".
+    posix = (
+        "[Errno 2] No such file or directory: "
+        "'/Users/u/Library/Application Support/com.x/project/.venv/lib/python3.11/"
+        "site-packages/transformers/models/qwen3/modeling_qwen3.py'"
+    )
+    win = (
+        "[Errno 2] No such file or directory: "
+        r"'C:\Users\u\AppData\Local\com.x\project\.venv\Lib\site-packages\transformers"
+        r"\models\qwen3\modeling_qwen3.py'"
+    )
+    assert failure.classify(posix) == "TRANSFORMERS_IMPORT"
+    assert failure.classify(win) == "TRANSFORMERS_IMPORT"
+    f = failure.build_failure(FileNotFoundError(posix), stage="model-load", include_diagnostic=False)
+    assert "reinstall" in f["hint"].lower()
+    # A missing file from an UNRELATED package must NOT be mislabelled as transformers.
+    assert failure.classify("[Errno 2] No such file or directory: '/x/site-packages/numpy/core/foo.py'") == ""
+
+
 def test_classify_video_download_classes():
     # #554: a non-downloadable link shape → actionable "paste a direct video URL".
     assert failure.classify("Unsupported URL: https://www.douyin.com/discover") == (


### PR DESCRIPTION
A model load failed with:
```
[Errno 2] No such file or directory:
'…/site-packages/transformers/models/qwen3/modeling_qwen3.py'
```
The user's `transformers` install was **incomplete** — that file is missing while a correct 5.3.0 install has it (an interrupted `uv sync`, antivirus quarantine, or a partial update drops it). The System Check showed the **raw path + "Check logs and try restarting"** — useless, since restarting can't restore a missing file.

## Fix

1. **`core.failure.classify()`** now recognizes this corrupted-install variant. It's a `FileNotFoundError`, not an `ImportError`, so the existing `TRANSFORMERS_IMPORT` match (`"could not import module"` / `"AutoFeatureExtractor"`) missed it. Now also matches `"no such file"`/`"errno 2"` + `"transformers"` + `"site-packages"` (substrings checked separately → works on POSIX `/` and Windows `\`). An unrelated package's missing file is **not** mislabelled.
2. **`model_manager._load()`** builds the `/model/status` error via `build_failure`, so it carries the classified **hint** and strips the home dir, instead of the raw `str(exc)`. The System Check now shows:
   > Your transformers install is incomplete. Reinstall it (`uv pip install --reinstall transformers`) or switch ASR to faster-whisper (Settings → Models).

## Docs & test

- Troubleshooting **§1a** documents the symptom + reinstall fix.
- `test_failure_classify.py` pins both POSIX + Windows path forms → `TRANSFORMERS_IMPORT` with a "reinstall" hint, and that an unrelated package's missing file does not classify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Behavior
```mermaid
flowchart TD
  A[Model load fails with FileNotFoundError] --> B{Missing file path mentions transformers + site-packages?}
  B -- yes --> C[Classify as TRANSFORMERS_IMPORT]
  B -- no --> D[Leave unclassified / other failure]
  C --> E[Build sanitized /model/status error]
  E --> F[Return actionable hint to reinstall transformers or use faster-whisper]
```

### Changes
- Detects corrupted/incomplete `transformers` installs from POSIX and Windows `FileNotFoundError` paths.
- Uses `build_failure` when forming `/model/status` errors so the response includes the classified hint and omits raw home-directory paths.
- Adds troubleshooting docs for the missing `modeling_*.py` case and remediation steps.
- Adds tests for POSIX, Windows, and unrelated missing-file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->