### PR TITLE
fix(linux): AppRun workaround detection reads the BUNDLED WebKitGTK version, not the host's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Linux AppImage's white-screen auto-workaround now checks the right WebKitGTK.** The launcher decided whether to apply the compositing workaround by asking the *system's* `pkg-config` — but the version that actually runs is the *bundled* one, which the AppImage prioritizes. On any machine where the two diverge (e.g. building from source with newer dev packages installed), the detection read the wrong number and could skip a workaround the running library needed. The build now stamps the bundled version into the AppImage at package time, and the launcher reads that stamp — correct by construction. The launcher's shell tests also now run in CI, which they previously never did. (#961 follow-up)
+
+### Docs
+
+- **Windows: installing to a different drive is documented** — the wizard's directory picker works for any local drive; mapped network drives are a Windows Installer limitation (not installable-to by design); and the big data (models/voices) moves independently via Settings → Storage or Portable mode. (#938)
+
 ## [0.3.13] — 2026-07-09
 
 The community-fixes release. Two contributors didn't just report bugs — they diagnosed them to the exact line and submitted the fixes that shipped: **voice cloning on mlx-audio's CSM model works for the first time**, and **macOS live recording finally gets its microphone permission prompt** (both @MahdiHedhli). A third reporter's A/B analysis fixed **cross-language dubs speaking the wrong language**. On top of that: a backend shutdown race that produced confusing crash-on-quit reports is fixed, the Linux AppImage stops shipping a stale WebKitGTK that white-screened current distros, and a new OpenAI-compatible transcription backend opens a path to Qwen3-ASR today. Thank you to everyone who filed, diagnosed, and contributed — this release is mostly yours.

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -77,6 +77,28 @@ Download the latest MSI from the
 run it, follow the wizard. The shortcut lands in the Start menu as
 **OmniVoice Studio**.
 
+### Installing to a different drive
+
+<a id="install-other-drive"></a>
+
+The wizard's **directory picker** lets you install the app to any **local**
+drive (D:, E:, …). Two caveats:
+
+- **Mapped network drives (Z: → a share) are not supported** — this is a
+  Windows Installer limitation, not an OmniVoice bug: MSI custom actions run
+  as a service account that doesn't see per-user drive mappings, so the
+  install fails or rolls back. Install to a local drive instead.
+- The install location only moves the ~200 MB app itself. The big data
+  (models, voices, projects — tens of GB) lives in the **data directory**,
+  which you move independently: **Settings → Storage → Models directory**
+  in-app, or `OMNIVOICE_DATA_DIR` / [Portable mode](#portable-install) for
+  the whole data tree.
+
+If an install to a local non-C: drive fails anyway, capture a log with
+`msiexec /i OmniVoice*.msi /L*V install.log` and
+[open an issue](https://github.com/debpalash/OmniVoice-Studio/issues) with it
+— that log shows exactly which step rolled back.
+
 ## Portable install (Windows)
 
 <a id="portable-install"></a>

--- a/frontend/src-tauri/appimage/AppRun
+++ b/frontend/src-tauri/appimage/AppRun
@@ -22,9 +22,27 @@ HERE="$(dirname -- "$(readlink -f -- "$0")")"
 # Sourced by AppRun.test.sh — keep this function pure so unit tests can stub
 # `pkg-config`, source the file, call _detect_webkit_workaround, and inspect
 # the resulting environment without exec'ing the binary.
+#
+# Version source (#961 follow-up): the WebKitGTK that actually RUNS is the
+# BUNDLED copy (LD_LIBRARY_PATH below puts $HERE/usr/lib first) — NOT the
+# host's. Asking the host's pkg-config therefore reads the wrong number
+# whenever host and bundle diverge (e.g. a user who builds from source has
+# dev packages installed, so pkg-config answers with their system's healthy
+# 2.48 while the bundle runs an older lib — skipping a workaround the running
+# library needs). inject-apprun.sh stamps the bundled version into
+# .bundled-webkitgtk-version at build time, where it is knowable by
+# construction; the host pkg-config path survives only as a fallback for
+# bundles predating the stamp. OMNIVOICE_APPRUN_WK_MARKER exists for the
+# unit tests to point at a fixture marker.
 _detect_webkit_workaround() {
   local wk_version="0.0"
-  if command -v pkg-config >/dev/null 2>&1; then
+  local marker="${OMNIVOICE_APPRUN_WK_MARKER:-$HERE/.bundled-webkitgtk-version}"
+  if [ -r "$marker" ]; then
+    # Empty/unreadable marker content → "0.0" (unknown) → fail-safe workaround,
+    # same philosophy as the missing-pkg-config branch below.
+    wk_version="$(cat "$marker" 2>/dev/null | tr -d '[:space:]')"
+    [ -n "$wk_version" ] || wk_version="0.0"
+  elif command -v pkg-config >/dev/null 2>&1; then
     wk_version="$(pkg-config --modversion webkit2gtk-4.1 2>/dev/null \
                || pkg-config --modversion webkit2gtk-4.0 2>/dev/null \
                || echo "0.0")"

--- a/frontend/src-tauri/appimage/AppRun.test.sh
+++ b/frontend/src-tauri/appimage/AppRun.test.sh
@@ -72,6 +72,56 @@ run_case "2.46 (broken)"          "2.46.1" "1"
 run_case "2.48 (healthy)"         "2.48.0" "unset"
 run_case "pkg-config absent"      "0.0"    "1"     "no"
 
+# ── Bundled-version marker cases (#961 follow-up) ───────────────────────────
+# inject-apprun.sh stamps the bundle's actual WebKitGTK version into
+# .bundled-webkitgtk-version at build time; AppRun must prefer that marker
+# over the host's pkg-config (which reports the SYSTEM version — wrong
+# whenever it diverges from the bundled copy, e.g. on a machine with newer
+# dev packages installed).
+
+run_marker_case() {
+  local label="$1" marker_content="$2" pkg_output="$3" expected="$4"
+  local marker_file
+  marker_file="$(mktemp)"
+  printf '%s\n' "$marker_content" > "$marker_file"
+
+  local actual
+  actual=$(
+    bash -c '
+      set +e
+      pkg_output="'"$pkg_output"'"
+      export OMNIVOICE_APPRUN_WK_MARKER="'"$marker_file"'"
+
+      pkg-config() { echo "$pkg_output"; }
+      export -f pkg-config
+
+      exec() { :; }
+      export -f exec
+
+      # shellcheck disable=SC1090
+      source "'"$THIS_DIR"'/AppRun" >/dev/null 2>&1 || true
+      echo "${WEBKIT_DISABLE_COMPOSITING_MODE:-unset}"
+    '
+  )
+  rm -f "$marker_file"
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS [$label]"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL [$label]: expected '$expected' got '$actual'" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# Marker says broken → workaround applies, even though host pkg-config says healthy.
+run_marker_case "marker 2.46 beats host 2.48"  "2.46.1" "2.48.0" "1"
+# Marker says healthy → no workaround, even though host pkg-config says broken
+# (the exact #961 inversion: from-source user with old system lib, new bundle).
+run_marker_case "marker 2.48 beats host 2.44"  "2.48.0" "2.44.3" "unset"
+# Empty marker → treated as unknown → fail-safe workaround.
+run_marker_case "empty marker fails safe"      ""       "2.48.0" "1"
+
 echo
 echo "─── AppRun test summary: $PASS_COUNT pass / $FAIL_COUNT fail ───"
 if [[ $FAIL_COUNT -ne 0 ]]; then

--- a/scripts/inject-apprun.sh
+++ b/scripts/inject-apprun.sh
@@ -42,6 +42,23 @@ for stage_base in "$STAGE_BASE_RELEASE" "$STAGE_BASE_DEBUG"; do
       echo "inject-apprun: replacing AppRun in $appdir"
       cp -f "$APPRUN_SRC" "$appdir/AppRun"
       chmod 755 "$appdir/AppRun"
+      # Stamp the bundled WebKitGTK version (#961 follow-up). The AppImage
+      # bundles THIS build host's libwebkit2gtk, so the host's pkg-config
+      # answer here is the version the shipped bundle will actually run —
+      # knowable by construction at bundle time, unknowable reliably at
+      # runtime (a user's pkg-config reports their SYSTEM's version, which
+      # LD_LIBRARY_PATH overrides with the bundled copy). AppRun's workaround
+      # auto-detection reads this marker first and only falls back to host
+      # pkg-config when the marker is absent (bundles predating the stamp).
+      wk_bundled="$(pkg-config --modversion webkit2gtk-4.1 2>/dev/null \
+                 || pkg-config --modversion webkit2gtk-4.0 2>/dev/null \
+                 || echo "")"
+      if [ -n "$wk_bundled" ]; then
+        printf '%s\n' "$wk_bundled" > "$appdir/.bundled-webkitgtk-version"
+        echo "inject-apprun: stamped bundled WebKitGTK version: $wk_bundled"
+      else
+        echo "inject-apprun: WARNING — could not read the bundled WebKitGTK version (pkg-config missing?); AppRun will use its runtime fallback" >&2
+      fi
       found=1
     fi
   done

--- a/tests/test_apprun_launcher.py
+++ b/tests/test_apprun_launcher.py
@@ -1,0 +1,29 @@
+"""Run the AppImage AppRun launcher's shell unit tests under pytest.
+
+AppRun.test.sh existed but was wired into NO CI job — the launcher's
+workaround auto-detection (which decides whether shipped Linux builds get
+WEBKIT_DISABLE_COMPOSITING_MODE) could regress silently. This wrapper rides
+the standard "Tests (backend + frontend)" gate instead of needing its own
+workflow step. Covers the #961 follow-up too: the build-time
+.bundled-webkitgtk-version marker must beat the host's pkg-config answer.
+"""
+import os
+import shutil
+import subprocess
+
+import pytest
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPT = os.path.join(_REPO, "frontend", "src-tauri", "appimage", "AppRun.test.sh")
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_apprun_shell_suite_passes():
+    proc = subprocess.run(
+        ["bash", _SCRIPT], capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, (
+        f"AppRun.test.sh failed (exit {proc.returncode}):\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+    assert "0 fail" in proc.stdout


### PR DESCRIPTION
## The second #961 bug — deferred in #1007, now fixed properly

The AppImage launcher decided whether to export `WEBKIT_DISABLE_COMPOSITING_MODE` by asking the **host's** `pkg-config` — but `LD_LIBRARY_PATH` makes the **bundled** libwebkit2gtk the one that actually runs, so on any machine where the two diverge the detection read the wrong number. This is exactly the inversion from #961's investigation: the reporter builds from source, so their dev packages answered pkg-config with their system's healthy version while the shipped bundle ran an older lib.

I deferred this in #1007 as "not safely fixable at runtime" — the insight here is it doesn't need runtime detection at all: **the version is knowable by construction at bundle time.** `inject-apprun.sh` runs on the build host whose libwebkit2gtk gets bundled, so it stamps that version into `.bundled-webkitgtk-version` inside the AppDir. AppRun reads the stamp first; host pkg-config survives only as a fallback for bundles predating it; an empty/unreadable stamp fails safe (workaround on).

## Tests

- 3 new `AppRun.test.sh` cases: marker-beats-host **in both directions** (broken-marker/healthy-host, and the #961 inversion healthy-marker/broken-host) + empty-marker fail-safe. 7/7 pass.
- **`AppRun.test.sh` now actually runs in CI** — it existed but was wired into no job; the launcher's workaround logic could regress silently. New `tests/test_apprun_launcher.py` runs it under the standard Tests gate.

## Also included

`docs/install/windows.md`: documents install-to-another-drive (#938) — local drives work via the wizard's picker, **mapped network drives are a Windows Installer limitation**, and the data directory moves independently of the app. Both docs validators pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Fixed AppImage/AppRun’s WebKitGTK workaround detection to use a build-time bundled version marker instead of the host system’s `pkg-config` result when available.
- Added a fail-safe path: empty or unreadable marker content now enables the compositing workaround by default, with host `pkg-config` kept as a fallback for older bundles.
- Stamped the bundled WebKitGTK version during AppImage injection so the launcher can make the decision at runtime.
- Expanded AppRun shell coverage and wired it into CI.
- Updated Windows install docs for installing to another drive and clarified mapped network drive limitations.

## Behavior
```mermaid
flowchart TD
  A[AppRun starts] --> B{Bundled version marker readable?}
  B -- yes --> C[Read .bundled-webkitgtk-version]
  C --> D{Version broken / unknown?}
  D -- yes --> E[Set WEBKIT_DISABLE_COMPOSITING_MODE=1]
  D -- no --> F[Leave compositing mode unchanged]
  B -- no --> G{Host pkg-config available?}
  G -- yes --> H[Use host WebKitGTK version as fallback]
  G -- no --> E
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->