### PR TITLE
fix: log full traceback when dub job persistence fails

### DIFF
--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -231,8 +231,8 @@ def save_job(job_id: str, job: dict, filename: str = "", duration: float = 0.0, 
                  len(segments), job.get("language", ""), job.get("language_code", ""),
                  json.dumps(tracks), json.dumps(job, default=str), content_hash or "", time.time()),
             )
-    except Exception as e:
-        logger.error("Failed to persist dub job %s: %s", job_id, e)
+    except Exception:
+        logger.exception("Failed to persist dub job %s", job_id)
         return
     event_bus.emit("dub_history", {"action": "saved", "id": job_id})
 


### PR DESCRIPTION
`save_job`'s `except` block catches the re-raised exception from `db_conn()` (which rolls back and re-raises on failure) but only logs the error message without the traceback.

### Problem
The caller (`ingest_pipeline`, `dub_generate`, etc.) receives no indication of failure and continues as if the job was persisted. After a server restart, the dub history entry is permanently lost.

### Root cause
`logger.error("Failed to persist dub job %s: %s", job_id, e)` logs only the exception message — not the traceback. When `db_conn()` raises (e.g. SQLite lock, disk full, schema mismatch), the stack trace pointing to the exact SQL statement and call path is discarded.

### Fix
Changed to `logger.exception()` which automatically includes the full traceback via `exc_info=True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Changed `save_job` to use `logger.exception()` for persistence failures, recording the complete database traceback before the error is handled and the function returns. No control-flow or public API changes.

```mermaid
flowchart TD
  A[Save job to SQLite] -->|failure| B[logger.exception]
  B --> C[Record error and traceback]
  C --> D[Return without emitting saved event]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->