### PR TITLE
feat(ui): convert Settings + misc page CSS to Tailwind utilities (partial)

### DIFF
--- a/frontend/src/components/settings/AboutTab.jsx
+++ b/frontend/src/components/settings/AboutTab.jsx
@@ -129,7 +129,7 @@ export default function AboutTab({
           />
         </>
       )}
-      <div className="settings-link-row">
+      <div className="settings-link-row mt-[var(--space-5)] flex flex-wrap gap-[var(--space-4)]">
         {isTauri() && (
           <Button
             variant="primary"
@@ -204,12 +204,17 @@ export default function AboutTab({
                     {t(`about.self_check_${c.status}`)}
                   </Badge>{' '}
                   {c.detail}
-                  {c.hint && <span className="settings-muted"> — {c.hint}</span>}
+                  {c.hint && (
+                    <span className="settings-muted font-sans text-[var(--text-md)] text-[var(--chrome-fg-dim)]">
+                      {' '}
+                      — {c.hint}
+                    </span>
+                  )}
                 </span>
               }
             />
           ))}
-          <p className="settings-muted">
+          <p className="settings-muted font-sans text-[var(--text-md)] text-[var(--chrome-fg-dim)]">
             {selfCheck.summary.ok
               ? t('about.self_check_healthy')
               : t('about.self_check_attention', { count: selfCheck.summary.failures })}

