### PR TITLE
fix(generate): classify WinError 193 as a corrupt native component, not OOM (#705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,12 @@ of error messages across dub, generate, and design.
   "get a free token" link. (#657, #669)
 ### Fixed
 
+- **A corrupt or wrong-architecture native component no longer masquerades as
+  "out of memory."** A synth failure caused by a bad `.dll`/`.pyd`/`.exe` on
+  Windows (`[WinError 193] %1 is not a valid Win32 application` — e.g. torch,
+  ffmpeg, or an engine binary) was labelled *"ran out of memory — try Flush,"*
+  sending users down the wrong path. It now says the component is corrupt or
+  built for the wrong architecture and to reinstall/repair it. (#705)
 - **File drag-and-drop works on macOS again.** The app's drop zones use HTML5
   file drops, but Tauri intercepts OS drag-and-drop by default (`dragDropEnabled`)
   and swallowed the files before the webview saw them — most visibly on macOS

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -192,6 +192,17 @@ def _oom_friendly_reraise(e):
             or "conflicting instruct items" in _low
             or "in a single instruct" in _low):
         raise ValueError(es) from e
+    # #705: a corrupt or wrong-architecture native component (a .dll / .pyd / .exe
+    # — torch, ffmpeg, or a bundled engine binary) fails to load/spawn on Windows
+    # with "[WinError 193] %1 is not a valid Win32 application". That is NOT OOM,
+    # and Flush won't help — reinstalling/repairing the component is the real fix.
+    if "winerror 193" in _low or "is not a valid win32 application" in _low:
+        raise RuntimeError(
+            f"A native component (a DLL / .pyd / .exe — e.g. torch, ffmpeg, or an "
+            f"engine binary) is corrupt or built for the wrong architecture "
+            f"([WinError 193]). Reinstall or repair that component — the Flush "
+            f"button won't help here. Underlying error: {e}"
+        ) from e
     raise RuntimeError(
         f"TTS engine stopped mid-generation. This usually means it ran out of memory. "
         f"Try the Flush button to reload the model, then regenerate. Underlying error: {e}"

--- a/tests/test_generation_audio_guard.py
+++ b/tests/test_generation_audio_guard.py
@@ -81,3 +81,19 @@ def test_instruct_error_wrapped_in_runtimeerror_is_still_validation():
         _oom_friendly_reraise(err)
     assert "Conflicting instruct items" in str(ei.value)
     assert "ran out of memory" not in str(ei.value)
+
+
+def test_winerror_193_is_a_corrupt_binary_not_oom():
+    # #705: a corrupt / wrong-architecture native component (torch, ffmpeg, an
+    # engine binary) fails on Windows with "[WinError 193] %1 is not a valid
+    # Win32 application". That is NOT OOM and Flush won't help — say so.
+    err = RuntimeError(
+        "TTS engine stopped mid-generation: [WinError 193] %1 is not a valid "
+        "Win32 application"
+    )
+    with pytest.raises(RuntimeError) as ei:
+        _oom_friendly_reraise(err)
+    msg = str(ei.value)
+    assert "WinError 193" in msg
+    assert "corrupt" in msg or "wrong architecture" in msg
+    assert "ran out of memory" not in msg


### PR DESCRIPTION
## Summary
Fixes #705 — a Windows synth 500 whose *real* cause (`[WinError 193] %1 is not a valid Win32 application`) was hidden behind a misleading **"ran out of memory — try Flush"** message.

## Root cause
WinError 193 means a **native component is corrupt or built for the wrong architecture** (a `.dll`/`.pyd`/`.exe` — torch, ffmpeg, or a bundled engine binary). `_oom_friendly_reraise()` already special-cases torch.compile/Triton, decode glitches (#629), permission errors (#437), and bad instructs (#664) — but WinError 193 fell through to the generic OOM fallback, so the user was told to Flush (which can't fix a bad binary).

## Fix
Detect the `WinError 193` / `is not a valid Win32 application` signature before the OOM fallback and surface an honest, actionable message: *reinstall or repair that component — Flush won't help.* (`asr_backend.py` already has the same WinError-193 handling for ffmpeg, so this is consistent.)

## Tests
New case in `tests/test_generation_audio_guard.py` (8 pass): WinError 193 → corrupt/wrong-arch message, **not** OOM. The reporter is on v0.3.7; this ships in 0.3.8 + the message guides them to the actual fix.

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
This PR fixes Windows synth failures with `[WinError 193] %1 is not a valid Win32 application` so they are no longer misreported as out-of-memory errors.

```mermaid
flowchart TD
  A[Native component failure] --> B{Exception text contains WinError 193 / valid Win32 application?}
  B -->|Yes| C[Raise targeted corrupt / wrong-architecture RuntimeError]
  B -->|No| D[Fallback to existing OOM-friendly handling]
  C --> E[User is told to reinstall or repair the native component]
  D --> F[Possible OOM message]
```

## Changes
- Updated `_oom_friendly_reraise` in `backend/api/routers/generation.py` to detect WinError 193 signatures before the generic OOM fallback.
- Switched the resulting message to a corrupt/wrong-architecture native component error with reinstall/repair guidance.
- Added a regression test in `tests/test_generation_audio_guard.py` covering this classification.
- Added a changelog entry documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->