### PR TITLE
test: exports coverage, fp16 leak instrumentation, order-pollution root-caused at source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,10 @@ jobs:
       - name: Validate install docs against desktop-prod.sh
         run: python scripts/validate-install-docs.py
 
-      # `backend/tests/` stubs core.config in sys.modules to avoid the heavy
-      # main app import chain — that pollutes import state for other modules,
-      # so it runs in its own pytest session to stay isolated from tests/.
+      # `backend/tests/` mounts routers on bare FastAPI apps (no heavy main
+      # import chain) with a hermetic data dir from its conftest.py. It no
+      # longer stubs sys.modules, so mixed sessions with tests/ are safe;
+      # the separate session is kept for cheaper, clearer CI output.
       - name: Run pytest (backend/tests, isolated)
         run: uv run pytest backend/tests/ -q --tb=short
 

--- a/backend/api/routers/exports.py
+++ b/backend/api/routers/exports.py
@@ -21,12 +21,17 @@ def _safe_destination(raw: str) -> str:
             status_code=400,
             detail="Export needs a destination folder. Pick where the file should go and try again.",
         )
-    dest = os.path.realpath(os.path.expanduser(raw))
-    if not os.path.isabs(dest):
+    expanded = os.path.expanduser(raw)
+    # Check BEFORE realpath(): realpath absolutizes a relative path against
+    # the server's cwd, which made this check dead code — a relative
+    # destination silently exported to a cwd-dependent location instead of
+    # the documented 400 (regression-tested in tests/test_exports_api.py).
+    if not os.path.isabs(expanded):
         raise HTTPException(
             status_code=400,
             detail="The destination needs to be a full path (e.g. /Users/you/Movies/OmniVoice) — not relative.",
         )
