### PR TITLE
fix(shell): root error boundary so an app-render throw can't blank the window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,21 @@ jobs:
         working-directory: frontend
         run: node --experimental-strip-types --no-warnings --test ../tests/frontend/*.test.mjs
 
+      # Production-bundle blank-screen gate. Everything above runs UN-minified
+      # (dev server + Vitest/jsdom), so a crash that exists ONLY in the minified
+      # release bundle — a TDZ reorder that throws before React mounts — passes
+      # every check and ships a black screen. That is how v0.3.22 went out (#1178),
+      # and it recurred pre-0.3.23. This builds the real dist/ and asserts the app
+      # actually mounts into #root. See frontend/e2e-prod/prod-bundle-smoke.spec.ts.
+      # (The in-app root <ErrorBoundary> in main-app.jsx catches such throws at
+      # runtime; this gate stops them reaching a release in the first place.)
+      - name: Install Playwright chromium
+        working-directory: frontend
+        run: bunx playwright install --with-deps chromium
+      - name: Production-bundle smoke — no blank screen
+        working-directory: frontend
+        run: bun run test:prod-bundle
+
   # ── Cross-platform Tauri shell check ────────────────────────────────────
   # Catches platform-specific Rust regressions on PR (cfg(target_os=...)
   # gates, missing Windows/macOS deps, etc.) without spending the 15+ min

--- a/frontend/e2e-prod/prod-bundle-smoke.spec.ts
+++ b/frontend/e2e-prod/prod-bundle-smoke.spec.ts
@@ -22,6 +22,12 @@ const IGNORABLE = [
   /ERR_CONNECTION_REFUSED/i,
   /__TAURI__/i, // not running inside the Tauri shell
   /favicon/i,
+  // The app opens ws://…/ws/events at startup. With no backend, the static
+  // preview server answers every path with the SPA's 200, so the WebSocket
+  // upgrade is refused ("Unexpected response code: 200"). That's the absent
+  // backend, not a render crash — the same class as the ERR_ entries above.
+  /WebSocket connection to .* failed/i,
+  /\/ws\//i,
 ];
 
 function isIgnorable(text: string): boolean {

--- a/frontend/src/main-app.jsx
+++ b/frontend/src/main-app.jsx
@@ -16,6 +16,7 @@ import './ui';
 // styles) consolidated in, so this one import pulls in the whole app's CSS.
 import './index.css';
 import App from './App.jsx';
+import ErrorBoundary from './components/ErrorBoundary';
 import RemoteAuthGate from './components/RemoteAuthGate';
 import { installConsoleCapture } from './utils/consoleBuffer.js';
 import { installGlobalErrorHandlers } from './utils/globalErrorHandlers.js';
@@ -59,45 +60,57 @@ export async function bootstrapApp() {
 
   createRoot(document.getElementById('root')).render(
     <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        {/* RemoteAuthGate is the TRUE outermost wrap so a remote device that
+      {/* Root error boundary — the missing layer between App's own render and
+          the shell's blank_guard (frontend/src-tauri/src/blank_guard.rs). App
+          and RemoteAuthGate render a large tree of hooks/store access BEFORE any
+          of App's per-tab <ErrorBoundary> wraps take effect; a throw up there
+          used to escape every boundary and leave #root empty (children === 0),
+          which the shell could only react to by reloading three times and then
+          painting a dead-end failure page (#1178-class blank window). Catching it
+          here turns "blank window, restart the app" into an in-app, recoverable
+          error card with Reload / Report — data untouched. The shell guard stays
+          as the last resort for the rarer case where even this can't render. */}
+      <ErrorBoundary name="app-root">
+        <QueryClientProvider client={queryClient}>
+          {/* RemoteAuthGate is the TRUE outermost wrap so a remote device that
             loads a bare URL (no ?pin=) during first-run setup states —
             setup-status check, SetupWizard, BootstrapSplash — still gets the
             PIN dialog instead of a silent 401. Loopback / QR users are
             unaffected (the gate only shows on an ov:auth-required event). */}
