### PR TITLE
feat(dub): per-language translations + per-track caches — switching languages stops destroying work (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Added
 
 - **"Generate N dubs" now actually translates each language first.** Multi-language generation used to synthesize every track from whatever text was in the editor — so at most one of your N dubs was really in its language. The batch now runs translate → generate per language with a visible "Translating → Bengali (2/3)…" phase, skips (and reports) any language whose translation fails instead of rendering a wrong-language track, and your multi-language picks and export-track selection are saved with the project instead of vanishing on tab switch. (#957)
+- **Switching dub languages no longer destroys your work — every track keeps its own text and audio.** Translations are now stored per language (switching the target swaps the editor text non-destructively; manual edits stay with their language), subtitles export each track's own text instead of N identical files, burned-in subs match their track, and the per-segment audio cache is keyed by language — "Regen changed" can no longer splice another language's audio into the track you're rebuilding, and staleness is tracked per track. Fully backward-compatible: existing projects and caches keep working; a pre-upgrade project's first "Regen changed" simply regenerates cleanly once. (#958)
 
 ### Fixed
 

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -170,8 +170,42 @@ async def dub_list_tracks(job_id: str):
     return {"tracks": job.get("dubbed_tracks", {})}
 
 
+def _segments_for_lang(job: dict, lang: "str | None") -> list:
+    """Job segments with `text` overlaid from ``job["segments_i18n"][lang]``.
+
+    P1.2 — ``job["segments"]`` is single-slot: it holds whichever language was
+    generated LAST, so exporting subtitles for track A after generating track B
+    emitted B's text under A's language label (the "N identical subtitle
+    files" class). ``segments_i18n`` ({lang: {segKey: text}}, written by
+    ``dub_generate._sync_job_segments``) preserves each generated track's text;
+    this overlays it non-destructively when present.
+
+    Back-compat: no lang requested, no ``segments_i18n`` on the job (predates
+    the field), no entry for this lang, or no text for a given segment — each
+    falls back to the segment as-is, i.e. exactly today's behaviour.
+    Segment keys are the stable id (str) with the list index (str) as the
+    legacy fallback, mirroring how the map is written.
+    """
+    segments = job.get("segments", [])
+    if not lang:
+        return segments
+    i18n = job.get("segments_i18n")
+    lang_texts = i18n.get(lang) if isinstance(i18n, dict) else None
+    if not isinstance(lang_texts, dict) or not lang_texts:
+        return segments
+    out = []
+    for i, seg in enumerate(segments):
+        key = str(seg.get("id")) if seg.get("id") is not None else str(i)
+        txt = lang_texts.get(key)
+        if txt is None:
+            txt = lang_texts.get(str(i))
+        out.append(dict(seg, text=txt) if isinstance(txt, str) and txt.strip() else seg)
+    return out
+
+
 def _write_burn_srt(job: dict, exports_dir: str, stamp: str, dual: bool,
-                    fitted_segments: "list[dict] | None" = None) -> str | None:
+                    fitted_segments: "list[dict] | None" = None,
+                    lang: "str | None" = None) -> str | None:
     """Build a temp SRT from job segments for use with ffmpeg's subtitles filter.
 
     Returned path is already ffmpeg-filter-safe (plain ASCII basename under exports_dir).
@@ -181,8 +215,11 @@ def _write_burn_srt(job: dict, exports_dir: str, stamp: str, dual: bool,
     fitted timeline — when provided, cue times come from there instead of
     the original ``job["segments"]`` timings, so burned subs track the
     retimed video / fitted audio rather than the source timeline.
+
+    ``lang`` (P1.2): burn the named track's text (see ``_segments_for_lang``)
+    instead of whatever language generated last.
     """
-    segments = job.get("segments", [])
+    segments = _segments_for_lang(job, lang)
     if not segments:
         return None
     if fitted_segments:
@@ -486,7 +523,9 @@ async def dub_download(
     # Smart Fit: cue times come from the fitted timeline — that's where the
     # dubbed audio actually sits, whether or not the video retime succeeds.
     fitted_segments = _fitted_segments_for(job, default_track) if default_track and default_track != "original" else None
-    sub_path = _write_burn_srt(job, exports_dir, stamp, dual, fitted_segments=fitted_segments) if burn_subs else None
+    # Burn the DEFAULT track's text (P1.2) — it's the audio the viewer hears.
+    _burn_lang = default_track if default_track and default_track != "original" else None
+    sub_path = _write_burn_srt(job, exports_dir, stamp, dual, fitted_segments=fitted_segments, lang=_burn_lang) if burn_subs else None
 
     # ── Smart Fit video retime (two-tier) ─────────────────────────────────
     # Tier 1 (≤48 chunks): single filter_complex graph inlined into the mux
@@ -1125,20 +1164,40 @@ async def dub_get_audio(job_id: str):
         raise HTTPException(status_code=404, detail="Audio file not found")
     return FileResponse(audio, media_type="audio/wav")
 
+def _seg_wav_candidates(job: dict, lang: "str | None", seg_keys: tuple) -> list:
+    """Per-segment WAV name candidates, language-keyed first (P1.3).
+
+    Generation writes ``seg_{lang}_{id}.wav`` now; ``lang`` defaults to the
+    job's last-generated track. Legacy un-keyed names (``seg_{id}.wav`` /
+    ``seg_{index}.wav``) stay as fallbacks so jobs rendered by previous
+    builds keep serving their audio — these read-only endpoints keep the
+    permissive fallback that matches their historic behaviour (the strict
+    single-track gate lives on the generate splice path, where a wrong-
+    language read would be baked into a track).
+    """
+    lang = lang or job.get("language_code")
+    keys = []
+    if lang:
+        keys.extend(f"{lang}_{k}" for k in seg_keys)
+    keys.extend(seg_keys)
+    return keys
+
+
 @router.get("/dub/preview/{job_id}/{segment_index}")
-async def dub_preview_segment(job_id: str, segment_index: int):
+async def dub_preview_segment(job_id: str, segment_index: int, lang: str = Query(None)):
     job = _get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    # Resolve the stable-id-named WAV via the render manifest; fall back to the
-    # legacy index name for jobs rendered before id-based naming (#185). Each
-    # candidate is realpath-normalised and containment-checked BEFORE any
-    # filesystem access, so the guard dominates every path sink.
+    # Resolve the stable-id-named WAV via the render manifest — language-keyed
+    # name first (P1.3), then the legacy id/index names for jobs rendered
+    # before per-language (and before id-based, #185) naming. Each candidate
+    # is realpath-normalised and containment-checked BEFORE any filesystem
+    # access, so the guard dominates every path sink.
     order = job.get("seg_order") or []
     seg_id = order[segment_index] if 0 <= segment_index < len(order) else segment_index
     base = os.path.realpath(DUB_DIR)
     seg_path = None
-    for _sid in (seg_id, segment_index):
+    for _sid in _seg_wav_candidates(job, lang, (seg_id, segment_index)):
         cand = os.path.realpath(dub_seg_path(job_id, _sid))
         if cand.startswith(base + os.sep) and os.path.exists(cand):
             seg_path = cand
@@ -1342,13 +1401,16 @@ def _fitted_cue_times(job: dict, lang: str | None) -> list | None:
 async def dub_export_srt(
     job_id: str,
     dual: bool = False,
-    lang: str = Query(None, description="Track language code. When that track was generated under Smart Fit or stretch_video, cue times come from the fitted timeline."),
+    lang: str = Query(None, description="Track language code. Emits that track's text (segments_i18n) when the job carries it; when that track was generated under Smart Fit or stretch_video, cue times come from the fitted timeline."),
 ):
     job = _get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    segments = job.get("segments", [])
+    # P1.2 — text follows the REQUESTED track, not whichever language was
+    # generated last (job["segments"] is single-slot). Legacy jobs without
+    # segments_i18n fall back to today's behaviour.
+    segments = _segments_for_lang(job, lang)
     if not segments:
         raise HTTPException(status_code=400, detail="No transcript segments available")
 
@@ -1391,13 +1453,14 @@ def _format_vtt_time(seconds):
 async def dub_export_vtt(
     job_id: str,
     dual: bool = False,
-    lang: str = Query(None, description="Track language code. When that track was generated under Smart Fit or stretch_video, cue times come from the fitted timeline."),
+    lang: str = Query(None, description="Track language code. Emits that track's text (segments_i18n) when the job carries it; when that track was generated under Smart Fit or stretch_video, cue times come from the fitted timeline."),
 ):
     job = _get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    segments = job.get("segments", [])
+    # Same per-track text resolution as /dub/srt (see comment there, P1.2).
+    segments = _segments_for_lang(job, lang)
     if not segments:
         raise HTTPException(status_code=400, detail="No transcript segments available")
 
@@ -1427,7 +1490,7 @@ async def dub_export_vtt(
 
 
 @router.get("/dub/export-segments/{job_id}")
-async def dub_export_segments_zip(job_id: str):
+async def dub_export_segments_zip(job_id: str, lang: str = Query(None)):
     import zipfile
     job = _get_job(job_id)
     if not job:
@@ -1445,7 +1508,7 @@ async def dub_export_segments_zip(job_id: str):
             seg_id = order[i] if i < len(order) else i
             # realpath + containment guard before any filesystem access.
             seg_path = None
-            for _sid in (seg_id, i):
+            for _sid in _seg_wav_candidates(job, lang, (seg_id, i)):
                 cand = os.path.realpath(dub_seg_path(job_id, _sid))
                 if cand.startswith(base + os.sep) and os.path.exists(cand):
                     seg_path = cand

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -87,6 +87,62 @@ def _sync_job_segments(job: dict, req: DubRequest) -> None:
         merged.append(row)
     job["segments"] = merged
 
+    # P1.2 — per-language text, additively. `job["segments"]` stays the flat
+    # single-slot map every existing consumer reads (last generated language);
+    # `job["segments_i18n"]` preserves EACH generated track's text so
+    # /dub/srt|vtt?lang= can emit that language instead of N identical files.
+    # Shape: { langCode: { segKey: text } } where segKey is the segment's
+    # stable id (str) or, for id-less legacy segments, its list index (str).
+    # The whole per-language map is rebuilt on every generate of that language
+    # (the request always carries the full segment list), so deleted segments
+    # never linger. Jobs predating this field simply lack it — every reader
+    # falls back to `job["segments"]`.
+    lang = (req.language_code or "und").strip() or "und"
+    i18n = job.setdefault("segments_i18n", {})
+    i18n[lang] = {
+        (str(row["id"]) if row.get("id") is not None else str(i)): row["text"]
+        for i, row in enumerate(merged)
+    }
+
+
+def _seg_hashes_by_lang(job: dict) -> dict:
+    """Per-language segment fingerprints: { langCode: { segId: hash } }.
+
+    Additive migration (P1.3): jobs written by previous builds carry ONE flat
+    `seg_hashes` map that was overwritten by whichever language generated
+    last. That flat map can only describe the job's last-generated track, so
+    it is attributed to `job["language_code"]` (which generate has always
+    kept in lock-step with the last run). When even that is unknown the
+    legacy hashes are dropped — segments then read as stale and regenerate
+    cleanly, which is safer than guessing a language and splicing wrong-track
+    audio. Note the legacy hashes also predate language-scoped fingerprints
+    (see services.incremental.segment_fingerprint), so they compare stale
+    once regardless — carrying them over just preserves the job shape.
+    """
+    by_lang = job.get("seg_hashes_by_lang")
+    if not isinstance(by_lang, dict):
+        by_lang = {}
+        legacy = job.get("seg_hashes")
+        prev_lang = job.get("language_code")
+        if isinstance(legacy, dict) and legacy and prev_lang:
+            by_lang[prev_lang] = dict(legacy)
+        job["seg_hashes_by_lang"] = by_lang
+    return by_lang
+
+
+def _legacy_seg_cache_ok(job: dict, lang_code: str) -> bool:
+    """May this run reuse legacy un-keyed ``seg_<id>.wav`` files?
+
+    Only when no OTHER language's audio could be sitting in them: the job has
+    no dubbed track in a different language. Single-language jobs rendered by
+    previous builds therefore keep their whole on-disk cache; the moment a
+    job carries a second language the un-keyed files are ambiguous (they hold
+    whichever language wrote them last) and must never be spliced into a
+    track again — the P1.3 cross-contamination class.
+    """
+    tracks = job.get("dubbed_tracks") or {}
+    return not any(lc != lang_code for lc in tracks)
+
 
 router = APIRouter()
 
@@ -106,6 +162,18 @@ async def dub_generate(job_id: str, req: DubRequest):
         total = len(req.segments)
         all_segment_wavs = []
         sync_scores = []
+
+        # Track language for this run. Everything per-track — the per-segment
+        # WAV cache, fingerprints, seg_wav_kind — is keyed by it (P1.3) so a
+        # multi-language job's tracks can't cross-contaminate.
+        lang_code = req.language_code or "und"
+
+        def _seg_lang_path(seg_key) -> str:
+            # Per-language per-segment WAV: seg_{lang}_{id}.wav. Built through
+            # dub_seg_path so the sanitisation + DUB_DIR containment guard
+            # apply to the combined key. Legacy un-keyed seg_{id}.wav files
+            # remain readable via the gated fallback (_legacy_seg_cache_ok).
+            return dub_seg_path(job_id, f"{lang_code}_{seg_key}")
 
         # Throttle the device cache flush. empty_cache() is a synchronous
         # device stall, so calling it every segment (as the old code did)
@@ -236,7 +304,16 @@ async def dub_generate(job_id: str, req: DubRequest):
         # double-compress. Force one full regen; afterwards seg_wav_kind is
         # "natural" and partial regen / fit-only re-mix (regen_only=[]) work.
         # Jobs predating this field have unknown kind → also regen once.
-        if strategy == "smart_fit" and regen_only is not None and job.get("seg_wav_kind") != "natural":
+        # P1.3: the kind is per-track now (each language renders under its own
+        # strategy); the flat job["seg_wav_kind"] is only consulted for jobs
+        # written before the per-language map existed — once the map is
+        # present, a language without an entry has unknown-kind WAVs (or none
+        # at all) and must regen once, exactly like the pre-field case.
+        _kind_map = job.get("seg_wav_kind_by_lang")
+        _wav_kind = (
+            _kind_map.get(lang_code) if isinstance(_kind_map, dict) else job.get("seg_wav_kind")
+        )
+        if strategy == "smart_fit" and regen_only is not None and _wav_kind != "natural":
             regen_only = None
         # Manifest: stable segment id per current index. Per-segment WAVs are
         # named by stable id (dub_seg_path) so regen reuses the right audio after
@@ -283,12 +360,19 @@ async def dub_generate(job_id: str, req: DubRequest):
             # Partial regen: if this segment isn't in the allow-list, reuse its
             # previously-rendered WAV so the final mix still covers the timeline.
             if regen_only is not None and seg_id not in regen_only:
-                seg_wav_path = dub_seg_path(job_id, seg_id)
-                if not os.path.exists(seg_wav_path):
-                    # Back-compat: jobs rendered before id-named files used seg_{index}.wav.
-                    _legacy = dub_seg_path(job_id, i)
-                    if os.path.exists(_legacy):
-                        seg_wav_path = _legacy
+                # This track's own cache first (seg_{lang}_{id}.wav). Legacy
+                # un-keyed files (seg_{id}.wav / seg_{index}.wav) are reused
+                # ONLY when no other-language track exists on the job — a
+                # multi-track job's un-keyed files hold whichever language
+                # rendered last, and splicing them here was exactly how
+                # "Regen N changed" mixed language B into track A (P1.3).
+                seg_wav_path = _seg_lang_path(seg_id)
+                if not os.path.exists(seg_wav_path) and _legacy_seg_cache_ok(job, lang_code):
+                    for _legacy_key in (seg_id, i):
+                        _legacy = dub_seg_path(job_id, _legacy_key)
+                        if os.path.exists(_legacy):
+                            seg_wav_path = _legacy
+                            break
                 if os.path.exists(seg_wav_path):
                     try:
                         _t_cache_0 = time.perf_counter()
@@ -584,6 +668,9 @@ async def dub_generate(job_id: str, req: DubRequest):
                 # and job flush to the batch-write phase after the GPU loop.
                 _seg_fp = None
                 try:
+                    # track_lang scopes the hash to THIS track (P1.3); the
+                    # client-side recompute (/tools/incremental) sends the
+                    # same code, so parity (#281 class) holds per language.
                     _seg_fp = segment_fingerprint({
                         "text": seg.text,
                         "target_lang": getattr(seg, "target_lang", None),
@@ -592,7 +679,7 @@ async def dub_generate(job_id: str, req: DubRequest):
                         "speed": getattr(seg, "speed", None),
                         "direction": getattr(seg, "direction", None),
                         "effect_preset": getattr(seg, "effect_preset", None),
-                    })
+                    }, track_lang=lang_code)
                 except Exception as e:
                     logger.debug("seg fingerprint skipped for %s: %s", seg_id, e)
 
@@ -601,7 +688,7 @@ async def dub_generate(job_id: str, req: DubRequest):
                 # RVC needs the WAV on disk, so write it immediately only
                 # when RVC is active (uncommon path).
                 if rvc_is_enabled():
-                    seg_wav_path = dub_seg_path(job_id, seg_id)
+                    seg_wav_path = _seg_lang_path(seg_id)
                     atomic_save_wav(seg_wav_path, audio_tensor, _model.sampling_rate)
                     try:
                         await loop.run_in_executor(_gpu_pool, apply_rvc, seg_wav_path)
@@ -619,15 +706,16 @@ async def dub_generate(job_id: str, req: DubRequest):
                         yield f"data: {json.dumps({'type': 'warning', 'segment': i, 'message': f'RVC skipped: {str(e)[:120]}'})}\n\n"
 
                 # Watermark this FRESH TTS output exactly once, right before it
-                # is persisted. The same seg_<id>.wav is BOTH the downloadable
-                # per-segment file AND the assembly input for the final track,
-                # so marking it here (and nowhere else) gives the downloadable
-                # WAV its mark back and the final mix inherits it — no double-
-                # mark. Cached-reuse audio is already marked; silence/zero slots
-                # carry no speech to mark, so neither is re-watermarked.
+                # is persisted. The same seg_{lang}_{id}.wav is BOTH the
+                # downloadable per-segment file AND the assembly input for the
+                # final track, so marking it here (and nowhere else) gives the
+                # downloadable WAV its mark back and the final mix inherits it —
+                # no double-mark. Cached-reuse audio is already marked;
+                # silence/zero slots carry no speech to mark, so neither is
+                # re-watermarked.
                 audio_tensor = embed_watermark(audio_tensor, _model.sampling_rate)
 
-                seg_wav_path = dub_seg_path(job_id, seg_id)
+                seg_wav_path = _seg_lang_path(seg_id)
                 try:
                     # Keep the existing per-segment WAV contract for previews
                     # and partial regeneration, but do not keep the tensor in RAM.
@@ -663,12 +751,19 @@ async def dub_generate(job_id: str, req: DubRequest):
         # Per-segment WAVs were written during the loop to keep RAM bounded.
         # Flush only lightweight fingerprints/quality metadata here.
         _t_diskw_0 = time.perf_counter()
-        hashes = job.setdefault("seg_hashes", {})
+        # P1.3 — fingerprints live per language so each track's staleness is
+        # judged against ITS OWN last generate. The flat job["seg_hashes"] is
+        # kept as a mirror of the CURRENT track's map: every existing consumer
+        # (the `done` event, dub-history restore, older frontends) already
+        # treats it as "the hashes of the language generated last", which is
+        # exactly what it now provably contains.
+        hashes = _seg_hashes_by_lang(job).setdefault(lang_code, {})
         quality_map = job.setdefault("seg_num_step", {})
         for (_si, _sr, _sid, _fp, _nstep) in _pending_seg_writes:
             if _fp is not None:
                 hashes[_sid] = _fp
             quality_map[_sid] = _nstep
+        job["seg_hashes"] = dict(hashes)
         # Single job flush instead of one per 8 segments.
         _save_job(job_id, job)
         _t_diskw = time.perf_counter() - _t_diskw_0
@@ -759,7 +854,6 @@ async def dub_generate(job_id: str, req: DubRequest):
         # not from the plan — so subtitles land exactly on the audio.
         fitted_cues: list[dict] = []
 
-        lang_code = req.language_code or "und"
         track_path = os.path.join(DUB_DIR, job_id, f"dubbed_{lang_code}.wav")
         os.makedirs(os.path.dirname(track_path), exist_ok=True)
 
@@ -1049,8 +1143,12 @@ async def dub_generate(job_id: str, req: DubRequest):
             job["dubbed_tracks"][lang_code]["fit_fp"] = fit_fp
         # Record what kind of per-segment WAVs are on disk so a later
         # smart_fit run knows whether partial regen / fit-only re-mix can
-        # reuse them ("natural") or must regen once ("slotted").
-        job["seg_wav_kind"] = "slotted" if strategy == "strict_slot" else "natural"
+        # reuse them ("natural") or must regen once ("slotted"). Per-track
+        # (P1.3) — each language renders under its own strategy; the flat
+        # field stays in lock-step for older readers.
+        _kind = "slotted" if strategy == "strict_slot" else "natural"
+        job.setdefault("seg_wav_kind_by_lang", {})[lang_code] = _kind
+        job["seg_wav_kind"] = _kind
         _save_job(job_id, job)
 
         _t_total = time.perf_counter() - _t_start

--- a/backend/api/routers/tools.py
+++ b/backend/api/routers/tools.py
@@ -77,6 +77,10 @@ async def probe(req: ProbeReq):
 class IncrementalReq(BaseModel):
     segments: list[dict]
     stored_hashes: Optional[dict[str, str]] = None
+    # P1.3 — the ACTIVE track's language code. When set, fingerprints are
+    # scoped to that language (pass that language's stored hashes alongside);
+    # omitted → legacy language-agnostic hashing, kept for old callers.
+    lang: Optional[str] = None
 
 
 @router.post("/tools/incremental")
@@ -84,6 +88,7 @@ def plan_incremental(req: IncrementalReq):
     return incremental.plan_incremental(
         req.segments,
         stored_hashes=req.stored_hashes or {},
+        track_lang=req.lang,
     )
 
 

--- a/backend/services/incremental.py
+++ b/backend/services/incremental.py
@@ -49,7 +49,7 @@ def _canon_value(field: str, value):
     return value
 
 
-def segment_fingerprint(seg: dict) -> str:
+def segment_fingerprint(seg: dict, track_lang: str | None = None) -> str:
     """Deterministic hash of the inputs that actually affect TTS output.
 
     Any change to `_GEN_INPUT_FIELDS` flips the hash and the segment becomes
@@ -61,8 +61,20 @@ def segment_fingerprint(seg: dict) -> str:
     so a fingerprint computed from the generate request (server defaults
     filled in) matches one recomputed later from the client's raw segment
     state — the root cause of #281's "1 edit re-dubs all N lines".
+
+    ``track_lang`` (P1.3) is the TRACK's language code (`req.language_code`,
+    e.g. "es"). It is part of the fingerprint because the same segment text
+    renders different audio per language — without it, a bn hash could
+    vouch for an es WAV on a multi-track job. It is only mixed in when
+    provided, so hashes computed by legacy callers (and hashes stored by
+    previous builds, which never carried a language) keep their old values;
+    a legacy hash therefore never matches a lang-scoped fingerprint and the
+    segment reads as stale — the safe direction (one clean regen, never a
+    wrong-language splice).
     """
     payload = {k: _canon_value(k, seg.get(k)) for k in _GEN_INPUT_FIELDS}
+    if track_lang:
+        payload["track_lang"] = str(track_lang)
     blob = json.dumps(payload, sort_keys=True, ensure_ascii=False)
     return hashlib.sha1(blob.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
 
@@ -120,6 +132,7 @@ def plan_incremental(
     segments: list[dict],
     *,
     stored_hashes: dict[str, str] | None = None,
+    track_lang: str | None = None,
 ) -> dict:
     """Return `{stale, fresh, total, fingerprints}` where:
 
@@ -133,6 +146,13 @@ def plan_incremental(
     `stored_hashes` may come from the caller's own bookkeeping (e.g. the
     `dub_history.job_data["seg_hashes"]` we'll start writing in Phase 4.5).
     When missing, every segment is considered stale (first run).
+
+    `track_lang` (P1.3) scopes the plan to ONE dub track: pass the track's
+    language code together with THAT language's stored hashes
+    (`job_data["seg_hashes_by_lang"][lang]`) so staleness is judged against
+    the active track, never against whatever language was generated last.
+    Must match the language the generate run hashed with, or every segment
+    reads stale (#281 parity class).
     """
     stored = stored_hashes or {}
     stale: list[str] = []
@@ -142,7 +162,7 @@ def plan_incremental(
         sid = str(seg.get("id", ""))
         if not sid:
             continue
-        fp = segment_fingerprint(seg)
+        fp = segment_fingerprint(seg, track_lang=track_lang)
         fingerprints[sid] = fp
         prev = stored.get(sid)
         if prev == fp:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -457,6 +457,8 @@ function App() {
     closeDirection,
     saveDirection,
     setLastGenFingerprints,
+    fingerprintsByLang,
+    setFingerprintsByLang,
     incrementalPlan,
     recomputeIncremental,
   } = useSegmentEditing();
@@ -965,6 +967,11 @@ function App() {
         multiLangMode,
         multiLangs,
         exportTracks,
+        // P1.3 — per-language segment fingerprints, so reopening a project
+        // keeps every track's "Regen N changed" plan. Additive: legacy
+        // loaders ignore the key; segments' `translations` maps ride along
+        // inside dubSegments above.
+        segHashesByLang: fingerprintsByLang,
       },
     };
     try {
@@ -1006,8 +1013,17 @@ function App() {
       setDubStep(s.dubStep === 'done' ? 'done' : s.dubSegments?.length ? 'editing' : 'idle');
       // Phase 4.5 — rehydrate per-segment fingerprints. The incremental plan
       // immediately shows "N segments changed" for any segments edited after
-      // the last generate.
-      setLastGenFingerprints(s.segHashes || {});
+      // the last generate. P1.3: prefer the per-language map; a legacy flat
+      // `segHashes` can only describe the project's saved target language.
+      if (
+        s.segHashesByLang &&
+        typeof s.segHashesByLang === 'object' &&
+        !Array.isArray(s.segHashesByLang)
+      ) {
+        setFingerprintsByLang(s.segHashesByLang);
+      } else {
+        setLastGenFingerprints(s.segHashes || {}, s.dubLangCode || 'en');
+      }
       setSpeakerClones(s.speakerClones || {});
       // P1.4 — restore multi-lang picks; legacy payloads default to off/empty
       // and leave the in-session exportTracks untouched (null sentinel).
@@ -1074,8 +1090,21 @@ function App() {
       setDubStep(Object.keys(job.dubbed_tracks || {}).length > 0 ? 'done' : 'editing');
       // Phase 4.5 — seg_hashes are written per successful segment by
       // dub_generate.py. Reloading a half-generated dub lets the "Regen N
-      // changed" button resume right where the crash happened.
-      setLastGenFingerprints(job.seg_hashes || {});
+      // changed" button resume right where the crash happened. P1.3: prefer
+      // the per-language map (multi-track jobs); a legacy flat map belongs to
+      // the job's last-generated language — the code restored just above.
+      if (
+        job.seg_hashes_by_lang &&
+        typeof job.seg_hashes_by_lang === 'object' &&
+        !Array.isArray(job.seg_hashes_by_lang)
+      ) {
+        setFingerprintsByLang(job.seg_hashes_by_lang);
+      } else {
+        setLastGenFingerprints(
+          job.seg_hashes || {},
+          item.language_code || job.language_code || 'und',
+        );
+      }
       // Rehydrate the auto-extracted speaker clones so the CAST dropdown's
       // "🎤 From video" option reappears after a reload. Projects that
       // predate the speaker-clone feature have an empty map; the Extract

--- a/frontend/src/components/ExportModal.jsx
+++ b/frontend/src/components/ExportModal.jsx
@@ -259,7 +259,11 @@ export default function ExportModal({
     onClose?.();
   };
   const runClips = () => {
-    handleAudioExport?.(`${API}/dub/export-segments/${jobId}`, 'segments.zip');
+    // Ask for the ACTIVE track's per-segment clips (P1.3 — the cache is
+    // language-keyed now); omitted lang falls back to the last-generated
+    // track server-side, which is all a legacy single-track job has.
+    const langQ = dubLangCode ? `?lang=${encodeURIComponent(dubLangCode)}` : '';
+    handleAudioExport?.(`${API}/dub/export-segments/${jobId}${langQ}`, 'segments.zip');
     onClose?.();
   };
 

--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -739,9 +739,15 @@ export default function useDubWorkflow({
           prev.map((s) => {
             const hit = translatedMap[s.id];
             if (!hit) return s;
+            const gotText = !!(hit.text && hit.text.trim());
             return {
               ...s,
-              text: hit.text && hit.text.trim() ? hit.text : s.text,
+              text: gotText ? hit.text : s.text,
+              // P1.2 — keep every language's translation, keyed by target.
+              // `text` stays the currently-shown language (legacy single-slot
+              // contract); switching the target language swaps from this map
+              // instead of destroying the previous language's work.
+              ...(gotText ? { translations: { ...s.translations, [targetLang]: hit.text } } : {}),
               translate_error: hit.error || undefined,
               translate_literal: hit.literal || undefined,
               translate_critique: hit.critique || undefined,
@@ -916,8 +922,12 @@ export default function useDubWorkflow({
                       .map(([id]) => id);
                     setPreviewSegIds(previewIds);
                   }
+                  // P1.3 — hashes belong to the track that just generated
+                  // (the event carries its language), not to whatever the
+                  // store's selection is when the stream drains.
+                  const genLang = evt.language_code || body.language_code;
                   if (evt.seg_hashes && Object.keys(evt.seg_hashes).length > 0) {
-                    setLastGenFingerprints(evt.seg_hashes);
+                    setLastGenFingerprints(evt.seg_hashes, genLang);
                   } else {
                     try {
                       const plan = await apiPost('/tools/incremental', {
@@ -925,8 +935,9 @@ export default function useDubWorkflow({
                           id: String(s.id),
                           ...segmentGenInputs(s),
                         })),
+                        lang: genLang,
                       });
-                      setLastGenFingerprints(plan.fingerprints || {});
+                      setLastGenFingerprints(plan.fingerprints || {}, genLang);
                     } catch (err) {
                       console.warn('Incremental plan fallback failed:', err);
                     }

--- a/frontend/src/hooks/useSegmentEditing.js
+++ b/frontend/src/hooks/useSegmentEditing.js
@@ -11,6 +11,10 @@ import { apiPost } from '../api/client';
 import { segmentGenInputs } from '../utils/segments';
 import { commitMoveResize } from '../utils/timeline';
 
+// Stable empty map so `lastGenFingerprints` keeps a constant identity for a
+// language with no stored hashes (avoids effect/callback churn).
+const EMPTY_FINGERPRINTS = {};
+
 export default function useSegmentEditing() {
   const dubSegments = useAppStore((s) => s.dubSegments);
   const setDubSegments = useAppStore((s) => s.setDubSegments);
@@ -50,7 +54,20 @@ export default function useSegmentEditing() {
   const segmentEditField = useCallback(
     (id, field, value) => {
       pushUndo(dubSegments);
-      setDubSegments((prev) => prev.map((s) => (s.id === id ? { ...s, [field]: value } : s)));
+      // P1.2 — a manual text edit is a translation edit for the CURRENT
+      // target language: keep `translations[lang]` in lock-step with `text`
+      // so switching languages and back never loses the edit.
+      const lang = useAppStore.getState().dubLangCode;
+      setDubSegments((prev) =>
+        prev.map((s) => {
+          if (s.id !== id) return s;
+          const next = { ...s, [field]: value };
+          if (field === 'text' && lang) {
+            next.translations = { ...s.translations, [lang]: value };
+          }
+          return next;
+        }),
+      );
     },
     [dubSegments],
   );
@@ -87,10 +104,22 @@ export default function useSegmentEditing() {
   const segmentRestoreOriginal = useCallback(
     (id) => {
       pushUndo(dubSegments);
+      // "Use the original text for this row" is a per-language decision like
+      // any other text edit — record it under the current language so a
+      // round-trip through another language doesn't resurrect the discarded
+      // translation (P1.2).
+      const lang = useAppStore.getState().dubLangCode;
       setDubSegments((prev) =>
-        prev.map((s) =>
-          s.id === id ? { ...s, text: s.text_original || s.text, translate_error: undefined } : s,
-        ),
+        prev.map((s) => {
+          if (s.id !== id) return s;
+          const restored = s.text_original || s.text;
+          return {
+            ...s,
+            text: restored,
+            ...(lang ? { translations: { ...s.translations, [lang]: restored } } : {}),
+            translate_error: undefined,
+          };
+        }),
       );
     },
     [dubSegments],
@@ -164,12 +193,16 @@ export default function useSegmentEditing() {
         const pos = Math.max(1, Math.min(cursorPos, text.length - 1));
         const ratio = text.length > 0 ? pos / text.length : 0.5;
         const midT = seg.start + (seg.end - seg.start) * ratio;
+        // Other languages' saved texts (P1.2) can't be split at a sensible
+        // position for the halves — drop them; the halves are new segment ids
+        // that need fresh TTS per language anyway.
         const left = {
           ...seg,
           id: `${seg.id}_a`,
           text: text.slice(0, pos).trim(),
           end: midT,
           text_original: text.slice(0, pos).trim(),
+          translations: undefined,
         };
         const right = {
           ...seg,
@@ -177,6 +210,7 @@ export default function useSegmentEditing() {
           text: text.slice(pos).trim(),
           start: midT,
           text_original: text.slice(pos).trim(),
+          translations: undefined,
         };
         return [...prev.slice(0, idx), left, right, ...prev.slice(idx + 1)];
       });
@@ -193,12 +227,24 @@ export default function useSegmentEditing() {
         if (idx < 0 || idx >= prev.length - 1) return prev;
         const a = prev[idx];
         const b = prev[idx + 1];
+        // Merge per-language texts (P1.2) only where BOTH sides carry the
+        // language — a half-known language would otherwise mix two languages
+        // in one entry. Missing entries just mean "translate again".
+        const ta = a.translations || {};
+        const tb = b.translations || {};
+        const mergedTranslations = {};
+        for (const lang of Object.keys(ta)) {
+          if (typeof ta[lang] === 'string' && typeof tb[lang] === 'string') {
+            mergedTranslations[lang] = `${ta[lang]} ${tb[lang]}`.trim();
+          }
+        }
         const merged = {
           ...a,
           text: `${a.text || ''} ${b.text || ''}`.trim(),
           text_original:
             `${a.text_original || a.text || ''} ${b.text_original || b.text || ''}`.trim(),
           end: b.end,
+          translations: Object.keys(mergedTranslations).length ? mergedTranslations : undefined,
         };
         return [...prev.slice(0, idx), merged, ...prev.slice(idx + 2)];
       });
@@ -221,8 +267,25 @@ export default function useSegmentEditing() {
     [directionSegId, dubSegments],
   );
 
-  // Incremental plan — tracks which segments changed since last generate
-  const [lastGenFingerprints, setLastGenFingerprints] = useState({});
+  // Incremental plan — tracks which segments changed since last generate.
+  // P1.3: fingerprints are stored PER LANGUAGE ({ lang: { segId: hash } }),
+  // and `lastGenFingerprints` is the ACTIVE language's map — so "Regen N
+  // changed" is judged against the track you're looking at, never against
+  // whichever language happened to generate last. Switching to a language
+  // that was never generated yields an empty map → no plan (no false
+  // "all fresh" / "all stale" claims).
+  const dubLangCode = useAppStore((s) => s.dubLangCode);
+  const [fingerprintsByLang, setFingerprintsByLang] = useState({});
+  const lastGenFingerprints = fingerprintsByLang[dubLangCode] || EMPTY_FINGERPRINTS;
+  // Same call signature as before for existing single-track callers; the
+  // optional `lang` pins the map to the track that produced the hashes
+  // (e.g. each pick of the multi-language batch loop) instead of whatever
+  // the store's selection is by the time the response lands.
+  const setLastGenFingerprints = useCallback((map, lang) => {
+    const key = lang || useAppStore.getState().dubLangCode;
+    if (!key) return;
+    setFingerprintsByLang((prev) => ({ ...prev, [key]: map || {} }));
+  }, []);
   const [incrementalPlan, setIncrementalPlan] = useState(null);
 
   const recomputeIncremental = useCallback(async () => {
@@ -232,16 +295,19 @@ export default function useSegmentEditing() {
     }
     try {
       // Same payload shape as the generate request (utils/segments.js) so
-      // stored fingerprints actually match unchanged segments (#281).
+      // stored fingerprints actually match unchanged segments (#281). `lang`
+      // must match the language the generate run hashed with — it's part of
+      // the fingerprint now (P1.3).
       const res = await apiPost('/tools/incremental', {
         segments: dubSegments.map((s) => ({ id: String(s.id), ...segmentGenInputs(s) })),
         stored_hashes: lastGenFingerprints,
+        lang: dubLangCode,
       });
       setIncrementalPlan({ stale: res.stale, fresh: res.fresh });
     } catch (e) {
       console.warn('incremental plan failed', e);
     }
-  }, [dubSegments, lastGenFingerprints]);
+  }, [dubSegments, lastGenFingerprints, dubLangCode]);
 
   return {
     // Undo/Redo
@@ -275,6 +341,10 @@ export default function useSegmentEditing() {
     // Incremental plan
     lastGenFingerprints,
     setLastGenFingerprints,
+    // Per-language fingerprint store (P1.3) — for project save/load and dub
+    // history restore, which persist/rehydrate ALL tracks' hashes at once.
+    fingerprintsByLang,
+    setFingerprintsByLang,
     incrementalPlan,
     setIncrementalPlan,
     recomputeIncremental,

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -84,7 +84,12 @@ export default function DubTab(props) {
   const dubLang = useAppStore((s) => s.dubLang);
   const setDubLang = useAppStore((s) => s.setDubLang);
   const dubLangCode = useAppStore((s) => s.dubLangCode);
-  const setDubLangCode = useAppStore((s) => s.setDubLangCode);
+  // User-driven language switches go through switchDubLangCode (P1.2): it
+  // swaps segment text through the per-language `translations` map instead
+  // of leaving the previous language's text on screen (and previously,
+  // letting the next translate destroy it). Non-user rehydration paths
+  // (project load, history restore) keep the plain setter.
+  const switchDubLangCode = useAppStore((s) => s.switchDubLangCode);
   const dubNumSpeakers = useAppStore((s) => s.dubNumSpeakers);
   const setDubNumSpeakers = useAppStore((s) => s.setDubNumSpeakers);
   const dubDialect = useAppStore((s) => s.dubDialect);
@@ -225,7 +230,10 @@ export default function DubTab(props) {
         for (let i = 0; i < multiLangs.length; i++) {
           const l = multiLangs[i];
           setDubLang(l.lang);
-          setDubLangCode(l.code); // keep UI/exports in sync
+          // Keep UI/exports in sync AND snapshot the previous pick's
+          // translations before this pick's translate pass overwrites the
+          // visible text (P1.2).
+          switchDubLangCode(l.code);
           const skipTranslate = i === 0 && l.code === dubLangCode && editorAlreadyTranslated;
           if (!skipTranslate) {
             // Honest phase label: this pill slot otherwise only says
@@ -272,7 +280,7 @@ export default function DubTab(props) {
     handleTranslateAll,
     handleDubGenerate,
     setDubLang,
-    setDubLangCode,
+    switchDubLangCode,
     t,
   ]);
 
@@ -546,7 +554,7 @@ export default function DubTab(props) {
           fetchYtSubs={fetchYtSubs}
           setFetchYtSubs={setFetchYtSubs}
           dubLangCode={dubLangCode}
-          setDubLangCode={setDubLangCode}
+          setDubLangCode={switchDubLangCode}
           setDubLang={setDubLang}
           landingAdvOpen={landingAdvOpen}
           setLandingAdvOpen={setLandingAdvOpen}
@@ -619,7 +627,7 @@ export default function DubTab(props) {
               hasAnyTranslation={hasAnyTranslation}
               handleCleanupSegments={handleCleanupSegments}
               setDubLang={setDubLang}
-              setDubLangCode={setDubLangCode}
+              setDubLangCode={switchDubLangCode}
               dubDialect={dubDialect}
               setDubDialect={setDubDialect}
               i18n={i18n}

--- a/frontend/src/store/dubSlice.ts
+++ b/frontend/src/store/dubSlice.ts
@@ -169,6 +169,17 @@ export interface DubSlice {
   bumpDubGenNonce: () => void;
   setDubLang: (v: Updater<string>) => void;
   setDubLangCode: (v: Updater<string>) => void;
+  /**
+   * User-driven target-language switch (P1.2). Unlike the plain setter it
+   * also remaps segment text through the per-language `translations` store:
+   * the outgoing language's text is snapshotted into `translations[prev]`
+   * (only when it's an actual translation — differs from `text_original`),
+   * and the incoming language's saved text is swapped into `text` when one
+   * exists. Non-destructive: with no saved entry, `text` is left untouched —
+   * exactly the legacy behaviour. Restore/rehydrate paths (project load, dub
+   * history) must keep using `setDubLangCode`, which never touches segments.
+   */
+  switchDubLangCode: (code: string) => void;
   setDubNumSpeakers: (v: Updater<number | null>) => void;
   setDubDialect: (v: Updater<string>) => void;
   setMultiLangMode: (v: Updater<boolean>) => void;
@@ -205,6 +216,7 @@ const INITIAL: Omit<
   | 'bumpDubGenNonce'
   | 'setDubLang'
   | 'setDubLangCode'
+  | 'switchDubLangCode'
   | 'setDubNumSpeakers'
   | 'setDubDialect'
   | 'setMultiLangMode'
@@ -274,6 +286,29 @@ export const createDubSlice: StateCreator<DubSlice, [], [], DubSlice> = (set, ge
   bumpDubGenNonce: () => set(() => ({ dubGenNonce: Date.now() })),
   setDubLang: (v) => set((s) => ({ dubLang: resolve(v, s.dubLang) })),
   setDubLangCode: (v) => set((s) => ({ dubLangCode: resolve(v, s.dubLangCode) })),
+  switchDubLangCode: (code) =>
+    set((s) => {
+      const prev = s.dubLangCode;
+      if (!code || code === prev) return {};
+      const dubSegments = s.dubSegments.map((seg) => {
+        const translations: Record<string, string> = {
+          ...(seg.translations as Record<string, string> | undefined),
+        };
+        // Snapshot the outgoing language's text — but only real translations
+        // (differs from the source), so a never-translated row can't stamp
+        // source-language text as the previous language's translation.
+        // Legacy projects (no `translations` yet) get theirs seeded here.
+        const text = typeof seg.text === 'string' ? seg.text : '';
+        if (prev && text.trim() && text !== seg.text_original) translations[prev] = text;
+        const incoming = translations[code];
+        return {
+          ...seg,
+          translations,
+          ...(typeof incoming === 'string' && incoming.trim() ? { text: incoming } : {}),
+        };
+      });
+      return { dubLangCode: code, dubSegments };
+    }),
   setDubNumSpeakers: (v) => set((s) => ({ dubNumSpeakers: resolve(v, s.dubNumSpeakers) })),
   setDubDialect: (v) => set((s) => ({ dubDialect: resolve(v, s.dubDialect) })),
   setMultiLangMode: (v) => set((s) => ({ multiLangMode: resolve(v, s.multiLangMode) })),

--- a/frontend/src/test/dubPerLangTranslations.test.jsx
+++ b/frontend/src/test/dubPerLangTranslations.test.jsx
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAppStore } from '../store';
+
+// P1.2 / P1.3 — per-language translation storage + per-track fingerprints.
+//
+// `dubSegments[].text` is single-slot (the currently-shown language); before
+// this fix, switching the dub target language left the previous language's
+// text on screen and the next Translate All DESTROYED it. Now every
+// translation is kept in `s.translations[langCode]`, `switchDubLangCode`
+// swaps `text` through that map non-destructively, manual edits update the
+// current language's entry, and the incremental-plan fingerprints are stored
+// per language so "Regen N changed" judges the ACTIVE track.
+
+const dubApi = vi.hoisted(() => ({
+  dubUpload: vi.fn(),
+  dubIngestUrl: vi.fn(),
+  dubAbort: vi.fn(),
+  dubCleanupSegments: vi.fn(),
+  dubTranslate: vi.fn(),
+  dubGenerate: vi.fn(),
+  tasksStreamUrl: vi.fn(() => ''),
+  tasksCancel: vi.fn(),
+  transcribeStreamUrl: vi.fn(() => ''),
+  dubImportSrt: vi.fn(),
+}));
+vi.mock('../api/dub', () => dubApi);
+const clientApi = vi.hoisted(() => ({
+  apiPost: vi.fn(),
+  apiFetch: vi.fn(),
+  apiJson: vi.fn(),
+  API: '',
+}));
+vi.mock('../api/client', () => clientApi);
+
+import useDubWorkflow from '../hooks/useDubWorkflow';
+import useSegmentEditing from '../hooks/useSegmentEditing';
+
+const baseState = useAppStore.getState();
+
+function renderWorkflow() {
+  return renderHook(() =>
+    useDubWorkflow({
+      loadProjects: vi.fn(),
+      loadProfiles: vi.fn(),
+      loadDubHistory: vi.fn(),
+      setLastGenFingerprints: vi.fn(),
+    }),
+  );
+}
+
+const seg = (over = {}) => ({
+  id: '1',
+  text: 'hello there',
+  text_original: 'hello there',
+  start: 0,
+  end: 2,
+  ...over,
+});
+
+beforeEach(() => {
+  useAppStore.setState(baseState, true);
+  dubApi.dubTranslate.mockReset();
+  clientApi.apiPost.mockReset();
+  useAppStore.setState({
+    dubJobId: 'job1',
+    dubStep: 'editing',
+    dubLangCode: 'bn',
+    dubSegments: [seg()],
+  });
+});
+
+const translateTo = async (result, lang, text) => {
+  dubApi.dubTranslate.mockResolvedValueOnce({
+    translated: [{ id: '1', text }],
+    target_lang: lang,
+  });
+  await act(async () => {
+    await result.current.handleTranslateAll(lang);
+  });
+};
+
+describe('per-language translations (P1.2)', () => {
+  it('translate bn then es retains BOTH languages in s.translations (pre-fix: bn lost)', async () => {
+    const { result } = renderWorkflow();
+    await translateTo(result, 'bn', 'ওহে');
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    await translateTo(result, 'es', 'hola');
+
+    const s = useAppStore.getState().dubSegments[0];
+    expect(s.text).toBe('hola'); // text stays the shown language (legacy slot)
+    expect(s.translations).toMatchObject({ bn: 'ওহে', es: 'hola' });
+  });
+
+  it('switching the target language swaps text non-destructively, both directions', async () => {
+    const { result } = renderWorkflow();
+    await translateTo(result, 'bn', 'ওহে');
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    await translateTo(result, 'es', 'hola');
+
+    act(() => useAppStore.getState().switchDubLangCode('bn'));
+    expect(useAppStore.getState().dubSegments[0].text).toBe('ওহে');
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    expect(useAppStore.getState().dubSegments[0].text).toBe('hola');
+  });
+
+  it('switching to a never-translated language leaves text unchanged (legacy behaviour)', () => {
+    useAppStore.setState({
+      dubSegments: [seg({ text: 'ওহে', translations: { bn: 'ওহে' } })],
+    });
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    // Non-destructive: no es entry → keep showing what was there.
+    expect(useAppStore.getState().dubSegments[0].text).toBe('ওহে');
+    expect(useAppStore.getState().dubLangCode).toBe('es');
+  });
+
+  it('legacy segments (no translations field) survive a switch round-trip', () => {
+    // A pre-upgrade project where bn text was already translated in place.
+    useAppStore.setState({
+      dubSegments: [seg({ text: 'ওহে' })], // text !== text_original, no map
+    });
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    act(() => useAppStore.getState().switchDubLangCode('bn'));
+    // The switch snapshotted bn's text into the map instead of losing it.
+    expect(useAppStore.getState().dubSegments[0].text).toBe('ওহে');
+    expect(useAppStore.getState().dubSegments[0].translations.bn).toBe('ওহে');
+  });
+
+  it('never stamps untranslated (source) text as a translation on switch', () => {
+    // text === text_original → not a translation, must not be snapshotted.
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    expect(useAppStore.getState().dubSegments[0].translations.bn).toBeUndefined();
+  });
+
+  it('manual segment edit updates the CURRENT language entry only', () => {
+    useAppStore.setState({
+      dubLangCode: 'es',
+      dubSegments: [seg({ text: 'hola', translations: { bn: 'ওহে', es: 'hola' } })],
+    });
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.segmentEditField('1', 'text', 'hola editada'));
+    const s = useAppStore.getState().dubSegments[0];
+    expect(s.text).toBe('hola editada');
+    expect(s.translations).toEqual({ bn: 'ওহে', es: 'hola editada' });
+  });
+
+  it('restore-original records the decision under the current language', () => {
+    useAppStore.setState({
+      dubLangCode: 'es',
+      dubSegments: [seg({ text: 'hola', translations: { es: 'hola' } })],
+    });
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.segmentRestoreOriginal('1'));
+    const s = useAppStore.getState().dubSegments[0];
+    expect(s.text).toBe('hello there');
+    expect(s.translations.es).toBe('hello there');
+  });
+
+  it('merge joins per-language texts only where both rows carry the language', () => {
+    useAppStore.setState({
+      dubLangCode: 'es',
+      dubSegments: [
+        seg({ id: 'a', end: 1, translations: { es: 'uno', bn: 'এক' } }),
+        seg({ id: 'b', start: 1, translations: { es: 'dos' } }),
+      ],
+    });
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.segmentMerge('a'));
+    const merged = useAppStore.getState().dubSegments[0];
+    expect(merged.translations).toEqual({ es: 'uno dos' }); // bn half-known → dropped
+  });
+
+  it('split drops the per-language map (new ids need fresh translations)', () => {
+    useAppStore.setState({
+      dubLangCode: 'es',
+      dubSegments: [seg({ text: 'hola mundo', translations: { es: 'hola mundo' } })],
+    });
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.segmentSplit('1', 5));
+    const segs = useAppStore.getState().dubSegments;
+    expect(segs).toHaveLength(2);
+    expect(segs[0].translations).toBeUndefined();
+    expect(segs[1].translations).toBeUndefined();
+  });
+});
+
+describe('per-track fingerprints (P1.3)', () => {
+  it('lastGenFingerprints follows the ACTIVE language', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.setLastGenFingerprints({ 1: 'hash-bn' }, 'bn'));
+    act(() => result.current.setLastGenFingerprints({ 1: 'hash-es' }, 'es'));
+    expect(useAppStore.getState().dubLangCode).toBe('bn');
+    expect(result.current.lastGenFingerprints).toEqual({ 1: 'hash-bn' });
+    act(() => useAppStore.getState().switchDubLangCode('es'));
+    expect(result.current.lastGenFingerprints).toEqual({ 1: 'hash-es' });
+  });
+
+  it('recomputeIncremental sends the active lang + that language’s hashes', async () => {
+    clientApi.apiPost.mockResolvedValue({ stale: [], fresh: ['1'], fingerprints: {} });
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.setLastGenFingerprints({ 1: 'hash-bn' }, 'bn'));
+    await act(async () => {
+      await result.current.recomputeIncremental();
+    });
+    expect(clientApi.apiPost).toHaveBeenCalledWith(
+      '/tools/incremental',
+      expect.objectContaining({ lang: 'bn', stored_hashes: { 1: 'hash-bn' } }),
+    );
+    expect(result.current.incrementalPlan).toEqual({ stale: [], fresh: ['1'] });
+  });
+
+  it('a language with no stored hashes yields no plan (unknowable ≠ stale)', async () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.setLastGenFingerprints({ 1: 'hash-es' }, 'es'));
+    // Active language is bn → no hashes → plan cleared, no API call.
+    await act(async () => {
+      await result.current.recomputeIncremental();
+    });
+    expect(clientApi.apiPost).not.toHaveBeenCalled();
+    expect(result.current.incrementalPlan).toBeNull();
+  });
+
+  it('setFingerprintsByLang restores every track at once (project/history load)', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.setFingerprintsByLang({ bn: { 1: 'hb' }, es: { 1: 'he' } }));
+    expect(result.current.lastGenFingerprints).toEqual({ 1: 'hb' }); // active = bn
+    expect(result.current.fingerprintsByLang.es).toEqual({ 1: 'he' });
+  });
+
+  it('setLastGenFingerprints without a lang defaults to the store selection', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    act(() => result.current.setLastGenFingerprints({ 1: 'h' }));
+    expect(result.current.fingerprintsByLang).toEqual({ bn: { 1: 'h' } });
+  });
+});

--- a/tests/test_dub_per_lang_subtitles.py
+++ b/tests/test_dub_per_lang_subtitles.py
@@ -1,0 +1,250 @@
+"""P1.2 — per-language translation storage on the dub job.
+
+``job["segments"]`` is single-slot: every generate rebuilds it with the text
+of the language generated LAST. On a multi-language job, subtitle export for
+track A after generating track B therefore emitted B's words under A's
+language label — ExportModal's "all dubs" subtitle batch produced N files
+with IDENTICAL text.
+
+Fix (additive, back-compat): ``_sync_job_segments`` also writes
+``job["segments_i18n"] = { langCode: { segKey: text } }`` (segKey = stable
+segment id, or the list index for id-less legacy segments), preserving each
+generated track's text. ``/dub/srt|vtt?lang=`` and subtitle burn-in overlay
+that language's text when present, falling back to today's behaviour for
+legacy jobs / unknown languages. ``job["segments"]`` itself is untouched for
+every existing consumer.
+"""
+
+import os
+import uuid
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+def _make_req(texts, seg_ids=None, language_code="und", **kwargs):
+    from schemas.requests import DubRequest, DubSegment
+    segs = [
+        DubSegment(start=float(i), end=float(i) + 1.0, text=t)
+        for i, t in enumerate(texts)
+    ]
+    return DubRequest(
+        segments=segs, segment_ids=seg_ids, language_code=language_code, **kwargs
+    )
+
+
+@pytest.fixture()
+def two_track_job():
+    """A job that generated Spanish first, then Bengali — the way
+    _sync_job_segments leaves it after the multi-language batch loop."""
+    from services.dub_pipeline import _dub_jobs
+    from api.routers.dub_generate import _sync_job_segments
+
+    job_id = str(uuid.uuid4())[:8]
+    job = {
+        "video_path": "/nonexistent/original.mp4",
+        "duration": 2.0,
+        "filename": "test_video.mp4",
+        "segments": [
+            {"id": "a1", "start": 0.0, "end": 1.0, "text": "hello world",
+             "speaker_id": "Speaker 1"},
+            {"id": "a2", "start": 1.0, "end": 2.0, "text": "see you soon",
+             "speaker_id": "Speaker 1"},
+        ],
+        "dubbed_tracks": {
+            "es": {"path": "/nonexistent/dubbed_es.wav",
+                   "language": "Spanish", "language_code": "es"},
+            "bn": {"path": "/nonexistent/dubbed_bn.wav",
+                   "language": "Bengali", "language_code": "bn"},
+        },
+    }
+    _sync_job_segments(job, _make_req(
+        ["hola mundo", "hasta pronto"], seg_ids=["a1", "a2"], language_code="es"))
+    _sync_job_segments(job, _make_req(
+        ["ohe prithibi", "abar dekha hobe"], seg_ids=["a1", "a2"], language_code="bn"))
+    _dub_jobs[job_id] = job
+    yield job_id, job
+    _dub_jobs.pop(job_id, None)
+
+
+# ---------------------------------------------------------------------------
+# _sync_job_segments — the additive per-language map
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentsI18n:
+    def test_each_generated_language_is_preserved(self, two_track_job):
+        _, job = two_track_job
+        assert job["segments_i18n"]["es"] == {"a1": "hola mundo", "a2": "hasta pronto"}
+        assert job["segments_i18n"]["bn"] == {"a1": "ohe prithibi", "a2": "abar dekha hobe"}
+        # job["segments"] keeps the legacy single-slot contract: last language.
+        assert [s["text"] for s in job["segments"]] == ["ohe prithibi", "abar dekha hobe"]
+
+    def test_regenerating_a_language_replaces_only_that_language(self, two_track_job):
+        from api.routers.dub_generate import _sync_job_segments
+        _, job = two_track_job
+        _sync_job_segments(job, _make_req(
+            ["hola mundo v2"], seg_ids=["a1"], language_code="es"))
+        # The es map was rebuilt from the (shorter) request — stale ids gone…
+        assert job["segments_i18n"]["es"] == {"a1": "hola mundo v2"}
+        # …and bn was untouched.
+        assert job["segments_i18n"]["bn"] == {"a1": "ohe prithibi", "a2": "abar dekha hobe"}
+
+    def test_idless_segments_key_by_index(self):
+        from api.routers.dub_generate import _sync_job_segments
+        job = {"segments": [{"start": 0.0, "end": 1.0, "text": "src"}]}
+        _sync_job_segments(job, _make_req(["übersetzt"], language_code="de"))
+        assert job["segments_i18n"]["de"] == {"0": "übersetzt"}
+
+
+# ---------------------------------------------------------------------------
+# /dub/srt + /dub/vtt — ?lang= now selects the TEXT, not just cue times
+# ---------------------------------------------------------------------------
+
+
+class TestPerLanguageSubtitles:
+    def test_srt_lang_selects_that_tracks_text(self, client, two_track_job):
+        """FAILED pre-fix: both languages returned the last-generated text."""
+        job_id, _ = two_track_job
+        es = client.get(f"/dub/srt/{job_id}", params={"lang": "es"}).text
+        bn = client.get(f"/dub/srt/{job_id}", params={"lang": "bn"}).text
+        assert "hola mundo" in es and "ohe prithibi" not in es
+        assert "ohe prithibi" in bn and "hola mundo" not in bn
+        assert es != bn
+
+    def test_vtt_lang_selects_that_tracks_text(self, client, two_track_job):
+        job_id, _ = two_track_job
+        es = client.get(f"/dub/vtt/{job_id}", params={"lang": "es"}).text
+        bn = client.get(f"/dub/vtt/{job_id}", params={"lang": "bn"}).text
+        assert "hasta pronto" in es and "abar dekha hobe" not in es
+        assert "abar dekha hobe" in bn and "hasta pronto" not in bn
+
+    def test_no_lang_keeps_legacy_behaviour(self, client, two_track_job):
+        # No ?lang= → job["segments"] text (last generated), exactly as today.
+        job_id, _ = two_track_job
+        res = client.get(f"/dub/srt/{job_id}")
+        assert res.status_code == 200
+        assert "ohe prithibi" in res.text
+
+    def test_unknown_lang_falls_back_to_job_segments(self, client, two_track_job):
+        job_id, _ = two_track_job
+        res = client.get(f"/dub/srt/{job_id}", params={"lang": "fr"})
+        assert res.status_code == 200
+        assert "ohe prithibi" in res.text  # graceful fallback, no 404/empty
+
+    def test_legacy_job_without_segments_i18n_falls_back(self, client):
+        """Jobs written by previous builds lack segments_i18n entirely."""
+        from services.dub_pipeline import _dub_jobs
+        job_id = str(uuid.uuid4())[:8]
+        _dub_jobs[job_id] = {
+            "filename": "old.mp4",
+            "segments": [{"id": "a1", "start": 0.0, "end": 1.0, "text": "vecchio"}],
+            "dubbed_tracks": {"it": {"path": "/nonexistent/dubbed_it.wav",
+                                     "language": "Italian", "language_code": "it"}},
+        }
+        try:
+            res = client.get(f"/dub/srt/{job_id}", params={"lang": "it"})
+            assert res.status_code == 200
+            assert "vecchio" in res.text
+        finally:
+            _dub_jobs.pop(job_id, None)
+
+    def test_dual_layout_keeps_original_under_lang_text(self, client, two_track_job):
+        job_id, _ = two_track_job
+        res = client.get(f"/dub/srt/{job_id}", params={"lang": "es", "dual": 1})
+        assert "hola mundo" in res.text
+        assert "<i>hello world</i>" in res.text  # text_original untouched
+
+
+class TestSegmentsForLang:
+    def test_index_fallback_for_idless_segments(self):
+        from api.routers.dub_export import _segments_for_lang
+        job = {
+            "segments": [{"start": 0.0, "end": 1.0, "text": "src"}],
+            "segments_i18n": {"de": {"0": "übersetzt"}},
+        }
+        assert _segments_for_lang(job, "de")[0]["text"] == "übersetzt"
+
+    def test_missing_per_segment_entry_keeps_row_text(self):
+        from api.routers.dub_export import _segments_for_lang
+        job = {
+            "segments": [
+                {"id": "a1", "start": 0.0, "end": 1.0, "text": "uno"},
+                {"id": "a2", "start": 1.0, "end": 2.0, "text": "dos"},
+            ],
+            "segments_i18n": {"de": {"a1": "eins"}},
+        }
+        out = _segments_for_lang(job, "de")
+        assert [s["text"] for s in out] == ["eins", "dos"]
+
+    def test_never_mutates_job_segments(self):
+        from api.routers.dub_export import _segments_for_lang
+        job = {
+            "segments": [{"id": "a1", "start": 0.0, "end": 1.0, "text": "uno"}],
+            "segments_i18n": {"de": {"a1": "eins"}},
+        }
+        _segments_for_lang(job, "de")
+        assert job["segments"][0]["text"] == "uno"
+
+    def test_malformed_i18n_shapes_are_ignored(self):
+        from api.routers.dub_export import _segments_for_lang
+        segs = [{"id": "a1", "start": 0.0, "end": 1.0, "text": "uno"}]
+        for bad in (None, [], "x", {"de": "not-a-dict"}, {"de": {}}):
+            job = {"segments": segs, "segments_i18n": bad}
+            assert _segments_for_lang(job, "de") == segs
+
+
+class TestBurnSrtPerLanguage:
+    def test_burn_uses_named_tracks_text(self, tmp_path, two_track_job):
+        from api.routers.dub_export import _write_burn_srt
+        _, job = two_track_job
+        content = open(
+            _write_burn_srt(job, str(tmp_path), "s1", dual=False, lang="es"),
+            encoding="utf-8",
+        ).read()
+        assert "hola mundo" in content
+        assert "ohe prithibi" not in content
+
+    def test_burn_without_lang_keeps_legacy_behaviour(self, tmp_path, two_track_job):
+        from api.routers.dub_export import _write_burn_srt
+        _, job = two_track_job
+        content = open(
+            _write_burn_srt(job, str(tmp_path), "s2", dual=False),
+            encoding="utf-8",
+        ).read()
+        assert "ohe prithibi" in content  # last-generated text, as today
+
+
+# ---------------------------------------------------------------------------
+# /tools/incremental — optional per-track lang (P1.3 client recompute)
+# ---------------------------------------------------------------------------
+
+
+class TestIncrementalEndpointLang:
+    def test_lang_scopes_the_plan(self, client):
+        from services.incremental import segment_fingerprint
+        stored = {"a1": segment_fingerprint({"text": "hola"}, track_lang="es")}
+        body = {"segments": [{"id": "a1", "text": "hola"}], "stored_hashes": stored}
+        # Judged for the track that produced the hashes → fresh.
+        res = client.post("/tools/incremental", json={**body, "lang": "es"}).json()
+        assert res["fresh"] == ["a1"]
+        # Judged for another track → stale (no cross-language reuse).
+        res = client.post("/tools/incremental", json={**body, "lang": "bn"}).json()
+        assert res["stale"] == ["a1"]
+
+    def test_omitted_lang_keeps_legacy_hashing(self, client):
+        from services.incremental import segment_fingerprint
+        stored = {"a1": segment_fingerprint({"text": "hola"})}
+        res = client.post(
+            "/tools/incremental",
+            json={"segments": [{"id": "a1", "text": "hola"}], "stored_hashes": stored},
+        ).json()
+        assert res["fresh"] == ["a1"]

--- a/tests/test_redub_incremental.py
+++ b/tests/test_redub_incremental.py
@@ -241,8 +241,9 @@ def test_edited_line_produces_different_cached_output(patched_generate):
     assert set(seg_hashes) == {"0", "1"}
     assert model.calls == ["Buenos dias", "Hasta luego"]
 
-    wav0_v1 = (job_dir / "seg_0.wav").read_bytes()
-    wav1_v1 = (job_dir / "seg_1.wav").read_bytes()
+    # P1.3 — per-segment WAVs are keyed by the track language now.
+    wav0_v1 = (job_dir / "seg_es_0.wav").read_bytes()
+    wav1_v1 = (job_dir / "seg_es_1.wav").read_bytes()
 
     # ── User edits line 0; client-side recompute marks ONLY it stale ──
     edited = [
@@ -252,6 +253,7 @@ def test_edited_line_produces_different_cached_output(patched_generate):
     plan = incremental.plan_incremental(
         [{"id": "0", "text": "Buenas noches"}, {"id": "1", "text": "Hasta luego"}],
         stored_hashes=seg_hashes,
+        track_lang="es",  # the recompute names the track it's judging (P1.3)
     )
     assert plan["stale"] == ["0"]
     assert plan["fresh"] == ["1"]
@@ -265,8 +267,8 @@ def test_edited_line_produces_different_cached_output(patched_generate):
     # TTS ran exactly once, with the edited text
     assert model.calls == ["Buenas noches"]
 
-    wav0_v2 = (job_dir / "seg_0.wav").read_bytes()
-    wav1_v2 = (job_dir / "seg_1.wav").read_bytes()
+    wav0_v2 = (job_dir / "seg_es_0.wav").read_bytes()
+    wav1_v2 = (job_dir / "seg_es_1.wav").read_bytes()
     # the edited line's cached audio changed…
     assert wav0_v2 != wav0_v1
     # …and the untouched line's cached audio was reused as-is
@@ -286,10 +288,174 @@ def test_full_rerun_rerenders_edited_text(patched_generate):
     run, model, job, job_dir = patched_generate
 
     run(_body([{"start": 0.0, "end": 1.0, "text": "primero"}]))
-    first = (job_dir / "seg_0.wav").read_bytes()
+    first = (job_dir / "seg_es_0.wav").read_bytes()
 
     run(_body([{"start": 0.0, "end": 1.0, "text": "segundo"}]))
-    second = (job_dir / "seg_0.wav").read_bytes()
+    second = (job_dir / "seg_es_0.wav").read_bytes()
 
     assert model.calls == ["primero", "segundo"]
     assert first != second
+
+
+# ── P1.3 — per-track WAV cache + per-language fingerprints ──────────────────
+#
+# The per-segment cache used to be keyed by job+segment only, and seg_hashes
+# was one flat map — so on a multi-language job, "Regen N changed" spliced
+# cached WAVs FROM THE LAST-GENERATED LANGUAGE into the current track, and
+# staleness was judged against whatever language ran last.
+
+
+def _amp_for(text: str) -> float:
+    """The deterministic amplitude _FakeModel renders for `text`."""
+    h = int(hashlib.sha1(text.encode("utf-8")).hexdigest()[:8], 16)
+    return 0.1 + (h % 1000) / 2000.0
+
+
+def _track_sample(job_dir, lang: str, t_seconds: float, sr: int = 24000) -> float:
+    """One sample (as float in [-1, 1]) of the final dubbed_{lang}.wav."""
+    import wave
+    with wave.open(str(job_dir / f"dubbed_{lang}.wav"), "rb") as wf:
+        assert wf.getframerate() == sr
+        wf.setpos(int(t_seconds * sr))
+        frame = wf.readframes(1)
+    return int.from_bytes(frame, "little", signed=True) / 32767.0
+
+
+_ES_SEGS = [
+    {"start": 0.0, "end": 1.0, "text": "Buenos dias"},
+    {"start": 1.0, "end": 2.0, "text": "Hasta luego"},
+]
+_BN_SEGS = [
+    {"start": 0.0, "end": 1.0, "text": "shubho sokal"},
+    {"start": 1.0, "end": 2.0, "text": "abar dekha hobe"},
+]
+
+
+def test_two_track_regen_never_splices_other_language(patched_generate):
+    """The P1.3 headline bug: regen on track A after generating track B used
+    to mix B's cached WAVs into A (the cache wasn't language-keyed)."""
+    run, model, job, job_dir = patched_generate
+
+    run(_body(_ES_SEGS))                      # track 1: es
+    run(_body(_BN_SEGS, language_code="bn"))  # track 2: bn
+    # Each track owns its cache files now.
+    assert (job_dir / "seg_es_1.wav").exists()
+    assert (job_dir / "seg_bn_1.wav").exists()
+
+    # Regen only line 0 of the es track. Line 1 must be reused from the ES
+    # cache — before the fix the un-keyed seg_1.wav held bn's audio.
+    model.calls.clear()
+    run(_body(_ES_SEGS, regen_only=["0"]))
+    assert model.calls == ["Buenos dias"]
+
+    # Mid-audio sample of line 1 in the rebuilt es track (0.5 s of natural
+    # audio at slot start 1.0 s → sample at 1.25 s, clear of the 15 ms fades).
+    got = _track_sample(job_dir, "es", 1.25)
+    assert abs(got - _amp_for("Hasta luego")) < 0.01, "es track must carry es audio"
+    assert abs(got - _amp_for("abar dekha hobe")) > 0.01, "bn audio spliced into es track"
+
+
+def test_legacy_single_track_job_still_hits_its_old_cache(patched_generate):
+    """On-disk back-compat: a job rendered by previous builds only has
+    un-keyed seg_{id}.wav files. With a single language on the job they are
+    unambiguous and must keep being reused (no forced re-render)."""
+    run, model, job, job_dir = patched_generate
+
+    run(_body(_ES_SEGS))
+    # Simulate the pre-upgrade cache: only legacy names on disk.
+    for i in range(2):
+        (job_dir / f"seg_es_{i}.wav").rename(job_dir / f"seg_{i}.wav")
+
+    model.calls.clear()
+    run(_body(_ES_SEGS, regen_only=[]))  # pure re-mix, reuse everything
+    assert model.calls == []             # no TTS — cache hit
+    got = _track_sample(job_dir, "es", 1.25)
+    assert abs(got - _amp_for("Hasta luego")) < 0.01, "legacy cache not reused"
+
+
+def test_legacy_cache_ignored_once_job_has_another_language(patched_generate):
+    """A multi-track job's un-keyed files hold whichever language wrote them
+    last — ambiguous, so they must never be spliced into a track again."""
+    run, model, job, job_dir = patched_generate
+
+    run(_body(_ES_SEGS))
+    for i in range(2):
+        (job_dir / f"seg_es_{i}.wav").rename(job_dir / f"seg_{i}.wav")
+    # Another language exists on the job → the legacy files are ambiguous.
+    job["dubbed_tracks"]["bn"] = {"path": str(job_dir / "dubbed_bn.wav"),
+                                  "language": "Bengali", "language_code": "bn"}
+
+    model.calls.clear()
+    run(_body(_ES_SEGS, regen_only=[]))
+    assert model.calls == []  # not in the regen list → still no TTS…
+    # …but the ambiguous legacy audio was NOT spliced in: the slot is silence.
+    assert abs(_track_sample(job_dir, "es", 1.25)) < 0.005
+
+
+def test_seg_hashes_stored_per_language_with_flat_mirror(patched_generate):
+    """seg_hashes_by_lang keeps every track's fingerprints; the flat
+    seg_hashes stays = the CURRENT track's map (what every legacy consumer
+    already assumed it meant)."""
+    run, model, job, job_dir = patched_generate
+
+    run(_body(_ES_SEGS))
+    es_hashes = dict(job["seg_hashes_by_lang"]["es"])
+    run(_body(_BN_SEGS, language_code="bn"))
+
+    assert set(job["seg_hashes_by_lang"]) == {"es", "bn"}
+    # es hashes survived the bn generate (single-slot loss was the bug)…
+    assert job["seg_hashes_by_lang"]["es"] == es_hashes
+    # …and differ from bn's (language is part of the fingerprint).
+    assert job["seg_hashes_by_lang"]["bn"] != es_hashes
+    # Flat mirror = last-generated track.
+    assert job["seg_hashes"] == job["seg_hashes_by_lang"]["bn"]
+
+
+# ── Language-scoped fingerprints + migration semantics (unit) ──────────────
+
+
+def test_track_lang_scopes_fingerprint():
+    assert fp({"text": "x"}, track_lang="es") != fp({"text": "x"}, track_lang="bn")
+    # No lang → the legacy payload, byte-for-byte (old stored hashes keep
+    # their values; see test_backcompat_with_hashes_stored_by_previous_builds).
+    assert fp({"text": "x"}, track_lang=None) == fp({"text": "x"})
+    # A legacy (lang-less) hash never vouches for a lang-scoped track.
+    assert fp({"text": "x"}) != fp({"text": "x"}, track_lang="es")
+
+
+def test_plan_incremental_track_lang_threads_through():
+    stored = {"0": fp({"text": "hola"}, track_lang="es")}
+    plan = incremental.plan_incremental(
+        [{"id": "0", "text": "hola"}], stored_hashes=stored, track_lang="es",
+    )
+    assert plan["fresh"] == ["0"]
+    # Same hashes judged for another track → stale (never reuse cross-lang).
+    plan = incremental.plan_incremental(
+        [{"id": "0", "text": "hola"}], stored_hashes=stored, track_lang="bn",
+    )
+    assert plan["stale"] == ["0"]
+
+
+def test_legacy_flat_seg_hashes_attributed_to_last_generated_language():
+    from api.routers.dub_generate import _seg_hashes_by_lang
+    # The flat map could only describe the job's last-generated track.
+    job = {"seg_hashes": {"0": "abc"}, "language_code": "es"}
+    assert _seg_hashes_by_lang(job) == {"es": {"0": "abc"}}
+    assert job["seg_hashes_by_lang"] == {"es": {"0": "abc"}}
+    # Unknown language → dropped (stale reads → clean regen; never a guess).
+    job = {"seg_hashes": {"0": "abc"}}
+    assert _seg_hashes_by_lang(job) == {}
+    # Already migrated → returned as-is, no double migration.
+    job = {"seg_hashes_by_lang": {"bn": {"1": "def"}}, "seg_hashes": {"0": "abc"},
+           "language_code": "es"}
+    assert _seg_hashes_by_lang(job) == {"bn": {"1": "def"}}
+
+
+def test_legacy_seg_cache_gate():
+    from api.routers.dub_generate import _legacy_seg_cache_ok
+    # No tracks yet / only this language → legacy files are unambiguous.
+    assert _legacy_seg_cache_ok({}, "es")
+    assert _legacy_seg_cache_ok({"dubbed_tracks": {"es": {}}}, "es")
+    # Any OTHER language on the job → ambiguous, never reuse.
+    assert not _legacy_seg_cache_ok({"dubbed_tracks": {"bn": {}}}, "es")
+    assert not _legacy_seg_cache_ok({"dubbed_tracks": {"es": {}, "bn": {}}}, "es")

--- a/tests/test_smart_fit_generate.py
+++ b/tests/test_smart_fit_generate.py
@@ -152,7 +152,7 @@ def test_final_dub_track_and_seg_wav_are_watermarked(patched_generate, monkeypat
     Fresh TTS output is watermarked exactly ONCE, right before its
     per-segment WAV is written. That seg WAV is BOTH the downloadable file
     and the assembly input, so:
-      - the downloadable seg_<id>.wav carries the mark, and
+      - the downloadable seg_{lang}_{id}.wav carries the mark, and
       - the final assembled track inherits it (the streaming memmap writer
         does NOT re-watermark, so there's no double-mark).
 
@@ -206,7 +206,7 @@ def test_final_dub_track_and_seg_wav_are_watermarked(patched_generate, monkeypat
     assert watermark.detect_watermark(final_wav, sr)["is_watermarked"] is True
 
     # Downloadable per-segment WAV is watermarked too.
-    seg_wav, seg_sr = torchaudio.load(str(job_dir / "seg_0.wav"))
+    seg_wav, seg_sr = torchaudio.load(str(job_dir / "seg_es_0.wav"))
     assert watermark.detect_watermark(seg_wav, seg_sr)["is_watermarked"] is True
 
     # Marked exactly once, on the FRESH seg (33s natural length) — NOT on the
@@ -225,7 +225,7 @@ def test_zero_and_negative_duration_segments_dont_crash(patched_generate):
 
     job["duration"] = 5.0
     segs = [
-        {"start": 0.0, "end": 1.0, "text": "0.5:hola"},  # normal → seg_0.wav
+        {"start": 0.0, "end": 1.0, "text": "0.5:hola"},  # normal → seg_es_0.wav
         {"start": 1.0, "end": 1.0, "text": ""},          # zero duration
         {"start": 2.0, "end": 2.8, "text": "   "},       # positive silence → mix temp
         {"start": 4.0, "end": 3.5, "text": "boom"},      # negative duration
@@ -279,7 +279,7 @@ def test_smart_fit_audio_only_stretch_keeps_original_duration(patched_generate):
     assert job["seg_wav_kind"] == "natural"
     # The on-disk per-segment WAV stays natural-rate (2.2s, not slot-squeezed).
     import torchaudio
-    wav, sr2 = torchaudio.load(str(job_dir / "seg_1.wav"))
+    wav, sr2 = torchaudio.load(str(job_dir / "seg_es_1.wav"))
     assert wav.shape[-1] == int(2.2 * SR)
 
 
@@ -356,7 +356,7 @@ def test_strict_slot_to_smart_fit_forces_one_full_regen(patched_generate):
     run(_body(segs, timing_strategy="strict_slot"))
     assert job["seg_wav_kind"] == "slotted"
     import torchaudio
-    wav, _ = torchaudio.load(str(job_dir / "seg_0.wav"))
+    wav, _ = torchaudio.load(str(job_dir / "seg_es_0.wav"))
     assert wav.shape[-1] == int(1.0 * SR)  # squeezed to the 1s slot
 
     # smart_fit "re-mix only" request — but the disk WAVs are slotted, so
@@ -365,7 +365,7 @@ def test_strict_slot_to_smart_fit_forces_one_full_regen(patched_generate):
     run(_body(segs, timing_strategy="smart_fit", regen_only=[]))
     assert model.calls == ["1.5:uno", "1.5:dos"]
     assert job["seg_wav_kind"] == "natural"
-    wav, _ = torchaudio.load(str(job_dir / "seg_0.wav"))
+    wav, _ = torchaudio.load(str(job_dir / "seg_es_0.wav"))
     assert wav.shape[-1] == int(1.5 * SR)  # natural-rate now
 
     # Now a fit-only change (re-mix): natural WAVs are reusable — zero TTS.


### PR DESCRIPTION
## The two structural gaps (verified investigation; completes the P1 multi-lang ladder after #956/#957)

**A. Single-slot translations** — `dubSegments[].text` and `job["segments"]` hold ONE language: switching the target destroyed the previous language's editable text, and `/dub/srt|vtt?lang=` only changed cue *times* — the "all dubs" subtitles batch emitted N files with identical text.

**B. Language-blind caches** — `seg_<id>.wav` + one global `seg_hashes` map: "Regen changed" on a multi-track project **spliced last-generated-language audio** into whatever track was being rebuilt, and per-track staleness was unknowable.

## What this does
- **Per-language translations**: `s.translations[lang]` (frontend) + `job["segments_i18n"][lang]` (backend) alongside the untouched legacy fields. Language switching snapshot-then-swaps non-destructively; manual edits stay with their language; srt/vtt/burn-in emit each track's own text with full fallback for legacy jobs.
- **Per-track caches**: WAVs keyed `seg_{lang}_{id}.wav` (legacy read fallback only while a job has a single track — existing users keep their cache; multi-track cross-splicing is dead), fingerprints include the track language, `seg_hashes_by_lang` with a flat mirror so the done-event/history/older frontends read unchanged, incremental staleness is per-active-track.
- **Deliberate safety trade-off**: pre-upgrade fingerprints read stale once → the first "Regen changed" after upgrading regenerates cleanly instead of ever risking a wrong-language splice.

## Tests
40 new (17 subtitle + 9 incremental backend, 14 frontend) — fail-before verified on the exact bug classes, including a sample-level amplitude assert that pre-fix regen mixes another track's audio. Full runs: backend 2207 passed (16 pre-existing env flakes byte-identical on clean main), frontend 888/888, typecheck/lint/format:check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added per-language translation storage across frontend/backend so switching dub languages is non-destructive and preserves each track’s text.
- Updated export paths so SRT/VTT/burn-in subtitles and clip exports use the selected language’s own text, with legacy fallbacks for older jobs.
- Made incremental regeneration and cache reuse language-scoped by keying segment hashes/WAVs by language, preventing cross-language audio reuse.
- Added/updated tests covering translation switching, subtitle export, cache migration, and per-language incremental planning.

## UI sketch
Before:
```
Dub tab
+-----------------------------+
| Language switch             |
| Segment text (single slot)   |
| Editing overwrites current   |
+-----------------------------+
```

After:
```
Dub tab
+-----------------------------+
| Language switch             |
| Segment text (per-language)  |
| Edit/switch preserves tracks |
+-----------------------------+
```

## Behavior flow
```mermaid
flowchart TD
  A[Select dub language] --> B[Load that language's translations]
  B --> C[Edit segment text]
  C --> D[Store in translations[lang]]
  D --> E[Generate / regenerate]
  E --> F[Compute lang-scoped fingerprints]
  F --> G[Use seg_{lang}_{id}.wav cache]
  G --> H[Export subtitles / audio for selected lang]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->