### PR TITLE
feat(ui): migrate Launchpad lp-* classes to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1180,39 +1180,10 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
   75%      { transform: translate(60px,  -30px) scale(0.95); }
 }
 
-.lp-hero {
-  padding: 42px 44px 24px;
-  position: relative; z-index: 1;
-}
-.lp-kicker {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  font-weight: 600;
-  letter-spacing: var(--chrome-label-track);
-  text-transform: uppercase;
-  color: var(--chrome-fg-muted);
-}
-
-/* Hero H1 — Source Serif 4 at display size. Eternal halo glow sits behind
-   the text (::before via the new lp-hero__halo span so we can z-layer
-   without re-scoping the h1 itself); animated sweep underneath. */
-.lp-hero__title {
-  font-size: 2.75rem; font-weight: 400; margin: 0;
-  color: var(--chrome-fg);
-  font-family: var(--font-serif);
-  letter-spacing: -0.02em;
-  line-height: 1.04;
-  display: inline-block; position: relative;
-  font-optical-sizing: auto;
-  /* Paint containing block for halo / sweep absolute children */
-  padding: 0 4px;
-}
-.lp-hero__title em {
-  font-style: italic; font-weight: 400;
-  color: var(--chrome-accent);
-  /* Italic text sits a hair above serif baseline; nudge it back down. */
-  position: relative;
-}
+/* Hero H1 halo + sweep — eternal glow behind the (now utility-styled) <h1>
+   and an animated accent line underneath. Kept here because they are pure
+   ::pseudo/@keyframes decoration on absolutely-positioned spans, and the
+   sweep is reused cross-page by ContactPage/SupportPage/DonatePage. */
 .lp-hero__halo {
   position: absolute;
   inset: -16px -24px;
@@ -1251,35 +1222,15 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
   0%, 100% { transform: scaleX(0.35); opacity: 0.35; }
   50%      { transform: scaleX(1);    opacity: 0.85; }
 }
-/* Legacy squiggle span — hidden for back-compat if ever rendered. */
-.lp-hero h1 .lp-underline { display: none; }
-.lp-hero p {
-  margin: 14px 0 0; color: var(--chrome-fg-muted); font-size: 0.82rem;
-  font-family: var(--font-sans);
-  font-weight: 400; max-width: 560px; line-height: 1.6;
-}
-.lp-hero p .lp-pill {
-  display: inline-block; padding: 1px 8px;
-  border-radius: var(--chrome-radius-pill);
-  background: var(--chrome-accent-bg);
-  border: 1px solid var(--chrome-accent-border);
-  color: var(--chrome-accent);
-  font-family: var(--chrome-font-mono);
-  font-weight: 500; font-size: 0.72rem;
-  transform: none;
-  margin: 0 2px;
-}
-
 /* Action cards — flat chrome frame, painted with:
      • an always-on breath ring (the "eternal glow")
      • a cursor-tracked spotlight that fires on hover
    `--card-hue` (inline style) drives everything — background tint, icon,
    accent border, glow color — so each card's personality flows from one
-   hex value. `isolation: isolate` contains the pseudo-layer z-stack. */
-.lp-actions {
-  display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
-  padding: 4px 44px; position: relative; z-index: 1;
-}
+   hex value. `isolation: isolate` contains the pseudo-layer z-stack.
+   (The `.lp-actions` grid container is utility-styled inline on the
+   component; only the card itself keeps a class here for its pseudo
+   spotlight / breath-ring layers and nth-child stagger.) */
 .lp-action-card {
   background: transparent;
   border: 1px solid var(--chrome-border);
@@ -1312,14 +1263,6 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
   transform: scale(1.05);
   box-shadow: 0 0 18px -2px color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 45%, transparent);
 }
-.lp-action-card__emoji {
-  display: inline-block;
-  margin-left: 2px;
-  /* Keep emoji out of the uppercase tracking of the h3 */
-  text-transform: none;
-  letter-spacing: 0;
-}
-
 /* ── Glow layer (spotlight + breath ring) ────────────────────────── */
 .lp-glow-layer {
   position: absolute;
@@ -1408,129 +1351,6 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
   background: var(--chrome-bg);
 }
 
