### PR TITLE
fix(dub): stop losing the race for the crash marker — the stream-drop guess is back (#1119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A dub that dies mid-transcription still guessed at the cause.** v0.3.20 taught it to check the crash report before blaming the ASR model — but it checked *instantly*, the moment the stream dropped, and the desktop shell needs about two seconds to notice the backend died and write that report. So it kept looking too early, finding nothing, and falling back to the same old guess ("Likely ASR backend failed to load") even when the backend had in fact just crashed. It now waits for the shell to catch up, so you get the real cause — exit code and error output — instead of a guess. (#1119)
+
 ### Added
 
 - **Opt-in analytics — off by default, and it can't lie to you.** OmniVoice still sends **nothing** out of the box: no accounts, no telemetry, no phone-home, and your text, audio, voices, and projects never leave your machine regardless of what you choose. There is now one toggle in **Settings → Privacy → "Help improve OmniVoice"**, **off unless you turn it on**. If you do, it sends anonymous usage stats — which engine and language you used, how long a generation took, how many *characters* the text had (a number, not the text), and the *type* of any error. It never sends the text you type, your audio, your file names, your voice names, or anything identifying you. That isn't a promise in a policy: an **allowlist in the code** drops any property that isn't on it, so a future change can't leak content by accident, and crash tracebacks are deliberately **not** auto-captured (they can carry file paths and tokens). Turning it off stops everything immediately. Builds from source have no analytics destination at all and don't even show the toggle.

--- a/frontend/src/test/streamDropError.test.ts
+++ b/frontend/src/test/streamDropError.test.ts
@@ -58,3 +58,57 @@ describe('streamDropError (#1062)', () => {
     expect(err.message).toBe(FALLBACK);
   });
 });
+
+// #1119 — reported on v0.3.21, which already HAD the #1098 fix. The user still
+// got the guess ("Likely ASR backend failed to load") because streamDropError
+// asked for the crash marker ONCE, instantly, at the moment the stream dropped —
+// racing the shell's ~2 s detect-and-write and losing. Same race #1102 fixed for
+// apiFetch; this path never got it.
+describe('streamDropError — waits for the shell to notice the death (#1119)', () => {
+  it('finds a marker that arrives LATE instead of falling back to the guess', async () => {
+    let calls = 0;
+    const getCrash = async () => {
+      calls += 1;
+      // The supervisor hasn't noticed yet on the first two polls.
+      return calls < 3 ? null : (marker() as never);
+    };
+    // Force the Tauri path so the wait loop engages, and make sleep instant.
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    try {
+      const err = await streamDropError(FALLBACK, getCrash, {
+        waitMs: 8000,
+        intervalMs: 1,
+        sleep: async () => {},
+      });
+      expect(err.message).toContain('backend crashed');
+      expect(err.message).not.toContain(FALLBACK);
+      expect(calls).toBeGreaterThanOrEqual(3);
+    } finally {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    }
+  });
+
+  it('still gives up and uses the caller message when no crash ever appears', async () => {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    try {
+      const err = await streamDropError(FALLBACK, async () => null, {
+        waitMs: 5,
+        intervalMs: 1,
+        sleep: async () => {},
+      });
+      expect(err.message).toBe(FALLBACK);
+    } finally {
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    }
+  });
+
+  it('does not stall a browser/Docker user — no shell means no marker, ever', async () => {
+    let calls = 0;
+    const err = await streamDropError(FALLBACK, async () => {
+      calls += 1;
+      return null;
+    });
+    expect(err.message).toBe(FALLBACK);
+    expect(calls).toBe(1); // asked once, then stopped — no 8 s wait
+  });
+});

