### PR TITLE
fix: prevent TDZ ReferenceError crash when bootstrap fails

### DIFF
--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -380,9 +380,9 @@ export function BootstrapSplash({ stage, message }) {
   const label = t(`bootstrap.${stage}`, STAGE_LABEL[stage]);
   const stepIndex = Math.max(0, STEPS.indexOf(stage));
   const isFailed = stage === 'failed';
+  const [logs, setLogs] = useState([]);
   // Retrying an Intel-Mac install can never succeed — don't offer the dead end.
   const isUnrecoverable = isFailed && isUnrecoverableFailure(message, logs);
-  const [logs, setLogs] = useState([]);
   const [logsOpen, setLogsOpen] = useState(true);
   const [copied, setCopied] = useState(false);
   const [progress, setProgress] = useState(null);


### PR DESCRIPTION
`isUnrecoverable` referenced `logs` before `useState([])` declared it. When the backend setup fails (`isFailed === true`), the short-circuit `&&` accesses `logs` in its temporal dead zone, throwing `ReferenceError` and crashing the splash screen.

### Fix
Moved `const [logs, setLogs] = useState([])` one line up, before `isUnrecoverable`.

### Before
```js
const isUnrecoverable = isFailed && isUnrecoverableFailure(message, logs);
const [logs, setLogs] = useState([]);
```
### After
```js
const [logs, setLogs] = useState([]);
const isUnrecoverable = isFailed && isUnrecoverableFailure(message, logs);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Initialize `logs` state before computing `isUnrecoverable`.
- Prevent a TDZ `ReferenceError` when backend setup fails, avoiding splash-screen crashes during bootstrap failures.

## Behavior

```mermaid
flowchart TD
  A[Bootstrap starts] --> B{Backend setup fails?}
  B -- No --> C[Render splash normally]
  B -- Yes --> D[Compute isUnrecoverable using initialized logs]
  D --> E[Render failure state without crashing]
```

## UI impact

```text
Before: BootstrapSplash
        └─ failure path → ReferenceError → splash crashes

After:  BootstrapSplash
        └─ failure path → initialized logs → failure UI renders
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->