--- a/frontend/src/components/settings/CredentialsTab.jsx
+++ b/frontend/src/components/settings/CredentialsTab.jsx
@@ -105,7 +105,7 @@ export default function CredentialsTab({ info }) {
       <LLMEndpointPanel />
 
       <Collapsible title={t('settings.credentials_more')} icon={KeyRound}>
-        <p className="settings-prose">
+        <p className="settings-prose m-0 mb-[var(--space-5)] font-sans text-[var(--text-md)] leading-[1.6] text-[var(--chrome-fg-muted)]">
           <Trans i18nKey="credentials.desc" components={{ 1: <strong /> }} />
         </p>
         {CREDENTIAL_FIELDS.filter((f) => f.key !== 'HF_TOKEN').map((field) => (

--- a/frontend/src/components/settings/HotkeyTab.jsx
+++ b/frontend/src/components/settings/HotkeyTab.jsx
@@ -114,7 +114,7 @@ export default function HotkeyTab() {
   return (
     <SettingsSection icon={Keyboard} title={t('settings.shortcut')}>
       {!tauri && (
-        <p className="settings-prose">
+        <p className="settings-prose m-0 mb-[var(--space-5)] font-sans text-[var(--text-md)] leading-[1.6] text-[var(--chrome-fg-muted)]">
           <Trans i18nKey="capture.desc" components={{ 1: <kbd /> }} />
         </p>
       )}
@@ -127,7 +127,7 @@ export default function HotkeyTab() {
         mono
       />
 
-      <div className="settings-actions-row">
+      <div className="settings-actions-row mt-[var(--space-5)] flex flex-wrap gap-[var(--space-4)]">
         <Button
           size="sm"
           variant="subtle"

--- a/frontend/src/components/settings/LogsTab.jsx
+++ b/frontend/src/components/settings/LogsTab.jsx
@@ -50,7 +50,7 @@ export default function LogsTab({
         onChange={setLogSource}
       />
 
-      <div className="settings-log-meta">
+      <div className="settings-log-meta flex items-center gap-[var(--space-4)] my-[var(--space-4)] font-mono text-[var(--text-base)] text-[var(--chrome-fg-dim)]">
         <span>{logMeta.path || '—'}</span>
         {logSource === 'tauri' && !logMeta.exists && (
           <Badge tone="warn">
@@ -60,7 +60,7 @@ export default function LogsTab({
       </div>
       <div className="settings-log">
         {logs.length === 0 ? (
-          <span className="settings-log__empty">
+          <span className="settings-log__empty font-sans text-[var(--chrome-fg-dim)]">
             {logSource === 'frontend'
               ? t('logs.empty_frontend')
               : logSource === 'tauri'

--- a/frontend/src/components/settings/ModelStoreTab.jsx
+++ b/frontend/src/components/settings/ModelStoreTab.jsx
@@ -396,7 +396,9 @@ export default function ModelStoreTab({ info, modelBadge }) {
   if (loading && !data) {
     return (
       <SettingsSection icon={Cpu} title={t('settings.models')}>
-        <div className="settings-muted">{t('common.loading')}</div>
+        <div className="settings-muted font-sans text-[var(--text-md)] text-[var(--chrome-fg-dim)]">
+          {t('common.loading')}
+        </div>
       </SettingsSection>
     );
   }

--- a/frontend/src/components/settings/PrivacyTab.jsx
+++ b/frontend/src/components/settings/PrivacyTab.jsx
@@ -10,7 +10,7 @@ export default function PrivacyTab({ info }) {
 
   return (
     <SettingsSection icon={ShieldCheck} title={t('settings.privacy')}>
-      <p className="settings-prose">
+      <p className="settings-prose m-0 mb-[var(--space-5)] font-sans text-[var(--text-md)] leading-[1.6] text-[var(--chrome-fg-muted)]">
         <Trans i18nKey="privacy.desc" components={{ 1: <strong /> }} />
       </p>
       <Row

--- a/frontend/src/components/settings/models/columns.jsx
+++ b/frontend/src/components/settings/models/columns.jsx
@@ -48,7 +48,7 @@ export function makeModelColumns({
               {m.note && <span className="models-row__note"> · {m.note}</span>}
             </span>
             {rt.showBar && (
-              <div className="models-row__progressline">
+              <div className="models-row__progressline flex flex-col gap-[3px] mt-[6px]">
                 <Progress value={rt.aggPct} tone={rt.isDeleting ? 'warn' : 'brand'} size="xs" />
                 <span className="models-row__progresstext">
                   {(() => {

--- a/frontend/src/pages/AudiobookTab.css
+++ b/frontend/src/pages/AudiobookTab.css
@@ -1,23 +1,19 @@
 /* Audiobook tab — full-bleed, full-height layout (matches the other studio
    tabs). A two-pane body: the script editor fills the left + grows to the
    window height; settings + results scroll on the right. Collapses to a single
-   column on narrow widths. */
-.audiobook-tab {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  box-sizing: border-box;
-  padding: 1.25rem 1.5rem;
-  gap: 12px;
-}
+   column on narrow widths.
 
-.audiobook-tab__head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  flex-wrap: wrap;
-}
+   Layout / spacing now live as Tailwind utilities in AudiobookTab.jsx. What
+   stays here:
+   - `.audiobook-tab__title` — an `<h2>` whose font-family (serif) fights the
+     unlayered global `h1..h4` rule (font-sans), which would win over utilities.
+   - `.audiobook-tab .field-label` — scoped override of the shared `.field-label`
+     class (descendant compound).
+   - `.audiobook-tab__script textarea` / `.audiobook-tab__field select` —
+     descendant element styling on tags rendered by `<Textarea>`/`<select>`.
+   - the `@media (max-width: 900px)` block — Tailwind's breakpoints differ from
+     this custom one, so the responsive collapse stays in CSS. */
+
 .audiobook-tab__title {
   display: flex;
   align-items: center;
@@ -28,7 +24,6 @@
   font-weight: var(--weight-semibold);
   color: var(--color-fg);
 }
-.audiobook-tab__sub { margin: 2px 0 0; color: var(--color-fg-muted); font-size: var(--text-sm); }
 
 /* Field/section labels — chrome mono uppercase, matching the rest of the app's
    form labels (the bare .field-label class has no global rule). */
@@ -40,28 +35,7 @@
   text-transform: uppercase;
   color: var(--chrome-fg-muted);
 }
-.audiobook-tab__actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
 
-/* Body fills the remaining height; min-height:0 lets the textarea shrink. */
-.audiobook-tab__body {
-  flex: 1 1 auto;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(300px, 380px);
-  gap: 16px;
-}
-
-.audiobook-tab__script {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  gap: 6px;
-}
 .audiobook-tab__script textarea {
   flex: 1 1 auto;
   min-height: 0;
@@ -70,25 +44,7 @@
   font-family: var(--font-mono, monospace);
 }
 
-.audiobook-tab__side {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 4px;
-}
-.audiobook-tab__field {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
 .audiobook-tab__field select { width: 100%; }
-.audiobook-tab__duo {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
-}
 
 @media (max-width: 900px) {
   .audiobook-tab__body { grid-template-columns: 1fr; }

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -236,15 +236,17 @@ export default function AudiobookTab({ profiles = [] }) {
   const canRun = text.trim().length > 0 && !busy;
 
   return (
-    <div className="audiobook-tab">
-      <div className="audiobook-tab__head">
+    <div className="audiobook-tab flex flex-col h-full box-border px-[1.5rem] py-[1.25rem] gap-[12px]">
+      <div className="audiobook-tab__head flex flex-wrap items-start justify-between gap-[16px]">
         <div>
           <h2 className="audiobook-tab__title">
             <BookMarked size={20} /> {t('audiobook.title')}
           </h2>
-          <p className="muted audiobook-tab__sub">{t('audiobook.subtitle')}</p>
+          <p className="muted audiobook-tab__sub mt-[2px] text-[var(--text-sm)] text-fg-muted">
+            {t('audiobook.subtitle')}
+          </p>
         </div>
-        <div className="audiobook-tab__actions">
+        <div className="audiobook-tab__actions flex flex-wrap items-center gap-[8px]">
           <label
             className="ui-btn ui-btn--subtle"
             style={{
@@ -274,9 +276,9 @@ export default function AudiobookTab({ profiles = [] }) {
         </div>
       </div>
 
-      <div className="audiobook-tab__body">
+      <div className="audiobook-tab__body grid flex-auto grid-cols-[minmax(0,1fr)_minmax(300px,380px)] gap-[16px] min-h-0">
         {/* Left: script editor fills the height */}
-        <div className="audiobook-tab__script">
+        <div className="audiobook-tab__script flex flex-col min-h-0 gap-[6px]">
           <label className="field-label">{t('audiobook.script')}</label>
           <textarea
             className="input-base"
@@ -288,8 +290,8 @@ export default function AudiobookTab({ profiles = [] }) {
         </div>
 
         {/* Right: settings + results, scrolls independently */}
-        <div className="audiobook-tab__side">
-          <div className="audiobook-tab__field">
+        <div className="audiobook-tab__side flex flex-col gap-[12px] min-h-0 overflow-y-auto pr-[4px]">
+          <div className="audiobook-tab__field flex flex-col gap-[4px]">
             <label className="field-label">{t('audiobook.default_voice')}</label>
             <VoiceSelector
               value={defaultVoice}
@@ -299,8 +301,8 @@ export default function AudiobookTab({ profiles = [] }) {
             />
           </div>
 
-          <div className="audiobook-tab__duo">
-            <div className="audiobook-tab__field">
+          <div className="audiobook-tab__duo grid grid-cols-[1fr_1fr] gap-[8px]">
+            <div className="audiobook-tab__field flex flex-col gap-[4px]">
               <label className="field-label">{t('audiobook.format')}</label>
               <select
                 className="input-base"
@@ -312,7 +314,7 @@ export default function AudiobookTab({ profiles = [] }) {
                 <option value="mp3">{t('audiobook.format_mp3')}</option>
               </select>
             </div>
-            <div className="audiobook-tab__field">
+            <div className="audiobook-tab__field flex flex-col gap-[4px]">
               <label className="field-label">{t('audiobook.loudness')}</label>
               <select
                 className="input-base"
@@ -328,7 +330,7 @@ export default function AudiobookTab({ profiles = [] }) {
           </div>
 
           {/* Cover + metadata */}
-          <div className="audiobook-tab__field">
+          <div className="audiobook-tab__field flex flex-col gap-[4px]">
             <label className="field-label">{t('audiobook.details')}</label>
             <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
               <div style={{ position: 'relative', width: 96, height: 96, flexShrink: 0 }}>
@@ -431,7 +433,7 @@ export default function AudiobookTab({ profiles = [] }) {
           </div>
 
           {/* Pronunciation lexicon */}
-          <div className="audiobook-tab__field">
+          <div className="audiobook-tab__field flex flex-col gap-[4px]">
             <label className="field-label">{t('audiobook.lexicon')}</label>
             {lex.map((row, i) => (
               <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
@@ -472,7 +474,7 @@ export default function AudiobookTab({ profiles = [] }) {
           </div>
 
           {/* Markup quick reference */}
-          <details className="audiobook-tab__field">
+          <details className="audiobook-tab__field flex flex-col gap-[4px]">
             <summary className="field-label" style={{ cursor: 'pointer' }}>
               {t('audiobook.markup_help')}
             </summary>

--- a/frontend/src/pages/BatchQueue.css
+++ b/frontend/src/pages/BatchQueue.css
@@ -1,19 +1,13 @@
-.batch-queue {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  padding: var(--space-5) var(--space-6);
-  min-height: 0;
-  overflow-y: auto;
-}
+/* Layout / spacing / typography / box styling now live as Tailwind utilities in
+   BatchQueue.jsx. What stays here:
+   - `.batch-queue__bar h1`: fights the unlayered global `h1` rule (font-sans),
+     so it must out-specify it from a non-utility rule.
+   - the `.batch-queue__card` transition + its `--running`/`--failed` border
+     modifiers: the modifier class is built from a dynamic template string, so
+     the pair stays as CSS rather than a JS class map.
+   - `.batch-queue__progress-fill` + its `::after` shimmer (pseudo-element,
+     layered gradient, keyframes) — not expressible as utilities. */
 
-.batch-queue__bar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  flex-shrink: 0;
-}
 .batch-queue__bar h1 {
   margin: 0;
   font-family: var(--font-display);
@@ -24,86 +18,15 @@
   align-items: center;
   gap: var(--space-3);
 }
-.batch-queue__bar-spacer { flex: 1; }
 
-.batch-queue__tabs { flex-shrink: 0; }
-
-.batch-queue__empty {
-  text-align: center;
-  color: var(--color-fg-muted);
-}
-.batch-queue__empty-sub { font-size: var(--text-sm); color: var(--color-fg-subtle); }
-
-.batch-queue__list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  flex: 1;
-  min-height: 0;
-}
-
-/* ── Cards ──────────────────────────────────────────────────────────── */
+/* ── Cards (transition + status border modifiers) ───────────────────── */
 
 .batch-queue__card            { transition: border-color var(--dur-fast); }
 .batch-queue__card--running   { border-color: rgba(211, 134, 155, 0.4); }
 .batch-queue__card--failed    { border-color: rgba(251, 73, 52, 0.35); }
 
-.batch-queue__card-head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-  margin-bottom: var(--space-2);
-}
-.batch-queue__card-filename {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--color-fg);
-  font-weight: var(--weight-semibold);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-.batch-queue__card-spacer { flex: 1; }
-.batch-queue__card-age {
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-  font-variant-numeric: tabular-nums;
-}
+/* ── Progress fill (gradient + shimmer pseudo-element) ──────────────── */
 
-/* ── Languages row ────────────────────────────────────────────────── */
-
-.batch-queue__card-langs {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
-  color: var(--color-fg-muted);
-  font-size: var(--text-xs);
-}
-.batch-queue__card-lang {
-  background: var(--color-bg-elev-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: 1px 6px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-/* ── Progress bar ─────────────────────────────────────────────────── */
-
-.batch-queue__progress {
-  margin: var(--space-2) 0 var(--space-3);
-}
-.batch-queue__progress-bar {
-  height: 6px;
-  background: var(--color-bg-elev-2);
-  border-radius: 3px;
-  overflow: hidden;
-  position: relative;
-}
 .batch-queue__progress-fill {
   height: 100%;
   border-radius: 3px;
@@ -123,95 +46,4 @@
   0%   { opacity: 0; }
   50%  { opacity: 1; }
   100% { opacity: 0; }
-}
-
-.batch-queue__progress-info {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  margin-top: var(--space-2);
-  font-size: var(--text-xs);
-  color: var(--color-fg-muted);
-}
-.batch-queue__progress-stage {
-  font-weight: var(--weight-semibold);
-  color: var(--color-fg);
-}
-.batch-queue__progress-lang {
-  background: var(--color-bg-elev-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  padding: 0 4px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  text-transform: uppercase;
-}
-.batch-queue__progress-segs {
-  font-variant-numeric: tabular-nums;
-}
-.batch-queue__progress-pct {
-  margin-left: auto;
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-  color: var(--color-fg);
-  font-weight: var(--weight-semibold);
-}
-
-/* ── Meta / Error ─────────────────────────────────────────────────── */
-
-.batch-queue__card-meta {
-  font-size: var(--text-xs);
-  color: var(--color-fg-muted);
-  margin-top: var(--space-1);
-}
-.batch-queue__card-error {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-2);
-  padding: var(--space-3);
-  margin-top: var(--space-3);
-  background: rgba(251, 73, 52, 0.06);
-  border: 1px solid rgba(251, 73, 52, 0.25);
-  border-radius: var(--radius-sm);
-  color: var(--color-danger);
-  font-size: var(--text-sm);
-  line-height: 1.4;
-}
-
-/* ── Output downloads ─────────────────────────────────────────────── */
-
-.batch-queue__card-outputs {
-  display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  margin-top: var(--space-3);
-}
-.batch-queue__card-dl {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: 3px 10px;
-  font-size: var(--text-xs);
-  font-family: var(--font-mono);
-  text-transform: uppercase;
-  background: var(--color-bg-elev-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  color: var(--color-fg);
-  text-decoration: none;
-  transition: all var(--dur-fast);
-}
-.batch-queue__card-dl:hover {
-  background: var(--color-bg-elev-3);
-  border-color: rgba(211, 134, 155, 0.5);
-  color: #f3a5b6;
-}
-
-/* ── Actions row ──────────────────────────────────────────────────── */
-
-.batch-queue__card-actions {
-  display: flex;
-  gap: var(--space-2);
-  margin-top: var(--space-3);
-  justify-content: flex-end;
 }

--- a/frontend/src/pages/BatchQueue.jsx
+++ b/frontend/src/pages/BatchQueue.jsx
@@ -139,8 +139,8 @@ export default function BatchQueue({ onBack }) {
   );
 
   return (
-    <div className="batch-queue">
-      <div className="batch-queue__bar">
+    <div className="batch-queue flex flex-1 flex-col gap-[var(--space-4)] min-h-0 overflow-y-auto px-[var(--space-6)] py-[var(--space-5)]">
+      <div className="batch-queue__bar flex shrink-0 items-center gap-[var(--space-4)]">
         {onBack && (
           <Button variant="ghost" size="sm" onClick={onBack}>
             {t('batch.back')}
@@ -149,7 +149,7 @@ export default function BatchQueue({ onBack }) {
         <h1>
           <Activity size={15} /> {t('batch.title')}
         </h1>
-        <div className="batch-queue__bar-spacer" />
+        <div className="batch-queue__bar-spacer flex-1" />
         <Button
           variant="subtle"
           size="sm"
@@ -169,17 +169,17 @@ export default function BatchQueue({ onBack }) {
         </Button>
       </div>
 
-      <Tabs items={TABS} value={tab} onChange={setTab} className="batch-queue__tabs" />
+      <Tabs items={TABS} value={tab} onChange={setTab} className="batch-queue__tabs shrink-0" />
 
       {jobs.length === 0 && !loading && (
-        <Panel variant="flat" padding="lg" className="batch-queue__empty">
+        <Panel variant="flat" padding="lg" className="batch-queue__empty text-center text-fg-muted">
           <div>
             <p>
               {tab === 'active' && t('batch.no_active')}
               {tab === 'done' && t('batch.no_completed')}
               {tab === 'failed' && t('batch.no_failed')}
             </p>
-            <p className="batch-queue__empty-sub">
+            <p className="batch-queue__empty-sub text-[var(--text-sm)] text-fg-subtle">
               {tab === 'active' && t('batch.drop_hint')}
               {tab === 'done' && 'Nothing has completed recently.'}
               {tab === 'failed' && 'No failed jobs — enjoy the silence.'}
@@ -188,7 +188,7 @@ export default function BatchQueue({ onBack }) {
         </Panel>
       )}
 
-      <div className="batch-queue__list">
+      <div className="batch-queue__list flex flex-1 flex-col gap-[var(--space-3)] min-h-0">
         {jobs.map((j) => (
           <JobCard key={j.id} job={j} onCancel={handleCancel} onDelete={handleDelete} t={t} />
         ))}
@@ -237,16 +237,16 @@ function JobCard({ job, onCancel, onDelete, t }) {
       padding="md"
       className={`batch-queue__card batch-queue__card--${job.status}`}
     >
-      <div className="batch-queue__card-head">
+      <div className="batch-queue__card-head flex flex-wrap items-center gap-[var(--space-3)] mb-[var(--space-2)]">
         <Badge tone={st.tone} dot>
           <StIcon size={10} /> {t(st.label)}
         </Badge>
-        <span className="batch-queue__card-filename">
+        <span className="batch-queue__card-filename inline-flex items-center gap-[var(--space-2)] font-mono text-[var(--text-xs)] font-semibold text-fg">
           <Film size={10} /> {job.filename}
         </span>
-        <span className="batch-queue__card-spacer" />
+        <span className="batch-queue__card-spacer flex-1" />
         <span
-          className="batch-queue__card-age"
+          className="batch-queue__card-age text-[var(--text-xs)] text-fg-subtle [font-variant-numeric:tabular-nums]"
           title={new Date((job.created_at || 0) * 1000).toLocaleString()}
         >
           {ageLabel}
@@ -254,10 +254,13 @@ function JobCard({ job, onCancel, onDelete, t }) {
       </div>
 
       {/* Languages */}
-      <div className="batch-queue__card-langs">
+      <div className="batch-queue__card-langs flex items-center gap-[var(--space-2)] mb-[var(--space-3)] text-[var(--text-xs)] text-fg-muted">
         <Globe size={9} />
         {job.langs.map((l) => (
-          <span key={l} className="batch-queue__card-lang">
+          <span
+            key={l}
+            className="batch-queue__card-lang rounded-sm [border:1px_solid_var(--color-border)] bg-bg-elev-2 px-[6px] py-[1px] font-mono text-[10px] uppercase tracking-[0.05em]"
+          >
             {l}
           </span>
         ))}
@@ -265,52 +268,56 @@ function JobCard({ job, onCancel, onDelete, t }) {
 
       {/* Progress bar for running jobs */}
       {job.status === 'running' && progress && (
-        <div className="batch-queue__progress">
-          <div className="batch-queue__progress-bar">
+        <div className="batch-queue__progress mt-[var(--space-2)] mb-[var(--space-3)]">
+          <div className="batch-queue__progress-bar relative h-[6px] overflow-hidden rounded-[3px] bg-bg-elev-2">
             <div
               className="batch-queue__progress-fill"
               style={{ width: `${Math.min(100, pct)}%` }}
             />
           </div>
-          <div className="batch-queue__progress-info">
-            <span className="batch-queue__progress-stage">{stageLabel}</span>
+          <div className="batch-queue__progress-info flex items-center gap-[var(--space-3)] mt-[var(--space-2)] text-[var(--text-xs)] text-fg-muted">
+            <span className="batch-queue__progress-stage font-semibold text-fg">{stageLabel}</span>
             {progress.current_lang && (
-              <span className="batch-queue__progress-lang">{progress.current_lang}</span>
+              <span className="batch-queue__progress-lang rounded-sm [border:1px_solid_var(--color-border)] bg-bg-elev-2 px-[4px] font-mono text-[10px] uppercase">
+                {progress.current_lang}
+              </span>
             )}
             {progress.current_segment != null && progress.total_segments && (
-              <span className="batch-queue__progress-segs">
+              <span className="batch-queue__progress-segs [font-variant-numeric:tabular-nums]">
                 {t('batch.seg', {
                   current: progress.current_segment,
                   total: progress.total_segments,
                 })}
               </span>
             )}
-            <span className="batch-queue__progress-pct">{pct}%</span>
+            <span className="batch-queue__progress-pct ml-auto font-mono [font-variant-numeric:tabular-nums] font-semibold text-fg">
+              {pct}%
+            </span>
           </div>
         </div>
       )}
 
       {/* Duration for completed jobs */}
       {duration != null && (
-        <div className="batch-queue__card-meta">
+        <div className="batch-queue__card-meta mt-[var(--space-1)] text-[var(--text-xs)] text-fg-muted">
           {t('batch.completed_in', { duration: formatDuration(duration) })}
         </div>
       )}
 
       {/* Error display */}
       {job.error && (
-        <div className="batch-queue__card-error">
+        <div className="batch-queue__card-error flex items-start gap-[var(--space-2)] mt-[var(--space-3)] rounded-sm [border:1px_solid_rgba(251,73,52,0.25)] bg-[rgba(251,73,52,0.06)] p-[var(--space-3)] text-[var(--text-sm)] leading-[1.4] text-danger">
           <AlertCircle size={11} /> {job.error}
         </div>
       )}
 
       {/* Output downloads for done jobs */}
       {job.status === 'done' && job.outputs && Object.keys(job.outputs).length > 0 && (
-        <div className="batch-queue__card-outputs">
+        <div className="batch-queue__card-outputs flex flex-wrap gap-[var(--space-2)] mt-[var(--space-3)]">
           {Object.entries(job.outputs).map(([lang]) => (
             <a
               key={lang}
-              className="batch-queue__card-dl"
+              className="batch-queue__card-dl inline-flex items-center gap-[var(--space-2)] rounded-sm [border:1px_solid_var(--color-border)] bg-bg-elev-2 px-[10px] py-[3px] font-mono text-[var(--text-xs)] uppercase text-fg no-underline [transition:all_var(--dur-fast)] hover:bg-bg-elev-3 hover:[border-color:rgba(211,134,155,0.5)] hover:text-[#f3a5b6]"
               href={`${API}/batch/download/${job.id}/${lang}`}
               download
             >
@@ -321,7 +328,7 @@ function JobCard({ job, onCancel, onDelete, t }) {
       )}
 
       {/* Actions */}
-      <div className="batch-queue__card-actions">
+      <div className="batch-queue__card-actions flex justify-end gap-[var(--space-2)] mt-[var(--space-3)]">
         {(job.status === 'queued' || job.status === 'running') && (
           <Button
             variant="ghost"

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -68,21 +68,21 @@ export default function ContactPage({ onBack }) {
   const { t } = useTranslation();
 
   return (
-    <div className="support-page donate-page">
+    <div className="support-page donate-page flex flex-1 flex-col overflow-y-auto relative isolate bg-[var(--chrome-bg)]">
       <div className="lp-aurora" aria-hidden="true">
         <span className="lp-aurora__blob lp-aurora__blob--pink" />
         <span className="lp-aurora__blob lp-aurora__blob--green" />
         <span className="lp-aurora__blob lp-aurora__blob--amber" />
       </div>
 
-      <div className="support-page__topbar">
+      <div className="support-page__topbar relative z-[2] flex items-center justify-between gap-[12px] pt-[16px] px-[44px]">
         <Button variant="subtle" size="sm" onClick={onBack} leading={<ArrowLeft size={14} />}>
           {t('donate.back')}
         </Button>
-        <span className="support-page__spacer" aria-hidden="true" />
+        <span className="support-page__spacer w-[96px] shrink-0" aria-hidden="true" />
       </div>
 
-      <div className="support-page__content donate-page__content support-page__content--support">
+      <div className="support-page__content donate-page__content support-page__content--support relative z-[1] mx-auto flex w-full max-w-[640px] flex-col gap-[24px] px-[32px] pb-[40px]">
         <div className="support-view">
           <div className="donate-hero">
             <div className="donate-hero__icon-wrap">
@@ -92,7 +92,7 @@ export default function ContactPage({ onBack }) {
               {t('contact.hero_title', { defaultValue: 'Get in touch' })}
               <span className="lp-hero__sweep" aria-hidden="true" />
             </h2>
-            <p className="donate-hero__subtitle">
+            <p className="donate-hero__subtitle mx-auto mt-[10px] max-w-[480px] font-sans text-[0.8rem] leading-[1.65] text-[var(--chrome-fg-muted)]">
               {t('contact.hero_desc', {
                 defaultValue:
                   'Questions, bugs, licensing, or just to say hi — here’s how to reach me.',
@@ -101,7 +101,7 @@ export default function ContactPage({ onBack }) {
           </div>
 
           <section className="donate-section">
-            <div className="donate-grid support-methods">
+            <div className="donate-grid support-methods grid grid-cols-[1fr] gap-[10px]">
               {CHANNELS.map((c, i) => {
                 const Icon = c.icon;
                 return (
@@ -123,7 +123,9 @@ export default function ContactPage({ onBack }) {
                       <div className="donate-card__desc">
                         {t(c.descKey, { defaultValue: c.descDefault })}
                       </div>
-                      <div className="contact-card__value">{c.value}</div>
+                      <div className="contact-card__value mt-[4px] font-mono text-[11px] text-[var(--text-muted,#928374)] opacity-[0.85] [word-break:break-all]">
+                        {c.value}
+                      </div>
                     </div>
                     <div className="donate-card__arrow">
                       <ExternalLink size={14} />

--- a/frontend/src/pages/DonatePage.css
+++ b/frontend/src/pages/DonatePage.css
@@ -3,15 +3,11 @@
    .lp-aurora__blob, .lp-hero__sweep, .lp-glow-card from the Launchpad
    styles so there's zero visual divergence. */
 
-.donate-page {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  background: var(--chrome-bg);
-  position: relative;
-  isolation: isolate;
-}
+/* .donate-page + .donate-page__content + .donate-hero__subtitle + .donate-footer
+   + .donate-social-proof (base) + .donate-amounts are now Tailwind utilities in
+   SupportPage.jsx / ContactPage.jsx. Everything below stays as CSS — it carries
+   keyframes, ::before/::after dividers, :hover combinators, color-mix accents,
+   the --card-hue/--anim-i custom props, and the reduced-motion overrides. */
 
 /* ── Top bar (Back + Commercial License) ──────────────────── */
 .donate-page__topbar {
@@ -22,19 +18,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-}
-
-/* ── Content container ─────────────────────────────────────── */
-.donate-page__content {
-  position: relative;
-  z-index: 1;
-  max-width: 640px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 0 32px 40px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
 }
 
 /* ── Hero ──────────────────────────────────────────────────── */
@@ -76,15 +59,6 @@
   display: inline-block;
   line-height: 1.1;
 }
-.donate-hero__subtitle {
-  font-family: var(--font-sans);
-  font-size: 0.8rem;
-  color: var(--chrome-fg-muted);
-  line-height: 1.65;
-  max-width: 480px;
-  margin: 10px auto 0;
-}
-
 /* ── Section dividers ─────────────────────────────────────── */
 .donate-section__title {
   display: flex;
@@ -225,16 +199,6 @@
   background: color-mix(in srgb, var(--card-hue, #d3869b) 8%, transparent);
 }
 
-/* ── Footer ───────────────────────────────────────────────── */
-.donate-footer {
-  text-align: center;
-  font-family: var(--chrome-font-mono);
-  font-size: 0.72rem;
-  color: var(--chrome-fg-dim);
-  letter-spacing: 0.02em;
-  padding-bottom: 20px;
-}
-
 /* ── "Fund Claude Max" goal section + social proof ─────────── */
 .donate-goal-section {
   display: flex;
@@ -246,24 +210,9 @@
   background: color-mix(in srgb, var(--chrome-accent) 4%, transparent);
   animation: donateCardIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
-.donate-social-proof {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  font-family: var(--chrome-font-mono);
-  font-size: 0.7rem;
-  color: var(--chrome-fg-muted);
-  letter-spacing: 0.01em;
-}
 .donate-social-proof svg { color: var(--chrome-accent); }
 
 /* ── Suggested amounts ─────────────────────────────────────── */
-.donate-amounts {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-}
 .donate-amount {
   position: relative;
   display: flex;

--- a/frontend/src/pages/EnterprisePage.css
+++ b/frontend/src/pages/EnterprisePage.css
@@ -35,14 +35,10 @@
   padding-top: 32px;
   animation: entIn 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
-.ent-hero__kicker {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  font-weight: 600;
-  letter-spacing: var(--chrome-label-track);
-  text-transform: uppercase;
-  color: var(--chrome-fg-muted);
-}
+/* .ent-hero__kicker / .ent-hero__subtitle (base) / .ent-why__grid /
+   .ent-why__label / .ent-why__desc are now Tailwind utilities in
+   SupportPage.jsx (LicenseView). The rest stays — keyframes, ::before/::after
+   dividers, :hover combinators, color-mix accents, !important, details markers. */
 .ent-hero__title {
   font-family: var(--font-serif);
   font-size: 2.4rem;
@@ -53,14 +49,6 @@
   position: relative;
   display: inline-block;
   line-height: 1.1;
-}
-.ent-hero__subtitle {
-  font-family: var(--font-sans);
-  font-size: 0.85rem;
-  color: var(--chrome-fg-muted);
-  line-height: 1.65;
-  max-width: 540px;
-  margin: 16px auto 0;
 }
 .ent-hero__subtitle strong {
   color: var(--chrome-fg);
@@ -93,11 +81,6 @@
 }
 
 /* ── Why grid ─────────────────────────────────────────────── */
-.ent-why__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 10px;
-}
 .ent-why__card {
   padding: 14px 16px;
   border: 1px solid var(--chrome-border);
@@ -121,22 +104,6 @@
   color: #d3869b;
   margin-bottom: 10px;
 }
-.ent-why__label {
-  font-family: var(--chrome-font-mono);
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--chrome-fg);
-  letter-spacing: var(--chrome-label-track);
-  text-transform: uppercase;
-  margin-bottom: 4px;
-}
-.ent-why__desc {
-  font-family: var(--font-sans);
-  font-size: 0.72rem;
-  color: var(--chrome-fg-muted);
-  line-height: 1.5;
-}
-
 /* ── Pricing — coming-soon panel ──────────────────────────── */
 .ent-coming-soon {
   display: flex;

--- a/frontend/src/pages/Projects.css
+++ b/frontend/src/pages/Projects.css
@@ -1,26 +1,22 @@
 /* Projects page — browse all project types in one place. Uses the same
    chrome tokens as the top/bottom bars so the page frame reads as a
-   continuation of the studio shell. */
+   continuation of the studio shell.
 
-.projects {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  min-height: 0;
-  background: var(--bg);
-  color: var(--text-primary);
-}
+   Layout / spacing / container styling now live as Tailwind utilities in
+   Projects.jsx. What stays here:
+   - `.projects__title` — an `<h1>` whose letter-spacing fights the unlayered
+     global `h1..h4` rule (which would win over @layer utilities).
+   - `.projects__search input` + `::placeholder` — descendant input reset +
+     placeholder pseudo-element.
+   - `.projects__view-toggle button` + states — descendant <button> reset with
+     `:hover`/`.is-active` variants.
+   - `.projects__rail-item` cluster — descendant span, `:hover`, `.is-active`,
+     and the compound `.is-active .projects__rail-count` selector.
+   - `.projects__content--grid` / `--list` and the list-view `.projects__card*`
+     overrides — modifier display + descendant-combinator overrides.
+   - all `.projects__card*` — <button> reset, the `--card-accent` custom prop,
+     `:hover`/`:active`, gradient color-mix, and text-ellipsis. */
 
-/* ── Header strip — title + search + view toggle ────────────────── */
-.projects__header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 18px;
-  border-bottom: 1px solid var(--chrome-border);
-  background: var(--chrome-bg);
-  flex-shrink: 0;
-}
 .projects__title {
   font-family: var(--font-sans);
   font-size: 0.92rem;
@@ -30,26 +26,7 @@
   margin: 0;
   flex-shrink: 0;
 }
-.projects__toolbar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex: 1;
-  justify-content: flex-end;
-}
-.projects__search {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  height: var(--chrome-pill-h);
-  padding: 0 10px;
-  background: var(--chrome-hover-bg);
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  color: var(--chrome-fg-muted);
-  flex: 1;
-  max-width: 420px;
-}
+
 .projects__search input {
   background: transparent;
   border: none;
@@ -62,14 +39,6 @@
 }
 .projects__search input::placeholder { color: var(--chrome-fg-dim); }
 
-.projects__view-toggle {
-  display: inline-flex;
-  gap: 1px;
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  overflow: hidden;
-  background: var(--chrome-hover-bg);
-}
 .projects__view-toggle button {
   background: transparent;
   border: none;
@@ -88,23 +57,6 @@
   color: var(--chrome-accent);
 }
 
-/* ── Body: filter rail + content pane ──────────────────────────── */
-.projects__body {
-  display: grid;
-  grid-template-columns: 200px minmax(0, 1fr);
-  flex: 1;
-  min-height: 0;
-}
-
-.projects__rail {
-  border-right: 1px solid var(--chrome-border);
-  background: var(--chrome-bg);
-  padding: 10px 8px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
 .projects__rail-item {
   display: flex;
   align-items: center;
@@ -139,12 +91,7 @@
 }
 .projects__rail-item.is-active .projects__rail-count { color: var(--chrome-accent); }
 
-/* ── Content: card grid / list view ────────────────────────────── */
-.projects__content {
-  padding: 14px 18px;
-  overflow-y: auto;
-  min-height: 0;
-}
+/* ── Content view modifiers (display differs per view) ─────────────── */
 .projects__content--grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
@@ -156,18 +103,6 @@
   flex-direction: column;
   gap: 4px;
 }
-
-.projects__empty {
-  grid-column: 1 / -1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  padding: 48px 16px;
-  color: var(--chrome-fg-dim);
-  text-align: center;
-}
-.projects__empty p { max-width: 380px; margin: 0; font-size: 0.82rem; line-height: 1.5; }
 
 /* ── Cards ─────────────────────────────────────────────────────── */
 .projects__card {

--- a/frontend/src/pages/Projects.jsx
+++ b/frontend/src/pages/Projects.jsx
@@ -304,11 +304,11 @@ export default function Projects({
   }, [items, filter, query]);
 
   return (
-    <div className="projects">
-      <div className="projects__header">
+    <div className="projects flex flex-col h-full min-h-0 bg-[var(--bg)] text-[var(--text-primary)]">
+      <div className="projects__header flex shrink-0 items-center gap-[12px] px-[18px] py-[12px] [border-bottom:1px_solid_var(--chrome-border)] bg-[var(--chrome-bg)]">
         <h1 className="projects__title">{t('projects.title')}</h1>
-        <div className="projects__toolbar">
-          <div className="projects__search">
+        <div className="projects__toolbar flex flex-1 items-center justify-end gap-[8px]">
+          <div className="projects__search flex flex-1 items-center gap-[6px] h-[var(--chrome-pill-h)] max-w-[420px] px-[10px] [border:1px_solid_var(--chrome-border)] rounded-[var(--chrome-radius-pill)] bg-[var(--chrome-hover-bg)] text-[var(--chrome-fg-muted)]">
             <Search size={12} />
             <input
               value={query}
@@ -317,7 +317,7 @@ export default function Projects({
               spellCheck={false}
             />
           </div>
-          <div className="projects__view-toggle">
+          <div className="projects__view-toggle inline-flex gap-[1px] overflow-hidden [border:1px_solid_var(--chrome-border)] rounded-[var(--chrome-radius-pill)] bg-[var(--chrome-hover-bg)]">
             <button
               className={view === 'grid' ? 'is-active' : ''}
               onClick={() => setView('grid')}
@@ -338,8 +338,8 @@ export default function Projects({
         </div>
       </div>
 
-      <div className="projects__body">
-        <aside className="projects__rail">
+      <div className="projects__body grid flex-1 grid-cols-[200px_minmax(0,1fr)] min-h-0">
+        <aside className="projects__rail flex flex-col gap-[2px] overflow-y-auto px-[8px] py-[10px] [border-right:1px_solid_var(--chrome-border)] bg-[var(--chrome-bg)]">
           {FILTERS.map((f) => {
             const FI = f.Icon;
             const n = counts[f.id] ?? 0;
@@ -358,11 +358,15 @@ export default function Projects({
           })}
         </aside>
 
-        <section className={`projects__content projects__content--${view}`}>
+        <section
+          className={`projects__content projects__content--${view} px-[18px] py-[14px] overflow-y-auto min-h-0`}
+        >
           {visible.length === 0 && (
-            <div className="projects__empty">
+            <div className="projects__empty [grid-column:1/-1] flex flex-col items-center gap-[8px] px-[16px] py-[48px] text-center text-[var(--chrome-fg-dim)]">
               <FolderOpen size={28} />
-              <p>{query ? t('projects.no_matches', { query }) : t('projects.empty_hint')}</p>
+              <p className="max-w-[380px] m-0 text-[0.82rem] leading-[1.5]">
+                {query ? t('projects.no_matches', { query }) : t('projects.empty_hint')}
+              </p>
             </div>
           )}
           {visible.map((it) => (

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -22,49 +22,16 @@
 .settings-tabs-ui                { margin-bottom: var(--space-3); }
 
 .settings-row__mono     { font-family: var(--chrome-font-mono); color: var(--chrome-fg-muted); }
-.settings-muted         { color: var(--chrome-fg-dim); font-size: var(--text-md); font-family: var(--font-sans); }
-.settings-prose {
-  margin: 0 0 var(--space-5);
-  color: var(--chrome-fg-muted);
-  line-height: 1.6;
-  font-size: var(--text-md);
-  font-family: var(--font-sans);
-}
+/* .settings-muted, .settings-prose (base), .settings-log-meta, .settings-log__empty,
+   .settings-link-row, .settings-actions-row, .models-row__progressline are now
+   Tailwind utilities in the settings/* tab components. The .settings-prose strong
+   override stays (descendant selector). .settings-section__head-* are unused in
+   JSX today, so they stay until a consumer needs them. */
 .settings-prose strong  { color: var(--chrome-fg); font-weight: 600; }
 
 .settings-section__head-row     { display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); }
 .settings-section__head-left    { display: flex; align-items: center; gap: var(--space-4); }
 .settings-section__head-actions { display: flex; gap: var(--space-3); }
-
-.settings-log-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  font-size: var(--text-base);
-  color: var(--chrome-fg-dim);
-  margin: var(--space-4) 0;
-  font-family: var(--chrome-font-mono);
-}
-
-.settings-log__empty {
-  color: var(--chrome-fg-dim);
-  font-family: var(--font-sans);
-}
-
-.settings-link-row {
-  margin-top: var(--space-5);
-  display: flex;
-  gap: var(--space-4);
-  flex-wrap: wrap;
-}
-
-/* Inline button cluster under a SettingRow group (e.g. record/save/reset). */
-.settings-actions-row {
-  display: flex;
-  gap: var(--space-4);
-  margin-top: var(--space-5);
-  flex-wrap: wrap;
-}
 
 /* We're migrating to the ui/ Tabs primitive — keep a thin class so the old
    .settings-tabs gradient-above space stays; the Tabs primitive itself
@@ -410,9 +377,6 @@
 .models-row:hover .models-row__hint { opacity: 1; }
 .models-row__role     { color: var(--chrome-fg-muted); font-size: var(--text-xs); font-family: var(--chrome-font-mono); text-transform: uppercase; letter-spacing: 0.03em; }
 .models-row__progress { color: var(--chrome-accent); font-size: var(--text-xs); font-family: var(--chrome-font-mono); margin-top: 2px; }
-.models-row__progressline {
-  display: flex; flex-direction: column; gap: 3px; margin-top: 6px;
-}
 .models-row__progresstext {
   color: var(--chrome-fg-muted); font-size: var(--text-xs);
   font-family: var(--chrome-font-mono); font-variant-numeric: tabular-nums;

--- a/frontend/src/pages/SetupWizard.css
+++ b/frontend/src/pages/SetupWizard.css
@@ -7,14 +7,8 @@
    CONTENT region scrolls, and the .frs-wnav action row is pinned below it so
    Continue/Back are visible at every window size (they used to fall below
    the fold on the first-open window). */
-.swiz-slide {
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
-  min-width: 0;
-  flex: 1 1 auto;
-  min-height: 0;
-}
+/* `.swiz-slide` base (flex column) is now a Tailwind utility set in
+   SetupWizard.jsx; its child-combinator rules below stay as CSS. */
 /* Every slide is exactly [content, .frs-wnav] — the content half scrolls,
    with a soft fade at the cut so clipped rows read as "scroll for more". */
 .swiz-slide > :not(.frs-wnav):not(.swiz-hfpin) {
@@ -37,13 +31,8 @@
   margin: 0;
 }
 
-.swiz-note {
-  margin: 0;
-  font-size: 0.74rem;
-  line-height: 1.5;
-  opacity: 0.6;
-}
-
+/* `.swiz-note` base is now a Tailwind utility set in SetupWizard.jsx; the
+   `--warn` modifier (uses a --frs token) stays as CSS. */
 .swiz-note--warn {
   opacity: 1;
   color: var(--chrome-severity-warn, #d79921);
@@ -55,31 +44,9 @@
 /* Preflight checks flow into responsive columns so the list stays short on a
    wide/maximized window instead of one tall single column. Collapses to a
    single column on narrow windows. */
-.swiz-checks {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  column-gap: 1.6rem;
-  row-gap: 0.55rem;
-  align-items: start;
-}
-
-.swiz-loading {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.78rem;
-  opacity: 0.65;
-  padding: 0.4rem 0;
-}
-
-/* Embedded Settings panels (Model Store / Engines / DictationDemo) manage
- * their own internals; cap their height so the act scrolls inside itself
- * rather than pushing the nav off-screen. */
-.frs-embed {
-  max-height: min(58vh, 640px);
-  overflow-y: auto;
-  border-radius: 10px;
-}
+/* `.swiz-checks` (responsive grid), `.swiz-loading` (flex row), and the
+   `.frs-embed` height cap are now Tailwind utilities in SetupWizard.jsx.
+   (`.frs-embed { min-width: 0 }` still lives in FirstRunSetup.css.) */
 
 /* ── Unified library list (models + engines, one grammar) ─────────────── */
 

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -77,7 +77,7 @@ function PreflightPanel({ report, loading, onRecheck }) {
   const { t } = useTranslation();
   if (loading && !report) {
     return (
-      <div className="swiz-loading">
+      <div className="swiz-loading flex items-center gap-[0.5rem] text-[0.78rem] opacity-65 py-[0.4rem]">
         <Loader className="spinner" size={14} /> {t('setup.probing')}
       </div>
     );
@@ -91,7 +91,7 @@ function PreflightPanel({ report, loading, onRecheck }) {
           ↻ {t('setup.recheck')}
         </button>
       </h2>
-      <div className="swiz-checks">
+      <div className="swiz-checks grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-x-[1.6rem] gap-y-[0.55rem] items-start">
         {report.checks.map((c) => (
           <div key={c.id} className={`frs-check frs-check--${c.status}`}>
             <span className="frs-check__led" aria-hidden="true" />
@@ -232,7 +232,10 @@ export default function SetupWizard({ onReady }) {
             no welcome ceremony (the journey rail + setup page already
             oriented them). */}
         {step === 0 && (
-          <div className="swiz-slide" key="step-0">
+          <div
+            className="swiz-slide flex flex-col gap-[0.8rem] min-w-0 flex-auto min-h-0"
+            key="step-0"
+          >
             <div className="frs-rise" style={{ '--rise': 1 }}>
               <PreflightPanel report={pre} loading={preLoading} onRecheck={recheckPreflight} />
             </div>
@@ -261,7 +264,10 @@ export default function SetupWizard({ onReady }) {
             Required models gate continue; engines and the optional tail
             ride in the same inventory. */}
         {step === 1 && (
-          <div className="swiz-slide" key="step-1">
+          <div
+            className="swiz-slide flex flex-col gap-[0.8rem] min-w-0 flex-auto min-h-0"
+            key="step-1"
+          >
             <section
               className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
               style={{ '--rise': 1 }}
@@ -269,7 +275,7 @@ export default function SetupWizard({ onReady }) {
               <h2 className="frs-panel__title">{t('firstrun.stage_models', 'Models & engines')}</h2>
               <WizardLibrary />
               {!modelsReady && status?.missing?.length > 0 && (
-                <p className="swiz-note swiz-note--warn">
+                <p className="swiz-note swiz-note--warn m-0 text-[0.74rem] leading-[1.5] opacity-60">
                   {t('setup.still_needed')} {status.missing.map((m) => m.label).join(', ')}
                 </p>
               )}
@@ -299,13 +305,16 @@ export default function SetupWizard({ onReady }) {
         {/* 2. Dictation — guided walkthrough. Skippable (per cross-platform
             parity rule: some users genuinely don't want dictation). */}
         {step === 2 && (
-          <div className="swiz-slide" key="step-2">
+          <div
+            className="swiz-slide flex flex-col gap-[0.8rem] min-w-0 flex-auto min-h-0"
+            key="step-2"
+          >
             <section
               className="frs-panel frs-rise relative flex flex-col gap-[0.6rem]"
               style={{ '--rise': 1 }}
             >
               <h2 className="frs-panel__title">{t('setup.try_dictation')}</h2>
-              <div className="frs-embed">
+              <div className="frs-embed max-h-[min(58vh,640px)] overflow-y-auto rounded-[10px]">
                 <DictationDemo />
               </div>
             </section>
@@ -331,7 +340,7 @@ export default function SetupWizard({ onReady }) {
         )}
 
         {!status && step > 0 && (
-          <div className="swiz-loading">
+          <div className="swiz-loading flex items-center gap-[0.5rem] text-[0.78rem] opacity-65 py-[0.4rem]">
             <Loader className="spinner" size={14} /> {t('setup.checking')}
           </div>
         )}

--- a/frontend/src/pages/SupportPage.css
+++ b/frontend/src/pages/SupportPage.css
@@ -2,18 +2,9 @@
    segmented toggle. Reuses the donate/enterprise chrome (DonatePage.css,
    EnterprisePage.css); this file only owns the toggle + panel transitions. */
 
-/* Top bar: Back · toggle (centered) · spacer */
-.support-page__topbar {
-  padding: 16px 44px 0;
-  position: relative;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-/* Mirrors the Back button's footprint so the toggle sits visually centered. */
-.support-page__spacer { width: 96px; flex-shrink: 0; }
+/* `.support-page__topbar` base + `.support-page__spacer` base are now Tailwind
+   utilities in SupportPage.jsx / ContactPage.jsx; their @media (max-width:540px)
+   overrides stay below. */
 
 /* ── Segmented toggle ─────────────────────────────────────────────────── */
 .support-toggle {
@@ -104,22 +95,9 @@
   justify-content: center;
 }
 
-/* Donation methods stack in a single clean column — three full-width rows,
-   no orphaned card in a half-empty second row. */
-.support-methods {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 10px;
-}
-
-/* ── "Other ways to help" chips ───────────────────────────────────────────
-   Non-monetary support (star, Discord) as quiet ghost pills, centered. */
-.support-chips {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 10px;
-}
+/* `.support-methods` (single-column grid) + `.support-chips` (centered flex
+   wrap) are now Tailwind utilities in the JSX. `.support-chip` stays — it has
+   :hover state + transitions + a descendant svg color. */
 .support-chip {
   display: inline-flex;
   align-items: center;
@@ -158,13 +136,5 @@
   .support-view { animation: none; }
 }
 
-/* Contact page — the small monospace channel value under each card's
-   description (e.g. "discord.gg/…", "palash.dev"). */
-.contact-card__value {
-  margin-top: 4px;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
-  color: var(--text-muted, #928374);
-  opacity: 0.85;
-  word-break: break-all;
-}
+/* `.contact-card__value` (the small monospace channel value under each Contact
+   card) is now a Tailwind utility set in ContactPage.jsx. */

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -99,13 +99,15 @@ function SupportView() {
           {t('donate.hero_title')}
           <span className="lp-hero__sweep" aria-hidden="true" />
         </h2>
-        <p className="donate-hero__subtitle">{t('donate.hero_desc')}</p>
+        <p className="donate-hero__subtitle mx-auto mt-[10px] max-w-[480px] font-sans text-[0.8rem] leading-[1.65] text-[var(--chrome-fg-muted)]">
+          {t('donate.hero_desc')}
+        </p>
       </div>
 
       {/* ── "Fund Claude Max" goal bar + social proof ──────────────────── */}
       <section className="donate-section donate-goal-section">
         <GoalBar progress={progress} />
-        <div className="donate-social-proof">
+        <div className="donate-social-proof flex items-center justify-center gap-[6px] font-mono text-[0.7rem] tracking-[0.01em] text-[var(--chrome-fg-muted)]">
           <Users size={13} />
           <span>
             {t('donate.goal.social_proof', {
@@ -124,7 +126,7 @@ function SupportView() {
           <span>{t('donate.suggested_title', { defaultValue: 'Pick an amount' })}</span>
         </div>
         <div
-          className="donate-amounts"
+          className="donate-amounts grid grid-cols-[repeat(4,1fr)] gap-[8px]"
           role="group"
           aria-label={t('donate.suggested_title', { defaultValue: 'Pick an amount' })}
         >
@@ -170,7 +172,7 @@ function SupportView() {
               : t('donate.choose_method', { defaultValue: 'Choose how to give' })}
           </span>
         </div>
-        <div className="donate-grid support-methods">
+        <div className="donate-grid support-methods grid grid-cols-[1fr] gap-[10px]">
           {METHODS.map((m, i) => (
             <LinkCard
               key={m.id}
@@ -188,7 +190,7 @@ function SupportView() {
         <div className="donate-section__title">
           <span>{t('support.other_ways')}</span>
         </div>
-        <div className="support-chips">
+        <div className="support-chips flex flex-wrap justify-center gap-[10px]">
           <button
             type="button"
             className="support-chip"
@@ -206,7 +208,9 @@ function SupportView() {
         </div>
       </section>
 
-      <div className="donate-footer">{t('donate.footer')}</div>
+      <div className="donate-footer pb-[20px] text-center font-mono text-[0.72rem] tracking-[0.02em] text-[var(--chrome-fg-dim)]">
+        {t('donate.footer')}
+      </div>
     </div>
   );
 }
@@ -234,12 +238,14 @@ function LicenseView() {
   return (
     <div className="support-view">
       <div className="ent-hero">
-        <span className="ent-hero__kicker">{t('enterprise.badge')}</span>
+        <span className="ent-hero__kicker font-mono text-[var(--chrome-label-size)] font-semibold uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
+          {t('enterprise.badge')}
+        </span>
         <h2 className="ent-hero__title">
           {t('enterprise.hero_title')}
           <span className="lp-hero__sweep" aria-hidden="true" />
         </h2>
-        <p className="ent-hero__subtitle">
+        <p className="ent-hero__subtitle mx-auto mt-[16px] max-w-[540px] font-sans text-[0.85rem] leading-[1.65] text-[var(--chrome-fg-muted)]">
           {t('enterprise.hero_simple', {
             defaultValue:
               'OmniVoice Studio is free and open-source under the AGPL-3.0 — including for commercial and internal business use. You only need a commercial license to embed it in a closed-source product without AGPL’s copyleft obligations.',
@@ -248,14 +254,18 @@ function LicenseView() {
       </div>
 
       <section className="ent-why">
-        <div className="ent-why__grid">
+        <div className="ent-why__grid grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-[10px]">
           {WHY_ITEMS.map(({ icon: Icon, label, desc }) => (
             <div key={label} className="ent-why__card">
               <div className="ent-why__icon">
                 <Icon size={16} />
               </div>
-              <div className="ent-why__label">{label}</div>
-              <div className="ent-why__desc">{desc}</div>
+              <div className="ent-why__label mb-[4px] font-mono text-[0.75rem] font-semibold uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg)]">
+                {label}
+              </div>
+              <div className="ent-why__desc font-sans text-[0.72rem] leading-[1.5] text-[var(--chrome-fg-muted)]">
+                {desc}
+              </div>
             </div>
           ))}
         </div>
@@ -307,7 +317,7 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
   const [view, setView] = useState(initialView === 'license' ? 'license' : 'support');
 
   return (
-    <div className="support-page donate-page">
+    <div className="support-page donate-page flex flex-1 flex-col overflow-y-auto relative isolate bg-[var(--chrome-bg)]">
       {/* Aurora backdrop — shared with the Launchpad */}
       <div className="lp-aurora" aria-hidden="true">
         <span className="lp-aurora__blob lp-aurora__blob--pink" />
@@ -316,7 +326,7 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
       </div>
 
       {/* Top bar: Back (left) · toggle (center) · spacer (right, balances Back) */}
-      <div className="support-page__topbar">
+      <div className="support-page__topbar relative z-[2] flex items-center justify-between gap-[12px] pt-[16px] px-[44px]">
         <Button variant="subtle" size="sm" onClick={onBack} leading={<ArrowLeft size={14} />}>
           {t('donate.back')}
         </Button>
@@ -343,7 +353,7 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
           </button>
         </div>
 
-        <span className="support-page__spacer" aria-hidden="true" />
+        <span className="support-page__spacer w-[96px] shrink-0" aria-hidden="true" />
       </div>
 
       {/* key={view} remounts the panel so its entry animations replay on toggle.
@@ -351,7 +361,7 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
           it doesn't float at the top of an empty page; License stays top-aligned
           since it's tall enough to fill on its own. */}
       <div
-        className={`support-page__content donate-page__content support-page__content--${view}`}
+        className={`support-page__content donate-page__content support-page__content--${view} relative z-[1] mx-auto flex w-full max-w-[640px] flex-col gap-[24px] px-[32px] pb-[40px]`}
         key={view}
       >
         {view === 'support' ? <SupportView /> : <LicenseView />}

--- a/frontend/src/pages/ToolsPage.css
+++ b/frontend/src/pages/ToolsPage.css
@@ -1,18 +1,9 @@
-.tools-page {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-5);
-  padding: var(--space-5) var(--space-6);
-  min-height: 0;
-  overflow-y: auto;
-}
-.tools-page__bar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  flex-shrink: 0;
-}
+/* Layout/spacing/box rules now live as Tailwind utilities in ToolsPage.jsx.
+   Only the rules below remain: the `<h1>` font-family + the descendant
+   `code`/`pre` typography — both fight the unlayered global element rules in
+   index.css (h1 → font-sans, code/pre → font-variant-numeric), which would win
+   over @layer utilities, so they stay as plain CSS. */
+
 .tools-page__bar h1 {
   margin: 0;
   font-family: var(--font-display);
@@ -22,41 +13,6 @@
   align-items: center;
   gap: var(--space-3);
 }
-.tools-page__grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
-  gap: var(--space-5);
-}
 
-.tools-card__desc {
-  margin: 0 0 var(--space-4);
-  font-size: var(--text-base);
-  color: var(--color-fg-muted);
-  line-height: 1.5;
-}
-.tools-card__row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-4);
-  margin-bottom: var(--space-4);
-}
-.tools-card__out {
-  margin-top: var(--space-4);
-  padding: var(--space-4);
-  background: var(--color-bg-elev-2);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  font-size: var(--text-sm);
-}
-.tools-card__out-row { margin-bottom: var(--space-2); }
 .tools-card__out code { font-family: var(--font-mono); color: var(--color-fg); }
 .tools-card__out pre  { margin: var(--space-2) 0 0; font-family: var(--font-mono); overflow-x: auto; white-space: pre-wrap; }
-.tools-card__result {
-  margin-top: var(--space-2);
-  padding: var(--space-3);
-  background: rgba(211, 134, 155, 0.08);
-  border: 1px solid rgba(211, 134, 155, 0.25);
-  border-radius: var(--radius-sm);
-  color: var(--color-fg);
-  font-size: var(--text-md);
-}

--- a/frontend/src/pages/ToolsPage.jsx
+++ b/frontend/src/pages/ToolsPage.jsx
@@ -13,8 +13,8 @@ import './ToolsPage.css';
 export default function ToolsPage({ onBack }) {
   const { t } = useTranslation();
   return (
-    <div className="tools-page">
-      <div className="tools-page__bar">
+    <div className="tools-page flex flex-1 flex-col gap-[var(--space-5)] min-h-0 overflow-y-auto px-[var(--space-6)] py-[var(--space-5)]">
+      <div className="tools-page__bar flex shrink-0 items-center gap-[var(--space-4)]">
         {onBack && (
           <Button variant="ghost" size="sm" onClick={onBack}>
             {t('common.back')}
@@ -25,7 +25,7 @@ export default function ToolsPage({ onBack }) {
         </h1>
       </div>
 
-      <div className="tools-page__grid">
+      <div className="tools-page__grid grid grid-cols-[repeat(auto-fit,minmax(380px,1fr))] gap-[var(--space-5)]">
         <DirectorTool />
         <RateFitTool />
         <ProbeTool />
@@ -62,7 +62,9 @@ function DirectorTool() {
         </>
       }
     >
-      <p className="tools-card__desc">{t('tools.directorial_desc')}</p>
+      <p className="tools-card__desc m-0 mb-[var(--space-4)] text-[var(--text-base)] leading-[1.5] text-fg-muted">
+        {t('tools.directorial_desc')}
+      </p>
       <Field label={t('tools.direction')}>
         <Textarea rows={2} value={text} onChange={(e) => setText(e.target.value)} />
       </Field>
@@ -70,8 +72,8 @@ function DirectorTool() {
         {t('tools.parse')}
       </Button>
       {result && (
-        <div className="tools-card__out">
-          <div className="tools-card__out-row">
+        <div className="tools-card__out mt-[var(--space-4)] rounded-sm [border:1px_solid_var(--color-border)] bg-bg-elev-2 p-[var(--space-4)] text-[var(--text-sm)]">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.method')}</strong>{' '}
             <Badge tone={result.method === 'llm' ? 'violet' : 'neutral'}>{result.method}</Badge>
             {result.error && (
@@ -80,13 +82,13 @@ function DirectorTool() {
               </Badge>
             )}
           </div>
-          <div className="tools-card__out-row">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.tts_instruct')}</strong> <code>{result.instruct_prompt || '—'}</code>
           </div>
-          <div className="tools-card__out-row">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.translate_hint')}</strong> <em>{result.translate_hint || '—'}</em>
           </div>
-          <div className="tools-card__out-row">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.rate_bias')}</strong> <code>{result.rate_bias?.toFixed?.(2)}</code>
           </div>
           <details>
@@ -139,11 +141,13 @@ function RateFitTool() {
         </>
       }
     >
-      <p className="tools-card__desc">{t('tools.speech_rate_desc')}</p>
+      <p className="tools-card__desc m-0 mb-[var(--space-4)] text-[var(--text-base)] leading-[1.5] text-fg-muted">
+        {t('tools.speech_rate_desc')}
+      </p>
       <Field label={t('tools.translated_line')}>
         <Textarea rows={2} value={text} onChange={(e) => setText(e.target.value)} />
       </Field>
-      <div className="tools-card__row">
+      <div className="tools-card__row mb-[var(--space-4)] grid grid-cols-[1fr_1fr] gap-[var(--space-4)]">
         <Field label={t('tools.slot_seconds')}>
           <Input size="sm" value={slot} onChange={(e) => setSlot(e.target.value)} />
         </Field>
@@ -155,8 +159,8 @@ function RateFitTool() {
         {t('tools.fit')}
       </Button>
       {result && (
-        <div className="tools-card__out">
-          <div className="tools-card__out-row">
+        <div className="tools-card__out mt-[var(--space-4)] rounded-sm [border:1px_solid_var(--color-border)] bg-bg-elev-2 p-[var(--space-4)] text-[var(--text-sm)]">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.ratio')}</strong> <code>{result.rate_ratio?.toFixed?.(2)}</code>{' '}
             {result.error && (
               <Badge tone="warn" size="xs">
@@ -164,13 +168,15 @@ function RateFitTool() {
               </Badge>
             )}
           </div>
-          <div className="tools-card__out-row">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.attempts')}</strong> <code>{result.attempts}</code>
           </div>
-          <div className="tools-card__out-row">
+          <div className="tools-card__out-row mb-[var(--space-2)]">
             <strong>{t('tools.result')}</strong>
           </div>
-          <div className="tools-card__result">{result.text}</div>
+          <div className="tools-card__result mt-[var(--space-2)] rounded-sm [border:1px_solid_rgba(211,134,155,0.25)] bg-[rgba(211,134,155,0.08)] p-[var(--space-3)] text-[var(--text-md)] text-fg">
+            {result.text}
+          </div>
         </div>
       )}
     </Panel>
@@ -205,7 +211,9 @@ function ProbeTool() {
         </>
       }
     >
-      <p className="tools-card__desc">{t('tools.probe_desc')}</p>
+      <p className="tools-card__desc m-0 mb-[var(--space-4)] text-[var(--text-base)] leading-[1.5] text-fg-muted">
+        {t('tools.probe_desc')}
+      </p>
       <Field label={t('tools.absolute_path')}>
         <Input
           size="sm"
@@ -218,7 +226,10 @@ function ProbeTool() {
         {t('tools.probe')}
       </Button>
       {result && (
-        <details open className="tools-card__out">
+        <details
+          open
+          className="tools-card__out mt-[var(--space-4)] rounded-sm [border:1px_solid_var(--color-border)] bg-bg-elev-2 p-[var(--space-4)] text-[var(--text-sm)]"
+        >
           <summary>{t('tools.result')}</summary>
           <pre>{JSON.stringify(result, null, 2)}</pre>
         </details>

--- a/frontend/src/pages/Transcriptions.css
+++ b/frontend/src/pages/Transcriptions.css
@@ -1,68 +1,16 @@
 /* ── Transcriptions Page ───────────────────────────────────────────── */
+/* Layout / spacing / typography / box styling now live as Tailwind utilities
+   in Transcriptions.jsx. What stays here:
+   - `.txn-search__input` + `:focus` + `::placeholder` — placeholder is a
+     pseudo-element; kept whole so the focus/placeholder pair reads together.
+   - `.txn-list` scrollbar pseudo-elements.
+   - `.txn-item` + `:hover` + `--active` — the hover/active border-color
+     specificity interplay (hover out-specifies active in source) is preserved
+     by keeping all three as unlayered CSS.
+   - `.txn-detail__seg-title` — an `<h4>` whose margin + letter-spacing fight
+     the unlayered global `h1..h4` rule, which would win over @layer utilities. */
 
-.txn-page {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  padding: 20px 24px;
-  gap: 16px;
-  font-family: var(--font-sans);
-}
-
-/* Header */
-.txn-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.txn-header__left {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.txn-header__title {
-  font-size: var(--text-xl);
-  font-weight: var(--weight-semibold);
-  color: var(--color-fg);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0;
-}
-
-.txn-header__count {
-  font-size: var(--text-xs);
-  color: var(--color-fg-subtle);
-  background: var(--color-bg-elev-1);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
-  padding: 2px 10px;
-}
-
-.txn-header__right {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-/* Search */
-.txn-search {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.txn-search__icon {
-  position: absolute;
-  left: 10px;
-  color: var(--color-fg-subtle);
-  pointer-events: none;
-}
-
+/* Search input */
 .txn-search__input {
   width: 220px;
   background: var(--color-bg-elev-1);
@@ -84,63 +32,14 @@
   color: var(--color-fg-subtle);
 }
 
-/* Content layout */
-.txn-content {
-  flex: 1;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-  min-height: 0;
-}
-
-/* List */
-.txn-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  overflow-y: auto;
-  padding-right: 4px;
-}
-
+/* List scrollbar */
 .txn-list::-webkit-scrollbar { width: 5px; }
 .txn-list::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.08);
   border-radius: 3px;
 }
 
-/* Empty state */
-.txn-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  gap: 8px;
-  text-align: center;
-  color: var(--color-fg-muted);
-  padding: 40px 20px;
-}
-
-.txn-empty__icon {
-  opacity: 0.3;
-}
-
-.txn-empty__title {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
-  color: var(--color-fg);
-  margin: 0;
-}
-
-.txn-empty__desc {
-  font-size: var(--text-xs);
-  color: var(--color-fg-muted);
-  max-width: 280px;
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* Item */
+/* Item (resting + hover + active state interplay) */
 .txn-item {
   padding: 10px 12px;
   background: var(--color-bg-elev-1);
@@ -159,80 +58,7 @@
   box-shadow: 0 0 0 1px var(--color-brand-glow);
 }
 
-.txn-item__text {
-  font-size: var(--text-sm);
-  color: var(--color-fg);
-  line-height: 1.5;
-  margin-bottom: 6px;
-  word-break: break-word;
-}
-
-.txn-item__meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 10px;
-  color: var(--color-fg-subtle);
-}
-
-.txn-item__time,
-.txn-item__lang,
-.txn-item__dur {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-}
-
-/* Detail panel */
-.txn-detail {
-  display: flex;
-  flex-direction: column;
-  background: var(--color-bg-elev-1);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-}
-
-.txn-detail__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.txn-detail__time {
-  font-size: var(--text-xs);
-  color: var(--color-fg-muted);
-}
-
-.txn-detail__actions {
-  display: flex;
-  gap: 4px;
-}
-
-.txn-detail__body {
-  flex: 1;
-  padding: 14px;
-  overflow-y: auto;
-}
-
-.txn-detail__text {
-  font-size: var(--text-sm);
-  color: var(--color-fg);
-  line-height: 1.7;
-  white-space: pre-wrap;
-  margin: 0;
-}
-
-/* Segments */
-.txn-detail__segments {
-  border-top: 1px solid var(--color-border);
-  padding: 10px 14px;
-  max-height: 200px;
-  overflow-y: auto;
-}
-
+/* Segments heading (h4 — fights global heading rule) */
 .txn-detail__seg-title {
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
@@ -240,22 +66,4 @@
   margin: 0 0 6px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-}
-
-.txn-detail__seg {
-  display: flex;
-  gap: 8px;
-  padding: 3px 0;
-  font-size: var(--text-xs);
-}
-
-.txn-detail__seg-time {
-  flex-shrink: 0;
-  font-family: var(--font-mono);
-  color: var(--color-fg-subtle);
-  min-width: 80px;
-}
-
-.txn-detail__seg-text {
-  color: var(--color-fg);
 }

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -125,21 +125,28 @@ export default function TranscriptionsPage() {
   };
 
   return (
-    <div className="txn-page" role="region" aria-label={t('transcriptions.title')}>
+    <div
+      className="txn-page flex flex-col h-full px-[24px] py-[20px] gap-[16px] font-sans"
+      role="region"
+      aria-label={t('transcriptions.title')}
+    >
       {/* Header */}
-      <div className="txn-header">
-        <div className="txn-header__left">
-          <h1 className="txn-header__title">
+      <div className="txn-header flex flex-wrap items-center justify-between gap-[12px]">
+        <div className="txn-header__left flex items-center gap-[12px]">
+          <h1 className="txn-header__title flex items-center gap-[8px] text-[var(--text-xl)] font-semibold text-fg">
             <FileText size={20} />
             {t('transcriptions.title')}
           </h1>
-          <span className="txn-header__count">
+          <span className="txn-header__count rounded-[var(--radius-pill)] [border:1px_solid_var(--color-border)] bg-bg-elev-1 px-[10px] py-[2px] text-[var(--text-xs)] text-fg-subtle">
             {t('transcriptions.entries', { count: transcriptions.length })}
           </span>
         </div>
-        <div className="txn-header__right">
-          <div className="txn-search">
-            <Search size={13} className="txn-search__icon" />
+        <div className="txn-header__right flex items-center gap-[6px]">
+          <div className="txn-search relative flex items-center">
+            <Search
+              size={13}
+              className="txn-search__icon absolute left-[10px] pointer-events-none text-fg-subtle"
+            />
             <input
               className="txn-search__input"
               placeholder={t('transcriptions.search_placeholder')}
@@ -172,16 +179,16 @@ export default function TranscriptionsPage() {
       </div>
 
       {/* Content */}
-      <div className="txn-content">
+      <div className="txn-content grid flex-1 grid-cols-[1fr_1fr] gap-[12px] min-h-0">
         {/* List */}
-        <div className="txn-list" role="list">
+        <div className="txn-list flex flex-col gap-[4px] overflow-y-auto pr-[4px]" role="list">
           {filtered.length === 0 ? (
-            <div className="txn-empty">
-              <Mic size={32} className="txn-empty__icon" />
-              <p className="txn-empty__title">
+            <div className="txn-empty flex h-full flex-col items-center justify-center gap-[8px] px-[20px] py-[40px] text-center text-fg-muted">
+              <Mic size={32} className="txn-empty__icon opacity-30" />
+              <p className="txn-empty__title m-0 text-[var(--text-sm)] font-medium text-fg">
                 {search ? t('transcriptions.empty_search_title') : t('transcriptions.empty_title')}
               </p>
-              <p className="txn-empty__desc">
+              <p className="txn-empty__desc m-0 max-w-[280px] text-[var(--text-xs)] leading-[1.6] text-fg-muted">
                 {search ? t('transcriptions.empty_search_desc') : t('transcriptions.empty_desc')}
               </p>
             </div>
@@ -193,20 +200,22 @@ export default function TranscriptionsPage() {
                 className={`txn-item ${selectedId === t.id ? 'txn-item--active' : ''}`}
                 onClick={() => setSelectedId(t.id)}
               >
-                <div className="txn-item__text">
+                <div className="txn-item__text mb-[6px] text-[var(--text-sm)] leading-[1.5] text-fg [word-break:break-word]">
                   {t.text.length > 120 ? t.text.slice(0, 120) + '…' : t.text}
                 </div>
-                <div className="txn-item__meta">
-                  <span className="txn-item__time">
+                <div className="txn-item__meta flex items-center gap-[10px] text-[10px] text-fg-subtle">
+                  <span className="txn-item__time flex items-center gap-[3px]">
                     <Clock size={10} /> {formatTime(t.timestamp)}
                   </span>
                   {t.language && t.language !== 'unknown' && (
-                    <span className="txn-item__lang">
+                    <span className="txn-item__lang flex items-center gap-[3px]">
                       <Languages size={10} /> {t.language}
                     </span>
                   )}
                   {t.duration_s > 0 && (
-                    <span className="txn-item__dur">{t.duration_s.toFixed(1)}s</span>
+                    <span className="txn-item__dur flex items-center gap-[3px]">
+                      {t.duration_s.toFixed(1)}s
+                    </span>
                   )}
                 </div>
               </div>
@@ -216,12 +225,12 @@ export default function TranscriptionsPage() {
 
         {/* Detail panel */}
         {selected && (
-          <div className="txn-detail">
-            <div className="txn-detail__header">
-              <span className="txn-detail__time">
+          <div className="txn-detail flex flex-col [border:1px_solid_var(--color-border)] bg-bg-elev-1 rounded-lg overflow-hidden">
+            <div className="txn-detail__header flex items-center justify-between px-[14px] py-[10px] [border-bottom:1px_solid_var(--color-border)]">
+              <span className="txn-detail__time text-[var(--text-xs)] text-fg-muted">
                 {new Date(selected.timestamp).toLocaleString()}
               </span>
-              <div className="txn-detail__actions">
+              <div className="txn-detail__actions flex gap-[4px]">
                 <Button size="sm" variant="ghost" onClick={() => copyText(selected.text)}>
                   <Copy size={12} /> {t('transcriptions.copy')}
                 </Button>
@@ -230,18 +239,23 @@ export default function TranscriptionsPage() {
                 </Button>
               </div>
             </div>
-            <div className="txn-detail__body">
-              <p className="txn-detail__text">{selected.text}</p>
+            <div className="txn-detail__body flex-1 p-[14px] overflow-y-auto">
+              <p className="txn-detail__text m-0 text-[var(--text-sm)] leading-[1.7] whitespace-pre-wrap text-fg">
+                {selected.text}
+              </p>
             </div>
             {selected.segments && selected.segments.length > 0 && (
-              <div className="txn-detail__segments">
+              <div className="txn-detail__segments [border-top:1px_solid_var(--color-border)] px-[14px] py-[10px] max-h-[200px] overflow-y-auto">
                 <h4 className="txn-detail__seg-title">{t('transcriptions.segments_title')}</h4>
                 {selected.segments.map((seg, i) => (
-                  <div key={i} className="txn-detail__seg">
-                    <span className="txn-detail__seg-time">
+                  <div
+                    key={i}
+                    className="txn-detail__seg flex gap-[8px] py-[3px] text-[var(--text-xs)]"
+                  >
+                    <span className="txn-detail__seg-time shrink-0 font-mono text-fg-subtle min-w-[80px]">
                       {seg.start.toFixed(1)}s – {seg.end.toFixed(1)}s
                     </span>
-                    <span className="txn-detail__seg-text">{seg.text}</span>
+                    <span className="txn-detail__seg-text text-fg">{seg.text}</span>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## What

Mechanical, **conservative** CSS → Tailwind v4 utilities migration of the safe layout/spacing/typography "80%" across the **Settings** page and several smaller pages. No intended visual change — this is a continuation of the per-component migration (PRs #778–#780), now for pages.

Net: **+293 / −923** (≈ −630 lines of CSS) across 25 files.

## Rules followed (from the migration plan + prior-agent guidance)
- **No preflight reliance**: borders via `[border:1px_solid_var(--color-border)]`, anchors get explicit `no-underline`/color, inputs/buttons keep their resets.
- BEM class names **retained** alongside utilities, so descendant selectors still match and removal stays safe; a rule is only converted when it's also removed from CSS.
- Only `@theme` tokens become **named** utilities (`text-fg`, `bg-bg-elev-2`, `rounded-lg`, `font-mono`); `--chrome-*` / `--space-*` / `--text-*` / `--frs-*` and exact pixels use **arbitrary** `var()`/px.
- Transitions via arbitrary `[transition:…]`.
- **Kept in CSS** (the "hard 20%"): `@keyframes`, `::before/::after`, `:has()`/child/sibling combinators, glass/`backdrop-filter`, `!important`, media/container queries, state-modifier specificity interplay, and any rule that fights an **unlayered global element rule** (`h1..h4` font-family/letter-spacing, `code`/`pre`, `a`) which would beat `@layer utilities`.

## Per file (converted → utilities; kept = hard 20%)
| File | Converted | Kept |
|---|---|---|
| ToolsPage | page/card layout, desc/out/result | `h1`, `code`/`pre` descendants |
| BatchQueue | page/cards/progress/meta/outputs/actions | `h1`, card status modifiers, progress-fill shimmer pseudo + keyframes |
| Transcriptions | header/list/detail/segments | search input (+placeholder), list scrollbar, item hover/active interplay, `h4` seg-title |
| Projects | page/header/toolbar/search/rail/body/content/empty | `h1` title, search input, view-toggle + rail-item + card clusters, list-view descendants, content view modifiers |
| AudiobookTab | page/head/body/script/side/field/duo | `h2` title, scoped `.field-label`, textarea/select descendants, `@media` collapse |
| Donate/Support/Enterprise (shared SupportPage + ContactPage) | page/content/hero-subtitle/footer/social-proof/amounts/topbar/spacer/methods/chips/contact-value/ent kicker+subtitle+why-grid+label+desc | all animation/pseudo/state/color-mix/custom-prop chrome |
| SetupWizard | standalone `swiz-slide`/`note`/`checks`/`loading` + `frs-embed` | `frs-`-coupled lib/hfbar rows (first-run; extends `frs-*` primitives) |
| Settings | `settings-muted`/`prose`(base)/`log-meta`/`log__empty`/`link-row`/`actions-row` + `models-row__progressline` (in the `settings/*` tab components) | page grid/container-query shell, tab-rail rules, tables, rows, reco-banner |

`Settings.css` is a shared surface — every converted class was grepped across `src` first; shared classes (donate/support cluster, `settings-muted`, `settings-prose`) were updated at **every** usage site (SupportPage + ContactPage; AboutTab/ModelStoreTab; Hotkey/Credentials/Privacy).

## Verification
- `npx vite build` — clean
- `npx oxlint` — exit 0 (only pre-existing warnings)
- `npx oxfmt --check .` — clean
- `npx vitest run` — **641/641** pass
- `bun install --frozen-lockfile` — no change

> Note: no Playwright visual baselines exist for these pages, so "no visual change" is verified by the conservative rule-set (keeping anything stateful/pseudo/animated/overridden in CSS) rather than pixel diff. Partial conversion by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR continues the conservative Tailwind v4 migration across Settings and several related pages, moving safe layout/spacing/typography rules into JSX while keeping the more complex CSS-only cases in place.

Key changes:
- Settings tabs: updated styling for About, Credentials, Hotkey, Logs, Model Store, and Privacy to use more explicit utility classes; shared `settings-muted` / `settings-prose` usage was normalized.
- Page migrations: refactored Tools, Batch Queue, Projects, Transcriptions, Audiobook, Support/Contact, Enterprise, Donate, and Setup Wizard layouts to Tailwind-driven wrappers and grids.
- CSS reduction: trimmed page stylesheets to keep only rules that still need to override globals or preserve special behavior (pseudo-elements, media queries, keyframes, etc.).
- No functional logic changes were reported in the JSX updates.

Layout sketch:
```text
Before:
[page wrapper]
  [header]
  [content]
    [legacy CSS layout blocks]

After:
[page wrapper flex/grid]
  [header + toolbar]
  [utility-driven content grid]
    [cards / panels / sidebars]
```

Verification:
- `npx vite build` clean
- `npx oxlint` exit 0
- `npx oxfmt --check .` clean
- `npx vitest run` 641/641 passing
- `bun install --frozen-lockfile` no change

<!-- end of auto-generated comment: release notes by coderabbit.ai -->