### PR TITLE
fix(asr): fall back instead of crashing when CTranslate2's .so won't load (#692)

### DIFF
--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -302,6 +302,13 @@ class WhisperXBackend(ASRBackend):
             return True, "ready"
         except ImportError as e:
             return False, f"whisperx not installed: {e}"
+        except Exception as e:  # noqa: BLE001
+            # The import can fail while loading a native dep — CTranslate2's .so
+            # is rejected by hardened kernels / newer glibc with "cannot enable
+            # executable stack" (#692), an OSError, not an ImportError. An
+            # availability probe must REPORT 'unusable here', never raise, so
+            # engine selection falls back instead of crashing the ASR preflight.
+            return False, f"whisperx failed to load ({type(e).__name__}): {e}"
 
     def ensure_loaded(self) -> None:
         # Surface a whisperx/CTranslate2/torch load failure at preflight (once,
@@ -667,6 +674,11 @@ class FasterWhisperBackend(ASRBackend):
             return True, "ready"
         except ImportError as e:
             return False, f"faster-whisper not installed: {e}"
+        except Exception as e:  # noqa: BLE001
+            # faster-whisper pulls in CTranslate2, whose .so is rejected by
+            # hardened kernels / newer glibc ("cannot enable executable stack",
+            # #692) — an OSError. Report unavailable so we fall back, not crash.
+            return False, f"faster-whisper failed to load ({type(e).__name__}): {e}"
 
     def _ensure_model(self):
         if self._model is not None:
@@ -1541,6 +1553,22 @@ def list_backends() -> list[dict]:
     return out
 
 
+def _probe_available(cls) -> bool:
+    """``is_available()`` that never raises. A probe that explodes (e.g. a native
+    lib that refuses to load — CTranslate2's exec-stack rejection, #692) means the
+    engine is unusable on this host, so treat it as unavailable and fall through
+    to the next candidate rather than crash engine selection."""
+    try:
+        ok, _ = cls.is_available()
+        return bool(ok)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "ASR auto-detect: %s.is_available() raised — treating as unavailable",
+            cls.__name__, exc_info=True,
+        )
+        return False
+
+
 def _auto_detect() -> str:
     """Pick the best available ASR engine for the current hardware.
 
@@ -1559,17 +1587,14 @@ def _auto_detect() -> str:
       4. pytorch-whisper — last resort; requires the TTS model to be loaded
                           so it can reuse `_asr_pipe`.
     """
-    ok, _ = WhisperXBackend.is_available()
-    if ok:
+    if _probe_available(WhisperXBackend):
         return "whisperx"
-    ok, _ = FasterWhisperBackend.is_available()
-    if ok:
+    if _probe_available(FasterWhisperBackend):
         return "faster-whisper"
     try:
         import torch
         if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-            ok, _ = MLXWhisperBackend.is_available()
-            if ok:
+            if _probe_available(MLXWhisperBackend):
                 return "mlx-whisper"
     except Exception:
         pass

