### PR TITLE
fix(api): /v1/audio/speech honors num_step + guidance_scale instead of silently dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- **The OpenAI-compatible speech endpoint stops silently discarding quality settings.** `POST /v1/audio/speech` accepted `num_step` and `guidance_scale` in the request body with a 200 OK — and dropped them without a word, so API callers couldn't reach the model's documented quality preset (`num_step: 32`). Both are now declared, validated, and passed through to the engine, matching the native `/generate` endpoint. Caught by a contributor's measured Tesla T4 verification pass. (#1014)
 - **Updating no longer uninstalls engines you added yourself.** Optional engines installed with pip into the app's environment (VoxCPM2, KittenTTS — exactly what Settings → Engines' own install hints say to do) were silently deleted by every app update, because the update's dependency sync removed anything not in the app's lockfile. Routine updates now leave your additions alone; the repair path ("Clean & Retry") still restores the exact known-good state, since a broken environment is sometimes *caused* by an extra package. (#1029)
 
 ## [0.3.14] — 2026-07-09

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -108,6 +108,23 @@ class SpeechRequest(BaseModel):
         ge=0,
         description="OmniVoice GGUF extension: long-form internal chunk threshold.",
     )
+    # #1014: these two were silently DISCARDED before (pydantic ignores
+    # undeclared fields) — a 200 OK that quietly dropped the caller's quality
+    # knobs. Declared now and passed through, matching the native /generate
+    # form fields (defaults there: num_step=16, guidance_scale=2.0; the
+    # model's documented "quality" preset is num_step=32).
+    num_step: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=128,
+        description="OmniVoice extension: iterative unmasking steps (app default 16; 32 = the model's documented quality preset).",
+    )
+    guidance_scale: Optional[float] = Field(
+        default=None,
+        gt=0,
+        le=20,
+        description="OmniVoice extension: classifier-free guidance scale (app default 2.0).",
+    )
 
 
 class TranscriptionResponse(BaseModel):
@@ -274,6 +291,10 @@ async def create_speech(req: SpeechRequest):
         kw["chunk_duration"] = req.chunk_duration
     if req.chunk_threshold is not None:
         kw["chunk_threshold"] = req.chunk_threshold
+    if req.num_step is not None:
+        kw["num_step"] = req.num_step
+    if req.guidance_scale is not None:
+        kw["guidance_scale"] = req.guidance_scale
     if req.language:
         kw["language"] = req.language
     if req.instruct:

--- a/tests/test_agentic_provider_contract.py
+++ b/tests/test_agentic_provider_contract.py
@@ -117,3 +117,33 @@ def test_speed_passthrough(client, monkeypatch):
     })
     assert res.status_code == 200, res.text
     assert fake.calls[0][1].get("speed") == pytest.approx(1.25)
+
+
+def test_num_step_and_guidance_scale_passthrough(client, monkeypatch):
+    """#1014: these were silently DISCARDED (200 OK, fields dropped) — a T4
+    hardware report caught it by comparing against the native /generate.
+    They must now reach the engine's generate() kwargs."""
+    fake = _make_fake_engine("fake-agent-quality")
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-agent-quality", fake)
+    res = client.post("/v1/audio/speech", json={
+        "model": "fake-agent-quality", "input": "Quality preset.",
+        "num_step": 32, "guidance_scale": 3.0,
+    })
+    assert res.status_code == 200, res.text
+    kw = fake.calls[0][1]
+    assert kw.get("num_step") == 32
+    assert kw.get("guidance_scale") == pytest.approx(3.0)
+
+
+def test_num_step_and_guidance_scale_omitted_stay_absent(client, monkeypatch):
+    """Engines that don't accept these kwargs must not suddenly receive
+    None values — omitted means absent, exactly like duration/seed."""
+    fake = _make_fake_engine("fake-agent-defaults")
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "fake-agent-defaults", fake)
+    res = client.post("/v1/audio/speech", json={
+        "model": "fake-agent-defaults", "input": "Defaults.",
+    })
+    assert res.status_code == 200, res.text
+    kw = fake.calls[0][1]
+    assert "num_step" not in kw
+    assert "guidance_scale" not in kw


### PR DESCRIPTION
Follow-up promised on #1014: a contributor's measured Tesla T4 verification caught that `POST /v1/audio/speech` accepted `num_step`/`guidance_scale` with a 200 OK and silently discarded both — API callers could never reach the model's documented quality preset (`num_step: 32`) through the OpenAI-compatible surface, while the native `/generate` exposes both.

Both are now declared as validated optional extensions and passed through to the engine — omitted means absent (no stray `None` for engines that don't accept the kwargs), exactly like the existing `duration`/`seed` extensions.

Tests: passthrough reaches engine kwargs; omitted stays absent. Contract suite 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- `POST /v1/audio/speech` now validates and forwards the optional `num_step` and `guidance_scale` fields instead of silently ignoring them.
- The router passes these values through to the TTS engine only when provided, matching existing optional fields like `duration` and `seed`.
- Added contract coverage for both passthrough and omission behavior, and updated the changelog.

## Behavior
```mermaid
flowchart TD
  A[Client sends POST /v1/audio/speech] --> B{num_step / guidance_scale provided?}
  B -->|Yes| C[Validate values]
  C --> D[Include fields in generate() kwargs]
  B -->|No| E[Skip fields]
  D --> F[TTS engine generates speech]
  E --> F
```

## Testing
- Added/updated contract tests confirming:
  - provided values reach `generate()`
  - omitted values stay absent from the engine call

<!-- end of auto-generated comment: release notes by coderabbit.ai -->