### PR TITLE
feat(longform): segment-level render cache — edit one sentence, re-render one segment

### DIFF
--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -314,31 +314,46 @@ async def _prepare_synth(default_voice: str | None, language: str | None = None)
 def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, lexicon=None):
     """Render one chapter, content-addressed so a re-run reuses it (resume).
 
-    Returns ``(wav_path, duration_s, was_cached)``. The WAV lives at
-    ``cache_dir/<key>.wav`` where ``key`` is :func:`chapter_cache_key` over the
-    chapter's spans + sample rate + engine + each voice's resolved signature
-    (+ the lexicon, so a lexicon edit re-renders), so an unchanged chapter is
-    never re-synthesized. Runs in the GPU-pool executor.
+    Returns ``(wav_path, duration_s, was_cached, seg_stats)``. Two cache
+    layers:
+
+    * Outer — the WAV at ``cache_dir/<key>.wav`` where ``key`` is
+      :func:`chapter_cache_key` over the chapter's spans + sample rate +
+      engine + each voice's resolved signature (+ the lexicon, so a lexicon
+      edit re-renders). A fully-unchanged chapter hits here and never touches
+      segment files; the key derivation is unchanged, so chapter caches
+      written by released versions keep hitting. ``seg_stats`` is ``None``.
+    * Inner — on a chapter miss, each spoken span goes through the
+      :class:`services.longform_render.SegmentCache` under
+      ``cache_dir/segments``: cached segments load from disk, only the
+      edited/missing ones synthesize, and each fresh segment persists the
+      moment it renders (an interrupted chapter resumes from them).
+      ``seg_stats`` is ``{"total": spoken_spans, "cached": reused}``.
+
+    Runs in the GPU-pool executor.
     """
     import json
     import wave
 
     from services.audio_io import atomic_save_wav
-    from services.longform_render import chapter_cache_key
+    from services.longform_render import SegmentCache, chapter_cache_key
     from services.pronunciation import normalize_lexicon
 
     spans_tuples = [(s.voice_id, s.text, s.pause_ms_after, getattr(s, "speed", None))
                     for s in chapter.spans]
-    sig: dict = {}
+    voice_sigs: dict = {}
     for s in chapter.spans:
         k = s.voice_id or ""
-        if k not in sig:
+        if k not in voice_sigs:
             v = resolve(s.voice_id)
-            sig[k] = f"{v.get('ref_audio')}|{v.get('ref_text')}|{v.get('instruct')}|{v.get('seed')}"
+            voice_sigs[k] = f"{v.get('ref_audio')}|{v.get('ref_text')}|{v.get('instruct')}|{v.get('seed')}"
+    sig: dict = dict(voice_sigs)
+    lex_sig = ""
     if lexicon:
         # Fold the lexicon into the cache key so editing pronunciations
         # invalidates cached chapters (reserved key can't collide with a voice id).
-        sig["\x00lexicon"] = json.dumps(normalize_lexicon(lexicon), sort_keys=True)
+        lex_sig = json.dumps(normalize_lexicon(lexicon), sort_keys=True)
+        sig["\x00lexicon"] = lex_sig
     key = chapter_cache_key(spans_tuples, sample_rate=sr, engine_id=engine_id, voice_sig=sig)
     wav_path = os.path.join(cache_dir, f"{key}.wav")
 
@@ -346,13 +361,17 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, le
         try:
             with wave.open(wav_path, "rb") as w:
                 dur = w.getnframes() / float(w.getframerate() or sr)
-            return wav_path, dur, True
+            return wav_path, dur, True, None
         except Exception:
             pass  # corrupt cache entry — fall through and re-render
 
-    audio, dur = synthesize_chapter(chapter.spans, synth, sr, lexicon=lexicon)
+    seg_cache = SegmentCache(cache_dir, sample_rate=sr, engine_id=engine_id,
+                             voice_sig=voice_sigs, extra_sig=lex_sig)
+    audio, dur = synthesize_chapter(chapter.spans, synth, sr, lexicon=lexicon,
+                                    segment_cache=seg_cache)
     atomic_save_wav(wav_path, audio, sr)
