### PR TITLE
fix(clone): AudioTrimmer preview plays the selected region on VBR clips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Voice-clone trimmer: the preview now plays exactly the selected region on variable-bitrate clips (it had drifted off on VBR/mis-reported-duration files by playing the original file on a different timeline) (#1210)
 - A backend that fails to start now says why — exit code and error output, with actionable hints and a one-click report — instead of the evidence-free "Can't reach the local OmniVoice backend" (#1177)
 - Generation no longer crawls on CPU after a cancelled or failed dub: the TTS model is moved back to the GPU on every exit path, and each generation now verifies its own placement (#1191)
 - A generation queued behind a busy one no longer spends its timeout waiting: the budget starts when a GPU worker picks the job up, so a queued request can't be failed as "too heavy for the available compute" without having run (#1190)

--- a/frontend/src/components/AudioTrimmer.jsx
+++ b/frontend/src/components/AudioTrimmer.jsx
@@ -13,6 +13,7 @@ import {
   zoomCenter,
   sliceToMono,
   selectionPlayhead,
+  loopWindow,
   decodeToMonoLowRate,
   DEFAULT_PEAK_BUCKETS,
 } from '../utils/audioTrim.js';
@@ -573,17 +574,19 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
       }
       if (ctx.state === 'suspended') ctx.resume().catch(() => {});
       const { start: s, end: e } = stateRef.current;
-      const seg = Math.max(0.01, e - s);
+      // loopWindow floors a zero-width/inverted selection so the loop range can
+      // never collapse and fall back to looping the whole buffer (#1210).
+      const { loopStart, loopEnd, seg } = loopWindow(s, e, buffer.duration);
       const src = ctx.createBufferSource();
       src.buffer = buffer;
       src.connect(ctx.destination);
       if (loopRef.current) {
         src.loop = true;
-        src.loopStart = s;
-        src.loopEnd = e;
-        src.start(0, s);
+        src.loopStart = loopStart;
+        src.loopEnd = loopEnd;
+        src.start(0, loopStart);
       } else {
-        src.start(0, s, seg);
+        src.start(0, loopStart, seg);
         src.onended = () => {
           if (sourceRef.current === src) stopPlayback();
         };

--- a/frontend/src/components/AudioTrimmer.jsx
+++ b/frontend/src/components/AudioTrimmer.jsx
@@ -12,6 +12,7 @@ import {
   zoomAtCursor,
   zoomCenter,
   sliceToMono,
+  selectionPlayhead,
   decodeToMonoLowRate,
   DEFAULT_PEAK_BUCKETS,
 } from '../utils/audioTrim.js';
@@ -38,7 +39,11 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
   const { t } = useTranslation();
   const waveRef = useRef(null);
   const rulerRef = useRef(null);
-  const audioRef = useRef(null);
+  const audioCtxRef = useRef(null);
+  const sourceRef = useRef(null);
+  const playClockRef = useRef(null);
+  const playRafRef = useRef(0);
+  const loopRef = useRef(true);
   const containerRef = useRef(null);
   const bufferRef = useRef(null);
   const peaksRef = useRef(null);
@@ -125,26 +130,11 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
     };
   }, [file, maxSeconds]);
 
-  // Bind audio src
+  // Keep the latest loop preference readable from the rAF playhead loop and the
+  // live-bounds effect without re-subscribing them.
   useEffect(() => {
-    if (!file) return;
-    const url = URL.createObjectURL(file);
-    const a = audioRef.current;
-    if (a) {
-      a.src = url;
-      a.load();
-    }
-    return () => {
-      if (a) {
-        try {
-          a.pause();
-          a.removeAttribute('src');
-          a.load();
-        } catch {}
-      }
-      URL.revokeObjectURL(url);
-    };
-  }, [file]);
+    loopRef.current = loop;
+  }, [loop]);
 
   const sizeCanvas = useCallback((canvas) => {
     if (!canvas) return null;
@@ -452,12 +442,6 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
       setStart(t);
       setEnd(t);
       setCursor(t);
-      const a = audioRef.current;
-      if (a) {
-        try {
-          a.currentTime = t;
-        } catch {}
-      }
       dragStateRef.current = { mode: 'new', anchorT: t };
     }
     pointerRef.current = { clientX: e.clientX };
@@ -530,83 +514,114 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
     setViewEnd(nve);
   };
 
