### PR TITLE
fix(dev): stop the Tauri dev app from killing concurrently's backend (bun desktop crash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "setup:api": "uv sync && uv run python scripts/setup.py",
     "dev:api": "uv run uvicorn main:app --app-dir backend --host 0.0.0.0 --port 3900 --reload --reload-dir backend",
     "dev:frontend": "bun run --cwd frontend dev",
-    "dev:desktop": "bun run --cwd frontend desktop",
+    "dev:desktop": "TAURI_SKIP_BACKEND=1 bun run --cwd frontend desktop",
     "wait:api": "wait-on -t 300000 http-get://localhost:3900/system/info",
     "wait:frontend": "wait-on -t 120000 http://localhost:5173",
     "predev": "kill-port 3900 3901 || true",


### PR DESCRIPTION
## Symptom
`bun desktop` dies almost immediately after the Tauri app finishes compiling:
```
[app] Port 3900 in use — taking ownership (killing whatever's there)
[app] Killing orphan process 11202 on port 3900        # <- concurrently's dev:api uvicorn
[api] error: script "dev:api" exited with code 137
--> Sending SIGTERM to other processes..               # --kill-others-on-fail cascade
```

## Root cause
`desktop` = `concurrently --kill-others-on-fail [dev:api, dev:desktop]`. `dev:api` is a uvicorn backend on :3900; the Tauri app launched by `dev:desktop` **also** manages a backend. On boot the app sees :3900 in use but not yet `backend_healthy()` (the dev backend is still importing torch + loading 32 models), so it hits the "take ownership" branch and kills `dev:api`. That exits 137 → `--kill-others-on-fail` → whole session torn down.

## Fix
The app already honors `TAURI_SKIP_BACKEND` to skip backend management (`lib.rs:654`); it just wasn't wired for the concurrently-managed dev flow. Set it on `dev:desktop` so the dev app **attaches** to concurrently's backend instead of fighting it.

- Scoped to `dev:desktop` only — `dev:api` is unaffected, and the standalone `frontend` `desktop` (`tauri dev`) still self-manages a backend for devs who run it alone.
- `bun run` evaluates inline `VAR=val` via its built-in cross-platform shell (verified on this machine), so **no `cross-env` dep / no `bun.lock` churn**.
- **Prod unaffected** (`desktop-prod`): there the Tauri app is the sole backend manager and the orphan-kill is correct.

## Verify
`bun desktop` → app boots, logs `TAURI_SKIP_BACKEND set — not spawning`, leaves `dev:api` alive; once the backend finishes loading the UI talks to :3900 normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `dev:desktop` to set `TAURI_SKIP_BACKEND=1` before launching the frontend desktop app.

```mermaid
flowchart LR
  A[bun desktop] --> B[concurrently: dev:api + dev:desktop]
  B --> C[dev:api starts backend on 3900]
  B --> D[dev:desktop launches Tauri app]
  D --> E[TAURI_SKIP_BACKEND=1]
  E --> F[Tauri skips backend takeover/killing]
  F --> G[Connects to the concurrently-managed backend]
```

This prevents the Tauri dev app from trying to claim port 3900 and terminating the API process, which was causing `bun desktop` to crash during development. Standalone backend-managed desktop flows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->