### PR TITLE
fix(launchpad): full-width responsive feature-card grid (retire the fixed ~780px deck)

### DIFF
--- a/frontend/src/components/LaunchpadDeck.jsx
+++ b/frontend/src/components/LaunchpadDeck.jsx
@@ -1,66 +1,58 @@
 import React, { useState } from 'react';
 
-// ── Deck-of-cards geometry ──────────────────────────────────────────
-// Per-card tilt (deg) and lift (px) for the fanned spread. Hand-picked so
-// the fan reads "artistically shuffled" but stays subtle (±4° / ≤14px) and
-// deterministic — same layout every launch, no randomness. Index-aligned
-// with the launchpad feature order.
-const DECK_TILT = [-3.5, 2, -1, 3, -2, 3.5, -1.5];
-const DECK_LIFT = [10, 2, 14, 0, 12, 4, 8];
+// ── Feature-card geometry ───────────────────────────────────────────
 // Decorative waveform bar heights (px) on each card face — 7 CSS-only bars
-// pulse via stagger-delayed scaleY keyframes (see .lp-deck-wave in
+// pulse via stagger-delayed scaleY keyframes (see .lp-card-wave in
 // index.css). Static under prefers-reduced-motion.
-const DECK_WAVE = [8, 15, 10, 19, 12, 16, 9];
+const CARD_WAVE = [8, 15, 10, 19, 12, 16, 9];
+// Card min-track (px) handed to the grid's `repeat(auto-fit, minmax(min, 1fr))`.
+// This floor is the ONLY responsive knob: the browser derives the column count
+// from the grid's OWN rendered width (= the shell's own width under the
+// `zoom: --ui-scale` model), so columns reflow 7→…→1 with zero viewport @media.
+// A wider floor on narrow shells yields fewer, comfier columns.
+const CARD_MIN_WIDE = '200px';
+const CARD_MIN_NARROW = '240px';
 
 /**
- * DeckCard — one card in the fanned deck. Absolutely positioned by CSS from
- * `--deck-i` (fan slot), `--deck-r` (tilt) and `--deck-y` (lift); `--card-hue`
- * drives the accent exactly like ActionCard. Hover OR keyboard focus raises
- * the card (`--front`: straighten + scale up + top z) while every sibling
- * tucks toward it underneath (`--tuck-r` for cards left of it slides them
- * right, `--tuck-l` slides the right-side ones left) — the raise/tuck classes
- * are state-driven so pointer and focus share one code path. The icon + name
- * cluster is width-capped to the peeking strip so it stays readable while the
- * card sits under its right neighbor; the waveform strip is pure decoration
- * (aria-hidden), the button's accessible name stays name + description.
+ * FeatureCard — one launchpad feature tile in the full-width grid. `--card-hue`
+ * (inline) drives the accent: icon, border, waveform, badge, glow. Hover OR
+ * keyboard focus raises the card forward (`lp-action-card--raised`: lift + glow
+ * + top z) — the raise is class-driven from React state so pointer and keyboard
+ * share one code path and tests can assert it. The waveform strip is pure
+ * decoration (aria-hidden); the button's accessible name stays title + desc.
  */