+  // Preview plays the SAME decoded buffer the waveform is drawn from and the
+  // confirmed clip is sliced from — never the original file on a second media
+  // element. Seeking a media element treats the selection's buffer-seconds as
+  // container-seconds, which drift apart for VBR / mis-reported-duration files
+  // (#1210): the preview then plays a different region than the one selected
+  // and exported. One buffer, one timeline, guarantees they match.
+  const stopPlayback = useCallback(() => {
+    if (playRafRef.current) {
+      cancelAnimationFrame(playRafRef.current);
+      playRafRef.current = 0;
+    }
+    const src = sourceRef.current;
+    sourceRef.current = null;
+    playClockRef.current = null;
+    if (src) {
+      try {
+        src.onended = null;
+        src.stop();
+      } catch {}
+    }
+    setPlaying(false);
+  }, []);
+
+  const startPlayhead = useCallback(() => {
+    const tick = () => {
+      const ctx = audioCtxRef.current;
+      const clock = playClockRef.current;
+      if (!ctx || !clock || !sourceRef.current) {
+        playRafRef.current = 0;
+        return;
+      }
+      const { start: s, end: e } = stateRef.current;
+      const elapsed = ctx.currentTime - clock.t0;
+      setCursor(selectionPlayhead(s, e, elapsed, loopRef.current));
+      if (!loopRef.current && elapsed >= Math.max(1e-6, e - s)) {
+        stopPlayback();
+        return;
+      }
+      playRafRef.current = requestAnimationFrame(tick);
+    };
+    if (!playRafRef.current) playRafRef.current = requestAnimationFrame(tick);
+  }, [stopPlayback]);
+
   const togglePlay = () => {
-    const a = audioRef.current;
-    if (!a) return;
+    const buffer = bufferRef.current;
+    if (!buffer) return;
     if (playing) {
-      a.pause();
-      setPlaying(false);
+      stopPlayback();
       return;
     }
-    const s = stateRef.current.start;
-    const doPlay = () => {
-      try {
-        a.currentTime = s;
-      } catch (err) {
-        console.warn('currentTime set failed', err);
+    try {
+      let ctx = audioCtxRef.current;
+      if (!ctx) {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        ctx = new Ctx();
+        audioCtxRef.current = ctx;
       }
-      a.play()
-        .then(() => setPlaying(true))
-        .catch((err) => {
-          setError(t('trimmer.playback_failed', { message: err.message || err }));
-        });
-    };
-    // HAVE_METADATA = 1 is enough to set currentTime on most browsers.
-    if (a.readyState >= 1) {
-      doPlay();
-    } else {
-      a.addEventListener('loadedmetadata', doPlay, { once: true });
-      a.addEventListener('error', () => setError(t('trimmer.audio_load_failed')), { once: true });
+      if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+      const { start: s, end: e } = stateRef.current;
+      const seg = Math.max(0.01, e - s);
+      const src = ctx.createBufferSource();
+      src.buffer = buffer;
+      src.connect(ctx.destination);
+      if (loopRef.current) {
+        src.loop = true;
+        src.loopStart = s;
+        src.loopEnd = e;
+        src.start(0, s);
+      } else {
+        src.start(0, s, seg);
+        src.onended = () => {
+          if (sourceRef.current === src) stopPlayback();
+        };
+      }
+      sourceRef.current = src;
+      playClockRef.current = { t0: ctx.currentTime };
+      setPlaying(true);
+      startPlayhead();
+    } catch (err) {
+      setError(t('trimmer.playback_failed', { message: err.message || err }));
     }
   };
 
+  // Editing the selection mid-preview retargets the live loop window so what
+  // you hear keeps matching the (moving) selection.
   useEffect(() => {
-    const a = audioRef.current;
-    if (!a) return;
-    let raf = null;
-    const tick = () => {
-      if (a.paused) {
-        raf = null;
-        return;
+    const src = sourceRef.current;
+    if (!src || !src.loop) return;
+    if (end > start) {
+      src.loopStart = start;
+      src.loopEnd = end;
+    }
+  }, [start, end]);
+
+  // Tear playback down on unmount so the AudioContext and its rAF never leak.
+  useEffect(
+    () => () => {
+      stopPlayback();
+      const ctx = audioCtxRef.current;
+      audioCtxRef.current = null;
+      if (ctx) {
+        try {
+          ctx.close();
+        } catch {}
       }
-      setCursor(a.currentTime);
-      const { start: s, end: e } = stateRef.current;
-      if (a.currentTime >= e) {
-        if (loop) {
-          try {
-            a.currentTime = s;
-          } catch {}
-        } else {
-          a.pause();
-          setPlaying(false);
-          raf = null;
-          return;
-        }
-      }
-      raf = requestAnimationFrame(tick);
-    };
-    // Only run the playhead loop while audio is actually playing — a
-    // free-running rAF would tick at ~60fps for the trimmer's whole life.
-    const startLoop = () => {
-      if (raf == null) raf = requestAnimationFrame(tick);
-    };
-    const stopLoop = () => {
-      if (raf != null) {
-        cancelAnimationFrame(raf);
-        raf = null;
-      }
-    };
-    a.addEventListener('play', startLoop);
-    a.addEventListener('pause', stopLoop);
-    a.addEventListener('ended', stopLoop);
-    if (!a.paused) startLoop(); // effect re-ran (loop toggled) mid-playback
-    return () => {
-      a.removeEventListener('play', startLoop);
-      a.removeEventListener('pause', stopLoop);
-      a.removeEventListener('ended', stopLoop);
-      stopLoop();
-    };
-  }, [loop]);
+    },
+    [stopPlayback],
+  );
 
   const duration = end - start;
   const tooLong = duration > maxSeconds;
@@ -881,8 +896,6 @@ export default function AudioTrimmer({ file, maxSeconds = 15, onConfirm, onCance
             </Button>
           </div>
         </div>
-
-        <audio ref={audioRef} preload="auto" onEnded={() => setPlaying(false)} className="hidden" />
       </div>
     </Dialog>
   );

--- a/frontend/src/test/AudioTrimmerPreview.test.jsx
+++ b/frontend/src/test/AudioTrimmerPreview.test.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+// Regression guard for #1210: the AudioTrimmer preview must play the SELECTED
+// region of the decoded buffer — the exact same buffer + [start,end] window the
+// waveform is drawn from and the confirmed clip is sliced from. The old preview
+// seeked a second <audio> element on the original file, treating the selection's
+// decoded-buffer-seconds as the file's container-seconds; for VBR /
+// mis-reported-duration clips those timelines diverge, so the preview played a
+// different region than the one selected and exported. This asserts preview is
+// wired to the buffer timeline (a BufferSource started at the selection start),
+// which fails against the old media-element implementation.
+
+const DECODED_DURATION = 8;
+const SAMPLE_RATE = 22050;
+
+function makeBuffer() {
+  const length = Math.round(DECODED_DURATION * SAMPLE_RATE);
+  return {
+    duration: DECODED_DURATION,
+    sampleRate: SAMPLE_RATE,
+    length,
+    numberOfChannels: 1,
+    getChannelData: () => new Float32Array(length),
+  };
+}
+
+let startedSources;
+
+class MockBufferSource {
+  constructor() {
+    this.buffer = null;
+    this.loop = false;
+    this.loopStart = 0;
+    this.loopEnd = 0;
+    this.onended = null;
+    this.startArgs = null;
+  }
+  connect() {}
+  start(...args) {
+    this.startArgs = args;
+    startedSources.push(this);
+  }
+  stop() {}
+}
+
+class MockAudioContext {
+  constructor() {
+    this.state = 'running';
+    this.currentTime = 0;
+    this.destination = {};
+  }
+  resume() {
+    return Promise.resolve();
+  }
+  createBufferSource() {
+    return new MockBufferSource();
+  }
+  close() {}
+}
+
+class MockOfflineAudioContext {
+  constructor() {}
+  decodeAudioData() {
+    return Promise.resolve(makeBuffer());
+  }
+}
+
+class MockAudio {
+  constructor() {
+    this.preload = '';
+    this.duration = DECODED_DURATION;
+  }
+  addEventListener(ev, cb) {
+    if (ev === 'loadedmetadata') queueMicrotask(cb);
+  }
+  set src(_) {}
+}
+
+function stubCanvas() {
+  const ctx = new Proxy(
+    {},
+    {
+      get: () => () => {},
+      set: () => true,
+    },
+  );
+  return vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx);
+}
+
+import AudioTrimmer from '../components/AudioTrimmer.jsx';
+
+describe('AudioTrimmer preview (#1210)', () => {
+  let canvasSpy;
+  beforeEach(() => {
+    startedSources = [];
+    canvasSpy = stubCanvas();
+    vi.stubGlobal('AudioContext', MockAudioContext);
+    vi.stubGlobal('Audio', MockAudio);
+    window.OfflineAudioContext = MockOfflineAudioContext;
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: () => 'blob:mock',
+      revokeObjectURL: () => {},
+    });
+  });
+  afterEach(() => {
+    canvasSpy.mockRestore();
+    vi.unstubAllGlobals();
+    delete window.OfflineAudioContext;
+    vi.restoreAllMocks();
+  });
+
+  it('previews the selected buffer region, not a second media timeline', async () => {
+    const file = new File([new Uint8Array([1, 2, 3, 4])], 'ref.wav', { type: 'audio/wav' });
+    render(<AudioTrimmer file={file} maxSeconds={15} onConfirm={() => {}} onCancel={() => {}} />);
+
+    const playBtn = await screen.findByRole('button', { name: /preview selection/i });
+    await waitFor(() => expect(playBtn).not.toBeDisabled());
+
+    // Select [2.5, 5.5] via the numeric fields (no canvas geometry needed).
+    const [startInput, endInput] = screen.getAllByRole('textbox');
+    fireEvent.change(startInput, { target: { value: '2.5' } });
+    fireEvent.blur(startInput);
+    fireEvent.change(endInput, { target: { value: '5.5' } });
+    fireEvent.blur(endInput);
+
+    fireEvent.click(playBtn);
+
+    await waitFor(() => expect(startedSources.length).toBe(1));
+    const src = startedSources[0];
+    // Playback is anchored at the selection START on the buffer timeline …
+    expect(src.startArgs[1]).toBeCloseTo(2.5, 6);
+    // … and (loop defaults on) loops exactly the selected window.
+    expect(src.loop).toBe(true);
+    expect(src.loopStart).toBeCloseTo(2.5, 6);
+    expect(src.loopEnd).toBeCloseTo(5.5, 6);
+  });
+});

