### PR TITLE
fix(export): audiobook/story download hijacked the desktop app; blank-guard fallback broken on macOS (#1218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Downloading a finished audiobook (or story mix) no longer hijacks the app: in the desktop WebView a plain download link to the media file made WebKit navigate the whole window to it and play it fullscreen (then the blank-window guard misfired) — downloads now go through the native Save dialog + a server-side copy instead (#1218)
+- The blank-window guard's fallback page is shown by injection rather than a `data:` URL the desktop WebViews refuse to navigate to, and its Reload button now returns to the app even if the window had navigated away (#1218)
 - Security (server mode): the admin routes (`/system/*`, `/api/settings/*` — RCE-class) now require the API key or genuine loopback — with an API key set and `OMNIVOICE_TRUSTED_NETWORKS` configured, a trusted-network client could previously reach them with no credential; the short share PIN no longer gates admin either (#1213)
 - A render error no longer blanks the whole window — a recoverable error card (Reload / Report) appears instead, and CI now builds the real production bundle so a pre-mount crash can't ship (#1209)
 - Voice-clone trimmer: the preview now plays exactly the selected region on variable-bitrate clips (it had drifted off on VBR/mis-reported-duration files by playing the original file on a different timeline) (#1210)

--- a/frontend/src-tauri/src/blank_guard.rs
+++ b/frontend/src-tauri/src/blank_guard.rs
@@ -26,7 +26,7 @@
 //! otherwise trip this on every launch.
 
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tauri::{AppHandle, Manager, Runtime};
@@ -69,7 +69,17 @@ fn probe_script() -> String {
         var invoke =
           (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke) ||
           (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke);
-        if (invoke) { invoke('report_render_state', { rootChildren: n }); }
+        if (invoke) {
+          // The invoke returns a promise. If the webview has navigated to a
+          // page where this command isn't registered (e.g. a media file WebKit
+          // decided to play), the promise REJECTS — and an unhandled rejection
+          // surfaces to the user as a console error ("report_render_state not
+          // allowed. Plugin not found"). Swallow it: a probe that reports
+          // nothing is already handled by the PROBE_TIMEOUT path, and a probe
+          // must never be the thing that emits an error.
+          var p = invoke('report_render_state', { rootChildren: n });
+          if (p && typeof p.catch === 'function') { p.catch(function () {}); }
+        }
       } catch (e) { /* a throwing probe must never be the thing that breaks us */ }
     })();
     "#
@@ -81,7 +91,18 @@ fn probe_script() -> String {
 /// app cannot also break the explanation of what broke. Styling is intentionally
 /// plain for the same reason (no external fonts or stylesheets).
 ///
-/// "Retry" reloads; if that fails the guard runs again and lands back here.
+/// This is the ONE way the fallback is shown (`show_fallback`). We deliberately
+/// do not navigate the top frame to a `data:` URL: WKWebView (macOS), WebView2
+/// (Windows), and WebKitGTK (Linux) all refuse top-frame navigation to a `data:`
+/// URL as a security policy — it both fails to show the page and logs a console
+/// error ("Not allowed to navigate top frame to data URL"). Injection runs in
+/// the current document and works identically on all three platforms.
+///
+/// "Reload" invokes `recover_main_window`, which re-navigates the main webview
+/// to the app's own entry URL — so it recovers the real app even if the webview
+/// had wandered off (e.g. to a media file). If the IPC bridge is unavailable it
+/// falls back to `location.reload()`; either way the guard re-runs and, if still
+/// blank, lands back here.
 fn fallback_html(detail: &str) -> String {
     format!(
         r##"
@@ -106,7 +127,25 @@ fn fallback_html(detail: &str) -> String {
           'margin-top:.5rem;">{detail}</pre>' +
           '</div></body>';
         var b = document.getElementById('ov-retry');
-        if (b) {{ b.onclick = function () {{ location.reload(); }}; }}
+        if (b) {{
+          b.onclick = function () {{
+            // Recover the actual app, not location.reload() of whatever page the
+            // webview is currently on (it may have wandered off to a media file
+            // or an error page). recover_main_window re-navigates the main
+            // webview to the app's entry URL from the Rust side.
+            try {{
+              var invoke =
+                (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke) ||
+                (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke);
+              if (invoke) {{
+                var p = invoke('recover_main_window');
+                if (p && typeof p.catch === 'function') {{ p.catch(function () {{ location.reload(); }}); }}
+                return;
+              }}
+            }} catch (e) {{ /* no IPC bridge here — fall through to a plain reload */ }}
+            location.reload();
+          }};
+        }}
       }} catch (e) {{ /* nothing left to fall back to */ }}
     }})();
     "##,
@@ -133,6 +172,11 @@ pub struct BlankGuardState {
     /// probing and compares after `PROBE_TIMEOUT`; an unchanged value means
     /// the page never answered.
     healthy_seq: AtomicU32,
+    /// The app's own entry URL, captured at `arm()` before anything can wander
+    /// off it. The fallback's Reload button re-navigates the main window here
+    /// (via `recover_main_window`) so it returns to the real app even if the
+    /// webview had already navigated away — e.g. to a media file it played.
+    app_url: Mutex<Option<String>>,
 }
 
 /// Reported by the injected probe. Not a public API — the frontend never calls
@@ -192,61 +236,49 @@ fn handle_blank<R: Runtime>(app: AppHandle<R>, root_children: i32) {
     }
 }
 
