### PR TITLE
docs(changelog): finalize the [0.3.8] release notes (tag-ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [0.3.8] — 2026-06-26
+## [0.3.8] — 2026-06-29
 
 A stability-focused release that makes first-run and Windows "just work," ships
 **live, faster-than-real-time local dictation** and a **user pronunciation
@@ -180,12 +180,12 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   transcribe hangs hard and never returns. Because ASR shares a small (1–2 worker)
   GPU pool with TTS, one stuck worker starved every other request — so the next
   thing you did (often a TTS *generate*) failed with "can't reach backend" even
-  though the process was alive. Two fixes: every whole-file transcribe path (dub
-  whole-file, batch, and live dictation) is now wall-clock **bounded** like the
-  dub QC / dictation / OpenAI paths already were; and on timeout the poisoned GPU
-  worker is **abandoned and the pool rebuilt**, so capacity is restored without
-  restarting the app. You still get an actionable message (Flush VRAM / pick a
-  smaller ASR model) for the durable fix. (#730)
+  though the process was alive. Two fixes: every transcribe path — whole-file
+  (dub whole-file, batch, live dictation) **and** the chunked dub stream — is now
+  wall-clock **bounded** like the dub QC / dictation / OpenAI paths already were;
+  and on timeout the poisoned GPU worker is **abandoned and the pool rebuilt**, so
+  capacity is restored without restarting the app. You still get an actionable
+  message (Flush VRAM / pick a smaller ASR model) for the durable fix. (#730)
 - **The stale-dub-session recovery now also covers the first upload/ingest, not
   just retry/import.** A dubbing job that vanished server-side during the initial
   transcribe flow showed the scary *"Job not found … report a bug"* toast; it
@@ -400,6 +400,12 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   guard and a route-count floor), and a frontend feature-coverage test asserts
   every app mode is wired to a page and every feature has its i18n namespace — so
   an endpoint or page silently disappearing now fails CI on every PR.
+- **`bun desktop` no longer kills its own dev backend.** The dev launcher runs the
+  API and the Tauri app side-by-side, but the app's backend manager would "take
+  ownership" of port 3900 and kill the API the moment it booted (before it was
+  healthy), tearing the whole session down. The dev app now sets
+  `TAURI_SKIP_BACKEND` so it attaches to the running API instead of fighting it —
+  production launch is unaffected. (#745)
 
 ## [0.3.7] — 2026-06-20
 


### PR DESCRIPTION
Finalizes the `## [0.3.8]` CHANGELOG section that `release.yml` extracts verbatim as the GitHub Release body, so `git tag v0.3.8` is a one-liner.

- Release date → **2026-06-29**.
- #730 entry extended to cover the **chunked dub-stream** path (bounded + pool-reset, #742), not just the whole-file paths.
- Added the **`bun desktop` dev-launch fix** (#745) under `### CI`.

Version files are already in lockstep at **0.3.8** (package.json + Cargo.toml + pyproject.toml), so the tag matches with no further bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Finalized the 0.3.8 changelog entry for release automation, updating the release date to 2026-06-29.
- Expanded the `#730` fix note to cover the chunked dub-stream ASR path, including bounded execution and poisoned-worker pool reset behavior from `#742`.
- Added the `bun desktop` dev-launch fix from `#745` under CI, noting `TAURI_SKIP_BACKEND` prevents the dev app from competing with the backend port.

```mermaid
flowchart TD
  A[ASR request starts] --> B{Path}
  B -->|whole-file or chunked dub-stream| C[Run with wall-clock bound]
  C --> D{Timeout?}
  D -->|No| E[Return result]
  D -->|Yes| F[Abandon poisoned GPU worker]
  F --> G[Rebuild worker pool]
  G --> H[Capacity restored without app restart]

  I[bun desktop dev launch] --> J[Set TAURI_SKIP_BACKEND]
  J --> K[Attach to already-running API]
  K --> L[Avoid backend port conflict]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->