--- a/frontend/src/test/audioTrimSelectionPlayhead.test.js
+++ b/frontend/src/test/audioTrimSelectionPlayhead.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { selectionPlayhead } from '../utils/audioTrim.js';
+
+// The preview playhead must live on the SAME [start,end] buffer timeline as the
+// waveform and the exported slice — never a second media-element timeline that
+// can drift for VBR / mis-reported-duration files (#1210).
+describe('selectionPlayhead', () => {
+  it('reports the elapsed offset inside a non-looping selection', () => {
+    expect(selectionPlayhead(2, 6, 0, false)).toBe(2);
+    expect(selectionPlayhead(2, 6, 1.5, false)).toBeCloseTo(3.5, 6);
+  });
+
+  it('clamps at the selection end when not looping', () => {
+    expect(selectionPlayhead(2, 6, 10, false)).toBe(6);
+  });
+
+  it('wraps within the selection window when looping', () => {
+    expect(selectionPlayhead(2, 6, 0, true)).toBe(2);
+    expect(selectionPlayhead(2, 6, 5, true)).toBeCloseTo(3, 6); // 5 % 4 = 1 -> 2+1
+    expect(selectionPlayhead(2, 6, 4, true)).toBeCloseTo(2, 6); // exact wrap
+  });
+
+  it('never divides by zero on a degenerate selection', () => {
+    expect(Number.isFinite(selectionPlayhead(3, 3, 2, true))).toBe(true);
+    expect(selectionPlayhead(3, 3, 2, false)).toBe(3);
+  });
+});

