### PR TITLE
fix(desktop): enable native HTML5 file drag-drop on macOS (#700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@ of error messages across dub, generate, and design.
   "get a free token" link. (#657, #669)
 ### Fixed
 
+- **File drag-and-drop works on macOS again.** The app's drop zones use HTML5
+  file drops, but Tauri intercepts OS drag-and-drop by default (`dragDropEnabled`)
+  and swallowed the files before the webview saw them — most visibly on macOS
+  WKWebView, and fully broken on macOS 26 (Tahoe), where dropping a file did
+  nothing. Disabled the interception so the webview handles native HTML5 drops
+  on every platform. (#700)
 - **A misconfigured `OMNIVOICE_MODEL` no longer bricks model load with a 500.**
   A stale or leaked TTS *engine id* (e.g. `omnivoice`) reaching the model loader
   used to fail every launch with *"omnivoice is not a local folder and is not a

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -24,7 +24,8 @@
         "fullscreen": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "maximized": true
+        "maximized": true,
+        "dragDropEnabled": false
       },
       {
         "label": "widget",


### PR DESCRIPTION
## Summary
Fixes the drag-and-drop half of #700 (macOS 26 Tahoe — files can't be dropped into the app).

## Root cause
Every drop zone in the app (clone reference audio, dub video, Stories, batch-add) uses **HTML5 `dataTransfer.files`**. But `tauri.conf.json` never set `dragDropEnabled`, so it took the Tauri v2 default of **`true`** — Tauri intercepts the OS-level file drop and the webview's HTML5 `drop` event never receives the files. This is harshest on macOS **WKWebView** (Chromium-based WebView2/WebKitGTK leak the files; WKWebView doesn't), and macOS 26 (Tahoe) tightened it to fully broken.

## Fix
Set **`"dragDropEnabled": false`** on the main window so the webview handles native HTML5 drag-drop — matching how the entire frontend is written, and uniformly across platforms (a cross-platform-parity win: behaviour no longer diverges by webview). `cargo check` validates the config (Tauri 2.11.0); the key is recognized.

## The other half of #700
The **Clone/Design textarea isn't resizable** part was already fixed for 0.3.8 by **#595/#607** (`.clone-text-area` is `flex: 0 1 auto; resize: vertical` on `main`). The reporter is on **v0.3.7**, which predates it — so updating to 0.3.8 resolves that half.

## Testing
Config-level + `cargo check` clean. The actual drop behaviour needs a macOS build to confirm (I can't drive a real file-drop here) — but this is the documented Tauri-v2 way to enable HTML5 file drop, and it's what the app's drop code requires.

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored macOS drag-and-drop support so file drops work consistently across platforms.
  * Improved native file handling in the main app window by avoiding OS-level interception of drag-and-drop actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->