### PR TITLE
fix(models): self-heal HF-cache snapshots with broken file links, retry load once

### DIFF
--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -46,6 +46,7 @@ _HINTS: dict[str, str] = {
     "UNSUPPORTED_VIDEO_URL": "This link isn't a directly downloadable video. Paste a direct video page (e.g. a youtube.com/watch?v=… or douyin.com/video/<id> link), not a share/profile/feed link — or download the file and drop it in directly.",
     "VIDEO_DOWNLOAD_NETWORK": "The connection to the video server dropped mid-download (often a transient CDN/network blip or a regional rate-limit). Just retry — OmniVoice already cleaned up the partial download. If it keeps failing, check your network/VPN.",
     "BROKEN_VENV": "The Python backend environment was moved or damaged. OmniVoice rebuilds it automatically on the next launch; if it keeps failing, use Clean & Retry on the setup screen.",
+    "MODEL_CACHE_CORRUPT": "The model cache had broken file links — snapshot entries that no longer point at their downloaded data (interrupted renames or antivirus interference can cause this). OmniVoice repairs this automatically and retries the load once. If the error persists, quit OmniVoice, delete the model's models--<org>--<name> folder inside the Hugging Face cache, and restart — the model re-downloads automatically.",
     # HF_MIRROR_UNREACHABLE has a DYNAMIC hint (it names the configured mirror)
     # — see hf_mirror_hint(); build_failure special-cases it.
 }
@@ -231,6 +232,17 @@ def classify(reason: str) -> str:
     # transformers + site-packages markers, which this signature lacks.
     if "errno 22" in low:
         return "OS_INVALID_ARGUMENT"
