### PR TITLE
fix: wizard version in masthead, mirror-unreachable rescue, lifecycle-aware backend reachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+### Fixed
+
+- **"Can't reach the local OmniVoice backend" stopped crying wolf during startups and restarts.** A real backend start or auto-restart takes 10–20+ seconds (Python spawn plus the PyTorch import), but the app's transport retry only bridged ~3 seconds — every click inside that window dead-ended with the scary toast, over and over, even though the backend healed itself moments later. The app now asks the desktop shell whether a start/restart is actually in progress and simply waits for it (up to the shell's own 2-minute restart budget), and shows a single "backend is restarting — hang tight" banner with a "back — carrying on" confirmation — the reconnecting affordance the supervisor has promised since #567. A truly dead backend (or a non-desktop deployment) still errors promptly, and the crash notice keeps telling the honest story.
+
+- **A dead Hugging Face mirror can no longer strand the first-run wizard.** When a model download failed because the *configured* mirror was unreachable, the error pointed at Settings — which first-run users can't open (the wizard gates the studio) — and falsely claimed the mirror setting only applies after a restart (downloads actually pick it up per call, immediately). Now the wizard shows the mirror quick-pick (including "Hugging Face (official)") right next to the failed download and retries it the moment you switch; the corrected hint says retry-first, restart only if it still fails. Two backend holes in the same flow are closed too: switching endpoints clears the "failed recently" retry cooldown (no more 429 on the immediate retry), and clearing to official also removes the legacy `hf_endpoint` pref, which used to silently keep the dead mirror in effect.
+
+### Changed
+
+- **The first-run wizard shows the app version in its masthead**, next to the OmniVoice Studio title — so setup-time screenshots and bug reports identify the build at a glance (the install splash already did).
+
 ## [0.3.18] — 2026-07-12
 
 The self-sufficiency release. Two long-standing "works on my network / works after four terminal commands" walls came down: model downloads now find a reachable Hugging Face endpoint on their own (no more restricted-network first-run dead-ends), and IndexTTS-2 — previously the only engine that demanded a manual clone-venv-install ritual — installs itself with one click. Under the hood, a test-debt sweep hardened the suite that guards all of it.

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -845,12 +845,25 @@ def set_hf_mirror(body: _HFMirrorBody):
             user_env.unset_user_env(_HF_ENDPOINT_ENV)
             os.environ.pop(_HF_ENDPOINT_ENV, None)
         from core import prefs
-        if mode == "auto":
-            prefs.delete("hf_endpoint")  # the pref fallback is explicit config too
+        if not url:
+            # No endpoint anywhere: clearing to official (manual) or switching
+            # to auto must also drop the legacy `hf_endpoint` pref fallback —
+            # otherwise it silently keeps resolving as an explicit mirror and
+            # "switch to official" doesn't actually switch.
+            prefs.delete("hf_endpoint")
         endpoint_race.set_mode_pref(mode)
     except Exception:
         logger.exception("set_hf_mirror failed")
         raise HTTPException(status_code=500, detail="Failed to persist mirror setting")
+    # An endpoint change invalidates the failed-recently install cooldowns: the
+    # user's next action is "retry that download on the new endpoint", and a
+    # 429 would dead-end the wizard's switch-and-retry flow.
+    try:
+        from api.routers.setup.download import clear_install_cooldowns
+
+        clear_install_cooldowns()
+    except Exception:  # pragma: no cover — cooldown reset must never fail the save
+        logger.warning("could not clear install cooldowns after mirror change", exc_info=True)
     if mode == "auto":
         # Freshly chosen Auto should show a real pick immediately — race now
         # unless a fresh cached decision already exists (probes are ≤3 s and

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -52,6 +52,15 @@ def _sweep_cooldowns(now: float) -> None:
     for k in stale:
         _install_cooldowns.pop(k, None)
 
+
+def clear_install_cooldowns() -> None:
+    """Reset every install cooldown. Called when the HF endpoint changes
+    (PUT /hf-mirror): the cooldown exists to stop hammering a network that
+    just failed, but switching endpoints changes that situation — the user's
+    very next action is "retry the failed download on the new mirror", and a
+    429 there would dead-end the wizard's switch-and-retry flow."""
+    _install_cooldowns.clear()
+
 # Repo_ids the user asked to cancel (FDL-11). Checked between retry attempts.
 # Note: a single in-flight snapshot_download/Xet fetch is not interruptible
 # mid-file in hf_hub 1.7.2 — cancel stops further retries, marks the row
@@ -552,14 +561,17 @@ async def install_model(req: InstallModelRequest):
             # unreachable, name the mirror + the setting instead of leaking the
             # raw connectivity error. #959: likewise for the SOCKS-proxy class
             # (missing socksio fails the download's session construction).
-            # No-op for every other failure.
-            from core.failure import append_hint
+            # No-op for every other failure. docs_topic carries the failure
+            # class so the wizard can react structurally (HF_MIRROR_UNREACHABLE
+            # raises the inline mirror picker) without string-matching.
+            from core.failure import append_hint, classify
             hf_progress.emit({
                 "repo_id": req.repo_id,
                 "filename": req.repo_id,
                 "downloaded": 0, "total": 0, "pct": 0.0,
                 "phase": "install_error",
                 "error": append_hint(str(e)),
+                "docs_topic": classify(str(e)),
             })
         finally:
             _cancelled.discard(req.repo_id)

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -141,10 +141,13 @@ def hf_mirror_hint(reason: Optional[str]) -> str:
     and a non-default mirror endpoint is configured; "" otherwise.
 
     The hint names the configured mirror, says it may be down, points at the
