### PR TITLE
fix(translate): bound the cinematic/autofit pass so a slow LLM can't hang "Translating…"

### DIFF
--- a/backend/services/translator.py
+++ b/backend/services/translator.py
@@ -137,6 +137,16 @@ def _llm_timeout() -> float:
         return 45.0
 
 
+def _cinematic_budget() -> float:
+    """Overall wall-clock cap for a whole cinematic/autofit refine pass (seconds).
+    Unfinished segments degrade to their literal (Fast) translation once hit, so
+    a slow provider can't hang the translate. Default 180s; <=0 disables."""
+    try:
+        return float(os.environ.get("OMNIVOICE_CINEMATIC_BUDGET_S", "180"))
+    except ValueError:
+        return 180.0
+
+
 def _glossary_text(glossary: Iterable[dict] | None) -> str:
     """Format the project glossary as a preamble for the LLM prompts.
 
@@ -332,4 +342,35 @@ async def cinematic_refine_many(
             )
         return {"id": seg_id, **res}
 
-    return await asyncio.gather(*(_one(sid, src, lit) for sid, src, lit in pairs))
+    # Overall wall-clock budget for the whole pass. Per-call timeout + bounded
+    # concurrency already cap it, but a slow/rate-limited provider on a large dub
+    # can still stall the "Translating…" spinner for minutes. Bound it: segments
+    # that finish in time keep their cinematic refine; any still-running segment
+    # degrades to its literal (Fast) translation so the translate ALWAYS returns
+    # within the budget instead of hanging. 0/negative disables the bound.
+    budget = _cinematic_budget()
+    tasks = [asyncio.ensure_future(_one(sid, src, lit)) for sid, src, lit in pairs]
+    if budget <= 0:
+        return await asyncio.gather(*tasks)
+
+    done, pending = await asyncio.wait(tasks, timeout=budget)
+    if pending:
+        logger.warning(
+            "Cinematic pass hit its %.0fs budget with %d/%d segment(s) unfinished "
+            "— falling back to the literal translation for those (slow LLM "
+            "provider?). Raise OMNIVOICE_CINEMATIC_BUDGET_S or pick a faster "
+            "provider.", budget, len(pending), len(tasks),
+        )
+    out: list[dict] = []
+    for task, (sid, _src, lit) in zip(tasks, pairs):
+        if task in done and not task.cancelled():
+            try:
+                out.append(task.result())
+                continue
+            except Exception as e:  # noqa: BLE001 — never let one seg sink the pass
+                logger.warning("cinematic segment %s failed: %s", sid, e)
+        else:
+            task.cancel()  # stop awaiting; the executor thread is abandoned (#730 pattern)
+        out.append({"id": sid, "text": lit, "literal": lit, "critique": "",
+                    "error": "cinematic-budget"})
+    return out

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -113,3 +113,58 @@ def test_cinematic_reflect_failure_returns_literal(monkeypatch):
     assert res["text"] == "Hola"
     assert res["literal"] == "Hola"
     assert "reflect" in res.get("error", "")
+
+
+# ── Cinematic pass wall-clock budget (#stall follow-up) ────────────────────
+
+def test_cinematic_budget_degrades_slow_segments_to_literal(monkeypatch):
+    """A slow LLM must not hang the translate: the pass returns within the
+    budget and unfinished segments fall back to their literal translation."""
+    import asyncio
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    monkeypatch.setenv("OMNIVOICE_CINEMATIC_BUDGET_S", "0.3")
+
+    def _slow(src, lit, **kw):
+        time.sleep(3.0)  # far over the 0.3s budget
+        return {"text": "REFINED", "literal": lit, "critique": ""}
+
+    monkeypatch.setattr(tr, "cinematic_refine_sync", _slow)
+    pairs = [("s1", "hi", "hola"), ("s2", "world", "mundo")]
+
+    async def _run():
+        ex = ThreadPoolExecutor(max_workers=4)
+        t0 = time.time()
+        out = await tr.cinematic_refine_many(
+            pairs, source_lang="en", target_lang="es", executor=ex,
+        )
+        return time.time() - t0, out
+
+    dt, out = asyncio.run(_run())
+    assert dt < 2.0, f"budget did not bound the pass (took {dt:.1f}s)"
+    assert [r["id"] for r in out] == ["s1", "s2"]      # order + length preserved
+    for r in out:
+        assert r["text"] == r["literal"]                # degraded to literal
+        assert r.get("error") == "cinematic-budget"
+
+
+def test_cinematic_budget_disabled_runs_to_completion(monkeypatch):
+    """Budget <= 0 disables the bound — every segment gets its refine."""
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    monkeypatch.setenv("OMNIVOICE_CINEMATIC_BUDGET_S", "0")
+    monkeypatch.setattr(
+        tr, "cinematic_refine_sync",
+        lambda src, lit, **kw: {"text": f"R:{lit}", "literal": lit, "critique": ""},
+    )
+
+    async def _run():
+        return await tr.cinematic_refine_many(
+            [("s1", "hi", "hola")], source_lang="en", target_lang="es",
+            executor=ThreadPoolExecutor(max_workers=2),
+        )
+
+    out = asyncio.run(_run())
+    assert out[0]["text"] == "R:hola" and "error" not in out[0]


### PR DESCRIPTION
## What

Bounds the whole Cinematic/Autofit translate pass with an overall wall-clock budget so a slow or rate-limited LLM provider can no longer hang the **"Translating…"** spinner indefinitely.

This is the follow-up to the LLM-wiring fix (the translate was stalling because the cinematic pass had **no ceiling on the whole pass** — only a per-call 45s timeout and bounded concurrency, which on a large dub still lets segments queue for minutes).

## How

- New `_cinematic_budget()` reads `OMNIVOICE_CINEMATIC_BUDGET_S` (default **180s**, `<=0` disables the bound).
- `cinematic_refine_many` now runs segments via `asyncio.wait(tasks, timeout=budget)`:
  - segments that finish in time keep their full cinematic refine;
  - any still in-flight when the budget hits is cancelled and **degrades to its literal (Fast) translation** (`error="cinematic-budget"`), so the translate **always returns** within the budget instead of hanging.
- Result **order and length are preserved** (one entry per input pair).
- Abandoned executor threads follow the same fire-and-forget pattern as the GPU-pool wedge guard (#730) — Python can't kill a wedged thread, so we stop awaiting and let it drain.

## Tests

`tests/test_translator.py`:
- `test_cinematic_budget_degrades_slow_segments_to_literal` — a 3s-per-segment refine under a 0.3s budget returns in <2s with every segment degraded to its literal (**fails before** this change: would take the full 3s×N).
- `test_cinematic_budget_disabled_runs_to_completion` — `budget<=0` runs every segment to completion.

```
8 passed in 0.33s
```

## Notes

- Fully backward-compatible; no schema, no API surface change. Default behavior identical on macOS/Windows/Linux (pure asyncio).
- `main` stays pinned at v0.3.8 — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a wall-clock budget to the cinematic/autofit translate pass so slow or rate-limited LLM calls can’t leave the “Translating…” state hanging indefinitely.

```mermaid
flowchart TD
  A[Start cinematic refine many] --> B[Read OMNIVOICE_CINEMATIC_BUDGET_S]
  B --> C{budget > 0?}
  C -- no --> D[Await all segment tasks to completion]
  C -- yes --> E[Wait for tasks up to budget]
  E --> F[Collect completed refinements]
  E --> G[Cancel unfinished waits]
  G --> H[Fallback to literal translation]
  H --> I[Mark error=cinematic-budget]
  F --> J[Return ordered results, one per input]
  I --> J
  D --> J
```

Also added tests covering:
- budgeted cinematic refine falling back quickly to literal translations,
- budget disabled so all segments can finish normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->