### PR TITLE
docs: link the community Colab notebook (#1038)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ print(result.text)
 
 Want the whole surface (100+ endpoints)? The full REST API reference is embedded in the app — **Settings → OpenAPI Reference** (Scalar-powered), or the `{}` button in the footer.
 
+### 📓 Run on Google Colab (community)
+
+No local GPU? A community member ([@shakib30](https://github.com/shakib30)) maintains a working Colab notebook: [shakib30/OmniVoice-Studio-google-colab](https://github.com/shakib30/OmniVoice-Studio-google-colab). Community-maintained — issues with the notebook go there; issues with OmniVoice itself come here.
+
 ### 🤝 Agent Skills
 
 Teach your AI agent (Claude Code, Cursor, Codex, …) to use OmniVoice with one command:


### PR DESCRIPTION
@shakib30 built and tested a working Colab notebook and offered it upstream (#1038). This links it from the README — credited, marked community-maintained — making the no-local-GPU path discoverable without taking on notebook maintenance in-repo. docs-drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a “Run on Google Colab (community)” section to the README.
- Linked the community-maintained notebook for users without a local GPU.
- Directed notebook issue reports to the community repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->