### PR TITLE
fix: prevent healthy WebSocket queues from being killed by race condition

### DIFF
--- a/backend/core/event_bus.py
+++ b/backend/core/event_bus.py
@@ -76,6 +76,13 @@ async def _broadcast(event_str: str) -> None:
                 try:
                     q.get_nowait()
                     q.put_nowait(event_str)
+                except asyncio.QueueEmpty:
+                    # Consumer drained the queue between our put_nowait
+                    # and get_nowait — queue has room; retry the put.
+                    try:
+                        q.put_nowait(event_str)
+                    except asyncio.QueueFull:
+                        dead.append(q)
                 except Exception:
                     dead.append(q)
         for q in dead:


### PR DESCRIPTION
When `put_nowait` raised `QueueFull`, the recovery handler called `get_nowait` to free a slot and retried the put.

### The race
Consumers drain queues asynchronously **without holding `_lock`**. If a consumer drains ALL items between the `QueueFull` from `put_nowait` and the `get_nowait` call, `get_nowait()` raises `asyncio.QueueEmpty`. The bare `except Exception` treated this as a fatal queue error and removed the queue from `_listeners` — permanently disconnecting that WebSocket client.

### Impact
Under high event throughput, a WebSocket client whose reader happens to drain the queue in that narrow window is silently disconnected from the event bus. The frontend sidebar freezes with no recovery mechanism.

### Fix
Explicitly catches `asyncio.QueueEmpty` and retries `put_nowait` (the queue now has room), only marking the queue dead on a subsequent `QueueFull` or other unexpected exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a race condition that could incorrectly remove healthy WebSocket queues from `_listeners`.

When recovering from a full queue, `_broadcast` now handles `asyncio.QueueEmpty` if another coroutine drains the queue between `put_nowait` and `get_nowait`. It retries inserting the event and only treats subsequent `QueueFull` or unexpected exceptions as listener failures.

```mermaid
flowchart TD
    A[Queue is full] --> B[Drop oldest item]
    B -->|QueueEmpty race| C[Retry put_nowait]
    B -->|Success| C
    C -->|Success| D[Keep listener]
    C -->|QueueFull or unexpected error| E[Mark listener failed]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->