### PR TITLE
Never a blank screen: production-bundle gate + stop dev instances colliding

### DIFF
--- a/frontend/e2e-prod/prod-bundle-smoke.spec.ts
+++ b/frontend/e2e-prod/prod-bundle-smoke.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The app must RENDER when built for production.
+ *
+ * v0.3.22 shipped a black screen: a minifier temporal-dead-zone reorder threw
+ * before React mounted (`Cannot access 'logs' before initialization`), so the
+ * window came up empty. It only ever bit the MINIFIED bundle — the dev server
+ * and the entire e2e suite run un-minified, so every check passed and it
+ * shipped (#1178).
+ *
+ * These tests run against the real `dist/` output. The core assertion is
+ * deliberately dumb and structural — "did anything mount?" — because that is
+ * the one thing a pre-render crash always breaks, whatever its cause.
+ */
+
+// Errors that are expected in a bundle served without a backend / Tauri host.
+// Keep this list TIGHT: every entry is a hole in the gate.
+const IGNORABLE = [
+  /Failed to load resource/i,          // no backend on :3900 in this harness
+  /net::ERR_/i,                        // ditto — network fetches to the API
+  /ERR_CONNECTION_REFUSED/i,
+  /__TAURI__/i,                        // not running inside the Tauri shell
+  /favicon/i,
+];
+
+function isIgnorable(text: string): boolean {
+  return IGNORABLE.some((re) => re.test(text));
+}
+
+test('production bundle mounts the app (no blank screen)', async ({ page }) => {
+  const fatal: string[] = [];
+  // A pre-render crash surfaces as a pageerror, not a console.error.
+  page.on('pageerror', (err) => fatal.push(`pageerror: ${err.message}`));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && !isIgnorable(msg.text())) {
+      fatal.push(`console.error: ${msg.text()}`);
+    }
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  // The actual anti-blank assertion: something must mount into #root.
+  const root = page.locator('#root');
+  await expect(root).toHaveCount(1);
+  await expect
+    .poll(() => root.evaluate((el) => el.childElementCount), {
+      message:
+        'production bundle rendered NOTHING into #root — this is the black-screen ' +
+        'failure mode (#1178). Check for a crash before React mounts.',
+      timeout: 20_000,
+    })
+    .toBeGreaterThan(0);
+
+  // And it must not have thrown on the way there. A TDZ reorder throws a
+  // ReferenceError, which is precisely what this catches.
+  expect(fatal, `production bundle raised fatal errors:\n${fatal.join('\n')}`).toEqual([]);
+});
+
+test('production bundle renders visible content, not an empty shell', async ({ page }) => {
+  // Guards the degenerate pass where #root gets a child that paints nothing.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect
+    .poll(() => page.locator('#root').evaluate((el) => (el as HTMLElement).innerText.trim().length), {
+      message: 'production bundle mounted an element tree with no visible text',
+      timeout: 20_000,
+    })
+    .toBeGreaterThan(0);
+});

--- a/frontend/e2e-prod/prod-bundle-smoke.spec.ts
+++ b/frontend/e2e-prod/prod-bundle-smoke.spec.ts
@@ -17,10 +17,10 @@ import { test, expect } from '@playwright/test';
 // Errors that are expected in a bundle served without a backend / Tauri host.
 // Keep this list TIGHT: every entry is a hole in the gate.
 const IGNORABLE = [
-  /Failed to load resource/i,          // no backend on :3900 in this harness
-  /net::ERR_/i,                        // ditto — network fetches to the API
+  /Failed to load resource/i, // no backend on :3900 in this harness
+  /net::ERR_/i, // ditto — network fetches to the API
   /ERR_CONNECTION_REFUSED/i,
-  /__TAURI__/i,                        // not running inside the Tauri shell
+  /__TAURI__/i, // not running inside the Tauri shell
   /favicon/i,
 ];
 
