### PR TITLE
fix(engines): sherpa "model not set" is a config error, not OOM — gate the engine on its model dir (#919)

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -1,5 +1,6 @@
 import os
 import io
+import re
 import uuid
 import time
 import random
@@ -233,6 +234,45 @@ def _is_oom_failure(e) -> bool:
     return False
 
 
+# #919: an engine that requires a model path / env var which isn't set (or is
+# set to a directory missing its model files) fails with a *configuration*
+# error, not a runtime one. The reporting user selected sherpa-onnx and hit
+# "OMNIVOICE_SHERPA_MODEL not set. Point it to a sherpa-onnx TTS model
+# directory …" — a pure setup problem — yet the OOM catch-all told them (on a
+# 63 GB-RAM box) to press Flush for memory they never ran out of. Classify the
+# whole CLASS of "engine not configured / required env var not set" errors so
+# any current or future opt-in engine (sherpa/Confucius4/dots/MOSS …) surfaces
+# actionable setup guidance instead of the memory hint. All lowercase; matched
+# over the whole exception chain (engines wrap the original error).
+_CONFIG_MSG_SIGNATURES = (
+    "not set. point it to",      # sherpa: OMNIVOICE_SHERPA_MODEL not set
+    "no model.onnx found in",    # sherpa: dir set but the model file is missing
+    "not configured",            # generic "engine not configured" wording
+    "venv not found. set",       # confucius4/dots/MOSS dedicated-venv opt-ins
+    "unavailable: omnivoice_",   # is_available() reason wrapped by _ensure_loaded
+)
+
+# An OMNIVOICE_* engine env var named alongside "not set" / "point it to" /
+# "set omnivoice_…" is the strongest config-missing signal and generalizes to
+# any engine gated on such a var (issue #919 class).
+_CONFIG_ENV_RE = re.compile(r"omnivoice_[a-z0-9_]+")
+
+
+def _is_config_failure(e) -> bool:
+    """True iff the failure is a *configuration* problem — a required engine
+    model path / env var that isn't set (or points nowhere) — rather than a
+    runtime fault. The remedy is to set the value, never to Flush VRAM."""
+    for exc in _exception_chain(e):
+        low = str(exc).lower()
+        if any(sig in low for sig in _CONFIG_MSG_SIGNATURES):
+            return True
+        if _CONFIG_ENV_RE.search(low) and (
+            "not set" in low or "point it to" in low or "set omnivoice_" in low
+        ):
+            return True
+    return False
+
+
 def _oom_friendly_reraise(e):
     """Best-effort cache flush + the user-facing OOM hint shared by both
     inference paths."""
@@ -340,6 +380,24 @@ def _oom_friendly_reraise(e):
             f"help. Retry the generation; if it keeps failing, check your "
             f"internet connection and any HF_ENDPOINT/mirror setting. "
             f"Underlying error: {e}"
+        ) from e
+    # #919: a required engine model path / env var that isn't set is a pure
+    # CONFIGURATION problem, not a runtime one. sherpa-onnx's
+    # "OMNIVOICE_SHERPA_MODEL not set. Point it to …" used to fall through to
+    # the OOM catch-all, telling a user with 63 GB of RAM to press Flush. Point
+    # at the real fix — set the variable — and never mention memory or Flush.
+    # The underlying error already names the exact variable + what to point it
+    # at (and Settings → Engines shows a copy-paste setup line), so keep it
+    # front-and-center. Checked before the OOM branch so a config error can
+    # never be mislabeled as memory.
+    if _is_config_failure(e):
+        raise RuntimeError(
+            f"This TTS engine isn't set up yet — it needs a model path or "
+            f"environment variable that isn't configured, so nothing was "
+            f"generated. Set it as the underlying error describes (it names the "
+            f"exact variable and what to point it at), then restart OmniVoice — "
+            f"or pick a ready engine in Settings → Engines. This is a setup "
+            f"problem, not a memory one. Underlying error: {e}"
         ) from e
     # #880 (the class bug): the OOM hint used to be the catch-all fallback,
     # so ANY unrecognized error told the user to press Flush for memory they

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1120,13 +1120,34 @@ class SherpaOnnxBackend(TTSBackend):
     def is_available(cls) -> tuple[bool, str]:
         try:
             import sherpa_onnx  # noqa: F401
