### PR TITLE
release: freeze v0.3.15 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+## [0.3.15] — 2026-07-10
+
+The cold-start release. Three "why is this broken on my machine" mysteries got solved at their roots: **first generations stop dying at 300 seconds** (the timeout was counting the model download as generation time — @moduvoice measured it on a Tesla T4: 0% GPU for the full window), **updates stop deleting engines you installed yourself** (the updater's dependency sync removed anything not in the app's lockfile — including things our own UI told you to install), and **the "slower than v0.3.5" regression is found and fixed** (clone profiles without a transcript were silently re-running a full Whisper transcription on every single generate). Also: Clear History is back, auto-played audio is finally stoppable, @stronghamjji hardened the dub pipeline against wedged transcribes, and @shakib30's community Colab notebook is now the linked no-GPU path. Thank you all.
+
+
 ### Added
 
 - **Agent Skills: `npx skills add debpalash/omnivoice-studio`.** Two installable [skills](https://skills.sh) now ship in the repo — `omnivoice` teaches any AI agent (Claude Code, Cursor, Codex, …) to speak and transcribe through your local install via the OpenAI-compatible API, including your cloned voices; `oss-maintainer` packages the maintainer methodology this project is run with.

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.14"
+_FALLBACK_VERSION = "0.3.15"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.14"
+version = "0.3.15"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.14"
+version = "0.3.15"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.14"
+version = "0.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Freezes v0.3.15 — **the cold-start release.** Headline fixes: first generations stop dying at 300s while the model downloads (#1033/#1037, measured in #1014), updates stop deleting user-installed engines (#1029), and the v0.3.5 speed regression is found and fixed (#1032's per-generate ASR tax). Plus: Clear History restored + stoppable auto-play (#1032), @stronghamjji's wedge-guard (#1031), num_step/guidance passthrough (#1014), Agent Skills (`npx skills add debpalash/omnivoice-studio`), T4 hardware notes, @shakib30's community Colab link.

- 4 version files bumped 0.3.14 → 0.3.15 in lockstep (`test_app_version.py` 6/6)
- `uv.lock` + `Cargo.lock` regenerated
- CHANGELOG `[Unreleased]` → `[0.3.15] — 2026-07-10` with headline, contributors credited

Gates (run to completion on final main BEFORE any mutation): backend **2445 passed, 0 failed** — notably the 16 low-disk-era local flakes are gone, confirming that diagnosis; frontend **942/942**. This PR's CI is the clean-room validation.

After merge: tag v0.3.15. Main HOLDS at 0.3.15 (AUTO_VERSION_BUMP off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Froze the v0.3.15 release dated 2026-07-10.
- Synchronized version numbers across backend, frontend, Tauri, and project metadata.
- Regenerated `uv.lock` and `Cargo.lock`.
- Updated the changelog with cold-start, engine preservation, ASR performance, Clear History, auto-playback, wedge guarding, guidance passthrough, Agent Skills, T4, and Colab improvements.
- Validation passed: 2,445 backend tests and 942 frontend tests.

## Release behavior

```mermaid
flowchart LR
  A[Start generation] --> B{Model downloaded?}
  B -->|No| C[Download model]
  C --> D[Start generation timeout]
  B -->|Yes| D
  D --> E[Generate]
  E --> F[Allow stopping auto-playback]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->