### PR TITLE
fix(clone): ⊕ Insert popover opens below the script input instead of climbing out of the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The ⊕ Insert token list no longer climbs out of the viewport.** In the voice-clone script panel, the insert popover (expression tags, CMU phoneme chips) always opened *upward* from the textarea — and since that input sits at the very top of the panel, the list disappeared past the top of the window with no way to see or scroll it. It now opens below the input, where there's always room. (owner-reported)
+
 ### Added
 
 - **A persistent mini-player for all the audio that used to play "invisibly".** Generated output, voice-profile and dub-segment previews, story lines, Gallery voices, and Projects renders all played through a bare audio pipe — no waveform, no seek, no time, and (until v0.3.15's stop pill) no way to stop them. A slim player bar now docks above the Logs footer whenever such audio plays, on every page: live waveform (decoded once from the audio already in memory — nothing is re-fetched), click/drag/keyboard seek, play/pause, elapsed/total time, what's-playing label, and a stop button. It replaces the stop-only pill, and because it's part of the app's layout rather than a floating overlay, the pill's "covers the Production Overrides row at 1440×900" overlap class can't come back. Stories line previews also route through it — which makes them stoppable *and* fixes them being silent on the macOS/Linux desktop builds (their old playback path used blob: URLs, which WebKit refuses to play). (no issue — owner request following #1032's stop-pill band-aid)

--- a/frontend/src/components/clone/ScriptPanel.jsx
+++ b/frontend/src/components/clone/ScriptPanel.jsx
@@ -34,8 +34,13 @@ export default function ScriptPanel({
 }) {
   return (
     <div className="flex flex-col gap-[6px] flex-none min-h-0 relative z-[2]">
-      {/* overflow-visible: the ⊕ Insert popover opens above the textarea and
-            must escape the panel's box instead of being clipped (#481). */}
+      {/* overflow-visible: the ⊕ Insert popover opens BELOW the textarea and
+            must escape the panel's box instead of being clipped (#481). It
+            used to open upward — but the script input sits at the very top of
+            the clone modal, so the tag list (max-h 280px) climbed straight out
+            of the viewport with no way to see or scroll it (owner-reported,
+            screenshot showed the CMU chips clipped). Below always has room
+            here: the panel is the topmost element in every mount. */}
       <div className={`${STUDIO_PANEL} relative z-[10] overflow-visible`}>
         <div className="label-row">
           <Command className="label-icon" size={14} />{' '}
@@ -100,7 +105,7 @@ export default function ScriptPanel({
           )}
           {insertOpen && (
             <div
-              className="absolute right-[8px] bottom-[60px] z-20 flex flex-wrap gap-1 max-w-[min(360px,calc(100vw-16px))] max-h-[min(280px,calc(100vh-120px))] overflow-y-auto overscroll-contain p-2 bg-[var(--chrome-bg)] border border-transparent rounded-[10px] shadow-[0_8px_24px_rgba(0,0,0,0.45)]"
+              className="absolute right-[8px] top-[calc(100%+6px)] z-20 flex flex-wrap gap-1 max-w-[min(360px,calc(100vw-16px))] max-h-[min(280px,calc(100vh-120px))] overflow-y-auto overscroll-contain p-2 bg-[var(--chrome-bg)] border border-transparent rounded-[10px] shadow-[0_8px_24px_rgba(0,0,0,0.45)]"
               role="menu"
             >
               {TAGS.map((tag) => (

--- a/frontend/src/test/scriptPanelInsertPopover.test.jsx
+++ b/frontend/src/test/scriptPanelInsertPopover.test.jsx
@@ -1,0 +1,38 @@
+// Regression guard (owner-reported): the ⊕ Insert popover used to open
+// UPWARD (`bottom-[60px]`) from the script textarea — but ScriptPanel's only
+// mount (CloneDesignTab) puts that input at the very top of the clone modal,
+// so the tag list (max-h 280px, incl. the CMU phoneme chips) climbed straight
+// out of the viewport with no way to see or scroll it. It must open BELOW
+// the input (`top-[calc(100%+…)]`), where the panel's topmost placement
+// guarantees room.
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React, { useState } from 'react';
+import ScriptPanel from '../components/clone/ScriptPanel';
+
+function Host() {
+  const [text, setText] = useState('');
+  const [insertOpen, setInsertOpen] = useState(false);
+  return (
+    <ScriptPanel
+      t={(k, opts) => opts?.defaultValue || k}
+      defineMethod="audio"
+      text={text}
+      setText={setText}
+      demoPresets={[]}
+      insertOpen={insertOpen}
+      setInsertOpen={setInsertOpen}
+      insertTag={() => {}}
+    />
+  );
+}
+
+describe('ScriptPanel insert popover placement', () => {
+  it('opens BELOW the input (top-anchored), never upward', () => {
+    render(<Host />);
+    fireEvent.click(screen.getByRole('button', { name: /insert/i }));
+    const popover = document.querySelector('[class*="top-[calc(100%"]');
+    expect(popover, 'popover must anchor below the panel via top-[calc(100%+…)]').toBeTruthy();
+    expect(popover.className).not.toMatch(/bottom-\[60px\]/);
+  });
+});


### PR DESCRIPTION
Owner-reported with screenshot: in the voice-clone script panel, the ⊕ Insert popover (expression tags + CMU phoneme chips) was hard-anchored `bottom-[60px]` — always growing **upward** from the textarea. That input sits at the very top of the panel, so the list (max-h 280px) climbed past the viewport top, unreachable and unscrollable.

Now anchored `top-[calc(100%+6px)]` — below the input, where the panel's topmost placement (single mount: CloneDesignTab) guarantees room. Regression test pins the placement. Full frontend suite: 969/969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Repositioned the Voice Clone “⊕ Insert token” popover to open below the textarea, preventing viewport clipping.
- Added a regression test confirming the top anchor and preventing the previous `bottom-[60px]` positioning.
- Documented the fix in `CHANGELOG.md`.
- Frontend suite passes: 969/969 tests.

### Layout

```text
Before:                 After:

┌──────────────┐        ┌──────────────┐
│ Popover      │        │ Textarea     │
├──────────────┤        ├──────────────┤
│ Textarea     │        │ Popover      │
└──────────────┘        └──────────────┘
  may clip above           opens below
```

### Mechanism

```mermaid
flowchart TD
  A[Open Insert popover] --> B[Anchor to textarea container]
  B --> C[Position at top: calc(100% + 6px)]
  C --> D[Token list remains visible below textarea]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->