### PR TITLE
feat(mcp): clone_voice tool — clone a new voice from reference audio (#1194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Official Google Colab notebook (`notebooks/OmniVoice_Studio_Colab.ipynb`) — full app + API feature tour on a free T4
 - ROCm Docker image `ghcr.io/debpalash/omnivoice-studio:rocm` (+ `:stable-rocm`, `:X.Y.Z-rocm`) (#1165)
 - `OMNIVOICE_TRUSTED_NETWORKS` — comma-separated CIDRs exempted from the consumption auth gates (share PIN / API key / dictation WS); admin routes stay loopback-only (#1170)
-- `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` (#1194)
+- `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` — thanks @paoloantinori! (#1194)
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Official Google Colab notebook (`notebooks/OmniVoice_Studio_Colab.ipynb`) — full app + API feature tour on a free T4
 - ROCm Docker image `ghcr.io/debpalash/omnivoice-studio:rocm` (+ `:stable-rocm`, `:X.Y.Z-rocm`) (#1165)
 - `OMNIVOICE_TRUSTED_NETWORKS` — comma-separated CIDRs exempted from the consumption auth gates (share PIN / API key / dictation WS); admin routes stay loopback-only (#1170)
+- `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` (#1194)
 
 ### Docs
 

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -7,9 +7,12 @@ Run standalone:
 
 Tools exposed:
     generate_speech   — text → WAV audio (voice clone or design)
+    clone_voice       — base64 reference audio → new voice profile
+    transcribe        — base64 audio → text
     list_voices       — enumerate saved voice profiles
     list_languages    — available TTS languages
     list_personalities — voice personality presets
+    check_health      — backend status + active GPU device
 
 Resources exposed:
     voice://{profile_id}  — voice profile metadata

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import json
 import logging
 import os
 import sys
@@ -252,6 +253,56 @@ def create_mcp_server():
         """Get the 20 most recent generation history items."""
         history = await _api_get("/history")
         return str(history[:20])
+
+    @mcp.tool()
+    async def clone_voice(
+        name: str,
+        ref_audio_base64: str,
+        ref_text: str = "",
+        instruct: str = "",
+        language: str = "Auto",
+    ) -> str:
+        """Clone a new voice profile from a reference audio sample.
+
+        The new voice is immediately available for use with generate_speech
+        (pass the returned profile_id as the profile_id argument).
+
+        Args:
+            name: A human-friendly name for the cloned voice.
+            ref_audio_base64: Base64-encoded audio (WAV, MP3, FLAC, etc.) of
+                the reference voice — 5-30 seconds of clean single-speaker
+                speech.
+            ref_text: Optional transcript of the reference audio (improves
+                quality for some engines).
+            instruct: Optional style instruction (e.g. 'whisper', 'excited').
+            language: Language of the reference audio (ISO code or 'Auto').
+
+        Returns:
+            JSON with the new profile's id, name, and kind.
+        """
+        # Reject oversized inputs before decoding (base64 is always larger
+        # than raw, so this is a safe lower bound on the decoded size).
+        if len(ref_audio_base64) > 200 * 1024 * 1024:
+            return '{"error":"reference audio exceeds 200 MB limit"}'
+        try:
+            raw = base64.b64decode(ref_audio_base64, validate=True)
+        except Exception:
+            return '{"error":"ref_audio_base64 is not valid base64"}'
+        if not raw:
+            return '{"error":"ref_audio_base64 is empty"}'
+        r = await _api_post_form(
+            "/profiles",
+            data={
+                "name": name,
+                "kind": "clone",
+                "ref_text": ref_text,
+                "instruct": instruct,
+                "language": language,
+            },
+            files={"ref_audio": ("ref_audio.wav", raw, "application/octet-stream")},
+        )
+        p = r.json()
+        return json.dumps({"profile_id": p["id"], "name": p["name"], "kind": p["kind"]})
 
     return mcp
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,8 +1,8 @@
 # MCP server — let agents speak in your voice
 
 OmniVoice ships an [MCP](https://modelcontextprotocol.io/) server so AI agents
-(Claude Code, Cursor, …) can synthesize speech, transcribe audio, and list
-your voices — locally, in a voice you choose per agent. The server is
+(Claude Code, Cursor, …) can synthesize speech, clone voices, transcribe audio,
+and list your voices — locally, in a voice you choose per agent. The server is
 **mounted on the running backend** at `/mcp`, so there's nothing extra to
 start once OmniVoice is open.
 
@@ -11,6 +11,7 @@ start once OmniVoice is open.
 | Tool | What it does |
 |---|---|
 | `generate_speech` | text → WAV (base64). Uses the agent's bound voice unless a `profile_id` is passed. |
+| `clone_voice` | base64 audio → new voice profile. Returns a `profile_id` for use with `generate_speech`. |
 | `transcribe` | base64 audio → text (646 languages). |
 | `list_voices` / `list_personalities` / `list_languages` | enumerate what's available. |
 | `check_health` | backend status + active GPU device. |

--- a/tests/test_mcp_mount.py
+++ b/tests/test_mcp_mount.py
@@ -20,8 +20,8 @@ def test_server_builds_with_expected_tools():
 
     server = create_mcp_server()
     names = {t.name for t in asyncio.run(server.list_tools())}
-    # v1 surface: speak, transcribe, and the read-only listers.
-    assert {"generate_speech", "transcribe", "list_voices", "list_personalities",
+    # v1 surface: speak, clone, transcribe, and the read-only listers.
+    assert {"generate_speech", "clone_voice", "transcribe", "list_voices", "list_personalities",
             "list_languages", "check_health"} <= names
 
 


### PR DESCRIPTION
Closes #1194.

## What

Adds a `clone_voice` MCP tool so AI agents can **create** a voice profile from a reference audio sample — not just use existing ones. The new tool:

- Takes `name` + `ref_audio_base64` (base64-encoded WAV/MP3/FLAC, 5-30s clean speech) + optional `ref_text`/`instruct`/`language`.
- Decodes the base64, POSTs as a multipart `ref_audio` file to the existing `POST /profiles` endpoint (`kind=clone`).
- Returns `{profile_id, name, kind}` so the agent can immediately use the voice with `generate_speech`.

Consistent with the existing `transcribe` tool's base64-audio pattern (validated decode + 200 MB cap + `application/octet-stream` content-type).

## Review

Self-reviewed against the `transcribe` tool (same base64-audio transport): caught and fixed three robustness gaps — missing base64 decode error handling, missing size cap, and wrong content-type (hardcoded `audio/wav` instead of `application/octet-stream`). The full bot review (CodeRabbit/Greptile) will run on push.

## Files
- `backend/mcp_server.py` — one new `@mcp.tool()` (~50 lines, follows the `generate_speech` pattern).
- `tests/test_mcp_mount.py` — added `clone_voice` to the asserted tool surface.
- `CHANGELOG.md` — `### Added` entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds a `clone_voice` MCP tool that lets agents create voice profiles from base64-encoded reference audio (WAV/MP3/FLAC).

- Exposes `clone_voice(name, ref_audio_base64, ref_text="", instruct="", language="Auto")`.
- Decodes and validates the base64 audio input, enforcing a 200 MB size cap; rejects empty/invalid reference audio.
- Uploads the decoded audio to `POST /profiles` as a multipart `ref_audio` file with `kind=clone` and content type `application/octet-stream`, along with optional `ref_text`, `instruct`, and `language`.
- Returns the created profile information (`{profile_id, name, kind}`) as a JSON string for immediate use with `generate_speech`.
- Updates MCP tool registration test expectations, and documents the new tool in `docs/mcp.md`; also adds a `CHANGELOG.md` entry.

```mermaid
flowchart LR
  A[AI agent] --> B[clone_voice MCP tool]
  B --> C[Decode + validate ref_audio_base64 (<=200MB)]
  C --> D[Multipart upload to POST /profiles (kind=clone)]
  D --> E[Return profile_id]
  E --> F[generate_speech]
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->