### PR TITLE
docs: add rust as prerequisite for from-source builds

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -11,6 +11,7 @@ working OmniVoice Studio install on a Debian / Ubuntu / Fedora / Arch host.
   `sudo dnf install python3.11` on Fedora, or already installed on Arch.
 - **Bun** — `curl -fsSL https://bun.sh/install | bash`.
 - **FFmpeg** — `sudo apt install ffmpeg` (Debian/Ubuntu), `sudo dnf install ffmpeg-free` (Fedora), or `sudo pacman -S ffmpeg` (Arch).
+- **Rust / Cargo** (required for building from source only) — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or via your package manager (e.g., `sudo apt install rustc cargo`).
 - **GTK/WebKit deps** for the Tauri shell:
 
   ```bash

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -12,6 +12,7 @@ working OmniVoice Studio install on a Debian / Ubuntu / Fedora / Arch host.
 - **Bun** — `curl -fsSL https://bun.sh/install | bash`.
 - **FFmpeg** — `sudo apt install ffmpeg` (Debian/Ubuntu), `sudo dnf install ffmpeg-free` (Fedora), or `sudo pacman -S ffmpeg` (Arch).
 - **Rust / Cargo** (required for building from source only) — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or via your package manager (e.g., `sudo apt install rustc cargo`).
+  If you use rustup, reopen the shell or source `"$HOME/.cargo/env"` before running `bun run desktop-prod`.
 - **GTK/WebKit deps** for the Tauri shell:
 
   ```bash

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -16,6 +16,7 @@ working OmniVoice Studio install on macOS (Apple Silicon or Intel).
 - **Xcode Command Line Tools** — `xcode-select --install`.
 - **FFmpeg** (used by the dubbing + capture pipelines) — `brew install ffmpeg`.
 - **Rust / Cargo** (required for building from source only) — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or `brew install rust`.
+  If you use rustup, reopen the terminal or source `"$HOME/.cargo/env"` before running `bun run desktop-prod`.
 
 Optional but recommended:
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -15,6 +15,7 @@ working OmniVoice Studio install on macOS (Apple Silicon or Intel).
 - **Bun** — `curl -fsSL https://bun.sh/install | bash`.
 - **Xcode Command Line Tools** — `xcode-select --install`.
 - **FFmpeg** (used by the dubbing + capture pipelines) — `brew install ffmpeg`.
+- **Rust / Cargo** (required for building from source only) — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or `brew install rust`.
 
 Optional but recommended:
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -19,6 +19,7 @@ working OmniVoice Studio install on Windows 10 / 11 (x64).
   `bun run desktop-prod` uses to run its build-and-launch script. Without it,
   `desktop-prod` stops with an error telling you to install it.
 - **Rust / Cargo** (required for building from source only) — `winget install Rust.Rustup` or download `rustup-init.exe` from [rustup.rs](https://rustup.rs/).
+  After installing Rustup, close and reopen PowerShell before running `bun run desktop-prod`.
 
 ## Install (from source)
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -18,6 +18,7 @@ working OmniVoice Studio install on Windows 10 / 11 (x64).
   You need it for `git clone` anyway, and it includes **Git Bash**, which
   `bun run desktop-prod` uses to run its build-and-launch script. Without it,
   `desktop-prod` stops with an error telling you to install it.
+- **Rust / Cargo** (required for building from source only) — `winget install Rust.Rustup` or download `rustup-init.exe` from [rustup.rs](https://rustup.rs/).
 
 ## Install (from source)
 


### PR DESCRIPTION
Adds Rust/Cargo to the prerequisites in macos.md, linux.md, and windows.md installation documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the installation documentation for building from source to add Rust/Cargo prerequisites across macOS, Linux, and Windows, including setup/verification notes to ensure the Rust toolchain environment is loaded before running `bun run desktop-prod`.

- macOS (`docs/install/macos.md`): Added a “Rust / Cargo” source-build prerequisite, including `rustup` install and a Homebrew alternative; added instructions to reopen the terminal or source `"$HOME/.cargo/env"`.
- Linux (`docs/install/linux.md`): Added a “Rust / Cargo” source-build prerequisite with `rustup` install plus distro package-manager alternatives; added instructions to reopen the shell or source `"$HOME/.cargo/env"`.
- Windows (`docs/install/windows.md`): Added a “Rust / Cargo” source-build prerequisite with `winget` (Rustup) or `rustup-init.exe`; added instructions to close and reopen PowerShell after installing Rustup.

Documentation-only change; no runtime/UI behavior was modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->