### PR TITLE
fix: return empty text instead of partial garbage when EPUB HTML parse fails

### DIFF
--- a/backend/services/longform_import.py
+++ b/backend/services/longform_import.py
@@ -12,6 +12,7 @@ just a front door onto the existing pipeline.
 from __future__ import annotations
 
 import io
+import logging
 import posixpath
 import re
 import zipfile
@@ -29,6 +30,8 @@ _CHAPTER_TITLE_MAX = 60
 # *uncompressed* bytes read from the archive.
 _EPUB_MAX_ENTRY_BYTES = 25 * 1024 * 1024
 _EPUB_MAX_TOTAL_BYTES = 300 * 1024 * 1024
+
+logger = logging.getLogger("omnivoice.longform_import")
 
 
 def chapterize_plaintext(text: str) -> str:
@@ -108,7 +111,8 @@ def _html_to_title_body(xhtml: str) -> tuple[str, str]:
     try:
         p.feed(xhtml)
     except Exception:
-        pass
+        logger.warning("HTML parsing failed for EPUB entry", exc_info=True)
+        return "", ""
     return p.title, p.text()
 
 

--- a/backend/services/longform_import.py
+++ b/backend/services/longform_import.py
@@ -111,8 +111,11 @@ def _html_to_title_body(xhtml: str) -> tuple[str, str]:
     try:
         p.feed(xhtml)
     except Exception:
-        logger.warning("HTML parsing failed for EPUB entry", exc_info=True)
-        return "", ""
+        # Keep whatever the extractor collected before the failure: an empty
+        # return would make the caller's `if not body.strip(): continue` drop
+        # the whole chapter from the audiobook silently — a partial chapter
+        # plus this log line is strictly more recoverable than a missing one.
+        logger.warning("HTML parsing failed for EPUB entry; using partial text", exc_info=True)
     return p.title, p.text()
 
 

--- a/backend/tests/test_longform_import_parse_failure.py
+++ b/backend/tests/test_longform_import_parse_failure.py
@@ -1,0 +1,94 @@
+"""A mid-chapter HTML parse failure must not silently drop the chapter.
+
+`_html_to_title_body` swallows parser exceptions. If it returned empty text
+on failure, `epub_to_chapter_script`'s `if not body.strip(): continue` would
+silently omit that chapter from the audiobook — the user only finds out when
+the narration skips from chapter 1 to chapter 3. The contract instead: keep
+the partial text extracted before the failure, and log a warning (#1161).
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from services import longform_import as li
+
+
+def _make_epub(n_chapters: int = 3) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("mimetype", "application/epub+zip")
+        z.writestr(
+            "META-INF/container.xml",
+            '<?xml version="1.0"?>'
+            '<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">'
+            '<rootfiles><rootfile full-path="OEBPS/content.opf"'
+            ' media-type="application/oebps-package+xml"/></rootfiles></container>',
+        )
+        manifest, spine = [], []
+        for i in range(1, n_chapters + 1):
+            z.writestr(
+                f"OEBPS/ch{i}.xhtml",
+                f"<html><head><title>Chapter {i}</title></head><body>"
+                f"<h1>Chapter {i}</h1>"
+                f"<p>Opening paragraph of chapter {i}.</p>"
+                f"<p>Closing paragraph of chapter {i}.</p></body></html>",
+            )
+            manifest.append(f'<item id="c{i}" href="ch{i}.xhtml" media-type="application/xhtml+xml"/>')
+            spine.append(f'<itemref idref="c{i}"/>')
+        z.writestr(
+            "OEBPS/content.opf",
+            '<?xml version="1.0"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="id">'
+            '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>Test Book</dc:title></metadata>'
+            f"<manifest>{''.join(manifest)}</manifest><spine>{''.join(spine)}</spine></package>",
+        )
+    return buf.getvalue()
+
+
+def test_clean_epub_yields_all_chapters():
+    script = li.epub_to_chapter_script(_make_epub())
+    assert script.count("# Chapter") == 3
+
+
+def test_mid_chapter_parse_failure_keeps_partial_text(monkeypatch, caplog):
+    """Parser dies halfway through chapter 2 → chapter 2 stays, with the text
+    extracted up to the failure point; the failure is logged, not silent."""
+    real_feed = li._TextExtractor.feed
+
+    def poisoned_feed(self, data):
+        if "chapter 2" in data:
+            half = data.index("Closing")
+            real_feed(self, data[:half])
+            raise ValueError("simulated parser blow-up mid-chapter")
+        return real_feed(self, data)
+
+    monkeypatch.setattr(li._TextExtractor, "feed", poisoned_feed)
+
+    with caplog.at_level("WARNING"):
+        script = li.epub_to_chapter_script(_make_epub())
+
+    # All three chapters still present — nothing silently dropped.
+    assert script.count("# Chapter") == 3
+    assert "# Chapter 2" in script
+    # The pre-failure text survived.
+    assert "Opening paragraph of chapter 2." in script
+    # And the failure left a trace for diagnosis.
+    assert any("HTML parsing failed" in r.message for r in caplog.records)
+
+
+def test_chapter_failing_before_any_text_is_skipped_not_fatal(monkeypatch):
+    """If the parser dies before extracting anything, that chapter is empty and
+    skipped (pre-existing behavior) — but the rest of the book still imports."""
+
+    def dead_feed(self, data):
+        if "chapter 2" in data:
+            raise ValueError("boom before any text")
+        return li.HTMLParser.feed(self, data)
+
+    monkeypatch.setattr(li._TextExtractor, "feed", dead_feed)
+
+    script = li.epub_to_chapter_script(_make_epub())
+    assert "# Chapter 1" in script and "# Chapter 3" in script
+    assert "chapter 2" not in script.lower()


### PR DESCRIPTION
`_html_to_title_body` used `except Exception: pass` when the HTMLParser raised.

### Problem
The parser accumulates state incrementally across `handle_starttag`, `handle_endtag`, and `handle_data` callbacks. A mid-parse failure returns whatever partial or corrupted `title` and `_parts` were accumulated before the error — with zero indication anything went wrong.

### Impact
An EPUB with a single corrupt XHTML entry produces silently wrong chapter text. The user sees incorrect audiobook chapter narration with no error feedback.

### Fix
- Returns `("", "")` on parse failure instead of partial state
- Logs the failure with `logger.warning(exc_info=True)` so the traceback is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserves partially extracted EPUB XHTML text when `_html_to_title_body` encounters a mid-chapter `HTMLParser` exception, instead of discarding the whole chapter by returning empty title/body.
- Emits a module-scoped warning with traceback (`logger.warning(..., exc_info=True)`) on HTML parsing failure, improving diagnosability while still returning `p.title` and `p.text()` accumulated before the failure.
- Adds regression tests ensuring:
  - A clean EPUB imports all chapters.
  - A simulated mid-chapter parse failure keeps Chapter 2 with pre-failure text and logs an “HTML parsing failed” warning.
  - If parsing fails before any text is collected, that chapter remains skippable while later chapters still import.

```mermaid
flowchart TD
    A[Parse EPUB XHTML] --> B{HTML parsing succeeds?}
    B -->|Yes| C[Return collected title and body]
    B -->|No| D[Log warning with traceback]
    D --> E[Return title/body collected before failure]
    E --> F{body has text?}
    F -->|Yes| G[Include chapter in audiobook]
    F -->|No| H[Caller skips chapter]
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->