### PR TITLE
fix(generate): self-heal schema so a history-write fail can't 500 a generated clip (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,12 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   "get a free token" link. (#657, #669)
 ### Fixed
 
+- **A synth that succeeded no longer 500s because of a history-logging hiccup.**
+  If the local database somehow missed schema init, recording the clip to
+  generation history failed with *"no such table: generation_history"* and
+  surfaced as a 500 — even though the audio had already been generated and saved.
+  The write now self-heals the schema and retries, and a history-logging failure
+  never fails the generation: you get your audio regardless. (#710)
 - **Long-video dubs no longer spike RAM during assembly.** Dub generation used
   to hold every segment's audio in memory until the whole track was mixed, so a
   50-video batch or a single feature-length dub could exhaust RAM and crash. Each

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -12,7 +12,8 @@ from typing import Optional
 from fastapi import APIRouter, File, Form, UploadFile, HTTPException
 from fastapi.responses import StreamingResponse
 
-from core.db import db_conn
+import sqlite3
+from core.db import db_conn, ensure_schema
 from core.config import OUTPUTS_DIR, VOICES_DIR
 from services.model_manager import get_model, _gpu_pool
 from services.audio_io import _safe_torchaudio_save
@@ -635,13 +636,29 @@ async def generate_speech(
 
         audio_dur = round(audio_tensor.shape[-1] / sample_rate, 2)
 
-        with db_conn() as conn:
-            conn.execute(
-                "INSERT INTO generation_history (id, text, mode, language, instruct, profile_id, audio_path, duration_seconds, generation_time, seed, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-                (audio_id, text[:200], history_mode or ("clone" if ref_audio_path else "design"),
-                 language or "Auto", instruct or "", resolved_profile_id,
-                 audio_filename, audio_dur, gen_time, used_seed, time.time())
-            )
+        # #710: the clip is already generated and saved above. A history-write
+        # failure — e.g. "no such table: generation_history" on a DB that missed
+        # schema init — must NOT 500 the user's generation. Self-heal the schema
+        # once and retry; if it still fails, log and return the audio anyway.
+        def _write_history():
+            with db_conn() as conn:
+                conn.execute(
+                    "INSERT INTO generation_history (id, text, mode, language, instruct, profile_id, audio_path, duration_seconds, generation_time, seed, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                    (audio_id, text[:200], history_mode or ("clone" if ref_audio_path else "design"),
+                     language or "Auto", instruct or "", resolved_profile_id,
+                     audio_filename, audio_dur, gen_time, used_seed, time.time())
+                )
+        try:
+            _write_history()
+        except sqlite3.OperationalError as e:
+            logger.warning("generation history write failed (%s); healing schema + retrying", e)
+            try:
+                ensure_schema()
+                _write_history()
+            except Exception as e2:
+                logger.warning("history write still failed after schema heal; returning audio anyway: %s", e2)
+        except Exception as e:
+            logger.warning("generation history write failed; returning audio anyway: %s", e)
         event_bus.emit("generation_history", {"action": "created", "id": audio_id})
 
         buffer = io.BytesIO()

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -268,6 +268,26 @@ def _reconcile_additive_columns(conn) -> None:
         canon.close()
 
 
