### PR TITLE
fix(test): close the reload-induced DB test-isolation leak at its source (#932 follow-up)

### DIFF
--- a/tests/test_db_migration_safety.py
+++ b/tests/test_db_migration_safety.py
@@ -17,7 +17,7 @@ import pytest
 
 import core.db as db_module
 from core import db_backup
-from core.db import _BASE_SCHEMA, MigrationError, _run_alembic_upgrade, init_db
+from core.db import _BASE_SCHEMA, _run_alembic_upgrade, init_db
 
 # Patch DB_PATH on the SAME module object these symbols were imported from
 # (``db_module``), not via the dotted string "core.db.DB_PATH". An earlier
@@ -121,7 +121,7 @@ def test_midflight_failure_stops_startup_and_names_backup(tmp_path, monkeypatch)
     # module attribute is what its `command.upgrade(...)` call resolves.
     monkeypatch.setattr(alembic.command, "upgrade", _boom)
 
-    with pytest.raises(MigrationError) as excinfo:
+    with pytest.raises(db_module.MigrationError) as excinfo:
         _run_alembic_upgrade()
 
     msg = str(excinfo.value)
@@ -151,7 +151,7 @@ def test_midflight_failure_without_backup_says_so(tmp_path, monkeypatch):
         lambda cfg, rev: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
-    with pytest.raises(MigrationError) as excinfo:
+    with pytest.raises(db_module.MigrationError) as excinfo:
         _run_alembic_upgrade()
 
     assert "No pre-migration backup was written" in str(excinfo.value)

--- a/tests/test_pronunciation_api.py
+++ b/tests/test_pronunciation_api.py
@@ -189,8 +189,14 @@ def client(tmp_path, monkeypatch):
     finally:
         monkeypatch.undo()
         importlib.reload(importlib.import_module("core.config"))
-        importlib.reload(importlib.import_module("core.db"))
+        _restored_db = importlib.reload(importlib.import_module("core.db"))
         importlib.reload(_main)
+        # Re-create the schema on the RESTORED data dir. The reload rebinds
+        # DB_PATH back but never re-runs init_db(), so without this the module
+        # is left pointing at a schema-less DB — which corrupts any later test
+        # that reuses the reloaded core.db / main.app (the #932 router-smoke
+        # leak; this closes the class at its source). init_db() is idempotent.
+        _restored_db.init_db()
 
 
 def test_crud_roundtrip(client):


### PR DESCRIPTION
#932 fixed the router-smoke symptom of a leak it traced to `test_pronunciation_api`'s `importlib.reload` teardown. This closes the class at the source: the teardown re-creates the schema on the restored data dir, and the migration-safety tests catch `MigrationError` through the live module object so a reload rebinding the class can't make `pytest.raises` miss. Verified both real alphabetical order and the artificial reverse order (which reproduced the leak) pass; test-only, no product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed reload-related test isolation in `tests/test_pronunciation_api.py` by re-running `init_db()` after restoring and reloading the data directory, ensuring the reloaded DB module has a valid schema.
- Made migration-safety assertions in `tests/test_db_migration_safety.py` resilient to module reloads by referencing `db_module.MigrationError` instead of a directly imported class.

## Behavior
```mermaid
flowchart TD
  A[Test fixture tears down reload state] --> B[Restore data directory]
  B --> C[Reload core.db and main]
  C --> D[Call _restored_db.init_db()]
  D --> E[DB schema exists for later tests]

  F[Migration test runs] --> G[Patch/use live core.db module]
  G --> H[Raise db_module.MigrationError]
  H --> I[pytest.raises matches reloaded exception class]
```

## Testing
- Verified against normal alphabetical test order.
- Verified against reversed test order that previously reproduced the leak.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->