### PR TITLE
fix(scripts): desktop-prod builds clean and stops wiping the shared HF cache; new desktop-fresh emulates a brand-new machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "desktop-prod:keep-models": "bun scripts/desktop-prod.mjs --keep-models",
     "desktop-prod:pill": "bun scripts/desktop-prod.mjs --pill",
     "desktop-prod:run:pill": "bun scripts/desktop-prod.mjs --skip-build --pill",
+    "desktop-fresh": "bun scripts/desktop-fresh.mjs",
+    "desktop-fresh:run": "bun scripts/desktop-fresh.mjs --skip-build",
     "build": "turbo run build",
     "start": "turbo run start",
     "test:frontend": "node --test tests/frontend/*.test.mjs",

--- a/scripts/desktop-common.mjs
+++ b/scripts/desktop-common.mjs
@@ -1,0 +1,165 @@
+// ──────────────────────────────────────────────────────────────────────────
+// desktop-common.mjs — pure, side-effect-free helpers shared by the local
+// desktop launcher scripts (desktop-fresh.mjs today; desktop-prod.sh mirrors
+// the build-command literal — see UPDATER_ARTIFACTS_OFF below).
+//
+// Everything in here is a pure function of its inputs so it can be unit
+// tested (tests/frontend/desktopScripts.test.mjs) without touching the
+// filesystem or the environment. Keep it that way: no fs, no process.env
+// reads, no child_process.
+// ──────────────────────────────────────────────────────────────────────────
+
+export const APP_ID = "com.debpalash.omnivoice-studio";
+export const APP_NAME = "OmniVoice Studio";
+
+/** Backend data dir name — backend/core/config.py::get_app_data_dir() writes
+ *  to "~/Library/Application Support/OmniVoice" on macOS (NOT under APP_ID). */
+export const BACKEND_DIR_NAME = "OmniVoice";
+
+/** PATH entries hidden from the app in fresh/new-user emulation: the Homebrew
+ *  and /usr/local prefixes where a dev's ffmpeg/ffprobe/yt-dlp live. A real
+ *  new user's machine has none of these tools on PATH. */
+export const STRIPPED_PATH_ENTRIES = [
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+  "/usr/local/bin",
+];
+
+/** Env vars hidden from the app in fresh/new-user emulation (exact names).
+ *  HF_HUB_CACHE is included because backend/core/config.py honours it the
+ *  same way it honours HF_HOME. */
+export const STRIPPED_ENV_VARS = [
+  "HF_TOKEN",
+  "HUGGING_FACE_HUB_TOKEN",
+  "HF_HOME",
+  "HF_HUB_CACHE",
+  "HF_ENDPOINT",
+];
+
+/** Env-var prefixes hidden from the app (any OMNIVOICE_* override:
+ *  OMNIVOICE_DATA_DIR, OMNIVOICE_CACHE_DIR, OMNIVOICE_IDLE_TIMEOUT, …). */
+export const STRIPPED_ENV_PREFIXES = ["OMNIVOICE_"];
+
+/** Inline `tauri build --config` override for LOCAL emulation builds: skip
+ *  updater artifacts (.app.tar.gz + .sig). Dev machines have no
+ *  TAURI_SIGNING_PRIVATE_KEY, so with createUpdaterArtifacts left at the
+ *  tauri.conf.json default (true) the build produced every bundle and THEN
+ *  exited 1 at the signing step. Local emulation never needs updater
+ *  artifacts — release.yml is where they are built and signed.
+ *  Kept in sync with the same literal in scripts/desktop-prod.sh. */
+export const UPDATER_ARTIFACTS_OFF =
+  '{"bundle":{"createUpdaterArtifacts":false}}';
+
+/**
+ * Arguments for the workspace-local Tauri CLI (`bun run --cwd frontend <…>`)
+ * to build a local-emulation debug bundle that exits 0:
+ *   - only the bundle the launcher actually uses (macOS .app / Linux
+ *     AppImage / raw .exe on Windows — no dmg/deb/msi busywork), and
+ *   - no updater artifacts (see UPDATER_ARTIFACTS_OFF).
+ *
+ * @param {NodeJS.Platform | string} platform  e.g. process.platform
+ */
+export function tauriBuildArgs(platform) {
+  const bundleFlags =
+    platform === "darwin"
+      ? ["--bundles", "app"]
+      : platform === "linux"
+        ? ["--bundles", "appimage"]
+        : ["--no-bundle"]; // Windows launches the raw debug .exe
+  return ["tauri", "build", "--debug", ...bundleFlags, "--config", UPDATER_ARTIFACTS_OFF];
+}
+
+/**
+ * True when a path is unambiguously OmniVoice-scoped and therefore safe to
+ * auto-delete. The HF cache defaults to the SHARED ~/.cache/huggingface on
+ * macOS/Linux (backend/core/config.py only relocates it on Windows), and
+ * HF_HOME can point anywhere — wiping a non-scoped path would delete models
+ * unrelated to OmniVoice.
+ */
+export function isAppScoped(p) {
+  const s = String(p).toLowerCase();
+  return s.includes("omnivoice") || s.includes("com.debpalash");
+}
+
+/**
+ * Every trace a past OmniVoice install leaves on macOS. Superset of what
+ * desktop-prod.sh cleans; desktop-fresh.mjs removes all of it for a true
+ * new-user blank slate. All paths are APP_ID / OmniVoice-scoped by
+ * construction — enforced by tests/frontend/desktopScripts.test.mjs.
+ *
+ * `kind: "prefix"` entries match every directory entry whose basename starts
+ * with the given basename (e.g. ~/Library/HTTPStorages/<APP_ID> AND
+ * <APP_ID>.binarycookies).
+ *
+ * @param {string} home  the user's home directory (os.homedir())
+ * @returns {{label: string, path: string, kind?: "prefix"}[]}
+ */
+export function macosFreshTraces(home) {
+  return [
+    // What desktop-prod.sh already cleans:
+    { label: "App data (Tauri venv + state)", path: `${home}/Library/Application Support/${APP_ID}` },
+    { label: "Backend data (db, voices, outputs)", path: `${home}/Library/Application Support/${BACKEND_DIR_NAME}` },
+    { label: "Tauri logs", path: `${home}/Library/Logs/${APP_ID}` },
+    { label: "WebKit storage (webview localStorage)", path: `${home}/Library/WebKit/${APP_ID}` },
+    // Extra traces that survive a reinstall + data wipe:
+    { label: "Caches", path: `${home}/Library/Caches/${APP_ID}` },
+    { label: "HTTP storages (cookies, HSTS)", path: `${home}/Library/HTTPStorages/${APP_ID}`, kind: "prefix" },
+    { label: "Preferences plist", path: `${home}/Library/Preferences/${APP_ID}.plist` },
+    { label: "Saved application state", path: `${home}/Library/Saved Application State/${APP_ID}.savedState` },
+  ];
+}
+
+/**
+ * Strip the dev-tool prefixes (STRIPPED_PATH_ENTRIES) from a PATH string,
+ * preserving the order of everything else. Trailing slashes on entries are
+ * normalised for comparison only ("/usr/local/bin/" is stripped too);
+ * look-alikes ("/usr/local/bin-extra") are preserved.
+ *
+ * @param {string} pathValue  a ":"-separated PATH string
+ */
+export function sanitizedPath(pathValue) {
+  const norm = (e) => e.replace(/\/+$/, "");
+  return String(pathValue)
+    .split(":")
+    .filter((e) => !STRIPPED_PATH_ENTRIES.includes(norm(e)))
+    .join(":");
+}
+
+/**
+ * Return a sanitized copy of an environment object for new-user emulation:
+ * STRIPPED_ENV_VARS and STRIPPED_ENV_PREFIXES-matching keys removed, PATH
+ * run through sanitizedPath(). The input object is not mutated.
+ *
+ * @param {Record<string, string | undefined>} env  e.g. process.env
+ */
+export function sanitizedEnv(env) {
+  const out = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (STRIPPED_ENV_VARS.includes(key)) continue;
+    if (STRIPPED_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))) continue;
+    out[key] = value;
+  }
+  if (out.PATH != null) out.PATH = sanitizedPath(out.PATH);
+  return out;
+}
+
+/**
+ * The env keys that sanitizedEnv() would remove from `env` and the PATH
+ * entries it would strip — for the camouflage banner, so the tester sees
+ * exactly what is hidden on THIS machine.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {{ vars: string[], pathEntries: string[] }}
+ */
+export function hiddenFrom(env) {
+  const norm = (e) => e.replace(/\/+$/, "");
+  const vars = Object.keys(env).filter(
+    (key) =>
+      STRIPPED_ENV_VARS.includes(key) ||
+      STRIPPED_ENV_PREFIXES.some((prefix) => key.startsWith(prefix)),
+  );
+  const pathEntries = String(env.PATH ?? "")
+    .split(":")
+    .filter((e) => STRIPPED_PATH_ENTRIES.includes(norm(e)));
+  return { vars, pathEntries };
+}

