### PR TITLE
fix(asr): reset the GPU pool when a chunked dub-stream chunk wedges too (#730)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -34,6 +34,25 @@ from services import dub_pipeline
 router = APIRouter()
 logger = logging.getLogger("omnivoice.api")
 
+
+def _reset_pool_on_wedge(pool) -> None:
+    """Abandon a GPU pool whose worker is wedged on a timed-out transcribe (#730).
+
+    Python can't kill the stuck thread, but dropping the poisoned pool means the
+    next submit (the next chunk, or a concurrent TTS generate) gets a fresh
+    worker instead of queueing behind the wedged one — the same recovery the
+    whole-file paths get inside ``run_transcribe_guarded``. Best-effort and a
+    no-op for a pool without ``reset`` (a plain executor), so it never raises on
+    the failure path it's trying to recover from.
+    """
+    _reset = getattr(pool, "reset", None)
+    if callable(_reset):
+        try:
+            _reset()
+        except Exception:
+            logger.exception("GPU pool reset after transcribe timeout failed")
+
+
 # ── Legacy-name aliases to services/dub_pipeline.py ────────────────────────
 # Phase 2.4 moved the business logic into a service. Other routers
 # (dub_generate, dub_translate, dub_export) + internal call sites below still
@@ -568,6 +587,11 @@ async def dub_transcribe_stream(
                     "Transcribe chunk %d/%d timed out after %.0fs (job=%s)",
                     i + 1, chunks_n, TRANSCRIBE_CHUNK_TIMEOUT_S, job_id,
                 )
+                # #730: the wedged chunk thread keeps holding its GPU-pool worker.
+                # Abandon the poisoned pool so the next chunk (and any TTS work)
+                # gets a fresh worker instead of queueing behind the stuck one —
+                # same recovery the whole-file paths get via run_transcribe_guarded.
+                _reset_pool_on_wedge(_gpu_pool)
                 part = {
                     "chunks": [], "language": None,
                     "error": f"Chunk {i+1} timed out after {TRANSCRIBE_CHUNK_TIMEOUT_S:.0f}s — "

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -287,6 +287,38 @@ def test_transcribe_stream_surfaces_asr_load_failure_at_preflight(tmp_path, monk
     assert done_idx > err_idx >= 0, f"error must be followed by terminal done: {body}"
 
 
+def test_reset_pool_on_wedge_resets_resilient_pool():
+    """#730: a chunk transcribe that times out wedges its GPU-pool worker. The
+    chunked stream must abandon the pool so the next chunk / a concurrent TTS
+    generate gets a fresh worker instead of starving behind it."""
+    from api.routers import dub_core as dc
+
+    class _Pool:
+        def __init__(self):
+            self.resets = 0
+
+        def reset(self):
+            self.resets += 1
+
+    pool = _Pool()
+    dc._reset_pool_on_wedge(pool)
+    assert pool.resets == 1
+
+
+def test_reset_pool_on_wedge_is_a_noop_without_reset():
+    """A plain executor has no reset(); the helper must no-op, never raise —
+    it runs on the failure path it's recovering from."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    from api.routers import dub_core as dc
+
+    pool = ThreadPoolExecutor(max_workers=1)
+    try:
+        dc._reset_pool_on_wedge(pool)  # must not raise
+    finally:
+        pool.shutdown(wait=False)
+
+
 @pytest.mark.xfail(
     reason="dub_core._transcribe was refactored to route through "
            "services.asr_backend.get_active_asr_backend; the MagicMock fixture "


### PR DESCRIPTION
Follow-up to #731 closing the residual noted on #730.

The whole-file transcribe paths recover from a wedged worker via `run_transcribe_guarded`'s pool reset, but the **chunked** dub transcribe-stream only recorded a per-chunk timeout and continued — leaving the stuck thread holding its GPU-pool worker, so later chunks or a concurrent TTS generate could still starve into "can't reach backend."

Now the per-chunk `asyncio.TimeoutError` handler resets the pool via a small `_reset_pool_on_wedge()` helper (best-effort; no-op for a plain executor). Same recovery the whole-file paths already get.

Tests (`tests/test_dub_transcribe.py`): the helper resets a reset-capable pool and no-ops a plain `ThreadPoolExecutor` without raising. (Extracted to a helper so the fail-before/pass-after test is fast — driving a real chunk timeout costs ~5s of hardcoded ping-wait.)

Refs #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added `_reset_pool_on_wedge(pool)` to perform a best-effort recovery from a “wedged” transcribe worker by calling an optional `pool.reset()` (suppresses/logs reset failures).
- Updated the chunked `transcribe-stream` SSE timeout path (when a chunk hits `TRANSCRIBE_CHUNK_TIMEOUT_S`) to invoke `_reset_pool_on_wedge(_gpu_pool)` before returning the timeout error, aligning chunked behavior with whole-file transcribe recovery.
- Added unit tests in `tests/test_dub_transcribe.py` verifying:
  - a reset-capable pool calls `reset()` exactly once
  - a plain `ThreadPoolExecutor` (no `reset()`) is a no-op and does not raise

```mermaid
flowchart TD
  A[Chunk transcription starts] --> B[Chunk hits TRANSCRIBE_CHUNK_TIMEOUT_S]
  B --> C[_reset_pool_on_wedge(_gpu_pool)]
  C --> D{pool has reset()?}
  D -- Yes --> E[Try pool.reset() best-effort]
  E --> F[Suppression/logging on reset errors]
  D -- No --> G[No-op]
  F --> H[Build and return timeout error payload]
  G --> H
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->