### PR TITLE
fix(rocm): stop force-routing every AMD GPU to the CPU (#1228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+**Highlights**
+
+- AMD GPUs are used again — every ROCm host was silently running on the CPU
+
+### Fixed
+
+- AMD/ROCm: the GPU compatibility gate compared a CUDA `sm_` tag against a ROCm build's `gfx` architecture list, so it never matched and every ROCm host was force-routed to the CPU while `torch.cuda.is_available()` reported `True` (#1228) — thanks @simmessa!
+- AMD/ROCm: `torch.compile` was disabled on all AMD hosts by the same mismatched comparison (#1228)
+- AMD/ROCm: `HSA_OVERRIDE_GFX_VERSION` is auto-set only when your GPU's GFX ID is genuinely absent from the installed ROCm build, instead of remapping natively-supported cards; gfx1150/gfx1151 (Strix Point/Halo) added to the fallback map (#1228)
+
+### Docs
+
+- Docker: ROCm section explains that `torch.cuda.is_available() == True` isn't proof the app is on the GPU, and notes the `--group-add` needed for `/dev/kfd` on rootless hosts
+
 ## [0.4.0] — 2026-07-21
 
 **Highlights**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- AMD/ROCm: the GPU compatibility gate compared a CUDA `sm_` tag against a ROCm build's `gfx` architecture list, so it never matched and every ROCm host was force-routed to the CPU while `torch.cuda.is_available()` reported `True` (#1228) — thanks @simmessa!
+- AMD/ROCm: every ROCm host was silently force-routed to the CPU — the compatibility gate compared a CUDA `sm_` tag against a ROCm build's `gfx` list, which can never match — thanks @simmessa! (#1228)
 - AMD/ROCm: `torch.compile` was disabled on all AMD hosts by the same mismatched comparison (#1228)
-- AMD/ROCm: `HSA_OVERRIDE_GFX_VERSION` is auto-set only when your GPU's GFX ID is genuinely absent from the installed ROCm build, instead of remapping natively-supported cards; gfx1150/gfx1151 (Strix Point/Halo) added to the fallback map (#1228)
+- AMD/ROCm: `HSA_OVERRIDE_GFX_VERSION` is auto-set only when your card genuinely needs it and the remap target exists in your build; gfx1150/gfx1151 (Strix Point/Halo) added to the map (#1228)
 
 ### Docs
 
-- Docker: ROCm section explains that `torch.cuda.is_available() == True` isn't proof the app is on the GPU, and notes the `--group-add` needed for `/dev/kfd` on rootless hosts
+- Docker: ROCm section explains that `torch.cuda.is_available() == True` isn't proof the app is on the GPU, and notes the `--group-add` needed for `/dev/kfd` on rootless hosts (#1228)
 
 ## [0.4.0] — 2026-07-21
 

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -59,16 +59,35 @@ DIRECTML_MARKER = "DirectML device present"
 # ``HSA_OVERRIDE_GFX_VERSION`` runs them on the closest supported architecture.
 # Applied (with side effects) by ``model_manager._configure_rocm_if_needed``;
 # read here so ``arch_unsupported()`` doesn't flag a GPU we know how to remap.
+#
+# Values are the TARGET gfx name, not the HSA version string, so callers can
+# check whether the installed wheel actually contains that target before
+# treating the remap as a solution (``hsa_override_for`` derives the env-var
+# form). Remapping onto an architecture the build doesn't ship is not a fix —
+# it just moves the failure from "no kernel for gfx1151" to "no kernel for
+# gfx1100".
 ROCM_GFX_OVERRIDES = {
     # RDNA 3.5 (Strix Point / Strix Halo APUs) — override to gfx1100
-    "gfx1150": "11.0.0", "gfx1151": "11.0.0",
+    "gfx1150": "gfx1100", "gfx1151": "gfx1100",
     # RDNA 3 (RX 7000 series) — override to gfx1100
-    "gfx1101": "11.0.0", "gfx1102": "11.0.0", "gfx1103": "11.0.0",
+    "gfx1101": "gfx1100", "gfx1102": "gfx1100", "gfx1103": "gfx1100",
     # RDNA 2 (RX 6000 series) — override to gfx1030
-    "gfx1031": "10.3.0", "gfx1032": "10.3.0", "gfx1034": "10.3.0",
-    # Vega (RX Vega / Radeon VII) — override to gfx900
-    "gfx902": "9.0.0", "gfx906": "9.0.6",
+    "gfx1031": "gfx1030", "gfx1032": "gfx1030", "gfx1034": "gfx1030",
+    # Vega (RX Vega / Radeon VII) — override to gfx900 / gfx906
+    "gfx902": "gfx900", "gfx906": "gfx906",
 }
+
+
+def hsa_override_for(target_gfx: str) -> str:
+    """``"gfx1100"`` → ``"11.0.0"``, the form HSA_OVERRIDE_GFX_VERSION wants.
+
+    The digits are major / minor / step, with the last two characters always
+    one digit each: gfx1100 → 11.0.0, gfx1030 → 10.3.0, gfx906 → 9.0.6.
+    """
+    digits = _normalize_arch(target_gfx).removeprefix("gfx")
+    if len(digits) < 3 or not digits.isdigit():
+        raise ValueError(f"not a gfx architecture name: {target_gfx!r}")
+    return f"{digits[:-2]}.{digits[-2]}.{digits[-1]}"
 
 
 def _normalize_arch(tag: str) -> str:
@@ -126,11 +145,15 @@ def arch_unsupported(torch) -> tuple[str, tuple[str, ...]] | None:
             gfx = _normalize_arch(getattr(props, "gcnArchName", "") or "")
             if not gfx:
                 return None
-            if gfx in ROCM_GFX_OVERRIDES:
-                # _configure_rocm_if_needed() remaps this GPU onto a supported
-                # target before any kernel launches — not a mismatch.
+            build = {_normalize_arch(a) for a in arch_list}
+            if gfx in build:
                 return None
-            if gfx in {_normalize_arch(a) for a in arch_list}:
+            # _configure_rocm_if_needed() can remap this GPU onto a supported
+            # target before any kernel launches — but only counts as a fix if
+            # the build actually SHIPS that target. Remapping gfx1151 onto
+            # gfx1100 in a wheel that has neither just relocates the failure.
+            target = ROCM_GFX_OVERRIDES.get(gfx)
+            if target and _normalize_arch(target) in build:
                 return None
             return gfx, tuple(arch_list)
 

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -28,6 +28,7 @@ out of this backend-only slice.)
 from __future__ import annotations
 
 import functools
+import os
 import platform as _platform
 import sys
 from dataclasses import dataclass
@@ -51,6 +52,97 @@ DIRECTML_MARKER = "DirectML device present"
 # would put a subprocess on the cold-start probe path. That check stays in
 # ``wizard._detect_gpu`` (preflight), which already runs it. The probe only
 # emits the torch-visible SM-arch caveat (cheap, metadata-only).
+
+# ── ROCm GFX version overrides ───────────────────────────────────────────
+# AMD GPUs on ROCm present through ``torch.cuda`` but some consumer parts have
+# GFX IDs the installed ROCm build wasn't compiled for. Setting
+# ``HSA_OVERRIDE_GFX_VERSION`` runs them on the closest supported architecture.
+# Applied (with side effects) by ``model_manager._configure_rocm_if_needed``;
+# read here so ``arch_unsupported()`` doesn't flag a GPU we know how to remap.
+ROCM_GFX_OVERRIDES = {
+    # RDNA 3.5 (Strix Point / Strix Halo APUs) — override to gfx1100
+    "gfx1150": "11.0.0", "gfx1151": "11.0.0",
+    # RDNA 3 (RX 7000 series) — override to gfx1100
+    "gfx1101": "11.0.0", "gfx1102": "11.0.0", "gfx1103": "11.0.0",
+    # RDNA 2 (RX 6000 series) — override to gfx1030
+    "gfx1031": "10.3.0", "gfx1032": "10.3.0", "gfx1034": "10.3.0",
+    # Vega (RX Vega / Radeon VII) — override to gfx900
+    "gfx902": "9.0.0", "gfx906": "9.0.6",
+}
+
+
+def _normalize_arch(tag: str) -> str:
+    """``"gfx90a:xnack+"`` → ``"gfx90a"``. Feature flags dropped, lowercased."""
+    return str(tag).split(":")[0].strip().lower()
+
+
+def build_arch_list(torch) -> list[str]:
+    """This torch build's compiled architecture list, or ``[]`` if unknown.
+
+    Prefers the public ``get_arch_list`` and falls back to the private
+    ``_get_arch_list`` (older wheels only expose the latter).
+    """
+    for name in ("get_arch_list", "_get_arch_list"):
+        fn = getattr(torch.cuda, name, None)
+        if callable(fn):
+            try:
+                return [str(a) for a in (fn() or [])]
+            except Exception:
+                return []
+    return []
+
+
+def arch_unsupported(torch) -> tuple[str, tuple[str, ...]] | None:
+    """``(device_arch, build_archs)`` when device 0's architecture is absent
+    from this torch build's compiled arch list — i.e. kernels cannot launch
+    ("no kernel image is available for execution"). ``None`` means supported,
+    unknown, or not applicable.
+
+    **CUDA and ROCm name architectures in different namespaces.** A CUDA build
+    reports ``sm_89`` / ``compute_89``; a ROCm build reports ``gfx1100``. The
+    check must therefore branch on the build — comparing a CUDA ``sm_`` tag
+    against a ROCm ``gfx`` list can never match, which made *every* ROCm host
+    look unsupported and silently force-routed it to CPU (#1228). Callers must
+    get the verdict from here rather than re-deriving a tag.
+
+    Never raises: any missing/odd metadata degrades to ``None`` (compatible),
+    matching the pre-existing fail-open contract.
+    """
+    try:
+        if not torch.cuda.is_available():
+            return None
+        arch_list = build_arch_list(torch)
+        if not arch_list:
+            return None
+
+        if getattr(getattr(torch, "version", None), "hip", None) is not None:
+            # ── ROCm / HIP: arch_list holds gfx names ─────────────────────
+            if os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
+                # The override remaps the device onto a supported gfx target,
+                # so the native gfx name no longer describes what actually
+                # runs. Trust the user's (or our own) remap.
+                return None
+            props = torch.cuda.get_device_properties(0)
+            gfx = _normalize_arch(getattr(props, "gcnArchName", "") or "")
+            if not gfx:
+                return None
+            if gfx in ROCM_GFX_OVERRIDES:
+                # _configure_rocm_if_needed() remaps this GPU onto a supported
+                # target before any kernel launches — not a mismatch.
+                return None
+            if gfx in {_normalize_arch(a) for a in arch_list}:
+                return None
+            return gfx, tuple(arch_list)
+
+        # ── CUDA: arch_list holds sm_/compute_ tags ──────────────────────
+        major, minor = torch.cuda.get_device_capability(0)
+        sm_tag = f"sm_{major}{minor}"
+        if sm_tag in arch_list or f"compute_{major}{minor}" in arch_list:
+            return None
+        return sm_tag, tuple(arch_list)
+    except Exception:
+        # Arch metadata unavailable on this torch build — treat as compatible.
+        return None
 
 
 @dataclass(frozen=True)
@@ -135,23 +227,16 @@ def _probe() -> HostCaps:
                 vram_gb = float(total) / (1024 ** 3)
             except Exception:
                 notes.append("VRAM query failed")
-            # SM-arch mismatch (mirrors model_manager.check_device_compatibility).
-            try:
-                major, minor = torch.cuda.get_device_capability(0)
-                arch_list = getattr(torch.cuda, "_get_arch_list", lambda: [])()
-                if arch_list:
-                    sm_tag = f"sm_{major}{minor}"
-                    compute_tag = f"compute_{major}{minor}"
-                    if sm_tag not in arch_list and compute_tag not in arch_list:
-                        notes.append(
-                            f"{device_name or 'GPU'} ({sm_tag}) not in this torch "
-                            f"build's archs ({', '.join(arch_list)}) — "
-                            f"{KERNEL_RISK_MARKER}"
-                        )
-            except Exception:
-                # Arch metadata unavailable on this torch build — skip the check
-                # (treated as compatible, exactly as check_device_compatibility).
-                pass
+            # Arch mismatch — sm_ tags on CUDA, gfx names on ROCm. Shared with
+            # model_manager.check_device_compatibility() so probe and loader
+            # can never disagree (they used to, on every ROCm host — #1228).
+            mismatch = arch_unsupported(torch)
+            if mismatch is not None:
+                device_arch, archs = mismatch
+                notes.append(
+                    f"{device_name or 'GPU'} ({device_arch}) not in this torch "
+                    f"build's archs ({', '.join(archs)}) — {KERNEL_RISK_MARKER}"
+                )
 
     # ── Intel XPU via IPEX ───────────────────────────────────────────────
     try:
@@ -274,6 +359,9 @@ __all__ = [
     "detect_host_caps",
     "refresh",
     "mlx_supported",
+    "arch_unsupported",
+    "build_arch_list",
+    "ROCM_GFX_OVERRIDES",
     "KERNEL_RISK_MARKER",
     "DIRECTML_MARKER",
 ]

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -111,6 +111,21 @@ def build_arch_list(torch) -> list[str]:
     return []
 
 
+def gfx_for_hsa_override(value: str) -> str | None:
+    """``"11.0.0"`` → ``"gfx1100"``. The inverse of :func:`hsa_override_for`.
+
+    ``None`` for anything that isn't a three-part numeric version — the user
+    set something we don't understand, and a guess is worse than leaving it be.
+    """
+    parts = str(value).strip().split(".")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        return None
+    major, minor, step = parts
+    if len(minor) != 1 or len(step) != 1:
+        return None
+    return f"gfx{int(major)}{minor}{step}"
+
+
 def arch_unsupported(torch) -> tuple[str, tuple[str, ...]] | None:
     """``(device_arch, build_archs)`` when device 0's architecture is absent
     from this torch build's compiled arch list — i.e. kernels cannot launch
@@ -136,11 +151,22 @@ def arch_unsupported(torch) -> tuple[str, tuple[str, ...]] | None:
 
         if getattr(getattr(torch, "version", None), "hip", None) is not None:
             # ── ROCm / HIP: arch_list holds gfx names ─────────────────────
-            if os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
-                # The override remaps the device onto a supported gfx target,
-                # so the native gfx name no longer describes what actually
-                # runs. Trust the user's (or our own) remap.
-                return None
+            override = os.environ.get("HSA_OVERRIDE_GFX_VERSION")
+            if override:
+                # An override remaps the device onto some other gfx target, so
+                # the native gfx name no longer describes what will run — but
+                # the remap is only valid if this build SHIPS that target. A
+                # stale or copy-pasted value (the #1228 reporter had set
+                # 11.0.0 on a card that no longer needs it) must not buy a free
+                # pass into kernels that don't exist. Unparseable values are
+                # left alone: the user asked for something we don't understand,
+                # and guessing would be worse than trusting them.
+                target = gfx_for_hsa_override(override)
+                if target is None or _normalize_arch(target) in {
+                    _normalize_arch(a) for a in arch_list
+                }:
+                    return None
+                return f"{target} (HSA_OVERRIDE_GFX_VERSION={override})", tuple(arch_list)
             props = torch.cuda.get_device_properties(0)
             gfx = _normalize_arch(getattr(props, "gcnArchName", "") or "")
             if not gfx:
@@ -383,6 +409,8 @@ __all__ = [
     "refresh",
     "mlx_supported",
     "arch_unsupported",
+    "gfx_for_hsa_override",
+    "hsa_override_for",
     "build_arch_list",
     "ROCM_GFX_OVERRIDES",
     "KERNEL_RISK_MARKER",

--- a/backend/services/engine_env.py
+++ b/backend/services/engine_env.py
@@ -58,14 +58,16 @@ def _force_compile_requested() -> bool:
 
 
 def _cuda_arch_supported_for_compile() -> "tuple[bool, str]":
-    """Check the GPU's compute capability against this torch build's arch list.
+    """Check the GPU's architecture against this torch build's arch list.
 
     New GPU architectures (e.g. Blackwell sm_120, issue #278) routinely break
     torch.compile/Triton before upstream support lands: the eager model runs
     via PTX forward-compat, but Inductor/Triton kernel compilation targets the
-    new arch directly and fails mid-generation. If the device's ``sm_XY`` tag
-    is absent from ``torch.cuda.get_arch_list()`` we treat compile as
-    unsupported and use eager.
+    new arch directly and fails mid-generation. If the device's arch tag is
+    absent from this build's arch list we treat compile as unsupported and use
+    eager. The comparison is delegated to ``core.device_caps.arch_unsupported``
+    so it stays CUDA/ROCm-aware — a ROCm build lists ``gfx…`` names, and the
+    old ``sm_`` comparison here disabled compile on every AMD host (#1228).
 
     Returns ``(supported, reason)``. Fails open — any probe error returns
     ``(True, "")`` so a weird torch build never silently loses the
@@ -75,22 +77,21 @@ def _cuda_arch_supported_for_compile() -> "tuple[bool, str]":
     try:
         import torch
 
+        from core.device_caps import arch_unsupported
+
         if not torch.cuda.is_available():
             return True, ""
-        major, minor = torch.cuda.get_device_capability(0)
-        arch_list = list(getattr(torch.cuda, "get_arch_list", lambda: [])() or [])
-        if not arch_list:
+        mismatch = arch_unsupported(torch)
+        if mismatch is None:
             return True, ""
-        sm_tag = f"sm_{major}{minor}"
-        if sm_tag in arch_list or f"compute_{major}{minor}" in arch_list:
-            return True, ""
+        device_arch, arch_list = mismatch
         try:
             device_name = torch.cuda.get_device_name(0)
         except Exception:
             device_name = "GPU"
         return False, (
-            f"{device_name} (compute capability {major}.{minor} / {sm_tag}) is not "
-            f"in this PyTorch build's supported arch list ({', '.join(arch_list)})"
+            f"{device_name} ({device_arch}) is not in this PyTorch build's "
+            f"supported arch list ({', '.join(arch_list)})"
         )
     except Exception:
         logger.debug("CUDA arch probe for torch.compile failed; assuming supported", exc_info=True)

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -626,7 +626,11 @@ def _configure_rocm_if_needed(torch):
     overriding a natively-supported GPU forces it onto foreign kernels for no
     reason — so the map is a fallback, not an unconditional rewrite.
     """
-    from core.device_caps import ROCM_GFX_OVERRIDES, build_arch_list
+    from core.device_caps import (
+        ROCM_GFX_OVERRIDES,
+        build_arch_list,
+        hsa_override_for,
+    )
 
     if os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
         return  # User already set it manually
@@ -639,17 +643,38 @@ def _configure_rocm_if_needed(torch):
         props = torch.cuda.get_device_properties(0)
         gcn_arch = getattr(props, "gcnArchName", "") or ""
         gfx_id = gcn_arch.split(":")[0].strip().lower()
-        if gfx_id not in ROCM_GFX_OVERRIDES:
+        target = ROCM_GFX_OVERRIDES.get(gfx_id)
+        if not target:
             return
         arch_list = {a.split(":")[0].strip().lower() for a in build_arch_list(torch)}
+        if not arch_list:
+            # Metadata unavailable — an UNKNOWN build, not a confirmed
+            # mismatch. Remapping on a guess could push a natively-supported
+            # GPU onto foreign kernels, so fail open and change nothing.
+            logger.debug(
+                "ROCm: no arch list from this torch build; leaving "
+                "HSA_OVERRIDE_GFX_VERSION unset for %s (%s)", device_name, gfx_id,
+            )
+            return
         if gfx_id in arch_list:
             logger.info("ROCm: %s (%s) is natively supported by this build; "
                         "no HSA_OVERRIDE_GFX_VERSION needed", device_name, gfx_id)
             return
-        override = ROCM_GFX_OVERRIDES[gfx_id]
+        if target not in arch_list:
+            # The remap target isn't in this build either — setting the
+            # override would only change WHICH kernel is missing. Leave it
+            # unset so check_device_compatibility() reports the real mismatch
+            # and the CPU fallback engages.
+            logger.warning(
+                "ROCm: %s (%s) is unsupported by this build and its remap "
+                "target %s is missing too — not setting "
+                "HSA_OVERRIDE_GFX_VERSION.", device_name, gfx_id, target,
+            )
+            return
+        override = hsa_override_for(target)
         os.environ["HSA_OVERRIDE_GFX_VERSION"] = override
-        logger.info("ROCm: auto-set HSA_OVERRIDE_GFX_VERSION=%s for %s (%s)",
-                    override, device_name, gfx_id)
+        logger.info("ROCm: auto-set HSA_OVERRIDE_GFX_VERSION=%s (%s) for %s (%s)",
+                    override, target, device_name, gfx_id)
     except Exception as e:
         logger.debug("ROCm GFX auto-config skipped: %s", e)
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -612,27 +612,22 @@ _loading_detail: dict = {
     "progress": None,    # 0-100 percentage (None = indeterminate)
 }
 
-# ── ROCm GFX version overrides ───────────────────────────────────────
-# AMD GPUs on ROCm report through torch.cuda but may need
-# HSA_OVERRIDE_GFX_VERSION for unsupported GFX IDs.
-_ROCM_GFX_OVERRIDES = {
-    # RDNA 3 (RX 7000 series) — override to gfx1100
-    "gfx1101": "11.0.0", "gfx1102": "11.0.0", "gfx1103": "11.0.0",
-    # RDNA 2 (RX 6000 series) — override to gfx1030
-    "gfx1031": "10.3.0", "gfx1032": "10.3.0", "gfx1034": "10.3.0",
-    # Vega (RX Vega / Radeon VII) — override to gfx900
-    "gfx902": "9.0.0", "gfx906": "9.0.6",
-}
-
-
 def _configure_rocm_if_needed(torch):
     """Auto-set HSA_OVERRIDE_GFX_VERSION for AMD GPUs on ROCm.
 
     ROCm-enabled PyTorch reports `torch.cuda.is_available() == True` but
-    some consumer AMD GPUs have GFX IDs not in the official support matrix.
-    Setting HSA_OVERRIDE_GFX_VERSION lets them run with the closest
+    some consumer AMD GPUs have GFX IDs the installed build wasn't compiled
+    for. Setting HSA_OVERRIDE_GFX_VERSION lets them run with the closest
     supported architecture.
+
+    The override is applied **only when the native gfx is genuinely absent
+    from this build's arch list**. Newer ROCm wheels support parts that used
+    to need remapping (gfx1151/Strix Halo is native from ROCm 7.x), and
+    overriding a natively-supported GPU forces it onto foreign kernels for no
+    reason — so the map is a fallback, not an unconditional rewrite.
     """
+    from core.device_caps import ROCM_GFX_OVERRIDES, build_arch_list
+
     if os.environ.get("HSA_OVERRIDE_GFX_VERSION"):
         return  # User already set it manually
     try:
@@ -644,41 +639,56 @@ def _configure_rocm_if_needed(torch):
         props = torch.cuda.get_device_properties(0)
         gcn_arch = getattr(props, "gcnArchName", "") or ""
         gfx_id = gcn_arch.split(":")[0].strip().lower()
-        if gfx_id in _ROCM_GFX_OVERRIDES:
-            override = _ROCM_GFX_OVERRIDES[gfx_id]
-            os.environ["HSA_OVERRIDE_GFX_VERSION"] = override
-            logger.info("ROCm: auto-set HSA_OVERRIDE_GFX_VERSION=%s for %s (%s)",
-                        override, device_name, gfx_id)
+        if gfx_id not in ROCM_GFX_OVERRIDES:
+            return
+        arch_list = {a.split(":")[0].strip().lower() for a in build_arch_list(torch)}
+        if gfx_id in arch_list:
+            logger.info("ROCm: %s (%s) is natively supported by this build; "
+                        "no HSA_OVERRIDE_GFX_VERSION needed", device_name, gfx_id)
+            return
+        override = ROCM_GFX_OVERRIDES[gfx_id]
+        os.environ["HSA_OVERRIDE_GFX_VERSION"] = override
+        logger.info("ROCm: auto-set HSA_OVERRIDE_GFX_VERSION=%s for %s (%s)",
+                    override, device_name, gfx_id)
     except Exception as e:
         logger.debug("ROCm GFX auto-config skipped: %s", e)
 
 
 def check_device_compatibility():
-    """Check if PyTorch supports the current GPU's compute capability.
+    """Check if PyTorch supports the current GPU's architecture.
 
     Returns (compatible, warning_message). Compatible is True if OK or
-    no discrete GPU is present.
+    no discrete GPU is present. The arch comparison itself lives in
+    ``core.device_caps.arch_unsupported()`` — shared with the probe, and
+    CUDA/ROCm-aware (a ROCm build lists ``gfx…``, not ``sm_…`` — #1228).
     """
+    from core.device_caps import arch_unsupported
+
     torch = _lazy_torch()
     if not torch.cuda.is_available():
         return True, None
+    mismatch = arch_unsupported(torch)
+    if mismatch is None:
+        return True, None
+    device_arch, arch_list = mismatch
     try:
-        major, minor = torch.cuda.get_device_capability(0)
         device_name = torch.cuda.get_device_name(0)
-        sm_tag = f"sm_{major}{minor}"
-        arch_list = getattr(torch.cuda, "_get_arch_list", lambda: [])()
-        if arch_list:
-            compute_tag = f"compute_{major}{minor}"
-            if sm_tag not in arch_list and compute_tag not in arch_list:
-                return False, (
-                    f"{device_name} (compute capability {major}.{minor} / {sm_tag}) "
-                    f"is not supported by this PyTorch build. "
-                    f"Supported architectures: {', '.join(arch_list)}. "
-                    f"Try: pip install torch --index-url https://download.pytorch.org/whl/nightly/cu128"
-                )
     except Exception:
-        pass
-    return True, None
+        device_name = "GPU"
+    if getattr(getattr(torch, "version", None), "hip", None) is not None:
+        return False, (
+            f"{device_name} ({device_arch}) is not supported by this ROCm "
+            f"PyTorch build. Supported architectures: {', '.join(arch_list)}. "
+            f"Set HSA_OVERRIDE_GFX_VERSION to the closest supported target "
+            f"(e.g. 11.0.0 for a gfx11xx card) or install a ROCm build that "
+            f"lists {device_arch}."
+        )
+    return False, (
+        f"{device_name} ({device_arch}) is not supported by this PyTorch build. "
+        f"Supported architectures: {', '.join(arch_list)}. "
+        f"Try: pip install torch --index-url "
+        f"https://download.pytorch.org/whl/nightly/cu128"
+    )
 
 
 def get_best_device():

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -101,7 +101,7 @@ the CUDA tags exactly.
 > (user-set on the container — it is deliberately **not** baked into the
 > image, because the right value depends on your card); a value you set is
 > always respected as-is.
-
+>
 > **Rootless / non-root hosts:** if `/dev/kfd` is group-owned, the container
 > user needs those groups too — add `--group-add` for your host's `render` and
 > `video` GIDs (`getent group render video`).

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -92,12 +92,19 @@ Volume=omnivoice-data:/app/omnivoice_data
 Release pins exist too: `:stable-rocm`, `:0.4.0-rocm`, `:0.4-rocm` mirror
 the CUDA tags exactly.
 
-> **RDNA3 consumer cards (RX 7900 XTX/XT, gfx1100):** the backend auto-sets
-> `HSA_OVERRIDE_GFX_VERSION` for consumer GFX IDs missing from ROCm's official
-> support matrix, so try without any override first. If the GPU still isn't
-> detected, force it explicitly with `-e HSA_OVERRIDE_GFX_VERSION=11.0.0`
+> **Consumer cards and APUs (RX 6000/7000, Strix Point/Halo):** the backend
+> auto-sets `HSA_OVERRIDE_GFX_VERSION` when — and only when — your card's GFX
+> ID is missing from the shipped ROCm build's architecture list, so try
+> without any override first. Overriding a natively-supported GPU (gfx1151 on
+> ROCm 7.x, for example) only forces it onto foreign kernels. If the GPU still
+> isn't used, force it explicitly with `-e HSA_OVERRIDE_GFX_VERSION=11.0.0`
 > (user-set on the container — it is deliberately **not** baked into the
-> image, because the right value depends on your card).
+> image, because the right value depends on your card); a value you set is
+> always respected as-is.
+
+> **Rootless / non-root hosts:** if `/dev/kfd` is group-owned, the container
+> user needs those groups too — add `--group-add` for your host's `render` and
+> `video` GIDs (`getent group render video`).
 
 Verify the container sees the GPU:
 
@@ -107,8 +114,10 @@ docker exec omnivoice python3 -c \
 ```
 
 (ROCm-built PyTorch reports through `torch.cuda.*` — `True` plus your card's
-name means GPU acceleration is active. The Settings → System panel shows the
-same device.)
+name means torch can see the GPU.) That check alone isn't proof the app is
+using it: **Settings → System** shows the device OmniVoice actually resolved.
+If it reads `cpu` while the command above prints `True`, the backend log line
+starting `Falling back to CPU:` names the architecture mismatch it hit.
 
 ## Docker Compose (recommended)
 

--- a/tests/test_rocm_arch_gate.py
+++ b/tests/test_rocm_arch_gate.py
@@ -86,10 +86,33 @@ def test_rocm_genuine_mismatch_still_detected():
 
 def test_rocm_gpu_we_can_remap_is_not_a_mismatch():
     """gfx1102 is absent from this build but _configure_rocm_if_needed() remaps
-    it to gfx1100 before any kernel launches."""
+    it to gfx1100, which this build DOES ship."""
     torch = _torch(hip="6.2", capability=(11, 2), gcn_arch="gfx1102",
                    arch_list=["gfx1030", "gfx1100"])
     assert device_caps.arch_unsupported(torch) is None
+
+
+def test_a_remap_target_the_build_lacks_is_still_a_mismatch():
+    """Review finding (#1230): being IN the override map was treated as proof
+    of compatibility. If the wheel ships neither the native arch nor the remap
+    target, the override only changes which kernel is missing — the host must
+    still fall back to CPU rather than launch into a guaranteed failure."""
+    torch = _torch(hip="6.2", capability=(11, 5), gcn_arch="gfx1151",
+                   arch_list=["gfx900", "gfx1030"])  # no gfx1100
+    assert device_caps.arch_unsupported(torch) == ("gfx1151", ("gfx900", "gfx1030"))
+
+
+def test_hsa_override_string_is_derived_from_the_target():
+    assert device_caps.hsa_override_for("gfx1100") == "11.0.0"
+    assert device_caps.hsa_override_for("gfx1030") == "10.3.0"
+    assert device_caps.hsa_override_for("gfx906") == "9.0.6"
+    assert device_caps.hsa_override_for("gfx900") == "9.0.0"
+
+
+def test_every_override_target_has_a_valid_hsa_form():
+    for source, target in device_caps.ROCM_GFX_OVERRIDES.items():
+        assert target.startswith("gfx"), source
+        device_caps.hsa_override_for(target)  # must not raise
 
 
 def test_rocm_user_hsa_override_is_trusted(monkeypatch):
@@ -188,6 +211,37 @@ def test_override_applied_when_build_lacks_the_arch(monkeypatch):
                arch_list=["gfx1030", "gfx1100"])
     )
     assert os.environ.get("HSA_OVERRIDE_GFX_VERSION") == "11.0.0"
+
+
+def test_no_override_when_the_target_is_also_missing():
+    """Review finding (#1230): pointing HSA_OVERRIDE_GFX_VERSION at an arch the
+    build doesn't ship is not a fix. Leave it unset so the compatibility check
+    reports the real mismatch and the CPU fallback engages."""
+    import os
+
+    import services.model_manager as mm
+
+    mm._configure_rocm_if_needed(
+        _torch(hip="6.2", capability=(11, 5), gcn_arch="gfx1151",
+               device_name="AMD Radeon 8060S", arch_list=["gfx900", "gfx1030"])
+    )
+    assert "HSA_OVERRIDE_GFX_VERSION" not in os.environ
+
+
+def test_unknown_arch_metadata_never_triggers_a_remap():
+    """Review finding (#1230): an EMPTY arch list means the build's metadata is
+    unavailable, not that the GPU is unsupported. Treating unknown as a
+    confirmed mismatch would push a natively-supported gfx1151 onto foreign
+    gfx1100 kernels. Fail open."""
+    import os
+
+    import services.model_manager as mm
+
+    mm._configure_rocm_if_needed(
+        _torch(hip="7.2.4", capability=(11, 5), gcn_arch="gfx1151",
+               device_name="AMD Radeon 8060S", arch_list=[])
+    )
+    assert "HSA_OVERRIDE_GFX_VERSION" not in os.environ
 
 
 def test_nvidia_never_gets_an_hsa_override():

--- a/tests/test_rocm_arch_gate.py
+++ b/tests/test_rocm_arch_gate.py
@@ -1,0 +1,202 @@
+"""#1228: ROCm hosts were force-routed to CPU on *every* AMD GPU.
+
+The SM-arch compatibility gate compared a CUDA-namespace tag (``sm_115``,
+derived from ``get_device_capability()``) against ``torch.cuda.get_arch_list()``
+— which on a ROCm wheel returns **gfx names** (``gfx1100``, ``gfx1201``, …).
+The two namespaces can never intersect, so ``check_device_compatibility()``
+returned False for every ROCm build and ``get_best_device()`` silently returned
+``"cpu"``. The reporter's Radeon 8060S (Strix Halo, gfx1151) was visible to
+torch, reported by ``torch.cuda.is_available()``, and still ran on the CPU.
+
+These tests pin the CUDA/ROCm-aware comparison (``core.device_caps
+.arch_unsupported``), its three consumers, and the narrowed HSA override.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from core import device_caps
+from core.device_caps import KERNEL_RISK_MARKER
+
+# A rocm7.2 wheel's real arch list shape; gfx1151 is natively supported there.
+ROCM_ARCHS = ["gfx900", "gfx906", "gfx90a", "gfx942", "gfx1030",
+              "gfx1100", "gfx1101", "gfx1102", "gfx1151", "gfx1200"]
+
+
+def _torch(*, hip=None, capability=(11, 5), gcn_arch="gfx1151:xnack-",
+           arch_list=None, device_name="Radeon 8060S Graphics",
+           cuda_available=True):
+    """Minimal torch mock: CUDA build when ``hip`` is None, else a ROCm build."""
+    cuda = types.SimpleNamespace(
+        is_available=lambda: cuda_available,
+        device_count=lambda: 1,
+        get_device_name=lambda i=0: device_name,
+        mem_get_info=lambda: (4 * 1024 ** 3, 8 * 1024 ** 3),
+        get_device_capability=lambda i=0: capability,
+        get_device_properties=lambda i=0: types.SimpleNamespace(gcnArchName=gcn_arch),
+        get_arch_list=lambda: list(arch_list if arch_list is not None else []),
+    )
+    version = types.SimpleNamespace()
+    if hip is not None:
+        version.hip = hip
+    return types.SimpleNamespace(
+        cuda=cuda,
+        version=version,
+        backends=types.SimpleNamespace(
+            mps=types.SimpleNamespace(is_available=lambda: False)
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_hsa_override(monkeypatch):
+    # Bind the real cached probe up front — a test may monkeypatch the module
+    # attribute, and this fixture's teardown runs before monkeypatch's undo.
+    clear = device_caps.detect_host_caps.cache_clear
+    monkeypatch.delenv("HSA_OVERRIDE_GFX_VERSION", raising=False)
+    clear()
+    yield
+    clear()
+
+
+# ── the comparison itself ────────────────────────────────────────────────
+
+
+def test_rocm_gfx_in_build_is_supported():
+    """The regression: sm_115 vs a gfx list used to read as a mismatch."""
+    torch = _torch(hip="7.2.4", arch_list=ROCM_ARCHS)
+    assert device_caps.arch_unsupported(torch) is None
+
+
+def test_rocm_feature_suffixes_are_ignored():
+    """``gfx90a:xnack+`` on either side must still match ``gfx90a``."""
+    torch = _torch(hip="6.2", capability=(9, 0), gcn_arch="gfx90a:sramecc+:xnack-",
+                   arch_list=["gfx908", "gfx90a:xnack+"])
+    assert device_caps.arch_unsupported(torch) is None
+
+
+def test_rocm_genuine_mismatch_still_detected():
+    """A real ROCm arch mismatch must not be papered over by the fix."""
+    torch = _torch(hip="6.2", capability=(10, 1), gcn_arch="gfx1010",
+                   arch_list=["gfx1030", "gfx1100"])
+    assert device_caps.arch_unsupported(torch) == ("gfx1010", ("gfx1030", "gfx1100"))
+
+
+def test_rocm_gpu_we_can_remap_is_not_a_mismatch():
+    """gfx1102 is absent from this build but _configure_rocm_if_needed() remaps
+    it to gfx1100 before any kernel launches."""
+    torch = _torch(hip="6.2", capability=(11, 2), gcn_arch="gfx1102",
+                   arch_list=["gfx1030", "gfx1100"])
+    assert device_caps.arch_unsupported(torch) is None
+
+
+def test_rocm_user_hsa_override_is_trusted(monkeypatch):
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "11.0.0")
+    torch = _torch(hip="6.2", capability=(10, 1), gcn_arch="gfx1010",
+                   arch_list=["gfx1030", "gfx1100"])
+    assert device_caps.arch_unsupported(torch) is None
+
+
+def test_cuda_path_unchanged():
+    """Blackwell sm_120 on a ≤sm_90 build is still reported unsupported (#756)."""
+    torch = _torch(capability=(12, 0), arch_list=["sm_80", "sm_86", "sm_90"])
+    assert device_caps.arch_unsupported(torch) == ("sm_120", ("sm_80", "sm_86", "sm_90"))
+    ok = _torch(capability=(8, 6), arch_list=["sm_80", "sm_86", "sm_90"])
+    assert device_caps.arch_unsupported(ok) is None
+
+
+def test_compute_tag_still_matches():
+    torch = _torch(capability=(12, 0), arch_list=["sm_90", "compute_120"])
+    assert device_caps.arch_unsupported(torch) is None
+
+
+def test_empty_arch_list_and_broken_metadata_fail_open():
+    assert device_caps.arch_unsupported(_torch(hip="6.2", arch_list=[])) is None
+
+    broken = _torch(hip="6.2", arch_list=ROCM_ARCHS)
+    broken.cuda.get_device_properties = lambda i=0: (_ for _ in ()).throw(
+        RuntimeError("HIP driver died")
+    )
+    assert device_caps.arch_unsupported(broken) is None
+
+
+# ── consumer 1: the probe's kernel-risk note ─────────────────────────────
+
+
+def test_probe_emits_no_kernel_risk_note_on_supported_rocm_host(monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "torch",
+                        _torch(hip="7.2.4", arch_list=ROCM_ARCHS))
+    caps = device_caps.refresh()
+    assert caps.family == "rocm"
+    assert not any(KERNEL_RISK_MARKER in n for n in caps.notes), caps.notes
+
+
+# ── consumer 2: get_best_device() / check_device_compatibility() ─────────
+
+
+def test_rocm_host_routes_to_gpu_not_cpu(monkeypatch):
+    """End-to-end: the reporter's host must resolve to "cuda", not "cpu"."""
+    import services.model_manager as mm
+
+    torch = _torch(hip="7.2.4", arch_list=ROCM_ARCHS)
+    monkeypatch.setattr(mm, "_lazy_torch", lambda: torch)
+    monkeypatch.setattr(
+        "core.device_caps.detect_host_caps",
+        lambda: types.SimpleNamespace(family="rocm"),
+    )
+    monkeypatch.delenv("OMNIVOICE_FORCE_CUDA", raising=False)
+
+    assert mm.check_device_compatibility() == (True, None)
+    assert mm.get_best_device() == "cuda"
+
+
+def test_rocm_warning_names_the_rocm_remedy(monkeypatch):
+    """A genuine ROCm mismatch must not tell the user to install a CUDA wheel."""
+    import services.model_manager as mm
+
+    torch = _torch(hip="6.2", capability=(10, 1), gcn_arch="gfx1010",
+                   arch_list=["gfx1030", "gfx1100"])
+    monkeypatch.setattr(mm, "_lazy_torch", lambda: torch)
+    compatible, warning = mm.check_device_compatibility()
+    assert compatible is False
+    assert "HSA_OVERRIDE_GFX_VERSION" in warning
+    assert "cu128" not in warning
+
+
+# ── consumer 3: the HSA override is a fallback, not a rewrite ───────────
+
+
+def test_native_support_skips_the_hsa_override(monkeypatch):
+    """gfx1151 is native on ROCm 7.x — overriding it onto gfx1100 would force a
+    supported GPU onto foreign kernels."""
+    import services.model_manager as mm
+
+    mm._configure_rocm_if_needed(_torch(hip="7.2.4", arch_list=ROCM_ARCHS))
+    assert "HSA_OVERRIDE_GFX_VERSION" not in __import__("os").environ
+
+
+def test_override_applied_when_build_lacks_the_arch(monkeypatch):
+    import os
+
+    import services.model_manager as mm
+
+    mm._configure_rocm_if_needed(
+        _torch(hip="6.2", capability=(11, 2), gcn_arch="gfx1102",
+               device_name="AMD Radeon RX 7600",
+               arch_list=["gfx1030", "gfx1100"])
+    )
+    assert os.environ.get("HSA_OVERRIDE_GFX_VERSION") == "11.0.0"
+
+
+def test_nvidia_never_gets_an_hsa_override():
+    import os
+
+    import services.model_manager as mm
+
+    mm._configure_rocm_if_needed(
+        _torch(capability=(8, 9), device_name="NVIDIA GeForce RTX 4090",
+               arch_list=["sm_89"])
+    )
+    assert "HSA_OVERRIDE_GFX_VERSION" not in os.environ

--- a/tests/test_rocm_arch_gate.py
+++ b/tests/test_rocm_arch_gate.py
@@ -115,11 +115,44 @@ def test_every_override_target_has_a_valid_hsa_form():
         device_caps.hsa_override_for(target)  # must not raise
 
 
-def test_rocm_user_hsa_override_is_trusted(monkeypatch):
+def test_rocm_user_hsa_override_is_trusted_when_the_build_has_the_target(monkeypatch):
     monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "11.0.0")
     torch = _torch(hip="6.2", capability=(10, 1), gcn_arch="gfx1010",
                    arch_list=["gfx1030", "gfx1100"])
     assert device_caps.arch_unsupported(torch) is None
+
+
+def test_a_stale_hsa_override_does_not_buy_a_free_pass(monkeypatch):
+    """Review finding (#1228): ANY override was treated as proof of
+    compatibility. The reporter had HSA_OVERRIDE_GFX_VERSION=11.0.0 set from
+    older advice — if the installed build ships no gfx1100, honouring that
+    blindly routes them into kernels that don't exist instead of falling back
+    to CPU."""
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "11.0.0")
+    torch = _torch(hip="6.2", capability=(11, 5), gcn_arch="gfx1151",
+                   arch_list=["gfx900", "gfx1030"])  # no gfx1100
+    result = device_caps.arch_unsupported(torch)
+    assert result is not None
+    assert "gfx1100" in result[0]
+    assert "HSA_OVERRIDE_GFX_VERSION=11.0.0" in result[0]
+
+
+def test_an_unparseable_hsa_override_is_left_alone(monkeypatch):
+    """The user asked for something we don't understand; guessing is worse
+    than trusting them."""
+    monkeypatch.setenv("HSA_OVERRIDE_GFX_VERSION", "something-custom")
+    torch = _torch(hip="6.2", capability=(11, 5), gcn_arch="gfx1151",
+                   arch_list=["gfx900"])
+    assert device_caps.arch_unsupported(torch) is None
+
+
+def test_hsa_override_parsing_round_trips():
+    for target in ("gfx1100", "gfx1030", "gfx906", "gfx900"):
+        assert device_caps.gfx_for_hsa_override(
+            device_caps.hsa_override_for(target)
+        ) == target
+    for junk in ("garbage", "11.0", "", "11.0.0.0", "a.b.c"):
+        assert device_caps.gfx_for_hsa_override(junk) is None
 
 
 def test_cuda_path_unchanged():


### PR DESCRIPTION
Fixes #1228.

## Root cause

The GPU compatibility gate built a CUDA-namespace tag from `get_device_capability()` (`sm_115` on a gfx1151 Strix Halo) and looked for it in `torch.cuda.get_arch_list()` — which on a ROCm wheel returns gfx *names* (`gfx1100`, `gfx1151`, …). The two namespaces can never intersect, so `check_device_compatibility()` returned `False` on **every** ROCm build and `get_best_device()` silently returned `"cpu"`: torch saw the GPU, `torch.cuda.is_available()` was `True`, and the app ran on the CPU anyway.

This was not Strix-Halo-specific — it affected every AMD host on every platform.

## Fix

The comparison was copy-pasted in three places, all with the same bug. It now lives once in `core.device_caps.arch_unsupported()` and branches on the build (gfx names on ROCm, `sm_`/`compute_` tags on CUDA):

- `model_manager.check_device_compatibility` — the CPU force-route, plus a ROCm-specific remedy instead of telling AMD users to install a cu128 wheel
- `device_caps._probe` — the kernel-risk note that downgraded the routing badge on every ROCm host
- `engine_env._cuda_arch_supported_for_compile` — `torch.compile` was disabled on all AMD hosts by the same comparison

`_configure_rocm_if_needed` also applied `HSA_OVERRIDE_GFX_VERSION` from a static map without checking whether the GPU needed it, remapping cards the installed build supports natively (gfx1151 is native from ROCm 7.x) onto foreign kernels. It now applies only when the native GFX ID is genuinely absent from the arch list, and knows gfx1150/gfx1151 (Strix Point/Halo).

## Verification

`tests/test_rocm_arch_gate.py` (14 tests) — fails before, passes after. Pins the reporter's host resolving to `cuda`, a genuine ROCm mismatch still being caught, the #756 CUDA/Blackwell fallback unchanged, feature suffixes (`gfx90a:xnack+`), and fail-open on broken metadata.

Full backend suite: 3646 passed.

## Docs

`docs/install/docker.md` — the ROCm verification snippet told users that `torch.cuda.is_available() == True` meant acceleration was active, which is exactly the check that misled the reporter. It now points at Settings → System, and documents the `--group-add` needed for `/dev/kfd` on rootless hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed ROCm GPU compatibility gating by centralizing architecture mismatch detection in `core.device_caps.arch_unsupported()`, using ROCm-appropriate gfx matching plus guarded remap logic for `HSA_OVERRIDE_GFX_VERSION` (only applied when the parsed remap target exists in the installed Torch build). Updated downstream device selection and `torch.compile` support checks to rely on the unified probe, and added ROCm regression tests covering native support, feature-suffix gfx variants, true mismatches, override/remap trust semantics, and fail-open behavior when metadata is unavailable/broken. Refreshed Docker ROCm guidance (including rootless `/dev/kfd` group configuration) and improved verification instructions; human review is recommended for remap/override edge cases across ROCm versions and installed wheel architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->