-    return wav_path, dur, False
+    return wav_path, dur, False, {"total": seg_cache.hits + seg_cache.misses,
+                                  "cached": seg_cache.hits}
 
 
 class AudiobookPreviewRequest(BaseModel):
@@ -388,7 +407,7 @@ async def audiobook_preview(req: AudiobookPreviewRequest) -> dict:
         language=_resolve_default_language(req.language, req.default_voice),
     )
     loop = asyncio.get_running_loop()
-    wav_path, dur, was_cached = await loop.run_in_executor(
+    wav_path, dur, was_cached, _seg_stats = await loop.run_in_executor(
         _gpu_pool, _render_chapter_cached, chapter, synth, sr, engine_id, resolve, cache_dir,
         req.lexicon,
     )
@@ -508,7 +527,7 @@ async def _render_longform_sse(
 
         for i, chapter in enumerate(plan.chapters):
             try:
-                wav_path, dur, was_cached = await loop.run_in_executor(
+                wav_path, dur, was_cached, seg_stats = await loop.run_in_executor(
                     _gpu_pool, _render_chapter_cached,
                     chapter, synth, sr, engine_id, resolve, cache_dir, lexicon,
                 )
@@ -522,9 +541,15 @@ async def _render_longform_sse(
             chapter_files.append(wav_path)
             chapters_meta.append((chapter.title, int(round(dur * 1000))))
             cached_n += 1 if was_cached else 0
-            yield _emit({"type": "chapter", "index": i, "total": total,
-                         "title": chapter.title, "duration_s": round(dur, 2),
-                         "cached": was_cached})
+            ev = {"type": "chapter", "index": i, "total": total,
+                  "title": chapter.title, "duration_s": round(dur, 2),
+                  "cached": was_cached}
+            if seg_stats is not None:
+                # Additive fields (old clients ignore them): segment-level
+                # reuse inside a re-rendered chapter.
+                ev["segments"] = seg_stats["total"]
+                ev["cached_segments"] = seg_stats["cached"]
+            yield _emit(ev)
 
         if not chapter_files:
             yield _emit({"type": "error", "error": "all chapters failed to render"})

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -101,6 +101,7 @@ def synthesize_chapter(
     *,
     crossfade_ms: int = 50,
     lexicon: Optional[dict] = None,
+    segment_cache: Optional["object"] = None,
 ):
     """Render a chapter's spans to one waveform via an injected ``synth``.
 
@@ -111,6 +112,12 @@ def synthesize_chapter(
     crossfaded; inter-span ``pause_ms_after`` becomes silence. ``lexicon`` (when
     given) respells each span's text before chunking so the engine pronounces
     tricky words correctly; a ``None``/empty lexicon is a no-op pass-through.
+    ``segment_cache`` (when given — a :class:`services.longform_render.
+    SegmentCache`) is consulted per spoken span: a cached segment WAV is reused
+    instead of synthesizing, and every freshly rendered span is stored the
+    moment it finishes — so a one-sentence edit re-renders one segment and an
+    interrupted chapter resumes from its finished segments. Pauses are
+    synthesized silence and never touch the cache.
 
     Returns ``(audio_tensor, duration_seconds)``. torch + chunked_tts are
     imported lazily so this module stays import-light for the pure parser path.
@@ -122,13 +129,19 @@ def synthesize_chapter(
     items: list = []  # ("a", tensor) for audio, ("s", n_samples) for silence
     for span in spans:
         if span.text:
-            chunks = split_text_into_chunks(apply_lexicon(span.text, lexicon))
-            rendered = [synth(c, span.voice_id, span.speed) for c in chunks]
-            rendered = [r for r in rendered if r is not None and getattr(r, "numel", lambda: 0)()]
-            if len(rendered) == 1:
-                items.append(("a", rendered[0]))
-            elif rendered:
-                items.append(("a", concatenate_audio_chunks(rendered, sample_rate, crossfade_ms=crossfade_ms)))
+            audio = segment_cache.load(span) if segment_cache is not None else None
+            if audio is None:
+                chunks = split_text_into_chunks(apply_lexicon(span.text, lexicon))
+                rendered = [synth(c, span.voice_id, span.speed) for c in chunks]
+                rendered = [r for r in rendered if r is not None and getattr(r, "numel", lambda: 0)()]
+                if len(rendered) == 1:
+                    audio = rendered[0]
+                elif rendered:
+                    audio = concatenate_audio_chunks(rendered, sample_rate, crossfade_ms=crossfade_ms)
+                if audio is not None and segment_cache is not None:
+                    segment_cache.store(span, audio)
+            if audio is not None:
+                items.append(("a", audio))
         if span.pause_ms_after > 0:
             n = int(sample_rate * span.pause_ms_after / 1000.0)
             if n > 0:

--- a/backend/services/longform_render.py
+++ b/backend/services/longform_render.py
@@ -18,10 +18,16 @@ reimplement it:
     (+ optional cover art, loudness filter), output as ``m4b`` or ``mp3``.
   * ``chapter_cache_key`` — deterministic content hash so a re-run reuses
     already-rendered chapters (resume) and re-renders only what changed.
+  * ``segment_cache_key`` / ``SegmentCache`` — the inner cache layer: each
+    spoken span's WAV is content-addressed under ``<cache_dir>/segments`` so
+    editing one sentence re-renders one segment (not the chapter) and an
+    interrupted chapter render resumes from its finished segments.
 
-Every function here is pure (string/argv in, string/argv out) so it's unit
-tested without ffmpeg, torch, or a GPU. The impure ffmpeg run lives in the
-caller (the audiobook router today; the stories job tomorrow).
+The builders are pure (string/argv in, string/argv out) so they're unit tested
+without ffmpeg, torch, or a GPU; the cache helpers (``prune_cache_dir``,
+``SegmentCache``) touch only local files and import torch lazily. The impure
+ffmpeg run lives in the caller (the audiobook router today; the stories job
+tomorrow).
 """
 
 from __future__ import annotations
@@ -65,30 +71,29 @@ def _escape_meta(value: str) -> str:
 
 def prune_cache_dir(cache_dir: str, max_bytes: int = _CACHE_MAX_BYTES) -> tuple[int, int]:
     """Evict the oldest files in ``cache_dir`` until the total size is within
-    ``max_bytes`` (LRU by mtime). The content-addressed chapter cache otherwise
+    ``max_bytes`` (LRU by mtime). The content-addressed render cache otherwise
     grows without bound — uncompressed WAVs accumulate across every render.
 
-    Best-effort: returns ``(remaining_bytes, removed_count)`` and never raises
-    (a missing dir / unstattable file is just skipped). Call it *before* writing
-    a job's chapters so the fresh ones are never the eviction target.
+    Walks the whole tree, so chapter WAVs at the root and segment WAVs under
+    ``segments/`` share ONE byte budget — the cap holds no matter which layer
+    grew. Best-effort: returns ``(remaining_bytes, removed_count)`` and never
+    raises (a missing dir / unstattable file is just skipped). Call it *before*
+    writing a job's files so the fresh ones are never the eviction target.
     """
-    try:
-        names = os.listdir(cache_dir)
-    except OSError:
-        return (0, 0)
     entries: list[tuple[float, int, str]] = []
     total = 0
-    for name in names:
-        p = os.path.join(cache_dir, name)
-        try:
-            if not os.path.isfile(p):
+    for root, _dirs, names in os.walk(cache_dir):
+        for name in names:
+            p = os.path.join(root, name)
+            try:
+                if not os.path.isfile(p):
+                    continue
+                size = os.path.getsize(p)
+                mtime = os.path.getmtime(p)
+            except OSError:
                 continue
-            size = os.path.getsize(p)
-            mtime = os.path.getmtime(p)
-        except OSError:
-            continue
-        entries.append((mtime, size, p))
-        total += size
+            entries.append((mtime, size, p))
+            total += size
     if total <= max_bytes:
         return (total, 0)
     entries.sort()  # oldest first
@@ -134,6 +139,126 @@ def chapter_cache_key(
     # Content-addressing only — not a security digest. usedforsecurity=False
     # keeps bandit's B324 (weak-hash) check quiet.
     return hashlib.sha1(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:20]
+
+
+# ── Segment cache (sub-chapter granularity) ─────────────────────────────────
+
+#: Segment WAVs live in a subdirectory of the chapter cache dir so both layers
+#: share one root — and one byte cap (``prune_cache_dir`` walks the tree).
+SEGMENT_SUBDIR = "segments"
+
+
+def segment_cache_key(
+    text: str,
+    *,
+    sample_rate: int,
+    engine_id: str,
+    voice_id: Optional[str] = None,
+    voice_sig: str = "",
+    speed: Optional[float] = None,
+    extra_sig: str = "",
+) -> str:
+    """Deterministic content hash for ONE rendered segment (a single spoken
+    span). Same dimensions as :func:`chapter_cache_key` minus span order and
+    pauses (pauses are synthesized silence — never cached): text, voice
+    identity (id + resolved signature), speed, sample rate, engine, plus
+    ``extra_sig`` for anything else that changes the rendered audio (the
+    pronunciation lexicon today). Any change → new key → re-synthesize just
+    this segment.
+    """
+    payload = {
+        "sr": int(sample_rate),
+        "engine": engine_id or "",
+        "voice": voice_id or "",
+        "text": text or "",
+        "speed": speed,
+        "voice_sig": voice_sig or "",
+        "extra": extra_sig or "",
+    }
+    raw = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    # Content-addressing only — not a security digest (see chapter_cache_key).
+    return hashlib.sha1(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:20]
+
+
+class SegmentCache:
+    """Content-addressed per-segment WAV store under ``cache_dir/segments``.
+
+    The chapter cache stays the fast outer layer — a fully-unchanged chapter
+    hits at the chapter key and never touches segment files. This inner layer
+    makes a *changed* chapter cheap: only the edited/new segments synthesize
+    (the rest load from disk), and an interrupted chapter render resumes from
+    the segments that already finished, because each segment is persisted the
+    moment it renders.
+
+    ``voice_sig`` maps ``voice_id or ""`` → resolved-profile signature (same
+    strings the chapter key uses) so a profile edit invalidates segments too.
+    Load/store are best-effort: a missing/corrupt/foreign-rate file is a clean
+    cache miss (re-render), and a failed store never fails the render — so
+    caches written by any app version degrade safely. torch/torchaudio import
+    lazily to keep this module import-light for the pure-builder callers.
+    """
+
+    def __init__(
+        self,
+        cache_dir: str,
+        *,
+        sample_rate: int,
+        engine_id: str,
+        voice_sig: Optional[dict] = None,
+        extra_sig: str = "",
+    ) -> None:
+        self.dir = os.path.join(cache_dir, SEGMENT_SUBDIR)
+        self.sample_rate = int(sample_rate)
+        self.engine_id = engine_id or ""
+        self.voice_sig = dict(voice_sig or {})
+        self.extra_sig = extra_sig or ""
+        self.hits = 0
+        self.misses = 0
+
+    def _path(self, span) -> str:
+        key = segment_cache_key(
+            span.text,
+            sample_rate=self.sample_rate,
+            engine_id=self.engine_id,
+            voice_id=span.voice_id,
+            voice_sig=self.voice_sig.get(span.voice_id or "", ""),
+            speed=getattr(span, "speed", None),
+            extra_sig=self.extra_sig,
+        )
+        return os.path.join(self.dir, f"{key}.wav")
+
+    def load(self, span):
+        """Cached audio tensor for ``span``, or ``None`` (miss). A hit bumps
+        the file's mtime so LRU eviction sees the segment as recently used."""
+        path = self._path(span)
+        if not os.path.isfile(path):
+            self.misses += 1
+            return None
+        try:
+            import torchaudio
+            audio, sr = torchaudio.load(path)
+        except Exception:
+            self.misses += 1
+            return None  # unreadable/corrupt entry — clean miss, re-render
+        if int(sr) != self.sample_rate or audio.numel() == 0:
+            self.misses += 1
+            return None  # foreign-rate/empty entry — clean miss, re-render
+        try:
+            os.utime(path, None)
+        except OSError:
+            pass
+        self.hits += 1
+        return audio
+
+    def store(self, span, audio) -> None:
+        """Persist a freshly rendered segment. Best-effort — a full disk or
+        unwritable cache dir must never fail the chapter render."""
+        try:
+            from services.audio_io import atomic_save_wav
+            os.makedirs(self.dir, exist_ok=True)
+            atomic_save_wav(self._path(span), audio, self.sample_rate)
+        except Exception:
+            pass
 
 
 # ── Loudness normalization ──────────────────────────────────────────────────

--- a/tests/test_audiobook_preview.py
+++ b/tests/test_audiobook_preview.py
@@ -55,7 +55,8 @@ def test_render_chapter_cache_hit_skips_synth(tmp_path):
     def boom(*_a, **_k):
         raise AssertionError("synth must not be called on a cache hit")
 
-    wav_path, dur, cached = _render_chapter_cached(chapter, boom, sr, "eng", resolve, str(tmp_path))
+    wav_path, dur, cached, seg_stats = _render_chapter_cached(chapter, boom, sr, "eng", resolve, str(tmp_path))
     assert cached is True
+    assert seg_stats is None  # chapter-level hit — the segment layer untouched
     assert wav_path.endswith(f"{key}.wav")
     assert abs(dur - 0.5) < 0.01

--- a/tests/test_longform_segment_cache.py
+++ b/tests/test_longform_segment_cache.py
@@ -1,0 +1,255 @@
+"""Segment-level render cache under the longform chapter cache.
+
+Covers the two-layer contract: segment key stability across every input
+dimension, a one-sentence edit re-rendering exactly one segment, an
+interrupted chapter resuming from its already-finished segments, missing /
+corrupt / foreign-rate segment files degrading to a clean cache miss, the
+byte-cap eviction walking both layers, and the fully-unchanged chapter
+short-circuiting at the chapter key without ever touching segment files.
+Drives the real `_render_chapter_cached` with a stub synth (no model/GPU).
+"""
+from __future__ import annotations
+
+import os
+import time
+import wave
+
+import pytest
+import torch
+
+from api.routers.audiobook import _render_chapter_cached
+from services.audiobook import Chapter, Span
+from services.longform_render import (
+    SEGMENT_SUBDIR,
+    chapter_cache_key,
+    prune_cache_dir,
+    segment_cache_key,
+)
+
+_SR = 24000
+_SIG = "None|None|None|None"  # resolved signature of the no-profile voice
+
+
+def _resolve(_voice_id):
+    return {"ref_audio": None, "ref_text": None, "instruct": None, "seed": None}
+
+
+def _chapter(*texts, title="C1"):
+    return Chapter(title=title, spans=[
+        Span(voice_id=None, text=t, pause_ms_after=100) for t in texts
+    ])
+
+
+def _counting_synth(calls):
+    def synth(text, voice_id, speed=None):
+        calls.append(text)
+        return torch.full((2400,), 0.1)  # 0.1 s @ 24k
+    return synth
+
+
+def _seg_path(tmp_path, text, **kw):
+    key = segment_cache_key(text, sample_rate=_SR, engine_id="eng",
+                            voice_id=None, voice_sig=_SIG, **kw)
+    return tmp_path / SEGMENT_SUBDIR / f"{key}.wav"
+
+
+# ── segment key ─────────────────────────────────────────────────────────────
+
+def test_segment_key_deterministic():
+    kw = dict(sample_rate=_SR, engine_id="eng", voice_id="v",
+              voice_sig="a|b|c|1", speed=None, extra_sig="")
+    a = segment_cache_key("Hello there.", **kw)
+    assert a == segment_cache_key("Hello there.", **kw)
+    assert len(a) == 20
+
+
+@pytest.mark.parametrize("mutation", [
+    {"text": "Different."},
+    {"sample_rate": 44100},
+    {"engine_id": "kokoro"},
+    {"voice_id": "other"},
+    {"voice_sig": "x|y|z|2"},
+    {"speed": 0.8},
+    {"extra_sig": '{"Dr": "Doctor"}'},
+])
+def test_segment_key_changes_on_any_dimension(mutation):
+    kw = dict(text="Hello there.", sample_rate=_SR, engine_id="eng",
+              voice_id="v", voice_sig="a|b|c|1", speed=None, extra_sig="")
+    base = segment_cache_key(kw["text"], **{k: v for k, v in kw.items() if k != "text"})
+    kw.update(mutation)
+    mutated = segment_cache_key(kw.pop("text"), **kw)
+    assert mutated != base
+
+
+def test_chapter_key_golden_unchanged_by_segment_layer():
+    # Locks the on-disk chapter key derivation: chapter caches written by
+    # released versions must keep hitting after the segment layer landed.
+    key = chapter_cache_key([(None, "hi", 0, None)], sample_rate=_SR,
+                            engine_id="eng", voice_sig={"": _SIG})
+    assert key == "ce2accacf51a70d04da0"
+
+
+# ── one-sentence edit → one segment re-renders ──────────────────────────────
+
+def test_one_sentence_edit_rerenders_exactly_one_segment(tmp_path):
+    calls: list[str] = []
+    _render_chapter_cached(_chapter("First sentence.", "Second sentence.", "Third sentence."),
+                           _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert len(calls) == 3  # cold cache — everything synthesized
+
+    calls.clear()
+    edited = _chapter("First sentence.", "Second EDITED sentence.", "Third sentence.")
+    wav_path, dur, cached, seg_stats = _render_chapter_cached(
+        edited, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert cached is False  # chapter content changed → chapter-level miss
+    assert calls == ["Second EDITED sentence."]  # only the edit synthesized
+    assert seg_stats == {"total": 3, "cached": 2}
+    assert os.path.isfile(wav_path) and dur > 0
+
+
+# ── interrupted chapter resumes from finished segments ──────────────────────
+
+def test_interrupted_chapter_resumes_from_cached_segments(tmp_path):
+    calls: list[str] = []
+
+    def failing(text, voice_id, speed=None):
+        calls.append(text)
+        if "THIRD" in text:
+            raise RuntimeError("interrupted mid-chapter")
+        return torch.full((2400,), 0.1)
+
+    ch = _chapter("First sentence.", "Second sentence.", "THIRD sentence fails.")
+    with pytest.raises(RuntimeError):
+        _render_chapter_cached(ch, failing, _SR, "eng", _resolve, str(tmp_path))
+    # The two spans that finished were persisted before the crash.
+    assert len(list((tmp_path / SEGMENT_SUBDIR).glob("*.wav"))) == 2
+
+    calls.clear()
+    wav_path, _dur, cached, seg_stats = _render_chapter_cached(
+        ch, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert cached is False
+    assert calls == ["THIRD sentence fails."]  # only the lost span re-renders
+    assert seg_stats == {"total": 3, "cached": 2}
+    assert os.path.isfile(wav_path)
+
+
+def test_resume_with_missing_segment_file(tmp_path):
+    calls: list[str] = []
+    ch = _chapter("First sentence.", "Second sentence.", "Third sentence.")
+    wav_path, *_ = _render_chapter_cached(ch, _counting_synth(calls), _SR, "eng",
+                                          _resolve, str(tmp_path))
+    # Evicted/deleted mid-way: chapter WAV and one segment gone.
+    os.remove(wav_path)
+    os.remove(_seg_path(tmp_path, "Second sentence."))
+
+    calls.clear()
+    _wav, _dur, cached, seg_stats = _render_chapter_cached(
+        ch, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert cached is False
+    assert calls == ["Second sentence."]
+    assert seg_stats == {"total": 3, "cached": 2}
+
+
+# ── corrupt / foreign segment files degrade to a clean miss ─────────────────
+
+def test_corrupt_segment_file_is_clean_miss(tmp_path):
+    calls: list[str] = []
+    ch = _chapter("First sentence.", "Second sentence.")
+    wav_path, *_ = _render_chapter_cached(ch, _counting_synth(calls), _SR, "eng",
+                                          _resolve, str(tmp_path))
+    os.remove(wav_path)
+    _seg_path(tmp_path, "First sentence.").write_bytes(b"not a wav at all")
+
+    calls.clear()
+    _wav, _dur, _cached, seg_stats = _render_chapter_cached(
+        ch, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert calls == ["First sentence."]  # corrupt entry re-rendered, no crash
+    assert seg_stats == {"total": 2, "cached": 1}
+
+
+def test_wrong_sample_rate_segment_is_clean_miss(tmp_path):
+    calls: list[str] = []
+    ch = _chapter("First sentence.")
+    wav_path, *_ = _render_chapter_cached(ch, _counting_synth(calls), _SR, "eng",
+                                          _resolve, str(tmp_path))
+    os.remove(wav_path)
+    # Overwrite the cached segment with a valid WAV at a foreign rate.
+    p = _seg_path(tmp_path, "First sentence.")
+    with wave.open(str(p), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(8000)
+        w.writeframes(b"\x00\x00" * 800)
+
+    calls.clear()
+    _wav, _dur, _cached, seg_stats = _render_chapter_cached(
+        ch, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert calls == ["First sentence."]
+    assert seg_stats == {"total": 1, "cached": 0}
+
+
+# ── unchanged chapter short-circuits at the chapter layer ───────────────────
+
+def test_unchanged_chapter_never_touches_segment_files(tmp_path):
+    calls: list[str] = []
+    ch = _chapter("First sentence.", "Second sentence.")
+    _render_chapter_cached(ch, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+
+    # Remove the whole segment layer: a chapter-level hit must not need it.
+    for p in (tmp_path / SEGMENT_SUBDIR).glob("*.wav"):
+        os.remove(p)
+    (tmp_path / SEGMENT_SUBDIR).rmdir()
+
+    def boom(*_a, **_k):
+        raise AssertionError("synth must not be called on a chapter cache hit")
+
+    _wav, dur, cached, seg_stats = _render_chapter_cached(
+        ch, boom, _SR, "eng", _resolve, str(tmp_path))
+    assert cached is True and dur > 0
+    assert seg_stats is None
+    assert not (tmp_path / SEGMENT_SUBDIR).exists()  # layer never recreated
+
+
+# ── LRU byte cap covers both layers ─────────────────────────────────────────
+
+def _seed(path, size, age_s):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\0" * size)
+    t = time.time() - age_s
+    os.utime(path, (t, t))
+    return path
+
+
+def test_prune_walks_segment_subdir(tmp_path):
+    chap = _seed(tmp_path / "chapter.wav", 600, age_s=5)
+    old_seg = _seed(tmp_path / SEGMENT_SUBDIR / "old.wav", 600, age_s=100)
+    new_seg = _seed(tmp_path / SEGMENT_SUBDIR / "new.wav", 600, age_s=1)
+
+    remaining, removed = prune_cache_dir(str(tmp_path), max_bytes=1300)
+    assert removed == 1
+    assert not old_seg.exists()               # oldest evicted — inside segments/
+    assert chap.exists() and new_seg.exists()
+    assert remaining == 1200                  # both layers counted in the budget
+
+
+def test_prune_evicts_stale_chapter_before_fresh_segment(tmp_path):
+    old_chap = _seed(tmp_path / "stale_chapter.wav", 600, age_s=100)
+    seg = _seed(tmp_path / SEGMENT_SUBDIR / "fresh.wav", 600, age_s=1)
+    remaining, removed = prune_cache_dir(str(tmp_path), max_bytes=700)
+    assert removed == 1
+    assert not old_chap.exists() and seg.exists()
+    assert remaining == 600
+
+
+def test_segment_hit_refreshes_mtime_for_lru(tmp_path):
+    calls: list[str] = []
+    ch = _chapter("First sentence.")
+    wav_path, *_ = _render_chapter_cached(ch, _counting_synth(calls), _SR, "eng",
+                                          _resolve, str(tmp_path))
+    os.remove(wav_path)  # force the segment layer on the next run
+    seg = _seg_path(tmp_path, "First sentence.")
+    stale = time.time() - 10_000
+    os.utime(seg, (stale, stale))
+
+    _render_chapter_cached(ch, _counting_synth(calls), _SR, "eng", _resolve, str(tmp_path))
+    assert os.path.getmtime(seg) > stale + 1_000  # hit bumped it — LRU-fresh


### PR DESCRIPTION
Audiobook/Stories renders get a content-addressed **segment cache** under the existing chapter cache.

**What users get:**
- Editing one sentence in a chapter re-synthesizes only that sentence; every untouched span's audio is reused.
- An interrupted chapter render (crash, quit, power loss) resumes from the segments that already finished — each segment persists the moment it renders.
- One byte cap (`OMNIVOICE_LONGFORM_CACHE_MAX_GB`) now bounds both cache layers; `prune_cache_dir` walks the tree.

**Compatibility:** `chapter_cache_key` derivation is byte-identical (locked by a golden-key test), so chapter caches written by released versions keep hitting. A fully-unchanged chapter short-circuits at the chapter layer and never touches segment files. Parser, JS twin, golden corpus, resume manifests, and the router API are untouched; chapter SSE events gain additive `segments`/`cached_segments` fields only.

**Tests:** `tests/test_longform_segment_cache.py` (18 new — key stability across all dimensions, one-sentence-edit → exactly one re-synthesis, interrupted-chapter resume, corrupt/foreign cache files degrade to misses, prune across both layers). Pre-existing longform/audiobook suites: 240 passed incl. the real-ffmpeg e2e; `backend/tests/test_audiobook_resume_api.py` 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds content-addressed segment caching for audiobook and story chapter rendering.

- Reuses unchanged synthesized segments when text is edited.
- Persists segments individually so interrupted renders can resume.
- Applies one shared `OMNIVOICE_LONGFORM_CACHE_MAX_GB` budget across chapter and segment caches with recursive LRU pruning.
- Preserves byte-identical chapter cache key derivation.
- Keeps unchanged chapters on the existing chapter-cache fast path.
- Adds `segments` and `cached_segments` to chapter SSE events.
- Includes 18 tests covering key stability, selective synthesis, resume behavior, invalid cache files, cache pruning, and compatibility.

```mermaid
flowchart TD
    A[Render chapter] --> B{Chapter cache hit?}
    B -- Yes --> C[Return cached chapter]
    B -- No --> D[Load each segment cache]
    D --> E{Segment cached and valid?}
    E -- Yes --> F[Reuse segment]
    E -- No --> G[Synthesize segment]
    G --> H[Persist segment immediately]
    F --> I[Assemble chapter]
    H --> I
    I --> J[Emit segment cache statistics]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->