### PR TITLE
feat(ui): move Settings page chrome to Tailwind, drop page-specific CSS (fast mode)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1419,22 +1419,11 @@ div[role="dialog"].audio-trimmer {
   border-radius: 0 !important;
 }
 
-/* ═══ SETTINGS PAGE ═══ */
-.settings-page {
-  flex: 1; display: flex; flex-direction: column; overflow-y: auto;
-  background: var(--chrome-bg);
-  padding: 28px 40px 48px;
-  font-family: var(--font-sans);
-}
-.settings-page h1 {
-  font-family: var(--font-sans);
-  font-weight: 600; font-size: 1.4rem; margin: 0 0 6px;
-  color: var(--chrome-fg); letter-spacing: -0.01em;
-}
-.settings-page .settings-subtitle {
-  color: var(--chrome-fg-muted); font-size: 0.78rem; margin-bottom: 24px;
-}
-/* ═══ Settings — badge, tabs, subtabs migrated to ui/Badge + ui/Tabs + ui/Segmented.
+/* ═══ Settings — page chrome (`.settings-page` layout / padding / scroll / the
+   ≥760px [rail | content] grid + `.settings-content`) is now Tailwind on the
+   token bridge in src/pages/Settings.jsx; the page-specific tab-rail look and
+   the Models / Engines rules that can't migrate stay in src/pages/Settings.css.
+   Badge, tabs, subtabs migrated to ui/Badge + ui/Tabs + ui/Segmented.
    The legacy section/row frames are gone too (P4): .settings-section + h2 and
    .settings-row(.label/.value) were superseded by the st-section primitive
    (components/settings/primitives/SettingsSection.jsx), and .settings-log moved

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1,37 +1,14 @@
 /* Settings page — page-specific styles layered over the design system.
    Chrome tokens only: every surface here should rhyme with the status bar. */
 
-/* Tighter page chrome — reclaim whitespace around title and section padding. */
-/* Fill the scroll container so short tabs (Appearance/About/Privacy) render as a
-   full-height panel instead of a stunted box floating in a void. min-height:100%
-   is a FLOOR — tall tabs (Models/Logs) grow past it and scroll as before; if the
-   parent height is ever indeterminate it simply no-ops. */
-.settings-page                   {
-  padding: var(--space-5) var(--space-7) var(--space-7);
-  display: flex; flex-direction: column; min-height: 100%; box-sizing: border-box;
-  /* Center the whole settings block (nav rail + content) as a unit so a wide
-     window doesn't leave everything jammed against the left with a dead void on
-     the right. The cap = rail + gap + content measure + the L/R page padding,
-     so the content track lands exactly at --settings-measure. */
-  width: 100%;
-  max-width: calc(var(--settings-rail) + var(--space-5) + var(--settings-measure) + 2 * var(--space-7));
-  margin-inline: auto;
-}
-.settings-page h1                { font-size: var(--text-lg); margin: 0 0 2px; }
-.settings-page .settings-subtitle{ font-size: var(--text-base); margin-bottom: var(--space-5); }
-.settings-tabs-ui                { margin-bottom: var(--space-3); }
-
-.settings-row__mono     { font-family: var(--chrome-font-mono); color: var(--chrome-fg-muted); }
-/* .settings-muted, .settings-prose (base), .settings-log-meta, .settings-log__empty,
-   .settings-link-row, .settings-actions-row, .models-row__progressline are now
-   Tailwind utilities in the settings/* tab components. The .settings-prose strong
-   override stays (descendant selector). .settings-section__head-* are unused in
-   JSX today, so they stay until a consumer needs them. */
+/* The page chrome itself (`.settings-page` layout + centering + the ≥760px
+   [rail | content] grid, and `.settings-content`) now lives as Tailwind on the
+   token bridge directly in Settings.jsx. What remains here is the page-specific
+   styling the shared primitives can't carry: the tab-rail look (which must stay
+   unlayered to win over the shadcn Tabs primitive), the `.settings-prose strong`
+   emphasis (a descendant override still used across tabs), and the Models /
+   Engines / recommendation rules consumed by their sub-components. */
 .settings-prose strong  { color: var(--chrome-fg); font-weight: 600; }
