### PR TITLE
fix(settings): full-width content + fix right-side wrapping/overflow/padding

### DIFF
--- a/frontend/src/components/settings/HFMirrorPanel.jsx
+++ b/frontend/src/components/settings/HFMirrorPanel.jsx
@@ -66,6 +66,7 @@ export default function HFMirrorPanel() {
       {error && <div className="perfpanel__error" role="alert">{error}</div>}
 
       <SettingRow
+        className="st-row--stack"
         title="Mirror preset"
         hint="On a restricted network, route model downloads through a mirror. Applies after a restart. Leave empty for the official endpoint."
         control={
@@ -81,12 +82,13 @@ export default function HFMirrorPanel() {
       />
 
       <SettingRow
+        className="st-row--stack"
         title="HF_ENDPOINT"
         subtitle={restart ? 'Restart the app for the change to take effect.' : undefined}
         control={
           <>
-            <input type="text" value={url} onChange={(e) => setUrl(e.target.value)}
-              placeholder="https://hf-mirror.com" style={{ flex: 1, minWidth: 180 }} data-testid="hf-mirror-url" />
+            <input className="st-input st-input--mono" type="text" value={url} onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://hf-mirror.com" data-testid="hf-mirror-url" />
             <button type="button" onClick={() => save(url)} disabled={saving} data-testid="hf-mirror-save">
               {saving ? 'Saving…' : 'Save'}
             </button>

--- a/frontend/src/components/settings/StoragePanel.css
+++ b/frontend/src/components/settings/StoragePanel.css
@@ -3,18 +3,23 @@
    buttons and the restart/error notices carry panel-specific chrome, all routed
    through --chrome-* tokens so they theme correctly across every theme. */
 
-/* The path input + Save/Reset cluster sits inside a SettingRow control. */
+/* The path input + Save/Reset cluster sits inside a SettingRow control. The row
+   is `--stack`, so the cluster gets the full row width below the label. */
 .storagepanel__field {
   display: flex;
   gap: var(--space-3);
   align-items: center;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  width: 100%;
 }
 
 .storagepanel__input {
   flex: 1 1 280px;
+  /* Path inputs read best wide, but cap so they don't sprawl edge-to-edge on an
+     ultra-wide window. Never overflow the panel: min-width:0 + border-box. */
+  max-width: 520px;
   min-width: 0;
+  box-sizing: border-box;
   padding: var(--space-2) var(--space-3);
   font-size: var(--text-base);
   font-family: var(--chrome-font-mono);

--- a/frontend/src/components/settings/StoragePanel.jsx
+++ b/frontend/src/components/settings/StoragePanel.jsx
@@ -87,6 +87,7 @@ export default function StoragePanel() {
       {error && <div className="storagepanel__error" role="alert">{error}</div>}
 
       <SettingRow
+        className="st-row--stack"
         align="start"
         title="Cache location"
         subtitle="Where model weights download"

--- a/frontend/src/components/settings/primitives/primitives.css
+++ b/frontend/src/components/settings/primitives/primitives.css
@@ -131,6 +131,10 @@
   min-width: 0;
   max-width: 60%;
   text-align: right;
+  box-sizing: border-box;
+  /* Breathing room so controls (toggles, dots, inputs, values) never sit flush
+     against the section's right border. */
+  padding-right: 2px;
   /* Short control values must never wrap mid-word. Long data values opt back
      into wrapping via the --mono rule below. */
   white-space: nowrap;
@@ -140,9 +144,15 @@
   font-size: var(--text-base);
   color: var(--chrome-fg-muted);
   font-variant-numeric: tabular-nums;
-  /* data values can be long paths — allow them to wrap rather than overflow */
+  /* Data values are paths ("Effective now" / "Configured"). Let them use more
+     of the row, but NEVER break mid-word — only at real path boundaries (/ etc).
+     overflow-wrap:anywhere is the last-resort break point; word-break:normal
+     keeps it from chopping inside a word the way break-word did. */
+  max-width: 75%;
   white-space: normal;
-  word-break: break-word;
+  word-break: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.45;
 }
 
 /* ── Input rows: label on top, full-width control row below ─────
@@ -172,6 +182,8 @@
 .st-input {
   width: 100%;
   min-width: 0;
+  max-width: min(360px, 100%);
+  box-sizing: border-box;
   background: color-mix(in srgb, var(--chrome-bg) 94%, white);
   border: 1px solid var(--chrome-border);
   border-radius: var(--chrome-radius-pill);
@@ -180,6 +192,11 @@
   font-size: var(--text-sm);
   padding: var(--space-3) var(--space-4);
 }
+/* In a stacked/full-width row the input is the primary control — let it use the
+   row width instead of the 360px right-aligned cap. */
+.st-row--stack .st-input { max-width: 100%; }
+/* The Models search lives in a flex toolbar where it should stretch to fill. */
+.models-search.st-input { max-width: none; }
 .st-input--mono { font-family: var(--chrome-font-mono); }
 .st-input:focus { outline: none; border-color: var(--chrome-accent); }
 .st-input:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -106,17 +106,18 @@
   .ui-tabs.settings-tabs-ui::-webkit-scrollbar { display: none; }
 }
 
-/* ── Content panel: a calm reading column — label↔control stay close on wide
-   screens. ~760px keeps inline rows premium; expansive controls (font/theme
-   grids, Models/Engines tables) get the full width via the opt-outs below. */
+/* ── Content panel: fills the 1fr column on every page. Owner asked for genuine
+   full-width usage — no narrow reading column, no dead right-hand gutter. A
+   generous max-width keeps lines from sprawling on ultra-wide monitors, with
+   the column left-aligned so it stays flush to the nav rail. The page's own
+   padding (--space-7 sides) plus section padding gives both-side breathing
+   room; per-row rules below keep values/inputs from going flush or overflowing. */
 .settings-content {
   flex: 1 1 auto;
   min-width: 0;
-  max-width: 760px;
+  max-width: 1280px;
   align-self: start;   /* size to content — don't stretch to the taller nav rail */
 }
-/* The Models/Engines table wants the full width — opt those panels out. */
-.settings-content:has(.models-table) { max-width: none; }
 .settings-content > :first-child { margin-top: 0; }
 
 /* ── Engines tab ─────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
Follow-up to the Settings redesign, from owner review of the **live** pages:
- **Appearance** was a narrow 760px box leaving the right ~40% of the window dead-empty.
- **Models** (full-width) showed **mid-word path breaks** (`/Users/user4/.cach⏎e/huggingface`), an **overflowing HF_ENDPOINT input**, and controls **flush to the border**.

## Fixes
- **Full width:** removed the `760px` cap (+ the redundant `:has(.models-table)` opt-out); content fills the column with comfortable side padding; a `1280px` ceiling only on ultra-wide.
- **No mid-word value wrapping:** read-only mono path values wrap only at real boundaries.
- **Inputs constrained:** `min(360px,100%)` + `box-sizing` so HF_ENDPOINT / Cache-location never overflow the panel.
- **Controls breathe:** right padding on `.st-row__control`.
- **Input-heavy rows** (Mirror preset, HF_ENDPOINT, Cache location) lay out full-width below their label.

Pure presentation, no behavior changes. **636 tests pass, build clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Settings UI to use a wider, more flexible content column and to fix overflow/wrapping in settings rows.

**What changed**
- Expanded the main settings content width from a narrow reading column to a `1280px` ceiling.
- Added side padding/box sizing so controls aren’t flush against the edge.
- Improved wrapping for long mono/path values so they break at sensible boundaries.
- Constrained standard inputs to prevent overflow while allowing full-width layouts where needed.
- Converted input-heavy rows like Mirror preset, HF_ENDPOINT, and cache/location fields to stacked layouts.

**Layout sketch**

Before:
```text
+--------------------------------------------------+
| Settings content                                  |
|  [ narrow 760px column ]                         |
|   label    [input]                               |
|   label    long path value overflows/wraps badly |
+--------------------------------------------------+
```

After:
```text
+--------------------------------------------------------------+
| Settings content                                             |
|  [ wider column, up to 1280px ]                              |
|   label                                                     |
|   [ full-width control / stacked input ]                    |
|   label    mono/path value wraps cleanly within bounds     |
+--------------------------------------------------------------+
```

**Files touched**
- `frontend/src/pages/Settings.css`
- `frontend/src/components/settings/primitives/primitives.css`
- `frontend/src/components/settings/HFMirrorPanel.jsx`
- `frontend/src/components/settings/StoragePanel.jsx`
- `frontend/src/components/settings/StoragePanel.css`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->