### PR TITLE
fix(dub): name the folder when a URL ingest fails on a disk error (#1225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+**Highlights**
+
+- A dub URL ingest that fails on a disk problem now says which folder and why
+
+### Fixed
+
+- Dub URL ingest: `[Errno 22] Invalid argument` was classified as the transcribe path's temp-file error, so the hint told users to check their system TEMP folder while the real failure was the job folder under the OmniVoice data directory; it now names that folder, its writability and the drive's free space, and says retrying the same link won't help (#1225) — thanks @dustmaker124-ui!
+- Dub URL ingest fails immediately with a clear message when the job folder is missing or unwritable, instead of starting a download that can only fail (#1225)
+
 ## [0.4.0] — 2026-07-21
 
 **Highlights**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- Dub URL ingest: `[Errno 22] Invalid argument` was classified as the transcribe path's temp-file error, so the hint told users to check their system TEMP folder while the real failure was the job folder under the OmniVoice data directory; it now names that folder, its writability and the drive's free space, and says retrying the same link won't help (#1225) — thanks @dustmaker124-ui!
-- Dub URL ingest fails immediately with a clear message when the job folder is missing or unwritable, instead of starting a download that can only fail (#1225)
+- Dub URL ingest: a disk error now names the job folder, its writability and the drive's free space, instead of pointing at the system TEMP folder it never used — thanks @dustmaker124-ui! (#1225)
+- Dub URL ingest fails immediately when the job folder is missing or unwritable, instead of starting a download that can only fail (#1225)
 
 ## [0.4.0] — 2026-07-21
 

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -254,17 +254,8 @@ def classify(reason: str) -> str:
     # under the OmniVoice data dir, not the system temp dir. Checked first so
     # a download's errno 22 stops being handed the transcribe path's
     # "check your TEMP folder" hint, which sends the user to the wrong place.
-    if any(sig in low for sig in (
-        "errno 22", "invalid argument",
-        "errno 13", "permission denied",
-        "errno 28", "no space left",
-        "errno 2", "no such file or directory",
-    )) and (
-        "unable to download video" in low
-        or "unable to open for writing" in low
-        or "unable to rename file" in low
-        or "yt_dlp" in low
-        or "yt-dlp" in low
+    if is_os_write_refusal(reason) and any(
+        marker in low for marker in _DOWNLOAD_CONTEXT_MARKERS
     ):
         return "VIDEO_DOWNLOAD_OS_ERROR"
     if "errno 22" in low:
@@ -429,6 +420,39 @@ def diagnostic(*, reason: str, error_class: str, stage: str) -> str:
         f"{_env_summary()}\n"
     )
     return sanitize(block)
+
+
+# Signatures of the OS refusing a file operation. One list, because two
+# consumers must agree: ``classify`` (which picks the class + hint) and
+# ``dub_pipeline._with_target_facts`` (which decides whether to attach the
+# destination). When they drifted, an ENOENT download classified as a disk
+# problem but never got the folder named — the one fact that would have made
+# the message actionable (#1225 review).
+_OS_WRITE_REFUSAL_SIGNATURES = (
+    "errno 22", "invalid argument",
+    "errno 13", "permission denied",
+    "errno 28", "no space left",
+    "errno 2", "no such file or directory",
+    "unable to open for writing",
+    "unable to rename file",
+)
+
+# Wording that places a failure in the video-download path specifically.
+_DOWNLOAD_CONTEXT_MARKERS = (
+    "unable to download video",
+    "unable to open for writing",
+    "unable to rename file",
+    "yt_dlp",
+    "yt-dlp",
+)
+
+
+def is_os_write_refusal(reason: Optional[str]) -> bool:
+    """True when *reason* looks like the OS refusing a file operation (a full
+    or removed drive, a read-only folder, an antivirus/cloud-sync lock) rather
+    than a network or format failure. Signature match only; never raises."""
+    low = (reason or "").lower()
+    return any(sig in low for sig in _OS_WRITE_REFUSAL_SIGNATURES)
 
 
 def describe_path_target(path: str) -> str:

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 import platform
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -40,6 +41,7 @@ _HINTS: dict[str, str] = {
     "PYANNOTE_LICENSE_REQUIRED": "Accept the pyannote model licenses on Hugging Face, then retry.",
     "COMPUTE_TYPE_UNSUPPORTED": "Your GPU doesn't support float16 — OmniVoice retried on int8. If transcription still fails, set OMNIVOICE/ASR_COMPUTE_TYPE=int8 or use CPU.",
     "TRANSFORMERS_IMPORT": "Your transformers install is incomplete. Reinstall it (`uv pip install --reinstall transformers`) or switch ASR to faster-whisper (Settings → Models).",
+    "VIDEO_DOWNLOAD_OS_ERROR": "The OS refused a file operation while saving the downloaded video — this is a disk/folder problem, not a network one, so retrying the same link won't help. The download is written to a job folder under your OmniVoice data directory (Settings → Storage shows the path): check that drive isn't full, that the folder exists and is writable, and that antivirus or a cloud-sync client (OneDrive, Dropbox) isn't locking it — add an OmniVoice exclusion if you use one. If your data directory sits on a synced or network drive, move it to a local one.",
     "OS_INVALID_ARGUMENT": "The OS rejected a file operation (Errno 22 / invalid argument) — in the transcribe path this is the temporary WAV write before ASR. It's almost always the temp directory: missing, read-only, on a full or removed drive, or blocked by antivirus. Check that your system TEMP/TMP folder exists and is writable and the drive has free space (add an OmniVoice antivirus exclusion if you use one), then retry.",
     "SOCKS_PROXY_SUPPORT_MISSING": "A SOCKS proxy is configured in your environment (ALL_PROXY/HTTPS_PROXY=socks5://…) and the backend's HTTP client is missing SOCKS support. Newer OmniVoice builds ship SOCKS support (the socksio package) — update the app. If you still see this, unset ALL_PROXY/HTTPS_PROXY for OmniVoice, or run `uv pip install 'httpx[socks]'` in the backend venv, then restart.",
     "SSL_HANDSHAKE_FAILURE": "A corporate or antivirus proxy is intercepting HTTPS traffic and re-signing certificates with its own CA — your OS trusts that CA, but Python's bundled certifi CA list doesn't, so the TLS handshake fails even though the connection reached the server. Newer OmniVoice builds trust the OS certificate store at startup (the truststore package), which should already fix this — update the app and retry. If you still see this, add an HTTPS-scanning exclusion for OmniVoice/Python in your antivirus, or ask IT for the proxy's CA bundle and set SSL_CERT_FILE to it, then restart.",
@@ -247,6 +249,24 @@ def classify(reason: str) -> str:
     # argument" wording) keeps this from mislabelling unrelated failures; the
     # transformers "errno 2" rule below is unaffected — it also requires the
     # transformers + site-packages markers, which this signature lacks.
+    # #1225: the same errno raised by the DUB video download is a different
+    # class with a different remedy — the failing directory is the job folder
+    # under the OmniVoice data dir, not the system temp dir. Checked first so
+    # a download's errno 22 stops being handed the transcribe path's
+    # "check your TEMP folder" hint, which sends the user to the wrong place.
+    if any(sig in low for sig in (
+        "errno 22", "invalid argument",
+        "errno 13", "permission denied",
+        "errno 28", "no space left",
+        "errno 2", "no such file or directory",
+    )) and (
+        "unable to download video" in low
+        or "unable to open for writing" in low
+        or "unable to rename file" in low
+        or "yt_dlp" in low
+        or "yt-dlp" in low
+    ):
+        return "VIDEO_DOWNLOAD_OS_ERROR"
     if "errno 22" in low:
         return "OS_INVALID_ARGUMENT"
     # An HF cache whose snapshot entries don't resolve (dangling symlinks /
@@ -409,6 +429,34 @@ def diagnostic(*, reason: str, error_class: str, stage: str) -> str:
         f"{_env_summary()}\n"
     )
     return sanitize(block)
+
+
+def describe_path_target(path: str) -> str:
+    """Observable facts about where we were writing — "the folder does not
+    exist", "the folder is not writable", "1,234 MB free on its drive".
+
+    A bare OS error ("[Errno 22] Invalid argument", "System error.") names
+    neither the target nor the reason, which is what makes those reports
+    un-actionable (#1225). Attaching what we CAN see distinguishes a full
+    drive from a removed one from an antivirus/OneDrive lock. Never raises —
+    diagnosis must never replace the failure being diagnosed.
+    """
+    facts: list[str] = []
+    try:
+        directory = os.path.dirname(os.path.abspath(path)) or "."
+        if not os.path.isdir(directory):
+            facts.append("the folder does not exist")
+        else:
+            if not os.access(directory, os.W_OK):
+                facts.append("the folder is not writable")
+            try:
+                free_mb = shutil.disk_usage(directory).free / (1024 ** 2)
+                facts.append(f"{free_mb:,.0f} MB free on its drive")
+            except OSError:
+                facts.append("free space could not be read")
+    except Exception:
+        return ""
+    return "; ".join(facts)
 
 
 def build_failure(

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -510,12 +510,10 @@ def _with_target_facts(exc: BaseException, job_dir: str) -> BaseException:
     already about the remote side, and appending disk facts would just be
     noise. Never raises."""
     try:
-        low = str(exc).lower()
-        if not any(sig in low for sig in (
-            "errno 22", "invalid argument", "errno 13", "permission denied",
-            "errno 28", "no space left", "unable to open for writing",
-            "unable to rename file",
-        )):
+        # Shared with failure.classify() so the "is this a disk problem?"
+        # answer can't differ between the class we assign and whether we
+        # bother naming the folder (#1225 review).
+        if not failure.is_os_write_refusal(str(exc)):
             return exc
         facts = failure.describe_path_target(os.path.join(job_dir, "original.mp4"))
         if not facts:
@@ -609,11 +607,14 @@ def yt_download_sync(
     # can already see it won't work.
     _target_facts = failure.describe_path_target(outtmpl)
     if "not writable" in _target_facts or "does not exist" in _target_facts:
+        # Worded so classify() places it in the download path: it must carry
+        # both an OS-refusal signature and download context, or the user gets
+        # no hint at all — the failure this PR exists to fix (#1225 review).
         raise OSError(
-            f"Can't save the download: {job_dir} ({_target_facts}). The video "
-            f"downloads into this job folder under your OmniVoice data "
-            f"directory — check it exists, is writable, and isn't locked by "
-            f"antivirus or a cloud-sync client."
+            f"Unable to download video: unable to open for writing in "
+            f"{job_dir} ({_target_facts}). The video downloads into this job "
+            f"folder under your OmniVoice data directory — check it exists, is "
+            f"writable, and isn't locked by antivirus or a cloud-sync client."
         )
     ydl_opts: dict = {
         "outtmpl": outtmpl,

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -502,6 +502,40 @@ def _ensure_browser_playable_mp4(video_path: str) -> str:
 _YT_DOWNLOAD_RETRIES = 2  # total attempts = 1 + retries = 3
 
 
+def _with_target_facts(exc: BaseException, job_dir: str) -> BaseException:
+    """``exc`` with the download destination described, when the failure looks
+    like the OS refusing a file operation (#1225).
+
+    Returns ``exc`` untouched for network/format failures — their message is
+    already about the remote side, and appending disk facts would just be
+    noise. Never raises."""
+    try:
+        low = str(exc).lower()
+        if not any(sig in low for sig in (
+            "errno 22", "invalid argument", "errno 13", "permission denied",
+            "errno 28", "no space left", "unable to open for writing",
+            "unable to rename file",
+        )):
+            return exc
+        facts = failure.describe_path_target(os.path.join(job_dir, "original.mp4"))
+        if not facts:
+            return exc
+        msg = (
+            f"{exc} — saving to {job_dir} ({facts}). The OS refused the write, "
+            f"so retrying the same link won't help: check the drive isn't full, "
+            f"the folder is writable, and antivirus or a cloud-sync client "
+            f"(OneDrive, Dropbox) isn't locking it."
+        )
+        try:
+            return type(exc)(msg)
+        except Exception:
+            # Not every exception class takes a plain message (soundfile's
+            # LibsndfileError wants an int code). Keep the text, drop the type.
+            return RuntimeError(msg)
+    except Exception:
+        return exc
+
+
 def _is_transient_download_error(exc: BaseException) -> bool:
     """True when a download failure is worth retrying (broken pipe / net drop).
 
@@ -568,6 +602,19 @@ def yt_download_sync(
     import glob
     import yt_dlp
     outtmpl = os.path.join(job_dir, "original.%(ext)s")
+    # #1225: yt-dlp surfaces an OS write rejection as a bare
+    # "Unable to download video: [Errno 22] Invalid argument" — no path, no
+    # reason, and three manual retries all fail identically because nothing
+    # about it is transient. Fail here instead, naming the directory, when we
+    # can already see it won't work.
+    _target_facts = failure.describe_path_target(outtmpl)
+    if "not writable" in _target_facts or "does not exist" in _target_facts:
+        raise OSError(
+            f"Can't save the download: {job_dir} ({_target_facts}). The video "
+            f"downloads into this job folder under your OmniVoice data "
+            f"directory — check it exists, is writable, and isn't locked by "
+            f"antivirus or a cloud-sync client."
+        )
     ydl_opts: dict = {
         "outtmpl": outtmpl,
         # Prefer h264+aac streams so the merged mp4 is natively decodable
@@ -658,7 +705,15 @@ def yt_download_sync(
                 )
                 time.sleep(2 * transient_used)  # brief, increasing backoff
                 continue
-            raise
+            # #1225: an OS-level rejection (errno 22 / EACCES / ENOSPC) tells
+            # the user nothing on its own. Attach what we can observe about
+            # the destination so the message identifies a full drive, a
+            # removed folder, or an antivirus/cloud-sync lock. Wording keeps
+            # the yt-dlp text so classify() still sees the download context.
+            described = _with_target_facts(exc, job_dir)
+            if described is exc:
+                raise
+            raise described from exc
     root, _ = os.path.splitext(path)
     mp4 = root + ".mp4"
     if os.path.exists(mp4):

--- a/tests/test_dub_download_os_error.py
+++ b/tests/test_dub_download_os_error.py
@@ -1,0 +1,161 @@
+"""#1225: `download: Unable to download video: [Errno 22] Invalid argument`.
+
+A Windows user hit this on three consecutive URL ingests. Two things made it a
+dead end:
+
+* `classify()` matched the generic `"errno 22"` rule (#763, written for the
+  ASR path) BEFORE any download rule, so the attached hint told the user to
+  check their system TEMP folder — while the failing directory is the job
+  folder under the OmniVoice data dir. The one actionable instruction pointed
+  at the wrong place.
+* The message named neither the target nor the reason, so nothing in it could
+  distinguish a full drive from a read-only folder from an antivirus lock.
+
+These tests pin the download-specific class, that the ASR path keeps its own,
+and the destination facts now attached to the failure.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from core.failure import _HINTS, build_failure, classify, describe_path_target
+from services import dub_pipeline
+
+
+class _ReachedYtDlp(Exception):
+    """Raised in place of any real yt-dlp call — no test here may hit the
+    network, and a test that silently does is a test that stopped testing."""
+
+
+def _block_network(monkeypatch):
+    import yt_dlp
+
+    def _explode(*_a, **_k):
+        raise _ReachedYtDlp("yt-dlp was invoked")
+
+    monkeypatch.setattr(dub_pipeline, "find_ffmpeg", lambda: None)
+    monkeypatch.setattr(yt_dlp, "YoutubeDL", _explode)
+
+
+# ── classification ───────────────────────────────────────────────────────
+
+
+def test_download_errno22_is_not_given_the_transcribe_hint():
+    reason = "Unable to download video: [Errno 22] Invalid argument"
+    assert classify(reason) == "VIDEO_DOWNLOAD_OS_ERROR"
+
+    fields = build_failure(OSError(reason), stage="download")
+    assert "TEMP" not in fields["hint"]
+    assert "data directory" in fields["hint"]
+
+
+def test_transcribe_errno22_keeps_its_own_class():
+    """#763's class must not be swallowed by the new download rule."""
+    assert classify("[Errno 22] Invalid argument") == "OS_INVALID_ARGUMENT"
+    assert "TEMP" in _HINTS["OS_INVALID_ARGUMENT"]
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "ERROR: unable to open for writing: [Errno 13] Permission denied",
+        "yt_dlp.utils.DownloadError: unable to rename file: [Errno 22] Invalid argument",
+    ],
+)
+def test_other_download_write_failures_share_the_class(reason):
+    assert classify(reason) == "VIDEO_DOWNLOAD_OS_ERROR"
+
+
+def test_a_network_download_failure_is_still_network():
+    """The new rule must not steal transient failures — those DO retry."""
+    reason = "Unable to download video: Connection reset by peer"
+    assert classify(reason) == "VIDEO_DOWNLOAD_NETWORK"
+    assert dub_pipeline._is_transient_download_error(OSError(reason))
+
+
+# ── destination diagnosis ────────────────────────────────────────────────
+
+
+def test_describe_path_target_reports_free_space(tmp_path):
+    facts = describe_path_target(str(tmp_path / "original.mp4"))
+    assert "MB free" in facts
+    assert "does not exist" not in facts
+
+
+def test_describe_path_target_flags_a_missing_folder(tmp_path):
+    facts = describe_path_target(str(tmp_path / "gone" / "original.mp4"))
+    assert "does not exist" in facts
+
+
+def test_describe_path_target_never_raises():
+    assert isinstance(describe_path_target("\x00not-a-path"), str)
+
+
+# ── the failure carries the destination ─────────────────────────────────
+
+
+def test_os_error_gains_the_destination_facts(tmp_path):
+    exc = OSError("Unable to download video: [Errno 22] Invalid argument")
+    described = dub_pipeline._with_target_facts(exc, str(tmp_path))
+
+    msg = str(described)
+    assert str(tmp_path) in msg
+    assert "MB free" in msg
+    assert "retrying the same link won't help" in msg
+    # Still classifies as the download class — the yt-dlp wording is preserved.
+    assert classify(msg) == "VIDEO_DOWNLOAD_OS_ERROR"
+
+
+def test_network_failures_are_left_alone(tmp_path):
+    exc = OSError("Unable to download video: Connection reset by peer")
+    assert dub_pipeline._with_target_facts(exc, str(tmp_path)) is exc
+
+
+def test_exception_types_that_reject_a_message_still_get_the_text(tmp_path):
+    import soundfile as sf
+
+    described = dub_pipeline._with_target_facts(
+        sf.LibsndfileError(1), str(tmp_path)
+    )
+    # LibsndfileError takes an int code — the helper must not build one whose
+    # str() raises. Either it declined to enrich, or it fell back to a type
+    # that works; both are fine, an unprintable exception is not.
+    assert isinstance(str(described), str)
+
+
+def test_unwritable_destination_fails_before_yt_dlp_runs(tmp_path, monkeypatch):
+    """The preflight: don't start a download into a folder we can already see
+    won't take the file."""
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    # Patch the module object dub_pipeline actually holds — a string-path
+    # patch of "core.failure…" misses it if anything in the suite reloaded
+    # the module, and the test then falls through to a REAL network call.
+    monkeypatch.setattr(
+        dub_pipeline.failure, "describe_path_target",
+        lambda _p: "the folder is not writable",
+    )
+    _block_network(monkeypatch)
+
+    with pytest.raises(OSError) as excinfo:
+        dub_pipeline.yt_download_sync("https://example.com/v", str(job_dir))
+
+    msg = str(excinfo.value)
+    assert str(job_dir) in msg
+    assert "not writable" in msg
+    assert classify(msg) != "OS_INVALID_ARGUMENT"
+
+
+def test_preflight_lets_a_healthy_folder_through(tmp_path, monkeypatch):
+    """A writable folder must not be blocked — the preflight only rejects what
+    it can positively see is broken."""
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    _block_network(monkeypatch)
+
+    # Reaching yt-dlp IS the pass condition: the preflight let it through.
+    with pytest.raises(_ReachedYtDlp):
+        dub_pipeline.yt_download_sync("https://example.com/v", str(job_dir))
+    assert os.path.isdir(job_dir)

--- a/tests/test_dub_download_os_error.py
+++ b/tests/test_dub_download_os_error.py
@@ -125,6 +125,33 @@ def test_exception_types_that_reject_a_message_still_get_the_text(tmp_path):
     assert isinstance(str(described), str)
 
 
+def test_enoent_download_failure_also_gets_the_destination_facts(tmp_path):
+    """Review finding (#1225): classify() covered ENOENT but the enrichment
+    gate did not, so a job folder that vanished after preflight produced a
+    disk-classified error that never named the folder — the one fact that
+    makes it actionable. Both now read the same signature list."""
+    exc = OSError("Unable to download video: [Errno 2] No such file or directory")
+    described = dub_pipeline._with_target_facts(exc, str(tmp_path))
+    assert str(tmp_path) in str(described)
+    assert classify(str(described)) == "VIDEO_DOWNLOAD_OS_ERROR"
+
+
+def test_the_two_consumers_share_one_signature_list():
+    """A drift between "is this a disk problem?" (classify) and "should we name
+    the folder?" (_with_target_facts) is what produced the finding above."""
+    from core.failure import is_os_write_refusal
+
+    for reason in (
+        "Unable to download video: [Errno 2] No such file or directory",
+        "Unable to download video: [Errno 22] Invalid argument",
+        "ERROR: unable to open for writing: [Errno 13] Permission denied",
+        "Unable to download video: [Errno 28] No space left on device",
+    ):
+        assert is_os_write_refusal(reason), reason
+        assert classify(reason) == "VIDEO_DOWNLOAD_OS_ERROR", reason
+    assert not is_os_write_refusal("Unable to download video: Connection reset by peer")
+
+
 def test_unwritable_destination_fails_before_yt_dlp_runs(tmp_path, monkeypatch):
     """The preflight: don't start a download into a folder we can already see
     won't take the file."""
@@ -145,7 +172,11 @@ def test_unwritable_destination_fails_before_yt_dlp_runs(tmp_path, monkeypatch):
     msg = str(excinfo.value)
     assert str(job_dir) in msg
     assert "not writable" in msg
-    assert classify(msg) != "OS_INVALID_ARGUMENT"
+    # Review finding (#1225): the preflight message classified as NOTHING, so
+    # the user got no hint at all — the very failure mode this PR fixes. It
+    # must carry both an OS-refusal signature and download context.
+    assert classify(msg) == "VIDEO_DOWNLOAD_OS_ERROR"
+    assert "data directory" in build_failure(excinfo.value, stage="download")["hint"]
 
 
 def test_preflight_lets_a_healthy_folder_through(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #1225.

`download: Unable to download video: [Errno 22] Invalid argument` — hit three times in a row on the same URL.

## Root cause

Not the filename template (the outtmpl is a fixed `original.%(ext)s`, so no title characters ever reach the filesystem) and not the #642 mtime fix. It's a genuine OS-level write rejection into the job folder. Two things made it a dead end:

- **The hint pointed at the wrong folder.** `classify()` matched the generic `"errno 22"` rule — added in #763 for the ASR temp-WAV path — before any download rule. So the user was told to check their system TEMP folder, while the failing directory is the job folder under the OmniVoice data dir. The one actionable instruction in the message was wrong.
- **The message named neither the target nor the reason**, so nothing in it distinguished a full drive from a read-only folder from an antivirus/OneDrive lock.

Bonus finding: `_is_transient_download_error` delegates to the same `classify()`, so errno 22 was correctly judged non-transient and the 3-attempt retry loop was skipped — which is why all three of the reporter's attempts failed identically.

## Fix

- New `VIDEO_DOWNLOAD_OS_ERROR` class, checked before the generic errno rule, covering the OS-refusal errnos (22/13/28/2) **when the message carries download context**. #763's `OS_INVALID_ARGUMENT` is untouched for everything else, and transient network failures keep their own retryable class.
- `failure.describe_path_target()` — shared with the #1221 audio-write path — attaches what we can observe about the destination: exists / writable / free space.
- The download site preflights the job dir and fails immediately when it can already see the write can't succeed, instead of starting a download that can only fail; and enriches an OS-refusal failure with the destination facts, leaving network/format failures alone.

## Verification

`tests/test_dub_download_os_error.py` — fails before (the helper didn't exist), passes after. Covers the new class, that the ASR path keeps `OS_INVALID_ARGUMENT`, that a transient network failure still classifies as retryable, and the preflight in both directions.

The tests block yt-dlp outright: the first draft passed standalone and silently made a **real network call** under full-suite ordering, because a string-path monkeypatch missed the module object `dub_pipeline` holds.

Full backend suite: 3645 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a dedicated `VIDEO_DOWNLOAD_OS_ERROR` classification for OS-level write/rename/open refusals during Dub video downloads (preserving ASR `OS_INVALID_ARGUMENT` and existing transient network/format handling) and enriches these errors with destination diagnostics (existence, writability, free space) via centralized helpers; the download flow now preflights the job output directory and fails immediately when it’s missing/unwritable. Updates changelog messaging and expands network-isolated regression tests to cover classification, preflight outcomes (including missing directories), enrichment behavior, and ensuring retry logic and network stubbing are unchanged. Human review risk: validate the errno/message matching used for OS-refusal detection and the cross-platform correctness/robustness of filesystem/disk-usage probing used in destination diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->