### PR TITLE
fix(translate): Dub LLM engine runs on the configured LLM provider (new dub_translation skill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - **Settings → Engines can no longer 500 under concurrent loads.** The lazy TTS/ASR engine registries held a *live* dictionary iterator open across each engine's `is_available()` probe while `list_backends()` ran in a FastAPI threadpool — so a second concurrent `/engines` request materializing a lazy engine entry (`self[key] = cls`) mutated the dict mid-iteration and crashed the request with `RuntimeError: dictionary changed size during iteration`. Both registries now snapshot their keys before iterating (atomic under the GIL), immune to a concurrent insert; regression-tested for TTS and ASR. (#940)
+- **The Dub tab's LLM translation engine now runs on your configured LLM provider.** Picking "LLM (OpenAI-compatible)" silently required three hand-set environment variables even when a provider was already configured and tested in Settings → LLM Providers; it now resolves through a new "Dub translation" LLM skill (route it to any provider — remote or local — in Settings → LLM Skills, independently of Cinematic refinement), keeps the `TRANSLATE_*` env vars as a power-user override, bounds every call with the LLM timeout instead of the SDK's 600-second default, tells the Engine dropdown whether the engine is actually ready (and via which provider), and — when nothing is configured — returns a clear pointer to Settings → LLM Providers instead of a raw 401 per segment. (#944)
 
 ## [0.3.9] — 2026-07-04
 

--- a/backend/api/routers/dub_translate.py
+++ b/backend/api/routers/dub_translate.py
@@ -308,14 +308,63 @@ async def dub_translate(req: TranslateRequest):
             # first is fine — the refine LLM is a separate network provider.
             return await _maybe_cinematic(translated, req, src_lang, loop)
 
-        # OpenAI / Ollama Local LLM Translation
+        # LLM translation — resolves through the LLM Skills registry: per-skill
+        # "Dub translation" override → global active provider (Settings → LLM
+        # Providers). The keys users configure + test in the app now actually
+        # power this engine; the raw TRANSLATE_* env vars stay working as a
+        # power-user override so pre-skills setups see zero behavior change.
         if provider == "openai":
-            base_url = os.environ.get("TRANSLATE_BASE_URL")
-            model_name = os.environ.get("TRANSLATE_MODEL", "gpt-3.5-turbo")
-            from openai import OpenAI
-            # max_retries=0: a 429 + long Retry-After must not let one segment's
-            # SDK call sleep+retry and blow the overall translate wall time.
-            client = OpenAI(base_url=base_url, api_key=api_key or "local", max_retries=0)
+            from services import llm_skills
+
+            llm_timeout = llm_skills._default_timeout()
+            handle = None
+            try:
+                handle = llm_skills.resolve_skill_client("dub_translation")
+            except Exception:  # noqa: BLE001 — resolution must never 500 a translate
+                logger.exception("dub_translation skill resolution failed; trying env fallback")
+            if handle is not None:
+                client = handle.client
+                model_name = handle.model
+                llm_timeout = handle.timeout
+                # The provider-store key never touches env; resolve it so the
+                # error scrubber below can redact it if a provider echoes it.
+                try:
+                    from services import llm_providers
+                    api_key = llm_providers.resolve_api_key(
+                        llm_skills.effective_provider("dub_translation")) or api_key
+                except Exception:  # noqa: BLE001 — scrub-key resolution is best-effort
+                    pass
+            elif os.environ.get("TRANSLATE_BASE_URL") or api_key:
+                # Legacy env-only setup (no provider configured in-app).
+                from openai import OpenAI
+                # max_retries=0: a 429 + long Retry-After must not let one segment's
+                # SDK call sleep+retry and blow the overall translate wall time.
+                client = OpenAI(base_url=os.environ.get("TRANSLATE_BASE_URL"),
+                                api_key=api_key or "local", max_retries=0)
+                model_name = os.environ.get("TRANSLATE_MODEL", "gpt-4o-mini")
+            else:
+                # Nothing configured anywhere — name the exact next step instead
+                # of letting an empty key surface as a raw 401 per segment.
+                try:
+                    reason = llm_skills.resolve_skill("dub_translation").reason
+                except Exception:  # noqa: BLE001
+                    reason = None
+                if reason == "disabled":
+                    friendly = (
+                        "The LLM translation engine is turned off — enable the "
+                        "'Dub translation' skill in Settings → LLM Skills, or "
+                        "pick another engine in the Engine dropdown."
+                    )
+                else:
+                    friendly = (
+                        "The LLM translation engine has no provider configured. "
+                        "Add and test one in Settings → LLM Providers (it powers "
+                        "this engine; route it per-skill in Settings → LLM "
+                        "Skills), or set TRANSLATE_BASE_URL + TRANSLATE_API_KEY "
+                        "+ TRANSLATE_MODEL. Or pick another engine in the "
+                        "Engine dropdown."
+                    )
+                return JSONResponse(status_code=400, content={"error": friendly})
 
             def _build_prompt(src_code: str, tgt_code: str) -> str:
                 """Build a system prompt that resists hallucinations on small
@@ -377,6 +426,7 @@ async def dub_translate(req: TranslateRequest):
                         res = client.chat.completions.create(
                             model=model_name,
                             temperature=0.2,  # less drift than default 1.0
+                            timeout=llm_timeout,  # bound per call (OMNIVOICE_LLM_TIMEOUT, 45s default)
                             messages=[
                                 {"role": "system", "content": sys_for_attempt},
                                 {"role": "user", "content": seg.text},

--- a/backend/services/llm_skills.py
+++ b/backend/services/llm_skills.py
@@ -5,8 +5,10 @@ the Settings → LLM Skills panel can (a) toggle it and (b) route it to a
 specific provider (a local Ollama/LM Studio vs a remote key) instead of
 everything riding the one global active provider.
 
-The five consumption points today:
+The six consumption points today:
 
+    dub_translation       — api/routers/dub_translate.py (the Dub tab's direct
+                            "LLM" translation engine; provider=openai branch)
     cinematic_translation — services/translator.py (Cinematic + Autofit
                             REFLECT/ADAPT rewrite; dub_translate quality gate)
     slot_fitting          — services/speech_rate.py (trim/expand a line to its
@@ -68,8 +70,9 @@ def _skill(sid: str) -> LLMSkill:
 
 
 # Display order in the settings panel: the dub pipeline first (translation →
-# fit → glossary → direction), then dictation.
+# refine → fit → glossary → direction), then dictation.
 _SKILLS: tuple[LLMSkill, ...] = (
+    _skill("dub_translation"),
     _skill("cinematic_translation"),
     _skill("slot_fitting"),
     _skill("glossary_extract"),

--- a/backend/services/translation_engines.py
+++ b/backend/services/translation_engines.py
@@ -92,9 +92,11 @@ REGISTRY: dict[str, dict] = {
         "category": "llm",
         "needs_key": True,
         "notes": (
-            "Any OpenAI-compatible endpoint: GPT-4/5 (OpenAI), Claude (via OpenRouter), "
-            "Gemini (OpenAI-compat mode), DeepSeek, Qwen, Ollama, LM Studio. "
-            "Set TRANSLATE_BASE_URL + TRANSLATE_API_KEY + TRANSLATE_MODEL."
+            "Uses the LLM provider you configure in Settings → LLM Providers "
+            "(route it via the 'Dub translation' skill in Settings → LLM Skills): "
+            "GPT (OpenAI), Claude (via OpenRouter), Gemini, DeepSeek, Qwen, "
+            "Ollama, LM Studio. Power-user env override: TRANSLATE_BASE_URL + "
+            "TRANSLATE_API_KEY + TRANSLATE_MODEL."
         ),
     },
 }
@@ -137,17 +139,45 @@ def install_command(engine: "str | dict | None") -> str | None:
     return f"uv pip install {pkg}" if pkg else None
 
 
+def _llm_configured() -> tuple[bool, "str | None"]:
+    """Whether the LLM translation engine has something to call, and via what.
+
+    Resolution mirrors the translate-time path in dub_translate.py: the
+    "dub_translation" LLM skill (per-skill override → active provider from
+    Settings → LLM Providers) first, then the TRANSLATE_* env override. Lets
+    the Engine dropdown say "ready via <provider>" / "needs setup" up front
+    instead of a per-segment failure after the user clicks Translate.
+    """
+    try:
+        from services import llm_skills
+        res = llm_skills.resolve_skill("dub_translation")
+        if res.ready and res.provider is not None:
+            return True, res.provider.display_name
+    except Exception:  # noqa: BLE001 — a probe must never break list_engines()
+        logger.debug("dub_translation skill probe failed", exc_info=True)
+    if os.environ.get("TRANSLATE_BASE_URL") or os.environ.get("TRANSLATE_API_KEY"):
+        return True, "env"
+    return False, None
+
+
 def list_engines() -> list[dict]:
     """Return a UI-ready list with per-engine availability stamped in."""
     out = []
     for e in REGISTRY.values():
         installed, reason = _probe(e)
-        out.append({
+        entry = {
             **e,
             "installed": installed,
             "availability_reason": reason,
             "install_command": install_command(e),
-        })
+        }
+        # LLM engines additionally need a provider/key — surface configured-ness
+        # so the UI can distinguish "importable" from "actually ready to call".
+        if e.get("category") == "llm":
+            configured, via = _llm_configured()
+            entry["configured"] = configured
+            entry["configured_via"] = via
+        out.append(entry)
     return out
 
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -370,6 +370,8 @@
     "llmskills_open_providers": "Configure providers",
     "llmskills_load_failed": "Failed to load LLM skills",
     "llmskills_save_failed": "Failed to save",
+    "llmskills_dub_translation_name": "Dub translation",
+    "llmskills_dub_translation_desc": "Translates dub lines directly with your configured LLM provider (the Dub tab's 'LLM' engine). Off: the LLM engine is unavailable — pick another engine.",
     "llmskills_cinematic_translation_name": "Cinematic & Autofit translation",
     "llmskills_cinematic_translation_desc": "Rewrites each translated line for natural, in-character delivery (and Autofit's time budget). Off: dubs use the Fast translation result.",
     "llmskills_slot_fitting_name": "Speech-rate slot fitting",

--- a/tests/test_dub_translate.py
+++ b/tests/test_dub_translate.py
@@ -326,12 +326,21 @@ async def test_argos_fast_stamps_rate_ratio(monkeypatch):
 
 def _install_fake_openai(monkeypatch, *, content="hola mundo", raises=None):
     """Register a fake `openai.OpenAI` whose chat.completions.create returns
-    `content` (or raises `raises`). Accepts the max_retries kwarg the code adds."""
+    `content` (or raises `raises`). Accepts the max_retries kwarg the code adds.
+
+    Also sets TRANSLATE_API_KEY so provider="openai" requests deterministically
+    take the legacy env-fallback branch — since the provider-wiring fix, a fully
+    unconfigured LLM engine 400s up front instead of reaching a client (the
+    skills-resolved path has its own tests below). Returns the recorded
+    chat.completions.create kwargs for call-shape assertions."""
     import sys
     import types
 
+    calls = []
+
     class _Completions:
         def create(self, **kw):
+            calls.append(kw)
             if raises is not None:
                 raise raises
             msg = type("M", (), {"content": content})
@@ -349,6 +358,8 @@ def _install_fake_openai(monkeypatch, *, content="hola mundo", raises=None):
     mod = types.ModuleType("openai")
     mod.OpenAI = _FakeClient
     monkeypatch.setitem(sys.modules, "openai", mod)
+    monkeypatch.setenv("TRANSLATE_API_KEY", "sk-test-env")
+    return calls
 
 
 # ── P1: the Autofit fit pass must be bounded by the cinematic wall-clock ─────
@@ -414,3 +425,123 @@ async def test_openai_segment_error_is_scrubbed(monkeypatch):
     assert "sk-LEAKLEAKLEAKLEAKLEAK12345" not in seg["error"]
     assert "/Users/bob" not in seg["error"]
     assert "***REDACTED***" in seg["error"]
+
+
+# ── provider="openai" resolves through the LLM Providers/Skills system ───────
+# The engine used to read only the TRANSLATE_* env vars, so a provider the user
+# configured + tested in Settings → LLM Providers silently didn't power it.
+
+
+class _RecordingLLMClient:
+    """Minimal OpenAI-compatible fake that records create() kwargs."""
+
+    def __init__(self, content):
+        self.calls = []
+        outer = self
+
+        class _Completions:
+            def create(self, **kw):
+                outer.calls.append(kw)
+                msg = type("M", (), {"content": content})
+                choice = type("C", (), {"message": msg})
+                return type("R", (), {"choices": [choice]})
+
+        self.chat = type("Chat", (), {"completions": _Completions()})()
+
+
+@pytest.mark.asyncio
+async def test_openai_uses_provider_configured_in_settings(monkeypatch):
+    """A ready dub_translation skill (Settings → LLM Providers) powers the
+    engine — its client, its model, its timeout — with no env vars set."""
+    import types
+    from api.routers import dub_translate
+    from schemas.requests import TranslateRequest, TranslateSegment
+    from services import llm_skills
+
+    for var in ("TRANSLATE_API_KEY", "TRANSLATE_BASE_URL", "TRANSLATE_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    fake = _RecordingLLMClient("hallo welt")
+    handle = types.SimpleNamespace(
+        client=fake, model="provider-model", provider_id="groq", timeout=7.0)
+    monkeypatch.setattr(llm_skills, "resolve_skill_client", lambda sid: handle)
+
+    req = TranslateRequest(
+        segments=[TranslateSegment(id="s1", text="Hello")],
+        target_lang="de", provider="openai", source_lang="en",
+    )
+    resp = await dub_translate.dub_translate(req)
+    assert resp["translated"][0]["text"] == "hallo welt"
+    assert fake.calls, "the skills-resolved client was not used"
+    assert fake.calls[0]["model"] == "provider-model"
+    assert fake.calls[0]["timeout"] == 7.0
+
+
+@pytest.mark.asyncio
+async def test_openai_unconfigured_400_names_llm_providers(monkeypatch):
+    """Nothing configured anywhere → an up-front actionable 400 pointing at
+    Settings → LLM Providers, not a raw per-segment 401."""
+    import types
+    from api.routers import dub_translate
+    from schemas.requests import TranslateRequest, TranslateSegment
+    from services import llm_skills
+
+    for var in ("TRANSLATE_API_KEY", "TRANSLATE_BASE_URL", "TRANSLATE_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(llm_skills, "resolve_skill_client", lambda sid: None)
+    monkeypatch.setattr(
+        llm_skills, "resolve_skill",
+        lambda sid: types.SimpleNamespace(reason="no_provider"))
+
+    req = TranslateRequest(
+        segments=[TranslateSegment(id="s1", text="Hello")],
+        target_lang="es", provider="openai", source_lang="en",
+    )
+    resp = await dub_translate.dub_translate(req)
+    assert resp.status_code == 400
+    assert b"LLM Providers" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_openai_disabled_skill_400_names_llm_skills(monkeypatch):
+    """A deliberately disabled dub_translation skill names the Skills page."""
+    import types
+    from api.routers import dub_translate
+    from schemas.requests import TranslateRequest, TranslateSegment
+    from services import llm_skills
+
+    for var in ("TRANSLATE_API_KEY", "TRANSLATE_BASE_URL", "TRANSLATE_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(llm_skills, "resolve_skill_client", lambda sid: None)
+    monkeypatch.setattr(
+        llm_skills, "resolve_skill",
+        lambda sid: types.SimpleNamespace(reason="disabled"))
+
+    req = TranslateRequest(
+        segments=[TranslateSegment(id="s1", text="Hello")],
+        target_lang="es", provider="openai", source_lang="en",
+    )
+    resp = await dub_translate.dub_translate(req)
+    assert resp.status_code == 400
+    assert b"LLM Skills" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_openai_env_fallback_still_works(monkeypatch):
+    """Legacy env-only setups (no provider in the app) keep working unchanged,
+    including TRANSLATE_MODEL selection."""
+    from api.routers import dub_translate
+    from schemas.requests import TranslateRequest, TranslateSegment
+    from services import llm_skills
+
+    calls = _install_fake_openai(monkeypatch, content="hola mundo")
+    monkeypatch.setenv("TRANSLATE_MODEL", "env-model")
+    monkeypatch.setattr(llm_skills, "resolve_skill_client", lambda sid: None)
+
+    req = TranslateRequest(
+        segments=[TranslateSegment(id="s1", text="Hello")],
+        target_lang="es", provider="openai", source_lang="en",
+    )
+    resp = await dub_translate.dub_translate(req)
+    assert resp["translated"][0]["text"] == "hola mundo"
+    assert calls and calls[0]["model"] == "env-model"

--- a/tests/test_llm_skills.py
+++ b/tests/test_llm_skills.py
@@ -62,8 +62,8 @@ def _activate_groq(store):
 
 def test_all_skills_cover_every_consumption_point(skills):
     assert [s.id for s in skills.all_skills()] == [
-        "cinematic_translation", "slot_fitting", "glossary_extract",
-        "direction_parse", "dictation_refinement",
+        "dub_translation", "cinematic_translation", "slot_fitting",
+        "glossary_extract", "direction_parse", "dictation_refinement",
     ]
     for s in skills.all_skills():
         assert s.name_key == f"settings.llmskills_{s.id}_name"


### PR DESCRIPTION
## The gap

The Dub tab's **LLM (OpenAI-compatible)** translation engine read only the raw `TRANSLATE_*` env vars (`dub_translate.py:312`) — bypassing **Settings → LLM Providers** entirely. A user who configured and one-click-tested their OpenAI/Claude/DeepSeek key in the app, then picked the LLM engine, got a raw 401 per segment unless they *also* hand-set three env vars. The Cinematic refiner was already properly rewired through LLM Skills (#910/#912); direct LLM translation was the last consumer left behind — the exact "configured features that silently don't work" class.

## The fix

- **New `dub_translation` LLM skill** — the engine resolves per-skill override → global active provider, like every other LLM consumer. Route translation to a cheap bulk model and Cinematic to a strong one, independently.
- **Env vars stay a power-user override** — env-only setups see zero behavior change (except the ancient `gpt-3.5-turbo` default → `gpt-4o-mini`, matching the cinematic path).
- **Per-call timeout** (45s default, `OMNIVOICE_LLM_TIMEOUT`) instead of the SDK's 600s default.
- **Actionable 400 when unconfigured** — names Settings → LLM Providers (or LLM Skills when deliberately disabled) up front, instead of a per-segment 401.
- **Key-scrub parity** — provider-store keys are fed to the error scrubber so an echoing provider can't leak them.
- **Engine dropdown honesty** — `list_engines()` stamps `configured` / `configured_via` on LLM entries ("ready via Groq" vs "needs setup") before the user clicks Translate.

i18n: skill name/desc keys added to `en.json` (the llmskills panel is en-fallback across locales, consistent with how #912 shipped).

## Tests

54 backend (4 new) + 6 frontend panel tests green. New coverage: skills-resolved client wins (its model + timeout), unconfigured→400 names LLM Providers, disabled→400 names LLM Skills, env fallback works incl. `TRANSLATE_MODEL`.

Changelog entry follows in this PR under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed Dub tab LLM translation to resolve through the configured LLM provider/skills system instead of relying only on raw `TRANSLATE_*` env vars.

```mermaid
flowchart TD
  A[Dub translate request] --> B{LLM skill resolves?}
  B -->|Yes| C[Use dub_translation skill client/model/timeout]
  C --> D[Translate segments with bounded timeout]
  B -->|No| E{Legacy env config present?}
  E -->|Yes| F[Fallback to OpenAI-compatible client via TRANSLATE_*]
  F --> D
  E -->|No| G[Return 400 with guidance for LLM Providers / LLM Skills]
```

Highlights:
- Added a new `dub_translation` LLM skill and wired it into provider resolution
- Kept `TRANSLATE_*` as a power-user fallback, with `gpt-4o-mini` as the default model
- Added per-call LLM timeout support with a 45s default via `OMNIVOICE_LLM_TIMEOUT`
- Improved error handling with clearer 400s and redacted provider-store details
- Updated engine metadata to report LLM configuration status and source
- Added English i18n strings for the new Dub translation skill
- Expanded backend tests for skill resolution, env fallback, and configuration errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->