### PR TITLE
feat(ui): convert FirstRunSetup layout CSS to Tailwind utilities (partial)

### DIFF
--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -376,13 +376,17 @@ export function BootstrapSplash({ stage, message }) {
   return (
     <div className="frs">
       <div className="frs__atmo" aria-hidden="true" />
-      <div className="frs__deck frs__deck--focus">
+      <div className="frs__deck frs__deck--focus relative w-full max-w-[1240px] m-0 flex flex-col flex-[1_1_auto] min-h-0 min-w-0">
         {/* ── Masthead: same identity as the setup screen ───────────────── */}
-        <header className="frs__mast frs-rise" style={{ '--rise': 0 }} data-tauri-drag-region>
+        <header
+          className="frs__mast frs-rise pb-[0.4rem]"
+          style={{ '--rise': 0 }}
+          data-tauri-drag-region
+        >
           <Waveform />
           {/* Journey rail: act 2 of the install flow (setup already done). */}
           <nav
-            className="frs-wsteps frs-wsteps--journey"
+            className="frs-wsteps frs-wsteps--journey flex items-center gap-[0.9rem] flex-wrap"
             aria-label={t('bootstrap.title', 'OmniVoice Studio')}
           >
             <span className="frs-wstep is-done">
@@ -398,15 +402,15 @@ export function BootstrapSplash({ stage, message }) {
               {t('firstrun.stage_models', 'Models & engines')}
             </span>
           </nav>
-          <div className="frs__mast-row">
+          <div className="frs__mast-row flex items-end justify-between gap-[2rem] mt-[1rem]">
             <div className="frs__mast-text">
               <h1 className="frs__title">{t('bootstrap.title', 'OmniVoice Studio')}</h1>
               <p className="frs__subtitle" aria-live="polite">
                 {label}
               </p>
             </div>
-            <div className="frs__mast-meta">
-              <div className="frs__mast-selects">
+            <div className="frs__mast-meta flex flex-col items-end gap-[0.45rem] shrink-0">
+              <div className="frs__mast-selects flex items-center gap-[0.5rem]">
                 <select
                   className="frs-select frs-select--lang"
                   value={locale}
@@ -444,7 +448,7 @@ export function BootstrapSplash({ stage, message }) {
                 lang: LANGUAGES.find((l) => l.code === systemLang)?.label || systemLang,
               })}
             </span>
-            <div className="frs-banner__actions">
+            <div className="frs-banner__actions flex items-center gap-[0.4rem]">
               <button type="button" className="frs-btn frs-btn--quiet" onClick={acceptSuggestion}>
                 {t('common.yes', 'Yes')}
               </button>
@@ -456,7 +460,10 @@ export function BootstrapSplash({ stage, message }) {
         )}
 
         {isFailed ? (
-          <section className="frs-panel frs-rise" style={{ '--rise': 1 }}>
+          <section
+            className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
+            style={{ '--rise': 1 }}
+          >
             <h2 className="frs-panel__title">{t('bootstrap.failed', 'Setup failed')}</h2>
             <pre className="frs__error">{message || t('bootstrap.unknown_error')}</pre>
             <div className="frs-hints">
@@ -469,7 +476,7 @@ export function BootstrapSplash({ stage, message }) {
                 ))}
               </ul>
             </div>
-            <div className="frs-banner__actions frs-banner__actions--end">
+            <div className="frs-banner__actions frs-banner__actions--end flex items-center gap-[0.4rem]">
               <button
                 type="button"
                 className="frs-btn frs-btn--quiet"
@@ -490,7 +497,10 @@ export function BootstrapSplash({ stage, message }) {
             </div>
           </section>
         ) : (
-          <section className="frs-panel frs-rise" style={{ '--rise': 1 }}>
+          <section
+            className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
+            style={{ '--rise': 1 }}
+          >
             <h2 className="frs-panel__title">{t('firstrun.installing_title', 'Installing')}</h2>
             {/* Overall journey meter — the same LED segments as the setup
                 screen's disk gate, now measuring progress instead of space. */}
@@ -546,14 +556,17 @@ export function BootstrapSplash({ stage, message }) {
         )}
 
         {/* ── Live log — always reachable, quiet by design ───────────────── */}