-        <RemoteAuthGate>
-          {isWidget ? (
-            <Suspense
-              fallback={
-                <div
-                  style={{
-                    position: 'fixed',
-                    inset: 0,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    background: 'rgba(18, 18, 22, 0.88)',
-                    backdropFilter: 'blur(24px) saturate(180%)',
-                    WebkitBackdropFilter: 'blur(24px) saturate(180%)',
-                    border: '1px solid rgba(255, 255, 255, 0.08)',
-                    borderRadius: '100px',
-                    color: 'rgba(255, 255, 255, 0.9)',
-                    fontFamily: '"Inter Variable", "Inter", -apple-system, sans-serif',
-                    fontSize: 13,
-                    userSelect: 'none',
-                  }}
-                >
-                  Loading dictation…
-                </div>
-              }
-            >
-              <CaptureWidget />
-            </Suspense>
-          ) : (
-            <App />
-          )}
-        </RemoteAuthGate>
-      </QueryClientProvider>
+          <RemoteAuthGate>
+            {isWidget ? (
+              <Suspense
+                fallback={
+                  <div
+                    style={{
+                      position: 'fixed',
+                      inset: 0,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      background: 'rgba(18, 18, 22, 0.88)',
+                      backdropFilter: 'blur(24px) saturate(180%)',
+                      WebkitBackdropFilter: 'blur(24px) saturate(180%)',
+                      border: '1px solid rgba(255, 255, 255, 0.08)',
+                      borderRadius: '100px',
+                      color: 'rgba(255, 255, 255, 0.9)',
+                      fontFamily: '"Inter Variable", "Inter", -apple-system, sans-serif',
+                      fontSize: 13,
+                      userSelect: 'none',
+                    }}
+                  >
+                    Loading dictation…
+                  </div>
+                }
+              >
+                <CaptureWidget />
+              </Suspense>
+            ) : (
+              <App />
+            )}
+          </RemoteAuthGate>
+        </QueryClientProvider>
+      </ErrorBoundary>
     </StrictMode>,
   );
 }

--- a/frontend/src/main-app.test.jsx
+++ b/frontend/src/main-app.test.jsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+// The whole point of this test: a throw in the top-level app tree (App itself,
+// or anything RemoteAuthGate/the providers render) must NOT blank #root. Before
+// the root <ErrorBoundary> in main-app.jsx, such a throw escaped every one of
+// App's per-tab boundaries and left #root with zero children — the exact
+// `#root children = 0` the shell's blank_guard logged before painting its
+// dead-end failure page (#1178-class white screen). We simulate that by making
+// the App module throw on render, then assert the window is a recoverable error
+// card, not an empty shell.
+vi.mock('./App.jsx', () => ({
+  default: function BoomApp() {
+    throw new Error('simulated top-level render crash');
+  },
+}));
+
+// detectIsWidget() awaits a dynamic import of the Tauri window API; in jsdom
+// that import never settles and would hang bootstrapApp(). Stub it to a plain
+// main window so the mount path is deterministic and fast.
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ label: 'main' }),
+}));
+
+// RemoteAuthGate is real (we want the true mount chain), but it must render its
+// children straight through in the default no-auth case; nothing to mock.
+
+describe('bootstrapApp root error boundary', () => {
+  beforeEach(() => {
+    // A thrown render logs loudly via React; silence it so the suite output
+    // stays readable (the throw is the point of the test, not a failure).
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    document.getElementById('root')?.remove();
+    vi.restoreAllMocks();
+  });
+
+  // Generous timeout: this test is the only one that imports the full app entry
+  // module (main-app.jsx), so it pays the one-time cold-transform cost of the
+  // whole ui/i18n/client import graph before it can run.
+  it('renders a recoverable error card instead of blanking #root when the app tree throws', async () => {
+    const { bootstrapApp } = await import('./main-app.jsx');
+    await bootstrapApp();
+
+    const root = document.getElementById('root');
+    await waitFor(() => {
+      // The invariant the blank_guard probe checks: #root must have mounted
+      // content. 0 children is the blank window this fix exists to prevent.
+      expect(root.childElementCount).toBeGreaterThan(0);
+    });
+
+    // And it must be the actual recovery UI showing the real error, not just
+    // any stray node — so the user has a way forward without restarting the app.
+    expect(root.textContent).toMatch(/simulated top-level render crash/);
+  }, 20000);
+});


### PR DESCRIPTION
A user hit the shell's dead-end failure page ("#root children = 0 after 3 reloads"). Root cause: the mount chain `StrictMode → QueryClientProvider → RemoteAuthGate → App` had **no error boundary above App**. App's per-tab `<ErrorBoundary>` wraps only cover their own subtrees, so a throw in App's own render escaped every boundary and blanked `#root`; the shell's `blank_guard` could then only reload 3× and paint the failure page.

Verified the clean production bundle mounts fine (built `dist/`, ran the real browser smoke — passes), so this was a state/transient throw in dev, not a universal break.

### Fixed
- Wrap the mount root in `<ErrorBoundary name="app-root">` — an app-render throw now shows the recoverable in-app error card (Reload / Report, data untouched) instead of a blank window. The shell guard stays as the last resort.

### CI
- Wire the existing production-bundle smoke (`e2e-prod/prod-bundle-smoke.spec.ts`) into CI. Everything else runs un-minified (dev + jsdom), so a pre-mount crash that only bites the **minified** bundle (the #1178 class) shipped invisibly. Now the real `dist/` is built and asserted to mount. Fixed its `IGNORABLE` list (no-backend WebSocket handshake was a harness artifact).

Regression test `main-app.test.jsx`: fail-before (throw → `#root` empty) / pass-after (throw → recovery card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Wrapped the shell mount root in an `app-root` error boundary and added regression coverage so top-level render failures display recovery actions instead of a blank window. Added a CI production-bundle smoke test and updated its handling of expected no-backend WebSocket errors. Human review should verify the expanded WebSocket ignore patterns cannot conceal genuine startup or rendering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->