### PR TITLE
fix(design): don't forward a clone profile_id in design mode (gender no-op) (#674)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -275,7 +275,7 @@ function App() {
     textAreaRef,
     ingestRefAudio, insertTag, applyPreset,
     handleGenerate,
-  } = useTTS({ selectedProfile, setSelectedProfile, loadHistory });
+  } = useTTS({ selectedProfile, setSelectedProfile, loadHistory, profiles });
 
   const handleSaveProfile = () => _handleSaveProfile(refAudio, refText, instruct, language);
 

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -5,7 +5,7 @@ import { pickDesignSeed } from '../utils/seed';
 import { playBlobAudio, playPing } from '../utils/media';
 import { probeAudioDuration } from '../utils/format';
 import { CLONE_MAX_SECONDS, PRESETS } from '../utils/constants';
-import { buildDesignInstruct } from '../utils/voiceInstruct';
+import { buildDesignInstruct, designModeProfileId } from '../utils/voiceInstruct';
 import { toast } from 'react-hot-toast';
 import { toastErrorWithReport } from '../utils/errorToast';
 import { addBreadcrumb } from '../utils/breadcrumbs';
@@ -21,7 +21,7 @@ let _lastRoutingStatus = null;
  * Encapsulates TTS generation logic, streaming response handling,
  * audio ingestion (with trim gate), and preset/tag helpers.
  */