-function DeckCard({ hue, Icon, title, desc, count, onClick, index, raised, onRaise, onSettle }) {
-  const state =
-    raised == null
-      ? ''
-      : raised === index
-        ? 'lp-deck-card--front'
-        : index < raised
-          ? 'lp-deck-card--tuck-r'
-          : 'lp-deck-card--tuck-l';
+function FeatureCard({ hue, Icon, title, desc, count, onClick, index, raised, onRaise, onSettle }) {
+  // Cursor-tracked spotlight: pointer position feeds --mx/--my so the
+  // .lp-glow-layer radial gradient follows the cursor (it centres itself on
+  // keyboard focus, which has no pointer).
+  const handleMouseMove = (e) => {
+    const r = e.currentTarget.getBoundingClientRect();
+    e.currentTarget.style.setProperty('--mx', `${e.clientX - r.left}px`);
+    e.currentTarget.style.setProperty('--my', `${e.clientY - r.top}px`);
+  };
   return (
     <button
       type="button"
-      className={`lp-deck-card ${state}`}
-      style={{
-        '--card-hue': hue,
-        '--deck-i': index,
-        '--deck-r': `${DECK_TILT[index]}deg`,
-        '--deck-y': `${DECK_LIFT[index]}px`,
-      }}
+      className={`lp-action-card lp-animate lp-glow-card${raised === index ? ' lp-action-card--raised' : ''}`}
+      style={{ '--card-hue': hue, '--lp-i': index }}
       onClick={onClick}
+      onMouseMove={handleMouseMove}
       onMouseEnter={() => onRaise(index)}
       onFocus={() => onRaise(index)}
       onBlur={onSettle}
     >
+      <span className="lp-glow-layer" aria-hidden="true" />
       {count > 0 && <span className="card-count">{count}</span>}
-      <span className="lp-deck-card__peek">
-        <span className="card-icon">
-          <Icon size={16} color={hue} />
-        </span>
-        <span className="lp-deck-card__name">{title}</span>
-      </span>
-      <span className="lp-deck-card__desc">{desc}</span>
-      <span className="lp-deck-wave" aria-hidden="true">
-        {DECK_WAVE.map((h, i) => (
+      <div className="card-icon">
+        <Icon size={18} color={hue} />
+      </div>
+      <h3>{title}</h3>
+      <p className="card-desc">{desc}</p>
+      <span className="lp-card-wave" aria-hidden="true">
+        {CARD_WAVE.map((h, i) => (
           <span
             key={i}
-            className="lp-deck-wave__bar"
+            className="lp-card-wave__bar"
             style={{ '--wave-h': `${h}px`, '--wave-i': i }}
           />
         ))}
@@ -70,23 +62,28 @@ function DeckCard({ hue, Icon, title, desc, count, onClick, index, raised, onRai
 }
 
 /**
- * LaunchpadDeck — the launchpad's feature cards as an overlapping
- * left→right fan (wide shells only; Launchpad.jsx renders the flat
- * ActionCard grid on shell-narrow/shell-mini instead). Interaction state —
- * which card is raised by hover/focus, or none — lives here in React (not
- * pure CSS :hover) so keyboard focus shares the exact same raise/tuck
- * behavior and tests can assert it.
+ * LaunchpadDeck — the launchpad's seven feature cards as a full-width,
+ * responsive grid. PR #904 fanned them into a fixed ~780px deck that left dead
+ * margins in a maximized window; this fills the content width instead and
+ * reflows its column count (7→…→1 from a maximized ~2560px display down to the
+ * 900×600 minimum) via `repeat(auto-fit, minmax(--lp-card-min, 1fr))` — the
+ * same container-driven mechanism the rest of the launchpad uses, never a
+ * viewport @media (which fires at the wrong width whenever --ui-scale ≠ 1).
+ * `narrow` (the app-container's own width class, via useShellNarrow) only
+ * widens the card floor so narrow shells get fewer, comfier columns. Which card
+ * is raised by hover/focus lives here in React so keyboard focus shares the
+ * exact same forward-lift as the pointer and tests can assert it.
  */
-export default function LaunchpadDeck({ features }) {
+export default function LaunchpadDeck({ features, narrow = false }) {
   const [raised, setRaised] = useState(null);
   return (
     <div
-      className={`lp-deck${raised != null ? ' lp-deck--active' : ''}`}
-      style={{ '--deck-n': features.length }}
+      className="lp-cards"
+      style={{ '--lp-card-min': narrow ? CARD_MIN_NARROW : CARD_MIN_WIDE }}
       onMouseLeave={() => setRaised(null)}
     >
       {features.map((f, i) => (
-        <DeckCard
+        <FeatureCard
           key={f.key}
           index={i}
           hue={f.hue}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1382,11 +1382,16 @@ select.input-base:focus-visible,
   /* Native <button> reset */
   font: inherit; color: inherit; text-align: left; width: 100%;
 }
-.lp-action-card:hover {
-  transform: translateY(-1px);
-  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 6%, transparent);
-  border-color: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 40%, transparent);
-  box-shadow: 0 12px 28px -14px color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 40%, transparent);
+/* Hover OR keyboard focus raises the card forward — the `--raised` class is
+   set from React state so pointer and keyboard share one path (`:hover` is
+   kept as a no-JS fallback). */
+.lp-action-card:hover,
+.lp-action-card--raised {
+  transform: translateY(-4px);
+  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 7%, transparent);
+  border-color: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 45%, transparent);
+  box-shadow: 0 18px 36px -18px color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 45%, transparent);
+  z-index: 2;
 }
 .lp-action-card .card-icon {
   width: 34px; height: 34px; position: relative; z-index: 1;
@@ -1397,7 +1402,8 @@ select.input-base:focus-visible,
   margin-bottom: 10px;
   transition: transform var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out);
 }
-.lp-action-card:hover .card-icon {
+.lp-action-card:hover .card-icon,
+.lp-action-card--raised .card-icon {
   transform: scale(1.05);
   box-shadow: 0 0 18px -2px color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 45%, transparent);
 }
@@ -1424,10 +1430,10 @@ select.input-base:focus-visible,
   opacity: 0;
   transition: opacity 260ms ease;
 }
-.lp-action-card:hover .lp-glow-layer::before { opacity: 1; }
-/* Eternal breath ring — pulses forever, tied to the card's hue. Subtle
-   enough that three of them running at staggered offsets read as "alive,"
-   not "strobing." */
+.lp-action-card:hover .lp-glow-layer::before,
+.lp-action-card--raised .lp-glow-layer::before { opacity: 1; }
+/* Eternal breath ring — pulses forever, tied to the card's hue. `--lp-i`
+   offsets each card's phase so the row reads "alive," not "strobing." */
 .lp-glow-layer::after {
   content: "";
   position: absolute;
@@ -1436,11 +1442,9 @@ select.input-base:focus-visible,
   border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 30%, transparent);
   opacity: 0.2;
   animation: lpBreath 5.2s ease-in-out infinite;
+  animation-delay: calc(var(--lp-i, 0) * -0.74s);
   box-shadow: 0 0 0 0 color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 50%, transparent);
 }
-.lp-action-card:nth-child(1) .lp-glow-layer::after { animation-delay: 0s; }
-.lp-action-card:nth-child(2) .lp-glow-layer::after { animation-delay: -1.7s; }
-.lp-action-card:nth-child(3) .lp-glow-layer::after { animation-delay: -3.4s; }
 @keyframes lpBreath {
   0%, 100% { opacity: 0.15; box-shadow: 0 0 0 0 transparent; }
   50%      { opacity: 0.55; box-shadow: 0 0 22px 0 color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 20%, transparent); }
@@ -1475,6 +1479,11 @@ select.input-base:focus-visible,
   font-weight: 400;
   position: relative; z-index: 1;
   min-height: 3em;
+  /* Clamp to two lines so every card in a grid row is the same height. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 .lp-action-card .card-count {
   font-family: var(--chrome-font-mono);
@@ -1510,10 +1519,12 @@ select.input-base:focus-visible,
   from { opacity: 0; transform: translateY(12px); }
   to { opacity: 1; transform: translateY(0); }
 }
-.lp-animate { animation: lpFadeUp 0.4s cubic-bezier(0.4,0,0.2,1) both; }
-.lp-animate:nth-child(1) { animation-delay: 0s; }
-.lp-animate:nth-child(2) { animation-delay: 0.06s; }
-.lp-animate:nth-child(3) { animation-delay: 0.12s; }
+.lp-animate {
+  animation: lpFadeUp 0.4s cubic-bezier(0.4, 0, 0.2, 1) both;
+  /* Stagger the deal across all cards via each card's own --lp-i (set inline
+     in LaunchpadDeck) — degrades to 0s where --lp-i is absent. */
+  animation-delay: calc(var(--lp-i, 0) * 0.05s);
+}
 
 /* Wave bars — each one reads its own --bar-h / --bar-dur / --bar-delay so
    the group breathes organically instead of marching in lockstep. Colour
@@ -1547,185 +1558,52 @@ select.input-base:focus-visible,
   animation-delay: var(--bar-delay, 0s);
 }
 
-/* ── Launchpad deck-of-cards (wide shells only) ────────────────────
-   The seven feature cards fanned left→right like a hand of cards: each
-   card is absolutely positioned in its fan slot (`--deck-i`), tilted a
-   few degrees (`--deck-r`) and lifted a few px (`--deck-y`) — values come
-   inline from Launchpad.jsx's DECK_TILT/DECK_LIFT so the spread is
-   deterministic. Geometry: 260px cards across a 780px fan → every card
-   peeks ~87px (~33%) out from under its right neighbor; z stacks
-   left→right so the right neighbor always covers. Raise/tuck classes are
-   set from React state (hover + keyboard focus share them):
-     --front   raised card: straighten, scale up, top of the stack
-     --tuck-r  cards left of the raised one slide right toward it
-     --tuck-l  cards right of it slide left — everything hides under it.
-   Fixed .lp-deck height = zero layout jump while cards move. Narrow/mini
-   shells never render the deck (JSX falls back to the flat grid). */
-.lp-deck {
-  position: relative;
-  height: 252px;
-  max-width: 780px;
-  --deck-card-w: 260px;
-  --deck-card-h: 200px;
+/* ── Launchpad feature cards — full-width responsive grid ──────────
+   PR #904 fanned these seven cards into a fixed ~780px deck, which left dead
+   margins in a maximized window. This fills the content width instead:
+   `repeat(auto-fit, minmax(--lp-card-min, 1fr))` lets the browser derive the
+   column count from the GRID'S OWN width — which, under the shell's
+   `zoom: --ui-scale` model, equals the shell's own width (the same
+   container-driven mechanism as the recent-files grid, never a viewport @media
+   that would fire at the wrong width when --ui-scale ≠ 1). Columns reflow
+   7→…→1 from a maximized ~2560px display down to the 900×600 minimum, every
+   column stretching (1fr) so there are no dead margins and no horizontal
+   scroll. `--lp-card-min` is set inline from useShellNarrow (a wider floor on
+   narrow shells → fewer, comfier columns). The cards are the .lp-action-card
+   tiles above, each carrying a decorative waveform strip. */
+.lp-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--lp-card-min, 200px), 1fr));
+  gap: 12px;
+  width: 100%;
 }
