### PR TITLE
docs(readme): cross-promote Opal + memxt (local open-source family)

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,17 @@ OmniVoice Studio is built on the shoulders of exceptional open-source work:
 
 ---
 
+## 🧰 More local open-source from the maker
+
+Like the local-first philosophy? It runs in the family:
+
+| Project | What it is |
+|---------|------------|
+| [**Opal**](https://github.com/debpalash/Opal) 💠 | **Play everything.** The evolved media player for the next decades of entertainment — video, anime, comics, torrents, Jellyfin/Plex, with local AI built in. |
+| [**memxt**](https://github.com/debpalash/memxt) 🧠 | **The fastest benchmarked open-source AI memory system.** 100% local memory for AI agents, with MCP support. |
+
+---
+
 <div align="center">
 
 <br/>


### PR DESCRIPTION
Adds a compact **🧰 More local open-source from the maker** section before the footer, cross-promoting [Opal](https://github.com/debpalash/Opal) (local-first media player) and [memxt](https://github.com/debpalash/memxt) (100% local AI memory for agents) — same local-first philosophy, same maker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new “🧰 More local open-source from the maker” section to the README before the footer, cross-promoting two related local-first projects: **Opal** and **memxt**. The section briefly describes each project and links out to their repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->