+    dest = os.path.realpath(expanded)
     parent = os.path.dirname(dest)
     if not parent or not os.path.isdir(parent):
         raise HTTPException(
@@ -39,7 +44,10 @@ def _safe_destination(raw: str) -> str:
 def _safe_source(filename: str) -> str:
     """Resolve a source filename against OUTPUTS_DIR / dub outputs, blocking traversal."""
     base = os.path.basename(filename or "")
-    if not base or base != filename:
+    # "." and ".." are their own basename, so they'd slip past the
+    # base != filename check and only die later on realpath containment —
+    # reject them up front with the same 400 as any other malformed name.
+    if not base or base != filename or base in (".", ".."):
         raise HTTPException(
             status_code=400,
             detail="The file to export has an unexpected name. Try re-generating the audio and exporting again.",

--- a/backend/services/batched_tts.py
+++ b/backend/services/batched_tts.py
@@ -151,9 +151,14 @@ async def generate_segments_batched(
                     # Raw: skip all DSP — return raw model output
                     return audio_out
 
-                # TODO(#312): this route runs the OmniVoice model directly (not the active
-                # backend), so VoxCPM2 never reaches it. When these routes become
-                # engine-aware, guard with `if not getattr(backend, "applies_own_mastering", False)`.
+                # NOTE(#312, closed): the live routes (generation.py,
+                # dub_generate.py, batch.py, tts_stream.py) are engine-aware
+                # and honor `applies_own_mastering` themselves. This module
+                # still drives the OmniVoice model directly and currently has
+                # NO call sites — it's an unintegrated throughput experiment.
+                # If it is ever wired into a route, thread the active backend
+                # through instead of `model` and guard the mastering below
+                # with `if not getattr(backend, "applies_own_mastering", False)`.
                 mastered = apply_mastering(audio_out, sample_rate=sr)
                 effect_chain = get_effect_chain(seg_effect_preset)
                 if effect_chain:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared setup for backend/tests — import path + hermetic data dir.
+
+Historically every module in this directory stubbed
+``sys.modules["core.config"]`` with a bare 3-4 attribute ``ModuleType``
+pointing at its own ``mkdtemp``. That stub leaked **process-wide at
+collection time**: pytest imports test modules while collecting, so in any
+mixed invocation (``pytest tests/... backend/tests/...``) every *later* lazy
+import of ``core.config`` resolved the stub instead of the real module —
+``tests/test_router_smoke.py``'s ``from main import app`` died with
+ImportError (missing config attrs), and
+``monkeypatch.setattr("core.config.X", ...)`` died with AttributeError
+(``core`` never gets a ``config`` attribute when the name is satisfied
+straight from ``sys.modules``). That was the root cause of the
+order-pollution combos around test_longform_e2e (8 AttributeErrors) and
+test_router_smoke (24 fixture ImportErrors).
+
+The real ``core.config`` derives every path from ``OMNIVOICE_DATA_DIR`` at
+import time, so pointing that env var at a throwaway dir *before* any test
+module imports it gives the same hermeticity (issue #878: never touch the
+developer's real app state) with zero ``sys.modules`` surgery. This mirrors
+``tests/conftest.py``; in a mixed run whichever conftest loads first wins
+(``setdefault`` semantics) and both point at a throwaway tmpdir.
+
+Do NOT reintroduce module-level ``sys.modules`` stubs in this directory —
+import the real module and rely on this conftest instead.
+"""
+import os
+import sys
+import tempfile
+
+# Backend runs with `--app-dir backend`, so tests must do the same.
+_BACKEND = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+if not os.environ.get("OMNIVOICE_DATA_DIR"):
+    os.environ["OMNIVOICE_DATA_DIR"] = tempfile.mkdtemp(prefix="omnivoice-test-data-")
+if not os.environ.get("OMNIVOICE_ENV_FILE"):
+    os.environ["OMNIVOICE_ENV_FILE"] = os.path.join(
+        os.environ["OMNIVOICE_DATA_DIR"], "user-env"
+    )

--- a/backend/tests/test_archetype_preview_quality.py
+++ b/backend/tests/test_archetype_preview_quality.py
@@ -14,24 +14,13 @@ verified manually (spectral flatness back in the speech range + Whisper ASR).
 from __future__ import annotations
 
 import math
-import os
-import sys
-import tempfile
-import types
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-# Stub core.config before the router imports OUTPUTS_DIR / VOICES_DIR from it.
-_TMP = tempfile.mkdtemp(prefix="omnivoice_preview_q_")
-_config = types.ModuleType("core.config")
-_config.DATA_DIR = _TMP
-_config.VOICES_DIR = str(Path(_TMP) / "voices")
-_config.OUTPUTS_DIR = str(Path(_TMP) / "outputs")
-sys.modules["core.config"] = _config
-
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before the router imports OUTPUTS_DIR / VOICES_DIR from
+# the REAL core.config (the old sys.modules stub leaked at collection time
+# and broke later importers in mixed runs — see conftest.py).
 torch = pytest.importorskip("torch")  # noqa: E402
 
 from api.routers import archetypes as arch  # noqa: E402

--- a/backend/tests/test_archetypes_api.py
+++ b/backend/tests/test_archetypes_api.py
@@ -9,29 +9,13 @@ generation.py's proven ``_run_inference`` rather than re-implementing it.
 """
 from __future__ import annotations
 
-import os
-import sys
-import tempfile
-import types
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-# Stub core.config before the router imports VOICES_DIR / OUTPUTS_DIR from it.
-_TMP = tempfile.mkdtemp(prefix="omnivoice_arch_test_")
-_VOICES = Path(_TMP) / "voices"
-_OUTPUTS = Path(_TMP) / "outputs"
-_VOICES.mkdir(parents=True, exist_ok=True)
-_OUTPUTS.mkdir(parents=True, exist_ok=True)
-
-_config = types.ModuleType("core.config")
-_config.DATA_DIR = _TMP
-_config.VOICES_DIR = str(_VOICES)
-_config.OUTPUTS_DIR = str(_OUTPUTS)
-sys.modules["core.config"] = _config
-
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before the router imports VOICES_DIR / OUTPUTS_DIR from
+# the REAL core.config (the old sys.modules stub leaked at collection time).
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 

--- a/backend/tests/test_asr_oom_fallback.py
+++ b/backend/tests/test_asr_oom_fallback.py
@@ -8,21 +8,14 @@ OOM deterministically (no GPU needed) and asserts the device switch.
 """
 from __future__ import annotations
 
-import os
 import sys
-import tempfile
 import types
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-_config = types.ModuleType("core.config")
-_config.DATA_DIR = tempfile.mkdtemp(prefix="omnivoice_asr_oom_")
-_config.VOICES_DIR = _config.DATA_DIR
-_config.OUTPUTS_DIR = _config.DATA_DIR
-sys.modules["core.config"] = _config
-
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before this module imports the REAL core.config (the old
+# sys.modules stub leaked at collection time and broke mixed runs).
 whisperx = pytest.importorskip("whisperx")
 
 from services.asr_backend import (  # noqa: E402

--- a/backend/tests/test_audiobook_resume_api.py
+++ b/backend/tests/test_audiobook_resume_api.py
@@ -3,32 +3,18 @@
 is covered by the manifest round-trip (tests/test_longform_resume.py) + the
 existing render tests, not here.
 
-Config-stub pattern (mounts only the audiobook router — torch-free at import) so
-it runs locally without the main+torch segfault.
+Mounts only the audiobook router (no ``main`` import) so it runs locally
+without the main+torch segfault; conftest.py provides the hermetic data dir.
 """
 from __future__ import annotations
 
 import json
-import os
-import sys
-import tempfile
-import types
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-_TMP = tempfile.mkdtemp(prefix="omnivoice_abresume_test_")
-_config = types.ModuleType("core.config")
-_config.DATA_DIR = _TMP
-_config.VOICES_DIR = str(Path(_TMP) / "voices")
-_config.OUTPUTS_DIR = str(Path(_TMP) / "outputs")
-_config.DB_PATH = str(Path(_TMP) / "omnivoice.db")
-os.makedirs(_config.VOICES_DIR, exist_ok=True)
-os.makedirs(_config.OUTPUTS_DIR, exist_ok=True)
-sys.modules["core.config"] = _config
-
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before this module imports the REAL core.config (the old
+# sys.modules stub leaked at collection time and broke mixed runs).
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 

--- a/backend/tests/test_batch.py
+++ b/backend/tests/test_batch.py
@@ -6,19 +6,11 @@ lightweight — it only imports os, uuid, time, asyncio, logging,
 fastapi, and pydantic at module level.
 """
 import io
-import os
-import sys
 import pytest
 
-# Add backend to path
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-# Stub core.config before batch imports it
-import types
-config_mod = types.ModuleType("core.config")
-config_mod.DATA_DIR = "/tmp/omnivoice_test_data"
-sys.modules["core.config"] = config_mod
-
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before the batch router imports the REAL core.config (the
+# old sys.modules stub leaked at collection time and broke mixed runs).
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from api.routers.batch import router, _jobs, _set_progress

--- a/backend/tests/test_capture_ws.py
+++ b/backend/tests/test_capture_ws.py
@@ -4,17 +4,11 @@ Only tests the pure-Python helper functions (no GPU needed).
 The WebSocket endpoint itself requires the full app, which we
 skip in CI — it's integration-tested via the browser.
 """
-import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-# Stub heavy deps
-import types
-for mod_name in ["services.model_manager", "services.asr_backend", "services.ffmpeg_utils"]:
-    if mod_name not in sys.modules:
-        sys.modules[mod_name] = types.ModuleType(mod_name)
-
+# conftest.py puts `backend/` on sys.path. capture_ws imports its heavy deps
+# (model_manager / asr_backend / ffmpeg_utils) lazily inside handlers, so no
+# stubbing is needed — the old empty-ModuleType stubs leaked process-wide at
+# collection time and broke every later `from services.ffmpeg_utils import
+# find_ffmpeg` in mixed runs (see conftest.py).
 from api.routers.capture_ws import _chunks_to_wav, MIN_BUFFER_BYTES
 
 

--- a/backend/tests/test_community.py
+++ b/backend/tests/test_community.py
@@ -9,23 +9,12 @@ are exercised at runtime.
 from __future__ import annotations
 
 import json
-import os
-import sys
-import tempfile
-import types
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-_TMP = tempfile.mkdtemp(prefix="omnivoice_community_test_")
-_config = types.ModuleType("core.config")
-_config.DATA_DIR = _TMP
-_config.VOICES_DIR = str(Path(_TMP) / "voices")
-_config.OUTPUTS_DIR = str(Path(_TMP) / "outputs")
-sys.modules["core.config"] = _config
-
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before this module imports the REAL core.config (the old
+# sys.modules stub leaked at collection time and broke mixed runs).
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 

--- a/backend/tests/test_no_module_stubs.py
+++ b/backend/tests/test_no_module_stubs.py
@@ -1,0 +1,44 @@
+"""Regression guard for the collection-time sys.modules stub class.
+
+Seven modules in this directory used to install bare ``types.ModuleType``
+stubs for ``core.config`` (and test_capture_ws.py for ``services.*``) at
+module level. pytest imports every test module during *collection*, so the
+stubs leaked process-wide before a single test ran: in any mixed invocation
+(``pytest tests/... backend/tests/...``) later lazy imports resolved the
+stub — tests/test_router_smoke.py's ``from main import app`` died with
+``ImportError: cannot import name 'find_ffmpeg' from 'services.ffmpeg_utils'
+(unknown location)`` and tests/test_longform_e2e.py's
+``monkeypatch.setattr("core.config.OUTPUTS_DIR", ...)`` died with
+``AttributeError: module 'core' has no attribute 'config'``.
+
+This test runs after collection has imported every sibling module, so any
+reintroduced module-level stub trips it even in a backend/tests-only run.
+A stub is recognizable because a bare ModuleType has neither ``__file__``
+(real module) nor ``__path__`` (namespace package).
+
+If you need a fake module in a test, use ``monkeypatch.setitem(sys.modules,
+name, fake)`` inside the test — pytest restores it. For hermetic data dirs,
+rely on conftest.py's ``OMNIVOICE_DATA_DIR`` redirect instead of stubbing
+``core.config``.
+"""
+import sys
+
+# Backend packages whose identity later tests depend on. Top-level third-party
+# modules are out of scope (some legitimately lack __file__, e.g. frozen ones).
+_GUARDED_PREFIXES = ("core.", "api.", "services.", "schemas.", "utils.")
+
+
+def test_no_collection_time_sys_modules_stubs():
+    offenders = []
+    for name, mod in list(sys.modules.items()):
+        if mod is None or not name.startswith(_GUARDED_PREFIXES):
+            continue
+        if getattr(mod, "__file__", None) is None and not hasattr(mod, "__path__"):
+            offenders.append(name)
+    assert not offenders, (
+        "Stub module(s) found in sys.modules: "
+        f"{offenders}. Some test module installed a bare ModuleType at import "
+        "time; that leaks process-wide from pytest collection and breaks "
+        "every later import of the real module in mixed runs. Use "
+        "monkeypatch.setitem(sys.modules, ...) inside the test instead."
+    )

--- a/backend/tests/test_personas_api.py
+++ b/backend/tests/test_personas_api.py
@@ -6,34 +6,23 @@ the model. The export path's preview generation needs torchaudio and is covered
 by the service-layer round-trip in ``tests/test_persona_bundle.py`` + CI; here we
 only assert export's 404 (which fails before any audio work).
 
-Follows the config-stub pattern of ``test_archetypes_api.py`` / ``test_community.py``
-so it mounts ONLY the persona router on a bare FastAPI app (no ``main`` import,
-no torch at collection).
+Follows the pattern of ``test_archetypes_api.py`` / ``test_community.py``:
+mounts ONLY the persona router on a bare FastAPI app (no ``main`` import,
+no torch at collection); conftest.py provides the hermetic data dir.
 """
 from __future__ import annotations
 
 import io
 import json
 import os
-import sys
-import tempfile
-import types
 import zipfile
-from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-_TMP = tempfile.mkdtemp(prefix="omnivoice_personas_test_")
-_VOICES = Path(_TMP) / "voices"
-_VOICES.mkdir(parents=True, exist_ok=True)
-_config = types.ModuleType("core.config")
-_config.DATA_DIR = _TMP
-_config.VOICES_DIR = str(_VOICES)
-_config.OUTPUTS_DIR = str(Path(_TMP) / "outputs")
-_config.DB_PATH = str(Path(_TMP) / "omnivoice.db")
-sys.modules["core.config"] = _config
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before this module imports the REAL core.config (the old
+# sys.modules stub leaked at collection time and broke mixed runs).
+from core import config as _config  # noqa: E402
 
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,9 +262,9 @@ dev = [
 [tool.pytest.ini_options]
 # Bare `pytest` would otherwise walk into `research/` (1.2 GB of vendored
 # upstream projects, each with its own test_*.py that calls sys.exit at
-# module level) and INTERNALERROR. `backend/tests/` runs separately because
-# it stubs `core.config` in sys.modules, which pollutes import state for
-# other modules in the same session.
+# module level) and INTERNALERROR. `backend/tests/` still runs as its own CI
+# session (see ci.yml) but no longer stubs sys.modules — its conftest.py sets
+# a hermetic OMNIVOICE_DATA_DIR instead, so mixed invocations are safe too.
 testpaths = ["tests"]
 norecursedirs = [
     "research",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,24 +50,104 @@ import warnings as _warnings
 # built under a leaked fp16 default. The same leak collapses
 # test_effects_chain's preset differences into identical quantized outputs,
 # and hands test_persona_bundle's soundfile writer fp16 data libsndfile
-# can't encode. The polluter only executes on CI-Linux (it never reproduces
-# on macOS), so rather than chase it blind, this guard makes the whole leak
-# class impossible — same philosophy as the LLM-state guard below — and
-# names the offender in CI output when it fires, so it CAN be chased.
+# can't encode. The known polluter TESTS are
+# test_dub_onsets_route.py::test_prefers_vocals_over_mix and
+# test_smart_fit_generate.py::test_final_dub_track_and_seg_wav_are_watermarked
+# — both now carry the opt-in `torch_dtype_isolation` fixture below, so this
+# autouse guard is pure insurance for new polluters. The CALL that flips the
+# dtype only executes on CI-Linux (it never reproduces on macOS — local
+# instrumentation of torch.set_default_dtype across both tests recorded zero
+# non-fp32 sets), so the recorder below captures the setter's stack trace and
+# both fixtures print it when they fire: the next CI occurrence hands us the
+# exact culprit call chain, not just the test nodeid.
+
+_DTYPE_SETTER = {"stack": None, "dtype": None}
+
+
+def _install_torch_dtype_recorder():
+    """Wrap torch's default-dtype setters to capture the caller's stack.
+
+    Only records on a *non-float32* set (the rare, offending case), so the
+    overhead on the hot path is one dtype comparison. Installed lazily the
+    first time torch shows up in sys.modules; idempotent. If torch is first
+    imported inside the polluting test itself, the recorder installs after
+    the fact and the warning says the stack wasn't captured.
+    """
+    torch = sys.modules.get("torch")
+    if torch is None or getattr(torch, "_omnivoice_dtype_recorder", False):
+        return
+
+    import traceback
+
+    _orig_set_dtype = torch.set_default_dtype
+
+    def _recording_set_default_dtype(d):
+        if d != torch.float32:
+            _DTYPE_SETTER["stack"] = "".join(traceback.format_stack(limit=30))
+            _DTYPE_SETTER["dtype"] = repr(d)
+        return _orig_set_dtype(d)
+
+    torch.set_default_dtype = _recording_set_default_dtype
+
+    # Legacy API — can also flip the default dtype (e.g. HalfTensor).
+    _orig_set_tt = torch.set_default_tensor_type
+    if _orig_set_tt is not None:  # removed in newer torch
+
+        def _recording_set_default_tensor_type(t):
+            _DTYPE_SETTER["stack"] = "".join(traceback.format_stack(limit=30))
+            _DTYPE_SETTER["dtype"] = f"tensor_type={t!r}"
+            return _orig_set_tt(t)
+
+        torch.set_default_tensor_type = _recording_set_default_tensor_type
+
+    torch._omnivoice_dtype_recorder = True
+
+
+def _drain_leaked_dtype(nodeid: str) -> None:
+    """Warn (with the captured setter stack, if any) and reset to float32."""
+    torch = sys.modules.get("torch")
+    if torch is None or torch.get_default_dtype() is torch.float32:
+        return
+    stack = _DTYPE_SETTER["stack"]
+    origin = (
+        f" set to {_DTYPE_SETTER['dtype']} at:\n{stack}"
+        if stack
+        else (
+            " (setter stack not captured — torch.set_default_dtype was "
+            "called before the recorder installed, or the dtype changed "
+            "through another API)"
+        )
+    )
+    _warnings.warn(
+        f"{nodeid} leaked torch default dtype {torch.get_default_dtype()} — "
+        f"resetting to float32.{origin}",
+        stacklevel=1,
+    )
+    torch.set_default_dtype(torch.float32)
+
+
 @pytest.fixture(autouse=True)
 def _torch_default_dtype_guard(request):
+    _install_torch_dtype_recorder()
     yield
-    torch = sys.modules.get("torch")
-    if torch is None:
-        return
-    if torch.get_default_dtype() is not torch.float32:
-        _warnings.warn(
-            f"{request.node.nodeid} leaked torch default dtype "
-            f"{torch.get_default_dtype()} — resetting to float32. This is "
-            f"the polluter behind the CI flaky trio; fix it at the source.",
-            stacklevel=1,
-        )
-        torch.set_default_dtype(torch.float32)
+    # The test itself may have been the first to import torch.
+    _install_torch_dtype_recorder()
+    _drain_leaked_dtype(request.node.nodeid)
+
+
+@pytest.fixture
+def torch_dtype_isolation(request):
+    """Opt-in save/restore for tests known to trip the CI-Linux fp16 leak.
+
+    Runs *inside* the test's own fixture stack (i.e. before the autouse
+    guard's teardown), so tagged tests can never spread a leaked default
+    dtype — and the warning below keeps CI attribution alive: it prints the
+    recorded setter stack so the culprit call chain lands in the CI log.
+    """
+    _install_torch_dtype_recorder()
+    yield
+    _install_torch_dtype_recorder()
+    _drain_leaked_dtype(request.node.nodeid)
 
 
 # ── LLM-provider state isolation (issue #878) ──────────────────────────────

--- a/tests/test_dub_onsets_route.py
+++ b/tests/test_dub_onsets_route.py
@@ -60,6 +60,11 @@ def test_404_when_no_audio_available(job_env):
     assert exc.value.status_code == 404
 
 
+# On CI-Linux (never reproduced on macOS) something in this test's call chain
+# flips torch's default dtype to float16 and leaks it into later tests. The
+# fixture save/restores the dtype and logs the setter's captured stack trace
+# so the CI log names the culprit call chain (see conftest.py).
+@pytest.mark.usefixtures("torch_dtype_isolation")
 def test_prefers_vocals_over_mix(job_env):
     vocals = job_env["job_dir"] / "vocals.wav"
     mix = job_env["job_dir"] / "audio.wav"

--- a/tests/test_exports_api.py
+++ b/tests/test_exports_api.py
@@ -1,0 +1,370 @@
+"""Tests for the export router (`backend/api/routers/exports.py`).
+
+Covers the full route surface — /export, /export/record, /export/history,
+/export/reveal — which previously had zero dedicated tests (only two smoke
+checks in test_router_smoke.py):
+
+* happy paths: copy-to-destination + history recording, record-only, history
+  listing order, reveal (with subprocess mocked so no Finder/Explorer opens);
+* the security guards: source traversal (`_safe_source` accepts basenames
+  only, resolved inside OUTPUTS_DIR), destination validation (absolute path
+  required, parent must exist);
+* the regression for the dead `isabs` check: `os.path.realpath()` absolutizes
+  a relative destination against the server's cwd, so relative destinations
+  used to silently export to a cwd-dependent location instead of the
+  documented 400 (fail-before/pass-after: `_safe_destination` now checks
+  `isabs` before realpath);
+* error mapping: copy failure → 500, reveal of a missing path → 404,
+  reveal spawn failure → 500;
+* the mp4 branch: visible watermark disabled → plain copy; ffmpeg overlay
+  failure → plain-copy fallback (the user still gets their file).
+"""
+import os
+import subprocess
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+
+@pytest.fixture(scope="module")
+def client():
+    # Same self-sufficient pattern as test_router_smoke.py: lazy import, and
+    # seed the schema explicitly because a bare TestClient never runs the app
+    # lifespan (where init_db() lives).
+    from fastapi.testclient import TestClient
+    from main import app
+    import core.db
+
+    core.db.init_db()
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+@pytest.fixture
+def outputs_dir(tmp_path, monkeypatch):
+    """A throwaway OUTPUTS_DIR wired into the router's frozen import."""
+    import api.routers.exports as exports
+
+    out = tmp_path / "outputs"
+    out.mkdir()
+    monkeypatch.setattr(exports, "OUTPUTS_DIR", str(out))
+    return out
+
+
+def _make_source(outputs_dir, name="clip.wav", data=b"RIFFxxxxWAVE-test-audio"):
+    p = outputs_dir / name
+    p.write_bytes(data)
+    return p
+
+
+# ── route shapes ─────────────────────────────────────────────────────────────
+def test_route_shapes(client):
+    from main import app
+
+    routes = {r.path: r.methods for r in app.routes if hasattr(r, "methods")}
+    assert "POST" in routes["/export"]
+    assert "POST" in routes["/export/record"]
+    assert "GET" in routes["/export/history"]
+    assert "POST" in routes["/export/reveal"]
+
+
+# ── /export happy path ───────────────────────────────────────────────────────
+def test_export_copies_file_and_records_history(client, outputs_dir, tmp_path):
+    src = _make_source(outputs_dir)
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+    dest = dest_dir / "exported.wav"
+
+    r = client.post("/export", json={
+        "source_filename": "clip.wav",
+        "destination_path": str(dest),
+        "mode": "history",
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert len(body["id"]) == 8
+
+    assert dest.read_bytes() == src.read_bytes()
+
+    hist = client.get("/export/history").json()
+    entry = next(h for h in hist if h["id"] == body["id"])
+    assert entry["filename"] == "clip.wav"
+    assert entry["destination_path"] == os.path.realpath(str(dest))
+    assert entry["mode"] == "history"
+
+
+def test_export_destination_may_be_an_existing_directory(client, outputs_dir, tmp_path):
+    # shutil.copy2 into a directory keeps the source basename.
+    _make_source(outputs_dir, name="take2.wav")
+    dest_dir = tmp_path / "outbox"
+    dest_dir.mkdir()
+
+    r = client.post("/export", json={
+        "source_filename": "take2.wav",
+        "destination_path": str(dest_dir),
+    })
+    assert r.status_code == 200
+    assert (dest_dir / "take2.wav").is_file()
+
+
+# ── /export source guards ────────────────────────────────────────────────────
+@pytest.mark.parametrize("bad_name", [
+    "../../../etc/passwd",       # classic traversal
+    "..",                        # bare parent hop
+    "sub/dir.wav",               # any separator is rejected (basename-only)
+    "/etc/passwd",               # absolute path
+    "",                          # empty
+])
+def test_export_rejects_non_basename_sources(client, outputs_dir, tmp_path, bad_name):
+    r = client.post("/export", json={
+        "source_filename": bad_name,
+        "destination_path": str(tmp_path),
+    })
+    assert r.status_code == 400
+    assert "unexpected name" in r.json()["detail"]
+
+
+def test_export_404_when_source_gone(client, outputs_dir, tmp_path):
+    r = client.post("/export", json={
+        "source_filename": "never-generated.wav",
+        "destination_path": str(tmp_path),
+    })
+    assert r.status_code == 404
+    assert "isn't on disk" in r.json()["detail"]
+
+
+def test_export_symlink_inside_outputs_pointing_outside_is_rejected(
+    client, outputs_dir, tmp_path
+):
+    # A symlink planted in OUTPUTS_DIR must not let /export read arbitrary
+    # files: realpath resolves it outside the root, failing containment.
+    secret = tmp_path / "secret.txt"
+    secret.write_bytes(b"credentials")
+    (outputs_dir / "innocent.wav").symlink_to(secret)
+
+    r = client.post("/export", json={
+        "source_filename": "innocent.wav",
+        "destination_path": str(tmp_path / "out.wav"),
+    })
+    assert r.status_code == 404
+
+
+# ── /export destination guards ───────────────────────────────────────────────
+@pytest.mark.parametrize("bad_dest", ["", "   "])
+def test_export_rejects_empty_destination(client, outputs_dir, bad_dest):
+    _make_source(outputs_dir)
+    r = client.post("/export", json={
+        "source_filename": "clip.wav",
+        "destination_path": bad_dest,
+    })
+    assert r.status_code == 400
+    assert "destination folder" in r.json()["detail"]
+
+
+def test_export_rejects_relative_destination_even_when_cwd_resolvable(
+    client, outputs_dir, tmp_path, monkeypatch
+):
+    """Regression: the isabs check ran on realpath()'s output, which is
+    always absolute — so a relative destination fell through and exported to
+    a directory relative to the server's cwd. Pass a relative path whose
+    parent EXISTS under cwd: before the fix this returned 200 and wrote a
+    cwd-dependent file; now it's the documented 400."""
+    _make_source(outputs_dir)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "rel_out").mkdir()
+
+    r = client.post("/export", json={
+        "source_filename": "clip.wav",
+        "destination_path": os.path.join("rel_out", "exported.wav"),
+    })
+    assert r.status_code == 400
+    assert "full path" in r.json()["detail"]
+    assert not (tmp_path / "rel_out" / "exported.wav").exists()
+
+
+def test_export_rejects_destination_with_missing_parent(client, outputs_dir, tmp_path):
+    _make_source(outputs_dir)
+    r = client.post("/export", json={
+        "source_filename": "clip.wav",
+        "destination_path": str(tmp_path / "no-such-dir" / "out.wav"),
+    })
+    assert r.status_code == 400
+    assert "doesn't exist yet" in r.json()["detail"]
+
+
+def test_export_copy_failure_maps_to_500(client, outputs_dir, tmp_path, monkeypatch):
+    import api.routers.exports as exports
+
+    _make_source(outputs_dir)
+
+    def _boom(src, dest):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(exports.shutil, "copy2", _boom)
+    r = client.post("/export", json={
+        "source_filename": "clip.wav",
+        "destination_path": str(tmp_path / "out.wav"),
+    })
+    assert r.status_code == 500
+    assert "disk full" in r.json()["detail"]
+
+
+# ── /export mp4 watermark branch ─────────────────────────────────────────────
+def test_export_mp4_plain_copy_when_visible_watermark_disabled(
+    client, outputs_dir, tmp_path, monkeypatch
+):
+    from services import watermark
+
+    src = _make_source(outputs_dir, name="dub.mp4", data=b"\x00\x00\x00\x1cftyp-fake-mp4")
+    monkeypatch.setattr(watermark, "is_visible_video_enabled", lambda: False)
+
+    called = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: called.append(a) or (_ for _ in ()).throw(AssertionError("ffmpeg must not run")),
+    )
+
+    dest = tmp_path / "dub-export.mp4"
+    r = client.post("/export", json={
+        "source_filename": "dub.mp4",
+        "destination_path": str(dest),
+    })
+    assert r.status_code == 200
+    assert dest.read_bytes() == src.read_bytes()
+    assert not called
+
+
+def test_export_mp4_falls_back_to_plain_copy_when_ffmpeg_fails(
+    client, outputs_dir, tmp_path, monkeypatch
+):
+    from services import watermark
+
+    src = _make_source(outputs_dir, name="dub.mp4", data=b"\x00\x00\x00\x1cftyp-fake-mp4")
+    monkeypatch.setattr(watermark, "is_visible_video_enabled", lambda: True)
+    monkeypatch.setattr(
+        watermark, "get_ffmpeg_overlay_args", lambda logo: ["-filter_complex", "overlay"]
+    )
+
+    def _ffmpeg_dies(cmd, **kw):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "run", _ffmpeg_dies)
+
+    dest = tmp_path / "dub-export.mp4"
+    r = client.post("/export", json={
+        "source_filename": "dub.mp4",
+        "destination_path": str(dest),
+    })
+    # The user still gets their file (unwatermarked) — never a hard failure.
+    assert r.status_code == 200
+    assert dest.read_bytes() == src.read_bytes()
+
+
+# ── /export/record ───────────────────────────────────────────────────────────
+def test_record_export_writes_history_row(client):
+    r = client.post("/export/record", json={
+        "filename": "narration.wav",
+        "destination_path": "~/Downloads",
+        "mode": "file",
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+
+    hist = client.get("/export/history").json()
+    entry = next(h for h in hist if h["id"] == body["id"])
+    assert entry["filename"] == "narration.wav"
+    assert entry["destination_path"] == "~/Downloads"
+    assert entry["mode"] == "file"
+
+
+def test_record_export_defaults(client):
+    # ExportRecordRequest defaults: destination "~/Downloads", mode "file".
+    r = client.post("/export/record", json={"filename": "only-name.wav"})
+    assert r.status_code == 200
+    hist = client.get("/export/history").json()
+    entry = next(h for h in hist if h["id"] == r.json()["id"])
+    assert entry["destination_path"] == "~/Downloads"
+    assert entry["mode"] == "file"
+
+
+# ── /export/history ──────────────────────────────────────────────────────────
+def test_history_is_newest_first(client):
+    a = client.post("/export/record", json={"filename": "older.wav"}).json()["id"]
+    b = client.post("/export/record", json={"filename": "newer.wav"}).json()["id"]
+    hist = client.get("/export/history").json()
+    ids = [h["id"] for h in hist]
+    assert ids.index(b) < ids.index(a)
+    assert len(hist) <= 50
+
+
+# ── /export/reveal ───────────────────────────────────────────────────────────
+@pytest.mark.parametrize("bad_path", ["", "   "])
+def test_reveal_rejects_empty_path(client, bad_path):
+    r = client.post("/export/reveal", json={"path": bad_path})
+    assert r.status_code == 400
+    assert "nothing to reveal" in r.json()["detail"].lower()
+
+
+def test_reveal_404_when_path_missing(client, tmp_path):
+    r = client.post("/export/reveal", json={"path": str(tmp_path / "gone.wav")})
+    assert r.status_code == 404
+    assert "no longer on disk" in r.json()["detail"]
+
+
+def test_reveal_file_spawns_file_manager_without_shell(client, tmp_path, monkeypatch):
+    import api.routers.exports as exports
+
+    target = tmp_path / "show-me.wav"
+    target.write_bytes(b"x")
+
+    calls = []
+
+    def _fake_popen(cmd, *a, **kw):
+        calls.append((cmd, kw))
+        return None
+
+    monkeypatch.setattr(exports.subprocess, "Popen", _fake_popen)
+    r = client.post("/export/reveal", json={"path": str(target)})
+    assert r.status_code == 200
+    assert r.json() == {"success": True}
+
+    assert len(calls) == 1
+    cmd, kw = calls[0]
+    # List argv, no shell interpolation — the security contract of the route.
+    assert isinstance(cmd, list)
+    assert kw.get("shell") is not True
+    # Whatever the platform's opener is, the target (or its folder) is an arg.
+    resolved = os.path.realpath(str(target))
+    assert any(resolved in str(part) or os.path.dirname(resolved) in str(part)
+               for part in cmd)
+
+
+def test_reveal_directory_opens_the_folder_itself(client, tmp_path, monkeypatch):
+    import api.routers.exports as exports
+
+    calls = []
+    monkeypatch.setattr(
+        exports.subprocess, "Popen", lambda cmd, *a, **kw: calls.append(cmd)
+    )
+    r = client.post("/export/reveal", json={"path": str(tmp_path)})
+    assert r.status_code == 200
+    assert len(calls) == 1
+    assert any(os.path.realpath(str(tmp_path)) in str(part) for part in calls[0])
+
+
+def test_reveal_spawn_failure_maps_to_500(client, tmp_path, monkeypatch):
+    import api.routers.exports as exports
+
+    target = tmp_path / "cursed.wav"
+    target.write_bytes(b"x")
+
+    def _no_opener(*a, **kw):
+        raise OSError("no file manager available")
+
+    monkeypatch.setattr(exports.subprocess, "Popen", _no_opener)
+    r = client.post("/export/reveal", json={"path": str(target)})
+    assert r.status_code == 500
+    assert "no file manager" in r.json()["detail"]

--- a/tests/test_smart_fit_generate.py
+++ b/tests/test_smart_fit_generate.py
@@ -164,6 +164,11 @@ def _track_samples(job_dir):
 # ── Audio-only stretch ─────────────────────────────────────────────────
 
 
+# On CI-Linux (never reproduced on macOS) something in this test's call chain
+# flips torch's default dtype to float16 and leaks it into later tests. The
+# fixture save/restores the dtype and logs the setter's captured stack trace
+# so the CI log names the culprit call chain (see conftest.py).
+@pytest.mark.usefixtures("torch_dtype_isolation")
 def test_final_dub_track_and_seg_wav_are_watermarked(patched_generate, monkeypatch):
     """Watermarking policy after the streaming-to-disk rewrite (#639).
 


### PR DESCRIPTION
Four test-debt items:

**1. `exports.py` gets its first tests** (26) — and they found two real bugs, both fixed: the `isabs` destination check ran on `realpath()` output (always absolute), so a relative destination silently exported to a cwd-dependent path instead of the documented 400; and `\".\"`/`\"..\"` slipped the basename guard into a confusing 404. Traversal/symlink-escape guards regression-tested.

**2. fp16 CI leak**: not reproducible on macOS (instrumented both named tests — zero non-fp32 sets locally, confirming CI-Linux-only). Both tests now carry a save/restore isolation fixture so the leak can never spread again, and `tests/conftest.py` gained a permanent cheap recorder that captures a **stack trace** on any non-fp32 default-dtype set — the next CI occurrence names the exact culprit in the log. Verified end-to-end with a synthetic leaking test.

**3. Test-order pollution root-caused**: seven `backend/tests/` modules installed bare `ModuleType` stubs for `core.config` (+ model_manager/asr/ffmpeg stubs in capture_ws) at module level — pytest imports test modules at *collection*, so the stubs leaked process-wide before any test ran, breaking files positioned earlier in the run. Fixed at source: hermetic `backend/tests/conftest.py` (mirrors #878), all eight files import the real modules, and a new guard test fails on any reintroduced stub. Both previously-failing combos re-run green in their exact orderings.

**4. `batched_tts.py` TODO(#312)**: audited — the module has zero call sites and #312's substance shipped elsewhere (all live routes are engine-aware). Comment corrected; recommendation: delete or deliberately integrate, not speculatively refactor. No code change.

**Verification:** full `tests/` **2796 passed / 0 failed**; `backend/tests/` **130 passed**; both pollution combos green; exports suite 26/26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added 26 export API tests covering validation, traversal and symlink protection, history, watermarking, error handling, and subprocess safety.
- Fixed export handling for relative destinations and `"."`/`".."` source names.
- Added PyTorch fp16 dtype-leak isolation and stack-trace diagnostics for CI.
- Removed collection-time `sys.modules` stubs from backend tests, centralized hermetic setup in `conftest.py`, and added a regression guard.
- Audited `batched_tts.py` and clarified its unintegrated status without changing runtime behavior.

```mermaid
flowchart TD
    A[Test execution] --> B{Backend test setup}
    B --> C[Hermetic data directory]
    B --> D[No collection-time module stubs]
    D --> E[Stable mixed pytest sessions]
    A --> F{Torch dtype changed?}
    F -->|Yes| G[Capture stack trace, warn, reset to float32]
    F -->|No| H[Continue]
    A --> I[Export request]
    I --> J[Validate source and destination]
    J --> K[Guard traversal and symlinks]
    K --> L[Copy, watermark, record history, or reveal safely]
```

## Verification

- `tests/`: 2,796 passed
- `backend/tests/`: 130 passed
- Export suite: 26 passed
- Both test-order pollution combinations passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->