### PR TITLE
fix(update): app updates stop uninstalling user-added engines — drift sync goes --inexact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Updating no longer uninstalls engines you added yourself.** Optional engines installed with pip into the app's environment (VoxCPM2, KittenTTS — exactly what Settings → Engines' own install hints say to do) were silently deleted by every app update, because the update's dependency sync removed anything not in the app's lockfile. Routine updates now leave your additions alone; the repair path ("Clean & Retry") still restores the exact known-good state, since a broken environment is sometimes *caused* by an extra package. (#1029)
+
 ## [0.3.14] — 2026-07-09
 
 A fast follow to v0.3.13: **every engine family now has a visible picker.** Settings → Engines showed only a TTS table, with the ASR and LLM pickers hidden behind a low-discoverability tab — so the 10 transcription engines (including the new OpenAI-compatible backend) looked unswitchable without env vars. Now all three families get their own table. Also in: the Linux AppImage's white-screen auto-workaround now checks the WebKitGTK it actually ships (not whatever your system reports), and installing to a different drive on Windows is properly documented.

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -713,6 +713,27 @@ fn sync_failure_is_torch_download(tail: &str) -> bool {
 /// distro-matched ROCm builds torch's own index doesn't carry).
 const ROCM_TORCH_INDEX: &str = "https://download.pytorch.org/whl/rocm6.4";
 
+/// Args for the routine update-drift sync (#307 path) — the one that runs on
+/// every app update when `uv.lock` changed. `--inexact` is the fix for #1029:
+/// plain `uv sync` UNINSTALLS every package not in the lockfile, which
+/// silently deleted user-pip-installed optional engines (voxcpm, kittentts —
+/// packages the app's own Settings → Engines hints tell users to install
+/// into this venv) on every single update. `--inexact` still installs/
+/// upgrades everything the lockfile demands — locked deps stay exactly
+/// correct — it just stops removing extras the user added on purpose.
+///
+/// Deliberately NOT applied to the repair sync (`repair_sync_args`): repair
+/// runs when the venv is *broken*, and a user-installed extra is a plausible
+/// cause — healing must restore the known-good locked state, extras
+/// included-out. An engine lost to a repair is re-installable; a venv that
+/// repair can't actually repair is a support thread.
+const DRIFT_SYNC_ARGS: [&str; 5] = ["sync", "--frozen", "--inexact", "--no-dev", "--verbose"];
+
+/// Exact-sync args for the venv-repair path — see `DRIFT_SYNC_ARGS` for why
+/// repair stays exact while the update-drift sync preserves user extras.
+const REPAIR_SYNC_ARGS_LOCKED: [&str; 4] = ["sync", "--frozen", "--no-dev", "--verbose"];
+const REPAIR_SYNC_ARGS_UNLOCKED: [&str; 3] = ["sync", "--no-dev", "--verbose"];
+
 /// `uv pip install` args that replace the default CUDA torch build with the AMD
 /// ROCm wheel (#124). Opt-in (gated on OMNIVOICE_TORCH_VARIANT=rocm by the
 /// caller); the detection side (`get_best_device`) already routes ROCm through
@@ -1254,7 +1275,7 @@ manually, then relaunch.",
                                 drift_cmd.env("UV_INDEX_URL", "https://mirrors.aliyun.com/pypi/simple/");
                             }
                             drift_cmd
-                                .args(["sync", "--frozen", "--no-dev", "--verbose"])
+                                .args(DRIFT_SYNC_ARGS)
                                 .current_dir(&project_dir);
                             match run_streaming(app, "installing_deps", &mut drift_cmd) {
                                 Ok(ref s) if s.success() => {
@@ -1329,9 +1350,9 @@ the existing venv; newly added dependencies may be missing (#307)",
         apply_uv_http_env(&mut repair_cmd);
         let has_lockfile = project_dir.join("uv.lock").is_file();
         if has_lockfile {
-            repair_cmd.args(["sync", "--frozen", "--no-dev", "--verbose"]);
+            repair_cmd.args(REPAIR_SYNC_ARGS_LOCKED);
         } else {
-            repair_cmd.args(["sync", "--no-dev", "--verbose"]);
+            repair_cmd.args(REPAIR_SYNC_ARGS_UNLOCKED);
         }
         repair_cmd.current_dir(&project_dir);
         let repair_status = run_streaming(app, "installing_deps", &mut repair_cmd);
@@ -1711,6 +1732,29 @@ See docs/install/linux.md (AMD GPU) to install the ROCm wheel manually.",
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn update_drift_sync_preserves_user_installed_engines() {
+        // #1029: the routine update sync must carry --inexact so a
+        // user-pip-installed optional engine (voxcpm, kittentts — packages
+        // the app's own Settings → Engines hints tell users to install into
+        // this venv) survives every update instead of being silently
+        // uninstalled. --frozen must stay (lockfile is the resolution truth).
+        assert!(DRIFT_SYNC_ARGS.contains(&"--inexact"),
+            "update-drift sync lost --inexact — user-installed engines get wiped on every update (#1029)");
+        assert!(DRIFT_SYNC_ARGS.contains(&"--frozen"));
+    }
+
+    #[test]
+    fn repair_sync_stays_exact() {
+        // Deliberate asymmetry with the drift sync: repair runs when the venv
+        // is BROKEN and a user-installed extra is a plausible cause — healing
+        // must restore the known-good locked state, extras included-out.
+        assert!(!REPAIR_SYNC_ARGS_LOCKED.contains(&"--inexact"),
+            "repair sync must stay exact — it's the recovery path when an extra broke the venv");
+        assert!(!REPAIR_SYNC_ARGS_UNLOCKED.contains(&"--inexact"));
+        assert!(REPAIR_SYNC_ARGS_LOCKED.contains(&"--frozen"));
+    }
 
     #[test]
     fn scrub_python_env_removes_bundled_runtime_vars() {


### PR DESCRIPTION
## Root cause (#1029)

Every app update whose `uv.lock` changed runs `uv sync --frozen` to reconcile the venv (the #307 drift path in `bootstrap.rs`) — and uv sync's exact mode **uninstalls every package not in the lockfile**. That silently deleted user-pip-installed optional engines (voxcpm, kittentts — packages the app's own Settings → Engines install hints tell users to add to this exact venv) on every single update. The app was instructing users to do something its own updater then undid.

## Fix

The routine drift sync now carries `--inexact`: locked deps are still installed/upgraded exactly per the lockfile, but user-added extras are left alone.

**Deliberate asymmetry**: the venv-*repair* sync stays exact — repair runs when the venv is broken, and a user-installed extra is a plausible cause, so healing must restore the known-good locked state. First-run syncs are untouched (a fresh venv has no extras; exact ≡ inexact there).

Both arg sets are named constants with contract tests pinning the asymmetry (`update_drift_sync_preserves_user_installed_engines`, `repair_sync_stays_exact`) so neither side can silently regress. `cargo test --lib bootstrap::tests`: 25 passed.

Honest caveat: verified at the args/contract level + uv's documented `--inexact` semantics; not driven through a real Windows update cycle from here — the reporter's next update (after this ships) is the end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed app updates so user-installed optional engines are preserved during drift reconciliation.

```mermaid
flowchart LR
  A[App update] --> B[Drift sync]
  B --> C[uv sync --inexact]
  C --> D[Locked deps stay aligned]
  C --> E[User-added optional engines remain installed]

  F[Clean & Retry repair] --> G[Repair sync]
  G --> H[uv sync exact / frozen]
  H --> I[Restore known-good lockfile state]
```

Also:
- Kept repair sync exact so broken environments can still be restored cleanly.
- Split sync arguments into named constants for drift vs. repair flows.
- Added contract/unit tests to enforce the intended asymmetry.
- Updated the changelog entry for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->