### PR TITLE
fix(macos): add microphone/camera entitlements

### DIFF
--- a/frontend/src-tauri/entitlements.plist
+++ b/frontend/src-tauri/entitlements.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Tauri's macOS bundle defaults `hardenedRuntime` to true. Hardened
+        Runtime blocks camera/microphone hardware access unless the matching
+        entitlement is present here — regardless of Info.plist's
+        NSMicrophoneUsageDescription and regardless of wry's own WKUIDelegate
+        already granting the request at the WebKit/JS layer
+        (WryWebViewUIDelegate::request_media_capture_permission unconditionally
+        calls WKPermissionDecision::Grant). Without this entitlement, TCC
+        never even registers a request for the app — nothing shows up in
+        System Settings → Privacy & Security → Microphone to enable, because
+        the OS never saw a legitimately-entitled process ask.
+    -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+
+    <!--
+        Matches Info.plist's forward-looking NSCameraUsageDescription — no
+        current feature uses the camera, but ship the entitlement now so a
+        future getUserMedia({video: true}) call doesn't hit this same bug.
+    -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -79,9 +79,18 @@ pub const TRAY_ICON_RECORDING: &[u8] = include_bytes!("../icons/tray-recording.p
 //   applies on top.
 // - Linux (WebKitGTK): media-stream must be enabled per-WebView and the
 //   permission request answered programmatically.
-// - macOS (WKWebView): nothing to do here — wry grants media-capture to the
-//   app origin and the user-visible consent is the system TCC prompt driven
-//   by NSMicrophoneUsageDescription in src-tauri/Info.plist.
+// - macOS (WKWebView): nothing to do here in code — wry's own WKUIDelegate
+//   (WryWebViewUIDelegate::request_media_capture_permission) already grants
+//   every media-capture request unconditionally at the WebKit/JS layer. But
+//   that alone isn't sufficient (#1013): Tauri's macOS bundle defaults
+//   `hardenedRuntime` to true, and Hardened Runtime blocks camera/microphone
+//   hardware access unless the matching entitlement is present — without it,
+//   TCC never even registers a request, so the app never appears in System
+//   Settings → Privacy & Security → Microphone for the user to enable. See
+//   src-tauri/entitlements.plist (wired in via tauri.conf.json's
+//   bundle.macOS.entitlements) for the actual grant; NSMicrophoneUsageDescription
+//   in Info.plist only supplies the *prompt text* TCC shows, it doesn't
+//   substitute for the entitlement.
 
 /// True for origins the app itself serves: the Tauri custom-protocol origin
 /// in production and the Vite dev server / loopback in `tauri dev`.

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -85,7 +85,8 @@
     ],
     "macOS": {
       "minimumSystemVersion": "12.0",
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "entitlements": "entitlements.plist"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Root cause

`getUserMedia()` in the WebView needs two separate grants on macOS — this fixes the second, missing one.

1. **WebKit/JS-layer grant** — already fine. `wry` 0.55.1's own `WKUIDelegate` (`WryWebViewUIDelegate::request_media_capture_permission`, in `wkwebview/class/wry_web_view_ui_delegate.rs`) unconditionally calls `WKPermissionDecision::Grant` for every media-capture request. Confirmed by reading the vendored source — this was never the bug.
2. **OS/Hardened-Runtime-layer grant — the actual gap.** Tauri's macOS bundle config defaults `hardenedRuntime` to `true`. Hardened Runtime blocks camera/microphone hardware access unless the matching entitlement is present in the signed binary — **regardless** of `Info.plist`'s `NSMicrophoneUsageDescription` (that only supplies the *prompt text* TCC would show, it isn't the grant itself). With Hardened Runtime on and zero entitlements, TCC never registers a request for the app at all — which is exactly the reported symptom: OmniVoice never appears in Privacy & Security → Microphone because the OS never saw a legitimately-entitled process ask.

This also explains the workaround already found in #1013: launching `Contents/MacOS/omnivoice-studio` directly from Terminal *does* trigger a real system prompt — attributed to **Terminal**, not the app. Terminal is a properly entitled, hardened-runtime, notarized system process; the ad-hoc-signed, unentitled app binary isn't, so when the request can't be attributed to the app's own identity, TCC falls back up the process tree to the (entitled) launching process.

## Fix

- Add `frontend/src-tauri/entitlements.plist` — `com.apple.security.device.audio-input`, plus `com.apple.security.device.camera` (matching the forward-looking `NSCameraUsageDescription` already in `Info.plist`).
- Wire it in via `tauri.conf.json`'s `bundle.macOS.entitlements`.
- Correct the stale `lib.rs` comment above `grant_webview_media_permissions` that documented the (falsified) assumption "macOS: nothing to do here."

## Verification

Built a debug `.app` (`bun run --cwd frontend tauri build --debug --bundles app`) and diffed `codesign -dv --entitlements -` before/after:

**Before** (current `main`, and matches the installed 0.3.12 release I have on this Mac):
```
CodeDirectory ... flags=0x10002(adhoc,runtime) ...
TeamIdentifier=not set
(no entitlements printed)
```

**After** (this branch):
```
CodeDirectory ... flags=0x10002(adhoc,runtime) ...
TeamIdentifier=not set
[Dict]
	[Key] com.apple.security.device.audio-input
	[Value] [Bool] true
	[Key] com.apple.security.device.camera
	[Value] [Bool] true
```

`cargo test` — 60 passed, 0 failed.

I wasn't able to fully exercise the live record button end-to-end in this build (external binaries — `uv`/`ffmpeg`/`ffprobe` — are `build.rs`-generated empty placeholders in a local debug build, so the Python backend doesn't actually run), but the entitlement — the exact thing Hardened Runtime checks — is now confirmed present where it wasn't before. Happy to test a real signed build if one gets cut.

Closes #1013.

## Cross-platform parity
This restores parity rather than diverging from it — Windows (WebView2 `PermissionRequested`) and Linux (WebKitGTK `connect_permission_request`) already grant media capture correctly in `grant_webview_media_permissions`; only macOS was silently broken. No new platform-divergent default behavior.

## Contribution license
Submitting under AGPL-3.0 per CONTRIBUTING.md, including the commercial-dual-license grant to the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes macOS microphone/camera access for OmniVoice Studio by adding the required hardened-runtime entitlements and wiring them into the macOS Tauri build config.

```mermaid
flowchart TD
  A[User starts mic/camera capture] --> B[WebView getUserMedia() request]
  B --> C[Wry/WebKit allows media-capture request]
  C --> D[Tauri app checks hardened runtime]
  D -->|Entitlements present| E[macOS TCC registers permission request]
  E --> F[System Settings shows Microphone/Camera access]
  F --> G[User can grant access]
  D -->|Entitlements missing| H[TCC never sees request]
  H --> I[Permission denied / no privacy entry]
```

Changes:
- Added `frontend/src-tauri/entitlements.plist` with `com.apple.security.device.audio-input` and `com.apple.security.device.camera`.
- Updated `frontend/src-tauri/tauri.conf.json` to use that entitlements file for macOS signing.
- Refreshed the `frontend/src-tauri/src/lib.rs` comment to explain that macOS needs the entitlement in addition to the usage description.

This should allow macOS to surface the microphone/camera prompt properly so live recording can be enabled in System Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->