### PR TITLE
fix(shell): deep health probe before attaching to a running backend; scripts kill before wiping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- **The app no longer attaches to a "zombie" backend that looks alive but fails everything.** If a backend process survived while its install was replaced or deleted underneath it, it kept answering health checks from memory — so the next launch attached to it and every real request failed with a confusing access-control error. The launcher now runs a deeper probe (an endpoint that actually touches the database) before attaching, and replaces any backend that fails it. The local dev/test scripts also now terminate running instances before wiping data, which is how this state was produced. (#1077)
+
 - **The app opens at 100% scale by default.** New installs rendered everything at 130% zoom, which read as oversized on typical displays. Fresh sessions now start at native size; if you already picked a scale in Settings → Appearance, your choice is kept. (#1074)
 
 - **The app no longer relaunches into a dead "generating" dub session — the blank-pane-and-spinner trap.** The saved dub session was restoring its in-flight state verbatim: quit (or crash) while a dub was generating and every subsequent launch waited forever for work that died with the process — and reinstalling couldn't clear it. Interrupted sessions now reopen on the segment editor with all your work intact (or the upload screen if nothing was transcribed yet). Thanks to @nanai97 for the screenshot that told the whole story. (#1067)

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -83,7 +83,41 @@ pub fn same_app_version(running: &str) -> bool {
     !running.is_empty() && base(running) == base(env!("CARGO_PKG_VERSION"))
 }
 
+/// Deep health probe for the attach-to-a-running-backend shortcut.
+///
+/// `/health` and `/system/info` keep answering from a backend whose install
+/// was deleted out from under it (files unlinked on disk, code already in
+/// memory) — that zombie passes the version check and then 500s every real
+/// route, so the UI looks alive but nothing works. Probe a DB-touching
+/// endpoint and require an actual `200` status line before attaching;
+/// anything else (500, timeout, refused) means the responder is not a
+/// backend worth keeping.
+pub fn backend_deep_healthy(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{}/profiles", port);
+    match raw_http_get(&url, Duration::from_millis(1500)) {
+        Ok(resp) => parse_http_status(&resp) == Some(200),
+        Err(_) => false,
+    }
+}
+
+/// Status code from a raw HTTP response ("HTTP/1.1 200 OK" → 200).
+fn parse_http_status(response: &str) -> Option<u16> {
+    let line = response.lines().next()?;
+    line.split_whitespace().nth(1)?.parse().ok()
+}
+
 fn ureq_get_with_timeout(url: &str, timeout: Duration) -> Result<String, String> {
+    let buf = raw_http_get(url, timeout)?;
+    if let Some(idx) = buf.find("\r\n\r\n") {
+        Ok(buf[idx + 4..].to_string())
+    } else {
+        Err("no body".into())
+    }
+}
+
+/// One raw loopback HTTP GET, returning the FULL response (status line +
+/// headers + body). Kept dependency-free on purpose — see module docs.
+fn raw_http_get(url: &str, timeout: Duration) -> Result<String, String> {
     let url = url.strip_prefix("http://").ok_or("only http:// supported")?;
     let (host_port, path) = match url.find('/') {
         Some(i) => (&url[..i], &url[i..]),
@@ -112,11 +146,7 @@ fn ureq_get_with_timeout(url: &str, timeout: Duration) -> Result<String, String>
     stream.write_all(req.as_bytes()).map_err(|e| e.to_string())?;
     let mut buf = String::new();
     stream.read_to_string(&mut buf).map_err(|e| e.to_string())?;
-    if let Some(idx) = buf.find("\r\n\r\n") {
-        Ok(buf[idx + 4..].to_string())
-    } else {
-        Err("no body".into())
-    }
+    Ok(buf)
 }
 
 /// Kill whatever process owns the port.
@@ -426,6 +456,17 @@ mod tests {
         // pre-app_version backends and foreign bodies yield None
         assert_eq!(parse_app_version(r#"{"data_dir":"/x"}"#), None);
         assert_eq!(parse_app_version("<html>not json</html>"), None);
+    }
+
+    #[test]
+    fn parse_http_status_reads_the_status_line_only() {
+        assert_eq!(super::parse_http_status("HTTP/1.1 200 OK\r\nX: 500\r\n\r\nbody"), Some(200));
+        assert_eq!(
+            super::parse_http_status("HTTP/1.1 500 Internal Server Error\r\n\r\nInternal Server Error"),
+            Some(500)
+        );
+        assert_eq!(super::parse_http_status("garbage"), None);
+        assert_eq!(super::parse_http_status(""), None);
     }
 
     #[test]

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -148,12 +148,24 @@ pub fn retry_bootstrap(app: tauri::AppHandle, state: tauri::State<'_, BootstrapS
         }
         match crate::backend::running_backend_version(backend_port()) {
             Some(v) if crate::backend::same_app_version(&v) => {
-                log::info!(
-                    "Port {} already serving OmniVoice backend v{} — attaching",
+                if crate::backend::backend_deep_healthy(backend_port()) {
+                    log::info!(
+                        "Port {} already serving OmniVoice backend v{} — attaching",
+                        backend_port(), v
+                    );
+                    set_stage(&stage_handle, BootstrapStage::Ready);
+                    return;
+                }
+                // Same version but a DB-touching probe fails: a backend whose
+                // install was wiped/corrupted while it kept running. Attaching
+                // would look alive and 500 on everything — replace it.
+                log::warn!(
+                    "Port {} serves OmniVoice v{} but failed the deep health probe — replacing it",
                     backend_port(), v
                 );
-                set_stage(&stage_handle, BootstrapStage::Ready);
-                return;
+                    set_backend_kill_intended(true); // deliberate kill, not a crash (#941)
+                crate::backend::kill_orphan_on_port(backend_port());
+                std::thread::sleep(Duration::from_millis(500));
             }
             Some(v) => {
                 // A healthy-but-stale backend from a previous version (the

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -807,12 +807,23 @@ pub fn run() {
                 }
                 match backend::running_backend_version(backend_port()) {
                     Some(v) if backend::same_app_version(&v) => {
-                        log::info!(
-                            "Port {} already serving OmniVoice backend v{} — attaching",
+                        if backend::backend_deep_healthy(backend_port()) {
+                            log::info!(
+                                "Port {} already serving OmniVoice backend v{} — attaching",
+                                backend_port(), v
+                            );
+                            set_stage(&stage_handle, BootstrapStage::Ready);
+                            return;
+                        }
+                        // Same version but a DB-touching probe fails: a backend whose
+                        // install was wiped/corrupted while it kept running. Attaching
+                        // would look alive and 500 on everything — replace it.
+                        log::warn!(
+                            "Port {} serves OmniVoice v{} but failed the deep health probe — replacing it",
                             backend_port(), v
                         );
-                        set_stage(&stage_handle, BootstrapStage::Ready);
-                        return;
+                        backend::kill_orphan_on_port(backend_port());
+                        std::thread::sleep(Duration::from_millis(500));
                     }
                     Some(v) => {
                         // Healthy-but-stale backend from a previous version —

--- a/scripts/desktop-fresh.mjs
+++ b/scripts/desktop-fresh.mjs
@@ -129,18 +129,51 @@ function sizeOf(p) {
   return size ? ` (${size})` : "";
 }
 
-// ── Refuse-footgun check: is the app running? ──────────────────────────────
-// Wiping data under a live instance lets its open file handles resurrect
-// state after we "cleaned" it — warn (don't kill the user's processes).
+// ── Kill-before-wipe: never clean under a live instance ────────────────────
+// Wiping data under a running app leaves a ZOMBIE backend: its code is in
+// memory, /health keeps answering, and the next launch happily attaches to
+// it — then every real route 500s off deleted site-packages and an empty DB
+// (observed 2026-07-11). Terminate app + backend first; --dry-run only reports.
 {
-  const pg = spawnSync("pgrep", ["-f", `${APP_NAME}.app|target/debug/omnivoice-studio`], {
-    encoding: "utf8",
-  });
-  if (pg.status === 0) {
-    console.warn(
-      `⚠️  ${APP_NAME} appears to be RUNNING (pids: ${pg.stdout.trim().split("\n").join(", ")}).\n` +
-        "   Quit it first — a live instance can rewrite the data being wiped.\n",
-    );
+  const patterns = [`${APP_NAME}.app`, "target/debug/omnivoice-studio"];
+  /** PIDs of our own processes: bundle/dev-binary matches + any 3900 listener
+   *  whose command is app-scoped (never a foreign process on the port). */
+  const findPids = () => {
+    const pids = new Set();
+    for (const pat of patterns) {
+      const pg = spawnSync("pgrep", ["-f", pat], { encoding: "utf8" });
+      if (pg.status === 0)
+        for (const pid of pg.stdout.trim().split("\n")) if (pid) pids.add(pid);
+    }
+    const lsof = spawnSync("lsof", ["-nP", "-iTCP:3900", "-sTCP:LISTEN", "-t"], {
+      encoding: "utf8",
+    });
+    if (lsof.status === 0) {
+      for (const pid of lsof.stdout.trim().split("\n")) {
+        if (!pid) continue;
+        const cmd = spawnSync("ps", ["-p", pid, "-o", "command="], { encoding: "utf8" }).stdout;
+        if (/omnivoice|com\.debpalash/i.test(cmd)) pids.add(pid);
+      }
+    }
+    return [...pids];
+  };
+  const pids = findPids();
+  if (pids.length > 0) {
+    if (DRY_RUN) {
+      console.log(`🔪 Would terminate running ${APP_NAME} processes: ${pids.join(", ")}\n`);
+    } else {
+      console.log(`🔪 Terminating running ${APP_NAME} processes (${pids.join(", ")})...`);
+      for (const pid of pids) spawnSync("kill", [pid]);
+      // Grace period, then force anything still alive.
+      const deadline = Date.now() + 5000;
+      let alive = pids;
+      while (alive.length > 0 && Date.now() < deadline) {
+        spawnSync("sleep", ["0.5"]);
+        alive = alive.filter((pid) => spawnSync("kill", ["-0", pid]).status === 0);
+      }
+      for (const pid of alive) spawnSync("kill", ["-9", pid]);
+      console.log("   All stopped — safe to wipe.\n");
+    }
   }
 }
 

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -117,8 +117,41 @@ is_app_scoped() {
   esac
 }
 
+# ── Kill-before-wipe: never clean under a live instance ────────────────────
+# A backend that survives the wipe becomes a zombie: /health keeps answering
+# from memory, the next launch attaches to it, and every real route 500s off
+# deleted files + an empty DB. Terminate our own processes first.
+kill_running_instances() {
+  local pids=""
+  pids="$(pgrep -f "${APP_NAME}.app|target/debug/omnivoice-studio" 2>/dev/null || true)"
+  local port_pid
+  for port_pid in $(lsof -nP -iTCP:3900 -sTCP:LISTEN -t 2>/dev/null || true); do
+    if ps -p "$port_pid" -o command= 2>/dev/null | grep -qiE 'omnivoice|com\.debpalash'; then
+      pids="$pids $port_pid"
+    fi
+  done
+  # shellcheck disable=SC2086
+  pids="$(echo $pids | tr ' ' '\n' | sort -u | tr '\n' ' ')"
+  [ -z "${pids// /}" ] && return 0
+  echo "🔪 Terminating running OmniVoice processes:$pids"
+  # shellcheck disable=SC2086
+  kill $pids 2>/dev/null || true
+  local i=0
+  while [ $i -lt 10 ]; do
+    sleep 0.5
+    # shellcheck disable=SC2086
+    if ! kill -0 $pids 2>/dev/null; then break; fi
+    i=$((i + 1))
+  done
+  # shellcheck disable=SC2086
+  kill -9 $pids 2>/dev/null || true
+  echo "   All stopped — safe to wipe."
+  echo ""
+}
+
 # ── Wipe app data for fresh-install simulation ─────────────────────────────
 if [ "$KEEP_DATA" = false ]; then
+  kill_running_instances
   echo "🧹 Cleaning all OmniVoice data for fresh prod emulation..."
   echo ""
 


### PR DESCRIPTION
Found live by `bun desktop-fresh` on its first real outing: the wipe ran while a backend from an earlier launch was still running. That process kept serving `/health` and `/system/info` from memory (correct version and all), so the next launch **attached to a zombie** whose site-packages and database had been deleted — every real route returned a raw 500 without CORS headers, which the webview surfaced as `Origin tauri://localhost is not allowed` spam. This is also the durable fix for the "bound port blocks the new version" class beyond version mismatches.

**Shell (Rust):**
- New `backend_deep_healthy()` — probes `/profiles` (touches the DB) and requires an actual `HTTP 200` **status line**; the raw HTTP helper previously discarded the status entirely, returning 500 bodies as `Ok`. New `parse_http_status()` + unit test (63 Rust tests pass).
- Both attach sites (startup in `lib.rs`, `retry_bootstrap` in `bootstrap.rs`): same-version backends must also pass the deep probe; failures log `failed the deep health probe — replacing it` and go through the existing kill-orphan + spawn path (kill-intent flag preserved where the site sets it).

**Scripts:**
- `desktop-prod.sh` / `desktop-fresh.mjs` now **terminate our own running instances** (app bundle, dev binary, and any port-3900 listener whose command is app-scoped) with a 5s grace then SIGKILL, *before* wiping — warn-only was how the zombie got made. `--dry-run` only reports. Script tests still 9/9; `bash -n` clean; dry-run exercised.

Changelog entry included (nothing else in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added deep `/profiles` health checks requiring HTTP 200 before attaching to same-version backends.
- Replaces unhealthy zombie backends during startup and retry flows.
- Terminates app-owned processes before fresh-install wipes, with a 5-second grace period followed by `SIGKILL`.
- Preserves dry-run reporting and adds changelog coverage.
- Added HTTP status parsing tests.

```mermaid
flowchart TD
  A[Find existing backend] --> B{Same app version?}
  B -- No --> C[Continue startup]
  B -- Yes --> D[Probe /profiles]
  D --> E{HTTP 200?}
  E -- Yes --> F[Attach and become Ready]
  E -- No --> G[Kill orphan backend]
  G --> C
```

## Validation

- 63 Rust tests passing
- 9/9 script tests passing
- Clean `bash -n` validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->