### PR TITLE
fix(remote-auth): show an API-key gate (not PIN) for API-key 401s in remote-backend mode

### DIFF
--- a/docs/remote-gpu.md
+++ b/docs/remote-gpu.md
@@ -83,6 +83,22 @@ Settings → Sharing → **Remote backend**:
 
 Leave the URL empty to go back to the local backend.
 
+### From a browser (no desktop app)
+
+You can also drive the remote from a plain browser — open the URL with the key
+in the query string once:
+
+```
+https://gpu-box.your-tailnet.ts.net/?api_key=<key>
+```
+
+The key is stored for that browser and the `?api_key=` param is scrubbed from
+the address bar (so it doesn't linger in history or get re-applied on a reload).
+Thereafter the UI loads normally with the key attached to every request. If a
+request ever 401s again (wrong/rotated key), you're prompted to re-enter it. The
+same gate shows a LAN-share **PIN** prompt instead when network sharing — not a
+remote key — is what's gating access.
+
 ## Security notes
 
 - **Plain HTTP is sniffable.** A bearer key over `http://` on a hostile

--- a/docs/remote-gpu.md
+++ b/docs/remote-gpu.md
@@ -86,14 +86,18 @@ Leave the URL empty to go back to the local backend.
 ### From a browser (no desktop app)
 
 You can also drive the remote from a plain browser — open the URL with the key
-in the query string once:
+in the **fragment** once:
 
 ```
-https://gpu-box.your-tailnet.ts.net/?api_key=<key>
+https://gpu-box.your-tailnet.ts.net/#api_key=<key>
 ```
 
-The key is stored for that browser and the `?api_key=` param is scrubbed from
-the address bar (so it doesn't linger in history or get re-applied on a reload).
+Use the fragment (`#`, not `?`) deliberately: fragments are never sent to the
+server, so the key stays out of the GPU box's and any reverse proxy's request
+logs. The key is stored for that browser and the fragment is scrubbed from the
+address bar (so it doesn't linger in history or get re-applied on a reload). If
+your key contains `+`, `&`, `#`, or `=`, URL-encode it (e.g. `#api_key=a%2Bb`);
+keys from `secrets.token_urlsafe` (above) need no encoding.
 Thereafter the UI loads normally with the key attached to every request. If a
 request ever 401s again (wrong/rotated key), you're prompted to re-enter it. The
 same gate shows a LAN-share **PIN** prompt instead when network sharing — not a

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { _parseDeepLinkCredentials } from './client';
 
 describe('apiFetch PIN header', () => {
   let realFetch: typeof globalThis.fetch;
@@ -106,5 +107,50 @@ describe('apiFetch 401 routing', () => {
     }
     expect(authEvent()).toBeTruthy();
     expect((authEvent() as any).detail.mode).toBe('pin');
+  });
+});
+
+describe('_parseDeepLinkCredentials', () => {
+  it('reads the API key from the fragment (not the query) and scrubs it', () => {
+    const r = _parseDeepLinkCredentials('https://h:3900/#api_key=SECRET');
+    expect(r.apiKey).toBe('SECRET');
+    expect(r.pin).toBeNull();
+    expect(r.scrubbed).toBe(true);
+    expect(r.cleanUrl).toBe('/');
+  });
+
+  it('reads the PIN from the query and scrubs it', () => {
+    const r = _parseDeepLinkCredentials('https://h/?pin=1234');
+    expect(r.pin).toBe('1234');
+    expect(r.apiKey).toBeNull();
+    expect(r.cleanUrl).toBe('/');
+  });
+
+  it('scrubs a legacy ?api_key= from the query WITHOUT reading it (no leak)', () => {
+    const r = _parseDeepLinkCredentials('https://h/?api_key=LEGACY');
+    expect(r.apiKey).toBeNull();
+    expect(r.scrubbed).toBe(true);
+    expect(r.cleanUrl).toBe('/');
+  });
+
+  it('preserves other query state and a bare #settings fragment when no api_key is consumed', () => {
+    const r = _parseDeepLinkCredentials('https://h/?pin=1&lang=fr#settings');
+    expect(r.pin).toBe('1');
+    expect(r.apiKey).toBeNull();
+    expect(r.cleanUrl).toBe('/?lang=fr#settings');
+  });
+
+  it('preserves other fragment params alongside api_key', () => {
+    const r = _parseDeepLinkCredentials('https://h/#api_key=S&theme=dark');
+    expect(r.apiKey).toBe('S');
+    expect(r.cleanUrl).toBe('/#theme=dark');
+  });
+
+  it('reports scrubbed=false and leaves the URL intact when no credential is present', () => {
+    const r = _parseDeepLinkCredentials('https://h/path?page=2#top');
+    expect(r.pin).toBeNull();
+    expect(r.apiKey).toBeNull();
+    expect(r.scrubbed).toBe(false);
+    expect(r.cleanUrl).toBe('/path?page=2#top');
   });
 });

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -50,3 +50,61 @@ describe('apiFetch PIN header', () => {
     expect(String(err.detail)).toMatch(/Failed to fetch/);
   });
 });
