### PR TITLE
docs(agents): add verified Tesla T4 (16GB) inference notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,16 @@ consistent with waiting on a download, not compute. Once the checkpoint is cache
 request succeeds in ~1s (reproduced 5x: 1.574s / 1.034s / 1.065s / 0.995s / 0.911s).
 
 **Workaround (no code change needed, both already exist):**
-- For headless/API-only setups, call `POST /models/install` to pre-fetch the checkpoint before
-  your first real TTS request, or
-- Raise `OMNIVOICE_GENERATE_TIMEOUT_S` for the first request.
+- For headless/API-only setups, pre-fetch the checkpoint before your first real TTS request:
+  ```bash
+  curl -X POST http://localhost:8000/models/install \
+    -H "Content-Type: application/json" \
+    -d '{"repo_id": "k2-fsa/OmniVoice"}'
+  ```
+  (`repo_id` is required — `InstallModelRequest` in `backend/api/schemas.py` rejects a bare/empty
+  body — and must match one of the entries in `KNOWN_MODELS`, e.g. the default engine's
+  `k2-fsa/OmniVoice`.) Progress streams over the existing `/setup/download-stream` SSE feed.
+- Or raise `OMNIVOICE_GENERATE_TIMEOUT_S` for the first request.
 
 ## OpenAI-compatible endpoint doesn't expose `num_step` / `guidance_scale`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md — verified Tesla T4 (16GB) inference notes
