### PR TITLE
docs(specs): ElevenLabs-parity roadmap + Tier-1 implementation specs

### DIFF
--- a/docs/specs/00-roadmap-elevenlabs-parity.md
+++ b/docs/specs/00-roadmap-elevenlabs-parity.md
@@ -1,0 +1,176 @@
+# OmniVoice → True ElevenLabs Alternative — Spec Roadmap
+
+This directory holds the implementation-ready specs that close the gap between
+OmniVoice Studio and ElevenLabs **without giving up what makes OmniVoice
+different**: fully local, no accounts, no API keys, no telemetry, 646 languages,
+cross-platform. The thesis is *counter-positioning*, not feature-cloning — we
+match the capabilities creators actually feel, and we win on "your voice never
+leaves your machine."
+
+## The thesis
+
+ElevenLabs' moat is **perceived voice quality + expressive control**, and its
+2025-26 expansion is **voice agents**. Everything else (library, studio editor,
+dubbing depth, API) is table-stakes polish. OmniVoice already has the hard parts
+— multi-engine TTS/ASR, cloning, design, dubbing, live dictation, an MCP server,
+a local-LLM adapter, streaming TTS, echo cancellation. The gap is mostly **the
+last mile of control and polish on top of infrastructure that already exists.**
+
+## Gap analysis
+
+| ElevenLabs capability | OmniVoice today | Spec that closes it |
+|---|---|---|
+| Expressive/emotional delivery (v3 audio tags) | Voice *design* attributes only; no per-utterance emotion | **01 — Expressive TTS** |
+| Pronunciation dictionaries (IPA/phoneme) | `pronunciation.py` alias/respell, not user-editable/persisted | **01 — Expressive TTS** |
+| Conversational AI / voice agents | Pieces exist (streaming STT+TTS, local LLM, AEC) but no loop | **02 — Conversational Agent** |
+| Projects / Dubbing Studio (per-line regen, edit transcript/translation, reassign speaker) | Dub already content-addresses segments; longform caches only per-chapter; no unified editor | **03 — Long-form Studio Editor** |
+| Voice Library / shareable voices / marketplace | Local profiles only; no portable/shareable format | **04 — Voice Packs (local library)** |
+| Streaming latency (Flash ~75ms) + SDKs | Streaming TTS exists; latency + API/SDK ergonomics unbenchmarked | **05 — Streaming latency + API/SDK parity** |
+| Voice Isolator (denoise), Sound Effects | Demucs is in the dub stack; not exposed as tools | **06 — Audio cleanup + Sound FX** |
+| Accounts, cloud sync, hosted marketplace, usage analytics | *(none — intentionally)* | **Won't build** (see below) |
+
+## The specs
+
+### Tier 1 — the moat-closers (highest leverage)
+
+- **[01 — Expressive TTS](01-expressive-tts.md)** — engine-agnostic emotion/style
+  intent (inline tags + controls) *lowered* onto each engine's real mechanism
+  (OmniVoice `instruct`, CosyVoice NL-instruct/`[laughter]`, IndexTTS2 emotion
+  vector, VoxCPM2 prefix), degrading **visibly** never silently; plus a
+  user-editable, per-language, DB-persisted **pronunciation dictionary** (IPA/CMU/
+  respell) applied pre-synthesis. Builds on `services/ssml_lite.py`,
+  `services/pronunciation.py`, `services/longform_parser.py`. Adds
+  `services/expression.py`, `api/routers/pronunciation.py`, alembic 0008.
+  *Status: spec complete, 5 shippable slices.*
+
+- **[02 — Conversational Agent](02-conversational-agent.md)** — fully-offline
+  full-duplex voice assistant: VAD → streaming STT → local LLM → streaming TTS
+  with **barge-in** (Silero VAD on AEC-cleaned mic) and a single server-side
+  `/ws/converse` orchestrator. Reuses `capture_ws.py` streaming ASR, `tts_stream.py`,
+  `aec.py`, `llm_backend.py` (Ollama/OpenAI-compat), `mcp_server.py`. Opt-in;
+  half-duplex/push-to-talk fallback on weak hardware. *Status: spec complete, 6 slices.*
+
+- **[03 — Long-form Studio Editor](03-longform-studio-editor.md)** — per-segment
+  edit / **regenerate-one-line** / reassign-voice / per-segment emotion / timing,
+  across dubbing, audiobooks, stories. Dubbing already content-addresses segments
+  (`incremental.py`, `regen_only`, `seg_hashes`); the spec extends that **span-level
+  cache to longform** (which today only caches per-chapter) and unifies the editor
+  UX. *Status: spec complete, 6 slices, no alembic needed.*
+
+### Tier 2 — ecosystem & developer parity (drafts — expand before implementation)
+
+- **04 — Voice Packs (local Voice Library).** A portable, importable voice-pack
+  format (profile + reference + design `instruct` + pronunciation overrides +
+  license/attribution, signed/hashed) and an **import/export** flow, plus an
+  opt-in community **GitHub index** (a JSON manifest repo, not a hosted service)
+  the app can browse and pull from. Local-first replacement for the marketplace:
+  creators share packs as files/links; nothing is hosted by us. *Touchpoints:*
+  voice profile storage, `omnivoice_data/`, the model-store download UI pattern.
+  *Open: pack schema, signing/trust, NSFW/abuse stance on the index.*
+
+- **05 — Streaming latency + API/SDK parity.** Honest benchmark of streaming TTS
+  **time-to-first-audio** and real-time-factor per engine/device, a latency
+  budget, and a documented **OpenAI-compatible + native streaming HTTP/WS API**
+  with thin Python/JS SDK wrappers so developers can drop OmniVoice in where they
+  used ElevenLabs. *Touchpoints:* `tts_stream.py` (`/ws/tts`), the MCP server, the
+  generate path. *Open: which engines get the low-latency "Flash-class" path; SDK
+  surface; OpenAI `/v1/audio/speech` compatibility scope.*
+
+- **06 — Audio cleanup + Sound FX.** Expose **Voice Isolator** (vocal/denoise via
+  the Demucs already vendored in the dub stack) and a **text-to-sound-effects**
+  generator as first-class tools (and MCP tools), reusing existing audio I/O.
+  *Touchpoints:* the dub separation stage, `services/audio_dsp.py`, MCP. *Open:
+  which local SFX model; scope vs. core TTS focus (likely lowest priority).*
+
+## Dependencies & recommended sequencing
+
+```
+01 Expressive TTS ──► (emotion/style field) ──► 03 Studio Editor (per-segment emotion)
+        │
+        └──► 02 Conversational Agent (expressive replies)
+02 reuses: 01's streaming TTS quality + the existing live-dictation STT
+05 (API/latency) underpins 02's "feels real-time" and is independently shippable
+04 / 06 are independent and can slot in anytime
+```
+
+Recommended order on the v0.3.x line (each spec is already sliced so early slices
+ship value without the whole feature):
+1. **01 Expressive TTS** — biggest perceived-quality win, unblocks 03's emotion-
+   per-segment and 02's expressive replies. Start with the pronunciation
+   dictionary slice (fast, high-trust) + inline emotion tags.
+2. **03 Studio Editor** — the dub transcript-edit + single-line-regen slice is
+   small (the cache already exists) and immediately feels "pro."
+3. **02 Conversational Agent** — the headline new *category*; ship half-duplex
+   first, then barge-in. Pair with the 05 latency benchmark.
+4. **05 / 04 / 06** — as capacity allows; 05 makes OmniVoice a real developer
+   drop-in, 04 builds community gravity, 06 is breadth.
+
+## Cross-cutting principles (every spec obeys these)
+
+- **Local-first, always.** No cloud calls, accounts, or keys on any default path.
+  New capabilities run on-device; "share" means files/links the user controls.
+- **Cross-platform default parity (hard rule).** Default behavior identical on
+  macOS / Windows / Linux; anything platform-specific is opt-in (Settings toggle,
+  env var, CLI flag). CPU-capable baselines everywhere.
+- **Back-compat (hard rule).** Existing engines, on-disk model state, and
+  `omnivoice_data/` keep working with no forced reinstall or re-render; schema
+  changes go through tested alembic upgrades.
+- **Sliceable onto v0.3.x.** No big-bang merges, no v0.4 deferrals — every spec is
+  decomposed into independently-shippable slices with fail-before/pass-after tests.
+- **Degrade visibly.** When an engine/host can't do something (an emotion an
+  engine lacks, latency on weak hardware), tell the user — never fail silently or
+  fake it.
+
+## What we deliberately will NOT build
+
+Accounts, login, cloud sync, a hosted voice marketplace, server-side rendering,
+and usage analytics/telemetry are ElevenLabs *features* that are **anti-features**
+for a local-first tool. We don't measure parity against them. "Fully local, no
+keys, 646 languages, free, your voice never leaves your machine" is the
+counter-position — these specs make OmniVoice match ElevenLabs on the things
+creators feel, while staying on the right side of that line.
+
+## Prior art & reconciliation
+
+This roadmap (00 + 01–03) is the single source of truth for the ElevenLabs-parity
+program as of **2026-06-25**. The table below classifies every pre-existing spec in
+`docs/specs/` against it: **(S) Superseded** — substantial overlap, the new specs
+are more current/grounded (a banner now points here); **(F) Folded-in** — distinct,
+still-valuable detail referenced from the new specs; **(K) Keep as-is** — distinct
+scope, no parity overlap, left untouched.
+
+| Pre-existing doc | Class | Disposition |
+|---|---|---|
+| `2026-06-12-elevenlabs-parity-program.md` | **S** | The previous parity roadmap. Its waves are reorganized into Tier 1/2 here; 01 explicitly carries forward its "perceived-quality half." Banner added. |
+| `2026-06-13-stories-audiobook-maturity.md` | **S** | Stories/Audiobook convergence + maturity. Its "one shared chapterized render core" and per-line/incremental asks are absorbed by **03** (longform Studio editor + span-level cache). Banner added. |
+| `studio-v1.md` | **S** | Long-form block editor v1 (paste→split→assign→stitch). Subsumed by **03**'s unified longform editor across Dub/Audiobook/Stories. Banner added. |
+| `voice-console-10x.md` | **K** | Voice-workspace *UI polish* (pinned action bar, identity line, a11y). No parity-capability overlap; left as-is. |
+| `voice-studio-unification.md` | **K** | Clone+Design → one "Voice" workspace + data-model unification. UI/IA scope, not parity capability. Left as-is. |
+| `workspace-connectivity.md` | **K** | Navigation IA + universal "Use in ▸" handoff + transcripts-to-backend. Cross-workspace plumbing, distinct scope. Left as-is. |
+| `2026-05-29-v0.3.0-stabilization-sweep.md` | **K** | Stabilization/bug-cluster + review/security gate program. Orthogonal to parity. Left as-is. |
+| `longform/` (#21–#34) | **F** | Granular per-task implementation specs (tied to tasks #21–34). Their capabilities feed the new specs: incremental/longform render → **03**; `.ovsvoice` (#29) → **04 Voice Packs**; ACX two-pass mastering (#28), EPUB/m4b export (#24/#30), transcriptions import (#23), shared voice selector (#22) → the longform editor + Voice Library work; phone calls (#32) → the **deliberately deferred** telephony note (gated on guardrails). Retained as the detailed build specs. |
+
+### Salvaged ideas now referenced (don't lose these)
+
+Concrete deliverables in the pre-existing docs that the new 01–03 did **not** already
+surface, captured here so they aren't dropped:
+
+- **GPU-compat preflight — "no silent CPU fallback"** (`longform/21-gpu-compat-matrix.md`). A
+  canonical device-family probe + per-engine *effective device*/routing status, surfaced at
+  engine-select and **every** synth entry point with an explicit warning when the active engine
+  can't use the user's GPU. This is the concrete enforcement of this roadmap's "degrade visibly"
+  principle and a "first-run that actually works" win — fold into the platform-robustness track.
+- **Standalone `.txt` chapter cue-sheet export** (`longform/33-cue-sheet-export.md`). A
+  human-readable `HH:MM:SS<TAB>Title` cue sheet for the longform front doors (for mp3/show-notes/
+  YouTube chapters), reusing existing `formatTimecode`/`buildCueSheet` helpers — no backend change.
+  A small, high-value nicety for **03**'s longform editor surfaces.
+- **Consent-locked voice profiles + AudioSeal watermarking on agentic/shared output**
+  (parity-program items 0.2/5.3/5.4; `longform/29-ovsvoice-format.md`, `longform/32-phone-calls.md`).
+  The consent/attestation + watermark guardrail is a hard prerequisite for **04 Voice Packs**
+  (sharing) and **02**'s agentic output (EU AI Act Art 50, applies 2026-08-02). The new specs assume
+  local-first sharing but don't yet spell out the consent-lock/watermark gate — it must land **with**
+  04 and any agentic-output path, not as a follow-up.
+- **Two-pass ACX loudness mastering + chaptered m4b/cover/metadata** (`2026-06-13-stories-audiobook-maturity.md`,
+  `longform/28-two-pass-acx-mastering.md`, `#24`). The audiobook-grade mastering/packaging detail lives
+  in those specs; **03** assumes the shared longform render core exists and should consume this rather
+  than re-specify it.

--- a/docs/specs/01-expressive-tts.md
+++ b/docs/specs/01-expressive-tts.md
@@ -1,0 +1,308 @@
+# Spec 01 — Expressive TTS: emotion/style direction + pronunciation control
+
+**Date:** 2026-06-25
+**Status:** Proposed
+**Target line:** v0.3.x (continuous-to-main; no RC, no deferral to v0.4)
+**Related:** `docs/specs/2026-06-12-elevenlabs-parity-program.md` (this is the "perceived-quality" half that program left open), issues #674/#679 (design-mode profile_id handling).
+
+---
+
+## 1. Context & Problem (gap vs ElevenLabs)
+
+The #1 perceived-quality gap users report vs ElevenLabs is **expressive delivery**. ElevenLabs v3 ships two things we don't expose coherently:
+
+1. **Audio tags** — inline square-bracket performance cues (`[excited]`, `[whispers]`, `[sigh]`, `[laughs]`) that steer emotion/tone *mid-line*, plus situational/reaction tags ([ElevenLabs v3 audio tags](https://elevenlabs.io/blog/eleven-v3-audio-tags-expressing-emotional-context-in-speech), [help: how audio tags work](https://help.elevenlabs.io/hc/en-us/articles/35869142561297-How-do-audio-tags-work-with-Eleven-v3)).
+2. **Pronunciation dictionaries** — per-term rules with **phoneme** (IPA/CMU via SSML `<phoneme>`) and **alias** (respelling) entries, checked start-to-end, first match wins, case-sensitive ([ElevenLabs pronunciation dictionaries](https://elevenlabs.io/docs/eleven-api/guides/how-to/text-to-speech/pronunciation-dictionaries)).
+
+**What we already have (and must reuse, not reinvent):**
+
+- `backend/services/ssml_lite.py` — inline `[slow]/[fast]/[emphasis]/[spell]` tags → ordered prosody segments `{text, speed, spell, emphasis}`. ReDoS-safe fixed-alternation regex. Already wired into `longform_parser.py`.
+- `backend/services/pronunciation.py` — `apply_lexicon(text, {term: respelling})`: whole-word, case-insensitive, longest-key-first, word-boundary aware, ReDoS-safe single-pass `re.sub`. **This is the alias-rule engine; it has no DB persistence and no IPA path yet.** Used today only by audiobook (`services/audiobook.py:119`, `api/routers/audiobook.py`).
+- `backend/services/longform_parser.py` — the canonical grammar: precedence `# chapter → [voice:NAME] → [pause] → SSML-lite → [spell]`. JS twin `frontend/src/utils/longformParser.js`, golden corpus `tests/fixtures/longform_parser_cases.json`. **This is where multi-voice `[voice:NAME]` story tags live — our new emotion tags must not collide with it.**
+- `backend/services/chunked_tts.py` — sentence-boundary splitter that already **refuses to cut inside `[...]` bracket tags** (`_BRACKET_TAG_RE`, line 43). New tags inherit that protection for free.
+- `omnivoice.utils.text.parse_pause_markers` — `[pause Nms]` span splitter, consumed in `generation.py:224`.
+
+**What's missing / the gap:**
+
+- No way to direct **emotion** at all from the Studio generate path. The only "style" the **OmniVoice base model** accepts is the validated `instruct` taxonomy (Gender/Age/Pitch/**Style=whisper only**/Accent/Dialect) — confirmed in `core/describe_voice.py` and the engine's `omnivoice/utils/voice_design.py` validator. The base model **does not** take `[happy]`/`[sad]` ([k2-fsa/OmniVoice issue #78 — Emotion/Tone](https://github.com/k2-fsa/OmniVoice/issues/78)); only a finetune does.
+- The capable engines express emotion **very differently**: CosyVoice 3 via natural-language instruct `…<|endofprompt|>` + inline `[laughter]`/`[breath]`/`<strong>` ([CosyVoice 3 paper](https://arxiv.org/html/2505.17589v1)); IndexTTS2 via an **8-dim emotion vector** `[happy,angry,sad,afraid,disgusted,melancholic,surprised,calm]` or an emotion-reference clip ([IndexTTS2](https://indextts.ai/), [arXiv 2506.21619](https://arxiv.org/html/2506.21619v2)); VoxCPM2 via a `(instruct)text` prefix (`tts_backend.py:423`).
+- The lexicon is project-local JSON only — no global, no per-language, no DB persistence, no UI, no IPA/phoneme path, no inline one-off override.
+
+**Design principle:** one engine-agnostic *intent* surface (tags + sliders + dictionary) that **lowers** to whatever each engine can actually do, and **degrades visibly** (never silently) where it can't.
+
+---
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- G1. Inline emotion/style tags in the generate text — `[excited]`, `[whispers]`, `[sad]`, `[shouting]`, `[laughs]`, … — parsed into per-span *expression intent*, composing cleanly with existing `[voice:]`/`[pause]`/SSML-lite/`[spell]`.
+- G2. A non-inline alternative for users who don't want to learn tags: an **Expression** panel on the generate/Studio UI (emotion dropdown + intensity slider + optional **emotion-reference clip** picker) that sets a per-render default.
+- G3. Per-engine **capability matrix** that maps expression intent → the engine's real mechanism, surfaced in the UI so users know what their selected engine will honor before they hit generate.
+- G4. A user-editable **pronunciation dictionary** persisted in the DB (global + per-language scope), with **alias** (respelling) and **phoneme** (IPA/CMU) entry types, applied at synth time before the model, plus inline one-off overrides.
+- G5. Backward-compatible: existing engines, on-disk profiles, the project-local audiobook lexicon JSON, and plain (tag-free) text all keep working byte-identically.
+- G6. Local-first, identical default behavior on macOS/Windows/Linux.
+
+**Non-goals**
+
+- N1. Per-phoneme prosody curves / full SSML (`<prosody>`/`<break>` trees). SSML-lite + `[pause]` stay our prosody surface.
+- N2. Training/finetuning an emotion model. We expose what shipped engines already do; the OmniVoice base model's emotion ceiling is its instruct taxonomy, and we say so.
+- N3. A learned text→emotion classifier in the base path (IndexTTS2's own T2E module is used when *that* engine is active; we don't build a global one).
+- N4. Auto-generating IPA from spelling (no g2p engine bundled in this spec — see Open Questions Q4).
+
+---
+
+## 3. User Experience (UI + flows)
+
+### 3.1 Inline expression tags (power path)
+
+In the Studio / generate text box the user writes:
+
+```
+[excited] We did it! [pause 400ms] [whispers] ...but don't tell anyone.
+```
+
+- Tags are stripped from spoken text and turned into per-span intent.
+- Tags compose with multi-voice stories: `[voice:Morgan] [angry] Get out. [voice:Sam] [nervous] O-okay.` — `[voice:]` switches narrator (existing), `[angry]`/`[nervous]` set that span's emotion.
+- An **"⊕ Insert"** popover (reusing the existing clone-tab insert popover pattern, #672) lists available tags **filtered to what the active engine supports**, with a tooltip showing the lowering ("`[excited]` → CosyVoice instruct / IndexTTS2 emo-vector / OmniVoice: not supported, ignored").
+- Unsupported-on-this-engine tags render with a subtle strikethrough chip and a one-line banner: *"OmniVoice ignores emotion tags — switch to CosyVoice 3 or IndexTTS2 for emotional delivery."* (never silent; mirrors the routing-banner convention from `engine_routing.py`).
+
+### 3.2 Expression panel (no-tags path)
+
+A collapsible **Expression** section under the generate controls:
+
+- **Emotion** dropdown: Neutral (default) / Happy / Sad / Angry / Afraid / Surprised / Calm / Whisper / Shout. Maps to the engine's mechanism (sliders for IndexTTS2; instruct phrase for CosyVoice/VoxCPM; whisper-only for OmniVoice).
+- **Intensity** slider 0–100 (default 50). Only enabled when the active engine supports graded intensity (IndexTTS2 emo-vector magnitude); otherwise greyed with a tooltip.
+- **Emotion reference** (optional): pick a short clip whose *delivery* (not timbre) is mimicked. Enabled only for engines with an emotion-ref path (IndexTTS2). This is **separate** from the voice-clone `ref_audio` — same control style, different slot.
+- A live **"This engine will: …"** line shows the resolved lowering, so the panel doubles as the capability disclosure.
+
+The panel sets request-level defaults; inline tags override per span (tag wins, same precedence rule as SSML-lite speed).
+
+### 3.3 Pronunciation dictionary (Settings → Voice → Pronunciation)
+
+A new **PronunciationPanel** (sibling of `VoicePanel.jsx`):
+
+- A table of entries: **Term** | **Scope** (Global / language) | **Type** (Respelling / IPA / CMU) | **Replacement** | **Enabled**.
+- Add/edit/delete rows; inline validation (IPA charset check; CMU ARPABET token check). Bad phoneme strings flagged before save, not at synth time.
+- A **"Test"** field: type a sentence, see the post-substitution text (and, for phoneme rows, the `[[…]]` markup that will be handed to the engine) — no model call needed.
+- Import/Export JSON (round-trips the existing audiobook lexicon shape, so a project lexicon can be promoted to global).
+
+### 3.4 Inline one-off pronunciation override
+
+Within text: `She lives on [[ˈnɛvʌdə]] street` (IPA in double brackets) or `[[Nuh-VAD-uh]]` (respelling). Applies once, overrides any dictionary entry for that occurrence. Chosen `[[…]]` because single `[...]` is already emotion/voice/pause tags — double brackets are unambiguous and don't collide.
+
+---
+
+## 4. Technical Design
+
+### 4.1 Architecture overview
+
+Two independent, composable layers, both **pure/CPU/stdlib** at the parse stage (model-free, unit-testable, cross-platform-identical):
+
+```
+text + request expression defaults
+        │
+        ▼
+[A] expression parse  ── extends services/longform_parser.py grammar:
+        # chapter → [voice:NAME] → [emotion] → [pause] → SSML-lite → [spell] → [[pronounce]]
+        │            (new layer, slotted between voice and pause)
+        ▼
+spans: {voice_id, text, pause_ms_after, speed, expression}   ← expression added
+        │
+        ▼
+[B] pronunciation apply  ── services/pronunciation.py (extended):
+        apply_pronunciation(span.text, dict, language) → text with aliases substituted
+        + [[…]] inline overrides resolved to engine phoneme markup or respelling
+        │
+        ▼
+[C] expression lowering  ── services/expression.py (NEW):
+        lower(expression, engine_id) → engine-specific kwargs
+        (instruct phrase | emo_vector | emo_ref | whisper | <none>)
+        │
+        ▼
+TTSBackend.generate(text, instruct=…, **expression_kwargs)
+```
+
+### 4.2 Files to add / extend (real paths)
+
+**Add**
+
+- `backend/services/expression.py` — the expression vocabulary + lowering. Pure, model-free. Defines:
+  - `EXPRESSIONS` — canonical emotion set `{neutral, happy, sad, angry, afraid, surprised, calm, whisper, shout, laugh, sigh}` (the cross-engine intersection; superset of OmniVoice's `whisper`).
+  - `Expression` dataclass `{emotion: str, intensity: float, ref_audio: str|None}`.
+  - `parse_expression_tags(text) -> list[(text, Expression|None)]` — splits a line on `[emotion]`/`[/emotion]` tags using the **same fixed-alternation, ReDoS-safe regex shape** as `ssml_lite.py` (`_TAG_RE`), tags drawn from `EXPRESSIONS`. Unknown bracket tokens are left **untouched** so they pass through to SSML-lite / `[voice:]` / `[pause]` — no grammar overlap.
+  - `lower(expr, engine_id) -> dict` — the capability matrix in code (see 4.4). Returns kwargs to merge into `generate()`; returns `{}` + a `degraded` note for engines that can't honor it.
+- `backend/api/routers/pronunciation.py` — CRUD for dictionary entries + `/pronunciation/test` (dry-run substitution, no model). Registered in `backend/main.py` alongside the other routers.
+- `frontend/src/components/settings/PronunciationPanel.jsx` (+ `.css`, + `.test.jsx`).
+- `frontend/src/utils/expressionTags.js` — JS twin of `parse_expression_tags` (mechanically mirrored, same golden corpus, exactly like `longformParser.js`).
+- `backend/migrations/versions/0008_pronunciation_dictionary.py` — alembic migration (see §5.3).
+
+**Extend**
+
+- `backend/services/longform_parser.py::_parse_chapter_body` — insert the expression layer between `[voice:]` runs and the existing pause/SSML loop. Each emitted span gains an `expression` key (default `None`). The `Span` dataclass / `to_dict()` and the JS twin update in lockstep; `tests/fixtures/longform_parser_cases.json` gains expression cases.
+- `backend/services/ssml_lite.py` — **no change to its grammar**; expression parsing runs as a sibling layer above it. `[whisper]` is handled by expression (engine-level), distinct from SSML-lite's prosody — documented so they don't drift.
+- `backend/services/pronunciation.py` — add:
+  - `apply_pronunciation(text, entries, language)` — alias substitution (delegates to existing `apply_lexicon` for respelling rows) **plus** phoneme rows lowered to the active engine's phoneme markup; per-language filtering (global rows always apply; language rows apply when `language` matches or is `Auto`).
+  - `parse_inline_pronunciation(text, engine_id)` — resolve `[[…]]` overrides (IPA/CMU/respelling autodetected by charset) to engine markup or plain respelling, ReDoS-safe `\[\[[^\]]*\]\]`.
+  - `load_dict_from_db()` / `save_dict_to_db()` — DB-backed counterpart to the existing JSON `load_lexicon`/`save_lexicon` (which stay for the audiobook project-local path).
+- `backend/api/routers/generation.py::generate_speech` — accept `expression`, `expression_intensity`, `expression_ref` (Form fields) and a `pronounce: bool` toggle (default ON). Thread them through `_run_inference` / `_run_backend_inference` so the lowering kwargs reach `model.generate()` / `backend.generate()`. Pronunciation applied **per chunk before** `split_text_into_chunks`, mirroring `services/audiobook.py:124`.
+- `backend/services/tts_backend.py` — extend the `generate(**extras)` contract with optional `emo_vector`, `emo_ref`, `emotion` kwargs. The ABC already takes `**extras`, so **no signature break**; each backend reads the kwargs it understands and ignores the rest (the existing graceful-degradation idiom, e.g. KittenTTS/MOSS at lines 510–527). Per-engine `generate()` bodies updated for CosyVoice (fold emotion into the `inference_instruct2` prompt), VoxCPM2 (`(instruct)` prefix), IndexTTS2 (`emo_vector`/`emo_ref` — its module in `engines/indextts/`).
+- A new class attribute on `TTSBackend`: `expression_caps: dict` (e.g. `{"mode": "instruct"|"emo_vector"|"emo_ref"|"whisper_only"|"none", "emotions": [...]}`), defaulting to `{"mode":"none"}`. `list_backends()` surfaces it next to `gpu_compat` so the UI can filter tags/sliders per engine without a model load.
+
+### 4.3 Data flow & composition (no collisions)
+
+Grammar precedence (extends `longform_parser.py:10`):
+
+```
+# chapter  →  [voice:NAME]  →  [emotion]  →  [pause]  →  SSML-lite  →  [spell]  →  [[pronounce]]
+```
+
+- `[voice:NAME]` (existing, `_VOICE_RE`) is matched first → switches narrator. Emotion tags live **inside** a voice run, so `[voice:Sam]` and `[angry]` never compete for the same token.
+- `[emotion]` tags are a **closed set** drawn from `EXPRESSIONS`; the regex only matches those literals, so a stray `[whatever]` is not consumed and flows to the lower layers (or out as literal text). This is the same closed-alternation safety `ssml_lite.py` relies on.
+- `[pause Nms]`, SSML-lite, `[spell]` are unchanged and parse *within* an emotion span — emotion is an outer attribute, prosody/speed inner, exactly like the current voice→pause→ssml nesting.
+- `[[pronounce]]` (double bracket) is resolved last, after tag stripping, so it can't be confused with single-bracket tags. `chunked_tts._BRACKET_TAG_RE` already protects single `[...]`; we widen it (or add a sibling) to also never split inside `[[...]]`.
+
+**Tag-vs-text disambiguation rule (the load-bearing invariant):** a `[token]` is consumed by a layer **iff** `token` (case-insensitive) is in that layer's closed vocabulary (`EXPRESSIONS`, SSML-lite `_TAGS`, `voice:`-prefixed, or `pause …`). Everything else is literal. This is asserted by the shared golden corpus against both Python and JS parsers.
+
+### 4.4 Per-engine capability matrix (`expression.lower`)
+
+| Engine (`id`) | Mechanism | emotion | intensity | emo-ref | How `lower()` maps it |
+|---|---|---|---|---|---|
+| `omnivoice` (base) | `instruct` taxonomy, **Style=whisper only** | whisper only | no | no | `[whispers]` → append `whisper` to instruct (validator-safe via existing `heal_design_instruct`). All other emotions → `degraded`, banner shown. |
+| `cosyvoice` | NL instruct `…<\|endofprompt\|>` + inline `[laughter]`/`[breath]`/`<strong>` | full set | coarse (phrasing) | no | emotion → instruct phrase ("speak in an excited tone") merged into `inference_instruct2`'s instruct arg (`tts_backend.py:846`). `[laughs]`/`[sigh]` → CosyVoice's own `[laughter]`/`[breath]` literals injected into text. |
+| `indextts2` | 8-dim **emo_vector** + emo-ref + text-infer | full set | **yes (0–1)** | **yes** | emotion+intensity → one-hot-ish 8-vector scaled by intensity; emo-ref → `emo_audio` path. (`engines/indextts/`.) |
+| `voxcpm2` | `(instruct)text` prefix | full set | coarse | no | emotion → `(speak excitedly)` prefix (`tts_backend.py:423`). |
+| `kittentts`, `sherpa-onnx`, `gpt-sovits`, `mlx-audio`(varies), `moss-tts-nano`, `supertonic3` | none / preset | — | — | — | `lower()` → `{}` + `degraded`; tags stripped, text spoken neutrally. Banner: *"This engine has no emotion control."* |
+
+`lower()` is the single source of truth for this table; `list_backends()['expression_caps']` is derived from the same constants so UI and synth never disagree (the `describe_voice.py` import-time-validation discipline — a missing/renamed capability fails loudly in a test, not at synth).
+
+### 4.5 Pronunciation lowering
+
+- **Respelling (alias) rows** → existing `apply_lexicon` (already correct: longest-first, boundary-aware, ReDoS-safe). Works on **every** engine — it's just text substitution.
+- **Phoneme rows (IPA/CMU)** → engine phoneme markup where supported (e.g. CosyVoice/sherpa-onnx models with a phoneme front-end), else **graceful fallback to the respelling** if the row also has one, else passed through and flagged "phoneme not honored on this engine" (parity-rule: visible degradation). No engine is *broken* by a phoneme row; worst case it's spoken as the literal grapheme.
+- Per-language: global rows always apply; language-tagged rows apply when request `language` matches (or is `Auto`). Matching is case-insensitive on the 2-letter prefix, consistent with `CosyVoiceBackend.LANG_TAGS` handling.
+
+---
+
+## 5. API / Schema / Data-model changes
+
+### 5.1 Endpoints
+
+- `POST /generate` (extend, `generation.py`): new optional Form fields
+  - `expression: str = Form("")` — emotion name or `""`/`neutral`.
+  - `expression_intensity: float = Form(50, ge=0, le=100)`.
+  - `expression_ref: UploadFile = File(None)` — emotion reference clip (engines that support it).
+  - `pronounce: bool = Form(True)` — apply the pronunciation dictionary.
+  Omitting all of them = byte-identical legacy behavior.
+- `GET /pronunciation` → `[{id, term, scope, type, replacement, enabled, language}]`.
+- `POST /pronunciation` / `PUT /pronunciation/{id}` / `DELETE /pronunciation/{id}` — CRUD with server-side IPA/CMU validation.
+- `POST /pronunciation/test` → `{input} → {substituted, phoneme_markup}` (no model).
+- `GET /engines/tts` (existing `list_backends`) gains `expression_caps` per entry. No new endpoint.
+
+### 5.2 Prefs / settings
+
+- New pref key `pronunciation_enabled` (default `true`) via `core/prefs.py` (`prefs.resolve`, env `OMNIVOICE_PRONUNCIATION` for power-users) — same pattern as `tts_backend`.
+- Expression defaults are per-request, not persisted globally (a render-time choice, like `effect_preset`).
+
+### 5.3 Alembic migration (additive, idempotent — sketch)
+
+`backend/migrations/versions/0008_pronunciation_dictionary.py`, `down_revision="0007_rebuild_poisoned_design_instruct"`. Follows the 0004 idempotent-guard pattern exactly.
+
+```python
+revision = "0008_pronunciation_dictionary"
+down_revision = "0007_rebuild_poisoned_design_instruct"
+
+def _has_table(name):  # same helper as 0004
+    bind = op.get_bind()
+    return bind.execute(sa.text(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=:n"),
+        {"n": name}).fetchone() is not None
+
+def upgrade():
+    if _has_table("pronunciation_entries"):
+        return
+    op.create_table(
+        "pronunciation_entries",
+        sa.Column("id", sa.Text(), primary_key=True),
+        sa.Column("term", sa.Text(), nullable=False),
+        sa.Column("replacement", sa.Text(), nullable=False, server_default=""),
+        sa.Column("type", sa.Text(), nullable=False, server_default="respelling"),  # respelling|ipa|cmu
+        sa.Column("language", sa.Text(), nullable=False, server_default="*"),        # '*' = global
+        sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.Float(), nullable=True),
+    )
+    op.create_index("idx_pron_lang", "pronunciation_entries", ["language"])
+
+def downgrade():
+    if _has_table("pronunciation_entries"):
+        op.drop_table("pronunciation_entries")
+```
+
+**Critically:** the same table must also be added to `core/db.py::_BASE_SCHEMA` as `CREATE TABLE IF NOT EXISTS pronunciation_entries (...)` so fresh installs and the `_reconcile_additive_columns` safety net converge on the identical end-state (the dual-path discipline already documented in `db.py:140`). The audiobook project-local JSON lexicon (`load_lexicon`/`save_lexicon`) is **untouched** — it remains the per-project override; DB entries are the global/default layer, merged dict-style (project JSON wins on key conflict, longest-first preserved).
+
+---
+
+## 6. Local-first & cross-platform compliance
+
+- **No cloud.** Parsing, lexicon, and lowering are pure Python/stdlib + JS — zero network, zero model for the control plane. Emotion is realized entirely by the **already-on-device** engine the user selected; IPA/CMU validation is charset/table-based (no g2p service).
+- **Default-parity (strict 2026-05-20 rule).** The *default* path — emotion tags, the dictionary, `[[…]]` overrides — behaves identically on macOS/Windows/Linux because it's pure text transformation guarded by the shared golden corpus run on both the Python and JS parsers. `longform_parser._normalize` already CRLF-normalizes, so Windows-authored scripts parse identically. **Engine-specific** emotion fidelity differs by engine (a property of the engine, not the platform) and is disclosed in the capability matrix UI — this is allowed because the *user-visible default behavior of the feature* (tags parse, dictionary applies, degradation is shown) is identical everywhere; only the opt-in *engine* changes what's honored.
+- No platform-only tag or shortcut. The "⊕ Insert" popover and panels are the same component on every OS.
+- Emotion-reference clip is processed on-device by the same engine path as voice refs; privacy unchanged (never uploaded, scrubbed from any bug report per CLAUDE.md capture rules).
+
+---
+
+## 7. Phasing (each slice lands independently on v0.3.x)
+
+- **Phase 1 — Pronunciation dictionary (DB + UI).** Migration 0008 + `_BASE_SCHEMA` row + `pronunciation.py` extensions (`apply_pronunciation`, DB load/save, per-language) + `/pronunciation` router + `PronunciationPanel`. Wires into `/generate` (`pronounce` toggle) and reuses the existing audiobook apply-site. **Respelling rows only** in this phase (alias rules work on every engine). Ships value immediately, zero engine risk.
+- **Phase 2 — Inline `[[pronounce]]` overrides + IPA/CMU rows.** Phoneme validation + engine-markup lowering for the engines that have a phoneme front-end; respelling fallback elsewhere. Widen `chunked_tts` bracket guard for `[[…]]`.
+- **Phase 3 — Expression engine + lowering.** `services/expression.py` + `expression_caps` on backends + `lower()` for CosyVoice/VoxCPM2/IndexTTS2/OmniVoice-whisper. `/generate` Form fields + `_run_*_inference` threading. No UI yet (API + tags usable headless/MCP).
+- **Phase 4 — Inline emotion tags in the grammar.** Extend `longform_parser` + JS twin + golden corpus; `[emotion]` spans flow through audiobook/story/Studio. This is the collision-sensitive change, landed only after Phase 3's vocabulary is stable.
+- **Phase 5 — Expression panel UI** (dropdown + intensity + emo-ref picker + "this engine will…" line + per-engine tag filtering in the Insert popover).
+
+Phases 1–2 (pronunciation) and 3–5 (expression) are independent tracks; either can lead. Each phase = one PR through the review+security gate with its tests, bisectable, docs-synced.
+
+---
+
+## 8. Testing strategy (fail-before / pass-after)
+
+**Pure-parser (no model, run in CI everywhere):**
+
+- `tests/test_expression_parse.py` — `parse_expression_tags`: plain text → one neutral span (fail-before: function doesn't exist); nested `[voice:][excited]…[pause]…` precedence; unknown `[token]` passes through untouched (the anti-collision invariant); unclosed tag → applies to EOL; ReDoS corpus (long adversarial bracket runs) completes < 50 ms.
+- Extend `tests/fixtures/longform_parser_cases.json` with expression cases; assert **byte-identical** output from `longform_parser.py` and `frontend/src/utils/expressionTags.js`/`longformParser.js` (the existing twin-parity gate). Fail-before: JS twin missing emotion key.
+- `tests/test_pronunciation.py` — `apply_pronunciation`: per-language filtering (global applies, mismatched-language skipped, `Auto` applies all); respelling delegation matches legacy `apply_lexicon`; `[[ipa]]` inline override resolves; phoneme-on-unsupported-engine falls back to respelling and sets `degraded`. Idempotency (apply twice == once).
+- `tests/test_expression_lowering.py` — `lower(expr, engine)` for every registered engine returns the matrix's expected kwargs; `expression_caps` on each backend matches what `lower()` actually consumes (the describe_voice-style import-time consistency assert, so a renamed cap fails a test, not synth).
+
+**API:**
+
+- `tests/test_pronunciation_api.py` — CRUD round-trip; IPA/CMU validation rejects garbage with 400; `/pronunciation/test` returns substituted text with no model loaded.
+- `tests/test_generate_expression.py` — `/generate` with `expression=excited` on OmniVoice returns 200 + an `X-OmniVoice-Expression: degraded` header (visible degradation, never silent); on a mock CosyVoice backend, asserts the instruct phrase was injected.
+
+**Migration:**
+
+- `tests/test_migration_0008.py` — upgrade on a 0007-stamped DB creates the table; re-running is a no-op (idempotent guard); a fresh `_BASE_SCHEMA` DB and a migrated DB have **identical** `PRAGMA table_info(pronunciation_entries)` (the dual-path convergence assert, like the existing `_reconcile_additive_columns` tests). Backward-compat: an existing `omnivoice_data/` DB with no table upgrades cleanly and old rows untouched.
+
+**Cross-platform / CI-green:**
+
+- Twin-parity test covers Win/mac/Linux line endings via `_normalize`.
+- No new Python runtime dep (Phase 1–4 are stdlib); no `frontend/package.json` change unless the panel pulls a new lib (it shouldn't) — if it does, regenerate root `bun.lock` and assert `bun install --frozen-lockfile` per the keep-main-green rule.
+
+---
+
+## 9. Risks & mitigations
+
+- **R1 — tag/grammar collision** (emotion tag eats a `[voice:]` or a literal `[bracketed]` word). *Mitigation:* closed-vocabulary matching + the shared golden corpus asserting passthrough of unknown tokens against both parsers. This is the single highest-risk change → isolated to Phase 4, after the vocab is frozen.
+- **R2 — silent degradation** (user picks `[excited]` on OmniVoice, hears neutral, blames us). *Mitigation:* strikethrough chips, banner, and an `X-OmniVoice-Expression: degraded` response header — parity with the no-silent-CPU-fallback rule. Capability matrix shown *before* generate.
+- **R3 — IPA/CMU garbage → engine crash.** *Mitigation:* validate on save (400), fall back to respelling/literal at synth, never pass unvalidated phoneme strings to a model. Worst case = spoken as written.
+- **R4 — IndexTTS2 emo-vector API drift** (it's subprocess-isolated, own venv). *Mitigation:* lowering for IndexTTS2 lives behind its `engines/indextts/` adapter; a contract test pins the kwarg names; if the kwarg is absent the adapter degrades to neutral (existing `**extras` ignore idiom).
+- **R5 — lexicon/dictionary double-apply** (project JSON + DB). *Mitigation:* single merge point, project-wins ordering, idempotency test; respelling pass is already idempotent by construction (`pronunciation.py` single-pass `re.sub`).
+- **R6 — DB migration on a preview-stamped DB** (alembic_version at a removed rev). *Mitigation:* the `_BASE_SCHEMA` + `_reconcile_additive_columns` belt already covers this class (`db.py`); the convergence test asserts it.
+
+---
+
+## 10. Open questions / decisions for the owner
+
+- Q1. **Tag vocabulary:** adopt ElevenLabs' exact tag names (`[excited]`, `[whispers]`, `[sighs]`) for muscle-memory parity, or a neutral set? (Recommendation: alias the common ElevenLabs names to our canonical set so pasted ElevenLabs scripts "just work.")
+- Q2. **Reaction tags** (`[laughs]`, `[sigh]`, `[gasp]`): treat as emotion spans, or as literal text injected for engines that support them (CosyVoice `[laughter]`/`[breath]`)? (Recommendation: a third tag class "sound" lowered per-engine; out of scope for Phase 3, note for later.)
+- Q3. **OmniVoice base-model emotion:** ship as whisper-only with honest degradation (this spec), or also wire the `ModelsLab/omnivoice-singing` finetune as an opt-in engine variant that *does* take `[happy]`/`[sad]`? (Recommendation: ship honest degradation now; the finetune is a separate engine-registry entry, a clean follow-up.)
+- Q4. **g2p for IPA generation:** bundle a small grapheme→IPA helper (e.g. `g2p-en` for English, ARPABET) so users get a suggested phoneme string, or keep this spec validation-only (user supplies IPA/CMU)? (Recommendation: validation-only now; g2p is a per-language native-dep rabbit hole — defer, document.)
+- Q5. **Docs-sync:** this adds inline-tag and pronunciation surfaces → `docs/voice-design.md`, `docs/generation-parameters.md`, and `docs/features.yaml` must update in the same PRs (hard rule). Confirm whether a dedicated `docs/expressive-tts.md` page is wanted.

--- a/docs/specs/02-conversational-agent.md
+++ b/docs/specs/02-conversational-agent.md
@@ -1,0 +1,587 @@
+# Local Conversational Voice Agent — Implementation Spec
+
+**Date:** 2026-06-25
+**Status:** Proposed
+**Owner:** debpalash
+**Spec #:** 02
+
+A fully-offline, low-latency full-duplex voice assistant for OmniVoice Studio:
+**VAD → streaming STT → local LLM (streaming tokens) → streaming TTS**, with
+barge-in / turn-taking and echo cancellation so the agent never hears itself.
+Opt-in, heavier "Conversation" mode. Composes components OmniVoice already ships
+(sub-second streaming ASR, sentence-chunked streaming TTS, an NLMS echo
+canceller, an OpenAI-compatible local LLM adapter, far-end audio bus) rather
+than introducing a parallel stack.
+
+---
+
+## Context & Problem
+
+### The category gap
+
+Voice **agents** are the product ElevenLabs (Conversational AI), OpenAI (Realtime
+API), and the open-source frameworks (LiveKit Agents, Pipecat, Ten) are all
+racing on. The defining UX is *full-duplex conversation*: you talk, it answers in
+~250–450 ms, and you can **interrupt it mid-sentence** and it stops and listens.
+Every production stack today is **cloud-tethered** — the STT, the LLM, and often
+the TTS are remote API calls, which means an account, an API key, per-minute
+billing, and your microphone audio leaving the machine.
+
+### Why OmniVoice is uniquely positioned
+
+OmniVoice already has **every pipeline stage** of a voice agent, running locally,
+and they were each built (and hardened) for the live-dictation feature that just
+landed:
+
+| Agent stage | Already in the codebase | Path |
+|---|---|---|
+| Streaming STT with endpointing | sherpa-onnx `OnlineRecognizer`, frame-by-frame decode, `is_endpoint()` turn detection, <300 ms perceived latency on CPU | `backend/api/routers/capture_ws.py:414-533` (`_run_sherpa_streaming`), `backend/services/sherpa_dictation.py:275-316` |
+| Echo cancellation (anti-self-trigger) | `NlmsEchoCanceller` with Geigel double-talk detector, server-side so it's platform-identical | `backend/services/aec.py:75-282` |
+| Far-end reference plumbing | publish/subscribe far-end bus + playback tap worklet feeding the AEC reference frame | `frontend/src/utils/aec/farEndBus.js`, `playbackTap.js`, `public/aec-worklet.js` |
+| Streaming TTS | `/ws/tts` sentence-chunked synthesis, <100 ms TTFA target, conversational keep-open socket | `backend/api/routers/tts_stream.py:54-272` |
+| Local LLM "brain" | OpenAI-compat adapter (Ollama / LM Studio / llama.cpp server), structured chat-messages surface | `backend/services/llm_backend.py:66-141` |
+| Tool surface | FastMCP server (`generate_speech`, `list_voices`, `transcribe`, …) | `backend/mcp_server.py:101-246` |
+
+No competitor can offer **"voice agent, zero cloud, your voice never leaves the
+box, runs on a CPU laptop."** OmniVoice can, because the parts are already here
+and already cross-platform. This spec wires them into one full-duplex loop.
+
+### The problem this solves for users
+
+Today a user can *dictate* to OmniVoice and *generate speech* from OmniVoice, but
+the two are disconnected. They cannot **talk to** it. The asks already arriving in
+Issues/Discord — "local Alexa", "offline ChatGPT voice mode", "talk to my docs
+without an API key" — all reduce to the same missing primitive: a turn-taking
+voice loop. That primitive is also the substrate for later agentic features
+(voice-driven dubbing direction, hands-free batch control via the MCP tools).
+
+---
+
+## Goals / Non-goals
+
+### Goals
+
+1. **Full-duplex conversation mode** — speak, get a spoken answer in a natural
+   turn gap (target **median end-of-speech → first-audio ≤ 700 ms** on Apple
+   Silicon / discrete GPU; degrade gracefully on CPU, see Phasing).
+2. **Barge-in** — the user can interrupt the agent mid-utterance; TTS playback
+   stops within **≤ 200 ms** and the loop returns to listening.
+3. **No self-trigger** — the agent's own TTS playback, leaking into the mic, must
+   not be transcribed as user speech. Reuse the existing AEC + far-end bus.
+4. **Fully local & opt-in** — no cloud, no keys, no accounts. Off by default;
+   one Settings toggle turns it on. Functions with reporting/telemetry disabled.
+5. **Cross-platform parity** — identical default behavior on macOS / Windows /
+   Linux. Any platform-only optimization is opt-in.
+6. **CPU-capable** — usable (if slower) on a CPU-only machine with a small quant
+   LLM and a CPU-realtime TTS engine; never a hard GPU requirement.
+7. **Conversation persistence** — turn history kept across a session and
+   resumable, with an additive alembic migration and no migration of existing
+   `omnivoice_data/`.
+8. **Engine back-compat** — no change to on-disk engine/model state; existing
+   IndexTTS/CosyVoice/etc. installs are untouched.
+
+### Non-goals
+
+- **Bundling an LLM in the installer.** We *standardize on* a local runtime and
+  guide the user to install a model (one-click where possible), but the ~1–4 GB
+  weights are a first-use download, not installer payload (mirrors the existing
+  TTS model-on-first-use pattern).
+- **A new TTS engine.** Real-time uses the engines already present (KittenTTS /
+  MOSS-TTS-Nano / Kokoro-via-MLX); no sample-level streaming engine is added.
+- **Telephony / SIP / multi-party.** Single local user, one mic, one speaker.
+- **Sample-level (sub-sentence) TTS streaming.** Sentence-chunked streaming is
+  the latency mechanism; sub-sentence is an open question, not a v0.3.x goal.
+- **Cloud LLM as a default.** Cloud OpenAI-compat endpoints remain *possible*
+  (the adapter already supports them) but stay opt-in and never the default.
+- **Wake-word / always-listening.** Mode is explicitly entered; no background
+  hot-mic.
+
+---
+
+## User Experience
+
+### Entering the mode
+
+- **Opt-in gate.** Settings → *Conversation (beta)* toggle (`prefs` key
+  `conversation.enabled`, default `false`). While off, nothing in the loop loads
+  and no new socket opens — zero footprint, identical to today on every platform.
+- A new left-nav entry **"Talk"** appears only when the toggle is on. First entry
+  runs a **readiness check**: is a local LLM reachable (`llm_backend.is_available()`),
+  is a streaming sherpa ASR model installed, is a real-time-capable TTS engine
+  selected? Any miss shows an inline, actionable card (the project's house error
+  style) — e.g. *"No local LLM detected. Install Ollama and pull `llama3.2:3b`,
+  then click Recheck"* with a copy-paste command per OS. Nothing auto-installs.
+
+### The conversation screen
+
+A single focused view:
+
+- **Big mic orb** at center with four visible states: *Idle* → *Listening*
+  (waveform reacts to mic) → *Thinking* (LLM streaming) → *Speaking* (orb pulses
+  with TTS playback). State transitions are the user's mental model of whose turn
+  it is.
+- **Live transcript rail** — the user's partial ASR text appears as they speak
+  (greyed, italic), commits on endpoint, then the agent's reply streams in token
+  by token as it's generated, with a speaker label and the **voice profile** the
+  agent is using (any saved clone/design voice — reuse the profile picker).
+- **Barge-in affordance** — while *Speaking*, a subtle "interrupt anytime" hint;
+  starting to talk visibly cuts the agent off (orb snaps Listening, the agent's
+  half-spoken line is marked *(interrupted)* in the rail).
+- **Controls** — push-to-talk vs. open-mic toggle (open-mic is VAD-gated;
+  push-to-talk is the CPU-friendly / noisy-room fallback), voice picker, LLM
+  model indicator, *End conversation* (persists + closes the session), mute.
+- **System prompt / persona** — a small "Agent persona" field (persisted per
+  conversation) so the user can set behavior ("You are a terse coding helper").
+  Defaults to a neutral, concise assistant prompt.
+
+### Core flow (happy path)
+
+1. User clicks **Talk**, mode initializes (warm the ASR recognizer, TTS model,
+   and confirm LLM reachable — show a one-time spinner).
+2. User speaks. Partial transcript streams (existing `partial` frames). On
+   `is_endpoint()` (trailing-silence turn detection) the utterance commits.
+3. The committed user turn (+ short rolling history + persona system prompt) is
+   sent to the local LLM, which **streams tokens**.
+4. Tokens feed the existing `SentenceChunker`; each completed sentence is handed
+   to streaming TTS the moment it's ready (first sentence starts speaking while
+   the LLM is still generating the rest — the core latency trick).
+5. TTS audio plays; **every playback frame is published to the far-end bus** and
+   sent to the ASR socket as an AEC reference (tag `0x01`) so the agent doesn't
+   transcribe itself.
+6. The mic stays open (open-mic mode): if the user starts talking (VAD speech +
+   AEC-cleaned energy over threshold for the barge-in window) → **barge-in**:
+   cancel the LLM stream, flush the TTS queue, stop playback, return to step 2.
+7. On *End conversation*, the turn history is persisted and the sockets close.
+
+### Degraded / edge flows
+
+- **Weak hardware:** if warm-up profiling predicts response latency over a
+  threshold, the UI suggests **push-to-talk + half-duplex** (no barge-in) and a
+  smaller LLM/TTS, but still works.
+- **No LLM:** mode is unavailable with the actionable install card; the rest of
+  the app is untouched.
+- **Noisy room / open-mic false triggers:** a sensitivity slider and a
+  push-to-talk escape hatch; barge-in defaults conservative to avoid the agent
+  interrupting itself on its own echo tail.
+
+---
+
+## Technical Design
+
+### The full-duplex pipeline
+
+```
+ mic ──worklet──► PCM16 frames ──┐
+                                 │  (tag 0x00 near-end)
+ TTS playback ──playbackTap──► far-end bus ──► PCM16 (tag 0x01 far-end)
+                                 │
+                                 ▼
+   ┌──────────────  /ws/converse  (NEW orchestration socket)  ──────────────┐
+   │                                                                         │
+   │  NlmsEchoCanceller.process_near_end()  ── clean mic ──► OnlineRecognizer│
+   │        (services/aec.py)                          (sherpa streaming)    │
+   │                                                          │ partial/final│
+   │                                                  is_endpoint() → TURN    │
+   │                                                          ▼              │
+   │              ConversationSession (NEW)  ── history + persona ──►        │
+   │                          │                                              │
+   │                          ▼ streaming chat                               │
+   │              llm_backend.chat_messages_stream() (NEW streaming surface) │
+   │                          │ tokens                                       │
+   │                          ▼                                              │
+   │              SentenceChunker.push() ── sentence ──► TTS generate        │
+   │                          │                     (services/tts_backend)   │
+   │                          ▼ PCM16 chunks                                 │
+   │              ◄── audio frames back to client ──►  (barge-in cancels)    │
+   └─────────────────────────────────────────────────────────────────────────┘
+```
+
+The whole loop is one **server-side orchestrator** so turn-state, barge-in
+cancellation, and history live in one place rather than being coordinated across
+three independent client sockets. The client streams mic+reference PCM up and
+receives transcript/state/audio frames down — one connection.
+
+### Files/services to add or extend
+
+**New — backend**
+
+- `backend/api/routers/converse_ws.py` — the `/ws/converse` orchestration
+  endpoint. Models on `capture_ws.py`'s loopback guard + `ws_remote_authorized`
+  pattern (`capture_ws.py:139-142`), the AEC-tagged PCM transport
+  (`_demux_aec_frame`, `_recv_pcm_frame` at `capture_ws.py:62-73, 383-411`), and
+  the sherpa streaming decode loop (`capture_ws.py:457-497`). Owns the
+  per-session `ConversationSession` and the cancellation token.
+- `backend/services/conversation.py` — `ConversationSession`: holds the rolling
+  message list (system persona + last *N* turns, token-budgeted), drives one
+  turn (ASR-final → LLM stream → sentence-chunk → TTS), and exposes an
+  `asyncio.Event`-based **interrupt** that barge-in trips to cancel the in-flight
+  LLM generation + drain the TTS queue. Persists turns via the new store.
+- `backend/services/conversation_store.py` — CRUD over the new `conversations`
+  and `conversation_turns` tables (below). Thin, mirrors `mcp_bindings.py`.
+- `backend/services/vad.py` — Silero-VAD wrapper (ONNX, CPU, ~1 MB) for
+  **barge-in detection** specifically: scores AEC-*cleaned* mic frames while the
+  agent is speaking, so the agent's own echo tail can't trip it. Endpointing of
+  the *user's* turn stays with sherpa's `is_endpoint()` (already tuned, rule1
+  2.4 s / rule2 1.2 s trailing silence — `sherpa_dictation.py:298-301`); VAD is a
+  fast speech-onset gate, not a replacement for endpointing.
+
+**Extend — backend**
+
+- `backend/services/llm_backend.py` — add `chat_messages_stream(messages, …)`
+  yielding token deltas. The `openai` client already supports `stream=True`;
+  this is an additive surface alongside the existing one-shot `chat_messages`
+  (`llm_backend.py:123-141`). `OffBackend` raises the same clear error.
+- `backend/services/tts_backend.py` — reuse `get_active_tts_backend` /
+  `generate` unchanged; add a thin per-sentence helper that the session calls so
+  TTS runs in the GPU/CPU pool exactly as `tts_stream.py:188-209` does today.
+- `backend/core/prefs.py` — new `conversation.*` keys (enabled, llm_model,
+  tts_engine, mode `open-mic|push-to-talk`, vad_sensitivity, persona_default).
+  Mirrors the existing `dictation.*` namespace and rebuild-on-change pattern
+  (`api/routers/dictation.py:99-127`).
+
+**New — frontend**
+
+- `frontend/src/components/Conversation/ConversationView.jsx` — the screen.
+  Reuses `startMicCapture` (`utils/aec/micCapture.js`), `frameFromFloat` +
+  `AEC_NEAR`/`AEC_FAR` tags (`utils/aec/pcm.js`), `subscribeFarEnd`
+  (`utils/aec/farEndBus.js`), and the voice/profile picker.
+- `frontend/src/utils/conversationSocket.js` — opens `/ws/converse?aec=1&sr=16000
+  &model=<sherpa>`, multiplexes: uploads tagged mic + far-end PCM, receives
+  `partial`/`final`/`token`/`state`/audio-bytes/`done` frames.
+- `frontend/src/utils/conversationPlayer.js` — a **gapless PCM16 queue player**
+  (Web Audio `AudioBufferSourceNode` scheduling) that (a) plays streamed agent
+  audio with minimal gaps between sentences and (b) **publishes each played frame
+  to `publishFarEnd()`** so it becomes the AEC reference — closing the
+  anti-self-trigger loop. Exposes `flush()` for instant barge-in stop. This is
+  the one genuinely new client primitive (today's TTS path buffers a whole WAV
+  then plays via `playBlobAudio`; a conversation needs incremental, interruptible
+  playback).
+
+### Per-stage latency budget
+
+Production voice agents target a **200–450 ms** end-of-user-speech → first-audio
+gap (human turn-taking rhythm), and **< 200 ms** barge-in stop
+([LiveKit](https://livekit.com/blog/turn-detection-voice-agents-vad-endpointing-model-based-detection),
+[FutureAGI](https://futureagi.com/blog/voice-ai-barge-in-turn-taking-2026/)).
+We split the gap as follows. Two budgets: a **GPU/Apple-Silicon** target and an
+honest **CPU-only** reality.
+
+| Stage | What | GPU/MPS target | CPU-only realistic |
+|---|---|---|---|
+| Endpoint detection | sherpa `is_endpoint()` trailing-silence commit | ~150–250 ms (silence rule, inherent) | same |
+| ASR finalize | drain stream for committed text (already decoded incrementally) | < 30 ms | < 80 ms |
+| LLM TTFT | first token from local model | 80–250 ms (3B 4-bit) | 300–600 ms (1–3B) |
+| First sentence ready | enough tokens for `SentenceChunker` first emit (aggressive first-clause flush, `sentence_chunker.py:475-555`) | +50–150 ms | +150–400 ms |
+| TTS TTFA | synth first sentence, first PCM chunk out | 80–200 ms (Kokoro/Kitten) | 150–400 ms (Kitten/MOSS-Nano) |
+| Playback startup | queue player schedules first buffer | < 30 ms | < 30 ms |
+| **Perceived gap** | end-of-speech → first audio | **≈ 450–750 ms** | **≈ 1.0–1.9 s** |
+| **Barge-in stop** | VAD onset → playback flush + LLM cancel | **< 200 ms** | < 250 ms |
+
+Notes grounding the numbers:
+- Local LLM TTFT for 1–3B models is the long pole on CPU; small-model streaming
+  runs ~9–14 ms/token with sub-500 ms TTFT on modern hardware, slower on old CPUs
+  ([daily.dev](https://daily.dev/blog/running-llms-locally-ollama-llama-cpp-self-hosted-ai-developers/),
+  [quantizelab](https://www.quantizelab.dev/articles/vllm-vs-llama-cpp-vs-ollama-benchmark-guide)).
+  The CPU path is *usable*, not snappy — hence push-to-talk + half-duplex on weak
+  hardware, set honestly by warm-up profiling rather than hidden.
+- The **sentence-chunk overlap is the core trick**: the first sentence speaks
+  while the LLM finishes the rest, so perceived latency is *first-sentence*
+  latency, not whole-response latency. `SentenceChunker`'s aggressive-first-flush
+  (emit first clause at ≥ 40 chars on a comma/dash) already exists to shave
+  200–500 ms off TTFA.
+- The **endpoint silence rule is itself ~1.2–2.4 s** in the current dictation
+  tuning, which is too slow for snappy conversation. The session will run a
+  **conversation-tuned endpoint profile** (shorter `rule2` trailing silence, e.g.
+  ~0.6–0.8 s) configured at recognizer build time — a new spec on
+  `sherpa_dictation.py`'s online builder, *not* a change to the dictation
+  defaults (back-compat).
+
+### Barge-in + AEC handling
+
+This is the make-or-break of full-duplex, and the existing AEC plumbing is what
+makes it tractable locally and identically cross-platform.
+
+1. **Reference path.** Every agent-audio frame the `conversationPlayer` schedules
+   is also `publishFarEnd()`-ed; `conversationSocket` subscribes and sends it up
+   tagged `0x01`. Server-side, `converse_ws` feeds it to
+   `NlmsEchoCanceller.push_far_end()` and cleans the mic with
+   `process_near_end()` before *either* ASR or VAD sees it
+   (`aec.py:153-207`). The canceller already passes-through when the far-end is
+   stale (`aec.py:_FAR_STALE_S`), so it won't buzz once the agent stops talking.
+2. **Onset detection.** While state == *Speaking*, the Silero VAD scores the
+   **cleaned** mic frames. Sustained speech for a short window (e.g. ≥ 120–200 ms,
+   `vad_sensitivity`-tunable) = barge-in. Using cleaned audio + a sustain window
+   is what prevents the agent's residual echo from self-interrupting (the classic
+   "agent talks over itself" bug).
+3. **Cancellation.** On barge-in the session: trips the interrupt `Event` →
+   the LLM stream generator is cancelled (stop pulling tokens, the `openai`
+   stream is closed), the pending-sentence TTS queue is dropped, a `state:
+   listening` + `interrupted` frame is sent, and the client `conversationPlayer.flush()`
+   stops playback **immediately** (Web Audio `stop()` on scheduled sources). The
+   committed-so-far agent text is saved as a partial turn.
+4. **Turn handoff.** The recognizer stream is `reset()` (as in
+   `capture_ws.py:493`) and the user's new utterance is decoded fresh.
+
+Server-side AEC was a deliberate cross-platform-parity choice for dictation
+(`aec.py:1-27`: browser `echoCancellation` quality/availability varies per
+webview, which would make a *default* behave differently per OS). The same
+reasoning applies — and is now load-bearing — for the agent.
+
+### LLM runtime choice (with alternatives)
+
+**Standardize on the existing OpenAI-compatible adapter pointed at a local
+server — recommend Ollama as the default local runtime, llama.cpp's
+`llama-server` as the power-user equal.** Rationale:
+
+- **Zero new code path.** `llm_backend.OpenAICompatBackend` already speaks this
+  shape and already names Ollama (`http://localhost:11434/v1`) and LM Studio as
+  first-class (`llm_backend.py:66-90`). Adding streaming is one additive method.
+- **Local-first & cross-platform.** Ollama ships for macOS/Windows/Linux, runs
+  CPU or GPU, auto-detects, streams over SSE with consistent inter-token latency
+  — same default behavior everywhere, which the parity rule demands.
+- **No weights in our installer.** Model is a guided first-use pull (e.g.
+  `ollama pull llama3.2:3b`), matching how OmniVoice already does models.
+- **Recommended default model:** a small instruct model (~3B, 4-bit) for the GPU
+  path; a ~1–1.5B for the CPU path. Selectable in Settings; we ship *guidance*,
+  not weights.
+
+Alternatives considered:
+
+| Option | When to prefer | Why not the default |
+|---|---|---|
+| **llama.cpp `llama-server`** (OpenAI-compat) | Power users wanting GGUF control / no Ollama daemon; lowest TTFT single-user | Same OpenAI-compat surface — *fully supported* via base-url, just less turn-key to install than Ollama. Documented as the equal alternative. |
+| **In-process `llama-cpp-python`** | Eliminate the localhost hop, bundle-friendlier | Adds a native build dep per platform (the very cross-platform fragility we avoid elsewhere); the localhost hop costs < 5 ms. Revisit only if a "no external daemon" install becomes a top ask. |
+| **`transformers` in-process** | Reuse the Python env | Heavy load, weak streaming ergonomics, GPU-memory contention with TTS in the single-worker `_gpu_pool` (`model_manager.py:71-104`). Wrong tool for low-latency chat. |
+| **Cloud OpenAI-compat** | User explicitly opts in | Violates the local-first default; allowed but never default, never required. |
+
+### Concurrency reality
+
+`model_manager._gpu_pool` is **1 worker on MPS/CPU and budget-limited on CUDA**
+(`model_manager.py:71-104`) — ASR, TTS, and a `transformers` LLM would *serialize*
+on one GPU. Standardizing the LLM on a **separate local server process** (Ollama /
+llama-server) sidesteps this entirely: the LLM runs in its own process/accelerator
+context, ASR runs on its sherpa CPU/ONNX path, and TTS uses the existing pool —
+three independent lanes, which is exactly what overlapping the pipeline stages
+requires. For CPU-only, choosing a **CPU-realtime TTS** (KittenTTS English /
+MOSS-TTS-Nano multilingual / Kokoro-via-MLX on Apple) keeps TTS off the LLM's
+cores enough to stay usable.
+
+---
+
+## API / Schema / Data-model changes
+
+### WebSocket protocol — `/ws/converse`
+
+Loopback-guarded (or `OMNIVOICE_API_KEY` bearer for the thin-client case), exactly
+like `/ws/transcribe`. Query: `?aec=1&sr=16000&model=<sherpa_id>&conversation=<id?>`.
+
+**Client → server**
+- Binary frames: tagged PCM16 mono, `0x00` near-end (mic), `0x01` far-end
+  (agent-playback reference) — identical framing to the AEC dictation transport.
+- JSON control frames:
+  - `{"type":"start","persona":"...","voice":"<profile_id>","llm_model":"...","mode":"open-mic|push-to-talk"}`
+  - `{"type":"barge_in"}` — explicit interrupt (push-to-talk re-key / UI button); server also detects barge-in via VAD autonomously.
+  - `{"type":"end"}` — persist + close.
+
+**Server → client**
+- `{"type":"state","value":"idle|listening|thinking|speaking"}`
+- `{"type":"partial","text":"..."}` — user ASR interim (reused frame shape).
+- `{"type":"final","text":"...","role":"user"}` — committed user turn.
+- `{"type":"token","text":"...","role":"assistant"}` — streamed LLM delta.
+- `{"type":"start_audio","sample_rate":N,"format":"pcm16","engine":"..."}` then
+  binary PCM16 chunks (mirrors `tts_stream.py`'s `start` + bytes contract).
+- `{"type":"interrupted","spoken_text":"..."}` — barge-in fired; partial agent turn.
+- `{"type":"turn_done","turn_id":N}` / `{"type":"error","detail":"..."}`.
+
+### REST endpoints (loopback-gated, Settings UI)
+
+- `GET/POST /conversation/prefs` — read/write the `conversation.*` prefs +
+  readiness status (LLM reachable, ASR model installed, TTS engine real-time).
+  Mirrors `dictation.py` prefs router.
+- `GET /conversations` — list saved conversations (id, title, started_at, turn_count).
+- `GET /conversations/{id}` — full turn history.
+- `DELETE /conversations/{id}` — delete one.
+
+### Persistence — additive alembic migration
+
+New migration `0008_conversations.py` (next after `0007_*`), additive only, no
+backfill, existing `omnivoice_data/` untouched:
+
+```sql
+CREATE TABLE conversations (
+  id            TEXT PRIMARY KEY,         -- uuid
+  title         TEXT,                     -- first user turn, truncated
+  persona       TEXT,                     -- system prompt for the session
+  voice_profile TEXT,                     -- profile_id the agent speaks with
+  llm_model     TEXT,                     -- model id used
+  created_at    REAL NOT NULL,
+  updated_at    REAL NOT NULL
+);
+CREATE TABLE conversation_turns (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  role            TEXT NOT NULL,          -- 'user' | 'assistant'
+  text            TEXT NOT NULL,
+  interrupted     INTEGER NOT NULL DEFAULT 0,
+  created_at      REAL NOT NULL
+);
+CREATE INDEX ix_turns_conversation ON conversation_turns(conversation_id, id);
+```
+
+**Privacy:** transcripts are stored locally only (same trust boundary as
+existing history). **No audio is persisted** — only text turns. The auto
+bug-reporter must never attach conversation transcripts (extend its scrub
+allow/deny exactly as it strips reference audio today).
+
+### Prefs (`core/prefs.py`, JSON store)
+
+`conversation.enabled` (bool, default false), `conversation.mode`
+(`open-mic|push-to-talk`, default `push-to-talk` for the safe first run),
+`conversation.llm_model`, `conversation.tts_engine`,
+`conversation.vad_sensitivity` (float), `conversation.endpoint_profile`
+(`conversation|dictation`), `conversation.persona_default` (str). Env overrides
+follow the existing `prefs.resolve` precedence.
+
+---
+
+## Local-first & Cross-platform compliance
+
+- **No cloud, no keys, no accounts.** STT (sherpa ONNX), VAD (Silero ONNX), TTS
+  (local engines), AEC (server NLMS) all run on-device. The LLM runs on a
+  **local** server (Ollama/llama-server) by default. A cloud OpenAI-compat
+  endpoint is only reachable if the user explicitly configures one — never the
+  default, never required.
+- **Opt-in by definition.** Off until the Settings toggle; while off, no socket,
+  no model load, no nav entry — the app is byte-for-byte today's behavior on
+  every platform. This satisfies the strict opt-in rule for a heavy new mode.
+- **Identical default behavior on mac/win/linux.** Server-side AEC was *chosen*
+  over browser `echoCancellation` precisely so the default behaves the same on
+  every webview (`aec.py:1-27`); the agent inherits that. The mic worklet, PCM
+  framing, sherpa decode, sentence chunker, and queue player are platform-neutral
+  JS/Python. The one platform-specific *implementation* allowance is the
+  Apple-only Kokoro-via-MLX TTS fast path — and it's behind the engine picker
+  (opt-in), with a cross-platform default (KittenTTS/MOSS-Nano) so the
+  *user-visible default* never diverges. No P0 platform gap.
+- **CPU-capable.** A 1–1.5B quant LLM + a CPU-realtime TTS + the CPU sherpa ASR +
+  the numpy NLMS AEC is the documented CPU path. Slower turns, push-to-talk +
+  half-duplex by default on weak hardware (set by warm-up profiling), but
+  functional — no hard GPU requirement.
+- **Engine back-compat.** Reuses `get_active_tts_backend` and the LLM adapter as-is;
+  no on-disk engine/model state changes; existing installs untouched.
+- **Docs-sync.** Lands with a `docs/` page (setup: install Ollama, pull a model,
+  pick a voice; the CPU vs GPU expectation table) **in the same PR** as the
+  feature, per the docs-sync rule. README feature grid updated.
+
+---
+
+## Phasing (sliceable on the v0.3.x line)
+
+Each phase is an independently-mergeable, bisectable PR (or small cluster) with
+tests in the same PR, continuous-to-main — no RC, no version bump beyond the
+standing patch. Value lands incrementally.
+
+- **P0 — Streaming LLM surface.** Add `chat_messages_stream()` to
+  `llm_backend.py` (+ `OffBackend` parity, + tests). Independently useful
+  (dictation refinement could stream later). *No UI.*
+- **P1 — Half-duplex conversation (the spine).** `/ws/converse` +
+  `ConversationSession` wiring ASR-final → LLM-stream → sentence-chunk → TTS →
+  client queue player. **Push-to-talk, no barge-in, no AEC reference loop yet**
+  (user holds to talk, releases, listens to the full answer). `ConversationView`
+  with the orb + transcript rail. This alone is a shippable "talk to your local
+  LLM, get a spoken answer" feature.
+- **P2 — Persistence.** `0008` migration + `conversation_store` + history list /
+  resume + the `GET/DELETE /conversations` endpoints. Bug-reporter scrub guard.
+- **P3 — AEC reference loop.** `conversationPlayer` publishes far-end frames;
+  `converse_ws` cancels echo via the existing `NlmsEchoCanceller`. Enables
+  **open-mic** safely (agent stops self-transcribing). Still no interruption.
+- **P4 — Barge-in.** `services/vad.py` (Silero) on cleaned mic during *Speaking*,
+  interrupt `Event`, LLM-stream cancel, TTS-queue flush, client `flush()`. This
+  is the full-duplex payoff. Conversation-tuned endpoint profile lands here.
+- **P5 — Graceful degradation + polish.** Warm-up latency profiling →
+  auto-suggest push-to-talk/half-duplex + smaller models on weak hardware;
+  sensitivity tuning; persona presets; readiness-card install guidance per OS;
+  docs page + README.
+
+---
+
+## Testing strategy
+
+- **Unit (backend):**
+  - `chat_messages_stream` yields deltas, cancels cleanly on interrupt, `OffBackend`
+    raises (mock the `openai` stream).
+  - `ConversationSession` turn lifecycle: final→tokens→sentences→tts calls in
+    order; interrupt `Event` cancels mid-stream and saves the partial turn.
+  - `conversation_store` CRUD; `0008` migration **up-then-down** on a copy of a
+    real `omnivoice_data/` DB (back-compat: existing tables untouched).
+  - VAD barge-in gate: synthetic cleaned-mic frames with/without speech onset →
+    fires only on sustained speech, **never** on a far-end echo fixture (the
+    self-interrupt regression — a fail-before/pass-after test per the fix-quality
+    rule).
+  - Conversation-tuned endpoint profile builds without touching dictation defaults.
+- **Integration (backend):** a fake LLM (deterministic token stream) + a fake
+  fast TTS through real `/ws/converse`; assert frame ordering
+  (`state`/`partial`/`final`/`token`/audio/`turn_done`) and that a `barge_in`
+  frame mid-speech produces `interrupted` + returns to `listening`.
+- **Frontend (vitest):** `conversationPlayer` gapless scheduling + instant
+  `flush()`; far-end publish on each played frame; `conversationSocket` framing
+  (tags `0x00`/`0x01`, control frames). Reuse the existing AEC PCM test patterns
+  (`frontend/src/test/aecPcm.test.js`, `aecFarEndBus.test.js`).
+- **Latency harness (non-gating, like the eval tier):** a scripted turn measures
+  endpoint→TTFT→TTFA→first-audio on the CI box and on a CPU-only profile, logging
+  the budget table so regressions are visible. Not a hard gate (hardware-variable)
+  but tracked.
+- **Cross-platform / full-matrix green:** no `frontend/package.json` dep churn
+  expected beyond a tiny Silero ONNX asset (verify root `bun.lock` regen +
+  `bun install --frozen-lockfile` for Docker), `uv tree` clean after adding the
+  Silero/onnxruntime path (onnxruntime already transitively present), Tauri cargo
+  build unaffected (no Rust change). CodeQL/security re-run on the new socket.
+- **Off-by-default proof:** a test that with `conversation.enabled=false`, no
+  conversation route/socket is reachable and no model loads — the opt-in guarantee.
+
+## Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| **CPU latency feels sluggish** (LLM TTFT is the long pole). | High on old CPUs | Honest warm-up profiling → default to push-to-talk + half-duplex + smaller model; sentence-overlap so perceived latency is first-sentence; never advertise sub-second on CPU. |
+| **Self-trigger / feedback loop** (agent transcribes itself, or interrupts itself). | High without care | Server AEC cleans mic *before* ASR+VAD; barge-in scores **cleaned** audio with a sustain window; far-end-stale pass-through already handled (`aec.py`). The dedicated VAD-vs-echo regression test gates this. |
+| **NLMS AEC is "good-enough," not WebRTC AES3** (`aec.py:14-18`) — residual echo on loud speakers. | Medium | Conservative barge-in sensitivity default; recommend headphones in the readiness card; sustain window; optional future upgrade to a stronger canceller is isolated behind the `aec.py` interface. |
+| **GPU contention** (LLM + TTS on one accelerator). | Medium | Standardize LLM on a **separate process** (Ollama/llama-server), keeping it off the single-worker `_gpu_pool`; CPU-realtime TTS option. |
+| **Endpoint silence too slow → laggy turns** (dictation tuning is 1.2–2.4 s). | Medium | Conversation-specific endpoint profile (shorter trailing silence) built at recognizer init; *dictation defaults unchanged* (back-compat). |
+| **User has no local LLM installed.** | High at launch | Readiness card with copy-paste per-OS install (Ollama) + Recheck; mode simply unavailable until satisfied; rest of app untouched. |
+| **Open-mic false triggers in noisy rooms.** | Medium | Push-to-talk is the default first-run mode; sensitivity slider; VAD sustain window. |
+| **Privacy regression via bug reporter.** | Low but serious | No audio persisted; transcripts excluded from auto bug reports by scrub rule + a test asserting it. |
+
+## Open questions / decisions for the owner
+
+1. **Default local LLM runtime + model.** Recommend **Ollama + `llama3.2:3b`
+   (GPU) / a ~1–1.5B (CPU)** as the documented default, llama-server as the
+   equal power-user path. Approve, or prefer llama-server-first / a different
+   default model?
+2. **Default first-run mode.** Spec proposes **push-to-talk** (safe, CPU-kind,
+   no false barge-in) with open-mic as opt-in once P3/P4 land. Agree, or
+   open-mic-first on capable hardware?
+3. **Ship half-duplex (P1) standalone?** It's a real, useful "talk to your local
+   LLM" feature before barge-in exists. Ship it as soon as it's green, or hold
+   the whole mode until P4?
+4. **Bundle the Silero VAD ONNX asset** (~1–2 MB) in-repo/installer vs.
+   first-use download? It's tiny and load-bearing for barge-in — leaning bundle,
+   but it's a (small) installer-size decision.
+5. **Conversation persistence default.** On (resumable history) or off
+   (ephemeral, nothing written) by default? Privacy-conservative would be
+   **ephemeral by default, opt-in to save**.
+6. **Persona / system-prompt library.** Ship a small preset set (concise
+   assistant, coding helper, tutor) or just a free-text field for v1?
+7. **MCP tool-calling in v1?** The agent *could* call the FastMCP tools
+   (`generate_speech`, `list_voices`, …) to act on the app by voice. Powerful but
+   adds tool-call orchestration + latency. Recommend **deferring tool-calling to
+   a follow-up spec** and shipping a pure conversational loop first — confirm.
+
+---
+
+**Sources (turn-taking, barge-in, local-LLM latency):**
+[LiveKit — Turn Detection: VAD, Endpointing, Model-Based](https://livekit.com/blog/turn-detection-voice-agents-vad-endpointing-model-based-detection) ·
+[FutureAGI — Voice AI Barge-In & Turn-Taking 2026](https://futureagi.com/blog/voice-ai-barge-in-turn-taking-2026/) ·
+[Sparkco — Optimizing Barge-in Detection 2025](https://sparkco.ai/blog/optimizing-voice-agent-barge-in-detection-for-2025) ·
+[Softcery — Real-Time vs Turn-Based Voice Agents](https://softcery.com/lab/ai-voice-agents-real-time-vs-turn-based-tts-stt-architecture) ·
+[daily.dev — Running LLMs Locally 2026 (Ollama/llama.cpp)](https://daily.dev/blog/running-llms-locally-ollama-llama-cpp-self-hosted-ai-developers/) ·
+[QuantizeLab — vLLM vs llama.cpp vs Ollama Benchmarks](https://www.quantizelab.dev/articles/vllm-vs-llama-cpp-vs-ollama-benchmark-guide)

--- a/docs/specs/03-longform-studio-editor.md
+++ b/docs/specs/03-longform-studio-editor.md
@@ -1,0 +1,265 @@
+# Implementation Spec — 03: Long-form "Studio" Editor (per-segment edit · regenerate-one-line · reassign-voice · emotion/timing)
+
+> Status: draft for owner review · Target line: **v0.3.x** (continuous-to-main, no RC) · Surfaces: Dub, Audiobook, Stories
+> Foundation: this is **90% a great editor UX + gap-filling on top of machinery that already exists**. Dubbing already content-addresses segments and regenerates exactly one line; the work is (a) lifting that pattern to the longform (Audiobook/Stories) renderer, which today only caches at *chapter* granularity, and (b) unifying the editor affordances to the ElevenLabs "Studio" bar.
+
+---
+
+## Context & Problem
+
+### The gap vs ElevenLabs Studio / Dubbing Studio
+
+ElevenLabs has converged its "pro polish" loop into two editors that OmniVoice partially matches and partially does not:
+
+- **Studio (Projects / Audiobooks)** — paste a manuscript, see chapters laid out, assign different voices per character/paragraph, and make **surgical edits without regenerating everything**: a *Replace voice* pop-up tells you *how many paragraphs* will be re-rendered, and editing one fragment re-renders only that fragment ([Studio overview](https://elevenlabs.io/docs/eleven-creative/products/studio), [change voice across paragraphs](https://help.elevenlabs.io/hc/en-us/articles/23370957112721-How-can-I-change-the-voice-and-settings-across-multiple-paragraphs-in-Studio), [Audiobooks](https://elevenlabs.io/docs/eleven-creative/products/audiobooks)).
+- **Dubbing Studio** — transcript **and** translation are edited inline in speaker cards; a clip carries a **"stale" badge** when its text/settings/length change; you **regenerate one clip** (refresh icon) or *Generate Stale Audio* in bulk; you **reassign a clip to another speaker** by dragging it to that track; and you adjust **timing** by dragging clip handles / Split / Merge ([Dubbing Studio](https://elevenlabs.io/docs/eleven-creative/products/dubbing/dubbing-studio)).
+
+OmniVoice today is **asymmetric** across its three longform surfaces:
+
+| Capability | Dub | Stories | Audiobook |
+|---|---|---|---|
+| Per-line text edit | ✅ `DubSegmentRow.jsx` (text 232–252, restore 253–273) | ✅ per-line `<textarea>` (`StoriesEditor.jsx:712–720`) | ❌ one script `<textarea>` only (`AudiobookTab.jsx:227–233`) |
+| Per-line voice/speaker reassign | ✅ profile `<select>` (288–313) + speaker_id (213–224) | ✅ per-line voice override (734–742) + cast panel | ⚠️ only via inline `[voice:NAME]` markup typed in the blob |
+| Per-line emotion/direction | ✅ `direction` (split/direction menu 335–383) | ✅ `emotion` tone tags (tune drawer 773–795) | ❌ none |
+| Per-line timing / fit | ✅ fit strategies + fit badges (`DubSegmentRow.jsx:74–105`) | n/a (longform has no slots) | n/a |
+| **Stale badge + regenerate ONE line** | ✅ `plan_incremental` + `regen_only` + "Regen changed (N)" (`DubTab.jsx:781–786`) | ❌ no incremental — server **re-streams the whole plan** on every export | ❌ chapter-cache only; editing one span re-keys the **whole chapter** |
+| Re-stitch / re-mux after a partial edit | ✅ `dub_generate` always rebuilds `dubbed_{lang}.wav`; mux is lazy in `dub_export` | ❌ full re-render | ⚠️ resume reuses *unchanged chapters* but never sub-chapter |
+
+### What already exists in-repo (the foundation we build on)
+
+The dub pipeline **already** content-addresses segments so that editing one line re-synthesizes only that line:
+
+- **`backend/services/incremental.py`** — `segment_fingerprint(seg)` (52–67) is a sha1 over the **generation inputs that actually affect TTS output**: `_GEN_INPUT_FIELDS = ("text","target_lang","profile_id","instruct","speed","direction","effect_preset")` (line 23). `_canon_value` (32–49) normalizes None/""/missing and int↔float so the **server-parsed view** and the **client-raw view** of the same logical segment hash identically — the root-cause fix for #281 ("1 edit re-dubs all N lines"). `fit_fingerprint(params)` (101–116) hashes the **fit configuration separately and on purpose** (70–76): a fit-knob change must trigger a **re-mix** of already-rendered natural-rate WAVs (`regen_only=[]`), never a re-TTS. `plan_incremental(segments, *, stored_hashes)` (119–157) returns `{stale, fresh, total, fingerprints}`.
+- **`backend/api/routers/dub_generate.py`** — honors `regen_only` (113): for a segment **not** in `regen_only` it reloads the cached `dub_seg_path(job_id, seg_id)` (160–197, with a legacy index-name fallback at 162–166) instead of re-running TTS; for stale segments it runs `_gen(...)`. After the loop it **always re-stitches the full `dubbed_{lang}.wav`** (766–770) and persists `job["seg_hashes"]` (498–512) + `seg_order` (127). The `done` SSE ships `seg_hashes`/`seg_num_step` back (840). Strategy-transition guard (122–123) and `seg_wav_kind` (830) keep smart_fit reuse correct.
+- **`tests/test_redub_incremental.py`** — already asserts the contract end-to-end with a mocked TTS engine: `test_edited_line_produces_different_cached_output` (228–281) proves an edited line's cached WAV changes, the **untouched line's cached WAV is reused byte-for-byte** (272–273), TTS ran exactly once (266), and the final track was rebuilt (281). `test_one_edit_marks_exactly_one_segment_stale` (101–118) proves the planner.
+- **Per-segment audio + metadata keying.** Audio lives on disk as `{DUB_DIR}/{job_id}/seg_{seg_id}.wav` via `dub_seg_path(job_id, seg_id)` (`backend/core/config.py:54–71`). Metadata lives in the job's `job_data` JSON blob (`dub_history` table, `backend/core/db.py:74–85`), holding `segments`, `seg_order`, `seg_hashes`, `seg_num_step`, `seg_wav_kind`, `dubbed_tracks`, `fit_plans`, `video_stretch_plans`. Stable ids are minted at transcribe time (`s{NNNNN:05x}`, `dub_core.py:600`). Job persistence is `dub_pipeline.get_job`/`save_job`/`put_job` (`backend/services/dub_pipeline.py:158–214`).
+- **Longform (Audiobook + Stories) share one renderer** `_render_longform_sse` (`backend/api/routers/audiobook.py:403–595`) and one **chapter-level** content-addressed key `chapter_cache_key` (`backend/services/longform_render.py:110–136`), cached under `OUTPUTS_DIR/longform_cache` (`_render_chapter_cached`, `audiobook.py:314–355`). The lexicon is folded into the key (338–341). Resume (`audiobook.py:714–759`) reuses already-rendered chapters because the key is content-based. **But the granularity is the whole chapter** (longform_render.py:117–125) — that is the gap.
+
+**Conclusion:** Dub is the reference implementation. Stories already has the *editor UI* but no incremental backend. Audiobook has neither a per-line editor nor sub-chapter incrementality. This spec makes all three behave like a "Studio" by (1) standardizing the editor affordances and (2) pushing the dub-proven `fingerprint → stale → regen_only → re-stitch` loop down into the longform renderer at **span granularity**.
+
+---
+
+## Goals / Non-goals
+
+### Goals
+1. **Per-segment edit across all three surfaces**: edit a line's **text** (and, for dub, its **translation** independently of the source text), change its **assigned voice/speaker**, set per-segment **emotion/style** (composes with the emotion/style field — see "Composition with emotion/style"), and adjust **timing** (dub only: fit/slot).
+2. **A visible "stale" badge + "regenerate this one line"** affordance on every surface, mirroring Dubbing Studio's refresh-icon + *Generate Stale Audio*. Editing a line invalidates **exactly one fingerprint** and triggers a **single-segment regen + re-stitch/re-mux**; unchanged lines are cache-hits (reused byte-for-byte).
+3. **Reuse the existing machinery, don't reinvent it.** Dub keeps `plan_incremental`/`regen_only`. Longform gets a **span-level** twin of `chapter_cache_key` so editing one span re-synthesizes one span, not the chapter.
+4. **A unified editor *contract*** (stale model, regen verb, voice-reassign affordance, the "N lines will regenerate" preview) shared in concept across surfaces, while respecting each surface's distinct timing model.
+5. **Zero forced re-render of existing projects.** Existing `omnivoice_data/` dub jobs, story projects, and audiobook renders keep working untouched; new keying degrades gracefully to "treat as stale once" rather than corrupting cached audio.
+6. **Local-first, cross-platform parity preserved**, docs-sync in the same PR.
+
+### Non-goals (explicitly deferred)
+- **A timeline/waveform DAW view.** ElevenLabs reassigns a speaker by dragging a clip between tracks on a timeline; OmniVoice reassigns via the existing per-row `<select>`. No timeline canvas, no clip-drag-to-track, no multi-track audio lanes in this spec. (Split/Merge already exist in `DubSegmentRow.jsx`.)
+- **New TTS engines or new emotion *models*.** This spec consumes whatever emotion/style field exists; it does not add a new style engine.
+- **Sub-chapter resume of an *interrupted* render.** Resume stays chapter-granular (`audiobook.py:714–759`); span-level incrementality is for *edits*, not for crash recovery, in this milestone.
+- **Collaborative / multi-user editing.** Local-first, single-user.
+- **Audiobook/Stories *slot* timing.** Longform has no per-line time slots (it's narration, not lip-sync); per-segment *timing* is a **dub-only** capability here. Longform "timing" is limited to the existing `[pause]` markers and per-line `speed`.
+- **Changing the dub fingerprint contract.** `segment_fingerprint`'s field set is stable (back-compat tested in `test_redub_incremental.py:87–98`); emotion/style integration extends it **only if** the field genuinely affects TTS output (see Open Questions Q1).
+
+---
+
+## User Experience
+
+The three surfaces converge on **one mental model — "edit a line, see it go stale, regenerate just that line"** — but keep surface-appropriate controls.
+
+### Shared "Studio" affordances (all surfaces)
+- **Stale badge.** A line whose generation inputs changed since its last successful render shows an amber **"changed"** chip (mirrors Dubbing Studio's stale state). Derived from `fingerprint(line) ≠ stored_hash[line.id]` — the dub planner today.
+- **Regenerate-this-line.** A per-row **↻** button regenerates only that line, then re-stitches. Disabled (no-op) when the line isn't stale.
+- **Regenerate-changed (bulk).** A header button **"Regenerate changed (N)"** counts stale lines and regenerates exactly those (dub already has this — `DubTab.jsx:781–786`; Stories/Audiobook gain it).
+- **"This will regenerate N lines" preview.** When a change has fan-out (e.g. reassigning a *cast* voice that M lines inherit, or editing the pronunciation lexicon that affects K chapters), a confirm step states the count before clearing that audio — ElevenLabs' *Replace voice* pop-up pattern.
+- **Instant preview vs final export.** A line-level **▶ preview** renders that one line quickly (low step count, no watermark/mux) and is *not* persisted; the **final** render/export re-stitches and re-muxes the full artifact. Dub already splits these (`preview_segment`, `dub_generate.py:867–951`; preview is `preview: true`, no disk write, 8 steps).
+
+### Dub surface (extend, don't rebuild)
+`DubTab.jsx` + `DubSegmentRow.jsx` already implement nearly all of this. Remaining UX work is **polish + parity**:
+- **Independent translation edit.** Today text edit + restore-original exists (`DubSegmentRow.jsx:232–273`); make the **transcript (`text_original`)** and the **translation (`text`)** independently editable in the row, with a **↻ re-translate this line** affordance routing to `dub_translate` (`dub_translate.py:222`) for one id, then marking the line stale. (ElevenLabs: edit transcript *or* translation freely.)
+- **Reassign speaker** keeps the per-row speaker `<select>` (213–224) and the per-row voice override (288–313); changing either flips the fingerprint via `profile_id` and goes stale.
+- **Timing** keeps the existing fit strategy + fit badges (`smart_fit`/`concise`/`stretch_video`/`strict_slot`, `DubSegmentRow.jsx:74–105`). A **fit-knob** change re-mixes (not re-TTS) via the existing `fit_fingerprint` path. Split/Merge/Direction stay (335–383).
+- Emotion/style → the per-segment **direction** field (already a fingerprint input).
+
+### Stories surface
+`StoriesEditor.jsx` already has the richest line editor (per-line text, per-line voice override, emotion tone tags, per-line speed, per-line preview). The **only** missing piece is the *incremental backend*: today `generateAll` (374–409) POSTs the whole plan to `/longform/render` and re-streams everything. New UX:
+- Each track card gains the shared **stale chip** + **↻ regenerate this line** + header **"Regenerate changed (N)"**.
+- Single-line preview stays client-side (`previewTrack`, 301–352) — unchanged.
+- Full export switches from "always full render" to "render with `regen_only`": only stale spans re-synthesize; fresh spans reuse cached span WAVs. Reassigning a **cast** voice shows the "N lines inherit this voice and will regenerate" confirm.
+
+### Audiobook surface
+`AudiobookTab.jsx` is the least mature — a single script `<textarea>` (227–233) with only per-*chapter* audition (372–397). It gets the biggest UX uplift:
+- **A segment/transcript view** for the parsed plan: render `AudiobookPlan.chapters[].spans[]` (the parser already produces spans — `audiobook.py:80–94`, `Span` at `services/audiobook.py:28–43`) as an editable list **under each chapter heading**, each span row carrying: editable text, a per-span **voice `<select>`** (writes back as inline `[voice:NAME]` so the script blob stays the single source of truth — see Technical Design), an emotion/style affordance, and the shared **stale chip + ↻**.
+- Editing a span edits the underlying script blob region; the plan re-parses; **only the edited span goes stale**, not the chapter.
+- Per-chapter audition stays; per-*span* preview is added (reuses the longform single-span render path).
+- The single-blob textarea remains available as a "raw script" toggle for power users; the structured view is the default. (Both bind to the same `script` string per the `LongformProject` store, spec 31.)
+
+---
+
+## Technical Design
+
+### Principle: one cache contract, two implementations
+
+Dub and longform both reduce to: **`fingerprint(unit) → diff vs stored → regen the stale units → reuse cached unit audio for the rest → re-stitch/re-mux the whole artifact`**. Dub's `unit` = dub segment (already shipped). Longform's `unit` becomes the **span** (new). We do **not** force them onto one code path — their timing/mux differ — but they share `incremental.py`'s primitives and the same persisted-hash discipline.
+
+### Part A — Dub (extend existing, minimal change)
+
+The edit → single-segment-regen → re-stitch flow already exists and is tested. Deltas:
+
+1. **Independent transcript/translation edit.** `DubSegment` already has `text` (translation) and the job carries `text_original` (set in `dub_core.py:601`, preserved by `_sync_job_segments`, `dub_generate.py:51–88`). Expose `text_original` as an editable field on the row; **only `text` is a fingerprint input** (incremental.py:23), so editing the *transcript* alone does **not** force a re-TTS unless the user re-translates. A **per-line re-translate** calls `POST /dub/translate` (`dub_translate.py:222`) for that single id; the returned `text` flips the fingerprint → the line goes stale → user clicks ↻.
+2. **No fingerprint change needed** for voice/speaker/direction/effect — all already in `_GEN_INPUT_FIELDS`. Timing/fit already routes through `fit_fingerprint` (re-mix, not re-TTS).
+3. **Re-mux** stays lazy in `dub_export.py` (download/preview endpoints, `dub_download` 366–740, `dub_preview_video` 789–1034), driven by the persisted `fit_plans`/`video_stretch_plans`. A single-segment regen only rebuilds `dubbed_{lang}.wav`; the video re-mux happens on next download/preview, gated by plan-staleness helpers (`_video_retime_plan_for` 260–277).
+
+> Net dub change is small: a transcript field + a single-id re-translate call. The heavy lifting (`regen_only`, `seg_hashes`, re-stitch) is untouched.
+
+### Part B — Longform (the real new machinery): span-level incremental
+
+Today `_render_chapter_cached` (`audiobook.py:314–355`) keys the **whole chapter** with `chapter_cache_key` (`longform_render.py:110–136`). We add a **span-level** key and a span cache, then make `_render_longform_sse` reuse fresh span WAVs and re-synthesize only stale ones.
+
+**New: `span_fingerprint` + span cache** (in `backend/services/longform_render.py`, alongside `chapter_cache_key`):
+- `span_fingerprint(span, *, engine_id, sample_rate, voice_sig, lexicon) -> str` — sha1 over the inputs that affect a span's rendered audio: `(voice_id, text, pause_ms_after, speed, emotion/style, lexicon-respelling-of-text, engine_id, sample_rate, voice_sig)`. This is the **longform twin of `segment_fingerprint`**; it deliberately mirrors the dub field discipline (same #281 canonicalization rules — reuse `incremental._canon_value` so int↔float / None↔"" parity holds).
+- Span audio cached at `OUTPUTS_DIR/longform_cache/span_{key}.wav` (sibling to the existing chapter WAVs). The chapter WAV becomes a **stitch of its span WAVs** (crossfade + inter-span silence already done by `synthesize_chapter`, `services/audiobook.py:97–141`) rather than a single monolithic render. `chapter_cache_key` is retained for the **final stitched chapter** (so resume still hits at chapter granularity), but the chapter render now internally reuses fresh span WAVs.
+
+**Refactor `synthesize_chapter`** (`services/audiobook.py:97–141`) so each span renders through a `render_span(span) -> tensor` that first checks the span cache by `span_fingerprint`; on hit it loads the WAV, on miss it runs the injected `synth` and writes the WAV. The function already iterates spans and stitches (121–139) — we wrap the per-span synth call (125) in the cache check. **This is the exact analog of dub's per-segment cache-load-or-`_gen` branch** (`dub_generate.py:160–199`).
+
+**New: `regen_only` for longform.** `_render_longform_sse` (`audiobook.py:403`) and the `POST /audiobook` / `POST /longform/render` request bodies accept an optional `regen_only: list[str]` (span ids) + `stored_span_hashes: dict[str,str]`. When present:
+- Spans **not** in `regen_only` and whose stored hash matches → **cache-hit**, reuse WAV.
+- Spans in `regen_only` (or all spans, when omitted = today's behavior) → re-synthesize.
+- The chapter is re-stitched from the (mostly cached) span WAVs; the book is re-muxed (the existing `build_ffmetadata` + concat-demux mux, `audiobook.py:536` / `services/longform_render.py`).
+- Emit `seg_hashes`-equivalent (`span_hashes`) in the `done` SSE so the client persists them, exactly like dub's `done` payload (`dub_generate.py:840`).
+
+**Span identity.** Longform spans need **stable ids** the way dub segments do (`s{NNNNN:05x}`). The longform parser (`services/longform_parser.parse_script_to_spans`, wrapped at `audiobook.py:80–94`) currently emits positional spans with no id. We add a **deterministic span id** derived from `(chapter_index, span_index)` *plus a content-stable suffix*, OR — preferred — mint stable ids in the parser and thread them through `Span` (`services/audiobook.py:28–43`, add `id: Optional[str]`). For Stories, the track card already has a stable `id` (`makeTrack`, `StoriesEditor.jsx:91–94`) → `storyToSpans` (`utils/storyToSpans.js:27–60`) threads it onto the span. The id is what `regen_only` addresses.
+
+> **Why not just keep chapter keys?** Because a 30-page chapter re-synthesizing on a one-word fix is exactly the wall this spec closes. Span keying makes "fix one sentence" cost one sentence — the ElevenLabs bar.
+
+### Composition with emotion/style (per-segment)
+
+Assume a per-segment emotion/style field exists (dub: `direction`; stories: `emotion` track field, `StoriesEditor.jsx:91–94`; audiobook: to be added per-span). Integration rule, derived from the existing `fit_fingerprint` precedent:
+
+- **If the field changes the TTS *output*** (e.g. an instruct/direction string fed to the engine) → it is a **fingerprint input**. Dub already includes `direction` (incremental.py:23; `test_direction_change_flips_fingerprint`, `test_redub_incremental.py:131–134`). Longform `span_fingerprint` includes the emotion/style field symmetrically.
+- **If the field is post-processing only** (a DSP/effect knob that re-mixes already-rendered audio) → it belongs in a **separate** fit-style fingerprint that triggers a re-mix, not a re-TTS — exactly how `fit_fingerprint` (incremental.py:70–116) is kept *out* of `segment_fingerprint`.
+
+This composes cleanly with a future emotion/style spec: whichever bucket the field falls into, the fingerprint discipline already has a slot for it. (Owner decision Q1.)
+
+### Edit → single-segment-regen → re-stitch/re-mux (end-to-end)
+
+```
+User edits line L's text / voice / emotion  (any surface)
+   │
+   ├─ client recomputes fingerprint(L)  → ≠ stored_hash[L.id]  → L shows "stale" chip
+   │     (dub: segment_fingerprint; longform: span_fingerprint — same canonicalization)
+   │
+User clicks ↻ (one line) or "Regenerate changed (N)"
+   │
+   ├─ DUB:      POST /dub/generate/{job} { segments, segment_ids, regen_only:[L.id], preview:false }
+   │              → dub_generate reuses cached seg_{id}.wav for all but L (dub_generate.py:160–197)
+   │              → re-TTS L only (_gen) → re-stitch dubbed_{lang}.wav (766–770)
+   │              → persist seg_hashes[L.id] (498–512) → done SSE returns new hashes (840)
+   │              → re-mux is lazy on next /dub/download (dub_export.py:366–740)
+   │
+   └─ LONGFORM: POST /audiobook (or /longform/render) { chapters, regen_only:[L.id], stored_span_hashes }
+                  → _render_longform_sse reuses span_{key}.wav for fresh spans
+                  → re-synthesize L only → re-stitch L's chapter → re-mux m4b/mp3 (audiobook.py:536)
+                  → done SSE returns span_hashes  → client persists them
+```
+
+Both paths **always rebuild the full final artifact** from a set that is mostly cache-hits — the dub invariant proven by `test_redub_incremental.py:280–281` (final track rebuilt) generalizes to longform's m4b/mp3.
+
+### Files to extend (with paths)
+
+| File | Change |
+|---|---|
+| `backend/services/incremental.py` | Add `span_fingerprint(...)` (or factor a shared `_fingerprint(fields, canon)` core that both `segment_fingerprint` and `span_fingerprint` call). Reuse `_canon_value`. |
+| `backend/services/longform_render.py` | Add span-level key + `span_{key}.wav` cache load/write helper; keep `chapter_cache_key` for the stitched chapter. |
+| `backend/services/audiobook.py` | `Span` gains stable `id`; `synthesize_chapter` (97–141) wraps per-span synth in span-cache load-or-render. |
+| `backend/api/routers/audiobook.py` | `_render_longform_sse` (403–595) honors `regen_only` + `stored_span_hashes`; `POST /audiobook` (598–610) + `POST /longform/render` (639–667) accept them; `done` SSE emits `span_hashes`. |
+| `backend/services/longform_parser.py` (+ `frontend/src/utils/longformParser.js` twin, byte-for-byte per #27) | Mint stable span ids. **Both must change together** (the JS twin is golden-corpus-verified). |
+| `backend/api/routers/dub_translate.py` | Allow a **single-id** re-translate (already id-keyed, `dub_translate.py:222`); ensure one-segment requests are cheap. |
+| `frontend/src/components/DubSegmentRow.jsx` | Expose editable `text_original` (transcript) distinct from `text` (translation); add per-line re-translate. |
+| `frontend/src/pages/AudiobookTab.jsx` | New structured span/transcript view over `AudiobookPlan`; per-span text/voice/emotion edit + stale chip + ↻; raw-script toggle retained. |
+| `frontend/src/components/StoriesEditor.jsx` | Add stale chip + ↻ + "Regenerate changed (N)"; `generateAll` (374–409) sends `regen_only`/`stored_span_hashes`. |
+| `frontend/src/utils/storyToSpans.js` | Thread track `id` → span `id`. |
+| `frontend/src/store/longformSlice.ts` (per spec 31) | Persist `span_hashes` alongside the project (the localStorage analog of `job_data.seg_hashes`). |
+
+---
+
+## API / Schema / Data-model changes
+
+### New / extended request fields (additive, all optional → back-compat)
+- **`DubSegment`** (`backend/schemas/requests.py:19–43`): unchanged field set; `text_original` is carried in the job, not the segment fingerprint. (No schema change required for dub — the transcript edit reuses existing job state.) If exposed in the request, add `text_original: Optional[str] = None` (additive, defaulted → old payloads parse unchanged).
+- **Longform render bodies** (`LongformChapter`/`LongformSpan` Pydantic models, `audiobook.py:615–636`; `AudiobookSynthesizeRequest`): add `regen_only: Optional[list[str]] = None` and `stored_span_hashes: Optional[dict[str,str]] = None`. `LongformSpan` gains `id: Optional[str] = None`. All defaulted → existing clients unaffected.
+
+### Endpoints
+- **Reuse** `POST /dub/generate/{job_id}` (`dub_generate.py:93`) — already takes `regen_only`. No new dub endpoint.
+- **Reuse** `POST /dub/translate` (`dub_translate.py:222`) for single-id re-translate (already id-keyed). No new endpoint.
+- **Extend** `POST /audiobook` (`audiobook.py:598`) and `POST /longform/render` (`audiobook.py:639`) to honor `regen_only`/`stored_span_hashes`; `done` SSE adds a `span_hashes` field (additive — old clients ignore unknown keys, matching dub's `seg_hashes`/`seg_num_step` additive precedent at `dub_generate.py:840`).
+- **New (optional, thin)** `POST /audiobook/preview-span/{job_id}` mirroring `dub_generate.py:867` `preview_segment` — fast single-span audition (low steps, no mux, no persist). Only if Stories' client-side preview (`previewTrack`) doesn't already cover the audiobook need; otherwise skip.
+
+### Persistence
+- **Dub**: no change. `seg_hashes`/`seg_order`/`seg_num_step` already live in `job_data` (`dub_history.job_data`, `db.py:74–85`), written by `_save_job` (`dub_pipeline.py:187–214`).
+- **Longform**: span audio cached on disk under `OUTPUTS_DIR/longform_cache/span_{key}.wav` (content-addressed → self-cleaning, pruned by the existing `prune_cache_dir`, `audiobook.py:494`). **`span_hashes` persist client-side** in the `LongformProject` zustand store (spec 31, `longformSlice.ts`) — the localStorage analog of `job_data.seg_hashes`. **No new SQLite table, no alembic migration** for longform (it's filesystem cache + browser state). If the owner later wants server-side longform job rows to carry `span_hashes`, *that* would go through alembic — flagged as a non-goal here.
+- **Migration / back-compat**: existing dub jobs already carry `seg_hashes` (or get them on next generate). Existing longform renders have **no** `span_hashes` → first edit treats all spans as stale **once** (the planner's "missing stored hash → stale" default, `incremental.plan_incremental` doc 134–136), which is safe (re-renders correctly, just not incrementally that one time). **No forced re-render** of any existing project on upgrade. No DB schema change → **no alembic migration needed**; the localStorage versioned `migrate` fn (spec 31) tolerates the absent `span_hashes` key.
+
+### Preferences
+- Per-surface toggle (Settings): "Default to structured editor view" (Audiobook), defaulting **on**. No network prefs. Stored in existing settings store.
+
+---
+
+## Local-first & Cross-platform compliance
+
+- **Local-first preserved.** Every path is local: TTS/regen runs on-device (MPS/CUDA/ROCm/CPU auto-detect, unchanged); span/segment WAVs are local files; fingerprints are local sha1; `span_hashes` persist locally (job_data / localStorage). **No cloud call, no account, no API key, no telemetry** is added. The optional `POST /dub/translate` offline providers (nllb, argos) keep translation local; cloud LLM translation stays the user's existing opt-in.
+- **Cross-platform parity (strict rule, 2026-05-20).** The editor + per-segment regen is **default behavior** and must be identical on macOS / Windows / Linux. The implementation uses only cross-platform pieces: `dub_seg_path`/cache paths use `os.path.join` + realpath containment (`config.py:54–71`, already cross-platform), ffmpeg mux is the existing cross-platform invocation (`build_render_cmd`), fingerprints are pure Python, and the UI is the existing Tauri/React stack. **No platform-only affordance** is introduced — no macOS-only shortcut, no Windows-only picker. The keyboard shortcuts already in `DubSegmentRow.jsx` (⌘D split / ⌘M merge, 335–383) must map to Ctrl on Windows/Linux (verify they already do; if not, that's a P0 parity fix in the same PR).
+- **Existing-engine + existing-`omnivoice_data/` back-compat.** No engine code touched in a way that requires reinstall; on-disk model state untouched. Existing dub jobs, story projects, audiobook renders open and play unchanged; the only first-edit cost is one non-incremental regen (correct output, just not cached yet). Span cache is purely additive on disk.
+
+---
+
+## Phasing (sliceable milestones on the v0.3.x line)
+
+Each slice is independently shippable, continuous-to-main, with its own regression test. Ordering puts the **lowest-risk, highest-leverage** work first (dub is already 90% there).
+
+- **03a — Dub transcript/translation split + single-id re-translate.** Expose editable transcript (`text_original`) vs translation (`text`) in `DubSegmentRow.jsx`; per-line re-translate via `POST /dub/translate` for one id. Reuses existing `regen_only`. *Smallest, proves the "edit translation → one line stale → ↻" loop end-to-end on the surface that already supports it.*
+- **03b — Longform span fingerprint + span cache (backend only, no UI).** `span_fingerprint` in `incremental.py`; span-cache load/write in `longform_render.py`; `synthesize_chapter` reuses fresh span WAVs; stable span ids in the parser (both twins). Gated by a test asserting **one edited span re-synthesizes; siblings cache-hit** (the dub test, lifted to longform).
+- **03c — Longform `regen_only` wiring + `span_hashes` in the store.** `_render_longform_sse` + the two POST bodies honor `regen_only`/`stored_span_hashes`; `done` SSE emits `span_hashes`; `longformSlice` persists them.
+- **03d — Stories editor: stale chip + ↻ + "Regenerate changed (N)".** Stories already has the row editor; just add the stale UX and switch `generateAll` to send `regen_only`. *First user-visible longform incrementality.*
+- **03e — Audiobook structured span editor.** The big UX uplift: structured per-span view over `AudiobookPlan`, per-span text/voice/emotion edit, stale chip + ↻, raw-script toggle. Rides 03b/03c.
+- **03f — Emotion/style-per-segment composition.** Wire the emotion/style field into `span_fingerprint` (re-TTS bucket) or a longform fit-style fingerprint (re-mix bucket) per the owner's Q1 decision; symmetric with dub's existing `direction`.
+
+(03a, 03b can land in parallel; 03d depends on 03c; 03e depends on 03b+03c; 03f is last.)
+
+---
+
+## Testing strategy
+
+**The load-bearing assertion (every surface): a single-line edit regenerates exactly one segment; all others are cache-hits.** This is already proven for dub — the new tests **lift that exact contract** to longform.
+
+- **Reuse + extend `tests/test_redub_incremental.py`.** It already asserts the dub contract: `test_one_edit_marks_exactly_one_segment_stale` (101–118), `test_edited_line_produces_different_cached_output` (228–281: edited line's WAV changes, **untouched line's WAV reused byte-for-byte** 272–273, TTS ran exactly once 266, final track rebuilt 281). 03a adds a test that editing **only `text_original`** does *not* flip the fingerprint, but a re-translate that changes `text` does (composes with `test_direction_change_flips_fingerprint`, 131–134).
+- **New `tests/test_longform_incremental.py`** (the centerpiece, mirrors the dub test with a stub `synth`):
+  - `span_fingerprint` parity: server-parsed span vs client-raw span hash identically (the #281 class, reusing `_canon_value`).
+  - **One-edit-one-span**: a 3-span chapter renders all 3; edit span 1's text; assert the planner marks **exactly** span 1 stale; regen reuses spans 0 and 2's cached WAVs **byte-for-byte**, re-synthesizes span 1 only (stub `synth` call-count == 1), and the re-stitched chapter WAV changed.
+  - **Voice reassign**: changing a span's `voice_id` flips its fingerprint (and only its); a *cast*-level reassign that M spans inherit marks exactly M stale.
+  - **Cross-chapter isolation**: editing a span in chapter 2 leaves chapter 1's cached chapter WAV untouched (chapter-key still hits).
+  - **Lexicon edit fan-out**: editing a lexicon entry marks stale exactly the spans whose respelled text changed (composes with the lexicon-in-key behavior, `audiobook.py:338–341`).
+- **Back-compat tests**: existing dub job with stored `seg_hashes` from an older build still matches (`test_backcompat_with_hashes_stored_by_previous_builds`, 87–98); an existing longform render with **no** `span_hashes` is treated as all-stale exactly once, then incremental thereafter — and produces byte-identical audio to a full render.
+- **Cross-platform**: the cache-path/realpath tests run on all three OSes in CI; assert `span_{key}.wav` path construction and containment hold on Windows path separators.
+- **Frontend**: a Playwright/unit test that editing one line shows the stale chip and that "Regenerate changed (N)" sends `regen_only` with exactly the stale ids.
+- **Keep main green**: any `frontend/package.json` touch regenerates root `bun.lock` and passes `bun install --frozen-lockfile` (Docker parity); parser twin change re-runs the golden-corpus equality test (#27).
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Span-cache explosion** (one WAV per span per fingerprint → thousands of files for a long book). | Content-addressed names self-dedupe; reuse the existing `prune_cache_dir` (`audiobook.py:494`) with an LRU/size cap; only the *current* project's fresh spans are kept hot. |
+| **Fingerprint parity drift** (server vs client hash differently → every span looks stale → degrades to full render, the #281 regression class). | Reuse `incremental._canon_value` verbatim; add the server-vs-client parity test first (TDD), exactly as dub did. |
+| **Parser-twin divergence** (Python `longform_parser` vs JS `longformParser.js` mint different span ids). | Stable ids derived from `(chapter_index, span_index)` are computed identically in both; the existing golden-corpus byte-for-byte test (#27) gates it. |
+| **Stitch seams** (per-span WAVs stitched may click vs a monolithic chapter render). | `synthesize_chapter` already crossfades spans (50 ms) and hard-concats silences (`services/audiobook.py:121–139`) — the seam behavior is identical whether a span was freshly rendered or cache-loaded (same WAV bytes). |
+| **smart_fit-style double-processing on dub** (reusing a slotted WAV under smart_fit). | Already solved: the strategy-transition guard (`dub_generate.py:122–123`) + `seg_wav_kind` (830) force a full regen when the cached WAVs are the wrong kind. No new exposure. |
+| **Existing projects forced to re-render.** | First edit treats unknown-hash spans as stale **once** (correct output), never corrupts cache; no upgrade-time mass re-render. |
+| **Emotion/style field lands in the wrong fingerprint bucket** (re-TTS when it should re-mix, or vice-versa, wasting compute or shipping stale audio). | Q1 decision pins the bucket per field; the `fit_fingerprint` precedent (incremental.py:70–116) gives both buckets a tested home; 03f ships last, after the field's semantics are known. |
+
+---
+
+## Open questions / decisions for the owner
+
+1. **Emotion/style field → which fingerprint bucket?** If the per-segment emotion/style field is fed to the engine as an instruct/direction (changes TTS output), it's a **`span_fingerprint`/`segment_fingerprint` input** (re-TTS on change). If it's a post-render DSP/style transfer (re-mix), it belongs in a **fit-style fingerprint** (re-mix, no re-TTS). Dub's `direction` is already the former. Please confirm the bucket per the emotion/style spec when it lands (drives 03f).
+2. **Audiobook span ids vs the raw-script-blob single-source-of-truth.** Editing a span writes back inline `[voice:NAME]`/text into the `script` string (so the blob stays authoritative, per spec 31). Stable span ids derived from `(chapter_index, span_index)` shift when the user inserts a paragraph above. Acceptable to treat an inserted span as "new → stale" and shift downstream ids (cheap, correct), or do we want content-anchored ids? Recommendation: positional ids + "shifted = stale once"; revisit only if users report churn.
+3. **Single-id re-translate cost.** `POST /dub/translate` (`dub_translate.py:222`) loads a translation model; a per-line re-translate pays that once per call. Cache the loaded model module-level (nllb already is, 232–306) so single-id calls are cheap — confirm acceptable, or batch re-translate the stale set instead of per-line.
+4. **`POST /audiobook/preview-span` — build it or reuse client-side preview?** Stories previews client-side (`previewTrack`). If audiobook structured view needs server-side single-span audition, add the thin endpoint; otherwise reuse the client path. Owner call on whether the thin endpoint is worth it for 03e.
+5. **Scope of "timing" for longform.** Confirmed non-goal: longform has no per-line slots, so per-segment *timing* stays dub-only; longform "timing" = existing `[pause]` + per-line `speed`. Flag if the owner wants longform pause/speed surfaced as first-class per-span timing controls (small add to the span row).

--- a/docs/specs/2026-06-12-elevenlabs-parity-program.md
+++ b/docs/specs/2026-06-12-elevenlabs-parity-program.md
@@ -1,3 +1,5 @@
+> **Superseded (2026-06-25)** by [00-roadmap-elevenlabs-parity.md](00-roadmap-elevenlabs-parity.md) and specs 01–03. Retained for historical context.
+
 # ElevenLabs-Parity Program — Implementation Spec
 
 **Date:** 2026-06-12

--- a/docs/specs/2026-06-13-stories-audiobook-maturity.md
+++ b/docs/specs/2026-06-13-stories-audiobook-maturity.md
@@ -1,3 +1,5 @@
+> **Superseded (2026-06-25)** by [00-roadmap-elevenlabs-parity.md](00-roadmap-elevenlabs-parity.md) and specs 01–03. Retained for historical context.
+
 # Stories Editor & Audiobook — Maturity Spec
 
 > Compiled 2026-06-13. Targets the v0.3.x continuous-to-main line. Grounds every

--- a/docs/specs/studio-v1.md
+++ b/docs/specs/studio-v1.md
@@ -1,3 +1,5 @@
+> **Superseded (2026-06-25)** by [00-roadmap-elevenlabs-parity.md](00-roadmap-elevenlabs-parity.md) and specs 01–03. Retained for historical context.
+
 # Studio / Projects — v1 spec
 
 **Goal:** ElevenLabs-Studio parity for long-form narration. A user pastes (or drags in) a 10-page script, the app splits it into blocks, they assign a voice per block, preview inline, then hit Generate to get one stitched WAV.


### PR DESCRIPTION
## Summary

Adds the implementation-ready spec set that maps OmniVoice toward ElevenLabs parity **while preserving local-first** (no accounts, no cloud, no telemetry). These are codebase-grounded — each cites the real files/services to extend and is decomposed into slices that land on the v0.3.x line.

## Contents
- **00-roadmap-elevenlabs-parity.md** — gap-analysis table, prioritized Tier 1/2, dependency graph + recommended sequencing, cross-cutting principles, a deliberate "won't build" list (accounts/cloud/marketplace/telemetry), and a **Prior art & reconciliation** section.
- **01-expressive-tts.md** — engine-agnostic emotion/style intent *lowered* onto each engine's real mechanism (OmniVoice `instruct`, CosyVoice tags, IndexTTS2 emotion vector, VoxCPM2 prefix), **degrading visibly**; + a DB-persisted, per-language pronunciation dictionary. Builds on `ssml_lite.py`/`pronunciation.py`/`longform_parser.py`.
- **02-conversational-agent.md** — fully-offline full-duplex voice agent (`/ws/converse`, Silero-VAD barge-in on AEC-cleaned mic) composing existing streaming STT/TTS + local LLM (`llm_backend.py`).
- **03-longform-studio-editor.md** — per-segment edit / regenerate-one-line / reassign across dub+audiobook+stories, extending the existing content-addressed cache to longform.

## Reconciliation
Prior planning docs classified S/F/K (table in 00). Three substantially-superseded docs (`2026-06-12-elevenlabs-parity-program`, `2026-06-13-stories-audiobook-maturity`, `studio-v1`) get a banner pointing here; distinct-scope docs left untouched. Salvaged ideas (consent-locked profiles + watermarking, ACX mastering, GPU-preflight) folded into 00.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Docs-only update adding an implementation-ready ElevenLabs-parity roadmap and three Tier-1 spec docs for local-first voice features.

### What changed
- Added a master roadmap that:
  - maps capability gaps vs. ElevenLabs
  - prioritizes Tier 1 vs Tier 2 work
  - defines sequencing/dependencies
  - captures cross-cutting principles and explicit “won’t build” boundaries
  - reconciles older planning docs as superseded/folded-in/retained
- Added **Expressive TTS** spec:
  - engine-agnostic emotion/style intent
  - degradation when engines can’t support a requested expression
  - DB-backed pronunciation dictionary with inline overrides
  - backend parsing/lowering and API wiring
- Added **Conversational Agent** spec:
  - offline full-duplex `/ws/converse` voice loop
  - VAD barge-in + AEC-cleaned mic input
  - streaming STT, local LLM, streaming TTS
  - conversation persistence and privacy constraints
- Added **Longform Studio Editor** spec:
  - per-segment edits, one-line regeneration, voice reassignment
  - cached span-level incremental rendering for dub/audiobook/stories
  - back-compat and testing plan
- Updated older planning docs with superseded banners pointing to the new roadmap/spec set.

### Behavior flow
```mermaid
flowchart LR
  A[Mic input] --> B[AEC cleanup]
  B --> C[VAD / barge-in]
  C --> D[Streaming STT]
  D --> E[Local LLM]
  E --> F[Sentence chunking]
  F --> G[Streaming TTS]
  G --> H[Playback]

  I[Longform editor change] --> J[Span fingerprint/cache lookup]
  J --> K{Cache hit?}
  K -- yes --> L[Reuse rendered span]
  K -- no --> M[Regenerate span]
  M --> L
  L --> N[Stitch final output]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->