### PR TITLE
feat(engines): expose MLX-Audio's curated model picker

### DIFF
--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -16,6 +16,7 @@ Environment variables (`OMNIVOICE_TTS_BACKEND`, `OMNIVOICE_ASR_BACKEND`,
 a backend without Settings silently undoing it.
 """
 import os
+import re
 import threading
 from time import perf_counter
 
@@ -429,6 +430,11 @@ def engine_selftest(engine_id: str):
 class SelectEngineRequest(BaseModel):
     family: str   # "tts" | "asr" | "llm"
     backend_id: str
+    # Only meaningful for family="tts", backend_id="mlx-audio" (#981) — picks
+    # which of mlx-audio's curated models is actually loaded. A curated key
+    # ("kokoro") or a raw HF repo id ("mlx-community/Kokoro-82M-bf16") — the
+    # same tolerance MLXAudioBackend.__init__ already has. Ignored otherwise.
+    model_id: str | None = None
 
 
 class SelectEngineResponse(BaseModel):
@@ -471,6 +477,24 @@ def select_engine(req: SelectEngineRequest):
             f"Backend {req.backend_id} can't run on this machine: {why}. "
             f"Pick an engine with a CPU path, or one that supports this host's GPU.",
         )
+    # #981: mlx-audio multiplexes 7+ curated models behind one backend id —
+    # persist the model pick alongside the backend id so the UI can actually
+    # select which curated model gets loaded (previously it always defaulted
+    # to Kokoro no matter what the user downloaded in Settings → Models).
+    if req.family == "tts" and req.backend_id == "mlx-audio" and req.model_id is not None:
+        known_keys = tts_backend.MLXAudioBackend.CURATED_MODELS
+        # Accept a curated key OR a raw HF repo id ("owner/name") — the same
+        # tolerance MLXAudioBackend.__init__ already has for power users.
+        # Anything else (typo'd key, malformed id) is rejected outright
+        # rather than silently persisted as a "custom repo" that then fails
+        # to resolve at load time.
+        if req.model_id not in known_keys and not re.fullmatch(r"[\w.-]+/[\w.-]+", req.model_id):
+            raise HTTPException(
+                400,
+                f"Unknown mlx-audio model: {req.model_id!r}. Expected one of "
+                f"{sorted(known_keys)} or a HF repo id like 'owner/name'.",
+            )
+        prefs.set_("mlx_audio_model_id", req.model_id)
     prefs.set_(pref_key, req.backend_id)
     return {
         "family": req.family,

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -729,7 +729,16 @@ class MLXAudioBackend(TTSBackend):
     def __init__(self):
         self._model = None
         self._sr = 24000  # most mlx-audio engines emit 24 kHz mono
-        key = os.environ.get("OMNIVOICE_MLX_AUDIO_MODEL", self.DEFAULT_MODEL_KEY)
+        # Env var > persisted UI choice (#981 — Settings → Engines curated-
+        # model picker) > default. Mirrors active_backend_id()'s resolution
+        # order exactly so power-users can still pin a model without the UI
+        # silently undoing it.
+        from core import prefs
+        key = prefs.resolve(
+            "mlx_audio_model_id",
+            env="OMNIVOICE_MLX_AUDIO_MODEL",
+            default=self.DEFAULT_MODEL_KEY,
+        )
         # Accept either a curated key ("kokoro") or a full HF repo id
         # ("mlx-community/Kokoro-82M-bf16") — flexibility for power users.
         self._model_id = self.CURATED_MODELS.get(key, key)
@@ -1387,6 +1396,21 @@ _SETUP_SNIPPETS: dict[str, str] = {
 }
 
 
+# Short, readable labels for mlx-audio's curated models (#981) — surfaced in
+# the Settings → Engines model picker so users see more than a bare key.
+# Single-sourced here rather than on MLXAudioBackend.CURATED_MODELS itself so
+# the class dict stays a plain key → repo-id map (what __init__ needs).
+_MLX_AUDIO_MODEL_LABELS: dict[str, str] = {
+    "kokoro":     "Kokoro (default, fast)",
+    "csm":        "CSM (voice cloning)",
+    "qwen3-tts":  "Qwen3-TTS (voice design)",
+    "dia":        "Dia",
+    "chatterbox": "Chatterbox",
+    "melotts":    "MeloTTS (lightweight)",
+    "outetts":    "OuteTTS",
+}
+
+
 def list_backends() -> list[dict]:
     """Enumerate every registered backend with its availability state.
 
@@ -1470,6 +1494,22 @@ def list_backends() -> list[dict]:
             # effective_device / routing_status / routing_reason (scrubbed):
             **routing_fields(gpu_compat, caps),
         })
