### PR TITLE
fix(tts): force re-download a corrupt-but-right-size model blob before giving up (#739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,7 +325,11 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   is preserved as the fallback. (#581) The repair now also **retries** the
   re-fetch (3 attempts, resuming each time) so a single transient blip — the very
   thing that interrupts a download in the first place — doesn't bounce you back
-  to a manual reinstall; tune with `OMNIVOICE_MODEL_REPAIR_RETRIES`. (#739)
+  to a manual reinstall; tune with `OMNIVOICE_MODEL_REPAIR_RETRIES`. And if a
+  resume-repair still won't load — the signature of a *corrupt* file that kept
+  its size, which a resume trusts and never re-fetches — it now **force
+  re-downloads** the model files once before giving up, so even a bit-rotted
+  cache self-heals without a manual reinstall. (#739)
 - **Dubbing a YouTube URL no longer dies on a transient "Broken pipe."**
   Pasting a video link could fail outright with `download: Unable to download
   video: [Errno 32] Broken pipe` — a broken pipe raised while the write side of

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -557,7 +557,7 @@ def _hf_offline() -> bool:
     return _env_flag("HF_HUB_OFFLINE") or _env_flag("TRANSFORMERS_OFFLINE")
 
 
-def _repair_model_cache(checkpoint: str) -> bool:
+def _repair_model_cache(checkpoint: str, *, force: bool = False) -> bool:
     """Re-fetch a checkpoint's missing files in place and report success.
 
     An interrupted download leaves the cache missing only some files;
@@ -566,7 +566,13 @@ def _repair_model_cache(checkpoint: str) -> bool:
     seconds and a complete one would no-op). Returns False — leaving the caller
     to surface the actionable delete-and-reinstall message — when repair is
     impossible (offline) or the re-fetch itself fails (no network, gated repo,
-    full disk). Never raises; repair is best-effort."""
+    full disk). Never raises; repair is best-effort.
+
+    ``force=True`` passes ``force_download`` so the re-fetch replaces files that
+    are *present but corrupt* — a truncated/garbled blob that still has the right
+    size won't be re-fetched by the default resume (#739). It re-downloads the
+    whole snapshot, so it's the last resort the load path only reaches after a
+    plain resume-repair didn't fix the cache."""
     if _hf_offline():
         logger.warning(
             "Model cache for %s is incomplete but HF offline mode is set — "
@@ -582,6 +588,9 @@ def _repair_model_cache(checkpoint: str) -> bool:
     endpoint = os.environ.get("HF_ENDPOINT")
     if endpoint:
         dl_kwargs["endpoint"] = endpoint
+    if force:
+        # Replace present-but-corrupt blobs that resume would trust by size.
+        dl_kwargs["force_download"] = True
     if os.name == "nt":
         # Match the install path (download.py): avoid symlinks on Windows.
         dl_kwargs["local_dir_use_symlinks"] = False
@@ -725,14 +734,36 @@ def _load_model_sync():
             try:
                 _model = _load()
             except OSError as e2:
-                # Repair ran but the cache is still unusable (e.g. the repo
-                # genuinely lacks weights, or the disk is corrupt). Fall back
-                # to the actionable message rather than the raw error.
-                raise RuntimeError(
-                    f"The TTS model cache for {checkpoint} is incomplete and "
-                    "could not be auto-repaired. Open Settings → Models, delete "
-                    "the OmniVoice TTS model, and install it again."
-                ) from e2
+                # Resume-repair ran but the cache is still unusable. The usual
+                # cause beyond "repo genuinely lacks weights" is a blob that's
+                # present with the right size but corrupt — snapshot_download's
+                # resume trusts it and never re-fetches it (#739). Force a full
+                # re-download (replaces corrupt blobs) and retry once more before
+                # falling back to the manual delete-and-reinstall message.
+                if _is_incomplete_cache_error(e2):
+                    _set_loading("loading_weights", "Re-downloading model files…")
+                    if _repair_model_cache(checkpoint, force=True):
+                        try:
+                            _model = _load()
+                        except OSError as e3:
+                            raise RuntimeError(
+                                f"The TTS model cache for {checkpoint} is incomplete "
+                                "and could not be auto-repaired. Open Settings → "
+                                "Models, delete the OmniVoice TTS model, and install "
+                                "it again."
+                            ) from e3
+                    else:
+                        raise RuntimeError(
+                            f"The TTS model cache for {checkpoint} is incomplete and "
+                            "could not be auto-repaired. Open Settings → Models, "
+                            "delete the OmniVoice TTS model, and install it again."
+                        ) from e2
+                else:
+                    raise RuntimeError(
+                        f"The TTS model cache for {checkpoint} is incomplete and "
+                        "could not be auto-repaired. Open Settings → Models, delete "
+                        "the OmniVoice TTS model, and install it again."
+                    ) from e2
 
         try:
             # plan-02 (#65): gate on Triton availability (+ user setting), not

--- a/tests/test_model_cache_repair.py
+++ b/tests/test_model_cache_repair.py
@@ -111,6 +111,72 @@ def test_repair_failure_surfaces_actionable_message(model_manager, monkeypatch):
         model_manager._load_model_sync()
 
 
+def test_corrupt_cache_force_repairs_on_second_failure(model_manager, monkeypatch):
+    """#739: resume-repair can't fix a present-but-corrupt blob (right size, wrong
+    bytes), so the reload fails again — a force re-download then replaces it and
+    the model loads, so the user never hits the manual delete-and-reinstall."""
+    repair_calls = []
+
+    def fake_repair(checkpoint, *, force=False):
+        repair_calls.append(force)
+        return True
+
+    monkeypatch.setattr(model_manager, "_repair_model_cache", fake_repair)
+
+    class TwiceTruncatedOmniVoice:
+        attempts = 0
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            cls.attempts += 1
+            if cls.attempts <= 2:  # initial load + post-resume reload both truncated
+                raise _TRUNCATED
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: TwiceTruncatedOmniVoice)
+
+    loaded = model_manager._load_model_sync()
+    assert loaded.llm is not None
+    assert repair_calls == [False, True]  # resume first, then force re-download
+    assert TwiceTruncatedOmniVoice.attempts == 3  # load, reload, force-reload
+
+
+def test_force_repair_failure_still_surfaces_actionable_message(model_manager, monkeypatch):
+    """If even the force re-download can't make the cache load, the user still
+    gets the actionable 'could not be auto-repaired' message, not a raw OSError."""
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache",
+        lambda checkpoint, *, force=False: True,  # repair "succeeds" but cache stays broken
+    )
+
+    class AlwaysTruncated:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise _TRUNCATED
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: AlwaysTruncated)
+
+    with pytest.raises(RuntimeError, match="could not be auto-repaired"):
+        model_manager._load_model_sync()
+
+
+def test_force_repair_passes_force_download(model_manager, monkeypatch):
+    """force=True must set force_download (replaces corrupt blobs); the default
+    resume path must NOT — re-downloading everything on a simple missing-file
+    repair would be wasteful."""
+    import huggingface_hub
+
+    calls = []
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: calls.append(k))
+
+    assert model_manager._repair_model_cache("test/checkpoint", force=True) is True
+    assert calls and calls[0].get("force_download") is True
+
+    calls.clear()
+    assert model_manager._repair_model_cache("test/checkpoint") is True
+    assert "force_download" not in calls[0]
+
+
 def test_repair_skipped_in_offline_mode(model_manager, monkeypatch):
     """Offline mode must not trigger a network re-fetch the user opted out of."""
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")


