### PR TITLE
feat(audiobook): expressive maturity — overrides, emotion, cache opt-out (#1208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Info/warn system notifications are dismissible and stay dismissed across restarts; error-level notices can't be dismissed, and the unclean-shutdown notice is now acknowledged server-side — thanks @agudmund! (#1192)
 - `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` — thanks @paoloantinori! (#1194)
 - Dub tab: **Paste Translation** — paste a translation made elsewhere (ChatGPT, DeepL, a human) as subtitles, numbered lines, or plain lines; it maps onto the existing segments with a before→after preview, keeping timings and the source transcript intact (#1203)
-- Audiobook tab: **Production Overrides** (position/class temperature, steps, guidance, postprocess) for expressive narration, plus IndexTTS2 emotion controls and a "vary repeated lines" toggle — defaults reproduce today's renders exactly (#1208)
+- Audiobook tab: **Production Overrides** (position/class temperature, steps, guidance, postprocess, seed) for expressive narration, plus IndexTTS2 emotion controls and a "vary repeated lines" toggle — defaults reproduce today's renders exactly (#1208)
 
 ### CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Info/warn system notifications are dismissible and stay dismissed across restarts; error-level notices can't be dismissed, and the unclean-shutdown notice is now acknowledged server-side — thanks @agudmund! (#1192)
 - `clone_voice` MCP tool — AI agents can clone a new voice from a base64 reference audio sample; returns a `profile_id` immediately usable with `generate_speech` — thanks @paoloantinori! (#1194)
 - Dub tab: **Paste Translation** — paste a translation made elsewhere (ChatGPT, DeepL, a human) as subtitles, numbered lines, or plain lines; it maps onto the existing segments with a before→after preview, keeping timings and the source transcript intact (#1203)
+- Audiobook tab: **Production Overrides** (position/class temperature, steps, guidance, postprocess) for expressive narration, plus IndexTTS2 emotion controls and a "vary repeated lines" toggle — defaults reproduce today's renders exactly (#1208)
 
 ### CI
 
@@ -48,9 +49,11 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - `docs/expressive-speech.md`: per-engine breaths/laughter/emotion control, incl. the default engine's 13 native reaction tags
 - Flush caches / Unload documented in the performance guide, incl. `POST /system/flush-memory` for scripts
 - README FAQ: why a longer reference clip doesn't clone better (zero-shot 15 s cap; fine-tuning is the audiobook-grade path)
+- `docs/expressive-speech.md` corrected so every recipe it names (breaths, temperature) is reachable in the surface it points to, including the Audiobook tab (#1208)
 
 ### Fixed
 
+- Audiobook language selection now reaches the backend — the client had dropped the `language` field, and the tab's Markup reference now lists the reaction tags (`[laughter]`, `[sigh]`, …) that already work there (#1208)
 - A backend that fails to start now says why — exit code and error output, with actionable hints and a one-click report — instead of the evidence-free "Can't reach the local OmniVoice backend" (#1177)
 - Generation no longer crawls on CPU after a cancelled or failed dub: the TTS model is moved back to the GPU on every exit path, and each generation now verifies its own placement (#1191)
 - A generation queued behind a busy one no longer spends its timeout waiting: the budget starts when a GPU worker picks the job up, so a queued request can't be failed as "too heavy for the available compute" without having run (#1190)

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -32,6 +32,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from services.audiobook import (
+    ExpressiveOptions,
     parse_audiobook_script,
     synthesize_chapter,
 )
@@ -77,6 +78,51 @@ def _safe_cover_path(cover_path: str | None) -> str | None:
     if os.path.commonpath([real, cover_dir]) != cover_dir:
         return None
     return real if os.path.isfile(real) else None
+
+
+class ExpressiveMixin(BaseModel):
+    """Optional expressive/quality knobs shared by every longform front door
+    (#1210). All optional — an omitted field reproduces today's exact render.
+
+    * Sampling: ``num_step`` / ``guidance_scale`` / ``position_temperature`` /
+      ``class_temperature`` / ``postprocess_output`` — the same surface the
+      Voice page's Production Overrides expose. Unset → the documented longform
+      preset (num_step 32, guidance 2.0, model-default temps, postprocess on).
+    * ``seed`` — a book-level determinism override (else the profile's pinned
+      seed, else fresh-render variety).
+    * Emotion (IndexTTS2 only): ``emo_vector`` (8 floats) / ``emo_text`` /
+      ``emo_alpha`` — reach engines that understand them via the generic synth
+      closure; other engines ignore them.
+    * ``vary_repeats`` — cache opt-out: give identical repeated lines distinct
+      takes instead of replaying one recording (default off = today).
+    """
+
+    num_step: int | None = None
+    guidance_scale: float | None = None
+    position_temperature: float | None = None
+    class_temperature: float | None = None
+    postprocess_output: bool | None = None
+    seed: int | None = None
+    emo_vector: list[float] | None = None
+    emo_text: str | None = None
+    emo_alpha: float | None = None
+    vary_repeats: bool = False
+
+
+def _expressive_opts(req: "ExpressiveMixin") -> ExpressiveOptions:
+    """Lower a request's expressive fields into the typed engine-options object."""
+    return ExpressiveOptions(
+        num_step=req.num_step,
+        guidance_scale=req.guidance_scale,
+        position_temperature=req.position_temperature,
+        class_temperature=req.class_temperature,
+        postprocess_output=req.postprocess_output,
+        seed=req.seed,
+        emo_vector=tuple(req.emo_vector) if req.emo_vector else None,
+        emo_text=(req.emo_text or None),
+        emo_alpha=req.emo_alpha,
+        vary_repeats=bool(req.vary_repeats),
+    )
 
 
 class AudiobookPlanRequest(BaseModel):
@@ -161,7 +207,7 @@ async def audiobook_cover(cover: UploadFile = File(...)) -> dict:
     return {"path": path}
 
 
-class AudiobookRequest(BaseModel):
+class AudiobookRequest(ExpressiveMixin):
     text: str
     default_voice: str | None = None   # voice profile id; None = engine default
     language: str | None = None        # None/"Auto" → profile language, else autodetect (#505)
@@ -256,7 +302,7 @@ LONGFORM_NUM_STEP = 32
 LONGFORM_GUIDANCE_SCALE = 2.0
 
 
-def _seed_segment_rng(base_seed, text: str) -> None:
+def _seed_segment_rng(base_seed, text: str, nonce: int = 0) -> None:
     """Apply a profile's pinned seed to this synth call (#1139).
 
     ``_resolve_voice`` has always fetched the profile ``seed`` — but only the
@@ -279,10 +325,87 @@ def _seed_segment_rng(base_seed, text: str) -> None:
     import torch
 
     from services.audiobook import segment_seed
-    torch.manual_seed(segment_seed(base_seed, text))
+    torch.manual_seed(segment_seed(base_seed, text, nonce))
 
 
-def _build_synth(default_voice: str | None, language: str | None = None) -> dict:
+def _base_seed(opts: ExpressiveOptions, voice: dict):
+    """The seed that drives this render's determinism: an explicit book-level
+    ``seed`` override wins, else the selected profile's pinned seed, else None
+    (fresh-render variety, unchanged)."""
+    return opts.seed if opts.seed is not None else voice.get("seed")
+
+
+def _make_occ_counter(opts: ExpressiveOptions):
+    """Per-closure occurrence counter for the cache opt-out (#1210).
+
+    When ``vary_repeats`` is on, every synth call gets a monotonically rising
+    nonce so a pinned-seed line that repeats is seeded distinctly per take (the
+    segment cache is defeated per-occurrence in parallel). Off → always 0, so
+    the seed derivation is byte-identical to pre-#1210."""
+    state = {"n": 0}
+
+    def next_nonce() -> int:
+        if not opts.vary_repeats:
+            return 0
+        n = state["n"]
+        state["n"] = n + 1
+        return n
+
+    return next_nonce
+
+
+def _omnivoice_sampling_kwargs(opts: ExpressiveOptions) -> dict:
+    """OmniVoice-model generate kwargs for the sampling knobs. UNSET reproduces
+    today exactly: num_step 32, guidance 2.0, and NO temperature/postprocess
+    kwargs (the model keeps its own defaults). Emotion is never forwarded —
+    the OmniVoice config rejects unknown kwargs."""
+    kw = {
+        "num_step": opts.num_step if opts.num_step is not None else LONGFORM_NUM_STEP,
+        "guidance_scale": (
+            opts.guidance_scale if opts.guidance_scale is not None else LONGFORM_GUIDANCE_SCALE
+        ),
+    }
+    if opts.position_temperature is not None:
+        kw["position_temperature"] = opts.position_temperature
+    if opts.class_temperature is not None:
+        kw["class_temperature"] = opts.class_temperature
+    if opts.postprocess_output is not None:
+        kw["postprocess_output"] = opts.postprocess_output
+    return kw
+
+
+def _generic_extra_kwargs(opts: ExpressiveOptions) -> dict:
+    """Extra generate kwargs for a non-OmniVoice engine. UNSET → empty dict →
+    byte-identical to the pre-#1210 generic call. Only present knobs are added,
+    and every shipped backend's ``generate(self, text, **kw)`` ignores the ones
+    it doesn't understand (never TypeError) — the engine-options contract. The
+    emotion trio reaches IndexTTS2's arbitration; other engines drop it."""
+    kw: dict = {}
+    if opts.num_step is not None:
+        kw["num_step"] = opts.num_step
+    if opts.guidance_scale is not None:
+        kw["guidance_scale"] = opts.guidance_scale
+    if opts.position_temperature is not None:
+        kw["position_temperature"] = opts.position_temperature
+    if opts.class_temperature is not None:
+        kw["class_temperature"] = opts.class_temperature
+    if opts.postprocess_output is not None:
+        kw["postprocess_output"] = opts.postprocess_output
+    if opts.emo_vector:
+        kw["emo_vector"] = list(opts.emo_vector)
+    if opts.emo_text:
+        kw["emo_text"] = opts.emo_text
+        kw["use_emo_text"] = True
+    if opts.emo_alpha is not None:
+        kw["emo_alpha"] = opts.emo_alpha
+    return kw
+
+
+def _build_synth(
+    default_voice: str | None,
+    language: str | None = None,
+    opts: ExpressiveOptions | None = None,
+) -> dict:
     """Describe how to synthesize for the active TTS engine.
 
     Returns a dict with ``mode``, ``resolve`` (voice-id → resolved refs, cached
@@ -295,9 +418,13 @@ def _build_synth(default_voice: str | None, language: str | None = None) -> dict
     threaded into every chunk's ``generate`` so a non-English clone stays in its
     language instead of re-autodetecting per chunk (#505 B2). ``None`` keeps the
     engine's autodetect behavior unchanged.
+
+    ``opts`` (#1210) carries the expressive/quality knobs + cache opt-out. A
+    default instance reproduces today's exact synth call and caching.
     """
     from services.tts_backend import OmniVoiceBackend, active_backend_id, get_backend_class
 
+    opts = opts or ExpressiveOptions()
     cache: dict = {}
 
     def resolve(voice_id):
@@ -310,29 +437,37 @@ def _build_synth(default_voice: str | None, language: str | None = None) -> dict
     cls = get_backend_class(engine_id)
     if cls is OmniVoiceBackend:
         from services.model_manager import get_model
-        return {"mode": "omnivoice", "resolve": resolve,
-                "engine_id": engine_id, "get_model": get_model, "language": language}
+        return {"mode": "omnivoice", "resolve": resolve, "engine_id": engine_id,
+                "get_model": get_model, "language": language, "opts": opts}
 
     backend = cls()
+    extra = _generic_extra_kwargs(opts)
+    next_nonce = _make_occ_counter(opts)
 
     def synth(text, voice_id, speed=None):
         v = resolve(voice_id)
-        _seed_segment_rng(v.get("seed"), text)
+        _seed_segment_rng(_base_seed(opts, v), text, next_nonce())
         return backend.generate(
             text, language=language, ref_audio=v["ref_audio"],
             ref_text=v["ref_text"], instruct=v["instruct"], duration=None,
-            speed=float(speed) if speed else 1.0,
+            speed=float(speed) if speed else 1.0, **extra,
         )
     return {"mode": "generic", "resolve": resolve, "engine_id": engine_id,
             "synth": synth, "sample_rate": backend.sample_rate}
 
 
-async def _prepare_synth(default_voice: str | None, language: str | None = None):
+async def _prepare_synth(
+    default_voice: str | None,
+    language: str | None = None,
+    opts: ExpressiveOptions | None = None,
+):
     """Resolve :func:`_build_synth` into ``(synth, sample_rate, resolve,
     engine_id)`` — awaiting the OmniVoice model load when needed. Shared by the
     full job and the per-chapter preview. ``language`` is threaded into every
-    chunk so a non-English clone holds its language (#505 B2)."""
-    info = _build_synth(default_voice, language=language)
+    chunk so a non-English clone holds its language (#505 B2). ``opts`` (#1210)
+    carries the expressive knobs; a default instance reproduces today exactly."""
+    opts = opts or ExpressiveOptions()
+    info = _build_synth(default_voice, language=language, opts=opts)
     resolve, engine_id = info["resolve"], info["engine_id"]
     if info["mode"] == "omnivoice":
         lang = info["language"]
@@ -341,25 +476,26 @@ async def _prepare_synth(default_voice: str | None, language: str | None = None)
 
         from services.tts_backend import generate_with_cached_ref
 
+        sampling = _omnivoice_sampling_kwargs(opts)
+        next_nonce = _make_occ_counter(opts)
+
         def synth(text, voice_id, speed=None):
             v = resolve(voice_id)
-            _seed_segment_rng(v.get("seed"), text)
+            _seed_segment_rng(_base_seed(opts, v), text, next_nonce())
             # A book is the worst case for the re-encode this avoids: hundreds of
             # segments, one voice. The reference is encoded on the first segment
             # and reused for every one after it.
             return generate_with_cached_ref(
                 model, ref_audio=v["ref_audio"], ref_text=v["ref_text"],
                 text=text, language=lang, instruct=v["instruct"], duration=None,
-                num_step=LONGFORM_NUM_STEP,
-                guidance_scale=LONGFORM_GUIDANCE_SCALE,
-                speed=float(speed) if speed else 1.0,
+                speed=float(speed) if speed else 1.0, **sampling,
             )[0]
         return synth, sr, resolve, engine_id
     return info["synth"], info["sample_rate"], resolve, engine_id
 
 
 def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, lexicon=None,
-                           language=None):
+                           language=None, opts=None):
     """Render one chapter, content-addressed so a re-run reuses it (resume).
 
     Returns ``(wav_path, duration_s, was_cached, seg_stats)``. Two cache
@@ -392,11 +528,13 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, le
     import wave
 
     from services.audio_io import atomic_save_wav
-    from services.audiobook import Span
+    from services.audiobook import ExpressiveOptions, Span
     from services.longform_render import SegmentCache, chapter_cache_key
     from services.pronunciation import normalize_lexicon
     from services.text_normalization import normalize_for_tts
     from services.watermark import mark_synthetic, will_mark
+
+    opts = opts or ExpressiveOptions()
 
     spans = [Span(voice_id=s.voice_id, text=normalize_for_tts(s.text, language),
                   pause_ms_after=s.pause_ms_after, speed=getattr(s, "speed", None))
@@ -416,6 +554,14 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, le
         # invalidates cached chapters (reserved key can't collide with a voice id).
         lex_sig = json.dumps(normalize_lexicon(lexicon), sort_keys=True)
         sig["\x00lexicon"] = lex_sig
+    # Fold the #1210 expressive signature into BOTH cache layers so changing any
+    # new knob (sampling, emotion, seed, cache opt-out) re-renders instead of
+    # replaying stale audio (the CRITICAL TRAP). Empty for a default render, so
+    # the derivation stays byte-identical to pre-#1210 and released caches hit.
+    expr_sig = opts.cache_signature()
+    if expr_sig:
+        sig["\x00expressive"] = expr_sig
+    seg_extra_sig = f"{lex_sig}\x00{expr_sig}" if expr_sig else lex_sig
     if will_mark():
         # Provenance-marked chapters cache under their own key (#1169): a
         # chapter WAV rendered while watermarking was off/unavailable —
@@ -438,7 +584,8 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, le
             pass  # corrupt cache entry — fall through and re-render
 
     seg_cache = SegmentCache(cache_dir, sample_rate=sr, engine_id=engine_id,
-                             voice_sig=voice_sigs, extra_sig=lex_sig)
+                             voice_sig=voice_sigs, extra_sig=seg_extra_sig,
+                             vary_repeats=opts.vary_repeats)
     audio, dur = synthesize_chapter(spans, synth, sr, lexicon=lexicon,
                                     segment_cache=seg_cache)
     # Invisible provenance mark on the assembled chapter (#1169), tensor stage,
@@ -456,7 +603,7 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, le
                                   "cached": seg_cache.hits}
 
 
-class AudiobookPreviewRequest(BaseModel):
+class AudiobookPreviewRequest(ExpressiveMixin):
     text: str
     chapter_index: int = 0
     default_voice: str | None = None
@@ -485,14 +632,16 @@ async def audiobook_preview(req: AudiobookPreviewRequest) -> dict:
     cache_dir = os.path.join(OUTPUTS_DIR, "longform_cache")  # shared with _render_longform_sse
     os.makedirs(cache_dir, exist_ok=True)
     resolved_lang = _resolve_default_language(req.language, req.default_voice)
+    opts = _expressive_opts(req)
     synth, sr, resolve, engine_id = await _prepare_synth(
         req.default_voice,
         language=resolved_lang,
+        opts=opts,
     )
     loop = asyncio.get_running_loop()
     wav_path, dur, was_cached, _seg_stats = await loop.run_in_executor(
         _gpu_pool, _render_chapter_cached, chapter, synth, sr, engine_id, resolve, cache_dir,
-        req.lexicon, resolved_lang,
+        req.lexicon, resolved_lang, opts,
     )
     return {
         "output": os.path.relpath(wav_path, OUTPUTS_DIR),  # served via /audio
@@ -513,6 +662,7 @@ async def _render_longform_sse(
     cover_path: str | None = None,
     metadata: dict | None = None,
     lexicon: dict | None = None,
+    opts: ExpressiveOptions | None = None,
     job_type: str = "audiobook",
     job_id: str | None = None,
     resume: bool = False,
@@ -528,6 +678,8 @@ async def _render_longform_sse(
     from core.config import OUTPUTS_DIR
     from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
     from services.model_manager import _gpu_pool
+
+    opts = opts or ExpressiveOptions()
 
     # Resume reuses the original job_id (continuing the same job row + cached
     # chapters); a fresh render generates a new one. The id may arrive from the
@@ -559,6 +711,9 @@ async def _render_longform_sse(
                 "fmt": fmt, "bitrate": bitrate,
                 "loudness": loudness, "cover_path": cover_path,
                 "metadata": metadata, "lexicon": lexicon,
+                # #1210: persist the expressive knobs so a resumed render is
+                # byte-consistent with the interrupted one (same cache keys).
+                "expressive": opts.to_manifest(),
             },
         ))
     except Exception:  # resume durability is an enhancement; never block the render
@@ -599,7 +754,7 @@ async def _render_longform_sse(
     try:
         resolved_lang = _resolve_default_language(language, default_voice)
         synth, sr, resolve, engine_id = await _prepare_synth(
-            default_voice, language=resolved_lang
+            default_voice, language=resolved_lang, opts=opts
         )
 
         total = len(plan.chapters)
@@ -614,7 +769,7 @@ async def _render_longform_sse(
                 wav_path, dur, was_cached, seg_stats = await loop.run_in_executor(
                     _gpu_pool, _render_chapter_cached,
                     chapter, synth, sr, engine_id, resolve, cache_dir, lexicon,
-                    resolved_lang,
+                    resolved_lang, opts,
                 )
             except Exception:  # isolate a bad chapter — keep going
                 logger.warning("[%s] chapter %d (%s) failed to render",
@@ -714,7 +869,7 @@ async def audiobook_synthesize(req: AudiobookRequest):
             plan, default_voice=req.default_voice, language=req.language,
             fmt=req.format, bitrate=req.bitrate,
             loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
-            lexicon=req.lexicon, job_type="audiobook",
+            lexicon=req.lexicon, opts=_expressive_opts(req), job_type="audiobook",
         ),
         media_type="text/event-stream",
     )
@@ -734,7 +889,7 @@ class LongformChapter(BaseModel):
     spans: list[LongformSpan] = []
 
 
-class LongformRenderRequest(BaseModel):
+class LongformRenderRequest(ExpressiveMixin):
     chapters: list[LongformChapter] = []
     default_voice: str | None = None
     language: str | None = None        # None/"Auto" → profile language, else autodetect (#505)
@@ -771,7 +926,7 @@ async def longform_render(req: LongformRenderRequest):
             plan, default_voice=req.default_voice, language=req.language,
             fmt=req.format, bitrate=req.bitrate,
             loudness=req.loudness, cover_path=req.cover_path, metadata=req.metadata,
-            lexicon=req.lexicon, job_type="story",
+            lexicon=req.lexicon, opts=_expressive_opts(req), job_type="story",
         ),
         media_type="text/event-stream",
     )
@@ -863,6 +1018,7 @@ async def resume_longform(job_id: str):
             fmt=p.get("fmt", "m4b"), bitrate=p.get("bitrate", "128k"),
             loudness=p.get("loudness"), cover_path=p.get("cover_path"),
             metadata=p.get("metadata"), lexicon=p.get("lexicon"),
+            opts=ExpressiveOptions.from_manifest(p.get("expressive")),
             job_type=entry["job_type"],
         ),
         media_type="text/event-stream",

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -29,7 +29,7 @@ import uuid
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from services.audiobook import (
     ExpressiveOptions,
@@ -97,15 +97,19 @@ class ExpressiveMixin(BaseModel):
       takes instead of replaying one recording (default off = today).
     """
 
-    num_step: int | None = None
-    guidance_scale: float | None = None
-    position_temperature: float | None = None
-    class_temperature: float | None = None
+    # Bounds so a loopback POST (reachable by a browser-tab CSRF) can't pin a
+    # GPU-pool worker with an absurd step count or otherwise feed the sampler
+    # nonsense. Ranges are generous supersets of the Voice-page controls; unset
+    # (None) still means "use the longform default", unchanged. (#1208)
+    num_step: int | None = Field(default=None, ge=1, le=512)
+    guidance_scale: float | None = Field(default=None, ge=0.0, le=20.0)
+    position_temperature: float | None = Field(default=None, ge=0.0, le=100.0)
+    class_temperature: float | None = Field(default=None, ge=0.0, le=100.0)
     postprocess_output: bool | None = None
-    seed: int | None = None
-    emo_vector: list[float] | None = None
-    emo_text: str | None = None
-    emo_alpha: float | None = None
+    seed: int | None = Field(default=None, ge=0, le=2**32 - 1)
+    emo_vector: list[float] | None = Field(default=None, min_length=8, max_length=8)
+    emo_text: str | None = Field(default=None, max_length=500)
+    emo_alpha: float | None = Field(default=None, ge=0.0, le=1.0)
     vary_repeats: bool = False
 
 

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -82,7 +82,7 @@ def _safe_cover_path(cover_path: str | None) -> str | None:
 
 class ExpressiveMixin(BaseModel):
     """Optional expressive/quality knobs shared by every longform front door
-    (#1210). All optional — an omitted field reproduces today's exact render.
+    (#1208). All optional — an omitted field reproduces today's exact render.
 
     * Sampling: ``num_step`` / ``guidance_scale`` / ``position_temperature`` /
       ``class_temperature`` / ``postprocess_output`` — the same surface the
@@ -336,12 +336,12 @@ def _base_seed(opts: ExpressiveOptions, voice: dict):
 
 
 def _make_occ_counter(opts: ExpressiveOptions):
-    """Per-closure occurrence counter for the cache opt-out (#1210).
+    """Per-closure occurrence counter for the cache opt-out (#1208).
 
     When ``vary_repeats`` is on, every synth call gets a monotonically rising
     nonce so a pinned-seed line that repeats is seeded distinctly per take (the
     segment cache is defeated per-occurrence in parallel). Off → always 0, so
-    the seed derivation is byte-identical to pre-#1210."""
+    the seed derivation is byte-identical to pre-#1208."""
     state = {"n": 0}
 
     def next_nonce() -> int:
@@ -376,7 +376,7 @@ def _omnivoice_sampling_kwargs(opts: ExpressiveOptions) -> dict:
 
 def _generic_extra_kwargs(opts: ExpressiveOptions) -> dict:
     """Extra generate kwargs for a non-OmniVoice engine. UNSET → empty dict →
-    byte-identical to the pre-#1210 generic call. Only present knobs are added,
+    byte-identical to the pre-#1208 generic call. Only present knobs are added,
     and every shipped backend's ``generate(self, text, **kw)`` ignores the ones
     it doesn't understand (never TypeError) — the engine-options contract. The
     emotion trio reaches IndexTTS2's arbitration; other engines drop it."""
@@ -419,7 +419,7 @@ def _build_synth(
     language instead of re-autodetecting per chunk (#505 B2). ``None`` keeps the
     engine's autodetect behavior unchanged.
 
-    ``opts`` (#1210) carries the expressive/quality knobs + cache opt-out. A
+    ``opts`` (#1208) carries the expressive/quality knobs + cache opt-out. A
     default instance reproduces today's exact synth call and caching.
     """
     from services.tts_backend import OmniVoiceBackend, active_backend_id, get_backend_class
@@ -464,7 +464,7 @@ async def _prepare_synth(
     """Resolve :func:`_build_synth` into ``(synth, sample_rate, resolve,
     engine_id)`` — awaiting the OmniVoice model load when needed. Shared by the
     full job and the per-chapter preview. ``language`` is threaded into every
-    chunk so a non-English clone holds its language (#505 B2). ``opts`` (#1210)
+    chunk so a non-English clone holds its language (#505 B2). ``opts`` (#1208)
     carries the expressive knobs; a default instance reproduces today exactly."""
     opts = opts or ExpressiveOptions()
     info = _build_synth(default_voice, language=language, opts=opts)
@@ -554,10 +554,10 @@ def _render_chapter_cached(chapter, synth, sr, engine_id, resolve, cache_dir, le
         # invalidates cached chapters (reserved key can't collide with a voice id).
         lex_sig = json.dumps(normalize_lexicon(lexicon), sort_keys=True)
         sig["\x00lexicon"] = lex_sig
-    # Fold the #1210 expressive signature into BOTH cache layers so changing any
+    # Fold the #1208 expressive signature into BOTH cache layers so changing any
     # new knob (sampling, emotion, seed, cache opt-out) re-renders instead of
     # replaying stale audio (the CRITICAL TRAP). Empty for a default render, so
-    # the derivation stays byte-identical to pre-#1210 and released caches hit.
+    # the derivation stays byte-identical to pre-#1208 and released caches hit.
     expr_sig = opts.cache_signature()
     if expr_sig:
         sig["\x00expressive"] = expr_sig
@@ -711,7 +711,7 @@ async def _render_longform_sse(
                 "fmt": fmt, "bitrate": bitrate,
                 "loudness": loudness, "cover_path": cover_path,
                 "metadata": metadata, "lexicon": lexicon,
-                # #1210: persist the expressive knobs so a resumed render is
+                # #1208: persist the expressive knobs so a resumed render is
                 # byte-consistent with the interrupted one (same cache keys).
                 "expressive": opts.to_manifest(),
             },

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -78,6 +78,7 @@ class IndexTTS2Backend(SubprocessBackend):
     id = "indextts2"
     display_name = "IndexTTS2 (emotion control, duration control, zero-shot)"
     supports_voice_design = False  # requires ref audio for timbre
+    supports_emotion = True  # graded emo_vector / emo_text / emo_alpha (#1210)
     _DEFAULT_SAMPLE_RATE = 24000
     # Explicit so IndexTTS2 stops advertising the inherited CPU-only default:
     # the sidecar runs the IndexTTS PyTorch model on CUDA when present, else

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -78,7 +78,7 @@ class IndexTTS2Backend(SubprocessBackend):
     id = "indextts2"
     display_name = "IndexTTS2 (emotion control, duration control, zero-shot)"
     supports_voice_design = False  # requires ref audio for timbre
-    supports_emotion = True  # graded emo_vector / emo_text / emo_alpha (#1210)
+    supports_emotion = True  # graded emo_vector / emo_text / emo_alpha (#1208)
     _DEFAULT_SAMPLE_RATE = 24000
     # Explicit so IndexTTS2 stops advertising the inherited CPU-only default:
     # the sidecar runs the IndexTTS PyTorch model on CUDA when present, else

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -22,12 +22,19 @@ ingestion, the streaming synth job + UI are deferred follow-ups.
 
 from __future__ import annotations
 
+import json
 import zlib
 from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 
-def segment_seed(base_seed: int, text: str) -> int:
+#: Mix constant for the per-occurrence seed nonce (#1210) — a large odd
+#: multiplier (Knuth) so occurrence 0/1/2 land in well-separated regions of the
+#: 2**31 seed space instead of adjacent integers.
+_NONCE_MIX = 2654435761
+
+
+def segment_seed(base_seed: int, text: str, nonce: int = 0) -> int:
     """Deterministic RNG seed for one longform synthesis call (#1139).
 
     A voice profile's pinned ``seed`` (locked takes, design profiles) makes
@@ -48,8 +55,105 @@ def segment_seed(base_seed: int, text: str) -> int:
     reproducibility. Position-based keys would break it: inserting one
     paragraph would shift every later span's seed, so a partial re-render
     after an edit would no longer match the original render.
+
+    ``nonce`` (default 0 — the shipped text-keyed behaviour, byte-identical)
+    is the cache opt-out lever (#1210): when the user asks to *vary repeated
+    lines*, the synth wrapper feeds a per-occurrence nonce so each repeat of an
+    identical pinned-seed line gets a distinct-but-deterministic seed instead
+    of replaying one take.
     """
-    return (int(base_seed) + zlib.crc32(text.encode("utf-8"))) % (2**31)
+    return (int(base_seed) + zlib.crc32(text.encode("utf-8")) + int(nonce) * _NONCE_MIX) % (2**31)
+
+
+@dataclass(frozen=True)
+class ExpressiveOptions:
+    """Optional expressive/quality knobs for a longform render (#1210).
+
+    Every field is ``None``/``False`` by default, and a default instance means
+    *reproduce today's bytes exactly*: the audiobook/longform path renders at
+    its documented quality preset (num_step 32, guidance 2.0, model-default
+    temperatures, postprocess on) with no emotion and the shipped
+    content-addressed caching. Any non-default field is folded into every cache
+    signature via :meth:`cache_signature` (chapter cache, segment cache, and the
+    preview cache all consume it) so a changed setting can never silently replay
+    stale audio — the whole point of the CRITICAL TRAP guard.
+
+    ``emo_*`` reach only engines that understand them (IndexTTS2) through the
+    generic synth closure; the OmniVoice model rejects unknown config kwargs, so
+    the omnivoice path forwards only the sampling knobs. ``vary_repeats`` is the
+    cache opt-out: identical lines get distinct takes.
+    """
+
+    num_step: Optional[int] = None
+    guidance_scale: Optional[float] = None
+    position_temperature: Optional[float] = None
+    class_temperature: Optional[float] = None
+    postprocess_output: Optional[bool] = None
+    seed: Optional[int] = None
+    emo_vector: Optional[tuple] = None
+    emo_text: Optional[str] = None
+    emo_alpha: Optional[float] = None
+    vary_repeats: bool = False
+
+    @property
+    def is_default(self) -> bool:
+        """True when every knob is untouched → today's exact render + caching."""
+        return self == ExpressiveOptions()
+
+    def cache_signature(self) -> str:
+        """Deterministic content string folded into every cache key. Empty for a
+        default instance (so unset → byte-identical keys to pre-#1210). Includes
+        EVERY field, so a future forgotten knob still perturbs the key (the
+        regression test loops over the fields asserting each changes this)."""
+        if self.is_default:
+            return ""
+        payload = {
+            "num_step": self.num_step,
+            "guidance_scale": self.guidance_scale,
+            "position_temperature": self.position_temperature,
+            "class_temperature": self.class_temperature,
+            "postprocess_output": self.postprocess_output,
+            "seed": self.seed,
+            "emo_vector": list(self.emo_vector) if self.emo_vector else None,
+            "emo_text": self.emo_text,
+            "emo_alpha": self.emo_alpha,
+            "vary_repeats": self.vary_repeats,
+        }
+        return json.dumps(payload, sort_keys=True, ensure_ascii=False)
+
+    def to_manifest(self) -> dict:
+        """JSON-safe dict for the durable resume manifest (emo_vector → list)."""
+        return {
+            "num_step": self.num_step,
+            "guidance_scale": self.guidance_scale,
+            "position_temperature": self.position_temperature,
+            "class_temperature": self.class_temperature,
+            "postprocess_output": self.postprocess_output,
+            "seed": self.seed,
+            "emo_vector": list(self.emo_vector) if self.emo_vector else None,
+            "emo_text": self.emo_text,
+            "emo_alpha": self.emo_alpha,
+            "vary_repeats": self.vary_repeats,
+        }
+
+    @classmethod
+    def from_manifest(cls, data: Optional[dict]) -> "ExpressiveOptions":
+        """Rebuild from a resume manifest dict (unknown keys ignored)."""
+        if not data:
+            return cls()
+        ev = data.get("emo_vector")
+        return cls(
+            num_step=data.get("num_step"),
+            guidance_scale=data.get("guidance_scale"),
+            position_temperature=data.get("position_temperature"),
+            class_temperature=data.get("class_temperature"),
+            postprocess_output=data.get("postprocess_output"),
+            seed=data.get("seed"),
+            emo_vector=tuple(ev) if ev else None,
+            emo_text=data.get("emo_text"),
+            emo_alpha=data.get("emo_alpha"),
+            vary_repeats=bool(data.get("vary_repeats", False)),
+        )
 
 
 @dataclass
@@ -154,9 +258,18 @@ def synthesize_chapter(
     from services.pronunciation import apply_lexicon
 
     items: list = []  # ("a", tensor) for audio, ("s", n_samples) for silence
+    # Per-occurrence index for identical spans (#1210 cache opt-out). The
+    # segment cache folds it into its key ONLY when vary_repeats is on (else
+    # the key is byte-identical to pre-#1210), so a repeated identical line
+    # gets a distinct cache slot — and therefore a distinct take — instead of
+    # replaying one WAV. Always computed (cheap); inert when the cache ignores it.
+    occ_counts: dict = {}
     for span in spans:
         if span.text:
-            audio = segment_cache.load(span) if segment_cache is not None else None
+            occ_key = (span.voice_id, span.text, getattr(span, "speed", None))
+            occ = occ_counts.get(occ_key, 0)
+            occ_counts[occ_key] = occ + 1
+            audio = segment_cache.load(span, nonce=occ) if segment_cache is not None else None
             if audio is None:
                 chunks = split_text_into_chunks(apply_lexicon(span.text, lexicon))
                 rendered = [synth(c, span.voice_id, span.speed) for c in chunks]
@@ -166,7 +279,7 @@ def synthesize_chapter(
                 elif rendered:
                     audio = concatenate_audio_chunks(rendered, sample_rate, crossfade_ms=crossfade_ms)
                 if audio is not None and segment_cache is not None:
-                    segment_cache.store(span, audio)
+                    segment_cache.store(span, audio, nonce=occ)
             if audio is not None:
                 items.append(("a", audio))
         if span.pause_ms_after > 0:

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 
-#: Mix constant for the per-occurrence seed nonce (#1210) — a large odd
+#: Mix constant for the per-occurrence seed nonce (#1208) — a large odd
 #: multiplier (Knuth) so occurrence 0/1/2 land in well-separated regions of the
 #: 2**31 seed space instead of adjacent integers.
 _NONCE_MIX = 2654435761
@@ -57,7 +57,7 @@ def segment_seed(base_seed: int, text: str, nonce: int = 0) -> int:
     after an edit would no longer match the original render.
 
     ``nonce`` (default 0 — the shipped text-keyed behaviour, byte-identical)
-    is the cache opt-out lever (#1210): when the user asks to *vary repeated
+    is the cache opt-out lever (#1208): when the user asks to *vary repeated
     lines*, the synth wrapper feeds a per-occurrence nonce so each repeat of an
     identical pinned-seed line gets a distinct-but-deterministic seed instead
     of replaying one take.
@@ -67,7 +67,7 @@ def segment_seed(base_seed: int, text: str, nonce: int = 0) -> int:
 
 @dataclass(frozen=True)
 class ExpressiveOptions:
-    """Optional expressive/quality knobs for a longform render (#1210).
+    """Optional expressive/quality knobs for a longform render (#1208).
 
     Every field is ``None``/``False`` by default, and a default instance means
     *reproduce today's bytes exactly*: the audiobook/longform path renders at
@@ -102,7 +102,7 @@ class ExpressiveOptions:
 
     def cache_signature(self) -> str:
         """Deterministic content string folded into every cache key. Empty for a
-        default instance (so unset → byte-identical keys to pre-#1210). Includes
+        default instance (so unset → byte-identical keys to pre-#1208). Includes
         EVERY field, so a future forgotten knob still perturbs the key (the
         regression test loops over the fields asserting each changes this)."""
         if self.is_default:
@@ -258,9 +258,9 @@ def synthesize_chapter(
     from services.pronunciation import apply_lexicon
 
     items: list = []  # ("a", tensor) for audio, ("s", n_samples) for silence
-    # Per-occurrence index for identical spans (#1210 cache opt-out). The
+    # Per-occurrence index for identical spans (#1208 cache opt-out). The
     # segment cache folds it into its key ONLY when vary_repeats is on (else
-    # the key is byte-identical to pre-#1210), so a repeated identical line
+    # the key is byte-identical to pre-#1208), so a repeated identical line
     # gets a distinct cache slot — and therefore a distinct take — instead of
     # replaying one WAV. Always computed (cheap); inert when the cache ignores it.
     occ_counts: dict = {}

--- a/backend/services/longform_render.py
+++ b/backend/services/longform_render.py
@@ -157,14 +157,19 @@ def segment_cache_key(
     voice_sig: str = "",
     speed: Optional[float] = None,
     extra_sig: str = "",
+    nonce: int = 0,
 ) -> str:
     """Deterministic content hash for ONE rendered segment (a single spoken
     span). Same dimensions as :func:`chapter_cache_key` minus span order and
     pauses (pauses are synthesized silence — never cached): text, voice
     identity (id + resolved signature), speed, sample rate, engine, plus
     ``extra_sig`` for anything else that changes the rendered audio (the
-    pronunciation lexicon today). Any change → new key → re-synthesize just
-    this segment.
+    pronunciation lexicon + the #1210 expressive signature). Any change → new
+    key → re-synthesize just this segment.
+
+    ``nonce`` (default 0 — omitted from the key, so pre-#1210 caches keep
+    hitting) is the per-occurrence disambiguator the cache opt-out feeds so a
+    repeated identical line gets a distinct segment instead of replaying one.
     """
     payload = {
         "sr": int(sample_rate),
@@ -175,6 +180,10 @@ def segment_cache_key(
         "voice_sig": voice_sig or "",
         "extra": extra_sig or "",
     }
+    if nonce:
+        # Absent when 0 so the derivation is byte-identical to pre-#1210 for
+        # every normal (non-vary_repeats) render.
+        payload["nonce"] = int(nonce)
     raw = json.dumps(payload, sort_keys=True, ensure_ascii=False)
     # Content-addressing only — not a security digest (see chapter_cache_key).
     return hashlib.sha1(raw.encode("utf-8"), usedforsecurity=False).hexdigest()[:20]
@@ -206,16 +215,21 @@ class SegmentCache:
         engine_id: str,
         voice_sig: Optional[dict] = None,
         extra_sig: str = "",
+        vary_repeats: bool = False,
     ) -> None:
         self.dir = os.path.join(cache_dir, SEGMENT_SUBDIR)
         self.sample_rate = int(sample_rate)
         self.engine_id = engine_id or ""
         self.voice_sig = dict(voice_sig or {})
         self.extra_sig = extra_sig or ""
+        # Cache opt-out (#1210): when on, a per-occurrence nonce enters the key
+        # so identical repeated lines no longer share one WAV. Off → the nonce
+        # is dropped and keys are byte-identical to pre-#1210 (default render).
+        self.vary_repeats = bool(vary_repeats)
         self.hits = 0
         self.misses = 0
 
-    def _path(self, span) -> str:
+    def _path(self, span, nonce: int = 0) -> str:
         key = segment_cache_key(
             span.text,
             sample_rate=self.sample_rate,
@@ -224,13 +238,16 @@ class SegmentCache:
             voice_sig=self.voice_sig.get(span.voice_id or "", ""),
             speed=getattr(span, "speed", None),
             extra_sig=self.extra_sig,
+            nonce=nonce if self.vary_repeats else 0,
         )
         return os.path.join(self.dir, f"{key}.wav")
 
-    def load(self, span):
+    def load(self, span, nonce: int = 0):
         """Cached audio tensor for ``span``, or ``None`` (miss). A hit bumps
-        the file's mtime so LRU eviction sees the segment as recently used."""
-        path = self._path(span)
+        the file's mtime so LRU eviction sees the segment as recently used.
+        ``nonce`` disambiguates repeated identical lines under the cache
+        opt-out (inert otherwise)."""
+        path = self._path(span, nonce)
         if not os.path.isfile(path):
             self.misses += 1
             return None
@@ -250,13 +267,14 @@ class SegmentCache:
         self.hits += 1
         return audio
 
-    def store(self, span, audio) -> None:
+    def store(self, span, audio, nonce: int = 0) -> None:
         """Persist a freshly rendered segment. Best-effort — a full disk or
-        unwritable cache dir must never fail the chapter render."""
+        unwritable cache dir must never fail the chapter render. ``nonce``
+        matches :meth:`load` so a varied repeat lands in its own slot."""
         try:
             from services.audio_io import atomic_save_wav
             os.makedirs(self.dir, exist_ok=True)
-            atomic_save_wav(self._path(span), audio, self.sample_rate)
+            atomic_save_wav(self._path(span, nonce), audio, self.sample_rate)
         except Exception:
             pass
 

--- a/backend/services/longform_render.py
+++ b/backend/services/longform_render.py
@@ -164,10 +164,10 @@ def segment_cache_key(
     pauses (pauses are synthesized silence — never cached): text, voice
     identity (id + resolved signature), speed, sample rate, engine, plus
     ``extra_sig`` for anything else that changes the rendered audio (the
-    pronunciation lexicon + the #1210 expressive signature). Any change → new
+    pronunciation lexicon + the #1208 expressive signature). Any change → new
     key → re-synthesize just this segment.
 
-    ``nonce`` (default 0 — omitted from the key, so pre-#1210 caches keep
+    ``nonce`` (default 0 — omitted from the key, so pre-#1208 caches keep
     hitting) is the per-occurrence disambiguator the cache opt-out feeds so a
     repeated identical line gets a distinct segment instead of replaying one.
     """
@@ -181,7 +181,7 @@ def segment_cache_key(
         "extra": extra_sig or "",
     }
     if nonce:
-        # Absent when 0 so the derivation is byte-identical to pre-#1210 for
+        # Absent when 0 so the derivation is byte-identical to pre-#1208 for
         # every normal (non-vary_repeats) render.
         payload["nonce"] = int(nonce)
     raw = json.dumps(payload, sort_keys=True, ensure_ascii=False)
@@ -222,9 +222,9 @@ class SegmentCache:
         self.engine_id = engine_id or ""
         self.voice_sig = dict(voice_sig or {})
         self.extra_sig = extra_sig or ""
-        # Cache opt-out (#1210): when on, a per-occurrence nonce enters the key
+        # Cache opt-out (#1208): when on, a per-occurrence nonce enters the key
         # so identical repeated lines no longer share one WAV. Off → the nonce
-        # is dropped and keys are byte-identical to pre-#1210 (default render).
+        # is dropped and keys are byte-identical to pre-#1208 (default render).
         self.vary_repeats = bool(vary_repeats)
         self.hits = 0
         self.misses = 0

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -171,6 +171,15 @@ class TTSBackend(ABC):
     #: (e.g. "young female, warm tone, British accent") without reference audio.
     supports_voice_design: bool = False
 
+    #: Whether this engine understands the graded-emotion generate kwargs
+    #: (``emo_vector`` / ``emo_text`` + ``use_emo_text`` / ``emo_alpha``).
+    #: Surfaced via ``list_backends()`` so UI surfaces (the Audiobook expressive
+    #: panel, #1210) can show emotion controls ONLY for engines that apply them
+    #: — no dead controls. Default False; IndexTTS2 overrides to True. Engines
+    #: that don't set it still ignore the kwargs (every generate() takes **kw),
+    #: so this is a discoverability hint, not an enforcement gate.
+    supports_emotion: bool = False
+
     def ensure_ready(self) -> None:
         """Load model weights now (blocking), so callers can separate the
         LOAD budget from the GENERATE budget (#1033/#1037 class).
@@ -1997,6 +2006,9 @@ def list_backends() -> list[dict]:
             # upgrade hint). None unless ok and the message carries advice.
             "hint": _available_hint(msg) if ok else None,
             "supports_cloning": _clone if isinstance(_clone, bool) else None,
+            # Graded-emotion capability (#1210) — drives the Audiobook emotion
+            # panel's engine gate. Class attr, defaults False.
+            "supports_emotion": bool(getattr(cls, "supports_emotion", False)),
             "install_hint": _INSTALL_HINTS.get(bid),
             # Exact `export VAR=...` line for path-gated opt-in engines, or None.
             "setup_snippet": _SETUP_SNIPPETS.get(bid),

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -174,7 +174,7 @@ class TTSBackend(ABC):
     #: Whether this engine understands the graded-emotion generate kwargs
     #: (``emo_vector`` / ``emo_text`` + ``use_emo_text`` / ``emo_alpha``).
     #: Surfaced via ``list_backends()`` so UI surfaces (the Audiobook expressive
-    #: panel, #1210) can show emotion controls ONLY for engines that apply them
+    #: panel, #1208) can show emotion controls ONLY for engines that apply them
     #: — no dead controls. Default False; IndexTTS2 overrides to True. Engines
     #: that don't set it still ignore the kwargs (every generate() takes **kw),
     #: so this is a discoverability hint, not an enforcement gate.
@@ -2006,7 +2006,7 @@ def list_backends() -> list[dict]:
             # upgrade hint). None unless ok and the message carries advice.
             "hint": _available_hint(msg) if ok else None,
             "supports_cloning": _clone if isinstance(_clone, bool) else None,
-            # Graded-emotion capability (#1210) — drives the Audiobook emotion
+            # Graded-emotion capability (#1208) — drives the Audiobook emotion
             # panel's engine gate. Class attr, defaults False.
             "supports_emotion": bool(getattr(cls, "supports_emotion", False)),
             "install_hint": _INSTALL_HINTS.get(bid),

--- a/docs/expressive-speech.md
+++ b/docs/expressive-speech.md
@@ -15,7 +15,7 @@ ignores.
 | Laughter or a sigh | ⊕ Insert → `[laughter]` / `[sigh]` | Default engine (OmniVoice) |
 | An audible breath **on demand** | `[breath]` in the text | CosyVoice 3 only (opt-in) — see [Breaths](#breaths-specifically) |
 | Whispering | Style → `whisper` (the voice-design/style field) | Default engine |
-| Emotion ("excited", "sad", graded intensity) | IndexTTS2's emotion controls (API), or CosyVoice 3 instruct | Opt-in engines only |
+| Emotion ("excited", "sad", graded intensity) | IndexTTS2's emotion controls — Audiobook tab's Production Overrides, or the `/ws/tts` API — or CosyVoice 3 instruct | Opt-in engines only |
 | The same take again | Pin the seed / lock the profile | Default engine |
 
 ## Why bracket tags work at all (and when they don't)
@@ -75,21 +75,27 @@ accepts (the taxonomy is Gender / Age / Pitch / Style / Accent / Dialect —
 see [voice-design.md](voice-design.md)). `[happy]` / `[sad]`-style emotion
 direction is **not** something the base model takes.
 
-**Sampling knobs + seed.** The Voice workspace's Production Overrides panel
-exposes the full sampling surface (defaults in parentheses; details in
-[generation-parameters.md](generation-parameters.md)):
+**Sampling knobs + seed.** The Voice workspace **and the Audiobook tab** each
+carry a Production Overrides panel exposing the sampling surface (defaults in
+parentheses; details in [generation-parameters.md](generation-parameters.md)):
 
 - `position_temperature` (5.0) and `class_temperature` (0.0) — 0 is greedy;
   higher is more random, which means more expressive variation *and* more
   artifacts.
-- `num_step` — the Voice page defaults to 16 (fast); Audiobook renders use 32
-  (cleaner). Fewer steps = rougher, occasionally more "human-sounding" edges.
+- `num_step` — the Voice page defaults to 16 (fast); Audiobook renders default
+  to 32 (cleaner), overridable in the Audiobook panel. Fewer steps = rougher,
+  occasionally more "human-sounding" edges.
 - **Seed** — unpinned by default, so every render differs. The history rail
   shows the seed each take used; "Keep this seed" (Design tab) or locking a
   profile from history pins reference + seed, making the voice
-  bit-reproducible.
+  bit-reproducible. The Audiobook panel also takes a book-level seed directly.
 - `postprocess_output` (on) — removes long silences from the output. Turn it
   off when the silence *is* the performance.
+
+The Audiobook panel adds two longform-only controls on top of that surface:
+IndexTTS2 emotion (see below), and **Vary repeated lines** — a cache opt-out
+that gives every identical line its own take instead of replaying one recording
+(off by default, so books stay byte-reproducible unless you ask for variety).
 
 **Longform-only tags.** Audiobook and Stories additionally parse SSML-lite —
 `[slow]…[/slow]`, `[fast]…[/fast]`, `[emphasis]…[/emphasis]`, `[spell]` —
@@ -132,10 +138,14 @@ guidance, not a guarantee — adherence varies by voice and language.
 The only engine with **graded** emotion control: an 8-value emotion vector
 (happy, angry, sad, afraid, disgusted, melancholic, surprised, calm), an
 emotion *reference clip* whose delivery is mimicked (with a blend strength),
-or a natural-language emotion description. Today these are exposed on the
-streaming WebSocket API (`/ws/tts` — `emo_vector`, `emo_audio`, `emo_alpha`,
-`emo_text` fields; `backend/api/routers/tts_stream.py`), **not** in the
-Studio UI yet.
+or a natural-language emotion description. The **Audiobook tab's Production
+Overrides** expose the natural-language path — an *Emotion description* field
+plus an *Emotion strength* slider (`emo_alpha`), shown only when IndexTTS2 is
+the active engine so there are no dead controls. The full surface (the 8-float
+`emo_vector`, an `emo_audio` reference clip) is on the streaming WebSocket API
+(`/ws/tts` — `emo_vector`, `emo_audio`, `emo_alpha`, `emo_text` fields;
+`backend/api/routers/tts_stream.py`). The single-shot Voice page does not carry
+emotion controls yet.
 
 ## Breaths, specifically
 
@@ -159,14 +169,19 @@ exactly what v0.3.9 was doing by accident. Roughly in order of effectiveness:
    clone mirrors the delivery. This alone gets most of the way there.
 2. **Write for it.** Short gasping fragments with pauses:
    `I can't… [pause 300ms] I can't keep… [pause 200ms] keep running.`
-3. **Turn off `postprocess_output`** (Production Overrides) so the silences —
-   where breath artifacts live — aren't trimmed away.
+3. **Turn off `postprocess_output`** (Production Overrides — Voice tab *or*
+   Audiobook tab) so the silences — where breath artifacts live — aren't
+   trimmed away.
 4. **Add randomness, then farm takes.** Raise `class_temperature` to 0.3–0.7
-   (default is 0, fully greedy), keep `num_step` at 16, and regenerate a few
-   times — the seed is unpinned, so each take differs.
+   (default is 0, fully greedy) and regenerate a few times — the seed is
+   unpinned, so each take differs. Both controls live in the same Production
+   Overrides panel, so this whole recipe now works for an audiobook chapter
+   (audition it with the per-chapter Preview button), not just a single Voice
+   render. In a book, the **Vary repeated lines** toggle farms takes across
+   repeated lines automatically.
 5. **Keep the winner.** When a take breathes right, its seed is on the
-   history entry — lock the profile from there and every future generation
-   uses the same reference + seed.
+   history entry — lock the profile from there (or set the Audiobook panel's
+   book-level seed) and every future generation uses the same reference + seed.
 
 Tradeoffs, stated plainly: temperature cuts both ways (the same randomness
 that produces a great gasp produces slurred words and timbre drift), takes
@@ -202,7 +217,10 @@ than something that happens to you.
 engine-agnostic tag surface (`[excited]`, `[whispers]`, reaction tags like
 `[breath]`) that lowers to whatever the active engine can really do and
 **visibly degrades** where it can't, plus an Expression panel (emotion
-dropdown + intensity + emotion-reference clip) in the UI. The pronunciation
-phases have shipped (dictionary + `[[…]]` overrides); the inline
-emotion/reaction tag grammar and the Expression panel have not. No promised
-date — when it lands, this page gets updated in the same PR.
+dropdown + intensity + emotion-reference clip) everywhere in the UI. The
+pronunciation phases have shipped (dictionary + `[[…]]` overrides), and the
+Audiobook tab now carries a first Expression surface — IndexTTS2 emotion
+description + strength, engine-gated. Still spec'd, not shipped: the
+engine-agnostic inline emotion/reaction tag grammar, the emotion-reference
+clip picker, and the Expression panel on the single-shot Voice page. No
+promised date — when each lands, this page gets updated in the same PR.

--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -36,13 +36,35 @@ export interface AudiobookPreview {
   title: string;
 }
 
+/**
+ * Expressive/quality knobs shared by the audiobook synth + per-chapter preview
+ * (#1210). All optional — an omitted field reproduces today's exact render on
+ * the backend. Preview MUST carry the same fields as the full render so a
+ * previewed chapter warms exactly the cache slot the render reuses.
+ */
+export interface ExpressiveRequestFields {
+  num_step?: number | null;
+  guidance_scale?: number | null;
+  position_temperature?: number | null;
+  class_temperature?: number | null;
+  postprocess_output?: boolean | null;
+  seed?: number | null;
+  emo_vector?: number[] | null;
+  emo_text?: string | null;
+  emo_alpha?: number | null;
+  vary_repeats?: boolean;
+}
+
 /** Render a single chapter to audition it (also warms the resume cache). */
-export async function audiobookPreviewChapter(body: {
-  text: string;
-  chapter_index: number;
-  default_voice?: string | null;
-  lexicon?: Record<string, string> | null;
-}): Promise<AudiobookPreview> {
+export async function audiobookPreviewChapter(
+  body: {
+    text: string;
+    chapter_index: number;
+    default_voice?: string | null;
+    language?: string | null;
+    lexicon?: Record<string, string> | null;
+  } & ExpressiveRequestFields,
+): Promise<AudiobookPreview> {
   const res = await apiFetch('/audiobook/preview', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -61,9 +83,13 @@ interface AudiobookMetadata {
   description?: string;
 }
 
-export interface AudiobookGenerateBody {
+export interface AudiobookGenerateBody extends ExpressiveRequestFields {
   text: string;
   default_voice?: string | null;
+  // #1210 / #505: the backend AudiobookRequest has always accepted `language`,
+  // but this body omitted it, so an audiobook language pick could never reach
+  // the backend. Now threaded through ('Auto' → the profile's language).
+  language?: string | null;
   bitrate?: string;
   format?: 'm4b' | 'mp3';
   loudness?: 'off' | 'acx' | 'podcast' | null;
@@ -101,7 +127,7 @@ export async function audiobookImport(file: File): Promise<{ text: string; chapt
   return res.json();
 }
 
-export interface LongformRenderBody {
+export interface LongformRenderBody extends ExpressiveRequestFields {
   chapters: Array<{
     title?: string;
     spans: Array<{
@@ -112,6 +138,7 @@ export interface LongformRenderBody {
     }>;
   }>;
   default_voice?: string | null;
+  language?: string | null;
   bitrate?: string;
   format?: 'm4b' | 'mp3';
   loudness?: 'off' | 'acx' | 'podcast' | null;

--- a/frontend/src/api/audiobook.ts
+++ b/frontend/src/api/audiobook.ts
@@ -38,7 +38,7 @@ export interface AudiobookPreview {
 
 /**
  * Expressive/quality knobs shared by the audiobook synth + per-chapter preview
- * (#1210). All optional — an omitted field reproduces today's exact render on
+ * (#1208). All optional — an omitted field reproduces today's exact render on
  * the backend. Preview MUST carry the same fields as the full render so a
  * previewed chapter warms exactly the cache slot the render reuses.
  */
@@ -86,7 +86,7 @@ interface AudiobookMetadata {
 export interface AudiobookGenerateBody extends ExpressiveRequestFields {
   text: string;
   default_voice?: string | null;
-  // #1210 / #505: the backend AudiobookRequest has always accepted `language`,
+  // #1208 / #505: the backend AudiobookRequest has always accepted `language`,
   // but this body omitted it, so an audiobook language pick could never reach
   // the backend. Now threaded through ('Auto' → the profile's language).
   language?: string | null;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -37,6 +37,10 @@ interface EngineBackend {
   // when model-dependent (mlx-audio's curated models differ). Only badge on
   // an explicit true.
   supports_cloning?: boolean | null;
+  // Graded-emotion capability (#1210) — the Audiobook expressive panel shows
+  // emotion controls only when the active engine sets this. Absent on legacy
+  // payloads (treated as false).
+  supports_emotion?: boolean;
   install_hint?: string | null;
   // Copy-paste-ready `export VAR=...` line for a path-gated opt-in engine
   // (IndexTTS / MOSS-v1.5 / dots.tts / Confucius4), else null/absent.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -37,7 +37,7 @@ interface EngineBackend {
   // when model-dependent (mlx-audio's curated models differ). Only badge on
   // an explicit true.
   supports_cloning?: boolean | null;
-  // Graded-emotion capability (#1210) — the Audiobook expressive panel shows
+  // Graded-emotion capability (#1208) — the Audiobook expressive panel shows
   // emotion controls only when the active engine sets this. Absent on legacy
   // payloads (treated as false).
   supports_emotion?: boolean;

--- a/frontend/src/components/audiobook/AudiobookOverrides.jsx
+++ b/frontend/src/components/audiobook/AudiobookOverrides.jsx
@@ -1,0 +1,215 @@
+import { useState } from 'react';
+import { Settings2, ChevronDown, ChevronUp, RotateCcw } from 'lucide-react';
+import { DEFAULT_OVERRIDES } from '../../store/longformSlice';
+
+// Longform render defaults the sliders display when a knob is UNSET (null) —
+// the documented audiobook/longform preset. A null value means "not overridden"
+// (the backend keeps the model default and today's bytes); moving a slider sets
+// an explicit override. Mirrors the Voice page's Production Overrides surface.
+const DISPLAY = { numStep: 32, guidanceScale: 2.0, posTemp: 5.0, classTemp: 0.0 };
+
+const CHIP =
+  'text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]';
+
+/**
+ * Production Overrides for the Audiobook tab (#1210) — the same sampling surface
+ * as the Voice page's ActionBar panel, plus a cache opt-out and (engine-gated)
+ * IndexTTS2 emotion. Every control is optional: an untouched panel leaves the
+ * store defaults (all null/false), which reproduce today's exact render.
+ *
+ * Controlled: `overrides` holds the values, `onChange(patch)` merges edits back
+ * to the store. `emotionSupported` gates the emotion block so there are no dead
+ * controls on engines that ignore emotion.
+ */
+export default function AudiobookOverrides({ t, overrides, onChange, emotionSupported = false }) {
+  const [open, setOpen] = useState(false);
+  const o = overrides;
+
+  return (
+    <div className="audiobook-tab__field flex flex-col gap-[6px]">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          className="inline-flex items-center gap-[4px] px-[4px] py-[4px] text-[0.72rem] text-[var(--chrome-fg-muted)] bg-transparent border-none cursor-pointer hover:text-[var(--chrome-fg)]"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+        >
+          <Settings2 size={13} /> {t('audiobook.expressive')}
+          {open ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        </button>
+        {open && (
+          <button
+            type="button"
+            className="inline-flex items-center gap-[4px] px-[6px] py-[2px] text-[0.65rem] text-[var(--chrome-fg-muted)] bg-transparent border-none cursor-pointer hover:text-[var(--chrome-fg)]"
+            onClick={() => onChange({ ...DEFAULT_OVERRIDES })}
+          >
+            <RotateCcw size={11} /> {t('audiobook.reset')}
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <div className="flex flex-col gap-[10px] pl-[2px]">
+          <div className="grid grid-cols-2 gap-[8px]">
+            <div>
+              <div className="label-row justify-between text-[0.7rem]">
+                <span>{t('clone.steps')}</span>
+                <span className={CHIP}>{o.numStep ?? DISPLAY.numStep}</span>
+              </div>
+              <input
+                type="range"
+                min="8"
+                max="64"
+                step="1"
+                aria-label={t('clone.steps')}
+                value={o.numStep ?? DISPLAY.numStep}
+                onChange={(e) => onChange({ numStep: Number(e.target.value) })}
+              />
+            </div>
+            <div>
+              <div className="label-row justify-between text-[0.7rem]">
+                <span>CFG</span>
+                <span className={CHIP}>{o.guidanceScale ?? DISPLAY.guidanceScale}</span>
+              </div>
+              <input
+                type="range"
+                min="1.0"
+                max="4.0"
+                step="0.1"
+                aria-label="CFG"
+                value={o.guidanceScale ?? DISPLAY.guidanceScale}
+                onChange={(e) => onChange({ guidanceScale: Number(e.target.value) })}
+              />
+            </div>
+            <div>
+              <div className="label-row justify-between text-[0.7rem]">
+                <span>{t('clone.pos_temp')}</span>
+                <span className={CHIP}>{o.posTemp ?? DISPLAY.posTemp}</span>
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="10"
+                step="0.5"
+                aria-label={t('clone.pos_temp')}
+                value={o.posTemp ?? DISPLAY.posTemp}
+                onChange={(e) => onChange({ posTemp: Number(e.target.value) })}
+              />
+            </div>
+            <div>
+              <div className="label-row justify-between text-[0.7rem]">
+                <span>{t('clone.class_temp')}</span>
+                <span className={CHIP}>{o.classTemp ?? DISPLAY.classTemp}</span>
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="2"
+                step="0.1"
+                aria-label={t('clone.class_temp')}
+                value={o.classTemp ?? DISPLAY.classTemp}
+                onChange={(e) => onChange({ classTemp: Number(e.target.value) })}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-[16px] gap-y-[6px]">
+            <label className="text-[0.72rem] flex items-center gap-[6px] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={o.postprocess ?? true}
+                onChange={(e) => onChange({ postprocess: e.target.checked })}
+              />{' '}
+              {t('clone.postprocess')}
+            </label>
+            <label
+              className="text-[0.72rem] flex items-center gap-[6px] cursor-pointer"
+              title={t('audiobook.vary_repeats_help')}
+            >
+              <input
+                type="checkbox"
+                checked={!!o.varyRepeats}
+                onChange={(e) => onChange({ varyRepeats: e.target.checked })}
+              />{' '}
+              {t('audiobook.vary_repeats')}
+            </label>
+            <label className="text-[0.72rem] flex items-center gap-[6px]">
+              {t('audiobook.seed')}
+              <input
+                type="text"
+                inputMode="numeric"
+                className="input-base text-[0.75rem] w-[86px]"
+                placeholder={t('audiobook.seed_ph')}
+                aria-label={t('audiobook.seed')}
+                value={o.seed ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value.trim();
+                  const n = Number.parseInt(v, 10);
+                  // Keep 0 as a valid seed — only empty / non-numeric clears it.
+                  onChange({ seed: v === '' || Number.isNaN(n) ? null : n });
+                }}
+              />
+            </label>
+          </div>
+
+          {emotionSupported && (
+            <div className="flex flex-col gap-[6px] pt-[6px] [border-top:1px_solid_rgba(255,255,255,0.06)]">
+              <div className="text-[0.7rem] text-fg-muted">{t('audiobook.emotion_help')}</div>
+              <label className="text-[0.72rem] flex flex-col gap-[3px]">
+                {t('audiobook.emotion_text')}
+                <input
+                  type="text"
+                  className="input-base text-[0.8rem]"
+                  placeholder={t('audiobook.emotion_text_ph')}
+                  aria-label={t('audiobook.emotion_text')}
+                  value={o.emoText ?? ''}
+                  onChange={(e) => onChange({ emoText: e.target.value })}
+                />
+              </label>
+              <div>
+                <div className="label-row justify-between text-[0.7rem]">
+                  <span>{t('audiobook.emotion_alpha')}</span>
+                  <span className={CHIP}>{o.emoAlpha ?? 1.0}</span>
+                </div>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  aria-label={t('audiobook.emotion_alpha')}
+                  value={o.emoAlpha ?? 1.0}
+                  onChange={(e) => onChange({ emoAlpha: Number(e.target.value) })}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Lower the persisted overrides (+ language) into the snake_case request fields
+ * the backend expects. Only NON-default values are emitted, so an untouched
+ * panel adds nothing to the body → today's exact request. Shared by the full
+ * render and the per-chapter preview so both hit the same cache slot.
+ */
+export function overridesToRequest(overrides, language) {
+  const o = overrides || DEFAULT_OVERRIDES;
+  const body = {};
+  if (language && language !== 'Auto') body.language = language;
+  if (o.numStep != null) body.num_step = o.numStep;
+  if (o.guidanceScale != null) body.guidance_scale = o.guidanceScale;
+  if (o.posTemp != null) body.position_temperature = o.posTemp;
+  if (o.classTemp != null) body.class_temperature = o.classTemp;
+  if (o.postprocess != null) body.postprocess_output = o.postprocess;
+  if (o.seed != null) body.seed = o.seed;
+  if (o.varyRepeats) body.vary_repeats = true;
+  const emo = (o.emoText || '').trim();
+  if (emo) {
+    body.emo_text = emo;
+    if (o.emoAlpha != null) body.emo_alpha = o.emoAlpha;
+  }
+  return body;
+}

--- a/frontend/src/components/audiobook/AudiobookOverrides.jsx
+++ b/frontend/src/components/audiobook/AudiobookOverrides.jsx
@@ -12,7 +12,7 @@ const CHIP =
   'text-[0.65rem] bg-black/35 px-[5px] py-px rounded-[3px] [border:1px_solid_rgba(255,255,255,0.04)] [font-variant-numeric:tabular-nums]';
 
 /**
- * Production Overrides for the Audiobook tab (#1210) — the same sampling surface
+ * Production Overrides for the Audiobook tab (#1208) — the same sampling surface
  * as the Voice page's ActionBar panel, plus a cache opt-out and (engine-gated)
  * IndexTTS2 emotion. Every control is optional: an untouched panel leaves the
  * store defaults (all null/false), which reproduce today's exact render.

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -2108,7 +2108,18 @@
     "lex_add": "أضف كلمة",
     "lex_remove": "إزالة",
     "markup_help": "مرجع العلامات",
-    "markup_hint": "# عنوان الفصل · [صوت: الاسم] تبديل الصوت · [إيقاف مؤقت 500 مللي ثانية] / [إيقاف مؤقت 1 ثانية] · [بطيء]…[/slow] · [سريع]…[/سريع] · [التشديد]…[/التشديد] · [تهجئة]…[/تهجئة]"
+    "markup_hint": "# عنوان الفصل · [صوت: الاسم] تبديل الصوت · [إيقاف مؤقت 500 مللي ثانية] / [إيقاف مؤقت 1 ثانية] · [بطيء]…[/slow] · [سريع]…[/سريع] · [التشديد]…[/التشديد] · [تهجئة]…[/تهجئة] · الردود (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "لغة",
+    "expressive": "تجاوزات الإنتاج",
+    "reset": "إعادة تعيين",
+    "seed": "بذرة",
+    "seed_ph": "تلقائي",
+    "vary_repeats": "تنويع الأسطر المكررة",
+    "vary_repeats_help": "امنح الأسطر المتطابقة لقطات مختلفة بدلاً من إعادة استخدام تسجيل واحد.",
+    "emotion_help": "عاطفة متدرجة — يتم تطبيقها فقط من خلال محرك IndexTTS2.",
+    "emotion_text": "وصف العاطفة",
+    "emotion_text_ph": "على سبيل المثال يبدو متعباً وحزيناً",
+    "emotion_alpha": "قوة العاطفة"
   },
   "voicePanel": {
     "title": "صوت",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -2108,7 +2108,7 @@
     "lex_add": "أضف كلمة",
     "lex_remove": "إزالة",
     "markup_help": "مرجع العلامات",
-    "markup_hint": "# عنوان الفصل · [صوت: الاسم] تبديل الصوت · [إيقاف مؤقت 500 مللي ثانية] / [إيقاف مؤقت 1 ثانية] · [بطيء]…[/slow] · [سريع]…[/سريع] · [التشديد]…[/التشديد] · [تهجئة]…[/تهجئة] · الردود (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# عنوان الفصل · [voice:NAME] تبديل الصوت · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · الردود (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "لغة",
     "expressive": "تجاوزات الإنتاج",
     "reset": "إعادة تعيين",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Wort hinzufügen",
     "lex_remove": "Entfernen",
     "markup_help": "Markup-Referenz",
-    "markup_hint": "# Kapiteltitel · [voice:NAME] Stimme wechseln · [Pause 500 ms] / [Pause 1 s] · [langsam]…[/slow] · [schnell]…[/fast] · [Hervorhebung]…[/emphasis] · [buchstabieren]…[/buchstabieren] · Reaktionen (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Kapiteltitel · [voice:NAME] Stimme wechseln · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reaktionen (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Sprache",
     "expressive": "Produktionsübersteuerungen",
     "reset": "Zurücksetzen",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Wort hinzufügen",
     "lex_remove": "Entfernen",
     "markup_help": "Markup-Referenz",
-    "markup_hint": "# Kapiteltitel · [voice:NAME] Stimme wechseln · [Pause 500 ms] / [Pause 1 s] · [langsam]…[/slow] · [schnell]…[/fast] · [Hervorhebung]…[/emphasis] · [buchstabieren]…[/buchstabieren]"
+    "markup_hint": "# Kapiteltitel · [voice:NAME] Stimme wechseln · [Pause 500 ms] / [Pause 1 s] · [langsam]…[/slow] · [schnell]…[/fast] · [Hervorhebung]…[/emphasis] · [buchstabieren]…[/buchstabieren] · Reaktionen (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Sprache",
+    "expressive": "Produktionsübersteuerungen",
+    "reset": "Zurücksetzen",
+    "seed": "Samen",
+    "seed_ph": "Automatisch",
+    "vary_repeats": "Wiederholt Zeilen variieren",
+    "vary_repeats_help": "Geben Sie identischen Zeilen unterschiedliche Takes, anstatt eine Aufnahme wiederzuverwenden.",
+    "emotion_help": "Abgestufte Emotion — nur vom IndexTTS2-Engine angewendet.",
+    "emotion_text": "Emotionsbeschreibung",
+    "emotion_text_ph": "z.B. klingt erschöpft und traurig",
+    "emotion_alpha": "Emotionale Stärke"
   },
   "voicePanel": {
     "title": "Stimme",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -197,7 +197,18 @@
     "lex_add": "Add word",
     "lex_remove": "Remove",
     "markup_help": "Markup reference",
-    "markup_hint": "# Chapter title · [voice:NAME] switch voice · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell]"
+    "markup_hint": "# Chapter title · [voice:NAME] switch voice · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reactions (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Language",
+    "expressive": "Production overrides",
+    "reset": "Reset",
+    "seed": "Seed",
+    "seed_ph": "Auto",
+    "vary_repeats": "Vary repeated lines",
+    "vary_repeats_help": "Give identical lines distinct takes instead of reusing one recording.",
+    "emotion_help": "Graded emotion — applied by the IndexTTS2 engine only.",
+    "emotion_text": "Emotion description",
+    "emotion_text_ph": "e.g. sounds exhausted and sad",
+    "emotion_alpha": "Emotion strength"
   },
   "launchpad": {
     "greeting": "hello there",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Agregar palabra",
     "lex_remove": "Quitar",
     "markup_help": "Referencia de marcado",
-    "markup_hint": "# Título del capítulo · [voz:NOMBRE] cambiar voz · [pausa 500ms] / [pausa 1s] · [lento]…[/lento] · [rápido]…[/rápido] · [énfasis]…[/énfasis] · [deletrear]…[/deletrear] · Reacciones (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Título del capítulo · [voice:NAME] cambiar voz · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reacciones (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Idioma",
     "expressive": "Anulaciones de producción",
     "reset": "Reiniciar",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Agregar palabra",
     "lex_remove": "Quitar",
     "markup_help": "Referencia de marcado",
-    "markup_hint": "# Título del capítulo · [voz:NOMBRE] cambiar voz · [pausa 500ms] / [pausa 1s] · [lento]…[/lento] · [rápido]…[/rápido] · [énfasis]…[/énfasis] · [deletrear]…[/deletrear]"
+    "markup_hint": "# Título del capítulo · [voz:NOMBRE] cambiar voz · [pausa 500ms] / [pausa 1s] · [lento]…[/lento] · [rápido]…[/rápido] · [énfasis]…[/énfasis] · [deletrear]…[/deletrear] · Reacciones (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Idioma",
+    "expressive": "Anulaciones de producción",
+    "reset": "Reiniciar",
+    "seed": "Semilla",
+    "seed_ph": "Automático",
+    "vary_repeats": "Variar líneas repetidas",
+    "vary_repeats_help": "Proporcione tomas distintas a líneas idénticas en lugar de reutilizar una grabación.",
+    "emotion_help": "Emoción graduada — aplicada solo por el motor IndexTTS2.",
+    "emotion_text": "Descripción de emoción",
+    "emotion_text_ph": "p. ej. suena agotado y triste",
+    "emotion_alpha": "Intensidad emocional"
   },
   "voicePanel": {
     "title": "Voz",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Ajouter un mot",
     "lex_remove": "Supprimer",
     "markup_help": "Référence de balisage",
-    "markup_hint": "# Titre du chapitre · [voix:NOM] changer de voix · [pause 500 ms] / [pause 1s] · [lent]…[/lent] · [rapide]…[/rapide] · [emphasis]…[/emphasis] · [spell]…[/spell]"
+    "markup_hint": "# Titre du chapitre · [voix:NOM] changer de voix · [pause 500 ms] / [pause 1s] · [lent]…[/lent] · [rapide]…[/rapide] · [emphasis]…[/emphasis] · [spell]…[/spell] · Réactions (OmniVoice) : [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Langue",
+    "expressive": "Remplacements de production",
+    "reset": "Réinitialiser",
+    "seed": "Graine",
+    "seed_ph": "Auto",
+    "vary_repeats": "Varier les lignes répétées",
+    "vary_repeats_help": "Donnez des prises distinctes aux lignes identiques au lieu de réutiliser un enregistrement.",
+    "emotion_help": "Émotion graduée — appliquée par le moteur IndexTTS2 uniquement.",
+    "emotion_text": "Description de l'émotion",
+    "emotion_text_ph": "p. ex. sonne épuisé et triste",
+    "emotion_alpha": "Force de l'émotion"
   },
   "voicePanel": {
     "title": "Voix",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Ajouter un mot",
     "lex_remove": "Supprimer",
     "markup_help": "Référence de balisage",
-    "markup_hint": "# Titre du chapitre · [voix:NOM] changer de voix · [pause 500 ms] / [pause 1s] · [lent]…[/lent] · [rapide]…[/rapide] · [emphasis]…[/emphasis] · [spell]…[/spell] · Réactions (OmniVoice) : [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Titre du chapitre · [voice:NAME] changer de voix · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Réactions (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Langue",
     "expressive": "Remplacements de production",
     "reset": "Réinitialiser",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -2108,7 +2108,18 @@
     "lex_add": "शब्द जोड़ें",
     "lex_remove": "हटाओ",
     "markup_help": "मार्कअप संदर्भ",
-    "markup_hint": "# अध्याय का शीर्षक · [आवाज:नाम] आवाज बदलें · [500 एमएस रोकें] / [1 सेकंड रोकें] · [धीमा]…[/धीमा] · [तेज]…[/तेज] · [जोर]…[/जोर] · [वर्तनी]…[/वर्तनी]"
+    "markup_hint": "# अध्याय का शीर्षक · [आवाज:नाम] आवाज बदलें · [500 एमएस रोकें] / [1 सेकंड रोकें] · [धीमा]…[/धीमा] · [तेज]…[/तेज] · [जोर]…[/जोर] · [वर्तनी]…[/वर्तनी] · प्रतिक्रियाएं (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "भाषा",
+    "expressive": "उत्पादन ओवरराइड",
+    "reset": "रीसेट करें",
+    "seed": "बीज",
+    "seed_ph": "स्वचालित",
+    "vary_repeats": "दोहराई गई पंक्तियों को अलग करें",
+    "vary_repeats_help": "एक रिकॉर्डिंग का पुनः उपयोग करने के बजाय समान पंक्तियों को अलग-अलग टेक दें।",
+    "emotion_help": "क्रमिक भावना — केवल IndexTTS2 इंजन द्वारा लागू किया गया।",
+    "emotion_text": "भावना विवरण",
+    "emotion_text_ph": "जैसे। थका हुआ और उदास लगता है",
+    "emotion_alpha": "भावना की शक्ति"
   },
   "voicePanel": {
     "title": "आवाज",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -2108,7 +2108,7 @@
     "lex_add": "शब्द जोड़ें",
     "lex_remove": "हटाओ",
     "markup_help": "मार्कअप संदर्भ",
-    "markup_hint": "# अध्याय का शीर्षक · [आवाज:नाम] आवाज बदलें · [500 एमएस रोकें] / [1 सेकंड रोकें] · [धीमा]…[/धीमा] · [तेज]…[/तेज] · [जोर]…[/जोर] · [वर्तनी]…[/वर्तनी] · प्रतिक्रियाएं (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# अध्याय का शीर्षक · [voice:NAME] आवाज बदलें · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · प्रतिक्रियाएं (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "भाषा",
     "expressive": "उत्पादन ओवरराइड",
     "reset": "रीसेट करें",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Tambahkan kata",
     "lex_remove": "Hapus",
     "markup_help": "Referensi markup",
-    "markup_hint": "# Judul bab · [suara:NAMA] ganti suara · [jeda 500 md] / [jeda 1 detik] · [lambat]…[/lambat] · [cepat]…[/cepat] · [penekanan]…[/penekanan] · [mantra]…[/mantra] · Reaksi (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Judul bab · [voice:NAME] ganti suara · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reaksi (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Bahasa",
     "expressive": "Overide produksi",
     "reset": "Setel ulang",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Tambahkan kata",
     "lex_remove": "Hapus",
     "markup_help": "Referensi markup",
-    "markup_hint": "# Judul bab · [suara:NAMA] ganti suara · [jeda 500 md] / [jeda 1 detik] · [lambat]…[/lambat] · [cepat]…[/cepat] · [penekanan]…[/penekanan] · [mantra]…[/mantra]"
+    "markup_hint": "# Judul bab · [suara:NAMA] ganti suara · [jeda 500 md] / [jeda 1 detik] · [lambat]…[/lambat] · [cepat]…[/cepat] · [penekanan]…[/penekanan] · [mantra]…[/mantra] · Reaksi (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Bahasa",
+    "expressive": "Overide produksi",
+    "reset": "Setel ulang",
+    "seed": "Benih",
+    "seed_ph": "Otomatis",
+    "vary_repeats": "Bervariasi baris berulang",
+    "vary_repeats_help": "Berikan pengambilan yang berbeda untuk baris identik daripada menggunakan kembali satu perekaman.",
+    "emotion_help": "Emosi berjenjang — diterapkan hanya oleh mesin IndexTTS2.",
+    "emotion_text": "Deskripsi emosi",
+    "emotion_text_ph": "mis. terdengar lelah dan sedih",
+    "emotion_alpha": "Kekuatan emosi"
   },
   "voicePanel": {
     "title": "Suara",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Aggiungi parola",
     "lex_remove": "Rimuovi",
     "markup_help": "Riferimento al markup",
-    "markup_hint": "# Titolo del capitolo · [voce:NOME] cambia voce · [pausa 500 ms] / [pausa 1 s] · [lento]…[/lento] · [veloce]…[/veloce] · [enfasi]…[/emphasis] · [incantesimo]…[/incantesimo] · Reazioni (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Titolo del capitolo · [voice:NAME] cambia voce · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reazioni (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Lingua",
     "expressive": "Sovrapposizioni di produzione",
     "reset": "Ripristina",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Aggiungi parola",
     "lex_remove": "Rimuovi",
     "markup_help": "Riferimento al markup",
-    "markup_hint": "# Titolo del capitolo · [voce:NOME] cambia voce · [pausa 500 ms] / [pausa 1 s] · [lento]…[/lento] · [veloce]…[/veloce] · [enfasi]…[/emphasis] · [incantesimo]…[/incantesimo]"
+    "markup_hint": "# Titolo del capitolo · [voce:NOME] cambia voce · [pausa 500 ms] / [pausa 1 s] · [lento]…[/lento] · [veloce]…[/veloce] · [enfasi]…[/emphasis] · [incantesimo]…[/incantesimo] · Reazioni (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Lingua",
+    "expressive": "Sovrapposizioni di produzione",
+    "reset": "Ripristina",
+    "seed": "Seme",
+    "seed_ph": "Auto",
+    "vary_repeats": "Varare le linee ripetute",
+    "vary_repeats_help": "Fornisci riprese distinte alle linee identiche invece di riutilizzare una registrazione.",
+    "emotion_help": "Emozione graduata — applicata solo dal motore IndexTTS2.",
+    "emotion_text": "Descrizione dell'emozione",
+    "emotion_text_ph": "es. suona stanco e triste",
+    "emotion_alpha": "Forza emotiva"
   },
   "voicePanel": {
     "title": "Voce",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -2108,7 +2108,7 @@
     "lex_add": "単語を追加",
     "lex_remove": "削除",
     "markup_help": "マークアップリファレンス",
-    "markup_hint": "# 章タイトル · [voice:NAME] 音声切り替え · [500ms 一時停止] / [1 秒一時停止] · [遅い]…[/遅い] · [速い]…[/速い] · [強調]…[/強調] · [呪文]…[/呪文] · リアクション (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# 章タイトル · [voice:NAME] 音声切り替え · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · リアクション (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "言語",
     "expressive": "プロダクションオーバーライド",
     "reset": "リセット",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -2108,7 +2108,18 @@
     "lex_add": "単語を追加",
     "lex_remove": "削除",
     "markup_help": "マークアップリファレンス",
-    "markup_hint": "# 章タイトル · [voice:NAME] 音声切り替え · [500ms 一時停止] / [1 秒一時停止] · [遅い]…[/遅い] · [速い]…[/速い] · [強調]…[/強調] · [呪文]…[/呪文]"
+    "markup_hint": "# 章タイトル · [voice:NAME] 音声切り替え · [500ms 一時停止] / [1 秒一時停止] · [遅い]…[/遅い] · [速い]…[/速い] · [強調]…[/強調] · [呪文]…[/呪文] · リアクション (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "言語",
+    "expressive": "プロダクションオーバーライド",
+    "reset": "リセット",
+    "seed": "シード",
+    "seed_ph": "自動",
+    "vary_repeats": "繰り返される行を変更",
+    "vary_repeats_help": "1つの録音を再利用する代わりに、同一の行に異なるテイクを与えます。",
+    "emotion_help": "段階的な感情 — IndexTTS2 エンジンによってのみ適用されます。",
+    "emotion_text": "感情の説明",
+    "emotion_text_ph": "例 疲れているように聞こえ、悲しい",
+    "emotion_alpha": "感情の強さ"
   },
   "voicePanel": {
     "title": "声",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -2108,7 +2108,7 @@
     "lex_add": "단어 추가",
     "lex_remove": "제거",
     "markup_help": "마크업 참조",
-    "markup_hint": "# 장 제목 · [음성:이름] 음성 전환 · [500ms 일시 정지] / [1초 일시 정지] · [느리게]…[/slow] · [빠르게]…[/fast] · [강조]…[/emphasis] · [주문]…[/spell] · 반응 (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# 장 제목 · [voice:NAME] 음성 전환 · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · 반응 (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "언어",
     "expressive": "제작 무시",
     "reset": "재설정",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -2108,7 +2108,18 @@
     "lex_add": "단어 추가",
     "lex_remove": "제거",
     "markup_help": "마크업 참조",
-    "markup_hint": "# 장 제목 · [음성:이름] 음성 전환 · [500ms 일시 정지] / [1초 일시 정지] · [느리게]…[/slow] · [빠르게]…[/fast] · [강조]…[/emphasis] · [주문]…[/spell]"
+    "markup_hint": "# 장 제목 · [음성:이름] 음성 전환 · [500ms 일시 정지] / [1초 일시 정지] · [느리게]…[/slow] · [빠르게]…[/fast] · [강조]…[/emphasis] · [주문]…[/spell] · 반응 (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "언어",
+    "expressive": "제작 무시",
+    "reset": "재설정",
+    "seed": "시드",
+    "seed_ph": "자동",
+    "vary_repeats": "반복된 라인 변경",
+    "vary_repeats_help": "하나의 녹음을 재사용하는 대신 동일한 라인에 서로 다른 테이크를 제공합니다.",
+    "emotion_help": "단계별 감정 — IndexTTS2 엔진에서만 적용됩니다.",
+    "emotion_text": "감정 설명",
+    "emotion_text_ph": "예: 지쳐 보이고 슬픈 소리",
+    "emotion_alpha": "감정의 강도"
   },
   "voicePanel": {
     "title": "음성",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Woord toevoegen",
     "lex_remove": "Verwijderen",
     "markup_help": "Opmaakreferentie",
-    "markup_hint": "# Hoofdstuktitel · [stem:NAAM] wisselstem · [pauze 500 ms] / [pauze 1s] · [langzaam]…[/langzaam] · [snel]…[/snel] · [nadruk]…[/nadruk] · [spell]…[/spell] · Reacties (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Hoofdstuktitel · [voice:NAME] wisselstem · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reacties (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Taal",
     "expressive": "Productie-overrides",
     "reset": "Opnieuw instellen",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Woord toevoegen",
     "lex_remove": "Verwijderen",
     "markup_help": "Opmaakreferentie",
-    "markup_hint": "# Hoofdstuktitel · [stem:NAAM] wisselstem · [pauze 500 ms] / [pauze 1s] · [langzaam]…[/langzaam] · [snel]…[/snel] · [nadruk]…[/nadruk] · [spell]…[/spell]"
+    "markup_hint": "# Hoofdstuktitel · [stem:NAAM] wisselstem · [pauze 500 ms] / [pauze 1s] · [langzaam]…[/langzaam] · [snel]…[/snel] · [nadruk]…[/nadruk] · [spell]…[/spell] · Reacties (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Taal",
+    "expressive": "Productie-overrides",
+    "reset": "Opnieuw instellen",
+    "seed": "Zaad",
+    "seed_ph": "Automatisch",
+    "vary_repeats": "Herhaal regels variëren",
+    "vary_repeats_help": "Geef identieke regels verschillende takes in plaats van één opname opnieuw te gebruiken.",
+    "emotion_help": "Gegradueerde emotie — alleen toegepast door de IndexTTS2-engine.",
+    "emotion_text": "Emotie beschrijving",
+    "emotion_text_ph": "bijv. klinkt uitgeput en verdrietig",
+    "emotion_alpha": "Emotie sterkte"
   },
   "voicePanel": {
     "title": "Stem",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Dodaj słowo",
     "lex_remove": "Usuń",
     "markup_help": "Odniesienie do znaczników",
-    "markup_hint": "# Tytuł rozdziału · [voice:NAME] zmień głos · [pauza 500 ms] / [pauza 1 s] · [wolno]…[/wolno] · [szybko]…[/szybko] · [podkreślenie]…[/emfaza] · [zaklęcie]…[/spell] · Reakcje (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Tytuł rozdziału · [voice:NAME] zmień głos · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reakcje (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Język",
     "expressive": "Zastępstwa produkcyjne",
     "reset": "Resetuj",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Dodaj słowo",
     "lex_remove": "Usuń",
     "markup_help": "Odniesienie do znaczników",
-    "markup_hint": "# Tytuł rozdziału · [voice:NAME] zmień głos · [pauza 500 ms] / [pauza 1 s] · [wolno]…[/wolno] · [szybko]…[/szybko] · [podkreślenie]…[/emfaza] · [zaklęcie]…[/spell]"
+    "markup_hint": "# Tytuł rozdziału · [voice:NAME] zmień głos · [pauza 500 ms] / [pauza 1 s] · [wolno]…[/wolno] · [szybko]…[/szybko] · [podkreślenie]…[/emfaza] · [zaklęcie]…[/spell] · Reakcje (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Język",
+    "expressive": "Zastępstwa produkcyjne",
+    "reset": "Resetuj",
+    "seed": "Ziarno",
+    "seed_ph": "Auto",
+    "vary_repeats": "Zmienić powtarzające się wiersze",
+    "vary_repeats_help": "Podaj odrębne ujęcia do identycznych wierszy zamiast ponownie używać jednego nagrania.",
+    "emotion_help": "Stopniowana emocja — zastosowana tylko przez silnik IndexTTS2.",
+    "emotion_text": "Opis emocji",
+    "emotion_text_ph": "np. brzmi wyczerpany i smutny",
+    "emotion_alpha": "Siła emocji"
   },
   "voicePanel": {
     "title": "Głos",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Adicionar palavra",
     "lex_remove": "Remover",
     "markup_help": "Referência de marcação",
-    "markup_hint": "# Título do capítulo · [voz:NOME] mudar voz · [pausa 500ms] / [pausa 1s] · [lento]…[/lento] · [rápido]…[/rápido] · [ênfase]…[/emphasis] · [feitiço]…[/spell] · Reações (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Título do capítulo · [voice:NAME] mudar voz · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reações (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Idioma",
     "expressive": "Substituições de produção",
     "reset": "Repor",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Adicionar palavra",
     "lex_remove": "Remover",
     "markup_help": "Referência de marcação",
-    "markup_hint": "# Título do capítulo · [voz:NOME] mudar voz · [pausa 500ms] / [pausa 1s] · [lento]…[/lento] · [rápido]…[/rápido] · [ênfase]…[/emphasis] · [feitiço]…[/spell]"
+    "markup_hint": "# Título do capítulo · [voz:NOME] mudar voz · [pausa 500ms] / [pausa 1s] · [lento]…[/lento] · [rápido]…[/rápido] · [ênfase]…[/emphasis] · [feitiço]…[/spell] · Reações (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Idioma",
+    "expressive": "Substituições de produção",
+    "reset": "Repor",
+    "seed": "Semente",
+    "seed_ph": "Automático",
+    "vary_repeats": "Variar linhas repetidas",
+    "vary_repeats_help": "Dê takes distintos a linhas idênticas em vez de reutilizar uma gravação.",
+    "emotion_help": "Emoção graduada — aplicada apenas pelo mecanismo IndexTTS2.",
+    "emotion_text": "Descrição da emoção",
+    "emotion_text_ph": "ex.: soa exausto e triste",
+    "emotion_alpha": "Força emocional"
   },
   "voicePanel": {
     "title": "Voz",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Добавить слово",
     "lex_remove": "Удалять",
     "markup_help": "Справочник по разметке",
-    "markup_hint": "# Название главы · [voice:NAME] переключить голос · [пауза 500 мс] / [пауза 1 с] · [медленно]…[/slow] · [быстро]…[/fast] · [акцент]…[/emphasis] · [spell]…[/spell] · Реакции (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Название главы · [voice:NAME] переключить голос · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Реакции (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Язык",
     "expressive": "Переопределения продакшена",
     "reset": "Сброс",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Добавить слово",
     "lex_remove": "Удалять",
     "markup_help": "Справочник по разметке",
-    "markup_hint": "# Название главы · [voice:NAME] переключить голос · [пауза 500 мс] / [пауза 1 с] · [медленно]…[/slow] · [быстро]…[/fast] · [акцент]…[/emphasis] · [spell]…[/spell]"
+    "markup_hint": "# Название главы · [voice:NAME] переключить голос · [пауза 500 мс] / [пауза 1 с] · [медленно]…[/slow] · [быстро]…[/fast] · [акцент]…[/emphasis] · [spell]…[/spell] · Реакции (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Язык",
+    "expressive": "Переопределения продакшена",
+    "reset": "Сброс",
+    "seed": "Семя",
+    "seed_ph": "Авто",
+    "vary_repeats": "Варьировать повторяющиеся строки",
+    "vary_repeats_help": "Предоставьте отдельные версии идентичным строкам вместо повторного использования одной записи.",
+    "emotion_help": "Градуированная эмоция — применяется только механизмом IndexTTS2.",
+    "emotion_text": "Описание эмоции",
+    "emotion_text_ph": "напр. звучит истощено и грустно",
+    "emotion_alpha": "Интенсивность эмоции"
   },
   "voicePanel": {
     "title": "Голос",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Lägg till ord",
     "lex_remove": "Ta bort",
     "markup_help": "Markeringsreferens",
-    "markup_hint": "# Kapiteltitel · [röst:NAMN] byt röst · [paus 500ms] / [paus 1s] · [långsam]…[/långsam] · [snabb]…[/snabb] · [betoning]...[/betoning] · [stavning]...[/stavning]"
+    "markup_hint": "# Kapiteltitel · [röst:NAMN] byt röst · [paus 500ms] / [paus 1s] · [långsam]…[/långsam] · [snabb]…[/snabb] · [betoning]...[/betoning] · [stavning]...[/stavning] · Reaktioner (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Språk",
+    "expressive": "Produktionsåsidosättanden",
+    "reset": "Återställ",
+    "seed": "Frö",
+    "seed_ph": "Auto",
+    "vary_repeats": "Variera upprepade rader",
+    "vary_repeats_help": "Ge identiska rader distinkta tagningar i stället för att återanvända en inspelning.",
+    "emotion_help": "Graderad emotion — endast tillämpas av IndexTTS2-motorn.",
+    "emotion_text": "Emotionsbeskrivning",
+    "emotion_text_ph": "t.ex. låter uttömd och ledsen",
+    "emotion_alpha": "Emotionsstyrka"
   },
   "voicePanel": {
     "title": "Röst",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Lägg till ord",
     "lex_remove": "Ta bort",
     "markup_help": "Markeringsreferens",
-    "markup_hint": "# Kapiteltitel · [röst:NAMN] byt röst · [paus 500ms] / [paus 1s] · [långsam]…[/långsam] · [snabb]…[/snabb] · [betoning]...[/betoning] · [stavning]...[/stavning] · Reaktioner (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Kapiteltitel · [voice:NAME] byt röst · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Reaktioner (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Språk",
     "expressive": "Produktionsåsidosättanden",
     "reset": "Återställ",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -2108,7 +2108,7 @@
     "lex_add": "เพิ่มคำ",
     "lex_remove": "ลบ",
     "markup_help": "การอ้างอิงมาร์กอัป",
-    "markup_hint": "# ชื่อบท · [เสียง:NAME] สลับเสียง · [หยุดชั่วคราว 500ms] / [หยุดชั่วคราว 1 วินาที] · [ช้า]…[/ช้า] · [เร็ว]…[/เร็ว] · [เน้น]…[/เน้น] · [สะกด]…[/สะกด] · ปฏิกิริยา (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# ชื่อบท · [voice:NAME] สลับเสียง · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · ปฏิกิริยา (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "ภาษา",
     "expressive": "การแทนที่การผลิต",
     "reset": "ตั้งค่าใหม่",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -2108,7 +2108,18 @@
     "lex_add": "เพิ่มคำ",
     "lex_remove": "ลบ",
     "markup_help": "การอ้างอิงมาร์กอัป",
-    "markup_hint": "# ชื่อบท · [เสียง:NAME] สลับเสียง · [หยุดชั่วคราว 500ms] / [หยุดชั่วคราว 1 วินาที] · [ช้า]…[/ช้า] · [เร็ว]…[/เร็ว] · [เน้น]…[/เน้น] · [สะกด]…[/สะกด]"
+    "markup_hint": "# ชื่อบท · [เสียง:NAME] สลับเสียง · [หยุดชั่วคราว 500ms] / [หยุดชั่วคราว 1 วินาที] · [ช้า]…[/ช้า] · [เร็ว]…[/เร็ว] · [เน้น]…[/เน้น] · [สะกด]…[/สะกด] · ปฏิกิริยา (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "ภาษา",
+    "expressive": "การแทนที่การผลิต",
+    "reset": "ตั้งค่าใหม่",
+    "seed": "เมล็ด",
+    "seed_ph": "อัตโนมัติ",
+    "vary_repeats": "เปลี่ยนแปลงบรรทัดที่ซ้ำ",
+    "vary_repeats_help": "ให้บทบาทที่แตกต่างกันสำหรับบรรทัดที่เหมือนกันแทนการใช้การบันทึกซ้ำ",
+    "emotion_help": "อารมณ์แบบระดับ — ใช้งานเฉพาะกับเครื่องยนต์ IndexTTS2 เท่านั้น",
+    "emotion_text": "คำอธิบายอารมณ์",
+    "emotion_text_ph": "เช่น ฟังดูเหนื่อยและเศร้า",
+    "emotion_alpha": "ความเข้มของอารมณ์"
   },
   "voicePanel": {
     "title": "เสียง",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Kelime ekle",
     "lex_remove": "Kaldır",
     "markup_help": "İşaretleme referansı",
-    "markup_hint": "# Bölüm başlığı · [ses:NAME] sesi değiştir · [500 ms duraklat] / [1 saniye duraklat] · [yavaş]…[/yavaş] · [hızlı]…[/hızlı] · [vurgu]…[/vurgu] · [büyü]…[/büyü]"
+    "markup_hint": "# Bölüm başlığı · [ses:NAME] sesi değiştir · [500 ms duraklat] / [1 saniye duraklat] · [yavaş]…[/yavaş] · [hızlı]…[/hızlı] · [vurgu]…[/vurgu] · [büyü]…[/büyü] · Tepkiler (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Dil",
+    "expressive": "Prodüksiyon geçersiz kılmalar",
+    "reset": "Sıfırla",
+    "seed": "Tohum",
+    "seed_ph": "Otomatik",
+    "vary_repeats": "Tekrarlanan satırları değiştirin",
+    "vary_repeats_help": "Özdeş satırlara bir kaydı yeniden kullanmak yerine farklı çekişler verin.",
+    "emotion_help": "Dereceli duygu — yalnızca IndexTTS2 motoru tarafından uygulanır.",
+    "emotion_text": "Duygu açıklaması",
+    "emotion_text_ph": "örn. tükenmiş ve üzgün geliyor",
+    "emotion_alpha": "Duygu gücü"
   },
   "voicePanel": {
     "title": "Ses",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Kelime ekle",
     "lex_remove": "Kaldır",
     "markup_help": "İşaretleme referansı",
-    "markup_hint": "# Bölüm başlığı · [ses:NAME] sesi değiştir · [500 ms duraklat] / [1 saniye duraklat] · [yavaş]…[/yavaş] · [hızlı]…[/hızlı] · [vurgu]…[/vurgu] · [büyü]…[/büyü] · Tepkiler (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Bölüm başlığı · [voice:NAME] sesi değiştir · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Tepkiler (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Dil",
     "expressive": "Prodüksiyon geçersiz kılmalar",
     "reset": "Sıfırla",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Додайте слово",
     "lex_remove": "видалити",
     "markup_help": "Посилання на розмітку",
-    "markup_hint": "# Назва розділу · [голос:ІМ’Я] змінити голос · [пауза 500 мс] / [пауза 1 с] · [повільно]…[/slow] · [швидко]…[/швидко] · [наголос]…[/наголос] · [заклинання]…[/spell]"
+    "markup_hint": "# Назва розділу · [голос:ІМ’Я] змінити голос · [пауза 500 мс] / [пауза 1 с] · [повільно]…[/slow] · [швидко]…[/швидко] · [наголос]…[/наголос] · [заклинання]…[/spell] · Реакції (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Мова",
+    "expressive": "Перевизначення продакшену",
+    "reset": "Скинути",
+    "seed": "Насіння",
+    "seed_ph": "Авто",
+    "vary_repeats": "Варіювати повторювані рядки",
+    "vary_repeats_help": "Надайте окремі версії однаковим рядкам замість повторного використання однієї записи.",
+    "emotion_help": "Градуйована емоція — застосовується тільки механізмом IndexTTS2.",
+    "emotion_text": "Опис емоції",
+    "emotion_text_ph": "напр. звучить виснажено і сумно",
+    "emotion_alpha": "Інтенсивність емоції"
   },
   "voicePanel": {
     "title": "Голос",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Додайте слово",
     "lex_remove": "видалити",
     "markup_help": "Посилання на розмітку",
-    "markup_hint": "# Назва розділу · [голос:ІМ’Я] змінити голос · [пауза 500 мс] / [пауза 1 с] · [повільно]…[/slow] · [швидко]…[/швидко] · [наголос]…[/наголос] · [заклинання]…[/spell] · Реакції (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Назва розділу · [voice:NAME] змінити голос · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Реакції (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Мова",
     "expressive": "Перевизначення продакшену",
     "reset": "Скинути",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -2108,7 +2108,18 @@
     "lex_add": "Thêm từ",
     "lex_remove": "Xóa",
     "markup_help": "Tham chiếu đánh dấu",
-    "markup_hint": "# Tiêu đề chương · [giọng nói:TÊN] chuyển giọng nói · [tạm dừng 500ms] / [tạm dừng 1 giây] · [chậm]…[/chậm] · [nhanh]…[/nhanh] · [nhấn mạnh]…[/nhấn mạnh] · [chính tả]…[/spell]"
+    "markup_hint": "# Tiêu đề chương · [giọng nói:TÊN] chuyển giọng nói · [tạm dừng 500ms] / [tạm dừng 1 giây] · [chậm]…[/chậm] · [nhanh]…[/nhanh] · [nhấn mạnh]…[/nhấn mạnh] · [chính tả]…[/spell] · Phản ứng (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "Ngôn ngữ",
+    "expressive": "Ghi đè sản xuất",
+    "reset": "Đặt lại",
+    "seed": "Hạt",
+    "seed_ph": "Tự động",
+    "vary_repeats": "Thay đổi dòng lặp lại",
+    "vary_repeats_help": "Cung cấp các bản ghi khác nhau cho các dòng giống nhau thay vì sử dụng lại một bản ghi.",
+    "emotion_help": "Cảm xúc dần dần — chỉ được áp dụng bởi công cụ IndexTTS2.",
+    "emotion_text": "Mô tả cảm xúc",
+    "emotion_text_ph": "ví dụ: nghe vẻ mệt mỏi và buồn",
+    "emotion_alpha": "Độ mạnh của cảm xúc"
   },
   "voicePanel": {
     "title": "Giọng nói",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -2108,7 +2108,7 @@
     "lex_add": "Thêm từ",
     "lex_remove": "Xóa",
     "markup_help": "Tham chiếu đánh dấu",
-    "markup_hint": "# Tiêu đề chương · [giọng nói:TÊN] chuyển giọng nói · [tạm dừng 500ms] / [tạm dừng 1 giây] · [chậm]…[/chậm] · [nhanh]…[/nhanh] · [nhấn mạnh]…[/nhấn mạnh] · [chính tả]…[/spell] · Phản ứng (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# Tiêu đề chương · [voice:NAME] chuyển giọng nói · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · Phản ứng (OmniVoice): [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "Ngôn ngữ",
     "expressive": "Ghi đè sản xuất",
     "reset": "Đặt lại",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -2115,7 +2115,7 @@
     "lex_add": "添加单词",
     "lex_remove": "删除",
     "markup_help": "标记参考",
-    "markup_hint": "# 章节标题 · [语音:NAME] 切换语音 · [暂停 500 毫秒] / [暂停 1 秒] · [慢]…[/慢] · [快]…[/快] · [强调]…[/强调] · [拼写]…[/拼写] · 反应（OmniVoice）： [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# 章节标题 · [voice:NAME] 切换语音 · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · 反应（OmniVoice）： [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]: [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "语言",
     "expressive": "制作覆盖",
     "reset": "重置",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -2115,7 +2115,18 @@
     "lex_add": "添加单词",
     "lex_remove": "删除",
     "markup_help": "标记参考",
-    "markup_hint": "# 章节标题 · [语音:NAME] 切换语音 · [暂停 500 毫秒] / [暂停 1 秒] · [慢]…[/慢] · [快]…[/快] · [强调]…[/强调] · [拼写]…[/拼写]"
+    "markup_hint": "# 章节标题 · [语音:NAME] 切换语音 · [暂停 500 毫秒] / [暂停 1 秒] · [慢]…[/慢] · [快]…[/快] · [强调]…[/强调] · [拼写]…[/拼写] · 反应（OmniVoice）： [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "语言",
+    "expressive": "制作覆盖",
+    "reset": "重置",
+    "seed": "种子",
+    "seed_ph": "自动",
+    "vary_repeats": "改变重复的行",
+    "vary_repeats_help": "为相同的行提供不同的 take，而不是重复使用一条录音。",
+    "emotion_help": "分层情感 — 仅由 IndexTTS2 引擎应用。",
+    "emotion_text": "情感描述",
+    "emotion_text_ph": "例如 听起来很疲劳和悲伤",
+    "emotion_alpha": "情感强度"
   },
   "voicePanel": {
     "title": "语音",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -2108,7 +2108,18 @@
     "lex_add": "添加單字",
     "lex_remove": "刪除",
     "markup_help": "標記參考",
-    "markup_hint": "# 章節標題 · [語音:NAME] 切換語音 · [暫停 500 毫秒] / [暫停 1 秒] · [慢]…[/慢] · [快]…[/快] · [強調]…[/強調] · [拼字]…[/拼字]"
+    "markup_hint": "# 章節標題 · [語音:NAME] 切換語音 · [暫停 500 毫秒] / [暫停 1 秒] · [慢]…[/慢] · [快]…[/快] · [強調]…[/強調] · [拼字]…[/拼字] · 反應 (OmniVoice)： [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "language": "語言",
+    "expressive": "製作覆蓋",
+    "reset": "重置",
+    "seed": "種子",
+    "seed_ph": "自動",
+    "vary_repeats": "改變重複的行",
+    "vary_repeats_help": "為相同的行提供不同的 take，而不是重複使用一條錄音。",
+    "emotion_help": "分層情感 — 僅由 IndexTTS2 引擎應用。",
+    "emotion_text": "情感描述",
+    "emotion_text_ph": "例如 聽起來很疲勞和悲傷",
+    "emotion_alpha": "情感強度"
   },
   "voicePanel": {
     "title": "語音",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -2108,7 +2108,7 @@
     "lex_add": "添加單字",
     "lex_remove": "刪除",
     "markup_help": "標記參考",
-    "markup_hint": "# 章節標題 · [語音:NAME] 切換語音 · [暫停 500 毫秒] / [暫停 1 秒] · [慢]…[/慢] · [快]…[/快] · [強調]…[/強調] · [拼字]…[/拼字] · 反應 (OmniVoice)： [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
+    "markup_hint": "# 章節標題 · [voice:NAME] 切換語音 · [pause 500ms] / [pause 1s] · [slow]…[/slow] · [fast]…[/fast] · [emphasis]…[/emphasis] · [spell]…[/spell] · 反應 (OmniVoice)： [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]: [laughter] [sigh] [confirmation-en] [question-en] [question-ah] [question-oh] [question-ei] [question-yi] [surprise-ah] [surprise-oh] [surprise-wa] [surprise-yo] [dissatisfaction-hnn]",
     "language": "語言",
     "expressive": "製作覆蓋",
     "reset": "重置",

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -19,9 +19,14 @@ import {
   audiobookImport,
 } from '../api/audiobook';
 import { audioUrl } from '../api/generate';
+import { listEngines } from '../api/engines';
 import { consumeLongformStream } from '../utils/longformStream';
 import { useAppStore } from '../store';
 import VoiceSelector from '../components/VoiceSelector';
+import SearchableSelect from '../components/SearchableSelect';
+import AudiobookOverrides, { overridesToRequest } from '../components/audiobook/AudiobookOverrides';
+import ALL_LANGUAGES from '../languages.json';
+import { POPULAR_LANGS } from '../utils/constants';
 import { Button } from '../ui';
 import { buttonVariants } from '@/components/ui/button.tsx';
 
@@ -50,6 +55,29 @@ export default function AudiobookTab({ profiles = [] }) {
   const setLexiconStore = useAppStore((s) => s.setLexicon);
   const storeLexicon = useAppStore((s) => s.lexicon);
   const setDefaultVoice = (v) => setOutputPrefs({ defaultVoice: v || null });
+  // Language pick + expressive overrides (#1210) — store-backed so a book's
+  // tuning survives a tab switch / reload (same persistence as the lexicon).
+  const language = useAppStore((s) => s.language) ?? 'Auto';
+  const setLanguage = (v) => setOutputPrefs({ language: v || 'Auto' });
+  const overrides = useAppStore((s) => s.overrides);
+  const setLongformOverrides = useAppStore((s) => s.setLongformOverrides);
+  // Show emotion controls only when the active engine understands them
+  // (IndexTTS2). Fetched once on mount; degrades to hidden if the probe fails.
+  const [emotionSupported, setEmotionSupported] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    listEngines()
+      .then((r) => {
+        if (!alive) return;
+        const active = r?.tts?.active;
+        const b = (r?.tts?.backends || []).find((x) => x.id === active);
+        setEmotionSupported(!!b?.supports_emotion);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
   const [plan, setPlan] = useState(null);
   const [planLoading, setPlanLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
@@ -178,6 +206,9 @@ export default function AudiobookTab({ profiles = [] }) {
           chapter_index: i,
           default_voice: defaultVoice || null,
           lexicon: Object.keys(lexicon).length ? lexicon : null,
+          // Same expressive fields as the full render so a preview warms the
+          // exact cache slot the render reuses (preview/render parity, #1210).
+          ...overridesToRequest(overrides, language),
         });
         setChapterPrev((p) => ({ ...p, [i]: { url: audioUrl(r.output), loading: false } }));
       } catch (e) {
@@ -185,7 +216,7 @@ export default function AudiobookTab({ profiles = [] }) {
         setError(e?.message || String(e));
       }
     },
-    [text, defaultVoice, lex],
+    [text, defaultVoice, lex, overrides, language],
   );
 
   const onCreate = useCallback(async () => {
@@ -211,6 +242,10 @@ export default function AudiobookTab({ profiles = [] }) {
         cover_path,
         metadata: Object.keys(metadata).length ? metadata : null,
         lexicon: Object.keys(lexicon).length ? lexicon : null,
+        // language pick + expressive/quality overrides + cache opt-out (#1210).
+        // Only non-default values are emitted, so an untouched panel keeps the
+        // request byte-identical to before.
+        ...overridesToRequest(overrides, language),
       });
       await consumeLongformStream(
         res,
@@ -240,7 +275,7 @@ export default function AudiobookTab({ profiles = [] }) {
     } finally {
       setGenerating(false);
     }
-  }, [text, defaultVoice, format, loudness, coverFile, meta, lex]);
+  }, [text, defaultVoice, format, loudness, coverFile, meta, lex, overrides, language]);
 
   const busy = planLoading || generating || importing;
   const canRun = text.trim().length > 0 && !busy;
@@ -314,6 +349,24 @@ export default function AudiobookTab({ profiles = [] }) {
               defaultLabel={t('audiobook.engine_default')}
             />
           </div>
+
+          <div className="audiobook-tab__field flex flex-col gap-[4px]">
+            <label className={FIELD_LABEL}>{t('audiobook.language')}</label>
+            <SearchableSelect
+              value={language}
+              options={ALL_LANGUAGES}
+              popular={POPULAR_LANGS}
+              recentsKey="omnivoice.recents.audiobookLang"
+              onChange={setLanguage}
+            />
+          </div>
+
+          <AudiobookOverrides
+            t={t}
+            overrides={overrides}
+            onChange={setLongformOverrides}
+            emotionSupported={emotionSupported}
+          />
 
           <div className="audiobook-tab__duo grid grid-cols-[1fr_1fr] gap-[8px]">
             <div className="audiobook-tab__field flex flex-col gap-[4px]">

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -55,7 +55,7 @@ export default function AudiobookTab({ profiles = [] }) {
   const setLexiconStore = useAppStore((s) => s.setLexicon);
   const storeLexicon = useAppStore((s) => s.lexicon);
   const setDefaultVoice = (v) => setOutputPrefs({ defaultVoice: v || null });
-  // Language pick + expressive overrides (#1210) — store-backed so a book's
+  // Language pick + expressive overrides (#1208) — store-backed so a book's
   // tuning survives a tab switch / reload (same persistence as the lexicon).
   const language = useAppStore((s) => s.language) ?? 'Auto';
   const setLanguage = (v) => setOutputPrefs({ language: v || 'Auto' });
@@ -207,7 +207,7 @@ export default function AudiobookTab({ profiles = [] }) {
           default_voice: defaultVoice || null,
           lexicon: Object.keys(lexicon).length ? lexicon : null,
           // Same expressive fields as the full render so a preview warms the
-          // exact cache slot the render reuses (preview/render parity, #1210).
+          // exact cache slot the render reuses (preview/render parity, #1208).
           ...overridesToRequest(overrides, language),
         });
         setChapterPrev((p) => ({ ...p, [i]: { url: audioUrl(r.output), loading: false } }));
@@ -242,7 +242,7 @@ export default function AudiobookTab({ profiles = [] }) {
         cover_path,
         metadata: Object.keys(metadata).length ? metadata : null,
         lexicon: Object.keys(lexicon).length ? lexicon : null,
-        // language pick + expressive/quality overrides + cache opt-out (#1210).
+        // language pick + expressive/quality overrides + cache opt-out (#1208).
         // Only non-default values are emitted, so an untouched panel keeps the
         // request byte-identical to before.
         ...overridesToRequest(overrides, language),

--- a/frontend/src/store/longformSlice.ts
+++ b/frontend/src/store/longformSlice.ts
@@ -48,6 +48,36 @@ export interface LongformMeta {
   description?: string;
 }
 
+/** Expressive/quality overrides for a longform render (#1210). Every field is
+ *  null/''/false by default — an untouched panel reproduces today's exact
+ *  render on the backend (num_step 32, guidance 2.0, model-default temps,
+ *  postprocess on, no emotion, content-addressed caching). Only non-null values
+ *  are sent, so the request stays backward-compatible. `emoText`/`emoAlpha`
+ *  reach IndexTTS2 only; `varyRepeats` is the cache opt-out. */
+export interface LongformOverrides {
+  numStep: number | null;
+  guidanceScale: number | null;
+  posTemp: number | null;
+  classTemp: number | null;
+  postprocess: boolean | null;
+  seed: number | null;
+  varyRepeats: boolean;
+  emoText: string;
+  emoAlpha: number | null;
+}
+
+export const DEFAULT_OVERRIDES: LongformOverrides = {
+  numStep: null,
+  guidanceScale: null,
+  posTemp: null,
+  classTemp: null,
+  postprocess: null,
+  seed: null,
+  varyRepeats: false,
+  emoText: '',
+  emoAlpha: null,
+};
+
 /** A re-uploadable cover reference. localStorage can't hold the File/blob, so
  *  we persist the picked filename + the server path from POST /audiobook/cover.
  *  serverPath is best-effort (the server may GC the temp cover); a re-picked
@@ -73,6 +103,8 @@ interface LongformProject {
   outputFormat: 'm4b' | 'mp3';
   loudness: 'off' | 'acx' | 'podcast';
   defaultVoice: string | null;
+  language: string;
+  overrides: LongformOverrides;
   updatedAt: number;
 }
 
@@ -90,6 +122,13 @@ export interface LongformSlice {
   outputFormat: 'm4b' | 'mp3';
   loudness: 'off' | 'acx' | 'podcast';
   defaultVoice: string | null;
+  // Longform render language (#1210 / #505): 'Auto' → the profile's language,
+  // else an explicit pick that reaches the backend (fixes the AudiobookGenerate
+  // body that used to omit `language` entirely).
+  language: string;
+  // Expressive/quality overrides + cache opt-out (#1210). Persisted like the
+  // lexicon so a book's tuning survives a tab switch / reload.
+  overrides: LongformOverrides;
   // Last finished render's server filename (#1139): the Audiobook tab's
   // player + Download link used to live in component useState, so a finished
   // book's export affordance evaporated on the first tab switch and users
@@ -114,7 +153,9 @@ export interface LongformSlice {
     outputFormat?: 'm4b' | 'mp3';
     loudness?: 'off' | 'acx' | 'podcast';
     defaultVoice?: string | null;
+    language?: string;
   }) => void; // merge (I2)
+  setLongformOverrides: (patch: Partial<LongformOverrides>) => void; // merge
   setCoverRef: (ref: CoverRef | null) => void;
   setLastOutput: (output: string) => void;
   convertMode: (mode: LongformMode) => void; // flips mode only (#24 seam)
@@ -140,6 +181,8 @@ export const SLICE_DEFAULTS = {
   outputFormat: 'm4b' as 'm4b' | 'mp3',
   loudness: 'off' as 'off' | 'acx' | 'podcast',
   defaultVoice: null as string | null,
+  language: 'Auto' as string,
+  overrides: DEFAULT_OVERRIDES as LongformOverrides,
   lastOutput: '' as string,
   projectMode: 'stories' as LongformMode,
 } as const;
@@ -171,6 +214,7 @@ export const createLongformSlice: StateCreator<LongformSlice, [], [], LongformSl
   ...SLICE_DEFAULTS,
   meta: { ...SLICE_DEFAULTS.meta },
   lexicon: { ...SLICE_DEFAULTS.lexicon },
+  overrides: { ...SLICE_DEFAULTS.overrides },
 
   setStoryTracks: (storyTracks) => set({ storyTracks }),
   setCast: (cast) => set({ cast }),
@@ -195,7 +239,9 @@ export const createLongformSlice: StateCreator<LongformSlice, [], [], LongformSl
       outputFormat: patch.outputFormat ?? s.outputFormat,
       loudness: patch.loudness ?? s.loudness,
       defaultVoice: patch.defaultVoice !== undefined ? patch.defaultVoice : s.defaultVoice,
+      language: patch.language ?? s.language,
     })),
+  setLongformOverrides: (patch) => set((s) => ({ overrides: { ...s.overrides, ...patch } })),
   setCoverRef: (coverRef) => set({ coverRef: coverRef ? { ...coverRef } : null }),
   setLastOutput: (lastOutput) => set({ lastOutput }),
   convertMode: (mode) => {
@@ -227,6 +273,8 @@ export const createLongformSlice: StateCreator<LongformSlice, [], [], LongformSl
         outputFormat: s.outputFormat,
         loudness: s.loudness,
         defaultVoice: s.defaultVoice,
+        language: s.language,
+        overrides: { ...s.overrides },
         updatedAt: ts,
       };
       const exists = s.storyProjects.some((p) => p.id === id);
@@ -251,6 +299,8 @@ export const createLongformSlice: StateCreator<LongformSlice, [], [], LongformSl
       outputFormat: p.outputFormat ?? SLICE_DEFAULTS.outputFormat,
       loudness: p.loudness ?? SLICE_DEFAULTS.loudness,
       defaultVoice: p.defaultVoice ?? SLICE_DEFAULTS.defaultVoice,
+      language: p.language ?? SLICE_DEFAULTS.language,
+      overrides: { ...SLICE_DEFAULTS.overrides, ...p.overrides },
       // A render belongs to the project it was made in — loading another
       // project must not present A's finished file as B's output (#1139).
       lastOutput: SLICE_DEFAULTS.lastOutput,
@@ -266,6 +316,7 @@ export const createLongformSlice: StateCreator<LongformSlice, [], [], LongformSl
       ...SLICE_DEFAULTS,
       meta: { ...SLICE_DEFAULTS.meta },
       lexicon: { ...SLICE_DEFAULTS.lexicon },
+      overrides: { ...SLICE_DEFAULTS.overrides },
       projectMode: mode === 'audiobook' ? 'audiobook' : 'stories',
       currentProjectId: null,
     }),

--- a/frontend/src/store/longformSlice.ts
+++ b/frontend/src/store/longformSlice.ts
@@ -48,7 +48,7 @@ export interface LongformMeta {
   description?: string;
 }
 
-/** Expressive/quality overrides for a longform render (#1210). Every field is
+/** Expressive/quality overrides for a longform render (#1208). Every field is
  *  null/''/false by default — an untouched panel reproduces today's exact
  *  render on the backend (num_step 32, guidance 2.0, model-default temps,
  *  postprocess on, no emotion, content-addressed caching). Only non-null values
@@ -122,11 +122,11 @@ export interface LongformSlice {
   outputFormat: 'm4b' | 'mp3';
   loudness: 'off' | 'acx' | 'podcast';
   defaultVoice: string | null;
-  // Longform render language (#1210 / #505): 'Auto' → the profile's language,
+  // Longform render language (#1208 / #505): 'Auto' → the profile's language,
   // else an explicit pick that reaches the backend (fixes the AudiobookGenerate
   // body that used to omit `language` entirely).
   language: string;
-  // Expressive/quality overrides + cache opt-out (#1210). Persisted like the
+  // Expressive/quality overrides + cache opt-out (#1208). Persisted like the
   // lexicon so a book's tuning survives a tab switch / reload.
   overrides: LongformOverrides;
   // Last finished render's server filename (#1139): the Audiobook tab's

--- a/frontend/src/test/audiobookOverrides.test.jsx
+++ b/frontend/src/test/audiobookOverrides.test.jsx
@@ -1,0 +1,124 @@
+// Audiobook Expressive Maturity — frontend surface (#1210).
+//
+// Covers the four things a WebUI regression would silently break: the markup
+// reference lists the reaction tags; the overrides panel renders + labels its
+// controls and persists edits; the request-body mapping only emits touched
+// values (so an untouched panel stays byte-identical) and carries the language
+// + emotion fields; and the emotion block is engine-conditional (no dead
+// controls). Logic-level like ssmlLite.test.js, plus a light RTL render.
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+
+import en from '../i18n/locales/en.json';
+import { DEFAULT_OVERRIDES } from '../store/longformSlice';
+import AudiobookOverrides, { overridesToRequest } from '../components/audiobook/AudiobookOverrides';
+
+const withI18n = (node) => <I18nextProvider i18n={i18n}>{node}</I18nextProvider>;
+
+describe('audiobook markup reference lists the reaction tags (#1210 D1)', () => {
+  it('markup_hint advertises the OmniVoice reaction tags', () => {
+    const hint = en.audiobook.markup_hint;
+    for (const tag of ['[laughter]', '[sigh]', '[question-en]', '[dissatisfaction-hnn]']) {
+      expect(hint).toContain(tag);
+    }
+  });
+});
+
+describe('overridesToRequest — only touched values reach the wire (#1210 D2/D3/D5)', () => {
+  it('an untouched panel + Auto language emits an empty body (today, byte-identical)', () => {
+    expect(overridesToRequest(DEFAULT_OVERRIDES, 'Auto')).toEqual({});
+  });
+
+  it('language is sent when a non-Auto pick is made (fixes the D5 omission)', () => {
+    expect(overridesToRequest(DEFAULT_OVERRIDES, 'Spanish')).toEqual({ language: 'Spanish' });
+    expect(overridesToRequest(DEFAULT_OVERRIDES, 'Auto').language).toBeUndefined();
+  });
+
+  it('maps sampling knobs to snake_case, omitting nulls', () => {
+    const body = overridesToRequest(
+      {
+        ...DEFAULT_OVERRIDES,
+        numStep: 40,
+        guidanceScale: 3,
+        posTemp: 1.5,
+        classTemp: 0.4,
+        postprocess: false,
+        seed: 7,
+      },
+      'Auto',
+    );
+    expect(body).toEqual({
+      num_step: 40,
+      guidance_scale: 3,
+      position_temperature: 1.5,
+      class_temperature: 0.4,
+      postprocess_output: false,
+      seed: 7,
+    });
+  });
+
+  it('vary_repeats is only present when on', () => {
+    expect(overridesToRequest({ ...DEFAULT_OVERRIDES, varyRepeats: true }, 'Auto')).toEqual({
+      vary_repeats: true,
+    });
+    expect('vary_repeats' in overridesToRequest(DEFAULT_OVERRIDES, 'Auto')).toBe(false);
+  });
+
+  it('emotion text + alpha map through; empty emotion text drops both', () => {
+    expect(
+      overridesToRequest({ ...DEFAULT_OVERRIDES, emoText: 'sad', emoAlpha: 0.5 }, 'Auto'),
+    ).toEqual({ emo_text: 'sad', emo_alpha: 0.5 });
+    // Alpha alone (no description) sends nothing — the description is the anchor.
+    expect(overridesToRequest({ ...DEFAULT_OVERRIDES, emoAlpha: 0.5 }, 'Auto')).toEqual({});
+  });
+});
+
+describe('AudiobookOverrides panel — renders, labels, persists (#1210 D2)', () => {
+  const open = (props = {}) => {
+    const onChange = vi.fn();
+    render(
+      withI18n(
+        <AudiobookOverrides
+          t={i18n.t.bind(i18n)}
+          overrides={DEFAULT_OVERRIDES}
+          onChange={onChange}
+          {...props}
+        />,
+      ),
+    );
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(en.audiobook.expressive, 'i') }));
+    return onChange;
+  };
+
+  it('exposes the labelled sampling controls and persists an edit', () => {
+    const onChange = open();
+    // Labelled sliders (reused clone.* labels) are present.
+    expect(screen.getByLabelText(en.clone.steps)).toBeTruthy();
+    expect(screen.getByLabelText(en.clone.pos_temp)).toBeTruthy();
+    const steps = screen.getByLabelText(en.clone.steps);
+    fireEvent.change(steps, { target: { value: '48' } });
+    expect(onChange).toHaveBeenCalledWith({ numStep: 48 });
+  });
+
+  it('persists the cache opt-out toggle', () => {
+    const onChange = open();
+    fireEvent.click(screen.getByLabelText(en.audiobook.vary_repeats, { exact: false }));
+    expect(onChange).toHaveBeenCalledWith({ varyRepeats: true });
+  });
+
+  it('hides emotion controls unless the active engine supports them', () => {
+    open({ emotionSupported: false });
+    expect(screen.queryByLabelText(en.audiobook.emotion_text)).toBeNull();
+  });
+
+  it('shows emotion controls when the engine supports them', () => {
+    const onChange = open({ emotionSupported: true });
+    const emo = screen.getByLabelText(en.audiobook.emotion_text);
+    expect(emo).toBeTruthy();
+    fireEvent.change(emo, { target: { value: 'weary' } });
+    expect(onChange).toHaveBeenCalledWith({ emoText: 'weary' });
+  });
+});

--- a/frontend/src/test/audiobookOverrides.test.jsx
+++ b/frontend/src/test/audiobookOverrides.test.jsx
@@ -1,4 +1,4 @@
-// Audiobook Expressive Maturity — frontend surface (#1210).
+// Audiobook Expressive Maturity — frontend surface (#1208).
 //
 // Covers the four things a WebUI regression would silently break: the markup
 // reference lists the reaction tags; the overrides panel renders + labels its
@@ -18,7 +18,7 @@ import AudiobookOverrides, { overridesToRequest } from '../components/audiobook/
 
 const withI18n = (node) => <I18nextProvider i18n={i18n}>{node}</I18nextProvider>;
 
-describe('audiobook markup reference lists the reaction tags (#1210 D1)', () => {
+describe('audiobook markup reference lists the reaction tags (#1208 D1)', () => {
   it('markup_hint advertises the OmniVoice reaction tags', () => {
     const hint = en.audiobook.markup_hint;
     for (const tag of ['[laughter]', '[sigh]', '[question-en]', '[dissatisfaction-hnn]']) {
@@ -27,7 +27,7 @@ describe('audiobook markup reference lists the reaction tags (#1210 D1)', () => 
   });
 });
 
-describe('overridesToRequest — only touched values reach the wire (#1210 D2/D3/D5)', () => {
+describe('overridesToRequest — only touched values reach the wire (#1208 D2/D3/D5)', () => {
   it('an untouched panel + Auto language emits an empty body (today, byte-identical)', () => {
     expect(overridesToRequest(DEFAULT_OVERRIDES, 'Auto')).toEqual({});
   });
@@ -76,7 +76,7 @@ describe('overridesToRequest — only touched values reach the wire (#1210 D2/D3
   });
 });
 
-describe('AudiobookOverrides panel — renders, labels, persists (#1210 D2)', () => {
+describe('AudiobookOverrides panel — renders, labels, persists (#1208 D2)', () => {
   const open = (props = {}) => {
     const onChange = vi.fn();
     render(

--- a/tests/backend/services/test_tts_backend_registry.py
+++ b/tests/backend/services/test_tts_backend_registry.py
@@ -162,6 +162,9 @@ def test_list_backends_shape(registry_sandbox):
         # Cloning capability: bool from the class attr, None when
         # model-dependent (a property, e.g. mlx-audio).
         "supports_cloning",
+        # Graded-emotion capability (#1210): bool from the class attr; drives
+        # the Audiobook expressive panel's emotion gate.
+        "supports_emotion",
         # True when services.sidecar_install can provision the engine in-app
         # (the Settings Install button keys off this).
         "one_click_install",
@@ -174,6 +177,8 @@ def test_list_backends_shape(registry_sandbox):
             f"missing {expected - entry.keys()}, "
             f"extra {entry.keys() - expected}"
         )
+        # #1210: supports_emotion is always a concrete bool (never a descriptor).
+        assert isinstance(entry["supports_emotion"], bool)
 
 
 def test_mlx_audio_curated_models_roster(registry_sandbox):

--- a/tests/backend/services/test_tts_backend_registry.py
+++ b/tests/backend/services/test_tts_backend_registry.py
@@ -162,7 +162,7 @@ def test_list_backends_shape(registry_sandbox):
         # Cloning capability: bool from the class attr, None when
         # model-dependent (a property, e.g. mlx-audio).
         "supports_cloning",
-        # Graded-emotion capability (#1210): bool from the class attr; drives
+        # Graded-emotion capability (#1208): bool from the class attr; drives
         # the Audiobook expressive panel's emotion gate.
         "supports_emotion",
         # True when services.sidecar_install can provision the engine in-app
@@ -177,7 +177,7 @@ def test_list_backends_shape(registry_sandbox):
             f"missing {expected - entry.keys()}, "
             f"extra {entry.keys() - expected}"
         )
-        # #1210: supports_emotion is always a concrete bool (never a descriptor).
+        # #1208: supports_emotion is always a concrete bool (never a descriptor).
         assert isinstance(entry["supports_emotion"], bool)
 
 

--- a/tests/test_audiobook_expressive.py
+++ b/tests/test_audiobook_expressive.py
@@ -135,6 +135,35 @@ def test_preview_and_render_derive_identical_opts_and_keys(tmp_path):
     assert _render_key(tmp_path, render_opts) == _render_key(tmp_path, preview_opts)
 
 
+# ── input bounds: a loopback POST can't feed the sampler abuse values ────────
+
+def test_expressive_knobs_reject_out_of_range_values():
+    """CodeRabbit #1208: the expressive knobs are a loopback POST body (reachable
+    by a browser-tab CSRF), so an absurd num_step could pin a GPU-pool worker.
+    Each knob must be bounds-checked at the model boundary."""
+    import pytest
+    from pydantic import ValidationError
+
+    from api.routers.audiobook import AudiobookRequest
+
+    base = dict(text="# A\nhello")
+    for bad in (
+        dict(num_step=100_000),      # would tie up a worker
+        dict(num_step=0),            # non-positive step count
+        dict(guidance_scale=-1.0),
+        dict(position_temperature=1e9),
+        dict(class_temperature=-0.5),
+        dict(emo_alpha=2.0),         # alpha is a 0..1 blend
+        dict(emo_vector=[0.1, 0.2]),  # must be the 8-emotion vector
+    ):
+        with pytest.raises(ValidationError):
+            AudiobookRequest(**base, **bad)
+
+    # In-range values still construct fine (defaults/None unaffected).
+    AudiobookRequest(**base, num_step=32, guidance_scale=2.0, emo_alpha=0.6,
+                     emo_vector=[0.0] * 8)
+
+
 # ── backward compat: default request → today's exact synth args ─────────────
 
 def _record_manual_seed(monkeypatch):

--- a/tests/test_audiobook_expressive.py
+++ b/tests/test_audiobook_expressive.py
@@ -1,0 +1,325 @@
+"""Audiobook Expressive Maturity (#1210).
+
+Covers the v0.3.23 headline: Production Overrides + IndexTTS2 graded emotion +
+the cache opt-out threaded through the shared longform render, plus the
+CRITICAL cache-signature guard (every new knob must perturb every cache key, or
+changing it silently replays stale audio).
+
+Engine + model boundary stubbed throughout — no model loads, no GPU, no ffmpeg.
+"""
+import dataclasses
+import os
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+import torch
+
+from services.audiobook import Chapter, ExpressiveOptions, Span, segment_seed
+
+
+_RESOLVE = lambda _vid: {  # noqa: E731
+    "ref_audio": None, "ref_text": None, "instruct": None, "seed": None,
+}
+_ALL_FIELDS = {
+    "num_step": 40,
+    "guidance_scale": 3.5,
+    "position_temperature": 1.0,
+    "class_temperature": 0.5,
+    "postprocess_output": False,
+    "seed": 7,
+    "emo_vector": (0.1, 0.2, 0, 0, 0, 0, 0, 0.7),
+    "emo_text": "sounds exhausted",
+    "emo_alpha": 0.4,
+    "vary_repeats": True,
+}
+
+
+# ── ExpressiveOptions.cache_signature: the CRITICAL TRAP guard ───────────────
+
+def test_default_options_have_empty_signature():
+    # A default render must be byte-identical to pre-#1210: no signature, so no
+    # perturbation of any cache key.
+    assert ExpressiveOptions().is_default
+    assert ExpressiveOptions().cache_signature() == ""
+
+
+def test_every_expressive_field_perturbs_the_cache_signature_distinctly():
+    """Loop over EVERY knob: each one, set alone, must change the signature —
+    and produce a signature distinct from every other knob's. A future field
+    added to the dataclass but forgotten in cache_signature() fails here."""
+    base = ExpressiveOptions()
+    seen = {base.cache_signature()}  # {""}
+    for field, value in _ALL_FIELDS.items():
+        opts = dataclasses.replace(base, **{field: value})
+        sig = opts.cache_signature()
+        assert sig, f"{field} did not produce a signature"
+        assert sig not in seen, f"{field} collided with another field's signature"
+        seen.add(sig)
+    # Every declared field was exercised (guards against a field added to the
+    # dataclass without a matching entry in _ALL_FIELDS / cache_signature).
+    assert {f.name for f in dataclasses.fields(base)} == set(_ALL_FIELDS)
+
+
+# ── segment_seed nonce (cache opt-out determinism) ──────────────────────────
+
+def test_segment_seed_nonce_zero_is_backward_compatible():
+    # nonce defaulting to 0 must reproduce the pre-#1210 value exactly.
+    assert segment_seed(1234, "hi") == segment_seed(1234, "hi", 0)
+
+
+def test_segment_seed_nonce_decorrelates_repeats():
+    a = segment_seed(1234, "hi", 0)
+    b = segment_seed(1234, "hi", 1)
+    c = segment_seed(1234, "hi", 2)
+    assert len({a, b, c}) == 3
+    assert all(0 <= s < 2**31 for s in (a, b, c))
+
+
+# ── Chapter cache key absorbs every knob (integration) ──────────────────────
+
+def _render_key(tmp_path, opts):
+    """Render a one-span chapter with a stub synth; return the cache WAV path
+    (its basename is the content-addressed chapter key)."""
+    from api.routers.audiobook import _render_chapter_cached
+
+    ch = Chapter(title="C", spans=[Span(voice_id=None, text="hello", pause_ms_after=0)])
+    synth = lambda text, vid, speed=None: torch.zeros(2400)  # noqa: E731
+    wav_path, *_ = _render_chapter_cached(
+        ch, synth, 24000, "eng", _RESOLVE, str(tmp_path), None, None, opts,
+    )
+    return os.path.basename(wav_path)
+
+
+def test_chapter_cache_key_changes_for_every_expressive_field(tmp_path):
+    """The end-to-end guard: two renders that differ only in one expressive knob
+    must land in different cache slots (else the second silently replays the
+    first). Default vs each single-field opts must all be distinct keys."""
+    base_key = _render_key(tmp_path, ExpressiveOptions())
+    keys = {base_key}
+    for field, value in _ALL_FIELDS.items():
+        opts = dataclasses.replace(ExpressiveOptions(), **{field: value})
+        k = _render_key(tmp_path, opts)
+        assert k not in keys, f"{field} did not change the chapter cache key"
+        keys.add(k)
+
+
+def test_default_opts_render_key_matches_no_opts(tmp_path):
+    # Passing an explicit default ExpressiveOptions() must be byte-identical to
+    # passing None (both == today's key) — backward compat for existing caches.
+    from api.routers.audiobook import _render_chapter_cached
+
+    ch = Chapter(title="C", spans=[Span(voice_id=None, text="hello", pause_ms_after=0)])
+    synth = lambda text, vid, speed=None: torch.zeros(2400)  # noqa: E731
+    a, *_ = _render_chapter_cached(ch, synth, 24000, "eng", _RESOLVE, str(tmp_path), None, None, None)
+    b, *_ = _render_chapter_cached(
+        ch, synth, 24000, "eng", _RESOLVE, str(tmp_path), None, None, ExpressiveOptions(),
+    )
+    assert os.path.basename(a) == os.path.basename(b)
+
+
+# ── preview / render parity ──────────────────────────────────────────────────
+
+def test_preview_and_render_derive_identical_opts_and_keys(tmp_path):
+    from api.routers.audiobook import (
+        AudiobookPreviewRequest, AudiobookRequest, _expressive_opts,
+    )
+
+    fields = dict(num_step=40, guidance_scale=3.0, position_temperature=1.0,
+                  emo_text="sad", vary_repeats=True)
+    render_opts = _expressive_opts(AudiobookRequest(text="# A\nhello", **fields))
+    preview_opts = _expressive_opts(AudiobookPreviewRequest(text="# A\nhello", **fields))
+    assert render_opts == preview_opts  # same knobs → same typed options
+    # …and therefore the same chapter cache slot (preview warms exactly what the
+    # full render reuses).
+    assert _render_key(tmp_path, render_opts) == _render_key(tmp_path, preview_opts)
+
+
+# ── backward compat: default request → today's exact synth args ─────────────
+
+def _record_manual_seed(monkeypatch):
+    seeds = []
+    real = torch.manual_seed
+    monkeypatch.setattr(torch, "manual_seed", lambda s: (seeds.append(s), real(s))[1])
+    return seeds
+
+
+def test_omnivoice_default_opts_reproduce_todays_synth_args(monkeypatch):
+    import asyncio
+
+    import api.routers.audiobook as ab
+    import services.model_manager as mm
+    import services.tts_backend as tb
+
+    gen_calls = []
+
+    class _FakeModel:
+        sampling_rate = 24000
+
+        def generate(self, **kw):
+            gen_calls.append(kw)
+            return [torch.zeros(1, 2400)]
+
+    async def fake_get_model():
+        return _FakeModel()
+
+    monkeypatch.setattr(tb, "active_backend_id", lambda: "omnivoice")
+    monkeypatch.setattr(mm, "get_model", fake_get_model)
+    monkeypatch.setattr(ab, "_resolve_voice", lambda _vid: {
+        "ref_audio": None, "ref_text": None, "instruct": None, "seed": None,
+    })
+
+    synth, *_ = asyncio.run(ab._prepare_synth("p", opts=ExpressiveOptions()))
+    synth("hello", None)
+
+    kw = gen_calls[0]
+    assert kw["num_step"] == 32 and kw["guidance_scale"] == 2.0
+    # No temperature / postprocess kwargs on the default path — the model keeps
+    # its own defaults, exactly as before #1210.
+    for k in ("position_temperature", "class_temperature", "postprocess_output",
+              "emo_vector", "emo_text"):
+        assert k not in kw
+
+
+def test_omnivoice_overrides_reach_model_but_emotion_never_does(monkeypatch):
+    import asyncio
+
+    import api.routers.audiobook as ab
+    import services.model_manager as mm
+    import services.tts_backend as tb
+
+    gen_calls = []
+
+    class _FakeModel:
+        sampling_rate = 24000
+
+        def generate(self, **kw):
+            gen_calls.append(kw)
+            return [torch.zeros(1, 2400)]
+
+    async def fake_get_model():
+        return _FakeModel()
+
+    monkeypatch.setattr(tb, "active_backend_id", lambda: "omnivoice")
+    monkeypatch.setattr(mm, "get_model", fake_get_model)
+    monkeypatch.setattr(ab, "_resolve_voice", lambda _vid: {
+        "ref_audio": None, "ref_text": None, "instruct": None, "seed": None,
+    })
+
+    opts = ExpressiveOptions(num_step=48, guidance_scale=3.0,
+                             position_temperature=2.0, class_temperature=0.6,
+                             postprocess_output=False, emo_text="sad",
+                             emo_vector=(0.5,) * 8)
+    synth, *_ = asyncio.run(ab._prepare_synth("p", opts=opts))
+    synth("hello", None)
+
+    kw = gen_calls[0]
+    assert kw["num_step"] == 48 and kw["guidance_scale"] == 3.0
+    assert kw["position_temperature"] == 2.0 and kw["class_temperature"] == 0.6
+    assert kw["postprocess_output"] is False
+    # The OmniVoice config rejects unknown kwargs — emotion must NEVER be
+    # forwarded to it (it belongs only on the generic/IndexTTS2 path).
+    assert "emo_vector" not in kw and "emo_text" not in kw
+
+
+# ── generic engine: options-ignored contract + emotion reaches the engine ───
+
+def _fake_backend_cls(calls):
+    from services.tts_backend import TTSBackend
+
+    class _Fake(TTSBackend):
+        id = "fake-longform-engine"
+        display_name = "Fake Longform Engine (test)"
+        gpu_compat = ("cpu",)
+
+        @property
+        def sample_rate(self):
+            return 24000
+
+        @property
+        def supported_languages(self):
+            return ["multi"]
+
+        @classmethod
+        def is_available(cls):
+            return True, "ready"
+
+        def generate(self, text, **kw):
+            calls.append((text, kw))
+            return torch.zeros(1, 2400)
+
+    return _Fake
+
+
+def _patch_generic_engine(monkeypatch, calls):
+    import services.tts_backend as tb
+    fake = _fake_backend_cls(calls)
+    monkeypatch.setattr(tb, "active_backend_id", lambda: "fake-longform-engine")
+    monkeypatch.setattr(tb, "get_backend_class", lambda _id: fake)
+
+
+def test_generic_default_opts_pass_no_extra_kwargs(monkeypatch):
+    import api.routers.audiobook as ab
+
+    calls = []
+    _patch_generic_engine(monkeypatch, calls)
+    monkeypatch.setattr(ab, "_resolve_voice", lambda _vid: _RESOLVE(_vid))
+
+    ab._build_synth(None)["synth"]("hello", None)
+    _text, kw = calls[0]
+    for k in ("num_step", "guidance_scale", "position_temperature",
+              "class_temperature", "postprocess_output", "emo_vector", "emo_text"):
+        assert k not in kw  # byte-identical to the pre-#1210 generic call
+
+
+def test_generic_emotion_and_overrides_reach_a_naive_backend(monkeypatch):
+    """A backend whose generate(self, text, **kw) does not understand the new
+    options must receive them without raising (the engine-options contract),
+    and the IndexTTS2 emotion trio must arrive intact from the longform path."""
+    import api.routers.audiobook as ab
+
+    calls = []
+    _patch_generic_engine(monkeypatch, calls)
+    monkeypatch.setattr(ab, "_resolve_voice", lambda _vid: _RESOLVE(_vid))
+
+    opts = ExpressiveOptions(num_step=40, guidance_scale=3.0,
+                             emo_vector=(0.9, 0, 0, 0, 0, 0, 0, 0.1),
+                             emo_text="whispering", emo_alpha=0.5)
+    # Must not raise even though the fake backend ignores every new kwarg.
+    ab._build_synth(None, opts=opts)["synth"]("hello", None)
+
+    _text, kw = calls[0]
+    assert kw["num_step"] == 40 and kw["guidance_scale"] == 3.0
+    assert kw["emo_vector"] == [0.9, 0, 0, 0, 0, 0, 0, 0.1]
+    assert kw["emo_text"] == "whispering" and kw["use_emo_text"] is True
+    assert kw["emo_alpha"] == 0.5
+
+
+# ── cache opt-out (vary_repeats) behaviour ──────────────────────────────────
+
+def _count_synth_calls(tmp_path, opts):
+    from api.routers.audiobook import _render_chapter_cached
+
+    ch = Chapter(title="C", spans=[
+        Span(voice_id=None, text="same line", pause_ms_after=0),
+        Span(voice_id=None, text="same line", pause_ms_after=0),
+    ])
+    n = {"c": 0}
+
+    def synth(text, vid, speed=None):
+        n["c"] += 1
+        return torch.zeros(2400)
+
+    _render_chapter_cached(ch, synth, 24000, "eng", _RESOLVE, str(tmp_path), None, None, opts)
+    return n["c"]
+
+
+def test_repeated_line_is_deduped_by_default(tmp_path):
+    # Today's behaviour: the segment cache replays one WAV for identical spans,
+    # so the repeated line synthesizes exactly once.
+    assert _count_synth_calls(tmp_path, ExpressiveOptions()) == 1
+
+
+def test_vary_repeats_gives_each_repeat_its_own_take(tmp_path):
+    # Opt-out on: each occurrence gets a distinct cache slot → both synthesize.
+    assert _count_synth_calls(tmp_path, ExpressiveOptions(vary_repeats=True)) == 2

--- a/tests/test_audiobook_expressive.py
+++ b/tests/test_audiobook_expressive.py
@@ -1,4 +1,4 @@
-"""Audiobook Expressive Maturity (#1210).
+"""Audiobook Expressive Maturity (#1208).
 
 Covers the v0.3.23 headline: Production Overrides + IndexTTS2 graded emotion +
 the cache opt-out threaded through the shared longform render, plus the
@@ -38,7 +38,7 @@ _ALL_FIELDS = {
 # ── ExpressiveOptions.cache_signature: the CRITICAL TRAP guard ───────────────
 
 def test_default_options_have_empty_signature():
-    # A default render must be byte-identical to pre-#1210: no signature, so no
+    # A default render must be byte-identical to pre-#1208: no signature, so no
     # perturbation of any cache key.
     assert ExpressiveOptions().is_default
     assert ExpressiveOptions().cache_signature() == ""
@@ -64,7 +64,7 @@ def test_every_expressive_field_perturbs_the_cache_signature_distinctly():
 # ── segment_seed nonce (cache opt-out determinism) ──────────────────────────
 
 def test_segment_seed_nonce_zero_is_backward_compatible():
-    # nonce defaulting to 0 must reproduce the pre-#1210 value exactly.
+    # nonce defaulting to 0 must reproduce the pre-#1208 value exactly.
     assert segment_seed(1234, "hi") == segment_seed(1234, "hi", 0)
 
 
@@ -175,7 +175,7 @@ def test_omnivoice_default_opts_reproduce_todays_synth_args(monkeypatch):
     kw = gen_calls[0]
     assert kw["num_step"] == 32 and kw["guidance_scale"] == 2.0
     # No temperature / postprocess kwargs on the default path — the model keeps
-    # its own defaults, exactly as before #1210.
+    # its own defaults, exactly as before #1208.
     for k in ("position_temperature", "class_temperature", "postprocess_output",
               "emo_vector", "emo_text"):
         assert k not in kw
@@ -269,7 +269,7 @@ def test_generic_default_opts_pass_no_extra_kwargs(monkeypatch):
     _text, kw = calls[0]
     for k in ("num_step", "guidance_scale", "position_temperature",
               "class_temperature", "postprocess_output", "emo_vector", "emo_text"):
-        assert k not in kw  # byte-identical to the pre-#1210 generic call
+        assert k not in kw  # byte-identical to the pre-#1208 generic call
 
 
 def test_generic_emotion_and_overrides_reach_a_naive_backend(monkeypatch):

--- a/tests/test_longform_e2e.py
+++ b/tests/test_longform_e2e.py
@@ -39,7 +39,7 @@ def _resolve(_voice_id):
 def _stub_build_synth(*, fail_on=None):
     """Return a drop-in for `audiobook._build_synth` whose `synth` emits 0.1s of
     silence per span. `fail_on(text)` → raise, to exercise per-chapter faults."""
-    def _factory(default_voice=None, language=None):
+    def _factory(default_voice=None, language=None, opts=None):
         def synth(text, voice_id, speed=None):
             if fail_on is not None and fail_on(text):
                 raise RuntimeError("stub synth deliberately failed")

--- a/tests/test_synthetic_audio_watermark_1169.py
+++ b/tests/test_synthetic_audio_watermark_1169.py
@@ -349,7 +349,7 @@ def test_audiobook_preview_route_output_is_watermarked(tmp_path, monkeypatch, ma
     outdir.mkdir()
     monkeypatch.setattr(cfg, "OUTPUTS_DIR", str(outdir))
 
-    async def _fake_prepare(default_voice, language=None):
+    async def _fake_prepare(default_voice, language=None, opts=None):
         return _fake_synth, SR, _resolve, "eng"
 
     monkeypatch.setattr(ab, "_prepare_synth", _fake_prepare)


### PR DESCRIPTION
Audiobook renders were locked to the model's most deterministic preset (32 steps / 2.0 guidance / model-default temps) with no way to change it — which is why books sounded flatter than the same voice on the Voice page. This opens expressive control without changing any default byte-for-byte.

### Added
- **Production Overrides in the Audiobook tab** — `position_temperature`, `class_temperature`, `num_step`, `guidance_scale`, `postprocess_output` (+ seed), reusing the Voice page's panel. Unset reproduces today exactly.
- **IndexTTS2 graded emotion** (`emo_vector` / `emo_text` / `emo_alpha`) reaches the longform path via a typed engine-options object; engines that don't understand an option ignore it (verified across the ~14 backends — no crash).
- **Cache opt-out** ("vary repeated lines") so identical lines can get distinct takes; default off keeps the content-addressed replay.

### Fixed
- Reaction tags (`[laughter]`, `[sigh]`, …) that already work in audiobooks are now listed in the tab's Markup reference.
- `AudiobookGenerateBody` dropped `language`, so audiobook language selection never reached the backend — now wired.

### Docs
- `docs/expressive-speech.md` corrected so no recipe it names is unreachable in the Audiobook surface.

**Correctness:** every new param is folded into **both** cache layers (chapter + segment) and the per-chapter preview, so changing a knob re-renders instead of replaying stale audio — and an all-default request keeps its old cache key, so **existing books don't re-render**. Regression tests: `tests/test_audiobook_expressive.py` (backward-compat, cache-signature loop, preview/render parity, engine-ignores-unknown, cache opt-out, emotion-reaches-engine) + `audiobookOverrides.test.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds audiobook production overrides, language forwarding, IndexTTS2 emotion controls, repeat-line variation, and expressive-aware preview/render/resume caching while preserving default behavior and cache keys. Updates the Audiobook UI, persistence, API types, documentation, translations, and regression coverage. Human review should focus on cache invalidation/resume compatibility and backend-specific option propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->