+def ensure_schema() -> None:
+    """Idempotently ensure the base tables + additive columns exist.
+
+    A runtime self-heal for a DB that somehow missed init — e.g. a write hitting
+    ``no such table: generation_history`` (#710) because ``init_db()``'s
+    ``executescript`` never took on that DB. Safe to call anytime: it's just
+    ``CREATE ... IF NOT EXISTS`` plus the additive-only column reconcile, so it
+    never drops or retypes anything and is backward-compatible with user data.
+    Cheaper than ``init_db()`` (skips the legacy ``_migrate`` + alembic), so a
+    write path can call it on a schema error and retry without a 500.
+    """
+    conn = get_db()
+    try:
+        conn.executescript(_BASE_SCHEMA)
+        _reconcile_additive_columns(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def init_db():
     conn = get_db()
     try:

--- a/tests/test_generation_history_self_heal.py
+++ b/tests/test_generation_history_self_heal.py
@@ -1,0 +1,76 @@
+"""#710: a synth 500 'no such table: generation_history'.
+
+The clip is already generated + saved before the history INSERT, so a DB that
+missed schema init must not 500 the user's generation. `ensure_schema()` is the
+runtime self-heal: idempotently (re)create the base tables + additive columns so
+the write can retry, and the generation route returns the audio either way.
+
+These tests redirect the DB by patching `core.db.get_db` (which `db_conn` and
+`ensure_schema` both call) rather than the `DB_PATH` global — the global proved
+flaky across the full suite when an earlier test leaves it repointed.
+"""
+import sqlite3
+
+import pytest
+
+import core.db as _db
+from core.db import ensure_schema, db_conn
+
+
+def _connect(path):
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Every core.db connection goes to a throwaway file for the test."""
+    path = tmp_path / "test.db"
+    monkeypatch.setattr(_db, "get_db", lambda: _connect(path))
+    return path
+
+
+def _tables(path):
+    with sqlite3.connect(str(path)) as conn:
+        return {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+
+
+def _seed_missing_history(path):
+    """A DB that missed init — only voice_profiles, no generation_history."""
+    with _connect(path) as conn:
+        conn.execute("CREATE TABLE voice_profiles (id TEXT PRIMARY KEY, name TEXT)")
+        conn.commit()
+
+
+def test_ensure_schema_creates_missing_generation_history(temp_db):
+    _seed_missing_history(temp_db)
+    assert "generation_history" not in _tables(temp_db)
+
+    ensure_schema()
+    assert "generation_history" in _tables(temp_db)
+
+
+def test_history_insert_self_heals_after_ensure_schema(temp_db):
+    """Fail-before / heal / pass-after — the exact #710 recovery contract."""
+    _seed_missing_history(temp_db)
+
+    # BEFORE heal: the write raises exactly the #710 error.
+    with pytest.raises(sqlite3.OperationalError, match="no such table: generation_history"):
+        with db_conn() as conn:
+            conn.execute("INSERT INTO generation_history (id, created_at) VALUES ('x', 1.0)")
+
+    # AFTER heal: the same write succeeds.
+    ensure_schema()
+    with db_conn() as conn:
+        conn.execute("INSERT INTO generation_history (id, created_at) VALUES ('x', 1.0)")
+    with _connect(temp_db) as conn:
+        assert conn.execute("SELECT id FROM generation_history").fetchone()[0] == "x"
+
+
+def test_ensure_schema_is_idempotent(temp_db):
+    ensure_schema()
+    ensure_schema()  # second call must be a clean no-op
+    assert "generation_history" in _tables(temp_db)


### PR DESCRIPTION
## Summary
Fixes #710 — a synth 500: `Couldn't synthesize audio … Underlying error: no such table: generation_history`.

## Root cause
The clip is **already generated and saved to disk** before the `generation_history` INSERT runs. On a DB that somehow missed schema init (`init_db()`'s `executescript` never took on that DB), the INSERT raised `no such table: generation_history` *after* the audio existed — so the user got a 500 and lost a generation they'd already paid for, over a logging side-effect.

## Fix
- **`db.ensure_schema()`** — a lightweight, idempotent runtime self-heal: `CREATE … IF NOT EXISTS` + the additive-only column reconcile (no `_migrate`/alembic), safe to call from a write path, backward-compatible with user data.
- The history write now **self-heals + is non-fatal**: on a `sqlite3.OperationalError` it runs `ensure_schema()` and retries once; if it still fails it **logs and returns the audio anyway**. A history-logging failure can never fail the generation.

## Tests
`tests/test_generation_history_self_heal.py` — the write raises `no such table: generation_history` **before** the heal and succeeds **after** (fail-before/pass-after), plus `ensure_schema` idempotency. 6 pass with the existing schema-reconcile suite.

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What changed

- Added `db.ensure_schema()` to self-heal the SQLite schema at runtime by creating missing tables and reconciling additive columns.
- Updated the audio generation flow to treat `generation_history` write failures as non-fatal:
  - on `sqlite3.OperationalError` (e.g., `no such table: generation_history`), it now calls `ensure_schema()`,
  - retries the `generation_history` insert once,
  - and if it still fails, logs the error and returns the generated audio instead of raising a 500.
- Added regression tests covering:
  - recovery when the `generation_history` table is missing,
  - successful insert-after-repair behavior,
  - and `ensure_schema()` idempotency/no-op on repeated calls.
- Updated `CHANGELOG.md` to note the fix.

## New behavior

```mermaid
flowchart TD
  A[Audio generation completes] --> B[Persist generation_history]
  B -->|Success| C[Return generated audio]
  B -->|sqlite3.OperationalError (e.g., missing table)| D[Call ensure_schema()]
  D --> E[Retry generation_history insert once]
  E -->|Success| C
  E -->|Fails again| F[Log error/warning and continue]
  F --> C
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->