-export default function useTTS({ selectedProfile, setSelectedProfile, loadHistory }) {
+export default function useTTS({ selectedProfile, setSelectedProfile, loadHistory, profiles }) {
   const text = useAppStore(s => s.text);
   const setText = useAppStore(s => s.setText);
   const language = useAppStore(s => s.language);
@@ -154,8 +154,12 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
           toast(t('tts_errors.ignored_duplicate', { items: duplicates.join(', ') }), { icon: '⚠️' });
         }
         if (finalInstruct) formData.append("instruct", finalInstruct);
-        if (selectedProfile) {
-          formData.append("profile_id", selectedProfile);
+        // #674: in design mode, never forward a CLONE profile_id — its reference
+        // voice would override the design attributes (e.g. "Male" has no effect).
+        // Design profiles still pass through (re-render a designed voice).
+        const designProfileId = designModeProfileId(selectedProfile, profiles);
+        if (designProfileId) {
+          formData.append("profile_id", designProfileId);
         }
       }
 

--- a/frontend/src/utils/voiceInstruct.js
+++ b/frontend/src/utils/voiceInstruct.js
@@ -67,6 +67,29 @@ export function buildDesignInstruct(vdStates = {}, freeText = '') {
 }
 
 /**
+ * Which `profile_id` (if any) to forward in DESIGN mode.
+ *
+ * Design mode generates a voice from attributes (the `instruct` built from the
+ * sliders). A *clone* profile (reference audio, no instruct) must NOT be sent:
+ * the backend would clone that voice, and its gender/timbre then overrides the
+ * design attributes — so e.g. "Male" appears to do nothing (#674). A *design*
+ * profile (carries an instruct) is fine to forward (re-render a designed voice).
+ *
+ * Conservative: only a KNOWN clone is suppressed; an unknown id (profiles not
+ * loaded yet) or a design profile passes through, preserving existing behavior.
+ *
+ * @param {string} selectedProfile  selected profile id (or '')
+ * @param {Array}  profiles         loaded profiles ({ id, instruct? })
+ * @returns {string|null} the id to send, or null to omit it
+ */
+export function designModeProfileId(selectedProfile, profiles) {
+  if (!selectedProfile) return null;
+  const p = (profiles || []).find((x) => x && x.id === selectedProfile);
+  if (p && !p.instruct) return null;   // known clone → omit so it can't hijack the design
+  return selectedProfile;
+}
+
+/**
  * Coerce an instruct value to the STRING that belongs in the FormData/payload.
  * `buildDesignInstruct()` returns `{ instruct, unsupported, duplicates }`, and
  * passing that object to `FormData.append` string-coerced it to the literal

--- a/frontend/src/utils/voiceInstruct.test.js
+++ b/frontend/src/utils/voiceInstruct.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildDesignInstruct, instructToFormValue } from './voiceInstruct';
+import { buildDesignInstruct, instructToFormValue, designModeProfileId } from './voiceInstruct';
 
 // plan-05 (#132): the Voice Design payload must be a validator-safe instruct —
 // one valid tag per category, no unsupported free-text — so Synthesize stops
@@ -71,6 +71,30 @@ describe('buildDesignInstruct', () => {
     const { instruct, unsupported } = buildDesignInstruct({ Gender: 'nonbinary' }, '');
     expect(instruct).toBe('');
     expect(unsupported).toEqual([]);
+  });
+});
+
+describe('designModeProfileId (#674 — clone must not hijack design attributes)', () => {
+  const profiles = [
+    { id: 'clone1', name: 'My Clone' },                 // no instruct → clone
+    { id: 'clone2', name: 'Demo', instruct: '' },        // empty instruct → clone
+    { id: 'design1', name: 'Narrator', instruct: 'male, low pitch' }, // design
+  ];
+
+  it('suppresses a known clone profile (so gender/timbre comes from the attributes)', () => {
+    expect(designModeProfileId('clone1', profiles)).toBeNull();
+    expect(designModeProfileId('clone2', profiles)).toBeNull();
+  });
+
+  it('forwards a design profile (re-render a designed voice)', () => {
+    expect(designModeProfileId('design1', profiles)).toBe('design1');
+  });
+
+  it('omits when nothing is selected; passes through an unknown id (profiles not loaded)', () => {
+    expect(designModeProfileId('', profiles)).toBeNull();
+    expect(designModeProfileId(null, profiles)).toBeNull();
+    expect(designModeProfileId('not-loaded-yet', [])).toBe('not-loaded-yet');
+    expect(designModeProfileId('x', undefined)).toBe('x');
   });
 });
 


### PR DESCRIPTION
Closes **#674**. In Voice Design, choosing **"Male"** (or any gender) could have **no audible effect**.

## Root cause

The design synthesize branch forwarded the selected `profile_id` alongside the design instruct. If that profile is a **clone** (reference audio, no instruct) — e.g. the **demo voice selected by default** — the backend clones it, and the reference voice's gender/timbre **overrides** the "male" attribute. So the design slider appears to do nothing.

## Fix

A pure, tested `designModeProfileId(selectedProfile, profiles)` decides what to send in design mode:
- **Known clone** (no instruct) → **suppressed**, so the design attributes drive the voice.
- **Design profile** (carries an instruct) → still forwarded (re-render a designed voice).
- **Unknown id** (profiles not loaded) or nothing selected → unchanged.

Conservative — it only removes the gender-hijacking case. Threaded `profiles` into `useTTS`.

## Test

`voiceInstruct.test.js`: clone (no/empty instruct) → `null`, design profile → its id, empty/null → `null`, unknown id → passthrough.

Closes #674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes Voice Design so a selected clone voice no longer overrides gender/timbre attributes in design mode.

```mermaid
flowchart TD
  A[User starts TTS in design mode] --> B[useTTS]
  B --> C[designModeProfileId(selectedProfile, profiles)]
  C --> D{Selected profile known?}
  D -->|No / empty / null| E[Send no profile_id]
  D -->|Clone profile| E
  D -->|Design profile| F[Send profile_id]
  D -->|Unknown while profiles unavailable| F
  E --> G[Backend applies design instruct only]
  F --> H[Backend may reuse profile state]
```

- Added `designModeProfileId(selectedProfile, profiles)` to suppress known clone `profile_id` values in design mode.
- Threaded `profiles` into `useTTS` and switched design-mode synthesis to use the helper instead of forwarding `selectedProfile` directly.
- Added tests covering clone, design, empty/null, and unknown profile cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->