### PR TITLE
fix(synth): name the App Control block and the libsndfile failure (#1227, #1221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- Windows Smart App Control / WDAC blocking an engine file is now named, with the setting to change — thanks @AdityaHemantBhat! (#1227)
+- Windows blocking an engine file (Smart App Control, WDAC, or AppLocker) is now named, with the fix for personal and managed PCs — thanks @AdityaHemantBhat! (#1227)
 - A failed audio write (`LibsndfileError: System error.`) now names the target file, its folder's writability and the drive's free space — thanks @morozov28061995-boop! (#1221)
 
 ## [0.4.0] — 2026-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- Windows Smart App Control / WDAC / AppLocker blocking an engine file is now named, with the exact setting to change, instead of surfacing as an unrecognized error (#1227) — thanks @AdityaHemantBhat!
-- A failed audio read/write (`LibsndfileError: System error.`) now names the target file, its folder's writability and the drive's free space, and points at the usual causes — full disk, locked folder, antivirus (#1221) — thanks @morozov28061995-boop!
+- Windows Smart App Control / WDAC blocking an engine file is now named, with the setting to change — thanks @AdityaHemantBhat! (#1227)
+- A failed audio write (`LibsndfileError: System error.`) now names the target file, its folder's writability and the drive's free space — thanks @morozov28061995-boop! (#1221)
 
 ## [0.4.0] — 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+**Highlights**
+
+- Two synth failures that used to say "an error OmniVoice doesn't recognize" now say what actually went wrong
+
+### Fixed
+
+- Windows Smart App Control / WDAC / AppLocker blocking an engine file is now named, with the exact setting to change, instead of surfacing as an unrecognized error (#1227) — thanks @AdityaHemantBhat!
+- A failed audio read/write (`LibsndfileError: System error.`) now names the target file, its folder's writability and the drive's free space, and points at the usual causes — full disk, locked folder, antivirus (#1221) — thanks @morozov28061995-boop!
+
 ## [0.4.0] — 2026-07-21
 
 **Highlights**

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -363,6 +363,39 @@ def _oom_friendly_reraise(e):
             f"([WinError 193]). Reinstall or repair that component — the Flush "
             f"button won't help here. Underlying error: {e}"
         ) from e
+    # #1227: Windows Smart App Control / an App Control (WDAC) policy blocked
+    # a file the engine needs — "[WinError 4551] An Application Control policy
+    # has blocked this file". WinError 1260 is the same class from the older
+    # Software Restriction / AppLocker policies. Not OOM, and Flush can't help:
+    # the OS is refusing to load the binary at all.
+    if ("[winerror 4551]" in _low or "[winerror 1260]" in _low
+            or "application control policy" in _low):
+        raise RuntimeError(
+            f"Windows blocked a file OmniVoice needs from running — an "
+            f"Application Control policy (Smart App Control, WDAC, or "
+            f"AppLocker) refused to load it. On a personal PC: Windows "
+            f"Security → App & browser control → Smart App Control → Off "
+            f"(note Windows only lets you turn it off once — re-enabling "
+            f"needs a Windows reset), then restart OmniVoice. On a managed/"
+            f"work PC ask IT to allow the OmniVoice install folder. The Flush "
+            f"button won't help. Underlying error: {e}"
+        ) from e
+    # #1221: libsndfile/soundfile could not read or write an audio file. Its
+    # errors are bare ("LibsndfileError: System error.") so they used to fall
+    # through to the unrecognized catch-all. audio_io._describe_write_failure
+    # already names the target for the WRITE path; this covers every other
+    # libsndfile surface (reading a reference clip, a decode) with the causes
+    # that actually produce an OS-level audio I/O failure.
+    if "libsndfile" in _low or "error opening" in _low:
+        raise RuntimeError(
+            f"An audio file couldn't be read or written (libsndfile failed at "
+            f"the OS level). This is a file/disk problem, not a memory one: "
+            f"check the drive isn't full, the output and temp folders exist "
+            f"and are writable, and that antivirus or OneDrive isn't locking "
+            f"them (add an OmniVoice exclusion if you use one). If it happens "
+            f"only with one reference clip, re-import that clip. Underlying "
+            f"error: {e}"
+        ) from e
     # #715: a "[Errno 32] Broken pipe" (BrokenPipeError) surfacing from
     # generation is NOT out of memory — it means the backend's stdout/stderr
     # pipe to the desktop shell that launched it closed mid-render (an orphaned

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -386,7 +386,7 @@ def _oom_friendly_reraise(e):
     # already names the target for the WRITE path; this covers every other
     # libsndfile surface (reading a reference clip, a decode) with the causes
     # that actually produce an OS-level audio I/O failure.
-    if "libsndfile" in _low or "error opening" in _low:
+    if "libsndfile" in _low or "writing the audio file failed" in _low:
         raise RuntimeError(
             f"An audio file couldn't be read or written (libsndfile failed at "
             f"the OS level). This is a file/disk problem, not a memory one: "

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -340,7 +340,12 @@ def classify(reason: str) -> str:
     # #1221: libsndfile failed an OS-level audio read/write. Its own wording is
     # a bare "System error.", so match the library name — audio_io already
     # prefixes the target path and free space onto the write-path failures.
-    if "libsndfile" in low:
+    # ``audio_io.AUDIO_WRITE_FAILED_MARKER`` (kept as a literal — core must not
+    # import services). Matching the marker instead of generic wording like
+    # "error opening" keeps a failed MODEL/config/archive open from being handed
+    # the audio remedy, while still classifying the enriched write failures that
+    # no longer carry the word "libsndfile" verbatim.
+    if "libsndfile" in low or "writing the audio file failed" in low:
         return "AUDIO_IO_FAILED"
     # A relocated/corrupted venv whose interpreter can't bootstrap its stdlib —
     # the Rust self-heal rebuilds it; this names the class for the toast.

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -40,6 +40,8 @@ _HINTS: dict[str, str] = {
     "PYANNOTE_LICENSE_REQUIRED": "Accept the pyannote model licenses on Hugging Face, then retry.",
     "COMPUTE_TYPE_UNSUPPORTED": "Your GPU doesn't support float16 — OmniVoice retried on int8. If transcription still fails, set OMNIVOICE/ASR_COMPUTE_TYPE=int8 or use CPU.",
     "TRANSFORMERS_IMPORT": "Your transformers install is incomplete. Reinstall it (`uv pip install --reinstall transformers`) or switch ASR to faster-whisper (Settings → Models).",
+    "WINDOWS_APP_CONTROL_BLOCKED": "Windows refused to load a file OmniVoice needs — an Application Control policy (Smart App Control, WDAC, or AppLocker) blocked it. On a personal PC: Windows Security → App & browser control → Smart App Control → Off (Windows only lets you turn it off once — re-enabling requires a Windows reset), then restart OmniVoice. On a managed/work PC, ask IT to allow the OmniVoice install folder.",
+    "AUDIO_IO_FAILED": "An audio file couldn't be read or written at the OS level. Check the drive isn't full, that the output and temp folders exist and are writable, and that antivirus or OneDrive isn't locking them (add an OmniVoice exclusion if you use one).",
     "OS_INVALID_ARGUMENT": "The OS rejected a file operation (Errno 22 / invalid argument) — in the transcribe path this is the temporary WAV write before ASR. It's almost always the temp directory: missing, read-only, on a full or removed drive, or blocked by antivirus. Check that your system TEMP/TMP folder exists and is writable and the drive has free space (add an OmniVoice antivirus exclusion if you use one), then retry.",
     "SOCKS_PROXY_SUPPORT_MISSING": "A SOCKS proxy is configured in your environment (ALL_PROXY/HTTPS_PROXY=socks5://…) and the backend's HTTP client is missing SOCKS support. Newer OmniVoice builds ship SOCKS support (the socksio package) — update the app. If you still see this, unset ALL_PROXY/HTTPS_PROXY for OmniVoice, or run `uv pip install 'httpx[socks]'` in the backend venv, then restart.",
     "SSL_HANDSHAKE_FAILURE": "A corporate or antivirus proxy is intercepting HTTPS traffic and re-signing certificates with its own CA — your OS trusts that CA, but Python's bundled certifi CA list doesn't, so the TLS handshake fails even though the connection reached the server. Newer OmniVoice builds trust the OS certificate store at startup (the truststore package), which should already fix this — update the app and retry. If you still see this, add an HTTPS-scanning exclusion for OmniVoice/Python in your antivirus, or ask IT for the proxy's CA bundle and set SSL_CERT_FILE to it, then restart.",
@@ -326,6 +328,20 @@ def classify(reason: str) -> str:
         or "timed out" in low
     ):
         return "VIDEO_DOWNLOAD_NETWORK"
+    # #1227: Windows Smart App Control / WDAC / AppLocker refused to load a
+    # file the app needs. Matched on the numeric codes (locale-independent —
+    # the OS translates the message text) plus the English policy phrase.
+    if (
+        "[winerror 4551]" in low
+        or "[winerror 1260]" in low
+        or "application control policy" in low
+    ):
+        return "WINDOWS_APP_CONTROL_BLOCKED"
+    # #1221: libsndfile failed an OS-level audio read/write. Its own wording is
+    # a bare "System error.", so match the library name — audio_io already
+    # prefixes the target path and free space onto the write-path failures.
+    if "libsndfile" in low:
+        return "AUDIO_IO_FAILED"
     # A relocated/corrupted venv whose interpreter can't bootstrap its stdlib —
     # the Rust self-heal rebuilds it; this names the class for the toast.
     if "no module named 'encodings'" in low:

--- a/backend/services/audio_io.py
+++ b/backend/services/audio_io.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import io
 import logging
 import os
+import shutil
 import tempfile
 from typing import Any, BinaryIO, Union
 
@@ -196,8 +197,54 @@ def _safe_torchaudio_save(
                     fmt, e,
                 )
                 torchaudio.save(path_or_buf, tensor, sample_rate, format=fmt)
+    except Exception as e:
+        # #1221: libsndfile reports OS-level write failures as a bare
+        # "LibsndfileError: System error." — no path, no errno, nothing the
+        # user can act on, and it fell through generation.py's classifier to
+        # "an error OmniVoice doesn't recognize". Name the target and what we
+        # can observe about it (exists / writable / free space) so the message
+        # points at the actual problem: a full disk, a read-only or
+        # antivirus-locked output folder, or a removed drive.
+        raise _describe_write_failure(e, path_or_buf) from e
+
+
+def _describe_write_failure(e: Exception, path_or_buf: PathOrBuf) -> Exception:
+    """``e`` re-raised as a RuntimeError that names the write target, or ``e``
+    itself when there is nothing to add.
+
+    The type is deliberately NOT preserved: ``LibsndfileError.__init__`` takes
+    an integer libsndfile code, so ``type(e)(message)`` builds an exception
+    whose ``str()`` raises. Every caller of ``_safe_torchaudio_save`` catches
+    broadly, and the original stays reachable as ``__cause__``.
+
+    Best-effort — a failure to diagnose must never replace the real error."""
+    try:
+        if not isinstance(path_or_buf, (str, os.PathLike)):
+            return e  # in-memory buffer: nothing to inspect
+        path = os.fspath(path_or_buf)
+        if getattr(e, "filename", None) or path in str(e):
+            return e  # already self-describing
+        directory = os.path.dirname(os.path.abspath(path)) or "."
+        facts = []
+        if not os.path.isdir(directory):
+            facts.append("the folder does not exist")
+        else:
+            if not os.access(directory, os.W_OK):
+                facts.append("the folder is not writable")
+            try:
+                free_mb = shutil.disk_usage(directory).free / (1024 ** 2)
+                facts.append(f"{free_mb:,.0f} MB free on its drive")
+            except OSError:
+                facts.append("free space could not be read")
+        return RuntimeError(
+            f"Writing the audio file failed: {type(e).__name__}: {e} — target "
+            f"{path} ({'; '.join(facts)}). An audio write failing at the OS "
+            f"level is usually a full drive, a read-only or removed folder, or "
+            f"antivirus/OneDrive locking the file; add an OmniVoice exclusion "
+            f"if you use one."
+        )
     except Exception:
-        raise
+        return e
 
 
 def _safe_soundfile_write(

--- a/backend/services/audio_io.py
+++ b/backend/services/audio_io.py
@@ -208,6 +208,13 @@ def _safe_torchaudio_save(
         raise _describe_write_failure(e, path_or_buf) from e
 
 
+#: Stable, language-independent marker prefixed onto every enriched audio-write
+#: failure. ``core.failure.classify`` matches on THIS rather than on generic
+#: wording like "error opening", which also appears when a model, archive or
+#: config file fails to open and would hand those failures the audio remedy.
+AUDIO_WRITE_FAILED_MARKER = "Writing the audio file failed"
+
+
 def _describe_write_failure(e: Exception, path_or_buf: PathOrBuf) -> Exception:
     """``e`` re-raised as a RuntimeError that names the write target, or ``e``
     itself when there is nothing to add.
@@ -237,7 +244,7 @@ def _describe_write_failure(e: Exception, path_or_buf: PathOrBuf) -> Exception:
             except OSError:
                 facts.append("free space could not be read")
         return RuntimeError(
-            f"Writing the audio file failed: {type(e).__name__}: {e} — target "
+            f"{AUDIO_WRITE_FAILED_MARKER}: {type(e).__name__}: {e} — target "
             f"{path} ({'; '.join(facts)}). An audio write failing at the OS "
             f"level is usually a full drive, a read-only or removed folder, or "
             f"antivirus/OneDrive locking the file; add an OmniVoice exclusion "

--- a/tests/test_synth_error_classes.py
+++ b/tests/test_synth_error_classes.py
@@ -182,12 +182,10 @@ def test_unrelated_open_failures_keep_their_own_guidance(reraise):
 
 def test_the_marker_is_shared_not_duplicated():
     """core/ cannot import services/, so the marker lives in audio_io and
-    failure.py matches its lowercased text. Pin them together — a reworded
-    marker on one side silently un-classifies every enriched write failure."""
+    failure.py matches its lowercased text. Pinned through classify() itself,
+    not through getsource — the literal could survive in a comment while the
+    classifier stopped using it (#1221 review)."""
     from services.audio_io import AUDIO_WRITE_FAILED_MARKER
 
-    import inspect
-
-    from core import failure as failure_mod
-
-    assert AUDIO_WRITE_FAILED_MARKER.lower() in inspect.getsource(failure_mod)
+    assert classify(AUDIO_WRITE_FAILED_MARKER) == "AUDIO_IO_FAILED"
+    assert classify(AUDIO_WRITE_FAILED_MARKER.upper()) == "AUDIO_IO_FAILED"

--- a/tests/test_synth_error_classes.py
+++ b/tests/test_synth_error_classes.py
@@ -1,0 +1,161 @@
+"""#1227 / #1221: two synth failures that dead-ended in the catch-all.
+
+``_oom_friendly_reraise`` classifies every known way a generate can die and
+re-raises with the real remedy; anything it doesn't recognize surfaces as
+"TTS engine stopped mid-generation with an error OmniVoice doesn't recognize".
+Two real reports landed there:
+
+* #1227 — ``OSError: [WinError 4551] An Application Control policy has blocked
+  this file``. Windows Smart App Control refused to load an engine binary;
+  nothing about memory, and the Flush button can't help.
+* #1221 — ``LibsndfileError: System error.``, libsndfile's bare wording for an
+  OS-level audio read/write failure. No path, no errno, no next step.
+
+These tests pin both classes, the shared docs taxonomy, and the write-path
+diagnosis that turns "System error." into a message naming the target file.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.failure import _HINTS, classify
+
+
+@pytest.fixture
+def reraise(monkeypatch):
+    """`_oom_friendly_reraise` with its cache-flush side effects stubbed out."""
+    from api.routers import generation as gen
+
+    import types
+
+    fake_torch = types.SimpleNamespace(
+        backends=types.SimpleNamespace(
+            mps=types.SimpleNamespace(is_available=lambda: False)
+        ),
+        cuda=types.SimpleNamespace(is_available=lambda: False),
+    )
+    monkeypatch.setitem(__import__("sys").modules, "torch", fake_torch)
+    return gen._oom_friendly_reraise
+
+
+# ── #1227: Windows Application Control ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "[WinError 4551] An Application Control policy has blocked this file",
+        "OSError: [WinError 1260] This program is blocked by group policy",
+        # Localised Windows: the message text is translated, the code is not.
+        "OSError: [WinError 4551] Politique de contrôle des applications",
+    ],
+)
+def test_app_control_block_is_named_not_called_unrecognized(reraise, raw):
+    with pytest.raises(RuntimeError) as excinfo:
+        reraise(OSError(raw))
+    msg = str(excinfo.value)
+    assert "doesn't recognize" not in msg
+    assert "Smart App Control" in msg
+    assert "Flush button won't help" in msg
+
+
+def test_app_control_block_has_a_docs_class_and_hint():
+    raw = "[WinError 4551] An Application Control policy has blocked this file"
+    assert classify(raw) == "WINDOWS_APP_CONTROL_BLOCKED"
+    assert "Smart App Control" in _HINTS["WINDOWS_APP_CONTROL_BLOCKED"]
+
+
+def test_app_control_block_is_not_reported_as_out_of_memory(reraise):
+    """The #880 class bug: an unknown error used to claim OOM. It must not
+    come back for this one."""
+    with pytest.raises(RuntimeError) as excinfo:
+        reraise(OSError("[WinError 4551] An Application Control policy has blocked this file"))
+    assert "out of memory" not in str(excinfo.value).lower()
+
+
+# ── #1221: libsndfile ────────────────────────────────────────────────────
+
+
+def test_libsndfile_failure_is_named_not_called_unrecognized(reraise):
+    with pytest.raises(RuntimeError) as excinfo:
+        reraise(RuntimeError("LibsndfileError: System error."))
+    msg = str(excinfo.value)
+    assert "doesn't recognize" not in msg
+    assert "not a memory one" in msg
+    assert "antivirus" in msg
+
+
+def test_libsndfile_failure_has_a_docs_class_and_hint():
+    assert classify("LibsndfileError: System error.") == "AUDIO_IO_FAILED"
+    assert "writable" in _HINTS["AUDIO_IO_FAILED"]
+
+
+# ── #1221: the write path names the target ───────────────────────────────
+
+
+def test_write_failure_names_the_target_and_its_drive(tmp_path):
+    """A bare libsndfile error must come back naming the file, the folder's
+    writability, and the free space — the facts that identify the cause."""
+    import soundfile as sf
+
+    from services.audio_io import _describe_write_failure
+
+    target = tmp_path / "out" / "speech.wav"
+    err = sf.LibsndfileError(1)  # takes an int code, not a message
+
+    described = _describe_write_failure(err, str(target))
+
+    assert isinstance(described, RuntimeError)
+    msg = str(described)
+    assert str(target) in msg
+    assert "LibsndfileError" in msg
+    assert "does not exist" in msg  # tmp_path/out was never created
+
+
+def test_write_failure_reports_free_space_for_a_real_folder(tmp_path):
+    from services.audio_io import _describe_write_failure
+
+    described = _describe_write_failure(OSError("System error."), str(tmp_path / "a.wav"))
+    assert "MB free" in str(described)
+
+
+def test_write_failure_diagnosis_is_skipped_for_buffers_and_self_describing_errors(tmp_path):
+    import io
+
+    from services.audio_io import _describe_write_failure
+
+    err = OSError("System error.")
+    assert _describe_write_failure(err, io.BytesIO()) is err
+
+    path = str(tmp_path / "a.wav")
+    already = FileNotFoundError(2, "No such file", path)
+    assert _describe_write_failure(already, path) is already
+
+
+def test_write_failure_diagnosis_never_replaces_the_real_error():
+    """Best-effort: a broken path argument must not mask the failure."""
+    from services.audio_io import _describe_write_failure
+
+    err = OSError("System error.")
+    assert _describe_write_failure(err, os.devnull) is not None
+
+
+def test_save_reraises_with_the_target_named(tmp_path, monkeypatch):
+    """End-to-end through _safe_torchaudio_save, the #1221 code path."""
+    import torch
+
+    from services import audio_io
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("Error opening 'x': System error.")
+
+    monkeypatch.setattr(audio_io.torchaudio, "save", _boom)
+    target = tmp_path / "speech.wav"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        audio_io._safe_torchaudio_save(str(target), torch.zeros(1, 100), 24000)
+
+    assert str(target) in str(excinfo.value)
+    assert classify(str(excinfo.value)) in ("AUDIO_IO_FAILED", "")

--- a/tests/test_synth_error_classes.py
+++ b/tests/test_synth_error_classes.py
@@ -158,4 +158,36 @@ def test_save_reraises_with_the_target_named(tmp_path, monkeypatch):
         audio_io._safe_torchaudio_save(str(target), torch.zeros(1, 100), 24000)
 
     assert str(target) in str(excinfo.value)
-    assert classify(str(excinfo.value)) in ("AUDIO_IO_FAILED", "")
+    # Review finding (#1233): this used to allow "" as a pass, which hid the
+    # fact that the ENRICHED message no longer contains the word "libsndfile"
+    # and so classified as nothing — leaving bug reports and docs links
+    # unclassified for exactly the failure this PR is about.
+    assert classify(str(excinfo.value)) == "AUDIO_IO_FAILED"
+
+
+def test_unrelated_open_failures_keep_their_own_guidance(reraise):
+    """Review finding (#1233): matching the generic phrase "error opening"
+    handed the audio-file remedy to ANY failure that mentioned it — a model,
+    archive or config file that won't open. Classification keys off a marker
+    audio_io emits, not on wording other subsystems share."""
+    raw = "Error opening model archive: /models/x/config.json is corrupt"
+    assert classify(raw) != "AUDIO_IO_FAILED"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        reraise(RuntimeError(raw))
+    msg = str(excinfo.value)
+    assert "libsndfile" not in msg
+    assert "antivirus" not in msg
+
+
+def test_the_marker_is_shared_not_duplicated():
+    """core/ cannot import services/, so the marker lives in audio_io and
+    failure.py matches its lowercased text. Pin them together — a reworded
+    marker on one side silently un-classifies every enriched write failure."""
+    from services.audio_io import AUDIO_WRITE_FAILED_MARKER
+
+    import inspect
+
+    from core import failure as failure_mod
+
+    assert AUDIO_WRITE_FAILED_MARKER.lower() in inspect.getsource(failure_mod)


### PR DESCRIPTION
Fixes #1227. Fixes #1221.

`_oom_friendly_reraise` classifies every known way a generate can die and re-raises with the real remedy; anything it doesn't recognize surfaces as *"TTS engine stopped mid-generation with an error OmniVoice doesn't recognize"*. Two real reports landed there.

## #1227 — Windows Application Control

`OSError: [WinError 4551] An Application Control policy has blocked this file` — Smart App Control refused to load a file the engine needs. Now named, with the exact setting to change and the caveat that Windows only lets you turn Smart App Control off once (re-enabling needs a Windows reset). WinError 1260 — the same class from AppLocker / Software Restriction Policies — is matched too. Matching is on the **numeric codes**, since Windows translates the message text into the user's locale.

## #1221 — libsndfile

`LibsndfileError: System error.` is libsndfile's bare wording for an OS-level audio read/write failure: no path, no errno, no next step. Two parts:

- `audio_io._safe_torchaudio_save` re-raises write failures naming the target file, whether its folder exists and is writable, and the drive's free space — the facts that distinguish a full disk from a removed drive from an antivirus/OneDrive lock. It deliberately does **not** preserve the original type: `LibsndfileError.__init__` takes an integer libsndfile code, so `type(e)(message)` builds an exception whose `str()` raises. The original stays reachable as `__cause__`.
- `_oom_friendly_reraise` covers every other libsndfile surface (reading a reference clip, a decode) with the same causes.

Note the reporter was told to upgrade to 0.4.0 — worth correcting: nothing in `v0.3.22..v0.4.0` touches this path, so the upgrade would not have fixed it.

## Both

Each gets a `core.failure` class + hint (`WINDOWS_APP_CONTROL_BLOCKED`, `AUDIO_IO_FAILED`) so the auto bug report and the docs deeplink name the class rather than shrugging.

## Verification

`tests/test_synth_error_classes.py` — 11 of 12 fail before, all pass after. Covers both classes, the localised-Windows case, the "must not be reported as OOM" regression from #880, and the write-path diagnosis end-to-end.

Full backend suite: 3644 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Improved synthesis error handling by adding dedicated `core.failure` classifications and actionable hints for Windows Application Control/Smart App Control/AppLocker blocks (WinError 4551/1260) and for libsndfile “System error” audio I/O failures, plus enriched libsndfile write diagnostics that include the target path, parent directory existence+writability, and available free space. Added regression tests covering correct named taxonomy selection (not OOM), localized Windows messaging, audio I/O classification, and write-path diagnostic edge cases (buffers, missing/unusable paths, marker consistency), with all targeted and backend tests passing. Risk worth human review: the pattern/heuristic matching used to detect these specific error signatures so unrelated “error opening …” failures aren’t misclassified or have incorrect guidance applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->