### PR TITLE
fix(dub): show transcribing/progress view instead of idle dropzone while the pipeline runs

### DIFF
--- a/frontend/src/components/dub/IdleSkeleton.jsx
+++ b/frontend/src/components/dub/IdleSkeleton.jsx
@@ -261,7 +261,22 @@ export default function IdleSkeleton({
               onAbort={handleDubAbort}
               large
             />
-          ) : (
+          ) : dubStep === 'transcribing' ? (
+            // URL-ingest / restored jobs have no local `dubVideoFile`, so the
+            // waveform-overlay branch above never runs for them. Without this
+            // case the no-file path fell straight through to the idle dropzone
+            // while the pipeline was actively transcribing: the stepper showed
+            // Transcribe (active) but the main pane still showed the "Drop
+            // video here" dropzone. Render the transcribe progress here too so
+            // the main view always reflects the pipeline stage, on every path.
+            <div className="flex-1 flex flex-col items-center justify-center min-h-0">
+              <TranscribeOverlay
+                elapsed={transcribeElapsed}
+                duration={dubDuration}
+                onAbort={handleDubAbort}
+              />
+            </div>
+          ) : dubStep === 'idle' ? (
             <>
               {!demoDismissed && <DubbingDemo onDismiss={dismissDubDemo} />}
               <label
@@ -429,6 +444,13 @@ export default function IdleSkeleton({
                 </div>
               )}
             </>
+          ) : (
+            // Any other active pipeline step reaching the no-file path (e.g.
+            // `stopping` after a URL-ingested generation) must never fall back
+            // to the idle dropzone — keep a neutral working indicator instead.
+            <div className="flex-1 flex flex-col items-center justify-center min-h-0">
+              <Loader className="spinner" size={24} color="#d3869b" />
+            </div>
           )}
 
           <input