-/// Put the built-in failure page on screen.
+/// Put the built-in failure page on screen by injecting it into the current
+/// document.
 ///
-/// Navigates to a `data:` URL rather than injecting HTML with `eval`. Injection
-/// only works if scripts run in the current document — and when the webview is
-/// parked on an internal error page they do not, which is exactly the situation
-/// this page exists to explain. Navigation works regardless of what the current
-/// document is. Falls back to injection if navigation is refused.
+/// We inject rather than navigate the top frame to a `data:` URL: every engine
+/// we ship on (WKWebView on macOS, WebView2 on Windows, WebKitGTK on Linux)
+/// refuses top-frame navigation to a `data:` URL as a hard security policy. On
+/// macOS that path did not just fail — it logged a console error ("Not allowed
+/// to navigate top frame to data URL") and left the Reload button unable to
+/// recover. Injection runs in the current document and works identically on all
+/// three platforms, so it is the one reliable way to guarantee something paints.
 fn show_fallback<R: Runtime>(window: &tauri::WebviewWindow<R>, detail: &str) {
-    let url = format!(
-        "data:text/html;charset=utf-8,{}",
-        urlencoding_minimal(&fallback_page(detail))
-    );
-    match url.parse() {
-        Ok(parsed) => {
-            if window.navigate(parsed).is_err() {
-                let _ = window.eval(&fallback_html(detail));
+    let _ = window.eval(&fallback_html(detail));
+}
+
+/// Re-navigate the main webview back to the app's own entry URL.
+///
+/// Invoked by the fallback page's Reload button. Unlike `location.reload()` —
+/// which reloads whatever page the webview happens to be on — this returns to
+/// the real app URL captured at `arm()`, so recovery works even after the
+/// webview navigated away (e.g. to a media file it decided to play, #1218).
+#[tauri::command]
+pub fn recover_main_window<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    let Some(window) = app.get_webview_window("main") else {
+        return Ok(());
+    };
+    // A manual recovery is a fresh start: clear the reload budget so the healed
+    // app gets its full allowance again, and keep the heartbeat alive.
+    if let Some(state) = app.try_state::<Arc<BlankGuardState>>() {
+        state.reloads.store(0, Ordering::Relaxed);
+        let target = state.app_url.lock().ok().and_then(|u| u.clone());
+        if let Some(url) = target {
+            if let Ok(parsed) = url.parse() {
+                if window.navigate(parsed).is_ok() {
+                    schedule_check(app.clone(), RETRY_BASE_DELAY);
+                    return Ok(());
+                }
             }
         }
-        Err(_) => {
-            let _ = window.eval(&fallback_html(detail));
-        }
     }
-}
-
-/// Percent-encode just enough for a `data:` URL to survive parsing.
-fn urlencoding_minimal(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() * 2);
-    for b in s.bytes() {
-        match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'!' | b'~' | b'*'
-            | b'\'' | b'(' | b')' => out.push(b as char),
-            b' ' => out.push_str("%20"),
-            _ => out.push_str(&format!("%{b:02X}")),
-        }
-    }
-    out
-}
-
-/// Standalone HTML for the `data:` URL fallback — a complete document, since
-/// navigation replaces everything. Same content as the injected variant.
-fn fallback_page(detail: &str) -> String {
-    format!(
-        r#"<!doctype html><html><head><meta charset="utf-8"><title>OmniVoice Studio</title></head>
-<body style="margin:0;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;background:#14161a;color:#e8eaed;display:flex;align-items:center;justify-content:center;height:100vh;">
-<div style="max-width:32rem;padding:2rem;text-align:center;">
-<div style="font-size:2.5rem;line-height:1;margin-bottom:1rem;">&#9888;&#65039;</div>
-<h1 style="font-size:1.25rem;margin:0 0 .75rem;">OmniVoice could not display its interface</h1>
-<p style="opacity:.8;line-height:1.5;margin:0 0 1.5rem;">The app started, but the window stayed empty.
-Your projects and voices are safe &mdash; this is a display problem, not data loss.</p>
-<button onclick="location.reload()" style="background:#4f7cff;color:#fff;border:0;border-radius:.5rem;padding:.6rem 1.4rem;font-size:.95rem;cursor:pointer;">Reload</button>
-<p style="opacity:.55;font-size:.8rem;margin-top:1.5rem;">If reloading does not help, restart the app. Still stuck? Report it with the detail below.</p>
-<pre style="opacity:.5;font-size:.7rem;text-align:left;white-space:pre-wrap;margin-top:.5rem;">{detail}</pre>
-</div></body></html>"#,
-        detail = detail.replace('<', "&lt;").replace('>', "&gt;")
-    )
+    // No captured URL (or navigation refused) — reload the current page as a
+    // last resort. Still better than a dead button.
+    let _ = window.eval("location.reload();");
+    Ok(())
 }
 
 /// Queue a render check `after` from now, and treat no answer as a blank.
