### PR TITLE
release: freeze v0.3.17 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.3.17] — 2026-07-11
+
+The polish release. The dubbing workspace can no longer trap you — an interrupted dub session used to relaunch into an eternal spinner that even reinstalling couldn't clear (thank you @nanai97 for the screenshot that cracked it). A 58-finding audit of every Settings panel got fixed end to end, **FFmpeg and yt-dlp stopped being your problem** (the app provisions its own, with a new Audio tools panel when you want control), the Engines and Models pages went compact and tabbed, the launcher stopped trusting half-dead backends, and the app finally opens at 100% scale.
 
 ### Added
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.16"
+_FALLBACK_VERSION = "0.3.17"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.16"
+version = "0.3.17"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.16"
+version = "0.3.17"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.16"
+version = "0.3.17"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Freeze for **v0.3.17** ("the polish release"). Version bumped across all four lockstep files + `uv.lock`/`Cargo.lock`; `[Unreleased]` renamed to `[0.3.17] — 2026-07-11` with the headline paragraph.

Contents since 0.3.16: the dub-trap fix (#1067), the 58-finding settings sweep (#1059–#1064), invisible media tools + Audio tools panel (#1071), compact tabbed Engines/Models (#1058/#1072), 100% default scale (#1074), zombie-backend deep-probe + script hardening (#1077/#1078), Models/Engines feature pass (#1058).

Gates run BEFORE version mutations: backend `tests/` **2770 passed** + `backend/tests/` **129 passed** (real exit codes), frontend **1139 passed** + node **51 passed**, typecheck/lint/format clean, lockstep test green after the bump. Blank-slate first-run smoked live via `desktop-fresh` (deep-healthy backend in ~10 s, preflight shows no tool rows, media engine ready via sidecar).

Tag `v0.3.17` goes on main immediately after this merges; `AUTO_VERSION_BUMP` stays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Released version `0.3.17` across Python, frontend, Tauri, and lock files.
- Updated the changelog with the `0.3.17` release entry dated 2026-07-11.
- Captured fixes and features from 0.3.16, including dubbing stability, Settings cleanup, Audio tools, compact navigation, default 100% scaling, backend health checks, and Models/Engines improvements.
- Validation passed across backend, frontend, Node, typecheck, lint, formatting, lockstep, and blank-slate smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->