### PR TITLE
fix(test): router-smoke tests leak-proof against full-suite order

### DIFF
--- a/tests/test_router_smoke.py
+++ b/tests/test_router_smoke.py
@@ -17,12 +17,31 @@ os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
 def client():
     # Lazy import so test_api.py's session fixtures can mock the model first
     # if both suites run together.
-    # `client=("127.0.0.1", 50000)` so `request.client.host` resolves to a
-    # loopback address — the system router is now gated by a router-level
-    # `require_loopback` dependency. Smoke tests are happy-path tests and
-    # should pass the gate.
     from fastapi.testclient import TestClient
     from main import app
+
+    # Create the DB schema explicitly against whatever DB is active *now*.
+    # A bare `TestClient(app)` (no `with` block) never enters the app
+    # lifespan, so the lifespan's `init_db()` — the only place the schema is
+    # laid down (main.py) — never runs. These smoke tests therefore used to
+    # free-ride on the schema some *earlier* module happened to create on the
+    # shared data dir. That made them order-dependent: run first / alone, or
+    # after a module that reloads `core.config`/`core.db` and leaves
+    # `core.db.DB_PATH` pointed at a fresh, schema-less DB (e.g.
+    # test_pronunciation_api's `importlib.reload` teardown), and every
+    # DB-backed route 500s with `no such table: jobs` / `voice_profiles`.
+    # Seeding the schema here — the same `init_db()` call test_api.py /
+    # test_personas_api.py use — makes the suite self-sufficient and
+    # leak-proof against full-suite ordering (same class as #878 / #917).
+    # Uses the live `core.db` from sys.modules so it targets the exact
+    # DB_PATH the app's routers resolve to.
+    import core.db
+    core.db.init_db()
+
+    # `client=("127.0.0.1", 50000)` so `request.client.host` resolves to a
+    # loopback address — the system router is gated by a router-level
+    # `require_loopback` dependency. Smoke tests are happy-path tests and
+    # should pass the gate.
     return TestClient(app, client=("127.0.0.1", 50000))
 
 


### PR DESCRIPTION
## Leaker

`tests/test_pronunciation_api.py` — its `client` fixture does
`importlib.reload(core.config)`/`core.db`/`main` under a monkeypatched
`OMNIVOICE_DATA_DIR`, and in teardown reloads them back to the restored data
dir **without re-running `init_db()`** on it. `monkeypatch.undo()` restores the
env var, but an in-place `importlib.reload` is not something monkeypatch undoes,
so `main.app` is left bound to a data dir whose `omnivoice.db` was never given a
schema. `pytest tests/test_pronunciation_api.py tests/test_router_smoke.py`
deterministically reproduces the reported **10 failures**.

## Root cause

The real defect is in `test_router_smoke.py`: its `client` fixture builds a bare
`TestClient(app)` with **no `with` block**, so the FastAPI **lifespan never
runs** — and `init_db()`, the only place the DB schema is created, lives in that
lifespan (`backend/main.py`). The smoke tests were free-riding on whatever schema
some *earlier* module happened to create on the shared data dir. That made them
order-dependent: run first / alone / after a module that repoints
`core.db.DB_PATH` at a fresh, schema-less DB (the pronunciation-api reload leak
above), and every DB-backed route 500s with `sqlite3.OperationalError: no such
table: jobs` (and `voice_profiles`, `generation_history`, …). Same **class** as
the recently-fixed #878 (LLM state leak) and #917 (alembic DB-URL leak).

## Fix

Test-only, zero blast radius. The `client` fixture now calls
`core.db.init_db()` against whatever DB is active **at run time**, right before
constructing the `TestClient` — the same `init_db()` seeding pattern
`tests/test_api.py` and `backend/tests/test_personas_api.py` already use. Because
it targets the live `core.db.DB_PATH` from `sys.modules`, it re-creates the
schema regardless of which path any prior module left active, making the smoke
suite self-sufficient and leak-proof against full-suite ordering. (Entering the
real lifespan via `with TestClient(app)` was rejected: the lifespan also spawns
workers, preloads the TTS model, and starts the MCP manager — far too heavy for
a happy-path smoke test that deliberately avoids the model.)

## Verification (fail-before / pass-after)

| Slice | Before | After |
|-------|--------|-------|
| `pytest tests/test_router_smoke.py` (alone) | 10 failed, 14 passed | **24 passed** |
| `pytest tests/test_pronunciation_api.py tests/test_router_smoke.py` (reproducer) | 10 failed, 28 passed | **38 passed** |
| `pytest tests/` (full suite) | ~10 failed | **2215 passed, 20 skipped, 10 xfailed, 4 xpassed, 0 failed / 0 errors** (6:12) |

The 10 xfailed are the pre-existing xfail baseline and the 4 xpassed are
xfail-marked tests that happened to pass — neither is a failure, and neither is a
regression from this change (test-only, single fixture touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `tests/test_router_smoke.py` so the smoke tests no longer rely on prior suite state. The `client` fixture now lazily imports `TestClient`/`main.app`, initializes the active database schema with `core.db.init_db()` before creating the client, and then constructs the app client against a ready database.

```mermaid
flowchart TD
  A[Smoke test fixture starts] --> B[Import TestClient and app lazily]
  B --> C[Call core.db.init_db() on active DB]
  C --> D[Create TestClient(app)]
  D --> E[Run router smoke tests with guaranteed schema]
```

Also adjusted nearby loopback-gating comments/wording for the system router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->