-
-.settings-section__head-row     { display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); }
-.settings-section__head-left    { display: flex; align-items: center; gap: var(--space-4); }
-.settings-section__head-actions { display: flex; gap: var(--space-3); }
 
 /* We're migrating to the ui/ Tabs primitive — keep a thin class so the old
    .settings-tabs gradient-above space stays; the Tabs primitive itself
@@ -53,17 +30,10 @@
   color: var(--chrome-accent);
 }
 
-/* ── Wide (≥760px): vertical rail + content column ──────────────── */
+/* ── Wide (≥760px): vertical rail beside the content column ─────────
+   The page grid that creates the [rail | content] tracks lives as Tailwind on
+   Settings.jsx; this block only turns the tab strip into that left-hand rail. */
 @media (min-width: 760px) {
-  /* minmax(0, 1fr) — NOT 1fr (= minmax(auto,1fr)) — so the content track can
-     shrink below its content's min-size. Without the 0 minimum, a non-shrinking
-     child (a nowrap status pill, a long path) forces the track wider than the
-     viewport and clips at the window edge, which max-width on .settings-content
-     can't claw back. This is the responsive-containment guarantee for EVERY
-     settings page (they all share this grid). */
-  .settings-page { display: grid; grid-template-columns: var(--settings-rail) minmax(0, 1fr); gap: var(--space-5); align-content: start; }
-  .settings-page h1,
-  .settings-page .settings-subtitle { grid-column: 1 / -1; }
   .ui-tabs.settings-tabs-ui {
     flex-direction: column;
     align-items: stretch;
@@ -89,27 +59,9 @@
   .ui-tabs.settings-tabs-ui::-webkit-scrollbar { display: none; }
 }
 
-/* ── Content panel: fills the 1fr column on every page. Owner asked for genuine
-   full-width usage — no narrow reading column, no dead right-hand gutter. A
-   generous max-width keeps lines from sprawling on ultra-wide monitors, with
-   the column left-aligned so it stays flush to the nav rail. The page's own
-   padding (--space-7 sides) plus section padding gives both-side breathing
-   room; per-row rules below keep values/inputs from going flush or overflowing. */
-.settings-content {
-  flex: 1 1 auto;
-  min-width: 0;
-  /* Cap the reading measure so rows don't sprawl edge-to-edge on wide windows
-     (the "too spread out" report). Left-aligned under the nav rail, macOS-style;
-     the extra space falls to the right as plain whitespace, not stretched rows. */
-  max-width: var(--settings-measure);
-  align-self: start;   /* size to content — don't stretch to the taller nav rail */
-  /* Make this the container the rows measure against. The nav rail steals
-     ~180px, so a *viewport* breakpoint misjudges the real content width — a
-     container query lets rows stack on their ACTUAL width instead (#primitives). */
-  container-type: inline-size;
-  container-name: settings;
-}
-.settings-content > :first-child { margin-top: 0; }
+/* The content panel (fills the 1fr track, caps the reading measure, and
+   establishes the `settings` container query that primitives.css's row-stacking
+   depends on) is Tailwind on Settings.jsx now — see the content `<div>` there. */
 
 /* ── Engines tab ─────────────────────────────────────────────── */
 .engines-family            { margin-bottom: var(--space-5); }

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -343,7 +343,12 @@ export default function Settings() {
     );
 
   return (
-    <div className="settings-page">
+    // Page chrome (formerly `.settings-page` in Settings.css/index.css) is now
+    // Tailwind on the token bridge: a centered, scrollable column that becomes a
+    // [rail | content] grid at ≥760px. The rail's internal look + the narrow
+    // horizontal-scroll strip stay in Settings.css (`.settings-tabs-ui`), which
+    // must remain unlayered to override the shared shadcn Tabs primitive.
+    <div className="flex min-h-full w-full max-w-[calc(var(--settings-rail)_+_var(--space-5)_+_var(--settings-measure)_+_2_*_var(--space-7))] mx-auto box-border flex-1 flex-col overflow-y-auto bg-[var(--chrome-bg)] p-[var(--space-5)_var(--space-7)_var(--space-7)] font-sans min-[760px]:grid min-[760px]:[grid-template-columns:var(--settings-rail)_minmax(0,1fr)] min-[760px]:gap-[var(--space-5)] min-[760px]:[align-content:start]">
       <Tabs
         items={TAB_DEFS.map((def) => ({ ...def, label: t(`settings.${def.id}`) }))}
         value={activeTab}
@@ -351,7 +356,10 @@ export default function Settings() {
         className="settings-tabs-ui"
       />
 
-      <div className="settings-content">
+      {/* Content column — fills the 1fr track; establishes the `settings`
+          container so primitives.css's `@container settings` row-stacking still
+          fires on the real content width (the rail steals ~168px). */}
+      <div className="min-w-0 max-w-[var(--settings-measure)] flex-auto self-start [container-type:inline-size] [container-name:settings] [&>*:first-child]:mt-0">
         {activeTab === 'general' && (
           <>
             <GeneralTab />


### PR DESCRIPTION
## What

FAST-mode shadcn pass over the **Settings page chrome**. The settings tab components already render on shadcn — the live `src/ui/*` primitives (Button/Badge/Tabs/Segmented/Slider/Input) are thin wrappers over `src/components/ui/*` shadcn primitives via the `index.css` token bridge — so the only non-shadcn layer left here that is **safe to migrate** is the page layout.

- **Settings.jsx** — `.settings-page` / `.settings-content` are now Tailwind on the token bridge: the centered, scrollable column that becomes a `[rail | content]` grid at ≥760px, and the content column that establishes the `settings` container query `primitives.css` relies on. Behavior unchanged.
- **Settings.css** — removed the page-chrome rules now in Tailwind (`.settings-page` + grid, `.settings-content`) and the dead ones (`.settings-row__mono`, `.settings-section__head-*`). Kept what can't migrate: the tab-rail look (must stay **unlayered** to win over the shared shadcn Tabs primitive), `.settings-prose strong`, and the `.models-*`/`.engines-*`/`.reco-*` rules consumed by their sub-components.
- **index.css** — removed the duplicate base `.settings-page` block.

Net: **3 files, ~51 fewer CSS lines.**

## Scope note (why this isn't a full Settings.css deletion)

Per the *"delete once unused — grep cross-file first"* discipline, two things turned out to be **shared foundations** depended on by out-of-scope code, so deleting them would break out-of-scope panels + main CI:

1. **primitives.css + the `.st-*` class contract** — out-of-scope `StoragePanel` passes `st-row--stack`; `AppearancePanel.css` / `VoicePanel.css` / `PronunciationPanel.test` reach into `.st-row__control`.
2. **Settings.css `.models-*` / `.engines-*` / `.reco-*`** — consumed by out-of-scope `ModelsTable`, `RecoBanner`, `EngineCompatibilityMatrix`.

A fuller rewrite (e.g. moving the settings primitives onto shadcn `Card`/`Switch` and deleting `primitives.css`) would require touching dub + ~6 out-of-scope panels — out of scope for this batch.

## Verification

- `vite build` ✓ · `oxlint` exit 0 ✓ · `oxfmt --check` ✓ · `vitest` 641 ✓ · `test:visual` 48 ✓ (no baseline change — snapshotted components untouched) · `bun install --frozen-lockfile` ✓ (no dep/lockfile change)
- Eyeballed Settings (General + Logs tabs) via the visual harness at desktop width: vertical rail beside centered content column, active-tab accent indicator, and tab switching all render coherently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Settings page chrome to use Tailwind-based layout in `Settings.jsx` instead of page-specific CSS.

Before:
```text
┌──────────────────────────────┐
│ Settings page chrome (CSS)   │
│ - full-page centering        │
│ - scroll/padding             │
│ - title/subtitle spacing     │
│                              │
│ [tabs]                       │
│ [content panel]              │
└──────────────────────────────┘
```

After:
```text
┌──────────────────────────────────────────────┐
│ Tailwind-centered, scrollable page column   │
│ ┌──────────────┬──────────────────────────┐ │
│ │ tab rail     │ content                  │ │
│ │ (≥760px)    │ (container-named)        │ │
│ └──────────────┴──────────────────────────┘ │
└──────────────────────────────────────────────┘
```

- Moved the page-level Settings layout/chrome to Tailwind utilities while preserving the existing container-query behavior.
- Trimmed `Settings.css` to keep only styles still needed for the tab rail, prose emphasis, and out-of-scope Models/Engines/Reco rules.
- Removed duplicate legacy `.settings-page` base styling from `index.css`.

No behavior changes; tab navigation, deep-linking, and panel rendering remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->