### PR TITLE
fix(settings): convert un-migrated panel controls to design-system primitives

### DIFF
--- a/frontend/src/components/settings/HFMirrorPanel.jsx
+++ b/frontend/src/components/settings/HFMirrorPanel.jsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Globe } from 'lucide-react';
 import { apiJson, apiFetch } from '../../api/client';
 import { SettingsSection, SettingRow, SettingsInput } from './primitives';
+import { Button } from '../../ui';
 import RestartBadge from './RestartBadge';
 
 export default function HFMirrorPanel() {
@@ -77,17 +78,17 @@ export default function HFMirrorPanel() {
         title="Mirror preset"
         hint="On a restricted network, route model downloads through a mirror. Applies after a restart. Leave empty for the official endpoint."
         control={
-          <div className="perfpanel__row" style={{ flexWrap: 'wrap', gap: 6 }}>
+          <div className="flex flex-wrap items-center gap-[6px] min-w-0 max-w-full">
             {state.presets.map((p) => (
-              <button
+              <Button
+                variant="preset"
                 key={p.label}
-                type="button"
                 onClick={() => save(p.url)}
                 disabled={saving}
                 data-testid={`hf-preset-${p.url || 'official'}`}
               >
                 {p.label}
-              </button>
+              </Button>
             ))}
           </div>
         }
@@ -107,14 +108,16 @@ export default function HFMirrorPanel() {
               placeholder="https://hf-mirror.com"
               data-testid="hf-mirror-url"
             />
-            <button
-              type="button"
+            <Button
+              variant="subtle"
+              size="sm"
               onClick={() => save(url)}
+              loading={saving}
               disabled={saving}
               data-testid="hf-mirror-save"
             >
-              {saving ? 'Saving…' : 'Save'}
-            </button>
+              Save
+            </Button>
           </>
         }
       />

--- a/frontend/src/components/settings/LLMEndpointPanel.jsx
+++ b/frontend/src/components/settings/LLMEndpointPanel.jsx
@@ -13,9 +13,10 @@
  *     TRANSLATE_* env vars, restored on restart.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { Brain, CheckCircle2, XCircle } from 'lucide-react';
+import { Brain } from 'lucide-react';
 import { apiJson, apiFetch } from '../../api/client';
-import { SettingsSection, SettingRow } from './primitives';
+import { SettingsSection, SettingRow, SettingsInput } from './primitives';
+import { Button, Badge } from '../../ui';
 
 const PRESETS = [
   ['Ollama', 'http://localhost:11434/v1', 'llama3.1'],
@@ -87,16 +88,16 @@ export default function LLMEndpointPanel() {
         title="Preset"
         hint="Powers cinematic translation, glossary auto-extract, and dictation refinement. Any OpenAI-compatible server: Ollama, LM Studio, vLLM, or a hosted API. Stays opt-in — features only call it when you enable them."
         control={
-          <div className="perfpanel__row" style={{ flexWrap: 'wrap', gap: 6 }}>
+          <div className="flex flex-wrap items-center gap-[6px] min-w-0 max-w-full">
             {PRESETS.map((p) => (
-              <button
-                type="button"
+              <Button
+                variant="preset"
                 key={p[0]}
                 onClick={() => applyPreset(p)}
                 data-testid={`llm-preset-${p[0]}`}
               >
                 {p[0]}
-              </button>
+              </Button>
             ))}
           </div>
         }
@@ -105,12 +106,12 @@ export default function LLMEndpointPanel() {
       <SettingRow
         title="Base URL"
         control={
-          <input
+          <SettingsInput
+            mono
             type="text"
             value={baseUrl}
             onChange={(e) => setBaseUrl(e.target.value)}
             placeholder="http://localhost:11434/v1"
-            style={{ flex: 1, minWidth: 200 }}
             data-testid="llm-base-url"
           />
         }
@@ -118,12 +119,12 @@ export default function LLMEndpointPanel() {
       <SettingRow
         title="Model"
         control={
-          <input
+          <SettingsInput
+            mono
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}
             placeholder="llama3.1"
-            style={{ flex: 1, minWidth: 200 }}
             data-testid="llm-model"
           />
         }
@@ -131,7 +132,8 @@ export default function LLMEndpointPanel() {
       <SettingRow
         title="API key"
         control={
-          <input
+          <SettingsInput
+            mono
             type="password"
             value={apiKey}
             onChange={(e) => setApiKey(e.target.value)}
@@ -140,7 +142,6 @@ export default function LLMEndpointPanel() {
                 ? `stored (${state.api_key_masked}) — type to replace`
                 : 'optional (Ollama needs none)'
             }
-            style={{ flex: 1, minWidth: 200 }}
             data-testid="llm-api-key"
           />
         }
@@ -156,20 +157,19 @@ export default function LLMEndpointPanel() {
         title="Connection"
         control={
           <>
-            <button type="button" onClick={onSave} disabled={saving} data-testid="llm-save">
-              {saving ? 'Saving…' : 'Save'}
-            </button>
-            <span className="perfpanel__badge" role="status">
-              {state.available ? (
-                <>
-                  <CheckCircle2 size={11} /> reachable
-                </>
-              ) : (
-                <>
-                  <XCircle size={11} /> {state.reason || 'not configured'}
-                </>
-              )}
-            </span>
+            <Button
+              variant="subtle"
+              size="sm"
+              onClick={onSave}
+              loading={saving}
+              disabled={saving}
+              data-testid="llm-save"
+            >
+              Save
+            </Button>
+            <Badge tone={state.available ? 'success' : 'warn'} dot role="status">
+              {state.available ? 'reachable' : state.reason || 'not configured'}
+            </Badge>
           </>
         }
       />

--- a/frontend/src/components/settings/MCPBindingsPanel.jsx
+++ b/frontend/src/components/settings/MCPBindingsPanel.jsx
@@ -14,7 +14,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Bot, Trash2 } from 'lucide-react';
 import { apiJson, apiFetch } from '../../api/client';
 import { listProfiles } from '../../api/profiles';
-import { SettingsSection, SettingRow } from './primitives';
+import { SettingsSection, SettingRow, SettingsInput } from './primitives';
+import { Button, Badge, Select } from '../../ui';
 
 export default function MCPBindingsPanel() {
   const [bindings, setBindings] = useState([]);
@@ -90,15 +91,16 @@ export default function MCPBindingsPanel() {
           }
           control={
             <>
-              <span className="perfpanel__badge">{profileName(b.profile_id)}</span>
-              <button
-                type="button"
+              <Badge tone="neutral">{profileName(b.profile_id)}</Badge>
+              <Button
+                variant="danger"
+                size="sm"
                 onClick={() => onDelete(b.client_id)}
                 aria-label={`Remove ${b.client_id}`}
                 data-testid={`mcp-del-${b.client_id}`}
               >
                 <Trash2 size={12} />
-              </button>
+              </Button>
             </>
           }
         />
@@ -108,15 +110,15 @@ export default function MCPBindingsPanel() {
         title="Add binding"
         control={
           <>
-            <input
+            <SettingsInput
               type="text"
               value={clientId}
               onChange={(e) => setClientId(e.target.value)}
               placeholder="client id (e.g. claude-code)"
-              style={{ flex: 1, minWidth: 160 }}
               data-testid="mcp-client-id"
             />
-            <select
+            <Select
+              size="sm"
               value={profileId}
               onChange={(e) => setProfileId(e.target.value)}
               data-testid="mcp-profile"
@@ -127,10 +129,10 @@ export default function MCPBindingsPanel() {
                   {p.name}
                 </option>
               ))}
-            </select>
-            <button type="button" onClick={onAdd} data-testid="mcp-add">
+            </Select>
+            <Button variant="subtle" size="sm" onClick={onAdd} data-testid="mcp-add">
               Bind
-            </button>
+            </Button>
           </>
         }
       />

--- a/frontend/src/components/settings/PronunciationPanel.jsx
+++ b/frontend/src/components/settings/PronunciationPanel.jsx
@@ -20,7 +20,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { BookA, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { apiJson, apiFetch } from '../../api/client';
-import { SettingsSection, SettingRow } from './primitives';
+import { SettingsSection, SettingRow, SettingsInput, SettingsToggle } from './primitives';
+import { Button, Badge, Select } from '../../ui';
 
 const TYPES = ['respelling', 'ipa', 'cmu'];
 
@@ -143,23 +144,23 @@ export default function PronunciationPanel() {
           }
           control={
             <>
-              <input
-                type="checkbox"
+              <SettingsToggle
                 checked={!!e.enabled}
                 onChange={() => onToggle(e)}
                 aria-label={t('pronunciation.enabled')}
                 data-testid={`pron-toggle-${e.id}`}
               />
-              <span className="perfpanel__badge">{typeLabel(e.type)}</span>
-              <span className="perfpanel__badge">{scopeLabel(e.scope || e.language)}</span>
-              <button
-                type="button"
+              <Badge tone="neutral">{typeLabel(e.type)}</Badge>
+              <Badge tone="neutral">{scopeLabel(e.scope || e.language)}</Badge>
+              <Button
+                variant="danger"
+                size="sm"
                 onClick={() => onDelete(e.id)}
                 aria-label={t('pronunciation.remove', { term: e.term })}
                 data-testid={`pron-del-${e.id}`}
               >
                 <Trash2 size={12} />
-              </button>
+              </Button>
             </>
           }
         />
@@ -169,24 +170,25 @@ export default function PronunciationPanel() {
         title={t('pronunciation.add')}
         align="start"
         control={
-          <div className="perfpanel__row" style={{ flexWrap: 'wrap', gap: 6 }}>
-            <input
+          <div className="flex flex-wrap items-center gap-[6px] min-w-0 max-w-full">
+            <SettingsInput
               type="text"
               value={term}
               onChange={(ev) => setTerm(ev.target.value)}
               placeholder={t('pronunciation.term_placeholder')}
-              style={{ flex: 1, minWidth: 120 }}
+              className="flex-[1_1_120px]"
               data-testid="pron-term"
             />
-            <input
+            <SettingsInput
               type="text"
               value={replacement}
               onChange={(ev) => setReplacement(ev.target.value)}
               placeholder={t('pronunciation.replacement_placeholder')}
-              style={{ flex: 1, minWidth: 120 }}
+              className="flex-[1_1_120px]"
               data-testid="pron-replacement"
             />
-            <select
+            <Select
+              size="sm"
               value={type}
               onChange={(ev) => setType(ev.target.value)}
               data-testid="pron-type"
@@ -196,18 +198,18 @@ export default function PronunciationPanel() {
                   {typeLabel(ty)}
                 </option>
               ))}
-            </select>
-            <input
+            </Select>
+            <SettingsInput
               type="text"
               value={language}
               onChange={(ev) => setLanguage(ev.target.value)}
               placeholder={t('pronunciation.lang_label')}
-              style={{ width: 90 }}
+              className="w-[90px] flex-none"
               data-testid="pron-language"
             />
-            <button type="button" onClick={onAdd} data-testid="pron-add">
+            <Button variant="subtle" size="sm" onClick={onAdd} data-testid="pron-add">
               {t('pronunciation.add')}
-            </button>
+            </Button>
           </div>
         }
       />
@@ -215,12 +217,11 @@ export default function PronunciationPanel() {
       <SettingRow
         title={t('pronunciation.test_placeholder')}
         control={
-          <input
+          <SettingsInput
             type="text"
             value={testText}
             onChange={(ev) => onTest(ev.target.value)}
             placeholder={t('pronunciation.test_placeholder')}
-            style={{ flex: 1, minWidth: 200 }}
             data-testid="pron-test-input"
           />
         }

--- a/frontend/src/components/settings/RemoteBackendPanel.jsx
+++ b/frontend/src/components/settings/RemoteBackendPanel.jsx
@@ -14,6 +14,7 @@ import React, { useState } from 'react';
 import { Server } from 'lucide-react';
 import { LS_BACKEND_URL, LS_API_KEY, API } from '../../api/client';
 import { SettingsSection, SettingRow, InfoHint, SettingsInput } from './primitives';
+import { Button, Badge } from '../../ui';
 import RestartBadge from './RestartBadge';
 
 const REMOTE_GPU_DOCS_URL =
@@ -97,17 +98,24 @@ export default function RemoteBackendPanel() {
         }
       />
 
-      <div className="perfpanel__row">
-        <button type="button" onClick={onTest} disabled={testing} data-testid="remote-backend-test">
-          {testing ? 'Testing…' : 'Test connection'}
-        </button>
-        <button type="button" onClick={onSave} data-testid="remote-backend-save">
+      <div className="flex flex-wrap items-center gap-[var(--space-3)] min-w-0 max-w-full">
+        <Button
+          variant="subtle"
+          size="sm"
+          onClick={onTest}
+          loading={testing}
+          disabled={testing}
+          data-testid="remote-backend-test"
+        >
+          Test connection
+        </Button>
+        <Button variant="subtle" size="sm" onClick={onSave} data-testid="remote-backend-save">
           Save &amp; reload
-        </button>
+        </Button>
         {probe && (
-          <span className="perfpanel__badge" role="status">
+          <Badge tone={probe.ok ? 'success' : 'danger'} dot role="status">
             {probe.ok ? `OK — ${probe.detail}` : `Failed — ${probe.detail}`}
-          </span>
+          </Badge>
         )}
       </div>
     </SettingsSection>


### PR DESCRIPTION
## What & why

Several Settings panels were re-hosted in the redesign without converting their raw `<input>`/`<select>`/`<button>` to the design system, so they rendered as **native UA controls** (white input fields, light-gray buttons, system fonts) that ignored the theme tokens — jarring on the dark chrome. This fixes the whole class: every native control in the affected panels now uses the shared primitives, so all of Settings themes coherently in every palette.

## Panels fixed (controls converted)

- **LLMEndpointPanel** — Ollama/LM Studio/vLLM/OpenAI **preset chips** → `Button` (preset); **Base URL / Model / API key** → `SettingsInput` (mono); **Save** → `Button` (subtle/sm, loading); **reachable / not-configured status** → `Badge` (success/warn, dot).
- **HFMirrorPanel** — **mirror preset chips** → `Button` (preset); **Save** → `Button` (subtle/sm, loading). (`HF_ENDPOINT` was already `SettingsInput`.)
- **PronunciationPanel** — **add-entry term/replacement/language + test** inputs → `SettingsInput`; **type selector** → `Select`; **per-row enable checkbox** → `SettingsToggle`; **type/scope pills** → `Badge`; **Add** + **per-row delete** → `Button` (subtle/sm, danger/sm).
- **RemoteBackendPanel** — **Test connection** + **Save & reload** → `Button` (subtle/sm, loading); **probe result** → `Badge` (success/danger, dot). (URL/key inputs were already `SettingsInput`.)
- **MCPBindingsPanel** — **client-id** input → `SettingsInput`; **voice select** → `Select`; **Bind** → `Button` (subtle/sm); **per-binding profile pill** → `Badge`; **delete** → `Button` (danger/sm).

## perfpanel

Dropped the `perfpanel__row` / `perfpanel__badge` / `perfpanel__checkbox` class usages from these panels (replaced by primitives + token flex utilities). The `perfpanel` CSS block lives in `src/index.css` (owned by an in-flight theme-cascade change), so it was **left in place** to avoid a conflict; the remaining `perfpanel__error` / `perfpanel__help` references are token-based **themed banners**, not native controls, so they were left as-is.

## Preserved

All behavior, handlers, state, endpoints, and `data-testid`s are unchanged. No new user-facing strings (styling-only), so no i18n changes.

## Gates

- `vite build` ✓
- `oxlint` — 0 on touched files (pre-existing warnings elsewhere only) ✓
- `oxfmt --check .` clean ✓
- `vitest run` — 645 pass (incl. PronunciationPanel) ✓
- `test:visual` — 48 snapshots unchanged (touched panels aren't in the manifest) ✓
- `bun install --frozen-lockfile` clean ✓
- **Live eyeball** across Translation (LLM endpoint), Models (HF mirror), Pronunciation, Sharing (Remote backend + MCP bindings), Dictation in **default + catppuccin** — no white fields, no native gray buttons; every control tracks the theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated several Settings panels to use shared design-system primitives instead of native form controls, so the UI now matches theme tokens consistently across palettes.

Before
```
[panel]
  <input> <select> <button>
  <span class="perfpanel__badge">
  <span class="perfpanel__row">
```

After
```
[panel]
  [SettingsInput] [Select] [Button] [Badge] [SettingsToggle]
  [flex/token-based layout]
```

### What changed
- Replaced raw `<button>`, `<input>`, `<select>`, checkbox, and badge markup with `Button`, `Badge`, `Select`, `SettingsInput`, and `SettingsToggle`
- Kept existing handlers, endpoints, state flow, and `data-testid`s intact
- Preserved existing save/test/bind/delete behavior and loading states
- Removed panel-local `perfpanel__row`, `perfpanel__badge`, and `perfpanel__checkbox` usage in favor of primitives and flex utilities

### Panels updated
- `LLMEndpointPanel`
- `HFMirrorPanel`
- `PronunciationPanel`
- `RemoteBackendPanel`
- `MCPBindingsPanel`

### Notable UI changes
- Preset/action controls now use design-system buttons
- Text fields and selectors now use shared settings inputs/selects
- Status/probe indicators now render as themed badges
- Binding/profile labels now use badges instead of raw spans

<!-- end of auto-generated comment: release notes by coderabbit.ai -->