### PR TITLE
fix(dub): transcribe stream opens instantly and survives long ASR loads

### DIFF
--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -495,7 +495,23 @@ async def dub_transcribe_stream(
                 # before emitting any event, and the UI shows a misleading generic
                 # "stream dropped" message instead of the real cause (issue #255).
                 try:
-                    _model = await get_model()
+                    # Same keepalive treatment as the ASR load below: a cold
+                    # TTS load can outlast a reverse proxy's per-read idle
+                    # timeout (~60-120 s nginx/Caddy defaults) — the initial
+                    # open comment stops the browser's no-response clock but
+                    # does not reset a proxy's idle timer.
+                    _model_task = asyncio.ensure_future(get_model())
+                    _model_task.add_done_callback(
+                        lambda f: f.cancelled() or f.exception()
+                    )
+                    while True:
+                        _done, _ = await asyncio.wait(
+                            {_model_task}, timeout=ASR_LOAD_KEEPALIVE_S
+                        )
+                        if _done:
+                            break
+                        yield b": tts-load keepalive\n\n"
+                    _model = _model_task.result()
                 except Exception as e:
                     logger.exception("transcribe preflight: model load failed (job=%s)", job_id)
                     from core.failure import build_failure
@@ -565,6 +581,15 @@ async def dub_transcribe_stream(
                                     load_active_asr_backend,
                                     asr_pipe=getattr(_model, "_asr_pipe", None),
                                 ),
+                            )
+                            # On client disconnect the ASGI server cancels this
+                            # generator mid-wait; the executor load keeps
+                            # running (and still caches its result). Retrieve
+                            # its eventual exception so asyncio never logs
+                            # "Task exception was never retrieved" into the
+                            # crash forensics log.
+                            _load_fut.add_done_callback(
+                                lambda f: f.cancelled() or f.exception()
                             )
                             # Keepalive while the load runs (#1196): a first-run
                             # load may download weights for minutes, and a

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -375,6 +375,12 @@ TRANSCRIBE_CHUNK_TIMEOUT_S = float(os.environ.get("OMNIVOICE_TRANSCRIBE_CHUNK_TI
 #: shouldn't silently drop that whole window — retry once on a fresh pool so the
 #: transcript doesn't come back "missing the beginning".
 _CHUNK_TRANSCRIBE_ATTEMPTS = max(1, int(os.environ.get("OMNIVOICE_TRANSCRIBE_CHUNK_ATTEMPTS", "2")))
+#: Seconds between SSE keepalive comments while the transcribe preflight loads
+#: the ASR backend (#1196). A first-run load can download multi-GB weights —
+#: minutes with zero bytes on the wire — and byte-silent streams get severed
+#: by Chrome's ~5 min no-response cap and by reverse-proxy idle timeouts,
+#: which the UI can only report as the generic "stream dropped" guess.
+ASR_LOAD_KEEPALIVE_S = float(os.environ.get("OMNIVOICE_ASR_LOAD_KEEPALIVE_S", "15.0"))
 
 
 _sse_event = dub_pipeline.sse_event
@@ -432,125 +438,159 @@ async def dub_transcribe_stream(
     # query string can never break the diarization call. None → auto-detect.
     num_speakers = _clamp_num_speakers(num_speakers)
 
-    # Crash forensics (#1164): transcription is a prime OOM-kill site (ASR
-    # model loading on top of a resident TTS model). Record that one started
-    # so an unclean death is attributable. Kind only — never media content.
-    from core.run_sentinel import touch_activity
-    touch_activity("transcribe", "dub")
-
-    job = _get_job(job_id)
-
-    preflight_error: Optional[str] = None
-    # Extra machine-readable fields merged into the preflight `error` SSE event
-    # (e.g. the typed asr_model_missing payload → download-CTA in the UI).
-    preflight_payload: Optional[dict] = None
-    asr_audio_target: Optional[str] = None
-    _asr_backend = None
-    scene_cuts: list = []
-    # Defaulted here, not just inside the preflight block below: it is read from
-    # _gen_body (separated_vocals=), so a preflight that bails early would
-    # otherwise leave it unbound and raise NameError instead of the real error.
-    asr_on_vocals = False
-
-    if not job:
-        preflight_error = "Job not found. It may have been cleaned up or was never created."
-    else:
-        # The TTS core model is loaded here for exactly one reason: to harvest a
-        # preloaded `_asr_pipe` off it (passed to get_active_asr_backend below).
-        # That attribute is only ever set by OmniVoice.from_pretrained under
-        # OMNIVOICE_PRELOAD_TTS_ASR, which is off by default — so in the default
-        # config this loaded ~3 GB, harvested None, and then offload_tts_for_asr()
-        # freed it again 60 lines below. On unified memory that offload is a full
-        # UNLOAD (#1119), so dub_generate later cold-reloaded the same model (~8s).
-        # Every dub paid load → unload → reload for an attribute that was always
-        # None. Load it only when there is actually something to harvest.
-        _model = None
-        if should_preload_tts_asr():
-            # Guard the model load: if it raises, the SSE stream would otherwise die
-            # before emitting any event, and the UI shows a misleading generic
-            # "stream dropped" message instead of the real cause (issue #255).
-            try:
-                _model = await get_model()
-            except Exception as e:
-                logger.exception("transcribe preflight: model load failed (job=%s)", job_id)
-                from core.failure import build_failure
-                f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
-                preflight_error = f["reason"] + (f" — {f['hint']}" if f.get("hint") else "")
-                _model = None
-        if preflight_error is None:
-            asr_audio_target = job.get("vocals_path")
-            if not asr_audio_target or not os.path.exists(asr_audio_target):
-                asr_audio_target = job.get("audio_path")
-            # #963: onset snapping is only trustworthy on the Demucs vocals
-            # track. When separation failed/was skipped, dub_pipeline sets
-            # vocals_path to the mixed audio_path — so compare paths instead
-            # of trusting the key's presence.
-            asr_on_vocals = bool(asr_audio_target) and asr_audio_target != job.get("audio_path")
-            if not asr_audio_target or not os.path.exists(asr_audio_target):
-                preflight_error = "No audio available for transcription."
-            else:
-                from services.asr_backend import (
-                    active_backend_id,
-                    asr_model_missing_detail,
-                    asr_model_missing_error,
-                    load_active_asr_backend,
-                )
-                # TTS-only install: no ASR model on disk. Bail BEFORE any
-                # backend is constructed/loaded — the whisper backends would
-                # otherwise silently auto-download multi-GB weights from HF.
-                # Typed payload → the UI renders a one-click download CTA.
-                # A preloaded `_asr_pipe` only substitutes for the
-                # *pytorch-whisper* backend (its sole consumer) — any other
-                # active backend still loads its own weights, so the preflight
-                # must run for them even when the pipe is present.
-                _missing = None
-                _skip_preflight = (
-                    getattr(_model, "_asr_pipe", None) is not None
-                    and active_backend_id() == "pytorch-whisper"
-                )
-                if not _skip_preflight:
-                    _missing = await asyncio.get_running_loop().run_in_executor(
-                        None, asr_model_missing_error
-                    )
-                if _missing is not None:
-                    preflight_error = asr_model_missing_detail(_missing)
-                    preflight_payload = _missing
-                if _missing is None:
-                    try:
-                        # The PyTorch-Whisper backend lazily builds its own pipeline
-                        # when no preloaded `_asr_pipe` is present (issue #255), so it
-                        # no longer needs OMNIVOICE_PRELOAD_TTS_ASR=1.
-                        #
-                        # Select + eagerly load in ONE call so a real load failure
-                        # (e.g. WhisperX: missing weights, CTranslate2/cuDNN
-                        # mismatch, the torch-2.6 weights-only VAD regression)
-                        # surfaces once, with its actual cause, as a clean preflight
-                        # `error` event — instead of being buried in N cryptic
-                        # per-chunk failures and retried on every chunk (#578) —
-                        # and so a backend whose deep import chain is rotted (e.g.
-                        # `No module named 'lightning_fabric'` from a partial
-                        # install, #1185) is marked unavailable and skipped in
-                        # favor of the next engine instead of failing ASR init
-                        # wholesale. Run in a thread so the (blocking) load
-                        # doesn't stall the event loop.
-                        import functools
-                        _asr_backend = await asyncio.get_running_loop().run_in_executor(
-                            _gpu_pool,
-                            functools.partial(
-                                load_active_asr_backend,
-                                asr_pipe=getattr(_model, "_asr_pipe", None),
-                            ),
-                        )
-                    except Exception as e:
-                        logger.exception("transcribe preflight: ASR load failed (job=%s)", job_id)
-                        from core.failure import build_failure
-                        f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
-                        preflight_error = "ASR backend initialization failed: " + f["reason"] + (
-                            f" — {f['hint']}" if f.get("hint") else ""
-                        )
-                scene_cuts = job.get("scene_cuts") or []
-
     async def _gen_body():
+        # ── Preflight — run INSIDE the stream, never before it (#1196) ──
+        # This whole block used to run in the endpoint body, before the
+        # StreamingResponse existed — i.e. OUTSIDE the stream's terminal-event
+        # contract (#516). Two real-world consequences (issue #1196):
+        #   * an exception on any unguarded line became an HTTP 500, whose
+        #     body EventSource cannot read — the UI could only show the
+        #     generic "Transcribe stream dropped … likely ASR backend failed"
+        #     guess while a perfectly alive backend knew the real cause;
+        #   * not a single byte (not even response headers) went out until
+        #     the ASR load finished — a first-run weight download can mean
+        #     minutes of total silence, tripping Chrome's hard ~5 min
+        #     no-response timeout (and any reverse-proxy timeout in front of
+        #     a Docker install), severing the stream with that same generic
+        #     message.
+        # In here, headers + a first comment go out immediately, keepalive
+        # comments flow while the ASR backend loads, and ANY preflight crash
+        # lands in gen()'s last-resort finalizer as a structured `error` +
+        # terminal `done`.
+        # Crash forensics (#1164): transcription is a prime OOM-kill site (ASR
+        # model loading on top of a resident TTS model). Record that one started
+        # so an unclean death is attributable. Kind only — never media content.
+        from core.run_sentinel import touch_activity
+        touch_activity("transcribe", "dub")
+
+        job = _get_job(job_id)
+
+        preflight_error: Optional[str] = None
+        # Extra machine-readable fields merged into the preflight `error` SSE event
+        # (e.g. the typed asr_model_missing payload → download-CTA in the UI).
+        preflight_payload: Optional[dict] = None
+        asr_audio_target: Optional[str] = None
+        _asr_backend = None
+        scene_cuts: list = []
+        # Defaulted here, not just inside the preflight block below: it is read from
+        # _gen_body (separated_vocals=), so a preflight that bails early would
+        # otherwise leave it unbound and raise NameError instead of the real error.
+        asr_on_vocals = False
+
+        if not job:
+            preflight_error = "Job not found. It may have been cleaned up or was never created."
+        else:
+            # The TTS core model is loaded here for exactly one reason: to harvest a
+            # preloaded `_asr_pipe` off it (passed to get_active_asr_backend below).
+            # That attribute is only ever set by OmniVoice.from_pretrained under
+            # OMNIVOICE_PRELOAD_TTS_ASR, which is off by default — so in the default
+            # config this loaded ~3 GB, harvested None, and then offload_tts_for_asr()
+            # freed it again 60 lines below. On unified memory that offload is a full
+            # UNLOAD (#1119), so dub_generate later cold-reloaded the same model (~8s).
+            # Every dub paid load → unload → reload for an attribute that was always
+            # None. Load it only when there is actually something to harvest.
+            _model = None
+            if should_preload_tts_asr():
+                # Guard the model load: if it raises, the SSE stream would otherwise die
+                # before emitting any event, and the UI shows a misleading generic
+                # "stream dropped" message instead of the real cause (issue #255).
+                try:
+                    _model = await get_model()
+                except Exception as e:
+                    logger.exception("transcribe preflight: model load failed (job=%s)", job_id)
+                    from core.failure import build_failure
+                    f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
+                    preflight_error = f["reason"] + (f" — {f['hint']}" if f.get("hint") else "")
+                    _model = None
+            if preflight_error is None:
+                asr_audio_target = job.get("vocals_path")
+                if not asr_audio_target or not os.path.exists(asr_audio_target):
+                    asr_audio_target = job.get("audio_path")
+                # #963: onset snapping is only trustworthy on the Demucs vocals
+                # track. When separation failed/was skipped, dub_pipeline sets
+                # vocals_path to the mixed audio_path — so compare paths instead
+                # of trusting the key's presence.
+                asr_on_vocals = bool(asr_audio_target) and asr_audio_target != job.get("audio_path")
+                if not asr_audio_target or not os.path.exists(asr_audio_target):
+                    preflight_error = "No audio available for transcription."
+                else:
+                    from services.asr_backend import (
+                        active_backend_id,
+                        asr_model_missing_detail,
+                        asr_model_missing_error,
+                        load_active_asr_backend,
+                    )
+                    # TTS-only install: no ASR model on disk. Bail BEFORE any
+                    # backend is constructed/loaded — the whisper backends would
+                    # otherwise silently auto-download multi-GB weights from HF.
+                    # Typed payload → the UI renders a one-click download CTA.
+                    # A preloaded `_asr_pipe` only substitutes for the
+                    # *pytorch-whisper* backend (its sole consumer) — any other
+                    # active backend still loads its own weights, so the preflight
+                    # must run for them even when the pipe is present.
+                    _missing = None
+                    _skip_preflight = (
+                        getattr(_model, "_asr_pipe", None) is not None
+                        and active_backend_id() == "pytorch-whisper"
+                    )
+                    if not _skip_preflight:
+                        _missing = await asyncio.get_running_loop().run_in_executor(
+                            None, asr_model_missing_error
+                        )
+                    if _missing is not None:
+                        preflight_error = asr_model_missing_detail(_missing)
+                        preflight_payload = _missing
+                    if _missing is None:
+                        try:
+                            # The PyTorch-Whisper backend lazily builds its own pipeline
+                            # when no preloaded `_asr_pipe` is present (issue #255), so it
+                            # no longer needs OMNIVOICE_PRELOAD_TTS_ASR=1.
+                            #
+                            # Select + eagerly load in ONE call so a real load failure
+                            # (e.g. WhisperX: missing weights, CTranslate2/cuDNN
+                            # mismatch, the torch-2.6 weights-only VAD regression)
+                            # surfaces once, with its actual cause, as a clean preflight
+                            # `error` event — instead of being buried in N cryptic
+                            # per-chunk failures and retried on every chunk (#578) —
+                            # and so a backend whose deep import chain is rotted (e.g.
+                            # `No module named 'lightning_fabric'` from a partial
+                            # install, #1185) is marked unavailable and skipped in
+                            # favor of the next engine instead of failing ASR init
+                            # wholesale. Run in a thread so the (blocking) load
+                            # doesn't stall the event loop.
+                            import functools
+                            _load_fut = asyncio.get_running_loop().run_in_executor(
+                                _gpu_pool,
+                                functools.partial(
+                                    load_active_asr_backend,
+                                    asr_pipe=getattr(_model, "_asr_pipe", None),
+                                ),
+                            )
+                            # Keepalive while the load runs (#1196): a first-run
+                            # load may download weights for minutes, and a
+                            # byte-silent stream gets severed by Chrome's
+                            # ~5 min no-response cap or a reverse proxy's idle
+                            # timeout — which the UI can only render as the
+                            # generic "stream dropped" guess. SSE comment
+                            # lines are invisible to EventSource, so no client
+                            # changes are needed.
+                            while True:
+                                _done, _ = await asyncio.wait(
+                                    {_load_fut}, timeout=ASR_LOAD_KEEPALIVE_S
+                                )
+                                if _done:
+                                    break
+                                yield b": asr-load keepalive\n\n"
+                            _asr_backend = _load_fut.result()
+                        except Exception as e:
+                            logger.exception("transcribe preflight: ASR load failed (job=%s)", job_id)
+                            from core.failure import build_failure
+                            f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
+                            preflight_error = "ASR backend initialization failed: " + f["reason"] + (
+                                f" — {f['hint']}" if f.get("hint") else ""
+                            )
+                    scene_cuts = job.get("scene_cuts") or []
+
         if preflight_error:
             # Always follow a terminal `error` with `done` so the stream closes
             # via a named event, not a raw connection drop. A bare error+close
@@ -1215,6 +1255,12 @@ async def dub_transcribe_stream(
         yield _sse_event("done", {})
 
     async def gen():
+        # First byte out the moment the stream starts (#1196): the browser's
+        # no-response clock stops, buffering middlemen flush the headers, and
+        # EventSource reports the stream open — all BEFORE the preflight
+        # (which may load models for minutes) runs inside _gen_body. A
+        # comment line is invisible to client event handlers.
+        yield b": transcribe-stream open\n\n"
         # Terminal-event guard (#516): the SSE stream must NEVER close without a
         # terminal event. Any unanticipated exception in the body (e.g. an ASR
         # load that escapes the per-chunk handler) previously dropped the

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -301,6 +301,112 @@ def test_transcribe_stream_surfaces_asr_load_failure_at_preflight(tmp_path, monk
     assert done_idx > err_idx >= 0, f"error must be followed by terminal done: {body}"
 
 
+def test_transcribe_stream_preflight_crash_is_a_structured_error(monkeypatch):
+    """Regression #1196: the whole preflight used to run in the endpoint body,
+    BEFORE the StreamingResponse existed. An exception on any line without its
+    own guard (the job-store lookup, the backend-id resolution, the
+    `services.asr_backend` import, …) became an HTTP 500 — whose body
+    EventSource cannot read — so the UI showed the generic "Transcribe stream
+    dropped … likely ASR backend failed to load" guess while a perfectly alive
+    backend knew the real cause. The preflight now runs INSIDE the stream, so
+    any such crash lands in the terminal-event guard (#516) as a structured
+    `error` + `done`.
+
+    `_get_job` stands in for the class: any raise, anywhere in the preflight,
+    must reach the client as a structured SSE error — never a non-2xx."""
+    import asyncio
+    from api.routers import dub_core as dc
+
+    def _boom_get_job(job_id):
+        raise RuntimeError("job store exploded: simulated")
+
+    monkeypatch.setattr(dc, "_get_job", _boom_get_job)
+
+    async def _collect():
+        resp = await dc.dub_transcribe_stream("t_preflightcrash")
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk))
+        return "".join(parts)
+
+    # Before the fix this raised straight out of the endpoint coroutine
+    # (→ HTTP 500 through the app); it must instead stream a terminal error.
+    body = asyncio.run(_collect())
+
+    assert "event: error" in body, body
+    assert "job store exploded: simulated" in body, body
+    err_idx = body.rfind("event: error")
+    done_idx = body.rfind("event: done")
+    assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"
+
+
+def test_transcribe_stream_sends_bytes_while_asr_loads(tmp_path, monkeypatch):
+    """Regression #1196 (silent-load drop class): the old endpoint-body
+    preflight sent NOT ONE byte — not even response headers — until the ASR
+    backend finished loading. A first-run load downloads multi-GB weights, so
+    minutes of byte-silence tripped Chrome's ~5 min no-response timeout (and
+    reverse-proxy timeouts in front of Docker installs), severing the stream
+    with the generic "stream dropped" message even though the backend was
+    healthy and still working.
+
+    The stream must now (a) open with an immediate comment byte before the
+    preflight runs, and (b) emit keepalive comments while the load is in
+    flight — both invisible to EventSource handlers, so no client changes."""
+    import asyncio
+    import time
+    from api.routers import dub_core as dc
+
+    job_id = "t_slowload"
+    audio = tmp_path / "a.wav"
+    _make_wav(audio, seconds=1.0)
+    dc._dub_jobs[job_id] = {
+        "audio_path": str(audio), "vocals_path": None, "scene_cuts": [],
+    }
+
+    fake_model = MagicMock()
+    fake_model._asr_pipe = None
+
+    async def _ok_model():
+        return fake_model
+
+    def _slow_boom(**_kw):
+        time.sleep(0.15)  # long enough for several keepalive intervals below
+        raise RuntimeError("weights download interrupted: simulated")
+
+    monkeypatch.setattr(dc, "get_model", _ok_model)
+    monkeypatch.setattr(
+        "services.asr_backend.load_active_asr_backend", _slow_boom
+    )
+    monkeypatch.setattr(dc, "ASR_LOAD_KEEPALIVE_S", 0.02)
+
+    async def _collect():
+        resp = await dc.dub_transcribe_stream(job_id)
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk))
+        return parts
+
+    try:
+        parts = asyncio.run(_collect())
+    finally:
+        dc._dub_jobs.pop(job_id, None)
+
+    body = "".join(parts)
+    # (a) The very first bytes are the stream-open comment — before any model
+    # work. This is what stops the browser/proxy no-response clocks.
+    assert parts[0].startswith(": transcribe-stream open"), parts[0]
+    # (b) Keepalives flowed during the slow load, before the terminal error.
+    assert ": asr-load keepalive" in body, body
+    assert body.index(": asr-load keepalive") < body.index("event: error"), body
+    # And the slow load's real failure still surfaces as the structured
+    # preflight error, followed by the terminal done.
+    assert "ASR backend initialization failed" in body, body
+    assert "weights download interrupted: simulated" in body, body
+    err_idx = body.find("event: error")
+    done_idx = body.find("event: done")
+    assert done_idx > err_idx >= 0, f"error must be followed by terminal done: {body}"
+
+
 def test_reset_pool_on_wedge_resets_resilient_pool():
     """#730: a chunk transcribe that times out wedges its GPU-pool worker. The
     chunked stream must abandon the pool so the next chunk / a concurrent TTS


### PR DESCRIPTION
Fixes #1196.

The transcribe SSE endpoint ran its entire preflight (job lookup, ASR-missing check, eager backend load) before the StreamingResponse existed — so a first-run model download meant minutes of total byte-silence, and Chrome/reverse proxies killed the connection with the generic "stream dropped" guess; any preflight exception became an unreadable 500. The preflight now runs inside the guarded generator: headers + an open comment go out immediately, keepalive comments flow during loads (OMNIVOICE_ASR_LOAD_KEEPALIVE_S, default 15s), and preflight failures land as structured error + done events per the #516 terminal-event contract. Zero client changes, no new strings.

Regression tests fail-before/pass-after; full suite 3241 passed; empty-cache guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `/dub/transcribe-stream/{job_id}` SSE stream dropping during ASR preflight by moving job lookup, audio validation, optional TTS preload, ASR “missing model” detection, and ASR backend initialization inside the guarded streaming generator.
- When the `StreamingResponse` starts, the stream now immediately emits an opening SSE comment (`: transcribe-stream open`) so clients observe activity before long preflight work begins.
- Added periodic SSE keepalive comments while long ASR/TTS model loads are in-flight, using a configurable interval:
  - `OMNIVOICE_ASR_LOAD_KEEPALIVE_S` → `ASR_LOAD_KEEPALIVE_S` (default `15.0` seconds).
- Preflight failures no longer surface as an HTTP 500 / abrupt disconnect; instead the stream emits:
  - a structured in-stream SSE `error` event (with machine-readable payload where applicable), followed by
  - a terminal `done` event to reliably close the client-side stream.
- Updated preflight/async load handling to prevent orphaned-load exceptions from being missed after client disconnects (avoids unhandled task-exception noise while still surfacing real preflight failures when possible).
- Added integration tests covering:
  - preflight crash → structured `error` then terminal `done` (regression for drop issue),
  - slow ASR backend load → initial open comment + repeated keepalive comment bytes, then eventual preflight `error` + terminal `done`.

```mermaid
flowchart TD
  A[StreamingResponse starts] --> B[Emit ': transcribe-stream open']
  B --> C[Run guarded transcribe preflight inside stream]
  C -->|TTS load (if needed)| D[Emit ': tts-load keepalive' comments]
  C -->|ASR backend loading| E[Emit ': asr-load keepalive' comments at interval]
  C -->|Success| F[Stream transcription events]
  C -->|Preflight failure/crash| G[Emit structured SSE 'error' event]
  G --> H[Emit terminal 'done' event]
  E --> H
```
<!-- end of auto-generated comment: release notes by coderabbit.ai -->