### PR TITLE
feat(setup): compact inline HF-token input pinned with Continue

### DIFF
--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -3,13 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { openExternal } from '../api/external';
 
 /**
- * HfTokenCard — the optional "add a free Hugging Face token for faster
- * downloads" card. Lifted out of the model library so the wizard can pin it
- * right next to the Continue / "Waiting for required models…" button (always
- * visible, no scrolling through the model list to find it). A free token gives
- * authenticated downloads — faster, higher rate limits, fewer stalls — and
- * unlocks gated models (pyannote speaker diarization). Persisted via the same
- * `set-env` endpoint Settings uses, so it survives restarts.
+ * HfTokenCard — a compact, single-line Hugging Face token input that lives in
+ * the wizard's pinned action area, right by the "Waiting for required models…"
+ * / Continue button. It takes only the HF token: paste it, Save, done. A free
+ * token gives authenticated downloads (faster, higher rate limits, fewer
+ * stalls) and unlocks gated models (pyannote diarization). Persisted via the
+ * same `set-env` endpoint Settings uses, so it survives restarts.
  *
  * @param {string=} className extra class on the root (e.g. layout pinning).
  */
@@ -37,56 +36,54 @@ export default function HfTokenCard({ className = '' }) {
     }
   };
 
-  return (
-    <div className={`swiz-lib__hfcard ${hfState === 'saved' ? 'is-saved' : ''} ${className}`.trim()}>
-      <div className="swiz-lib__hfcard-main">
-        <span className="swiz-lib__hfcard-icon" aria-hidden="true">⚡</span>
-        <div className="swiz-lib__hfcard-text">
-          <div className="swiz-lib__hfcard-title">
-            {hfState === 'saved'
-              ? `✓ ${t('firstrun.hf_token_saved_fast', 'Hugging Face token saved — downloads are now faster')}`
-              : t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
-          </div>
-          <p className="swiz-lib__hfcard-hint">
-            {t('firstrun.hf_token_hint', 'A free account token gives authenticated downloads (faster, higher rate limits, fewer stalls) and unlocks gated models like speaker diarization for multi-speaker dubbing (pyannote). Stays on this machine.')}
-          </p>
-        </div>
+  if (hfState === 'saved') {
+    return (
+      <div className={`swiz-hfbar is-saved ${className}`.trim()}>
+        <span className="swiz-hfbar__done">
+          <span aria-hidden="true">✓</span>{' '}
+          {t('firstrun.hf_token_saved_fast', 'Hugging Face token saved — downloads are now faster')}
+        </span>
       </div>
-      {hfState !== 'saved' && (
-        <>
-          <div className="swiz-lib__hf-row">
-            <input
-              className="frs-input"
-              type="password"
-              placeholder="hf_…"
-              value={hfToken}
-              autoComplete="off"
-              onChange={(e) => { setHfToken(e.target.value); if (hfState !== 'idle') setHfState('idle'); }}
-              onKeyDown={(e) => { if (e.key === 'Enter') saveHfToken(); }}
-              aria-label={t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
-            />
-            <button
-              type="button"
-              className="frs-btn frs-btn--primary swiz-lib__hfcard-save"
-              disabled={!hfToken.trim() || hfState === 'saving'}
-              onClick={saveHfToken}
-            >
-              {hfState === 'saving'
-                ? t('firstrun.hf_token_saving', 'saving…')
-                : t('firstrun.hf_token_save', 'Save')}
-            </button>
-          </div>
-          <button
-            type="button"
-            className="swiz-lib__hfcard-link"
-            onClick={() => openExternal('https://huggingface.co/settings/tokens')}
-          >
-            {t('firstrun.hf_token_get', "Don't have a token? Get one free →")}
-          </button>
-        </>
-      )}
+    );
+  }
+
+  return (
+    <div className={`swiz-hfbar ${className}`.trim()}>
+      <span className="swiz-hfbar__icon" aria-hidden="true">⚡</span>
+      <span className="swiz-hfbar__prompt">
+        {t('firstrun.hf_token_inline_prompt', 'Speed up downloads with a free Hugging Face token')}
+      </span>
+      <input
+        className="frs-input swiz-hfbar__input"
+        type="password"
+        placeholder={t('firstrun.hf_token_inline_ph', 'Paste hf_… token (optional)')}
+        value={hfToken}
+        autoComplete="off"
+        onChange={(e) => { setHfToken(e.target.value); if (hfState !== 'idle') setHfState('idle'); }}
+        onKeyDown={(e) => { if (e.key === 'Enter') saveHfToken(); }}
+        aria-label={t('firstrun.hf_token_card_title', 'Add a free Hugging Face token for faster downloads')}
+      />
+      <button
+        type="button"
+        className="frs-btn frs-btn--primary swiz-hfbar__save"
+        disabled={!hfToken.trim() || hfState === 'saving'}
+        onClick={saveHfToken}
+      >
+        {hfState === 'saving'
+          ? t('firstrun.hf_token_saving', 'saving…')
+          : t('firstrun.hf_token_save', 'Save')}
+      </button>
+      <button
+        type="button"
+        className="swiz-hfbar__link"
+        onClick={() => openExternal('https://huggingface.co/settings/tokens')}
+      >
+        {t('firstrun.hf_token_get_short', 'Get one free →')}
+      </button>
       {hfState === 'error' && (
-        <p className="frs__blocker">{t('firstrun.hf_token_error', 'Could not save the token — try again or set it later in Settings → Credentials.')}</p>
+        <span className="swiz-hfbar__err">
+          {t('firstrun.hf_token_error', 'Could not save the token — try again or set it later in Settings → Credentials.')}
+        </span>
       )}
     </div>
   );

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2027,7 +2027,10 @@
     "hf_token_saving": "saving…",
     "hf_token_saved": "Hugging Face token saved",
     "hf_token_saved_fast": "Hugging Face token saved — downloads are now faster",
-    "hf_token_error": "Could not save the token — try again or set it later in Settings → Credentials."
+    "hf_token_error": "Could not save the token — try again or set it later in Settings → Credentials.",
+    "hf_token_inline_prompt": "Speed up downloads with a free Hugging Face token",
+    "hf_token_inline_ph": "Paste hf_… token (optional)",
+    "hf_token_get_short": "Get one free →"
   },
   "history": {
     "dub_title": "Dub history",

--- a/frontend/src/pages/SetupWizard.css
+++ b/frontend/src/pages/SetupWizard.css
@@ -36,11 +36,6 @@
   flex-shrink: 0;
   margin: 0;
 }
-.swiz-hfpin .swiz-lib__hfcard-hint {
-  font-size: 0.72rem;
-  line-height: 1.45;
-  opacity: 0.7;
-}
 
 .swiz-note {
   margin: 0;
@@ -183,38 +178,40 @@
 
 .swiz-lib__more { align-self: flex-start; }
 
-/* HF token — prominent card just above Continue (was a quiet fold). A free
-   token = authenticated, faster downloads, so we surface + encourage it. */
-.swiz-lib__hfcard {
-  margin-top: 0.9rem;
-  padding: 0.8rem 0.9rem;
+/* HF token — a compact single-line input pinned with the Continue action.
+   Paste a token, Save; a free token = authenticated, faster downloads. */
+.swiz-hfbar {
   display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-  max-width: 560px;
-  border: 1px solid color-mix(in srgb, var(--frs-accent, #d3869b) 38%, transparent);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--frs-accent, #d3869b) 8%, transparent);
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--frs-accent, #d3869b) 32%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--frs-accent, #d3869b) 7%, transparent);
+  font-size: 0.8rem;
 }
-.swiz-lib__hfcard.is-saved {
+.swiz-hfbar.is-saved {
   border-color: color-mix(in srgb, var(--frs-ok, #b8bb26) 45%, transparent);
   background: color-mix(in srgb, var(--frs-ok, #b8bb26) 9%, transparent);
 }
-.swiz-lib__hfcard-main { display: flex; gap: 0.6rem; align-items: flex-start; }
-.swiz-lib__hfcard-icon { font-size: 1.1rem; line-height: 1.3; }
-.swiz-lib__hfcard-text { display: flex; flex-direction: column; gap: 0.2rem; }
-.swiz-lib__hfcard-title { font-weight: 600; font-size: 0.92rem; }
-.swiz-lib__hfcard-hint { margin: 0; font-size: 0.78rem; opacity: 0.66; line-height: 1.4; }
-.swiz-lib__hfcard-save { white-space: nowrap; }
-.swiz-lib__hfcard-link {
-  align-self: flex-start;
+.swiz-hfbar__icon { font-size: 1rem; line-height: 1; }
+.swiz-hfbar__prompt { font-weight: 600; }
+.swiz-hfbar__input { flex: 1 1 180px; min-width: 130px; }
+.swiz-hfbar__save { white-space: nowrap; }
+.swiz-hfbar__link {
   background: none;
   border: none;
   padding: 0;
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   color: var(--frs-accent, #d3869b);
   cursor: pointer;
   text-decoration: underline;
+  white-space: nowrap;
 }
-.swiz-lib__hf-row { display: flex; gap: 0.45rem; }
-.swiz-lib__hf-row .frs-input { flex: 1; }
+.swiz-hfbar__done { font-weight: 600; color: var(--frs-ok, #b8bb26); }
+.swiz-hfbar__err { flex-basis: 100%; font-size: 0.76rem; color: var(--frs-err, #fb4934); }
+/* On a tight width drop the prose prompt; the placeholder still explains it. */
+@media (max-width: 560px) {
+  .swiz-hfbar__prompt { display: none; }
+}


### PR DESCRIPTION
## Summary

Follow-up to #687. Converts the Hugging Face token element on the first-run **Models & engines** step from a bulky card into a **compact single-line input bar**, pinned right by the *"Waiting for required models…" / Continue* button.

**Before:** a card with an icon, bold title, a 3-line paragraph, an input row, a Save button, and a separate "get one free" link — a lot of vertical weight.

**After:** one slim row — `⚡ Speed up downloads with a free Hugging Face token  [ paste hf_… ] [Save]  Get one free →` — that takes **only the token**. On save it collapses to a slim `✓ … saved — downloads are now faster`. The prose prompt hides under 560px (placeholder still explains it).

## Changes
- Rewrote `HfTokenCard.jsx` as the inline bar (same `set-env` save path, Enter-to-save, error inline).
- Swapped the `.swiz-lib__hfcard*` card CSS for compact `.swiz-hfbar*` styles in `SetupWizard.css` (still pinned via `swiz-hfpin`, excluded from the scrolling model list); removed the now-dead hint rule.
- Added 3 i18n keys (`hf_token_inline_prompt`, `hf_token_inline_ph`, `hf_token_get_short`).

## Testing
- `bun run build` clean; `en.json` valid; wizard tests pass; no dangling refs to the old classes.
- Same endpoint + behavior — purely a presentation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
Updated the first-run **Models & engines** Hugging Face token step from a large card into a compact inline bar pinned beside the **Waiting for required models… / Continue** action.

### What changed
- Reworked `HfTokenCard.jsx` into a single-line token entry with inline save/error handling and a separate saved state.
- Replaced the old card-based styles in `SetupWizard.css` with compact pinned bar styling.
- Added new i18n strings for the inline prompt, token placeholder, and “Get one free” link.
- Kept the same save endpoint and overall flow.

### Layout sketch
**Before**
```text
[ Hugging Face token card ]
[ title ]
[ hint text ]
[ token input                    ]
[ save button ] [ get one free ]
[ error / saved state ]
```

**After**
```text
[ 📦 prompt text ] [ token input ][ Save ][ Get one free ]
[ inline error / saved message ]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->