### PR TITLE
fix(generate): device-aware timeout guidance — stop telling CPU hosts to "set the engine to CPU"

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -249,15 +249,38 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
                 )
             except Exception:
                 logger.exception("GPU pool reset after %s timeout failed", what)
-        raise GpuJobTimeoutError(
-            f"{what} exceeded {timeout:.0f}s and was abandoned — the backend is "
-            "running, but the job was too heavy for the available compute. Most "
-            "often the GPU is VRAM-starved (a resident model and this job contend "
-            "for memory). Capacity was restored automatically; for a durable fix "
-            "try shorter text, a lighter engine, or set the engine to CPU in "
-            "Settings → Models. (Raise OMNIVOICE_GENERATE_TIMEOUT_S for very long "
-            "single generations.)"
+        raise GpuJobTimeoutError(_timeout_guidance(what, timeout))
+
+
+def _timeout_guidance(what: str, timeout: float) -> str:
+    """Device-aware timeout message (#896): a CPU-only host must never be told
+    to "set the engine to CPU" or blamed on VRAM — on CPU the job is simply
+    compute-bound. GPU hosts keep the VRAM-contention guidance."""
+    family = "cuda"  # conservative default: GPU wording if the probe fails
+    try:
+        from core.device_caps import detect_host_caps
+        family = detect_host_caps().family
+    except Exception:  # noqa: BLE001 — guidance must never mask the timeout
+        pass
+    common = (
+        f"{what} exceeded {timeout:.0f}s and was abandoned — the backend is "
+        "running, but the job was too heavy for the available compute. "
+        "Capacity was restored automatically; "
+    )
+    if family == "cpu":
+        return common + (
+            "this machine renders on CPU, where long generations are "
+            "compute-bound. For a durable fix try shorter text or a lighter "
+            "engine (OmniVoice GGUF and Supertonic-3 are CPU-tuned). If you "
+            "expect very long single generations, raise "
+            "OMNIVOICE_GENERATE_TIMEOUT_S."
         )
+    return common + (
+        "most often the GPU is VRAM-starved (a resident model and this job "
+        "contend for memory). For a durable fix try shorter text, a lighter "
+        "engine, or set the engine to CPU in Settings → Models. (Raise "
+        "OMNIVOICE_GENERATE_TIMEOUT_S for very long single generations.)"
+    )
 
 
 model = None  # type: ignore

--- a/tests/test_generate_timeout_730.py
+++ b/tests/test_generate_timeout_730.py
@@ -111,3 +111,43 @@ def test_guard_without_reset_still_bounds(model_manager):
     finally:
         release.set()
         ex.shutdown(wait=False)
+
+
+# ── Device-aware timeout guidance (#896) ────────────────────────────────────
+# A CPU-only host was told "the GPU is VRAM-starved … set the engine to CPU
+# in Settings" — nonsense when the resolved device already IS cpu.
+
+def _guidance_for(monkeypatch, family):
+    import types
+    from services import model_manager as mm
+    import core.device_caps as caps
+    monkeypatch.setattr(
+        caps, "detect_host_caps", lambda: types.SimpleNamespace(family=family)
+    )
+    return mm._timeout_guidance("TTS generate", 300.0)
+
+
+def test_cpu_host_gets_compute_bound_guidance(monkeypatch):
+    msg = _guidance_for(monkeypatch, "cpu")
+    assert "VRAM" not in msg
+    assert "set the engine to CPU" not in msg
+    assert "compute-bound" in msg
+    assert "OMNIVOICE_GENERATE_TIMEOUT_S" in msg
+
+
+def test_gpu_host_keeps_vram_guidance(monkeypatch):
+    msg = _guidance_for(monkeypatch, "cuda")
+    assert "VRAM-starved" in msg
+    assert "set the engine to CPU" in msg
+
+
+def test_probe_failure_defaults_to_gpu_wording(monkeypatch):
+    import core.device_caps as caps
+    from services import model_manager as mm
+
+    def _boom():
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(caps, "detect_host_caps", _boom)
+    msg = mm._timeout_guidance("TTS generate", 300.0)
+    assert "VRAM-starved" in msg  # conservative default, never crashes


### PR DESCRIPTION
## What

The `GpuJobTimeoutError` message unconditionally blamed VRAM starvation and suggested switching the engine to CPU — nonsense on a host already resolved to CPU (proven by #896: Intel U-series laptop, `Compute device: cpu`, told to check VRAM). The guidance now branches on `core.device_caps.detect_host_caps().family` (the single source of truth): CPU hosts get honest compute-bound advice (shorter text, the CPU-tuned GGUF/Supertonic-3 engines, the `OMNIVOICE_GENERATE_TIMEOUT_S` knob); GPU hosts keep the VRAM-contention text. Probe failure conservatively defaults to the GPU wording and can never mask the timeout itself.

## Tests

3 new regression tests in `tests/test_generate_timeout_730.py` (CPU wording excludes VRAM/switch-to-CPU, GPU wording unchanged, probe-failure default) — 7/7 pass. Ref #896 (kept open for the reporter's follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated GPU job timeout messaging to be device-aware.

```mermaid
flowchart TD
  A[GpuJobTimeoutError occurs] --> B[Probe host caps via detect_host_caps()]
  B -->|CPU family| C[Return compute-bound guidance]
  C --> C1[Mention CPU-tuned GGUF/Supertonic-3 engines]
  C --> C2[Recommend OMNIVOICE_GENERATE_TIMEOUT_S]
  B -->|GPU / non-CPU family| D[Return VRAM-contention guidance]
  D --> D1[Keep existing "VRAM-starved" / CPU-switch advice]
  B -->|Probe fails| E[Fallback to GPU wording]
  E --> D
```

Added regression tests covering:
- CPU-host wording
- GPU-host wording
- probe-failure fallback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->