### PR TITLE
fix(wizard): keep Continue pinned — scroll the models list, not the page

### DIFF
--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -228,8 +228,9 @@ export default function SetupWizard({ onReady }) {
 
   // Whether to insert the analytics consent step. Resolved once at mount
   // (the user is on step 0 when this lands, so indices never shift underfoot):
-  // only when the build CAN send (token baked in) and the user was never
-  // asked. Source builds have no destination — asking would be dishonest.
+  // only when the build CAN send and the user was never asked. Since #1193
+  // every build has a destination (in-repo default token), so source builds
+  // get this same ask; skipping the wizard still means analytics stays off.
   const [askConsent, setAskConsent] = useState(false);
   useEffect(() => {
     let cancelled = false;
@@ -379,7 +380,12 @@ export default function SetupWizard({ onReady }) {
               style={{ '--rise': 1 }}
             >
               <SectionHead>{t('firstrun.stage_models', 'Models & engines')}</SectionHead>
-              <WizardLibrary />
+              {/* The list scrolls; the Continue footer below stays pinned —
+                  same pattern as the System step. Without this clamp the
+                  curated rows push the footer below the viewport. */}
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <WizardLibrary />
+              </div>
               {!modelsReady && status?.missing?.length > 0 && (
                 <p className="m-0 text-xs leading-snug text-warn">
                   {t('setup.still_needed')} {status.missing.map((m) => m.label).join(', ')}


### PR DESCRIPTION
The curated model rows made the Models & engines step taller than the
viewport; the step's list section lacked the overflow-y-auto clamp the
System step already has, so the pinned footer (Back/Continue) was pushed
offscreen. The list now scrolls; Continue stays visible, disabled until
required models install.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the setup wizard’s models and engines step with a scrollable list, keeping the Continue area visible while browsing options.

* **Documentation**
  * Clarified internal guidance for displaying the one-time analytics consent step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->