-/* Sections — softer headings */
-.lp-section {
-  padding: 28px 44px 40px; position: relative; z-index: 1;
-}
-/* Section titles on the launchpad — same chrome label treatment as the
-   sidebar / settings headings and the LOGS label in the footer. Drops
-   the Fraunces serif heading style so the three section dividers
-   ("Cloned Voices", "Designed Voices", "Dubbing Projects") rhyme with
-   the rest of the app's labels. */
-.lp-section-title {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: var(--chrome-label-track);
-  color: var(--chrome-fg-muted);
-  margin: 0 0 12px;
-  display: flex; align-items: center; gap: 8px;
-}
-.lp-section-title::after {
-  content: ""; flex: 1; height: 1px;
-  background-image: radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px);
-  background-size: 6px 1px;
-}
-
-/* ── Launchpad extracted layout classes ──────────────────── */
-.lp-hero__row {
-  display: flex; justify-content: space-between; align-items: flex-start;
-  gap: 24px; flex-wrap: wrap;
-}
-.lp-hero__col { max-width: 640px; }
-.lp-hero__kicker-row {
-  display: flex; align-items: center; gap: 10px; margin-bottom: 12px;
-}
-.lp-hero__wave-group {
-  display: flex; align-items: center; gap: 2px; height: 22px;
-}
-.lp-section__grid {
-  display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 20px;
-}
-.lp-col { display: flex; flex-direction: column; gap: 8px; }
-.lp-proj-icon--clone  { background: rgba(211,134,155,0.1); }
-.lp-proj-icon--design { background: rgba(142,192,124,0.1); }
-.lp-proj-icon--locked { background: rgba(184,187,38,0.1); }
-.lp-proj-icon--dub    { background: rgba(254,128,25,0.1); overflow: hidden; }
-.lp-proj-icon--file   { background: rgba(250,189,47,0.1); }
-.lp-proj-meta--italic { font-style: italic; }
-
-/* Recent files (OmniDrive) strip on the Launchpad */
-.lp-files__head {
-  display: flex; align-items: center; justify-content: space-between; gap: 12px;
-  margin-bottom: 12px;
-}
-.lp-files__head .lp-section-title { margin: 0; }
-.lp-files__head .lp-section-title::after { display: none; }
-.lp-view-all {
-  display: inline-flex; align-items: center; gap: 5px; flex-shrink: 0;
-  border: none; background: transparent; cursor: pointer; padding: 2px 4px;
-  font-family: var(--chrome-font-mono); font-size: var(--chrome-label-size);
-  font-weight: 600; text-transform: uppercase; letter-spacing: var(--chrome-label-track);
-  color: var(--chrome-fg-muted); transition: color 0.15s ease;
-}
-.lp-view-all:hover { color: #fabd2f; }
-.lp-files__grid {
-  display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 8px;
-}
-.lp-file-card {
-  width: 100%; font: inherit; color: inherit; text-align: left; cursor: pointer;
-}
-.lp-locked-badge {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  letter-spacing: var(--chrome-label-track);
-  padding: 1px 7px;
-  border-radius: var(--chrome-radius-pill);
-  background: color-mix(in srgb, #b8bb26 10%, transparent);
-  border: 1px solid color-mix(in srgb, #b8bb26 40%, transparent);
-  color: #b8bb26; font-weight: 600;
-}
-.lp-empty {
-  flex: 1; display: flex; align-items: center; justify-content: center;
-  position: relative; z-index: 1;
-}
-.lp-empty__inner { text-align: center; max-width: 360px; }
-.lp-empty__bars {
-  display: flex; justify-content: center; gap: 3px;
-  margin-bottom: 16px; opacity: 0.3;
-}
-.lp-empty__hint {
-  font-family: var(--chrome-font-mono);
-  font-size: 0.8rem; color: var(--chrome-fg-muted); margin: 0;
-}
-.lp-dub-thumb {
-  width: 100%; height: 100%; object-fit: cover;
-  border-radius: inherit; display: block;
-}
-
-/* ── Demo-profile callout ────────────────────────────────── */
-.lp-demo-callout {
-  display: flex; align-items: center; gap: 10px;
-  padding: 10px 18px; margin: 8px 44px 0;
-  background: color-mix(in srgb, var(--chrome-accent) 8%, var(--chrome-bg));
-  border: 1px solid var(--chrome-accent-border);
-  border-radius: var(--chrome-radius-pill);
-  font-size: 0.76rem; color: var(--chrome-fg);
-  position: relative; z-index: 1;
-  animation: lpFadeUp 0.5s cubic-bezier(0.4,0,0.2,1) both;
-}
-.lp-demo-callout__icon { font-size: 1.1rem; }
-.lp-demo-callout__btn {
-  margin-left: auto; padding: 4px 14px;
-  font-family: var(--font-sans); font-size: 0.7rem; font-weight: 600;
-  border-radius: var(--chrome-radius-pill);
-  background: var(--chrome-accent-bg);
-  border: 1px solid var(--chrome-accent-border);
-  color: var(--chrome-accent); cursor: pointer;
-  transition: background var(--dur-fast);
-}
-.lp-demo-callout__btn:hover {
-  background: color-mix(in srgb, var(--chrome-accent) 22%, transparent);
-}
-
 /* ── Personality picker strip ────────────────────────────── */
 .personality-strip {
   display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px;
@@ -1565,76 +1385,6 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
   letter-spacing: var(--chrome-label-track);
   color: var(--chrome-fg-muted);
   margin-bottom: 6px;
-}
-
-/* Project rows — chrome-radius pills so the launchpad project list
-   rhymes with the Projects page cards. Dropped the squircle corners,
-   the translate-X hover, and the icon rotation/scale micro-animation
-   — they read as playful overlay on a chrome frame; simple hover-tint
-   fits the status-bar visual language instead. */
-.lp-project-card {
-  background: var(--chrome-bg);
-  border: 1px solid var(--chrome-border);
-  border-radius: var(--chrome-radius-pill);
-  padding: 10px 14px;
-  transition: background 0.15s, border-color 0.15s;
-  display: flex; align-items: center; gap: 12px;
-}
-.lp-project-card:hover {
-  background: var(--chrome-hover-bg);
-  border-color: var(--chrome-border-strong);
-}
-.lp-project-card .proj-icon {
-  width: 32px; height: 32px;
-  border-radius: var(--chrome-radius-pill);
-  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
-}
-.lp-project-card .proj-info { flex: 1; min-width: 0; }
-.lp-project-card .proj-name {
-  font-family: var(--font-sans);
-  font-size: 0.78rem; font-weight: 600; color: var(--chrome-fg);
-  letter-spacing: 0.01em;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.lp-project-card .proj-meta {
-  font-family: var(--chrome-font-mono);
-  font-size: 0.62rem; color: var(--chrome-fg-dim); margin-top: 2px; font-weight: 400;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.lp-project-card .proj-action {
-  font-family: var(--font-sans);
-  font-size: 0.7rem; font-weight: 500; padding: 4px 12px;
-  border-radius: var(--chrome-radius-pill);
-  background: transparent;
-  border: 1px solid var(--chrome-border-strong);
-  color: var(--chrome-fg-muted); cursor: pointer;
-  transition: background var(--dur-fast), color var(--dur-fast), border-color var(--dur-fast);
-  flex-shrink: 0;
-  white-space: nowrap;
-  letter-spacing: 0.02em;
-}
-.lp-project-card .proj-action:hover {
-  background: var(--chrome-hover-bg); color: var(--chrome-fg);
-  border-color: var(--chrome-fg-muted);
-  transform: none;
-}
-
-/* Launchpad A/B Compare trigger — flat chrome accent button, no rotation. */
-.lp-ab-compare {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 6px 14px;
-  font-family: var(--font-sans);
-  font-size: 0.72rem; font-weight: 500;
-  letter-spacing: 0.02em;
-  color: var(--chrome-accent);
-  background: var(--chrome-accent-bg);
-  border: 1px solid var(--chrome-accent-border);
-  border-radius: var(--chrome-radius-pill);
-  cursor: pointer; flex-shrink: 0;
-  transition: background var(--dur-fast), border-color var(--dur-fast);
-}
-.lp-ab-compare:hover {
-  background: color-mix(in srgb, var(--chrome-accent) 22%, transparent);
 }
 
 /* Staggered fade-in */
@@ -2368,25 +2118,16 @@ div[role="dialog"].audio-trimmer {
 
 /* ── Launchpad ── */
 @media (max-width: 900px) {
-  .lp-hero { padding: 24px 20px 16px; }
-  .lp-hero h1 { font-size: 1.8rem; }
-  .lp-hero p { font-size: 0.85rem; }
-  .lp-actions { padding: 0 20px 16px; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
   .lp-action-card { min-width: 0; padding: 14px 12px; }
   .lp-action-card:nth-child(1),
   .lp-action-card:nth-child(2),
   .lp-action-card:nth-child(3) { transform: none; }
-  .lp-section { padding: 0 20px 24px; }
 }
 @media (max-width: 640px) {
-  .lp-hero h1 { font-size: 1.4rem; }
-  .lp-hero p { font-size: 0.78rem; max-width: 100%; }
-  .lp-actions { grid-template-columns: 1fr; padding: 0 12px 12px; }
   .lp-action-card { min-height: auto; padding: 12px 10px; }
   .lp-action-card h3 { font-size: 0.88rem; }
   .lp-action-card .card-desc { font-size: 0.68rem; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow: hidden; }
   .lp-action-card .card-icon { width: 28px; height: 28px; }
-  .lp-section { padding: 0 12px 16px; }
 }
 
 /* ── Studio panels — tighter on small screens ── */

--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -18,6 +18,26 @@ import { API } from '../api/client';
 import { useAppStore } from '../store';
 import ReadinessChecklist from '../components/ReadinessChecklist';
 
+// Shared utility-class strings for the Launchpad project/section rows. Migrated
+// from the former `.lp-project-card`/`.lp-section-title`/`.proj-*` global rules
+// (P4 shadcn/Tailwind pass). Defined once here so the four card instances stay
+// in lockstep; Tailwind's scanner picks the literals up from this file.
+const projCard =
+  'bg-[var(--chrome-bg)] border border-solid border-[var(--chrome-border)] rounded-[var(--chrome-radius-pill)] py-[10px] px-[14px] [transition:background_0.15s,border-color_0.15s] flex items-center gap-[12px] hover:bg-[var(--chrome-hover-bg)] hover:border-[var(--chrome-border-strong)]';
+const projIcon =
+  'w-[32px] h-[32px] rounded-[var(--chrome-radius-pill)] flex items-center justify-center shrink-0';
+const projInfo = 'flex-1 min-w-0';
+const projName =
+  '[font-family:var(--font-sans)] text-[0.78rem] font-semibold text-[color:var(--chrome-fg)] [letter-spacing:0.01em] whitespace-nowrap overflow-hidden text-ellipsis';
+const projMeta =
+  '[font-family:var(--chrome-font-mono)] text-[0.62rem] text-[color:var(--chrome-fg-dim)] mt-[2px] font-normal whitespace-nowrap overflow-hidden text-ellipsis';
+const projAction =
+  '[font-family:var(--font-sans)] text-[0.7rem] font-medium py-[4px] px-[12px] rounded-[var(--chrome-radius-pill)] bg-transparent border border-solid border-[var(--chrome-border-strong)] text-[color:var(--chrome-fg-muted)] cursor-pointer [transition:background_var(--dur-fast),color_var(--dur-fast),border-color_var(--dur-fast)] shrink-0 whitespace-nowrap [letter-spacing:0.02em] hover:bg-[var(--chrome-hover-bg)] hover:text-[color:var(--chrome-fg)] hover:border-[var(--chrome-fg-muted)]';
+// Section divider label ("Cloned Voices" etc.) — the trailing dotted rule lives
+// on an ::after pseudo, expressed via the after: variant.
+const sectionTitle =
+  "[font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] font-semibold uppercase [letter-spacing:var(--chrome-label-track)] text-[color:var(--chrome-fg-muted)] m-0 mb-[12px] flex items-center gap-[8px] after:content-[''] after:flex-1 after:h-px after:[background-image:radial-gradient(circle,rgba(255,255,255,0.12)_1px,transparent_1px)] after:[background-size:6px_1px]";
+
 function DubThumb({ jobId, fallback }) {
   const [failed, setFailed] = useState(false);
   if (!jobId || failed) return fallback;
@@ -27,7 +47,7 @@ function DubThumb({ jobId, fallback }) {
       alt=""
       onError={() => setFailed(true)}
       loading="lazy"
-      className="lp-dub-thumb"
+      className="w-full h-full object-cover [border-radius:inherit] block"
     />
   );
 }
@@ -104,11 +124,11 @@ export default function Launchpad({
       </div>
 
       {/* Hero */}
-      <div className="lp-hero">
-        <div className="lp-hero__row">
-          <div className="lp-hero__col">
-            <div className="lp-hero__kicker-row">
-              <div className="lp-hero__wave-group">
+      <div className="relative z-[1] pt-[42px] px-[44px] pb-[24px] max-[900px]:pt-[24px] max-[900px]:px-[20px] max-[900px]:pb-[16px]">
+        <div className="flex justify-between items-start gap-[24px] flex-wrap">
+          <div className="max-w-[640px]">
+            <div className="flex items-center gap-[10px] mb-[12px]">
+              <div className="flex items-center gap-[2px] h-[22px]">
                 {[10, 14, 8, 16, 12, 14, 9, 12].map((h, i) => (
                   <span
                     key={i}
@@ -124,18 +144,31 @@ export default function Launchpad({
                   />
                 ))}
               </div>
-              <span className="lp-kicker">{t('launchpad.greeting')}</span>
+              <span className="[font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] font-semibold [letter-spacing:var(--chrome-label-track)] uppercase text-[color:var(--chrome-fg-muted)]">
+                {t('launchpad.greeting')}
+              </span>
             </div>
-            <h1 className="lp-hero__title">
+            <h1 className="text-[2.75rem] max-[900px]:text-[1.8rem] max-[640px]:text-[1.4rem] font-normal m-0 text-[color:var(--chrome-fg)] [font-family:var(--font-serif)]! [letter-spacing:-0.02em]! [line-height:1.04] inline-block relative [font-optical-sizing:auto] px-[4px]">
               <span className="lp-hero__halo" aria-hidden="true" />
-              <Trans i18nKey="launchpad.hero_title" components={{ 1: <em /> }} />
+              <Trans
+                i18nKey="launchpad.hero_title"
+                components={{
+                  1: (
+                    <em className="italic font-normal text-[color:var(--chrome-accent)] relative" />
+                  ),
+                }}
+              />
               <span className="lp-hero__sweep" aria-hidden="true" />
             </h1>
-            <p>
+            <p className="m-0 mt-[14px] text-[color:var(--chrome-fg-muted)] text-[0.82rem] max-[900px]:text-[0.85rem] max-[640px]:text-[0.78rem] [font-family:var(--font-sans)] font-normal max-w-[560px] max-[640px]:max-w-full [line-height:1.6]">
               <Trans
                 i18nKey="launchpad.hero_desc"
                 values={{ count: 646 }}
-                components={{ 1: <span className="lp-pill" /> }}
+                components={{
+                  1: (
+                    <span className="inline-block py-[1px] px-[8px] rounded-[var(--chrome-radius-pill)] bg-[var(--chrome-accent-bg)] border border-solid border-[var(--chrome-accent-border)] text-[color:var(--chrome-accent)] [font-family:var(--chrome-font-mono)] font-medium text-[0.72rem] mx-[2px] my-0" />
+                  ),
+                }}
               />
             </p>
           </div>
@@ -146,7 +179,7 @@ export default function Launchpad({
           {profiles.length >= 2 && (
             <button
               onClick={() => setIsCompareModalOpen(true)}
-              className="lp-ab-compare"
+              className="inline-flex items-center gap-[6px] py-[6px] px-[14px] [font-family:var(--font-sans)] text-[0.72rem] font-medium [letter-spacing:0.02em] text-[color:var(--chrome-accent)] bg-[var(--chrome-accent-bg)] border border-solid border-[var(--chrome-accent-border)] rounded-[var(--chrome-radius-pill)] cursor-pointer shrink-0 [transition:background_var(--dur-fast),border-color_var(--dur-fast)] hover:bg-[color-mix(in_srgb,var(--chrome-accent)_22%,transparent)]"
               title={t('launchpad.ab_compare_title')}
             >
               <Scale size={12} /> {t('launchpad.ab_compare')}
@@ -156,7 +189,7 @@ export default function Launchpad({
       </div>
 
       {/* Action Cards */}
-      <div className="lp-actions">
+      <div className="grid grid-cols-3 gap-[12px] py-[4px] px-[44px] relative z-[1] max-[900px]:pt-0 max-[900px]:px-[20px] max-[900px]:pb-[16px] max-[900px]:[grid-template-columns:repeat(auto-fit,minmax(180px,1fr))] max-[640px]:grid-cols-1 max-[640px]:pt-0 max-[640px]:px-[12px] max-[640px]:pb-[12px]">
         <ActionCard
           hue="#d3869b"
           Icon={Fingerprint}
@@ -221,16 +254,20 @@ export default function Launchpad({
       {/* Recent files from OmniDrive — last few exports, with a jump to the
           full file browser (the Projects/OmniDrive page). */}
       {recentFiles.length > 0 && (
-        <div className="lp-section lp-files">
-          <div className="lp-files__head">
-            <div className="lp-section-title">
+        <div className="pt-[28px] px-[44px] pb-[40px] relative z-[1] max-[900px]:pt-0 max-[900px]:px-[20px] max-[900px]:pb-[24px] max-[640px]:pt-0 max-[640px]:px-[12px] max-[640px]:pb-[16px]">
+          <div className="flex items-center justify-between gap-[12px] mb-[12px]">
+            <div className="[font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] font-semibold uppercase [letter-spacing:var(--chrome-label-track)] text-[color:var(--chrome-fg-muted)] m-0 flex items-center gap-[8px]">
               <HardDrive size={12} color="#fabd2f" /> {t('launchpad.recent_files')}
             </div>
-            <button type="button" className="lp-view-all" onClick={() => setMode('projects')}>
+            <button
+              type="button"
+              className="inline-flex items-center gap-[5px] shrink-0 border-0 bg-transparent cursor-pointer py-[2px] px-[4px] [font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] font-semibold uppercase [letter-spacing:var(--chrome-label-track)] text-[color:var(--chrome-fg-muted)] [transition:color_0.15s_ease] hover:text-[#fabd2f]"
+              onClick={() => setMode('projects')}
+            >
               {t('launchpad.view_all_files')} <ArrowRight size={12} />
             </button>
           </div>
-          <div className="lp-files__grid">
+          <div className="grid [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))] gap-[8px]">
             {recentFiles.map((f, i) => {
               const name =
                 (f.destination_path || f.path || f.filename || '').split('/').pop() ||
@@ -239,16 +276,16 @@ export default function Launchpad({
                 <button
                   key={f.id || f.destination_path || i}
                   type="button"
-                  className="lp-project-card lp-file-card"
+                  className={`${projCard} w-full [font:inherit] text-inherit text-left cursor-pointer`}
                   onClick={() => setMode('projects')}
                   title={name}
                 >
-                  <div className="proj-icon lp-proj-icon--file">
+                  <div className={`${projIcon} bg-[rgba(250,189,47,0.1)]`}>
                     <Download size={14} color="#fabd2f" />
                   </div>
-                  <div className="proj-info">
-                    <div className="proj-name">{name}</div>
-                    {f.mode && <div className="proj-meta">{f.mode}</div>}
+                  <div className={projInfo}>
+                    <div className={projName}>{name}</div>
+                    {f.mode && <div className={projMeta}>{f.mode}</div>}
                   </div>
                 </button>
               );
@@ -259,11 +296,11 @@ export default function Launchpad({
 
       {/* Demo profile callout */}
       {demoProfile && profiles.length === 1 && studioProjects.length === 0 && (
-        <div className="lp-demo-callout">
-          <span className="lp-demo-callout__icon">👋</span>
+        <div className="flex items-center gap-[10px] py-[10px] px-[18px] mt-[8px] mx-[44px] mb-0 bg-[color-mix(in_srgb,var(--chrome-accent)_8%,var(--chrome-bg))] border border-solid border-[var(--chrome-accent-border)] rounded-[var(--chrome-radius-pill)] text-[0.76rem] text-[color:var(--chrome-fg)] relative z-[1] animate-[lpFadeUp_0.5s_cubic-bezier(0.4,0,0.2,1)_both]">
+          <span className="text-[1.1rem]">👋</span>
           <span>{t('launchpad.demo_callout')}</span>
           <button
-            className="lp-demo-callout__btn"
+            className="ml-auto py-[4px] px-[14px] [font-family:var(--font-sans)] text-[0.7rem] font-semibold rounded-[var(--chrome-radius-pill)] bg-[var(--chrome-accent-bg)] border border-solid border-[var(--chrome-accent-border)] text-[color:var(--chrome-accent)] cursor-pointer [transition:background_var(--dur-fast)] hover:bg-[color-mix(in_srgb,var(--chrome-accent)_22%,transparent)]"
             onClick={() => {
               openStudio('audio');
               handleSelectProfile(demoProfile);
@@ -276,26 +313,26 @@ export default function Launchpad({
 
       {/* Recent Projects */}
       {(profiles.length > 0 || studioProjects.length > 0) && (
-        <div className="lp-section">
-          <div className="lp-section__grid">
+        <div className="pt-[28px] px-[44px] pb-[40px] relative z-[1] max-[900px]:pt-0 max-[900px]:px-[20px] max-[900px]:pb-[24px] max-[640px]:pt-0 max-[640px]:px-[12px] max-[640px]:pb-[16px]">
+          <div className="grid [grid-template-columns:repeat(auto-fit,minmax(280px,1fr))] gap-[20px]">
             {/* Cloned voices */}
             {cloneProfiles.length > 0 && (
               <div>
-                <div className="lp-section-title">
+                <div className={sectionTitle}>
                   <Fingerprint size={12} color="#d3869b" /> {t('launchpad.cloned_voices')}
                 </div>
-                <div className="lp-col">
+                <div className="flex flex-col gap-[8px]">
                   {cloneProfiles.map((p) => (
-                    <div key={p.id} className="lp-project-card">
-                      <div className="proj-icon lp-proj-icon--clone">
+                    <div key={p.id} className={projCard}>
+                      <div className={`${projIcon} bg-[rgba(211,134,155,0.1)]`}>
                         <Fingerprint size={14} color="#d3869b" />
                       </div>
-                      <div className="proj-info">
-                        <div className="proj-name">{p.name}</div>
-                        <div className="proj-meta">{p.ref_audio_path}</div>
+                      <div className={projInfo}>
+                        <div className={projName}>{p.name}</div>
+                        <div className={projMeta}>{p.ref_audio_path}</div>
                       </div>
                       <button
-                        className="proj-action"
+                        className={projAction}
                         onClick={() => {
                           openStudio('audio');
                           handleSelectProfile(p);
@@ -312,14 +349,14 @@ export default function Launchpad({
             {/* Designed voices */}
             {designProfiles.length > 0 && (
               <div>
-                <div className="lp-section-title">
+                <div className={sectionTitle}>
                   <Wand2 size={12} color="#8ec07c" /> {t('launchpad.designed_voices')}
                 </div>
-                <div className="lp-col">
+                <div className="flex flex-col gap-[8px]">
                   {designProfiles.map((p) => (
-                    <div key={p.id} className="lp-project-card">
+                    <div key={p.id} className={projCard}>
                       <div
-                        className={`proj-icon ${p.is_locked ? 'lp-proj-icon--locked' : 'lp-proj-icon--design'}`}
+                        className={`${projIcon} ${p.is_locked ? 'bg-[rgba(184,187,38,0.1)]' : 'bg-[rgba(142,192,124,0.1)]'}`}
                       >
                         {p.is_locked ? (
                           <Lock size={14} color="#b8bb26" />
@@ -327,15 +364,17 @@ export default function Launchpad({
                           <Wand2 size={14} color="#8ec07c" />
                         )}
                       </div>
-                      <div className="proj-info">
-                        <div className="proj-name">{p.name}</div>
-                        <div className="proj-meta lp-proj-meta--italic">{p.instruct}</div>
+                      <div className={projInfo}>
+                        <div className={projName}>{p.name}</div>
+                        <div className={`${projMeta} italic`}>{p.instruct}</div>
                       </div>
                       {p.is_locked && (
-                        <span className="lp-locked-badge">{t('launchpad.locked')}</span>
+                        <span className="[font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] [letter-spacing:var(--chrome-label-track)] py-[1px] px-[7px] rounded-[var(--chrome-radius-pill)] bg-[color-mix(in_srgb,#b8bb26_10%,transparent)] border border-solid border-[color-mix(in_srgb,#b8bb26_40%,transparent)] text-[#b8bb26] font-semibold">
+                          {t('launchpad.locked')}
+                        </span>
                       )}
                       <button
-                        className="proj-action"
+                        className={projAction}
                         onClick={() => {
                           openStudio('design');
                           handleSelectProfile(p);
@@ -352,26 +391,26 @@ export default function Launchpad({
             {/* Dubbing projects */}
             {studioProjects.length > 0 && (
               <div>
-                <div className="lp-section-title">
+                <div className={sectionTitle}>
                   <Film size={12} color="#fe8019" /> {t('launchpad.dubbing_projects')}
                 </div>
-                <div className="lp-col">
+                <div className="flex flex-col gap-[8px]">
                   {studioProjects.map((proj) => (
-                    <div key={proj.id} className="lp-project-card">
-                      <div className="proj-icon lp-proj-icon--dub">
+                    <div key={proj.id} className={projCard}>
+                      <div className={`${projIcon} bg-[rgba(254,128,25,0.1)] overflow-hidden`}>
                         <DubThumb
                           jobId={proj.state?.dubJobId || proj.id}
                           fallback={<Film size={14} color="#fe8019" />}
                         />
                       </div>
-                      <div className="proj-info">
-                        <div className="proj-name">{proj.name}</div>
-                        <div className="proj-meta">
+                      <div className={projInfo}>
+                        <div className={projName}>{proj.name}</div>
+                        <div className={projMeta}>
                           {proj.video_path || t('launchpad.audio_only')}
                         </div>
                       </div>
                       <button
-                        className="proj-action"
+                        className={projAction}
                         onClick={() => {
                           setMode('dub');
                           loadProject(proj.id);
@@ -390,9 +429,9 @@ export default function Launchpad({
 
       {/* Empty state */}
       {profiles.length === 0 && studioProjects.length === 0 && (
-        <div className="lp-empty">
-          <div className="lp-empty__inner">
-            <div className="lp-empty__bars">
+        <div className="flex-1 flex items-center justify-center relative z-[1]">
+          <div className="text-center max-w-[360px]">
+            <div className="flex justify-center gap-[3px] mb-[16px] opacity-30">
               {[8, 14, 22, 18, 26, 14, 20, 10, 16].map((h, i) => (
                 <span
                   key={i}
@@ -405,7 +444,9 @@ export default function Launchpad({
                 />
               ))}
             </div>
-            <p className="lp-empty__hint">{t('launchpad.empty_hint')}</p>
+            <p className="[font-family:var(--chrome-font-mono)] text-[0.8rem] text-[color:var(--chrome-fg-muted)] m-0">
+              {t('launchpad.empty_hint')}
+            </p>
           </div>
           {/* No `showWhenAllPass` — let the component self-hide when every
               check is pass-or-warn. Surfacing "everything is fine" on the


### PR DESCRIPTION
## What

Part 4 of the shadcn/Tailwind migration. Moves the Launchpad's static layout/typography `lp-*` global classes out of `src/index.css` onto the component as Tailwind utilities, then deletes the now-unused rules. Net: **index.css −218 lines** (60 `lp-*` selector rules removed; only `lp-*` selectors were touched, every other rule family left intact).

Utilities reference the existing `--chrome-*`/`--font-*`/`--dur-*` tokens via arbitrary `var()` values for exact parity, use explicit `border border-solid border-[var(--…)]` for the no-preflight setup, and reproduce the former `@media` rules with `max-[900px]:`/`max-[640px]:` variants.

## Migrated + deleted
`lp-hero` (+`__row`/`__col`/`__kicker-row`/`__wave-group`), `lp-kicker`, `lp-hero__title` (+`em`), `lp-hero p` / `.lp-pill`, the dead `.lp-underline` rule, `lp-actions` (grid container), `lp-section`, `lp-section-title` (+`::after` divider via `after:`), `lp-section__grid`, `lp-col`, `lp-proj-icon--*` tints, `lp-proj-meta--italic`, `lp-files__head`/`__grid` + `lp-view-all` + `lp-file-card`, `lp-locked-badge`, `lp-empty` (+`__inner`/`__bars`/`__hint`), `lp-dub-thumb`, `lp-demo-callout` (+`__icon`/`__btn`), `lp-project-card` (+ `.proj-icon`/`info`/`name`/`meta`/`action`), `lp-ab-compare`, and the unused `lp-action-card__emoji`.

## Kept (reported, not forced)
- **Cross-file shared** — reused by ContactPage/SupportPage/DonatePage.css/EnterprisePage.css: `.lp-aurora`, `.lp-aurora__blob(+--pink/green/amber)`, `.lp-hero__sweep` (+ their `@keyframes`).
- **::pseudo / structural-selector / cursor-tracking** that can't be flat utilities: the `.lp-action-card` family + `.lp-glow-layer` (`::before` cursor spotlight, `::after` breath ring, `nth-child` stagger), `.lp-animate`.
- **@keyframes-driven**: `.lp-wave-bar`, `.lp-hero__halo`, and every `@keyframes` block + the `prefers-reduced-motion` block.

The bare unlayered `h1,h2,h3,h4` rule outranks layered Tailwind utilities, so the hero title's serif `font-family` + `letter-spacing` use the `!` important modifier to win the cascade.

## Verification
- **Launchpad landing screenshot pixel-identical** before/after (Playwright chromium, animations disabled, full populated page).
- `oxlint` exit 0 (no new findings) · `oxfmt --check` clean · `vite build` ok · `vitest run` **641 passed** · `bun run test:visual` **48 passed** · `bun install --frozen-lockfile` no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Part 4 of the Launchpad shadcn/Tailwind migration: the landing page moved off legacy `lp-*` global CSS for layout/typography and onto Tailwind utilities in `Launchpad.jsx`, while `src/index.css` dropped the now-unused Launchpad rules.

Key updates:
- Hero, kicker, section, files, empty state, demo callout, project card, and related sub-elements were restyled with utility classes.
- Shared card/row helpers replaced older `.lp-project-card` / `.proj-*` markup patterns.
- Action cards kept the chrome-frame composition, with breakpoint tweaks applied directly to the component.
- Unused `lp-underline` and `lp-action-card__emoji` rules were removed.
- Cross-file decoration/animation CSS like `.lp-aurora`, `.lp-hero__sweep`, and keyframe-driven rules were preserved.

Verification:
- Pixel-identical landing screenshot before/after
- `oxlint` clean
- `oxfmt --check` clean
- `vite build` successful
- `vitest run` passed (641 tests)
- `bun run test:visual` passed (48 tests)

Layout sketch:
Before
[ Hero + legacy lp-* CSS ]
[ Section grids / recent files / projects ]
[ Empty state / demo callout ]

After
[ Hero (Tailwind utilities) ]
[ Action cards grid ]
[ Recent files grid ]
[ Recent projects grid ]
[ Empty state hint / checklist ]

<!-- end of auto-generated comment: release notes by coderabbit.ai -->