### PR TITLE
feat(dub): multi-language generate translates each language first + picks persist (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Added
+
+- **"Generate N dubs" now actually translates each language first.** Multi-language generation used to synthesize every track from whatever text was in the editor — so at most one of your N dubs was really in its language. The batch now runs translate → generate per language with a visible "Translating → Bengali (2/3)…" phase, skips (and reports) any language whose translation fails instead of rendering a wrong-language track, and your multi-language picks and export-track selection are saved with the project instead of vanishing on tab switch. (#957)
+
 ### Fixed
 
 - **Completed dub tracks always show their video tabs.** Opening a project with a finished dubbed track hid the Original/track switcher until you re-selected the language — visibility was keyed to the language dropdown instead of the project's tracks, and restored projects couldn't set the language because the history database froze it at empty forever. Tabs now render from the tracks themselves, history keeps its language (existing projects heal without migration), restoring a project can no longer 404 the video preview, and track pills gained duration/timing tooltips plus an accurate now-playing indicator. (#956)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -72,6 +72,7 @@ import {
   CLONE_MAX_SECONDS,
 } from './utils/constants';
 import { LANG_CODES } from './utils/languages';
+import { restoreProjectExtras } from './utils/projectState';
 import { API, apiFetch } from './api/client';
 import { flushMemory as apiFlushMemory } from './api/system';
 import {
@@ -416,9 +417,15 @@ function App() {
   const defaultTrack = useAppStore((s) => s.defaultTrack);
   const setDefaultTrack = useAppStore((s) => s.setDefaultTrack);
   const exportTracks = useAppStore((s) => s.exportTracks);
+  const setExportTracks = useAppStore((s) => s.setExportTracks);
   const previewSegIds = useAppStore((s) => s.previewSegIds);
   const speakerClones = useAppStore((s) => s.speakerClones);
   const setSpeakerClones = useAppStore((s) => s.setSpeakerClones);
+  // Multi-language batch picks (P1.4) — saved with the project payload.
+  const multiLangMode = useAppStore((s) => s.multiLangMode);
+  const setMultiLangMode = useAppStore((s) => s.setMultiLangMode);
+  const multiLangs = useAppStore((s) => s.multiLangs);
+  const setMultiLangs = useAppStore((s) => s.setMultiLangs);
 
   const setGlossaryTerms = useAppStore((s) => s.setGlossaryTerms);
   const dualSubs = useAppStore((s) => s.dualSubs);
@@ -952,6 +959,12 @@ function App() {
         preserveBg,
         defaultTrack,
         speakerClones,
+        // P1.4 — multi-language batch setup + export-track prefs travel with
+        // the project. Additive: loaders default them when absent (see
+        // utils/projectState.js).
+        multiLangMode,
+        multiLangs,
+        exportTracks,
       },
     };
     try {
@@ -996,6 +1009,12 @@ function App() {
       // the last generate.
       setLastGenFingerprints(s.segHashes || {});
       setSpeakerClones(s.speakerClones || {});
+      // P1.4 — restore multi-lang picks; legacy payloads default to off/empty
+      // and leave the in-session exportTracks untouched (null sentinel).
+      const extras = restoreProjectExtras(s);
+      setMultiLangMode(extras.multiLangMode);
+      setMultiLangs(extras.multiLangs);
+      if (extras.exportTracks) setExportTracks(extras.exportTracks);
       toast.success(i18n.t('app.toast_opened', { name: data.name }));
     } catch (err) {
       toast.error(err.message);

--- a/frontend/src/components/dub/DubHeader.jsx
+++ b/frontend/src/components/dub/DubHeader.jsx
@@ -25,6 +25,7 @@ export default function DubHeader({
   handleDubStop,
   dubProgress,
   onGenerateClick,
+  isTranslating,
   multiLangMode,
   multiLangs,
   incrementalPlan,
@@ -99,9 +100,12 @@ export default function DubHeader({
               <>
                 <FooterBtn
                   sm
-                  tone={dubSegments.length ? 'pink' : 'idle'}
+                  tone={dubSegments.length && !isTranslating ? 'pink' : 'idle'}
                   onClick={onGenerateClick}
-                  disabled={!dubSegments.length}
+                  // The multi-language batch translates between generates while
+                  // dubStep briefly sits back at 'editing' — keep the CTA inert
+                  // during that phase so a re-click can't start a second batch.
+                  disabled={!dubSegments.length || isTranslating}
                   icon={<Play size={11} />}
                   label={
                     multiLangMode && multiLangs.length > 1

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -687,109 +687,131 @@ export default function useDubWorkflow({
     }
   }, [dubJobId, dubSegments, setDubSegments]);
 
-  const handleTranslateAll = useCallback(async () => {
-    if (!dubSegments.length || !dubLangCode) return;
-    setIsTranslating(true);
-    // Root cause of the "sticky TRANSLATION FAILED banner": a new translate
-    // attempt never cleared the previous failure, so a stale 400 survived even
-    // a successful retry. Clear it up front — the whole class of translate/
-    // pipeline error banners should reset on the next relevant action.
-    setDubError('');
-    try {
-      const data = await dubTranslate({
-        segments: dubSegments.map((s) => ({
-          id: String(s.id),
-          text: s.text_original && s.text_original.trim() ? s.text_original : s.text,
-          target_lang: s.target_lang,
-          direction: s.direction || undefined,
-          slot_seconds: s.end != null && s.start != null ? s.end - s.start : undefined,
-        })),
-        target_lang: dubLangCode,
-        provider: translateProvider,
-        quality: translateQuality,
-        // #280: regional dialect — only sent when it matches the target
-        // language so a stale "es-AR" never rides on a French translate.
-        dialect: dialectMatchesLang(dubDialect, dubLangCode) ? dubDialect : undefined,
-        glossary: glossaryTerms.length
-          ? glossaryTerms.map((t) => ({ source: t.source, target: t.target, note: t.note || '' }))
-          : undefined,
-      });
-      const translatedMap = {};
-      const errors = [];
-      (data.translated || []).forEach((t) => {
-        translatedMap[t.id] = t;
-        if (t.error) errors.push({ id: t.id, error: t.error });
-      });
-      setDubSegments(
-        dubSegments.map((s) => {
-          const hit = translatedMap[s.id];
-          if (!hit) return s;
-          return {
-            ...s,
-            text: hit.text && hit.text.trim() ? hit.text : s.text,
-            translate_error: hit.error || undefined,
-            translate_literal: hit.literal || undefined,
-            translate_critique: hit.critique || undefined,
-            // Carry over the predicted compression ratio so the per-row
-            // badge + job-level compression warning can light up before
-            // the user clicks Generate Dub.
-            rate_ratio: hit.rate_ratio != null ? hit.rate_ratio : s.rate_ratio,
-            rate_error: hit.rate_error || s.rate_error,
-          };
-        }),
-      );
-      if (data.cinematic_skipped === 'no-llm-configured') {
-        toast(t('dub_workflow.cinematic_no_llm'), { icon: 'ℹ️', duration: 8000 });
-        // #372: the backend fell back to Fast — reflect that in the toggle so
-        // the UI doesn't claim Cinematic while delivering Fast.
-        useAppStore.getState().setTranslateQuality?.('fast');
-      }
-      // #280: the user picked a dialect but the chosen engine can't honor it
-      // (Argos/NLLB/Google in Fast mode). Tell them how to make it count.
-      // #372: skip when the cinematic toast above already fired — both at once
-      // sent users in a circle ("pick Cinematic" ↔ "Cinematic needs an LLM").
-      if (
-        data.dialect &&
-        data.dialect_applied === false &&
-        data.cinematic_skipped !== 'no-llm-configured'
-      ) {
-        toast(t('dub_workflow.dialect_not_applied'), { icon: 'ℹ️', duration: 8000 });
-      }
-      if (errors.length) {
-        const unique = [...new Set(errors.map((e) => e.error))];
-        toast.error(
-          t('dub_workflow.translate_errors', {
-            errorCount: errors.length,
-            totalCount: data.translated.length,
-            firstError: unique[0].slice(0, 120),
+  // `langOverride` (optional ISO code string) is the multi-language batch path:
+  // the generate loop translates INTO each pick before dubbing it. No-arg calls
+  // (the Translate All button, the review checkpoint) behave exactly as before
+  // — the guard also shields the direct `onClick={handleTranslateAll}` usages,
+  // where the first argument is a click event, not a language.
+  // Resolves `true` when a translation landed in the segments, `false` when the
+  // request failed or nothing got translated — the batch loop skips generating
+  // that language rather than rendering a wrong-language track.
+  const handleTranslateAll = useCallback(
+    async (langOverride) => {
+      const targetLang =
+        typeof langOverride === 'string' && langOverride ? langOverride : dubLangCode;
+      // Snapshot segments at call time: inside the multi-language loop the
+      // click-time closure is stale after the previous pick's translate pass.
+      const segs = useAppStore.getState().dubSegments;
+      if (!segs.length || !targetLang) return false;
+      setIsTranslating(true);
+      // Root cause of the "sticky TRANSLATION FAILED banner": a new translate
+      // attempt never cleared the previous failure, so a stale 400 survived even
+      // a successful retry. Clear it up front — the whole class of translate/
+      // pipeline error banners should reset on the next relevant action.
+      setDubError('');
+      let ok = false;
+      try {
+        const data = await dubTranslate({
+          segments: segs.map((s) => ({
+            id: String(s.id),
+            text: s.text_original && s.text_original.trim() ? s.text_original : s.text,
+            target_lang: s.target_lang,
+            direction: s.direction || undefined,
+            slot_seconds: s.end != null && s.start != null ? s.end - s.start : undefined,
+          })),
+          target_lang: targetLang,
+          provider: translateProvider,
+          quality: translateQuality,
+          // #280: regional dialect — only sent when it matches the target
+          // language so a stale "es-AR" never rides on a French translate.
+          dialect: dialectMatchesLang(dubDialect, targetLang) ? dubDialect : undefined,
+          glossary: glossaryTerms.length
+            ? glossaryTerms.map((t) => ({ source: t.source, target: t.target, note: t.note || '' }))
+            : undefined,
+        });
+        const translatedMap = {};
+        const errors = [];
+        (data.translated || []).forEach((t) => {
+          translatedMap[t.id] = t;
+          if (t.error) errors.push({ id: t.id, error: t.error });
+        });
+        setDubSegments((prev) =>
+          prev.map((s) => {
+            const hit = translatedMap[s.id];
+            if (!hit) return s;
+            return {
+              ...s,
+              text: hit.text && hit.text.trim() ? hit.text : s.text,
+              translate_error: hit.error || undefined,
+              translate_literal: hit.literal || undefined,
+              translate_critique: hit.critique || undefined,
+              // Carry over the predicted compression ratio so the per-row
+              // badge + job-level compression warning can light up before
+              // the user clicks Generate Dub.
+              rate_ratio: hit.rate_ratio != null ? hit.rate_ratio : s.rate_ratio,
+              rate_error: hit.rate_error || s.rate_error,
+            };
           }),
-          { duration: 6000 },
         );
-      } else {
-        const qLabel =
-          data.quality_used === 'cinematic' ? t('dub_workflow.translated_cinematic_suffix') : '';
-        toast.success(
-          t('dub_workflow.translated_segments', {
-            count: data.translated.length,
-            lang: data.target_lang,
-          }) + qLabel,
-        );
+        // "Translated" for the batch loop means at least one segment actually
+        // got new text — an empty result or an all-errors result would make
+        // the follow-up generate render the source language verbatim.
+        const total = (data.translated || []).length;
+        ok = total > 0 && errors.length < total;
+        if (data.cinematic_skipped === 'no-llm-configured') {
+          toast(t('dub_workflow.cinematic_no_llm'), { icon: 'ℹ️', duration: 8000 });
+          // #372: the backend fell back to Fast — reflect that in the toggle so
+          // the UI doesn't claim Cinematic while delivering Fast.
+          useAppStore.getState().setTranslateQuality?.('fast');
+        }
+        // #280: the user picked a dialect but the chosen engine can't honor it
+        // (Argos/NLLB/Google in Fast mode). Tell them how to make it count.
+        // #372: skip when the cinematic toast above already fired — both at once
+        // sent users in a circle ("pick Cinematic" ↔ "Cinematic needs an LLM").
+        if (
+          data.dialect &&
+          data.dialect_applied === false &&
+          data.cinematic_skipped !== 'no-llm-configured'
+        ) {
+          toast(t('dub_workflow.dialect_not_applied'), { icon: 'ℹ️', duration: 8000 });
+        }
+        if (errors.length) {
+          const unique = [...new Set(errors.map((e) => e.error))];
+          toast.error(
+            t('dub_workflow.translate_errors', {
+              errorCount: errors.length,
+              totalCount: data.translated.length,
+              firstError: unique[0].slice(0, 120),
+            }),
+            { duration: 6000 },
+          );
+        } else {
+          const qLabel =
+            data.quality_used === 'cinematic' ? t('dub_workflow.translated_cinematic_suffix') : '';
+          toast.success(
+            t('dub_workflow.translated_segments', {
+              count: data.translated.length,
+              lang: data.target_lang,
+            }) + qLabel,
+          );
+        }
+      } catch (err) {
+        setDubError(t('dub_workflow.translation_failed', { message: err.message }));
       }
-    } catch (err) {
-      setDubError(t('dub_workflow.translation_failed', { message: err.message }));
-    }
-    setIsTranslating(false);
-  }, [
-    dubSegments,
-    dubLangCode,
-    dubDialect,
-    translateProvider,
-    translateQuality,
-    glossaryTerms,
-    setIsTranslating,
-    setDubSegments,
-    setDubError,
-  ]);
+      setIsTranslating(false);
+      return ok;
+    },
+    [
+      dubLangCode,
+      dubDialect,
+      translateProvider,
+      translateQuality,
+      glossaryTerms,
+      setIsTranslating,
+      setDubSegments,
+      setDubError,
+    ],
+  );
 
   const handleDubGenerate = useCallback(
     async (opts = {}) => {
@@ -801,8 +823,12 @@ export default function useDubWorkflow({
       // here, overriding the store's single selection (which is stale inside the
       // loop). Each run appends its track to the job's dubbed_tracks.
       const langOv = opts.langOverride || null;
+      // Snapshot segments at call time, not click time: the multi-language
+      // loop awaits a translate pass right before each generate, and the
+      // click-time closure would still hold the pre-translation text.
+      const segs = useAppStore.getState().dubSegments;
       setDubStep('generating');
-      setDubProgress({ current: 0, total: dubSegments.length, text: '' });
+      setDubProgress({ current: 0, total: segs.length, text: '' });
       setDubError('');
       const genLabel = regenOnly
         ? t('dub_workflow.regenerating', { count: regenOnly.length })
@@ -812,12 +838,12 @@ export default function useDubWorkflow({
         .showPill('generating', genLabel, { cancellable: true, homeMode: 'dub' });
       try {
         const body = {
-          segment_ids: dubSegments.map((s) => String(s.id)),
+          segment_ids: segs.map((s) => String(s.id)),
           regen_only: regenOnly,
           // Generation inputs come from the shared helper so the stored
           // fingerprints (seg_hashes) match what /tools/incremental recomputes
           // later — see utils/segments.js (#281).
-          segments: dubSegments.map((s) => ({
+          segments: segs.map((s) => ({
             start: s.start,
             end: s.end,
             gain: s.gain !== undefined && s.gain !== 1.0 ? s.gain : undefined,
@@ -895,7 +921,7 @@ export default function useDubWorkflow({
                   } else {
                     try {
                       const plan = await apiPost('/tools/incremental', {
-                        segments: dubSegments.map((s) => ({
+                        segments: segs.map((s) => ({
                           id: String(s.id),
                           ...segmentGenInputs(s),
                         })),
@@ -941,7 +967,6 @@ export default function useDubWorkflow({
     },
     [
       dubJobId,
-      dubSegments,
       dubLang,
       dubLangCode,
       dubInstruct,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -927,6 +927,8 @@
     "hq_needs_llm_hint": "High-quality translation fits each line to its segment time using a local or cloud LLM. Set one up to enable it.",
     "set_up_llm": "Set up",
     "generate_dub_multi": "Generate {{count}} dubs",
+    "multi_translating": "Translating → {{lang}} ({{current}}/{{total}})…",
+    "multi_lang_skipped": "Translation failed for {{langs}} — those dubs were skipped so you never get a wrong-language track.",
     "pipeline": "Dubbing pipeline",
     "preview_language": "Preview language",
     "target_language": "Dub into",

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -188,31 +188,93 @@ export default function DubTab(props) {
   const [exportOpen, setExportOpen] = useState(false);
   const [qcRunning, setQcRunning] = useState(false);
 
-  // Multi-language mode
-  const [multiLangMode, setMultiLangMode] = useState(false);
-  const [multiLangs, setMultiLangs] = useState([]);
+  // Multi-language mode — store-backed (P1.4) so the picks survive tab
+  // switches and ride the project save/load payload.
+  const multiLangMode = useAppStore((s) => s.multiLangMode);
+  const setMultiLangMode = useAppStore((s) => s.setMultiLangMode);
+  const multiLangs = useAppStore((s) => s.multiLangs);
+  const setMultiLangs = useAppStore((s) => s.setMultiLangs);
   // Landing "Advanced" disclosure (pre-upload options).
   const [landingAdvOpen, setLandingAdvOpen] = useState(false);
 
   // Generate CTA — when multi-language mode has picks, dub each language
   // sequentially; every run appends its track to dubbed_tracks, so the
   // preview switcher pills fill up one by one.
+  //
+  // P1.1: each language is TRANSLATED first (`handleTranslateAll(code)`), then
+  // generated — the backend synthesizes segment text verbatim, so without the
+  // translate pass every "multi-language" track rendered the same words.
+  // A pick whose translate fails is skipped (never render a wrong-language
+  // track); the batch continues and the skips are reported at the end.
+  const multiBatchRunningRef = useRef(false);
   const onGenerateClick = useCallback(async () => {
     if (multiLangMode && multiLangs.length > 0) {
+      if (multiBatchRunningRef.current) return; // ignore re-clicks mid-batch
+      multiBatchRunningRef.current = true;
+      const skipped = [];
+      // Skip the redundant translate ONLY for the first pick, and only when
+      // it targets the language the editor text is already in (every segment
+      // carries a translation differing from its original — i.e. the user
+      // just ran Translate All into this exact language). After the first
+      // pick the editor text is the previous pick's language, so every later
+      // pick always translates. Correctness beats cleverness.
+      const editorAlreadyTranslated =
+        dubSegments.length > 0 &&
+        dubSegments.every((s) => s.text_original && s.text !== s.text_original);
       try {
-        for (const l of multiLangs) {
+        for (let i = 0; i < multiLangs.length; i++) {
+          const l = multiLangs[i];
           setDubLang(l.lang);
           setDubLangCode(l.code); // keep UI/exports in sync
+          const skipTranslate = i === 0 && l.code === dubLangCode && editorAlreadyTranslated;
+          if (!skipTranslate) {
+            // Honest phase label: this pill slot otherwise only says
+            // "Generating…", hiding the translate pass entirely.
+            useAppStore.getState().showPill(
+              'translating',
+              t('dub.multi_translating', {
+                lang: l.lang,
+                current: i + 1,
+                total: multiLangs.length,
+              }),
+              { homeMode: 'dub' },
+            );
+            // eslint-disable-next-line no-await-in-loop
+            const ok = await handleTranslateAll(l.code);
+            if (!ok) {
+              // Error already surfaced by handleTranslateAll (banner/toast);
+              // drop the phase pill and move on to the next language.
+              useAppStore.getState().dismissPill();
+              skipped.push(l.lang);
+              continue;
+            }
+          }
           // eslint-disable-next-line no-await-in-loop
           await handleDubGenerate({ langOverride: { language: l.lang, language_code: l.code } });
         }
       } catch {
         /* a failed language stops the batch; its error is already surfaced */
       }
+      multiBatchRunningRef.current = false;
+      if (skipped.length) {
+        toast.error(t('dub.multi_lang_skipped', { langs: skipped.join(', ') }), {
+          duration: 8000,
+        });
+      }
     } else {
       handleDubGenerate();
     }
-  }, [multiLangMode, multiLangs, handleDubGenerate, setDubLang, setDubLangCode]);
+  }, [
+    multiLangMode,
+    multiLangs,
+    dubSegments,
+    dubLangCode,
+    handleTranslateAll,
+    handleDubGenerate,
+    setDubLang,
+    setDubLangCode,
+    t,
+  ]);
 
   // Live ETA while generating — elapsed ticks each second; remaining is
   // extrapolated from the current/total rate so it's only meaningful once
@@ -508,6 +570,7 @@ export default function DubTab(props) {
             handleDubStop={handleDubStop}
             dubProgress={dubProgress}
             onGenerateClick={onGenerateClick}
+            isTranslating={isTranslating}
             multiLangMode={multiLangMode}
             multiLangs={multiLangs}
             incrementalPlan={incrementalPlan}

--- a/frontend/src/store/dubSlice.ts
+++ b/frontend/src/store/dubSlice.ts
@@ -45,6 +45,12 @@ interface DubPrepProgress {
 /** Segments are a loose shape — many optional fields added over time. */
 type DubSegment = Record<string, unknown> & { id: string; text: string };
 
+/** One multi-language batch pick — display name + ISO code (MultiLangPicker). */
+export interface MultiLangPick {
+  lang: string;
+  code: string;
+}
+
 type Updater<T> = T | ((prev: T) => T);
 
 function resolve<T>(updater: Updater<T>, prev: T): T {
@@ -103,6 +109,13 @@ export interface DubSlice {
   // paths (OpenAI/Ollama provider or Cinematic quality).
   dubDialect: string;
 
+  // Multi-language batch mode (P1.4) — the checkbox + language picks used by
+  // the "Generate N dubs" loop. Lived in DubTab component state before, so a
+  // tab switch or project reload silently dropped the picks; now they ride
+  // the store and the project save/load payload.
+  multiLangMode: boolean;
+  multiLangs: MultiLangPick[];
+
   // ── Generation options ────────────────────────────────────────────────
   dubInstruct: string;
   preserveBg: boolean;
@@ -158,6 +171,8 @@ export interface DubSlice {
   setDubLangCode: (v: Updater<string>) => void;
   setDubNumSpeakers: (v: Updater<number | null>) => void;
   setDubDialect: (v: Updater<string>) => void;
+  setMultiLangMode: (v: Updater<boolean>) => void;
+  setMultiLangs: (v: Updater<MultiLangPick[]>) => void;
   setDubInstruct: (v: Updater<string>) => void;
   setPreserveBg: (v: Updater<boolean>) => void;
   setDefaultTrack: (v: Updater<string>) => void;
@@ -192,6 +207,8 @@ const INITIAL: Omit<
   | 'setDubLangCode'
   | 'setDubNumSpeakers'
   | 'setDubDialect'
+  | 'setMultiLangMode'
+  | 'setMultiLangs'
   | 'setDubInstruct'
   | 'setPreserveBg'
   | 'setDefaultTrack'
@@ -223,6 +240,8 @@ const INITIAL: Omit<
   dubLangCode: 'en',
   dubNumSpeakers: null,
   dubDialect: '',
+  multiLangMode: false,
+  multiLangs: [],
   dubInstruct: '',
   preserveBg: true,
   defaultTrack: 'original',
@@ -257,6 +276,8 @@ export const createDubSlice: StateCreator<DubSlice, [], [], DubSlice> = (set, ge
   setDubLangCode: (v) => set((s) => ({ dubLangCode: resolve(v, s.dubLangCode) })),
   setDubNumSpeakers: (v) => set((s) => ({ dubNumSpeakers: resolve(v, s.dubNumSpeakers) })),
   setDubDialect: (v) => set((s) => ({ dubDialect: resolve(v, s.dubDialect) })),
+  setMultiLangMode: (v) => set((s) => ({ multiLangMode: resolve(v, s.multiLangMode) })),
+  setMultiLangs: (v) => set((s) => ({ multiLangs: resolve(v, s.multiLangs) })),
   setDubInstruct: (v) => set((s) => ({ dubInstruct: resolve(v, s.dubInstruct) })),
   setPreserveBg: (v) => set((s) => ({ preserveBg: resolve(v, s.preserveBg) })),
   setDefaultTrack: (v) => set((s) => ({ defaultTrack: resolve(v, s.defaultTrack) })),

--- a/frontend/src/test/dubMultiLangGenerate.test.jsx
+++ b/frontend/src/test/dubMultiLangGenerate.test.jsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import toast from 'react-hot-toast';
+import { useAppStore } from '../store';
+
+// P1.1 — the multi-language generate loop must TRANSLATE each pick before it
+// generates it. Pre-fix the loop only called handleDubGenerate per language,
+// so "Generate 3 dubs" synthesized the same (untranslated) text three times —
+// at most one track was actually in its language.
+//
+// Contract under test (call order, per pick):
+//   translate(code) → generate({ langOverride: { language, language_code } })
+// and on a failed translate: skip that pick's generate, keep going, report
+// the skipped languages in a final toast.
+
+const captured = vi.hoisted(() => ({ header: [] }));
+vi.mock('../components/dub/DubHeader', () => ({
+  default: (props) => {
+    captured.header.push(props);
+    return null;
+  },
+}));
+vi.mock('../components/dub/DubLeftColumn', () => ({ default: () => null }));
+vi.mock('../components/dub/DubRightColumn', () => ({ default: () => null }));
+vi.mock('../components/dub/DubFooter', () => ({ default: () => null }));
+vi.mock('../components/dub/DubPipelineStepper', () => ({ default: () => null }));
+vi.mock('../components/dub/IdleSkeleton', () => ({ default: () => null }));
+vi.mock('../components/ExportModal', () => ({ default: () => null }));
+vi.mock('../hooks/useTimelineOnsets', () => ({ default: () => ({ onsets: [] }) }));
+vi.mock('../api/dub', () => ({ dubQc: vi.fn() }));
+// Never-resolving async deps keep the render synchronous (no post-test act noise).
+vi.mock('../api/engines', () => ({
+  listTranslationEngines: vi.fn(() => new Promise(() => {})),
+  installTranslationEngine: vi.fn(),
+}));
+vi.mock('../api/client', async (importOriginal) => {
+  const mod = await importOriginal();
+  return { ...mod, apiJson: vi.fn(() => new Promise(() => {})) };
+});
+
+import DubTab from '../pages/DubTab';
+
+const noop = () => {};
+function makeProps(over = {}) {
+  return {
+    dubVideoFile: null,
+    dubLocalBlobUrl: null,
+    transcribeElapsed: 0,
+    translateProvider: 'google',
+    setTranslateProvider: noop,
+    showTranscript: false,
+    setShowTranscript: noop,
+    onGlossaryChange: noop,
+    profiles: [],
+    segmentPreviewLoading: null,
+    selectedSegIds: new Set(),
+    setDubVideoFile: noop,
+    setDubLocalBlobUrl: noop,
+    handleDubAbort: noop,
+    handleDubUpload: noop,
+    handleDubIngestUrl: noop,
+    handleDubRetryTranscribe: noop,
+    handleDubStop: noop,
+    handleDubGenerate: noop,
+    handleDubImportSrt: noop,
+    handleDubDownload: noop,
+    handleDubAudioDownload: noop,
+    handleAudioExport: noop,
+    handleSegmentPreview: noop,
+    onDirectSegment: noop,
+    handleTranslateAll: noop,
+    handleCleanupSegments: noop,
+    incrementalPlan: null,
+    triggerDownload: noop,
+    fileToMediaUrl: noop,
+    editSegments: noop,
+    saveProject: noop,
+    resetDub: noop,
+    segmentEditField: noop,
+    segmentDelete: noop,
+    segmentRestoreOriginal: noop,
+    segmentSplit: noop,
+    segmentMerge: noop,
+    segmentMoveResize: noop,
+    timelineSelSegId: null,
+    setTimelineSelSegId: noop,
+    toggleSegSelect: noop,
+    selectAllSegs: noop,
+    clearSegSelection: noop,
+    bulkApplyToSelected: noop,
+    bulkDeleteSelected: noop,
+    ...over,
+  };
+}
+
+const baseState = useAppStore.getState();
+const PICKS = [
+  { lang: 'Bengali', code: 'bn' },
+  { lang: 'Spanish', code: 'es' },
+];
+
+/** Render DubTab in multi-lang mode and return { onGenerateClick, calls, mocks }. */
+function setup({ translateOk = () => true, langCode = 'en', segments } = {}) {
+  const calls = [];
+  const handleTranslateAll = vi.fn(async (code) => {
+    calls.push(`translate:${code}`);
+    return translateOk(code);
+  });
+  const handleDubGenerate = vi.fn(async (opts) => {
+    calls.push(`generate:${opts?.langOverride?.language_code ?? 'default'}`);
+  });
+  useAppStore.setState({
+    dubJobId: 'job1',
+    dubStep: 'editing',
+    dubLangCode: langCode,
+    dubLang: 'English',
+    multiLangMode: true,
+    multiLangs: PICKS,
+    dubSegments: segments ?? [{ id: '1', text: 'hello', text_original: 'hello' }],
+  });
+  render(<DubTab {...makeProps({ handleTranslateAll, handleDubGenerate })} />);
+  return {
+    onGenerateClick: captured.header.at(-1).onGenerateClick,
+    calls,
+    handleTranslateAll,
+    handleDubGenerate,
+  };
+}
+
+describe('DubTab — multi-language generate translates each language first (P1.1)', () => {
+  beforeEach(() => {
+    useAppStore.setState(baseState, true);
+    captured.header.length = 0;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("picks ['bn','es']: each language's translate runs BEFORE its generate, in order", async () => {
+    const { onGenerateClick, calls, handleDubGenerate } = setup();
+    await act(async () => {
+      await onGenerateClick();
+    });
+    // Pre-fix this was ['generate:bn', 'generate:es'] — translate never ran.
+    expect(calls).toEqual(['translate:bn', 'generate:bn', 'translate:es', 'generate:es']);
+    // langOverride keeps the existing handleDubGenerate call shape.
+    expect(handleDubGenerate).toHaveBeenNthCalledWith(1, {
+      langOverride: { language: 'Bengali', language_code: 'bn' },
+    });
+    expect(handleDubGenerate).toHaveBeenNthCalledWith(2, {
+      langOverride: { language: 'Spanish', language_code: 'es' },
+    });
+  });
+
+  it('a failed translate skips ONLY that language’s generate, continues, and reports it', async () => {
+    const errorSpy = vi.spyOn(toast, 'error');
+    const { onGenerateClick, calls } = setup({ translateOk: (code) => code !== 'bn' });
+    await act(async () => {
+      await onGenerateClick();
+    });
+    expect(calls).toEqual(['translate:bn', 'translate:es', 'generate:es']);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('Bengali');
+  });
+
+  it('skips the redundant translate only when the FIRST pick already matches freshly-translated editor text', async () => {
+    const { onGenerateClick, calls } = setup({
+      langCode: 'bn',
+      // text differs from text_original on every segment = a translation into
+      // dubLangCode ('bn') is already applied — pick 1 can go straight to generate.
+      segments: [{ id: '1', text: 'ওহে', text_original: 'hello' }],
+    });
+    await act(async () => {
+      await onGenerateClick();
+    });
+    expect(calls).toEqual(['generate:bn', 'translate:es', 'generate:es']);
+  });
+
+  it('untranslated editor text is ALWAYS translated, even when the first pick matches dubLangCode', async () => {
+    const { onGenerateClick, calls } = setup({
+      langCode: 'bn',
+      segments: [{ id: '1', text: 'hello', text_original: 'hello' }],
+    });
+    await act(async () => {
+      await onGenerateClick();
+    });
+    expect(calls).toEqual(['translate:bn', 'generate:bn', 'translate:es', 'generate:es']);
+  });
+
+  it('single-language mode is untouched: generate only, no translate, no override', async () => {
+    const { onGenerateClick, calls, handleDubGenerate, handleTranslateAll } = setup();
+    act(() => {
+      useAppStore.setState({ multiLangMode: false });
+    });
+    void onGenerateClick; // stale capture — re-read after the mode flip
+    const fresh = captured.header.at(-1).onGenerateClick;
+    await act(async () => {
+      await fresh();
+    });
+    expect(handleTranslateAll).not.toHaveBeenCalled();
+    expect(handleDubGenerate).toHaveBeenCalledWith();
+    expect(calls).toEqual(['generate:default']);
+  });
+});

--- a/frontend/src/test/dubMultiLangPersist.test.js
+++ b/frontend/src/test/dubMultiLangPersist.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../store';
+import { restoreProjectExtras } from '../utils/projectState';
+import appSrc from '../App.jsx?raw';
+
+// P1.4 — multi-language picks live in the dub store slice (not DubTab-local
+// state) and ride the project save/load payload, so "Generate 3 dubs" setups
+// survive tab switches and project reopens. Legacy payloads (saved before
+// these fields existed) must default cleanly: multi-lang off/empty, and the
+// in-session exportTracks left untouched.
+
+const baseState = useAppStore.getState();
+
+describe('dub slice — multiLangMode / multiLangs', () => {
+  beforeEach(() => {
+    useAppStore.setState(baseState, true);
+  });
+
+  it('defaults to off/empty', () => {
+    expect(useAppStore.getState().multiLangMode).toBe(false);
+    expect(useAppStore.getState().multiLangs).toEqual([]);
+  });
+
+  it('setters accept values and functional updaters (slice pattern)', () => {
+    const s = useAppStore.getState();
+    s.setMultiLangMode(true);
+    s.setMultiLangs([{ lang: 'Bengali', code: 'bn' }]);
+    expect(useAppStore.getState().multiLangMode).toBe(true);
+    expect(useAppStore.getState().multiLangs).toEqual([{ lang: 'Bengali', code: 'bn' }]);
+    s.setMultiLangs((prev) => [...prev, { lang: 'Spanish', code: 'es' }]);
+    expect(useAppStore.getState().multiLangs).toHaveLength(2);
+    s.setMultiLangMode((prev) => !prev);
+    expect(useAppStore.getState().multiLangMode).toBe(false);
+  });
+
+  it('resetDubState clears the picks with the rest of the pipeline state', () => {
+    const s = useAppStore.getState();
+    s.setMultiLangMode(true);
+    s.setMultiLangs([{ lang: 'Bengali', code: 'bn' }]);
+    s.resetDubState();
+    expect(useAppStore.getState().multiLangMode).toBe(false);
+    expect(useAppStore.getState().multiLangs).toEqual([]);
+  });
+});
+
+describe('project payload — save/load round-trip (restoreProjectExtras)', () => {
+  beforeEach(() => {
+    useAppStore.setState(baseState, true);
+  });
+
+  it('round-trips multiLangMode, multiLangs and exportTracks through the payload', () => {
+    const s = useAppStore.getState();
+    s.setMultiLangMode(true);
+    s.setMultiLangs([
+      { lang: 'Bengali', code: 'bn' },
+      { lang: 'Spanish', code: 'es' },
+    ]);
+    s.setExportTracks({ original: true, bn: true, es: false });
+    // Mirror App.jsx's saveProject: the store values land in state as-is.
+    const cur = useAppStore.getState();
+    const payload = {
+      multiLangMode: cur.multiLangMode,
+      multiLangs: cur.multiLangs,
+      exportTracks: cur.exportTracks,
+    };
+    const restored = restoreProjectExtras(JSON.parse(JSON.stringify(payload)));
+    expect(restored.multiLangMode).toBe(true);
+    expect(restored.multiLangs).toEqual([
+      { lang: 'Bengali', code: 'bn' },
+      { lang: 'Spanish', code: 'es' },
+    ]);
+    expect(restored.exportTracks).toEqual({ original: true, bn: true, es: false });
+  });
+
+  it('legacy payload (fields absent) defaults to off/empty and leaves exportTracks alone', () => {
+    const restored = restoreProjectExtras({ dubJobId: 'old', dubSegments: [] });
+    expect(restored.multiLangMode).toBe(false);
+    expect(restored.multiLangs).toEqual([]);
+    expect(restored.exportTracks).toBeNull(); // null = don't touch the current value
+  });
+
+  it('is shape-safe: malformed picks are dropped, junk exportTracks is ignored', () => {
+    const restored = restoreProjectExtras({
+      multiLangMode: 'yes', // not boolean true → off
+      multiLangs: [{ lang: 'Bengali', code: 'bn' }, { code: 'es' }, 'fr', null],
+      exportTracks: ['original'],
+    });
+    expect(restored.multiLangMode).toBe(false);
+    expect(restored.multiLangs).toEqual([{ lang: 'Bengali', code: 'bn' }]);
+    expect(restored.exportTracks).toBeNull();
+    expect(restoreProjectExtras(undefined)).toEqual({
+      multiLangMode: false,
+      multiLangs: [],
+      exportTracks: null,
+    });
+  });
+});
+
+describe('App.jsx wiring guard (raw source — keeps the util honest)', () => {
+  it('saveProject persists the three fields in statePayload.state', () => {
+    const start = appSrc.indexOf('const statePayload');
+    expect(start).toBeGreaterThan(-1);
+    const block = appSrc.slice(start, appSrc.indexOf('apiSaveProject', start));
+    for (const key of ['multiLangMode', 'multiLangs', 'exportTracks']) {
+      expect(block, `statePayload.state must include ${key}`).toContain(key);
+    }
+  });
+
+  it('loadProject restores through restoreProjectExtras', () => {
+    const start = appSrc.indexOf('const loadProject');
+    expect(start).toBeGreaterThan(-1);
+    const block = appSrc.slice(start, start + 3000);
+    expect(block).toContain('restoreProjectExtras');
+    expect(block).toContain('setMultiLangMode');
+    expect(block).toContain('setMultiLangs');
+  });
+});

--- a/frontend/src/test/dubTranslateAllOverride.test.jsx
+++ b/frontend/src/test/dubTranslateAllOverride.test.jsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAppStore } from '../store';
+
+// P1.1 — `handleTranslateAll(langOverride?)`:
+//  - no-arg keeps the existing Translate All behavior (target = store's
+//    dubLangCode),
+//  - a string override translates INTO that language (the multi-language
+//    generate loop passes each pick's code),
+//  - a non-string first arg (the `onClick={handleTranslateAll}` click event)
+//    must be ignored, not treated as a language,
+//  - resolves true only when a translation actually landed — the batch loop
+//    keys "skip this language's generate" off that.
+
+const dubApi = vi.hoisted(() => ({
+  dubUpload: vi.fn(),
+  dubIngestUrl: vi.fn(),
+  dubAbort: vi.fn(),
+  dubCleanupSegments: vi.fn(),
+  dubTranslate: vi.fn(),
+  dubGenerate: vi.fn(),
+  tasksStreamUrl: vi.fn(() => ''),
+  tasksCancel: vi.fn(),
+  transcribeStreamUrl: vi.fn(() => ''),
+  dubImportSrt: vi.fn(),
+}));
+vi.mock('../api/dub', () => dubApi);
+vi.mock('../api/client', () => ({
+  apiPost: vi.fn(),
+  apiFetch: vi.fn(),
+  apiJson: vi.fn(),
+  API: '',
+}));
+
+import useDubWorkflow from '../hooks/useDubWorkflow';
+
+const baseState = useAppStore.getState();
+
+function renderWorkflow() {
+  return renderHook(() =>
+    useDubWorkflow({
+      loadProjects: vi.fn(),
+      loadProfiles: vi.fn(),
+      loadDubHistory: vi.fn(),
+      setLastGenFingerprints: vi.fn(),
+    }),
+  );
+}
+
+describe('handleTranslateAll(langOverride) — multi-language target override', () => {
+  beforeEach(() => {
+    useAppStore.setState(baseState, true);
+    dubApi.dubTranslate.mockReset();
+    useAppStore.setState({
+      dubJobId: 'job1',
+      dubStep: 'editing',
+      dubLangCode: 'es',
+      dubSegments: [
+        { id: '1', text: 'hello there', text_original: 'hello there', start: 0, end: 2 },
+      ],
+    });
+  });
+
+  it('no-arg behavior unchanged: translates into the store dubLangCode and applies the text', async () => {
+    dubApi.dubTranslate.mockResolvedValue({
+      translated: [{ id: '1', text: 'hola' }],
+      target_lang: 'es',
+    });
+    const { result } = renderWorkflow();
+    let ok;
+    await act(async () => {
+      ok = await result.current.handleTranslateAll();
+    });
+    expect(dubApi.dubTranslate).toHaveBeenCalledTimes(1);
+    expect(dubApi.dubTranslate.mock.calls[0][0].target_lang).toBe('es');
+    expect(ok).toBe(true);
+    expect(useAppStore.getState().dubSegments[0].text).toBe('hola');
+  });
+
+  it('string override translates INTO the override language, not the store selection', async () => {
+    dubApi.dubTranslate.mockResolvedValue({
+      translated: [{ id: '1', text: 'ওহে' }],
+      target_lang: 'bn',
+    });
+    const { result } = renderWorkflow();
+    let ok;
+    await act(async () => {
+      ok = await result.current.handleTranslateAll('bn');
+    });
+    expect(dubApi.dubTranslate.mock.calls[0][0].target_lang).toBe('bn');
+    expect(ok).toBe(true);
+    expect(useAppStore.getState().dubSegments[0].text).toBe('ওহে');
+  });
+
+  it('a click event as first arg (onClick={handleTranslateAll}) falls back to dubLangCode', async () => {
+    dubApi.dubTranslate.mockResolvedValue({
+      translated: [{ id: '1', text: 'hola' }],
+      target_lang: 'es',
+    });
+    const { result } = renderWorkflow();
+    await act(async () => {
+      await result.current.handleTranslateAll({ preventDefault() {}, type: 'click' });
+    });
+    expect(dubApi.dubTranslate.mock.calls[0][0].target_lang).toBe('es');
+  });
+
+  it('request failure resolves false and surfaces the existing error banner', async () => {
+    dubApi.dubTranslate.mockRejectedValue(new Error('engine down'));
+    const { result } = renderWorkflow();
+    let ok;
+    await act(async () => {
+      ok = await result.current.handleTranslateAll('bn');
+    });
+    expect(ok).toBe(false);
+    expect(useAppStore.getState().dubError).toMatch(/engine down/);
+    expect(useAppStore.getState().isTranslating).toBe(false);
+  });
+
+  it('an all-errors result resolves false (nothing translated → no wrong-language dub)', async () => {
+    dubApi.dubTranslate.mockResolvedValue({
+      translated: [{ id: '1', text: '', error: 'boom' }],
+      target_lang: 'bn',
+    });
+    const { result } = renderWorkflow();
+    let ok;
+    await act(async () => {
+      ok = await result.current.handleTranslateAll('bn');
+    });
+    expect(ok).toBe(false);
+  });
+
+  it('reads segments from the store at call time (stale click-time closure is the loop bug class)', async () => {
+    dubApi.dubTranslate.mockResolvedValue({
+      translated: [{ id: '2', text: 'nuevo' }],
+      target_lang: 'es',
+    });
+    const { result } = renderWorkflow();
+    const stale = result.current.handleTranslateAll; // captured before the segments change
+    act(() => {
+      useAppStore
+        .getState()
+        .setDubSegments([{ id: '2', text: 'fresh', text_original: 'fresh', start: 0, end: 1 }]);
+    });
+    await act(async () => {
+      await stale();
+    });
+    const sent = dubApi.dubTranslate.mock.calls[0][0].segments;
+    expect(sent).toHaveLength(1);
+    expect(sent[0].id).toBe('2');
+    expect(sent[0].text).toBe('fresh');
+  });
+});

--- a/frontend/src/utils/projectState.js
+++ b/frontend/src/utils/projectState.js
@@ -1,0 +1,35 @@
+/**
+ * Project payload extras (P1.4) — multi-language picks + export-track prefs
+ * ride the saved project state so reopening a project restores the batch
+ * setup the user configured.
+ *
+ * Legacy payloads (projects saved before these fields existed) simply lack
+ * the keys — restoring them must default cleanly: multi-lang OFF/empty, and
+ * exportTracks left untouched (`null` sentinel) so a legacy load never
+ * clobbers the user's current in-session export choices.
+ */
+
+/** True for a plain `{ track: boolean }` map (rejects arrays/null). */
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Normalize the multi-lang / export-track fields of a loaded project payload.
+ *
+ * @param {object} [state] - `data.state` from the projects API (may be legacy).
+ * @returns {{ multiLangMode: boolean, multiLangs: {lang: string, code: string}[], exportTracks: Record<string, boolean> | null }}
+ *   `exportTracks === null` means "absent in payload — keep the current value".
+ */
+export function restoreProjectExtras(state = {}) {
+  const s = isPlainObject(state) ? state : {};
+  return {
+    multiLangMode: s.multiLangMode === true,
+    multiLangs: Array.isArray(s.multiLangs)
+      ? s.multiLangs.filter(
+          (l) => isPlainObject(l) && typeof l.lang === 'string' && typeof l.code === 'string',
+        )
+      : [],
+    exportTracks: isPlainObject(s.exportTracks) ? s.exportTracks : null,
+  };
+}


### PR DESCRIPTION
## The correctness gap (found by the multi-lang investigation)
"Generate N dubs" looped generate-only — the backend synthesizes `seg.text` verbatim and no server-side translation exists — so **all N tracks rendered from the same text**; at most one was actually in its language.

## What this does
- **Per-language translate → generate**, strictly sequential and awaited, with a visible pill phase ("Translating → Bengali (2/3)…").
- **Honest failure semantics**: a language whose translation fails (request error or all segments errored) is **skipped** — never a verbatim wrong-language track — and reported in the final toast; the rest continue. Partial per-segment errors still generate (matches the manual Translate-All UX).
- **Stale-closure class fix**: `handleTranslateAll`/`handleDubGenerate` snapshot `dubSegments` from the store at call time — without this the click-time closure would synthesize *pre-translation* text and silently defeat the feature.
- **Persistence (P1.4)**: `multiLangMode`/`multiLangs` move into the dub slice and — with `exportTracks` — into the project save payload; legacy payloads default cleanly (and never clobber in-session export prefs).
- Double-batch guard + CTA disabled during the translate phase.

## Tests
19 new across 3 files — **9 fail pre-fix** (incl. the headline call-order test: translate never ran in the loop). Full suite **111 files / 874 tests green**; typecheck, oxlint, **oxfmt format:check** (verified again on the PR branch), vite production build, legacy node tests 41/41 all pass.

Base: built on #956's branch; cherry-picked clean onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added multi-language dub generation that translates each selected language first, then generates dubs sequentially per language.
- Added progress/CTA state for translation, including disabled generate behavior while translating.
- Fixed stale segment state by snapshotting `dubSegments` at call time for translation and generation.
- Persisted `multiLangMode`, `multiLangs`, and `exportTracks` with project save/load, with safe legacy defaults.
- Added tests covering multi-language generation order, skip-on-translation-failure behavior, override translation targets, and persistence.

## Behavior flow
```mermaid
flowchart TD
  A[Click Generate] --> B{Multi-language mode?}
  B -- No --> C[Generate current language]
  B -- Yes --> D[For each selected language]
  D --> E[Translate language]
  E --> F{Translation succeeded?}
  F -- No --> G[Skip language, record failure, continue]
  F -- Yes --> H[Generate audio for that language]
  G --> D
  H --> D
  D --> I[Show skipped-language toast if needed]
```

## UI sketch
```text
Before:
[ Generate ]
(single CTA, enabled whenever segments exist)

After:
[ Translating... (n/m) ]
[ Generate ]  (disabled while translating)
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->