### PR TITLE
docs(sponsors): sponsorship home — SPONSORS.md, README section, inquiry form + FUNDING link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,6 +2,8 @@
 # GitHub Sponsors isn't set up for this account — fund via Ko-fi or PayPal.
 
 ko_fi: debpalash
-custom: ["https://paypal.me/palashCoder"]
+custom:
+  - "https://paypal.me/palashCoder"
+  - "https://github.com/debpalash/OmniVoice-Studio/blob/main/SPONSORS.md"
 # github: [debpalash]            # not available
 # open_collective: omnivoice-studio

--- a/.github/ISSUE_TEMPLATE/sponsor.yml
+++ b/.github/ISSUE_TEMPLATE/sponsor.yml
@@ -1,0 +1,78 @@
+name: 🤝 Sponsorship inquiry
+description: Support OmniVoice and (optionally) claim a logo slot. Not for bugs or feature requests.
+title: "Sponsorship inquiry: "
+labels: ["sponsor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for considering sponsoring **OmniVoice Studio** 💛
+
+        OmniVoice is free, local-first, and AGPL-3.0 — sponsorship keeps development going.
+        See **[SPONSORS.md](https://github.com/debpalash/OmniVoice-Studio/blob/main/SPONSORS.md)** for tiers, placements, and logo guidelines.
+        Prefer to just donate? [Ko-fi](https://ko-fi.com/debpalash) (recurring) or [PayPal](https://paypal.me/palashCoder) (one-time) — you don't need this form for that.
+  - type: input
+    id: name
+    attributes:
+      label: Name or organization
+      description: How you'd like to be credited (person or company).
+    validations:
+      required: true
+  - type: input
+    id: website
+    attributes:
+      label: Website / link
+      description: The URL your name or logo should link to (homepage, product page, profile…).
+      placeholder: https://example.com
+  - type: input
+    id: logo
+    attributes:
+      label: Logo URL (optional)
+      description: Link to your logo (SVG preferred, else 2× PNG, transparent background). You can also attach it in the description below.
+      placeholder: https://example.com/logo.svg
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Tier you're interested in
+      description: See SPONSORS.md for what each tier includes. Not sure? Pick "Not sure yet".
+      options:
+        - Backer
+        - Bronze
+        - Silver
+        - Gold
+        - Not sure yet — let's talk
+        - Custom / annual arrangement
+    validations:
+      required: true
+  - type: dropdown
+    id: method
+    attributes:
+      label: How you'd like to support
+      options:
+        - Ko-fi (recurring)
+        - Ko-fi (one-time)
+        - PayPal (one-time)
+        - Not sure yet — let's discuss
+    validations:
+      required: true
+  - type: input
+    id: contact
+    attributes:
+      label: How should we reach you?
+      description: Email or another contact. (GitHub will also notify you on this issue.)
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else?
+      description: Questions, constraints, timeline, or context. Attach your logo here if you didn't link it above.
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I understand sponsorship is a thank-you, not a paywall — OmniVoice stays fully free and AGPL-3.0, and sponsors don't get gated features.
+          required: true
+        - label: If I provide a logo, I have the right to use it and grant OmniVoice permission to display it in the README, the app, and the project website.
+          required: false

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     <a href="#why-ovs">Why OVS</a> ·
     <a href="#tts-engines">TTS Engines</a> ·
     <a href="#asr-engines">ASR Engines</a> ·
+    <a href="#sponsors">Sponsors</a> ·
     <a href="#sponsor--donate">Donate</a> ·
     <a href="#contributing">Contributing</a> ·
     <a href="https://discord.gg/bzQavDfVV9">Discord</a> ·
@@ -400,6 +401,22 @@ OmniVoice Studio is built by one developer using Claude Code and AI agents — a
 <sub>Every dollar goes directly to agent bills — keeping OmniVoice development continuous.</sub>
 
 </div>
+
+### Sponsors
+
+OmniVoice is **free** and **AGPL-3.0** — no paid tier, no SaaS revenue. Sponsors keep development going, and in return get a logo slot here, in the app, and (for top tiers) on the project website. It's a thank-you, never a paywall. **[See tiers & become a sponsor →](SPONSORS.md)**
+
+<div align="center">
+
+<!-- SPONSORS:START — logo slots are filled here as sponsors come aboard; see SPONSORS.md -->
+
+**Your logo here** — [become a sponsor](SPONSORS.md)
+
+<!-- SPONSORS:END -->
+
+</div>
+
+<sub>💡 GitHub also shows a **Sponsor** button at the top of this repo, wired to the same links via <a href=".github/FUNDING.yml"><code>.github/FUNDING.yml</code></a>.</sub>
 
 ---
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,119 @@
+<div align="center">
+  <img src="docs/logo.png" alt="OmniVoice Logo" width="96" />
+  <h1>Sponsor OmniVoice Studio</h1>
+  <p><b>Keep the open-source ElevenLabs alternative free, local, and shipping.</b></p>
+</div>
+
+---
+
+## Why sponsor?
+
+OmniVoice Studio is built by one developer, in the open, using Claude Code and AI agents — and the agent bills are real. Over the last few months I've spent thousands of dollars on Claude subscriptions to keep features shipping, bugs fixed, and your issues answered.
+
+OmniVoice is **free**, **fully local**, and **AGPL-3.0**. There's no paid tier, no accounts, no cloud, and no SaaS revenue — nothing runs on a server we bill you for, because nothing runs on a server at all. That's the whole point, and it's also why there's no recurring revenue to fund development. Sponsorship is what makes continued full-time work possible.
+
+If OmniVoice has created value for you or your company, sponsoring means the next release keeps coming — and you get a thank-you (and, at most tiers, a logo slot) in return.
+
+### Where your money goes
+
+Every dollar goes to the cost of building OmniVoice — chiefly the **AI agent bills that keep it shipping** (Claude subscriptions and API usage), plus the occasional signing certificate, test hardware, and model-hosting costs. It is not a salary top-up; it's what keeps the lights on for continuous development.
+
+---
+
+## Sponsorship tiers
+
+Tiers are about **visibility and gratitude** — what you get is placement, not gated features (see [Not a paywall](#not-a-paywall)). Higher tiers include everything in the tiers below them.
+
+| Tier | Suggested monthly | What you get |
+|------|-------------------|--------------|
+| **🥉 Backer** | _set by owner_ <!-- OWNER: set amounts --> | Your name or handle listed in the **Backers** section of this file, with a link of your choice. |
+| **🟫 Bronze** | _set by owner_ <!-- OWNER: set amounts --> | Everything above, **plus** a small logo in `SPONSORS.md` **and** in the README [Sponsors section](README.md#sponsors). |
+| **🥈 Silver** | _set by owner_ <!-- OWNER: set amounts --> | Everything above, **plus** your logo in the **README** and in the app's **in-app Sponsors page footer** (as that page ships). |
+| **🥇 Gold** | _set by owner_ <!-- OWNER: set amounts --> | Everything above, **plus** a **prominent logo slot** and link on the project **website / landing page**. |
+
+> **Amounts are set by the maintainer** — look for the `<!-- OWNER: set amounts -->` markers in this file's source. If you don't see a price that fits, say so in your inquiry; custom and annual arrangements are welcome.
+
+Placements marked "as that page ships" (the in-app Sponsors page and the project website) are on the near-term roadmap. Until they exist, Silver/Gold logos live in `SPONSORS.md` and the README, and are added to the app and site the moment those land — no re-application needed.
+
+---
+
+## How to become a sponsor
+
+**1. Open a sponsorship inquiry (recommended).** This opens a short GitHub form (name/org, logo, tier, contact) so we can get you set up:
+
+> **[→ Open a sponsorship inquiry](https://github.com/debpalash/OmniVoice-Studio/issues/new?template=sponsor.yml)**
+
+**2. Or start recurring support directly:**
+
+- **Ko-fi (recurring or one-time):** [ko-fi.com/debpalash](https://ko-fi.com/debpalash)
+- **PayPal (one-time):** [paypal.me/palashCoder](https://paypal.me/palashCoder)
+
+If you sponsor via Ko-fi/PayPal and want a logo slot, still open an inquiry (or drop a note there) so we know who to credit and where to link.
+
+**3. Prefer to talk first?** Reach out directly:
+
+- Email: <!-- OWNER: add your sponsor contact email here if you want one public -->
+- Or ask in the `#dev` / `#announcements` channels on [Discord](https://discord.gg/bzQavDfVV9).
+
+---
+
+## Logo & asset guidelines
+
+To make your logo look sharp everywhere (README on GitHub, the in-app page, the website), please send:
+
+- **Format:** **SVG preferred** (scales cleanly); otherwise **PNG at 2× resolution**.
+- **Background:** **transparent** — no baked-in white/black box.
+- **Contrast:** send a variant that stays legible on **both light and dark** backgrounds, or one light-mode and one dark-mode file (GitHub and the app both render in either theme).
+- **Dimensions:** legible at **~40px tall**; keep the wordmark within roughly **480px wide**. Landscape/wordmark shapes work best in the README row.
+- **File size:** keep SVGs under ~50 KB and PNGs under ~100 KB.
+- **Link target:** the destination URL you want the logo to point to (usually your homepage).
+
+**How your logo gets added:**
+
+- **Easiest:** attach the asset and link in your [sponsorship inquiry](https://github.com/debpalash/OmniVoice-Studio/issues/new?template=sponsor.yml) — the maintainer places it.
+- **Or open a PR:** add your asset under `docs/sponsors/` and an entry to the tables in this file. Silver/Gold logos are also wired into the app's in-app Sponsors page (via the `sponsors.js` manifest) and the project website as those surfaces ship.
+
+By sponsoring you confirm you have the right to use the submitted logo and grant OmniVoice permission to display it in the contexts above. We won't alter your logo beyond scaling, and we'll remove it promptly on request.
+
+---
+
+## Current sponsors
+
+OmniVoice doesn't have any sponsors yet — **you could be the first.** These slots fill in as sponsors come aboard.
+
+### 🥇 Gold
+
+_Be the first Gold sponsor — [claim this slot](#how-to-become-a-sponsor)._
+
+### 🥈 Silver
+
+_Open — [become a Silver sponsor](#how-to-become-a-sponsor)._
+
+### 🟫 Bronze
+
+_Open — [become a Bronze sponsor](#how-to-become-a-sponsor)._
+
+### 🥉 Backers
+
+_Open — [become a Backer](#how-to-become-a-sponsor)._
+
+<!-- When a sponsor joins, add them to the matching section above:
+     - Logo tiers (Bronze+):  <a href="https://sponsor.example"><img src="docs/sponsors/name.svg" alt="Name" height="48" /></a>
+     - Backers:               - [Name / handle](https://link)  -->
+
+---
+
+## Not a paywall
+
+Sponsorship is a **thank-you, never a paywall.**
+
+Every feature of OmniVoice Studio is and will remain **free** and **open-source under [AGPL-3.0](LICENSE)**. Sponsors do **not** get private builds, gated features, license exceptions, or anything that degrades the experience for people who don't (or can't) pay. What sponsors get is **visibility and our gratitude** — and the knowledge that they're directly funding the next release.
+
+OmniVoice stays local-first and fully functional with zero dollars spent. Sponsoring just helps it keep getting better, faster.
+
+---
+
+<div align="center">
+<sub>Thank you for keeping local-first voice AI alive and free. ❤️</sub><br/>
+<sub>Questions? <a href="https://github.com/debpalash/OmniVoice-Studio/issues/new?template=sponsor.yml">Open an inquiry</a> · <a href="https://discord.gg/bzQavDfVV9">Discord</a></sub>
+</div>


### PR DESCRIPTION
Adds the sponsorship documentation the owner asked for — a logo/link sponsor section on the README, a `SPONSORS.md` home, a way to contact for a slot, and website/app logo-slot placeholders — while keeping the existing candid "AI agent bills keep OmniVoice shipping" voice. Docs-only; OmniVoice stays fully free and AGPL-3.0.

### What's here
- **`SPONSORS.md`** (new) — the sponsorship home: why-sponsor intro, where-the-money-goes transparency, tiers, how to become a sponsor, logo/asset guidelines, an empty "be the first" current-sponsors board, and a "not a paywall" note.
- **`README.md`** — new **Sponsors** subsection under the existing *Sponsor / Donate* section (logo-slot placeholder `**Your logo here** — become a sponsor`, one-line pitch, link to `SPONSORS.md`), a **Sponsors** entry in the top nav, and a note about GitHub's native Sponsor button. Existing Ko-fi/PayPal badges untouched.
- **`.github/ISSUE_TEMPLATE/sponsor.yml`** (new) — a lightweight "Sponsorship inquiry" issue form (name/org, website, logo URL, tier, support method, contact, acknowledgements) so the "become a sponsor" link opens a real, structured form.
- **`.github/FUNDING.yml`** — adds the `SPONSORS.md` link to `custom` alongside the existing `ko_fi: debpalash` and PayPal. No `github:` sponsors added (owner isn't set up for it).

### Tiers (placements, not gated features)
| Tier | What you get |
|------|--------------|
| Backer | Name/handle listed in `SPONSORS.md` |
| Bronze | + small logo in `SPONSORS.md` and the README Sponsors section |
| Silver | + logo in README and the in-app Sponsors page footer (as it ships) |
| Gold | + prominent logo slot & link on the project website/landing |

### Owner-input placeholders (search these before publishing)
- **Tier amounts** — every tier row carries `<!-- OWNER: set amounts -->`; no prices were invented.
- **Public contact email** — `<!-- OWNER: add your sponsor contact email here if you want one public -->` in `SPONSORS.md` (nothing personal published).

### Notes
- The "become a sponsor" link points at `issues/new?template=sponsor.yml` (the new form) rather than a bare `?body=…` blank-issue link, because `blank_issues_enabled: false` in `config.yml` redirects bare prefills to the template chooser — the form route works and carries the structured fields.
- No fabricated sponsors, prices, or testimonials.

### Gates
- `uv run pytest tests/ -q -k "readme or docs or features or inventory or cjk"` → **71 passed, 1 skipped**
- `tests/test_no_hardcoded_cjk.py` → pass (new files are English-only)
- `scripts/check-docs-drift.py` → clean (39 inventory entries verified)
- Discord-link sweep (`test_issue_fixes.py -k discord`) → pass (new invite only)
- `CHANGELOG.md` left untouched. Suggested `[0.3.9]` bullet:
  > **Sponsorship docs** — added `SPONSORS.md` (tiers, logo guidelines, how to sponsor), a README Sponsors section with logo slots, and a "Sponsorship inquiry" issue form; sponsorship is a thank-you, not a paywall — OmniVoice stays free and AGPL-3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added sponsorship documentation and intake support for OmniVoice Studio.

- Introduced `SPONSORS.md` as the central sponsorship page, covering sponsor rationale, tier structure, logo/asset guidelines, how to sponsor, and a clear note that sponsorship does not create a paywall.
- Updated `README.md` with a Sponsors section and navigation link, plus a note pointing to GitHub’s native Sponsor flow while preserving the existing Ko-fi and PayPal badges.
- Added `.github/ISSUE_TEMPLATE/sponsor.yml` to capture structured sponsorship inquiries, including organization details, tier interest, support method, contact info, and acknowledgements.
- Updated `.github/FUNDING.yml` to include the new sponsors documentation link alongside the existing funding options.

OmniVoice remains free and AGPL-3.0, with no fabricated sponsors, prices, or testimonials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->