### PR TITLE
fix(engines): revive dead license dialog, refresh matrix on select, surface routing verdict

### DIFF
--- a/backend/services/engine_routing.py
+++ b/backend/services/engine_routing.py
@@ -63,7 +63,21 @@ def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResul
             "routing_reason": _caveat(caps),
         }
 
-    # 3. Host has an accelerator the engine lacks, but engine supports cpu
+    # 3. CPU-native engine (declares ONLY cpu) has nothing to fall back FROM,
+    #    so on ANY accelerator host it is benign cpu_only (neutral), never a
+    #    warn-tone "CPU fallback". This must precede the fallback rule below —
+    #    a ("cpu",) engine matches `"cpu" in targets` too, and would otherwise
+    #    be mis-classed cpu_fallback on a GPU/MPS host. (A cpu host reaches
+    #    rule 5 unchanged, keeping its DirectML note.) Engines that *could*
+    #    accelerate elsewhere (e.g. ("cuda", "cpu")) are untouched.
+    if fam != "cpu" and targets == ("cpu",):
+        return {
+            "effective_device": "cpu",
+            "routing_status": "cpu_only",
+            "routing_reason": None,
+        }
+
+    # 4. Host has an accelerator the engine lacks, but engine supports cpu
     #    → the no-silent-fallback signal.
     if fam != "cpu" and "cpu" in targets:
         if fam == "rocm" and "cuda" in targets and "rocm" not in targets:
@@ -76,7 +90,7 @@ def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResul
             "routing_reason": reason,
         }
 
-    # 4. Genuine CPU-only host (or DirectML, which the probe reports as cpu)
+    # 5. Genuine CPU-only host (or DirectML, which the probe reports as cpu)
     #    and engine supports cpu → benign; must not warn or block.
     if fam == "cpu" and "cpu" in targets:
         reason = None
@@ -93,7 +107,7 @@ def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResul
             "routing_reason": reason,
         }
 
