### PR TITLE
feat(dub): consolidate the pipeline stepper + title/meta into one compact header row

### DIFF
--- a/frontend/src/components/dub/DubHeader.jsx
+++ b/frontend/src/components/dub/DubHeader.jsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { Button } from '../../ui';
 import FooterBtn from './FooterBtn';
+import DubPipelineStepper from './DubPipelineStepper';
 import { formatTime } from '../../utils/format';
 
 export default function DubHeader({
@@ -33,7 +34,9 @@ export default function DubHeader({
   setExportOpen,
 }) {
   return (
-    <div className="flex justify-between items-center px-[12px] py-[5px] shrink-0 bg-[rgba(255,255,255,0.015)] [border:1px_solid_rgba(255,255,255,0.04)] rounded-md mb-[2px]">
+    <div className="flex flex-wrap justify-between items-center gap-x-[var(--space-3)] gap-y-[4px] px-[12px] py-[5px] shrink-0 bg-[rgba(255,255,255,0.015)] [border:1px_solid_rgba(255,255,255,0.04)] rounded-md mb-[2px]">
+      {/* Pipeline spine, inlined onto the header row (Upload → … → Export). */}
+      <DubPipelineStepper dubStep={dubStep} inline />
       <div className="label-row dub-head__title">
         <FileText className="label-icon" size={11} />
         <span className="font-semibold text-[0.85rem] overflow-hidden text-ellipsis whitespace-nowrap text-fg">

--- a/frontend/src/components/dub/DubPipelineStepper.jsx
+++ b/frontend/src/components/dub/DubPipelineStepper.jsx
@@ -31,7 +31,7 @@ const DUB_PHASE_BY_STEP = {
   done: 5,
 };
 
-function DubPipelineStepper({ dubStep }) {
+function DubPipelineStepper({ dubStep, inline = false }) {
   const { t } = useTranslation();
   const current = DUB_PHASE_BY_STEP[dubStep] ?? 0;
   const busy =
@@ -41,7 +41,7 @@ function DubPipelineStepper({ dubStep }) {
     dubStep === 'stopping';
   return (
     <div
-      className="dub-stepper"
+      className={inline ? 'dub-stepper dub-stepper--inline' : 'dub-stepper'}
       role="list"
       aria-label={t('dub.pipeline', { defaultValue: 'Dubbing pipeline' })}
     >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3402,6 +3402,19 @@ body:has(.capture-pill) {
 .dub-stepper__spin { animation: dub-stepper-spin 1s linear infinite; }
 @keyframes dub-stepper-spin { to { transform: rotate(360deg); } }
 
+/* ── Inline variant — sits on the DubHeader row alongside title + actions ── */
+.dub-stepper--inline {
+  padding: 0;
+  border-bottom: none;
+  justify-content: flex-start;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+.dub-stepper--inline .dub-stepper__step:not(:first-child)::before {
+  width: 14px;
+  margin: 0 5px;
+}
+
 /* ── Idle / drop-zone ─────────────────────────────────────────────────── */
 .dub-idle-drop {
   flex: 1;

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -423,8 +423,14 @@ export default function DubTab(props) {
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Pipeline spine — shown once a file/job is in play so the user always
-          knows which stage they're at (Upload → … → Export). */}
-      {(dubVideoFile || dubJobId || dubStep !== 'idle') && <DubPipelineStepper dubStep={dubStep} />}
+          knows which stage they're at (Upload → … → Export). In the editor view
+          it's inlined onto the DubHeader row (see below), so only render the
+          standalone spine before the editor exists. */}
+      {(dubVideoFile || dubJobId || dubStep !== 'idle') &&
+        !(
+          dubJobId &&
+          (dubStep === 'editing' || dubStep === 'generating' || dubStep === 'done')
+        ) && <DubPipelineStepper dubStep={dubStep} />}
       {/* ── Idle: show full editor skeleton with drop zone ── */}
       {showIdleSkeleton && (
         <IdleSkeleton


### PR DESCRIPTION
Merges the two stacked header rows in the Dub editor into **one compact row** to reclaim vertical space.

**Before:** two rows — a centered 6-step pipeline spine (`Upload → Prepare → Transcribe → Edit → Generate → Export`) on top, then a separate row with the title · duration · segment-count + action buttons.

**After:** one row — `[stepper] … [title · duration · N segs] … [Save · Reset | Generate Dub · QC · Export]`, vertically centered, wrapping gracefully on narrow widths.

## What changed (4 files)
- `DubPipelineStepper.jsx` — new `inline` prop that swaps to a slimmer `dub-stepper--inline` variant (tighter connectors). Step active/done/spinning state logic untouched.
- `DubHeader.jsx` — renders the stepper inline as the leftmost element; container switched to `flex flex-wrap justify-between` so it wraps instead of overflowing. Title/meta + all buttons unchanged.
- `DubTab.jsx` — the standalone stepper now renders only when the editor view is **not** active, so it isn't duplicated (the stepper still shows during idle/uploading/transcribing).
- `index.css` — `.dub-stepper--inline` rules (drops the standalone border/padding, tighter layout).

## Behavior preserved
Pure layout consolidation — the `dubStep`-driven step styling, the title/duration/segment-count bindings, and every button's `onClick`/`disabled`/loading props carry over verbatim.

## Narrow widths
The header container is `flex-wrap`: on narrow windows the action-button cluster wraps to a second line rather than squeezing the title (which still truncates). Inline stepper uses tighter connectors to buy horizontal room first.

## Verification
- `bun run build` ✓ · `format:check` ✓ (oxfmt) · eslint on changed files clean (pre-existing DubTab effect warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Compact the Dub editor header into a single inline row.

Before:
```text
[ Stepper row: Upload → Prepare → Transcribe → Edit → Generate → Export ]
[ Title | Duration | Segments | Save | Reset | Generate Dub | QC | Export ]
```

After:
```text
[ Stepper | Title | Duration | Segments | Save | Reset | Generate Dub | QC | Export ]
```

```mermaid
flowchart TD
  A[DubTab renders editor state] --> B{Active editor state?}
  B -- no --> C[Render standalone DubPipelineStepper]
  B -- yes --> D[Hide standalone stepper]
  D --> E[DubHeader renders inline DubPipelineStepper]
  E --> F[Header wraps gracefully on narrow widths]
```

- Added an `inline` variant to `DubPipelineStepper` for the slimmer header presentation.
- Updated `DubHeader` to render the stepper inline and use a flex-wrap layout.
- Narrowed `DubTab` so the standalone stepper is not duplicated while the editor is active.
- Added inline stepper CSS with tighter spacing and no extra border/padding.

Step state logic, metadata bindings, and button behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->