### PR TITLE
fix(settings): right-anchored controls fill leftward on the full-width hub

### DIFF
--- a/frontend/src/components/settings/primitives/SettingRow.jsx
+++ b/frontend/src/components/settings/primitives/SettingRow.jsx
@@ -49,7 +49,7 @@ export default function SettingRow({
         align === 'start' ? 'items-start' : 'items-center',
         stack
           ? 'grid-cols-[1fr] gap-[var(--space-3)]'
-          : 'grid-cols-[minmax(0,1fr)_auto] gap-x-[var(--space-5)] @max-[600px]/settings:grid-cols-[1fr] @max-[600px]/settings:gap-[var(--space-2)] max-[560px]:grid-cols-[1fr] max-[560px]:gap-[var(--space-2)]',
+          : 'grid-cols-[minmax(0,1fr)_auto] gap-x-[var(--space-5)] @min-[601px]/settings:has-[input:not([type=checkbox]):not([type=radio]):not([type=range])]:[grid-template-columns:minmax(0,1fr)_minmax(0,1.9fr)] @min-[601px]/settings:has-[select]:[grid-template-columns:minmax(0,1fr)_minmax(0,1.9fr)] @min-[601px]/settings:has-[textarea]:[grid-template-columns:minmax(0,1fr)_minmax(0,1.9fr)] @max-[600px]/settings:grid-cols-[1fr] @max-[600px]/settings:gap-[var(--space-2)] max-[560px]:grid-cols-[1fr] max-[560px]:gap-[var(--space-2)]',
         className,
       )}
     >