-    # 5. Engine needs an accelerator this host lacks and has no cpu path.
+    # 6. Engine needs an accelerator this host lacks and has no cpu path.
     first = targets[0]
     return {
         "effective_device": first,

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -152,7 +152,7 @@ export default function EngineCompatibilityMatrix({
   const [activeFamily, setActiveFamily] = useState(family);
   // Phase 3 Plan 03-01 / TTS-05: which engine has its license dialog
   // currently open, or null. Only one dialog is ever open at a time.
-  const [, setLicenseDialogFor] = useState(null);
+  const [licenseDialogFor, setLicenseDialogFor] = useState(null);
 
   // health state keyed by engine id:
   //   { [id]: { inflight: boolean, ok?: boolean, message?: string,
@@ -266,6 +266,9 @@ export default function EngineCompatibilityMatrix({
   if (!familyData) return null;
 
   const activeBackendId = activeId ?? familyData.active;
+  // TTS-05: the license dialog registered for the engine awaiting acceptance
+  // (or null). Capitalized so JSX renders it as a component below.
+  const LicenseDialog = licenseDialogFor ? LICENSE_DIALOGS[licenseDialogFor] : null;
 
   return (
     <section className="engine-matrix flex flex-col gap-[var(--space-3,8px)]">
@@ -415,7 +418,7 @@ export default function EngineCompatibilityMatrix({
                     shows a single "Remote" badge instead of device chips. */}
                 <div
                   role="cell"
-                  className="engine-matrix__cell engine-matrix__cell--gpu flex items-center shrink-0"
+                  className="engine-matrix__cell engine-matrix__cell--gpu flex flex-col items-start justify-center shrink-0 gap-[3px]"
                   style={{ width: 170 }}
                 >
                   <div className="engine-matrix__chips inline-flex flex-wrap gap-[4px]">
@@ -467,6 +470,22 @@ export default function EngineCompatibilityMatrix({
                       </>
                     )}
                   </div>
+                  {/* Make the routing reason reachable without a hover: the
+                      badge `title` is invisible to keyboard + touch users, so
+                      surface the same string as small visible text. Shown for
+                      available, non-remote, non-unavailable rows that carry a
+                      reason (cpu_fallback always; accelerated w/ a caveat). */}
+                  {b.routing_reason &&
+                    b.available &&
+                    b.routing_status !== 'n/a' &&
+                    b.routing_status !== 'unavailable' && (
+                      <span
+                        className="engine-matrix__routing-reason text-[10px] leading-[1.25] text-[color:var(--chrome-fg-muted,#888)]"
+                        data-testid={`routing-reason-${b.id}`}
+                      >
+                        {b.routing_reason}
+                      </span>
+                    )}
                 </div>
 
                 {/* Isolation mode */}
@@ -528,7 +547,14 @@ export default function EngineCompatibilityMatrix({
                       title={health.message}
                     >
                       {health.ok
-                        ? t('engines.latencyMs', { ms: health.latency_ms })
+                        ? // A subprocess row spawns + pings its sidecar → the
+                          // latency is a real round-trip. An in-process row only
+                          // imports + `is_available()`-checks (a ~0 ms liveness
+                          // probe, not a synthesis test), so label it as such
+                          // rather than a misleading "0 ms" latency.
+                          b.isolation_mode === 'subprocess'
+                          ? t('engines.latencyMs', { ms: health.latency_ms })
+                          : t('engines.depsOk')
                         : t('engines.failed')}
                     </span>
                   )}
@@ -536,7 +562,13 @@ export default function EngineCompatibilityMatrix({
                     <Button
                       size="sm"
                       variant="subtle"
-                      onClick={() => onSelect(activeFamily, b.id)}
+                      onClick={async () => {
+                        // Await the pick, then re-fetch so the active badge,
+                        // Use buttons, and family-tab captions reflect the new
+                        // engine immediately — no manual Refresh needed (#…).
+                        await onSelect(activeFamily, b.id);
+                        reload();
+                      }}
                       aria-label={`Use ${b.display_name}`}
                     >
                       {t('engines.use')}
@@ -570,6 +602,21 @@ export default function EngineCompatibilityMatrix({
           )}
         </div>
       </Table>
+
+      {/* TTS-05: license-acceptance dialog for the selected engine. Mounted
+          only while `licenseDialogFor` is set (one at a time). On Accept the
+          dialog POSTs the acceptance then `onAccepted` reloads the matrix so
+          the row flips from unavailable → available without a manual refresh. */}
+      {LicenseDialog && (
+        <LicenseDialog
+          open
+          onClose={() => setLicenseDialogFor(null)}
+          onAccepted={() => {
+            setLicenseDialogFor(null);
+            reload();
+          }}
+        />
+      )}
     </section>
   );
 }

--- a/frontend/src/components/WizardLibrary.jsx
+++ b/frontend/src/components/WizardLibrary.jsx
@@ -25,6 +25,7 @@ import { cn } from '@/lib/utils';
 import { useModels, useInstallModel } from '../api/hooks';
 import { setupDownloadStreamUrl } from '../api/setup';
 import { listEngines, selectEngine } from '../api/engines';
+import { notifyEngineSelected } from '../utils/engineSelectToast';
 import { Badge, Button } from '../ui';
 
 const fmtGB = (gb) => (gb == null ? '' : `${gb.toFixed(gb < 10 ? 1 : 0)} GB`);
@@ -253,6 +254,9 @@ export default function WizardLibrary() {
     try {
       const r = await selectEngine('tts', id);
       setEngines((e) => (e ? { ...e, active: r.active } : e));
+      // Consume the routing echo: warn when the pick lands on a CPU fallback
+      // on this host, otherwise confirm the switch. See notifyEngineSelected.
+      notifyEngineSelected(r, t, 'tts');
     } catch (e) {
       toast.error(e?.message || 'switch failed');
     } finally {

--- a/frontend/src/components/settings/EnginesTab.jsx
+++ b/frontend/src/components/settings/EnginesTab.jsx
@@ -3,6 +3,7 @@ import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { addBreadcrumb } from '../../utils/breadcrumbs';
 import { selectEngine } from '../../api/engines';
+import { notifyEngineSelected } from '../../utils/engineSelectToast';
 import EngineCompatibilityMatrix from '../EngineCompatibilityMatrix';
 import { SETTINGS_SECTION_SURFACE } from './primitives';
 
@@ -15,17 +16,20 @@ export default function EnginesTab() {
   // its install / GPU / isolation state.
   //
   // Review mode (the staged-checkpoint nudges) moved to Settings → General.
-  const onSelect = useCallback(async (family, backendId) => {
-    try {
-      addBreadcrumb(`engine:${family}=${backendId}`);
-      const r = await selectEngine(family, backendId);
-      toast.success(
-        t('settings.engine_switched', { family: family.toUpperCase(), engine: r.active }),
-      );
-    } catch (e) {
-      toast.error(e.message || t('engines.switch_failed'));
-    }
-  }, []);
+  const onSelect = useCallback(
+    async (family, backendId) => {
+      try {
+        addBreadcrumb(`engine:${family}=${backendId}`);
+        const r = await selectEngine(family, backendId);
+        // Consume the routing echo: warn (not a bare success) when the pick
+        // lands on a CPU fallback on this host. See notifyEngineSelected.
+        notifyEngineSelected(r, t, family);
+      } catch (e) {
+        toast.error(e.message || t('engines.switch_failed'));
+      }
+    },
+    [t],
+  );
 
   return (
     <section className={SETTINGS_SECTION_SURFACE} data-slot="settings-section">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1477,6 +1477,7 @@
     "recheck": "Re-check",
     "rechecking": "Re-checking…",
     "latencyMs": "{{ms}} ms",
+    "depsOk": "deps OK",
     "failed": "failed",
     "acceptLicense": "Accept license",
     "noBackends": "No backends registered.",
@@ -1487,7 +1488,8 @@
     "routingRemote": "Remote",
     "routingUnknown": "Unknown",
     "routingEffectiveChip": "Runs on {{device}} on this machine",
-    "routingCaveatTitle": "GPU selected, but: {{reason}}"
+    "routingCaveatTitle": "GPU selected, but: {{reason}}",
+    "selectCpuFallback": "{{engine}}: running on CPU — {{reason}}"
   },
   "errors": {
     "title": "This tab hit a snag.",

--- a/frontend/src/test/EngineCompatibilityMatrix.test.jsx
+++ b/frontend/src/test/EngineCompatibilityMatrix.test.jsx
@@ -392,4 +392,149 @@ describe('EngineCompatibilityMatrix', () => {
       expect(within(indexRow).getByText(/failed/i)).toBeInTheDocument();
     });
   });
+
+  // ── P3-A: routing reason is reachable without a hover ──────────────────
+  it('surfaces the routing reason as visible text, not only a hover title', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(routingResponse());
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('Fallback TTS'));
+    const row = screen.getByText('Fallback TTS').closest('[role="row"]');
+    // Visible text (keyboard/touch reachable) — was previously only a badge title.
+    expect(within(row).getByTestId('routing-reason-fallback')).toHaveTextContent(
+      'engine has no CUDA path; running on CPU',
+    );
+    // A clean accelerated row (no caveat reason) shows no reason line.
+    const accelRow = screen.getByText('Accel TTS').closest('[role="row"]');
+    expect(within(accelRow).queryByTestId('routing-reason-accel')).not.toBeInTheDocument();
+  });
+
+  // ── P3-B: in-process health check reads as a liveness/deps check ────────
+  it('labels an in-process health check "deps OK" while subprocess shows real ms', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(makeEnginesResponse());
+    const apiGetEngineHealth = vi
+      .fn()
+      .mockResolvedValue({ id: 'omnivoice', ok: true, message: 'import ok', latency_ms: 0 });
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={apiGetEngineHealth}
+      />,
+    );
+    await waitFor(() => screen.getByText('OmniVoice (test)'));
+    const omniRow = screen.getByText('OmniVoice (test)').closest('[role="row"]');
+    fireEvent.click(within(omniRow).getByRole('button', { name: /test omnivoice/i }));
+    await waitFor(() => {
+      expect(within(omniRow).getByTestId('health-result-omnivoice')).toHaveTextContent('deps OK');
+    });
+    // The misleading "0 ms" latency is NOT shown for an in-process liveness probe.
+    expect(within(omniRow).queryByText(/0 ms/)).not.toBeInTheDocument();
+  });
+
+  // ── P1-B: matrix refreshes after a successful select (no manual Refresh) ─
+  it('reflects the new active engine after select resolves, without a manual Refresh', async () => {
+    let active = 'omnivoice';
+    const resp = () => ({
+      tts: {
+        active,
+        backends: [
+          {
+            id: 'omnivoice',
+            display_name: 'OmniVoice (test)',
+            available: true,
+            reason: null,
+            install_hint: null,
+            last_error: null,
+            isolation_mode: 'in-process',
+            gpu_compat: ['cpu'],
+          },
+          {
+            id: 'indextts2',
+            display_name: 'IndexTTS2 (test)',
+            available: true,
+            reason: null,
+            install_hint: null,
+            last_error: null,
+            isolation_mode: 'subprocess',
+            gpu_compat: ['cuda', 'cpu'],
+          },
+        ],
+      },
+      asr: { active: '', backends: [] },
+      llm: { active: 'off', backends: [] },
+    });
+    const apiListEngines = vi.fn(async () => resp());
+    const onSelect = vi.fn(async (_family, id) => {
+      active = id; // backend now reports the new active engine
+    });
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        onSelect={onSelect}
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('IndexTTS2 (test)'));
+    const indexRow = () => screen.getByText('IndexTTS2 (test)').closest('[role="row"]');
+    // Not active yet.
+    expect(within(indexRow()).queryByText('active')).not.toBeInTheDocument();
+
+    fireEvent.click(within(indexRow()).getByRole('button', { name: /use indextts2/i }));
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith('tts', 'indextts2'));
+
+    // Active badge moves to IndexTTS2 after the post-select reload — no manual Refresh.
+    await waitFor(() => {
+      expect(within(indexRow()).getByText('active')).toBeInTheDocument();
+    });
+    // The reload re-fetched the engine list (initial mount + post-select).
+    expect(apiListEngines.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── P1-A: the license dialog actually mounts on "Accept license" ────────
+  it('mounts the Supertonic license dialog when "Accept license" is clicked', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue({
+      tts: {
+        active: 'omnivoice',
+        backends: [
+          {
+            id: 'supertonic3',
+            display_name: 'Supertonic-3',
+            available: false,
+            reason: 'Supertonic-3 license not accepted — review and accept to enable it.',
+            install_hint: null,
+            last_error: null,
+            isolation_mode: 'in-process',
+            gpu_compat: ['cpu'],
+          },
+        ],
+      },
+      asr: { active: '', backends: [] },
+      llm: { active: 'off', backends: [] },
+    });
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('Supertonic-3'));
+    // Dialog is not mounted until the button is clicked (state was previously
+    // discarded, so this click did nothing — the regression this guards).
+    expect(screen.queryByText('Supertonic-3 — License Acceptance')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /review and accept supertonic-3 license/i }),
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Supertonic-3 — License Acceptance')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/test/engineSelectToast.test.js
+++ b/frontend/src/test/engineSelectToast.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// A single callable spy that also carries `.success` / `.error`, matching the
+// react-hot-toast shape (default + named `toast` are the same object).
+const { toastFn } = vi.hoisted(() => {
+  const fn = vi.fn();
+  fn.success = vi.fn();
+  fn.error = vi.fn();
+  return { toastFn: fn };
+});
+vi.mock('react-hot-toast', () => ({ default: toastFn, toast: toastFn }));
+
+import { notifyEngineSelected } from '../utils/engineSelectToast';
+
+// Fake `t` that echoes key + interpolation vars so assertions can see both.
+const t = (key, vars) => `${key}:${JSON.stringify(vars || {})}`;
+
+describe('notifyEngineSelected (routing echo → toast)', () => {
+  beforeEach(() => {
+    toastFn.mockClear();
+    toastFn.success.mockClear();
+  });
+
+  it('warns (with the reason) when the pick lands on a cpu_fallback', () => {
+    notifyEngineSelected(
+      {
+        active: 'indextts2',
+        routing_status: 'cpu_fallback',
+        routing_reason: 'engine has no CUDA path; running on CPU',
+      },
+      t,
+      'tts',
+    );
+    // Warn path uses the bare toast() with an icon; NOT toast.success.
+    expect(toastFn.success).not.toHaveBeenCalled();
+    expect(toastFn).toHaveBeenCalledTimes(1);
+    const [msg, opts] = toastFn.mock.calls[0];
+    expect(msg).toContain('engines.selectCpuFallback');
+    expect(msg).toContain('indextts2');
+    expect(msg).toContain('engine has no CUDA path; running on CPU');
+    expect(opts).toMatchObject({ icon: expect.any(String) });
+  });
+
+  it('shows a plain success toast for an accelerated pick', () => {
+    notifyEngineSelected(
+      { active: 'omnivoice', routing_status: 'accelerated', routing_reason: null },
+      t,
+      'tts',
+    );
+    expect(toastFn).not.toHaveBeenCalled(); // no warn toast
+    expect(toastFn.success).toHaveBeenCalledTimes(1);
+    expect(toastFn.success.mock.calls[0][0]).toContain('settings.engine_switched');
+    expect(toastFn.success.mock.calls[0][0]).toContain('TTS');
+  });
+
+  it('shows a plain success toast for a benign cpu_only pick', () => {
+    notifyEngineSelected(
+      { active: 'kittentts', routing_status: 'cpu_only', routing_reason: null },
+      t,
+      'tts',
+    );
+    expect(toastFn).not.toHaveBeenCalled();
+    expect(toastFn.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a plain success toast for a legacy response with no routing_status', () => {
+    notifyEngineSelected({ active: 'legacy' }, t, 'asr');
+    expect(toastFn).not.toHaveBeenCalled();
+    expect(toastFn.success).toHaveBeenCalledTimes(1);
+    expect(toastFn.success.mock.calls[0][0]).toContain('ASR');
+  });
+});

--- a/frontend/src/utils/engineSelectToast.js
+++ b/frontend/src/utils/engineSelectToast.js
@@ -1,0 +1,36 @@
+/**
+ * notifyEngineSelected — post-select feedback for a TTS/ASR/LLM engine pick.
+ *
+ * `/engines/select` echoes the routing verdict (routing_status /
+ * effective_device / routing_reason) for the picked engine on THIS host
+ * precisely so the UI can warn when the pick lands on a CPU fallback — it
+ * still runs, just slower. Before this, every pick fired the same plain
+ * "switched" success toast, hiding the fact that a GPU engine was silently
+ * downgraded to CPU on this machine (backend note: engines.py select echo).
+ *
+ *   - routing_status === 'cpu_fallback' → warn-tone toast naming the reason.
+ *   - everything else (accelerated / cpu_only / n/a / legacy) → plain success.
+ *
+ * Shared by Settings → Engines and the first-run WizardLibrary so both paths
+ * consume the echo identically.
+ */
+import { toast } from 'react-hot-toast';
+
+export function notifyEngineSelected(r, t, family = 'tts') {
+  if (r?.routing_status === 'cpu_fallback') {
+    toast(
+      t('engines.selectCpuFallback', {
+        engine: r.active,
+        reason: r.routing_reason || '',
+      }),
+      { icon: '⚠️' },
+    );
+    return;
+  }
+  toast.success(
+    t('settings.engine_switched', {
+      family: (family || '').toUpperCase(),
+      engine: r?.active,
+    }),
+  );
+}

--- a/tests/test_engine_routing.py
+++ b/tests/test_engine_routing.py
@@ -50,9 +50,34 @@ def test_accelerated_ignores_advisory_notes():
     assert r["routing_reason"] is None
 
 
-# ── Rule 3: cpu_fallback (the no-silent-fallback signal) ──────────────────
-def test_cuda_host_cpu_only_engine_falls_back():
+# ── Rule 3: cpu-native engine (gpu_compat == ("cpu",)) is neutral anywhere ──
+# A cpu-native engine (kittentts / moonshine / sherpa) has nothing to fall back
+# FROM, so an accelerator host must NOT warn-tone it as a "CPU fallback" — it's
+# benign cpu_only on ANY host. Regression for the badge-tone bug (#…).
+def test_cpu_native_engine_neutral_on_mps_host():
+    r = resolve_routing(("cpu",), _caps("mps"))
+    assert r == {"effective_device": "cpu", "routing_status": "cpu_only",
+                 "routing_reason": None}
+
+
+def test_cpu_native_engine_neutral_on_cuda_host():
+    # Was mis-classed cpu_fallback (warn) before the fix; now cpu_only (neutral).
     r = resolve_routing(("cpu",), _caps("cuda"))
+    assert r["routing_status"] == "cpu_only"
+    assert r["routing_reason"] is None
+
+
+def test_cpu_native_engine_neutral_on_cpu_host():
+    # A cpu host already routed cpu-native → cpu_only; unchanged by the new rule.
+    r = resolve_routing(("cpu",), _caps("cpu"))
+    assert r["routing_status"] == "cpu_only"
+
+
+# ── Rule 4: cpu_fallback (the no-silent-fallback signal) ──────────────────
+# Only a MULTI-target engine that genuinely could accelerate elsewhere but
+# lacks THIS host's accelerator falls back (and warns).
+def test_cuda_host_engine_without_cuda_path_falls_back():
+    r = resolve_routing(("mps", "cpu"), _caps("cuda"))
     assert r["routing_status"] == "cpu_fallback"
     assert r["effective_device"] == "cpu"
     assert "no CUDA path" in r["routing_reason"]
@@ -70,7 +95,7 @@ def test_xpu_host_cpu_engine_falls_back():
     assert "no XPU path" in r["routing_reason"]
 
 
-# ── Rule 4: cpu_only (benign) ─────────────────────────────────────────────
+# ── Rule 5: cpu_only (benign) ─────────────────────────────────────────────
 def test_cpu_host_cpu_engine_is_neutral():
     r = resolve_routing(("cuda", "cpu"), _caps("cpu"))
     assert r == {"effective_device": "cpu", "routing_status": "cpu_only",
@@ -84,7 +109,7 @@ def test_directml_host_gets_explanatory_reason_but_stays_neutral():
     assert "DirectML" in r["routing_reason"]
 
 
-# ── Rule 5: unavailable ───────────────────────────────────────────────────
+# ── Rule 6: unavailable ───────────────────────────────────────────────────
 def test_cpu_host_gpu_only_engine_unavailable():
     r = resolve_routing(("cuda",), _caps("cpu"))
     assert r["routing_status"] == "unavailable"
@@ -118,14 +143,16 @@ def test_deterministic_across_calls():
 
 
 def test_reason_str_for_fallback_and_unavailable_none_for_clean():
-    assert resolve_routing(("cpu",), _caps("cuda"))["routing_reason"] is not None
+    # A genuine fallback (multi-target engine lacking the host accel) carries a
+    # reason; a cpu-native ("cpu",) engine is neutral (covered above).
+    assert resolve_routing(("mps", "cpu"), _caps("cuda"))["routing_reason"] is not None
     assert resolve_routing(("cuda",), _caps("cpu"))["routing_reason"] is not None
     assert resolve_routing(("cuda", "cpu"), _caps("cuda"))["routing_reason"] is None
 
 
 # ── routing_notice (synth-time surfacing decision) ──────────────────────────
 def test_notice_emitted_for_cpu_fallback():
-    r = resolve_routing(("cpu",), _caps("cuda"))
+    r = resolve_routing(("mps", "cpu"), _caps("cuda"))
     n = routing_notice(r)
     assert n is not None and n[0] == "cpu_fallback" and n[1]
 

--- a/tests/test_routing_redaction.py
+++ b/tests/test_routing_redaction.py
@@ -41,6 +41,8 @@ def test_none_reason_must_not_become_empty_string():
 
 
 def test_fallback_reason_scrubs_clean_and_nonempty():
-    r = resolve_routing(("cpu",), _caps("cuda"))
+    # A genuine fallback: multi-target engine lacking the host accel. (A
+    # cpu-native ("cpu",) engine is neutral cpu_only with a None reason now.)
+    r = resolve_routing(("mps", "cpu"), _caps("cuda"))
     clean = scrub_text(r["routing_reason"])
     assert clean and "***REDACTED***" not in clean  # no secret to redact here


### PR DESCRIPTION
Six live-audit fixes for the **Settings → Engines** surface (matrix + first-run wizard), priority order.

### Fixed
- **P1-A · Dead Supertonic license dialog (broken since #101).** `const [, setLicenseDialogFor] = useState(null)` discarded the state value and the imported `SupertonicLicenseDialog` was never mounted, so the "Accept license" button set state nobody read — a dead button. Now keeps the value (`licenseDialogFor`) and renders the registered dialog with `open` / `onClose` / `onAccepted` (accept → matrix reload, so the row flips unavailable → available without a manual refresh).
- **P1-B · Stale matrix after "Use".** The active badge, Use buttons and family-tab captions stayed stale until a manual Refresh. The Use button now awaits `onSelect` then `reload()`s, so the picked engine is reflected immediately.
- **P2-A · Consume the routing echo on select.** `/engines/select` echoes `routing_status` / `effective_device` / `routing_reason` precisely so the UI can warn on a fallback pick, but both call sites showed the same success toast regardless. A `cpu_fallback` pick now shows a **warn-tone** toast naming the reason ("running on CPU — …"); accelerated/cpu_only keep the plain success toast. Shared `notifyEngineSelected` helper wires both Settings→Engines and the first-run `WizardLibrary`.
- **P2-B · CPU-native engines no longer badge warn-tone "CPU fallback".** An engine whose `gpu_compat == ("cpu",)` (kittentts, moonshine, sherpa) has nothing to fall back FROM, yet on a GPU/MPS host it was classed `cpu_fallback` (warn). A new routing rule (before the fallback rule) classifies `("cpu",)` as `cpu_only` (neutral) on any accelerator host. Multi-target engines that genuinely could accelerate elsewhere (e.g. `("cuda","cpu")`) are untouched; a cpu host keeps its DirectML note.
- **P3-A · Routing reason reachable without a hover.** It was only a badge `title` tooltip (invisible to keyboard/touch). Surfaced as small visible text under the badge.
- **P3-B · In-process "Test engine" wording.** An in-process pass is an import/`is_available()` liveness check, not a synthesis test — labelling it "0 ms" was misleading. In-process rows now read "deps OK"; subprocess rows keep their real spawn-and-ping latency.

### Tests
- RTL regressions for P1-A (dialog mounts on click), P1-B (active badge moves after select, no manual refresh), P3-A (reason is visible text, not just a title), P3-B ("deps OK" for in-process while subprocess shows real ms).
- Unit tests for the `notifyEngineSelected` helper (warn on `cpu_fallback`, success otherwise).
- Backend routing unit tests updated to the corrected cpu-native intent (`("cpu",)` on cuda/mps → `cpu_only`), plus a fail-before/pass-after MPS-host case; `test_routing_redaction` / `test_generate_engine` fallback examples re-pointed to genuine multi-target engines.

### Gates
- `bunx vitest run` (full): **737 passed** incl. the new tests.
- Backend pytest: `test_engine_routing` + `test_routing_redaction` + `test_gpu_routing_verdict` + `test_generate_engine` (38+30), `test_asr_gpu_compat`, `test_no_hardcoded_cjk` — all green.
- `bun run lint` exit 0 (warnings only); `format:check` clean; `bun install --frozen-lockfile` clean (no package.json change).

_Not touched: `CHANGELOG.md`._ Suggested `## [Unreleased]` bullet:
> **Engines settings, sharper feedback.** The Supertonic license "Accept" button works again, the engine matrix refreshes the moment you pick an engine, picking a GPU engine that lands on CPU now warns you (with the reason), CPU-only engines stop being mislabelled "CPU fallback", the routing reason is readable without hovering, and an in-process "Test engine" pass reads as a dependency check ("deps OK") instead of a fake "0 ms" latency. (#…)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed several Settings → Engines issues across routing, selection feedback, and the compatibility matrix.

### What changed
- Restored the Supertonic license accept flow and reloaded the matrix after acceptance.
- Refreshed the engine matrix immediately after selecting an engine so active badges, buttons, and captions update right away.
- Added selection toast handling that warns when routing falls back to CPU, while keeping normal success toasts for direct selections.
- Corrected routing classification so CPU-native engines are treated as `cpu_only` on accelerator hosts instead of `cpu_fallback`.
- Made routing reasons visible in the matrix row instead of hiding them in hover-only metadata.
- Updated in-process test engine status text from a latency-like label to `deps OK`.

### UI sketch
```text
Before:
[ GPU/CPU badge ] [ status text ] [ tooltip-only reason ]
[ Use ]          [ manual refresh needed after select ]

After:
[ GPU/CPU badge ] [ status text ] [ reason text ]
[ Use ]          [ auto-refresh after select ]
```

### Behavior flow
```mermaid
flowchart TD
  A[User selects engine] --> B[selectEngine / useEngine]
  B --> C[API returns routing result]
  C --> D{routing_status == cpu_fallback?}
  D -- yes --> E[Show warning toast with reason]
  D -- no --> F[Show success toast]
  C --> G[Reload engine matrix]
  G --> H[Update active badge, buttons, captions]
```

### Tests
- Added coverage for license dialog mounting/acceptance.
- Added coverage for matrix reload after selection.
- Added coverage for visible routing reason text.
- Added coverage for `deps OK` vs timing display.
- Added toast tests for success and CPU-fallback warning cases.
- Expanded routing tests for cpu-only vs cpu-fallback classification and reason handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->