### PR TITLE
fix(api): an alive-but-unresponsive backend says so, instead of "it stopped" (#1113)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -165,6 +165,11 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
     : opts;
   const signal = finalOpts.signal as AbortSignal | null | undefined;
   let lastDetail = '';
+  // The shell's last word on the backend. When it still says `ready` after we've
+  // exhausted the reconcile window, the process is demonstrably ALIVE and simply
+  // not answering — a different failure from "it stopped", and it deserves a
+  // different sentence (#1113).
+  let lastStage = 'unknown';
   const startedAt = Date.now();
   for (let attempt = 0; ; attempt++) {
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -191,12 +196,12 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
       // "starting", bounded by STARTUP_GRACE_MS.
       const elapsed = Date.now() - startedAt;
       if (elapsed < STARTUP_GRACE_MS) {
-        let stage = 'unknown';
         try {
-          stage = await backendLifecycleStage();
+          lastStage = await backendLifecycleStage();
         } catch {
           /* never let the lifecycle probe mask the real transport error */
         }
+        const stage = lastStage;
         if (stage === 'starting') {
           await new Promise((r) => setTimeout(r, RESTART_WAIT_INTERVAL_MS));
           continue;
@@ -231,6 +236,22 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
           `The local OmniVoice backend crashed (${describeCrashExit(crash)}) ${crashAge(crash)} ago ` +
             'and is being restarted — this request could not reach it. ' +
             'Open the crash notice for the error output, or check Settings → Logs → Backend.',
+          { status: 0, detail: lastDetail },
+        );
+      }
+      // #1113: no crash was recorded AND the shell still reports the backend as
+      // running — so it did NOT stop; it is alive and has stopped answering.
+      // Telling this user "it may still be starting up, or it stopped" is simply
+      // false, and it sends them to restart the app when the real cause is a
+      // wedged job holding the worker (a heavy generate/transcribe on a small
+      // GPU). Name what actually happened and point at the thing that fixes it.
+      if (lastStage === 'ready') {
+        throw new ApiError(
+          'The local OmniVoice backend is running but stopped responding. This usually means a ' +
+            'job (a generation or a transcription) is stuck holding the engine — often a model ' +
+            'too heavy for the available memory on this machine. Check Settings → Logs → Backend ' +
+            'for the last thing it was doing; a smaller model or engine (Settings → Models) is ' +
+            'the usual fix. Restarting the app clears it for now.',
           { status: 0, detail: lastDetail },
         );
       }

--- a/frontend/src/test/client.restart.test.ts
+++ b/frontend/src/test/client.restart.test.ts
@@ -139,3 +139,45 @@ describe('classifyBootstrapStage', () => {
     expect(classifyBootstrapStage(undefined)).toBe('unknown');
   });
 });
+
+// #1113 — reported on v0.3.21, the release that was supposed to end this class.
+// The user got "it may still be starting up, or it stopped" while the shell knew
+// the backend was RUNNING and no crash was ever recorded. Both halves of that
+// sentence were false: it hadn't stopped, and it wasn't starting. It was alive
+// and wedged. Saying "restart the app" for a stuck job is the wrong advice.
+describe('apiFetch — an alive-but-unresponsive backend says so (#1113)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    stageMock.mockReset();
+    stageMock.mockResolvedValue('unknown');
+  });
+
+  it('names the wedged-job case instead of claiming it stopped', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    stageMock.mockResolvedValue('ready'); // the shell KNOWS the process is alive
+
+    const p = apiFetch('/generate');
+    const assertion = expect(p).rejects.toMatchObject({
+      status: 0,
+      message: expect.stringContaining('running but stopped responding'),
+    });
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 12_000 + 2000);
+    await assertion;
+  });
+
+  it('still says "starting up or stopped" when the shell has no idea (no shell)', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    stageMock.mockResolvedValue('unknown');
+
+    const p = apiFetch('/model/status');
+    const assertion = expect(p).rejects.toMatchObject({
+      message: expect.stringContaining("Can't reach the local OmniVoice backend"),
+    });
+    await vi.advanceTimersByTimeAsync(CASCADE_MS + 100);
+    await assertion;
+  });
+});


### PR DESCRIPTION
Refs #1113 — reported on **v0.3.21**, the release that was supposed to end this class.

## What the report tells us, without reproducing it
The user got the **generic** message — not the crash story. On 0.3.21 `apiFetch` consults the crash marker, and a real process death **always** writes one. So:

- **No marker ⇒ the backend did not die.**
- **The shell still said `ready` ⇒ the process was alive.**

Both halves of *"it may still be starting up, or it stopped"* were therefore **false**. It hadn't stopped, and it wasn't starting. It was **alive and not answering** — a job wedged holding the engine (troubleshooting §14: a generate or transcribe too heavy for the available memory starves the worker).

Telling that user to *"restart the app"* is the wrong advice for a stuck job, and it buries the real cause.

## The fix
When the reconcile window expires and the shell **still** reports `ready`, we *know* the process is running — so say so. Name the wedged-job cause, point at **Settings → Logs → Backend** for what it was last doing, and at a smaller model/engine as the usual fix.

The genuine "stopped or starting" message stays for the case where the shell has no idea (no shell — browser/Docker), and the crash story still wins whenever a marker exists.

## What this is *not*
It does **not** claim to stop the wedge. It stops the app from **lying** about it, and gives the next reporter the right words — which is what we need to actually chase the underlying stall. I'd rather ship an honest message than a third "fixed!" that isn't.

## Verification
2 new tests (the wedged case names itself / the no-shell case keeps the old message), plus the existing crash-story tests still pass unchanged. **Frontend suite 1213 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Improved backend-unreachable errors when the shell reports the backend as `ready` but requests continue to fail.
- Identifies the backend as alive but unresponsive, suggests a wedged generate/transcribe job, and directs users to **Settings → Logs → Backend**.
- Recommends trying a smaller model or engine.
- Preserves the generic startup/stopped message when shell status is unavailable and prioritizes crash-marker errors.
- Added tests for wedged-backend and no-shell scenarios. Frontend suite passes with 1,213 tests.

```mermaid
flowchart TD
  A[Transport failures] --> B[Retry and startup grace period]
  B --> C[Probe backend lifecycle stage]
  C --> D{Crash detected?}
  D -- Yes --> E[Show crash-marker error]
  D -- No --> F{Stage is ready?}
  F -- Yes --> G[Show alive but unresponsive guidance]
  F -- No --> H[Show generic unreachable message]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->