### PR TITLE
fix(api): don't believe a stale "ready" — close the race that let #1101 fire on 0.3.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Can't reach the local OmniVoice backend" could still fire on 0.3.19 — the fix had a hole.** The app asks the desktop shell whether a start/restart is in progress before showing that error, but the shell learns of a dead backend from a **2-second poll**: when the backend dies mid-generation, the supervisor needs a moment to notice it, record the crash, and flip its state to "restarting". The app was asking **once**, ~3 seconds in — often still hearing "everything's fine" — and dead-ending on the generic toast anyway. A failed connection *contradicts* "everything's fine", so that answer is now treated as stale rather than authoritative: the app keeps retrying briefly, letting the shell catch up, which turns the failure into the "backend is restarting — hang tight" banner (and gives the crash report time to be written, so you get the real cause instead of a guess). A shell that has genuinely given up, or no shell at all, still errors immediately. (#1101)
+
 ### Added
 
 - **Uninstall is now in the app: Settings → Storage → "Remove all data".** The v0.3.19 uninstaller was a *script* — which never reached the people who needed it, since anyone who installed the .dmg / .msi / AppImage has no repo to run it from (exactly the case in #1089). The app now lists every folder this install owns with its real size, deletes them behind a typed confirmation, and quits. The **downloaded model weights are a separate, opt-in checkbox**, because that's the standard Hugging Face cache shared with other AI tools on your machine — removing it can delete models OmniVoice never downloaded. Custom and portable install locations are honored, and nothing outside OmniVoice's own folders can be touched. The scripts now also ship as **release assets**, so you can clean up without launching the app at all. (#1089)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -133,6 +133,24 @@ const TRANSPORT_RETRY_BACKOFF_MS = [400, 900, 1600];
 const RESTART_WAIT_INTERVAL_MS = 1500;
 const STARTUP_GRACE_MS = 120_000;
 
+// #1101: the shell's stage is a 2-second POLL, not a live probe. When the
+// backend dies mid-generate, `supervise_backend` needs up to ~2 s to notice the
+// exit, record the crash marker, and flip the stage to "starting" — so a single
+// check at the end of the ~2.9 s cascade very often still sees `ready` and we
+// dead-ended on the generic "Can't reach the backend" anyway. That was the hole
+// in the #1094 fix, reported against 0.3.19.
+//
+// A transport failure CONTRADICTS `ready`: if the shell believed the backend
+// were reachable, the fetch would have succeeded. So `ready` is treated as a
+// STALE belief, not an authority — we keep retrying across this reconciliation
+// window, re-asking each time, which lets a death the supervisor hasn't noticed
+// yet turn into "starting" (→ the long wait + banner) and gives the crash marker
+// time to be written so the error can tell the honest story instead of guessing.
+// Only `failed` (the shell gave up) or `unknown` (no shell — browser/Docker)
+// still errors immediately.
+const RECONCILE_MS = 12_000;
+const RECONCILE_INTERVAL_MS = 1000;
+
 export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Response> {
   const pin = typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('ov_pin') : null;
   const key = _apiKey();
@@ -170,10 +188,9 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
       // The short cascade is exhausted, but the desktop shell may KNOW the
       // backend is mid-start/restart (a real one takes 10–20+ s — torch
       // import — not 2.9 s). Keep waiting exactly as long as the shell says
-      // "starting", bounded by STARTUP_GRACE_MS; 'failed'/'unknown' (no
-      // shell, or the shell gave up) falls through to the error below so a
-      // truly dead backend still surfaces promptly.
-      if (Date.now() - startedAt < STARTUP_GRACE_MS) {
+      // "starting", bounded by STARTUP_GRACE_MS.
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < STARTUP_GRACE_MS) {
         let stage = 'unknown';
         try {
           stage = await backendLifecycleStage();
@@ -182,6 +199,16 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
         }
         if (stage === 'starting') {
           await new Promise((r) => setTimeout(r, RESTART_WAIT_INTERVAL_MS));
+          continue;
+        }
+        // `ready` while the transport is failing is a contradiction — the
+        // shell's 2 s poll simply hasn't caught up with a backend that just
+        // died (#1101). Don't believe it yet: keep retrying briefly so the
+        // supervisor can notice, flip to "starting", and write the crash
+        // marker. 'failed'/'unknown' fall through and error now, so a shell
+        // that gave up — or no shell at all — still surfaces promptly.
+        if (stage === 'ready' && elapsed < RECONCILE_MS) {
+          await new Promise((r) => setTimeout(r, RECONCILE_INTERVAL_MS));
           continue;
         }
       }

--- a/frontend/src/test/client.restart.test.ts
+++ b/frontend/src/test/client.restart.test.ts
@@ -64,6 +64,47 @@ describe('apiFetch — lifecycle-aware restart wait', () => {
     await assertion;
   });
 
+  // #1101 — the hole in the original fix, reported against 0.3.19. The shell's
+  // stage is a 2 s POLL: when the backend dies mid-generate the supervisor needs
+  // a moment to notice, flip to "starting" and write the crash marker. Asking
+  // once at the end of the cascade still saw `ready`, so the request dead-ended
+  // on the generic toast anyway. A transport failure contradicts `ready`, so we
+  // must keep retrying long enough for the shell to catch up.
+  it('does NOT believe a stale "ready" — it waits for the shell to notice the death', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    vi.stubGlobal('fetch', fetchMock);
+    // The supervisor hasn't ticked yet: still 'ready' for the first few polls,
+    // then it notices the death and flips to 'starting'.
+    stageMock
+      .mockResolvedValueOnce('ready')
+      .mockResolvedValueOnce('ready')
+      .mockResolvedValue('starting');
+
+    const p = apiFetch('/generate');
+    // Never settles into the generic error — it keeps waiting.
+    const settled = vi.fn();
+    p.then(settled, settled);
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 1000 + 1000 + 1500);
+    expect(settled).not.toHaveBeenCalled();
+
+    // Once the backend comes back, the request succeeds — the toast never fired.
+    fetchMock.mockResolvedValue(new Response('ok', { status: 200 }));
+    await vi.advanceTimersByTimeAsync(1500 * 2);
+    await expect(p).resolves.toMatchObject({ status: 200 });
+  });
+
+  it('still gives up when a "ready" backend stays unreachable past the reconcile window', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    stageMock.mockResolvedValue('ready'); // shell insists it's fine; it never recovers
+
+    const p = apiFetch('/model/status');
+    const assertion = expect(p).rejects.toMatchObject({ status: 0 });
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 12_000 + 2000);
+    await assertion;
+  });
+
   it('keeps the old prompt failure outside the Tauri shell (stage unknown)', async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));