@@ -73,9 +73,9 @@ export default function SettingRow({
             '[&_input:not([type=checkbox]):not([type=radio]):not([type=range])]:min-w-0 [&_input:not([type=checkbox]):not([type=radio]):not([type=range])]:max-w-full [&_select]:min-w-0 [&_select]:max-w-full [&_textarea]:min-w-0 [&_textarea]:max-w-full',
             stack
               ? 'justify-self-stretch max-w-full text-left flex-wrap whitespace-normal [&_[data-slot=settings-input]]:max-w-full [&_[data-slot=settings-input]]:flex-[1_1_220px]'
-              : 'justify-self-end max-w-[60%] text-right whitespace-nowrap @max-[600px]/settings:justify-self-start @max-[600px]/settings:max-w-full @max-[600px]/settings:text-left @max-[600px]/settings:whitespace-normal max-[560px]:justify-self-start max-[560px]:max-w-full max-[560px]:text-left',
+              : 'justify-self-end max-w-[85%] text-right whitespace-nowrap has-[input:not([type=checkbox]):not([type=radio]):not([type=range])]:w-full has-[select]:w-full has-[textarea]:w-full @max-[600px]/settings:justify-self-start @max-[600px]/settings:w-full @max-[600px]/settings:max-w-full @max-[600px]/settings:text-left @max-[600px]/settings:whitespace-normal max-[560px]:justify-self-start max-[560px]:w-full max-[560px]:max-w-full max-[560px]:text-left',
             mono &&
-              '[font-family:var(--chrome-font-mono)] text-[length:var(--text-base)] text-[color:var(--chrome-fg-muted)] tabular-nums max-w-[75%] whitespace-normal [word-break:normal] [overflow-wrap:anywhere] leading-[1.45]',
+              '[font-family:var(--chrome-font-mono)] text-[length:var(--text-base)] text-[color:var(--chrome-fg-muted)] tabular-nums max-w-[42ch] whitespace-normal [word-break:normal] [overflow-wrap:break-word] leading-[1.45]',
           )}
         >
           {control}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -451,7 +451,7 @@ export default function Settings() {
         <SettingsSidebar visibleIds={visibleSet} active={active} onSelect={setActive} />
       </aside>
 
-      <div className="min-w-0 flex-auto self-start [container-type:inline-size] [container-name:settings]">
+      <div className="min-w-0 w-full max-w-[1100px] mx-auto flex-auto self-start [container-type:inline-size] [container-name:settings]">
         <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-3)]">
           {CatIcon && (
             <span


### PR DESCRIPTION
## What & why

On the full-width Settings hub (#843), every right-aligned `SettingRow` control was capped at `max-w-[60%]`, so wide fields (text/URL/key inputs, selects, textareas, the model/engine search) sat cramped against the right edge with a big empty gap to the label. Two related regressions surfaced on the About page at wide viewports: read-only **mono** values (`0.3.8`, `2.11.2`, `OmniVoice Studio`) wrapped **character-by-character** (`[overflow-wrap:anywhere]` collapsed the auto grid cell to a 1-char min-content), and dropping the content measure in #843 spread rows **edge-to-edge** on wide/ultrawide screens with a huge void in the middle.

This makes right-aligned controls stay **right-anchored** and **grow leftward to fill** the available space — while short controls (toggles, segmented, sliders, single buttons) stay compact and right-pinned.

## Changes

**`frontend/src/components/settings/primitives/SettingRow.jsx`**
- Widen the control grid track to `minmax(0,1fr) minmax(0,1.9fr)` **only** when the row contains a real field (`has-[input:not(checkbox/radio/range)]`, `has-[select]`, `has-[textarea]`), gated to `@min-[601px]/settings` so the narrow-container stacking + `max-[560px]` fallback + `stack` branch are untouched. Toggles (`input[type=checkbox]`), Radix Segmented/Slider (buttons/spans), and buttons don't match → they keep the `auto` track and stay compact.
- Lift `max-w-[60%]` → `max-w-[85%]` and make the control cell `w-full` (has-gated) so wide fields fill the widened track leftward to a clean right edge.
- Mono fix: `[overflow-wrap:anywhere]` → `break-word`, and percentage `max-w-[75%]` → length-based `max-w-[42ch]` — short values now render on one line (the percentage cap was forcing the auto track to min-content); long paths still wrap on boundaries.

**`frontend/src/pages/Settings.jsx`**
- Re-introduce a generous, centered content measure (`w-full max-w-[1100px] mx-auto`) on the content column so rows "fill from the middle" instead of spreading to the screen edges; the rail stays fixed. Wider than the old cramped 660px `--settings-measure`, capped for readability.

## Verification (Playwright, real backend stubbed)

Screenshotted at **1400px** — General (select fills), Translation (Base URL/Model/API-key inputs fill leftward; Segmented + preset buttons + Save stay compact), Network (proxy/ffmpeg inputs fill), Credentials (HF token rows; Test-now compact), Appearance (toggles/slider/swatches compact right-pinned), Dictation (mix), About (mono values `OmniVoice Studio` / `0.3.8` / `no` / `web preview` each on one line, content centered not edge-to-edge). At **700px**, rows stack correctly.

Gates: `vite build` ✓ · `oxlint` exit 0 ✓ · `oxfmt --check` clean ✓ · `vitest run` 641 pass ✓ · `test:visual` 48 pass (no baseline change — has-widen is gated behind the `/settings` container the isolated harness doesn't provide) ✓ · `bun install --frozen-lockfile` no changes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adjusted the Settings UI to prevent right-aligned controls from getting pinned near the edge on wide screens.

Before:
```text
| Settings page width fills the screen |
| Row label ............ [control]     |
| Row label ............ [control]     |
```

After:
```text
|      centered content (max 1100px)      |
| Row label ............     [control]    |
| Row label ............     [control]    |
| mono/read-only values wrap by words      |
```

Key changes:
- `SettingRow.jsx`
  - Expanded the control grid only for rows with real inputs/selects/textareas.
  - Kept short controls compact and right-pinned.
  - Increased the control width cap from `60%` to `85%`.
  - Switched mono/read-only wrapping from `overflow-wrap:anywhere` to `break-word`.
  - Added a `42ch` cap to avoid character-by-character wrapping.
- `Settings.jsx`
  - Restored a centered content container with `w-full max-w-[1100px] mx-auto` so rows don’t span edge-to-edge on large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->