-        <section className="frs-panel frs-rise" style={{ '--rise': 2 }}>
+        <section
+          className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
+          style={{ '--rise': 2 }}
+        >
           <h2 className="frs-panel__title">
             {t('firstrun.activity_title', 'Activity')}
             <span className="frs-log__meta">
               {logs.length > 0 && t('bootstrap.lines', { count: logs.length })}
             </span>
           </h2>
-          <div className="frs-log__bar">
+          <div className="frs-log__bar flex items-center gap-[0.4rem]">
             <button
               type="button"
               className="frs-btn frs-btn--quiet"
@@ -585,7 +598,7 @@ export function BootstrapSplash({ stage, message }) {
         </section>
 
         <footer className="frs__foot frs-rise" style={{ '--rise': 3 }}>
-          <div className="frs__foot-row">
+          <div className="frs__foot-row flex items-center justify-between gap-[1rem]">
             <span className="frs__totals">
               <span className="frs__plate">OVS&thinsp;·&thinsp;v{APP_VERSION}</span>
             </span>

--- a/frontend/src/components/FirstRunSetup.css
+++ b/frontend/src/components/FirstRunSetup.css
@@ -46,17 +46,9 @@
 
 /* ── Deck: the whole console, borderless, wide ─────────────────────────── */
 
-.frs__deck {
-  position: relative;
-  width: 100%;
-  max-width: 1240px;
-  margin: 0;
-  flex: 1 1 auto;           /* fill the column height; the inner region scrolls */
-  min-height: 0;            /* let the inner scroll region shrink + scroll */
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
+/* .frs__deck base layout → Tailwind utilities in JSX
+   (relative w-full max-w-[1240px] m-0 flex flex-col flex-[1_1_auto] min-h-0 min-w-0).
+   The --focus max-width override below stays in CSS. */
 
 /* Scrollable region: masthead + decision grid. Only this scrolls — the action
    bar (.frs__foot) is a sibling below it, so it stays flush at the bottom with
@@ -95,17 +87,11 @@
 
 /* ── Masthead ──────────────────────────────────────────────────────────── */
 
-.frs__mast {
-  padding-bottom: 0.4rem;
-}
+/* .frs__mast → Tailwind utility in JSX (pb-[0.4rem]). */
 
-.frs__mast-row {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 2rem;
-  margin-top: 1rem;
-}
+/* .frs__mast-row base → Tailwind utilities in JSX
+   (flex items-end justify-between gap-[2rem] mt-[1rem]); the max-width:620px
+   column override below stays in CSS. */
 
 .frs__title {
   margin: 0;
@@ -125,19 +111,9 @@
   min-height: 2.4em;          /* two lines reserved — stage swaps don't shift */
 }
 
-.frs__mast-meta {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.45rem;
-  flex-shrink: 0;
-}
-
-.frs__mast-selects {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
+/* .frs__mast-meta → Tailwind utilities in JSX
+   (flex flex-col items-end gap-[0.45rem] shrink-0).
+   .frs__mast-selects → flex items-center gap-[0.5rem]. */
 
 /* Mirrors hang under the region select they extend; the fields open as a
    right-aligned column so the masthead stays balanced. */
@@ -192,29 +168,16 @@
 
 /* ── Wide grid: storage rail (left, 7fr) + decision rail (right, 5fr) ──── */
 
-.frs__grid {
-  display: grid;
-  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
-  gap: 1.1rem;
-  align-items: start;
-}
-
-.frs__col {
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-  min-width: 0;
-}
+/* .frs__grid base → Tailwind utilities in JSX
+   (grid grid-cols-[minmax(0,7fr)_minmax(0,5fr)] gap-[1.1rem] items-start);
+   the responsive single-column overrides below stay in CSS.
+   .frs__col → flex flex-col gap-[1.1rem] min-w-0. */
 
 /* ── Sections: no boxes — an engraved title rule and whitespace carry the
    structure. Borders appear only where state demands them. ─────────────── */
 
-.frs-panel {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
+/* .frs-panel base → Tailwind utilities in JSX
+   (relative flex flex-col gap-[0.6rem]); .frs-panel__title rule stays below. */
 
 .frs-panel__title {
   margin: 0;
@@ -294,12 +257,8 @@
     inset 0 0 2px rgba(255, 255, 255, 0.5);
 }
 
-.frs-opt__head {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
+/* .frs-opt__head → Tailwind utilities in JSX
+   (flex items-baseline gap-[0.5rem] flex-wrap). */
 
 .frs-opt__name { font-size: 0.82rem; font-weight: 650; letter-spacing: 0.01em; }
 
@@ -332,13 +291,8 @@
 
 /* ── Detected hardware readout (Compute panel) ─────────────────────────── */
 
-.frs__hw {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.1rem 0.1rem 0.3rem;
-  min-width: 0;
-}
+/* .frs__hw → Tailwind utilities in JSX
+   (flex items-center gap-[0.5rem] p-[0.1rem_0.1rem_0.3rem] min-w-0). */
 
 .frs__hw-dot {
   width: 6px;
@@ -416,15 +370,9 @@
   margin-top: 0.1rem;
 }
 
-.frs-row__gauge {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.3rem;
-  min-width: 170px;
-  flex-shrink: 0;
-}
-
+/* .frs-row__gauge base → Tailwind utilities in JSX
+   (flex flex-col items-end gap-[0.3rem] min-w-[170px] shrink-0); the
+   descendant meter rule + the max-width:980px overrides stay in CSS. */
 .frs-row__gauge .frs-meter { width: 100%; }
 
 /* One quiet line: "needs ~9 GB · 449 GB free". */
@@ -582,12 +530,9 @@
   border-top: 1px solid var(--frs-line);
 }
 
-.frs__foot-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
+/* .frs__foot-row base → Tailwind utilities in JSX
+   (flex items-center justify-between gap-[1rem]); the max-width:620px
+   column override below stays in CSS. */
 
 .frs__totals {
   display: inline-flex;
@@ -819,11 +764,7 @@
 
 /* ── Live log panel ────────────────────────────────────────────────────── */
 
-.frs-log__bar {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
+/* .frs-log__bar → Tailwind utilities in JSX (flex items-center gap-[0.4rem]). */
 
 .frs-log__meta {
   margin-left: auto;
@@ -860,12 +801,8 @@
   background: color-mix(in srgb, var(--frs-accent) 8%, transparent);
 }
 
-.frs-banner__actions {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
+/* .frs-banner__actions base → Tailwind utilities in JSX
+   (flex items-center gap-[0.4rem]); the --end modifier stays in CSS. */
 .frs-banner__actions--end { justify-content: flex-end; margin-top: 0.3rem; }
 
 /* ── Failure hints ─────────────────────────────────────────────────────── */
@@ -885,12 +822,9 @@
 
 /* ── Wizard chrome (model/engine selection act) ────────────────────────── */
 
-.frs-wsteps {
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  flex-wrap: wrap;
-}
+/* .frs-wsteps base → Tailwind utilities in JSX
+   (flex items-center gap-[0.9rem] flex-wrap); the --journey variant (gap +
+   margin-top + cursor) stays in CSS. */
 
 .frs-wstep {
   display: inline-flex;

--- a/frontend/src/components/FirstRunSetup.jsx
+++ b/frontend/src/components/FirstRunSetup.jsx
@@ -128,7 +128,7 @@ function StorageRow({ label, desc, path, need, check, onPick }) {
           {path}
         </code>
       </div>
-      <div className="frs-row__gauge">
+      <div className="frs-row__gauge flex flex-col items-end gap-[0.3rem] min-w-[170px] shrink-0">
         {(blocked || tight) && check?.freeBytes != null && (
           <CapacityMeter need={need} free={check.freeBytes} />
         )}
@@ -158,7 +158,10 @@ function StorageRow({ label, desc, path, need, check, onPick }) {
 /** Section: engraved mono title + rule — structure by line, not by box. */
 function Panel({ title, delay, className = '', children }) {
   return (
-    <section className={`frs-panel frs-rise ${className}`} style={{ '--rise': delay }}>
+    <section
+      className={`frs-panel frs-rise relative flex flex-col gap-[0.6rem] ${className}`}
+      style={{ '--rise': delay }}
+    >
       <h2 className="frs-panel__title">{title}</h2>
       {children}
     </section>
@@ -196,7 +199,7 @@ function OptionCard({ active, disabled, onSelect, name, desc, badge, compact }) 
       onClick={() => !disabled && onSelect()}
     >
       <span className="frs-opt__led" aria-hidden="true" />
-      <span className="frs-opt__head">
+      <span className="frs-opt__head flex items-baseline gap-[0.5rem] flex-wrap">
         <span className="frs-opt__name">{name}</span>
         {badge && <span className="frs-opt__badge">{badge}</span>}
       </span>
@@ -396,14 +399,18 @@ export default function FirstRunSetup() {
   return (
     <div className="frs">
       <div className="frs__atmo" aria-hidden="true" />
-      <div className="frs__deck">
+      <div className="frs__deck relative w-full max-w-[1240px] m-0 flex flex-col flex-[1_1_auto] min-h-0 min-w-0">
         <div className="frs__scroll">
           {/* ── Masthead: waveform + serif headline + serial plate ────────── */}
-          <header className="frs__mast frs-rise" style={{ '--rise': 0 }} data-tauri-drag-region>
+          <header
+            className="frs__mast frs-rise pb-[0.4rem]"
+            style={{ '--rise': 0 }}
+            data-tauri-drag-region
+          >
             <Waveform />
             {/* Journey rail: this page is stage 1 of the install flow. */}
             <nav
-              className="frs-wsteps frs-wsteps--journey"
+              className="frs-wsteps frs-wsteps--journey flex items-center gap-[0.9rem] flex-wrap"
               aria-label={t('firstrun.title', 'Set up OmniVoice Studio')}
             >
               <span className="frs-wstep is-active">
@@ -419,7 +426,7 @@ export default function FirstRunSetup() {
                 {t('firstrun.stage_models', 'Models & engines')}
               </span>
             </nav>
-            <div className="frs__mast-row">
+            <div className="frs__mast-row flex items-end justify-between gap-[2rem] mt-[1rem]">
               <div className="frs__mast-text">
                 <h1 className="frs__title">{t('firstrun.title', 'Set up OmniVoice Studio')}</h1>
                 <p className="frs__subtitle">
@@ -429,11 +436,11 @@ export default function FirstRunSetup() {
                   )}
                 </p>
               </div>
-              <div className="frs__mast-meta">
+              <div className="frs__mast-meta flex flex-col items-end gap-[0.45rem] shrink-0">
                 {/* Language + download region live together: the two "where am
                   I" choices, settled before anything else. Custom mirrors
                   hang quietly beneath them, where they belong. */}
-                <div className="frs__mast-selects">
+                <div className="frs__mast-selects flex items-center gap-[0.5rem]">
                   <select
                     className="frs-select frs-select--lang"
                     value={locale}
@@ -508,8 +515,8 @@ export default function FirstRunSetup() {
           </header>
 
           {/* ── Wide deck: storage rail (left) + decision rail (right) ────── */}
-          <div className="frs__grid">
-            <div className="frs__col frs__col--main">
+          <div className="frs__grid grid grid-cols-[minmax(0,7fr)_minmax(0,5fr)] gap-[1.1rem] items-start">
+            <div className="frs__col frs__col--main flex flex-col gap-[1.1rem] min-w-0">
               <Panel title={t('firstrun.mode_title', 'Install mode')} delay={1}>
                 <div
                   className="frs__options frs__options--two"
@@ -612,10 +619,13 @@ export default function FirstRunSetup() {
               </Panel>
             </div>
 
-            <div className="frs__col frs__col--side">
+            <div className="frs__col frs__col--side flex flex-col gap-[1.1rem] min-w-0">
               <Panel title={t('firstrun.compute_title', 'Compute')} delay={2}>
                 {hwLine && (
-                  <div className="frs__hw" title={hwLine}>
+                  <div
+                    className="frs__hw flex items-center gap-[0.5rem] p-[0.1rem_0.1rem_0.3rem] min-w-0"
+                    title={hwLine}
+                  >
                     <span className="frs__hw-dot" aria-hidden="true" />
                     <span className="frs__hw-label">
                       {t('firstrun.compute_detected', { defaultValue: 'Detected' })}
@@ -755,7 +765,7 @@ export default function FirstRunSetup() {
               )}
             </p>
           )}
-          <div className="frs__foot-row">
+          <div className="frs__foot-row flex items-center justify-between gap-[1rem]">
             <span className="frs__totals">
               <span className="frs__plate">OVS&thinsp;·&thinsp;v{APP_VERSION}</span>
               <span className="frs__totals-sep" aria-hidden="true">

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -84,7 +84,7 @@ function PreflightPanel({ report, loading, onRecheck }) {
   }
   if (!report) return null;
   return (
-    <section className="frs-panel">
+    <section className="frs-panel relative flex flex-col gap-[0.6rem]">
       <h2 className="frs-panel__title">
         {t('setup.system_preflight')}
         <button type="button" className="frs-btn frs-btn--quiet swiz-recheck" onClick={onRecheck}>
@@ -122,7 +122,7 @@ function StepperNav({ step, maxUnlockedStep, onStep }) {
     t('setup.try_dictation'),
   ];
   return (
-    <nav className="frs-wsteps" data-tauri-drag-region>
+    <nav className="frs-wsteps flex items-center gap-[0.9rem] flex-wrap" data-tauri-drag-region>
       {stepLabels.map((label, i) => (
         <button
           key={label}
@@ -200,16 +200,16 @@ export default function SetupWizard({ onReady }) {
   return (
     <div className="frs swiz">
       <div className="frs__atmo" aria-hidden="true" />
-      <div className="frs__deck">
+      <div className="frs__deck relative w-full max-w-[1240px] m-0 flex flex-col flex-[1_1_auto] min-h-0 min-w-0">
         {/* ── Masthead: identical identity to setup + install acts ──────── */}
         <header
-          className="frs__mast frs-rise"
+          className="frs__mast frs-rise pb-[0.4rem]"
           style={{ '--rise': 0 }}
           data-tauri-drag-region
           onDoubleClick={doubleClickMaximize}
         >
           <Waveform />
-          <div className="frs__mast-row">
+          <div className="frs__mast-row flex items-end justify-between gap-[2rem] mt-[1rem]">
             <div className="frs__mast-text">
               <h1 className="frs__title" data-tauri-drag-region>
                 OmniVoice Studio
@@ -218,7 +218,7 @@ export default function SetupWizard({ onReady }) {
                 {STEP_SUBTITLES[step]}
               </p>
             </div>
-            <div className="frs__mast-meta">
+            <div className="frs__mast-meta flex flex-col items-end gap-[0.45rem] shrink-0">
               <StepperNav
                 step={step}
                 maxUnlockedStep={preflightOk ? (modelsReady ? 2 : 1) : 0}
@@ -262,7 +262,10 @@ export default function SetupWizard({ onReady }) {
             ride in the same inventory. */}
         {step === 1 && (
           <div className="swiz-slide" key="step-1">
-            <section className="frs-panel frs-rise" style={{ '--rise': 1 }}>
+            <section
+              className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
+              style={{ '--rise': 1 }}
+            >
               <h2 className="frs-panel__title">{t('firstrun.stage_models', 'Models & engines')}</h2>
               <WizardLibrary />
               {!modelsReady && status?.missing?.length > 0 && (
@@ -297,7 +300,10 @@ export default function SetupWizard({ onReady }) {
             parity rule: some users genuinely don't want dictation). */}
         {step === 2 && (
           <div className="swiz-slide" key="step-2">
-            <section className="frs-panel frs-rise" style={{ '--rise': 1 }}>
+            <section
+              className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
+              style={{ '--rise': 1 }}
+            >
               <h2 className="frs-panel__title">{t('setup.try_dictation')}</h2>
               <div className="frs-embed">
                 <DictationDemo />
@@ -331,7 +337,7 @@ export default function SetupWizard({ onReady }) {
         )}
 
         <footer className="frs__foot">
-          <div className="frs__foot-row">
+          <div className="frs__foot-row flex items-center justify-between gap-[1rem]">
             <span className="frs__totals">
               {t('setup.footer_downloads')}
               <span className="frs__totals-sep" aria-hidden="true">


### PR DESCRIPTION
## What

Converts the **clearly-mechanical, low-risk layout rules** of the shared "studio console" sheet (`frontend/src/components/FirstRunSetup.css`) to Tailwind v4 utilities in its JSX consumers. This is a deliberately **partial** conversion — most of the 1020-line sheet stays in CSS.

CSS net: **-98 lines of rules, +32 breadcrumb comments** (1020 → 954 lines).

## Converted (15 static, layout-only rules)

- **Containers:** `.frs__deck`, `.frs__col`, `.frs-panel`, `.frs__grid`
- **Masthead:** `.frs__mast`, `.frs__mast-row`, `.frs__mast-meta`, `.frs__mast-selects`, `.frs-wsteps`
- **Misc layout:** `.frs-opt__head`, `.frs__hw`, `.frs-row__gauge`, `.frs__foot-row`, `.frs-log__bar`, `.frs-banner__actions`

Touched: `FirstRunSetup.jsx`, `BootstrapSplash.jsx`, `SetupWizard.jsx` (every consumer of the converted classes).

## How (rules honored)

- **No preflight** in this app (only `theme.css` + `utilities.css` imported), so exact rem/px are preserved with arbitrary values (`gap-[1.1rem]`, `grid-cols-[minmax(0,7fr)_minmax(0,5fr)]`, `p-[0.1rem_0.1rem_0.3rem]`, `flex-[1_1_auto]`, …) — no reliance on preflight-provided defaults.
- Component CSS is **unlayered** (would beat `@layer utilities`), so each converted base rule is **removed** from CSS and replaced with a one-line breadcrumb.
- Every remaining override stays in CSS and still wins because it is unlayered: responsive **media queries** (`.frs__grid` / `.frs__mast-row` / `.frs__foot-row` / `.frs-row__gauge`), **modifier classes** (`.frs__deck--focus`, `.frs-banner__actions--end`, `.frs-wsteps--journey`), and **descendant rules** (`.frs-row__gauge .frs-meter`).

## Kept in CSS (by design)

All `@keyframes`/animations (rise, breathe, alarm, hw-pulse, meter), `::before`/`::after`, glass/masks, `color-mix` backgrounds, hover/focus/state rules (`.is-active`, `.is-armed`, …), typography, and media queries. Cross-file / combinator-bound classes (`.frs-wnav`, `.frs-embed`, `.frs-row*`, `.frs-check*`) were left as CSS.

## Verification

- `npx oxlint` → exit 0 (only pre-existing warnings)
- `npx oxfmt --write src && npx oxfmt --check .` → clean
- `npx vite build` → OK
- `npx vitest run` → **641 passing**
- `bun install --frozen-lockfile` → no change

No visual test exists for this flow; conversions were kept conservative and behavior-preserving (exact values, overrides retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Partial Tailwind migration for the first-run/setup “studio console” layout. The PR moves a small set of static container/layout rules out of `FirstRunSetup.css` and into the JSX consumers, while leaving typography, animations, pseudo-elements, media queries, and state/descendant rules in CSS.

Affected areas:
- deck/container sizing and centering
- masthead/header/meta/selects layout
- grid/columns and panel wrappers
- option header, hardware row, gauge row, footer row
- banner actions and wizard step rail
- live log / splash panel wrappers

Layout sketch:

Before
```
[ deck ]
  [ masthead ]
  [ grid / cols ]
    [ panel ]
    [ panel ]
  [ footer row ]
```

After
```
[ centered deck ]
  [ masthead (flex) ]
  [ grid / cols (tailwind) ]
    [ relative flex panel ]
    [ relative flex panel ]
  [ flex footer row ]
```

CSS cleanup:
- removed the base layout rules for the converted classes from `FirstRunSetup.css`
- kept the remaining component-specific styling intact so existing overrides still work

Verification reported:
- `npx oxlint`
- `npx oxfmt --write src && npx oxfmt --check .`
- `npx vite build`
- `npx vitest run` (641 passing)
- `bun install --frozen-lockfile`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->