### PR TITLE
fix(watermark): bound AudioSeal memory — long audio embeds/detects in 30s chunks (#1045)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- **Long generations no longer risk a multi-gigabyte memory spike while being watermarked.** The invisible watermark (on by default) pushed the entire waveform through AudioSeal in a single call, and its memory use grows with audio length — a multi-minute generation demanded a single ~2 GB allocation, enough to fail outright on a 16 GB machine already holding a model ("DefaultCPUAllocator: not enough memory"). Watermark embedding — and the Verify-audio detector, which had the same flaw with uploaded files — now processes audio in ~30-second chunks, so peak memory stays flat no matter how long the audio is. Detection also got sharper for spliced files: it now reports the strongest chunk instead of a whole-file average. (#1045)
+
 - **The ⊕ Insert token list no longer climbs out of the viewport.** In the voice-clone script panel, the insert popover (expression tags, CMU phoneme chips) always opened *upward* from the textarea — and since that input sits at the very top of the panel, the list disappeared past the top of the window with no way to see or scroll it. It now opens below the input, where there's always room. (owner-reported)
 
 ### Added

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -39,6 +39,27 @@ _audioseal_available: Optional[bool] = None
 # This is our signature — every OmniVoice-generated audio carries it.
 OMNI_MESSAGE = [0, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1]
 
+# Watermark ops run chunk-by-chunk: AudioSeal's activation memory grows
+# linearly with input length — a single multi-minute waveform demands a
+# multi-GB CPU buffer, which OOM'd a 16 GB machine mid-generate (#1045).
+# 30 s bounds each call to tens of MB; the 16-bit message repeats throughout
+# the audio, so per-chunk embedding/detection is equivalent.
+_CHUNK_SECONDS = 30
+
+
+def _iter_chunks(audio: torch.Tensor, sample_rate: int):
+    """Yield ≤ ~_CHUNK_SECONDS slices of (batch, channels, samples) audio
+    along the time axis. A sub-second tail is folded into the previous chunk
+    (AudioSeal embeds poorly on very short segments)."""
+    total = audio.shape[-1]
+    step = _CHUNK_SECONDS * sample_rate
+    starts = list(range(0, total, step))
+    if len(starts) > 1 and total - starts[-1] < sample_rate:
+        starts.pop()
+    for i, start in enumerate(starts):
+        end = starts[i + 1] if i + 1 < len(starts) else total
+        yield audio[..., start:end]
+
 
 def _check_available() -> bool:
     """Check if AudioSeal is installed and importable."""
@@ -135,7 +156,13 @@ def embed_watermark(
 
         # AudioSeal operates at 16kHz internally; it handles resampling, but
         # we need to inform it of the source rate for correct embedding.
-        watermarked = generator(audio, sample_rate=sample_rate, message=msg)
+        watermarked = torch.cat(
+            [
+                generator(seg, sample_rate=sample_rate, message=msg)
+                for seg in _iter_chunks(audio, sample_rate)
+            ],
+            dim=-1,
+        )
 
         # Restore original shape
         if len(original_shape) == 2:
@@ -189,11 +216,17 @@ def detect_watermark(
         else:
             audio = waveform
 
-        result = detector.detect_watermark(audio, sample_rate=sample_rate, message_threshold=0.5)
-
-        # result is (detection_confidence, decoded_message)
-        confidence = float(result[0]) if isinstance(result, tuple) else 0.0
-        decoded_msg = result[1] if isinstance(result, tuple) and len(result) > 1 else None
+        # Detect per chunk and keep the best hit: bounds memory the same way
+        # embedding does, and a splice where only part of the file is
+        # OmniVoice audio still registers (a whole-file average would dilute it).
+        best_conf, decoded_msg = -1.0, None
+        for seg in _iter_chunks(audio, sample_rate):
+            result = detector.detect_watermark(seg, sample_rate=sample_rate, message_threshold=0.5)
+            seg_conf = float(result[0]) if isinstance(result, tuple) else 0.0
+            if seg_conf > best_conf:
+                best_conf = seg_conf
+                decoded_msg = result[1] if isinstance(result, tuple) and len(result) > 1 else None
+        confidence = max(best_conf, 0.0)
 
         # Decode message bits
         message_bits = ""

--- a/tests/test_watermark_chunking_1045.py
+++ b/tests/test_watermark_chunking_1045.py
@@ -1,0 +1,123 @@
+"""Watermark ops must run in bounded chunks (#1045).
+
+AudioSeal's activation memory grows linearly with input length: embedding a
+single multi-minute waveform in one call demanded a >2 GB CPU buffer, which
+OOM'd a reporter's 16 GB Windows machine mid-generate ("DefaultCPUAllocator:
+not enough memory: you tried to allocate 2202777600 bytes"). embed_watermark
+and detect_watermark now slice the audio into ≤ ~30 s chunks so peak memory
+is bounded regardless of generation length. Fail-before/pass-after: on the
+pre-fix code the fakes below observe one call spanning the whole waveform.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from services import watermark
+from services.watermark import (
+    _CHUNK_SECONDS,
+    _iter_chunks,
+    detect_watermark,
+    embed_watermark,
+)
+
+SR = 24000
+
+
+class FakeGenerator:
+    """Stands in for the AudioSeal generator; records chunk lengths."""
+
+    def __init__(self):
+        self.seen_lengths: list[int] = []
+
+    def __call__(self, audio, sample_rate, message=None):
+        self.seen_lengths.append(audio.shape[-1])
+        return audio * 2.0  # position-independent transform → order is checkable
+
+
+class FakeDetector:
+    """Stands in for the AudioSeal detector; confidence peaks on the chunk
+    holding the sentinel spike so best-chunk aggregation is observable."""
+
+    def __init__(self):
+        self.seen_lengths: list[int] = []
+
+    def detect_watermark(self, audio, sample_rate, message_threshold=0.5):
+        self.seen_lengths.append(audio.shape[-1])
+        conf = 0.9 if float(audio.abs().max()) > 100.0 else 0.1
+        msg = torch.tensor(watermark.OMNI_MESSAGE) if conf > 0.5 else torch.zeros(16)
+        return (conf, msg)
+
+
+@pytest.fixture
+def fake_audioseal(monkeypatch):
+    gen, det = FakeGenerator(), FakeDetector()
+    monkeypatch.setattr(watermark, "_generator", gen)
+    monkeypatch.setattr(watermark, "_detector", det)
+    monkeypatch.setattr(watermark, "_audioseal_available", True)
+    return gen, det
+
+
+def test_embed_long_audio_is_chunk_bounded(fake_audioseal):
+    gen, _ = fake_audioseal
+    seconds = 95  # → 30 + 30 + 30 + 5
+    wave = torch.arange(SR * seconds, dtype=torch.float32).unsqueeze(0)
+
+    out = embed_watermark(wave, SR, force=True)
+
+    max_chunk = _CHUNK_SECONDS * SR
+    assert len(gen.seen_lengths) == 4
+    assert all(n <= max_chunk for n in gen.seen_lengths), gen.seen_lengths
+    # Every sample processed, in order, shape preserved
+    assert out.shape == wave.shape
+    assert torch.equal(out, wave * 2.0)
+
+
+def test_embed_short_audio_single_call(fake_audioseal):
+    gen, _ = fake_audioseal
+    wave = torch.randn(1, SR * 3)
+    out = embed_watermark(wave, SR, force=True)
+    assert gen.seen_lengths == [SR * 3]
+    assert torch.equal(out, wave * 2.0)
+
+
+def test_embed_subsecond_tail_folds_into_previous_chunk(fake_audioseal):
+    gen, _ = fake_audioseal
+    # 30.5 s → a lone 0.5 s tail would embed poorly; folded into chunk 1
+    wave = torch.randn(1, int(SR * 30.5))
+    embed_watermark(wave, SR, force=True)
+    assert gen.seen_lengths == [int(SR * 30.5)]
+    assert max(gen.seen_lengths) <= (_CHUNK_SECONDS + 1) * SR
+
+
+def test_embed_1d_shape_restored(fake_audioseal):
+    wave = torch.randn(SR * 65)
+    out = embed_watermark(wave, SR, force=True)
+    assert out.shape == wave.shape
+
+
+def test_detect_long_audio_is_chunk_bounded_and_keeps_best_chunk(fake_audioseal):
+    _, det = fake_audioseal
+    # Spike (→ high confidence) only in the LAST chunk: a whole-file pass or
+    # first-chunk-only shortcut would miss it.
+    wave = torch.randn(1, SR * 95) * 0.01
+    wave[0, -SR:] = 500.0
+
+    result = detect_watermark(wave, SR)
+
+    max_chunk = _CHUNK_SECONDS * SR
+    assert len(det.seen_lengths) == 4
+    assert all(n <= max_chunk for n in det.seen_lengths), det.seen_lengths
+    assert result["is_watermarked"] is True
+    assert result["confidence"] == 0.9
+    assert result["is_omnivoice"] is True
+
+
+def test_iter_chunks_covers_everything_exactly_once():
+    audio = torch.arange(SR * 95, dtype=torch.float32).reshape(1, 1, -1)
+    rejoined = torch.cat(list(_iter_chunks(audio, SR)), dim=-1)
+    assert torch.equal(rejoined, audio)
+
+
+def test_iter_chunks_empty_audio_yields_nothing():
+    assert list(_iter_chunks(torch.zeros(1, 1, 0), SR)) == []


### PR DESCRIPTION
Fixes the memory-exhaustion half of #1045.

## What the crash forensics showed

First auto-report from **v0.3.15** (16 GB RAM, RTX 3060 Ti 8 GB, Windows). The captured backend crash log has the real cause:

```
[enforce fail at alloc_cpu.cpp:121] data. DefaultCPUAllocator: not enough memory: you tried to allocate 2202777600 bytes.
```

That ~2.2 GB allocation is AudioSeal watermark embedding (`watermark.py` logged it as "Watermark embedding failed (passing through original)"): `embed_watermark` pushed the **entire waveform through the generator in one call**, and AudioSeal's activation memory grows linearly with audio length. A multi-minute generation on a machine already holding a TTS model = one giant allocation the OS can't serve; on this box it tipped the system into hard memory pressure, the backend got killed/respawned, and the retry burned the 300 s generate budget → the 503 the user reported.

## Fix

- `embed_watermark` and `detect_watermark` now slice audio into **~30 s chunks** (`_iter_chunks`); peak memory is flat regardless of generation length. Sub-second tails fold into the previous chunk (AudioSeal embeds poorly on very short segments).
- The 16-bit message repeats throughout the audio, so per-chunk embedding is detection-equivalent.
- Detection keeps the **best-confidence chunk** instead of a whole-file pass — same memory bound, and spliced files (only part OmniVoice audio) no longer get diluted by averaging.
- Fixes the whole class: the same single-call flaw existed in the Verify-audio detector route, where a user-uploaded long file could do the same thing.

## Tests

`tests/test_watermark_chunking_1045.py` — fail-before/pass-after via fake generator/detector recording what lengths reach the model: chunk bounds on a 95 s waveform (embed + detect), every-sample-once ordering, short-audio single-call fast path, sub-second tail folding, 1-D shape restore, best-chunk aggregation (spike only in the last chunk), empty-audio edge. 7 new tests pass; `test_persona_bundle.py` (watermark consumer) still green.

CHANGELOG `[Unreleased]` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Process AudioSeal watermark embedding and detection in ~30-second chunks to prevent memory exhaustion on long audio.
- Fold sub-second tails into the preceding chunk during processing.
- Select the highest-confidence detection chunk, improving spliced-audio handling.
- Apply chunked detection to the Verify-audio route.
- Add seven regression tests covering chunking, ordering, tail handling, shape restoration, confidence selection, and empty audio.
- Update the changelog.

```mermaid
flowchart LR
    A[Input audio] --> B[Normalize and split into ~30s chunks]
    B --> C{Operation}
    C -->|Embed| D[Watermark each chunk]
    D --> E[Concatenate output]
    C -->|Detect| F[Detect each chunk]
    F --> G[Select highest-confidence result]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->