### PR TITLE
fix(asr): close the #730 residuals — chunked dub wedge shares the guarded reset; repeated timeouts recommend the crash-isolated engine

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -16,6 +16,7 @@ from core.tasks import task_manager
 from core import event_bus
 from schemas.requests import DubIngestUrlRequest
 from services.model_manager import get_model, _gpu_pool, _cpu_pool, get_diarization_pipeline, offload_tts_for_asr, restore_tts_after_asr
+from services.asr_backend import ASRTimeoutError, reset_pool_after_wedge, run_transcribe_guarded
 from services.audio_io import _safe_soundfile_write
 from services.ffmpeg_utils import find_ffmpeg
 from services.segmentation import (
@@ -33,24 +34,6 @@ from services import dub_pipeline
 
 router = APIRouter()
 logger = logging.getLogger("omnivoice.api")
-
-
-def _reset_pool_on_wedge(pool) -> None:
-    """Abandon a GPU pool whose worker is wedged on a timed-out transcribe (#730).
-
-    Python can't kill the stuck thread, but dropping the poisoned pool means the
-    next submit (the next chunk, or a concurrent TTS generate) gets a fresh
-    worker instead of queueing behind the wedged one — the same recovery the
-    whole-file paths get inside ``run_transcribe_guarded``. Best-effort and a
-    no-op for a pool without ``reset`` (a plain executor), so it never raises on
-    the failure path it's trying to recover from.
-    """
-    _reset = getattr(pool, "reset", None)
-    if callable(_reset):
-        try:
-            _reset()
-        except Exception:
-            logger.exception("GPU pool reset after transcribe timeout failed")
 
 
 # ── Legacy-name aliases to services/dub_pipeline.py ────────────────────────
@@ -580,35 +563,38 @@ async def dub_transcribe_stream(
             # the hole instead of leaving silent gaps.
             part = None
             for _attempt in range(1, _CHUNK_TRANSCRIBE_ATTEMPTS + 1):
+                # A wedged chunk gets the SAME guarded-timeout + pool-reset
+                # semantics as the whole-file paths (#730/#851):
+                # run_transcribe_guarded bounds the call, abandons the poisoned
+                # pool so the retry (and any concurrent TTS work) gets a fresh
+                # worker, and raises the actionable ASRTimeoutError. Run it as
+                # a task and poll so we can keep yielding pings — the
+                # EventSource connection drops without them.
+                pool_reset_by_guard = False
+                task = asyncio.ensure_future(run_transcribe_guarded(
+                    _gpu_pool, _transcribe_chunk,
+                    what=f"Dub chunk {i + 1}/{chunks_n}",
+                    timeout=TRANSCRIBE_CHUNK_TIMEOUT_S,
+                    timeout_env="OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S",
+                ))
+                while True:
+                    done, _pending = await asyncio.wait({task}, timeout=5.0)
+                    if done:
+                        break
+                    yield _sse_event("ping", {})
                 try:
-                    # wait_for in a loop to yield pings so the EventSource connection doesn't drop
-                    fut = loop.run_in_executor(_gpu_pool, _transcribe_chunk)
-                    waited = 0.0
-                    while True:
-                        done, pending = await asyncio.wait([fut], timeout=5.0)
-                        if done:
-                            part = done.pop().result()
-                            break
-                        yield _sse_event("ping", {})
-                        waited += 5.0
-                        if waited >= TRANSCRIBE_CHUNK_TIMEOUT_S:
-                            # Re-raise TimeoutError if we exceed the overall limit
-                            raise asyncio.TimeoutError()
-                except asyncio.TimeoutError:
+                    part = task.result()
+                except ASRTimeoutError as e:
+                    # The guard already reset the pool; keep the actionable
+                    # message (it names the durable fixes, and — after repeated
+                    # timeouts — the crash-isolated engine escape hatch).
+                    pool_reset_by_guard = True
                     logger.error(
                         "Transcribe chunk %d/%d timed out after %.0fs (attempt %d/%d, job=%s)",
                         i + 1, chunks_n, TRANSCRIBE_CHUNK_TIMEOUT_S, _attempt,
                         _CHUNK_TRANSCRIBE_ATTEMPTS, job_id,
                     )
-                    # #730: the wedged chunk thread keeps holding its GPU-pool
-                    # worker. Abandon the poisoned pool so the retry (and any TTS
-                    # work) gets a fresh worker instead of queueing behind it.
-                    _reset_pool_on_wedge(_gpu_pool)
-                    part = {
-                        "chunks": [], "language": None,
-                        "error": f"Chunk {i+1} timed out after {TRANSCRIBE_CHUNK_TIMEOUT_S:.0f}s — "
-                                 f"ASR backend may be stuck. Try restarting the server.",
-                    }
+                    part = {"chunks": [], "language": None, "error": str(e)}
                 # Success → keep it. Failure/timeout → retry once on a fresh
                 # worker (the internal _transcribe_chunk except returns an
                 # error-part; the timeout path already reset the pool).
@@ -619,7 +605,9 @@ async def dub_transcribe_stream(
                         "Retrying transcribe chunk %d/%d after failure/timeout (next attempt %d/%d, job=%s)",
                         i + 1, chunks_n, _attempt + 1, _CHUNK_TRANSCRIBE_ATTEMPTS, job_id,
                     )
-                    _reset_pool_on_wedge(_gpu_pool)
+                    if not pool_reset_by_guard:
+                        reset_pool_after_wedge(
+                            _gpu_pool, what=f"Dub chunk {i + 1}/{chunks_n}")
             if part.get("error"):
                 chunk_errors.append(part["error"])
                 logger.warning("Chunk %d/%d error: %s", i + 1, chunks_n, part["error"])
@@ -1068,7 +1056,6 @@ async def dub_transcribe(job_id: str):
             # call would otherwise hold its GPU-pool worker forever and starve
             # every other request into a "can't reach backend". run_transcribe_guarded
             # also resets the pool on timeout so capacity is restored.
-            from services.asr_backend import run_transcribe_guarded
             segments_result = await run_transcribe_guarded(_gpu_pool, _transcribe, what="Dub")
         except asyncio.CancelledError:
             job["aborted"] = True

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -27,6 +27,7 @@ import asyncio
 import logging
 import os
 import re
+import threading
 from abc import ABC, abstractmethod
 
 logger = logging.getLogger("omnivoice.asr")
@@ -51,8 +52,95 @@ class ASRTimeoutError(TimeoutError):
     """
 
 
+def reset_pool_after_wedge(executor, *, what: str = "ASR") -> bool:
+    """Abandon a GPU pool whose worker is wedged on a timed-out transcribe (#730).
+
+    Python can't kill the stuck thread, but dropping the poisoned pool means the
+    next submit (a retry, the next chunk, or a concurrent TTS generate) gets a
+    fresh worker instead of queueing behind the wedged one. This is the ONE
+    recovery mechanism shared by every transcribe path — the whole-file guards
+    (via :func:`run_transcribe_guarded`) and the chunked dub stream both route
+    through it, so the semantics can't drift between them again.
+
+    Best-effort: an executor without ``reset()`` (a plain ThreadPoolExecutor in
+    tests) is a no-op, and a failing reset never raises — this runs on the very
+    failure path it's trying to recover from. Returns True when a reset ran.
+    """
+    _reset = getattr(executor, "reset", None)
+    if not callable(_reset):
+        return False
+    try:
+        _reset()
+        logger.warning(
+            "%s transcribe wedged — abandoned the GPU-pool worker to restore "
+            "capacity (#730).", what,
+        )
+        return True
+    except Exception:
+        logger.exception("GPU pool reset after %s timeout failed", what)
+        return False
+
+
+# ── Consecutive-timeout streak → recommend the crash-isolated engine ────────
+# A pool reset restores *capacity*, but the wedged CTranslate2/whisperx thread
+# keeps its VRAM until the process exits. When guarded transcribes keep timing
+# out back-to-back in one session, resets clearly aren't recovering the
+# underlying hang — the durable fix is the crash-isolated sidecar engine
+# (services.subprocess_asr, #393), whose child process CAN be hard-killed to
+# reclaim the hung call and its VRAM. We only *recommend* it (log + error
+# message); we never switch engines automatically (owner rule: no silent
+# behavior divergence).
+_TIMEOUT_STREAK_FOR_ISOLATED_HINT = 2
+_timeout_streak = 0
+_timeout_streak_lock = threading.Lock()
+
+
+def _note_transcribe_timeout() -> int:
+    global _timeout_streak
+    with _timeout_streak_lock:
+        _timeout_streak += 1
+        return _timeout_streak
+
+
+def _note_transcribe_success() -> None:
+    global _timeout_streak
+    with _timeout_streak_lock:
+        _timeout_streak = 0
+
+
+def _isolated_engine_hint(streak: int) -> str:
+    """User-facing recommendation once resets stop recovering (streak ≥ 2).
+
+    Empty when the streak is below the threshold, or when the user is already
+    on the isolated engine (recommending it to itself would be noise — the
+    base message's smaller-model/CPU guidance is all that's left)."""
+    if streak < _TIMEOUT_STREAK_FOR_ISOLATED_HINT:
+        return ""
+    try:
+        if active_backend_id() == "faster-whisper-isolated":
+            return ""
+    except Exception:  # noqa: BLE001 — the hint must never break the error path
+        pass
+    logger.warning(
+        "%d consecutive ASR transcribe timeouts this session — pool resets are "
+        "not recovering the hang. Recommend switching the ASR engine to "
+        "'Faster-Whisper (crash-isolated subprocess)' [faster-whisper-isolated] "
+        "in Settings → Engines. Not switching automatically (#730).", streak,
+    )
+    return (
+        f"This is {streak} transcribe timeouts in a row this session, so pool "
+        "resets aren't recovering the underlying hang. Recommended: switch the "
+        "ASR engine to 'Faster-Whisper (crash-isolated subprocess)' "
+        "(faster-whisper-isolated) in Settings → Engines — it runs "
+        "transcription in a separate process that can be force-killed to "
+        "reclaim a hung transcribe and its VRAM. OmniVoice never switches "
+        "engines automatically."
+    )
+
+
 async def run_transcribe_guarded(executor, fn, *, what: str = "ASR",
-                                 timeout: float = ASR_TRANSCRIBE_TIMEOUT_S):
+                                 timeout: float = ASR_TRANSCRIBE_TIMEOUT_S,
+                                 timeout_env: str = "OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S"):
     """Run a blocking transcribe ``fn`` in ``executor`` with a hard wall-clock
     bound. On timeout, raise :class:`ASRTimeoutError` with guidance instead of
     letting the request hang forever.
@@ -73,30 +161,30 @@ async def run_transcribe_guarded(executor, fn, *, what: str = "ASR",
     loop = asyncio.get_running_loop()
     fut = loop.run_in_executor(executor, fn)
     try:
-        return await asyncio.wait_for(fut, timeout=timeout)
+        result = await asyncio.wait_for(fut, timeout=timeout)
     except asyncio.TimeoutError:
         # Free the poisoned pool so a hung transcribe can't keep starving TTS /
         # other ASR work (the "can't reach backend" symptom, #730).
-        _reset = getattr(executor, "reset", None)
-        if callable(_reset):
-            try:
-                _reset()
-                logger.warning(
-                    "%s transcription exceeded %.0fs — abandoned the GPU-pool "
-                    "worker to restore capacity (#730).", what, timeout,
-                )
-            except Exception:
-                logger.exception("GPU pool reset after ASR timeout failed")
-        raise ASRTimeoutError(
+        reset_pool_after_wedge(executor, what=what)
+        streak = _note_transcribe_timeout()
+        msg = (
             f"{what} transcription exceeded {timeout:.0f}s and was abandoned — "
             "the backend is running, but the ASR model is too heavy for the "
             "available compute. Most often the GPU is VRAM-starved: the resident "
             "TTS model and a large ASR model (large-v3) contend for memory. "
             "Capacity was restored automatically, but for a durable fix Flush the "
             "TTS model to free VRAM, pick a smaller ASR model in Settings → "
-            "Models, or set ASR to CPU. (Raise OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S "
-            "for very long single files.)"
+            f"Models, or set ASR to CPU. (Raise {timeout_env} "
+            "for very long transcribes.)"
         )
+        hint = _isolated_engine_hint(streak)
+        if hint:
+            msg += " " + hint
+        raise ASRTimeoutError(msg)
+    # A completed transcribe (even a failed-but-returned one) proves the pool
+    # isn't hung — only genuine timeouts count toward the consecutive streak.
+    _note_transcribe_success()
+    return result
 
 
 def _compute_type_candidates(device: str) -> list[str]:
@@ -1594,6 +1682,12 @@ _INSTALL_HINTS: dict[str, str] = {
     "moonshine":       "pip install useful-moonshine  (edge/CPU-optimized ASR)",
     "funasr":          "pip install funasr  (SenseVoiceSmall + FSMN-VAD; CUDA or CPU)",
     "sherpa-onnx-asr": "uv add sherpa-onnx  (ONNX live dictation; CPU, cross-platform)",
+    "faster-whisper-isolated": (
+        "No extra install (reuses faster-whisper). Escape hatch for hanging "
+        "transcribes: runs ASR in a separate process that can be force-killed "
+        "to reclaim a hung transcribe and its VRAM (#730). Slightly slower per "
+        "call than in-process faster-whisper."
+    ),
 }
 
 # Most-recent failure per backend, so a transient probe error survives between
@@ -1707,6 +1801,14 @@ def active_backend_id() -> str:
     return _auto_detect()
 
 
+# Subprocess-isolated backends must be process-wide singletons: their
+# ``__init__`` registers an atexit shutdown hook and the instance owns the
+# sidecar child process, so a fresh instance per request would leak handler
+# entries and respawn the sidecar (reloading its model) on every transcribe.
+# Same rationale as api.routers.engines._ENGINE_INSTANCES.
+_ISOLATED_INSTANCES: dict[str, "ASRBackend"] = {}
+
+
 def get_active_asr_backend(*, asr_pipe=None) -> ASRBackend:
     bid = active_backend_id()
     if bid == "pytorch-whisper":
@@ -1719,7 +1821,14 @@ def get_active_asr_backend(*, asr_pipe=None) -> ASRBackend:
         return WhisperXBackend()
     if bid not in _REGISTRY:
         raise ValueError(f"Unknown ASR backend: {bid!r}. Known: {list(_REGISTRY)}")
-    return _REGISTRY[bid]()
+    cls = _REGISTRY[bid]
+    if getattr(cls, "_is_subprocess_isolated", False):
+        inst = _ISOLATED_INSTANCES.get(bid)
+        if inst is None:
+            inst = cls()
+            _ISOLATED_INSTANCES[bid] = inst
+        return inst
+    return cls()
 
 
 def transcribe_reference(audio_path: str) -> str | None:

--- a/backend/services/subprocess_asr.py
+++ b/backend/services/subprocess_asr.py
@@ -132,6 +132,10 @@ class IsolatedFasterWhisperBackend(SubprocessASRBackend):
 
     id = "faster-whisper-isolated"
     display_name = "Faster-Whisper (crash-isolated subprocess)"
+    # Same engine as FasterWhisperBackend, so the same device support — the
+    # sidecar picks cuda/cpu itself via `_device()`. Without this the registry
+    # default ("cpu",) would dishonestly report cpu_only routing on CUDA hosts.
+    gpu_compat = ("cuda", "cpu")
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:

--- a/backend/tests/test_asr_transcribe_timeout.py
+++ b/backend/tests/test_asr_transcribe_timeout.py
@@ -17,12 +17,23 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+from services import asr_backend  # noqa: E402
 from services.asr_backend import (  # noqa: E402
     ASRTimeoutError,
     ASR_TRANSCRIBE_TIMEOUT_S,
+    reset_pool_after_wedge,
     run_transcribe_guarded,
 )
 from concurrent.futures import ThreadPoolExecutor  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh_timeout_streak(monkeypatch):
+    """The consecutive-timeout streak (#730 residual B) is process-global
+    session state; zero it per test so ordering can't leak recommendations,
+    and pin the active engine so a dev box's prefs can't flip the hint."""
+    monkeypatch.setattr(asr_backend, "_timeout_streak", 0)
+    monkeypatch.setattr(asr_backend, "active_backend_id", lambda: "whisperx")
 
 
 def test_default_timeout_is_env_overridable(monkeypatch):
@@ -113,3 +124,115 @@ def test_timeout_without_reset_capable_pool_does_not_crash():
 
     asyncio.run(_go())
     pool.shutdown(wait=False)
+
+
+# ── Residual B on #730: consecutive timeouts recommend the isolated engine ──
+
+
+def _hang_forever():
+    time.sleep(5)
+    return "never"
+
+
+async def _timeout_once(pool, timeout=0.1) -> str:
+    with pytest.raises(ASRTimeoutError) as ei:
+        await run_transcribe_guarded(pool, _hang_forever, what="Dub", timeout=timeout)
+    return str(ei.value)
+
+
+def test_second_consecutive_timeout_recommends_isolated_engine():
+    """When guarded timeouts hit twice in a row in one session, pool resets
+    clearly aren't recovering the hang — the error the user sees must name the
+    crash-isolated escape-hatch engine (and make clear we never auto-switch)."""
+    pool = ThreadPoolExecutor(max_workers=2)
+
+    async def _go():
+        first = await _timeout_once(pool)
+        assert "faster-whisper-isolated" not in first  # one timeout ≠ a pattern
+        second = await _timeout_once(pool)
+        assert "faster-whisper-isolated" in second
+        assert "Settings → Engines" in second
+        assert "never switches engines automatically" in second
+
+    asyncio.run(_go())
+    pool.shutdown(wait=False)
+
+
+def test_successful_transcribe_resets_the_timeout_streak():
+    """'Consecutive' must mean consecutive: a transcribe that completes between
+    two timeouts proves the pool recovered, so the recommendation must not fire."""
+    pool = ThreadPoolExecutor(max_workers=3)
+
+    async def _go():
+        await _timeout_once(pool)
+        out = await run_transcribe_guarded(pool, lambda: "ok", what="Dub", timeout=5.0)
+        assert out == "ok"
+        second = await _timeout_once(pool)
+        assert "faster-whisper-isolated" not in second
+
+    asyncio.run(_go())
+    pool.shutdown(wait=False)
+
+
+def test_no_recommendation_when_already_on_isolated_engine(monkeypatch):
+    """Recommending the isolated engine to a user already running it is noise —
+    the base message's smaller-model/CPU guidance is all that's left."""
+    monkeypatch.setattr(
+        asr_backend, "active_backend_id", lambda: "faster-whisper-isolated"
+    )
+    pool = ThreadPoolExecutor(max_workers=2)
+
+    async def _go():
+        await _timeout_once(pool)
+        second = await _timeout_once(pool)
+        assert "faster-whisper-isolated) in Settings" not in second
+        assert "never switches engines automatically" not in second
+
+    asyncio.run(_go())
+    pool.shutdown(wait=False)
+
+
+def test_timeout_env_name_is_parameterized():
+    """The chunked dub path passes its own knob; the message must name IT, not
+    the whole-file env var (actionable errors point at the right dial)."""
+    pool = ThreadPoolExecutor(max_workers=1)
+
+    async def _go():
+        with pytest.raises(ASRTimeoutError) as ei:
+            await run_transcribe_guarded(
+                pool, _hang_forever, what="Dub chunk 1/3", timeout=0.1,
+                timeout_env="OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S",
+            )
+        msg = str(ei.value)
+        assert "OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S" in msg
+        assert "OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S" not in msg
+
+    asyncio.run(_go())
+    pool.shutdown(wait=False)
+
+
+def test_reset_pool_after_wedge_is_shared_and_best_effort():
+    """One reset mechanism for every transcribe path (#730 residual A): it
+    resets a reset-capable pool, no-ops a plain executor, and never raises."""
+
+    class _Pool:
+        resets = 0
+
+        def reset(self):
+            self.resets += 1
+
+    p = _Pool()
+    assert reset_pool_after_wedge(p, what="Dub chunk 1/2") is True
+    assert p.resets == 1
+
+    plain = ThreadPoolExecutor(max_workers=1)
+    try:
+        assert reset_pool_after_wedge(plain) is False
+    finally:
+        plain.shutdown(wait=False)
+
+    class _Broken:
+        def reset(self):
+            raise RuntimeError("reset blew up")
+
+    assert reset_pool_after_wedge(_Broken()) is False  # must not raise

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -346,14 +346,25 @@ did was `generate:start (audio)`, a dub, or a dictation.
 4. **Test with a 10-second clip** first — if that returns quickly, it confirms a
    compute/VRAM limit rather than a true hang.
 
-Newer builds **bound** every GPU job — whole-file transcription **and** TTS
-generation: instead of hanging forever and starving the backend, a wedged job now
-fails after a timeout with this exact guidance, and the worker pool is reset so
-capacity is restored automatically (no app restart needed). Tune the bounds with
-`OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S` (transcription) and
-`OMNIVOICE_GENERATE_TIMEOUT_S` (generation) — both in seconds, default 300.
-**Raise** them for very long single files/generations, **lower** them to fail
-faster on a small machine.
+Newer builds **bound** every GPU job — whole-file transcription, **chunked dub
+transcription**, **and** TTS generation: instead of hanging forever and starving
+the backend, a wedged job now fails after a timeout with this exact guidance,
+and the worker pool is reset so capacity is restored automatically (no app
+restart needed). Tune the bounds with `OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S`
+(whole-file transcription) and `OMNIVOICE_GENERATE_TIMEOUT_S` (generation) —
+both in seconds, default 300 — and `OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S`
+(per-chunk dub transcription, default 120). **Raise** them for very long single
+files/generations, **lower** them to fail faster on a small machine.
+
+**If transcribe timeouts keep repeating back-to-back**, pool resets aren't
+recovering the underlying hang — the wedged thread keeps its VRAM until the app
+exits. The error message will then recommend switching the ASR engine to
+**Faster-Whisper (crash-isolated subprocess)** (`faster-whisper-isolated`) in
+**Settings → Engines**: it runs transcription in a separate process that can be
+force-killed to reclaim a hung transcribe *and* its VRAM, at a small per-call
+overhead. It reuses your existing faster-whisper install (nothing extra to
+download). OmniVoice never switches engines automatically — this stays your
+call.
 
 ## 15. Stuck at "preparing" forever after a crash / BSOD (Windows)
 

--- a/tests/backend/services/test_subprocess_asr.py
+++ b/tests/backend/services/test_subprocess_asr.py
@@ -91,6 +91,49 @@ def test_registry_exposes_isolated_backend():
     assert cls.id == "faster-whisper-isolated"
     ok, msg = cls.is_available()
     assert isinstance(ok, bool)  # available iff faster-whisper installed + script present
+    assert isinstance(msg, str) and msg  # honest reason either way
+
+
+def test_isolated_backend_listed_in_settings_with_explanatory_hint():
+    """#730 residual B: the escape-hatch engine must be a first-class row in the
+    Settings engine list — subprocess isolation flagged, an install_hint that
+    explains WHAT it's for (reclaiming hung transcribes + their VRAM), and an
+    honest availability verdict."""
+    from services import asr_backend
+
+    entries = {b["id"]: b for b in asr_backend.list_backends()}
+    entry = entries.get("faster-whisper-isolated")
+    assert entry is not None, "isolated backend missing from list_backends()"
+    assert entry["display_name"] == "Faster-Whisper (crash-isolated subprocess)"
+    assert entry["isolation_mode"] == "subprocess"
+    hint = entry["install_hint"] or ""
+    assert "separate process" in hint and "VRAM" in hint, hint
+    assert isinstance(entry["available"], bool)
+    if not entry["available"]:
+        assert entry["reason"]  # unavailable must always say why
+    # Wraps the same CTranslate2 engine as faster-whisper → same device support
+    # (the registry default ("cpu",) would dishonestly hide CUDA routing).
+    assert entry["gpu_compat"] == ["cuda", "cpu"]
+
+
+def test_get_active_asr_backend_caches_isolated_singleton(monkeypatch):
+    """Selecting the isolated engine must not spawn a fresh sidecar (and leak an
+    atexit hook) per request: SubprocessBackend instances own a child process,
+    so get_active_asr_backend must hand back one process-wide instance."""
+    from services import asr_backend
+
+    monkeypatch.setenv("OMNIVOICE_ASR_BACKEND", "faster-whisper-isolated")
+    monkeypatch.setattr(asr_backend, "_ISOLATED_INSTANCES", {})
+    a = asr_backend.get_active_asr_backend()
+    b = asr_backend.get_active_asr_backend()
+    try:
+        assert a is b, "isolated backend must be a process-wide singleton"
+        assert a.id == "faster-whisper-isolated"
+    finally:
+        try:
+            a.shutdown()
+        except Exception:
+            pass
 
 
 def test_generate_is_not_supported(asr):

--- a/tests/test_asr_gpu_compat.py
+++ b/tests/test_asr_gpu_compat.py
@@ -22,6 +22,9 @@ _EXPECTED = {
     "nemo-parakeet": ("cuda", "cpu"),
     "moonshine": ("cpu",),
     "funasr": ("cuda", "cpu"),
+    # Crash-isolated sidecar wraps the same CTranslate2 engine as
+    # faster-whisper — same device support (#730 residual B).
+    "faster-whisper-isolated": ("cuda", "cpu"),
 }
 
 # Engines that legitimately have NO cpu path (hard GPU gate in is_available).

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -290,7 +290,9 @@ def test_transcribe_stream_surfaces_asr_load_failure_at_preflight(tmp_path, monk
 def test_reset_pool_on_wedge_resets_resilient_pool():
     """#730: a chunk transcribe that times out wedges its GPU-pool worker. The
     chunked stream must abandon the pool so the next chunk / a concurrent TTS
-    generate gets a fresh worker instead of starving behind it."""
+    generate gets a fresh worker instead of starving behind it. dub_core now
+    shares asr_backend.reset_pool_after_wedge with the whole-file guards — one
+    mechanism, no drift."""
     from api.routers import dub_core as dc
 
     class _Pool:
@@ -301,7 +303,7 @@ def test_reset_pool_on_wedge_resets_resilient_pool():
             self.resets += 1
 
     pool = _Pool()
-    dc._reset_pool_on_wedge(pool)
+    assert dc.reset_pool_after_wedge(pool) is True
     assert pool.resets == 1
 
 
@@ -314,9 +316,117 @@ def test_reset_pool_on_wedge_is_a_noop_without_reset():
 
     pool = ThreadPoolExecutor(max_workers=1)
     try:
-        dc._reset_pool_on_wedge(pool)  # must not raise
+        assert dc.reset_pool_after_wedge(pool) is False  # must not raise
     finally:
         pool.shutdown(wait=False)
+
+
+def test_wedged_chunk_goes_through_guarded_reset_with_actionable_error(tmp_path, monkeypatch):
+    """Residual A on #730: a chunk that WEDGES (hangs past its timeout) must get
+    the SAME guarded-timeout + pool-reset semantics as the whole-file paths
+    (#851) — run_transcribe_guarded resets the pool once per wedged attempt and
+    the user sees the actionable ASRTimeoutError, not the old dead-end "Try
+    restarting the server". And because the retry (#867) wedges too, the second
+    consecutive timeout must surface the crash-isolated engine recommendation
+    (Residual B) in the stream error the user sees.
+    """
+    import asyncio
+    import threading
+    from concurrent.futures import Executor, ThreadPoolExecutor
+
+    from api.routers import dub_core as dc
+    from services import asr_backend
+
+    class _RecordingPool(Executor):
+        """Executor with a #851-style reset(): swap the inner pool, count calls."""
+
+        def __init__(self):
+            self.resets = 0
+            self._inner = ThreadPoolExecutor(max_workers=1)
+
+        def submit(self, fn, /, *args, **kwargs):
+            return self._inner.submit(fn, *args, **kwargs)
+
+        def reset(self):
+            self.resets += 1
+            old, self._inner = self._inner, ThreadPoolExecutor(max_workers=1)
+            old.shutdown(wait=False, cancel_futures=True)
+
+        def shutdown(self, wait=True, *, cancel_futures=False):
+            self._inner.shutdown(wait=False, cancel_futures=True)
+
+    release_wedge = threading.Event()
+
+    class _WedgedASR:
+        id = "whisperx"
+
+        def ensure_loaded(self):
+            pass
+
+        def transcribe(self, path, *, word_timestamps=True):
+            release_wedge.wait(timeout=30)  # wedge far past the tiny chunk timeout
+            return {"chunks": [], "segments": [], "language": "en"}
+
+        def unload(self):
+            pass
+
+    job_id = "t_wedge"
+    audio = tmp_path / "a.wav"
+    _make_wav(audio, seconds=1.0)
+    dc._dub_jobs[job_id] = {
+        "audio_path": str(audio), "vocals_path": None, "scene_cuts": [],
+    }
+
+    fake_model = MagicMock()
+    fake_model._asr_pipe = MagicMock()
+
+    async def _ok_model():
+        return fake_model
+
+    pool = _RecordingPool()
+    monkeypatch.setattr(dc, "get_model", _ok_model)
+    monkeypatch.setattr(dc, "_gpu_pool", pool)
+    monkeypatch.setattr(dc, "TRANSCRIBE_CHUNK_TIMEOUT_S", 0.2)
+    monkeypatch.setattr(dc, "_CHUNK_TRANSCRIBE_ATTEMPTS", 2)
+    monkeypatch.setattr(dc, "offload_tts_for_asr", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "services.asr_backend.get_active_asr_backend",
+        lambda *a, **k: _WedgedASR(),
+    )
+    # Deterministic streak + recommendation: start at 0, active engine is not
+    # already the isolated one (prefs on the dev box must not leak in).
+    monkeypatch.setattr(asr_backend, "_timeout_streak", 0)
+    monkeypatch.setattr(asr_backend, "active_backend_id", lambda: "whisperx")
+
+    async def _collect():
+        resp = await dc.dub_transcribe_stream(job_id)
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk))
+        return "".join(parts)
+
+    try:
+        body = asyncio.run(_collect())
+    finally:
+        release_wedge.set()  # let the wedged worker threads exit
+        pool.shutdown()
+        dc._dub_jobs.pop(job_id, None)
+
+    # Pool reset exactly once per wedged attempt, inside run_transcribe_guarded
+    # (no double-reset from the retry branch).
+    assert pool.resets == 2, f"expected one guarded reset per attempt, got {pool.resets}"
+    # The user-facing chunk error is the guard's actionable message …
+    assert "backend is running" in body, body
+    assert "OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S" in body, body
+    # … not the old parallel mechanism's dead-end advice.
+    assert "Try restarting the server" not in body, body
+    # Second consecutive timeout-with-reset → the crash-isolated engine
+    # recommendation surfaces in the error the user sees (Residual B).
+    assert "faster-whisper-isolated" in body, body
+    # Terminal error followed by done — stream still closes via named events.
+    err_idx = body.rfind("event: error")
+    done_idx = body.rfind("event: done")
+    assert done_idx > err_idx >= 0, body
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Closes out the two residuals left open on #730 after #731/#851 (bounded transcribes + pool reset) and #870 (VRAM preflight).

## Residual A — chunked dub-stream wedge now shares the guarded reset

The chunked transcribe (`/dub/transcribe-stream`) had a **parallel** wedge mechanism: its own ping-loop timeout, its own local `_reset_pool_on_wedge`, and a dead-end per-chunk message ("ASR backend may be stuck. Try restarting the server."). That's exactly the drift #730 warned about — the whole-file paths got the actionable bound+reset (#851 semantics) and the chunked path got a divergent copy.

Now a wedged chunk routes through the **same** `run_transcribe_guarded` as the whole-file paths:

- the guard bounds the chunk, resets the poisoned pool **once per wedged attempt** (the old code double-reset on the #867 retry), and raises the actionable `ASRTimeoutError` the user actually gets to see (via the chunk `segments` event and the terminal "no segments" error);
- the reset logic is extracted to `asr_backend.reset_pool_after_wedge` — **one shared mechanism** used by the guard and by the non-timeout retry path, so chunked/whole-file semantics can't drift again;
- `run_transcribe_guarded` gains a `timeout_env` param so chunk timeouts name `OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S` (the right dial) instead of the whole-file knob;
- bonus: because the guarded call runs as an independent task, a client that disconnects mid-wedge no longer skips the reset (the old inline ping-loop abandoned the future without one).

## Residual B — the crash-isolated ASR sidecar is a wired escape hatch (not a default)

`faster-whisper-isolated` (#393) runs ASR in a child process that **can** be hard-killed to reclaim a hung CTranslate2 call and its VRAM — a pool reset can't do that (the wedged thread keeps its VRAM until the app exits).

1. **Selectable end-to-end:** the Settings engine list entry now carries an explanatory `install_hint` (what it's for, no extra install), honest `gpu_compat = ("cuda","cpu")` (it wraps the same CTranslate2 engine as faster-whisper; the registry default dishonestly reported cpu-only routing on CUDA hosts), and `get_active_asr_backend` returns a **process-wide singleton** for subprocess-isolated backends — a fresh instance per request would leak atexit hooks and respawn the sidecar (reloading its model) on every transcribe.
2. **Recommendation on the 2nd consecutive timeout-with-reset in one session:** when guarded timeouts repeat back-to-back, resets clearly aren't recovering the hang — the log and the user-facing error now name the isolated engine and where to switch (Settings → Engines). A completed transcribe resets the streak ("consecutive" means consecutive); the hint is suppressed if the user is already on the isolated engine. **No auto-switch** — the message states OmniVoice never switches engines automatically (owner rule: no silent behavior divergence).

Docs-sync: troubleshooting §14 documents the per-chunk knob and the escape-hatch guidance in the same PR.

## Tests (fail-before verified by reverting sources to origin/main)

- **A:** wedged-chunk SSE integration test — fake ASR wedges past a tiny chunk timeout → asserts pool reset fires exactly once per attempt inside the guard, the stream carries the actionable error (`backend is running`, chunk env var) not the old dead-end advice, and the 2nd consecutive timeout surfaces the isolated-engine recommendation in the stream body.
- **B:** consecutive-timeout streak (no hint on 1st, hint on 2nd, success resets, suppressed when already isolated), `timeout_env` parametrization, shared reset helper (reset-capable / plain / broken pools), isolated backend present in `list_backends()` with hint + `isolation_mode="subprocess"` + honest availability, `get_active_asr_backend` singleton caching, gpu_compat matrix entry.

```
backend/tests/test_asr_transcribe_timeout.py            11 passed
tests/test_dub_transcribe.py + test_asr_gpu_compat.py
  + tests/backend/services/test_subprocess_asr.py
  + tests/test_no_hardcoded_cjk.py                      34 passed, 8 xfailed (pre-existing), 3 xpassed
tests/test_engines.py + tests/scripts/test_check_docs_drift.py  31 passed
tests/test_router_smoke.py + tests/test_api_route_inventory.py  54 passed
```

cargo/frontend untouched; no CHANGELOG edits (release flow owns it). Refs #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR hardens chunked dub transcription by routing `/dub/transcribe-stream` through the same guarded ASR timeout flow as whole-file transcribes, so chunk timeouts now share the common reset/retry behavior and use the chunk-specific timeout setting.

It also adds a crash-isolated `faster-whisper-isolated` engine as an explicit recovery option: backend selection now exposes clearer install guidance and GPU compatibility, subprocess backends are cached as a singleton, and repeated guarded timeouts surface a recommendation to switch engines without auto-switching. Successful transcribes clear the timeout streak.

Troubleshooting docs were updated for the new chunk timeout knob and recovery guidance.

```mermaid
flowchart TD
  A[Start ASR transcribe] --> B{Whole-file or chunked?}
  B -->|Whole-file| C[run_transcribe_guarded]
  B -->|Chunked dub stream| D[run_transcribe_guarded with chunk timeout]
  C --> E{Timeout?}
  D --> E
  E -->|No| F[Reset timeout streak]
  E -->|Yes| G[Best-effort reset pool after wedge]
  G --> H[Increment consecutive-timeout streak]
  H --> I{Streak threshold reached?}
  I -->|No| J[Return actionable timeout error]
  I -->|Yes| K[Recommend faster-whisper-isolated in Settings]
  J --> L[Retry / continue stream]
  K --> L
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->