+
+Measured on a real NVIDIA Tesla T4 (16GB, Turing/sm_75), driver 550.163.01 (CUDA 12.8), torch
+2.8.0+cu128, transformers 5.3.0, Python 3.11.15 (uv-managed). Engine under test: the default
+`omnivoice` TTS backend (`OMNIVOICE_TTS_BACKEND=omnivoice`).
+
+## Cold-cache first call can time out at 300s
+
+The first `generate()` call lazily downloads the ~2.3GB `k2-fsa/OmniVoice` checkpoint, and that
+download happens *inside* the `OMNIVOICE_GENERATE_TIMEOUT_S` budget (default 300s). On a fresh
+install, the very first `POST /v1/audio/speech` can fail like this even though the GPU isn't
+actually short on memory:
+
+```
+ERROR [omnivoice.openai_compat] OpenAI TTS failed: OpenAI TTS generate exceeded 300s and was
+abandoned — the backend is running, but the job was too heavy for the available compute.
+... most often the GPU is VRAM-starved ...
+```
+
+VRAM sampling during the failure showed a flat ~2GB with 0% GPU utilization for the whole 300s —
+consistent with waiting on a download, not compute. Once the checkpoint is cached, the identical
+request succeeds in ~1s (reproduced 5x: 1.574s / 1.034s / 1.065s / 0.995s / 0.911s).
+
+**Workaround (no code change needed, both already exist):**
+- For headless/API-only setups, call `POST /models/install` to pre-fetch the checkpoint before
+  your first real TTS request, or
+- Raise `OMNIVOICE_GENERATE_TIMEOUT_S` for the first request.
+
+## OpenAI-compatible endpoint doesn't expose `num_step` / `guidance_scale`
+
+`POST /v1/audio/speech`'s request schema doesn't declare `num_step` or `guidance_scale` fields —
+sending them in the JSON body returns `200 OK` but they're silently discarded (pydantic's default
+`extra=ignore` behavior). The native multipart `POST /generate` endpoint *does* expose both as
+explicit form fields, so use that endpoint if you need to control them.
+
+Separately: the app's own default for `num_step` is 16 — half of the model's documented default of
+32 (see `docs/generation-parameters.md`, "Use 16 for faster inference"). Not a bug, just not stated
+that the app already runs the "fast" preset unless you override it via `/generate`.
+
+## T4 acceleration checklist
+
+| Option | Status |
+|---|---|
+| dtype | `torch.float16` hardcoded for the `omnivoice` engine (`model_manager.py`) — correct for Turing (no bf16 tensor cores this generation). No env var override for this engine specifically (ASR engines have `ASR_COMPUTE_TYPE`; `dots_tts`/`indextts` have their own precision vars; `omnivoice` doesn't). |
+| Attention | `sdpa`, selected automatically since `flash_attn` isn't installed (`_supports_flash_attn_2=True` is declared but the package itself is absent) — safe on T4. |
+| int8 | No int8 path for this engine (ASR's CTranslate2 `int8` and `sherpa-onnx`'s int8 ONNX models are separate/unrelated). |
+| CUDA Graphs | No direct API usage in the app. Reachable indirectly via `torch.compile(mode="reduce-overhead")`, which the app attempts **by default** on this GPU (T4/sm_75 isn't in the framework's compile-exclusion list, unlike newer/Blackwell GPUs). The numbers above were measured with `TORCH_COMPILE_DISABLE=1` for a clean eager baseline. |
+| torch.compile | Attempted by default on T4 (see above) — not evaluated further here. |
+
+## VRAM
+
+Peak measured: 2487 MiB (`nvidia-smi`) / 2.050 GB (`torch.cuda.max_memory_allocated()`) for the
+default `omnivoice` engine — comfortably fits even the README's stated "minimum" (4GB) tier.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ request succeeds in ~1s (reproduced 5x: 1.574s / 1.034s / 1.065s / 0.995s / 0.91
 **Workaround (no code change needed, both already exist):**
 - For headless/API-only setups, pre-fetch the checkpoint before your first real TTS request:
   ```bash
-  curl -X POST http://localhost:8000/models/install \
+  curl -X POST http://localhost:3900/models/install \
     -H "Content-Type: application/json" \
     -d '{"repo_id": "k2-fsa/OmniVoice"}'
   ```

--- a/docs/hardware-notes-tesla-t4.md
+++ b/docs/hardware-notes-tesla-t4.md
@@ -1,4 +1,4 @@
-# AGENTS.md — verified Tesla T4 (16GB) inference notes
+# Verified Tesla T4 (16GB) inference notes
 
 Measured on a real NVIDIA Tesla T4 (16GB, Turing/sm_75), driver 550.163.01 (CUDA 12.8), torch
 2.8.0+cu128, transformers 5.3.0, Python 3.11.15 (uv-managed). Engine under test: the default


### PR DESCRIPTION
## Summary

Adds a new `AGENTS.md` (no code changes) documenting two things found while verifying inference on a Tesla T4 (16GB):

1. **Cold-cache first call to `/v1/audio/speech` can time out at 300s.** The first `generate()` call lazily downloads the ~2.3GB `omnivoice` checkpoint *inside* the `OMNIVOICE_GENERATE_TIMEOUT_S` budget (default 300s), so a fresh install's first request can fail with the "GPU-pool worker abandoned" 500 error even though nothing is actually VRAM-starved — it's just still downloading. Once cached, the same request succeeds in ~1s (reproduced 5x). This is already avoidable with existing features (`POST /models/install` to pre-fetch, or raising `OMNIVOICE_GENERATE_TIMEOUT_S`) — just not documented for headless/API-only usage.
2. **The OpenAI-compatible `/v1/audio/speech` endpoint silently ignores `num_step`/`guidance_scale`.** Its request schema (`backend/api/routers/openai_compat.py`) doesn't declare those fields, so sending them in the JSON body is accepted (200 OK) but discarded — confirmed by comparing against the native `/generate` endpoint, which *does* declare `num_step`/`guidance_scale` as explicit form fields. Also noted: the app's own default for `num_step` is 16, half of the 32 documented as the model's default in `docs/generation-parameters.md` — not wrong, just not stated anywhere that the app already uses the "fast" preset by default.

No code/behavior change.

## Verification (Tesla T4 16GB)

- Environment: driver 550.163.01 (CUDA 12.8), torch 2.8.0+cu128, transformers 5.3.0, Python 3.11.15 (uv-managed).
- Warm-cache `POST /v1/audio/speech` reproduced 5x: 1.574s / 1.034s / 1.065s / 0.995s / 0.911s, all 200 OK.
- Peak VRAM: 2487 MiB (nvidia-smi) / 2.050 GB (`torch.cuda.max_memory_allocated()`) — comfortably under even the README's stated "minimum" (4GB) tier, let alone "recommended" (8GB+).
- Confirmed via source (`model_manager.py:840`) that the default `omnivoice` engine already loads in `torch.float16` — correct choice for Turing/T4 (no bf16 tensor cores on this generation) — and uses `sdpa` attention automatically since `flash_attn` isn't installed. No int8 path exists for this engine. `torch.compile(mode="reduce-overhead")` is attempted by default on this GPU architecture (T4/sm_75 isn't in the framework's compile-exclusion list) — this PR's benchmark numbers were measured with `TORCH_COMPILE_DISABLE=1` for a clean eager baseline, noted in `AGENTS.md`.
- Confirmed the declared `speed` field *does* work (2x speed → output duration 5.8s → 3.04s), to contrast with the two silently-ignored fields above.

<details><summary>Raw metrics JSON</summary>

```json
{
  "env": {"gpu": "Tesla T4", "driver": "550.163.01", "cuda": "12.8", "torch": "2.8.0+cu128", "transformers": "5.3.0"},
  "warm_cache_calls_s": [1.574, 1.034, 1.065, 0.995, 0.911],
  "peak_vram_nvidia_smi_mib": 2487,
  "peak_vram_torch_alloc_gb": 2.050166784
}
```
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added verified Tesla T4 hardware notes in `docs/hardware-notes-tesla-t4.md`.

- Documented the test environment, backend defaults, and measured warm-cache performance/VRAM usage on a Tesla T4 (16GB).
- Recorded the cold-cache first-call timeout case for `/v1/audio/speech`, where lazy checkpoint download can exceed the 300s generate timeout and trigger a worker-abandoned 500 on fresh installs.
- Noted workarounds: pre-installing the model via `POST /models/install` or increasing the timeout.
- Clarified that `/v1/audio/speech` accepts but ignores `num_step` and `guidance_scale`, while the native `/generate` endpoint supports them.
- Included the app/model default `num_step` discrepancy and a T4 acceleration checklist.

The notes were moved out of `AGENTS.md` into the docs path to avoid conflicting with auto-loaded agent instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->