### PR TITLE
review(1198 follow-up): non-blocking ASR unload on the normal completion path too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          choco install ffmpeg -y --no-progress
+          # The community chocolatey feed 504s intermittently (broke a PR run
+          # on 2026-07-20) — retry with backoff before failing the job.
+          for i in 1 2 3; do
+            choco install ffmpeg -y --no-progress && break
+            echo "choco attempt $i failed — retrying in $((i * 30))s"
+            sleep $((i * 30))
+          done
           ffmpeg -version
 
       - name: System deps (Linux)

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -1274,10 +1274,14 @@ async def dub_transcribe_stream(
         job["full_transcript"] = " ".join(s.get("text", "") for s in final_segs)
         _save_job(job_id, job)
 
-        # Restore TTS model to GPU now that ASR is done
+        # Restore TTS model to GPU now that ASR is done. unload() blocks
+        # (gc.collect + CUDA cache drop) — run it on the GPU pool so the
+        # event loop stays responsive; await it, because the TTS restore
+        # below must not contend with the ASR weights for VRAM
+        # (CodeRabbit review, #1198 — normal-completion half).
         if _asr_backend:
             try:
-                _asr_backend.unload()
+                await loop.run_in_executor(_gpu_pool, _asr_backend.unload)
             except Exception as e:
                 logger.warning("Failed to unload ASR backend: %s", e)
             # Unload attempted once — don't retry from gen()'s finally.


### PR DESCRIPTION
CodeRabbit's finding covered both unload sites; the harvest fixed only
gen()'s finally. The success path still blocked the event loop for the
gc/CUDA-cache drop on every completed transcription.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription stream responsiveness by offloading speech-recognition model cleanup from the active streaming path.
  * Ensured cleanup failures behave consistently and prevent repeated unload attempts.

* **Chores / CI**
  * Enhanced the Windows smoke-test dependency setup by installing ffmpeg with a retry loop and incremental backoff, including clearer logs for failed attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->