### PR TITLE
feat(install): clean uninstaller + document every folder OmniVoice writes (#1089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Added
+
+- **A clean uninstaller + a straight answer to "where's my data?"** OmniVoice is fully local, so removing it is just deleting the folders it wrote — but until now users had to guess which ones. New `scripts/uninstall.sh` (macOS/Linux) and `scripts/uninstall.ps1` (Windows) find every OmniVoice folder — app data, the multi-GB managed Python env, config, logs, and (separately, because it's shared) the Hugging Face model cache — print each with its size as a **dry-run first**, and delete only on `--yes`. They honor your custom locations (`OMNIVOICE_DATA_DIR`, `HF_HOME`, portable mode) and never touch the app binary. The complete per-platform path list lives in the new `docs/install/uninstall.md`, linked from the README FAQ, SUPPORT, and troubleshooting. (#1089)
+
 ### Fixed
 
 - **"Can't reach the local OmniVoice backend" stopped crying wolf during startups and restarts.** A real backend start or auto-restart takes 10–20+ seconds (Python spawn plus the PyTorch import), but the app's transport retry only bridged ~3 seconds — every click inside that window dead-ended with the scary toast, over and over, even though the backend healed itself moments later. The app now asks the desktop shell whether a start/restart is actually in progress and simply waits for it (up to the shell's own 2-minute restart budget), and shows a single "backend is restarting — hang tight" banner with a "back — carrying on" confirmation — the reconnecting affordance the supervisor has promised since #567. A truly dead backend (or a non-desktop deployment) still errors promptly, and the crash notice keeps telling the honest story.

--- a/README.md
+++ b/README.md
@@ -582,6 +582,12 @@ Yes. MPS acceleration is auto-detected. MLX-optimized Whisper models are availab
 Yes. OmniVoice uses a <b>built-in backend registry</b>. To add an engine in ~50 lines, subclass <code>TTSBackend</code> in <code>backend/services/tts_backend.py</code> and add it to the <code>_REGISTRY</code> dictionary. Fourteen engines are built in: OmniVoice, CosyVoice 3, GPT-SoVITS, MLX-Audio (14+ sub-engines), VoxCPM2, MOSS-TTS-Nano, KittenTTS, Sherpa-ONNX, plus lazy-registered IndexTTS 2, OmniVoice GGUF, Supertonic 3, MOSS-TTS-v1.5, dots.tts, and Confucius4-TTS. See the <a href="#tts-engines">TTS Engines</a> section for details.
 </details>
 
+<details>
+<summary><b>How do I uninstall it / remove all its data?</b></summary>
+<br/>
+OmniVoice is fully local — uninstalling is just deleting the app plus the folders it wrote (model cache, Python env, your voices/projects, config). Run <code>scripts/uninstall.sh</code> (macOS/Linux) or <code>scripts\uninstall.ps1</code> (Windows) — it prints every folder with its size as a dry-run first, then deletes on <code>--yes</code>. The full per-platform path list and app-removal steps are in <a href="docs/install/uninstall.md"><b>docs/install/uninstall.md</b></a>.
+</details>
+
 ---
 
 <a id="license"></a>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,6 +9,14 @@
 | [GitHub Discussions](https://github.com/debpalash/OmniVoice-Studio/discussions) | Design questions, ideas, show & tell |
 | Security issues | **Never a public issue** — see [SECURITY.md](SECURITY.md) for private reporting |
 
+## Uninstalling / removing all data
+
+OmniVoice is fully local — there's nothing to deactivate, just folders to
+delete. `scripts/uninstall.sh` (macOS/Linux) or `scripts\uninstall.ps1`
+(Windows) lists every OmniVoice folder with its size (dry-run first) and
+removes them on `--yes`. The complete per-platform path list is in
+[docs/install/uninstall.md](docs/install/uninstall.md).
+
 ## Model sources we support
 
 OmniVoice is built on the idea that everything it runs is **open and available

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -575,3 +575,27 @@ OmniVoice now tries, in order: the default GitHub host → a gh-proxy mirror →
    you can raise them further in the environment if a mirror is very slow.
 
 **Linked issues:** [#130](https://github.com/debpalash/OmniVoice-Studio/issues/130), [#60](https://github.com/debpalash/OmniVoice-Studio/issues/60), [#57](https://github.com/debpalash/OmniVoice-Studio/issues/57)
+
+## Uninstalling / removing all of OmniVoice's data
+
+OmniVoice is fully local — no accounts, no services, nothing to deactivate. To
+reclaim disk space or fully remove it, run the uninstaller, which lists every
+OmniVoice folder with its size (dry-run first) and deletes on `--yes`:
+
+```bash
+scripts/uninstall.sh            # macOS/Linux — dry-run
+scripts/uninstall.sh --yes      # delete app data/env/config/logs
+scripts/uninstall.sh --yes --models   # also delete the shared HF model cache
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1 -Yes   # Windows
+```
+
+The two big folders are the **model cache** (Hugging Face weights, several GB)
+and the **managed Python env** (`project/.venv`, a few GB). The complete
+per-platform path list, env-var overrides, portable-mode note, and the steps to
+remove the app binary itself are in
+[docs/install/uninstall.md](uninstall.md).
+
+**Linked issue:** [#1089](https://github.com/debpalash/OmniVoice-Studio/issues/1089)

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -1,0 +1,121 @@
+# Uninstalling OmniVoice Studio
+
+OmniVoice is **fully local** — it has no accounts, no cloud state, and no
+background services. Removing it is just deleting the app plus the folders it
+wrote on your machine. This page lists every one of those folders per platform,
+and ships a script that finds and removes them for you (with a dry-run first).
+
+> **TL;DR (the space hogs):** the two folders worth deleting are the **model
+> cache** (the Hugging Face weights — several GB) and the **managed Python
+> environment** (`project/.venv` — a few GB). Everything else is small.
+
+## The one-command uninstaller (recommended)
+
+From a clone or the source tarball:
+
+```bash
+# macOS / Linux — prints what it WOULD delete, with sizes, and stops:
+scripts/uninstall.sh
+
+# actually delete, after you've read the dry-run:
+scripts/uninstall.sh --yes
+```
+
+```powershell
+# Windows (PowerShell) — dry-run, then delete:
+powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1
+powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1 -Yes
+```
+
+The script honors your custom locations: if you set `OMNIVOICE_DATA_DIR`,
+`OMNIVOICE_CACHE_DIR`, `HF_HOME`, or `HF_HUB_CACHE` (or picked custom
+data/model folders during setup), export the same variables before running it
+and it will target those instead of the defaults. It never touches anything
+outside the OmniVoice folders, and it does **not** delete the app binary itself
+(see "Remove the app" below) — so it's safe to run even if you only want to
+reclaim disk space and keep the app installed.
+
+## What OmniVoice writes, and where
+
+Four kinds of data, in up to four locations:
+
+| What | Size | Notes |
+|---|---|---|
+| **Model cache** (Hugging Face weights) | GBs | The big one. Shared HF cache — see the caveat below. |
+| **Managed Python env** (`project/.venv`) | GBs | Rebuilt automatically if you reinstall. |
+| **App data** (voices, projects, DB, generated audio, logs) | small–MBs | Your voice profiles and history live here. |
+| **App config + logs** (`config.json`, window state, Tauri logs) | tiny | Settings and desktop-shell logs. |
+
+### macOS
+
+```
+~/Library/Application Support/OmniVoice/                       ← app data (voices, projects, omnivoice.db, outputs, omnivoice.log)
+~/Library/Application Support/com.debpalash.omnivoice-studio/  ← config.json + the managed Python env (project/.venv)
+~/Library/Logs/OmniVoice/                                      ← backend logs (backend.log, backend_err.log)
+~/Library/Logs/com.debpalash.omnivoice-studio/                ← desktop-shell log (tauri.log)
+~/.cache/huggingface/                                          ← model weights (shared HF cache — see caveat)
+```
+
+### Linux (AppImage / .deb)
+
+```
+~/.omnivoice/                                     ← app data (voices, projects, omnivoice.db, outputs, omnivoice.log)
+~/.local/share/com.debpalash.omnivoice-studio/    ← config.json, logs, AND the managed Python env (project/.venv)
+~/.cache/huggingface/                             ← model weights (shared HF cache — see caveat)
+```
+
+### Windows
+
+```
+%APPDATA%\OmniVoice\                              ← app data (voices, projects, omnivoice.db, outputs, omnivoice.log)
+%LOCALAPPDATA%\com.debpalash.omnivoice-studio\    ← config.json, logs, AND the managed Python env (project\.venv)
+%LOCALAPPDATA%\OmniVoice\hf_cache\                ← model weights (OmniVoice uses a short path here to dodge MAX_PATH)
+```
+
+On Windows, if `HF_HOME` isn't set, OmniVoice redirects the model cache to
+`%LOCALAPPDATA%\OmniVoice\hf_cache` (instead of `~/.cache/huggingface`) so deep
+model paths don't hit the 260-character `MAX_PATH` limit.
+
+### Custom / portable locations
+
+- **Custom folders:** if you chose a custom data or model folder in setup (or
+  set `OMNIVOICE_DATA_DIR` / `OMNIVOICE_CACHE_DIR` / `HF_HOME` /
+  `HF_HUB_CACHE`), your data is there instead of the defaults above.
+- **Portable mode:** everything lives in an `OmniVoiceStudio-Data/` folder next
+  to the app binary — delete that one folder and you're done.
+- **Optional engine sidecars:** if you installed IndexTTS-2, CosyVoice, or
+  another sidecar engine, its isolated venv lives under the app-config folder
+  above and is removed with it.
+
+> **Shared HF cache caveat:** `~/.cache/huggingface/` is the **standard Hugging
+> Face cache**, shared by any tool that uses `huggingface_hub` (other ML apps,
+> `transformers`, etc.). If you use other Hugging Face tools, deleting the whole
+> folder removes *their* cached models too. To remove only OmniVoice's models,
+> delete the `models--*` subfolders you recognize under
+> `~/.cache/huggingface/hub/`, or just let it be — it's only a cache and any
+> tool re-downloads what it needs. The uninstaller script prints the cache size
+> and asks about it separately for this reason.
+
+## Remove the app itself
+
+The script above clears the **data**; removing the installed **app** is the
+normal per-platform step:
+
+- **macOS:** drag **OmniVoice Studio.app** from `/Applications` to the Trash.
+- **Windows:** **Settings → Apps → Installed apps → OmniVoice Studio →
+  Uninstall** (or via "Add or remove programs").
+- **Linux (AppImage):** delete the `.AppImage` file. If you integrated it into
+  your menu (e.g. with AppImageLauncher or a hand-written `.desktop` file),
+  also remove `~/.local/share/applications/*omnivoice*.desktop` and any icon
+  under `~/.local/share/icons/`.
+- **Linux (.deb):** `sudo apt remove omnivoice-studio` (this removes the
+  program; your data folders above are user data and are left in place — delete
+  them with the script or by hand).
+
+## Reinstalling later
+
+Nothing above is required before reinstalling — a fresh install rebuilds the
+Python env and re-downloads models on demand. Keep `~/Library/Application
+Support/OmniVoice/` (macOS) / `~/.omnivoice/` (Linux) / `%APPDATA%\OmniVoice\`
+(Windows) if you want to preserve your **voice profiles and projects** across a
+reinstall; delete it too for a truly clean slate.

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+  OmniVoice Studio — clean uninstaller (Windows).
+
+.DESCRIPTION
+  Finds every folder OmniVoice wrote (app data, the managed Python env, config,
+  logs) and — separately, because it's a SHARED cache — the Hugging Face model
+  cache, prints each with its size, and removes them. Dry-run by default: it
+  prints what it WOULD delete and stops, so you always see the plan first.
+
+  It NEVER deletes the app binary itself (uninstall that via Settings > Apps),
+  and never touches anything outside the paths it lists. Mirrors
+  backend/core/config.py + frontend/src-tauri/src/setup.rs.
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1
+  powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1 -Yes
+  powershell -ExecutionPolicy Bypass -File scripts\uninstall.ps1 -Yes -Models
+#>
+[CmdletBinding()]
+param(
+  [switch]$Yes,
+  [switch]$Models
+)
+
+$ErrorActionPreference = 'Stop'
+$identifier = 'com.debpalash.omnivoice-studio'
+
+# ── Resolve platform default paths (mirrors the app) ────────────────────────
+$appData   = [Environment]::GetEnvironmentVariable('APPDATA')
+$localApp   = [Environment]::GetEnvironmentVariable('LOCALAPPDATA')
+
+$dataDefault   = Join-Path $appData 'OmniVoice'
+$configDefault = Join-Path $localApp $identifier
+# Windows model-cache default: OmniVoice redirects HF cache to a short path to
+# dodge MAX_PATH, unless HF_HOME is set (see backend/core/config.py).
+$modelsDefault = Join-Path (Join-Path $localApp 'OmniVoice') 'hf_cache'
+
+# ── Apply the env overrides the app honors ──────────────────────────────────
+$dataDir = if ($env:OMNIVOICE_DATA_DIR) { $env:OMNIVOICE_DATA_DIR } else { $dataDefault }
+$modelsDir =
+  if     ($env:OMNIVOICE_CACHE_DIR) { $env:OMNIVOICE_CACHE_DIR }
+  elseif ($env:HF_HOME)             { $env:HF_HOME }
+  elseif ($env:HF_HUB_CACHE)        { $env:HF_HUB_CACHE }
+  else                              { $modelsDefault }
+
+function Get-FolderSize($path) {
+  if (-not (Test-Path -LiteralPath $path)) { return $null }
+  try {
+    $bytes = (Get-ChildItem -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue |
+      Measure-Object -Property Length -Sum).Sum
+    if (-not $bytes) { return '0 B' }
+    $units = 'B','KB','MB','GB','TB'; $i = 0
+    while ($bytes -ge 1024 -and $i -lt 4) { $bytes /= 1024; $i++ }
+    return ('{0:N1} {1}' -f $bytes, $units[$i])
+  } catch { return '?' }
+}
+
+$appTargets = @()
+foreach ($p in @($dataDir, $configDefault)) {
+  if (Test-Path -LiteralPath $p) { $appTargets += $p }
+}
+
+Write-Host 'OmniVoice Studio uninstaller (Windows)'
+Write-Host '--------------------------------------'
+if ($appTargets.Count -eq 0) {
+  Write-Host 'No OmniVoice app data / env / config folders found at the default or'
+  Write-Host 'env-configured locations. Nothing to remove.'
+} else {
+  Write-Host 'App data, managed Python env, config, and logs:'
+  foreach ($t in $appTargets) { '  {0,-9} {1}' -f (Get-FolderSize $t), $t | Write-Host }
+}
+
+$modelsPresent = Test-Path -LiteralPath $modelsDir
+if ($modelsPresent) {
+  Write-Host ''
+  Write-Host 'Model cache (Hugging Face weights — SHARED with other HF tools):'
+  '  {0,-9} {1}' -f (Get-FolderSize $modelsDir), $modelsDir | Write-Host
+  Write-Host '  -> pass -Models to include this (it may hold models from OTHER apps too).'
+}
+
+Write-Host ''
+if (-not $Yes) {
+  Write-Host 'DRY RUN — nothing deleted. Re-run with -Yes to remove the app folders'
+  if ($modelsPresent) { Write-Host '         (add -Models to also remove the shared model cache).' }
+  Write-Host 'To remove the app itself: Settings > Apps > OmniVoice Studio > Uninstall.'
+  exit 0
+}
+
+$deleted = 0
+foreach ($t in $appTargets) {
+  Write-Host "Removing $t"
+  Remove-Item -LiteralPath $t -Recurse -Force -ErrorAction SilentlyContinue
+  $deleted++
+}
+if ($Models -and $modelsPresent) {
+  Write-Host "Removing $modelsDir"
+  Remove-Item -LiteralPath $modelsDir -Recurse -Force -ErrorAction SilentlyContinue
+  $deleted++
+} elseif ($modelsPresent) {
+  Write-Host "Kept model cache ($modelsDir) — re-run with -Models to remove it."
+}
+
+Write-Host ''
+Write-Host "Done — removed $deleted folder(s)."
+Write-Host 'To remove the app itself: Settings > Apps > OmniVoice Studio > Uninstall.'

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# OmniVoice Studio — clean uninstaller (macOS + Linux).
+#
+# Finds every folder OmniVoice wrote (app data, the managed Python env, config,
+# logs) and — separately, because it's a SHARED cache — the Hugging Face model
+# cache, prints each with its size, and removes them. Dry-run by default: it
+# prints what it WOULD delete and stops, so you always see the plan first.
+#
+#   scripts/uninstall.sh            # dry-run: list targets + sizes, delete nothing
+#   scripts/uninstall.sh --yes      # delete the OmniVoice data/env/config/logs
+#   scripts/uninstall.sh --yes --models   # also delete the shared HF model cache
+#
+# Honors custom locations via the same env vars the app reads:
+#   OMNIVOICE_DATA_DIR, OMNIVOICE_CACHE_DIR, HF_HOME, HF_HUB_CACHE
+# Export the ones you set for OmniVoice before running, and it targets those.
+#
+# It NEVER deletes the app binary itself (that's a per-platform step — see
+# docs/install/uninstall.md), and it never touches anything outside the paths
+# it lists. Mirrors backend/core/config.py + frontend/src-tauri/src/setup.rs.
+set -euo pipefail
+
+APPLY=0
+INCLUDE_MODELS=0
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) APPLY=1 ;;
+    --models) INCLUDE_MODELS=1 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//' | sed '1d'
+      exit 0 ;;
+    *) echo "unknown option: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+IDENTIFIER="com.debpalash.omnivoice-studio"
+OS="$(uname -s)"
+
+# ── Resolve platform default paths (mirrors the app) ────────────────────────
+data_default=""
+config_default=""
+logs_extra=()
+models_default=""
+case "$OS" in
+  Darwin)
+    data_default="$HOME/Library/Application Support/OmniVoice"
+    config_default="$HOME/Library/Application Support/$IDENTIFIER"
+    logs_extra=("$HOME/Library/Logs/OmniVoice" "$HOME/Library/Logs/$IDENTIFIER")
+    models_default="$HOME/.cache/huggingface"
+    ;;
+  Linux)
+    data_default="$HOME/.omnivoice"
+    config_default="${XDG_DATA_HOME:-$HOME/.local/share}/$IDENTIFIER"
+    models_default="$HOME/.cache/huggingface"
+    ;;
+  *)
+    echo "This script supports macOS and Linux. On Windows use scripts/uninstall.ps1." >&2
+    exit 1 ;;
+esac
+
+# ── Apply env overrides the app honors ──────────────────────────────────────
+DATA_DIR="${OMNIVOICE_DATA_DIR:-$data_default}"
+# Model cache precedence matches the app: OMNIVOICE_CACHE_DIR → HF_HOME → HF_HUB_CACHE → default.
+MODELS_DIR="${OMNIVOICE_CACHE_DIR:-${HF_HOME:-${HF_HUB_CACHE:-$models_default}}}"
+
+# ── Collect existing targets ────────────────────────────────────────────────
+app_targets=()
+[ -e "$DATA_DIR" ] && app_targets+=("$DATA_DIR")
+[ -e "$config_default" ] && app_targets+=("$config_default")
+for d in "${logs_extra[@]:-}"; do [ -n "$d" ] && [ -e "$d" ] && app_targets+=("$d"); done
+
+human_size() { du -sh "$1" 2>/dev/null | cut -f1 || echo "?"; }
+
+echo "OmniVoice Studio uninstaller ($OS)"
+echo "----------------------------------"
+if [ "${#app_targets[@]}" -eq 0 ]; then
+  echo "No OmniVoice app data / env / config folders found at the default or"
+  echo "env-configured locations. Nothing to remove."
+else
+  echo "App data, managed Python env, config, and logs:"
+  for t in "${app_targets[@]}"; do printf "  %-6s %s\n" "$(human_size "$t")" "$t"; done
+fi
+
+models_present=0
+if [ -e "$MODELS_DIR" ]; then
+  models_present=1
+  echo
+  echo "Model cache (Hugging Face weights — SHARED with other HF tools):"
+  printf "  %-6s %s\n" "$(human_size "$MODELS_DIR")" "$MODELS_DIR"
+  echo "  ↳ pass --models to include this (it may hold models from OTHER apps too)."
+fi
+
+echo
+if [ "$APPLY" -ne 1 ]; then
+  echo "DRY RUN — nothing deleted. Re-run with --yes to remove the app folders"
+  [ "$models_present" -eq 1 ] && echo "         (add --models to also remove the shared model cache)."
+  echo "See docs/install/uninstall.md to also remove the app binary itself."
+  exit 0
+fi
+
+# ── Delete ──────────────────────────────────────────────────────────────────
+deleted=0
+for t in "${app_targets[@]:-}"; do
+  [ -z "$t" ] && continue
+  echo "Removing $t"
+  rm -rf -- "$t" && deleted=$((deleted + 1))
+done
+if [ "$INCLUDE_MODELS" -eq 1 ] && [ "$models_present" -eq 1 ]; then
+  echo "Removing $MODELS_DIR"
+  rm -rf -- "$MODELS_DIR" && deleted=$((deleted + 1))
+elif [ "$models_present" -eq 1 ]; then
+  echo "Kept model cache ($MODELS_DIR) — re-run with --models to remove it."
+fi
+
+echo
+echo "Done — removed $deleted folder(s)."
+echo "To remove the app itself, see docs/install/uninstall.md (drag to Trash /"
+echo "Add-or-remove-programs / delete the .AppImage)."


### PR DESCRIPTION
Closes #1089 — a Linux AppImage user asked *"which directories does OmniVoice use so I can delete them? Is there a way to uninstall it?"* and had to guess. They shouldn't have to: OmniVoice is fully local, so uninstalling **is** just deleting the folders it wrote — and we'd never documented them.

## The uninstaller
`scripts/uninstall.sh` (macOS/Linux) and `scripts/uninstall.ps1` (Windows):

- Find every OmniVoice folder: **app data** (voices/projects/DB/outputs/logs), the **managed Python env** (`project/.venv`, multi-GB), **config**, and **logs**.
- List the **Hugging Face model cache separately** — it's a *shared* cache other HF tools use, so it's opt-in via `--models` / `-Models` rather than swept up silently.
- **Dry-run by default**: print every target with its size and stop. Deletion only on `--yes`.
- Honor the same env overrides the app reads (`OMNIVOICE_DATA_DIR`, `OMNIVOICE_CACHE_DIR`, `HF_HOME`, `HF_HUB_CACHE`) and note portable mode.
- Never touch the app binary or anything outside the listed paths — safe to run just to reclaim disk space.

## The docs
New `docs/install/uninstall.md`: complete per-platform path table (what each folder holds + rough size), the shared-cache caveat, custom/portable locations, how to remove the app itself per platform, and what to keep if you'll reinstall. Linked from the **README FAQ**, **SUPPORT.md**, and **install troubleshooting** (docs-sync rule).

Answering the reporter directly: their three guesses were right for Linux — `~/.omnivoice/`, `~/.local/share/com.debpalash.omnivoice-studio/`, `~/.cache/huggingface/` — and the middle one is where the multi-GB Python venv hides, which is the real space reclaim.

## Verification
Paths mirror `backend/core/config.py` + `frontend/src-tauri/src/setup.rs`. Verified on macOS: the dry-run correctly lists the real app dirs and the 7.5 GB cache and deletes nothing; sandboxed-`HOME` runs confirm `--yes` removes the app folders while **keeping** the shared cache, `--models` removes it, and `OMNIVOICE_DATA_DIR`/`HF_HOME` retarget correctly. Shell syntax checked; the `.ps1` mirrors it (incl. the Windows `%LOCALAPPDATA%\OmniVoice\hf_cache` MAX_PATH redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added cross-platform uninstallers for macOS/Linux and Windows.
- Defaults to dry-run mode with path and size reporting; deletion requires explicit confirmation.
- Supports environment-variable overrides and portable installations.
- Preserves the shared Hugging Face cache unless `--models`/`-Models` is specified.
- Added comprehensive uninstall documentation covering data locations, cache handling, manual app removal, and reinstall guidance.
- Linked the guide from the README FAQ, support documentation, and troubleshooting.
- Verified dry-run, deletion scope, cache preservation, and environment overrides on macOS.

```mermaid
flowchart TD
    A[Run uninstaller] --> B[Discover OmniVoice paths]
    B --> C[Show targets and sizes]
    C --> D{Explicit confirmation?}
    D -- No --> E[Dry run only]
    D -- Yes --> F[Delete app data, config, and logs]
    F --> G{Models requested?}
    G -- No --> H[Preserve shared Hugging Face cache]
    G -- Yes --> I[Delete model cache]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->