### PR TITLE
fix(dub): compact + responsive dub header (stages/title/actions)

### DIFF
--- a/frontend/src/components/dub/DubHeader.jsx
+++ b/frontend/src/components/dub/DubHeader.jsx
@@ -34,24 +34,24 @@ export default function DubHeader({
   setExportOpen,
 }) {
   return (
-    <div className="flex flex-wrap justify-between items-center gap-x-[var(--space-3)] gap-y-[4px] px-[12px] py-[5px] shrink-0 bg-[rgba(255,255,255,0.015)] [border:1px_solid_rgba(255,255,255,0.04)] rounded-md mb-[2px]">
+    <div className="flex flex-wrap justify-between items-center gap-x-[var(--space-2)] gap-y-[4px] min-w-0 px-[10px] py-[4px] shrink-0 bg-[var(--color-bg-elev-1)] rounded-md mb-[2px]">
       {/* Pipeline spine, inlined onto the header row (Upload → … → Export). */}
       <DubPipelineStepper dubStep={dubStep} inline />
-      <div className="label-row dub-head__title">
+      <div className="label-row dub-head__title !gap-[6px]">
         <FileText className="label-icon" size={11} />
-        <span className="font-semibold text-[0.85rem] overflow-hidden text-ellipsis whitespace-nowrap text-fg">
+        <span className="font-medium text-[0.78rem] min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-fg normal-case">
           {dubFilename}
         </span>
-        <span className="text-fg-muted font-normal whitespace-nowrap text-[0.72rem]">
+        <span className="text-fg-muted font-normal whitespace-nowrap text-[0.68rem] normal-case shrink-0">
           · {formatTime(dubDuration)} · {dubSegments.length} {t('dub.segs')}
         </span>
         {activeProjectName && activeProjectName !== dubFilename && (
-          <span className="text-[#b8bb26] ml-[var(--space-3)] whitespace-nowrap text-[0.72rem]">
+          <span className="text-[#b8bb26] ml-[var(--space-2)] whitespace-nowrap text-[0.68rem] normal-case overflow-hidden text-ellipsis min-w-0">
             — {activeProjectName}
           </span>
         )}
       </div>
-      <div className="flex gap-[var(--space-2)] items-center shrink-0">
+      <div className="flex gap-[6px] items-center shrink-0">
         {/* Icon-only secondary actions (tooltips carry the labels);
                   Generate Dub keeps its label as the primary verb. */}
         <Button
@@ -73,7 +73,7 @@ export default function DubHeader({
           <RotateCcw size={12} />
         </Button>
         {/* Primary actions live on the header bar (compact) — moved up from the footer. */}
-        <div className="flex gap-[var(--space-2)] items-center pl-[var(--space-2)] [border-left:1px_solid_var(--color-border,#3a3a3a)]">
+        <div className="flex gap-[6px] items-center pl-[var(--space-2)] ml-[2px]">
           {dubStep === 'stopping' ? (
             <FooterBtn
               sm

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3489,9 +3489,19 @@ body:has(.capture-pill) {
   flex: 0 1 auto;
   min-width: 0;
 }
+/* Tighter footprint when inlined on the header row so the stages, title, and
+   actions all fit before wrapping. */
+.dub-stepper--inline .dub-stepper__step {
+  gap: 5px;
+  font-size: 0.66rem;
+}
+.dub-stepper--inline .dub-stepper__icon {
+  width: 19px;
+  height: 19px;
+}
 .dub-stepper--inline .dub-stepper__step:not(:first-child)::before {
-  width: 14px;
-  margin: 0 5px;
+  width: 10px;
+  margin: 0 4px;
 }
 
 /* ── Idle / drop-zone ─────────────────────────────────────────────────── */


### PR DESCRIPTION
The consolidated dub header (stages + project name + duration/segs + Save/Reset/Generate Dub/Export) was wide and cramped. Compacts it so everything fits nicely and wraps responsively:

- **Stepper:** inline variant now uses a smaller step gap + 0.66rem labels + 19px icons + 10px connectors — the 6 stages take far less horizontal room.
- **Title:** lighter weight (medium, 0.78rem), `normal-case`, proper `min-w-0` truncation; metadata 0.68rem; the project-name suffix truncates too.
- **Chrome:** removed the hardcoded 1px header border + the `border-left` divider (borderless direction) and swapped the `rgba(255,255,255,…)` bg for the `--color-bg-elev-1` token; tighter padding/gaps.

Behavior unchanged. build ✓ · format ✓ · borderless guardrail 5/5 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the consolidated Dub header to be more compact and responsive.

Before
```text
[Project title + metadata]   [actions]
[inline stepper with wider labels/icons/connectors]
```

After
```text
[Project title…] [metadata…]   [actions]
[tighter inline stepper with smaller labels/icons/connectors]
```

- Tightened header spacing, padding, gaps, and background treatment.
- Reduced title/filename typography and enabled truncation with `min-w-0`.
- Kept the project-name suffix truncating as well.
- Removed the hardcoded border/left divider from the action area and adjusted spacing.
- Condensed the inline stepper by shrinking step gaps, label size, icon size, and connector width/margins.

Behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->