### PR TITLE
feat(ui): migrate app-container shell + Sidebar to utilities, trim index.css (fast mode)

### DIFF
--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,22 +1,16 @@
 /* Sidebar — page-specific layout + accents, base comes from ui/ primitives. */
 
-/* .sidebar base (flex column) + .sidebar__tabs layout → Tailwind utilities in
-   Sidebar.jsx. Collapsed-mode combinator overrides stay here (unlayered). */
-.sidebar.is-collapsed .sidebar__tabs {
-  flex-direction: column;
-  padding: var(--space-3) var(--space-2);
-  align-items: center;
-}
+/* .sidebar base (flex column) + .sidebar__tabs layout (incl. its collapsed
+   variant) → Tailwind utilities in Sidebar.jsx. The .sidebar__tab collapsed
+   override stays here: the .sidebar__tab base is still unlayered CSS below, so
+   the collapsed combinator must also be unlayered to win the cascade over it.
+   (Collapsed icon size is handled by the JSX `size` prop, not CSS.) */
 .sidebar.is-collapsed .sidebar__tab {
   max-width: 100%;
   padding: 0;
   width: 36px;
   height: 36px;
   flex: none;
-}
-.sidebar.is-collapsed .sidebar__tab svg {
-  width: 18px;
-  height: 18px;
 }
 
 .sidebar__tab {
@@ -99,10 +93,11 @@
 /* .sidebar__empty + __empty-icon/__empty-title/__empty-sub → utilities in
    Sidebar.jsx (EmptyState). Collapsed-hide combinator below stays here. */
 
-/* Hide text-heavy blocks when sidebar is collapsed to icon-only width */
+/* Hide the empty-state card when collapsed to icon-only width. EmptyState is a
+   shared component with no collapsed-state prop, so the hide stays a parent-
+   state combinator here. (The subtitle + search blocks are already gated out of
+   the JSX when collapsed, so they need no CSS hide.) */
 .sidebar.is-collapsed .sidebar__empty     { display: none; }
-.sidebar.is-collapsed .sidebar__subtitle  { display: none; }
-.sidebar.is-collapsed .sidebar__search    { display: none; }
 
 /* Section label — matches the status-bar's "LOGS" uppercase treatment.
    Labels are displays (not buttons) but this one IS clickable (collapses
@@ -130,12 +125,7 @@
    combinator above stays here. */
 
 /* ── Scrollable body + collapsed-mode tweaks ─────────────────── */
-/* .sidebar__scroll base → utilities in Sidebar.jsx; .is-collapsed stays here. */
-.sidebar__scroll.is-collapsed {
-  padding: 8px 4px;
-  align-items: center;
-  gap: 8px;
-}
+/* .sidebar__scroll base + its collapsed-mode tweaks → utilities in Sidebar.jsx. */
 
 /* Preset rows that don't need a computed accent */
 .history-item--dub       { --row-accent: #83a598; }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -196,7 +196,9 @@ export default function Sidebar(props) {
       className={`glass-panel history-panel sidebar flex flex-col ${isSidebarCollapsed ? 'is-collapsed' : ''}`}
     >
       {/* Tab bar — only tabs relevant to the current view */}
-      <div className="sidebar__tabs flex gap-[var(--space-2)] px-[var(--space-2)] py-[var(--space-1)] [border-bottom:1px_solid_var(--chrome-border)] bg-[var(--chrome-bg)] shrink-0 justify-center">
+      <div
+        className={`sidebar__tabs flex gap-[var(--space-2)] px-[var(--space-2)] [border-bottom:1px_solid_var(--chrome-border)] bg-[var(--chrome-bg)] shrink-0 justify-center ${isSidebarCollapsed ? 'flex-col py-[var(--space-3)] items-center' : 'py-[var(--space-1)]'}`}
+      >
         {SIDEBAR_TABS.filter((t) => availableTabs.includes(t.id)).map(
           ({ id, icon: Icon, accent }) => (
             <button
@@ -244,7 +246,7 @@ export default function Sidebar(props) {
       )}
 
       <div
-        className={`sidebar__scroll flex-1 overflow-y-auto px-[4px] py-[3px] flex flex-col items-stretch gap-0 ${isSidebarCollapsed ? 'is-collapsed' : ''}`}
+        className={`sidebar__scroll flex-1 overflow-y-auto px-[4px] flex flex-col ${isSidebarCollapsed ? 'py-[8px] items-center gap-[8px]' : 'py-[3px] items-stretch gap-0'}`}
       >
         {/* ── PROJECTS TAB ── */}
         {sidebarTab === 'projects' && (


### PR DESCRIPTION
## Summary

FAST-mode shadcn/Tailwind migration of the **app shell** (`app-container` layout grid) + the remaining `Sidebar.css`. Palette kept, behavior intact, no feature internals touched. **HELD batch.**

## Shell (`app-container` grid) — KEPT as-is, by design

The outer `.app-container` grid family (38 rules) is the canonical cross-cutting positioning hook and is deliberately left in `index.css` (net delta: 0):

- **Test-guarded:** `appShellScale.test.js` parses the literal `.app-container { … }` block and asserts the `zoom` / `calc(100vw/--ui-scale)` scale pattern + the `[data-zoom-layout=off]` 100vw/100vh fallback. Migrating the base rule away breaks that regression guard.
- **Externally hooked:** `LogsFooter.css` insets the fixed footer via `.app-container .logs-footer` and `.app-container.rail-right .logs-footer` ancestor combinators (+ a ≤600px media query) — not expressible as utilities.
- **Child placement:** nav-rail / history-panel / main-content are positioned by `.app-container > .child` descendant combinators that reflow `grid-column` across six dynamic state classes (`sidebar-collapsed` / `sidebar-hidden` / `rail-right` / `shell-narrow` / `shell-mini`). Reproducing that needs edits to out-of-scope child components.

This is exactly the "safer kept as a class — keep and report" case in the brief.

## `Sidebar.css` — safe migrations + dead-rule removal

**Migrated to conditional utilities in `Sidebar.jsx`** (base already utilities; mutually-exclusive classes avoid the Tailwind same-property ordering trap):
- `.sidebar.is-collapsed .sidebar__tabs` → tabs div
- `.sidebar__scroll.is-collapsed` → scroll div

**Removed (dead / redundant):**
- `.sidebar.is-collapsed .sidebar__tab svg` — icon size already set by the JSX `size` prop
- `.sidebar.is-collapsed .sidebar__subtitle` / `__search` — both blocks already gated out of the JSX when collapsed

**Kept (with reasons):** `.sidebar__tab` base + `:hover`/`.is-active`/`:focus-visible` (is-active must beat :hover via source order — not cleanly reproducible in layered utilities), `.sidebar.is-collapsed .sidebar__tab` (base still unlayered, override must stay unlayered), `.sidebar__search-input` (overrides unlayered `.input-base`), `.sidebar__search-clear` (`!important` Button overrides), `.sidebar__save-btn*` (consumed by out-of-scope `WorkspaceProjects.jsx`), `.sidebar__section-title:hover` + `.sidebar__icon-tile` states (prior-wave unlayered-by-design), `.sidebar.is-collapsed .sidebar__empty` (shared `EmptyState`, no collapsed prop), all `history-*` rules (consumed by out-of-scope `Workspace*` panels).

## Verification

- `vite build` ✓ · `oxlint` exit 0 ✓ · `oxfmt --check` clean ✓
- `vitest run` **641/641** (incl. the `appShellScale` shell guard) ✓
- `bun run test:visual` **48/48** ✓ · `bun install --frozen-lockfile` ✓
- Eyeballed Launchpad + responsive widths (1280 / 1000 / 560 / 1366) + a forced-render of the collapsed Sidebar: rail / header / main / footer placement intact, footer reclaims full width at ≤600px, **0 console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Sidebar collapsed-state styling by moving the remaining layout tweaks into JSX utilities and trimming redundant CSS.

**What changed**
- `Sidebar.jsx`: collapsed mode now applies conditional utility classes for:
  - the tab bar layout/alignment
  - the scroll container padding/alignment/spacing
- `Sidebar.css`: removed several collapsed-mode overrides and dead rules, including:
  - tab-bar layout overrides
  - tab SVG sizing override
  - collapsed empty-state hides for subtitle/search
  - collapsed scroll-container padding/alignment/gap rules
- Kept other CSS rules intact where they still depend on source order, unlayered CSS, `!important`, or out-of-scope components.

**Layout sketch**

Before
```text
Sidebar
├─ Tabs row
│  ├─ tab
│  ├─ tab
│  └─ tab
└─ Scroll content
   └─ items stacked with CSS-driven collapsed tweaks
```

After
```text
Sidebar
├─ Tabs column (collapsed) / row (expanded)
│  ├─ tab
│  ├─ tab
│  └─ tab
└─ Scroll content
   └─ items spaced/aligned via conditional utilities
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->