### PR TITLE
fix(errors): name the configured HF mirror when a model download fails (#874)

### DIFF
--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -507,12 +507,16 @@ async def install_model(req: InstallModelRequest):
             logger.info("model install failed for %s: %s", req.repo_id, e)
             import time as _time_fail
             _install_cooldowns[req.repo_id] = _time_fail.time()
+            # #874: when the install failed because the configured HF mirror is
+            # unreachable, name the mirror + the setting instead of leaking the
+            # raw connectivity error. No-op for every other failure.
+            from core.failure import append_hf_mirror_hint
             hf_progress.emit({
                 "repo_id": req.repo_id,
                 "filename": req.repo_id,
                 "downloaded": 0, "total": 0, "pct": 0.0,
                 "phase": "install_error",
-                "error": str(e),
+                "error": append_hf_mirror_hint(str(e)),
             })
         finally:
             _cancelled.discard(req.repo_id)

--- a/backend/core/error_journal.py
+++ b/backend/core/error_journal.py
@@ -76,6 +76,12 @@ _CLASS_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
         "connection refused",
         "connection reset",
         "connection aborted",
+        # transformers' download-failure wording ("We couldn't connect to
+        # '<endpoint>' to load the files") — the #874 mirror-down class was
+        # journaled as UNKNOWN without these.
+        "couldn't connect to",
+        "could not connect to",
+        "max retries exceeded",
         "timed out",
         "timeout",
         "name or service not known",

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -21,6 +21,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 from core import error_docs_map
 from core.logging_filter import REDACTED, _HF_TOKEN_RE
@@ -42,7 +43,128 @@ _HINTS: dict[str, str] = {
     "UNSUPPORTED_VIDEO_URL": "This link isn't a directly downloadable video. Paste a direct video page (e.g. a youtube.com/watch?v=… or douyin.com/video/<id> link), not a share/profile/feed link — or download the file and drop it in directly.",
     "VIDEO_DOWNLOAD_NETWORK": "The connection to the video server dropped mid-download (often a transient CDN/network blip or a regional rate-limit). Just retry — OmniVoice already cleaned up the partial download. If it keeps failing, check your network/VPN.",
     "BROKEN_VENV": "The Python backend environment was moved or damaged. OmniVoice rebuilds it automatically on the next launch; if it keeps failing, use Clean & Retry on the setup screen.",
+    # HF_MIRROR_UNREACHABLE has a DYNAMIC hint (it names the configured mirror)
+    # — see hf_mirror_hint(); build_failure special-cases it.
 }
+
+
+# ── HF mirror connectivity (#874) ────────────────────────────────────────────
+# When a non-default HF_ENDPOINT (a mirror, e.g. hf-mirror.com — set via
+# Settings → Models → Hugging Face mirror) is configured and a model
+# download/load fails with a connectivity error, the raw transformers/hf_hub
+# message ("We couldn't connect to 'https://hf-mirror.com' to load the files…")
+# gives the user no next step. This is the single classifier for that class,
+# shared by every surface: build_failure() (model status, dub/task events),
+# the global 500 handler (main.py — covers /generate and every other route
+# that can leak a model-load error), and the model-install SSE
+# (setup/download.py).
+
+_OFFICIAL_HF_ENDPOINTS = {"https://huggingface.co", "https://hf.co"}
+
+# Connectivity signatures across the layers an HF download failure surfaces
+# from: transformers' wording, huggingface_hub errors, requests/urllib3, and
+# raw socket/DNS failures (Linux/macOS/Windows variants).
+_HF_CONNECTIVITY_SIGNATURES = (
+    "couldn't connect to",             # transformers: "We couldn't connect to '<endpoint>' …"
+    "could not connect to",
+    "connection error",                # huggingface_hub / requests
+    "connection refused",
+    "connection reset",
+    "connection aborted",
+    "max retries exceeded",            # urllib3 via requests
+    "failed to establish a new connection",
+    "name or service not known",       # Linux DNS
+    "temporary failure in name resolution",
+    "nodename nor servname provided",  # macOS DNS
+    "getaddrinfo failed",              # Windows DNS
+    "timed out",
+    "an error happened while trying to locate the file on the hub",  # LocalEntryNotFoundError
+    "we cannot find the requested files",                            # LocalEntryNotFoundError
+)
+
+# The failure must also be Hugging-Face-shaped — the configured endpoint/host
+# named in the message, or HF-download wording — so a random socket error
+# (e.g. a local LLM provider being down) doesn't get the mirror hint just
+# because a mirror happens to be configured.
+_HF_CONTEXT_MARKERS = (
+    "huggingface",
+    "hf_hub",
+    "hf-hub",
+    "load the files",          # transformers
+    "cached files",            # transformers
+    "the requested files",     # LocalEntryNotFoundError
+    "locate the file on the hub",
+    "snapshot_download",
+)
+
+
+def configured_hf_mirror() -> str:
+    """The non-default Hugging Face endpoint (mirror) in effect, or "".
+
+    Same resolution the download paths use: ``HF_ENDPOINT`` env (what
+    Settings → Models → Hugging Face mirror persists via user_env, and what
+    the HF libraries read) with the ``hf_endpoint`` pref as fallback
+    (mirrors setup/download.py's ``prefs.resolve``). Never raises.
+    """
+    ep = (os.environ.get("HF_ENDPOINT") or "").strip()
+    if not ep:
+        try:
+            from core import prefs
+
+            ep = str(prefs.get("hf_endpoint", "") or "").strip()
+        except Exception:
+            ep = ""
+    ep = ep.rstrip("/")
+    if not ep or ep.lower() in _OFFICIAL_HF_ENDPOINTS:
+        return ""
+    return ep
+
+
+def hf_mirror_hint(reason: Optional[str]) -> str:
+    """Actionable hint when ``reason`` is an HF-download connectivity failure
+    and a non-default mirror endpoint is configured; "" otherwise.
+
+    The hint names the configured mirror, says it may be down, points at the
+    setting (Settings → Models → Hugging Face mirror), suggests the official
+    endpoint when the model isn't cached yet, and notes the restart
+    requirement (HF reads HF_ENDPOINT at import time — see the hf-mirror
+    endpoints in api/routers/settings.py). Never raises.
+    """
+    mirror = configured_hf_mirror()
+    if not mirror:
+        return ""
+    low = (reason or "").lower()
+    if not any(sig in low for sig in _HF_CONNECTIVITY_SIGNATURES):
+        return ""
+    try:
+        host = (urlsplit(mirror).netloc or "").lower()
+    except Exception:
+        host = ""
+    if not (
+        mirror.lower() in low
+        or (host and host in low)
+        or any(m in low for m in _HF_CONTEXT_MARKERS)
+    ):
+        return ""
+    return (
+        f"Your Hugging Face mirror is set to {mirror}, which couldn't be "
+        "reached — the mirror may be down or blocked on your network. If the "
+        'model isn\'t in your local cache yet, switch to "Hugging Face '
+        '(official)" in Settings → Models → Hugging Face mirror (or wait for '
+        "the mirror to recover), then restart OmniVoice — the mirror setting "
+        "is applied when the app starts."
+    )
+
+
+def append_hf_mirror_hint(text: str) -> str:
+    """``"{text} — {hint}"`` when the mirror-connectivity class applies;
+    ``text`` unchanged otherwise. For surfaces that hand a raw error string to
+    the UI (the global 500 handler, the model-install SSE). Never raises."""
+    try:
+        hint = hf_mirror_hint(text)
+    except Exception:
+        return text
+    return f"{text} — {hint}" if hint else text
 
 
 def classify(reason: str) -> str:
@@ -88,6 +210,13 @@ def classify(reason: str) -> str:
         "token" in low or "auth" in low or "401" in low or "unauthorized" in low
     ):
         return "HF_AUTH_FAILED"
