### PR TITLE
feat(launchpad): deck-of-cards redesign — fanned feature cards with animated waveform faces

### DIFF
--- a/frontend/src/components/LaunchpadDeck.jsx
+++ b/frontend/src/components/LaunchpadDeck.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+
+// ── Deck-of-cards geometry ──────────────────────────────────────────
+// Per-card tilt (deg) and lift (px) for the fanned spread. Hand-picked so
+// the fan reads "artistically shuffled" but stays subtle (±4° / ≤14px) and
+// deterministic — same layout every launch, no randomness. Index-aligned
+// with the launchpad feature order.
+const DECK_TILT = [-3.5, 2, -1, 3, -2, 3.5, -1.5];
+const DECK_LIFT = [10, 2, 14, 0, 12, 4, 8];
+// Decorative waveform bar heights (px) on each card face — 7 CSS-only bars
+// pulse via stagger-delayed scaleY keyframes (see .lp-deck-wave in
+// index.css). Static under prefers-reduced-motion.
+const DECK_WAVE = [8, 15, 10, 19, 12, 16, 9];
+
+/**
+ * DeckCard — one card in the fanned deck. Absolutely positioned by CSS from
+ * `--deck-i` (fan slot), `--deck-r` (tilt) and `--deck-y` (lift); `--card-hue`
+ * drives the accent exactly like ActionCard. Hover OR keyboard focus raises
+ * the card (`--front`: straighten + scale up + top z) while every sibling
+ * tucks toward it underneath (`--tuck-r` for cards left of it slides them
+ * right, `--tuck-l` slides the right-side ones left) — the raise/tuck classes
+ * are state-driven so pointer and focus share one code path. The icon + name
+ * cluster is width-capped to the peeking strip so it stays readable while the
+ * card sits under its right neighbor; the waveform strip is pure decoration
+ * (aria-hidden), the button's accessible name stays name + description.
+ */
+function DeckCard({ hue, Icon, title, desc, count, onClick, index, raised, onRaise, onSettle }) {
+  const state =
+    raised == null
+      ? ''
+      : raised === index
+        ? 'lp-deck-card--front'
+        : index < raised
+          ? 'lp-deck-card--tuck-r'
+          : 'lp-deck-card--tuck-l';
+  return (
+    <button
+      type="button"
+      className={`lp-deck-card ${state}`}
+      style={{
+        '--card-hue': hue,
+        '--deck-i': index,
+        '--deck-r': `${DECK_TILT[index]}deg`,
+        '--deck-y': `${DECK_LIFT[index]}px`,
+      }}
+      onClick={onClick}
+      onMouseEnter={() => onRaise(index)}
+      onFocus={() => onRaise(index)}
+      onBlur={onSettle}
+    >
+      {count > 0 && <span className="card-count">{count}</span>}
+      <span className="lp-deck-card__peek">
+        <span className="card-icon">
+          <Icon size={16} color={hue} />
+        </span>
+        <span className="lp-deck-card__name">{title}</span>
+      </span>
+      <span className="lp-deck-card__desc">{desc}</span>
+      <span className="lp-deck-wave" aria-hidden="true">
+        {DECK_WAVE.map((h, i) => (
+          <span
+            key={i}
+            className="lp-deck-wave__bar"
+            style={{ '--wave-h': `${h}px`, '--wave-i': i }}
+          />
+        ))}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * LaunchpadDeck — the launchpad's feature cards as an overlapping
+ * left→right fan (wide shells only; Launchpad.jsx renders the flat
+ * ActionCard grid on shell-narrow/shell-mini instead). Interaction state —
+ * which card is raised by hover/focus, or none — lives here in React (not
+ * pure CSS :hover) so keyboard focus shares the exact same raise/tuck
+ * behavior and tests can assert it.
+ */
+export default function LaunchpadDeck({ features }) {
+  const [raised, setRaised] = useState(null);
+  return (
+    <div
+      className={`lp-deck${raised != null ? ' lp-deck--active' : ''}`}
+      style={{ '--deck-n': features.length }}
+      onMouseLeave={() => setRaised(null)}
+    >
+      {features.map((f, i) => (
+        <DeckCard
+          key={f.key}
+          index={i}
+          hue={f.hue}
+          Icon={f.Icon}
+          title={f.title}
+          desc={f.desc}
+          count={f.count}
+          onClick={f.go}
+          raised={raised}
+          onRaise={setRaised}
+          onSettle={() => setRaised(null)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useShellNarrow.js
+++ b/frontend/src/hooks/useShellNarrow.js
@@ -1,0 +1,28 @@
+import { useLayoutEffect, useState } from 'react';
+
+/**
+ * useShellNarrow — mirrors the app shell's own width breakpoints instead of
+ * viewport @media queries (which fire at the wrong threshold whenever the UI
+ * scale ≠ 1 — see the shellWidth ResizeObserver rationale in App.jsx). The
+ * shell already publishes its effective width as `shell-narrow` / `shell-mini`
+ * classes on `.app-container`, so we read those and track flips with a
+ * MutationObserver. Outside an app shell (isolated render) defaults to wide.
+ *
+ * @param {React.RefObject<HTMLElement>} rootRef — ref to any element inside
+ *   the app shell (the component's root).
+ * @returns {boolean} true when the shell is narrow or mini.
+ */
+export default function useShellNarrow(rootRef) {
+  const [narrow, setNarrow] = useState(false);
+  useLayoutEffect(() => {
+    const shell = rootRef.current?.closest('.app-container');
+    if (!shell) return undefined;
+    const read = () =>
+      setNarrow(shell.classList.contains('shell-narrow') || shell.classList.contains('shell-mini'));
+    read();
+    const mo = new MutationObserver(read);
+    mo.observe(shell, { attributes: true, attributeFilter: ['class'] });
+    return () => mo.disconnect();
+  }, [rootRef]);
+  return narrow;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1547,6 +1547,187 @@ select.input-base:focus-visible,
   animation-delay: var(--bar-delay, 0s);
 }
 
+/* ── Launchpad deck-of-cards (wide shells only) ────────────────────
+   The seven feature cards fanned left→right like a hand of cards: each
+   card is absolutely positioned in its fan slot (`--deck-i`), tilted a
+   few degrees (`--deck-r`) and lifted a few px (`--deck-y`) — values come
+   inline from Launchpad.jsx's DECK_TILT/DECK_LIFT so the spread is
+   deterministic. Geometry: 260px cards across a 780px fan → every card
+   peeks ~87px (~33%) out from under its right neighbor; z stacks
+   left→right so the right neighbor always covers. Raise/tuck classes are
+   set from React state (hover + keyboard focus share them):
+     --front   raised card: straighten, scale up, top of the stack
+     --tuck-r  cards left of the raised one slide right toward it
+     --tuck-l  cards right of it slide left — everything hides under it.
+   Fixed .lp-deck height = zero layout jump while cards move. Narrow/mini
+   shells never render the deck (JSX falls back to the flat grid). */
+.lp-deck {
+  position: relative;
+  height: 252px;
+  max-width: 780px;
+  --deck-card-w: 260px;
+  --deck-card-h: 200px;
+}
+@keyframes lpDeckDeal {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.lp-deck-card {
+  position: absolute;
+  top: 14px;
+  left: calc(var(--deck-i, 0) * (100% - var(--deck-card-w)) / (var(--deck-n, 7) - 1));
+  width: var(--deck-card-w);
+  height: var(--deck-card-h);
+  z-index: calc(var(--deck-i, 0) + 1);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 12px 14px 12px 12px;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 26%, var(--chrome-border));
+  border-radius: var(--chrome-radius-pill);
+  /* Opaque face — lower cards must actually disappear underneath. */
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 10%, var(--chrome-bg)) 0%,
+    var(--chrome-bg) 55%
+  );
+  box-shadow: -12px 10px 26px -18px rgba(0, 0, 0, 0.55);
+  transform: translateY(var(--deck-y, 0px)) rotate(var(--deck-r, 0deg));
+  transform-origin: 20% 90%;
+  transition:
+    transform 240ms var(--ease-out),
+    opacity 240ms ease-out,
+    border-color 240ms ease-out,
+    box-shadow 240ms ease-out;
+  animation: lpDeckDeal 0.5s ease-out both;
+  animation-delay: calc(var(--deck-i, 0) * 60ms);
+}
+/* Raised card (hover or keyboard focus, class-driven from React state):
+   straighten, lift, scale up, and take the top of the stack. */
+.lp-deck-card--front {
+  z-index: 40;
+  transform: translateY(-8px) rotate(0deg) scale(1.04);
+  border-color: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 55%, transparent);
+  box-shadow: 0 22px 44px -20px color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 55%, transparent);
+}
+/* Everyone else tucks under it: slide toward the raised card (increasing
+   the overlap), settle slightly lower, scale down and fade a touch. */
+.lp-deck--active .lp-deck-card:not(.lp-deck-card--front) {
+  opacity: 0.55;
+  transform: translate(var(--deck-slide, 0px), calc(var(--deck-y, 0px) + 6px))
+    rotate(var(--deck-r, 0deg)) scale(0.96);
+}
+.lp-deck-card--tuck-r { --deck-slide: 30px; }
+.lp-deck-card--tuck-l { --deck-slide: -30px; }
+.lp-deck-card:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 70%, transparent);
+  outline-offset: 2px;
+}
+/* Icon + name cluster, width-capped to the ~87px strip each card keeps
+   visible under its right neighbor — the "peeking edge" stays labeled. */
+.lp-deck-card__peek {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 74px;
+  flex: none;
+}
+.lp-deck-card .card-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: var(--chrome-radius-pill);
+  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 28%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+.lp-deck-card__name {
+  font-family: var(--chrome-font-mono);
+  font-size: 0.66rem;
+  font-weight: 600;
+  /* Tighter than --chrome-label-track so 11-char names ("TRANSCRIPTS")
+     still fit the peek column without a mid-word break. */
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  line-height: 1.35;
+  color: var(--chrome-fg);
+  overflow-wrap: anywhere;
+}
+.lp-deck-card__desc {
+  margin-top: 10px;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  line-height: 1.5;
+  font-weight: 400;
+  color: var(--chrome-fg-muted);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+/* Count badge sits inside the peek strip (right of the icon) so it stays
+   visible even while the card is tucked under its right neighbor. */
+.lp-deck-card .card-count {
+  font-family: var(--chrome-font-mono);
+  font-size: var(--chrome-label-size);
+  font-weight: 600;
+  letter-spacing: var(--chrome-label-track);
+  padding: 1px 7px;
+  border-radius: var(--chrome-radius-pill);
+  position: absolute;
+  top: 16px;
+  left: 48px;
+  z-index: 2;
+  border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 50%, transparent);
+  color: var(--card-hue, var(--chrome-accent));
+  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 10%, var(--chrome-bg));
+}
+/* Decorative waveform strip — 7 bars breathing on stagger-delayed scaleY
+   keyframes in the card's accent. `--deck-i` shifts each card's phase so
+   the deck never pulses in lockstep. aria-hidden in the JSX. */
+@keyframes lpDeckWave {
+  0%, 100% { transform: scaleY(0.35); opacity: 0.55; }
+  50%      { transform: scaleY(1);    opacity: 1; }
+}
+.lp-deck-wave {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  height: 20px;
+  margin-top: auto;
+}
+.lp-deck-wave__bar {
+  width: 3px;
+  height: var(--wave-h, 12px);
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 75%, var(--chrome-fg-muted));
+  transform-origin: center;
+  animation: lpDeckWave 1.6s ease-in-out infinite;
+  animation-delay: calc((var(--wave-i, 0) + var(--deck-i, 0)) * -0.19s);
+}
+/* Reduced motion: no dealing/pulsing, and the raise/tuck effect becomes a
+   plain z-index + opacity swap — cards keep their static fan transform. */
+@media (prefers-reduced-motion: reduce) {
+  .lp-deck-card {
+    animation: none;
+    transition: opacity 160ms linear, border-color 160ms linear, box-shadow 160ms linear;
+  }
+  .lp-deck-card--front {
+    transform: translateY(var(--deck-y, 0px)) rotate(var(--deck-r, 0deg));
+  }
+  .lp-deck--active .lp-deck-card:not(.lp-deck-card--front) {
+    transform: translateY(var(--deck-y, 0px)) rotate(var(--deck-r, 0deg));
+    opacity: 0.45;
+  }
+  .lp-deck-wave__bar { animation: none; }
+}
+
 /* ── Searchable combobox ─────────────────────────────────── */
 /* .ss-* (wrap/trigger/label/chev/sm/md/pop/search/list/group-label/option/
    hl/sel/kind-icon/check/empty/more) → Tailwind utilities inline in

--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import {
   Scale,
@@ -17,6 +17,8 @@ import {
 import { API } from '../api/client';
 import { useAppStore } from '../store';
 import ReadinessChecklist from '../components/ReadinessChecklist';
+import LaunchpadDeck from '../components/LaunchpadDeck';
+import useShellNarrow from '../hooks/useShellNarrow';
 
 // Shared utility-class strings for the Launchpad project/section rows. Migrated
 // from the former `.lp-project-card`/`.lp-section-title`/`.proj-*` global rules
@@ -56,7 +58,8 @@ function DubThumb({ jobId, fallback }) {
 // accent line under the H1. Less static, no SVG dependency.
 
 /**
- * ActionCard — the three big Launchpad tiles. Reads its accent from a
+ * ActionCard — the flat Launchpad tiles (narrow-shell fallback for the deck).
+ * Reads its accent from a
  * single `--card-hue` var so the CSS derives background / border / glow /
  * spotlight from one hex color. Cursor-tracking spotlight: pointer events
  * set --mx/--my so `.lp-glow-layer` can paint a radial gradient at the
@@ -112,8 +115,76 @@ export default function Launchpad({
   // off" strip. exportHistory arrives newest-first from /export/history.
   const recentFiles = exportHistory.slice(0, 4);
 
+  // The seven feature cards — single source for BOTH renderings (deck fan on
+  // wide shells, flat ActionCard grid on narrow ones) so hues, i18n keys,
+  // counts and navigation targets can never drift between the two branches.
+  const features = [
+    {
+      key: 'clone',
+      hue: '#d3869b',
+      Icon: Fingerprint,
+      title: t('launchpad.clone_title'),
+      desc: t('launchpad.clone_desc'),
+      count: cloneProfiles.length,
+      go: () => openStudio('audio'),
+    },
+    {
+      key: 'design',
+      hue: '#8ec07c',
+      Icon: Wand2,
+      title: t('launchpad.design_title'),
+      desc: t('launchpad.design_desc'),
+      count: designProfiles.length,
+      go: () => openStudio('design'),
+    },
+    {
+      key: 'dub',
+      hue: '#fe8019',
+      Icon: Film,
+      title: t('launchpad.dub_title'),
+      desc: t('launchpad.dub_desc'),
+      count: studioProjects.length,
+      go: () => setMode('dub'),
+    },
+    {
+      key: 'stories',
+      hue: '#83a598',
+      Icon: BookOpen,
+      title: t('launchpad.stories_title'),
+      desc: t('launchpad.stories_desc'),
+      go: () => setMode('stories'),
+    },
+    {
+      key: 'audiobook',
+      hue: '#458588',
+      Icon: BookMarked,
+      title: t('launchpad.audiobook_title'),
+      desc: t('launchpad.audiobook_desc'),
+      go: () => setMode('audiobook'),
+    },
+    {
+      key: 'gallery',
+      hue: '#fabd2f',
+      Icon: LibraryBig,
+      title: t('launchpad.gallery_title'),
+      desc: t('launchpad.gallery_desc'),
+      go: () => setMode('gallery'),
+    },
+    {
+      key: 'transcripts',
+      hue: '#b8bb26',
+      Icon: FileText,
+      title: t('launchpad.transcripts_title'),
+      desc: t('launchpad.transcripts_desc'),
+      go: () => setMode('transcriptions'),
+    },
+  ];
+
+  const rootRef = useRef(null);
+  const shellNarrow = useShellNarrow(rootRef);
+
   return (
-    <div className="launchpad">
+    <div className="launchpad" ref={rootRef}>
       {/* Ambient backdrop — chrome-accent aurora that drifts forever. Lives
           behind everything at z=0, contributes the "eternal glow" the user
           asked for without painting any one surface. */}