-@keyframes lpDeckDeal {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+/* Decorative waveform strip on each card — 7 accent bars breathing on
+   stagger-delayed scaleY; `--lp-i` shifts each card's phase so the row never
+   pulses in lockstep. aria-hidden in the JSX. Frozen under reduced motion. */
+@keyframes lpCardWave {
+  0%, 100% { transform: scaleY(0.35); opacity: 0.5; }
+  50%      { transform: scaleY(1);    opacity: 0.95; }
 }
-.lp-deck-card {
-  position: absolute;
-  top: 14px;
-  left: calc(var(--deck-i, 0) * (100% - var(--deck-card-w)) / (var(--deck-n, 7) - 1));
-  width: var(--deck-card-w);
-  height: var(--deck-card-h);
-  z-index: calc(var(--deck-i, 0) + 1);
+.lp-card-wave {
   display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  padding: 12px 14px 12px 12px;
-  text-align: left;
-  font: inherit;
-  color: inherit;
-  cursor: pointer;
-  border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 26%, var(--chrome-border));
-  border-radius: var(--chrome-radius-pill);
-  /* Opaque face — lower cards must actually disappear underneath. */
-  background: linear-gradient(
-    160deg,
-    color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 10%, var(--chrome-bg)) 0%,
-    var(--chrome-bg) 55%
-  );
-  box-shadow: -12px 10px 26px -18px rgba(0, 0, 0, 0.55);
-  transform: translateY(var(--deck-y, 0px)) rotate(var(--deck-r, 0deg));
-  transform-origin: 20% 90%;
-  transition:
-    transform 240ms var(--ease-out),
-    opacity 240ms ease-out,
-    border-color 240ms ease-out,
-    box-shadow 240ms ease-out;
-  animation: lpDeckDeal 0.5s ease-out both;
-  animation-delay: calc(var(--deck-i, 0) * 60ms);
-}
-/* Raised card (hover or keyboard focus, class-driven from React state):
-   straighten, lift, scale up, and take the top of the stack. */
-.lp-deck-card--front {
-  z-index: 40;
-  transform: translateY(-8px) rotate(0deg) scale(1.04);
-  border-color: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 55%, transparent);
-  box-shadow: 0 22px 44px -20px color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 55%, transparent);
-}
-/* Everyone else tucks under it: slide toward the raised card (increasing
-   the overlap), settle slightly lower, scale down and fade a touch. */
-.lp-deck--active .lp-deck-card:not(.lp-deck-card--front) {
-  opacity: 0.55;
-  transform: translate(var(--deck-slide, 0px), calc(var(--deck-y, 0px) + 6px))
-    rotate(var(--deck-r, 0deg)) scale(0.96);
-}
-.lp-deck-card--tuck-r { --deck-slide: 30px; }
-.lp-deck-card--tuck-l { --deck-slide: -30px; }
-.lp-deck-card:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 70%, transparent);
-  outline-offset: 2px;
-}
-/* Icon + name cluster, width-capped to the ~87px strip each card keeps
-   visible under its right neighbor — the "peeking edge" stays labeled. */
-.lp-deck-card__peek {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  width: 74px;
-  flex: none;
-}
-.lp-deck-card .card-icon {
-  width: 30px;
-  height: 30px;
-  border-radius: var(--chrome-radius-pill);
-  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 28%, transparent);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: none;
-}
-.lp-deck-card__name {
-  font-family: var(--chrome-font-mono);
-  font-size: 0.66rem;
-  font-weight: 600;
-  /* Tighter than --chrome-label-track so 11-char names ("TRANSCRIPTS")
-     still fit the peek column without a mid-word break. */
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  line-height: 1.35;
-  color: var(--chrome-fg);
-  overflow-wrap: anywhere;
-}
-.lp-deck-card__desc {
-  margin-top: 10px;
-  font-family: var(--font-sans);
-  font-size: 0.7rem;
-  line-height: 1.5;
-  font-weight: 400;
-  color: var(--chrome-fg-muted);
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-  overflow: hidden;
-}
-/* Count badge sits inside the peek strip (right of the icon) so it stays
-   visible even while the card is tucked under its right neighbor. */
-.lp-deck-card .card-count {
-  font-family: var(--chrome-font-mono);
-  font-size: var(--chrome-label-size);
-  font-weight: 600;
-  letter-spacing: var(--chrome-label-track);
-  padding: 1px 7px;
-  border-radius: var(--chrome-radius-pill);
-  position: absolute;
-  top: 16px;
-  left: 48px;
-  z-index: 2;
-  border: 1px solid color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 50%, transparent);
-  color: var(--card-hue, var(--chrome-accent));
-  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 10%, var(--chrome-bg));
-}
-/* Decorative waveform strip — 7 bars breathing on stagger-delayed scaleY
-   keyframes in the card's accent. `--deck-i` shifts each card's phase so
-   the deck never pulses in lockstep. aria-hidden in the JSX. */
-@keyframes lpDeckWave {
-  0%, 100% { transform: scaleY(0.35); opacity: 0.55; }
-  50%      { transform: scaleY(1);    opacity: 1; }
-}
-.lp-deck-wave {
-  display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 3px;
-  height: 20px;
-  margin-top: auto;
+  height: 18px;
+  margin-top: 12px;
+  position: relative;
+  z-index: 1;
 }
