### PR TITLE
feat(dictation): live local dictation via sherpa-onnx + Voice settings panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.3.8] — 2026-06-24
+
+A stability-focused release that makes first-run and Windows "just work" — and
+ships **live, faster-than-real-time local dictation**. It clears the wave of
+**"Can't reach the local backend"** reports at the source — the 8 GB-card OOM
+crash, the slow-load future-scheduling break, a Windows-only WhisperX load
+failure, and transcription stalls that *looked* like a dead backend are all
+fixed or now fail with a clear, actionable message. Downloads are faster out of
+the box (parallel segmented transfer on by default) and the Hugging Face token
+that speeds them up is front-and-center on setup. Plus first-run polish, faster
+long-form previews on Windows, multi-voice story casting, and a friendlier batch
+of error messages across dub, generate, and design.
 
 ### Added
 
@@ -30,22 +41,9 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
   its download and switches to it once ready. **Toggle vs Hold** is wired for
   both the desktop global hotkey and the in-app Ctrl/Cmd+Shift+Space fallback, so
   the behaviour is identical on macOS, Windows, and Linux. While you speak, the
-  dictation pill shows the transcript building **live**, and each sentence is
-  pasted into the focused field as you pause — not only at the end.
-
-## [0.3.8] — 2026-06-24
-
-A stability-focused release that makes first-run and Windows "just work." It
-clears the wave of **"Can't reach the local backend"** reports at the source —
-the 8 GB-card OOM crash, the slow-load future-scheduling break, a Windows-only
-WhisperX load failure, and transcription stalls that *looked* like a dead backend
-are all fixed or now fail with a clear, actionable message. Downloads are faster
-out of the box (parallel segmented transfer on by default) and the Hugging Face
-token that speeds them up is front-and-center on setup. Plus first-run polish,
-faster long-form previews on Windows, multi-voice story casting, and a friendlier
-batch of error messages across dub, generate, and design.
-
-### Added
+  dictation pill shows the transcript building **live**, and words type straight
+  into the focused field *as you speak* — self-correcting with backspaces as the
+  streaming recognizer refines, with clipboard-paste as an automatic fallback.
 
 - **Tagged scripts auto-cast into a multi-voice podcast/audiobook.** Paste a
   `[Alice] … [Bob] …` script into Stories and hit Auto-cast: it now recognizes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Added
+
+- **Live, faster-than-real-time dictation via a new sherpa-onnx ASR engine.**
+  Pick one of seven small ONNX speech-to-text models (Parakeet TDT v3/v2,
+  streaming Zipformer EN/ZH/bilingual, streaming Paraformer, multilingual
+  Whisper Tiny) for dictation, and watch text appear *as you speak*. Streaming
+  models emit partials frame-by-frame and commit a sentence on natural silence;
+  offline models surface live partials too by re-decoding a growing buffer.
+  Runs CPU-only and identically on macOS, Windows, and Linux — no GPU, no cloud,
+  no extra setup beyond a ~75–180 MB one-time model download. Parakeet TDT v3 is
+  the recommended default; existing Whisper/MLX/NeMo dictation engines are
+  untouched and still the fallback.
+
+- **New "Voice" settings panel for live dictation.** Settings → Capture now
+  leads with a Voice card: an Enable Voice Dictation toggle (showing your real
+  registered shortcut), a Toggle/Hold mode switch, and a Speech Model dropdown
+  that lists all seven models with offline/streaming + recommended badges, size,
+  one-line descriptions, the installed checkmark, and inline download/delete —
+  reusing the model-store download progress. Picking an uninstalled model starts
+  its download and switches to it once ready. **Toggle vs Hold** is wired for
+  both the desktop global hotkey and the in-app Ctrl/Cmd+Shift+Space fallback, so
+  the behaviour is identical on macOS, Windows, and Linux. While you speak, the
+  dictation pill shows the transcript building **live**, and each sentence is
+  pasted into the focused field as you pause — not only at the end.
+
 ## [0.3.8] — 2026-06-24
 
 A stability-focused release that makes first-run and Windows "just work." It

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ ElevenLabs charges **$5–$330/mo** and processes your audio on their servers. O
 | **GPU Support** | N/A (cloud) | CUDA · Apple Silicon · ROCm · CPU |
 | **Desktop App** | ❌ | ✅ macOS · Windows · Linux |
 | **TTS Engines** | 1 | **11** (OmniVoice, CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX, IndexTTS 2, OmniVoice GGUF, Supertonic 3) |
-| **ASR Engines** | 1 | **8** (WhisperX, Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet, Moonshine, FunASR, isolated Faster-Whisper) |
+| **ASR Engines** | 1 | **9** (WhisperX, Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet, Moonshine, FunASR, isolated Faster-Whisper, sherpa-onnx live dictation) |
 | **MCP Server** | ❌ | ✅ Use from Claude, Cursor, any MCP client |
 | **Self-check** | ❌ | ✅ Diagnostics suite, error journal, scrubbed debug bundles |
 | **Customizable** | ❌ Closed | ✅ Fork it, extend it, ship it |
@@ -311,8 +311,9 @@ OmniVoice ships a multi-engine ASR (speech-to-text) backend that powers dictatio
 | **Parakeet TDT** | `nemo-parakeet` | English + 25 EU | SOTA English accuracy, auto language detection (NVIDIA NeMo, GPU only) |
 | **Moonshine** | `moonshine` | English | Edge / low-latency, ONNX |
 | **FunASR** | `funasr` | 50+ | All-in-one multilingual — built-in VAD + inline speaker diarization (SenseVoice) |
+| **sherpa-onnx** (live dictation) | `sherpa-onnx-asr` | 25 EU + 90+ | Live, faster-than-real-time dictation — small streaming/offline ONNX models (Parakeet TDT v3/v2, streaming Zipformer & Paraformer, Whisper Tiny), CPU, identical on macOS / Windows / Linux. Picked per-model in **Settings → Voice**. |
 
-> Whisper-family engines cover ~100 languages; **FunASR / SenseVoice** adds an all-in-one multilingual path with built-in voice-activity detection and inline speaker diarization. Every engine runs on-device — no API keys, no cloud.
+> Whisper-family engines cover ~100 languages; **FunASR / SenseVoice** adds an all-in-one multilingual path with built-in voice-activity detection and inline speaker diarization. **sherpa-onnx** powers the live dictation model picker — you talk and text appears as you speak. Every engine runs on-device — no API keys, no cloud.
 
 > **GPU without efficient float16?** On older NVIDIA GPUs (Maxwell/Pascal, GTX 16xx) or after a CTranslate2/cuDNN mismatch, the CTranslate2 ASR engines (WhisperX, Faster-Whisper) can't run `float16` and OmniVoice automatically retries on `int8` — no config needed. If transcription still fails, pin the compute type with the `ASR_COMPUTE_TYPE` env var (escape hatch): `ASR_COMPUTE_TYPE=int8` (or `float32` for CPU). Set it to `int8` and restart the backend.
 
@@ -350,7 +351,7 @@ OmniVoice ships a multi-engine ASR (speech-to-text) backend that powers dictatio
 | **Audio** | Demucs vocal isolation, per-segment gain, selective track export, stem/SRT/VTT/MP3 export, unlimited-length TTS via sentence-chunked generation |
 | **Multi-Lang** | Multi-language batch picker, batch dubbing queue with sequential GPU execution |
 | **Diarization** | Pyannote ML diarization, auto speaker clone extraction, per-speaker voice assignment |
-| **ASR** | 8 engines (WhisperX, Faster-Whisper, isolated Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet TDT, Moonshine, FunASR/SenseVoice), crash-isolated subprocess backend |
+| **ASR** | 9 engines (WhisperX, Faster-Whisper, isolated Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet TDT, Moonshine, FunASR/SenseVoice, sherpa-onnx live dictation), crash-isolated subprocess backend |
 | **TTS** | 11 engines (OmniVoice, CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX, + lazy: IndexTTS 2, OmniVoice GGUF, Supertonic 3), engine routing with GPU preflight |
 | **Infra** | Docker deployment, CUDA/MPS/ROCm auto-detect, cuDNN 8 compat, VRAM-aware model offloading, engine routing (no silent CPU fallback), diagnostics suite & error journal, restricted-network mirror support |
 | **AI Provenance** | AudioSeal invisible watermarking (SynthID-like), video logo overlay, watermark detection API |

--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -101,6 +101,30 @@ def _pcm16_to_wav(pcm: bytes, sample_rate: int) -> str | None:
         return None
 
 
+def _select_sherpa_spec(websocket: WebSocket):
+    """Resolve the sherpa dictation model for this WS session, or None.
+
+    A ``?model=<id>`` query param wins (the frontend can pin a model per
+    session); otherwise the persisted ``dictation.model_id`` pref is used (only
+    when dictation is enabled). Returns the :class:`SherpaModelSpec` or None
+    (None → the legacy Whisper/WebM path runs unchanged).
+    """
+    try:
+        from services import sherpa_dictation as sd
+    except Exception:
+        return None
+    requested = websocket.query_params.get("model")
+    if requested:
+        return sd.get_spec(requested)  # explicit selection (may be None if bad)
+    # Fall back to the persisted dictation pref.
+    try:
+        from services.asr_backend import dictation_model_id
+        mid = dictation_model_id()
+    except Exception:
+        mid = None
+    return sd.get_spec(mid) if mid else None
+
+
 @router.websocket("/ws/transcribe")
 async def ws_transcribe(websocket: WebSocket):
     """Stream audio in, get partial + final transcription out."""
@@ -118,6 +142,24 @@ async def ws_transcribe(websocket: WebSocket):
         return
 
     await websocket.accept()
+
+    # Live-dictation engine selection. When a sherpa-onnx model is selected
+    # (via ?model= or the dictation.model_id pref) AND sherpa is installed,
+    # run the dedicated low-latency handler. Otherwise fall through to the
+    # legacy Whisper/WebM path, byte-for-byte unchanged.
+    spec = _select_sherpa_spec(websocket)
+    if spec is not None:
+        from services.asr_backend import SherpaDictationBackend
+        ok, _reason = SherpaDictationBackend.is_available()
+        if ok:
+            if spec.streaming:
+                await _run_sherpa_streaming(websocket, spec)
+            else:
+                await _run_sherpa_offline(websocket, spec)
+            return
+        # sherpa not installed → fall through to the legacy path so the user
+        # still gets dictation (just not live partials).
+        logger.info("sherpa dictation selected but unavailable — legacy path")
 
     # Opt-in dictate-over-playback AEC (parity Action 8b). Default OFF →
     # identical legacy behaviour. When on, frames are 1-byte-tagged raw PCM
@@ -286,6 +328,321 @@ async def ws_transcribe(websocket: WebSocket):
         })
 
     if not client_disconnected:
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+
+
+# ── sherpa-onnx live dictation handlers ─────────────────────────────────────
+#
+# Both handlers read raw int16 mono PCM frames (reusing the AEC framing: an
+# opt-in 1-byte type prefix when ?aec=1, else bare PCM) at ?sr= (default 16000).
+# This is the low-latency transport — no WebM/ffmpeg in the hot path.
+
+# How often the offline-kind handler re-decodes the growing buffer for a live
+# partial (streaming-kind decodes every frame, no cadence needed).
+SHERPA_OFFLINE_PARTIAL_S = float(os.environ.get("OMNIVOICE_SHERPA_OFFLINE_PARTIAL", "0.8"))
+
+
+def _pcm16_to_f32(pcm: bytes):
+    """int16 little-endian mono PCM bytes → float32 numpy in [-1, 1]."""
+    import numpy as np
+    if not pcm:
+        return np.zeros(0, dtype=np.float32)
+    # Guard against an odd trailing byte from a split frame.
+    if len(pcm) % 2:
+        pcm = pcm[:-1]
+    return np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
+
+
+async def _sherpa_session(websocket: WebSocket):
+    """Shared WS receive setup for the sherpa handlers.
+
+    Returns ``(get_frame, state)`` where ``get_frame`` is an async callable
+    that yields the next near-end (mic) PCM bytes, ``b""`` for a keepalive/ref
+    frame, or ``None`` on EOF/disconnect. ``state`` carries sample rate, AEC,
+    and the disconnect flag for the caller's finaliser.
+    """
+    pcm_sr = 16000
+    try:
+        pcm_sr = int(websocket.query_params.get("sr", "16000"))
+    except (TypeError, ValueError):
+        pcm_sr = 16000
+    aec = None
+    if websocket.query_params.get("aec") in ("1", "true", "on"):
+        try:
+            from services.aec import NlmsEchoCanceller
+            aec = NlmsEchoCanceller(sample_rate=pcm_sr)
+        except Exception as e:
+            logger.warning("AEC requested but disabled (sherpa): %s", e)
+            aec = None
+    return pcm_sr, aec
+
+
+async def _recv_pcm_frame(websocket: WebSocket, aec):
+    """Receive one frame; return (kind, pcm_bytes).
+
+    kind ∈ {"near","eof","skip"}. Demuxes AEC-tagged frames when ``aec`` is on
+    and feeds the playback reference into the canceller. A text "EOF" or an
+    empty/closed socket yields kind "eof".
+    """
+    msg = await websocket.receive()
+    mtype = msg.get("type")
+    if mtype == "websocket.disconnect":
+        return "eof", b""
+    if mtype != "websocket.receive":
+        return "skip", b""
+    data = msg.get("bytes")
+    if data is not None:
+        if len(data) == 0:
+            return "eof", b""
+        if aec is not None:
+            kind, payload = _demux_aec_frame(data)
+            if kind == "far":
+                aec.push_far_end(payload)
+                return "skip", b""
+            if not payload:
+                return "skip", b""
+            return "near", aec.process_near_end(payload)
+        return "near", data
+    if msg.get("text") == "EOF":
+        return "eof", b""
+    return "skip", b""
+
+
+async def _run_sherpa_streaming(websocket: WebSocket, spec):
+    """True streaming: feed the OnlineRecognizer frame-by-frame, emit `partial`
+    every time the decoded text grows, and `final` on sherpa's endpoint (silence)
+    detection and on EOF. <300ms perceived latency on CPU for the tiny models.
+    """
+    import numpy as np
+    from services.asr_backend import SherpaDictationBackend
+
+    pcm_sr, aec = await _sherpa_session(websocket)
+    logger.info("sherpa streaming dictation: model=%s sr=%d aec=%s",
+                spec.id, pcm_sr, bool(aec))
+
+    backend = SherpaDictationBackend(model_id=spec.id)
+    # Build the recognizer off the event loop (download-on-first-use + ONNX
+    # session init can take a moment); keep the socket responsive.
+    try:
+        await asyncio.to_thread(backend.ensure_loaded)
+    except Exception as e:
+        logger.error("sherpa streaming load failed: %s", e)
+        try:
+            await websocket.send_json({"type": "error", "detail": str(e)})
+            await websocket.close()
+        except Exception:
+            pass
+        return
+    rec = backend._rec
+    stream = rec.create_stream()
+
+    last_partial = ""
+    committed: list[str] = []     # finalized utterances this session
+    client_disconnected = False
+
+    async def _send(payload) -> bool:
+        nonlocal client_disconnected
+        if client_disconnected:
+            return False
+        try:
+            await websocket.send_json(payload)
+            return True
+        except Exception:
+            client_disconnected = True
+            return False
+
+    def _decode_after_feed(pcm: bytes):
+        """Blocking: feed one PCM frame, decode, return (text, is_endpoint).
+        Runs in a thread so the ONNX work never blocks the event loop."""
+        samples = _pcm16_to_f32(pcm)
+        if len(samples):
+            stream.accept_waveform(pcm_sr, samples)
+        while rec.is_ready(stream):
+            rec.decode_stream(stream)
+        endpoint = rec.is_endpoint(stream)
+        text = (rec.get_result(stream) or "").strip()
+        return text, endpoint
+
+    def _flush_final():
+        """Blocking: pad + drain the stream for the trailing utterance."""
+        tail = np.zeros(int(0.5 * pcm_sr), dtype=np.float32)
+        stream.accept_waveform(pcm_sr, tail)
+        stream.input_finished()
+        while rec.is_ready(stream):
+            rec.decode_stream(stream)
+        return (rec.get_result(stream) or "").strip()
+
+    try:
+        while True:
+            kind, pcm = await _recv_pcm_frame(websocket, aec)
+            if kind == "eof":
+                break
+            if kind == "skip":
+                continue
+            text, endpoint = await asyncio.to_thread(_decode_after_feed, pcm)
+            if endpoint:
+                # Commit this utterance; reset for the next one.
+                if text:
+                    committed.append(text)
+                    await _send({"type": "final", "text": text,
+                                 "segments": [{"start": 0.0, "end": None, "text": text}],
+                                 "language": "auto", "engine": backend.id})
+                rec.reset(stream)
+                last_partial = ""
+            elif text and text != last_partial:
+                last_partial = text
+                await _send({"type": "partial", "text": text})
+    except WebSocketDisconnect:
+        client_disconnected = True
+    except Exception as e:
+        logger.warning("sherpa streaming loop ended: %s", e)
+        client_disconnected = True
+
+    # Drain the trailing (un-endpointed) utterance on EOF.
+    try:
+        tail_text = await asyncio.to_thread(_flush_final)
+    except Exception as e:
+        logger.debug("sherpa streaming flush failed: %s", e)
+        tail_text = ""
+    if tail_text and tail_text != (committed[-1] if committed else None):
+        committed.append(tail_text)
+
+    full = " ".join(t for t in committed if t).strip()
+    segments = [{"start": 0.0, "end": None, "text": t} for t in committed if t]
+    if not client_disconnected:
+        if full:
+            try:
+                from services.refinement import maybe_refine
+                refined = await asyncio.to_thread(maybe_refine, full)
+            except Exception:
+                refined = None
+            payload = {"type": "final", "text": full, "segments": segments,
+                       "language": "auto", "engine": backend.id}
+            if refined and refined != full:
+                payload["refined_text"] = refined
+            await _send(payload)
+        else:
+            await _send({"type": "final", "text": "", "segments": [],
+                         "language": "auto", "engine": backend.id})
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+
+
+async def _run_sherpa_offline(websocket: WebSocket, spec):
+    """Offline-kind sherpa model with live partials: buffer raw PCM and
+    re-decode the growing buffer every ~800ms so the user still sees text
+    appear while speaking; finalize on EOF/silence."""
+    from services.asr_backend import SherpaDictationBackend
+
+    pcm_sr, aec = await _sherpa_session(websocket)
+    logger.info("sherpa offline dictation: model=%s sr=%d aec=%s",
+                spec.id, pcm_sr, bool(aec))
+
+    backend = SherpaDictationBackend(model_id=spec.id)
+    try:
+        await asyncio.to_thread(backend.ensure_loaded)
+    except Exception as e:
+        logger.error("sherpa offline load failed: %s", e)
+        try:
+            await websocket.send_json({"type": "error", "detail": str(e)})
+            await websocket.close()
+        except Exception:
+            pass
+        return
+
+    buf = bytearray()
+    last_partial = ""
+    running = True
+    client_disconnected = False
+    last_audio = time.monotonic()
+
+    async def _send(payload) -> bool:
+        nonlocal client_disconnected
+        if client_disconnected:
+            return False
+        try:
+            await websocket.send_json(payload)
+            return True
+        except Exception:
+            client_disconnected = True
+            return False
+
+    def _decode_buffer() -> str:
+        samples = _pcm16_to_f32(bytes(buf))
+        if not len(samples):
+            return ""
+        return backend._decode_offline(samples, pcm_sr)
+
+    async def receive():
+        nonlocal running, client_disconnected, last_audio
+        try:
+            while running:
+                kind, pcm = await _recv_pcm_frame(websocket, aec)
+                if kind == "eof":
+                    running = False
+                    break
+                if kind == "skip":
+                    continue
+                buf.extend(pcm)
+                last_audio = time.monotonic()
+        except WebSocketDisconnect:
+            client_disconnected = True
+            running = False
+        except Exception as e:
+            logger.debug("sherpa offline receive ended: %s", e)
+            running = False
+
+    async def partials():
+        nonlocal last_partial, running
+        while running:
+            await asyncio.sleep(SHERPA_OFFLINE_PARTIAL_S)
+            if not running or len(buf) < 2000:
+                continue
+            try:
+                text = await asyncio.to_thread(_decode_buffer)
+            except Exception as e:
+                logger.debug("sherpa offline partial failed: %s", e)
+                continue
+            if text and text != last_partial:
+                last_partial = text
+                await _send({"type": "partial", "text": text})
+
+    recv_task = asyncio.create_task(receive())
+    part_task = asyncio.create_task(partials())
+    await asyncio.wait([recv_task, part_task], return_when=asyncio.FIRST_COMPLETED)
+    running = False
+    for t in (recv_task, part_task):
+        if not t.done():
+            t.cancel()
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    try:
+        full = await asyncio.to_thread(_decode_buffer)
+    except Exception as e:
+        logger.error("sherpa offline final failed: %s", e)
+        full = ""
+    full = (full or "").strip()
+    segments = [{"start": 0.0, "end": None, "text": full}] if full else []
+    if not client_disconnected:
+        payload = {"type": "final", "text": full, "segments": segments,
+                   "language": "auto", "engine": backend.id}
+        if full:
+            try:
+                from services.refinement import maybe_refine
+                refined = await asyncio.to_thread(maybe_refine, full)
+                if refined and refined != full:
+                    payload["refined_text"] = refined
+            except Exception:
+                pass
+        await _send(payload)
         try:
             await websocket.close()
         except Exception:

