### PR TITLE
fix(clone): re-transcribe written reference clips so (ref_audio, ref_text) match (#1004)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -977,6 +977,9 @@ async def dub_transcribe_stream(
             from services.speaker_clone import extract_speaker_clones, auto_profile_id
             vocals_for_clone = job.get("vocals_path") or asr_audio_target
             clones = {}
+            # One-way latch: set when a reference re-transcription wedges past
+            # its timeout, so later references skip ASR entirely (see below).
+            _ref_tx_wedged = {"flag": False}
 
             def _ref_transcriber(path: str) -> str:
                 # Re-transcribe the exact written reference clip so its
@@ -991,8 +994,14 @@ async def dub_transcribe_stream(
                 # with a joined side thread instead. On timeout we return ""
                 # (caller falls back to the segment text) rather than letting
                 # a wedged transcribe (#730) keep the SSE ping loop alive
-                # forever. The abandoned daemon thread mirrors the guarded
-                # path's known tradeoff.
+                # forever. Once one call wedges, all later calls short-circuit:
+                # the abandoned thread may still hold the backend, and a second
+                # concurrent transcribe on a GPU backend risks corrupting its
+                # CUDA context.
+                from core.failure import sanitize
+
+                if _ref_tx_wedged["flag"]:
+                    return ""
                 done: list[str] = []
 
                 def _run():
@@ -1005,15 +1014,21 @@ async def dub_transcribe_stream(
                             ).strip()
                         done.append(text)
                     except Exception as e:
-                        logger.warning("ref re-transcription failed for %s: %s", path, e)
+                        logger.warning(
+                            "ref re-transcription failed for %s: %s", sanitize(path), e,
+                        )
+                        done.append("")
 
                 from services.asr_backend import ASR_TRANSCRIBE_TIMEOUT_S
                 t = threading.Thread(target=_run, daemon=True)
                 t.start()
                 t.join(ASR_TRANSCRIBE_TIMEOUT_S)
                 if not done:
+                    _ref_tx_wedged["flag"] = True
                     logger.warning(
-                        "ref re-transcription timed out for %s; keeping segment text", path,
+                        "ref re-transcription timed out for %s; falling back to "
+                        "segment text for this and all remaining references",
+                        sanitize(path),
                     )
                     return ""
                 return done[0]

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -976,6 +976,22 @@ async def dub_transcribe_stream(
             from services.speaker_clone import extract_speaker_clones, auto_profile_id
             vocals_for_clone = job.get("vocals_path") or asr_audio_target
             clones = {}
+
+            def _ref_transcriber(path: str) -> str:
+                # Re-transcribe the exact written reference clip so its
+                # (ref_audio, ref_text) pair matches by construction — the
+                # ASR segment text can drift from what is audible inside the
+                # sliced window, and a mismatched pair makes cross-language
+                # dubs speak the reference text verbatim (#1004). The ASR
+                # backend is still warm from the transcription pass above.
+                r = _asr_backend.transcribe(path, word_timestamps=False)
+                text = (r.get("text") or "").strip()
+                if not text:
+                    text = " ".join(
+                        (c.get("text") or "").strip() for c in (r.get("chunks") or [])
+                    ).strip()
+                return text
+
             if labels_source == "heuristic":
                 # Clone-purity guard: heuristic labels are silence-gap
                 # estimates, not voice identity — a per-speaker reference cut
@@ -998,6 +1014,7 @@ async def dub_transcribe_stream(
                         vocals_for_clone, final_segs,
                         os.path.dirname(vocals_for_clone),
                         labels_source=labels_source,
+                        transcriber=_ref_transcriber,
                     ),
                 )
                 while True:
@@ -1022,6 +1039,7 @@ async def dub_transcribe_stream(
                             vocals_for_clone, final_segs,
                             os.path.dirname(vocals_for_clone),
                             seg_ids=seg_ids_for_clone,
+                            transcriber=_ref_transcriber,
                         ),
                     )
                     if seg_clones:

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import shutil
 import subprocess
+import threading
 import soundfile as sf
 import torch
 from typing import Optional
@@ -984,13 +985,38 @@ async def dub_transcribe_stream(
                 # sliced window, and a mismatched pair makes cross-language
                 # dubs speak the reference text verbatim (#1004). The ASR
                 # backend is still warm from the transcription pass above.
-                r = _asr_backend.transcribe(path, word_timestamps=False)
-                text = (r.get("text") or "").strip()
-                if not text:
-                    text = " ".join(
-                        (c.get("text") or "").strip() for c in (r.get("chunks") or [])
-                    ).strip()
-                return text
+                #
+                # Runs inside the clone-extraction executor thread, so the
+                # async run_transcribe_guarded can't wrap it — bound the call
+                # with a joined side thread instead. On timeout we return ""
+                # (caller falls back to the segment text) rather than letting
+                # a wedged transcribe (#730) keep the SSE ping loop alive
+                # forever. The abandoned daemon thread mirrors the guarded
+                # path's known tradeoff.
+                done: list[str] = []
+
+                def _run():
+                    try:
+                        r = _asr_backend.transcribe(path, word_timestamps=False)
+                        text = (r.get("text") or "").strip()
+                        if not text:
+                            text = " ".join(
+                                (c.get("text") or "").strip() for c in (r.get("chunks") or [])
+                            ).strip()
+                        done.append(text)
+                    except Exception as e:
+                        logger.warning("ref re-transcription failed for %s: %s", path, e)
+
+                from services.asr_backend import ASR_TRANSCRIBE_TIMEOUT_S
+                t = threading.Thread(target=_run, daemon=True)
+                t.start()
+                t.join(ASR_TRANSCRIBE_TIMEOUT_S)
+                if not done:
+                    logger.warning(
+                        "ref re-transcription timed out for %s; keeping segment text", path,
+                    )
+                    return ""
+                return done[0]
 
             if labels_source == "heuristic":
                 # Clone-purity guard: heuristic labels are silence-gap

--- a/backend/services/speaker_clone.py
+++ b/backend/services/speaker_clone.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 
 import numpy as np
 import soundfile as sf
@@ -55,12 +56,43 @@ MIN_SLICE_DURATION_S = 1.5
 ADJACENT_TURN_GUARD_S = 0.3
 
 
+def _retranscribe_ref(
+    transcriber: Callable[[str], str] | None,
+    ref_path: str,
+    fallback: str,
+    label: str,
+) -> str:
+    """Return a transcript that matches the written reference clip.
+
+    ASR segment text routinely drifts from what is actually audible inside
+    the sliced ``[start, end]`` window (boundary jitter, dropped trailing
+    words). A mismatched ``(ref_audio, ref_text)`` pair breaks the TTS
+    prompt priming and can make cross-language dubs speak the reference
+    text verbatim in the source language (#1004). Re-transcribing the exact
+    written clip makes the pair match by construction. Falls back to the
+    segment text when no transcriber is given, ASR fails, or ASR returns
+    nothing.
+    """
+    if transcriber is None:
+        return fallback
+    try:
+        text = (transcriber(ref_path) or "").strip()
+    except Exception as e:
+        logger.warning(
+            "%s: reference re-transcription failed (%s); keeping segment text",
+            label, e,
+        )
+        return fallback
+    return text or fallback
+
+
 def extract_speaker_clones(
     vocals_path: str,
     segments: list[dict],
     out_dir: str,
     *,
     labels_source: str | None = None,
+    transcriber: Callable[[str], str] | None = None,
 ) -> dict[str, dict]:
     """Build a per-speaker reference sample from `vocals_path` + `segments`.
 
@@ -141,6 +173,7 @@ def extract_speaker_clones(
             continue
 
         ref_text = " ".join((seg.get("text") or "").strip() for _, seg in chosen).strip()
+        ref_text = _retranscribe_ref(transcriber, ref_path, ref_text, "speaker_clone")
         out[speaker_id] = {
             "ref_audio": ref_path,
             "ref_text": ref_text,
@@ -161,6 +194,7 @@ def extract_segment_refs(
     out_dir: str,
     *,
     seg_ids: list | None = None,
+    transcriber: Callable[[str], str] | None = None,
 ) -> dict[str, dict]:
     """Per-segment clone references (Wave 3.2 / Spec 4).
 
@@ -213,6 +247,7 @@ def extract_segment_refs(
         # reference transcript is the SOURCE text (text_original), not the
         # translated `text`. Falls back to text only if no original is kept.
         ref_text = (seg.get("text_original") or seg.get("text") or "").strip()
+        ref_text = _retranscribe_ref(transcriber, ref_path, ref_text, "segment_refs")
         out[seg_id] = {
             "ref_audio": ref_path,
             "ref_text": ref_text,


### PR DESCRIPTION
Closes #1004

## Problem

`extract_speaker_clones` / `extract_segment_refs` pair the sliced vocals audio with the ASR segment text. Whisper's segment text routinely drifts from what is actually audible inside `[start, end]` (boundary jitter, dropped trailing words). When the `(ref_audio, ref_text)` pair disagrees, TTS prompt priming breaks down and cross-language dubs can speak the **reference text verbatim in the source language** — see the A/B evidence in #1004 (mismatched pair: 6/6 generations came out in the source language; matched pair: clean target-language output on the first try).

The module docstring already states the invariant this PR enforces: *"The accompanying transcript text must align with the audio slice or the TTS cloner will mis-align its phoneme lookups."*

## Fix

After writing each reference wav (per-speaker and per-segment), re-transcribe the exact written clip via the active ASR backend and use that transcript as `ref_text`. The pair now matches by construction.

- `speaker_clone.py`: new `_retranscribe_ref()` helper + optional `transcriber` kwarg on both extract functions. `transcriber=None` (default) keeps the previous behaviour, so existing callers/tests are unaffected.
- `dub_core.py`: the transcribe flow passes a small wrapper around the live `_asr_backend` (already warm — the transcription pass just used it). Reads `text` with a `chunks`-join fallback so every ASR backend shape works.
- Any ASR failure logs a warning and falls back to the segment text — never worse than before.

## Cost

One extra short ASR call per written reference on a warm backend. Per-speaker refs are few; per-segment refs add roughly one call per ≥3 s segment.

## Verification (real ko→es dub, Docker/CUDA)

- Before: the CEO speaker's auto-clone `ref_text` was missing the trailing word audible in the clip; every generation using it spoke Korean instead of Spanish.
- After: stored `ref_text` matches an independent transcription of the written clips at 0.97–0.99 similarity for all speaker clones, and the verbatim source-language failure no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes cross-language dubbing failures caused by `(ref_audio, ref_text)` mismatches by re-transcribing the exact WAV reference clip immediately after it’s written, using the already-warmed ASR backend; the re-transcript replaces `ref_text` for both per-speaker and per-segment clone references (falling back to the original segment text if re-transcription fails or times out).

```mermaid
flowchart LR
  A[Slice vocal audio window(s)] --> B[Write reference WAV(s)]
  B --> C{transcriber provided?}
  C -- no --> Z[Use computed segment text as ref_text]
  C -- yes --> D{one-way wedged latch?}
  D -- yes --> Y[Return \"\" immediately]
  D -- no --> E[Start daemon thread:\n_asr_backend.transcribe(ref)\njoin <= ASR_TRANSCRIBE_TIMEOUT_S]
  E --> F{thread finished?}
  F -- no --> G[Set _ref_tx_wedged flag;\nlog warning (sanitized path);\nreturn \"\"]
  F -- yes --> H[Extract transcript:\nprefer r.text else concat chunk.text;\ntrim]
  H --> Y[Return transcript (possibly empty)]
  G --> Y
  Y --> I[_retranscribe_ref:\nif empty/exception -> fallback segment text\nelse use re-transcript as ref_text]
  I --> J[Clone/TTS prompt priming uses matching (ref_audio, ref_text)]
```

- `backend/services/speaker_clone.py`
  - Added `transcriber: Callable[[str], str] | None` support to both:
    - `extract_speaker_clones(...)` (overwrites `ref_text` from the written per-speaker WAV)
    - `extract_segment_refs(...)` (overwrites `ref_text` from the written per-segment WAV)
  - New `_retranscribe_ref(...)` helper:
    - if no transcriber: returns `fallback`
    - if transcriber throws or returns empty/whitespace: logs warning (by label) and falls back to `fallback`
- `backend/api/routers/dub_core.py`
  - In the `/dub/transcribe-stream/{job_id}` SSE auto-speaker-clone flow, added `_ref_transcriber(path)`:
    - logs reference paths via `core.failure.sanitize`
    - runs ` _asr_backend.transcribe(path, word_timestamps=False)` in a joined daemon thread bounded by `ASR_TRANSCRIBE_TIMEOUT_S`
    - on timeout: sets a one-way latch (`_ref_tx_wedged`) so all later reference re-transcriptions short-circuit and return `""`, preventing backend wedging/races
    - falls back to segment text when the helper returns `""` (handled by `_retranscribe_ref`)
- Net effect: ensures the audible slice’s transcript matches the exact written reference clip, preventing prompts from priming with source-language reference text in cross-language dubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->