### PR TITLE
fix(backend): quitting mid-preload no longer reports a clean shutdown while a GPU-pool thread is still importing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -504,6 +504,35 @@ async def _start_mcp_session_manager(session_manager, *, timeout: float):
     return task, stop, mounted
 
 
+async def _cancel_and_await_tasks(*tasks, timeout: float = 3.0) -> None:
+    """Cancel each background task and give it a bounded chance to actually
+    finish before shutdown proceeds — ``None`` entries are skipped (a task
+    that's conditionally created, e.g. ``capture_preload_task``, may not
+    exist).
+
+    ``task.cancel()`` alone is not enough for a task awaiting
+    ``run_in_executor()``: once the underlying OS thread is inside blocking
+    native/import work, cancellation can't stop it, so cancel-and-move-on lets
+    shutdown finish while that thread is still running — invisible to
+    asyncio, but very much alive when the interpreter starts tearing down
+    module state under it (#1000 class). Awaiting with a bound (instead of
+    just cancelling) gives an early-stage task a real chance to exit cleanly
+    first; a task that's genuinely still deep in blocking work times out here
+    same as before, and the caller's own GPU-pool reset handles that case.
+    """
+    for t in tasks:
+        if t is None:
+            continue
+        t.cancel()
+    for t in tasks:
+        if t is None:
+            continue
+        try:
+            await asyncio.wait_for(t, timeout=timeout)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup watchdog (#632): a silent hang during startup (e.g. a model-load /
@@ -578,6 +607,7 @@ async def lifespan(app: FastAPI):
     # lean and the first dictation is instant instead of a cold model load.
     # OMNIVOICE_PRELOAD_CAPTURE_ASR=0 opts out; the warm-up is also skipped
     # under 4 GB free RAM (checked at warm time, not boot time).
+    capture_preload_task = None  # only assigned when the preload actually runs (#1000 class)
     if _env_flag("OMNIVOICE_PRELOAD_CAPTURE_ASR", default=True):
         async def _preload_capture_asr():
             await asyncio.sleep(_capture_preload_delay_s())
@@ -646,14 +676,21 @@ async def lifespan(app: FastAPI):
             pass
         except Exception:
             pass
-    idle_task.cancel()
-    worker_task.cancel()
-    # Wait for tasks to finish their current iteration
-    for t in (idle_task, worker_task):
-        try:
-            await asyncio.wait_for(t, timeout=3.0)
-        except (asyncio.CancelledError, asyncio.TimeoutError):
-            pass
+    # preload_task/capture_preload_task matter most here (#1000 class): a quit
+    # mid-preload used to fall straight through to "Shutdown: done." while the
+    # model load was still running on a GPU-pool thread — cancel() can't stop
+    # a thread already inside blocking import/load work, so the process
+    # reported a clean exit while that background thread was still mid-
+    # `import transformers`, and got torn down by interpreter finalization
+    # instead. That surfaced as a misleading "Could not import module
+    # 'AutoFeatureExtractor'" — transformers' own generic lazy-import wrapper,
+    # not a real dependency problem. Awaiting here lets an early-stage load
+    # (still importing, not yet mid weight-download) finish cleanly before we
+    # report done; a load that's genuinely deep into a multi-GB download still
+    # times out — _reset_gpu_pool() below abandons it either way.
+    await _cancel_and_await_tasks(
+        idle_task, worker_task, preload_task, capture_preload_task, timeout=3.0,
+    )
     # Unload the model and free GPU memory
     try:
         import services.model_manager as mm
@@ -661,6 +698,10 @@ async def lifespan(app: FastAPI):
             mm.model = None
             logger.info("Shutdown: model unloaded.")
         mm.free_vram()
+        # Abandon a still-running preload's GPU-pool thread (Python can't kill
+        # a thread mid blocking call) so it can't outlive this shutdown block
+        # holding a reference into module state that's about to be torn down.
+        mm._reset_gpu_pool()
     except Exception:
         pass
     # Run GC to release any remaining references

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -957,7 +957,13 @@ def _load_model_sync():
         except Exception:  # never let failure-formatting mask the real error
             err_msg = str(exc)
         _set_loading("error", "Model loading failed", error=err_msg)
-        logger.error("Model loading failed: %s", str(exc))
+        # #1000 class: transformers' lazy-import machinery wraps ANY disruption
+        # to an inner import (including one interrupted by process teardown)
+        # in a generic "Could not import module X. Are this object's
+        # requirements defined correctly?" — logging only str(exc) discarded
+        # the real cause in __cause__/__context__ and made a shutdown race
+        # look like a broken install. exc_info surfaces the full chain.
+        logger.error("Model loading failed: %s", str(exc), exc_info=exc)
         raise
     finally:
         unregister_listener(lid)
@@ -1089,7 +1095,11 @@ async def preload_model():
                 model = await _load_model_with_timeout()
         logger.info("Preload complete — model ready.")
     except Exception as e:
-        logger.warning("Model preload failed (non-fatal): %s", e)
+        # See the matching exc_info note on the _load_model_sync handler above
+        # (#1000 class) — the full chain, not just str(e), is what actually
+        # distinguishes a real dependency problem from a shutdown-interrupted
+        # import.
+        logger.warning("Model preload failed (non-fatal): %s", e, exc_info=e)
 
 def get_model_status():
     is_loaded = model is not None

--- a/tests/test_shutdown_preload_race_1000.py
+++ b/tests/test_shutdown_preload_race_1000.py
@@ -1,0 +1,112 @@
+"""A quit mid-preload must not report a clean shutdown while a GPU-pool
+thread is still running (#1000 class).
+
+Field report: a backend log showed three rapid restart cycles, each ending
+with "Shutdown: done." immediately followed by a "Model loading failed:
+Could not import module 'AutoFeatureExtractor'" error — transformers' own
+generic lazy-import wrapper, not a real dependency problem. The real cause:
+`preload_task` (and the optional `capture_preload_task`) were created at
+startup but never referenced in the shutdown block, so `idle_task`/
+`worker_task` got cancelled-and-awaited while the preload task was simply
+abandoned — the process declared "done" while a background GPU-pool thread
+was still mid-`import`, and got torn down by interpreter finalization under
+it.
+
+`_cancel_and_await_tasks` is the extracted, directly-testable shutdown
+helper — the full `lifespan()` context manager touches too much startup
+machinery (DB init, gallery init, MCP session manager) to drive directly in
+a unit test (this suite's own test_mcp_mount.py notes exactly this: running
+the full lifespan contaminates other tests' event loops).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+from main import _cancel_and_await_tasks  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_a_task_that_finished_before_cancel_keeps_its_result():
+    """An early-stage task (mirrors preload still importing, not yet deep in
+    blocking weight-load work) that completes on its own before the shutdown
+    helper even reaches it must not be treated as an error — `.cancel()` on
+    an already-done task is a no-op, and its real result survives. This is
+    the fix: previously preload_task was never referenced in shutdown at
+    all, so this case (the common one — most quits don't land mid-import)
+    was never even checked."""
+    finished = []
+
+    async def _quick():
+        await asyncio.sleep(0.01)
+        finished.append("done")
+
+    async def _scenario():
+        t = asyncio.create_task(_quick())
+        await asyncio.sleep(0.05)  # long enough for _quick() to fully finish
+        assert t.done()
+        await _cancel_and_await_tasks(t, timeout=1.0)  # must not raise on a done task
+
+    _run(_scenario())
+    assert finished == ["done"]
+
+
+def test_none_entries_are_skipped_without_error():
+    """capture_preload_task is None when OMNIVOICE_PRELOAD_CAPTURE_ASR=0 —
+    the helper must not crash on a mix of real tasks and None."""
+    async def _noop():
+        return None
+
+    async def _scenario():
+        t = asyncio.create_task(_noop())
+        await _cancel_and_await_tasks(t, None, timeout=1.0)
+
+    _run(_scenario())  # must not raise
+
+
+def test_a_task_stuck_past_the_bound_times_out_without_hanging():
+    """A task that never yields back (mirroring a GPU-pool thread stuck in a
+    blocking native call) must not hang shutdown forever — the bound is the
+    backstop, same as the pre-existing idle_task/worker_task pattern."""
+    async def _wedged():
+        await asyncio.sleep(10.0)
+
+    async def _scenario():
+        t = asyncio.create_task(_wedged())
+        await asyncio.sleep(0.01)
+        await _cancel_and_await_tasks(t, timeout=0.2)
+
+    import time
+    start = time.monotonic()
+    _run(_scenario())
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0, f"shutdown helper did not bound its wait: took {elapsed:.2f}s"
+
+
+def test_multiple_tasks_are_all_cancelled_before_any_await():
+    """Cancel-then-await (not cancel-then-immediately-await-one-at-a-time) —
+    every task gets its cancellation requested up front, so a slow task
+    earlier in the list can't delay a later task's cancel signal."""
+    cancelled_order = []
+
+    async def _tracked(name, delay):
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            cancelled_order.append(name)
+            raise
+
+    async def _scenario():
+        t1 = asyncio.create_task(_tracked("slow", 5.0))
+        t2 = asyncio.create_task(_tracked("fast", 5.0))
+        await asyncio.sleep(0.01)
+        await _cancel_and_await_tasks(t1, t2, timeout=0.5)
+
+    _run(_scenario())
+    assert set(cancelled_order) == {"slow", "fast"}


### PR DESCRIPTION
## The bug

Issue #1000 (and likely a contributor to #941/#979's class of "can't reach backend" reports): a user pasted an actual backend log that revealed the real mechanism behind these — three rapid restart cycles, each ending with `Shutdown: done.` immediately followed by:
```
ERROR [omnivoice.model] Model loading failed: Could not import module 'AutoFeatureExtractor'. Are this object's requirements defined correctly?
```

**That error text is a red herring.** It's `transformers`'s own generic lazy-import wrapper (`_LazyModule.__getattr__` in `import_utils.py`), not a real dependency problem — `transformers`/`torch`/`torchaudio`/`soundfile`/`librosa` are all core, non-optional deps in `pyproject.toml`, and the very same venv loaded the model successfully 90 seconds later in the same log.

## Root cause

`preload_task` (and the optional `capture_preload_task`) were created at startup but **never referenced in the lifespan shutdown block** — `idle_task`/`worker_task` got cancelled-and-awaited; the preload tasks were simply abandoned. Cancelling an asyncio task that's awaiting `run_in_executor()` can't stop the underlying OS thread once it's inside blocking import/load work — so `"Shutdown: done."` logged while a GPU-pool thread was still mid-`import transformers`, and interpreter finalization tore down module state under it. That's exactly what produces this specific, misleading error.

## The fix

- Extracted the existing cancel+bounded-await pattern into `_cancel_and_await_tasks()` and applied it to all four background tasks (previously only 2 of 4). An early-stage load (still importing, not yet mid weight-download — which is what the log showed) now gets a real chance to finish before shutdown proceeds; a load genuinely deep in blocking work still times out at the same 3s bound, and the existing `_reset_gpu_pool()` abandons it same as before.
- Both error handlers around this path logged only `str(exc)`, discarding `__cause__`/`__context__` — added `exc_info` so a future incident (even one this fix doesn't fully prevent — e.g. a quit landing deep into the load) surfaces the real underlying error instead of the misleading generic wrapper text.

## Tests

New `tests/test_shutdown_preload_race_1000.py` (4 tests) — the helper is extracted specifically so it's testable without driving the full `lifespan()` context manager (this suite's own `test_mcp_mount.py` notes that doing so contaminates other tests' event loops). Covers: a task that finishes before cancellation keeps its result (the common case this fix restores), `None` entries are skipped safely, a genuinely wedged task times out without hanging shutdown, and multiple tasks are all signaled to cancel before any is awaited (so one slow task can't delay another's cancellation).

Broader regression check: `test_generate_timeout_730.py`, `test_mcp_startup_timeout.py`, `test_mcp_mount.py`, `test_api.py` — 53 passed, 1 xpassed, no regressions. CJK guard: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes a shutdown race during model preload by extending the existing cancel-and-await shutdown pattern to all background tasks, including preload-related ones.

```mermaid
flowchart TD
  A[Lifespan shutdown begins] --> B[Cancel idle, worker, preload, and capture tasks]
  B --> C[Await each task with bounded timeout]
  C --> D[Unload model / free VRAM]
  D --> E[Reset GPU pool to drop any still-running preload work]
  C --> F[Ignore CancelledError / TimeoutError]
```

### What changed
- Added `_cancel_and_await_tasks(...)` in `backend/main.py` to cancel tasks, await them with a timeout, and safely skip `None`.
- Applied that helper to all four background tasks during shutdown:
  - `idle_task`
  - `worker_task`
  - `preload_task`
  - `capture_preload_task`
- Ensured `capture_preload_task` is initialized to `None` during lifespan setup.
- Added `mm._reset_gpu_pool()` after unload to abandon any preload thread that can’t be interrupted cleanly.
- Updated model load/preload error logging in `backend/services/model_manager.py` to include `exc_info`, preserving full traceback/context.

### Tests
- Added regression coverage for:
  - completed tasks preserving results
  - `None` task entries being ignored
  - timeout behavior for stuck tasks
  - cancellation being requested for all tasks before awaiting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->