### PR TITLE
fix(api): route backend fetches through apiFetch (LAN-share auth + retry)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,7 +59,7 @@ import {
   POPULAR_LANGS, POPULAR_ISO, TAGS, CATEGORIES, PRESETS, CLONE_MAX_SECONDS,
 } from './utils/constants';
 import { LANG_CODES } from './utils/languages';
-import { API } from './api/client';
+import { API, apiFetch } from './api/client';
 import { flushMemory as apiFlushMemory } from './api/system';
 import { saveProject as apiSaveProject, loadProject as apiLoadProject, deleteProject as apiDeleteProject, renameProject as apiRenameProject } from './api/projects';
 import { exportAction, exportReveal, exportRecord } from './api/exports';
@@ -480,8 +480,7 @@ function App() {
         // voice warm without depending on seeded profiles.
         fd.append('instruct', 'A warm, friendly narrator voice, medium pace');
         fd.append('num_step', '16');
-        const res = await fetch(`${API}/generate`, { method: 'POST', body: fd });
-        if (!res.ok) return;
+        const res = await apiFetch(`${API}/generate`, { method: 'POST', body: fd });
         const blob = await res.blob();
         await playBlobAudio(blob);
         toast.success(i18n.t('firstrun.first_sound_done'), { duration: 7000 });
@@ -674,11 +673,7 @@ function App() {
         // pick is the write authorization, and the backend never handles a
         // destination path (#309).
         if (['srt', 'vtt'].includes(extGuess)) {
-          const res = await fetch(url);
-          if (!res.ok) {
-            const err = await res.json().catch(() => ({}));
-            throw new Error(err.detail || 'Save failed');
-          }
+          const res = await apiFetch(url);
           const text = await res.text();
           const { invoke } = await import('@tauri-apps/api/core');
           await invoke('save_text_file', { path: destPath, contents: text });
@@ -691,11 +686,7 @@ function App() {
         }
 
         const sep = url.includes('?') ? '&' : '?';
-        const res = await fetch(`${url}${sep}save_path=${encodeURIComponent(destPath)}`);
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}));
-          throw new Error(err.detail || 'Save failed');
-        }
+        const res = await apiFetch(`${url}${sep}save_path=${encodeURIComponent(destPath)}`);
         // Every save_path-aware endpoint returns a JSON envelope. Guard the
         // content-type so a raw-body response surfaces as a clear error
         // instead of a cryptic JSON.parse failure (#309).
