### PR TITLE
feat(ui): migrate waveform-* to utilities, trim index.css (P4)

### DIFF
--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -25,6 +25,14 @@ import { unlockAudio } from '../utils/audioUnlock';
 import SegmentTrack from './SegmentTrack';
 import './WaveformErrorBoundary.css';
 
+// Transport-control button chrome (migrated from the .waveform-btn family in
+// index.css). UA <button> padding/font are intentionally left untouched — the
+// app ships without a preflight reset, so this matches the pre-migration look.
+const WF_BTN_BASE =
+  'flex h-[22px] w-[22px] cursor-pointer items-center justify-center rounded-[4px] [transition:all_var(--transition-smooth)] disabled:cursor-not-allowed disabled:opacity-30';
+const WF_BTN = `${WF_BTN_BASE} bg-[rgba(255,255,255,0.04)] text-[color:var(--text-secondary)] [border:1px_solid_rgba(255,255,255,0.06)] hover:bg-[rgba(255,255,255,0.1)] hover:text-[color:var(--text-primary)] hover:[border-color:rgba(255,255,255,0.12)]`;
+const WF_BTN_PLAY = `${WF_BTN_BASE} bg-[var(--chrome-accent-bg)] text-[color:var(--chrome-accent)] [border:1px_solid_var(--chrome-accent-border)] hover:bg-[color-mix(in_srgb,var(--chrome-accent)_22%,transparent)] hover:shadow-none`;
+
 /**
  * WaveformTimeline
  *
@@ -709,7 +717,7 @@ function WaveformTimeline(
   // ── Error fallback ──────────────────────────────────────────────────────────
   if (loadError) {
     return (
-      <div className="waveform-timeline">
+      <div className="mb-[6px]">
         <div className="wfm-error">
           <AlertTriangle size={13} style={{ flexShrink: 0, marginRight: 6 }} />
           {sourceMissing ? t('waveform.source_missing') : t('waveform.load_failed')}
@@ -719,11 +727,7 @@ function WaveformTimeline(
   }
 
   return (
-    <div
-      className="waveform-timeline wfm-layout"
-      role="region"
-      aria-label="Audio waveform timeline"
-    >
+    <div className="mb-[6px] wfm-layout" role="region" aria-label="Audio waveform timeline">
       {/* Video + Waveform stacked vertically */}
       <div className="wfm-stack">
         {/* Video preview — pinned to its aspect ratio so we don't letterbox
@@ -776,10 +780,14 @@ function WaveformTimeline(
       </div>
 
       {/* Controls */}
-      <div className="waveform-controls wfm-controls" role="toolbar" aria-label="Playback controls">
-        <div className="waveform-controls-left">
+      <div
+        className="flex items-center justify-between gap-[4px] wfm-controls"
+        role="toolbar"
+        aria-label="Playback controls"
+      >
+        <div className="flex items-center gap-[4px]">
           <button
-            className="waveform-btn"
+            className={WF_BTN}
             onClick={() => seekTo(0)}
             title="Restart"
             aria-label="Restart playback"