--- a/scripts/desktop-fresh.mjs
+++ b/scripts/desktop-fresh.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// ──────────────────────────────────────────────────────────────────────────
+// desktop-fresh.mjs — true NEW-USER emulation for OmniVoice Studio (macOS)
+//
+// Stricter sibling of `bun desktop-prod`. Two things beyond what prod does:
+//
+//   1. COMPLETE blank slate — removes every trace a past install leaves on
+//      macOS, not just app/backend data: WebKit storage (webview
+//      localStorage survives a reinstall + data wipe — bugs hiding there are
+//      invisible to desktop-prod), Caches, HTTPStorages, the Preferences
+//      plist (+ `defaults delete`, since cfprefsd caches beyond the file),
+//      and Saved Application State.
+//
+//   2. DEV-MACHINE CAMOUFLAGE — launches the app with a sanitized
+//      environment so it behaves like a non-developer machine: PATH without
+//      /opt/homebrew/bin, /opt/homebrew/sbin, /usr/local/bin (no brew
+//      ffmpeg/ffprobe/yt-dlp), and HF_TOKEN / HUGGING_FACE_HUB_TOKEN /
+//      HF_HOME / HF_HUB_CACHE / HF_ENDPOINT / OMNIVOICE_* unset.
+//
+//      Env propagation: the app is launched by DIRECT EXEC of the bundle's
+//      Mach-O (Contents/MacOS/omnivoice-studio), which inherits our env.
+//      `open` (what desktop-prod uses) hands off to LaunchServices/launchd,
+//      which starts the app with launchd's environment — the sanitized env
+//      would be silently ignored.
+//
+//      Known limitation: backend/core/config.py re-prepends /opt/homebrew/bin
+//      and /usr/local/bin to the backend's own PATH when those dirs exist on
+//      disk, so brew tools can still be visible to the *backend*. Full
+//      isolation needs a clean VM / macOS user account.
+//
+// The shared global HF cache (~/.cache/huggingface — what the app resolves
+// on macOS, see backend/core/config.py) is NEVER wiped by default: it holds
+// models unrelated to OmniVoice. Set FRESH_NUKE_HF=1 to opt in.
+//
+// Usage:
+//   bun desktop-fresh              # wipe traces + build + launch camouflaged
+//   bun desktop-fresh:run          # same, but skip the build
+//   bun desktop-fresh --dry-run    # print what WOULD be removed; change nothing
+//   FRESH_NUKE_HF=1 bun desktop-fresh   # also wipe the global HF model cache
+//
+// This script is deliberately macOS-only (the trace paths and the launch
+// mechanism are macOS-specific) and refuses to run elsewhere.
+// ──────────────────────────────────────────────────────────────────────────
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+import {
+  APP_ID,
+  APP_NAME,
+  hiddenFrom,
+  isAppScoped,
+  macosFreshTraces,
+  sanitizedEnv,
+  tauriBuildArgs,
+} from "./desktop-common.mjs";
+
+// ── macOS only ─────────────────────────────────────────────────────────────
+if (process.platform !== "darwin") {
+  console.error(
+    [
+      "",
+      `❌ \`desktop-fresh\` is macOS-only (detected: ${process.platform}).`,
+      "",
+      "   The traces it wipes (~/Library/WebKit, ~/Library/HTTPStorages,",
+      "   Preferences plists, Saved Application State) and its launch",
+      "   mechanism (direct exec of the .app's Mach-O to propagate a",
+      "   sanitized env) are macOS-specific.",
+      "",
+      "   On this platform use the regular fresh-install emulator instead:",
+      "       bun desktop-prod",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+// ── Flags ──────────────────────────────────────────────────────────────────
+const HELP = `Usage: bun desktop-fresh [--skip-build] [--dry-run] [--pill]
+
+  --skip-build   Skip the tauri build, launch the last compiled .app
+  --dry-run      Print every path that WOULD be removed and what the
+                 camouflaged launch would look like — change nothing
+  --pill         Launch in dictation-widget mode (no main window)
+
+Environment:
+  FRESH_NUKE_HF=1   Also wipe the SHARED global Hugging Face cache
+                    (~/.cache/huggingface). Off by default because it holds
+                    models unrelated to OmniVoice.`;
+
+let skipBuild = false;
+let dryRun = false;
+const launchArgs = [];
+for (const arg of process.argv.slice(2)) {
+  switch (arg) {
+    case "--skip-build":
+      skipBuild = true;
+      break;
+    case "--dry-run":
+      dryRun = true;
+      break;
+    case "--pill":
+      launchArgs.push("--pill");
+      break;
+    case "-h":
+    case "--help":
+      console.log(HELP);
+      process.exit(0);
+      break;
+    default:
+      console.error(`❌ Unknown flag: ${arg}\n\n${HELP}`);
+      process.exit(1);
+  }
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const home = homedir();
+const appBundle = join(
+  repoRoot, "frontend", "src-tauri", "target", "debug", "bundle", "macos", `${APP_NAME}.app`,
+);
+const WOULD = dryRun ? " (dry-run)" : "";
+
+/** Human dir/file size via `du -sh` (darwin-only script, du is always there). */
+function sizeOf(p) {
+  const res = spawnSync("du", ["-sh", p], { encoding: "utf8" });
+  const size = res.status === 0 ? res.stdout.split("\t")[0].trim() : "";
+  return size ? ` (${size})` : "";
+}
+
+// ── Refuse-footgun check: is the app running? ──────────────────────────────
+// Wiping data under a live instance lets its open file handles resurrect
+// state after we "cleaned" it — warn (don't kill the user's processes).
+{
+  const pg = spawnSync("pgrep", ["-f", `${APP_NAME}.app|target/debug/omnivoice-studio`], {
+    encoding: "utf8",
+  });
+  if (pg.status === 0) {
+    console.warn(
+      `⚠️  ${APP_NAME} appears to be RUNNING (pids: ${pg.stdout.trim().split("\n").join(", ")}).\n` +
+        "   Quit it first — a live instance can rewrite the data being wiped.\n",
+    );
+  }
+}
+
+// ── 1. Blank slate: remove every install trace ─────────────────────────────
+console.log(`🧹 Wiping every OmniVoice trace for new-user emulation${WOULD}...\n`);
+
+/** Expand a trace entry into concrete existing paths. */
+function expandTrace(trace) {
+  if (trace.kind === "prefix") {
+    const parent = dirname(trace.path);
+    const prefix = basename(trace.path);
+    if (!existsSync(parent)) return [];
+    return readdirSync(parent)
+      .filter((name) => name.startsWith(prefix))
+      .map((name) => join(parent, name));
+  }
+  return existsSync(trace.path) ? [trace.path] : [];
+}
+
+for (const trace of macosFreshTraces(home)) {
+  const targets = expandTrace(trace);
+  if (targets.length === 0) {
+    console.log(`   ○ absent        ${trace.label}: ${trace.path}${trace.kind === "prefix" ? "*" : ""}`);
+    continue;
+  }
+  for (const target of targets) {
+    const size = sizeOf(target);
+    if (dryRun) {
+      console.log(`   ▷ would remove  ${trace.label}: ${target}${size}`);
+    } else {
+      rmSync(target, { recursive: true, force: true });
+      console.log(`   ✓ removed       ${trace.label}: ${target}${size}`);
+    }
+  }
+}
+
+// Preferences live in cfprefsd's cache beyond the plist file — flush them.
+if (dryRun) {
+  console.log(`   ▷ would run     defaults delete ${APP_ID} (flush cfprefsd cache)`);
+} else {
+  const res = spawnSync("defaults", ["delete", APP_ID], { stdio: "ignore" });
+  console.log(
+    res.status === 0
+      ? `   ✓ flushed       cfprefsd preferences (defaults delete ${APP_ID})`
+      : `   ○ absent        cfprefsd preferences (no cached domain)`,
+  );
+}
+
+// ── 1b. HF model cache — shared, so opt-in only ────────────────────────────
+// On macOS the app resolves the DEFAULT global cache (~/.cache/huggingface):
+// backend/core/config.py only relocates the cache on Windows, and the
+// camouflaged launch below hides HF_HOME/HF_HUB_CACHE from the app anyway.
+const hfCache = join(home, ".cache", "huggingface");
+console.log("");
+if (!existsSync(hfCache)) {
+  console.log(`   ○ absent        HF model cache: ${hfCache}`);
+} else if (process.env.FRESH_NUKE_HF === "1") {
+  const size = sizeOf(hfCache);
+  if (dryRun) {
+    console.log(`   ▷ would remove  HF model cache: ${hfCache}${size} — FRESH_NUKE_HF=1`);
+  } else {
+    rmSync(hfCache, { recursive: true, force: true });
+    console.log(`   ✓ removed       HF model cache: ${hfCache}${size} — FRESH_NUKE_HF=1`);
+  }
+  console.log("     ↳ that was the machine-wide Hugging Face cache: ALL HF models are gone.");
+} else {
+  console.log(`   ◆ kept          HF model cache: ${hfCache}${sizeOf(hfCache)} — SHARED global cache`);
+  console.log("     ↳ Not OmniVoice-scoped; wiping it would delete models unrelated to this app.");
+  console.log("       Models will be REUSED (not re-downloaded). For a true cold first run:");
+  console.log("       FRESH_NUKE_HF=1 bun desktop-fresh");
+}
+if (process.env.HF_HOME && !isAppScoped(process.env.HF_HOME)) {
+  console.log(`     ↳ Note: your shell's HF_HOME (${process.env.HF_HOME}) is hidden from the app,`);
+  console.log("       so the launched app uses the default cache path above.");
+}
+
+// ── 2. Build (debug bundle, updater artifacts off → exits 0) ───────────────
+if (dryRun) {
+  console.log(
+    `\n▷ would ${skipBuild ? "skip the build (--skip-build)" : `build: bun run --cwd frontend ${tauriBuildArgs("darwin").join(" ")}`}`,
+  );
+} else if (skipBuild) {
+  console.log("\n⏭️  Skipping build (--skip-build)");
+} else {
+  console.log("\n🔨 Building debug bundle (updater artifacts disabled)...");
+  // Remove the stale bundle so we never accidentally launch old code.
+  rmSync(appBundle, { recursive: true, force: true });
+  // #962: invoke the Tauri CLI via the frontend workspace's `tauri` script,
+  // not `bunx tauri` (bunx can fetch the unrelated npm `tauri` v1 package).
+  const res = spawnSync("bun", ["run", "--cwd", "frontend", ...tauriBuildArgs("darwin")], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  if (res.status !== 0) {
+    console.error(`\n❌ Build failed (exit ${res.status ?? `signal ${res.signal}`}).`);
+    process.exit(res.status ?? 1);
+  }
+  console.log("✅ Build complete.");
+}
+
+// ── 3. Camouflage banner + launch ──────────────────────────────────────────
+const env = sanitizedEnv(process.env);
+const hidden = hiddenFrom(process.env);
+
+console.log("\n🥸 Dev-machine camouflage — the app will NOT see:");
+console.log(
+  `   PATH entries: ${hidden.pathEntries.length > 0 ? hidden.pathEntries.join(", ") : "(none were on your PATH)"}`,
+);
+console.log(
+  `   Env vars:     ${hidden.vars.length > 0 ? hidden.vars.join(", ") : "(none were set)"}`,
+);
+console.log("   ⚠ Limitation: the backend re-prepends /opt/homebrew/bin + /usr/local/bin to");
+console.log("     its own PATH when those dirs exist (backend/core/config.py), so brew");
+console.log("     ffmpeg/yt-dlp may still be visible to the backend. Full isolation needs a");
+console.log("     clean VM or a separate macOS user account.");
+
+const innerBinary = join(appBundle, "Contents", "MacOS", "omnivoice-studio");
+if (dryRun) {
+  console.log(`\n▷ would launch (direct exec, sanitized env): ${innerBinary}`);
+  if (launchArgs.length > 0) console.log(`  with args: ${launchArgs.join(" ")}`);
+  console.log("\n✅ Dry run complete — nothing was removed, built, or launched.");
+  process.exit(0);
+}
+
+if (!existsSync(innerBinary)) {
+  console.error(`\n❌ No app bundle at ${appBundle}.\n   Run without --skip-build first.`);
+  process.exit(1);
+}
+
+console.log(`\n🚀 Launching ${APP_NAME} as a brand-new user...`);
+console.log(`   Binary: ${innerBinary}`);
+// Direct exec (NOT `open`) so the sanitized env actually reaches the app —
+// see the header comment. detached+unref lets this script exit while the
+// app keeps running, like `open` would.
+const child = spawn(innerBinary, launchArgs, { env, detached: true, stdio: "ignore" });
+child.unref();
+
+console.log("\n✅ App launched in new-user mode. Check the splash for a full bootstrap.");
+console.log("   To re-launch without rebuilding: bun desktop-fresh:run");

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -12,6 +12,10 @@
 #   bun desktop-prod          # build debug + wipe + launch
 #   bun desktop-prod:run      # re-launch last build (skip compile)
 #   bun desktop-prod:upgrade  # rebuild, but keep data (test upgrade)
+#
+# For a stricter NEW-USER emulation on macOS (webview localStorage, prefs,
+# caches wiped too + launch with a dev-tools-hidden environment), see
+# `bun desktop-fresh` (scripts/desktop-fresh.mjs).
 # ──────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -90,10 +94,28 @@ for arg in "$@"; do
       echo "                 HF model cache — fresh first-run without re-downloading"
       echo "                 the multi-GB weights. Ignored when --keep-data is set."
       echo "  --pill         Launch in dictation-widget mode (no main window)"
+      echo ""
+      echo "Environment:"
+      echo "  FRESH_NUKE_HF=1  Also wipe the HF cache when it is the SHARED global"
+      echo "                   cache (~/.cache/huggingface). By default only an"
+      echo "                   OmniVoice-scoped cache path is removed."
       exit 0
       ;;
   esac
 done
+
+# Is a path unambiguously OmniVoice-scoped (safe to auto-delete)? The HF
+# cache defaults to the SHARED ~/.cache/huggingface on macOS/Linux — the app
+# only relocates it on Windows (backend/core/config.py) — and HF_HOME can
+# point anywhere. Wiping a shared cache would delete models unrelated to
+# OmniVoice, so non-scoped paths are kept unless FRESH_NUKE_HF=1.
+# (Kept in sync with isAppScoped() in scripts/desktop-common.mjs.)
+is_app_scoped() {
+  case "$1" in
+    *[Oo]mni[Vv]oice*|*com.debpalash*) return 0 ;;
+    *)                                 return 1 ;;
+  esac
+}
 
 # ── Wipe app data for fresh-install simulation ─────────────────────────────
 if [ "$KEEP_DATA" = false ]; then
@@ -102,7 +124,7 @@ if [ "$KEEP_DATA" = false ]; then
 
   # 1. App data (Tauri bundle dir: post-install venv + webview state)
   if [ -d "${APP_DATA}" ]; then
-    echo "   ✗ App data:     ${APP_DATA}"
+    echo "   ✓ App data:     ${APP_DATA} — removed"
     rm -rf "${APP_DATA}"
   else
     echo "   ○ App data:     (already clean)"
@@ -112,7 +134,7 @@ if [ "$KEEP_DATA" = false ]; then
   #     — separate dir hardcoded in backend/core/config.py, NOT under APP_ID.
   if [ -d "${BACKEND_DATA}" ]; then
     BD_SIZE=$(du -sh "${BACKEND_DATA}" 2>/dev/null | cut -f1)
-    echo "   ✗ Backend data: ${BACKEND_DATA} (${BD_SIZE})"
+    echo "   ✓ Backend data: ${BACKEND_DATA} (${BD_SIZE}) — removed"
     rm -rf "${BACKEND_DATA}"
   else
     echo "   ○ Backend data: (already clean)"
@@ -122,6 +144,9 @@ if [ "$KEEP_DATA" = false ]; then
   #    --keep-models preserves it so a "fresh app" run doesn't re-pull multi-GB
   #    weights (the model-download is the slow, bandwidth-heavy part of a clean
   #    run; everything else still resets for an honest first-run emulation).
+  #    Only an OmniVoice-scoped path is auto-removed: on macOS/Linux the app
+  #    uses the SHARED ~/.cache/huggingface, which also holds models from
+  #    other projects — wiping it needs the explicit FRESH_NUKE_HF=1 opt-in.
   if [ "$KEEP_MODELS" = true ]; then
     if [ -d "${HF_CACHE}" ]; then
       HF_SIZE=$(du -sh "${HF_CACHE}" 2>/dev/null | cut -f1)
@@ -129,17 +154,23 @@ if [ "$KEEP_DATA" = false ]; then
     else
       echo "   ○ HF cache:     (already clean)"
     fi
-  elif [ -d "${HF_CACHE}" ]; then
+  elif [ ! -d "${HF_CACHE}" ]; then
+    echo "   ○ HF cache:     (already clean)"
+  elif is_app_scoped "${HF_CACHE}" || [ "${FRESH_NUKE_HF:-0}" = "1" ]; then
     HF_SIZE=$(du -sh "${HF_CACHE}" 2>/dev/null | cut -f1)
-    echo "   ✗ HF cache:     ${HF_CACHE} (${HF_SIZE})"
+    echo "   ✓ HF cache:     ${HF_CACHE} (${HF_SIZE}) — removed"
     rm -rf "${HF_CACHE}"
   else
-    echo "   ○ HF cache:     (already clean)"
+    HF_SIZE=$(du -sh "${HF_CACHE}" 2>/dev/null | cut -f1)
+    echo "   ◆ HF cache:     ${HF_CACHE} (${HF_SIZE}) — KEPT (shared global cache)"
+    echo "     ↳ Not OmniVoice-scoped; wiping it would delete models unrelated to"
+    echo "       this app. Models will be REUSED, not re-downloaded. To wipe anyway:"
+    echo "       FRESH_NUKE_HF=1 bun desktop-prod"
   fi
 
   # 3. Tauri log dir
   if [ -d "${TAURI_LOGS}" ]; then
-    echo "   ✗ Tauri logs:   ${TAURI_LOGS}"
+    echo "   ✓ Tauri logs:   ${TAURI_LOGS} — removed"
     rm -rf "${TAURI_LOGS}"
   else
     echo "   ○ Tauri logs:   (already clean)"
@@ -147,7 +178,7 @@ if [ "$KEEP_DATA" = false ]; then
 
   # 4. WebView cache / local storage
   if [ -d "${WEBKIT_DATA}" ]; then
-    echo "   ✗ WebKit data:  ${WEBKIT_DATA}"
+    echo "   ✓ WebKit data:  ${WEBKIT_DATA} — removed"
     rm -rf "${WEBKIT_DATA}"
   else
     echo "   ○ WebKit data:  (already clean)"
@@ -164,10 +195,14 @@ if [ "$SKIP_BUILD" = false ]; then
   echo ""
   echo "🔨 Building debug bundle (this takes 1-3 min first time)..."
 
-  # Remove stale bundle so we never accidentally launch old code
+  # Remove stale bundles so we never accidentally launch old code
   if [ "$PLATFORM" = "macos" ]; then
     APP_BUNDLE="${TAURI_DIR}/target/debug/bundle/macos/${APP_NAME}.app"
     [ -d "$APP_BUNDLE" ] && rm -rf "$APP_BUNDLE"
+  elif [ "$PLATFORM" = "linux" ]; then
+    # A stale AppImage would be picked up by the `find` in the launch step
+    # below even if this build's bundling fails (tolerated case — see grep).
+    rm -rf "${TAURI_DIR}/target/debug/bundle/appimage"
   fi
 
   # Linux: linuxdeploy uses FUSE to mount itself; if FUSE is unavailable
@@ -177,9 +212,17 @@ if [ "$SKIP_BUILD" = false ]; then
     export APPIMAGE_EXTRACT_AND_RUN=1
   fi
 
-  # The build creates the bundle successfully, but then may fail trying
-  # to sign the updater artifact (no TAURI_SIGNING_PRIVATE_KEY) or to
-  # run linuxdeploy. The binary itself is fine — tolerate known errors.
+  # Local emulation builds must exit 0, so:
+  #   - createUpdaterArtifacts is overridden to false (inline --config merge,
+  #     mirrors bundle.createUpdaterArtifacts in tauri.conf.json; kept in sync
+  #     with UPDATER_ARTIFACTS_OFF in scripts/desktop-common.mjs). Dev
+  #     machines have no TAURI_SIGNING_PRIVATE_KEY, so the updater-artifact
+  #     signing step used to fail the build AFTER all bundles were produced.
+  #     Local runs never need updater artifacts — release.yml builds and
+  #     signs them.
+  #   - only the bundle this script launches is built: .app on macOS (no
+  #     dmg), AppImage on Linux (no deb — its bundling is broken in
+  #     tauri-cli, see release.yml), nothing on Windows (raw debug .exe).
   # #962: invoke the Tauri CLI via the frontend workspace's `tauri` script,
   # NOT `bunx tauri`. In the bun workspace monorepo `@tauri-apps/cli` is a
   # frontend/package.json dependency, and `bunx` resolves by npm package
@@ -187,21 +230,32 @@ if [ "$SKIP_BUILD" = false ]; then
   # falls back to fetching the unrelated `tauri` (v1) package from npm and
   # dies with "could not determine executable to run for package tauri".
   # `bun run --cwd frontend tauri` always resolves the workspace-local CLI.
+  UPDATER_ARTIFACTS_OFF='{"bundle":{"createUpdaterArtifacts":false}}'
+  case "$PLATFORM" in
+    macos)   BUNDLE_FLAGS=(--bundles app) ;;
+    linux)   BUNDLE_FLAGS=(--bundles appimage) ;;
+    windows) BUNDLE_FLAGS=(--no-bundle) ;;
+  esac
   BUILD_LOG=$(mktemp)
   set +e
