### PR TITLE
fix(test): DB migration-safety tests leak-proof against full-suite order (#909 follow-up)

### DIFF
--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -3,6 +3,8 @@ import sqlite3
 import logging
 from contextlib import contextmanager
 from core.config import DB_PATH
+from core import db_backup
+from core.version import APP_VERSION
 
 logger = logging.getLogger("omnivoice.db")
 
@@ -429,11 +431,14 @@ def _run_alembic_upgrade() -> None:
     # Migrations may actually execute: snapshot the DB first so a failed or
     # interrupted migration can never cost user data. A backup problem alone
     # must not brick startup (the >500 MB skip is by design), so log and go on.
+    # ``db_backup``/``APP_VERSION`` are module-level imports (top of file), not
+    # re-imported here: a test that patches ``core.db_backup.MAX_BACKUP_DB_BYTES``
+    # on the object it imported at collection must see the same object this
+    # function uses. A lazy ``from core import db_backup`` would re-resolve
+    # through the (possibly re-imported) ``core`` package and silently miss the
+    # patch after another suite purged ``core.*`` from ``sys.modules``.
     backup_path = None
     try:
-        from core import db_backup
-        from core.version import APP_VERSION
-
         backup_path = db_backup.snapshot_before_migration(DB_PATH, APP_VERSION)
     except Exception:  # noqa: BLE001
         logger.exception("Pre-migration DB backup failed — continuing without one")

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -17,7 +17,13 @@ from core.config import DB_PATH  # noqa: E402 — backend/ is on sys.path via al
 
 config = context.config
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # `disable_existing_loggers=False` is deliberate: this env runs *inside* the
+    # live app (startup `alembic upgrade head`), so the default (True) would
+    # disable every already-created application logger — e.g. silence
+    # `omnivoice.db.backup`'s "Skipping pre-migration DB backup" line and the
+    # rest of the app's logging for the remainder of the process. A migration
+    # must never mute the app (or leak that mute across a test session).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # SQLite file URL. Honour an externally-set URL (tests pass one via
 # `cfg.set_main_option("sqlalchemy.url", ...)` to point at a fixture DB),

--- a/tests/test_db_migration_safety.py
+++ b/tests/test_db_migration_safety.py
@@ -15,8 +15,17 @@ import sqlite3
 
 import pytest
 
+import core.db as db_module
 from core import db_backup
 from core.db import _BASE_SCHEMA, MigrationError, _run_alembic_upgrade, init_db
+
+# Patch DB_PATH on the SAME module object these symbols were imported from
+# (``db_module``), not via the dotted string "core.db.DB_PATH". An earlier
+# suite (tests/backend/**) purges ``core.*`` from ``sys.modules`` and never
+# restores it, so the string re-resolves to a *re-imported* ``core.db`` while
+# ``_run_alembic_upgrade``/``init_db`` — bound here at collection — keep
+# reading the ORIGINAL module's globals. Patching the imported object is the
+# correct, self-contained seam and is immune to that leak (#909 full-suite).
 
 
 def _seed_user_db(path, stamp=None):
@@ -49,7 +58,7 @@ def test_pending_migrations_snapshot_first_then_upgrade(tmp_path, monkeypatch):
     """A DB behind head (here: never stamped) gets a backup, then migrates."""
     db = tmp_path / "omnivoice.db"
     _seed_user_db(db)
-    monkeypatch.setattr("core.db.DB_PATH", str(db))
+    monkeypatch.setattr(db_module, "DB_PATH", str(db))
 
     _run_alembic_upgrade()
 
@@ -71,7 +80,7 @@ def test_up_to_date_db_is_not_resnapshotted(tmp_path, monkeypatch):
     """Once at head, later launches must not churn new backups."""
     db = tmp_path / "omnivoice.db"
     _seed_user_db(db)
-    monkeypatch.setattr("core.db.DB_PATH", str(db))
+    monkeypatch.setattr(db_module, "DB_PATH", str(db))
 
     _run_alembic_upgrade()
     first = db_backup.list_backups(str(db))
@@ -87,7 +96,7 @@ def test_unknown_revision_stays_nonfatal_and_makes_no_backup(tmp_path, monkeypat
     behavior, and don't churn a pointless backup every launch."""
     db = tmp_path / "omnivoice.db"
     _seed_user_db(db, stamp="9999_from_a_newer_build")
-    monkeypatch.setattr("core.db.DB_PATH", str(db))
+    monkeypatch.setattr(db_module, "DB_PATH", str(db))
 
     init_db()  # must NOT raise (same contract as test_db_schema_reconcile)
 
@@ -101,7 +110,7 @@ def test_midflight_failure_stops_startup_and_names_backup(tmp_path, monkeypatch)
     data reachable, and point the user at the pre-migration backup."""
     db = tmp_path / "omnivoice.db"
     _seed_user_db(db)
-    monkeypatch.setattr("core.db.DB_PATH", str(db))
+    monkeypatch.setattr(db_module, "DB_PATH", str(db))
 
     import alembic.command
 
@@ -132,7 +141,7 @@ def test_midflight_failure_without_backup_says_so(tmp_path, monkeypatch):
     say a backup wasn't written instead of naming a phantom path."""
     db = tmp_path / "omnivoice.db"
     _seed_user_db(db)
-    monkeypatch.setattr("core.db.DB_PATH", str(db))
+    monkeypatch.setattr(db_module, "DB_PATH", str(db))
     monkeypatch.setattr(db_backup, "MAX_BACKUP_DB_BYTES", 1)
 
     import alembic.command


### PR DESCRIPTION
## Symptom

The PR #909 data-safe-update tests passed in isolation but failed **only in full-suite CI order** (`pytest tests/`):

- `tests/test_db_backup.py::test_oversized_db_is_skipped_with_log_line` — skip log line not emitted
- `tests/test_db_migration_safety.py::test_pending_migrations_snapshot_first_then_upgrade` — "a pre-migration backup must exist / assert []"
- `tests/test_db_migration_safety.py::test_midflight_failure_stops_startup_and_names_backup` — DID NOT RAISE MigrationError
- `tests/test_db_migration_safety.py::test_midflight_failure_without_backup_says_so` — named a backup instead of "No pre-migration backup was written"

## The leaker + root cause

Two independent, order-dependent leaks — both proven by reproduction, not guessed.

**1. Module-identity leak (the #878/#894 class).** The `isolated_db` / `fresh_app` / `fresh_resolver` fixtures in `tests/backend/**` (e.g. `tests/backend/services/test_settings_store.py`) purge `core.*` / `services.*` from `sys.modules` to force a fresh load under a per-test `OMNIVOICE_DATA_DIR`, and **never restore them**. Afterwards `sys.modules["core.db"]` is a *different object* than the one the migration-safety tests imported at collection.

- `monkeypatch.setattr("core.db.DB_PATH", str(db))` re-resolves the dotted string to the **re-imported** `core.db`, while `_run_alembic_upgrade` / `init_db` — bound at collection via `from core.db import ...` — keep reading the **original** module's globals. The patch lands on the wrong object, so the upgrade snapshots/migrates the ambient **session DB**, not the test's tmp DB (the migration even failed with `no such table: voice_profiles` against the empty session DB). No backup at the asserted path; the mid-flight-failure injection never hit the expected DB → no `MigrationError`.
- The same divergence hit the lazy `from core import db_backup` *inside* `_run_alembic_upgrade`, so `monkeypatch.setattr(db_backup, "MAX_BACKUP_DB_BYTES", 1)` was silently lost and the snapshot was not skipped.

**2. Logger-disable leak.** Alembic's `backend/migrations/env.py` called `fileConfig(config.config_file_name)` with the default `disable_existing_loggers=True`. The first time any earlier test ran a real `alembic upgrade head`, this **disabled the already-created `omnivoice.db.backup` logger** for the rest of the session, so the oversized-DB "Skipping pre-migration DB backup" line was never emitted. (This also silently mutes the live app's logging after a real startup migration — a latent production bug.)

## The fix

- **`backend/migrations/env.py`** — `fileConfig(..., disable_existing_loggers=False)` so a migration never mutes the app's (or another test's) loggers.
- **`backend/core/db.py`** — import `db_backup` / `APP_VERSION` at module level instead of lazily inside `_run_alembic_upgrade`, so the function uses a stable reference immune to a `sys.modules` purge and matches what tests patch at collection. (No circular-import risk: both modules are stdlib-only; `core/__init__.py` is empty.)
- **`tests/test_db_migration_safety.py`** — patch `DB_PATH` on the imported `core.db` module object (`db_module`) rather than the re-resolvable dotted string — the correct, self-contained seam, immune to the purge regardless.

## Verification

- Reproduced the failures in full-suite order (`pytest tests/backend/ tests/test_db_backup.py tests/test_db_migration_safety.py` → 5 failed) and confirmed the exact mechanism (proved the collection-bound `_run_alembic_upgrade` reads the original module while the string monkeypatch hits the re-imported one).
- After the fix: that slice is **281 passed, 0 failed**; the four migration-safety tests + the oversized-backup test pass in **both** full-suite order and isolation.
- Full `pytest tests/` is green: **2206 passed, 20 skipped, 10 xfailed, 4 xpassed, 0 failed, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Fixed order-dependent migration-safety failures by keeping Alembic from disabling existing application loggers during startup migrations.
- Stabilized `core.db` references used by migration code by importing `db_backup` and `APP_VERSION` at module scope.
- Updated migration safety tests to patch `DB_PATH` on the actual imported `core.db` module object, avoiding stale module-target issues after `sys.modules` reloads.

### Behavior flow
```mermaid
flowchart TD
  A[App startup / migration test] --> B[core.db._run_alembic_upgrade()]
  B --> C[Use module-scoped db_backup + APP_VERSION]
  C --> D[Check snapshot eligibility]
  D -->|needed| E[Create pre-migration backup]
  D -->|not needed| F[Skip backup]
  B --> G[Alembic env.py loads logging]
  G --> H[disable_existing_loggers=false]
  H --> I[Preserve existing app logs]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->