### PR TITLE
feat(ui): back Dialog/Tooltip/Tabs/Menu/Panel with shadcn (prop APIs preserved)

### DIFF
--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * shadcn/ui Card — new-york style, themed through the OmniVoice token bridge
+ * (see index.css). `bg-card`/`text-card-foreground`/`border` resolve to the
+ * OmniVoice palette. `src/ui/Panel.jsx` builds on `Card` (as the surface
+ * primitive) plus its own header/body structure, layering the glass/solid/flat
+ * variants + the `.ui-panel*` cross-file hooks while keeping its
+ * `variant`/`padding`/`title`/`actions`/`as` prop API.
+ *
+ * The base `Card` accepts `asChild` (via Radix `Slot`) so a wrapper can render
+ * the surface as an arbitrary element (Panel's `as` prop) without losing the
+ * card styling.
+ */
+function Card({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'div'> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : 'div';
+  return (
+    <Comp
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * shadcn/ui Dialog — new-york style, themed through the OmniVoice token bridge
+ * (see index.css). `bg-background`/`border`/`ring-ring` resolve to the
+ * OmniVoice palette and the enter/exit transitions use tw-animate-css
+ * `animate-in`/`animate-out` keyed off Radix `data-[state]`.
+ *
+ * The app-facing primitive `src/ui/Dialog.jsx` wraps these parts, layering the
+ * glass surface + per-size widths and rendering its own close button
+ * (`showCloseButton={false}`) so call sites keep their existing prop API.
+ */
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * shadcn/ui DropdownMenu — new-york style, themed through the OmniVoice token
+ * bridge (see index.css). `src/ui/Menu.jsx` wraps `DropdownMenu` + `Trigger` +
+ * `Content` + `Item` + `Separator`, layering the OmniVoice glass surface +
+ * destructive/disabled item states via className while keeping its
+ * `items`/`placement`/`open`/`onOpenChange`/`width` prop API. Keyboard nav,
+ * collision-aware positioning, and ARIA come from Radix; enter/exit transitions
+ * use tw-animate-css `animate-in`/`animate-out`.
+ */
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+};

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * shadcn/ui Tabs — new-york style, themed through the OmniVoice token bridge
+ * (see index.css). `src/ui/Tabs.jsx` wraps `Tabs` + `TabsList` + `TabsTrigger`
+ * and supplies the OmniVoice pill/underline rail look via className while
+ * keeping its `items`/`value`/`onChange`/`size`/`variant` prop API. Provides
+ * roving tabindex, arrow-key navigation, and proper ARIA roles for free.
+ */
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * shadcn/ui Tooltip — new-york style, themed through the OmniVoice token bridge
+ * (see index.css). The arrow + body use `bg-primary`/`text-primary-foreground`
+ * by default; `src/ui/Tooltip.jsx` overrides the surface with the OmniVoice
+ * dark chrome look via className and maps the legacy `placement`/`delay` props.
+ * Enter/exit transitions use tw-animate-css `animate-in`/`animate-out` keyed off
+ * Radix `data-[state]` + `data-[side]`.
+ */
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  showArrow = true,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  showArrow?: boolean;
+}) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showArrow && (
+          <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        )}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/frontend/src/ui/Dialog.css
+++ b/frontend/src/ui/Dialog.css
@@ -1,51 +1,26 @@
 /* ── Dialog primitive ───────────────────────────────────────────── */
+/* Backed by shadcn/ui Dialog (src/components/ui/dialog.tsx). shadcn's
+   DialogContent owns the fixed centering, z-index, and open/close animation
+   (Radix data-[state] + tw-animate-css animate-in/out). What remains here is
+   the GLASS look, which Tailwind utilities can't express in this build (the app
+   ships Tailwind v4 without the backdrop-filter `--tw-*` plumbing):
 
-.ui-dialog-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+   • the content surface (warm layered gradient + backdrop blur), applied via
+     the `.ui-dialog` class the wrapper passes to DialogContent. It is unlayered
+     so it wins over shadcn's layered `bg-background`/`border`/`shadow` defaults.
+   • the overlay backdrop blur, keyed off shadcn's `data-slot="dialog-overlay"`
+     (shadcn already paints the `bg-black/50` scrim; we only add the blur). */
+
+[data-slot='dialog-overlay'] {
   backdrop-filter: var(--glass-blur-sm);
   -webkit-backdrop-filter: var(--glass-blur-sm);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-6);
