### PR TITLE
fix(desktop): always open maximized (not fullscreen) — stop window-state restoring stale geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Changed
+
+- **The app now always opens maximized (not fullscreen).** Window size and
+  position are no longer carried over from the previous session — one manual
+  resize used to make every later launch reopen at that smaller size,
+  overriding the intended maximized default. Same behavior on macOS
+  (zoomed window, not a fullscreen Space), Windows, and Linux.
+
 ### Fixed
 
 - **Confucius4-TTS is now validated end-to-end — and actually loads.** The

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -274,10 +274,14 @@ pub fn run() {
             // launch if the user happened to be dictating when they quit,
             // overriding the WebviewWindowBuilder `.visible(false)` below.
             // Symptom: pill appears on app load with no shortcut press.
-            // The main window is fine to persist (size/position are useful).
+            // "main" is denylisted too (owner decision, 2026-07-02): the app
+            // must ALWAYS open maximized — not fullscreen — per
+            // tauri.conf.json (`maximized: true`, `fullscreen: false`).
+            // Persisting geometry meant one manual resize made every later
+            // launch reopen at that smaller size, overriding the config.
             app.handle().plugin(
                 tauri_plugin_window_state::Builder::default()
-                    .with_denylist(&["widget"])
+                    .with_denylist(&["widget", "main"])
                     .build(),
             )?;
             app.handle().plugin(

--- a/tests/test_window_launch_state.py
+++ b/tests/test_window_launch_state.py
@@ -1,0 +1,42 @@
+"""Launch-window contract (owner decision, 2026-07-02): the app must ALWAYS
+open maximized — never fullscreen — on every platform.
+
+Two halves enforce it, and both must hold:
+  1. tauri.conf.json declares `maximized: true` + `fullscreen: false`.
+  2. lib.rs denylists BOTH "widget" and "main" in tauri-plugin-window-state —
+     otherwise restored geometry silently overrides the config, and one manual
+     resize makes every later launch reopen at that smaller size.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_CONF = _ROOT / "frontend" / "src-tauri" / "tauri.conf.json"
+_LIB = _ROOT / "frontend" / "src-tauri" / "src" / "lib.rs"
+
+
+def _main_window() -> dict:
+    windows = json.loads(_CONF.read_text())["app"]["windows"]
+    mains = [w for w in windows if w.get("label", "main") == "main"]
+    assert len(mains) == 1, f"expected exactly one main window, got {len(mains)}"
+    return mains[0]
+
+
+def test_main_window_opens_maximized_not_fullscreen():
+    win = _main_window()
+    assert win.get("maximized") is True
+    assert win.get("fullscreen") is False
+
+
+def test_window_state_plugin_denylists_main_and_widget():
+    src = _LIB.read_text()
+    m = re.search(r"with_denylist\(&\[(?P<labels>[^\]]*)\]\)", src)
+    assert m, "tauri-plugin-window-state denylist not found in lib.rs"
+    labels = set(re.findall(r'"([^"]+)"', m.group("labels")))
+    assert {"main", "widget"} <= labels, (
+        f"window-state denylist must include main+widget, got {labels} — "
+        "without 'main', restored geometry overrides maximized-on-open"
+    )


### PR DESCRIPTION
## What

The main window is now denylisted in `tauri-plugin-window-state` (alongside the existing `widget` entry), so every launch honors `tauri.conf.json`'s `maximized: true` + `fullscreen: false` instead of restoring the previous session's geometry.

## Why

The config has always declared maximized-on-open, but the window-state plugin restored whatever size the window was last closed at — one manual resize meant every subsequent launch reopened at that smaller size. Owner request: the app must always open maximized, never fullscreen (on macOS that's a zoomed window, not a fullscreen Space — identical default behavior on all three platforms per the parity rule).

## Tests

- New `tests/test_window_launch_state.py` pins both halves of the contract: the conf declares `maximized: true`/`fullscreen: false`, and the lib.rs denylist includes both `main` and `widget` (fails if either regresses).
- `cargo check` clean; 8/8 window/version tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated desktop launch behavior so the main window now opens maximized, not fullscreen, and no longer restores stale saved geometry from prior sessions.

```mermaid
flowchart TD
  A[App startup] --> B[Tauri reads tauri.conf.json]
  B --> C[main window config: maximized=true, fullscreen=false]
  B --> D[window-state plugin denylist]
  D --> E[Skip restoring saved geometry for main + widget]
  C --> F[Main window opens maximized]
  E --> F
```

```ascii
Before: saved geometry could override launch
+-------------------------+
|        window           |
|   resized / restored    |
+-------------------------+

After: launch follows config
+-------------------------+
|      maximized app      |
|                         |
+-------------------------+
```

Also:
- Expanded `tauri-plugin-window-state` denylist to include `main` alongside `widget`
- Added a test that checks both the Tauri config values and the denylist entries
- Updated changelog to document the new launch behavior across macOS, Windows, and Linux

<!-- end of auto-generated comment: release notes by coderabbit.ai -->