@@ -188,68 +259,29 @@ export default function Launchpad({
         </div>
       </div>
 
-      {/* Action Cards */}
-      <div className="grid grid-cols-3 gap-[12px] py-[4px] px-[44px] relative z-[1] max-[900px]:pt-0 max-[900px]:px-[20px] max-[900px]:pb-[16px] max-[900px]:[grid-template-columns:repeat(auto-fit,minmax(180px,1fr))] max-[640px]:grid-cols-1 max-[640px]:pt-0 max-[640px]:px-[12px] max-[640px]:pb-[12px]">
-        <ActionCard
-          hue="#d3869b"
-          Icon={Fingerprint}
-          title={t('launchpad.clone_title')}
-          count={cloneProfiles.length}
-          onClick={() => openStudio('audio')}
-        >
-          {t('launchpad.clone_desc')}
-        </ActionCard>
-        <ActionCard
-          hue="#8ec07c"
-          Icon={Wand2}
-          title={t('launchpad.design_title')}
-          count={designProfiles.length}
-          onClick={() => openStudio('design')}
-        >
-          {t('launchpad.design_desc')}
-        </ActionCard>
-        <ActionCard
-          hue="#fe8019"
-          Icon={Film}
-          title={t('launchpad.dub_title')}
-          count={studioProjects.length}
-          onClick={() => setMode('dub')}
-        >
-          {t('launchpad.dub_desc')}
-        </ActionCard>
-        <ActionCard
-          hue="#83a598"
-          Icon={BookOpen}
-          title={t('launchpad.stories_title')}
-          onClick={() => setMode('stories')}
-        >
-          {t('launchpad.stories_desc')}
-        </ActionCard>
-        <ActionCard
-          hue="#458588"
-          Icon={BookMarked}
-          title={t('launchpad.audiobook_title')}
-          onClick={() => setMode('audiobook')}
-        >
-          {t('launchpad.audiobook_desc')}
-        </ActionCard>
-        <ActionCard
-          hue="#fabd2f"
-          Icon={LibraryBig}
-          title={t('launchpad.gallery_title')}
-          onClick={() => setMode('gallery')}
-        >
-          {t('launchpad.gallery_desc')}
-        </ActionCard>
-        <ActionCard
-          hue="#b8bb26"
-          Icon={FileText}
-          title={t('launchpad.transcripts_title')}
-          onClick={() => setMode('transcriptions')}
-        >
-          {t('launchpad.transcripts_desc')}
-        </ActionCard>
-      </div>
+      {/* Feature cards — deck-of-cards fan on wide shells; the flat grid
+          below is the narrow/mini fallback (same features, same order, same
+          navigation — only the presentation degrades). */}
+      {!shellNarrow ? (
+        <div className="relative z-[1] py-[4px] px-[44px]">
+          <LaunchpadDeck features={features} />
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-[12px] py-[4px] px-[44px] relative z-[1] max-[900px]:pt-0 max-[900px]:px-[20px] max-[900px]:pb-[16px] max-[900px]:[grid-template-columns:repeat(auto-fit,minmax(180px,1fr))] max-[640px]:grid-cols-1 max-[640px]:pt-0 max-[640px]:px-[12px] max-[640px]:pb-[12px]">
+          {features.map((f) => (
+            <ActionCard
+              key={f.key}
+              hue={f.hue}
+              Icon={f.Icon}
+              title={f.title}
+              count={f.count}
+              onClick={f.go}
+            >
+              {f.desc}
+            </ActionCard>
+          ))}
+        </div>
+      )}
 
       {/* Recent files from OmniDrive — last few exports, with a jump to the
           full file browser (the Projects/OmniDrive page). */}

--- a/frontend/src/test/LaunchpadDeck.test.jsx
+++ b/frontend/src/test/LaunchpadDeck.test.jsx
@@ -1,0 +1,192 @@
+// Launchpad deck-of-cards regression suite (feat/launchpad-deck).
+//
+// The launchpad's seven feature cards render as an overlapping left→right
+// fan on wide shells; hovering or keyboard-focusing any card raises it
+// (`--front`) while every other card tucks toward/under it (`--tuck-r` /
+// `--tuck-l`). On `shell-narrow`/`shell-mini` shells (the app-container's
+// own width classes — NOT viewport @media) the deck degrades to the
+// pre-existing flat ActionCard grid. Both branches share one feature list,
+// so these tests pin: card count + order, navigation targets, the
+// raise/tuck interaction for pointer AND focus, and the narrow fallback.
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+import { useAppStore } from '../store';
+import Launchpad from '../pages/Launchpad';
+
+// ReadinessChecklist needs a react-query provider + live endpoints — not
+// under test here.
+vi.mock('../components/ReadinessChecklist', () => ({ default: () => null }));
+
+// Feature order is part of the contract: deck slot i = grid slot i.
+const FEATURE_NAMES = [
+  'Voice Clone',
+  'Voice Design',
+  'Video Dubbing',
+  'Stories',
+  'Audiobook',
+  'Voice Gallery',
+  'Transcripts',
+];
+
+function makeProps(overrides = {}) {
+  return {
+    profiles: [],
+    studioProjects: [],
+    exportHistory: [],
+    setMode: vi.fn(),
+    setIsCompareModalOpen: vi.fn(),
+    handleSelectProfile: vi.fn(),
+    loadProject: vi.fn(),
+    ...overrides,
+  };
+}
+
+// The component reads its breakpoint from the closest `.app-container`'s
+// shell-narrow/shell-mini classes (mirroring App.jsx's shell-width classes),
+// so tests wrap it in a stand-in shell.
+function renderShell(props, shellClass = 'app-container') {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <div className={shellClass}>
+        <Launchpad {...props} />
+      </div>
+    </I18nextProvider>,
+  );
+}
+
+const deckCards = (container) => [...container.querySelectorAll('.lp-deck-card')];
+
+describe('Launchpad deck (wide shell)', () => {
+  it('renders all 7 features as deck cards, in the canonical order', () => {
+    const { container } = renderShell(makeProps());
+    const cards = deckCards(container);
+    expect(cards).toHaveLength(7);
+    expect(cards.map((c) => c.querySelector('.lp-deck-card__name').textContent)).toEqual(
+      FEATURE_NAMES,
+    );
+    // Deck replaces the grid on wide shells — never both.
+    expect(container.querySelectorAll('.lp-action-card')).toHaveLength(0);
+  });
+
+  it('every card keeps its navigation target', () => {
+    const setMode = vi.fn();
+    const { container } = renderShell(makeProps({ setMode }));
+    const cards = deckCards(container);
+    const modeTargets = [
+      [2, 'dub'],
+      [3, 'stories'],
+      [4, 'audiobook'],
+      [5, 'gallery'],
+      [6, 'transcriptions'],
+    ];
+    for (const [i, mode] of modeTargets) {
+      fireEvent.click(cards[i]);
+      expect(setMode).toHaveBeenLastCalledWith(mode);
+    }
+  });
+
+  it('clone/design cards open the studio preset to the matching method', () => {
+    const setMode = vi.fn();
+    const { container } = renderShell(makeProps({ setMode }));
+    const cards = deckCards(container);
+
+    act(() => useAppStore.getState().setDefineMethod('design'));
+    fireEvent.click(cards[0]); // Voice Clone
+    expect(setMode).toHaveBeenLastCalledWith('studio');
+    expect(useAppStore.getState().defineMethod).toBe('audio');
+
+    fireEvent.click(cards[1]); // Voice Design
+    expect(setMode).toHaveBeenLastCalledWith('studio');
+    expect(useAppStore.getState().defineMethod).toBe('design');
+  });
+
+  it('hovering a card raises it and tucks every other card toward it', () => {
+    const { container } = renderShell(makeProps());
+    const deck = container.querySelector('.lp-deck');
+    const cards = deckCards(container);
+
+    fireEvent.mouseOver(cards[3]);
+    expect(deck.className).toContain('lp-deck--active');
+    expect(cards[3].className).toContain('lp-deck-card--front');
+    // Cards left of the raised one slide right toward it…
+    for (const i of [0, 1, 2]) expect(cards[i].className).toContain('lp-deck-card--tuck-r');
+    // …cards right of it slide left — everything hides under the raised card.
+    for (const i of [4, 5, 6]) expect(cards[i].className).toContain('lp-deck-card--tuck-l');
+
+    // Symmetric: raising a different card re-partitions the tuck sides.
+    fireEvent.mouseOver(cards[6]);
+    expect(cards[6].className).toContain('lp-deck-card--front');
+    for (const i of [0, 1, 2, 3, 4, 5]) {
+      expect(cards[i].className).toContain('lp-deck-card--tuck-r');
+    }
+
+    // Leaving the deck settles the fan back to rest.
+    fireEvent.mouseOut(deck);
+    expect(deck.className).not.toContain('lp-deck--active');
+    expect(container.querySelector('.lp-deck-card--front')).toBeNull();
+  });
+
+  it('keyboard focus raises a card exactly like hover (a11y parity)', () => {
+    const { container } = renderShell(makeProps());
+    const deck = container.querySelector('.lp-deck');
+    const cards = deckCards(container);
+
+    act(() => cards[5].focus());
+    expect(deck.className).toContain('lp-deck--active');
+    expect(cards[5].className).toContain('lp-deck-card--front');
+    expect(cards[6].className).toContain('lp-deck-card--tuck-l');
+
+    act(() => cards[5].blur());
+    expect(deck.className).not.toContain('lp-deck--active');
+    expect(container.querySelector('.lp-deck-card--front')).toBeNull();
+  });
+
+  it('waveform strips are decorative only (aria-hidden, 7 bars each)', () => {
+    const { container } = renderShell(makeProps());
+    for (const card of deckCards(container)) {
+      const wave = card.querySelector('.lp-deck-wave');
+      expect(wave).not.toBeNull();
+      expect(wave.getAttribute('aria-hidden')).toBe('true');
+      expect(wave.querySelectorAll('.lp-deck-wave__bar')).toHaveLength(7);
+    }
+  });
+});
+
+describe('Launchpad deck (narrow fallback)', () => {
+  it.each(['shell-narrow', 'shell-mini'])(
+    'degrades to the flat ActionCard grid under %s',
+    (cls) => {
+      const setMode = vi.fn();
+      const { container } = renderShell(makeProps({ setMode }), `app-container ${cls}`);
+      expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(0);
+      const gridCards = [...container.querySelectorAll('.lp-action-card')];
+      expect(gridCards).toHaveLength(7);
+      expect(gridCards.map((c) => c.querySelector('h3').textContent)).toEqual(FEATURE_NAMES);
+      // Fallback cards keep the same navigation wiring.
+      fireEvent.click(gridCards[2]);
+      expect(setMode).toHaveBeenLastCalledWith('dub');
+    },
+  );
+
+  it('reacts to the shell class flipping at runtime (resize past breakpoint)', async () => {
+    const { container } = renderShell(makeProps());
+    expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(7);
+
+    const shell = container.querySelector('.app-container');
+    await act(async () => {
+      shell.classList.add('shell-narrow');
+      await Promise.resolve(); // flush the MutationObserver microtask
+    });
+    expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(0);
+    expect(container.querySelectorAll('.lp-action-card')).toHaveLength(7);
+
+    await act(async () => {
+      shell.classList.remove('shell-narrow');
+      await Promise.resolve();
+    });
+    expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(7);
+  });
+});


### PR DESCRIPTION
Implements the owner's spec: *"launchpad like deck of cards design, stack left to right lil artistic way, and on them the feature logos as waveform animating on the cards, and on hover on a card the rest hides under it — happens for all of them."*

## Before

The seven feature entries (Voice Clone, Voice Design, Video Dubbing, Stories, Audiobook, Voice Gallery, Transcripts) rendered as a flat 3-column grid of ActionCards. Hovering a card lifted it 1px and tinted its border — no relationship between cards.

## After

**Deck layout.** The seven cards are fanned left→right as an overlapping deck: 260×200px cards across a 780px fan, so each card peeks ~87px (~33%) out from under its right neighbor. Each card gets a deterministic hand-fanned tilt (−3.5° … +3.5°) and vertical stagger (0–14px). Card order, per-feature accent hues, i18n keys, counts, and navigation targets are all unchanged.

**Card face.** The lucide icon + feature name live in a width-capped column on the always-visible peek edge; the full face adds the one-line description and a decorative animated waveform strip — 7 CSS-only bars in the card's accent, pulsing on stagger-delayed `scaleY` keyframes with a per-card phase offset so the deck never beats in lockstep. The waveform is `aria-hidden`; under `prefers-reduced-motion` the bars render static.

**Hover / focus interaction.** Hovering **or keyboard-focusing** any card brings it fully forward: it straightens to 0°, lifts, scales to 1.04 and takes the top of the stack, while **every other card slides toward it and tucks underneath** — cards left of it slide right, cards right of it slide left, all dimmed to 0.55 opacity and scaled to 0.96 (240ms ease-out). The raise/tuck classes are React-state-driven, so pointer and focus share one code path, `:focus-visible` keeps an accent-tinted ring, and the effect works symmetrically for every card. The deck has a fixed height, so nothing below it reflows. Under reduced motion the interaction becomes a plain z-index + opacity swap (no movement).

**Responsive fallback.** On `shell-narrow` / `shell-mini` (the app-container's *own* width classes — not viewport `@media`, matching the UI-scale rationale in App.jsx) the deck degrades to the pre-existing flat ActionCard grid, which is kept intact as the fallback branch. A new `useShellNarrow` hook reads the shell class and tracks flips live via MutationObserver, so resizing across the breakpoint swaps renderings at runtime. 900×600 stays fully usable.

Both renderings are driven by a single shared feature list, so hues/keys/targets can never drift between deck and grid.

## Verification

- `bunx vitest run`: **89 files / 738 tests green**, including the new `LaunchpadDeck.test.jsx` (7 cards + order, every navigation target incl. clone/design → studio + defineMethod, hover raise/tuck partitioning, focus parity, waveform decorativeness, fallback under both shell classes, runtime class flip).
- `bun run lint`: 0 errors, finding count identical to main (no new warnings). `bun run format:check` clean. `bun run typecheck:ci` clean. `bun run build` succeeds.
- `tests/test_no_hardcoded_cjk.py` + frontend-scanning pytest suites pass. No i18n changes needed — the design reuses the existing `launchpad.*` keys.
- Rendered in a real browser (Playwright against the visual harness) to verify rest state, hover-forward/tuck-under, keyboard-focus ring, and the narrow fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
Redesigned the Launchpad feature area into a fanned deck-of-cards layout for wide shells, while preserving the existing feature order, labels, counts, colors, translations, and navigation targets.

### UI
- Added a new `LaunchpadDeck` component that renders the seven feature cards as overlapping, tilted cards.
- Cards now raise on hover or keyboard focus, straighten/scale to the front, and tuck the others underneath with dimmed opacity.
- Added a decorative animated waveform strip to each card, marked `aria-hidden` and disabled under reduced-motion.
- Kept the previous flat `ActionCard` grid as the narrow-shell fallback.

### Behavior
- Introduced `useShellNarrow` to track `.app-container` width classes live and switch between deck/grid at runtime.
- Consolidated Launchpad data into a shared feature list to avoid drift between render modes.

### Styling
- Added deck layout, card stacking, hover/focus transitions, tuck states, badge styling, waveform animation, and reduced-motion overrides.

### Tests
- Added coverage for wide-shell deck rendering, interaction/stacking behavior, accessibility, narrow-shell fallback, and runtime switching.

### Layout sketch
Before:
```
[ Card ] [ Card ] [ Card ]
[ Card ] [ Card ] [ Card ]
[ Card ]
```

After:
```
      [Card]
   [Card] [Card]
[Card] [Card] [Card]
```

### Behavior flow
```mermaid
flowchart TD
  A[Launchpad renders] --> B{Shell narrow?}
  B -->|Yes| C[Render flat ActionCard grid]
  B -->|No| D[Render LaunchpadDeck]
  D --> E[Hover / focus a card]
  E --> F[Raise active card]
  F --> G[Dim and tuck siblings]
  G --> H[Mouse leave / blur]
  H --> I[Settle deck]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->