### PR TITLE
fix(setup): first-run network check is mirror-aware and never hard-blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+### Fixed
+
+- **First-run no longer dead-ends behind restricted networks (e.g. China).** The system check probed hardcoded huggingface.co, and any failure locked the Continue button — users behind the Great Firewall were stuck on the very first screen, even when they had already configured a working mirror. The check now probes the Hugging Face endpoint actually in effect, an unreachable endpoint is a warning instead of a blocker (models already on disk keep working offline), and when huggingface.co is blocked but the hf-mirror.com community mirror answers, the wizard says so and offers a one-click mirror switch right on the check screen — no restart needed. (#984)
+
 ## [0.3.11] — 2026-07-05
 
 The multi-language release — dubbing into several languages at once is finally a mature, honest workflow: **"Generate N dubs" now translates each language before rendering it** (with visible per-language progress), **switching languages never destroys your work** (every track keeps its own text, subtitles, and audio cache), completed tracks always show their tabs, and dialogue stops starting seconds early because of footsteps — a community reporter's theory, confirmed exactly. Around it, a reliability sweep driven by same-day field reports: your LLM provider finally survives a restart, SOCKS-proxy users can synthesize again (installed models now load without touching the network at all), timeline boxes are visible on every WebView2 runtime, running from source works again — and when the backend crashes, **it now tells you the exit code and attaches the evidence to your bug report automatically**.

--- a/backend/api/routers/setup/wizard.py
+++ b/backend/api/routers/setup/wizard.py
@@ -168,14 +168,38 @@ def _detect_gpu() -> dict:
     return info
 
 
-def _probe_network(host: str = "huggingface.co", timeout: float = 2.0) -> bool:
+def _probe_network(host: str = "huggingface.co", port: int = 443, timeout: float = 2.0) -> bool:
     """Tiny TCP connect test."""
     import socket
     try:
-        with socket.create_connection((host, 443), timeout=timeout):
+        with socket.create_connection((host, port), timeout=timeout):
             return True
     except Exception:
         return False
+
+
+def _hf_endpoint_host() -> tuple[str, int]:
+    """Host/port of the Hugging Face endpoint actually in effect.
+
+    Mirror-aware: restricted-network users (e.g. behind the Great Firewall)
+    point HF_ENDPOINT at a mirror via Settings → Models → Hugging Face
+    mirror. Probing hardcoded huggingface.co would fail them even when their
+    configured mirror works fine.
+    """
+    try:
+        from core.failure import configured_hf_mirror
+        mirror = configured_hf_mirror()
+    except Exception:
+        mirror = ""
+    if mirror:
+        try:
+            from urllib.parse import urlsplit
+            u = urlsplit(mirror)
+            if u.hostname:
+                return u.hostname, u.port or (80 if u.scheme == "http" else 443)
+        except Exception:
+            pass
+    return "huggingface.co", 443
 
 
 def _ram_gb() -> float:
@@ -400,15 +424,49 @@ def preflight():
             "status": r_status, "detail": r_detail, "fix": r_fix,
         })
 
-    # ── Network
-    net_ok = _probe_network()
+    # ── Network — probes the HF endpoint actually in effect (mirror-aware),
+    # and a dead network is a WARNING, not a blocker. The app is local-first:
+    # already-downloaded models work offline, and a hard fail here dead-ends
+    # restricted-network users (e.g. China, where huggingface.co is blocked)
+    # on the very first screen — before they can reach the mirror setting
+    # that fixes it. Model downloads surface their own actionable errors.
+    net_host, net_port = _hf_endpoint_host()
+    net_ok = _probe_network(net_host, net_port)
+    mirror_reachable = False
+    if not net_ok and net_host == "huggingface.co":
+        # Official endpoint blocked — if the community mirror is reachable,
+        # tell the user exactly which switch unblocks them.
+        mirror_reachable = _probe_network("hf-mirror.com")
+    if net_ok:
+        net_fix = None
+    elif mirror_reachable:
+        net_fix = (
+            "huggingface.co is blocked on this network, but the hf-mirror.com "
+            "community mirror is reachable — apply it below and re-check. "
+            "Model downloads will use the mirror immediately."
+        )
+    elif net_host != "huggingface.co":
+        net_fix = (
+            f"Your configured Hugging Face mirror ({net_host}) is unreachable "
+            "— it may be down or blocked. Pick another mirror or the official "
+            "endpoint below, or continue offline: models already downloaded "
+            "keep working."
+        )
+    else:
+        net_fix = (
+            "Check internet connection, VPN, or corporate firewall whitelist "
+            "for huggingface.co. You can continue — models already downloaded "
+            "keep working offline; new downloads need a connection or a "
+            "mirror (configurable below)."
+        )
     checks.append({
-        "id": "network", "label": "Network (huggingface.co)",
-        "status": "pass" if net_ok else "fail",
-        "detail": "Reachable" if net_ok else "Unreachable on port 443",
-        "fix": None if net_ok else
-            "Check internet connection, VPN, or corporate firewall "
-            "whitelist for huggingface.co.",
+        "id": "network", "label": f"Network ({net_host})",
+        "status": "pass" if net_ok else "warn",
+        "detail": "Reachable" if net_ok else f"Unreachable on port {net_port}",
+        "fix": net_fix,
+        # Frontend affordance hint: the wizard offers the mirror quick-pick
+        # when the endpoint is unreachable (PreflightCheck allows extras).
+        "mirror_reachable": mirror_reachable,
     })
 
     # Aggregate

