### PR TITLE
feat(ui): convert modal/dialog CSS to Tailwind utilities

### DIFF
--- a/frontend/src/components/BatchAddDialog.css
+++ b/frontend/src/components/BatchAddDialog.css
@@ -1,3 +1,10 @@
+/* BatchAddDialog — most layout/typography rules are now Tailwind utilities
+   on the JSX. What stays here: the fixed overlay + backdrop, the card chrome
+   and its open animation, the drop zone (its hover / drag-over state combo
+   `.batch-add__drop.is-over` is toggled imperatively), the `<select>` sizing
+   override on top of the global `.input-base`, and the toggle (which styles a
+   descendant `input`). */
+
 .batch-add-overlay {
   position: fixed;
   inset: 0;
@@ -25,46 +32,6 @@
   to   { opacity: 1; transform: scale(1); }
 }
 
-.batch-add__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 18px;
-  border-bottom: 1px solid var(--chrome-border);
-}
-.batch-add__title {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--chrome-fg);
-}
-.batch-add__close {
-  background: none;
-  border: none;
-  color: var(--chrome-fg-muted);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 6px;
-  transition: background 0.15s;
-}
-.batch-add__close:hover {
-  background: var(--chrome-hover-bg);
-}
-
-.batch-add__body {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
 .batch-add__drop {
   display: flex;
   flex-direction: column;
@@ -85,74 +52,7 @@
   background: rgba(255,255,255,0.02);
   color: var(--chrome-fg);
 }
-.batch-add__drop-hint {
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  color: var(--chrome-fg-dim);
-}
-.batch-add__file-input {
-  display: none;
-}
 
-.batch-add__files {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.batch-add__kicker {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--chrome-fg-dim);
-  margin-bottom: 4px;
-}
-.batch-add__file-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
-  background: var(--chrome-hover-bg);
-  border-radius: 6px;
-  font-size: 0.76rem;
-}
-.batch-add__file-name {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--chrome-fg);
-}
-.batch-add__file-size {
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
-  color: var(--chrome-fg-dim);
-  flex-shrink: 0;
-}
-.batch-add__file-x {
-  background: none;
-  border: none;
-  color: var(--chrome-fg-dim);
-  cursor: pointer;
-  padding: 2px;
-  border-radius: 4px;
-}
-.batch-add__file-x:hover { color: var(--color-danger); }
-
-.batch-add__settings {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.batch-add__field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
 .batch-add__select {
   font-size: 0.78rem;
 }
@@ -165,17 +65,3 @@
   cursor: pointer;
 }
 .batch-add__toggle input { cursor: pointer; }
-
-.batch-add__foot {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 18px;
-  border-top: 1px solid var(--chrome-border);
-}
-.batch-add__estimate {
-  flex: 1;
-  font-family: var(--font-mono);
-  font-size: 0.68rem;
-  color: var(--chrome-fg-dim);
-}