--- a/frontend/src/utils/backendCrash.ts
+++ b/frontend/src/utils/backendCrash.ts
@@ -103,12 +103,33 @@ export function crashAge(marker: Pick<BackendCrashMarker, 'ts'>, nowMs = Date.no
 export async function streamDropError(
   fallbackMessage: string,
   getCrash: () => Promise<BackendCrashMarker | null> = getUnacknowledgedBackendCrash,
+  opts: { waitMs?: number; intervalMs?: number; sleep?: (ms: number) => Promise<void> } = {},
 ): Promise<Error> {
+  // #1119: the shell learns the backend died from a ~2 s POLL — it must notice
+  // the child exit and write the crash marker. Asking for that marker ONCE, at
+  // the instant the stream drops, races that poll and loses: we found nothing
+  // and fell back to the guess ("Likely ASR backend failed to load") even when
+  // the backend had in fact just died. That's the same race #1102 fixed for
+  // apiFetch, which this path never got. Give the shell time to catch up before
+  // believing there was no crash.
+  const waitMs = opts.waitMs ?? 8_000;
+  const intervalMs = opts.intervalMs ?? 1_000;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
   let crash: BackendCrashMarker | null = null;
-  try {
-    crash = await getCrash();
-  } catch {
-    return new Error(fallbackMessage); // forensics unavailable — don't mask the caller
+  const deadline = Date.now() + waitMs;
+  for (;;) {
+    try {
+      crash = await getCrash();
+    } catch {
+      return new Error(fallbackMessage); // forensics unavailable — don't mask the caller
+    }
+    if (crash) break;
+    // Outside the Tauri shell there is no marker to wait for, ever — don't
+    // stall a browser/Docker user for 8 s to learn nothing.
+    if (!inTauri()) break;
+    if (Date.now() >= deadline) break;
+    await sleep(intervalMs);
   }
   if (!crash) return new Error(fallbackMessage);
   try {


### PR DESCRIPTION
Fixes #1119 — reported on **v0.3.21**, which *already had* the #1098 fix. The user still got *"Transcribe stream dropped… **Likely** ASR backend failed to load"* — the exact guess that fix was supposed to retire.

## Why it came back
`streamDropError()` consults the crash marker before falling back to the guess. But it asked **exactly once**, at the instant the stream dropped.

The shell learns a backend died from a **~2 second poll** — it has to notice the child exit and *then* write the marker. So the check raced that poll and lost: no marker yet ⇒ "no crash" ⇒ fall back to the guess, **even when the backend had just died**.

That is precisely the race #1102 fixed for `apiFetch`. **This path never got it** — I fixed the symptom in one place and left the identical bug in the other.

## The fix
Poll for the marker across a short window (8 s, 1 s apart) before believing there was no crash. A late-arriving marker is now found, so the user gets the **real cause** — exit code and captured stderr, one click from the crash notice — instead of a guess.

Outside the Tauri shell there is no marker to wait for, so it asks once and returns immediately (no 8 s stall for a browser/Docker user). Sleep and clock are injectable, so the race itself is unit-tested rather than hoped about.

## Verification
3 new tests: a **late** marker is found rather than missed (this is the bug), no marker ever still yields the caller's message, and a no-shell caller asks exactly once. **Frontend suite 1218 passed.**

## Honest note
This makes the *reporting* correct. Both #1119 and #1113 are 16 GB Apple-Silicon machines dying under a heavy job, and I still want the reporter's backend log before I claim the underlying stall is understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes the `streamDropError()` race where crash markers could be written after the initial lookup.

- Tauri builds poll for an unacknowledged crash marker for up to 8 seconds.
- Detected markers produce detailed exit-code/signal and stderr-based errors.
- Non-Tauri environments check once and immediately use the fallback message.
- Added injectable timing and sleep dependencies for testing.
- Preserves the fallback message if crash forensics fail.

```mermaid
flowchart TD
  A[Stream drops] --> B[Check crash marker]
  B --> C{Marker found?}
  C -- Yes --> D[Report detailed backend crash]
  C -- No, Tauri --> E{8-second deadline reached?}
  E -- No --> F[Wait 1 second and retry]
  F --> B
  E -- Yes --> G[Return fallback message]
  C -- No, non-Tauri --> G
```

## Tests

Added coverage for late marker detection, missing markers, forensics lookup failures, and immediate non-shell behavior.

## Changelog

Documented the mid-transcription crash diagnosis fix under Unreleased → Fixed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->