### PR TITLE
feat(voices): gallery voices in the Stories + Dub pickers; drop the redundant dub presets (#1220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Added
 
 - Voice picker: the designed-voice **Gallery** is now selectable anywhere a voice is chosen — the audiobook default voice and each Cast row can pick a gallery archetype (searchable, favourites first), and it's materialised into a real profile on pick so it just works everywhere (#1219)
+- The Stories editor and the Dubbing per-segment voice pickers now use the same gallery-enabled picker, so designed-voice archetypes are selectable there too; the dub picker drops its redundant hardcoded presets group in favour of the richer Gallery (existing picks unchanged) (#1220)
 - Audiobook tab: a Cast panel maps each `[voice:NAME]` in the script to a profile so multi-voice renders correctly (it previously fell back to a single voice), plus a markup insert toolbar, live stats (chapters · words · est. runtime), and pre-flight validation for unknown voices and empty chapters (#1217)
 - Audiobook tab: a **Stop** button that truly cancels a running generation (not just the UI) and live per-chapter progress — a bar, elapsed + ETA, and each chapter's status (rendering / done / cached / failed); finished chapters stay cached so Create again resumes. `Cmd/Ctrl+Enter` starts a render (#1216)
 - Settings → Permissions + wizard System Check: live mic/Accessibility grant state, per-OS guidance, Open Settings deep-links; dictation pre-flights the mic grant (#1175)

--- a/frontend/src/components/DubSegmentRow.jsx
+++ b/frontend/src/components/DubSegmentRow.jsx
@@ -14,8 +14,8 @@ import {
 } from 'lucide-react';
 import { formatTime } from '../utils/format';
 import { LANG_CODES } from '../utils/languages';
-import { PRESETS } from '../utils/constants';
 import { Menu, Button, Badge } from '../ui';
+import VoiceSelector from './VoiceSelector';
 
 const CHAR_BUDGET_RATIO = 1.3;
 const SENTENCE_END = /[.!?。！？]/;
@@ -420,44 +420,25 @@ function DubSegmentRow({
         ))}
       </select>
 
-      <select
-        className="input-base seg-profile-select"
-        value={seg.profile_id || ''}
-        disabled={disabled}
-        onChange={(e) => onEditField(seg.id, 'profile_id', e.target.value)}
-      >
-        <option value="">{t('segment.voice_default')}</option>
-        {speakerClones && Object.keys(speakerClones).length > 0 && (
-          <optgroup label={t('segment.from_video')}>
-            {Object.keys(speakerClones).map((spk) => {
-              const autoId = `auto:${(spk || '').toLowerCase().replace(/\s+/g, '_')}`;
-              return (
-                <option key={autoId} value={autoId}>
-                  🎤 {spk}
-                </option>
-              );
-            })}
-          </optgroup>
-        )}
-        {profiles.length > 0 && (
-          <optgroup label={t('segment.clone_profiles')}>
-            {profiles.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </optgroup>
-        )}
-        {PRESETS.length > 0 && (
-          <optgroup label={t('segment.design_presets')}>
-            {PRESETS.map((p) => (
-              <option key={p.id} value={`preset:${p.id}`}>
-                {p.name}
-              </option>
-            ))}
-          </optgroup>
-        )}
-      </select>
+      {/* Shared gallery-enabled picker (#1220). `data-noseek` + stopPropagation
+          keep a voice pick from also seeking the player (handleRowClick). The
+          dropdown portals to <body> so it isn't clipped by the react-window
+          virtualized row's overflow. The from-video `auto:<slug>` options come
+          through `speakerClones`; the legacy hardcoded design PRESETS group is
+          intentionally dropped — the Gallery supersedes it (see #1220). */}
+      <span className="seg-voice-col min-w-0" data-noseek onClick={(e) => e.stopPropagation()}>
+        <VoiceSelector
+          value={seg.profile_id || ''}
+          onChange={(v) => onEditField(seg.id, 'profile_id', v)}
+          profiles={profiles}
+          speakerClones={speakerClones}
+          disabled={disabled}
+          size="sm"
+          menuPortal
+          buttonClassName="input-base seg-profile-select"
+          defaultLabel={t('segment.voice_default')}
+        />
+      </span>
 
       <input
         type="range"

--- a/frontend/src/components/SearchableSelect.jsx
+++ b/frontend/src/components/SearchableSelect.jsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Search, ChevronDown, Check, Star, Clock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -55,6 +56,12 @@ export default function SearchableSelect({
   // to no-ops so the pre-existing call sites are unaffected. (#1219)
   onQueryChange,
   onOpenChange,
+  // Render the dropdown in a body portal with fixed positioning instead of
+  // inline. Required inside clipping ancestors (overflow:auto / react-window
+  // virtualized rows) where an inline absolute popup would be cut off — the dub
+  // segment table is the driving case (#1220). Default false so the existing
+  // inline call sites are unaffected.
+  menuPortal = false,
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -64,6 +71,8 @@ export default function SearchableSelect({
   const wrapRef = useRef(null);
   const listRef = useRef(null);
   const inputRef = useRef(null);
+  const menuRef = useRef(null);
+  const [menuPos, setMenuPos] = useState(null);
 
   const getVal = useCallback((o) => (typeof o === 'string' ? o : o?.value), []);
   const getLabel = useCallback(
@@ -130,11 +139,38 @@ export default function SearchableSelect({
   useEffect(() => {
     if (!open) return;
     const onDoc = (e) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+      // The portaled menu lives outside wrapRef, so it must be checked too —
+      // otherwise a click inside the dropdown reads as "outside" and closes it.
+      const insideWrap = wrapRef.current && wrapRef.current.contains(e.target);
+      const insideMenu = menuRef.current && menuRef.current.contains(e.target);
+      if (!insideWrap && !insideMenu) setOpen(false);
     };
     document.addEventListener('mousedown', onDoc);
     return () => document.removeEventListener('mousedown', onDoc);
   }, [open]);
+
+  // Portal positioning: glue the fixed dropdown to the trigger and keep it there
+  // while ancestors scroll / the window resizes. Only active when portaling.
+  useLayoutEffect(() => {
+    if (!open || !menuPortal) return;
+    const place = () => {
+      const el = wrapRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      // Clamp within the viewport so a right-edge (narrow-column) trigger can't
+      // push the min-220px menu off-screen and force a horizontal scrollbar.
+      const width = Math.max(r.width, 220);
+      const left = Math.min(r.left, Math.max(8, window.innerWidth - width - 8));
+      setMenuPos({ top: r.bottom + 4, left, width: r.width });
+    };
+    place();
+    window.addEventListener('scroll', place, true);
+    window.addEventListener('resize', place);
+    return () => {
+      window.removeEventListener('scroll', place, true);
+      window.removeEventListener('resize', place);
+    };
+  }, [open, menuPortal]);
 
   useEffect(() => {
     if (open) {
@@ -192,6 +228,10 @@ export default function SearchableSelect({
   // that directly on the trigger now that the descendant selectors are gone.
   const triggerSizeCls = size === 'sm' ? 'text-[0.65rem] px-[8px] py-[4px]' : 'text-[0.75rem]';
 
+  // Escape clipping ancestors (overflow:auto / react-window rows) by portaling
+  // the dropdown to <body>; otherwise render it inline as an absolute child.
+  const wrapMenu = (el) => (menuPortal ? createPortal(el, document.body) : el);
+
   return (
     // `ss-wrap` is retained as a marker class: residual.css targets
     // `.voice-selector > .ss-wrap` (cross-file child combinator). Its own
@@ -213,126 +253,135 @@ export default function SearchableSelect({
         <ChevronDown size={12} className="text-[color:var(--text-secondary)] shrink-0" />
       </button>
 
-      {open && (
-        <div
-          className="absolute top-[calc(100%+4px)] left-0 right-0 z-[1000] bg-[rgba(29,32,33,0.98)] [border:1px_solid_rgba(255,255,255,0.1)] rounded-[6px] shadow-[0_8px_24px_rgba(0,0,0,0.5)] [backdrop-filter:blur(12px)] overflow-hidden min-w-[220px] max-w-[min(360px,90vw)]"
-          role="listbox"
-        >
-          <div className="relative p-[6px] [border-bottom:1px_solid_rgba(255,255,255,0.06)] flex items-center gap-[6px]">
-            <Search
-              size={12}
-              className="absolute left-[12px] top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)] pointer-events-none"
-            />
-            <input
-              ref={inputRef}
-              className="flex-1 w-full bg-[rgba(0,0,0,0.25)] [border:1px_solid_rgba(255,255,255,0.08)] rounded-[4px] py-[5px] pr-[8px] pl-[24px] text-[0.72rem] text-[color:var(--text-primary)] outline-none [font-family:inherit] focus:[border-color:rgba(250,189,47,0.4)]"
-              placeholder={t('common.search')}
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setHighlight(0);
-              }}
-              onKeyDown={onKey}
-            />
-          </div>
-
+      {open &&
+        wrapMenu(
           <div
-            ref={listRef}
-            className="max-h-[280px] overflow-y-auto py-[2px] [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:bg-[rgba(255,255,255,0.1)] [&::-webkit-scrollbar-thumb]:rounded-[3px]"
+            ref={menuRef}
+            className={`z-[1000] bg-[rgba(29,32,33,0.98)] [border:1px_solid_rgba(255,255,255,0.1)] rounded-[6px] shadow-[0_8px_24px_rgba(0,0,0,0.5)] [backdrop-filter:blur(12px)] overflow-hidden min-w-[220px] max-w-[min(360px,90vw)] ${
+              menuPortal ? 'fixed' : 'absolute top-[calc(100%+4px)] left-0 right-0'
+            }`}
+            style={
+              menuPortal && menuPos
+                ? { top: menuPos.top, left: menuPos.left, width: menuPos.width }
+                : undefined
+            }
+            role="listbox"
           >
-            {flatItems.length === 0 && (
-              <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center">
-                {t('common.no_matches')}
-              </div>
-            )}
+            <div className="relative p-[6px] [border-bottom:1px_solid_rgba(255,255,255,0.06)] flex items-center gap-[6px]">
+              <Search
+                size={12}
+                className="absolute left-[12px] top-1/2 -translate-y-1/2 text-[color:var(--text-secondary)] pointer-events-none"
+              />
+              <input
+                ref={inputRef}
+                className="flex-1 w-full bg-[rgba(0,0,0,0.25)] [border:1px_solid_rgba(255,255,255,0.08)] rounded-[4px] py-[5px] pr-[8px] pl-[24px] text-[0.72rem] text-[color:var(--text-primary)] outline-none [font-family:inherit] focus:[border-color:rgba(250,189,47,0.4)]"
+                placeholder={t('common.search')}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setHighlight(0);
+                }}
+                onKeyDown={onKey}
+              />
+            </div>
 
-            {pinned.length > 0 && (
-              <div className={GROUP_LABEL_CLS}>
-                {recents.length ? (
-                  <>
-                    <Clock size={9} /> {t('common.recent_and_popular')}
-                  </>
-                ) : (
-                  <>
-                    <Star size={9} /> {t('common.popular_label')}
-                  </>
-                )}
-              </div>
-            )}
+            <div
+              ref={listRef}
+              className="max-h-[280px] overflow-y-auto py-[2px] [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:bg-[rgba(255,255,255,0.1)] [&::-webkit-scrollbar-thumb]:rounded-[3px]"
+            >
+              {flatItems.length === 0 && (
+                <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center">
+                  {t('common.no_matches')}
+                </div>
+              )}
 
-            {(() => {
-              let lastGroup;
-              return flatItems.map((it, idx) => {
-                const v = getVal(it.o);
-                const selected = v === value;
-                const highlighted = idx === highlight;
-                // Group header: emitted lazily on the first MAIN row of a new
-                // group whose option carries a non-empty groupLabel (#22). Pinned
-                // recent/popular rows never trigger a header. `lastGroup` advances
-                // only on main rows so a pinned row can't swallow the first header.
-                const showHeader =
-                  renderGroupHeaders &&
-                  it.kind === 'main' &&
-                  it.o &&
-                  it.o.groupLabel &&
-                  it.o.group !== lastGroup;
-                if (it.kind === 'main') lastGroup = it.o?.group;
-                return (
-                  <React.Fragment key={`${it.kind}-${v}-${idx}`}>
-                    {showHeader && <div className={GROUP_LABEL_CLS}>{it.o.groupLabel}</div>}
-                    <div
-                      data-idx={idx}
-                      // Migrated `.ss-option`/`.ss-hl`/`.ss-sel` cascade. Selected
-                      // wins its color/weight; selected+highlighted gets the
-                      // stronger amber wash; highlight (and hover, when neither
-                      // selected nor highlighted) gets the amber accent.
-                      className={[
-                        'flex items-center gap-[6px] py-[5px] px-[10px] text-[0.72rem] cursor-pointer select-none',
-                        selected
-                          ? 'text-[#8ec07c] font-medium'
-                          : highlighted
-                            ? 'text-[color:var(--accent)]'
-                            : 'text-[color:var(--text-primary)] hover:text-[color:var(--accent)]',
-                        selected && highlighted
-                          ? 'bg-[rgba(250,189,47,0.18)]'
-                          : selected
-                            ? 'bg-[rgba(142,192,124,0.1)]'
+              {pinned.length > 0 && (
+                <div className={GROUP_LABEL_CLS}>
+                  {recents.length ? (
+                    <>
+                      <Clock size={9} /> {t('common.recent_and_popular')}
+                    </>
+                  ) : (
+                    <>
+                      <Star size={9} /> {t('common.popular_label')}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {(() => {
+                let lastGroup;
+                return flatItems.map((it, idx) => {
+                  const v = getVal(it.o);
+                  const selected = v === value;
+                  const highlighted = idx === highlight;
+                  // Group header: emitted lazily on the first MAIN row of a new
+                  // group whose option carries a non-empty groupLabel (#22). Pinned
+                  // recent/popular rows never trigger a header. `lastGroup` advances
+                  // only on main rows so a pinned row can't swallow the first header.
+                  const showHeader =
+                    renderGroupHeaders &&
+                    it.kind === 'main' &&
+                    it.o &&
+                    it.o.groupLabel &&
+                    it.o.group !== lastGroup;
+                  if (it.kind === 'main') lastGroup = it.o?.group;
+                  return (
+                    <React.Fragment key={`${it.kind}-${v}-${idx}`}>
+                      {showHeader && <div className={GROUP_LABEL_CLS}>{it.o.groupLabel}</div>}
+                      <div
+                        data-idx={idx}
+                        // Migrated `.ss-option`/`.ss-hl`/`.ss-sel` cascade. Selected
+                        // wins its color/weight; selected+highlighted gets the
+                        // stronger amber wash; highlight (and hover, when neither
+                        // selected nor highlighted) gets the amber accent.
+                        className={[
+                          'flex items-center gap-[6px] py-[5px] px-[10px] text-[0.72rem] cursor-pointer select-none',
+                          selected
+                            ? 'text-[#8ec07c] font-medium'
                             : highlighted
-                              ? 'bg-[rgba(250,189,47,0.12)]'
-                              : 'hover:bg-[rgba(250,189,47,0.12)]',
-                      ].join(' ')}
-                      onMouseEnter={() => setHighlight(idx)}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        commit(it.o);
-                      }}
-                      role="option"
-                      aria-selected={selected}
-                    >
-                      {it.kind === 'recent' && (
-                        <Clock size={9} className="text-[color:var(--text-secondary)] shrink-0" />
-                      )}
-                      {it.kind === 'popular' && (
-                        <Star size={9} className="text-[color:var(--text-secondary)] shrink-0" />
-                      )}
-                      <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                        {renderOption ? renderOption(it.o) : getLabel(it.o)}
-                      </span>
-                      {selected && <Check size={10} className="text-[#8ec07c] shrink-0" />}
-                    </div>
-                  </React.Fragment>
-                );
-              });
-            })()}
+                              ? 'text-[color:var(--accent)]'
+                              : 'text-[color:var(--text-primary)] hover:text-[color:var(--accent)]',
+                          selected && highlighted
+                            ? 'bg-[rgba(250,189,47,0.18)]'
+                            : selected
+                              ? 'bg-[rgba(142,192,124,0.1)]'
+                              : highlighted
+                                ? 'bg-[rgba(250,189,47,0.12)]'
+                                : 'hover:bg-[rgba(250,189,47,0.12)]',
+                        ].join(' ')}
+                        onMouseEnter={() => setHighlight(idx)}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          commit(it.o);
+                        }}
+                        role="option"
+                        aria-selected={selected}
+                      >
+                        {it.kind === 'recent' && (
+                          <Clock size={9} className="text-[color:var(--text-secondary)] shrink-0" />
+                        )}
+                        {it.kind === 'popular' && (
+                          <Star size={9} className="text-[color:var(--text-secondary)] shrink-0" />
+                        )}
+                        <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                          {renderOption ? renderOption(it.o) : getLabel(it.o)}
+                        </span>
+                        {selected && <Check size={10} className="text-[#8ec07c] shrink-0" />}
+                      </div>
+                    </React.Fragment>
+                  );
+                });
+              })()}
 
-            {!query && filtered.length > MAX_DISPLAY && (
-              <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center [border-top:1px_solid_rgba(255,255,255,0.04)]">
-                {t('common.showing_of', { shown: MAX_DISPLAY, total: filtered.length })}
-              </div>
-            )}
-          </div>
-        </div>
-      )}
+              {!query && filtered.length > MAX_DISPLAY && (
+                <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center [border-top:1px_solid_rgba(255,255,255,0.04)]">
+                  {t('common.showing_of', { shown: MAX_DISPLAY, total: filtered.length })}
+                </div>
+              )}
+            </div>
+          </div>,
+        )}
     </div>
   );
 }

--- a/frontend/src/components/SearchableSelect.jsx
+++ b/frontend/src/components/SearchableSelect.jsx
@@ -161,7 +161,21 @@ export default function SearchableSelect({
       // push the min-220px menu off-screen and force a horizontal scrollbar.
       const width = Math.max(r.width, 220);
       const left = Math.min(r.left, Math.max(8, window.innerWidth - width - 8));
-      setMenuPos({ top: r.bottom + 4, left, width: r.width });
+      // Flip above the trigger when there isn't enough room below (e.g. the last
+      // dub segment row, near the viewport bottom) — otherwise a below-anchored
+      // fixed menu runs off-screen and scrolling just re-pins it there. Also cap
+      // the list to the available space so the chosen side always fits.
+      const GAP = 4;
+      const vh = window.innerHeight;
+      const below = vh - r.bottom - GAP;
+      const above = r.top - GAP;
+      const openUp = below < 220 && above > below;
+      const listMax = Math.max(120, Math.floor(Math.min(280, openUp ? above : below)));
+      setMenuPos(
+        openUp
+          ? { bottom: vh - r.top + GAP, left, width: r.width, listMax }
+          : { top: r.bottom + GAP, left, width: r.width, listMax },
+      );
     };
     place();
     window.addEventListener('scroll', place, true);
@@ -262,7 +276,11 @@ export default function SearchableSelect({
             }`}
             style={
               menuPortal && menuPos
-                ? { top: menuPos.top, left: menuPos.left, width: menuPos.width }
+                ? {
+                    left: menuPos.left,
+                    width: menuPos.width,
+                    ...(menuPos.bottom != null ? { bottom: menuPos.bottom } : { top: menuPos.top }),
+                  }
                 : undefined
             }
             role="listbox"
@@ -288,6 +306,7 @@ export default function SearchableSelect({
             <div
               ref={listRef}
               className="max-h-[280px] overflow-y-auto py-[2px] [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:bg-[rgba(255,255,255,0.1)] [&::-webkit-scrollbar-thumb]:rounded-[3px]"
+              style={menuPortal && menuPos ? { maxHeight: menuPos.listMax } : undefined}
             >
               {flatItems.length === 0 && (
                 <div className="py-[8px] px-[10px] text-[0.65rem] text-[color:var(--text-secondary)] italic text-center">

--- a/frontend/src/components/StoriesEditor.jsx
+++ b/frontend/src/components/StoriesEditor.jsx
@@ -43,6 +43,7 @@ import {
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { Button, Menu } from '../ui';
+import VoiceSelector from './VoiceSelector';
 import { useAppStore } from '../store';
 import { recordValueMoment } from '../utils/donationMoments';
 import {
@@ -838,19 +839,19 @@ export default function StoriesEditor({ profiles = [] }) {
                 onChange={(e) => upsertCastMember({ ...c, name: e.target.value })}
                 aria-label={t('stories.characterName')}
               />
-              <select
-                className={`${SELECT_CHROME} flex-1`}
-                value={c.profileId || ''}
-                onChange={(e) => setCharacterVoice(c.id, e.target.value || null)}
-                aria-label={`${c.name} ${t('stories.voice')}`}
-              >
-                <option value="">{t('stories.defaultVoice')}</option>
-                {profiles.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
+              {/* Shared gallery-enabled picker (#1220): a gallery pick
+                  materializes to a real profile id, stored exactly like a
+                  clone/designed voice. `|| null` preserves the store's existing
+                  "no voice = null" shape (backward-compatible projects). */}
+              <span className="flex-1 min-w-0">
+                <VoiceSelector
+                  value={c.profileId || ''}
+                  onChange={(v) => setCharacterVoice(c.id, v || null)}
+                  profiles={profiles}
+                  menuPortal
+                  defaultLabel={t('stories.defaultVoice')}
+                />
+              </span>
               <button
                 type="button"
                 className={DEL_BTN}
@@ -1075,21 +1076,21 @@ export default function StoriesEditor({ profiles = [] }) {
                   </select>
                 </div>
 
-                <select
-                  className="[font-size:var(--text-xs)] text-fg-muted bg-bg-elev-2 border border-border [border-radius:var(--radius-pill)] px-[8px] py-[2px] text-center max-w-[100px] overflow-hidden text-ellipsis whitespace-nowrap [color-scheme:dark]"
-                  value={track.profileId || ''}
-                  onChange={(e) => updateTrack(track.id, 'profileId', e.target.value || null)}
-                  aria-label={t('stories.voice')}
-                >
-                  <option value="">
-                    {inheritedName ? `↳ ${inheritedName}` : t('stories.defaultVoice')}
-                  </option>
-                  {profiles.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-                </select>
+                {/* Per-line voice override → shared gallery-enabled picker
+                    (#1220). '' inherits the character's cast voice (label shows
+                    "↳ <name>"); any pick stores a real profile id (gallery picks
+                    materialize first). `|| null` keeps the store's null-default
+                    shape so existing projects load unchanged. */}
+                <span className="min-w-0" onClick={(e) => e.stopPropagation()}>
+                  <VoiceSelector
+                    value={track.profileId || ''}
+                    onChange={(v) => updateTrack(track.id, 'profileId', v || null)}
+                    profiles={profiles}
+                    size="sm"
+                    menuPortal
+                    defaultLabel={inheritedName ? `↳ ${inheritedName}` : t('stories.defaultVoice')}
+                  />
+                </span>
 
                 <div
                   className={`flex gap-[4px] [transition:opacity_0.12s_ease] ${

--- a/frontend/src/components/VoiceSelector.jsx
+++ b/frontend/src/components/VoiceSelector.jsx
@@ -47,6 +47,8 @@ import { useAppStore } from '../store';
  * @param {()=>void} [onCreateVoice]  render an inline "create voice" button
  * @param {string}   [recentsKey='']  persist recents under this key (real ids only)
  * @param {string}   [placeholder]    trigger placeholder when nothing resolves
+ * @param {boolean}  [menuPortal=false] portal the dropdown to <body> (needed
+ *   inside clipping ancestors: overflow:auto panels / react-window rows — #1220)
  */
 // Adornment icon-button (preview / gallery / create). Layout + reset as
 // utilities; :hover/:disabled states stay in VoiceSelector.css.
@@ -84,6 +86,7 @@ export default function VoiceSelector({
   disabled = false,
   size = 'md',
   buttonClassName,
+  menuPortal = false,
 }) {
   const { t } = useTranslation();
 
@@ -296,6 +299,7 @@ export default function VoiceSelector({
         disabled={disabled || materializing}
         size={size}
         buttonClassName={buttonClassName}
+        menuPortal={menuPortal}
         onOpenChange={setOpen}
         onQueryChange={setRawQuery}
       />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3362,6 +3362,10 @@ body:has(.capture-pill) {
   width: 100%; min-width: 0; font-size: 0.6rem; padding: 1px 4px;
   overflow: hidden; text-overflow: ellipsis;
 }
+/* Voice column now hosts the shared <VoiceSelector> (#1220). The grid cell must
+   let the picker shrink to the (narrow) track instead of forcing overflow. */
+.seg-voice-col { display: flex; min-width: 0; width: 100%; }
+.seg-voice-col .voice-selector { width: 100%; min-width: 0; }
 /* Range slider — overrides the unlayered input[type=range] base. */
 .seg-gain-slider {
   width: 100%; min-width: 0; padding: 0; margin: 0;

--- a/frontend/src/test/DubSegmentRowPlanBadge.test.jsx
+++ b/frontend/src/test/DubSegmentRowPlanBadge.test.jsx
@@ -8,6 +8,12 @@ import '../i18n';
 // the row must warn on tight/impossible BEFORE any GPU time is spent, stay
 // silent on fits, and let the user apply a suggested rewrite in one click.
 
+// The row now embeds the shared VoiceSelector, which reads /archetypes and
+// materializes gallery picks. Mock both so this badge-focused test needs no
+// react-query provider or backend (the dropdown stays closed → no fetch anyway).
+vi.mock('../api/hooks', () => ({ useArchetypes: vi.fn(() => ({ data: undefined })) }));
+vi.mock('../api/archetypes', () => ({ useArchetypeAsProfile: vi.fn() }));
+
 import DubSegmentRow from '../components/DubSegmentRow';
 
 function makeProps(plan, over = {}) {

--- a/frontend/src/test/DubSegmentRowVoicePicker.test.jsx
+++ b/frontend/src/test/DubSegmentRowVoicePicker.test.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '../i18n';
+
+// The dub per-segment picker migrated from a native <select> to the shared,
+// gallery-enabled VoiceSelector (#1220). VoiceSelector fetches /archetypes and
+// materializes gallery picks — mock both so the row renders without a backend.
+vi.mock('../api/hooks', () => ({ useArchetypes: vi.fn(() => ({ data: undefined })) }));
+vi.mock('../api/archetypes', () => ({ useArchetypeAsProfile: vi.fn() }));
+
+import DubSegmentRow from '../components/DubSegmentRow';
+import { segmentGenInputs } from '../utils/segments';
+
+const PROFILES = [{ id: 'p_clone', name: 'Aria' }];
+const SPEAKER_CLONES = { 'Speaker 1': { duration: 3.2 } };
+
+function makeProps(over = {}) {
+  return {
+    seg: { id: 's1', start: 0, end: 2, text: 'hola', profile_id: '' },
+    idx: 0,
+    disabled: false,
+    isActive: false,
+    isDone: false,
+    isPlaying: false,
+    previewLoading: false,
+    selected: false,
+    profiles: PROFILES,
+    speakerClones: SPEAKER_CLONES,
+    onEditField: vi.fn(),
+    onDelete: vi.fn(),
+    onRestore: vi.fn(),
+    onPreview: vi.fn(),
+    onSelect: vi.fn(),
+    onSplit: vi.fn(),
+    onMerge: vi.fn(),
+    canMerge: false,
+    onDirect: vi.fn(),
+    onSeek: vi.fn(),
+    timelineSelected: false,
+    ...over,
+  };
+}
+
+function renderRow(props) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <DubSegmentRow {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+function openPicker() {
+  // The picker trigger shows the current voice label ("Default" for '').
+  fireEvent.click(screen.getByRole('button', { name: /Default/ }));
+}
+
+describe('DubSegmentRow voice picker (#1220)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('renders the shared VoiceSelector with clone + from-video options', () => {
+    renderRow(makeProps());
+    openPicker();
+    expect(screen.getByText('Aria')).toBeInTheDocument(); // clone profile
+    // from-video auto:<slug> option is preserved via speakerClones
+    expect(screen.getByText('🎤 Speaker 1')).toBeInTheDocument();
+  });
+
+  it('writes seg.profile_id via onEditField on a pick', () => {
+    const onEditField = vi.fn();
+    renderRow(makeProps({ onEditField }));
+    openPicker();
+    fireEvent.mouseDown(screen.getByText('Aria'));
+    expect(onEditField).toHaveBeenCalledWith('s1', 'profile_id', 'p_clone');
+  });
+
+  it('emits the auto:<slug> value for a from-video speaker (byte-identical to the old select)', () => {
+    const onEditField = vi.fn();
+    renderRow(makeProps({ onEditField }));
+    openPicker();
+    fireEvent.mouseDown(screen.getByText('🎤 Speaker 1'));
+    expect(onEditField).toHaveBeenCalledWith('s1', 'profile_id', 'auto:speaker_1');
+  });
+
+  it('no longer offers the legacy design PRESETS group (superseded by the Gallery)', () => {
+    renderRow(makeProps());
+    openPicker();
+    expect(screen.queryByText('Presets')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Authoritative/)).not.toBeInTheDocument();
+  });
+
+  // Backward-compat: dropping presets from the PICKER must not break already
+  // stored `preset:` segment values — they still expand to instruct on generate
+  // via the shared segmentGenInputs helper (utils/segments.js), unchanged.
+  it('keeps expanding a stored preset: value on generate (backward compatible)', () => {
+    const gi = segmentGenInputs({ text: 'hi', profile_id: 'preset:narrator' });
+    expect(gi.profile_id).toBe(''); // preset is not a profile id
+    expect(gi.instruct).toContain('male'); // design attrs expanded into instruct
+  });
+});

--- a/frontend/src/test/StoriesEditorVoicePicker.test.jsx
+++ b/frontend/src/test/StoriesEditorVoicePicker.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import '../i18n';
+
+// The Stories cast + per-line pickers migrated from native <select>s to the
+// shared, gallery-enabled VoiceSelector (#1220). VoiceSelector reads /archetypes
+// and materializes gallery picks — mock both so the editor renders standalone.
+vi.mock('../api/hooks', () => ({ useArchetypes: vi.fn(() => ({ data: undefined })) }));
+vi.mock('../api/archetypes', () => ({ useArchetypeAsProfile: vi.fn() }));
+
+import StoriesEditor from '../components/StoriesEditor';
+import { useAppStore } from '../store';
+
+const PROFILES = [{ id: 'p_clone', name: 'Aria' }];
+
+function seedStore() {
+  useAppStore.setState({
+    cast: [{ id: 'narrator', name: 'Narrator', color: '#b8bb26', profileId: null }],
+    storyTracks: [
+      {
+        id: 1,
+        character: 'narrator',
+        text: 'Once upon a time',
+        profileId: null,
+        emotion: null,
+        speed: null,
+        generating: false,
+        audioUrl: null,
+      },
+    ],
+    storyProjects: [],
+    currentProjectId: null,
+  });
+}
+
+function renderEditor() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <StoriesEditor profiles={PROFILES} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('StoriesEditor voice pickers (#1220)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    seedStore();
+  });
+
+  it('per-line picker renders VoiceSelector and stores the picked profile id', () => {
+    renderEditor();
+    const list = screen.getByRole('list');
+    // The line-card voice picker trigger shows the default label.
+    const trigger = within(list).getByRole('button', { name: /Default/ });
+    fireEvent.click(trigger);
+    fireEvent.mouseDown(screen.getByText('Aria'));
+    expect(useAppStore.getState().storyTracks[0].profileId).toBe('p_clone');
+  });
+
+  it('cast picker renders VoiceSelector and stores the character voice', () => {
+    renderEditor();
+    // Open the Cast panel.
+    fireEvent.click(screen.getByRole('button', { name: /Cast/ }));
+    const castRegion = screen.getByRole('region', { name: /Cast/ });
+    const trigger = within(castRegion).getByRole('button', { name: /Default/ });
+    fireEvent.click(trigger);
+    fireEvent.mouseDown(screen.getByText('Aria'));
+    expect(useAppStore.getState().cast[0].profileId).toBe('p_clone');
+  });
+});


### PR DESCRIPTION
Completes "use the voice gallery everywhere" (follow-up to #1219). Migrates the last two pickers off native `<select>` onto the shared, gallery-enabled `VoiceSelector`.

### Added
- **Stories editor** — the cast picker and the per-line voice override now use `VoiceSelector` (Gallery on), so a designed-voice archetype is pickable there. Preserves the store's "no voice = null" shape and the `↳ inherited` label; a gallery pick materialises to a real profile so preview/export are unchanged.
- **Dubbing** — the per-segment picker now uses `VoiceSelector` with the from-video clone (`auto:<slug>`) options preserved; writes `seg.profile_id` exactly as before.

### Changed
- The dub picker **drops its hardcoded design-presets group** — it's superseded by the richer Gallery. Backward-compatible: stored `preset:<id>` segments still expand to their instruct and generate identically (the expansion lives in `utils/segments.js`, untouched). Investigation note: `preset:` was a *frontend* sentinel expanded before the request — never a backend bug.

### Under the hood
- New opt-in `menuPortal` on `SearchableSelect`/`VoiceSelector` (body portal + fixed positioning) so the dropdown isn't clipped inside the dub table's **virtualized/overflow** list. Default off — audiobook and other pickers keep the inline dropdown, unchanged.

No backend change, no new i18n keys. Verify: `bun run test` 1509; `test:prod-bundle` 2; dub/stories/voice backend 483; parity 104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Stories and Dubbing voice pickers now use the shared gallery-enabled `VoiceSelector` (replacing native `<select>`), preserving existing “no voice = null”, inherited cast labels, and `auto:<slug>` cloning, while keeping legacy `preset:<id>` expansion compatible even as the Dubbing UI removes its hardcoded presets group. For the virtualized Dub per-segment list, `SearchableSelect`/`VoiceSelector` gained an opt-in `menuPortal` that renders the dropdown into `document.body` with viewport-aware fixed positioning that flips above and clamps height, updating on scroll/resize and handling click-outside correctly. Main risk to review: portal positioning/z-index and click-outside behavior plus any edge-case compatibility in stored preset/voice selection interactions and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->