--- a/frontend/src/test/audioTrimSelectionPlayhead.test.js
+++ b/frontend/src/test/audioTrimSelectionPlayhead.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { selectionPlayhead } from '../utils/audioTrim.js';
+import { selectionPlayhead, loopWindow, MIN_LOOP_SEC } from '../utils/audioTrim.js';
 
 // The preview playhead must live on the SAME [start,end] buffer timeline as the
 // waveform and the exported slice — never a second media-element timeline that
@@ -23,5 +23,36 @@ describe('selectionPlayhead', () => {
   it('never divides by zero on a degenerate selection', () => {
     expect(Number.isFinite(selectionPlayhead(3, 3, 2, true))).toBe(true);
     expect(selectionPlayhead(3, 3, 2, false)).toBe(3);
+  });
+});
+
+// The loop window fed to a BufferSource must never collapse: a zero-width or
+// inverted range makes Web Audio ignore loopStart/loopEnd and loop the WHOLE
+// buffer, which is the preview≠selection bug #1210. loopStart < loopEnd always.
+describe('loopWindow', () => {
+  it('passes a normal selection through unchanged', () => {
+    const { loopStart, loopEnd, seg } = loopWindow(2, 5, 8);
+    expect(loopStart).toBeCloseTo(2, 6);
+    expect(loopEnd).toBeCloseTo(5, 6);
+    expect(seg).toBeCloseTo(3, 6);
+  });
+
+  it('floors an empty selection (a plain canvas click leaves start === end)', () => {
+    const { loopStart, loopEnd } = loopWindow(7, 7, 8);
+    expect(loopEnd).toBeGreaterThan(loopStart); // <- would be equal without the floor
+    expect(loopEnd - loopStart).toBeCloseTo(MIN_LOOP_SEC, 6);
+  });
+
+  it('floors an inverted selection instead of producing a negative window', () => {
+    const { loopStart, loopEnd } = loopWindow(5, 2, 8);
+    expect(loopEnd).toBeGreaterThan(loopStart);
+    expect(loopEnd - loopStart).toBeCloseTo(MIN_LOOP_SEC, 6);
+  });
+
+  it('clamps the window into the buffer near the end', () => {
+    const { loopStart, loopEnd } = loopWindow(7.999, 9, 8);
+    expect(loopStart).toBeLessThanOrEqual(8);
+    expect(loopEnd).toBeLessThanOrEqual(8);
+    expect(loopEnd).toBeGreaterThan(loopStart);
   });
 });