+    # An HF cache whose snapshot entries don't resolve (dangling symlinks /
+    # zero-byte stand-ins): transformers reports the weights missing ("does
+    # not appear to have a file named pytorch_model.bin or model.safetensors")
+    # even though the blobs are fully on disk. model_manager self-heals this
+    # (delete broken entries → snapshot_download → retry once); the class here
+    # covers both the raw transformers wording (any load surface can leak it)
+    # and OmniVoice's own repair messages, so the user-facing error and the
+    # auto bug report name the class and its automatic repair.
+    if ("does not appear to have a file named" in low
+            or "broken file link" in low):
+        return "MODEL_CACHE_CORRUPT"
     if (
         "could not import module" in low
         or "autofeatureextractor" in low

--- a/backend/services/hf_cache_repair.py
+++ b/backend/services/hf_cache_repair.py
@@ -1,0 +1,292 @@
+"""Self-heal for HF cache snapshots whose entries no longer resolve.
+
+The Hugging Face hub cache stores each file's bytes once under
+``models--<org>--<name>/blobs/<hash>`` and exposes every revision as
+``snapshots/<rev>/<filename>`` entries that link into ``blobs/``. Several
+real-world events leave a snapshot entry *broken* — a dangling symlink (its
+blob target doesn't exist) or a zero-byte stand-in file — while the actual
+bytes are safely on disk under ``blobs/``: a blob-naming mismatch between
+download modes, an interrupted rename mid-download, antivirus interference.
+
+``os.path.isfile()`` on a dangling symlink is False, so transformers concludes
+the weights are missing ("… does not appear to have a file named
+pytorch_model.bin or model.safetensors") even though the multi-GB download
+completed. A plain ``snapshot_download`` doesn't reliably fix this — depending
+on hub version and platform symlink support, the existing-but-broken entry can
+short-circuit the restore. Deleting exactly the broken entries first makes
+``snapshot_download`` deterministically restore them (reusing completed blobs
+where the naming matches, re-downloading only where it doesn't).
+
+Conservative by design, repairing STATE rather than chasing one cause:
+  * never touches ``blobs/`` (the downloaded bytes),
+  * never touches snapshot entries that resolve,
+  * never force-redownloads healthy files,
+  * never raises — any internal failure logs and returns a summary,
+  * a healthy cache is a cheap lstat/stat walk of ``snapshots/`` (no hashing,
+    no network) on every platform; the heal is generic, not Windows-gated.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger("omnivoice.hf_cache_repair")
+
+# Snapshot entries that are never legitimately zero bytes: weight formats and
+# JSON/sentencepiece config-tokenizer files (an empty file is not valid JSON /
+# not a valid serialized model). Zero-byte files with any OTHER suffix — an
+# empty .txt, .md, .gitattributes, a marker file a repo genuinely ships empty —
+# are left alone: when unsure, don't flag.
+_NEVER_EMPTY_SUFFIXES = frozenset({
+    # weights / tensors
+    ".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".onnx", ".gguf",
+    ".msgpack", ".h5", ".pb", ".tflite",
+    # config / tokenizer
+    ".json", ".model", ".spm",
+})
+
+
+def _env_flag(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def hf_cache_home() -> str:
+    """The hub cache root in effect. Mirrors huggingface_hub's resolution
+    (``HF_HUB_CACHE`` > ``HF_HOME``/hub > default) but reads the env at call
+    time — hub's constants freeze at import, which is too early for tests and
+    for the Windows short-cache redirect in ``core.config``."""
+    env = (os.environ.get("HF_HUB_CACHE") or "").strip()
+    if env:
+        return env
+    hf_home = (os.environ.get("HF_HOME") or "").strip()
+    if hf_home:
+        return os.path.join(hf_home, "hub")
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+        return HF_HUB_CACHE
+    except Exception:
+        return os.path.join(os.path.expanduser("~"), ".cache", "huggingface", "hub")
+
+
+def repo_cache_dir(repo_id: str, cache_dir: str | None = None) -> str:
+    """The ``models--<org>--<name>`` folder for ``repo_id`` (repo_type=model)."""
+    return os.path.join(cache_dir or hf_cache_home(),
+                        "models--" + repo_id.replace("/", "--"))
+
+
+def _is_dangling_symlink(path: str) -> bool:
+    # islink() uses lstat (True even when the target is gone); exists()
+    # resolves the link — False for a dangling one. Never raises for a path
+    # that came out of os.walk.
+    return os.path.islink(path) and not os.path.exists(path)
+
+
+def _is_suspicious_zero_byte(path: str) -> bool:
+    """A zero-byte REGULAR file standing where model content must be.
+
+    Conservative: only weight/config-typed names are flagged (those are never
+    legitimately empty — the bytes to restore them live in ``blobs/`` or on
+    the Hub); anything else is presumed intentional and left alone."""
+    if os.path.islink(path):
+        return False  # resolving symlinks are handled by the dangling check
+    try:
+        if not os.path.isfile(path) or os.path.getsize(path) != 0:
+            return False
+    except OSError:
+        return False
+    return os.path.splitext(path)[1].lower() in _NEVER_EMPTY_SUFFIXES
+
+
+def find_dangling_entries(repo_cache_dir: str) -> list[str]:
+    """Broken entries under ``<repo_cache_dir>/snapshots/*/``: dangling
+    symlinks plus suspicious zero-byte regular files (see above).
+
+    Returns absolute paths. On a healthy cache this is a no-op scan — a pure
+    lstat/stat walk of ``snapshots/`` (``blobs/`` is never visited), no
+    hashing, no network. Never raises."""
+    broken: list[str] = []
+    snapshots = os.path.join(repo_cache_dir, "snapshots")
+    if not os.path.isdir(snapshots):
+        return broken
+    try:
+        # followlinks=False: a dangling symlink is not a dir, so os.walk lists
+        # it among the files of its parent — exactly where we scan.
+        for root, _dirs, files in os.walk(snapshots, followlinks=False):
+            for name in files:
+                path = os.path.join(root, name)
+                if _is_dangling_symlink(path) or _is_suspicious_zero_byte(path):
+                    broken.append(path)
+    except OSError as walk_err:  # pragma: no cover - defensive
+        logger.warning("HF cache scan of %s aborted: %s", snapshots, walk_err)
+    return broken
+
+
+def _force_copy_mode(cache_root: str) -> bool:
+    """Best-effort: make huggingface_hub materialize snapshot entries as real
+    file COPIES instead of symlinks for the rest of this process.
+
+    Why: hub's ``are_symlinks_supported()`` probe can succeed in-process while
+    real snapshot symlink creation fails or produces broken links (Windows
+    without Developer Mode is the reported case) — and the result is memoized
+    in the private ``file_download._are_symlinks_supported_in_dir`` dict, so a
+    plain ``snapshot_download`` retry would recreate the SAME dangling links.
+    Pre-seeding that memo with False flips hub into copy mode. It's private
+    API, so any failure (attribute/shape changed across hub versions) is
+    logged and reported as False — the caller then skips the copy-mode pass
+    rather than crash. Deliberately NOT undone: on a host where links come
+    out broken, every later download should use copies too."""
+    try:
+        from pathlib import Path
+        import huggingface_hub.file_download as _fd
+
+        memo = getattr(_fd, "_are_symlinks_supported_in_dir", None)
+        if not isinstance(memo, dict):
+            raise TypeError(
+                f"_are_symlinks_supported_in_dir is {type(memo).__name__}, expected dict"
+            )
+        # Same key normalization hub's are_symlinks_supported() applies.
+        memo[str(Path(cache_root).expanduser().resolve())] = False
+        return True
+    except Exception as e:
+        logger.warning(
+            "Could not force copy-mode for the HF cache (%s) — "
+            "huggingface_hub's private memo may have changed; skipping the "
+            "copy-mode repair pass.", e,
+        )
+        return False
+
+
+def repair_repo_cache(repo_id: str, cache_dir: str | None = None) -> dict:
+    """Repair a repo's cache: delete broken snapshot entries (and ONLY those),
+    then ``snapshot_download`` to restore the missing files — hub reuses
+    completed blobs where the naming matches and re-downloads otherwise.
+
+    Verified after the fact: if the restore recreated dangling links (a host
+    where hub's symlink probe passes but real links come out broken — Windows
+    without Developer Mode), force copy mode and repair once more so the
+    snapshot ends up with real files.
+
+    Returns a summary dict; never raises:
+      ``found``    broken entries detected up front,
+      ``removed``  entries actually deleted (both passes),
+      ``restored`` True when a snapshot_download completed,
+      ``outcome``  "healthy" | "healed_with_links" | "healed_with_copies"
+                   | "repair_failed",
+      ``ok``       True unless outcome == "repair_failed",
+      ``error``    "" or why the repair failed.
+    """
+    summary: dict = {
+        "repo_id": repo_id,
+        "repo_dir": "",
+        "found": 0,
+        "removed": 0,
+        "restored": False,
+        "outcome": "repair_failed",
+        "ok": False,
+        "error": "",
+    }
+    try:
+        cache_root = cache_dir or hf_cache_home()
+        repo_dir = repo_cache_dir(repo_id, cache_root)
+        summary["repo_dir"] = repo_dir
+        broken = find_dangling_entries(repo_dir)
+        summary["found"] = len(broken)
+        if not broken:
+            summary["ok"] = True  # nothing broken → nothing to do
+            summary["outcome"] = "healthy"
+            return summary
+        if _env_flag("HF_HUB_OFFLINE") or _env_flag("TRANSFORMERS_OFFLINE"):
+            # Don't delete what we can't restore: offline mode means the
+            # follow-up snapshot_download is off the table.
+            summary["error"] = (
+                "Hugging Face offline mode is enabled "
+                "(HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE) — cannot restore files"
+            )
+            logger.warning(
+                "Model cache for %s has %d broken snapshot entr%s but HF "
+                "offline mode is set — skipping repair.",
+                repo_id, len(broken), "y" if len(broken) == 1 else "ies",
+            )
+            return summary
+
+        def _remove(paths: list[str]) -> int:
+            n = 0
+            for path in paths:
+                try:
+                    os.remove(path)  # removes the link/file itself, never a blob
+                    n += 1
+                    logger.info(
+                        "HF cache self-heal: removed broken snapshot entry %s", path
+                    )
+                except OSError as rm_err:
+                    logger.warning(
+                        "HF cache self-heal: could not remove broken entry %s: %s",
+                        path, rm_err,
+                    )
+            return n
+
+        summary["removed"] = _remove(broken)
+        if summary["removed"] == 0:
+            summary["error"] = "broken entries could not be removed"
+            return summary
+
+        from huggingface_hub import snapshot_download
+
+        dl_kwargs: dict = {"repo_id": repo_id}
+        if cache_dir:
+            dl_kwargs["cache_dir"] = cache_dir
+        endpoint = os.environ.get("HF_ENDPOINT")
+        if endpoint:
+            dl_kwargs["endpoint"] = endpoint
+        snapshot_download(**dl_kwargs)
+        summary["restored"] = True
+
+        # Verify-after-repair: hub's memoized symlink probe can claim support
+        # while the links it just recreated dangle again. If so, force copy
+        # mode and repair once more so real files land in the snapshot.
+        still_broken = find_dangling_entries(repo_dir)
+        if not still_broken:
+            summary["ok"] = True
+            summary["outcome"] = "healed_with_links"
+            logger.info(
+                "HF cache self-heal for %s: removed %d broken snapshot entr%s "
+                "and restored the snapshot from existing blobs / the Hub.",
+                repo_id, summary["removed"],
+                "y" if summary["removed"] == 1 else "ies",
+            )
+            return summary
+        logger.warning(
+            "HF cache self-heal for %s: the restore recreated %d broken "
+            "link(s) — forcing copy-mode and repairing once more.",
+            repo_id, len(still_broken),
+        )
+        if not _force_copy_mode(cache_root):
+            summary["error"] = (
+                "the snapshot restore recreated broken links and copy-mode "
+                "could not be forced"
+            )
+            return summary
+        summary["removed"] += _remove(still_broken)
+        snapshot_download(**dl_kwargs)
+        remaining = find_dangling_entries(repo_dir)
+        if remaining:
+            summary["error"] = (
+                f"{len(remaining)} snapshot entr"
+                f"{'y is' if len(remaining) == 1 else 'ies are'} still broken "
+                "after the copy-mode repair"
+            )
+            return summary
+        summary["ok"] = True
+        summary["outcome"] = "healed_with_copies"
+        logger.info(
+            "HF cache self-heal for %s: healed with real file copies "
+            "(symlinks on this host come out broken; hub stays in copy-mode "
+            "for the rest of this run).", repo_id,
+        )
+        return summary
+    except Exception as e:  # never raise — repair is best-effort
+        summary["error"] = f"{type(e).__name__}: {e}"
+        logger.warning(
+            "HF cache self-heal for %s failed: %s", repo_id, summary["error"],
+        )
+        return summary

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -657,6 +657,78 @@ def _hf_offline() -> bool:
     return _env_flag("HF_HUB_OFFLINE") or _env_flag("TRANSFORMERS_OFFLINE")
 
 
+# ── Broken-snapshot-link self-heal ───────────────────────────────────
+# A sibling of the incomplete-cache class above: the blobs are FULLY
+# downloaded, but the snapshots/<rev>/ entries pointing at them are dangling
+# symlinks (0 KB) or zero-byte stand-ins — blob-naming mismatches between
+# download modes, interrupted renames, or antivirus interference all produce
+# this state (reported on Windows, where the NTFS links show as 0 KB, but the
+# heal is generic). os.path.isfile() on a dangling link is False, so
+# transformers raises the same "does not appear to have a file named …"
+# signature even though the bytes are on disk. The resume repair below can't
+# fix it (snapshot_download may trust/short-circuit on the existing broken
+# entry), so rung 0 of the recovery ladder deletes exactly the broken entries
+# and restores them — see services.hf_cache_repair.
+
+# Repos this process already attempted the link self-heal for — the retry
+# after a repair may only happen ONCE per repo per process, so a cache that
+# stays broken can't loop repair↔retry.
+_LINK_REPAIR_ATTEMPTED: set[str] = set()
+
+
+def _selfheal_broken_snapshot_links(checkpoint: str) -> bool:
+    """Rung 0 of cache recovery: delete-and-restore broken snapshot entries.
+
+    Returns True only when broken entries were found, removed AND restored —
+    i.e. retrying the load is worth it. At most one attempt per repo per
+    process. Never raises; when it returns False the legacy resume/force
+    ladder still runs."""
+    if checkpoint in _LINK_REPAIR_ATTEMPTED:
+        return False
+    _LINK_REPAIR_ATTEMPTED.add(checkpoint)
+    if os.path.isdir(checkpoint):
+        return False  # a local-directory checkpoint doesn't use the hub cache
+    try:
+        from services.hf_cache_repair import repair_repo_cache
+        summary = repair_repo_cache(checkpoint)
+    except Exception as repair_err:  # repair must never break the ladder
+        logger.warning("Snapshot-link self-heal for %s errored: %s",
+                       checkpoint, repair_err)
+        return False
+    if summary.get("removed") and summary.get("ok"):
+        logger.warning(
+            "Model cache for %s had %d broken file link(s) — repaired "
+            "automatically (%s), retrying the load.",
+            checkpoint, summary["removed"],
+            summary.get("outcome") or "healed",
+        )
+        return True
+    if summary.get("found"):
+        logger.warning(
+            "Model cache for %s has %d broken file link(s) that could not be "
+            "auto-repaired (%s).",
+            checkpoint, summary["found"], summary.get("error") or "unknown",
+        )
+    return False
+
+
+def _manual_cache_delete_hint(checkpoint: str) -> str:
+    """Names the exact on-disk folder to delete when every auto-repair rung
+    failed — "delete the model" is only actionable if the user can find it.
+    Empty for local-directory checkpoints (they don't live in the hub cache)."""
+    try:
+        if os.path.isdir(checkpoint):
+            return ""
+        from services.hf_cache_repair import repo_cache_dir
+        return (
+            f" If the problem persists, quit OmniVoice, delete "
+            f"{repo_cache_dir(checkpoint)} and restart — the model "
+            "re-downloads automatically."
+        )
+    except Exception:
+        return ""
+
+
 # Why the LAST _repair_model_cache run failed ("" when it succeeded / hasn't
 # run). #886: the "could not be auto-repaired" message used to drop the cause
 # entirely, so a mirror outage, offline mode, or a full disk all read the same.
@@ -852,50 +924,76 @@ def _load_model_sync():
             # cache never reaches this branch, so the fast path is untouched).
             if not _is_incomplete_cache_error(e):
                 raise
-            _set_loading("loading_weights", "Repairing incomplete model cache…")
-            if not _repair_model_cache(checkpoint):
-                raise RuntimeError(
-                    f"The TTS model cache for {checkpoint} is incomplete "
-                    "(weights missing — usually an interrupted download)."
-                    f"{_repair_failure_detail()} "
-                    "Open Settings → Models, delete the OmniVoice TTS model, "
-                    "and install it again."
-                ) from e
-            _set_loading("loading_weights", f"Loading TTS weights on {device}…")
-            try:
-                _model = _load()
-            except OSError as e2:
-                # Resume-repair ran but the cache is still unusable. The usual
-                # cause beyond "repo genuinely lacks weights" is a blob that's
-                # present with the right size but corrupt — snapshot_download's
-                # resume trusts it and never re-fetches it (#739). Force a full
-                # re-download (replaces corrupt blobs) and retry once more before
-                # falling back to the manual delete-and-reinstall message.
-                if _is_incomplete_cache_error(e2):
-                    _set_loading("loading_weights", "Re-downloading model files…")
-                    if _repair_model_cache(checkpoint, force=True):
-                        try:
-                            _model = _load()
-                        except OSError as e3:
+            # Rung 0: broken snapshot links — the blobs are on disk but the
+            # snapshot entries don't resolve (dangling symlinks / zero-byte
+            # stand-ins). Delete exactly the broken entries, restore, and
+            # retry the load ONCE (guarded per repo per process). A cache
+            # without broken links falls straight through to the resume
+            # ladder below.
+            _model = None
+            if _selfheal_broken_snapshot_links(checkpoint):
+                _set_loading(
+                    "loading_weights",
+                    "Model cache had broken file links — repaired "
+                    "automatically, retrying…",
+                )
+                try:
+                    _model = _load()
+                except OSError as e_link:
+                    if not _is_incomplete_cache_error(e_link):
+                        raise
+                    logger.warning(
+                        "Load still failing after snapshot-link repair of %s — "
+                        "falling back to resume repair.", checkpoint,
+                    )
+                    e = e_link
+                    _model = None
+            if _model is None:
+                _set_loading("loading_weights", "Repairing incomplete model cache…")
+                if not _repair_model_cache(checkpoint):
+                    raise RuntimeError(
+                        f"The TTS model cache for {checkpoint} is incomplete "
+                        "(weights missing — usually an interrupted download)."
+                        f"{_repair_failure_detail()} "
+                        "Open Settings → Models, delete the OmniVoice TTS model, "
+                        f"and install it again.{_manual_cache_delete_hint(checkpoint)}"
+                    ) from e
+                _set_loading("loading_weights", f"Loading TTS weights on {device}…")
+                try:
+                    _model = _load()
+                except OSError as e2:
+                    # Resume-repair ran but the cache is still unusable. The usual
+                    # cause beyond "repo genuinely lacks weights" is a blob that's
+                    # present with the right size but corrupt — snapshot_download's
+                    # resume trusts it and never re-fetches it (#739). Force a full
+                    # re-download (replaces corrupt blobs) and retry once more before
+                    # falling back to the manual delete-and-reinstall message.
+                    if _is_incomplete_cache_error(e2):
+                        _set_loading("loading_weights", "Re-downloading model files…")
+                        if _repair_model_cache(checkpoint, force=True):
+                            try:
+                                _model = _load()
+                            except OSError as e3:
+                                raise RuntimeError(
+                                    f"The TTS model cache for {checkpoint} is incomplete "
+                                    "and could not be auto-repaired. Open Settings → "
+                                    "Models, delete the OmniVoice TTS model, and install "
+                                    f"it again.{_manual_cache_delete_hint(checkpoint)}"
+                                ) from e3
+                        else:
                             raise RuntimeError(
-                                f"The TTS model cache for {checkpoint} is incomplete "
-                                "and could not be auto-repaired. Open Settings → "
-                                "Models, delete the OmniVoice TTS model, and install "
-                                "it again."
-                            ) from e3
+                                f"The TTS model cache for {checkpoint} is incomplete and "
+                                f"could not be auto-repaired.{_repair_failure_detail()} "
+                                "Open Settings → Models, delete the OmniVoice TTS model, "
+                                f"and install it again.{_manual_cache_delete_hint(checkpoint)}"
+                            ) from e2
                     else:
                         raise RuntimeError(
                             f"The TTS model cache for {checkpoint} is incomplete and "
-                            f"could not be auto-repaired.{_repair_failure_detail()} "
-                            "Open Settings → Models, delete the OmniVoice TTS model, "
-                            "and install it again."
+                            "could not be auto-repaired. Open Settings → Models, delete "
+                            "the OmniVoice TTS model, and install it again."
+                            f"{_manual_cache_delete_hint(checkpoint)}"
                         ) from e2
-                else:
-                    raise RuntimeError(
-                        f"The TTS model cache for {checkpoint} is incomplete and "
-                        "could not be auto-repaired. Open Settings → Models, delete "
-                        "the OmniVoice TTS model, and install it again."
-                    ) from e2
 
         try:
             # plan-02 (#65): gate on Triton availability (+ user setting), not

--- a/tests/test_hf_cache_repair.py
+++ b/tests/test_hf_cache_repair.py
@@ -1,0 +1,494 @@
+"""Regression tests for the broken-snapshot-link cache self-heal.
+
+The reported first-run breaker (Windows 11): every blob of the TTS repo is
+fully downloaded (multi-GB files under ``blobs/``), but the
+``snapshots/<rev>/`` entries pointing at them are dangling symlinks (0 KB) —
+so ``os.path.isfile()`` is False and transformers dies with "… does not appear
+to have a file named pytorch_model.bin or model.safetensors" even though the
+bytes are on disk. The pre-existing resume repair (#581/#739) can't fix that
+state; the fix adds rung 0 to the recovery ladder: delete exactly the broken
+entries, ``snapshot_download`` to restore them, retry the load once (guarded
+per repo per process). These tests fail before the fix and pass after.
+
+All network is mocked — ``snapshot_download`` never runs for real.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from core import failure
+from services import hf_cache_repair
+
+
+_SIGNATURE = (
+    "test/checkpoint does not appear to have a file named pytorch_model.bin "
+    "or model.safetensors"
+)
+
+
+def _symlink_or_skip(target: str, link: str) -> None:
+    """Create a symlink, skipping the test where the OS forbids it (Windows
+    without Developer Mode). CI's full pytest run is Linux, so coverage holds."""
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError):  # pragma: no cover - Windows-only
+        pytest.skip("symlinks not supported in this environment")
+
+
+def _mk_repo_cache(tmp_path, repo_id: str = "test/checkpoint"):
+    """The canonical HF cache layout for ``repo_id``, with one healthy blob,
+    one healthy snapshot link, one healthy regular file — and no breakage yet.
+
+    Returns (cache_dir, repo_dir, snap_dir)."""
+    repo_dir = tmp_path / ("models--" + repo_id.replace("/", "--"))
+    blobs = repo_dir / "blobs"
+    snap = repo_dir / "snapshots" / "abc123"
+    blobs.mkdir(parents=True)
+    snap.mkdir(parents=True)
+    (blobs / "blob-config").write_bytes(b'{"ok": true}')
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "blob-config"),
+                     str(snap / "config.json"))
+    (snap / "tokenizer.json").write_bytes(b'{"tok": 1}')
+    return tmp_path, repo_dir, snap
+
+
+# ── find_dangling_entries ──────────────────────────────────────────────────
+
+
+def test_healthy_cache_scan_is_a_noop(tmp_path):
+    _cache, repo_dir, _snap = _mk_repo_cache(tmp_path)
+    assert hf_cache_repair.find_dangling_entries(str(repo_dir)) == []
+
+
+def test_missing_repo_dir_scans_empty(tmp_path):
+    assert hf_cache_repair.find_dangling_entries(str(tmp_path / "nope")) == []
+
+
+def test_dangling_symlink_detected(tmp_path):
+    _cache, repo_dir, snap = _mk_repo_cache(tmp_path)
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "MISSING"),
+                     str(snap / "model.safetensors"))
+    broken = hf_cache_repair.find_dangling_entries(str(repo_dir))
+    assert broken == [str(snap / "model.safetensors")]
+
+
+def test_dangling_symlink_in_subfolder_detected(tmp_path):
+    # Repos with nested paths (e.g. onnx/model.onnx) must be scanned too.
+    _cache, repo_dir, snap = _mk_repo_cache(tmp_path)
+    sub = snap / "onnx"
+    sub.mkdir()
+    _symlink_or_skip(os.path.join("..", "..", "..", "blobs", "MISSING"),
+                     str(sub / "model.onnx"))
+    assert hf_cache_repair.find_dangling_entries(str(repo_dir)) == [
+        str(sub / "model.onnx")
+    ]
+
+
+def test_zero_byte_weight_and_config_files_flagged(tmp_path):
+    # A 0-byte regular file standing where weights/config must be is broken —
+    # those formats are never legitimately empty.
+    _cache, repo_dir, snap = _mk_repo_cache(tmp_path)
+    (snap / "model.safetensors").write_bytes(b"")
+    (snap / "generation_config.json").write_bytes(b"")
+    assert sorted(hf_cache_repair.find_dangling_entries(str(repo_dir))) == sorted([
+        str(snap / "model.safetensors"),
+        str(snap / "generation_config.json"),
+    ])
+
+
+def test_zero_byte_unknown_suffix_not_flagged(tmp_path):
+    # Conservatism: when unsure, don't flag — repos legitimately ship empty
+    # markers / text files.
+    _cache, repo_dir, snap = _mk_repo_cache(tmp_path)
+    (snap / "README.md").write_bytes(b"")
+    (snap / ".gitattributes").write_bytes(b"")
+    (snap / "empty.txt").write_bytes(b"")
+    assert hf_cache_repair.find_dangling_entries(str(repo_dir)) == []
+
+
+def test_resolving_symlink_to_zero_byte_blob_not_flagged(tmp_path):
+    # An entry that RESOLVES is never touched, even if its target is empty —
+    # the heal repairs broken links, it doesn't second-guess repo content.
+    _cache, repo_dir, snap = _mk_repo_cache(tmp_path)
+    (repo_dir / "blobs" / "blob-empty").write_bytes(b"")
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "blob-empty"),
+                     str(snap / "vocab.json"))
+    assert hf_cache_repair.find_dangling_entries(str(repo_dir)) == []
+
+
+# ── repair_repo_cache ──────────────────────────────────────────────────────
+
+
+def test_repair_removes_only_broken_and_redownloads(tmp_path, monkeypatch):
+    import huggingface_hub
+
+    cache, repo_dir, snap = _mk_repo_cache(tmp_path)
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "MISSING"),
+                     str(snap / "model.safetensors"))
+    calls = []
+    monkeypatch.setattr(huggingface_hub, "snapshot_download",
+                        lambda **k: calls.append(k))
+
+    summary = hf_cache_repair.repair_repo_cache("test/checkpoint",
+                                                cache_dir=str(cache))
+    assert summary["found"] == 1
+    assert summary["removed"] == 1
+    assert summary["restored"] is True
+    assert summary["ok"] is True
+    assert summary["outcome"] == "healed_with_links"
+    assert summary["error"] == ""
+    # The broken entry is gone; snapshot_download was asked to restore it.
+    assert not os.path.lexists(snap / "model.safetensors")
+    assert calls == [{"repo_id": "test/checkpoint", "cache_dir": str(cache)}]
+    # Healthy entries and blobs are untouched.
+    assert (snap / "config.json").read_bytes() == b'{"ok": true}'
+    assert (snap / "tokenizer.json").read_bytes() == b'{"tok": 1}'
+    assert (repo_dir / "blobs" / "blob-config").exists()
+
+
+def test_repair_noop_on_healthy_cache_skips_download(tmp_path, monkeypatch):
+    import huggingface_hub
+
+    cache, _repo_dir, _snap = _mk_repo_cache(tmp_path)
+    called = []
+    monkeypatch.setattr(huggingface_hub, "snapshot_download",
+                        lambda **k: called.append(k))
+
+    summary = hf_cache_repair.repair_repo_cache("test/checkpoint",
+                                                cache_dir=str(cache))
+    assert summary == {
+        "repo_id": "test/checkpoint",
+        "repo_dir": str(cache / "models--test--checkpoint"),
+        "found": 0, "removed": 0, "restored": False,
+        "outcome": "healthy", "ok": True, "error": "",
+    }
+    assert called == []  # healthy caches never hit the network
+
+
+def test_repair_never_raises_when_download_fails(tmp_path, monkeypatch):
+    import huggingface_hub
+
+    cache, _repo_dir, snap = _mk_repo_cache(tmp_path)
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "MISSING"),
+                     str(snap / "model.safetensors"))
+
+    def boom(**_k):
+        raise OSError("network down")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", boom)
+    summary = hf_cache_repair.repair_repo_cache("test/checkpoint",
+                                                cache_dir=str(cache))
+    assert summary["ok"] is False
+    assert summary["restored"] is False
+    assert summary["outcome"] == "repair_failed"
+    assert "network down" in summary["error"]
+
+
+def test_restore_that_recreates_dangling_links_forces_copy_mode(
+    tmp_path, monkeypatch
+):
+    """The reporter's root cause: hub's memoized symlink probe says links work,
+    but real snapshot links come out dangling — a plain snapshot_download retry
+    recreates the SAME broken links. The repair must verify after restoring,
+    force copy-mode (pre-seed hub's private memo with False), delete the
+    re-broken entries, and restore once more with real file copies."""
+    import huggingface_hub
+    import huggingface_hub.file_download as fd
+
+    cache, _repo_dir, snap = _mk_repo_cache(tmp_path)
+    entry = snap / "model.safetensors"
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "MISSING"), str(entry))
+    monkeypatch.setattr(fd, "_are_symlinks_supported_in_dir", {}, raising=False)
+
+    calls = []
+
+    def fake_snapshot_download(**k):
+        calls.append(k)
+        if len(calls) == 1:  # first restore: the broken-probe host relinks badly
+            os.symlink(os.path.join("..", "..", "blobs", "MISSING"), str(entry))
+        else:                # copy-mode restore: a real file materializes
+            entry.write_bytes(b"weights")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    summary = hf_cache_repair.repair_repo_cache("test/checkpoint",
+                                                cache_dir=str(cache))
+    assert summary["ok"] is True
+    assert summary["outcome"] == "healed_with_copies"
+    assert summary["removed"] == 2  # original dangling link + the recreated one
+    assert len(calls) == 2
+    assert entry.read_bytes() == b"weights"
+    # Copy-mode was forced via hub's memo, keyed by the resolved cache root,
+    # and stays False so every later download uses copies too.
+    from pathlib import Path
+    key = str(Path(str(cache)).expanduser().resolve())
+    assert fd._are_symlinks_supported_in_dir[key] is False
+
+
+def test_copy_mode_pass_skipped_when_private_api_changed(tmp_path, monkeypatch):
+    """_force_copy_mode leans on huggingface_hub's PRIVATE memo dict; if a
+    future hub changes it, the second pass must be skipped gracefully (repair
+    reports failure with a clear error) rather than crash the load path."""
+    import huggingface_hub
+    import huggingface_hub.file_download as fd
+
+    cache, _repo_dir, snap = _mk_repo_cache(tmp_path)
+    entry = snap / "model.safetensors"
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "MISSING"), str(entry))
+    # Simulate the private attribute changing shape in a future hub version.
+    monkeypatch.setattr(fd, "_are_symlinks_supported_in_dir", None, raising=False)
+
+    calls = []
+
+    def fake_snapshot_download(**k):
+        calls.append(k)
+        os.symlink(os.path.join("..", "..", "blobs", "MISSING"), str(entry))
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+
+    summary = hf_cache_repair.repair_repo_cache("test/checkpoint",
+                                                cache_dir=str(cache))
+    assert summary["ok"] is False
+    assert summary["outcome"] == "repair_failed"
+    assert "copy-mode" in summary["error"]
+    assert len(calls) == 1  # no second download without forced copy-mode
+    # The still-broken entry was NOT deleted a second time (nothing left to
+    # restore it with) and no exception escaped.
+    assert os.path.lexists(entry)
+
+
+def test_repair_offline_deletes_nothing(tmp_path, monkeypatch):
+    # Don't delete what we can't restore: offline mode leaves the cache as-is.
+    import huggingface_hub
+
+    cache, _repo_dir, snap = _mk_repo_cache(tmp_path)
+    _symlink_or_skip(os.path.join("..", "..", "blobs", "MISSING"),
+                     str(snap / "model.safetensors"))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    called = []
+    monkeypatch.setattr(huggingface_hub, "snapshot_download",
+                        lambda **k: called.append(k))
+
+    summary = hf_cache_repair.repair_repo_cache("test/checkpoint",
+                                                cache_dir=str(cache))
+    assert summary["ok"] is False
+    assert summary["removed"] == 0
+    assert "offline" in summary["error"].lower()
+    assert os.path.lexists(snap / "model.safetensors")  # nothing deleted
+    assert called == []
+
+
+def test_repo_cache_dir_uses_env_cache(monkeypatch, tmp_path):
+    # Mirrors the Windows short-cache redirect (core.config sets HF_HUB_CACHE),
+    # read at call time so the manual-delete hint names the REAL folder.
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    assert hf_cache_repair.repo_cache_dir("org/name") == str(
+        tmp_path / "models--org--name"
+    )
+
+
+# ── model_manager wiring ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def model_manager(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+
+    import services.model_manager as mm
+
+    monkeypatch.setattr(mm, "_torch", None)
+    monkeypatch.setattr(mm, "_OmniVoice", None)
+    monkeypatch.setattr(mm, "model", None)
+    monkeypatch.setattr(mm, "_LINK_REPAIR_ATTEMPTED", set())
+    monkeypatch.setenv("OMNIVOICE_MODEL", "test/checkpoint")
+    monkeypatch.delenv("OMNIVOICE_PRELOAD_TTS_ASR", raising=False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising=False)
+    monkeypatch.setattr(mm, "_lazy_torch", lambda: SimpleNamespace(float16="float16"))
+    monkeypatch.setattr(mm, "get_best_device", lambda: "cpu")
+    return mm
+
+
+def _healed_summary(repo_id="test/checkpoint"):
+    return {"repo_id": repo_id, "repo_dir": "/cache/models--test--checkpoint",
+            "found": 2, "removed": 2, "restored": True,
+            "outcome": "healed_with_links", "ok": True, "error": ""}
+
+
+def test_signature_failure_link_repairs_and_retries(model_manager, monkeypatch):
+    """The core fix: first load hits the missing-weights signature, the link
+    self-heal repairs the snapshot, and the single retry succeeds — the legacy
+    resume ladder (a real network re-download) is never entered."""
+    repair_calls = []
+    monkeypatch.setattr(
+        "services.hf_cache_repair.repair_repo_cache",
+        lambda repo_id, cache_dir=None: repair_calls.append(repo_id)
+        or _healed_summary(repo_id),
+    )
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache",
+        lambda *a, **k: pytest.fail("resume repair must not run when the link heal fixed the cache"),
+    )
+
+    class FlakyOmniVoice:
+        attempts = 0
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            cls.attempts += 1
+            if cls.attempts == 1:
+                raise OSError(_SIGNATURE)
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: FlakyOmniVoice)
+
+    loaded = model_manager._load_model_sync()
+    assert loaded.llm is not None
+    assert repair_calls == ["test/checkpoint"]
+    assert FlakyOmniVoice.attempts == 2  # load, link-repair, reload — once
+
+
+def test_link_repair_runs_at_most_once_per_repo(model_manager, monkeypatch):
+    """Retry-once guard: when the cache stays broken after a 'successful'
+    repair, the second load failure must NOT re-trigger the link repair —
+    it falls through to the legacy ladder / actionable message instead."""
+    repair_calls = []
+    monkeypatch.setattr(
+        "services.hf_cache_repair.repair_repo_cache",
+        lambda repo_id, cache_dir=None: repair_calls.append(repo_id)
+        or _healed_summary(repo_id),
+    )
+    monkeypatch.setattr(model_manager, "_repair_model_cache",
+                        lambda *a, **k: False)
+
+    class AlwaysBroken:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise OSError(_SIGNATURE)
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: AlwaysBroken)
+
+    with pytest.raises(RuntimeError, match="incomplete"):
+        model_manager._load_model_sync()
+    assert repair_calls == ["test/checkpoint"]  # ran once for this failure
+
+    # A second load attempt in the same process: no second link repair.
+    with pytest.raises(RuntimeError, match="incomplete"):
+        model_manager._load_model_sync()
+    assert repair_calls == ["test/checkpoint"]
+
+
+def test_unrelated_load_error_does_not_trigger_repair(model_manager, monkeypatch):
+    repair_calls = []
+    monkeypatch.setattr(
+        "services.hf_cache_repair.repair_repo_cache",
+        lambda repo_id, cache_dir=None: repair_calls.append(repo_id)
+        or _healed_summary(repo_id),
+    )
+
+    class DiskFull:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: DiskFull)
+
+    with pytest.raises(OSError, match="disk full"):
+        model_manager._load_model_sync()
+    assert repair_calls == []
+
+
+def test_noop_repair_falls_through_to_resume_ladder(model_manager, monkeypatch):
+    """No broken links found → rung 0 must not eat the load retry budget; the
+    pre-existing resume repair (#581) still runs and heals the cache."""
+    monkeypatch.setattr(
+        "services.hf_cache_repair.repair_repo_cache",
+        lambda repo_id, cache_dir=None: {
+            "repo_id": repo_id, "repo_dir": "", "found": 0, "removed": 0,
+            "restored": False, "ok": True, "error": "",
+        },
+    )
+    resume_calls = []
+    monkeypatch.setattr(
+        model_manager, "_repair_model_cache",
+        lambda checkpoint: resume_calls.append(checkpoint) or True,
+    )
+
+    class Flaky:
+        attempts = 0
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            cls.attempts += 1
+            if cls.attempts == 1:
+                raise OSError(_SIGNATURE)
+            return SimpleNamespace(llm=object())
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: Flaky)
+
+    loaded = model_manager._load_model_sync()
+    assert loaded.llm is not None
+    assert resume_calls == ["test/checkpoint"]
+    assert Flaky.attempts == 2  # no extra load attempt for a no-op rung 0
+
+
+def test_repair_failed_message_names_the_real_cache_path(
+    model_manager, monkeypatch, tmp_path
+):
+    """When every rung fails, the surfaced error must tell the user the exact
+    models--<org>--<name> folder to delete — resolved from the cache in effect
+    (the Windows short cache, HF_HOME, or the default)."""
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setattr(
+        "services.hf_cache_repair.repair_repo_cache",
+        lambda repo_id, cache_dir=None: {
+            "repo_id": repo_id, "repo_dir": "", "found": 1, "removed": 0,
+            "restored": False, "ok": False, "error": "PermissionError: locked",
+        },
+    )
+    monkeypatch.setattr(model_manager, "_repair_model_cache",
+                        lambda *a, **k: False)
+
+    class AlwaysBroken:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            raise OSError(_SIGNATURE)
+
+    monkeypatch.setattr(model_manager, "_lazy_omnivoice", lambda: AlwaysBroken)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        model_manager._load_model_sync()
+    expected = str(tmp_path / "models--test--checkpoint")
+    assert expected in str(excinfo.value)
+    assert "restart" in str(excinfo.value)
+
+
+# ── failure classification ─────────────────────────────────────────────────
+
+
+def test_classify_missing_weights_signature():
+    assert failure.classify(_SIGNATURE) == "MODEL_CACHE_CORRUPT"
+    evt = failure.build_failure(_SIGNATURE, stage="model-load",
+                                include_diagnostic=False)
+    assert evt["docs_topic"] == "MODEL_CACHE_CORRUPT"
+    assert "broken file links" in evt["hint"]
+    assert "repairs this automatically" in evt["hint"]
+
+
+def test_classify_repair_messages():
+    # OmniVoice's own wording (status detail / logs / bug reports) must name
+    # the same class as the raw transformers error.
+    assert failure.classify(
+        "Model cache had broken file links — repaired automatically, retrying…"
+    ) == "MODEL_CACHE_CORRUPT"
+
+
+def test_classify_unrelated_errors_not_cache_corrupt():
+    assert failure.classify("disk full") != "MODEL_CACHE_CORRUPT"
+    assert failure.classify("") != "MODEL_CACHE_CORRUPT"


### PR DESCRIPTION
Fixes the Windows first-run breaker reported on Discord: all model blobs download, but the snapshot's symlinks come out **dangling** (the symlink-support probe passes while real link creation fails without Developer Mode/admin), so transformers reports `does not appear to have a file named pytorch_model.bin or model.safetensors` even though the bytes are on disk. The reporter root-caused the probe-vs-reality mismatch themselves — this ships their suggested verify-and-repair as a generic self-heal.

**How it works** (`backend/services/hf_cache_repair.py`, wired as rung 0 of the existing cache-recovery ladder in `_load_model_sync`):
1. On the missing-weights load failure, scan `snapshots/*/` for dangling symlinks + zero-byte weight/config files (conservative allowlist; resolving links and legitimately-empty files never touched; `blobs/` never touched).
2. Delete only the broken entries, `snapshot_download` to restore (reuses the already-downloaded blobs), retry the load **once** (per repo per process).
3. **Verify after repair**: if the restore recreated dangling links (the memoized probe still says "symlinks OK"), force copy-mode (guarded pre-seed of hub's probe memo; graceful skip if the private API changes) and restore again — real files instead of links, so the model loads even on machines where links are silently broken.
4. New `MODEL_CACHE_CORRUPT` failure class: during a heal the status pill says what's happening; if repair fails, the error names the **real** cache folder to delete instead of pretending the file doesn't exist. Offline mode deletes nothing.

**Tests:** `tests/test_hf_cache_repair.py` (22 new — detection conservatism, only-broken-removed, forced-copy second pass, private-API graceful skip, offline, retry-once guard, unrelated-errors-don't-repair, classification). Touched-module suites 66 passed; full backend suite on the branch: 2698 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds self-healing for Hugging Face cache snapshots affected by dangling symlinks or zero-byte weight/config files, including Windows environments where symlink creation fails silently.

## Changes

- Detects and removes only broken snapshot entries, preserving valid files and `blobs/`.
- Restores entries through `snapshot_download`, reusing existing blobs.
- Falls back to forced copy mode when symlink restoration remains broken.
- Retries model loading once per repository per process.
- Avoids cache mutations in offline mode.
- Reports the exact corrupted cache directory for manual removal.
- Adds `MODEL_CACHE_CORRUPT` failure classification and repair status updates.
- Adds 22 tests covering detection, repair safety, fallback behavior, offline mode, retry limits, and error classification.

## Repair flow

```mermaid
flowchart TD
    A[Model load fails with missing-file signature] --> B[Scan snapshot entries]
    B -->|Healthy| C[Continue existing recovery]
    B -->|Broken entries found| D{Offline mode?}
    D -->|Yes| E[Report corruption without modifying cache]
    D -->|No| F[Remove broken entries]
    F --> G[snapshot_download]
    G --> H{Entries still broken?}
    H -->|No| I[Retry model load]
    H -->|Yes| J[Force copy mode]
    J --> K[Restore entries again]
    K --> I
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->