### PR TITLE
feat(firstrun): app version beside the app name on Setup / Installing / Models & Engines

### DIFF
--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -565,9 +565,17 @@ export function BootstrapSplash({ stage, message }) {
           <JourneyRail t={t} />
           <div className="mt-2 flex flex-wrap items-end justify-between gap-6">
             <div className="min-w-0">
-              <h1 className="m-0 font-serif text-[clamp(1.6rem,3vw,2.2rem)] font-semibold leading-tight tracking-tight">
-                {t('bootstrap.title', 'OmniVoice Studio')}
-              </h1>
+              {/* Version rides beside the app name — same masthead across all
+                  three first-run acts (setup → install → models & engines), so a
+                  screenshot from any of them identifies the build. */}
+              <div className="flex flex-wrap items-baseline gap-2.5">
+                <h1 className="m-0 font-serif text-[clamp(1.6rem,3vw,2.2rem)] font-semibold leading-tight tracking-tight">
+                  {t('bootstrap.title', 'OmniVoice Studio')}
+                </h1>
+                <span className="font-mono text-[0.62rem] tracking-[0.14em] text-fg-subtle">
+                  v{APP_VERSION}
+                </span>
+              </div>
               <p className="mt-1.5 text-sm leading-snug text-fg-muted" aria-live="polite">
                 {label}
               </p>
@@ -765,12 +773,6 @@ export function BootstrapSplash({ stage, message }) {
             </pre>
           )}
         </section>
-
-        <footer className="mt-auto pt-2">
-          <span className="font-mono text-[0.62rem] tracking-[0.14em] text-fg-subtle">
-            OVS&thinsp;·&thinsp;v{APP_VERSION}
-          </span>
-        </footer>
       </div>
     </div>
   );

--- a/frontend/src/components/FirstRunSetup.jsx
+++ b/frontend/src/components/FirstRunSetup.jsx
@@ -446,9 +446,17 @@ export default function FirstRunSetup() {
             <JourneyRail active="setup" t={t} />
             <div className="mt-2 flex flex-wrap items-end justify-between gap-6">
               <div className="min-w-0">
-                <h1 className="m-0 font-serif text-[clamp(1.6rem,3vw,2.2rem)] font-semibold leading-tight tracking-tight">
-                  {t('firstrun.title', 'Set up OmniVoice Studio')}
-                </h1>
+                {/* Version rides beside the app name — same masthead across all
+                    three first-run acts (setup → install → models & engines), so
+                    a screenshot from any of them identifies the build. */}
+                <div className="flex flex-wrap items-baseline gap-2.5">
+                  <h1 className="m-0 font-serif text-[clamp(1.6rem,3vw,2.2rem)] font-semibold leading-tight tracking-tight">
+                    {t('firstrun.title', 'Set up OmniVoice Studio')}
+                  </h1>
+                  <span className="font-mono text-[0.62rem] tracking-[0.14em] text-fg-subtle">
+                    v{APP_VERSION}
+                  </span>
+                </div>
                 <p className="mt-1.5 max-w-[58ch] text-sm leading-snug text-fg-muted">
                   {t(
                     'firstrun.subtitle',
@@ -789,11 +797,9 @@ export default function FirstRunSetup() {
             </p>
           )}
           <div className="flex flex-wrap items-center justify-between gap-4">
+            {/* Version moved up beside the app name (masthead) — the footer now
+                carries only the download total. */}
             <span className="inline-flex flex-wrap items-baseline gap-2 text-xs tabular-nums text-fg-muted">
-              <span className="whitespace-nowrap font-mono text-[0.62rem] tracking-[0.14em] text-fg-subtle">
-                OVS&thinsp;·&thinsp;v{APP_VERSION}
-              </span>
-              <span aria-hidden="true">—</span>
               {t('firstrun.total_required', {
                 size: fmtGB(combinedNeed),
                 defaultValue: 'Total disk needed: ~{{size}} (one-time download on first use)',


### PR DESCRIPTION
The version was already in the **Models & Engines** masthead, but on **Setup** and **Installing** it sat in a footer as `OVS · v0.3.x` — and those are exactly the two screens a user screenshots when an install goes wrong.

Moved it up beside the app name on both, so all three acts of the first run — **setup → installing → models & engines** — carry the same masthead and any screenshot identifies the build at a glance. The footers keep their real content (the download total on Setup); the duplicated version line is removed.

## Verification
Frontend suite **1211 passed**, including the `cssTokens` guard — which matters here, because a token that doesn't exist renders an invalid declaration that *silently does nothing* (it caught exactly that on my last PR). Also re-ran the backend JSX design guards (border/CJK): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Displays `v{APP_VERSION}` beside the app name in the masthead across all first-run screens.
- Removes the duplicated footer version label while preserving the Setup download total and other footer content.
- Keeps build identification consistent with the Models & Engines screen.

## Layout

```text
Before:
Masthead: App name
Footer:   OVS · vX.Y.Z

After:
Masthead: App name  vX.Y.Z
Footer:   Download total / existing content
```

## Validation

- Frontend tests passed.
- Backend JSX design guards passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->