### PR TITLE
feat(tts): streaming playback preview — audio starts on the first chunk while the rest renders

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -625,6 +625,94 @@ def _persist_profile_ref_text(profile_id: str, ref_text: str) -> None:
         )
 
 
+async def _finalize_generation(
+    audio_tensor, sample_rate, *, text, history_mode, ref_audio_path,
+    language, instruct, resolved_profile_id, used_seed, start_time,
+):
+    """Shared tail of a successful generation: watermark → save WAV →
+    history row (self-healing) → retention prune → event emit.
+
+    Used verbatim by both the classic whole-file response path and the
+    streaming-preview path (``stream=true``), so the on-disk artifact —
+    watermark, filename, history row, retention behavior — is identical
+    regardless of how the audio was delivered to the client.
+
+    Returns ``(watermarked_tensor, meta)`` where ``meta`` carries
+    ``id`` / ``filename`` / ``duration`` / ``gen_time``.
+    """
+    loop = asyncio.get_running_loop()
+    # Invisible AudioSeal provenance watermark on the final audio. Embedding
+    # was previously only wired into the dub pipeline (dub_generate.py), so
+    # plain TTS came out unmarked despite the setting being on. embed_watermark
+    # self-gates on the user's watermark setting + AudioSeal availability and
+    # passes the audio through unchanged on any failure, so it never breaks
+    # generation.
+    from services.watermark import embed_watermark
+    audio_tensor = await loop.run_in_executor(
+        _gpu_pool, embed_watermark, audio_tensor, sample_rate
+    )
+    gen_time = round(time.time() - start_time, 2)
+
+    audio_id = str(uuid.uuid4())[:8]
+    audio_filename = f"{audio_id}.wav"
+    audio_path = os.path.join(OUTPUTS_DIR, audio_filename)
+    _safe_torchaudio_save(audio_path, audio_tensor, sample_rate)
+
+    audio_dur = round(audio_tensor.shape[-1] / sample_rate, 2)
+
+    # #710: the clip is already generated and saved above. A history-write
+    # failure — e.g. "no such table: generation_history" on a DB that missed
+    # schema init — must NOT 500 the user's generation. Self-heal the schema
+    # once and retry; if it still fails, log and return the audio anyway.
+    def _write_history():
+        with db_conn() as conn:
+            conn.execute(
+                "INSERT INTO generation_history (id, text, mode, language, instruct, profile_id, audio_path, duration_seconds, generation_time, seed, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                (audio_id, text[:200], history_mode or ("clone" if ref_audio_path else "design"),
+                 language or "Auto", instruct or "", resolved_profile_id,
+                 audio_filename, audio_dur, gen_time, used_seed, time.time())
+            )
+    try:
+        _write_history()
+    except sqlite3.OperationalError as e:
+        logger.warning("generation history write failed (%s); healing schema + retrying", e)
+        try:
+            ensure_schema()
+            _write_history()
+        except Exception as e2:
+            logger.warning("history write still failed after schema heal; returning audio anyway: %s", e2)
+    except Exception as e:
+        logger.warning("generation history write failed; returning audio anyway: %s", e)
+    # Retention cap: without it, takes (rows + WAVs in OUTPUTS_DIR) grow
+    # unbounded forever. Best-effort — a prune failure must never affect
+    # the generation that just succeeded.
+    try:
+        _prune_history_over_cap()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("history retention prune failed (non-fatal): %s", e)
+    event_bus.emit("generation_history", {"action": "created", "id": audio_id})
+
+    return audio_tensor, {
+        "id": audio_id,
+        "filename": audio_filename,
+        "duration": audio_dur,
+        "gen_time": gen_time,
+    }
+
+
+def _pcm16_b64(wav_tensor) -> str:
+    """Mono 16-bit little-endian PCM, base64-encoded — the streaming-preview
+    wire format (same conversion as /ws/tts). N-D tensors take channel 0."""
+    import base64
+
+    import torch
+
+    pcm = (wav_tensor * 32767).clamp(-32768, 32767).to(torch.int16)
+    while pcm.ndim > 1:
+        pcm = pcm[0]
+    return base64.b64encode(pcm.cpu().numpy().tobytes()).decode("ascii")
+
+
 @router.post("/generate")
 async def generate_speech(
     text: str = Form(...),
@@ -655,6 +743,14 @@ async def generate_speech(
     # OMNIVOICE_PRONUNCIATION pref can disable it for power users. Omitting it
     # with an empty dictionary is byte-identical to legacy behavior.
     pronounce: bool = Form(True),
+    # Streaming preview: when true, the response is application/x-ndjson —
+    # one JSON event per line ("start" → N × "chunk" (base64 PCM16 preview of
+    # each text chunk, playable the moment it arrives) → "done" with the saved
+    # take's metadata, or "error"). The final WAV on disk (watermark, history
+    # row, retention) is produced by the exact same finalize path as the
+    # classic flow, so streaming is purely a delivery channel — engine-agnostic
+    # (text-level chunking, no per-engine token streaming).
+    stream: bool = Form(False),
 ):
     # #502: NFC-normalize the input text so decomposed (NFD) diacritics — common
     # in pasted Vietnamese and other Latin-with-marks text — are composed to the
@@ -918,8 +1014,207 @@ async def generate_speech(
         text = apply_inline_overrides(text)
 
     start_time = time.time()
+
+    # ── Streaming preview (feat: streaming-tts-preview) ─────────────────────
+    # Long scripts used to mean staring at a spinner until the ENTIRE render
+    # finished. With stream=true the existing text chunks (the Wave 1.2
+    # sentence-boundary splitter — unchanged) are synthesized sequentially and
+    # each chunk's audio is yielded the moment it's rendered, so playback can
+    # begin after the first chunk. The final file is then assembled through
+    # the SAME concat → effect-chain → watermark → save → history pipeline as
+    # the classic path, so the on-disk take is identical to a non-streamed
+    # one. [pause]-marker inputs and single-chunk (short) texts keep their
+    # unchanged single-shot pipeline and stream as one chunk. All prep above
+    # (engine warm under the #1039 model-load budget, routing gate, profile /
+    # seed / normalization) already ran, so per-chunk jobs spend the generate
+    # budget on generation only — and each chunk gets its own budget, so a
+    # long script can't time out merely for being long.
+    if stream:
+        from omnivoice.utils.text import parse_pause_markers
+        from services.chunked_tts import split_text_into_chunks
+
+        _segments = parse_pause_markers(text)
+        _has_pause = len(_segments) > 1 or (_segments and _segments[0][1] > 0)
+        _text_chunks = [] if _has_pause else split_text_into_chunks(text, max_chunk_chars)
+
+        def _render_stream_chunk(i: int, chunk_text: str):
+            """One text chunk → (raw engine tensor, preview-DSP tensor, sr).
+
+            Runs on the GPU pool. Mirrors ONE iteration of the multi-chunk
+            loop in _run_inference/_run_backend_inference exactly (per-chunk
+            deterministic seed, same generate kwargs), so concatenating the
+            raw parts afterwards reproduces the non-streaming output. The
+            preview copy gets the same effect chain the final file will get,
+            so what the user hears mid-stream matches the saved take.
+            """
+            import torch
+            try:
+                if used_seed is not None:
+                    torch.manual_seed(used_seed + i)
+                if _backend is not None:
+                    _lang = None if (language and language.lower() == "auto") else language
+                    raw = _backend.generate(
+                        chunk_text, duration=None, language=_lang,
+                        ref_audio=ref_audio_path, ref_text=ref_text,
+                        instruct=instruct, num_step=num_step,
+                        guidance_scale=guidance_scale, speed=speed,
+                        denoise=denoise, postprocess_output=postprocess_output,
+                    )
+                    sr = _backend.sample_rate
+                    skip = getattr(_backend, "applies_own_mastering", False)
+                else:
+                    kwargs = {}
+                    if t_shift is not None: kwargs["t_shift"] = t_shift
+                    if layer_penalty_factor is not None: kwargs["layer_penalty_factor"] = layer_penalty_factor
+                    if position_temperature is not None: kwargs["position_temperature"] = position_temperature
+                    if class_temperature is not None: kwargs["class_temperature"] = class_temperature
+                    raw = _model.generate(
+                        text=chunk_text, language=language, ref_audio=ref_audio_path,
+                        ref_text=ref_text, instruct=instruct, duration=None,
+                        num_step=num_step, guidance_scale=guidance_scale, speed=speed,
+                        denoise=denoise, postprocess_output=postprocess_output,
+                        **kwargs
+                    )[0]
+                    sr = _model.sampling_rate if hasattr(_model, "sampling_rate") else 24000
+                    skip = False
+                preview = _apply_effect_chain(raw, sr, effect_preset, skip_mastering=skip)
+                return raw, preview, sr
+            except ValueError:
+                raise
+            except Exception as e:
+                _oom_friendly_reraise(e)
+
+        def _assemble_stream_chunks(parts, sr):
+            """Concat + whole-take effect chain — the same tail the
+            non-streaming multi-chunk loop runs, as one pool job."""
+            from services.chunked_tts import concatenate_audio_chunks
+            try:
+                audio_out = concatenate_audio_chunks(parts, sr, crossfade_ms)
+                skip = (getattr(_backend, "applies_own_mastering", False)
+                        if _backend is not None else False)
+                return _apply_effect_chain(audio_out, sr, effect_preset, skip_mastering=skip)
+            except ValueError:
+                raise
+            except Exception as e:
+                _oom_friendly_reraise(e)
+
+        async def _stream_events():
+            import json
+
+            def _line(obj) -> bytes:
+                return (json.dumps(obj, separators=(",", ":")) + "\n").encode("utf-8")
+
+            try:
+                if _has_pause or len(_text_chunks) <= 1:
+                    # Single-shot pipeline, unchanged — streamed as one chunk.
+                    if _backend is not None:
+                        audio_tensor = await run_on_gpu_pool_guarded(
+                            functools.partial(
+                                _run_backend_inference,
+                                _backend, text, language, ref_audio_path, ref_text,
+                                instruct, duration, num_step, guidance_scale, speed,
+                                denoise, postprocess_output, used_seed, effect_preset,
+                                max_chunk_chars, crossfade_ms,
+                            ),
+                            what="TTS generate",
+                        )
+                        sample_rate = _backend.sample_rate
+                    else:
+                        audio_tensor = await run_on_gpu_pool_guarded(
+                            functools.partial(
+                                _run_inference,
+                                _model, text, language, ref_audio_path, ref_text,
+                                instruct, duration, num_step, guidance_scale, speed,
+                                t_shift, denoise, postprocess_output,
+                                layer_penalty_factor, position_temperature,
+                                class_temperature, used_seed, effect_preset,
+                                max_chunk_chars, crossfade_ms,
+                            ),
+                            what="TTS generate",
+                        )
+                        sample_rate = _model.sampling_rate
+                    yield _line({
+                        "type": "start", "sample_rate": sample_rate, "channels": 1,
+                        "format": "pcm16", "total_chunks": 1, "crossfade_ms": 0,
+                        "seed": used_seed,
+                    })
+                    yield _line({"type": "chunk", "seq": 0, "pcm": _pcm16_b64(audio_tensor)})
+                else:
+                    parts = []
+                    sample_rate = None
+                    for i, chunk_text in enumerate(_text_chunks):
+                        # Bounded per chunk + pool-reset on hang (#730 class);
+                        # a timeout surfaces as an "error" event below.
+                        raw, preview, sample_rate = await run_on_gpu_pool_guarded(
+                            functools.partial(_render_stream_chunk, i, chunk_text),
+                            what="TTS generate",
+                        )
+                        parts.append(raw)
+                        if i == 0:
+                            # After the first render so lazy-loading engines
+                            # report their REAL sample rate (see /ws/tts).
+                            yield _line({
+                                "type": "start", "sample_rate": sample_rate,
+                                "channels": 1, "format": "pcm16",
+                                "total_chunks": len(_text_chunks),
+                                "crossfade_ms": crossfade_ms, "seed": used_seed,
+                            })
+                        yield _line({"type": "chunk", "seq": i, "pcm": _pcm16_b64(preview)})
+                    audio_tensor = await run_on_gpu_pool_guarded(
+                        functools.partial(_assemble_stream_chunks, parts, sample_rate),
+                        what="TTS assemble",
+                    )
+
+                _, meta = await _finalize_generation(
+                    audio_tensor, sample_rate, text=text, history_mode=history_mode,
+                    ref_audio_path=ref_audio_path, language=language,
+                    instruct=instruct, resolved_profile_id=resolved_profile_id,
+                    used_seed=used_seed, start_time=start_time,
+                )
+                yield _line({
+                    "type": "done", "id": meta["id"], "audio_path": meta["filename"],
+                    "duration": meta["duration"], "gen_time": meta["gen_time"],
+                    "seed": used_seed, "sample_rate": sample_rate,
+                })
+            except (asyncio.CancelledError, GeneratorExit):
+                # Client went away mid-stream — same semantics as aborting a
+                # classic /generate mid-render: nothing is saved.
+                raise
+            except GpuJobTimeoutError as e:
+                logger.error("Streaming generate timed out: %s", e)
+                yield _line({"type": "error", "detail": str(e)})
+            except ValueError as e:
+                logger.error("Streaming generate validation failed: %s", e)
+                yield _line({"type": "error", "detail": str(e)})
+            except Exception as e:
+                logger.error("Streaming generate failed: %s\n%s", e, traceback.format_exc())
+                yield _line({"type": "error", "detail": _safe_exc_text(e)})
+            finally:
+                # Ownership of the temp reference clip moves to this generator
+                # in stream mode (the route returns before rendering starts).
+                if cleanup_ref and ref_audio_path:
+                    with contextlib.suppress(OSError):
+                        os.remove(ref_audio_path)
+
+        _stream_headers = {
+            "X-Seed": str(used_seed) if used_seed is not None else "",
+            "Cache-Control": "no-cache",
+        }
+        # Routing notice (#21): known before the stream starts, so it rides the
+        # same headers the classic path uses.
+        if _routing_notice:
+            from services.engine_routing import header_safe_reason
+            _stream_headers["X-OmniVoice-Routing"] = _routing_notice[0]
+            _hr = header_safe_reason(_routing_notice[1])
+            if _hr:
+                _stream_headers["X-OmniVoice-Routing-Reason"] = _hr
+        return StreamingResponse(
+            _stream_events(),
+            media_type="application/x-ndjson",
+            headers=_stream_headers,
+        )
+
     try:
-        loop = asyncio.get_running_loop()
         if _backend is not None:
             # Bounded + pool-reset on hang so a wedged generate can't starve the
             # GPU pool and brick the backend ("can't reach backend", #730 class).
@@ -949,56 +1244,18 @@ async def generate_speech(
                 what="TTS generate",
             )
             sample_rate = _model.sampling_rate
-        # Invisible AudioSeal provenance watermark on the final audio. Embedding
-        # was previously only wired into the dub pipeline (dub_generate.py), so
-        # plain TTS came out unmarked despite the setting being on. embed_watermark
-        # self-gates on the user's watermark setting + AudioSeal availability and
-        # passes the audio through unchanged on any failure, so it never breaks
-        # generation.
-        from services.watermark import embed_watermark
-        audio_tensor = await loop.run_in_executor(
-            _gpu_pool, embed_watermark, audio_tensor, sample_rate
+        # Watermark → save → history → prune → emit, shared with the streaming
+        # path (see _finalize_generation) so both flows produce identical takes.
+        audio_tensor, _meta = await _finalize_generation(
+            audio_tensor, sample_rate, text=text, history_mode=history_mode,
+            ref_audio_path=ref_audio_path, language=language, instruct=instruct,
+            resolved_profile_id=resolved_profile_id, used_seed=used_seed,
+            start_time=start_time,
         )
-        gen_time = round(time.time() - start_time, 2)
-
-        audio_id = str(uuid.uuid4())[:8]
-        audio_filename = f"{audio_id}.wav"
-        audio_path = os.path.join(OUTPUTS_DIR, audio_filename)
-        _safe_torchaudio_save(audio_path, audio_tensor, sample_rate)
-
-        audio_dur = round(audio_tensor.shape[-1] / sample_rate, 2)
-
-        # #710: the clip is already generated and saved above. A history-write
-        # failure — e.g. "no such table: generation_history" on a DB that missed
-        # schema init — must NOT 500 the user's generation. Self-heal the schema
-        # once and retry; if it still fails, log and return the audio anyway.
-        def _write_history():
-            with db_conn() as conn:
-                conn.execute(
-                    "INSERT INTO generation_history (id, text, mode, language, instruct, profile_id, audio_path, duration_seconds, generation_time, seed, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
-                    (audio_id, text[:200], history_mode or ("clone" if ref_audio_path else "design"),
-                     language or "Auto", instruct or "", resolved_profile_id,
-                     audio_filename, audio_dur, gen_time, used_seed, time.time())
-                )
-        try:
-            _write_history()
-        except sqlite3.OperationalError as e:
-            logger.warning("generation history write failed (%s); healing schema + retrying", e)
-            try:
-                ensure_schema()
-                _write_history()
-            except Exception as e2:
-                logger.warning("history write still failed after schema heal; returning audio anyway: %s", e2)
-        except Exception as e:
-            logger.warning("generation history write failed; returning audio anyway: %s", e)
-        # Retention cap: without it, takes (rows + WAVs in OUTPUTS_DIR) grow
-        # unbounded forever. Best-effort — a prune failure must never affect
-        # the generation that just succeeded.
-        try:
-            _prune_history_over_cap()
-        except Exception as e:  # noqa: BLE001
-            logger.warning("history retention prune failed (non-fatal): %s", e)
-        event_bus.emit("generation_history", {"action": "created", "id": audio_id})
+        audio_id = _meta["id"]
+        audio_filename = _meta["filename"]
+        audio_dur = _meta["duration"]
+        gen_time = _meta["gen_time"]
 
         buffer = io.BytesIO()
         _safe_torchaudio_save(buffer, audio_tensor, sample_rate, format="wav")

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -3,6 +3,11 @@ import { useAppStore } from '../store';
 import { generateSpeech } from '../api/generate';
 import { pickDesignSeed } from '../utils/seed';
 import { playBlobAudio, playPing } from '../utils/media';
+import {
+  StreamingPreviewError,
+  streamGenerateSpeech,
+  supportsStreamingPreview,
+} from '../utils/streamingTts';
 import { probeAudioDuration } from '../utils/format';
 import { CLONE_MAX_SECONDS, PRESETS } from '../utils/constants';
 import { buildDesignInstruct, designModeProfileId } from '../utils/voiceInstruct';
@@ -202,55 +207,94 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
       // so the backend's descriptive error wins in the normal case.
       const ac = new AbortController();
       abortTimer = setTimeout(() => ac.abort(), 21 * 60 * 1000);
-      const response = await generateSpeech(formData, { signal: ac.signal });
-      const reader = response.body.getReader();
-      const chunks = [];
-      let receivedLength = 0;
-      const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
 
-      // #526: surface the seed the backend actually used so the Design tab can
-      // display it and offer "keep this seed". Authoritative over the client
-      // guess (covers the profile-seed / materialized-seed paths too).
-      const xSeed = parseInt(response.headers.get('X-Seed') || '', 10);
-      if (Number.isInteger(xSeed)) setDesignSeed(xSeed);
+      // Header handling shared by both delivery paths (streaming + classic).
+      const applyResponseHeaders = (response) => {
+        // #526: surface the seed the backend actually used so the Design tab
+        // can display it and offer "keep this seed". Authoritative over the
+        // client guess (covers the profile-seed / materialized-seed paths too).
+        const xSeed = parseInt(response.headers.get('X-Seed') || '', 10);
+        if (Number.isInteger(xSeed)) setDesignSeed(xSeed);
 
-      // #21: one-time, non-blocking routing notice. The backend sets these
-      // headers only on cpu_fallback / accelerated-with-caveat (never on the
-      // benign cpu_only / clean-accelerated paths), so their mere presence is
-      // the signal. De-duped by status so a batch doesn't spam.
-      const routingStatus = response.headers.get('X-OmniVoice-Routing');
-      if (routingStatus && routingStatus !== _lastRoutingStatus) {
-        _lastRoutingStatus = routingStatus;
-        const reason = response.headers.get('X-OmniVoice-Routing-Reason') || '';
-        if (routingStatus === 'cpu_fallback') {
-          toast(t('tts.routingFallback', { reason }), { icon: '🐢' });
-        } else if (routingStatus === 'accelerated' && reason) {
-          // accelerated is only surfaced WITH a driver/arch caveat reason.
-          toast(t('tts.routingCaveat', { reason }), { icon: '⚠️' });
+        // #21: one-time, non-blocking routing notice. The backend sets these
+        // headers only on cpu_fallback / accelerated-with-caveat (never on the
+        // benign cpu_only / clean-accelerated paths), so their mere presence is
+        // the signal. De-duped by status so a batch doesn't spam.
+        const routingStatus = response.headers.get('X-OmniVoice-Routing');
+        if (routingStatus && routingStatus !== _lastRoutingStatus) {
+          _lastRoutingStatus = routingStatus;
+          const reason = response.headers.get('X-OmniVoice-Routing-Reason') || '';
+          if (routingStatus === 'cpu_fallback') {
+            toast(t('tts.routingFallback', { reason }), { icon: '🐢' });
+          } else if (routingStatus === 'accelerated' && reason) {
+            // accelerated is only surfaced WITH a driver/arch caveat reason.
+            toast(t('tts.routingCaveat', { reason }), { icon: '⚠️' });
+          }
         }
-      }
+      };
+      const setProgressPct = (pct) =>
+        setGenerationTime((prev) => `${prev.toString().split(' ')[0]} (${pct}%)`);
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        chunks.push(value);
-        receivedLength += value.length;
-        if (contentLength > 0) {
-          const pct = Math.round((receivedLength / contentLength) * 100);
-          setGenerationTime((prev) => `${prev.toString().split(' ')[0]} (${pct}%)`);
-        }
-      }
-
-      const blob = new Blob(chunks, { type: 'audio/wav' });
-      // #1032: honor the Settings → Appearance "Auto-play preview" pref here
-      // too. #667 added the toggle ("play the output as soon as a render
-      // finishes") but only wired the WaveformPlayer preview sites — the main
-      // generate path kept auto-playing unconditionally. getState() (not a
-      // subscription) so the freshest value is read at completion time.
-      if (useAppStore.getState().autoPlayPreview) {
+      // Streaming preview (feat: streaming-tts-preview): playback starts from
+      // the FIRST synthesized chunk while the rest is still rendering, via
+      // /generate stream=true — instead of staring at the spinner until the
+      // whole render lands. Only when the preview would auto-play anyway, and
+      // only when Web Audio exists (all three Tauri webviews have it; if it's
+      // ever missing we take the classic path below — identical to today).
+      // Any MID-stream failure falls back to the classic whole-file flow with
+      // no user-visible difference beyond the old wait; pre-stream HTTP errors
+      // (ApiError) throw straight to the shared catch, exactly like before.
+      let streamed = false;
+      if (useAppStore.getState().autoPlayPreview && supportsStreamingPreview()) {
         try {
-          await playBlobAudio(blob, { label: t('player.generated_audio') });
-        } catch (e) {}
+          await streamGenerateSpeech(formData, {
+            signal: ac.signal,
+            label: t('player.streaming_preview'),
+            finalLabel: t('player.generated_audio'),
+            onHeaders: applyResponseHeaders,
+            onProgress: setProgressPct,
+          });
+          streamed = true;
+        } catch (err) {
+          if (!(err instanceof StreamingPreviewError)) throw err;
+          console.warn(
+            'Streaming preview failed mid-stream; falling back to the classic generate:',
+            err?.message || err,
+          );
+          addBreadcrumb('generate:stream-fallback');
+        }
+      }
+
+      if (!streamed) {
+        const response = await generateSpeech(formData, { signal: ac.signal });
+        const reader = response.body.getReader();
+        const chunks = [];
+        let receivedLength = 0;
+        const contentLength = parseInt(response.headers.get('Content-Length') || '0', 10);
+
+        applyResponseHeaders(response);
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+          receivedLength += value.length;
+          if (contentLength > 0) {
+            setProgressPct(Math.round((receivedLength / contentLength) * 100));
+          }
+        }
+
+        const blob = new Blob(chunks, { type: 'audio/wav' });
+        // #1032: honor the Settings → Appearance "Auto-play preview" pref here
+        // too. #667 added the toggle ("play the output as soon as a render
+        // finishes") but only wired the WaveformPlayer preview sites — the main
+        // generate path kept auto-playing unconditionally. getState() (not a
+        // subscription) so the freshest value is read at completion time.
+        if (useAppStore.getState().autoPlayPreview) {
+          try {
+            await playBlobAudio(blob, { label: t('player.generated_audio') });
+          } catch (e) {}
+        }
       }
 
       await loadHistory();

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2063,6 +2063,7 @@
   "player": {
     "now_playing": "Now playing",
     "generated_audio": "Generated audio",
+    "streaming_preview": "Streaming preview…",
     "untitled": "Audio",
     "play": "Play",
     "pause": "Pause",

--- a/frontend/src/test/streamingTts.test.js
+++ b/frontend/src/test/streamingTts.test.js
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Streaming TTS preview (feat: streaming-tts-preview): the NDJSON client must
+// start Web Audio playback from the FIRST chunk, register as a tracked
+// 'output' playback (mini-player bar), flip its label on completion, resolve
+// with the "done" metadata — and turn ANY mid-stream failure into
+// StreamingPreviewError so useTTS can fall back to the classic flow.
+
+vi.mock('../api/client', () => ({
+  apiFetch: vi.fn(),
+}));
+
+const { apiFetch } = await import('../api/client');
+const {
+  streamGenerateSpeech,
+  createStreamingChunkPlayer,
+  supportsStreamingPreview,
+  decodePcm16Base64,
+  peaksFromChunkList,
+  StreamingPreviewError,
+} = await import('../utils/streamingTts');
+const { getPlaybackTrack, stopActivePlayback, seekActivePlayback } =
+  await import('../utils/playback');
+
+// ── Web Audio fakes ─────────────────────────────────────────────────────────
+
+class FakeGainParam {
+  setValueAtTime() {}
+  linearRampToValueAtTime() {}
+}
+class FakeGain {
+  constructor() {
+    this.gain = new FakeGainParam();
+  }
+  connect() {}
+  disconnect() {}
+}
+class FakeSource {
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+  connect() {}
+  disconnect() {}
+  start(when, offset) {
+    this.startedAt = { when, offset: offset || 0 };
+    this.ctx.started.push(this);
+  }
+  stop() {
+    this.stopped = true;
+  }
+}
+class FakeAudioContext {
+  static instances = [];
+  constructor() {
+    this.currentTime = 0;
+    this.state = 'running';
+    this.destination = {};
+    this.started = []; // every source that called start()
+    FakeAudioContext.instances.push(this);
+  }
+  resume() {
+    this.state = 'running';
+    return Promise.resolve();
+  }
+  suspend() {
+    this.state = 'suspended';
+    return Promise.resolve();
+  }
+  close() {
+    this.state = 'closed';
+  }
+  createBuffer(channels, length, sampleRate) {
+    const data = new Float32Array(length);
+    return {
+      length,
+      duration: length / sampleRate,
+      numberOfChannels: channels,
+      sampleRate,
+      copyToChannel: (src) => data.set(src),
+      getChannelData: () => data,
+    };
+  }
+  createBufferSource() {
+    return new FakeSource(this);
+  }
+  createGain() {
+    return new FakeGain();
+  }
+}
+
+// ── NDJSON fixtures ─────────────────────────────────────────────────────────
+
+const b64Pcm = (samples) => {
+  // Int16 PCM little-endian → base64.
+  const pcm = new Int16Array(samples);
+  const bytes = new Uint8Array(pcm.buffer);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+};
+
+const CHUNK_SAMPLES = 2400; // 100 ms @ 24 kHz
+
+const startEvent = (totalChunks) => ({
+  type: 'start',
+  sample_rate: 24000,
+  channels: 1,
+  format: 'pcm16',
+  total_chunks: totalChunks,
+  crossfade_ms: 50,
+  seed: 7,
+});
+const chunkEvent = (seq) => ({
+  type: 'chunk',
+  seq,
+  pcm: b64Pcm(Array.from({ length: CHUNK_SAMPLES }, (_, i) => (i % 100) * 50)),
+});
+const doneEvent = {
+  type: 'done',
+  id: 'abc12345',
+  audio_path: 'abc12345.wav',
+  duration: 0.3,
+  gen_time: 1.2,
+  seed: 7,
+  sample_rate: 24000,
+};
+
+const ndjsonResponse = (events, headers = {}) => {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const e of events) controller.enqueue(enc.encode(JSON.stringify(e) + '\n'));
+      controller.close();
+    },
+  });
+  return { headers: new Headers(headers), body: stream };
+};
+
+beforeEach(() => {
+  FakeAudioContext.instances = [];
+  window.AudioContext = FakeAudioContext;
+  apiFetch.mockReset();
+});
+
+afterEach(() => {
+  stopActivePlayback();
+});
+
+// ── unit: codecs ────────────────────────────────────────────────────────────
+
+describe('decodePcm16Base64', () => {
+  it('roundtrips int16 samples to normalized floats', () => {
+    const out = decodePcm16Base64(b64Pcm([0, 16384, -16384, 32767, -32768]));
+    expect(out.length).toBe(5);
+    expect(out[0]).toBe(0);
+    expect(out[1]).toBeCloseTo(0.5, 3);
+    expect(out[2]).toBeCloseTo(-0.5, 3);
+    expect(out[3]).toBeCloseTo(1, 2);
+    expect(out[4]).toBe(-1);
+  });
+});
+
+describe('peaksFromChunkList', () => {
+  it('returns normalized peaks across chunk boundaries', () => {
+    const quiet = new Float32Array(1000).fill(0.1);
+    const loud = new Float32Array(1000).fill(0.8);
+    const peaks = peaksFromChunkList([quiet, loud], 10);
+    expect(peaks.length).toBe(10);
+    expect(Math.max(...peaks)).toBe(1); // normalized
+    expect(peaks[0]).toBeLessThan(peaks[9]); // loud tail dominates
+  });
+  it('handles empty input', () => {
+    expect(peaksFromChunkList([])).toBeNull();
+  });
+});
+
+describe('supportsStreamingPreview', () => {
+  it('is true with an AudioContext and false without', () => {
+    expect(supportsStreamingPreview()).toBe(true);
+    const saved = window.AudioContext;
+    delete window.AudioContext;
+    delete window.webkitAudioContext;
+    expect(supportsStreamingPreview()).toBe(false);
+    window.AudioContext = saved;
+  });
+});
+
+// ── streamGenerateSpeech ────────────────────────────────────────────────────
+
+describe('streamGenerateSpeech', () => {
+  it('plays chunks progressively, flips the label on done, resolves metadata', async () => {
+    apiFetch.mockResolvedValue(
+      ndjsonResponse([startEvent(3), chunkEvent(0), chunkEvent(1), chunkEvent(2), doneEvent], {
+        'X-Seed': '7',
+      }),
+    );
+    const onHeaders = vi.fn();
+    const onProgress = vi.fn();
+
+    const meta = await streamGenerateSpeech(new FormData(), {
+      label: 'Streaming preview…',
+      finalLabel: 'Generated audio',
+      onHeaders,
+      onProgress,
+    });
+
+    expect(meta.id).toBe('abc12345');
+    expect(meta.audio_path).toBe('abc12345.wav');
+    expect(onHeaders).toHaveBeenCalledTimes(1);
+    expect(onProgress).toHaveBeenLastCalledWith(100);
+
+    // All three chunks were scheduled on one context.
+    const ctx = FakeAudioContext.instances[0];
+    expect(ctx.started.length).toBe(3);
+
+    // Tracked 'output' claim → mini-player bar; label flipped at completion;
+    // duration covers the buffered chunks (3 × 100 ms minus 2 × 50 ms fades).
+    const track = getPlaybackTrack();
+    expect(track.source).toBe('output');
+    expect(track.label).toBe('Generated audio');
+    expect(track.duration).toBeCloseTo(0.2, 3);
+    expect(track.peaks?.length).toBeGreaterThan(0);
+    expect(track.canSeek).toBe(true);
+  });
+
+  it('appends stream=true without mutating the caller FormData', async () => {
+    apiFetch.mockResolvedValue(ndjsonResponse([startEvent(1), chunkEvent(0), doneEvent]));
+    const fd = new FormData();
+    fd.append('text', 'hello');
+    await streamGenerateSpeech(fd, {});
+    expect(fd.get('stream')).toBeNull(); // caller's copy untouched
+    const sent = apiFetch.mock.calls[0][1].body;
+    expect(sent.get('stream')).toBe('true');
+    expect(sent.get('text')).toBe('hello');
+  });
+
+  it('turns an in-band error event into StreamingPreviewError and releases the bar', async () => {
+    apiFetch.mockResolvedValue(
+      ndjsonResponse([startEvent(3), chunkEvent(0), { type: 'error', detail: 'engine boom' }]),
+    );
+    await expect(streamGenerateSpeech(new FormData(), {})).rejects.toThrow(StreamingPreviewError);
+    expect(getPlaybackTrack()).toBeNull(); // playback torn down for the fallback
+    expect(FakeAudioContext.instances[0].state).toBe('closed');
+  });
+
+  it('rejects with StreamingPreviewError when the stream ends without done', async () => {
+    apiFetch.mockResolvedValue(ndjsonResponse([startEvent(2), chunkEvent(0)]));
+    await expect(streamGenerateSpeech(new FormData(), {})).rejects.toThrow(StreamingPreviewError);
+  });
+
+  it('wraps a mid-body transport drop but lets pre-stream ApiError through untouched', async () => {
+    // Mid-body drop → StreamingPreviewError (fallback signal).
+    const enc = new TextEncoder();
+    apiFetch.mockResolvedValue({
+      headers: new Headers(),
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(enc.encode(JSON.stringify(startEvent(2)) + '\n'));
+          c.error(new TypeError('network dropped'));
+        },
+      }),
+    });
+    await expect(streamGenerateSpeech(new FormData(), {})).rejects.toThrow(StreamingPreviewError);
+
+    // Pre-stream HTTP failure → original error identity (NO fallback; the
+    // classic flow would fail identically).
+    const apiErr = Object.assign(new Error('400 Bad Request: nope'), { name: 'ApiError' });
+    apiFetch.mockRejectedValue(apiErr);
+    await expect(streamGenerateSpeech(new FormData(), {})).rejects.toBe(apiErr);
+  });
+});
+
+// ── createStreamingChunkPlayer transport ────────────────────────────────────
+
+describe('createStreamingChunkPlayer', () => {
+  it('supports seek within the buffered region (reschedules from the target)', () => {
+    const player = createStreamingChunkPlayer({
+      label: 'x',
+      sampleRate: 24000,
+      crossfadeMs: 0,
+    });
+    player.appendPcm16Base64(chunkEvent(0).pcm);
+    player.appendPcm16Base64(chunkEvent(1).pcm);
+    const ctx = FakeAudioContext.instances[0];
+    const before = ctx.started.length;
+    seekActivePlayback(0.15); // inside chunk 1 (0.1–0.2 s timeline)
+    expect(ctx.started.length).toBeGreaterThan(before); // rescheduled
+    const reseek = ctx.started[ctx.started.length - 1];
+    expect(reseek.startedAt.offset).toBeCloseTo(0.05, 3); // intra-chunk offset
+    expect(getPlaybackTrack().currentTime).toBeCloseTo(0.15, 3);
+    player.fail();
+  });
+
+  it('stop via the manager finishes the player and closes the context', () => {
+    const onDone = vi.fn();
+    const player = createStreamingChunkPlayer({
+      label: 'x',
+      sampleRate: 24000,
+      crossfadeMs: 50,
+      onDone,
+    });
+    player.appendPcm16Base64(chunkEvent(0).pcm);
+    stopActivePlayback();
+    expect(onDone).toHaveBeenCalledWith('stopped');
+    expect(player.stopped).toBe(true);
+    expect(FakeAudioContext.instances[0].state).toBe('closed');
+  });
+});

