### PR TITLE
fix(engines): mlx-audio no longer crashes on unsupported languages

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -143,6 +143,28 @@ def _apply_effect_chain(audio_out, sample_rate, effect_preset, *, skip_mastering
     return normalize_audio(audio_out, target_dBFS=-2.0)
 
 
+def _safe_exc_text(e: BaseException) -> str:
+    """``f"{type(e).__name__}: {e}"`` — the house style used for
+    unrecognized-error formatting throughout the backend (grep
+    ``type(e).__name__`` in settings.py / asr_backend.py / model_manager.py
+    / engines.py) — with a guard against leaking a raw container repr.
+
+    #977: an AssertionError raised deep inside a vendored dependency
+    (mlx-audio's Kokoro pipeline) had ``.args`` shaped like
+    ``('du', {'a': 'American English', ...})`` — a tuple containing a dict.
+    ``str(e)`` on that renders the WHOLE table straight into the user-facing
+    message. Any engine's ``generate()`` can raise something shaped like
+    this (not just Kokoro), so guard generically: if any element of
+    ``e.args`` is a container rather than a plain string, don't interpolate
+    ``str(e)`` at all — name the exception type and point at the log
+    instead.
+    """
+    args = getattr(e, "args", ())
+    if any(isinstance(a, (dict, list, tuple, set, frozenset)) for a in args):
+        return f"{type(e).__name__} — see Settings → Logs → Backend for details"
+    return f"{type(e).__name__}: {e}"
+
+
 def _exception_chain(e):
     """Yield ``e`` plus every ``__cause__``/``__context__`` beneath it
     (cycle-safe). Engines and hub libraries routinely wrap the original
@@ -412,7 +434,7 @@ def _oom_friendly_reraise(e):
     raise RuntimeError(
         f"TTS engine stopped mid-generation with an error OmniVoice doesn't "
         f"recognize. Retry once; if it keeps failing, please report it with "
-        f"the full trace. Underlying error: {e}"
+        f"the full trace. Underlying error: {_safe_exc_text(e)}"
     ) from e
 
 
@@ -934,7 +956,7 @@ async def generate_speech(
             status_code=500,
             detail=(
                 f"Couldn't synthesize audio. See Settings → Logs → Backend for the full trace. "
-                f"Underlying error: {e}"
+                f"Underlying error: {_safe_exc_text(e)}"
             ),
         )
     finally:

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -691,6 +691,54 @@ class KittenTTSBackend(TTSBackend):
 # ── MLX-Audio (mac-ARM engine multiplexer) ──────────────────────────────────
 
 
+# #977: Kokoro's own ALIASES table (mlx_audio.tts.models.kokoro.pipeline) only
+# recognizes ISO-ish tokens ("en", "es", "fr-fr", "pt-br", …) — it has no idea
+# what a full language name is. OmniVoice's `language` kwarg is normally a
+# full display name from frontend/src/languages.json (e.g. "Dutch",
+# "Spanish"), forwarded verbatim by the frontend and by
+# `OmniVoiceBackend.generate()`. Translate the subset Kokoro actually
+# supports to the ISO token its own ALIASES expects; a caller that already
+# passes an ISO code (or one of Kokoro's own single-letter codes) is
+# resolved unchanged by `resolve_kokoro_lang_code()` below.
+_KOKORO_ISO_BY_FULL_NAME = {
+    "english": "en",
+    "spanish": "es",
+    "french": "fr",
+    "hindi": "hi",
+    "italian": "it",
+    "portuguese": "pt",
+    "japanese": "ja",
+    "chinese": "zh",
+}
+
+
+def resolve_kokoro_lang_code(language: str) -> str:
+    """Map a full language name / ISO code to Kokoro's single-letter
+    `lang_code`, against the AUTHORITATIVE table read from the installed
+    mlx-audio package (never a hardcoded guess — the vendored table is the
+    only source of truth and can change across mlx-audio versions).
+
+    Raises ``ValueError`` for anything Kokoro doesn't support, naming what
+    it *does* support — instead of forwarding a bogus code into Kokoro's
+    `assert lang_code in LANG_CODES`, which crashes with an unreadable
+    ``(lang_code, LANG_CODES)`` tuple/dict repr (#977).
+    """
+    from mlx_audio.tts.models.kokoro.pipeline import ALIASES, LANG_CODES
+
+    key = language.strip().lower()
+    iso = _KOKORO_ISO_BY_FULL_NAME.get(key, key)
+    code = ALIASES.get(iso, iso)
+    if code not in LANG_CODES:
+        supported = ", ".join(sorted(name.title() for name in _KOKORO_ISO_BY_FULL_NAME))
+        raise ValueError(
+            f"mlx-audio's Kokoro model (mlx-community/Kokoro-82M-bf16) doesn't "
+            f"support language={language!r}. Kokoro supports: {supported}. "
+            f"Pick one of those, leave language as 'Auto', or switch to a "
+            f"multilingual engine (e.g. OmniVoice) for other languages."
+        )
+    return code
+
+
 class MLXAudioBackend(TTSBackend):
     """Blaizzy/mlx-audio — Apple-Silicon-only wrapper over 14+ TTS engines
     (Kokoro, CSM, Dia, Qwen3-TTS, Chatterbox, MeloTTS, OuteTTS, Spark,
@@ -802,7 +850,25 @@ class MLXAudioBackend(TTSBackend):
         kwargs = {"text": text, "speed": speed}
         if voice:     kwargs["voice"] = voice
         if ref_audio: kwargs["ref_audio"] = ref_audio
-        if language:  kwargs["lang_code"] = language[:2].lower()
+        if language and language != "Auto":
+            if self._model_id == self.CURATED_MODELS.get("kokoro"):
+                # Kokoro's vendored pipeline hard-asserts `lang_code` against
+                # its own single-letter table — a bogus code crashes with an
+                # unreadable AssertionError instead of failing cleanly
+                # (#977). Resolve against the authoritative installed table
+                # instead of guessing via `language[:2]`.
+                kwargs["lang_code"] = resolve_kokoro_lang_code(language)
+            else:
+                # `lang_code`-as-2-letter-truncation is Kokoro's own
+                # convention, not mlx-audio's in general — other curated
+                # models either ignore unrecognized kwargs (CSM/Dia/OuteTTS
+                # accept **kwargs and drop it) or expect something else
+                # entirely (Qwen3-TTS's own docstring: "lang_code: Language
+                # code (auto, chinese, english, etc.)" — a full name, not a
+                # 2-letter code). Kokoro's strict validation doesn't apply to
+                # them, so don't reject a language that's valid for whatever
+                # model is actually active.
+                kwargs["lang_code"] = language[:2].lower()
 
         pieces = []
         try:

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -238,3 +238,96 @@ def test_hf_retry_is_single_shot():
     with pytest.raises(RuntimeError):
         tts_backend._retry_once_with_fresh_hf_client(loader, what="test")
     assert len(calls) == 2
+
+
+# ── #977: MLX-Audio Kokoro language-code resolution ─────────────────────────
+# Kokoro's own vendored pipeline (mlx_audio.tts.models.kokoro.pipeline)
+# hard-asserts `lang_code` against a fixed single-letter table. The old code
+# blindly truncated a full language name — "Dutch"[:2].lower() == "du" — into
+# that assert, crashing with an unreadable `(lang_code, LANG_CODES)` repr
+# instead of a clean error. The resolution tests need the real mlx-audio
+# package (Apple-Silicon-only) since they validate against ITS installed
+# table, never a hardcoded guess; they skip cleanly where mlx-audio isn't
+# installed (every non-macOS-ARM CI runner).
+
+
+def test_mlx_audio_kokoro_resolves_supported_language_names():
+    pytest.importorskip("mlx_audio", reason="mlx-audio is Apple-Silicon-only")
+    resolve = tts_backend.resolve_kokoro_lang_code
+    assert resolve("English") == "a"
+    assert resolve("Spanish") == "e"
+    assert resolve("French") == "f"
+    assert resolve("Hindi") == "h"
+    assert resolve("Italian") == "i"
+    assert resolve("Portuguese") == "p"
+    assert resolve("Japanese") == "j"
+    assert resolve("Chinese") == "z"
+    # Some callers may already pass an ISO code — those resolve unchanged
+    # through Kokoro's own ALIASES table, not just our full-name map.
+    assert resolve("es") == "e"
+    assert resolve("en-gb") == "b"
+
+
+@pytest.mark.parametrize("language", ["Dutch", "German"])
+def test_mlx_audio_kokoro_rejects_unsupported_language_cleanly(language):
+    # The literal #977 report case ("Dutch") plus one more Kokoro doesn't
+    # support ("German") — neither's first two letters happen to alias to a
+    # valid Kokoro code, so both used to crash.
+    pytest.importorskip("mlx_audio", reason="mlx-audio is Apple-Silicon-only")
+    with pytest.raises(ValueError) as ei:
+        tts_backend.resolve_kokoro_lang_code(language)
+    msg = str(ei.value)
+    assert language in msg
+    assert "Kokoro" in msg
+    assert "English" in msg  # names what Kokoro DOES support
+
+
+def test_mlx_audio_generate_rejects_unsupported_kokoro_language_before_calling_model():
+    pytest.importorskip("mlx_audio", reason="mlx-audio is Apple-Silicon-only")
+    backend = tts_backend.MLXAudioBackend()
+    backend._model_id = backend.CURATED_MODELS["kokoro"]
+    backend._ensure_loaded = lambda: None  # never actually load the model
+
+    def _boom_generate(**kw):
+        raise AssertionError("model.generate() must not run for a rejected language")
+
+    backend._model = types.SimpleNamespace(generate=_boom_generate)
+
+    with pytest.raises(ValueError, match="Dutch"):
+        backend.generate("hello", language="Dutch")
+
+
+def test_mlx_audio_generate_auto_language_skips_lang_code_entirely():
+    # Matches the "Auto" convention other engines in this file use
+    # (OmniVoiceBackend.generate(), _run_backend_inference) — never resolved,
+    # never forwarded as lang_code.
+    backend = tts_backend.MLXAudioBackend()
+    backend._model_id = backend.CURATED_MODELS["kokoro"]
+    backend._ensure_loaded = lambda: None
+    seen_kwargs = {}
+
+    def _fake_generate(**kw):
+        seen_kwargs.update(kw)
+        return iter([types.SimpleNamespace(audio=[0.0, 0.0, 0.0, 0.0])])
+
+    backend._model = types.SimpleNamespace(generate=_fake_generate)
+    backend.generate("hello", language="Auto")
+    assert "lang_code" not in seen_kwargs
+
+
+def test_mlx_audio_generate_non_kokoro_model_ignores_kokoro_validation():
+    # Qwen3-TTS (and CSM/Dia/Chatterbox/MeloTTS/OuteTTS) don't use Kokoro's
+    # lang_code convention — a language Kokoro would reject must NOT be
+    # rejected when a different curated model is active (#977 nuance).
+    backend = tts_backend.MLXAudioBackend()
+    backend._model_id = backend.CURATED_MODELS["qwen3-tts"]
+    backend._ensure_loaded = lambda: None
+    seen_kwargs = {}
+
+    def _fake_generate(**kw):
+        seen_kwargs.update(kw)
+        return iter([types.SimpleNamespace(audio=[0.0, 0.0, 0.0, 0.0])])
+
+    backend._model = types.SimpleNamespace(generate=_fake_generate)
+    backend.generate("hello", language="Dutch")  # must not raise
+    assert seen_kwargs.get("lang_code") == "du"

--- a/tests/test_generation_audio_guard.py
+++ b/tests/test_generation_audio_guard.py
@@ -14,7 +14,11 @@ import torch
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
 
-from api.routers.generation import _sanitize_audio, _oom_friendly_reraise  # noqa: E402
+from api.routers.generation import (  # noqa: E402
+    _oom_friendly_reraise,
+    _safe_exc_text,
+    _sanitize_audio,
+)
 
 
 def test_sanitize_replaces_non_finite_with_silence():
@@ -257,3 +261,41 @@ def test_config_failure_does_not_swallow_real_oom():
     with pytest.raises(RuntimeError) as ei:
         _oom_friendly_reraise(RuntimeError("CUDA error: out of memory"))
     assert "ran out of memory" in str(ei.value)
+
+
+# ── #977: generic exception formatters never leak a raw container repr ─────
+# mlx-audio's vendored Kokoro pipeline raises
+# `assert lang_code in LANG_CODES, (lang_code, LANG_CODES)` — an
+# AssertionError whose .args is a (str, dict) tuple. str(e) on that
+# interpolates the ENTIRE table straight into the user-facing 500 message
+# ("Underlying error: ('du', {'a': 'American English', ...})"). Any engine's
+# generate() can raise something shaped like this, not just Kokoro, so the
+# guard is class-level: _safe_exc_text() backs both of generation.py's
+# generic (catch-all) exception formatters.
+
+
+def test_safe_exc_text_plain_message_uses_house_style():
+    err = RuntimeError("plain readable message")
+    assert _safe_exc_text(err) == "RuntimeError: plain readable message"
+
+
+def test_safe_exc_text_container_args_do_not_leak_raw_repr():
+    # Mirrors the exact #977 AssertionError shape.
+    err = AssertionError(("du", {"a": "American English", "b": "British English"}))
+    text = _safe_exc_text(err)
+    assert text.startswith("AssertionError")
+    assert "American English" not in text
+    assert "{" not in text and "}" not in text
+    assert "(" not in text and ")" not in text
+
+
+def test_unrecognized_error_catchall_does_not_leak_container_repr():
+    # End-to-end through _oom_friendly_reraise's catch-all fallback (none of
+    # the specific classifiers above it match an AssertionError like this).
+    err = AssertionError(("du", {"a": "American English", "b": "British English"}))
+    with pytest.raises(RuntimeError) as ei:
+        _oom_friendly_reraise(err)
+    msg = str(ei.value)
+    assert "AssertionError" in msg
+    assert "American English" not in msg
+    assert "{" not in msg and "}" not in msg


### PR DESCRIPTION
## The bug

Issue #977: selecting certain languages with the mlx-audio TTS engine crashed with a raw, unreadable 500:
```
Underlying error: TTS engine stopped mid-generation with an error OmniVoice doesn't recognize. ...
Underlying error: ('du', {'a': 'American English', 'b': 'British English', ...})
```

Root cause: `MLXAudioBackend.generate()` blindly truncated the full language display name to 2 characters (`language[:2].lower()`), assuming it was already an ISO code. But `language` is a full display name ("Dutch", "Spanish", "Portuguese", ...) from a 646-language list, forwarded verbatim by the frontend. `"Dutch"[:2].lower()` → `"du"`, which crashed Kokoro's vendored pipeline's internal assertion (`assert lang_code in LANG_CODES, (lang_code, LANG_CODES)`) — this only "worked" by coincidence for languages whose first two letters happened to match one of Kokoro's single-letter codes (English→en, French→fr, Italian→it...); Spanish, Portuguese, Chinese, German, Dutch all crashed. The raw `AssertionError`'s tuple-containing-a-dict `.args` then leaked straight through two stacked `f"...{e}"` formatters in `generation.py`.

## The fix

- **`resolve_kokoro_lang_code()`** resolves against the **authoritative** `ALIASES`/`LANG_CODES` table read from the installed `mlx_audio` package (never a hardcoded guess), and is only applied when Kokoro is the actual active curated model — other curated models (CSM, Dia, Qwen3-TTS, OuteTTS...) either ignore the kwarg or expect a different format entirely, so Kokoro's strict validation doesn't wrongly reject a language that's valid for whatever model is actually loaded. Unsupported languages now raise a clean `ValueError` naming what Kokoro supports, which `generation.py` already converts to an actionable 400 — no crash.
- **`_safe_exc_text()`** hardens both of `generation.py`'s generic exception formatters: if any element of an exception's `.args` is a container (dict/list/tuple/set), the message never interpolates `str(e)` raw — it names the exception type and points at the log instead. This protects **every** current and future engine's `generate()` from leaking a raw container repr, not just this one Kokoro assertion — the "fix the whole class" part.

## Tests

`tests/test_engines.py` + `tests/test_generation_audio_guard.py`: 55 passed. Covers: resolving supported names/ISO codes, cleanly rejecting unsupported languages (Dutch/German) before `model.generate()` is ever called, "Auto" skipping validation, non-Kokoro curated models bypassing Kokoro's strict check, and the exact reported `AssertionError` shape (tuple containing a dict) no longer leaking into either exception-formatting site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed MLX-audio Kokoro language handling to resolve supported language names/codes through the package’s authoritative mappings instead of truncating the frontend value, preventing raw 500s for unsupported inputs and returning clean validation errors instead.

Also hardened generation error formatting so container-like exception contents no longer leak into user-facing messages.

```mermaid
flowchart TD
  A[generate() receives language] --> B{Active MLX model is Kokoro?}
  B -- yes --> C[resolve_kokoro_lang_code()]
  C --> D{Supported by ALIASES/LANG_CODES?}
  D -- yes --> E[Set kwargs.lang_code to Kokoro code]
  D -- no --> F[Raise ValueError]
  F --> G[Return actionable 400 response]
  B -- no --> H[Use existing 2-char lowercase lang_code behavior]

  I[Unhandled exception] --> J[_safe_exc_text()]
  J --> K[Safe user-facing error text]
  K --> L[No raw container repr leakage]
</mermaid>

Tests were added for:
- Kokoro language resolution
- Unsupported-language rejection
- Kokoro-only validation behavior
- `Auto` language passthrough
- Safe exception formatting in generation error paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->