### PR TITLE
fix(settings): contain + tighten the whole Settings surface (design-system pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,16 @@ across dub, generate, and design (a corrupt-binary failure no longer poses as
   the backend's output pipe breaks and a synth can fail with `[Errno 32] Broken
   pipe`. That was labelled *"ran out of memory — try Flush,"* which never helps;
   it now tells you the backend lost its pipe and to restart the app. (#715)
+- **Settings content no longer sprawls or spills out of view.** The content
+  column capped at 1280px, so on wide windows rows stretched edge-to-edge with a
+  big empty gap between each label and its control ("too spread out"), and a few
+  panels (API keys, the shared button rows, appearance scale) used rigid pixel
+  widths that pushed controls past the card's padding on narrow content. Now the
+  content sits at a readable measure (a single `--settings-measure` token), the
+  shared button/badge rows wrap instead of overflowing, rigid widths can shrink,
+  and rows decide whether to sit side-by-side or stack based on their **actual**
+  width (a container query) — not the viewport, which the 168px nav rail skews.
+  Everything stays inside its padding, edge to edge, on every width. (#696)
 - **File drag-and-drop works on macOS again.** The app's drop zones use HTML5
   file drops, but Tauri intercepts OS drag-and-drop by default (`dragDropEnabled`)
   and swallowed the files before the webview saw them — most visibly on macOS

--- a/frontend/src/components/settings/ApiKeysPanel.css
+++ b/frontend/src/components/settings/ApiKeysPanel.css
@@ -103,8 +103,13 @@
 }
 
 .apikeys-input {
+  /* flex-basis already prefers 220px; a rigid min-width:220 only stopped the
+     input from shrinking, so it escaped the row's cap and overflowed on narrow
+     content. min-width:0 lets flexbox shrink it; it still grows to fill. */
   flex: 1 1 220px;
-  min-width: 220px;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
   padding: var(--space-2) var(--space-3);
   background: var(--chrome-hover-bg);
   border: 1px solid var(--chrome-border);

--- a/frontend/src/components/settings/AppearancePanel.css
+++ b/frontend/src/components/settings/AppearancePanel.css
@@ -13,12 +13,15 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-4);
-  min-width: 220px;
+  /* Was a rigid 220px floor that overflowed the control column when the row
+     stacked on narrow content. Prefer ~220 but allow it to shrink. */
+  min-width: 0;
+  width: clamp(160px, 100%, 260px);
 }
 
 .appearance-panel__scale input[type='range'] {
   flex: 1;
-  min-width: 160px;
+  min-width: 0;
   accent-color: var(--chrome-accent);
   cursor: pointer;
 }

--- a/frontend/src/components/settings/PerformancePanel.css
+++ b/frontend/src/components/settings/PerformancePanel.css
@@ -30,6 +30,13 @@
 
 .perfpanel__row {
   display: inline-flex;
+  /* Shared button/badge row across 6+ panels (RemoteBackend, HFMirror,
+     LLMEndpoint, Pronunciation, MCPBindings, …). Without these it ran off the
+     right edge on narrow content — wrap instead of overflow, and never exceed
+     the container; min-width:0 lets text children ellipsis rather than push out. */
+  flex-wrap: wrap;
+  max-width: 100%;
+  min-width: 0;
   align-items: center;
   gap: 8px;
   cursor: pointer;

--- a/frontend/src/components/settings/primitives/primitives.css
+++ b/frontend/src/components/settings/primitives/primitives.css
@@ -189,7 +189,19 @@
 }
 .st-row--stack .st-row__control .st-input { flex: 1 1 220px; }
 
-/* ── Narrow: stack the row so the control drops below the label ── */
+/* ── Narrow: stack the row so the control drops below the label ──
+   Two triggers, same outcome (idempotent):
+   1. Container query on the settings content width — the correct signal, since
+      the 168px nav rail makes the *viewport* width lie about how much room a row
+      actually has. This catches the case where the window is "wide" (≥760px) but
+      the content column is only ~530px and a side-by-side row would be cramped.
+   2. The legacy viewport media query, kept as a fallback for any .st-row used
+      OUTSIDE the settings container (no `settings` ancestor → no container query).
+*/
+@container settings (max-width: 600px) {
+  .st-row { grid-template-columns: 1fr; gap: var(--space-2); }
+  .st-row__control { justify-self: start; max-width: 100%; text-align: left; white-space: normal; }
+}
 @media (max-width: 560px) {
   .st-row { grid-template-columns: 1fr; gap: var(--space-2); }
   .st-row__control { justify-self: start; max-width: 100%; text-align: left; }

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -6,7 +6,17 @@
    full-height panel instead of a stunted box floating in a void. min-height:100%
    is a FLOOR — tall tabs (Models/Logs) grow past it and scroll as before; if the
    parent height is ever indeterminate it simply no-ops. */
-.settings-page                   { padding: var(--space-5) var(--space-7) var(--space-7); display: flex; flex-direction: column; min-height: 100%; box-sizing: border-box; }
+.settings-page                   {
+  padding: var(--space-5) var(--space-7) var(--space-7);
+  display: flex; flex-direction: column; min-height: 100%; box-sizing: border-box;
+  /* Center the whole settings block (nav rail + content) as a unit so a wide
+     window doesn't leave everything jammed against the left with a dead void on
+     the right. The cap = rail + gap + content measure + the L/R page padding,
+     so the content track lands exactly at --settings-measure. */
+  width: 100%;
+  max-width: calc(var(--settings-rail) + var(--space-5) + var(--settings-measure) + 2 * var(--space-7));
+  margin-inline: auto;
+}
 .settings-page h1                { font-size: var(--text-lg); margin: 0 0 2px; }
 .settings-page .settings-subtitle{ font-size: var(--text-base); margin-bottom: var(--space-5); }
 .settings-tabs-ui                { margin-bottom: var(--space-3); }

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -84,7 +84,7 @@
      viewport and clips at the window edge, which max-width on .settings-content
      can't claw back. This is the responsive-containment guarantee for EVERY
      settings page (they all share this grid). */
-  .settings-page { display: grid; grid-template-columns: 168px minmax(0, 1fr); gap: var(--space-5); align-content: start; }
+  .settings-page { display: grid; grid-template-columns: var(--settings-rail) minmax(0, 1fr); gap: var(--space-5); align-content: start; }
   .settings-page h1,
   .settings-page .settings-subtitle { grid-column: 1 / -1; }
   .ui-tabs.settings-tabs-ui {
@@ -121,8 +121,16 @@
 .settings-content {
   flex: 1 1 auto;
   min-width: 0;
-  max-width: 1280px;
+  /* Cap the reading measure so rows don't sprawl edge-to-edge on wide windows
+     (the "too spread out" report). Left-aligned under the nav rail, macOS-style;
+     the extra space falls to the right as plain whitespace, not stretched rows. */
+  max-width: var(--settings-measure);
   align-self: start;   /* size to content — don't stretch to the taller nav rail */
+  /* Make this the container the rows measure against. The nav rail steals
+     ~180px, so a *viewport* breakpoint misjudges the real content width — a
+     container query lets rows stack on their ACTUAL width instead (#primitives). */
+  container-type: inline-size;
+  container-name: settings;
 }
 .settings-content > :first-child { margin-top: 0; }
 

--- a/frontend/src/ui/tokens.css
+++ b/frontend/src/ui/tokens.css
@@ -50,7 +50,7 @@
      edge-to-edge (the "too spread out" report). The measure caps the content
      column at a readable width — like macOS System Settings — instead of the
      old 1280px; the rail token keeps the nav width in lockstep with the grid. */
-  --settings-measure: 720px;
+  --settings-measure: 660px;
   --settings-rail:    168px;
 
   /* ── Radius ─────────────────────────────────────────────────────── */

--- a/frontend/src/ui/tokens.css
+++ b/frontend/src/ui/tokens.css
@@ -45,6 +45,14 @@
   --space-8:  32px;
   --space-9:  44px;
 
+  /* ── Settings layout ────────────────────────────────────────────────
+     One source of truth for the Settings shell so the content can't sprawl
+     edge-to-edge (the "too spread out" report). The measure caps the content
+     column at a readable width — like macOS System Settings — instead of the
+     old 1280px; the rail token keeps the nav width in lockstep with the grid. */
+  --settings-measure: 720px;
+  --settings-rail:    168px;
+
   /* ── Radius ─────────────────────────────────────────────────────── */
   --radius-xs:  2px;
   --radius-sm:  3px;


### PR DESCRIPTION
Addresses the recurring **"Settings too spread out / elements go out of view / not responsive"** report with a design-system-level pass, not per-page patching. Backed by a full audit of the shell + every panel.

## Root causes
1. **Spread** — `.settings-content` was capped at **1280px**, so on wide windows each label-left / control-right row stretched with a huge void in the middle.
2. **Cramped/overflow** — the row-stack breakpoint was a **viewport** media query (560px), but the 168px nav rail means a 760px-viewport window only has ~530px of content → rows sat side-by-side in a cramped box.
3. **Golden flaw** — the shared `.perfpanel__row` (button/badge row reused by **6+ panels**: RemoteBackend, HFMirror, LLMEndpoint, Pronunciation, MCPBindings…) was an `inline-flex` with no wrap and no `max-width` → ran off the right edge. Plus rigid pixel widths (ApiKeys input `min-width:220`, Appearance scale) that escaped the row cap.

## Fix
- **Tokens** — new `--settings-measure: 720px` (macOS-like reading width) + `--settings-rail: 168px`; `.settings-content` caps to the measure, left-aligned under the nav.
- **Container queries** — `.settings-content` becomes a container (`container-type: inline-size`); `.st-row` stacks on its **actual content width** (`@container settings (max-width:600px)`), with the viewport `@media` kept as a fallback for `.st-row` used **outside** Settings (Splash / FirstRun / Dub / SetupWizard — verified).
- **Containment** — `.perfpanel__row` gets `flex-wrap + max-width:100% + min-width:0`; rigid widths in ApiKeys / Appearance can now shrink.

One `--settings-measure` token now controls the spread — trivially tunable.

## Verify
`bun run build` is clean; `@container settings`, `container-type:inline-size`, the `perfpanel__row` wrap, and the measure token are all confirmed in the emitted CSS. Visually: open Settings, resize narrow → ultra-wide — content stays at a readable measure, rows stack on real width, nothing leaves the card padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added new Settings layout tokens (`--settings-measure: 660px`, `--settings-rail: 168px`) and used them as the single source of truth for the Settings shell’s grid.
- Centered the entire Settings block (rail + content) by capping `.settings-page` with `max-width` and `margin-inline: auto`.
- Updated `.settings-content` to cap reading width with `max-width: var(--settings-measure)` and made it a named inline-size container (`container-name: settings`) so descendants can respond to the *actual* content column width.
- Changed `.st-row` responsive behavior to stack based on a container query: `@container settings (max-width: 600px)` (with `@media (max-width: 560px)` kept as a fallback for non-Settings `.st-row`s).
- Improved overflow/wrapping across Settings panels:
  - `.perfpanel__row` now wraps and allows children to shrink (`flex-wrap: wrap`, `min-width: 0`, bounded to `max-width: 100%`).
  - ApiKeys input (`.apikeys-input`) now uses `min-width: 0`, `max-width: 100%`, and `box-sizing: border-box`.
  - Appearance panel scale controls now use more flexible sizing (`min-width: 0`) so they don’t force overflow.
- Documented the layout fix in `CHANGELOG.md` (v0.3.8 Fixed).

## Layout sketch
Before
```text
┌──────────────────────────────────────────────┐
│ Rail │   Wide fixed content area            │
│      │  [row label] [controls on one line]
│      │  (can clip/overflow on narrower widths)
└──────────────────────────────────────────────┘
```

After
```text
┌──────────────────────────────────────────────┐
│ (centered as a unit)                          │
│ Rail │   Settings content (measure=660px)   │
│      │  [row label]                         │
│      │  [controls] (wrap/shrink within bounds)
│      │  when container <= 600px: controls stack under label
└──────────────────────────────────────────────┘
```

## Behavior flow
```mermaid
flowchart TD
  A[Settings renders .settings-content as container "settings"] --> B{settings-content <= 600px?}
  B -->|yes| C[Stack .st-row: 1 column (label above controls)]
  B -->|no| D[Keep .st-row side-by-side]
  D --> E[Rows/controls wrap and shrink safely within max-width]
  C --> E
  A --> F[Fallback: if no "settings" container ancestor]
  F --> G{viewport <= 560px?}
  G -->|yes| C
  G -->|no| D
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->