### PR TITLE
feat(ui): migrate hq-* classes to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -90,11 +90,14 @@ const VIEW_META = {
 function WaveBars({ color = '#f3a5b6', active }) {
   const heights = [4, 9, 5, 11, 6, 10, 5, 8];
   return (
-    <div className={`hq-wave ${active ? 'is-active' : ''}`} aria-hidden="true">
+    <div
+      className={`inline-flex items-center gap-[2px] h-[16px] px-[6px] transition-opacity duration-200 max-[1351px]:hidden ${active ? 'opacity-100' : 'opacity-[0.35]'}`}
+      aria-hidden="true"
+    >
       {heights.map((h, i) => (
         <span
           key={i}
-          className={active ? 'hq-wave-bar active' : 'hq-wave-bar'}
+          className={`inline-block w-[2.5px] rounded-[2px] transition-opacity duration-200 ${active ? '[animation:hqBounce_1.3s_ease-in-out_infinite]' : ''}`}
           style={{
             // Height + color are per-instance; animation-delay is per-bar.
             // These three are genuinely dynamic so stay inline.
@@ -214,20 +217,31 @@ export default function Header({
   return (
     <div className="header-area" data-tauri-drag-region onDoubleClick={doubleClickMaximize}>
       {/* Left: view title + breadcrumb */}
-      <div className="hq-col-left">
-        <div className="hq-col-left__spacer" />
-        <div className="hq-view-title">
-          <span className="hq-view-dot" style={dotStyle} />
-          <span className="hq-view-kicker">{t(view.kickerKey)}</span>
-          <ChevronRight size={10} color="#504945" className="hq-breadcrumb-sep" />
-          <span className="hq-view-label" style={labelStyle}>
-            <ViewIcon size={12} className="hq-view-icon" />
+      <div className="flex items-center gap-[14px] justify-self-start min-w-0">
+        <div className="min-w-[80px] shrink-0" />
+        <div className="inline-flex items-center gap-[6px] h-[var(--chrome-pill-h)] [font-family:var(--font-sans)] max-[961px]:gap-[5px]">
+          <span
+            className="w-[7px] h-[7px] rounded-full shrink-0 [animation:hqPulse_2.4s_ease-in-out_infinite] max-[821px]:hidden"
+            style={dotStyle}
+          />
+          <span className="text-[length:var(--chrome-label-size)] font-semibold tracking-[var(--chrome-label-track)] uppercase text-[var(--chrome-fg-muted)] max-[1501px]:hidden">
+            {t(view.kickerKey)}
+          </span>
+          <ChevronRight size={10} color="#504945" className="mx-[2px] max-[1501px]:hidden" />
+          <span
+            className="inline-flex items-center gap-1 [font-family:var(--font-sans)] text-[0.72rem] font-semibold tracking-[0.02em] max-[961px]:text-[0.78rem]"
+            style={labelStyle}
+          >
+            <ViewIcon size={12} className="mr-1 align-[-1px]" />
             {t(view.labelKey)}
           </span>
           {activeProjectName ? (
             <>
-              <ChevronRight size={10} color="#504945" className="hq-breadcrumb-sep" />
-              <span className="hq-view-project" title={activeProjectName}>
+              <ChevronRight size={10} color="#504945" className="mx-[2px]" />
+              <span
+                className="[font-family:var(--font-sans)] text-[0.68rem] font-medium text-[var(--chrome-fg-muted)] max-w-[180px] overflow-hidden text-ellipsis whitespace-nowrap max-[1201px]:hidden"
+                title={activeProjectName}
+              >
                 {activeProjectName}
               </span>
             </>
@@ -240,7 +254,7 @@ export default function Header({
             title={t('common.reload')}
             onClick={() => window.location.reload()}
             leading={<RefreshCw size={9} />}
-            className="hq-reload-btn"
+            className="shrink-0"
           >
             {t('common.reload')}
           </Button>
@@ -248,7 +262,7 @@ export default function Header({
       </div>
 
       {/* Center: logo */}
-      <div className="hq-col-center">
+      <div className="flex items-center gap-2 justify-self-center pointer-events-none whitespace-nowrap">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="20"
@@ -259,7 +273,6 @@ export default function Header({
           strokeWidth="2.5"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="hq-logo-mark"
         >
           <circle cx="12" cy="12" r="10" opacity="0.18" fill="#f3a5b6" />
           <circle cx="12" cy="12" r="10" />
@@ -267,36 +280,37 @@ export default function Header({
           <path d="M8 9v6" />
           <path d="M16 9v6" />
         </svg>
-        <span className="hq-logo-word">
-          Omni<span className="hq-logo-word__accent">Voice</span>
+        <span className="text-[0.92rem] font-semibold text-[var(--chrome-fg)] tracking-[0.02em] [font-family:var(--font-sans)] not-italic">
+          Omni<span className="text-[var(--chrome-accent)]">Voice</span>
         </span>
       </div>
 
       {/* Right: wave + sys stats. UI scale (S/M/L) lives in the bottom
           LogsFooter bar so all app-wide chrome sits together. */}
-      <div className="hq-col-right">
+      <div className="flex items-center justify-end gap-3 justify-self-end min-w-0 overflow-visible">
         <NotificationPanel onNavigate={setMode} />
         <WaveBars
           color={view.accent}
           active={modelStatus === 'ready' || modelStatus === 'loading'}
         />
         {sysStats && (
-          <div className="hq-stats">
+          <div className="flex items-center gap-[10px] [font-family:var(--chrome-font-mono)] text-[10.5px] text-[var(--chrome-fg-dim)] bg-transparent h-[var(--chrome-pill-h)] whitespace-nowrap shrink overflow-hidden tabular-nums slashed-zero max-[851px]:hidden!">
             {showLiveStats && (
               <>
-                <span>
-                  <b className="hq-stats__key">RAM</b> {sysStats.ram.toFixed(1)}/
-                  {sysStats.total_ram.toFixed(0)}G
+                <span className="max-[1081px]:hidden">
+                  <b className="text-[var(--chrome-fg-muted)] font-semibold">RAM</b>{' '}
+                  {sysStats.ram.toFixed(1)}/{sysStats.total_ram.toFixed(0)}G
                 </span>
-                <span>
-                  <b className="hq-stats__key">CPU</b> {sysStats.cpu.toFixed(0)}%
+                <span className="max-[1081px]:hidden">
+                  <b className="text-[var(--chrome-fg-muted)] font-semibold">CPU</b>{' '}
+                  {sysStats.cpu.toFixed(0)}%
                 </span>
                 <span
-                  className="hq-stats__sep"
+                  className="[border-left:1px_solid_var(--chrome-border)] pl-[6px]"
                   aria-label={`VRAM usage: ${sysStats.vram.toFixed(1)} gigabytes`}
                 >
                   <b
-                    className={`hq-stats__key ${sysStats.gpu_active ? 'hq-stats__key--gpu-active' : ''}`}
+                    className={`font-semibold ${sysStats.gpu_active ? 'text-[var(--chrome-severity-ok)]' : 'text-[var(--chrome-fg-muted)]'}`}
                   >
                     VRAM
                   </b>{' '}
@@ -304,7 +318,7 @@ export default function Header({
                 </span>
               </>
             )}
-            <span className="hq-stats__status-wrap">
+            <span className="[border-left:1px_solid_var(--chrome-border)] pl-[6px] flex items-center gap-1">
               <Badge
                 tone={
                   modelStatus === 'ready'
@@ -315,7 +329,7 @@ export default function Header({
                 }
                 size="xs"
                 dot
-                className={`hq-stats__status-badge ${modelStatus === 'loading' ? 'ui-badge--pulse' : ''}`}
+                className={`[border:none]! bg-transparent! p-0! normal-case! tracking-normal! font-semibold! ${modelStatus === 'loading' ? 'ui-badge--pulse' : ''}`}
               >
                 {modelStatus === 'ready'
                   ? t('header.status_ready')
@@ -335,32 +349,41 @@ export default function Header({
                   leading={!flushing && <Zap size={8} />}
                   trailing={<ChevronDown size={8} />}
                   onClick={() => setFlushOpen((o) => !o)}
-                  className="hq-flush-btn"
+                  className="ml-[2px]"
                 >
                   {t('header.flush')}
                 </Button>
                 {flushOpen &&
                   createPortal(
                     <div
-                      className="hq-flush-dropdown"
+                      className="fixed w-[260px] bg-[var(--color-bg-elev-1)] [border:1px_solid_var(--color-border)] rounded-[var(--radius-lg)] [box-shadow:0_8px_24px_rgba(0,0,0,0.5)] z-[9999] py-[4px] [animation:flush-slide_0.12s_ease-out]"
                       style={{ top: dropdownPos.top, left: dropdownPos.left }}
                       ref={dropdownRef}
                     >
-                      <div className="hq-flush-dropdown__header">{t('header.loaded_models')}</div>
+                      <div className="text-[10px] font-semibold text-[var(--color-fg-subtle)] uppercase tracking-[0.5px] pt-[6px] px-[12px] pb-[4px]">
+                        {t('header.loaded_models')}
+                      </div>
                       {loadedModels.length === 0 ? (
-                        <div className="hq-flush-dropdown__empty">{t('header.no_models')}</div>
+                        <div className="p-[12px] text-[11px] text-[var(--color-fg-muted)] text-center">
+                          {t('header.no_models')}
+                        </div>
                       ) : (
                         loadedModels.map((m) => (
-                          <div key={m.id} className="hq-flush-dropdown__item">
-                            <div className="hq-flush-dropdown__info">
-                              <span className="hq-flush-dropdown__name">{m.name}</span>
-                              <span className="hq-flush-dropdown__meta">
+                          <div
+                            key={m.id}
+                            className="flex items-center justify-between py-[6px] px-[12px] gap-2 hover:bg-[rgba(255,255,255,0.03)]"
+                          >
+                            <div className="flex flex-col gap-[1px] min-w-0">
+                              <span className="text-[12px] text-[var(--color-fg)] font-medium">
+                                {m.name}
+                              </span>
+                              <span className="text-[10px] text-[var(--color-fg-subtle)] [font-family:var(--font-mono)]">
                                 {m.device} {m.vram_mb > 0 ? `· ${m.vram_mb.toFixed(0)} MB` : ''}
                               </span>
                             </div>
                             {m.unloadable && (
                               <button
-                                className="hq-flush-dropdown__unload"
+                                className="text-[10px] font-semibold text-[var(--color-brand)] bg-[rgba(211,134,155,0.1)] [border:1px_solid_rgba(211,134,155,0.2)] rounded-[var(--radius-pill)] py-[2px] px-[8px] cursor-pointer shrink-0 hover:bg-[rgba(211,134,155,0.2)]"
                                 onClick={() => unloadModel(m.id)}
                                 disabled={unloading === m.id}
                                 aria-label={`Unload ${m.name}`}
@@ -371,9 +394,9 @@ export default function Header({
                           </div>
                         ))
                       )}
-                      <div className="hq-flush-dropdown__divider" />
+                      <div className="h-[1px] bg-[var(--color-border)] my-[4px]" />
                       <button
-                        className="hq-flush-dropdown__action"
+                        className="flex items-center gap-[6px] w-full py-[6px] px-[12px] text-[12px] text-[var(--color-fg)] bg-transparent border-none cursor-pointer text-left hover:bg-[rgba(255,255,255,0.04)]"
                         onClick={async () => {
                           setFlushing(true);
                           setFlushOpen(false);
@@ -387,7 +410,7 @@ export default function Header({
                         <Zap size={10} /> {t('header.flush_caches')}
                       </button>
                       <button
-                        className="hq-flush-dropdown__action hq-flush-dropdown__action--danger"
+                        className="flex items-center gap-[6px] w-full py-[6px] px-[12px] text-[12px] text-[#fb4934] bg-transparent border-none cursor-pointer text-left hover:bg-[rgba(251,73,52,0.08)]"
                         onClick={async () => {
                           setFlushing(true);
                           setFlushOpen(false);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -216,7 +216,6 @@ h1, h2, h3, h4 {
 .segment-time,
 .segment-table code,
 .ui-table-toolbar__meta,
-.hq-stats,
 .dub-gen-overlay__stats,
 .dub-trans-overlay__stats,
 .logs-footer__count,
@@ -430,236 +429,24 @@ html[data-zoom-layout='off'] .app-container {
   padding-right: 8px;
 }
 
-/* ── Header columns ──────────────────────────────────────────── */
-.hq-col-left {
-  display: flex; align-items: center; gap: 14px;
-  justify-self: start; min-width: 0;
-}
-.hq-col-left__spacer   { min-width: 80px; flex-shrink: 0; }
-.hq-col-center {
-  display: flex; align-items: center; gap: 8px;
-  justify-self: center;
-  pointer-events: none;
-  white-space: nowrap;
-}
-.hq-col-right {
-  display: flex; align-items: center; justify-content: flex-end;
-  gap: 12px; justify-self: end;
-  min-width: 0; overflow: visible;
-}
-
-/* Logo */
-.hq-logo-mark   { transform: none; }
-.hq-logo-word {
-  font-size: 0.92rem; font-weight: 600; color: var(--chrome-fg);
-  letter-spacing: 0.02em;
-  font-family: var(--font-sans);
-  font-style: normal;
-}
-.hq-logo-word__accent { color: var(--chrome-accent); }
-
-/* Breadcrumb chevron spacing + inline-icon spacing */
-.hq-breadcrumb-sep  { margin: 0 2px; }
-.hq-view-icon       { margin-right: 4px; vertical-align: -1px; }
-
-/* Stats readout — informational, not a button. No outer pill/shell;
-   the thin vertical dividers between groups do the visual grouping. */
-.hq-stats {
-  display: flex;
-  gap: 10px;
-  font-family: var(--chrome-font-mono);
-  font-size: 10.5px;
-  color: var(--chrome-fg-dim);
-  background: transparent;
-  height: var(--chrome-pill-h);
-  padding: 0;
-  border: none;
-  white-space: nowrap;
-  flex-shrink: 1;
-  align-items: center;
-  overflow: hidden;
-}
-.hq-stats__key     { color: var(--chrome-fg-muted); font-weight: 600; }
-.hq-stats__key--gpu-active { color: var(--chrome-severity-ok); }
-.hq-stats__sep {
-  border-left: 1px solid var(--chrome-border);
-  padding-left: 6px;
-}
-.hq-stats__status-wrap {
-  border-left: 1px solid var(--chrome-border);
-  padding-left: 6px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-.hq-stats__status-badge {
-  border: none !important;
-  background: transparent !important;
-  padding: 0 !important;
-  text-transform: none !important;
-  letter-spacing: 0 !important;
-  font-weight: 600 !important;
-}
-.hq-flush-btn      { margin-left: 2px; }
-.hq-reload-btn     { flex-shrink: 0; }
-
-/* Flush dropdown — portalled to document.body, positioned dynamically via JS */
-.hq-flush-dropdown {
-  position: fixed;
-  width: 260px;
-  background: var(--color-bg-elev-1);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
-  z-index: 9999;
-  padding: 4px 0;
-  animation: flush-slide 0.12s ease-out;
-}
 @keyframes flush-slide {
   from { opacity: 0; transform: translateY(-4px); }
   to   { opacity: 1; transform: translateY(0); }
-}
-.hq-flush-dropdown__header {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--color-fg-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  padding: 6px 12px 4px;
-}
-.hq-flush-dropdown__empty {
-  padding: 12px;
-  font-size: 11px;
-  color: var(--color-fg-muted);
-  text-align: center;
-}
-.hq-flush-dropdown__item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 12px;
-  gap: 8px;
-}
-.hq-flush-dropdown__item:hover { background: rgba(255,255,255,0.03); }
-.hq-flush-dropdown__info { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.hq-flush-dropdown__name { font-size: 12px; color: var(--color-fg); font-weight: 500; }
-.hq-flush-dropdown__meta { font-size: 10px; color: var(--color-fg-subtle); font-family: var(--font-mono); }
-.hq-flush-dropdown__unload {
-  font-size: 10px; font-weight: 600;
-  color: var(--color-brand);
-  background: rgba(211,134,155,0.1);
-  border: 1px solid rgba(211,134,155,0.2);
-  border-radius: var(--radius-pill);
-  padding: 2px 8px; cursor: pointer;
-  flex-shrink: 0;
-}
-.hq-flush-dropdown__unload:hover { background: rgba(211,134,155,0.2); }
-.hq-flush-dropdown__divider { height: 1px; background: var(--color-border); margin: 4px 0; }
-.hq-flush-dropdown__action {
-  display: flex; align-items: center; gap: 6px;
-  width: 100%; padding: 6px 12px;
-  font-size: 12px; color: var(--color-fg);
-  background: none; border: none; cursor: pointer;
-  text-align: left;
-}
-.hq-flush-dropdown__action:hover { background: rgba(255,255,255,0.04); }
-.hq-flush-dropdown__action--danger { color: #fb4934; }
-.hq-flush-dropdown__action--danger:hover { background: rgba(251,73,52,0.08); }
-/* Decorative wavy SVG ribbon was removed — the flat chrome gets its
-   separation from the hairline `border-bottom` above, matching the
-   LogsFooter's top edge. */
-
-/* HQ breadcrumb — informational label, not a button. No pill shell. */
-.hq-view-title {
-  display: inline-flex; align-items: center; gap: 6px;
-  height: var(--chrome-pill-h);
-  padding: 0;
-  background: transparent;
-  border: none;
-  font-family: var(--font-sans);
-}
-.hq-view-dot {
-  width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
-  animation: hqPulse 2.4s ease-in-out infinite;
 }
 @keyframes hqPulse {
   0%, 100% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.15); opacity: 0.7; }
 }
-.hq-view-kicker {
-  font-size: var(--chrome-label-size);
-  font-weight: 600;
-  letter-spacing: var(--chrome-label-track);
-  text-transform: uppercase;
-  color: var(--chrome-fg-muted);
-}
-.hq-view-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-family: var(--font-sans);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-.hq-view-project {
-  font-family: var(--font-sans);
-  font-size: 0.68rem; font-weight: 500;
-  color: var(--chrome-fg-muted);
-  max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-
-.hq-wave {
-  display: inline-flex; align-items: center; gap: 2px; height: 16px;
-  padding: 0 6px;
-  opacity: 0.35;
-  transition: opacity 0.2s;
-}
-.hq-wave.is-active { opacity: 1; }
-
 /* Responsive header — hide low-priority elements as width tightens.
    Priority (least → most important):
    reload → wave → kicker+chevron → project name → stats pill → S/M/L picker
    → dot → logo wordmark. Label + icon always visible.
 */
 
-/* ≤1500: drop dev reload + kicker + first chevron */
+/* ≤1500: drop dev reload (kicker + first chevron now handled by utilities on
+   the elements themselves in Header.jsx) */
 @media (max-width: 1500px) {
-  .hq-view-kicker { display: none; }
-  .hq-view-title > svg.lucide-chevron-right:first-of-type { display: none; }
   .header-area button[title="Force Reload UI"] { display: none; }
-}
-
-/* ≤1350: drop mini-waveform */
-@media (max-width: 1350px) {
-  .hq-wave { display: none; }
-}
-
-/* ≤1200: drop active project name */
-@media (max-width: 1200px) {
-  .hq-view-project { display: none; }
-}
-
-/* ≤1080: hide RAM/CPU text, keep VRAM + status + flush */
-@media (max-width: 1080px) {
-  .hq-stats > span:not(.hq-stats__status-wrap):not(.hq-stats__sep) { display: none; }
-}
-
-/* ≤960: shrink breadcrumb, hide S/M/L scale picker */
-@media (max-width: 960px) {
-  .hq-view-title { gap: 5px; }
-  .hq-view-label { font-size: 0.78rem; }
-  .hq-scale { display: none; }
-}
-
-/* ≤850: hide stats pill entirely */
-@media (max-width: 850px) {
-  .hq-stats { display: none !important; }
-}
-
-/* ≤820: drop pulsing dot + shrink logo */
-@media (max-width: 820px) {
-  .hq-view-dot { display: none; }
 }
 
 /* ≤720: hide logo wordmark, keep icon only */
@@ -677,13 +464,6 @@ html[data-zoom-layout='off'] .app-container {
 .header-area > div { min-width: 0; overflow: hidden; }
 .header-area > div:nth-child(2),
 .header-area > div:nth-child(3) { overflow: visible; }
-.hq-wave-bar {
-  display: inline-block; width: 2.5px; border-radius: 2px;
-  transition: opacity 0.2s;
-}
-.hq-wave-bar.active {
-  animation: hqBounce 1.3s ease-in-out infinite;
-}
 @keyframes hqBounce {
   0%, 100% { transform: scaleY(0.6); opacity: 0.75; }
   50% { transform: scaleY(1.25); opacity: 1; }


### PR DESCRIPTION
## P4 shadcn/Tailwind migration — `hq-*` families

Moves the header "quick" chrome (`hq-*`) global class families out of `frontend/src/index.css` onto Tailwind v4 utilities on their **sole** consumer (`Header.jsx`), then deletes the dead rules. **No visual change.**

### Migrated (every `hq-*` family, all usages were in `Header.jsx`)
- `hq-col-left/-left__spacer/-center/-right` — header layout columns
- `hq-logo-mark/-word/-word__accent` — center logo (`hq-logo-mark` was `transform:none`, a no-op → dropped)
- `hq-breadcrumb-sep`, `hq-view-icon`
- `hq-view-title/-dot/-kicker/-label/-project` — breadcrumb
- `hq-stats` + `__key/__key--gpu-active/__sep/__status-wrap/__status-badge`
- `hq-flush-btn`, `hq-reload-btn`
- `hq-flush-dropdown` + `__header/__empty/__item/__info/__name/__meta/__unload/__divider/__action/__action--danger` (portalled memory dropdown)
- `hq-wave`/`hq-wave.is-active`, `hq-wave-bar`/`.active` (mini waveform)

### Notes
- **`@keyframes` kept** (`flush-slide`, `hqPulse`, `hqBounce`) — driven via `[animation:…]` arbitrary utilities.
- **No-preflight**: borders use explicit `[border:1px_solid_var(--…)]`.
- **Badge override** (`hq-stats__status-badge`) uses important modifiers (`foo!`) to beat the primitive's own utilities.
- **Responsive `@media` → `max-[Npx]:` variants.** Tailwind v4 compiles `max-[N]` to `not all and (width>=N)` (strictly `< N`), but the original `@media (max-width: N)` is `<= N`; each breakpoint bumped **+1px** (e.g. `820 → max-[821px]`) so the boundary pixel matches exactly.
- Dead `.hq-scale` rule (zero usages) dropped; surviving **non-`hq`** `@media` rules (`.header-area` reload/wordmark hide) stay.
- `index.css`: **224 lines removed, 2 added** (net −220).

### Verification (live)
Vite `:3922`, Playwright chromium, backend `:3900` stubbed. Header captured at **1600 / 1000 / 820px** + **flush dropdown open**, before vs after pixel-diff:
- **820px: identical (0 px).**
- Residual sub-1% diffs at other widths are **purely the live pulse-dot / wave-bar animation phase** (the only red regions in the diff image coincide exactly with those two animated elements).

Gates: `oxlint` 0 · `oxfmt --check .` clean · `vite build` ok · `vitest` **641 passed** · `bun install --frozen-lockfile` no change · `test:visual` **48 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Migrated the header’s legacy `hq-*` styling from global CSS to Tailwind v4 utility classes on `Header.jsx`, while keeping the existing animation keyframes and preserving behavior.

- Reworked the header layout, logo, breadcrumb/title, stats pill, waveform bars, and flush/reload controls to use utility classes and inline SVG/variable-driven styling.
- Updated the memory dropdown markup/styles, but kept its behavior the same: load models on open, dismiss on outside click, unload individual models, and expose flush actions.
- Removed unused header rules from `index.css`, including dead `.hq-scale` and `.hq-stats` styling, while retaining non-header media rules and the keyframes definitions.
- Converted responsive breakpoint handling to `max-[Npx]` variants with +1px adjustments to match the previous boundary behavior.

Before/after sketch:

```text
BEFORE
[Logo] [View breadcrumb/title] [Stats] [Wave]                      [Reload] [Memory ▼]

AFTER
[Logo+wordmark] [View pill / breadcrumb / active project] [Stats] [Wave] [Reload] [Memory ▼]
```

Behavior flow for the memory dropdown:

```mermaid
flowchart TD
  A[Open Memory dropdown] --> B[Fetch loaded models]
  B --> C[Render model list]
  C --> D[Click outside?]
  D -- yes --> E[Close dropdown]
  D -- no --> C
  C --> F[Unload single model]
  C --> G[Trigger flush caches]
  C --> H[Trigger unload_all_flush]
</mermaid>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->