### PR TITLE
fix(download): retry a truncated model download instead of aborting (#1224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- A truncated model download (`peer closed connection without sending complete message body`) is now retried and resumed; it arrives as a transport error that isn't an `OSError`, so it escaped the installer's retry loop entirely and aborted multi-GB installs near the end (#1224) — thanks @Reaksa-Cambodia!
+- A model download truncated near the end is now retried and resumed instead of aborting the whole install — thanks @Reaksa-Cambodia! (#1224)
 - Engine first-use downloads (VoxCPM2, MOSS-TTS-Nano) retry transient network failures instead of failing the load outright (#1224)
-- The streaming synth path now logs the low-memory advisory before loading a model, so a backend killed by the OS leaves a trail in the crash report — only the non-streaming path did (#1224)
+- A backend killed by the OS mid-stream now leaves a low-memory trail in the crash report (#1224)
 
 ## [0.4.0] — 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+**Highlights**
+
+- A model download that dies at 90% now resumes instead of failing the install
+
+### Fixed
+
+- A truncated model download (`peer closed connection without sending complete message body`) is now retried and resumed; it arrives as a transport error that isn't an `OSError`, so it escaped the installer's retry loop entirely and aborted multi-GB installs near the end (#1224) — thanks @Reaksa-Cambodia!
+- Engine first-use downloads (VoxCPM2, MOSS-TTS-Nano) retry transient network failures instead of failing the load outright (#1224)
+- The streaming synth path now logs the low-memory advisory before loading a model, so a backend killed by the OS leaves a trail in the crash report — only the non-streaming path did (#1224)
+
 ## [0.4.0] — 2026-07-21
 
 **Highlights**

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -341,7 +341,17 @@ def _is_retryable_download_error(exc: BaseException) -> bool:
 
     if isinstance(exc, _InstallCancelled):
         return False
-    if isinstance(exc, (HfHubHTTPError, LocalEntryNotFoundError, OSError)):
+    if isinstance(exc, HfHubHTTPError):
+        # An auth / not-found / gone answer from the Hub is a settled verdict:
+        # the token is wrong, the repo is gated, or it isn't there. Retrying
+        # five times with backoff just delays the same message and postpones
+        # the install cooldown. (Pre-existing behaviour — the type-based tuple
+        # this replaced retried every HfHubHTTPError; surfaced in #1224 review.)
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (401, 403, 404, 410):
+            return False
+        return True
+    if isinstance(exc, (LocalEntryNotFoundError, OSError)):
         return True
     return is_hf_connectivity_error(str(exc))
 

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -321,6 +321,31 @@ class InstallModelRequest(BaseModel):
     repo_id: str
 
 
+
+def _is_retryable_download_error(exc: BaseException) -> bool:
+    """Whether a failed download attempt is worth retrying.
+
+    Decides by CLASSIFICATION, not by exception type. The type-based tuple this
+    replaced — ``(HfHubHTTPError, LocalEntryNotFoundError, OSError)`` — silently
+    excluded ``httpx.RemoteProtocolError``, which inherits ``Exception``: a
+    4.6 GB model truncated at 4.0 GB escaped all five attempts and aborted the
+    install (#1224). Any future transport error with a novel base class would
+    have reopened the same hole.
+
+    A user cancel is never retryable, and neither is anything
+    ``is_hf_connectivity_error`` does not recognise.
+    """
+    # Imported here, not at module scope, for the same reason the worker does:
+    # huggingface_hub is heavy and this module is on the setup import path.
+    from huggingface_hub.utils import HfHubHTTPError, LocalEntryNotFoundError
+
+    if isinstance(exc, _InstallCancelled):
+        return False
+    if isinstance(exc, (HfHubHTTPError, LocalEntryNotFoundError, OSError)):
+        return True
+    return is_hf_connectivity_error(str(exc))
+
+
 @router.post("/models/install")
 async def install_model(req: InstallModelRequest):
     """Download one HF repo snapshot; progress goes through the shared
@@ -506,12 +531,9 @@ async def install_model(req: InstallModelRequest):
                     # truncation signatures. Anything unrecognised (a cancel, a
                     # validation failure, a bug) propagates untouched, exactly
                     # as before.
-                    if isinstance(net_err, _InstallCancelled):
-                        raise
-                    _retryable = isinstance(
-                        net_err, (HfHubHTTPError, LocalEntryNotFoundError, OSError)
-                    ) or is_hf_connectivity_error(str(net_err))
-                    if _attempt >= _max_attempts or not _retryable:
+                    if _attempt >= _max_attempts or not _is_retryable_download_error(
+                        net_err
+                    ):
                         raise
                     _backoff = min(30, 2 ** _attempt)
                     logger.info(

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -19,6 +19,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from core import prefs
+from core.failure import is_hf_connectivity_error
 from utils import hf_progress
 from utils import download_aggregator
 # Weight-floor scan (MM2-07 / #352) lives in ``models.py`` — the lowest module in
@@ -492,8 +493,25 @@ async def install_model(req: InstallModelRequest):
                         _snapshot_path = snapshot_download(**dl_kwargs)
                     _validate_snapshot_has_weights(req.repo_id, _snapshot_path)
                     break
-                except (HfHubHTTPError, LocalEntryNotFoundError, OSError) as net_err:
-                    if _attempt >= _max_attempts:
+                except Exception as net_err:
+                    # #1224: a truncated body ("peer closed connection without
+                    # sending complete message body") arrives as
+                    # httpx.RemoteProtocolError, which inherits from Exception
+                    # — NOT OSError — so it escaped the old
+                    # (HfHubHTTPError, LocalEntryNotFoundError, OSError) tuple
+                    # and aborted a 4.6 GB install at 4.0 GB with no retry.
+                    # Widen to Exception and decide by CLASSIFICATION:
+                    # is_hf_connectivity_error is already the single source of
+                    # truth for "transient download failure" and now knows the
+                    # truncation signatures. Anything unrecognised (a cancel, a
+                    # validation failure, a bug) propagates untouched, exactly
+                    # as before.
+                    if isinstance(net_err, _InstallCancelled):
+                        raise
+                    _retryable = isinstance(
+                        net_err, (HfHubHTTPError, LocalEntryNotFoundError, OSError)
+                    ) or is_hf_connectivity_error(str(net_err))
+                    if _attempt >= _max_attempts or not _retryable:
                         raise
                     _backoff = min(30, 2 ** _attempt)
                     logger.info(

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -90,6 +90,20 @@ async def ws_tts(websocket: WebSocket):
                     get_backend_class,
                 )
                 engine_id = data.get("engine")
+                # #1224: leave a breadcrumb when memory is already tight before
+                # a heavy load. /generate has done this since the 16 GB-Mac
+                # reports, but the streaming path — which the desktop UI tries
+                # FIRST — never did, so the load most likely to tip the machine
+                # into an OS OOM kill was the one load with no trail. The
+                # captured stderr tail is what a SIGKILL report has to go on.
+                # Advisory only: the OS can reclaim cache, and refusing here
+                # would brick loads that would actually have coped.
+                try:
+                    from services.memory_budget import log_if_low
+
+                    log_if_low(f"TTS stream load ({engine_id or 'active engine'})")
+                except Exception:
+                    pass
                 if engine_id:
                     cls = get_backend_class(engine_id)
                     backend = cls()

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -84,6 +84,18 @@ _HF_CONNECTIVITY_SIGNATURES = (
     "timed out",
     "an error happened while trying to locate the file on the hub",  # LocalEntryNotFoundError
     "we cannot find the requested files",                            # LocalEntryNotFoundError
+    # #1224: a TRUNCATED download — the server closed mid-body, so the client
+    # got fewer bytes than Content-Length promised. httpx words it "peer closed
+    # connection without sending complete message body"; urllib3/http.client
+    # raise IncompleteRead. This is as transient as a refused connection and
+    # must retry — a 4.6 GB model that dies at 4.0 GB used to abort the whole
+    # install (and, on the reporter's 16 GB Mac, take the process with it).
+    "peer closed connection",
+    "incomplete message body",
+    "incompleteread",
+    "incomplete read",
+    "connection broken",               # urllib3 ProtocolError wrapper
+    "response ended prematurely",
 )
 
 # The failure must also be Hugging-Face-shaped — the configured endpoint/host

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -132,7 +132,6 @@ def _retry_once_with_fresh_hf_client(loader, what: str):
     client_reset_used = False
     attempt = 0
     while True:
-        attempt += 1
         try:
             return loader()
         except Exception as e:
@@ -152,7 +151,12 @@ def _retry_once_with_fresh_hf_client(loader, what: str):
                         "%s: couldn't reset the HF Hub client; retrying anyway.",
                         what,
                     )
+                # Deliberately does NOT consume a download attempt: the two
+                # budgets are independent, and letting the session reset eat
+                # one left a resumable multi-GB download a retry short of its
+                # configured budget (#1224 review).
                 continue  # immediate — nothing to back off from
+            attempt += 1
             if not is_hf_connectivity_error(str(e)) or attempt >= attempts:
                 raise
             logger.warning(
@@ -174,9 +178,15 @@ def _int_env(name: str, default: int) -> int:
 
 def _float_env(name: str, default: float) -> float:
     try:
-        return float(os.environ.get(name, default))
+        value = float(os.environ.get(name, default))
     except (TypeError, ValueError):
         return default
+    # inf/nan parse fine and then poison the caller: `sleep(inf)` raises
+    # OverflowError, turning a retryable download failure into an unrelated
+    # crash that hides the original error (#1224 review).
+    if value != value or value in (float("inf"), float("-inf")):
+        return default
+    return value
 
 
 # ── Protocol ────────────────────────────────────────────────────────────────

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -106,27 +106,77 @@ def _is_closed_client_error(e) -> bool:
 
 def _retry_once_with_fresh_hf_client(loader, what: str):
     """Run ``loader()`` — a model constructor that may download from the HF
-    Hub on first use. On the specific closed-client failure above, reset the
-    hub's shared client and retry exactly ONCE. Any other failure (and a
-    repeat closed-client failure) propagates untouched, where the generation
-    error classifier labels it as a network problem (#880)."""
-    try:
-        return loader()
-    except Exception as e:
-        if not _is_closed_client_error(e):
-            raise
-        logger.warning(
-            "%s: HF Hub httpx client was closed mid-download (%s); "
-            "retrying once with a fresh client.", what, e,
-        )
+    Hub on first use — retrying transient download failures.
+
+    Two failure shapes are retried, with deliberately different budgets:
+
+    * the httpx **closed-client** lifecycle error (#880) — retried exactly
+      ONCE, after resetting the hub's shared session. It's a client-state bug,
+      not a network condition: if a fresh session hits it again, repeating
+      won't help, and #880 chose to surface it rather than loop.
+    * any **transient download** failure ``core.failure
+      .is_hf_connectivity_error`` recognises — refused/reset connections, DNS,
+      timeouts, and (#1224) a truncated body ("peer closed connection without
+      sending complete message body"). A multi-GB model that dies at 90% is
+      the single most retry-worthy failure in the path, so this gets the full
+      bounded budget. The HF cache is resumable (correctly-sized blobs are
+      skipped by hash), so each retry continues rather than restarting.
+
+    Anything unrecognised propagates untouched, where the generation error
+    classifier labels it.
+    """
+    from core.failure import is_hf_connectivity_error
+
+    attempts = max(1, _int_env("OMNIVOICE_MODEL_LOAD_RETRIES", 3))
+    backoff = max(0.0, _float_env("OMNIVOICE_MODEL_LOAD_BACKOFF_S", 2.0))
+    client_reset_used = False
+    attempt = 0
+    while True:
+        attempt += 1
         try:
-            from huggingface_hub.utils import close_session
-            close_session()
-        except Exception:  # pragma: no cover — hub too old / API renamed
+            return loader()
+        except Exception as e:
+            if _is_closed_client_error(e):
+                if client_reset_used:
+                    raise  # #880: single-shot — a second one is not transient
+                client_reset_used = True
+                logger.warning(
+                    "%s: HF Hub httpx client was closed mid-download (%s); "
+                    "retrying once with a fresh client.", what, e,
+                )
+                try:
+                    from huggingface_hub.utils import close_session
+                    close_session()
+                except Exception:  # pragma: no cover — hub too old / renamed
+                    logger.warning(
+                        "%s: couldn't reset the HF Hub client; retrying anyway.",
+                        what,
+                    )
+                continue  # immediate — nothing to back off from
+            if not is_hf_connectivity_error(str(e)) or attempt >= attempts:
+                raise
             logger.warning(
-                "%s: couldn't reset the HF Hub client; retrying anyway.", what,
+                "%s: model download failed (%s); retrying (attempt %d/%d). "
+                "Already-downloaded files are reused.",
+                what, e, attempt, attempts,
             )
-        return loader()
+            if backoff:
+                import time as _time
+                _time.sleep(backoff * attempt)
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
 
 
 # ── Protocol ────────────────────────────────────────────────────────────────
@@ -749,7 +799,12 @@ class VoxCPM2Backend(TTSBackend):
         from voxcpm import VoxCPM  # type: ignore[import-not-found]
         checkpoint = os.environ.get("OMNIVOICE_VOXCPM_MODEL", "openbmb/VoxCPM2")
         logger.info("Loading VoxCPM2 from %s", checkpoint)
-        self._model = VoxCPM.from_pretrained(checkpoint, load_denoiser=False)
+        # #1224: this first-use download is multi-GB. Unretried, a truncated
+        # body at 90% aborted the load outright.
+        self._model = _retry_once_with_fresh_hf_client(
+            lambda: VoxCPM.from_pretrained(checkpoint, load_denoiser=False),
+            "VoxCPM2",
+        )
 
     def generate(self, text, **kw) -> torch.Tensor:
         self._ensure_loaded()
@@ -884,7 +939,10 @@ class MossTTSNanoBackend(TTSBackend):
             "OMNIVOICE_MOSS_TTS_MODEL", "OpenMOSS-Team/MOSS-TTS-Nano"
         )
         logger.info("Loading MOSS-TTS-Nano from %s", checkpoint)
-        self._model = MossTTSNano.from_pretrained(checkpoint, trust_remote_code=True)
+        self._model = _retry_once_with_fresh_hf_client(
+            lambda: MossTTSNano.from_pretrained(checkpoint, trust_remote_code=True),
+            "MOSS-TTS-Nano",
+        )
 
     def generate(self, text, **kw) -> torch.Tensor:
         self._ensure_loaded()

--- a/tests/test_truncated_download_retry.py
+++ b/tests/test_truncated_download_retry.py
@@ -240,6 +240,38 @@ def test_installer_does_not_retry_a_cancel_or_a_real_error():
     assert not _is_retryable_download_error(RuntimeError("401 Unauthorized"))
 
 
+@pytest.mark.parametrize("status", [401, 403, 404, 410])
+def test_installer_does_not_retry_a_settled_hub_verdict(status):
+    """Review finding (#1224): every HfHubHTTPError was retried, so a wrong
+    token or a gated repo burned all five attempts with backoff before showing
+    the user the same message. The verdict is settled — fail fast."""
+    import httpx
+    from huggingface_hub.utils import HfHubHTTPError
+
+    from api.routers.setup.download import _is_retryable_download_error
+
+    response = httpx.Response(status, request=httpx.Request("GET", "https://hf.co/x"))
+    assert not _is_retryable_download_error(
+        HfHubHTTPError(f"{status} Client Error", response=response)
+    )
+
+
+def test_installer_still_retries_a_server_side_hub_error():
+    """A 5xx (or a rate-limit) is transient and must keep retrying."""
+    import httpx
+    from huggingface_hub.utils import HfHubHTTPError
+
+    from api.routers.setup.download import _is_retryable_download_error
+
+    for status in (429, 500, 503):
+        response = httpx.Response(
+            status, request=httpx.Request("GET", "https://hf.co/x")
+        )
+        assert _is_retryable_download_error(
+            HfHubHTTPError(f"{status} Error", response=response)
+        ), status
+
+
 def test_installer_still_retries_the_original_type_based_cases():
     """Widening to classification must not drop what the old tuple caught."""
     from huggingface_hub.utils import LocalEntryNotFoundError

--- a/tests/test_truncated_download_retry.py
+++ b/tests/test_truncated_download_retry.py
@@ -143,32 +143,111 @@ def test_the_closed_client_path_stays_single_shot(monkeypatch):
     assert len(calls) == 2, "closed-client must stay single-shot regardless of the budget"
 
 
-def test_voxcpm2_load_goes_through_the_retry_wrapper():
-    """The #1224 call site itself — a direct from_pretrained here would mean
-    the fix above never runs for the engine the reporter was using."""
-    import inspect
+def test_voxcpm2_load_actually_retries_a_truncated_download(monkeypatch):
+    """The #1224 call site itself, exercised — not grepped.
 
-    src = inspect.getsource(tts_backend.VoxCPM2Backend._ensure_loaded)
-    assert "_retry_once_with_fresh_hf_client" in src
-    assert "VoxCPM.from_pretrained(checkpoint" not in src.replace(
-        "lambda: VoxCPM.from_pretrained(checkpoint", ""
+    An earlier version of this test asserted the wrapper's NAME appeared in the
+    method source, which would have passed even if the wrapper were called with
+    the wrong argument or its result discarded (#1224 review)."""
+    import sys
+    import types
+
+    calls = []
+
+    class _FakeVoxCPM:
+        @staticmethod
+        def from_pretrained(checkpoint, **kw):
+            calls.append(checkpoint)
+            if len(calls) < 3:
+                raise RuntimeError(
+                    "peer closed connection without sending complete message body"
+                )
+            return f"model:{checkpoint}"
+
+    monkeypatch.setitem(
+        sys.modules, "voxcpm", types.SimpleNamespace(VoxCPM=_FakeVoxCPM)
     )
+    monkeypatch.setenv("OMNIVOICE_VOXCPM_MODEL", "openbmb/VoxCPM2")
+    monkeypatch.setattr(
+        tts_backend.VoxCPM2Backend, "is_available", classmethod(lambda cls: (True, ""))
+    )
+    monkeypatch.setattr(tts_backend, "_voxcpm_upgrade_hint", lambda: None)
+
+    backend = tts_backend.VoxCPM2Backend()
+    backend._ensure_loaded()
+
+    assert backend._model == "model:openbmb/VoxCPM2"
+    assert len(calls) == 3, "the load must retry, not fail on the first truncation"
+
+
+def test_voxcpm2_load_still_fails_fast_on_a_real_error(monkeypatch):
+    import sys
+    import types
+
+    calls = []
+
+    class _FakeVoxCPM:
+        @staticmethod
+        def from_pretrained(checkpoint, **kw):
+            calls.append(1)
+            raise ValueError("checkpoint has no config.json")
+
+    monkeypatch.setitem(
+        sys.modules, "voxcpm", types.SimpleNamespace(VoxCPM=_FakeVoxCPM)
+    )
+    monkeypatch.setattr(
+        tts_backend.VoxCPM2Backend, "is_available", classmethod(lambda cls: (True, ""))
+    )
+    monkeypatch.setattr(tts_backend, "_voxcpm_upgrade_hint", lambda: None)
+
+    with pytest.raises(ValueError):
+        tts_backend.VoxCPM2Backend()._ensure_loaded()
+    assert len(calls) == 1
 
 
 # ── the installer's retry loop catches it ────────────────────────────────
 
 
-def test_installer_retry_catches_non_oserror_transport_failures():
-    """RemoteProtocolError is not an OSError — the loop must decide by
-    classification, not by exception type."""
-    import inspect
+def test_installer_retries_a_real_remoteprotocolerror():
+    """The #1224 root cause, against a REAL httpx exception instance.
 
-    from api.routers.setup import download
+    An earlier version asserted `"is_hf_connectivity_error" in getsource(...)`,
+    which passed merely because the module imports it — it would not have
+    noticed the loop ignoring the classifier entirely (#1224 review)."""
+    import httpx
 
-    src = inspect.getsource(download)
-    assert "is_hf_connectivity_error" in src, (
-        "the install retry loop must classify failures, not match OSError only"
+    from api.routers.setup.download import _is_retryable_download_error
+
+    truncated = httpx.RemoteProtocolError(
+        "peer closed connection without sending complete message body "
+        "(received 4084175097 bytes, expected 4580080592)"
     )
+    assert not isinstance(truncated, OSError), (
+        "if this ever becomes an OSError the original bug is gone, but the "
+        "classification path must still hold"
+    )
+    assert _is_retryable_download_error(truncated)
+
+
+def test_installer_does_not_retry_a_cancel_or_a_real_error():
+    from api.routers.setup.download import (
+        _InstallCancelled,
+        _is_retryable_download_error,
+    )
+
+    assert not _is_retryable_download_error(_InstallCancelled())
+    assert not _is_retryable_download_error(ValueError("no such repo"))
+    assert not _is_retryable_download_error(RuntimeError("401 Unauthorized"))
+
+
+def test_installer_still_retries_the_original_type_based_cases():
+    """Widening to classification must not drop what the old tuple caught."""
+    from huggingface_hub.utils import LocalEntryNotFoundError
+
+    from api.routers.setup.download import _is_retryable_download_error
+
+    assert _is_retryable_download_error(OSError("connection reset by peer"))
+    assert _is_retryable_download_error(LocalEntryNotFoundError("offline"))
 
 
 # ── the streaming path leaves an OOM breadcrumb ──────────────────────────
@@ -178,11 +257,52 @@ def test_stream_path_checks_memory_before_loading():
     """The reporter was SIGKILLed on a 16 GB Mac. /generate has logged a
     low-memory advisory since the earlier reports of that class, but the
     STREAMING path — which the desktop UI tries first — did not, so the load
-    most likely to tip the machine over was the one with no trail in the
-    captured stderr tail."""
+    most likely to tip the machine over left no trail in the captured stderr
+    tail a SIGKILL report has to go on.
+
+    Structural rather than behavioural: reaching the call needs a live
+    WebSocket session. Kept honest by also resolving the symbol it names, so a
+    rename or removal on either side fails here (#1224 review).
+    """
     import inspect
 
     from api.routers import tts_stream
+    from services.memory_budget import log_if_low
 
+    assert callable(log_if_low)
     src = inspect.getsource(tts_stream)
-    assert "log_if_low" in src
+    assert "from services.memory_budget import log_if_low" in src
+    assert "log_if_low(f\"TTS stream load" in src
+
+
+def test_the_two_budgets_do_not_share_a_counter(monkeypatch):
+    """Review finding (#1224): the closed-client reset incremented the same
+    counter as the download retries, so a session reset followed by transient
+    failures left a resumable multi-GB download one attempt short of its
+    configured budget."""
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_RETRIES", "3")
+    import huggingface_hub.utils as hub_utils
+
+    monkeypatch.setattr(hub_utils, "close_session", lambda: None, raising=False)
+
+    calls = []
+
+    def loader():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+        raise RuntimeError("peer closed connection without sending complete message body")
+
+    with pytest.raises(RuntimeError):
+        tts_backend._retry_once_with_fresh_hf_client(loader, "VoxCPM2")
+    # 1 closed-client + a full budget of 3 download attempts.
+    assert len(calls) == 4
+
+
+@pytest.mark.parametrize("bad", ["inf", "-inf", "nan"])
+def test_a_non_finite_backoff_falls_back_to_the_default(monkeypatch, bad):
+    """Review finding (#1224): `float("inf")` parses fine and then makes
+    `sleep(inf)` raise OverflowError, replacing a retryable download failure
+    with an unrelated crash that hides the original error."""
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_BACKOFF_S", bad)
+    assert tts_backend._float_env("OMNIVOICE_MODEL_LOAD_BACKOFF_S", 2.0) == 2.0

--- a/tests/test_truncated_download_retry.py
+++ b/tests/test_truncated_download_retry.py
@@ -1,0 +1,188 @@
+"""#1224: a truncated model download aborted the install instead of retrying.
+
+The reporter's log tail, captured just before the backend was SIGKILLed:
+
+    httpx.RemoteProtocolError: peer closed connection without sending complete
+    message body (received 4084175097 bytes, expected 4580080592)
+
+That is a 4.6 GB model dying at 4.0 GB — the single most retry-worthy failure
+in the whole download path, and it was retried nowhere:
+
+* the installer's retry loop caught ``(HfHubHTTPError, LocalEntryNotFoundError,
+  OSError)``. ``httpx.RemoteProtocolError`` inherits ``Exception``, NOT
+  ``OSError``, so it escaped all five attempts;
+* ``is_hf_connectivity_error`` — the single source of truth for "transient
+  download failure" — had no truncation signature, so even a widened catch
+  would have classified it as permanent;
+* the engine load path (``VoxCPM.from_pretrained``) had no retry at all.
+
+The HF cache is resumable (correctly-sized blobs are skipped by hash), so a
+retry continues rather than restarting — which is what makes retrying correct
+here and not merely hopeful.
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.failure import is_hf_connectivity_error
+from services import tts_backend
+
+
+# ── classification ───────────────────────────────────────────────────────
+
+
+def test_the_reporters_error_is_recognised_as_transient():
+    assert is_hf_connectivity_error(
+        "peer closed connection without sending complete message body "
+        "(received 4084175097 bytes, expected 4580080592)"
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        # urllib3 / http.client wording for the same truncation.
+        "IncompleteRead(4084175097 bytes read, 495905495 more expected)",
+        "ProtocolError('Connection broken: IncompleteRead(…)')",
+        "http.client.IncompleteRead: incomplete read",
+        "Response ended prematurely",
+    ],
+)
+def test_other_truncation_wordings_are_recognised(reason):
+    assert is_hf_connectivity_error(reason)
+
+
+def test_a_real_failure_is_still_permanent():
+    """Widening the net must not make genuine errors retry forever."""
+    assert not is_hf_connectivity_error("401 Unauthorized: invalid token")
+    assert not is_hf_connectivity_error("No such file or directory: config.json")
+    assert not is_hf_connectivity_error("CUDA out of memory")
+
+
+# ── the engine load path retries ─────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_BACKOFF_S", "0")
+
+
+def test_truncated_download_is_retried_and_succeeds(monkeypatch):
+    calls = []
+
+    def loader():
+        calls.append(1)
+        if len(calls) < 3:
+            raise RuntimeError(
+                "peer closed connection without sending complete message body"
+            )
+        return "model"
+
+    assert tts_backend._retry_once_with_fresh_hf_client(loader, "VoxCPM2") == "model"
+    assert len(calls) == 3
+
+
+def test_retries_are_bounded(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_RETRIES", "2")
+    calls = []
+
+    def loader():
+        calls.append(1)
+        raise RuntimeError("peer closed connection without sending complete message body")
+
+    with pytest.raises(RuntimeError):
+        tts_backend._retry_once_with_fresh_hf_client(loader, "VoxCPM2")
+    assert len(calls) == 2
+
+
+def test_a_non_transient_failure_is_not_retried():
+    calls = []
+
+    def loader():
+        calls.append(1)
+        raise ValueError("checkpoint has no config.json")
+
+    with pytest.raises(ValueError):
+        tts_backend._retry_once_with_fresh_hf_client(loader, "VoxCPM2")
+    assert len(calls) == 1, "a permanent failure must fail fast, not retry"
+
+
+def test_the_closed_client_path_still_resets_the_session(monkeypatch):
+    """#880's behaviour must survive the widening."""
+    reset = []
+    import huggingface_hub.utils as hub_utils
+
+    monkeypatch.setattr(hub_utils, "close_session", lambda: reset.append(1), raising=False)
+
+    calls = []
+
+    def loader():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+        return "model"
+
+    assert tts_backend._retry_once_with_fresh_hf_client(loader, "VoxCPM2") == "model"
+    assert reset, "the HF session must be reset before retrying a closed client"
+
+
+def test_the_closed_client_path_stays_single_shot(monkeypatch):
+    """The two failure shapes get deliberately different budgets. A closed
+    client is a client-state bug, not a network condition: if a FRESH session
+    hits it again, repeating won't help, and #880 chose to surface it. Only
+    the transient-download path gets the multi-attempt budget."""
+    monkeypatch.setenv("OMNIVOICE_MODEL_LOAD_RETRIES", "5")
+    calls = []
+
+    def loader():
+        calls.append(1)
+        raise RuntimeError("Cannot send a request, as the client has been closed.")
+
+    with pytest.raises(RuntimeError):
+        tts_backend._retry_once_with_fresh_hf_client(loader, "VoxCPM2")
+    assert len(calls) == 2, "closed-client must stay single-shot regardless of the budget"
+
+
+def test_voxcpm2_load_goes_through_the_retry_wrapper():
+    """The #1224 call site itself — a direct from_pretrained here would mean
+    the fix above never runs for the engine the reporter was using."""
+    import inspect
+
+    src = inspect.getsource(tts_backend.VoxCPM2Backend._ensure_loaded)
+    assert "_retry_once_with_fresh_hf_client" in src
+    assert "VoxCPM.from_pretrained(checkpoint" not in src.replace(
+        "lambda: VoxCPM.from_pretrained(checkpoint", ""
+    )
+
+
+# ── the installer's retry loop catches it ────────────────────────────────
+
+
+def test_installer_retry_catches_non_oserror_transport_failures():
+    """RemoteProtocolError is not an OSError — the loop must decide by
+    classification, not by exception type."""
+    import inspect
+
+    from api.routers.setup import download
+
+    src = inspect.getsource(download)
+    assert "is_hf_connectivity_error" in src, (
+        "the install retry loop must classify failures, not match OSError only"
+    )
+
+
+# ── the streaming path leaves an OOM breadcrumb ──────────────────────────
+
+
+def test_stream_path_checks_memory_before_loading():
+    """The reporter was SIGKILLed on a 16 GB Mac. /generate has logged a
+    low-memory advisory since the earlier reports of that class, but the
+    STREAMING path — which the desktop UI tries first — did not, so the load
+    most likely to tip the machine over was the one with no trail in the
+    captured stderr tail."""
+    import inspect
+
+    from api.routers import tts_stream
+
+    src = inspect.getsource(tts_stream)
+    assert "log_if_low" in src


### PR DESCRIPTION
Fixes #1224.

The reporter's captured log tail, just before the backend was SIGKILLed on a 16 GB M4:

```
httpx.RemoteProtocolError: peer closed connection without sending complete message body
(received 4084175097 bytes, expected 4580080592)
```

A 4.6 GB model died at 4.0 GB. That is the single most retry-worthy failure in the whole download path — and it was retried **nowhere**.

## Three independent holes

1. **The installer's retry loop couldn't catch it.** It caught `(HfHubHTTPError, LocalEntryNotFoundError, OSError)`. `httpx.RemoteProtocolError` inherits `Exception`, **not** `OSError`, so it escaped all five attempts. The loop now decides by **classification** rather than exception type — so the next transport error with a novel type doesn't reopen the same hole.

2. **The classifier didn't recognise it.** `is_hf_connectivity_error` is the single source of truth for "transient download failure" and had no truncation signature, so a widened catch alone would still have called it permanent. It now knows the httpx wording plus the urllib3/`http.client` equivalents (`IncompleteRead`, `connection broken`, `response ended prematurely`).

3. **The engine load path had no retry at all.** `VoxCPM.from_pretrained` — the engine the reporter was using — called straight through. It and MOSS-TTS-Nano now go through the existing `_retry_once_with_fresh_hf_client` hook, widened to retry transient download failures with a bounded, backed-off budget.

Retrying is correct here rather than merely hopeful: the HF cache is resumable (correctly-sized blobs are skipped by hash), so each retry **continues** instead of restarting.

## Two budgets, deliberately different

The closed-client path (#880) keeps its single-shot budget: that's a client-state bug, not a network condition, so if a *fresh* session hits it again, repeating won't help. Only the transient-download path gets the multi-attempt budget. Both are now pinned by tests — the existing `test_hf_retry_is_single_shot` caught an earlier draft of this change that had flattened the distinction.

## The SIGKILL itself

The kill was the OS memory killer on a 16 GB machine. `/generate` has logged a low-memory advisory since the earlier reports of that class, but the **streaming** path — which the desktop UI tries first — did not. So the load most likely to tip the machine over was the one leaving no trail in the captured stderr tail that a SIGKILL report has to go on. It now logs it too.

Note the crash notice itself showing `signal 9` with no explanation is fixed in #1235 (the hint existed but was only wired to the stream-drop path).

## Verification

`tests/test_truncated_download_retry.py` — 9 of 13 fail before. Covers the reporter's exact error string, the alternative truncation wordings, both retry budgets, and that genuine failures (401, missing config, CUDA OOM) still fail fast.

Full backend suite: 3646 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Hugging Face model download and engine first-load retries now classify truncated/incomplete HTTP responses (including `httpx.RemoteProtocolError` and similar early-termination signatures) as transient, applying bounded retry budgets with backed-off delays for VoxCPM2 and MOSS-TTS-Nano while failing fast on settled/non-retryable outcomes such as 401/403/404/410. The installer retry loop was updated to use this failure classification (not exception types), and the HF “closed client” path remains intentionally single-shot via a session reset before the one retry. Streaming TTS now emits a low-memory advisory breadcrumb, with regression coverage for truncation recognition, retry budgets/non-finite backoff fallback, and ensuring the two retry counters don’t interfere—review risk: misclassification or retry/backoff settings could cause unnecessary repeated large downloads or suppress real permanent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->