-    setting (Settings → Models → Hugging Face mirror), suggests the official
-    endpoint when the model isn't cached yet, and notes the restart
-    requirement (HF reads HF_ENDPOINT at import time — see the hf-mirror
-    endpoints in api/routers/settings.py). Never raises.
+    setting (Settings → Models → Hugging Face mirror; during first-run the
+    wizard renders its own inline picker), and suggests the official endpoint
+    when the model isn't cached yet. Model *downloads* pick up a mirror change
+    immediately (PUT /hf-mirror updates os.environ and the download paths
+    resolve the endpoint per call) — only transformers-side model *loads*,
+    which read HF_ENDPOINT at import time, still need a restart, so restart is
+    framed as the fallback when a retry still fails. Never raises.
     """
     mirror = configured_hf_mirror()
     if not mirror:
@@ -166,9 +169,11 @@ def hf_mirror_hint(reason: Optional[str]) -> str:
         f"Your Hugging Face mirror is set to {mirror}, which couldn't be "
         "reached — the mirror may be down or blocked on your network. If the "
         'model isn\'t in your local cache yet, switch to "Hugging Face '
-        '(official)" in Settings → Models → Hugging Face mirror (or wait for '
-        "the mirror to recover), then restart OmniVoice — the mirror setting "
-        "is applied when the app starts."
+        '(official)" in Settings → Models → Hugging Face mirror — during '
+        "first-run setup, use the mirror picker right on this screen — or "
+        "wait for the mirror to recover, then retry: downloads pick up a "
+        "mirror change immediately. If a retry still fails after switching, "
+        "restart OmniVoice."
     )
 
 

--- a/docs/downloading-models.md
+++ b/docs/downloading-models.md
@@ -102,7 +102,12 @@ first run, the setup wizard's network check reports which endpoint the
 automatic selection picked, and still offers the mirror quick-pick when
 nothing is reachable — the check is a warning, not a blocker, so an offline
 or firewalled machine can still finish setup once models are available
-(mirror, or manual download below). Caveats:
+(mirror, or manual download below). If a wizard download fails because the
+**configured** mirror is unreachable, the same quick-pick (including
+**Hugging Face (official)**) appears right next to the failed row — switching
+applies to downloads **immediately** (no restart; only already-loaded engines
+re-read the endpoint at startup), clears the retry cooldown, and retries the
+failed download at once. Caveats:
 
 - A mirror serves the **classic** download path, **not Xet** — you lose
   chunk-dedup and Xet's parallel fetch, but you gain reachability. On the

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -444,6 +444,28 @@ call.
 > paths scrubbed. The raw markers live next to the backend logs in
 > `backend_crash_markers.json`.
 
+## 14b. "Can't reach the local OmniVoice backend" flashing during startup or an automatic restart
+
+**Symptom (older builds):** while the backend was still starting — or while the
+desktop shell was auto-restarting a crashed backend — every click produced a
+**"Can't reach the local OmniVoice backend"** toast, over and over, even though
+the backend came back on its own a few seconds later.
+
+**Cause:** a real backend start/restart takes **10–20+ seconds** (Python venv
+spawn plus the PyTorch import), but the UI's transport retry only bridged ~3
+seconds before giving up — so every request landing inside that window
+dead-ended with the scary toast, which read as a recurring bug rather than a
+self-heal in progress.
+
+**Fixed:** newer desktop builds ask the shell whether a start/restart is
+actually in progress and simply **wait for it** (up to 2 minutes, matching the
+shell's own restart budget) instead of erroring, and show a single pinned
+**"backend is restarting — hang tight"** banner while it happens, followed by a
+"backend is back" confirmation. A backend that is *truly* dead (the shell gave
+up, or you're not running the desktop app) still errors promptly. If you see
+the error persistently on a current build, that's section **14** (a wedged GPU
+job) or the crash notice above — not this window.
+
 ## 15. Stuck at "preparing" forever after a crash / BSOD (Windows)
 
 **Symptom:** after an unclean shutdown (Windows BSOD, forced power-off), every

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,6 +44,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import FloatingPill from './components/FloatingPill';
 import GlobalAudioPlayer from './components/GlobalAudioPlayer';
 import BackendCrashNotice from './components/BackendCrashNotice';
+import BackendRestartBanner from './components/BackendRestartBanner';
 // RemoteAuthGate is mounted at the true outermost provider in main-app.jsx so
 // it covers all app states (setup check / wizard / bootstrap), not just the
 // main studio return below. Do not re-wrap here — double-gating renders two
@@ -1248,6 +1249,9 @@ function App() {
         {/* Double-click-to-maximize is handled globally in main.jsx for every
             drag region (splash, first-run, wizard, main) on all platforms. */}
         <div data-tauri-drag-region className="app-wizard-dragstrip" />
+        {/* The wizard is where the multi-GB downloads happen — a mid-download
+            backend restart needs its banner here too, not only in the studio. */}
+        <BackendRestartBanner />
         <Suspense fallback={<LazyFallback />}>
           <SetupWizard
             onReady={() => {
@@ -1328,6 +1332,11 @@ function App() {
       {/* #941: honest surfacing of backend process crashes (exit code +
           stderr tail from the shell's crash marker), with ack-on-view. */}
       <BackendCrashNotice />
+
+      {/* #567's visible half: while the shell auto-restarts a dead backend
+          (10–20 s), say so once — instead of every request surfacing its own
+          "Can't reach the backend" toast. */}
+      <BackendRestartBanner />
 
       <Header
         mode={mode}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,7 @@ import {
   crashAge,
   type BackendCrashMarker,
 } from '../utils/backendCrash.ts';
+import { backendLifecycleStage } from '../utils/backendLifecycle.ts';
 
 const viteEnv = import.meta.env ?? {};
 // Remote-backend settings (Wave 2.3): user-configured in Settings → Sharing.
@@ -116,9 +117,21 @@ async function readError(res: Response): Promise<string> {
 
 // Backoff (ms) for retrying a *transport-level* failure — the backend briefly
 // down while the auto-restart supervisor brings it back (#567/#570/#571). One
-// short cascade (~2.9 s total) so a restart window becomes invisible, yet a
+// short cascade (~2.9 s total) so a blip becomes invisible, yet a
 // genuinely-down backend still surfaces the actionable error promptly.
 const TRANSPORT_RETRY_BACKOFF_MS = [400, 900, 1600];
+
+// A REAL backend start/restart is 10–20+ s (venv python spawn + torch
+// import), not 2.9 s — measured on a 16 GB M-series Mac; slower disks take
+// longer. When the desktop shell says the backend is starting/restarting
+// (bootstrap_status ≠ ready/failed), keep retrying at this interval instead
+// of dead-ending every request mid-restart with "Can't reach the local
+// OmniVoice backend". Bounded by STARTUP_GRACE_MS (matches the supervisor's
+// own 120 s respawn-health wait in src-tauri/src/bootstrap.rs); the shell
+// flipping to `failed` — or being absent (browser/Docker) — exits the wait
+// immediately, so a truly dead backend still errors promptly.
+const RESTART_WAIT_INTERVAL_MS = 1500;
+const STARTUP_GRACE_MS = 120_000;
 
 export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Response> {
   const pin = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('ov_pin') : null;
@@ -134,6 +147,7 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
     : opts;
   const signal = finalOpts.signal as AbortSignal | null | undefined;
   let lastDetail = '';
+  const startedAt = Date.now();
   for (let attempt = 0; ; attempt++) {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     let res: Response;
@@ -152,6 +166,24 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
       if (attempt < TRANSPORT_RETRY_BACKOFF_MS.length) {
         await new Promise((r) => setTimeout(r, TRANSPORT_RETRY_BACKOFF_MS[attempt]));
         continue;
+      }
+      // The short cascade is exhausted, but the desktop shell may KNOW the
+      // backend is mid-start/restart (a real one takes 10–20+ s — torch
+      // import — not 2.9 s). Keep waiting exactly as long as the shell says
+      // "starting", bounded by STARTUP_GRACE_MS; 'failed'/'unknown' (no
+      // shell, or the shell gave up) falls through to the error below so a
+      // truly dead backend still surfaces promptly.
+      if (Date.now() - startedAt < STARTUP_GRACE_MS) {
+        let stage = 'unknown';
+        try {
+          stage = await backendLifecycleStage();
+        } catch {
+          /* never let the lifecycle probe mask the real transport error */
+        }
+        if (stage === 'starting') {
+          await new Promise((r) => setTimeout(r, RESTART_WAIT_INTERVAL_MS));
+          continue;
+        }
       }
       // #941: if the desktop shell recorded an unacknowledged backend crash,
       // tell the honest story instead of the vague "can't reach" — and let

--- a/frontend/src/components/BackendRestartBanner.jsx
+++ b/frontend/src/components/BackendRestartBanner.jsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-hot-toast';
+import { Loader, AlertTriangle, X } from 'lucide-react';
+import { Button } from '../ui';
+
+/**
+ * BackendRestartBanner — the visible half of the #567 supervisor.
+ *
+ * The desktop shell auto-restarts a backend that dies mid-session and emits
+ * `backend-restarting` / `backend-restored` / `backend-restart-failed` Tauri
+ * events (src-tauri/src/bootstrap.rs promised a frontend banner for them —
+ * this is it; until now nothing listened). Without it, a 10–20 s respawn
+ * window was invisible: every in-flight request surfaced its own "Can't
+ * reach the local OmniVoice backend" toast with zero context, which read as
+ * a recurring bug rather than a self-heal in progress.
+ *
+ * While restarting: a quiet pinned banner ("restarting — hang tight");
+ * api/client.ts is simultaneously holding requests open via
+ * backendLifecycleStage(), so most of the time the banner is ALL the user
+ * sees before work resumes. Restored: brief success toast. Failed (restart
+ * budget exhausted): a persistent danger banner — BackendCrashNotice and the
+ * bootstrap splash own the deeper forensics.
+ *
+ * Outside the Tauri shell there are no lifecycle events; renders nothing.
+ */
+export default function BackendRestartBanner() {
+  const { t } = useTranslation();
+  const [state, setState] = useState(null); // null | 'restarting' | 'failed'
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return undefined;
+    let alive = true;
+    let unlisteners = [];
+    (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        unlisteners = await Promise.all([
+          listen('backend-restarting', () => {
+            if (alive) setState('restarting');
+          }),
+          listen('backend-restored', () => {
+            if (!alive) return;
+            setState(null);
+            toast.success(t('backend.restored', 'Voice backend is back — carrying on.'));
+          }),
+          listen('backend-restart-failed', () => {
+            if (alive) setState('failed');
+          }),
+        ]);
+        if (!alive) unlisteners.forEach((u) => u());
+      } catch {
+        /* shell events unavailable (web preview) — nothing to show */
+      }
+    })();
+    return () => {
+      alive = false;
+      unlisteners.forEach((u) => u());
+    };
+  }, [t]);
+
+  if (!state) return null;
+
+  const failed = state === 'failed';
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed left-1/2 top-[var(--space-4)] z-[70] flex w-[min(600px,92vw)] -translate-x-1/2 items-center gap-[var(--space-3)] rounded-lg border border-border bg-bg-elev-1 px-[var(--space-4)] py-[var(--space-3)] shadow-lg backdrop-blur-md"
+    >
+      {failed ? (
+        <AlertTriangle size={16} className="shrink-0 text-danger" aria-hidden />
+      ) : (
+        <Loader size={16} className="shrink-0 animate-spin text-warn" aria-hidden />
+      )}
+      <span className="flex-1 text-[length:var(--text-sm)] text-fg">
+        {failed
+          ? t(
+              'backend.restart_failed',
+              "The voice backend keeps crashing and couldn't be restarted — check the crash notice or Settings → Logs → Backend.",
+            )
+          : t(
+              'backend.restarting',
+              'The voice backend stopped and is restarting automatically — hang tight, this takes ~15 seconds.',
+            )}
+      </span>
+      {failed && (
+        <Button
+          variant="ghost"
+          size="sm"
+          iconSize="sm"
+          onClick={() => setState(null)}
+          title={t('common.close', 'Close')}
+        >
+          <X size={12} />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MirrorRescue.jsx
+++ b/frontend/src/components/MirrorRescue.jsx
@@ -1,0 +1,106 @@
+/**
+ * MirrorRescue — the restricted-network escape hatch of the first-run wizard.
+ *
+ * Users behind restricted networks (e.g. China, where huggingface.co is
+ * blocked) can't reach Settings yet — the wizard gates the studio — so the
+ * mirror quick-pick has to live right in the wizard. It renders in two spots:
+ *   - step 0 (System) when the network preflight can't reach the HF endpoint,
+ *   - step 1 (Models) when a model install failed because the CONFIGURED
+ *     mirror is unreachable (docs_topic HF_MIRROR_UNREACHABLE) — switching
+ *     mirrors and retrying right here beats a hint pointing at Settings the
+ *     user can't open yet.
+ * PUT /hf-mirror takes effect immediately for downloads (no restart during
+ * setup) and clears the install cooldown, so onApplied can retry at once.
+ */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { apiJson, apiFetch } from '../api/client';
+import { Button } from '../ui';
+
+export default function MirrorRescue({ onApplied }) {
+  const { t } = useTranslation();
+  const [presets, setPresets] = useState([]);
+  const [url, setUrl] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    apiJson('/api/settings/hf-mirror')
+      .then((d) => {
+        if (!alive) return;
+        // Keep the official preset (empty url) too: when the CONFIGURED
+        // mirror is the thing that's unreachable, official IS the rescue.
+        setPresets(d?.presets || []);
+        setUrl(d?.configured || '');
+      })
+      .catch(() => {
+        /* endpoint unavailable — keep the free-text input usable */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const apply = async (value) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch('/api/settings/hf-mirror', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: value }),
+      });
+      setUrl(value);
+      onApplied();
+    } catch (e) {
+      setError(e?.message || t('setup.mirror_apply_error'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 flex flex-col gap-1.5 rounded-md border border-border px-3 py-2.5">
+      <span className="text-sm font-semibold">{t('setup.mirror_rescue_title')}</span>
+      <span className="text-xs leading-snug text-fg-muted">{t('setup.mirror_rescue_hint')}</span>
+      {error && (
+        <span className="text-xs text-danger" role="alert">
+          {error}
+        </span>
+      )}
+      <div className="mt-1 flex flex-wrap items-center gap-2">
+        {presets.map((p) => (
+          <Button
+            key={p.url || 'official'}
+            variant="preset"
+            size="sm"
+            disabled={saving}
+            onClick={() => apply(p.url)}
+            data-testid={`wizard-mirror-${p.url || 'official'}`}
+          >
+            {p.label}
+          </Button>
+        ))}
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://hf-mirror.com"
+          className="min-w-[220px] flex-1 rounded border border-border bg-transparent px-2 py-1 font-mono text-xs text-fg"
+          data-testid="wizard-mirror-url"
+        />
+        <Button
+          variant="subtle"
+          size="sm"
+          loading={saving}
+          disabled={saving || !url.trim()}
+          onClick={() => apply(url.trim())}
+          data-testid="wizard-mirror-apply"
+        >
+          {t('setup.mirror_apply')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WizardLibrary.jsx
+++ b/frontend/src/components/WizardLibrary.jsx
@@ -26,6 +26,7 @@ import { useModels, useInstallModel } from '../api/hooks';
 import { setupDownloadStreamUrl } from '../api/setup';
 import { listEngines, selectEngine } from '../api/engines';
 import { notifyEngineSelected } from '../utils/engineSelectToast';
+import MirrorRescue from './MirrorRescue';
 import { Badge, Button } from '../ui';
 
 const fmtGB = (gb) => (gb == null ? '' : `${gb.toFixed(gb < 10 ? 1 : 0)} GB`);
@@ -125,8 +126,19 @@ export function reduceWizardDownloadEvent(prev, ev) {
     return next;
   }
   // Error terminal → KEEP the row + its message so it renders with a Retry.
+  // docs_topic carries the backend's failure class (core.failure.classify) so
+  // the wizard can react structurally — e.g. HF_MIRROR_UNREACHABLE raises the
+  // inline mirror picker — instead of string-matching the error text.
   if (ev.phase === 'install_error') {
-    return { ...prev, [ev.repo_id]: { ...cur, phase: 'install_error', error: ev.error } };
+    return {
+      ...prev,
+      [ev.repo_id]: {
+        ...cur,
+        phase: 'install_error',
+        error: ev.error,
+        docsTopic: ev.docs_topic || '',
+      },
+    };
   }
   // Authoritative overall progress (download_aggregator).
   if (ev.phase === 'aggregate') {
@@ -155,6 +167,19 @@ export function reduceWizardDownloadEvent(prev, ev) {
     },
   };
   return { ...prev, [ev.repo_id]: { ...cur, files } };
+}
+
+/**
+ * Repo ids whose install failed because the CONFIGURED Hugging Face mirror is
+ * unreachable (#874 class). Non-empty → the wizard shows the inline mirror
+ * picker next to the failed rows: during first-run the Settings panel the
+ * error hint names is unreachable (the wizard gates the studio), so the
+ * switch-and-retry affordance must live right here. Pure + exported for tests.
+ */
+export function mirrorBlockedRepos(progress) {
+  return Object.entries(progress || {})
+    .filter(([, p]) => p?.phase === 'install_error' && p?.docsTopic === 'HF_MIRROR_UNREACHABLE')
+    .map(([repoId]) => repoId);
 }
 
 // LED dot tone per row state.
@@ -324,7 +349,7 @@ export default function WizardLibrary() {
         size={fmtGB(m.size_gb)}
         sub={
           errored ? (
-            <span className="block max-w-[280px] font-mono text-[0.64rem] leading-snug text-danger">
+            <span className="block max-w-[520px] font-mono text-[0.64rem] leading-snug text-danger">
               {t('firstrun.lib_install_failed', {
                 error: p.error,
                 defaultValue: 'Install failed: {{error}}',
@@ -424,6 +449,16 @@ export default function WizardLibrary() {
         </Button>
       )}
       {showTail && tail.map((m) => modelRow(m, t('firstrun.chip_optional', 'optional'), 'opt'))}
+      {/* A download failed because the CONFIGURED mirror is unreachable: the
+          error hint points at Settings, but the wizard gates the studio — so
+          the mirror picker renders right here. PUT /hf-mirror applies to
+          downloads immediately and clears the install cooldown, so the failed
+          rows retry the moment a new endpoint is applied. */}
+      {mirrorBlockedRepos(progress).length > 0 && (
+        <MirrorRescue
+          onApplied={() => mirrorBlockedRepos(progress).forEach((repoId) => install(repoId))}
+        />
+      )}
       {Object.keys(progress).length > 0 && (
         <p className="m-0 text-xs text-fg-subtle">
           {t(

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1778,6 +1778,11 @@
     "stderr_title": "Last error output (stderr)",
     "no_stderr": "No error output was captured."
   },
+  "backend": {
+    "restarting": "The voice backend stopped and is restarting automatically — hang tight, this takes ~15 seconds.",
+    "restored": "Voice backend is back — carrying on.",
+    "restart_failed": "The voice backend keeps crashing and couldn't be restarted — check the crash notice or Settings → Logs → Backend."
+  },
   "common": {
     "open": "Open",
     "cancel": "Cancel",

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { Loader, RotateCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSetupStatus, usePreflight } from '../api/hooks';
-import { apiJson, apiFetch } from '../api/client';
 import WizardLibrary from '../components/WizardLibrary';
 import MediaEngineCard from '../components/MediaEngineCard';
+import MirrorRescue from '../components/MirrorRescue';
 import HfTokenCard from '../components/HfTokenCard';
 import DictationDemo from '../components/DictationDemo';
+import { APP_VERSION } from '../utils/appVersion';
 import { Button } from '../ui';
 
 // macOS convention: double-click the title-bar drag region to toggle zoom.
@@ -132,101 +133,6 @@ function PreflightPanel({ report, loading, onRecheck }) {
         ))}
       </div>
     </section>
-  );
-}
-
-/* ── Mirror rescue — restricted-network escape hatch on step 0 ─────────── */
-
-/**
- * Shown when the network preflight check can't reach the Hugging Face
- * endpoint. Users behind restricted networks (e.g. China, where
- * huggingface.co is blocked) can't reach Settings yet — the wizard gates the
- * studio — so the mirror quick-pick has to live right here. PUT /hf-mirror
- * takes effect immediately for downloads (no restart during setup).
- */
-function MirrorRescue({ onApplied }) {
-  const { t } = useTranslation();
-  const [presets, setPresets] = useState([]);
-  const [url, setUrl] = useState('');
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
-
-  useEffect(() => {
-    let alive = true;
-    apiJson('/api/settings/hf-mirror')
-      .then((d) => {
-        if (!alive) return;
-        setPresets((d?.presets || []).filter((p) => p.url));
-        setUrl(d?.configured || '');
-      })
-      .catch(() => {
-        /* endpoint unavailable — keep the free-text input usable */
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  const apply = async (value) => {
-    setSaving(true);
-    setError(null);
-    try {
-      await apiFetch('/api/settings/hf-mirror', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: value }),
-      });
-      setUrl(value);
-      onApplied();
-    } catch (e) {
-      setError(e?.message || t('setup.mirror_apply_error'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className="mt-3 flex flex-col gap-1.5 rounded-md border border-border px-3 py-2.5">
-      <span className="text-sm font-semibold">{t('setup.mirror_rescue_title')}</span>
-      <span className="text-xs leading-snug text-fg-muted">{t('setup.mirror_rescue_hint')}</span>
-      {error && (
-        <span className="text-xs text-danger" role="alert">
-          {error}
-        </span>
-      )}
-      <div className="mt-1 flex flex-wrap items-center gap-2">
-        {presets.map((p) => (
-          <Button
-            key={p.url}
-            variant="preset"
-            size="sm"
-            disabled={saving}
-            onClick={() => apply(p.url)}
-            data-testid={`wizard-mirror-${p.url}`}
-          >
-            {p.label}
-          </Button>
-        ))}
-        <input
-          type="text"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://hf-mirror.com"
-          className="min-w-[220px] flex-1 rounded border border-border bg-transparent px-2 py-1 font-mono text-xs text-fg"
-          data-testid="wizard-mirror-url"
-        />
-        <Button
-          variant="subtle"
-          size="sm"
-          loading={saving}
-          disabled={saving || !url.trim()}
-          onClick={() => apply(url.trim())}
-          data-testid="wizard-mirror-apply"
-        >
-          {t('setup.mirror_apply')}
-        </Button>
-      </div>
-    </div>
   );
 }
 
@@ -364,12 +270,21 @@ export default function SetupWizard({ onReady }) {
           <Waveform />
           <div className="mt-2 flex flex-wrap items-end justify-between gap-6">
             <div className="min-w-0">
-              <h1
-                className="m-0 font-serif text-[clamp(1.6rem,3vw,2.2rem)] font-semibold leading-tight tracking-tight"
-                data-tauri-drag-region
-              >
-                OmniVoice Studio
-              </h1>
+              <div className="flex flex-wrap items-baseline gap-2.5" data-tauri-drag-region>
+                <h1
+                  className="m-0 font-serif text-[clamp(1.6rem,3vw,2.2rem)] font-semibold leading-tight tracking-tight"
+                  data-tauri-drag-region
+                >
+                  OmniVoice Studio
+                </h1>
+                {/* Same identity mark as the install splash footer. */}
+                <span
+                  className="font-mono text-[0.62rem] tracking-[0.14em] text-fg-subtle"
+                  data-tauri-drag-region
+                >
+                  v{APP_VERSION}
+                </span>
+              </div>
               <p className="mt-1.5 text-sm leading-snug text-fg-muted" data-tauri-drag-region>
                 {STEP_SUBTITLES[step]}
               </p>

--- a/frontend/src/test/client.restart.test.ts
+++ b/frontend/src/test/client.restart.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { apiFetch } from '../api/client';
+import { backendLifecycleStage, classifyBootstrapStage } from '../utils/backendLifecycle';
+
+// The recurring "Can't reach the local OmniVoice backend" class: a REAL
+// backend start/restart takes 10–20+ s (venv spawn + torch import), but the
+// transport cascade used to give up after ~2.9 s — every request landing in a
+// restart window dead-ended with the scary toast. apiFetch must now keep
+// retrying exactly as long as the desktop shell says the backend is starting,
+// and still fail promptly when the shell says failed / is absent.
+vi.mock('../utils/backendLifecycle', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/backendLifecycle')>();
+  return {
+    ...actual,
+    backendLifecycleStage: vi.fn().mockResolvedValue('unknown'),
+  };
+});
+
+const stageMock = vi.mocked(backendLifecycleStage);
+const CASCADE_MS = 400 + 900 + 1600;
+
+describe('apiFetch — lifecycle-aware restart wait', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    stageMock.mockReset();
+    stageMock.mockResolvedValue('unknown');
+  });
+
+  it('keeps retrying while the shell says the backend is starting, then succeeds', async () => {
+    vi.useFakeTimers();
+    // 5 transport failures (cascade of 3 + 2 lifecycle-waited attempts), then OK.
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    stageMock.mockResolvedValue('starting');
+
+    const p = apiFetch('/model/status');
+    const assertion = expect(p).resolves.toMatchObject({ status: 200 });
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 1500 * 2 + 100);
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(stageMock).toHaveBeenCalled();
+  });
+
+  it('fails promptly when the shell says the backend start failed', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    stageMock.mockResolvedValue('failed');
+
+    const p = apiFetch('/model/status');
+    const assertion = expect(p).rejects.toMatchObject({
+      status: 0,
+      message: expect.stringContaining("Can't reach the local OmniVoice backend"),
+    });
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 100);
+    await assertion;
+  });
+
+  it('keeps the old prompt failure outside the Tauri shell (stage unknown)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+    stageMock.mockResolvedValue('unknown');
+
+    const p = apiFetch('/model/status');
+    const assertion = expect(p).rejects.toMatchObject({ status: 0 });
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 100);
+    await assertion;
+    // Exactly the short cascade — no lifecycle-extended retries.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('classifyBootstrapStage', () => {
+  it('maps shell stages to the coarse lifecycle answer', () => {
+    expect(classifyBootstrapStage('ready')).toBe('ready');
+    expect(classifyBootstrapStage('failed')).toBe('failed');
+    for (const s of [
+      'checking',
+      'awaiting_setup',
+      'downloading_uv',
+      'creating_venv',
+      'installing_deps',
+      'starting_backend',
+    ]) {
+      expect(classifyBootstrapStage(s)).toBe('starting');
+    }
+    expect(classifyBootstrapStage('')).toBe('unknown');
+    expect(classifyBootstrapStage(null)).toBe('unknown');
+    expect(classifyBootstrapStage(undefined)).toBe('unknown');
+  });
+});

--- a/frontend/src/test/wizardLibraryInstallError.test.js
+++ b/frontend/src/test/wizardLibraryInstallError.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reduceWizardDownloadEvent } from '../components/WizardLibrary.jsx';
+import { reduceWizardDownloadEvent, mirrorBlockedRepos } from '../components/WizardLibrary.jsx';
 
 const REPO = 'org/model';
 
@@ -44,5 +44,38 @@ describe('reduceWizardDownloadEvent — install_error persists (P1-A)', () => {
   it('ignores keepalive events without a repo_id', () => {
     const prev = { [REPO]: { phase: 'install_error', error: 'x' } };
     expect(reduceWizardDownloadEvent(prev, {})).toBe(prev);
+  });
+
+  it('stores the docs_topic failure class on install_error (mirror rescue trigger)', () => {
+    let s = reduceWizardDownloadEvent({}, { repo_id: REPO, phase: 'install_start' });
+    s = reduceWizardDownloadEvent(s, {
+      repo_id: REPO,
+      phase: 'install_error',
+      error: 'mirror down',
+      docs_topic: 'HF_MIRROR_UNREACHABLE',
+    });
+    expect(s[REPO].docsTopic).toBe('HF_MIRROR_UNREACHABLE');
+    // Absent docs_topic (older backend / other failures) degrades to ''.
+    const s2 = reduceWizardDownloadEvent({}, { repo_id: REPO, phase: 'install_error', error: 'x' });
+    expect(s2[REPO].docsTopic).toBe('');
+  });
+});
+
+// The wizard renders the inline mirror picker (MirrorRescue) ONLY for the
+// mirror-unreachable class — the error hint points at Settings, which the
+// first-run wizard gates, so switch-and-retry must be possible in place.
+describe('mirrorBlockedRepos', () => {
+  it('lists only install_error rows with the HF_MIRROR_UNREACHABLE class', () => {
+    const progress = {
+      'a/mirror-blocked': { phase: 'install_error', docsTopic: 'HF_MIRROR_UNREACHABLE' },
+      'b/other-error': { phase: 'install_error', docsTopic: '' },
+      'c/downloading': { phase: 'active', docsTopic: 'HF_MIRROR_UNREACHABLE' },
+    };
+    expect(mirrorBlockedRepos(progress)).toEqual(['a/mirror-blocked']);
+  });
+
+  it('is empty for empty/undefined progress', () => {
+    expect(mirrorBlockedRepos({})).toEqual([]);
+    expect(mirrorBlockedRepos(undefined)).toEqual([]);
   });
 });

--- a/frontend/src/utils/backendLifecycle.ts
+++ b/frontend/src/utils/backendLifecycle.ts
@@ -1,0 +1,52 @@
+/**
+ * backendLifecycle — frontend bridge to the desktop shell's backend lifecycle
+ * (src-tauri/src/bootstrap.rs).
+ *
+ * The shell always knows whether the backend process is starting, ready,
+ * being auto-restarted by the supervisor (#567), or terminally failed — but
+ * until this module, api/client.ts guessed: it retried a transport failure
+ * for ~2.9 s and then threw "Can't reach the local OmniVoice backend", while
+ * a real backend start/restart takes 10–20+ s (venv spawn + torch import).
+ * Every request that landed in that window dead-ended with the scary toast,
+ * which is why the error "kept coming up" on every restart/cold-start race.
+ *
+ * `backendLifecycleStage()` asks the shell (`bootstrap_status`) so the client
+ * can keep waiting exactly as long as a start/restart is actually in
+ * progress, and give up immediately when the shell says failed.
+ *
+ * Outside the Tauri shell (browser dev, Docker, LAN share) there is no shell
+ * to ask — the stage is 'unknown' and callers keep today's short-retry
+ * behavior.
+ */
+
+export type BackendLifecycleStage = 'ready' | 'starting' | 'failed' | 'unknown';
+
+function inTauri(): boolean {
+  const w = window as unknown as Record<string, unknown> | undefined;
+  return typeof window !== 'undefined' && !!(w?.__TAURI__ || w?.__TAURI_INTERNALS__);
+}
+
+/** Map the shell's BootstrapStage tag to the coarse lifecycle answer the
+ * transport layer needs. Pure + exported for unit tests. */
+export function classifyBootstrapStage(stage: string | null | undefined): BackendLifecycleStage {
+  if (!stage) return 'unknown';
+  if (stage === 'ready') return 'ready';
+  if (stage === 'failed') return 'failed';
+  // checking / awaiting_setup / downloading_uv / creating_venv /
+  // installing_deps / starting_backend — the backend is legitimately not
+  // listening yet, and the shell is actively working on it.
+  return 'starting';
+}
+
+/** The shell's current backend stage, or 'unknown' outside Tauri / on IPC
+ * failure. Never throws. */
+export async function backendLifecycleStage(): Promise<BackendLifecycleStage> {
+  if (!inTauri()) return 'unknown';
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const res = (await invoke('bootstrap_status')) as { stage?: string } | null;
+    return classifyBootstrapStage(res?.stage);
+  } catch {
+    return 'unknown';
+  }
+}

--- a/tests/test_hf_mirror_error_class.py
+++ b/tests/test_hf_mirror_error_class.py
@@ -1,10 +1,13 @@
 """#874: a model download that fails because the CONFIGURED Hugging Face
 mirror (HF_ENDPOINT, Settings → Models → Hugging Face mirror) is unreachable
 must surface an actionable error that (1) names the mirror, (2) says it may be
