### PR TITLE
docs(linux): stop advertising a .deb package that isn't published

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ The eight headliners — and twelve more waiting under the fold.
   <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/macOS-DMG_(Apple_Silicon)-000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS DMG" /></a>
   <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Windows-MSI_(x64)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows MSI" /></a>
   <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Linux-AppImage_(x64)-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download Linux AppImage" /></a>
-  <a href="https://github.com/debpalash/OmniVoice-Studio/releases/latest"><img src="https://img.shields.io/badge/Debian-.deb-A81D33?style=for-the-badge&logo=debian&logoColor=white" alt="Download Debian .deb" /></a>
   <br/>
   <sub><b>macOS:</b> first launch needs a one-time approval — right-click → <b>Open</b> (or System Settings → Privacy &amp; Security → <b>"Open Anyway"</b> on macOS 15). No Terminal needed. <a href="docs/install/macos.md#gatekeeper-quarantine">Why?</a></sub>
   <br/>

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -5,7 +5,7 @@ working OmniVoice Studio install on a Debian / Ubuntu / Fedora / Arch host.
 
 ## Prerequisites
 
-### Using the AppImage or .deb
+### Using the AppImage
 
 - **Linux x86_64** with a desktop session (X11 or Wayland) capable of running
   a Tauri / WebKitGTK app.
@@ -73,12 +73,15 @@ No FUSE? Use `--appimage-extract-and-run`:
 ./OmniVoice.Studio_*.AppImage --appimage-extract-and-run
 ```
 
-## Install (.deb)
+## .deb package
 
-```bash
-sudo apt install ./OmniVoice.Studio_*.amd64.deb
-omnivoice-studio
-```
+Not currently published: `.deb` bundling is disabled in the release pipeline
+because of a `tauri-cli` bug (`Failed to create control scripts`) — see the
+comment in `.github/workflows/release.yml` for the tracking note. The
+AppImage above is the supported Linux install path until a `tauri-cli`
+version resolves it. `apt install`-able `.deb`s shipped before v0.3 (see
+[.deb ffprobe conflict](#deb-ffprobe-conflict) below) if you're upgrading
+from one of those.
 
 The desktop app uses these canonical paths (kept in sync with
 `scripts/desktop-prod.sh` by the docs-drift CI gate):


### PR DESCRIPTION
## The gap

README's Quickstart badges include a **"Download Debian .deb"** button linking straight to the releases page — but `.deb` bundling was deliberately dropped from `release.yml` (tauri-cli bug: `Failed to create control scripts`, tracked in a comment there) and **no release has ever shipped one**. `docs/install/linux.md` also has a full `## Install (.deb)` section with install commands for a file that doesn't exist in any release's assets.

Found while investigating #961 (Ubuntu white screen) — a commenter there noted "The .deb is not available in the assets of the project" while troubleshooting, which I confirmed directly against `gh release view v0.3.11 --json assets`: AppImage only for Linux.

## The fix

- Removed the phantom .deb badge from README's Quickstart.
- `docs/install/linux.md`'s `.deb` section now honestly states it's unavailable pending a tauri-cli fix, points to the AppImage as the supported path, and links the existing tracking comment. The historical pre-v0.3 `.deb` upgrade note (ffprobe path conflict) stays, since that's still relevant to anyone who installed one of those old packages.

Not attempting to re-enable `.deb` bundling itself in this PR — that's a CI pipeline change with real risk (a broken release build) that deserves its own verification cycle, not bundled into a docs fix.

## Verification

`scripts/check-docs-drift.py`: OK — 39 inventory entries verified. `tests/scripts/test_check_docs_drift.py`: 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated Linux install documentation to stop advertising an unavailable Debian `.deb` package.

- Removed the Debian `.deb` badge/link from the README quickstart.
- Reworked the Linux install guide to make AppImage the supported Linux install path.
- Replaced the old `.deb` install section with a note that `.deb` bundling is currently disabled in the release pipeline due to a `tauri-cli` issue, with a link to the existing tracking note.
- Preserved the historical note about pre-v0.3 `.deb` upgrades and the `ffprobe` path conflict.

Docs-only change; `.deb` packaging is not re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->