### PR TITLE
feat(ui): migrate ss-*/file-drag to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/components/SearchableSelect.jsx
+++ b/frontend/src/components/SearchableSelect.jsx
@@ -23,6 +23,11 @@ const writeRecents = (key, list) => {
 
 const normalize = (s) => (s || '').toString().toLowerCase();
 
+// Migrated `.ss-group-label` — used for both the pinned header and lazy group
+// headers, so share one string.
+const GROUP_LABEL_CLS =
+  'pt-[4px] px-[10px] pb-[2px] text-[0.55rem] uppercase tracking-[0.06em] text-[color:var(--text-secondary)] opacity-70 flex items-center gap-[4px]';
+
 export default function SearchableSelect({
   value,
   onChange,
@@ -168,13 +173,18 @@ export default function SearchableSelect({
     }
   };
 
-  const sizeCls = size === 'sm' ? 'ss-sm' : 'ss-md';
+  // `.ss-sm/.ss-md` only sized the trigger (`.ss-{sm,md} .ss-trigger`); apply
+  // that directly on the trigger now that the descendant selectors are gone.
+  const triggerSizeCls = size === 'sm' ? 'text-[0.65rem] px-[8px] py-[4px]' : 'text-[0.75rem]';
 
   return (
-    <div ref={wrapRef} className={`ss-wrap ${sizeCls}`}>
+    // `ss-wrap` is retained as a marker class: residual.css targets
+    // `.voice-selector > .ss-wrap` (cross-file child combinator). Its own
+    // position/width rule now lives in these utilities.
+    <div ref={wrapRef} className="ss-wrap relative w-full">
       <button
         type="button"
-        className={`${buttonClassName} ss-trigger`}
+        className={`${buttonClassName} flex items-center justify-between gap-[6px] w-full text-left cursor-pointer [font-family:inherit] disabled:cursor-not-allowed disabled:opacity-50 ${triggerSizeCls}`}
         style={buttonStyle}
         onClick={() => !disabled && setOpen((o) => !o)}
         disabled={disabled}
@@ -182,17 +192,25 @@ export default function SearchableSelect({
         aria-expanded={open}
         title={currentLabel}
       >
-        <span className="ss-trigger-label">{currentLabel}</span>
-        <ChevronDown size={12} className="ss-chev" />
+        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[color:var(--text-primary)]">
+          {currentLabel}
+        </span>
+        <ChevronDown size={12} className="text-[color:var(--text-secondary)] shrink-0" />
       </button>
 
       {open && (
-        <div className="ss-pop" role="listbox">
-          <div className="ss-search">
-            <Search size={12} className="ss-search-icon" />
+        <div
+          className="absolute top-[calc(100%+4px)] left-0 right-0 z-[1000] bg-[rgba(29,32,33,0.98)] [border:1px_solid_rgba(255,255,255,0.1)] rounded-[6px] shadow-[0_8px_24px_rgba(0,0,0,0.5)] [backdrop-filter:blur(12px)] overflow-hidden min-w-[220px] max-w-[min(360px,90vw)]"
+          role="listbox"
+        >
+          <div className="relative p-[6px] [border-bottom:1px_solid_rgba(255,255,255,0.06)] flex items-center gap-[6px]">
+            <Search
+              size={12}
+              className="absolute left-[12px] top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)] pointer-events-none"
+            />
             <input
               ref={inputRef}
-              className="ss-search-input"
+              className="flex-1 w-full bg-[rgba(0,0,0,0.25)] [border:1px_solid_rgba(255,255,255,0.08)] rounded-[4px] py-[5px] pr-[8px] pl-[24px] text-[0.72rem] text-[color:var(--text-primary)] outline-none [font-family:inherit] focus:[border-color:rgba(250,189,47,0.4)]"
               placeholder={t('common.search')}
               value={query}
               onChange={(e) => {
@@ -203,11 +221,18 @@ export default function SearchableSelect({
             />
           </div>
 
-          <div ref={listRef} className="ss-list">
-            {flatItems.length === 0 && <div className="ss-empty">{t('common.no_matches')}</div>}
+          <div
+            ref={listRef}
+            className="max-h-[280px] overflow-y-auto py-[2px] [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:bg-[rgba(255,255,255,0.1)] [&::-webkit-scrollbar-thumb]:rounded-[3px]"
+          >
+            {flatItems.length === 0 && (
+              <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center">
+                {t('common.no_matches')}
+              </div>
+            )}
 
             {pinned.length > 0 && (
-              <div className="ss-group-label">
+              <div className={GROUP_LABEL_CLS}>
                 {recents.length ? (
                   <>
                     <Clock size={9} /> {t('common.recent_and_popular')}
@@ -239,10 +264,28 @@ export default function SearchableSelect({
                 if (it.kind === 'main') lastGroup = it.o?.group;
                 return (
                   <React.Fragment key={`${it.kind}-${v}-${idx}`}>
-                    {showHeader && <div className="ss-group-label">{it.o.groupLabel}</div>}
+                    {showHeader && <div className={GROUP_LABEL_CLS}>{it.o.groupLabel}</div>}
                     <div
                       data-idx={idx}
-                      className={`ss-option ${highlighted ? 'ss-hl' : ''} ${selected ? 'ss-sel' : ''}`}
+                      // Migrated `.ss-option`/`.ss-hl`/`.ss-sel` cascade. Selected
+                      // wins its color/weight; selected+highlighted gets the
+                      // stronger amber wash; highlight (and hover, when neither
+                      // selected nor highlighted) gets the amber accent.
+                      className={[
+                        'flex items-center gap-[6px] py-[5px] px-[10px] text-[0.72rem] cursor-pointer select-none',
+                        selected
+                          ? 'text-[#8ec07c] font-medium'
+                          : highlighted
+                            ? 'text-[color:var(--accent)]'
+                            : 'text-[color:var(--text-primary)] hover:text-[color:var(--accent)]',
+                        selected && highlighted
+                          ? 'bg-[rgba(250,189,47,0.18)]'
+                          : selected
+                            ? 'bg-[rgba(142,192,124,0.1)]'
+                            : highlighted
+                              ? 'bg-[rgba(250,189,47,0.12)]'
+                              : 'hover:bg-[rgba(250,189,47,0.12)]',
+                      ].join(' ')}
                       onMouseEnter={() => setHighlight(idx)}
                       onMouseDown={(e) => {
                         e.preventDefault();
@@ -251,12 +294,16 @@ export default function SearchableSelect({
                       role="option"
                       aria-selected={selected}
                     >
-                      {it.kind === 'recent' && <Clock size={9} className="ss-kind-icon" />}
-                      {it.kind === 'popular' && <Star size={9} className="ss-kind-icon" />}
-                      <span className="ss-option-label">
+                      {it.kind === 'recent' && (
+                        <Clock size={9} className="text-[color:var(--text-secondary)] shrink-0" />
+                      )}
+                      {it.kind === 'popular' && (
+                        <Star size={9} className="text-[color:var(--text-secondary)] shrink-0" />
+                      )}
+                      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
                         {renderOption ? renderOption(it.o) : getLabel(it.o)}
                       </span>
-                      {selected && <Check size={10} className="ss-check" />}
+                      {selected && <Check size={10} className="text-[#8ec07c] shrink-0" />}
                     </div>
                   </React.Fragment>
                 );
@@ -264,7 +311,7 @@ export default function SearchableSelect({
             })()}
 
             {!query && filtered.length > MAX_DISPLAY && (
-              <div className="ss-more">
+              <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center [border-top:1px_solid_rgba(255,255,255,0.04)]">
                 {t('common.showing_of', { shown: MAX_DISPLAY, total: filtered.length })}
               </div>
             )}

--- a/frontend/src/components/clone/AudioMethodPanel.jsx
+++ b/frontend/src/components/clone/AudioMethodPanel.jsx
@@ -48,7 +48,10 @@ export default function AudioMethodPanel({
           />
           <label
             htmlFor="audio-upload"
-            className="file-drag clone-drop-zone"
+            // Migrated `.file-drag` → utilities. `is-dragging` stays as a JS-toggled
+            // state marker, matched via the `[&.is-dragging]:` variant. `clone-drop-zone`
+            // (out-of-scope `clone-` family, unlayered) still wins the padding override.
+            className="clone-drop-zone [border:1px_dashed_var(--chrome-border-strong)] rounded-[var(--chrome-radius-pill)] p-[10px] text-center cursor-pointer flex flex-col items-center gap-[4px] bg-transparent [transition:border-color_var(--dur-fast),background_var(--dur-fast)] hover:[border-color:var(--chrome-accent)] hover:bg-[var(--chrome-accent-bg)] [&.is-dragging]:[border-color:var(--chrome-accent)] [&.is-dragging]:bg-[var(--chrome-accent-bg)]"
             onDragOver={(e) => {
               e.preventDefault();
               e.currentTarget.classList.add('is-dragging');
@@ -68,7 +71,7 @@ export default function AudioMethodPanel({
             }}
           >
             <UploadCloud color="#a89984" size={18} />
-            <p>
+            <p className="m-0 text-[0.72rem] text-[color:var(--chrome-fg-muted)] font-[family-name:var(--font-sans)] font-medium">
               {refAudio ? <span className="text-fg">{refAudio.name}</span> : t('clone.drop_audio')}
             </p>
           </label>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -564,18 +564,8 @@ input[type="range"]::-webkit-slider-thumb:active {
 .tags-container { display: flex; flex-wrap: wrap; gap: 3px; margin: 4px 0; }
 /* .tag-btn → Tailwind utilities inline in clone/ScriptPanel.jsx (P4). */
 
-.file-drag {
-  border: 1px dashed var(--chrome-border-strong); border-radius: var(--chrome-radius-pill); padding: 10px;
-  text-align: center; cursor: pointer; display: flex; flex-direction: column; align-items: center; gap: 4px;
-  background: transparent;
-  transition: background var(--dur-fast), border-color var(--dur-fast);
-}
-.file-drag:hover,
-.file-drag.is-dragging {
-  border-color: var(--chrome-accent); background: var(--chrome-accent-bg);
-  box-shadow: none;
-}
-.file-drag p { margin: 0; font-size: 0.72rem; color: var(--chrome-fg-muted); }
+/* .file-drag (+ :hover/.is-dragging/p) → Tailwind utilities inline in
+   clone/AudioMethodPanel.jsx (P4). is-dragging stays a JS-toggled marker. */
 
 /* ═══ PROGRESS — migrated to ui/Progress primitive. ═══ */
 
@@ -1169,108 +1159,11 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
 }
 
 /* ── Searchable combobox ─────────────────────────────────── */
-.ss-wrap { position: relative; width: 100%; }
-.ss-trigger {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: 6px; width: 100%; text-align: left; cursor: pointer;
-  font-family: inherit;
-}
-.ss-trigger:disabled { cursor: not-allowed; opacity: 0.5; }
-.ss-trigger-label {
-  flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  color: var(--text-primary);
-}
-.ss-chev { color: var(--text-secondary); flex-shrink: 0; }
-.ss-sm .ss-trigger { font-size: 0.65rem; padding: 4px 8px; }
-.ss-md .ss-trigger { font-size: 0.75rem; }
-
-.ss-pop {
-  position: absolute; top: calc(100% + 4px); left: 0; right: 0;
-  z-index: 1000;
-  background: rgba(29, 32, 33, 0.98);
-  border: 1px solid rgba(255,255,255,0.1);
-  border-radius: 6px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
-  backdrop-filter: blur(12px);
-  overflow: hidden;
-  min-width: 220px;
-  max-width: min(360px, 90vw);
-}
-.ss-search {
-  position: relative;
-  padding: 6px;
-  border-bottom: 1px solid rgba(255,255,255,0.06);
-  display: flex; align-items: center; gap: 6px;
-}
-.ss-search-icon {
-  position: absolute; left: 12px; top: 50%; transform: translateY(-50%);
-  color: var(--text-secondary); pointer-events: none;
-}
-.ss-search-input {
-  flex: 1; width: 100%;
-  background: rgba(0,0,0,0.25);
-  border: 1px solid rgba(255,255,255,0.08);
-  border-radius: 4px;
-  padding: 5px 8px 5px 24px;
-  font-size: 0.72rem; color: var(--text-primary);
-  outline: none;
-  font-family: inherit;
-}
-.ss-search-input:focus { border-color: rgba(250, 189, 47, 0.4); }
-
-.ss-list {
-  max-height: 280px;
-  overflow-y: auto;
-  padding: 2px 0;
-}
-.ss-list::-webkit-scrollbar { width: 6px; }
-.ss-list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 3px; }
-
-.ss-group-label {
-  padding: 4px 10px 2px;
-  font-size: 0.55rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-secondary);
-  opacity: 0.7;
-  display: flex; align-items: center; gap: 4px;
-}
-
-.ss-option {
-  display: flex; align-items: center; gap: 6px;
-  padding: 5px 10px;
-  font-size: 0.72rem;
-  color: var(--text-primary);
-  cursor: pointer;
-  user-select: none;
-}
-.ss-option:hover, .ss-option.ss-hl {
-  background: rgba(250, 189, 47, 0.12);
-  color: var(--accent);
-}
-.ss-option.ss-sel {
-  background: rgba(142, 192, 124, 0.1);
-  color: #8ec07c;
-  font-weight: 500;
-}
-.ss-option.ss-sel.ss-hl {
-  background: rgba(250, 189, 47, 0.18);
-}
-.ss-option-label {
-  flex: 1;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.ss-kind-icon { color: var(--text-secondary); flex-shrink: 0; }
-.ss-check { color: #8ec07c; flex-shrink: 0; }
-
-.ss-empty, .ss-more {
-  padding: 8px 10px;
-  font-size: 0.65rem;
-  color: var(--text-secondary);
-  font-style: italic;
-  text-align: center;
-}
-.ss-more { border-top: 1px solid rgba(255,255,255,0.04); }
+/* .ss-* (wrap/trigger/label/chev/sm/md/pop/search/list/group-label/option/
+   hl/sel/kind-icon/check/empty/more) → Tailwind utilities inline in
+   components/SearchableSelect.jsx (P4). The `ss-wrap` class name is retained
+   there (no longer styled here) only as a marker for residual.css's
+   `.voice-selector > .ss-wrap` cross-file child combinator. */
 
 /* ═══ PERSONALITY PASS — shared controls ═══ */
 
@@ -1390,23 +1283,9 @@ textarea.input-base::placeholder {
   margin-top: 4px;
 }
 
-/* Searchable select popup — flat chrome, no warm gradient, no wobbly radius */
-.ss-popover, .ss-menu, .ss-dropdown {
-  background: var(--chrome-bg) !important;
-  border: 1px solid var(--chrome-border-strong) !important;
-  border-radius: var(--chrome-radius-pill) !important;
-  box-shadow: 0 14px 32px -14px rgba(0,0,0,0.6) !important;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-}
-.ss-item {
-  font-family: var(--font-sans) !important;
-  color: var(--chrome-fg-muted) !important;
-}
-.ss-item:hover, .ss-item.active, .ss-highlighted {
-  background: var(--chrome-hover-bg) !important;
-  color: var(--chrome-fg) !important;
-}
+/* .ss-popover/.ss-menu/.ss-dropdown/.ss-item/.ss-highlighted removed (P4):
+   dead rules — SearchableSelect.jsx renders its own popup markup and never
+   emitted these class names (zero JSX usages). */
 
 /* Transcript block */
 .override-toggle + div {
@@ -1466,18 +1345,8 @@ div[role="dialog"].audio-trimmer {
   border-radius: var(--chrome-radius-pill);
 }
 
-/* File drop zone — flat chrome, no squircle, no hover lift */
-.file-drag {
-  border-radius: var(--chrome-radius-pill) !important;
-  transition: border-color var(--dur-fast), background var(--dur-fast);
-}
-.file-drag:hover {
-  transform: none;
-}
-.file-drag p {
-  font-family: var(--font-sans);
-  font-weight: 500;
-}
+/* File drop zone — flat chrome → Tailwind utilities inline in
+   clone/AudioMethodPanel.jsx (P4). */
 
 /* Section tab buttons (sidebar) */
 /* Sidebar item — compact card with hover-reveal actions */


### PR DESCRIPTION
## P4 shadcn/Tailwind migration — `ss-*` (searchable-select) + `file-drag` (dropzone)

Moves two global class families out of `frontend/src/index.css` into inline Tailwind utilities and deletes the now-dead rules. **Net −131 lines in index.css** (12 insertions, 143 deletions); 3 files changed overall.

### Migrated → deleted
- **`ss-*`** (`ss-wrap`, `ss-trigger`, `ss-trigger-label`, `ss-chev`, `ss-sm`/`ss-md`, `ss-pop`, `ss-search`, `ss-search-icon`, `ss-search-input`, `ss-list` incl. `::-webkit-scrollbar`, `ss-group-label`, `ss-option`/`ss-hl`/`ss-sel`, `ss-kind-icon`, `ss-option-label`, `ss-check`, `ss-empty`, `ss-more`) → utilities in `components/SearchableSelect.jsx`. The `:focus`/`:hover` states became Tailwind variants; the four-way option cascade (base / highlighted / selected / selected+highlighted) is reproduced with conditional classes; the `.ss-{sm,md} .ss-trigger` descendant rules collapse to a size-conditional class on the trigger.
- **`.ss-popover` / `.ss-menu` / `.ss-dropdown` / `.ss-item` / `.ss-highlighted`** → **deleted as dead rules** (zero JSX usages anywhere — SearchableSelect renders its own popup markup).
- **`.file-drag`** (+ `:hover` / `.is-dragging` / `p`, both blocks) → utilities in `components/clone/AudioMethodPanel.jsx`. `is-dragging` stays a JS-toggled state marker, matched via the `[&.is-dragging]:` arbitrary variant.

### Kept (irreducible) + why
- **`ss-wrap` class *name*** is retained on the SearchableSelect root (its own `position/width` is now utilities). `residual.css` styles `.voice-selector > .ss-wrap` via a **cross-file child combinator**; dropping the name would break VoiceSelector layout. The index.css rule is still deleted.
- **`.clone-drop-zone`** (out-of-scope `clone-` family, unlayered) keeps overriding the dropzone padding — preserved as-is.

No-preflight borders were made explicit; `@keyframes` untouched (none in scope).

### Verification
- Live (Vite on :3923 + Playwright/chromium, backend stubbed): Clone screen dropzone + an open SearchableSelect popup (search box, POPULAR group label, highlighted option) render coherently.
- Gates: `oxlint` 0, `oxfmt --check` clean, `vite build` OK, `vitest` **641 pass**, visual suite **48 pass**, `bun install --frozen-lockfile` no-op (no dep/lockfile change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Migrated the searchable-select and file-drag/dropzone styling from `index.css` into inline Tailwind utilities in the relevant components, then removed the unused legacy CSS rules.

**What changed**
- `SearchableSelect.jsx`
  - Replaced the legacy `ss-*` styling cascade with utility classes.
  - Updated trigger sizing, popup/search/list layout, scrollbar styling, empty state, option states, pinned rows, and selected/highlight indicators.
  - Kept existing search/filter/selection behavior intact.
- `AudioMethodPanel.jsx`
  - Moved `file-drag` presentation into component-level utility classes.
  - Preserved `is-dragging` as the JS-driven state marker.
- `index.css`
  - Deleted now-unused `ss-*` and `file-drag` rules.
  - Removed dead popup/menu rules (`.ss-popover`, `.ss-menu`, `.ss-dropdown`, `.ss-item`, `.ss-highlighted`).

**UI sketch**

Before:
```text
[Searchable Select]
[legacy ss-trigger]
   └─ popup
      ├─ search
      ├─ grouped options
      └─ empty/more states

[Audio Upload Dropzone]
+----------------------+
| legacy file-drag     |
|  drag text          |
+----------------------+
```

After:
```text
[Searchable Select]
[tailwind trigger]
   └─ popup
      ├─ styled search
      ├─ option rows with inline icons/checks
      └─ empty/more states

[Audio Upload Dropzone]
+----------------------+
| utility-styled zone  |
|  drag text           |
+----------------------+
```

Net result: cleaner component-local styling, less global CSS, and removal of dead selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->