### PR TITLE
release: freeze v0.3.21 — the memory release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.3.21] — 2026-07-12
+
+The memory release. The reason the app kept saying "Can't reach the local backend" on 16 GB machines was never really the network — the backend was quietly running out of memory and getting killed. This release fixes that at the source: the models it holds now get out of each other's way. Plus the uninstaller and factory reset grew into a proper Settings → Storage pair.
 
 ### Added
 
@@ -18,10 +20,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 - **Switching TTS engines no longer stacks their models in memory.** Using a second engine in a session (or a per-request engine override) loaded its model *on top of* the first one's, because the OmniVoice core model and the other engines live in two separate caches that never coordinated — measured on a 16 GB M2, an `omnivoice` → `mlx-audio` switch left the machine holding both (footprint 3.9 GB → 4.3 GB, the ~2.8 GB core never freed). That accumulation is a direct contributor to the memory pressure behind the "Can't reach the local backend" OOM deaths. Now only one TTS engine's model stays resident: resolving an engine hands back every *other* resident engine first (the same `omnivoice → mlx-audio` switch now drops to ~1.5 GB). Steady-state single-engine use is unaffected; an A/B switch pays a re-load on the way back (~8 s for the OmniVoice core, ~1–2 s for the lighter engines). Opt out with `OMNIVOICE_SINGLE_ENGINE_RESIDENT=0` if you have RAM to keep several warm. Two underlying leaks are fixed as part of this: every in-process TTS engine's `unload()` now actually frees its model and empties the device cache (previously all but OmniVoice were silent no-ops), and `faster-whisper`'s `unload()` cleared the wrong attribute so its model was never released.
 
-
-### Fixed
-
 - **The backend no longer sits on ~2 GB of idle dictation model — the real reason it was being killed on 16 GB Macs.** Four reports of *"Can't reach the local OmniVoice backend"* (#1076, #1092, #1093, #1101) all died at the same moment: during a generate, on a 16 GB machine. Measuring it showed the generate was never the problem — it costs about 116 MB. The problem was the **baseline**: the backend sat at **~6.2 GB even while idle**. The TTS model has always been unloaded after an idle timeout, but the speech-recognition model used for dictation never was — so once you dictated a single time, ~2 GB stayed resident for as long as the app ran. On a 16 GB Mac, that plus the app, macOS, and your other programs is enough for the system to run out of memory and kill the backend, which surfaced as the "can't reach the backend" error. Dictation's model now gets the same idle release the TTS model already had, handing that memory back. The only cost is a ~1.4-second re-warm on your next dictation after a long pause, and a live dictation session is pinned so nothing is ever unloaded mid-sentence.
+
 - **Folder sizes under 1 KB displayed as "0 KB".** The uninstall panel's `391 B` config folder rendered as `0 KB` — which reads as "nothing here" for a folder that very much exists. The Storage panels now share one byte formatter that can say `391 B`.
 
 - **Some styling silently did nothing.** A handful of components referenced CSS custom properties that were never defined (`--chrome-fg-subtle`, `--chrome-bg-raised`, `--color-warning`). An undefined `var()` makes the whole declaration invalid, so the browser drops it and the element quietly inherits — the dimmed folder paths in the Storage panels weren't dimmed at all. Fixed in those panels, and a new guard (`frontend/src/test/cssTokens.test.js`) fails on any bare `var(--token)` in JSX that isn't defined in a stylesheet or documented as runtime-injected, so a typo can't ship as invisible styling again.

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.3.20"
+_FALLBACK_VERSION = "0.3.21"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.3.20"
+version = "0.3.21"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.3.20"
+version = "0.3.21"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3207,7 +3207,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.3.20"
+version = "0.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
The release that actually closes the 16 GB OOM class — the real reason behind the "Can't reach the local backend" reports.

- `frontend/package.json` → 0.3.21 (single source of truth) + the three toolchain mirrors
- `Cargo.lock` + `uv.lock` regenerated — diffs are the single version lines
- `CHANGELOG.md`: `[Unreleased]` → `## [0.3.21] — 2026-07-12`, sections merged into house style

## What's in it
**Fixed (memory):** the backend no longer sits at ~6.2 GB idle on a 16 GB Mac — the dictation ASR is idle-released (#1104), and only one TTS engine's model stays resident instead of stacking (#1105, measured `omnivoice → mlx-audio`: 4.3 GB → 1.5 GB). Plus two underlying `unload()` leaks (every non-OmniVoice engine's no-op unload; faster-whisper freeing the wrong attribute).
**Added:** Settings → Storage grew a proper pair — "Reset & remove" (scoped reset, #1100) and "Remove all data" (the in-app uninstaller, #1089/#1099).

## Release-infra note
This is the first tag under the #1106 fix (uninstall scripts attach via `gh release upload`, not a second softprops publish). I'll watch the build to confirm all platform installers land on **one** release with a complete `latest.json` — the failure mode that hit v0.3.20 (repaired by hand).

## Verification
`tests/test_app_version.py` 6/6 · `bun install --frozen-lockfile` clean · changelog extracts cleanly as the Release body · backend + frontend green on main with all features combined.

After merge: tag `v0.3.21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Released version `0.3.21` (“the memory release”) across frontend, backend, Rust, and Python metadata, with regenerated lockfiles and an updated changelog.
- Reduced memory pressure by unloading idle dictation ASR resources, keeping only one TTS model resident, and fixing two `unload()` resource leaks.
- Added Settings → Storage actions for **Reset & remove** and **Remove all data**.
- Updated release automation to publish installer assets to a single GitHub release with a complete `latest.json`.

```mermaid
flowchart TD
    A[ASR/TTS resources active] --> B{Idle or replaced?}
    B -->|Yes| C[Unload model/resources]
    B -->|No| A
    C --> D[Lower backend memory usage]
    D --> E[Fewer memory-related backend kills]
```

### Settings UI

```text
Before                         After
Settings → Storage              Settings → Storage
                                 ├─ Reset & remove
                                 └─ Remove all data
```

### Verification

- `tests/test_app_version.py`: 6/6 passed
- `bun install --frozen-lockfile`: successful
- Backend and frontend checks: passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->