--- a/frontend/src/components/BatchAddDialog.jsx
+++ b/frontend/src/components/BatchAddDialog.jsx
@@ -53,16 +53,20 @@ export default function BatchAddDialog({
   return (
     <div className="batch-add-overlay" onClick={onClose}>
       <div className="batch-add" onClick={(e) => e.stopPropagation()}>
-        <div className="batch-add__head">
-          <span className="batch-add__title">
+        <div className="flex items-center justify-between p-[14px_18px] [border-bottom:1px_solid_var(--chrome-border)]">
+          <span className="flex items-center gap-[6px] font-mono text-[0.78rem] font-semibold uppercase tracking-[0.04em] text-[var(--chrome-fg)]">
             <Plus size={13} /> {t('batch.add_to_queue_title')}
           </span>
-          <button type="button" className="batch-add__close" onClick={onClose}>
+          <button
+            type="button"
+            className="cursor-pointer rounded-[6px] border-0 bg-transparent p-[4px] text-[var(--chrome-fg-muted)] transition-[background] duration-[0.15s] hover:bg-[var(--chrome-hover-bg)]"
+            onClick={onClose}
+          >
             <X size={13} />
           </button>
         </div>
 
-        <div className="batch-add__body">
+        <div className="flex flex-1 flex-col gap-[14px] overflow-y-auto p-[16px_18px]">
           {/* Drop zone */}
           <div
             className="batch-add__drop"
@@ -79,14 +83,16 @@ export default function BatchAddDialog({
           >
             <Upload size={24} />
             <span>{t('batch.drop_hint_text')}</span>
-            <span className="batch-add__drop-hint">{t('batch.drop_formats')}</span>
+            <span className="font-mono text-[0.65rem] text-[var(--chrome-fg-dim)]">
+              {t('batch.drop_formats')}
+            </span>
           </div>
           <input
             ref={fileInputRef}
             type="file"
             accept="video/*"
             multiple
-            className="batch-add__file-input"
+            className="hidden"
             onChange={(e) => {
               const added = Array.from(e.target.files);
               if (added.length) setFiles((prev) => [...prev, ...added]);
@@ -96,18 +102,27 @@ export default function BatchAddDialog({
 
           {/* File list */}
           {files.length > 0 && (
-            <div className="batch-add__files">
-              <span className="batch-add__kicker">
+            <div className="flex flex-col gap-[4px]">
+              <span className="mb-[4px] flex items-center gap-[4px] font-mono text-[0.62rem] font-semibold uppercase tracking-[0.04em] text-[var(--chrome-fg-dim)]">
                 {t('batch.files_kicker', { count: files.length })}
               </span>
               {files.map((f, i) => (
-                <div key={`${f.name}-${i}`} className="batch-add__file-row">
+                <div
+                  key={`${f.name}-${i}`}
+                  className="flex items-center gap-[6px] rounded-[6px] bg-[var(--chrome-hover-bg)] p-[4px_8px] text-[0.76rem]"
+                >
                   <Film size={10} />
-                  <span className="batch-add__file-name">{f.name}</span>
-                  <span className="batch-add__file-size">
+                  <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[var(--chrome-fg)]">
+                    {f.name}
+                  </span>
+                  <span className="shrink-0 font-mono text-[0.68rem] text-[var(--chrome-fg-dim)]">
                     {t('batch.file_size_mb', { size: (f.size / 1024 / 1024).toFixed(1) })}
                   </span>
-                  <button type="button" className="batch-add__file-x" onClick={() => removeFile(i)}>
+                  <button
+                    type="button"
+                    className="cursor-pointer rounded-[4px] border-0 bg-transparent p-[2px] text-[var(--chrome-fg-dim)] hover:text-[var(--color-danger)]"
+                    onClick={() => removeFile(i)}
+                  >
                     <X size={9} />
                   </button>
                 </div>
@@ -116,16 +131,18 @@ export default function BatchAddDialog({
           )}
 
           {/* Settings */}
-          <div className="batch-add__settings">
-            <div className="batch-add__field">
-              <span className="batch-add__kicker">
+          <div className="flex flex-col gap-[12px]">
+            <div className="flex flex-col gap-[6px]">
+              <span className="mb-[4px] flex items-center gap-[4px] font-mono text-[0.62rem] font-semibold uppercase tracking-[0.04em] text-[var(--chrome-fg-dim)]">
                 <Globe size={9} /> {t('batch.target_languages')}
               </span>
               <MultiLangPicker selected={langs} onChange={setLangs} />
             </div>
 
-            <div className="batch-add__field">
-              <span className="batch-add__kicker">{t('batch.voice_kicker')}</span>
+            <div className="flex flex-col gap-[6px]">
+              <span className="mb-[4px] flex items-center gap-[4px] font-mono text-[0.62rem] font-semibold uppercase tracking-[0.04em] text-[var(--chrome-fg-dim)]">
+                {t('batch.voice_kicker')}
+              </span>
               <select
                 className="input-base batch-add__select"
                 value={voiceId}
@@ -166,8 +183,8 @@ export default function BatchAddDialog({
           </div>
         </div>
 
-        <div className="batch-add__foot">
-          <span className="batch-add__estimate">
+        <div className="flex items-center gap-[8px] p-[12px_18px] [border-top:1px_solid_var(--chrome-border)]">
+          <span className="flex-1 font-mono text-[0.68rem] text-[var(--chrome-fg-dim)]">
             {files.length > 0 && langs.length > 0
               ? t('batch.estimate', {
                   videos: files.length,

--- a/frontend/src/components/CompareModal.css
+++ b/frontend/src/components/CompareModal.css
@@ -1,6 +1,11 @@
 /* CompareModal — non-modal bottom drawer. Leaves the app interactive;
    no backdrop wash. ESC or click-outside dismisses. Mirrors
-   ExportModal's drawer chrome so the two read as siblings. */
+   ExportModal's drawer chrome so the two read as siblings.
+
+   Mechanical layout/typography rules now live as Tailwind utilities on the
+   JSX. What stays here: the fixed overlay positioning, the sheet chrome +
+   slide-up animation, and `.ui-compare__grid` (its responsive collapse is
+   driven by media queries here AND in index.css). */
 
 .compare-drawer {
   position: fixed;
@@ -33,111 +38,11 @@
   to   { transform: translateY(0);    opacity: 1; }
 }
 
-.compare-drawer__head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  padding: 10px var(--space-4);
-  border-bottom: 1px solid var(--chrome-border);
-  background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
-  position: relative;
-}
-.compare-drawer__handle {
-  position: absolute;
-  top: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 36px;
-  height: 3px;
-  border-radius: 2px;
-  background: var(--chrome-border-strong);
-}
-.compare-drawer__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--font-display, inherit);
-  font-size: var(--text-md);
-  font-weight: 600;
-  color: var(--chrome-fg);
-}
-.compare-drawer__close {
-  margin-left: auto;
-  width: var(--chrome-icon-btn, 22px);
-  height: var(--chrome-icon-btn, 22px);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--chrome-radius-pill);
-  color: var(--chrome-fg-muted);
-  cursor: pointer;
-  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
-}
-.compare-drawer__close:hover {
-  background: var(--chrome-hover-bg);
-  color: var(--chrome-fg);
-  border-color: var(--chrome-border-strong);
-}
-
-.compare-drawer__body {
-  padding: var(--space-4);
-  overflow-y: auto;
-}
-.compare-drawer__foot {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  border-top: 1px solid var(--chrome-border);
-  background: var(--chrome-bg);
-}
-
-/* CompareModal — content-specific styles. Base controls (Panel, Button,
-   Select, Textarea) come from ui/. */
-
-.ui-compare__desc {
-  margin: 0 0 var(--space-5);
-  font-size: var(--text-base);
-  color: var(--color-fg-muted);
-  line-height: 1.5;
-}
-
 .ui-compare__grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--space-6);
   margin-top: var(--space-5);
-}
-
-.ui-compare__head {
-  margin: 0 0 var(--space-4);
-  font-family: var(--font-display);
-  font-size: var(--text-lg);
-  font-weight: var(--weight-bold);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-3);
-}
-
-.ui-compare__audio {
-  width: 100%;
-  margin-top: var(--space-3);
-}
-
-.ui-compare__audio-empty {
-  height: 32px;
-  margin-top: var(--space-3);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--color-bg-elev-2);
-  color: var(--color-fg-subtle);
-  font-size: var(--text-sm);
-  font-style: italic;
-  border-radius: var(--radius-sm);
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/components/CompareModal.jsx
+++ b/frontend/src/components/CompareModal.jsx
@@ -119,14 +119,17 @@ export default function CompareModal({
       aria-label={t('compare.title')}
     >
       <div className="compare-drawer__sheet" ref={drawerRef}>
-        <header className="compare-drawer__head">
-          <span className="compare-drawer__handle" aria-hidden="true" />
-          <span className="compare-drawer__title">
+        <header className="relative flex items-center gap-[var(--space-3)] p-[10px_var(--space-4)] [border-bottom:1px_solid_var(--chrome-border)] [background:linear-gradient(180deg,rgba(255,255,255,0.02),transparent)]">
+          <span
+            className="absolute top-[4px] left-1/2 -translate-x-1/2 w-[36px] h-[3px] rounded-[2px] bg-[var(--chrome-border-strong)]"
+            aria-hidden="true"
+          />
+          <span className="inline-flex items-center gap-[6px] [font-family:var(--font-display,inherit)] text-[length:var(--text-md)] font-semibold text-[var(--chrome-fg)]">
             <Scale size={14} /> {t('compare.title')}
           </span>
           <button
             type="button"
-            className="compare-drawer__close"
+            className="ml-auto inline-flex h-[var(--chrome-icon-btn,22px)] w-[var(--chrome-icon-btn,22px)] cursor-pointer items-center justify-center rounded-[var(--chrome-radius-pill)] bg-transparent text-[var(--chrome-fg-muted)] [border:1px_solid_transparent] transition-[background,color,border-color] duration-[var(--dur-fast)] hover:border-[var(--chrome-border-strong)] hover:bg-[var(--chrome-hover-bg)] hover:text-[var(--chrome-fg)]"
             onClick={onClose}
             aria-label={t('compare.close')}
           >
@@ -134,8 +137,10 @@ export default function CompareModal({
           </button>
         </header>
 
-        <div className="compare-drawer__body">
-          <p className="ui-compare__desc">{t('compare.desc')}</p>
+        <div className="overflow-y-auto p-[var(--space-4)]">
+          <p className="mx-0 mt-0 mb-[var(--space-5)] text-[length:var(--text-base)] text-fg-muted leading-[1.5]">
+            {t('compare.desc')}
+          </p>
 
           <Field label={t('compare.test_phrase')}>
             <Textarea
@@ -166,7 +171,7 @@ export default function CompareModal({
           </div>
         </div>
 
-        <footer className="compare-drawer__foot">
+        <footer className="flex justify-end gap-[var(--space-2)] bg-[var(--chrome-bg)] p-[var(--space-3)_var(--space-4)] [border-top:1px_solid_var(--chrome-border)]">
           <Button variant="ghost" onClick={onClose}>
             {t('compare.close_btn')}
           </Button>
@@ -189,7 +194,10 @@ function CompareSide({ accent, label, profiles, value, onChange, audio }) {
   const { t } = useTranslation();
   return (
     <Panel variant="flat" padding="sm">
-      <h3 className="ui-compare__head" style={{ color: accent }}>
+      <h3
+        className="mx-0 mt-0 mb-[var(--space-4)] flex items-center justify-center gap-[var(--space-3)] [font-family:var(--font-display)] text-[length:var(--text-lg)] [font-weight:var(--weight-bold)]"
+        style={{ color: accent }}
+      >
         <Fingerprint size={14} /> {label}
       </h3>
       <Field>
@@ -208,9 +216,11 @@ function CompareSide({ accent, label, profiles, value, onChange, audio }) {
         </Select>
       </Field>
       {audio ? (
-        <WaveformPlayer src={audio} source="compare" className="ui-compare__audio" />
+        <WaveformPlayer src={audio} source="compare" className="mt-[var(--space-3)] w-full" />
       ) : (
-        <div className="ui-compare__audio-empty">{t('compare.no_audio')}</div>
+        <div className="mt-[var(--space-3)] flex h-[32px] items-center justify-center rounded-sm bg-bg-elev-2 text-[length:var(--text-sm)] italic text-fg-subtle">
+          {t('compare.no_audio')}
+        </div>
       )}
     </Panel>
   );

--- a/frontend/src/components/ExportModal.css
+++ b/frontend/src/components/ExportModal.css
@@ -1,7 +1,14 @@
 /* ExportModal — non-blocking bottom drawer. Uses --chrome-* tokens so it
    reads as part of the studio chrome. Slides up from above the LogsFooter
    and leaves the dub editor interactive behind it (click-outside dismisses,
-   no backdrop wash). */
+   no backdrop wash).
+
+   Mechanical layout/typography rules are now Tailwind utilities on the JSX.
+   What stays here: the fixed overlay positioning, the sheet chrome +
+   slide-up animation, and the rules whose selectors depend on state classes
+   (`.is-on`, `.is-active`) or style unclassed descendants (`button`,
+   `input`) — track chips, the quick-pick buttons, the tab strip, and the
+   toggles. */
 
 .export-drawer {
   position: fixed;
@@ -34,122 +41,7 @@
   to   { transform: translateY(0);    opacity: 1; }
 }
 
-.export-drawer__head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  padding: 6px var(--space-4) 10px;
-  border-bottom: 1px solid var(--chrome-border);
-  background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent);
-  position: relative;
-}
-.export-drawer__handle {
-  position: absolute;
-  top: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 36px;
-  height: 3px;
-  border-radius: 2px;
-  background: var(--chrome-border-strong);
-}
-.export-drawer__close {
-  margin-left: auto;
-  width: var(--chrome-icon-btn, 22px);
-  height: var(--chrome-icon-btn, 22px);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--chrome-radius-pill);
-  color: var(--chrome-fg-muted);
-  cursor: pointer;
-  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
-}
-.export-drawer__close:hover {
-  background: var(--chrome-hover-bg);
-  color: var(--chrome-fg);
-  border-color: var(--chrome-border-strong);
-}
-
-.export-modal {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-}
-.export-modal--drawer {
-  padding: var(--space-3) var(--space-4) var(--space-4);
-  overflow-y: auto;
-}
-
-.export-modal__title-inner {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-.export-modal__filename {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--text-sm);
-  color: var(--chrome-fg-muted);
-  margin-left: var(--space-2);
-  max-width: 260px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.export-modal__kicker {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  letter-spacing: var(--chrome-label-track);
-  text-transform: uppercase;
-  color: var(--chrome-fg-muted);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-/* ── Presets ───────────────────────────────────────────────── */
-.export-modal__presets {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  padding-bottom: var(--space-3);
-  border-bottom: 1px solid var(--chrome-border);
-}
-.export-modal__preset-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  font-size: var(--text-xs);
-  font-family: var(--font-sans);
-  background: transparent;
-  color: var(--chrome-fg-muted);
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  cursor: pointer;
-  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
-}
-.export-modal__preset-chip:hover {
-  background: var(--chrome-hover-bg);
-  color: var(--chrome-fg);
-  border-color: var(--chrome-border-strong);
-}
-
 /* ── Track row ─────────────────────────────────────────────── */
-.export-modal__tracks {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-.export-modal__section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
 .export-modal__track-quick {
   display: inline-flex;
   align-items: center;
@@ -167,11 +59,6 @@
 }
 .export-modal__track-quick button:hover { color: var(--chrome-fg); }
 
-.export-modal__track-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
 .export-modal__track {
   display: inline-flex;
   align-items: center;
@@ -195,17 +82,8 @@
   background: var(--chrome-accent-bg);
   color: var(--chrome-accent);
 }
-.export-modal__track-label {
-  font-family: var(--chrome-font-mono);
-  letter-spacing: 0.02em;
-}
 
 /* ── Tabs ──────────────────────────────────────────────────── */
-.export-modal__tabs {
-  display: flex;
-  gap: var(--space-1);
-  border-bottom: 1px solid var(--chrome-border);
-}
 .export-modal__tab {
   display: inline-flex;
   align-items: center;
@@ -225,29 +103,7 @@
   border-bottom-color: var(--chrome-accent);
 }
 
-/* ── Body / fields ─────────────────────────────────────────── */
-.export-modal__body { min-height: 160px; }
-
-.export-modal__grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-4) var(--space-5);
-}
-.export-modal__field { display: flex; flex-direction: column; gap: 6px; }
-.export-modal__field-head { display: flex; flex-direction: column; gap: 2px; }
-.export-modal__field-label {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  letter-spacing: var(--chrome-label-track);
-  text-transform: uppercase;
-  color: var(--chrome-fg-muted);
-}
-.export-modal__field-hint {
-  font-size: var(--text-xs);
-  color: var(--chrome-fg-dim);
-  line-height: 1.4;
-}
-
+/* ── Toggles ───────────────────────────────────────────────── */
 .export-modal__toggle {
   display: inline-flex;
   align-items: center;
@@ -258,105 +114,3 @@
 }
 .export-modal__toggle input { accent-color: var(--color-brand); }
 .export-modal__toggle--indent { margin-left: var(--space-4); color: var(--chrome-fg-muted); }
-
-.export-modal__mt6 { margin-top: 6px; }
-
-.export-modal__note {
-  grid-column: 1 / -1;
-  font-size: var(--text-xs);
-  color: var(--chrome-fg-dim);
-  padding: var(--space-2) var(--space-3);
-  background: var(--chrome-hover-bg);
-  border-left: 2px solid var(--chrome-border-strong);
-  border-radius: 2px;
-}
-
-/* ── Package tab ───────────────────────────────────────────── */
-.export-modal__pkg-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: var(--space-3);
-}
-.export-modal__pkg-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: var(--space-3);
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  background: var(--chrome-bg);
-}
-.export-modal__pkg-card.is-ghost { opacity: 0.75; }
-.export-modal__pkg-head {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: var(--text-sm);
-  color: var(--chrome-fg);
-  font-weight: 500;
-}
-.export-modal__pkg-body {
-  margin: 0;
-  font-size: var(--text-xs);
-  color: var(--chrome-fg-muted);
-  line-height: 1.4;
-  flex: 1;
-}
-
-/* ── Summary footer ────────────────────────────────────────── */
-.export-modal__summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--chrome-border);
-}
-.export-modal__summary-left {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  min-width: 0;
-}
-.export-modal__summary-name {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--text-xs);
-  color: var(--chrome-fg);
-  background: var(--chrome-hover-bg);
-  padding: 3px 8px;
-  border-radius: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 340px;
-}
-.export-modal__summary-right {
-  display: inline-flex;
-  gap: var(--space-2);
-}
-
-/* ── License notice ─────────────────────────────────────────── */
-.export-modal__license-notice {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px var(--space-3);
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  letter-spacing: var(--chrome-label-track);
-  color: var(--chrome-fg-dim);
-  border-top: 1px solid var(--chrome-border);
-}
-.export-modal__license-link {
-  background: none;
-  border: none;
-  color: var(--chrome-accent);
-  font: inherit;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-  padding: 0;
-}
-.export-modal__license-link:hover {
-  color: var(--chrome-fg);
-}

--- a/frontend/src/components/ExportModal.jsx
+++ b/frontend/src/components/ExportModal.jsx
@@ -266,30 +266,39 @@ export default function ExportModal({
       aria-label={t('exportModal.export_options')}
     >
       <div className="export-drawer__sheet" ref={drawerRef}>
-        <header className="export-drawer__head">
-          <span className="export-drawer__handle" aria-hidden="true" />
-          <span className="export-modal__title-inner">
+        <header className="relative flex items-center gap-[var(--space-3)] p-[6px_var(--space-4)_10px] [border-bottom:1px_solid_var(--chrome-border)] [background:linear-gradient(180deg,rgba(255,255,255,0.02),transparent)]">
+          <span
+            className="absolute top-[4px] left-1/2 -translate-x-1/2 w-[36px] h-[3px] rounded-[2px] bg-[var(--chrome-border-strong)]"
+            aria-hidden="true"
+          />
+          <span className="inline-flex items-center gap-[var(--space-2)]">
             <Download size={13} /> {t('exportModal.export')}
-            {filename && <span className="export-modal__filename">· {filename}</span>}
+            {filename && (
+              <span className="ml-[var(--space-2)] max-w-[260px] overflow-hidden text-ellipsis whitespace-nowrap [font-family:var(--chrome-font-mono)] text-[length:var(--text-sm)] text-[var(--chrome-fg-muted)]">
+                · {filename}
+              </span>
+            )}
           </span>
           <button
             type="button"
-            className="export-drawer__close"
+            className="ml-auto inline-flex h-[var(--chrome-icon-btn,22px)] w-[var(--chrome-icon-btn,22px)] cursor-pointer items-center justify-center rounded-[var(--chrome-radius-pill)] bg-transparent text-[var(--chrome-fg-muted)] [border:1px_solid_transparent] transition-[background,color,border-color] duration-[var(--dur-fast)] hover:border-[var(--chrome-border-strong)] hover:bg-[var(--chrome-hover-bg)] hover:text-[var(--chrome-fg)]"
             onClick={onClose}
             aria-label={t('exportModal.close_drawer')}
           >
             <X size={13} />
           </button>
         </header>
-        <div className="export-modal export-modal--drawer">
+        <div className="flex flex-col gap-[var(--space-4)] overflow-y-auto p-[var(--space-3)_var(--space-4)_var(--space-4)]">
           {/* Preset chips */}
-          <div className="export-modal__presets">
-            <span className="export-modal__kicker">{t('exportModal.presets')}</span>
+          <div className="flex flex-wrap items-center gap-[var(--space-2)] pb-[var(--space-3)] [border-bottom:1px_solid_var(--chrome-border)]">
+            <span className="inline-flex items-center gap-[4px] uppercase [font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
+              {t('exportModal.presets')}
+            </span>
             {Object.entries(PRESETS).map(([k, v]) => (
               <button
                 key={k}
                 type="button"
-                className="export-modal__preset-chip"
+                className="inline-flex cursor-pointer items-center gap-[4px] rounded-[var(--chrome-radius-pill)] bg-transparent px-[8px] py-[3px] font-sans text-[length:var(--text-xs)] text-[var(--chrome-fg-muted)] [border:1px_solid_var(--chrome-border)] transition-[background,color,border-color] duration-[var(--dur-fast)] hover:border-[var(--chrome-border-strong)] hover:bg-[var(--chrome-hover-bg)] hover:text-[var(--chrome-fg)]"
                 onClick={() => applyPreset(k)}
                 title={t('exportModal.preset_title', { tab: v.tab, label: t(v.labelKey) })}
               >
@@ -299,9 +308,9 @@ export default function ExportModal({
           </div>
 
           {/* Track checklist — shared across tabs */}
-          <div className="export-modal__tracks">
-            <div className="export-modal__section-head">
-              <span className="export-modal__kicker">
+          <div className="flex flex-col gap-[var(--space-2)]">
+            <div className="flex items-center justify-between">
+              <span className="inline-flex items-center gap-[4px] uppercase [font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
                 <Globe size={9} /> {t('exportModal.tracks')}
               </span>
               <div className="export-modal__track-quick">
@@ -318,7 +327,7 @@ export default function ExportModal({
                 </button>
               </div>
             </div>
-            <div className="export-modal__track-row">
+            <div className="flex flex-wrap gap-[6px]">
               {allTracks.map((track) => {
                 const on = exportTracks[track.code] !== false;
                 return (
@@ -327,7 +336,9 @@ export default function ExportModal({
                     className={`export-modal__track ${on ? 'is-on' : ''} ${track.kind === 'original' ? 'is-original' : 'is-dub'}`}
                   >
                     <input type="checkbox" checked={on} onChange={() => toggleTrack(track.code)} />
-                    <span className="export-modal__track-label">{track.label}</span>
+                    <span className="[font-family:var(--chrome-font-mono)] tracking-[0.02em]">
+                      {track.label}
+                    </span>
                     {track.kind === 'dub' && track.code === dubLangCode && (
                       <Badge tone="brand" size="xs">
                         {t('exportModal.primary')}
@@ -340,7 +351,7 @@ export default function ExportModal({
           </div>
 
           {/* Tabs */}
-          <div className="export-modal__tabs">
+          <div className="flex gap-[var(--space-1)] [border-bottom:1px_solid_var(--chrome-border)]">
             <button
               type="button"
               className={`export-modal__tab ${tab === 'video' ? 'is-active' : ''}`}
@@ -372,9 +383,9 @@ export default function ExportModal({
           </div>
 
           {/* Tab body */}
-          <div className="export-modal__body">
+          <div className="min-h-[160px]">
             {tab === 'video' && (
-              <div className="export-modal__grid">
+              <div className="grid grid-cols-2 gap-x-[var(--space-5)] gap-y-[var(--space-4)]">
                 <Field label={t('exportModal.container')}>
                   <Segmented
                     size="sm"
@@ -435,13 +446,15 @@ export default function ExportModal({
                   )}
                 </Field>
                 {(timingStrategy === 'smart_fit' || timingStrategy === 'stretch_video') && (
-                  <div className="export-modal__note">{t('exportModal.retime_note')}</div>
+                  <div className="col-span-full rounded-[2px] bg-[var(--chrome-hover-bg)] p-[var(--space-2)_var(--space-3)] text-[length:var(--text-xs)] text-[var(--chrome-fg-dim)] [border-left:2px_solid_var(--chrome-border-strong)]">
+                    {t('exportModal.retime_note')}
+                  </div>
                 )}
               </div>
             )}
 
             {tab === 'audio' && (
-              <div className="export-modal__grid">
+              <div className="grid grid-cols-2 gap-x-[var(--space-5)] gap-y-[var(--space-4)]">
                 <Field label={t('exportModal.format')}>
                   <Segmented
                     size="sm"
@@ -480,7 +493,7 @@ export default function ExportModal({
                   />
                   {audioBatch === 'primary' && (
                     <select
-                      className="input-base input-base--xs export-modal__mt6"
+                      className="input-base input-base--xs mt-[6px]"
                       value={audioPrimaryLang}
                       onChange={(e) => setAudioPrimaryLang(e.target.value)}
                     >
@@ -506,7 +519,7 @@ export default function ExportModal({
             )}
 
             {tab === 'subs' && (
-              <div className="export-modal__grid">
+              <div className="grid grid-cols-2 gap-x-[var(--space-5)] gap-y-[var(--space-4)]">
                 <Field label={t('exportModal.format')}>
                   <Segmented
                     size="sm"
@@ -547,12 +560,14 @@ export default function ExportModal({
                     ]}
                   />
                 </Field>
-                <div className="export-modal__note">{t('exportModal.subs_note')}</div>
+                <div className="col-span-full rounded-[2px] bg-[var(--chrome-hover-bg)] p-[var(--space-2)_var(--space-3)] text-[length:var(--text-xs)] text-[var(--chrome-fg-dim)] [border-left:2px_solid_var(--chrome-border-strong)]">
+                  {t('exportModal.subs_note')}
+                </div>
               </div>
             )}
 
             {tab === 'pkg' && (
-              <div className="export-modal__pkg-grid">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-[var(--space-3)]">
                 <PkgCard
                   icon={<Package size={14} />}
                   title={t('exportModal.pkg_clips_title')}
@@ -580,13 +595,13 @@ export default function ExportModal({
           </div>
 
           {/* Commercial license notice */}
-          <div className="export-modal__license-notice">
+          <div className="flex items-center gap-[6px] p-[5px_var(--space-3)] [font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-dim)] [border-top:1px_solid_var(--chrome-border)]">
             <Building2 size={11} />
             <span>
               {t('exportModal.license_text')}{' '}
               <button
                 type="button"
-                className="export-modal__license-link"
+                className="cursor-pointer p-0 text-[var(--chrome-accent)] underline underline-offset-2 [font:inherit] border-0 bg-transparent hover:text-[var(--chrome-fg)]"
                 onClick={() => {
                   onClose();
                   onEnterprise?.();
@@ -599,14 +614,19 @@ export default function ExportModal({
           </div>
 
           {/* Summary footer */}
-          <div className="export-modal__summary">
-            <div className="export-modal__summary-left">
-              <span className="export-modal__kicker">{t('exportModal.output')}</span>
-              <code className="export-modal__summary-name" title={filenamePreview}>
+          <div className="flex items-center justify-between gap-[var(--space-3)] pt-[var(--space-3)] [border-top:1px_solid_var(--chrome-border)]">
+            <div className="flex min-w-0 items-center gap-[var(--space-2)]">
+              <span className="inline-flex items-center gap-[4px] uppercase [font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
+                {t('exportModal.output')}
+              </span>
+              <code
+                className="max-w-[340px] overflow-hidden text-ellipsis whitespace-nowrap rounded-[2px] bg-[var(--chrome-hover-bg)] px-[8px] py-[3px] [font-family:var(--chrome-font-mono)] text-[length:var(--text-xs)] text-[var(--chrome-fg)]"
+                title={filenamePreview}
+              >
                 {filenamePreview}
               </code>
             </div>
-            <div className="export-modal__summary-right">
+            <div className="inline-flex gap-[var(--space-2)]">
               {tab !== 'pkg' && (
                 <>
                   <Button variant="ghost" size="sm" onClick={onClose}>
@@ -640,10 +660,16 @@ export default function ExportModal({
 
 function Field({ label, hint, children }) {
   return (
-    <div className="export-modal__field">
-      <div className="export-modal__field-head">
-        <span className="export-modal__field-label">{label}</span>
-        {hint && <span className="export-modal__field-hint">{hint}</span>}
+    <div className="flex flex-col gap-[6px]">
+      <div className="flex flex-col gap-[2px]">
+        <span className="uppercase [font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
+          {label}
+        </span>
+        {hint && (
+          <span className="text-[length:var(--text-xs)] text-[var(--chrome-fg-dim)] leading-[1.4]">
+            {hint}
+          </span>
+        )}
       </div>
       {children}
     </div>
@@ -652,12 +678,16 @@ function Field({ label, hint, children }) {
 
 function PkgCard({ icon, title, body, onClick, cta, ghost = false }) {
   return (
-    <div className={`export-modal__pkg-card ${ghost ? 'is-ghost' : ''}`}>
-      <div className="export-modal__pkg-head">
+    <div
+      className={`flex flex-col gap-[8px] rounded-[var(--chrome-radius-pill)] bg-[var(--chrome-bg)] p-[var(--space-3)] [border:1px_solid_var(--chrome-border)] ${ghost ? 'opacity-[0.75]' : ''}`}
+    >
+      <div className="inline-flex items-center gap-[6px] font-medium text-[length:var(--text-sm)] text-[var(--chrome-fg)]">
         {icon}
         <span>{title}</span>
       </div>
-      <p className="export-modal__pkg-body">{body}</p>
+      <p className="m-0 flex-1 text-[length:var(--text-xs)] text-[var(--chrome-fg-muted)] leading-[1.4]">
+        {body}
+      </p>
       <Button
         variant={ghost ? 'subtle' : 'primary'}
         size="sm"

--- a/frontend/src/components/NotificationPanel.css
+++ b/frontend/src/components/NotificationPanel.css
@@ -1,56 +1,7 @@
-/* ── Notification Panel ────────────────────────────────────────────── */
-
-.notif-trigger {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  background: none;
-  border: none;
-  border-radius: var(--radius-md);
-  color: var(--color-fg-muted);
-  cursor: pointer;
-  transition: all 0.15s;
-  padding: 0;
-  flex-shrink: 0;
-}
-
-.notif-trigger:hover {
-  color: var(--color-fg);
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.notif-trigger--has-items {
-  color: var(--color-brand);
-}
-
-/* Badge count */
-.notif-badge {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  min-width: 14px;
-  height: 14px;
-  background: var(--color-danger, #cc241d);
-  color: #fff;
-  font-size: 9px;
-  font-weight: 700;
-  font-family: var(--font-mono);
-  border-radius: 7px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 3px;
-  line-height: 1;
-  pointer-events: none;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-}
-
-.notif-badge--warn {
-  background: var(--color-warn, #d79921);
-}
+/* ── Notification Panel ──────────────────────────────────────────────
+   The header bell trigger + its count badge are now Tailwind utilities on
+   the JSX. The dropdown-panel / item / inline-HF-input rules below remain
+   here. */
 
 /* Dropdown panel */
 .notif-panel {

--- a/frontend/src/components/NotificationPanel.jsx
+++ b/frontend/src/components/NotificationPanel.jsx
@@ -21,14 +21,16 @@ export default function NotificationPanel() {
 
   return (
     <button
-      className={`notif-trigger ${count > 0 ? 'notif-trigger--has-items' : ''}`}
+      className={`relative flex h-[28px] w-[28px] shrink-0 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 transition-all duration-[0.15s] hover:bg-[rgba(255,255,255,0.04)] hover:text-fg ${count > 0 ? 'text-brand' : 'text-fg-muted'}`}
       onClick={openNotifications}
       aria-label={`Notifications (${count})`}
       title="Notifications"
     >
       <Bell size={14} />
       {count > 0 && (
-        <span className={`notif-badge ${hasErrors ? '' : hasWarns ? 'notif-badge--warn' : ''}`}>
+        <span
+          className={`pointer-events-none absolute -top-[4px] -right-[4px] flex h-[14px] min-w-[14px] items-center justify-center rounded-[7px] px-[3px] font-mono text-[9px] font-bold leading-none text-white shadow-[0_1px_3px_rgba(0,0,0,0.4)] ${!hasErrors && hasWarns ? 'bg-warn' : 'bg-danger'}`}
+        >
           {count}
         </span>
       )}

--- a/frontend/src/components/SupertonicLicenseDialog.css
+++ b/frontend/src/components/SupertonicLicenseDialog.css
@@ -3,6 +3,12 @@
  * Uses the same CSS-variable palette as BootstrapSplash so the modal
  * blends with the rest of the app chrome regardless of the user's
  * light/dark theme.
+ *
+ * Mechanical title/intro/sections/link/footer/actions rules are now Tailwind
+ * utilities on the JSX. What stays here: the fixed overlay + backdrop, the
+ * card chrome (color-mix border + shadow), the section block (which styles
+ * unclassed `h3`/`p`/`code` descendants via color-mix), and the buttons
+ * (color-mix hover/focus states gated by `:not(:disabled)`).
  */
 
 .supertonic-license {
@@ -26,26 +32,6 @@
   padding: 1.75rem 1.75rem 1.5rem;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
   text-align: left;
-}
-
-.supertonic-license__title {
-  margin: 0 0 0.5rem;
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-.supertonic-license__intro {
-  margin: 0 0 1rem;
-  font-size: 0.9rem;
-  opacity: 0.85;
-  line-height: 1.5;
-}
-
-.supertonic-license__sections {
-  display: grid;
-  gap: 0.85rem;
-  margin-bottom: 1rem;
 }
 
 .supertonic-license__section {
@@ -77,30 +63,6 @@
   border-radius: 3px;
   font-family: 'JetBrains Mono', 'Menlo', monospace;
   font-size: 0.78rem;
-}
-
-.supertonic-license__link {
-  font-size: 0.83rem;
-  color: var(--accent, #8ab4f8);
-  text-decoration: none;
-}
-
-.supertonic-license__link:hover,
-.supertonic-license__link:focus-visible {
-  text-decoration: underline;
-}
-
-.supertonic-license__footer {
-  margin: 0 0 1.1rem;
-  font-size: 0.78rem;
-  opacity: 0.7;
-  line-height: 1.5;
-}
-
-.supertonic-license__actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
 }
 
 .supertonic-license__btn {

--- a/frontend/src/components/SupertonicLicenseDialog.jsx
+++ b/frontend/src/components/SupertonicLicenseDialog.jsx
@@ -82,13 +82,18 @@ export default function SupertonicLicenseDialog({ open, onClose, onAccepted }) {
       }}
     >
       <div className="supertonic-license__card">
-        <h2 id="supertonic-license-title" className="supertonic-license__title">
+        <h2
+          id="supertonic-license-title"
+          className="mx-0 mt-0 mb-[0.5rem] text-[1.05rem] font-semibold tracking-[0.01em]"
+        >
           {t('license.title')}
         </h2>
 
-        <p className="supertonic-license__intro">{t('license.intro')}</p>
+        <p className="mx-0 mt-0 mb-[1rem] text-[0.9rem] leading-[1.5] opacity-[0.85]">
+          {t('license.intro')}
+        </p>
 
-        <div className="supertonic-license__sections">
+        <div className="mb-[1rem] grid gap-[0.85rem]">
           <section className="supertonic-license__section">
             <h3>{t('license.sdk_heading')}</h3>
             <p>{t('license.sdk_desc')}</p>
@@ -96,7 +101,7 @@ export default function SupertonicLicenseDialog({ open, onClose, onAccepted }) {
               href={LICENSE_URLS.code}
               target="_blank"
               rel="noopener noreferrer"
-              className="supertonic-license__link"
+              className="text-[0.83rem] text-[var(--accent,#8ab4f8)] no-underline hover:underline focus-visible:underline"
             >
               {t('license.read_mit')}
             </a>
@@ -109,16 +114,18 @@ export default function SupertonicLicenseDialog({ open, onClose, onAccepted }) {
               href={LICENSE_URLS.model}
               target="_blank"
               rel="noopener noreferrer"
-              className="supertonic-license__link"
+              className="text-[0.83rem] text-[var(--accent,#8ab4f8)] no-underline hover:underline focus-visible:underline"
             >
               {t('license.read_openrail')}
             </a>
           </section>
         </div>
 
-        <p className="supertonic-license__footer">{t('license.footer')}</p>
+        <p className="mx-0 mt-0 mb-[1.1rem] text-[0.78rem] leading-[1.5] opacity-[0.7]">
+          {t('license.footer')}
+        </p>
 
-        <div className="supertonic-license__actions">
+        <div className="flex justify-end gap-[0.5rem]">
           <button
             type="button"
             className="supertonic-license__btn supertonic-license__btn--secondary"


### PR DESCRIPTION
## Summary

Converts the **mechanical** layout/typography CSS of five modal/dialog/panel components to Tailwind v4 utilities on the JSX, trimming each `.css` to only what genuinely belongs there. Net **-476 lines** of CSS.

Exact pixels are preserved via arbitrary utilities that reference the same design tokens / px values (e.g. `gap-[var(--space-3)]`, `text-[length:var(--text-sm)]`, `p-[14px_18px]`, `[border:1px_solid_var(--chrome-border)]`), following the patterns already established in `ui/Tabs.jsx`, `ui/Segmented.jsx`, `ui/Badge.jsx`. There is **no preflight** in this project, so UA button resets (`bg-transparent`, `border-0`, `p-0`) are replicated explicitly.

## Conservatively left in CSS (per scope rules)
- Fixed overlays / drawer positioning / `pointer-events` backdrops
- `@keyframes` + open/close slide/scale animations (Radix-style)
- State-class selectors (`.is-on`, `.is-active`, `.is-dub.is-on`, `.is-over`) and unclassed descendant selectors (`button`, `input`, `h3/p/code`)
- `color-mix()` card/section/button styling
- `linear-gradient` head backgrounds where coupled to kept chrome
- **`.ui-compare__grid`** — its responsive collapse is driven by a media query in `CompareModal.css` **and** `index.css` (cross-file → STOP rule)
- `BatchAddDialog`'s `<select>` font-size override on top of the global `.input-base`

## Notes
- `NotificationPanel`: only the live bell trigger + count badge were converted; color/bg are made conditional in JSX to avoid Tailwind utility-ordering ties. The pre-existing **unused** `.notif-panel/.notif-item/.notif-hf-input` blocks were left untouched (dead-code removal is out of scope for a CSS→TW conversion).

## Verification
- `npx oxlint` → exit **0** (only pre-existing warnings)
- `npx oxfmt --check .` → clean
- `npx vite build` → OK
- `npx vitest run` → **641 passed** (78 files), incl. `ExportModal.test.jsx`
- `bun install --frozen-lockfile` → no lockfile change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Reworked five modal/dialog/panel UIs to move mechanical layout and typography into Tailwind utilities in JSX, while keeping overlay/chrome, animations, state-driven styles, and other non-mechanical CSS in the stylesheets.

- `ExportModal`, `CompareModal`, `BatchAddDialog`, and `SupertonicLicenseDialog` now use utility class strings for headers, bodies, footers, grids, and form/layout spacing.
- `NotificationPanel` now styles the bell trigger and count badge via computed utility classes, including explicit warn/danger badge color selection.
- CSS files were trimmed to retain only structural/statedependent rules that were intentionally left out of the refactor.

Before/after sketch:
```text
BEFORE
[CSS classes] -> [modal/panel DOM]
  header/body/footer/layout/typography mostly in CSS

AFTER
[Tailwind utilities in JSX] + [small CSS for overlays/state]
  header/body/footer/layout/typography in JSX
  overlays/animations/state selectors remain in CSS
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->