--- a/docs/downloading-models.md
+++ b/docs/downloading-models.md
@@ -82,8 +82,12 @@ If `huggingface.co` is slow or blocked, point the client at a mirror:
 HF_ENDPOINT=https://hf-mirror.com
 ```
 
-Set it as an environment variable (or in **Settings → environment**) before
-downloading. Caveats:
+Set it in **Settings → Models → Hugging Face mirror** (quick-pick presets
+included), or as an environment variable before launching. On first run, the
+setup wizard offers the same mirror quick-pick right on the system-check
+screen when the endpoint is unreachable — the network check is a warning, not
+a blocker, so an offline or firewalled machine can still finish setup once
+models are available (mirror, or manual download below). Caveats:
 
 - A mirror serves the **classic** download path, **not Xet** — you lose
   chunk-dedup and Xet's parallel fetch, but you gain reachability. On the

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -314,8 +314,10 @@ order:
   files are a common false-positive quarantine), then re-enable.
 - **Connection** — use a stable, direct connection; pause any VPN; avoid
   corporate/school networks.
-- **Region mirror** — if `huggingface.co` is slow/blocked where you are, set a
-  mirror **before** launching and relaunch:
+- **Region mirror** — if `huggingface.co` is slow/blocked where you are, pick a
+  mirror in-app (**Settings → Models → Hugging Face mirror**, or the quick-pick
+  the first-run system check offers when the endpoint is unreachable), or set
+  it as an env var before launching and relaunch:
   - macOS/Linux: `export HF_ENDPOINT=https://hf-mirror.com`
   - Windows (PowerShell): `[Environment]::SetEnvironmentVariable("HF_ENDPOINT","https://hf-mirror.com","User")`
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1291,7 +1291,11 @@
     "try_dictation": "Try dictation",
     "next_try_dictation": "Next: Try dictation",
     "step_aria": "Step {{num}}: {{label}}",
-    "step_completed": "completed"
+    "step_completed": "completed",
+    "mirror_rescue_title": "Can't reach Hugging Face? Use a mirror",
+    "mirror_rescue_hint": "Model downloads switch to the mirror immediately — no restart needed during setup. hf-mirror.com is the community mirror commonly used in China.",
+    "mirror_apply": "Apply & re-check",
+    "mirror_apply_error": "Could not save the mirror setting."
   },
   "donate": {
     "title": "Support",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1144,7 +1144,11 @@
     "next_try_dictation": "下一步：试用听写",
     "step_aria": "第 {{num}} 步:{{label}}",
     "step_completed": "已完成",
-    "cache_label": "模型缓存"
+    "cache_label": "模型缓存",
+    "mirror_rescue_title": "无法连接 Hugging Face？使用镜像",
+    "mirror_rescue_hint": "模型下载会立即切换到镜像地址，安装过程无需重启。hf-mirror.com 是国内常用的社区镜像。",
+    "mirror_apply": "应用并重新检查",
+    "mirror_apply_error": "镜像设置保存失败。"
   },
   "donate": {
     "title": "支持项目",

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Loader, RotateCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSetupStatus, usePreflight } from '../api/hooks';
+import { apiJson, apiFetch } from '../api/client';
 import WizardLibrary from '../components/WizardLibrary';
 import HfTokenCard from '../components/HfTokenCard';
 import DictationDemo from '../components/DictationDemo';
@@ -133,6 +134,101 @@ function PreflightPanel({ report, loading, onRecheck }) {
   );
 }
 
