### PR TITLE
fix(settings): sidebar items show UA button-gray in dark themes

### DIFF
--- a/frontend/src/components/settings/SettingsSidebar.jsx
+++ b/frontend/src/components/settings/SettingsSidebar.jsx
@@ -74,7 +74,7 @@ export default function SettingsSidebar({ visibleIds, active, onSelect }) {
                     aria-current={isActive ? 'page' : undefined}
                     data-testid={`settings-nav-${it.id}`}
                     className={cn(
-                      'group relative flex w-full items-center gap-[var(--space-3)] rounded-[var(--chrome-radius-pill)] border border-transparent px-[var(--space-3)] py-[var(--space-2)] text-left [font-family:var(--font-sans)] text-[length:var(--text-sm)] transition-[background,color] duration-[120ms] focus-visible:shadow-[var(--focus-ring)] focus-visible:outline-none',
+                      'group relative flex w-full appearance-none items-center gap-[var(--space-3)] rounded-[var(--chrome-radius-pill)] border border-transparent bg-transparent px-[var(--space-3)] py-[var(--space-2)] text-left [font-family:var(--font-sans)] text-[length:var(--text-sm)] transition-[background,color] duration-[120ms] focus-visible:shadow-[var(--focus-ring)] focus-visible:outline-none',
                       isActive
                         ? 'bg-[var(--chrome-hover-bg)] font-semibold text-[color:var(--chrome-fg)] shadow-[inset_2px_0_0_var(--chrome-accent)]'
                         : 'font-medium text-[color:var(--chrome-fg-muted)] hover:bg-[var(--chrome-hover-bg)] hover:text-[color:var(--chrome-fg)]',


### PR DESCRIPTION
The sidebar nav items are native `<button>`s with no explicit background on the non-active state; with preflight disabled they fell back to the UA `ButtonFace` (light gray) — washed-out pills in dark themes. Adds `bg-transparent` + `appearance-none` so items are theme-adaptive; active/hover keep the `--chrome-hover-bg` overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the settings sidebar category buttons to avoid inheriting the browser’s default light gray `ButtonFace` styling in dark themes when Tailwind preflight is off.

Changes:
- Added `appearance-none` to neutralize native button styling.
- Added `bg-transparent` so inactive items follow the theme instead of a default button background.
- Preserved the existing `--chrome-hover-bg` overlay for hover/active states.

Before/after:
```text
Before:                              After:
[ ButtonFace ]                       [ transparent ]
[ label ]                            [ label ]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->