--- a/frontend/src/utils/playback.js
+++ b/frontend/src/utils/playback.js
@@ -73,8 +73,10 @@ const publish = () => {
  * @returns {{ release: () => void, update: (patch: object) => void }}
  *   `release()` — call when playback ends on its own (idempotent; stale
  *   releases after another claim are no-ops). `update(patch)` — push
- *   track-state changes ({ currentTime, duration, paused, peaks }); stale
- *   updates after another claim are no-ops.
+ *   track-state changes ({ currentTime, duration, paused, peaks }); may also
+ *   carry `label` to retitle the bar mid-playback (the streaming TTS preview
+ *   flips "streaming" → "generated" on completion); stale updates after
+ *   another claim are no-ops.
  */
 export function claimTrackedPlayback({
   stop,
@@ -103,7 +105,9 @@ export function claimTrackedPlayback({
     },
     update: (patch) => {
       if (_current !== entry) return; // superseded — must not clobber the new owner
-      Object.assign(entry.track, patch);
+      const { label: nextLabel, ...trackPatch } = patch;
+      if (nextLabel !== undefined) entry.label = nextLabel;
+      Object.assign(entry.track, trackPatch);
       publish();
     },
   };

--- a/frontend/src/utils/streamingTts.js
+++ b/frontend/src/utils/streamingTts.js
@@ -1,0 +1,349 @@
+/**
+ * streamingTts.js — streaming TTS preview (feat: streaming-tts-preview).
+ *
+ * POSTs /generate with stream=true (NDJSON: "start" → N × "chunk" → "done")
+ * and starts playback from the FIRST received chunk while the backend is
+ * still synthesizing the rest, instead of waiting for the whole render.
+ *
+ * Playback is plain Web Audio (AudioContext + scheduled AudioBufferSource
+ * nodes) — available in all three Tauri webviews (WKWebView / WebView2 /
+ * WebKitGTK) and regular browsers, so the default behavior is identical on
+ * macOS, Windows and Linux (strict repo rule). No MediaSource, which WKWebView
+ * does not reliably support for audio/wav. Chunks are joined with the same
+ * linear crossfade the backend uses for the final file, so the preview
+ * timeline matches the saved take.
+ *
+ * The mini-player integration is the same tracked-'output' claim that
+ * playBlobAudio uses (utils/playback.js), so the GlobalAudioPlayer bar shows
+ * the streaming state (label + growing duration) with live seek inside the
+ * buffered region, pause/resume, and stop.
+ *
+ * Failure contract: ANY problem after the HTTP response starts — an in-band
+ * "error" event, a transport drop mid-body, a Web Audio failure — surfaces as
+ * StreamingPreviewError so the caller (useTTS) can fall back to the classic
+ * whole-file flow with the user none the wiser. Pre-stream HTTP errors keep
+ * their ApiError identity (they would fail the classic flow identically, so
+ * falling back would only duplicate the failure).
+ */
+import { apiFetch } from '../api/client';
+import { claimTrackedPlayback } from './playback';
+
+/** True when the webview can progressively play PCM chunks (Web Audio). */
+export const supportsStreamingPreview = () =>
+  typeof window !== 'undefined' &&
+  typeof (window.AudioContext || window.webkitAudioContext) === 'function';
+
+/** A failure AFTER the stream started — the signal to fall back to the
+ *  classic whole-file /generate flow. */
+export class StreamingPreviewError extends Error {
+  constructor(message, opts) {
+    super(message, opts);
+    this.name = 'StreamingPreviewError';
+  }
+}
+
+/** base64 → Int16 PCM → Float32 samples in [-1, 1]. Exported for tests. */
+export const decodePcm16Base64 = (b64) => {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  const pcm = new Int16Array(bytes.buffer, 0, bytes.length >> 1);
+  const out = new Float32Array(pcm.length);
+  for (let i = 0; i < pcm.length; i++) out[i] = pcm[i] / 32768;
+  return out;
+};
+
+/**
+ * Normalized [0..1] waveform peaks across a LIST of sample chunks — the
+ * incremental twin of media.js computePeaks (which needs one decoded
+ * AudioBuffer). Strided like the original so it stays O(buckets) per call
+ * even for hour-long renders. Exported for tests.
+ */
+export const peaksFromChunkList = (chunkArrays, buckets = 240) => {
+  const total = chunkArrays.reduce((n, c) => n + c.length, 0);
+  if (!total) return null;
+  const n = Math.min(buckets, total);
+  const peaks = Array.from({ length: n }, () => 0);
+  const bucketSize = total / n;
+  const step = Math.max(1, Math.floor(bucketSize / 64));
+  let base = 0;
+  for (const data of chunkArrays) {
+    for (let j = 0; j < data.length; j += step) {
+      const v = Math.abs(data[j]);
+      const b = Math.min(n - 1, Math.floor((base + j) / bucketSize));
+      if (v > peaks[b]) peaks[b] = v;
+    }
+    base += data.length;
+  }
+  const top = Math.max(...peaks, 0.001);
+  return peaks.map((p) => p / top);
+};
+
+/**
+ * Progressive chunk player: schedules each appended PCM chunk on a shared
+ * AudioContext timeline with the backend's crossfade, so playback runs
+ * continuously while later chunks are still being synthesized. If synthesis
+ * is slower than playback, the playhead waits at the buffered edge and
+ * resumes when the next chunk lands (re-anchoring the schedule).
+ *
+ * Registered as a tracked 'output' playback: live time, growing duration,
+ * progressive peaks, seek within the buffered region, pause/resume, stop.
+ * Exported for tests; production entry point is streamGenerateSpeech below.
+ */
+export const createStreamingChunkPlayer = ({ label, sampleRate, crossfadeMs = 0, onDone } = {}) => {
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  const ctx = new Ctx();
+  if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+  const xf = Math.max(0, crossfadeMs) / 1000;
+
+  const chunks = []; // Float32Array per received chunk
+  const starts = []; // timeline start (s) of each chunk, crossfade-overlapped
+  let totalDuration = 0; // buffered timeline seconds
+  let scheduled = []; // live nodes: { src, gain, index }
+  let baseOffset = 0; // timeline position where the current chain started
+  let anchor = 0; // ctx.currentTime when the current chain started
+  let finished = false;
+  let complete = false; // all chunks received (finalize() called)
+  let timer = null;
+
+  const dur = (i) => chunks[i].length / sampleRate;
+  const fadeFor = (i) => (i > 0 ? Math.min(xf, dur(i - 1), dur(i)) : 0);
+  const currentPos = () =>
+    Math.max(0, Math.min(baseOffset + (ctx.currentTime - anchor), totalDuration));
+
+  const finish = (reason) => {
+    if (finished) return;
+    finished = true;
+    if (timer) clearInterval(timer);
+    stopScheduled();
+    try {
+      ctx.close();
+    } catch {
+      /* already closed */
+    }
+    try {
+      onDone?.(reason);
+    } catch {
+      /* consumer callbacks must not break the manager */
+    }
+  };
+
+  const stopScheduled = () => {
+    for (const node of scheduled) {
+      try {
+        node.src.stop();
+      } catch {
+        /* not started / already stopped */
+      }
+      try {
+        node.src.disconnect();
+        node.gain.disconnect();
+      } catch {
+        /* noop */
+      }
+    }
+    scheduled = [];
+  };
+
+  // Schedule chunk `i` at its timeline slot on the current anchor. `intra`
+  // starts mid-chunk (seek); `withFade` crossfades against the chain's tail.
+  const scheduleChunk = (i, intra = 0, withFade = true) => {
+    const buffer = ctx.createBuffer(1, chunks[i].length, sampleRate);
+    // copyToChannel is on every real AudioBuffer; fall back for old shims.
+    if (buffer.copyToChannel) buffer.copyToChannel(chunks[i], 0);
+    else buffer.getChannelData(0).set(chunks[i]);
+    const src = ctx.createBufferSource();
+    const gain = ctx.createGain();
+    src.buffer = buffer;
+    src.connect(gain);
+    gain.connect(ctx.destination);
+
+    const when = anchor + (starts[i] + intra - baseOffset);
+    const fade = withFade && intra === 0 ? fadeFor(i) : 0;
+    const tail = scheduled[scheduled.length - 1];
+    if (fade > 0 && tail) {
+      // Linear crossfade — same shape the backend bakes into the final file.
+      tail.gain.gain.setValueAtTime(1, when);
+      tail.gain.gain.linearRampToValueAtTime(0, when + fade);
+      gain.gain.setValueAtTime(0, when);
+      gain.gain.linearRampToValueAtTime(1, when + fade);
+    }
+    src.start(Math.max(when, ctx.currentTime), intra);
+    scheduled.push({ src, gain, index: i });
+  };
+
+  const session = claimTrackedPlayback({
+    source: 'output',
+    label,
+    stop: () => finish('stopped'),
+    seek: (t) => {
+      if (finished || !chunks.length) return;
+      const target = Math.max(0, Math.min(t, Math.max(0, totalDuration - 0.02)));
+      stopScheduled();
+      let j = 0;
+      for (let i = 0; i < starts.length; i++) if (starts[i] <= target) j = i;
+      baseOffset = target;
+      anchor = ctx.currentTime + 0.02;
+      scheduleChunk(j, target - starts[j], false);
+      for (let i = j + 1; i < chunks.length; i++) scheduleChunk(i);
+      session.update({ currentTime: target });
+    },
+    pause: () => {
+      if (finished) return;
+      ctx
+        .suspend()
+        .then(() => session.update({ paused: true, currentTime: currentPos() }))
+        .catch(() => {});
+    },
+    resume: () => {
+      if (finished) return;
+      ctx
+        .resume()
+        .then(() => session.update({ paused: false }))
+        .catch(() => {});
+    },
+  });
+
+  timer = setInterval(() => {
+    if (finished || ctx.state !== 'running') return;
+    const pos = currentPos();
+    session.update({ currentTime: pos });
+    if (complete && pos >= totalDuration - 0.03) {
+      session.update({ currentTime: totalDuration });
+      session.release();
+      finish('ended');
+    }
+  }, 250);
+
+  return {
+    /** Append one base64 PCM16 chunk and schedule it for gapless playback. */
+    appendPcm16Base64: (b64) => {
+      if (finished) return;
+      const data = decodePcm16Base64(b64);
+      if (!data.length) return;
+      const i = chunks.length;
+      chunks.push(data);
+      starts.push(i === 0 ? 0 : starts[i - 1] + dur(i - 1) - fadeFor(i));
+      totalDuration = starts[i] + dur(i);
+
+      const when = anchor + (starts[i] - baseOffset);
+      if (i > 0 && when < ctx.currentTime - 0.01) {
+        // Underrun: playback drained the buffered chunks before this one
+        // arrived. Re-anchor so the new chunk starts now (the playhead sat at
+        // the buffered edge) instead of clipping its head.
+        baseOffset = starts[i];
+        anchor = ctx.currentTime + 0.02;
+        scheduleChunk(i, 0, false);
+      } else {
+        scheduleChunk(i);
+      }
+      session.update({
+        duration: totalDuration,
+        peaks: peaksFromChunkList(chunks),
+      });
+    },
+    /** All chunks received: freeze the duration and retitle the bar. */
+    finalize: ({ label: finalLabel } = {}) => {
+      if (finished) return;
+      complete = true;
+      const patch = { duration: totalDuration };
+      if (finalLabel) patch.label = finalLabel;
+      session.update(patch);
+    },
+    /** Mid-stream failure: tear down silently (the caller falls back). */
+    fail: () => {
+      if (finished) return;
+      session.release();
+      finish('error');
+    },
+    get stopped() {
+      return finished;
+    },
+  };
+};
+
+/**
+ * Run one streaming generation end-to-end: POST /generate (stream=true),
+ * progressively play the preview, and resolve with the "done" metadata
+ * ({ id, audio_path, duration, gen_time, seed, sample_rate }) once the final
+ * file is saved server-side (same watermark/history/retention pipeline as the
+ * classic flow).
+ *
+ * @param {FormData} formData  The exact classic /generate form (not mutated).
+ * @param {object}   opts
+ * @param {AbortSignal} [opts.signal]
+ * @param {string}   [opts.label]      Bar label while streaming.
+ * @param {string}   [opts.finalLabel] Bar label once generation completes.
+ * @param {(res: Response) => void} [opts.onHeaders]  Same X-Seed / routing
+ *                    header handling as the classic path.
+ * @param {(pct: number) => void}   [opts.onProgress] Chunk progress 0–100.
+ * @throws {StreamingPreviewError} on any mid-stream failure (fall back to the
+ *         classic flow); ApiError/AbortError propagate untouched.
+ */
+export async function streamGenerateSpeech(
+  formData,
+  { signal, label, finalLabel, onHeaders, onProgress } = {},
+) {
+  const fd = new FormData();
+  for (const [k, v] of formData.entries()) fd.append(k, v);
+  fd.append('stream', 'true');
+
+  // Pre-stream failures (400/503/transport) throw ApiError here — identical
+  // to the classic flow, so they are NOT wrapped for fallback.
+  const response = await apiFetch('/generate', { method: 'POST', body: fd, signal });
+  onHeaders?.(response);
+
+  let player = null;
+  let meta = null;
+  try {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    let totalChunks = 0;
+    let received = 0;
+
+    const handleEvent = (ev) => {
+      if (ev.type === 'start') {
+        totalChunks = ev.total_chunks || 0;
+        player = createStreamingChunkPlayer({
+          label,
+          sampleRate: ev.sample_rate,
+          crossfadeMs: ev.crossfade_ms || 0,
+        });
+      } else if (ev.type === 'chunk') {
+        received += 1;
+        player?.appendPcm16Base64(ev.pcm);
+        if (totalChunks > 0) onProgress?.(Math.min(100, Math.round((received / totalChunks) * 100)));
+      } else if (ev.type === 'done') {
+        meta = ev;
+      } else if (ev.type === 'error') {
+        throw new StreamingPreviewError(ev.detail || 'TTS stream reported an error');
+      }
+    };
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line) handleEvent(JSON.parse(line));
+      }
+    }
+    if (!meta) throw new StreamingPreviewError('TTS stream ended without a completion event');
+    player?.finalize({ label: finalLabel });
+    return meta;
+  } catch (err) {
+    try {
+      player?.fail();
+    } catch {
+      /* teardown must not mask the original error */
+    }
+    if (err?.name === 'AbortError' || err instanceof StreamingPreviewError) throw err;
+    // Anything else mid-stream (transport drop, JSON parse, Web Audio) → the
+    // fallback signal.
+    throw new StreamingPreviewError(err?.message || String(err), { cause: err });
+  }
+}