-            return True, "ready"
         except ImportError as e:
             return False, (
                 f"sherpa-onnx not installed: {e}. "
                 "Install with: pip install sherpa-onnx. "
                 "Download models from https://github.com/k2-fsa/sherpa-onnx/releases"
             )
+        # #919: sherpa-onnx ships no bundled default model — it can only
+        # synthesize once OMNIVOICE_SHERPA_MODEL points at a downloaded model
+        # directory. Gate on it here (like the other path-configured opt-in
+        # engines: Confucius4/dots/MOSS) so the picker marks it unavailable-
+        # with-a-reason instead of letting a user select it, generate, and hit
+        # a config error that used to be mislabeled as out-of-memory.
+        model_dir = os.environ.get("OMNIVOICE_SHERPA_MODEL", "").strip()
+        if not model_dir:
+            return False, (
+                "OMNIVOICE_SHERPA_MODEL not set. Point it to a sherpa-onnx TTS "
+                "model directory (containing model.onnx + tokens.txt), then "
+                "restart OmniVoice. Download models from "
+                "https://github.com/k2-fsa/sherpa-onnx/releases"
+            )
+        if not os.path.isfile(os.path.join(model_dir, "model.onnx")):
+            return False, (
+                f"No model.onnx in OMNIVOICE_SHERPA_MODEL ({model_dir}). Point "
+                "it at a sherpa-onnx TTS model directory containing model.onnx "
+                "+ tokens.txt. Download models from "
+                "https://github.com/k2-fsa/sherpa-onnx/releases"
+            )
+        return True, "ready"
 
     @property
     def sample_rate(self) -> int:
@@ -1334,6 +1355,8 @@ _SETUP_SNIPPETS: dict[str, str] = {
     "moss-tts-v15":   "export OMNIVOICE_MOSS_TTS_V15_DIR=/path/to/MOSS-TTS",
     "dots-tts":       "export OMNIVOICE_DOTS_TTS_DIR=/path/to/dots.tts",
     "confucius4-tts": "export OMNIVOICE_CONFUCIUS4_TTS_DIR=/path/to/Confucius4-TTS",
+    # #919: sherpa-onnx gates on a downloaded model dir (model.onnx + tokens.txt).
+    "sherpa-onnx":    "export OMNIVOICE_SHERPA_MODEL=/path/to/sherpa-onnx-model",
 }
 
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -2,6 +2,9 @@
 import os
 os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
 
+import sys
+import types
+
 import pytest
 from services import tts_backend, asr_backend, llm_backend
 
@@ -48,6 +51,44 @@ def test_tts_active_backend_env_override(monkeypatch):
     from core import prefs as _prefs
     _prefs.set_("tts_backend", "omnivoice")
     assert tts_backend.active_backend_id() == "omnivoice"
