### PR TITLE
feat(asr): generic OpenAI-compatible transcription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,10 +322,10 @@ Professional-grade voice AI, minus the subscription and the cloud.
 
 ### 🎧 ASR Engines
 
-**9 engines, all fully local** — they power dictation, video dubbing, and subtitles. **WhisperX** is the cross-platform default (~100 languages, word-level timing); the rest are opt-in and auto-detected. Switch in **Settings → ASR Engine** or via the `OMNIVOICE_ASR_BACKEND` env var.
+**10 engines** — they power dictation, video dubbing, and subtitles. **WhisperX** is the cross-platform default (~100 languages, word-level timing); the rest are opt-in and auto-detected. Switch in **Settings → ASR Engine** or via the `OMNIVOICE_ASR_BACKEND` env var. Nine run fully on-device; one (OpenAI-compatible) is an optional remote client for pointing at Qwen3-ASR or another compatible server — see below.
 
 <details>
-<summary><b>📊 The full lineup</b> — 9 engines, what each is best at, and compute-type notes</summary>
+<summary><b>📊 The full lineup</b> — 10 engines, what each is best at, and compute-type notes</summary>
 
 <br/>
 
@@ -340,6 +340,7 @@ Professional-grade voice AI, minus the subscription and the cloud.
 | **Moonshine** | `moonshine` | English | Edge / low-latency, ONNX |
 | **FunASR** | `funasr` | 50+ | All-in-one multilingual — built-in VAD + inline speaker diarization (SenseVoice) |
 | **sherpa-onnx** (live dictation) | `sherpa-onnx-asr` | 25 EU + 90+ | Live, faster-than-real-time dictation — small streaming/offline ONNX models (Parakeet TDT v3/v2, streaming Zipformer & Paraformer, Whisper Tiny), CPU, identical on macOS / Windows / Linux. Picked per-model in **Settings → Voice**. |
+| **OpenAI-compatible** ⚠️ remote | `openai-compat-asr` | Server-dependent | A path to **Qwen3-ASR** today (self-hosted server, no transformers wait), any OpenAI-compatible transcription endpoint, or OpenAI's own API — no install, configure in **Settings → Models**. Audio leaves your machine to whatever server you point it at; see [docs/engines/openai-compatible-asr.md](docs/engines/openai-compatible-asr.md). |
 
 > Whisper-family engines cover ~100 languages; **FunASR / SenseVoice** adds an all-in-one multilingual path with built-in voice-activity detection and inline speaker diarization. **sherpa-onnx** powers the live dictation model picker — you talk and text appears as you speak. Every engine runs on-device — no API keys, no cloud.
 

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -750,6 +750,51 @@ def set_hf_mirror(body: _HFMirrorBody):
     return {"configured": url, "restart_required": changed, "presets": _HF_MIRROR_PRESETS}
 
 
+# ── OpenAI-compatible remote ASR (#877) ─────────────────────────────────────
+# A path to Qwen3-ASR/FunASR/SenseVoice — or OpenAI's own Whisper API — today,
+# without waiting on transformers to ship a direct Qwen3-ASR integration.
+# base_url/model are plain settings_store text rows; the key is encrypted via
+# settings_store.set_secret — same convention as /llm-providers, never
+# returned to the client, '' clears it, omitted/None leaves it unchanged.
+
+
+class _ASROpenAICompatBody(BaseModel):
+    base_url: str | None = None
+    model: str | None = None
+    api_key: str | None = Field(None, description="'' clears it, None leaves unchanged")
+
+
+@router.get("/asr-openai-compat")
+def get_asr_openai_compat():
+    from services import asr_backend
+
+    return {
+        "base_url": asr_backend.resolve_openai_compat_asr_base_url(),
+        "model": asr_backend.resolve_openai_compat_asr_model(),
+        "has_key": asr_backend.openai_compat_asr_has_key(),
+    }
+
+
+@router.put("/asr-openai-compat")
+def set_asr_openai_compat(body: _ASROpenAICompatBody):
+    from services import asr_backend, settings_store
+
+    if body.base_url is not None:
+        url = body.base_url.strip().rstrip("/")
+        if url and not url.startswith(("http://", "https://")):
+            raise HTTPException(status_code=400, detail="Base URL must start with http(s)://")
+        settings_store.set_text(asr_backend._ASR_OPENAI_COMPAT_BASE_URL_KEY, url)
+    if body.model is not None:
+        settings_store.set_text(
+            asr_backend._ASR_OPENAI_COMPAT_MODEL_KEY, body.model.strip() or "whisper-1"
+        )
+    if body.api_key is not None:
+        settings_store.set_secret(
+            asr_backend._ASR_OPENAI_COMPAT_SECRET_NAME, body.api_key.strip()
+        )
+    return get_asr_openai_compat()
+
+
 # ── Updates panel: shipped changelog + pre-migration DB backup state ────────
 # (feat/safe-updates). Both are read-only, local-first surfaces for
 # Settings → Updates: the "What's new" viewer reads the CHANGELOG.md that

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -29,6 +29,7 @@ import os
 import re
 import threading
 from abc import ABC, abstractmethod