@@ -283,7 +315,18 @@ pub fn schedule_check<R: Runtime>(app: AppHandle<R>, after: Duration) {
 
 /// Arm the guard. Call once from `setup`.
 pub fn arm<R: Runtime>(app: &AppHandle<R>) {
-    app.manage(Arc::new(BlankGuardState::default()));
+    let state = BlankGuardState::default();
+    // Capture the app's entry URL now, before anything can navigate away from
+    // it, so `recover_main_window` can always send the webview back to the real
+    // app rather than reloading whatever page it later wandered onto.
+    if let Some(window) = app.get_webview_window("main") {
+        if let Ok(url) = window.url() {
+            if let Ok(mut slot) = state.app_url.lock() {
+                *slot = Some(url.to_string());
+            }
+        }
+    }
+    app.manage(Arc::new(state));
     schedule_check(app.clone(), FIRST_CHECK_DELAY);
 }
 
@@ -301,6 +344,20 @@ mod tests {
         for forbidden in ["React", "window.app", "import(", "require("] {
             assert!(!js.contains(forbidden), "probe must not depend on {forbidden}");
         }
+    }
+
+    #[test]
+    fn probe_swallows_a_rejected_invoke() {
+        // If the webview has navigated away (e.g. to a media file it decided to
+        // play), `report_render_state` isn't registered and the invoke promise
+        // rejects. Without a `.catch` that becomes an *unhandled* rejection the
+        // user sees in the console (#1218). The probe must guard the promise.
+        let js = probe_script();
+        assert!(js.contains(".catch"), "probe must catch a rejected invoke");
+        assert!(
+            js.contains("typeof p.catch === 'function'"),
+            "the .catch must be guarded so a non-promise return can't throw",
+        );
     }
 
     #[test]
@@ -335,45 +392,36 @@ mod tests {
     fn fallback_reassures_about_data() {
         // A blank window reads like data loss. Say plainly that it isn't.
         assert!(fallback_html("x").contains("safe"));
-        assert!(fallback_page("x").contains("safe"));
     }
 
     #[test]
-    fn navigable_fallback_is_a_complete_document() {
-        // It is reached by NAVIGATION, which replaces the whole document, so a
-        // fragment would render as bare text.
-        let page = fallback_page("d");
-        assert!(page.starts_with("<!doctype html>"));
-        assert!(page.contains("</html>"));
-        assert!(page.contains("location.reload()"));
+    fn fallback_is_shown_by_injection_not_data_url_navigation() {
+        // WKWebView (macOS), WebView2, and WebKitGTK all refuse top-frame
+        // navigation to a `data:` URL, which both failed to show the page and
+        // logged a console error (#1218). The guard must therefore never build a
+        // top-frame `data:` HTML navigation for the fallback — injection is the
+        // only path. Scan the whole source so a future edit can't quietly bring
+        // it back. The needle is assembled at runtime so this file (scanned via
+        // include_str!) doesn't itself contain the literal it forbids.
+        let needle = format!("{}{}", "data:text/", "html");
+        let src = include_str!("blank_guard.rs");
+        assert!(
+            !src.contains(&needle),
+            "the fallback must not depend on top-frame data: navigation",
+        );
     }
 
     #[test]
-    fn navigable_fallback_needs_no_network() {
-        let page = fallback_page("d");
-        for forbidden in ["http://", "https://", "<script src", "@import"] {
-            assert!(!page.contains(forbidden), "fallback must not reference {forbidden}");
-        }
-    }
-
-    #[test]
-    fn fallback_detail_cannot_inject_markup() {
-        // The detail is interpolated into HTML; angle brackets must not be
-        // able to close a tag and wreck the one page that has to render.
-        let page = fallback_page("<script>bad()</script>");
-        assert!(!page.contains("<script>bad()"));
-        assert!(page.contains("&lt;script&gt;"));
-    }
-
-    #[test]
-    fn data_url_encoding_survives_the_characters_html_actually_uses() {
-        // '#' would truncate the URL at a fragment and '%' would corrupt other
-        // escapes — both would leave the window blank, defeating the purpose.
-        let enc = urlencoding_minimal("<html># 100% \"quoted\"");
-        assert!(!enc.contains('#'));
-        assert!(!enc.contains('<'));
-        assert!(!enc.contains('"'));
-        assert!(enc.contains("%20"), "spaces must be encoded");
-        assert_eq!(urlencoding_minimal("abcXYZ019-_.!~*'()"), "abcXYZ019-_.!~*'()");
+    fn fallback_reload_recovers_the_app_not_the_current_page() {
+        // The Reload button must return to the real app (recover_main_window
+        // re-navigates the main webview to the captured app URL), not
+        // location.reload() whatever page the webview wandered onto (#1218).
+        let html = fallback_html("x");
+        assert!(
+            html.contains("recover_main_window"),
+            "Reload must invoke the recover command",
+        );
+        // …with a plain reload only as the no-IPC-bridge fallback.
+        assert!(html.contains("location.reload()"));
     }
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -430,6 +430,7 @@ pub fn run() {
             reset::reset_scan,
             reset::reset_purge,
             blank_guard::report_render_state,
+            blank_guard::recover_main_window,
         ])
         .setup(move |app| {
             // Blank-window guard: watch the main window and, if nothing ever

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -98,6 +98,7 @@ import { clearDubHistory as apiClearDubHistory } from './api/dub';
 
 import { isTauri, doubleClickMaximize, fileToMediaUrl, playBlobAudio } from './utils/media';
 import { browserDownload } from './utils/download';
+import { downloadMedia } from './utils/mediaDownload';
 import { checkForUpdate, fetchAppVersion } from './utils/updater';
 import { syncChannel } from './utils/channelControl';
 import i18n from './i18n';
@@ -811,123 +812,16 @@ function App() {
       toast.error(i18n.t('app.toast_open_folder_failed', { message: err.message }));
     }
   };
-  const triggerDownload = async (url, fallbackName) => {
-    const extGuess = (
-      fallbackName.includes('.') ? fallbackName.split('.').pop() : 'bin'
-    ).toLowerCase();
-    const modeGuess = ['mp4', 'mov', 'mkv', 'webm'].includes(extGuess)
-      ? 'video'
-      : ['wav', 'mp3', 'flac'].includes(extGuess)
-        ? 'audio'
-        : 'file';
-
-    // In Tauri, WebKit silently drops blob downloads. Use native save dialog
-    // + server-side copy so the file actually lands on disk at a known path.
-    if (isTauri) {
-      try {
-        const { save } = await import('@tauri-apps/plugin-dialog');
-        const destPath = await save({
-          defaultPath: fallbackName,
-          filters: [
-            {
-              name: modeGuess === 'video' ? 'Video' : 'Audio',
-              extensions: [extGuess],
-            },
-          ],
-        });
-        if (!destPath) return; // user cancelled
-        toast.loading(i18n.t('app.toast_saving', { name: fallbackName }), {
-          id: fallbackName,
-        });
-
-        // Subtitles are small text bodies: fetch them raw and write from this
-        // (trusted) process via the save_text_file command — the user's dialog
-        // pick is the write authorization, and the backend never handles a
-        // destination path (#309).
-        if (['srt', 'vtt'].includes(extGuess)) {
-          const res = await apiFetch(url);
-          const text = await res.text();
-          const { invoke } = await import('@tauri-apps/api/core');
-          await invoke('save_text_file', { path: destPath, contents: text });
-          toast.success(i18n.t('app.toast_saved', { path: destPath }), {
-            id: fallbackName,
-          });
-          recordValueMoment('export'); // success-only donation moment
-          try {
-            await exportRecord({
-              filename: fallbackName,
-              destination_path: destPath,
-              mode: modeGuess,
-            });
-            loadExportHistory();
-          } catch (err) {
-            console.warn('exportRecord (subtitle save) failed:', err);
-          }
-          return;
-        }
-
-        const sep = url.includes('?') ? '&' : '?';
-        const res = await apiFetch(`${url}${sep}save_path=${encodeURIComponent(destPath)}`);
-        // Every save_path-aware endpoint returns a JSON envelope. Guard the
-        // content-type so a raw-body response surfaces as a clear error
-        // instead of a cryptic JSON.parse failure (#309).
-        const ctype = res.headers.get('content-type') || '';
-        if (!ctype.includes('application/json')) {
-          throw new Error(
-            `Server returned ${ctype || 'an unknown content type'} instead of a JSON save confirmation`,
-          );
-        }
-        const data = await res.json();
-        toast.success(i18n.t('app.toast_saved', { path: data.path }), {
-          id: fallbackName,
-        });
-        recordValueMoment('export'); // success-only donation moment
-        try {
-          await exportRecord({
-            filename: data.display_name || fallbackName,
-            destination_path: data.path,
-            mode: modeGuess,
-          });
-          loadExportHistory();
-        } catch (err) {
-          console.warn('exportRecord (Tauri save path) failed:', err);
-        }
-      } catch (err) {
-        console.error(err);
-        toast.error(i18n.t('app.toast_save_error', { message: err.message }), {
-          id: fallbackName,
-        });
-      }
-      return;
-    }
-
-    // Browser path: standard blob download.
-    try {
-      toast.loading(i18n.t('app.toast_processing', { name: fallbackName }), {
-        id: fallbackName,
-      });
-      const finalName = await browserDownload(url, fallbackName);
-      toast.success(i18n.t('app.toast_downloaded', { name: finalName }), {
-        id: fallbackName,
-      });
-      recordValueMoment('export'); // success-only donation moment
-      try {
-        await exportRecord({
-          filename: finalName,
-          destination_path: `~/Downloads/${finalName}`,
-          mode: modeGuess,
-        });
-        loadExportHistory();
-      } catch (err) {
-        console.warn('exportRecord (browser download path) failed:', err);
-      }
-    } catch (err) {
-      console.error(err);
-      toast.error(i18n.t('app.toast_download_error', { message: err.message }), {
-        id: fallbackName,
-      });
-    }
-  };
+  // Save a dynamic (save_path-aware) export — dub video/audio/subtitles — to
+  // disk. The parity-safe dialog + server-side copy vs browser-blob branch now
+  // lives in the shared `downloadMedia` util (#1218) so audiobook/story exports
+  // reuse the exact same path and never fall back to a webview-hijacking
+  // `<a href download>`. App-specific niceties are passed as callbacks.
+  const triggerDownload = (url, fallbackName) =>
+    downloadMedia(url, fallbackName, {
+      onValueMoment: () => recordValueMoment('export'), // success-only donation
+      onHistoryChanged: loadExportHistory,
+    });
   // Pre-flight for audio/video exports. If any segments are at preview
   // quality (num_step=8, from a "Regen changed" click), re-render those at
   // full quality first so the user's exported file isn't carrying preview

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -554,11 +554,14 @@ export default function StoriesEditor({ profiles = [] }) {
       // navigates the Tauri webview to the m4b and hijacks the app. Pass
       // `sourceFilename` so the Tauri copy uses the /export server-side copy.
       const mixName = output.split('/').pop();
-      await downloadMedia(audioUrl(output), mixName, { sourceFilename: mixName });
-      toast.success(t('stories.exportDone'));
-      // Success-only donation moment — a finished audiobook export is a real
-      // deliverable. Stays out of the catch/error branch below.
-      recordValueMoment('audiobook');
+      // downloadMedia owns all user-facing toasts (loading → saved/error) and
+      // fires onValueMoment only on a real save — so no success toast here (it
+      // would fire even when the native save dialog is cancelled) and the
+      // donation moment goes through the callback instead of unconditionally.
+      await downloadMedia(audioUrl(output), mixName, {
+        sourceFilename: mixName,
+        onValueMoment: () => recordValueMoment('audiobook'),
+      });
     } catch (err) {
       console.warn('Story render failed:', err);
       toast.error(t('stories.exportFailed'));

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -55,6 +55,7 @@ import { parseScript } from '../utils/parseScript';
 import { importToText } from '../utils/importStory';
 import { generateSpeech, audioUrl } from '../api/generate';
 import { playBlobAudio } from '../utils/media';
+import { downloadMedia } from '../utils/mediaDownload';
 import { encodeAudio } from '../api/stories';
 import { longformRender } from '../api/audiobook';
 import { exportStems } from '../utils/storyExport';
@@ -88,16 +89,6 @@ function download(blob, filename) {
   a.click();
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 10000);
-}
-
-// Trigger a browser download for a same-origin URL (server-rendered file).
-function downloadUrl(url, filename) {
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
 }
 
 // A chapter line is any track whose text is a markdown heading (`# …`). It
@@ -558,7 +549,12 @@ export default function StoriesEditor({ profiles = [] }) {
       });
       if (streamErr) throw new Error(streamErr);
       if (!output) throw new Error('no output produced');
-      downloadUrl(audioUrl(output), output.split('/').pop());
+      // Route through the shared save util (#1218): the story mix is a file in
+      // OUTPUTS_DIR served at /audio/<output>, so a raw `<a href download>`
+      // navigates the Tauri webview to the m4b and hijacks the app. Pass
+      // `sourceFilename` so the Tauri copy uses the /export server-side copy.
+      const mixName = output.split('/').pop();
+      await downloadMedia(audioUrl(output), mixName, { sourceFilename: mixName });
       toast.success(t('stories.exportDone'));
       // Success-only donation moment — a finished audiobook export is a real
       // deliverable. Stays out of the catch/error branch below.

--- a/frontend/src/components/audiobook/AudiobookResult.jsx
+++ b/frontend/src/components/audiobook/AudiobookResult.jsx
@@ -1,14 +1,22 @@
 import React from 'react';
 import { Download } from 'lucide-react';
 import { audioUrl } from '../../api/generate';
-import { buttonVariants } from '@/components/ui/button.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import { downloadMedia } from '../../utils/mediaDownload';
 
 /**
  * The finished-render result: the "ready" note (with cached/failed chapter
- * summaries), the player, and the Download link. Extracted from AudiobookTab to
- * keep that page under the line lint; behaviour is unchanged.
+ * summaries), the player, and the Download button. Extracted from AudiobookTab
+ * to keep that page under the line lint; behaviour is unchanged.
+ *
+ * Download goes through the shared `downloadMedia` util (#1218), NOT a raw
+ * `<a href={audioUrl(output)} download>`. In the Tauri WebView that anchor does
+ * not download an m4b the engine can play — WebKit navigates the whole webview
+ * to the file and plays it fullscreen, hijacking the app. `downloadMedia` uses
+ * the native save dialog + a server-side copy from OUTPUTS_DIR instead.
  */
 export default function AudiobookResult({ t, output, done }) {
+  const filename = output.split('/').pop();
   return (
     <div className="audiobook-done">
       <div style={{ marginBottom: 8 }}>✅ {t('audiobook.ready')}</div>
@@ -24,13 +32,13 @@ export default function AudiobookResult({ t, output, done }) {
       )}
       <audio controls src={audioUrl(output)} style={{ width: '100%' }} />
       <div style={{ marginTop: 8 }}>
-        <a
-          className={buttonVariants({ variant: 'subtle', size: 'omniMd' })}
-          href={audioUrl(output)}
-          download={output}
+        <Button
+          variant="subtle"
+          size="omniMd"
+          onClick={() => downloadMedia(audioUrl(output), filename, { sourceFilename: filename })}
         >
           <Download size={14} /> {t('audiobook.download')}
-        </a>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/utils/mediaDownload.js
+++ b/frontend/src/utils/mediaDownload.js
@@ -110,6 +110,7 @@ export async function downloadMedia(url, fallbackName, opts = {}) {
       // process — the backend never handles the destination path (#309).
       if (['srt', 'vtt'].includes(extGuess)) {
         const res = await apiFetch(url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`); // don't write an error body to disk
         const text = await res.text();
         const { invoke } = await import('@tauri-apps/api/core');
         await invoke('save_text_file', { path: destPath, contents: text });
@@ -124,6 +125,7 @@ export async function downloadMedia(url, fallbackName, opts = {}) {
       // raw-body response surfaces a clear error, not a JSON.parse crash (#309).
       const sep = url.includes('?') ? '&' : '?';
       const res = await apiFetch(`${url}${sep}save_path=${encodeURIComponent(destPath)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`); // a 4xx/5xx isn't a successful save
       const ctype = res.headers.get('content-type') || '';
       if (!ctype.includes('application/json')) {
         throw new Error(

--- a/frontend/src/utils/mediaDownload.js
+++ b/frontend/src/utils/mediaDownload.js
@@ -1,0 +1,155 @@
+// Shared "save this rendered file to disk" util — the ONE place that decides
+// how a finished media file leaves the app, on every platform.
+//
+// Why this exists (#1218): a raw `<a href={httpMediaUrl} download>` does NOT
+// download in the Tauri desktop WebView. WebKit (macOS/WKWebView) "handles the
+// load" for any media URL its engine can play by NAVIGATING the whole webview
+// to the file and playing it fullscreen — replacing the app. The blank-window
+// guard then reloads and eventually paints its failure page. So server media
+// must never be reached via `<a download>` inside the shell.
+//
+// The parity-safe route, ported from App.jsx's `triggerDownload`:
+//   * Tauri  → native save dialog (`plugin-dialog.save`) → server-side copy so
+//              the bytes actually land on disk at the user's chosen path. WebKit
+//              silently drops blob downloads too, so a blob is not sufficient.
+//   * Browser/Docker → `browserDownload` (fetch → blob → temporary <a download>),
+//              which is correct outside the shell.
+//
+// Two Tauri copy mechanisms, picked by the caller's knowledge of the source:
+//   (a) `sourceFilename` set → the file already lives in OUTPUTS_DIR (audiobook
+//       / story renders, served at /audio/<file>): copy it via the /export API
+//       (`exportAction`), which resolves the name inside OUTPUTS_DIR and copies
+//       to the destination. The /audio mount is a StaticFiles mount with no
+//       ?save_path= support, so this is the only server-side copy that works
+//       for those files.
+//   (b) no `sourceFilename` → a dynamic, save_path-aware endpoint (dub exports):
+//       append ?save_path= and let that endpoint render + copy, returning JSON.
+//   Subtitles (srt/vtt) are small text bodies fetched raw and written via the
+//   trusted `save_text_file` command — the backend never handles their dest
+//   path (#309).
+import { toast } from 'react-hot-toast';
+import i18n from '../i18n';
+import { isTauri } from './media';
+import { apiFetch } from '../api/client';
+import { browserDownload } from './download';
+import { exportAction, exportRecord } from '../api/exports';
+
+const VIDEO_EXTS = ['mp4', 'mov', 'mkv', 'webm'];
+const AUDIO_EXTS = ['wav', 'mp3', 'flac', 'm4b', 'm4a', 'aac', 'ogg', 'opus'];
+
+function guessMode(ext) {
+  if (VIDEO_EXTS.includes(ext)) return 'video';
+  if (AUDIO_EXTS.includes(ext)) return 'audio';
+  return 'file';
+}
+
+/**
+ * Save a server-rendered media file to disk without ever navigating the
+ * webview. Works in the Tauri shell (native dialog + server-side copy) and in
+ * the browser/Docker build (blob download). Shows the same user-facing toasts
+ * as the App's own export flow. Never creates an `<a href={httpUrl} download>`.
+ *
+ * @param {string} url            HTTP URL of the file (also the source for the
+ *                                browser blob download + dynamic save_path copy).
+ * @param {string} fallbackName   Suggested filename in the save dialog / for the
+ *                                download.
+ * @param {object} [opts]
+ * @param {string} [opts.sourceFilename] Basename of a file in OUTPUTS_DIR — when
+ *                                set, the Tauri copy goes through `exportAction`
+ *                                (/export) instead of a ?save_path= append.
+ * @param {() => void} [opts.onValueMoment]   Fires once on a successful save
+ *                                (App wires `recordValueMoment('export')`).
+ * @param {() => void} [opts.onHistoryChanged] Fires after the export-history
+ *                                row is written (App wires `loadExportHistory`).
+ */
+export async function downloadMedia(url, fallbackName, opts = {}) {
+  const { sourceFilename = null, onValueMoment = null, onHistoryChanged = null } = opts;
+  const extGuess = (
+    fallbackName.includes('.') ? fallbackName.split('.').pop() : 'bin'
+  ).toLowerCase();
+  const modeGuess = guessMode(extGuess);
+
+  // exportRecord writes the history row for paths the backend didn't already
+  // record (browser download, save_path, subtitle). Non-fatal: a failed record
+  // must not turn a successful save into an error toast.
+  const recordHistory = async (filename, destinationPath) => {
+    try {
+      await exportRecord({ filename, destination_path: destinationPath, mode: modeGuess });
+      onHistoryChanged?.();
+    } catch (err) {
+      console.warn('exportRecord failed:', err);
+    }
+  };
+
+  // ── Tauri: native save dialog + server-side copy ────────────────────────
+  if (isTauri) {
+    try {
+      const { save } = await import('@tauri-apps/plugin-dialog');
+      const destPath = await save({
+        defaultPath: fallbackName,
+        filters: [{ name: modeGuess === 'video' ? 'Video' : 'Audio', extensions: [extGuess] }],
+      });
+      if (!destPath) return; // user cancelled
+      toast.loading(i18n.t('app.toast_saving', { name: fallbackName }), { id: fallbackName });
+
+      // (a) File already in OUTPUTS_DIR — copy by source filename via /export.
+      // /export records its own history row, so no exportRecord here.
+      if (sourceFilename) {
+        await exportAction({
+          source_filename: sourceFilename,
+          destination_path: destPath,
+          mode: modeGuess,
+        });
+        toast.success(i18n.t('app.toast_saved', { path: destPath }), { id: fallbackName });
+        onValueMoment?.();
+        onHistoryChanged?.();
+        return;
+      }
+
+      // (b) Subtitles: fetch the small text body and write it from this trusted
+      // process — the backend never handles the destination path (#309).
+      if (['srt', 'vtt'].includes(extGuess)) {
+        const res = await apiFetch(url);
+        const text = await res.text();
+        const { invoke } = await import('@tauri-apps/api/core');
+        await invoke('save_text_file', { path: destPath, contents: text });
+        toast.success(i18n.t('app.toast_saved', { path: destPath }), { id: fallbackName });
+        onValueMoment?.();
+        await recordHistory(fallbackName, destPath);
+        return;
+      }
+
+      // (c) Dynamic save_path-aware endpoint (dub exports): the endpoint copies
+      // to destPath and returns a JSON envelope. Guard the content-type so a
+      // raw-body response surfaces a clear error, not a JSON.parse crash (#309).
+      const sep = url.includes('?') ? '&' : '?';
+      const res = await apiFetch(`${url}${sep}save_path=${encodeURIComponent(destPath)}`);
+      const ctype = res.headers.get('content-type') || '';
+      if (!ctype.includes('application/json')) {
+        throw new Error(
+          `Server returned ${ctype || 'an unknown content type'} instead of a JSON save confirmation`,
+        );
+      }
+      const data = await res.json();
+      toast.success(i18n.t('app.toast_saved', { path: data.path }), { id: fallbackName });
+      onValueMoment?.();
+      await recordHistory(data.display_name || fallbackName, data.path);
+    } catch (err) {
+      console.error(err);
+      toast.error(i18n.t('app.toast_save_error', { message: err.message }), { id: fallbackName });
+    }
+    return;
+  }
+
+  // ── Browser / Docker: standard blob download ────────────────────────────
+  try {
+    toast.loading(i18n.t('app.toast_processing', { name: fallbackName }), { id: fallbackName });
+    const finalName = await browserDownload(url, fallbackName);
+    toast.success(i18n.t('app.toast_downloaded', { name: finalName }), { id: fallbackName });
+    onValueMoment?.();
+    await recordHistory(finalName, `~/Downloads/${finalName}`);
+  } catch (err) {
+    console.error(err);
+    toast.error(i18n.t('app.toast_download_error', { message: err.message }), { id: fallbackName });
+  }
+}

--- a/frontend/src/utils/mediaDownload.test.js
+++ b/frontend/src/utils/mediaDownload.test.js
@@ -101,6 +101,7 @@ describe('downloadMedia — Tauri branch (isTauri=true)', () => {
     const downloadMedia = await loadDownloadMedia({ tauri: true });
     save.mockResolvedValueOnce('/Users/me/Movies/dubbed_video.mp4');
     apiFetch.mockResolvedValueOnce({
+      ok: true,
       headers: { get: () => 'application/json' },
       json: async () => ({
         path: '/Users/me/Movies/dubbed_video.mp4',

--- a/frontend/src/utils/mediaDownload.test.js
+++ b/frontend/src/utils/mediaDownload.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// #1218: `downloadMedia` must save a finished render without ever navigating
+// the webview. In the browser it uses `browserDownload`; in Tauri it uses the
+// native save dialog + a server-side copy — NEVER an `<a href={httpUrl} download>`
+// (which WebKit turns into a fullscreen media navigation that hijacks the app).
+
+const browserDownload = vi.fn(async (_url, name) => name);
+const exportAction = vi.fn(async () => ({ success: true }));
+const exportRecord = vi.fn(async () => ({ success: true }));
+const apiFetch = vi.fn();
+const save = vi.fn();
+const invoke = vi.fn(async () => {});
+const toast = {
+  loading: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+};
+
+// Load the util with a chosen isTauri value. resetModules + doMock so both
+// branches can be exercised from one file (isTauri is a module-load const).
+async function loadDownloadMedia({ tauri }) {
+  vi.resetModules();
+  vi.doMock('./media', () => ({ isTauri: tauri }));
+  vi.doMock('./download', () => ({ browserDownload }));
+  vi.doMock('../api/exports', () => ({ exportAction, exportRecord }));
+  vi.doMock('../api/client', () => ({ apiFetch }));
+  vi.doMock('react-hot-toast', () => ({ toast }));
+  vi.doMock('../i18n', () => ({
+    default: { t: (key, opts) => `${key}:${JSON.stringify(opts || {})}` },
+  }));
+  vi.doMock('@tauri-apps/plugin-dialog', () => ({ save }));
+  vi.doMock('@tauri-apps/api/core', () => ({ invoke }));
+  return (await import('./mediaDownload')).downloadMedia;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('downloadMedia — browser branch (isTauri=false)', () => {
+  it('routes through browserDownload and never opens the save dialog or copies server-side', async () => {
+    const downloadMedia = await loadDownloadMedia({ tauri: false });
+    const onValueMoment = vi.fn();
+    const onHistoryChanged = vi.fn();
+
+    await downloadMedia('http://x/audio/foo.m4b', 'foo.m4b', { onValueMoment, onHistoryChanged });
+
+    expect(browserDownload).toHaveBeenCalledWith('http://x/audio/foo.m4b', 'foo.m4b');
+    expect(save).not.toHaveBeenCalled(); // no native dialog in the browser
+    expect(exportAction).not.toHaveBeenCalled(); // no server-side copy
+    // History row still recorded for the browser download, + the callbacks.
+    expect(exportRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'foo.m4b', mode: 'audio' }),
+    );
+    expect(onValueMoment).toHaveBeenCalledOnce();
+    expect(onHistoryChanged).toHaveBeenCalledOnce();
+  });
+});
+
+describe('downloadMedia — Tauri branch (isTauri=true)', () => {
+  it('OUTPUTS_DIR file: opens the save dialog + copies via exportAction, no blob download, no <a>', async () => {
+    const downloadMedia = await loadDownloadMedia({ tauri: true });
+    save.mockResolvedValueOnce('/Users/me/Books/foo.m4b');
+    const createElement = vi.spyOn(document, 'createElement');
+    const onValueMoment = vi.fn();
+
+    await downloadMedia('http://x/audio/foo.m4b', 'foo.m4b', {
+      sourceFilename: 'foo.m4b',
+      onValueMoment,
+    });
+
+    expect(save).toHaveBeenCalledOnce();
+    expect(exportAction).toHaveBeenCalledWith({
+      source_filename: 'foo.m4b',
+      destination_path: '/Users/me/Books/foo.m4b',
+      mode: 'audio',
+    });
+    // The webview-hijack bug was a raw `<a href={httpUrl} download>`; the util
+    // must never create one, and must not fall back to the blob download.
+    expect(browserDownload).not.toHaveBeenCalled();
+    const madeAnchor = createElement.mock.calls.some(([tag]) => tag === 'a');
+    expect(madeAnchor).toBe(false);
+    // /export records its own history row — no double exportRecord here.
+    expect(exportRecord).not.toHaveBeenCalled();
+    expect(onValueMoment).toHaveBeenCalledOnce();
+    createElement.mockRestore();
+  });
+
+  it('cancelled save dialog is a no-op (no copy, no error)', async () => {
+    const downloadMedia = await loadDownloadMedia({ tauri: true });
+    save.mockResolvedValueOnce(null); // user cancelled
+
+    await downloadMedia('http://x/audio/foo.m4b', 'foo.m4b', { sourceFilename: 'foo.m4b' });
+
+    expect(exportAction).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('dynamic endpoint (no sourceFilename): appends ?save_path= and records history', async () => {
+    const downloadMedia = await loadDownloadMedia({ tauri: true });
+    save.mockResolvedValueOnce('/Users/me/Movies/dubbed_video.mp4');
+    apiFetch.mockResolvedValueOnce({
+      headers: { get: () => 'application/json' },
+      json: async () => ({
+        path: '/Users/me/Movies/dubbed_video.mp4',
+        display_name: 'dubbed_video.mp4',
+      }),
+    });
+
+    await downloadMedia(
+      'http://x/dub/download/job/dubbed_video.mp4?preserve_bg=1',
+      'dubbed_video.mp4',
+    );
+
+    const fetchedUrl = apiFetch.mock.calls[0][0];
+    expect(fetchedUrl).toContain('save_path=');
+    expect(fetchedUrl).toContain(encodeURIComponent('/Users/me/Movies/dubbed_video.mp4'));
+    expect(exportAction).not.toHaveBeenCalled(); // dynamic endpoint copies itself
+    expect(exportRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'dubbed_video.mp4', mode: 'video' }),
+    );
+  });
+});


### PR DESCRIPTION
**P0, user-reported.** Clicking Download on a finished audiobook blanked the whole app.

### Root cause
`AudiobookResult` (and Stories) used `<a href={mediaUrl} download>`. In the desktop WebView (WKWebView especially) the `download` attribute isn't honored for a media URL it can play — WebKit **navigates the whole window to the m4b and plays it fullscreen**, replacing the app. `#root` goes empty, the blank-window guard reloads 3× and paints its failure page, and its probe then throws `report_render_state not allowed` (it's running on the media page). One download click cascades into the whole thing.

### Fix
- New shared `downloadMedia(url, name, { sourceFilename })` (`utils/mediaDownload.js`) — the mechanism `App.jsx` already used correctly: **desktop** → native Save dialog + a server-side copy via the pre-existing `/export` endpoint (path-safe `_safe_source`/`_safe_destination`); **browser/Docker** → the existing blob download. No `<a href={media} download>` anywhere.
- Routed the **audiobook** and **Stories** downloads through it; `App.jsx`'s `triggerDownload` DRY'd onto the same util (its callers unchanged). Whole-class grep: those were the only two raw-anchor sites.
- **Blank-guard hardening** (defense-in-depth for the same incident): the probe now `.catch()`es its invoke (kills the unhandled rejection); the fallback page is shown by **injection** instead of a `data:` URL the WebViews refuse to top-frame-navigate to (the `Not allowed to navigate top frame to data URL` error); and Reload invokes a new `recover_main_window` Rust command that re-navigates to the app's entry URL — so it returns to the app even if the window had wandered off to a media file.

Cross-platform (macOS/Windows/Linux) — the Save-dialog + server-copy path is the parity-safe route. No new deps. Verify: `bun run test` 1498; new `mediaDownload.test.js` 4; `test:prod-bundle` 2; `cargo test --lib blank_guard` 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Introduced a shared `downloadMedia` utility to route audiobook, Story, and app downloads through the native Tauri Save dialog plus server-side export/copy on desktop—preserving blob-based downloads in browsers/Docker—and removed raw `download` anchors that could hijack the WebView/app window; it also added `res.ok`/status guards for subtitle and dynamic-endpoint paths and moved success/history recording so cancelled downloads don’t show “export done.” Hardened the blank-window guard by swallowing probe/invoke errors, injecting the fallback page into the current document instead of using a `data:` navigation, and adding a `recover_main_window` IPC command so Reload restores the main webview (falling back to `location.reload()` when needed). Human review is most worth a look for correctness and edge cases in the Tauri save-path/export/copy flows and the blank-guard injection/recovery behavior across navigation/registration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->