+
+
+# ── #919: sherpa-onnx gates on OMNIVOICE_SHERPA_MODEL ────────────────────────
+# sherpa-onnx ships no bundled model, so with the package installed but no model
+# dir configured it must report unavailable-with-a-reason — not "ready" and then
+# a generate-time config error the OOM catch-all mislabeled. A fake module makes
+# these deterministic whether or not sherpa-onnx is installed on CI.
+
+
+def test_tts_sherpa_unavailable_without_model_env(monkeypatch):
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", types.ModuleType("sherpa_onnx"))
+    monkeypatch.delenv("OMNIVOICE_SHERPA_MODEL", raising=False)
+    ok, msg = tts_backend.SherpaOnnxBackend.is_available()
+    assert ok is False
+    assert "OMNIVOICE_SHERPA_MODEL" in msg   # names the exact env var
+    assert "model.onnx" in msg               # says what to point it at
+
+
+def test_tts_sherpa_unavailable_when_model_dir_lacks_onnx(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", types.ModuleType("sherpa_onnx"))
+    monkeypatch.setenv("OMNIVOICE_SHERPA_MODEL", str(tmp_path))  # empty dir
+    ok, msg = tts_backend.SherpaOnnxBackend.is_available()
+    assert ok is False
+    assert "model.onnx" in msg
+
+
+def test_tts_sherpa_available_when_model_env_points_at_model(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "sherpa_onnx", types.ModuleType("sherpa_onnx"))
+    (tmp_path / "model.onnx").write_bytes(b"")
+    monkeypatch.setenv("OMNIVOICE_SHERPA_MODEL", str(tmp_path))
+    ok, _msg = tts_backend.SherpaOnnxBackend.is_available()
+    assert ok is True
+
+
+def test_tts_sherpa_setup_snippet_registered():
+    # The Compat Matrix's copy-paste setup line must exist for the now
+    # path-gated engine (parity with Confucius4/dots/MOSS).
+    assert "OMNIVOICE_SHERPA_MODEL" in tts_backend._SETUP_SNIPPETS["sherpa-onnx"]
 
 
 def test_tts_active_backend_prefs_fallback(monkeypatch, tmp_path):

--- a/tests/test_generation_audio_guard.py
+++ b/tests/test_generation_audio_guard.py
@@ -205,3 +205,55 @@ def test_winerror_193_is_a_corrupt_binary_not_oom():
     assert "WinError 193" in msg
     assert "corrupt" in msg or "wrong architecture" in msg
     assert "ran out of memory" not in msg
+
+
+def test_sherpa_model_not_set_is_a_config_error_not_oom():
+    # #919: the reporter selected sherpa-onnx and hit "OMNIVOICE_SHERPA_MODEL
+    # not set. Point it to a sherpa-onnx TTS model directory …" — a pure setup
+    # problem — but the OOM catch-all told them (63 GB RAM) to press Flush for
+    # memory they never ran out of. It must classify as a CONFIGURATION error:
+    # name the env var, point at Settings → Engines, and never mention memory
+    # or the Flush button.
+    err = RuntimeError(
+        "OMNIVOICE_SHERPA_MODEL not set. Point it to a sherpa-onnx TTS model "
+        "directory (containing model.onnx + tokens.txt)."
+    )
+    with pytest.raises(RuntimeError) as ei:
+        _oom_friendly_reraise(err)
+    msg = str(ei.value)
+    assert "OMNIVOICE_SHERPA_MODEL" in msg      # names the exact env var
+    assert "Settings" in msg                     # tells the user where to fix it
+    assert "out of memory" not in msg
+    assert "ran out of memory" not in msg
+    assert "Flush" not in msg
+
+
+def test_engine_not_configured_class_is_not_oom():
+    # #919 (the class, not just the one string): any opt-in engine failing
+    # because its required model path / env var isn't set is configuration, not
+    # OOM — including when a lower layer wraps the original message. Covers
+    # sherpa's is_available() wrapper, sherpa's "no model.onnx" variant, and a
+    # Confucius4/dots/MOSS-style "venv not found. Set OMNIVOICE_…_DIR".
+    for raw in (
+        "Sherpa-ONNX unavailable: OMNIVOICE_SHERPA_MODEL not set. Point it to a "
+        "sherpa-onnx TTS model directory (containing model.onnx + tokens.txt).",
+        "No model.onnx found in /tts/models. Download a model from "
+        "https://github.com/k2-fsa/sherpa-onnx/releases",
+        "Confucius4-TTS venv not found. Set OMNIVOICE_CONFUCIUS4_TTS_DIR to your "
+        "clone and restart OmniVoice.",
+    ):
+        with pytest.raises(RuntimeError) as ei:
+            _oom_friendly_reraise(RuntimeError(raw))
+        msg = str(ei.value)
+        assert "isn't set up yet" in msg
+        assert "ran out of memory" not in msg
+        assert "out of memory" not in msg
+        assert "Flush" not in msg
+
+
+def test_config_failure_does_not_swallow_real_oom():
+    # Guard the ordering: a genuine OOM must still be OOM even though the config
+    # branch now runs first.
+    with pytest.raises(RuntimeError) as ei:
+        _oom_friendly_reraise(RuntimeError("CUDA error: out of memory"))
+    assert "ran out of memory" in str(ei.value)


### PR DESCRIPTION
## Problem

A user selected the **sherpa-onnx** TTS engine and hit a 500:

> Couldn't synthesize audio… Underlying error: **TTS engine stopped mid-generation. This usually means it ran out of memory. Try the Flush button…** Underlying error: **OMNIVOICE_SHERPA_MODEL not set. Point it to a sherpa-onnx TTS model directory (containing model.onnx + tokens.txt).**

The real cause is a pure **configuration** problem (a required env var isn't set), but it was mislabeled as **out-of-memory** with useless "press Flush" advice — on a 63 GB-RAM / 12 GB-VRAM box. Same misclassification class as #880/#893 (which tightened the OOM catch-all on the generation path), but the engine-not-configured case still fell through to the memory hint.

`sherpa-onnx` is a real, directly-selectable engine (`SherpaOnnxBackend` in `_REGISTRY`), and its old `is_available()` only checked that the `sherpa_onnx` package imports — never whether a model was configured — so it showed as **ready** and failed only at generate time.

## Fix (the whole class, two layers)

**1. Error classification** — `backend/api/routers/generation.py`
New `_is_config_failure()` recognizes "required engine model path / env var not set" over the whole exception chain (an `OMNIVOICE_*` var named with "not set" / "point it to" / "set omnivoice_…", plus sherpa's "no model.onnx found in", generic "not configured", and "venv not found. set" for the dedicated-venv opt-ins). `_oom_friendly_reraise` now checks it **before** the OOM branch and re-raises actionable setup guidance that names the variable, points at Settings → Engines, and never mentions memory or Flush. Generalizes to sherpa / Confucius4 / dots / MOSS and any future env-gated engine.

**2. Engine availability gating** — `backend/services/tts_backend.py`
`SherpaOnnxBackend.is_available()` now gates on `OMNIVOICE_SHERPA_MODEL` (set **and** containing `model.onnx`) — like the other path-configured opt-in engines (Confucius4/dots/MOSS) — returning `False` with an actionable reason instead of `"ready"`, so the picker marks it **unavailable-with-a-reason** rather than selectable-but-broken. Added the copy-paste `_SETUP_SNIPPETS` line for the Compat Matrix. Backward-compatible: a correctly configured `OMNIVOICE_SHERPA_MODEL` keeps the engine available.

## Tests (fail-before / pass-after)
- `tests/test_generation_audio_guard.py`: the sherpa "model not set" error and the wider not-configured class classify as config — message names the env var + "Settings", and contains no "out of memory" / "ran out of memory" / "Flush"; plus an ordering guard that a genuine OOM is still OOM.
- `tests/test_engines.py`: `is_available()` gates on `OMNIVOICE_SHERPA_MODEL` (unset → unavailable naming the var; dir without `model.onnx` → unavailable; valid dir → available) and the setup snippet is registered.

Verified fail-before (4 new tests fail on the pre-fix source) and pass-after. Also ran `tests/test_no_hardcoded_cjk.py`, `tests/test_api_route_inventory.py`, and the registry/route-shape/Confucius4 regression suites — all green.

Fixes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed sherpa-onnx synthesis failures being mislabeled as out-of-memory errors when the model path/config is missing.

```mermaid
flowchart TD
  A[Generation error occurs] --> B{Config failure?}
  B -- yes --> C[Raise setup/config guidance]
  B -- no --> D{OOM failure?}
  D -- yes --> E[Raise OOM guidance]
  D -- no --> F[Preserve original error]
```

- `generation.py` now detects sherpa/configuration-style failures in the exception chain and re-raises them with setup-oriented messaging instead of “Flush”/OOM advice.
- `SherpaOnnxBackend.is_available()` now requires `OMNIVOICE_SHERPA_MODEL` and a valid `model.onnx`, so the engine is marked unavailable with a reason instead of being selectable-but-broken.
- Added a sherpa-onnx setup snippet for the Engines UI.
- Updated tests for config-failure classification, OOM preservation, backend availability gating, and setup-snippet registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->