### PR TITLE
fix(bootstrap): stop clobbering the real failure reason with "never started" (#1112)

### DIFF
--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -54,6 +54,20 @@ pub fn set_stage(state: &Arc<Mutex<BootstrapStage>>, stage: BootstrapStage) {
     }
 }
 
+/// True when the stage already carries a `Failed` diagnosis.
+///
+/// The venv bootstrap (`ensure_venv_ready`) records the REAL reason a start
+/// failed — "Intel Macs can't run the local AI backend", a `uv sync` error, a
+/// blocked GitHub — through `fail()`, which sets exactly this. The spawn watcher
+/// must not then bulldoze it with the generic "never started" (#1112): a caller
+/// that already knows the cause outranks one that only knows the symptom.
+pub fn already_diagnosed(state: &Arc<Mutex<BootstrapStage>>) -> bool {
+    state
+        .lock()
+        .map(|g| matches!(*g, BootstrapStage::Failed { .. }))
+        .unwrap_or(false)
+}
+
 // ── Splash log + byte-progress event channel ─────────────────────────────
 
 #[derive(Clone, Serialize)]
@@ -316,6 +330,27 @@ pub fn spawn_backend_and_wait(app: &tauri::AppHandle, stage_handle: &Arc<Mutex<B
                             venv_dir.display()
                         );
                     }
+                }
+                // #1112: when the backend NEVER started, `ensure_venv_ready` has
+                // usually already diagnosed exactly why — Intel Mac unsupported,
+                // a failed `uv sync`, a blocked GitHub — and recorded it via
+                // `fail()` as a Failed stage carrying that reason. Overwriting it
+                // here with the generic "never started — no error output captured"
+                // destroyed every precise diagnosis: the user saw a message with
+                // no cause, and the UI's hint matcher (which keys off the specific
+                // text — e.g. the Intel-Mac hint) could never fire, so they were
+                // offered a Retry that can never work. Keep the specific reason.
+                //
+                // A REAL spawn failure (exec error) is unaffected: it writes its
+                // diagnostic to backend_err.log and leaves the stage un-Failed, so
+                // the message below still forms with that tail. Likewise a genuine
+                // crash after a successful start (stage is Ready/StartingBackend).
+                if already_diagnosed(stage_handle) {
+                    log::error!(
+                        "Backend never started ({}) — keeping the specific failure already diagnosed",
+                        exit_info
+                    );
+                    return;
                 }
                 let msg = if err_tail.is_empty() {
                     format!("Backend process exited ({}) — no error output captured", exit_info)
@@ -2225,5 +2260,51 @@ mod tests {
         invalidate_cudnn8_probe_cache(&venv_dir);
         assert!(!marker.is_file());
         let _ = fs::remove_dir_all(&venv_dir);
+    }
+}
+
+#[cfg(test)]
+mod failure_preservation_tests {
+    use super::*;
+
+    fn stage(s: BootstrapStage) -> Arc<Mutex<BootstrapStage>> {
+        Arc::new(Mutex::new(s))
+    }
+
+    /// #1112: the venv bootstrap diagnoses the REAL reason (Intel Mac, uv sync
+    /// failure, blocked GitHub) and records it as Failed. The spawn watcher, on
+    /// seeing "no child ever started", must NOT replace that with the generic
+    /// "never started — no error output captured": doing so left the user with a
+    /// causeless message AND stopped the UI's hint matcher (which keys off the
+    /// specific text) from ever firing, so they were offered a Retry that could
+    /// never work.
+    #[test]
+    fn a_specific_failure_is_recognised_as_already_diagnosed() {
+        let s = stage(BootstrapStage::Failed {
+            message: INTEL_MAC_UNSUPPORTED_MSG.to_string(),
+        });
+        assert!(already_diagnosed(&s));
+    }
+
+    #[test]
+    fn a_non_failed_stage_is_not_diagnosed_so_the_generic_message_still_forms() {
+        // A real crash after a successful start, or a raw exec failure: nobody
+        // diagnosed it, so the spawn watcher's message is the only one there is.
+        for st in [
+            BootstrapStage::Checking,
+            BootstrapStage::StartingBackend,
+            BootstrapStage::Ready,
+            BootstrapStage::InstallingDeps,
+        ] {
+            assert!(!already_diagnosed(&stage(st)));
+        }
+    }
+
+    /// The Intel-Mac message must keep the exact wording the frontend hint
+    /// matcher greps for — if this drifts, the user silently loses the only
+    /// hint that tells them retrying is pointless.
+    #[test]
+    fn intel_mac_message_matches_what_the_ui_hint_matcher_greps_for() {
+        assert!(INTEL_MAC_UNSUPPORTED_MSG.contains("Intel Macs can't run the local AI backend"));
     }
 }

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -151,6 +151,16 @@ function detectHints(message, logs) {
   return hints;
 }
 
