### PR TITLE
feat(ui): convert StoriesEditor + LogsFooter CSS to Tailwind utilities (partial)

### DIFF
--- a/frontend/src/components/LogsFooter.css
+++ b/frontend/src/components/LogsFooter.css
@@ -53,47 +53,13 @@
   min-height: 180px;
 }
 
-/* Drag handle — 4 px strip on the top edge. Cursor + subtle hover
-   hint so it feels grabbable. */
-.logs-footer__resize {
-  position: absolute;
-  top: -2px;
-  left: 0;
-  right: 0;
-  height: 5px;
-  cursor: ns-resize;
-  z-index: 1;
-}
-.logs-footer__resize:hover {
-  background: var(--chrome-accent-border);
-}
-
-/* Top bar — always visible */
-.logs-footer__bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 28px;
-  padding: 0 8px;
-  gap: 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-  flex-shrink: 0;
-}
-.logs-footer__left {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  flex: 1;
-  overflow: hidden;
-}
-.logs-footer__title {
-  color: var(--chrome-fg-muted);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-right: 4px;
-}
+/* Drag handle, top bar, left/right clusters, title, badge base, log-line base,
+   and the notification panel layout now live as Tailwind utilities in
+   LogsFooter.jsx. What stays here is the chrome chrome: the fixed footer shell
+   (it's the anchor for the `.app-container .logs-footer` inset combinators + the
+   ≤600px media query), every interactive button with its hover/disabled/animation
+   states, the severity color modifiers + their descendant overrides, scrollbar
+   pseudo-elements, and the @keyframes. */
 /* Thin vertical divider between the UI-scale toggle (leftmost) and the
    Logs title + source pills. Keeps the two distinct control groups from
    visually running into each other. */
@@ -180,23 +146,6 @@
 .logs-footer__pill--warn {
   color: #fabd2f;
 }
-.logs-footer__pill-label {
-  font-weight: 500;
-}
-.logs-footer__badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  padding: 0 5px;
-  height: 14px;
-  border-radius: 7px;
-  font-size: 10px;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--chrome-fg);
-  font-family: var(--chrome-font-mono);
-}
 .logs-footer__badge--error {
   background: rgba(251, 73, 52, 0.2);
   color: #fb4934;
@@ -207,18 +156,6 @@
 }
 
 /* Action buttons on the right */
-.logs-footer__right {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
-}
-.logs-footer__actions {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-}
-
 /* Clickable app-version badge → Settings → Updates (sits by the network icon) */
 .logs-footer__version {
   background: none;
@@ -361,89 +298,29 @@
 .logs-footer__body::-webkit-scrollbar        { width: 8px; height: 8px; }
 .logs-footer__body::-webkit-scrollbar-thumb  { background: rgba(255, 255, 255, 0.08); border-radius: 4px; }
 .logs-footer__body::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.15); }
-.logs-footer__empty {
-  padding: 12px;
-  color: var(--chrome-fg-dim);
-  font-style: normal;
-  font-size: 11px;
-  text-align: center;
-}
 
-.logs-footer__line {
-  display: flex;
-  align-items: flex-start;
-  gap: 6px;
-  padding: 1px 2px;
-  border-radius: 2px;
-}
 .logs-footer__line--error {
   background: rgba(251, 73, 52, 0.06);
 }
 .logs-footer__line--warn {
   background: rgba(250, 189, 47, 0.04);
 }
