### PR TITLE
fix(generate): classify [Errno 32] Broken pipe as a lost-pipe error, not OOM (#715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   ffmpeg, or an engine binary) was labelled *"ran out of memory — try Flush,"*
   sending users down the wrong path. It now says the component is corrupt or
   built for the wrong architecture and to reinstall/repair it. (#705)
+- **A "[Errno 32] Broken pipe" mid-generation no longer poses as "out of
+  memory."** When the desktop app that launched the backend closes or relaunches,
+  the backend's output pipe breaks and a synth can fail with `[Errno 32] Broken
+  pipe`. That was labelled *"ran out of memory — try Flush,"* which never helps;
+  it now tells you the backend lost its pipe and to restart the app. (#715)
 - **File drag-and-drop works on macOS again.** The app's drop zones use HTML5
   file drops, but Tauri intercepts OS drag-and-drop by default (`dragDropEnabled`)
   and swallowed the files before the webview saw them — most visibly on macOS

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -204,6 +204,20 @@ def _oom_friendly_reraise(e):
             f"([WinError 193]). Reinstall or repair that component — the Flush "
             f"button won't help here. Underlying error: {e}"
         ) from e
+    # #715: a "[Errno 32] Broken pipe" (BrokenPipeError) surfacing from
+    # generation is NOT out of memory — it means the backend's stdout/stderr
+    # pipe to the desktop shell that launched it closed mid-render (an orphaned
+    # backend whose parent shell exited or relaunched). main.py wraps
+    # sys.stdout/stderr to swallow EPIPE, but a C-level write inside the native
+    # engine/torch can still raise one past that guard. Flush won't help —
+    # relaunching the app re-parents the backend to a live shell.
+    if isinstance(e, BrokenPipeError) or "broken pipe" in _low or "errno 32" in _low:
+        raise RuntimeError(
+            f"The backend lost its output pipe mid-generation — the desktop app "
+            f"that launched it closed or relaunched ([Errno 32] Broken pipe). "
+            f"Restart the app and try again; the Flush button won't help here. "
+            f"Underlying error: {e}"
+        ) from e
     raise RuntimeError(
         f"TTS engine stopped mid-generation. This usually means it ran out of memory. "
         f"Try the Flush button to reload the model, then regenerate. Underlying error: {e}"

--- a/tests/test_generation_audio_guard.py
+++ b/tests/test_generation_audio_guard.py
@@ -83,6 +83,25 @@ def test_instruct_error_wrapped_in_runtimeerror_is_still_validation():
     assert "ran out of memory" not in str(ei.value)
 
 
+def test_broken_pipe_is_a_lost_pipe_not_oom():
+    # #715: a "[Errno 32] Broken pipe" surfacing from generation means the
+    # backend's stdout/stderr pipe to the desktop shell closed mid-render (an
+    # orphaned/relaunched backend) — NOT out of memory. Telling the user to
+    # press Flush for memory they never ran out of is the wrong next step;
+    # restarting the app re-parents the backend. Covers both the typed
+    # BrokenPipeError and a string-wrapped "[Errno 32] Broken pipe".
+    for err in (
+        BrokenPipeError(32, "Broken pipe"),
+        RuntimeError("model.generate failed: [Errno 32] Broken pipe"),
+    ):
+        with pytest.raises(RuntimeError) as ei:
+            _oom_friendly_reraise(err)
+        msg = str(ei.value)
+        assert "pipe" in msg.lower()
+        assert "Restart the app" in msg
+        assert "ran out of memory" not in msg
+
+
 def test_winerror_193_is_a_corrupt_binary_not_oom():
     # #705: a corrupt / wrong-architecture native component (torch, ffmpeg, an
     # engine binary) fails on Windows with "[WinError 193] %1 is not a valid


### PR DESCRIPTION
## What

A `[Errno 32] Broken pipe` (`BrokenPipeError`) surfacing from TTS generation was
classified as **out of memory** by `_oom_friendly_reraise`, telling the user to
"press Flush" — advice that never helps. The real cause: the desktop app that
launched the backend closed or relaunched, breaking the backend's stdout/stderr
pipe; a C-level write inside the native engine/torch then raised `[Errno 32]`
past `main.py`'s `SafeFileWrapper` EPIPE guard.

Adds a `BrokenPipeError` / `[Errno 32]` branch (same pattern as the existing
`#705` WinError-193 and `#437` permission branches) that tells the user to
restart the app instead.

## Why it's the right layer

`main.py` already wraps `sys.stdout`/`sys.stderr` to swallow EPIPE process-wide.
A `BrokenPipeError` that still escapes generation came from a write that bypassed
the wrapper (a C-level write in the native model/torch), which Python can't wrap
— so classifying the error is the correct and complete Python-side fix.

## Test

`tests/test_generation_audio_guard.py::test_broken_pipe_is_a_lost_pipe_not_oom`
— fail-before/pass-after, covers both the typed `BrokenPipeError` and a
string-wrapped `"[Errno 32] Broken pipe"`. Full guard suite: 9 passed.

Closes #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Reclassifies generation-time broken-pipe failures (`BrokenPipeError` / `"[Errno 32] Broken pipe"`) as a lost connection to the desktop app instead of an out-of-memory condition.
- Updates the user-facing guidance to tell them to restart the app when the backend’s output pipe is closed mid-generation.
- Adds a regression test covering both typed and string-wrapped broken-pipe errors.
- Updates the changelog for the fix.

```mermaid
flowchart TD
  A[Generation error occurs] --> B{Broken pipe?}
  B -- Yes --> C[Classify as lost-pipe error]
  C --> D[Raise RuntimeError with restart-app guidance]
  B -- No --> E[Existing OOM / other error handling]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->