### PR DESCRIPTION
Final piece of #739. The retry fix (#741) covers a transient blip; this covers a *corrupt* cache.

## Problem
`snapshot_download`'s resume trusts an existing file **by size**. A blob that's present with the right size but corrupt (bit-rot, a half-flushed write) is never re-fetched — so the resume-repair 'succeeds', the reload still raises the truncated-cache `OSError`, and the user is dumped to a manual delete-and-reinstall.

## Fix
Add `force=True` to `_repair_model_cache` (passes `force_download`, which replaces present blobs) and wire it as a **last resort**: on the post-resume reload failure, force a full re-download once and retry the load before falling back to the actionable message. Force is only reached *after* a plain resume-repair didn't fix the cache, so the common missing-file case still avoids re-downloading everything.

## Tests (`tests/test_model_cache_repair.py`)
- `test_corrupt_cache_force_repairs_on_second_failure` — resume then force, model loads, no error.
- `test_force_repair_passes_force_download` — `force_download` set only when `force=True`.
- `test_force_repair_failure_still_surfaces_actionable_message` — unfixable cache → 'could not be auto-repaired'.
- Full file: 12 passed.

Closes #739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
Improves OmniVoice TTS model cache recovery by adding a forced re-download fallback when normal resume-based repair succeeds by size but the model still fails to load due to corruption. The repair path can now run with `force_download=True`, and the loader retries once more before surfacing the existing actionable cache-repair error.

## Behavior
```mermaid
flowchart TD
  A[Load OmniVoice model] --> B{Load succeeds?}
  B -->|Yes| C[Done]
  B -->|No: incomplete/corrupt cache| D[Repair cache with normal resume]
  D --> E{Reload succeeds?}
  E -->|Yes| C
  E -->|No| F[Repair cache with force re-download]
  F --> G{Reload succeeds?}
  G -->|Yes| C
  G -->|No| H[Raise actionable auto-repair failure message]
```

## Testing
- Added coverage for second-failure force repair success
- Added coverage for actionable failure when forced repair still cannot fix the cache
- Added coverage that `force=True` forwards `force_download=True` to Hugging Face snapshot download

<!-- end of auto-generated comment: release notes by coderabbit.ai -->