### PR TITLE
docs: correct troubleshooting §16 — mic bug was a missing entitlement, not an upstream limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,16 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - **Voice cloning on mlx-audio's CSM model no longer crashes with an opaque "list index out of range".** `MLXAudioBackend.generate()` read `voice`/`ref_audio`/`language`/`speed` from its kwargs but silently dropped `ref_text` — CSM only builds its cloning context when both `ref_audio` and `ref_text` are present, so cloning on this engine could never have worked as shipped. Reported with the exact root cause and a working fix. (#1012, #1013)
 - **A dub segment's free-text style tags no longer 400 the segment preview.** A validator-safe instruct builder already keeps Studio and Clone generation from round-tripping a 400 on unsupported free-text (a preset's raw attrs, an old profile's stray descriptive phrase) — but the Dub tab's segment preview, and saving a profile from a clone or from history, built their instruct strings directly and skipped it. Same guard now applies everywhere an instruct string is sent. (#1010)
 - **The dub editor's play button no longer sticks permanently disabled after an audio-decode hiccup.** When the initial WaveSurfer decode fails, the timeline falls back to loading pre-computed peaks — the waveform draws fine, but the button's enabled state only relied on the `ready` event firing again for that recovery load, which it didn't reliably do. Each fallback path now confirms readiness explicitly once it settles.
+- **macOS: live recording finally works — the microphone permission prompt now actually appears.** The app never showed up in System Settings → Privacy & Security → Microphone because macOS never saw a legitimate request: Tauri enables Hardened Runtime by default, which blocks microphone hardware access unless the matching entitlement is in the signed bundle — and it wasn't. Diagnosed to the exact mechanism and fixed by a community contributor (@MahdiHedhli), who also corrected our initial mis-read of this as an upstream WebKit limitation. (#1013, #1016)
+- **Quitting during a slow model load waits longer before giving up.** A post-merge code review of the shutdown-race fix flagged that its 3-second wait could still be outrun by a cold model import on a slow disk, reproducing the original confusing-crash-on-quit in rare cases. The wait is now 20 seconds — imperceptible on a normal quit (tasks finish or cancel in milliseconds), only felt in the exact case it protects. (#1020)
 
 ### Changed
 
 - **Removed the donate heart from the nav rail.** Support OmniVoice is still one click away from Settings and the Contact page.
+
+### CI
+
+- **The "flaky trio" is root-caused and neutralized.** Three tests failed intermittently on CI — never locally — across unrelated PRs, costing a re-run each time. Cause: a leaked half-precision torch default from some earlier test in CI's ordering (the giveaway: a failing assertion's observed value was exactly float16(0.1)). An autouse test-suite guard now resets the leak between tests and names the offending test in CI output when it fires. (#1021)
 
 ## [0.3.12] — 2026-07-08
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -455,22 +455,28 @@ resetting the permission (`tccutil reset Microphone
 com.debpalash.omnivoice-studio`) followed by a relaunch changes nothing — no
 system prompt ever appears.
 
-**Cause:** an upstream Tauri/WebKit limitation, not an OmniVoice bug. On
-macOS, WKWebView (the engine behind Tauri's desktop window) only forwards a
-page's `getUserMedia()` call to the OS permission system (TCC) if the native
-app implements a `WKUIDelegate` media-capture-permission handler — without
-one, WebKit denies the request internally before macOS's TCC layer ever sees
-it, which is also why the app never appears in the System Settings list (TCC
-only lists apps that have actually made a request). This is tracked upstream:
-[wry#1195](https://github.com/tauri-apps/wry/issues/1195),
-[tauri#11951](https://github.com/tauri-apps/tauri/issues/11951) — the fix
-([wry#1196](https://github.com/tauri-apps/wry/pull/1196)) is still open and
-unmerged as of this writing, so there's no released Tauri/wry version to
-bump to yet.
+**Cause:** the app bundle was missing the Hardened Runtime *entitlement* for
+microphone access. An earlier revision of this section blamed an upstream
+Tauri/WebKit limitation — that was wrong (a community contributor,
+[@MahdiHedhli](https://github.com/MahdiHedhli), read the sources more
+carefully and found the real gap). wry's `WKUIDelegate` already grants the
+WebKit-layer media-capture request; but Tauri's macOS bundler enables
+Hardened Runtime by default, and Hardened Runtime blocks microphone hardware
+access unless `com.apple.security.device.audio-input` is present in the
+signed binary's entitlements — regardless of `Info.plist`'s
+`NSMicrophoneUsageDescription` (that only supplies the prompt *text*).
+Without the entitlement, macOS's TCC layer never registers a request, which
+is exactly why the app never appears in the System Settings list.
 
-**Workaround:** record your voice sample in any other app (Voice Memos,
-QuickTime, etc.) and upload the resulting file in OmniVoice instead of using
-live recording — upload-based cloning is unaffected and works normally.
+**Fix:** ships in the release after v0.3.12 (the bundle now carries
+`src-tauri/entitlements.plist` — [#1016](https://github.com/debpalash/OmniVoice-Studio/pull/1016),
+contributed by the same person who diagnosed it). Update and live recording
+works, with a normal macOS permission prompt on first use.
+
+**Workaround on older builds (≤ v0.3.12):** record your voice sample in any
+other app (Voice Memos, QuickTime, etc.) and upload the resulting file in
+OmniVoice instead of using live recording — upload-based cloning is
+unaffected and works normally.
 
 **Linked issue:** [#1013](https://github.com/debpalash/OmniVoice-Studio/issues/1013)
 


### PR DESCRIPTION
## Docs-sync follow-up to #1016 (immediate next commit per the hard rule)

`troubleshooting.md` §16 claimed the macOS microphone-permission bug was an unresolved upstream Tauri/wry limitation with no available fix. **That was wrong** — @MahdiHedhli read the wry/tauri sources more carefully and found the real cause: Tauri's Hardened Runtime default blocks mic hardware access without `com.apple.security.device.audio-input` in the bundle entitlements, which also explains the "never appears in System Settings" symptom (TCC never saw a legitimately-entitled request). Their fix (#1016) is merged.

§16 now documents the real mechanism, credits the correction, and keeps the record-elsewhere workaround for users on ≤0.3.12 builds.

Also brings CHANGELOG `[Unreleased]` current for the three merges that lacked entries: #1016 (mic fix, credited), #1020 (shutdown wait 3s→20s, post-merge review finding), #1021 (CI flaky-trio root cause + guard).

docs-drift + install-docs validators: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)