### PR TITLE
fix(settings): harden control inputs against right-edge overflow

### DIFF
--- a/frontend/src/components/settings/RemoteBackendPanel.jsx
+++ b/frontend/src/components/settings/RemoteBackendPanel.jsx
@@ -67,6 +67,7 @@ export default function RemoteBackendPanel() {
       }
     >
       <SettingRow
+        className="st-row--stack"
         title="Backend URL"
         control={
           <input
@@ -74,12 +75,13 @@ export default function RemoteBackendPanel() {
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="http://gpu-box.tailnet.ts.net:3900"
-            style={{ flex: 1, minWidth: 220 }}
+            className="st-input st-input--mono"
             data-testid="remote-backend-url"
           />
         }
       />
       <SettingRow
+        className="st-row--stack"
         title="API key"
         control={
           <input
@@ -87,7 +89,7 @@ export default function RemoteBackendPanel() {
             value={key}
             onChange={(e) => setKey(e.target.value)}
             placeholder="value of OMNIVOICE_API_KEY on the server"
-            style={{ flex: 1, minWidth: 220 }}
+            className="st-input"
             data-testid="remote-backend-key"
           />
         }

--- a/frontend/src/components/settings/primitives/primitives.css
+++ b/frontend/src/components/settings/primitives/primitives.css
@@ -159,6 +159,19 @@
   line-height: 1.45;
 }
 
+/* Belt-and-suspenders: any text-ish input / select inside a control must be
+   able to shrink and can NEVER overflow the row — regardless of an inline width
+   or min-width a panel hard-codes (e.g. RemoteBackend's inputs). Pairs with the
+   page/row minmax(0,1fr) grids so no Settings page can spill a control past the
+   available width. Excludes toggles/checkboxes/radios (fixed-size by design). */
+.st-row__control input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+.st-row__control select,
+.st-row__control textarea {
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 /* ── Input rows: label on top, full-width control row below ─────
    Used where the control is a text input + buttons that needs the full
    width (proxy / ffmpeg / credentials), not a squeezed right-aligned slot. */


### PR DESCRIPTION
## Summary
Belt-and-suspenders follow-up to #713 (responsive Settings containment). Even though the page/row `minmax(0,1fr)` grids fix the layout, a panel that hard-codes an input width could still spill a control past the available width. This makes that impossible.

## Changes
- **RemoteBackend `Backend URL` + `API key` inputs** used `style={{flex:1, minWidth:220}}` inside a right-aligned 60%-max control — that 220px floor can overflow a narrow control. They're long-value fields, so they're now **full-width stacked rows** (`st-row--stack`) with the shrinkable `.st-input` class — better UX *and* overflow-proof.
- **Universal guard:** any `input`/`select`/`textarea` (excluding checkbox/radio/range) inside `.st-row__control` gets `min-width:0; max-width:100%; box-sizing:border-box`, so no panel's raw input can ever push past the row.

Pure presentation. 638 frontend tests pass; build clean; both rules confirmed in the compiled bundle.

Note: this complements #713 — if the running app still clipped, it was a stale bundle (the fix is in the compiled CSS); this guarantees containment regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
Hardened Settings controls against right-edge overflow by making the RemoteBackend “Backend URL” and “API key” rows full-width stacked fields and by adding a global width clamp for form controls inside `.st-row__control`.

## Layout sketch
Before:
```text
[Label |  [input..................] ]
[Label |  [input..................] ]   (fixed min width could overflow)
```

After:
```text
[Label ]
[      [input........................] ]
[Label ]
[      [input........................] ]   (stacks and shrinks safely)
```

## Details
- Switched RemoteBackend inputs from inline flex sizing to shared stacked row styling.
- Replaced hard-coded input sizing with shrinkable `.st-input` classes.
- Added a CSS safeguard so text-like `input`, `select`, and `textarea` elements inside `.st-row__control` can’t exceed container width:
  - `min-width: 0`
  - `max-width: 100%`
  - `box-sizing: border-box`
- Excluded checkbox/radio/range controls from the width clamp.

## Testing
- Frontend tests passing
- Build clean

<!-- end of auto-generated comment: release notes by coderabbit.ai -->