### PR TITLE
docs(contributing): frontend CSS guidance → utilities-first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ class MyEngineBackend(TTSBackend):
 
 - **Components**: Functional components with hooks
 - **State**: Zustand stores in `src/stores/`, organized by slice
-- **CSS**: Vanilla CSS in component-level files — no Tailwind
+- **CSS**: **Utilities-first** — use Tailwind v4 utility classes (mapped to the design tokens in `src/ui/tokens.css` via the `@theme` block in `src/index.css`) for layout, spacing, and typography. Keep component-level `.css` files only for what utilities can't express cleanly: glassmorphism/`backdrop-filter`, `@keyframes`, pseudo-elements, `:has()`, and theme-specific rules. New components should not reflexively spawn a `.css` file. (Migration in progress — see `docs/css-to-tailwind-migration.md`.)
 - **Naming**: `PascalCase` for components, `camelCase` for hooks and utils
 
 ### Rust (Tauri)


### PR DESCRIPTION
Replaces the `CSS: Vanilla CSS … no Tailwind` rule (which contradicted the wired Tailwind v4 setup + the migration plan #772) with the **utilities-first** standard: Tailwind utilities for layout/spacing/typography, `.css` files only for glass/keyframes/pseudo-elements/`:has()`/theme rules.

P0 of the CSS→Tailwind migration; required by the docs-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `CONTRIBUTING.md` frontend styling guidance to match the Tailwind v4 setup and the CSS→Tailwind migration plan.

- Replaced the old “vanilla CSS / no Tailwind” rule with a utilities-first standard
- Directed component styling toward Tailwind utilities for layout, spacing, and typography
- Kept `.css` usage for cases Tailwind is less suited for, such as glass effects, keyframes, pseudo-elements, `:has()`, and theme-specific rules
- Removed the conflicting instruction that discouraged Tailwind use

<!-- end of auto-generated comment: release notes by coderabbit.ai -->