@@ -905,7 +896,7 @@ function App() {
     if (!(await askConfirm('Delete this history item?'))) return;
     try {
       const endpoint = type === 'dub' ? `${API}/dub/history/${id}` : `${API}/history/${id}`;
-      await fetch(endpoint, { method: 'DELETE' });
+      await apiFetch(endpoint, { method: 'DELETE' });
       if (type === 'dub') {
         loadDubHistory();
       } else {

--- a/frontend/src/components/DictationDemo.jsx
+++ b/frontend/src/components/DictationDemo.jsx
@@ -23,7 +23,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Play, Pause, Keyboard, Mic, CheckCircle2, AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { API } from '../api/client';
+import { API, apiFetch } from '../api/client';
 import { Button } from '../ui';
 import './DictationDemo.css';
 
@@ -72,8 +72,8 @@ export default function DictationDemo({ embedded = false }) {
   // demo if not, mirroring DubbingDemo's missing-manifest behavior.
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API}${SCRIPTS[0].wav}`, { method: 'HEAD' })
-      .then((r) => { if (!cancelled) setAssetsAvailable(r.ok); })
+    apiFetch(`${API}${SCRIPTS[0].wav}`, { method: 'HEAD' })
+      .then(() => { if (!cancelled) setAssetsAvailable(true); })
       .catch(() => { if (!cancelled) setAssetsAvailable(false); });
     return () => { cancelled = true; };
   }, []);
@@ -148,16 +148,11 @@ export default function DictationDemo({ embedded = false }) {
       [script.id]: { state: 'loading', text: '', error: '' },
     }));
     try {
-      const wavRes = await fetch(`${API}${script.wav}`);
-      if (!wavRes.ok) throw new Error(`Could not fetch sample: ${wavRes.status}`);
+      const wavRes = await apiFetch(`${API}${script.wav}`);
       const blob = await wavRes.blob();
       const fd = new FormData();
       fd.append('audio', blob, `${script.id}.wav`);
-      const tRes = await fetch(`${API}/transcribe`, { method: 'POST', body: fd });
-      if (!tRes.ok) {
-        const errBody = await tRes.text().catch(() => '');
-        throw new Error(`Transcribe failed (${tRes.status}): ${errBody.slice(0, 120)}`);
-      }
+      const tRes = await apiFetch(`${API}/transcribe`, { method: 'POST', body: fd });
       const json = await tRes.json();
       setTranscripts((prev) => ({
         ...prev,

--- a/frontend/src/components/DubbingDemo.jsx
+++ b/frontend/src/components/DubbingDemo.jsx
@@ -13,7 +13,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Play, Film, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { API } from '../api/client';
+import { API, apiFetch } from '../api/client';
 import './DubbingDemo.css';
 
 export default function DubbingDemo({ onDismiss }) {
@@ -27,11 +27,8 @@ export default function DubbingDemo({ onDismiss }) {
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${API}/demo_audio/demo/dubbing/manifest.json`)
-      .then(r => {
-        if (!r.ok) throw new Error(`manifest ${r.status}`);
-        return r.json();
-      })
+    apiFetch(`${API}/demo_audio/demo/dubbing/manifest.json`)
+      .then(r => r.json())
       .then(j => { if (!cancelled) setManifest(j); })
       .catch(e => { if (!cancelled) setError(e?.message || String(e)); });
     return () => { cancelled = true; };

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -106,12 +106,10 @@ export default function Header({
     if (!flushOpen) return;
     const fetchModels = async () => {
       try {
-        const { API } = await import('../api/client');
-        const res = await fetch(`${API}/model/loaded`);
-        if (res.ok) {
-          const data = await res.json();
-          setLoadedModels(data.models || []);
-        }
+        const { apiFetch } = await import('../api/client');
+        const res = await apiFetch('/model/loaded');
+        const data = await res.json();
+        setLoadedModels(data.models || []);
       } catch {}
     };
     fetchModels();
@@ -133,11 +131,9 @@ export default function Header({
   const unloadModel = async (modelId) => {
     setUnloading(modelId);
     try {
-      const { API } = await import('../api/client');
-      const res = await fetch(`${API}/model/unload/${modelId}`, { method: 'POST' });
-      if (res.ok) {
-        setLoadedModels(prev => prev.filter(m => m.id !== modelId));
-      }
+      const { apiFetch } = await import('../api/client');
+      await apiFetch(`/model/unload/${modelId}`, { method: 'POST' });
+      setLoadedModels(prev => prev.filter(m => m.id !== modelId));
     } catch {} finally {
       setUnloading(null);
     }

--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -22,13 +22,12 @@ export default function HfTokenCard({ className = '' }) {
     if (!value || hfState === 'saving') return;
     setHfState('saving');
     try {
-      const { API } = await import('../api/client');
-      const res = await fetch(`${API}/system/set-env`, {
+      const { apiFetch } = await import('../api/client');
+      await apiFetch('/system/set-env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key: 'HF_TOKEN', value }),
       });
-      if (!res.ok) throw new Error(String(res.status));
       setHfState('saved');
       setHfToken('');
     } catch {

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -499,7 +499,7 @@ export default function LogsFooter() {
                   // every session until a NEW crash grows the log.
                   if (notif.id === 'crash-last-session') {
                     import('../api/client')
-                      .then(({ API }) => fetch(`${API}/system/crash/ack`, { method: 'POST' }))
+                      .then(({ apiFetch }) => apiFetch('/system/crash/ack', { method: 'POST' }))
                       .catch(() => {});
                   }
                   if (notif.action.type === 'navigate') {

--- a/frontend/src/components/gallery/ImportsZone.jsx
+++ b/frontend/src/components/gallery/ImportsZone.jsx
@@ -10,7 +10,7 @@ import {
   saveVoiceAsProfile, uploadVoiceClip, previewVoiceUrl,
 } from '../../api/gallery';
 import AudioTrimmer from '../AudioTrimmer';
-import { apiUrl } from '../../api/client';
+import { apiFetch } from '../../api/client';
 import { askConfirm } from '../../utils/dialog';
 
 // ── My Imports zone (neutral importer) ───────────────────────────────────────
@@ -140,8 +140,7 @@ export default function ImportsZone({ t, playingId, loadingPreviewId, onPlayGall
 
   const handleTrimClick = async (v) => {
     try {
-      const resp = await fetch(apiUrl(previewVoiceUrl(v.id)));
-      if (!resp.ok) throw new Error('fetch failed');
+      const resp = await apiFetch(previewVoiceUrl(v.id));
       const blob = await resp.blob();
       const file = new File([blob], `${v.name}.wav`, { type: 'audio/wav' });
       setTrimming({ voice: v, file });

--- a/frontend/src/components/settings/ApiKeysPanel.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.jsx
@@ -22,7 +22,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CheckCircle2, KeyRound, RefreshCw, Save, Trash2, XCircle } from 'lucide-react';
-import { apiJson, apiPost, API } from '../../api/client';
+import { apiJson, apiPost, apiFetch, API } from '../../api/client';
 import { SettingsSection, InfoHint } from './primitives';
 import './ApiKeysPanel.css';
 
@@ -96,8 +96,7 @@ export default function ApiKeysPanel() {
     try {
       const qs = alsoClearCli ? '?also_clear_hf_cli=true' : '';
       const url = `${API}/api/settings/hf-token${qs}`;
-      const res = await fetch(url, { method: 'DELETE' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await apiFetch(url, { method: 'DELETE' });
       setClearOpen(false);
       setAlsoClearCli(false);
       await refresh();

--- a/frontend/src/components/settings/CredentialsTab.jsx
+++ b/frontend/src/components/settings/CredentialsTab.jsx
@@ -38,20 +38,15 @@ export default function CredentialsTab({ info }) {
     if (!value) return;
     setSaving(key);
     try {
-      const { API } = await import('../../api/client');
-      const res = await fetch(`${API}/system/set-env`, {
+      const { apiFetch } = await import('../../api/client');
+      await apiFetch('/system/set-env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key, value }),
       });
-      if (res.ok) {
-        toast.success(t('credentials.saved_session', { key }));
-        setSaved(prev => ({ ...prev, [key]: true }));
-        setValues(prev => ({ ...prev, [key]: '' }));
-      } else {
-        const d = await res.json().catch(() => ({}));
-        toast.error(d.detail || t('credentials.save_failed'));
-      }
+      toast.success(t('credentials.saved_session', { key }));
+      setSaved(prev => ({ ...prev, [key]: true }));
+      setValues(prev => ({ ...prev, [key]: '' }));
     } catch (e) {
       toast.error(t('credentials.save_error', { message: e.message }));
     } finally {

--- a/frontend/src/components/settings/GeneralTab.jsx
+++ b/frontend/src/components/settings/GeneralTab.jsx
@@ -39,20 +39,15 @@ export default function GeneralTab() {
     const value = ffmpegPath.trim();
     setFfmpegSaving(true);
     try {
-      const { API } = await import('../../api/client');
-      const r = await fetch(`${API}/system/set-env`, {
+      const { apiFetch } = await import('../../api/client');
+      await apiFetch('/system/set-env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key: 'FFMPEG_PATH', value }),
       });
-      if (r.ok) {
-        toast.success(t('settings.ffmpeg_saved'));
-        setFfmpegPath('');
-        queryClient.invalidateQueries({ queryKey: queryKeys.systemInfo });
-      } else {
-        const d = await r.json().catch(() => ({}));
-        toast.error(d.detail || t('credentials.save_failed'));
-      }
+      toast.success(t('settings.ffmpeg_saved'));
+      setFfmpegPath('');
+      queryClient.invalidateQueries({ queryKey: queryKeys.systemInfo });
     } catch (e) { toast.error(t('settings.save_failed', { message: e.message })); }
     finally { setFfmpegSaving(false); }
   };
@@ -67,28 +62,23 @@ export default function GeneralTab() {
     const value = proxyUrl.trim();
     setProxySaving(true);
     try {
-      const { API } = await import('../../api/client');
-      const setEnv = (key, val) => fetch(`${API}/system/set-env`, {
+      const { apiFetch } = await import('../../api/client');
+      const setEnv = (key, val) => apiFetch('/system/set-env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key, value: val }),
       });
-      const r = await setEnv('HTTP_PROXY', value);
-      if (r.ok) {
-        await Promise.all([
-          setEnv('HTTPS_PROXY', value),
-          setEnv('ALL_PROXY', value),
-          setEnv('http_proxy', value),
-          setEnv('https_proxy', value),
-          setEnv('all_proxy', value),
-        ]);
-        toast.success(t('settings.proxy_saved'));
-        setProxySaved(true);
-        queryClient.invalidateQueries({ queryKey: queryKeys.systemInfo });
-      } else {
-        const d = await r.json().catch(() => ({}));
-        toast.error(d.detail || t('settings.proxy_save_failed'));
-      }
+      await setEnv('HTTP_PROXY', value);
+      await Promise.all([
+        setEnv('HTTPS_PROXY', value),
+        setEnv('ALL_PROXY', value),
+        setEnv('http_proxy', value),
+        setEnv('https_proxy', value),
+        setEnv('all_proxy', value),
+      ]);
+      toast.success(t('settings.proxy_saved'));
+      setProxySaved(true);
+      queryClient.invalidateQueries({ queryKey: queryKeys.systemInfo });
     } catch (e) { toast.error(t('settings.save_failed', { message: e.message })); }
     finally { setProxySaving(false); }
   };
@@ -96,8 +86,8 @@ export default function GeneralTab() {
   const clearProxy = async () => {
     setProxySaving(true);
     try {
-      const { API } = await import('../../api/client');
-      const setEnv = (key, val) => fetch(`${API}/system/set-env`, {
+      const { apiFetch } = await import('../../api/client');
+      const setEnv = (key, val) => apiFetch('/system/set-env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key, value: val }),

--- a/frontend/src/components/settings/ModelStoreTab.jsx
+++ b/frontend/src/components/settings/ModelStoreTab.jsx
@@ -79,21 +79,16 @@ export default function ModelStoreTab({ info, modelBadge }) {
     if (!value) return;
     setHfSaving(true);
     try {
-      const { API } = await import('../../api/client');
-      const res = await fetch(`${API}/system/set-env`, {
+      const { apiFetch } = await import('../../api/client');
+      await apiFetch('/system/set-env', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ key: 'HF_TOKEN', value }),
       });
-      if (res.ok) {
-        toast.success(t('models.hf_token_set_toast'));
-        setHfSaved(true);
-        setHfToken('');
-        setHfExpanded(false);
-      } else {
-        const d = await res.json().catch(() => ({}));
-        toast.error(d.detail || t('models.hf_token_save_failed'));
-      }
+      toast.success(t('models.hf_token_set_toast'));
+      setHfSaved(true);
+      setHfToken('');
+      setHfExpanded(false);
     } catch (e) { toast.error(t('settings.save_failed', { message: e.message })); }
     finally { setHfSaving(false); }
   };

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -7,7 +7,7 @@ import {
 } from '../api/dub';
 import { dialectMatchesLang } from '../api/dialects';
 import { segmentGenInputs, applySpeakerCloneDefaults } from '../utils/segments';
-import { apiPost } from '../api/client';
+import { apiPost, apiFetch } from '../api/client';
 import { API } from '../api/client';
 import { playPing } from '../utils/media';
 import { toast } from 'react-hot-toast';
@@ -495,7 +495,7 @@ export default function useDubWorkflow({ loadProjects, loadProfiles, loadDubHist
       };
       const data = await dubGenerate(dubJobId, body);
       setDubTaskId(data.task_id);
-      const streamRes = await fetch(tasksStreamUrl(data.task_id));
+      const streamRes = await apiFetch(tasksStreamUrl(data.task_id));
       const reader = streamRes.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';

--- a/frontend/src/hooks/useProfiles.js
+++ b/frontend/src/hooks/useProfiles.js
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import { createProfile, deleteProfile as apiDeleteProfile, lockProfile, unlockProfile } from '../api/profiles';
 import { generateSpeech, audioUrlWithCacheBust } from '../api/generate';
+import { apiFetch } from '../api/client';
 import { playBlobAudio } from '../utils/media';
 import { PRESETS } from '../utils/constants';
 import { instructToFormValue } from '../utils/voiceInstruct';
@@ -192,8 +193,7 @@ export default function useProfiles({ loadHistory, loadProfiles }) {
   const handleSaveHistoryAsProfile = useCallback(async (item) => {
     try {
       const pName = `Voice ${new Date().toLocaleTimeString('en', {hour:'2-digit', minute:'2-digit'})} — ${(item.mode||'design').toUpperCase()}`;
-      const response = await fetch(audioUrlWithCacheBust(item.audio_path));
-      if (!response.ok) throw new Error("Audio not found");
+      const response = await apiFetch(audioUrlWithCacheBust(item.audio_path));
       const blob = await response.blob();
       const file = new File([blob], item.audio_path, { type: "audio/wav" });
 

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { CATEGORIES } from '../utils/constants';
 import { Segmented } from '../ui';
 import { useAppStore } from '../store';
-import { API, apiPost } from '../api/client';
+import { API, apiPost, apiFetch } from '../api/client';
 import { mergeDescribedAttrs } from '../utils/voiceInstruct';
 import { listEngines } from '../api/engines';
 import { claimPlayback, stopActivePlayback, usePlaybackSource } from '../utils/playback';
@@ -119,7 +119,7 @@ export default function CloneDesignTab(props) {
   // Fetch personality presets from backend
   const { data: personalities = [] } = useQuery({
     queryKey: ['personalities'],
-    queryFn: () => fetch(`${API}/personalities`).then(r => r.json()),
+    queryFn: () => apiFetch(`${API}/personalities`).then(r => r.json()),
     staleTime: Infinity,
   });
 

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -64,8 +64,7 @@ function fmtDuration(sec) {
  */
 async function playRenderInApp(url) {
   try {
-    const resp = await fetch(url, { cache: 'no-store' });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const resp = await apiFetch(url, { cache: 'no-store' });
     await playBlobAudio(await resp.blob());
   } catch (e) {
     console.error('[Projects] render playback failed:', e);

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -8,7 +8,7 @@ import {
   Keyboard, Wifi, Palette, ArrowDownToLine, Settings2,
 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
-import { API } from '../api/client';
+import { API, apiFetch } from '../api/client';
 import { useTranslation } from 'react-i18next';
 import { systemLogs, systemLogsTauri, clearSystemLogs, clearTauriLogs } from '../api/system';
 import { useSysinfo, useModelStatus, useSystemInfo } from '../api/hooks';
@@ -119,8 +119,7 @@ export default function Settings() {
   const runSelfCheck = useCallback(async () => {
     setSelfCheckRunning(true);
     try {
-      const r = await fetch(`${API}/system/diagnose`);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const r = await apiFetch(`${API}/system/diagnose`);
       setSelfCheck(await r.json());
     } catch (e) {
       toast.error(t('about.self_check_failed', { message: e?.message || e }));
@@ -136,8 +135,7 @@ export default function Settings() {
   const saveDiagnosticBundle = useCallback(async () => {
     setBundleBuilding(true);
     try {
-      const r = await fetch(`${API}/system/diagnostic-bundle`, { method: 'POST' });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const r = await apiFetch(`${API}/system/diagnostic-bundle`, { method: 'POST' });
       const j = await r.json();
       toast.success(t('about.bundle_saved', { filename: j.filename }));
       try {

--- a/frontend/src/test/ProjectsAudiobookPlayback.test.jsx
+++ b/frontend/src/test/ProjectsAudiobookPlayback.test.jsx
@@ -9,18 +9,20 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 vi.mock('../utils/media', () => ({ playBlobAudio: vi.fn() }));
 vi.mock('../api/generate', () => ({ audioUrl: (f) => `http://test.local/audio/${f}` }));
-vi.mock('../api/client', () => ({
-  apiFetch: vi.fn(async (path) => {
-    if (path === '/longform/jobs') {
-      return {
-        json: async () => ({
-          jobs: [{ job_id: 'jb1', output: 'book.wav', title: 'My Audiobook', type: 'audiobook', created_at: 1 }],
-        }),
-      };
-    }
-    return { json: async () => ({}) };
-  }),
-}));
+// The render now plays in-app via apiFetch (carries the LAN-share PIN /
+// remote API-key headers a raw fetch would skip), so the mock serves both the
+// job list and the audio blob.
+const apiFetchMock = vi.fn(async (path) => {
+  if (path === '/longform/jobs') {
+    return {
+      json: async () => ({
+        jobs: [{ job_id: 'jb1', output: 'book.wav', title: 'My Audiobook', type: 'audiobook', created_at: 1 }],
+      }),
+    };
+  }
+  return { blob: async () => new Blob(['x']), json: async () => ({}) };
+});
+vi.mock('../api/client', () => ({ apiFetch: (...a) => apiFetchMock(...a) }));
 
 import Projects from '../pages/Projects';
 import { playBlobAudio } from '../utils/media';
@@ -47,8 +49,10 @@ describe('Projects — audiobook playback (#532)', () => {
     fireEvent.click(card);
 
     await waitFor(() => expect(playBlobAudio).toHaveBeenCalledTimes(1));
-    // In-app fetch of the render file, never a new window/OS media surface.
-    expect(fetchMock).toHaveBeenCalledWith('http://test.local/audio/book.wav', { cache: 'no-store' });
+    // In-app fetch of the render file (via apiFetch), never a new window/OS
+    // media surface.
+    expect(apiFetchMock).toHaveBeenCalledWith('http://test.local/audio/book.wav', { cache: 'no-store' });
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(openSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/utils/download.js
+++ b/frontend/src/utils/download.js
@@ -5,6 +5,7 @@
 // native save dialog instead; calling that dialog when no Tauri runtime is
 // present throws "Cannot read properties of undefined (reading 'invoke')"
 // (issue #256), so callers must guard on isTauri and route here otherwise.
+import { apiFetch } from '../api/client';
 
 /**
  * Parse a download filename out of a Content-Disposition header.
@@ -30,9 +31,11 @@ export function parseFilenameFromContentDisposition(header) {
  * filename, falling back to `fallbackName`. Returns the filename used.
  *
  * `deps` lets tests inject fetch/document/url without a real DOM + network.
+ * The default fetch is `apiFetch`, so backend downloads carry the LAN-share
+ * PIN / remote API-key headers (a raw fetch would 401 under remote-backend).
  */
 export async function browserDownload(url, fallbackName, deps = {}) {
-  const _fetch = deps.fetch ?? globalThis.fetch;
+  const _fetch = deps.fetch ?? apiFetch;
   const doc = deps.document ?? globalThis.document;
   const urlApi = deps.url ?? globalThis.URL;
 

--- a/frontend/src/utils/media.js
+++ b/frontend/src/utils/media.js
@@ -5,6 +5,7 @@
  */
 import { API_BASE as _PREVIEW_API, isTauriContext } from './apiBase';
 import { claimPlayback } from './playback';
+import { apiFetch } from '../api/client';
 
 const isTauri = isTauriContext();
 
@@ -36,7 +37,7 @@ export const fileToMediaUrl = async (file, prevUrls) => {
     try {
       const form = new FormData();
       form.append('video', file, file.name || 'media.wav');
-      const res = await fetch(`${_PREVIEW_API}/preview/upload`, { method: 'POST', body: form });
+      const res = await apiFetch(`${_PREVIEW_API}/preview/upload`, { method: 'POST', body: form });
       const data = await res.json();
       return {
         videoUrl: `${_PREVIEW_API}${data.url}`,
@@ -95,8 +96,7 @@ export const playBlobAudio = async (blob) => {
       try {
         const form = new FormData();
         form.append('video', blob, 'preview.audio');
-        const res = await fetch(`${_PREVIEW_API}/preview/upload`, { method: 'POST', body: form });
-        if (!res.ok) throw new Error(`preview upload failed: ${res.status}`);
+        const res = await apiFetch(`${_PREVIEW_API}/preview/upload`, { method: 'POST', body: form });
         const data = await res.json();
         const url = `${_PREVIEW_API}${data.audioUrl || data.url}`;
         const a = new Audio(url);


### PR DESCRIPTION
## Why
Under LAN-share / remote-backend (a PIN or API key is set), ~28 raw `fetch()` calls to the backend **401'd** — they skipped the `X-OmniVoice-Pin` / `Authorization: Bearer` headers `apiFetch` injects. This routes them through `apiFetch` (fixing auth) and gives them transport-retry robustness.

## What
- **28 backend fetches → `apiFetch`** (export/save/generate, media uploads, model load/unload, settings panels, gallery/profile audio, dub stream, …). `apiFetch` throws `ApiError` on `!ok` (+ fires `ov:pin-required` on 401), so dead `if(!res.ok)` blocks were removed; try/catch handles it. Streaming/FormData/cache/signal preserved.
- **6 left raw** (documented): auth-exempt `/health`, RemoteBackendPanel connectivity test, WaveformTimeline (404-branch + `blob:`), VoiceGallery `playUrl` (external CDN), bugReport hard-2.5s-timeout.
- Updated the #532 in-app-playback regression test.

## Verification
- ✅ oxlint 0 errors · `vite build` · full suite **638/638**

*(Recreated from #762, which auto-closed when its stacked base branch merged. Rebased to a clean single-commit delta on `main`.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Routed many backend requests through `apiFetch` across app flows: generation, downloads, history actions, model load/unload, settings/env writes, gallery/profile audio, dubbing, and preview uploads.
- Removed most manual `res.ok` branching and moved failure handling to `apiFetch`/`try-catch`, while preserving existing streaming, `FormData`, cache, and signal behavior.
- Kept a small set of raw `fetch` calls intentionally for health checks, a connectivity test, a 404/blob branch, direct playback URL loading, and the bug-report timeout path.
- Updated the in-app audiobook playback regression test to mock/assert the `apiFetch` path.

## Behavior
```mermaid
flowchart TD
  A[UI action / request] --> B[apiFetch]
  B --> C{Response OK?}
  C -->|Yes| D[Parse JSON / Blob / Stream]
  C -->|No| E[ApiError / ov:pin-required on 401]
  D --> F[Existing success UI/update]
  E --> G[Catch / toast / retry / auth flow]
```

## UI sketch
```text
Before:  [Button] --fetch--> [res.ok check] --manual error handling
After:   [Button] --apiFetch--> [ApiError/catch] --shared auth/retry handling
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->