### PR TITLE
feat(ui): convert dub/demo component CSS to Tailwind utilities

### DIFF
--- a/frontend/src/components/DemoPresetGrid.css
+++ b/frontend/src/components/DemoPresetGrid.css
@@ -1,109 +1,11 @@
 /* Demo preset grid — empty state of the Voice Design tab.
-   7 cards in a responsive grid; cards self-size on column count. */
-
-.demo-preset-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 10px;
-  margin-bottom: 12px;
-}
-
-.demo-preset-card {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
-  background: rgba(255, 255, 255, 0.02);
-  transition: border-color 120ms ease, background 120ms ease;
-}
-
-.demo-preset-card:hover {
-  border-color: rgba(243, 165, 182, 0.35);
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.demo-preset-card__head {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.demo-preset-card__icon {
-  font-size: 16px;
-  line-height: 1;
-}
-
-.demo-preset-card__name {
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--color-fg, currentColor);
-}
-
-.demo-preset-card__desc {
-  margin: 0;
-  font-size: 11px;
-  line-height: 1.35;
-  color: var(--color-fg-muted, #b0aaa1);
-}
-
-.demo-preset-card__instruct {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 10px;
-  color: var(--color-fg-subtle, #928374);
-  background: rgba(0, 0, 0, 0.22);
-  padding: 2px 6px;
-  border-radius: 4px;
-  align-self: flex-start;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.demo-preset-card__actions {
-  display: flex;
-  gap: 6px;
-  margin-top: auto;
-  padding-top: 4px;
-}
-
-.demo-preset-card__preview,
-.demo-preset-card__use {
-  flex: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 5px 8px;
-  font-size: 11px;
-  font-weight: 600;
-  border-radius: 6px;
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
-  background: transparent;
-  color: var(--color-fg, currentColor);
-  cursor: pointer;
-  transition: background 100ms ease, border-color 100ms ease;
-}
-
-.demo-preset-card__preview:hover,
-.demo-preset-card__use:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.2);
-}
+   Layout/typography moved to Tailwind utilities on DemoPresetGrid.jsx.
+   Kept here: the active-preview state, an attribute selector
+   ([aria-pressed="true"]) that must stay unlayered so it wins over the
+   button's hover utilities. */
 
 .demo-preset-card__preview[aria-pressed="true"] {
   background: rgba(243, 165, 182, 0.18);
   border-color: rgba(243, 165, 182, 0.4);
   color: #fff9ef;
-}
-
-.demo-preset-card__use {
-  background: rgba(243, 165, 182, 0.12);
-  border-color: rgba(243, 165, 182, 0.3);
-}
-
-.demo-preset-card__use:hover {
-  background: rgba(243, 165, 182, 0.22);
 }

--- a/frontend/src/components/DemoPresetGrid.jsx
+++ b/frontend/src/components/DemoPresetGrid.jsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { DEMO_ICONS, FALLBACK_VOICE_ICON, stripVoiceEmoji } from '../utils/voiceIcons';
 import { API } from '../api/client';
 import { claimPlayback, stopActivePlayback } from '../utils/playback';
-import './DemoPresetGrid.css';
+import './DemoPresetGrid.css'; // .demo-preset-card__preview[aria-pressed] only
 
 export default function DemoPresetGrid({ presets, onUse }) {
   const { t } = useTranslation();
@@ -70,7 +70,7 @@ export default function DemoPresetGrid({ presets, onUse }) {
   };
 
   return (
-    <div className="demo-preset-grid">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-[10px] mb-[12px]">
       {/* Single audio element shared across cards — keeps the "only one
           plays at a time" invariant without per-card state coordination. */}
       <audio
@@ -86,19 +86,24 @@ export default function DemoPresetGrid({ presets, onUse }) {
         const isPlaying = playingId === p.id;
         const Icon = DEMO_ICONS[p.id] || FALLBACK_VOICE_ICON;
         return (
-          <div key={p.id} className="demo-preset-card">
-            <div className="demo-preset-card__head">
-              <span className="demo-preset-card__icon" aria-hidden>
+          <div
+            key={p.id}
+            className="flex flex-col gap-[6px] p-[12px] rounded-xl border border-border bg-[rgba(255,255,255,0.02)] [transition:border-color_120ms_ease,background_120ms_ease] hover:border-[rgba(243,165,182,0.35)] hover:bg-[rgba(255,255,255,0.04)]"
+          >
+            <div className="inline-flex items-center gap-[6px]">
+              <span className="text-[16px] leading-none" aria-hidden>
                 <Icon size={18} />
               </span>
-              <span className="demo-preset-card__name">{stripVoiceEmoji(p.name)}</span>
+              <span className="text-[13px] font-bold text-fg">{stripVoiceEmoji(p.name)}</span>
             </div>
-            <p className="demo-preset-card__desc">{p.description}</p>
-            <code className="demo-preset-card__instruct">{p.instruct}</code>
-            <div className="demo-preset-card__actions">
+            <p className="m-0 text-[11px] leading-[1.35] text-fg-muted">{p.description}</p>
+            <code className="font-mono text-[10px] text-fg-subtle bg-[rgba(0,0,0,0.22)] px-[6px] py-[2px] rounded-md self-start max-w-full overflow-hidden text-ellipsis whitespace-nowrap">
+              {p.instruct}
+            </code>
+            <div className="flex gap-[6px] mt-auto pt-[4px]">
               <button
                 type="button"
-                className="demo-preset-card__preview"
+                className="demo-preset-card__preview flex-1 inline-flex items-center justify-center gap-[4px] px-[8px] py-[5px] text-[11px] font-semibold rounded-lg border border-border bg-transparent text-fg cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease] hover:bg-[rgba(255,255,255,0.05)] hover:border-[rgba(255,255,255,0.2)]"
                 onClick={() => handlePreview(p)}
                 aria-label={isPlaying ? `Pause ${p.name}` : `Preview ${p.name}`}
                 aria-pressed={isPlaying}
@@ -108,7 +113,7 @@ export default function DemoPresetGrid({ presets, onUse }) {
               </button>
               <button
                 type="button"
-                className="demo-preset-card__use"
+                className="flex-1 inline-flex items-center justify-center gap-[4px] px-[8px] py-[5px] text-[11px] font-semibold rounded-lg border border-[rgba(243,165,182,0.3)] bg-[rgba(243,165,182,0.12)] text-fg cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease] hover:border-[rgba(255,255,255,0.2)] hover:bg-[rgba(243,165,182,0.22)]"
                 onClick={() => onUse(p)}
                 aria-label={`Use ${p.name} design`}
               >

--- a/frontend/src/components/DictationDemo.css
+++ b/frontend/src/components/DictationDemo.css
@@ -1,5 +1,9 @@
 /* Dictation demo — guided walkthrough panel.
-   Used in Settings → Capture & Dictation and SetupWizard step 4. */
+   Used in Settings → Capture & Dictation and SetupWizard step 4.
+   Most layout/typography now lives in Tailwind utilities on DictationDemo.jsx.
+   Kept here: the container base + `--embedded` override (the test queries
+   `.dictation-demo`), `.dictation-demo__scripts` (also queried by the test),
+   and the status/result state variants with their descendant selectors. */
 
 .dictation-demo {
   display: flex;
@@ -18,24 +22,6 @@
   background: transparent;
   padding: 0;
   margin-bottom: 12px;
-}
-
-.dictation-demo__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.dictation-demo__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin: 0;
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--color-fg, currentColor);
 }
 
 .dictation-demo__status {
@@ -74,79 +60,10 @@
   color: #fb4934;
 }
 
-.dictation-demo__lede {
-  margin: 0;
-  font-size: 11px;
-  line-height: 1.45;
-  color: var(--color-fg-muted, #b0aaa1);
-}
-
 .dictation-demo__scripts {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 10px;
-}
-
-.dictation-demo__card {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
-  background: rgba(0, 0, 0, 0.15);
-}
-
-.dictation-demo__card-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 10px;
-  color: var(--color-fg-muted, #928374);
-}
-
-.dictation-demo__lang {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 9px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.06);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.dictation-demo__card-label {
-  font-weight: 600;
-  font-size: 11px;
-  color: var(--color-fg, currentColor);
-  text-transform: none;
-}
-
-.dictation-demo__script {
-  margin: 0;
-  padding: 6px 8px;
-  font-size: 11.5px;
-  line-height: 1.45;
-  border-left: 2px solid rgba(243, 165, 182, 0.4);
-  background: rgba(255, 255, 255, 0.02);
-  color: var(--color-fg, currentColor);
-  font-style: italic;
-}
-
-.dictation-demo__card-actions {
-  display: flex;
-  gap: 6px;
-  margin-top: 2px;
-}
-
-.dictation-demo__result {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-  font-size: 11px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  line-height: 1.4;
 }
 
 .dictation-demo__result--ok {

--- a/frontend/src/components/DictationDemo.jsx
+++ b/frontend/src/components/DictationDemo.jsx
@@ -215,14 +215,14 @@ export default function DictationDemo({ embedded = false }) {
 
   return (
     <section className={`dictation-demo ${embedded ? 'dictation-demo--embedded' : ''}`}>
-      <header className="dictation-demo__head">
-        <h3 className="dictation-demo__title">
+      <header className="flex items-center justify-between gap-[12px] flex-wrap">
+        <h3 className="inline-flex items-center gap-[6px] m-0 text-[13px] font-bold text-fg">
           <Mic size={14} /> {t('demo.dictation_title')}
         </h3>
         {statusBadge}
       </header>
 
-      <p className="dictation-demo__lede">
+      <p className="m-0 text-[11px] leading-[1.45] text-fg-muted">
         {showScripts
           ? t('demo.dictation_lede')
           : t(
@@ -239,13 +239,22 @@ export default function DictationDemo({ embedded = false }) {
             const isPlaying = playingId === s.id;
             const tx = transcripts[s.id] || {};
             return (
-              <div key={s.id} className="dictation-demo__card">
-                <div className="dictation-demo__card-head">
-                  <span className="dictation-demo__lang">{s.language}</span>
-                  <span className="dictation-demo__card-label">{t(s.labelKey)}</span>
+              <div
+                key={s.id}
+                className="flex flex-col gap-[6px] px-[12px] py-[10px] rounded-[8px] border border-border bg-[rgba(0,0,0,0.15)]"
+              >
+                <div className="flex items-center gap-[8px] text-[10px] text-fg-muted">
+                  <span className="font-mono text-[9px] px-[5px] py-[1px] rounded-sm bg-[rgba(255,255,255,0.06)] uppercase tracking-[0.04em]">
+                    {s.language}
+                  </span>
+                  <span className="font-semibold text-[11px] text-fg normal-case">
+                    {t(s.labelKey)}
+                  </span>
                 </div>
-                <blockquote className="dictation-demo__script">{s.text}</blockquote>
-                <div className="dictation-demo__card-actions">
+                <blockquote className="m-0 px-[8px] py-[6px] text-[11.5px] leading-[1.45] border-l-2 border-l-[rgba(243,165,182,0.4)] bg-[rgba(255,255,255,0.02)] text-fg italic">
+                  {s.text}
+                </blockquote>
+                <div className="flex gap-[6px] mt-[2px]">
                   <Button
                     size="sm"
                     variant="subtle"
@@ -273,12 +282,12 @@ export default function DictationDemo({ embedded = false }) {
                   </Button>
                 </div>
                 {tx.state === 'ok' && (
-                  <div className="dictation-demo__result dictation-demo__result--ok">
+                  <div className="dictation-demo__result--ok flex items-start gap-[6px] text-[11px] px-[8px] py-[6px] rounded-lg leading-[1.4]">
                     <CheckCircle2 size={11} /> <em>{tx.text}</em>
                   </div>
                 )}
                 {tx.state === 'fail' && (
-                  <div className="dictation-demo__result dictation-demo__result--fail">
+                  <div className="dictation-demo__result--fail flex items-start gap-[6px] text-[11px] px-[8px] py-[6px] rounded-lg leading-[1.4]">
                     <AlertTriangle size={11} /> {tx.error}
                   </div>
                 )}

--- a/frontend/src/components/DubSegmentRow.css
+++ b/frontend/src/components/DubSegmentRow.css
@@ -1,4 +1,10 @@
-/* ═══ DubSegmentRow extracted layout styles ═══ */
+/* ═══ DubSegmentRow extracted layout styles ═══
+   Per-cell badge/label/time-span layout now lives in Tailwind utilities on
+   DubSegmentRow.jsx. Kept here: the row + its generation/selection/playhead
+   state classes (shared with DubSegmentTable.css + index.css, !important,
+   compound selectors), the text inputs (font:inherit + focus rings), and the
+   select/range/actions cells whose `input-base` / `input[type=range]` siblings
+   are unlayered and would otherwise beat utilities in the cascade. */
 
 /* Row transition — smooth bg/border changes during generation */
 .segment-row {
@@ -30,22 +36,8 @@
   box-shadow: inset 2px 0 0 var(--chrome-accent);
 }
 
-/* Per-cell widths are inherited from the shared grid template defined
-   in DubSegmentTable.css (--seg-grid-cols). Cells here only control
-   intra-cell layout: stacking, font, overflow. */
-.seg-check {
-  cursor: pointer;
-  justify-self: center;
-}
-.seg-time {
-  min-width: 0; overflow: hidden;
-  display: flex; flex-direction: column;
-  font-variant-numeric: tabular-nums;
-}
-.seg-time-row {
-  display: flex; align-items: baseline; gap: 2px;
-  min-width: 0;
-}
+/* Time + speaker inputs: `font: inherit` and the focus ring don't map to
+   utilities cleanly, so they stay here. */
 .seg-time-input {
   background: transparent;
   border: none;
@@ -61,22 +53,6 @@
   outline: 1px solid var(--chrome-accent);
   outline-offset: 1px;
   background: var(--chrome-hover-bg);
-}
-.seg-time-sep { color: var(--chrome-fg-muted); }
-.seg-time-end {
-  color: var(--chrome-fg-muted);
-  font-size: 0.62rem;
-}
-.seg-sync-badge {
-  font-size: 0.48rem; margin-top: 1px;
-  display: inline-flex; align-items: center; gap: 1px;
-}
-.seg-rate-badge {
-  font-size: 0.48rem; margin-top: 1px;
-  font-variant-numeric: tabular-nums;
-}
-.seg-speed-badge {
-  font-size: 0.52rem; margin-left: 1px;
 }
 .seg-speaker-input {
   width: 100%;
@@ -96,6 +72,8 @@
   background: var(--chrome-hover-bg);
   color: var(--chrome-fg);
 }
+/* Descendant override of the shared (unlayered) .segment-input — must stay
+   unlayered to win over index.css. */
 .seg-text-col {
   display: flex; flex-direction: column; gap: 1px;
   min-width: 0; overflow: hidden;
@@ -103,23 +81,8 @@
 .seg-text-col .segment-input {
   width: 100%; min-width: 0;
 }
-.seg-orig-row {
-  font-size: 0.52rem; color: #6b6657;
-  display: flex; align-items: center; gap: 3px;
-  padding: 0 2px; overflow: hidden;
-}
-.seg-orig-label {
-  opacity: 0.8; text-transform: uppercase; font-weight: 600;
-  font-size: 0.48rem; color: #7c6f64;
-}
-.seg-orig-text {
-  flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.seg-budget-warn { color: #fabd2f; font-size: 0.48rem; }
-.seg-restore-btn {
-  background: none; border: none; color: #83a598;
-  cursor: pointer; padding: 0; font-size: 0.52rem;
-}
+/* Selects carry `input-base` (unlayered) — these size/padding overrides must
+   stay unlayered too, else input-base would win over a utilities-layer class. */
 .seg-lang-select {
   width: 100%; min-width: 0; font-size: 0.6rem; padding: 1px 2px;
 }
@@ -127,6 +90,7 @@
   width: 100%; min-width: 0; font-size: 0.6rem; padding: 1px 4px;
   overflow: hidden; text-overflow: ellipsis;
 }
+/* Range slider — overrides the unlayered input[type=range] base. */
 .seg-gain-slider {
   width: 100%; min-width: 0; padding: 0; margin: 0;
   height: 3px;

--- a/frontend/src/components/DubSegmentRow.jsx
+++ b/frontend/src/components/DubSegmentRow.jsx
@@ -196,11 +196,11 @@ function DubSegmentRow({
         onClick={(e) => onSelect(seg.id, idx, e.shiftKey)}
         disabled={disabled}
         style={{ accentColor: '#d3869b' }}
-        className="seg-check"
+        className="cursor-pointer justify-self-center"
         title={t('segment.select_title')}
       />
-      <span className="segment-time seg-time">
-        <span className="seg-time-row">
+      <span className="segment-time flex flex-col min-w-0 overflow-hidden tabular-nums">
+        <span className="flex items-baseline gap-[2px] min-w-0">
           <input
             type="text"
             className="seg-time-input"
@@ -229,11 +229,13 @@ function DubSegmentRow({
               }
             }}
           />
-          <span className="seg-time-sep">–</span>
-          <span className="seg-time-end">{formatTime(seg.end)}</span>
+          <span className="text-[var(--chrome-fg-muted)]">–</span>
+          <span className="text-[var(--chrome-fg-muted)] text-[0.62rem]">
+            {formatTime(seg.end)}
+          </span>
           {seg.speed && seg.speed !== 1.0 && (
             <span
-              className="seg-speed-badge"
+              className="text-[0.52rem] ml-[1px]"
               style={{ color: seg.speed > 1 ? '#d3869b' : '#8ec07c' }}
             >
               {seg.speed.toFixed(2)}x
@@ -241,7 +243,11 @@ function DubSegmentRow({
           )}
         </span>
         {fitBadge && (
-          <span className="seg-sync-badge" style={{ color: fitBadge.color }} title={fitBadge.title}>
+          <span
+            className="text-[0.48rem] mt-[1px] inline-flex items-center gap-[1px]"
+            style={{ color: fitBadge.color }}
+            title={fitBadge.title}
+          >
             <fitBadge.Icon size={8} /> {fitBadge.label}
           </span>
         )}
@@ -249,7 +255,7 @@ function DubSegmentRow({
           // Wave 3.3: second-pass ASR heard something different from the
           // target text for this line — worth a re-listen / re-dub.
           <span
-            className="seg-sync-badge"
+            className="text-[0.48rem] mt-[1px] inline-flex items-center gap-[1px]"
             style={{ color: '#fb4934' }}
             title={t('segment.qc_verify_title', { heard: seg.qc_recognized || '' })}
           >
@@ -258,7 +264,7 @@ function DubSegmentRow({
         )}
         {seg.rate_ratio != null && Math.abs(seg.rate_ratio - 1.0) > 0.03 && (
           <span
-            className="seg-rate-badge"
+            className="text-[0.48rem] mt-[1px] tabular-nums"
             style={{
               color:
                 seg.rate_ratio > 1.15 ? '#fb4934' : seg.rate_ratio < 0.85 ? '#83a598' : '#a89984',
@@ -327,13 +333,18 @@ function DubSegmentRow({
           }
         />
         {seg.text_original && seg.text_original !== seg.text && (
-          <span className="seg-orig-row">
-            <span className="seg-orig-label">{t('segment.orig_label')}</span>
-            <span className="seg-orig-text" title={seg.text_original}>
+          <span className="text-[0.52rem] text-[#6b6657] flex items-center gap-[3px] px-[2px] overflow-hidden">
+            <span className="opacity-80 uppercase font-semibold text-[0.48rem] text-[#7c6f64]">
+              {t('segment.orig_label')}
+            </span>
+            <span
+              className="flex-1 whitespace-nowrap overflow-hidden text-ellipsis"
+              title={seg.text_original}
+            >
               {seg.text_original}
             </span>
             {overBudget && (
-              <span className="seg-budget-warn">
+              <span className="text-[#fabd2f] text-[0.48rem]">
                 {Math.round((seg.text.length / seg.text_original.length) * 100)}%
               </span>
             )}
@@ -341,7 +352,7 @@ function DubSegmentRow({
               onClick={() => onRestore(seg.id)}
               disabled={disabled}
               title={t('segment.restore_title')}
-              className="seg-restore-btn"
+              className="bg-transparent border-none text-[#83a598] cursor-pointer p-0 text-[0.52rem]"
             >
               ↺
             </button>

--- a/frontend/src/components/DubbingDemo.css
+++ b/frontend/src/components/DubbingDemo.css
@@ -1,4 +1,8 @@
-/* Synthetic dubbing demo — side-by-side player. */
+/* Synthetic dubbing demo — side-by-side player.
+   Most layout/typography now lives in Tailwind utilities on DubbingDemo.jsx.
+   Kept here: the shared container base (reused by the loading state), the
+   responsive media query, and descendant/compound selectors that don't map
+   cleanly to utilities (and must stay unlayered to win the cascade). */
 
 .dubbing-demo {
   display: flex;
@@ -17,77 +21,12 @@
   text-align: center;
 }
 
-.dubbing-demo__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.dubbing-demo__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--color-fg, currentColor);
-}
-
-.dubbing-demo__head-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.dubbing-demo__sync {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 11px;
-  color: var(--color-fg-muted, #b0aaa1);
-  cursor: pointer;
-  user-select: none;
-}
-
-.dubbing-demo__sync input {
-  accent-color: #f3a5b6;
-}
-
-.dubbing-demo__dismiss {
-  border: 0;
-  background: transparent;
-  color: var(--color-fg-muted, #928374);
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 4px;
-  display: inline-flex;
-}
-
-.dubbing-demo__dismiss:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--color-fg, currentColor);
-}
-
-.dubbing-demo__players {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-}
-
 @media (max-width: 720px) {
   .dubbing-demo__players { grid-template-columns: 1fr; }
 }
 
-.dubbing-demo__pane {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.dubbing-demo__pane-label {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-fg, currentColor);
+.dubbing-demo__sync input {
+  accent-color: #f3a5b6;
 }
 
 .dubbing-demo__pane-label span {
@@ -107,69 +46,8 @@
   outline-offset: -1px;
 }
 
-.dubbing-demo__caption {
-  margin: 0;
-  font-size: 10.5px;
-  line-height: 1.4;
-  color: var(--color-fg-muted, #b0aaa1);
-  padding: 4px 6px;
-  background: rgba(0, 0, 0, 0.18);
-  border-radius: 4px;
-}
-
-.dubbing-demo__picker {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  padding-top: 4px;
-}
-
-.dubbing-demo__picker-label {
-  font-size: 10px;
-  color: var(--color-fg-muted, #928374);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-right: 4px;
-}
-
-.dubbing-demo__chip {
-  font-size: 11px;
-  padding: 3px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
-  background: transparent;
-  color: var(--color-fg-muted, #b0aaa1);
-  cursor: pointer;
-  transition: background 100ms ease, border-color 100ms ease, color 100ms ease;
-}
-
-.dubbing-demo__chip:hover {
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--color-fg, currentColor);
-}
-
 .dubbing-demo__chip.is-active {
   background: rgba(243, 165, 182, 0.18);
   border-color: rgba(243, 165, 182, 0.45);
   color: #fff9ef;
-}
-
-.dubbing-demo__cta {
-  align-self: flex-end;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 11px;
-  font-weight: 600;
-  border-radius: 6px;
-  border: 1px solid rgba(243, 165, 182, 0.4);
-  background: rgba(243, 165, 182, 0.12);
-  color: var(--color-fg, currentColor);
-  cursor: pointer;
-}
-
-.dubbing-demo__cta:hover {
-  background: rgba(243, 165, 182, 0.22);
 }

--- a/frontend/src/components/DubbingDemo.jsx
+++ b/frontend/src/components/DubbingDemo.jsx
@@ -100,12 +100,12 @@ export default function DubbingDemo({ onDismiss }) {
 
   return (
     <div className="dubbing-demo">
-      <header className="dubbing-demo__head">
-        <div className="dubbing-demo__title">
+      <header className="flex items-center justify-between gap-[12px]">
+        <div className="inline-flex items-center gap-[6px] text-[12px] font-bold text-fg">
           <Film size={13} /> {t('demo.dubbing_title')}
         </div>
-        <div className="dubbing-demo__head-actions">
-          <label className="dubbing-demo__sync">
+        <div className="inline-flex items-center gap-[8px]">
+          <label className="dubbing-demo__sync inline-flex items-center gap-[5px] text-[11px] text-fg-muted cursor-pointer select-none">
             <input
               type="checkbox"
               checked={syncPlay}
@@ -116,7 +116,7 @@ export default function DubbingDemo({ onDismiss }) {
           {onDismiss && (
             <button
               type="button"
-              className="dubbing-demo__dismiss"
+              className="border-0 bg-transparent text-fg-muted cursor-pointer px-[4px] py-[2px] rounded-md inline-flex hover:bg-[rgba(255,255,255,0.05)] hover:text-fg"
               onClick={onDismiss}
               aria-label={t('demo.dubbing_dismiss')}
             >
@@ -126,9 +126,9 @@ export default function DubbingDemo({ onDismiss }) {
         </div>
       </header>
 
-      <div className="dubbing-demo__players">
-        <div className="dubbing-demo__pane">
-          <div className="dubbing-demo__pane-label">
+      <div className="dubbing-demo__players grid grid-cols-2 gap-[12px]">
+        <div className="dubbing-demo__pane flex flex-col gap-[6px]">
+          <div className="dubbing-demo__pane-label text-[11px] font-semibold text-fg">
             {source.label} <span>· {t('demo.original_tag')}</span>
           </div>
           <video
@@ -138,10 +138,12 @@ export default function DubbingDemo({ onDismiss }) {
             playsInline
             preload="metadata"
           />
-          <p className="dubbing-demo__caption">{source.script}</p>
+          <p className="m-0 text-[10.5px] leading-[1.4] text-fg-muted px-[6px] py-[4px] bg-bg-elev-3 rounded-md">
+            {source.script}
+          </p>
         </div>
-        <div className="dubbing-demo__pane">
-          <div className="dubbing-demo__pane-label">
+        <div className="dubbing-demo__pane flex flex-col gap-[6px]">
+          <div className="dubbing-demo__pane-label text-[11px] font-semibold text-fg">
             {dubbed.label} <span>· {t('demo.dubbed_tag')}</span>
           </div>
           <video
@@ -152,19 +154,24 @@ export default function DubbingDemo({ onDismiss }) {
             preload="metadata"
             dir={dubbed.dir}
           />
-          <p className="dubbing-demo__caption" dir={dubbed.dir}>
+          <p
+            className="m-0 text-[10.5px] leading-[1.4] text-fg-muted px-[6px] py-[4px] bg-bg-elev-3 rounded-md"
+            dir={dubbed.dir}
+          >
             {dubbed.script}
           </p>
         </div>
       </div>
 
-      <div className="dubbing-demo__picker">
-        <span className="dubbing-demo__picker-label">{t('demo.dubbing_picker')}</span>
+      <div className="flex flex-wrap items-center gap-[6px] pt-[4px]">
+        <span className="text-[10px] text-fg-muted uppercase tracking-[0.05em] mr-[4px]">
+          {t('demo.dubbing_picker')}
+        </span>
         {manifest.dubbed.map((d) => (
           <button
             key={d.code}
             type="button"
-            className={`dubbing-demo__chip ${pickedCode === d.code ? 'is-active' : ''}`}
+            className={`dubbing-demo__chip text-[11px] px-[10px] py-[3px] rounded-[999px] border border-border bg-transparent text-fg-muted cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease,color_100ms_ease] hover:bg-[rgba(255,255,255,0.04)] hover:text-fg ${pickedCode === d.code ? 'is-active' : ''}`}
             onClick={() => setPickedCode(d.code)}
           >
             {d.label}
@@ -173,7 +180,11 @@ export default function DubbingDemo({ onDismiss }) {
       </div>
 
       {onDismiss && (
-        <button type="button" className="dubbing-demo__cta" onClick={onDismiss}>
+        <button
+          type="button"
+          className="self-end inline-flex items-center gap-[6px] px-[12px] py-[6px] text-[11px] font-semibold rounded-lg border border-[rgba(243,165,182,0.4)] bg-[rgba(243,165,182,0.12)] text-fg cursor-pointer hover:bg-[rgba(243,165,182,0.22)]"
+          onClick={onDismiss}
+        >
           <Play size={12} /> {t('demo.dubbing_cta')}
         </button>
       )}

--- a/frontend/src/components/SegmentTrack.css
+++ b/frontend/src/components/SegmentTrack.css
@@ -1,39 +1,15 @@
-/* SegmentTrack — custom dub-timeline segment lane (#280, item 3). */
-
-.seg-track {
-  position: relative;
-  width: 100%;
-  user-select: none;
-  -webkit-user-select: none;
-  margin-top: 2px;
-}
-
-.seg-track__onsets {
-  display: block;
-  width: 100%;
-  pointer-events: none;
-}
-
-.seg-track__viewport {
-  position: relative;
-  width: 100%;
-  height: 40px;
-  overflow: hidden;
-}
+/* SegmentTrack — custom dub-timeline segment lane (#280, item 3).
+   Container/onset/lane/label/handle-base/actions/action-btn/playhead layout
+   now lives in Tailwind utilities on SegmentTrack.jsx. Kept here: the box and
+   its many JS-toggled state variants, the resize-handle edges (with their
+   hover/selected compounds), the self-scroll viewport modifier, the disabled
+   compound, and the visually-hidden announce region — all selectors that are
+   compound / stateful / pseudo and must stay unlayered to win the cascade. */
 
 /* WebKit fallback: the lane scrolls itself (no WaveSurfer wrapper to sync). */
 .seg-track__viewport--scroll {
   overflow-x: auto;
   overflow-y: hidden;
-}
-
-.seg-track__lane {
-  position: relative;
-  height: 100%;
-  /* No `will-change: transform` — the persistent compositor layer it forces
-     made the semi-transparent segment boxes vanish/reappear during playback
-     and drags on some Windows GPU drivers (#373). The lane only translates
-     while scrolling; a permanent layer isn't worth the paint glitch. */
 }
 
 .seg-track__box {
@@ -84,28 +60,6 @@
   border-color: #fb4934;
 }
 
-.seg-track__label {
-  flex: 1;
-  min-width: 0;
-  padding: 0 8px;
-  font-size: 9px;
-  line-height: 1.2;
-  color: #ebdbb2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  pointer-events: none;
-}
-
-.seg-track__handle {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 6px;
-  cursor: ew-resize;
-  z-index: 2;
-}
-
 .seg-track__handle--l { left: 0; border-left: 2px solid rgba(235, 219, 178, 0.45); }
 .seg-track__handle--r { right: 0; border-right: 2px solid rgba(235, 219, 178, 0.45); }
 
@@ -113,42 +67,6 @@
 .seg-track__box.is-selected .seg-track__handle--l { border-left-color: #d3869b; }
 .seg-track__box:hover .seg-track__handle--r,
 .seg-track__box.is-selected .seg-track__handle--r { border-right-color: #d3869b; }
-
-.seg-track__actions {
-  display: inline-flex;
-  gap: 2px;
-  margin-right: 8px;
-  z-index: 3;
-}
-
-.seg-track__action-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  padding: 0;
-  border: 1px solid rgba(168, 153, 132, 0.4);
-  border-radius: 3px;
-  background: rgba(40, 40, 40, 0.85);
-  color: #ebdbb2;
-  cursor: pointer;
-}
-
-.seg-track__action-btn:hover {
-  border-color: #d3869b;
-  color: #d3869b;
-}
-
-.seg-track__playhead {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 1px;
-  background: #d3869b;
-  opacity: 0.8;
-  pointer-events: none;
-}
 
 .seg-track.is-disabled .seg-track__box {
   cursor: default;

--- a/frontend/src/components/SegmentTrack.jsx
+++ b/frontend/src/components/SegmentTrack.jsx
@@ -468,20 +468,23 @@ export default function SegmentTrack({
   const windowed = effSegments.slice(lo, hi);
 
   return (
-    <div className={`seg-track ${disabled ? 'is-disabled' : ''}`} ref={hostRef}>
+    <div
+      className={`seg-track relative w-full select-none mt-[2px] ${disabled ? 'is-disabled' : ''}`}
+      ref={hostRef}
+    >
       <canvas
         ref={canvasRef}
-        className="seg-track__onsets"
+        className="block w-full pointer-events-none"
         style={{ height: ONSET_STRIP_H }}
         aria-hidden="true"
       />
       <div
         ref={viewportRef}
-        className={`seg-track__viewport ${selfScroll ? 'seg-track__viewport--scroll' : ''}`}
+        className={`relative w-full h-[40px] overflow-hidden ${selfScroll ? 'seg-track__viewport--scroll' : ''}`}
         onScroll={selfScroll ? (e) => setInnerScroll(e.currentTarget.scrollLeft) : undefined}
       >
         <div
-          className="seg-track__lane"
+          className="relative h-full"
           role="listbox"
           aria-label={t('timeline.track_label')}
           aria-orientation="horizontal"
@@ -541,16 +544,19 @@ export default function SegmentTrack({
                 onBlur={onBoxBlur}
               >
                 {!disabled && (
-                  <span className="seg-track__handle seg-track__handle--l" data-handle="start" />
+                  <span
+                    className="seg-track__handle--l absolute top-0 bottom-0 w-[6px] cursor-ew-resize z-[2]"
+                    data-handle="start"
+                  />
                 )}
-                <span className="seg-track__label">
+                <span className="flex-1 min-w-0 px-[8px] text-[9px] leading-[1.2] text-[#ebdbb2] whitespace-nowrap overflow-hidden text-ellipsis pointer-events-none">
                   {s.text?.length > 32 ? `${s.text.slice(0, 30)}…` : s.text || ''}
                 </span>
                 {isSel && !disabled && width > 64 && (
-                  <span className="seg-track__actions">
+                  <span className="inline-flex gap-[2px] mr-[8px] z-[3]">
                     <button
                       type="button"
-                      className="seg-track__action-btn"
+                      className="inline-flex items-center justify-center w-[16px] h-[16px] p-0 border border-[rgba(168,153,132,0.4)] rounded-sm bg-[rgba(40,40,40,0.85)] text-[#ebdbb2] cursor-pointer hover:border-[#d3869b] hover:text-[#d3869b]"
                       aria-label={t('timeline.play_slot')}
                       title={t('timeline.play_slot')}
                       onPointerDown={(ev) => ev.stopPropagation()}
@@ -564,7 +570,7 @@ export default function SegmentTrack({
                     {onPreviewSegment && (
                       <button
                         type="button"
-                        className="seg-track__action-btn"
+                        className="inline-flex items-center justify-center w-[16px] h-[16px] p-0 border border-[rgba(168,153,132,0.4)] rounded-sm bg-[rgba(40,40,40,0.85)] text-[#ebdbb2] cursor-pointer hover:border-[#d3869b] hover:text-[#d3869b]"
                         aria-label={t('timeline.preview_dub')}
                         title={t('timeline.preview_dub')}
                         onPointerDown={(ev) => ev.stopPropagation()}
@@ -579,14 +585,21 @@ export default function SegmentTrack({
                   </span>
                 )}
                 {!disabled && (
-                  <span className="seg-track__handle seg-track__handle--r" data-handle="end" />
+                  <span
+                    className="seg-track__handle--r absolute top-0 bottom-0 w-[6px] cursor-ew-resize z-[2]"
+                    data-handle="end"
+                  />
                 )}
               </div>
             );
           })}
         </div>
         {playheadX >= 0 && playheadX <= viewWidth && (
-          <div className="seg-track__playhead" style={{ left: playheadX }} aria-hidden="true" />
+          <div
+            className="absolute top-0 bottom-0 w-px bg-[#d3869b] opacity-80 pointer-events-none"
+            style={{ left: playheadX }}
+            aria-hidden="true"
+          />
         )}
       </div>
       <div className="seg-track__sr-announce" aria-live="polite" role="status">


### PR DESCRIPTION
Converts mechanical layout/typography from five dub/demo component CSS files into Tailwind v4 utilities on the JSX, per the no-preflight token setup in `src/index.css` (`@theme`). Net: **149 insertions / 521 deletions** across 10 files.

## Approach (conservative)
Only **mechanical** single-class rules (flex/grid/gap/padding/margin, sizing, typography, simple color/border/radius, simple hover/aria) were moved to utilities. Left in CSS: `@keyframes`/animations, `@media`, `!important`/`color-mix`, descendant/child/compound/attribute selectors, focus rings, `font: inherit`, any class referenced from another file, and — critically — any rule that would **lose the cascade** because `index.css` is **unlayered** (unlayered wins over the `utilities` layer regardless of specificity). Exact pixels preserved via arbitrary utilities (`px-[6px]`, `rounded-[999px]`, `[transition:…]`); tokens used where they map (`text-fg`, `border-border`, `bg-bg-elev-3`, `rounded-lg/md/sm/xl`, `font-mono`).

## Per file
- **DemoPresetGrid** — fully converted; CSS trimmed to only `.demo-preset-card__preview[aria-pressed="true"]` (attribute selector kept unlayered so it beats the button's hover utilities).
- **DubbingDemo** — converted head/title/dismiss/pane/caption/picker/chip/cta; kept the shared container base (reused by the loading state), the `max-width:720px` media query, the `input` / `pane-label span` / `pane video` descendants, and `.chip.is-active`.
- **DictationDemo** — converted head/title/lede/card/lang/script/actions/result-base; kept `.dictation-demo` and `.dictation-demo__scripts` (**queried by `DictationDemo.test.jsx`**), plus the status/result variants and their descendants.
- **DubSegmentRow** — converted the local cell badges/labels/time-spans/restore-button/checkbox; kept the shared `.segment-*` row/state classes (used by `DubSegmentTable.css`, `index.css`, `IdleSkeleton.jsx`), the text inputs (`font:inherit` + focus), and the select/range/actions cells whose unlayered `input-base` / `input[type=range]` siblings would otherwise beat utilities.
- **SegmentTrack** — converted container/onsets/viewport-base/lane/label/handle-base/actions/action-btn/playhead; kept the box + its JS-toggled state variants, handle edges with hover/selected compounds, the self-scroll viewport modifier, the disabled compound, and the visually-hidden announce region. Tests assert via roles/`data-segid`, not classes.

## Verification
- `npx oxlint` → exit 0 (only pre-existing warnings)
- `npx oxfmt --write src && npx oxfmt --check .` → clean
- `npx vite build` → success
- `npx vitest run` → **641 passed**
- `bun install --frozen-lockfile` → no lockfile change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Converted the dub/demo UI components from legacy CSS classes to Tailwind utilities in JSX, while keeping cascade-sensitive, shared, and stateful rules in CSS.

### What changed
- **DemoPresetGrid**
  - Moved grid/card/button layout and typography to Tailwind utilities.
  - Kept only the pressed-preview selector in CSS.

- **DubbingDemo**
  - Reworked the header, players, captions, picker, and CTA markup to Tailwind-based classes.
  - Retained shared container/loading styles, the mobile players layout rule, sync accent color, pane video/label styles, and active chip styling.

- **DictationDemo**
  - Moved the main header and script card layout to Tailwind utilities.
  - Kept container base styles, test-used scripts container, and status/result variants in CSS.

- **DubSegmentRow**
  - Shifted checkbox, timing/badge, original text, and restore button presentation to utilities.
  - Kept row-state, input, select, and other shared/compound rules in CSS.

- **SegmentTrack**
  - Converted track/container, segment content, handles, action buttons, and playhead rendering to Tailwind utilities.
  - Kept box/state variants, disabled/announce-region behavior, and other non-mechanical rules in CSS.

### Verification
- `npx oxlint` passed with only pre-existing warnings
- `npx oxfmt --write src && npx oxfmt --check .` clean
- `npx vite build` successful
- `npx vitest run` passed (`641` tests)
- `bun install --frozen-lockfile` made no lockfile changes

### Layout sketch
**Before**
```text
[ legacy CSS classes ]
┌─────────────────────────────┐
│ title / controls            │
│ ┌──────── cards/grid ─────┐ │
│ │ card │ card │ card      │ │
│ └──────────────────────────┘ │
└─────────────────────────────┘
```

**After**
```text
[ Tailwind utilities + minimal CSS ]
┌─────────────────────────────┐
│ title / controls            │
│ ┌──────── grid ───────────┐ │
│ │ utility-styled cards    │ │
│ └──────────────────────────┘ │
└─────────────────────────────┘
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->