### PR TITLE
fix(diagnostics): TTS generate timeout message tells you to Flush/Unload

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -277,9 +277,11 @@ def _timeout_guidance(what: str, timeout: float) -> str:
         )
     return common + (
         "most often the GPU is VRAM-starved (a resident model and this job "
-        "contend for memory). For a durable fix try shorter text, a lighter "
-        "engine, or set the engine to CPU in Settings → Models. (Raise "
-        "OMNIVOICE_GENERATE_TIMEOUT_S for very long single generations.)"
+        "contend for memory). For a durable fix, Flush caches / Unload the "
+        "resident model (top toolbar or Settings → Models) before retrying, "
+        "try shorter text, a lighter engine, or set the engine to CPU in "
+        "Settings → Models. (Raise OMNIVOICE_GENERATE_TIMEOUT_S for very "
+        "long single generations.)"
     )
 
 

--- a/tests/test_generate_timeout_730.py
+++ b/tests/test_generate_timeout_730.py
@@ -139,6 +139,10 @@ def test_gpu_host_keeps_vram_guidance(monkeypatch):
     msg = _guidance_for(monkeypatch, "cuda")
     assert "VRAM-starved" in msg
     assert "set the engine to CPU" in msg
+    # #939: the sibling ASR timeout guard already recommends Flush/Unload —
+    # this message was missing it, forcing the maintainer to explain it
+    # manually in every report instead of the error saying so upfront.
+    assert "Flush" in msg
 
 
 def test_probe_failure_defaults_to_gpu_wording(monkeypatch):


### PR DESCRIPTION
## Investigated #939

The 300s TTS-generate timeout guard (#851/#896) is working as designed — this isn't a logic bug. But the GPU-branch error message had a real gap: it explains VRAM contention but never mentions the Flush/Unload action that actually resolves it, even though:

- That action already exists (`POST /system/flush-memory`, wired to the header's Flush button — reachable at any time, including mid-error).
- The **sibling ASR-timeout guard's** message already recommends it verbatim (`asr_backend.py`'s VRAM-preflight guidance).
- The maintainer ended up manually typing "Settings → Models → Flush caches / Unload" in an issue-thread reply — exactly the information the error message should have carried itself.

## The fix

String-only addition to `_timeout_guidance()`'s GPU branch, no control flow touched — mirrors the exact precedent of #896 (a guidance-only change to this same function).

## Tests

`tests/test_generate_timeout_730.py`: 7 passed, including a new assertion that the GPU-family message mentions "Flush".

Also investigated whether a genuinely proactive fix exists (pre-emptive memory-pressure eviction before committing to a job) — concluded that's a real but bigger architectural change (model residency is split across several independent managers, MPS has no reliable free-VRAM signal, there's a real concurrency hazard in evicting mid-request) and shouldn't be scoped into this fix without separate design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated GPU TTS timeout diagnostics to make the VRAM-contention guidance clearer: the message now explicitly recommends Flush/Unload before retrying, while preserving the existing timeout advice and no control-flow changes.

Adjusted `tests/test_generate_timeout_730.py` to assert the GPU-family timeout message includes the new “Flush” guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->