### PR TITLE
fix(css): make @theme the single source for design tokens (dedup drift) + parity test

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,10 +39,13 @@
   --radius-lg:  6px;
   --radius-xl: 10px;
 
-  /* Fonts */
-  --font-sans:    'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-mono:    'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
-  --font-serif:   'Source Serif 4 Variable', 'Source Serif 4', Georgia, serif;
+  /* Fonts — full font stacks. These are the single source of truth; the
+     identical declarations were removed from ui/tokens.css (which, being
+     unlayered, used to win — so these literals carry the exact stacks that
+     were computed before the de-dup, preserving every resolved value). */
+  --font-sans:    'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, 'Söhne', 'Helvetica Neue', Arial, sans-serif;
+  --font-mono:    'IBM Plex Mono', ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace;
+  --font-serif:   'Source Serif 4 Variable', 'Source Serif 4', 'Söhne Breit', Georgia, serif;
 }
 
 /* Font imports removed — the chrome token system uses only system monospace

--- a/frontend/src/test/tokenParity.test.js
+++ b/frontend/src/test/tokenParity.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Design-token drift guard (CSS → Tailwind v4 migration, "Solution A").
+ *
+ * The semantic color/radius/font tokens (`--color-*`, `--radius-*`,
+ * `--font-*`) are owned by the Tailwind v4 `@theme` block in
+ * `src/index.css` — that is their SINGLE source of truth. They used to be
+ * re-declared in `src/ui/tokens.css`'s default `:root`, and because that
+ * `:root` is unlayered while `@theme` lands in `@layer theme`, the
+ * tokens.css copy silently WON. The two copies had already drifted (the
+ * font stacks differed), so the `@theme` literals were dead, losing
+ * duplicates.
+ *
+ * After the de-dup, each of those tokens is declared exactly once. This test
+ * fails if the drift ever returns: if a `--color-*` / `--radius-*` /
+ * `--font-*` token is declared in BOTH the `@theme` block and tokens.css's
+ * default `:root` with DIFFERENT values (the silent-loser bug), or — more
+ * strictly — if it is duplicated at all (re-introducing the second home).
+ *
+ * Note: `[data-theme=...]` overrides in themes.css are intentionally NOT
+ * checked here — those are unlayered theme overrides that are SUPPOSED to
+ * re-declare `--color-*` to beat the `@theme` base.
+ */
+
+const stripComments = (css) => css.replace(/\/\*[\s\S]*?\*\//g, '');
+
+/** Extract the body of the first `<opener> {` block via brace matching. */
+function blockBody(css, opener) {
+  const start = css.indexOf(opener);
+  if (start === -1) throw new Error(`could not find "${opener}" block`);
+  let i = css.indexOf('{', start);
+  let depth = 0;
+  const bodyStart = i + 1;
+  for (; i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') {
+      depth--;
+      if (depth === 0) return css.slice(bodyStart, i);
+    }
+  }
+  throw new Error(`unbalanced braces after "${opener}"`);
+}
+
+/** Parse top-level `--name: value;` custom-property declarations. */
+function parseTokens(body) {
+  const tokens = {};
+  const re = /(--[a-z0-9-]+)\s*:\s*([^;]+);/gi;
+  let m;
+  while ((m = re.exec(body))) {
+    tokens[m[1]] = m[2].trim().replace(/\s+/g, ' ');
+  }
+  return tokens;
+}
+
+const TARGET = /^--(color|radius|font)-/;
+
+const indexCss = stripComments(readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8'));
+const tokensCss = stripComments(readFileSync(resolve(process.cwd(), 'src/ui/tokens.css'), 'utf8'));
+
+const theme = parseTokens(blockBody(indexCss, '@theme'));
+const root = parseTokens(blockBody(tokensCss, ':root'));
+
+const themeTargets = Object.keys(theme).filter((k) => TARGET.test(k));
+const rootTargets = Object.keys(root).filter((k) => TARGET.test(k));
+const overlap = themeTargets.filter((k) => k in root);
+
+describe('design-token parity: @theme vs ui/tokens.css', () => {
+  it('parses real tokens from both sources (sanity)', () => {
+    // @theme owns the color/radius/font scale.
+    expect(theme['--color-fg']).toBe('#ebdbb2');
+    expect(theme['--radius-md']).toBe('4px');
+    expect(theme['--font-sans']).toContain('Inter');
+    // tokens.css still owns its non-overlapping tokens.
+    expect(root['--color-muted-mono']).toBe('#d5c4a1');
+    expect(rootTargets.length).toBeGreaterThan(0);
+  });
+
+  it('never declares a --color/--radius/--font token in BOTH with different values', () => {
+    const drift = overlap
+      .filter((k) => theme[k] !== root[k])
+      .map((k) => `  ${k}: @theme=${theme[k]} | tokens.css=${root[k]}`);
+    expect(drift, `design-token drift detected:\n${drift.join('\n')}`).toEqual([]);
+  });
+
+  it('declares each shared token exactly once (no duplicate home in tokens.css)', () => {
+    expect(
+      overlap,
+      `these tokens are re-declared in ui/tokens.css; they belong only in @theme:\n  ${overlap.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/ui/tokens.css
+++ b/frontend/src/ui/tokens.css
@@ -6,31 +6,12 @@
 
 :root {
   /* ── Color scale (semantic) ─────────────────────────────────────── */
+  /* The semantic --color-* base tokens are the single source of truth in
+     index.css's `@theme` block (so Tailwind v4 owns them and they can't
+     drift). `[data-theme]` overrides in themes.css are unlayered, so they
+     still win over the @theme base. Only tokens NOT in @theme live here. */
   /* legacy aliases live in index.css: --primary, --accent, --bg, etc. */
 
-  --color-fg:            #ebdbb2;
-  --color-fg-muted:      #a89984;
-  --color-fg-subtle:     #7c6f64;
-  --color-fg-inverse:    #1d2021;
-
-  --color-bg:            #1d2021;
-  --color-bg-elev-1:     rgba(50, 48, 47, 0.85);   /* panel glass */
-  --color-bg-elev-2:     rgba(0, 0, 0, 0.30);      /* input/track well */
-  --color-bg-elev-3:     rgba(0, 0, 0, 0.18);      /* list row */
-
-  --color-border:        rgba(255, 255, 255, 0.07);
-  --color-border-strong: rgba(255, 255, 255, 0.15);
-  --color-border-warm:   rgba(243, 165, 182, 0.08);
-
-  --color-brand:         #d3869b;                  /* pink */
-  --color-brand-hover:   #b16286;
-  --color-brand-glow:    rgba(211, 134, 155, 0.4);
-
-  --color-accent:        #fabd2f;                  /* amber */
-  --color-success:       #8ec07c;                  /* green */
-  --color-warn:          #fe8019;                  /* orange */
-  --color-danger:        #fb4934;                  /* red */
-  --color-info:          #83a598;                  /* blue */
   --color-muted-mono:    #d5c4a1;
 
   /* ── Spacing (4px base) ─────────────────────────────────────────── */
@@ -54,21 +35,17 @@
   --settings-rail:    168px;
 
   /* ── Radius ─────────────────────────────────────────────────────── */
-  --radius-xs:  2px;
-  --radius-sm:  3px;
-  --radius-md:  4px;      /* alias: --radius-base */
-  --radius-lg:  6px;      /* alias: --radius */
-  --radius-xl: 10px;
+  /* --radius-xs..xl are the single source of truth in index.css's @theme.
+     Only --radius-pill (not in @theme) lives here. */
   --radius-pill: 999px;
 
   /* ── Typography (Option A — Codex-inspired stack) ──────────────────
      Inter for UI/body (closest OSS Söhne analog), IBM Plex Mono for chrome
      labels + data + logs (warmer than Geist Mono, pairs with OpenAI's feel),
      Source Serif 4 for hero moments only. Variable faces where possible so
-     weight 400–700 comes from a single file download. */
-  --font-sans:    'Inter Variable', 'Inter', -apple-system, BlinkMacSystemFont, 'Söhne', 'Helvetica Neue', Arial, sans-serif;
-  --font-mono:    'IBM Plex Mono', ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace;
-  --font-serif:   'Source Serif 4 Variable', 'Source Serif 4', 'Söhne Breit', Georgia, serif;
+     weight 400–700 comes from a single file download.
+     --font-sans / --font-mono / --font-serif are the single source of truth
+     in index.css's @theme (full stacks). Only the aliases below live here. */
   --font-display: var(--font-serif);
   --font-ui:      var(--font-sans);
 


### PR DESCRIPTION
## P0 — CSS → Tailwind v4 migration: design-token drift

### The bug
`src/index.css`'s Tailwind v4 `@theme` block and the unlayered `:root` in `src/ui/tokens.css` both declared the same `--color-*`, `--radius-*`, and `--font-*` tokens. Because `@theme` lands in `@layer theme` (low priority) while tokens.css's `:root` is **unlayered**, the tokens.css copy silently **won** — the `@theme` literals were dead, losing duplicates.

The two copies had already **drifted**: `@theme`'s font stacks were the *short* variants while tokens.css carried the *full* stacks (`'Söhne'`, `'Cascadia Code'`, `'Söhne Breit'`). The resolved `font-family` therefore came from tokens.css, and the `@theme` font literals were never used.

### The fix (Solution A — pure de-dup, zero computed-value change)
- `@theme` becomes the single home for the overlapping color/radius/font tokens.
- The duplicate declarations are deleted from `tokens.css`.
- To keep every resolved value **byte-identical**, `@theme` adopts the full font stacks that were actually winning at runtime (a value move within the silently-losing block, not a restyle).
- Tokens unique to tokens.css are untouched: `--color-muted-mono`, `--radius-pill`, `--font-display`, `--font-ui`, and the spacing / shadow / motion / z-index / focus / glass scales.

**De-duped (27 tokens):** 19 colors (`--color-fg`, `-fg-muted`, `-fg-subtle`, `-fg-inverse`, `-bg`, `-bg-elev-1/2/3`, `-border`, `-border-strong`, `-border-warm`, `-brand`, `-brand-hover`, `-brand-glow`, `-accent`, `-success`, `-warn`, `-danger`, `-info`), 5 radii (`--radius-xs/sm/md/lg/xl`), 3 fonts (`--font-sans/mono/serif`).

### Theme switching preserved
themes.css's `[data-theme=...]` overrides are **unlayered**, so they still beat the now-`@theme`-sourced base. Unlayered always wins over `@layer theme` regardless of source order — so this is actually *more* robust than before (previously base and overrides were both unlayered and relied on source order).

### Verification (computed values unchanged)
A before/after `vite build` was diffed with a script that extracts each token's effective value for the default theme across all emitted CSS (honoring unlayered-beats-`@layer theme`): **all 31 effective `--color/--radius/--font` values are identical before and after.** Confirmed in the emitted CSS that the default `:root` no longer re-declares these tokens (only the 5 `[data-theme]` theme overrides remain) and that `@theme` now carries the full font stacks.

### Regression guard
Adds `src/test/tokenParity.test.js` — fails if any `--color/--radius/--font` token is ever declared in **both** `@theme` and tokens.css's default `:root` (with different values, or at all), catching the drift before it can recur.

### Checks
- `npx oxlint` — 0 errors (pre-existing warnings only)
- `npx oxfmt --check .` — clean (new test formatted via `oxfmt --write src/test`)
- `npx vite build` — passes
- `npx vitest run` — 641 tests pass, incl. the new 3 parity tests
- `bun install --frozen-lockfile` — no changes (no dependency edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Tailwind v4 token setup so `@theme` in `src/index.css` is the single source of truth for shared `--color-*`, `--radius-*`, and `--font-*` values.

- Removed duplicate shared token declarations from `src/ui/tokens.css`
- Kept theme-specific overrides working via existing `[data-theme=...]` rules
- Preserved runtime font behavior by moving the winning font stacks into `@theme`
- Added `src/test/tokenParity.test.js` to catch future token drift between `@theme` and `:root`

UI sketch:

Before
+----------------------+
| index.css  tokens.css|
| shared tokens split  |
| across both files    |
+----------------------+

After
+----------------------+
| index.css: `@theme`    |
| single source of     |
| truth for shared     |
| tokens               |
+----------------------+
| tokens.css: aliases  |
| + theme overrides    |
+----------------------+

Flow:

```mermaid
flowchart LR
  A[src/index.css `@theme`] --> B[Shared semantic tokens]
  C[src/ui/tokens.css :root] --> D[File-specific aliases]
  E[data-theme overrides] --> F[Final themed values]
  G[tokenParity.test.js] --> H[Detect drift / duplication]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->