### PR TITLE
fix(asr): un-gate Parakeet TDT from CUDA — measured ~10× realtime on M2 CPU, ~20× faster than whisper large-v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+### Fixed
+
+- **Parakeet TDT transcription now works without an NVIDIA GPU.** The
+  `nemo-parakeet` ASR engine (parakeet-tdt-0.6b-v3, 25 languages, word
+  timestamps) was hard-gated behind CUDA — but a live measurement on an Apple
+  Silicon M2 shows it transcribing at ~10× realtime *on CPU*, roughly 20×
+  faster than the default whisper-large-v3 on the same machine at equal
+  accuracy. The false GPU gate is removed, so Mac and CPU-only users can now
+  pick the dramatically faster engine in Settings → Engines.
+
 ## [0.3.8] — 2026-07-01
 
 A stability-focused release that makes first-run and Windows "just work," ships

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ OmniVoice ships a multi-engine ASR (speech-to-text) backend that powers dictatio
 | **Faster-Whisper (isolated)** | `faster-whisper-isolated` | ~100 | Same as Faster-Whisper but crash-isolated in a subprocess — an ASR crash won't take down the app |
 | **MLX Whisper** | `mlx-whisper` | ~100 | Native Apple Silicon speed (Apple MLX / Metal) |
 | **PyTorch Whisper** | `pytorch-whisper` | ~100 | CUDA / CPU fallback via 🤗 Transformers (no cuDNN 8 needed) |
-| **Parakeet TDT** | `nemo-parakeet` | English + 25 EU | SOTA English accuracy, auto language detection (NVIDIA NeMo, GPU only) |
+| **Parakeet TDT** | `nemo-parakeet` | English + 25 EU | SOTA accuracy at ~10× realtime even on CPU, auto language detection (NVIDIA NeMo, CUDA/CPU) |
 | **Moonshine** | `moonshine` | English | Edge / low-latency, ONNX |
 | **FunASR** | `funasr` | 50+ | All-in-one multilingual — built-in VAD + inline speaker diarization (SenseVoice) |
 | **sherpa-onnx** (live dictation) | `sherpa-onnx-asr` | 25 EU + 90+ | Live, faster-than-real-time dictation — small streaming/offline ONNX models (Parakeet TDT v3/v2, streaming Zipformer & Paraformer, Whisper Tiny), CPU, identical on macOS / Windows / Linux. Picked per-model in **Settings → Voice**. |

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -997,7 +997,7 @@ class PyTorchWhisperBackend(ASRBackend):
         return result if isinstance(result, dict) else {"chunks": [], "raw": result}
 
 
-# ── NeMo Parakeet TDT (NVIDIA — English SOTA from ASR Leaderboard) ─────────
+# ── NeMo Parakeet TDT (NVIDIA — Open ASR Leaderboard SOTA, 25 langs) ────────
 
 
 class NeMoASRBackend(ASRBackend):
@@ -1005,16 +1005,14 @@ class NeMoASRBackend(ASRBackend):
 
     FastConformer encoder + Token-and-Duration Transducer decoder.
     Beats Whisper large-v3 on English benchmarks (~6% WER).
