### PR TITLE
feat(ui): migrate history-* to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -306,7 +306,7 @@ export default function Sidebar(props) {
                           className={`history-item history-item--dub ${activeProjectId === proj.id ? 'project-active' : ''}`}
                           onClick={() => loadProject(proj.id)}
                         >
-                          <div className="history-row-head">
+                          <div className="flex items-center justify-between gap-2 min-w-0">
                             <span className="history-kind history-kind--audio">
                               <Film size={9} /> {t('sidebar.dub_label')}
                             </span>
@@ -391,7 +391,7 @@ export default function Sidebar(props) {
                             style={{ '--row-accent': accent }}
                             onClick={() => handleSelectProfile(proj)}
                           >
-                            <div className="history-row-head">
+                            <div className="flex items-center justify-between gap-2 min-w-0">
                               <span
                                 className="history-kind"
                                 style={{ color: accent, borderColor: `${accent}40` }}
@@ -558,7 +558,7 @@ export default function Sidebar(props) {
                       className="history-item history-item--dub"
                       onClick={() => restoreDubHistory(item)}
                     >
-                      <div className="history-row-head">
+                      <div className="flex items-center justify-between gap-2 min-w-0">
                         <span className="history-kind history-kind--audio">
                           <Film size={9} /> {t('sidebar.dub_label')}
                         </span>
@@ -606,7 +606,7 @@ export default function Sidebar(props) {
                         className="history-item"
                         style={{ '--row-accent': accent }}
                       >
-                        <div className="history-row-head">
+                        <div className="flex items-center justify-between gap-2 min-w-0">
                           <span
                             className="history-kind"
                             style={{ color: accent, borderColor: `${accent}40` }}
@@ -764,7 +764,7 @@ export default function Sidebar(props) {
                         style={{ '--row-accent': accent }}
                         onClick={() => revealInFolder(item.destination_path)}
                       >
-                        <div className="history-row-head">
+                        <div className="flex items-center justify-between gap-2 min-w-0">
                           <span
                             className="history-kind"
                             style={{ color: accent, borderColor: `${accent}40` }}

--- a/frontend/src/components/WorkspaceHistory.jsx
+++ b/frontend/src/components/WorkspaceHistory.jsx
@@ -111,7 +111,7 @@ export default function WorkspaceHistory({
                 className="history-item history-item--dub"
                 onClick={() => restoreDubHistory(item)}
               >
-                <div className="history-row-head">
+                <div className="flex items-center justify-between gap-2 min-w-0">
                   <span className="history-kind history-kind--audio">
                     <Film size={9} /> {t('sidebar.dub_label')}
                   </span>
@@ -191,7 +191,7 @@ export default function WorkspaceHistory({
             const KindIcon = item.mode === 'clone' ? Fingerprint : Wand2;
             return (
               <div key={item.id} className="history-item" style={{ '--row-accent': accent }}>
-                <div className="history-row-head">
+                <div className="flex items-center justify-between gap-2 min-w-0">
                   <span
                     className="history-kind"
                     style={{ color: accent, borderColor: `${accent}40` }}

--- a/frontend/src/components/WorkspaceProjects.jsx
+++ b/frontend/src/components/WorkspaceProjects.jsx
@@ -102,7 +102,7 @@ export default function WorkspaceProjects({
               className={`history-item history-item--dub ${activeProjectId === proj.id ? 'project-active' : ''}`}
               onClick={() => loadProject(proj.id)}
             >
-              <div className="history-row-head">
+              <div className="flex items-center justify-between gap-2 min-w-0">
                 <span className="history-kind history-kind--audio">
                   <Film size={9} /> {t('sidebar.dub_label')}
                 </span>

--- a/frontend/src/components/WorkspaceVoices.jsx
+++ b/frontend/src/components/WorkspaceVoices.jsx
@@ -168,7 +168,7 @@ export default function WorkspaceVoices({
                 style={{ '--row-accent': accent }}
                 onClick={() => handleSelectProfile(proj)}
               >
-                <div className="history-row-head">
+                <div className="flex items-center justify-between gap-2 min-w-0">
                   <span
                     className="history-kind"
                     style={{ color: accent, borderColor: `${accent}40` }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1509,11 +1509,7 @@ div[role="dialog"].audio-trimmer {
   opacity: 1; background: #b8bb26;
 }
 
-/* Header row: kind pill + time */
-.history-row-head {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: 8px; min-width: 0;
-}
+/* Header row container migrated to utilities: flex items-center justify-between gap-2 min-w-0 */
 .history-kind {
   display: inline-flex; align-items: center; gap: 4px;
   font-family: var(--chrome-font-mono);


### PR DESCRIPTION
## P4 — `history-*` shadcn/Tailwind migration

The `history-*` family is a **shared, cross-file-composed component system** rendered by `WorkspaceHistory.jsx`, `Sidebar.jsx`, `WorkspaceProjects.jsx` and `WorkspaceVoices.jsx` (and styled across `index.css` **and** `Sidebar.css`). Most of it is irreducible to per-usage Tailwind utilities, so this batch migrates the one cleanly-isolable class and documents the rest.

### Migrated + deleted
- **`.history-row-head`** → `flex items-center justify-between gap-2 min-w-0`. Pure flex layout — no variants, pseudo-elements, descendant selectors, or cross-file/selector coupling. All **9 usages** converted; the `index.css` rule deleted (zero remaining usages).
  - `index.css` net: **−4 rule lines** (5-line rule replaced by a 1-line breadcrumb comment).

### Kept — composed cross-file / irreducible (with reasons)
- **`.history-item`** — `::before` accent bar, descendant hover-reveal of `.history-actions`, `.project-active` compound state, `--row-accent` set inline + `.history-item--dub` variant in `Sidebar.css`, plus a duplicate `!important` definition.
- **`.history-panel`** — selector target of out-of-scope `.app-container > .history-panel` and `.glass-panel.history-panel` rules; the class must stay on the element.
- **`.history-kind` / `.history-meta` / `.history-title` / `.history-subtitle`** — each has modifier variants (`--audio` / `--locked` / `--clamp`+`--expanded` / `--italic`+`--seed`) defined in `Sidebar.css` (out-of-scope component file).
- **`.history-actions`** — revealed only via `.history-item:hover` / `:focus-within` descendant selectors.
- **`.history-action-btn` / `.history-action-icon`** — compound `.accent` / `.danger` hover modifiers, ~30 usages; kept whole as a cohesive button subsystem rather than left half-migrated.

### Verification
- **Computed-style equivalence** (live, running app w/ Tailwind + index.css): the new utilities compute byte-for-byte identically to the deleted rule — `display:flex`, `align-items:center`, `justify-content:space-between`, `gap:8px`, `min-width:0`. Pixel-identical by construction for a pure layout class.
- `npx oxlint` → exit 0 (pre-existing warnings only)
- `npx oxfmt --write src && npx oxfmt --check .` → clean
- `npx vite build` → ok
- `npx vitest run` → **641 passed**
- `bun run test:visual` → **48 passed**
- `bun install --frozen-lockfile` → no lockfile change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Migrated the `history-*` UI family off the shared `.history-row-head` CSS rule and onto Tailwind utility classes across the remaining call sites.

**What changed**
- Replaced `history-row-head` with `flex items-center justify-between gap-2 min-w-0` in:
  - `Sidebar.jsx`
  - `WorkspaceHistory.jsx`
  - `WorkspaceProjects.jsx`
  - `WorkspaceVoices.jsx`
- Removed the legacy `.history-row-head` selector from `index.css`
- Left the other shared `history-*` selectors in CSS where cross-file reuse or selector coupling still makes them necessary

**Layout sketch**
```text
Before:
[ left content .............. ] [ actions ]

After:
<div class="flex items-center justify-between gap-2 min-w-0">
  [ left content ............ ] [ actions ]
</div>
```

**Verification**
- Style parity confirmed for the migrated row header
- `npx oxlint` passes with only pre-existing warnings
- Formatting checks are clean
- `npx vite build` succeeds
- `npx vitest run` passes 641 tests
- `bun run test:visual` passes 48 tests
- `bun install --frozen-lockfile` produces no lockfile changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->