### PR TITLE
fix(dub): reset gracefully on a stale job during initial upload/ingest (#695)

### DIFF
--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -289,10 +289,11 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     } catch (err) {
       setDubPrepStage(null);
       if (err.name === 'AbortError') { toast(t('dub_workflow.upload_cancelled')); setDubStep('idle'); useAppStore.getState().dismissPill(); }
+      else if (isExpiredDubJobError(err)) { _resetStaleDubSession(); }
       else { setDubError(err.message); setDubStep('idle'); toastErrorWithReport(t('dub_workflow.upload_failed', { message: err.message }), err); useAppStore.getState().errorPill(err.message); }
       setTranscribeStart(null);
     } finally { dubAbortCtrlRef.current = null; }
-  }, [setDubStep, setDubError, setDubFailure, setDubTracks, setDubPrepStage, setDubJobId, setDubFilename, setDubTaskId, setDubSegments, _waitForPrep, _waitForTranscribe, loadProjects, loadProfiles]);
+  }, [setDubStep, setDubError, setDubFailure, setDubTracks, setDubPrepStage, setDubJobId, setDubFilename, setDubTaskId, setDubSegments, _waitForPrep, _waitForTranscribe, loadProjects, loadProfiles, _resetStaleDubSession]);
 
   const handleDubIngestUrl = useCallback(async (url, opts = {}) => {
     const clean = (url || '').trim();
@@ -321,10 +322,11 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
     } catch (err) {
       setDubPrepStage(null);
       if (err.name === 'AbortError') { toast(t('dub_workflow.ingest_cancelled')); setDubStep('idle'); useAppStore.getState().dismissPill(); }
+      else if (isExpiredDubJobError(err)) { _resetStaleDubSession(); }
       else { setDubError(err.message); setDubStep('idle'); toastErrorWithReport(t('dub_workflow.ingest_failed', { message: err.message }), err); useAppStore.getState().errorPill(err.message); }
       setTranscribeStart(null);
     } finally { dubAbortCtrlRef.current = null; }
-  }, [setDubStep, setDubError, setDubFailure, setDubTracks, setDubPrepStage, setDubJobId, setDubTaskId, setDubSegments, _waitForPrep, _waitForTranscribe, loadProjects, loadProfiles]);
+  }, [setDubStep, setDubError, setDubFailure, setDubTracks, setDubPrepStage, setDubJobId, setDubTaskId, setDubSegments, _waitForPrep, _waitForTranscribe, loadProjects, loadProfiles, _resetStaleDubSession]);
 
   const handleDubAbort = useCallback(async () => {
     const jobId = dubClientJobIdRef.current || dubJobId;

--- a/frontend/src/test/dubExpiredJobError.test.js
+++ b/frontend/src/test/dubExpiredJobError.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { isExpiredDubJobError } from '../hooks/useDubWorkflow.js';
+import dubWorkflowSrc from '../hooks/useDubWorkflow.js?raw';
 
 describe('isExpiredDubJobError (#660 — stale dub session)', () => {
   it('matches the backend dub_core preflight message', () => {
@@ -30,5 +31,30 @@ describe('isExpiredDubJobError (#660 — stale dub session)', () => {
     expect(isExpiredDubJobError(null)).toBe(false);
     expect(isExpiredDubJobError(undefined)).toBe(false);
     expect(isExpiredDubJobError({})).toBe(false);
+  });
+});
+
+describe('#695 — every dub handler resets on a stale job (regression of #660)', () => {
+  const src = dubWorkflowSrc;
+
+  it('all four catch handlers route a stale-job error through the predicate, not a bug-report toast', () => {
+    // upload, ingest, retry, import — #660 only wired retry+import, leaving the
+    // two initial handlers to surface the scary "report a bug" toast (#695).
+    const matches = src.match(/isExpiredDubJobError\(err\)/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('the initial upload + ingest handlers check the predicate BEFORE toastErrorWithReport', () => {
+    for (const fn of ['handleDubUpload', 'handleDubIngestUrl']) {
+      const start = src.indexOf(`const ${fn} =`);
+      expect(start, `${fn} should exist`).toBeGreaterThan(-1);
+      const body = src.slice(start, start + 2500);
+      const guardIdx = body.indexOf('isExpiredDubJobError(err)');
+      const reportIdx = body.indexOf('toastErrorWithReport');
+      expect(guardIdx, `${fn} must handle a stale job`).toBeGreaterThan(-1);
+      expect(reportIdx, `${fn} should still report real failures`).toBeGreaterThan(-1);
+      // graceful stale-job reset must come before the reportable fallback
+      expect(guardIdx).toBeLessThan(reportIdx);
+    }
   });
 });


### PR DESCRIPTION
## Summary
Fixes #695 — Video Dubbing Studio showing **"Job not found. It may have been cleaned up or was never created."** with a *report-a-bug* toast.

## Root cause
The #660 fix added stale-job recovery (`isExpiredDubJobError(err)` → `_resetStaleDubSession()`) to the **retry** and **SRT-import** handlers — but missed the two **initial** handlers (`handleDubUpload`, `handleDubIngestUrl`). So when a job went missing during the first upload→prep→transcribe flow (backend reload, in-memory cache eviction, or manual cleanup), those handlers fell through to the reportable `toastErrorWithReport` path — the exact scary error the user hit. It's a recoverable stale-session state, not a bug.

## Fix
- Route stale-job errors through `isExpiredDubJobError()` in **both initial handlers** (before the reportable fallback), matching retry/import. Added `_resetStaleDubSession` to their dep arrays.
- **Regression guard:** a source-level test asserts all four dub catch-handlers check the predicate before `toastErrorWithReport` — so the #660→#695 regression class can't recur silently.

## Notes
Backend has a related race (jobs live in an in-memory `_dub_jobs` dict, lost on reload) — left untouched here because early-registering an empty job risks the transcribe path running on a half-populated job; the graceful frontend reset (the project's chosen recovery) is the correct, low-risk fix for the reported symptom.

638 frontend tests pass (+2 regression); build clean.

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed Dub Studio’s stale-job recovery so initial upload and URL ingest flows no longer surface a report-a-bug toast for recoverable “job not found” / expired-session errors.

```mermaid
flowchart TD
  A[handleDubUpload / handleDubIngestUrl error] --> B{isExpiredDubJobError?}
  B -- yes --> C[_resetStaleDubSession()]
  B -- no --> D[Generic failure path]
  D --> E[Set dubError]
  D --> F[toastErrorWithReport]
  D --> G[Show error pill]
```

Added a shared `isExpiredDubJobError(err)` helper and wired it into the initial handlers, matching the existing retry and SRT-import recovery path. A regression test now verifies all dub catch handlers check the stale-job predicate before falling back to `toastErrorWithReport`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->