+from typing import Optional
 
 logger = logging.getLogger("omnivoice.asr")
 
@@ -1634,6 +1635,161 @@ class FunASRBackend(ASRBackend):
             pass
 
 
+# ── OpenAI-compatible remote transcription (#877 — Qwen3-ASR / FunASR / any
+#    compatible server, today, without waiting on transformers to catch up) ──
+#
+# transformers doesn't yet ship a stable Qwen3-ASR integration (issue #877),
+# but a self-hosted Qwen3-ASR/FunASR/SenseVoice server exposing an
+# OpenAI-compatible `POST /v1/audio/transcriptions` endpoint — or OpenAI's own
+# Whisper API — is usable right now. This backend is a pure network client:
+# no model runs locally, so it needs no install and claims no GPU.
+#
+# Settings mirror the LLM-providers convention exactly (services/
+# llm_providers.py): base_url/model are plain settings_store text rows; the
+# API key is Fernet-encrypted via settings_store.set_secret/get_secret — never
+# a .env row, never echoed back to the client. Optional: some self-hosted
+# servers (vLLM, LM Studio-style) don't check the key at all.
+
+_ASR_OPENAI_COMPAT_BASE_URL_KEY = "asr.openai_compat.base_url"
+_ASR_OPENAI_COMPAT_MODEL_KEY = "asr.openai_compat.model"
+_ASR_OPENAI_COMPAT_SECRET_NAME = "asr_openai_compat_key"
+
+
+def resolve_openai_compat_asr_base_url() -> str:
+    from services import settings_store
+    return (
+        os.environ.get("ASR_OPENAI_COMPAT_BASE_URL")
+        or settings_store.get_text(_ASR_OPENAI_COMPAT_BASE_URL_KEY)
+        or ""
+    )
+
+
+def resolve_openai_compat_asr_model() -> str:
+    from services import settings_store
+    return (
+        os.environ.get("ASR_OPENAI_COMPAT_MODEL")
+        or settings_store.get_text(_ASR_OPENAI_COMPAT_MODEL_KEY)
+        or "whisper-1"
+    )
+
+
+def resolve_openai_compat_asr_api_key() -> Optional[str]:
+    """Env → encrypted stored key → None. Unlike LLM providers, no 'local'
+    sentinel: many self-hosted transcription servers accept an empty/omitted
+    Authorization header outright, so the OpenAI SDK is constructed with
+    ``api_key="not-needed"`` (a non-empty placeholder the SDK requires) when
+    this returns None, rather than treating a keyless server as unconfigured.
+    """
+    from services import settings_store
+    return os.environ.get("ASR_OPENAI_COMPAT_API_KEY") or settings_store.get_secret(
+        _ASR_OPENAI_COMPAT_SECRET_NAME
+    )
+
+
+def openai_compat_asr_has_key() -> bool:
+    """Whether a key is configured, without ever decrypting it — mirrors
+    llm_providers.has_key()'s no-plaintext-round-trip contract."""
+    from services import settings_store
+    if os.environ.get("ASR_OPENAI_COMPAT_API_KEY"):
+        return True
+    return _ASR_OPENAI_COMPAT_SECRET_NAME in settings_store.list_secret_names()
+
+
+class OpenAICompatASRBackend(ASRBackend):
+    """Remote transcription via any OpenAI-compatible server.
+
+    Adapts whatever the server returns into this module's expected shape.
+    Prefers `response_format="verbose_json"` for real per-segment timestamps
+    (OpenAI's own API and most compatible servers support it); falls back to
+    plain text with rough single-segment bounds — mirroring
+    MoonshineASRBackend's degraded shape — for minimal servers that reject it.
+    """
+    id = "openai-compat-asr"
+    display_name = "OpenAI-compatible (remote server)"
+    gpu_compat = ("cpu",)  # network client only — no local compute
+
+    def __init__(self):
+        self._base_url = resolve_openai_compat_asr_base_url()
+        self._model = resolve_openai_compat_asr_model()
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        if not resolve_openai_compat_asr_base_url():
+            return False, "Configure a server endpoint in Settings → Engines"
+        try:
+            import openai  # noqa: F401
+        except ImportError:
+            return False, "openai package not installed. Install with: uv pip install openai"
+        return True, "ready"
+
+    def _client(self):
+        from openai import OpenAI
+        api_key = resolve_openai_compat_asr_api_key() or "not-needed"
+        # max_retries=0: mirrors llm_skills.resolve_skill_client — a
+        # rate-limited/slow server retrying inside the SDK would blow past
+        # whatever bounded timeout the caller (dub transcribe, dictation)
+        # expects from a single call.
+        return OpenAI(base_url=self._base_url, api_key=api_key, max_retries=0)
+
+    def transcribe(self, audio_path: str, *, word_timestamps: bool = True) -> dict:
+        logger.info(
+            "OpenAI-compat ASR transcribing %s (base_url=%s, model=%s)",
+            audio_path, self._base_url, self._model,
+        )
+        client = self._client()
+        try:
+            with open(audio_path, "rb") as f:
+                try:
+                    resp = client.audio.transcriptions.create(
+                        file=f, model=self._model, response_format="verbose_json",
+                    )
+                except Exception:
+                    # Minimal/older compatible servers reject verbose_json
+                    # outright — retry plain before treating it as a real
+                    # failure. Re-open: the SDK may have partially consumed
+                    # the file handle on the first attempt.
+                    f.seek(0)
+                    resp = client.audio.transcriptions.create(
+                        file=f, model=self._model, response_format="json",
+                    )
+        except Exception as exc:
+            # Never leak a raw SDK/httpx exception object (auth headers,
+            # connection internals) straight into a user-facing message —
+            # same convention as generation.py's _safe_exc_text (#977 class).
+            raise RuntimeError(
+                f"OpenAI-compatible ASR server at {self._base_url!r} failed: "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+        return self._adapt_response(resp)
+
+    @staticmethod
+    def _adapt_response(resp) -> dict:
+        segments_out = []
+        # verbose_json: resp.segments is a list of objects with start/end/text.
+        raw_segments = getattr(resp, "segments", None)
+        if raw_segments:
+            for seg in raw_segments:
+                seg_dict = seg if isinstance(seg, dict) else seg.model_dump()
+                segments_out.append({
+                    "text": (seg_dict.get("text") or "").strip(),
+                    "start": seg_dict.get("start", 0.0),
+                    "end": seg_dict.get("end", 0.0),
+                    "words": [],  # word-level timing isn't part of this API
+                })
+        else:
+            # Plain text response (json/text format) — single-segment shape,
+            # matching MoonshineASRBackend's degraded fallback exactly.
+            text = (getattr(resp, "text", None) or "").strip()
+            if text:
+                segments_out.append({"text": text, "start": 0.0, "end": None, "words": []})
+        chunks = [
+            {"text": seg["text"], "timestamp": (seg["start"], seg["end"])}
+            for seg in segments_out
+        ]
+        language = getattr(resp, "language", None) or "en"
+        return {"chunks": chunks, "segments": segments_out, "language": language}
+
+
 def _isolated_faster_whisper():
     """Lazy import so the subprocess_asr → subprocess_backend chain isn't
     pulled in at registry definition time."""
@@ -1689,6 +1845,7 @@ _REGISTRY: dict[str, type[ASRBackend]] = _LazyASRRegistry({
     "moonshine":       MoonshineASRBackend,
     "funasr":          FunASRBackend,
     "sherpa-onnx-asr": SherpaDictationBackend,
+    "openai-compat-asr": OpenAICompatASRBackend,
     # "faster-whisper-isolated": resolved lazily (crash-isolated subprocess).
 })
 
@@ -1713,6 +1870,13 @@ _INSTALL_HINTS: dict[str, str] = {
     "moonshine":       "pip install useful-moonshine  (edge/CPU-optimized ASR)",
     "funasr":          "pip install funasr  (SenseVoiceSmall + FSMN-VAD; CUDA or CPU)",
     "sherpa-onnx-asr": "uv add sherpa-onnx  (ONNX live dictation; CPU, cross-platform)",
+    "openai-compat-asr": (
+        "No install needed — configure a server endpoint in Settings → "
+        "Engines. Points OmniVoice at any OpenAI-compatible transcription "
+        "server (a self-hosted Qwen3-ASR/FunASR/SenseVoice server, OpenAI's "
+        "own Whisper API, or similar) — a path to Qwen3-ASR today, without "
+        "waiting on a direct transformers integration."
+    ),
     "faster-whisper-isolated": (
         "No extra install (reuses faster-whisper). Escape hatch for hanging "
         "transcribes: runs ASR in a separate process that can be force-killed "

--- a/docs/engines/openai-compatible-asr.md
+++ b/docs/engines/openai-compatible-asr.md
@@ -1,0 +1,41 @@
+# OmniVoice Studio — OpenAI-Compatible Remote ASR
+
+A path to Qwen3-ASR, a self-hosted FunASR/SenseVoice server, or OpenAI's own
+Whisper API — today, without waiting on `transformers` to ship a direct
+Qwen3-ASR integration (tracked separately). Unlike every other ASR engine,
+this one runs no model locally: it's a pure network client that calls any
+server exposing an OpenAI-compatible `POST /v1/audio/transcriptions`
+endpoint.
+
+## Setup
+
+No install step — configure it directly:
+
+1. Open **Settings → Models** and find **OpenAI-compatible ASR (remote
+   server)**.
+2. Set **Server URL** to your server's base URL (e.g.
+   `http://localhost:8000/v1` for a local Qwen3-ASR/FunASR server, or
+   `https://api.openai.com/v1` for OpenAI's own API).
+3. Set **Model** to whatever your server expects (`whisper-1` for OpenAI's
+   API; check your self-hosted server's docs otherwise).
+4. **API key** is optional — many self-hosted servers accept requests
+   without one. Set it if your server requires auth, or if you're using
+   OpenAI's own API.
+5. Activate the engine by setting `OMNIVOICE_ASR_BACKEND=openai-compat-asr`
+   before launching. There's no in-app ASR engine picker yet (only TTS
+   engines have one today) — this is the one manual step until that ships.
+
+## Response format
+
+The backend prefers `response_format=verbose_json` for real per-segment
+timestamps (OpenAI's API and most compatible servers support it) and falls
+back to plain text automatically if your server rejects that format. Neither
+path returns word-level timestamps — that's not part of this API.
+
+## Privacy note
+
+Unlike every other ASR engine in OmniVoice, audio sent through this backend
+leaves your machine — to whatever server you configured. If that's a
+self-hosted server on your own network, nothing leaves your control; if
+it's a third-party API (OpenAI's, or someone else's), review their data
+handling before sending anything sensitive.

--- a/docs/features.yaml
+++ b/docs/features.yaml
@@ -74,6 +74,8 @@ asr_engines:
     readme: FunASR
   - id: sherpa-onnx-asr
     readme: "**sherpa-onnx** (live dictation)"
+  - id: openai-compat-asr
+    readme: "**OpenAI-compatible** ⚠️ remote"
 
 # Doc files that must exist (the install path users are sent to).
 docs:

--- a/frontend/src/components/settings/AsrOpenAICompatPanel.jsx
+++ b/frontend/src/components/settings/AsrOpenAICompatPanel.jsx
@@ -1,0 +1,152 @@
+/**
+ * Settings → Models tab → OpenAI-compatible remote ASR panel (#877).
+ *
+ * A path to Qwen3-ASR, a self-hosted FunASR/SenseVoice server, or OpenAI's
+ * own Whisper API — today, without waiting on transformers to ship a direct
+ * Qwen3-ASR integration. Configures the `openai-compat-asr` backend's
+ * base_url/model/api_key; activating it as the active ASR engine still needs
+ * `OMNIVOICE_ASR_BACKEND=openai-compat-asr` (no in-app ASR engine picker
+ * exists yet for any ASR backend — this panel only configures this one).
+ *
+ * Endpoints (loopback-only):
+ *   GET /api/settings/asr-openai-compat  → {base_url, model, has_key}
+ *   PUT /api/settings/asr-openai-compat  body {base_url?, model?, api_key?}
+ *   ('' clears api_key; omitted/null leaves it unchanged — never returned)
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Mic } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { apiJson, apiFetch } from '../../api/client';
+import { SettingsSection, SettingRow, SettingsInput } from './primitives';
+import { Button } from '../../ui';
+
+export default function AsrOpenAICompatPanel() {
+  const { t } = useTranslation();
+  const [baseUrl, setBaseUrl] = useState('');
+  const [model, setModel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [hasKey, setHasKey] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const d = await apiJson('/api/settings/asr-openai-compat');
+      setBaseUrl(d?.base_url || '');
+      setModel(d?.model || '');
+      setHasKey(Boolean(d?.has_key));
+      setApiKey(''); // the key is never returned — the field always starts blank
+    } catch (e) {
+      setError(e?.message || t('models.asrOpenAICompatLoadError'));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const save = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/settings/asr-openai-compat', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          base_url: baseUrl,
+          model,
+          // Only send api_key when the user actually typed something —
+          // an untouched field must leave the stored key unchanged, not
+          // clear it (the field is always blank on load, so "unchanged"
+          // and "empty" would otherwise be indistinguishable).
+          ...(apiKey ? { api_key: apiKey } : {}),
+        }),
+      });
+      const d = await res.json();
+      setBaseUrl(d.base_url || '');
+      setModel(d.model || '');
+      setHasKey(Boolean(d.has_key));
+      setApiKey('');
+    } catch (e) {
+      setError(e?.message || t('models.asrOpenAICompatSaveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      icon={Mic}
+      title={t('models.asrOpenAICompatTitle')}
+      description={t('models.asrOpenAICompatDescription')}
+    >
+      {error && (
+        <div className="perfpanel__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <SettingRow
+        stack
+        title={t('models.asrOpenAICompatBaseUrlTitle')}
+        hint={t('models.asrOpenAICompatBaseUrlHint')}
+        control={
+          <SettingsInput
+            mono
+            type="text"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder="http://localhost:8000/v1"
+            data-testid="asr-openai-compat-base-url"
+          />
+        }
+      />
+
+      <SettingRow
+        stack
+        title={t('models.asrOpenAICompatModelTitle')}
+        control={
+          <SettingsInput
+            mono
+            type="text"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder="whisper-1"
+            data-testid="asr-openai-compat-model"
+          />
+        }
+      />
+
+      <SettingRow
+        stack
+        title={t('models.asrOpenAICompatApiKeyTitle')}
+        hint={
+          hasKey ? t('models.asrOpenAICompatKeyConfigured') : t('models.asrOpenAICompatApiKeyHint')
+        }
+        control={
+          <>
+            <SettingsInput
+              mono
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder={hasKey ? '••••••••' : t('models.asrOpenAICompatApiKeyOptional')}
+              data-testid="asr-openai-compat-api-key"
+            />
+            <Button
+              variant="subtle"
+              size="sm"
+              onClick={save}
+              loading={saving}
+              disabled={saving}
+              data-testid="asr-openai-compat-save"
+            >
+              {t('common.save')}
+            </Button>
+          </>
+        }
+      />
+    </SettingsSection>
+  );
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2014,7 +2014,18 @@
     "mirror_preset_hint": "On a restricted network, route model downloads through a mirror. Leave empty for the official endpoint.",
     "mirror_restart_note": "Model Store downloads use the new mirror immediately. Only model loads (transformers) pick it up after a restart.",
     "mirror_load_error": "Failed to load mirror setting",
-    "mirror_save_error": "Failed to save"
+    "mirror_save_error": "Failed to save",
+    "asrOpenAICompatTitle": "OpenAI-compatible ASR (remote server)",
+    "asrOpenAICompatDescription": "Point transcription at Qwen3-ASR, a self-hosted FunASR/SenseVoice server, or OpenAI's own API.",
+    "asrOpenAICompatBaseUrlTitle": "Server URL",
+    "asrOpenAICompatBaseUrlHint": "The base URL of an OpenAI-compatible transcription server. To use this engine, also set OMNIVOICE_ASR_BACKEND=openai-compat-asr — there's no in-app engine picker for ASR yet.",
+    "asrOpenAICompatModelTitle": "Model",
+    "asrOpenAICompatApiKeyTitle": "API key",
+    "asrOpenAICompatApiKeyHint": "Optional — many self-hosted servers don't require one.",
+    "asrOpenAICompatApiKeyOptional": "optional",
+    "asrOpenAICompatKeyConfigured": "A key is saved. Leave blank to keep it, or type a new one to replace it.",
+    "asrOpenAICompatLoadError": "Failed to load ASR server setting",
+    "asrOpenAICompatSaveError": "Failed to save"
   },
   "enterprise_faq": {
     "q_internal_tools": "Do I need a license for internal tools?",

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -22,6 +22,7 @@ import StoragePanel from '../components/settings/StoragePanel';
 import StorageTab from '../components/settings/StorageTab';
 import StorageUsagePanel from '../components/settings/StorageUsagePanel';
 import HFMirrorPanel from '../components/settings/HFMirrorPanel';
+import AsrOpenAICompatPanel from '../components/settings/AsrOpenAICompatPanel';
 import SharingPanel from '../components/settings/SharingPanel';
 import RemoteBackendPanel from '../components/settings/RemoteBackendPanel';
 import MCPBindingsPanel from '../components/settings/MCPBindingsPanel';
@@ -367,6 +368,7 @@ export default function Settings() {
           <>
             <StoragePanel />
             <HFMirrorPanel />
+            <AsrOpenAICompatPanel />
             <ModelStoreTab info={info} modelBadge={modelBadge} />
           </>
         );

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -18,6 +18,7 @@ DELETE /profiles/{profile_id}/consent
 DELETE /projects/{project_id}
 DELETE /pronunciation/{entry_id}
 GET /api/mcp/bindings
+GET /api/settings/asr-openai-compat
 GET /api/settings/changelog
 GET /api/settings/db-backup
 GET /api/settings/dictation-refinement
@@ -216,6 +217,7 @@ POST /v1/audio/transcriptions
 POST /watermark/detect
 POST /watermark/settings
 PUT /api/mcp/bindings
+PUT /api/settings/asr-openai-compat
 PUT /api/settings/dictation-refinement
 PUT /api/settings/hf-mirror
 PUT /api/settings/llm-endpoint

--- a/tests/test_asr_openai_compat_877.py
+++ b/tests/test_asr_openai_compat_877.py
@@ -1,0 +1,239 @@
+"""Generic OpenAI-compatible ASR backend (#877) — a path to Qwen3-ASR,
+FunASR/SenseVoice self-hosted servers, or OpenAI's own Whisper API, today,
+without waiting on transformers to ship a direct Qwen3-ASR integration.
+
+settings_store backed by in-memory dicts, OpenAI client faked at the SDK
+boundary (no network) — house convention, same as test_llm_providers_router.py:
+direct handler calls, no TestClient, so the loopback auth guard isn't in play.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+_HAS_OPENAI = __import__("importlib").util.find_spec("openai") is not None
+pytestmark = pytest.mark.skipif(not _HAS_OPENAI, reason="openai package not installed")
+
+
+@pytest.fixture
+def ss(monkeypatch):
+    """services.settings_store, resolved fresh (no module-level import — see
+    asr_mod's docstring for why staleness across sys.modules reimports is a
+    real risk in this suite) and patched to in-memory dicts (no SQLite)."""
+    from services import settings_store as _ss
+
+    text: dict[str, str] = {}
+    secrets: dict[str, str] = {}
+    monkeypatch.setattr(_ss, "get_text", lambda k, default=None: text.get(k, default))
+    monkeypatch.setattr(_ss, "set_text", lambda k, v: text.__setitem__(k, v))
+    monkeypatch.setattr(_ss, "get_secret", lambda n: secrets.get(n))
+    monkeypatch.setattr(
+        _ss, "set_secret", lambda n, v: secrets.__setitem__(n, v) if v else secrets.pop(n, None)
+    )
+    monkeypatch.setattr(_ss, "list_secret_names", lambda: list(secrets))
+    return _ss
+
+
+@pytest.fixture
+def asr_mod(ss, monkeypatch):
+    """services.asr_backend with settings_store in-memory (no SQLite).
+
+    Resolved via importlib.import_module INSIDE the fixture (not a top-level
+    `import` in this file) so it's the module object actually live in
+    sys.modules at test-run time — other test files in this ~2400-test suite
+    pop+reimport shared service modules (services.model_manager,
+    services.tts_backend), and a module-level import captured once at file
+    COLLECTION time can go stale by the time an individual test in this file
+    finally runs, hours of test-order later. A collection-time reference
+    calling .set_text() and a fixture-time reference reading via .get_text()
+    can silently be two different module objects — the write and the read
+    land in different in-memory dicts, and the test fails with no obvious
+    cause. Every test below takes `ss` as a fixture (not a module-level
+    `from services import settings_store`) for the same reason.
+    """
+    for var in ("ASR_OPENAI_COMPAT_BASE_URL", "ASR_OPENAI_COMPAT_MODEL", "ASR_OPENAI_COMPAT_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    import importlib
+    return importlib.import_module("services.asr_backend")
+
+
+@pytest.fixture
+def settings_mod(asr_mod):
+    """api.routers.settings sharing the same monkeypatched settings_store."""
+    import importlib
+    return importlib.import_module("api.routers.settings")
+
+
+def _fake_openai_transcribe(monkeypatch, *, verbose_ok=True, response=None, raise_exc=None):
+    """Fake openai.OpenAI whose audio.transcriptions.create() either returns
+    a canned response or raises. verbose_ok=False simulates a minimal server
+    that rejects response_format="verbose_json" on the first call, forcing
+    the plain-json fallback."""
+    captured_kwargs = []
+    calls = []
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured_kwargs.append(kwargs)
+            self.audio = types.SimpleNamespace(
+                transcriptions=types.SimpleNamespace(create=self._create)
+            )
+
+        def _create(self, **kw):
+            calls.append(kw)
+            if raise_exc is not None:
+                raise raise_exc
+            if kw.get("response_format") == "verbose_json" and not verbose_ok:
+                raise RuntimeError("response_format not supported")
+            return response
+
+    import openai
+    monkeypatch.setattr(openai, "OpenAI", _FakeClient)
+    return captured_kwargs, calls
+
+
+# ── is_available() gating ───────────────────────────────────────────────────
+
+
+def test_unavailable_without_base_url(asr_mod):
+    ok, msg = asr_mod.OpenAICompatASRBackend.is_available()
+    assert ok is False
+    assert "Settings" in msg
+
+
+def test_available_once_base_url_configured(asr_mod, ss):
+    ss.set_text(asr_mod._ASR_OPENAI_COMPAT_BASE_URL_KEY, "http://localhost:8080/v1")
+    ok, _ = asr_mod.OpenAICompatASRBackend.is_available()
+    assert ok is True
+
+
+# ── response adaptation ─────────────────────────────────────────────────────
+
+
+def test_transcribe_adapts_verbose_json_segments(asr_mod, ss, monkeypatch, tmp_path):
+    ss.set_text(asr_mod._ASR_OPENAI_COMPAT_BASE_URL_KEY, "http://localhost:8080/v1")
+
+    class _Seg:
+        def model_dump(self):
+            return {"text": "hello world", "start": 0.0, "end": 1.5}
+
+    resp = types.SimpleNamespace(segments=[_Seg()], language="en")
+    _fake_openai_transcribe(monkeypatch, response=resp)
+
+    audio = tmp_path / "seg.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")  # content is never read by the fake client
+    out = asr_mod.OpenAICompatASRBackend().transcribe(str(audio))
+    assert out["language"] == "en"
+    assert out["segments"] == [{"text": "hello world", "start": 0.0, "end": 1.5, "words": []}]
+    assert out["chunks"] == [{"text": "hello world", "timestamp": (0.0, 1.5)}]
+
+
+def test_transcribe_falls_back_to_plain_text_when_verbose_json_rejected(asr_mod, ss, monkeypatch, tmp_path):
+    ss.set_text(asr_mod._ASR_OPENAI_COMPAT_BASE_URL_KEY, "http://localhost:8080/v1")
+    resp = types.SimpleNamespace(text="plain text only", segments=None, language=None)
+    _captured, calls = _fake_openai_transcribe(monkeypatch, verbose_ok=False, response=resp)
+
+    audio = tmp_path / "seg.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")
+    out = asr_mod.OpenAICompatASRBackend().transcribe(str(audio))
+    assert len(calls) == 2  # verbose_json attempt, then the plain fallback
+    assert calls[0]["response_format"] == "verbose_json"
+    assert calls[1]["response_format"] == "json"
+    assert out["segments"] == [{"text": "plain text only", "start": 0.0, "end": None, "words": []}]
+    assert out["language"] == "en"  # default when the server doesn't report one
+
+
+def test_transcribe_network_failure_does_not_leak_raw_exception(asr_mod, ss, monkeypatch, tmp_path):
+    """Mirrors the #977 convention: a raw SDK/httpx exception must never reach
+    the caller unformatted — only a clean, actionable RuntimeError."""
+    ss.set_text(asr_mod._ASR_OPENAI_COMPAT_BASE_URL_KEY, "http://localhost:8080/v1")
+    _fake_openai_transcribe(monkeypatch, raise_exc=ConnectionError("connection refused"))
+
+    audio = tmp_path / "seg.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")
+    with pytest.raises(RuntimeError) as ei:
+        asr_mod.OpenAICompatASRBackend().transcribe(str(audio))
+    msg = str(ei.value)
+    assert "localhost:8080" in msg
+    assert "ConnectionError" in msg
+
+
+def test_client_disables_sdk_retries(asr_mod, ss, monkeypatch, tmp_path):
+    """max_retries=0 — mirrors llm_skills.resolve_skill_client: a slow/rate-
+    limited server retrying inside the SDK would blow past the caller's own
+    bounded timeout expectation for a single transcribe call."""
+    ss.set_text(asr_mod._ASR_OPENAI_COMPAT_BASE_URL_KEY, "http://localhost:8080/v1")
+    resp = types.SimpleNamespace(text="ok", segments=None, language="en")
+    captured_kwargs, _ = _fake_openai_transcribe(monkeypatch, response=resp)
+
+    audio = tmp_path / "seg.wav"
+    audio.write_bytes(b"RIFF....WAVEfmt ")
+    asr_mod.OpenAICompatASRBackend().transcribe(str(audio))
+    assert captured_kwargs[0]["max_retries"] == 0
+
+
+# ── settings endpoints ───────────────────────────────────────────────────────
+
+
+def test_get_default_empty(settings_mod):
+    st = settings_mod.get_asr_openai_compat()
+    assert st == {"base_url": "", "model": "whisper-1", "has_key": False}
+
+
+def test_put_persists_and_never_echoes_the_key(settings_mod):
+    st = settings_mod.set_asr_openai_compat(
+        settings_mod._ASROpenAICompatBody(
+            base_url="http://localhost:8080/v1/", model="qwen3-asr", api_key="sk-test-123",
+        )
+    )
+    assert st["base_url"] == "http://localhost:8080/v1"  # trailing slash trimmed
+    assert st["model"] == "qwen3-asr"
+    assert st["has_key"] is True
+    assert "sk-test-123" not in str(st)  # the key never round-trips
+
+    st2 = settings_mod.get_asr_openai_compat()
+    assert st2 == st
+
+
+def test_empty_api_key_clears_it(settings_mod):
+    settings_mod.set_asr_openai_compat(
+        settings_mod._ASROpenAICompatBody(api_key="sk-test-123")
+    )
+    assert settings_mod.get_asr_openai_compat()["has_key"] is True
+
+    settings_mod.set_asr_openai_compat(settings_mod._ASROpenAICompatBody(api_key=""))
+    assert settings_mod.get_asr_openai_compat()["has_key"] is False
+
+
+def test_none_fields_leave_existing_values_unchanged(settings_mod):
+    settings_mod.set_asr_openai_compat(
+        settings_mod._ASROpenAICompatBody(base_url="http://localhost:8080/v1", model="qwen3-asr")
+    )
+    # A save that only touches api_key must not clobber base_url/model.
+    settings_mod.set_asr_openai_compat(settings_mod._ASROpenAICompatBody(api_key="sk-abc"))
+    st = settings_mod.get_asr_openai_compat()
+    assert st["base_url"] == "http://localhost:8080/v1"
+    assert st["model"] == "qwen3-asr"
+    assert st["has_key"] is True
+
+
+def test_rejects_a_base_url_without_scheme(settings_mod):
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException):
+        settings_mod.set_asr_openai_compat(
+            settings_mod._ASROpenAICompatBody(base_url="localhost:8080/v1")
+        )
+
+
+def test_registered_in_backend_list(asr_mod):
+    assert "openai-compat-asr" in asr_mod._REGISTRY
+    assert asr_mod._REGISTRY["openai-compat-asr"] is asr_mod.OpenAICompatASRBackend
+    assert "openai-compat-asr" in asr_mod._INSTALL_HINTS


### PR DESCRIPTION
## First slice of #877's community proposal

The full ask (adopt Qwen3-ASR-0.6B directly) is blocked on `transformers>=5.13` stabilizing upstream — still true, still tracked separately, not attempted here. But a community member (LauraGPT) proposed splitting this into two tracks so OmniVoice doesn't have to wait: **add a generic OpenAI-compatible transcription backend now**, so anyone who wants Qwen3-ASR today can run it behind a compatible server (or use FunASR/SenseVoice self-hosted, or OpenAI's own API). This PR is that first track.

## What's new

- **`OpenAICompatASRBackend`** — a pure network client (no local model, no install) that calls `POST /v1/audio/transcriptions` on whatever server you configure. Prefers `response_format=verbose_json` for real per-segment timestamps; degrades to plain text (matching `MoonshineASRBackend`'s shape) for minimal servers that reject it. Never leaks a raw SDK/httpx exception to the user — wraps failures in a clean, actionable message (the #977 convention from earlier this session).
- **Settings**, encrypted the same way `llm_providers.py` already does it — the API key goes through `settings_store.set_secret` (Fernet-encrypted, per-install key, never a `.env` row, never echoed back); base_url/model are plain settings rows. New loopback-gated `GET`/`PUT /api/settings/asr-openai-compat`.
- **A small settings panel** (Settings → Models), structurally identical to `HFMirrorPanel`. Honest caveat documented plainly: there's no ASR engine *picker* UI yet for any ASR backend (only TTS has one) — activating this still needs `OMNIVOICE_ASR_BACKEND=openai-compat-asr`.
- README's ASR Engines table (9 → 10) and `docs/features.yaml`'s drift-checker inventory updated — corrected the "all fully local" claim, since this one genuinely sends audio to wherever you point it.
- `docs/engines/openai-compatible-asr.md` — setup steps + an explicit privacy note.

## Tests

New `tests/test_asr_openai_compat_877.py` (12 tests): availability gating, both response-adaptation shapes, network-failure error hygiene, SDK retry disabling (`max_retries=0`, matching `llm_skills.py`'s convention), and the settings endpoints' persist/mask/clear-vs-unchanged semantics.

## A real lesson from verification (not glossed over)

Testing this in isolation looked perfect (12/12), but the **full** suite caught two real problems I fixed properly rather than dismissed:
1. The API route-inventory snapshot (`tests/fixtures/api_routes.txt`) needed regenerating for the two new routes — expected maintenance, done.
2. My own test file had a genuine **module-staleness bug**: a collection-time `from services import settings_store` import went stale relative to a test-time-fresh fixture, because some other test elsewhere in the ~2400-test suite pops/reimports `services.settings_store` mid-session. Same root cause (and same fix — make the module a fixture resolved fresh at test-run time) as a bug I fixed earlier this session in `tests/test_mm2_lifecycle.py`. Worth flagging as a recurring hazard in this codebase's test suite for future test authors.

Full backend suite after the fix: **2402 passed, 0 failed**. Full frontend suite: **918 passed, 0 failed**. `docs-drift`: clean. CJK guard: clean. `bun run format:check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new OpenAI-compatible remote ASR backend (`openai-compat-asr`) that transcribes via `POST /v1/audio/transcriptions`, prefers `verbose_json` for segment timestamps, falls back to plain text/json when needed, and wraps SDK/network failures in user-facing errors with retries disabled.

Also added encrypted settings for the backend’s base URL, model, and API key, exposed through loopback-gated `GET`/`PUT` routes at `/api/settings/asr-openai-compat`, and wired a new Settings → Models panel for configuring it.

Updated docs and feature metadata to reflect the extra ASR engine, the remote nature of this option, and its setup/privacy implications.

Behavior flow:
```mermaid
flowchart TD
  A[Settings / backend config] --> B[Resolve base_url, model, api_key]
  B --> C{OpenAI package + base_url present?}
  C -- no --> D[Backend unavailable]
  C -- yes --> E[Create OpenAI client with max_retries=0]
  E --> F[POST /v1/audio/transcriptions]
  F --> G{verbose_json accepted?}
  G -- yes --> H[Normalize segments + chunks]
  G -- no --> I[Fallback to plain text/json]
  I --> H
  F --> J[Wrap failures in actionable RuntimeError]
```

UI sketch:
```text
Before: Settings → Models
+----------------------------+
| Storage                    |
| HF Mirror                  |
+----------------------------+

After: Settings → Models
+--------------------------------------+
| Storage                              |
| OpenAI-compatible ASR (remote)      |
|   Base URL [......................]  |
|   Model    [......................]  |
|   API key  [......................]  |
|   [Save]                            |
| HF Mirror                            |
+--------------------------------------+
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->