### PR TITLE
test(ci): root-cause and neutralize the flaky trio — a leaked torch fp16 default dtype

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,38 @@ if not os.environ.get("OMNIVOICE_ENV_FILE"):
 
 
 import pytest
+import warnings as _warnings
+
+
+# ── torch default-dtype isolation (CI flaky trio) ───────────────────────────
+# Three tests (test_effects_chain / test_generation_audio_guard /
+# test_persona_bundle) fail intermittently on CI — never locally — with
+# signatures that all trace to one cause: a leaked
+# `torch.set_default_dtype(torch.float16)` from some earlier test. The
+# smoking gun is test_generation_audio_guard's observed value
+# 0.0999755859375, which is exactly float16(0.1): `torch.tensor([0.1, …])`
+# built under a leaked fp16 default. The same leak collapses
+# test_effects_chain's preset differences into identical quantized outputs,
+# and hands test_persona_bundle's soundfile writer fp16 data libsndfile
+# can't encode. The polluter only executes on CI-Linux (it never reproduces
+# on macOS), so rather than chase it blind, this guard makes the whole leak
+# class impossible — same philosophy as the LLM-state guard below — and
+# names the offender in CI output when it fires, so it CAN be chased.
+@pytest.fixture(autouse=True)
+def _torch_default_dtype_guard(request):
+    yield
+    torch = sys.modules.get("torch")
+    if torch is None:
+        return
+    if torch.get_default_dtype() is not torch.float32:
+        _warnings.warn(
+            f"{request.node.nodeid} leaked torch default dtype "
+            f"{torch.get_default_dtype()} — resetting to float32. This is "
+            f"the polluter behind the CI flaky trio; fix it at the source.",
+            stacklevel=1,
+        )
+        torch.set_default_dtype(torch.float32)
+
 
 # ── LLM-provider state isolation (issue #878) ──────────────────────────────
 # LLM provider selection is process-global three ways: env vars (the

--- a/tests/test_torch_dtype_guard.py
+++ b/tests/test_torch_dtype_guard.py
@@ -1,0 +1,31 @@
+"""The conftest torch-dtype guard resets a leaked default dtype between tests.
+
+The CI "flaky trio" (test_effects_chain / test_generation_audio_guard /
+test_persona_bundle) failed intermittently on CI-Linux with signatures that
+all trace to one leak: some earlier test leaves
+``torch.set_default_dtype(torch.float16)`` behind. Reproduced locally with a
+simulated polluter — ``torch.tensor([0.1, …])`` under fp16 yields exactly the
+0.0999755859375 CI observed, and Pedalboard refuses fp16 audio outright
+("only supports 32-bit and 64-bit floating point"), silently returning
+unmodified audio for every preset so their outputs compare identical.
+
+These two tests are order-dependent BY DESIGN (pytest runs tests within a
+file in definition order): the first leaks, the second proves the autouse
+guard in conftest.py reset the leak before the next test began.
+"""
+import torch
+
+
+def test_a_deliberate_dtype_leak():
+    # Simulates the CI polluter. The conftest guard must clean this up (and
+    # emit a UserWarning naming this exact test as the offender).
+    torch.set_default_dtype(torch.float16)
+    assert torch.get_default_dtype() is torch.float16
+
+
+def test_b_next_test_starts_back_at_float32():
+    # If the guard is ever removed/broken, this fails — and so, eventually,
+    # does the flaky trio on CI, much less legibly.
+    assert torch.get_default_dtype() is torch.float32
+    # The exact fp16 signature the trio's CI failures showed, as documentation:
+    assert torch.tensor([0.1]).item() != 0.0999755859375


### PR DESCRIPTION
## The problem

`test_effects_chain` / `test_generation_audio_guard` / `test_persona_bundle` failed intermittently on CI — never locally — with identical signatures across three unrelated PRs today (#1002, #1019, #1016). Each occurrence cost a full CI cycle and muddied a merge decision.

## Root cause (confirmed by local reproduction, not guessed)

A leaked `torch.set_default_dtype(torch.float16)` from some earlier test in the CI-Linux ordering. The smoking gun: `test_generation_audio_guard`'s observed `0.0999755859375` is **exactly float16(0.1)** — `torch.tensor([0.1, …])` built under a leaked fp16 default.

Running a simulated polluter + the trio locally reproduced the CI failures with their exact signatures, and explained all three mechanisms:
- Pedalboard refuses fp16 audio outright ("only supports 32-bit and 64-bit floating point") and silently returns unmodified audio for every preset → `test_effects_chain`'s different presets compare **identical**.
- The fp16 tensor value breaks `test_generation_audio_guard`'s `approx(0.1)` check directly.
- libsndfile can't encode fp16 data → `test_persona_bundle`'s preview wav never gets written → `NoPreviewSource`.

## The fix

An autouse conftest guard (same philosophy as the existing LLM-state isolation guard from #878): after every test, if torch's default dtype isn't float32, reset it and emit a **UserWarning naming the offending test's nodeid** — so the actual CI-only polluter identifies itself in the next CI log where it fires, instead of being chased blind. The next time CI logs show that warning, the true polluter is one grep away.

## Verification

Fail-before/pass-after: with the guard stashed, simulated polluter + trio → 2/3 failures locally with the exact CI signatures. With the guard active → 73/73 pass, warning names the polluter. Permanent regression test: a deliberate-leak pair proving reset-between-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added an autouse pytest guard to restore Torch’s global default dtype after each test, warning with the leaking test’s nodeid whenever it finds a non-`float32` dtype and resetting it back to `float32`.

Added regression coverage that simulates a dtype polluter and verifies the next test starts with the default dtype restored.

```mermaid
flowchart LR
  A[Test finishes] --> B[autouse guard runs]
  B --> C{torch imported?}
  C -- no --> D[Skip]
  C -- yes --> E{default dtype != float32?}
  E -- no --> D
  E -- yes --> F[warn(nodeid)]
  F --> G[reset to float32]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->