### PR TITLE
ci(release): version-first release titles (tag visible in the truncated release list)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,7 +524,9 @@ jobs:
           # Every other invocation — crucially the `v*` tag-push stable release
           # — evaluates these expressions to exactly their prior values.
           tagName: ${{ (needs.preview-gate.outputs.is_preview == 'true') && 'preview' || github.ref_name }}
-          releaseName: ${{ (needs.preview-gate.outputs.is_preview == 'true') && 'OmniVoice Studio (Preview)' || format('OmniVoice Studio {0}', github.ref_name) }}
+          # Version-first so the tag is readable in GitHub's truncated
+          # release-list sidebar (which clips the title mid-string).
+          releaseName: ${{ (needs.preview-gate.outputs.is_preview == 'true') && 'Preview — OmniVoice Studio' || format('{0} — OmniVoice Studio', github.ref_name) }}
           releaseBody: ${{ steps.changelog.outputs.body }}
           releaseDraft: ${{ (needs.preview-gate.outputs.is_preview == 'true') && 'false' || (inputs.draft || 'true') }}
           prerelease: ${{ needs.preview-gate.outputs.is_preview == 'true' }}


### PR DESCRIPTION
GitHub's release-list sidebar truncates the title mid-string, so 'OmniVoice Studio v0.3.8' shows as 'OmniVoice Studio …' — the version, the thing you scan for, is hidden. This names releases version-first: stable → `vX.Y.Z — OmniVoice Studio`, preview → `Preview — OmniVoice Studio`. The 13 existing releases were renamed to match via `gh release edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Changed GitHub release naming to be version-first so truncated release titles still show the version.

```mermaid
flowchart TD
  A[Release workflow runs] --> B{Preview build?}
  B -- yes --> C[Name release: Preview — OmniVoice Studio]
  B -- no --> D[Name release: vX.Y.Z — OmniVoice Studio]
  C --> E[GitHub release list keeps intent visible when truncated]
  D --> E
```

Also renamed the existing releases to match the new convention using `gh release edit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->