### PR TITLE
feat(ui): remove all decorative borders/dividers app-wide (keep focus rings)

### DIFF
--- a/frontend/src/components/AudioTrimmer.jsx
+++ b/frontend/src/components/AudioTrimmer.jsx
@@ -767,14 +767,14 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
         {/* Ruler */}
         <canvas
           ref={rulerRef}
-          className="w-full h-[18px] bg-[#141414] rounded-md border-b border-solid border-b-[rgba(255,255,255,0.05)]"
+          className="w-full h-[18px] bg-[#141414] rounded-md border-b border-solid border-b-transparent"
         />
 
         {/* Waveform */}
         <canvas
           ref={waveRef}
           onMouseDown={onCanvasDown}
-          className="w-full h-[160px] bg-[#0f1112] rounded-lg border border-solid border-[rgba(255,255,255,0.05)] cursor-crosshair touch-none"
+          className="w-full h-[160px] bg-[#0f1112] rounded-lg border border-solid border-transparent cursor-crosshair touch-none"
         />
 
         {/* Numeric fields */}

--- a/frontend/src/components/DemoPresetGrid.jsx
+++ b/frontend/src/components/DemoPresetGrid.jsx
@@ -87,7 +87,7 @@ export default function DemoPresetGrid({ presets, onUse }) {
         return (
           <div
             key={p.id}
-            className="flex flex-col gap-[6px] p-[12px] rounded-xl border border-border bg-[rgba(255,255,255,0.02)] [transition:border-color_120ms_ease,background_120ms_ease] hover:border-[rgba(243,165,182,0.35)] hover:bg-[rgba(255,255,255,0.04)]"
+            className="flex flex-col gap-[6px] p-[12px] rounded-xl border border-border bg-[rgba(255,255,255,0.02)] [transition:border-color_120ms_ease,background_120ms_ease] hover:border-transparent hover:bg-[rgba(255,255,255,0.04)]"
           >
             <div className="inline-flex items-center gap-[6px]">
               <span className="text-[16px] leading-none" aria-hidden>
@@ -102,7 +102,7 @@ export default function DemoPresetGrid({ presets, onUse }) {
             <div className="flex gap-[6px] mt-auto pt-[4px]">
               <button
                 type="button"
-                className="demo-preset-card__preview flex-1 inline-flex items-center justify-center gap-[4px] px-[8px] py-[5px] text-[11px] font-semibold rounded-lg border border-border bg-transparent text-fg cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease] hover:bg-[rgba(255,255,255,0.05)] hover:border-[rgba(255,255,255,0.2)]"
+                className="demo-preset-card__preview flex-1 inline-flex items-center justify-center gap-[4px] px-[8px] py-[5px] text-[11px] font-semibold rounded-lg border border-border bg-transparent text-fg cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease] hover:bg-[rgba(255,255,255,0.05)] hover:border-transparent"
                 onClick={() => handlePreview(p)}
                 aria-label={isPlaying ? `Pause ${p.name}` : `Preview ${p.name}`}
                 aria-pressed={isPlaying}
@@ -112,7 +112,7 @@ export default function DemoPresetGrid({ presets, onUse }) {
               </button>
               <button
                 type="button"
-                className="flex-1 inline-flex items-center justify-center gap-[4px] px-[8px] py-[5px] text-[11px] font-semibold rounded-lg border border-[rgba(243,165,182,0.3)] bg-[rgba(243,165,182,0.12)] text-fg cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease] hover:border-[rgba(255,255,255,0.2)] hover:bg-[rgba(243,165,182,0.22)]"
+                className="flex-1 inline-flex items-center justify-center gap-[4px] px-[8px] py-[5px] text-[11px] font-semibold rounded-lg border border-transparent bg-[rgba(243,165,182,0.12)] text-fg cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease] hover:border-transparent hover:bg-[rgba(243,165,182,0.22)]"
                 onClick={() => onUse(p)}
                 aria-label={`Use ${p.name} design`}
               >

--- a/frontend/src/components/DictationDemo.jsx
+++ b/frontend/src/components/DictationDemo.jsx
@@ -192,7 +192,7 @@ export default function DictationDemo({ embedded = false }) {
       case 'verified':
         return (
           <span
-            className={`${STATUS_BASE} border-[rgba(152,151,26,0.35)] bg-[rgba(152,151,26,0.12)] text-[#b8bb26]`}
+            className={`${STATUS_BASE} border-transparent bg-[rgba(152,151,26,0.12)] text-[#b8bb26]`}
           >
             <CheckCircle2 size={12} /> {t('demo.dictation_status_ok')}
           </span>
@@ -200,7 +200,7 @@ export default function DictationDemo({ embedded = false }) {
       case 'registered':
         return (
           <span
-            className={`${STATUS_BASE} border-[rgba(215,153,33,0.30)] bg-[rgba(215,153,33,0.10)] text-[#fabd2f]`}
+            className={`${STATUS_BASE} border-transparent bg-[rgba(215,153,33,0.10)] text-[#fabd2f]`}
           >
             <Keyboard size={12} /> {t('demo.dictation_status_pending')}{' '}
             <code className="font-mono text-[10px] px-[4px] py-[1px] bg-[rgba(0,0,0,0.3)] rounded-[3px]">
@@ -211,7 +211,7 @@ export default function DictationDemo({ embedded = false }) {
       default:
         return (
           <span
-            className={`${STATUS_BASE} border-[rgba(204,36,29,0.30)] bg-[rgba(204,36,29,0.10)] text-[#fb4934]`}
+            className={`${STATUS_BASE} border-transparent bg-[rgba(204,36,29,0.10)] text-[#fb4934]`}
           >
             <AlertTriangle size={12} /> {t('demo.dictation_status_warn')}
           </span>
@@ -270,7 +270,7 @@ export default function DictationDemo({ embedded = false }) {
                     {t(s.labelKey)}
                   </span>
                 </div>
-                <blockquote className="m-0 px-[8px] py-[6px] text-[11.5px] leading-[1.45] border-l-2 border-l-[rgba(243,165,182,0.4)] bg-[rgba(255,255,255,0.02)] text-fg italic">
+                <blockquote className="m-0 px-[8px] py-[6px] text-[11.5px] leading-[1.45] border-l-2 border-l-transparent bg-[rgba(255,255,255,0.02)] text-fg italic">
                   {s.text}
                 </blockquote>
                 <div className="flex gap-[6px] mt-[2px]">
@@ -301,12 +301,12 @@ export default function DictationDemo({ embedded = false }) {
                   </Button>
                 </div>
                 {tx.state === 'ok' && (
-                  <div className="flex items-start gap-[6px] text-[11px] px-[8px] py-[6px] rounded-lg leading-[1.4] text-[#b8bb26] bg-[rgba(152,151,26,0.08)] border border-[rgba(152,151,26,0.25)]">
+                  <div className="flex items-start gap-[6px] text-[11px] px-[8px] py-[6px] rounded-lg leading-[1.4] text-[#b8bb26] bg-[rgba(152,151,26,0.08)] border border-transparent">
                     <CheckCircle2 size={11} /> <em className="not-italic">{tx.text}</em>
                   </div>
                 )}
                 {tx.state === 'fail' && (
-                  <div className="flex items-start gap-[6px] text-[11px] px-[8px] py-[6px] rounded-lg leading-[1.4] text-[#fb4934] bg-[rgba(204,36,29,0.08)] border border-[rgba(204,36,29,0.25)]">
+                  <div className="flex items-start gap-[6px] text-[11px] px-[8px] py-[6px] rounded-lg leading-[1.4] text-[#fb4934] bg-[rgba(204,36,29,0.08)] border border-transparent">
                     <AlertTriangle size={11} /> {tx.error}
                   </div>
                 )}

--- a/frontend/src/components/DubSegmentRow.jsx
+++ b/frontend/src/components/DubSegmentRow.jsx
@@ -325,9 +325,9 @@ function DubSegmentRow({
           }
           style={
             overBudget
-              ? { borderColor: 'rgba(250,189,47,0.6)', background: 'rgba(250,189,47,0.06)' }
+              ? { background: 'rgba(250,189,47,0.10)' }
               : seg.translate_error
-                ? { borderColor: 'rgba(251,73,52,0.5)' }
+                ? { background: 'rgba(251,73,52,0.10)' }
                 : undefined
           }
         />

--- a/frontend/src/components/DubbingDemo.jsx
+++ b/frontend/src/components/DubbingDemo.jsx
@@ -186,7 +186,7 @@ export default function DubbingDemo({ onDismiss }) {
           <button
             key={d.code}
             type="button"
-            className={`text-[11px] px-[10px] py-[3px] rounded-[999px] border border-border bg-transparent text-fg-muted cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease,color_100ms_ease] hover:bg-[rgba(255,255,255,0.04)] hover:text-fg ${pickedCode === d.code ? 'bg-[rgba(243,165,182,0.18)] border-[rgba(243,165,182,0.45)] text-[#fff9ef]' : ''}`}
+            className={`text-[11px] px-[10px] py-[3px] rounded-[999px] border border-border bg-transparent text-fg-muted cursor-pointer [transition:background_100ms_ease,border-color_100ms_ease,color_100ms_ease] hover:bg-[rgba(255,255,255,0.04)] hover:text-fg ${pickedCode === d.code ? 'bg-[rgba(243,165,182,0.18)] border-transparent text-[#fff9ef]' : ''}`}
             onClick={() => setPickedCode(d.code)}
           >
             {d.label}
@@ -197,7 +197,7 @@ export default function DubbingDemo({ onDismiss }) {
       {onDismiss && (
         <button
           type="button"
-          className="self-end inline-flex items-center gap-[6px] px-[12px] py-[6px] text-[11px] font-semibold rounded-lg border border-[rgba(243,165,182,0.4)] bg-[rgba(243,165,182,0.12)] text-fg cursor-pointer hover:bg-[rgba(243,165,182,0.22)]"
+          className="self-end inline-flex items-center gap-[6px] px-[12px] py-[6px] text-[11px] font-semibold rounded-lg border border-transparent bg-[rgba(243,165,182,0.12)] text-fg cursor-pointer hover:bg-[rgba(243,165,182,0.22)]"
           onClick={onDismiss}
         >
           <Play size={12} /> {t('demo.dubbing_cta')}

--- a/frontend/src/components/FirstRunSetup.jsx
+++ b/frontend/src/components/FirstRunSetup.jsx
@@ -211,7 +211,9 @@ function OptionCard({ active, disabled, onSelect, name, desc, badge }) {
       className={cn(
         'flex flex-col gap-1 rounded-md border px-3 py-2.5 text-left transition-colors',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        active ? 'border-primary bg-primary/10' : 'border-border bg-bg-elev-2 hover:bg-bg-elev-1',
+        active
+          ? 'border-transparent bg-primary/10'
+          : 'border-border bg-bg-elev-2 hover:bg-bg-elev-1',
         disabled && 'cursor-not-allowed opacity-40 hover:bg-bg-elev-2',
       )}
     >

--- a/frontend/src/components/GlossaryPanel.jsx
+++ b/frontend/src/components/GlossaryPanel.jsx
@@ -189,7 +189,7 @@ export default function GlossaryPanel({
           </div>
         ) : (
           <>
-            <table className="w-full border-collapse text-[length:var(--text-sm)] [&_td]:border-b [&_td]:border-b-white/[0.04] [&_td]:px-[6px] [&_td]:py-[3px] [&_td]:text-left [&_td]:align-middle [&_th]:border-b [&_th]:border-b-[var(--color-border)] [&_th]:px-[6px] [&_th]:py-[3px] [&_th]:text-left [&_th]:align-middle [&_th]:text-[length:var(--text-xs)] [&_th]:font-semibold [&_th]:uppercase [&_th]:tracking-[0.04em] [&_th]:text-[var(--color-fg-subtle)]">
+            <table className="w-full border-collapse text-[length:var(--text-sm)] [&_td]:border-b [&_td]:border-b-transparent [&_td]:px-[6px] [&_td]:py-[3px] [&_td]:text-left [&_td]:align-middle [&_th]:border-b [&_th]:border-b-[var(--color-border)] [&_th]:px-[6px] [&_th]:py-[3px] [&_th]:text-left [&_th]:align-middle [&_th]:text-[length:var(--text-xs)] [&_th]:font-semibold [&_th]:uppercase [&_th]:tracking-[0.04em] [&_th]:text-[var(--color-fg-subtle)]">
               <thead>
                 <tr>
                   <th>{t('glossary.source')}</th>

--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -42,7 +42,7 @@ export default function HfTokenCard({ className = '' }) {
     return (
       <div
         className={cn(
-          'flex flex-wrap items-center gap-2 rounded-md border border-success/45 bg-success/[0.09] px-3 py-2 text-sm',
+          'flex flex-wrap items-center gap-2 rounded-md border border-transparent bg-success/[0.09] px-3 py-2 text-sm',
           className,
         )}
       >
@@ -57,7 +57,7 @@ export default function HfTokenCard({ className = '' }) {
   return (
     <div
       className={cn(
-        'flex flex-wrap items-center gap-2 rounded-md border border-primary/30 bg-primary/[0.07] px-3 py-2 text-sm',
+        'flex flex-wrap items-center gap-2 rounded-md border border-transparent bg-primary/[0.07] px-3 py-2 text-sm',
         className,
       )}
     >

--- a/frontend/src/components/NetworkToggle.jsx
+++ b/frontend/src/components/NetworkToggle.jsx
@@ -80,7 +80,7 @@ export default function NetworkToggle() {
   return (
     <div className="relative inline-flex items-center flex-shrink-0">
       <button
-        className={`inline-flex items-center gap-[5px] py-[2px] px-[8px] h-[20px] rounded-sm font-medium text-[11px] [font-family:inherit] cursor-pointer [transition:all_0.1s] border border-solid disabled:opacity-50 disabled:cursor-not-allowed ${st.enabled ? 'bg-[rgba(184,187,38,0.12)] border-[rgba(184,187,38,0.4)] text-[#b8bb26] hover:bg-[rgba(184,187,38,0.18)]' : 'bg-transparent border-transparent text-[#a89984] hover:bg-[rgba(255,255,255,0.04)] hover:text-fg'}`}
+        className={`inline-flex items-center gap-[5px] py-[2px] px-[8px] h-[20px] rounded-sm font-medium text-[11px] [font-family:inherit] cursor-pointer [transition:all_0.1s] border border-solid disabled:opacity-50 disabled:cursor-not-allowed ${st.enabled ? 'bg-[rgba(184,187,38,0.12)] border-transparent text-[#b8bb26] hover:bg-[rgba(184,187,38,0.18)]' : 'bg-transparent border-transparent text-[#a89984] hover:bg-[rgba(255,255,255,0.04)] hover:text-fg'}`}
         onClick={st.enabled ? () => setOpen((o) => !o) : () => setConfirming((c) => !c)}
         disabled={busy}
         title={st.enabled ? t('network.sharing_on_title') : t('network.share_on_network')}
@@ -92,7 +92,7 @@ export default function NetworkToggle() {
       </button>
 
       {!st.enabled && confirming && (
-        <div className="absolute bottom-[calc(100%+8px)] right-0 z-[60] w-[248px] flex flex-col gap-[8px] p-[12px] bg-[var(--chrome-bg,#1d2021)] border border-solid border-[rgba(184,187,38,0.35)] rounded-[8px] shadow-[0_8px_24px_rgba(0,0,0,0.45)] text-fg">
+        <div className="absolute bottom-[calc(100%+8px)] right-0 z-[60] w-[248px] flex flex-col gap-[8px] p-[12px] bg-[var(--chrome-bg,#1d2021)] border border-solid border-transparent rounded-[8px] shadow-[0_8px_24px_rgba(0,0,0,0.45)] text-fg">
           <div className="text-[11px] font-semibold uppercase [letter-spacing:0.06em] text-[#b8bb26]">
             {t('network.share_confirm_title')}
           </div>
@@ -110,7 +110,7 @@ export default function NetworkToggle() {
             </button>
             <button
               type="button"
-              className="bg-[rgba(184,187,38,0.15)] border border-solid border-[rgba(184,187,38,0.4)] text-[#b8bb26] text-[11px] font-semibold [font-family:inherit] py-[5px] px-[12px] rounded-md cursor-pointer hover:bg-[rgba(184,187,38,0.25)] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-[rgba(184,187,38,0.15)] border border-solid border-transparent text-[#b8bb26] text-[11px] font-semibold [font-family:inherit] py-[5px] px-[12px] rounded-md cursor-pointer hover:bg-[rgba(184,187,38,0.25)] disabled:opacity-50 disabled:cursor-not-allowed"
               onClick={enable}
               disabled={busy}
             >
@@ -121,7 +121,7 @@ export default function NetworkToggle() {
       )}
 
       {st.enabled && open && (
-        <div className="absolute bottom-[calc(100%+8px)] right-0 z-[60] w-[248px] flex flex-col gap-[8px] p-[12px] bg-[var(--chrome-bg,#1d2021)] border border-solid border-[rgba(184,187,38,0.35)] rounded-[8px] shadow-[0_8px_24px_rgba(0,0,0,0.45)] text-fg">
+        <div className="absolute bottom-[calc(100%+8px)] right-0 z-[60] w-[248px] flex flex-col gap-[8px] p-[12px] bg-[var(--chrome-bg,#1d2021)] border border-solid border-transparent rounded-[8px] shadow-[0_8px_24px_rgba(0,0,0,0.45)] text-fg">
           <div className="text-[11px] font-semibold uppercase [letter-spacing:0.06em] text-[#b8bb26]">
             {t('network.shared_title')}
           </div>
@@ -135,7 +135,7 @@ export default function NetworkToggle() {
             return (
               <div
                 key={ip}
-                className="flex flex-col items-center gap-[8px] p-[8px] rounded-lg bg-[rgba(255,255,255,0.03)] border border-solid border-[rgba(255,255,255,0.05)]"
+                className="flex flex-col items-center gap-[8px] p-[8px] rounded-lg bg-[rgba(255,255,255,0.03)] border border-solid border-transparent"
               >
                 <div className="flex items-center justify-between gap-[8px] w-full">
                   <code className="[font-family:var(--chrome-font-mono,var(--font-mono,monospace))] text-[11.5px] text-fg break-all">
@@ -182,7 +182,7 @@ export default function NetworkToggle() {
           </div>
           <button
             type="button"
-            className="bg-[rgba(251,73,52,0.12)] border border-solid border-[rgba(251,73,52,0.35)] text-danger text-[11px] font-semibold [font-family:inherit] py-[5px] px-[10px] rounded-md cursor-pointer [transition:all_0.1s] hover:bg-[rgba(251,73,52,0.2)] disabled:opacity-50 disabled:cursor-not-allowed"
+            className="bg-[rgba(251,73,52,0.12)] border border-solid border-transparent text-danger text-[11px] font-semibold [font-family:inherit] py-[5px] px-[10px] rounded-md cursor-pointer [transition:all_0.1s] hover:bg-[rgba(251,73,52,0.2)] disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={disable}
             disabled={busy}
           >

--- a/frontend/src/components/ReadinessChecklist.jsx
+++ b/frontend/src/components/ReadinessChecklist.jsx
@@ -125,7 +125,7 @@ export default function ReadinessChecklist({ compact = false, showWhenAllPass = 
     const issues = checks.filter((c) => c.status !== 'pass');
     if (issues.length === 0) {
       return (
-        <div className="flex items-center gap-[var(--space-3)] py-[var(--space-3)] px-[var(--space-4)] bg-[rgba(142,192,124,0.08)] border border-solid border-[rgba(142,192,124,0.15)] rounded-md text-success font-medium [font-size:var(--text-sm)]">
+        <div className="flex items-center gap-[var(--space-3)] py-[var(--space-3)] px-[var(--space-4)] bg-[rgba(142,192,124,0.08)] border border-solid border-transparent rounded-md text-success font-medium [font-size:var(--text-sm)]">
           <CheckCircle size={14} />
           {t('readiness.all_ready')}
         </div>

--- a/frontend/src/components/SegmentTrack.jsx
+++ b/frontend/src/components/SegmentTrack.jsx
@@ -555,7 +555,7 @@ export default function SegmentTrack({
                   <span className="inline-flex gap-[2px] mr-[8px] z-[3]">
                     <button
                       type="button"
-                      className="inline-flex items-center justify-center w-[16px] h-[16px] p-0 border border-[rgba(168,153,132,0.4)] rounded-sm bg-[rgba(40,40,40,0.85)] text-[#ebdbb2] cursor-pointer hover:border-[#d3869b] hover:text-[#d3869b]"
+                      className="inline-flex items-center justify-center w-[16px] h-[16px] p-0 border border-transparent rounded-sm bg-[rgba(40,40,40,0.85)] text-[#ebdbb2] cursor-pointer hover:border-transparent hover:text-[#d3869b]"
                       aria-label={t('timeline.play_slot')}
                       title={t('timeline.play_slot')}
                       onPointerDown={(ev) => ev.stopPropagation()}
@@ -569,7 +569,7 @@ export default function SegmentTrack({
                     {onPreviewSegment && (
                       <button
                         type="button"
-                        className="inline-flex items-center justify-center w-[16px] h-[16px] p-0 border border-[rgba(168,153,132,0.4)] rounded-sm bg-[rgba(40,40,40,0.85)] text-[#ebdbb2] cursor-pointer hover:border-[#d3869b] hover:text-[#d3869b]"
+                        className="inline-flex items-center justify-center w-[16px] h-[16px] p-0 border border-transparent rounded-sm bg-[rgba(40,40,40,0.85)] text-[#ebdbb2] cursor-pointer hover:border-transparent hover:text-[#d3869b]"
                         aria-label={t('timeline.preview_dub')}
                         title={t('timeline.preview_dub')}
                         onPointerDown={(ev) => ev.stopPropagation()}

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -395,7 +395,7 @@ export default function Sidebar(props) {
                             <div className="flex items-center justify-between gap-2 min-w-0">
                               <span
                                 className="history-kind"
-                                style={{ color: accent, borderColor: `${accent}40` }}
+                                style={{ color: accent, background: `${accent}22` }}
                               >
                                 <KindIcon size={9} />{' '}
                                 {proj.is_locked
@@ -610,7 +610,7 @@ export default function Sidebar(props) {
                         <div className="flex items-center justify-between gap-2 min-w-0">
                           <span
                             className="history-kind"
-                            style={{ color: accent, borderColor: `${accent}40` }}
+                            style={{ color: accent, background: `${accent}22` }}
                           >
                             <KindIcon size={9} /> {item.mode || 'synth'}
                           </span>
@@ -768,7 +768,7 @@ export default function Sidebar(props) {
                         <div className="flex items-center justify-between gap-2 min-w-0">
                           <span
                             className="history-kind"
-                            style={{ color: accent, borderColor: `${accent}40` }}
+                            style={{ color: accent, background: `${accent}22` }}
                           >
                             <KindIcon size={9} /> {item.mode}
                           </span>

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -64,7 +64,7 @@ import { effectiveProfile, effectiveSpeed, castMember, nextCastColor } from '../
 
 // ── Shared class strings (replacing the old stories-* BEM chrome) ─────────
 const ADD_BTN =
-  'inline-flex items-center gap-[4px] bg-transparent border border-border text-fg [font-size:var(--text-xs)] px-[8px] py-[3px] rounded-sm cursor-pointer hover:border-accent hover:text-accent';
+  'inline-flex items-center gap-[4px] bg-transparent border border-border text-fg [font-size:var(--text-xs)] px-[8px] py-[3px] rounded-sm cursor-pointer hover:text-accent';
 const NAME_INPUT =
   'bg-bg-elev-2 border border-border rounded-sm text-fg [font-size:var(--text-xs)] px-[8px] py-[4px]';
 const SELECT_CHROME =
@@ -1035,9 +1035,7 @@ export default function StoriesEditor({ profiles = [] }) {
                 role="listitem"
                 className={[
                   'group grid [grid-template-columns:32px_1fr_160px_100px_44px] gap-[8px] items-center px-[10px] py-[8px] bg-bg-elev-1 border border-border rounded-lg [transition:border-color_0.15s,box-shadow_0.15s] cursor-grab flex-wrap hover:border-border-strong hover:[box-shadow:var(--shadow-sm)]',
-                  activeTrack === track.id
-                    ? 'border-brand [box-shadow:0_0_0_1px_var(--color-brand-glow)]'
-                    : '',
+                  activeTrack === track.id ? 'bg-primary/[0.12]' : '',
                   track.character === 'narrator'
                     ? '[border-left:3px_solid_var(--color-accent)]'
                     : '',
@@ -1192,7 +1190,7 @@ export default function StoriesEditor({ profiles = [] }) {
                         <button
                           key={tn.tag}
                           type="button"
-                          className="inline-flex items-center gap-[4px] bg-bg-elev-2 border border-border rounded-full text-fg [font-size:var(--text-xs)] px-[9px] py-[3px] cursor-pointer hover:border-accent hover:text-accent"
+                          className="inline-flex items-center gap-[4px] bg-bg-elev-2 border border-border rounded-full text-fg [font-size:var(--text-xs)] px-[9px] py-[3px] cursor-pointer hover:text-accent"
                           onClick={() => insertTokenInto(track.id, tn.tag)}
                           title={tn.tag}
                         >

--- a/frontend/src/components/SupertonicLicenseDialog.jsx
+++ b/frontend/src/components/SupertonicLicenseDialog.jsx
@@ -41,7 +41,7 @@ const LICENSE_URLS = {
 
 const LINK_CLS =
   'text-[0.83rem] text-[color:var(--accent,#8ab4f8)] no-underline hover:underline focus-visible:underline';
-const SECTION_CLS = 'rounded-lg border border-white/10 bg-white/[0.04] px-[0.9rem] py-3';
+const SECTION_CLS = 'rounded-lg border border-transparent bg-white/[0.04] px-[0.9rem] py-3';
 const SECTION_H_CLS =
   'm-0 mb-[0.3rem] text-[0.85rem] font-semibold uppercase tracking-[0.02em] opacity-85';
 const SECTION_P_CLS = 'm-0 mb-2 text-[0.85rem] leading-[1.5] opacity-90';

--- a/frontend/src/components/WaveformPlayer.jsx
+++ b/frontend/src/components/WaveformPlayer.jsx
@@ -276,7 +276,7 @@ export default function WaveformPlayer({
   if (missing) {
     return (
       <div
-        className={`flex items-center justify-center w-full min-w-0 box-border opacity-55 border border-solid border-[rgba(168,153,132,0.18)] bg-[rgba(168,153,132,0.08)] ${
+        className={`flex items-center justify-center w-full min-w-0 box-border opacity-55 border border-solid border-transparent bg-[rgba(168,153,132,0.08)] ${
           compact
             ? 'gap-[8px] py-[4px] px-[8px] rounded-[8px]'
             : 'gap-[10px] py-[6px] px-[10px] rounded-[10px]'
@@ -328,7 +328,7 @@ export default function WaveformPlayer({
 
   return (
     <div
-      className={`flex items-center w-full min-w-0 box-border border border-solid border-[rgba(168,153,132,0.18)] bg-[rgba(168,153,132,0.08)] ${
+      className={`flex items-center w-full min-w-0 box-border border border-solid border-transparent bg-[rgba(168,153,132,0.08)] ${
         compact
           ? 'gap-[8px] py-[4px] px-[8px] rounded-[8px]'
           : 'gap-[10px] py-[6px] px-[10px] rounded-[10px]'

--- a/frontend/src/components/WorkspaceHistory.jsx
+++ b/frontend/src/components/WorkspaceHistory.jsx
@@ -166,7 +166,7 @@ export default function WorkspaceHistory({
               type="button"
               className={`flex-[0_0_auto] py-[2px] px-[10px] text-[0.68rem] font-medium border border-solid rounded-[var(--chrome-radius-pill,999px)] cursor-pointer [transition:background_0.15s_ease,color_0.15s_ease,border-color_0.15s_ease] ${
                 filter === f.id
-                  ? 'text-[color:var(--color-brand,#d3869b)] bg-[color-mix(in_srgb,var(--color-brand,#d3869b)_12%,transparent)] border-[color-mix(in_srgb,var(--color-brand,#d3869b)_35%,transparent)]'
+                  ? 'text-[color:var(--color-brand,#d3869b)] bg-[color-mix(in_srgb,var(--color-brand,#d3869b)_12%,transparent)] border-transparent'
                   : 'bg-transparent text-[color:var(--chrome-fg-muted)] border-[var(--chrome-border-strong)] hover:bg-[var(--chrome-hover-bg)] hover:text-[color:var(--chrome-fg)]'
               }`}
               onClick={() => setFilter(f.id)}
@@ -193,7 +193,7 @@ export default function WorkspaceHistory({
                 <div className="flex items-center justify-between gap-2 min-w-0">
                   <span
                     className="history-kind"
-                    style={{ color: accent, borderColor: `${accent}40` }}
+                    style={{ color: accent, background: `${accent}22` }}
                   >
                     <KindIcon size={9} /> {item.mode || 'synth'}
                   </span>

--- a/frontend/src/components/WorkspaceVoices.jsx
+++ b/frontend/src/components/WorkspaceVoices.jsx
@@ -83,7 +83,7 @@ export default function WorkspaceVoices({
                 className="history-kind"
                 style={{
                   color: active.instruct ? '#8ec07c' : '#d3869b',
-                  borderColor: active.instruct ? '#8ec07c40' : '#d3869b40',
+                  background: active.instruct ? '#8ec07c22' : '#d3869b22',
                 }}
               >
                 {active.instruct ? t('sidebar.design_label') : t('sidebar.clone_label')}
@@ -170,7 +170,7 @@ export default function WorkspaceVoices({
                 <div className="flex items-center justify-between gap-2 min-w-0">
                   <span
                     className="history-kind"
-                    style={{ color: accent, borderColor: `${accent}40` }}
+                    style={{ color: accent, background: `${accent}22` }}
                   >
                     <KindIcon size={9} />{' '}
                     {proj.is_locked

--- a/frontend/src/components/clone/MicButton.jsx
+++ b/frontend/src/components/clone/MicButton.jsx
@@ -7,11 +7,11 @@ import { Sparkles, Square, Mic } from 'lucide-react';
 const MIC_BASE =
   'flex flex-col items-center justify-center gap-[var(--space-2)] px-4 py-2 min-w-[70px] rounded-[var(--radius-xl)] text-[length:var(--text-xs)] font-semibold cursor-pointer transition-all duration-[var(--dur-base)] ease-[var(--ease-out)]';
 const MIC_IDLE =
-  'bg-white/[0.03] border border-white/10 text-[var(--color-fg-muted)] hover:border-[var(--color-danger)] hover:text-[var(--color-danger)]';
+  'bg-white/[0.03] border border-transparent text-[var(--color-fg-muted)] hover:border-[var(--color-danger)] hover:text-[var(--color-danger)]';
 const MIC_RECORDING =
   'bg-[rgba(251,73,52,0.15)] border-2 border-[var(--color-danger)] text-[var(--color-danger)] animate-[pulse_1s_ease-in-out_infinite]';
 const MIC_CLEANING =
-  'bg-[rgba(184,187,38,0.10)] border border-[rgba(184,187,38,0.20)] text-[#b8bb26] cursor-default';
+  'bg-[rgba(184,187,38,0.10)] border border-transparent text-[#b8bb26] cursor-default';
 
 export default function MicButton({ isCleaning, isRecording, recordingTime, onStart, onStop }) {
   const { t } = useTranslation();

--- a/frontend/src/components/clone/ScriptPanel.jsx
+++ b/frontend/src/components/clone/ScriptPanel.jsx
@@ -117,7 +117,7 @@ export default function ScriptPanel({
                 </button>
               ))}
               <button
-                className={`${TAG_BTN} !border-[#b8bb26] !text-[#b8bb26]`}
+                className={`${TAG_BTN} !border-transparent !text-[#b8bb26]`}
                 role="menuitem"
                 onClick={() => {
                   insertTag('[B EY1 S]');

--- a/frontend/src/components/dub/DubFooter.jsx
+++ b/frontend/src/components/dub/DubFooter.jsx
@@ -15,7 +15,7 @@ const TRACK_ON =
   'text-[var(--chrome-fg)] border-[var(--chrome-border-strong)] bg-[var(--chrome-hover-bg)]';
 const TRACK_OFF = 'text-[var(--chrome-fg-dim)]';
 const TRACK_ON_SUCCESS =
-  'text-[var(--chrome-severity-ok)] border-[color-mix(in_srgb,var(--chrome-severity-ok)_45%,transparent)] bg-[color-mix(in_srgb,var(--chrome-severity-ok)_10%,transparent)]';
+  'text-[var(--chrome-severity-ok)] border-transparent bg-[color-mix(in_srgb,var(--chrome-severity-ok)_10%,transparent)]';
 
 export default function DubFooter({
   t,
@@ -132,7 +132,7 @@ export default function DubFooter({
         const worst = hot.reduce((a, b) => (a.rate_ratio > b.rate_ratio ? a : b));
         return (
           <div
-            className="flex items-start gap-[8px] px-[10px] py-[6px] my-[4px] bg-[color-mix(in_srgb,#fabd2f_12%,transparent)] border border-[color-mix(in_srgb,#fabd2f_35%,transparent)] border-l-2 border-l-[#fabd2f] rounded-[var(--chrome-radius-pill)] text-[0.72rem] text-[var(--chrome-fg)] leading-[1.35]"
+            className="flex items-start gap-[8px] px-[10px] py-[6px] my-[4px] bg-[color-mix(in_srgb,#fabd2f_12%,transparent)] border border-transparent border-l-2 border-l-transparent rounded-[var(--chrome-radius-pill)] text-[0.72rem] text-[var(--chrome-fg)] leading-[1.35]"
             role="status"
           >
             <span className="text-[#fabd2f] text-[0.9rem] leading-none shrink-0">⚠</span>

--- a/frontend/src/components/dub/DubLeftColumn.jsx
+++ b/frontend/src/components/dub/DubLeftColumn.jsx
@@ -40,12 +40,12 @@ const FIELD_LABEL =
   'label-row !text-[0.58rem] !text-fg-muted !m-0 whitespace-nowrap overflow-hidden text-ellipsis';
 const FIELD_INPUT = 'input-base !w-full !text-[0.65rem] !px-[5px] !py-[3px]';
 const ENGINE_CHIP =
-  'ml-[6px] px-[6px] py-[1px] text-[0.55rem] leading-[1.4] bg-[rgba(211,134,155,0.14)] border border-[rgba(211,134,155,0.35)] text-[#d3869b] rounded-[999px] whitespace-nowrap transition-colors';
+  'ml-[6px] px-[6px] py-[1px] text-[0.55rem] leading-[1.4] bg-[rgba(211,134,155,0.14)] border border-transparent text-[#d3869b] rounded-[999px] whitespace-nowrap transition-colors';
 // Highlighted accent Install affordance — brand accent (#d3869b) filled pill,
 // deliberately louder than ENGINE_CHIP so an uninstalled selected engine is an
 // obvious call to action rather than a muted footnote.
 const ENGINE_INSTALL_BTN =
-  'inline-flex items-center gap-[3px] ml-[6px] px-[7px] py-[1px] text-[0.55rem] font-semibold leading-[1.5] bg-[#d3869b] hover:bg-[#e0a0b3] text-[#1d2021] border border-[#d3869b] rounded-[999px] whitespace-nowrap cursor-pointer transition-colors shadow-[0_0_0_2px_rgba(211,134,155,0.25)] disabled:opacity-60 disabled:cursor-default';
+  'inline-flex items-center gap-[3px] ml-[6px] px-[7px] py-[1px] text-[0.55rem] font-semibold leading-[1.5] bg-[#d3869b] hover:bg-[#e0a0b3] text-[#1d2021] border border-transparent rounded-[999px] whitespace-nowrap cursor-pointer transition-colors shadow-[0_0_0_2px_rgba(211,134,155,0.25)] disabled:opacity-60 disabled:cursor-default';
 
 export default function DubLeftColumn({
   hasDubbedTrack,

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -216,7 +216,7 @@ export default function DubRightColumn({
                   thing per-speaker (and handles the multi-speaker case cleanly). */}
 
       {selectedSegIds.size > 0 && (
-        <div className="flex items-center gap-[var(--space-3)] px-[6px] py-[3px] rounded-[var(--radius-md)] mb-[var(--space-2)] text-[length:var(--text-xs)] bg-[rgba(211,134,155,0.08)] border border-[rgba(211,134,155,0.25)]">
+        <div className="flex items-center gap-[var(--space-3)] px-[6px] py-[3px] rounded-[var(--radius-md)] mb-[var(--space-2)] text-[length:var(--text-xs)] bg-[rgba(211,134,155,0.08)] border border-transparent">
           <span className="text-brand font-bold whitespace-nowrap">
             {t('dub.selected_count', { count: selectedSegIds.size })}
           </span>

--- a/frontend/src/components/dub/FooterBtn.jsx
+++ b/frontend/src/components/dub/FooterBtn.jsx
@@ -18,16 +18,15 @@ const TONES = {
   stopping:
     'text-[var(--chrome-fg-muted)] border-[var(--chrome-border)] hover:bg-[var(--chrome-hover-bg)]',
   danger:
-    'text-[var(--chrome-severity-err)] border-[color-mix(in_srgb,var(--chrome-severity-err)_45%,transparent)] bg-[color-mix(in_srgb,var(--chrome-severity-err)_10%,transparent)] hover:bg-[color-mix(in_srgb,var(--chrome-severity-err)_18%,transparent)]',
+    'text-[var(--chrome-severity-err)] border-transparent bg-[color-mix(in_srgb,var(--chrome-severity-err)_10%,transparent)] hover:bg-[color-mix(in_srgb,var(--chrome-severity-err)_18%,transparent)]',
   green:
-    'text-[var(--chrome-severity-ok)] border-[color-mix(in_srgb,var(--chrome-severity-ok)_45%,transparent)] bg-[color-mix(in_srgb,var(--chrome-severity-ok)_10%,transparent)] hover:bg-[color-mix(in_srgb,var(--chrome-severity-ok)_18%,transparent)]',
+    'text-[var(--chrome-severity-ok)] border-transparent bg-[color-mix(in_srgb,var(--chrome-severity-ok)_10%,transparent)] hover:bg-[color-mix(in_srgb,var(--chrome-severity-ok)_18%,transparent)]',
   pink: 'text-[var(--chrome-accent)] border-[var(--chrome-accent-border)] bg-[var(--chrome-accent-bg)] hover:bg-[color-mix(in_srgb,var(--chrome-accent)_20%,transparent)]',
-  blue: 'text-[#83a598] border-[color-mix(in_srgb,#83a598_45%,transparent)] bg-[color-mix(in_srgb,#83a598_10%,transparent)]',
-  lime: 'text-[#b8bb26] border-[color-mix(in_srgb,#b8bb26_45%,transparent)] bg-[color-mix(in_srgb,#b8bb26_10%,transparent)]',
+  blue: 'text-[#83a598] border-transparent bg-[color-mix(in_srgb,#83a598_10%,transparent)]',
+  lime: 'text-[#b8bb26] border-transparent bg-[color-mix(in_srgb,#b8bb26_10%,transparent)]',
   amber:
-    'text-[var(--chrome-severity-warn)] border-[color-mix(in_srgb,var(--chrome-severity-warn)_45%,transparent)] bg-[color-mix(in_srgb,var(--chrome-severity-warn)_10%,transparent)]',
-  orange:
-    'text-[#fe8019] border-[color-mix(in_srgb,#fe8019_45%,transparent)] bg-[color-mix(in_srgb,#fe8019_10%,transparent)]',
+    'text-[var(--chrome-severity-warn)] border-transparent bg-[color-mix(in_srgb,var(--chrome-severity-warn)_10%,transparent)]',
+  orange: 'text-[#fe8019] border-transparent bg-[color-mix(in_srgb,#fe8019_10%,transparent)]',
 };
 
 const FooterBtn = React.forwardRef(function FooterBtn(

--- a/frontend/src/components/gallery/ArchetypeCard.jsx
+++ b/frontend/src/components/gallery/ArchetypeCard.jsx
@@ -39,7 +39,7 @@ export default function ArchetypeCard({
     'motion-reduce:transition-none motion-reduce:hover:translate-y-0';
   const cardState = isPlaying
     ? 'border-[color:var(--card-accent)] shadow-[0_0_0_1px_var(--card-accent),0_6px_22px_rgba(0,0,0,0.4)]'
-    : 'border-white/[0.07] hover:border-white/[0.13]';
+    : 'border-transparent hover:border-transparent';
 
   return (
     <div className={`${cardBase} ${cardState}`} style={{ '--card-accent': color }}>
@@ -84,7 +84,7 @@ export default function ArchetypeCard({
 
       <div className="flex items-center gap-[6px] mt-auto">
         <button
-          className="inline-flex items-center gap-[6px] px-[11px] py-[6px] border border-white/[0.09] bg-white/[0.03] text-[var(--text-primary)] rounded-[8px] text-[0.7rem] cursor-pointer transition-colors hover:border-[color:var(--card-accent)] hover:text-[var(--card-accent)]"
+          className="inline-flex items-center gap-[6px] px-[11px] py-[6px] border border-transparent bg-white/[0.03] text-[var(--text-primary)] rounded-[8px] text-[0.7rem] cursor-pointer transition-colors hover:border-[color:var(--card-accent)] hover:text-[var(--card-accent)]"
           onClick={() => onPreview(a)}
           title={t('gallery.preview', { defaultValue: 'Preview' })}
         >
@@ -104,7 +104,7 @@ export default function ArchetypeCard({
           <UserPlus size={14} /> {t('gallery.use_voice', { defaultValue: 'Use voice' })}
         </button>
         <button
-          className="inline-flex items-center justify-center w-[30px] h-[30px] flex-shrink-0 border border-white/[0.09] bg-white/[0.03] text-[var(--text-secondary)] rounded-[8px] cursor-pointer opacity-50 transition-[opacity,border-color,color] duration-150 group-hover:opacity-100 focus-visible:opacity-100 hover:text-[var(--card-accent)] hover:border-[color:var(--card-accent)]"
+          className="inline-flex items-center justify-center w-[30px] h-[30px] flex-shrink-0 border border-transparent bg-white/[0.03] text-[var(--text-secondary)] rounded-[8px] cursor-pointer opacity-50 transition-[opacity,border-color,color] duration-150 group-hover:opacity-100 focus-visible:opacity-100 hover:text-[var(--card-accent)] hover:border-[color:var(--card-accent)]"
           onClick={() => onDesign(a)}
           title={t('gallery.open_designer', { defaultValue: 'Open in Designer' })}
         >

--- a/frontend/src/components/gallery/CommunityZone.jsx
+++ b/frontend/src/components/gallery/CommunityZone.jsx
@@ -30,7 +30,7 @@ export default function CommunityZone({
   };
 
   const submitBtn =
-    'inline-flex items-center gap-[5px] px-[10px] py-[6px] border border-white/10 bg-white/[0.03] text-[var(--text-primary)] rounded-[8px] text-[0.7rem] cursor-pointer transition-colors hover:border-[color:var(--accent)] hover:text-[var(--accent)]';
+    'inline-flex items-center gap-[5px] px-[10px] py-[6px] border border-transparent bg-white/[0.03] text-[var(--text-primary)] rounded-[8px] text-[0.7rem] cursor-pointer transition-colors hover:border-[color:var(--accent)] hover:text-[var(--accent)]';
 
   return (
     <div className="flex-1 min-h-0 flex flex-col overflow-y-auto">

--- a/frontend/src/components/profile/ProfileDetails.jsx
+++ b/frontend/src/components/profile/ProfileDetails.jsx
@@ -90,7 +90,7 @@ export default function ProfileDetails({
           )}
         </Field>
         {profile.is_locked && !editing && (
-          <div className="mt-[var(--space-4)] flex flex-wrap items-center gap-[var(--space-4)] rounded-[var(--radius-md)] border border-[rgba(250,189,47,0.25)] bg-[rgba(250,189,47,0.06)] px-[var(--space-4)] py-[var(--space-3)]">
+          <div className="mt-[var(--space-4)] flex flex-wrap items-center gap-[var(--space-4)] rounded-[var(--radius-md)] border border-transparent bg-[rgba(250,189,47,0.06)] px-[var(--space-4)] py-[var(--space-3)]">
             <Badge tone="warn" dot>
               <Lock size={10} /> {t('voice_profile.locked')}
             </Badge>
@@ -115,7 +115,7 @@ export default function ProfileDetails({
         }
       >
         {profile.verified_own_voice ? (
-          <div className="mt-[var(--space-4)] flex flex-wrap items-center gap-[var(--space-4)] rounded-[var(--radius-md)] border border-[rgba(250,189,47,0.25)] bg-[rgba(250,189,47,0.06)] px-[var(--space-4)] py-[var(--space-3)]">
+          <div className="mt-[var(--space-4)] flex flex-wrap items-center gap-[var(--space-4)] rounded-[var(--radius-md)] border border-transparent bg-[rgba(250,189,47,0.06)] px-[var(--space-4)] py-[var(--space-3)]">
             <Badge tone="success" dot>
               <ShieldCheck size={10} /> {t('voice_profile.verified')}
             </Badge>

--- a/frontend/src/components/profile/ProfileHeader.jsx
+++ b/frontend/src/components/profile/ProfileHeader.jsx
@@ -94,8 +94,8 @@ export default function ProfileHeader({
             <div
               className={`flex h-[54px] w-[54px] shrink-0 items-center justify-center rounded-[16px_20px_14px_22px/18px_14px_22px_16px] border ${
                 isDesign
-                  ? 'border-[rgba(142,192,124,0.35)] bg-[rgba(142,192,124,0.15)] text-success'
-                  : 'border-[rgba(211,134,155,0.35)] bg-[rgba(211,134,155,0.15)] text-brand'
+                  ? 'border-transparent bg-[rgba(142,192,124,0.15)] text-success'
+                  : 'border-transparent bg-[rgba(211,134,155,0.15)] text-brand'
               }`}
             >
               <TypeIcon size={22} />

--- a/frontend/src/components/settings/primitives/SettingsSection.jsx
+++ b/frontend/src/components/settings/primitives/SettingsSection.jsx
@@ -44,7 +44,7 @@ export default function SettingsSection({
       <header className="flex items-center gap-[var(--space-3)] mb-[var(--space-3)] pb-[var(--space-3)] border-b border-[var(--chrome-border)]">
         {Icon && (
           <span
-            className="shrink-0 inline-flex items-center justify-center w-[20px] h-[20px] rounded-[var(--chrome-radius-pill)] text-[color:var(--chrome-fg-muted)] bg-[color-mix(in_srgb,currentColor_12%,var(--chrome-bg))] border border-[color-mix(in_srgb,currentColor_26%,var(--chrome-border))]"
+            className="shrink-0 inline-flex items-center justify-center w-[20px] h-[20px] rounded-[var(--chrome-radius-pill)] text-[color:var(--chrome-fg-muted)] bg-[color-mix(in_srgb,currentColor_12%,var(--chrome-bg))] border border-transparent"
             style={accent ? { color: accent } : undefined}
             aria-hidden="true"
           >

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -10,9 +10,9 @@ import { cn } from '@/lib/utils';
  * Beyond the stock shadcn variants (default / secondary / destructive /
  * outline) the CVA carries the OmniVoice *tones* (neutral / brand / success /
  * warn / danger / info / violet) that back the legacy `src/ui/Badge.jsx`
- * wrapper. Tones render as chrome chips — a mono uppercase pill with an
- * explicit border + tinted fill — using palette token utilities so each tone
- * recolors with every [data-theme].
+ * wrapper. Tones render as chrome chips — a mono uppercase pill with a
+ * tinted fill (borders removed app-wide) — using palette token utilities so
+ * each tone recolors with every [data-theme].
  */
 const badgeVariants = cva(
   'inline-flex items-center gap-[2px] rounded-[var(--chrome-radius-pill)] font-mono font-semibold tracking-[var(--chrome-label-track)] uppercase whitespace-nowrap select-none leading-[1.2] [&>svg]:size-3 [&>svg]:pointer-events-none',
@@ -23,15 +23,15 @@ const badgeVariants = cva(
         default: 'border border-transparent bg-primary text-primary-foreground',
         secondary: 'border border-transparent bg-secondary text-secondary-foreground',
         destructive: 'border border-transparent bg-destructive text-destructive-foreground',
-        outline: 'border border-border text-foreground',
+        outline: 'border border-transparent bg-secondary text-foreground',
         // ── OmniVoice tones ──
-        neutral: 'text-muted-foreground border border-white/15 bg-transparent',
-        brand: 'text-primary border border-primary/35 bg-primary/[0.12]',
-        success: 'text-success border border-success/45 bg-success/10',
-        warn: 'text-accent border border-accent/45 bg-accent/10',
-        danger: 'text-destructive border border-destructive/45 bg-destructive/10',
-        info: 'text-info border border-info/45 bg-info/10',
-        violet: 'text-muted-foreground border border-white/15 bg-transparent',
+        neutral: 'text-muted-foreground border border-transparent bg-transparent',
+        brand: 'text-primary border border-transparent bg-primary/[0.12]',
+        success: 'text-success border border-transparent bg-success/10',
+        warn: 'text-accent border border-transparent bg-accent/10',
+        danger: 'text-destructive border border-transparent bg-destructive/10',
+        info: 'text-info border border-transparent bg-info/10',
+        violet: 'text-muted-foreground border border-transparent bg-transparent',
       },
       size: {
         xs: 'px-1.5 py-0 text-[11px]',

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -44,20 +44,20 @@ const buttonVariants = cva(
         primary:
           'border border-transparent bg-primary text-primary-foreground font-semibold shadow-xs hover:bg-primary/90 active:scale-[0.98]',
         subtle:
-          'border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-white/15',
+          'border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-transparent',
         softGhost:
           'border border-transparent bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground',
         danger:
-          'text-destructive bg-destructive/10 border border-destructive/45 hover:bg-destructive/20 hover:border-destructive',
-        chip: 'border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-white/15',
-        chipActive: 'text-success bg-success/10 border border-success/45',
+          'text-destructive bg-destructive/10 border border-transparent hover:bg-destructive/20 hover:border-transparent',
+        chip: 'border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-transparent',
+        chipActive: 'text-success bg-success/10 border border-transparent',
         preset:
-          'justify-start text-left border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-white/15',
+          'justify-start text-left border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-transparent',
         presetActive:
-          'justify-start text-left text-primary bg-primary/[0.12] border border-primary/30',
+          'justify-start text-left text-primary bg-primary/[0.12] border border-transparent',
         iconBtn:
-          'border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-white/15',
-        iconBtnActive: 'text-primary bg-primary/[0.12] border border-primary/30',
+          'border border-border bg-transparent text-muted-foreground hover:bg-white/[0.04] hover:text-foreground hover:border-transparent',
+        iconBtnActive: 'text-primary bg-primary/[0.12] border border-transparent',
       },
       size: {
         // ── stock shadcn ──

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -25,7 +25,7 @@ function Card({
     <Comp
       data-slot="card"
       className={cn(
-        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border border-transparent py-6 shadow-sm',
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-transparent p-6 shadow-lg duration-200',
           className,
         )}
         {...props}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -39,7 +39,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-transparent p-1 shadow-md',
           className,
         )}
         {...props}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -65,7 +65,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-transparent shadow-md',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -774,12 +774,9 @@ html[data-zoom-layout='off'] .app-container {
   margin-bottom: 0;
 }
 .glass-panel::before {
-  content: "";
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, rgba(255,255,255,0), rgba(255,255,255,0.08) 30%, rgba(255,255,255,0.12) 50%, rgba(255,255,255,0.08) 70%, rgba(255,255,255,0));
-  pointer-events: none;
+  /* Decorative top-highlight hairline removed as part of the app-wide
+     border/divider removal. */
+  display: none;
 }
 
 /* ═══ HEADER — warm + cute ═══ */
@@ -876,8 +873,10 @@ html[data-zoom-layout='off'] .app-container {
 /* ═══ INPUTS ═══ */
 .input-base {
   width: 100%;
-  background: var(--chrome-hover-bg);
-  border: 1px solid var(--chrome-border);
+  /* Borders are removed app-wide; a recessed surface fill keeps text
+     fields / selects / textareas perceivable as inputs. */
+  background: var(--color-bg-elev-2);
+  border: 1px solid transparent;
   border-radius: var(--chrome-radius-pill);
   padding: 5px 8px;
   color: var(--chrome-fg);
@@ -888,9 +887,11 @@ html[data-zoom-layout='off'] .app-container {
 }
 .input-base:focus {
   outline: none;
-  border-color: var(--chrome-border-strong);
+  border-color: transparent;
   box-shadow: none;
-  background: var(--chrome-bg);
+  /* Subtle elevation shift on focus (keyboard focus also gets the global
+     :focus-visible ring). */
+  background: var(--color-bg-elev-1);
 }
 .input-base::placeholder { color: var(--chrome-fg-dim); }
 textarea.input-base { min-height: 60px; resize: vertical; line-height: 1.5; }
@@ -905,7 +906,7 @@ select.input-base {
   cursor: pointer;
 }
 select.input-base:hover {
-  border-color: rgba(255,255,255,0.12);
+  border-color: transparent;
 }
 
 /* ═══ CHECKBOX STYLING ═══ */
@@ -987,23 +988,25 @@ input[type="range"]::-webkit-slider-thumb:active {
   max-height: none;
   overflow-y: auto;
   box-sizing: border-box;
-  border-right: 1px solid rgba(255,255,255,0.04);
+  border-right: 1px solid transparent;
 }
 .history-item {
-  background: rgba(0,0,0,0.18); border: 1px solid rgba(255,255,255,0.04);
+  background: rgba(0,0,0,0.18); border: 1px solid transparent;
   border-radius: 5px; padding: 6px 8px; margin-bottom: 4px;
   transition: all var(--transition-smooth);
   animation: fadeIn 0.2s ease-out;
 }
 .history-item:hover {
   background: rgba(0,0,0,0.28);
-  border-color: rgba(255,255,255,0.08);
+  border-color: transparent;
 }
 /* .history-header / .history-badge / .history-time / .history-text migrated to Badge + Sidebar.css. */
 .project-active {
-  border-color: rgba(184,187,38,0.4) !important;
-  background: rgba(184,187,38,0.06) !important;
-  box-shadow: inset 0 0 0 1px rgba(184,187,38,0.12), 0 0 8px rgba(184,187,38,0.06);
+  /* Selection cue via background tint (not a border) so the active project
+     stays perceivable after the app-wide border removal. */
+  border-color: transparent !important;
+  background: rgba(184,187,38,0.14) !important;
+  box-shadow: none;
 }
 
 /* ═══ AUDIO PLAYER ═══ */
@@ -1012,7 +1015,7 @@ audio {
 }
 audio::-webkit-media-controls-enclosure {
   background-color: rgba(40,38,37,0.95);
-  border: 1px solid rgba(255,255,255,0.04);
+  border: 1px solid transparent;
   border-radius: 4px;
 }
 audio::-webkit-media-controls-play-button,
@@ -1027,12 +1030,12 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
   display: flex; align-items: center; justify-content: space-between;
   background: rgba(0,0,0,0.18); padding: 4px 8px; border-radius: 4px;
   font-size: 0.72rem; color: var(--text-primary); cursor: pointer;
-  border: 1px solid rgba(255,255,255,0.04); margin-top: 6px;
+  border: 1px solid transparent; margin-top: 6px;
   transition: all var(--transition-smooth);
 }
-.override-toggle:hover { background: rgba(0,0,0,0.3); border-color: rgba(255,255,255,0.08); }
+.override-toggle:hover { background: rgba(0,0,0,0.3); border-color: transparent; }
 .override-content {
-  background: rgba(0,0,0,0.1); border: 1px solid rgba(255,255,255,0.04); border-top: none;
+  background: rgba(0,0,0,0.1); border: 1px solid transparent; border-top: none;
   padding: 6px 8px; border-radius: 0 0 4px 4px; margin-bottom: 6px;
 }
 .preset-grid {
@@ -1045,14 +1048,14 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
 .segment-table {
   /* No max-height cap — the list is virtualised via react-window and measures
      its own body container. Capping at 320 px left a huge gap below. */
-  border: 1px solid rgba(255,255,255,0.04); border-radius: 4px; margin-top: 4px;
+  border: 1px solid transparent; border-radius: 4px; margin-top: 4px;
 }
 .segment-header {
   display: flex; align-items: center; gap: 4px;
   padding: 3px 6px; background: rgba(0,0,0,0.35);
   font-size: 0.62rem; font-weight: 600; color: var(--text-secondary);
   position: sticky; top: 0; z-index: 1;
-  border-bottom: 1px solid rgba(255,255,255,0.06);
+  border-bottom: 1px solid transparent;
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
@@ -1060,7 +1063,7 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
   display: flex; align-items: center; gap: 3px;
   padding: 2px 4px;
   box-sizing: border-box;
-  border-bottom: 1px solid rgba(255,255,255,0.02);
+  border-bottom: 1px solid transparent;
   transition: background var(--transition-fast);
 }
 .segment-row:hover { background: var(--chrome-hover-bg); }
@@ -1122,13 +1125,13 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
    waveform-* family migrated to utilities on WaveformTimeline.jsx (P4). */
 .waveform-container {
   background: rgba(0,0,0,0.22);
-  border: 1px solid rgba(255,255,255,0.05);
+  border: 1px solid transparent;
   border-radius: var(--radius);
   padding: 4px;
   overflow-x: auto;
   height: 80px !important;
   position: relative;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid transparent;
 }
 
 .waveform-container [data-id^="wavesurfer-region"] {
@@ -1140,7 +1143,7 @@ audio::-webkit-media-controls-time-remaining-display { color: var(--chrome-fg); 
   top: 52px !important;
   height: 26px !important;
   border-radius: 3px !important;
-  border: 1px solid rgba(255,255,255,0.15) !important;
+  border: 1px solid transparent !important;
   display: flex !important; align-items: center !important;
   padding: 0 3px !important; color: white !important;
   font-size: 0.58rem !important;
@@ -1525,11 +1528,13 @@ select:focus:not(:focus-visible) { outline: none; box-shadow: none; }
 
 /* Textarea — flat chrome surface for design/clone prompt box */
 textarea.input-base {
-  background: var(--chrome-bg);
+  /* Recessed fill (not --chrome-bg, which equals the panel background and
+     would be invisible once the border is gone). */
+  background: var(--color-bg-elev-2);
   font-family: var(--font-sans);
   font-size: 0.82rem; line-height: 1.55;
   color: var(--chrome-fg);
-  border: 1px solid var(--chrome-border);
+  border: 1px solid transparent;
   border-radius: var(--chrome-radius-pill);
   padding: 12px 14px;
 }
@@ -2259,7 +2264,7 @@ input[type="file"]::file-selector-button:hover {
 }
 .voice-selector__btn:hover:not(:disabled) {
   color: var(--chrome-fg, #eee);
-  border-color: var(--chrome-border-strong, rgba(255, 255, 255, 0.22));
+  border-color: var(--chrome-border-strong, transparent);
 }
 .voice-selector__btn:disabled {
   opacity: 0.5;
@@ -2596,7 +2601,7 @@ input[type="file"]::file-selector-button:hover {
 .history-item--dub       { --row-accent: #83a598; }
 
 /* ── History-item kind badge variants ────────────────────────── */
-.history-kind--audio     { color: #83a598; border-color: rgba(131, 165, 152, 0.25); }
+.history-kind--audio     { color: #83a598; background: rgba(131, 165, 152, 0.13); }
 
 /* Locked project label + italic subtitle */
 .history-meta--locked    { color: #b8bb26; font-style: italic; }
@@ -2733,7 +2738,7 @@ input[type="file"]::file-selector-button:hover {
   background: rgba(18, 18, 22, 0.88);
   backdrop-filter: blur(24px) saturate(180%);
   -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
   border-radius: 100px;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
@@ -3382,7 +3387,7 @@ body:has(.capture-pill) {
   height: 22px;
   flex: 0 0 auto;
   border-radius: 50%;
-  border: 1.5px solid var(--chrome-border-strong, rgba(255, 255, 255, 0.15));
+  border: 1.5px solid var(--chrome-border-strong, transparent);
   color: var(--chrome-fg-dim, #665c54);
 }
 .dub-stepper__step.is-done .dub-stepper__icon {
@@ -3424,7 +3429,7 @@ body:has(.capture-pill) {
   justify-content: center;
   gap: 10px;
   cursor: pointer;
-  border: 2px dashed rgba(255, 255, 255, 0.06);
+  border: 2px dashed transparent;
   border-radius: 8px;
   transition: background 0.3s, border-color 0.3s;
   margin: 2px;
@@ -3455,7 +3460,7 @@ body:has(.capture-pill) {
   border-radius: 4px;
   font-size: 0.7rem;
   background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid transparent;
   color: #665c54;
   cursor: default;
 }
@@ -3516,7 +3521,7 @@ body:has(.capture-pill) {
   padding: 1px 6px;
   border-radius: var(--radius-xs);
   background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid transparent;
   color: var(--color-fg-subtle);
 }
 .dub-prep-chip.is-active {
@@ -3649,7 +3654,7 @@ body:has(.capture-pill) {
   aspect-ratio: 16 / 9;
   max-height: 60vh;
   background: #000; border-radius: 4px; overflow: hidden;
-  border: 1px solid rgba(255,255,255,0.05); display: flex;
+  border: 1px solid transparent; display: flex;
 }
 .wfm-wave-wrap {
   overflow: hidden; flex: 1 1 auto; min-height: 80px; max-height: 160px;
@@ -3680,7 +3685,7 @@ body:has(.capture-pill) {
 .wfm-error {
   display: flex; align-items: center; justify-content: center;
   padding: 8px; background: rgba(0,0,0,0.15); border-radius: 4px;
-  border: 1px solid rgba(255,255,255,0.04); color: #a89984; font-size: 0.7rem;
+  border: 1px solid transparent; color: #a89984; font-size: 0.7rem;
 }
 
 /* NOTE: the ErrorBoundary (`errbnd-*`) styles that used to live here were
@@ -4900,4 +4905,17 @@ body:has(.capture-pill) {
   white-space: nowrap;
   pointer-events: none;
   max-width: 240px;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   APP-WIDE BORDER / DIVIDER REMOVAL (owner-approved)
+   Zero every decorative border/hairline token. Kept LAST in source order so
+   it wins over the default `:root` and every `[data-theme]` override at equal
+   specificity. Focus indicators (--color-ring / --focus-ring) are deliberately
+   NOT zeroed — keyboard a11y focus rings stay.
+   ═══════════════════════════════════════════════════════════════════════ */
+:root, [data-theme] {
+  --color-border: transparent; --color-border-strong: transparent; --color-border-warm: transparent;
+  --chrome-border: transparent; --chrome-border-strong: transparent; --chrome-accent-border: transparent;
+  --glass-border: transparent;
 }

--- a/frontend/src/pages/BatchQueue.jsx
+++ b/frontend/src/pages/BatchQueue.jsx
@@ -37,8 +37,8 @@ const STATUS_TONE = {
 
 // Per-status card border accent (was .batch-queue__card--{status} in CSS).
 const CARD_BORDER = {
-  running: 'border-[rgba(211,134,155,0.4)]',
-  failed: 'border-[rgba(251,73,52,0.35)]',
+  running: 'border-transparent',
+  failed: 'border-transparent',
 };
 
 const STAGE_LABELS = {

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -83,7 +83,7 @@ export default function ContactPage({ onBack }) {
       <div className="relative z-[1] mx-auto flex w-full max-w-[640px] flex-1 flex-col justify-center gap-6 px-8 pb-10">
         <div className="flex flex-col gap-6">
           <div className="text-center">
-            <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-md border border-[color-mix(in_srgb,#d3869b_30%,transparent)] bg-[color-mix(in_srgb,#d3869b_12%,transparent)]">
+            <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,#d3869b_12%,transparent)]">
               <MessageCircle
                 size={24}
                 className="text-[#f3a5b6] drop-shadow-[0_0_12px_rgba(243,165,182,0.5)]"
@@ -110,9 +110,9 @@ export default function ContactPage({ onBack }) {
                   type="button"
                   onClick={() => openExternal(c.url)}
                   style={{ '--card-hue': c.hue }}
-                  className="flex w-full items-center gap-3 overflow-hidden rounded-md border border-border bg-transparent px-3.5 py-2.5 text-left transition-colors hover:border-[color-mix(in_srgb,var(--card-hue)_40%,transparent)] hover:bg-[color-mix(in_srgb,var(--card-hue)_6%,transparent)]"
+                  className="flex w-full items-center gap-3 overflow-hidden rounded-md border border-border bg-transparent px-3.5 py-2.5 text-left transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,var(--card-hue)_6%,transparent)]"
                 >
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-[color-mix(in_srgb,var(--card-hue)_22%,transparent)] bg-[color-mix(in_srgb,var(--card-hue)_10%,transparent)]">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,var(--card-hue)_10%,transparent)]">
                     <Icon size={20} />
                   </span>
                   <span className="min-w-0 flex-1">

--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -369,7 +369,7 @@ export default function Launchpad({
                         <div className={`${projMeta} italic`}>{p.instruct}</div>
                       </div>
                       {p.is_locked && (
-                        <span className="[font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] [letter-spacing:var(--chrome-label-track)] py-[1px] px-[7px] rounded-[var(--chrome-radius-pill)] bg-[color-mix(in_srgb,#b8bb26_10%,transparent)] border border-solid border-[color-mix(in_srgb,#b8bb26_40%,transparent)] text-[#b8bb26] font-semibold">
+                        <span className="[font-family:var(--chrome-font-mono)] text-[length:var(--chrome-label-size)] [letter-spacing:var(--chrome-label-track)] py-[1px] px-[7px] rounded-[var(--chrome-radius-pill)] bg-[color-mix(in_srgb,#b8bb26_10%,transparent)] border border-solid border-transparent text-[#b8bb26] font-semibold">
                           {t('launchpad.locked')}
                         </span>
                       )}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -458,7 +458,7 @@ export default function Settings() {
         <header className="mb-[var(--space-4)] flex items-center gap-[var(--space-3)]">
           {CatIcon && (
             <span
-              className="shrink-0 inline-flex items-center justify-center w-[26px] h-[26px] rounded-[var(--chrome-radius-pill)] text-[color:var(--chrome-accent)] bg-[color-mix(in_srgb,var(--chrome-accent)_12%,var(--chrome-bg))] border border-[color-mix(in_srgb,var(--chrome-accent)_26%,var(--chrome-border))]"
+              className="shrink-0 inline-flex items-center justify-center w-[26px] h-[26px] rounded-[var(--chrome-radius-pill)] text-[color:var(--chrome-accent)] bg-[color-mix(in_srgb,var(--chrome-accent)_12%,var(--chrome-bg))] border border-transparent"
               aria-hidden="true"
             >
               <CatIcon size={15} />

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -59,9 +59,9 @@ function LinkCard({ icon, label, desc, value, hue, onClick }) {
       type="button"
       onClick={onClick}
       style={{ '--card-hue': hue }}
-      className="flex w-full items-center gap-3 overflow-hidden rounded-md border border-border bg-transparent px-3.5 py-2.5 text-left transition-colors hover:border-[color-mix(in_srgb,var(--card-hue)_40%,transparent)] hover:bg-[color-mix(in_srgb,var(--card-hue)_6%,transparent)]"
+      className="flex w-full items-center gap-3 overflow-hidden rounded-md border border-border bg-transparent px-3.5 py-2.5 text-left transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,var(--card-hue)_6%,transparent)]"
     >
-      <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-[color-mix(in_srgb,var(--card-hue)_22%,transparent)] bg-[color-mix(in_srgb,var(--card-hue)_10%,transparent)] text-[1.1rem]">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,var(--card-hue)_10%,transparent)] text-[1.1rem]">
         {icon}
       </span>
       <span className="min-w-0 flex-1">
@@ -115,7 +115,7 @@ function SupportView() {
   return (
     <div className="flex flex-col gap-6">
       <div className="text-center">
-        <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-md border border-[color-mix(in_srgb,#d3869b_30%,transparent)] bg-[color-mix(in_srgb,#d3869b_12%,transparent)]">
+        <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,#d3869b_12%,transparent)]">
           <Heart
             size={24}
             className="text-[#f3a5b6] [fill:rgba(243,165,182,0.35)] drop-shadow-[0_0_12px_rgba(243,165,182,0.5)]"
@@ -167,7 +167,7 @@ function SupportView() {
                 className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border px-1.5 py-2 transition-colors ${
                   selected
                     ? 'border-[var(--chrome-accent)] bg-[var(--chrome-accent-bg)]'
-                    : `${a.common ? 'border-[color-mix(in_srgb,var(--chrome-accent)_35%,transparent)]' : 'border-border'} hover:border-[color-mix(in_srgb,var(--chrome-accent)_40%,transparent)] hover:bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)]`
+                    : `${a.common ? 'border-transparent' : 'border-border'} hover:border-transparent hover:bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)]`
                 }`}
               >
                 <span className="font-serif text-[1.05rem] font-medium text-[var(--chrome-fg)]">
@@ -188,7 +188,7 @@ function SupportView() {
             className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border px-1.5 py-2 transition-colors ${
               amount === 'custom'
                 ? 'border-[var(--chrome-accent)] bg-[var(--chrome-accent-bg)]'
-                : 'border-border hover:border-[color-mix(in_srgb,var(--chrome-accent)_40%,transparent)] hover:bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)]'
+                : 'border-border hover:border-transparent hover:bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)]'
             }`}
           >
             <span className="font-mono text-[0.78rem] uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
@@ -298,7 +298,7 @@ function LicenseView() {
             key={label}
             className="gap-0 rounded-md border-border bg-transparent p-4 shadow-none transition-colors hover:border-border-strong hover:bg-[var(--chrome-hover-bg)]"
           >
-            <span className="mb-2.5 flex size-[30px] items-center justify-center rounded-md border border-[color-mix(in_srgb,#d3869b_22%,transparent)] bg-[color-mix(in_srgb,#d3869b_10%,transparent)] text-[#d3869b]">
+            <span className="mb-2.5 flex size-[30px] items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,#d3869b_10%,transparent)] text-[#d3869b]">
               <Icon size={16} />
             </span>
             <div className="mb-1 font-mono text-[0.75rem] font-semibold uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg)]">
@@ -325,7 +325,7 @@ function LicenseView() {
             variant="subtle"
             leading={<Mail size={13} />}
             onClick={() => openExternal(LICENSE_MAILTO)}
-            className="border-[color-mix(in_srgb,#fe8019_50%,transparent)] bg-[color-mix(in_srgb,#fe8019_18%,transparent)] font-semibold text-[var(--chrome-fg)] hover:border-[color-mix(in_srgb,#fe8019_70%,transparent)] hover:bg-[color-mix(in_srgb,#fe8019_28%,transparent)]"
+            className="border-transparent bg-[color-mix(in_srgb,#fe8019_18%,transparent)] font-semibold text-[var(--chrome-fg)] hover:border-transparent hover:bg-[color-mix(in_srgb,#fe8019_28%,transparent)]"
           >
             {t('enterprise.request_quote')}
           </Button>
@@ -360,9 +360,9 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
   const TAB_INACTIVE =
     'border-transparent text-[var(--chrome-fg-muted)] hover:text-[var(--chrome-fg)]';
   const TAB_SUPPORT_ACTIVE =
-    'border-[color-mix(in_srgb,#d3869b_38%,transparent)] bg-[color-mix(in_srgb,#d3869b_18%,transparent)] text-[var(--chrome-fg)]';
+    'border-transparent bg-[color-mix(in_srgb,#d3869b_18%,transparent)] text-[var(--chrome-fg)]';
   const TAB_LICENSE_ACTIVE =
-    'border-[color-mix(in_srgb,#83a598_40%,transparent)] bg-[color-mix(in_srgb,#83a598_18%,transparent)] text-[var(--chrome-fg)]';
+    'border-transparent bg-[color-mix(in_srgb,#83a598_18%,transparent)] text-[var(--chrome-fg)]';
 
   return (
     <div className="relative isolate flex flex-1 flex-col overflow-y-auto bg-[var(--chrome-bg)]">

--- a/frontend/src/ui/Tabs.jsx
+++ b/frontend/src/ui/Tabs.jsx
@@ -55,7 +55,7 @@ export default function Tabs({
           const Icon = item.icon;
           const tabClass = isPill
             ? [
-                'relative flex flex-none cursor-pointer items-center justify-center gap-[var(--space-3)] rounded-[var(--chrome-radius-pill)] border font-sans tracking-[0.01em] data-[state=active]:shadow-none',
+                'relative flex flex-none cursor-pointer items-center justify-center gap-[var(--space-3)] rounded-[var(--chrome-radius-pill)] border border-transparent font-sans tracking-[0.01em] data-[state=active]:shadow-none',
                 '[transition:background_var(--dur-fast)_var(--ease-out),color_var(--dur-fast)_var(--ease-out),border-color_var(--dur-fast)_var(--ease-out)]',
                 'focus-visible:shadow-[var(--focus-ring)] focus-visible:outline-none',
                 isSm

--- a/frontend/src/utils/archetypeIcons.jsx
+++ b/frontend/src/utils/archetypeIcons.jsx
@@ -143,7 +143,6 @@ export function ArchetypeAvatar({ item, size = 44 }) {
         width: size,
         height: size,
         background: tint(color, 0.14),
-        borderColor: tint(color, 0.32),
       }}
     >
       <ArchetypeIcon name={item.icon} size={Math.round(size * 0.46)} color={color} />

--- a/tests/test_no_literal_borders.py
+++ b/tests/test_no_literal_borders.py
@@ -1,0 +1,116 @@
+"""Hard rule: no decorative literal-color borders in the frontend.
+
+The app-wide border/divider removal (owner-approved) stripped every decorative
+border, hairline, divider, and panel frame. Perceivability is preserved through
+background/elevation cues (selection, inputs, chips) and the kept
+``:focus-visible`` / ``--color-ring`` / ``--focus-ring`` focus indicators.
+
+This guard fails if the *regression class* reappears — the hardcoded neutral
+hairlines and inline border colors that ``--color-border`` token-zeroing can't
+reach:
+
+  1. Neutral (white / black) literal ``border[-x]:`` colors in ``index.css``.
+  2. ``border-white/…`` / ``border-black/…`` Tailwind utilities, or
+     ``border-[#…]`` / ``border-[rgb(a)(…)]`` / ``border-[hsl(…)]`` literal-color
+     arbitrary utilities, in ``*.jsx`` / ``*.tsx``.
+  3. Inline ``style={{ borderColor: … }}`` (non-transparent) in ``*.jsx`` /
+     ``*.tsx``.
+
+It deliberately does NOT flag: ``:focus-visible`` / ring rules, the
+``--color-ring`` / ``--focus-ring`` focus tokens, ``border-transparent`` /
+``border-0``, ``var(--…)``-driven borders (the ``--*-border`` tokens are zeroed
+centrally; accent/severity token borders are intentional semantic state cues),
+or colored non-neutral literal CSS borders kept as functional editor / severity
+affordances (e.g. the waveform segment editor).
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SRC = _REPO / "frontend" / "src"
+_INDEX_CSS = _SRC / "index.css"
+
+# This enforcement file's own pattern literals must not trip the scan.
+_SELF = Path(__file__).name
+
+# ── 1) Neutral literal border colors in index.css ────────────────────────────
+# `(?<![\w-])` keeps `--color-border` / `--chrome-border` custom-property
+# *definitions* (which are token-zeroed by the trailing override block) from
+# matching; only real `border[-x]:` declarations using a white/black rgba fill.
+_CSS_NEUTRAL_BORDER = re.compile(
+    r"(?<![\w-])border[a-z-]*\s*:[^;{}]*?"
+    r"rgba\(\s*(?:255\s*,\s*255\s*,\s*255|0\s*,\s*0\s*,\s*0)\s*,",
+)
+
+# ── 2) Literal-color border utilities in JSX/TSX ─────────────────────────────
+_JSX_BORDER_UTIL = re.compile(
+    r"border(?:-[trblxy])?-(?:white|black)(?:/|\b)"
+    r"|border(?:-[trblxy])?-\[(?:#|rgba?\(|hsl\()",
+)
+
+# ── 3) Inline borderColor (non-transparent) ──────────────────────────────────
+_JSX_BORDERCOLOR = re.compile(r"borderColor\s*:")
+
+
+def _iter_frontend_files(suffixes):
+    for p in _SRC.rglob("*"):
+        if p.suffix in suffixes and p.name != _SELF:
+            yield p
+
+
+def test_no_neutral_literal_borders_in_index_css():
+    offenders = []
+    for i, line in enumerate(_INDEX_CSS.read_text().splitlines(), 1):
+        if _CSS_NEUTRAL_BORDER.search(line):
+            offenders.append(f"index.css:{i}: {line.strip()}")
+    assert not offenders, (
+        "Decorative neutral (white/black) literal borders reappeared in "
+        "index.css. Use `border: … transparent` (or drop the border) — the "
+        "app-wide border removal zeroed these.\n" + "\n".join(offenders)
+    )
+
+
+def test_no_literal_color_border_utilities_in_jsx():
+    offenders = []
+    for p in _iter_frontend_files({".jsx", ".tsx"}):
+        for i, line in enumerate(p.read_text().splitlines(), 1):
+            for m in _JSX_BORDER_UTIL.finditer(line):
+                token = m.group(0)
+                if "border-transparent" in token:
+                    continue
+                offenders.append(f"{p.relative_to(_REPO)}:{i}: …{token}…")
+    assert not offenders, (
+        "Literal-color border utilities reappeared. Use `border-transparent` "
+        "(keep the width to suppress the no-Preflight UA border) or a "
+        "background tint for active/selected state.\n" + "\n".join(offenders)
+    )
+
+
+def test_no_inline_border_color_in_jsx():
+    offenders = []
+    for p in _iter_frontend_files({".jsx", ".tsx"}):
+        for i, line in enumerate(p.read_text().splitlines(), 1):
+            if _JSX_BORDERCOLOR.search(line) and "transparent" not in line:
+                offenders.append(f"{p.relative_to(_REPO)}:{i}: {line.strip()}")
+    assert not offenders, (
+        "Inline `borderColor` reappeared. Convey selection/error via a "
+        "background tint (see WorkspaceHistory / DubSegmentRow) instead.\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_focus_indicators_are_preserved():
+    """Regression guard: the border removal must not strip focus a11y."""
+    css = _INDEX_CSS.read_text()
+    assert "--color-ring:" in css, "--color-ring focus token was removed"
+    assert "--focus-ring:" in css, "--focus-ring token was removed"
+    assert ":focus-visible" in css, ":focus-visible ring rules were removed"
+    # The token-zeroing override must NOT have zeroed the focus ring.
+    assert "--color-ring: transparent" not in css
+    assert "--focus-ring: transparent" not in css
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Phase 1 of the styling pass: eliminate every **decorative** border, divider, hairline, and the fat panel frame — while keeping keyboard **focus rings** (a11y) and swapping selection/input borders for subtle **background cues** so nothing becomes invisible.

## Approach (hybrid: token-zeroing + targeted sweep)
- **Token zeroing** (`index.css`): one final `:root, [data-theme]` block sets `--color-border*`, `--chrome-border*`, `--glass-border` → `transparent` (kept last so it wins). This removes the bulk in a tiny diff. `--color-ring` / `--focus-ring` deliberately untouched.
- **Fat panel frame:** `.glass-panel::before` decorative top-highlight → `display:none` (the extra-bright white streak); the border goes transparent via the tokens.
- **Literal-color sweep:** 22 neutral CSS hairlines → transparent; **79** literal-color Tailwind utilities (`border-white/…`, `border-[#|rgba|color-mix]`) → `border-transparent`; bare `border` on shadcn card/dialog/select/dropdown/Tabs → `border-transparent`; **9** inline `borderColor` styles removed or swapped to a bg tint.
- **Inputs:** `.input-base`/`textarea` now use a recessed `--color-bg-elev-2` fill (+ focus elevation) so fields stay perceivable.
- **Selection/active states** (`.project-active`, active chips, selected tracks, status cards) now read via **background tint**, not a border.

## Preserved on purpose
- **Focus rings** (`:focus-visible` outlines, `--focus-ring`, `--color-ring`, shadcn `focus-visible:border-ring` / `aria-invalid:border-destructive`) — WCAG 2.4.7.
- **Functional editor affordances**: waveform segment boundaries / drag handles / selection ring, dropzone drag-active accent, severity/error state borders — these convey state, not chrome.
- No `<hr>` exist in the app (0 found).

## Guardrail (recurrence-proof)
`tests/test_no_literal_borders.py` fails if neutral literal borders reappear in `index.css`, or literal-color border utilities / inline `borderColor` reappear in jsx/tsx — and asserts the focus-ring tokens/rules survive. 4/4 pass (verified it flags bad samples, ignores kept ones).

## Verify
`bun run build` ✓ · `format:check` ✓ · `lint` (oxlint) exit 0 ✓ · guardrail 4/4 ✓. 43 files.

Phase 2 (unify all controls onto design tokens, borderless) follows in a separate PR on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

UI chrome was flattened across the frontend by removing decorative borders, dividers, hairlines, and panel frames while keeping focus rings intact.

Before/after sketch:
```text
Before: [ card | border ]  [ input | border ]  [ panel ::before divider ]
After : [ card         ]  [ input         ]  [ panel               ]
         (focus rings preserved)
```

- Zeroed border-related design tokens in `frontend/src/index.css` so most decorative borders resolve to transparent.
- Removed the glass-panel highlight/divider and converted many surfaces to rely on background/elevation instead of borders.
- Updated numerous JSX components to replace literal colored borders and inline `borderColor` styles with `border-transparent` or background tints.
- Preserved functional/accessibility borders such as focus rings, error/selection affordances where needed, waveform boundaries, drag handles, and dropzone states.
- Added a regression test that blocks literal decorative border colors and inline `borderColor` reintroductions, while verifying focus-ring tokens remain present and non-transparent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->