### PR TITLE
redesign(gallery): cleaner, more elegant voice cards

### DIFF
--- a/frontend/src/components/gallery/ArchetypeCard.jsx
+++ b/frontend/src/components/gallery/ArchetypeCard.jsx
@@ -30,34 +30,41 @@ export default function ArchetypeCard({
   const accentLabel = a.facets.accent
     ? facetLabel(a.facets.accent)
     : dialect || (a.language === 'Chinese' ? 'Chinese' : null);
+  const hasChips = Boolean(accentLabel || a.facets.whisper);
 
+  // Borderless by direction: the card keeps a transparent border only to reserve
+  // the box width; the playing state is conveyed by an accent ring (box-shadow)
+  // + lift, never a literal border.
   const cardBase =
-    'group relative flex flex-col gap-[10px] p-[13px] rounded-[13px] ' +
-    'bg-[linear-gradient(180deg,rgba(255,255,255,0.038),rgba(255,255,255,0.012))] border ' +
-    'transition-[transform,border-color,box-shadow] duration-150 ' +
+    'group relative flex flex-col gap-[11px] p-[14px] rounded-[13px] border border-transparent ' +
+    'bg-[linear-gradient(180deg,rgba(255,255,255,0.038),rgba(255,255,255,0.012))] ' +
+    'transition-[transform,box-shadow] duration-150 ' +
     'hover:-translate-y-[2px] hover:shadow-[0_6px_22px_rgba(0,0,0,0.4)] ' +
     'motion-reduce:transition-none motion-reduce:hover:translate-y-0';
   const cardState = isPlaying
-    ? 'border-[color:var(--card-accent)] shadow-[0_0_0_1px_var(--card-accent),0_6px_22px_rgba(0,0,0,0.4)]'
-    : 'border-transparent hover:border-transparent';
+    ? 'shadow-[0_0_0_1px_var(--card-accent),0_6px_22px_rgba(0,0,0,0.4)]'
+    : '';
 
   return (
     <div className={`${cardBase} ${cardState}`} style={{ '--card-accent': color }}>
-      <div className="flex items-center gap-[10px]">
+      {/* Header — the name is the focal point; metadata recedes (smaller, muted). */}
+      <div className="flex items-center gap-[11px]">
         <ArchetypeAvatar item={a} />
         <div className="flex-1 min-w-0">
-          <div className="text-[0.84rem] font-semibold text-[var(--text-primary)] truncate">
+          <div className="text-[0.86rem] font-semibold leading-tight text-[var(--color-fg)] truncate">
             {a.name}
           </div>
           {sub && (
-            <div className="text-[0.68rem] text-[var(--text-secondary)] mt-[2px] truncate">
+            <div className="text-[0.66rem] text-[var(--color-fg-muted)] mt-[3px] truncate">
               {sub}
             </div>
           )}
         </div>
         <button
-          className={`flex-shrink-0 flex items-center justify-center w-[26px] h-[26px] rounded-[7px] cursor-pointer transition-colors hover:bg-white/[0.05] ${
-            isFavorite ? 'text-[#fabd2f]' : 'text-[var(--text-secondary)] hover:text-[#fabd2f]'
+          className={`flex-shrink-0 flex items-center justify-center w-[26px] h-[26px] rounded-[7px] cursor-pointer transition-[color,background-color,opacity] hover:bg-[var(--chrome-hover-bg)] ${
+            isFavorite
+              ? 'text-[#fabd2f]'
+              : 'text-[var(--color-fg-subtle)] opacity-70 group-hover:opacity-100 hover:text-[#fabd2f]'
           }`}
           onClick={() => onToggleFavorite(a.id)}
           title={t('gallery.favorite', { defaultValue: 'Favorite' })}
@@ -66,25 +73,30 @@ export default function ArchetypeCard({
         </button>
       </div>
 
-      {/* Always render the chip row (even when empty) so every card shares the
-          same height and the action rows align across the grid. */}
-      <div className="flex flex-wrap items-center gap-[5px] min-h-[21px]">
-        {accentLabel && (
-          <span className="inline-flex items-center gap-[5px] pl-[5px] pr-[8px] py-[2px] rounded-[7px] bg-white/[0.05] text-[var(--text-secondary)] text-[0.64rem] leading-[1.6]">
-            <AccentFlag accent={a.facets.accent} lang={a.language} size={14} />
-            {accentLabel}
-          </span>
-        )}
-        {a.facets.whisper && (
-          <span className="inline-flex items-center gap-[5px] px-[8px] py-[2px] rounded-[7px] bg-white/[0.05] text-[var(--text-secondary)] text-[0.64rem] leading-[1.6]">
-            {t('archetypes.facet_whisper', { defaultValue: 'Whisper' })}
-          </span>
-        )}
-      </div>
+      {/* Chips only render when present — no empty reserved row. Cards without
+          chips stay compact; the grid stretches each row to equal height so the
+          `mt-auto` action row still bottom-aligns across the grid. */}
+      {hasChips && (
+        <div className="flex flex-wrap items-center gap-[5px]">
+          {accentLabel && (
+            <span className="inline-flex items-center gap-[5px] pl-[5px] pr-[8px] py-[2px] rounded-[7px] bg-[var(--color-bg-elev-2)] text-[var(--color-fg-muted)] text-[0.64rem] leading-[1.6]">
+              <AccentFlag accent={a.facets.accent} lang={a.language} size={14} />
+              {accentLabel}
+            </span>
+          )}
+          {a.facets.whisper && (
+            <span className="inline-flex items-center gap-[5px] px-[8px] py-[2px] rounded-[7px] bg-[var(--color-bg-elev-2)] text-[var(--color-fg-muted)] text-[0.64rem] leading-[1.6]">
+              {t('archetypes.facet_whisper', { defaultValue: 'Whisper' })}
+            </span>
+          )}
+        </div>
+      )}
 
+      {/* Actions — quiet Preview (ghost, token hover), confident accent Use voice
+          (tinted → solid accent with inverse text), subtle magic-wand icon. */}
       <div className="flex items-center gap-[6px] mt-auto">
         <button
-          className="inline-flex items-center gap-[6px] px-[11px] py-[6px] border border-transparent bg-white/[0.03] text-[var(--text-primary)] rounded-[8px] text-[0.7rem] cursor-pointer transition-colors hover:border-[color:var(--card-accent)] hover:text-[var(--card-accent)]"
+          className="inline-flex items-center gap-[6px] px-[11px] py-[6px] rounded-[8px] bg-transparent text-[var(--color-fg-muted)] text-[0.7rem] cursor-pointer transition-colors hover:bg-[var(--chrome-hover-bg)] hover:text-[var(--color-fg)]"
           onClick={() => onPreview(a)}
           title={t('gallery.preview', { defaultValue: 'Preview' })}
         >
@@ -98,13 +110,13 @@ export default function ArchetypeCard({
           <span>{t('gallery.preview', { defaultValue: 'Preview' })}</span>
         </button>
         <button
-          className="flex-1 inline-flex items-center justify-center gap-[6px] px-[10px] py-[6px] rounded-[8px] border border-[color:color-mix(in_srgb,var(--card-accent)_36%,transparent)] bg-[color-mix(in_srgb,var(--card-accent)_13%,transparent)] text-[var(--card-accent)] text-[0.72rem] font-semibold cursor-pointer transition-colors hover:bg-[var(--card-accent)] hover:border-[color:var(--card-accent)] hover:text-[#1d2021] focus-visible:bg-[var(--card-accent)] focus-visible:border-[color:var(--card-accent)] focus-visible:text-[#1d2021]"
+          className="flex-1 inline-flex items-center justify-center gap-[6px] px-[10px] py-[6px] rounded-[8px] bg-[color-mix(in_srgb,var(--card-accent)_15%,transparent)] text-[var(--card-accent)] text-[0.72rem] font-semibold cursor-pointer transition-colors hover:bg-[var(--card-accent)] hover:text-[var(--color-fg-inverse)] focus-visible:bg-[var(--card-accent)] focus-visible:text-[var(--color-fg-inverse)]"
           onClick={() => onUse(a)}
         >
           <UserPlus size={14} /> {t('gallery.use_voice', { defaultValue: 'Use voice' })}
         </button>
         <button
-          className="inline-flex items-center justify-center w-[30px] h-[30px] flex-shrink-0 border border-transparent bg-white/[0.03] text-[var(--text-secondary)] rounded-[8px] cursor-pointer opacity-50 transition-[opacity,border-color,color] duration-150 group-hover:opacity-100 focus-visible:opacity-100 hover:text-[var(--card-accent)] hover:border-[color:var(--card-accent)]"
+          className="inline-flex items-center justify-center w-[30px] h-[30px] flex-shrink-0 rounded-[8px] bg-transparent text-[var(--color-fg-muted)] cursor-pointer opacity-50 transition-[opacity,color,background-color] duration-150 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-[var(--chrome-hover-bg)] hover:text-[var(--card-accent)]"
           onClick={() => onDesign(a)}
           title={t('gallery.open_designer', { defaultValue: 'Open in Designer' })}
         >


### PR DESCRIPTION
Refines the Gallery voice card (`ArchetypeCard.jsx`) to be calmer and more elegant — visual/token only, behavior unchanged.

## Before → after
- **Hierarchy:** the name is now the clear focal point (semibold, `--color-fg`); the `Female · Middle-Aged · Low` metadata recedes — smaller (`0.66rem`), muted (`--color-fg-muted`), with a little breathing room.
- **Surfaces → tokens:** `bg-white/[0.05]`/`[0.03]` chips & buttons → `--color-bg-elev-2` / transparent-with-`--chrome-hover-bg`-on-hover; literal `#1d2021` hover text → `--color-fg-inverse`; `--text-primary/secondary` → canonical `--color-fg`/`--color-fg-muted`/`--color-fg-subtle`.
- **Borderless:** removed every hover/state border (buttons + the playing-state card border). Hover = bg tint + text color; the *playing* state is now an accent **box-shadow ring**, not a border. Respects the guardrail.
- **Actions:** quiet ghost **Preview**, a confident accent **Use voice** (tinted → solid `--card-accent` on hover/focus, accent reserved for this primary action), subtle magic-wand.
- **Chips:** the always-on empty `min-h-[21px]` row is gone — chips render only when present; `mt-auto` keeps action rows bottom-aligned so chip-less cards stay compact + aligned.
- **Favorite star:** subtle until hover/active.

## Verify
`build` ✓ · `format:check` ✓ · `lint` 0 errors ✓ · borderless guardrail 5/5 ✓.

Flagged (left as-is): the favorite gold `#fabd2f` (no theme-neutral gold token; shared with `postcard__star`) and the card's own subtle bg gradient (not in scope; theme-regression risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `ArchetypeCard` to feel calmer and more refined without changing behavior.

**What changed**
- Rebalanced the card hierarchy so the voice name stands out more and metadata reads softer.
- Replaced hardcoded surface/text colors with theme tokens.
- Swapped the playing-state border treatment for an accent box-shadow ring.
- Made **Preview** stay understated while **Use voice** becomes the primary accent action on hover/focus.
- Rendered chips only when present, keeping chip-less cards tighter and cleaner.
- Softened the favorite star until hover/active.

**Layout sketch**

Before:
```text
+------------------------------+
| Voice name                   |
| metadata line                |
| [chip] [chip]                |
| Preview   Use voice          |
| ★                            |
+------------------------------+
```

After:
```text
+------------------------------+
| Voice name                   |
| metadata line (muted/smaller)|
| [chip] [chip]   (only if any) |
| Preview   Use voice (accent)  |
| ★ (subtle until hover)        |
+------------------------------+
```

**Verification**
- Build
- Format check
- Lint
- Borderless guardrail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->