### PR TITLE
release: freeze v0.3.10 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.3.10] — 2026-07-05
+
+The listening release — nine fixes in twenty-four hours, almost all driven by your v0.3.9 field reports (several with same-day turnaround). The dubbing pipeline stops lying: **Cinematic and Autofit can no longer invent dialogue**, the **speaker count you set is honored on every path** (and auto-cloning stops fabricating voices from guessed labels), and the timeline stops flashing invisible on Windows. Audiobook chapters with pauses render again. And one fix everyone should want: **updating can no longer leave you secretly running the old version** — a leftover backend from a previous install holding the port is now detected and replaced at launch. Plus: the Dub tab's LLM engine finally runs on the provider you configured in Settings, history timestamps stop reading "20617d ago", and the Engines page can't crash under concurrent load.
 
 ### Fixed
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.9"
+_FALLBACK_VERSION = "0.3.10"
 
 
 def _fallback_version() -> str:

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "frontend": {
       "name": "omnivoice-studio",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/source-serif-4": "^5.2.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.9"
+version = "0.3.10"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.9"
+version = "0.3.10"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Freezes **v0.3.10** for tagging (owner-directed release).

- `frontend/package.json` → 0.3.10 + the three mirrors (Cargo.toml, pyproject.toml, `_FALLBACK_VERSION`) in lockstep — `test_app_version.py` green
- `Cargo.lock` / `uv.lock` / `bun.lock` regenerated (1 line each); `bun install --frozen-lockfile` verified (Docker gate)
- `CHANGELOG.md`: `[Unreleased]` → `## [0.3.10] — 2026-07-05` with the house-style headline; release-body extraction simulated clean (13 lines, no bleed)

Nine fixes since v0.3.9: #936 #940 #944 #946 #947 #950 #951 #952 #953. On merge: tag `v0.3.10` from main; main then **holds at 0.3.10** (AUTO_VERSION_BUMP off, per owner rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Bumped the release version to 0.3.10 across the codebase, including `frontend/package.json`, `frontend/src-tauri/Cargo.toml`, `pyproject.toml`, and the backend fallback version constant.

Updated `CHANGELOG.md` with the 0.3.10 release entry dated 2026-07-05, replacing the Unreleased placeholder and capturing the nine fixes included in this release.

Regenerated and synced the lockfiles (`Cargo.lock`, `uv.lock`, and `bun.lock`) to match the version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->