### PR TITLE
fix(release): stop the uninstall-scripts job from splitting release assets across two releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -723,6 +723,13 @@ jobs:
   # path, but a user who wants to clean up WITHOUT launching the app — or after
   # already deleting it — has no repo to run scripts/uninstall.sh from. Ship the
   # two scripts alongside the installers so they're one download away.
+  #
+  # MUST use `gh release upload` (attach to the EXISTING release), NOT
+  # softprops/action-gh-release: a second softprops publish races tauri-action's
+  # per-matrix draft and splits the platform installers across two releases for
+  # the tag (v0.3.20 shipped with only the Linux AppImage that way). `needs:
+  # [build]` guarantees the release already exists; `--clobber` makes a re-run
+  # idempotent. This can never create a second release.
   uninstall-scripts:
     needs: [build]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -731,14 +738,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Attach uninstall scripts to the release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: |
-            scripts/uninstall.sh
-            scripts/uninstall.ps1
-          fail_on_unmatched_files: true
+      - name: Attach uninstall scripts to the existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            scripts/uninstall.sh scripts/uninstall.ps1 \
+            --clobber --repo "${{ github.repository }}"
 
   # ── Auto-generated preview release notes ──────────────────────────────────
   # tauri-action publishes the rolling `preview` release with the plain


### PR DESCRIPTION
**v0.3.20 shipped with only the Linux AppImage** — the macOS `.dmg` and Windows `.msi` were missing from the published release, and the auto-updater manifest was incomplete on every platform.

## Root cause
The `uninstall-scripts` job (added in #1097) ran `softprops/action-gh-release@v2` as a **second publish** for the tag. That raced `tauri-action`'s per-matrix draft release and **split the assets across two releases**: a draft holding the macOS/Windows bundles, and a published one holding Linux + checksums + the scripts. Each release's `latest.json` covered only its half of the platforms, so the updater would find no entry for the other platforms.

v0.3.19 didn't hit this because it had no such second-publish job.

## Fix
Attach the scripts with `gh release upload <tag> … --clobber` — which adds assets to the **existing** release and can never create a second one — instead of softprops. `needs: [build]` guarantees the release exists first; `--clobber` makes a re-run idempotent.

## v0.3.20 already repaired by hand
The live v0.3.20 release is fixed: I re-attached the macOS/Windows bundles from the draft (integrity-verified against the published SHA256SUMS), merged the two `latest.json` manifests into one covering all 8 platform keys, deleted the stray draft, and confirmed the published release now has all 17 assets. This PR prevents recurrence on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the release workflow to attach uninstall scripts to the existing release rather than creating a separate release.

- Replaces `softprops/action-gh-release@v2` with `gh release upload <tag> … --clobber`.
- Makes the `uninstall-scripts` job depend on `build`, ensuring the release already exists.
- Enables idempotent reruns and prevents assets from being split across releases for the same tag.

```mermaid
flowchart TD
  A[Build assets] --> B[Create existing release]
  B --> C[Upload uninstall scripts with gh release upload]
  C --> D[Overwrite matching assets with --clobber]
  D --> E[Single complete release]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->