-down, (3) points at the setting + the restart requirement (HF reads
-HF_ENDPOINT at backend start), and (4) suggests the official endpoint when the
-model isn't cached — instead of leaking the raw transformers message
-("We couldn't connect to 'https://hf-mirror.com' …") as a bare 500 detail.
+down, (3) points at the setting AND says downloads pick up a mirror change
+immediately (the download paths resolve the endpoint per call — the old hint
+falsely claimed a restart was always required, dead-ending first-run users
+whose only recovery path is switch-and-retry inside the wizard), and
+(4) suggests the official endpoint when the model isn't cached — instead of
+leaking the raw transformers message ("We couldn't connect to
+'https://hf-mirror.com' …") as a bare 500 detail.
 
 Fail-before/pass-after: before the fix `classify()` had no mirror class and
 `build_failure()` / `append_hf_mirror_hint()` attached no hint to these
@@ -51,7 +54,7 @@ def test_hub_connection_error_classifies_by_host(mirror_env):
     assert failure.classify(_HUB_CONN_ERROR) == "HF_MIRROR_UNREACHABLE"
 
 
-def test_hint_names_mirror_setting_restart_and_official(mirror_env):
+def test_hint_names_mirror_setting_retry_and_official(mirror_env):
     evt = failure.build_failure(
         OSError(_TRANSFORMERS_874), stage="model-load", include_diagnostic=False
     )
@@ -59,8 +62,15 @@ def test_hint_names_mirror_setting_restart_and_official(mirror_env):
     hint = evt["hint"]
     assert "https://hf-mirror.com" in hint  # (1) names the configured mirror
     assert "may be down" in hint  # (2) says it may be down
-    # (3) the setting path + the restart requirement (HF_ENDPOINT applies at start)
+    # (3) the setting path + the truth about when the change applies: downloads
+    # resolve the endpoint per call, so switch-and-retry works WITHOUT a
+    # restart — the old "applied when the app starts" claim dead-ended
+    # first-run users, who can't reach Settings and would lose wizard progress.
     assert "Settings → Models → Hugging Face mirror" in hint
+    assert "immediately" in hint
+    assert "applied when the app starts" not in hint
+    # Restart survives only as the fallback for import-time readers
+    # (transformers-side model loads) when a retry still fails.
     assert "restart" in hint.lower()
     # (4) suggests the official endpoint for an un-cached model
     assert "Hugging Face (official)" in hint

--- a/tests/test_hf_mirror_settings.py
+++ b/tests/test_hf_mirror_settings.py
@@ -163,6 +163,32 @@ def test_put_mode_auto_clears_pref_fallback(settings_mod):
     assert prefs.get("hf_endpoint") is None
 
 
+def test_clear_to_official_also_clears_pref_fallback(settings_mod):
+    """Switching to official (manual, empty url) must also drop the legacy
+    `hf_endpoint` pref fallback — the download paths resolve it as an explicit
+    mirror, so leaving it behind meant "switch to official" didn't actually
+    switch (the wizard's mirror rescue kept failing on the dead mirror)."""
+    from core import prefs
+    import services.endpoint_race as er
+
+    prefs.set_("hf_endpoint", "https://hf-mirror.com")
+    settings_mod.set_hf_mirror(settings_mod._HFMirrorBody(url="", mode="manual"))
+    assert prefs.get("hf_endpoint") is None
+    assert er.explicit_endpoint() == ""
+
+
+def test_mirror_change_clears_install_cooldowns(settings_mod):
+    """A mirror change resets the failed-recently install cooldowns: the
+    wizard's switch-and-retry flow retries the failed download immediately,
+    and a 429 there would dead-end it (the cooldown guards against hammering
+    a broken network — which the endpoint switch just changed)."""
+    from api.routers.setup import download as dl
+
+    dl._install_cooldowns["org/model"] = 10.0 ** 12  # far future — never sweeps
+    settings_mod.set_hf_mirror(settings_mod._HFMirrorBody(url="https://hf-mirror.com"))
+    assert dl._install_cooldowns == {}
+
+
 def test_put_rejects_unknown_mode(settings_mod):
     from fastapi import HTTPException
     with pytest.raises(HTTPException) as ei:


### PR DESCRIPTION
Three fixes from one first-run session report (owner screenshot + follow-up):

## 1. App version at the top of the first-run wizard
`SetupWizard` now shows `v{APP_VERSION}` next to the "OmniVoice Studio" title — the same identity mark the install splash footer already carries — so setup-time screenshots and bug reports identify the build at a glance.

## 2. A dead configured HF mirror can no longer strand the wizard
The screenshot showed the exact dead-end: Whisper large-v3 failing with the #874 hint, which points at **Settings → Models** (unreachable during first-run — the wizard gates the studio) and falsely claims the mirror setting is only "applied when the app starts" (downloads resolve the endpoint per call since the per-call `endpoint=` work).

- `install_error` SSE events now carry `docs_topic` (from `core.failure.classify`), so the wizard reacts to the failure **class**, not error-text matching.
- `MirrorRescue` is extracted from `SetupWizard` and now also renders on the Models step next to a mirror-blocked download — including the **Hugging Face (official)** preset (previously filtered out; official is the escape hatch when the mirror is what's dead). Applying an endpoint retries the failed rows immediately.
- `PUT /hf-mirror` clears the install cooldowns (the immediate retry used to 429) and — new class fix — clearing to official also deletes the legacy `hf_endpoint` pref, which used to silently keep the dead mirror in effect.
- The hint is corrected to retry-first, restart-only-if-it-still-fails.

## 3. "Can't reach the local OmniVoice backend" stops crying wolf (permanent class fix)
The owner's own logs show a backend start takes **12–20 s** (venv spawn + torch import) while `apiFetch`'s transport cascade gave up after **~2.9 s** — so every request landing in a cold-start or supervisor-restart window dead-ended with the scary toast, repeatedly, with zero context. Nothing listened to the `backend-restarting`/`backend-restored` events `bootstrap.rs` has emitted since #567 (the promised banner was never built).

- New `utils/backendLifecycle.ts`: asks the shell (`bootstrap_status`) whether a start/restart is in progress.
- `apiFetch` keeps retrying while the shell says "starting", capped at 120 s (matching the supervisor's own respawn-health budget). Shell says failed / no shell (browser, Docker) → prompt error exactly as before; the #941 crash-honesty path is untouched.
- New `BackendRestartBanner` (mounted in the studio **and** the wizard): one pinned "restarting — hang tight" banner, a "back — carrying on" toast on recovery, a danger banner when the restart budget is exhausted.

## Verification
- Backend: full suite **2891 passed** (0 failures); new regression tests for the cooldown clear, pref clear, and the corrected hint semantics.
- Frontend: full suite **1162 passed** across 150 files; new `client.restart.test.ts` (waits while starting / fails promptly on failed / unchanged outside Tauri) + reducer/`mirrorBlockedRepos` tests. Lint, typecheck, format all clean.
- Docs synced in-PR: `docs/downloading-models.md` (wizard rescue + immediate-apply semantics), `docs/install/troubleshooting.md` new §14b, `CHANGELOG.md` `[Unreleased]`.
- No `package.json`/lockfile/version-file changes (main stays pinned at 0.3.18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added the app version to the setup wizard masthead.
- Added mirror rescue controls for unreachable Hugging Face endpoints, including official endpoint fallback, immediate retries, cooldown clearing, legacy preference cleanup, and classified install errors.
- Added lifecycle-aware backend retry handling for startup/restart windows, plus restart status banners in the wizard and studio.
- Added regression tests and updated documentation/changelog.

### UI

```text
Before:  OmniVoice Studio
After:   OmniVoice Studio  v{APP_VERSION}

Before:  Install failure → error text
After:   Install failure → error text + mirror picker → immediate retry

Before:  Backend unreachable → repeated toast
After:   Backend restarting → status banner → restored/failed state
```

### Backend retry flow

```mermaid
flowchart TD
  A[API request fails] --> B[Short retry cascade]
  B --> C{Shell lifecycle stage}
  C -->|starting| D[Retry during restart window up to 120s]
  D --> C
  C -->|ready| E[Continue request handling]
  C -->|failed or unknown| F[Show existing backend failure behavior]
```

- Added frontend and backend tests covering lifecycle retries, mirror error classification, endpoint transitions, cooldown resets, and blocked repository detection.
- Updated troubleshooting and model-download documentation.
- Backend/frontend tests, linting, type checking, and formatting pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->