### PR TITLE
fix(settings): contain page content within available width on every page

### DIFF
--- a/frontend/src/components/settings/primitives/primitives.css
+++ b/frontend/src/components/settings/primitives/primitives.css
@@ -82,7 +82,11 @@
    ~32px title-only, ~40px when a description wraps under the title. */
 .st-row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  /* minmax(0, 1fr) so a long title can't push the control column off the right
+     edge; the label shrinks (its children wrap / ellipsis) instead of forcing
+     row overflow. Pairs with the page grid's minmax(0,1fr) to keep every row
+     contained within the available width. */
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 1px var(--space-5);             /* tight row-gap, breathable col-gap */
   padding: var(--space-4) 0;           /* 8px → ~34px title-only row */

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -78,7 +78,13 @@
 
 /* ── Wide (≥760px): vertical rail + content column ──────────────── */
 @media (min-width: 760px) {
-  .settings-page { display: grid; grid-template-columns: 168px 1fr; gap: var(--space-5); align-content: start; }
+  /* minmax(0, 1fr) — NOT 1fr (= minmax(auto,1fr)) — so the content track can
+     shrink below its content's min-size. Without the 0 minimum, a non-shrinking
+     child (a nowrap status pill, a long path) forces the track wider than the
+     viewport and clips at the window edge, which max-width on .settings-content
+     can't claw back. This is the responsive-containment guarantee for EVERY
+     settings page (they all share this grid). */
+  .settings-page { display: grid; grid-template-columns: 168px minmax(0, 1fr); gap: var(--space-5); align-content: start; }
   .settings-page h1,
   .settings-page .settings-subtitle { grid-column: 1 / -1; }
   .ui-tabs.settings-tabs-ui {


### PR DESCRIPTION
## Summary
Right-side control values and status pills clipped off the **right edge** of the window on wider viewports — e.g. Privacy's `LOCAL SQLITE` / `OFFLINE TRANSLATION` / `NONE — NO TRACKING` pills (and long stored-at paths) were cut off.

## Root cause
Both Settings grids used a bare `1fr` track, which is `minmax(auto, 1fr)` — its minimum is the content's **min-size**. A child that can't shrink (a `nowrap` status pill, an unbreakable path) forces the track **wider than the viewport**, and `.settings-content`'s `max-width: 1280px` can't claw it back, so it clips at the window edge.

## Fix
`minmax(0, 1fr)` on both grids so the tracks can shrink below content min-size:
- `.settings-page` → `168px minmax(0, 1fr)` (the content column)
- `.st-row` → `minmax(0, 1fr) auto` (a long title can't shove the control column off-screen — the label shrinks/wraps instead)

These are the **shared** settings layout primitives, so the fix contains **every** settings page responsively, at every width. Pure presentation — 638 frontend tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes settings layouts so right-side controls and status pills no longer get clipped on wider viewports.

### What changed
- Updated the wide settings page grid to use `minmax(0, 1fr)` for the main content column.
- Updated shared settings rows to use `minmax(0, 1fr) auto` so labels/content can shrink instead of pushing controls offscreen.
- Added comments explaining why the min-size reset is needed.

### Layout sketch

Before:
```
|  left nav  |  content (1fr, can expand) | control |
|            |  long text grows track ->   | clipped |
```

After:
```
|  left nav  | content (minmax(0,1fr)) | control |
|            | long text shrinks/wraps  | visible |
```

### Files updated
- `frontend/src/pages/Settings.css`
- `frontend/src/components/settings/primitives/primitives.css`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->