### PR TITLE
feat(ui): convert DubTab page layout CSS to Tailwind utilities (partial; complex/stateful CSS kept)

### DIFF
--- a/frontend/src/components/dub/DubFailureNotice.jsx
+++ b/frontend/src/components/dub/DubFailureNotice.jsx
@@ -21,9 +21,9 @@ function DubFailureNotice({ failure }) {
     }
   };
   return (
-    <div className="dub-failure-notice">
-      {failure.hint && <span className="dub-failure-notice__hint">{failure.hint}</span>}
-      <div className="dub-failure-notice__actions">
+    <div className="flex flex-col gap-[4px] mt-[4px]">
+      {failure.hint && <span className="text-[11px] opacity-[0.85]">{failure.hint}</span>}
+      <div className="flex gap-[6px] flex-wrap">
         {topic && (
           <Button variant="subtle" size="sm" onClick={() => openDocsFor(topic)}>
             <ExternalLink size={11} /> {t('dub.open_docs')}

--- a/frontend/src/components/dub/DubFooter.jsx
+++ b/frontend/src/components/dub/DubFooter.jsx
@@ -17,26 +17,26 @@ export default function DubFooter({
   return (
     <div className="studio-panel dub-footer-panel">
       {dubStep === 'done' && (
-        <div className="dub-footer-banner">
+        <div className="mb-[var(--space-2)]">
           <Badge tone="success">
             <Check size={11} /> {t('dub.tracks_done', { tracks: dubTracks.join(', ') })}
           </Badge>
           {incrementalPlan && incrementalPlan.stale?.length > 0 && (
-            <Badge tone="warn" className="dub-footer-banner__badge-gap">
+            <Badge tone="warn" className="ml-[6px]">
               {t('dub.segments_changed', { count: incrementalPlan.stale.length })}
             </Badge>
           )}
           {incrementalPlan &&
             incrementalPlan.stale?.length === 0 &&
             incrementalPlan.fresh?.length > 0 && (
-              <Badge tone="neutral" className="dub-footer-banner__badge-gap">
+              <Badge tone="neutral" className="ml-[6px]">
                 {t('dub.all_up_to_date', { count: incrementalPlan.fresh.length })}
               </Badge>
             )}
         </div>
       )}
       {dubError && (
-        <div className="dub-footer-banner">
+        <div className="mb-[var(--space-2)]">
           <Badge tone="danger">
             <AlertCircle size={11} /> {dubError}
           </Badge>

--- a/frontend/src/components/dub/DubHeader.jsx
+++ b/frontend/src/components/dub/DubHeader.jsx
@@ -33,18 +33,22 @@ export default function DubHeader({
   setExportOpen,
 }) {
   return (
-    <div className="dub-head">
+    <div className="flex justify-between items-center px-[12px] py-[5px] shrink-0 bg-[rgba(255,255,255,0.015)] [border:1px_solid_rgba(255,255,255,0.04)] rounded-md mb-[2px]">
       <div className="label-row dub-head__title">
         <FileText className="label-icon" size={11} />
-        <span className="dub-head__filename">{dubFilename}</span>
-        <span className="dub-head__meta">
+        <span className="font-semibold text-[0.85rem] overflow-hidden text-ellipsis whitespace-nowrap text-fg">
+          {dubFilename}
+        </span>
+        <span className="text-fg-muted font-normal whitespace-nowrap text-[0.72rem]">
           · {formatTime(dubDuration)} · {dubSegments.length} {t('dub.segs')}
         </span>
         {activeProjectName && activeProjectName !== dubFilename && (
-          <span className="dub-head__project">— {activeProjectName}</span>
+          <span className="text-[#b8bb26] ml-[var(--space-3)] whitespace-nowrap text-[0.72rem]">
+            — {activeProjectName}
+          </span>
         )}
       </div>
-      <div className="dub-head__actions">
+      <div className="flex gap-[var(--space-2)] items-center shrink-0">
         {/* Icon-only secondary actions (tooltips carry the labels);
                   Generate Dub keeps its label as the primary verb. */}
         <Button
@@ -66,7 +70,7 @@ export default function DubHeader({
           <RotateCcw size={12} />
         </Button>
         {/* Primary actions live on the header bar (compact) — moved up from the footer. */}
-        <div className="dub-head__primary">
+        <div className="flex gap-[var(--space-2)] items-center pl-[var(--space-2)] [border-left:1px_solid_var(--color-border,#3a3a3a)]">
           {dubStep === 'stopping' ? (
             <FooterBtn
               sm

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -7,7 +7,7 @@ import { LANG_CODES } from '../../utils/languages';
 
 const DubSegmentTable = lazy(() => import('../DubSegmentTable'));
 
-const LazyFallback = () => <div className="dub-lazy-fallback">Loading…</div>;
+const LazyFallback = () => <div className="p-[12px] text-[#6b6657] text-[0.7rem]">Loading…</div>;
 
 export default function DubRightColumn({
   t,
@@ -200,7 +200,7 @@ export default function DubRightColumn({
 
       {selectedSegIds.size > 0 && (
         <div className="dub-bulk-row dub-bulk-row--select">
-          <span className="dub-bulk-row__label-brand">
+          <span className="text-brand font-bold whitespace-nowrap">
             {t('dub.selected_count', { count: selectedSegIds.size })}
           </span>
           <select

--- a/frontend/src/components/dub/IdleSkeleton.jsx
+++ b/frontend/src/components/dub/IdleSkeleton.jsx
@@ -67,24 +67,26 @@ export default function IdleSkeleton({
   setDubInstruct,
 }) {
   return (
-    <div className="dub-col">
+    <div className="flex-1 flex flex-col min-h-0">
       {/* Header bar */}
-      <div className="dub-head">
+      <div className="flex justify-between items-center px-[12px] py-[5px] shrink-0 bg-[rgba(255,255,255,0.015)] [border:1px_solid_rgba(255,255,255,0.04)] rounded-md mb-[2px]">
         <div className="label-row dub-head__title">
           <Film className="label-icon" size={11} />
-          <span className="dub-head__filename">
+          <span className="font-semibold text-[0.85rem] overflow-hidden text-ellipsis whitespace-nowrap text-fg">
             {dubVideoFile ? dubVideoFile.name : t('dub.video_dubbing_studio')}
           </span>
           {dubVideoFile && (
-            <span className="dub-head__meta">
+            <span className="text-fg-muted font-normal whitespace-nowrap text-[0.72rem]">
               · {(dubVideoFile.size / 1024 / 1024).toFixed(1)} MB
             </span>
           )}
           {activeProjectName && activeProjectName !== dubFilename && (
-            <span className="dub-head__project">— {activeProjectName}</span>
+            <span className="text-[#b8bb26] ml-[var(--space-3)] whitespace-nowrap text-[0.72rem]">
+              — {activeProjectName}
+            </span>
           )}
         </div>
-        <div className="dub-head__actions">
+        <div className="flex gap-[var(--space-2)] items-center shrink-0">
           <Button
             variant="subtle"
             size="sm"
@@ -111,7 +113,7 @@ export default function IdleSkeleton({
               Surfaces the backend error detail and offers one-click retry,
               which re-runs the ASR stream on the same job without re-uploading. */}
       {dubError && dubJobId && dubStep === 'idle' && (
-        <div className="dub-footer-banner">
+        <div className="mb-[var(--space-2)]">
           <Badge tone="danger">
             <AlertCircle size={11} /> {dubError}
           </Badge>
@@ -151,7 +153,9 @@ export default function IdleSkeleton({
       )}
 
       {/* SPLIT LAYOUT skeleton */}
-      <div className={`dub-split-grid ${dubVideoFile ? 'dub-split-2' : 'dub-split-1'}`}>
+      <div
+        className={`dub-split-grid ${dubVideoFile ? 'grid grid-cols-2 gap-[6px] flex-1 min-h-0 overflow-hidden' : 'grid grid-cols-1 gap-[6px] flex-1 min-h-0'}`}
+      >
         {/* LEFT */}
         <div className="studio-panel dub-panel-col">
           {dubVideoFile ? (
@@ -177,7 +181,7 @@ export default function IdleSkeleton({
                   ) : null
                 }
               />
-              <div className="dub-change-row">
+              <div className="flex gap-[8px] mt-[8px] items-center">
                 <label htmlFor="video-upload" className="dub-idle-upload-label">
                   <Film size={13} /> {t('dub.change_file')}
                 </label>
@@ -202,7 +206,10 @@ export default function IdleSkeleton({
                     />
                   </label>
                 )}
-                <label className="dub-speakers-hint" title={t('dub.num_speakers_help')}>
+                <label
+                  className="inline-flex items-center gap-[5px] text-[12px] text-[var(--muted,#a89984)] whitespace-nowrap"
+                  title={t('dub.num_speakers_help')}
+                >
                   <Users size={13} /> {t('dub.num_speakers_label')}
                   <input
                     type="number"

--- a/frontend/src/components/dub/PrepOverlay.jsx
+++ b/frontend/src/components/dub/PrepOverlay.jsx
@@ -77,7 +77,7 @@ function PrepOverlay({ stage, progress, onAbort, large = false }) {
   const body = (
     <>
       <Loader className="spinner" size={large ? 28 : 20} color="#d3869b" />
-      <span className="dub-prep-overlay__title" style={{ fontSize: large ? '0.95rem' : '0.85rem' }}>
+      <span className="text-fg font-medium" style={{ fontSize: large ? '0.95rem' : '0.85rem' }}>
         {LABEL[stage] || t('dub.prep_preparing')}
       </span>
       {hasPct && (
@@ -86,9 +86,13 @@ function PrepOverlay({ stage, progress, onAbort, large = false }) {
         </div>
       )}
       {detailBits.length > 0 && (
-        <span className="dub-prep-overlay__detail">{detailBits.join(' · ')}</span>
+        <span className="text-[var(--text-xs)] text-fg-subtle [font-variant-numeric:tabular-nums] tracking-[0.02em]">
+          {detailBits.join(' · ')}
+        </span>
       )}
-      <div className={`dub-prep-chips ${large ? 'dub-prep-chips--lg' : ''}`}>
+      <div
+        className={`flex gap-[var(--space-2)] text-[var(--text-xs)] text-fg-subtle ${large ? 'dub-prep-chips--lg' : ''}`}
+      >
         {stages.map((s) => (
           <span
             key={s}
@@ -98,16 +102,22 @@ function PrepOverlay({ stage, progress, onAbort, large = false }) {
           </span>
         ))}
       </div>
-      {note && <span className="dub-prep-overlay__note">{note}</span>}
+      {note && (
+        <span className="text-[var(--text-xs)] text-fg-subtle max-w-[min(320px,90vw)] text-center">
+          {note}
+        </span>
+      )}
       <Button variant="danger" size="sm" onClick={onAbort} leading={<Square size={11} />}>
         {t('dub.prep_stop')}
       </Button>
     </>
   );
   return large ? (
-    <div className="dub-prep-overlay dub-prep-overlay--large">{body}</div>
+    <div className="flex flex-col items-center gap-[var(--space-5)] dub-prep-overlay--large">
+      {body}
+    </div>
   ) : (
-    <div className="dub-prep-overlay">{body}</div>
+    <div className="flex flex-col items-center gap-[var(--space-5)]">{body}</div>
   );
 }
 

--- a/frontend/src/components/dub/TranscribeOverlay.jsx
+++ b/frontend/src/components/dub/TranscribeOverlay.jsx
@@ -11,10 +11,10 @@ function TranscribeOverlay({ elapsed, duration, onAbort }) {
   const mm = Math.floor(elapsed / 60);
   const ss = String(elapsed % 60).padStart(2, '0');
   return (
-    <div className="dub-trans-overlay">
-      <div className="dub-trans-overlay__head">
+    <div className="flex flex-col items-center gap-[var(--space-5)] w-full">
+      <div className="flex items-center gap-[var(--space-4)]">
         <Loader className="spinner" size={18} color="#d3869b" />
-        <span className="dub-trans-overlay__title">{t('dub.transcribing')}</span>
+        <span className="text-fg font-medium text-[var(--text-lg)]">{t('dub.transcribing')}</span>
       </div>
       <div className="dub-trans-overlay__stats">
         <span>
@@ -28,7 +28,7 @@ function TranscribeOverlay({ elapsed, duration, onAbort }) {
         )}
       </div>
       {duration > 0 && (
-        <div className="dub-trans-overlay__bar">
+        <div className="w-[80%] max-w-[340px]">
           <Progress value={Math.min(95, (elapsed / est) * 100)} tone="brand" size="sm" />
         </div>
       )}

--- a/frontend/src/pages/DubTab.css
+++ b/frontend/src/pages/DubTab.css
@@ -4,25 +4,11 @@
 /* Top-bar — anchors to the top of the workspace, claims the full width
    above the video + segment-table split. Drop the card chrome so it reads
    as a header strip, not a floating panel. */
-.dub-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 5px 12px;
-  flex-shrink: 0;
-  background: rgba(255, 255, 255, 0.015);
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  border-radius: var(--radius-md);
-  margin: 0 0 2px 0;
-}
+/* .dub-head strip + filename/meta/project/actions/primary → Tailwind utilities
+   (DubHeader.jsx, IdleSkeleton.jsx). .dub-head__title stays: it coexists with
+   the unlayered global .label-row rule (which it overrides), so a utility would
+   lose to it. */
 .dub-head__title     { display: flex; align-items: center; gap: var(--space-3); margin-bottom: 0; min-width: 0; flex: 1; }
-.dub-head__actions   { display: flex; gap: var(--space-2); align-items: center; flex-shrink: 0; }
-/* Primary actions (Generate/Export/Stop) relocated onto the header bar; a thin
-   divider separates them from Save/Reset and sm FooterBtns keep it compact. */
-.dub-head__primary   { display: flex; gap: var(--space-2); align-items: center; padding-left: var(--space-2); border-left: 1px solid var(--color-border, #3a3a3a); }
-.dub-head__filename  { font-weight: var(--weight-semibold); font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--color-fg); }
-.dub-head__meta      { color: var(--color-fg-muted); font-weight: 400; white-space: nowrap; font-size: 0.72rem; }
-.dub-head__project   { color: #b8bb26; margin-left: var(--space-3); white-space: nowrap; font-size: 0.72rem; }
 
 /* ── Preview toggle wrapper (above waveform) ─────────────────── */
 .dub-preview-toggle {
@@ -52,12 +38,8 @@
 }
 
 /* ── Prep stage chips (upload/preparation flow) ──────────────── */
-.dub-prep-chips {
-  display: flex;
-  gap: var(--space-2);
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-}
+/* .dub-prep-chips container → utilities (PrepOverlay.jsx). The --lg modifier and
+   the .dub-prep-chip items below stay (state/modifier combinators). */
 .dub-prep-chip {
   padding: 1px 6px;
   border-radius: var(--radius-xs);
@@ -79,12 +61,8 @@
 .dub-prep-chips--lg .dub-prep-chip.is-active { font-weight: var(--weight-semibold); }
 
 /* ── Prep / Transcribe overlays ──────────────────────────────── */
-.dub-prep-overlay {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-5);
-}
+/* .dub-prep-overlay base + __title/__note/__detail → utilities (PrepOverlay.jsx).
+   The --large modifier (and its descendant .dub-prep-bar override) stays. */
 .dub-prep-overlay--large {
   flex: 1;
   justify-content: center;
@@ -94,22 +72,6 @@
   border: 2px dashed rgba(211, 134, 155, 0.2);
   border-radius: var(--radius-xl);
   background: rgba(211, 134, 155, 0.03);
-}
-.dub-prep-overlay__title {
-  color: var(--color-fg);
-  font-weight: var(--weight-medium);
-}
-.dub-prep-overlay__note {
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-  max-width: min(320px, 90vw);
-  text-align: center;
-}
-.dub-prep-overlay__detail {
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.02em;
 }
 .dub-prep-bar {
   width: min(240px, 85vw);
@@ -126,32 +88,13 @@
   transition: width 220ms ease-out;
 }
 
-.dub-trans-overlay {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-5);
-  width: 100%;
-}
-.dub-trans-overlay__head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-}
-.dub-trans-overlay__title {
-  color: var(--color-fg);
-  font-weight: var(--weight-medium);
-  font-size: var(--text-lg);
-}
+/* .dub-trans-overlay base + __head/__title/__bar → utilities (TranscribeOverlay.jsx).
+   __stats stays: it's targeted by the unlayered global tabular-nums rule in index.css. */
 .dub-trans-overlay__stats {
   display: flex;
   gap: var(--space-6);
   font-size: var(--text-md);
   color: var(--color-fg-muted);
-}
-.dub-trans-overlay__bar {
-  width: 80%;
-  max-width: 340px;
 }
 
 /* ── Bulk selection + Apply-voice rows ───────────────────────── */
@@ -168,10 +111,10 @@
 .dub-bulk-row--select { background: rgba(211, 134, 155, 0.08); border: 1px solid rgba(211, 134, 155, 0.25); }
 
 .dub-bulk-row__label-success { color: var(--color-success); font-weight: var(--weight-bold); white-space: nowrap; }
-.dub-bulk-row__label-brand   { color: var(--color-brand);   font-weight: var(--weight-bold); white-space: nowrap; }
+/* .dub-bulk-row__label-brand → utilities (DubRightColumn.jsx). */
 
 /* ── Footer status banner ────────────────────────────────────── */
-.dub-footer-banner { margin-bottom: var(--space-2); }
+/* .dub-footer-banner → utilities (DubFooter.jsx, IdleSkeleton.jsx). */
 .dub-footer-banner__badge { display: inline-flex; }
 
 /* ── Output options row (checkboxes + default track) ─────────── */
@@ -258,10 +201,10 @@
 .dub-compression-warn strong { color: #fabd2f; font-weight: var(--weight-semibold); }
 
 /* ── Utility: column flex that fills remaining height ────────── */
-.dub-col            { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+/* .dub-col + .dub-split-1/.dub-split-2 → utilities (DubTab.jsx, IdleSkeleton.jsx).
+   .dub-panel-col stays: it sits on .studio-panel (unlayered) and overrides its
+   overflow, so a utility would lose. */
 .dub-panel-col      { margin-bottom: 0; overflow: hidden; display: flex; flex-direction: column; }
-.dub-split-2        { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; flex: 1; min-height: 0; overflow: hidden; }
-.dub-split-1        { display: grid; grid-template-columns: 1fr; gap: 6px; flex: 1; min-height: 0; }
 
 /* ── Idle / drop-zone skeleton ───────────────────────────────── */
 .dub-idle-drop {
@@ -350,9 +293,10 @@
 
 .dub-hidden-file { display: none; }
 
-.dub-change-row       { display: flex; gap: 8px; margin-top: 8px; align-items: center; }
+/* .dub-change-row + .dub-speakers-hint → utilities (IdleSkeleton.jsx).
+   .dub-change-row__cta stays: it sits on .btn-primary (unlayered) and overrides
+   its margin-top, so a utility would lose. */
 .dub-change-row__cta  { flex: 1; margin-top: 0; }
-.dub-speakers-hint    { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--muted, #a89984); white-space: nowrap; }
 .dub-speakers-input   { width: 52px; margin-left: 4px; padding: 4px 6px; border-radius: 6px; border: 1px solid var(--border, #3c3836); background: var(--input-bg, #282828); color: inherit; font-size: 12px; }
 
 /* Compact disabled inputs in the idle skeleton */
@@ -632,9 +576,9 @@
 .dub-bulk-row__clear           { margin-left: auto; }
 
 /* Footer banner gapping */
-.dub-footer-banner__badge-gap  { margin-left: 6px; }
+/* .dub-footer-banner__badge-gap → utilities (DubFooter.jsx). */
 
-.dub-lazy-fallback             { padding: 12px; color: #6b6657; font-size: 0.7rem; }
+/* .dub-lazy-fallback → utilities (DubRightColumn.jsx). */
 
 /* ── Landing options — the one pre-upload decision + Advanced disclosure ── */
 .dub-landing-opts {
@@ -961,22 +905,8 @@
   background: color-mix(in srgb, #fe8019 10%, transparent) !important;
 }
 
-/* plan-04 (#131): actionable failure detail beneath the error badge. */
-.dub-failure-notice {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-top: 4px;
-}
-.dub-failure-notice__hint {
-  font-size: 11px;
-  opacity: 0.85;
-}
-.dub-failure-notice__actions {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
+/* plan-04 (#131): actionable failure detail beneath the error badge.
+   .dub-failure-notice + __hint/__actions → Tailwind utilities (DubFailureNotice.jsx). */
 
 /* ── Reduced motion (10x P4, spec §3): shimmer/pulse die; the stepper
    spinner holds a static frame. ───────────────────────────────────────── */

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -407,7 +407,7 @@ export default function DubTab(props) {
   }, [dubJobId, qcRunning, previewMode, dubSegments, setDubSegments, t]);
 
   return (
-    <div className="dub-col">
+    <div className="flex-1 flex flex-col min-h-0">
       {/* Pipeline spine — shown once a file/job is in play so the user always
           knows which stage they're at (Upload → … → Export). */}
       {(dubVideoFile || dubJobId || dubStep !== 'idle') && <DubPipelineStepper dubStep={dubStep} />}
@@ -457,7 +457,7 @@ export default function DubTab(props) {
 
       {/* ── After transcription: side-by-side editor ── */}
       {dubJobId && (dubStep === 'editing' || dubStep === 'generating' || dubStep === 'done') && (
-        <div className="dub-col">
+        <div className="flex-1 flex flex-col min-h-0">
           <DubHeader
             t={t}
             dubFilename={dubFilename}
@@ -478,7 +478,7 @@ export default function DubTab(props) {
             handleDubQc={handleDubQc}
             setExportOpen={setExportOpen}
           />
-          <div className="dub-split-grid dub-split-2">
+          <div className="dub-split-grid grid grid-cols-2 gap-[6px] flex-1 min-h-0 overflow-hidden">
             <DubLeftColumn
               hasDubbedTrack={hasDubbedTrack}
               t={t}


### PR DESCRIPTION
## What

Converts the **safe, mechanical** layout/spacing/typography/simple-color rules on the DubTab page (and its `components/dub/*` section components) from `DubTab.css` to Tailwind v4 utilities. Each converted rule is **removed from the CSS** so the unlayered page CSS can't shadow the `@layer utilities` output. This is a deliberately **partial** conversion — complex/stateful CSS stays in CSS.

`DubTab.css`: **989 → 919 lines** (92 CSS lines removed, 22 explanatory notes added).

## Converted (rule removed from CSS + utilities applied in JSX)

- **DubHeader / IdleSkeleton:** `.dub-head` strip, `__filename` / `__meta` / `__project` / `__actions` / `__primary`
- **PrepOverlay:** `.dub-prep-overlay` base, `.dub-prep-chips` base, `__title` / `__note` / `__detail`
- **TranscribeOverlay:** `.dub-trans-overlay` base, `__head` / `__title` / `__bar`
- **DubFailureNotice:** `.dub-failure-notice` + `__hint` / `__actions`
- **DubFooter / IdleSkeleton:** `.dub-footer-banner`, `__badge-gap`
- **DubRightColumn:** `.dub-bulk-row__label-brand`, `.dub-lazy-fallback`
- **DubTab / IdleSkeleton:** `.dub-col`, `.dub-split-1`, `.dub-split-2`
- **IdleSkeleton:** `.dub-change-row`, `.dub-speakers-hint`

## Kept in CSS (and why)

- `.dub-head__title` — coexists with the **unlayered global `.label-row`** rule it overrides (a utility would lose the cascade).
- `.dub-panel-col` / `.dub-ghost-footer` — sit on `.studio-panel`, override its `overflow`/`padding` (unlayered would win).
- `.dub-change-row__cta` — sits on `.btn-primary`, overrides its `margin-top`.
- `.dub-trans-overlay__stats` — targeted by the global `tabular-nums` rule in `index.css`.
- `.dub-prep-bar` / `__fill`, `.dub-prep-chip`, `--large` / `--lg` modifiers — combinators / state / animation.
- `.dub-hidden-file` — used outside the converted files.
- All `@keyframes`/animations, `::before`, `:has()`/combinators, `!important`, media queries, chrome-token surfaces, the pipeline stepper, skeleton shimmer bars, the footer-btn family, etc.

## Fidelity notes

- Spacing / text / chrome tokens → arbitrary `var()`/px utilities (exact pixels).
- `@theme` colors + radius + weight → named utilities (`text-fg`, `rounded-md`, `font-semibold`, …).
- Borders use the arbitrary `[border:1px_solid_…]` form (app ships Tailwind v4 **without preflight**, so bare `border` renders nothing).

## Verification

- `npx oxlint` → exit 0 (only pre-existing warnings)
- `npx oxfmt --write src && npx oxfmt --check .` → clean
- `npx vite build` → OK
- `npx vitest run` → **641 passed**
- `bun install --frozen-lockfile` → no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Converted the DubTab page and related `components/dub/*` UI from page CSS hooks to Tailwind v4 utilities for the safe, mechanical layout/spacing/typography cases.

### What changed
- Reworked `DubHeader`, `DubFooter`, `DubFailureNotice`, `DubRightColumn`, `IdleSkeleton`, `PrepOverlay`, `TranscribeOverlay`, and `DubTab` markup to use utility classes.
- Simplified `DubTab.css` by removing styles that were moved to utilities, while keeping stateful/special-case rules in CSS.
- Preserved complex selectors and behaviors in CSS where needed (`:has()`, media queries, keyframes, pseudo-elements, modifier/state rules, and other cascade-sensitive styles).

### Layout sketch

**Before**
```text
DubTab
├─ .dub-head
│  ├─ filename/meta
│  └─ primary actions
├─ split layout (.dub-split-2 / .dub-col)
│  ├─ left panel
│  └─ right column
└─ footer / overlays
   ├─ banner classes
   ├─ prep/transcribe overlay classes
   └─ failure notice BEM blocks
```

**After**
```text
DubTab
├─ flex/grid utility header
│  ├─ truncated title + metadata
│  └─ action group with border/spacing utilities
├─ utility-based split layout
│  ├─ left panel
│  └─ right column
└─ utility-based footer / overlays
   ├─ spacing-only banners
   ├─ Tailwind-styled prep/transcribe overlays
   └─ utility-styled failure notice
```

### Verification
- `oxlint` passes
- `oxfmt` clean
- `vite build` succeeds
- `vitest` passes (641 tests)
- `bun install --frozen-lockfile` makes no changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->