### PR TITLE
feat(ui): migrate misc global helper classes to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/components/clone/ActionBar.jsx
+++ b/frontend/src/components/clone/ActionBar.jsx
@@ -55,11 +55,13 @@ export default function ActionBar({
     <div className="studio-action-bar clone-panel--overflow-visible">
       {showOverrides && (
         <div className="override-content">
-          <div className="grid-4">
+          <div className="grid [grid-template-columns:repeat(auto-fit,minmax(120px,1fr))] gap-[6px] max-[500px]:grid-cols-2">
             <div>
               <div className="label-row label-row--spread">
                 <span>CFG</span>
-                <span className="val-bubble">{cfg}</span>
+                <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+                  {cfg}
+                </span>
               </div>
               <input
                 type="range"
@@ -73,7 +75,9 @@ export default function ActionBar({
             <div>
               <div className="label-row label-row--spread">
                 <span>{t('clone.speed')}</span>
-                <span className="val-bubble">{speed}x</span>
+                <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+                  {speed}x
+                </span>
               </div>
               <input
                 type="range"
@@ -87,7 +91,9 @@ export default function ActionBar({
             <div>
               <div className="label-row label-row--spread">
                 <span>{t('clone.tshift')}</span>
-                <span className="val-bubble">{tShift}</span>
+                <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+                  {tShift}
+                </span>
               </div>
               <input
                 type="range"
@@ -101,7 +107,9 @@ export default function ActionBar({
             <div>
               <div className="label-row label-row--spread">
                 <span>{t('clone.pos_temp')}</span>
-                <span className="val-bubble">{posTemp}</span>
+                <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+                  {posTemp}
+                </span>
               </div>
               <input
                 type="range"
@@ -115,7 +123,9 @@ export default function ActionBar({
             <div>
               <div className="label-row label-row--spread">
                 <span>{t('clone.class_temp')}</span>
-                <span className="val-bubble">{classTemp}</span>
+                <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+                  {classTemp}
+                </span>
               </div>
               <input
                 type="range"
@@ -129,7 +139,9 @@ export default function ActionBar({
             <div>
               <div className="label-row label-row--spread">
                 <span>{t('clone.layer_pen')}</span>
-                <span className="val-bubble">{layerPenalty}</span>
+                <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+                  {layerPenalty}
+                </span>
               </div>
               <input
                 type="range"
@@ -195,7 +207,9 @@ export default function ActionBar({
             value={steps}
             onChange={(e) => setSteps(Number(e.target.value))}
           />
-          <span className="val-bubble">{steps}</span>
+          <span className="text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]">
+            {steps}
+          </span>
         </label>
         <button
           type="button"

--- a/frontend/src/components/clone/AudioMethodPanel.jsx
+++ b/frontend/src/components/clone/AudioMethodPanel.jsx
@@ -101,7 +101,7 @@ export default function AudioMethodPanel({
         </div>
       )}
 
-      <div className="grid-2 mt-[6px]">
+      <div className="grid grid-cols-2 gap-[6px] max-[700px]:grid-cols-1 mt-[6px]">
         <div>
           <div className="label-row">{t('clone.transcript')}</div>
           <input

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -699,8 +699,8 @@ html[data-zoom-layout='off'] .app-container {
 /* ═══ TABS — migrated to ui/Tabs primitive; legacy .tabs/.tab removed. ═══ */
 
 /* ═══ GRID SYSTEMS ═══ */
-.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
-.grid-4 { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 6px; }
+/* .grid-2 / .grid-4 → Tailwind utilities (grid + grid-cols + responsive
+   max-[…] variants) inline in AudioMethodPanel.jsx / clone/ActionBar.jsx (P4). */
 
 /* Shared section-label style across workspace pages (Clone / Design /
    Dub) — rhymes with the status bar's "LOGS" label and the Sidebar
@@ -778,11 +778,7 @@ input[type="range"]::-webkit-slider-thumb:active {
   transform: scale(1.1);
   background: var(--primary);
 }
-.val-bubble {
-  font-size: 0.65rem; background: rgba(0,0,0,0.35); padding: 1px 5px; border-radius: 3px;
-  border: 1px solid rgba(255,255,255,0.04);
-  font-variant-numeric: tabular-nums;
-}
+/* .val-bubble → Tailwind utilities inline in clone/ActionBar.jsx (P4). */
 
 /* ═══ TAGS ═══ */
 .tags-container { display: flex; flex-wrap: wrap; gap: 3px; margin: 4px 0; }
@@ -2411,15 +2407,9 @@ div[role="dialog"].audio-trimmer {
      see CloneDesignTab.css); no narrow-viewport override needed. */
 }
 
-/* ── Grid utilities collapse ── */
-@media (max-width: 700px) {
-  .grid-2 { grid-template-columns: 1fr !important; }
-  .grid-3 { grid-template-columns: 1fr 1fr !important; }
-}
-@media (max-width: 500px) {
-  .grid-3 { grid-template-columns: 1fr !important; }
-  .grid-4 { grid-template-columns: 1fr 1fr !important; }
-}
+/* .grid-2 / .grid-4 responsive collapse → Tailwind max-[700px]/max-[500px]
+   variants inline at the usage sites (P4). .grid-3 was already dead (no base
+   rule, no usages) and is dropped with them. */
 
 /* ── Launchpad ── */
 @media (max-width: 900px) {


### PR DESCRIPTION
## P4 — shadcn/Tailwind migration: MISC global helpers

Eliminates small, self-contained MISC global helper classes from `frontend/src/index.css` by converting their raw-`className` usages to Tailwind utilities, then deleting the dead rules. Conservative, small-safe-wins scope.

### Migrated + deleted
| Class | Usages | Tailwind replacement |
|-------|--------|----------------------|
| `.grid-2` | 1 (`clone/AudioMethodPanel.jsx`) | `grid grid-cols-2 gap-[6px] max-[700px]:grid-cols-1` (responsive collapse preserved) |
| `.grid-4` | 1 (`clone/ActionBar.jsx`) | `grid [grid-template-columns:repeat(auto-fit,minmax(120px,1fr))] gap-[6px] max-[500px]:grid-cols-2` (responsive collapse preserved) |
| `.val-bubble` | 7 (`clone/ActionBar.jsx`) | `text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]` (explicit border — preflight is disabled) |
| `.grid-3` | 0 (already dead) | dropped with the grid collapse media block |

`index.css` net **−10 lines** (6 comment lines added, 16 rule lines removed).

### Left untouched (out of scope)
All remaining `index.css` classes are component-scoped families (`hq-*`, `lp-*`, `ss-*`, `segment-*`, `waveform-*`, `settings-*`, `nav-rail`/`rail-*`, `studio-*`, `glass-panel`, etc.), button families, settings-owned classes, or global element/reset/token rules. The candidate generic helpers from the brief (`.muted`, `.prose`, `.hint`, `.divider`, `.kbd`, `.pill`, `.row`, `.col`, `.stack`, `.spacer`, `.eyebrow`) do not exist in this file. No classes were left **blocked** — nothing in scope was composed/extended cross-file.

### Verification
- Live before/after Playwright (chromium) screenshots of the Clone tab — base view (`grid-2`) and Production Overrides expanded (`grid-4` + `val-bubble`): pixel-identical.
- Gates: `oxlint` exit 0 (only pre-existing warnings), `oxfmt --check` clean, `vite build` OK, `vitest` 641/641 pass, `bun run test:visual` 48/48 pass, `bun install --frozen-lockfile` no change.

⚠️ Part of a HELD batch — do not merge standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved generation status feedback with screen-reader announcements for start and completion.
* **UI/UX Improvements**
  * Updated override value displays to a cleaner, more compact pill-style look.
  * Made override and input layouts more responsive, with better spacing and column behavior on smaller screens.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->