--- a/backend/api/routers/dictation.py
+++ b/backend/api/routers/dictation.py
@@ -1,0 +1,127 @@
+"""
+Dictation router — sherpa-onnx live-dictation engine.
+
+Exposes the seven sherpa-onnx dictation models and the dictation prefs the
+frontend dictation UI binds to.
+
+    GET  /dictation/models   → the 7 models + install state (frontend model list)
+    GET  /dictation/prefs    → { enabled, mode, model_id }
+    POST /dictation/prefs    → persist any subset of those prefs
+
+Install state reuses the same HF-cache check the model store uses, so a model
+shown "installed" here is the same snapshot the backend will load.
+
+Prefs are stored in the shared ``prefs.json`` store under the ``dictation.*``
+namespace (``dictation.enabled``, ``dictation.mode``, ``dictation.model_id``),
+mirroring how the ASR/TTS engine picks persist.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+
+from api.dependencies import require_loopback
+from core import prefs
+from services import sherpa_dictation as sd
+
+router = APIRouter()
+logger = logging.getLogger("omnivoice.dictation")
+
+# Pref keys (the binding contract — the frontend writes exactly these).
+PREF_ENABLED = "dictation.enabled"
+PREF_MODE = "dictation.mode"
+PREF_MODEL_ID = "dictation.model_id"
+
+_DEFAULT_ENABLED = True
+_DEFAULT_MODE = "toggle"
+_VALID_MODES = ("toggle", "hold")
+
+
+def _read_prefs() -> dict:
+    mid = prefs.get(PREF_MODEL_ID, sd.DEFAULT_MODEL_ID)
+    if not sd.is_sherpa_model(mid):
+        mid = sd.DEFAULT_MODEL_ID
+    mode = prefs.get(PREF_MODE, _DEFAULT_MODE)
+    if mode not in _VALID_MODES:
+        mode = _DEFAULT_MODE
+    return {
+        "enabled": bool(prefs.get(PREF_ENABLED, _DEFAULT_ENABLED)),
+        "mode": mode,
+        "model_id": mid,
+    }
+
+
+@router.get("/dictation/models", dependencies=[Depends(require_loopback)])
+def list_dictation_models():
+    """The seven sherpa-onnx dictation models + install state.
+
+    Each entry: id, repo_id, label, tag ("offline"|"streaming"), recommended,
+    size_gb, languages, kind, and install state (installed/installing). The
+    ``installed`` flag is computed from the same HF cache the model store reads,
+    so it matches the model-store row state.
+    """
+    available, reason = sd.sherpa_available()
+    out = []
+    for spec in sd.list_specs():
+        out.append({
+            "id": spec.id,
+            "repo_id": spec.repo_id,
+            "label": spec.label,
+            "tag": spec.tag,
+            "recommended": spec.recommended,
+            "size_gb": spec.size_gb,
+            "languages": spec.languages,
+            "kind": spec.kind,
+            "installed": sd.is_installed(spec),
+        })
+    return {
+        "models": out,
+        "engine_available": available,
+        "engine_reason": None if available else reason,
+        "default_model_id": sd.DEFAULT_MODEL_ID,
+    }
+
+
+@router.get("/dictation/prefs", dependencies=[Depends(require_loopback)])
+def get_dictation_prefs():
+    return _read_prefs()
+
+
+class DictationPrefsUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    mode: Optional[str] = None
+    model_id: Optional[str] = None
+
+
+@router.post("/dictation/prefs", dependencies=[Depends(require_loopback)])
+def set_dictation_prefs(req: DictationPrefsUpdate):
+    """Persist any subset of the dictation prefs. Validates ``mode`` and
+    ``model_id`` so a bad value can't wedge the capture engine."""
+    if req.mode is not None:
+        if req.mode not in _VALID_MODES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"mode must be one of {_VALID_MODES}",
+            )
+        prefs.set_(PREF_MODE, req.mode)
+    if req.model_id is not None:
+        if not sd.is_sherpa_model(req.model_id):
+            raise HTTPException(
+                status_code=400,
+                detail=f"unknown dictation model_id {req.model_id!r}",
+            )
+        # Normalise to the canonical dictation id (accept repo_id too).
+        prefs.set_(PREF_MODEL_ID, sd.get_spec(req.model_id).id)
+    if req.enabled is not None:
+        prefs.set_(PREF_ENABLED, bool(req.enabled))
+    # Rebuild the cached capture singleton so the change takes effect at once.
+    try:
+        from services import asr_backend
+        asr_backend._capture_backend = None
+        asr_backend._capture_backend_key = None
+    except Exception:
+        pass
+    return _read_prefs()

--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -120,6 +120,76 @@ models:
     size_gb: 0.05
     note: "Smallest/fastest Moonshine, sub-200ms latency. Lower accuracy than base. Requires moonshine-onnx."
 
+  # ── sherpa-onnx live dictation (ONNX, CPU, streaming + offline) ────────
+  # Live faster-than-real-time dictation via the k2-fsa/sherpa-onnx runtime.
+  # `engine: sherpa-onnx`, `dictation_id` (backend model id), and `tag`
+  # (offline | streaming) are extra fields the model-store list passes through
+  # so the dictation UI can filter/group these (role=ASR, engine=sherpa-onnx).
+  # Requires `uv add sherpa-onnx` (CPU wheels, all platforms).
+
+  - repo_id: "csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8"
+    label: "Parakeet TDT v3 (sherpa-onnx — dictation, 25 EU langs)"
+    role: ASR
+    size_gb: 0.18
+    engine: sherpa-onnx
+    dictation_id: sherpa-parakeet-tdt-v3
+    tag: offline
+    note: "Recommended live-dictation default. CPU, int8 ONNX. Requires sherpa-onnx."
+
+  - repo_id: "csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8"
+    label: "Parakeet TDT v2 (sherpa-onnx — dictation, English)"
+    role: ASR
+    size_gb: 0.17
+    engine: sherpa-onnx
+    dictation_id: sherpa-parakeet-tdt-v2
+    tag: offline
+    note: "English live dictation. CPU, int8 ONNX. Requires sherpa-onnx."
+
+  - repo_id: "csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20"
+    label: "Zipformer Bilingual (sherpa-onnx — streaming, zh+en)"
+    role: ASR
+    size_gb: 0.13
+    engine: sherpa-onnx
+    dictation_id: sherpa-zipformer-bilingual-zh-en
+    tag: streaming
+    note: "True streaming partials as you speak (zh+en). CPU. Requires sherpa-onnx."
+
+  - repo_id: "csukuangfj/sherpa-onnx-streaming-paraformer-bilingual-zh-en"
+    label: "Paraformer Bilingual (sherpa-onnx — streaming, zh+en)"
+    role: ASR
+    size_gb: 0.115
+    engine: sherpa-onnx
+    dictation_id: sherpa-paraformer-bilingual-zh-en
+    tag: streaming
+    note: "True streaming partials (zh+en). CPU. Requires sherpa-onnx."
+
+  - repo_id: "csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17"
+    label: "Zipformer Streaming EN 20M (sherpa-onnx — streaming, English)"
+    role: ASR
+    size_gb: 0.128
+    engine: sherpa-onnx
+    dictation_id: sherpa-zipformer-en-20m
+    tag: streaming
+    note: "Tiny English streaming model, very low latency. CPU. Requires sherpa-onnx."
+
+  - repo_id: "csukuangfj/sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23"
+    label: "Zipformer Streaming ZH 14M (sherpa-onnx — streaming, Chinese)"
+    role: ASR
+    size_gb: 0.074
+    engine: sherpa-onnx
+    dictation_id: sherpa-zipformer-zh-14m
+    tag: streaming
+    note: "Tiny Chinese streaming model, very low latency. CPU. Requires sherpa-onnx."
+
+  - repo_id: "csukuangfj/sherpa-onnx-whisper-tiny"
+    label: "Whisper Tiny (sherpa-onnx — dictation, 90+ langs)"
+    role: ASR
+    size_gb: 0.116
+    engine: sherpa-onnx
+    dictation_id: sherpa-whisper-tiny
+    tag: offline
+    note: "Multilingual offline dictation (auto-detect). CPU, int8 ONNX. Requires sherpa-onnx."
+
   # ── Diarisation ───────────────────────────────────────────────────────
 
   - repo_id: "pyannote/speaker-diarization-3.1"

--- a/backend/main.py
+++ b/backend/main.py
@@ -337,6 +337,7 @@ from api.routers import (
     events,
     capture,
     capture_ws,
+    dictation,
     openai_compat,
     tts_stream,
     marketplace,
@@ -909,6 +910,7 @@ app.include_router(watermark.router)
 app.include_router(events.router)
 app.include_router(capture.router)
 app.include_router(capture_ws.router)
+app.include_router(dictation.router)
 app.include_router(openai_compat.router)
 app.include_router(tts_stream.router)
 app.include_router(marketplace.router)

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -1167,6 +1167,148 @@ class MoonshineASRBackend(ASRBackend):
         self._transcriber = None
 
 
+# ── sherpa-onnx live dictation (ONNX, CPU, streaming + offline) ─────────────
+
+
+def _load_audio_16k_mono_f32(audio_path: str):
+    """Decode any audio file to 16 kHz mono float32 in [-1, 1] for sherpa.
+
+    Prefers soundfile (WAV/FLAC — the dictation buffers are already WAV) and
+    resamples to 16 kHz when needed; falls back to OmniVoice's validated ffmpeg
+    for containers soundfile can't read (WebM/Opus). 16 kHz is sherpa's cheapest
+    feed; it resamples internally too, but doing it here keeps the contract tight.
+    """
+    import numpy as np
+    try:
+        import soundfile as sf
+        data, sr = sf.read(audio_path, dtype="float32", always_2d=False)
+        if getattr(data, "ndim", 1) > 1:
+            data = data.mean(axis=1)
+        data = np.ascontiguousarray(data, dtype=np.float32)
+        if sr != 16000:
+            # Lightweight linear resample — adequate for ASR features.
+            n = int(round(len(data) * 16000 / sr))
+            if n > 0:
+                xp = np.linspace(0.0, 1.0, num=len(data), endpoint=False)
+                x = np.linspace(0.0, 1.0, num=n, endpoint=False)
+                data = np.interp(x, xp, data).astype(np.float32)
+            sr = 16000
+        return data, sr
+    except Exception:
+        # Container soundfile can't read (WebM/Opus) — use the validated ffmpeg
+        # path, which already yields 16 kHz mono float32.
+        return _decode_audio_16k_mono(audio_path), 16000
+
+
+class SherpaDictationBackend(ASRBackend):
+    """k2-fsa/sherpa-onnx ONNX dictation engine (CPU, live + offline).
+
+    One :class:`ASRBackend` instance is bound to one of the seven sherpa
+    dictation models (see :mod:`services.sherpa_dictation`). For the offline
+    ``transcribe(path)`` contract it runs an ``OfflineRecognizer`` for offline
+    models and a one-shot ``OnlineRecognizer`` decode for streaming models
+    (so ``POST /transcribe`` works for every sherpa model). The *live* WS path
+    drives the streaming recognizer incrementally — see ``capture_ws.py``.
+
+    CPU provider only (cross-platform default-parity rule); no CUDA dep.
+    """
+    id = "sherpa-onnx-asr"
+    display_name = "Sherpa-ONNX dictation (live, CPU — streaming + offline)"
+    gpu_compat = ("cpu",)
+
+    def __init__(self, model_id: str | None = None):
+        from services import sherpa_dictation as _sd
+        mid = model_id or os.environ.get(
+            "OMNIVOICE_SHERPA_ASR_MODEL", _sd.DEFAULT_MODEL_ID
+        )
+        spec = _sd.get_spec(mid)
+        if spec is None:
+            raise ValueError(
+                f"Unknown sherpa dictation model {mid!r}. Known: "
+                f"{[s.id for s in _sd.list_specs()]}"
+            )
+        self._spec = spec
+        self._rec = None  # lazy OfflineRecognizer / OnlineRecognizer
+
+    @property
+    def spec(self):
+        return self._spec
+
+    @property
+    def streaming(self) -> bool:
+        return self._spec.streaming
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        from services.sherpa_dictation import sherpa_available
+        return sherpa_available()
+
+    def ensure_loaded(self) -> None:
+        self._ensure_rec()
+
+    def _ensure_rec(self):
+        if self._rec is not None:
+            return
+        from services import sherpa_dictation as _sd
+        if self._spec.streaming:
+            self._rec = _sd.build_online_recognizer(self._spec)
+        else:
+            self._rec = _sd.build_offline_recognizer(self._spec)
+
+    def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
+        self._ensure_rec()
+        logger.info(
+            "sherpa-onnx dictation transcribing %s (model=%s, kind=%s)",
+            audio_path, self._spec.id, self._spec.kind,
+        )
+        samples, sr = _load_audio_16k_mono_f32(audio_path)
+        if self._spec.streaming:
+            text = self._decode_online_oneshot(samples, sr)
+        else:
+            text = self._decode_offline(samples, sr)
+        return _sherpa_result(text, samples, sr)
+
+    def _decode_offline(self, samples, sr) -> str:
+        s = self._rec.create_stream()
+        s.accept_waveform(sr, samples)
+        self._rec.decode_stream(s)
+        return (s.result.text or "").strip()
+
+    def _decode_online_oneshot(self, samples, sr) -> str:
+        """One-shot decode of a whole buffer through the streaming recognizer
+        (for the non-streaming ``transcribe()`` / partial re-decode path)."""
+        import numpy as np
+        s = self._rec.create_stream()
+        s.accept_waveform(sr, samples)
+        tail = np.zeros(int(0.5 * sr), dtype=np.float32)
+        s.accept_waveform(sr, tail)
+        s.input_finished()
+        while self._rec.is_ready(s):
+            self._rec.decode_stream(s)
+        return (self._rec.get_result(s) or "").strip()
+
+    def unload(self) -> None:
+        self._rec = None
+        import gc
+        gc.collect()
+
+
+def _sherpa_result(text: str, samples, sr) -> dict:
+    """Normalise a sherpa decode to OmniVoice's ``{chunks, segments, language,
+    text}`` contract. sherpa gives plain text (no VAD split), so emit a single
+    segment spanning the buffer — same shape Moonshine uses."""
+    text = (text or "").strip()
+    try:
+        duration = round(len(samples) / float(sr), 3)
+    except Exception:
+        duration = None
+    segments = []
+    if text:
+        segments.append({"text": text, "start": 0.0, "end": duration, "words": []})
+    chunks = [{"text": s["text"], "timestamp": (s["start"], s["end"])} for s in segments]
+    return {"chunks": chunks, "segments": segments, "language": "auto", "text": text}
+
+
 # ── Registry ────────────────────────────────────────────────────────────────
 
 
@@ -1329,6 +1471,7 @@ _REGISTRY: dict[str, type[ASRBackend]] = _LazyASRRegistry({
     "nemo-parakeet":   NeMoASRBackend,
     "moonshine":       MoonshineASRBackend,
     "funasr":          FunASRBackend,
+    "sherpa-onnx-asr": SherpaDictationBackend,
     # "faster-whisper-isolated": resolved lazily (crash-isolated subprocess).
 })
 
@@ -1343,6 +1486,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "nemo-parakeet":   "pip install nemo_toolkit[asr]  (NVIDIA Parakeet; CUDA or CPU)",
     "moonshine":       "pip install useful-moonshine  (edge/CPU-optimized ASR)",
     "funasr":          "pip install funasr  (SenseVoiceSmall + FSMN-VAD; CUDA or CPU)",
+    "sherpa-onnx-asr": "uv add sherpa-onnx  (ONNX live dictation; CPU, cross-platform)",
 }
 
 # Most-recent failure per backend, so a transient probe error survives between
@@ -1497,40 +1641,91 @@ def transcribe_reference(audio_path: str) -> str | None:
 
 
 _capture_backend: ASRBackend | None = None
+# The sherpa model id the cached capture backend was built for, so a model
+# switch in Settings rebuilds the singleton instead of serving the old model.
+_capture_backend_key: str | None = None
+
+
+def dictation_model_id() -> str | None:
+    """The selected sherpa dictation model id, or None when dictation is off /
+    no sherpa model is chosen. Env var wins (power-user pin), then prefs."""
+    explicit = os.environ.get("OMNIVOICE_SHERPA_ASR_MODEL")
+    if explicit:
+        return explicit
+    try:
+        from core import prefs
+        if not prefs.get("dictation.enabled", True):
+            return None
+        mid = prefs.get("dictation.model_id")
+    except Exception:
+        return None
+    from services.sherpa_dictation import is_sherpa_model
+    return mid if is_sherpa_model(mid) else None
 
 
 def get_capture_asr_backend() -> ASRBackend:
     """Pick the fastest ASR engine for capture / dictation.
 
-    Priority order (speed-first — word alignment is unnecessary for
-    dictation, so we skip WhisperX's forced-alignment overhead):
+    Selection order:
 
-      1. mlx-whisper Turbo  — Apple Silicon, ~5× faster than large-v3
-      2. mlx-whisper large  — still native Metal, faster than CPU int8
-      3. faster-whisper     — cross-platform CTranslate2 fallback
-      4. pytorch-whisper    — last resort
+      0. sherpa-onnx dictation — when ``dictation.model_id`` names one of the
+         seven sherpa models (live/CPU; the new live-dictation path).
+      1. mlx-whisper Turbo     — Apple Silicon, ~5× faster than large-v3
+      2. mlx-whisper large     — still native Metal, faster than CPU int8
+      3. faster-whisper        — cross-platform CTranslate2 fallback
+      4. pytorch-whisper       — last resort
 
     The caller should also pass ``word_timestamps=False`` to the returned
     backend to skip per-word timing and shave another ~30% latency.
 
-    Returns a cached singleton so the model stays warm between calls.
+    Returns a cached singleton so the model stays warm between calls; the
+    singleton is rebuilt if the selected sherpa model changes.
     """
-    global _capture_backend
-    if _capture_backend is not None:
+    global _capture_backend, _capture_backend_key
+
+    # 0. Honor an explicit sherpa dictation model selection.
+    sherpa_id = dictation_model_id()
+    if sherpa_id:
+        ok, _ = SherpaDictationBackend.is_available()
+        if ok:
+            if not (isinstance(_capture_backend, SherpaDictationBackend)
+                    and _capture_backend_key == sherpa_id):
+                try:
+                    _capture_backend = SherpaDictationBackend(model_id=sherpa_id)
+                    _capture_backend_key = sherpa_id
+                except Exception as e:  # noqa: BLE001 — fall through to Whisper
+                    logger.warning(
+                        "sherpa dictation model %r unavailable (%s) — falling "
+                        "back to Whisper capture engine", sherpa_id, e,
+                    )
+                    _capture_backend = None
+                    _capture_backend_key = None
+            if _capture_backend is not None:
+                return _capture_backend
+        else:
+            logger.info(
+                "dictation.model_id=%r selected but sherpa-onnx not installed — "
+                "falling back to Whisper capture engine", sherpa_id,
+            )
+
+    if _capture_backend is not None and _capture_backend_key is None:
         return _capture_backend
 
     # Prefer MLX Turbo on Apple Silicon
     ok, _ = MLXWhisperBackend.is_available()
     if ok:
         _capture_backend = MLXWhisperBackend(model_name=_MLX_MODEL_TURBO)
+        _capture_backend_key = None
         return _capture_backend
 
     # Fall back to faster-whisper (CPU int8 on non-Apple)
     ok, _ = FasterWhisperBackend.is_available()
     if ok:
         _capture_backend = FasterWhisperBackend()
+        _capture_backend_key = None
         return _capture_backend
 
     # Last resort
     _capture_backend = PyTorchWhisperBackend()
+    _capture_backend_key = None
     return _capture_backend

