### PR TITLE
feat(docker): publish ROCm/AMD GPU image variant (#1165)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,14 @@
 #   :0.3      — major.minor floating tag (updated on every patch within the minor)
 #   :sha-xxxx — specific commit SHA; produced by workflow_dispatch
 #
+# ROCm/AMD GPU variant (#1165) — same semantics, `-rocm` suffixed, built by the
+# build-and-push-rocm job from the same Dockerfile via the BASE_IMAGE build-arg:
+#   :rocm           — rolling preview from main (the ROCm analogue of :latest)
+#   :stable-rocm    — most recent versioned release, ROCm build
+#   :0.3.6-rocm     — exact version, ROCm build
+#   :0.3-rocm       — major.minor floating tag, ROCm build
+#   :sha-xxxx-rocm  — specific commit SHA, ROCm build
+#
 # Images land at: ghcr.io/debpalash/omnivoice-studio AND docker.io/palashdeb/omnivoice-studio
 # (Docker Hub push gated on the DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets;
 # if unset the build still pushes to GHCR.)
@@ -136,3 +144,85 @@ jobs:
           repository: ${{ env.DOCKERHUB_IMAGE }}
           short-description: "Local ElevenLabs alternative: voice cloning, design & video dubbing in 646 languages. No API keys."
           readme-filepath: ./deploy/dockerhub-overview.md
+
+  # ── ROCm/AMD GPU image variant (#1165) ──────────────────────────────────
+  # Same Dockerfile, ROCm PyTorch base swapped in via the BASE_IMAGE
+  # build-arg; tags mirror the CUDA job's with a `-rocm` suffix (table in the
+  # header comment). Kept as a SEPARATE job — not a matrix leg or a second
+  # build step — so it gets a full runner disk to itself: the ROCm base alone
+  # is ~10 GB compressed / ~25 GB unpacked.
+  build-and-push-rocm:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # The ROCm base plus the built image don't fit in the runner's default
+      # free space. Drop the preinstalled toolchains this job never uses
+      # (~25-30 GB reclaimed).
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same Docker Hub gating as the CUDA job: push there only when the
+      # secret exists, so forks still publish to GHCR.
+      - name: Check Docker Hub credentials
+        id: dockerhub
+        run: echo "enabled=${{ secrets.DOCKERHUB_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Mirrors the CUDA job's tag rules (incl. the workflow_dispatch and
+      # prerelease gating) with a `-rocm` suffix on every tag.
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ steps.dockerhub.outputs.enabled == 'true' && env.DOCKERHUB_IMAGE || '' }}
+          # latest=false is load-bearing: metadata-action's default (`auto`)
+          # would add a bare un-suffixed `:latest` on release-tag pushes,
+          # clobbering the CUDA preview channel with a ROCm image.
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},suffix=-rocm,enable=${{ github.event_name == 'push' }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-rocm,enable=${{ github.event_name == 'push' }}
+            type=raw,value=stable-rocm,enable=${{ github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref, '-') }}
+            type=raw,value=rocm,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-,suffix=-rocm,format=short
+
+      # cache-from only: reading the CUDA job's exported cache reuses the
+      # identical frontend-builder stage. Deliberately NO cache-to — the
+      # multi-GB ROCm runtime layers would blow GitHub's 10 GB per-repo
+      # Actions cache budget and evict the CUDA job's cache.
+      - name: Build and push (ROCm)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          build-args: |
+            BASE_IMAGE=rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.8.0
+            GPU_FLAVOR=rocm
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Added
+
+- **A Docker image for AMD GPUs: `ghcr.io/debpalash/omnivoice-studio:rocm`.** The Docker image was CUDA-only, so AMD cards (an RX 7900 XTX under Podman, say) silently ran on CPU. Every preview and release now also ships a ROCm variant — `:rocm` is the rolling preview, with `:stable-rocm` / `:X.Y.Z-rocm` mirroring the release tags on GHCR and Docker Hub alike. Pass the GPU through with `--device /dev/kfd --device /dev/dri` (works for Docker and Podman/Quadlet; no container toolkit needed) and it's auto-detected; a new `rocm` profile in the Compose file does the same. (#1165)
+
 ### Fixed
 
 - **A missing (or broken) MCP dependency can no longer kill the whole backend at startup.** One Windows user's backend loaded all 32 models and then died with exit code 1 because the `mcp` package couldn't be imported — the MCP integration called "exit the program" and a technicality (`SystemExit` isn't an `Exception`) let it slip past the guard meant to make MCP optional. The MCP layer now degrades to "/mcp disabled" on any import failure, the error names what actually failed (the package can be present but broken — e.g. pywin32 on Windows — and "not installed" was a misdiagnosis), and the exit-containment now covers this whole class. (#1156)

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Professional-grade voice AI, minus the subscription and the cloud.
 > On GPUs with **≤8 GB VRAM**, OmniVoice automatically offloads TTS to CPU during transcription — no config needed. A dedicated GPU is not required; the entire pipeline runs on CPU (just slower).
 
 > [!NOTE]
-> **AMD GPUs:** ROCm acceleration is **Linux-only and opt-in** — pick **"AMD GPU (ROCm)"** on the first-run setup screen or set `OMNIVOICE_TORCH_VARIANT=rocm` ([docs/install/linux.md](docs/install/linux.md#amd-gpu-rocm)). **On Windows, AMD GPUs (incl. Ryzen AI iGPUs) run CPU-only**: PyTorch has no Windows ROCm wheels, so Windows GPU acceleration is NVIDIA/CUDA-only ([docs/install/windows.md](docs/install/windows.md#gpu-support)).
+> **AMD GPUs:** ROCm acceleration is **Linux-only and opt-in** — pick **"AMD GPU (ROCm)"** on the first-run setup screen or set `OMNIVOICE_TORCH_VARIANT=rocm` ([docs/install/linux.md](docs/install/linux.md#amd-gpu-rocm)). In **Docker/Podman**, pull the dedicated ROCm image instead: `ghcr.io/debpalash/omnivoice-studio:rocm` ([docs/install/docker.md](docs/install/docker.md#pull-and-run-amd-gpu--rocm)). **On Windows, AMD GPUs (incl. Ryzen AI iGPUs) run CPU-only**: PyTorch has no Windows ROCm wheels, so Windows GPU acceleration is NVIDIA/CUDA-only ([docs/install/windows.md](docs/install/windows.md#gpu-support)).
 
 > [!IMPORTANT]
 > **macOS Intel (x86_64) is unsupported for the local backend:** the app UI installs, but the Python backend cannot run because PyTorch no longer ships Intel-Mac wheels ([#889](https://github.com/debpalash/OmniVoice-Studio/issues/889)). Intel-Mac users can still point the UI at a remote backend on another machine — see [docs/install/macos.md](docs/install/macos.md).

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,3 +1,11 @@
+# Base image for the Python/PyTorch runtime stage. The default builds the
+# CUDA variant; CI also builds a ROCm/AMD variant (issue #1165) by overriding:
+#   BASE_IMAGE=rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.8.0
+#   GPU_FLAVOR=rocm
+# Both bases ship torch/torchaudio 2.8.0 preinstalled; the dependency install
+# below deliberately preserves them (see the GPU_FLAVOR guard).
+ARG BASE_IMAGE=pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime
+
 # ==========================================
 # Builder Stage: Compile React Frontend
 # ==========================================
@@ -18,7 +26,7 @@ RUN bun run --cwd frontend build
 # ==========================================
 # Runtime Stage: Python & PyTorch Backend
 # ==========================================
-FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime AS runtime
+FROM ${BASE_IMAGE} AS runtime
 WORKDIR /app
 
 # Enable unbuffered logs and optimizations
@@ -45,15 +53,40 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
+# PEP 668: the ROCm base (Ubuntu 24.04) marks its system Python
+# EXTERNALLY-MANAGED, which would refuse `pip install` / `uv pip install
+# --system`. Inside a single-purpose container image installing into the
+# base env is exactly what we want. No-ops on the conda-based CUDA image.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV UV_BREAK_SYSTEM_PACKAGES=1
+
 # Install `uv` for blazing-fast reliable pip resolution
-RUN pip install --no-cache-dir uv
+# (`python3 -m pip` — not every base symlinks a bare `pip` onto PATH)
+RUN python3 -m pip install --no-cache-dir uv
 
 # Copy python packaging specs (README.md required by hatchling metadata)
 COPY pyproject.toml uv.lock README.md ./
 
 # Install the project (non-editable — no need for -e in containers).
 # Uses `uv` for exponentially faster resolution than plain pip.
-RUN uv pip install --system --no-cache .  
+#
+# NOTE: `uv pip install` (without --upgrade) keeps already-installed packages
+# that satisfy the requirements, so the base image's GPU-built torch/torchaudio
+# (2.8.0, satisfying our `torch>=2.4`) survive this step instead of being
+# clobbered by PyPI's CUDA-default wheels. That property is what makes the
+# ROCm variant possible at all — the guard below pins it down.
+RUN uv pip install --system --no-cache .
+
+# Guard (fails the build, not the user at runtime): assert the dependency
+# install did NOT replace the base image's GPU torch. A future dep bump that
+# forces a different torch version would otherwise silently ship a CUDA build
+# in the ROCm image (= CPU-only for AMD users) — catch it here instead.
+ARG GPU_FLAVOR=cuda
+RUN python3 -c "import os, torch, torchaudio; \
+    flavor = os.environ['GPU_FLAVOR']; \
+    accel = torch.version.hip if flavor == 'rocm' else torch.version.cuda; \
+    print(f'torch={torch.__version__} torchaudio={torchaudio.__version__} {flavor}={accel}'); \
+    assert accel, f'base image {flavor} torch was clobbered (now {torch.__version__})'"
 
 # Copy application source
 COPY backend/ ./backend/

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,10 +2,11 @@
 #  OmniVoice Studio — Docker Compose
 #
 #  Quick start:
-#    docker compose -f deploy/docker-compose.yml --profile cpu up   # CPU mode
-#    docker compose -f deploy/docker-compose.yml --profile gpu up   # GPU mode
+#    docker compose -f deploy/docker-compose.yml --profile cpu up    # CPU mode
+#    docker compose -f deploy/docker-compose.yml --profile gpu up    # NVIDIA GPU
+#    docker compose -f deploy/docker-compose.yml --profile rocm up   # AMD GPU (ROCm)
 #
-#  Both services bind to port 3900, so they MUST be opt-in via profiles —
+#  All services bind to port 3900, so they MUST be opt-in via profiles —
 #  otherwise `compose up` would race them and one would fail to bind.
 #
 #  First run downloads ~4 GB of models. Progress is shown in logs.
@@ -98,6 +99,53 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
+    restart: unless-stopped
+
+  # ── AMD GPU (ROCm) mode — activate with: docker compose --profile rocm up
+  # Uses the dedicated `:rocm` image variant (#1165). The GPU is passed
+  # through as plain device nodes — no toolkit needed, the host only needs
+  # the amdgpu kernel driver (the ROCm userspace ships inside the image).
+  # Podman works with the same two --device flags (Quadlet: AddDevice=).
+  omnivoice-rocm:
+    image: ghcr.io/debpalash/omnivoice-studio:rocm
+    # To build from source instead of pulling, comment out `image:` and
+    # uncomment the lines below. BASE_IMAGE/GPU_FLAVOR are required — the
+    # Dockerfile's defaults build the CUDA variant.
+    # build:
+    #   context: ..
+    #   dockerfile: deploy/Dockerfile
+    #   args:
+    #     BASE_IMAGE: rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.8.0
+    #     GPU_FLAVOR: rocm
+    container_name: omnivoice-studio-rocm
+    profiles: ["rocm"]
+    ports:
+      - "127.0.0.1:3900:3900"
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    volumes:
+      - omnivoice-data:/app/omnivoice_data
+    environment:
+      - HF_HOME=/app/omnivoice_data/huggingface
+      - HF_TOKEN=${HF_TOKEN:-}
+      - OMNIVOICE_DATA_DIR=/app/omnivoice_data
+      - PYTHONPATH=/app/backend
+      - PYTHONUNBUFFERED=1
+      # See the CPU service above — container-internal bind + relaxed
+      # loopback origin gate for the headless Docker deployment.
+      - OMNIVOICE_BIND_HOST=0.0.0.0
+      - OMNIVOICE_SERVER_MODE=1
+      # RDNA3 consumer cards (RX 7900 XTX/XT and friends, gfx1100): if the
+      # GPU is not detected, uncomment the override below. The backend
+      # auto-sets it for known consumer GFX IDs, so try without it first.
+      # - HSA_OVERRIDE_GFX_VERSION=11.0.0
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3900/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 180s
     restart: unless-stopped
 
 volumes:

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -49,7 +49,29 @@ docker run -d --name omnivoice --gpus all \
 
 GPU mode needs the
 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-on the host. There's also a Compose file in the repo with `cpu` / `gpu` profiles
+on the host.
+
+## Quick start (AMD GPU / ROCm)
+
+AMD GPUs use the dedicated `:rocm` image variant (the default image is
+CUDA-only and runs on CPU on AMD hardware). No toolkit needed — pass the GPU
+through as device nodes; the host only needs the `amdgpu` kernel driver:
+
+```bash
+docker run -d --name omnivoice \
+  --device /dev/kfd --device /dev/dri \
+  -p 127.0.0.1:3900:3900 \
+  -v omnivoice-data:/app/omnivoice_data \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  palashdeb/omnivoice-studio:rocm
+```
+
+Podman users: same two `--device` flags (Quadlet: `AddDevice=/dev/kfd` +
+`AddDevice=/dev/dri`). On RDNA3 consumer cards (RX 7900 XTX/XT), add
+`-e HSA_OVERRIDE_GFX_VERSION=11.0.0` if the GPU isn't detected — details in
+the [Docker install guide](https://github.com/debpalash/OmniVoice-Studio/blob/main/docs/install/docker.md).
+
+There's also a Compose file in the repo with `cpu` / `gpu` / `rocm` profiles
 — see the [Docker install guide](https://github.com/debpalash/OmniVoice-Studio/blob/main/docs/install/docker.md).
 
 ---
@@ -64,6 +86,8 @@ on the host. There's also a Compose file in the repo with `cpu` / `gpu` profiles
 | `:0.3` | Latest patch within the `0.3` minor |
 | `:main` | Alias of the same rolling `main` build as `:latest` |
 | `:sha-xxxxxxx` | A specific commit (produced by manual workflow dispatch) |
+| `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
+| `:stable-rocm`, `:0.3.6-rocm`, `:0.3-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
 
 `main` always carries *last release + 1 patch*, so `:latest` (preview)
 version-sorts above `:stable` — upgrades flow naturally. The same images and tags

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -17,6 +17,8 @@ and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palash
 > | `:0.3` | Latest patch within the 0.3 minor |
 > | `:main` | Alias of the same rolling `main` build as `:latest` |
 > | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |
+> | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
+> | `:stable-rocm`, `:0.3.17-rocm`, `:0.3-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
 >
 > Versioning rule: `main` always carries *last release + 1 patch*, so `:latest`
 > (preview) version-sorts above `:stable` — upgrades flow naturally.
@@ -58,6 +60,56 @@ GPU mode requires the
 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 on the host.
 
+## Pull and run (AMD GPU / ROCm)
+
+AMD GPUs use the dedicated **`:rocm` image variant** — the default (CUDA)
+image runs CPU-only on AMD hardware. The ROCm userspace ships inside the
+image; the host only needs the `amdgpu` kernel driver. Pass the GPU through
+as plain device nodes (no container toolkit needed):
+
+```bash
+docker run -d --name omnivoice \
+  --device /dev/kfd --device /dev/dri \
+  -p 127.0.0.1:3900:3900 \
+  -v omnivoice-data:/app/omnivoice_data \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  ghcr.io/debpalash/omnivoice-studio:rocm
+```
+
+The same flags work with **Podman** (`podman run --device /dev/kfd
+--device /dev/dri …`); in a **Quadlet** unit that's two `AddDevice=` lines:
+
+```ini
+# ~/.config/containers/systemd/omnivoice.container
+[Container]
+Image=ghcr.io/debpalash/omnivoice-studio:rocm
+AddDevice=/dev/kfd
+AddDevice=/dev/dri
+PublishPort=127.0.0.1:3900:3900
+Volume=omnivoice-data:/app/omnivoice_data
+```
+
+Release pins exist too: `:stable-rocm`, `:0.3.22-rocm`, `:0.3-rocm` mirror
+the CUDA tags exactly.
+
+> **RDNA3 consumer cards (RX 7900 XTX/XT, gfx1100):** the backend auto-sets
+> `HSA_OVERRIDE_GFX_VERSION` for consumer GFX IDs missing from ROCm's official
+> support matrix, so try without any override first. If the GPU still isn't
+> detected, force it explicitly with `-e HSA_OVERRIDE_GFX_VERSION=11.0.0`
+> (user-set on the container — it is deliberately **not** baked into the
+> image, because the right value depends on your card).
+
+Verify the container sees the GPU:
+
+```bash
+docker exec omnivoice python3 -c \
+  "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+```
+
+(ROCm-built PyTorch reports through `torch.cuda.*` — `True` plus your card's
+name means GPU acceleration is active. The Settings → System panel shows the
+same device.)
+
 ## Docker Compose (recommended)
 
 ```bash
@@ -66,6 +118,9 @@ docker compose -f deploy/docker-compose.yml --profile cpu up -d
 
 # NVIDIA GPU
 docker compose -f deploy/docker-compose.yml --profile gpu up -d
+
+# AMD GPU (ROCm)
+docker compose -f deploy/docker-compose.yml --profile rocm up -d
 ```
 
 The `docker-compose.yml` shipped in `deploy/` defaults to `127.0.0.1:3900`
@@ -142,5 +197,11 @@ Two paths are worth persisting across container restarts:
   to re-enable the strict gate.
 - **Media-preview 404 in LAN mode:** see the [LAN access](#lan-access) section
   above — the `window.location.host` fix shipped in v0.3.
-- **GPU not detected:** verify `docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi` succeeds first.
+- **GPU not detected (NVIDIA):** verify `docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu22.04 nvidia-smi` succeeds first.
+- **GPU not detected (AMD):** make sure you pulled the `:rocm` tag (the default
+  image is CUDA-only) and passed `--device /dev/kfd --device /dev/dri`. Check
+  the container sees the card with
+  `docker exec omnivoice rocminfo | grep -i gfx`; on RDNA3 consumer cards try
+  `-e HSA_OVERRIDE_GFX_VERSION=11.0.0` — see
+  [Pull and run (AMD GPU / ROCm)](#pull-and-run-amd-gpu--rocm) above.
 - More entries: [docs/install/troubleshooting.md](troubleshooting.md).

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -181,7 +181,12 @@ that picks these defaults automatically; for v0.3 set them by hand.
 ROCm support is **Linux-only and opt-in**. The **default install ships the
 CUDA build** of PyTorch (the `pytorch-cuda` index in `pyproject.toml`), so on
 an AMD-only machine `torch.cuda.is_available()` is `False` and OmniVoice runs
-on CPU until you opt into the ROCm variant. (On Windows there is no ROCm path
+on CPU until you opt into the ROCm variant.
+
+> **Running in Docker or Podman instead?** There's a prebuilt ROCm image —
+> `ghcr.io/debpalash/omnivoice-studio:rocm` — with GPU acceleration out of the
+> box; see [docker.md](docker.md#pull-and-run-amd-gpu--rocm). The rest of this
+> section is about source/desktop installs. (On Windows there is no ROCm path
 at all — PyTorch publishes no Windows ROCm wheels; see
 [windows.md](windows.md#gpu-support).)
 


### PR DESCRIPTION
Publishes a ROCm/AMD GPU variant of the Docker image alongside the existing CUDA one, so AMD cards (the reporter's RX 7900 XTX under Podman Quadlet, and RDNA generally) get GPU acceleration instead of silently running on CPU.

Closes #1165

## Design

**One Dockerfile, parameterized — not a duplicate.** The runtime stage's base is now a build-arg (`BASE_IMAGE`, default unchanged: `pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime`). Nothing else in the Dockerfile was CUDA-specific (apt packages, env, healthcheck, entrypoint are all GPU-agnostic), but two ROCm-specific needs are handled:

- **PEP 668:** the ROCm base's Ubuntu 24.04 Python is `EXTERNALLY-MANAGED`, which would refuse `pip install` / `uv pip install --system`. `PIP_BREAK_SYSTEM_PACKAGES=1` + `UV_BREAK_SYSTEM_PACKAGES=1` handle it (no-ops on the conda-based CUDA image), and `pip` → `python3 -m pip` since not every base symlinks a bare `pip`.
- **Torch survival guard:** the whole variant only works because `uv pip install` (without `--upgrade`) keeps already-installed packages that satisfy requirements — the base image's GPU-built torch/torchaudio 2.8.0 satisfy our `torch>=2.4` and every transitive pin, so they survive the dependency install instead of being clobbered by PyPI's CUDA-default wheels. That property is now **asserted at build time**: a `GPU_FLAVOR` guard checks `torch.version.hip` (ROCm) / `torch.version.cuda` (CUDA) after the install and fails the build if a future dep bump ever forces a torch reinstall. Without the guard, that failure mode ships a "ROCm" image that is silently CPU-only.

**Base image: `rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.8.0`** (pinned, verified to exist on Docker Hub, amd64). Chosen because:
- torch **2.8.0 exactly matches** the CUDA image's torch, so `uv`'s resolution is identical and keeps the base torch;
- Python 3.12 satisfies `requires-python >=3.11` — the `ubuntu22.04` variants ship py3.10 and would fail the project install;
- rocm 7.2.4 is the newest ROCm point release carrying a 2.8.0 build (~10.3 GB compressed). The reporter's ROCm 7.8 host driver is forward-compatible with the 7.2.4 userspace in the image.

**CI: separate `build-and-push-rocm` job** in `docker.yml` (not a matrix leg / second build step) so it gets a full runner disk — the base alone is ~25 GB unpacked; the job frees ~25–30 GB of unused preinstalled toolchains first. Tags mirror the existing semantics with a `-rocm` suffix, pushed to GHCR **and** Docker Hub under the same secret gating and the same mutable-tag/`workflow_dispatch` rules (`:sha-*-rocm` only on dispatch, `:stable-rocm` excludes prereleases):

| Tag | Meaning |
|---|---|
| `:rocm` | rolling `main` preview (ROCm analogue of `:latest`) |
| `:stable-rocm`, `:X.Y.Z-rocm`, `:X.Y-rocm` | releases |
| `:sha-xxxx-rocm` | specific commit |

Two deliberate deltas from the CUDA job: `flavor: latest=false` (metadata-action's default would add a bare `:latest` on release-tag pushes and clobber the CUDA preview channel with a ROCm image) and **no `cache-to`** (the multi-GB ROCm layers would blow GitHub's 10 GB per-repo Actions cache and evict the CUDA job's cache; `cache-from` still reuses the shared frontend-builder stage).

**Runtime:** no entrypoint changes needed — ROCm torch reports through `torch.cuda.*`, `backend/core/device_caps.py` already classifies it as `family="rocm"`, and `backend/services/model_manager.py` auto-sets `HSA_OVERRIDE_GFX_VERSION` for consumer GFX IDs missing from ROCm's support matrix. Per the issue discussion, `HSA_OVERRIDE_GFX_VERSION=11.0.0` is **documented as user-set, not baked into the image** (the right value depends on the card, and gfx1100 is officially supported so most 7900-class users won't need it).

**Docs-sync (same PR):** `docs/install/docker.md` (ROCm quick start incl. Podman/Quadlet `AddDevice=` example, tag table, AMD troubleshooting entry), `deploy/dockerhub-overview.md`, `deploy/docker-compose.yml` (new opt-in `rocm` profile with `/dev/kfd` + `/dev/dri` passthrough), README's AMD-GPU note, `docs/install/linux.md` cross-link, `docker.yml` header tag table, and a `CHANGELOG.md` `[Unreleased]` entry.

## Verified locally vs. needs CI

Verified locally:
- `docker.yml` and `docker-compose.yml` parse (`yaml.safe_load`); job/step/tag structure inspected.
- Dockerfile instruction grammar sanity-checked and the guard's inline Python compiles; no CUDA-specific leftovers.
- Base image tag confirmed present on Docker Hub (amd64).
- `pytest tests/test_issue_fixes.py::test_dockerfile_has_pythonpath tests/test_no_hardcoded_cjk.py` — pass.
- `scripts/validate-install-docs.py` and `scripts/check-docs-drift.py` — both clean.

**Not verifiable locally (honestly):** I could not run the actual ROCm image build (no Docker on this machine, and no AMD GPU to smoke-test inference). The two open questions the first CI build will answer definitively — both covered by the new build-time guard, which fails the build rather than shipping a broken image:
1. that `uv`'s resolution on the ROCm base keeps the base torch/torchaudio (expected, since versions match the CUDA case exactly);
2. that the pinned base ships torchaudio (AMD's release images document torch/torchvision/torchaudio, but the guard `import torchaudio` makes it a hard check).

Since `docker.yml` doesn't run on PRs, the first real build happens on the merge to `main` — or earlier via `gh workflow run docker.yml --ref feat/rocm-docker-image`, which by the existing gating produces only throwaway `:sha-*` / `:sha-*-rocm` tags and is the cheap way to validate before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a parameterized Docker runtime supporting both CUDA and pinned ROCm/PyTorch 2.8.0 images.
- Added build-time safeguards to ensure GPU-enabled `torch` and `torchaudio` packages are not replaced.
- Added CI publishing for ROCm images with `-rocm` tags across GHCR and Docker Hub.
- Added an opt-in ROCm Docker Compose profile with `/dev/kfd` and `/dev/dri` passthrough.
- Expanded Docker, Podman, Quadlet, AMD GPU, RDNA3, and `HSA_OVERRIDE_GFX_VERSION` documentation.
- Documented the new ROCm image in the README and changelog.

```mermaid
flowchart LR
  A[Select GPU flavor] --> B{CUDA or ROCm}
  B -->|CUDA| C[CUDA base image]
  B -->|ROCm| D[ROCm PyTorch base image]
  C --> E[Install dependencies]
  D --> E
  E --> F[Verify GPU-enabled PyTorch]
  F --> G[Publish flavor-specific image tags]
```

<!-- end of auto-generated comment: release notes by coderabbit.ai -->