-  bun run --cwd frontend tauri build --debug 2>&1 | tee "$BUILD_LOG"
-  BUILD_EXIT=$?
+  bun run --cwd frontend tauri build --debug "${BUNDLE_FLAGS[@]}" \
+    --config "$UPDATER_ARTIFACTS_OFF" 2>&1 | tee "$BUILD_LOG"
+  BUILD_EXIT=$?  # pipefail is on (set -euo pipefail) → the build's status, not tee's
   set -e
   if [ $BUILD_EXIT -ne 0 ]; then
-    # Known-harmless failures:
-    #   - Missing TAURI_SIGNING_PRIVATE_KEY (updater signing)
-    #   - "failed to run linuxdeploy" (AppImage bundling — binary still works)
-    if grep -qi "TAURI_SIGNING_PRIVATE_KEY\|private key\|failed to run linuxdeploy\|failed to bundle" "$BUILD_LOG"; then
-      echo "⚠️  Non-fatal bundle error — binary is fine (see above for details)."
+    # The ONLY tolerated failure, specifically detected: linuxdeploy needs
+    # FUSE and can still die in containers/hardened kernels despite
+    # APPIMAGE_EXTRACT_AND_RUN=1. Tolerate it only when the raw debug binary
+    # was actually produced — the launch step below falls back to it.
+    # Anything else (compile error, config error, signing, …) fails loudly.
+    if [ "$PLATFORM" = "linux" ] \
+       && grep -qi "failed to run linuxdeploy" "$BUILD_LOG" \
+       && [ -f "${TAURI_DIR}/target/debug/omnivoice-studio" ]; then
+      echo "⚠️  AppImage packaging failed (linuxdeploy/FUSE) — falling back to the raw debug binary."
     else
       echo "❌ Build failed with exit code $BUILD_EXIT"
       rm -f "$BUILD_LOG"
