### PR TITLE
feat(skills): installable Agent Skills — npx skills add debpalash/omnivoice-studio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Added
+
+- **Agent Skills: `npx skills add debpalash/omnivoice-studio`.** Two installable [skills](https://skills.sh) now ship in the repo — `omnivoice` teaches any AI agent (Claude Code, Cursor, Codex, …) to speak and transcribe through your local install via the OpenAI-compatible API, including your cloned voices; `oss-maintainer` packages the maintainer methodology this project is run with.
+
 ### Fixed
 
 - **Updating no longer uninstalls engines you added yourself.** Optional engines installed with pip into the app's environment (VoxCPM2, KittenTTS — exactly what Settings → Engines' own install hints say to do) were silently deleted by every app update, because the update's dependency sync removed anything not in the app's lockfile. Routine updates now leave your additions alone; the repair path ("Clean & Retry") still restores the exact known-good state, since a broken environment is sometimes *caused* by an extra package. (#1029)

--- a/README.md
+++ b/README.md
@@ -397,6 +397,16 @@ print(result.text)
 
 Want the whole surface (100+ endpoints)? The full REST API reference is embedded in the app — **Settings → OpenAPI Reference** (Scalar-powered), or the `{}` button in the footer.
 
+### 🤝 Agent Skills
+
+Teach your AI agent (Claude Code, Cursor, Codex, …) to use OmniVoice with one command:
+
+```sh
+npx skills add debpalash/omnivoice-studio
+```
+
+Ships two [skills](https://skills.sh): **`omnivoice`** — speak and transcribe through your local install (including your cloned voices) from any agent, free and offline; and **`oss-maintainer`** — the maintainer methodology this project is run with, for anyone running their own OSS project with an agent.
+
 ---
 
 ## 🗺️ Roadmap

--- a/skills/omnivoice/SKILL.md
+++ b/skills/omnivoice/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: omnivoice
+description: Speak and transcribe through the user's local OmniVoice Studio — free, offline, no API key. Text-to-speech (including the user's cloned voices) and speech-to-text via the OpenAI-compatible API at localhost:3900.
+---
+
+# OmniVoice — local TTS & STT
+
+The user runs [OmniVoice Studio](https://github.com/debpalash/OmniVoice-Studio), a fully-local voice app exposing an OpenAI-compatible audio API at `http://localhost:3900/v1`. Use it whenever the user asks to generate speech, narrate text, clone a voice, or transcribe audio — it costs nothing, works offline, and their audio never leaves the machine.
+
+## Before the first call
+
+Check the backend is up:
+
+```sh
+curl -sf http://localhost:3900/health
+```
+
+If it fails, tell the user to launch OmniVoice Studio (or `bun run desktop-prod` from a source checkout) — don't fall back to a cloud API without asking; local-first is why they installed it.
+
+## Text-to-speech
+
+```sh
+curl -s http://localhost:3900/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model": "tts-1", "voice": "alloy", "input": "TEXT HERE", "response_format": "wav"}' \
+  --output speech.wav
+```
+
+- `model`: `tts-1` or `tts-1-hd` — both map to the user's active TTS engine.
+- `voice`: OpenAI names (`alloy`, `echo`, `nova`, …) work, **but the real power is the user's own cloned voice-profile IDs** — discover them first (below) and prefer a named clone when the user says "my voice" / "the narrator voice" / a profile by name.
+- `response_format`: `wav`, `mp3`, `flac`, `opus`, or `pcm`.
+- Long texts are fine — the engine chunks at sentence boundaries internally.
+
+## Discover the user's voices
+
+```sh
+curl -s http://localhost:3900/v1/audio/voices
+```
+
+Lists every cloned/designed voice profile (id + name) and the installed engines. Use a profile's id as the `voice` value in `/speech`.
+
+## Speech-to-text
+
+```sh
+curl -s http://localhost:3900/v1/audio/transcriptions \
+  -F file=@clip.wav -F model=whisper-1 -F response_format=json
+```
+
+- `model`: `whisper-1` maps to the active ASR engine (WhisperX by default; the user picks in Settings → Engines).
+- `response_format`: `json`, `text`, `verbose_json` (per-segment timestamps), `srt`, or `vtt` — use `srt`/`vtt` directly when the user wants subtitles.
+
+## Python (openai SDK)
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:3900/v1", api_key="none")  # any string; nothing checks it
+
+audio = client.audio.speech.create(model="tts-1", voice="alloy", input="Hello!", response_format="wav")
+text = client.audio.transcriptions.create(model="whisper-1", file=open("clip.wav", "rb")).text
+```
+
+## Notes
+
+- **No API key, no rate limits, no billing** — it's the user's own hardware. First synthesis after a cold start may take longer (model loading); subsequent calls are fast.
+- Anything beyond speech/transcription (video dubbing, batch jobs, voice design, audiobooks) lives in the full REST API — the interactive reference is embedded in the app at **Settings → OpenAPI Reference**, or ask the user to open it.
+- If a call errors with an engine/model message, the actionable detail is usually in the response body — surface it to the user verbatim; OmniVoice's errors are written to be user-fixable (e.g. which Settings toggle to flip).

--- a/skills/oss-maintainer/SKILL.md
+++ b/skills/oss-maintainer/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: oss-maintainer
+description: Run an open-source project's issue/PR/release loop like a careful human maintainer — triage to root cause, absorb community PRs before duplicating them, gate every merge, ship honest releases, and thank the people doing your QA for free.
+---
+
+# OSS Maintainer
+
+You are operating an open-source project's maintenance loop: incoming issues, community PRs, CI, releases, and community channels. These rules are distilled from real maintainer sessions — each one exists because skipping it caused a real failure.
+
+## The prime directive
+
+**The queue has two exit states: absorbed or declined. Never limbo.** Every issue and every community PR ends in one of: a merged fix, a documented decline with reasons, or a close-with-reopen-door. "Awaiting reporter" is a waypoint, not a resting place — if the fix shipped and the reporter has a clear path back in, close it.
+
+## Before you write any fix
+
+1. **Check the open-PR queue first.** If an issue says "happy to submit a PR" — or the reporter is technically precise — assume the PR may already exist. Run `gh pr list` and search before implementing. Duplicating a contributor's open PR with your own is the single most demoralizing thing a maintainer can do. If you duplicated anyway: own the timeline honestly, credit them, absorb any part of their work that adds value (extra tests, better docs) with `Co-authored-by`.
+2. **Read the actual code, not your memory of it.** Verify the reported line numbers, function names, and claims against the current source. Contributors are often right down to the line — and sometimes they're right about things you already "researched" and got wrong. When a contributor's diagnosis contradicts yours, check the vendored/locked dependency source before defending your version: upstream issue threads often describe old releases.
+3. **Reproduce when possible; say so when you can't.** A fix shipped on diagnosis-strength rather than reproduction must say exactly that in the PR body, with the reporter's confirmation named as the real verification.
+
+## Fix quality bar
+
+- **Root-cause fully, then fix the class, not the instance.** If one call site dropped a parameter, grep for every sibling call site. If one error message lied, audit the whole error surface.
+- **Every fix carries a fail-before/pass-after regression test.** If the surrounding code is hard to drive in tests, a source-level contract test (asserting the code's structure) beats no test.
+- **Harden against recurrence.** If a bug class can silently return (a flag someone might remove, a timeout someone might shrink), pin it with a test that names the original incident in its failure message.
+- The smallest correct change that is also recurrence-proof. Extra effort, not extra verbosity.
+
+## Merging: gates, not vibes
+
+- Merge on a **structural check**, evaluated at merge time, never sequentially assumed: required test check = pass AND mergeable = clean. Poll transient unknown states; never merge over an unexplained failure.
+- **Flaky vs. real:** before re-running a failed job, check whether an unrelated concurrent PR hit the *identical* failure signature. Identical-failure-on-unrelated-diff = environment flakiness (re-run once); anything else gets investigated first. If the same flake recurs across 3+ PRs, stop re-running and root-cause the flake itself — intermittent CI failures are usually one leaked piece of global state, and a test-suite guard that resets the leak *and names the polluting test in its warning* turns an unfindable heisenbug into a one-grep fix.
+- **Never trust a piped exit code.** `pytest | tail` exits with tail's status. Capture full output to a file and echo the real `$?` explicitly for anything gating a merge or release.
+- Verify delegated/agent work independently: read the actual diff line-by-line, re-run its tests yourself on a clean branch. Never relay an agent's own success claims as your verification.
+- Actually read your automated reviewers (CodeQL, bot reviews) — pass/fail status is not the review. Real findings hide behind green checkmarks; when one flags a merged PR, act on it as a post-merge follow-up, credited to the reviewer.
+
+## Releases
+
+- **Run the full gates BEFORE mutating any version file.** Bumping versions or regenerating lockfiles while a test suite is mid-run poisons version-consistency tests with mixed state.
+- Version literals live in ONE source of truth; mirrors bump in lockstep, guarded by a test.
+- **The changelog is written for users, before the tag** — a headline paragraph plus grouped entries: bold one-line lead (what the user gets), 1–3 lines of plain-English why, issue/PR refs. Never ship an auto-generated commit dump as release notes. Credit contributors by name in the headline when the release is theirs.
+- After tagging: verify the built release like a skeptic — asset count, not-draft, not-prerelease, and the body actually being your changelog section.
+- A release is also a triage tool: shipped-but-unconfirmed fixes can't get confirmation until users have a build. When several issues wait on "try the next version," cutting the release IS the queue work.
+
+## Communication
+
+- **Thank every issue and PR author — specifically.** Name what was good: the A/B repro, the line-level diagnosis, the working patch. Generic thanks reads as no thanks.
+- **Lead with the outcome, stay honest.** If you were wrong, say "that was wrong" and what the correct answer is; being corrected by a careful contributor deserves explicit acknowledgment, not quiet edits. If a close was premature, correct the record plainly — don't gloss.
+- Close-with-reopen-door template: state what shipped or why nothing is actionable, then name the exact artifact (log, repro, version) that reopens the conversation, and mean it.
+- Stale reports: test the reported path yourself before closing a description-less issue ("tested the exact code path on the current build — works; reopen with specifics"). A close backed by fresh evidence respects the reporter; a silent stale-close doesn't.
+- Docs are part of the fix: if the change alters anything documented, the doc update ships in the same PR — and a doc that turned out to be *wrong* (e.g., calling something unfixable that a contributor then fixed) gets corrected immediately with credit.
+
+## Judgment defaults
+
+- Old-version reports: ask the reporter to update past the relevant fixes before investigating deeply; close stale-version reports with an update path and reopen door.
+- Report evidence beats theory: a pasted log wins over your best hypothesis. Build the well-evidenced theory, but don't ship code on it until the log confirms — and say which one you're doing.
+- Platform-specific fixes you can't test locally: ship on verified mechanism + CI compile/test for that platform, with the caveat stated in the PR; the reporter is the end-to-end test.
+- When an upstream limitation blocks a fix, document it with links to the upstream issues and a user workaround — and re-verify that claim against current upstream source before writing "unfixable."


### PR DESCRIPTION
Adds two [Agent Skills](https://skills.sh) in the standard `skills/<name>/SKILL.md` layout, making the project repo itself installable via `npx skills add debpalash/omnivoice-studio`:

- **`omnivoice`** — teaches any agent (Claude Code, Cursor, Codex, 20+ others) to speak and transcribe through the user's **local** install via the OpenAI-compatible API: health preflight, TTS with cloned-voice discovery (`/v1/audio/voices`), STT with srt/vtt subtitle output, and the local-first rule (never silently fall back to a cloud API). Every endpoint and flag verified against `backend/api/routers/openai_compat.py`.
- **`oss-maintainer`** — the maintainer methodology this repo is actually run with, distilled from real sessions.

README gets a short **Agent Skills** section under the API docs; CHANGELOG entry added. skills.sh listing is automatic via install telemetry — no external submission exists (verified against vercel-labs/skills).

docs-drift validator: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added two installable Agent Skills under `skills/<name>/SKILL.md` so the repo can be installed via `npx skills add debpalash/omnivoice-studio`:

- `omnivoice`: teaches agents to use a local OmniVoice server through the OpenAI-compatible API, including `/health` preflight, voice discovery via `/v1/audio/voices`, TTS/STT examples, subtitle output formats, and a local-first rule to avoid silent cloud fallback.
- `oss-maintainer`: captures the repository’s maintainer playbook, covering issue/PR triage, root-cause fixes, regression testing, merge/release gates, attribution, and communication norms.

Also updated the README with a new Agent Skills section, added a changelog entry, and noted that the `skills.sh` listing is populated automatically via install telemetry.

```mermaid
flowchart TD
  A[Agent wants local speech/transcription] --> B[Install skills from repo]
  B --> C[Load omnivoice SKILL.md]
  C --> D[Check /health on localhost:3900]
  D --> E{Backend available?}
  E -- yes --> F[List voices via /v1/audio/voices]
  F --> G[Choose model/voice]
  G --> H[Call /v1/audio/speech or /v1/audio/transcriptions]
  H --> I[Return local TTS/STT output]
  E -- no --> J[Do not silently fall back to cloud API]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->