@@ -787,23 +795,26 @@ function WaveformTimeline(
             <SkipBack size={11} />
           </button>
           <button
-            className="waveform-btn waveform-btn-play"
+            className={WF_BTN_PLAY}
             onClick={togglePlay}
             disabled={!ready}
             aria-label={isPlaying ? 'Pause' : 'Play'}
           >
             {isPlaying ? <Pause size={11} /> : <Play size={11} />}
           </button>
-          <span className="waveform-time" aria-live="off">
+          <span
+            className="rounded-[3px] bg-[var(--chrome-hover-bg)] px-[5px] py-[1px] text-[0.62rem] text-[color:var(--chrome-fg-muted)] [border:1px_solid_var(--chrome-border)] [font-family:var(--font-mono)] [font-variant-numeric:tabular-nums]"
+            aria-live="off"
+          >
             {fmt(currentTime)} / {fmt(duration)}
           </span>
           <span className="wfm-kbd-hint" title="J/K/L: rewind, play/pause, forward">
             <Keyboard size={10} />
           </span>
         </div>
-        <div className="waveform-controls-right">
+        <div className="flex items-center gap-[4px]">
           <button
-            className="waveform-btn"
+            className={WF_BTN}
             onClick={() => setZoom((z) => Math.max(10, z - 20))}
             aria-label="Zoom out"
           >
@@ -815,11 +826,11 @@ function WaveformTimeline(
             max="300"
             value={zoom}
             onChange={(e) => setZoom(Number(e.target.value))}
-            className="waveform-zoom-slider"
+            className="!mt-0 !h-[2px] !w-[60px]"
             aria-label="Zoom level"
           />
           <button
-            className="waveform-btn"
+            className={WF_BTN}
             onClick={() => setZoom((z) => Math.min(300, z + 20))}
             aria-label="Zoom in"
           >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -750,13 +750,10 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
 .segment-play:hover { background: var(--chrome-hover-bg); color: var(--chrome-fg); border-color: var(--chrome-border-strong); }
 
 /* ═══ WAVEFORM TIMELINE ═══ */
-.waveform-timeline { margin-bottom: 6px; }
-
-.waveform-video-preview {
-  margin-bottom: 4px; border-radius: var(--radius);
-  overflow: hidden; border: 1px solid rgba(255,255,255,0.06); background: #1d2021;
-}
-
+/* .waveform-container is kept as a styling hook for the WaveSurfer-generated
+   region DOM ([data-id^="wavesurfer-region"]) below — those elements aren't
+   rendered in JSX, so they can't carry Tailwind utilities. The rest of the
+   waveform-* family migrated to utilities on WaveformTimeline.jsx (P4). */
 .waveform-container {
   background: rgba(0,0,0,0.22);
   border: 1px solid rgba(255,255,255,0.05);
@@ -772,56 +769,7 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
   border-radius: 3px !important;
 }
 
-.waveform-controls {
-  display: flex; align-items: center; justify-content: space-between;
-  margin-top: 4px; gap: 4px;
-}
-.waveform-controls-left { display: flex; align-items: center; gap: 4px; }
-.waveform-controls-right { display: flex; align-items: center; gap: 4px; }
-
-.waveform-btn {
-  width: 22px; height: 22px;
-  display: flex; align-items: center; justify-content: center;
-  background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.06);
-  color: var(--text-secondary); border-radius: 4px; cursor: pointer;
-  transition: all var(--transition-smooth);
-}
-.waveform-btn:hover {
-  background: rgba(255,255,255,0.1); color: var(--text-primary);
-  border-color: rgba(255,255,255,0.12);
-}
-.waveform-btn:disabled { opacity: 0.3; cursor: not-allowed; }
-
-.waveform-btn-play {
-  background: var(--chrome-accent-bg); border-color: var(--chrome-accent-border); color: var(--chrome-accent);
-}
-.waveform-btn-play:hover {
-  background: color-mix(in srgb, var(--chrome-accent) 22%, transparent);
-  box-shadow: none;
-}
-
-.waveform-time {
-  font-size: 0.62rem; font-family: var(--chrome-font-mono); color: var(--chrome-fg-muted);
-  padding: 1px 5px; background: var(--chrome-hover-bg); border-radius: 3px;
-  border: 1px solid var(--chrome-border);
-  font-variant-numeric: tabular-nums;
-}
-
-.waveform-zoom-slider {
-  width: 60px !important; height: 2px !important; margin-top: 0 !important;
-}
-
-/* ═══ MULTI-TRACK ═══ */
-.waveform-track-bg {
-  position: absolute; left: 0; right: 0; height: 26px;
-  background: rgba(255,255,255,0.015);
-  border-bottom: 1px dashed rgba(255,255,255,0.04);
-  pointer-events: none; z-index: 1;
-}
-.waveform-track-bg:nth-child(1) { top: 0px; }
-.waveform-track-bg:nth-child(2) { top: 26px; }
-.waveform-track-bg:nth-child(3) { top: 52px; }
-
+/* ═══ MULTI-TRACK (WaveSurfer region DOM) ═══ */
 .waveform-container [data-id^="wavesurfer-region"] {
   top: 52px !important;
   height: 26px !important;
@@ -1726,13 +1674,10 @@ div[role="dialog"].audio-trimmer {
 }
 
 /* ── Waveform timeline — reduce height on small screens ──
-   Track geometry shrinks with the container: 3 tracks of 18px so the
-   region row (track 3) stays inside the 60px box. */
+   The container shrinks to 60px and the WaveSurfer region row drops to an
+   18px lane pinned at top:36px so it stays inside the smaller box. */
 @media (max-width: 800px) {
   .waveform-container { height: 60px !important; }
-  .waveform-track-bg { height: 18px; }
-  .waveform-track-bg:nth-child(2) { top: 18px; }
-  .waveform-track-bg:nth-child(3) { top: 36px; }
   .waveform-container [data-id^="wavesurfer-region"] {
     top: 36px !important;
     height: 18px !important;

--- a/scripts/record_promo.js
+++ b/scripts/record_promo.js
@@ -94,7 +94,9 @@ async function run() {
     // Click play button (WaveSurfer play or native)
     // Finding the play button by its lucide icon class or explicit text is best
     // Using a broad selector for the play button in the waveform bar
-    const playBtn = page.locator('button:has(.lucide-play), .waveform-controls button').first();
+    const playBtn = page
+        .locator('button:has(.lucide-play), [aria-label="Playback controls"] button')
+        .first();
     if (await playBtn.isVisible()) {
         await playBtn.click();
     }


### PR DESCRIPTION
## P4 shadcn/Tailwind migration — `waveform-*` family

Moves the `waveform-*` global class family out of `frontend/src/index.css` onto Tailwind v4 utilities on `WaveformTimeline.jsx`, deleting the now-dead rules.

### Migrated to utilities (rules deleted)
| Class | Notes |
|-------|-------|
| `waveform-timeline` | `mb-[6px]` |
| `waveform-controls` / `-left` / `-right` | `flex items-center justify[-between] gap-[4px]` — no `mt` utility added (see cascade note) |
| `waveform-btn` + `:hover` + `:disabled` | shared `WF_BTN` const; states → `hover:`/`disabled:`; UA `<button>` padding/font preserved (no preflight) |
| `waveform-btn-play` + `:hover` | shared `WF_BTN_PLAY` const |
| `waveform-time` | text/border/bg + mono + tabular-nums |
| `waveform-zoom-slider` | `!w-[60px] !h-[2px] !mt-0` |

no-preflight borders → explicit `[border:1px_solid_…]`; exact px via arbitrary values.

### Deleted as dead (zero usages anywhere)
`waveform-video-preview`, `waveform-track-bg` (+ `:nth-child` + the `max-width:800px` track rows).

### Kept (irreducible) + why
`.waveform-container` and its `.waveform-container [data-id^="wavesurfer-region"]` descendant rules (plus the 800px container/region media query). These style **WaveSurfer-generated DOM** that isn't rendered in JSX, so they can't be expressed as utilities; the class stays as a styling hook.

`index.css` net **−55 lines** (+7 / −62).

### Verification (live)
- Playwright `getComputedStyle` (both stylesheets loaded) — new utilities reproduce the pre-migration computed styles **exactly**.
- Caught two subtleties:
  1. `controls` margin-top computes to **3px** — the unlayered `wfm-controls` already wins over the old 4px, so adding a layered `mt` utility would *regress* it. No `mt` utility added.
  2. Referencing `var(--chrome-font-mono)` inside a class string tripped the global `[class*="chrome-font-mono"]` selector (adds `slashed-zero` + `ss02`). Switched the time font to `var(--font-mono)` (identical stack) to avoid the substring match.
- **Screenshot pixel-diff old vs new = 0 (AE).**
- Updated `scripts/record_promo.js` fallback selector (`.waveform-controls` → `[aria-label="Playback controls"]`).

### Gates
oxlint `0` · oxfmt clean · `vite build` ✓ · vitest **641 pass** · `test:visual` **48 pass** · `bun install --frozen-lockfile` no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### UI layout
```
Before:
[ waveform-timeline ]
  [ controls row ]
    [ restart ] [ play/pause ] [ time ] [ zoom ]

After:
[ waveform-timeline (Tailwind utilities) ]
  [ controls row (flex/rounded/border/padding utilities) ]
    [ restart ] [ play/pause ] [ time ] [ zoom ]
```

### Behavior
```mermaid
flowchart LR
  A[record_promo.js] --> B{find play button}
  B -->|old| C[.waveform-controls button]
  B -->|new| D[button:has(.lucide-play)\nor [aria-label=\"Playback controls\"] button]
  D --> E[check visible]
  E --> F[click play if found]
```

### Summary
- Migrated waveform timeline/control styling from global CSS to Tailwind utilities in `WaveformTimeline.jsx`, preserving the existing playback, time display, and zoom UI.
- Removed dead `waveform-*` CSS rules from `frontend/src/index.css`, while keeping WaveSurfer-generated DOM styling that still needs CSS hooks.
- Updated `scripts/record_promo.js` to use a more robust play-button locator after the class migration.
- Verified the visual and behavioral changes with style/screenshot checks and test/build runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->