### PR TITLE
fix(translate+dub): wire Cinematic/Autofit to LLM Providers; retry wedged transcribe chunk

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -382,6 +382,11 @@ async def dub_ingest_url(req: DubIngestUrlRequest):
 
 TRANSCRIBE_CHUNK_S = float(os.environ.get("OMNIVOICE_TRANSCRIBE_CHUNK_S", "30.0"))
 TRANSCRIBE_CHUNK_TIMEOUT_S = float(os.environ.get("OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S", "120.0"))
+#: How many times to attempt each transcribe chunk before giving up on it. A
+#: transient wedge (esp. the first chunk, where whisperx cold-loads its model)
+#: shouldn't silently drop that whole window — retry once on a fresh pool so the
+#: transcript doesn't come back "missing the beginning".
+_CHUNK_TRANSCRIBE_ATTEMPTS = max(1, int(os.environ.get("OMNIVOICE_TRANSCRIBE_CHUNK_ATTEMPTS", "2")))
 
 
 _sse_event = dub_pipeline.sse_event
@@ -567,36 +572,54 @@ async def dub_transcribe_stream(
                     logger.exception("chunk transcribe failed (backend=%s)", _asr_backend.id)
                     return {"chunks": [], "language": None, "error": str(e)}
 
-            try:
-                # wait_for in a loop to yield pings so the EventSource connection doesn't drop
-                fut = loop.run_in_executor(_gpu_pool, _transcribe_chunk)
-                waited = 0.0
-                part = None
-                while True:
-                    done, pending = await asyncio.wait([fut], timeout=5.0)
-                    if done:
-                        part = done.pop().result()
-                        break
-                    yield _sse_event("ping", {})
-                    waited += 5.0
-                    if waited >= TRANSCRIBE_CHUNK_TIMEOUT_S:
-                        # Re-raise TimeoutError if we exceed the overall limit
-                        raise asyncio.TimeoutError()
-            except asyncio.TimeoutError:
-                logger.error(
-                    "Transcribe chunk %d/%d timed out after %.0fs (job=%s)",
-                    i + 1, chunks_n, TRANSCRIBE_CHUNK_TIMEOUT_S, job_id,
-                )
-                # #730: the wedged chunk thread keeps holding its GPU-pool worker.
-                # Abandon the poisoned pool so the next chunk (and any TTS work)
-                # gets a fresh worker instead of queueing behind the stuck one —
-                # same recovery the whole-file paths get via run_transcribe_guarded.
-                _reset_pool_on_wedge(_gpu_pool)
-                part = {
-                    "chunks": [], "language": None,
-                    "error": f"Chunk {i+1} timed out after {TRANSCRIBE_CHUNK_TIMEOUT_S:.0f}s — "
-                             f"ASR backend may be stuck. Try restarting the server.",
-                }
+            # Retry a failed/timed-out chunk once on a fresh pool before giving
+            # up. Otherwise a transient wedge on the FIRST chunk (whisperx often
+            # cold-loads its model there, the #730 hang) drops that whole window
+            # and the transcript is "missing the beginning, only middle+end".
+            # The retry reuses the same audio window, so a recovered chunk fills
+            # the hole instead of leaving silent gaps.
+            part = None
+            for _attempt in range(1, _CHUNK_TRANSCRIBE_ATTEMPTS + 1):
+                try:
+                    # wait_for in a loop to yield pings so the EventSource connection doesn't drop
+                    fut = loop.run_in_executor(_gpu_pool, _transcribe_chunk)
+                    waited = 0.0
+                    while True:
+                        done, pending = await asyncio.wait([fut], timeout=5.0)
+                        if done:
+                            part = done.pop().result()
+                            break
+                        yield _sse_event("ping", {})
+                        waited += 5.0
+                        if waited >= TRANSCRIBE_CHUNK_TIMEOUT_S:
+                            # Re-raise TimeoutError if we exceed the overall limit
+                            raise asyncio.TimeoutError()
+                except asyncio.TimeoutError:
+                    logger.error(
+                        "Transcribe chunk %d/%d timed out after %.0fs (attempt %d/%d, job=%s)",
+                        i + 1, chunks_n, TRANSCRIBE_CHUNK_TIMEOUT_S, _attempt,
+                        _CHUNK_TRANSCRIBE_ATTEMPTS, job_id,
+                    )
+                    # #730: the wedged chunk thread keeps holding its GPU-pool
+                    # worker. Abandon the poisoned pool so the retry (and any TTS
+                    # work) gets a fresh worker instead of queueing behind it.
+                    _reset_pool_on_wedge(_gpu_pool)
+                    part = {
+                        "chunks": [], "language": None,
+                        "error": f"Chunk {i+1} timed out after {TRANSCRIBE_CHUNK_TIMEOUT_S:.0f}s — "
+                                 f"ASR backend may be stuck. Try restarting the server.",
+                    }
+                # Success → keep it. Failure/timeout → retry once on a fresh
+                # worker (the internal _transcribe_chunk except returns an
+                # error-part; the timeout path already reset the pool).
+                if part is not None and not part.get("error"):
+                    break
+                if _attempt < _CHUNK_TRANSCRIBE_ATTEMPTS:
+                    logger.warning(
+                        "Retrying transcribe chunk %d/%d after failure/timeout (next attempt %d/%d, job=%s)",
+                        i + 1, chunks_n, _attempt + 1, _CHUNK_TRANSCRIBE_ATTEMPTS, job_id,
+                    )
+                    _reset_pool_on_wedge(_gpu_pool)
             if part.get("error"):
                 chunk_errors.append(part["error"])
                 logger.warning("Chunk %d/%d error: %s", i + 1, chunks_n, part["error"])

--- a/backend/services/translator.py
+++ b/backend/services/translator.py
@@ -94,18 +94,26 @@ def _looks_like_target_script(text: str, code: str, threshold: float = 0.5) -> b
 
 
 def _llm_client():
-    """Lazy-build the OpenAI-compatible client. Returns None if no key + no local base_url."""
+    """Lazy-build the OpenAI-compatible client for the ACTIVE LLM provider.
+
+    Resolves through the LLM Providers registry (Settings → LLM Providers) so a
+    provider configured there actually powers Cinematic/Autofit — previously this
+    only read ``TRANSLATE_*``/``OPENAI_*`` directly, so the registry-configured
+    provider was ignored (the "LLM not wired" bug). The registry's ``custom``
+    provider still maps ``TRANSLATE_BASE_URL``/``TRANSLATE_API_KEY``, so legacy
+    env setups keep working. Returns None if no provider is configured.
+    """
     try:
         from openai import OpenAI
     except ImportError:
         logger.warning("openai package not installed — cinematic mode unavailable.")
         return None
-    base_url = os.environ.get("TRANSLATE_BASE_URL")
-    api_key = (
-        os.environ.get("TRANSLATE_API_KEY")
-        or os.environ.get("OPENAI_API_KEY")
-        or ("local" if base_url else None)  # local providers often accept any key
-    )
+    from services import llm_providers
+    p = llm_providers.active_provider()
+    if p is None:
+        return None
+    base_url = llm_providers.resolve_base_url(p)
+    api_key = llm_providers.resolve_api_key(p)
     if not api_key:
         return None
     kw = {"api_key": api_key}
@@ -115,6 +123,10 @@ def _llm_client():
 
 
 def _llm_model() -> str:
+    from services import llm_providers
+    p = llm_providers.active_provider()
+    if p is not None:
+        return llm_providers.resolve_model(p)
     return os.environ.get("TRANSLATE_MODEL", "gpt-4o-mini")
 
 


### PR DESCRIPTION
Two bugs from live reports.

## 1. Cinematic/Autofit not actually using the LLM Providers page ("LLMs not wired")
`translator._llm_client()` / `_llm_model()` read `TRANSLATE_*` / `OPENAI_*` **directly**, bypassing the LLM Providers registry from #854. So a provider you configure in **Settings → LLM Providers** never powered Cinematic/Autofit — it silently used the old env path (usually unconfigured). Now both resolve the **active provider** (base_url/key/model) via `llm_providers`. Backward-compatible: the registry's `custom` provider still maps `TRANSLATE_BASE_URL/API_KEY/MODEL`, so legacy env setups keep working.

## 2. Transcription "missing a lot from the beginning"
The chunked dub transcribe **dropped a whole chunk's window** on failure/timeout — returned empty segments, no retry, moved on. A transient wedge on the **first** chunk (whisperx cold-loads its model there — the #730 hang) therefore lost the start and left only middle+end (exactly the reported symptom). Now a failed/timed-out chunk is **retried once on a fresh pool** (`OMNIVOICE_TRANSCRIBE_CHUNK_ATTEMPTS`, default 2), so the recovered chunk fills the hole instead of leaving a silent gap.

## Note on the "Translating…" hang
With #1 fixed, Cinematic uses your active provider. If it still stalls, the provider is slow/rate-limited — Cinematic makes ~2 LLM calls per segment (reflect+adapt), so on a free/throttled model a 17-segment dub is slow. Use a faster provider, or **Autofit** (lighter), or **Fast**. (A follow-up could bound the overall cinematic pass — flagged, not done here.)

Imports + `test_dub_transcribe` / `test_translator` / `test_llm_providers` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes two live-report issues in translate + dub:

- Cinematic/Autofit now resolve the active LLM provider through `services.llm_providers` instead of reading `TRANSLATE_*` / `OPENAI_*` env vars directly.
- The legacy `custom` provider still maps to `TRANSLATE_BASE_URL`, `TRANSLATE_API_KEY`, and `TRANSLATE_MODEL` for backward compatibility.
- Chunked dub transcription now retries failed or timed-out chunks once on a fresh GPU pool, so recovered chunks are included instead of being dropped.
- A new `OMNIVOICE_TRANSCRIBE_CHUNK_ATTEMPTS` setting controls per-chunk retry attempts, with a minimum of 1.

```mermaid
flowchart TD
  A[Start chunk transcription] --> B[Attempt chunk]
  B --> C{Success?}
  C -->|Yes| D[Emit segment / continue]
  C -->|No: timeout or error| E{Attempts left?}
  E -->|Yes| F[Reset GPU pool]
  F --> B
  E -->|No| G[Return error part]
  G --> D
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->