### PR TITLE
fix(dictation): refinement never stalls a final (~51s→≤4s), REST polish parity, real ASR preload reuse

### DIFF
--- a/backend/api/routers/capture.py
+++ b/backend/api/routers/capture.py
@@ -120,6 +120,15 @@ async def transcribe_audio(
         from services.refinement import collapse_repetitive_artifacts
         full_text = collapse_repetitive_artifacts(full_text)
 
+        # Cross-transport parity: deterministically polish the final text
+        # (leading capital + terminal punctuation) exactly like the live
+        # dictation socket (capture_ws) does, so the widget's POST fallback and
+        # MCP/CLI callers get the same typed-looking result the WS returns —
+        # not the raw "...test" the REST path used to leak. Segments stay raw
+        # (their timings/verbatim recognition are the contract).
+        from services.text_polish import polish_text
+        full_text = polish_text(full_text)
+
         # Calculate audio duration from segments if available
         duration = 0.0
         if segments:
@@ -135,8 +144,12 @@ async def transcribe_audio(
         if _truthy(refine) and full_text:
             from services.refinement import maybe_refine
             refined = await asyncio.to_thread(maybe_refine, full_text)
-            if refined and refined != full_text:
-                refined_text = refined
+            if refined:
+                # Polish the refined text too, so both surfaced strings read as
+                # typed text (mirrors the raw-vs-refined contract of the WS).
+                refined = polish_text(refined)
+                if refined != full_text:
+                    refined_text = refined
 
         logger.info(
             "Capture transcription done: engine=%s, elapsed=%.2fs, duration=%.1fs, mode=%s, refined=%s",

--- a/backend/api/routers/capture_ws.py
+++ b/backend/api/routers/capture_ws.py
@@ -315,14 +315,19 @@ async def ws_transcribe(websocket: WebSocket):
             # like typed text (leading capital, terminal punctuation).
             result["text"] = polish_text(result.get("text", ""))
             # Wave 2.1: optional local-LLM refinement of the final text.
-            # Off-thread (network call, not GPU); pass-through on any
-            # failure or when no LLM backend is configured. The raw text
-            # always ships too — clients paste refined_text ?? text.
+            # HARD-BOUNDED (maybe_refine_async, ~4s OMNIVOICE_REFINE_TIMEOUT_S):
+            # a slow/dead LLM can never delay this `final` beyond the budget —
+            # it falls back to the unrefined (but polished) text. Best-effort:
+            # never let refinement turn a good final into an error. The raw
+            # text always ships too — clients paste refined_text ?? text.
             if result.get("text"):
-                from services.refinement import maybe_refine
-                refined = await asyncio.to_thread(maybe_refine, result["text"])
-                if refined and refined != result["text"]:
-                    result["refined_text"] = refined
+                try:
+                    from services.refinement import maybe_refine_async
+                    refined = await maybe_refine_async(result["text"])
+                    if refined and refined != result["text"]:
+                        result["refined_text"] = refined
+                except Exception as e:  # noqa: BLE001
+                    logger.debug("Dictation refinement skipped: %s", e)
             if not await _safe_send({"type": "final", **result}):
                 logger.debug("Skipped final send — client already disconnected")
         except Exception as e:
@@ -476,15 +481,20 @@ async def _run_sherpa_streaming(websocket: WebSocket, spec):
     detection and on EOF. <300ms perceived latency on CPU for the tiny models.
     """
     import numpy as np
-    from services.asr_backend import SherpaDictationBackend
+    from services.asr_backend import get_sherpa_dictation_backend
 
     pcm_sr, aec = await _sherpa_session(websocket)
     logger.info("sherpa streaming dictation: model=%s sr=%d aec=%s",
                 spec.id, pcm_sr, bool(aec))
 
-    backend = SherpaDictationBackend(model_id=spec.id)
-    # Build the recognizer off the event loop (download-on-first-use + ONNX
-    # session init can take a moment); status frames keep the widget honest.
+    # Reuse the shared, per-model warm backend (#888): the recognizer is built
+    # once and shared across sessions instead of rebuilt (1.3–2.5s) per connect,
+    # so the first dictation is instant when the preload warmed it. Each session
+    # still gets its own decode stream below.
+    backend = get_sherpa_dictation_backend(spec.id)
+    # Build the recognizer off the event loop if it isn't warm yet
+    # (download-on-first-use + ONNX session init can take a moment); status
+    # frames keep the widget honest.
     if not await _sherpa_load_with_status(websocket, backend, spec):
         return
     rec = backend._rec
@@ -569,9 +579,11 @@ async def _run_sherpa_streaming(websocket: WebSocket, spec):
     segments = [{"start": 0.0, "end": None, "text": t} for t in committed if t]
     if not client_disconnected:
         if full:
+            # Hard-bounded refinement (~4s): never delays this summary `final`
+            # beyond OMNIVOICE_REFINE_TIMEOUT_S even with a dead LLM endpoint.
             try:
-                from services.refinement import maybe_refine
-                refined = await asyncio.to_thread(maybe_refine, full)
+                from services.refinement import maybe_refine_async
+                refined = await maybe_refine_async(full)
             except Exception:
                 refined = None
             payload = {"type": "final", "text": full, "segments": segments,
@@ -598,13 +610,14 @@ async def _run_sherpa_offline(websocket: WebSocket, spec):
     its samples dropped — so per-partial cost is bounded by one utterance
     (not the whole session) and sentences commit as the user pauses instead
     of only at EOF."""
-    from services.asr_backend import SherpaDictationBackend
+    from services.asr_backend import get_sherpa_dictation_backend
 
     pcm_sr, aec = await _sherpa_session(websocket)
     logger.info("sherpa offline dictation: model=%s sr=%d aec=%s",
                 spec.id, pcm_sr, bool(aec))
 
-    backend = SherpaDictationBackend(model_id=spec.id)
+    # Shared, per-model warm backend (#888) — built once, reused per session.
+    backend = get_sherpa_dictation_backend(spec.id)
     if not await _sherpa_load_with_status(websocket, backend, spec):
         return
 
@@ -731,9 +744,10 @@ async def _run_sherpa_offline(websocket: WebSocket, spec):
         payload = {"type": "final", "text": full, "segments": segments,
                    "language": "auto", "engine": backend.id}
         if full:
+            # Hard-bounded refinement (~4s) — never delays the `final`.
             try:
-                from services.refinement import maybe_refine
-                refined = await asyncio.to_thread(maybe_refine, full)
+                from services.refinement import maybe_refine_async
+                refined = await maybe_refine_async(full)
                 if refined and refined != full:
                     payload["refined_text"] = refined
             except Exception:

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -134,12 +134,17 @@ class _RefinementBody(BaseModel):
 
 
 def _refinement_state():
-    from services.refinement import get_refinement_config
+    from services.refinement import get_refinement_config, get_last_refine_status
     from services.llm_backend import get_active_llm_backend
 
     cfg = get_refinement_config()
-    # The UI shows whether refinement can actually run (needs an LLM).
+    # `llm_ready` only means "an endpoint is CONFIGURED" — a placeholder/dead
+    # endpoint still reads ready. The honesty layer is `last_refine_status`:
+    # {ok, reason, at} from the most recent final, so the panel can flag a
+    # configured-but-failing LLM (the real safety is the hard refine timeout,
+    # which keeps a dead endpoint from ever stalling the dictation final).
     cfg["llm_ready"] = get_active_llm_backend().id != "off"
+    cfg["last_refine_status"] = get_last_refine_status()
     return cfg
 
 

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -1424,6 +1424,11 @@ class SherpaDictationBackend(ASRBackend):
             )
         self._spec = spec
         self._rec = None  # lazy OfflineRecognizer / OnlineRecognizer
+        # One backend is shared across live-dictation WS sessions (see
+        # get_sherpa_dictation_backend), so guard the one-time recognizer build
+        # against two sessions racing to construct it concurrently. Each session
+        # still owns its own decode stream — only the recognizer is shared.
+        self._rec_lock = threading.Lock()
 
     @property
     def spec(self):
@@ -1441,14 +1446,25 @@ class SherpaDictationBackend(ASRBackend):
     def ensure_loaded(self) -> None:
         self._ensure_rec()
 
+    def warmup(self) -> None:
+        """Eagerly build the recognizer so the FIRST live-dictation session
+        doesn't pay the 1.3–2.5s ONNX-session load (#888 'instant first
+        dictation'). Called by the background capture-ASR preload; idempotent,
+        and the built recognizer is reused across sessions via
+        get_sherpa_dictation_backend (the same singleton the preload warms)."""
+        self._ensure_rec()
+
     def _ensure_rec(self):
         if self._rec is not None:
             return
-        from services import sherpa_dictation as _sd
-        if self._spec.streaming:
-            self._rec = _sd.build_online_recognizer(self._spec)
-        else:
-            self._rec = _sd.build_offline_recognizer(self._spec)
+        with self._rec_lock:
+            if self._rec is not None:
+                return
+            from services import sherpa_dictation as _sd
+            if self._spec.streaming:
+                self._rec = _sd.build_online_recognizer(self._spec)
+            else:
+                self._rec = _sd.build_offline_recognizer(self._spec)
 
     def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
         self._ensure_rec()
@@ -1873,6 +1889,34 @@ _capture_backend: ASRBackend | None = None
 # The sherpa model id the cached capture backend was built for, so a model
 # switch in Settings rebuilds the singleton instead of serving the old model.
 _capture_backend_key: str | None = None
+# Guards the read-modify-write of the two globals above. Both the background
+# capture-ASR preload (runs in the GPU-pool thread) and the live-dictation WS
+# handlers (run on the event loop) resolve/replace the singleton, so the
+# check-then-build must be atomic to avoid two threads each building a model.
+_capture_backend_lock = threading.Lock()
+
+
+def get_sherpa_dictation_backend(model_id: str) -> "SherpaDictationBackend":
+    """Return a shared, warm-cached :class:`SherpaDictationBackend` for
+    ``model_id``, building it at most once and reusing the recognizer across
+    live-dictation WS sessions.
+
+    Live sessions previously constructed a FRESH backend per WebSocket connect,
+    so every session reloaded the ONNX recognizer (1.3–2.5s "loading…") and the
+    #888 background preload was a no-op. This reuses the SAME module-level
+    ``_capture_backend`` singleton the preload warms (when the ids match), and
+    rebuilds on a model switch — identical invalidation to
+    :func:`get_capture_asr_backend`. Thread-safe: the recognizer is shared;
+    each session creates its own decode stream (see capture_ws)."""
+    global _capture_backend, _capture_backend_key
+    with _capture_backend_lock:
+        if (isinstance(_capture_backend, SherpaDictationBackend)
+                and _capture_backend_key == model_id):
+            return _capture_backend
+        backend = SherpaDictationBackend(model_id=model_id)
+        _capture_backend = backend
+        _capture_backend_key = model_id
+        return backend
 
 
 def dictation_model_id() -> str | None:
@@ -1912,49 +1956,52 @@ def get_capture_asr_backend() -> ASRBackend:
     """
     global _capture_backend, _capture_backend_key
 
-    # 0. Honor an explicit sherpa dictation model selection.
-    sherpa_id = dictation_model_id()
-    if sherpa_id:
-        ok, _ = SherpaDictationBackend.is_available()
+    # Atomic resolve+build so the preload thread and a WS session (which may
+    # call get_sherpa_dictation_backend concurrently) can't both build a model.
+    with _capture_backend_lock:
+        # 0. Honor an explicit sherpa dictation model selection.
+        sherpa_id = dictation_model_id()
+        if sherpa_id:
+            ok, _ = SherpaDictationBackend.is_available()
+            if ok:
+                if not (isinstance(_capture_backend, SherpaDictationBackend)
+                        and _capture_backend_key == sherpa_id):
+                    try:
+                        _capture_backend = SherpaDictationBackend(model_id=sherpa_id)
+                        _capture_backend_key = sherpa_id
+                    except Exception as e:  # noqa: BLE001 — fall through to Whisper
+                        logger.warning(
+                            "sherpa dictation model %r unavailable (%s) — falling "
+                            "back to Whisper capture engine", sherpa_id, e,
+                        )
+                        _capture_backend = None
+                        _capture_backend_key = None
+                if _capture_backend is not None:
+                    return _capture_backend
+            else:
+                logger.info(
+                    "dictation.model_id=%r selected but sherpa-onnx not installed — "
+                    "falling back to Whisper capture engine", sherpa_id,
+                )
+
+        if _capture_backend is not None and _capture_backend_key is None:
+            return _capture_backend
+
+        # Prefer MLX Turbo on Apple Silicon
+        ok, _ = MLXWhisperBackend.is_available()
         if ok:
-            if not (isinstance(_capture_backend, SherpaDictationBackend)
-                    and _capture_backend_key == sherpa_id):
-                try:
-                    _capture_backend = SherpaDictationBackend(model_id=sherpa_id)
-                    _capture_backend_key = sherpa_id
-                except Exception as e:  # noqa: BLE001 — fall through to Whisper
-                    logger.warning(
-                        "sherpa dictation model %r unavailable (%s) — falling "
-                        "back to Whisper capture engine", sherpa_id, e,
-                    )
-                    _capture_backend = None
-                    _capture_backend_key = None
-            if _capture_backend is not None:
-                return _capture_backend
-        else:
-            logger.info(
-                "dictation.model_id=%r selected but sherpa-onnx not installed — "
-                "falling back to Whisper capture engine", sherpa_id,
-            )
+            _capture_backend = MLXWhisperBackend(model_name=_MLX_MODEL_TURBO)
+            _capture_backend_key = None
+            return _capture_backend
 
-    if _capture_backend is not None and _capture_backend_key is None:
-        return _capture_backend
+        # Fall back to faster-whisper (CPU int8 on non-Apple)
+        ok, _ = FasterWhisperBackend.is_available()
+        if ok:
+            _capture_backend = FasterWhisperBackend()
+            _capture_backend_key = None
+            return _capture_backend
 
-    # Prefer MLX Turbo on Apple Silicon
-    ok, _ = MLXWhisperBackend.is_available()
-    if ok:
-        _capture_backend = MLXWhisperBackend(model_name=_MLX_MODEL_TURBO)
+        # Last resort
+        _capture_backend = PyTorchWhisperBackend()
         _capture_backend_key = None
         return _capture_backend
-
-    # Fall back to faster-whisper (CPU int8 on non-Apple)
-    ok, _ = FasterWhisperBackend.is_available()
-    if ok:
-        _capture_backend = FasterWhisperBackend()
-        _capture_backend_key = None
-        return _capture_backend
-
-    # Last resort
-    _capture_backend = PyTorchWhisperBackend()
-    _capture_backend_key = None
-    return _capture_backend

--- a/backend/services/refinement.py
+++ b/backend/services/refinement.py
@@ -19,12 +19,68 @@ Two tiers, both applied only to FINAL transcripts (never partials):
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
 import re
+import time
 from dataclasses import dataclass
 
 logger = logging.getLogger("omnivoice.refinement")
+
+# Hard wall-clock budget (seconds) for a single dictation refinement LLM call.
+# The dictation FINAL must never be delayed longer than this by a slow or dead
+# LLM endpoint — refinement is best-effort and falls back to the unrefined
+# (but polished) text on timeout. 4s keeps a healthy local model (Ollama /
+# LM Studio, sub-second on the tiny cleanup prompt) fully usable while turning
+# the old worst case — a placeholder/dead endpoint blocking the send ~51s until
+# the widget's 15s fallback fired — into a bounded ~4s at most. Env-tunable so
+# power users on a slow local LLM can raise it. Guarded by the regression tests
+# in tests/backend/services/test_refinement_llm.py and tests/test_capture_ws.py.
+_DEFAULT_REFINE_TIMEOUT_S = 4.0
+
+
+def _refine_timeout_s() -> float:
+    """The refinement LLM budget in seconds (OMNIVOICE_REFINE_TIMEOUT_S).
+
+    Falls back to :data:`_DEFAULT_REFINE_TIMEOUT_S` on an unset/invalid/non-
+    positive value so a bad env var can never disable the bound."""
+    raw = os.environ.get("OMNIVOICE_REFINE_TIMEOUT_S", "")
+    try:
+        v = float(raw)
+        if v > 0:
+            return v
+    except (TypeError, ValueError):
+        pass
+    return _DEFAULT_REFINE_TIMEOUT_S
+
+
+# Most-recent refinement outcome, so the Settings panel can tell the user when a
+# configured LLM is actually failing/timing out (the honesty layer behind the
+# `llm_ready` flag, which only means "an endpoint is configured"). Best-effort,
+# process-local, cleared on success.
+_last_refine_status: dict | None = None
+
+
+def _note_refine_status(*, ok: bool, reason: str | None = None) -> None:
+    global _last_refine_status
+    _last_refine_status = {"ok": bool(ok), "reason": reason, "at": time.time()}
+
+
+def get_last_refine_status() -> dict | None:
+    """The last refinement outcome as ``{ok, reason, at}`` or None if refinement
+    hasn't run this session. ``ok=False`` with ``reason`` ("timeout" or a short
+    error string) means a configured LLM failed the most recent final."""
+    return dict(_last_refine_status) if _last_refine_status else None
+
+
+def _short_reason(exc: Exception) -> str:
+    """A compact, non-leaky label for a refinement failure (for the UI hint)."""
+    name = type(exc).__name__
+    if "Timeout" in name or "timeout" in str(exc).lower():
+        return "timeout"
+    return name
 
 # A token (or unit) must repeat at least this many times consecutively to be
 # treated as an STT artifact. Rhetorical repetition ("no, no, no, no, no" —
@@ -274,9 +330,18 @@ def set_refinement_config(cfg: dict) -> dict:
     return merged
 
 
-def refine_transcript(transcript: str, flags: RefinementFlags | None = None) -> str:
+def refine_transcript(
+    transcript: str,
+    flags: RefinementFlags | None = None,
+    *,
+    timeout_s: float | None = None,
+) -> str:
     """Run the transcript through the configured LLM. Raises on failure —
-    callers decide the fallback (maybe_refine swallows into pass-through)."""
+    callers decide the fallback (maybe_refine swallows into pass-through).
+
+    The LLM HTTP call is bounded by ``timeout_s`` (default: the refinement
+    budget) so a dead/slow endpoint can't tie the call up for the client's full
+    45s LLM timeout — the class of stall this whole module guards against."""
     from services.llm_backend import get_active_llm_backend
 
     flags = flags or RefinementFlags()
@@ -286,31 +351,78 @@ def refine_transcript(transcript: str, flags: RefinementFlags | None = None) -> 
         messages.append({"role": "user", "content": user_turn})
         messages.append({"role": "assistant", "content": assistant_turn})
     messages.append({"role": "user", "content": transcript})
-    return backend.chat_messages(messages=messages).strip()
+    budget = timeout_s if timeout_s is not None else _refine_timeout_s()
+    return backend.chat_messages(messages=messages, timeout=budget).strip()
 
 
-def maybe_refine(transcript: str) -> str | None:
+def maybe_refine(transcript: str, *, timeout_s: float | None = None) -> str | None:
     """Best-effort refinement for the dictation final path.
 
     Returns the refined text, or None when refinement is off, no LLM
     backend is configured, the result is empty, or anything fails — the
-    raw transcript always stands. Never raises.
+    raw transcript always stands. Never raises. Records the outcome via
+    :func:`get_last_refine_status` so the UI can flag a failing LLM.
+
+    Blocking (network I/O); the WS/REST callers run it off-thread. Prefer
+    :func:`maybe_refine_async` on the live-dictation path — it adds the hard
+    wall-clock bound so a slow endpoint can never delay the ``final`` send.
     """
     if not transcript or not transcript.strip():
         return None
-    try:
-        cfg = get_refinement_config()
-        if not cfg.get("auto", True):
-            return None
-        from services.llm_backend import get_active_llm_backend
+    cfg = get_refinement_config()
+    if not cfg.get("auto", True):
+        return None
+    from services.llm_backend import get_active_llm_backend
 
-        backend = get_active_llm_backend()
-        if backend.id == "off":
-            return None
-        refined = refine_transcript(transcript, RefinementFlags.from_dict(cfg))
+    backend = get_active_llm_backend()
+    if backend.id == "off":
+        # No LLM configured is not a failure — leave the last status untouched.
+        return None
+    try:
+        refined = refine_transcript(
+            transcript, RefinementFlags.from_dict(cfg), timeout_s=timeout_s
+        )
         if not refined:
             return None
+        _note_refine_status(ok=True)
         return refined
     except Exception as e:  # noqa: BLE001 — pass-through is the contract
         logger.warning("Dictation refinement skipped: %s", e)
+        _note_refine_status(ok=False, reason=_short_reason(e))
+        return None
+
+
+async def maybe_refine_async(
+    transcript: str, *, timeout_s: float | None = None
+) -> str | None:
+    """Async, hard-time-bounded refinement for the live-dictation final path.
+
+    Runs :func:`maybe_refine` off-thread under a hard ``OMNIVOICE_REFINE_TIMEOUT_S``
+    (~4s) budget so a slow or dead LLM endpoint can NEVER block the caller — and
+    therefore the dictation ``final`` send — longer than the budget. On timeout
+    (or any failure) it returns None and the raw, already-polished transcript
+    stands. Never raises.
+
+    ``asyncio.wait_for`` can't cancel the worker thread, but the LLM call it runs
+    is itself bounded to the same budget (see :func:`refine_transcript`), so an
+    orphaned thread unwinds shortly after rather than lingering the full 45s.
+    """
+    if not transcript or not transcript.strip():
+        return None
+    budget = timeout_s if timeout_s is not None else _refine_timeout_s()
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(maybe_refine, transcript, timeout_s=budget),
+            timeout=budget,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Dictation refinement exceeded its %.1fs budget — sending the "
+            "unrefined final (set OMNIVOICE_REFINE_TIMEOUT_S to adjust).", budget,
+        )
+        _note_refine_status(ok=False, reason="timeout")
+        return None
+    except Exception as e:  # noqa: BLE001 — best-effort; the raw final stands
+        logger.warning("Dictation refinement failed: %s", e)
+        _note_refine_status(ok=False, reason=_short_reason(e))
         return None