+        # #981: mlx-audio multiplexes 7+ curated models behind one backend id
+        # — surface the roster + the currently-active pick so Settings can
+        # render a model picker instead of always defaulting to Kokoro.
+        # mlx-audio ONLY; every other backend loads a single fixed model.
+        if bid == "mlx-audio":
+            from core import prefs
+            active_model = prefs.resolve(
+                "mlx_audio_model_id",
+                env="OMNIVOICE_MLX_AUDIO_MODEL",
+                default=cls.DEFAULT_MODEL_KEY,
+            )
+            out[-1]["curated_models"] = [
+                {"key": key, "label": _MLX_AUDIO_MODEL_LABELS.get(key, key), "repo_id": repo_id}
+                for key, repo_id in cls.CURATED_MODELS.items()
+            ]
+            out[-1]["active_model_id"] = active_model
     return out
 
 
@@ -1570,15 +1610,21 @@ def active_backend_id() -> str:
 # call the outgoing engine's unload() before switching.
 _active_instance: "TTSBackend | None" = None
 _active_instance_id: "str | None" = None
+# mlx-audio multiplexes 7+ curated models behind one backend id — a model-only
+# switch (same "mlx-audio" id, different curated model) must also invalidate
+# the cache, or picking a different model in Settings has no effect until the
+# app restarts (#981). Only meaningful when _active_instance_id == "mlx-audio".
+_active_mlx_model_key: "str | None" = None
 
 
 def reset_active_backend() -> None:
     """Unload + clear the cached active backend. For app shutdown and tests.
     Idempotent and best-effort — a raising unload() never propagates."""
-    global _active_instance, _active_instance_id
+    global _active_instance, _active_instance_id, _active_mlx_model_key
     inst = _active_instance
     _active_instance = None
     _active_instance_id = None
+    _active_mlx_model_key = None
     if inst is not None:
         try:
             inst.unload()
@@ -1596,13 +1642,32 @@ def get_active_tts_backend(*, model=None) -> TTSBackend:
     ``model=`` (caller already holds a loaded model), we return a fresh view
     over the shared singleton rather than caching it — but a switch *away from*
     a different engine still triggers that engine's unload().
