### PR TITLE
fix(gpu-pool): bound execution, not queue wait (#1190, #1202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - No silent multi-GB downloads anywhere — explicit, one-click prompts instead
 - Windows: custom install drives honored, no console-window storms, no black-screen boot
 - Quiet recordings clone; broken engine deps repair-hint and fall back
+- Queued and long generations stop failing with a bogus "too heavy for your hardware"
 - First-run analytics consent, Colab notebook, ROCm Docker image, trusted-network CIDRs
 
 ### Changed
@@ -50,6 +51,13 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- A generation queued behind a busy one no longer spends its timeout waiting: the budget starts when a GPU worker picks the job up, so a queued request can't be failed as "too heavy for the available compute" without having run (#1190)
+- One request's timeout no longer cancels unrelated jobs already waiting in the GPU queue (#1190)
+- Timeout messages stopped claiming capacity was restored automatically — the abandoned job keeps the device until it finishes, and the guidance now says to let it drain (#1190)
+- The length-scaled generate budget now covers every path — streaming previews, batch dubbing, `/v1/audio/speech`, dub and archetype previews — instead of only the two classic call sites, so long inputs stop failing at a flat 300s (#1190)
+- Provenance watermarking moved off the GPU worker pool: on 1-worker machines each embed was serializing ahead of the next generation (#1190)
+- A batch segment that times out fails the job with a reason instead of shipping a finished-looking dub with silent gaps (#1190)
+- `/v1/audio/speech` refuses work up front with 429 + `Retry-After` when the pool is saturated, and returns a retryable 503 rather than a 500 on timeout (#1190)
 - Subtitle parsing no longer stalls on a blank-line-heavy `.srt`: the timing-line regex backtracked across newlines, so a mis-saved export could pin an import for hours (#1203)
 - A broken ASR engine's fallback could silently auto-download multi-GB weights — every fallback now passes the same no-download preflight and shows the download CTA instead (#1189)
 - Dub transcription releases the ASR model from VRAM on every exit — crashes, early errors, and client disconnects included (#1175)

--- a/backend/api/routers/archetypes.py
+++ b/backend/api/routers/archetypes.py
@@ -169,9 +169,13 @@ async def _render_archetype_wav(a: dict, out_path: Path) -> None:
         )
 
     # Bounded + pool-reset on hang so a wedged preview render can't starve the
-    # GPU pool and brick the backend (#730 class).
+    # GPU pool and brick the backend (#730 class). Budget comes from the shared
+    # length-scaled helper (#1190) instead of the flat 300s default.
+    from services.model_manager import generate_timeout_s
+    _budget = generate_timeout_s(text)
     audio_tensor = await run_on_gpu_pool_guarded(
-        lambda: _infer(_PREVIEW_SEED), what="Archetype preview generate")
+        lambda: _infer(_PREVIEW_SEED), what="Archetype preview generate",
+        timeout=_budget)
     if _is_unusable_audio(audio_tensor):
         # Blank OR a degenerate tonal buzz — retry once on a different seed to
         # step off the bad diffusion trajectory. Static message only: the
@@ -179,7 +183,8 @@ async def _render_archetype_wav(a: dict, out_path: Path) -> None:
         # module constant, safe to log.
         logger.warning("Archetype rendered unusable at seed %d — retrying once", _PREVIEW_SEED)
         audio_tensor = await run_on_gpu_pool_guarded(
-            lambda: _infer(_PREVIEW_SEED + 1), what="Archetype preview generate")
+            lambda: _infer(_PREVIEW_SEED + 1), what="Archetype preview generate",
+            timeout=_budget)
     if _is_unusable_audio(audio_tensor):
         raise RuntimeError("the voice engine returned no audible audio for this archetype")
 
@@ -191,12 +196,18 @@ async def _render_archetype_wav(a: dict, out_path: Path) -> None:
     # never raises (degrades to unmarked on failure). User-uploaded/recorded
     # reference audio is human speech and is never marked — this only touches
     # audio the engine synthesized.
+    # Runs on the dedicated watermark pool (#1190): AudioSeal embedding is CPU
+    # work that holds no VRAM, so it must not occupy a GPU worker ahead of the
+    # next generate on 1-worker hosts.
     from services.watermark import mark_synthetic
+    from services.model_manager import get_watermark_pool
     import functools
     audio_tensor = await run_on_gpu_pool_guarded(
         functools.partial(mark_synthetic, audio_tensor, model.sampling_rate,
                           context="archetypes.render"),
         what="Archetype watermark",
+        timeout=generate_timeout_s(""),
+        executor=get_watermark_pool(),
     )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -334,12 +334,27 @@ async def _run_batch_pipeline(job_id: str, job: dict):
                     return normalize_audio(audio_out, target_dBFS=-2.0)
                 except Exception as e:
                     logger.warning("TTS failed for seg %d (lang=%s): %s", i, lang, e)
+                    # #1190: the silence still stands in for the segment (one
+                    # bad line shouldn't bin an otherwise good dub), but it is
+                    # no longer INVISIBLE — the job carries a warning the UI /
+                    # API consumer can see instead of shipping a
+                    # finished-looking track with unexplained silence.
+                    job.setdefault("warnings", []).append(
+                        f"Segment {i + 1} of the {lang} track failed to "
+                        f"synthesize and was left silent: {e}"
+                    )
                     return torch.zeros(1, int(dur * sr))
 
             try:
                 # Bounded + pool-reset on hang so a wedged batch segment can't
                 # starve the GPU pool and brick the backend (#730 class).
-                audio_tensor = await run_on_gpu_pool_guarded(_gen, what="Batch generate")
+                # Budget is the shared length-scaled one (#1190): a long segment
+                # on CPU-class hardware no longer dies on the flat 300s.
+                from services.model_manager import generate_timeout_s
+                audio_tensor = await run_on_gpu_pool_guarded(
+                    _gen, what="Batch generate",
+                    timeout=generate_timeout_s(seg_text),
+                )
 
                 # Fit to slot
                 target_samples_seg = int(seg_duration * sr)
@@ -364,8 +379,28 @@ async def _run_batch_pipeline(job_id: str, job: dict):
                 e_idx = min(s_idx + wl, total_samples)
                 full_audio[:, s_idx:e_idx] += audio_tensor[:, :e_idx - s_idx]
 
+            except TimeoutError as e:
+                # #1190/#1202: a GPU timeout (or a saturated pool) used to be
+                # swallowed into a silent gap in the dubbed track — the user got
+                # a finished-looking video with missing speech and no warning,
+                # and on a 1-worker host the abandoned job made every later
+                # segment likelier to time out too (the "22-chunk batch dies at
+                # chunk 3" cascade). Fail the job loudly instead: _worker()'s
+                # except-Exception handler records a structured failure the UI
+                # surfaces. Non-timeout per-segment errors keep the old
+                # degrade-to-gap behaviour, but are now recorded on the job.
+                logger.error("Batch TTS seg %d timed out — failing the job: %s", i, e)
+                raise RuntimeError(
+                    f"Segment {i + 1} of the {target_lang} track did not "
+                    f"render, so the dubbed track would have shipped with a "
+                    f"silent gap. {e}"
+                ) from e
             except Exception as e:
                 logger.warning("Batch TTS seg %d failed: %s", i, e)
+                job.setdefault("warnings", []).append(
+                    f"Segment {i + 1} of the {target_lang} track failed and was "
+                    f"left silent: {e}"
+                )
 
         # ── 3c. Save dubbed audio track ───────────────────────────────
         # Invisible provenance mark on the assembled track (#1169), tensor
@@ -375,10 +410,15 @@ async def _run_batch_pipeline(job_id: str, job: dict):
         # dub_generate's per-segment marks: the 16-bit message repeats
         # throughout. Runs in the GPU pool like generate's finalize; never
         # raises (degrades to unmarked on failure, same as every producer).
+        # Dispatched to the dedicated watermark pool, not the GPU pool (#1190):
+        # AudioSeal embedding is CPU work that holds no VRAM, and a whole-track
+        # embed is long enough that occupying a GPU worker with it stalled the
+        # next language's segments on 1-worker hosts.
         from services.watermark import mark_synthetic
+        from services.model_manager import get_watermark_pool
         import functools
         full_audio = await loop.run_in_executor(
-            _gpu_pool,
+            get_watermark_pool(),
             functools.partial(mark_synthetic, full_audio, sr,
                               context="batch.dub_track"),
         )

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -805,12 +805,16 @@ async def dub_generate(job_id: str, req: DubRequest):
 
                 # Bounded + pool-reset on hang so a wedged dub segment can't
                 # starve the GPU pool and brick the backend (#730 class).
+                # Budget from the shared length-scaled helper (#1190): a long
+                # dub segment used to die on the flat 300s even after v0.3.22.
+                from services.model_manager import generate_timeout_s
                 audio_tensor = await run_on_gpu_pool_guarded(
                     lambda: _gen(
                         seg.text, seg_lang, seg_instruct, _dur_for_tts,
                         _num_step, req.guidance_scale, seg_speed, seg_profile, seg_effect_preset,
                     ),
                     what="Dub generate",
+                    timeout=generate_timeout_s(seg.text),
                 )
                 _t_tts += time.perf_counter() - _t_tts_0
 
@@ -1498,8 +1502,12 @@ async def preview_segment(job_id: str, req: SegmentPreviewRequest):
                               context="dub_generate.preview_segment")
 
     # Bounded + pool-reset on hang so a wedged preview generate can't starve the
-    # GPU pool and brick the backend (#730 class).
-    audio_tensor = await run_on_gpu_pool_guarded(_gen, what="Dub preview generate")
+    # GPU pool and brick the backend (#730 class). Length-scaled budget (#1190).
+    from services.model_manager import generate_timeout_s
+    audio_tensor = await run_on_gpu_pool_guarded(
+        _gen, what="Dub preview generate",
+        timeout=generate_timeout_s(req.text),
+    )
 
     sr = backend.sample_rate
     buf = io.BytesIO()

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -20,6 +20,7 @@ from core.config import OUTPUTS_DIR, VOICES_DIR
 import functools
 from services.model_manager import (
     get_model, _gpu_pool, run_on_gpu_pool_guarded, GpuJobTimeoutError,
+    GpuPoolBusyError,
 )
 from services.audio_io import _safe_torchaudio_save
 from services.binary_preflight import InvalidBinaryError
@@ -443,17 +444,13 @@ def _oom_friendly_reraise(e):
 def _generate_timeout_s(text: str) -> float:
     """Wall-clock budget for one generate, scaled to the request.
 
-    The fixed OMNIVOICE_GENERATE_TIMEOUT_S (300s) was sized for typical
-    requests on a GPU — a legitimately long text on a slow CPU box times out
-    with the exact user-facing 503 the audit flagged as a recurring class
-    (#1033/#1037 wave), and the remedy was "go set an env var". Scale the
-    budget with input size instead: the floor stays the configured value, and
-    long inputs get 1 extra second per 40 characters — generous enough for
-    CPU-class hardware, still bounded (a wedged job is caught in minutes, not
-    hours). An explicit OMNIVOICE_GENERATE_TIMEOUT_S remains the floor/knob.
+    Thin alias for the canonical helper, which moved to
+    ``services.model_manager.generate_timeout_s`` (#1190) so /v1/audio/speech,
+    batch, dub and archetype previews share it instead of each re-deriving (or,
+    as they did, silently keeping the flat 300s).
     """
-    from services.model_manager import GPU_JOB_TIMEOUT_S
-    return max(GPU_JOB_TIMEOUT_S, GPU_JOB_TIMEOUT_S + (max(0, len(text or "") - 1200) / 40.0))
+    from services.model_manager import generate_timeout_s
+    return generate_timeout_s(text)
 
 
 def _run_inference(
@@ -658,9 +655,13 @@ async def _finalize_generation(
     # producers now share the mark_synthetic chokepoint. It self-gates on the
     # user's watermark setting + AudioSeal availability and passes the audio
     # through unchanged on any failure, so it never breaks generation.
+    # Dispatched to the dedicated watermark pool, not the GPU pool (#1190):
+    # AudioSeal embedding is CPU work that holds no VRAM, so occupying a GPU
+    # worker with it only delays the next generate on 1-worker hosts.
     from services.watermark import mark_synthetic
+    from services.model_manager import get_watermark_pool
     audio_tensor = await loop.run_in_executor(
-        _gpu_pool,
+        get_watermark_pool(),
         functools.partial(mark_synthetic, audio_tensor, sample_rate,
                           context="generate.finalize"),
     )
@@ -1015,8 +1016,14 @@ async def generate_speech(
             ref_text = await run_on_gpu_pool_guarded(
                 functools.partial(transcribe_reference, ref_audio_path),
                 what="Reference transcribe",
+                # Floor budget (#1190): a reference clip is seconds of audio,
+                # so the length-scaled bonus never applies — but the timeout is
+                # explicit here too, so no dispatch relies on a hidden default.
+                timeout=_generate_timeout_s(""),
             )
-        except GpuJobTimeoutError as e:
+        # TimeoutError covers both the execution bound and pool saturation:
+        # this path is best-effort either way.
+        except TimeoutError as e:
             logger.warning("reference transcribe hung (%s); using model ASR fallback", e)
             ref_text = None
         # #1032: cache the transcript onto its clone profile so the ASR model
@@ -1140,14 +1147,15 @@ async def generate_speech(
                     sr = _model.sampling_rate if hasattr(_model, "sampling_rate") else 24000
                     skip = False
                 preview = _apply_effect_chain(raw, sr, effect_preset, skip_mastering=skip)
-                # Provenance-mark the STREAMED copy only (#1169): the preview
-                # PCM leaves the app the moment it's yielded, before
+                # The STREAMED copy is provenance-marked by the caller (#1169
+                # mark, moved off this GPU job in #1190): the preview PCM
+                # leaves the app the moment it's yielded, before
                 # _finalize_generation marks the assembled take, so it needs
-                # its own mark. `raw` stays unmarked — the saved artifact gets
-                # exactly one whole-take mark in the finalize path (no
-                # double-embed on the file users keep).
-                from services.watermark import mark_synthetic
-                preview = mark_synthetic(preview, sr, context="generate.stream_preview")
+                # its own mark — but AudioSeal embedding is CPU work, and
+                # doing it here held the GPU worker for the whole embed on
+                # every one of N chunks. `raw` stays unmarked — the saved
+                # artifact gets exactly one whole-take mark in the finalize
+                # path (no double-embed on the file users keep).
                 return raw, preview, sr
             except ValueError:
                 raise
@@ -1187,6 +1195,7 @@ async def generate_speech(
                                 max_chunk_chars, crossfade_ms,
                             ),
                             what="TTS generate",
+                            timeout=_generate_timeout_s(text),
                         )
                         sample_rate = _backend.sample_rate
                     else:
@@ -1201,6 +1210,7 @@ async def generate_speech(
                                 max_chunk_chars, crossfade_ms,
                             ),
                             what="TTS generate",
+                            timeout=_generate_timeout_s(text),
                         )
                         sample_rate = _model.sampling_rate
                     yield _line({
@@ -1213,9 +1223,14 @@ async def generate_speech(
                     # the saved take. Marking a copy keeps the artifact's
                     # single whole-take mark (embed_watermark returns a new
                     # tensor; audio_tensor itself is untouched).
+                    # Runs on the dedicated watermark pool, not the GPU pool
+                    # (#1190): AudioSeal embedding is CPU work that owns no
+                    # VRAM, and on a 1-worker host it used to serialize
+                    # directly ahead of the next generate.
                     from services.watermark import mark_synthetic
+                    from services.model_manager import get_watermark_pool
                     _preview = await asyncio.get_running_loop().run_in_executor(
-                        _gpu_pool,
+                        get_watermark_pool(),
                         functools.partial(mark_synthetic, audio_tensor, sample_rate,
                                           context="generate.stream_preview"),
                     )
@@ -1229,8 +1244,22 @@ async def generate_speech(
                         raw, preview, sample_rate = await run_on_gpu_pool_guarded(
                             functools.partial(_render_stream_chunk, i, chunk_text),
                             what="TTS generate",
+                            # Budget scaled to THIS chunk (#1190) — the flat
+                            # 300s here is what made long streamed renders fail
+                            # even after the v0.3.22 scaled budget shipped.
+                            timeout=_generate_timeout_s(chunk_text),
                         )
                         parts.append(raw)
+                        # Provenance-mark the streamed copy off the GPU pool
+                        # (#1169 mark, #1190 placement): CPU-only AudioSeal
+                        # work must not occupy a GPU worker between chunks.
+                        from services.watermark import mark_synthetic
+                        from services.model_manager import get_watermark_pool
+                        preview = await asyncio.get_running_loop().run_in_executor(
+                            get_watermark_pool(),
+                            functools.partial(mark_synthetic, preview, sample_rate,
+                                              context="generate.stream_preview"),
+                        )
                         if i == 0:
                             # After the first render so lazy-loading engines
                             # report their REAL sample rate (see /ws/tts).
@@ -1244,6 +1273,7 @@ async def generate_speech(
                     audio_tensor = await run_on_gpu_pool_guarded(
                         functools.partial(_assemble_stream_chunks, parts, sample_rate),
                         what="TTS assemble",
+                        timeout=_generate_timeout_s(text),
                     )
 
                 _, meta = await _finalize_generation(
@@ -1261,9 +1291,15 @@ async def generate_speech(
                 # Client went away mid-stream — same semantics as aborting a
                 # classic /generate mid-render: nothing is saved.
                 raise
-            except GpuJobTimeoutError as e:
+            except (GpuJobTimeoutError, GpuPoolBusyError) as e:
+                # In-band error frame carries the machine-readable retryable
+                # marker (#1190) — an NDJSON consumer can back off instead of
+                # guessing from the prose.
                 logger.error("Streaming generate timed out: %s", e)
-                yield _line({"type": "error", "detail": str(e)})
+                yield _line({
+                    "type": "error", "detail": str(e), "retryable": True,
+                    "retry_after": getattr(e, "retry_after", 30),
+                })
             except ValueError as e:
                 logger.error("Streaming generate validation failed: %s", e)
                 yield _line({"type": "error", "detail": str(e)})
@@ -1373,12 +1409,25 @@ async def generate_speech(
         )
     except HTTPException:
         raise
+    except GpuPoolBusyError as e:
+        # Saturation, not failure (#1190): the job never started, so the caller
+        # can retry the identical request. Retry-After + the retryable marker
+        # make that machine-readable for scripted clients.
+        logger.warning("Generate refused — GPU pool saturated: %s", e)
+        raise HTTPException(
+            status_code=503, detail=str(e),
+            headers={"Retry-After": str(e.retry_after),
+                     "X-OmniVoice-Retryable": "true"},
+        ) from e
     except GpuJobTimeoutError as e:
-        # A wedged GPU generate — the pool was already reset to restore capacity
-        # (#730 class). Report the actionable timeout instead of the misleading
-        # "can't reach backend" the frontend shows when the pool starves.
+        # A generate that really ran and overran its budget (#730 class). The
+        # abandoned worker still holds the device until it drains — the message
+        # says so, and Retry-After spaces the retry out accordingly.
         logger.error("Generate timed out: %s", e)
-        raise HTTPException(status_code=503, detail=str(e)) from e
+        raise HTTPException(
+            status_code=503, detail=str(e),
+            headers={"Retry-After": "30", "X-OmniVoice-Retryable": "true"},
+        ) from e
     except InvalidBinaryError as e:
         # #1172 class: a managed engine binary is a placeholder / corrupt /
         # refused by the OS. The message carries the repair hint — surface it

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -257,6 +257,12 @@ def _typed_speech_http_error(e: Exception) -> Optional[HTTPException]:
     - InvalidBinaryError (managed engine binary is a placeholder / corrupt /
       refused by the OS) → 503 with the repair hint, instead of the bare
       "[Errno 8] Exec format error" 500.
+    - TimeoutError (#1190/#1202: pool saturation or a job that overran its
+      execution budget) → 503 + Retry-After + X-OmniVoice-Retryable, instead of
+      the 500 a scripted client can't distinguish from a real crash. Matched on
+      the BUILTIN base, not GpuJobTimeoutError by name, so a mid-suite module
+      reload can't break the isinstance check (same rationale as the load-path
+      catch below).
     Returns None for anything else (caller falls through to the generic 500).
     """
     from services.binary_preflight import InvalidBinaryError
@@ -266,6 +272,12 @@ def _typed_speech_http_error(e: Exception) -> Optional[HTTPException]:
         return HTTPException(status_code=400, detail=str(e))
     if isinstance(e, InvalidBinaryError):
         return HTTPException(status_code=503, detail=str(e))
+    if isinstance(e, TimeoutError):
+        return HTTPException(
+            status_code=503, detail=str(e),
+            headers={"Retry-After": str(getattr(e, "retry_after", 30)),
+                     "X-OmniVoice-Retryable": "true"},
+        )
     return None
 
 
@@ -410,11 +422,32 @@ async def create_speech(req: SpeechRequest):
         logger.warning("OpenAI TTS engine load failed: %s", e)
         raise http from e
 
+    # Admission control at SUBMIT (#1190/#1202). This is the scripted-client
+    # surface: a script fanning out N requests at a 1-worker pool used to get N
+    # silent multi-minute waits and then "too heavy for the available compute".
+    # Refusing up front with 429 + Retry-After lets a client back off correctly,
+    # and costs an interactive user nothing (the policy only trips when a full
+    # wave of jobs is ALREADY queued — see check_gpu_admission).
+    from services.model_manager import check_gpu_admission
+    try:
+        check_gpu_admission(what="OpenAI TTS generate")
+    except TimeoutError as e:
+        logger.warning("OpenAI TTS refused — GPU pool saturated: %s", e)
+        raise HTTPException(
+            status_code=429, detail=str(e),
+            headers={"Retry-After": str(getattr(e, "retry_after", 30)),
+                     "X-OmniVoice-Retryable": "true"},
+        ) from e
+
     try:
         # Bounded + pool-reset on hang so a wedged TTS request can't starve the
-        # GPU pool and brick the backend (#730 class).
+        # GPU pool and brick the backend (#730 class). The budget is the shared
+        # length-scaled one (#1190) — this route used to hardcode the flat 300s,
+        # so long inputs failed here even after v0.3.22 shipped the scaling.
+        from services.model_manager import generate_timeout_s
         wav, sr = await run_on_gpu_pool_guarded(
-            lambda: _run_tts(backend, text, kw), what="OpenAI TTS generate")
+            lambda: _run_tts(backend, text, kw), what="OpenAI TTS generate",
+            timeout=generate_timeout_s(text))
     except Exception as e:
         # #1172/#1173: typed failures get their real status + actionable
         # message (400 bad input / 503 broken engine binary) instead of a

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -234,9 +234,13 @@ async def ws_tts(websocket: WebSocket):
                     # starve the GPU pool and brick the backend (#730 class). On
                     # timeout GpuJobTimeoutError propagates to the handler below,
                     # which sends an actionable error frame.
+                    # Length-scaled budget per sentence (#1190) — the flat 300s
+                    # default is gone from every dispatch.
+                    from services.model_manager import generate_timeout_s
                     wav_tensor, sr = await run_on_gpu_pool_guarded(
                         functools.partial(_generate, sentence),
                         what="TTS generate",
+                        timeout=generate_timeout_s(sentence),
                     )
 
                     if not started:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -462,6 +462,12 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
             {waiter, fut}, timeout=queue_timeout,
             return_when=asyncio.FIRST_COMPLETED,
         )
+    except asyncio.CancelledError:
+        # Caller went away (client disconnect). We stop awaiting the job, so
+        # make sure its eventual result/exception is consumed rather than
+        # logged as "Future exception was never retrieved".
+        fut.add_done_callback(_swallow_abandoned)
+        raise
     finally:
         waiter.cancel()
 
@@ -470,7 +476,7 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
         # concurrent future cancels cleanly) and report saturation, NOT a
         # too-heavy job.
         fut.cancel()
-        _swallow_abandoned(fut)
+        fut.add_done_callback(_swallow_abandoned)
         stats = gpu_pool_stats(ex)
         logger.warning(
             "%s waited %.0fs for a free GPU worker and was never started "
@@ -490,7 +496,9 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
     try:
         return await asyncio.wait_for(fut, timeout=timeout)
     except asyncio.TimeoutError:
-        _swallow_abandoned(fut)
+        # wait_for already cancelled the asyncio wrapper; the worker thread
+        # keeps going regardless. Consume whatever it eventually produces.
+        fut.add_done_callback(_swallow_abandoned)
         _reset = getattr(ex, "reset", None)
         if callable(_reset):
             try:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -132,6 +132,15 @@ class _ResilientGpuPool(Executor):
     def __init__(self):
         self._pool: "ThreadPoolExecutor | None" = None
         self._lock = threading.Lock()
+        # ── Queue accounting (#1190/#1202) ───────────────────────────────
+        # `queued` = submitted but not yet picked up by a worker; `running` =
+        # executing right now. Admission control (check_gpu_admission) and the
+        # Retry-After estimate both read these, so a scripted client learns the
+        # pool is saturated at SUBMIT instead of after a 300s silent wait.
+        self._stats_lock = threading.Lock()
+        self._queued = 0
+        self._running = 0
+        self._avg_job_s = 0.0  # EMA of completed job wall time
 
     def _live_pool(self) -> ThreadPoolExecutor:
         pool = self._pool
@@ -142,7 +151,7 @@ class _ResilientGpuPool(Executor):
                 pool = self._pool
         return pool
 
-    def submit(self, fn, /, *args, **kwargs):
+    def _submit_live(self, fn, /, *args, **kwargs):
         try:
             return self._live_pool().submit(fn, *args, **kwargs)
         except RuntimeError as e:
@@ -157,19 +166,82 @@ class _ResilientGpuPool(Executor):
                 pool = self._pool
             return pool.submit(fn, *args, **kwargs)
 
+    def submit(self, fn, /, *args, **kwargs):
+        # Every dispatch (guarded or raw run_in_executor) funnels through here,
+        # so wrapping the callable is the one place that sees queue→run→done
+        # for the whole pool.
+        token = {"counted": False}
+
+        def _tracked(*a, **kw):
+            with self._stats_lock:
+                token["counted"] = True
+                self._queued -= 1
+                self._running += 1
+            t0 = time.monotonic()
+            try:
+                return fn(*a, **kw)
+            finally:
+                elapsed = time.monotonic() - t0
+                with self._stats_lock:
+                    self._running -= 1
+                    self._avg_job_s = (
+                        elapsed if self._avg_job_s <= 0
+                        else 0.7 * self._avg_job_s + 0.3 * elapsed
+                    )
+
+        with self._stats_lock:
+            self._queued += 1
+        try:
+            fut = self._submit_live(_tracked, *args, **kwargs)
+        except BaseException:
+            with self._stats_lock:
+                if not token["counted"]:
+                    token["counted"] = True
+                    self._queued -= 1
+            raise
+
+        def _drain(_f, token=token):
+            # A job cancelled before a worker picked it up never runs _tracked;
+            # release its queue slot here so the depth can't drift upward.
+            with self._stats_lock:
+                if not token["counted"]:
+                    token["counted"] = True
+                    self._queued -= 1
+
+        fut.add_done_callback(_drain)
+        return fut
+
+    def stats(self) -> dict:
+        """Live queue depth / worker occupancy — the input to admission control."""
+        with self._stats_lock:
+            queued, running, avg = self._queued, self._running, self._avg_job_s
+        pool = self._pool
+        workers = getattr(pool, "_max_workers", None) or 1
+        return {"queued": queued, "running": running,
+                "workers": workers, "avg_job_s": avg}
+
     def reset(self) -> None:
         """Abandon the current worker pool; the next submit builds a fresh one.
 
-        Python can't kill a thread wedged in a timed-out load, but dropping the
-        poisoned pool means a retry gets a clean worker instead of queueing
-        behind the wedged one. The wrapper identity is preserved, so references
-        held by importers stay valid.
+        Deliberately **not** ``cancel_futures=True`` (#1190/#1202): that killed
+        innocent peers — a queued job belonging to a *different* request was
+        cancelled because *this* request timed out, and surfaced to that caller
+        as a bare ``CancelledError``. ``shutdown(wait=False)`` only refuses NEW
+        submissions; work already in the old pool's queue still drains on the
+        old pool's workers, so peers complete normally while new work goes to
+        the fresh pool.
+
+        Honesty about what this reclaims: **nothing**. Python cannot kill the
+        thread wedged in the timed-out job — it keeps running (and keeps its
+        VRAM) until it finishes on its own. Dropping the pool only stops NEW
+        work from queueing behind it; it does not restore the device. That is
+        why the timeout guidance no longer claims capacity was restored.
         """
         with self._lock:
             pool, self._pool = self._pool, None
         if pool is not None:
             try:
-                pool.shutdown(wait=False, cancel_futures=True)
+                pool.shutdown(wait=False)
             except Exception:
                 pass
 
@@ -214,41 +286,220 @@ def __getattr__(name: str):
 # guard generalised so every GPU dispatch shares one recovery path.
 GPU_JOB_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GENERATE_TIMEOUT_S", "300.0"))
 
+# Queue-wait budget — a SEPARATE, deliberately generous clock (#1190/#1202).
+# The execution bound above must never be spent waiting in line: a job queued
+# behind a busy 1-worker pool used to burn its whole 300s budget without
+# executing a single instruction and then be told it was "too heavy for the
+# available compute". Waiting long is normal on a 1-worker host (that is what
+# serialization means); waiting *forever* is not, so the queue still has a
+# bound — crossing it means saturation, which is a retryable 503, not a
+# too-heavy job.
+GPU_QUEUE_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GPU_QUEUE_TIMEOUT_S", "1800.0"))
+
 
 class GpuJobTimeoutError(TimeoutError):
-    """A GPU-pool job exceeded its wall-clock bound and was abandoned.
+    """A GPU-pool job **that actually started executing** overran its bound.
 
-    The backend is alive — the job was too heavy for the available compute
-    (most often a VRAM-starved GPU). Pool capacity is restored automatically by
-    resetting the pool; the message carries the durable fix.
+    Only raised once a worker picked the job up, so the message's "too heavy
+    for the available compute" reading is truthful. Queue wait is bounded
+    separately and surfaces as :class:`GpuPoolBusyError`.
     """
+
+
+class GpuPoolBusyError(TimeoutError):
+    """The GPU pool is saturated — the job never started, so nothing was lost.
+
+    Retryable verbatim: no compute was spent, no partial state exists. Carries
+    ``retry_after`` (seconds) so HTTP callers can emit a real ``Retry-After``
+    and scripted clients can back off instead of hammering a busy backend.
+    """
+
+    def __init__(self, message: str, *, retry_after: float = 30.0):
+        super().__init__(message)
+        self.retry_after = max(1, int(round(retry_after)))
+
+
+def generate_timeout_s(text: "str | None") -> float:
+    """THE wall-clock execution budget for one synthesis job, scaled to input.
+
+    Single source of truth for every TTS dispatch (#1190/#1202). The
+    length-scaled budget landed in v0.3.22 but was wired into only two call
+    sites in generation.py's classic path — the streaming path the UI tries
+    FIRST, plus /v1/audio/speech, batch, dub and archetype previews, all still
+    used the flat 300s, which is why 0.3.22 users kept seeing "exceeded 300s"
+    on long inputs. Lives here (not in a router) so every router shares it
+    without importing generation.py.
+
+    Policy: floor at the configured OMNIVOICE_GENERATE_TIMEOUT_S, plus 1s per
+    40 characters past a 1200-character free allowance — generous enough for
+    CPU-class hardware, still bounded (a wedged job is caught in minutes, not
+    hours).
+    """
+    return max(
+        GPU_JOB_TIMEOUT_S,
+        GPU_JOB_TIMEOUT_S + (max(0, len(text or "") - 1200) / 40.0),
+    )
+
+
+def _retry_after_estimate(stats: dict) -> float:
+    """Seconds a caller should wait before retrying, from live pool state.
+
+    Queue depth ahead of you, divided by workers, times a recent job's wall
+    time. Bounded to 5..300s so the hint is always usable (and never zero on a
+    cold pool with no timing history yet)."""
+    base = stats.get("avg_job_s") or 0.0
+    if base <= 0:
+        base = 30.0
+    workers = max(1, int(stats.get("workers") or 1))
+    waves = (int(stats.get("queued") or 0) + 1) / workers
+    return max(5.0, min(300.0, base * waves))
+
+
+def gpu_pool_stats(executor=None) -> dict:
+    """Live pool occupancy, or a permissive default for executors that don't
+    track it (plain ThreadPoolExecutor in tests / injected executors)."""
+    ex = executor if executor is not None else _get_gpu_pool()
+    fn = getattr(ex, "stats", None)
+    if callable(fn):
+        try:
+            return fn()
+        except Exception:  # noqa: BLE001 — telemetry must never break a request
+            pass
+    return {"queued": 0, "running": 0, "workers": 1, "avg_job_s": 0.0}
+
+
+def check_gpu_admission(*, what: str = "GPU job", executor=None) -> None:
+    """Admission control at SUBMIT (#1190/#1202) — raise before queueing when
+    the pool is already backed up.
+
+    Policy: refuse when ``queued >= workers`` — every worker is busy AND a full
+    wave of jobs is *already waiting* ahead of this one. Deliberately NOT the
+    stricter "no worker is free": on the 1-worker hosts this bug hurts most,
+    that would reject the ordinary second concurrent request the desktop UI
+    issues routinely and which completes fine today. The looser rule still
+    catches the case that matters — a scripted client fanning out N requests at
+    a pool that can only serialize them — and turns a silent multi-minute wait
+    into an immediate, honest "retry in N seconds".
+    """
+    stats = gpu_pool_stats(executor)
+    if stats.get("queued", 0) < max(1, int(stats.get("workers") or 1)):
+        return
+    retry_after = _retry_after_estimate(stats)
+    raise GpuPoolBusyError(
+        f"{what} was not accepted: the local GPU worker pool is saturated "
+        f"({stats.get('running', 0)} running, {stats.get('queued', 0)} already "
+        f"queued on {stats.get('workers', 1)} worker(s)). Nothing was started, "
+        f"so this request is safe to retry as-is in about "
+        f"{int(retry_after)}s. To raise throughput, run fewer "
+        f"concurrent requests, or set OMNIVOICE_GPU_WORKERS if the machine has "
+        f"spare VRAM.",
+        retry_after=retry_after,
+    )
+
+
+def _swallow_abandoned(fut) -> None:
+    """Consume the result of a future we stopped awaiting, so an abandoned
+    wedged job can't emit "Future exception was never retrieved" noise."""
+    try:
+        if not fut.cancelled():
+            fut.exception()
+    except BaseException:  # noqa: BLE001 — best-effort cleanup only
+        pass
 
 
 async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
-                                  timeout: float = GPU_JOB_TIMEOUT_S,
-                                  executor=None):
-    """Run blocking ``fn`` on the GPU pool with a hard wall-clock bound.
+                                  timeout: "float | None" = None,
+                                  executor=None,
+                                  queue_timeout: "float | None" = None):
+    """Run blocking ``fn`` on the GPU pool, bounding **execution** — not the
+    wait for a free worker.
 
-    On timeout, ``reset()`` the pool (abandon the wedged worker so the next
-    submit gets a fresh one) and raise :class:`GpuJobTimeoutError`. ``fn`` must
-    be a zero-arg callable — wrap args with ``functools.partial`` at the call
-    site. Deliberately mirrors ``asr_backend.run_transcribe_guarded`` so every
-    GPU dispatch shares one bound+recover path (#730 class). Executors without
-    ``reset`` (a plain ThreadPoolExecutor in tests) still get the bound + error.
+    Two clocks (#1190/#1202):
+
+    * ``queue_timeout`` (generous, ``GPU_QUEUE_TIMEOUT_S``) covers the time the
+      job sits in the pool queue. Exceeding it raises :class:`GpuPoolBusyError`
+      — the job is cancelled out of the queue before it ever runs, so no
+      compute is wasted and the caller can retry verbatim.
+    * ``timeout`` (``GPU_JOB_TIMEOUT_S`` by default) starts only when a worker
+      actually picks the job up. Exceeding *that* is a genuinely wedged/too-slow
+      job → :class:`GpuJobTimeoutError` + pool ``reset()``.
+
+    Previously both were one clock started at submit: ``run_in_executor``
+    returns immediately, so a job queued behind a busy 1-worker pool burned its
+    entire budget waiting and then reported "too heavy for the available
+    compute" without having executed one instruction.
+
+    ``fn`` must be a zero-arg callable — wrap args with ``functools.partial``.
+    Executors without ``reset`` (a plain ThreadPoolExecutor in tests) still get
+    both bounds; only the reset step is skipped.
     """
     loop = asyncio.get_running_loop()
     ex = executor if executor is not None else _get_gpu_pool()
-    fut = loop.run_in_executor(ex, contain_system_exit(fn, what))
+    # Resolved at CALL time, not def time, so monkeypatching/reloading the
+    # module constant reaches every call site (the old default bound at def).
+    timeout = GPU_JOB_TIMEOUT_S if timeout is None else float(timeout)
+    queue_timeout = GPU_QUEUE_TIMEOUT_S if queue_timeout is None else float(queue_timeout)
+
+    started = asyncio.Event()
+    _inner = contain_system_exit(fn, what)
+
+    def _job():
+        # First thing the worker does: tell the awaiting coroutine the
+        # execution clock may start. call_soon_threadsafe is the only
+        # loop-safe way to touch an asyncio primitive from a pool thread.
+        try:
+            loop.call_soon_threadsafe(started.set)
+        except RuntimeError:
+            pass  # loop already closed (caller vanished) — still run the job
+        return _inner()
+
+    fut = loop.run_in_executor(ex, _job)
+    waiter = asyncio.ensure_future(started.wait())
+    try:
+        # Phase 1 — queue wait. Watch the future too, so a job that fails or is
+        # cancelled while still queued resolves here instead of hanging.
+        done, _pending = await asyncio.wait(
+            {waiter, fut}, timeout=queue_timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    finally:
+        waiter.cancel()
+
+    if not done:
+        # Never picked up: cancel it out of the queue (a not-yet-started
+        # concurrent future cancels cleanly) and report saturation, NOT a
+        # too-heavy job.
+        fut.cancel()
+        _swallow_abandoned(fut)
+        stats = gpu_pool_stats(ex)
+        logger.warning(
+            "%s waited %.0fs for a free GPU worker and was never started "
+            "(%d queued / %d running) — reporting pool saturation (#1190).",
+            what, queue_timeout, stats.get("queued", 0), stats.get("running", 0),
+        )
+        raise GpuPoolBusyError(
+            f"{what} waited {queue_timeout:.0f}s for a free GPU worker and "
+            f"never started, so nothing was computed and the request is safe "
+            f"to retry as-is. The backend is alive but every worker is busy "
+            f"with earlier jobs. Run fewer concurrent requests, or raise "
+            f"OMNIVOICE_GPU_WORKERS if the machine has spare VRAM.",
+            retry_after=_retry_after_estimate(stats),
+        )
+
+    # Phase 2 — execution. The clock starts here: this job owns a worker.
     try:
         return await asyncio.wait_for(fut, timeout=timeout)
     except asyncio.TimeoutError:
+        _swallow_abandoned(fut)
         _reset = getattr(ex, "reset", None)
         if callable(_reset):
             try:
                 _reset()
                 logger.warning(
-                    "%s exceeded %.0fs — abandoned the GPU-pool worker to "
-                    "restore capacity (#730).", what, timeout,
+                    "%s exceeded %.0fs of EXECUTION time — abandoned the "
+                    "GPU-pool worker; it keeps running (and holding the "
+                    "device) until it finishes on its own (#730/#1190).",
+                    what, timeout,
                 )
             except Exception:
                 logger.exception("GPU pool reset after %s timeout failed", what)
@@ -258,7 +509,16 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
 def _timeout_guidance(what: str, timeout: float) -> str:
     """Device-aware timeout message (#896): a CPU-only host must never be told
     to "set the engine to CPU" or blamed on VRAM — on CPU the job is simply
-    compute-bound. GPU hosts keep the VRAM-contention guidance."""
+    compute-bound. GPU hosts keep the VRAM-contention guidance.
+
+    Honesty fix (#1190/#1202): this used to promise "Capacity was restored
+    automatically". It was not. Python cannot kill the abandoned worker
+    thread — it runs to completion still holding its VRAM, so an immediate
+    retry contends with the zombie and is *more* likely to fail, which is
+    exactly how one slow chunk cascaded into a whole failed batch. The message
+    now says what actually happens and gives both interactive and scripted
+    callers something to do about it.
+    """
     family = "cuda"  # conservative default: GPU wording if the probe fails
     try:
         from core.device_caps import detect_host_caps
@@ -266,9 +526,12 @@ def _timeout_guidance(what: str, timeout: float) -> str:
     except Exception:  # noqa: BLE001 — guidance must never mask the timeout
         pass
     common = (
-        f"{what} exceeded {timeout:.0f}s and was abandoned — the backend is "
-        "running, but the job was too heavy for the available compute. "
-        "Capacity was restored automatically; "
+        f"{what} ran for more than {timeout:.0f}s of actual compute time and "
+        "was abandoned — the backend is running, but this job was too heavy "
+        "for the available compute. The abandoned job cannot be killed: it "
+        "keeps running and keeps holding the device until it finishes on its "
+        "own, so an immediate retry competes with it. Wait for the current "
+        "job to drain (or restart the backend) before retrying; "
     )
     if family == "cpu":
         return common + (
@@ -286,6 +549,33 @@ def _timeout_guidance(what: str, timeout: float) -> str:
         "Settings → Models. (Raise OMNIVOICE_GENERATE_TIMEOUT_S for very "
         "long single generations.)"
     )
+
+
+# ── Watermark pool (#1169 load, split out in #1190) ──────────────────────
+# AudioSeal's generator is loaded with `AudioSeal.load_generator(...)` and
+# never moved to an accelerator: `embed_watermark` is CPU work on CPU tensors.
+# Running it on the GPU pool therefore reserves a *GPU* worker for a job that
+# uses no VRAM — and since #1169 routed every producer (including per-chunk
+# stream previews) through mark_synthetic, on an 8 GB host (exactly 1 GPU
+# worker) each watermark embed serialized directly ahead of the next generate,
+# doubling the effective queue depth of a streamed multi-chunk render.
+# Giving it its own tiny pool removes that head-of-line blocking with no VRAM
+# risk, because the work was never on the device to begin with.
+_watermark_pool_singleton: "ThreadPoolExecutor | None" = None
+_watermark_pool_lock = threading.Lock()
+
+
+def get_watermark_pool() -> ThreadPoolExecutor:
+    """Dedicated 1-worker pool for provenance marking. Built lazily so hosts
+    with watermarking disabled never spawn the thread."""
+    global _watermark_pool_singleton
+    if _watermark_pool_singleton is None:
+        with _watermark_pool_lock:
+            if _watermark_pool_singleton is None:
+                _watermark_pool_singleton = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="watermark",
+                )
+    return _watermark_pool_singleton
 
 
 model = None  # type: ignore

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -397,13 +397,21 @@ def check_gpu_admission(*, what: str = "GPU job", executor=None) -> None:
     )
 
 
+def _log_safe(what: str) -> str:
+    """`what` is caller-supplied and can embed request data (engine ids reach
+    it via f-strings), so strip CR/LF and clamp the length before it lands in a
+    log line — a request must not be able to forge extra log entries
+    (CodeQL py/log-injection)."""
+    return str(what).replace("\r", " ").replace("\n", " ")[:120]
+
+
 def _swallow_abandoned(fut) -> None:
     """Consume the result of a future we stopped awaiting, so an abandoned
     wedged job can't emit "Future exception was never retrieved" noise."""
     try:
         if not fut.cancelled():
             fut.exception()
-    except BaseException:  # noqa: BLE001 — best-effort cleanup only
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001 — cleanup only
         pass
 
 
@@ -481,7 +489,8 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
         logger.warning(
             "%s waited %.0fs for a free GPU worker and was never started "
             "(%d queued / %d running) — reporting pool saturation (#1190).",
-            what, queue_timeout, stats.get("queued", 0), stats.get("running", 0),
+            _log_safe(what), queue_timeout,
+            stats.get("queued", 0), stats.get("running", 0),
         )
         raise GpuPoolBusyError(
             f"{what} waited {queue_timeout:.0f}s for a free GPU worker and "
@@ -507,10 +516,11 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
                     "%s exceeded %.0fs of EXECUTION time — abandoned the "
                     "GPU-pool worker; it keeps running (and holding the "
                     "device) until it finishes on its own (#730/#1190).",
-                    what, timeout,
+                    _log_safe(what), timeout,
                 )
             except Exception:
-                logger.exception("GPU pool reset after %s timeout failed", what)
+                logger.exception("GPU pool reset after %s timeout failed",
+                                 _log_safe(what))
         raise GpuJobTimeoutError(_timeout_guidance(what, timeout))
 
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -443,13 +443,45 @@ did was `generate:start (audio)`, a dub, or a dictation.
 
 Newer builds **bound** every GPU job — whole-file transcription, **chunked dub
 transcription**, **and** TTS generation: instead of hanging forever and starving
-the backend, a wedged job now fails after a timeout with this exact guidance,
-and the worker pool is reset so capacity is restored automatically (no app
-restart needed). Tune the bounds with `OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S`
-(whole-file transcription) and `OMNIVOICE_GENERATE_TIMEOUT_S` (generation) —
-both in seconds, default 300 — and `OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S`
-(per-chunk dub transcription, default 120). **Raise** them for very long single
-files/generations, **lower** them to fail faster on a small machine.
+the backend, a wedged job fails after a timeout with this exact guidance. Tune
+the bounds with `OMNIVOICE_ASR_TRANSCRIBE_TIMEOUT_S` (whole-file transcription)
+and `OMNIVOICE_GENERATE_TIMEOUT_S` (generation) — both in seconds, default 300
+— and `OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S` (per-chunk dub transcription,
+default 120). **Raise** them for very long single files/generations, **lower**
+them to fail faster on a small machine.
+
+**Two things changed here** ([#1190](https://github.com/debpalash/OmniVoice-Studio/issues/1190)):
+
+- **Waiting in line is no longer counted as compute.** The generate budget used
+  to start the moment a job was *queued*, so on a 1-worker machine a request
+  sitting behind a busy one burned its whole 300s without executing a single
+  instruction and then blamed your hardware. The budget now starts when a
+  worker actually picks the job up. Queue wait has its own, far more generous
+  bound (`OMNIVOICE_GPU_QUEUE_TIMEOUT_S`, default 1800s); crossing *that*
+  reports a saturated pool — an explicitly **retryable** condition, not a
+  too-heavy job.
+- **The old message over-promised.** It said "Capacity was restored
+  automatically". It wasn't: Python can't kill the abandoned worker thread, so
+  it keeps running — and keeps its VRAM — until it finishes on its own. The
+  pool reset only stops *new* work from queueing behind it. That is why an
+  immediate retry often failed too, and why a long batch could die a few
+  segments in. **Give the abandoned job time to drain (or restart the backend)
+  before retrying.** The message now says so.
+
+The generation budget also **scales with the length of the text** (the floor is
+`OMNIVOICE_GENERATE_TIMEOUT_S`, plus 1 second per 40 characters past the first
+1200), and every path uses it — the streaming preview the UI tries first, batch
+dubbing, `/v1/audio/speech`, and dub/archetype previews included. Long inputs
+should not need the env var at all.
+
+**Scripting the API?** `/v1/audio/speech` now tells you about pressure instead
+of going quiet: a **429** with a `Retry-After` header means the request was
+*refused before it started* because the worker pool is already backed up (safe
+to retry verbatim — nothing ran), and a **503** with `Retry-After` means the
+job was accepted but hit its bound. Both carry
+`X-OmniVoice-Retryable: true`, and the streaming NDJSON error frame carries
+`"retryable": true` with `retry_after`. Back off on those rather than
+hammering — on a 1-worker machine, concurrent requests serialize by design.
 
 **If transcribe timeouts keep repeating back-to-back**, pool resets aren't
 recovering the underlying hang — the wedged thread keeps its VRAM until the app

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -78,7 +78,8 @@ None of them are required — the defaults are chosen for the common case.
 | `OMNIVOICE_UNIFIED_OFFLOAD_HEADROOM_GB` | `6` | On unified memory (Apple Silicon): if free RAM is below this when a dub needs the transcription model, the TTS model is fully released first (it reloads on the next generation). Raise to be more aggressive about freeing, lower on 32 GB+ machines to avoid the reload. |
 | `OMNIVOICE_INDEXTTS_FP16` | `1` | IndexTTS half-precision. Leave on. |
 | `OMNIVOICE_ASR_VRAM_PREFLIGHT` | `1` | Downgrade transcription precision instead of crashing when VRAM is short (CUDA). Leave on. |
-| `OMNIVOICE_GENERATE_TIMEOUT_S` | `300` | Abandon a generation after this many seconds. Raise for very long single generations on slow hardware. |
+| `OMNIVOICE_GENERATE_TIMEOUT_S` | `300` | Abandon a generation after this many seconds **of actual compute** — the clock starts when a GPU worker picks the job up, never while it waits in line. It's a floor, not a ceiling: the budget grows with the text (+1 s per 40 characters past the first 1200), so long inputs rarely need this raised. |
+| `OMNIVOICE_GPU_QUEUE_TIMEOUT_S` | `1800` | How long a job may sit in the GPU queue before it's reported as a saturated pool (a retryable condition — nothing ran). Waiting is normal on 1-worker machines; lower this only if you'd rather fail fast than queue. |
 
 **torch.compile** is probe-based, not platform-based: it's attempted only
 where the runtime check says it can work (a CUDA device with Triton importable
@@ -91,10 +92,16 @@ install makes the probe pass but the compile attempt itself crash — see
 
 ## Flush caches / Unload resident model
 
-This is the feature the VRAM-starved timeout error ("TTS generate exceeded
-300s … Flush caches / Unload the resident model") points at. It frees
+This is the feature the VRAM-starved timeout error ("TTS generate ran for more
+than 300s … Flush caches / Unload the resident model") points at. It frees
 RAM/VRAM **without restarting the app**, and it never loses data — an
 unloaded model simply reloads lazily (~8 s) on the next generation.
+
+One thing Flush **can't** free: the job that just timed out. An abandoned
+generation cannot be killed from Python — its thread runs to completion and
+holds its VRAM until it does, so a Flush (or a retry) issued seconds after a
+timeout is competing with a job that is still on the device. Wait for it to
+drain, or restart the backend, and then Flush.
 
 **Where it lives:**
 

--- a/frontend/src/hooks/useTTS.js
+++ b/frontend/src/hooks/useTTS.js
@@ -257,6 +257,18 @@ export default function useTTS({ selectedProfile, setSelectedProfile, loadHistor
           streamed = true;
         } catch (err) {
           if (!(err instanceof StreamingPreviewError)) throw err;
+          // #1190: a RETRYABLE mid-stream failure (GPU timeout / saturated
+          // pool) must not trigger the classic re-render. The backend already
+          // spent the full budget on this text, and the abandoned job keeps
+          // holding the device until it drains — re-synthesizing the whole
+          // text right now makes the user wait out a second timeout to see the
+          // same error. Surface the backend's actionable message instead.
+          // Non-retryable failures (transport drop, Web Audio glitch) keep the
+          // classic fallback: there the whole-file path genuinely can succeed.
+          if (err.retryable) {
+            addBreadcrumb('generate:stream-retryable-abort');
+            throw err;
+          }
           console.warn(
             'Streaming preview failed mid-stream; falling back to the classic generate:',
             err?.message || err,

--- a/frontend/src/test/streamingTts.test.js
+++ b/frontend/src/test/streamingTts.test.js
@@ -243,6 +243,32 @@ describe('streamGenerateSpeech', () => {
     expect(FakeAudioContext.instances[0].state).toBe('closed');
   });
 
+  it('carries the retryable marker from a GPU-timeout error frame (#1190)', async () => {
+    // A retryable failure means the backend already spent the full budget on
+    // this text and the abandoned job still holds the device — useTTS uses
+    // this flag to skip the classic re-render instead of paying the timeout
+    // a second time.
+    apiFetch.mockResolvedValue(
+      ndjsonResponse([
+        startEvent(3),
+        chunkEvent(0),
+        { type: 'error', detail: 'ran for more than 300s', retryable: true, retry_after: 45 },
+      ]),
+    );
+    const err = await streamGenerateSpeech(new FormData(), {}).catch((e) => e);
+    expect(err).toBeInstanceOf(StreamingPreviewError);
+    expect(err.retryable).toBe(true);
+    expect(err.retryAfter).toBe(45);
+
+    // A plain engine failure stays non-retryable → the classic fallback still
+    // applies, unchanged.
+    apiFetch.mockResolvedValue(
+      ndjsonResponse([startEvent(2), chunkEvent(0), { type: 'error', detail: 'engine boom' }]),
+    );
+    const plain = await streamGenerateSpeech(new FormData(), {}).catch((e) => e);
+    expect(plain.retryable).toBe(false);
+  });
+
   it('rejects with StreamingPreviewError when the stream ends without done', async () => {
     apiFetch.mockResolvedValue(ndjsonResponse([startEvent(2), chunkEvent(0)]));
     await expect(streamGenerateSpeech(new FormData(), {})).rejects.toThrow(StreamingPreviewError);

--- a/frontend/src/utils/streamingTts.js
+++ b/frontend/src/utils/streamingTts.js
@@ -39,6 +39,13 @@ export class StreamingPreviewError extends Error {
   constructor(message, opts) {
     super(message, opts);
     this.name = 'StreamingPreviewError';
+    // #1190: the backend marks GPU-timeout / pool-saturation error frames
+    // `retryable`. Those are NOT worth re-rendering on the classic path — the
+    // whole text would be synthesized again against a pool still occupied by
+    // the abandoned job, so the user pays the same timeout twice before seeing
+    // the same error. Carried here so useTTS can tell the two apart.
+    this.retryable = opts?.retryable === true;
+    this.retryAfter = opts?.retryAfter ?? null;
   }
 }
 
@@ -318,7 +325,10 @@ export async function streamGenerateSpeech(
       } else if (ev.type === 'done') {
         meta = ev;
       } else if (ev.type === 'error') {
-        throw new StreamingPreviewError(ev.detail || 'TTS stream reported an error');
+        throw new StreamingPreviewError(ev.detail || 'TTS stream reported an error', {
+          retryable: ev.retryable === true,
+          retryAfter: ev.retry_after ?? null,
+        });
       }
     };
 

--- a/tests/test_gpu_pool_queue_accounting_1190.py
+++ b/tests/test_gpu_pool_queue_accounting_1190.py
@@ -1,0 +1,419 @@
+"""Queue wait is not compute time (#1190/#1202).
+
+Field reports: a 22-chunk batch dies around chunk 3 with "the job was too heavy
+for the available compute", on hardware that renders chunk 1 and 2 fine. Three
+defects in `run_on_gpu_pool_guarded` / `_ResilientGpuPool` compound into that:
+
+1. The 300s clock started at SUBMIT. `loop.run_in_executor()` returns
+   immediately, so `asyncio.wait_for` was timing the queue wait, not the work.
+   A job queued behind a busy 1-worker pool burned its entire budget without
+   executing one instruction and then blamed the hardware.
+2. `reset()` used `cancel_futures=True`, so one request's timeout cancelled
+   innocent QUEUED peers, which surfaced to their own callers as a bare
+   CancelledError.
+3. The timeout message promised "Capacity was restored automatically". It
+   isn't: Python cannot kill the abandoned worker thread, which keeps running
+   (and holding the device) until it finishes.
+
+Plus the v0.3.22 length-scaled budget was wired into only two of the eleven
+GPU dispatches, which is why 0.3.22 users still saw "exceeded 300s".
+
+Every test below fails on the pre-fix code and passes after.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+_BACKEND = Path(__file__).resolve().parents[1] / "backend"
+
+
+@pytest.fixture
+def mm(monkeypatch):
+    for mod_name in ("core.config", "services.model_manager"):
+        if getattr(sys.modules.get(mod_name), "__file__", None) is None:
+            sys.modules.pop(mod_name, None)
+    import services.model_manager as _mm
+    return _mm
+
+
+# ── Defect 1: the execution clock must not start at submit ──────────────────
+
+
+def test_queue_wait_is_not_charged_to_the_execution_budget(mm):
+    """A job that waits in line longer than its execution budget, then runs
+    quickly, must SUCCEED. Pre-fix this raised GpuJobTimeoutError without the
+    job ever having started."""
+    ex = ThreadPoolExecutor(max_workers=1)
+    hog_started = threading.Event()
+    release = threading.Event()
+    ran = threading.Event()
+
+    def _hog():
+        hog_started.set()
+        release.wait(10)
+
+    def _quick():
+        ran.set()
+        return "done"
+
+    async def _drive():
+        loop = asyncio.get_running_loop()
+        hog = loop.run_in_executor(ex, _hog)
+        assert hog_started.wait(5), "blocker never occupied the single worker"
+
+        task = asyncio.ensure_future(mm.run_on_gpu_pool_guarded(
+            _quick, what="TTS generate",
+            timeout=0.3,          # execution budget: tiny
+            queue_timeout=30.0,   # queue budget: generous
+            executor=ex,
+        ))
+        # Sit in the queue for 4x the execution budget.
+        await asyncio.sleep(1.2)
+        assert not ran.is_set(), "job started early — test is not exercising the queue"
+        assert not task.done(), "queue wait was charged to the execution budget (#1190)"
+
+        release.set()
+        result = await asyncio.wait_for(task, timeout=10)
+        await hog
+        return result
+
+    try:
+        assert asyncio.run(_drive()) == "done"
+    finally:
+        release.set()
+        ex.shutdown(wait=False)
+
+
+def test_never_started_job_reports_saturation_not_too_heavy(mm):
+    """Crossing the QUEUE budget is a retryable saturation error, never the
+    "too heavy for the available compute" verdict — nothing was computed."""
+    ex = ThreadPoolExecutor(max_workers=1)
+    release = threading.Event()
+    ran = threading.Event()
+
+    def _hog():
+        release.wait(10)
+
+    def _never():
+        ran.set()
+
+    async def _drive():
+        loop = asyncio.get_running_loop()
+        loop.run_in_executor(ex, _hog)
+        await asyncio.sleep(0.2)
+        with pytest.raises(mm.GpuPoolBusyError) as exc:
+            await mm.run_on_gpu_pool_guarded(
+                _never, what="TTS generate", timeout=30.0,
+                queue_timeout=0.3, executor=ex,
+            )
+        return exc.value
+
+    try:
+        err = asyncio.run(_drive())
+        assert isinstance(err, TimeoutError)          # retryable by base class
+        assert not isinstance(err, mm.GpuJobTimeoutError)
+        assert "too heavy" not in str(err)
+        assert "safe to retry" in str(err)
+        assert err.retry_after >= 1
+        # The job was pulled out of the queue, so no compute is wasted later.
+        release.set()
+        assert not ran.wait(1.0)
+    finally:
+        release.set()
+        ex.shutdown(wait=False)
+
+
+# ── Defect 2: a timeout must not cancel innocent peers ──────────────────────
+
+
+def test_timeout_does_not_cancel_queued_peers(mm, monkeypatch):
+    """reset() may drop the pool, but a peer already queued behind the wedged
+    job must still run to completion. Pre-fix (`cancel_futures=True`) the peer
+    came back cancelled — a bare CancelledError in an unrelated request."""
+    monkeypatch.setattr(mm, "_build_gpu_pool",
+                        lambda: ThreadPoolExecutor(max_workers=1))
+    pool = mm._ResilientGpuPool()
+    release = threading.Event()
+
+    def _wedge():
+        release.wait(10)
+        return "late"
+
+    def _peer():
+        return "peer-ok"
+
+    try:
+        with pytest.raises(mm.GpuJobTimeoutError):
+            asyncio.run(mm.run_on_gpu_pool_guarded(
+                _wedge, what="TTS generate", timeout=0.3,
+                queue_timeout=30.0, executor=pool,
+            ))
+        # Queue the peer while the wedged worker still holds the only thread,
+        # then let the wedge finish — the peer must run, not be cancelled.
+        peer_fut = pool.submit(_peer)
+        release.set()
+        assert peer_fut.result(timeout=10) == "peer-ok"
+        assert not peer_fut.cancelled()
+    finally:
+        release.set()
+        pool.shutdown(wait=False)
+
+
+def test_reset_still_swaps_the_pool_for_new_work(mm, monkeypatch):
+    """Dropping the poisoned pool (so new submits get a clean worker) is
+    preserved — only the peer-cancelling part is gone."""
+    monkeypatch.setattr(mm, "_build_gpu_pool",
+                        lambda: ThreadPoolExecutor(max_workers=1))
+    pool = mm._ResilientGpuPool()
+    release = threading.Event()
+    try:
+        assert pool._live_pool() is not None
+        with pytest.raises(mm.GpuJobTimeoutError):
+            asyncio.run(mm.run_on_gpu_pool_guarded(
+                lambda: release.wait(10), what="TTS generate",
+                timeout=0.3, queue_timeout=30.0, executor=pool,
+            ))
+        assert pool._pool is None
+        assert asyncio.run(mm.run_on_gpu_pool_guarded(
+            lambda: "ok", what="TTS generate", timeout=10.0, executor=pool,
+        )) == "ok"
+    finally:
+        release.set()
+        pool.shutdown(wait=False)
+
+
+# ── Defect 3: the message must tell the truth ───────────────────────────────
+
+
+def test_timeout_guidance_does_not_claim_capacity_was_restored(mm):
+    msg = mm._timeout_guidance("TTS generate", 300.0)
+    assert "Capacity was restored automatically" not in msg
+    assert "restored" not in msg
+    # It says what actually happens instead.
+    assert "cannot be killed" in msg
+    assert "until it finishes" in msg
+    # Actionable for interactive users AND scripted clients.
+    assert "restart the backend" in msg
+    assert "OMNIVOICE_GENERATE_TIMEOUT_S" in msg
+
+
+# ── Defect 4: every dispatch uses the shared length-scaled budget ───────────
+
+
+def _guarded_calls():
+    """(file, lineno, keywords) for every run_on_gpu_pool_guarded call in the
+    backend."""
+    out = []
+    for path in sorted(_BACKEND.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+            if name == "run_on_gpu_pool_guarded":
+                out.append((path, node.lineno,
+                            {kw.arg for kw in node.keywords if kw.arg}))
+    return out
+
+
+def test_no_gpu_dispatch_relies_on_the_flat_default_budget():
+    """Structural: every guarded dispatch passes an explicit `timeout=`.
+
+    The v0.3.22 length-scaled budget only reached 2 of the call sites; the
+    streaming path the UI tries FIRST, /v1/audio/speech, batch, dub and
+    archetype previews all silently kept the flat 300s. A new dispatch that
+    forgets the budget fails here."""
+    calls = _guarded_calls()
+    assert len(calls) >= 10, "call-site scan found suspiciously few dispatches"
+    missing = [f"{p.relative_to(_BACKEND)}:{line}"
+               for p, line, kws in calls if "timeout" not in kws]
+    assert not missing, (
+        "GPU dispatches with no explicit timeout (they silently inherit the "
+        f"flat GPU_JOB_TIMEOUT_S): {missing}"
+    )
+
+
+def test_scaled_budget_has_one_implementation(mm):
+    """generation.py's helper delegates to the canonical one, so the routers
+    that import it directly can't drift from /generate."""
+    import api.routers.generation as g
+
+    long_text = "x" * 41_200
+    assert mm.generate_timeout_s("hi") == mm.GPU_JOB_TIMEOUT_S
+    assert mm.generate_timeout_s(long_text) == pytest.approx(
+        mm.GPU_JOB_TIMEOUT_S + 1000.0)
+    assert g._generate_timeout_s(long_text) == mm.generate_timeout_s(long_text)
+    assert mm.generate_timeout_s(None) == mm.GPU_JOB_TIMEOUT_S
+
+
+def test_watermark_dispatches_leave_the_gpu_pool():
+    """#1169 put an AudioSeal embed (CPU work, no VRAM) on the GPU pool for
+    every producer including per-chunk stream previews; on a 1-worker host each
+    one serialized ahead of the next generate."""
+    for rel in ("api/routers/generation.py", "api/routers/batch.py",
+                "api/routers/archetypes.py"):
+        src = (_BACKEND / rel).read_text(encoding="utf-8")
+        for idx in range(len(src)):
+            if not src.startswith("run_in_executor(", idx):
+                continue
+            window = src[idx:idx + 400]
+            if "mark_synthetic" in window:
+                assert "get_watermark_pool" in window, (
+                    f"{rel}: watermark embed still dispatched to the GPU pool")
+
+
+# ── Defect 5: the scripted-client contract ──────────────────────────────────
+
+
+def test_admission_refuses_only_a_backed_up_pool(mm, monkeypatch):
+    """No worker free but nothing queued → admit (the ordinary interactive
+    second request). A full wave already waiting → refuse with a usable
+    Retry-After."""
+    monkeypatch.setattr(mm, "gpu_pool_stats", lambda ex=None: {
+        "queued": 0, "running": 1, "workers": 1, "avg_job_s": 12.0})
+    mm.check_gpu_admission(what="OpenAI TTS generate")  # must not raise
+
+    monkeypatch.setattr(mm, "gpu_pool_stats", lambda ex=None: {
+        "queued": 3, "running": 1, "workers": 1, "avg_job_s": 12.0})
+    with pytest.raises(mm.GpuPoolBusyError) as exc:
+        mm.check_gpu_admission(what="OpenAI TTS generate")
+    assert 5 <= exc.value.retry_after <= 300
+    assert "saturated" in str(exc.value)
+
+
+def test_pool_tracks_queue_depth(mm, monkeypatch):
+    """Admission control is only as good as the accounting behind it."""
+    monkeypatch.setattr(mm, "_build_gpu_pool",
+                        lambda: ThreadPoolExecutor(max_workers=1))
+    pool = mm._ResilientGpuPool()
+    started = threading.Event()
+    release = threading.Event()
+    try:
+        pool.submit(lambda: (started.set(), release.wait(10)))
+        assert started.wait(5)
+        queued = [pool.submit(lambda: "q") for _ in range(3)]
+        stats = pool.stats()
+        assert stats["running"] == 1
+        assert stats["queued"] == 3
+        assert stats["workers"] == 1
+        release.set()
+        for f in queued:
+            assert f.result(timeout=10) == "q"
+        # Depth drains back to zero — no leak that would 429 forever.
+        assert pool.stats()["queued"] == 0
+    finally:
+        release.set()
+        pool.shutdown(wait=False)
+
+
+def test_openai_compat_maps_timeouts_to_retryable_503(mm):
+    """A timed-out generate must not look like a server crash to a script."""
+    import api.routers.openai_compat as oc
+
+    for err in (mm.GpuJobTimeoutError("overran"),
+                mm.GpuPoolBusyError("busy", retry_after=42)):
+        http = oc._typed_speech_http_error(err)
+        assert http is not None, "TimeoutError fell through to the generic 500"
+        assert http.status_code == 503
+        assert http.headers["X-OmniVoice-Retryable"] == "true"
+        assert int(http.headers["Retry-After"]) >= 1
+    assert oc._typed_speech_http_error(mm.GpuPoolBusyError(
+        "busy", retry_after=42)).headers["Retry-After"] == "42"
+
+
+def _register_engine(monkeypatch, engine_id, *, sleep_s=0.0):
+    import importlib
+    import torch
+    tts = importlib.import_module("services.tts_backend")
+
+    class _Fake(tts.TTSBackend):
+        id = engine_id
+        display_name = "Fake engine (test)"
+
+        @property
+        def sample_rate(self) -> int:
+            return 24000
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return ["multi"]
+
+        @classmethod
+        def is_available(cls):
+            return True, "ready"
+
+        def generate(self, text, **kw):
+            if sleep_s:
+                threading.Event().wait(sleep_s)
+            return torch.zeros(1, 2400)
+
+    monkeypatch.setitem(tts._REGISTRY, engine_id, _Fake)
+    return _Fake
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+    from main import app
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+def test_speech_429s_at_submit_when_the_pool_is_saturated(mm, client, monkeypatch):
+    """The scripted-client contract: refuse at SUBMIT with a real Retry-After
+    instead of accepting the job and going quiet for minutes."""
+    _register_engine(monkeypatch, "admission-fake")
+    monkeypatch.setattr(mm, "gpu_pool_stats", lambda ex=None: {
+        "queued": 5, "running": 1, "workers": 1, "avg_job_s": 9.0})
+
+    res = client.post("/v1/audio/speech", json={
+        "model": "admission-fake", "input": "Hello.", "response_format": "wav",
+    })
+    assert res.status_code == 429, res.text
+    assert int(res.headers["Retry-After"]) >= 1
+    assert res.headers["X-OmniVoice-Retryable"] == "true"
+    assert "saturated" in res.json()["detail"]
+
+
+def test_speech_timeout_is_a_retryable_503_not_a_500(mm, client, monkeypatch):
+    """A generate that overran its budget used to reach the scripted client as
+    a generic 500 — indistinguishable from a crash."""
+    _register_engine(monkeypatch, "slow-gen-fake", sleep_s=3.0)
+    # The route derives its budget from the shared helper at call time, so
+    # shrinking the constant proves the route is actually using it (#1190).
+    monkeypatch.setattr(mm, "GPU_JOB_TIMEOUT_S", 0.3)
+
+    res = client.post("/v1/audio/speech", json={
+        "model": "slow-gen-fake", "input": "Hello.", "response_format": "wav",
+    })
+    assert res.status_code == 503, res.text
+    assert res.headers["X-OmniVoice-Retryable"] == "true"
+    assert int(res.headers["Retry-After"]) >= 1
+
+
+def test_batch_surfaces_a_timed_out_segment_instead_of_a_silent_gap():
+    """batch.py used to swallow a timed-out segment into a silent stretch of
+    the dubbed track: a finished-looking video with missing speech."""
+    src = (_BACKEND / "api/routers/batch.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    handlers = [h for node in ast.walk(tree) if isinstance(node, ast.Try)
+                for h in node.handlers
+                if isinstance(h.type, ast.Name) and h.type.id == "TimeoutError"]
+    assert handlers, "batch.py has no TimeoutError handler — timeouts are still swallowed"
+    assert any(isinstance(n, ast.Raise) for h in handlers for n in ast.walk(h)), (
+        "batch.py catches TimeoutError but does not surface it"
+    )

--- a/tests/test_gpu_pool_queue_accounting_1190.py
+++ b/tests/test_gpu_pool_queue_accounting_1190.py
@@ -336,6 +336,15 @@ def test_openai_compat_maps_timeouts_to_retryable_503(mm):
         "busy", retry_after=42)).headers["Retry-After"] == "42"
 
 
+def test_job_label_cannot_forge_log_lines(mm):
+    """`what` embeds request-derived data (engine ids), and it reaches the
+    timeout/saturation log lines — CodeQL py/log-injection."""
+    forged = "TTS engine 'x\r\nERROR forged log line' model load"
+    safe = mm._log_safe(forged)
+    assert "\n" not in safe and "\r" not in safe
+    assert len(mm._log_safe("y" * 500)) <= 120
+
+
 def _register_engine(monkeypatch, engine_id, *, sleep_s=0.0):
     import importlib
     import torch


### PR DESCRIPTION
Queue wait was charged to the 300s generate budget, so a job queued behind a busy 1-worker pool failed as "too heavy for the available compute" without executing an instruction. The clock now starts when a worker picks the job up; queue wait gets its own generous bound and reports retryable saturation instead.

Also: `reset()` no longer cancels innocent queued peers; the timeout message stops claiming capacity was restored (the abandoned job holds the device until it drains); every GPU dispatch now uses the shared length-scaled budget (v0.3.22's scaling reached only 2 of 11 call sites); AudioSeal watermark embeds move off the GPU pool; `/v1/audio/speech` gets admission-control 429 + retryable 503 with `Retry-After`; a timed-out batch segment fails the job instead of shipping a silent gap.

14 fail-before/pass-after tests in `tests/test_gpu_pool_queue_accounting_1190.py`; full backend suite green (3396 passed). Docs synced (performance.md, troubleshooting §14) + CHANGELOG.

Closes #1190. Closes #1202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

GPU pool accounting now starts generation time when workers begin execution, separates queue waits with retryable saturation errors, protects queued jobs during resets, and applies length-scaled budgets consistently while moving watermarking off GPU workers. API and streaming clients now receive actionable retryable 429/503 responses, timed-out batch segments fail explicitly, and abandoned work is safely drained with sanitized logging. The main risk is concurrency and timeout behavior across GPU execution, queue recovery, and client retry flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->