### PR TITLE
fix(settings): system panels — honest factory reset, temp-file reclaim, log workflows, i18n

### DIFF
--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -725,6 +725,26 @@ async def get_storage_report(refresh: bool = Query(False)):
         raise HTTPException(status_code=500, detail="Failed to compute storage report")
 
 
+@router.post("/storage/temp/clear")
+async def clear_temp_files():
+    """Delete OmniVoice-owned temp files (Settings → Storage → Temporary files).
+
+    Removes only the ``omnivoice*`` entries in the OS temp dir — the exact
+    population the storage report's "temp" category counts — and invalidates
+    the cached report so the next scan reflects the reclaimed space. Partial
+    failures (files held open by a running job) are returned per entry.
+    """
+    from services import storage_report
+
+    try:
+        result = await asyncio.to_thread(storage_report.clear_temp)
+        storage_report.clear_cache()
+        return result
+    except Exception:
+        logger.exception("clear temp files failed")
+        raise HTTPException(status_code=500, detail="Failed to clear temporary files")
+
+
 # ── HF mirror endpoint (parity program Wave 4.3 / §R4 c) ──────────────────
 # Restricted-network users (e.g. behind the Great Firewall) need to point
 # huggingface_hub at a mirror. HF reads HF_ENDPOINT at import time, so a

--- a/backend/services/storage_report.py
+++ b/backend/services/storage_report.py
@@ -469,3 +469,39 @@ def clear_cache() -> None:
     """Testing hook — drop the in-process cache."""
     with _cache_lock:
         _cache.update(key=None, ts=0.0, report=None)
+
+
+def clear_temp(temp_root: str | None = None) -> dict:
+    """Delete the app-owned ``omnivoice*`` entries in the OS temp dir.
+
+    Removes exactly the population ``build_report`` counts as the "temp"
+    category — direct children of ``temp_root`` whose basename starts with
+    ``omnivoice`` — so nothing outside OmniVoice's own working files can ever
+    be swept up. Symlinked entries are unlinked, never followed, so a stray
+    ``omnivoice*`` link cannot make this delete its target's contents.
+
+    Returns ``{"removed": [basenames], "freed_bytes": int, "errors":
+    [{"path", "error"}]}`` — partial failures (e.g. a file held open by a
+    running job on Windows) are reported per entry instead of aborting.
+    """
+    temp_root = temp_root if temp_root is not None else tempfile.gettempdir()
+    removed: list[str] = []
+    errors: list[dict] = []
+    freed = 0
+    deadline = time.monotonic() + CATEGORY_TIMEOUT_SECONDS
+    for p in sorted(glob.glob(os.path.join(glob.escape(temp_root), "omnivoice*"))):
+        try:
+            if os.path.islink(p):
+                size = 0
+                os.unlink(p)
+            elif os.path.isfile(p):
+                size = os.path.getsize(p)
+                os.unlink(p)
+            else:
+                size, _complete, _err = _dir_size(p, deadline)
+                shutil.rmtree(p)
+            removed.append(os.path.basename(p))
+            freed += size
+        except OSError as e:
+            errors.append({"path": p, "error": str(e)})
+    return {"removed": removed, "freed_bytes": freed, "errors": errors}

--- a/frontend/src/components/settings/HistoryRetentionPanel.jsx
+++ b/frontend/src/components/settings/HistoryRetentionPanel.jsx
@@ -15,6 +15,7 @@ import { History } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { apiJson, apiFetch } from '../../api/client';
+import { Button } from '../../ui';
 import { SettingsSection, SettingRow, InfoHint } from './primitives';
 
 export default function HistoryRetentionPanel() {
@@ -22,20 +23,36 @@ export default function HistoryRetentionPanel() {
   const [cap, setCap] = useState('');
   const [def, setDef] = useState(200);
   const [loading, setLoading] = useState(true);
+  const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const d = await apiJson('/api/settings/history-retention');
       setCap(String(d?.cap ?? ''));
       if (Number.isInteger(d?.default)) setDef(d.default);
+      setLoaded(true);
     } catch (e) {
-      // Backend older than this panel — leave the default hint in place.
+      if (e?.status === 404) {
+        // Backend older than this panel — leave the default hint in place.
+        setLoaded(true);
+      } else {
+        // Transport failure / 500: the shown default may not be the real cap,
+        // so say so and hold Save until a load succeeds.
+        setError(
+          e?.message ||
+            t('settings.history_retention_load_failed', {
+              defaultValue: 'Could not load the current retention limit',
+            }),
+        );
+      }
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     refresh();
@@ -49,15 +66,12 @@ export default function HistoryRetentionPanel() {
     }
     setSaving(true);
     try {
+      // apiFetch throws ApiError on any non-OK response.
       const res = await apiFetch('/api/settings/history-retention', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ cap: n }),
       });
