### PR TITLE
fix(clone): bound the ref-text re-transcribe like every other ASR dispatch (#730)

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -1008,9 +1008,22 @@ async def dub_transcribe_stream(
                     yield _sse_event("ping", {})
                 if clones:
                     from services.speaker_clone import refine_ref_texts
-                    clones = await loop.run_in_executor(
-                        _gpu_pool, lambda: refine_ref_texts(clones, _asr_backend),
-                    )
+                    # Bound the re-transcribe like every other ASR dispatch in
+                    # this file (#730): a wedged transcribe would otherwise hold
+                    # the GPU-pool worker forever and starve later work into a
+                    # "can't reach backend". On timeout the guard resets the pool
+                    # and raises — keep the original (unrefined) clones, matching
+                    # refine_ref_text's own "failure is a strict no-op" fallback.
+                    try:
+                        clones = await run_transcribe_guarded(
+                            _gpu_pool,
+                            lambda: refine_ref_texts(clones, _asr_backend),
+                            what="Dub clone ref-text refine",
+                        )
+                    except ASRTimeoutError as e:
+                        logger.warning(
+                            "clone ref-text refine timed out; keeping original ref_text: %s", e
+                        )
             # Wave 3.2: per-segment clone refs. Cut each long-enough segment's
             # own reference from the vocals so the dub of each line matches the
             # prosody of its source line. Short lines fall back to the
@@ -1031,9 +1044,18 @@ async def dub_transcribe_stream(
                     )
                     if seg_clones:
                         from services.speaker_clone import refine_ref_texts
-                        seg_clones = await loop.run_in_executor(
-                            _gpu_pool, lambda: refine_ref_texts(seg_clones, _asr_backend),
-                        )
+                        # Same guard as the per-speaker refine above (#730):
+                        # keep the original seg_clones on a wedge/timeout.
+                        try:
+                            seg_clones = await run_transcribe_guarded(
+                                _gpu_pool,
+                                lambda: refine_ref_texts(seg_clones, _asr_backend),
+                                what="Dub segment ref-text refine",
+                            )
+                        except ASRTimeoutError as e:
+                            logger.warning(
+                                "segment ref-text refine timed out; keeping original ref_text: %s", e
+                            )
                         job["segment_clones"] = seg_clones
                 except Exception as e:
                     logger.warning("per-segment clone refs skipped: %s", e)

--- a/tests/test_speaker_clone_purity.py
+++ b/tests/test_speaker_clone_purity.py
@@ -11,10 +11,16 @@ These tests pin the three guards:
 
 Pure tests over a synthetic vocals wav — no model, no main import.
 """
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
+
 import numpy as np
 import pytest
 import soundfile as sf
 
+from services.asr_backend import ASRTimeoutError, run_transcribe_guarded
 from services.speaker_clone import (
     ADJACENT_TURN_GUARD_S,
     MIN_REF_DURATION_S,
@@ -206,3 +212,59 @@ class TestRefineRefTexts:
         refine_ref_texts(clones, asr)
         assert clones["Speaker 1"]["ref_text"] == "kept on failure"
         assert clones["Speaker 2"]["ref_text"] == "buenos dias"
+
+
+class _HangingASR:
+    """An ASR backend whose .transcribe() *wedges* (blocks) instead of raising
+    — the #730 whisperx/CTranslate2 hang. `refine_ref_text`'s try/except only
+    catches a raised Exception, so on its own this dispatch has no wall-clock
+    bound; it must go through the same `run_transcribe_guarded` every other
+    transcribe in dub_core.py uses."""
+    def __init__(self):
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def transcribe(self, path, *, word_timestamps=True):
+        self.started.set()
+        self.release.wait()  # blocks until the test releases it
+        return {"chunks": [{"text": "arrived too late"}]}
+
+
+class TestRefineWedgeIsGuarded:
+    # Issue #730 class: a re-transcribe can hang rather than raise. The other
+    # transcribe dispatches in dub_core.py bound this via run_transcribe_guarded
+    # (chunk loop + whole-file "Dub"); the clone/segment refine dispatches must
+    # too, or a wedge holds the 1-worker GPU pool forever ("can't reach backend").
+
+    def test_refine_ref_texts_alone_has_no_wall_clock_bound(self):
+        # Proves the gap: dispatched raw (as #1008 did), a wedged transcribe
+        # never returns — refine_ref_text's except can't catch a hang.
+        asr = _HangingASR()
+        clones = {"S1": {"ref_audio": "/tmp/a.wav", "ref_text": "orig"}}
+        pool = ThreadPoolExecutor(max_workers=1)
+        fut = pool.submit(refine_ref_texts, clones, asr)
+        assert asr.started.wait(timeout=2.0)
+        with pytest.raises(FuturesTimeout):
+            fut.result(timeout=0.3)  # still blocked — no internal bound
+        asr.release.set()            # let the worker unwind before teardown
+        pool.shutdown(wait=False)
+
+    def test_run_transcribe_guarded_bounds_the_wedge_and_falls_back(self):
+        # Proves the fix: routing the same call through the guard bounds the
+        # hang, raises ASRTimeoutError, and the original ref_text is preserved
+        # (matching refine_ref_text's "failure is a strict no-op" fallback).
+        asr = _HangingASR()
+        clones = {"S1": {"ref_audio": "/tmp/a.wav", "ref_text": "orig"}}
+        pool = ThreadPoolExecutor(max_workers=1)
+
+        async def _go():
+            with pytest.raises(ASRTimeoutError):
+                await run_transcribe_guarded(
+                    pool, lambda: refine_ref_texts(clones, asr),
+                    what="Dub clone ref-text refine", timeout=0.3,
+                )
+
+        asyncio.run(_go())
+        assert clones["S1"]["ref_text"] == "orig"  # fallback kept the original
+        asr.release.set()
+        pool.shutdown(wait=False)


### PR DESCRIPTION
Follow-up to #1008 (the merged fix for #1004), on your invitation to send anything my #1005 handled that the merged version doesn't.

#1008 correctly fixes the (ref_audio, ref_text) mismatch, and its exception/empty-transcript fallbacks are clean. The one case it doesn't cover is a re-transcribe that **wedges** (hangs) rather than raises — the #730 whisperx/CTranslate2 class.

### The gap

`refine_ref_texts` is dispatched with a bare `run_in_executor(_gpu_pool, ...)` at both call sites in `dub_core.py`, and `refine_ref_text` calls `asr_backend.transcribe()` directly. Its `try/except Exception` catches a *raised* error, but a hang isn't an exception, so that dispatch has no wall-clock bound. Every other transcribe in the same file already routes through `run_transcribe_guarded` — the chunk loop and the whole-file `what="Dub"` call — which bounds the call and `reset()`s the pool on timeout.

On a ≤10 GB card the GPU pool is 1 worker (the #567 sizing), so a wedged refine holds that worker and starves later GPU work into the misleading "Can't reach the local backend". There's also no `ping` on that `await`, so the EventSource drops.

### The fix

Route both refine dispatches (per-speaker and per-segment) through the existing `run_transcribe_guarded` — `ASRTimeoutError` and the guard are already imported in this file. On timeout it resets the pool and raises; keep the original clones, matching `refine_ref_text`'s own "failure is a strict no-op" fallback. No new machinery, just the convention the rest of the file already uses.

### Test

Adds a repro to `tests/test_speaker_clone_purity.py`:
- `refine_ref_texts` dispatched raw is unbounded on a hang (the gap), and
- through `run_transcribe_guarded` it times out and falls back to the original `ref_text` (the fix).

If `_gpu_pool` already bounds this somewhere I've missed, feel free to close — just wanted the wedge path covered the same way as the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This change bounds speaker-clone reference text refinement in the dub transcription stream so it uses the same guarded ASR path as other dispatches.

### What changed
- Routed both speaker-clone refinement paths in `backend/api/routers/dub_core.py` through `run_transcribe_guarded` instead of calling `asr_backend.transcribe()` indirectly via an unbounded executor path.
- On `ASRTimeoutError`, the flow now logs a warning and falls back to the original `ref_text` values, preserving the existing “failure is a strict no-op” behavior.
- Added a regression test in `tests/test_speaker_clone_purity.py` that reproduces the wedge scenario and verifies timeout handling plus fallback behavior.

### New behavior
```mermaid
flowchart TD
  A[Start ref-text refinement] --> B[Dispatch via run_transcribe_guarded]
  B --> C{ASR completes before timeout?}
  C -->|Yes| D[Use refined ref_texts]
  C -->|No| E[Raise ASRTimeoutError]
  E --> F[Log warning]
  F --> G[Keep original clone ref_texts]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->