-  z-index: var(--z-dialog);
-  animation: ui-dialog-fade var(--dur-base) var(--ease-out);
-}
-
-@keyframes ui-dialog-fade {
-  from { opacity: 0; }
-  to   { opacity: 1; }
-}
-
-@keyframes ui-dialog-pop {
-  from { opacity: 0; transform: translate(-50%, -50%) translateY(8px) scale(0.98); }
-  to   { opacity: 1; transform: translate(-50%, -50%) translateY(0)   scale(1);    }
 }
 
 .ui-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: calc(var(--z-dialog) + 1);
   background: linear-gradient(160deg, rgba(47, 41, 39, 0.95) 0%, rgba(32, 28, 27, 0.95) 100%);
   backdrop-filter: var(--glass-blur-md);
   -webkit-backdrop-filter: var(--glass-blur-md);
   border: 1px solid var(--color-border-warm);
-  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-xl);
   max-height: calc(100vh - var(--space-7) * 2);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  width: 100%;
-  animation: ui-dialog-pop var(--dur-base) var(--ease-spring);
 }
-
-/* sizes — the per-size max-width now lives in Dialog.jsx (DIALOG_MAX_W) as
-   `max-w-[…]` utilities. The header / title / body / footer box-model +
-   typography were likewise converted to utilities in Dialog.jsx. Only the
-   glass surface + fixed centering + open/close keyframes remain here, since
-   those can't be reduced to utilities. */

