### PR TITLE
release: freeze v0.3.14 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+## [0.3.14] — 2026-07-09
+
+A fast follow to v0.3.13: **every engine family now has a visible picker.** Settings → Engines showed only a TTS table, with the ASR and LLM pickers hidden behind a low-discoverability tab — so the 10 transcription engines (including the new OpenAI-compatible backend) looked unswitchable without env vars. Now all three families get their own table. Also in: the Linux AppImage's white-screen auto-workaround now checks the WebKitGTK it actually ships (not whatever your system reports), and installing to a different drive on Windows is properly documented.
+
 ### Added
 
 - **ASR engines get the same Settings picker TTS has.** Settings → Engines now shows a visible picker table per family — TTS, ASR, and LLM — instead of a single TTS-titled table with the other families tucked behind a tab (README even promised a Settings ASR picker that didn't exist). The OpenAI-compatible backend and the 9 local ASR engines become selectable with one click, no env vars needed; an explicit `OMNIVOICE_ASR_BACKEND` still wins over the Settings pick, so pinned setups behave exactly as before. (no issue — UX gap found during #877)

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.13"
+_FALLBACK_VERSION = "0.3.14"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.13"
+version = "0.3.14"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.13"
+version = "0.3.14"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.13"
+version = "0.3.14"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Freezes v0.3.14 — a fast follow to v0.3.13: **every engine family gets a visible picker** (Settings → Engines now shows TTS, ASR, and LLM tables — #1026), the AppImage launcher checks the WebKitGTK it actually ships (#1024), and Windows install-to-another-drive is documented (#1024).

- All 4 version files bumped 0.3.13 → 0.3.14 in lockstep (`test_app_version.py` 6/6)
- `uv.lock` + `Cargo.lock` regenerated
- CHANGELOG `[Unreleased]` → `[0.3.14] — 2026-07-09` with headline

Gate results (run to completion BEFORE any version mutation this time): backend **2428 passed, 0 failed**; frontend **931/931**. This PR's clean-room CI is the final validation.

After merge: tag v0.3.14 from main. Main HOLDS at 0.3.14 (AUTO_VERSION_BUMP off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Froze release version to `0.3.14` across backend, frontend, Tauri, and Python package metadata.
- Regenerated lockfiles (`uv.lock`, `Cargo.lock`) to match the release bump.
- Updated `CHANGELOG.md` to move `[Unreleased]` to `[0.3.14] — 2026-07-09` and record the fast-follow release notes.

## Validation
- Backend tests: 2428 passed, 0 failed.
- Frontend tests: 931/931 passed.
- Clean-room CI remains the final release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->