### PR TITLE
test(voice-design): lock in RTL/non-Latin script handling for the instruct field (#980)

### DIFF
--- a/frontend/src/utils/voiceInstruct.test.js
+++ b/frontend/src/utils/voiceInstruct.test.js
@@ -52,6 +52,22 @@ describe('buildDesignInstruct', () => {
     expect(unsupported).toEqual(['sôi nổi']);
   });
 
+  it('clone path (#980): RTL/non-Latin script (Hebrew) is dropped like any other unsupported free-text, not a crash', () => {
+    // #612 covered Latin-script-with-diacritics (Vietnamese); #980 was the same
+    // failure mode with a right-to-left script — a name typed into the Style
+    // field must degrade the same way (dropped client-side + unsupported bucket),
+    // never round-trip to the backend's 400.
+    const { instruct, unsupported } = buildDesignInstruct({}, 'שמואל');
+    expect(instruct).toBe('');
+    expect(unsupported).toEqual(['שמואל']);
+  });
+
+  it('clone path (#980): RTL script mixed with a valid tag keeps the tag, drops the rest', () => {
+    const { instruct, unsupported } = buildDesignInstruct({}, 'whisper, שמואל');
+    expect(instruct).toBe('whisper');
+    expect(unsupported).toEqual(['שמואל']);
+  });
+
   it('buckets a valid tag outranked by a dropdown as a duplicate, not unsupported (#114)', () => {
     const { instruct, unsupported, duplicates } = buildDesignInstruct(
       { Pitch: 'low pitch' },


### PR DESCRIPTION
## Status: already fixed, adding regression coverage

Issue #980 reported a raw 400 ("Unsupported instruct items found in שמואל") from typing Hebrew text into the Clone tab's Style field. Investigated the full chain — this is the exact same failure class as #612 (Vietnamese free-text), and was already fixed when #612 landed in commit `10b9d69` (`fix(synthesize): validate clone-path instruct client-side so non-EN/ZH prose can't 400 (#612) (#658)`), first released in **v0.3.8**. `buildDesignInstruct()` drops any unsupported free-text client-side (regardless of script) before it ever reaches the backend's validator — the reporter was on **v0.3.7**, which predates the fix.

## What this PR adds

No behavior change — the existing Vietnamese test case (`frontend/src/utils/voiceInstruct.test.js`) only exercised Latin-script-with-diacritics; nothing exercised a right-to-left / non-Latin script. Two new cases lock in that Hebrew text is dropped the same way: alone, and mixed with a valid tag.

## Tests

`bunx vitest run src/utils/voiceInstruct.test.js`: 16 passed (14 existing + 2 new).

I'll close #980 referencing this once merged, since the actual bug is already resolved on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added regression tests for `buildDesignInstruct` to cover RTL/non-Latin free-text handling in the voice design instruct field.

```mermaid
flowchart LR
  A[Style field input] --> B{Contains supported tags?}
  B -->|Yes| C[Keep valid tags in instruct]
  B -->|No| D[Drop unsupported free-text]
  D --> E[Record text in unsupported]
  C --> E
```

Covered cases:
- Hebrew text alone is stripped from `instruct` and reported as `unsupported`
- Mixed input like `whisper, שמואל` keeps `whisper` and moves the Hebrew text to `unsupported`

No production code was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->