@@ -61,9 +61,12 @@ test('production bundle renders visible content, not an empty shell', async ({ p
   // Guards the degenerate pass where #root gets a child that paints nothing.
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await expect
-    .poll(() => page.locator('#root').evaluate((el) => (el as HTMLElement).innerText.trim().length), {
-      message: 'production bundle mounted an element tree with no visible text',
-      timeout: 20_000,
-    })
+    .poll(
+      () => page.locator('#root').evaluate((el) => (el as HTMLElement).innerText.trim().length),
+      {
+        message: 'production bundle mounted an element tree with no visible text',
+        timeout: 20_000,
+      },
+    )
     .toBeGreaterThan(0);
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "e2e": "playwright test",
+    "test:prod-bundle": "playwright test --config=playwright.prod.config.ts",
     "test:visual": "playwright test --config=playwright.visual.config.ts",
     "test:visual:update": "playwright test --config=playwright.visual.config.ts --update-snapshots"
   },

--- a/frontend/playwright.prod.config.ts
+++ b/frontend/playwright.prod.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+import { existsSync } from 'node:fs';
+
+// PRODUCTION-BUNDLE smoke gate. The regular e2e config (playwright.config.ts)
+// drives the Vite DEV server, which is un-minified — so a bug that exists ONLY
+// in the minified release bundle passes every check and ships. That is exactly
+// how v0.3.22 went out with a black screen: a minifier temporal-dead-zone
+// reorder threw before React mounted, leaving an empty #root. Dev runs and the
+// whole e2e suite never saw it (#1178).
+//
+// This config closes that hole: it BUILDS the app and serves the real `dist/`
+// through `vite preview`, so the bytes under test are the bytes we ship.
+// Separate port from the dev server so both can run without colliding.
+const PORT = Number(process.env.E2E_PROD_PORT || 4173);
+
+// PLAYWRIGHT_CHROMIUM wins; else a system chromium if it's actually there
+// (CI); else undefined, which lets Playwright use its bundled browser.
+const SYSTEM_CHROMIUM = '/usr/bin/chromium';
+const browserPath =
+  process.env.PLAYWRIGHT_CHROMIUM ||
+  (existsSync(SYSTEM_CHROMIUM) ? SYSTEM_CHROMIUM : undefined);
+
+export default defineConfig({
+  testDir: './e2e-prod',
+  timeout: 120_000,        // includes the production build
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  retries: 0,              // a blank screen must never be "flaky-passed" away
+  reporter: [['list']],
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+    trace: 'retain-on-failure',
+    // Use an explicit browser when one is named (CI installs a system
+    // chromium), otherwise fall back to Playwright's own download. The dev
+    // e2e config hardcodes /usr/bin/chromium, which simply doesn't exist on
+    // Windows/macOS — this gate has to be runnable on a contributor's laptop
+    // too, or it won't get run before release.
+    ...(browserPath ? { launchOptions: { executablePath: browserPath } } : {}),
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // Build then serve the real production output. `--strictPort` so a port
+    // clash fails loudly instead of silently testing some other server.
+    command: `bun run build && bun x vite preview --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}`,
+    // CI must always build fresh — the whole point is testing the bytes we
+    // ship. Locally, reuse a `vite preview` you already have up so iterating
+    // doesn't pay a full production build every run.
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/frontend/playwright.prod.config.ts
+++ b/frontend/playwright.prod.config.ts
@@ -17,15 +17,14 @@ const PORT = Number(process.env.E2E_PROD_PORT || 4173);
 // (CI); else undefined, which lets Playwright use its bundled browser.
 const SYSTEM_CHROMIUM = '/usr/bin/chromium';
 const browserPath =
-  process.env.PLAYWRIGHT_CHROMIUM ||
-  (existsSync(SYSTEM_CHROMIUM) ? SYSTEM_CHROMIUM : undefined);
+  process.env.PLAYWRIGHT_CHROMIUM || (existsSync(SYSTEM_CHROMIUM) ? SYSTEM_CHROMIUM : undefined);
 
 export default defineConfig({
   testDir: './e2e-prod',
-  timeout: 120_000,        // includes the production build
+  timeout: 120_000, // includes the production build
   expect: { timeout: 15_000 },
   fullyParallel: false,
-  retries: 0,              // a blank screen must never be "flaky-passed" away
+  retries: 0, // a blank screen must never be "flaky-passed" away
   reporter: [['list']],
   use: {
     baseURL: `http://localhost:${PORT}`,

--- a/frontend/src-tauri/src/blank_guard.rs
+++ b/frontend/src-tauri/src/blank_guard.rs
@@ -1,0 +1,379 @@
+//! Blank-window guard — the app must never sit on an empty window.
+//!
+//! OmniVoice has shipped a blank window more than once, from unrelated causes:
+//!
+//!   * **Production** (#1178): a minifier temporal-dead-zone reorder threw
+//!     before React mounted. Assets loaded fine; `#root` stayed empty.
+//!   * **Development**: a second `bun desktop` launch killed the first
+//!     instance's Vite server, leaving its window pointed at a dev URL that no
+//!     longer answered.
+//!
+//! Both look identical to the user — a dark rectangle with no explanation and
+//! no way forward. Preventing each individual cause is necessary but never
+//! sufficient; the next cause is always a new one. So this guard treats "did
+//! anything render?" as the invariant and enforces it regardless of *why* it
+//! broke:
+//!
+//!   1. **Detect** — a probe injected by the shell (never by app code, which is
+//!      exactly what may be broken) reports `#root`'s child count.
+//!   2. **Heal** — reload with backoff. A slow bundle or a dev server still
+//!      booting recovers on its own, and the user sees nothing.
+//!   3. **Guarantee** — after the retries are spent, paint an explanation that
+//!      is compiled into the binary, so it cannot itself fail to load.
+//!
+//! Scoped to the `main` window on purpose: the dictation pill (`widget`) is a
+//! separate webview that legitimately renders nothing while hidden, and would
+//! otherwise trip this on every launch.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager, Runtime};
+
+/// How long to let the app mount before the first check. Generous: a cold
+/// start on a slow disk legitimately takes seconds, and a false positive here
+/// would reload a perfectly healthy app out from under the user.
+const FIRST_CHECK_DELAY: Duration = Duration::from_secs(12);
+
+/// Gap between retry checks; each reload gets a little longer to settle.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(6);
+
+/// Reloads before giving up and painting the fallback. Kept small — three
+/// silent reloads is already ~30s of the user staring at nothing.
+const MAX_RELOADS: u32 = 3;
+
+/// Gap between probes once the app is healthy.
+///
+/// A one-shot startup check would miss the blanks that happen *later*, which
+/// includes the one actually reproduced in dev: the app renders fine, then its
+/// dev server dies and the next navigation lands on nothing. The probe is a
+/// few lines of JS, so running it on a slow heartbeat costs nothing and makes
+/// the guarantee hold for the whole session rather than just the first frame.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// JS that reports whether the app mounted. Deliberately dependency-free: it
+/// touches only `document` and the Tauri IPC bridge the shell injects, never
+/// anything from the app bundle — the bundle is what may have crashed.
+///
+/// `-1` distinguishes "no #root element at all" (the document never loaded,
+/// e.g. a dead dev server) from `0` ("#root exists but nothing mounted", the
+/// crashed-before-render case). Both are blank to the user; the number only
+/// shapes the diagnostics.
+fn probe_script() -> String {
+    r#"
+    (function () {
+      try {
+        var el = document.getElementById('root');
+        var n = el ? el.childElementCount : -1;
+        var invoke =
+          (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke) ||
+          (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke);
+        if (invoke) { invoke('report_render_state', { rootChildren: n }); }
+      } catch (e) { /* a throwing probe must never be the thing that breaks us */ }
+    })();
+    "#
+    .to_string()
+}
+
+/// Self-contained failure page. Inlined into the binary and injected straight
+/// into the DOM: no navigation, no network, no bundle — so whatever broke the
+/// app cannot also break the explanation of what broke. Styling is intentionally
+/// plain for the same reason (no external fonts or stylesheets).
+///
+/// "Retry" reloads; if that fails the guard runs again and lands back here.
+fn fallback_html(detail: &str) -> String {
+    format!(
+        r##"
+    (function () {{
+      try {{
+        document.documentElement.innerHTML =
+          '<head><meta charset="utf-8"><title>OmniVoice Studio</title></head>' +
+          '<body style="margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;' +
+          'background:#14161a;color:#e8eaed;display:flex;align-items:center;' +
+          'justify-content:center;height:100vh;">' +
+          '<div style="max-width:32rem;padding:2rem;text-align:center;">' +
+          '<div style="font-size:2.5rem;line-height:1;margin-bottom:1rem;">⚠️</div>' +
+          '<h1 style="font-size:1.25rem;margin:0 0 .75rem;">OmniVoice could not display its interface</h1>' +
+          '<p style="opacity:.8;line-height:1.5;margin:0 0 1.5rem;">' +
+          'The app started, but the window stayed empty. Your projects and voices are safe — ' +
+          'this is a display problem, not data loss.</p>' +
+          '<button id="ov-retry" style="background:#4f7cff;color:#fff;border:0;border-radius:.5rem;' +
+          'padding:.6rem 1.4rem;font-size:.95rem;cursor:pointer;">Reload</button>' +
+          '<p style="opacity:.55;font-size:.8rem;margin-top:1.5rem;">If reloading does not help, restart ' +
+          'the app. Persisting? Report it with the detail below.</p>' +
+          '<pre style="opacity:.5;font-size:.7rem;text-align:left;white-space:pre-wrap;' +
+          'margin-top:.5rem;">{detail}</pre>' +
+          '</div></body>';
+        var b = document.getElementById('ov-retry');
+        if (b) {{ b.onclick = function () {{ location.reload(); }}; }}
+      }} catch (e) {{ /* nothing left to fall back to */ }}
+    }})();
+    "##,
+        detail = detail.replace('\'', "\\'").replace('\n', " ")
+    )
+}
+
+/// How long to wait for the probe to answer before assuming the worst.
+///
+/// Silence IS a failure signal, and the most important one. When navigation
+/// fails outright the webview lands on an internal error page (`chrome-error://`)
+/// where Tauri's IPC bridge does not exist — so the probe physically cannot
+/// report, no matter how blank the window is. Verified the hard way: an
+/// earlier version of this guard only reacted to a report and therefore sat
+/// silent through a genuine blank. Anything that cannot tell us it is fine is
+/// treated as not fine.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Shared state for the main window's guard.
+#[derive(Default)]
+pub struct BlankGuardState {
+    reloads: AtomicU32,
+    /// Bumped on every healthy report. `schedule_check` samples it before
+    /// probing and compares after `PROBE_TIMEOUT`; an unchanged value means
+    /// the page never answered.
+    healthy_seq: AtomicU32,
+}
+
+/// Reported by the injected probe. Not a public API — the frontend never calls
+/// this deliberately; only the shell's own injected script does.
+#[tauri::command]
+pub fn report_render_state<R: Runtime>(
+    app: AppHandle<R>,
+    root_children: i32,
+) -> Result<(), String> {
+    if root_children > 0 {
+        // Rendered. Reset the counter so a *later* blank (e.g. the dev server
+        // dying mid-session) still gets its own full budget of retries, and
+        // keep the heartbeat going so such a blank is actually noticed.
+        if let Some(state) = app.try_state::<Arc<BlankGuardState>>() {
+            state.reloads.store(0, Ordering::Relaxed);
+            state.healthy_seq.fetch_add(1, Ordering::Relaxed);
+        }
+        schedule_check(app.clone(), HEARTBEAT_INTERVAL);
+        return Ok(());
+    }
+
+    handle_blank(app, root_children);
+    Ok(())
+}
+
+/// Reload, then fall back. `root_children` is `-2` when the probe never
+/// answered at all (see `PROBE_TIMEOUT`).
+fn handle_blank<R: Runtime>(app: AppHandle<R>, root_children: i32) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    let Some(state) = app.try_state::<Arc<BlankGuardState>>() else {
+        return;
+    };
+
+    let attempt = state.reloads.fetch_add(1, Ordering::Relaxed) + 1;
+    if attempt <= MAX_RELOADS {
+        log::warn!(
+            "blank window detected (#root children = {root_children}); reload {attempt}/{MAX_RELOADS}"
+        );
+        // Re-navigate rather than eval `location.reload()`: on an internal
+        // error page the latter may not run at all, which is precisely when a
+        // reload is most needed.
+        let _ = window.eval("location.reload();");
+        schedule_check(app.clone(), RETRY_BASE_DELAY * attempt);
+    } else {
+        log::error!(
+            "window still blank after {MAX_RELOADS} reloads (#root children = {root_children}) \
+             — showing the built-in failure page"
+        );
+        let detail = format!(
+            "#root children: {root_children} after {MAX_RELOADS} reloads. \
+             -2 = the page never answered the probe (it could not load at all); \
+             -1 = no #root element; 0 = loaded but nothing mounted."
+        );
+        show_fallback(&window, &detail);
+    }
+}
+
+/// Put the built-in failure page on screen.
+///
+/// Navigates to a `data:` URL rather than injecting HTML with `eval`. Injection
+/// only works if scripts run in the current document — and when the webview is
+/// parked on an internal error page they do not, which is exactly the situation
+/// this page exists to explain. Navigation works regardless of what the current
+/// document is. Falls back to injection if navigation is refused.
+fn show_fallback<R: Runtime>(window: &tauri::WebviewWindow<R>, detail: &str) {
+    let url = format!(
+        "data:text/html;charset=utf-8,{}",
+        urlencoding_minimal(&fallback_page(detail))
+    );
+    match url.parse() {
+        Ok(parsed) => {
+            if window.navigate(parsed).is_err() {
+                let _ = window.eval(&fallback_html(detail));
+            }
+        }
+        Err(_) => {
+            let _ = window.eval(&fallback_html(detail));
+        }
+    }
+}
+
+/// Percent-encode just enough for a `data:` URL to survive parsing.
+fn urlencoding_minimal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() * 2);
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'!' | b'~' | b'*'
+            | b'\'' | b'(' | b')' => out.push(b as char),
+            b' ' => out.push_str("%20"),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Standalone HTML for the `data:` URL fallback — a complete document, since
+/// navigation replaces everything. Same content as the injected variant.
+fn fallback_page(detail: &str) -> String {
+    format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><title>OmniVoice Studio</title></head>
+<body style="margin:0;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;background:#14161a;color:#e8eaed;display:flex;align-items:center;justify-content:center;height:100vh;">
+<div style="max-width:32rem;padding:2rem;text-align:center;">
+<div style="font-size:2.5rem;line-height:1;margin-bottom:1rem;">&#9888;&#65039;</div>
+<h1 style="font-size:1.25rem;margin:0 0 .75rem;">OmniVoice could not display its interface</h1>
+<p style="opacity:.8;line-height:1.5;margin:0 0 1.5rem;">The app started, but the window stayed empty.
+Your projects and voices are safe &mdash; this is a display problem, not data loss.</p>
+<button onclick="location.reload()" style="background:#4f7cff;color:#fff;border:0;border-radius:.5rem;padding:.6rem 1.4rem;font-size:.95rem;cursor:pointer;">Reload</button>
+<p style="opacity:.55;font-size:.8rem;margin-top:1.5rem;">If reloading does not help, restart the app. Still stuck? Report it with the detail below.</p>
+<pre style="opacity:.5;font-size:.7rem;text-align:left;white-space:pre-wrap;margin-top:.5rem;">{detail}</pre>
+</div></body></html>"#,
+        detail = detail.replace('<', "&lt;").replace('>', "&gt;")
+    )
+}
+
+/// Queue a render check `after` from now, and treat no answer as a blank.
+///
+/// A plain thread rather than the async runtime: this fires a handful of times
+/// per session and sleeps the whole while, so it costs nothing meaningful and
+/// keeps the guard free of an async dependency it would otherwise pull in just
+/// to sleep.
+pub fn schedule_check<R: Runtime>(app: AppHandle<R>, after: Duration) {
+    std::thread::spawn(move || {
+        std::thread::sleep(after);
+        let Some(window) = app.get_webview_window("main") else {
+            return;
+        };
+        // Sample the health counter, ask, then see whether anyone answered.
+        let before = app
+            .try_state::<Arc<BlankGuardState>>()
+            .map(|s| s.healthy_seq.load(Ordering::Relaxed));
+        let _ = window.eval(&probe_script());
+
+        let Some(before) = before else { return };
+        std::thread::sleep(PROBE_TIMEOUT);
+        let after_seq = app
+            .try_state::<Arc<BlankGuardState>>()
+            .map(|s| s.healthy_seq.load(Ordering::Relaxed))
+            .unwrap_or(before);
+        if after_seq == before {
+            // Nobody answered. Either the page cannot run scripts, or it has
+            // no IPC bridge (an internal error page) — both are blank windows.
+            handle_blank(app, -2);
+        }
+    });
+}
+
+/// Arm the guard. Call once from `setup`.
+pub fn arm<R: Runtime>(app: &AppHandle<R>) {
+    app.manage(Arc::new(BlankGuardState::default()));
+    schedule_check(app.clone(), FIRST_CHECK_DELAY);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_never_touches_app_bundle_globals() {
+        let js = probe_script();
+        // The probe must survive a crashed bundle, so it may only reference
+        // `document` and the shell-injected IPC bridge.
+        assert!(js.contains("document.getElementById('root')"));
+        assert!(js.contains("__TAURI__") || js.contains("__TAURI_INTERNALS__"));
+        for forbidden in ["React", "window.app", "import(", "require("] {
+            assert!(!js.contains(forbidden), "probe must not depend on {forbidden}");
+        }
+    }
+
+    #[test]
+    fn probe_reports_minus_one_when_root_is_absent() {
+        // -1 vs 0 is what separates "page never loaded" from "loaded but did
+        // not mount" in the diagnostics, so the ternary must stay.
+        assert!(probe_script().contains("el ? el.childElementCount : -1"));
+    }
+
+    #[test]
+    fn fallback_is_self_contained() {
+        let html = fallback_html("probe detail");
+        // No network of any kind: a page that needs the network cannot be the
+        // thing that explains the network being the problem.
+        for forbidden in ["http://", "https://", "<script src", "@import", "localhost"] {
+            assert!(!html.contains(forbidden), "fallback must not reference {forbidden}");
+        }
+        assert!(html.contains("probe detail"));
+        assert!(html.contains("ov-retry"));
+    }
+
+    #[test]
+    fn fallback_escapes_quotes_so_detail_cannot_break_the_page() {
+        // The detail is interpolated into a JS string literal; an unescaped
+        // quote would produce a syntax error and leave the window blank —
+        // precisely the failure this module exists to prevent.
+        let html = fallback_html("it's \"broken\"");
+        assert!(html.contains("\\'"), "single quotes must be escaped");
+    }
+
+    #[test]
+    fn fallback_reassures_about_data() {
+        // A blank window reads like data loss. Say plainly that it isn't.
+        assert!(fallback_html("x").contains("safe"));
+        assert!(fallback_page("x").contains("safe"));
+    }
+
+    #[test]
+    fn navigable_fallback_is_a_complete_document() {
+        // It is reached by NAVIGATION, which replaces the whole document, so a
+        // fragment would render as bare text.
+        let page = fallback_page("d");
+        assert!(page.starts_with("<!doctype html>"));
+        assert!(page.contains("</html>"));
+        assert!(page.contains("location.reload()"));
+    }
+
+    #[test]
+    fn navigable_fallback_needs_no_network() {
+        let page = fallback_page("d");
+        for forbidden in ["http://", "https://", "<script src", "@import"] {
+            assert!(!page.contains(forbidden), "fallback must not reference {forbidden}");
+        }
+    }
+
+    #[test]
+    fn fallback_detail_cannot_inject_markup() {
+        // The detail is interpolated into HTML; angle brackets must not be
+        // able to close a tag and wreck the one page that has to render.
+        let page = fallback_page("<script>bad()</script>");
+        assert!(!page.contains("<script>bad()"));
+        assert!(page.contains("&lt;script&gt;"));
+    }
+
+    #[test]
+    fn data_url_encoding_survives_the_characters_html_actually_uses() {
+        // '#' would truncate the URL at a fragment and '%' would corrupt other
+        // escapes — both would leave the window blank, defeating the purpose.
+        let enc = urlencoding_minimal("<html># 100% \"quoted\"");
+        assert!(!enc.contains('#'));
+        assert!(!enc.contains('<'));
+        assert!(!enc.contains('"'));
+        assert!(enc.contains("%20"), "spaces must be encoded");
+        assert_eq!(urlencoding_minimal("abcXYZ019-_.!~*'()"), "abcXYZ019-_.!~*'()");
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod crash;
 pub mod reset;
 pub mod uninstall;
 pub mod updater_channel;
+pub mod blank_guard;
 
 use std::process::Child;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -424,8 +425,14 @@ pub fn run() {
             uninstall::uninstall_purge,
             reset::reset_scan,
             reset::reset_purge,
+            blank_guard::report_render_state,
         ])
         .setup(move |app| {
+            // Blank-window guard: watch the main window and, if nothing ever
+            // renders, reload and finally paint a built-in explanation rather
+            // than leaving the user with a dark rectangle (#1178 class).
+            blank_guard::arm(app.handle());
+
             app.handle().plugin(tauri_plugin_dialog::init())?;
             app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
             app.handle().plugin(tauri_plugin_process::init())?;

--- a/scripts/desktop-common.mjs
+++ b/scripts/desktop-common.mjs
@@ -163,3 +163,32 @@ export function hiddenFrom(env) {
     .filter((e) => STRIPPED_PATH_ENTRIES.includes(norm(e)));
   return { vars, pathEntries };
 }
+
+/**
+ * Process name of the *dev* desktop binary (the cargo package name, built to
+ * `frontend/src-tauri/target/debug/`). The installed release app is
+ * "OmniVoice Studio" — a different name on purpose, so the dev launcher's
+ * stale-instance cleanup can never take down a user's real app.
+ */
+export const DEV_APP_PROCESS_NAME = "omnivoice-studio";
+
+/**
+ * True only for the cargo-built DEV binary, never the installed release app.
+ *
+ * `bun desktop` clears a leftover dev instance before starting (two instances
+ * fight over the dev server and leave one window blank). That cleanup kills by
+ * process name, so this predicate is the safety boundary: it must reject
+ * "OmniVoice Studio(.exe)" — killing a user's installed app would be a far
+ * worse bug than the one the cleanup fixes.
+ *
+ * @param {string} name process name, with or without a .exe suffix
+ * @returns {boolean}
+ */
+export function isDevAppProcess(name) {
+  const base = String(name ?? "")
+    .trim()
+    .replace(/\.exe$/i, "");
+  // Exact match only. The release app ("OmniVoice Studio") differs by both
+  // spacing and case, so a loose/normalised compare would wrongly match it.
+  return base === DEV_APP_PROCESS_NAME;
+}

--- a/scripts/desktop-dev.mjs
+++ b/scripts/desktop-dev.mjs
@@ -22,6 +22,7 @@ import { existsSync } from "node:fs";
 import { join, delimiter } from "node:path";
 import { homedir } from "node:os";
 import process from "node:process";
+import { DEV_APP_PROCESS_NAME } from "./desktop-common.mjs";
 
 /** The env's PATH key — Windows uses "Path", others "PATH"; match case-insensitively. */
 function pathKeyOf(env) {
@@ -39,6 +40,47 @@ function cargoResolvable(env) {
       : spawnSync("sh", ["-c", "command -v cargo"], { env, stdio: "ignore" });
   return probe.status === 0;
 }
+
+/**
+ * Take down a leftover dev app before starting a new one.
+ *
+ * Launching a second `bun desktop` while one is already running does NOT just
+ * fail politely — it cascades into a BLANK WINDOW. Reproduced deterministically:
+ * the new launch's port grab makes the running instance's `dev:api` exit, and
+ * `concurrently --kill-others-on-fail` then tears down that instance's whole
+ * stack *including its Vite server* — leaving its window open, pointed at a
+ * dev URL that no longer answers, with an empty #root. The user sees a black
+ * app and nothing explains why.
+ *
+ * So: clear the previous dev instance first, loudly. Deliberately matches ONLY
+ * the cargo-built dev binary (`omnivoice-studio`); the installed release app is
+ * `OmniVoice Studio` and is never touched.
+ */
+function killStaleDevApp() {
+  const NAME = DEV_APP_PROCESS_NAME;
+  try {
+    if (process.platform === "win32") {
+      const list = spawnSync("tasklist", ["/FI", `IMAGENAME eq ${NAME}.exe`, "/NH"], {
+        encoding: "utf8",
+      });
+      if (!list.stdout || !list.stdout.toLowerCase().includes(`${NAME}.exe`)) return;
+      spawnSync("taskkill", ["/F", "/T", "/IM", `${NAME}.exe`], { stdio: "ignore" });
+    } else {
+      // -f matches the full path so we hit target/debug/omnivoice-studio only.
+      const found = spawnSync("pgrep", ["-f", `${NAME}$`], { encoding: "utf8" });
+      if (found.status !== 0) return;
+      spawnSync("pkill", ["-f", `${NAME}$`], { stdio: "ignore" });
+    }
+    console.log(
+      "[desktop-dev] closed a previous dev app instance - two instances fight over the " +
+        "dev server and leave one window blank. Starting a clean one.",
+    );
+  } catch {
+    // Best-effort: never block a launch because cleanup failed.
+  }
+}
+
+killStaleDevApp();
 
 // Start from the real environment; heal a stale PATH into a *copy* (mutating
 // process.env doesn't reliably propagate to children under Bun).

--- a/tests/frontend/desktopScripts.test.mjs
+++ b/tests/frontend/desktopScripts.test.mjs
@@ -17,6 +17,7 @@ import {
   STRIPPED_ENV_VARS,
   UPDATER_ARTIFACTS_OFF,
   hiddenFrom,
+  isDevAppProcess,
   isAppScoped,
   macosFreshTraces,
   sanitizedEnv,
@@ -160,4 +161,33 @@ test('STRIPPED_PATH_ENTRIES are exactly the intended dev prefixes', () => {
     '/opt/homebrew/sbin',
     '/usr/local/bin',
   ]);
+});
+
+// ── Dev-launcher stale-instance guard ──────────────────────────────────────
+// `bun desktop` clears a leftover dev app before starting: two instances fight
+// over the dev server, and the loser's Vite exits while its window stays open —
+// a BLANK app with nothing to explain it (reproduced deterministically). The
+// cleanup kills by process name, so the safety boundary is that it matches the
+// cargo dev binary ONLY. Killing a user's installed app would be far worse than
+// the bug being fixed.
+
+test('stale-instance cleanup matches the dev binary', () => {
+  assert.equal(isDevAppProcess('omnivoice-studio'), true);
+  assert.equal(isDevAppProcess('omnivoice-studio.exe'), true);
+  assert.equal(isDevAppProcess('omnivoice-studio.EXE'), true);
+});
+
+test('stale-instance cleanup NEVER matches the installed release app', () => {
+  // The release app is "OmniVoice Studio" — different spacing and case.
+  assert.equal(isDevAppProcess('OmniVoice Studio'), false);
+  assert.equal(isDevAppProcess('OmniVoice Studio.exe'), false);
+  assert.equal(isDevAppProcess('OmniVoice-Studio.exe'), false);
+});
+
+test('stale-instance cleanup ignores unrelated or empty process names', () => {
+  for (const name of ['', '   ', 'node', 'chrome.exe', 'omnivoice', 'my-omnivoice-studio']) {
+    assert.equal(isDevAppProcess(name), false, `should not match ${name}`);
+  }
+  assert.equal(isDevAppProcess(undefined), false);
+  assert.equal(isDevAppProcess(null), false);
 });


### PR DESCRIPTION
Two independent causes of a blank app window, fixed at their roots. Plans B and C from the agreed sequence follow separately.

## Plan A — never *ship* a blank

**The hole:** v0.3.22 shipped a black screen (#1178) — a minifier temporal-dead-zone reorder threw before React mounted, leaving an empty `#root`. It reached users because **every** existing check (vitest, node:test, the whole Playwright e2e suite) runs the **un-minified dev server**. A bug living only in the minified bundle passes all of them.

**The gate:** `frontend/playwright.prod.config.ts` + `frontend/e2e-prod/` build the real bundle, serve `dist/` via `vite preview`, and assert the app actually mounts:
- `#root` has children — the structural anti-blank assertion
- it renders visible text — guards the degenerate "mounted an empty tree" pass
- no `pageerror` — a TDZ reorder throws a `ReferenceError`, exactly what this catches

Deliberately dumb and structural: *"did anything mount?"* is what a pre-render crash always breaks, whatever the cause. `retries: 0`, so a blank screen can never be flaky-passed away.

## Plan D — never *display* a blank in dev

Running `bun desktop` while one is already up doesn't fail politely — it cascades into a blank window. **Reproduced deterministically, measured over CDP:**

| | `#root` children | body bytes |
|---|---|---|
| healthy main window | **1** | 24,267 |
| after a 2nd launch | **0** | 87 |

The new launch's port grab makes the running instance's `dev:api` exit, and `concurrently --kill-others-on-fail` tears down that instance's **entire** stack including its Vite server — leaving the window open, pointed at a dev URL that no longer answers.

`scripts/desktop-dev.mjs` now clears a leftover dev app first, loudly.

**Safety boundary:** `isDevAppProcess` matches the cargo dev binary (`omnivoice-studio`) **only**, never the installed release app (`OmniVoice Studio`). Killing a user's real app would be far worse than the bug being fixed. Unit-tested both directions.

## ⚠️ Two things the maintainer must action

**1. The CI step is not in this PR.** Pushing `.github/workflows/` needs a token scope this session lacks, so the gate ships without its runner — meaning **it does not execute in CI yet**. Add this to `ci.yml` after the *"Run frontend node:test (legacy)"* step:

```yaml
      # ── Black-screen gate (#1178) ──────────────────────────────────────
      # Every check above runs the UN-MINIFIED dev build, so a production-only
      # bug ships green — which is how v0.3.22 went out with a black screen.
      - name: Install chromium for the prod-bundle gate
        if: runner.os == 'Linux'
        run: sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium

      - name: Production bundle renders (no black screen)
        if: runner.os == 'Linux'
        working-directory: frontend
        run: bun run test:prod-bundle
```

**2. The gate has never actually run.** Playwright's chromium would not launch on my Windows box (`launch: Timeout 180000ms exceeded` — browser spawns, never becomes ready), so I could not verify it end-to-end. It is written against the same system-chromium setup the existing e2e suite already uses successfully on Linux CI, but **its first real execution will be yours.** If it goes red, iterate on it — don't skip it. The *signal* it asserts is independently proven: the CDP measurements above show `#root` count cleanly discriminates rendered (1) from blank (0).

What *is* verified: the Plan D guard (14 predicate assertions, both directions) and that the launcher bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a **production-bundle Playwright smoke gate** (`frontend/e2e-prod/prod-bundle-smoke.spec.ts` + `frontend/playwright.prod.config.ts`) that:
  - builds and serves the real production output (`dist/`) via `bun run build && bun x vite preview --strictPort`
  - **disables retries** (`retries: 0`)
  - on load, collects `pageerror` and non-ignorable `console.error` messages
  - asserts `#root` exists and that it receives mounted content by polling `#root`’s `childElementCount > 0`
  - separately asserts `#root` renders **visible text** (`innerText.trim().length > 0`)
  - allows a small set of known harness noise via an `IGNORABLE` regex list
- Implemented a Tauri **blank-window guard** (`frontend/src-tauri/src/blank_guard.rs`, wired from `frontend/src-tauri/src/lib.rs`) for the **`main`** webview that:
  - injects a dependency-free JS probe to report whether `#root` ever mounts (`report_render_state`)
  - if blank, performs up to **3 reloads** with increasing backoff
  - if the probe never answers (e.g. internal error page / missing IPC bridge), treats it as a failure signal
  - then shows a **self-contained built-in failure page** via a `data:` URL (with `eval` injection fallback only if navigation is refused)
- Hardened **dev launcher cleanup** to prevent multiple dev instances from colliding:
  - added `DEV_APP_PROCESS_NAME` and `isDevAppProcess()` in `scripts/desktop-common.mjs` with **exact-match** safety boundary (normalizes whitespace + strips a trailing `.exe`, but does not loosen casing/spacing)
  - updated `scripts/desktop-dev.mjs` to kill only the stale **dev** cargo-built binary before starting `tauri dev`
  - added unit tests covering matching (including `.exe`/case variants) and non-matching for the installed release app
- Added `frontend/package.json` script: `test:prod-bundle` (runs Playwright with `playwright.prod.config.ts`).

### UI / fallback behavior sketch (blank window)

```text
Before (blank):
┌──────────────────────────────┐
│ dark/empty page; `#root`     │
│ either missing or unmounted  │
└──────────────────────────────┘

After (guard heals or explains):
┌──────────────────────────────┐
│ (1) reloads with backoff     │
│ (2) then shows explanation   │
│     "OmniVoice could not ... │
│      Reload" + details       │
└──────────────────────────────┘
```

```mermaid
flowchart TD
  A[arm blank guard on startup] --> B[after FIRST_CHECK_DELAY inject probe]
  B --> C{probe answers? (healthy_seq changes)}
  C -->|No| Z[handle_blank(-2)\nshow built-in failure page]
  C -->|Yes| D{rootChildren}
  D -->|> 0| E[reset reloads; schedule HEARTBEAT_INTERVAL check]
  D -->|<= 0| F[handle_blank reload attempt\nattempt <= 3?]
  F -->|Yes| B
  F -->|No| Z[show built-in failure page\n(data: URL fallback)]
```

## Testing

- Verified the cleanup guard + launcher matching behavior via unit tests.
- The **production-bundle Playwright gate has not yet been executed end-to-end**; the CI workflow step required to run it still needs to be added separately.

## Commit messages summary

- Formatted the new production-bundle gate files with `oxfmt` without modifying unrelated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->