### PR TITLE
fix(model): self-heal a leaked engine id in OMNIVOICE_MODEL instead of 500 (#693)

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -604,6 +604,37 @@ def _repair_model_cache(checkpoint: str) -> bool:
     return True
 
 
+_DEFAULT_OMNIVOICE_CHECKPOINT = "k2-fsa/OmniVoice"
+
+
+def resolve_omnivoice_checkpoint() -> str:
+    """Resolve the OmniVoice TTS checkpoint from ``OMNIVOICE_MODEL``, self-healing
+    a misconfigured value.
+
+    A valid checkpoint is either a HuggingFace repo id (``org/repo`` — contains a
+    ``/``) or an existing local directory. A bare token like ``"omnivoice"`` — a
+    TTS *engine id* that leaked into ``OMNIVOICE_MODEL`` (e.g. a stale pref/env) —
+    is neither, and would crash model load with *"omnivoice is not a local folder
+    and is not a valid model identifier listed on huggingface.co/models"* (#693).
+    Fall back to the default rather than 500 on every launch.
+    """
+    checkpoint = os.environ.get("OMNIVOICE_MODEL", _DEFAULT_OMNIVOICE_CHECKPOINT).strip()
+    if not checkpoint:
+        return _DEFAULT_OMNIVOICE_CHECKPOINT
+    # Honor a HF repo id (org/repo) or an EXPLICIT local path (absolute, or with
+    # a path separator). A bare token like "omnivoice" must NOT be treated as a
+    # local dir even if a cwd-relative folder happens to share its name — that
+    # is exactly the engine-id leak (#693), so self-heal to the default.
+    if "/" in checkpoint or "\\" in checkpoint or os.path.isabs(checkpoint):
+        return checkpoint
+    logger.warning(
+        "OMNIVOICE_MODEL=%r is not a HuggingFace repo id (org/repo) or a local "
+        "path — falling back to %s (#693).",
+        checkpoint, _DEFAULT_OMNIVOICE_CHECKPOINT,
+    )
+    return _DEFAULT_OMNIVOICE_CHECKPOINT
+
+
 def _load_model_sync():
     global model
     from utils.hf_progress import register_listener, unregister_listener
@@ -630,7 +661,7 @@ def _load_model_sync():
         OmniVoice = _lazy_omnivoice()
         device = get_best_device()
 
-        checkpoint = os.environ.get("OMNIVOICE_MODEL", "k2-fsa/OmniVoice")
+        checkpoint = resolve_omnivoice_checkpoint()
         _set_loading("loading_weights", f"Loading TTS weights on {device}…")
         logger.info("Loading OmniVoice model on device: %s", device)
         preload_asr = should_preload_tts_asr()

--- a/tests/test_model_checkpoint_resolve.py
+++ b/tests/test_model_checkpoint_resolve.py
@@ -1,0 +1,50 @@
+"""Regression tests for #693 — a leaked engine id ("omnivoice") in
+OMNIVOICE_MODEL must not be passed to OmniVoice.from_pretrained() (which 500s
+with "omnivoice is not a local folder and is not a valid model identifier").
+
+The resolver self-heals: only a HF repo id (org/repo) or an existing local dir
+is honored; anything else falls back to the default.
+"""
+import pytest
+
+from services.model_manager import (
+    resolve_omnivoice_checkpoint,
+    _DEFAULT_OMNIVOICE_CHECKPOINT,
+)
+
+
+def _set(monkeypatch, val):
+    if val is None:
+        monkeypatch.delenv("OMNIVOICE_MODEL", raising=False)
+    else:
+        monkeypatch.setenv("OMNIVOICE_MODEL", val)
+
+
+def test_default_when_unset(monkeypatch):
+    _set(monkeypatch, None)
+    assert resolve_omnivoice_checkpoint() == _DEFAULT_OMNIVOICE_CHECKPOINT
+
+
+@pytest.mark.parametrize("leaked", ["omnivoice", "voxcpm2", "cosyvoice", "kittentts"])
+def test_bare_engine_id_falls_back(monkeypatch, leaked):
+    """#693: an engine id (no '/', not a path) must self-heal to the default."""
+    _set(monkeypatch, leaked)
+    assert resolve_omnivoice_checkpoint() == _DEFAULT_OMNIVOICE_CHECKPOINT
+
+
+@pytest.mark.parametrize("repo", ["k2-fsa/OmniVoice", "some-org/some-model"])
+def test_valid_hf_repo_id_is_kept(monkeypatch, repo):
+    _set(monkeypatch, repo)
+    assert resolve_omnivoice_checkpoint() == repo
+
+
+def test_existing_local_dir_is_kept(monkeypatch, tmp_path):
+    d = tmp_path / "mymodel"
+    d.mkdir()
+    _set(monkeypatch, str(d))
+    assert resolve_omnivoice_checkpoint() == str(d)
+
+
+def test_blank_or_whitespace_falls_back(monkeypatch):
+    _set(monkeypatch, "   ")
+    assert resolve_omnivoice_checkpoint() == _DEFAULT_OMNIVOICE_CHECKPOINT


### PR DESCRIPTION
## Summary
Fixes #693 — `500: omnivoice is not a local folder and is not a valid model identifier listed on huggingface.co/models`.

## Root cause
A bare TTS **engine id** (`"omnivoice"`) had leaked into `OMNIVOICE_MODEL` (stale pref/env) and was passed straight to `OmniVoice.from_pretrained(checkpoint)` in `model_manager._load_model_sync`. A valid checkpoint is a HF repo id (`org/repo`) or a local path — a bare token is neither, so the load 500s on every launch.

## Fix
`resolve_omnivoice_checkpoint()` honors only a HF repo id (contains `/`) or an **explicit** local path (absolute or with a separator); any bare token **self-heals to `k2-fsa/OmniVoice`** with a logged warning. Crucially it does NOT treat a bare token as a local dir even if a cwd-relative folder shares its name (the test caught that exact false-positive).

This makes model load robust to *any* way a bad value reaches `OMNIVOICE_MODEL`, rather than band-aiding one source.

## Tests
New `tests/test_model_checkpoint_resolve.py` — engine-id leak → fallback, valid repo ids kept, absolute local dirs kept, blanks → fallback. 9 pass; route-inventory unchanged; module imports clean.

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated OmniVoice checkpoint resolution to prevent model-loading failures when `OMNIVOICE_MODEL` is stale, blank, or set to a bare engine id like `omnivoice`.

```mermaid
flowchart TD
  A[Read OMNIVOICE_MODEL] --> B[Trim value]
  B --> C{Empty or invalid?}
  C -->|Yes| D[Use default k2-fsa/OmniVoice]
  C -->|No| E{Valid checkpoint form?}
  E -->|org/repo or explicit local path| F[Use provided value]
  E -->|Bare token| G[Warn and self-heal to default]
  F --> H[Load OmniVoice model]
  D --> H
  G --> H
```

- Added `resolve_omnivoice_checkpoint()` in `backend/services/model_manager.py`
- Tightened validation so only Hugging Face repo IDs and explicit local paths are accepted
- Bare cwd-relative names no longer count as valid checkpoints
- Added regression tests covering unset, blank, bare engine id, valid repo ID, and local path cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->