+/* ── Mirror rescue — restricted-network escape hatch on step 0 ─────────── */
+
+/**
+ * Shown when the network preflight check can't reach the Hugging Face
+ * endpoint. Users behind restricted networks (e.g. China, where
+ * huggingface.co is blocked) can't reach Settings yet — the wizard gates the
+ * studio — so the mirror quick-pick has to live right here. PUT /hf-mirror
+ * takes effect immediately for downloads (no restart during setup).
+ */
+function MirrorRescue({ onApplied }) {
+  const { t } = useTranslation();
+  const [presets, setPresets] = useState([]);
+  const [url, setUrl] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    apiJson('/api/settings/hf-mirror')
+      .then((d) => {
+        if (!alive) return;
+        setPresets((d?.presets || []).filter((p) => p.url));
+        setUrl(d?.configured || '');
+      })
+      .catch(() => {
+        /* endpoint unavailable — keep the free-text input usable */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const apply = async (value) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch('/api/settings/hf-mirror', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: value }),
+      });
+      setUrl(value);
+      onApplied();
+    } catch (e) {
+      setError(e?.message || t('setup.mirror_apply_error'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 flex flex-col gap-1.5 rounded-md border border-border px-3 py-2.5">
+      <span className="text-sm font-semibold">{t('setup.mirror_rescue_title')}</span>
+      <span className="text-xs leading-snug text-fg-muted">{t('setup.mirror_rescue_hint')}</span>
+      {error && (
+        <span className="text-xs text-danger" role="alert">
+          {error}
+        </span>
+      )}
+      <div className="mt-1 flex flex-wrap items-center gap-2">
+        {presets.map((p) => (
+          <Button
+            key={p.url}
+            variant="preset"
+            size="sm"
+            disabled={saving}
+            onClick={() => apply(p.url)}
+            data-testid={`wizard-mirror-${p.url}`}
+          >
+            {p.label}
+          </Button>
+        ))}
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://hf-mirror.com"
+          className="min-w-[220px] flex-1 rounded border border-border bg-transparent px-2 py-1 font-mono text-xs text-fg"
+          data-testid="wizard-mirror-url"
+        />
+        <Button
+          variant="subtle"
+          size="sm"
+          loading={saving}
+          disabled={saving || !url.trim()}
+          onClick={() => apply(url.trim())}
+          data-testid="wizard-mirror-apply"
+        >
+          {t('setup.mirror_apply')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 /* ── LED stepper rail ──────────────────────────────────────────────────── */
 
 function StepperNav({ step, maxUnlockedStep, onStep }) {
@@ -241,6 +337,10 @@ export default function SetupWizard({ onReady }) {
 
   const modelsReady = !!status?.models_ready;
   const preflightOk = !!pre?.ok;
+  // Offer the mirror quick-pick whenever the HF endpoint probe didn't pass —
+  // the wizard is the only surface these users can reach (Settings is gated
+  // behind setup), so the escape hatch must live here.
+  const networkDown = (pre?.checks || []).some((c) => c.id === 'network' && c.status !== 'pass');
 
   const cachePath = status?.hf_cache_dir || '~/.cache/huggingface';
 
@@ -288,6 +388,7 @@ export default function SetupWizard({ onReady }) {
           <div className="flex min-h-0 flex-auto flex-col gap-3" key="step-0">
             <div className="fr-rise min-h-0 flex-1 overflow-y-auto" style={{ '--rise': 1 }}>
               <PreflightPanel report={pre} loading={preLoading} onRecheck={recheckPreflight} />
+              {networkDown && <MirrorRescue onApplied={recheckPreflight} />}
             </div>
             <div
               className="fr-rise flex shrink-0 items-center justify-between gap-4 border-t border-border pt-3"

--- a/tests/test_setup_preflight.py
+++ b/tests/test_setup_preflight.py
@@ -269,6 +269,63 @@ def test_preflight_network_handles_offline():
     assert _probe_network(host="10.255.255.1", timeout=0.3) is False
 
 
+def test_preflight_network_unreachable_is_warn_not_blocker():
+    """A dead network must NOT hard-block the wizard (restricted-network
+    first-run, e.g. China where huggingface.co is blocked): the check is a
+    warning and the aggregate `ok` is unaffected by it."""
+    from api.routers.setup import wizard as setup_mod
+
+    with patch.object(setup_mod, "_probe_network", return_value=False):
+        body = client_factory().get("/setup/preflight").json()
+
+    net = next(c for c in body["checks"] if c["id"] == "network")
+    assert net["status"] == "warn", net
+    assert "continue" in (net["fix"] or "").lower()
+    # ok must still equal "no fail among checks" — network can't be the fail.
+    any_fail = any(c["status"] == "fail" for c in body["checks"])
+    assert body["ok"] is (not any_fail)
+
+
+def test_preflight_network_probes_configured_mirror():
+    """With HF_ENDPOINT set, the probe targets the mirror host — not the
+    hardcoded official host that may be blocked on the user's network."""
+    import os
+    from api.routers.setup import wizard as setup_mod
+
+    seen_hosts: list[str] = []
+
+    def fake_probe(host="huggingface.co", port=443, timeout=2.0):
+        seen_hosts.append(host)
+        return True
+
+    with patch.dict(os.environ, {"HF_ENDPOINT": "https://mirror.example.test"}), \
+         patch.object(setup_mod, "_probe_network", side_effect=fake_probe):
+        body = client_factory().get("/setup/preflight").json()
+
+    net = next(c for c in body["checks"] if c["id"] == "network")
+    assert "mirror.example.test" in net["label"]
+    assert net["status"] == "pass"
+    assert "mirror.example.test" in seen_hosts
+
+
+def test_preflight_network_suggests_reachable_mirror():
+    """Official endpoint blocked but hf-mirror.com reachable → the fix names
+    the mirror and the check carries mirror_reachable=True for the wizard's
+    quick-pick affordance."""
+    from api.routers.setup import wizard as setup_mod
+
+    def fake_probe(host="huggingface.co", port=443, timeout=2.0):
+        return host == "hf-mirror.com"
+
+    with patch.object(setup_mod, "_probe_network", side_effect=fake_probe):
+        body = client_factory().get("/setup/preflight").json()
+
+    net = next(c for c in body["checks"] if c["id"] == "network")
+    assert net["status"] == "warn"
+    assert net.get("mirror_reachable") is True
+    assert "hf-mirror.com" in (net["fix"] or "")
+
+
 # ── RAM thresholds ───────────────────────────────────────────────────────
 
 def test_preflight_ram_fail_threshold():


### PR DESCRIPTION
## The wall

A user in China reported (Discord `#general`) that they cannot get past the very first screen: the Launchpad system check probes hardcoded `huggingface.co:443`, the GFW blocks it, the check reports **fail**, and any fail disables the Continue button. There is no skip, and Settings — where the existing Hugging Face mirror quick-pick lives — is unreachable because the wizard gates the studio. A first-run dead end.

Worse: a user who had already configured `HF_ENDPOINT=https://hf-mirror.com` (the documented escape) **still failed preflight**, because the probe ignored the mirror and checked the blocked official host.

## The fix

- **Mirror-aware probe** — `_probe_network` now targets the HF endpoint actually in effect (`configured_hf_mirror()`: `HF_ENDPOINT` env / `hf_endpoint` pref), honoring the URL's port. The check label names the probed host.
- **Warn, not fail** — an unreachable endpoint is a warning. The app is local-first: cached models work offline, and model downloads surface their own actionable errors. Continue reads "Continue with warnings" instead of locking.
- **Actionable rescue** — when `huggingface.co` is blocked, the backend also probes `hf-mirror.com` and, if reachable, says exactly that. The wizard renders an inline **mirror quick-pick** (presets from `GET /hf-mirror` + custom URL) that applies via `PUT /hf-mirror` — which takes effect immediately for downloads (no restart during setup) — then re-runs the preflight.
- **i18n** — new wizard strings in `en` + `zh-CN` (the audience that hit this).
- **Docs** — `docs/downloading-models.md` + `docs/install/troubleshooting.md` now describe the in-app mirror paths.

## Regression tests

`tests/test_setup_preflight.py`: network-unreachable → `warn` and never flips aggregate `ok`; probe follows `HF_ENDPOINT`; blocked-official + reachable-mirror → fix text names hf-mirror.com and the check carries `mirror_reachable` for the UI. All 20 pass (5 platform skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- First-run setup now probes the configured Hugging Face endpoint instead of always checking `huggingface.co:443`.
- Network failures are downgraded to warnings, so setup can continue for offline use when models are already available.
- If `huggingface.co` is blocked but `hf-mirror.com` works, setup now surfaces that mirror as an immediate recovery option.
- Added a setup wizard mirror rescue panel with presets, custom URL entry, save/apply, and automatic re-check.
- Updated docs, changelog, locale strings, and regression tests for the new mirror-aware flow.

## UI sketch
Before:
```text
Setup Wizard
└─ Preflight checks
   └─ Network check (blocker)
```

After:
```text
Setup Wizard
└─ Preflight checks
   ├─ Network check (warning if unreachable)
   └─ Mirror Rescue panel (when blocked)
      ├─ Preset mirror picker
      ├─ Custom mirror URL
      └─ Apply & re-check
```

## Flow
```mermaid
flowchart TD
  A[Run setup preflight] --> B[Determine configured HF endpoint]
  B --> C[Probe endpoint host:port]
  C -->|Reachable| D[Network check passes]
  C -->|Unreachable| E[Mark warning, not blocker]
  E --> F{Official endpoint blocked?}
  F -->|Yes| G[Probe hf-mirror.com]
  G -->|Reachable| H[Show mirror available + offer switch]
  G -->|Unreachable| I[Show offline/connection warning]
  H --> J[Apply mirror]
  J --> K[Re-run preflight]
```

## Testing
- Added coverage for warning-only network failures.
- Added coverage for probing configured mirrors.
- Added coverage for suggesting a reachable mirror when the official endpoint is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->