### PR TITLE
fix(ui): default UI scale is 100% — native size out of the box

### DIFF
--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -101,7 +101,9 @@ export const createUiSlice: StateCreator<UiSlice, [], [], UiSlice> = (set, get) 
   isSidebarProjectsCollapsed: false,
   sidebarTab: 'projects',
   showCheatsheet: false,
-  uiScale: 1.3,
+  // 100% by default — the app renders at native size out of the box; users
+  // who prefer larger UI pick their scale in Settings → Appearance (persisted).
+  uiScale: 1.0,
 
   setMode: (mode) => set({ mode }),
   setDefineMethod: (method) => set({ defineMethod: method }),


### PR DESCRIPTION
New installs rendered at 130% zoom (`uiScale: 1.3` default in `uiSlice.ts`, applied via `zoom` in App.jsx). Fresh sessions now start at **100%**. Existing users are unaffected — `uiScale` is persisted (zustand partialize + `omni_ui`), and the persisted value always wins over the default.

Full frontend suite 1139 passed; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Changed the default UI scale for new installations from 130% to 100% (native sizing).
- Existing users’ persisted `uiScale` preferences continue to take precedence.
- Users can adjust the scale via Settings → Appearance.
- Frontend suite passed with 1,139 tests; typechecking passed.

## UI scale

```text
Before: [ Content rendered at 130% ]
After:  [ Content rendered at 100% ]
        Existing saved preferences remain unchanged
```

## Behavior

```mermaid
flowchart TD
    A[Start application] --> B{Persisted uiScale exists?}
    B -- Yes --> C[Use saved preference]
    B -- No --> D[Use 100% default]
    C --> E[Render UI]
    D --> E
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->