+    # #874: a model download that failed because the CONFIGURED HF mirror is
+    # unreachable. Env-aware by design — the class only exists when a
+    # non-default HF_ENDPOINT is configured. Checked BEFORE the video-download
+    # network class so a model download's "timed out"/"connection reset"
+    # names the mirror instead of the "video server".
+    if hf_mirror_hint(reason):
+        return "HF_MIRROR_UNREACHABLE"
     # Video download (#554/#536): a non-downloadable URL shape vs a transient
     # network drop — both previously surfaced as a bare yt-dlp string with no
     # next step. UNSUPPORTED first (more specific) so "Unable to download video:
@@ -207,12 +336,15 @@ def build_failure(
 
     reason = sanitize(raw) or error_class
     docs_topic = classify(raw)
+    # HF_MIRROR_UNREACHABLE's hint is dynamic (it names the configured mirror)
+    # so it can't live in the static _HINTS table.
+    hint = hf_mirror_hint(raw) if docs_topic == "HF_MIRROR_UNREACHABLE" else _HINTS.get(docs_topic, "")
     fields: dict[str, Any] = {
         "reason": reason,
         "error": reason,  # backward-compat mirror for older frontends
         "error_class": error_class,
         "stage": stage,
-        "hint": _HINTS.get(docs_topic, ""),
+        "hint": hint,
         "docs_topic": docs_topic,
         "docs_url": error_docs_map.ERROR_DOCS.get(docs_topic, ""),
         "detail": sanitize(raw),

--- a/backend/main.py
+++ b/backend/main.py
@@ -681,8 +681,16 @@ async def global_exception_handler(request: Request, exc: Exception):
         headers["Access-Control-Allow-Origin"] = origin
         headers["Access-Control-Allow-Credentials"] = "true"
         headers["Vary"] = "Origin"
+    # #874: a model download that failed because the CONFIGURED Hugging Face
+    # mirror (HF_ENDPOINT) is unreachable used to leak the raw transformers
+    # message ("We couldn't connect to 'https://hf-mirror.com' …") as the 500
+    # detail with no next step. Appending the shared mirror hint HERE covers
+    # every route that can leak a model-load/download error (generate, dub,
+    # archetypes, …), not just TTS generate. append_hf_mirror_hint is a no-op
+    # for every other error and never raises.
+    from core.failure import append_hf_mirror_hint
     return JSONResponse(
-        {"detail": str(exc), "error_class": _entry.get("error_class")},
+        {"detail": append_hf_mirror_hint(str(exc)), "error_class": _entry.get("error_class")},
         status_code=500,
         headers=headers,
     )

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -632,6 +632,29 @@ def _hf_offline() -> bool:
     return _env_flag("HF_HUB_OFFLINE") or _env_flag("TRANSFORMERS_OFFLINE")
 
 
+# Why the LAST _repair_model_cache run failed ("" when it succeeded / hasn't
+# run). #886: the "could not be auto-repaired" message used to drop the cause
+# entirely, so a mirror outage, offline mode, or a full disk all read the same.
+_last_repair_error: str = ""
+
+
+def _repair_failure_detail() -> str:
+    """One sanitized clause naming why auto-repair failed, or "" (#886).
+
+    Feeds user-facing messages (the generate 500 detail / model status), so it
+    goes through core.failure.sanitize — and because the cause text is now part
+    of the surfaced error, the shared HF-mirror hint (#874) fires on it when
+    the repair failed against an unreachable configured mirror."""
+    if not _last_repair_error:
+        return ""
+    try:
+        from core.failure import sanitize
+        cause = sanitize(_last_repair_error)
+    except Exception:
+        cause = _last_repair_error
+    return f" Auto-repair failed with: {cause}."
+
+
 def _repair_model_cache(checkpoint: str, *, force: bool = False) -> bool:
     """Re-fetch a checkpoint's missing files in place and report success.
 
@@ -648,16 +671,22 @@ def _repair_model_cache(checkpoint: str, *, force: bool = False) -> bool:
     size won't be re-fetched by the default resume (#739). It re-downloads the
     whole snapshot, so it's the last resort the load path only reaches after a
     plain resume-repair didn't fix the cache."""
+    global _last_repair_error
+    _last_repair_error = ""
     if _hf_offline():
         logger.warning(
             "Model cache for %s is incomplete but HF offline mode is set — "
             "cannot auto-repair.", checkpoint,
+        )
+        _last_repair_error = (
+            "Hugging Face offline mode is enabled (HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE)"
         )
         return False
     try:
         from huggingface_hub import snapshot_download
     except Exception as imp_err:  # pragma: no cover - huggingface_hub is a hard dep
         logger.warning("Cannot import snapshot_download to repair cache: %s", imp_err)
+        _last_repair_error = f"{type(imp_err).__name__}: {imp_err}"
         return False
     dl_kwargs: dict = {"repo_id": checkpoint}
     endpoint = os.environ.get("HF_ENDPOINT")
@@ -710,6 +739,7 @@ def _repair_model_cache(checkpoint: str, *, force: bool = False) -> bool:
                 "Auto-repair of %s attempt %d/%d failed: %s",
                 checkpoint, attempt, retries, e,
             )
+            _last_repair_error = f"{type(e).__name__}: {e}"
             if attempt < retries and backoff:
                 time.sleep(backoff * attempt)
     return False
@@ -801,7 +831,8 @@ def _load_model_sync():
             if not _repair_model_cache(checkpoint):
                 raise RuntimeError(
                     f"The TTS model cache for {checkpoint} is incomplete "
-                    "(weights missing — usually an interrupted download). "
+                    "(weights missing — usually an interrupted download)."
+                    f"{_repair_failure_detail()} "
                     "Open Settings → Models, delete the OmniVoice TTS model, "
                     "and install it again."
                 ) from e
@@ -830,8 +861,9 @@ def _load_model_sync():
                     else:
                         raise RuntimeError(
                             f"The TTS model cache for {checkpoint} is incomplete and "
-                            "could not be auto-repaired. Open Settings → Models, "
-                            "delete the OmniVoice TTS model, and install it again."
+                            f"could not be auto-repaired.{_repair_failure_detail()} "
+                            "Open Settings → Models, delete the OmniVoice TTS model, "
+                            "and install it again."
                         ) from e2
                 else:
                     raise RuntimeError(

--- a/tests/test_hf_mirror_error_class.py
+++ b/tests/test_hf_mirror_error_class.py
@@ -1,0 +1,208 @@
+"""#874: a model download that fails because the CONFIGURED Hugging Face
+mirror (HF_ENDPOINT, Settings → Models → Hugging Face mirror) is unreachable
+must surface an actionable error that (1) names the mirror, (2) says it may be
+down, (3) points at the setting + the restart requirement (HF reads
+HF_ENDPOINT at backend start), and (4) suggests the official endpoint when the
+model isn't cached — instead of leaking the raw transformers message
+("We couldn't connect to 'https://hf-mirror.com' …") as a bare 500 detail.
+
+Fail-before/pass-after: before the fix `classify()` had no mirror class and
+`build_failure()` / `append_hf_mirror_hint()` attached no hint to these
+reasons. Also covers the #886 family: when the incomplete-cache auto-repair
+fails, the surfaced message now names WHY (so a mirror outage / offline mode /
+full disk stop reading identically).
+"""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from core import failure
+
+# The exact transformers wording from issue #874 (mirror down, model not cached).
+_TRANSFORMERS_874 = (
+    "We couldn't connect to 'https://hf-mirror.com' to load the files, and "
+    "couldn't find them in the cached files.\n"
+    "Check your internet connection or see how to run the library in offline "
+    "mode at 'https://huggingface.co/docs/transformers/installation#offline-mode'."
+)
+
+# huggingface_hub / requests shape: names the mirror HOST, not the full URL.
+_HUB_CONN_ERROR = (
+    "(MaxRetryError(\"HTTPSConnectionPool(host='hf-mirror.com', port=443): "
+    "Max retries exceeded with url: /api/models/k2-fsa/OmniVoice (Caused by "
+    "NewConnectionError('Failed to establish a new connection: "
+    "[Errno 61] Connection refused'))\"))"
+)
+
+
+@pytest.fixture
+def mirror_env(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.com")
+
+
+def test_transformers_connect_error_classifies_as_mirror(mirror_env):
+    assert failure.classify(_TRANSFORMERS_874) == "HF_MIRROR_UNREACHABLE"
+
+
+def test_hub_connection_error_classifies_by_host(mirror_env):
+    assert failure.classify(_HUB_CONN_ERROR) == "HF_MIRROR_UNREACHABLE"
+
+
+def test_hint_names_mirror_setting_restart_and_official(mirror_env):
+    evt = failure.build_failure(
+        OSError(_TRANSFORMERS_874), stage="model-load", include_diagnostic=False
+    )
+    assert evt["docs_topic"] == "HF_MIRROR_UNREACHABLE"
+    hint = evt["hint"]
+    assert "https://hf-mirror.com" in hint  # (1) names the configured mirror
+    assert "may be down" in hint  # (2) says it may be down
+    # (3) the setting path + the restart requirement (HF_ENDPOINT applies at start)
+    assert "Settings → Models → Hugging Face mirror" in hint
+    assert "restart" in hint.lower()
+    # (4) suggests the official endpoint for an un-cached model
+    assert "Hugging Face (official)" in hint
+
+
+def test_timeout_with_mirror_not_misclassified_as_video_network(mirror_env):
+    # A bare "timed out" used to fall into VIDEO_DOWNLOAD_NETWORK, whose hint
+    # talks about "the video server" — a model download naming the mirror host
+    # must classify as the mirror class instead.
+    reason = "HTTPSConnectionPool(host='hf-mirror.com', port=443): Read timed out."
+    assert failure.classify(reason) == "HF_MIRROR_UNREACHABLE"
+
+
+def test_no_class_without_configured_mirror(monkeypatch):
+    # The same #874 reason with NO mirror configured: not this class (the
+    # official endpoint being unreachable is plain connectivity, not a
+    # switch-your-mirror problem).
+    monkeypatch.delenv("HF_ENDPOINT", raising=False)
+    from core import prefs
+
+    monkeypatch.setattr(prefs, "get", lambda key, default=None: default)
+    assert failure.classify(_TRANSFORMERS_874) == ""
+    assert failure.hf_mirror_hint(_TRANSFORMERS_874) == ""
+
+
+def test_official_endpoint_is_not_a_mirror(monkeypatch):
+    monkeypatch.setenv("HF_ENDPOINT", "https://huggingface.co")
+    assert failure.hf_mirror_hint(_TRANSFORMERS_874) == ""
+    # Trailing slash normalizes away too.
+    monkeypatch.setenv("HF_ENDPOINT", "https://huggingface.co/")
+    assert failure.hf_mirror_hint(_TRANSFORMERS_874) == ""
+
+
+def test_non_hf_connectivity_error_gets_no_mirror_hint(mirror_env):
+    # A random socket failure (e.g. a local LLM provider being down) while a
+    # mirror happens to be configured must NOT get the mirror hint.
+    assert failure.hf_mirror_hint("Connection refused by localhost:11434") == ""
+
+
+def test_append_helper_appends_or_passes_through(mirror_env):
+    # append_hf_mirror_hint is the 500-detail surface (main.py global handler)
+    # and the model-install SSE surface (setup/download.py).
+    out = failure.append_hf_mirror_hint(_TRANSFORMERS_874)
+    assert out.startswith(_TRANSFORMERS_874)
+    assert "Settings → Models → Hugging Face mirror" in out
+    assert failure.append_hf_mirror_hint("some unrelated failure") == "some unrelated failure"
+
+
+def test_journal_classifies_mirror_download_as_network_error(mirror_env):
+    # Bug reports auto-attach the journal entry — #874's error was UNKNOWN.
+    from core import error_journal
+
+    assert error_journal.classify_exception(OSError(_TRANSFORMERS_874)) == "NETWORK_ERROR"
+
+
+# ── #886 family: the incomplete-cache auto-repair failure names its cause ───
+
+
+@pytest.fixture
+def model_manager(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+
+    import services.model_manager as mm
+
+    monkeypatch.setattr(mm, "_torch", None)
+    monkeypatch.setattr(mm, "_OmniVoice", None)
+    monkeypatch.setattr(mm, "model", None)
+    monkeypatch.setenv("OMNIVOICE_MODEL", "test/checkpoint")
+    monkeypatch.delenv("OMNIVOICE_PRELOAD_TTS_ASR", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    monkeypatch.setattr(mm, "_lazy_torch", lambda: SimpleNamespace(float16="float16"))
+    monkeypatch.setattr(mm, "get_best_device", lambda: "cpu")
+    monkeypatch.setattr(mm, "_last_repair_error", "")
+    return mm
+
+
+_TRUNCATED = OSError(
+    "test/checkpoint does not appear to have a file named pytorch_model.bin "
+    "or model.safetensors"
+)
+
+
+def test_repair_records_why_it_failed(model_manager, monkeypatch):
+    import huggingface_hub
+
+    def boom(**kwargs):
+        raise OSError(_TRANSFORMERS_874)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", boom)
+    monkeypatch.setenv("OMNIVOICE_MODEL_REPAIR_BACKOFF_S", "0")
+    monkeypatch.setenv("OMNIVOICE_MODEL_REPAIR_RETRIES", "1")
+    assert model_manager._repair_model_cache("test/checkpoint") is False
+    assert "hf-mirror.com" in model_manager._last_repair_error
+
+
+def test_repair_failure_message_names_cause_and_mirror(model_manager, monkeypatch, mirror_env):
+    """#886 family: 'could not be auto-repaired' used to drop the cause, so a
+    mirror outage, offline mode, and a full disk all read identically. The
+    message now carries the cause — and because the cause text is part of the
+    surfaced error, the shared #874 mirror hint fires on it downstream."""
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache", lambda checkpoint, **kw: False
+    )
+    monkeypatch.setattr(
+        model_manager, "_last_repair_error", f"OSError: {_TRANSFORMERS_874}"
+    )
+
+    class BrokenOmniVoice:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise _TRUNCATED
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: BrokenOmniVoice)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        model_manager._load_model_sync()
+    msg = str(exc_info.value)
+    assert "incomplete" in msg  # the existing actionable class is preserved
+    assert "Settings → Models" in msg
+    assert "hf-mirror.com" in msg  # NEW: the cause is named
+    # …and the surfaced text now carries enough signal for the shared mirror
+    # hint to fire on the 500-detail surface (main.py appends it).
+    assert failure.hf_mirror_hint(msg) != ""
+
+
+def test_repair_failure_without_cause_keeps_legacy_message(model_manager, monkeypatch):
+    """No recorded cause (e.g. tests/plugins stubbing repair) → the message is
+    byte-compatible with the pre-#874 wording, no dangling clause."""
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache", lambda checkpoint, **kw: False
+    )
+    monkeypatch.setattr(model_manager, "_last_repair_error", "")
+
+    class BrokenOmniVoice:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise _TRUNCATED
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: BrokenOmniVoice)
+
+    with pytest.raises(RuntimeError, match="interrupted download"):
+        model_manager._load_model_sync()


### PR DESCRIPTION
Fixes #874

## Problem

A user configured the hf-mirror.com mirror (Settings quick-pick → `HF_ENDPOINT`); the mirror was down and the raw transformers error — *"We couldn't connect to 'https://hf-mirror.com' to load the files, and couldn't find them in the cached files."* — leaked to the UI as a bare 500 on generate, with no next step.

## Fix (class-level, one shared classifier)

`core/failure.py` gains the `HF_MIRROR_UNREACHABLE` class: an HF-download connectivity failure **while a non-default `HF_ENDPOINT` is configured**. Detection requires both a connectivity signature (transformers / huggingface_hub / requests / DNS wording, cross-platform) and HF context (the configured mirror host named in the message, or HF-download wording) — so a random socket error (e.g. a local LLM provider being down) never gets the mirror hint.

The hint delivers all four requirements: **(1)** names the configured mirror, **(2)** says it may be down or blocked, **(3)** points at **Settings → Models → Hugging Face mirror** and notes the restart requirement (verified: HF reads `HF_ENDPOINT` at import time; the settings endpoint persists via user_env and returns `restart_required: true`), **(4)** suggests switching to "Hugging Face (official)" when the model isn't cached yet.

Wired into every surface, so **all** model-download paths benefit — not just TTS generate:

- **`build_failure()`** attaches the dynamic hint (model status / first-run System Check, dub + task failure events). Checked before the video-download network class so a model download's "timed out" no longer gets the *"video server"* hint.
- **`main.py` global 500 handler** appends the hint to the surfaced `detail` — covers generate and every other route that can leak a model-load error (dub, archetypes, batch, wizard, tts_stream).
- **`setup/download.py`** install SSE (`install_error`) gets the same hint in the Model Store UI.
- **`error_journal`**: `"couldn't connect to"` / `"max retries exceeded"` now classify as `NETWORK_ERROR` (was `UNKNOWN`) in auto-attached bug reports.

## #886 triage (same family — partially covered here)

#886 ("TTS model cache for k2-fsa/OmniVoice is incomplete and could not be auto-repaired" 500) is the **same family** (model cache/download error surfacing) but a different instance: the classified message already existed, yet it **dropped the cause** — a mirror outage, HF offline mode, and a full disk all read identically, making the report undiagnosable. Covered here: `_repair_model_cache` now records why the last repair attempt failed and the surfaced message names it (sanitized). When the cause is a mirror connectivity failure, the #874 hint fires on that surface too. Root-causing the reporter's specific repair failure still needs their backend logs.

## Tests

`tests/test_hf_mirror_error_class.py` — fail-before/pass-after (12 of 13 fail on main): classification of the exact #874 transformers message + the huggingface_hub `MaxRetryError` shape, hint content asserts for all four requirements, no-mirror/official-endpoint/non-HF negative cases, the append helper (500-detail + install SSE surface), journal classification, and the #886-family repair-cause surfacing (including byte-compatible legacy wording when no cause is recorded).

Backend-generated English messages match the existing classified-error pattern (no frontend strings added → no i18n keys needed). No CHANGELOG changes per task instruction.

```
uv run pytest tests/test_hf_mirror_error_class.py tests/test_failure_classify.py \
  tests/test_failure_helper.py tests/test_model_cache_repair.py \
  tests/test_hf_mirror_settings.py            # 44 passed
uv run pytest tests/test_no_hardcoded_cjk.py tests/test_api_route_inventory.py \
  tests/test_error_journal.py                 # 47 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)