--- a/frontend/src/utils/streamingTts.js
+++ b/frontend/src/utils/streamingTts.js
@@ -313,7 +313,8 @@ export async function streamGenerateSpeech(
       } else if (ev.type === 'chunk') {
         received += 1;
         player?.appendPcm16Base64(ev.pcm);
-        if (totalChunks > 0) onProgress?.(Math.min(100, Math.round((received / totalChunks) * 100)));
+        if (totalChunks > 0)
+          onProgress?.(Math.min(100, Math.round((received / totalChunks) * 100)));
       } else if (ev.type === 'done') {
         meta = ev;
       } else if (ev.type === 'error') {

--- a/tests/test_generate_streaming.py
+++ b/tests/test_generate_streaming.py
@@ -22,6 +22,7 @@ import base64
 import importlib
 import json
 import os
+import sqlite3
 import time
 import zlib
 
@@ -30,6 +31,45 @@ os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
 
 import pytest
 import torch
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_store(tmp_path, monkeypatch):
+    """Pin the outputs dir AND the history DB at throwaway paths for every test
+    here, so a streamed take is saved and read back through the SAME location
+    no matter what ran before.
+
+    Why it's needed: the router SAVES the final WAV through
+    ``api.routers.generation.OUTPUTS_DIR`` while these tests READ it back
+    through ``core.config.OUTPUTS_DIR``. Those are two separate module
+    bindings, and a full-suite run can split them apart — an earlier test that
+    reloads ``core.config`` / ``main`` under a tmp data dir (e.g.
+    ``test_dub_transcribe``'s ``app_client`` fixture) moves one binding and not
+    the other. The save then lands in one dir while the read-back looks in
+    another, so the take "vanishes" — the #1088 CI ``FileNotFoundError``.
+    Pinning BOTH bindings — plus the DB, through the same
+    ``ensure_schema.__globals__`` seam the takes suite uses against the
+    #909/#932 module-purge leak — makes each test hermetic and order-independent.
+    """
+    import core.config as cfg
+    import api.routers.generation as gen
+
+    outdir = tmp_path / "outputs"
+    outdir.mkdir()
+    monkeypatch.setattr(cfg, "OUTPUTS_DIR", str(outdir))
+    monkeypatch.setattr(gen, "OUTPUTS_DIR", str(outdir))
+
+    dbf = tmp_path / "history.db"
+
+    def _get_db():
+        conn = sqlite3.connect(str(dbf))
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    monkeypatch.setitem(gen.ensure_schema.__globals__, "get_db", _get_db)
+    gen.ensure_schema()
 
 LONG_TEXT = (
     "The first sentence sets the scene tonight. "

--- a/tests/test_generate_streaming.py
+++ b/tests/test_generate_streaming.py
@@ -1,0 +1,289 @@
+"""Streaming TTS preview (feat: streaming-tts-preview).
+
+POST /generate with stream=true returns application/x-ndjson events —
+"start" → N × "chunk" (base64 PCM16 preview per text chunk) → "done" — while
+the classic stream=false path stays byte-identical. These tests prove:
+
+  1. Chunks are yielded INCREMENTALLY: the first chunk's audio reaches the
+     client while later chunks are still synthesizing (a mock engine with a
+     per-chunk delay + wall-clock bookkeeping).
+  2. The final saved WAV is byte-identical to the non-streaming output for
+     the same request (same chunking, same per-chunk seeds, same concat /
+     effect-chain / watermark / save pipeline).
+  3. A mid-stream engine failure yields an "error" event (no "done"), writes
+     no history row and saves no file — the client falls back to the classic
+     whole-file flow.
+  4. Short single-chunk text streams as one chunk through the unchanged
+     single-shot pipeline, and the take lands in /history like any other.
+
+Engine layer is stubbed per the test_generate_engine.py idiom.
+"""
+import base64
+import importlib
+import json
+import os
+import time
+import zlib
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import pytest
+import torch
+
+LONG_TEXT = (
+    "The first sentence sets the scene tonight. "
+    "A second sentence carries the middle part. "
+    "The third sentence wraps everything up now."
+)
+
+
+def _tts_mod():
+    """Run-time resolve (see test_generate_engine.py for the rationale)."""
+    return importlib.import_module("services.tts_backend")
+
+
+def _make_deterministic_engine(engine_id="stream-fake", *, delay_s=0.0,
+                               fail_on_call=None):
+    """TTSBackend stub whose output is a pure function of the input text, so
+    the streamed per-chunk renders and the classic whole-request render can be
+    compared bit-for-bit. Optional per-call delay (to observe incrementality)
+    and fail-on-Nth-call (to drive the mid-stream error path)."""
+
+    class _Engine(_tts_mod().TTSBackend):
+        id = engine_id
+        display_name = "Streaming fake engine (test)"
+        gpu_compat = ("cpu",)
+        calls: list = []  # (text, monotonic_start_time)
+
+        @property
+        def sample_rate(self) -> int:
+            return 24000
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return ["multi"]
+
+        @classmethod
+        def is_available(cls):
+            return True, "ready"
+
+        def generate(self, text, **kw) -> torch.Tensor:
+            type(self).calls.append((text, time.monotonic()))
+            if fail_on_call is not None and len(type(self).calls) == fail_on_call:
+                raise RuntimeError("engine exploded mid-stream (test)")
+            if delay_s:
+                time.sleep(delay_s)
+            # Deterministic, text-dependent waveform (crc-seeded sine-ish ramp).
+            amp = 0.2 + (zlib.crc32(text.encode("utf-8")) % 1000) / 2000.0
+            n = 4800  # 200 ms @ 24 kHz
+            return (torch.linspace(-1.0, 1.0, n) * amp).unsqueeze(0)
+
+    return _Engine
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+@pytest.fixture()
+def no_omnivoice_model(monkeypatch):
+    async def _boom():
+        raise AssertionError("get_model() was called — engine selection ignored")
+
+    import api.routers.generation as gen_mod
+    monkeypatch.setattr(gen_mod, "get_model", _boom)
+
+
+def _stream_events(client, data):
+    """POST /generate with stream=true; return [(event_dict, recv_time), ...]."""
+    events = []
+    with client.stream("POST", "/generate", data={**data, "stream": "true"}) as r:
+        assert r.status_code == 200, r.read()
+        assert r.headers["content-type"].startswith("application/x-ndjson")
+        for line in r.iter_lines():
+            if line.strip():
+                events.append((json.loads(line), time.monotonic()))
+    return events
+
+
+def _saved_wav_bytes(filename):
+    from core.config import OUTPUTS_DIR
+    with open(os.path.join(OUTPUTS_DIR, filename), "rb") as f:
+        return f.read()
+
+
+async def _asgi_stream_post(path, form_data):
+    """POST form data straight at the ASGI app, timestamping every
+    http.response.body message as it is SENT — the boundary uvicorn flushes
+    per message. (TestClient/httpx's ASGITransport buffer the whole body, so
+    they cannot observe incrementality.) Returns [(event_dict, sent_time)]."""
+    from urllib.parse import urlencode
+
+    from main import app
+
+    import asyncio
+
+    body = urlencode(form_data).encode()
+    sent = []
+    request_delivered = False
+
+    async def receive():
+        # Deliver the request body once; afterwards BLOCK (never resolve) —
+        # StreamingResponse's listen_for_disconnect awaits receive() in a
+        # loop, and an always-ready receive() busy-spins the event loop
+        # without ever yielding to the response generator (deadlock).
+        nonlocal request_delivered
+        if not request_delivered:
+            request_delivered = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        await asyncio.Event().wait()  # cancelled by the app when it finishes
+
+    async def send(msg):
+        sent.append((msg, time.monotonic()))
+
+    scope = {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "POST", "scheme": "http", "path": path,
+        "raw_path": path.encode(), "query_string": b"", "root_path": "",
+        "client": ("127.0.0.1", 50000), "server": ("127.0.0.1", 3900),
+        "headers": [
+            (b"content-type", b"application/x-www-form-urlencoded"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+    }
+    await app(scope, receive, send)
+
+    start_msg = sent[0][0]
+    assert start_msg["type"] == "http.response.start", sent
+    assert start_msg["status"] == 200, sent
+    events, buf = [], b""
+    for msg, ts in sent[1:]:
+        if msg["type"] != "http.response.body":
+            continue
+        buf += msg.get("body", b"")
+        while b"\n" in buf:
+            line, buf = buf.split(b"\n", 1)
+            if line.strip():
+                events.append((json.loads(line), ts))
+    return events
+
+
+def test_stream_yields_chunks_incrementally(monkeypatch, no_omnivoice_model):
+    """First chunk audio must be SENT to the client BEFORE the last chunk has
+    even started synthesizing — the whole point of the streaming preview."""
+    import asyncio
+
+    fake = _make_deterministic_engine(delay_s=0.25)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "stream-fake", fake)
+
+    events = asyncio.run(_asgi_stream_post("/generate", {
+        "text": LONG_TEXT, "engine": "stream-fake",
+        "seed": "7", "max_chunk_chars": "60", "stream": "true",
+    }))
+    types = [e["type"] for e, _ in events]
+    assert types[0] == "start"
+    assert types[-1] == "done"
+    n_chunks = types.count("chunk")
+    assert n_chunks >= 3, f"expected >=3 text chunks, got {types}"
+    assert len(fake.calls) == n_chunks
+
+    # Incrementality: chunk 0 arrived before the LAST chunk's render started.
+    first_chunk_recv = next(t for e, t in events if e["type"] == "chunk")
+    last_render_start = fake.calls[-1][1]
+    assert first_chunk_recv < last_render_start, (
+        "first chunk was not delivered until after the last chunk began "
+        "rendering — the stream is buffering, not streaming"
+    )
+
+    # Chunk payloads are non-empty PCM16 (whole samples).
+    for e, _ in events:
+        if e["type"] == "chunk":
+            pcm = base64.b64decode(e["pcm"])
+            assert len(pcm) > 0 and len(pcm) % 2 == 0
+
+    start = events[0][0]
+    assert start["sample_rate"] == 24000
+    assert start["total_chunks"] == n_chunks
+    assert start["seed"] == 7
+
+
+def test_stream_final_file_identical_to_classic_output(client, monkeypatch,
+                                                       no_omnivoice_model):
+    """The saved take must be byte-identical whether or not the preview
+    streamed — streaming is a delivery channel, not a different render."""
+    fake = _make_deterministic_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "stream-fake", fake)
+    data = {
+        "text": LONG_TEXT, "engine": "stream-fake",
+        "seed": "42", "max_chunk_chars": "60",
+    }
+
+    classic = client.post("/generate", data=data)
+    assert classic.status_code == 200, classic.text
+    classic_bytes = _saved_wav_bytes(classic.headers["x-audio-path"])
+
+    events = _stream_events(client, data)
+    done = events[-1][0]
+    assert done["type"] == "done"
+    streamed_bytes = _saved_wav_bytes(done["audio_path"])
+
+    assert streamed_bytes == classic_bytes
+    assert done["seed"] == 42
+    assert done["duration"] > 0
+
+
+def test_stream_midstream_error_yields_error_event(client, monkeypatch,
+                                                   no_omnivoice_model):
+    """Chunk 2 blowing up must surface as an in-band error event AFTER the
+    already-delivered chunk — no done, no history row, no saved file."""
+    fake = _make_deterministic_engine(fail_on_call=2)
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "stream-fake", fake)
+
+    before_ids = {h["id"] for h in client.get("/history").json()}
+    events = _stream_events(client, {
+        "text": LONG_TEXT, "engine": "stream-fake",
+        "seed": "7", "max_chunk_chars": "60",
+    })
+    types = [e["type"] for e, _ in events]
+    assert types[0] == "start"
+    assert "chunk" in types            # chunk 0 was delivered before the crash
+    assert types[-1] == "error"
+    assert "done" not in types
+    assert events[-1][0]["detail"]     # actionable message for the fallback log
+
+    after_ids = {h["id"] for h in client.get("/history").json()}
+    assert after_ids == before_ids     # nothing was recorded for the failure
+
+
+def test_stream_short_text_single_chunk(client, monkeypatch, no_omnivoice_model):
+    """Short text = one chunk through the unchanged single-shot pipeline; the
+    take lands in /history exactly like a classic generate."""
+    fake = _make_deterministic_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "stream-fake", fake)
+
+    events = _stream_events(client, {"text": "Hello there.", "engine": "stream-fake"})
+    types = [e["type"] for e, _ in events]
+    assert types == ["start", "chunk", "done"]
+    assert events[0][0]["total_chunks"] == 1
+    assert len(fake.calls) == 1
+
+    done = events[-1][0]
+    ids = {h["id"] for h in client.get("/history").json()}
+    assert done["id"] in ids
+    assert _saved_wav_bytes(done["audio_path"])  # file exists and is non-empty
+
+
+def test_classic_generate_unaffected_by_stream_default(client, monkeypatch,
+                                                       no_omnivoice_model):
+    """stream defaults to false → classic WAV response with the same headers."""
+    fake = _make_deterministic_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "stream-fake", fake)
+    res = client.post("/generate", data={"text": "Hello.", "engine": "stream-fake"})
+    assert res.status_code == 200, res.text
+    assert res.headers.get("content-type") == "audio/wav"
+    assert res.headers.get("x-audio-id")

