### PR TITLE
fix(engines): nemo-parakeet install hint stops recommending a shared-venv-breaking pip install

### DIFF
--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -1700,7 +1700,16 @@ _INSTALL_HINTS: dict[str, str] = {
     "faster-whisper":  "pip install faster-whisper  (CTranslate2; cross-platform, CUDA or CPU)",
     "mlx-whisper":     "pip install mlx-whisper  (Apple Silicon only)",
     "pytorch-whisper": "Bundled with transformers — no extra install (CUDA/MPS/CPU)",
-    "nemo-parakeet":   "pip install nemo_toolkit[asr]  (NVIDIA Parakeet; CUDA or CPU)",
+    "nemo-parakeet":   (
+        "No safe install path in this app yet — nemo_toolkit's ASR extras pin "
+        "transformers>=4.57,<4.58, which conflicts with OmniVoice's own "
+        "transformers>=5.3 requirement and WILL break the backend "
+        "(ImportError on startup) if installed into this shared venv. Do NOT "
+        "install nemo_toolkit here. If you want to try Parakeet TDT, set it "
+        "up in a separate/dedicated Python environment — not the one "
+        "OmniVoice manages; in-app isolation for this engine is tracked "
+        "separately."
+    ),
     "moonshine":       "pip install useful-moonshine  (edge/CPU-optimized ASR)",
     "funasr":          "pip install funasr  (SenseVoiceSmall + FSMN-VAD; CUDA or CPU)",
     "sherpa-onnx-asr": "uv add sherpa-onnx  (ONNX live dictation; CPU, cross-platform)",

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -242,6 +242,15 @@ for the dedicated CosyVoice path.
 
 **Linked issue:** [#55](https://github.com/debpalash/OmniVoice-Studio/issues/55)
 
+**Same class, ASR side:** the `nemo-parakeet` ASR engine has the identical
+problem and currently has **no safe install path** at all — `nemo_toolkit[asr]`
+hard-pins `transformers>=4.57,<4.58`, which is unsatisfiable alongside
+OmniVoice's own `transformers>=5.3` requirement. Installing it into the
+shared venv breaks the backend outright. Do not `pip install nemo_toolkit`
+into OmniVoice's environment; if you want to try it, use a separate Python
+environment. Isolated-venv support for this engine (matching CosyVoice/
+dots-tts) is tracked in [#974](https://github.com/debpalash/OmniVoice-Studio/issues/974).
+
 ## 12. CUDA PyTorch wheel download fails on first run
 
 **Symptom:** first-run setup stops at **Installing dependencies** with a failure

--- a/tests/test_nemo_parakeet_install_hint.py
+++ b/tests/test_nemo_parakeet_install_hint.py
@@ -1,0 +1,47 @@
+"""Regression test for issue #974.
+
+The nemo-parakeet install hint used to tell users to run
+`pip install nemo_toolkit[asr]` directly into OmniVoice's shared venv.
+nemo_toolkit[asr]==2.7.3 hard-pins transformers>=4.57,<4.58, which is
+UNSATISFIABLE alongside the app's own transformers>=5.3 requirement (needed
+by omnivoice/models/omnivoice.py for HiggsAudioV2TokenizerModel). A user who
+followed the old hint ended up with a backend that wouldn't even start
+(ImportError: cannot import name 'HiggsAudioV2TokenizerModel').
+
+nemo-parakeet has no isolated-venv option yet (unlike dots-tts /
+moss-tts-v15 / confucius4-tts, which do), so the hint must not imply a safe
+one-line fix — it must say plainly that installing into the shared venv
+will break the backend.
+"""
+from __future__ import annotations
+
+from services.asr_backend import _INSTALL_HINTS, list_backends
+
+
+def test_nemo_parakeet_hint_does_not_recommend_shared_venv_install():
+    hint = _INSTALL_HINTS["nemo-parakeet"]
+    # The literal old, destructive recommendation must never reappear.
+    assert "pip install nemo_toolkit[asr]" not in hint, (
+        f"nemo-parakeet install_hint regressed to the shared-venv-breaking "
+        f"bare pip install: {hint!r}"
+    )
+
+
+def test_nemo_parakeet_hint_warns_about_transformers_conflict():
+    hint = _INSTALL_HINTS["nemo-parakeet"]
+    assert "transformers" in hint
+    lowered = hint.lower()
+    assert "conflict" in lowered or "break" in lowered
+
+
+def test_nemo_parakeet_hint_does_not_imply_isolated_venv_exists():
+    """Unlike dots-tts/moss-tts-v15/confucius4-tts, nemo-parakeet has no
+    isolated-venv env var yet — the hint must not invent one."""
+    hint = _INSTALL_HINTS["nemo-parakeet"]
+    assert "OMNIVOICE_NEMO_PARAKEET_DIR" not in hint
+
+
+def test_nemo_parakeet_hint_surfaced_in_list_backends():
+    rows = list_backends()
+    row = next(r for r in rows if r["id"] == "nemo-parakeet")
+    assert row["install_hint"] == _INSTALL_HINTS["nemo-parakeet"]


### PR DESCRIPTION
## The bug

Issue #974: the Engines page's install hint for NVIDIA NeMo's Parakeet TDT ASR engine told users to run `pip install nemo_toolkit[asr]`. `nemo_toolkit[asr]==2.7.3` hard-pins `transformers>=4.57,<4.58` — unsatisfiable alongside OmniVoice's own `transformers>=5.3` requirement (needed by `omnivoice/models/omnivoice.py` for `HiggsAudioV2TokenizerModel`). A user who followed the in-app hint got a backend that wouldn't even start: `ImportError: cannot import name 'HiggsAudioV2TokenizerModel'`. The install itself reported success — the breakage only showed up on the next restart.

## The fix

`_INSTALL_HINTS["nemo-parakeet"]` in `backend/services/asr_backend.py` now states plainly that installing into the shared venv **will** break the backend, names the exact conflict, and tells users to use a separate/dedicated Python environment — without implying a safe one-line fix exists, and without inventing an isolated-venv env var (unlike dots-tts/moss-tts-v15/confucius4-tts, nemo-parakeet has no isolated-venv option yet — that's a real, larger follow-up, intentionally out of scope here to ship the safety fix fast).

One sentence added to `docs/install/troubleshooting.md`'s existing engine-venv-clash section pointing at the same class of problem on the ASR side.

## Regression test

New `tests/test_nemo_parakeet_install_hint.py` (4 tests): the hint never again contains the literal `pip install nemo_toolkit[asr]` string, it names the transformers conflict, it doesn't imply a nonexistent isolated-venv env var, and it's correctly surfaced through `list_backends()`. Also ran the broader ASR/registry/CJK suites (81 passed) to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Updated the `nemo-parakeet` ASR install hint to replace the old shared-venv `pip install nemo_toolkit[asr]` guidance with a warning that this path breaks the backend due to `transformers` dependency conflicts.
- Added troubleshooting docs for the ASR/venv conflict, steering users toward a separate Python environment.
- Added regression tests to ensure the unsafe install string stays out, the transformers conflict is mentioned, no nonexistent isolated-venv option is implied, and `list_backends()` surfaces the expected hint.

## Behavior flow
```mermaid
flowchart TD
  A[User opens Engines page] --> B[Sees nemo-parakeet install hint]
  B --> C{Install in shared OmniVoice venv?}
  C -->|Yes| D[Warning: breaks backend due to transformers conflict]
  C -->|No| E[Use a separate Python environment]
  D --> F[Refer to troubleshooting docs]
  E --> F
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->