--- a/frontend/src/components/settings/RefinementPanel.jsx
+++ b/frontend/src/components/settings/RefinementPanel.jsx
@@ -15,6 +15,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Wand2 } from 'lucide-react';
 import { apiJson, apiFetch } from '../../api/client';
+import { useAppStore } from '../../store';
+import { refineFailureNote } from './refineStatus';
 import { SettingsSection, SettingRow, SettingsToggle } from './primitives';
 
 const FLAG_ROWS = [
@@ -78,6 +80,7 @@ export default function RefinementPanel() {
 
   if (!cfg) return null;
   const llmReady = Boolean(cfg.llm_ready);
+  const failureNote = refineFailureNote(cfg.last_refine_status);
 
   return (
     <SettingsSection
@@ -92,6 +95,19 @@ export default function RefinementPanel() {
       {error && (
         <div className="perfpanel__error" role="alert">
           {error}
+        </div>
+      )}
+
+      {failureNote && (
+        <div className="perfpanel__error" role="status">
+          {failureNote}{' '}
+          <button
+            type="button"
+            className="underline"
+            onClick={() => useAppStore.getState().openSettingsTab('llm-providers')}
+          >
+            Open LLM Providers
+          </button>
         </div>
       )}
 

--- a/frontend/src/components/settings/refineStatus.js
+++ b/frontend/src/components/settings/refineStatus.js
@@ -1,0 +1,19 @@
+/**
+ * Honesty layer for the dictation-refinement `llm_ready` flag.
+ *
+ * `llm_ready` only means "an endpoint is CONFIGURED" — a placeholder key or a
+ * dead local endpoint still reads ready. The backend also reports
+ * `last_refine_status` ({ok, reason, at}) from the most recent final, so the
+ * panel can tell the user when a configured LLM is actually failing/timing out.
+ * The dictation final is never blocked (the hard refine timeout inserts the raw
+ * text regardless), so this message is purely informational.
+ *
+ * Returns the user-facing string, or null when the last refinement succeeded /
+ * hasn't run.
+ */
+export function refineFailureNote(status) {
+  if (!status || status.ok !== false) return null;
+  return status.reason === 'timeout'
+    ? 'The last dictation refinement timed out — the LLM endpoint is slow or unreachable. Dictation still works (the raw transcript is inserted). Test the connection in LLM Providers.'
+    : 'The last dictation refinement failed — the configured LLM endpoint rejected the request. Dictation still works (the raw transcript is inserted). Test the connection in LLM Providers.';
+}

--- a/frontend/src/test/refinementFailureNote.test.js
+++ b/frontend/src/test/refinementFailureNote.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { refineFailureNote } from '../components/settings/refineStatus';
+
+// The honesty layer behind `llm_ready` (which only means "an endpoint is
+// configured"): when the backend reports the last dictation refinement failed
+// or timed out, the panel surfaces WHY and points at the LLM Providers Test
+// button. A healthy/absent status shows nothing.
+describe('refineFailureNote — RefinementPanel honesty hint', () => {
+  it('is silent when there is no status', () => {
+    expect(refineFailureNote(null)).toBeNull();
+    expect(refineFailureNote(undefined)).toBeNull();
+  });
+
+  it('is silent when the last refinement succeeded', () => {
+    expect(refineFailureNote({ ok: true, reason: null })).toBeNull();
+  });
+
+  it('flags a timeout as a slow/unreachable endpoint (dictation still works)', () => {
+    const note = refineFailureNote({ ok: false, reason: 'timeout' });
+    expect(note).toMatch(/timed out/i);
+    expect(note).toMatch(/raw transcript is inserted/i);
+    expect(note).toMatch(/LLM Providers/i);
+  });
+
+  it('flags a non-timeout failure as a rejected request', () => {
+    const note = refineFailureNote({ ok: false, reason: 'RuntimeError' });
+    expect(note).toMatch(/failed/i);
+    expect(note).toMatch(/LLM Providers/i);
+  });
+});

--- a/tests/backend/services/test_refinement_llm.py
+++ b/tests/backend/services/test_refinement_llm.py
@@ -6,6 +6,9 @@ No real LLM: the active backend is monkeypatched. The pass-through contract
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 
 from services import refinement
@@ -135,6 +138,79 @@ def test_maybe_refine_respects_flag_config(monkeypatch, stored_config):
     monkeypatch.setattr("services.llm_backend.get_active_llm_backend", lambda: fake)
     refinement.maybe_refine("hello world out there")
     assert "Preserve technical terms" not in fake.seen_messages[0]["content"]
+
+
+# ── maybe_refine_async: hard timeout budget (P0 — 51s stall) ─────────────────
+
+
+class _SlowBackend:
+    """A live-but-unresponsive LLM: accepts the call, never answers in time —
+    the class of endpoint (placeholder key, dead Ollama) that stalled dictation."""
+
+    id = "openai-compat"
+
+    def __init__(self, sleep_s=5.0):
+        self.sleep_s = sleep_s
+
+    def chat_messages(self, *, messages, timeout=None):
+        time.sleep(self.sleep_s)
+        return "too late"
+
+
+def test_refine_timeout_env_default_and_override(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_REFINE_TIMEOUT_S", raising=False)
+    assert refinement._refine_timeout_s() == 4.0
+    monkeypatch.setenv("OMNIVOICE_REFINE_TIMEOUT_S", "1.5")
+    assert refinement._refine_timeout_s() == 1.5
+    # Invalid / non-positive values can never disable the bound.
+    monkeypatch.setenv("OMNIVOICE_REFINE_TIMEOUT_S", "junk")
+    assert refinement._refine_timeout_s() == 4.0
+    monkeypatch.setenv("OMNIVOICE_REFINE_TIMEOUT_S", "-3")
+    assert refinement._refine_timeout_s() == 4.0
+
+
+def test_maybe_refine_async_hard_timeout_returns_none_fast(monkeypatch, stored_config):
+    """A slow LLM (5s) must NOT block past the 0.3s budget — the raw text stands
+    and the outcome is recorded as a timeout. Fail-before: the WS handler used
+    to `await asyncio.to_thread(maybe_refine, ...)` unbounded (the ~51s stall)."""
+    monkeypatch.setattr(
+        "services.llm_backend.get_active_llm_backend", lambda: _SlowBackend(3.0))
+
+    async def _timed():
+        # Measure the AWAIT inside the loop — the caller (the WS handler) is
+        # unblocked here, and the status is read at the instant dictation
+        # completes (before the orphaned to_thread finishes at loop shutdown;
+        # the long-lived app loop never waits on it).
+        t0 = time.perf_counter()
+        out = await refinement.maybe_refine_async("um hello there", timeout_s=0.3)
+        return out, time.perf_counter() - t0, refinement.get_last_refine_status()
+
+    out, dt, status = asyncio.run(_timed())
+    assert out is None
+    assert dt < 2.0, f"refinement blocked the caller {dt:.1f}s — the budget was 0.3s"
+    assert status and status["ok"] is False and status["reason"] == "timeout"
+
+
+def test_maybe_refine_async_success_records_ok(monkeypatch, stored_config):
+    fake = _FakeBackend("So the meeting is at 3pm.")
+    monkeypatch.setattr("services.llm_backend.get_active_llm_backend", lambda: fake)
+
+    out = asyncio.run(refinement.maybe_refine_async("so um the meeting is at 3pm"))
+    assert out == "So the meeting is at 3pm."
+    status = refinement.get_last_refine_status()
+    assert status and status["ok"] is True
+
+
+def test_maybe_refine_async_off_backend_is_noop(monkeypatch, stored_config):
+    class _Off:
+        id = "off"
+    monkeypatch.setattr("services.llm_backend.get_active_llm_backend", lambda: _Off())
+    assert asyncio.run(refinement.maybe_refine_async("some words here")) is None
+
+
+def test_maybe_refine_async_empty_transcript(stored_config):
+    assert asyncio.run(refinement.maybe_refine_async("")) is None
+    assert asyncio.run(refinement.maybe_refine_async("   ")) is None
 
 
 # ── Config round-trip ───────────────────────────────────────────────────────

--- a/tests/test_capture_refine.py
+++ b/tests/test_capture_refine.py
@@ -59,6 +59,30 @@ def _post(client, **data):
     )
 
 
+def test_rest_polishes_text_like_ws_socket(client):
+    """P1 parity regression: the REST /transcribe `text` is polished (leading
+    capital + terminal punctuation) exactly like the WS `final`. Before the fix
+    REST leaked the raw recognizer string (e.g. "um … you know") while the WS
+    returned "Um … you know." — the widget's POST fallback and MCP/CLI callers
+    saw different text than live dictation."""
+    body = _post(client).json()
+    assert body["text"][0].isupper()
+    assert body["text"].endswith(".")
+    # Segments stay raw (their verbatim recognition / timing is the contract).
+    assert body["segments"][0]["text"] == "um so like the meeting is at 3pm you know"
+
+
+def test_refined_text_is_also_polished(client, monkeypatch):
+    """`refined_text` is polished too, so both surfaced strings read as typed
+    text (an LLM that forgets the trailing period still yields a clean final)."""
+    monkeypatch.setattr(
+        "services.refinement.maybe_refine",
+        lambda _t: "so the meeting is at 3pm")  # lowercase, no period
+
+    body = _post(client, refine="true").json()
+    assert body["refined_text"] == "So the meeting is at 3pm."
+
+
 def test_no_refine_flag_returns_raw_only(client, monkeypatch):
     # maybe_refine must never even be called when the flag is absent.
     called = {"n": 0}
@@ -72,7 +96,10 @@ def test_no_refine_flag_returns_raw_only(client, monkeypatch):
     r = _post(client)
     assert r.status_code == 200
     body = r.json()
-    assert body["text"].startswith("um so like")
+    # REST now polishes the final exactly like the WS socket (leading capital +
+    # terminal punctuation) — no more raw "um so like…" leaking to the widget
+    # fallback / MCP / CLI.
+    assert body["text"] == "Um so like the meeting is at 3pm you know."
     assert "refined_text" not in body
     assert called["n"] == 0
 
@@ -85,9 +112,10 @@ def test_refine_flag_adds_refined_text_when_changed(client, monkeypatch):
     r = _post(client, refine="true")
     assert r.status_code == 200
     body = r.json()
-    # Raw text is preserved verbatim …
-    assert body["text"].startswith("um so like")
-    # … and the cleaned text rides alongside it.
+    # The (polished) raw text is preserved …
+    assert body["text"] == "Um so like the meeting is at 3pm you know."
+    # … and the cleaned text rides alongside it (already terminal-punctuated,
+    # so polish is idempotent here).
     assert body["refined_text"] == "So the meeting is at 3pm."
 
 

--- a/tests/test_capture_ws.py
+++ b/tests/test_capture_ws.py
@@ -11,6 +11,8 @@ The ASR backends are mocked — we're testing protocol, not transcription
 quality.
 """
 import os
+import time
+
 import pytest
 
 os.environ.setdefault("OMNIVOICE_MODEL", "test")
@@ -102,6 +104,45 @@ def test_empty_binary_frame_acts_as_eof(client):
                 break
         assert final is not None
         assert final["engine"] == "stub"
+
+
+def test_slow_llm_never_blocks_final_beyond_budget(client, monkeypatch):
+    """P0 regression (the measured ~51s stall): with refinement armed and a
+    slow/dead LLM, the `final` must arrive within the hard
+    OMNIVOICE_REFINE_TIMEOUT_S budget, NOT after the LLM's full latency.
+
+    Fail-before: the handler awaited ``maybe_refine`` unbounded, so a 3s (in
+    prod, ~51s) LLM held the `final` — the pill hung "Transcribing…". Pass-
+    after: the final ships the unrefined (but polished) text within the budget.
+    """
+    monkeypatch.setenv("OMNIVOICE_REFINE_TIMEOUT_S", "0.3")
+
+    def _slow(_t, **_kw):
+        time.sleep(3.0)  # a dead endpoint would never answer in the test window
+        return "REFINED (must never arrive)"
+
+    # Patch at the source module — the handler runs maybe_refine off-thread and
+    # maybe_refine_async resolves the name from services.refinement at call time.
+    monkeypatch.setattr("services.refinement.maybe_refine", _slow)
+
+    with client.websocket_connect("/ws/transcribe") as ws:
+        ws.send_bytes(_audio_chunk())
+        ws.send_text("EOF")
+        t0 = time.perf_counter()
+        final = None
+        for _ in range(10):
+            msg = ws.receive_json()
+            if msg.get("type") == "final":
+                final = msg
+                break
+        elapsed = time.perf_counter() - t0
+
+    assert final is not None, "server never delivered final"
+    # The unrefined, polished text — refinement timed out and fell back.
+    assert final["text"] == "Hello world."
+    assert "refined_text" not in final
+    # Well under the 3s LLM sleep; the 0.3s budget + overhead is the ceiling.
+    assert elapsed < 2.0, f"final blocked {elapsed:.1f}s on the slow LLM"
 
 
 # ── Capture-ASR background warm-up gating (dictation v2) ─────────────────────

--- a/tests/test_sherpa_dictation.py
+++ b/tests/test_sherpa_dictation.py
@@ -268,6 +268,56 @@ def test_capture_backend_honors_dictation_model_id(fake_sherpa, no_download, mon
     assert b2.spec.id == "sherpa-parakeet-tdt-v3"
 
 
+# ── #888: warmup builds the recognizer; WS sessions reuse it ────────────────
+
+
+def test_sherpa_warmup_builds_recognizer(fake_sherpa, no_download):
+    """warmup() eagerly builds the recognizer so the first live session doesn't
+    pay the ONNX-session load. Before the fix SherpaDictationBackend had no
+    warmup(), so the #888 preload's `if hasattr(backend, 'warmup')` was a no-op
+    and the recognizer stayed cold until the first dictation."""
+    from services import asr_backend as ab
+
+    b = ab.SherpaDictationBackend(model_id="sherpa-whisper-tiny")
+    assert hasattr(b, "warmup")
+    assert b._rec is None
+    b.warmup()
+    assert b._rec is not None  # recognizer built eagerly
+    # Idempotent — a second warmup keeps the SAME recognizer (no rebuild).
+    rec = b._rec
+    b.warmup()
+    assert b._rec is rec
+
+
+def test_get_sherpa_dictation_backend_reuses_warm_singleton(fake_sherpa, no_download, monkeypatch):
+    """A second WS session for the same model reuses the warm backend instead
+    of rebuilding the recognizer (1.3–2.5s) per connect — the reuse that makes
+    the #888 preload actually pay off. A model switch rebuilds (same
+    invalidation as the get_capture_asr_backend singleton)."""
+    from services import asr_backend as ab
+
+    ab._capture_backend = None
+    ab._capture_backend_key = None
+    monkeypatch.setattr(ab.SherpaDictationBackend, "is_available",
+                        classmethod(lambda cls: (True, "ready")))
+
+    b1 = ab.get_sherpa_dictation_backend("sherpa-whisper-tiny")
+    b1.warmup()
+    rec = b1._rec
+
+    b2 = ab.get_sherpa_dictation_backend("sherpa-whisper-tiny")
+    assert b2 is b1, "same-model session rebuilt the backend instead of reusing"
+    assert b2._rec is rec, "recognizer was rebuilt on reuse"
+
+    # Switching the model rebuilds and rebinds the shared singleton.
+    b3 = ab.get_sherpa_dictation_backend("sherpa-parakeet-tdt-v3")
+    assert b3 is not b1
+    assert b3.spec.id == "sherpa-parakeet-tdt-v3"
+
+    ab._capture_backend = None
+    ab._capture_backend_key = None
+
+
 def test_capture_backend_falls_back_when_dictation_disabled(monkeypatch):
     from services import asr_backend as ab
     ab._capture_backend = None


### PR DESCRIPTION
## Why

A live audit of Dictation surfaced a **measured 51-second stall** on every final plus three correctness gaps. This fixes the class of each.

## P0 — Refinement blocked every dictation final with no timeout
With refinement `auto:true` and a slow/dead LLM endpoint, `maybe_refine` ran **unbounded** and blocked the `final` send in all three `capture_ws` handlers (legacy, sherpa-streaming, sherpa-offline) — ~51s measured, the pill stuck on "Transcribing…" until the widget's 15s fallback fired.

**Fix:** a hard, env-tunable budget `OMNIVOICE_REFINE_TIMEOUT_S` (default **4s**) via a new `maybe_refine_async`, wired into all three final paths. A slow/dead endpoint now falls back to the unrefined-but-**polished** text within the budget and can **never** delay the final beyond it. The LLM HTTP call is bounded to the same budget so the orphaned worker unwinds instead of holding a connection for the client's full 45s. The legacy handler's refinement is now fully best-effort too (it can't turn a good final into an `error` frame).

**Before/after (regression harness):** a fake LLM sleeping 3s → old code blocked the final ~3s (prod: ~51s); new code delivers the final in **~0.3s** (0.3s test budget), unrefined. Unit test: `maybe_refine_async` returns in <2s against a 5s→3s LLM vs. the full sleep before.

Chose approach **(a)** (hard timeout) over **(b)** (send final immediately, swap in a `refined` frame). (b) does not fit cleanly: the refined text is what currently gets *pasted*, so a late swap means either re-inserting into an arbitrary focused field (risk of double-insert / a disruptive backspace-storm to replace) or silently downgrading the feature to "paste raw, refine only cosmetically." The ≤4s bound preserves paste-the-refined-text while eliminating the stall. Noted as a possible follow-up if the team wants instant-insert-raw semantics.

## P1 — REST `/transcribe` lacked polish parity
`capture.py` never applied `polish_text`, so REST returned raw `"…test"` while the WS returned `"…test."`. Now polishes `text` **and** `refined_text` (segments stay raw), so the widget POST fallback and MCP/CLI callers match the live socket.

## P1 — The #888 "instant first dictation" preload was a no-op
The preload called `warmup()` only `if hasattr`, but `SherpaDictationBackend` had none, and the WS handlers built a **fresh** backend per session (so a warm singleton was never reused). Added `SherpaDictationBackend.warmup()` (builds the recognizer) and a shared, per-model warm backend `get_sherpa_dictation_backend()` (same invalidation as the capture singleton, guarded by a shared lock); each session keeps its own decode stream. First dictation no longer pays the 1.3–2.5s load — the changelog claim is now true.

## P1 — `llm_ready` honesty
`llm_ready` only means "an endpoint is configured" (a placeholder key reads ready). The P0 timeout makes a dead endpoint harmless; added `last_refine_status` so `RefinementPanel` flags a configured-but-failing LLM and links to **LLM Providers → Test** (#887).

## Not done (follow-ups, per the P2 "only if room" guidance)
Kept scope tight and the widget stable (it's central to the P0 area). Deferred: i18n of `RefinementPanel.jsx` + `AecPanel.jsx` (currently hardcoded English — no CJK, so no gate break); surfacing the `omni_capture_live_typing` pref as a Settings toggle; removing the dead `LS_CAPTURE_MODE` pref.

## Tests / gates
- Backend: `test_refinement_llm` (+ new async-timeout/status), `test_capture_ws` (+ new slow-LLM-final-under-budget), `test_capture_refine` (updated to the polished contract + new parity/refined-polish tests), `test_sherpa_dictation` (+ new warmup-builds / session-reuse). `test_no_hardcoded_cjk` + `test_api_route_inventory` green (no route changes).
- Frontend: full `vitest run` — **733 passed** (incl. new `refineFailureNote` test); `lint` 0 errors; `format:check` clean; `bun install --frozen-lockfile` clean (no package.json change).

## Suggested CHANGELOG bullet (not edited here)
```
### Fixed
- **Dictation no longer freezes on a slow/dead LLM.** Transcript refinement is now hard-bounded (OMNIVOICE_REFINE_TIMEOUT_S, default 4s): a placeholder key or unreachable endpoint falls back to the clean unrefined text instead of stalling the paste ~51s. REST /transcribe now polishes text like live dictation, the sherpa dictation model is genuinely pre-warmed and reused across sessions (instant first dictation), and Settings flags a configured-but-failing LLM. (#refine-preload)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added a hard timeout for dictation refinement so slow/dead LLM endpoints no longer block final transcript delivery.
- Switched live and Sherpa dictation final refinement to the async path with timeout enforcement.
- Made Sherpa dictation preload reuse a warmed shared backend instead of rebuilding per session.
- Applied text polishing to REST `/transcribe` so it matches live dictation output.
- Exposed refinement health/status to settings UI and added a clearer failure hint with a direct link to LLM provider settings.

## Behavior flow
```mermaid
flowchart TD
  A[Dictation final transcript ready] --> B{Refinement enabled?}
  B -- no --> E[Polish text + send final]
  B -- yes --> C[Run async refinement with timeout]
  C --> D{Refinement finished in time?}
  D -- yes --> E2[Polish refined text]
  D -- no / error --> E
  E2 --> F{Refined text differs?}
  F -- yes --> G[Return refined_text]
  F -- no --> E
  E --> H[Deliver final immediately]
```

## UI sketch
```text
Before
[ Refine status ]
[ generic error only ]

After
[ Refine status ]
[ failure note from backend ]
[ Open LLM Providers ]
```

## Testing
- Updated backend refinement, capture WS, REST capture, and Sherpa backend coverage.
- Added frontend vitest coverage for refinement failure messaging.
- Test/lint/format/lockfile checks were updated and passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->