### PR TITLE
release: freeze v0.3.19 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.3.19] — 2026-07-12
+
+The honesty release. Every error in here was already *technically* true and practically useless — so this round went after the lies the app tells when something goes wrong. "Can't reach the local OmniVoice backend" no longer fires while the backend is simply still starting; a dead Hugging Face mirror no longer strands the setup wizard with advice it can't follow; and a dub that dies mid-transcription now names the actual cause instead of guessing at it. Alongside that: generated speech starts playing on the *first* chunk instead of the last, and there's finally a real uninstaller.
 
 ### Added
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.18"
+_FALLBACK_VERSION = "0.3.19"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.18"
+version = "0.3.19"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.18"
+version = "0.3.19"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.18"
+version = "0.3.19"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Freeze for **v0.3.19**. Rebuilt on current `main` after the hold, so it now covers everything that landed since the first cut.

- `frontend/package.json` → 0.3.19 (single source of truth) + the three toolchain mirrors (`frontend/src-tauri/Cargo.toml`, `pyproject.toml`, `backend/core/version.py` `_FALLBACK_VERSION`)
- `Cargo.lock` + `uv.lock` regenerated — diffs are the single version lines
- `CHANGELOG.md`: `[Unreleased]` → `## [0.3.19] — 2026-07-12` with the release headline

## What's in the release
**Added** — streaming playback preview (#1088) · clean uninstaller + data-location docs (#1097)
**Fixed** — dub stream-drop tells the truth instead of guessing (#1062/#1098) · "Can't reach the local backend" stops crying wolf during starts/restarts (#1094) · dead HF mirror no longer strands the first-run wizard (#1094)
**Changed** — app version in the wizard masthead (#1094) · repo root decluttered (#1095)

Also backfilled the #1088 changelog entry, which shipped a user-facing feature with no release note.

## Verification
`tests/test_app_version.py` 6/6 (lockstep + tauri.conf derivation) · `bun install --frozen-lockfile` clean (the Docker gate) · all six entries extract cleanly as the GitHub Release body via `release.yml`'s section extractor.

**Issue queue is empty (0 open) as of this cut.** After merge: tag `v0.3.19` from main. Per the `AUTO_VERSION_BUMP=off` pin there's no post-release bump — main holds at 0.3.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Freeze release `v0.3.19` by syncing versions to `0.3.19` across the frontend (`frontend/package.json`), Tauri crate (`frontend/src-tauri/Cargo.toml`), backend fallback version (`backend/core/version.py`), and Python package (`pyproject.toml`).
- Regenerated `Cargo.lock` and `uv.lock`, reflecting updated toolchain mirrors.
- Updated `CHANGELOG.md` by converting the previous `## [Unreleased]` items into `## [0.3.19] — 2026-07-12` (including backend “honesty” recovery improvements, first-run wizard masthead version visibility, repo declutter, streaming TTS first-chunk playback, and the new clean uninstaller).
- Kept the release freeze **on hold**; after rebase/merge, the plan is to tag `v0.3.19` from `main` with no post-release version bump.

## Verification

- `tests/test_app_version.py`: 6/6 passed
- `bun install --frozen-lockfile`: clean

## Behavior flow

```mermaid
flowchart LR
  A[Backend restart/auto-restart or dead HF mirror] --> B[App detects a recoverable condition]
  B --> C[Waits for the restart, or lets the wizard retry with the right mirror]
  C --> D[Wizard proceeds with honest guidance]
```

## UI/layout

```text
Before                         After
First-run wizard               First-run wizard
┌──────────────────┐           ┌──────────────────┐
│ Masthead          │           │ Masthead v0.3.19│
└──────────────────┘           └──────────────────┘
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->