-.logs-footer__line-icon {
-  padding-top: 2px;
-  flex-shrink: 0;
-}
-.logs-footer__line-text {
-  margin: 0;
-  padding: 0;
-  font-family: inherit;
-  font-size: 11.5px;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-  color: #ebdbb2;
-  flex: 1;
-}
+/* line-text base lives in JSX utilities; these severity overrides recolor it. */
 .logs-footer__line--error .logs-footer__line-text { color: #fb4934; }
 .logs-footer__line--warn  .logs-footer__line-text { color: #fabd2f; }
 
 /* ── Notification panel in footer ────────────────────────────────── */
-
-.logs-footer__notif-body {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 6px 8px;
-}
-
-.logs-footer__notif-item {
-  display: flex;
-  gap: 8px;
-  align-items: flex-start;
-  padding: 8px 10px;
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid transparent;
-}
-.logs-footer__notif-item:hover { background: rgba(255, 255, 255, 0.04); }
+/* notif-body / notif-item base+hover / notif-icon / notif-content layout /
+   notif-msg / notif-action are utilities in JSX. The severity border-left
+   modifiers, the clickable hover, and the `notif-content strong` rule stay. */
 
 .logs-footer__notif-item--warn  { border-left: 2px solid #fabd2f; }
 .logs-footer__notif-item--error { border-left: 2px solid #fb4934; }
 .logs-footer__notif-item--info  { border-left: 2px solid #83a598; }
 
-.logs-footer__notif-icon {
-  flex-shrink: 0;
-  margin-top: 2px;
-}
-
-.logs-footer__notif-content {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: 1;
-  min-width: 0;
-}
 .logs-footer__notif-content strong {
   font-size: 12px;
   color: var(--color-fg);
-}
-.logs-footer__notif-msg {
-  font-size: 11px;
-  color: var(--color-fg-muted);
-  line-height: 1.5;
 }
 
 .logs-footer__notif-link {
@@ -488,14 +365,6 @@
 
 .logs-footer__notif-item--clickable { cursor: pointer; }
 .logs-footer__notif-item--clickable:hover { background: rgba(255, 255, 255, 0.06); }
-
-.logs-footer__notif-action {
-  flex-shrink: 0;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--color-brand);
-  white-space: nowrap;
-}
 
 /* ── Reduced motion (10x P4, spec §3): the heart stops glowing; the
    refresh spinner holds a static frame. ───────────────────────────────── */

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -92,6 +92,13 @@ function SeverityIcon({ level, size = 11 }) {
 // fields (uiScale, theme, setUiScale, setTheme) are unchanged; only the
 // rendering moved.
 
+// Count badge base (layout/typography). The severity color variants
+// (--error/--warn) remain in LogsFooter.css.
+const BADGE =
+  'inline-flex items-center justify-center min-w-[18px] px-[5px] h-[14px] rounded-[7px] ' +
+  'text-[10px] font-semibold [background:rgba(255,255,255,0.08)] [color:var(--chrome-fg)] ' +
+  '[font-family:var(--chrome-font-mono)]';
+
 function SourcePill({ source, counts, active, onClick }) {
   const hasErrors = counts.error > 0;
   const hasWarns = counts.warn > 0;
@@ -108,16 +115,12 @@ function SourcePill({ source, counts, active, onClick }) {
       onClick={onClick}
       aria-label={`${source.label} logs${hasErrors ? `, ${counts.error} errors` : hasWarns ? `, ${counts.warn} warnings` : ''}`}
     >
-      <span className="logs-footer__pill-label">{source.label}</span>
-      {hasErrors && (
-        <span className="logs-footer__badge logs-footer__badge--error">{counts.error}</span>
-      )}
+      <span className="font-medium">{source.label}</span>
+      {hasErrors && <span className={`${BADGE} logs-footer__badge--error`}>{counts.error}</span>}
       {!hasErrors && hasWarns && (
-        <span className="logs-footer__badge logs-footer__badge--warn">{counts.warn}</span>
+        <span className={`${BADGE} logs-footer__badge--warn`}>{counts.warn}</span>
       )}
-      {!hasErrors && !hasWarns && counts.total > 0 && (
-        <span className="logs-footer__badge">{counts.total}</span>
-      )}
+      {!hasErrors && !hasWarns && counts.total > 0 && <span className={BADGE}>{counts.total}</span>}
     </button>
   );
 }
@@ -382,14 +385,14 @@ export default function LogsFooter() {
       {!collapsed && (
         <div
           ref={dragRef}
-          className="logs-footer__resize"
+          className="absolute top-[-2px] left-0 right-0 h-[5px] cursor-ns-resize z-[1] hover:[background:var(--chrome-accent-border)]"
           onMouseDown={onDragStart}
           title={t('logs.drag_resize')}
         />
       )}
 
-      <div className="logs-footer__bar">
-        <div className="logs-footer__left">
+      <div className="flex items-center justify-between h-[28px] px-[8px] gap-[8px] [border-bottom:1px_solid_rgba(255,255,255,0.04)] shrink-0">
+        <div className="flex items-center gap-[8px] min-w-0 flex-1 overflow-hidden">
           {/* UI scale + theme picker moved to Settings → Appearance.
               Footer is logs-focused now; rarely-used display prefs don't
               belong in always-visible chrome. */}
@@ -414,7 +417,9 @@ export default function LogsFooter() {
             />
           ) : (
             <>
-              <span className="logs-footer__title">{t('logs.title')}</span>
+              <span className="[color:var(--chrome-fg-muted)] text-[11px] uppercase tracking-[0.06em] mr-[4px]">
+                {t('logs.title')}
+              </span>
               {SOURCES.map((s) => (
                 <SourcePill
                   key={s.id}
@@ -427,9 +432,9 @@ export default function LogsFooter() {
             </>
           )}
         </div>
-        <div className="logs-footer__right">
+        <div className="flex items-center gap-[4px] shrink-0">
           {!collapsed && (
-            <div className="logs-footer__actions">
+            <div className="flex items-center gap-[2px]">
               <button
                 className="logs-footer__icon-btn"
                 onClick={refreshAll}
@@ -540,18 +545,21 @@ export default function LogsFooter() {
       {!collapsed && active !== 'notifications' && (
         <div ref={scrollRef} className="logs-footer__body">
           {current.length === 0 && (
-            <div className="logs-footer__empty">
+            <div className="p-[12px] [color:var(--chrome-fg-dim)] not-italic text-[11px] text-center">
               {active === 'frontend' ? t('logs.empty_frontend_short') : t('logs.empty_lines')}
             </div>
           )}
           {current.map((line, i) => {
             const level = classifyLine(line);
             return (
-              <div key={i} className={`logs-footer__line logs-footer__line--${level}`}>
-                <span className="logs-footer__line-icon">
+              <div
+                key={i}
+                className={`flex items-start gap-[6px] px-[2px] py-[1px] rounded-[2px] logs-footer__line--${level}`}
+              >
+                <span className="pt-[2px] shrink-0">
                   <SeverityIcon level={level} />
                 </span>
-                <pre className="logs-footer__line-text">
+                <pre className="logs-footer__line-text m-0 p-0 [font-family:inherit] text-[11.5px] leading-[1.5] whitespace-pre-wrap [word-break:break-word] [color:#ebdbb2] flex-1">
                   {typeof line === 'string' ? line : JSON.stringify(line)}
                 </pre>
               </div>
@@ -561,14 +569,16 @@ export default function LogsFooter() {
       )}
 
       {!collapsed && active === 'notifications' && (
-        <div className="logs-footer__body logs-footer__notif-body">
+        <div className="logs-footer__body flex flex-col gap-[2px] px-[8px] py-[6px]">
           {notifications.length === 0 ? (
-            <div className="logs-footer__empty">{t('logs.all_clear')}</div>
+            <div className="p-[12px] [color:var(--chrome-fg-dim)] not-italic text-[11px] text-center">
+              {t('logs.all_clear')}
+            </div>
           ) : (
             notifications.map((notif) => (
               <div
                 key={notif.id}
-                className={`logs-footer__notif-item logs-footer__notif-item--${notif.level} ${notif.action ? 'logs-footer__notif-item--clickable' : ''}`}
+                className={`flex gap-[8px] items-start px-[10px] py-[8px] rounded-md [background:rgba(255,255,255,0.02)] [border:1px_solid_transparent] hover:[background:rgba(255,255,255,0.04)] logs-footer__notif-item--${notif.level} ${notif.action ? 'logs-footer__notif-item--clickable' : ''}`}
                 onClick={() => {
                   if (!notif.action) return;
                   // Acting on the crash notice acknowledges it — the backend
@@ -589,15 +599,17 @@ export default function LogsFooter() {
                 role={notif.action ? 'button' : undefined}
                 tabIndex={notif.action ? 0 : undefined}
               >
-                <span className="logs-footer__notif-icon">
+                <span className="shrink-0 mt-[2px]">
                   <SeverityIcon level={notif.level} />
                 </span>
-                <div className="logs-footer__notif-content">
+                <div className="logs-footer__notif-content flex flex-col gap-[2px] flex-1 min-w-0">
                   <strong>{notif.title}</strong>
-                  <span className="logs-footer__notif-msg">{notif.message}</span>
+                  <span className="text-[11px] text-fg-muted leading-[1.5]">{notif.message}</span>
                 </div>
                 {notif.action && (
-                  <span className="logs-footer__notif-action">{notif.action.label} →</span>
+                  <span className="shrink-0 text-[11px] font-semibold text-brand whitespace-nowrap">
+                    {notif.action.label} →
+                  </span>
                 )}
               </div>
             ))

--- a/frontend/src/components/StoriesEditor.css
+++ b/frontend/src/components/StoriesEditor.css
@@ -1,22 +1,10 @@
 /* ── Stories / Audiobook Editor ─────────────────────────────────────── */
-
-.stories-editor {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  gap: 12px;
-  padding: 16px;
-  font-family: var(--font-sans);
-}
-
-/* ── Header ───────────────────────────────────────────────────────── */
-
-.stories-editor__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
+/* Layout/spacing/typography for the editor shell, header, panels, stats and
+   the cast/split rows now live as Tailwind utilities in StoriesEditor.jsx.
+   What remains here is the hard-to-express stuff: the track grid + its
+   hover/active/drag combinators, native control chrome (textarea/select/range/
+   buttons + their focus/hover/disabled states), pseudo-element scrollbars, the
+   per-character color palette attribute selectors, and the chapter bar. */
 
 .stories-editor__title {
   font-family: var(--font-serif);
@@ -27,16 +15,6 @@
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.stories-editor__subtitle {
-  color: var(--color-fg-muted);
-  font-size: var(--text-sm);
-}
-
-.stories-editor__actions {
-  display: flex;
-  gap: 6px;
 }
 
 /* ── Track list ───────────────────────────────────────────────────── */
@@ -120,12 +98,6 @@
 }
 
 /* Voice selector */
-.stories-track__voice {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .stories-track__voice-select {
   flex: 1;
   background: var(--color-bg-elev-2);
@@ -135,13 +107,6 @@
   font-size: var(--text-xs);
   padding: 4px 6px;
   font-family: var(--font-sans);
-}
-
-.stories-track__voice-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
 }
 
 /* Character tag */
@@ -189,53 +154,6 @@
   color: var(--color-danger);
 }
 
-/* ── Empty state ──────────────────────────────────────────────────── */
-
-.stories-editor__empty {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  color: var(--color-fg-muted);
-  text-align: center;
-}
-
-.stories-editor__empty-icon {
-  font-size: 2rem;
-  opacity: 0.4;
-}
-
-.stories-editor__empty-text {
-  font-size: var(--text-sm);
-  max-width: 320px;
-  line-height: 1.6;
-}
-
-/* ── Footer / generate bar ────────────────────────────────────────── */
-
-.stories-editor__footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 0 0;
-  border-top: 1px solid var(--color-border);
-}
-
-.stories-editor__stats {
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-  display: flex;
-  gap: 12px;
-}
-
-.stories-editor__stat {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
 /* ── Character color palette ──────────────────────────────────────── */
 
 .stories-track__voice-dot[data-char="narrator"]  { background: var(--color-accent); }
@@ -249,16 +167,6 @@
 
 /* ── Paste & auto-split panel ────────────────────────────────────── */
 
-.stories-editor__split-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  margin: 8px 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.02);
-}
 .stories-editor__split-text {
   width: 100%;
   min-height: 96px;
@@ -271,19 +179,6 @@
   font-size: var(--text-sm);
   resize: vertical;
 }
-.stories-editor__split-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-.stories-editor__split-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: var(--text-xs);
-  color: var(--color-fg-muted);
-}
 .stories-editor__split-num {
   width: 64px;
   padding: 4px 6px;
@@ -294,34 +189,7 @@
   font-family: var(--font-mono);
   font-size: var(--text-xs);
 }
-.stories-editor__split-hint {
-  flex: 1;
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-}
-
 /* ── Cast panel ───────────────────────────────────────────────────── */
-.stories-cast {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  background: var(--color-bg-elev-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-}
-.stories-cast__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.stories-editor__panel-title {
-  font-size: var(--text-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--color-accent);
-}
 .stories-cast__add {
   display: inline-flex;
   align-items: center;
@@ -336,17 +204,6 @@
   cursor: pointer;
 }
 .stories-cast__add:hover { border-color: var(--color-accent); color: var(--color-accent); }
-.stories-cast__row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.stories-cast__dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
 .stories-cast__name {
   flex: 0 0 140px;
   background: var(--color-bg, rgba(0, 0, 0, 0.2));
@@ -372,11 +229,6 @@
 }
 .stories-cast__del:hover:not(:disabled) { color: #fb4934; background: rgba(255, 255, 255, 0.06); }
 .stories-cast__del:disabled { opacity: 0.35; cursor: not-allowed; }
-.stories-editor__hint {
-  margin: 0;
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-}
 
 /* ── Drag-to-reorder ──────────────────────────────────────────────── */
 .stories-track { cursor: grab; flex-wrap: wrap; }
@@ -384,17 +236,6 @@
 
 /* ── Per-line tone/speed drawer ───────────────────────────────────── */
 .stories-track__btn--on { color: var(--color-accent); background: rgba(255, 255, 255, 0.06); }
-.stories-track__drawer {
-  flex-basis: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--color-border);
-}
-.stories-track__tones { display: flex; flex-wrap: wrap; gap: 4px; }
 .stories-track__tone {
   display: inline-flex;
   align-items: center;
@@ -431,7 +272,6 @@
 .stories-track__reset:hover { color: var(--color-fg); }
 
 /* ── Projects panel ───────────────────────────────────────────────── */
-.stories-proj__name { flex: 1; }
 .stories-proj__open {
   flex: 1;
   display: inline-flex;
@@ -459,22 +299,6 @@
 }
 
 /* ── Redesign: grouped toolbar, chapter bars, readable column ──────── */
-
-/* Full-bleed like the other studio tabs — fill the content area edge to edge
-   instead of a centered column. */
-.stories-editor { width: 100%; }
-
-/* Toolbar: logical clusters (project · content · output) with thin dividers. */
-.stories-editor__actions { flex-wrap: wrap; }
-.stories-editor__group { display: inline-flex; align-items: center; gap: 4px; }
-.stories-editor__divider {
-  align-self: stretch;
-  width: 1px;
-  min-height: 18px;
-  margin: 0 4px;
-  background: var(--color-border);
-  opacity: 0.7;
-}
 
 /* Chapter = a section heading, not a voiced line. */
 .stories-chapter {

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -603,16 +603,20 @@ export default function StoriesEditor({ profiles = [] }) {
   const profileName = (id) => (profiles.find((p) => p.id === id) || {}).name;
 
   return (
-    <div className="stories-editor" role="region" aria-label="Stories editor">
+    <div
+      className="flex flex-col h-full w-full gap-[12px] p-[16px] font-sans"
+      role="region"
+      aria-label="Stories editor"
+    >
       {/* Header / toolbar */}
-      <div className="stories-editor__header">
+      <div className="flex items-center justify-between gap-[12px]">
         <div>
           <h2 className="stories-editor__title">
             <BookOpen size={18} /> {t('stories.title')}
           </h2>
-          <p className="stories-editor__subtitle">{t('stories.subtitle')}</p>
+          <p className="text-fg-muted [font-size:var(--text-sm)]">{t('stories.subtitle')}</p>
         </div>
-        <div className="stories-editor__actions">
+        <div className="flex flex-wrap gap-[6px]">
           <input
             ref={fileInputRef}
             type="file"
@@ -622,7 +626,7 @@ export default function StoriesEditor({ profiles = [] }) {
           />
 
           {/* Project */}
-          <div className="stories-editor__group">
+          <div className="inline-flex items-center gap-[4px]">
             <Button
               size="sm"
               variant="ghost"
@@ -641,10 +645,13 @@ export default function StoriesEditor({ profiles = [] }) {
             </Button>
           </div>
 
-          <span className="stories-editor__divider" aria-hidden="true" />
+          <span
+            className="self-stretch w-px min-h-[18px] mx-[4px] bg-border opacity-70"
+            aria-hidden="true"
+          />
 
           {/* Content */}
-          <div className="stories-editor__group">
+          <div className="inline-flex items-center gap-[4px]">
             <Button
               size="sm"
               variant="ghost"
@@ -674,11 +681,14 @@ export default function StoriesEditor({ profiles = [] }) {
             </Button>
           </div>
 
-          <span className="stories-editor__divider" aria-hidden="true" />
+          <span
+            className="self-stretch w-px min-h-[18px] mx-[4px] bg-border opacity-70"
+            aria-hidden="true"
+          />
 
           {/* Global reading speed (#415) — one speed for every line that has no
               per-line override. */}
-          <div className="stories-editor__group">
+          <div className="inline-flex items-center gap-[4px]">
             <label
               className="stories-editor__speed"
               title={t('stories.global_speed_hint', {
@@ -708,10 +718,13 @@ export default function StoriesEditor({ profiles = [] }) {
             </label>
           </div>
 
-          <span className="stories-editor__divider" aria-hidden="true" />
+          <span
+            className="self-stretch w-px min-h-[18px] mx-[4px] bg-border opacity-70"
+            aria-hidden="true"
+          />
 
           {/* Output */}
-          <div className="stories-editor__group">
+          <div className="inline-flex items-center gap-[4px]">
             <Button
               size="sm"
               variant="ghost"
@@ -740,16 +753,22 @@ export default function StoriesEditor({ profiles = [] }) {
 
       {/* Projects panel */}
       {projectsOpen && (
-        <div className="stories-cast" role="region" aria-label={t('stories.projects')}>
-          <div className="stories-cast__head">
-            <span className="stories-editor__panel-title">{t('stories.projects')}</span>
+        <div
+          className="flex flex-col gap-[8px] p-[12px] bg-bg-elev-2 [border:1px_solid_var(--color-border)] rounded-sm"
+          role="region"
+          aria-label={t('stories.projects')}
+        >
+          <div className="flex items-center justify-between">
+            <span className="[font-size:var(--text-xs)] font-semibold uppercase tracking-[0.06em] text-accent">
+              {t('stories.projects')}
+            </span>
             <button type="button" className="stories-cast__add" onClick={newStory}>
               <Plus size={12} /> {t('stories.newStory')}
             </button>
           </div>
-          <div className="stories-cast__row">
+          <div className="flex items-center gap-[8px]">
             <input
-              className="stories-cast__name stories-proj__name"
+              className="stories-cast__name flex-1"
               value={projectName}
               onChange={(e) => setProjectName(e.target.value)}
               placeholder={t('stories.untitled')}
@@ -762,7 +781,7 @@ export default function StoriesEditor({ profiles = [] }) {
           {storyProjects.map((p) => (
             <div
               key={p.id}
-              className={`stories-cast__row ${p.id === currentProjectId ? 'stories-proj--current' : ''}`}
+              className={`flex items-center gap-[8px] ${p.id === currentProjectId ? 'stories-proj--current' : ''}`}
             >
               <button
                 type="button"
@@ -782,23 +801,34 @@ export default function StoriesEditor({ profiles = [] }) {
             </div>
           ))}
           {storyProjects.length === 0 && (
-            <p className="stories-editor__hint">{t('stories.noProjects')}</p>
+            <p className="m-0 [font-size:var(--text-xs)] text-fg-subtle">
+              {t('stories.noProjects')}
+            </p>
           )}
         </div>
       )}
 
       {/* Cast panel */}
       {castOpen && (
-        <div className="stories-cast" role="region" aria-label={t('stories.castTitle')}>
-          <div className="stories-cast__head">
-            <span className="stories-editor__panel-title">{t('stories.castTitle')}</span>
+        <div
+          className="flex flex-col gap-[8px] p-[12px] bg-bg-elev-2 [border:1px_solid_var(--color-border)] rounded-sm"
+          role="region"
+          aria-label={t('stories.castTitle')}
+        >
+          <div className="flex items-center justify-between">
+            <span className="[font-size:var(--text-xs)] font-semibold uppercase tracking-[0.06em] text-accent">
+              {t('stories.castTitle')}
+            </span>
             <button type="button" className="stories-cast__add" onClick={addCharacter}>
               <Plus size={12} /> {t('stories.addCharacter')}
             </button>
           </div>
           {cast.map((c) => (
-            <div key={c.id} className="stories-cast__row">
-              <span className="stories-cast__dot" style={{ background: c.color }} />
+            <div key={c.id} className="flex items-center gap-[8px]">
+              <span
+                className="w-[10px] h-[10px] rounded-full shrink-0"
+                style={{ background: c.color }}
+              />
               <input
                 className="stories-cast__name"
                 value={c.name}
@@ -833,7 +863,9 @@ export default function StoriesEditor({ profiles = [] }) {
             </div>
           ))}
           {profiles.length === 0 && (
-            <p className="stories-editor__hint">{t('stories.noProfiles')}</p>
+            <p className="m-0 [font-size:var(--text-xs)] text-fg-subtle">
+              {t('stories.noProfiles')}
+            </p>
           )}
         </div>
       )}
@@ -841,7 +873,7 @@ export default function StoriesEditor({ profiles = [] }) {
       {/* Paste & split */}
       {splitOpen && (
         <div
-          className="stories-editor__split-panel"
+          className="flex flex-col gap-[8px] p-[12px] my-[8px] [border:1px_solid_var(--color-border)] rounded-md [background:rgba(255,255,255,0.02)]"
           role="region"
           aria-label={t('stories.pasteSplit')}
         >
@@ -853,8 +885,8 @@ export default function StoriesEditor({ profiles = [] }) {
             rows={6}
             aria-label={t('stories.splitPlaceholder')}
           />
-          <div className="stories-editor__split-controls">
-            <label className="stories-editor__split-label">
+          <div className="flex items-center gap-[12px] flex-wrap">
+            <label className="flex items-center gap-[6px] [font-size:var(--text-xs)] text-fg-muted">
               {t('stories.maxChars')}
               <input
                 type="number"
@@ -866,7 +898,7 @@ export default function StoriesEditor({ profiles = [] }) {
                 className="stories-editor__split-num"
               />
             </label>
-            <span className="stories-editor__split-hint">
+            <span className="flex-1 [font-size:var(--text-xs)] text-fg-subtle">
               {splitText
                 ? t('stories.segmentsHint', {
                     count: splitIntoChunks(splitText, splitMax).length,
@@ -901,9 +933,11 @@ export default function StoriesEditor({ profiles = [] }) {
 
       {/* Tracks */}
       {tracks.length === 0 ? (
-        <div className="stories-editor__empty">
-          <BookOpen size={32} className="stories-editor__empty-icon" aria-hidden="true" />
-          <p className="stories-editor__empty-text">{t('stories.emptyText')}</p>
+        <div className="flex-1 flex flex-col items-center justify-center gap-[12px] text-fg-muted text-center">
+          <BookOpen size={32} className="text-[2rem] opacity-40" aria-hidden="true" />
+          <p className="[font-size:var(--text-sm)] max-w-[320px] leading-[1.6]">
+            {t('stories.emptyText')}
+          </p>
           <Button size="sm" onClick={addTrack}>
             <Plus size={13} /> {t('stories.addFirst')}
           </Button>
@@ -1009,9 +1043,9 @@ export default function StoriesEditor({ profiles = [] }) {
                   aria-label={`${member ? member.name : ''} ${t('stories.text')}`}
                 />
 
-                <div className="stories-track__voice">
+                <div className="flex items-center gap-[6px]">
                   <span
-                    className="stories-track__voice-dot"
+                    className="stories-track__voice-dot w-[10px] h-[10px] rounded-full shrink-0"
                     style={{ background: member ? member.color : '#a89984' }}
                   />
                   <select
@@ -1120,8 +1154,11 @@ export default function StoriesEditor({ profiles = [] }) {
                 </div>
 
                 {expandedLine === track.id && (
-                  <div className="stories-track__drawer" onClick={(e) => e.stopPropagation()}>
-                    <div className="stories-track__tones">
+                  <div
+                    className="basis-full flex flex-wrap items-center gap-[12px] mt-[8px] pt-[8px] [border-top:1px_solid_var(--color-border)]"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex flex-wrap gap-[4px]">
                       {STORY_TONES.map((tn) => (
                         <button
                           key={tn.tag}
@@ -1168,25 +1205,25 @@ export default function StoriesEditor({ profiles = [] }) {
 
       {/* Footer stats */}
       {tracks.length > 0 && (
-        <div className="stories-editor__footer">
-          <div className="stories-editor__stats">
-            <span className="stories-editor__stat">
+        <div className="flex items-center justify-between pt-[8px] [border-top:1px_solid_var(--color-border)]">
+          <div className="[font-size:var(--text-xs)] text-fg-subtle flex gap-[12px]">
+            <span className="flex items-center gap-[4px]">
               <FileText size={12} aria-hidden="true" />{' '}
               {t('stories.lines', { count: tracks.length })}
             </span>
-            <span className="stories-editor__stat">
+            <span className="flex items-center gap-[4px]">
               <Drama size={12} aria-hidden="true" />{' '}
               {t('stories.characters', { count: usedCharacters })}
             </span>
-            <span className="stories-editor__stat">
+            <span className="flex items-center gap-[4px]">
               <Timer size={12} aria-hidden="true" /> {t('stories.minutes', { count: estMinutes })}
             </span>
-            <span className="stories-editor__stat">
+            <span className="flex items-center gap-[4px]">
               <ChartColumn size={12} aria-hidden="true" />{' '}
               {t('stories.chars', { count: totalChars })}
             </span>
             {exporting && (
-              <span className="stories-editor__stat">
+              <span className="flex items-center gap-[4px]">
                 <Hourglass size={12} aria-hidden="true" /> {exportPct}%
               </span>
             )}


### PR DESCRIPTION
## What

Partial, conservative CSS → Tailwind v4 conversion of two components, migrating the **safe mechanical** layout/spacing/typography to utilities while leaving the hard-to-express rules in CSS. No intended visual change.

Follows the migration plan (`docs/css-to-tailwind-migration.md` §8) and prior-PR conventions: app ships Tailwind v4 **without preflight**, so borders/transitions/chrome-tokens are arbitrary properties referencing the exact original vars; `@theme` tokens use named utilities; every non-`@theme` value (`--chrome-*`, `--space-*`, `--text-*`) is exact px / `var()`.

## Per-file

**StoriesEditor.css 525 → 349 (−176)** — converted: editor shell, header, subtitle, toolbar groups/divider, stats/footer, empty state, cast + paste/split panels, panel title, voice/cast dots, tone/drawer containers.
**Kept in CSS:** the `<h2>` title (global `h1..h4` element rule is unlayered and beats a `font-serif` utility), `.stories-track` grid + hover/active/drag combinators, all native controls (textarea/select/range + focus), every button (UA reset + states), the chapter bar (hover combinators), `::-webkit-scrollbar` pseudos, `[data-char]` palette attribute selectors.

**LogsFooter.css 507 → 376 (−131)** — converted: resize handle, top bar, left/right clusters, LOGS title, count-badge base, log-line base + icon + line-text base, notification panel (body/item/icon/content/msg/action).
**Kept in CSS:** the `.logs-footer` fixed shell (anchor for `.app-container .logs-footer` inset combinators + the ≤600px media query), every button (toggle/pill/version/discord/donate/icon-btn with hover/disabled/animations), severity color modifiers + their descendant overrides, body scrollbar pseudos, `notif-content strong`, all `@keyframes` + reduced-motion.

Classes still referenced by kept CSS keep their BEM class alongside utilities; fully-removed rules drop the class. Grep-confirmed no class used elsewhere in `frontend/src` was removed.

## Verification

- `npx oxlint` → 0 errors (only pre-existing warnings)
- `npx oxfmt --write src && npx oxfmt --check .` → clean
- `npx vite build` → ok
- `npx vitest run` → 641 passed
- `bun install --frozen-lockfile` → no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
This PR partially migrates the StoriesEditor and LogsFooter UI from bespoke CSS to Tailwind utilities, keeping only the rules that depend on combinators, pseudos, native controls, or animation behavior in CSS. The result is a conservative refactor that preserves existing visuals while reducing the amount of component-scoped stylesheet code.

### StoriesEditor
- Moved shell/header/panel layout, spacing, typography, and several toolbar/divider styles into JSX utility classes.
- Refactored Projects, Cast, Paste & split, empty state, per-track voice row, drawer layout, and footer stats markup toward utility-based structure.
- Added a new chapter bar section with dragover/grip/title/delete styling and row-hover reveal behavior.
- Kept track grid mechanics, native controls, scrollbar pseudos, and character-specific selectors in CSS.

### LogsFooter
- Moved resize handle, top bar, badge/pill, log line structure, and notification panel layout into utilities / CSS-variable-driven classes.
- Simplified badge rendering with a shared `BADGE` class string.
- Kept the fixed shell, severity modifiers, scrollbar pseudos, and reduced-motion/animation-related CSS rules.

## UI sketch

### StoriesEditor
Before:
```text
[Header]
[Toolbar buttons --- dividers]
[Empty state / Projects / Cast / Split panels]
[Track list]
[Footer stats]
```

After:
```text
[Header (utility layout)]
[Toolbar buttons | dividers | utility groups]
[Panels (utility containers)]
[Track list + chapter bar]
[Footer stats (utility row)]
```

### LogsFooter
Before:
```text
[Resize strip]
[Top bar: title | pills | actions]
[Expanded logs / notifications]
```

After:
```text
[Resize handle (utility)]
[Top bar: flex layout + shared badges]
[Expanded logs / notifications (utility content)]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->