### PR TITLE
feat(ui): migrate settings/form/row global classes to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/components/settings/LogsTab.jsx
+++ b/frontend/src/components/settings/LogsTab.jsx
@@ -58,7 +58,7 @@ export default function LogsTab({
           </Badge>
         )}
       </div>
-      <div className="settings-log">
+      <div className="bg-[var(--chrome-bg)] [border:1px_solid_var(--chrome-border)] rounded-[var(--chrome-radius-pill)] px-[12px] py-[10px] max-h-[280px] overflow-auto font-mono text-[0.72rem] text-[var(--chrome-fg-muted)] whitespace-pre-wrap break-words">
         {logs.length === 0 ? (
           <span className="settings-log__empty font-sans text-[var(--chrome-fg-dim)]">
             {logSource === 'frontend'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2205,56 +2205,11 @@ div[role="dialog"].audio-trimmer {
 .settings-page .settings-subtitle {
   color: var(--chrome-fg-muted); font-size: 0.78rem; margin-bottom: 24px;
 }
-/* Settings section — chrome-flat frame to match the rest of the app.
-   Keeps the content-forward padding; drops the warm gradient + squircle
-   corners + drop-shadow so it reads as a panel, not a jewel. */
-.settings-section {
-  background: var(--chrome-bg);
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  padding: 14px 18px; margin-bottom: 12px;
-}
-/* Section heading — chrome label, same typographic rhythm as "LOGS"
-   and sidebar section titles. */
-.settings-section h2 {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  font-weight: 600;
-  color: var(--chrome-fg-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--chrome-label-track);
-  margin: 0 0 10px; display: flex; align-items: center; gap: 8px;
-}
-.settings-row {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 8px 0; border-bottom: 1px solid var(--chrome-border);
-  font-family: var(--font-sans);
-  font-size: 0.76rem;
-}
-.settings-row:last-child { border-bottom: none; }
-.settings-row .label { color: var(--chrome-fg); font-weight: 500; letter-spacing: 0.01em; }
-/* Informational readout, not a button — no pill shell. The monospace
-   font alone signals "this is data"; bg/border would masquerade as
-   interactive. */
-.settings-row .value {
-  color: var(--chrome-fg-muted);
-  font-family: var(--chrome-font-mono);
-  font-size: 0.76rem;
-  background: transparent;
-  border: none;
-  padding: 0;
-}
-.settings-log {
-  background: var(--chrome-bg);
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  padding: 10px 12px;
-  max-height: 280px; overflow: auto;
-  font-family: var(--chrome-font-mono);
-  font-size: 0.72rem; color: var(--chrome-fg-muted);
-  white-space: pre-wrap; word-break: break-word;
-}
-/* ═══ Settings — badge, tabs, subtabs migrated to ui/Badge + ui/Tabs + ui/Segmented ═══ */
+/* ═══ Settings — badge, tabs, subtabs migrated to ui/Badge + ui/Tabs + ui/Segmented.
+   The legacy section/row frames are gone too (P4): .settings-section + h2 and
+   .settings-row(.label/.value) were superseded by the st-section primitive
+   (components/settings/primitives/SettingsSection.jsx), and .settings-log moved
+   to Tailwind utilities inline in components/settings/LogsTab.jsx. ═══ */
 
 /* Studio panels — flat chrome surface. Radial warmth + paper grain removed
    so Clone / Design / Dub panes sit on the same neutral frame as the rest


### PR DESCRIPTION
## P4 — settings/form/row global classes → Tailwind utilities

Part of the shadcn/Tailwind migration. Eliminates tractable settings/form/row LAYOUT globals from `frontend/src/index.css`.

**HELD BATCH — do not merge standalone.** This is one wave of the migration and should land with its batch.

### Migrated + deleted
- **`.settings-log`** — converted its sole usage (`components/settings/LogsTab.jsx`) to Tailwind utilities (`bg`/`border`/`rounded`/`padding`/`max-h`/`overflow`/`font-mono`/`whitespace`/`break-words`), then deleted the rule. `--chrome-font-mono` is an alias of `--font-mono`, so `font-mono` is exact parity → no visual change.

### Deleted as dead code (zero usages anywhere in `frontend/src`)
- **`.settings-section`** + **`.settings-section h2`** and **`.settings-row`** (`.label` / `.value` / `:last-child`) — superseded in an earlier wave by the `st-section` primitive (`components/settings/primitives/SettingsSection.jsx`).

### Left BLOCKED (cross-file / cross-wave contracts — not forced, per P4 safety rule)
- **`.settings-page` / `.settings-page h1` / `.settings-page .settings-subtitle`** — extended by `pages/Settings.css` via descendant selectors + a media-query grid override that depend on the class being in the DOM.
- **`.label-row` / `.label-icon`** — owned by the clone/dub workspaces (out of scope), extended in `CloneDesignTab.css` and `DubTab.css`.

### index.css delta
`-51 / +6` lines (net ~45 lines trimmed).

### Verification
- `npx oxlint` → exit 0 (pre-existing warnings only)
- `npx oxfmt --write src && npx oxfmt --check .` → clean
- `npx vite build` → ok
- `npx vitest run` → **641 passed**
- `bun install --frozen-lockfile` → no change
- `bun run test:visual` → **48 passed**
- Live screenshot diff (app on a dev port, `/setup/status` stubbed) of Settings tabs — General / Appearance / Models / Engines / Credentials / Logs — before vs after: palette + layout intact; the `.settings-log` empty-log panel is pixel-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Migrated the Settings logs container from the legacy `.settings-log` CSS class to Tailwind utilities in `LogsTab`, preserving the same empty/populated rendering behavior and header structure.

Removed now-dead Settings layout CSS from `index.css`:
- `.settings-section`
- `.settings-section h2`
- `.settings-row` and its label/value variants
- `.settings-log`

Kept the remaining Settings page/global styles intact where they still serve cross-file contracts.

Before/after sketch:

Before
```
[ Logs tab ]
----------------------------------
| [meta header]                 |
|                                |
| .settings-log                 |
|   (legacy CSS block)          |
|   empty state / log lines     |
----------------------------------
```

After
```
[ Logs tab ]
----------------------------------
| [meta header]                 |
|                                |
| Tailwind-styled container     |
|  bg + border + rounded + pad  |
|  max-h + overflow-auto        |
|  smaller mono-like text       |
|   empty state / log lines     |
----------------------------------
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->