### PR TITLE
docs(linux): mention yt-dlp as an optional prerequisite

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -12,6 +12,10 @@ working OmniVoice Studio install on a Debian / Ubuntu / Fedora / Arch host.
 - **~10 GB free disk** for the app, its Python environment, and model weights.
 - Optional: an **NVIDIA driver** for CUDA GPU acceleration — the app runs
   CPU-only without one. For AMD GPUs see [AMD GPU (ROCm)](#amd-gpu-rocm).
+- Optional: **yt-dlp** for downloading YouTube/video clips directly in the
+  Voice Gallery and Dub tabs — `sudo apt install yt-dlp` (Debian/Ubuntu),
+  `sudo dnf install yt-dlp` (Fedora), or `sudo pacman -S yt-dlp` (Arch).
+  Without it those downloads fail; everything else works fine.
 
 That's it — Python, FFmpeg, and the model weights are bundled or bootstrapped
 by the app itself on first launch. No toolchain needed.


### PR DESCRIPTION
Issue #973: the Linux install docs never mentioned `yt-dlp`, even though the in-app preflight check already warns about it being missing (YouTube/video downloads in Voice Gallery and Dub fail without it). Added a one-line optional prerequisite alongside the existing NVIDIA driver note, with the install command for apt/dnf/pacman.

`scripts/check-docs-drift.py`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Updated the Linux AppImage installation docs to call out `yt-dlp` as an optional prerequisite.
- Added distro-specific install commands for `apt`, `dnf`, and `pacman`.
- Clarified that Voice Gallery and Dub video/clip downloads fail without `yt-dlp`.

## Verification
- `scripts/check-docs-drift.py`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->