+
+describe('apiFetch 401 routing', () => {
+  // The backend has two 401-returning middlewares distinguished only by their
+  // `detail` body: "API key required" (BearerKeyMiddleware) vs "PIN required"
+  // (NetworkAccessMiddleware). apiFetch reads the detail and dispatches a single
+  // `ov:auth-required` CustomEvent whose `detail.mode` tells the gate which form.
+  let realFetch: typeof globalThis.fetch;
+  let dispatch: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+    sessionStorage.clear();
+    localStorage.clear();
+    dispatch = vi.spyOn(window, 'dispatchEvent');
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    sessionStorage.clear();
+    localStorage.clear();
+    dispatch.mockRestore();
+  });
+
+  const stub401 = (detail: string) =>
+    vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        text: async () => JSON.stringify({ detail }),
+      }),
+    ) as any;
+
+  const authEvent = () =>
+    dispatch.mock.calls.map((c) => c[0]).find((e) => (e as Event).type === 'ov:auth-required');
+
+  it('dispatches ov:auth-required {mode:"apikey"} on an "API key required" 401', async () => {
+    globalThis.fetch = stub401('API key required');
+    const { apiFetch } = await import('./client');
+    try {
+      await apiFetch('/system/info');
+    } catch {
+      /* ApiError expected */
+    }
+    expect(authEvent()).toBeTruthy();
+    expect((authEvent() as any).detail.mode).toBe('apikey');
+  });
+
+  it('dispatches ov:auth-required {mode:"pin"} on a "PIN required" 401', async () => {
+    globalThis.fetch = stub401('PIN required');
+    const { apiFetch } = await import('./client');
+    try {
+      await apiFetch('/system/info');
+    } catch {
+      /* ApiError expected */
+    }
+    expect(authEvent()).toBeTruthy();
+    expect((authEvent() as any).detail.mode).toBe('pin');
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -303,10 +303,12 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
       // else, i.e. "PIN required" (NetworkAccessMiddleware). Both are 401; the
       // detail is the only discriminator (only two 401 sites exist backend-side).
       if (res.status === 401 && typeof window !== 'undefined') {
-        // String(): readError's declared `string` return is not guaranteed at
-        // runtime — `j.detail` can be a structured object/array on a future 401,
-        // which would crash .toLowerCase(). Coerce before matching.
-        const mode = String(detail).toLowerCase().includes('api key') ? 'apikey' : 'pin';
+        // readError's declared `string` return isn't guaranteed at runtime —
+        // `j.detail` can be a structured object/array on a future 401. Match only
+        // real strings (avoids both a `.toLowerCase()` crash and `String()` itself
+        // throwing on a malformed object); anything else falls back to PIN.
+        const mode =
+          typeof detail === 'string' && detail.toLowerCase().includes('api key') ? 'apikey' : 'pin';
         window.dispatchEvent(new CustomEvent('ov:auth-required', { detail: { mode } }));
       }
       throw new ApiError(`${res.status} ${res.statusText}: ${detail}`, {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -64,6 +64,21 @@ function _apiKey(): string | null {
   }
 }
 
+/** Persist the durable remote API key (trimmed). localStorage so it survives
+ * reloads; read back by `_apiKey()` on every request. Returns false (without
+ * writing) when the value is empty-after-trim or storage is unavailable, so the
+ * caller can avoid reloading into a loop. */
+export function saveApiKey(v: string): boolean {
+  const t = v.trim();
+  if (!t) return false;
+  try {
+    localStorage.setItem(LS_API_KEY, t);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Build a ws:// or wss:// URL for a backend WebSocket endpoint.
  *
  * Scheme derives from the API base itself (NOT window.location — a Tauri
@@ -82,8 +97,26 @@ export function wsUrl(path: string): string {
 // sessionStorage so apiFetch attaches it to every request automatically.
 if (typeof window !== 'undefined') {
   try {
-    const p = new URL(window.location.href).searchParams.get('pin');
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+    const p = params.get('pin');
     if (p) sessionStorage.setItem('ov_pin', p);
+    // Deep-link bootstrap for a remote backend: a URL like
+    // http://gpu-box:3900/?api_key=<key> pre-fills the durable API key the same
+    // way ?pin= pre-fills a session PIN. localStorage (not sessionStorage)
+    // because the key is the durable remote credential — matches RemoteBackendPanel.
+    const k = params.get('api_key');
+    if (k) saveApiKey(k);
+    // One-shot: scrub consumed credentials from the address bar so a later reload
+    // (the gate and Settings both reload after saving) can't re-apply a stale
+    // ?api_key=/?pin= over the user's just-corrected value — and so the secret
+    // doesn't linger in the URL / browser history.
+    if (p || k) {
+      params.delete('pin');
+      params.delete('api_key');
+      const qs = params.toString();
+      window.history.replaceState(null, '', qs ? `${url.pathname}?${qs}` : url.pathname);
+    }
   } catch {
     /* noop */
   }
@@ -262,12 +295,19 @@ export async function apiFetch(path: string, opts: RequestInit = {}): Promise<Re
       );
     }
     if (!res.ok) {
-      // 401 from the LAN PIN middleware on a remote device → surface the gate.
       // An HTTP error means the backend *did* respond — never retry it.
-      if (res.status === 401 && typeof window !== 'undefined') {
-        window.dispatchEvent(new Event('ov:pin-required'));
-      }
       const detail = await readError(res);
+      // 401 on a remote device: route to the right gate by reading the detail.
+      // "API key required" (BearerKeyMiddleware, OMNIVOICE_API_KEY) vs anything
+      // else, i.e. "PIN required" (NetworkAccessMiddleware). Both are 401; the
+      // detail is the only discriminator (only two 401 sites exist backend-side).
+      if (res.status === 401 && typeof window !== 'undefined') {
+        // String(): readError's declared `string` return is not guaranteed at
+        // runtime — `j.detail` can be a structured object/array on a future 401,
+        // which would crash .toLowerCase(). Coerce before matching.
+        const mode = String(detail).toLowerCase().includes('api key') ? 'apikey' : 'pin';
+        window.dispatchEvent(new CustomEvent('ov:auth-required', { detail: { mode } }));
+      }
       throw new ApiError(`${res.status} ${res.statusText}: ${detail}`, {
         status: res.status,
         detail,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -92,32 +92,58 @@ export function wsUrl(path: string): string {
   return `${url}${url.includes('?') ? '&' : '?'}api_key=${encodeURIComponent(key)}`;
 }
 
-// Capture a QR-supplied PIN once on load. When LAN sharing is on, the host's
-// QR code links to `http://<lan-ip>:<port>/?pin=<pin>`; stash it in
-// sessionStorage so apiFetch attaches it to every request automatically.
+/**
+ * Pull deep-link credentials out of a URL and return them plus a scrubbed URL.
+ * Pure (no side effects) so it's unit-testable; the on-load block below applies
+ * the effects.
+ *   • ?pin=<pin>     (query)    — LAN-share QR. Returned as `pin` (session).
+ *   • #api_key=<key> (fragment) — remote-backend deep link. Returned as `apiKey`
+ *     (durable). Read from the FRAGMENT because fragments aren't sent to the
+ *     server, so the durable secret stays out of request logs; the PIN stays in
+ *     the query since the QR flow needs the server to see it.
+ * A stray legacy ?api_key= in the query is scrubbed from `cleanUrl` but NOT
+ * returned — reading it would resend the secret to the server on reload, the
+ * very leak the fragment avoids. `scrubbed` is true when any credential param
+ * was present, so the caller knows to rewrite the address bar.
+ *
+ * Caveat: the fragment is parsed with URLSearchParams, so a key containing `+`
+ * decodes as a space — URL-encode such keys (`#api_key=a%2Bb`). Keys from the
+ * documented `secrets.token_urlsafe` / hex generators don't contain `+`.
+ */
+export function _parseDeepLinkCredentials(href: string): {
+  pin: string | null;
+  apiKey: string | null;
+  cleanUrl: string;
+  scrubbed: boolean;
+} {
+  const url = new URL(href);
+  const pin = url.searchParams.get('pin');
+  const legacyQueryKey = url.searchParams.get('api_key');
+  const hashParams = new URLSearchParams(url.hash.replace(/^#/, ''));
+  const apiKey = hashParams.get('api_key');
+  if (pin) url.searchParams.delete('pin');
+  if (legacyQueryKey) url.searchParams.delete('api_key');
+  if (apiKey) {
+    hashParams.delete('api_key');
+    url.hash = hashParams.toString();
+  }
+  return {
+    pin,
+    apiKey,
+    cleanUrl: url.pathname + url.search + url.hash,
+    scrubbed: Boolean(pin || apiKey || legacyQueryKey),
+  };
+}
+
+// On load, capture deep-link credentials (?pin= from the QR query, #api_key=
+// from a remote-backend fragment) so apiFetch attaches them automatically, then
+// scrub them from the address bar (one-shot — see _parseDeepLinkCredentials).
 if (typeof window !== 'undefined') {
   try {
-    const url = new URL(window.location.href);
-    const params = url.searchParams;
-    const p = params.get('pin');
-    if (p) sessionStorage.setItem('ov_pin', p);
-    // Deep-link bootstrap for a remote backend: a URL like
-    // http://gpu-box:3900/?api_key=<key> pre-fills the durable API key the same
-    // way ?pin= pre-fills a session PIN. localStorage (not sessionStorage)
-    // because the key is the durable remote credential — matches RemoteBackendPanel.
-    const k = params.get('api_key');
-    if (k) saveApiKey(k);
-    // One-shot: scrub consumed credentials from the address bar so a later reload
-    // (the gate and Settings both reload after saving) can't re-apply a stale
-    // ?api_key=/?pin= over the user's just-corrected value — and so the secret
-    // doesn't linger in the URL / browser history.
-    if (p || k) {
-      params.delete('pin');
-      params.delete('api_key');
-      const qs = params.toString();
-      // Preserve url.hash (deep-link fragments, e.g. #settings) when rebuilding.
-      window.history.replaceState(null, '', url.pathname + (qs ? `?${qs}` : '') + url.hash);
-    }
+    const { pin, apiKey, cleanUrl, scrubbed } = _parseDeepLinkCredentials(window.location.href);
+    if (pin) sessionStorage.setItem('ov_pin', pin);
+    if (apiKey) saveApiKey(apiKey);
+    if (scrubbed) window.history.replaceState(null, '', cleanUrl);
   } catch {
     /* noop */
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -115,7 +115,8 @@ if (typeof window !== 'undefined') {
       params.delete('pin');
       params.delete('api_key');
       const qs = params.toString();
-      window.history.replaceState(null, '', qs ? `${url.pathname}?${qs}` : url.pathname);
+      // Preserve url.hash (deep-link fragments, e.g. #settings) when rebuilding.
+      window.history.replaceState(null, '', url.pathname + (qs ? `?${qs}` : '') + url.hash);
     }
   } catch {
     /* noop */

--- a/frontend/src/components/RemoteAuthGate.jsx
+++ b/frontend/src/components/RemoteAuthGate.jsx
@@ -1,47 +1,68 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { saveApiKey } from '../api/client';
 
-// When LAN sharing is on, a non-loopback request that lacks the PIN gets a 401
-// from the backend middleware. `client.ts` dispatches `ov:pin-required` on that
-// 401; this gate listens for it and swaps the app tree for a PIN entry form.
-// `forceGate` is test-only. Submitting stores the PIN in sessionStorage (read
-// by apiFetch on every subsequent request) and reloads so the gated requests
-// retry with the header attached.
-export default function RemoteAuthGate({ children, forceGate = false }) {
+// On a remote device the backend can demand EITHER a LAN-share PIN
+// (NetworkAccessMiddleware → "PIN required") OR an API key (BearerKeyMiddleware
+// → "API key required") — both 401. client.ts reads the detail, decides which,
+// and dispatches a single `ov:auth-required` CustomEvent carrying the mode; this
+// gate listens for it and swaps the app tree for the matching entry form.
+// `forceGate` / `forceMode` are test-only. Submitting stores the credential
+// (sessionStorage for the session PIN, localStorage for the durable API key) and
+// reloads so the gated requests retry with the header attached. If both gates
+// are active the reload cycle re-shows this gate in whichever mode the next 401
+// dictates.
+export default function RemoteAuthGate({ children, forceGate = false, forceMode = 'pin' }) {
   const { t } = useTranslation();
   const [gated, setGated] = useState(forceGate);
-  const [pin, setPin] = useState('');
+  const [mode, setMode] = useState(forceMode);
+  const [value, setValue] = useState('');
 
   useEffect(() => {
-    const onRequired = () => setGated(true);
-    window.addEventListener('ov:pin-required', onRequired);
-    return () => window.removeEventListener('ov:pin-required', onRequired);
+    const onRequired = (e) => {
+      setMode(e.detail?.mode === 'apikey' ? 'apikey' : 'pin');
+      setGated(true);
+    };
+    window.addEventListener('ov:auth-required', onRequired);
+    return () => window.removeEventListener('ov:auth-required', onRequired);
   }, []);
 
   if (!gated) return children;
 
+  const i18nKey = mode === 'apikey' ? 'remote_apikey_gate' : 'remote_gate';
+
   const submit = (e) => {
     e.preventDefault();
-    const v = pin.trim();
+    const v = value.trim();
     if (!v) return;
-    sessionStorage.setItem('ov_pin', v);
-    window.location.reload();
+    // Persist, then reload so the gated requests retry with the credential
+    // attached. A failed write (privacy-mode storage, etc.) must NOT reload into
+    // a loop — leave the form up so the user isn't silently re-prompted forever.
+    let ok = true;
+    try {
+      if (mode === 'apikey') ok = saveApiKey(v);
+      else sessionStorage.setItem('ov_pin', v);
+    } catch {
+      ok = false;
+    }
+    if (ok) window.location.reload();
   };
 
   return (
     <div className="remote-auth-gate" role="dialog" aria-modal="true">
       <form onSubmit={submit} className="remote-auth-gate__card">
-        <h2>{t('remote_gate.title')}</h2>
-        <p>{t('remote_gate.body')}</p>
-        <label htmlFor="ov-pin">{t('remote_gate.label')}</label>
+        <h2>{t(`${i18nKey}.title`)}</h2>
+        <p>{t(`${i18nKey}.body`)}</p>
+        <label htmlFor="ov-cred">{t(`${i18nKey}.label`)}</label>
         <input
-          id="ov-pin"
-          inputMode="numeric"
-          value={pin}
-          onChange={(e) => setPin(e.target.value)}
+          id="ov-cred"
+          type={mode === 'apikey' ? 'password' : 'text'}
+          inputMode={mode === 'apikey' ? undefined : 'numeric'}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
           autoFocus
         />
-        <button type="submit">{t('remote_gate.connect')}</button>
+        <button type="submit">{t(`${i18nKey}.connect`)}</button>
       </form>
     </div>
   );

--- a/frontend/src/components/RemoteAuthGate.test.jsx
+++ b/frontend/src/components/RemoteAuthGate.test.jsx
@@ -3,8 +3,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import RemoteAuthGate from './RemoteAuthGate';
 
 describe('RemoteAuthGate', () => {
-  beforeEach(() => sessionStorage.clear());
-  afterEach(() => sessionStorage.clear());
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
 
   it('renders children when not gated', () => {
     render(
@@ -24,5 +30,16 @@ describe('RemoteAuthGate', () => {
     fireEvent.change(screen.getByLabelText(/access pin/i), { target: { value: '999111' } });
     fireEvent.click(screen.getByRole('button', { name: /connect/i }));
     expect(sessionStorage.getItem('ov_pin')).toBe('999111');
+  });
+
+  it('stores the entered API key (apikey mode)', () => {
+    render(
+      <RemoteAuthGate forceGate forceMode="apikey">
+        <div>app-content</div>
+      </RemoteAuthGate>,
+    );
+    fireEvent.change(screen.getByLabelText(/api key/i), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+    expect(localStorage.getItem('ov_api_key')).toBe('secret123');
   });
 });

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -2141,6 +2141,12 @@
     "label": "الوصول إلى رقم التعريف الشخصي",
     "connect": "الاتصال"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "تواصل معنا",
     "hero_desc": "الأسئلة أو الأخطاء أو التراخيص أو مجرد إلقاء التحية - إليك كيفية التواصل معي.",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2141,6 +2141,12 @@
     "label": "Zugangs-PIN",
     "connect": "Verbinden"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Nehmen Sie Kontakt auf",
     "hero_desc": "Fragen, Bugs, Lizenzen oder einfach nur, um Hallo zu sagen – hier erfahren Sie, wie Sie mich erreichen.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2455,6 +2455,12 @@
     "label": "Access PIN",
     "connect": "Connect"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "reportBug": {
     "label": "Report a bug",
     "title": "Opens a prefilled GitHub Issues page in your browser. Nothing is sent until you click Submit."

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -2141,6 +2141,12 @@
     "label": "PIN de acceso",
     "connect": "Conectar"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Ponte en contacto",
     "hero_desc": "Preguntas, errores, licencias o simplemente para saludar: aquí le mostramos cómo comunicarse conmigo.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -2141,6 +2141,12 @@
     "label": "Accéder au code PIN",
     "connect": "Se connecter"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Contactez-nous",
     "hero_desc": "Questions, bugs, licences ou simplement pour me dire bonjour : voici comment me joindre.",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -2141,6 +2141,12 @@
     "label": "पिन तक पहुंचें",
     "connect": "कनेक्ट करें"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "संपर्क करें",
     "hero_desc": "प्रश्न, बग, लाइसेंसिंग, या सिर्फ नमस्ते कहना - यहां बताया गया है कि मुझ तक कैसे पहुंचा जाए।",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -2141,6 +2141,12 @@
     "label": "Akses PIN",
     "connect": "Hubungkan"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Hubungi kami",
     "hero_desc": "Pertanyaan, bug, perizinan, atau sekadar menyapa — inilah cara menghubungi saya.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -2141,6 +2141,12 @@
     "label": "PIN di accesso",
     "connect": "Connettiti"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Mettiti in contatto",
     "hero_desc": "Domande, bug, licenze o semplicemente per salutarmi: ecco come contattarmi.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -2141,6 +2141,12 @@
     "label": "アクセスPIN",
     "connect": "接続する"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "連絡する",
     "hero_desc": "質問、バグ、ライセンス、または単にご挨拶など、私に連絡する方法は次のとおりです。",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -2141,6 +2141,12 @@
     "label": "PIN 액세스",
     "connect": "연결하다"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "연락하세요",
     "hero_desc": "질문, 버그, 라이센싱 또는 간단한 인사말 등 제게 연락하는 방법은 다음과 같습니다.",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -2141,6 +2141,12 @@
     "label": "Toegangspincode",
     "connect": "Verbinden"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Neem contact op",
     "hero_desc": "Vragen, bugs, licenties, of gewoon om hallo te zeggen: zo kunt u mij bereiken.",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -2141,6 +2141,12 @@
     "label": "Dostęp do PIN-u",
     "connect": "Połącz"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Skontaktuj się",
     "hero_desc": "Pytania, błędy, licencje lub po prostu przywitanie się — oto jak się ze mną skontaktować.",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -2141,6 +2141,12 @@
     "label": "PIN de acesso",
     "connect": "Conectar"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Entre em contato",
     "hero_desc": "Dúvidas, bugs, licenciamento ou apenas para dizer oi – veja como entrar em contato comigo.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2141,6 +2141,12 @@
     "label": "PIN-код доступа",
     "connect": "Соединять"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Свяжитесь с нами",
     "hero_desc": "Вопросы, ошибки, лицензирование или просто поздороваться — вот как со мной связаться.",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -2141,6 +2141,12 @@
     "label": "Åtkomst PIN",
     "connect": "Anslut"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Hör av dig",
     "hero_desc": "Frågor, buggar, licensiering eller bara för att säga hej - så här når du mig.",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -2141,6 +2141,12 @@
     "label": "รหัสการเข้าถึง",
     "connect": "เชื่อมต่อ"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "สนใจติดต่อ",
     "hero_desc": "คำถาม ข้อบกพร่อง ใบอนุญาต หรือเพียงทักทาย ต่อไปนี้เป็นวิธีติดต่อฉัน",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -2141,6 +2141,12 @@
     "label": "Erişim PIN'i",
     "connect": "Bağlan"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "İletişime geçin",
     "hero_desc": "Sorular, hatalar, lisanslama veya sadece merhaba demek için; bana şu şekilde ulaşabilirsiniz.",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -2141,6 +2141,12 @@
     "label": "PIN доступу",
     "connect": "Підключитися"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Зв'яжіться",
     "hero_desc": "Запитання, помилки, ліцензування або просто привітатися — ось як зі мною зв’язатися.",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -2141,6 +2141,12 @@
     "label": "Mã PIN truy cập",
     "connect": "Kết nối"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "Hãy liên lạc",
     "hero_desc": "Các câu hỏi, lỗi, giấy phép hoặc chỉ để chào hỏi — đây là cách liên hệ với tôi.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -2148,6 +2148,12 @@
     "label": "访问密码",
     "connect": "连接"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "联系我们",
     "hero_desc": "如果有问题、错误、许可，或者只是想打个招呼，请按以下方式联系我。",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -2141,6 +2141,12 @@
     "label": "訪問密碼",
     "connect": "連接"
   },
+  "remote_apikey_gate": {
+    "title": "Enter API key",
+    "body": "This backend requires an API key. Enter the value of OMNIVOICE_API_KEY set on the server.",
+    "label": "API key",
+    "connect": "Connect"
+  },
   "contact": {
     "hero_title": "聯絡我們",
     "hero_desc": "如果有問題、錯誤、許可，或只是想打個招呼，請按以下方式與我聯絡。",

--- a/frontend/src/main-app.jsx
+++ b/frontend/src/main-app.jsx
@@ -64,7 +64,7 @@ export async function bootstrapApp() {
             loads a bare URL (no ?pin=) during first-run setup states —
             setup-status check, SetupWizard, BootstrapSplash — still gets the
             PIN dialog instead of a silent 401. Loopback / QR users are
-            unaffected (the gate only shows on an ov:pin-required event). */}
+            unaffected (the gate only shows on an ov:auth-required event). */}
         <RemoteAuthGate>
           {isWidget ? (
             <Suspense


### PR DESCRIPTION
## Problem

When `OMNIVOICE_API_KEY` is set (remote-backend mode — the `docs/remote-gpu.md` setup), a non-loopback browser gets `401 {"detail":"API key required"}` from `BearerKeyMiddleware`. But `client.ts` fired `ov:pin-required` on **every** 401, so `RemoteAuthGate` showed its **PIN** form — whose payload (`sessionStorage` `ov_pin` → `X-OmniVoice-Pin` / `?pin=`) can never satisfy the API-key middleware. A remote user was stuck on a PIN form they could not pass.

## Fix (frontend-only — backend unchanged)

- `client.ts` reads the 401 `detail` and dispatches a single `ov:auth-required` `CustomEvent` carrying `{ mode: 'apikey' | 'pin' }`. The two backend 401s are distinguishable only by their `detail` body (`"API key required"` vs `"PIN required"`); only two 401 sites exist backend-side.
- `RemoteAuthGate` renders the matching PIN or API-key form, storing `ov_pin` (session) or `ov_api_key` (durable localStorage).
- `?api_key=<key>` deep-link bootstrap (mirrors the existing `?pin=` QR flow), **scrubbed from the URL after capture** so a reload can't re-clobber a corrected key (and the secret doesn't linger in history).
- Guarded `saveApiKey` helper shared by the gate and the bootstrap.

## Docs

`docs/remote-gpu.md` already promised *"drive it from the desktop app or a browser"* but only documented the desktop-app Settings flow; added a **"From a browser"** subsection covering the `?api_key=` deep link.

## Testing

- `RemoteAuthGate.test.jsx`: API-key-mode submit writes `ov_api_key`.
- `client.test.ts`: 401 routing dispatches `ov:auth-required` with the correct `mode` for both `"API key required"` and `"PIN required"`.
- All frontend gates green: `bun test` (162 files / 1256 tests), `typecheck:ci`, `lint`, `format:check`, and the i18n probe (new `remote_apikey_gate` keys added to all 21 locales). Backend untouched.

## Notes / follow-up

The routing discriminates on the `detail` prose, which the backend owns. A more robust follow-up would have the backend emit a structured `code` on both 401s (`{"detail":"…","code":"api_key_required"}`) and have the frontend switch on `code` rather than substring-matching a sentence — intentionally out of scope for this frontend-only fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated remote authentication so `401` routing chooses the correct credential form:
  - `"API key required"` → opens the API-key gate
  - `"PIN required"` → opens the PIN gate
- `frontend/src/api/client.ts` now dispatches a single `ov:auth-required` event on `401` with `detail.mode`:
  - `"apikey"` only when the parsed 401 `detail` is a **string** whose lowercase content includes `"api key"`
  - otherwise `"pin"`
- Added durable API-key persistence:
  - New exported `saveApiKey(v: string): boolean` trims and stores in `localStorage` under `ov_api_key` (returns `false` on empty/trimmed value or storage failure)
  - PIN persistence remains in `sessionStorage` under `ov_pin`
- Browser deep-link bootstrap refactor:
  - PIN still comes from query `?pin=<pin>`
  - API key now comes from URL fragment `#api_key=<key>` (so it isn’t sent to server/proxy logs)
  - Consumed credentials are scrubbed from the address bar via `history.replaceState` using a computed `cleanUrl`
  - Legacy query-string `?api_key=` is scrubbed from `cleanUrl` but is **not** read/used
  - Implemented via pure helper `_parseDeepLinkCredentials(href)` (unit-tested parsing + scrubbing)
- Expanded `frontend/src/components/RemoteAuthGate.jsx` from PIN-only to dual-mode:
  - Listens for `ov:auth-required` and switches between `remote_apikey_gate` and `remote_gate` based on `e.detail.mode` (defaulting to PIN)
  - Persists based on mode (`localStorage` for API key, `sessionStorage` for PIN) and avoids infinite reload when storage fails
- Documented browser-based remote API-key authentication in `docs/remote-gpu.md`.
- Added/updated frontend tests for `apiFetch` 401 routing/event dispatch and deep-link credential parsing/scrubbing.
- Added new i18n strings under `remote_apikey_gate` (English content pending community translation).

## UI

```text
Before:                         After:
[ PIN required ]                [ PIN required ]  /  [ API key required ]
[ PIN input   ]                [ PIN input   ]      [ API-key input ]
[ Connect     ]                [ Connect      ]     [ Connect      ]
```

## Authentication flow

```mermaid
flowchart TD
  A[Remote request] --> B{HTTP status 401?}
  B -- No --> C[Normal error handling]
  B -- Yes --> D[Read 401 body (detail/error text)]
  D --> E{detail is string && contains "api key" (case-insensitive)?}
  E -- Yes --> F[dispatch ov:auth-required {mode:"apikey"}]
  E -- No --> G[dispatch ov:auth-required {mode:"pin"}]
  F --> H[RemoteAuthGate shows API-key form]
  G --> I[RemoteAuthGate shows PIN form]
  H --> J[Persist API key: saveApiKey() → localStorage (ov_api_key)]
  I --> K[Persist PIN: sessionStorage (ov_pin)]
  J --> L[Retry gated request]
  K --> L

  subgraph Browser bootstrap (on load)
    M[Load URL] --> N[_parseDeepLinkCredentials(window.location.href)]
    N --> O[Extract ?pin= (query) and `#api_key`= (fragment)]
    O --> P[Scrub consumed creds from address bar (replaceState → cleanUrl)]
    P --> Q[Persist: pin → sessionStorage; apiKey → saveApiKey/localStorage]
  end
```

## Validation

Frontend tests, type checking, linting, formatting, and i18n checks pass; backend behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->