### PR TITLE
fix(security): admin routes require a credential in SERVER_MODE (trusted-network privilege escalation) (#1213)

### DIFF
--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -114,38 +114,31 @@ def _admin_credential_configured(request) -> bool:
 
 
 def _request_presents_admin_credential(request) -> bool:
-    """Whether the request carries a valid API key or share PIN via the same
-    channels the middleware accepts (``Authorization: Bearer`` / ``?api_key`` /
-    ``ov_key`` cookie; ``x-omnivoice-pin`` / ``?pin`` / ``ov_pin`` cookie).
+    """Whether the request carries a valid **API key** via the channels the
+    middleware accepts (``Authorization: Bearer`` / ``?api_key`` / ``ov_key``
+    cookie).
 
-    Used only by the admin gate under server mode so that trusted-network
-    membership — a *consumption* exemption (``is_local_host``) that bypasses the
-    middleware — can never by itself unlock the RCE-class admin surface. All
-    lookups are getattr-defensive so a minimal Request stub never raises."""
+    Admin is RCE-class (``/system/set-env`` + ``/api/settings/*``), so only the
+    API key — a long operator-chosen secret — unlocks it. The 6-digit share PIN
+    is deliberately NOT accepted here: it is a *consumption* credential for LAN
+    playback and is short enough to brute-force (10^6, no lockout), so it must
+    never gate the admin surface (CodeRabbit #1213). A trusted-network CIDR
+    (``is_local_host`` — also a consumption exemption) likewise never unlocks
+    admin. Net: remote admin in server mode requires the API key; a PIN-only
+    deployment keeps admin loopback-only. getattr-defensive so a minimal Request
+    stub never raises."""
+    api_key = os.environ.get("OMNIVOICE_API_KEY") or ""
+    if not api_key:
+        return False
     headers = getattr(request, "headers", None) or {}
     query = getattr(request, "query_params", None) or {}
     cookies = getattr(request, "cookies", None) or {}
 
-    api_key = os.environ.get("OMNIVOICE_API_KEY") or ""
-    if api_key:
-        auth = headers.get("authorization", "")
-        supplied = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
-        if not supplied:
-            supplied = query.get("api_key") or cookies.get("ov_key") or ""
-        if supplied and secrets.compare_digest(supplied, api_key):
-            return True
-
-    pin = _configured_pin(request)
-    if pin:
-        supplied = (
-            headers.get("x-omnivoice-pin")
-            or query.get("pin")
-            or cookies.get("ov_pin")
-            or ""
-        )
-        if supplied and secrets.compare_digest(supplied, pin):
-            return True
-    return False
+    auth = headers.get("authorization", "")
+    supplied = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+    if not supplied:
+        supplied = query.get("api_key") or cookies.get("ov_key") or ""
+    return bool(supplied and secrets.compare_digest(supplied, api_key))
 
 
 def require_loopback(request: Request) -> None:
@@ -171,12 +164,15 @@ def require_loopback(request: Request) -> None:
     - No credential configured (no API key, no PIN) → open, matching the #261
       Docker flow where the operator reaches ``/system/*`` off the bridge
       gateway with nothing set.
-    - A credential IS configured → the request must present it. This keeps the
-      two-tier privilege model intact under server mode: ``OMNIVOICE_TRUSTED_NETWORKS``
-      is a *consumption* exemption (``is_local_host``) that bypasses the PIN /
-      API-key middleware, and it must NEVER by itself unlock the admin surface
-      (``/system/set-env`` — RCE-class — and ``/api/settings/*``). A LAN client
-      in a trusted CIDR that presents no credential gets 403 here even though it
+    - A credential IS configured → the request must present the **API key**.
+      This keeps the two-tier privilege model intact under server mode:
+      ``OMNIVOICE_TRUSTED_NETWORKS`` is a *consumption* exemption
+      (``is_local_host``) that bypasses the PIN / API-key middleware, and it must
+      NEVER by itself unlock the admin surface (``/system/set-env`` — RCE-class —
+      and ``/api/settings/*``). The 6-digit share PIN is a consumption credential
+      too and does not gate admin, so a PIN-only deployment keeps admin
+      loopback-only; remote admin requires the (long) API key. A LAN client in a
+      trusted CIDR — or one holding only the PIN — gets 403 here even though it
       sails through the consumption gates. See docs/api-auth.md (#1213).
     """
     host = request.client.host if request.client else None

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -94,6 +94,60 @@ def _server_mode() -> bool:
     return os.environ.get("OMNIVOICE_SERVER_MODE", "").strip().lower() in _TRUTHY
 
 
+def _configured_pin(request) -> str | None:
+    """The active share PIN (``app.state.network_share.pin``) or None. Read via
+    getattr so a bare Request stub (or a request that hit before lifespan set
+    the state) never raises — a missing PIN just means 'no PIN gate'."""
+    app = getattr(request, "app", None)
+    state = getattr(app, "state", None) if app is not None else None
+    ns = getattr(state, "network_share", None) if state is not None else None
+    return getattr(ns, "pin", None) if ns is not None else None
+
+
+def _admin_credential_configured(request) -> bool:
+    """Whether the operator has set ANY credential gate — the remote API key or
+    a share PIN. When neither is set, server mode leaves admin open (the Docker
+    issue #261 flow the image depends on)."""
+    if os.environ.get("OMNIVOICE_API_KEY"):
+        return True
+    return bool(_configured_pin(request))
+
+
+def _request_presents_admin_credential(request) -> bool:
+    """Whether the request carries a valid API key or share PIN via the same
+    channels the middleware accepts (``Authorization: Bearer`` / ``?api_key`` /
+    ``ov_key`` cookie; ``x-omnivoice-pin`` / ``?pin`` / ``ov_pin`` cookie).
+
+    Used only by the admin gate under server mode so that trusted-network
+    membership — a *consumption* exemption (``is_local_host``) that bypasses the
+    middleware — can never by itself unlock the RCE-class admin surface. All
+    lookups are getattr-defensive so a minimal Request stub never raises."""
+    headers = getattr(request, "headers", None) or {}
+    query = getattr(request, "query_params", None) or {}
+    cookies = getattr(request, "cookies", None) or {}
+
+    api_key = os.environ.get("OMNIVOICE_API_KEY") or ""
+    if api_key:
+        auth = headers.get("authorization", "")
+        supplied = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+        if not supplied:
+            supplied = query.get("api_key") or cookies.get("ov_key") or ""
+        if supplied and secrets.compare_digest(supplied, api_key):
+            return True
+
+    pin = _configured_pin(request)
+    if pin:
+        supplied = (
+            headers.get("x-omnivoice-pin")
+            or query.get("pin")
+            or cookies.get("ov_pin")
+            or ""
+        )
+        if supplied and secrets.compare_digest(supplied, pin):
+            return True
+    return False
+
+
 def require_loopback(request: Request) -> None:
     """Reject any request whose `client.host` is not a loopback address.
 
@@ -110,15 +164,29 @@ def require_loopback(request: Request) -> None:
     on rejection — the response body is `{"detail": "loopback origin required"}`
     so existing tests for `/system/set-env` keep passing without modification.
 
-    In server mode (Docker, see `_server_mode`) the gate is a no-op: the
-    loopback origin is unenforceable there and exposure is governed by the
-    deployment's port mapping + the optional share PIN instead.
+    In server mode (Docker, see `_server_mode`) the loopback origin is
+    unenforceable, so the gate can't require true loopback. It then applies the
+    admin-credential rule instead:
+
+    - No credential configured (no API key, no PIN) → open, matching the #261
+      Docker flow where the operator reaches ``/system/*`` off the bridge
+      gateway with nothing set.
+    - A credential IS configured → the request must present it. This keeps the
+      two-tier privilege model intact under server mode: ``OMNIVOICE_TRUSTED_NETWORKS``
+      is a *consumption* exemption (``is_local_host``) that bypasses the PIN /
+      API-key middleware, and it must NEVER by itself unlock the admin surface
+      (``/system/set-env`` — RCE-class — and ``/api/settings/*``). A LAN client
+      in a trusted CIDR that presents no credential gets 403 here even though it
+      sails through the consumption gates. See docs/api-auth.md (#1213).
     """
     host = request.client.host if request.client else None
     if is_loopback(host):
         return
     if _server_mode():
-        return
+        if not _admin_credential_configured(request):
+            return
+        if _request_presents_admin_credential(request):
+            return
     raise HTTPException(status_code=403, detail="loopback origin required")
 
 

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -45,8 +45,9 @@ Comma-separated CIDRs (`192.168.1.0/24,10.0.0.0/8`) that are treated as
 loopback-trusted **for consumption only**. Set it so LAN clients or a reverse
 proxy can hit TTS/dictation without the PIN/API key. It **never** exempts the
 admin surface — a trusted-network client still gets `403` on `/system/*` and
-`/api/settings/*` unless it is genuine loopback or (in server mode) presents a
-credential.
+`/api/settings/*` unless it is genuine loopback or (in server mode) presents the
+**API key** — and only when a credential is configured at all (a bare
+no-credential deployment leaves admin open; see Server mode below).
 
 ## Server mode (`OMNIVOICE_SERVER_MODE=1`, the Docker image)
 
@@ -60,11 +61,16 @@ It does **not** drop the credential requirement. Under server mode the admin
 gate applies this rule (see `require_loopback` in
 `backend/api/dependencies.py`):
 
-- **No credential configured** (no API key, no PIN) → admin is open. This is the
+- **No credential configured** (no API key, no PIN) → admin is open (`403` never fires). This is the
   #261 flow: a bare Docker deployment where the operator reaches `/system/*` off
   the bridge gateway with nothing set. Exposure rests on the port mapping.
-- **A credential IS configured** → the request must present it (API key or PIN,
-  via any accepted channel). Loopback still passes with no credential.
+- **A credential IS configured** (API key and/or PIN) → the request must present
+  the **API key** (`Authorization: Bearer` / `?api_key` / `ov_key` cookie).
+  Loopback still passes with no credential. The 6-digit share PIN is a
+  *consumption* credential and is **not** accepted for admin — it is short enough
+  to brute-force, so it must never gate `/system/set-env` (RCE-class). A PIN-only
+  deployment therefore keeps admin **loopback-only**; remote admin requires the
+  (long) API key.
 
 ### Why the credential re-check exists (#1213)
 
@@ -81,12 +87,12 @@ A client at `10.1.2.3` (in the trusted CIDR) could then `POST /system/set-env`
 *consumption* exemption, silently unlocked full admin (read the masked HF-token
 preview, install engines, set arbitrary env, clear logs, …).
 
-The fix keeps the admin gate independent: in server mode a configured credential
-gates admin, and trusted-network membership alone never satisfies it. The trusted
-client keeps its consumption exemption (TTS/dictation still work without the key)
-but is `403`'d on the admin surface until it presents the credential. A
-deployment that sets **no** credential is unchanged, and the loopback operator
-path is unchanged.
+The fix keeps the admin gate independent: in server mode admin requires the API
+key (or loopback), and neither trusted-network membership nor the share PIN
+satisfies it. The trusted client keeps its consumption exemption (TTS/dictation
+still work without the key) but is `403`'d on the admin surface until it presents
+the API key. A deployment that sets **no** credential is unchanged (admin open,
+#261), and the loopback operator path is unchanged.
 
 ## Quick reference — who reaches admin (`/system/*`, `/api/settings/*`)?
 

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -1,0 +1,103 @@
+# API access control & the two-tier trust model
+
+OmniVoice's backend is local-first: by default it is reachable only from the
+machine it runs on. Everything below is about the opt-in paths that let a
+*non*-loopback client reach it (LAN share, remote GPU box, Docker), and the
+boundary that keeps those clients out of the admin surface.
+
+## Two tiers of trust
+
+The backend distinguishes **consumption** from **administration**, and they do
+not share a gate:
+
+| Tier | Routes (examples) | Gate helper | Trusted-network client? |
+|------|-------------------|-------------|-------------------------|
+| **Consumption** | TTS generate, dubbing, dictation model/prefs + WS | `require_local` / middleware (`is_local_host`) | ✅ exempt |
+| **Administration** | `/system/*` (incl. `set-env` — RCE-class), `/api/settings/*`, engine install/uninstall, pronunciation, media tools, MCP bindings | `require_loopback` (`is_loopback`) | ❌ never, by membership alone |
+
+`is_loopback` matches only `127.0.0.1` / `::1` / `localhost`. `is_local_host`
+matches those **plus** any CIDR in `OMNIVOICE_TRUSTED_NETWORKS`. The admin gate
+uses `is_loopback`; the consumption gates use `is_local_host`. That split is the
+whole model: **consumption trust ≠ admin trust.**
+
+## The credential gates (middleware)
+
+Two ASGI middlewares sit in front of every route. Both are **inert unless
+configured**, and both **bypass loopback and trusted-network clients**
+(`is_local_host`):
+
+- **Share PIN** (`NetworkAccessMiddleware`) — when a PIN is set, a non-local
+  client must send `x-omnivoice-pin` / `?pin=` / the `ov_pin` cookie. Guards
+  casual LAN-share guests for one session.
+- **API key** (`BearerKeyMiddleware`, `OMNIVOICE_API_KEY`) — when set, a
+  non-local client must send `Authorization: Bearer <key>` / `?api_key=` / the
+  `ov_key` cookie, on HTTP **and** WebSocket. The durable credential for
+  running the backend remotely (Tailscale, Docker GPU box).
+
+Because both bypass `is_local_host`, a client in a trusted CIDR presents **no
+credential at all** and is still let through — that is the point:
+`OMNIVOICE_TRUSTED_NETWORKS` exists for a reverse proxy / LAN that *cannot*
+present the credential (e.g. a proxy that strips `Authorization`).
+
+## `OMNIVOICE_TRUSTED_NETWORKS`
+
+Comma-separated CIDRs (`192.168.1.0/24,10.0.0.0/8`) that are treated as
+loopback-trusted **for consumption only**. Set it so LAN clients or a reverse
+proxy can hit TTS/dictation without the PIN/API key. It **never** exempts the
+admin surface — a trusted-network client still gets `403` on `/system/*` and
+`/api/settings/*` unless it is genuine loopback or (in server mode) presents a
+credential.
+
+## Server mode (`OMNIVOICE_SERVER_MODE=1`, the Docker image)
+
+In Docker the loopback origin is **unenforceable**: NAT rewrites every
+`request.client.host` to the bridge gateway (e.g. `172.17.0.1`), so even a
+`-p 127.0.0.1:3900:3900` mapping makes every request look non-loopback. Server
+mode therefore drops the *true-loopback* requirement on admin routes (issue
+#261 — otherwise the operator is 403'd out of `/system/info`, `set-env`, etc.).
+
+It does **not** drop the credential requirement. Under server mode the admin
+gate applies this rule (see `require_loopback` in
+`backend/api/dependencies.py`):
+
+- **No credential configured** (no API key, no PIN) → admin is open. This is the
+  #261 flow: a bare Docker deployment where the operator reaches `/system/*` off
+  the bridge gateway with nothing set. Exposure rests on the port mapping.
+- **A credential IS configured** → the request must present it (API key or PIN,
+  via any accepted channel). Loopback still passes with no credential.
+
+### Why the credential re-check exists (#1213)
+
+Before #1213, server mode made `require_loopback` an unconditional no-op. That
+collapsed the two-tier model in one specific configuration:
+
+> `OMNIVOICE_SERVER_MODE=1` **+** `OMNIVOICE_API_KEY=secret` (lock the backend)
+> **+** `OMNIVOICE_TRUSTED_NETWORKS=10.0.0.0/8` (let a LAN proxy do TTS without
+> the key).
+
+A client at `10.1.2.3` (in the trusted CIDR) could then `POST /system/set-env`
+— RCE-class — with **no API key**: the API-key middleware bypassed it as
+`is_local_host`, and the admin gate was a no-op. Trusted-network membership, a
+*consumption* exemption, silently unlocked full admin (read the masked HF-token
+preview, install engines, set arbitrary env, clear logs, …).
+
+The fix keeps the admin gate independent: in server mode a configured credential
+gates admin, and trusted-network membership alone never satisfies it. The trusted
+client keeps its consumption exemption (TTS/dictation still work without the key)
+but is `403`'d on the admin surface until it presents the credential. A
+deployment that sets **no** credential is unchanged, and the loopback operator
+path is unchanged.
+
+## Quick reference — who reaches admin (`/system/*`, `/api/settings/*`)?
+
+| Client | Desktop (no server mode) | Server mode, no credential | Server mode, API key/PIN set |
+|--------|--------------------------|----------------------------|------------------------------|
+| Loopback (`127.0.0.1`) | ✅ | ✅ | ✅ (no credential needed) |
+| Trusted CIDR, no credential | ❌ 403 | ✅ | ❌ 403 |
+| Trusted CIDR, valid credential | ❌ 403 | ✅ | ✅ |
+| Other non-loopback, valid credential | ❌ 403 | ✅ | ✅ |
+| Other non-loopback, no credential | ❌ 403 | ✅ | ❌ (blocked at middleware) |
+
+Consumption routes (TTS, dubbing, dictation) follow `is_local_host`, so every
+loopback **and** trusted-CIDR client reaches them; other non-loopback clients
+need the credential when one is set.

--- a/docs/remote-gpu.md
+++ b/docs/remote-gpu.md
@@ -112,8 +112,9 @@ remote key — is what's gating access.
   casual share session, the key is the durable remote credential. Either can
   be active; both are checked when set.
 - Admin routes (`/system/*`, `/api/settings/*`) stay loopback-gated unless
-  `OMNIVOICE_SERVER_MODE=1` is set on the box; in server mode the key (or PIN)
-  is the access control for those too — see the credential rule below.
+  `OMNIVOICE_SERVER_MODE=1` is set on the box; in server mode the **API key** is
+  the access control for those too (the short share PIN is consumption-only and
+  does not gate admin) — see the credential rule below.
 - **Trust a LAN or reverse proxy with `OMNIVOICE_TRUSTED_NETWORKS`.** If you run
   OmniVoice behind a reverse proxy (nginx, Caddy, NPM) or only expose it on a
   trusted LAN/Tailnet, set `OMNIVOICE_TRUSTED_NETWORKS` to a comma-separated list
@@ -128,7 +129,8 @@ remote key — is what's gating access.
   *consumption* exemption only — it never unlocks admin by itself, even in
   server mode (#1213).** When combined with `OMNIVOICE_SERVER_MODE=1`, a
   trusted-network client that presents no credential still gets `403` on the
-  admin routes; if a key/PIN is set, it must present it to reach admin, exactly
-  like any other non-loopback client. See [`api-auth.md`](api-auth.md) for the
-  full two-tier model.
+  admin routes (unless no credential is configured at all, the bare-Docker #261
+  flow, where admin is open); if a credential is set, only the **API key** — not
+  the share PIN — reaches admin. See [`api-auth.md`](api-auth.md) for the full
+  two-tier model.
 - The key is compared in constant time and never logged.

--- a/docs/remote-gpu.md
+++ b/docs/remote-gpu.md
@@ -112,8 +112,8 @@ remote key — is what's gating access.
   casual share session, the key is the durable remote credential. Either can
   be active; both are checked when set.
 - Admin routes (`/system/*`, `/api/settings/*`) stay loopback-gated unless
-  `OMNIVOICE_SERVER_MODE=1` is set on the box; in server mode the key is the
-  access control for those too.
+  `OMNIVOICE_SERVER_MODE=1` is set on the box; in server mode the key (or PIN)
+  is the access control for those too — see the credential rule below.
 - **Trust a LAN or reverse proxy with `OMNIVOICE_TRUSTED_NETWORKS`.** If you run
   OmniVoice behind a reverse proxy (nginx, Caddy, NPM) or only expose it on a
   trusted LAN/Tailnet, set `OMNIVOICE_TRUSTED_NETWORKS` to a comma-separated list
@@ -124,9 +124,11 @@ remote key — is what's gating access.
   headless admin. It's the granular alternative to
   `OMNIVOICE_SERVER_MODE=1` (which trusts *all* non-loopback sources) and
   sidesteps a proxy that strips the `Authorization` header. Default empty — no
-  change to the strict loopback default. Note: when combined with
-  `OMNIVOICE_SERVER_MODE=1` (which disables the admin loopback gate for Docker
-  NAT), trusted-network clients can also reach admin routes — in that mode
-  admin protection rests solely on the consumption middleware. Don't set
-  `OMNIVOICE_TRUSTED_NETWORKS` if you need admin protection in server mode.
+  change to the strict loopback default. **Trusted-network membership is a
+  *consumption* exemption only — it never unlocks admin by itself, even in
+  server mode (#1213).** When combined with `OMNIVOICE_SERVER_MODE=1`, a
+  trusted-network client that presents no credential still gets `403` on the
+  admin routes; if a key/PIN is set, it must present it to reach admin, exactly
+  like any other non-loopback client. See [`api-auth.md`](api-auth.md) for the
+  full two-tier model.
 - The key is compared in constant time and never logged.

--- a/tests/test_loopback_server_mode.py
+++ b/tests/test_loopback_server_mode.py
@@ -202,15 +202,25 @@ def test_server_mode_admin_rejects_wrong_api_key(monkeypatch):
     assert exc.value.status_code == 403
 
 
-def test_server_mode_pin_gates_admin_and_is_accepted(monkeypatch):
-    # A share PIN (no API key) also counts as the operator credential in server
-    # mode: a trusted client without it is blocked; presenting it is accepted.
+def test_server_mode_pin_does_not_unlock_admin(monkeypatch):
+    # CodeRabbit #1213: the 6-digit share PIN is a CONSUMPTION credential and is
+    # brute-forceable (10^6, no lockout), so it must NEVER gate the RCE-class
+    # admin surface. With a PIN set but no API key, admin is still *gated* (not
+    # left open) — but only loopback or the long API key can reach it. Presenting
+    # even the correct PIN over the network does NOT unlock admin.
     monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
     monkeypatch.setenv("OMNIVOICE_TRUSTED_NETWORKS", "10.0.0.0/8")
     monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    # No PIN presented → 403.
     with pytest.raises(HTTPException):
         require_loopback(_req_full("10.1.2.3", pin="1234"))
-    require_loopback(_req_full("10.1.2.3", pin="1234", headers={"x-omnivoice-pin": "1234"}))
+    # Correct PIN presented → STILL 403 (the PIN never gates admin).
+    with pytest.raises(HTTPException):
+        require_loopback(_req_full("10.1.2.3", pin="1234", headers={"x-omnivoice-pin": "1234"}))
+    # Loopback admin still needs no credential (the local operator path)…
+    require_loopback(_req_full("127.0.0.1", pin="1234"))
+    # …and the trusted client keeps its consumption exemption.
+    require_local(_req_full("10.1.2.3"))
 
 
 def test_server_mode_loopback_admin_never_needs_credential(monkeypatch):

--- a/tests/test_loopback_server_mode.py
+++ b/tests/test_loopback_server_mode.py
@@ -134,6 +134,93 @@ def test_require_local_rejects_untrusted_non_loopback(monkeypatch):
     assert exc.value.status_code == 403
 
 
+def _req_full(host, *, headers=None, query=None, cookies=None, pin=None):
+    """Richer stub carrying the channels the admin-credential check reads:
+    headers, query params, cookies, and app.state.network_share.pin."""
+    ns = SimpleNamespace(pin=pin) if pin is not None else None
+    app = SimpleNamespace(state=SimpleNamespace(network_share=ns))
+    return SimpleNamespace(
+        client=SimpleNamespace(host=host) if host else None,
+        headers=headers or {},
+        query_params=query or {},
+        cookies=cookies or {},
+        app=app,
+    )
+
+
+# Server mode + trusted network + credential — issue #1213.
+# Regression for the two-tier collapse: with OMNIVOICE_SERVER_MODE=1 the
+# loopback origin is unenforceable, so admin can't require true loopback. But a
+# configured credential (API key / PIN) must still gate admin — a trusted-network
+# client that presents NO credential must NOT reach /system/* or /api/settings/*
+# just because is_local_host exempts it from the consumption middleware.
+
+
+def test_server_mode_trusted_network_no_credential_reaches_admin(monkeypatch):
+    # No credential configured → admin stays open in server mode (the #261
+    # Docker flow: operator reaches /system/* off the bridge gateway).
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_TRUSTED_NETWORKS", "10.0.0.0/8")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    require_loopback(_req_full("10.1.2.3"))  # must not raise
+
+
+def test_server_mode_trusted_network_blocked_when_api_key_set(monkeypatch):
+    # THE FIX: API key set to lock the backend + trusted CIDR for consumption.
+    # A trusted-network client with NO key must be 403'd on the admin surface —
+    # trusted-network membership is a consumption exemption, never admin.
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_TRUSTED_NETWORKS", "10.0.0.0/8")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    with pytest.raises(HTTPException) as exc:
+        require_loopback(_req_full("10.1.2.3"))
+    assert exc.value.status_code == 403
+    # ...but consumption stays exempt for that same trusted client.
+    require_local(_req_full("10.1.2.3"))  # must not raise
+
+
+def test_server_mode_admin_allowed_with_api_key_header(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    require_loopback(
+        _req_full("172.17.0.1", headers={"authorization": "Bearer s3cret"})
+    )  # must not raise
+
+
+def test_server_mode_admin_allowed_with_api_key_cookie_or_query(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    require_loopback(_req_full("172.17.0.1", cookies={"ov_key": "s3cret"}))
+    require_loopback(_req_full("172.17.0.1", query={"api_key": "s3cret"}))
+
+
+def test_server_mode_admin_rejects_wrong_api_key(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    with pytest.raises(HTTPException) as exc:
+        require_loopback(_req_full("172.17.0.1", headers={"authorization": "Bearer nope"}))
+    assert exc.value.status_code == 403
+
+
+def test_server_mode_pin_gates_admin_and_is_accepted(monkeypatch):
+    # A share PIN (no API key) also counts as the operator credential in server
+    # mode: a trusted client without it is blocked; presenting it is accepted.
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_TRUSTED_NETWORKS", "10.0.0.0/8")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    with pytest.raises(HTTPException):
+        require_loopback(_req_full("10.1.2.3", pin="1234"))
+    require_loopback(_req_full("10.1.2.3", pin="1234", headers={"x-omnivoice-pin": "1234"}))
+
+
+def test_server_mode_loopback_admin_never_needs_credential(monkeypatch):
+    # The local operator on the Docker host (loopback) reaches admin with no
+    # credential even when one is configured — the desktop shell path.
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    require_loopback(_req_full("127.0.0.1"))  # must not raise
+
+
 def test_is_local_host_unwraps_ipv4_mapped_ipv6(monkeypatch):
     # Dual-stack proxies (Caddy, Node.js) pass ::ffff:192.168.1.5 — should
     # match an IPv4 CIDR after unwrapping the mapped address.


### PR DESCRIPTION
**Security fix — RCE-class privilege escalation.**

In `OMNIVOICE_SERVER_MODE=1`, `require_loopback` (`backend/api/dependencies.py`) returned unconditionally, before any loopback or credential check. Combined with `OMNIVOICE_TRUSTED_NETWORKS` (which `is_local_host` counts as trusted and the auth middlewares bypass), admin routes had **no independent gate** in server mode.

### Exploit
Operator runs the image with `SERVER_MODE=1` + `OMNIVOICE_API_KEY=secret` (to lock the backend) + `OMNIVOICE_TRUSTED_NETWORKS=10.0.0.0/8` (to let a LAN proxy do TTS without the key). A client at `10.1.2.3` reaches `POST /system/set-env` (RCE-class), `/api/settings/*` (masked HF-token preview), engine install, and log wipe — **with no credential**. The trusted-CIDR exemption, documented as consumption-only, silently unlocked full admin. This contradicts the code's own two-tier model (`dependencies.py`: a trusted CIDR exempts consumption but "never the RCE-class admin surface").

### Fix
`require_loopback` in server mode now applies a credential rule instead of a blanket no-op:
- **No credential configured** (no API key, no PIN) → admin open (preserves the existing Docker flow unchanged).
- **A credential is configured** → the request must present it (API key or PIN, via the same header/query/cookie channels the middleware accepts). **Trusted-network membership alone never satisfies it.**

Loopback still passes with no credential; consumption gates are untouched, so trusted networks keep their TTS/dictation exemption. Strictly tighter in server mode, no change in desktop mode.

### Tests
- Fail-before/pass-after confirmed (revert → `DID NOT RAISE HTTPException`).
- `tests/test_loopback_server_mode.py` → 41 passed
- Every consumer path (PIN, API key, dictation WS, loopback admin, trusted-network consumption) → 43 passed
- `backend/tests/` → 188 passed

Docs: `docs/api-auth.md` (two-tier model + who-reaches-admin table), `docs/remote-gpu.md` corrected (it previously documented the hole as accepted behavior).

Note: overlaps `docs/api-auth.md` with #1212 — will reconcile at merge into one guide reflecting this fixed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Server-mode admin routes now require the configured API key or share PIN, while remaining open when no credential is configured; trusted-network membership alone no longer bypasses authorization. This prevents unauthenticated access to sensitive administrative endpoints while preserving loopback, consumption-route, and desktop behavior, with regression tests and documentation updates covering the authorization model. Human review should focus on credential detection across HTTP/WebSocket channels and the intentional no-credential server-mode access policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->