-.lp-deck-wave__bar {
+.lp-card-wave__bar {
   width: 3px;
   height: var(--wave-h, 12px);
   border-radius: 2px;
-  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 75%, var(--chrome-fg-muted));
-  transform-origin: center;
-  animation: lpDeckWave 1.6s ease-in-out infinite;
-  animation-delay: calc((var(--wave-i, 0) + var(--deck-i, 0)) * -0.19s);
+  background: color-mix(in srgb, var(--card-hue, var(--chrome-accent)) 72%, var(--chrome-fg-muted));
+  transform-origin: bottom center;
+  animation: lpCardWave 1.6s ease-in-out infinite;
+  animation-delay: calc((var(--wave-i, 0) + var(--lp-i, 0)) * -0.19s);
 }
-/* Reduced motion: no dealing/pulsing, and the raise/tuck effect becomes a
-   plain z-index + opacity swap — cards keep their static fan transform. */
 @media (prefers-reduced-motion: reduce) {
-  .lp-deck-card {
-    animation: none;
-    transition: opacity 160ms linear, border-color 160ms linear, box-shadow 160ms linear;
-  }
-  .lp-deck-card--front {
-    transform: translateY(var(--deck-y, 0px)) rotate(var(--deck-r, 0deg));
-  }
-  .lp-deck--active .lp-deck-card:not(.lp-deck-card--front) {
-    transform: translateY(var(--deck-y, 0px)) rotate(var(--deck-r, 0deg));
-    opacity: 0.45;
-  }
-  .lp-deck-wave__bar { animation: none; }
+  .lp-card-wave__bar { animation: none; }
 }
 
 /* ── Searchable combobox ─────────────────────────────────── */
