### PR TITLE
release: freeze v0.3.20 — version bump, lockfiles, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.3.20] — 2026-07-12
 
-### Fixed
-
-- **"Can't reach the local OmniVoice backend" could still fire on 0.3.19 — the fix had a hole.** The app asks the desktop shell whether a start/restart is in progress before showing that error, but the shell learns of a dead backend from a **2-second poll**: when the backend dies mid-generation, the supervisor needs a moment to notice it, record the crash, and flip its state to "restarting". The app was asking **once**, ~3 seconds in — often still hearing "everything's fine" — and dead-ending on the generic toast anyway. A failed connection *contradicts* "everything's fine", so that answer is now treated as stale rather than authoritative: the app keeps retrying briefly, letting the shell catch up, which turns the failure into the "backend is restarting — hang tight" banner (and gives the crash report time to be written, so you get the real cause instead of a guess). A shell that has genuinely given up, or no shell at all, still errors immediately. (#1101)
+The follow-through release. v0.3.19 promised that "Can't reach the local OmniVoice backend" would stop firing while the backend was merely restarting — and then a user hit it anyway, on 0.3.19, because the fix had a race in it. That's closed properly here. Uninstalling also stopped being a thing only maintainers could do: it's now a button in the app, where the person who asked for it can actually reach it.
 
 ### Added
 
 - **Uninstall is now in the app: Settings → Storage → "Remove all data".** The v0.3.19 uninstaller was a *script* — which never reached the people who needed it, since anyone who installed the .dmg / .msi / AppImage has no repo to run it from (exactly the case in #1089). The app now lists every folder this install owns with its real size, deletes them behind a typed confirmation, and quits. The **downloaded model weights are a separate, opt-in checkbox**, because that's the standard Hugging Face cache shared with other AI tools on your machine — removing it can delete models OmniVoice never downloaded. Custom and portable install locations are honored, and nothing outside OmniVoice's own folders can be touched. The scripts now also ship as **release assets**, so you can clean up without launching the app at all. (#1089)
 
 ### Fixed
+
+- **"Can't reach the local OmniVoice backend" could still fire on 0.3.19 — the fix had a hole.** The app asks the desktop shell whether a start/restart is in progress before showing that error, but the shell learns of a dead backend from a **2-second poll**: when the backend dies mid-generation, the supervisor needs a moment to notice it, record the crash, and flip its state to "restarting". The app was asking **once**, ~3 seconds in — often still hearing "everything's fine" — and dead-ending on the generic toast anyway. A failed connection *contradicts* "everything's fine", so that answer is now treated as stale rather than authoritative: the app keeps retrying briefly, letting the shell catch up, which turns the failure into the "backend is restarting — hang tight" banner (and gives the crash report time to be written, so you get the real cause instead of a guess). A shell that has genuinely given up, or no shell at all, still errors immediately. (#1101)
 
 - **The uninstaller was leaving the backend's log folder behind on Linux and Windows.** It cleaned the app-data, config, and Python-env folders but missed where the backend actually writes `backend.log` / `backend_err.log` — `~/.local/state/OmniVoice` on Linux and `%LOCALAPPDATA%\OmniVoice\Logs` on Windows. Both the scripts and the documented path lists now cover them. (#1089)
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.19"
+_FALLBACK_VERSION = "0.3.20"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.19"
+version = "0.3.20"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.19"
+version = "0.3.20"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.19"
+version = "0.3.20"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Patch release, cut promptly because **0.3.19 users are hitting #1101 today**.

- `frontend/package.json` → 0.3.20 (single source of truth) + the three toolchain mirrors (`Cargo.toml`, `pyproject.toml`, `core/version.py`)
- `Cargo.lock` + `uv.lock` regenerated — diffs are the single version lines
- `CHANGELOG.md`: `[Unreleased]` → `## [0.3.20] — 2026-07-12`, sections merged into house style

## What's in it
**Fixed** — "Can't reach the local OmniVoice backend" could still fire on 0.3.19: the #1094 fix asked the shell once, ~3 s in, but the shell only learns of a dead backend from a 2-second poll, so it still heard "ready" and dead-ended anyway. `ready` is now treated as a stale belief, not an authority (#1101/#1102). Also: the uninstaller was leaving the backend's log folder behind on Linux and Windows.

**Added** — Uninstall is now *in the app* (Settings → Storage → Remove all data), so the .dmg/.msi/AppImage users who can't reach `scripts/uninstall.sh` finally can (#1089/#1099).

Note: PR #1100 (scoped reset) is deliberately **not** in this cut — it lands in the next patch. This one is about getting the #1101 fix to users now.

## Verification
`tests/test_app_version.py` 6/6 · `bun install --frozen-lockfile` clean · changelog section extracts cleanly as the Release body. Backend 2897 / frontend 1184 green on main.

After merge: tag `v0.3.20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Bumped the application version to `0.3.20` across frontend, Rust, Python, and fallback metadata.
- Regenerated lockfiles with version-only updates.
- Published the `0.3.20` changelog entry dated `2026-07-12`.
- Included the local backend connection race-condition fix.
- Added **Settings → Storage → Remove all data**.
- Fixed leftover backend log directories after uninstall on Linux and Windows.
- Excluded scoped reset from this release.

## UI

```text
Before                         After
Settings                       Settings
└─ Storage                     └─ Storage
   └─ ...                         ├─ Remove all data
                                 └─ ...
```

## Behavior

```mermaid
flowchart TD
  A[User opens Settings → Storage] --> B[Selects Remove all data]
  B --> C[Application removes local data]
  C --> D[Backend logs and platform-specific leftovers are cleaned up]
  D --> E[Application reports completion]
```

## Verification

- Six version tests pass.
- Frozen Bun installation succeeds.
- Changelog extraction succeeds.
- Release can be tagged `v0.3.20` after merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->