### PR TITLE
fix(diagnostics): filter Tauri's benign IPC-fallback warning from frontend log capture

### DIFF
--- a/frontend/src/utils/consoleBuffer.js
+++ b/frontend/src/utils/consoleBuffer.js
@@ -5,7 +5,20 @@
 const MAX = 500;
 const buf = [];
 
+// Tauri's own internal IPC fallback (#975): on some Windows configurations
+// the custom-protocol IPC probe fails once at startup and Tauri logs this
+// exact console.warn before silently — and successfully — falling back to
+// postMessage + WebSocket. It's benign and fires at most once per launch,
+// but as a captured console.warn it spuriously flips the Logs footer's
+// Frontend pill to "1 warning" on every affected launch. Filtered at the
+// capture source (not the display layer) so it never enters the ring
+// buffer or a copied diagnostic dump either.
+const BENIGN_WARNING_PREFIXES = ['IPC custom protocol failed'];
+
 function push(level, args) {
+  if (level === 'warn' && typeof args[0] === 'string') {
+    if (BENIGN_WARNING_PREFIXES.some((p) => args[0].startsWith(p))) return;
+  }
   const msg = Array.from(args)
     .map((a) => {
       if (a instanceof Error) return `${a.name}: ${a.message}${a.stack ? '\n' + a.stack : ''}`;

--- a/frontend/src/utils/consoleBuffer.test.js
+++ b/frontend/src/utils/consoleBuffer.test.js
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearFrontendLogs, getFrontendLogs, installConsoleCapture } from './consoleBuffer';
+
+describe('consoleBuffer', () => {
+  // installConsoleCapture() wraps console.* exactly once per page load (a
+  // module-level `installed` guard) — it must NOT be re-installed or have
+  // console.warn restored between tests, or later tests run against the
+  // un-wrapped original. Install once; only the ring buffer resets per test.
+  installConsoleCapture();
+
+  beforeEach(() => {
+    clearFrontendLogs();
+  });
+
+  it('captures an ordinary warning', () => {
+    console.warn('something genuinely worth seeing');
+    expect(getFrontendLogs().some((l) => l.msg.includes('something genuinely worth seeing'))).toBe(
+      true,
+    );
+  });
+
+  it("#975: filters Tauri's benign IPC-fallback warning out of the captured buffer", () => {
+    console.warn(
+      'IPC custom protocol failed, Tauri will now use the postMessage interface instead',
+    );
+    expect(getFrontendLogs().some((l) => l.msg.includes('IPC custom protocol failed'))).toBe(false);
+  });
+
+  it('does not filter a different warning that merely mentions IPC', () => {
+    // Prefix match, not a substring match — only Tauri's exact known message
+    // is suppressed; anything else that happens to mention "IPC" is not.
+    console.warn('some other IPC warning entirely');
+    expect(getFrontendLogs().some((l) => l.msg.includes('some other IPC warning entirely'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Follow-up on #975

Investigated: the warning itself (`IPC custom protocol failed, Tauri will now use the postMessage interface instead`) is **Tauri's own internal fallback mechanism** — fully functional (falls back to postMessage + WebSocket), fires at most once per launch, structurally intentional across recent Tauri 2.11.x releases rather than something being actively patched upstream. Not bumping the framework speculatively for a cosmetic warning — that's a real cross-cutting change deserving its own testing cycle, not a reactive fix.

What IS worth fixing: as a captured `console.warn`, it spuriously flips the Settings → Logs footer's Frontend pill to "1 warning" on every affected Windows launch — real, if minor, diagnostic noise.

## The fix

Filtered at the capture source (`consoleBuffer.js`), not the display layer — so it never enters the ring buffer or a copied diagnostic dump either. Narrowly scoped to this one known message prefix (not a general warning-suppression mechanism that could hide something that actually matters).

## Tests

New `consoleBuffer.test.js` (3 tests): an ordinary warning is still captured, the exact Tauri message is filtered, and a different warning that merely mentions "IPC" is not falsely filtered (prefix match, not substring). `bun run format:check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### What changed
- Filters a known benign Tauri Windows startup warning (`IPC custom protocol failed...`) at the console capture source in `frontend/src/utils/consoleBuffer.js`.
- Prevents that message from entering the ring buffer, copied diagnostics, and the Settings → Logs footer, avoiding false “1 warning” indicators.
- Adds tests in `frontend/src/utils/consoleBuffer.test.js` to verify:
  - normal warnings are still captured,
  - the exact Tauri warning is filtered,
  - similar warnings mentioning “IPC” are not filtered unless they match the known prefix.

### Behavior flow
```mermaid
flowchart TD
  A[console.warn called] --> B{Level is warn?}
  B -- no --> C[Capture normally]
  B -- yes --> D{Message starts with known benign prefix?}
  D -- yes --> E[Skip capture]
  D -- no --> C
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->