@@ -2104,18 +1982,10 @@ div[role="dialog"].audio-trimmer {
    rule, no usages) and is dropped with them. */
 
 /* ── Launchpad ── */
-@media (max-width: 900px) {
-  .lp-action-card { min-width: 0; padding: 14px 12px; }
-  .lp-action-card:nth-child(1),
-  .lp-action-card:nth-child(2),
-  .lp-action-card:nth-child(3) { transform: none; }
-}
-@media (max-width: 640px) {
-  .lp-action-card { min-height: auto; padding: 12px 10px; }
-  .lp-action-card h3 { font-size: 0.88rem; }
-  .lp-action-card .card-desc { font-size: 0.68rem; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; overflow: hidden; }
-  .lp-action-card .card-icon { width: 28px; height: 28px; }
-}
+/* The feature cards now reflow via `.lp-cards` (auto-fit minmax, driven by the
+   grid's OWN width) with the card floor tuned by useShellNarrow — so there are
+   no viewport @media overrides here (they fire at the wrong width whenever
+   --ui-scale ≠ 1). See the ".lp-cards / .lp-action-card" rules above. */
 
 /* ── Studio panels — tighter on small screens ── */
 @media (max-width: 800px) {

--- a/frontend/src/pages/Launchpad.jsx
+++ b/frontend/src/pages/Launchpad.jsx
@@ -56,40 +56,8 @@ function DubThumb({ jobId, fallback }) {
 
 // Squiggle was replaced by the .lp-hero__sweep span — a pure-CSS animated
 // accent line under the H1. Less static, no SVG dependency.
-
-/**
- * ActionCard — the flat Launchpad tiles (narrow-shell fallback for the deck).
- * Reads its accent from a
- * single `--card-hue` var so the CSS derives background / border / glow /
- * spotlight from one hex color. Cursor-tracking spotlight: pointer events
- * set --mx/--my so `.lp-glow-layer` can paint a radial gradient at the
- * cursor position. Eternal breath ring lives on `.lp-glow-layer::after`
- * and pulses forever whether the card is hovered or not.
- */
-function ActionCard({ hue, Icon, title, count, onClick, children }) {
-  const handleMouseMove = (e) => {
-    const r = e.currentTarget.getBoundingClientRect();
-    e.currentTarget.style.setProperty('--mx', `${e.clientX - r.left}px`);
-    e.currentTarget.style.setProperty('--my', `${e.clientY - r.top}px`);
-  };
-  return (
-    <button
-      type="button"
-      className="lp-action-card lp-animate lp-glow-card"
-      onClick={onClick}
-      onMouseMove={handleMouseMove}
-      style={{ '--card-hue': hue }}
-    >
-      <span className="lp-glow-layer" aria-hidden="true" />
-      {count > 0 && <span className="card-count">{count}</span>}
-      <div className="card-icon">
-        <Icon size={18} color={hue} />
-      </div>
-      <h3>{title}</h3>
-      <p className="card-desc">{children}</p>
-    </button>
-  );
-}
+// The feature-card tile (.lp-action-card + waveform + hover-forward) lives in
+// components/LaunchpadDeck.jsx — one card, one rendering, at every shell width.
 
 export default function Launchpad({
   profiles,
@@ -115,9 +83,9 @@ export default function Launchpad({
   // off" strip. exportHistory arrives newest-first from /export/history.
   const recentFiles = exportHistory.slice(0, 4);
 
-  // The seven feature cards — single source for BOTH renderings (deck fan on
-  // wide shells, flat ActionCard grid on narrow ones) so hues, i18n keys,
-  // counts and navigation targets can never drift between the two branches.
+  // The seven feature cards — single source of truth for the full-width
+  // responsive grid (LaunchpadDeck) so hues, i18n keys, counts and navigation
+  // targets stay in one place.
   const features = [
     {
       key: 'clone',
@@ -259,29 +227,15 @@ export default function Launchpad({
         </div>
       </div>
 
-      {/* Feature cards — deck-of-cards fan on wide shells; the flat grid
-          below is the narrow/mini fallback (same features, same order, same
-          navigation — only the presentation degrades). */}
-      {!shellNarrow ? (
-        <div className="relative z-[1] py-[4px] px-[44px]">
-          <LaunchpadDeck features={features} />
-        </div>
-      ) : (
-        <div className="grid grid-cols-3 gap-[12px] py-[4px] px-[44px] relative z-[1] max-[900px]:pt-0 max-[900px]:px-[20px] max-[900px]:pb-[16px] max-[900px]:[grid-template-columns:repeat(auto-fit,minmax(180px,1fr))] max-[640px]:grid-cols-1 max-[640px]:pt-0 max-[640px]:px-[12px] max-[640px]:pb-[12px]">
-          {features.map((f) => (
-            <ActionCard
-              key={f.key}
-              hue={f.hue}
-              Icon={f.Icon}
-              title={f.title}
-              count={f.count}
-              onClick={f.go}
-            >
-              {f.desc}
-            </ActionCard>
-          ))}
-        </div>
-      )}
+      {/* Feature cards — one full-width, responsive grid at every shell width.
+          It reflows its column count from the shell's OWN width (see
+          LaunchpadDeck), filling a maximized display edge-to-edge and packing
+          down to the 900×600 minimum without a viewport @media. `shellNarrow`
+          (the app-container's own width class) only tunes how comfortably the
+          columns pack. */}
+      <div className="py-[4px] px-[44px] relative z-[1] max-[900px]:px-[20px] max-[640px]:px-[12px]">
+        <LaunchpadDeck features={features} narrow={shellNarrow} />
+      </div>
 
       {/* Recent files from OmniDrive — last few exports, with a jump to the
           full file browser (the Projects/OmniDrive page). */}

--- a/frontend/src/test/LaunchpadDeck.test.jsx
+++ b/frontend/src/test/LaunchpadDeck.test.jsx
@@ -1,13 +1,16 @@
-// Launchpad deck-of-cards regression suite (feat/launchpad-deck).
+// Launchpad feature-card regression suite (feat/launchpad-fullwidth).
 //
-// The launchpad's seven feature cards render as an overlapping left→right
-// fan on wide shells; hovering or keyboard-focusing any card raises it
-// (`--front`) while every other card tucks toward/under it (`--tuck-r` /
-// `--tuck-l`). On `shell-narrow`/`shell-mini` shells (the app-container's
-// own width classes — NOT viewport @media) the deck degrades to the
-// pre-existing flat ActionCard grid. Both branches share one feature list,
-// so these tests pin: card count + order, navigation targets, the
-// raise/tuck interaction for pointer AND focus, and the narrow fallback.
+// PR #904 fanned the seven feature cards into a fixed ~780px deck; this reworks
+// them into a full-width, responsive grid (`.lp-cards`) that reflows its column
+// count from the shell's OWN width — `repeat(auto-fit, minmax(--lp-card-min,
+// 1fr))`, never a viewport @media. The grid renders at EVERY shell width (no
+// deck-vs-fallback split); `useShellNarrow` only widens the card floor
+// (`--lp-card-min`) so narrow shells pack fewer, comfier columns. Each card
+// keeps #904's character: hue accent, count badge, animated waveform, and a
+// hover/focus-forward raise (class-driven from React state so pointer and
+// keyboard share one path). These tests pin: card count + order, that the cards
+// fill width via the grid (not a fixed deck), the narrow-vs-wide responsive
+// floor, navigation targets, and the raise interaction for pointer AND focus.
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -20,7 +23,7 @@ import Launchpad from '../pages/Launchpad';
 // under test here.
 vi.mock('../components/ReadinessChecklist', () => ({ default: () => null }));
 
-// Feature order is part of the contract: deck slot i = grid slot i.
+// Feature order is part of the contract: grid slot i = feature i.
 const FEATURE_NAMES = [
   'Voice Clone',
   'Voice Design',
@@ -57,24 +60,49 @@ function renderShell(props, shellClass = 'app-container') {
   );
 }
 
-const deckCards = (container) => [...container.querySelectorAll('.lp-deck-card')];
+const cardEls = (container) => [...container.querySelectorAll('.lp-action-card')];
+const cardTitles = (container) => cardEls(container).map((c) => c.querySelector('h3').textContent);
+const cardMin = (container) =>
+  container.querySelector('.lp-cards').style.getPropertyValue('--lp-card-min').trim();
 
-describe('Launchpad deck (wide shell)', () => {
-  it('renders all 7 features as deck cards, in the canonical order', () => {
+describe('Launchpad feature cards (full-width grid)', () => {
+  it('renders all 7 features as grid cards, in the canonical order', () => {
     const { container } = renderShell(makeProps());
-    const cards = deckCards(container);
+    const cards = cardEls(container);
     expect(cards).toHaveLength(7);
-    expect(cards.map((c) => c.querySelector('.lp-deck-card__name').textContent)).toEqual(
-      FEATURE_NAMES,
-    );
-    // Deck replaces the grid on wide shells — never both.
-    expect(container.querySelectorAll('.lp-action-card')).toHaveLength(0);
+    expect(cardTitles(container)).toEqual(FEATURE_NAMES);
+  });
+
+  it('lays the cards out in the full-width grid, not a fixed-width deck', () => {
+    const { container } = renderShell(makeProps());
+    const grid = container.querySelector('.lp-cards');
+    expect(grid).not.toBeNull();
+    // Every card is a direct child of the one grid — no leftover deck fan.
+    expect(container.querySelectorAll('.lp-deck, .lp-deck-card')).toHaveLength(0);
+    expect(grid.querySelectorAll(':scope > .lp-action-card')).toHaveLength(7);
+    // The grid's responsive column floor is wired (auto-fit minmax reads it).
+    expect(cardMin(container)).toBe('200px');
+  });
+
+  it('uses a wider card floor on narrow shells — responsive columns, same 7 cards', () => {
+    const wide = renderShell(makeProps());
+    const narrow = renderShell(makeProps(), 'app-container shell-narrow');
+    const mini = renderShell(makeProps(), 'app-container shell-mini');
+
+    // The only responsive knob differs by the shell's OWN width class…
+    expect(cardMin(wide.container)).toBe('200px');
+    expect(cardMin(narrow.container)).toBe('240px');
+    expect(cardMin(mini.container)).toBe('240px');
+    // …but every shell renders the same seven cards (nothing is dropped).
+    for (const r of [wide, narrow, mini]) {
+      expect(cardTitles(r.container)).toEqual(FEATURE_NAMES);
+    }
   });
 
   it('every card keeps its navigation target', () => {
     const setMode = vi.fn();
     const { container } = renderShell(makeProps({ setMode }));
-    const cards = deckCards(container);
+    const cards = cardEls(container);
     const modeTargets = [
       [2, 'dub'],
       [3, 'stories'],
@@ -91,7 +119,7 @@ describe('Launchpad deck (wide shell)', () => {
   it('clone/design cards open the studio preset to the matching method', () => {
     const setMode = vi.fn();
     const { container } = renderShell(makeProps({ setMode }));
-    const cards = deckCards(container);
+    const cards = cardEls(container);
 
     act(() => useAppStore.getState().setDefineMethod('design'));
     fireEvent.click(cards[0]); // Voice Clone
@@ -103,90 +131,70 @@ describe('Launchpad deck (wide shell)', () => {
     expect(useAppStore.getState().defineMethod).toBe('design');
   });
 
-  it('hovering a card raises it and tucks every other card toward it', () => {
+  it('hovering a card raises it forward; the others stay put', () => {
     const { container } = renderShell(makeProps());
-    const deck = container.querySelector('.lp-deck');
-    const cards = deckCards(container);
+    const grid = container.querySelector('.lp-cards');
+    const cards = cardEls(container);
 
     fireEvent.mouseOver(cards[3]);
-    expect(deck.className).toContain('lp-deck--active');
-    expect(cards[3].className).toContain('lp-deck-card--front');
-    // Cards left of the raised one slide right toward it…
-    for (const i of [0, 1, 2]) expect(cards[i].className).toContain('lp-deck-card--tuck-r');
-    // …cards right of it slide left — everything hides under the raised card.
-    for (const i of [4, 5, 6]) expect(cards[i].className).toContain('lp-deck-card--tuck-l');
-
-    // Symmetric: raising a different card re-partitions the tuck sides.
-    fireEvent.mouseOver(cards[6]);
-    expect(cards[6].className).toContain('lp-deck-card--front');
-    for (const i of [0, 1, 2, 3, 4, 5]) {
-      expect(cards[i].className).toContain('lp-deck-card--tuck-r');
+    expect(cards[3].className).toContain('lp-action-card--raised');
+    // No overlap/tuck — every other card is unaffected.
+    for (const i of [0, 1, 2, 4, 5, 6]) {
+      expect(cards[i].className).not.toContain('lp-action-card--raised');
     }
 
-    // Leaving the deck settles the fan back to rest.
-    fireEvent.mouseOut(deck);
-    expect(deck.className).not.toContain('lp-deck--active');
-    expect(container.querySelector('.lp-deck-card--front')).toBeNull();
+    // Raising a different card moves the raise, never stacking two.
+    fireEvent.mouseOver(cards[6]);
+    expect(cards[6].className).toContain('lp-action-card--raised');
+    expect(cards[3].className).not.toContain('lp-action-card--raised');
+
+    // Leaving the grid settles every card back to rest.
+    fireEvent.mouseOut(grid);
+    expect(container.querySelector('.lp-action-card--raised')).toBeNull();
   });
 
   it('keyboard focus raises a card exactly like hover (a11y parity)', () => {
     const { container } = renderShell(makeProps());
-    const deck = container.querySelector('.lp-deck');
-    const cards = deckCards(container);
+    const cards = cardEls(container);
 
     act(() => cards[5].focus());
-    expect(deck.className).toContain('lp-deck--active');
-    expect(cards[5].className).toContain('lp-deck-card--front');
-    expect(cards[6].className).toContain('lp-deck-card--tuck-l');
+    expect(cards[5].className).toContain('lp-action-card--raised');
+    for (const i of [0, 1, 2, 3, 4, 6]) {
+      expect(cards[i].className).not.toContain('lp-action-card--raised');
+    }
 
     act(() => cards[5].blur());
-    expect(deck.className).not.toContain('lp-deck--active');
-    expect(container.querySelector('.lp-deck-card--front')).toBeNull();
+    expect(container.querySelector('.lp-action-card--raised')).toBeNull();
   });
 
   it('waveform strips are decorative only (aria-hidden, 7 bars each)', () => {
     const { container } = renderShell(makeProps());
-    for (const card of deckCards(container)) {
-      const wave = card.querySelector('.lp-deck-wave');
+    for (const card of cardEls(container)) {
+      const wave = card.querySelector('.lp-card-wave');
       expect(wave).not.toBeNull();
       expect(wave.getAttribute('aria-hidden')).toBe('true');
-      expect(wave.querySelectorAll('.lp-deck-wave__bar')).toHaveLength(7);
+      expect(wave.querySelectorAll('.lp-card-wave__bar')).toHaveLength(7);
     }
   });
-});
-
-describe('Launchpad deck (narrow fallback)', () => {
-  it.each(['shell-narrow', 'shell-mini'])(
-    'degrades to the flat ActionCard grid under %s',
-    (cls) => {
-      const setMode = vi.fn();
-      const { container } = renderShell(makeProps({ setMode }), `app-container ${cls}`);
-      expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(0);
-      const gridCards = [...container.querySelectorAll('.lp-action-card')];
-      expect(gridCards).toHaveLength(7);
-      expect(gridCards.map((c) => c.querySelector('h3').textContent)).toEqual(FEATURE_NAMES);
-      // Fallback cards keep the same navigation wiring.
-      fireEvent.click(gridCards[2]);
-      expect(setMode).toHaveBeenLastCalledWith('dub');
-    },
-  );
 
   it('reacts to the shell class flipping at runtime (resize past breakpoint)', async () => {
     const { container } = renderShell(makeProps());
-    expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(7);
+    expect(cardEls(container)).toHaveLength(7);
+    expect(cardMin(container)).toBe('200px');
 
     const shell = container.querySelector('.app-container');
     await act(async () => {
       shell.classList.add('shell-narrow');
       await Promise.resolve(); // flush the MutationObserver microtask
     });
-    expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(0);
-    expect(container.querySelectorAll('.lp-action-card')).toHaveLength(7);
+    // Same seven cards, just a wider column floor — no card dropped on resize.
+    expect(cardEls(container)).toHaveLength(7);
+    expect(cardMin(container)).toBe('240px');
 
     await act(async () => {
       shell.classList.remove('shell-narrow');
       await Promise.resolve();
     });
-    expect(container.querySelectorAll('.lp-deck-card')).toHaveLength(7);
+    expect(cardMin(container)).toBe('200px');
   });
 });


### PR DESCRIPTION
## What & why

PR #904 fanned the seven Launchpad feature cards — **Voice Clone, Voice Design, Video Dubbing, Stories, Audiobook, Voice Gallery, Transcripts** — into a fixed **~780px** deck-of-cards. On a maximized display that left large dead margins on either side; the cards never used the space they had.

This reworks them into **one full-width, responsive grid** that fills the content area edge-to-edge and reflows its column count from a maximized ~2560px display all the way down to the 900×600 minimum window.

## Before → after (width behavior)

| | Before (#904 deck) | After (this PR) |
|---|---|---|
| Wide / maximized (~2560px) | fixed ~780px fan, dead margins left & right | **7 cards fill the full content width** in one row (measured: grid 2472px = container, cards stretch to ~343px each) |
| Narrow shell (~960px) | separate flat `ActionCard` grid fallback | same grid, **3 comfy columns** (wider 240px floor) |
| Minimum window (900×600) | — | **3 columns**, still edge-to-edge, no horizontal scroll |
| Reflow mechanism | fixed geometry + viewport `@media` fallback | `repeat(auto-fit, minmax(--lp-card-min, 1fr))` — column count derived from the grid's **own** width |

## How

- **One rendering at every width.** `LaunchpadDeck` now renders a single `.lp-cards` grid — no deck-vs-narrow-fallback split (which also removes the duplicate `ActionCard`). Columns come from `repeat(auto-fit, minmax(var(--lp-card-min), 1fr))`, so the browser derives the count from the grid's rendered width and every column stretches (`1fr`) → **no dead margins, no horizontal scroll**.
- **Shell-own-width, not viewport.** The only responsive knob, `--lp-card-min`, is set inline from the existing `useShellNarrow` hook (the `.app-container` `shell-narrow`/`shell-mini` classes): **200px** wide, **240px** narrow. No viewport `@media` — those fire at the wrong width under the shell's `zoom: --ui-scale` model. The old `@media (max-width: …)` launchpad overrides are deleted.
- **#904's character preserved.** Animated waveform card faces, cursor spotlight + per-card phase-offset breath ring (`--lp-i`), and a hover **or** keyboard-focus forward raise (`lp-action-card--raised`, driven from React state so pointer and keyboard share one code path). Reduced-motion freezes the waveform. All **7 navigation targets and i18n keys** are unchanged.

## Tests / gates

- `bunx vitest run` — **802 passed** (99 files); the LaunchpadDeck suite was rewritten to assert full-width grid layout, the narrow-vs-wide `--lp-card-min` floor, runtime shell-class reflow, and the raise interaction for pointer **and** focus.
- `bun run lint` (oxlint) — **0 errors**.
- `bun run format:check` (oxfmt) — clean.
- `tests/test_no_hardcoded_cjk.py` — passed.
- Real-browser (chromium) layout check: 7 cards fill full width in one row at 2472px, reflow to 3 columns at 920/876px, grid width == container at every size (no overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Launchpad feature cards

- Replaced the old fan/overlap deck with a single full-width responsive grid for all seven feature cards.
- Removed the narrow-shell fallback path and viewport-based deck breakpoints.
- Added shell-driven card sizing via `--lp-card-min` so the grid reflows from the container width.
- Preserved card interactions and visuals: hover/focus lift, spotlight, wave animation, breath ring offset, reduced-motion behavior, and all navigation targets.

### Layout sketch

Before:
```
[ deck card ] [ deck card ] [ deck card ]
   \ overlap / \ overlap / \ overlap
   fixed ~780px fan layout
```

After:
```
[ card ] [ card ] [ card ] [ card ]
[ card ] [ card ] [ card ]
full-width grid, auto-fits by available width
```

### Behavior flow

```mermaid
flowchart TD
  A[Launchpad shell renders] --> B[Pass shellNarrow to LaunchpadDeck]
  B --> C[Set --lp-card-min: 200px or 240px]
  C --> D[Render one lp-cards grid]
  D --> E[auto-fit columns based on container width]
  E --> F[Cards reflow without overflow]
  G[Hover / focus / pointer move] --> H[Set raised card + spotlight vars]
  H --> I[Apply lifted styling and decorative effects]
</flowchart>
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->