### PR TITLE
docs(readme): Launchpad screenshot as the hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 <br/>
 
 <div align="center">
-  <img src=".github/assets/social-preview.png" alt="OmniVoice Studio — The open-source ElevenLabs alternative" width="100%"/>
+  <img src="docs/screenshot-launchpad.png" alt="OmniVoice Studio — Launchpad" width="100%"/>
 </div>
 
 > [!WARNING]
@@ -188,13 +188,6 @@ options, see [docs/downloading-models.md](docs/downloading-models.md).
 ## 📸 See it in action
 
 <table>
-  <tr>
-    <td align="center" colspan="2">
-      <img src="docs/screenshot-launchpad.png" alt="Launchpad" width="100%"/>
-      <br/><b>🚀 Launchpad</b><br/>
-      <sub>Your creative home — jump straight into cloning, design, dubbing, stories, or dictation.</sub>
-    </td>
-  </tr>
   <tr>
     <td align="center" width="50%">
       <img src="docs/screenshot-studio.png" alt="Studio" width="100%"/>


### PR DESCRIPTION
Per owner: the Launchpad shot becomes the README hero (replacing the static social-preview banner), and the duplicate Launchpad row is removed from the gallery — each shot appears once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the README hero to use the Launchpad screenshot instead of the static social-preview banner, with refreshed alt text/branding.

Removed the duplicate Launchpad entry from the “See it in action” gallery so the screenshot appears only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->