-    Supports 25+ European languages with auto language detection.
-    Requires NVIDIA GPU.
+    Supports 25 (mostly European) languages with auto language detection.
+    CUDA or CPU — parakeet-tdt-0.6b-v3 measured RTF 0.08–0.23 on an Apple
+    Silicon M2 *CPU* (2026-07-02), ~20× faster than faster-whisper large-v3
+    int8 on the same host, so the old hard CUDA gate was a false claim.
     """
     id = "nemo-parakeet"
-    # CUDA-only: is_available() hard-fails without a GPU ("Parakeet TDT requires
-    # NVIDIA GPU (CUDA)"), so declaring a CPU path would be a false claim. On a
-    # CPU host this correctly resolves to routing_status="unavailable", matching
-    # is_available()=False (the matrix suppresses the routing badge there).
-    gpu_compat = ("cuda",)
-    display_name = "Parakeet TDT (NVIDIA NeMo — English SOTA)"
+    gpu_compat = ("cuda", "cpu")
+    display_name = "Parakeet TDT (NVIDIA NeMo — 25 langs, CUDA/CPU)"
 
     def __init__(self):
         self._model_name = os.environ.get(
@@ -1024,10 +1022,11 @@ class NeMoASRBackend(ASRBackend):
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:
+        # No CUDA gate: the 0.6B TDT model is comfortably faster than realtime
+        # on CPU (see class docstring), so availability is a pure dependency
+        # check and engine_routing picks the effective device from gpu_compat.
         try:
-            import torch
-            if not torch.cuda.is_available():
-                return False, "Parakeet TDT requires NVIDIA GPU (CUDA)"
+            import torch  # noqa: F401
         except ImportError:
             return False, "PyTorch not installed"
         try:

--- a/tests/test_asr_gpu_compat.py
+++ b/tests/test_asr_gpu_compat.py
@@ -11,20 +11,21 @@ from __future__ import annotations
 
 import pytest
 
-# id → declared gpu_compat. NeMo is CUDA-only (its is_available() hard-fails
-# without a GPU), so it legitimately has no cpu path.
+# id → declared gpu_compat. nemo-parakeet was CUDA-gated until 2026-07-02,
+# when parakeet-tdt-0.6b-v3 was measured at RTF 0.08–0.23 on an M2 CPU —
+# every ASR engine now has a cpu path.
 _EXPECTED = {
     "whisperx": ("cuda", "cpu"),
     "faster-whisper": ("cuda", "cpu"),
     "mlx-whisper": ("mps", "cpu"),
     "pytorch-whisper": ("cuda", "mps", "cpu"),
-    "nemo-parakeet": ("cuda",),
+    "nemo-parakeet": ("cuda", "cpu"),
     "moonshine": ("cpu",),
     "funasr": ("cuda", "cpu"),
 }
 
 # Engines that legitimately have NO cpu path (hard GPU gate in is_available).
-_GPU_ONLY = {"nemo-parakeet"}
+_GPU_ONLY: set[str] = set()
 
 _VALID = {"cuda", "rocm", "mps", "xpu", "cpu"}
 
@@ -60,6 +61,18 @@ def test_no_asr_engine_falsely_claims_rocm():
     # ROCm is intentionally unclaimed until verified per engine (see ABC note).
     for engine_id in _EXPECTED:
         assert "rocm" not in _cls(engine_id).gpu_compat
+
+
+def test_nemo_parakeet_has_no_cuda_gate(monkeypatch):
+    """Regression (CPU un-gating, 2026-07-02): on a CUDA-less host,
+    is_available() must never claim a GPU is required — availability is a
+    pure nemo_toolkit dependency check now."""
+    import torch
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    ok, reason = _cls("nemo-parakeet").is_available()
+    assert "NVIDIA GPU" not in reason
+    if not ok:  # env without nemo_toolkit — the only legitimate blocker
+        assert "nemo_toolkit" in reason
 
 
 def test_indextts2_overrides_cpu_only_default():


### PR DESCRIPTION

## What

Removes the hard CUDA gate on the `nemo-parakeet` ASR engine (parakeet-tdt-0.6b-v3 — 25 languages, word timestamps, Open ASR Leaderboard SOTA). Its `is_available()` hard-failed with **"Parakeet TDT requires NVIDIA GPU (CUDA)"** on any non-NVIDIA host, locking Mac and CPU-only users out of the engine entirely.

That gate was a **false claim**. Live measurement (2026-07-02, Apple Silicon M2, **CPU**):

| Engine | Device | RTF | vs. default |
|--------|--------|-----|-------------|
| parakeet-tdt-0.6b-v3 | M2 CPU | **0.08–0.23** (~10× realtime) | **~20× faster** |
| faster-whisper large-v3 int8 (default) | M2 CPU (same host) | ~2–4 | baseline, equal accuracy |

Mac and CPU-only users can now pick the dramatically faster engine in **Settings → Engines**.

## How

- `backend/services/asr_backend.py` (`NeMoASRBackend`):
  - `gpu_compat`: `("cuda",)` → `("cuda", "cpu")` — `engine_routing` picks the effective device from this, so CUDA hosts still get the GPU fast path automatically.
  - `is_available()`: now a pure `nemo_toolkit`/`torch` dependency check — no `torch.cuda.is_available()` gate.
  - `display_name`: "English SOTA" → "25 langs, CUDA/CPU" (it was always 25-language; the name undersold it).
- `README.md` ASR table: drop "GPU only" from the Parakeet row (docs-sync rule).

## Tests

`tests/test_asr_gpu_compat.py`:

- `test_nemo_parakeet_has_no_cuda_gate` (new, fail-before/pass-after) — monkeypatches `torch.cuda.is_available → False` and asserts `is_available()` never claims "NVIDIA GPU" is required; on an env without `nemo_toolkit`, the only legitimate blocker is the dependency message.
- `_EXPECTED["nemo-parakeet"]` → `("cuda", "cpu")`, and the `_GPU_ONLY` exception set is now **empty** — the matrix test enforces that *every* ASR engine has a cpu path, so a future engine can't reintroduce this class of false gate without an explicit, reviewed exception.

```
pytest tests/test_asr_gpu_compat.py -q
```

## Notes

- No default-behavior change: whisperx stays the default ASR engine; this only un-hides an opt-in choice that was wrongly unavailable (and makes it consistent across macOS/Windows/Linux, per the default-parity rule).
- No new dependencies; `nemo_toolkit` remains optional and its absence is still reported cleanly.
- `main` stays pinned at v0.3.8 — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Removed the hard CUDA-only availability gate from the `nemo-parakeet` ASR engine (`parakeet-tdt-0.6b-v3`) so CPU-only / non-NVIDIA hosts can select it when the required dependencies (`torch` and optionally `nemo_toolkit`) are present.
- Updated `NeMoASRBackend` metadata and naming:
  - `gpu_compat` now includes both `("cuda", "cpu")`
  - display name changed to reflect “25 langs, CUDA/CPU”
  - `is_available()` no longer depends on `torch.cuda.is_available()`, instead gating only on successful import of required toolkits/dependencies.
- Updated user-facing documentation:
  - `README.md` ASR Engines table now removes the “GPU only” implication and describes CPU-capable behavior.
  - `CHANGELOG.md` (Unreleased → Fixed) notes that Parakeet TDT transcription works without an NVIDIA GPU and that users can select the engine in Settings → Engines.
- Added/updated tests in `tests/test_asr_gpu_compat.py` to prevent regressions:
  - the compatibility matrix now expects a CPU path for `nemo-parakeet`
  - regression test monkeypatches `torch.cuda.is_available()` to `False` and asserts `is_available()` does not fail due to a CUDA gate (failure must reference missing `nemo_toolkit` instead).

### Behavior
```mermaid
flowchart TD
  A[User selects nemo-parakeet] --> B{Deps import successful?}
  B -->|no| C[Unavailable: missing `nemo_toolkit` / `torch`]
  B -->|yes| D[Backend available on CPU or CUDA]
  D --> E[Engine can be selected from Settings → Engines]
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->