-      if (!res.ok) {
-        const b = await res.json().catch(() => ({}));
-        throw new Error(b?.detail || `HTTP ${res.status}`);
-      }
       const b = await res.json();
       setCap(String(b?.cap ?? n));
       toast.success(
@@ -89,6 +103,11 @@ export default function HistoryRetentionPanel() {
         </InfoHint>
       }
     >
+      {error && (
+        <div className="perfpanel__error" role="alert">
+          {error}
+        </div>
+      )}
       <SettingRow
         title={t('settings.history_retention_cap', { defaultValue: 'Takes to keep' })}
         subtitle={t('settings.history_retention_cap_hint', {
@@ -105,20 +124,28 @@ export default function HistoryRetentionPanel() {
               value={cap}
               placeholder={String(def)}
               onChange={(e) => setCap(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !saving && !loading && loaded) {
+                  e.preventDefault();
+                  save();
+                }
+              }}
               disabled={saving || loading}
               aria-label={t('settings.history_retention_cap', { defaultValue: 'Takes to keep' })}
               data-testid="history-retention-input"
             />
-            <button
-              className="flex-none cursor-pointer rounded-[var(--chrome-radius-pill)] [border:1px_solid_transparent] bg-[var(--chrome-accent)] px-[var(--space-4)] py-[var(--space-2)] font-sans text-[length:var(--text-base)] text-[var(--chrome-bg)] disabled:cursor-default disabled:opacity-50"
+            <Button
+              variant="primary"
+              size="sm"
               onClick={save}
-              disabled={saving || loading}
+              loading={saving}
+              disabled={loading || !loaded}
               data-testid="history-retention-save"
             >
               {saving
                 ? t('common.saving', { defaultValue: 'Saving…' })
                 : t('common.save', { defaultValue: 'Save' })}
-            </button>
+            </Button>
           </div>
         }
       />

--- a/frontend/src/components/settings/HistoryRetentionPanel.test.jsx
+++ b/frontend/src/components/settings/HistoryRetentionPanel.test.jsx
@@ -50,6 +50,43 @@ describe('HistoryRetentionPanel', () => {
     });
   });
 
+  it('saves on Enter in the input', async () => {
+    const fetchMock = mockFetchSequence(
+      { status: 200, body: { cap: 200, default: 200 } }, // initial GET
+      { status: 200, body: { cap: 75, default: 200 } }, // PUT
+    );
+    global.fetch = fetchMock;
+
+    render(<HistoryRetentionPanel />);
+    await waitFor(() => screen.getByTestId('history-retention-input'));
+    const input = screen.getByTestId('history-retention-input');
+    fireEvent.change(input, { target: { value: '75' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(([_u, opts]) => opts && opts.method === 'PUT');
+      expect(put).toBeTruthy();
+      expect(JSON.parse(put[1].body)).toEqual({ cap: 75 });
+    });
+  });
+
+  it('surfaces a load failure (500) and holds Save until a load succeeds', async () => {
+    global.fetch = mockFetchSequence({ status: 500, body: { detail: 'db locked' } });
+    render(<HistoryRetentionPanel />);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveTextContent(/db locked/);
+    expect(screen.getByTestId('history-retention-save')).toBeDisabled();
+  });
+
+  it('stays silent and usable on a 404 (backend older than the panel)', async () => {
+    global.fetch = mockFetchSequence({ status: 404, body: { detail: 'Not Found' } });
+    render(<HistoryRetentionPanel />);
+    await waitFor(() => expect(screen.getByTestId('history-retention-save')).not.toBeDisabled());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    // The hardcoded default hint stays in place.
+    expect(screen.getByTestId('history-retention-input')).toHaveAttribute('placeholder', '200');
+  });
+
   it('rejects a negative cap client-side without a PUT', async () => {
     const fetchMock = mockFetchSequence({ status: 200, body: { cap: 200, default: 200 } });
     global.fetch = fetchMock;

--- a/frontend/src/components/settings/LogsTab.jsx
+++ b/frontend/src/components/settings/LogsTab.jsx
@@ -1,6 +1,9 @@
-import React from 'react';
-import { FileText, RefreshCw, Trash2, AlertCircle } from 'lucide-react';
+import React, { useEffect, useRef } from 'react';
+import { Copy, FileText, FolderOpen, RefreshCw, Trash2, AlertCircle } from 'lucide-react';
+import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
+import { exportReveal } from '../../api/exports';
+import { copyText } from '../../utils/copyText';
 import { Segmented, Button, Badge } from '../../ui';
 import { SettingsSection } from './primitives';
 import ReportBugButton from '../ReportBugButton';
@@ -21,6 +24,37 @@ export default function LogsTab({
   onClearLogs,
 }) {
   const { t } = useTranslation();
+  const scrollRef = useRef(null);
+
+  // Fresh log loads land scrolled to the newest entries — the tail is the
+  // whole point of checking logs; without this the viewer opens at the oldest
+  // line of the tailed window on every refresh.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [logs]);
+
+  // The frontend "log" is an in-memory buffer — there is no file to reveal.
+  const hasLogFile = logSource !== 'frontend' && !!logMeta.exists && !!logMeta.path;
+
+  const openLogFolder = async () => {
+    try {
+      await exportReveal({ path: logMeta.path });
+    } catch (e) {
+      toast.error(
+        e?.message || t('settings.open_folder_failed', { defaultValue: 'Could not open folder' }),
+      );
+    }
+  };
+
+  const copyLogs = async () => {
+    const ok = await copyText(logs.join(''));
+    if (ok) {
+      toast.success(t('logs.log_copied', { source: t(`common.${logSource}`) }));
+    } else {
+      toast.error(t('logs.copy_failed_short', { defaultValue: 'Could not copy the log' }));
+    }
+  };
 
   return (
     <SettingsSection
@@ -29,6 +63,16 @@ export default function LogsTab({
       actions={
         <>
           <ReportBugButton />
+          <Button
+            variant="subtle"
+            size="sm"
+            onClick={copyLogs}
+            disabled={logs.length === 0}
+            leading={<Copy size={11} />}
+            data-testid="logs-copy"
+          >
+            {t('logs.copy_visible', { defaultValue: 'Copy visible log' })}
+          </Button>
           <Button
             variant="subtle"
             size="sm"
@@ -48,17 +92,37 @@ export default function LogsTab({
         items={LOG_SOURCE_DEFS.map((d) => ({ ...d, label: t(`common.${d.key}`) }))}
         value={logSource}
         onChange={setLogSource}
+        aria-label={t('logs.source', { defaultValue: 'Log source' })}
       />
 
       <div className="settings-log-meta flex items-center gap-[var(--space-4)] my-[var(--space-4)] font-mono text-[var(--text-base)] text-[var(--chrome-fg-dim)]">
         <span>{logMeta.path || '—'}</span>
+        {hasLogFile && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={openLogFolder}
+            leading={<FolderOpen size={11} />}
+            title={logMeta.path}
+            data-testid="logs-open-folder"
+          >
+            {t('settings.storage_open_folder', { defaultValue: 'Open folder' })}
+          </Button>
+        )}
         {logSource === 'tauri' && !logMeta.exists && (
           <Badge tone="warn">
             <AlertCircle size={11} /> {t('logs.no_tauri_log')}
           </Badge>
         )}
       </div>
-      <div className="bg-[var(--chrome-bg)] [border:1px_solid_var(--chrome-border)] rounded-[var(--chrome-radius-pill)] px-[12px] py-[10px] max-h-[280px] overflow-auto font-mono text-[0.72rem] text-[var(--chrome-fg-muted)] whitespace-pre-wrap break-words">
+      <div
+        ref={scrollRef}
+        tabIndex={0}
+        role="log"
+        aria-label={t('settings.logs')}
+        data-testid="logs-scroll"
+        className="bg-[var(--chrome-bg)] [border:1px_solid_var(--chrome-border)] rounded-[var(--chrome-radius-pill)] px-[12px] py-[10px] max-h-[280px] overflow-auto font-mono text-[0.72rem] text-[var(--chrome-fg-muted)] whitespace-pre-wrap break-words focus-visible:outline-none focus-visible:border-[var(--chrome-accent)] focus-visible:shadow-[var(--focus-ring)]"
+      >
         {logs.length === 0 ? (
           <span className="settings-log__empty font-sans text-[var(--chrome-fg-dim)]">
             {logSource === 'frontend'

--- a/frontend/src/components/settings/LogsTab.test.jsx
+++ b/frontend/src/components/settings/LogsTab.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import LogsTab from './LogsTab';
+
+const LINES = ['[10:00:00] boot\n', '[10:00:01] ready\n'];
+
+function renderTab(overrides = {}) {
+  const props = {
+    logSource: 'backend',
+    setLogSource: vi.fn(),
+    logs: LINES,
+    logMeta: { path: '/home/u/.omnivoice/omnivoice.log', exists: true },
+    loadingLogs: false,
+    refreshLogs: vi.fn(),
+    onClearLogs: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<LogsTab {...props} />), props };
+}
+
+describe('LogsTab', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('offers Open folder for on-disk logs and reveals via /export/reveal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+      text: async () => '{"success":true}',
+    });
+    global.fetch = fetchMock;
+
+    renderTab();
+    fireEvent.click(screen.getByTestId('logs-open-folder'));
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => u.endsWith('/export/reveal'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse(call[1].body)).toEqual({ path: '/home/u/.omnivoice/omnivoice.log' });
+    });
+  });
+
+  it('hides Open folder for the in-memory frontend buffer and missing files', () => {
+    renderTab({ logSource: 'frontend', logMeta: { path: 'in-memory (last 500)', exists: true } });
+    expect(screen.queryByTestId('logs-open-folder')).not.toBeInTheDocument();
+
+    renderTab({ logSource: 'tauri', logMeta: { path: '—', exists: false } });
+    expect(screen.queryByTestId('logs-open-folder')).not.toBeInTheDocument();
+  });
+
+  it('copies the visible tail to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+
+    renderTab();
+    fireEvent.click(screen.getByTestId('logs-copy'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(LINES.join('')));
+
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+  });
+
+  it('disables Copy when there is nothing to copy', () => {
+    renderTab({ logs: [] });
+    expect(screen.getByTestId('logs-copy')).toBeDisabled();
+  });
+
+  it('log viewport is keyboard-reachable and labelled', () => {
+    renderTab();
+    const box = screen.getByTestId('logs-scroll');
+    expect(box).toHaveAttribute('tabindex', '0');
+    expect(box).toHaveAttribute('role', 'log');
+    expect(box).toHaveAccessibleName('Logs');
+  });
+
+  it('scrolls to the newest entries when logs load', () => {
+    const { rerender, props } = renderTab({ logs: [] });
+    const box = screen.getByTestId('logs-scroll');
+    Object.defineProperty(box, 'scrollHeight', { value: 640, configurable: true });
+    rerender(<LogsTab {...props} logs={LINES} />);
+    expect(box.scrollTop).toBe(640);
+  });
+});

--- a/frontend/src/components/settings/PerformanceDeviceTab.jsx
+++ b/frontend/src/components/settings/PerformanceDeviceTab.jsx
@@ -70,7 +70,13 @@ export default function PerformanceDeviceTab() {
                     : 'neutral'
               }
             >
-              {status?.status || 'unknown'}
+              {status?.status === 'ready'
+                ? t('models.ready_badge')
+                : status?.status === 'loading'
+                  ? t('models.loading_badge')
+                  : status?.status === 'idle'
+                    ? t('models.idle_badge')
+                    : status?.status || t('common.unknown', { defaultValue: 'unknown' })}
             </Badge>
           }
         />

--- a/frontend/src/components/settings/PerformancePanel.jsx
+++ b/frontend/src/components/settings/PerformancePanel.jsx
@@ -17,11 +17,13 @@
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { Cpu } from 'lucide-react';
+import { Trans, useTranslation } from 'react-i18next';
 import { apiJson, apiFetch } from '../../api/client';
 import { SettingsSection, SettingRow, SettingsToggle } from './primitives';
 import RestartBadge from './RestartBadge';
 
 export default function PerformancePanel() {
+  const { t } = useTranslation();
   const [enabled, setEnabled] = useState(false);
   const [platform, setPlatform] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -36,11 +38,14 @@ export default function PerformancePanel() {
       setEnabled(Boolean(data?.enabled));
       setPlatform(data?.platform ?? null);
     } catch (e) {
-      setError(e?.message || 'Failed to load performance settings');
+      setError(
+        e?.message ||
+          t('settings.perf_load_failed', { defaultValue: 'Failed to load performance settings' }),
+      );
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     refresh();
@@ -60,7 +65,9 @@ export default function PerformancePanel() {
       const body = await res.json().catch(() => ({}));
       setEnabled(Boolean(body?.enabled ?? next));
     } catch (err) {
-      setError(err?.message || 'Failed to save setting');
+      setError(
+        err?.message || t('settings.perf_save_failed', { defaultValue: 'Failed to save setting' }),
+      );
       // Re-sync on failure so the UI doesn't show a stale state
       refresh();
     } finally {
@@ -68,8 +75,12 @@ export default function PerformancePanel() {
     }
   };
 
+  const toggleLabel = t('settings.perf_torch_compile', {
+    defaultValue: 'Disable torch.compile (Windows)',
+  });
+
   return (
-    <SettingsSection icon={Cpu} title="Performance">
+    <SettingsSection icon={Cpu} title={t('settings.perf_title', { defaultValue: 'Performance' })}>
       {error && (
         <div className="perfpanel__error" role="alert">
           {error}
@@ -79,33 +90,49 @@ export default function PerformancePanel() {
       <SettingRow
         title={
           <>
-            Disable torch.compile (Windows)
+            {toggleLabel}
             <RestartBadge />
           </>
         }
-        subtitle={!isWindows ? (platform === null ? '…' : 'not applicable') : undefined}
-        note={isWindows ? 'Falls back to eager mode — fixes Triton OOM on <16 GB GPUs.' : undefined}
+        subtitle={
+          !isWindows
+            ? platform === null
+              ? '…'
+              : t('settings.perf_torch_compile_na', {
+                  defaultValue: 'Windows only — not needed on this platform',
+                })
+            : undefined
+        }
+        note={
+          isWindows
+            ? t('settings.perf_torch_compile_note', {
+                defaultValue: 'Falls back to eager mode — fixes Triton OOM on <16 GB GPUs.',
+              })
+            : undefined
+        }
         hint={
-          <>
-            Workaround for{' '}
-            <a
-              href="https://github.com/debpalash/OmniVoice-Studio/issues/65"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              #65
-            </a>{' '}
-            — Windows users may hit Triton / <code>torch.compile</code> OOM during model load on
-            GPUs with &lt;16 GB VRAM. Enabling this sets <code>TORCH_COMPILE_DISABLE=1</code> on
-            engine subprocesses, which falls back to eager mode. macOS and Linux are unaffected.
-          </>
+          <Trans
+            i18nKey="settings.perf_torch_compile_hint"
+            defaults="Workaround for <issueLink>#65</issueLink> — Windows users may hit Triton / <code>torch.compile</code> OOM during model load on GPUs with less than 16 GB VRAM. Enabling this sets <code>TORCH_COMPILE_DISABLE=1</code> on engine subprocesses, which falls back to eager mode. macOS and Linux are unaffected."
+            components={{
+              // Trans injects the link text ("#65") from the translation string.
+              issueLink: (
+                <a
+                  href="https://github.com/debpalash/OmniVoice-Studio/issues/65"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              ),
+              code: <code />,
+            }}
+          />
         }
         control={
           <SettingsToggle
             checked={enabled}
             onChange={onToggle}
             disabled={!isWindows || saving || loading}
-            aria-label="Disable torch.compile (Windows)"
+            aria-label={toggleLabel}
             data-testid="torch-compile-toggle"
           />
         }

--- a/frontend/src/components/settings/PerformancePanel.test.jsx
+++ b/frontend/src/components/settings/PerformancePanel.test.jsx
@@ -65,7 +65,30 @@ describe('PerformancePanel', () => {
       const toggle = screen.getByTestId('torch-compile-toggle');
       expect(toggle).toBeDisabled();
     });
-    expect(screen.getByText(/not applicable/i)).toBeInTheDocument();
+    expect(screen.getByText(/not needed on this platform/i)).toBeInTheDocument();
+  });
+
+  it('renders every user-facing string through i18n (en fallback)', async () => {
+    global.fetch = mockFetchSequence({
+      status: 200,
+      body: { enabled: false, platform: 'win32' },
+    });
+    render(<PerformancePanel />);
+    await waitFor(() => screen.getByTestId('torch-compile-toggle'));
+    // Section title + row label resolve from settings.perf_* keys.
+    expect(screen.getByText('Performance')).toBeInTheDocument();
+    expect(screen.getByText(/Disable torch\.compile \(Windows\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Falls back to eager mode/)).toBeInTheDocument();
+    expect(screen.getByTestId('torch-compile-toggle')).toHaveAccessibleName(
+      /Disable torch\.compile \(Windows\)/,
+    );
+  });
+
+  it('surfaces a translated load error when the GET fails', async () => {
+    global.fetch = mockFetchSequence({ status: 500, body: { detail: 'boom' } });
+    render(<PerformancePanel />);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveTextContent(/boom|Failed to load/i);
   });
 
   it('renders disabled on linux platform', async () => {

--- a/frontend/src/components/settings/StorageTab.jsx
+++ b/frontend/src/components/settings/StorageTab.jsx
@@ -1,29 +1,29 @@
 /**
  * Settings → Storage (System group).
  *
- * Shows where OmniVoice keeps its data and outputs (read-only, from systemInfo)
- * and provides a NEW "Factory reset" action that clears the locally-persisted
- * UI preferences (the zustand `omnivoice.app` localStorage blob) behind a
+ * Shows where OmniVoice keeps its data and outputs (read-only, from systemInfo,
+ * each with an Open-folder affordance via the /export/reveal endpoint) and a
+ * "Factory reset" action that clears every locally-persisted UI preference —
+ * the full registry in utils/prefKeys.js, not just the zustand blob — behind a
  * confirm Dialog, then reloads.
  *
  * NOTE: the models *cache* directory lives in the Models category (StoragePanel)
  * — this category is about the app's own data/outputs paths and a clean-slate
  * reset of UI prefs. Factory reset only touches localStorage prefs; it never
- * deletes the user's voices, projects, or outputs on disk.
+ * deletes the user's voices, projects, or outputs on disk, and never wipes the
+ * remote-backend connection or dictation history (see prefKeys.PRESERVED_KEYS).
  */
 import React, { useState } from 'react';
-import { HardDrive, RotateCcw } from 'lucide-react';
+import { FolderOpen, HardDrive, RotateCcw } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { useSystemInfo } from '../../api/hooks';
+import { exportReveal } from '../../api/exports';
+import { clearLocalPreferences } from '../../utils/prefKeys';
 import { Button, Dialog } from '../../ui';
 import { SettingsSection } from './primitives';
 import Row from './Row';
 import HistoryRetentionPanel from './HistoryRetentionPanel';
-
-// The zustand persist key (see store/index.ts `name`). Clearing it resets every
-// persisted UI preference to its slice default on the next load.
-const PREFS_LS_KEY = 'omnivoice.app';
 
 export default function StorageTab() {
   const { t } = useTranslation();
@@ -32,7 +32,7 @@ export default function StorageTab() {
 
   const factoryReset = () => {
     try {
-      localStorage.removeItem(PREFS_LS_KEY);
+      clearLocalPreferences();
       toast.success(
         t('settings.factory_reset_done', { defaultValue: 'Preferences cleared — reloading…' }),
       );
@@ -41,10 +41,47 @@ export default function StorageTab() {
       setTimeout(() => window.location.reload(), 350);
     } catch (e) {
       toast.error(
-        t('settings.factory_reset_failed', { defaultValue: 'Reset failed', message: e?.message }),
+        t('settings.factory_reset_failed', {
+          defaultValue: 'Reset failed: {{message}}',
+          message: e?.message || e,
+        }),
       );
     }
   };
+
+  const openFolder = async (path) => {
+    try {
+      await exportReveal({ path });
+    } catch (e) {
+      toast.error(
+        e?.message || t('settings.open_folder_failed', { defaultValue: 'Could not open folder' }),
+      );
+    }
+  };
+
+  const pathRow = (label, path, testId) => (
+    <Row
+      label={label}
+      value={
+        <>
+          <span>{path || '—'}</span>
+          {path && (
+            <Button
+              variant="ghost"
+              size="sm"
+              leading={<FolderOpen size={12} />}
+              onClick={() => openFolder(path)}
+              title={path}
+              data-testid={testId}
+            >
+              {t('settings.storage_open_folder', { defaultValue: 'Open folder' })}
+            </Button>
+          )}
+        </>
+      }
+      mono
+    />
+  );
 
   return (
     <>
@@ -55,13 +92,13 @@ export default function StorageTab() {
           defaultValue: 'Where OmniVoice keeps your data and outputs.',
         })}
       >
-        <Row
-          label={t('privacy.uploads_at')}
-          value={info?.data_dir ? `${info.data_dir}/` : '—'}
-          mono
-        />
-        <Row label={t('privacy.outputs_at')} value={info?.outputs_dir || '—'} mono />
-        <Row label={t('about.crash_log')} value={info?.crash_log_path || '—'} mono />
+        {pathRow(
+          t('settings.data_dir_at', { defaultValue: 'App data stored at' }),
+          info?.data_dir ? `${info.data_dir}/` : '',
+          'storage-open-data-dir',
+        )}
+        {pathRow(t('privacy.outputs_at'), info?.outputs_dir || '', 'storage-open-outputs-dir')}
+        {pathRow(t('about.crash_log'), info?.crash_log_path || '', 'storage-open-crash-log')}
       </SettingsSection>
 
       <HistoryRetentionPanel />

--- a/frontend/src/components/settings/StorageTab.test.jsx
+++ b/frontend/src/components/settings/StorageTab.test.jsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import StorageTab from './StorageTab';
+
+const INFO = {
+  data_dir: '/home/u/.omnivoice',
+  outputs_dir: '/home/u/.omnivoice/outputs',
+  crash_log_path: '/home/u/.omnivoice/crash_log.txt',
+};
+
+/** URL-aware fetch mock: /system/info + history-retention + export/reveal. */
+function mockFetch() {
+  const fn = vi.fn(async (url) => {
+    const body = /\/system\/info/.test(url)
+      ? INFO
+      : /history-retention/.test(url)
+        ? { cap: 200, default: 200 }
+        : { success: true };
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    };
+  });
+  global.fetch = fn;
+  return fn;
+}
+
+function renderTab() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <StorageTab />
+    </QueryClientProvider>,
+  );
+}
+
+describe('StorageTab', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('labels the data dir as app data (not uploads) and offers Open folder on every path', async () => {
+    mockFetch();
+    renderTab();
+    await waitFor(() => expect(screen.getByText(`${INFO.data_dir}/`)).toBeInTheDocument());
+    expect(screen.getByText('App data stored at')).toBeInTheDocument();
+    expect(screen.getByTestId('storage-open-data-dir')).toBeInTheDocument();
+    expect(screen.getByTestId('storage-open-outputs-dir')).toBeInTheDocument();
+    expect(screen.getByTestId('storage-open-crash-log')).toBeInTheDocument();
+  });
+
+  it('Open folder reveals the path via /export/reveal', async () => {
+    const fetchMock = mockFetch();
+    renderTab();
+    const btn = await screen.findByTestId('storage-open-outputs-dir');
+    fireEvent.click(btn);
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => u.endsWith('/export/reveal'));
+      expect(call).toBeTruthy();
+      expect(JSON.parse(call[1].body)).toEqual({ path: INFO.outputs_dir });
+    });
+  });
+
+  it('factory reset clears every registered preference key, not just the zustand blob', async () => {
+    mockFetch();
+    // Preferences scattered across the app (the pre-registry bug left these behind):
+    localStorage.setItem('omnivoice.app', '{"state":{}}');
+    localStorage.setItem('omnivoice.navRailSide', 'right');
+    localStorage.setItem('omnivoice.settings.category', 'storage');
+    localStorage.setItem('omni_capture_live_typing', '1');
+    localStorage.setItem('ov_stories_global_speed', '1.4');
+    localStorage.setItem('omni_ui', '{"uiScale":1.2}');
+    localStorage.setItem('dismissed_lang_suggestion', 'true');
+    // User data + connection state that must survive a reset:
+    localStorage.setItem('omni_transcriptions', '[{"text":"note"}]');
+    localStorage.setItem('ov_backend_url', 'http://192.168.1.4:7842');
+
+    renderTab();
+    await waitFor(() => expect(screen.getByTestId('factory-reset-open')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('factory-reset-open'));
+    await waitFor(() => expect(screen.getByTestId('factory-reset-confirm')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('factory-reset-confirm'));
+
+    await waitFor(() => expect(localStorage.getItem('omnivoice.app')).toBeNull());
+    expect(localStorage.getItem('omnivoice.navRailSide')).toBeNull();
+    expect(localStorage.getItem('omnivoice.settings.category')).toBeNull();
+    expect(localStorage.getItem('omni_capture_live_typing')).toBeNull();
+    expect(localStorage.getItem('ov_stories_global_speed')).toBeNull();
+    expect(localStorage.getItem('omni_ui')).toBeNull();
+    expect(localStorage.getItem('dismissed_lang_suggestion')).toBeNull();
+    // Never touch user data or the remote-backend connection:
+    expect(localStorage.getItem('omni_transcriptions')).toBe('[{"text":"note"}]');
+    expect(localStorage.getItem('ov_backend_url')).toBe('http://192.168.1.4:7842');
+  });
+});

--- a/frontend/src/components/settings/StorageUsagePanel.jsx
+++ b/frontend/src/components/settings/StorageUsagePanel.jsx
@@ -21,6 +21,7 @@ import { exportReveal } from '../../api/exports';
 import { clearSystemLogs } from '../../api/system';
 import { useAppStore } from '../../store';
 import { fmtBytes } from './models/format';
+import { askConfirm } from './native';
 import { SettingsSection } from './primitives';
 
 // Once-per-session guard for the out-of-Settings critical toast.
@@ -137,7 +138,10 @@ export default function StorageUsagePanel() {
           toast.error(warningText(t, critical), { id: 'storage-critical', duration: 8000 });
         }
       } catch (e) {
-        setError(e?.message || 'Failed to load storage info');
+        setError(
+          e?.message ||
+            t('settings.storage_load_failed', { defaultValue: 'Failed to load storage info' }),
+        );
       } finally {
         setLoading(false);
         setRefreshing(false);
@@ -154,17 +158,58 @@ export default function StorageUsagePanel() {
     try {
       await exportReveal({ path });
     } catch (e) {
-      toast.error(e?.message || 'Could not open folder');
+      toast.error(
+        e?.message || t('settings.open_folder_failed', { defaultValue: 'Could not open folder' }),
+      );
     }
   };
 
+  // Same confirm gate as Settings → Logs → Clear: this truncates the crash log
+  // too (the primary bug-report artifact), so it must never be one stray click.
   const clearLogs = async () => {
+    const ok = await askConfirm(
+      t('settings.clear_backend_confirm', {
+        defaultValue: 'Clear the backend runtime + crash logs? This cannot be undone.',
+      }),
+      t('settings.clear_backend_title', { defaultValue: 'Clear logs' }),
+    );
+    if (!ok) return;
     try {
       await clearSystemLogs();
       toast.success(t('settings.storage_logs_cleared', { defaultValue: 'Logs cleared' }));
       load(true);
     } catch (e) {
-      toast.error(e?.message || 'Could not clear logs');
+      toast.error(
+        e?.message || t('settings.clear_backend_failed', { defaultValue: 'Failed to clear logs' }),
+      );
+    }
+  };
+
+  const clearTemp = async () => {
+    const ok = await askConfirm(
+      t('settings.storage_clear_temp_confirm', {
+        defaultValue:
+          "Delete OmniVoice's temporary working files? Don't do this while a dub or batch job is running.",
+      }),
+      t('settings.storage_clear_temp', { defaultValue: 'Clear temp files' }),
+    );
+    if (!ok) return;
+    try {
+      const r = await apiJson('/api/settings/storage/temp/clear', { method: 'POST' });
+      toast.success(
+        t('settings.storage_temp_cleared', {
+          defaultValue: 'Temporary files cleared — {{freed}} freed',
+          freed: fmtBytes(r?.freed_bytes || 0),
+        }),
+      );
+      load(true);
+    } catch (e) {
+      toast.error(
+        e?.message ||
+          t('settings.storage_clear_temp_failed', {
+            defaultValue: 'Could not clear temporary files',
+          }),
+      );
     }
   };
 
@@ -311,6 +356,19 @@ export default function StorageUsagePanel() {
                   >
                     <Package size={12} />
                     {t('settings.storage_manage_models', { defaultValue: 'Manage models' })}
+                  </SmallButton>
+                )}
+                {cat.id === 'temp' && (
+                  <SmallButton
+                    onClick={clearTemp}
+                    title={t('settings.storage_clear_temp_hint', {
+                      defaultValue: "Delete OmniVoice's own files in the temp directory",
+                    })}
+                    testId="storage-clear-temp"
+                    disabled={(cat.bytes || 0) === 0}
+                  >
+                    <Trash2 size={12} />
+                    {t('settings.storage_clear_temp', { defaultValue: 'Clear temp files' })}
                   </SmallButton>
                 )}
                 {cat.exists && (

--- a/frontend/src/components/settings/StorageUsagePanel.test.jsx
+++ b/frontend/src/components/settings/StorageUsagePanel.test.jsx
@@ -164,6 +164,65 @@ describe('StorageUsagePanel', () => {
     });
   });
 
+  it('Clear logs is confirm-gated: declining leaves the logs untouched', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const fetchMock = mockFetchWith(REPORT);
+    render(<StorageUsagePanel />);
+    await waitFor(() => expect(screen.getByTestId('storage-clear-logs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('storage-clear-logs'));
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    expect(confirmSpy.mock.calls[0][0]).toMatch(/cannot be undone/i);
+    expect(fetchMock.mock.calls.filter(([u]) => /\/system\/logs\/clear/.test(u))).toHaveLength(0);
+  });
+
+  it('Clear logs POSTs after the user confirms', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const fetchMock = mockFetchWith(REPORT);
+    render(<StorageUsagePanel />);
+    await waitFor(() => expect(screen.getByTestId('storage-clear-logs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('storage-clear-logs'));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) => /\/system\/logs\/clear/.test(u));
+      expect(call).toBeTruthy();
+      expect(call[1]?.method).toBe('POST');
+    });
+  });
+
+  it('Clear temp files is confirm-gated and hits the temp-clear endpoint', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const report = {
+      ...REPORT,
+      categories: REPORT.categories.map((c) =>
+        c.id === 'temp' ? { ...c, bytes: 512 * 1024 ** 2 } : c,
+      ),
+    };
+    const fetchMock = mockFetchWith(report);
+    render(<StorageUsagePanel />);
+    await waitFor(() => expect(screen.getByTestId('storage-clear-temp')).toBeInTheDocument());
+    expect(screen.getByTestId('storage-clear-temp')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('storage-clear-temp'));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([u]) =>
+        u.endsWith('/api/settings/storage/temp/clear'),
+      );
+      expect(call).toBeTruthy();
+      expect(call[1]?.method).toBe('POST');
+    });
+  });
+
+  it('Clear temp files is disabled when there is nothing to reclaim', async () => {
+    mockFetchWith(REPORT); // REPORT's temp category is 0 bytes
+    render(<StorageUsagePanel />);
+    await waitFor(() => expect(screen.getByTestId('storage-clear-temp')).toBeInTheDocument());
+    expect(screen.getByTestId('storage-clear-temp')).toBeDisabled();
+  });
+
   it('shows the load error state when the endpoint fails', async () => {
     // An HTTP error (not a transport failure) — apiFetch surfaces it without retrying.
     global.fetch = vi.fn().mockResolvedValue({

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -516,7 +516,7 @@
     "factory_reset_confirm": "Reset and reload",
     "factory_reset_confirm_body": "This clears all saved UI preferences and reloads the app. Your voices, projects, and outputs on disk are not affected. Continue?",
     "factory_reset_done": "Preferences cleared — reloading…",
-    "factory_reset_failed": "Reset failed",
+    "factory_reset_failed": "Reset failed: {{message}}",
     "storage_usage": "Disk usage",
     "storage_usage_desc": "What OmniVoice stores on this machine, and how much space is left.",
     "storage_refresh": "Refresh",
@@ -554,7 +554,23 @@
     "history_retention_cap_hint": "Starred takes never count against cleanup · 0 = unlimited",
     "history_retention_saved": "Retention limit saved",
     "history_retention_save_failed": "Could not save",
-    "history_retention_invalid": "Enter 0 or more"
+    "history_retention_invalid": "Enter 0 or more",
+    "perf_title": "Performance",
+    "perf_torch_compile": "Disable torch.compile (Windows)",
+    "perf_torch_compile_na": "Windows only — not needed on this platform",
+    "perf_torch_compile_note": "Falls back to eager mode — fixes Triton OOM on <16 GB GPUs.",
+    "perf_torch_compile_hint": "Workaround for <issueLink>#65</issueLink> — Windows users may hit Triton / <code>torch.compile</code> OOM during model load on GPUs with less than 16 GB VRAM. Enabling this sets <code>TORCH_COMPILE_DISABLE=1</code> on engine subprocesses, which falls back to eager mode. macOS and Linux are unaffected.",
+    "perf_load_failed": "Failed to load performance settings",
+    "perf_save_failed": "Failed to save setting",
+    "storage_load_failed": "Failed to load storage info",
+    "open_folder_failed": "Could not open folder",
+    "storage_clear_temp": "Clear temp files",
+    "storage_clear_temp_hint": "Delete OmniVoice's own files in the temp directory",
+    "storage_clear_temp_confirm": "Delete OmniVoice's temporary working files? Don't do this while a dub or batch job is running.",
+    "storage_clear_temp_failed": "Could not clear temporary files",
+    "storage_temp_cleared": "Temporary files cleared — {{freed}} freed",
+    "data_dir_at": "App data stored at",
+    "history_retention_load_failed": "Could not load the current retention limit"
   },
   "about": {
     "app": "App",
@@ -1696,7 +1712,8 @@
     "no": "No",
     "more_info": "More info",
     "learn_more": "Learn more",
-    "saving": "Saving…"
+    "saving": "Saving…",
+    "unknown": "unknown"
   },
   "keyboard": {
     "title": "Keyboard shortcuts",
@@ -1904,7 +1921,10 @@
     "log_copied": "Copied {{source}} log",
     "copy_failed": "Copy failed: {{message}}",
     "report_copied": "Diagnostic report copied — paste it into a GitHub issue.",
-    "report_failed": "Report failed: {{message}}"
+    "report_failed": "Report failed: {{message}}",
+    "source": "Log source",
+    "frontend_buffer": "in-memory (last 500)",
+    "copy_failed_short": "Could not copy the log"
   },
   "trimmer": {
     "title": "Trim reference audio",

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -289,7 +289,10 @@ export default function Settings() {
           return `[${ts}] [${e.level}] ${e.msg}\n`;
         });
         setLogs(lines);
-        setLogMeta({ path: 'in-memory (last 500)', exists: true });
+        setLogMeta({
+          path: t('logs.frontend_buffer', { defaultValue: 'in-memory (last 500)' }),
+          exists: true,
+        });
       }
     } catch (e) {
       toast.error(t('settings.logs_load_failed', { message: e.message }));

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -20,6 +20,12 @@ const localStorageMock = (function () {
     removeItem(key) {
       delete store[key];
     },
+    key(i) {
+      return Object.keys(store)[i] ?? null;
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
   };
 })();
 

--- a/frontend/src/utils/prefKeys.js
+++ b/frontend/src/utils/prefKeys.js
@@ -1,0 +1,56 @@
+/**
+ * Registry of every localStorage key OmniVoice uses, split into the
+ * preferences that Settings → Factory reset clears and the keys it must
+ * preserve. Factory reset promises "reset ALL in-app preferences" — before
+ * this registry it only removed the zustand blob ('omnivoice.app'), leaving
+ * nav-rail side, capture live-typing, stories speed, dismissed-tip flags and
+ * the legacy 'omni_ui' blob behind.
+ *
+ * Adding a new persisted preference? Pick a key under one of
+ * PREF_KEY_PREFIXES (preferred: 'omnivoice.<area>.<name>') and factory reset
+ * covers it automatically. Keys that must NOT be wiped (user data,
+ * connection/credentials) go in PRESERVED_KEYS with a reason.
+ * utils/prefKeys.test.js scans the source tree and fails on any localStorage
+ * key that is in neither bucket.
+ */
+
+/** Prefixes owned by UI preferences — factory reset clears every match. */
+export const PREF_KEY_PREFIXES = [
+  'omnivoice.', // zustand blob ('omnivoice.app') + navRailSide, logs.*, settings.category, donate.*, recents.*, dismissed-tip flags
+  'omni_capture_', // CaptureWidget mode + live-typing
+  'ov_stories_', // StoriesEditor global speed
+];
+
+/** Exact preference keys that don't fit a prefix (legacy spellings). */
+export const PREF_KEYS = [
+  'omni_ui', // legacy pre-zustand UI blob (useAppData shim)
+  'dismissed_lang_suggestion', // BootstrapSplash language-suggestion dismissal
+];
+
+/**
+ * Keys factory reset must NEVER touch:
+ *  - 'ov_backend_url' / 'ov_api_key': remote-backend connection + credential —
+ *    wiping them would sever a LAN-connected instance from its backend.
+ *  - 'omni_transcriptions': dictation history — user DATA, not a preference.
+ */
+export const PRESERVED_KEYS = ['ov_backend_url', 'ov_api_key', 'omni_transcriptions'];
+
+/** True when `key` is a resettable in-app preference. */
+export function isPrefKey(key) {
+  if (PRESERVED_KEYS.includes(key)) return false;
+  return PREF_KEYS.includes(key) || PREF_KEY_PREFIXES.some((p) => key.startsWith(p));
+}
+
+/**
+ * Remove every persisted in-app preference (and nothing else) from storage.
+ * Returns the list of keys that were removed.
+ */
+export function clearLocalPreferences(storage = window.localStorage) {
+  const keys =
+    typeof storage.length === 'number' && typeof storage.key === 'function'
+      ? Array.from({ length: storage.length }, (_, i) => storage.key(i))
+      : Object.keys(storage);
+  const doomed = keys.filter((k) => k && isPrefKey(k));
+  for (const k of doomed) storage.removeItem(k);
+  return doomed;
+}

--- a/frontend/src/utils/prefKeys.test.js
+++ b/frontend/src/utils/prefKeys.test.js
@@ -1,0 +1,112 @@
+/**
+ * Guard for the factory-reset preference registry (utils/prefKeys.js).
+ *
+ * Scans the whole src tree for localStorage keys — direct string literals in
+ * localStorage.*Item(...) calls plus the LS_* / *_KEY constant convention —
+ * and fails when a key is neither a resettable preference (covered by the
+ * registry, so Settings → Factory reset clears it) nor an explicitly
+ * PRESERVED key. This makes "add a pref key but forget factory reset"
+ * impossible to reintroduce silently.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  isPrefKey,
+  PRESERVED_KEYS,
+  PREF_KEYS,
+  PREF_KEY_PREFIXES,
+  clearLocalPreferences,
+} from './prefKeys';
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_EXT = new Set(['.js', '.jsx', '.ts', '.tsx']);
+
+function* sourceFiles(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'test' || entry.name === 'node_modules') continue;
+      yield* sourceFiles(p);
+    } else if (SOURCE_EXT.has(path.extname(entry.name)) && !/\.test\.[jt]sx?$/.test(entry.name)) {
+      yield p;
+    }
+  }
+}
+
+function collectLocalStorageKeys() {
+  const found = new Map(); // key → first file seen
+  const record = (key, file) => {
+    if (!found.has(key)) found.set(key, path.relative(SRC_ROOT, file));
+  };
+  // 1. Literal keys passed straight to localStorage.
+  const directRe = /localStorage\.(?:getItem|setItem|removeItem)\(\s*['"]([^'"]+)['"]/g;
+  // 2. The storage-key constant convention (LS_FOO / FOO_KEY / zustand `name:`).
+  const constRe = /(?:const|let|var)\s+(?:LS_[A-Z0-9_]+|[A-Z0-9_]*_KEY)\s*=\s*['"]([^'"]+)['"]/g;
+  const zustandRe = /name:\s*['"](omnivoice\.[^'"]+)['"]\s*,?\s*\n\s*storage:\s*createJSONStorage/g;
+  for (const file of sourceFiles(SRC_ROOT)) {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const re of [directRe, constRe, zustandRe]) {
+      re.lastIndex = 0;
+      for (let m; (m = re.exec(text)); ) record(m[1], file);
+    }
+  }
+  return found;
+}
+
+describe('prefKeys registry', () => {
+  it('categorizes every localStorage key in src as pref (resettable) or preserved', () => {
+    const found = collectLocalStorageKeys();
+    expect(found.size).toBeGreaterThanOrEqual(15); // sanity: the scan actually finds keys
+    const uncategorized = [...found.entries()].filter(
+      ([key]) => !isPrefKey(key) && !PRESERVED_KEYS.includes(key),
+    );
+    expect(
+      uncategorized,
+      `localStorage keys not covered by the factory-reset registry (utils/prefKeys.js).\n` +
+        `Either use a registered prefix (${PREF_KEY_PREFIXES.join(', ')}), add the key to ` +
+        `PREF_KEYS, or — if it is user data / connection state — to PRESERVED_KEYS with a reason:\n` +
+        uncategorized.map(([k, f]) => `  '${k}' (${f})`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('never classifies preserved keys as resettable', () => {
+    for (const k of PRESERVED_KEYS) expect(isPrefKey(k)).toBe(false);
+    for (const k of PREF_KEYS) expect(isPrefKey(k)).toBe(true);
+  });
+
+  describe('clearLocalPreferences', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('removes every pref key and keeps data/connection keys', () => {
+      localStorage.setItem('omnivoice.app', '{"state":{}}');
+      localStorage.setItem('omnivoice.navRailSide', 'right');
+      localStorage.setItem('omnivoice.logs.collapsed', '1');
+      localStorage.setItem('omnivoice.settings.category', 'storage');
+      localStorage.setItem('omni_capture_live_typing', '1');
+      localStorage.setItem('ov_stories_global_speed', '1.2');
+      localStorage.setItem('omni_ui', '{"uiScale":1.1}');
+      localStorage.setItem('dismissed_lang_suggestion', 'true');
+      // Must survive:
+      localStorage.setItem('ov_backend_url', 'http://192.168.1.10:7842');
+      localStorage.setItem('ov_api_key', 'k');
+      localStorage.setItem('omni_transcriptions', '[{"text":"hi"}]');
+
+      const removed = clearLocalPreferences();
+
+      expect(removed).toHaveLength(8);
+      expect(localStorage.getItem('omnivoice.app')).toBeNull();
+      expect(localStorage.getItem('omnivoice.navRailSide')).toBeNull();
+      expect(localStorage.getItem('omnivoice.logs.collapsed')).toBeNull();
+      expect(localStorage.getItem('omnivoice.settings.category')).toBeNull();
+      expect(localStorage.getItem('omni_capture_live_typing')).toBeNull();
+      expect(localStorage.getItem('ov_stories_global_speed')).toBeNull();
+      expect(localStorage.getItem('omni_ui')).toBeNull();
+      expect(localStorage.getItem('dismissed_lang_suggestion')).toBeNull();
+      expect(localStorage.getItem('ov_backend_url')).toBe('http://192.168.1.10:7842');
+      expect(localStorage.getItem('ov_api_key')).toBe('k');
+      expect(localStorage.getItem('omni_transcriptions')).toBe('[{"text":"hi"}]');
+    });
+  });
+});

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -132,6 +132,7 @@ POST /api/settings/hf-token
 POST /api/settings/license
 POST /api/settings/llm-providers/active
 POST /api/settings/llm-providers/{provider_id}/test
+POST /api/settings/storage/temp/clear
 POST /archetypes/{archetype_id}/use
 POST /audiobook
 POST /audiobook/cover

--- a/tests/test_storage_report.py
+++ b/tests/test_storage_report.py
@@ -269,3 +269,65 @@ def test_endpoint_returns_report_shape(roots, monkeypatch):
     from api.routers.setup.wizard import MIN_FREE_GB
     assert res["min_free_gb"] == MIN_FREE_GB
     assert res["volumes"] and {"total_bytes", "free_bytes", "used_percent", "roots"} <= set(res["volumes"][0])
+
+
+# ── Temp-files cleanup (Settings → Storage → "Clear temp files") ────────────
+
+def test_clear_temp_removes_only_app_owned_entries(tmp_path):
+    tmp = tmp_path / "tmp"
+    _write(str(tmp / "omnivoice_frames_abc" / "f.png"), 25)
+    _write(str(tmp / "omnivoice.chunk"), 10)
+    _write(str(tmp / "unrelated" / "keep.bin"), 999)
+    _write(str(tmp / "keep.txt"), 7)
+
+    res = storage_report.clear_temp(str(tmp))
+
+    assert sorted(res["removed"]) == ["omnivoice.chunk", "omnivoice_frames_abc"]
+    assert res["freed_bytes"] == 35
+    assert res["errors"] == []
+    assert not (tmp / "omnivoice_frames_abc").exists()
+    assert not (tmp / "omnivoice.chunk").exists()
+    # Anything not app-owned is never touched.
+    assert (tmp / "unrelated" / "keep.bin").exists()
+    assert (tmp / "keep.txt").exists()
+
+
+def test_clear_temp_unlinks_symlinks_without_following(tmp_path):
+    tmp = tmp_path / "tmp"
+    target = tmp_path / "precious"
+    _write(str(target / "data.bin"), 50)
+    os.makedirs(tmp, exist_ok=True)
+    os.symlink(str(target), str(tmp / "omnivoice_link"))
+
+    res = storage_report.clear_temp(str(tmp))
+
+    assert res["removed"] == ["omnivoice_link"]
+    assert not os.path.lexists(tmp / "omnivoice_link")
+    # The symlink target's contents must survive.
+    assert (target / "data.bin").exists()
+
+
+def test_clear_temp_empty_dir_is_a_noop(tmp_path):
+    tmp = tmp_path / "tmp"
+    os.makedirs(tmp, exist_ok=True)
+    res = storage_report.clear_temp(str(tmp))
+    assert res == {"removed": [], "freed_bytes": 0, "errors": []}
+
+
+def test_clear_temp_endpoint_clears_and_invalidates_cache(roots, monkeypatch, tmp_path):
+    from api.routers import settings as s
+
+    tmp = tmp_path / "endpoint_tmp"
+    _write(str(tmp / "omnivoice_job" / "seg.wav"), 40)
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp))
+
+    # Prime the report cache, then clear — the endpoint must invalidate it.
+    monkeypatch.setattr(s, "_effective_models_dir", lambda: roots["hf_cache_dir"])
+    monkeypatch.setattr("core.config.DATA_DIR", roots["data_dir"])
+    asyncio.run(s.get_storage_report(refresh=True))
+
+    res = asyncio.run(s.clear_temp_files())
+    assert res["removed"] == ["omnivoice_job"]
+    assert res["freed_bytes"] == 40
+    assert not (tmp / "omnivoice_job").exists()
+    assert storage_report._cache["report"] is None  # cache invalidated


### PR DESCRIPTION
Twelve audited defects across PerformancePanel, StorageTab, StorageUsagePanel, HistoryRetentionPanel, LogsTab, PerformanceDeviceTab, each with tests:

- **Factory reset now does what it promises**: a `prefKeys.js` registry clears every locally-saved preference (connection credentials and user data explicitly preserved), plus a class-guard test that scans the source tree for localStorage keys and fails on any uncategorized one.
- **Temporary files can be reclaimed**: new `POST /api/settings/storage/temp/clear` deleting only the app's own temp entries (route inventory regenerated), wired to a confirmed button on the temp row.
- **Log workflows**: Open-folder + Copy-visible-log on LogsTab; viewer scrolls to the newest line; keyboard-reachable scroll region; Clear-logs now confirms before truncating.
- **HistoryRetentionPanel** surfaces load failures instead of swallowing them; Enter saves.
- **PerformancePanel** fully i18n'd; status badges reuse the models.* vocabulary; error toasts keep the real message.

**Tests:** frontend suite on the branch **1004 passed** (+18 across 7 new/extended files); backend storage/perf/route suites **93 passed**; typecheck/lint/format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Expanded factory reset to clear registered UI preferences while preserving credentials, connection settings, and user data.
- Added safe temporary-file cleanup for app-owned `omnivoice*` entries, with cache invalidation and symlink protection.
- Improved storage and log workflows:
  - Confirm before clearing logs or temp files.
  - Open storage/log folders.
  - Copy visible logs.
  - Auto-scroll and keyboard-enable the log viewer.
- Improved history-retention loading, error handling, and Enter-to-save behavior.
- Completed Performance settings internationalization, localized model status badges, and preserved backend error messages.
- Added comprehensive frontend and backend tests for these behaviors.

## UI sketch

```text
Storage
├─ App data path       [Open folder]
├─ Outputs path        [Open folder]
└─ Crash log path      [Open folder]

Storage usage
├─ Logs                [Clear logs]
└─ Temporary files     [Clear temp files]

Logs
├─ Log source/path     [Open folder]
├─ Log viewer (scrollable, auto-follow)
└─ [Copy visible logs]
```

## Behavior flow

```mermaid
flowchart TD
  A[User selects reset or cleanup action] --> B{Confirmation required?}
  B -- Yes --> C{Confirmed?}
  C -- No --> Z[Cancel]
  C -- Yes --> D[Perform action]
  B -- No --> D
  D --> E{Success?}
  E -- Yes --> F[Refresh data and show success toast]
  E -- No --> G[Show localized error toast]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->