--- a/backend/services/sherpa_dictation.py
+++ b/backend/services/sherpa_dictation.py
@@ -1,0 +1,316 @@
+"""
+sherpa-onnx live-dictation ASR backend.
+
+Adds the k2-fsa/sherpa-onnx ONNX runtime as a *dictation* engine alongside the
+existing Whisper/NeMo family — without touching any of them. The whole point of
+this engine is **live, faster-than-real-time dictation on CPU**:
+
+  • STREAMING models (OnlineRecognizer) emit partial text frame-by-frame as the
+    user speaks, finalising on sherpa's built-in endpoint (silence) detection.
+  • OFFLINE models (OfflineRecognizer) re-transcribe a growing buffer on a short
+    cadence so the user still sees live partials, finalising on EOF/silence.
+
+CPU provider only (strict cross-platform-default parity rule): identical
+behaviour on macOS arm64+x86_64, Windows x64, Linux. No CUDA dependency.
+
+Model weights are the small int8 ONNX checkpoints published under
+``csukuangfj/`` on HuggingFace; they download on first use through the same HF
+cache the rest of the app uses (``snapshot_download``). Exact asset filenames
+were verified against the live HF repo trees (see ``_MODELS`` below) — the
+streaming zipformer repos use the plain ``encoder-epoch-99-avg-1.int8.onnx``
+naming, NOT a ``-chunk-16-left-64`` variant.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+logger = logging.getLogger("omnivoice.asr.sherpa")
+
+# CPU only — strict cross-platform default-parity rule. Overridable for
+# power users on a verified GPU build, but the default never diverges.
+_PROVIDER = os.environ.get("OMNIVOICE_SHERPA_ASR_PROVIDER", "cpu")
+_NUM_THREADS = int(os.environ.get("OMNIVOICE_SHERPA_ASR_THREADS", "2"))
+
+
+@dataclass(frozen=True)
+class SherpaModelSpec:
+    """One downloadable sherpa-onnx dictation model.
+
+    ``files`` maps a logical role (encoder/decoder/joiner/tokens) to the EXACT
+    asset filename in the HF repo. ``kind`` selects the recognizer factory:
+    ``offline-transducer`` | ``offline-whisper`` | ``online-transducer`` |
+    ``online-paraformer``. ``tag`` is the frontend-facing "offline"/"streaming".
+    """
+    id: str
+    repo_id: str
+    label: str
+    tag: str            # "offline" | "streaming"
+    kind: str           # recognizer factory selector
+    size_gb: float
+    languages: str
+    files: dict[str, str]
+    recommended: bool = False
+    model_type: str = ""           # offline transducer only (nemo_transducer)
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def streaming(self) -> bool:
+        return self.tag == "streaming"
+
+
+# ── The 7 models (HF repo ids under csukuangfj/, filenames VERIFIED against the
+#    live HF /api/models/<repo>/tree/main on 2026-06-25; int8 variants pinned).
+_MODELS: dict[str, SherpaModelSpec] = {
+    "sherpa-parakeet-tdt-v3": SherpaModelSpec(
+        id="sherpa-parakeet-tdt-v3",
+        repo_id="csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8",
+        label="Parakeet TDT v3",
+        tag="offline",
+        kind="offline-transducer",
+        size_gb=0.18,
+        languages="25 European languages",
+        recommended=True,
+        model_type="nemo_transducer",
+        files={
+            "encoder": "encoder.int8.onnx",
+            "decoder": "decoder.int8.onnx",
+            "joiner": "joiner.int8.onnx",
+            "tokens": "tokens.txt",
+        },
+    ),
+    "sherpa-parakeet-tdt-v2": SherpaModelSpec(
+        id="sherpa-parakeet-tdt-v2",
+        repo_id="csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8",
+        label="Parakeet TDT v2",
+        tag="offline",
+        kind="offline-transducer",
+        size_gb=0.17,
+        languages="English",
+        model_type="nemo_transducer",
+        files={
+            "encoder": "encoder.int8.onnx",
+            "decoder": "decoder.int8.onnx",
+            "joiner": "joiner.int8.onnx",
+            "tokens": "tokens.txt",
+        },
+    ),
+    "sherpa-zipformer-bilingual-zh-en": SherpaModelSpec(
+        id="sherpa-zipformer-bilingual-zh-en",
+        repo_id="csukuangfj/sherpa-onnx-streaming-zipformer-bilingual-zh-en-2023-02-20",
+        label="Zipformer Bilingual",
+        tag="streaming",
+        kind="online-transducer",
+        size_gb=0.13,
+        languages="Chinese + English",
+        files={
+            "encoder": "encoder-epoch-99-avg-1.int8.onnx",
+            "decoder": "decoder-epoch-99-avg-1.int8.onnx",
+            "joiner": "joiner-epoch-99-avg-1.int8.onnx",
+            "tokens": "tokens.txt",
+        },
+    ),
+    "sherpa-paraformer-bilingual-zh-en": SherpaModelSpec(
+        id="sherpa-paraformer-bilingual-zh-en",
+        repo_id="csukuangfj/sherpa-onnx-streaming-paraformer-bilingual-zh-en",
+        label="Paraformer Bilingual",
+        tag="streaming",
+        kind="online-paraformer",
+        size_gb=0.115,
+        languages="Chinese + English",
+        files={
+            "encoder": "encoder.int8.onnx",
+            "decoder": "decoder.int8.onnx",
+            "tokens": "tokens.txt",
+        },
+    ),
+    "sherpa-zipformer-en-20m": SherpaModelSpec(
+        id="sherpa-zipformer-en-20m",
+        repo_id="csukuangfj/sherpa-onnx-streaming-zipformer-en-20M-2023-02-17",
+        label="Zipformer Streaming EN",
+        tag="streaming",
+        kind="online-transducer",
+        size_gb=0.128,
+        languages="English",
+        files={
+            "encoder": "encoder-epoch-99-avg-1.int8.onnx",
+            "decoder": "decoder-epoch-99-avg-1.int8.onnx",
+            "joiner": "joiner-epoch-99-avg-1.int8.onnx",
+            "tokens": "tokens.txt",
+        },
+    ),
+    "sherpa-zipformer-zh-14m": SherpaModelSpec(
+        id="sherpa-zipformer-zh-14m",
+        repo_id="csukuangfj/sherpa-onnx-streaming-zipformer-zh-14M-2023-02-23",
+        label="Zipformer Streaming ZH",
+        tag="streaming",
+        kind="online-transducer",
+        size_gb=0.074,
+        languages="Chinese",
+        files={
+            "encoder": "encoder-epoch-99-avg-1.int8.onnx",
+            "decoder": "decoder-epoch-99-avg-1.int8.onnx",
+            "joiner": "joiner-epoch-99-avg-1.int8.onnx",
+            "tokens": "tokens.txt",
+        },
+    ),
+    "sherpa-whisper-tiny": SherpaModelSpec(
+        id="sherpa-whisper-tiny",
+        repo_id="csukuangfj/sherpa-onnx-whisper-tiny",
+        label="Whisper Tiny",
+        tag="offline",
+        kind="offline-whisper",
+        size_gb=0.116,
+        languages="90+ languages (auto-detect)",
+        files={
+            "encoder": "tiny-encoder.int8.onnx",
+            "decoder": "tiny-decoder.int8.onnx",
+            "tokens": "tiny-tokens.txt",
+        },
+    ),
+}
+
+DEFAULT_MODEL_ID = "sherpa-parakeet-tdt-v3"
+
+# repo_id → model id, so the model-store list (keyed by repo_id) can be
+# enriched with the dictation metadata, and so capture can map either key.
+_REPO_TO_ID: dict[str, str] = {m.repo_id: mid for mid, m in _MODELS.items()}
+
+
+def list_specs() -> list[SherpaModelSpec]:
+    return list(_MODELS.values())
+
+
+def get_spec(model_id: str) -> SherpaModelSpec | None:
+    """Look up a spec by its dictation id OR its HF repo_id."""
+    if model_id in _MODELS:
+        return _MODELS[model_id]
+    if model_id in _REPO_TO_ID:
+        return _MODELS[_REPO_TO_ID[model_id]]
+    return None
+
+
+def is_sherpa_model(model_id: str | None) -> bool:
+    return bool(model_id) and get_spec(model_id) is not None
+
+
+def sherpa_available() -> tuple[bool, str]:
+    try:
+        import sherpa_onnx  # noqa: F401
+        return True, "ready"
+    except ImportError as e:
+        return False, f"sherpa-onnx not installed: {e}. Install with: uv add sherpa-onnx"
+
+
+def _resolve_model_dir(spec: SherpaModelSpec, *, download: bool = True) -> str:
+    """Return the local directory containing this model's ONNX assets.
+
+    Tries the HF cache offline first (``local_files_only=True``); on a miss,
+    downloads on first use (like every other engine) unless ``download=False``.
+    Restricts the fetch to the exact int8 assets we pin via ``allow_patterns``
+    so we never pull the bundled fp32 weights or test wavs.
+    """
+    from huggingface_hub import snapshot_download
+
+    wanted = list(spec.files.values())
+    try:
+        return snapshot_download(
+            repo_id=spec.repo_id,
+            local_files_only=True,
+            allow_patterns=wanted,
+        )
+    except Exception:
+        if not download:
+            raise
+    logger.info("sherpa dictation: downloading %s on first use", spec.repo_id)
+    return snapshot_download(repo_id=spec.repo_id, allow_patterns=wanted)
+
+
+def is_installed(spec: SherpaModelSpec) -> bool:
+    """True if every pinned asset is already present in the HF cache."""
+    try:
+        d = _resolve_model_dir(spec, download=False)
+    except Exception:
+        return False
+    return all(os.path.isfile(os.path.join(d, f)) for f in spec.files.values())
+
+
+# ── Recognizers ──────────────────────────────────────────────────────────────
+
+
+def build_offline_recognizer(spec: SherpaModelSpec, *, download: bool = True):
+    """Construct an ``OfflineRecognizer`` for an offline transducer/whisper model."""
+    import sherpa_onnx
+
+    d = _resolve_model_dir(spec, download=download)
+
+    def p(role: str) -> str:
+        return os.path.join(d, spec.files[role])
+
+    if spec.kind == "offline-transducer":
+        return sherpa_onnx.OfflineRecognizer.from_transducer(
+            encoder=p("encoder"),
+            decoder=p("decoder"),
+            joiner=p("joiner"),
+            tokens=p("tokens"),
+            num_threads=_NUM_THREADS,
+            provider=_PROVIDER,
+            decoding_method="greedy_search",
+            model_type=spec.model_type or "nemo_transducer",
+        )
+    if spec.kind == "offline-whisper":
+        return sherpa_onnx.OfflineRecognizer.from_whisper(
+            encoder=p("encoder"),
+            decoder=p("decoder"),
+            tokens=p("tokens"),
+            num_threads=_NUM_THREADS,
+            provider=_PROVIDER,
+            language="",          # auto-detect
+            task="transcribe",
+        )
+    raise ValueError(f"{spec.id} is not an offline model (kind={spec.kind})")
+
+
+def build_online_recognizer(spec: SherpaModelSpec, *, download: bool = True):
+    """Construct an ``OnlineRecognizer`` (true streaming) with endpoint detection.
+
+    Endpoint (silence) detection drives the live "final" boundary: sherpa
+    commits a sentence after trailing silence so we can flush a ``final`` and
+    reset the stream for the next utterance — all within one WS session.
+    """
+    import sherpa_onnx
+
+    d = _resolve_model_dir(spec, download=download)
+
+    def p(role: str) -> str:
+        return os.path.join(d, spec.files[role])
+
+    if spec.kind == "online-transducer":
+        return sherpa_onnx.OnlineRecognizer.from_transducer(
+            tokens=p("tokens"),
+            encoder=p("encoder"),
+            decoder=p("decoder"),
+            joiner=p("joiner"),
+            num_threads=_NUM_THREADS,
+            provider=_PROVIDER,
+            decoding_method="greedy_search",
+            enable_endpoint_detection=True,
+            rule1_min_trailing_silence=2.4,
+            rule2_min_trailing_silence=1.2,
+            rule3_min_utterance_length=20,
+        )
+    if spec.kind == "online-paraformer":
+        return sherpa_onnx.OnlineRecognizer.from_paraformer(
+            tokens=p("tokens"),
+            encoder=p("encoder"),
+            decoder=p("decoder"),
+            num_threads=_NUM_THREADS,
+            provider=_PROVIDER,
+            decoding_method="greedy_search",
+            enable_endpoint_detection=True,
+            rule1_min_trailing_silence=2.4,
+            rule2_min_trailing_silence=1.2,
+            rule3_min_utterance_length=20,
+        )
+    raise ValueError(f"{spec.id} is not a streaming model (kind={spec.kind})")

--- a/docs/features.yaml
+++ b/docs/features.yaml
@@ -69,6 +69,8 @@ asr_engines:
     readme: Moonshine
   - id: funasr
     readme: FunASR
+  - id: sherpa-onnx-asr
+    readme: "**sherpa-onnx** (live dictation)"
 
 # Doc files that must exist (the install path users are sent to).
 docs:

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -299,6 +299,47 @@ pub fn simulate_paste(text: Option<String>) -> Result<(), String> {
     Ok(())
 }
 
+// ── Simulate live typing ──────────────────────────────────────────────────
+
+/// Type a string at the current cursor and/or emit N backspaces, for live
+/// word-by-word dictation (text appears in the focused field as you speak).
+///
+/// `backspaces` are sent FIRST (to retract characters a streaming recognizer
+/// revised), then `text` is typed. Either may be empty/zero, so a single call
+/// can correct-then-type in one round trip.
+///
+/// Cross-platform: `enigo`'s `.text()` synthesizes Unicode key events on macOS
+/// (CGEvent), Windows (`SendInput` w/ `KEYEVENTF_UNICODE`), and Linux (X11/
+/// libei). Backspace is a plain virtual-key `Click`, identical on all three.
+/// On macOS this reuses the SAME accessibility permission `simulate_paste`
+/// already requires (both go through `enigo` → CGEvent); no new grant needed.
+///
+/// Returns `Err` if the input layer is unavailable (e.g. accessibility not
+/// granted) so the JS caller can fall back to the clipboard+paste path for
+/// that segment without double-inserting.
+#[tauri::command]
+pub fn simulate_type(text: Option<String>, backspaces: Option<u32>) -> Result<(), String> {
+    let mut enigo = Enigo::new(&EnigoSettings::default())
+        .map_err(|e| format!("Failed to init keyboard sim: {e}"))?;
+
+    let n = backspaces.unwrap_or(0);
+    for _ in 0..n {
+        enigo
+            .key(Key::Backspace, Direction::Click)
+            .map_err(|e| format!("backspace failed: {e}"))?;
+    }
+
+    if let Some(t) = text {
+        if !t.is_empty() {
+            enigo
+                .text(&t)
+                .map_err(|e| format!("type failed: {e}"))?;
+        }
+    }
+
+    Ok(())
+}
+
 // ── Tray icon swap ────────────────────────────────────────────────────────
 
 #[tauri::command]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -253,6 +253,7 @@ pub fn run() {
             commands::read_log_tail,
             commands::hf_cache_scan,
             commands::simulate_paste,
+            commands::simulate_type,
             commands::set_tray_recording,
             commands::quit_app,
             commands::save_text_file,

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -21,6 +21,98 @@ async function setTrayRecording(recording) {
 
 const LS_CAPTURE_MODE = 'omni_capture_mode';
 
+// A dictation model id is a sherpa-onnx live model when it carries the
+// `sherpa-` prefix the backend assigns (see services/sherpa_dictation.py). Only
+// then do we open the low-latency raw-PCM streaming path; anything else (or no
+// selection) falls through to the legacy MediaRecorder/WebM path unchanged.
+export function isSherpaModel(id) {
+  return typeof id === 'string' && id.startsWith('sherpa-');
+}
+
+/**
+ * Classify a sherpa `final` message against the utterances committed so far.
+ * Pure + exported for unit testing the live-streaming state machine.
+ *   • 'summary'    — the authoritative EOF summary (text === the committed
+ *                    join): finalise, don't re-paste.
+ *   • 'utterance'  — a new per-utterance commit: paste it live + append.
+ *   • 'terminator' — an empty no-speech EOF final with nothing committed:
+ *                    finalise (resolve the pill).
+ *   • 'ignore'     — empty final but utterances exist (covered by the summary).
+ */
+export function classifySherpaFinal(segText, committed) {
+  const text = (segText || '').trim();
+  const joined = (committed || []).join(' ').trim();
+  if (text && text === joined && joined !== '') return 'summary';
+  if (!text) return committed && committed.length ? 'ignore' : 'terminator';
+  return 'utterance';
+}
+
+/**
+ * Compute the keystroke delta to turn `prevTyped` (what we've already typed into
+ * the focused field for the in-flight utterance) into `nextText` (the recognizer's
+ * latest revision of that same utterance). Pure + exported for unit testing.
+ *
+ * Streaming recognizers don't only append — they REVISE earlier words ("recognise"
+ * → "recognize", "to" → "two"). So we find the longest common prefix, retract
+ * everything after it with backspaces, then type the corrected suffix. The common
+ * case (pure append) yields `backspaces: 0` and just the new tail.
+ *
+ *   computeTypeDelta('hello wor', 'hello world') → { backspaces: 0, text: 'ld' }
+ *   computeTypeDelta('hello to', 'hello two')    → { backspaces: 1, text: 'wo' }
+ *   computeTypeDelta('hello', 'hello')           → { backspaces: 0, text: '' }  (noop)
+ *
+ * Returns `{ backspaces, text }`; `noop` is true when both are empty.
+ */
+export function computeTypeDelta(prevTyped, nextText) {
+  const prev = prevTyped || '';
+  const next = nextText || '';
+  // Longest common prefix (by UTF-16 code unit — enigo types code points but the
+  // backspace count we send is per-character; spread to count code points so an
+  // astral char like an emoji retracts/types as one unit on every platform).
+  const prevChars = Array.from(prev);
+  const nextChars = Array.from(next);
+  let i = 0;
+  const max = Math.min(prevChars.length, nextChars.length);
+  while (i < max && prevChars[i] === nextChars[i]) i++;
+  const backspaces = prevChars.length - i;
+  const text = nextChars.slice(i).join('');
+  return { backspaces, text, noop: backspaces === 0 && text === '' };
+}
+
+// Best-effort live paste of a committed utterance into whatever app has focus.
+// Reuses the same native clipboard+⌘V/Ctrl+V path as the session final, so each
+// silence-endpoint utterance lands in the target field as the user pauses —
+// that's what makes streaming dictation feel live (text appears as you speak,
+// committing on pauses) rather than only at the very end.
+async function pasteSegment(text) {
+  if (!text) return;
+  try {
+    await copyText(text);
+    try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      await invoke('simulate_paste', { text });
+    } catch { /* not in Tauri — WebView clipboard copy above already ran */ }
+  } catch { /* clipboard unavailable */ }
+}
+
+// Live, word-by-word typing of the in-flight utterance into whatever app has
+// focus — the native-dictation experience (words appear AS you speak, not only
+// on pauses). Given the delta vs what we last typed, it backspaces any revised
+// tail then types the corrected suffix via the `simulate_type` Tauri command
+// (one round trip). Returns true on success, false if the input layer was
+// unavailable (not in Tauri, or accessibility not granted) so the caller can
+// fall back to the paste path for that segment without double-inserting.
+async function typeDelta({ backspaces, text }) {
+  if (!backspaces && !text) return true;
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('simulate_type', { text, backspaces });
+    return true;
+  } catch {
+    return false; // not in Tauri, or simulate_type errored (e.g. no a11y grant)
+  }
+}
+
 function formatElapsed(ms) {
   const secs = Math.floor(ms / 1000);
   const mins = Math.floor(secs / 60);
@@ -48,6 +140,42 @@ export default function CaptureWidget({ onDismiss }) {
   const [lastTime, setLastTime] = useState(0);
   const [partialText, setPartialText] = useState('');
 
+  // Live-dictation prefs (mirrored from the backend dictation.* namespace).
+  // `mode` switches the hotkey start/stop semantics; `modelId` selects the
+  // sherpa-onnx live engine; `enabled` gates the hotkey entirely.
+  const dictationEnabled = useAppStore((s) => s.dictationEnabled);
+  const dictationMode = useAppStore((s) => s.dictationMode);
+  const loadDictationPrefs = useAppStore((s) => s.loadDictationPrefs);
+  // Mode/enabled are also read through refs inside event listeners so the
+  // long-lived tray/keyboard handlers always see the current value without
+  // re-subscribing on every pref change.
+  const modeRef = useRef(dictationMode);
+  const enabledRef = useRef(dictationEnabled);
+  useEffect(() => { modeRef.current = dictationMode; }, [dictationMode]);
+  useEffect(() => { enabledRef.current = dictationEnabled; }, [dictationEnabled]);
+
+  // Sherpa live-streaming session refs. `sherpaModeRef` flips on at start when a
+  // sherpa model is selected; `committedRef` accumulates per-utterance finals so
+  // the pill can show the running transcript and the EOF summary can reconcile.
+  const sherpaModeRef = useRef(false);
+  const committedRef = useRef([]);
+  // Live-typing state. `typedRef` is the exact text we have typed into the
+  // focused field for the CURRENT in-flight utterance (committed utterances are
+  // left alone — we never backspace across an utterance boundary). It resets to
+  // '' each time an utterance is committed. `liveTypingRef` latches off if a
+  // simulate_type call fails so the rest of the session uses the paste fallback
+  // instead of typing-then-also-pasting (which would double-insert).
+  const typedRef = useRef('');
+  const liveTypingRef = useRef(true);
+  // Set after an utterance commits: the next utterance's first typed delta is
+  // prefixed with a single separating space (so we don't trail a space after the
+  // final utterance, and words across utterances don't run together).
+  const pendingSepRef = useRef(false);
+  // Serialise simulate_type calls: partials can arrive faster than the OS input
+  // queue drains; chaining on this promise keeps backspaces/types strictly
+  // ordered so a late delta can't interleave and corrupt the field.
+  const typeChainRef = useRef(Promise.resolve());
+
   const mediaRecorderRef = useRef(null);
   const chunksRef = useRef([]);
   const streamRef = useRef(null);
@@ -73,19 +201,39 @@ export default function CaptureWidget({ onDismiss }) {
     aecModeRef.current = false;
   }, []);
 
-  // ── Hold-to-talk: listen for tray-dictate (start) and tray-dictate-stop (release) ──
+  // Hydrate dictation prefs (enabled / mode / model) from the backend once. The
+  // widget runs in its own Tauri webview (a separate JS context from the main
+  // window), so it loads the prefs itself rather than relying on the Settings
+  // window having loaded them.
+  useEffect(() => { loadDictationPrefs(); }, [loadDictationPrefs]);
+
+  // ── Tray hotkey: tray-dictate (start) + tray-dictate-stop (release) ──
+  // Toggle mode: tray-dictate flips start↔stop, tray-dictate-stop is ignored
+  //   (Tauri only emits tray-dictate-stop on key *release* in hold registration;
+  //   in toggle registration the backend emits tray-dictate on each press).
+  // Hold mode: tray-dictate starts, tray-dictate-stop stops.
+  // Both branches are gated on `enabled` so a disabled toggle makes the hotkey
+  // inert. Behaviour is identical on macOS / Windows / Linux.
   useEffect(() => {
     let unlistenStart, unlistenStop;
     (async () => {
       try {
         const { listen } = await import('@tauri-apps/api/event');
         unlistenStart = await listen('tray-dictate', () => {
-          if (state === 'idle' || state === 'done' || state === 'error') {
+          if (!enabledRef.current) return;
+          const idle = state === 'idle' || state === 'done' || state === 'error';
+          if (modeRef.current === 'toggle') {
+            // Press once to start, again to stop.
+            if (idle) startRecording();
+            else if (state === 'recording') stopRecording();
+          } else if (idle) {
+            // Hold mode: keydown → start.
             startRecording();
           }
         });
         unlistenStop = await listen('tray-dictate-stop', () => {
-          if (state === 'recording') {
+          // Only hold mode acts on release; toggle ignores it.
+          if (modeRef.current === 'hold' && state === 'recording') {
             stopRecording();
           }
         });
@@ -97,20 +245,40 @@ export default function CaptureWidget({ onDismiss }) {
     };
   }, [state]);
 
-  // Keyboard fallback: ⌘+Shift+Space toggles in web mode
+  // Keyboard fallback (web UI / Docker — no global tray hotkey). Mirrors the
+  // tray semantics so the DEFAULT dictation behaviour is identical with or
+  // without Tauri: Toggle = keydown flips start↔stop; Hold = keydown starts,
+  // keyup stops. The Ctrl/Cmd+Shift+Space combo matches the documented default
+  // shortcut; the desktop app's user-rebindable accelerator is a Tauri concern.
   useEffect(() => {
-    const handler = (e) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.code === 'Space') {
-        e.preventDefault();
-        if (state === 'idle' || state === 'done' || state === 'error') {
-          startRecording();
-        } else if (state === 'recording') {
-          stopRecording();
-        }
+    const isCombo = (e) =>
+      (e.metaKey || e.ctrlKey) && e.shiftKey && e.code === 'Space';
+    const onKeyDown = (e) => {
+      if (!isCombo(e)) return;
+      e.preventDefault();
+      if (!enabledRef.current) return;
+      const idle = state === 'idle' || state === 'done' || state === 'error';
+      if (modeRef.current === 'toggle') {
+        if (idle) startRecording();
+        else if (state === 'recording') stopRecording();
+      } else if (idle) {
+        // Hold mode: holding the combo records; auto-repeat keydowns are
+        // ignored because we only start from an idle state.
+        startRecording();
       }
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    const onKeyUp = (e) => {
+      // Hold mode stops as soon as Space (or a modifier) is released.
+      if (modeRef.current !== 'hold') return;
+      if (e.code !== 'Space' && e.key !== 'Meta' && e.key !== 'Control' && e.key !== 'Shift') return;
+      if (state === 'recording') stopRecording();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
   }, [state]);
 
   // Timer while recording
@@ -177,6 +345,66 @@ export default function CaptureWidget({ onDismiss }) {
     }
   }, [onDismiss]);
 
+  // Finalise a sherpa LIVE-streaming session. The per-utterance finals were
+  // already pasted into the focused field as the user paused, so this does NOT
+  // re-paste — it shows the authoritative full transcript in the pill, records
+  // it in history, and auto-dismisses. The EOF-summary `final` (or an early
+  // socket close) drives this.
+  const finalizeSession = useCallback(async (data) => {
+    const fullText = data.refined_text || data.text || '';
+    setTranscript(fullText);
+    setLastEngine(data.engine || 'sherpa-onnx-asr');
+    setLastTime(data.transcription_time_s || 0);
+    setState('done');
+    // NB: history was already recorded per-utterance as each `final` was pasted
+    // live (see the message handler), so finalisation does NOT re-record — that
+    // would duplicate the session. It only resolves the pill + auto-dismisses.
+    setPartialText('');
+    committedRef.current = [];
+    const delay = fullText ? 1500 : 2500;
+    setTimeout(async () => {
+      setState('idle');
+      setTranscript('');
+      setDuration(0);
+      try {
+        const { getCurrentWindow } = await import('@tauri-apps/api/window');
+        await getCurrentWindow().hide();
+      } catch { /* not in Tauri */ }
+      if (onDismiss) onDismiss();
+    }, delay);
+  }, [onDismiss]);
+
+  // Type the recognizer's latest revision of the in-flight utterance into the
+  // focused field, reconciling against what we typed before via a prefix diff.
+  // Serialised on `typeChainRef` so concurrent partials can't interleave. If the
+  // delta typing fails (no Tauri / no a11y grant), latch live-typing off and let
+  // the per-utterance paste fallback carry the text instead — never both.
+  const liveType = useCallback((nextText) => {
+    if (!liveTypingRef.current) return typeChainRef.current;
+    const run = async () => {
+      if (!liveTypingRef.current) return;
+      // Prefix the first delta of a new (non-first) utterance with a separator,
+      // tracked inside typedRef so the diff stays self-consistent.
+      let target = nextText || '';
+      if (pendingSepRef.current && target !== '') {
+        target = ' ' + target;
+        pendingSepRef.current = false;
+      }
+      const delta = computeTypeDelta(typedRef.current, target);
+      if (delta.noop) return;
+      const ok = await typeDelta(delta);
+      if (ok) {
+        typedRef.current = target;
+      } else {
+        // Input layer unavailable — stop typing for the rest of the session so
+        // we don't half-type. The paste path (pasteSegment on finals) takes over.
+        liveTypingRef.current = false;
+      }
+    };
+    typeChainRef.current = typeChainRef.current.then(run, run);
+    return typeChainRef.current;
+  }, []);
+
   const startRecording = useCallback(async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
@@ -186,6 +414,11 @@ export default function CaptureWidget({ onDismiss }) {
       chunksRef.current = [];
       wsPendingRef.current = [];
       wsHadFinalRef.current = false;
+      committedRef.current = [];
+      typedRef.current = '';
+      liveTypingRef.current = true;
+      pendingSepRef.current = false;
+      typeChainRef.current = Promise.resolve();
       if (fallbackTimerRef.current) {
         clearTimeout(fallbackTimerRef.current);
         fallbackTimerRef.current = null;
@@ -195,17 +428,31 @@ export default function CaptureWidget({ onDismiss }) {
         ? 'audio/webm;codecs=opus'
         : 'audio/webm';
 
-      // Read the opt-in AEC pref at start time (avoids a stale closure).
+      // Read prefs at start time (avoids stale closures). AEC is opt-in; the
+      // sherpa live engine is selected when the persisted dictation model is a
+      // sherpa-onnx model — that path streams raw int16 PCM and emits live
+      // partials + a `final` per spoken utterance (committed on silence).
       const aecOn = useAppStore.getState().aecEnabled === true;
+      const modelId = useAppStore.getState().dictationModelId;
+      const sherpaOn = isSherpaModel(modelId);
       aecModeRef.current = aecOn;
+      sherpaModeRef.current = sherpaOn;
+      // Raw-PCM transport is used whenever AEC or the sherpa live engine is on.
+      const pcmMode = aecOn || sherpaOn;
 
-      // Open WebSocket BEFORE starting recorder
+      // Open WebSocket BEFORE starting capture.
       try {
         // Scheme + host + remote api key all derive from the API base
         // (Wave 2.3) — window.location lies inside the Tauri webview.
-        // AEC mode adds ?aec=1 so the server runs the NLMS canceller and
-        // expects tagged raw-PCM frames.
-        const wsPath = aecOn ? '/ws/transcribe?aec=1&sr=16000' : '/ws/transcribe';
+        //   • sherpa → ?model=<id>&sr=16000  (raw int16 PCM, live partials)
+        //   • AEC    → ?aec=1&sr=16000       (tagged raw PCM, NLMS canceller)
+        //   • both   → ?model=<id>&aec=1&sr=16000
+        //   • neither → /ws/transcribe       (legacy MediaRecorder/WebM)
+        const params = [];
+        if (sherpaOn) params.push(`model=${encodeURIComponent(modelId)}`);
+        if (aecOn) params.push('aec=1');
+        if (pcmMode) params.push('sr=16000');
+        const wsPath = params.length ? `/ws/transcribe?${params.join('&')}` : '/ws/transcribe';
         const ws = new WebSocket(buildWsUrl(wsPath));
         ws.binaryType = 'arraybuffer';
         ws.onopen = () => {
@@ -218,15 +465,79 @@ export default function CaptureWidget({ onDismiss }) {
           try {
             const msg = JSON.parse(evt.data);
             if (msg.type === 'partial') {
-              setPartialText(msg.text || '');
+              // Live interim text — show the running transcript so far plus the
+              // in-flight partial, so the pill reads as continuous speech.
+              const committed = committedRef.current.join(' ');
+              const live = [committed, msg.text || ''].filter(Boolean).join(' ');
+              setPartialText(live);
+              // …and type the revised in-flight utterance into the focused field
+              // word-by-word (the native-dictation experience). The diff handles
+              // recognizer self-corrections via backspaces; committed utterances
+              // are untouched. Only sherpa live partials drive typing — the
+              // legacy WebM path has no partials.
+              if (sherpaModeRef.current) liveType(msg.text || '');
             } else if (msg.type === 'final') {
-              wsHadFinalRef.current = true;
-              if (fallbackTimerRef.current) {
-                clearTimeout(fallbackTimerRef.current);
-                fallbackTimerRef.current = null;
+              if (sherpaModeRef.current) {
+                // Two sherpa `final` shapes:
+                //   • STREAMING models emit a `final` per spoken utterance (on
+                //     each silence endpoint) THEN a session-summary `final` on
+                //     EOF whose text is the join of every utterance.
+                //   • OFFLINE models (incl. the default Parakeet v3) emit live
+                //     partials then exactly ONE `final` (the whole transcript)
+                //     on EOF.
+                // Rule: a `final` whose text equals what we've already committed
+                // is the authoritative EOF SUMMARY → finalise without re-pasting
+                // (its pieces already landed live). Any other `final` is a NEW
+                // utterance → paste it live and append. The single offline final
+                // is "new" (nothing committed yet) so it pastes once; the socket
+                // close then finalises from the committed text.
+                const segText = msg.refined_text || msg.text || '';
+                const cls = classifySherpaFinal(segText, committedRef.current);
+                if (cls === 'summary' || cls === 'terminator') {
+                  // Authoritative EOF (summary text already pasted live, or an
+                  // empty no-speech terminator) → finalise so the pill resolves.
+                  wsHadFinalRef.current = true;
+                  if (fallbackTimerRef.current) {
+                    clearTimeout(fallbackTimerRef.current);
+                    fallbackTimerRef.current = null;
+                  }
+                  finalizeSession(msg);
+                  try { ws.close(); } catch {}
+                } else if (cls === 'utterance') {
+                  // A per-utterance commit. Reconcile the focused field to the
+                  // recognizer's AUTHORITATIVE final for this utterance (it can
+                  // differ from the last partial — e.g. final punctuation / a
+                  // late self-correction), then FREEZE it: reset typedRef so the
+                  // next utterance's partials diff from empty. We never backspace
+                  // across this boundary. If live typing is unavailable, fall
+                  // back to pasting the segment — never do both (no double-insert).
+                  committedRef.current.push(segText);
+                  setPartialText(committedRef.current.join(' '));
+                  if (msg.text) addTranscription(msg);
+                  if (liveTypingRef.current) {
+                    liveType(segText);
+                    typeChainRef.current = typeChainRef.current.then(() => {
+                      typedRef.current = '';
+                      // Seed the next utterance's typed-state with a separating
+                      // space (matching the ' '.join used by the pill/history) so
+                      // its first delta types " word" — words never run together,
+                      // and there is no trailing space after the LAST utterance.
+                      pendingSepRef.current = true;
+                    });
+                  } else {
+                    pasteSegment(segText);
+                  }
+                }
+              } else {
+                // Legacy single-final path (Whisper/WebM) — unchanged.
+                wsHadFinalRef.current = true;
+                if (fallbackTimerRef.current) {
+                  clearTimeout(fallbackTimerRef.current);
+                  fallbackTimerRef.current = null;
+                }
+                applyResult(msg);
+                try { ws.close(); } catch {}
               }
-              applyResult(msg);
-              try { ws.close(); } catch {}
             } else if (msg.type === 'error') {
               if (fallbackTimerRef.current) {
                 clearTimeout(fallbackTimerRef.current);
@@ -241,6 +552,16 @@ export default function CaptureWidget({ onDismiss }) {
         ws.onerror = () => { wsRef.current = null; };
         ws.onclose = () => {
           wsRef.current = null;
+          if (sherpaModeRef.current) {
+            // Sherpa: nothing to POST (no WebM blob). If the socket dropped
+            // before the EOF summary but we committed utterances live, close out
+            // the session from what we have so the pill resolves.
+            if (!wsHadFinalRef.current && committedRef.current.length) {
+              wsHadFinalRef.current = true;
+              finalizeSession({ text: committedRef.current.join(' '), engine: 'sherpa-onnx-asr' });
+            }
+            return;
+          }
           if (
             !wsHadFinalRef.current
             && mediaRecorderRef.current
@@ -258,19 +579,19 @@ export default function CaptureWidget({ onDismiss }) {
         wsRef.current = null;
       }
 
-      if (aecOn) {
-        // AEC path: stream raw PCM. The mic is tagged 0x00; whatever the app
-        // is playing (published to the far-end bus by the audio player) is
-        // tagged 0x01 so the server can cancel the echo. No MediaRecorder and
-        // no WebM POST fallback here — the WS is the only path in this mode.
-        const [{ startMicCapture }, { subscribeFarEnd }, { frameFromFloat, AEC_NEAR, AEC_FAR }] =
+      if (pcmMode) {
+        // Raw-PCM path: stream int16 mono frames at 16 kHz via the AudioWorklet
+        // (no MediaRecorder, no WebM POST fallback — the WS is the only channel).
+        //   • sherpa live engine → UNTAGGED int16 frames (the non-AEC sherpa
+        //     handler reads plain PCM); the far-end bus is NOT subscribed.
+        //   • AEC on → frames are 1-byte tagged (0x00 mic / 0x01 far-end) and the
+        //     audio player's output is subscribed as the echo reference.
+        const [{ startMicCapture }, { frameFromFloat, floatToInt16, AEC_NEAR, AEC_FAR }] =
           await Promise.all([
             import('../utils/aec/micCapture'),
-            import('../utils/aec/farEndBus'),
             import('../utils/aec/pcm'),
           ]);
-        const sendTagged = (float32, kind) => {
-          const buf = frameFromFloat(float32, kind);
+        const sendBuf = (buf) => {
           const ws = wsRef.current;
           if (ws && ws.readyState === WebSocket.OPEN) {
             try { ws.send(buf); } catch { /* ignore */ }
@@ -278,10 +599,29 @@ export default function CaptureWidget({ onDismiss }) {
             wsPendingRef.current.push(buf);
           }
         };
-        aecStopRef.current = await startMicCapture(
-          stream, (f) => sendTagged(f, AEC_NEAR), { sampleRate: 16000 },
-        );
-        farEndUnsubRef.current = subscribeFarEnd((f) => sendTagged(f, AEC_FAR));
+        if (aecOn) {
+          // Tagged frames + far-end reference (echo cancellation). Works for the
+          // sherpa+AEC combo too — the backend demuxes the tag before the
+          // sherpa handler sees the cleaned near-end PCM.
+          const { subscribeFarEnd } = await import('../utils/aec/farEndBus');
+          const sendTagged = (float32, kind) => sendBuf(frameFromFloat(float32, kind));
+          aecStopRef.current = await startMicCapture(
+            stream, (f) => sendTagged(f, AEC_NEAR), { sampleRate: 16000 },
+          );
+          farEndUnsubRef.current = subscribeFarEnd((f) => sendTagged(f, AEC_FAR));
+        } else {
+          // Untagged int16 frames for the plain sherpa live path. Send the
+          // Int16Array's underlying buffer verbatim (little-endian on every
+          // target platform = numpy's native int16 read on the server).
+          aecStopRef.current = await startMicCapture(
+            stream,
+            (f) => {
+              const i16 = floatToInt16(f);
+              sendBuf(i16.buffer.slice(i16.byteOffset, i16.byteOffset + i16.byteLength));
+            },
+            { sampleRate: 16000 },
+          );
+        }
         mediaRecorderRef.current = null;
       } else {
         const recorder = new MediaRecorder(stream, { mimeType });
@@ -315,15 +655,16 @@ export default function CaptureWidget({ onDismiss }) {
       setTrayRecording(false);
       setState('error');
     }
-  }, [applyResult, t]);
+  }, [applyResult, finalizeSession, t]);
 
   const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
       mediaRecorderRef.current.stop();
     }
-    // AEC mode: stop the mic worklet + far-end subscription before EOF so no
-    // stray frames arrive after the end-of-stream signal.
-    if (aecModeRef.current) {
+    // Any raw-PCM mode (AEC and/or sherpa live): stop the mic worklet + far-end
+    // subscription before EOF so no stray frames arrive after the end-of-stream
+    // signal. teardownAec no-ops the far-end unsub when there isn't one.
+    if (aecModeRef.current || sherpaModeRef.current) {
       teardownAec();
     }
     if (streamRef.current) {
@@ -358,8 +699,9 @@ export default function CaptureWidget({ onDismiss }) {
 
   const sendForTranscription = useCallback(async () => {
     if (wsHadFinalRef.current) return;
-    // No WebM blob exists on the AEC path — the WS is the only result channel.
-    if (aecModeRef.current) return;
+    // No WebM blob exists on any raw-PCM path (AEC or sherpa live) — the WS is
+    // the only result channel there.
+    if (aecModeRef.current || sherpaModeRef.current) return;
 
     const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
     const formData = new FormData();
@@ -385,7 +727,7 @@ export default function CaptureWidget({ onDismiss }) {
   }, [captureMode, applyResult]);
 
   const dismiss = async () => {
-    if (aecModeRef.current) teardownAec();
+    if (aecModeRef.current || sherpaModeRef.current) teardownAec();
     setState('idle');
     setTranscript('');
     setDuration(0);

--- a/frontend/src/components/settings/VoicePanel.css
+++ b/frontend/src/components/settings/VoicePanel.css
@@ -1,0 +1,311 @@
+/* Settings → Capture → Voice panel. Matches the Settings-section visual
+   language (chrome tokens, pill radii) used elsewhere in Settings. */
+
+.voicepanel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 0 12px;
+}
+
+.voicepanel__head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.voicepanel__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--chrome-fg);
+}
+
+.voicepanel__subtitle {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--chrome-fg-muted);
+}
+
+.voicepanel__card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--chrome-border, rgba(255, 255, 255, 0.08));
+  background: var(--chrome-panel-bg, rgba(255, 255, 255, 0.02));
+  border-radius: 12px;
+  padding: 4px 14px;
+}
+
+.voicepanel__warn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0;
+  padding: 8px 10px;
+  font-size: 0.78rem;
+  color: var(--chrome-severity-warn, #fabd2f);
+  background: color-mix(in srgb, var(--chrome-severity-warn, #fabd2f) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--chrome-severity-warn, #fabd2f) 32%, transparent);
+  border-radius: 8px;
+}
+
+.voicepanel__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 0;
+}
+
+.voicepanel__row--model {
+  align-items: flex-start;
+}
+
+.voicepanel__row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.voicepanel__row-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--chrome-fg);
+}
+
+.voicepanel__row-sub {
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--chrome-fg-muted);
+}
+
+.voicepanel__divider {
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--chrome-border, rgba(255, 255, 255, 0.06));
+}
+
+/* ── Toggle switch ─────────────────────────────────────────────────────── */
+.voicepanel__switch {
+  position: relative;
+  flex: none;
+  width: 42px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--chrome-hover-bg, rgba(255, 255, 255, 0.12));
+  cursor: pointer;
+  transition: background 0.16s ease;
+}
+
+.voicepanel__switch.is-on {
+  background: var(--chrome-accent, #83a598);
+}
+
+.voicepanel__switch-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.16s ease;
+}
+
+.voicepanel__switch.is-on .voicepanel__switch-knob {
+  transform: translateX(18px);
+}
+
+.voicepanel__switch:focus-visible {
+  outline: 2px solid var(--chrome-accent, #83a598);
+  outline-offset: 2px;
+}
+
+/* ── Speech-model dropdown ─────────────────────────────────────────────── */
+.voicepanel__dropdown {
+  position: relative;
+  flex: none;
+  width: 260px;
+  max-width: 50%;
+}
+
+.voicepanel__dd-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 11px;
+  font-size: 0.84rem;
+  color: var(--chrome-fg);
+  background: var(--chrome-input-bg, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--chrome-border, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.voicepanel__dd-trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.voicepanel__dd-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voicepanel__dd-chev {
+  flex: none;
+  transition: transform 0.15s ease;
+  color: var(--chrome-fg-muted);
+}
+
+.voicepanel__dd-chev.is-open {
+  transform: rotate(180deg);
+}
+
+.voicepanel__dd-list {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  width: 360px;
+  max-width: 80vw;
+  max-height: 380px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 5px;
+  list-style: none;
+  background: var(--chrome-menu-bg, #1d1d22);
+  border: 1px solid var(--chrome-border, rgba(255, 255, 255, 0.1));
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.voicepanel__dd-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  border-radius: 8px;
+}
+
+.voicepanel__dd-item.is-selected {
+  background: var(--chrome-hover-bg, rgba(255, 255, 255, 0.06));
+}
+
+.voicepanel__dd-item:hover {
+  background: var(--chrome-hover-bg, rgba(255, 255, 255, 0.08));
+}
+
+.voicepanel__dd-itembtn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 9px 4px 9px 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--chrome-fg);
+}
+
+.voicepanel__dd-check {
+  flex: none;
+  width: 16px;
+  margin-top: 1px;
+  color: var(--chrome-accent, #83a598);
+}
+
+.voicepanel__dd-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.voicepanel__dd-itemtop {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.voicepanel__dd-itemname {
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.voicepanel__dd-size {
+  font-size: 0.74rem;
+  color: var(--chrome-fg-muted);
+  margin-left: auto;
+}
+
+.voicepanel__dd-itemdesc {
+  font-size: 0.76rem;
+  line-height: 1.4;
+  color: var(--chrome-fg-muted);
+}
+
+.voicepanel__dd-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 3px;
+}
+
+.voicepanel__dd-progress > :first-child {
+  flex: 1 1 auto;
+}
+
+.voicepanel__dd-progresstext {
+  flex: none;
+  font-size: 0.72rem;
+  color: var(--chrome-fg-muted);
+}
+
+.voicepanel__dd-action {
+  display: flex;
+  align-items: center;
+  flex: none;
+  padding: 9px 6px 0 0;
+}
+
+.voicepanel__iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  color: var(--chrome-fg-muted);
+  cursor: pointer;
+}
+
+.voicepanel__iconbtn:hover {
+  background: var(--chrome-hover-bg, rgba(255, 255, 255, 0.1));
+  color: var(--chrome-fg);
+}
+
+.voicepanel__spin {
+  animation: voicepanel-spin 0.9s linear infinite;
+  color: var(--chrome-fg-muted);
+}
+
+@keyframes voicepanel-spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/components/settings/VoicePanel.jsx
+++ b/frontend/src/components/settings/VoicePanel.jsx
@@ -1,0 +1,405 @@
+/**
+ * Settings → Capture → Voice panel.
+ *
+ * The home of the live-dictation controls (the "Voice" card in the screenshot):
+ *
+ *   1. Enable Voice Dictation — master toggle. Subtitle shows the REAL
+ *      registered dictation shortcut (read from the `get_dictation_shortcut`
+ *      Tauri command, same source as HotkeyTab); changing the shortcut still
+ *      lives in HotkeyTab below.
+ *   2. Dictation Mode — Toggle / Hold segmented control. Toggle = press once to
+ *      start, again to stop. Hold = dictate while the key is held.
+ *   3. Speech Model — a dropdown of the seven sherpa-onnx dictation models. The
+ *      collapsed control shows the selected model's name + description; expanded,
+ *      each row shows offline/streaming + recommended badges, the size, a
+ *      one-line description, a checkmark on the selected one, and a trash icon to
+ *      delete an installed model. Not-installed models show a Download action and
+ *      inline download progress while installing.
+ *
+ * Prefs are the backend `dictation.*` namespace (GET/POST /dictation/prefs),
+ * mirrored into the zustand store; model install/delete/progress REUSE the
+ * model-store endpoints + SSE stream the ModelStoreTab already drives, so a
+ * model installed here shows installed there and vice-versa.
+ *
+ * Cross-platform: every control behaves identically on macOS / Windows / Linux.
+ * The shortcut read no-ops gracefully in the web UI (no Tauri) and falls back to
+ * the documented Ctrl/Cmd+Shift+Space default label.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Mic, Check, Download, Trash2, ChevronDown, Loader, AlertTriangle,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-hot-toast';
+import { useAppStore } from '../../store';
+import { apiJson } from '../../api/client';
+import { useInstallModel, useDeleteModel } from '../../api/hooks';
+import { setupDownloadStreamUrl } from '../../api/setup';
+import { isTauri as _isTauri } from '../../utils/media';
+import { Badge, Progress, Segmented } from '../../ui';
+import './VoicePanel.css';
+
+/** Native confirm dialog in Tauri, window.confirm in the web UI. Mirrors the
+ * `askConfirm` helper in Settings.jsx (kept local to avoid coupling). */
+async function askConfirm(message, title = 'Confirm') {
+  if (_isTauri) {
+    try {
+      const { ask } = await import('@tauri-apps/plugin-dialog');
+      return ask(message, { title, kind: 'warning' });
+    } catch { /* dialog plugin unavailable — fall through */ }
+  }
+  return Promise.resolve(typeof window !== 'undefined' ? window.confirm(message) : true);
+}
+
+/** Format a model's download size for display (e.g. "180 MB", "1.2 GB"). */
+function fmtSize(sizeGb) {
+  if (sizeGb == null) return '';
+  if (sizeGb < 1) return `${Math.round(sizeGb * 1000)} MB`;
+  return `${sizeGb.toFixed(sizeGb < 10 ? 1 : 0)} GB`;
+}
+
+/** The default shortcut label HotkeyTab resets to — used when not in Tauri or
+ * the read fails, so the subtitle never shows a bare placeholder. */
+const DEFAULT_SHORTCUT = 'CmdOrCtrl+Shift+Space';
+
+export default function VoicePanel() {
+  const { t } = useTranslation();
+
+  const enabled = useAppStore((s) => s.dictationEnabled);
+  const setEnabled = useAppStore((s) => s.setDictationEnabled);
+  const mode = useAppStore((s) => s.dictationMode);
+  const setMode = useAppStore((s) => s.setDictationMode);
+  const modelId = useAppStore((s) => s.dictationModelId);
+  const setModelId = useAppStore((s) => s.setDictationModelId);
+  const loadPrefs = useAppStore((s) => s.loadDictationPrefs);
+
+  const [models, setModels] = useState([]);
+  const [engineAvailable, setEngineAvailable] = useState(true);
+  const [engineReason, setEngineReason] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+  const [shortcut, setShortcut] = useState('');
+
+  // Per-repo download runtime, keyed by repo_id, driven by the shared SSE
+  // progress stream (same events ModelStoreTab consumes):
+  //   { [repo_id]: { phase, pct } }
+  const [rowState, setRowState] = useState({});
+  const esRef = useRef(null);
+  const dropdownRef = useRef(null);
+
+  const installMutation = useInstallModel();
+  const deleteMutation = useDeleteModel();
+
+  // Hydrate prefs from the backend on mount (write-through setters keep them in
+  // sync after that).
+  useEffect(() => { loadPrefs(); }, [loadPrefs]);
+
+  // Read the registered dictation shortcut the same way HotkeyTab does.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!_isTauri) { setShortcut(DEFAULT_SHORTCUT); return; }
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const v = await invoke('get_dictation_shortcut');
+        if (!cancelled) setShortcut(v || DEFAULT_SHORTCUT);
+      } catch {
+        if (!cancelled) setShortcut(DEFAULT_SHORTCUT);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const loadModels = React.useCallback(async () => {
+    try {
+      const data = await apiJson('/dictation/models');
+      setModels(Array.isArray(data?.models) ? data.models : []);
+      setEngineAvailable(data?.engine_available !== false);
+      setEngineReason(data?.engine_reason || null);
+    } catch {
+      setModels([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { loadModels(); }, [loadModels]);
+
+  // Subscribe to the model-store SSE so install progress shows inline here too.
+  // We only track the aggregate percent + lifecycle phase per repo — the full
+  // per-file accounting lives in ModelStoreTab; here a single bar is enough.
+  useEffect(() => {
+    const es = new EventSource(setupDownloadStreamUrl());
+    esRef.current = es;
+    es.onmessage = (evt) => {
+      try {
+        const ev = JSON.parse(evt.data);
+        if (!ev?.repo_id) return;
+        setRowState((prev) => {
+          const cur = prev[ev.repo_id] || {};
+          if (ev.phase === 'install_start') return { ...prev, [ev.repo_id]: { phase: 'active', pct: 0 } };
+          if (ev.phase === 'install_done') return { ...prev, [ev.repo_id]: { phase: 'install_done', pct: 100 } };
+          if (ev.phase === 'install_error') return { ...prev, [ev.repo_id]: { phase: 'install_error', error: ev.error } };
+          if (ev.phase === 'install_cancelled') return { ...prev, [ev.repo_id]: { phase: 'install_cancelled' } };
+          if (ev.phase === 'delete_done') return { ...prev, [ev.repo_id]: { phase: 'delete_done' } };
+          if (ev.phase === 'aggregate') {
+            const total = ev.total_bytes || 0;
+            const bytePct = total > 0 ? (ev.bytes_done / total) * 100 : 0;
+            const ft = ev.files_total || 0;
+            const filePct = ft > 0 ? ((ev.files_done || 0) / ft) * 100 : 0;
+            return { ...prev, [ev.repo_id]: { phase: 'active', pct: Math.max(bytePct, filePct) } };
+          }
+          // Plain per-file tqdm event: approximate with its pct if no aggregate yet.
+          if (ev.pct != null && cur.phase !== 'active') {
+            return { ...prev, [ev.repo_id]: { phase: 'active', pct: ev.pct } };
+          }
+          return prev;
+        });
+      } catch { /* keepalive */ }
+    };
+    return () => es.close();
+  }, []);
+
+  // When an install/delete terminates, refresh the model list so the installed
+  // flag flips, then clear the terminal row so it reverts to the list state.
+  useEffect(() => {
+    const term = Object.entries(rowState).find(([, s]) =>
+      ['install_done', 'delete_done', 'install_error', 'install_cancelled'].includes(s.phase));
+    if (!term) return;
+    const id = setTimeout(() => {
+      loadModels();
+      setRowState((prev) => { const n = { ...prev }; delete n[term[0]]; return n; });
+    }, 800);
+    return () => clearTimeout(id);
+  }, [rowState, loadModels]);
+
+  // Close the dropdown on outside-click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) setOpen(false);
+    };
+    const onKey = (e) => { if (e.key === 'Escape') setOpen(false); };
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const selected = useMemo(
+    () => models.find((m) => m.id === modelId) || models.find((m) => m.recommended) || models[0],
+    [models, modelId],
+  );
+
+  const onInstall = async (repoId) => {
+    setRowState((p) => ({ ...p, [repoId]: { phase: 'active', pct: 0 } }));
+    try {
+      await installMutation.mutateAsync(repoId);
+    } catch (e) {
+      toast.error(e?.message || String(e));
+      setRowState((p) => { const n = { ...p }; delete n[repoId]; return n; });
+    }
+  };
+
+  const onDelete = async (model) => {
+    const ok = await askConfirm(
+      t('voicePanel.delete_confirm', { label: model.label }),
+      t('voicePanel.delete_confirm_title'),
+    );
+    if (!ok) return;
+    setRowState((p) => ({ ...p, [model.repo_id]: { phase: 'deleting' } }));
+    try {
+      await deleteMutation.mutateAsync(model.repo_id);
+    } catch (e) {
+      toast.error(e?.message || String(e));
+      setRowState((p) => { const n = { ...p }; delete n[model.repo_id]; return n; });
+    }
+  };
+
+  // Picking a model: write the pref. If it isn't installed yet, also kick off
+  // the download — the user gets the model the moment it lands, and the live
+  // socket will pick it up via the persisted pref.
+  const onPick = (model) => {
+    setModelId(model.id);
+    setOpen(false);
+    if (!model.installed && !rowState[model.repo_id]) {
+      onInstall(model.repo_id);
+    }
+  };
+
+  // Human-readable, i18n-keyed description per model id (one line each). Falls
+  // back to the backend `languages` string when a key is missing.
+  const modelDesc = (m) =>
+    t(`voicePanel.model_desc.${m.id}`, { defaultValue: m.languages || '' });
+
+  const shortcutLabel = shortcut || DEFAULT_SHORTCUT;
+
+  return (
+    <section className="voicepanel" aria-labelledby="voicepanel-heading">
+      <header className="voicepanel__head">
+        <h2 id="voicepanel-heading" className="voicepanel__title">
+          <Mic size={16} color="#83a598" /> {t('voicePanel.title')}
+        </h2>
+        <p className="voicepanel__subtitle">{t('voicePanel.subtitle')}</p>
+      </header>
+
+      <div className="voicepanel__card">
+        {!engineAvailable && (
+          <div className="voicepanel__warn" role="alert">
+            <AlertTriangle size={13} />
+            <span>{engineReason || t('voicePanel.engine_unavailable')}</span>
+          </div>
+        )}
+
+        {/* 1 — Enable Voice Dictation */}
+        <div className="voicepanel__row">
+          <div className="voicepanel__row-text">
+            <span className="voicepanel__row-label">{t('voicePanel.enable_label')}</span>
+            <span className="voicepanel__row-sub">
+              {t('voicePanel.enable_sub', { shortcut: shortcutLabel })}
+            </span>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label={t('voicePanel.enable_label')}
+            className={`voicepanel__switch ${enabled ? 'is-on' : ''}`}
+            onClick={() => setEnabled(!enabled)}
+            data-testid="dictation-enabled"
+          >
+            <span className="voicepanel__switch-knob" />
+          </button>
+        </div>
+
+        <hr className="voicepanel__divider" />
+
+        {/* 2 — Dictation Mode */}
+        <div className="voicepanel__row">
+          <div className="voicepanel__row-text">
+            <span className="voicepanel__row-label">{t('voicePanel.mode_label')}</span>
+            <span className="voicepanel__row-sub">{t('voicePanel.mode_sub')}</span>
+          </div>
+          <Segmented
+            size="sm"
+            value={mode}
+            onChange={(v) => setMode(v)}
+            items={[
+              { value: 'toggle', label: t('voicePanel.mode_toggle') },
+              { value: 'hold', label: t('voicePanel.mode_hold') },
+            ]}
+          />
+        </div>
+
+        <hr className="voicepanel__divider" />
+
+        {/* 3 — Speech Model */}
+        <div className="voicepanel__row voicepanel__row--model">
+          <div className="voicepanel__row-text">
+            <span className="voicepanel__row-label">{t('voicePanel.model_label')}</span>
+            <span className="voicepanel__row-sub">
+              {selected ? modelDesc(selected) : t('voicePanel.model_sub')}
+            </span>
+          </div>
+
+          <div className="voicepanel__dropdown" ref={dropdownRef}>
+            <button
+              type="button"
+              className="voicepanel__dd-trigger"
+              aria-haspopup="listbox"
+              aria-expanded={open}
+              disabled={loading || models.length === 0}
+              onClick={() => setOpen((o) => !o)}
+              data-testid="dictation-model-trigger"
+            >
+              <span className="voicepanel__dd-name">
+                {selected ? selected.label : t('common.loading')}
+              </span>
+              <ChevronDown size={14} className={`voicepanel__dd-chev ${open ? 'is-open' : ''}`} />
+            </button>
+
+            {open && (
+              <ul className="voicepanel__dd-list" role="listbox" aria-label={t('voicePanel.model_label')}>
+                {models.map((m) => {
+                  const rs = rowState[m.repo_id];
+                  const installing = rs && rs.phase === 'active';
+                  const deleting = rs && rs.phase === 'deleting';
+                  const isSel = m.id === (selected?.id);
+                  return (
+                    <li key={m.id} className={`voicepanel__dd-item ${isSel ? 'is-selected' : ''}`} role="option" aria-selected={isSel}>
+                      <button
+                        type="button"
+                        className="voicepanel__dd-itembtn"
+                        onClick={() => onPick(m)}
+                        data-testid={`dictation-model-${m.id}`}
+                      >
+                        <span className="voicepanel__dd-check">
+                          {isSel && <Check size={14} />}
+                        </span>
+                        <span className="voicepanel__dd-body">
+                          <span className="voicepanel__dd-itemtop">
+                            <span className="voicepanel__dd-itemname">{m.label}</span>
+                            <Badge tone="neutral" size="xs">
+                              {m.tag === 'streaming' ? t('voicePanel.badge_streaming') : t('voicePanel.badge_offline')}
+                            </Badge>
+                            {m.recommended && (
+                              <Badge tone="success" size="xs">{t('voicePanel.badge_recommended')}</Badge>
+                            )}
+                            <span className="voicepanel__dd-size">{fmtSize(m.size_gb)}</span>
+                          </span>
+                          <span className="voicepanel__dd-itemdesc">{modelDesc(m)}</span>
+                          {installing && (
+                            <span className="voicepanel__dd-progress">
+                              <Progress value={rs.pct ?? null} tone="brand" size="xs" />
+                              <span className="voicepanel__dd-progresstext">
+                                {rs.pct != null && rs.pct > 0
+                                  ? t('voicePanel.downloading_pct', { pct: Math.round(rs.pct) })
+                                  : t('voicePanel.downloading')}
+                              </span>
+                            </span>
+                          )}
+                        </span>
+                      </button>
+
+                      {/* Right-edge affordance: download (not installed), spinner
+                          (installing/deleting), or delete (installed). */}
+                      <span className="voicepanel__dd-action">
+                        {installing || deleting ? (
+                          <Loader size={14} className="voicepanel__spin" />
+                        ) : m.installed ? (
+                          <button
+                            type="button"
+                            className="voicepanel__iconbtn"
+                            title={t('voicePanel.delete_model')}
+                            aria-label={t('voicePanel.delete_model')}
+                            onClick={(e) => { e.stopPropagation(); onDelete(m); }}
+                            data-testid={`dictation-delete-${m.id}`}
+                          >
+                            <Trash2 size={13} />
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className="voicepanel__iconbtn"
+                            title={t('voicePanel.download_model')}
+                            aria-label={t('voicePanel.download_model')}
+                            onClick={(e) => { e.stopPropagation(); onInstall(m.repo_id); }}
+                            data-testid={`dictation-install-${m.id}`}
+                          >
+                            <Download size={13} />
+                          </button>
+                        )}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -464,6 +464,37 @@
     "mic_error_generic": "Could not start the microphone: {{message}}",
     "transcription_failed": "Transcription failed: {{message}}"
   },
+  "voicePanel": {
+    "title": "Voice",
+    "subtitle": "Local speech-to-text dictation with on-device models.",
+    "enable_label": "Enable Voice Dictation",
+    "enable_sub": "Press {{shortcut}} to dictate text into any focused pane.",
+    "mode_label": "Dictation Mode",
+    "mode_sub": "Toggle: press once to start, again to stop. Hold: dictate while the key is held.",
+    "mode_toggle": "Toggle",
+    "mode_hold": "Hold",
+    "model_label": "Speech Model",
+    "model_sub": "Pick the on-device model used for dictation.",
+    "badge_offline": "offline",
+    "badge_streaming": "streaming",
+    "badge_recommended": "recommended",
+    "download_model": "Download model",
+    "delete_model": "Delete model",
+    "downloading": "Downloading…",
+    "downloading_pct": "Downloading {{pct}}%",
+    "delete_confirm": "Delete the \"{{label}}\" speech model? You can re-download it later.",
+    "delete_confirm_title": "Delete speech model",
+    "engine_unavailable": "The live-dictation engine isn't available on this install. Dictation falls back to the standard transcription path.",
+    "model_desc": {
+      "sherpa-parakeet-tdt-v3": "Recommended. Fast, accurate dictation across 25 European languages.",
+      "sherpa-parakeet-tdt-v2": "Fast, accurate English-only dictation.",
+      "sherpa-zipformer-bilingual-zh-en": "Streaming Chinese + English with live partials.",
+      "sherpa-paraformer-bilingual-zh-en": "Streaming Chinese + English, compact model.",
+      "sherpa-zipformer-en-20m": "Tiny streaming English model — lowest latency.",
+      "sherpa-zipformer-zh-14m": "Tiny streaming Chinese model — lowest latency.",
+      "sherpa-whisper-tiny": "Multilingual (90+ languages) with auto language detection."
+    }
+  },
   "profiles": {
     "need_name_audio": "Need a name and reference audio",
     "synthesizing_preview": "Synthesizing preview for {{name}}...",

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -36,6 +36,7 @@ import LLMEndpointPanel from '../components/settings/LLMEndpointPanel';
 import PerformancePanel from '../components/settings/PerformancePanel';
 import RefinementPanel from '../components/settings/RefinementPanel';
 import AecPanel from '../components/settings/AecPanel';
+import VoicePanel from '../components/settings/VoicePanel';
 import AppearancePanel from '../components/settings/AppearancePanel';
 import StoragePanel from '../components/settings/StoragePanel';
 import HFMirrorPanel from '../components/settings/HFMirrorPanel';
@@ -1434,6 +1435,7 @@ export default function Settings() {
 
       {activeTab === 'capture' && (
         <>
+          <VoicePanel />
           <DictationDemo />
           <HotkeyTab />
           <RefinementPanel />

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -7,9 +7,18 @@
  * the storage round-trip once instead of per-field.
  */
 import type { StateCreator } from 'zustand';
+import { apiJson, apiPost } from '../api/client';
 
 export type TranslateQuality = 'fast' | 'cinematic';
 export type ThemeId = 'gruvbox' | 'midnight' | 'nord' | 'solarized' | 'rose-pine' | 'catppuccin';
+
+/** Dictation start/stop semantics — mirror of the backend `dictation.mode`. */
+export type DictationMode = 'toggle' | 'hold';
+
+/** Default sherpa dictation model id — matches the backend
+ * `sherpa_dictation.DEFAULT_MODEL_ID`. Used only as the pre-hydration seed;
+ * the authoritative value comes from `GET /dictation/prefs`. */
+export const DEFAULT_DICTATION_MODEL_ID = 'sherpa-parakeet-tdt-v3';
 
 /**
  * Global UI font. Applied app-wide by overriding the `--font-sans` CSS custom
@@ -118,6 +127,34 @@ export interface PrefsSlice {
   setAecEnabled: (on: boolean) => void;
 
   /**
+   * Live-dictation prefs — MIRRORED from the backend `GET /dictation/prefs`
+   * (the backend `prefs.json` `dictation.*` namespace is the source of truth).
+   * On app init we hydrate these from the backend; every setter write-throughs
+   * to `POST /dictation/prefs` so the capture engine and the UI never diverge.
+   * They're intentionally NOT in `partialize` (store/index.ts) — the backend
+   * owns them, so persisting a stale localStorage copy would fight the server.
+   *
+   *   • dictationEnabled  — master on/off for the dictation hotkey.
+   *   • dictationMode     — 'toggle' (press to start, press to stop) | 'hold'
+   *                          (record while the key is held).
+   *   • dictationModelId  — the selected sherpa-onnx model id (e.g.
+   *                          'sherpa-parakeet-tdt-v3'); drives `?model=` on the
+   *                          live `/ws/transcribe` socket.
+   */
+  dictationEnabled: boolean;
+  dictationMode: DictationMode;
+  dictationModelId: string;
+  /** Local-only flag: true once the backend prefs have been hydrated, so the
+   * Voice panel can avoid flashing defaults before the first load. */
+  dictationLoaded: boolean;
+  /** Optimistic local set + write-through to POST /dictation/prefs. */
+  setDictationEnabled: (on: boolean) => void;
+  setDictationMode: (mode: DictationMode) => void;
+  setDictationModelId: (id: string) => void;
+  /** Hydrate from GET /dictation/prefs (called once on app init). */
+  loadDictationPrefs: () => Promise<void>;
+
+  /**
    * Auto-play the output preview as soon as a render finishes (Voice Clone /
    * Design / profile preview). Default ON — preserves the long-standing
    * behavior. Users batch-generating segments (#666) can turn it off so each
@@ -136,7 +173,20 @@ export interface PrefsSlice {
   setFont: (id: FontId) => void;
 }
 
-export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (set) => ({
+/** Map a `GET/POST /dictation/prefs` response → the store's dictation fields.
+ * Tolerant of partial/garbage payloads so a malformed response can never wedge
+ * the store. */
+function _dictationFromPrefs(p: any): Partial<PrefsSlice> {
+  const out: Partial<PrefsSlice> = {};
+  if (p && typeof p === 'object') {
+    if (typeof p.enabled === 'boolean') out.dictationEnabled = p.enabled;
+    if (p.mode === 'toggle' || p.mode === 'hold') out.dictationMode = p.mode;
+    if (typeof p.model_id === 'string' && p.model_id) out.dictationModelId = p.model_id;
+  }
+  return out;
+}
+
+export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (set, get) => ({
   translateQuality: 'fast',
   dualSubs: false,
   burnSubs: false,
@@ -148,6 +198,13 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   aecEnabled: false,
   autoPlayPreview: true,
 
+  // Seeds only — overwritten by loadDictationPrefs() on init. The backend
+  // default is enabled:true / mode:'toggle' / model:Parakeet TDT v3.
+  dictationEnabled: true,
+  dictationMode: 'toggle',
+  dictationModelId: DEFAULT_DICTATION_MODEL_ID,
+  dictationLoaded: false,
+
   setTranslateQuality:    (q) => set({ translateQuality: q }),
   setDualSubs:            (on) => set({ dualSubs: on }),
   setBurnSubs:            (on) => set({ burnSubs: on }),
@@ -158,6 +215,45 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   setFitOptions:          (o) => set({ fitOptions: o }),
   setAecEnabled:          (on) => set({ aecEnabled: on }),
   setAutoPlayPreview:     (on) => set({ autoPlayPreview: on }),
+
+  // ── Dictation prefs (backend-backed) ──────────────────────────────────
+  // Each setter is optimistic (update the store immediately so the UI is
+  // snappy) then write-throughs to POST /dictation/prefs, which returns the
+  // full authoritative prefs — we re-sync from that so a backend rejection
+  // (400 on a bad value) or normalisation (repo_id → canonical id) can't leave
+  // the UI out of step. A failed write rolls the optimistic value back.
+  setDictationEnabled: (on) => {
+    const prev = get().dictationEnabled;
+    set({ dictationEnabled: on });
+    apiPost('/dictation/prefs', { enabled: on })
+      .then((p: any) => set(_dictationFromPrefs(p)))
+      .catch(() => set({ dictationEnabled: prev }));
+  },
+  setDictationMode: (mode) => {
+    const prev = get().dictationMode;
+    set({ dictationMode: mode });
+    apiPost('/dictation/prefs', { mode })
+      .then((p: any) => set(_dictationFromPrefs(p)))
+      .catch(() => set({ dictationMode: prev }));
+  },
+  setDictationModelId: (id) => {
+    const prev = get().dictationModelId;
+    set({ dictationModelId: id });
+    apiPost('/dictation/prefs', { model_id: id })
+      .then((p: any) => set(_dictationFromPrefs(p)))
+      .catch(() => set({ dictationModelId: prev }));
+  },
+  loadDictationPrefs: async () => {
+    try {
+      const p = await apiJson<any>('/dictation/prefs');
+      set({ ..._dictationFromPrefs(p), dictationLoaded: true });
+    } catch {
+      // Backend not ready / older build without the route — keep the seeds and
+      // mark loaded so the panel renders defaults rather than a perpetual
+      // spinner. A later manual interaction will retry the write-through.
+      set({ dictationLoaded: true });
+    }
+  },
 
   locale: typeof navigator !== 'undefined' ? (() => {
     const nav = navigator.language || '';

--- a/frontend/src/test/VoicePanel.test.jsx
+++ b/frontend/src/test/VoicePanel.test.jsx
@@ -1,0 +1,117 @@
+/**
+ * Settings → Capture → Voice panel render + interaction.
+ *
+ * Verifies the screenshot contract: the Voice title/subtitle, the enable
+ * toggle, the Toggle/Hold mode control, and the Speech Model dropdown listing
+ * models with badges + size + a download/delete affordance. Also asserts the
+ * panel writes the model pref through the store on selection.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+const apiJson = vi.fn();
+const apiPost = vi.fn();
+vi.mock('../api/client', () => ({
+  apiJson: (...a) => apiJson(...a),
+  apiPost: (...a) => apiPost(...a),
+}));
+
+const installMutate = vi.fn(() => Promise.resolve());
+const deleteMutate = vi.fn(() => Promise.resolve());
+vi.mock('../api/hooks', () => ({
+  useInstallModel: () => ({ mutateAsync: installMutate }),
+  useDeleteModel: () => ({ mutateAsync: deleteMutate }),
+}));
+vi.mock('../api/setup', () => ({ setupDownloadStreamUrl: () => 'http://localhost/stream' }));
+
+import VoicePanel from '../components/settings/VoicePanel';
+import { useAppStore } from '../store';
+
+const MODELS = {
+  models: [
+    { id: 'sherpa-parakeet-tdt-v3', repo_id: 'org/parakeet-v3', label: 'Parakeet TDT v3', tag: 'offline', recommended: true, size_gb: 0.18, languages: '25 European languages', installed: true },
+    { id: 'sherpa-whisper-tiny', repo_id: 'org/whisper-tiny', label: 'Whisper Tiny', tag: 'offline', recommended: false, size_gb: 0.116, languages: '90+ languages', installed: false },
+  ],
+  engine_available: true,
+  engine_reason: null,
+  default_model_id: 'sherpa-parakeet-tdt-v3',
+};
+
+function withI18n(node) {
+  return <I18nextProvider i18n={i18n}>{node}</I18nextProvider>;
+}
+
+describe('VoicePanel', () => {
+  beforeEach(() => {
+    apiJson.mockReset();
+    apiPost.mockReset();
+    installMutate.mockClear();
+    deleteMutate.mockClear();
+    // Stub EventSource (jsdom lacks it).
+    global.EventSource = class {
+      constructor() { this.onmessage = null; }
+      close() {}
+    };
+    // /dictation/models and /dictation/prefs both go through apiJson.
+    apiJson.mockImplementation((path) => {
+      if (path === '/dictation/models') return Promise.resolve(MODELS);
+      if (path === '/dictation/prefs') return Promise.resolve({ enabled: true, mode: 'toggle', model_id: 'sherpa-parakeet-tdt-v3' });
+      return Promise.resolve({});
+    });
+    apiPost.mockResolvedValue({ enabled: true, mode: 'toggle', model_id: 'sherpa-whisper-tiny' });
+    useAppStore.setState({
+      dictationEnabled: true, dictationMode: 'toggle',
+      dictationModelId: 'sherpa-parakeet-tdt-v3', dictationLoaded: true,
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('renders the Voice title, subtitle, toggle, mode control and model dropdown', async () => {
+    render(withI18n(<VoicePanel />));
+    expect(screen.getByText('Voice')).toBeInTheDocument();
+    expect(screen.getByText(/Local speech-to-text dictation/)).toBeInTheDocument();
+    expect(screen.getByText('Enable Voice Dictation')).toBeInTheDocument();
+    expect(screen.getByText('Dictation Mode')).toBeInTheDocument();
+    // The switch reflects the enabled pref.
+    expect(screen.getByTestId('dictation-enabled')).toHaveAttribute('aria-checked', 'true');
+    // The dropdown trigger shows the selected model once models load.
+    await waitFor(() => expect(screen.getByTestId('dictation-model-trigger')).toHaveTextContent('Parakeet TDT v3'));
+  });
+
+  it('lists models with badges, size and install/delete affordances when expanded', async () => {
+    render(withI18n(<VoicePanel />));
+    await waitFor(() => expect(screen.getByTestId('dictation-model-trigger')).toHaveTextContent('Parakeet TDT v3'));
+    fireEvent.click(screen.getByTestId('dictation-model-trigger'));
+
+    const v3 = screen.getByTestId('dictation-model-sherpa-parakeet-tdt-v3').closest('li');
+    expect(within(v3).getByText('recommended')).toBeInTheDocument();
+    expect(within(v3).getByText('offline')).toBeInTheDocument();
+    expect(within(v3).getByText('180 MB')).toBeInTheDocument();
+    // Installed → delete affordance.
+    expect(screen.getByTestId('dictation-delete-sherpa-parakeet-tdt-v3')).toBeInTheDocument();
+    // Not installed → download affordance.
+    expect(screen.getByTestId('dictation-install-sherpa-whisper-tiny')).toBeInTheDocument();
+  });
+
+  it('writes the model pref and kicks off install when picking an uninstalled model', async () => {
+    render(withI18n(<VoicePanel />));
+    await waitFor(() => expect(screen.getByTestId('dictation-model-trigger')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('dictation-model-trigger'));
+    fireEvent.click(screen.getByTestId('dictation-model-sherpa-whisper-tiny'));
+
+    // Pref write-through (POST /dictation/prefs with the new model id).
+    await waitFor(() => expect(apiPost).toHaveBeenCalledWith('/dictation/prefs', { model_id: 'sherpa-whisper-tiny' }));
+    // Uninstalled → download started via the model-store install mutation.
+    expect(installMutate).toHaveBeenCalledWith('org/whisper-tiny');
+  });
+
+  it('toggles the enable switch through the store write-through', async () => {
+    render(withI18n(<VoicePanel />));
+    fireEvent.click(screen.getByTestId('dictation-enabled'));
+    await waitFor(() => expect(apiPost).toHaveBeenCalledWith('/dictation/prefs', { enabled: false }));
+  });
+});

--- a/frontend/src/test/captureSherpaFinal.test.js
+++ b/frontend/src/test/captureSherpaFinal.test.js
@@ -1,0 +1,118 @@
+/**
+ * CaptureWidget live-dictation state machine — pure helpers.
+ *
+ * `isSherpaModel` gates the raw-PCM streaming path; `classifySherpaFinal`
+ * distinguishes a per-utterance commit from the authoritative EOF summary so we
+ * paste each sentence live (committing on pauses) without re-pasting the summary
+ * — the heart of the "text appears as you speak" behaviour.
+ */
+import { describe, it, expect } from 'vitest';
+import { isSherpaModel, classifySherpaFinal, computeTypeDelta } from '../components/CaptureWidget';
+
+describe('isSherpaModel', () => {
+  it('matches the sherpa- dictation ids and nothing else', () => {
+    expect(isSherpaModel('sherpa-parakeet-tdt-v3')).toBe(true);
+    expect(isSherpaModel('sherpa-whisper-tiny')).toBe(true);
+    expect(isSherpaModel('whisper-large-v3')).toBe(false);
+    expect(isSherpaModel('')).toBe(false);
+    expect(isSherpaModel(undefined)).toBe(false);
+  });
+});
+
+describe('classifySherpaFinal', () => {
+  it('treats the first non-empty offline final as a new utterance (then close finalises)', () => {
+    // Offline model (Parakeet v3 default): one final, nothing committed yet.
+    expect(classifySherpaFinal('hello world', [])).toBe('utterance');
+  });
+
+  it('treats a streaming per-utterance final as an utterance', () => {
+    expect(classifySherpaFinal('second sentence', ['first sentence'])).toBe('utterance');
+  });
+
+  it('detects the EOF summary (text === the committed join)', () => {
+    const committed = ['first sentence', 'second sentence'];
+    expect(classifySherpaFinal('first sentence second sentence', committed)).toBe('summary');
+  });
+
+  it('detects a single-utterance summary (summary equals the one commit)', () => {
+    expect(classifySherpaFinal('hello world', ['hello world'])).toBe('summary');
+  });
+
+  it('finalises on an empty no-speech terminator', () => {
+    expect(classifySherpaFinal('', [])).toBe('terminator');
+  });
+
+  it('ignores an empty final once utterances were committed (the summary covers it)', () => {
+    expect(classifySherpaFinal('', ['something'])).toBe('ignore');
+  });
+});
+
+describe('computeTypeDelta', () => {
+  it('pure append: no backspaces, types only the new tail', () => {
+    expect(computeTypeDelta('hello wor', 'hello world')).toEqual({
+      backspaces: 0, text: 'ld', noop: false,
+    });
+  });
+
+  it('types the whole string from empty', () => {
+    expect(computeTypeDelta('', 'hello')).toEqual({
+      backspaces: 0, text: 'hello', noop: false,
+    });
+  });
+
+  it('no change is a noop (no keystrokes)', () => {
+    expect(computeTypeDelta('hello', 'hello')).toEqual({
+      backspaces: 0, text: '', noop: true,
+    });
+  });
+
+  it('both empty is a noop', () => {
+    expect(computeTypeDelta('', '')).toEqual({ backspaces: 0, text: '', noop: true });
+  });
+
+  it('handles null/undefined inputs as empty', () => {
+    expect(computeTypeDelta(undefined, null)).toEqual({ backspaces: 0, text: '', noop: true });
+    expect(computeTypeDelta(null, 'hi')).toEqual({ backspaces: 0, text: 'hi', noop: false });
+  });
+
+  it('recognizer self-correction: backspaces the revised tail then types the fix', () => {
+    // "hello to" → "hello two": common prefix "hello t", retract "o", type "wo".
+    expect(computeTypeDelta('hello to', 'hello two')).toEqual({
+      backspaces: 1, text: 'wo', noop: false,
+    });
+  });
+
+  it('full-word revision: "recognise" → "recognize"', () => {
+    // common prefix "recogni", retract "se", type "ze".
+    expect(computeTypeDelta('recognise', 'recognize')).toEqual({
+      backspaces: 2, text: 'ze', noop: false,
+    });
+  });
+
+  it('shorter revision retracts the extra chars and types nothing', () => {
+    // "helloo" → "hello": retract one 'o', type nothing.
+    expect(computeTypeDelta('helloo', 'hello')).toEqual({
+      backspaces: 1, text: '', noop: false,
+    });
+  });
+
+  it('a leading separator is just another typed prefix delta', () => {
+    // First delta of a new utterance is seeded as " word".
+    expect(computeTypeDelta('', ' world')).toEqual({
+      backspaces: 0, text: ' world', noop: false,
+    });
+  });
+
+  it('counts astral (emoji/CJK surrogate-pair) chars as single units', () => {
+    // "ab😀" → "ab😁": the emoji is one code point — retract 1, type 1, not 2.
+    expect(computeTypeDelta('ab😀', 'ab😁')).toEqual({
+      backspaces: 1, text: '😁', noop: false,
+    });
+  });
+
+  it('appends after a multibyte char without disturbing it', () => {
+    expect(computeTypeDelta('café', 'café au')).toEqual({
+      backspaces: 0, text: ' au', noop: false,
+    });
+  });
+});

--- a/frontend/src/test/dictationPrefs.test.ts
+++ b/frontend/src/test/dictationPrefs.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Store wiring for the backend-backed dictation prefs (prefsSlice).
+ *
+ * Asserts the contract the Voice panel + CaptureWidget depend on:
+ *   • loadDictationPrefs() hydrates enabled/mode/model from GET /dictation/prefs
+ *   • each setter is optimistic AND write-throughs to POST /dictation/prefs
+ *   • the store re-syncs from the POST response (so a server-side normalisation
+ *     like repo_id → canonical id can't leave the UI out of step)
+ *   • a failed write rolls the optimistic value back
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the api client BEFORE importing the store (prefsSlice imports it at
+// module load). Each test swaps the implementations via the spies below.
+const apiJson = vi.fn();
+const apiPost = vi.fn();
+vi.mock('../api/client', () => ({
+  apiJson: (...a: any[]) => apiJson(...a),
+  apiPost: (...a: any[]) => apiPost(...a),
+}));
+
+import { useAppStore } from '../store';
+
+function flush() {
+  // Let the write-through promise (.then) settle.
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+describe('dictation prefs store wiring', () => {
+  beforeEach(() => {
+    apiJson.mockReset();
+    apiPost.mockReset();
+    // Reset to slice seeds.
+    useAppStore.setState({
+      dictationEnabled: true,
+      dictationMode: 'toggle',
+      dictationModelId: 'sherpa-parakeet-tdt-v3',
+      dictationLoaded: false,
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('hydrates from GET /dictation/prefs', async () => {
+    apiJson.mockResolvedValue({ enabled: false, mode: 'hold', model_id: 'sherpa-whisper-tiny' });
+    await useAppStore.getState().loadDictationPrefs();
+    const s = useAppStore.getState();
+    expect(apiJson).toHaveBeenCalledWith('/dictation/prefs');
+    expect(s.dictationEnabled).toBe(false);
+    expect(s.dictationMode).toBe('hold');
+    expect(s.dictationModelId).toBe('sherpa-whisper-tiny');
+    expect(s.dictationLoaded).toBe(true);
+  });
+
+  it('still marks loaded when the backend route fails (older build)', async () => {
+    apiJson.mockRejectedValue(new Error('404'));
+    await useAppStore.getState().loadDictationPrefs();
+    expect(useAppStore.getState().dictationLoaded).toBe(true);
+    // Seeds preserved.
+    expect(useAppStore.getState().dictationMode).toBe('toggle');
+  });
+
+  it('setDictationMode is optimistic and write-throughs, then re-syncs', async () => {
+    apiPost.mockResolvedValue({ enabled: true, mode: 'hold', model_id: 'sherpa-parakeet-tdt-v3' });
+    useAppStore.getState().setDictationMode('hold');
+    // Optimistic update happened synchronously.
+    expect(useAppStore.getState().dictationMode).toBe('hold');
+    await flush();
+    expect(apiPost).toHaveBeenCalledWith('/dictation/prefs', { mode: 'hold' });
+    expect(useAppStore.getState().dictationMode).toBe('hold');
+  });
+
+  it('re-syncs the model id from the POST response (repo_id → canonical id)', async () => {
+    // The user picks via repo_id; the backend normalises to the canonical id.
+    apiPost.mockResolvedValue({ enabled: true, mode: 'toggle', model_id: 'sherpa-parakeet-tdt-v2' });
+    useAppStore.getState().setDictationModelId('csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2-int8');
+    await flush();
+    expect(useAppStore.getState().dictationModelId).toBe('sherpa-parakeet-tdt-v2');
+  });
+
+  it('rolls back the optimistic value when the write fails', async () => {
+    apiPost.mockRejectedValue(new Error('boom'));
+    useAppStore.getState().setDictationEnabled(false);
+    expect(useAppStore.getState().dictationEnabled).toBe(false); // optimistic
+    await flush();
+    expect(useAppStore.getState().dictationEnabled).toBe(true); // rolled back
+  });
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,14 @@ dependencies = [
     # is_available() returned "openai package missing"); the UI's `pip install
     # openai` hint landed in the wrong interpreter on a managed venv.
     "openai>=1.40",
+    # sherpa-onnx live-dictation ASR engine (CPU, cross-platform). The thin
+    # `sherpa-onnx` wheel declares `sherpa-onnx-core` only in its *wheel*
+    # metadata (not the sdist), so uv's resolver does NOT pull it transitively
+    # — without core, `import sherpa_onnx` fails at load time (missing
+    # libonnxruntime). Pin core EXPLICITLY so the lock captures it and Docker's
+    # frozen `uv sync` installs a working engine on every platform.
+    "sherpa-onnx>=1.13.3",
+    "sherpa-onnx-core>=1.13.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -36,6 +36,8 @@ GET /community/items
 GET /community/manifest
 GET /community/sources
 GET /community/submit-url
+GET /dictation/models
+GET /dictation/prefs
 GET /docs
 GET /dub/audio/{job_id}
 GET /dub/download-audio/{job_id}
@@ -129,6 +131,7 @@ POST /batch/jobs/{job_id}/cancel
 POST /clean-audio
 POST /community/items/{item_id}/use
 POST /design/describe
+POST /dictation/prefs
 POST /dub/abort/{job_id}
 POST /dub/cleanup-segments/{job_id}
 POST /dub/generate/{job_id}

--- a/tests/test_dictation_router.py
+++ b/tests/test_dictation_router.py
@@ -1,0 +1,80 @@
+"""
+Tests for the dictation router (GET /dictation/models, GET/POST /dictation/prefs)
+— the exact contract the frontend dictation UI binds to.
+"""
+import os
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    # Import the app first (it pulls in core.prefs for real), then patch the
+    # REAL core.prefs get/set_ functions with an in-memory store so the test
+    # never touches the real prefs.json (and is immune to reference-swap order).
+    from main import app
+    store: dict = {}
+    # Patch the prefs object the dictation handler actually holds (its own
+    # module-level `prefs` reference), so the test is immune to any prior
+    # test that swapped sys.modules["core.prefs"].
+    from api.routers import dictation as dr
+    monkeypatch.setattr(dr.prefs, "get", lambda k, d=None: store.get(k, d))
+    monkeypatch.setattr(dr.prefs, "set_", lambda k, v: store.__setitem__(k, v))
+    c = TestClient(app, client=("127.0.0.1", 50000))
+    c._store = store
+    return c
+
+
+def test_list_models_shape(client):
+    r = client.get("/dictation/models")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["default_model_id"] == "sherpa-parakeet-tdt-v3"
+    assert len(body["models"]) == 7
+    keys = {"id", "repo_id", "label", "tag", "recommended", "size_gb",
+            "languages", "kind", "installed"}
+    for m in body["models"]:
+        assert keys <= set(m), f"missing keys in {m}"
+        assert m["tag"] in ("offline", "streaming")
+    rec = [m for m in body["models"] if m["recommended"]]
+    assert [m["id"] for m in rec] == ["sherpa-parakeet-tdt-v3"]
+
+
+def test_get_prefs_defaults(client):
+    r = client.get("/dictation/prefs")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"enabled": True, "mode": "toggle",
+                    "model_id": "sherpa-parakeet-tdt-v3"}
+
+
+def test_set_prefs_persists_and_validates(client):
+    r = client.post("/dictation/prefs", json={
+        "enabled": False, "mode": "hold", "model_id": "sherpa-whisper-tiny"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"enabled": False, "mode": "hold",
+                    "model_id": "sherpa-whisper-tiny"}
+    # Persistence: a follow-up GET sees the written values (round-trips through
+    # the store the handler actually used — robust to prefs-reference swaps).
+    got = client.get("/dictation/prefs").json()
+    assert got == {"enabled": False, "mode": "hold",
+                   "model_id": "sherpa-whisper-tiny"}
+
+    # Bad mode rejected.
+    assert client.post("/dictation/prefs", json={"mode": "nope"}).status_code == 400
+    # Bad model rejected.
+    assert client.post("/dictation/prefs", json={"model_id": "nope"}).status_code == 400
+
+
+def test_set_prefs_accepts_repo_id_and_normalizes(client):
+    r = client.post("/dictation/prefs",
+                    json={"model_id": "csukuangfj/sherpa-onnx-whisper-tiny"})
+    assert r.status_code == 200
+    # Stored as the canonical dictation id, not the repo_id.
+    assert r.json()["model_id"] == "sherpa-whisper-tiny"

--- a/tests/test_sherpa_dictation.py
+++ b/tests/test_sherpa_dictation.py
@@ -1,0 +1,287 @@
+"""
+Tests for the sherpa-onnx live-dictation backend (services/sherpa_dictation.py
++ services/asr_backend.SherpaDictationBackend).
+
+sherpa_onnx is mocked end-to-end so these run in CI without downloading any
+model: we assert the dispatch/wiring (right recognizer factory per kind, right
+CPU provider) and the output-shape normalisation to OmniVoice's
+{chunks, segments, language, text} contract.
+
+Also pins the verified ONNX asset filenames so a silent registry typo (the
+streaming zipformer repos use plain `encoder-epoch-99-avg-1.int8.onnx`, NOT a
+`-chunk-16-left-64` variant) fails loudly.
+"""
+import os
+import sys
+import types
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+
+# ── A fake sherpa_onnx module ────────────────────────────────────────────────
+
+
+class _FakeStream:
+    def __init__(self, owner):
+        self._owner = owner
+        self._fed = 0
+        self._finished = False
+
+    def accept_waveform(self, sr, samples):
+        self._fed += len(samples)
+
+    def input_finished(self):
+        self._finished = True
+
+    @property
+    def result(self):
+        # OfflineStream.result.text
+        return types.SimpleNamespace(text="hello world", tokens=[], timestamps=[])
+
+
+class _FakeOfflineRecognizer:
+    last_kwargs = None
+    factory = None
+
+    def __init__(self, kwargs, factory):
+        type(self).last_kwargs = kwargs
+        type(self).factory = factory
+
+    @classmethod
+    def from_transducer(cls, **kw):
+        return cls(kw, "from_transducer")
+
+    @classmethod
+    def from_whisper(cls, **kw):
+        return cls(kw, "from_whisper")
+
+    def create_stream(self):
+        return _FakeStream(self)
+
+    def decode_stream(self, s):
+        pass
+
+
+class _FakeOnlineRecognizer:
+    last_kwargs = None
+    factory = None
+
+    def __init__(self, kwargs, factory):
+        type(self).last_kwargs = kwargs
+        type(self).factory = factory
+        self._decodes = 0
+
+    @classmethod
+    def from_transducer(cls, **kw):
+        return cls(kw, "from_transducer")
+
+    @classmethod
+    def from_paraformer(cls, **kw):
+        return cls(kw, "from_paraformer")
+
+    def create_stream(self):
+        return _FakeStream(self)
+
+    def is_ready(self, s):
+        # Become "not ready" after one decode pass so loops terminate.
+        self._decodes += 1
+        return self._decodes <= 1
+
+    def decode_stream(self, s):
+        pass
+
+    def get_result(self, s):
+        return "hello world"
+
+    def is_endpoint(self, s):
+        return False
+
+    def reset(self, s):
+        self._decodes = 0
+
+
+@pytest.fixture
+def fake_sherpa(monkeypatch):
+    mod = types.ModuleType("sherpa_onnx")
+    mod.OfflineRecognizer = _FakeOfflineRecognizer
+    mod.OnlineRecognizer = _FakeOnlineRecognizer
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", mod)
+    # Reset captured state between tests.
+    _FakeOfflineRecognizer.last_kwargs = None
+    _FakeOnlineRecognizer.last_kwargs = None
+    return mod
+
+
+@pytest.fixture
+def no_download(monkeypatch):
+    """Make _resolve_model_dir return a fake dir without touching HF."""
+    from services import sherpa_dictation as sd
+    monkeypatch.setattr(sd, "_resolve_model_dir", lambda spec, download=True: "/fake/model/dir")
+    return sd
+
+
+# ── Registry / filename pinning ──────────────────────────────────────────────
+
+
+def test_seven_models_registered():
+    from services import sherpa_dictation as sd
+    specs = sd.list_specs()
+    assert len(specs) == 7
+    ids = {s.id for s in specs}
+    assert ids == {
+        "sherpa-parakeet-tdt-v3", "sherpa-parakeet-tdt-v2",
+        "sherpa-zipformer-bilingual-zh-en", "sherpa-paraformer-bilingual-zh-en",
+        "sherpa-zipformer-en-20m", "sherpa-zipformer-zh-14m", "sherpa-whisper-tiny",
+    }
+    # Exactly one recommended default.
+    rec = [s for s in specs if s.recommended]
+    assert [s.id for s in rec] == ["sherpa-parakeet-tdt-v3"]
+    assert sd.DEFAULT_MODEL_ID == "sherpa-parakeet-tdt-v3"
+
+
+def test_verified_filenames_pinned():
+    from services import sherpa_dictation as sd
+    g = sd.get_spec
+    # Offline transducers — int8 triplet.
+    assert g("sherpa-parakeet-tdt-v3").files == {
+        "encoder": "encoder.int8.onnx", "decoder": "decoder.int8.onnx",
+        "joiner": "joiner.int8.onnx", "tokens": "tokens.txt"}
+    # Streaming zipformer — VERIFIED epoch naming (NOT -chunk-16-left-64).
+    assert g("sherpa-zipformer-bilingual-zh-en").files["encoder"] == \
+        "encoder-epoch-99-avg-1.int8.onnx"
+    assert g("sherpa-zipformer-en-20m").files["joiner"] == \
+        "joiner-epoch-99-avg-1.int8.onnx"
+    assert g("sherpa-zipformer-zh-14m").files["decoder"] == \
+        "decoder-epoch-99-avg-1.int8.onnx"
+    # Streaming paraformer — NO joiner.
+    assert "joiner" not in g("sherpa-paraformer-bilingual-zh-en").files
+    # Whisper tiny — tiny-prefixed assets.
+    assert g("sherpa-whisper-tiny").files == {
+        "encoder": "tiny-encoder.int8.onnx", "decoder": "tiny-decoder.int8.onnx",
+        "tokens": "tiny-tokens.txt"}
+
+
+def test_get_spec_accepts_repo_id():
+    from services import sherpa_dictation as sd
+    spec = sd.get_spec("csukuangfj/sherpa-onnx-whisper-tiny")
+    assert spec is not None and spec.id == "sherpa-whisper-tiny"
+    assert sd.is_sherpa_model("sherpa-whisper-tiny")
+    assert not sd.is_sherpa_model("Systran/faster-whisper-large-v3")
+    assert not sd.is_sherpa_model(None)
+
+
+# ── The 4 recognizer kinds construct + transcribe ───────────────────────────
+
+
+@pytest.mark.parametrize("model_id,kind,factory,is_online", [
+    ("sherpa-parakeet-tdt-v3", "offline-transducer", "from_transducer", False),
+    ("sherpa-whisper-tiny", "offline-whisper", "from_whisper", False),
+    ("sherpa-zipformer-en-20m", "online-transducer", "from_transducer", True),
+    ("sherpa-paraformer-bilingual-zh-en", "online-paraformer", "from_paraformer", True),
+])
+def test_recognizer_kind_constructs_and_transcribes(
+    fake_sherpa, no_download, monkeypatch, tmp_path, model_id, kind, factory, is_online,
+):
+    from services import asr_backend as ab
+    from services import sherpa_dictation as sd
+
+    # Feed a fixed waveform so transcribe() doesn't read a real file.
+    monkeypatch.setattr(
+        ab, "_load_audio_16k_mono_f32",
+        lambda path: (np.zeros(16000, dtype=np.float32), 16000),
+    )
+
+    spec = sd.get_spec(model_id)
+    assert spec.kind == kind
+
+    backend = ab.SherpaDictationBackend(model_id=model_id)
+    out = backend.transcribe(str(tmp_path / "x.wav"))
+
+    # Right factory on the right recognizer class + CPU provider.
+    cls = fake_sherpa.OnlineRecognizer if is_online else fake_sherpa.OfflineRecognizer
+    assert cls.factory == factory
+    assert cls.last_kwargs["provider"] == "cpu"
+    assert cls.last_kwargs["num_threads"] == 2
+    if kind == "offline-transducer":
+        assert cls.last_kwargs["model_type"] == "nemo_transducer"
+    if kind == "offline-whisper":
+        assert cls.last_kwargs["language"] == ""
+        assert cls.last_kwargs["task"] == "transcribe"
+
+    # Output-shape normalisation.
+    assert out["text"] == "hello world"
+    assert out["chunks"][0]["text"] == "hello world"
+    assert out["chunks"][0]["timestamp"][0] == 0.0
+    assert out["segments"][0]["text"] == "hello world"
+    assert "language" in out
+
+
+def test_backend_streaming_flag(fake_sherpa, no_download):
+    from services import asr_backend as ab
+    assert ab.SherpaDictationBackend(model_id="sherpa-zipformer-en-20m").streaming
+    assert not ab.SherpaDictationBackend(model_id="sherpa-parakeet-tdt-v3").streaming
+
+
+def test_unknown_model_id_raises(fake_sherpa):
+    from services import asr_backend as ab
+    with pytest.raises(ValueError):
+        ab.SherpaDictationBackend(model_id="nope")
+
+
+def test_registered_in_asr_registry():
+    from services import asr_backend as ab
+    assert "sherpa-onnx-asr" in ab._REGISTRY
+    assert ab._REGISTRY["sherpa-onnx-asr"] is ab.SherpaDictationBackend
+    assert "sherpa-onnx-asr" in ab._INSTALL_HINTS
+
+
+# ── get_capture_asr_backend() honors dictation.model_id ─────────────────────
+
+
+def test_capture_backend_honors_dictation_model_id(fake_sherpa, no_download, monkeypatch):
+    from services import asr_backend as ab
+
+    # Reset the cached singleton + force sherpa "available".
+    ab._capture_backend = None
+    ab._capture_backend_key = None
+    monkeypatch.setattr(ab.SherpaDictationBackend, "is_available",
+                        classmethod(lambda cls: (True, "ready")))
+
+    prefs_store = {"dictation.enabled": True, "dictation.model_id": "sherpa-whisper-tiny"}
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "get", lambda k, d=None: prefs_store.get(k, d))
+    monkeypatch.delenv("OMNIVOICE_SHERPA_ASR_MODEL", raising=False)
+
+    b = ab.get_capture_asr_backend()
+    assert isinstance(b, ab.SherpaDictationBackend)
+    assert b.spec.id == "sherpa-whisper-tiny"
+
+    # Switching the pref rebuilds the singleton for the new model.
+    prefs_store["dictation.model_id"] = "sherpa-parakeet-tdt-v3"
+    ab._capture_backend = None
+    ab._capture_backend_key = None
+    b2 = ab.get_capture_asr_backend()
+    assert b2.spec.id == "sherpa-parakeet-tdt-v3"
+
+
+def test_capture_backend_falls_back_when_dictation_disabled(monkeypatch):
+    from services import asr_backend as ab
+    ab._capture_backend = None
+    ab._capture_backend_key = None
+
+    prefs_store = {"dictation.enabled": False, "dictation.model_id": "sherpa-whisper-tiny"}
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "get", lambda k, d=None: prefs_store.get(k, d))
+    monkeypatch.delenv("OMNIVOICE_SHERPA_ASR_MODEL", raising=False)
+
+    # dictation_model_id() returns None → not a sherpa backend.
+    assert ab.dictation_model_id() is None
+    b = ab.get_capture_asr_backend()
+    assert not isinstance(b, ab.SherpaDictationBackend)
+    # cleanup singleton so other tests start clean
+    ab._capture_backend = None
+    ab._capture_backend_key = None

--- a/tests/test_sherpa_ws_streaming.py
+++ b/tests/test_sherpa_ws_streaming.py
@@ -1,0 +1,183 @@
+"""
+Streaming-protocol test for the sherpa-onnx live-dictation WS path.
+
+North-star: partials must arrive AS THE TEXT GROWS, before the final. This
+drives ``/ws/transcribe?model=<streaming-id>`` with a mocked OnlineRecognizer
+whose decoded text grows frame-by-frame, then fires an endpoint, and asserts:
+  • ≥1 {"type":"partial"} arrives with growing text BEFORE the committed result,
+  • an endpoint produces a {"type":"final"} mid-session,
+  • a trailing {"type":"final"} is sent on EOF.
+
+Everything is mocked (no sherpa wheel, no model download) — protocol only.
+"""
+import os
+import sys
+import types
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+
+class _GrowingStream:
+    def accept_waveform(self, sr, samples):
+        pass
+
+    def input_finished(self):
+        pass
+
+
+class _GrowingOnlineRecognizer:
+    """Emits "a", "a b", "a b c" on successive frames, then an endpoint."""
+
+    def __init__(self):
+        self._texts = ["a", "a b", "a b c"]
+        self._i = 0
+        self._endpoint_at = 3  # endpoint after the 3rd frame
+
+    def create_stream(self):
+        return _GrowingStream()
+
+    def is_ready(self, s):
+        return False  # decode loop is a no-op; text advances per frame
+
+    def decode_stream(self, s):
+        pass
+
+    def get_result(self, s):
+        idx = min(self._i, len(self._texts) - 1)
+        return self._texts[idx]
+
+    def is_endpoint(self, s):
+        return self._i >= self._endpoint_at
+
+    def reset(self, s):
+        self._i = 0
+        self._texts = ["tail"]
+        self._endpoint_at = 999
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from fastapi.testclient import TestClient
+    from api.routers import capture_ws as cw
+    from services import sherpa_dictation as sd
+    from services import asr_backend as ab
+
+    spec = sd.get_spec("sherpa-zipformer-en-20m")  # streaming
+    monkeypatch.setattr(cw, "_select_sherpa_spec", lambda ws: spec)
+    monkeypatch.setattr(ab.SherpaDictationBackend, "is_available",
+                        classmethod(lambda cls: (True, "ready")))
+
+    rec = _GrowingOnlineRecognizer()
+
+    def fake_ensure(self):
+        self._rec = rec
+
+    # Each accepted near-end frame advances the recognizer's text pointer.
+    real_recv = cw._recv_pcm_frame
+
+    async def counting_recv(ws, aec):
+        kind, pcm = await real_recv(ws, aec)
+        if kind == "near":
+            rec._i += 1
+        return kind, pcm
+
+    monkeypatch.setattr(ab.SherpaDictationBackend, "ensure_loaded", fake_ensure)
+    monkeypatch.setattr(cw, "_recv_pcm_frame", counting_recv)
+    # Avoid LLM refinement network calls.
+    monkeypatch.setitem(sys.modules, "services.refinement",
+                        types.SimpleNamespace(maybe_refine=lambda t: None,
+                                              collapse_repetitive_artifacts=lambda t: t))
+
+    from main import app
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+def _pcm(nbytes=2000):
+    return b"\x00" * nbytes
+
+
+def test_partials_before_final(client):
+    with client.websocket_connect("/ws/transcribe?model=sherpa-zipformer-en-20m&sr=16000") as ws:
+        # Three frames → growing partials, then endpoint → mid-session final.
+        ws.send_bytes(_pcm())
+        ws.send_bytes(_pcm())
+        ws.send_bytes(_pcm())
+        ws.send_text("EOF")
+
+        msgs = []
+        for _ in range(20):
+            try:
+                msgs.append(ws.receive_json())
+            except Exception:
+                break
+            if msgs[-1].get("type") == "final" and msgs[-1].get("text") in ("a b c", ""):
+                # got the endpoint-final; keep draining for the EOF final too
+                if len([m for m in msgs if m["type"] == "final"]) >= 1:
+                    # try one more receive for trailing final, then stop
+                    try:
+                        msgs.append(ws.receive_json())
+                    except Exception:
+                        pass
+                    break
+
+    types_seen = [m["type"] for m in msgs]
+    partials = [m for m in msgs if m["type"] == "partial"]
+    finals = [m for m in msgs if m["type"] == "final"]
+
+    # At least one partial arrived, and the FIRST partial came before the
+    # FIRST final (the whole point — live text as you speak).
+    assert partials, f"no partials emitted; saw {types_seen}"
+    assert finals, f"no final emitted; saw {types_seen}"
+    assert types_seen.index("partial") < types_seen.index("final")
+
+    # Partials grow monotonically in length.
+    lengths = [len(p["text"]) for p in partials]
+    assert lengths == sorted(lengths)
+
+
+def test_non_streaming_model_uses_offline_handler(monkeypatch):
+    """An offline-kind sherpa model routes to the offline cadence handler and
+    still finalizes (sanity that the kind branch wires up)."""
+    from fastapi.testclient import TestClient
+    from api.routers import capture_ws as cw
+    from services import sherpa_dictation as sd
+    from services import asr_backend as ab
+
+    spec = sd.get_spec("sherpa-whisper-tiny")  # offline
+    monkeypatch.setattr(cw, "_select_sherpa_spec", lambda ws: spec)
+    monkeypatch.setattr(ab.SherpaDictationBackend, "is_available",
+                        classmethod(lambda cls: (True, "ready")))
+
+    def fake_ensure(self):
+        self._rec = object()
+
+    monkeypatch.setattr(ab.SherpaDictationBackend, "ensure_loaded", fake_ensure)
+    monkeypatch.setattr(ab.SherpaDictationBackend, "_decode_offline",
+                        lambda self, samples, sr: "offline text")
+    monkeypatch.setitem(sys.modules, "services.refinement",
+                        types.SimpleNamespace(maybe_refine=lambda t: None,
+                                              collapse_repetitive_artifacts=lambda t: t))
+    monkeypatch.setenv("OMNIVOICE_SHERPA_OFFLINE_PARTIAL", "0.05")
+    # reload module-level cadence constant
+    cw.SHERPA_OFFLINE_PARTIAL_S = 0.05
+
+    from main import app
+    client = TestClient(app, client=("127.0.0.1", 50000))
+    with client.websocket_connect("/ws/transcribe?model=sherpa-whisper-tiny&sr=16000") as ws:
+        ws.send_bytes(b"\x00" * 4000)
+        ws.send_text("EOF")
+        final = None
+        for _ in range(20):
+            try:
+                m = ws.receive_json()
+            except Exception:
+                break
+            if m.get("type") == "final":
+                final = m
+                break
+    assert final is not None
+    assert final["text"] == "offline text"
+    assert final["engine"] == "sherpa-onnx-asr"

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.6"
+version = "0.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -3237,6 +3237,8 @@ dependencies = [
     { name = "python-multipart" },
     { name = "scalar-fastapi" },
     { name = "setuptools" },
+    { name = "sherpa-onnx" },
+    { name = "sherpa-onnx-core" },
     { name = "soundfile" },
     { name = "tensorboardx" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -3314,6 +3316,8 @@ requires-dist = [
     { name = "s3prl", marker = "extra == 'eval'" },
     { name = "scalar-fastapi" },
     { name = "setuptools", specifier = ">=75,<80" },
+    { name = "sherpa-onnx", specifier = ">=1.13.3" },
+    { name = "sherpa-onnx-core", specifier = ">=1.13.3" },
     { name = "soundfile" },
     { name = "supertonic", marker = "extra == 'supertonic'", specifier = "==1.3.1" },
     { name = "tensorboardx" },
@@ -5298,6 +5302,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sherpa-onnx"
+version = "1.13.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/ed/09eab65801ae251777674d47e31ebcfc68632c4d0ffde87aa04b2f265f88/sherpa_onnx-1.13.3.tar.gz", hash = "sha256:c69449efa1841c823098fb658cbd55f632b511d39457869e5d8447ab1e0903e0", size = 963221, upload-time = "2026-06-15T09:16:53.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/fc/1c21d2675b66ad1850dbcb43687d53985f29c4657478becceadd495d7983/sherpa_onnx-1.13.3-cp311-cp311-linux_armv7l.whl", hash = "sha256:5360e3b14c3416fbf6a70fde4a889b590cc2a16fa664a9c72bd972024decd605", size = 11551027, upload-time = "2026-06-15T10:52:48.931Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/851985affbfee395344b2b50f8e68f5cd839985fe69e79fc02f5e1ae5f61/sherpa_onnx-1.13.3-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:0347ddfd258613d0a5dbc0d59d713aa4b39b7b74de093e99500ddaf774cf6fb1", size = 4407539, upload-time = "2026-06-15T09:11:34.203Z" },
+    { url = "https://files.pythonhosted.org/packages/66/30/92cfe6ee99a58cde40ab0841215fac0428893066009e5673fe6c35f77ab2/sherpa_onnx-1.13.3-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:5f860cb89a0f9aa9da9d132e05b7602559012e007e5cfcdb171576f895e2fff6", size = 2333161, upload-time = "2026-06-15T08:51:04.427Z" },
+    { url = "https://files.pythonhosted.org/packages/80/eb/f55c7aceda850c81bd7b27b84099620b7fc80dd62bd93302fd1c9c7747e5/sherpa_onnx-1.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cf02cf14f77cfaa85368227bbbc3ec3e04249c0b80ea9ed34bf15abe88b19076", size = 2112122, upload-time = "2026-06-15T09:17:56.113Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ad/a2b96c3e21c5e5957528e0c35a10f47f89c028f64f4f0bbd75fa6b99fd36/sherpa_onnx-1.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ccef66d305509622daaae3e175509d3f048325193a7e483f94137ee89ebdcb5", size = 4130599, upload-time = "2026-06-15T08:36:50.78Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/59/23916294036ecd2fa6b0c8c8b441b0d33961a4887653dee15fb4321cfafd/sherpa_onnx-1.13.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f5e403138b7cbe2bc6c676ccf5b73d5b7a52ff57416c851fe9604203f7b4a7e", size = 4355012, upload-time = "2026-06-15T08:52:59.547Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d9/b695a0dc7871b6aa3c0c9ef24c2a42dde14989d11b95552446517564bde4/sherpa_onnx-1.13.3-cp311-cp311-win32.whl", hash = "sha256:3b7fdaf62ff59fe1b4e0feb2c91540e908e1b2656379708fe3893649f9bccb7b", size = 1925227, upload-time = "2026-06-15T08:44:39.346Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1d/1f68369d1aeceffccdeeb0459ae56406cb1702d0efd7db7fba2df2778e37/sherpa_onnx-1.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:84cffcf1fc534d15fbcfe0274ca1c484b4f0bdc9a8a4615a9dd20b60fde0120a", size = 2235034, upload-time = "2026-06-15T09:31:53.866Z" },
+    { url = "https://files.pythonhosted.org/packages/86/11/5bdb69b0520ca8b1c8a4e05e1c6175c159eb32113ba76183f42f2ca15942/sherpa_onnx-1.13.3-cp312-cp312-linux_armv7l.whl", hash = "sha256:6a782c1c577bd9e87b17933679c7fd25f1a269b0b195d35fb81e48b918dfab76", size = 11555612, upload-time = "2026-06-15T10:59:14.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/52/10f068e8f2958d609fb7e9b2f7d6865a02929c698da0b1171d075270af98/sherpa_onnx-1.13.3-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:8b4c6f417d50ae5fbe0948b96574ae1bb8da82e0f10bc9c225164a0d16696da6", size = 4429577, upload-time = "2026-06-15T08:51:11.358Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/f9c27b6d0979b2148fe0f68a59312e2b1254eb3ef2a3f7e74d8f1da6614d/sherpa_onnx-1.13.3-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:0a2eb6dd471ca1cac1394dda9f688784edf4bd045308808ff20451ba06cb3e59", size = 2350785, upload-time = "2026-06-15T08:51:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/1b910152c38e19c1a1c52c77cb1d5041ac0ae75aaf6973c4299b6b7c8d4d/sherpa_onnx-1.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68ed17ced6852a084f9eb10843e1cbf790f8e64a0c6c7147f7195e4790acc291", size = 2116196, upload-time = "2026-06-15T08:56:27.424Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/eb/89d96c60b3e2de1fd3bba7314c65c01e20fc8207e6012c843092e58a3ce6/sherpa_onnx-1.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9cac189cb38512adbb2ddd100a59ba108443e287abae6e75faad25cf632471f2", size = 4134195, upload-time = "2026-06-15T08:36:20.479Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f9/b3d4d78c6b5c1b3ac5a9f0ba6b2e1acd97c510ea10dc600df8b54dcd54f4/sherpa_onnx-1.13.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f3636caaad41547bff28ff01f2d890021a693e67391168ef9b575abbc5275ea5", size = 4355516, upload-time = "2026-06-15T09:16:44.889Z" },
+    { url = "https://files.pythonhosted.org/packages/23/17/e1130e6b8565805f192e06048febc64c9e3a0d0f3482a29a3739a2d6b353/sherpa_onnx-1.13.3-cp312-cp312-win32.whl", hash = "sha256:2edfad57805740ac17d1c3f961e9148cab1ca4a1e8e76821945ea0eb475ac828", size = 1926017, upload-time = "2026-06-15T09:01:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/49/fd55ed81516f64c6c42d83a785a32ddbb2c3b39803e7d54139f0ebe9b02f/sherpa_onnx-1.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:aac2e4a7e8691656595df10bd1894c0bc61d5418647c695c157dc6e0a0f816ac", size = 2237008, upload-time = "2026-06-15T09:22:43.201Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bf/a15173869b744672e774078c5de6152b128d0af7022cdf1885879e00c917/sherpa_onnx-1.13.3-cp313-cp313-linux_armv7l.whl", hash = "sha256:ba05e7a701cb292d7737b8e0a4de1e10faf53cf00e4b949d498ed31a303fdb47", size = 11555815, upload-time = "2026-06-15T10:58:14.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3b/246a8c71c3c89697952c10fd9f9d6be7cdab7fbfb78d8c3707a93876e957/sherpa_onnx-1.13.3-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:4571c149f1c2a196ad0e3fa5c82546eade7a393b78b34c243f82b8670983a4ec", size = 4429630, upload-time = "2026-06-15T08:35:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/78/07/bc33e219810a890bb67427b665a52b7ec2e47973a08e2fbc699ceb47ff2c/sherpa_onnx-1.13.3-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:2d0d93f4c4df5bb930d850d658a3d92762b26d94812a383384b101c46d643d9f", size = 2350765, upload-time = "2026-06-15T09:30:21.061Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f5/43071a8120532a57bceb4f3ccd3cc7fb1bd6e17d9465b56e58f3c9b16876/sherpa_onnx-1.13.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be57b1599b65dfa3ccc1ee6750c865b23f43556325a853e2e7827aa6be180023", size = 2116383, upload-time = "2026-06-15T09:11:46.739Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f9/b5b1ba5bae8aa88244709ec69a7c5c31c00158dad37ee84d3d6c3e1a1a2b/sherpa_onnx-1.13.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:427b282082cc84486b9da9ab7c34f7697ca4ab07767dc0de3b2706b54b842bf1", size = 4134345, upload-time = "2026-06-15T08:50:27.976Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/51/541f4611631213ad7d701c23877519286df86da0dca1158dcbe9c9cd5caa/sherpa_onnx-1.13.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:880ad624dd22fe9cc6d2aac99013fa4ac293eaafe3467771593f97ad6bcedb21", size = 4355420, upload-time = "2026-06-15T08:48:02.193Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/00da9df800d1630936bd010792131c0020035ef4ac39a0538b3ebf1444ca/sherpa_onnx-1.13.3-cp313-cp313-win32.whl", hash = "sha256:51c0a91cf471c6514241dcb4e27102074e79212c053e22a18ae0a0e461880152", size = 1925975, upload-time = "2026-06-15T08:41:10.864Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c7/7b38eca0d329d11b8a0d95ff391ed14b310c1956ff72754438d6b9229b1f/sherpa_onnx-1.13.3-cp313-cp313-win_amd64.whl", hash = "sha256:1a22c18d7b2d46abb15af609b0fe1cc150c5718d6bb7782c12669abf96f79ece", size = 2239378, upload-time = "2026-06-15T09:27:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2c/765435112957dd9ec95803400bf7129d6974f11dc71c372323f56102f99c/sherpa_onnx-1.13.3-cp314-cp314-linux_armv7l.whl", hash = "sha256:7706f03ea2c61d25880202c227a52b4bc71fec4a355cf81e8df5e6a9fbf9722d", size = 11552535, upload-time = "2026-06-15T11:16:59.598Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6f/30a511f755e015148cce502b18b06b5953942d35668ee706fdb98097f32e/sherpa_onnx-1.13.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4dc9fb2fa6a8cf0fdffbb3adf86c030c6ebe22ca7a501f386e363e887a9b73b1", size = 4433328, upload-time = "2026-06-15T08:58:30.354Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/51/95a4a98760169daaf3a926fe04a6882709b8a1e54f533dd11e6c2bad55b4/sherpa_onnx-1.13.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3c9f31658c8435713d04384f265de8ec668bc332c47033c155daa43d9017aed4", size = 2351155, upload-time = "2026-06-15T09:22:21.673Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ae/942f28d0d6c0d71a7b9ccdd64727b4424587f88940bfbcd7a9ea1df88ba8/sherpa_onnx-1.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9d0065d016535f285c9772cf89200d169362cd12a4762ad510645754cd2a7ccd", size = 2119434, upload-time = "2026-06-15T09:12:36.772Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/3fb8df8e1315da2df5504c1aefc41eff8a9abbc7ebded6e991daf2da28d9/sherpa_onnx-1.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cd61cd8565c76eec195173b67721495fe6411baf08fbca400f86cf782851676", size = 4140368, upload-time = "2026-06-15T08:33:35.438Z" },
+    { url = "https://files.pythonhosted.org/packages/20/93/e9f442d37d7df923d9420e2db624090be34e2ae845ff2cfda41ca20906ba/sherpa_onnx-1.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f81744142f4b6800ebd1aac0fd37f4e88f6e64b45d4c48c7c3ece49535ae8d66", size = 4356908, upload-time = "2026-06-15T09:01:12.112Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d5/3d063fbb90d54e46d809f7dc994c479226e7533f9335bcbc3a64b5102053/sherpa_onnx-1.13.3-cp314-cp314-win32.whl", hash = "sha256:2b3324f2ad8f76de08dec9070822e01d4ad8ab86cae23ff82e37d7b87327e6fc", size = 1965474, upload-time = "2026-06-15T08:32:31.284Z" },
+    { url = "https://files.pythonhosted.org/packages/96/dd/57196e377f387cdde53cc72c47456053900392d506559741dee0f8be71a9/sherpa_onnx-1.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9c9d9459ed916b43cd4c21b2c4e433a77010e16299d6511bc8c4bb7562a1fb28", size = 2304469, upload-time = "2026-06-15T09:33:46.609Z" },
+]
+
+[[package]]
+name = "sherpa-onnx-core"
+version = "1.13.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/a0/7738c2731d3d1c34640850c72a375311b333971d62ef6ebb3e5876dd221c/sherpa_onnx_core-1.13.3-py3-none-macosx_10_15_universal2.whl", hash = "sha256:12e6d8b865b9772421c2b5866e161626fd3e84f546f8805f39a4abf93e22cdd2", size = 34077728, upload-time = "2026-06-15T08:22:28.489Z" },
+    { url = "https://files.pythonhosted.org/packages/13/35/28dec7a82884ec9da2781d894d73604fc597342a9462cbe0e942d155e03d/sherpa_onnx_core-1.13.3-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2de3c28baef9e2a386fde2e7c688caa129c73c0a4f15fb2d8442701f10b1192a", size = 18316542, upload-time = "2026-06-15T08:21:41.872Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5c/9846e0be70b704fa98918bfcbca904e64ed96b8d0eca5af7d938ef0f1157/sherpa_onnx_core-1.13.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:23efbad8af51c794fbd560622bdec5ece9b459d6d20b0a72de230701f9ec1cad", size = 21206052, upload-time = "2026-06-15T08:12:38.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/35/d1aa2deb0d137bb07f401def418968eedfe5dde32f56466c1f0ee5c90b98/sherpa_onnx_core-1.13.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4c913ef4e42d96e8081d51101d39913916e85d24c19f93e320b0723b84338a54", size = 12442037, upload-time = "2026-06-15T08:17:37.791Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/df59066fa1c4d979b6465742980038e674a44df11d03395d278d7ca5eaec/sherpa_onnx_core-1.13.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:98565b2158161da047f2a86d1ab794a8971389f2c96d77979f029478159ea93b", size = 9856010, upload-time = "2026-06-15T08:28:29.542Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b4/baeec0fc7ab1ef1a11ef33583f2a216d9d0b98ad1882e529c9ed718ef0ff/sherpa_onnx_core-1.13.3-py3-none-manylinux_2_35_armv7l.whl", hash = "sha256:b4c8f224630a572ffa49fb4414d57e01971393af08b3a9340636a6283d01a40a", size = 9513303, upload-time = "2026-06-15T10:07:31.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/71/0b70576a1d8279d2b3075364ad28c432e7851ea40e25803607b1415d59b7/sherpa_onnx_core-1.13.3-py3-none-win32.whl", hash = "sha256:783ef066a6a59a9509e1f93a24c3b847da37235166d19d76230131beb9895470", size = 13825606, upload-time = "2026-06-15T08:19:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6e/d4c239c7e143aa18b4354490f14bd1737b61e46b04ff42d0648d2193de1c/sherpa_onnx_core-1.13.3-py3-none-win_amd64.whl", hash = "sha256:c0422955d525244599c7d1b57198ff5c9644cec021bf82f7a1067bfe44c34966", size = 15765455, upload-time = "2026-06-15T08:17:04.117Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a **live, local dictation engine** built on **sherpa-onnx**, alongside the existing Whisper/NeMo path, plus the **"Voice" settings panel** from the design. The headline experience: you press the hotkey, talk, and words **type straight into the focused field as you speak** — self-correcting with backspaces when the streaming recognizer revises — committing per pause. sherpa-onnx is pure-ONNX on the CPU provider, so this default feature behaves identically on macOS, Windows, and Linux.

## What's in it

### Added
- **7 dictation models** wired to `csukuangfj/*` int8 HF repos (download-on-first-use via the existing model store): Parakeet TDT v3 (recommended default) / v2, streaming Zipformer EN/ZH/bilingual, streaming Paraformer bilingual, and multilingual Whisper Tiny — matching the mockup's tags/sizes exactly.
- **`SherpaDictationBackend`** + `services/sherpa_dictation.py` registry dispatching the four recognizer kinds (offline-transducer, offline-whisper, online-transducer, online-paraformer).
- **`/dictation/models`** and **`/dictation/prefs`** routes (enable / Toggle-Hold mode / selected model, persisted in prefs).
- **True streaming** over `/ws/transcribe`: streaming models run a sherpa `OnlineRecognizer` over raw int16 PCM frames, emitting live `partial`s and a `final` per silence-endpoint (the lightweight streaming zipformers run many× faster than real-time on CPU). Offline models surface partials via a short re-decode cadence.
- **"Voice" settings panel** (`VoicePanel.jsx`): enable toggle showing the real registered shortcut, Toggle/Hold control, and a model picker with `offline`/`streaming`/`recommended` badges, sizes, descriptions, and per-model download/delete reusing the existing model-store progress.
- **Live word-by-word typing**: new `simulate_type` Tauri command (enigo) driven by a prefix-diff delta + backspace correction in `CaptureWidget`, with the paste path retained as fallback and guarded against double-insertion.

### Changed
- `get_capture_asr_backend()` honors the selected dictation model. **`get_active_asr_backend()` (video-dub transcription) is untouched**, and the legacy WebM/Opus capture path is preserved byte-for-byte for non-sherpa engines — sherpa is never returned by auto-detect, so users who don't pick a sherpa model keep the existing behavior everywhere.

### Deps / build
- Adds `sherpa-onnx>=1.13.3` (+ `sherpa-onnx-core`); `uv.lock` regenerated with full mac/linux/win wheel coverage; Docker frozen-install verified. The desktop installer uses `uv sync --frozen` at runtime (not PyInstaller), so the native ONNX libs ship via the real wheel. API route-inventory snapshot updated.

## Testing
- **40+ new tests** (4 recognizer kinds, capture-backend selection, streaming partials-before-final ordering, dictation router, Voice panel, `computeTypeDelta`, prefs write-through) — all green.
- Regression-verified the shared ASR path: **dub transcription and every feature surface** (cloning, design, audiobooks, stories, transcription, dubbing) pass their suites unchanged.
- Launched the desktop app: cargo build clean (`simulate_type` compiled in), backend boots, and `/dictation/models` returns the correct 7-model list live.
- `cargo check`, `bun run build`, `bun run test` (629), `bun install --frozen-lockfile` (no changes) all pass.

## Notes
- Live-typing into other apps needs the same macOS Accessibility grant the existing paste command already uses.
- Default model (Parakeet v3) downloads ~180 MB on first selection; for live English partials, Zipformer Streaming EN is the lightest streaming option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds live, local voice dictation powered by `sherpa-onnx`, alongside the existing Whisper/NeMo transcription flow, including per-pause commits, live partials, backspace self-correction, and true streaming over `/ws/transcribe`.

```text
Before
Settings → Capture
  [Hotkey]
  [Dictation demo]

After
Settings → Capture
  [Hotkey]
  [Voice panel: Enable toggle | Toggle vs Hold | Speech model dropdown w/ install/delete + progress]
  [Dictation demo]
```

```text
Before (Capture widget)
  WebM/Opus recording path for dictation/transcription

After (Capture widget)
  Sherpa models: raw PCM websocket stream + word-by-word typing corrections (simulate_type), with paste fallback
  Non-sherpa: legacy Whisper/WebM capture path preserved
```

```mermaid
flowchart TD
  A[Start dictation] --> B[Hydrate dictation prefs + selected model]
  B --> C{Selected model is sherpa-onnx? (and backend available)}
  C -- no --> D[Legacy capture path: WebM/Opus → Whisper/etc transcription]
  C -- yes --> E[Open /ws/transcribe with model=&aec=&sr=16000]
  E --> F[Stream raw PCM frames to sherpa recognizer]
  F --> G[Emit partials while text changes]
  G --> H{Endpoint / pause?}
  H -- yes --> I[Emit final + engine metadata; classify vs commit]
  H -- no --> F
  I --> J[Type live corrections via simulate_type (backspaces+text) or paste fallback]
```

### What changed
- Added a **Voice** settings panel under **Settings → Capture**:
  - **Enable Voice Dictation** toggle
  - **Toggle vs Hold** mode
  - **Speech Model** dropdown for all **7** pinned `sherpa-onnx` dictation models, with inline **install/delete** and progress indicators.
- Added FastAPI routes:
  - `GET /dictation/models` (model metadata + installed/recommended status + availability)
  - `GET/POST /dictation/prefs` (persist enabled/mode/model_id; validates and normalizes ids)
- Implemented **SherpaDictationBackend** (`sherpa-onnx`) with:
  - CPU-focused streaming vs offline decode paths
  - Omnivoice-compatible normalization (`chunks/segments/language/text`)
  - Lazy recognizer construction + unload
- Updated websocket capture:
  - For sherpa models, `/ws/transcribe` now accepts **raw PCM** frames (optional AEC tag) and streams **partials/finals**; otherwise it keeps the existing Whisper/WebM path unchanged.
- Added Tauri IPC command **`simulate_type`** to support word-by-word live typing using backspaces + typed deltas (paste remains as fallback).
- Added extensive tests for:
  - dictation router contracts and prefs persistence/normalization
  - sherpa backend wiring + output normalization
  - websocket streaming protocol behavior (partial/final/EOF)
  - frontend VoicePanel rendering and CaptureWidget helper logic.

### Notes
- Includes `sherpa-onnx>=1.13.3` / `sherpa-onnx-core>=1.13.3` dependency updates and **regenerated `uv.lock`** (including frozen-install verification).
- Changelog/release notes updated to describe live dictation with **local streaming typing** rather than paste-on-pause.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->