### PR TITLE
feat(ui): dismissible info/warn system notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Official Google Colab notebook (`notebooks/OmniVoice_Studio_Colab.ipynb`) — full app + API feature tour on a free T4
 - ROCm Docker image `ghcr.io/debpalash/omnivoice-studio:rocm` (+ `:stable-rocm`, `:X.Y.Z-rocm`) (#1165)
 - `OMNIVOICE_TRUSTED_NETWORKS` — comma-separated CIDRs exempted from the consumption auth gates (share PIN / API key / dictation WS); admin routes stay loopback-only (#1170)
-- Info/warn system notifications are dismissible (✕ on the note; persists across restarts). Errors stay until fixed, and a note that recurs with a new occurrence id — an unclean-shutdown record, say — re-notifies. Acting on the unclean-shutdown notice now acknowledges it server-side, like the crash notice always did
+- Info/warn system notifications are dismissible and stay dismissed across restarts; error-level notices can't be dismissed, and the unclean-shutdown notice is now acknowledged server-side — thanks @agudmund! (#1192)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Official Google Colab notebook (`notebooks/OmniVoice_Studio_Colab.ipynb`) — full app + API feature tour on a free T4
 - ROCm Docker image `ghcr.io/debpalash/omnivoice-studio:rocm` (+ `:stable-rocm`, `:X.Y.Z-rocm`) (#1165)
 - `OMNIVOICE_TRUSTED_NETWORKS` — comma-separated CIDRs exempted from the consumption auth gates (share PIN / API key / dictation WS); admin routes stay loopback-only (#1170)
+- Info/warn system notifications are dismissible (✕ on the note; persists across restarts). Errors stay until fixed, and a note that recurs with a new occurrence id — an unclean-shutdown record, say — re-notifies. Acting on the unclean-shutdown notice now acknowledges it server-side, like the crash notice always did
 
 ### Docs
 

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -95,8 +95,11 @@ export function useVisibleNotifications(enabled = true) {
   const query = useNotifications(enabled);
   const dismissed = useAppStore((s) => s.dismissedNotificationIds);
   const all = query.data?.notifications || [];
+  // A note is hidden only while it is *currently* dismissible: if a stable id
+  // ever escalates to error level, an old info/warn dismissal must not hide it.
   const notifications = all.filter(
-    (n: { id?: string }) => !n.id || !dismissed.includes(n.id),
+    (n: { id?: string; level?: string }) =>
+      !n.id || !isDismissibleNotification(n) || !dismissed.includes(n.id),
   );
   return { ...query, notifications };
 }

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -5,6 +5,7 @@
 // network request and one cache entry.
 
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { useAppStore } from '../store';
 import * as systemApi from './system';
 import * as setupApi from './setup';
 import * as galleryApi from './gallery';
@@ -76,6 +77,28 @@ export function useNotifications(enabled = true) {
     retryDelay: 1_500,
     enabled,
   });
+}
+
+/** A system notification the user may hide: info/warn describe standing facts
+ * (CPU-only box, low disk) that can be acknowledged; errors describe broken
+ * things that stay visible until actually fixed. */
+export function isDismissibleNotification(n: { level?: string }): boolean {
+  return n?.level === 'info' || n?.level === 'warn';
+}
+
+// The bell and the footer tab must agree on what is visible, so the
+// dismissed-ids filter lives here, next to the query they share. Dismissals
+// persist in the app store (prefsSlice.dismissedNotificationIds); the backend
+// keeps re-emitting the note every poll, which is exactly why filtering is
+// client-side — see the slice doc for the id-stability contract.
+export function useVisibleNotifications(enabled = true) {
+  const query = useNotifications(enabled);
+  const dismissed = useAppStore((s) => s.dismissedNotificationIds);
+  const all = query.data?.notifications || [];
+  const notifications = all.filter(
+    (n: { id?: string }) => !n.id || !dismissed.includes(n.id),
+  );
+  return { ...query, notifications };
 }
 
 export function useSystemLogs(tail = 300, enabled = true, refetchInterval = 10_000) {

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -21,7 +21,12 @@ import {
 
 import toast from 'react-hot-toast';
 import { clearSystemLogs, clearTauriLogs } from '../api/system';
-import { useSystemLogs, useTauriLogs, useNotifications } from '../api/hooks';
+import {
+  useSystemLogs,
+  useTauriLogs,
+  useVisibleNotifications,
+  isDismissibleNotification,
+} from '../api/hooks';
 import { getFrontendLogs, clearFrontendLogs } from '../utils/consoleBuffer';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
@@ -323,8 +328,9 @@ export default function LogsFooter() {
   }, [pullFrontend, collapsed]);
 
   // ── Notifications (shared TanStack Query cache with the header bell) ────
-  const notifQuery = useNotifications();
-  const notifications = notifQuery.data?.notifications || [];
+  // Already filtered to what the user hasn't dismissed — badge and tab agree.
+  const { notifications } = useVisibleNotifications();
+  const dismissNotification = useAppStore((s) => s.dismissNotification);
 
   // ── Donation moment popover (see utils/donationMoments.js) ─────────────
   // The eligibility engine dispatches DONATION_MOMENT_EVENT after a rare,
@@ -795,6 +801,16 @@ export default function LogsFooter() {
                         .then(({ apiFetch }) => apiFetch('/system/crash/ack', { method: 'POST' }))
                         .catch(() => {});
                     }
+                    // Same contract for the run-sentinel notice (#1164):
+                    // acting on it watermarks the record server-side, so it
+                    // stops re-firing — a NEW unclean death re-arms (its id
+                    // carries a fresh detected_at).
+                    if (notif.id?.startsWith('last-run-crash-')) {
+                      import('../api/client')
+                        .then(({ apiFetch }) =>
+                          apiFetch('/system/last-run-crash/ack', { method: 'POST' }))
+                        .catch(() => {});
+                    }
                     if (notif.action.type === 'navigate') {
                       useAppStore.getState().setMode?.(notif.action.target);
                       setCollapsed(true);
@@ -819,6 +835,20 @@ export default function LogsFooter() {
                     <span className="shrink-0 text-[11px] font-semibold text-brand whitespace-nowrap">
                       {notif.action.label} →
                     </span>
+                  )}
+                  {isDismissibleNotification(notif) && notif.id && (
+                    <button
+                      className="shrink-0 flex h-[18px] w-[18px] cursor-pointer items-center justify-center rounded border-0 bg-transparent p-0 text-fg-muted transition-colors hover:text-fg hover:[background:rgba(255,255,255,0.08)]"
+                      onClick={(e) => {
+                        // The row itself may navigate; hiding must not.
+                        e.stopPropagation();
+                        dismissNotification(notif.id);
+                      }}
+                      aria-label={t('common.dismiss')}
+                      title={t('common.dismiss')}
+                    >
+                      <X size={11} />
+                    </button>
                   )}
                 </div>
               );

--- a/frontend/src/components/NotificationPanel.jsx
+++ b/frontend/src/components/NotificationPanel.jsx
@@ -4,12 +4,13 @@
  */
 import React from 'react';
 import { Bell } from 'lucide-react';
-import { useNotifications } from '../api/hooks';
+import { useVisibleNotifications } from '../api/hooks';
 
 export default function NotificationPanel() {
-  // Shared TanStack Query cache entry with LogsFooter — one 30s poll.
-  const { data } = useNotifications();
-  const notifs = data?.notifications || [];
+  // Shared TanStack Query cache entry with LogsFooter — one 30s poll,
+  // minus the notes the user has dismissed (the badge must agree with
+  // what the footer tab actually shows).
+  const { notifications: notifs } = useVisibleNotifications();
   const count = notifs.length;
   const hasErrors = notifs.some((n) => n.level === 'error');
   const hasWarns = notifs.some((n) => n.level === 'warn');

--- a/frontend/src/store/dismissedNotifications.test.ts
+++ b/frontend/src/store/dismissedNotifications.test.ts
@@ -1,0 +1,50 @@
+// Dismissed system notifications — the persisted id list behind the bell /
+// footer filter (prefsSlice.dismissedNotificationIds). The contract under
+// test: append-only with dedupe, newest-50 cap, and level gating via
+// isDismissibleNotification (info/warn hideable, errors never).
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from '../store';
+import { isDismissibleNotification } from '../api/hooks';
+
+beforeEach(() => {
+  useAppStore.setState({ dismissedNotificationIds: [] });
+});
+
+describe('dismissNotification', () => {
+  it('records a dismissed id', () => {
+    useAppStore.getState().dismissNotification('gpu-unavailable');
+    expect(useAppStore.getState().dismissedNotificationIds).toEqual(['gpu-unavailable']);
+  });
+
+  it('dedupes: re-dismissing the same id keeps a single entry', () => {
+    const { dismissNotification } = useAppStore.getState();
+    dismissNotification('gpu-unavailable');
+    dismissNotification('disk-low');
+    dismissNotification('gpu-unavailable');
+    expect(useAppStore.getState().dismissedNotificationIds).toEqual([
+      'disk-low',
+      'gpu-unavailable',
+    ]);
+  });
+
+  it('caps the list at 50, aging out the oldest', () => {
+    const { dismissNotification } = useAppStore.getState();
+    for (let i = 0; i < 55; i += 1) dismissNotification(`last-run-crash-${i}`);
+    const ids = useAppStore.getState().dismissedNotificationIds;
+    expect(ids).toHaveLength(50);
+    expect(ids[0]).toBe('last-run-crash-5'); // 0..4 aged out
+    expect(ids.at(-1)).toBe('last-run-crash-54');
+  });
+});
+
+describe('isDismissibleNotification', () => {
+  it('lets info and warn notes be hidden', () => {
+    expect(isDismissibleNotification({ level: 'info' })).toBe(true);
+    expect(isDismissibleNotification({ level: 'warn' })).toBe(true);
+  });
+
+  it('keeps error notes visible — broken things stay on screen until fixed', () => {
+    expect(isDismissibleNotification({ level: 'error' })).toBe(false);
+    expect(isDismissibleNotification({})).toBe(false);
+  });
+});

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -97,6 +97,9 @@ export const useAppStore = create<AppStore>()(
         // "What's new" affordance (feat/safe-updates) — remembering which
         // version's notes were seen only works if it survives restarts.
         whatsNewSeenVersion: s.whatsNewSeenVersion,
+        // Dismissed system-notification ids — a dismissal only means anything
+        // if it survives restarts (the notes are re-emitted on every poll).
+        dismissedNotificationIds: s.dismissedNotificationIds,
         autoPlayPreview: s.autoPlayPreview,
         mode: s.mode,
         defineMethod: s.defineMethod,

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -139,6 +139,18 @@ export interface PrefsSlice {
   setWhatsNewSeenVersion: (v: string | null) => void;
 
   /**
+   * System-notification ids the user has dismissed (bell + footer tab).
+   * Only info/warn notes are dismissible — errors describe conditions that
+   * need fixing and stay visible until the condition clears. Ids are stable
+   * per condition (e.g. `gpu-unavailable` on a CPU-only box), so a dismissal
+   * is durable across sessions; notes whose id encodes an occurrence (the
+   * `last-run-crash-<ts>` family) naturally re-notify as a fresh id when
+   * they recur. Capped so the list can't grow unbounded.
+   */
+  dismissedNotificationIds: string[];
+  dismissNotification: (id: string) => void;
+
+  /**
    * LLM dub engine — auto-glossary. One up-front LLM pass over the whole
    * transcript extracts a theme summary + terminology map, merged with the
    * manual glossary (manual entries always win) and injected into every
@@ -254,6 +266,7 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   fitOptions: null,
   voiceMatch: 'per_line',
   whatsNewSeenVersion: null,
+  dismissedNotificationIds: [],
   aecEnabled: false,
   autoPlayPreview: true,
 
@@ -277,6 +290,15 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   setFitOptions: (o) => set({ fitOptions: o }),
   setVoiceMatch: (m) => set({ voiceMatch: m }),
   setWhatsNewSeenVersion: (v) => set({ whatsNewSeenVersion: v }),
+  dismissNotification: (id) =>
+    set((s) => ({
+      // Dedupe + keep the newest 50: stable ids make re-dismissal a no-op,
+      // and occurrence-stamped ids (last-run-crash-<ts>) age out the oldest.
+      dismissedNotificationIds: [
+        ...s.dismissedNotificationIds.filter((x) => x !== id),
+        id,
+      ].slice(-50),
+    })),
   setAecEnabled: (on) => set({ aecEnabled: on }),
   setAutoPlayPreview: (on) => set({ autoPlayPreview: on }),
 

--- a/frontend/src/test/LogsFooterDonatePopover.test.jsx
+++ b/frontend/src/test/LogsFooterDonatePopover.test.jsx
@@ -11,6 +11,8 @@ vi.mock('../api/hooks', () => ({
   useSystemLogs: () => ({ data: null, refetch: vi.fn() }),
   useTauriLogs: () => ({ data: null, refetch: vi.fn() }),
   useNotifications: () => ({ data: null }),
+  useVisibleNotifications: () => ({ data: null, notifications: [] }),
+  isDismissibleNotification: () => false,
 }));
 vi.mock('../api/system', () => ({
   clearSystemLogs: vi.fn(),

--- a/frontend/src/test/LogsFooterNotifications.test.jsx
+++ b/frontend/src/test/LogsFooterNotifications.test.jsx
@@ -1,0 +1,107 @@
+// LogsFooter notifications tab — dismissible system notes. Render-level
+// coverage of the dismissed-ids filter through the REAL hook chain
+// (useVisibleNotifications → useNotifications → TanStack Query): the API
+// layer is mocked, a real QueryClient serves the render, and the store is
+// the real one. Contract: an info note carries a dismiss button that hides
+// it everywhere (tab + shared visible list), an error note does not, and
+// dismissing never triggers the row's own action.
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const NOTES = [
+  {
+    id: 'gpu-unavailable',
+    level: 'info',
+    title: 'Running on CPU',
+    message: 'No GPU detected.',
+    action: null,
+  },
+  {
+    id: 'ffmpeg-missing',
+    level: 'error',
+    title: 'Media engine unavailable',
+    message: 'ffmpeg is missing.',
+    action: { label: 'Open Audio tools', type: 'settings-tab', target: 'audio-tools' },
+  },
+];
+
+vi.mock('../api/hooks', async (importOriginal) => {
+  const real = await importOriginal();
+  return {
+    ...real,
+    useSystemLogs: () => ({ data: null, refetch: vi.fn() }),
+    useTauriLogs: () => ({ data: null, refetch: vi.fn() }),
+  };
+});
+vi.mock('../api/system', () => ({
+  clearSystemLogs: vi.fn(),
+  clearTauriLogs: vi.fn(),
+  // The poll behind useNotifications — the filter under test runs REAL.
+  systemNotifications: vi.fn(async () => ({ notifications: NOTES })),
+}));
+// NetworkToggle fetches /system/network/state on mount — out of scope here.
+vi.mock('../components/NetworkToggle', () => ({ default: () => null }));
+
+import LogsFooter from '../components/LogsFooter';
+import { useAppStore } from '../store';
+
+function renderFooter() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LogsFooter />
+    </QueryClientProvider>,
+  );
+}
+
+function openNotificationsTab() {
+  act(() => {
+    window.dispatchEvent(new CustomEvent('omni:open-notifications'));
+  });
+}
+
+const rowOf = (title) => screen.getByText(title).closest('div[class*="rounded-md"]');
+const dismissBtnIn = (row) => row.querySelector('button[aria-label]');
+
+beforeEach(() => {
+  localStorage.clear();
+  useAppStore.setState({ dismissedNotificationIds: [] });
+});
+
+describe('LogsFooter notifications tab — dismissals', () => {
+  it('shows both notes; only the info note offers a dismiss button', async () => {
+    renderFooter();
+    openNotificationsTab();
+
+    await screen.findByText('Running on CPU');
+    expect(dismissBtnIn(rowOf('Running on CPU'))).not.toBeNull();
+    expect(dismissBtnIn(rowOf('Media engine unavailable'))).toBeNull();
+  });
+
+  it('dismissing the info note hides it and records the id', async () => {
+    renderFooter();
+    openNotificationsTab();
+
+    await screen.findByText('Running on CPU');
+    fireEvent.click(dismissBtnIn(rowOf('Running on CPU')));
+
+    expect(screen.queryByText('Running on CPU')).toBeNull();
+    expect(screen.getByText('Media engine unavailable')).not.toBeNull();
+    expect(useAppStore.getState().dismissedNotificationIds).toEqual(['gpu-unavailable']);
+  });
+
+  it('dismiss does not fire the row action (stopPropagation)', async () => {
+    const openSettingsTab = vi.fn();
+    useAppStore.setState({ openSettingsTab });
+    renderFooter();
+    openNotificationsTab();
+
+    await screen.findByText('Running on CPU');
+    fireEvent.click(dismissBtnIn(rowOf('Running on CPU')));
+    expect(openSettingsTab).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

System notifications are re-generated on every `/system/notifications` poll, so notes describing a standing fact about the machine — `gpu-unavailable` on a CPU-only box, `disk-low` — sit in the bell and the footer tab permanently, with no way to acknowledge them. This adds client-side dismissals for info/warn notes, keeps the header bell badge and the footer tab in agreement, and fixes a small gap where the run-sentinel unclean-shutdown notice (#1164) could never be acknowledged from the UI at all.

## Changes

- **Dismissible info/warn notifications.** Each info/warn note in the footer tab renders a small ✕ (reuses the existing `common.dismiss` string — no new translations). Dismissed ids persist in the app store (`prefsSlice.dismissedNotificationIds`, deduped, capped at the newest 50). Error notes are deliberately **not** dismissible — they describe broken things that should stay visible until actually fixed.
- **`useVisibleNotifications`** — a shared hook next to the existing `useNotifications` poll applies the dismissed-ids filter in one place, so the bell badge count and the footer tab always agree.
- **Id stability is the re-arm contract.** Stable ids (`gpu-unavailable`) stay dismissed across sessions; occurrence-stamped ids (the `last-run-crash-<detected_at>` family) return as fresh ids when they recur — matching the intent already documented at their generator ("a NEW unclean death re-notifies even after an older one was dismissed").
- 🐛 **Bug fix (for completeness):** nothing in the UI ever called `POST /system/last-run-crash/ack`, so the run-sentinel "did not shut down cleanly" notice could only be cleared by hand-issuing the request — discovered in the field on a CPU box where the record's banner outlived the investigation that explained it. Acting on the notice now acknowledges it server-side, mirroring what `crash-last-session` has always done via `/system/crash/ack`.

## Type

- [x] ✨ New feature
- [x] 🐛 Bug fix

## Testing

- New store contract test (`store/dismissedNotifications.test.ts`): dismiss records the id, dedupes, caps at the newest 50; `isDismissibleNotification` gates info/warn true, error/undefined false.
- New render-level test (`test/LogsFooterNotifications.test.jsx`) through the **real** hook chain (`useVisibleNotifications` → `useNotifications` → TanStack Query with a real `QueryClient`; only the API layer mocked): info note offers the dismiss button and an error note doesn't; dismissing hides the note and records the id; dismissal never triggers the row's own action (stopPropagation).
- Existing `LogsFooterDonatePopover` mock extended for the new hook exports; full frontend suite green: **1388 passed**, `oxlint` and `tsc --noEmit` clean.
- Verified live against a running backend on a CPU-only Windows box: dismissed "Running on CPU", bell went to 0 and the tab showed all-clear, hard-reloaded, dismissal persisted.

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable) — CHANGELOG entry under Unreleased
- [x] No local machine paths, logs, or personal env details in this PR
- [ ] Version files are in sync (if version bump): n/a — no version bump
- [x] If this PR changes runtime behavior, the regression fixture at `tests/fixtures/omnivoice_data/` still loads green on the `smoke-matrix` CI job (macOS + Windows + Linux) — frontend-only change; no data-shape or backend behavior touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds dismissible **info/warn** client-side handling for system notifications (persisted across restarts) while keeping **error** notifications undismissable. Introduces shared filtering via `useVisibleNotifications` so the header bell badge and footer notifications tab always agree, adds per-notification dismiss (“X”) controls, and extends “unclean shutdown / run-sentinel” acknowledgement to the backend via `POST /system/last-run-crash/ack`.

- Persists `dismissedNotificationIds` in the app store with **dedupe**, **newest-first**, and a **cap of 50**.
- Adds `isDismissibleNotification(level)` (only `info`/`warn`) and `useVisibleNotifications()` to filter dismissed notifications.
- Footer renders a dismiss “X” **only** for dismissible **info/warn** notifications; clicking “X” uses `stopPropagation` so row actions (navigation/links/settings) are unaffected.
- Dismissal is durable for **stable IDs**; **occurrence-stamped IDs** (e.g. `last-run-crash-<ts>`) reappear as new events because each occurrence has a new ID.
- Fixes acknowledgement of run-sentinel unclean-shutdown notices by sending `POST /system/last-run-crash/ack` when the notice row is acted on (existing crash ack remains `POST /system/crash/ack`).
- Hardens filtering so if a notification with a previously dismissed ID **escalates to error level**, it becomes visible again (dismissal only applies while the notification is currently `info`/`warn`).

## UI

```text
Before                         After
[Info notification]            [Info notification]   [×]
[Error notification]           [Error notification]
```

## Behavior

```mermaid
flowchart TD
  A[Poll system notifications] --> B[Load dismissedNotificationIds from persisted store]
  B --> C[useVisibleNotifications filters notifications]
  C --> D{level is dismissible (info/warn)?}
  D -->|No (error/other)| E[Always show notification]
  D -->|Yes| F{id in dismissed IDs?}
  F -->|Yes| G[Hide notification]
  F -->|No| H[Show notification]

  H --> I[Render header bell badge + footer notifications tab from visible list]

  I --> J{User clicks footer row action?}
  J -->|Yes| K[Run action (navigate/link/settings)]
  K --> L{Row id startsWith last-run-crash- ?}
  L -->|Yes| M[POST /system/last-run-crash/ack]
  L -->|No| N[No last-run-crash ack]

  I --> O{User clicks dismiss "×"?}
  O -->|Info/Warn| P[stopPropagation + dismissNotification(id)]
  P --> Q[Store dedupes, appends newest, caps to 50 (persisted)]
  Q --> C
```

## Testing / Docs

- Adds store and UI render tests covering:
  - dismissed ID persistence (dedupe + cap behavior),
  - dismissibility rules (`info`/`warn` dismissible, `error` not),
  - footer dismissal UX (row removal only; no row-action triggering).
- Adds an **Unreleased** CHANGELOG entry describing the notification dismissal/ack behavior and credits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->