--- a/tests/test_generate_streaming.py
+++ b/tests/test_generate_streaming.py
@@ -278,6 +278,46 @@ def test_stream_short_text_single_chunk(client, monkeypatch, no_omnivoice_model)
     assert _saved_wav_bytes(done["audio_path"])  # file exists and is non-empty
 
 
+def test_stream_native_model_path(client, monkeypatch, tmp_path):
+    """The native OmniVoice model path streams too (per-chunk generate calls
+    with duration=None), and its saved take matches the classic render."""
+    from unittest.mock import MagicMock
+
+    from core import prefs as _prefs
+    monkeypatch.setattr(_prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
+    monkeypatch.delenv("OMNIVOICE_TTS_BACKEND", raising=False)
+
+    mock_model = MagicMock()
+    mock_model.sampling_rate = 24000
+
+    def _gen(**kw):
+        amp = 0.2 + (zlib.crc32(kw["text"].encode("utf-8")) % 1000) / 2000.0
+        return [(torch.linspace(-1.0, 1.0, 4800) * amp).unsqueeze(0)]
+
+    mock_model.generate.side_effect = lambda **kw: _gen(**kw)
+
+    async def _get():
+        return mock_model
+
+    import api.routers.generation as gen_mod
+    monkeypatch.setattr(gen_mod, "get_model", _get)
+
+    data = {"text": LONG_TEXT, "seed": "9", "max_chunk_chars": "60"}
+    events = _stream_events(client, data)
+    types = [e["type"] for e, _ in events]
+    n_chunks = types.count("chunk")
+    assert n_chunks >= 3 and types[-1] == "done"
+    assert mock_model.generate.call_count == n_chunks
+    for call in mock_model.generate.call_args_list:
+        assert call.kwargs["duration"] is None  # chunk loop contract
+    streamed_bytes = _saved_wav_bytes(events[-1][0]["audio_path"])
+
+    mock_model.generate.reset_mock()
+    classic = client.post("/generate", data=data)
+    assert classic.status_code == 200, classic.text
+    assert streamed_bytes == _saved_wav_bytes(classic.headers["x-audio-path"])
+
+
 def test_classic_generate_unaffected_by_stream_default(client, monkeypatch,
                                                        no_omnivoice_model):
     """stream defaults to false → classic WAV response with the same headers."""


### PR DESCRIPTION
## What

Long scripts made users stare at a spinner until the **entire** audio was synthesized. This adds **streaming TTS playback**: audio starts playing as soon as the first chunk is ready, while the rest generates — as a preview channel layered on top of the existing generate path, not a rewrite of it.

## Backend — `POST /generate` + `stream=true`

- New optional `stream` form field on the existing route (default `false` → classic WAV response, byte-unchanged). With `stream=true` the response is `application/x-ndjson`: `start` → N × `chunk` (base64 PCM16 preview per text chunk, with the same effect chain the final take gets) → `done` (saved take metadata: id, path, duration, gen_time, seed) or in-band `error`.
- **Reuses the existing Wave 1.2 sentence-boundary chunking** (`split_text_into_chunks`) and per-chunk seeding — each chunk is one GPU-pool job whose raw output is yielded immediately, then concatenated with the same crossfade. **Engine-agnostic**: text-level chunking only, works with any `TTSBackend` (and the native OmniVoice path); no per-engine token streaming.
- **The saved file is untouched**: the finalize tail (watermark → save → history row → retention prune → event emit) was extracted verbatim into `_finalize_generation`, now shared by both paths — so the on-disk take is **byte-identical** to a non-streamed render (regression-tested, plus verified over real HTTP).
- `[pause]`-marker inputs and short single-chunk texts keep their unchanged single-shot pipeline and stream as one chunk.
- **Timeout budgets follow #1039**: engine warm-up runs under the model-load budget *before* the stream starts; each chunk then gets its own generate budget, so a long script can't time out merely for being long.
- All prep (engine resolution, routing gate #21, profile/seed/normalization/pronunciation) is 100% shared — a prep failure raises the same HTTP errors as today. `X-Seed` and routing-notice headers ride the streaming response too.

## Frontend

- When the preview would auto-play anyway (`autoPlayPreview` on) **and** Web Audio exists, `useTTS` drives the stream and the **global mini-player (#1042)** starts playback from the first received chunk: scheduled `AudioBufferSource` nodes with the backend's linear crossfade, live seek within the buffered region, progressive waveform peaks, growing duration, and a "Streaming preview…" label that flips to "Generated audio" on completion (i18n'd).
- **Platform parity (strict rule)**: plain `AudioContext` — present in WKWebView, WebView2, and WebKitGTK alike; no MediaSource (unreliable for audio/wav in WKWebView). If Web Audio is ever absent, the code takes the classic path — identical to today on every OS, so no opt-in toggle is needed.
- **Underruns** (synthesis slower than playback): the playhead waits at the buffered edge and resumes when the next chunk lands — no clipped audio.
- **Fallback**: any **mid-stream** failure (in-band `error`, transport drop, Web Audio failure) tears the preview down silently and re-runs the classic whole-file flow — the user sees nothing beyond the old wait. **Pre-stream** HTTP errors keep their `ApiError` identity, so real 400/503s surface exactly as before without a wasted second render.
- No new dependencies; no `package.json` change (root `bun.lock` verified with `bun install --frozen-lockfile`).

## Tests

- **Backend** (`tests/test_generate_streaming.py`): incremental delivery proven at the ASGI-message boundary with a per-chunk-delay mock engine (TestClient/httpx buffer whole bodies and can't observe it); final saved file **byte-identical** to the classic output; mid-stream engine failure → `error` event, no `done`, no history row, no file; single-chunk short text; classic default untouched.
- **Frontend** (`frontend/src/test/streamingTts.test.js`, 11 tests): NDJSON client → progressive scheduling, label flip, metadata resolution; `stream=true` appended without mutating the caller's FormData; error-event / no-done / mid-body-drop → `StreamingPreviewError` (fallback signal) vs pre-stream `ApiError` passthrough; chunk-player seek + stop transport.
- **Verified end-to-end over real HTTP** (uvicorn + fake engine): chunk arrival spread 1.0s across 3 chunks (truly incremental on the wire), saved file byte-identical to the classic take.
- Full frontend suite (1160 tests), touched-area backend suites (78 tests), `test_app_version.py` + `test_no_hardcoded_cjk.py` — all green; oxlint/tsc clean (no new warnings); vite build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds an optional streaming TTS preview path to `POST /generate` via `stream=true`, delivering NDJSON (`start` → base64 PCM16 `chunk`×N → `done`, with in-band `error`). Classic (non-streaming) generation behavior remains unchanged, including byte-identical saved WAV outputs. Mid-stream failures are prevented from creating incomplete history entries/files, and mid-stream streaming failures fall back silently to classic generation on the frontend.

### Backend
- Refactors the shared “successful generation tail” into `_finalize_generation`, which performs:
  - AudioSeal watermark embedding (executor)
  - WAV saving to `OUTPUTS_DIR`
  - Generation-history insertion with best-effort SQLite schema self-healing on `OperationalError`
  - Best-effort history retention pruning
  - `event_bus` emission
- Adds `stream: bool = Form(False)` to `@router.post("/generate")`.
- When `stream=true`:
  - Uses the existing chunking vs single-shot decision (including pause-marker parsing).
  - Streams NDJSON events:
    - `start`
    - per-text-chunk preview PCM16 audio as base64 via `chunk`
    - `done` once the full audio is assembled and finalized
    - `error` for validation/network/timeout/other failures that occur after streaming begins
  - Assembles the final audio (concat + effect chain) and then runs the exact same `_finalize_generation` path to persist the final WAV + history.
  - Client disconnects propagate without saving; in-band mid-stream `error` events avoid writing incomplete outputs/history.
- When `stream=false`:
  - Uses `_finalize_generation` and returns the same classic `audio/wav` semantics as before (including unchanged saved-file identity).

### Frontend
- Introduces `frontend/src/utils/streamingTts.js`:
  - `supportsStreamingPreview()` capability detection.
  - `streamGenerateSpeech(formData, ...)` that requests `stream=true` without mutating the caller’s `FormData`.
  - NDJSON parsing and progressive Web Audio playback (mini-player “output” track), including:
    - seeking/rescheduling within the buffered region
    - waveform/peaks updates
    - duration/progress updates
    - pause/resume via `AudioContext.suspend/resume`
    - teardown/cleanup on failure or stop
  - In-band streaming `error` (and other mid-body transport drops) become `StreamingPreviewError` to trigger fallback; pre-stream HTTP failures keep the original error identity.
- Updates `frontend/src/hooks/useTTS.js`:
  - Uses streaming preview only when `autoPlayPreview` is enabled and `supportsStreamingPreview()` is true.
  - Centralizes shared response-header handling via `applyResponseHeaders`:
    - updates UI seed from `X-Seed`
    - shows a one-time de-duped routing notice based on `X-OmniVoice-Routing`
  - Falls back to classic generation on `StreamingPreviewError`; pre-stream HTTP errors retain existing behavior.
- Adds `player.streaming_preview` i18n string (“Streaming preview…”).
- Clarifies mini-player retitling behavior in `frontend/src/utils/playback.js` so `update({ label })` retitles the active entry without merging `label` into the track payload.

#### Player flow

```mermaid
flowchart LR
  A[Generate with autoplay preview enabled] --> B{supportsStreamingPreview?}
  B -- No --> C[Classic whole-file generation]
  B -- Yes --> D[POST /generate with stream=true]
  D --> E{Outcome}
  E -- start/chunks/done --> F[Progressive mini-player playback + seek/waveform/progress updates]
  E -- Mid-stream in-band error/transport drop --> G[Throw StreamingPreviewError → fallback silently]
  E -- Pre-stream HTTP/validation error --> H[Preserve existing error behavior]
  F --> I[Finalize: persist WAV + history on backend; update status/label on completion]
  G --> C
```

### Validation & test reliability
- Backend/end-to-end tests for streaming preview validate:
  - NDJSON event ordering (`start` → incremental `chunk`s → `done`)
  - incremental delivery (first chunk arrives before later chunks finish rendering)
  - short inputs producing a single chunk while following the same persisted-history/file flow
  - mid-stream engine exception semantics: in-band `error`, no `done`, and no new history entry
  - native OmniVoice path parity: streamed saved WAV matches classic saved WAV
  - classic generation remains `audio/wav` with the expected `x-audio-id`
- Frontend unit tests cover:
  - PCM16 base64 decoding, waveform peak extraction, and streaming helpers
  - playback scheduling/teardown/seek behavior in Web Audio fakes
  - fallback wrapping rules (`StreamingPreviewError` only for mid-stream issues; pre-stream errors unchanged)
  - `streamGenerateSpeech` appends `stream=true` without mutating caller `FormData`
- Test stability fix: an autouse fixture pins both `OUTPUTS_DIR` bindings and the history database to per-test temporary paths, preventing saved-file lookups from diverging during full-suite runs and resolving the previously observed deterministic failures.
- Includes native OmniVoice coverage updates and an `oxfmt` line-length adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->