### PR DESCRIPTION
Closes #1101 — and it's a hole in **my own** #1094 fix, reported against the release that was supposed to end this class.

## What went wrong
`apiFetch` asks the desktop shell whether a start/restart is in progress before showing "Can't reach the local OmniVoice backend". But the shell's stage is a **2-second poll, not a live probe**: when the backend dies mid-generation, `supervise_backend` needs up to ~2 s to notice the child exit, write the crash marker, and `set_stage(StartingBackend)`.

`apiFetch` asked **exactly once**, at the end of the ~2.9 s transport cascade — so it very often still read `Ready` and fell straight through to the generic toast. The crash marker usually hadn't landed yet either, so even the honest crash story (#941) was missed.

## The actual bug
Trusting `ready` as **authoritative**. A transport failure *contradicts* it: if the backend were reachable, the fetch would have succeeded.

So `ready` is now treated as a **stale belief**. We keep retrying across a bounded reconciliation window (12 s), re-asking each time — which lets the supervisor catch up and flip to `starting` (→ the long wait and the "backend is restarting" banner), and gives the crash marker time to land so the error can name the real cause instead of guessing.

`failed` (the shell gave up) and `unknown` (no shell — browser/Docker) still error **immediately**, so a genuinely dead backend surfaces exactly as promptly as before.

## The reporter's trace tells the real story
```
14:50:03 generate:start (design)
14:51:26 generate:stream-fallback
```
16 GB M1 / MPS. The backend **process died under memory pressure during generation** — the streaming preview bailed to the classic path, and that request hit the dead backend. Same signature as #1076/#1092/#1093 (all ended at `generate:start`). This PR makes that failure *honest*; the underlying death on 16 GB machines is the next thread to pull, and the crash notice will now hand us the exit code to pull it with.

## Verification
Regression test **reproduces the bug against the shipped 0.3.19 logic** (fails) and passes on the fix. Frontend **1184 passed**; backend **2897 passed** (design guards included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a race in `apiFetch` where stale `ready` state caused generic backend connectivity errors after a backend crash during generation.

- Adds a bounded 12-second reconciliation window that retries transport failures while the shell still reports `ready`.
- Preserves immediate errors for `failed` and `unknown` states.
- Allows restart detection to surface the appropriate “backend is restarting” message.
- Adds regression coverage for stale `ready` transitions and persistent backend failure.
- Updates the changelog with the fix.

```mermaid
flowchart TD
  A[Transport failure] --> B{Shell state}
  B -->|starting| C[Wait and retry]
  B -->|ready| D[Reconcile for up to 12 seconds]
  D -->|Backend recovers| E[Request succeeds]
  D -->|State changes to starting| C
  D -->|Still unreachable| F[Report connectivity error]
  B -->|failed or unknown| F
```

Verification: 1,184 frontend tests and 2,897 backend tests passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->