### PR TITLE
fix(setup): pin the HF-token card next to Continue (not buried in the model list)

### DIFF
--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { openExternal } from '../api/external';
+
+/**
+ * HfTokenCard — the optional "add a free Hugging Face token for faster
+ * downloads" card. Lifted out of the model library so the wizard can pin it
+ * right next to the Continue / "Waiting for required models…" button (always
+ * visible, no scrolling through the model list to find it). A free token gives
+ * authenticated downloads — faster, higher rate limits, fewer stalls — and
+ * unlocks gated models (pyannote speaker diarization). Persisted via the same
+ * `set-env` endpoint Settings uses, so it survives restarts.
+ *
+ * @param {string=} className extra class on the root (e.g. layout pinning).
+ */
+export default function HfTokenCard({ className = '' }) {
+  const { t } = useTranslation();
+  const [hfToken, setHfToken] = useState('');
+  const [hfState, setHfState] = useState('idle'); // idle | saving | saved | error
+
+  const saveHfToken = async () => {
+    const value = hfToken.trim();
+    if (!value || hfState === 'saving') return;
+    setHfState('saving');
+    try {
+      const { API } = await import('../api/client');
+      const res = await fetch(`${API}/system/set-env`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'HF_TOKEN', value }),
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      setHfState('saved');
+      setHfToken('');
+    } catch {
+      setHfState('error');
+    }
+  };
+
+  return (
+    <div className={`swiz-lib__hfcard ${hfState === 'saved' ? 'is-saved' : ''} ${className}`.trim()}>
+      <div className="swiz-lib__hfcard-main">
+        <span className="swiz-lib__hfcard-icon" aria-hidden="true">⚡</span>
+        <div className="swiz-lib__hfcard-text">
+          <div className="swiz-lib__hfcard-title">
+            {hfState === 'saved'
+              ? `✓ ${t('firstrun.hf_token_saved_fast', 'Hugging Face token saved — downloads are now faster')}`
+              : t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
+          </div>
+          <p className="swiz-lib__hfcard-hint">
+            {t('firstrun.hf_token_hint', 'A free account token gives authenticated downloads (faster, higher rate limits, fewer stalls) and unlocks gated models like speaker diarization for multi-speaker dubbing (pyannote). Stays on this machine.')}
+          </p>
+        </div>
+      </div>
+      {hfState !== 'saved' && (
+        <>
+          <div className="swiz-lib__hf-row">
+            <input
+              className="frs-input"
+              type="password"
+              placeholder="hf_…"
+              value={hfToken}
+              autoComplete="off"
+              onChange={(e) => { setHfToken(e.target.value); if (hfState !== 'idle') setHfState('idle'); }}
+              onKeyDown={(e) => { if (e.key === 'Enter') saveHfToken(); }}
+              aria-label={t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
+            />
+            <button
+              type="button"
+              className="frs-btn frs-btn--primary swiz-lib__hfcard-save"
+              disabled={!hfToken.trim() || hfState === 'saving'}
+              onClick={saveHfToken}
+            >
+              {hfState === 'saving'
+                ? t('firstrun.hf_token_saving', 'saving…')
+                : t('firstrun.hf_token_save', 'Save')}
+            </button>
+          </div>
+          <button
+            type="button"
+            className="swiz-lib__hfcard-link"
+            onClick={() => openExternal('https://huggingface.co/settings/tokens')}
+          >
+            {t('firstrun.hf_token_get', "Don't have a token? Get one free →")}
+          </button>
+        </>
+      )}
+      {hfState === 'error' && (
+        <p className="frs__blocker">{t('firstrun.hf_token_error', 'Could not save the token — try again or set it later in Settings → Credentials.')}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WizardLibrary.jsx
+++ b/frontend/src/components/WizardLibrary.jsx
@@ -20,7 +20,6 @@ import { toast } from 'react-hot-toast';
 import { useModels, useInstallModel } from '../api/hooks';
 import { setupDownloadStreamUrl } from '../api/setup';
 import { listEngines, selectEngine } from '../api/engines';
-import { openExternal } from '../api/external';
 
 const fmtGB = (gb) => (gb == null ? '' : `${gb.toFixed(gb < 10 ? 1 : 0)} GB`);
 
@@ -119,31 +118,7 @@ export default function WizardLibrary() {
   const [progress, setProgress] = useState({}); // { repo_id: { phase, files } }
   const [showTail, setShowTail] = useState(false);
   const [switching, setSwitching] = useState(null);
-  const [hfToken, setHfToken] = useState('');
-  const [hfState, setHfState] = useState('idle'); // idle | saving | saved | error
   const esRef = useRef(null);
-
-  // Optional HF token: unlocks gated models (e.g. pyannote speaker
-  // diarization). Same persistence endpoint Settings uses — the backend
-  // writes it durably so it survives restarts.
-  const saveHfToken = async () => {
-    const value = hfToken.trim();
-    if (!value || hfState === 'saving') return;
-    setHfState('saving');
-    try {
-      const { API } = await import('../api/client');
-      const res = await fetch(`${API}/system/set-env`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: 'HF_TOKEN', value }),
-      });
-      if (!res.ok) throw new Error(String(res.status));
-      setHfState('saved');
-      setHfToken('');
-    } catch {
-      setHfState('error');
-    }
-  };
 
   const models = useMemo(() => {
     const list = modelsQuery.data;
@@ -336,62 +311,6 @@ export default function WizardLibrary() {
           {t('firstrun.resume_note', 'Interrupted downloads resume automatically — closing the app is safe.')}
         </p>
       )}
-      {/* Prominent, always-visible (no longer a collapsed "advanced" fold that
-          nobody opened) and positioned right above Continue. A free token gives
-          authenticated downloads — faster, higher rate limits, fewer stalls — so
-          first-run setup finishes quicker. Encouraged, not hidden (#657 → owner
-          follow-up). */}
-      <div className={`swiz-lib__hfcard ${hfState === 'saved' ? 'is-saved' : ''}`}>
-        <div className="swiz-lib__hfcard-main">
-          <span className="swiz-lib__hfcard-icon" aria-hidden="true">⚡</span>
-          <div className="swiz-lib__hfcard-text">
-            <div className="swiz-lib__hfcard-title">
-              {hfState === 'saved'
-                ? `✓ ${t('firstrun.hf_token_saved_fast', 'Hugging Face token saved — downloads are now faster')}`
-                : t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
-            </div>
-            <p className="swiz-lib__hfcard-hint">
-              {t('firstrun.hf_token_hint', 'A free account token gives authenticated downloads (faster, higher rate limits, fewer stalls) and unlocks gated models like speaker diarization for multi-speaker dubbing (pyannote). Stays on this machine.')}
-            </p>
-          </div>
-        </div>
-        {hfState !== 'saved' && (
-          <>
-            <div className="swiz-lib__hf-row">
-              <input
-                className="frs-input"
-                type="password"
-                placeholder="hf_…"
-                value={hfToken}
-                autoComplete="off"
-                onChange={(e) => { setHfToken(e.target.value); if (hfState !== 'idle') setHfState('idle'); }}
-                onKeyDown={(e) => { if (e.key === 'Enter') saveHfToken(); }}
-                aria-label={t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
-              />
-              <button
-                type="button"
-                className="frs-btn frs-btn--primary swiz-lib__hfcard-save"
-                disabled={!hfToken.trim() || hfState === 'saving'}
-                onClick={saveHfToken}
-              >
-                {hfState === 'saving'
-                  ? t('firstrun.hf_token_saving', 'saving…')
-                  : t('firstrun.hf_token_save', 'Save')}
-              </button>
-            </div>
-            <button
-              type="button"
-              className="swiz-lib__hfcard-link"
-              onClick={() => openExternal('https://huggingface.co/settings/tokens')}
-            >
-              {t('firstrun.hf_token_get', "Don't have a token? Get one free →")}
-            </button>
-          </>
-        )}
-        {hfState === 'error' && (
-          <p className="frs__blocker">{t('firstrun.hf_token_error', 'Could not save the token — try again or set it later in Settings → Credentials.')}</p>
-        )}
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SetupWizard.css
+++ b/frontend/src/pages/SetupWizard.css
@@ -17,7 +17,7 @@
 }
 /* Every slide is exactly [content, .frs-wnav] — the content half scrolls,
    with a soft fade at the cut so clipped rows read as "scroll for more". */
-.swiz-slide > :not(.frs-wnav) {
+.swiz-slide > :not(.frs-wnav):not(.swiz-hfpin) {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
@@ -28,6 +28,18 @@
 .swiz-slide > .frs-wnav {
   flex-shrink: 0;
   border-top: 1px solid var(--frs-line, rgba(255, 255, 255, 0.08));
+}
+/* The HF-token card is pinned with the action row (not part of the scrolling
+   model list) so it's always visible right by Continue — see it, click it,
+   drop in a token without scrolling. Compact so it doesn't crowd the button. */
+.swiz-slide > .swiz-hfpin {
+  flex-shrink: 0;
+  margin: 0;
+}
+.swiz-hfpin .swiz-lib__hfcard-hint {
+  font-size: 0.72rem;
+  line-height: 1.45;
+  opacity: 0.7;
 }
 
 .swiz-note {

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Loader } from 'lucide-react';
 import { useSetupStatus, usePreflight } from '../api/hooks';
 import WizardLibrary from '../components/WizardLibrary';
+import HfTokenCard from '../components/HfTokenCard';
 import DictationDemo from '../components/DictationDemo';
 import '../components/FirstRunSetup.css';
 import './SetupWizard.css';
@@ -251,6 +252,10 @@ export default function SetupWizard({ onReady }) {
                 </p>
               )}
             </section>
+            {/* Pinned next to Continue (not buried at the bottom of the
+                scrolling model list) so it's visible without scrolling — you
+                can see it and drop in a token right by the action. */}
+            <HfTokenCard className="swiz-hfpin" />
             <div className="frs-wnav frs-rise" style={{ '--rise': 2 }}>
               <button type="button" className="frs-btn frs-btn--quiet" onClick={() => setStep(0)}>
                 ← {t('setup.back')}


### PR DESCRIPTION
## Summary

On the first-run **Models & engines** step, the *"Add a free Hugging Face token for faster downloads"* card was rendered at the **bottom of the scrolling model library** — so you had to scroll past every model to find it, even though the action it sits next to (the **"Waiting for required models…" / Continue** button) is pinned and always visible.

This moves the card into the wizard's **pinned action area, right above that button** — visible at a glance, so you can drop in a token without scrolling.

## Changes
- Extracted the card from `WizardLibrary.jsx` into a standalone **`HfTokenCard.jsx`** (self-contained state + the same `set-env` save path — no behavior change).
- Rendered it pinned in `SetupWizard.jsx` between the scrolling model list and the `.frs-wnav` button row; `SetupWizard.css` excludes it from the scroll region (`flex-shrink: 0`) and compacts the hint so it doesn't crowd the button.
- Removed the now-orphaned `openExternal` import from `WizardLibrary`.

## Testing
- `bun run build` clean; full suite **636 pass** (incl. `wizardLibraryAggregate` / `wizardLibraryPlatformPick`).
- Same i18n keys, same save endpoint — purely a placement change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What changed

- Moved the “Add a free Hugging Face token for faster downloads” card out of the scrollable model library and into the pinned action area of the Models & engines setup step.
- Extracted the card into a standalone `HfTokenCard` component, keeping the same token save flow (`set-env` via `HF_TOKEN`) and local save states.
- Updated wizard layout/CSS so the card stays visible above the Continue button and doesn’t scroll with the model list.
- Removed the unused `openExternal` import and the old inlined HF token UI from `WizardLibrary`.

## Layout

Before:
```text
[scrollable model library]
  ...
  [Hugging Face token card]
[always-visible Continue button]
```

After:
```text
[scrollable model library]
  ...
[pinned Hugging Face token card]
[always-visible Continue button]
```

## Behavior

```mermaid
flowchart TD
  A[SetupWizard step 1 renders] --> B[Show scrollable model list]
  B --> C[Render pinned HfTokenCard above Continue]
  C --> D[User enters token]
  D --> E[Save clicked]
  E --> F[POST HF_TOKEN to /system/set-env]
  F -->|success| G[Clear input and show saved state]
  F -->|failure| H[Show error state]

<!-- end of auto-generated comment: release notes by coderabbit.ai -->