+/** Failures no retry can ever fix — offering a Retry button for these is the
+ *  dead end #1112 reported ("clicking the buttons does nothing"): the bootstrap
+ *  re-fails identically every time. Today that's the Intel Mac (#889): PyTorch
+ *  ships no macOS x86_64 wheels, so the dependency set can never resolve there.
+ *  Keyed off the same hint the matcher produces, so the two can't drift.
+ *  Pure + exported for tests. */
+export function isUnrecoverableFailure(message, logs = []) {
+  return detectHints(message, logs).includes('bootstrap.hint_intel_mac');
+}
+
 function formatEta(seconds) {
   if (!Number.isFinite(seconds) || seconds <= 0) return '';
   if (seconds < 60) return '<1m';
@@ -370,6 +380,8 @@ export function BootstrapSplash({ stage, message }) {
   const label = t(`bootstrap.${stage}`, STAGE_LABEL[stage]);
   const stepIndex = Math.max(0, STEPS.indexOf(stage));
   const isFailed = stage === 'failed';
+  // Retrying an Intel-Mac install can never succeed — don't offer the dead end.
+  const isUnrecoverable = isFailed && isUnrecoverableFailure(message, logs);
   const [logs, setLogs] = useState([]);
   const [logsOpen, setLogsOpen] = useState(true);
   const [copied, setCopied] = useState(false);
@@ -650,18 +662,35 @@ export function BootstrapSplash({ stage, message }) {
               </ul>
             </div>
             <div className="flex items-center justify-end gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleCleanRetry}
-                disabled={retrying}
-                leading={<Brush size={12} />}
-              >
-                {t('bootstrap.clean_retry', 'Clean & Retry')}
-              </Button>
-              <Button variant="primary" onClick={handleRetry} disabled={retrying}>
-                {retrying ? t('bootstrap.retrying', 'Retrying…') : t('bootstrap.retry', 'Retry')}
-              </Button>
+              {/* #1112: some failures can NEVER be retried away — an Intel Mac
+                  has no PyTorch wheels, so every retry re-fails identically and
+                  the buttons just look broken ("clicking them does nothing").
+                  Say so plainly and don't offer the dead end. */}
+              {isUnrecoverable ? (
+                <span className="text-sm text-fg-muted">
+                  {t(
+                    'bootstrap.unrecoverable',
+                    'Retrying cannot fix this — see the guidance above.',
+                  )}
+                </span>
+              ) : (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleCleanRetry}
+                    disabled={retrying}
+                    leading={<Brush size={12} />}
+                  >
+                    {t('bootstrap.clean_retry', 'Clean & Retry')}
+                  </Button>
+                  <Button variant="primary" onClick={handleRetry} disabled={retrying}>
+                    {retrying
+                      ? t('bootstrap.retrying', 'Retrying…')
+                      : t('bootstrap.retry', 'Retry')}
+                  </Button>
+                </>
+              )}
             </div>
           </section>
         ) : (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1671,6 +1671,7 @@
     "failed": "Setup failed",
     "what_to_try": "What to try:",
     "retry": "Retry",
+    "unrecoverable": "Retrying cannot fix this — see the guidance above.",
     "clean_retry": "Clean & Retry",
     "clean_retry_confirm": "This will delete the cached Python environment and re-download all dependencies (~5-10 min). Continue?",
     "hide_logs": "Hide logs",

--- a/frontend/src/test/splashWatchdog.test.js
+++ b/frontend/src/test/splashWatchdog.test.js
@@ -138,3 +138,24 @@ describe('startSplashWatchdog (#879)', () => {
     expect(onStuck).not.toHaveBeenCalled();
   });
 });
