### PR TITLE
fix(desktop): enforce maximize() at startup — macOS can ignore the conf flag (#881 follow-up)

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -596,6 +596,17 @@ pub fn run() {
                 if let Some(win) = app.get_webview_window("widget") {
                     let _ = win.hide();
                 }
+                // Enforce the always-open-maximized contract (#881) at
+                // runtime: macOS can ignore `maximized: true` from
+                // tauri.conf.json at window creation when combined with the
+                // Overlay title-bar style, so the config flag alone isn't
+                // reliable. maximize() zooms the window — it never enters a
+                // fullscreen Space. Guarded by tests/test_window_launch_state.py.
+                if let Some(main_win) = app.get_webview_window("main") {
+                    if !main_win.is_maximized().unwrap_or(false) {
+                        let _ = main_win.maximize();
+                    }
+                }
             }
 
             // ── WebView media-capture permissions (mic for dictation) ────

--- a/tests/test_window_launch_state.py
+++ b/tests/test_window_launch_state.py
@@ -31,6 +31,16 @@ def test_main_window_opens_maximized_not_fullscreen():
     assert win.get("fullscreen") is False
 
 
+def test_startup_enforces_maximize_in_rust():
+    """The conf flag alone isn't reliable: macOS can ignore `maximized: true`
+    at window creation with the Overlay title-bar style. lib.rs must enforce
+    maximize() on the main window during setup (studio mode)."""
+    src = _LIB.read_text()
+    assert re.search(
+        r'get_webview_window\("main"\)[\s\S]{0,600}\.maximize\(\)', src
+    ), "lib.rs must call .maximize() on the main window during setup"
+
+
 def test_window_state_plugin_denylists_main_and_widget():
     src = _LIB.read_text()
     m = re.search(r"with_denylist\(&\[(?P<labels>[^\]]*)\]\)", src)


### PR DESCRIPTION
## What

Belt-and-braces for the always-open-maximized contract from #881: in studio mode, `setup()` now calls `main_win.maximize()` if the window isn't already maximized.

## Why

Owner still saw a small window. Two causes: (1) no release carries #881 yet — installed v0.3.8 predates it; (2) independently, macOS can ignore `maximized: true` from tauri.conf.json at window creation when combined with `titleBarStyle: Overlay`, so the config flag alone is not a reliable mechanism. Runtime enforcement is. `maximize()` zooms the window — never a fullscreen Space.

## Tests

- `tests/test_window_launch_state.py` gains `test_startup_enforces_maximize_in_rust` (fails if the maximize() call is removed); 3/3 pass.
- `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Summary:
- Enforced studio window maximize behavior at startup in Tauri setup by checking the main window state and calling `maximize()` when needed.
- Kept the existing window-state persistence denylist intact; this adds a runtime fallback for cases where config-based maximization is ignored on launch.
- Added a regression test to ensure the Rust startup path still contains the `maximize()` call for the main window.

Behavior flow:
```mermaid
flowchart TD
  A[App startup] --> B[Create main window]
  B --> C{Already maximized?}
  C -- yes --> D[Continue startup]
  C -- no --> E[Call main_win.maximize()]
  E --> D
  D --> F[Continue WebView/media setup]
```

Window state sketch:
```text
Before startup:
+----------------------+
| Main window          |
| may open normal size |
+----------------------+

After startup:
+----------------------+
| Main window          |
| starts maximized     |
+----------------------+
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->