### PR TITLE
fix(docker): ship alembic.ini in the image, add an image-level HEALTHCHECK

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -58,12 +58,22 @@ RUN uv pip install --system --no-cache .
 # Copy application source
 COPY backend/ ./backend/
 COPY omnivoice/ ./omnivoice/
+# Alembic config so schema migrations run natively on existing volumes
+# (without it the backend fell back to the additive-column self-heal —
+# functional, but the real migration chain is the first-class path).
+COPY alembic.ini ./
 
 # Copy the pre-built React frontend from the builder stage
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 
 # Expose the single unified API and UI port
 EXPOSE 3900
+
+# Image-level health probe (compose files define their own; this covers plain
+# `docker run`). Generous start period: first boot creates the venv-less
+# schema + may pull model metadata before /health answers.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=5 \
+  CMD curl -fsS http://127.0.0.1:3900/health || exit 1
 
 # Mount points for persistent data (sqlite db, user voices, huggingface cache)
 VOLUME ["/app/omnivoice_data"]

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -13,7 +13,7 @@ and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palash
 > |-----|--------------|
 > | `:latest` | **Rolling preview** — latest commit on `main` (always one patch ahead of the last release). This is the preview channel; pin `:stable` for production. |
 > | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-> | `:0.3.6` | Exact release version |
+> | `:0.3.17` | Exact release version |
 > | `:0.3` | Latest patch within the 0.3 minor |
 > | `:main` | Alias of the same rolling `main` build as `:latest` |
 > | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |


### PR DESCRIPTION
Two gaps in `deploy/Dockerfile` (last substantive touch predates the migration-heavy releases):

- **`alembic.ini` was never copied into the image**, so on existing Docker volumes the backend silently fell back to the additive-column self-heal instead of the first-class migration chain (functional — that fallback exists for exactly this class — but migrations like 0009 should run natively).
- **No image-level `HEALTHCHECK`**: the compose files define their own, but plain `docker run` had none. Added with a 120 s start period (first boot creates the schema before /health answers); `curl` is already in the image.
- `docs/install/docker.md`: version-tag example freshened.

Kept deliberately minimal (no daemon on this box to build-test; the CI image build on main is the validator — both changes are provably safe: COPY of an existing file + standard HEALTHCHECK syntax against an installed curl). Intended to merge **before** the v0.3.17 tag so the `:0.3.17` image carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Copied `alembic.ini` into the Docker runtime image so native migrations work with existing volumes.
- Added a Docker image health check against `/health` on port `3900`, including a 120-second start period.
- Updated the Docker image version example from `0.3.6` to `0.3.17`.

```mermaid
flowchart TD
  A[Container starts] --> B[Wait up to 120 seconds]
  B --> C{curl 127.0.0.1:3900/health succeeds?}
  C -->|Yes| D[Container healthy]
  C -->|No| E[Retry health check]
  E --> F[Container unhealthy after configured retries]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->