--- a/frontend/src/test/DubIdleSkeleton.test.jsx
+++ b/frontend/src/test/DubIdleSkeleton.test.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+
+import IdleSkeleton from '../components/dub/IdleSkeleton';
+
+// Regression guard for the Dub "transcribe-idle-desync" bug: on the
+// URL-ingest (and restored-job) path there is no local `dubVideoFile`, so the
+// waveform-overlay branch never runs. Before the fix, the no-file path handled
+// only `uploading` and otherwise fell through to the idle dropzone — meaning
+// while the pipeline was actively transcribing, the stepper showed
+// Transcribe (active) but the main pane still showed the "Drop video here"
+// dropzone + paste-URL input + "Pull YouTube captions" checkbox. The main
+// view must instead reflect the pipeline stage on every ingest path.
+
+const DROP_HINT = 'Drop video or audio here';
+const URL_PLACEHOLDER = '…or paste YouTube / video URL';
+const TRANSCRIBING = 'Transcribing with Whisper…';
+
+function baseProps(overrides = {}) {
+  const noop = vi.fn();
+  return {
+    t: i18n.t,
+    dubVideoFile: null, // URL-ingest / restored job: no local File
+    activeProjectName: '',
+    dubFilename: '',
+    dubError: '',
+    dubJobId: null,
+    dubStep: 'idle',
+    dubFailure: null,
+    handleDubRetryTranscribe: noop,
+    handleDubImportSrt: noop,
+    dubLocalBlobUrl: null,
+    dubPrepStage: null,
+    dubPrepProgress: { percent: null, speedBps: null, etaS: null, stageStartedAt: null },
+    handleDubAbort: noop,
+    transcribeElapsed: 7,
+    dubDuration: 60,
+    dubNumSpeakers: null,
+    setDubNumSpeakers: noop,
+    handleDubUpload: noop,
+    demoDismissed: true, // skip DubbingDemo (network manifest) in the idle branch
+    dismissDubDemo: noop,
+    setDubVideoFile: noop,
+    setDubInputType: noop,
+    setDubStep: noop,
+    fileToMediaUrl: noop,
+    setDubLocalBlobUrl: noop,
+    ingestUrl: '',
+    setIngestUrl: noop,
+    onIngestUrl: noop,
+    fetchYtSubs: false,
+    setFetchYtSubs: noop,
+    dubLangCode: 'en',
+    setDubLangCode: noop,
+    setDubLang: noop,
+    landingAdvOpen: false,
+    setLandingAdvOpen: noop,
+    dubInstruct: '',
+    setDubInstruct: noop,
+    ...overrides,
+  };
+}
+
+function renderIdle(overrides) {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <IdleSkeleton {...baseProps(overrides)} />
+    </I18nextProvider>,
+  );
+}
+
+describe('IdleSkeleton — pipeline-stage vs idle dropzone', () => {
+  it('shows the idle dropzone only when the pipeline is truly idle (no job)', () => {
+    const { container } = renderIdle({ dubStep: 'idle', dubJobId: null });
+    expect(container.querySelector('.dub-idle-drop')).not.toBeNull();
+    expect(screen.getByText(DROP_HINT)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(URL_PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it('does NOT show the idle dropzone while transcribing a URL-ingested job', () => {
+    const { container } = renderIdle({ dubStep: 'transcribing', dubJobId: 'job-url-1' });
+    // The desync: dropzone + paste-URL input must be gone during transcribe.
+    expect(container.querySelector('.dub-idle-drop')).toBeNull();
+    expect(screen.queryByText(DROP_HINT)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(URL_PLACEHOLDER)).not.toBeInTheDocument();
+    // …and the transcribe progress view is shown instead.
+    expect(screen.getByText(TRANSCRIBING)).toBeInTheDocument();
+  });
+
+  it('does NOT show the idle dropzone while preparing a URL-ingested job', () => {
+    const { container } = renderIdle({
+      dubStep: 'uploading',
+      dubJobId: 'job-url-2',
+      dubPrepStage: 'download',
+    });
+    expect(container.querySelector('.dub-idle-drop')).toBeNull();
+    expect(screen.queryByPlaceholderText(URL_PLACEHOLDER)).not.toBeInTheDocument();
+  });
+
+  it('never falls back to the dropzone for a non-idle no-file step (e.g. stopping)', () => {
+    const { container } = renderIdle({ dubStep: 'stopping', dubJobId: 'job-url-3' });
+    expect(container.querySelector('.dub-idle-drop')).toBeNull();
+    expect(screen.queryByPlaceholderText(URL_PLACEHOLDER)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## The bug

The Dub pipeline stepper could show **Upload ✓ → Prepare ✓ → Transcribe (active)** while the main content pane still rendered the **idle upload dropzone** ("Drop video or audio here" + paste-URL input + "Pull YouTube captions"). Contradictory state: if the pipeline is transcribing, the pane must reflect that stage — not the landing.

## Root cause

`frontend/src/components/dub/IdleSkeleton.jsx`. The main-view branch keys off the non-serialisable local File `dubVideoFile`, which is only set on the drag/drop + file-input path — **never on the URL-ingest path**, and not on a restored job.

- The `dubVideoFile ?` branch correctly renders both the prepare (`PrepOverlay`) and transcribe (`TranscribeOverlay`) overlays via `WaveformTimeline`.
- The **no-file branch** only handled `dubStep === 'uploading'` (`PrepOverlay large`) and otherwise **fell straight through to the idle dropzone**.

So a URL-ingested job in `dubStep === 'transcribing'` (no File) rendered the dropzone — the exact desync in the user's screenshot.

## Is it a #818 regression?

**No.** The no-file branch never handled `transcribing`; it was identical before #818 (verified against `9d79bb8`). A pre-existing gap that only bites the **URL-ingest / restored-job** paths (the file-upload path was always fine because it sets `dubVideoFile`).

## The fix (whole class, recurrence-proof)

- Add a `dubStep === 'transcribing'` case to the no-file path that renders `TranscribeOverlay`, symmetric to the existing `uploading` → `PrepOverlay` case. Covers URL-ingest **and** restored/resumed jobs lacking a local File.
- Gate the idle dropzone on `dubStep === 'idle'` so it renders **only** when genuinely idle; any other non-idle no-file step (e.g. `stopping`) shows a neutral working indicator instead of falling back to the dropzone. This makes it structurally impossible to show the dropzone during an active pipeline.

All existing behavior/handlers preserved (the idle-after-failure banner + retry still show, since failure sets `dubStep` back to `'idle'`).

## Regression test

`frontend/src/test/DubIdleSkeleton.test.jsx` — asserts the dropzone renders only when truly idle, is hidden (and the transcribe overlay shown) while transcribing a URL-ingested job, is hidden while preparing, and never falls back to the dropzone for a non-idle no-file step. **Fails before / passes after** (2 of 4 fail on the unpatched component).

## Verification

- Live (Playwright, real backend :3900, URL-ingest transcribe stage driven with no local File):
  - **before:** `transcribingHasDrop=1, overlay=0` (dropzone shown during transcribe — the bug)
  - **after:** `transcribingHasDrop=0, overlay=1` (transcribe progress shown); idle still shows the dropzone; reset returns to idle.
- Gates: `vite build` ✓ · `oxlint` 0 errors ✓ · `oxfmt --check .` clean ✓ · `vitest run` 645 pass (641 + 4 new) ✓ · `test:visual` 48 pass ✓ · `bun install --frozen-lockfile` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed a Dub pipeline UI desync in `IdleSkeleton` so no-file jobs no longer fall back to the idle dropzone during active stages.

Before:
```
[ stepper: Upload ✓ → Prepare ✓ → Transcribe (active) ]
[ main pane: idle upload dropzone ]
```

After:
```
[ stepper: Upload ✓ → Prepare ✓ → Transcribe (active) ]
[ main pane: transcribe overlay / loading spinner ]
```

```mermaid
flowchart TD
  A[No local dubVideoFile] --> B{dubStep}
  B -->|idle| C[Show idle dropzone]
  B -->|uploading| D[Show upload / prep UI]
  B -->|transcribing| E[Show TranscribeOverlay]
  B -->|any other non-idle step| F[Show centered loading spinner]
```

Updated `frontend/src/components/dub/IdleSkeleton.jsx` to:
- explicitly render `TranscribeOverlay` for `dubStep === 'transcribing'` when no file is present
- keep the idle dropzone visible only for `dubStep === 'idle'`
- show a neutral loading spinner for other non-idle no-file states

Added regression coverage in `frontend/src/test/DubIdleSkeleton.test.jsx` to verify:
- idle still shows the dropzone
- transcribing hides the dropzone and shows the transcribing view
- preparing also hides the dropzone
- other non-idle no-file steps never revert to idle UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->