--- a/frontend/src/ui/Dialog.jsx
+++ b/frontend/src/ui/Dialog.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
-import * as RadixDialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
+import {
+  Dialog as ShadcnDialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import Button from './Button';
 import './Dialog.css';
 
-// Per-size max-width. The rest of the dialog surface (glass gradient,
-// backdrop-filter, fixed centering, open/close keyframes) stays in Dialog.css
-// because those rules can't be expressed as — or safely reduced to — utilities.
+// Per-size max-width. The dialog surface (glass gradient + backdrop-filter) and
+// the blurred overlay live in Dialog.css, keyed off shadcn's data-slot
+// attributes; centering + open/close animation come from shadcn's DialogContent
+// (Radix data-[state] + tw-animate-css). The header/title/body/footer box-model
+// stays as utilities below.
 const DIALOG_MAX_W = {
   sm: 'max-w-[380px]',
   md: 'max-w-[560px]',
@@ -15,7 +22,8 @@ const DIALOG_MAX_W = {
 };
 
 /**
- * Dialog — accessible modal backed by @radix-ui/react-dialog.
+ * Dialog — accessible modal backed by shadcn/ui Dialog (which wraps
+ * @radix-ui/react-dialog).
  *
  * Provides focus trapping, Escape-to-close, scroll lock, and
  * proper ARIA attributes out of the box.
@@ -49,40 +57,38 @@ export default function Dialog({
   };
 
   return (
-    <RadixDialog.Root open={open} onOpenChange={handleOpenChange}>
-      <RadixDialog.Portal>
-        <RadixDialog.Overlay className="ui-dialog-backdrop" />
-        <RadixDialog.Content
-          className={`ui-dialog ${DIALOG_MAX_W[size] || DIALOG_MAX_W.md}`}
-          onEscapeKeyDown={handleEscapeKeyDown}
-          onPointerDownOutside={handlePointerDownOutside}
-          aria-describedby={undefined}
-        >
-          {(title || dismissable) && (
-            <header className="flex shrink-0 items-center justify-between gap-[var(--space-4)] border-b border-border px-[var(--space-6)] py-[var(--space-5)]">
-              {title && (
-                <RadixDialog.Title className="m-0 font-serif text-[length:var(--text-lg)] font-bold tracking-[-0.01em] text-fg">
-                  {title}
-                </RadixDialog.Title>
-              )}
-              {dismissable && (
-                <RadixDialog.Close asChild>
-                  <Button variant="icon" iconSize="sm" aria-label="Close">
-                    <X size={12} />
-                  </Button>
-                </RadixDialog.Close>
-              )}
-            </header>
-          )}
-          {!title && <RadixDialog.Title className="sr-only">Dialog</RadixDialog.Title>}
-          <div className="min-h-0 overflow-y-auto p-[var(--space-6)]">{children}</div>
-          {footer && (
-            <footer className="flex shrink-0 items-center justify-end gap-[var(--space-3)] border-t border-border px-[var(--space-6)] py-[var(--space-4)]">
-              {footer}
-            </footer>
-          )}
-        </RadixDialog.Content>
-      </RadixDialog.Portal>
-    </RadixDialog.Root>
+    <ShadcnDialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className={`ui-dialog flex flex-col gap-0 overflow-hidden p-0 ${DIALOG_MAX_W[size] || DIALOG_MAX_W.md}`}
+        onEscapeKeyDown={handleEscapeKeyDown}
+        onPointerDownOutside={handlePointerDownOutside}
+        aria-describedby={undefined}
+      >
+        {(title || dismissable) && (
+          <header className="flex shrink-0 items-center justify-between gap-[var(--space-4)] border-b border-border px-[var(--space-6)] py-[var(--space-5)]">
+            {title && (
+              <DialogTitle className="m-0 font-serif text-[length:var(--text-lg)] font-bold tracking-[-0.01em] text-fg">
+                {title}
+              </DialogTitle>
+            )}
+            {dismissable && (
+              <DialogClose asChild>
+                <Button variant="icon" iconSize="sm" aria-label="Close">
+                  <X size={12} />
+                </Button>
+              </DialogClose>
+            )}
+          </header>
+        )}
+        {!title && <DialogTitle className="sr-only">Dialog</DialogTitle>}
+        <div className="min-h-0 overflow-y-auto p-[var(--space-6)]">{children}</div>
+        {footer && (
+          <footer className="flex shrink-0 items-center justify-end gap-[var(--space-3)] border-t border-border px-[var(--space-6)] py-[var(--space-4)]">
+            {footer}
+          </footer>
+        )}
+      </DialogContent>
+    </ShadcnDialog>
   );
 }

--- a/frontend/src/ui/Menu.css
+++ b/frontend/src/ui/Menu.css
@@ -1,9 +1,14 @@
 /* ── Menu primitive ─────────────────────────────────────────────── */
+/* Backed by shadcn/ui DropdownMenu (src/components/ui/dropdown-menu.tsx).
+   shadcn's DropdownMenuContent owns positioning (Radix anchored placement, set
+   via inline styles) and the enter/exit animation (data-[state]/data-[side] +
+   tw-animate-css). What remains here is the OmniVoice glass SURFACE + the item
+   rows — applied via the `.ui-menu*` classes the wrapper passes through.
+   `.ui-menu` is unlayered so it wins over shadcn's layered
+   `bg-popover`/`border`/`rounded-md`/`shadow-md` defaults. Position must NOT be
+   declared here — it would fight Radix's anchored placement. */
 
 .ui-menu {
-  /* Position is set by Radix via inline styles — declaring `position` here
-   * (especially `fixed`) fights its anchored placement and can cause the
-   * popover to render against the viewport edge instead of the trigger. */
   z-index: var(--z-overlay);
   min-width: 160px;
   max-width: 320px;
@@ -17,20 +22,6 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  animation-duration: var(--dur-fast);
-  animation-timing-function: var(--ease-out);
-  animation-fill-mode: both;
-}
-.ui-menu--below { animation-name: ui-menu-pop-down; transform-origin: top; }
-.ui-menu--above { animation-name: ui-menu-pop-up;   transform-origin: bottom; }
-
-@keyframes ui-menu-pop-down {
-  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0)    scale(1);    }
-}
-@keyframes ui-menu-pop-up {
-  from { opacity: 0; transform: translateY( 4px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0)    scale(1);    }
 }
 
 .ui-menu__item {

--- a/frontend/src/ui/Menu.jsx
+++ b/frontend/src/ui/Menu.jsx
@@ -1,12 +1,18 @@
 import React, { isValidElement } from 'react';
-import * as RadixMenu from '@radix-ui/react-dropdown-menu';
-import { ChevronRight } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import './Menu.css';
 
 /**
  * Menu — floating action menu triggered by a child element.
- * Backed by @radix-ui/react-dropdown-menu for keyboard navigation,
- * collision-aware positioning, and proper ARIA attributes.
+ * Backed by shadcn/ui DropdownMenu (which wraps @radix-ui/react-dropdown-menu)
+ * for keyboard navigation, collision-aware positioning, enter/exit animation,
+ * and proper ARIA attributes.
  *
  * @param children   exactly one child — the trigger element
  * @param items      array of items or 'separator' strings
@@ -47,41 +53,39 @@ export default function Menu({
   }
 
   return (
-    <RadixMenu.Root {...rootProps}>
-      <RadixMenu.Trigger asChild disabled={disabled}>
+    <DropdownMenu {...rootProps}>
+      <DropdownMenuTrigger asChild disabled={disabled}>
         {children}
-      </RadixMenu.Trigger>
-      <RadixMenu.Portal>
-        <RadixMenu.Content
-          side={side}
-          align={align}
-          sideOffset={4}
-          avoidCollisions
-          collisionPadding={8}
-          className={`ui-menu ui-menu--below ui-menu--${align}`}
-          style={width ? { width } : undefined}
-        >
-          {items.map((item, i) => {
-            if (item === 'separator' || item?.type === 'separator') {
-              return <RadixMenu.Separator key={`sep-${i}`} className="ui-menu__separator" />;
-            }
-            const Icon = item.icon;
-            return (
-              <RadixMenu.Item
-                key={item.id ?? i}
-                className={`ui-menu__item ${item.destructive ? 'is-destructive' : ''} ${item.disabled ? 'is-disabled' : ''}`}
-                disabled={item.disabled}
-                onSelect={() => item.onSelect?.()}
-              >
-                {Icon && <Icon size={12} className="ui-menu__icon" />}
-                <span className="ui-menu__label">{item.label}</span>
-                {item.shortcut && <span className="ui-menu__shortcut">{item.shortcut}</span>}
-                {item.trailing}
-              </RadixMenu.Item>
-            );
-          })}
-        </RadixMenu.Content>
-      </RadixMenu.Portal>
-    </RadixMenu.Root>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side={side}
+        align={align}
+        sideOffset={4}
+        avoidCollisions
+        collisionPadding={8}
+        className="ui-menu"
+        style={width ? { width } : undefined}
+      >
+        {items.map((item, i) => {
+          if (item === 'separator' || item?.type === 'separator') {
+            return <DropdownMenuSeparator key={`sep-${i}`} className="ui-menu__separator" />;
+          }
+          const Icon = item.icon;
+          return (
+            <DropdownMenuItem
+              key={item.id ?? i}
+              className={`ui-menu__item ${item.destructive ? 'is-destructive' : ''} ${item.disabled ? 'is-disabled' : ''}`}
+              disabled={item.disabled}
+              onSelect={() => item.onSelect?.()}
+            >
+              {Icon && <Icon size={12} className="ui-menu__icon" />}
+              <span className="ui-menu__label">{item.label}</span>
+              {item.shortcut && <span className="ui-menu__shortcut">{item.shortcut}</span>}
+              {item.trailing}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/ui/Panel.jsx
+++ b/frontend/src/ui/Panel.jsx
@@ -1,23 +1,25 @@
 import React, { forwardRef } from 'react';
-// Panel.css now holds ONLY the glass variant's backdrop-filter + gradient
-// surface + ::before highlight (effects Tailwind utilities can't express).
-// Everything else is utilities below. The `.ui-panel*` class names are kept so
-// the retained glass rule and external contextual overrides
-// (`.glossary-panel .ui-panel__body`, `.voice-profile__hero .ui-panel__body`)
-// still match.
-
-/* Token-faithful utilities. App ships Tailwind v4 without Preflight and themes
- * override `--color-*`, so colors/borders/shadows use arbitrary properties
- * referencing the exact original variables (radius/color use the @theme-mapped
- * named utilities, which resolve to the same `var(--…)` and track themes). */
+import { Card } from '@/components/ui/card';
+// The root surface is shadcn/ui Card (src/components/ui/card.tsx). Card runs the
+// class merge through cn()/twMerge, so the resets below (block / gap-0 / p-0 /
+// rounded-lg + the border/bg variant utilities) cleanly override Card's
+// opinionated defaults (flex / gap-6 / py-6 / rounded-xl / bg-card / shadow-sm),
+// and the result is forwarded to the requested `as` tag via Card's `asChild`.
+//
+// residual.css still holds ONLY the glass variant's backdrop-filter + gradient
+// surface + ::before highlight (effects Tailwind utilities can't express); being
+// unlayered, `.ui-panel--glass` wins over Card's layered `bg-card`. The
+// `.ui-panel*` class names are kept so that rule and external contextual
+// overrides (`.glossary-panel .ui-panel__body`, `.voice-profile__hero
+// .ui-panel__body`) still match.
 
 const VARIANT = {
-  // glass: surface (gradients + backdrop-filter) + ::before stay in Panel.css.
-  glass: '[border:1px_solid_var(--color-border-warm)]',
+  // glass: surface (gradients + backdrop-filter) + ::before stay in residual.css.
+  glass: 'border border-[var(--color-border-warm)]',
   solid:
-    '[border:1px_solid_var(--color-border-warm)] ' +
+    'border border-[var(--color-border-warm)] ' +
     '[background-image:linear-gradient(160deg,#2a2624_0%,#201c1b_100%)] [box-shadow:var(--shadow-md)]',
-  flat: '[border:1px_solid_var(--color-border)] [background-color:rgba(0,0,0,0.08)]',
+  flat: 'border border-[var(--color-border)] [background-color:rgba(0,0,0,0.08)]',
 };
 
 const PAD = {
@@ -28,7 +30,8 @@ const PAD = {
 };
 
 /**
- * Panel — a content surface. Replaces the ad-hoc card divs + `.glass-panel`.
+ * Panel — a content surface, backed by shadcn/ui Card. Replaces the ad-hoc card
+ * divs + `.glass-panel`.
  *
  * @param variant 'glass' | 'solid' | 'flat'
  * @param padding 'none' | 'sm' | 'md' | 'lg'
@@ -52,7 +55,8 @@ const Panel = forwardRef(function Panel(
   const classes = [
     'ui-panel',
     `ui-panel--${variant}`,
-    'relative overflow-hidden rounded-lg text-fg',
+    // resets for Card's opinionated root defaults + Panel's own surface.
+    'block gap-0 p-0 relative overflow-hidden rounded-lg text-fg',
     VARIANT[variant] || VARIANT.glass,
     className,
   ]
@@ -65,23 +69,25 @@ const Panel = forwardRef(function Panel(
     .join(' ');
 
   return (
-    <Tag ref={ref} className={classes} {...rest}>
-      {hasHeader && (
-        <header className="ui-panel__header flex items-center justify-between py-[var(--space-4)] px-[var(--space-5)] gap-[var(--space-4)] [border-bottom:1px_solid_var(--color-border)]">
-          {title != null && (
-            <div className="ui-panel__title flex items-center gap-[var(--space-3)] min-w-0 [font-size:var(--text-md)] font-bold text-fg tracking-[-0.01em]">
-              {title}
-            </div>
-          )}
-          {actions != null && (
-            <div className="ui-panel__actions flex items-center gap-[var(--space-3)] shrink-0">
-              {actions}
-            </div>
-          )}
-        </header>
-      )}
-      <div className={bodyClasses}>{children}</div>
-    </Tag>
+    <Card asChild className={classes}>
+      <Tag ref={ref} {...rest}>
+        {hasHeader && (
+          <header className="ui-panel__header flex items-center justify-between py-[var(--space-4)] px-[var(--space-5)] gap-[var(--space-4)] [border-bottom:1px_solid_var(--color-border)]">
+            {title != null && (
+              <div className="ui-panel__title flex items-center gap-[var(--space-3)] min-w-0 [font-size:var(--text-md)] font-bold text-fg tracking-[-0.01em]">
+                {title}
+              </div>
+            )}
+            {actions != null && (
+              <div className="ui-panel__actions flex items-center gap-[var(--space-3)] shrink-0">
+                {actions}
+              </div>
+            )}
+          </header>
+        )}
+        <div className={bodyClasses}>{children}</div>
+      </Tag>
+    </Card>
   );
 });
 

--- a/frontend/src/ui/Tabs.jsx
+++ b/frontend/src/ui/Tabs.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import * as RadixTabs from '@radix-ui/react-tabs';
+import { Tabs as ShadcnTabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 /**
- * Tabs — pill-style segmented tab group, backed by @radix-ui/react-tabs.
+ * Tabs — pill-style segmented tab group, backed by shadcn/ui Tabs (which wraps
+ * @radix-ui/react-tabs).
  *
  * Provides roving tabindex, arrow-key navigation, and proper
  * aria-selected / role="tab" / role="tablist" attributes.
@@ -30,38 +31,48 @@ export default function Tabs({
   // retained as stable hooks for page-level overrides — Settings.css restyles
   // the tab rail via `.ui-tabs.settings-tabs-ui .ui-tabs__tab.is-active …`,
   // which is unlayered and so still wins over these layered utilities.
+  //
+  // Active/inactive visual state is expressed with `data-[state=active]` /
+  // `data-[state=inactive]` variants (Radix sets data-state) rather than a JS
+  // boolean, so it carries the same CSS specificity as — and twMerge-overrides
+  // — shadcn's TabsTrigger defaults (e.g. `data-[state=active]:bg-background`).
+  // The leading utilities also reset shadcn's list/trigger box-model defaults
+  // (h-9, bg-muted, rounded-lg, flex-1, active shadow) back to OmniVoice's.
   const listClass = isPill
-    ? 'inline-flex shrink-0 gap-[3px] rounded-[var(--chrome-radius-pill)] border border-[var(--chrome-border)] bg-[var(--chrome-bg)] p-[3px]'
-    : 'inline-flex shrink-0 gap-[var(--space-5)] border-b border-[var(--chrome-border)]';
+    ? 'h-auto inline-flex shrink-0 gap-[3px] rounded-[var(--chrome-radius-pill)] border border-[var(--chrome-border)] bg-[var(--chrome-bg)] p-[3px]'
+    : 'h-auto inline-flex shrink-0 gap-[var(--space-5)] rounded-none border-0 border-b border-[var(--chrome-border)] bg-transparent p-0';
 
   return (
-    <RadixTabs.Root value={value} onValueChange={onChange} activationMode="manual">
-      <RadixTabs.List className={`ui-tabs ${listClass} ${className}`} {...rest}>
+    <ShadcnTabs
+      value={value}
+      onValueChange={onChange}
+      activationMode="manual"
+      className="block gap-0"
+    >
+      <TabsList className={`ui-tabs ${listClass} ${className}`} {...rest}>
         {items.map((item) => {
           const active = value === item.id;
           const Icon = item.icon;
           const tabClass = isPill
             ? [
-                'relative flex flex-[0_0_auto] cursor-pointer items-center justify-center gap-[var(--space-3)] rounded-[var(--chrome-radius-pill)] border font-sans tracking-[0.01em]',
+                'relative flex flex-none cursor-pointer items-center justify-center gap-[var(--space-3)] rounded-[var(--chrome-radius-pill)] border font-sans tracking-[0.01em] data-[state=active]:shadow-none',
                 '[transition:background_var(--dur-fast)_var(--ease-out),color_var(--dur-fast)_var(--ease-out),border-color_var(--dur-fast)_var(--ease-out)]',
                 'focus-visible:shadow-[var(--focus-ring)] focus-visible:outline-none',
                 isSm
                   ? 'px-[10px] py-[3px] text-[length:var(--text-xs)]'
                   : 'px-[14px] py-[5px] text-[length:var(--text-base)]',
-                active
-                  ? 'border-[var(--chrome-accent-border)] bg-[var(--chrome-accent-bg)] font-semibold text-[color:var(--chrome-accent)]'
-                  : 'border-transparent bg-transparent font-medium text-[color:var(--chrome-fg-muted)] hover:bg-[var(--chrome-hover-bg)] hover:text-[color:var(--chrome-fg)]',
+                'data-[state=active]:border-[var(--chrome-accent-border)] data-[state=active]:bg-[var(--chrome-accent-bg)] data-[state=active]:font-semibold data-[state=active]:text-[color:var(--chrome-accent)]',
+                'data-[state=inactive]:border-transparent data-[state=inactive]:bg-transparent data-[state=inactive]:font-medium data-[state=inactive]:text-[color:var(--chrome-fg-muted)] hover:data-[state=inactive]:bg-[var(--chrome-hover-bg)] hover:data-[state=inactive]:text-[color:var(--chrome-fg)]',
               ].join(' ')
             : [
-                'mb-[-1px] flex cursor-pointer items-center gap-[var(--space-2)] border-b-2 bg-transparent px-[2px] py-[6px] font-sans font-medium text-[length:var(--text-base)]',
+                'mb-[-1px] flex flex-none cursor-pointer items-center gap-[var(--space-2)] rounded-none border-0 border-b-2 bg-transparent px-[2px] py-[6px] font-sans font-medium text-[length:var(--text-base)] data-[state=active]:bg-transparent data-[state=active]:shadow-none',
                 '[transition:color_var(--dur-fast),border-color_var(--dur-fast)]',
                 'focus-visible:shadow-[var(--focus-ring)] focus-visible:outline-none',
-                active
-                  ? 'border-b-[var(--chrome-accent)] text-[color:var(--chrome-accent)]'
-                  : 'border-b-transparent text-[color:var(--chrome-fg-muted)] hover:text-[color:var(--chrome-fg)]',
+                'data-[state=active]:border-b-[var(--chrome-accent)] data-[state=active]:text-[color:var(--chrome-accent)]',
+                'data-[state=inactive]:border-b-transparent data-[state=inactive]:text-[color:var(--chrome-fg-muted)] hover:data-[state=inactive]:text-[color:var(--chrome-fg)]',
               ].join(' ');
           return (
-            <RadixTabs.Trigger
+            <TabsTrigger
               key={item.id}
               value={item.id}
               className={`ui-tabs__tab ${active ? 'is-active' : ''} ${tabClass}`}
@@ -69,10 +80,10 @@ export default function Tabs({
             >
               {Icon && <Icon size={12} className="ui-tabs__icon" />}
               <span>{item.label}</span>
-            </RadixTabs.Trigger>
+            </TabsTrigger>
           );
         })}
-      </RadixTabs.List>
-    </RadixTabs.Root>
+      </TabsList>
+    </ShadcnTabs>
   );
 }

--- a/frontend/src/ui/Tooltip.css
+++ b/frontend/src/ui/Tooltip.css
@@ -1,13 +1,12 @@
 /* ── Tooltip primitive ──────────────────────────────────────────── */
-
-.ui-tooltip-wrap {
-  position: relative;
-  display: inline-flex;
-}
+/* Backed by shadcn/ui Tooltip (src/components/ui/tooltip.tsx). shadcn's
+   TooltipContent owns positioning (Radix Popper) and the enter/exit animation
+   (data-[state]/data-[side] + tw-animate-css). What remains here is only the
+   OmniVoice tooltip SURFACE, applied via the `.ui-tooltip` class the wrapper
+   passes to TooltipContent — unlayered, so it wins over shadcn's layered
+   `bg-primary`/`text-primary-foreground`/`rounded-md`/`px-3 py-1.5` defaults. */
 
 .ui-tooltip {
-  position: absolute;
-  z-index: var(--z-overlay);
   background: #0f0e0d;
   color: var(--color-fg);
   font-family: var(--font-sans);
@@ -19,38 +18,5 @@
   box-shadow: var(--shadow-md);
   white-space: nowrap;
   pointer-events: none;
-  animation: ui-tooltip-in 0.15s var(--ease-out);
   max-width: 240px;
-}
-
-@keyframes ui-tooltip-in {
-  from { opacity: 0; transform: translate(-50%, 4px); }
-  to   { opacity: 1; transform: translate(-50%, 0); }
-}
-
-/* placements */
-.ui-tooltip--top {
-  bottom: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-}
-.ui-tooltip--bottom {
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  animation: ui-tooltip-in-b 0.15s var(--ease-out);
-}
-@keyframes ui-tooltip-in-b {
-  from { opacity: 0; transform: translate(-50%, -4px); }
-  to   { opacity: 1; transform: translate(-50%, 0); }
-}
-.ui-tooltip--left {
-  right: calc(100% + 6px);
-  top: 50%;
-  transform: translateY(-50%);
-}
-.ui-tooltip--right {
-  left: calc(100% + 6px);
-  top: 50%;
-  transform: translateY(-50%);
 }

--- a/frontend/src/ui/Tooltip.jsx
+++ b/frontend/src/ui/Tooltip.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import * as RadixTooltip from '@radix-ui/react-tooltip';
+import { Tooltip as ShadcnTooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import './Tooltip.css';
 
 /**
  * Tooltip — keyboard-accessible replacement for `title=`.
- * Backed by @radix-ui/react-tooltip for collision-aware positioning.
+ * Backed by shadcn/ui Tooltip (which wraps @radix-ui/react-tooltip) for
+ * collision-aware positioning + enter/exit animation.
  *
  * @param content    tooltip body (string or node)
  * @param placement  'top' | 'bottom' | 'left' | 'right'
@@ -17,20 +18,14 @@ export default function Tooltip({ content, placement = 'top', delay = 300, child
   const sideMap = { top: 'top', bottom: 'bottom', left: 'left', right: 'right' };
   const side = sideMap[placement] || 'top';
 
+  // shadcn's <Tooltip> supplies its own TooltipProvider; passing delayDuration
+  // to the Root overrides that provider's default so the `delay` prop is honored.
   return (
-    <RadixTooltip.Provider delayDuration={delay}>
-      <RadixTooltip.Root>
-        <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
-        <RadixTooltip.Portal>
-          <RadixTooltip.Content
-            side={side}
-            sideOffset={5}
-            className={`ui-tooltip ui-tooltip--${placement}`}
-          >
-            {content}
-          </RadixTooltip.Content>
-        </RadixTooltip.Portal>
-      </RadixTooltip.Root>
-    </RadixTooltip.Provider>
+    <ShadcnTooltip delayDuration={delay}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} sideOffset={5} showArrow={false} className="ui-tooltip">
+        {content}
+      </TooltipContent>
+    </ShadcnTooltip>
   );
 }


### PR DESCRIPTION
## What

Migrate the five overlay/nav primitives in `frontend/src/ui` to be **backed by the shadcn/ui layer** in `frontend/src/components/ui`, while keeping their **existing prop APIs + exports unchanged** — no call site changes.

shadcn wraps the **same** `@radix-ui` primitives these already used (`dialog`, `tooltip`, `tabs`, `dropdown-menu`) plus `Card` for `Panel`, so this is a structural swap, not a behavior change.

## shadcn components added (`src/components/ui/`)
`dialog.tsx`, `tooltip.tsx`, `tabs.tsx`, `dropdown-menu.tsx`, `card.tsx` — new-york style, themed through the existing `index.css` token bridge (recolor per `[data-theme]` automatically). Three minimal, canonical-style extensions let the wrappers preserve their exact look: `DialogContent` gains `showCloseButton`, `TooltipContent` gains `showArrow`, `Card` gains `asChild`.

**No new dependencies** — every required `@radix` package was already pinned. `package.json` and `bun.lock` are unchanged; `bun install --frozen-lockfile` is clean.

## Per-primitive prop-API mapping (all preserved)
- **Dialog** — `open / onClose / title / footer / size(sm|md|lg|xl) / dismissable / children`. Wraps `Dialog`+`DialogContent`(`showCloseButton={false}`, renders own close `Button`)+`DialogTitle`.
- **Tooltip** — `content / placement(top|bottom|left|right) / delay / children`. Wraps `Tooltip`+`TooltipTrigger`+`TooltipContent`(`showArrow={false}`); `delay` passed to Root to override shadcn's provider default.
- **Tabs** — `items[] / value / onChange / size(sm|md) / variant(pill|underline) / className`. Wraps `Tabs`+`TabsList`+`TabsTrigger`.
- **Menu** — `children(trigger) / items[] / placement / open / onOpenChange / width / disabled`. Wraps `DropdownMenu`+`Trigger`+`Content`+`Item`+`Separator`.
- **Panel** — `variant(glass|solid|flat) / padding / title / actions / as / className / forwardRef / …rest`. Root surface = `Card` (`asChild` preserves `as`).

## Glass + animation preservation
- **Animation** → delegated to shadcn (Radix `data-[state]`/`data-[side]` + `tw-animate-css` `animate-in/out`); obsolete `@keyframes` + manual positioning removed from `Dialog.css`/`Menu.css`/`Tooltip.css`.
- **Glass** (backdrop-filter + layered gradients — not expressible as utilities in this Tailwind v4 build) stays in CSS, now keyed off shadcn `data-slot`s or passed via the `.ui-*` classes. Those rules are **unlayered**, so they win over shadcn's layered `bg-popover`/`bg-card`/`bg-background`. `residual.css` `.ui-panel--glass` is untouched.
- **Tabs** active/inactive state moved to `data-[state]` variants so it has the specificity to override shadcn's `TabsTrigger` defaults; `.ui-tabs`/`.is-active` and all cross-file hooks (`settings-tabs-ui`, `glossary-panel`, `voice-profile__hero`, `ui-panel__*`) preserved.

## Harness coverage
- **Harness-coverable & verified:** Panel, Tabs — both render **pixel-identical** to existing baselines (visual suite 48 pass, **no baseline updates needed**).
- **Not snapshot-harness-coverable:** Dialog, Menu, Tooltip are Radix-**portal** primitives — verified via build + vitest + review instead.

## Gates
`oxlint` → 0 · `oxfmt --check .` → clean · `vite build` → ok · `vitest run` → **641 pass** · `bun run test:visual` → **48 pass** · `bun install --frozen-lockfile` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Migrated the core UI primitives in `frontend/src/ui` to shadcn-backed wrappers while preserving the existing public APIs and call sites.

- Added shadcn/ui component modules for `Card`, `Dialog`, `DropdownMenu`, `Tabs`, and `Tooltip`.
- Updated the local UI wrappers to consume those new components instead of direct Radix primitives.
- Kept behavior and exports stable, including small API extensions like `DialogContent.showCloseButton`, `TooltipContent.showArrow`, and `Card.asChild`.
- Simplified CSS so most positioning/animation now comes from shadcn/Radix state attributes, while OmniVoice glass styling remains in the stylesheet.
- Adjusted Tabs styling to use `data-[state]` variants, preserving active/inactive visuals.
- No dependency or lockfile changes.

ASCII sketch:

Before
```
Dialog/Menu/Tooltip/Tabs/Panel
  └─ direct Radix primitives
       └─ local CSS handles layout + animation
```

After
```
Dialog/Menu/Tooltip/Tabs/Panel
  └─ local wrappers
       └─ shadcn/ui primitives (Radix-based)
            └─ local CSS keeps glass/brand styling
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->