+
+    For mlx-audio specifically, the backend id alone doesn't capture *which*
+    curated model is loaded (#981) — so we also track the resolved model key
+    and treat a model-only change as a switch, reusing the exact same
+    unload-and-reconstruct path as an id switch.
     """
-    global _active_instance, _active_instance_id
+    global _active_instance, _active_instance_id, _active_mlx_model_key
     bid = active_backend_id()
 
-    # Switching engines: release the outgoing one first. Best-effort so a bad
-    # unload() can never block the switch.
-    if _active_instance is not None and _active_instance_id != bid:
+    mlx_model_key = None
+    if bid == "mlx-audio":
+        from core import prefs
+        mlx_model_key = prefs.resolve(
+            "mlx_audio_model_id",
+            env="OMNIVOICE_MLX_AUDIO_MODEL",
+            default=MLXAudioBackend.DEFAULT_MODEL_KEY,
+        )
+
+    # Switching engines (or, for mlx-audio, switching curated models): release
+    # the outgoing one first. Best-effort so a bad unload() can never block
+    # the switch.
+    switching = _active_instance is not None and (
+        _active_instance_id != bid
+        or (bid == "mlx-audio" and mlx_model_key != _active_mlx_model_key)
+    )
+    if switching:
         try:
             _active_instance.unload()
         except Exception as exc:  # noqa: BLE001
@@ -1610,6 +1675,7 @@ def get_active_tts_backend(*, model=None) -> TTSBackend:
                            type(_active_instance).__name__, exc)
         _active_instance = None
         _active_instance_id = None
+        _active_mlx_model_key = None
 
     cls = get_backend_class(bid)
     if cls is OmniVoiceBackend and model is not None:
@@ -1621,6 +1687,7 @@ def get_active_tts_backend(*, model=None) -> TTSBackend:
     if _active_instance is None or _active_instance_id != bid:
         _active_instance = OmniVoiceBackend(model=model) if cls is OmniVoiceBackend else cls()
         _active_instance_id = bid
+        _active_mlx_model_key = mlx_model_key
     return _active_instance
 
 

--- a/frontend/src/api/engines.ts
+++ b/frontend/src/api/engines.ts
@@ -46,8 +46,15 @@ export async function listEngines(): Promise<AllEnginesResponse> {
 export async function selectEngine(
   family: EngineFamily,
   backendId: string,
+  modelId?: string,
 ): Promise<SelectEngineResponse> {
-  return apiPost<SelectEngineResponse>('/engines/select', { family, backend_id: backendId });
+  return apiPost<SelectEngineResponse>('/engines/select', {
+    family,
+    backend_id: backendId,
+    // Only mlx-audio's curated-model picker (#981) sets this — omit
+    // entirely rather than send `undefined`/null for every other call site.
+    ...(modelId ? { model_id: modelId } : {}),
+  });
 }
 
 /**

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -40,6 +40,19 @@ interface EngineBackend {
   effective_device?: EffectiveDevice;
   routing_status?: RoutingStatus;
   routing_reason?: string | null;
+  // #981 — mlx-audio ONLY: it multiplexes 7+ curated models behind one
+  // backend id, so its entry also carries the roster + current pick so
+  // Settings can render a model picker. Absent on every other backend.
+  curated_models?: CuratedModel[];
+  active_model_id?: string;
+}
+
+// #981 — one of mlx-audio's curated models (see backend
+// MLXAudioBackend.CURATED_MODELS / _MLX_AUDIO_MODEL_LABELS).
+export interface CuratedModel {
+  key: string;
+  label: string;
+  repo_id: string;
 }
 
 interface EngineFamilyResponse {

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 import { listEngines, getEngineHealth, selfTestEngine } from '../api/engines';
 import { copyText } from '../utils/copyText';
 import { ChevronRight } from 'lucide-react';
-import { Badge, Button, Segmented, Table } from '../ui';
+import { Badge, Button, Segmented, Select, Table } from '../ui';
 import { cn } from '@/lib/utils';
 import SupertonicLicenseDialog from './SupertonicLicenseDialog';
 
@@ -63,10 +63,11 @@ function reasonMentionsLicense(reason) {
  *
  * Props:
  *   - family: 'tts' | 'asr' | 'llm'  default 'tts'
- *   - onSelect?: (family, backendId) => Promise<void>  optional — when
- *     provided, a "Use" button appears next to "Test engine" for
+ *   - onSelect?: (family, backendId, modelId?) => Promise<void>  optional —
+ *     when provided, a "Use" button appears next to "Test engine" for
  *     available, non-active rows. Lets the matrix double as an engine
- *     picker so Settings doesn't need a parallel table.
+ *     picker so Settings doesn't need a parallel table. The optional third
+ *     arg is set only by mlx-audio's curated-model picker (#981).
  *   - activeId?: string  the currently-active backend id for this
  *     family. Used to render the "active" badge.
  */
@@ -139,6 +140,10 @@ function normalizeEntry(entry) {
     effective_device: entry.effective_device || null,
     routing_status: entry.routing_status || null,
     routing_reason: entry.routing_reason || null,
+    // #981 — mlx-audio ONLY: the curated-model roster + current pick.
+    // null/absent on every other backend, which never renders a picker.
+    curated_models: Array.isArray(entry.curated_models) ? entry.curated_models : null,
+    active_model_id: entry.active_model_id || null,
   };
 }
 
@@ -291,6 +296,18 @@ export default function EngineCompatibilityMatrix({
     setTimeout(() => setCopiedId((c) => (c === id ? null : c)), 1500);
   }, []);
 
+  // #981 — mlx-audio's curated-model picker. Reuses the same onSelect the
+  // "Use" button calls, with the curated model key as the optional third
+  // arg, then reloads so active_model_id reflects the new pick immediately.
+  const changeModel = useCallback(
+    async (id, modelId) => {
+      if (!onSelect || !modelId) return;
+      await onSelect(activeFamily, id, modelId);
+      reload();
+    },
+    [onSelect, activeFamily, reload],
+  );
+
   const COLUMNS = [
     { key: 'name', label: t('engines.matrixTitle').split(' ')[0] || 'Engine', flex: 3 },
     { key: 'status', label: t('engines.status'), width: 130, align: 'center' },
@@ -413,6 +430,35 @@ export default function EngineCompatibilityMatrix({
                   <code className="engine-matrix__id font-mono text-[11px] text-[color:var(--chrome-fg-muted,#888)]">
                     {b.id}
                   </code>
+                  {/* #981 — mlx-audio multiplexes 7+ curated models behind this
+                      one backend id (Kokoro, CSM, OuteTTS, …); without this
+                      picker there's no way to load anything but the default
+                      (Kokoro) even after downloading a different model's
+                      weights in Settings → Models. Disabled while the row
+                      itself isn't available/selectable, matching the "Use"
+                      button's gating. */}
+                  {b.curated_models && b.curated_models.length > 0 && (
+                    <div className="engine-matrix__model-picker flex items-center gap-[6px] mt-[2px]">
+                      <span className="text-[11px] text-[color:var(--chrome-fg-muted,#888)]">
+                        {t('engines.curatedModelLabel')}
+                      </span>
+                      <Select
+                        size="sm"
+                        className="w-auto min-w-[150px]"
+                        value={b.active_model_id || ''}
+                        disabled={!onSelect || !b.available}
+                        onChange={(e) => changeModel(b.id, e.target.value)}
+                        aria-label={t('engines.curatedModelAria', { engine: b.display_name })}
+                        data-testid={`curated-model-select-${b.id}`}
+                      >
+                        {b.curated_models.map((m) => (
+                          <option key={m.key} value={m.key}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                  )}
                   {/* For available rows, show install_hint inline (one line — usually
                       a parenthetical like "(bundled — no extra install needed)").
                       For unavailable rows, collapse reason + install_hint + last_error

--- a/frontend/src/components/settings/EnginesTab.jsx
+++ b/frontend/src/components/settings/EnginesTab.jsx
@@ -17,10 +17,12 @@ export default function EnginesTab() {
   //
   // Review mode (the staged-checkpoint nudges) moved to Settings → General.
   const onSelect = useCallback(
-    async (family, backendId) => {
+    // modelId is only ever set by mlx-audio's curated-model picker (#981) —
+    // every other call site (the "Use" button) omits it.
+    async (family, backendId, modelId) => {
       try {
         addBreadcrumb(`engine:${family}=${backendId}`);
-        const r = await selectEngine(family, backendId);
+        const r = await selectEngine(family, backendId, modelId);
         // Consume the routing echo: warn (not a bare success) when the pick
         // lands on a CPU fallback on this host. See notifyEngineSelected.
         notifyEngineSelected(r, t, family);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1592,7 +1592,9 @@
     "routingUnknown": "Unknown",
     "routingEffectiveChip": "Runs on {{device}} on this machine",
     "routingCaveatTitle": "GPU selected, but: {{reason}}",
-    "selectCpuFallback": "{{engine}}: running on CPU — {{reason}}"
+    "selectCpuFallback": "{{engine}}: running on CPU — {{reason}}",
+    "curatedModelLabel": "Model",
+    "curatedModelAria": "Model for {{engine}}"
   },
   "errors": {
     "title": "This tab hit a snag.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -515,7 +515,9 @@
     "routingRemote": "远程",
     "routingUnknown": "未知",
     "routingEffectiveChip": "在此机器上的 {{device}} 上运行",
-    "routingCaveatTitle": "已选择 GPU，但是：{{reason}}"
+    "routingCaveatTitle": "已选择 GPU，但是：{{reason}}",
+    "curatedModelLabel": "模型",
+    "curatedModelAria": "{{engine}} 的模型"
   },
   "capture": {
     "desc": "全局热键仅在桌面应用中有效。网页界面使用页面内快捷键 <1>Ctrl+Shift+Space</1>（窗口聚焦时可用）。",

--- a/frontend/src/test/EngineCompatibilityMatrix.test.jsx
+++ b/frontend/src/test/EngineCompatibilityMatrix.test.jsx
@@ -702,4 +702,119 @@ describe('EngineCompatibilityMatrix', () => {
     // KittenTTS in the fixture carries no setup_snippet → no snippet block.
     expect(screen.queryByTestId('setup-snippet-kittentts')).not.toBeInTheDocument();
   });
+
+  // ── #981 — mlx-audio curated-model picker ───────────────────────────────
+  function mlxAudioResponse({ activeModelId = 'kokoro' } = {}) {
+    return {
+      tts: {
+        active: 'mlx-audio',
+        backends: [
+          {
+            id: 'mlx-audio',
+            display_name: 'MLX-Audio (test)',
+            available: true,
+            reason: null,
+            install_hint: null,
+            last_error: null,
+            isolation_mode: 'in-process',
+            gpu_compat: ['mps', 'cpu'],
+            curated_models: [
+              {
+                key: 'kokoro',
+                label: 'Kokoro (default, fast)',
+                repo_id: 'mlx-community/Kokoro-82M-bf16',
+              },
+              { key: 'csm', label: 'CSM (voice cloning)', repo_id: 'mlx-community/csm-1b-8bit' },
+              {
+                key: 'outetts',
+                label: 'OuteTTS',
+                repo_id: 'mlx-community/Llama-OuteTTS-1.0-1B-4bit',
+              },
+            ],
+            active_model_id: activeModelId,
+          },
+        ],
+      },
+      asr: { active: '', backends: [] },
+      llm: { active: 'off', backends: [] },
+    };
+  }
+
+  it('renders the curated-model picker for mlx-audio, pre-selected to the active model', async () => {
+    const apiListEngines = vi
+      .fn()
+      .mockResolvedValue(mlxAudioResponse({ activeModelId: 'outetts' }));
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        onSelect={vi.fn()}
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('MLX-Audio (test)'));
+    const select = screen.getByTestId('curated-model-select-mlx-audio');
+    expect(select).toHaveValue('outetts');
+    // All curated models are offered as options.
+    expect(
+      within(select).getByRole('option', { name: 'Kokoro (default, fast)' }),
+    ).toBeInTheDocument();
+    expect(within(select).getByRole('option', { name: 'CSM (voice cloning)' })).toBeInTheDocument();
+    expect(within(select).getByRole('option', { name: 'OuteTTS' })).toBeInTheDocument();
+  });
+
+  it('picking a different curated model calls onSelect with the model key and refreshes', async () => {
+    let activeModelId = 'kokoro';
+    const apiListEngines = vi.fn(async () => mlxAudioResponse({ activeModelId }));
+    const onSelect = vi.fn(async (_family, _id, modelId) => {
+      activeModelId = modelId;
+    });
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        onSelect={onSelect}
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('MLX-Audio (test)'));
+    const select = screen.getByTestId('curated-model-select-mlx-audio');
+    fireEvent.change(select, { target: { value: 'csm' } });
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('tts', 'mlx-audio', 'csm');
+    });
+    // Reloaded after the pick — matrix reflects the new active_model_id.
+    await waitFor(() => {
+      expect(screen.getByTestId('curated-model-select-mlx-audio')).toHaveValue('csm');
+    });
+    expect(apiListEngines.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not render a curated-model picker for engines without curated_models', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(makeEnginesResponse());
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        onSelect={vi.fn()}
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('OmniVoice (test)'));
+    expect(screen.queryByTestId(/curated-model-select-/)).not.toBeInTheDocument();
+  });
+
+  it('disables the curated-model picker when no onSelect is provided', async () => {
+    const apiListEngines = vi.fn().mockResolvedValue(mlxAudioResponse());
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        apiListEngines={apiListEngines}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await waitFor(() => screen.getByText('MLX-Audio (test)'));
+    expect(screen.getByTestId('curated-model-select-mlx-audio')).toBeDisabled();
+  });
 });

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -247,6 +247,98 @@ def test_select_llm_never_routing_gated(fresh_app, monkeypatch):
     assert r.status_code == 200, r.text
 
 
+# ── #981 — mlx-audio curated-model selection via /engines/select ───────────
+#
+# mlx-audio multiplexes 7+ curated models behind one backend id. Before this
+# fix there was NO way anywhere in the UI/API to pick which curated model
+# actually loads — it always defaulted to Kokoro even if the user had
+# downloaded e.g. Llama-OuteTTS via Settings → Models.
+
+
+def _make_mlx_audio_available(monkeypatch):
+    """mlx-audio is Apple-Silicon-gated; force is_available()=True + a
+    CPU-friendly host so the routing gate doesn't block these tests on
+    non-mac CI runners."""
+    from services import tts_backend as tts_mod
+    monkeypatch.setattr(
+        tts_mod.MLXAudioBackend, "is_available",
+        classmethod(lambda cls: (True, "ready")),
+    )
+    _force_cpu_host(monkeypatch)
+
+
+def test_select_mlx_audio_unknown_model_id_is_400(fresh_app, monkeypatch):
+    _make_mlx_audio_available(monkeypatch)
+    r = _client(fresh_app).post(
+        "/engines/select",
+        json={"family": "tts", "backend_id": "mlx-audio", "model_id": "not-a-real-model"},
+    )
+    assert r.status_code == 400
+    assert "Unknown mlx-audio model" in r.json()["detail"]
+
+
+def test_select_mlx_audio_curated_key_persists(fresh_app, monkeypatch):
+    from core import prefs as _prefs
+    _make_mlx_audio_available(monkeypatch)
+    r = _client(fresh_app).post(
+        "/engines/select",
+        json={"family": "tts", "backend_id": "mlx-audio", "model_id": "outetts"},
+    )
+    assert r.status_code == 200, r.text
+    assert _prefs.get("mlx_audio_model_id") == "outetts"
+    assert _prefs.get("tts_backend") == "mlx-audio"
+
+
+def test_select_mlx_audio_raw_repo_id_accepted(fresh_app, monkeypatch):
+    """MLXAudioBackend already tolerates a raw HF repo id, not just a
+    curated key (tts_backend.py ~733) — the API must too."""
+    from core import prefs as _prefs
+    _make_mlx_audio_available(monkeypatch)
+    r = _client(fresh_app).post(
+        "/engines/select",
+        json={
+            "family": "tts", "backend_id": "mlx-audio",
+            "model_id": "mlx-community/Some-Other-Model-4bit",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert _prefs.get("mlx_audio_model_id") == "mlx-community/Some-Other-Model-4bit"
+
+
+def test_select_mlx_audio_without_model_id_does_not_touch_pref(fresh_app, monkeypatch):
+    """Selecting mlx-audio without a model_id (e.g. an older frontend) must
+    leave any existing mlx_audio_model_id pref untouched."""
+    from core import prefs as _prefs
+    _prefs.set_("mlx_audio_model_id", "csm")
+    _make_mlx_audio_available(monkeypatch)
+    r = _client(fresh_app).post(
+        "/engines/select", json={"family": "tts", "backend_id": "mlx-audio"})
+    assert r.status_code == 200, r.text
+    assert _prefs.get("mlx_audio_model_id") == "csm"
+
+
+def test_select_model_id_ignored_for_non_mlx_audio_backend(fresh_app):
+    """model_id is only meaningful for mlx-audio; picking a different TTS
+    backend with a model_id set must not persist a stray pref."""
+    from core import prefs as _prefs
+    r = _client(fresh_app).post(
+        "/engines/select",
+        json={"family": "tts", "backend_id": "omnivoice", "model_id": "kokoro"},
+    )
+    assert r.status_code == 200, r.text
+    assert _prefs.get("mlx_audio_model_id") is None
+
+
+def test_engines_response_curated_models_only_on_mlx_audio(fresh_app):
+    client = _client(fresh_app)
+    body = client.get("/engines").json()
+    by_id = {b["id"]: b for b in body["tts"]["backends"]}
+    assert "curated_models" in by_id["mlx-audio"]
+    assert "active_model_id" in by_id["mlx-audio"]
+    assert "curated_models" not in by_id["omnivoice"]
+    assert "active_model_id" not in by_id["omnivoice"]
+
+
 # ── /engines/{id}/health round-trip ────────────────────────────────────────
 
 

--- a/tests/backend/services/test_tts_backend_registry.py
+++ b/tests/backend/services/test_tts_backend_registry.py
@@ -141,7 +141,10 @@ def test_list_backends_resilient(registry_sandbox):
 
 
 def test_list_backends_shape(registry_sandbox):
-    """Every entry must contain exactly the documented keys — no more, no less."""
+    """Every entry must contain exactly the documented keys — no more, no
+    less — EXCEPT mlx-audio, which also carries `curated_models` +
+    `active_model_id` (#981): it multiplexes 7+ curated models behind one
+    backend id, so the Settings picker needs the roster + current pick."""
     out = list_backends()
     # `gpu_compat` joined the documented shape in Plan 02-04 alongside the
     # Engine Compatibility Matrix UI (ENGINE-06). The three routing keys
@@ -154,12 +157,49 @@ def test_list_backends_shape(registry_sandbox):
         # Copy-paste env-var line for path-gated opt-in engines (None otherwise).
         "setup_snippet",
     }
+    mlx_audio_extra = {"curated_models", "active_model_id"}
     for entry in out:
-        assert set(entry.keys()) == required, (
+        expected = required | mlx_audio_extra if entry["id"] == "mlx-audio" else required
+        assert set(entry.keys()) == expected, (
             f"entry {entry.get('id')} has wrong keys: "
-            f"missing {required - entry.keys()}, "
-            f"extra {entry.keys() - required}"
+            f"missing {expected - entry.keys()}, "
+            f"extra {entry.keys() - expected}"
         )
+
+
+def test_mlx_audio_curated_models_roster(registry_sandbox):
+    """#981 — mlx-audio's entry carries the curated-model roster + the
+    currently-active pick, so Settings can render a model picker instead of
+    always silently defaulting to Kokoro."""
+    out = {entry["id"]: entry for entry in list_backends()}
+    entry = out["mlx-audio"]
+    assert entry["active_model_id"] == "kokoro"  # DEFAULT_MODEL_KEY, no prefs set
+    keys = {m["key"] for m in entry["curated_models"]}
+    assert keys == set(tts_backend.MLXAudioBackend.CURATED_MODELS)
+    for m in entry["curated_models"]:
+        assert set(m.keys()) == {"key", "label", "repo_id"}
+        assert m["repo_id"] == tts_backend.MLXAudioBackend.CURATED_MODELS[m["key"]]
+        assert m["label"]  # non-empty, readable
+
+
+def test_mlx_audio_active_model_id_reflects_prefs(registry_sandbox, monkeypatch, tmp_path):
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    monkeypatch.delenv("OMNIVOICE_MLX_AUDIO_MODEL", raising=False)
+    _prefs.set_("mlx_audio_model_id", "outetts")
+    out = {entry["id"]: entry for entry in list_backends()}
+    assert out["mlx-audio"]["active_model_id"] == "outetts"
+
+
+def test_curated_models_not_present_on_other_backends(registry_sandbox):
+    """Only mlx-audio multiplexes multiple models behind one backend id — no
+    other entry should carry curated_models/active_model_id."""
+    out = list_backends()
+    for entry in out:
+        if entry["id"] == "mlx-audio":
+            continue
+        assert "curated_models" not in entry
+        assert "active_model_id" not in entry
 
 
 def test_isolation_mode_in_process_vs_subprocess(registry_sandbox):

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -113,6 +113,66 @@ def test_tts_unknown_backend_raises():
         tts_backend.get_backend_class("not-a-real-one")
 
 
+# ── #981 — MLX-Audio curated-model selection ─────────────────────────────
+#
+# MLXAudioBackend.__init__ used to resolve its active model ONLY from
+# OMNIVOICE_MLX_AUDIO_MODEL, invisible to Settings and unchangeable without
+# restarting the process with an env var set. It must now mirror
+# active_backend_id()'s env > prefs > default resolution.
+
+
+def test_mlx_audio_model_id_resolves_via_prefs(monkeypatch, tmp_path):
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    monkeypatch.delenv("OMNIVOICE_MLX_AUDIO_MODEL", raising=False)
+    _prefs.set_("mlx_audio_model_id", "outetts")
+    be = tts_backend.MLXAudioBackend()
+    assert be._model_id == tts_backend.MLXAudioBackend.CURATED_MODELS["outetts"]
+
+
+def test_mlx_audio_model_id_env_overrides_prefs(monkeypatch, tmp_path):
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    _prefs.set_("mlx_audio_model_id", "outetts")
+    monkeypatch.setenv("OMNIVOICE_MLX_AUDIO_MODEL", "csm")
+    be = tts_backend.MLXAudioBackend()
+    assert be._model_id == tts_backend.MLXAudioBackend.CURATED_MODELS["csm"]
+
+
+def test_mlx_audio_model_id_defaults_to_kokoro(monkeypatch, tmp_path):
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    monkeypatch.delenv("OMNIVOICE_MLX_AUDIO_MODEL", raising=False)
+    be = tts_backend.MLXAudioBackend()
+    assert be._model_id == tts_backend.MLXAudioBackend.CURATED_MODELS["kokoro"]
+
+
+def test_get_active_tts_backend_reconstructs_on_mlx_model_switch(monkeypatch, tmp_path):
+    """A curated-model-only change (same backend id 'mlx-audio') must
+    invalidate the cached instance too — otherwise picking a different
+    curated model in Settings has no effect until an app restart."""
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    monkeypatch.delenv("OMNIVOICE_MLX_AUDIO_MODEL", raising=False)
+    monkeypatch.delenv("OMNIVOICE_TTS_BACKEND", raising=False)
+    _prefs.set_("tts_backend", "mlx-audio")
+    _prefs.set_("mlx_audio_model_id", "kokoro")
+    tts_backend.reset_active_backend()
+    try:
+        be1 = tts_backend.get_active_tts_backend()
+        assert be1._model_id == tts_backend.MLXAudioBackend.CURATED_MODELS["kokoro"]
+        # Same instance on a repeat call with nothing changed (still cached).
+        assert tts_backend.get_active_tts_backend() is be1
+
+        _prefs.set_("mlx_audio_model_id", "outetts")
+        be2 = tts_backend.get_active_tts_backend()
+        assert be2 is not be1
+        assert be2._model_id == tts_backend.MLXAudioBackend.CURATED_MODELS["outetts"]
+    finally:
+        tts_backend.reset_active_backend()
+        _prefs.set_("tts_backend", "omnivoice")
+
+
 # ── ASR ─────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## The bug

Issue #981: `mlx-audio` multiplexes 7+ curated models (Kokoro, CSM, Qwen3-TTS, Dia, Chatterbox, MeloTTS, OuteTTS) behind a single `mlx-audio` backend id, but `MLXAudioBackend` resolved its active model **only** from the `OMNIVOICE_MLX_AUDIO_MODEL` env var — invisible to Settings and unreachable without restarting the packaged app with that var set. A user who downloaded e.g. Llama-OuteTTS via Settings → Models had no way anywhere in the UI or API to actually load it; the backend silently kept using Kokoro.

## The fix

- `MLXAudioBackend.__init__` now resolves its model via `prefs.resolve("mlx_audio_model_id", env=..., default=...)`, mirroring `active_backend_id()`'s env > prefs > default order exactly.
- `get_active_tts_backend()`'s switch-detection now also tracks the resolved mlx-audio model key, so a model-only change (same backend id) invalidates the cached instance and reconstructs it — no app restart needed to pick up a different curated model.
- `POST /engines/select` gained an optional `model_id` field; for `family=tts`/`backend_id=mlx-audio` it validates against `MLXAudioBackend.CURATED_MODELS` (or a raw HF repo id, matching the class's existing tolerance) and persists it via prefs.
- `GET /engines` now includes a `curated_models` roster + `active_model_id` on the mlx-audio entry only.
- Settings → Engines renders a small model dropdown on the mlx-audio row, pre-selected to the active model, wired through `selectEngine`'s new optional `modelId` argument.

## Test plan

- [x] Regression coverage: prefs resolution + env override, cache invalidation on model-only switch, `/engines/select` 400s on an unknown model id and persists a valid one, `curated_models` present only on mlx-audio
- [x] New `EngineCompatibilityMatrix` vitest suite for the dropdown
- [x] `uv run pytest tests/test_engines.py tests/backend/services/test_tts_backend_registry.py tests/backend/api/test_engines_route_shape.py` — 68 passed on a clean branch off main

🤖 Generated with [Claude Code](https://claude.com/claude-code)