### PR TITLE
feat(dub): paste a translation from an external source onto existing segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - `OMNIVOICE_TRUSTED_NETWORKS` — comma-separated CIDRs exempted from the consumption auth gates (share PIN / API key / dictation WS); admin routes stay loopback-only (#1170)
 - Info/warn system notifications are dismissible and stay dismissed across restarts; error-level notices can't be dismissed, and the unclean-shutdown notice is now acknowledged server-side — thanks @agudmund! (#1192)
 - `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` — thanks @paoloantinori! (#1194)
-- Dub tab: **Paste Translation** — paste a translation made elsewhere (ChatGPT, DeepL, a human) as subtitles, numbered lines, or plain lines; it maps onto the existing segments with a before→after preview, keeping timings and the source transcript intact (#1202)
+- Dub tab: **Paste Translation** — paste a translation made elsewhere (ChatGPT, DeepL, a human) as subtitles, numbered lines, or plain lines; it maps onto the existing segments with a before→after preview, keeping timings and the source transcript intact (#1203)
 
 ### CI
 
@@ -50,7 +50,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- Subtitle parsing no longer stalls on a blank-line-heavy `.srt`: the timing-line regex backtracked across newlines, so a mis-saved export could pin an import for hours (#1202)
+- Subtitle parsing no longer stalls on a blank-line-heavy `.srt`: the timing-line regex backtracked across newlines, so a mis-saved export could pin an import for hours (#1203)
 - A broken ASR engine's fallback could silently auto-download multi-GB weights — every fallback now passes the same no-download preflight and shows the download CTA instead (#1189)
 - Dub transcription releases the ASR model from VRAM on every exit — crashes, early errors, and client disconnects included (#1175)
 - An invalid dictation model override could bypass the missing-model check for the Whisper fallback (#1175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - `OMNIVOICE_TRUSTED_NETWORKS` — comma-separated CIDRs exempted from the consumption auth gates (share PIN / API key / dictation WS); admin routes stay loopback-only (#1170)
 - Info/warn system notifications are dismissible and stay dismissed across restarts; error-level notices can't be dismissed, and the unclean-shutdown notice is now acknowledged server-side — thanks @agudmund! (#1192)
 - `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` — thanks @paoloantinori! (#1194)
+- Dub tab: **Paste Translation** — paste a translation made elsewhere (ChatGPT, DeepL, a human) as subtitles, numbered lines, or plain lines; it maps onto the existing segments with a before→after preview, keeping timings and the source transcript intact (#1202)
 
 ### CI
 
@@ -49,6 +50,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Subtitle parsing no longer stalls on a blank-line-heavy `.srt`: the timing-line regex backtracked across newlines, so a mis-saved export could pin an import for hours (#1202)
 - A broken ASR engine's fallback could silently auto-download multi-GB weights — every fallback now passes the same no-download preflight and shows the download CTA instead (#1189)
 - Dub transcription releases the ASR model from VRAM on every exit — crashes, early errors, and client disconnects included (#1175)
 - An invalid dictation model override could bypass the missing-model check for the Whisper fallback (#1175)

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Ships two [skills](https://skills.sh): **`omnivoice`** — speak and transcribe 
 | Category | Features |
 |----------|----------|
 | **Longform** | Audiobook editor (text/EPUB/PDF → chaptered .m4b), Stories multi-voice editor, two-pass loudnorm mastering, crash-resume for interrupted renders, pronunciation control + SSML-lite prosody |
-| **Dubbing** | Full pipeline (transcribe→translate→synthesize→mux), scene-aware splitting, lip-sync scoring, streaming TTS, per-speaker voice assignment, Smart Fit timing + second-pass QC, dedicated Dub home |
+| **Dubbing** | Full pipeline (transcribe→translate→synthesize→mux), scene-aware splitting, lip-sync scoring, streaming TTS, per-speaker voice assignment, Smart Fit timing + second-pass QC, paste-in translations from any external tool, dedicated Dub home |
 | **Voice** | Zero-shot cloning, voice design, A/B comparison, voice preview widget, gallery with favorites/tags, portable persona bundles (`.ovsvoice`), voice console workspace |
 | **Audio** | Demucs vocal isolation, per-segment gain, selective track export, stem/SRT/VTT/MP3 export, unlimited-length TTS via sentence-chunked generation |
 | **Multi-Lang** | Multi-language batch picker, batch dubbing queue with sequential GPU execution |

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -14,7 +14,7 @@ from core.db import db_conn
 from core.config import PREVIEW_DIR
 from core.tasks import task_manager
 from core import event_bus
-from schemas.requests import DubIngestUrlRequest
+from schemas.requests import DubIngestUrlRequest, ParseSubtitleTextRequest
 from services.model_manager import get_model, _gpu_pool, _cpu_pool, get_diarization_pipeline, offload_tts_for_asr, restore_tts_after_asr, should_preload_tts_asr
 from services.asr_backend import (
     ASR_TRANSCRIBE_TIMEOUT_S,
@@ -62,6 +62,55 @@ _unregister_proc   = dub_pipeline.unregister_proc
 _kill_job_procs    = dub_pipeline.kill_job_procs
 _get_job           = dub_pipeline.get_job
 _save_job          = dub_pipeline.save_job
+
+# Pasted subtitle text is a transcript, not a media file: a feature-length
+# film's .srt is ~150 KB. 2 MB of characters is ~13x the worst realistic case
+# and still cheap to regex — past that we refuse rather than let a stray
+# paste (or a mis-aimed binary) burn CPU in the parser.
+_MAX_SUBTITLE_PASTE_CHARS = 2_000_000
+
+
+@router.post("/dub/parse-subtitle-text")
+def dub_parse_subtitle_text(req: ParseSubtitleTextRequest):
+    """Parse pasted subtitle text into timed cues. Stateless — no job, no I/O.
+
+    A thin wrapper over `services.srt_parser.parse_srt` so the client's
+    "paste a translation" flow reuses the exact lenient parser the .srt
+    import path uses (BOM / CRLF / `.`-vs-`,` ms / missing indices, plus
+    de-overlapping). Unlike `/dub/import-srt/{job_id}` this mutates
+    nothing: the caller maps these cues onto the segments it already has,
+    keeping the existing timings and `text_original`.
+    """
+    text = req.text or ""
+    if len(text) > _MAX_SUBTITLE_PASTE_CHARS:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Pasted text is too large ({len(text)} characters). "
+                f"Limit is {_MAX_SUBTITLE_PASTE_CHARS} characters."
+            ),
+        )
+
+    from services.srt_parser import parse_srt
+    result = parse_srt(text)
+    if not result.segments:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No timed cues found in the pasted text. "
+                f"Skipped {result.skipped_cues} malformed cue(s). "
+                "Expected timestamp lines like '00:00:01,000 --> 00:00:04,500'."
+            ),
+        )
+    return {
+        "segments": [
+            {"start": s["start"], "end": s["end"], "text": s["text"]}
+            for s in result.segments
+        ],
+        "skipped_cues": result.skipped_cues,
+        "dropped_overlaps": result.dropped_overlaps,
+    }
+
 
 @router.post("/dub/import-srt/{job_id}")
 async def dub_import_srt(job_id: str, file: UploadFile = File(...)):

--- a/backend/schemas/requests.py
+++ b/backend/schemas/requests.py
@@ -175,6 +175,18 @@ class TranslateRequest(BaseModel):
     # No LLM configured / LLM failure → silently no suggestion.
     condense: Optional[bool] = False
 
+class ParseSubtitleTextRequest(BaseModel):
+    """Raw pasted subtitle text (SRT/VTT-ish) to be parsed into timed cues.
+
+    Used by the "paste translation from an external source" flow: the user
+    pastes what ChatGPT/DeepL/a human gave them and the client needs the
+    SAME lenient cue parsing the .srt import path uses — parsing it here
+    keeps `services.srt_parser` the single source of truth instead of
+    growing a second, subtly-different implementation in JavaScript.
+    """
+    text: str
+
+
 class DubIngestUrlRequest(BaseModel):
     url: str
     job_id: Optional[str] = None

--- a/backend/services/srt_parser.py
+++ b/backend/services/srt_parser.py
@@ -25,9 +25,17 @@ from dataclasses import dataclass
 
 # Captures: HH MM SS sep(`,` or `.`) ms (1-3 digits)
 _TS = r"(\d{1,2}):([0-5]?\d):([0-5]?\d)[,.](\d{1,3})"
+# Horizontal whitespace only — NEVER plain `\s`, which matches newlines.
+# A timing line lives on ONE line, so `\s*` bought nothing but catastrophic
+# backtracking: under re.MULTILINE the engine restarts at every line start,
+# and `^\s*` there happily consumes every remaining blank line before
+# failing on the first digit, making the scan quadratic in the input size.
+# A .srt of blank lines (a mis-saved export, a paste gone wrong) pinned the
+# parse for hours — 20k blank lines already took 1.7s, 2 MB never returned.
+_H = r"[^\S\n]*"
 # Whole timing line: `00:00:01,000 --> 00:00:04,500` plus optional trailing
 # cue style hints (X1: Y1: ... ) we just throw away.
-_TIMING_RE = re.compile(rf"^\s*{_TS}\s*-->\s*{_TS}.*$", re.MULTILINE)
+_TIMING_RE = re.compile(rf"^{_H}{_TS}{_H}-->{_H}{_TS}.*$", re.MULTILINE)
 
 
 def _ts_to_seconds(h: str, m: str, s: str, ms: str) -> float:

--- a/docs/dubbing/translation-engines.md
+++ b/docs/dubbing/translation-engines.md
@@ -21,6 +21,35 @@ backend returns a single, actionable error telling you exactly what to install
 (the install command is single-sourced, so the button and the error never
 disagree).
 
+## Bring your own translation (Paste Translation)
+
+You don't have to use any of these engines. If you already translated the
+transcript somewhere else — ChatGPT, DeepL's website, a human translator — click
+**Paste Translation** above the segment table and paste the result. It maps onto
+the segments you already have: **no re-transcription, no timing loss**, and the
+original transcript (`text_original`) is left alone so a later *Translate All*
+still works from the source text.
+
+Three input shapes are auto-detected:
+
+| Shape | Looks like | Mapped by |
+|-------|-----------|-----------|
+| **Timestamped** | a full `.srt` / `.vtt` | time overlap with your segments |
+| **Numbered lines** | `1. …` / `2) …` / `[3] …` | the line number (falls back to order if a model renumbers) |
+| **Plain lines** | one translated line per segment | position; blank lines are separators, never empty translations |
+
+You can also drop (or pick) a `.srt`/`.vtt` file straight into the dialog.
+
+Nothing is applied until you confirm: the dialog previews every row as
+before → after, flags rows nothing matched, and counts how many pasted lines
+went unused. **Apply** is disabled only when *nothing* matched, unmatched rows
+are left exactly as they were, and the whole paste is a single undo step. The
+rows you changed are marked stale for regeneration automatically, so a
+**Regen N changed** pass re-speaks just those lines.
+
+This writes only the **currently selected** target language, so you can paste a
+different external translation per language tab without disturbing the others.
+
 ## Installing optional translation engines (from-source vs packaged build)
 
 How you add an engine depends on **how you installed OmniVoice**.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -460,6 +460,7 @@ function App() {
     segmentEditField,
     segmentDelete,
     segmentRestoreOriginal,
+    pasteTranslations,
     segmentSplit,
     segmentMerge,
     segmentMoveResize,
@@ -1575,6 +1576,7 @@ function App() {
                     segmentEditField={segmentEditField}
                     segmentDelete={segmentDelete}
                     segmentRestoreOriginal={segmentRestoreOriginal}
+                    pasteTranslations={pasteTranslations}
                     segmentSplit={segmentSplit}
                     segmentMerge={segmentMerge}
                     segmentMoveResize={segmentMoveResize}

--- a/frontend/src/api/dub.ts
+++ b/frontend/src/api/dub.ts
@@ -87,6 +87,29 @@ export async function dubImportSrt(
   return apiPost<DubImportSrtResponse>(`/dub/import-srt/${jobId}`, fd);
 }
 
+export interface ParsedSubtitleCue {
+  start: number;
+  end: number;
+  text: string;
+}
+
+export interface ParseSubtitleTextResponse {
+  segments: ParsedSubtitleCue[];
+  skipped_cues: number;
+  dropped_overlaps: number;
+}
+
+/**
+ * Parse pasted subtitle text (SRT/VTT-ish) into timed cues.
+ *
+ * Stateless: unlike `dubImportSrt` this touches no job and replaces no
+ * segments — it exists so the "paste a translation" flow reuses the
+ * backend's lenient cue parser instead of reimplementing it in JS.
+ */
+export async function dubParseSubtitleText(text: string): Promise<ParseSubtitleTextResponse> {
+  return apiPost<ParseSubtitleTextResponse>('/dub/parse-subtitle-text', { text });
+}
+
 export async function dubTranslate(body: Record<string, unknown>): Promise<DubTranslateResponse> {
   return apiPost<DubTranslateResponse>('/dub/translate', body);
 }

--- a/frontend/src/components/dub/DubPasteTranslationDialog.jsx
+++ b/frontend/src/components/dub/DubPasteTranslationDialog.jsx
@@ -150,11 +150,17 @@ export default function DubPasteTranslationDialog({ open, segments = [], onApply
           className="flex items-center gap-[6px] px-[10px] py-[4px] rounded-[6px] cursor-pointer text-[length:var(--text-xs)] text-fg-muted bg-[rgba(255,255,255,0.05)] [border:1px_solid_rgba(255,255,255,0.1)]"
         >
           <FileText size={11} /> {t('dub.paste_translation_load_file')}
+          {/* `sr-only`, never `hidden`: a bare <label> isn't in the tab order,
+              and `hidden` drops the input from both the tab order and the
+              accessibility tree — together they leave keyboard-only users with
+              no way to reach the file picker at all. Visually hidden but
+              focusable keeps the pointer affordance and restores the keyboard
+              path (focus the input, Enter/Space opens the picker). */}
           <input
             id="paste-translation-file"
             type="file"
             accept=".srt,.vtt,.txt,text/plain"
-            hidden
+            className="sr-only"
             onChange={(e) => {
               readFile(e.target.files?.[0]);
               e.target.value = '';

--- a/frontend/src/components/dub/DubPasteTranslationDialog.jsx
+++ b/frontend/src/components/dub/DubPasteTranslationDialog.jsx
@@ -1,0 +1,247 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ClipboardPaste, FileText, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, Button, Textarea, Badge } from '../../ui';
+import { buildPastePlan, detectPasteMode } from '../../utils/pasteTranslations';
+import { dubParseSubtitleText } from '../../api/dub';
+
+/**
+ * DubPasteTranslationDialog — paste a translation produced somewhere else
+ * (ChatGPT, DeepL, a human translator) onto the segments that already exist.
+ *
+ * Nothing is applied until the user has seen the full before→after mapping:
+ * a wrong-by-one paste over a 400-line transcript is expensive to notice
+ * later and annoying to undo row by row. Unmatched rows are shown as such
+ * rather than being quietly filled with the neighbouring line.
+ *
+ * `onApply(text, { mode, cues })` re-derives the identical plan through
+ * `pasteTranslations`, so applying goes through the normal undo stack.
+ */
+const MODE_ICON = { timestamped: FileText, numbered: ClipboardPaste, plain: ClipboardPaste };
+
+// A feature-length transcript runs to thousands of rows; mounting all of them
+// in a 280px scroll box just to preview costs more than it informs. Show a
+// window and say how many are hidden — the count banner above already carries
+// the totals the decision actually rests on.
+const PREVIEW_ROW_LIMIT = 200;
+
+export default function DubPasteTranslationDialog({ open, segments = [], onApply, onClose }) {
+  const { t } = useTranslation();
+  const [text, setText] = useState('');
+  const [cues, setCues] = useState(null);
+  const [parsing, setParsing] = useState(false);
+  const [parseError, setParseError] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      setText('');
+      setCues(null);
+      setParseError(null);
+    }
+  }, [open]);
+
+  const mode = useMemo(() => detectPasteMode(text), [text]);
+
+  // Timestamped pastes need the backend's lenient cue parser before a plan
+  // can exist. Debounced so a long paste isn't re-parsed on every keystroke.
+  useEffect(() => {
+    if (!open || mode !== 'timestamped' || !text.trim()) {
+      setCues(null);
+      setParseError(null);
+      setParsing(false);
+      return undefined;
+    }
+    let cancelled = false;
+    // Drop the previous parse the moment the text changes: keeping it would
+    // let the preview — and an eager Apply during the debounce window — run
+    // against cues from text the user has already edited away.
+    setCues(null);
+    setParseError(null);
+    setParsing(true);
+    const timer = setTimeout(() => {
+      dubParseSubtitleText(text)
+        .then((res) => {
+          if (cancelled) return;
+          setCues(res.segments || []);
+          setParseError(null);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          setCues([]);
+          setParseError(e?.message || String(e));
+        })
+        .finally(() => {
+          if (!cancelled) setParsing(false);
+        });
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [open, mode, text]);
+
+  const plan = useMemo(() => {
+    if (!text.trim()) return null;
+    if (mode === 'timestamped' && cues === null) return null;
+    return buildPastePlan(text, segments, { mode, cues: cues || [] });
+  }, [text, segments, mode, cues]);
+
+  const readFile = useCallback((file) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setText(String(reader.result || ''));
+    reader.readAsText(file);
+  }, []);
+
+  const apply = () => {
+    onApply?.(text, { mode, cues: cues || [] });
+    onClose?.();
+  };
+
+  if (!open) return null;
+
+  const ModeIcon = MODE_ICON[mode] || ClipboardPaste;
+  const canApply = !!plan && plan.matchedCount > 0;
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      size="lg"
+      title={
+        <>
+          <ClipboardPaste size={14} /> {t('dub.paste_translation_title')}
+        </>
+      }
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>
+            {t('dub.paste_translation_cancel')}
+          </Button>
+          <Button variant="primary" onClick={apply} disabled={!canApply} loading={parsing}>
+            {t('dub.paste_translation_apply', { count: plan?.matchedCount || 0 })}
+          </Button>
+        </>
+      }
+    >
+      <p className="text-[length:var(--text-xs)] text-fg-muted mb-[var(--space-3)]">
+        {t('dub.paste_translation_desc')}
+      </p>
+
+      <Textarea
+        rows={7}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={t('dub.paste_translation_placeholder')}
+        aria-label={t('dub.paste_translation_title')}
+        autoFocus
+        onDrop={(e) => {
+          const file = e.dataTransfer?.files?.[0];
+          if (file) {
+            e.preventDefault();
+            readFile(file);
+          }
+        }}
+      />
+
+      <div className="flex items-center gap-[var(--space-3)] mt-[var(--space-3)] flex-wrap">
+        <label
+          htmlFor="paste-translation-file"
+          className="flex items-center gap-[6px] px-[10px] py-[4px] rounded-[6px] cursor-pointer text-[length:var(--text-xs)] text-fg-muted bg-[rgba(255,255,255,0.05)] [border:1px_solid_rgba(255,255,255,0.1)]"
+        >
+          <FileText size={11} /> {t('dub.paste_translation_load_file')}
+          <input
+            id="paste-translation-file"
+            type="file"
+            accept=".srt,.vtt,.txt,text/plain"
+            hidden
+            onChange={(e) => {
+              readFile(e.target.files?.[0]);
+              e.target.value = '';
+            }}
+          />
+        </label>
+        {!!text.trim() && (
+          <Badge tone="neutral" size="xs">
+            <ModeIcon size={10} /> {t(`dub.paste_translation_mode_${mode}`)}
+          </Badge>
+        )}
+      </div>
+
+      {parseError && (
+        <div
+          role="alert"
+          data-testid="paste-translation-error"
+          className="flex items-center gap-[6px] mt-[var(--space-3)] text-[length:var(--text-xs)] text-[#fb4934]"
+        >
+          <AlertTriangle size={11} /> {parseError}
+        </div>
+      )}
+
+      {plan && (
+        <>
+          <div
+            className="mt-[var(--space-4)] px-[var(--space-3)] py-[6px] rounded-[var(--radius-md)] text-[length:var(--text-xs)] bg-[rgba(255,255,255,0.03)] [border:1px_solid_rgba(255,255,255,0.06)]"
+            data-testid="paste-translation-summary"
+          >
+            {t('dub.paste_translation_counts', {
+              segments: plan.rows.length,
+              lines: plan.sourceCount,
+              unmatched: plan.unmatchedCount,
+            })}
+            {plan.unusedCount > 0 && (
+              <span className="text-[#fabd2f] ml-[var(--space-2)]">
+                {t('dub.paste_translation_unused', { count: plan.unusedCount })}
+              </span>
+            )}
+          </div>
+
+          {plan.matchedCount === 0 && (
+            <div
+              role="alert"
+              className="flex items-center gap-[6px] mt-[var(--space-2)] text-[length:var(--text-xs)] text-[#fb4934]"
+            >
+              <AlertTriangle size={11} /> {t('dub.paste_translation_none_matched')}
+            </div>
+          )}
+
+          <div className="mt-[var(--space-3)] max-h-[280px] overflow-y-auto [border:1px_solid_var(--chrome-border)] rounded-[var(--radius-md)]">
+            {plan.rows.slice(0, PREVIEW_ROW_LIMIT).map((row) => (
+              <div
+                key={row.id}
+                data-testid="paste-translation-row"
+                data-matched={row.matched ? 'true' : 'false'}
+                className={`flex gap-[var(--space-3)] px-[var(--space-3)] py-[4px] text-[length:var(--text-xs)] [border-bottom:1px_solid_var(--chrome-border)] ${
+                  row.matched ? '' : 'bg-[rgba(251,73,52,0.06)]'
+                }`}
+              >
+                <span className="w-[28px] shrink-0 text-fg-muted font-[family-name:var(--chrome-font-mono)]">
+                  {row.index + 1}
+                </span>
+                <span className="flex-1 min-w-0 text-fg-muted line-through decoration-[rgba(255,255,255,0.25)]">
+                  {row.before || '—'}
+                </span>
+                <span className="flex-1 min-w-0 text-fg">
+                  {row.matched ? (
+                    row.after
+                  ) : (
+                    <em className="text-[#fb4934] not-italic">
+                      {t('dub.paste_translation_row_unmatched')}
+                    </em>
+                  )}
+                </span>
+              </div>
+            ))}
+            {plan.rows.length > PREVIEW_ROW_LIMIT && (
+              <div className="px-[var(--space-3)] py-[6px] text-[length:var(--text-xs)] text-fg-muted text-center">
+                {t('dub.paste_translation_more_rows', {
+                  count: plan.rows.length - PREVIEW_ROW_LIMIT,
+                })}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </Dialog>
+  );
+}

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -1,11 +1,12 @@
-import { Suspense, lazy } from 'react';
-import { ChevronUp, ChevronDown, FileText } from 'lucide-react';
+import { Suspense, lazy, useState } from 'react';
+import { ChevronUp, ChevronDown, FileText, ClipboardPaste } from 'lucide-react';
 import { Button, Segmented } from '../../ui';
 import GlossaryPanel from '../GlossaryPanel';
 import CheckpointBanner from '../CheckpointBanner';
 import { LANG_CODES } from '../../utils/languages';
 
 const DubSegmentTable = lazy(() => import('../DubSegmentTable'));
+const DubPasteTranslationDialog = lazy(() => import('./DubPasteTranslationDialog'));
 
 const LazyFallback = () => <div className="p-[12px] text-[#6b6657] text-[0.7rem]">Loading…</div>;
 
@@ -71,7 +72,9 @@ export default function DubRightColumn({
   timelineSelSegId,
   dubStep,
   dubProgress,
+  pasteTranslations,
 }) {
+  const [pasteOpen, setPasteOpen] = useState(false);
   return (
     <div className="studio-panel dub-panel-col">
       {/* Output options + timing — moved to the top of the right section. */}
@@ -323,6 +326,34 @@ export default function DubRightColumn({
           onDismiss={onCheckpointDismiss}
           continueLoading={isTranslating}
         />
+      )}
+
+      {/* Segment-table toolbar. "Paste translation" is the manual counterpart
+          to Translate All: the user translated elsewhere (ChatGPT/DeepL/a
+          human) and pastes the result onto the timing we already have. */}
+      {pasteTranslations && (
+        <div className="flex items-center justify-end mb-[4px]">
+          <Button
+            variant="subtle"
+            size="sm"
+            onClick={() => setPasteOpen(true)}
+            disabled={!dubSegments.length}
+            title={t('dub.paste_translation_title')}
+            leading={<ClipboardPaste size={10} />}
+          >
+            {t('dub.paste_translation_btn')}
+          </Button>
+        </div>
+      )}
+      {pasteOpen && (
+        <Suspense fallback={null}>
+          <DubPasteTranslationDialog
+            open
+            segments={dubSegments}
+            onApply={pasteTranslations}
+            onClose={() => setPasteOpen(false)}
+          />
+        </Suspense>
       )}
 
       <Suspense fallback={<LazyFallback />}>

--- a/frontend/src/hooks/useSegmentEditing.js
+++ b/frontend/src/hooks/useSegmentEditing.js
@@ -10,6 +10,7 @@ import { askConfirm } from '../utils/dialog';
 import { apiPost } from '../api/client';
 import { segmentGenInputs } from '../utils/segments';
 import { commitMoveResize } from '../utils/timeline';
+import { buildPastePlan } from '../utils/pasteTranslations';
 
 // Stable empty map so `lastGenFingerprints` keeps a constant identity for a
 // language with no stored hashes (avoids effect/callback churn).
@@ -130,6 +131,46 @@ export default function useSegmentEditing() {
           };
         }),
       );
+    },
+    [dubSegments],
+  );
+
+  // Paste a translation produced outside the app (ChatGPT / DeepL / a human)
+  // onto the EXISTING segments. Same three duties as `segmentEditField`, run
+  // across every matched row in one undo step:
+  //   1. push undo   2. write `text` AND `translations[lang]` in lock-step
+  //   3. clear the machine-translation badges the new words invalidate
+  // and the same two prohibitions: `text_original` is never touched (it is
+  // `handleTranslateAll`'s translate source — overwriting it would poison
+  // every later re-translate), and no language other than the ACTIVE
+  // `dubLangCode` is written. Changed `text` alone marks those segments
+  // stale for regeneration via the existing per-language fingerprints
+  // (services/incremental.py) — no extra flag needed.
+  //
+  // Mapping lives in utils/pasteTranslations so the preview dialog and this
+  // applier derive an identical plan; unmatched rows are left exactly as
+  // they were.
+  const pasteTranslations = useCallback(
+    (text, opts = {}) => {
+      const plan = buildPastePlan(text, dubSegments, opts);
+      const byId = new Map(plan.rows.filter((r) => r.matched).map((r) => [String(r.id), r.after]));
+      if (!byId.size) return plan;
+      pushUndo(dubSegments);
+      const lang = useAppStore.getState().dubLangCode;
+      setDubSegments((prev) =>
+        prev.map((s) => {
+          const next = byId.get(String(s.id));
+          if (next === undefined) return s;
+          return {
+            ...s,
+            text: next,
+            ...(lang ? { translations: { ...s.translations, [lang]: next } } : {}),
+            translate_error: undefined,
+            translate_degraded: undefined,
+          };
+        }),
+      );
+      return plan;
     },
     [dubSegments],
   );
@@ -335,6 +376,7 @@ export default function useSegmentEditing() {
     segmentEditField,
     segmentDelete,
     segmentRestoreOriginal,
+    pasteTranslations,
     segmentSplit,
     segmentMerge,
     segmentMoveResize,

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -878,7 +878,22 @@
     "qc_running": "جارٍ التحقق من توقيت الدبلجة…",
     "qc_result": "{{flagged}} من {{total}} قد تحتاج الأسطر إلى إعادة الاستماع",
     "qc_clean": "جميع أسطر {{total}} تتطابق مع النص",
-    "qc_failed": "فشل التحقق من التوقيت: {{message}}"
+    "qc_failed": "فشل التحقق من التوقيت: {{message}}",
+    "paste_translation_btn": "لصق ترجمة",
+    "paste_translation_title": "لصق ترجمة",
+    "paste_translation_desc": "الصق ترجمة أعددتها في مكان آخر (ChatGPT أو DeepL أو مترجم بشري). ستُطابَق مع المقاطع الموجودة لديك — تبقى التوقيتات والنص الأصلي دون تغيير.",
+    "paste_translation_placeholder": "الصق ترجمات (SRT/VTT) أو أسطرًا مرقّمة (1. …) أو سطرًا مترجمًا لكل مقطع — أو أفلت ملف ‎.srt/.vtt هنا.",
+    "paste_translation_load_file": "تحميل ملف ‎.srt / .vtt",
+    "paste_translation_mode_timestamped": "بتوقيتات (SRT/VTT)",
+    "paste_translation_mode_numbered": "أسطر مرقّمة",
+    "paste_translation_mode_plain": "أسطر عادية",
+    "paste_translation_counts": "{{segments}} مقاطع · {{lines}} أسطر · {{unmatched}} بلا مطابقة",
+    "paste_translation_unused": "عدد الأسطر الملصقة غير المستخدمة: {{count}}",
+    "paste_translation_none_matched": "لا توجد أي مطابقة. تحقّق من أن النص الملصوق يوافق المقاطع أدناه.",
+    "paste_translation_row_unmatched": "لا مطابقة — دون تغيير",
+    "paste_translation_apply": "تطبيق على {{count}} مقاطع",
+    "paste_translation_cancel": "إلغاء",
+    "paste_translation_more_rows": "+ {{count}} صفوف إضافية"
   },
   "glossary": {
     "title": "مسرد",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -878,7 +878,22 @@
     "qc_running": "Dub-Timing wird überprüft…",
     "qc_result": "{{flagged}} von {{total}} Zeilen müssen möglicherweise erneut abgehört werden",
     "qc_clean": "Alle {{total}}-Zeilen stimmen mit dem Skript überein",
-    "qc_failed": "Zeitprüfung fehlgeschlagen: {{message}}"
+    "qc_failed": "Zeitprüfung fehlgeschlagen: {{message}}",
+    "paste_translation_btn": "Übersetzung einfügen",
+    "paste_translation_title": "Übersetzung einfügen",
+    "paste_translation_desc": "Füge eine anderswo erstellte Übersetzung ein (ChatGPT, DeepL, ein menschlicher Übersetzer). Sie wird den vorhandenen Segmenten zugeordnet — Timings und Originaltranskript bleiben unverändert.",
+    "paste_translation_placeholder": "Untertitel (SRT/VTT), nummerierte Zeilen (1. …) oder eine übersetzte Zeile pro Segment einfügen — oder eine .srt/.vtt-Datei hier ablegen.",
+    "paste_translation_load_file": ".srt-/.vtt-Datei laden",
+    "paste_translation_mode_timestamped": "Mit Zeitstempeln (SRT/VTT)",
+    "paste_translation_mode_numbered": "Nummerierte Zeilen",
+    "paste_translation_mode_plain": "Einfache Zeilen",
+    "paste_translation_counts": "{{segments}} Segmente · {{lines}} Zeilen · {{unmatched}} ohne Zuordnung",
+    "paste_translation_unused": "{{count}} eingefügte Zeile(n) blieben ungenutzt",
+    "paste_translation_none_matched": "Keine Zuordnung gefunden. Prüfe, ob der eingefügte Text zu den Segmenten unten passt.",
+    "paste_translation_row_unmatched": "keine Zuordnung — unverändert",
+    "paste_translation_apply": "Auf {{count}} Segmente anwenden",
+    "paste_translation_cancel": "Abbrechen",
+    "paste_translation_more_rows": "+ {{count}} weitere Zeilen"
   },
   "glossary": {
     "title": "Glossar",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1131,7 +1131,22 @@
     "pipeline": "Dubbing pipeline",
     "preview_language": "Preview language",
     "target_language": "Dub into",
-    "transcript_after_extract": "Transcript appears after extraction."
+    "transcript_after_extract": "Transcript appears after extraction.",
+    "paste_translation_btn": "Paste Translation",
+    "paste_translation_title": "Paste a translation",
+    "paste_translation_desc": "Paste a translation you produced elsewhere (ChatGPT, DeepL, a human translator). It maps onto the segments you already have — timings and the original transcript stay untouched.",
+    "paste_translation_placeholder": "Paste subtitles (SRT/VTT), numbered lines (1. …), or one translated line per segment — or drop a .srt/.vtt file here.",
+    "paste_translation_load_file": "Load .srt / .vtt file",
+    "paste_translation_mode_timestamped": "Timestamped (SRT/VTT)",
+    "paste_translation_mode_numbered": "Numbered lines",
+    "paste_translation_mode_plain": "Plain lines",
+    "paste_translation_counts": "{{segments}} segments · {{lines}} lines · {{unmatched}} unmatched",
+    "paste_translation_unused": "{{count}} pasted line(s) went unused",
+    "paste_translation_none_matched": "Nothing matched. Check that the pasted text lines up with the segments below.",
+    "paste_translation_row_unmatched": "no match — left unchanged",
+    "paste_translation_apply": "Apply to {{count}} segments",
+    "paste_translation_cancel": "Cancel",
+    "paste_translation_more_rows": "+ {{count}} more rows"
   },
   "glossary": {
     "title": "Glossary",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -878,7 +878,22 @@
     "qc_running": "Comprobando el tiempo de doblaje...",
     "qc_result": "Es posible que sea necesario volver a escuchar {{flagged}} de {{total}} líneas",
     "qc_clean": "Todas las líneas {{total}} coinciden con el guión.",
-    "qc_failed": "Error en la verificación de tiempo: {{message}}"
+    "qc_failed": "Error en la verificación de tiempo: {{message}}",
+    "paste_translation_btn": "Pegar traducción",
+    "paste_translation_title": "Pegar una traducción",
+    "paste_translation_desc": "Pega una traducción hecha en otro sitio (ChatGPT, DeepL, un traductor humano). Se asigna a los segmentos que ya tienes: los tiempos y la transcripción original no cambian.",
+    "paste_translation_placeholder": "Pega subtítulos (SRT/VTT), líneas numeradas (1. …) o una línea traducida por segmento — o suelta aquí un archivo .srt/.vtt.",
+    "paste_translation_load_file": "Cargar archivo .srt / .vtt",
+    "paste_translation_mode_timestamped": "Con marcas de tiempo (SRT/VTT)",
+    "paste_translation_mode_numbered": "Líneas numeradas",
+    "paste_translation_mode_plain": "Líneas simples",
+    "paste_translation_counts": "{{segments}} segmentos · {{lines}} líneas · {{unmatched}} sin coincidencia",
+    "paste_translation_unused": "{{count}} línea(s) pegada(s) sin usar",
+    "paste_translation_none_matched": "No hubo ninguna coincidencia. Comprueba que el texto pegado se corresponda con los segmentos de abajo.",
+    "paste_translation_row_unmatched": "sin coincidencia — sin cambios",
+    "paste_translation_apply": "Aplicar a {{count}} segmentos",
+    "paste_translation_cancel": "Cancelar",
+    "paste_translation_more_rows": "+ {{count}} filas más"
   },
   "glossary": {
     "title": "Glosario",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -878,7 +878,22 @@
     "qc_running": "Vérification du timing de doublage…",
     "qc_result": "{{flagged}} lignes sur {{total}} peuvent nécessiter une réécoute",
     "qc_clean": "Toutes les lignes {{total}} correspondent au script",
-    "qc_failed": "Échec de la vérification du timing : {{message}}"
+    "qc_failed": "Échec de la vérification du timing : {{message}}",
+    "paste_translation_btn": "Coller une traduction",
+    "paste_translation_title": "Coller une traduction",
+    "paste_translation_desc": "Collez une traduction réalisée ailleurs (ChatGPT, DeepL, un traducteur humain). Elle est appliquée aux segments existants — les timings et la transcription d'origine restent intacts.",
+    "paste_translation_placeholder": "Collez des sous-titres (SRT/VTT), des lignes numérotées (1. …) ou une ligne traduite par segment — ou déposez un fichier .srt/.vtt ici.",
+    "paste_translation_load_file": "Charger un fichier .srt / .vtt",
+    "paste_translation_mode_timestamped": "Horodaté (SRT/VTT)",
+    "paste_translation_mode_numbered": "Lignes numérotées",
+    "paste_translation_mode_plain": "Lignes simples",
+    "paste_translation_counts": "{{segments}} segments · {{lines}} lignes · {{unmatched}} sans correspondance",
+    "paste_translation_unused": "{{count}} ligne(s) collée(s) inutilisée(s)",
+    "paste_translation_none_matched": "Aucune correspondance. Vérifiez que le texte collé correspond aux segments ci-dessous.",
+    "paste_translation_row_unmatched": "aucune correspondance — inchangé",
+    "paste_translation_apply": "Appliquer à {{count}} segments",
+    "paste_translation_cancel": "Annuler",
+    "paste_translation_more_rows": "+ {{count}} lignes supplémentaires"
   },
   "glossary": {
     "title": "Glossaire",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -878,7 +878,22 @@
     "qc_running": "डब समय की जाँच की जा रही है...",
     "qc_result": "{{total}} पंक्तियों में से {{flagged}} को दोबारा सुनने की आवश्यकता हो सकती है",
     "qc_clean": "सभी {{total}} पंक्तियाँ स्क्रिप्ट से मेल खाती हैं",
-    "qc_failed": "समय की जाँच विफल: {{message}}"
+    "qc_failed": "समय की जाँच विफल: {{message}}",
+    "paste_translation_btn": "अनुवाद चिपकाएँ",
+    "paste_translation_title": "अनुवाद चिपकाएँ",
+    "paste_translation_desc": "कहीं और तैयार किया गया अनुवाद चिपकाएँ (ChatGPT, DeepL, कोई मानव अनुवादक)। यह आपके मौजूदा सेगमेंट पर लागू होगा — टाइमिंग और मूल ट्रांसक्रिप्ट अछूते रहते हैं।",
+    "paste_translation_placeholder": "सबटाइटल (SRT/VTT), क्रमांकित पंक्तियाँ (1. …), या प्रति सेगमेंट एक अनुवादित पंक्ति चिपकाएँ — या यहाँ .srt/.vtt फ़ाइल छोड़ें।",
+    "paste_translation_load_file": ".srt / .vtt फ़ाइल लोड करें",
+    "paste_translation_mode_timestamped": "टाइमस्टैम्प सहित (SRT/VTT)",
+    "paste_translation_mode_numbered": "क्रमांकित पंक्तियाँ",
+    "paste_translation_mode_plain": "सादी पंक्तियाँ",
+    "paste_translation_counts": "{{segments}} सेगमेंट · {{lines}} पंक्तियाँ · {{unmatched}} बिना मिलान",
+    "paste_translation_unused": "{{count}} चिपकाई गई पंक्तियाँ अप्रयुक्त रहीं",
+    "paste_translation_none_matched": "कुछ भी मेल नहीं खाया। जाँचें कि चिपकाया गया टेक्स्ट नीचे के सेगमेंट से मेल खाता है।",
+    "paste_translation_row_unmatched": "कोई मिलान नहीं — अपरिवर्तित",
+    "paste_translation_apply": "{{count}} सेगमेंट पर लागू करें",
+    "paste_translation_cancel": "रद्द करें",
+    "paste_translation_more_rows": "+ {{count}} और पंक्तियाँ"
   },
   "glossary": {
     "title": "शब्दावली",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -878,7 +878,22 @@
     "qc_running": "Memeriksa waktu sulih suara…",
     "qc_result": "{{flagged}} dari {{total}} baris mungkin perlu didengarkan ulang",
     "qc_clean": "Semua baris {{total}} cocok dengan skrip",
-    "qc_failed": "Pemeriksaan waktu gagal: {{message}}"
+    "qc_failed": "Pemeriksaan waktu gagal: {{message}}",
+    "paste_translation_btn": "Tempel terjemahan",
+    "paste_translation_title": "Tempel terjemahan",
+    "paste_translation_desc": "Tempel terjemahan yang kamu buat di tempat lain (ChatGPT, DeepL, penerjemah manusia). Terjemahan itu dipetakan ke segmen yang sudah ada — pewaktuan dan transkrip asli tidak diubah.",
+    "paste_translation_placeholder": "Tempel subtitle (SRT/VTT), baris bernomor (1. …), atau satu baris terjemahan per segmen — atau jatuhkan berkas .srt/.vtt di sini.",
+    "paste_translation_load_file": "Muat berkas .srt / .vtt",
+    "paste_translation_mode_timestamped": "Bertanda waktu (SRT/VTT)",
+    "paste_translation_mode_numbered": "Baris bernomor",
+    "paste_translation_mode_plain": "Baris biasa",
+    "paste_translation_counts": "{{segments}} segmen · {{lines}} baris · {{unmatched}} tanpa kecocokan",
+    "paste_translation_unused": "{{count}} baris tempelan tidak terpakai",
+    "paste_translation_none_matched": "Tidak ada yang cocok. Periksa apakah teks yang ditempel sejalan dengan segmen di bawah.",
+    "paste_translation_row_unmatched": "tidak cocok — tidak diubah",
+    "paste_translation_apply": "Terapkan ke {{count}} segmen",
+    "paste_translation_cancel": "Batal",
+    "paste_translation_more_rows": "+ {{count}} baris lagi"
   },
   "glossary": {
     "title": "Glosarium",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -878,7 +878,22 @@
     "qc_running": "Controllo dei tempi di duplicazione…",
     "qc_result": "{{flagged}} delle righe {{total}} potrebbe richiedere un nuovo ascolto",
     "qc_clean": "Tutte le righe {{total}} corrispondono allo script",
-    "qc_failed": "Controllo cronometraggio fallito: {{message}}"
+    "qc_failed": "Controllo cronometraggio fallito: {{message}}",
+    "paste_translation_btn": "Incolla traduzione",
+    "paste_translation_title": "Incolla una traduzione",
+    "paste_translation_desc": "Incolla una traduzione prodotta altrove (ChatGPT, DeepL, un traduttore umano). Viene mappata sui segmenti che hai già: tempi e trascrizione originale restano invariati.",
+    "paste_translation_placeholder": "Incolla sottotitoli (SRT/VTT), righe numerate (1. …) o una riga tradotta per segmento — oppure trascina qui un file .srt/.vtt.",
+    "paste_translation_load_file": "Carica file .srt / .vtt",
+    "paste_translation_mode_timestamped": "Con timecode (SRT/VTT)",
+    "paste_translation_mode_numbered": "Righe numerate",
+    "paste_translation_mode_plain": "Righe semplici",
+    "paste_translation_counts": "{{segments}} segmenti · {{lines}} righe · {{unmatched}} senza corrispondenza",
+    "paste_translation_unused": "{{count}} riga/e incollata/e non utilizzata/e",
+    "paste_translation_none_matched": "Nessuna corrispondenza. Verifica che il testo incollato corrisponda ai segmenti qui sotto.",
+    "paste_translation_row_unmatched": "nessuna corrispondenza — invariato",
+    "paste_translation_apply": "Applica a {{count}} segmenti",
+    "paste_translation_cancel": "Annulla",
+    "paste_translation_more_rows": "+ altre {{count}} righe"
   },
   "glossary": {
     "title": "Glossario",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -878,7 +878,22 @@
     "qc_running": "ダビングのタイミングを確認中…",
     "qc_result": "{{total}} 行中 {{flagged}} 行は再試行が必要な可能性があります",
     "qc_clean": "すべての {{total}} 行がスクリプトと一致します",
-    "qc_failed": "タイミング チェックに失敗しました: {{message}}"
+    "qc_failed": "タイミング チェックに失敗しました: {{message}}",
+    "paste_translation_btn": "翻訳を貼り付け",
+    "paste_translation_title": "翻訳を貼り付け",
+    "paste_translation_desc": "他所で用意した翻訳（ChatGPT、DeepL、人間の翻訳者）を貼り付けます。既存のセグメントに割り当てられ、タイミングと元の文字起こしはそのまま残ります。",
+    "paste_translation_placeholder": "字幕（SRT/VTT）、番号付きの行（1. …）、またはセグメントごとに1行の翻訳を貼り付けてください。.srt/.vtt ファイルをここにドロップすることもできます。",
+    "paste_translation_load_file": ".srt / .vtt ファイルを読み込む",
+    "paste_translation_mode_timestamped": "タイムスタンプ付き（SRT/VTT）",
+    "paste_translation_mode_numbered": "番号付きの行",
+    "paste_translation_mode_plain": "通常の行",
+    "paste_translation_counts": "{{segments}} セグメント · {{lines}} 行 · 未対応 {{unmatched}}",
+    "paste_translation_unused": "貼り付けた行のうち {{count}} 行が未使用です",
+    "paste_translation_none_matched": "一致するものがありません。貼り付けたテキストが下のセグメントと対応しているか確認してください。",
+    "paste_translation_row_unmatched": "一致なし — 変更しません",
+    "paste_translation_apply": "{{count}} セグメントに適用",
+    "paste_translation_cancel": "キャンセル",
+    "paste_translation_more_rows": "他 {{count}} 行"
   },
   "glossary": {
     "title": "用語集",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -878,7 +878,22 @@
     "qc_running": "더빙 타이밍 확인 중…",
     "qc_result": "{{total}} 줄 중 {{flagged}} 줄을 다시 들어야 할 수 있습니다.",
     "qc_clean": "모든 {{total}} 줄은 스크립트와 일치합니다.",
-    "qc_failed": "타이밍 확인 실패: {{message}}"
+    "qc_failed": "타이밍 확인 실패: {{message}}",
+    "paste_translation_btn": "번역 붙여넣기",
+    "paste_translation_title": "번역 붙여넣기",
+    "paste_translation_desc": "다른 곳에서 만든 번역(ChatGPT, DeepL, 사람 번역가)을 붙여넣으세요. 이미 있는 세그먼트에 매핑되며 타이밍과 원본 전사는 그대로 유지됩니다.",
+    "paste_translation_placeholder": "자막(SRT/VTT), 번호가 매겨진 줄(1. …), 또는 세그먼트당 한 줄의 번역을 붙여넣으세요 — .srt/.vtt 파일을 여기에 놓아도 됩니다.",
+    "paste_translation_load_file": ".srt / .vtt 파일 불러오기",
+    "paste_translation_mode_timestamped": "타임스탬프 포함(SRT/VTT)",
+    "paste_translation_mode_numbered": "번호 매긴 줄",
+    "paste_translation_mode_plain": "일반 줄",
+    "paste_translation_counts": "{{segments}}개 세그먼트 · {{lines}}줄 · 미매칭 {{unmatched}}개",
+    "paste_translation_unused": "붙여넣은 줄 중 {{count}}줄이 사용되지 않았습니다",
+    "paste_translation_none_matched": "일치하는 항목이 없습니다. 붙여넣은 텍스트가 아래 세그먼트와 맞는지 확인하세요.",
+    "paste_translation_row_unmatched": "일치 없음 — 변경 안 함",
+    "paste_translation_apply": "{{count}}개 세그먼트에 적용",
+    "paste_translation_cancel": "취소",
+    "paste_translation_more_rows": "+ {{count}}개 행 더"
   },
   "glossary": {
     "title": "용어집",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -878,7 +878,22 @@
     "qc_running": "De dubtiming controleren...",
     "qc_result": "{{flagged}} van {{total}} regels moeten mogelijk opnieuw worden beluisterd",
     "qc_clean": "Alle {{total}} regels komen overeen met het script",
-    "qc_failed": "Timingcontrole mislukt: {{message}}"
+    "qc_failed": "Timingcontrole mislukt: {{message}}",
+    "paste_translation_btn": "Vertaling plakken",
+    "paste_translation_title": "Een vertaling plakken",
+    "paste_translation_desc": "Plak een elders gemaakte vertaling (ChatGPT, DeepL, een menselijke vertaler). Die wordt op je bestaande segmenten toegepast — timings en het originele transcript blijven ongewijzigd.",
+    "paste_translation_placeholder": "Plak ondertitels (SRT/VTT), genummerde regels (1. …) of één vertaalde regel per segment — of sleep hier een .srt/.vtt-bestand naartoe.",
+    "paste_translation_load_file": ".srt-/.vtt-bestand laden",
+    "paste_translation_mode_timestamped": "Met tijdcodes (SRT/VTT)",
+    "paste_translation_mode_numbered": "Genummerde regels",
+    "paste_translation_mode_plain": "Gewone regels",
+    "paste_translation_counts": "{{segments}} segmenten · {{lines}} regels · {{unmatched}} zonder match",
+    "paste_translation_unused": "{{count}} geplakte regel(s) ongebruikt",
+    "paste_translation_none_matched": "Niets kwam overeen. Controleer of de geplakte tekst aansluit op de segmenten hieronder.",
+    "paste_translation_row_unmatched": "geen match — ongewijzigd",
+    "paste_translation_apply": "Toepassen op {{count}} segmenten",
+    "paste_translation_cancel": "Annuleren",
+    "paste_translation_more_rows": "+ nog {{count}} rijen"
   },
   "glossary": {
     "title": "Woordenlijst",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -878,7 +878,22 @@
     "qc_running": "Sprawdzam synchronizację dubbingu…",
     "qc_result": "{{flagged}} z {{total}} wierszy może wymagać ponownego przesłuchania",
     "qc_clean": "Wszystkie linie {{total}} odpowiadają skryptowi",
-    "qc_failed": "Kontrola czasu nie powiodła się: {{message}}"
+    "qc_failed": "Kontrola czasu nie powiodła się: {{message}}",
+    "paste_translation_btn": "Wklej tłumaczenie",
+    "paste_translation_title": "Wklej tłumaczenie",
+    "paste_translation_desc": "Wklej tłumaczenie przygotowane gdzie indziej (ChatGPT, DeepL, tłumacz). Zostanie dopasowane do istniejących segmentów — czasy i oryginalna transkrypcja pozostają bez zmian.",
+    "paste_translation_placeholder": "Wklej napisy (SRT/VTT), numerowane wiersze (1. …) albo jeden przetłumaczony wiersz na segment — lub upuść tutaj plik .srt/.vtt.",
+    "paste_translation_load_file": "Wczytaj plik .srt / .vtt",
+    "paste_translation_mode_timestamped": "Ze znacznikami czasu (SRT/VTT)",
+    "paste_translation_mode_numbered": "Numerowane wiersze",
+    "paste_translation_mode_plain": "Zwykłe wiersze",
+    "paste_translation_counts": "{{segments}} segmentów · {{lines}} wierszy · {{unmatched}} bez dopasowania",
+    "paste_translation_unused": "Niewykorzystane wklejone wiersze: {{count}}",
+    "paste_translation_none_matched": "Nic nie zostało dopasowane. Sprawdź, czy wklejony tekst odpowiada segmentom poniżej.",
+    "paste_translation_row_unmatched": "brak dopasowania — bez zmian",
+    "paste_translation_apply": "Zastosuj do {{count}} segmentów",
+    "paste_translation_cancel": "Anuluj",
+    "paste_translation_more_rows": "+ jeszcze {{count}} wierszy"
   },
   "glossary": {
     "title": "Glosariusz",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -878,7 +878,22 @@
     "qc_running": "Verificando o tempo de dublagem…",
     "qc_result": "{{flagged}} de {{total}} linhas podem precisar de uma nova escuta",
     "qc_clean": "Todas as linhas {{total}} correspondem ao script",
-    "qc_failed": "Falha na verificação de tempo: {{message}}"
+    "qc_failed": "Falha na verificação de tempo: {{message}}",
+    "paste_translation_btn": "Colar tradução",
+    "paste_translation_title": "Colar uma tradução",
+    "paste_translation_desc": "Cole uma tradução feita noutro lugar (ChatGPT, DeepL, um tradutor humano). Ela é mapeada nos segmentos que já existem — os tempos e a transcrição original ficam intactos.",
+    "paste_translation_placeholder": "Cole legendas (SRT/VTT), linhas numeradas (1. …) ou uma linha traduzida por segmento — ou solte aqui um ficheiro .srt/.vtt.",
+    "paste_translation_load_file": "Carregar ficheiro .srt / .vtt",
+    "paste_translation_mode_timestamped": "Com marcações de tempo (SRT/VTT)",
+    "paste_translation_mode_numbered": "Linhas numeradas",
+    "paste_translation_mode_plain": "Linhas simples",
+    "paste_translation_counts": "{{segments}} segmentos · {{lines}} linhas · {{unmatched}} sem correspondência",
+    "paste_translation_unused": "{{count}} linha(s) colada(s) não utilizada(s)",
+    "paste_translation_none_matched": "Nada correspondeu. Verifique se o texto colado bate com os segmentos abaixo.",
+    "paste_translation_row_unmatched": "sem correspondência — inalterado",
+    "paste_translation_apply": "Aplicar a {{count}} segmentos",
+    "paste_translation_cancel": "Cancelar",
+    "paste_translation_more_rows": "+ {{count}} linhas adicionais"
   },
   "glossary": {
     "title": "Glossário",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -878,7 +878,22 @@
     "qc_running": "Проверка синхронизации дубляжа…",
     "qc_result": "{{flagged}} из {{total}} строк может потребоваться повторное прослушивание",
     "qc_clean": "Все строки {{total}} соответствуют сценарию",
-    "qc_failed": "Проверка времени не удалась: {{message}}"
+    "qc_failed": "Проверка времени не удалась: {{message}}",
+    "paste_translation_btn": "Вставить перевод",
+    "paste_translation_title": "Вставить перевод",
+    "paste_translation_desc": "Вставьте перевод, сделанный в другом месте (ChatGPT, DeepL, живой переводчик). Он ляжет на уже имеющиеся сегменты — тайминги и исходная расшифровка не изменятся.",
+    "paste_translation_placeholder": "Вставьте субтитры (SRT/VTT), нумерованные строки (1. …) или по одной переведённой строке на сегмент — либо перетащите сюда файл .srt/.vtt.",
+    "paste_translation_load_file": "Загрузить файл .srt / .vtt",
+    "paste_translation_mode_timestamped": "С таймкодами (SRT/VTT)",
+    "paste_translation_mode_numbered": "Нумерованные строки",
+    "paste_translation_mode_plain": "Обычные строки",
+    "paste_translation_counts": "{{segments}} сегментов · {{lines}} строк · {{unmatched}} без совпадения",
+    "paste_translation_unused": "Не использовано вставленных строк: {{count}}",
+    "paste_translation_none_matched": "Совпадений нет. Проверьте, что вставленный текст соответствует сегментам ниже.",
+    "paste_translation_row_unmatched": "нет совпадения — без изменений",
+    "paste_translation_apply": "Применить к {{count}} сегментам",
+    "paste_translation_cancel": "Отмена",
+    "paste_translation_more_rows": "+ ещё {{count}} строк"
   },
   "glossary": {
     "title": "Глоссарий",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -878,7 +878,22 @@
     "qc_running": "Kontrollerar dubbningstid...",
     "qc_result": "{{flagged}} av {{total}} rader kan behöva lyssnas om",
     "qc_clean": "Alla {{total}} rader matchar skriptet",
-    "qc_failed": "Tidskontroll misslyckades: {{message}}"
+    "qc_failed": "Tidskontroll misslyckades: {{message}}",
+    "paste_translation_btn": "Klistra in översättning",
+    "paste_translation_title": "Klistra in en översättning",
+    "paste_translation_desc": "Klistra in en översättning som gjorts någon annanstans (ChatGPT, DeepL, en mänsklig översättare). Den mappas mot segmenten du redan har — tidkoder och originaltranskriptet rörs inte.",
+    "paste_translation_placeholder": "Klistra in undertexter (SRT/VTT), numrerade rader (1. …) eller en översatt rad per segment — eller släpp en .srt/.vtt-fil här.",
+    "paste_translation_load_file": "Läs in .srt-/.vtt-fil",
+    "paste_translation_mode_timestamped": "Med tidkoder (SRT/VTT)",
+    "paste_translation_mode_numbered": "Numrerade rader",
+    "paste_translation_mode_plain": "Vanliga rader",
+    "paste_translation_counts": "{{segments}} segment · {{lines}} rader · {{unmatched}} utan träff",
+    "paste_translation_unused": "{{count}} inklistrad(e) rad(er) användes inte",
+    "paste_translation_none_matched": "Inget matchade. Kontrollera att den inklistrade texten stämmer med segmenten nedan.",
+    "paste_translation_row_unmatched": "ingen träff — oförändrad",
+    "paste_translation_apply": "Använd på {{count}} segment",
+    "paste_translation_cancel": "Avbryt",
+    "paste_translation_more_rows": "+ {{count}} rader till"
   },
   "glossary": {
     "title": "Ordlista",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -878,7 +878,22 @@
     "qc_running": "กำลังตรวจสอบเวลาพากย์...",
     "qc_result": "{{flagged}} จาก {{total}} บรรทัดอาจต้องฟังซ้ำ",
     "qc_clean": "{{total}} บรรทัดทั้งหมดตรงกับสคริปต์",
-    "qc_failed": "การตรวจสอบเวลาล้มเหลว: {{message}}"
+    "qc_failed": "การตรวจสอบเวลาล้มเหลว: {{message}}",
+    "paste_translation_btn": "วางคำแปล",
+    "paste_translation_title": "วางคำแปล",
+    "paste_translation_desc": "วางคำแปลที่คุณทำไว้จากที่อื่น (ChatGPT, DeepL หรือผู้แปลที่เป็นคน) ระบบจะจับคู่กับเซกเมนต์ที่มีอยู่แล้ว โดยเวลาและถอดความต้นฉบับยังคงเดิม",
+    "paste_translation_placeholder": "วางคำบรรยาย (SRT/VTT) บรรทัดที่มีหมายเลข (1. …) หรือหนึ่งบรรทัดต่อหนึ่งเซกเมนต์ — หรือวางไฟล์ .srt/.vtt ที่นี่",
+    "paste_translation_load_file": "โหลดไฟล์ .srt / .vtt",
+    "paste_translation_mode_timestamped": "มีเวลากำกับ (SRT/VTT)",
+    "paste_translation_mode_numbered": "บรรทัดมีหมายเลข",
+    "paste_translation_mode_plain": "บรรทัดธรรมดา",
+    "paste_translation_counts": "{{segments}} เซกเมนต์ · {{lines}} บรรทัด · {{unmatched}} ไม่จับคู่",
+    "paste_translation_unused": "มี {{count}} บรรทัดที่วางแล้วไม่ได้ใช้",
+    "paste_translation_none_matched": "ไม่มีอะไรจับคู่ได้ ตรวจสอบว่าข้อความที่วางตรงกับเซกเมนต์ด้านล่าง",
+    "paste_translation_row_unmatched": "ไม่จับคู่ — คงเดิม",
+    "paste_translation_apply": "ใช้กับ {{count}} เซกเมนต์",
+    "paste_translation_cancel": "ยกเลิก",
+    "paste_translation_more_rows": "+ อีก {{count}} แถว"
   },
   "glossary": {
     "title": "อภิธานศัพท์",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -878,7 +878,22 @@
     "qc_running": "Dub zamanlaması kontrol ediliyor…",
     "qc_result": "{{flagged}} / {{total}} satırların yeniden dinlenmesi gerekebilir",
     "qc_clean": "Tüm {{total}} satırları komut dosyasıyla eşleşiyor",
-    "qc_failed": "Zamanlama kontrolü başarısız oldu: {{message}}"
+    "qc_failed": "Zamanlama kontrolü başarısız oldu: {{message}}",
+    "paste_translation_btn": "Çeviriyi yapıştır",
+    "paste_translation_title": "Bir çeviri yapıştır",
+    "paste_translation_desc": "Başka bir yerde hazırladığın çeviriyi yapıştır (ChatGPT, DeepL, bir insan çevirmen). Mevcut segmentlere eşlenir — zamanlamalar ve özgün döküm olduğu gibi kalır.",
+    "paste_translation_placeholder": "Altyazı (SRT/VTT), numaralı satırlar (1. …) veya segment başına bir çeviri satırı yapıştır — ya da buraya bir .srt/.vtt dosyası bırak.",
+    "paste_translation_load_file": ".srt / .vtt dosyası yükle",
+    "paste_translation_mode_timestamped": "Zaman damgalı (SRT/VTT)",
+    "paste_translation_mode_numbered": "Numaralı satırlar",
+    "paste_translation_mode_plain": "Düz satırlar",
+    "paste_translation_counts": "{{segments}} segment · {{lines}} satır · {{unmatched}} eşleşmeyen",
+    "paste_translation_unused": "{{count}} yapıştırılan satır kullanılmadı",
+    "paste_translation_none_matched": "Hiçbir şey eşleşmedi. Yapıştırdığın metnin aşağıdaki segmentlerle örtüştüğünü kontrol et.",
+    "paste_translation_row_unmatched": "eşleşme yok — değişmedi",
+    "paste_translation_apply": "{{count}} segmente uygula",
+    "paste_translation_cancel": "İptal",
+    "paste_translation_more_rows": "+ {{count}} satır daha"
   },
   "glossary": {
     "title": "Sözlük",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -878,7 +878,22 @@
     "qc_running": "Перевірка часу дубляжу…",
     "qc_result": "{{flagged}} з {{total}} рядків може знадобитися переслухати",
     "qc_clean": "Усі {{total}} рядки відповідають сценарію",
-    "qc_failed": "Помилка перевірки часу: {{message}}"
+    "qc_failed": "Помилка перевірки часу: {{message}}",
+    "paste_translation_btn": "Вставити переклад",
+    "paste_translation_title": "Вставити переклад",
+    "paste_translation_desc": "Вставте переклад, зроблений деінде (ChatGPT, DeepL, живий перекладач). Він накладеться на наявні сегменти — таймінги й початкова транскрипція лишаться незмінними.",
+    "paste_translation_placeholder": "Вставте субтитри (SRT/VTT), нумеровані рядки (1. …) або по одному перекладеному рядку на сегмент — чи перетягніть сюди файл .srt/.vtt.",
+    "paste_translation_load_file": "Завантажити файл .srt / .vtt",
+    "paste_translation_mode_timestamped": "З таймкодами (SRT/VTT)",
+    "paste_translation_mode_numbered": "Нумеровані рядки",
+    "paste_translation_mode_plain": "Звичайні рядки",
+    "paste_translation_counts": "{{segments}} сегментів · {{lines}} рядків · {{unmatched}} без відповідності",
+    "paste_translation_unused": "Невикористаних вставлених рядків: {{count}}",
+    "paste_translation_none_matched": "Нічого не збіглося. Перевірте, чи вставлений текст відповідає сегментам нижче.",
+    "paste_translation_row_unmatched": "немає відповідності — без змін",
+    "paste_translation_apply": "Застосувати до {{count}} сегментів",
+    "paste_translation_cancel": "Скасувати",
+    "paste_translation_more_rows": "+ ще {{count}} рядків"
   },
   "glossary": {
     "title": "Глосарій",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -878,7 +878,22 @@
     "qc_running": "Đang kiểm tra thời gian lồng tiếng…",
     "qc_result": "{{flagged}} trong số {{total}} dòng có thể cần nghe lại",
     "qc_clean": "Tất cả các dòng {{total}} đều khớp với tập lệnh",
-    "qc_failed": "Kiểm tra thời gian không thành công: {{message}}"
+    "qc_failed": "Kiểm tra thời gian không thành công: {{message}}",
+    "paste_translation_btn": "Dán bản dịch",
+    "paste_translation_title": "Dán một bản dịch",
+    "paste_translation_desc": "Dán bản dịch bạn đã làm ở nơi khác (ChatGPT, DeepL, người dịch). Nó sẽ được ánh xạ vào các phân đoạn sẵn có — thời điểm và bản ghi gốc giữ nguyên.",
+    "paste_translation_placeholder": "Dán phụ đề (SRT/VTT), các dòng đánh số (1. …), hoặc mỗi phân đoạn một dòng đã dịch — hoặc thả tệp .srt/.vtt vào đây.",
+    "paste_translation_load_file": "Tải tệp .srt / .vtt",
+    "paste_translation_mode_timestamped": "Có dấu thời gian (SRT/VTT)",
+    "paste_translation_mode_numbered": "Dòng đánh số",
+    "paste_translation_mode_plain": "Dòng thuần",
+    "paste_translation_counts": "{{segments}} phân đoạn · {{lines}} dòng · {{unmatched}} không khớp",
+    "paste_translation_unused": "{{count}} dòng đã dán không được dùng",
+    "paste_translation_none_matched": "Không có gì khớp. Hãy kiểm tra xem văn bản đã dán có tương ứng với các phân đoạn bên dưới không.",
+    "paste_translation_row_unmatched": "không khớp — giữ nguyên",
+    "paste_translation_apply": "Áp dụng cho {{count}} phân đoạn",
+    "paste_translation_cancel": "Hủy",
+    "paste_translation_more_rows": "+ {{count}} dòng nữa"
   },
   "glossary": {
     "title": "Thuật ngữ",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -837,7 +837,22 @@
     "qc_running": "检查配音时间...",
     "qc_result": "{{flagged}} 行（共 {{total}} 行）可能需要重新收听",
     "qc_clean": "所有 {{total}} 行都与脚本匹配",
-    "qc_failed": "计时检查失败：{{message}}"
+    "qc_failed": "计时检查失败：{{message}}",
+    "paste_translation_btn": "粘贴译文",
+    "paste_translation_title": "粘贴译文",
+    "paste_translation_desc": "粘贴你在别处完成的译文（ChatGPT、DeepL 或人工译者）。它会映射到已有的片段上——时间轴和原始转写保持不变。",
+    "paste_translation_placeholder": "粘贴字幕（SRT/VTT）、带编号的行（1. …），或每个片段一行译文——也可以把 .srt/.vtt 文件拖到这里。",
+    "paste_translation_load_file": "载入 .srt / .vtt 文件",
+    "paste_translation_mode_timestamped": "带时间戳（SRT/VTT）",
+    "paste_translation_mode_numbered": "带编号的行",
+    "paste_translation_mode_plain": "纯文本行",
+    "paste_translation_counts": "{{segments}} 个片段 · {{lines}} 行 · {{unmatched}} 个未匹配",
+    "paste_translation_unused": "有 {{count}} 行粘贴内容未被使用",
+    "paste_translation_none_matched": "没有任何匹配。请检查粘贴的文本是否与下方片段对应。",
+    "paste_translation_row_unmatched": "无匹配——保持不变",
+    "paste_translation_apply": "应用到 {{count}} 个片段",
+    "paste_translation_cancel": "取消",
+    "paste_translation_more_rows": "还有 {{count}} 行"
   },
   "glossary": {
     "title": "术语表",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -878,7 +878,22 @@
     "qc_running": "檢查配音時間...",
     "qc_result": "{{flagged}} 行（共 {{total}} 行）可能需要重新聆聽",
     "qc_clean": "所有 {{total}} 行都與腳本匹配",
-    "qc_failed": "計時檢查失敗：{{message}}"
+    "qc_failed": "計時檢查失敗：{{message}}",
+    "paste_translation_btn": "貼上譯文",
+    "paste_translation_title": "貼上譯文",
+    "paste_translation_desc": "貼上你在別處完成的譯文（ChatGPT、DeepL 或真人譯者）。它會對應到既有的片段上——時間軸與原始逐字稿維持不變。",
+    "paste_translation_placeholder": "貼上字幕（SRT/VTT）、有編號的行（1. …），或每個片段一行譯文——也可以把 .srt/.vtt 檔案拖到這裡。",
+    "paste_translation_load_file": "載入 .srt / .vtt 檔案",
+    "paste_translation_mode_timestamped": "含時間碼（SRT/VTT）",
+    "paste_translation_mode_numbered": "有編號的行",
+    "paste_translation_mode_plain": "純文字行",
+    "paste_translation_counts": "{{segments}} 個片段 · {{lines}} 行 · {{unmatched}} 個未對應",
+    "paste_translation_unused": "有 {{count}} 行貼上的內容未被使用",
+    "paste_translation_none_matched": "沒有任何對應。請檢查貼上的文字是否與下方片段相符。",
+    "paste_translation_row_unmatched": "無對應——維持原樣",
+    "paste_translation_apply": "套用到 {{count}} 個片段",
+    "paste_translation_cancel": "取消",
+    "paste_translation_more_rows": "還有 {{count}} 行"
   },
   "glossary": {
     "title": "詞彙表",

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -58,6 +58,7 @@ export default function DubTab(props) {
     segmentEditField,
     segmentDelete,
     segmentRestoreOriginal,
+    pasteTranslations,
     segmentSplit,
     segmentMerge,
     segmentMoveResize,
@@ -693,6 +694,7 @@ export default function DubTab(props) {
               segmentEditField={segmentEditField}
               segmentDelete={segmentDelete}
               segmentRestoreOriginal={segmentRestoreOriginal}
+              pasteTranslations={pasteTranslations}
               handleSegmentPreview={handleSegmentPreview}
               onDirectSegment={onDirectSegment}
               segmentSplit={segmentSplit}

--- a/frontend/src/test/dubPasteTranslation.test.jsx
+++ b/frontend/src/test/dubPasteTranslation.test.jsx
@@ -369,6 +369,21 @@ describe('DubPasteTranslationDialog', () => {
     expect(screen.getByRole('button', { name: /Apply/i })).toBeDisabled();
   });
 
+  it('keeps the file picker reachable by keyboard (not `hidden`)', () => {
+    // A bare <label> is not focusable and `hidden` removes the input from the
+    // tab order AND the accessibility tree — together they leave keyboard-only
+    // users with no path to the file picker at all.
+    render(
+      <DubPasteTranslationDialog open segments={SEGMENTS} onApply={vi.fn()} onClose={vi.fn()} />,
+    );
+    // The dialog renders through a portal, so query the document, not the
+    // render container.
+    const input = document.querySelector('input[type="file"]');
+    expect(input).not.toBeNull();
+    expect(input.hidden).toBe(false);
+    expect(input.className).toContain('sr-only');
+  });
+
   it('sends a timestamped paste to the backend parser and previews the cues', async () => {
     dubApi.dubParseSubtitleText.mockResolvedValue({
       segments: [

--- a/frontend/src/test/dubPasteTranslation.test.jsx
+++ b/frontend/src/test/dubPasteTranslation.test.jsx
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { useAppStore } from '../store';
+import {
+  detectPasteMode,
+  parseNumberedLines,
+  buildPastePlan,
+  matchByOverlap,
+} from '../utils/pasteTranslations';
+
+// "Paste translation from an external source": the user transcribes once,
+// translates elsewhere (ChatGPT / DeepL / a human), and pastes the result
+// back onto the segments that already exist. The two invariants this
+// feature must never break:
+//   - `text_original` stays the SOURCE text — `handleTranslateAll` reads it
+//     as the translate input, so overwriting it poisons every later
+//     re-translate (the same guard the backend keeps at dub_generate.py:96);
+//   - only the ACTIVE `dubLangCode` entry of `translations` is written.
+
+const dubApi = vi.hoisted(() => ({ dubParseSubtitleText: vi.fn() }));
+vi.mock('../api/dub', () => dubApi);
+
+import useSegmentEditing from '../hooks/useSegmentEditing';
+import DubPasteTranslationDialog from '../components/dub/DubPasteTranslationDialog';
+
+const baseState = useAppStore.getState();
+
+const seg = (id, start, end, text) => ({
+  id,
+  start,
+  end,
+  text,
+  text_original: text,
+});
+
+const SEGMENTS = [
+  seg('1', 0, 2, 'Hello there'),
+  seg('2', 2, 4, 'How are you'),
+  seg('3', 4, 6, 'Goodbye'),
+];
+
+beforeEach(() => {
+  useAppStore.setState(baseState, true);
+  dubApi.dubParseSubtitleText.mockReset();
+  useAppStore.setState({
+    dubJobId: 'job1',
+    dubStep: 'editing',
+    dubLangCode: 'es',
+    dubSegments: SEGMENTS.map((s) => ({ ...s })),
+  });
+});
+
+// ── Mode auto-detection ───────────────────────────────────────────────────
+describe('detectPasteMode', () => {
+  it('detects a timestamped SRT paste', () => {
+    expect(detectPasteMode('1\n00:00:01,000 --> 00:00:04,500\nHola.\n')).toBe('timestamped');
+  });
+
+  it('detects a VTT paste (dot ms separator, no cue indices)', () => {
+    expect(detectPasteMode('WEBVTT\n\n00:00:01.000 --> 00:00:04.500\nHola.\n')).toBe('timestamped');
+  });
+
+  it('detects numbered lines in every common prefix style', () => {
+    expect(detectPasteMode('1. Hola\n2. Que tal\n3. Adios')).toBe('numbered');
+    expect(detectPasteMode('1) Hola\n2) Que tal')).toBe('numbered');
+    expect(detectPasteMode('[1] Hola\n[2] Que tal')).toBe('numbered');
+  });
+
+  it('ignores an LLM preamble line when deciding numbered', () => {
+    expect(detectPasteMode('Here are the translations:\n1. Hola\n2. Que tal\n3. Adios')).toBe(
+      'numbered',
+    );
+  });
+
+  it('falls back to plain for ordinary lines', () => {
+    expect(detectPasteMode('Hola\nQue tal\nAdios')).toBe('plain');
+  });
+
+  it('does not mistake prose that happens to start with a number for numbered', () => {
+    expect(detectPasteMode('2024 was a good year\nWe shipped a lot\nThanks for watching')).toBe(
+      'plain',
+    );
+  });
+
+  it('prefers timestamped even when cue indices look numbered', () => {
+    const srt =
+      '1\n00:00:01,000 --> 00:00:02,000\nHola.\n\n2\n00:00:03,000 --> 00:00:04,000\nAdios.\n';
+    expect(detectPasteMode(srt)).toBe('timestamped');
+  });
+});
+
+// ── Mapping ───────────────────────────────────────────────────────────────
+describe('buildPastePlan — plain (positional)', () => {
+  it('maps one line per segment in order', () => {
+    const plan = buildPastePlan('Hola\nQue tal\nAdios', SEGMENTS);
+    expect(plan.mode).toBe('plain');
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+    expect(plan.matchedCount).toBe(3);
+    expect(plan.unmatchedCount).toBe(0);
+  });
+
+  it('treats blank lines as separators, never as empty translations', () => {
+    const plan = buildPastePlan('Hola\n\n\nQue tal\n\nAdios\n', SEGMENTS);
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('reports a short paste as unmatched rows instead of blanking them', () => {
+    const plan = buildPastePlan('Hola\nQue tal', SEGMENTS);
+    expect(plan.matchedCount).toBe(2);
+    expect(plan.unmatchedCount).toBe(1);
+    expect(plan.rows[2].matched).toBe(false);
+    expect(plan.rows[2].after).toBeNull();
+  });
+
+  it('reports leftover lines from an over-long paste', () => {
+    const plan = buildPastePlan('a\nb\nc\nd\ne', SEGMENTS);
+    expect(plan.matchedCount).toBe(3);
+    expect(plan.sourceCount).toBe(5);
+    expect(plan.unusedCount).toBe(2);
+  });
+});
+
+describe('buildPastePlan — numbered', () => {
+  it('strips the prefix and maps by number', () => {
+    const plan = buildPastePlan('1. Hola\n2) Que tal\n[3] Adios', SEGMENTS);
+    expect(plan.mode).toBe('numbered');
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('maps by the number, not position, when the LLM skips one', () => {
+    const plan = buildPastePlan('1. Hola\n3. Adios', SEGMENTS);
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', null, 'Adios']);
+    expect(plan.unmatchedCount).toBe(1);
+  });
+
+  it('falls back to positional when the LLM renumbers from 1 mid-answer', () => {
+    // "1. … 2. … 1. …" — the numbers are junk but the ORDER is right.
+    const plan = buildPastePlan('1. Hola\n2. Que tal\n1. Adios', SEGMENTS);
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('joins wrapped continuation lines into the entry above', () => {
+    const plan = buildPastePlan('1. Hola\nmundo entero\n2. Que tal\n3. Adios', SEGMENTS);
+    expect(plan.rows[0].after).toBe('Hola mundo entero');
+  });
+
+  it('drops an LLM preamble instead of shifting every row by one', () => {
+    const plan = buildPastePlan('Here you go:\n1. Hola\n2. Que tal\n3. Adios', SEGMENTS);
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('parseNumberedLines returns entries in encounter order', () => {
+    expect(parseNumberedLines('2) dos\n1) uno')).toEqual([
+      { num: 2, text: 'dos' },
+      { num: 1, text: 'uno' },
+    ]);
+  });
+});
+
+describe('buildPastePlan — timestamped (time overlap)', () => {
+  const cues = [
+    { start: 0.1, end: 1.9, text: 'Hola' },
+    { start: 2.1, end: 3.9, text: 'Que tal' },
+    { start: 4.1, end: 5.9, text: 'Adios' },
+  ];
+
+  it('matches cues to segments by overlap, not by index', () => {
+    const plan = buildPastePlan('x', SEGMENTS, { mode: 'timestamped', cues });
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('still matches when cue boundaries drift from ours', () => {
+    const drifted = [
+      { start: 0.0, end: 2.4, text: 'Hola' },
+      { start: 2.4, end: 4.4, text: 'Que tal' },
+    ];
+    const plan = buildPastePlan('x', SEGMENTS, { mode: 'timestamped', cues: drifted });
+    expect(plan.rows[0].after).toBe('Hola');
+    expect(plan.rows[1].after).toBe('Que tal');
+    expect(plan.rows[2].matched).toBe(false);
+  });
+
+  it('flags a segment no cue overlaps', () => {
+    const plan = buildPastePlan('x', SEGMENTS, {
+      mode: 'timestamped',
+      cues: [{ start: 0, end: 2, text: 'Hola' }],
+    });
+    expect(plan.matchedCount).toBe(1);
+    expect(plan.rows[1].matched).toBe(false);
+    expect(plan.rows[2].matched).toBe(false);
+  });
+
+  it('never copies one cue onto several segments (greedy one-to-one)', () => {
+    // One long cue spanning all three rows: argmax matching would stamp the
+    // same sentence three times; only the strongest overlap may claim it.
+    const plan = buildPastePlan('x', SEGMENTS, {
+      mode: 'timestamped',
+      cues: [{ start: 0, end: 6, text: 'Una frase larga' }],
+    });
+    expect(plan.matchedCount).toBe(1);
+    expect(plan.rows.filter((r) => r.after === 'Una frase larga')).toHaveLength(1);
+  });
+
+  it('matches correctly when cues arrive out of chronological order', () => {
+    // The matcher sweeps both lists by start time; it must sort first rather
+    // than trust the caller's ordering.
+    const plan = buildPastePlan('x', SEGMENTS, {
+      mode: 'timestamped',
+      cues: [
+        { start: 4.1, end: 5.9, text: 'Adios' },
+        { start: 0.1, end: 1.9, text: 'Hola' },
+        { start: 2.1, end: 3.9, text: 'Que tal' },
+      ],
+    });
+    expect(plan.rows.map((r) => r.after)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('matchByOverlap resolves ties deterministically by document order', () => {
+    const { bySeg } = matchByOverlap(
+      [
+        { start: 0, end: 2, text: 'a' },
+        { start: 0, end: 2, text: 'b' },
+      ],
+      [seg('1', 0, 2, 'x')],
+    );
+    expect(bySeg.get(0)).toBe(0);
+  });
+});
+
+// ── Applying through the hook ─────────────────────────────────────────────
+describe('pasteTranslations (useSegmentEditing)', () => {
+  const paste = (result, text, opts) => {
+    let plan;
+    act(() => {
+      plan = result.current.pasteTranslations(text, opts);
+    });
+    return plan;
+  };
+
+  it('writes text and translations[activeLang] in lock-step', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    paste(result, 'Hola\nQue tal\nAdios');
+    const segs = useAppStore.getState().dubSegments;
+    expect(segs.map((s) => s.text)).toEqual(['Hola', 'Que tal', 'Adios']);
+    expect(segs.map((s) => s.translations.es)).toEqual(['Hola', 'Que tal', 'Adios']);
+  });
+
+  it('NEVER overwrites text_original (would poison a later re-translate)', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    paste(result, 'Hola\nQue tal\nAdios');
+    expect(useAppStore.getState().dubSegments.map((s) => s.text_original)).toEqual([
+      'Hello there',
+      'How are you',
+      'Goodbye',
+    ]);
+  });
+
+  it('touches only the ACTIVE language entry, leaving other languages intact', () => {
+    useAppStore.setState({
+      dubSegments: [{ ...SEGMENTS[0], translations: { bn: 'ওহে', es: 'viejo' } }],
+    });
+    const { result } = renderHook(() => useSegmentEditing());
+    paste(result, 'Hola');
+    const s = useAppStore.getState().dubSegments[0];
+    expect(s.translations).toEqual({ bn: 'ওহে', es: 'Hola' });
+  });
+
+  it('clears stale machine-translation badges on the rows it rewrites', () => {
+    useAppStore.setState({
+      dubSegments: [
+        { ...SEGMENTS[0], translate_error: 'engine down', translate_degraded: true },
+        { ...SEGMENTS[1], translate_error: 'engine down' },
+      ],
+    });
+    const { result } = renderHook(() => useSegmentEditing());
+    paste(result, 'Hola'); // only row 1 is matched
+    const segs = useAppStore.getState().dubSegments;
+    expect(segs[0].translate_error).toBeUndefined();
+    expect(segs[0].translate_degraded).toBeUndefined();
+    // Untouched row keeps its badge — its text really is still the bad one.
+    expect(segs[1].translate_error).toBe('engine down');
+  });
+
+  it('leaves unmatched rows byte-identical rather than blanking them', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    const plan = paste(result, 'Hola');
+    expect(plan.unmatchedCount).toBe(2);
+    const segs = useAppStore.getState().dubSegments;
+    expect(segs[1].text).toBe('How are you');
+    expect(segs[2].text).toBe('Goodbye');
+    expect(segs[1].translations).toBeUndefined();
+  });
+
+  it('reports the mismatch counts instead of applying silently', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    const plan = paste(result, 'a\nb\nc\nd');
+    expect(plan).toMatchObject({ mode: 'plain', matchedCount: 3, sourceCount: 4, unusedCount: 1 });
+  });
+
+  it('applies nothing (and pushes no undo) when zero rows match', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    const plan = paste(result, 'x', { mode: 'timestamped', cues: [] });
+    expect(plan.matchedCount).toBe(0);
+    expect(useAppStore.getState().dubSegments.map((s) => s.text)).toEqual([
+      'Hello there',
+      'How are you',
+      'Goodbye',
+    ]);
+    act(() => result.current.undo());
+    // Undo had nothing to pop, so the timeline is still untouched.
+    expect(useAppStore.getState().dubSegments[0].text).toBe('Hello there');
+  });
+
+  it('is one undo step for the whole paste', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    paste(result, 'Hola\nQue tal\nAdios');
+    act(() => result.current.undo());
+    const segs = useAppStore.getState().dubSegments;
+    expect(segs.map((s) => s.text)).toEqual(['Hello there', 'How are you', 'Goodbye']);
+    expect(segs[0].translations).toBeUndefined();
+  });
+
+  it('maps timestamped cues onto existing rows without changing their timings', () => {
+    const { result } = renderHook(() => useSegmentEditing());
+    paste(result, 'x', {
+      mode: 'timestamped',
+      cues: [
+        { start: 0.5, end: 3.0, text: 'Hola' },
+        { start: 3.0, end: 5.5, text: 'Adios' },
+      ],
+    });
+    const segs = useAppStore.getState().dubSegments;
+    expect(segs.map((s) => [s.start, s.end])).toEqual([
+      [0, 2],
+      [2, 4],
+      [4, 6],
+    ]);
+    expect(segs[0].text).toBe('Hola');
+  });
+});
+
+// ── Preview dialog ────────────────────────────────────────────────────────
+describe('DubPasteTranslationDialog', () => {
+  it('previews before→after rows, flags unmatched, and applies on confirm', async () => {
+    const onApply = vi.fn();
+    render(
+      <DubPasteTranslationDialog open segments={SEGMENTS} onApply={onApply} onClose={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Hola\nQue tal' } });
+
+    const rows = await screen.findAllByTestId('paste-translation-row');
+    expect(rows).toHaveLength(3);
+    expect(rows[2].getAttribute('data-matched')).toBe('false');
+    expect(screen.getByTestId('paste-translation-summary').textContent).toContain('3');
+
+    const apply = screen.getByRole('button', { name: /Apply/i });
+    expect(apply).not.toBeDisabled();
+    fireEvent.click(apply);
+    expect(onApply).toHaveBeenCalledWith(
+      'Hola\nQue tal',
+      expect.objectContaining({ mode: 'plain' }),
+    );
+  });
+
+  it('disables Apply only when nothing matched', async () => {
+    render(<DubPasteTranslationDialog open segments={[]} onApply={vi.fn()} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Hola' } });
+    expect(screen.getByRole('button', { name: /Apply/i })).toBeDisabled();
+  });
+
+  it('sends a timestamped paste to the backend parser and previews the cues', async () => {
+    dubApi.dubParseSubtitleText.mockResolvedValue({
+      segments: [
+        { start: 0, end: 2, text: 'Hola' },
+        { start: 2, end: 4, text: 'Que tal' },
+        { start: 4, end: 6, text: 'Adios' },
+      ],
+      skipped_cues: 0,
+      dropped_overlaps: 0,
+    });
+    render(
+      <DubPasteTranslationDialog open segments={SEGMENTS} onApply={vi.fn()} onClose={vi.fn()} />,
+    );
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '1\n00:00:01,000 --> 00:00:02,000\nHola.\n' },
+    });
+
+    await waitFor(() => expect(dubApi.dubParseSubtitleText).toHaveBeenCalled());
+    const rows = await screen.findAllByTestId('paste-translation-row');
+    expect(rows.every((r) => r.getAttribute('data-matched') === 'true')).toBe(true);
+  });
+
+  it('surfaces a backend parse failure instead of applying a silent no-op', async () => {
+    dubApi.dubParseSubtitleText.mockRejectedValue(new Error('No timed cues found'));
+    render(
+      <DubPasteTranslationDialog open segments={SEGMENTS} onApply={vi.fn()} onClose={vi.fn()} />,
+    );
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '1\n00:00:01,000 --> 00:00:02,000\nHola.\n' },
+    });
+
+    expect(await screen.findByTestId('paste-translation-error')).toHaveTextContent(
+      'No timed cues found',
+    );
+    expect(screen.getByRole('button', { name: /Apply/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -42,8 +42,7 @@ import type { PostHog } from 'posthog-js';
  * live in exactly this file and backend/core/analytics.py.
  */
 const PUBLIC_PROJECT_TOKEN = 'phc_v5wMjnYMPMaEcRNLRKQsTYCzPaYWh7wcHPhXNkNajVf9'; // gitleaks:allow — publishable write-only key (#1193)
-const POSTHOG_TOKEN: string =
-  (import.meta.env?.VITE_POSTHOG_KEY as string) || PUBLIC_PROJECT_TOKEN;
+const POSTHOG_TOKEN: string = (import.meta.env?.VITE_POSTHOG_KEY as string) || PUBLIC_PROJECT_TOKEN;
 const POSTHOG_HOST: string =
   (import.meta.env?.VITE_POSTHOG_HOST as string) || 'https://eu.i.posthog.com';
 

--- a/frontend/src/utils/pasteTranslations.js
+++ b/frontend/src/utils/pasteTranslations.js
@@ -1,0 +1,197 @@
+/**
+ * pasteTranslations — map externally-produced translated text onto the dub
+ * timeline's EXISTING segments.
+ *
+ * The workflow this serves: the user transcribes once, then translates
+ * elsewhere (ChatGPT, DeepL, a human translator) and pastes the result back.
+ * Nothing about the timeline may change — no re-transcription, no re-timing,
+ * no touching `text_original` (which `handleTranslateAll` reads as its
+ * translate source; overwriting it would poison every later re-translate).
+ *
+ * Three input shapes cover essentially everything people paste. They are
+ * auto-detected, and every mapping is previewed before it is applied:
+ *
+ *   timestamped — a full .srt/.vtt. Cues are parsed by the BACKEND
+ *     (`/dub/parse-subtitle-text`, the same lenient parser the .srt import
+ *     uses) and matched to segments by TIME OVERLAP, so a translation whose
+ *     cue boundaries drift from ours still lands on the right rows.
+ *   numbered — `1. …` / `2) …` / `[3] …`, what an LLM emits when asked to
+ *     keep lines aligned. Mapped by the number, tolerant of renumbering.
+ *   plain — one translation per line, mapped positionally.
+ *
+ * Everything here is pure so the preview dialog and the applying hook derive
+ * the SAME plan from the same inputs.
+ */
+
+// A timing line, e.g. `00:00:01,000 --> 00:00:04,500` (`.` ms separator and
+// missing leading zeros allowed — mirrors backend/services/srt_parser.py).
+const TIMING_RE = /\d{1,2}:[0-5]?\d:[0-5]?\d[,.]\d{1,3}\s*-->/;
+
+// `1. text` / `2) text` / `[3] text` / `4 - text` / `5: text`.
+const NUMBERED_RE = /^\s*(?:\[\s*(\d{1,5})\s*\]|\(\s*(\d{1,5})\s*\)|(\d{1,5}))\s*[.):\-—]?\s+(.*)$/;
+
+/** Lines that carry content. Blank lines are separators, never translations. */
+const nonBlank = (text) =>
+  String(text || '')
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+/**
+ * Which of the three shapes is this paste?
+ *
+ * @returns {'timestamped'|'numbered'|'plain'}
+ */
+export function detectPasteMode(text) {
+  const raw = String(text || '');
+  if (TIMING_RE.test(raw)) return 'timestamped';
+  const lines = nonBlank(raw);
+  if (lines.length >= 2) {
+    const numbered = lines.filter((l) => NUMBERED_RE.test(l)).length;
+    // A majority rules: LLM output often carries a stray preamble line
+    // ("Here are the translations:") that must not veto the detection.
+    if (numbered >= 2 && numbered / lines.length >= 0.6) return 'numbered';
+  }
+  return 'plain';
+}
+
+/**
+ * Numbered paste → entries in encounter order, prefix stripped.
+ * Continuation lines (no number) append to the entry above them.
+ *
+ * @returns {Array<{num: number|null, text: string}>}
+ */
+export function parseNumberedLines(text) {
+  const entries = [];
+  for (const line of nonBlank(text)) {
+    const m = NUMBERED_RE.exec(line);
+    if (m) {
+      const num = parseInt(m[1] ?? m[2] ?? m[3], 10);
+      entries.push({ num: Number.isFinite(num) ? num : null, text: (m[4] || '').trim() });
+    } else if (entries.length) {
+      entries[entries.length - 1].text = `${entries[entries.length - 1].text} ${line}`.trim();
+    }
+    // A leading line with no number and no entry yet is a preamble — dropped.
+  }
+  return entries.filter((e) => e.text);
+}
+
+/**
+ * Time-overlap matching, one-to-one and greedy by best overlap.
+ *
+ * Greedy-unique rather than per-segment-argmax on purpose: when one long cue
+ * overlaps several short segments, argmax would copy the same sentence into
+ * every one of them. Claiming the strongest pair first and then excluding
+ * both sides leaves the weaker rows honestly unmatched, which the preview
+ * flags instead of silently duplicating text.
+ *
+ * Candidate pairs come from a sweep over both lists sorted by start time, so
+ * a feature-length transcript (thousands of segments × thousands of cues)
+ * costs "pairs that actually overlap" rather than the full cross product.
+ */
+export function matchByOverlap(cues, segments) {
+  const byStart = (a, b) => a.start - b.start || a.i - b.i;
+  const segIv = segments.map((s, i) => ({ i, start: s.start, end: s.end })).sort(byStart);
+  const cueIv = cues.map((c, i) => ({ i, start: c.start, end: c.end })).sort(byStart);
+
+  const pairs = [];
+  let lo = 0;
+  for (const s of segIv) {
+    // Segments are visited in start order, so a cue ending at or before this
+    // segment's start cannot reach any later segment either — retire it.
+    while (lo < cueIv.length && cueIv[lo].end <= s.start) lo++;
+    for (let k = lo; k < cueIv.length && cueIv[k].start < s.end; k++) {
+      const ov = Math.min(s.end, cueIv[k].end) - Math.max(s.start, cueIv[k].start);
+      if (ov > 0) pairs.push({ si: s.i, ci: cueIv[k].i, ov });
+    }
+  }
+  // Ties resolve by document order so the plan is deterministic.
+  pairs.sort((a, b) => b.ov - a.ov || a.si - b.si || a.ci - b.ci);
+  const bySeg = new Map();
+  const usedCues = new Set();
+  for (const p of pairs) {
+    if (bySeg.has(p.si) || usedCues.has(p.ci)) continue;
+    bySeg.set(p.si, p.ci);
+    usedCues.add(p.ci);
+  }
+  return { bySeg, usedCues };
+}
+
+/**
+ * Build the full before→after plan for a paste. Pure — the dialog renders it
+ * and the hook applies exactly the same thing.
+ *
+ * @param {string} text        raw pasted text
+ * @param {Array}  segments    current dub segments (unchanged)
+ * @param {object} opts
+ * @param {string} [opts.mode] force a mode; defaults to auto-detection
+ * @param {Array}  [opts.cues] parsed cues (required for 'timestamped')
+ * @returns {{mode, rows, matchedCount, unmatchedCount, sourceCount, unusedCount}}
+ *   `rows` has one entry per segment: {id, index, before, after, matched}.
+ */
+export function buildPastePlan(text, segments, opts = {}) {
+  const segs = Array.isArray(segments) ? segments : [];
+  const mode = opts.mode || detectPasteMode(text);
+  const assigned = new Map(); // segment index -> new text
+  let sourceCount = 0;
+  let usedCount = 0;
+
+  if (mode === 'timestamped') {
+    const cues = (opts.cues || []).filter(
+      (c) => c && Number.isFinite(c.start) && Number.isFinite(c.end),
+    );
+    sourceCount = cues.length;
+    const { bySeg } = matchByOverlap(cues, segs);
+    for (const [si, ci] of bySeg) {
+      const t = String(cues[ci].text || '').trim();
+      if (t) assigned.set(si, t);
+    }
+    usedCount = assigned.size;
+  } else if (mode === 'numbered') {
+    const entries = parseNumberedLines(text);
+    sourceCount = entries.length;
+    // Trust the numbers only when they read as a clean 1-based index into
+    // the segment list. LLMs happily restart at 1 mid-answer or emit
+    // "1)…2)…2)…" — in that case the ORDER is still right, so fall back to
+    // positional rather than scattering lines onto wrong rows.
+    const nums = entries.map((e) => e.num);
+    const usable =
+      nums.every((n) => Number.isFinite(n) && n >= 1 && n <= segs.length) &&
+      nums.every((n, i) => i === 0 || n > nums[i - 1]);
+    entries.forEach((e, i) => {
+      const si = usable ? e.num - 1 : i;
+      if (si < segs.length && !assigned.has(si)) assigned.set(si, e.text);
+    });
+    usedCount = assigned.size;
+  } else {
+    const lines = nonBlank(text);
+    sourceCount = lines.length;
+    lines.forEach((line, i) => {
+      if (i < segs.length) assigned.set(i, line);
+    });
+    usedCount = assigned.size;
+  }
+
+  const rows = segs.map((s, i) => ({
+    id: s.id,
+    index: i,
+    start: s.start,
+    end: s.end,
+    before: s.text || '',
+    after: assigned.has(i) ? assigned.get(i) : null,
+    matched: assigned.has(i),
+  }));
+
+  return {
+    mode,
+    rows,
+    matchedCount: assigned.size,
+    unmatchedCount: segs.length - assigned.size,
+    sourceCount,
+    // Pasted lines/cues that found no home — an over-long paste, or cues
+    // outside the timeline. Surfaced so the user can tell "nothing was
+    // dropped" from "12 lines went nowhere".
+    unusedCount: Math.max(0, sourceCount - usedCount),
+  };
+}

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -160,6 +160,7 @@ POST /dub/cleanup-segments/{job_id}
 POST /dub/generate/{job_id}
 POST /dub/import-srt/{job_id}
 POST /dub/ingest-url
+POST /dub/parse-subtitle-text
 POST /dub/preview-segment/{job_id}
 POST /dub/qc/{job_id}
 POST /dub/transcribe/{job_id}

--- a/tests/test_dub_parse_subtitle_text.py
+++ b/tests/test_dub_parse_subtitle_text.py
@@ -1,0 +1,105 @@
+"""Tests for POST /dub/parse-subtitle-text.
+
+Stateless wrapper over `services.srt_parser.parse_srt` that backs the
+"paste a translation from an external source" flow. It must stay
+job-free (no mutation, no file I/O), reject oversized pastes, and give a
+typed 400 when the paste has no timed cues at all.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+
+
+def _call(text):
+    from api.routers import dub_core
+    from schemas.requests import ParseSubtitleTextRequest
+
+    return dub_core.dub_parse_subtitle_text(ParseSubtitleTextRequest(text=text))
+
+
+SRT = """1
+00:00:01,000 --> 00:00:04,500
+Hola mundo.
+
+2
+00:00:05,250 --> 00:00:08,000
+Segunda línea.
+"""
+
+VTT = """WEBVTT
+
+00:00:01.000 --> 00:00:04.500
+Hola mundo.
+
+00:00:05.250 --> 00:00:08.000
+Segunda línea.
+"""
+
+
+def test_parses_srt_into_cues():
+    res = _call(SRT)
+    assert res["skipped_cues"] == 0
+    assert res["dropped_overlaps"] == 0
+    assert res["segments"] == [
+        {"start": 1.0, "end": 4.5, "text": "Hola mundo."},
+        {"start": 5.25, "end": 8.0, "text": "Segunda línea."},
+    ]
+
+
+def test_parses_vtt_style_timestamps():
+    # WebVTT uses `.` for the ms separator and has no cue indices; the
+    # lenient parser handles both, and the `WEBVTT` header sits before the
+    # first timing line so it is never mistaken for cue text.
+    res = _call(VTT)
+    assert [s["text"] for s in res["segments"]] == ["Hola mundo.", "Segunda línea."]
+    assert res["segments"][0]["start"] == 1.0
+
+
+def test_response_carries_no_job_shaped_fields():
+    # The client keeps its own segments (ids, timings, text_original); this
+    # endpoint must hand back cues only, never a segment record that could
+    # tempt a caller into replacing rows wholesale.
+    res = _call(SRT)
+    assert set(res["segments"][0]) == {"start", "end", "text"}
+
+
+def test_garbage_input_is_a_typed_400():
+    with pytest.raises(HTTPException) as exc:
+        _call("Just some translated prose with no timestamps at all.")
+    assert exc.value.status_code == 400
+    assert "no timed cues" in str(exc.value.detail).lower()
+
+
+def test_empty_input_is_a_typed_400():
+    with pytest.raises(HTTPException) as exc:
+        _call("")
+    assert exc.value.status_code == 400
+
+
+def test_oversized_paste_is_rejected_before_parsing():
+    from api.routers import dub_core
+
+    with pytest.raises(HTTPException) as exc:
+        _call("x" * (dub_core._MAX_SUBTITLE_PASTE_CHARS + 1))
+    assert exc.value.status_code == 413
+    assert "too large" in str(exc.value.detail).lower()
+
+
+def test_at_the_size_limit_is_still_parsed():
+    from api.routers import dub_core
+
+    pad = "\n" * (dub_core._MAX_SUBTITLE_PASTE_CHARS - len(SRT))
+    res = _call(SRT + pad)
+    assert len(res["segments"]) == 2
+
+
+def test_route_is_registered_without_a_job_id():
+    from api.routers import dub_core
+
+    paths = {r.path for r in dub_core.router.routes}
+    assert "/dub/parse-subtitle-text" in paths

--- a/tests/test_srt_parser.py
+++ b/tests/test_srt_parser.py
@@ -145,6 +145,36 @@ def test_returns_empty_result_for_empty_input():
     assert parse_srt("").skipped_cues == 0
 
 
+def test_blank_line_flood_parses_in_linear_time():
+    # Regression: the timing-line regex used `^\s*` under re.MULTILINE, so at
+    # every one of N line starts the engine consumed all remaining blank
+    # lines before failing — quadratic. 20k blank lines already took ~1.7s
+    # and a 2 MB blank-line file never returned, pinning the request thread
+    # (reachable from /dub/import-srt with a mis-saved export, and from the
+    # pasted-text endpoint). Horizontal-whitespace-only classes make it
+    # linear: this input parses in milliseconds.
+    import time
+
+    srt = "1\n00:00:01,000 --> 00:00:02,000\nOnly cue.\n" + "\n" * 400_000
+    started = time.monotonic()
+    result = parse_srt(srt)
+    elapsed = time.monotonic() - started
+    assert len(result.segments) == 1
+    assert result.segments[0]["text"] == "Only cue."
+    # Pre-fix this was minutes; the bound is loose enough for a slow CI box
+    # and still ~3 orders of magnitude under the quadratic behaviour.
+    assert elapsed < 5.0, f"parse_srt took {elapsed:.1f}s — quadratic scan is back"
+
+
+def test_timing_line_tolerates_leading_and_inner_spaces():
+    # The linearity fix narrowed `\s*` to horizontal whitespace; indented
+    # cues and extra spaces around the arrow must still parse.
+    srt = "  \t00:00:01,000  -->  \t00:00:02,000\nIndented.\n"
+    result = parse_srt(srt)
+    assert len(result.segments) == 1
+    assert result.segments[0]["text"] == "Indented."
+
+
 def test_segments_get_sequential_ids_and_required_fields():
     srt = """1
 00:00:01,000 --> 00:00:02,000


### PR DESCRIPTION
Paste a translation made elsewhere (ChatGPT, DeepL, a human) onto the segments you already have — no re-transcription, no timing loss. Auto-detects timestamped `.srt`/`.vtt` (matched by time overlap), numbered lines, and plain lines; a preview dialog shows every row before→after with unmatched rows flagged before anything is applied.

Applying mirrors `segmentEditField` across rows in one undo step: writes `text` + `translations[dubLangCode]` in lock-step, never `text_original` (the translate source — overwriting it poisons later re-translates), never another language. `POST /dub/parse-subtitle-text` is a stateless wrapper so the lenient cue parser stays single-sourced.

**Separate real bug fixed here:** `srt_parser._TIMING_RE` used `^\s*` under `re.MULTILINE` — the engine consumed all remaining blank lines at every line start before failing, making the scan quadratic. Reachable today via `/dub/import-srt`: 20k blank lines took 1.7s, a 2 MB blank-line file never returned and pinned the request thread. Now linear (regression test included).

Tests: backend 22 targeted (8 new endpoint + 2 new parser regressions), frontend 36 new; full suites green apart from 4 pre-existing cross-test-pollution failures unrelated to this change (verified against `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Paste Translation” to the dubbing editor, letting you paste subtitles from external tools (or upload SRT/VTT/text) and map them onto existing segments.
  * Supports timestamped, numbered, and plain-text formats with previews, match/unmatched counts, and safe application to the selected target language (preserving original timing/transcripts).
  * Added localized UI text for the new workflow across supported languages.
* **Bug Fixes**
  * Improved subtitle parsing reliability/performance when importing files with many blank lines.
* **Documentation**
  * Updated the dubbing roadmap and added documentation for the paste translation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->