### PR TITLE
fix(scripts): desktop-fresh kill guard referenced the wrong dry-run flag

### DIFF
--- a/scripts/desktop-fresh.mjs
+++ b/scripts/desktop-fresh.mjs
@@ -159,7 +159,7 @@ function sizeOf(p) {
   };
   const pids = findPids();
   if (pids.length > 0) {
-    if (DRY_RUN) {
+    if (dryRun) {
       console.log(`🔪 Would terminate running ${APP_NAME} processes: ${pids.join(", ")}\n`);
     } else {
       console.log(`🔪 Terminating running ${APP_NAME} processes (${pids.join(", ")})...`);


### PR DESCRIPTION
One-line fix: the kill-before-wipe block from #1077 referenced `DRY_RUN`; the script's actual flag is `dryRun`, so any run with a live instance crashed with a ReferenceError before wiping. Dry-run re-verified (correctly detects and reports a running instance); script tests 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed the `desktop-fresh` kill-before-wipe guard to use the defined `dryRun` flag instead of undefined `DRY_RUN`.
- Prevented `ReferenceError` when a live instance is detected.
- Preserved dry-run messaging and enabled live wiping to proceed.
- Verified all 9 script tests pass.

## Behavior

```mermaid
flowchart TD
  A[Live instance detected] --> B{dryRun enabled?}
  B -- Yes --> C[Print Would terminate message]
  B -- No --> D[Terminate processes]
  D --> E[Proceed with wipe]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->