### PR TITLE
fix(shell): LogsFooter becomes a real grid row — bottom content can't clip under it at small window sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- **Buttons can no longer hide under the logs footer on small windows.** The
+  bottom status/logs bar was a fixed overlay that pages had to compensate for
+  with padding — any view that missed it (voice-card grids in Gallery and
+  Community, bottom action rows) clipped under the bar at small window sizes,
+  a class previously patched one page at a time (#476, #504). The footer is
+  now a real row of the app shell, so content physically ends at its top edge
+  at every window size, collapsed or expanded — guarded by a new layout test
+  plus a 900×600 Playwright check at the app's minimum window size.
+
 - **Confucius4-TTS is now validated end-to-end — and actually loads.** The
   opt-in engine's first live run (Apple Silicon, CPU) caught three
   scaffold-era faults: the sidecar could never import `confuciustts` (upstream

--- a/frontend/e2e/footer-clipping.spec.ts
+++ b/frontend/e2e/footer-clipping.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { gotoMode } from './_helpers';
+
+/**
+ * Footer-clipping guard — "buttons hidden under the footer on small windows"
+ * (owner report 2026-07-02; same class as #476/#504).
+ *
+ * The LogsFooter is a grid row of .app-container (see index.css), so page
+ * content must physically end at the footer's top edge — no card, button, or
+ * action bar may render underneath it. Verified at the app's minimum window
+ * size (tauri.conf.json minWidth 900 × minHeight 600), where the old fixed
+ * overlay + padding reservation clipped the bottom card row.
+ */
+
+const MIN_WINDOW = { width: 900, height: 600 };
+
+async function footerTop(page): Promise<number> {
+  const footer = page.locator('.app-container .logs-footer');
+  await expect(footer).toBeVisible();
+  const box = await footer.boundingBox();
+  expect(box).not.toBeNull();
+  return box!.y;
+}
+
+test.describe('LogsFooter never covers page content @ 900x600', () => {
+  test.use({ viewport: MIN_WINDOW });
+
+  test('gallery: bottom-most voice card stays above the collapsed footer', async ({ page }) => {
+    await gotoMode(page, 'gallery');
+    const cards = page.locator('.archetype-card');
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 });
+
+    const top = await footerTop(page);
+    // Scroll the last card into view — with the footer in the grid flow the
+    // scroll container ends at the footer's top, so the card must fit fully
+    // above it once scrolled.
+    const last = cards.last();
+    await last.scrollIntoViewIfNeeded();
+    const box = await last.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(top + 1); // 1px AA tolerance
+  });
+
+  test('expanded footer still cannot cover content — scroll container shrinks instead', async ({
+    page,
+  }) => {
+    await gotoMode(page, 'gallery');
+    const cards = page.locator('.archetype-card');
+    await expect(cards.first()).toBeVisible({ timeout: 20_000 });
+
+    // Expand the logs panel (chevron toggle in the collapsed bar).
+    const toggle = page.locator('.logs-footer [title], .logs-footer button').first();
+    await toggle.click();
+    await expect(page.locator('.logs-footer--open')).toBeVisible();
+
+    const top = await footerTop(page);
+    const last = cards.last();
+    await last.scrollIntoViewIfNeeded();
+    const box = await last.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.y + box!.height).toBeLessThanOrEqual(top + 1);
+  });
+});

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -226,10 +226,11 @@ export default function LogsFooter() {
   useEffect(() => localStorage.setItem(LS_HEIGHT, String(height)), [height]);
   useEffect(() => localStorage.setItem(LS_ACTIVE, active), [active]);
 
-  // Expose the current footer height as a CSS variable on :root so the
-  // studio's .app-container grid + the setup-wizard wrapper both shrink
-  // by exactly the right amount. Keeps sidebar + main content out from
-  // under the expanded panel without any JS-driven layout math.
+  // Expose the current footer height as a CSS variable on :root. Inside the
+  // studio shell the footer is a grid ROW (index.css .app-container), so
+  // content clearance needs no variable — but the fixed toasts/previews that
+  // anchor above the footer (VoicePreview, ExportModal, …) and the
+  // setup-wizard wrapper still position off --logs-footer-height.
   useEffect(() => {
     const h = collapsed ? 28 : height;
     document.documentElement.style.setProperty('--logs-footer-height', `${h}px`);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -694,16 +694,16 @@ samp,
   display: grid;
   /* [rail 48px] [sidebar 180–220] [main 1fr] */
   grid-template-columns: 48px minmax(180px, 220px) minmax(0, 4fr);
-  grid-template-rows: auto 1fr;
+  /* Rows: [header] [content 1fr] [LogsFooter]. The footer is a REAL grid row
+     (not a fixed overlay): content in row 2 physically ends at the footer's
+     top edge, so bottom buttons can never render underneath it — at any
+     window height, collapsed or expanded. This retires the whole
+     padding-bottom/--logs-footer-height reservation class of clipping bugs
+     (#476, #504, and the small-window "buttons hidden under footer" report).
+     The nav rail spans rows 2/-1 so it still runs top-to-bottom beside the
+     footer, exactly like the old fixed-inset look. */
+  grid-template-rows: auto 1fr auto;
   gap: 0px;
-  /* Shrink the studio grid by the LogsFooter's current height so its
-     sidebar + main column always stop exactly at the footer's top edge.
-     The footer itself (position:fixed) writes `--logs-footer-height` on
-     :root whenever it toggles collapsed/expanded or the user resizes. */
-  /* Full window height: the nav rail must run top-to-bottom regardless of the
-     footer's state. Content columns (not the grid) yield to the fixed footer
-     via padding-bottom below, so expanding the logs panel never compresses
-     the side menubar. */
   overflow: hidden;
   transition: grid-template-columns var(--transition-smooth);
 }
@@ -717,14 +717,11 @@ html[data-zoom-layout='off'] .app-container {
   height: 100vh;
   zoom: 1;
 }
-/* Keep scrollable content clear of the fixed footer. The footer writes its
-   current height (pre-zoom px — same coordinate space as these children) to
-   --logs-footer-height whenever it collapses/expands/resizes. */
-.app-container > .main-content,
-.app-container > .history-panel {
-  padding-bottom: var(--logs-footer-height, 28px);
-  box-sizing: border-box;
-}
+/* No padding-bottom footer reservation here anymore: the LogsFooter occupies
+   grid row 3 (see grid-template-rows above), so row-2 content stops at its
+   top edge by construction. The footer still writes --logs-footer-height for
+   the fixed toasts/previews that anchor above it (VoicePreview, ExportModal,
+   etc.). */
 .app-container.sidebar-collapsed {
   grid-template-columns: 48px 46px minmax(0, 4fr);
 }
@@ -759,7 +756,9 @@ html[data-zoom-layout='off'] .app-container {
 .app-container.rail-right.sidebar-collapsed > .history-panel { grid-column: 1; }
 .app-container > .nav-rail {
   grid-column: 1;
-  grid-row: 2;
+  /* Span the footer row too: the rail runs top-to-bottom beside the footer
+     (same look as the old fixed-footer 48px inset). */
+  grid-row: 2 / -1;
 }
 .app-container > .history-panel {
   grid-column: 2;
@@ -2749,24 +2748,26 @@ input[type="file"]::file-selector-button:hover {
   user-select: none;
 }
 
-/* The footer sits *beside* the nav rail (a 48px grid column of .app-container),
-   never under or over it. Splash/wizard footers render outside .app-container
-   and stay full-width. */
+/* Inside the shell the footer is a GRID ITEM (row 3), not a fixed overlay —
+   content in row 2 physically cannot render underneath it (the fix for
+   "buttons hidden under the footer on small windows"; class previously
+   band-aided per-page in #476/#504). The base `position: fixed` above still
+   applies to the splash/wizard footers, which render outside .app-container
+   and stay full-width. It sits *beside* the nav rail (rail spans rows 2/-1). */
 .app-container .logs-footer {
-  left: 48px;
-  right: 0;
+  position: static;
+  grid-row: 3;
+  grid-column: 2 / -1;
 }
 .app-container.rail-right .logs-footer {
-  left: 0;
-  right: 48px;
+  grid-column: 1 / -2;
 }
-/* ≤600px the nav rail is hidden — footer reclaims the full width. */
-@media (max-width: 600px) {
-  .app-container .logs-footer,
-  .app-container.rail-right .logs-footer {
-    left: 0;
-    right: 0;
-  }
+/* shell-mini: the nav rail is hidden — footer reclaims the full width.
+   (Class-driven like the other shell-* rules, so it tracks the EFFECTIVE
+   scaled width rather than a raw @media viewport width.) */
+.app-container.shell-mini .logs-footer,
+.app-container.shell-mini.rail-right .logs-footer {
+  grid-column: 1 / -1;
 }
 
 /* (b) Collapsed/open height ----------------------------------------------- */

--- a/frontend/src/test/logsFooterInFlow.test.js
+++ b/frontend/src/test/logsFooterInFlow.test.js
@@ -1,0 +1,51 @@
+// LogsFooter in-flow guard — "buttons hidden under the footer on small
+// windows" (owner report, 2026-07-02; same clipping class as #476/#504).
+//
+// The footer must be a real grid row of .app-container (rows: auto 1fr auto),
+// NOT a fixed overlay compensated by padding-bottom on .main-content. A fixed
+// overlay + padding reservation lets any nested page scroller that misses the
+// padding (or any absolutely-positioned bottom bar) slide underneath the
+// footer at small window heights. As a grid row, row-2 content physically
+// ends at the footer's top edge — clipping is impossible by construction.
+//
+// Static CSS-string assertions, same style as appShellScale.test.js (jsdom
+// does no layout; the real 900x600 geometry check lives in
+// e2e/footer-clipping.spec.ts).
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(resolve(__dirname, '../index.css'), 'utf8');
+
+const appContainerBlock = css.match(/\.app-container\s*\{[^}]*\}/s)?.[0] ?? '';
+const footerInShellBlock = css.match(/\.app-container \.logs-footer\s*\{[^}]*\}/s)?.[0] ?? '';
+
+describe('LogsFooter is in the shell grid flow (not a fixed overlay)', () => {
+  it('shell grid reserves a third row for the footer', () => {
+    expect(appContainerBlock).toMatch(/grid-template-rows:\s*auto\s+1fr\s+auto/);
+  });
+
+  it('footer inside .app-container is a static grid item in row 3', () => {
+    expect(footerInShellBlock).toMatch(/position:\s*static/);
+    expect(footerInShellBlock).toMatch(/grid-row:\s*3/);
+  });
+
+  it('the padding-bottom footer reservation on .main-content is gone', () => {
+    // The old mechanism this fix retires — its return would reintroduce the
+    // overlay-clipping class.
+    expect(css).not.toMatch(
+      /\.app-container\s*>\s*\.main-content[^{]*\{[^}]*padding-bottom:\s*var\(--logs-footer-height/s,
+    );
+  });
+
+  it('shell-mini gives the footer the full grid width (rail hidden)', () => {
+    expect(css).toMatch(
+      /\.app-container\.shell-mini \.logs-footer[^{]*\{[^}]*grid-column:\s*1\s*\/\s*-1/s,
+    );
+  });
+
+  it('base .logs-footer stays fixed for splash/wizard (outside the shell)', () => {
+    const base = css.match(/(^|\n)\.logs-footer\s*\{[^}]*\}/s)?.[0] ?? '';
+    expect(base).toMatch(/position:\s*fixed/);
+  });
+});


### PR DESCRIPTION
## What

The logs footer is no longer a `position: fixed` overlay inside the studio shell. `.app-container` now has a third grid row (`auto 1fr auto`) that the footer occupies; the nav rail spans rows 2/-1 so it still runs top-to-bottom beside it (same visual). The `padding-bottom: var(--logs-footer-height)` reservation on `.main-content`/`.history-panel` is deleted — content in row 2 physically ends at the footer's top edge, at any window height, collapsed or expanded. The ≤600px `@media` full-width footer rule is replaced by a `shell-mini` class rule (tracks the *effective* scaled width, consistent with the other shell-* rules).

Splash/wizard footers (rendered outside `.app-container`) keep the fixed full-width behavior. `--logs-footer-height` is still written for the fixed toasts/previews that anchor above the footer (VoicePreview, ExportModal, dub toast).

## Why

Owner report: buttons (e.g. voice-card favorites in Gallery/Community, bottom action rows) hide under the footer on small windows. Root cause is structural: a fixed overlay compensated only by padding on two direct children means any nested page scroller that misses the reservation (missing `min-h-0`, absolute bottom bars) slides underneath. This class was previously patched one page at a time — #504 (bottom CTA clipping), #476 (`.studio-action-bar` went sticky). In the grid flow, the whole class is impossible by construction, for every current and future page.

## Tests

- `src/test/logsFooterInFlow.test.js` (5 assertions, house static-CSS-guard style): 3-row grid, footer static in row 3, padding reservation absent, shell-mini full-width, base fixed retained for wizard/splash.
- `e2e/footer-clipping.spec.ts`: real-geometry guard at 900×600 (the app's `minWidth`/`minHeight`) — bottom-most gallery card must sit fully above the footer, collapsed *and* expanded. (E2E is owner-run like the rest of `e2e/`; CI runs vitest only.)
- Full frontend suite: 669/669 passed (incl. the #504/#476 regression guards `appShellScale.test.js` + `workspaceHistoryReflow.test.js`). `oxfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Reworked the studio shell so `LogsFooter` is part of the app grid instead of a fixed overlay.
- Removed footer-reservation bottom padding from scroll/content areas, preventing content from sliding under the footer on small windows.
- Updated small-screen full-width footer behavior to use `.shell-mini` grid rules.
- Added static CSS tests and a Playwright check for footer clipping at minimum app size.
- Clarified the `--logs-footer-height` comment for shell consumers.

## Layout sketch

Before
```text
+------------------------------+
|            nav rail          |
|------------------------------|
|         main content         |
|         (scrolls under)      |
+------------------------------+
|     fixed logs footer        |
+------------------------------+
```

After
```text
+------------------------------+
|            nav rail          |
|------------------------------|
|         main content         |
|------------------------------|
|         logs footer          |
+------------------------------+
```

## Behavior flow
```mermaid
flowchart TD
  A[Render app shell] --> B{Inside .app-container?}
  B -->|Yes| C[Use grid rows: auto 1fr auto]
  C --> D[Place LogsFooter in row 3]
  D --> E[Main content ends above footer]
  B -->|No| F[Keep fixed footer behavior]
  F --> G[Splash / wizard use full-width fixed footer]
</mermaid>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->