-      exit $BUILD_EXIT
+      exit "$BUILD_EXIT"
     fi
   fi
   rm -f "$BUILD_LOG"
@@ -227,11 +281,13 @@ if [ "$PLATFORM" = "macos" ]; then
     echo ""
     echo "🚀 Launching ${APP_NAME} (.app bundle)..."
     echo "   Bundle: ${APP_BUNDLE}"
-    # macOS `open` needs -n to spawn a fresh instance, --args to forward flags.
+    # macOS `open` needs -n to spawn a fresh instance (plain `open` would just
+    # focus an already-running one — stale process, freshly wiped data),
+    # --args to forward flags.
     if [ ${#LAUNCH_ARGS[@]} -gt 0 ]; then
       open -n "$APP_BUNDLE" --args "${LAUNCH_ARGS[@]}"
     else
-      open "$APP_BUNDLE"
+      open -n "$APP_BUNDLE"
     fi
   elif [ -f "$BINARY" ]; then
     echo ""

--- a/tests/frontend/desktopScripts.test.mjs
+++ b/tests/frontend/desktopScripts.test.mjs
@@ -1,0 +1,163 @@
+// Unit tests for scripts/desktop-common.mjs — the pure helpers behind the
+// local desktop launcher scripts (desktop-fresh.mjs / desktop-prod.sh).
+//
+// The load-bearing guarantees:
+//   * every path the fresh script may delete is app-scoped (contains
+//     "omnivoice" or "com.debpalash") and lives under the given home dir —
+//     a typo can never widen a rm -rf beyond OmniVoice's own traces;
+//   * the PATH sanitizer strips exactly the intended dev-tool prefixes and
+//     preserves order otherwise;
+//   * the env sanitizer removes exactly the HF/OMNIVOICE keys, nothing else.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  APP_ID,
+  STRIPPED_PATH_ENTRIES,
+  STRIPPED_ENV_VARS,
+  UPDATER_ARTIFACTS_OFF,
+  hiddenFrom,
+  isAppScoped,
+  macosFreshTraces,
+  sanitizedEnv,
+  sanitizedPath,
+  tauriBuildArgs,
+} from '../../scripts/desktop-common.mjs';
+
+const HOME = '/Users/testuser';
+
+test('every fresh-trace path is app-scoped and under home', () => {
+  const traces = macosFreshTraces(HOME);
+  assert.ok(traces.length >= 8, 'expected the full trace list');
+  for (const { path } of traces) {
+    assert.ok(path.startsWith(`${HOME}/`), `not under home: ${path}`);
+    // The scoping must come from the path BELOW home, not from home itself.
+    const rel = path.slice(HOME.length);
+    assert.ok(isAppScoped(rel), `not app-scoped below home: ${path}`);
+  }
+});
+
+test('fresh traces cover every macOS install remnant', () => {
+  const paths = macosFreshTraces(HOME).map((t) => t.path);
+  const mustCover = [
+    `${HOME}/Library/Application Support/${APP_ID}`, // Tauri app data
+    `${HOME}/Library/Application Support/OmniVoice`, // backend data
+    `${HOME}/Library/Logs/${APP_ID}`,
+    `${HOME}/Library/WebKit/${APP_ID}`, // webview localStorage
+    `${HOME}/Library/Caches/${APP_ID}`,
+    `${HOME}/Library/HTTPStorages/${APP_ID}`,
+    `${HOME}/Library/Preferences/${APP_ID}.plist`,
+    `${HOME}/Library/Saved Application State/${APP_ID}.savedState`,
+  ];
+  for (const p of mustCover) {
+    assert.ok(paths.includes(p), `missing trace: ${p}`);
+  }
+  // HTTPStorages must be prefix-matched (dir AND .binarycookies file).
+  const http = macosFreshTraces(HOME).find((t) => t.path.includes('HTTPStorages'));
+  assert.equal(http.kind, 'prefix');
+});
+
+test('isAppScoped accepts app dirs, rejects shared paths', () => {
+  assert.ok(isAppScoped(`/x/Library/Caches/${APP_ID}`));
+  assert.ok(isAppScoped('/x/Library/Application Support/OmniVoice'));
+  assert.ok(isAppScoped('C:/Users/u/AppData/Local/OmniVoice/hf_cache'));
+  assert.ok(!isAppScoped(`${HOME}/.cache/huggingface`)); // shared global HF cache
+  assert.ok(!isAppScoped(`${HOME}/Library`));
+  assert.ok(!isAppScoped(''));
+});
+
+test('sanitizedPath strips exactly the dev-tool entries, keeps order', () => {
+  const input = [
+    '/opt/homebrew/bin',
+    '/usr/bin',
+    '/opt/homebrew/sbin',
+    '/bin',
+    '/usr/local/bin',
+    '/usr/sbin',
+    '/sbin',
+  ].join(':');
+  assert.equal(sanitizedPath(input), '/usr/bin:/bin:/usr/sbin:/sbin');
+});
+
+test('sanitizedPath normalises trailing slashes but not look-alikes', () => {
+  assert.equal(
+    sanitizedPath('/usr/local/bin/:/usr/bin:/opt/homebrew/bin//'),
+    '/usr/bin',
+  );
+  // Prefix look-alikes and subdirectories must survive.
+  assert.equal(
+    sanitizedPath('/usr/local/bin-extra:/usr/local/bin/sub:/opt/homebrew/binx'),
+    '/usr/local/bin-extra:/usr/local/bin/sub:/opt/homebrew/binx',
+  );
+  assert.equal(sanitizedPath(''), '');
+});
+
+test('sanitizedEnv removes exactly the HF and OMNIVOICE_* keys', () => {
+  const input = {
+    HOME: '/Users/testuser',
+    USER: 'testuser',
+    PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+    HF_TOKEN: 'x',
+    HUGGING_FACE_HUB_TOKEN: 'x',
+    HF_HOME: '/tmp/hf',
+    HF_HUB_CACHE: '/tmp/hf/hub',
+    HF_ENDPOINT: 'https://example.invalid',
+    OMNIVOICE_DATA_DIR: '/tmp/ov',
+    OMNIVOICE_CACHE_DIR: '/tmp/ovc',
+    // Look-alikes that must survive:
+    HF_TOKENX: 'keep',
+    MY_HF_TOKEN: 'keep',
+    OMNIVOICEX: 'keep', // no underscore → not the OMNIVOICE_ prefix
+  };
+  const out = sanitizedEnv(input);
+  for (const key of STRIPPED_ENV_VARS) assert.ok(!(key in out), `should strip ${key}`);
+  assert.ok(!('OMNIVOICE_DATA_DIR' in out));
+  assert.ok(!('OMNIVOICE_CACHE_DIR' in out));
+  assert.equal(out.HOME, '/Users/testuser');
+  assert.equal(out.USER, 'testuser');
+  assert.equal(out.HF_TOKENX, 'keep');
+  assert.equal(out.MY_HF_TOKEN, 'keep');
+  assert.equal(out.OMNIVOICEX, 'keep');
+  assert.equal(out.PATH, '/usr/bin:/bin'); // PATH sanitized too
+  // Input must not be mutated.
+  assert.equal(input.HF_TOKEN, 'x');
+  assert.equal(input.PATH, '/opt/homebrew/bin:/usr/bin:/bin');
+});
+
+test('hiddenFrom reports only what is actually present', () => {
+  const { vars, pathEntries } = hiddenFrom({
+    PATH: '/usr/bin:/opt/homebrew/bin',
+    HF_TOKEN: 'x',
+    OMNIVOICE_DATA_DIR: '/tmp',
+    HOME: '/Users/testuser',
+  });
+  assert.deepEqual(vars.sort(), ['HF_TOKEN', 'OMNIVOICE_DATA_DIR']);
+  assert.deepEqual(pathEntries, ['/opt/homebrew/bin']);
+  const empty = hiddenFrom({ HOME: '/Users/testuser' });
+  assert.deepEqual(empty.vars, []);
+  assert.deepEqual(empty.pathEntries, []);
+});
+
+test('tauriBuildArgs builds only the launched bundle, updater artifacts off', () => {
+  const macos = tauriBuildArgs('darwin');
+  assert.deepEqual(macos.slice(0, 3), ['tauri', 'build', '--debug']);
+  assert.ok(macos.join(' ').includes('--bundles app'));
+  assert.deepEqual(tauriBuildArgs('linux').join(' ').includes('--bundles appimage'), true);
+  assert.ok(tauriBuildArgs('win32').includes('--no-bundle'));
+
+  for (const platform of ['darwin', 'linux', 'win32']) {
+    const args = tauriBuildArgs(platform);
+    const config = args[args.indexOf('--config') + 1];
+    // The override must parse and target the exact tauri.conf.json key.
+    assert.deepEqual(JSON.parse(config), { bundle: { createUpdaterArtifacts: false } });
+    assert.equal(config, UPDATER_ARTIFACTS_OFF);
+  }
+});
+
+test('STRIPPED_PATH_ENTRIES are exactly the intended dev prefixes', () => {
+  assert.deepEqual(STRIPPED_PATH_ENTRIES, [
+    '/opt/homebrew/bin',
+    '/opt/homebrew/sbin',
+    '/usr/local/bin',
+  ]);
+});


### PR DESCRIPTION
Two fixes and one new tool for the local prod-emulation scripts:

**`desktop-prod` fixes:**
- The build no longer dies at updater signing: `tauri build --debug` now passes `--config '{"bundle":{"createUpdaterArtifacts":false}}'` + per-platform bundle narrowing (macOS `--bundles app`, Linux `--bundles appimage`, Windows `--no-bundle`). Verified end-to-end: exit 0, .app produced, no updater artifact. Error handling is honest now — nonzero tauri exit fails the script; the single tolerated case (Linux linuxdeploy flakiness with a usable raw binary) is specifically detected, not assumed.
- **Dangerous clean removed:** the script `rm -rf`'d `~/.cache/huggingface` — the *shared global* HF cache on macOS/Linux (the app only relocates its cache on Windows). Shared caches are now preserved with a notice; `FRESH_NUKE_HF=1` opts into wiping. App-scoped caches still auto-clean.
- Cosmetics/correctness: ✓/✗ status marks fixed, `open -n` so a stale running instance isn't focused instead of the new build, stale AppImage removed before rebuild.

**New `bun desktop-fresh`** (+ `:run`, `--dry-run`, `--pill`) — true new-user emulation on macOS (explicit refusal elsewhere):
- Cleans every trace a past install leaves, including `~/Library/WebKit/<app>` — the webview localStorage that survives reinstall (exactly what made this week's dub-restore bug uncatchable in normal testing) — plus Caches, HTTPStorages, Preferences (+`defaults delete`), Saved Application State.
- **Dev-machine camouflage:** direct-execs the bundle binary (`open` drops env) with PATH stripped of homebrew/usr-local and all HF_*/OMNIVOICE_* vars unset, so the app behaves like a machine without your dev tools; banner states what's hidden and the one known limitation (the backend re-prepends brew paths itself — noted for a follow-up).

**Tests:** 9 new node tests (app-scoped-paths guard, PATH/env sanitizers) — CI-style suite 51/51; dry-run exercised on this machine (found 1.8 GB of real traces, removed nothing); docs-drift validator green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `desktop-fresh` and `desktop-fresh:run` for macOS first-run emulation.
- Centralized desktop build, cleanup, app-scope, and environment-sanitization helpers.
- Updated `desktop-prod` with safer Hugging Face cache handling, platform-specific bundles, stricter build failures, stale AppImage cleanup, disabled updater artifacts, and fresh macOS launches.
- Added 9 helper tests; the full suite passes 51/51.

```mermaid
flowchart TD
  A[desktop-prod] --> B[Clean app traces and backend data]
  B --> C[Preserve shared HF cache]
  C --> D[Build platform-specific bundle]
  D --> E[Launch fresh macOS instance]

  F[desktop-fresh] --> G[Validate macOS]
  G --> H[Remove app traces and preferences]
  H --> I[Sanitize PATH and environment]
  I --> J[Directly launch app binary]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->