### PR TITLE
release: freeze v0.3.13 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+## [0.3.13] — 2026-07-09
+
+The community-fixes release. Two contributors didn't just report bugs — they diagnosed them to the exact line and submitted the fixes that shipped: **voice cloning on mlx-audio's CSM model works for the first time**, and **macOS live recording finally gets its microphone permission prompt** (both @MahdiHedhli). A third reporter's A/B analysis fixed **cross-language dubs speaking the wrong language**. On top of that: a backend shutdown race that produced confusing crash-on-quit reports is fixed, the Linux AppImage stops shipping a stale WebKitGTK that white-screened current distros, and a new OpenAI-compatible transcription backend opens a path to Qwen3-ASR today. Thank you to everyone who filed, diagnosed, and contributed — this release is mostly yours.
+
 ### Added
 
 - **A path to Qwen3-ASR today: generic OpenAI-compatible transcription.** The direct integration is still blocked on `transformers>=5.13` stabilizing upstream, but a community member proposed splitting the work — add a backend that talks to any OpenAI-compatible transcription server right now. Point OmniVoice at a self-hosted Qwen3-ASR/FunASR/SenseVoice server, or OpenAI's own API, configured in Settings → Models. No install; audio does leave your machine to whichever server you configure, unlike every other ASR engine. (#877)

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.12"
+_FALLBACK_VERSION = "0.3.13"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.12"
+version = "0.3.13"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.12"
+version = "0.3.13"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.12"
+version = "0.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Freezes v0.3.13 — **the community-fixes release**. 12 PRs since v0.3.12: two contributor-authored fixes (CSM cloning ref_text + macOS mic entitlements, both @MahdiHedhli), the cross-language dub reference fix (diagnosed by its reporter), the backend shutdown race (#1000-class), the AppImage stale-WebKitGTK fix, the OpenAI-compatible ASR backend (#877), gallery error messages, instruct-validation gaps, the dub play-button fix, and the CI flaky-trio root-cause guard.

- All 4 version files bumped 0.3.12 → 0.3.13 in lockstep (`test_app_version.py` 6/6)
- `uv.lock` + `Cargo.lock` regenerated
- CHANGELOG `[Unreleased]` → `[0.3.13] — 2026-07-09` with headline; empty `[Unreleased]` kept

Gate results: frontend 926/926. Backend 2417/2418 locally — the single failure (`test_app_version_matches_installed_package_metadata`) was self-inflicted: the version bump + `uv lock` ran while the suite was mid-flight, so that test saw mixed 0.3.12/0.3.13 metadata; it passes 6/6 in the consistent post-bump environment. This PR's own CI run installs from scratch and is the authoritative clean-room validation.

After merge: tag `v0.3.13` from main. Main HOLDS at 0.3.13 (AUTO_VERSION_BUMP off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the release to **v0.3.13** across all version sources, regenerated lockfiles, and added the new changelog entry for the “community-fixes” release.

### Included updates
- Bumped version from **0.3.12 → 0.3.13** in:
  - `backend/core/version.py`
  - `pyproject.toml`
  - `frontend/package.json`
  - `frontend/src-tauri/Cargo.toml`
- Regenerated:
  - `uv.lock`
  - `Cargo.lock`
- Updated `CHANGELOG.md`:
  - moved `[Unreleased]` to `[0.3.13] — 2026-07-09`
  - kept an empty `[Unreleased]` section
  - added release notes for the fixes included in this cut

### Behavior
```mermaid
flowchart TD
  A[Version lookup starts] --> B{Installed package metadata available?}
  B -- yes --> C[Use installed metadata version]
  B -- no --> D{pyproject.toml found?}
  D -- yes --> E[Read version from pyproject.toml]
  D -- no --> F[Fallback to hardcoded _FALLBACK_VERSION = 0.3.13]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->