### PR TITLE
docs+scripts: install fixes — desktop-prod tauri resolution, Ubuntu white-screen guidance, honest GPU/prereq docs (#960 #961 #962)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,12 @@ jobs:
         working-directory: frontend
         run: bun run format:check
 
+      # `bun run test` (frontend/package.json), not `bunx vitest` — bunx
+      # resolves by npm package name and can miss workspace-hoisted bins,
+      # then falls back to fetching from npm (#962 class).
       - name: Run Vitest (frontend)
         working-directory: frontend
-        run: bunx vitest run
+        run: bun run test
 
       # Legacy node:test runner for tests/frontend/*.test.mjs
       - name: Run frontend node:test (legacy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - **Completed dub tracks always show their video tabs.** Opening a project with a finished dubbed track hid the Original/track switcher until you re-selected the language — visibility was keyed to the language dropdown instead of the project's tracks, and restored projects couldn't set the language because the history database froze it at empty forever. Tabs now render from the tracks themselves, history keeps its language (existing projects heal without migration), restoring a project can no longer 404 the video preview, and track pills gained duration/timing tooltips plus an accurate now-playing indicator. (#956)
+- **Running from source works again, and the install docs stop lying.** `bun run desktop-prod` broke when the frontend became a workspace (`bunx` could fetch the wrong "tauri" package from npm — fixed everywhere including CI); the Linux white-screen guidance now leads with the variable that actually fixes modern Ubuntu (`WEBKIT_DISABLE_DMABUF_RENDERER=1`, with the exact `EGL_BAD_PARAMETER` error quoted); Windows docs now state plainly that GPU acceleration is NVIDIA-only there; the Linux docs document the ROCm support that already shipped (the "planned follow-up" note was stale); and prerequisites are split installer-vs-source with git and curl included. (#964)
 
 ## [0.3.10] — 2026-07-05
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thanks for your interest in improving OmniVoice Studio! This guide covers everyt
 ### Prerequisites
 
 - [Git](https://git-scm.com/)
+- `curl` (used by the Bun / uv / rustup install one-liners on macOS and Linux)
 - [Bun](https://bun.sh/) (frontend package manager)
 - [uv](https://docs.astral.sh/uv/) (Python environment manager)
 - [ffmpeg](https://ffmpeg.org/) (audio/video processing)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The eight headliners — and twelve more waiting under the fold.
 - 📦 **Batch Queue** — drop 50 videos, walk away; per-job progress bars.
 - 🛡️ **AI Watermark** — AudioSeal (Meta): invisible, survives compression.
 - 🔬 **Diagnostics** — self-check suite, error journal, scrubbed diagnostic bundles.
-- ⚡ **GPU Auto-Detect** — CUDA · MPS · ROCm · CPU; ≤8 GB VRAM auto-offloads.
+- ⚡ **GPU Auto-Detect** — CUDA · MPS · ROCm (Linux, opt-in) · CPU; ≤8 GB VRAM auto-offloads.
 - 🧭 **Engine routing** — preflight GPU check per engine; no silent CPU fallback.
 - 🧩 **Extensible** — subclass `TTSBackend`, add any engine in ~50 lines.
 - 🎒 **Portable personas** — export voices as `.ovsvoice` bundles: identity + watermark.
@@ -244,7 +244,7 @@ ElevenLabs charges **$5–$330/mo** and processes your audio on their servers. O
 | **Video Dubbing** | ✅ Cloud-only | ✅ Fully local |
 | **Data Privacy** | Audio sent to cloud | **Nothing leaves your machine** |
 | **API Keys** | Required | Not needed |
-| **GPU Support** | N/A (cloud) | CUDA · Apple Silicon · ROCm · CPU |
+| **GPU Support** | N/A (cloud) | CUDA · Apple Silicon · ROCm (Linux) · CPU |
 | **Desktop App** | ❌ | ✅ macOS · Windows · Linux |
 | **TTS Engines** | 1 | **14** (OmniVoice, CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX, IndexTTS 2, OmniVoice GGUF, Supertonic 3, MOSS-TTS-v1.5, dots.tts, Confucius4-TTS) |
 | **ASR Engines** | 1 | **9** (WhisperX, Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet, Moonshine, FunASR, isolated Faster-Whisper, sherpa-onnx live dictation) |
@@ -272,10 +272,13 @@ Professional-grade voice AI, minus the subscription and the cloud.
 | **VRAM (GPU)** | 4 GB (auto-offloads TTS to CPU) | 8 GB+ (NVIDIA RTX 3060+) |
 | **Disk** | 10 GB free (models + cache) | 20 GB+ SSD |
 | **Python** | 3.10+ (managed by `uv`) | 3.11–3.12 |
-| **GPU** | Optional — CPU works | NVIDIA CUDA · Apple Silicon MPS · AMD ROCm |
+| **GPU** | Optional — CPU works | NVIDIA CUDA · Apple Silicon MPS · AMD ROCm (Linux only) |
 
 > [!TIP]
 > On GPUs with **≤8 GB VRAM**, OmniVoice automatically offloads TTS to CPU during transcription — no config needed. A dedicated GPU is not required; the entire pipeline runs on CPU (just slower).
+
+> [!NOTE]
+> **AMD GPUs:** ROCm acceleration is **Linux-only and opt-in** — pick **"AMD GPU (ROCm)"** on the first-run setup screen or set `OMNIVOICE_TORCH_VARIANT=rocm` ([docs/install/linux.md](docs/install/linux.md#amd-gpu-rocm)). **On Windows, AMD GPUs (incl. Ryzen AI iGPUs) run CPU-only**: PyTorch has no Windows ROCm wheels, so Windows GPU acceleration is NVIDIA/CUDA-only ([docs/install/windows.md](docs/install/windows.md#gpu-support)).
 
 > [!IMPORTANT]
 > **macOS Intel (x86_64) is unsupported for the local backend:** the app UI installs, but the Python backend cannot run because PyTorch no longer ships Intel-Mac wheels ([#889](https://github.com/debpalash/OmniVoice-Studio/issues/889)). Intel-Mac users can still point the UI at a remote backend on another machine — see [docs/install/macos.md](docs/install/macos.md).

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -5,13 +5,28 @@ working OmniVoice Studio install on a Debian / Ubuntu / Fedora / Arch host.
 
 ## Prerequisites
 
+### Using the AppImage or .deb
+
 - **Linux x86_64** with a desktop session (X11 or Wayland) capable of running
   a Tauri / WebKitGTK app.
+- **~10 GB free disk** for the app, its Python environment, and model weights.
+- Optional: an **NVIDIA driver** for CUDA GPU acceleration — the app runs
+  CPU-only without one. For AMD GPUs see [AMD GPU (ROCm)](#amd-gpu-rocm).
+
+That's it — Python, FFmpeg, and the model weights are bundled or bootstrapped
+by the app itself on first launch. No toolchain needed.
+
+### Building from source
+
+Everything above, plus the toolchain:
+
+- **git** — `sudo apt install git` (Debian/Ubuntu), `sudo dnf install git` (Fedora), or `sudo pacman -S git` (Arch).
+- **curl** — usually preinstalled; used by the Bun and rustup install one-liners below.
 - **Python 3.11+** — typically `sudo apt install python3.11` on Debian/Ubuntu,
   `sudo dnf install python3.11` on Fedora, or already installed on Arch.
 - **Bun** — `curl -fsSL https://bun.sh/install | bash`.
 - **FFmpeg** — `sudo apt install ffmpeg` (Debian/Ubuntu), `sudo dnf install ffmpeg-free` (Fedora), or `sudo pacman -S ffmpeg` (Arch).
-- **Rust / Cargo** (required for building from source only) — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or via your package manager (e.g., `sudo apt install rustc cargo`).
+- **Rust / Cargo** — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or via your package manager (e.g., `sudo apt install rustc cargo`).
   If you use rustup, reopen the shell or source `"$HOME/.cargo/env"` before running `bun run desktop-prod`.
 - **GTK/WebKit deps** for the Tauri shell:
 
@@ -74,24 +89,49 @@ APP_ID="com.debpalash.omnivoice-studio"
 APP_NAME="OmniVoice Studio"
 ```
 
-## AppImage white-screen on Fedora 44 / Ubuntu 24.04
+## AppImage white screen / EGL errors (Fedora 44, Ubuntu 24.04+, 26.04)
 
 <a id="appimage-white-screen-on-fedora-44--ubuntu-2404"></a>
 
-Newer distros ship WebKitGTK 2.44 / 2.46, which has a compositing-mode
-regression that lands the Tauri window as a fully-white frame with no UI.
+Two separate WebKitGTK rendering issues land the Tauri window as a
+fully-white frame with no UI. Which one you have depends on your WebKitGTK
+version (`pkg-config --modversion webkit2gtk-4.1` prints it).
 
-**Workaround:** set `WEBKIT_DISABLE_COMPOSITING_MODE=1` before launching:
+**Modern WebKitGTK (2.48+ — Ubuntu 24.04 and newer, incl. 26.04): try this
+first.** WebKit's DMA-BUF renderer fails against some GPU drivers; the
+terminal typically shows:
+
+```
+Could not create default EGL display: EGL_BAD_PARAMETER
+```
+
+Disable the DMA-BUF renderer before launching:
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 ./OmniVoice.Studio_*.AppImage
+```
+
+**WebKitGTK 2.44 / 2.46 (Fedora 44, Ubuntu 24.04 at release):** a
+compositing-mode regression blanks the surface on first paint. Disable
+compositing mode instead:
 
 ```bash
 WEBKIT_DISABLE_COMPOSITING_MODE=1 ./OmniVoice.Studio_*.AppImage
 ```
 
-OmniVoice's AppRun launcher autodetects the broken WebKitGTK range and sets
-this for you (shipped in v0.3+). The manual env-var path remains the documented
-fallback when running from a checked-out source tree.
+OmniVoice's AppRun launcher autodetects the broken 2.44/2.46 range and sets
+this second variable for you (shipped in v0.3+). The manual env-var path
+remains the documented fallback when running from a checked-out source tree.
 
-Tracking issue: [#62](https://github.com/debpalash/OmniVoice-Studio/issues/62).
+**Last resort** — if neither variable alone helps, force software rendering
+(slower, but always paints):
+
+```bash
+WEBKIT_DISABLE_DMABUF_RENDERER=1 LIBGL_ALWAYS_SOFTWARE=1 ./OmniVoice.Studio_*.AppImage
+```
+
+Tracking issues: [#62](https://github.com/debpalash/OmniVoice-Studio/issues/62),
+[#961](https://github.com/debpalash/OmniVoice-Studio/issues/961).
 
 ## .deb ffprobe conflict
 
@@ -134,17 +174,35 @@ that picks these defaults automatically; for v0.3 set them by hand.
 
 <a id="amd-gpu-rocm"></a>
 
-OmniVoice **auto-detects AMD GPUs** — `get_best_device()` returns the GPU when a
-ROCm build of PyTorch is installed (ROCm-built PyTorch reports through
-`torch.cuda.is_available()`), and OmniVoice auto-sets `HSA_OVERRIDE_GFX_VERSION`
-for consumer cards whose GFX ID isn't in the official ROCm support matrix. No
-code changes or flags are needed.
+ROCm support is **Linux-only and opt-in**. The **default install ships the
+CUDA build** of PyTorch (the `pytorch-cuda` index in `pyproject.toml`), so on
+an AMD-only machine `torch.cuda.is_available()` is `False` and OmniVoice runs
+on CPU until you opt into the ROCm variant. (On Windows there is no ROCm path
+at all — PyTorch publishes no Windows ROCm wheels; see
+[windows.md](windows.md#gpu-support).)
 
-The catch: the **default install ships the CUDA build** of PyTorch (the
-`pytorch-cuda` index in `pyproject.toml`), so on an AMD-only machine
-`torch.cuda.is_available()` is `False` and OmniVoice falls back to CPU. To use
-your AMD GPU, replace torch with the ROCm wheel **after** the first-run install
-populates the venv:
+Three ways to opt in, in order of preference:
+
+**1. First-run setup screen (recommended).** On Linux the setup screen's
+**Compute** card offers **"AMD GPU (ROCm, Linux)"** next to the default
+**Auto**. When OmniVoice detects an AMD GPU *and* the ROCm userspace
+(`/opt/rocm` present, or `rocminfo` on PATH), the ROCm option is pre-selected;
+with an AMD GPU but no ROCm runtime it stays offered-but-unselected — install
+ROCm first (or continue on CPU). Choosing ROCm makes the bootstrap reinstall
+`torch`/`torchaudio` from the ROCm wheel index
+(`https://download.pytorch.org/whl/rocm6.2` by default) right after the
+dependency sync.
+
+**2. Environment variable (existing installs / headless).** Set
+`OMNIVOICE_TORCH_VARIANT=rocm` before launching — the next bootstrap performs
+the same ROCm reinstall. `OMNIVOICE_TORCH_INDEX=<url>` overrides the wheel
+index when you need a different ROCm version
+([pytorch.org](https://pytorch.org/get-started/locally/) lists available
+wheels). If the reinstall fails (network, unsupported card), OmniVoice keeps
+the default torch build and warns instead of breaking the install.
+
+**3. Manual wheel swap (fallback).** Replace torch with the ROCm wheel
+**after** the first-run install populates the venv:
 
 ```bash
 # From the project directory (source install), into OmniVoice's uv venv.
@@ -154,16 +212,20 @@ uv pip install --reinstall torch torchaudio \
   --index-url https://download.pytorch.org/whl/rocm6.2
 ```
 
-Then relaunch — the Settings → System panel should now report the GPU device
-instead of `cpu`. Verify the wheel sees your card:
+Once a ROCm build of PyTorch is in the venv, detection is automatic —
+`get_best_device()` returns the GPU (ROCm-built PyTorch reports through
+`torch.cuda.is_available()`), and OmniVoice auto-sets
+`HSA_OVERRIDE_GFX_VERSION` for consumer cards whose GFX ID isn't in the
+official ROCm support matrix. Relaunch and the Settings → System panel should
+report the GPU device instead of `cpu`. Verify the wheel sees your card:
 
 ```bash
 uv run python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
 ```
 
 Notes:
-- ROCm is **Linux-only** and **opt-in** — the default cross-platform behavior
-  (CUDA on NVIDIA, MPS on Apple, CPU elsewhere) is unchanged.
+- ROCm is exercised far less than the default CUDA/MPS/CPU paths — it works,
+  but expect rough edges on consumer cards and report what you hit.
 - Unsupported GFX (e.g. some consumer RDNA cards): if it still won't run, set
   `HSA_OVERRIDE_GFX_VERSION` yourself (e.g. `export HSA_OVERRIDE_GFX_VERSION=11.0.0`)
   to the nearest supported architecture before launching.
@@ -171,8 +233,6 @@ Notes:
   native ROCm wheel.
 
 Tracking issue: [#124](https://github.com/debpalash/OmniVoice-Studio/issues/124).
-An installer-integrated, env-var-driven ROCm wheel selection is a planned
-follow-up; until then this manual step is the supported path.
 
 ## Hugging Face token (optional but recommended)
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -17,13 +17,26 @@ working OmniVoice Studio install on macOS (Apple Silicon).
 
 ## Prerequisites
 
+### Using the DMG
+
 - **macOS 12 (Monterey) or newer** — Apple Silicon (Intel: UI only, see the
   note above).
+- **~10 GB free disk** for the app, its Python environment, and model weights.
+
+That's it — GPU acceleration (Apple MPS) is automatic on Apple Silicon, and
+Python, FFmpeg, and the model weights are bundled or bootstrapped by the app
+itself on first launch. No toolchain needed.
+
+### Building from source
+
+Everything above, plus the toolchain:
+
+- **Xcode Command Line Tools** — `xcode-select --install` (includes **git**
+  and the C toolchain; `curl` ships with macOS).
 - **Python 3.11+** — `brew install python@3.11` (or use `pyenv` / the system Python if you already have ≥3.11).
 - **Bun** — `curl -fsSL https://bun.sh/install | bash`.
-- **Xcode Command Line Tools** — `xcode-select --install`.
 - **FFmpeg** (used by the dubbing + capture pipelines) — `brew install ffmpeg`.
-- **Rust / Cargo** (required for building from source only) — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or `brew install rust`.
+- **Rust / Cargo** — `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` or `brew install rust`.
   If you use rustup, reopen the terminal or source `"$HOME/.cargo/env"` before running `bun run desktop-prod`.
 
 Optional but recommended:

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -115,13 +115,22 @@ quarantines every download.
 
 **Fix:** see [macos.md#gatekeeper-quarantine](macos.md#gatekeeper-quarantine).
 
-## 4. AppImage white screen on Fedora 44 / Ubuntu 24.04
+## 4. AppImage white screen / EGL errors (Fedora 44, Ubuntu 24.04+, 26.04)
 
-**Symptom:** the AppImage window opens fully white. No UI ever appears.
+**Symptom:** the AppImage window opens fully white. No UI ever appears. On
+newer distros (Ubuntu 24.04 and later, incl. 26.04) the terminal often shows
+`Could not create default EGL display: EGL_BAD_PARAMETER`.
 
-**Cause:** WebKitGTK 2.44 / 2.46 compositing-mode regression.
+**Cause:** WebKitGTK rendering regressions — the DMA-BUF renderer on modern
+WebKitGTK (2.48+), or the 2.44 / 2.46 compositing mode.
 
-**Fix:** see [linux.md#appimage-white-screen-on-fedora-44--ubuntu-2404](linux.md#appimage-white-screen-on-fedora-44--ubuntu-2404).
+**Fix:** try `WEBKIT_DISABLE_DMABUF_RENDERER=1` first (modern WebKitGTK / the
+EGL error), then `WEBKIT_DISABLE_COMPOSITING_MODE=1` — full walkthrough incl.
+the software-rendering last resort:
+[linux.md#appimage-white-screen-on-fedora-44--ubuntu-2404](linux.md#appimage-white-screen-on-fedora-44--ubuntu-2404).
+
+**Linked issues:** [#62](https://github.com/debpalash/OmniVoice-Studio/issues/62),
+[#961](https://github.com/debpalash/OmniVoice-Studio/issues/961)
 
 ## 5. Windows Triton / torch.compile OOM
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -5,7 +5,24 @@ working OmniVoice Studio install on Windows 10 / 11 (x64).
 
 ## Prerequisites
 
+### Using the MSI installer
+
 - **Windows 10 (21H2 or newer) or Windows 11**, x64.
+- **~10 GB free disk** for the app, its Python environment, and model weights.
+- Optional: an **NVIDIA GPU + driver** for CUDA acceleration — see
+  [GPU support on Windows](#gpu-support). AMD GPUs run CPU-only on Windows.
+
+That's it — Python, FFmpeg, and the model weights are bundled or bootstrapped
+by the app itself on first launch. No toolchain needed.
+
+### Building from source
+
+Everything above, plus the toolchain:
+
+- **Git for Windows** — `winget install --id Git.Git -e`. Needed for
+  `git clone`, and it includes **Git Bash**, which `bun run desktop-prod`
+  uses to run its build-and-launch script. Without it, `desktop-prod` stops
+  with an error telling you to install it.
 - **Python 3.11+** — `winget install Python.Python.3.11` (or download from
   [python.org](https://www.python.org/downloads/windows/)).
 - **Microsoft C++ Build Tools** — required by some PyPI source distributions
@@ -14,12 +31,23 @@ working OmniVoice Studio install on Windows 10 / 11 (x64).
   with the **"Desktop development with C++"** workload checked.
 - **Bun** — `powershell -c "irm bun.sh/install.ps1 | iex"`.
 - **FFmpeg** — `winget install Gyan.FFmpeg`.
-- **Git for Windows** (from-source installs only) — `winget install --id Git.Git -e`.
-  You need it for `git clone` anyway, and it includes **Git Bash**, which
-  `bun run desktop-prod` uses to run its build-and-launch script. Without it,
-  `desktop-prod` stops with an error telling you to install it.
-- **Rust / Cargo** (required for building from source only) — `winget install Rust.Rustup` or download `rustup-init.exe` from [rustup.rs](https://rustup.rs/).
+- **Rust / Cargo** — `winget install Rust.Rustup` or download `rustup-init.exe` from [rustup.rs](https://rustup.rs/).
   After installing Rustup, close and reopen PowerShell before running `bun run desktop-prod`.
+
+## GPU support on Windows
+
+<a id="gpu-support"></a>
+
+**GPU acceleration on Windows is NVIDIA/CUDA-only.** The Windows install
+ships the CUDA build of PyTorch; with an NVIDIA GPU and a regular NVIDIA
+driver it's picked up automatically (no CUDA Toolkit install needed).
+
+**AMD GPUs — including Ryzen / Ryzen AI integrated Radeon graphics — run
+CPU-only on Windows.** ROCm is not supported on Windows: PyTorch publishes no
+Windows ROCm wheels, and OmniVoice's ROCm option is Linux-only. (The Ryzen AI
+NPU is likewise not used.) Everything still works on CPU, just slower. If you
+have an AMD GPU and want GPU acceleration, run OmniVoice on Linux instead —
+see [linux.md — AMD GPU (ROCm)](linux.md#amd-gpu-rocm).
 
 ## Install (from source)
 

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -15,6 +15,11 @@
 # ──────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+# Always run from the repo root — every path below (frontend/, ${TAURI_DIR},
+# …) is repo-root-relative, so invoking the script from any other directory
+# used to mis-resolve them (#962 hardening).
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 APP_ID="com.debpalash.omnivoice-studio"
 TAURI_DIR="frontend/src-tauri"
 APP_NAME="OmniVoice Studio"
@@ -175,13 +180,18 @@ if [ "$SKIP_BUILD" = false ]; then
   # The build creates the bundle successfully, but then may fail trying
   # to sign the updater artifact (no TAURI_SIGNING_PRIVATE_KEY) or to
   # run linuxdeploy. The binary itself is fine — tolerate known errors.
+  # #962: invoke the Tauri CLI via the frontend workspace's `tauri` script,
+  # NOT `bunx tauri`. In the bun workspace monorepo `@tauri-apps/cli` is a
+  # frontend/package.json dependency, and `bunx` resolves by npm package
+  # name — when the locally installed bin isn't exactly where bunx looks it
+  # falls back to fetching the unrelated `tauri` (v1) package from npm and
+  # dies with "could not determine executable to run for package tauri".
+  # `bun run --cwd frontend tauri` always resolves the workspace-local CLI.
   BUILD_LOG=$(mktemp)
-  cd frontend
   set +e
-  bunx tauri build --debug 2>&1 | tee "$BUILD_LOG"
+  bun run --cwd frontend tauri build --debug 2>&1 | tee "$BUILD_LOG"
   BUILD_EXIT=$?
   set -e
-  cd ..
   if [ $BUILD_EXIT -ne 0 ]; then
     # Known-harmless failures:
     #   - Missing TAURI_SIGNING_PRIVATE_KEY (updater signing)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -25,6 +25,10 @@
 # ──────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+# Always run from the repo root — every path below is repo-root-relative
+# (#962 hardening, same as scripts/desktop-prod.sh).
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 APP_ID="com.debpalash.omnivoice-studio"
 TAURI_DIR="frontend/src-tauri"
 APP_NAME="OmniVoice Studio"
@@ -155,13 +159,15 @@ if [ "$SKIP_BUILD" = false ]; then
         [ -d "$APP_BUNDLE" ] && rm -rf "$APP_BUNDLE"
     fi
 
+    # #962: resolve the workspace-local Tauri CLI via the frontend package's
+    # `tauri` script — `bunx tauri` resolves by npm package name and can miss
+    # the workspace bin, then fetches the wrong npm package. Keep in sync
+    # with scripts/desktop-prod.sh.
     BUILD_LOG=$(mktemp)
-    cd frontend
     set +e
-    bunx tauri build --debug >"$BUILD_LOG" 2>&1
+    bun run --cwd frontend tauri build --debug >"$BUILD_LOG" 2>&1
     BUILD_EXIT=$?
     set -e
-    cd ..
 
     if [ $BUILD_EXIT -ne 0 ]; then
         if grep -qi "TAURI_SIGNING_PRIVATE_KEY\|private key\|failed to bundle" "$BUILD_LOG"; then


### PR DESCRIPTION
Fixes three fresh v0.3.10 install reports in one batch.

## #962 — `bun run desktop-prod` broken from source
Root cause: post-monorepo, `@tauri-apps/cli` lives in `frontend/` — `bunx tauri` resolves by npm package name and can fetch the unrelated `tauri` v1 package ("could not determine executable to run"). Fixed as a class: `bun run --cwd frontend tauri …` in `desktop-prod.sh` + `smoke-test.sh`, both scripts now work from any cwd, and the last stray `bunx` in **ci.yml** got the same treatment. Verified: `tauri-cli 2.11.2` resolves from root, `scripts/`, and `/tmp`.

## #961 — Ubuntu 26.04 AppImage white screen
Our docs contradicted our own error taxonomy: they led with `WEBKIT_DISABLE_COMPOSITING_MODE` while `failure.py` prescribes `WEBKIT_DISABLE_DMABUF_RENDERER=1`. Docs rewritten as two cases (WebKitGTK 2.48+ → DMABUF first, with the verbatim `EGL_BAD_PARAMETER` string so searches land; 2.44/2.46 → compositing mode, which AppRun still auto-sets), `LIBGL_ALWAYS_SOFTWARE=1` last resort. Deeplink anchors preserved (hardcoded in both error-docs maps — verified by the anchor-guard tests).

## #960 — honest GPU/prereq documentation
ROCm reality verified in-repo before writing a word: **Linux ROCm is shipped** (first-run Compute card auto-detects `/opt/rocm`, `OMNIVOICE_TORCH_VARIANT=rocm` bootstrap path, `HSA_OVERRIDE_GFX_VERSION` auto-set) — the docs' "planned follow-up" was stale in the *pessimistic* direction. **Windows has no ROCm path at all** — now stated plainly (AMD incl. Ryzen AI = CPU-only there). Prerequisites split installer-vs-source in all three platform docs; git + curl added; README GPU claims aligned ("AMD ROCm (Linux only)").

## Tests
Docs-drift (39 entries) + install-docs validator (3 blocks) + anchor guards: 42 tests green; `bash -n` both scripts; ci.yml YAML-valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed desktop prod and smoke-test launch flows to resolve Tauri from `frontend/` via `bun run --cwd frontend tauri ...`, avoiding incorrect `bunx tauri` resolution.
- Hardened the related shell scripts and CI workflow to use the updated invocation and repo-root-relative execution.
- Refreshed Linux/Windows/macOS install docs to separate installer vs source prerequisites, add missing tooling (`git`, `curl`), and clarify platform-specific GPU support.
- Rewrote AppImage troubleshooting guidance to distinguish newer WebKitGTK DMA-BUF failures from older compositing-mode issues, with `LIBGL_ALWAYS_SOFTWARE=1` as fallback.

```mermaid
flowchart TD
  A[Run desktop-prod / smoke test] --> B[cd to repo root]
  B --> C[Invoke Tauri from frontend with bun run --cwd frontend tauri ...]
  C --> D[Build/launch uses correct workspace package]
  D --> E[Avoid unrelated tauri package resolution]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->