--- a/frontend/src/utils/audioTrim.js
+++ b/frontend/src/utils/audioTrim.js
@@ -218,6 +218,21 @@ export function selectionPlayhead(startSec, endSec, elapsedSec, loop) {
   return Math.min(endSec, startSec + e);
 }
 
+// Loop window for a BufferSource previewing selection [startSec, endSec] of a
+// `durationSec`-long buffer. A plain canvas click anchors a fresh selection with
+// start === end; if a loop source is started with loopStart === loopEnd (or an
+// inverted range), the Web Audio node IGNORES the loop points and loops the
+// WHOLE buffer — the preview≠selection failure #1210 exists to prevent. Floor
+// the segment at MIN_LOOP_SEC so loopStart < loopEnd always holds, and clamp the
+// window into the buffer. Pure so the guarantee is unit-tested, not eyeballed.
+export const MIN_LOOP_SEC = 0.01;
+export function loopWindow(startSec, endSec, durationSec) {
+  const start = clamp(startSec, 0, Math.max(0, durationSec));
+  const seg = Math.max(MIN_LOOP_SEC, endSec - start);
+  const loopEnd = Math.min(durationSec, start + seg);
+  return { loopStart: start, loopEnd, seg: loopEnd - start };
+}
+
 export function sliceToMono(buffer, startSec, endSec) {
   const sr = buffer.sampleRate;
   const s0 = Math.floor(startSec * sr);

--- a/frontend/src/utils/audioTrim.js
+++ b/frontend/src/utils/audioTrim.js
@@ -206,6 +206,18 @@ export async function decodeToMonoLowRate(file, targetSR = 22050) {
   return buf;
 }
 
+// Playhead position for a selection [startSec, endSec] that has been playing
+// for `elapsedSec`, measured on the SAME decoded-buffer timeline the waveform
+// and the exported slice use. Kept pure so the preview and the export can never
+// drift onto different timelines again (#1210). Looping wraps within the
+// selection; non-looping clamps at the selection end.
+export function selectionPlayhead(startSec, endSec, elapsedSec, loop) {
+  const seg = Math.max(1e-6, endSec - startSec);
+  const e = Math.max(0, elapsedSec);
+  if (loop) return startSec + (e % seg);
+  return Math.min(endSec, startSec + e);
+}
+
 export function sliceToMono(buffer, startSec, endSec) {
   const sr = buffer.sampleRate;
   const s0 = Math.floor(startSec * sr);


### PR DESCRIPTION
The trimmer's waveform, selection, and exported clip all live on the decoded-AudioBuffer timeline, but **preview** played the original file through an `<audio>` element seeked with *buffer-seconds* as if they were *container-seconds*. On any clip whose container duration diverges from the decoded length (VBR MP3, estimated/mis-reported durations), the preview drifted off the region the user selected — and off the region that actually gets exported for cloning.

### Fixed
- Preview now plays the **same decoded `AudioBuffer`** the waveform is drawn from and the export slices, over the exact `[start, end]` window (Web Audio `BufferSource`, native `loopStart`/`loopEnd`). One timeline — preview, waveform, and exported clip can't diverge. Also removes per-container media-decoding differences across the three platform WebViews.

Regression tests (fail-before/pass-after): `AudioTrimmerPreview.test.jsx` + `audioTrimSelectionPlayhead.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
AudioTrimmer preview playback was reworked to use the decoded `AudioBuffer` with a Web Audio `BufferSource` (via `loopWindow`) and to drive the playhead from an `AudioContext` clock, so the preview loops and stop behavior match the waveform/export timeline for the exact selected `[start, end]` region. This fixes prior drift caused by VBR and misreported-duration clips by ensuring preview, waveform, and exported audio all read from the same decoded buffer. Risk to human review: `AudioContext`/source lifecycle and correct loop/playhead retargeting when the user edits the selection during active playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->