+
+// #1112: an Intel-Mac install can never be retried into working (PyTorch ships
+// no macOS x86_64 wheels), so the splash must not offer a Retry that re-fails
+// identically — the "clicking the buttons does nothing" dead end.
+describe('isUnrecoverableFailure (#1112)', () => {
+  it('flags the Intel-Mac failure as unrecoverable', async () => {
+    const { isUnrecoverableFailure } = await import('../components/BootstrapSplash.jsx');
+    expect(
+      isUnrecoverableFailure(
+        "Intel Macs can't run the local AI backend — PyTorch no longer ships…",
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves ordinary failures retryable', async () => {
+    const { isUnrecoverableFailure } = await import('../components/BootstrapSplash.jsx');
+    expect(isUnrecoverableFailure('uv sync failed: connection timed out')).toBe(false);
+    expect(isUnrecoverableFailure('Backend process exited (never started)')).toBe(false);
+    expect(isUnrecoverableFailure('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #1112 — and it turns out to destroy **every** precise bootstrap diagnosis, not just the Intel one.

## The report
An Intel-Mac user got `Backend process exited (never started) — no error output captured`, and said **Retry and Clean & Retry did nothing at all**.

## One cause, both symptoms
`ensure_venv_ready()` diagnoses the *real* reason a start failed — *"Intel Macs can't run the local AI backend"* (#889: PyTorch ships no macOS x86_64 wheels), a failed `uv sync`, a blocked GitHub — and records it via `fail()` as `Failed{that reason}`.

It then returns `None` → `spawn_backend` returns `None` → and `spawn_backend_and_wait`, seeing no child, **overwrote the stage** with the generic *"Backend process exited (never started) — no error output captured"*. The honest cause was written and immediately bulldozed.

That also explains the dead buttons: the UI's hint matcher keys off the **specific message text**, so with it gone the Intel hint (*"retrying can never help"*) never fired. The user was offered a Retry that re-failed identically every time — which looks exactly like a button that does nothing.

## The fix
- **`already_diagnosed()`** — a caller that knows the **cause** outranks one that only knows the **symptom**. If the stage is already `Failed`, the spawn watcher keeps it. A *real* exec failure is unaffected (it writes its diagnostic to `backend_err.log` and leaves the stage un-`Failed`, so the generic message still forms with that tail), and a genuine post-start crash is untouched.
- **`isUnrecoverableFailure()`** — an Intel Mac can never be retried into working, so stop offering the dead end and say so. Keyed off the same hint the matcher produces, so the two can't drift.

## Verification
3 Rust tests (specific failure preserved / non-failed stages still form the generic message / the Intel wording stays in sync with the UI matcher) + 2 frontend tests. **Rust 81 passed, frontend 1213 passed**, backend JSX design guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserves specific bootstrap failure diagnoses instead of overwriting them with the generic “Backend process exited (never started)” message.
- Detects unrecoverable Intel Mac/no-wheels failures and removes ineffective retry actions.
- Adds localized guidance directing users to the available troubleshooting information.

## Behavior flow

```mermaid
flowchart TD
  A[Backend exits before startup] --> B{Existing Failed diagnosis?}
  B -- Yes --> C[Preserve specific failure]
  B -- No --> D[Use generic never-started failure]
  C --> E{Intel Mac/no-wheels failure?}
  D --> E
  E -- Yes --> F[Show unrecoverable guidance]
  E -- No --> G[Show Retry and Clean & Retry]
```

## UI

```text
Before                         After
----------------------------   ----------------------------
Failure details                Failure details
[Clean & Retry] [Retry]        Intel Mac failure guidance
                               No ineffective retry buttons
```

## Tests

- 81 Rust tests passed.
- 1,213 frontend tests passed.
- Backend JSX design guards passed.
- Added Rust coverage for diagnosis preservation and Intel-specific wording.
- Added frontend coverage for unrecoverable versus retryable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->