--- a/tests/test_asr_execstack_fallback_692.py
+++ b/tests/test_asr_execstack_fallback_692.py
@@ -1,0 +1,50 @@
+"""Regression tests for #692 — CTranslate2's native lib is rejected by hardened
+kernels / newer glibc with "libctranslate2…cannot enable executable stack" (an
+OSError, not ImportError). The ASR availability probes must REPORT this rather
+than raise, and engine auto-detect must fall back to a non-CTranslate2 engine
+(pytorch-whisper) instead of crashing the dub/transcribe preflight.
+"""
+import builtins
+
+from services import asr_backend as ab
+
+_EXECSTACK = OSError(
+    "libctranslate2-d3638643.so.4.4.0: cannot enable executable stack "
+    "as shared object requires: Invalid argument"
+)
+
+
+def test_probe_available_never_raises():
+    class Boom:
+        @classmethod
+        def is_available(cls):
+            raise _EXECSTACK
+    assert ab._probe_available(Boom) is False
+
+
+def test_auto_detect_falls_back_to_pytorch_when_ctranslate2_so_fails(monkeypatch):
+    def boom():
+        raise _EXECSTACK
+    monkeypatch.setattr(ab.WhisperXBackend, "is_available", classmethod(lambda cls: boom()))
+    monkeypatch.setattr(ab.FasterWhisperBackend, "is_available", classmethod(lambda cls: boom()))
+    # Pin MLX unavailable so the result is platform-independent (MPS hosts would
+    # otherwise probe it before the pytorch-whisper last resort).
+    monkeypatch.setattr(ab.MLXWhisperBackend, "is_available", classmethod(lambda cls: (False, "n/a")))
+    assert ab._auto_detect() == "pytorch-whisper"
+
+
+def test_is_available_reports_not_raises_on_so_load_failure(monkeypatch):
+    """whisperx + faster-whisper probes return (False, reason) — not raise — when
+    the import dies loading the native .so (a non-ImportError)."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in ("whisperx", "faster_whisper"):
+            raise _EXECSTACK
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    okx, msgx = ab.WhisperXBackend.is_available()
+    okf, msgf = ab.FasterWhisperBackend.is_available()
+    assert okx is False and "failed to load" in msgx and "executable stack" in msgx
+    assert okf is False and "failed to load" in msgf and "executable stack" in msgf


### PR DESCRIPTION
## Summary
Fixes #692 — `ASR backend initialization failed: libctranslate2-d3638643.so.4.4.0: cannot enable executable stack as shared object requires: Invalid argument` (reporter on WSL2 / glibc 2.43, CUDA RTX 5070), which bricked dub transcription.

## Root cause
On hardened kernels / newer glibc, the dynamic loader rejects CTranslate2's `.so` (it requests an executable stack) — raising an **OSError**, not an ImportError. The `WhisperXBackend`/`FasterWhisperBackend` `is_available()` probes only `except ImportError`, so the OSError escaped the probe and crashed the ASR/dub preflight instead of marking the engine unavailable and falling back.

## Fix (the whole class)
- Both probes now also catch the non-ImportError load failure → return `(False, "…failed to load…")`. **An availability probe must report, never raise.**
- `_auto_detect()` routes every probe through a new never-raising `_probe_available()`, so *no* exploding probe can crash engine selection — it falls through to **pytorch-whisper** (transformers-based, no CTranslate2; works on CUDA/CPU). Users can also pick the new CPU **sherpa-onnx** ASR.

## Tests
`tests/test_asr_execstack_fallback_692.py` — raising probe swallowed, the `.so` OSError surfaces as unavailable, and auto-detect falls back to pytorch-whisper. 50 ASR/route tests pass.

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR makes ASR backend selection resilient to CTranslate2 load failures so dub transcription no longer crashes on executable-stack errors.

```mermaid
flowchart TD
  A[ASR backend selection] --> B[Probe WhisperX]
  B -->|available| Z[Use WhisperX]
  B -->|load/import error| C[Mark unavailable]

  C --> D[Probe Faster-Whisper]
  D -->|available| Y[Use Faster-Whisper]
  D -->|load/import error| E[Mark unavailable]

  E --> F[Probe MLX]
  F -->|available| X[Use mlx-whisper]
  F -->|unavailable| G[Fall back to pytorch-whisper]

  B -. unexpected exception .-> C
  D -. unexpected exception .-> E
  F -. unexpected exception .-> G
```

### What changed
- `WhisperXBackend.is_available()` now treats any import/load failure as unavailable, not just `ImportError`.
- `FasterWhisperBackend.is_available()` gets the same treatment for CTranslate2-related load errors.
- Added a never-raising `_probe_available()` helper so auto-detection can safely continue past backend probe failures.
- Updated auto-detection to use the safer probe path, allowing fallback to continue instead of crashing.
- Added a regression test covering the executable-stack `OSError` path and fallback behavior.

### Result
When CTranslate2-backed ASR engines fail to load, backend selection now degrades gracefully to a working alternative instead of aborting initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->