### PR TITLE
fix(asr): bound every transcribe path + reset GPU pool on hang so a wedged ASR can't brick the backend (#730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,17 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   OSError the WhisperX/faster-whisper checks didn't catch, so it took down the
   whole preflight. They now report the engine as unavailable and auto-detect
   falls back to PyTorch-Whisper instead of dead-ending. (#692)
+- **A wedged transcription can no longer take the whole backend offline ("Can't
+  reach the local backend").** On some Windows + CUDA setups a whisperx/CTranslate2
+  transcribe hangs hard and never returns. Because ASR shares a small (1–2 worker)
+  GPU pool with TTS, one stuck worker starved every other request — so the next
+  thing you did (often a TTS *generate*) failed with "can't reach backend" even
+  though the process was alive. Two fixes: every whole-file transcribe path (dub
+  whole-file, batch, and live dictation) is now wall-clock **bounded** like the
+  dub QC / dictation / OpenAI paths already were; and on timeout the poisoned GPU
+  worker is **abandoned and the pool rebuilt**, so capacity is restored without
+  restarting the app. You still get an actionable message (Flush VRAM / pick a
+  smaller ASR model) for the durable fix. (#730)
 - **The stale-dub-session recovery now also covers the first upload/ingest, not
   just retry/import.** A dubbing job that vanished server-side during the initial
   transcribe flow showed the scary *"Job not found … report a bug"* toast; it

--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -162,7 +162,12 @@ async def _run_batch_pipeline(job_id: str, job: dict):
             pass
         return segments, detected_lang
 
-    segments, source_lang = await loop.run_in_executor(_gpu_pool, _transcribe)
+    # Bound the batch transcribe (#730) so a wedged whisperx/CTranslate2 call
+    # can't hold its GPU-pool worker forever and starve the rest of the backend
+    # ("can't reach backend"); run_transcribe_guarded also resets the pool on
+    # timeout to restore capacity.
+    from services.asr_backend import run_transcribe_guarded
+    segments, source_lang = await run_transcribe_guarded(_gpu_pool, _transcribe, what="Batch")
     source_lang = (source_lang or "en").split("_")[0][:2].lower()
     job["segments"] = segments
     job["source_lang"] = source_lang

--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -658,15 +658,17 @@ async def _transcribe_buffer(chunks: list[bytes], *, pcm_sr: int | None = None) 
 
     try:
         from services.model_manager import _gpu_pool
-        from services.asr_backend import get_capture_asr_backend
+        from services.asr_backend import get_capture_asr_backend, run_transcribe_guarded
 
         def _run():
             backend = get_capture_asr_backend()
             result = backend.transcribe(tmp, word_timestamps=False)
             return result.get("text", "")
 
-        loop = asyncio.get_running_loop()
-        text = await loop.run_in_executor(_gpu_pool, _run)
+        # Bound dictation transcribes (#730): a wedged whisperx/CTranslate2 call
+        # must not hold its GPU-pool worker forever and starve TTS / other ASR
+        # into a "can't reach backend"; on timeout the pool is reset to recover.
+        text = await run_transcribe_guarded(_gpu_pool, _run, what="Dictation")
         return text.strip()
     finally:
         try:
@@ -684,7 +686,7 @@ async def _transcribe_buffer_full(chunks: list[bytes], *, pcm_sr: int | None = N
 
     try:
         from services.model_manager import _gpu_pool
-        from services.asr_backend import get_capture_asr_backend
+        from services.asr_backend import get_capture_asr_backend, run_transcribe_guarded
 
         def _run():
             backend = get_capture_asr_backend()
@@ -719,8 +721,9 @@ async def _transcribe_buffer_full(chunks: list[bytes], *, pcm_sr: int | None = N
                 "engine": backend.id,
             }
 
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(_gpu_pool, _run)
+        # Bounded + pool-resetting on timeout (#730), same rationale as the
+        # partial path above.
+        return await run_transcribe_guarded(_gpu_pool, _run, what="Dictation")
     finally:
         try:
             os.unlink(tmp)

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -1017,7 +1017,12 @@ async def dub_transcribe(job_id: str):
     try:
         loop = asyncio.get_running_loop()
         try:
-            segments_result = await loop.run_in_executor(_gpu_pool, _transcribe)
+            # Bound the whole-file transcribe (#730): a wedged whisperx/CTranslate2
+            # call would otherwise hold its GPU-pool worker forever and starve
+            # every other request into a "can't reach backend". run_transcribe_guarded
+            # also resets the pool on timeout so capacity is restored.
+            from services.asr_backend import run_transcribe_guarded
+            segments_result = await run_transcribe_guarded(_gpu_pool, _transcribe, what="Dub")
         except asyncio.CancelledError:
             job["aborted"] = True
             raise

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -57,23 +57,44 @@ async def run_transcribe_guarded(executor, fn, *, what: str = "ASR",
     bound. On timeout, raise :class:`ASRTimeoutError` with guidance instead of
     letting the request hang forever.
 
-    NOTE: ``run_in_executor`` cannot cancel the underlying thread, so the worker
-    stays busy after a timeout — the message tells the user to restart and
-    reduce ASR load, which is the only real remedy for a starved GPU.
+    ``run_in_executor`` cannot cancel the underlying thread, so a wedged
+    transcribe (a CTranslate2 / whisperx / VAD hang seen on some Windows + CUDA
+    setups, #730) keeps occupying its GPU-pool worker. With a 1–2 worker pool
+    that starves every *other* request — including TTS generate — and the next
+    thing the user does surfaces as "Can't reach the local backend" even though
+    the process is alive. So on timeout we also ``reset()`` the pool when it
+    supports it (``_ResilientGpuPool``): the wedged thread is abandoned and the
+    next submit gets a fresh worker, restoring capacity without an app restart.
+    The orphaned thread still holds its VRAM until the process exits, which is
+    why the message still recommends a smaller ASR model / Flush as the durable
+    fix. Executors without ``reset`` (a plain ThreadPoolExecutor in tests) just
+    get the bound + actionable error.
     """
     loop = asyncio.get_running_loop()
     fut = loop.run_in_executor(executor, fn)
     try:
         return await asyncio.wait_for(fut, timeout=timeout)
     except asyncio.TimeoutError:
+        # Free the poisoned pool so a hung transcribe can't keep starving TTS /
+        # other ASR work (the "can't reach backend" symptom, #730).
+        _reset = getattr(executor, "reset", None)
+        if callable(_reset):
+            try:
+                _reset()
+                logger.warning(
+                    "%s transcription exceeded %.0fs — abandoned the GPU-pool "
+                    "worker to restore capacity (#730).", what, timeout,
+                )
+            except Exception:
+                logger.exception("GPU pool reset after ASR timeout failed")
         raise ASRTimeoutError(
             f"{what} transcription exceeded {timeout:.0f}s and was abandoned — "
             "the backend is running, but the ASR model is too heavy for the "
             "available compute. Most often the GPU is VRAM-starved: the resident "
             "TTS model and a large ASR model (large-v3) contend for memory. "
-            "Fixes: Flush the TTS model to free VRAM, pick a smaller ASR model "
-            "in Settings → Models, or set ASR to CPU. Then restart the app to "
-            "clear the stuck worker. (Raise OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S "
+            "Capacity was restored automatically, but for a durable fix Flush the "
+            "TTS model to free VRAM, pick a smaller ASR model in Settings → "
+            "Models, or set ASR to CPU. (Raise OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S "
             "for very long single files.)"
         )
 

--- a/backend/tests/test_asr_transcribe_timeout.py
+++ b/backend/tests/test_asr_transcribe_timeout.py
@@ -67,3 +67,49 @@ def test_fast_transcribe_passes_through():
 def test_timeout_error_is_a_timeouterror_subclass():
     # Routers that catch broad TimeoutError (openai_compat) must also catch ours.
     assert issubclass(ASRTimeoutError, TimeoutError)
+
+
+def test_timeout_resets_a_resilient_pool_to_restore_capacity():
+    # #730: a wedged transcribe holds its GPU-pool worker forever; with a 1-2
+    # worker pool that starves TTS generate and surfaces as "can't reach
+    # backend". On timeout, run_transcribe_guarded must reset() a pool that
+    # supports it (the real _ResilientGpuPool) so the next submit gets a fresh
+    # worker — capacity restored without an app restart.
+    class _FakePool(ThreadPoolExecutor):
+        def __init__(self):
+            super().__init__(max_workers=1)
+            self.reset_calls = 0
+
+        def reset(self):
+            self.reset_calls += 1
+
+    pool = _FakePool()
+
+    def _hang():
+        time.sleep(5)
+        return "never"
+
+    async def _go():
+        with pytest.raises(ASRTimeoutError):
+            await run_transcribe_guarded(pool, _hang, what="Dub", timeout=0.2)
+
+    asyncio.run(_go())
+    assert pool.reset_calls == 1
+    pool.shutdown(wait=False)
+
+
+def test_timeout_without_reset_capable_pool_does_not_crash():
+    # A plain ThreadPoolExecutor (no reset) must still bound + raise cleanly —
+    # the reset() is best-effort, never required.
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    def _hang():
+        time.sleep(5)
+        return "never"
+
+    async def _go():
+        with pytest.raises(ASRTimeoutError):
+            await run_transcribe_guarded(pool, _hang, what="QC", timeout=0.2)
+
+    asyncio.run(_go())
+    pool.shutdown(wait=False)


### PR DESCRIPTION
Root-cause + fix for the **"Can't reach the local backend"** wave (#730 tracker; live evidence in #723's logs on 0.3.8-55 / RTX 4060 Ti).

## Root cause
A `whisperx large-v3 (float16)` transcribe can **hang hard** on some Windows + CUDA setups and never return (#723's log: transcribe starts, then the backend is silent for 10h until a manual restart). ASR runs in the shared `_gpu_pool` — a `ThreadPoolExecutor` sized to just **1–2 workers** on 6–8 GB cards (`model_manager._pick_gpu_workers`). One wedged worker that can't be killed starves **every other request**, including TTS *generate*, so the next user action surfaces as "Can't reach the local backend" even though the process is alive. `#656`'s `run_transcribe_guarded` bounded the *await* but its own docstring noted the worker "stays busy after a timeout" — so the pool stayed starved.

Two gaps compounded it: the **dub whole-file** (`dub_core.py`), **batch** (`batch.py`), and **live-dictation** (`capture_ws.py`) transcribes were never wrapped in `run_transcribe_guarded` at all — fully unbounded. (#723's log shows `word_timestamps=False`, the dictation/whole-file signature, not the already-bounded dub *stream*.)

## Fix
1. **Bound the three unguarded paths** with `run_transcribe_guarded` (`what="Dub"/"Batch"/"Dictation"`), matching the dub-QC / dictation / OpenAI paths already bounded by `#656`.
2. **Free the pool on hang.** `run_transcribe_guarded` now calls `executor.reset()` on timeout when the pool supports it — that's `_ResilientGpuPool.reset()`, already built for the model-load-timeout case (`#589`/`#599`). The wedged worker is abandoned and the next submit builds a fresh one, so **capacity is restored without an app restart** and the TTS-generate "can't reach backend" symptom clears. The orphaned thread still holds its VRAM until the process exits, so the message still recommends Flush / a smaller ASR model as the durable fix. Best-effort: a plain `ThreadPoolExecutor` (tests) just gets the bound + actionable error.

## Tests
`backend/tests/test_asr_transcribe_timeout.py` — new cases assert `reset()` is invoked on timeout (capacity restored) and that a non-reset pool still bounds cleanly. Full file: 6 passed; generation guard suite: 9 passed.

## Residual (follow-up, tracked in #730)
The chunked dub *stream* already bounds each chunk at 120s but doesn't yet reset the pool on a wedged chunk; and the truly durable cure (kill a hung transcribe to reclaim its VRAM too) is the dormant killable ASR sidecar (`subprocess_asr.py` / `_asr_sidecar`). Both noted on #730.

Refs #730, #720, #721, #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Guarded the remaining whole-file ASR transcription paths so timeouts can no longer leave a GPU worker wedged indefinitely:
  - batch dubbing
  - live dictation
  - non-streaming dub transcription
- Updated `run_transcribe_guarded()` to attempt `executor.reset()` on timeout when supported, restoring pool capacity without restarting the app.
- Added regression tests for both reset-capable and non-reset-capable executor behavior.
- Documented the fix in the changelog and clarified timeout guidance.

```mermaid
flowchart LR
  A[Whole-file ASR request] --> B[run_transcribe_guarded]
  B --> C{Transcribe finishes before timeout?}
  C -->|Yes| D[Return result]
  C -->|No| E[Raise ASRTimeoutError]
  E --> F{Executor supports reset()?}
  F -->|Yes| G[Call executor.reset()]
  G --> H[Restore GPU pool capacity]
  F -->|No| I[Fail safely with bounded timeout]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->