### PR TITLE
docs(readme): community table lists the Discord server's real channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,11 +492,12 @@ OmniVoice is **free** and **AGPL-3.0** — no paid tier, no SaaS revenue. Sponso
 
 | Channel | What happens there |
 |---------|--------------------|
-| `#showcase` | Members share their dubs, clones, and voice designs |
-| `#help` | Setup issues, GPU troubleshooting, model questions |
-| `#feature-requests` | Vote on what gets built next |
-| `#dev` | Architecture discussions, PR reviews, engine integrations |
-| `#announcements` | Release notes, breaking changes, early access |
+| `#announcements` | Release news and the big moments — new versions land here first |
+| `#releases` + `#changelog` | Every build and exactly what's inside it |
+| `#issues` | Bug reports as forum posts — triaged straight into GitHub issues |
+| `#ideas` | Feature requests, discussed and voted on |
+| `#discuss-ideas` | Design talk before things get built |
+| `#general` | Setup help, GPU troubleshooting, and showing off your dubs |
 
 </details>
 


### PR DESCRIPTION
The README's community table described channels that don't exist on the server (#showcase, #help, #feature-requests, #dev). Verified against the live guild via the bot's channel list; the table now names the real ones: #announcements, #releases + #changelog, the #issues and #ideas forums, #discuss-ideas, and #general.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the README Community table to match the Discord server’s real channels.

- Replaced outdated entries like `#showcase`, `#help`, `#feature-requests`, and `#dev`
- Added the actual channels/forums: `#announcements`, `#releases` + `#changelog`, `#issues`, `#ideas`, `#discuss-ideas`, and `#general`
- Revised the descriptions to reflect their current purposes, including release updates, issue triage, idea discussion, and general help/setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->