### PR TITLE
fix(tts): forward ref_text in MLXAudioBackend so CSM cloning doesn't crash

### DIFF
--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -849,6 +849,7 @@ class MLXAudioBackend(TTSBackend):
 
         voice     = kw.get("voice")
         ref_audio = kw.get("ref_audio")
+        ref_text  = kw.get("ref_text")
         language  = kw.get("language")
         speed     = float(kw.get("speed", 1.0))
 
@@ -858,6 +859,12 @@ class MLXAudioBackend(TTSBackend):
         # — we pass them all and let the engine ignore what it doesn't use.
         kwargs = {"text": text, "speed": speed}
         if voice:     kwargs["voice"] = voice
+        # CSM (sesame) only builds its voice-clone context when BOTH ref_audio
+        # and ref_text are present — with ref_text missing it silently builds
+        # an empty context and later crashes with an unrelated-looking
+        # `IndexError: list index out of range`. Forward it whenever we have
+        # both, same as every other ref_text-accepting backend in this file.
+        if ref_audio and ref_text: kwargs["ref_text"] = ref_text
         if ref_audio: kwargs["ref_audio"] = ref_audio
         if language and language != "Auto":
             if self._model_id == self.CURATED_MODELS.get("kokoro"):

--- a/tests/backend/services/test_mlx_audio_ref_text.py
+++ b/tests/backend/services/test_mlx_audio_ref_text.py
@@ -1,0 +1,69 @@
+"""Regression: MLXAudioBackend.generate() must forward ref_text.
+
+CSM (sesame) only builds its voice-clone context when BOTH ref_audio and
+ref_text are present. Before this fix, generate() read voice/ref_audio/
+language/speed from kwargs but silently dropped ref_text, so cloning on the
+CSM engine always crashed downstream with an unrelated-looking
+`IndexError: list index out of range` (sesame.py builds an empty context and
+then indexes context[0]) — even though generation.py's caller already has a
+ref_text (either user-supplied or auto-transcribed at ~line 780).
+"""
+from __future__ import annotations
+
+# tests/conftest.py prepends ./backend to sys.path so `services.*` resolves.
+from services.tts_backend import MLXAudioBackend
+
+
+class _FakeResult:
+    def __init__(self, audio):
+        self.audio = audio
+
+
+class _FakeModel:
+    """Stands in for the loaded mlx-audio model — records the kwargs
+    generate() was called with instead of doing real inference."""
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        yield _FakeResult([0.0, 0.0, 0.0])
+
+
+def _backend_with_fake_model(monkeypatch) -> tuple[MLXAudioBackend, _FakeModel]:
+    backend = MLXAudioBackend()
+    fake_model = _FakeModel()
+    monkeypatch.setattr(backend, "_ensure_loaded", lambda: setattr(backend, "_model", fake_model))
+    return backend, fake_model
+
+
+def test_ref_text_forwarded_when_ref_audio_present(monkeypatch):
+    backend, fake_model = _backend_with_fake_model(monkeypatch)
+
+    backend.generate("hello", ref_audio="/tmp/ref.wav", ref_text="reference transcript")
+
+    assert fake_model.calls, "generate() was never called on the model"
+    assert fake_model.calls[0].get("ref_text") == "reference transcript"
+    assert fake_model.calls[0].get("ref_audio") == "/tmp/ref.wav"
+
+
+def test_ref_text_omitted_without_ref_audio(monkeypatch):
+    """ref_text alone (no ref_audio) shouldn't be forwarded — matches the
+    existing ref_audio-gated pattern used by every other backend in this
+    file (e.g. omnivoice_gguf, dots_tts)."""
+    backend, fake_model = _backend_with_fake_model(monkeypatch)
+
+    backend.generate("hello", ref_text="orphaned transcript, no ref_audio")
+
+    assert "ref_text" not in fake_model.calls[0]
+
+
+def test_no_ref_text_still_works(monkeypatch):
+    """Design/instruct path (no ref_audio, no ref_text) is unaffected."""
+    backend, fake_model = _backend_with_fake_model(monkeypatch)
+
+    backend.generate("hello")
+
+    assert "ref_text" not in fake_model.calls[0]
+    assert "ref_audio" not in fake_model.calls[0]


### PR DESCRIPTION
## Summary
- `MLXAudioBackend.generate()` read `voice`/`ref_audio`/`language`/`speed` from `kwargs` but never read `ref_text`, so it was silently dropped before reaching `self._model.generate()`.
- CSM (sesame) only builds its voice-clone context when **both** `ref_audio` and `ref_text` are present. Without `ref_text`, the context stays empty and indexing it later raises an unrelated-looking `IndexError: list index out of range` — so voice cloning on the CSM engine could never work as shipped, even though `generation.py` already has a `ref_text` by the time it calls the backend (user-supplied, or auto-transcribed at `generation.py:~780` when absent).
- Every sibling backend in this file (`omnivoice_gguf`, `moss_tts_v15`, `dots_tts`) already forwards `ref_text` — `MLXAudioBackend` was the outlier.

## Fix
Forward `ref_text` whenever `ref_audio` is also present, matching the existing pattern used by the other `ref_text`-accepting backends:

```python
if ref_audio and ref_text: kwargs["ref_text"] = ref_text
```

## Test plan
- Added `tests/backend/services/test_mlx_audio_ref_text.py` (3 tests, mocked model — no real `mlx_audio`/CSM weights needed): `ref_text` is forwarded when `ref_audio` is present, omitted when `ref_audio` is absent, and the no-ref design/instruct path is unaffected.
- `uv run pytest backend/ -x -q` — 132 passed.

Related: surfaced while triaging #1013 (a separate mic-permission issue, whose body had this diagnosis pasted into it by mistake — not related to this fix).

## Contribution license
Submitting under AGPL-3.0 per CONTRIBUTING.md, including the commercial-dual-license grant to the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed `MLXAudioBackend.generate()` to forward `ref_text` only when `ref_audio` is present, matching the behavior of the other TTS backends.
- Added regression tests covering:
  - `ref_text` is forwarded with `ref_audio`
  - `ref_text` is omitted without `ref_audio`
  - the no-reference path remains unchanged

```mermaid
flowchart TD
  A[generate() called] --> B{ref_audio provided?}
  B -- no --> C[Do not forward ref_text]
  B -- yes --> D{ref_text provided?}
  D -- yes --> E[Forward ref_audio + ref_text to MLX model]
  D -- no --> F[Forward ref_audio only]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->