### PR TITLE
fix(routing): warn about an under-provisioned GPU before the job, not after (#1226, #1222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- Engines can declare the VRAM they need, and a card below that gets a caveat in Settings → Engines before you generate — a 4 GB card previously showed a clean green "accelerated" until the job timed out, because only GPU family was ever checked (#1226, #1222) — thanks @AdityaHemantBhat and @beingavais!
-- The generation-timeout message now names your actual card and its VRAM instead of blaming generic "VRAM starvation", and recommends a lighter engine rather than reading as transient contention you can flush away (#1226, #1222)
+- A GPU with less VRAM than the chosen engine needs is flagged in Settings → Engines before you generate, instead of showing a clean green "accelerated" until the job times out — thanks @AdityaHemantBhat and @beingavais! (#1226, #1222)
+- A generation timeout now names your actual card and its VRAM and recommends a lighter engine (#1226, #1222)
 
 ## [0.4.0] — 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
+## [Unreleased]
+
+**Highlights**
+
+- A GPU too small for the chosen engine now says so up front, not after a five-minute wait
+
+### Fixed
+
+- Engines can declare the VRAM they need, and a card below that gets a caveat in Settings → Engines before you generate — a 4 GB card previously showed a clean green "accelerated" until the job timed out, because only GPU family was ever checked (#1226, #1222) — thanks @AdityaHemantBhat and @beingavais!
+- The generation-timeout message now names your actual card and its VRAM instead of blaming generic "VRAM starvation", and recommends a lighter engine rather than reading as transient contention you can flush away (#1226, #1222)
+
 ## [0.4.0] — 2026-07-21
 
 **Highlights**

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -870,9 +870,14 @@ async def generate_speech(
     # /engines/select gate, so this is the only place it's enforced for synth).
     from core.device_caps import detect_host_caps
     from services.engine_routing import resolve_routing, routing_notice
+    # The engine's declared VRAM floor (#1226) — used by the routing gate and,
+    # below, to let a generate TIMEOUT name the same shortfall. Resolved once:
+    # every other job on this GPU pool (reference transcribe, assemble) leaves
+    # it at 0, so only TTS generates can get the under-provisioned wording.
+    _engine_min_vram_gb = getattr(backend_cls, "min_vram_gb", 0.0)
     _routing = resolve_routing(
         getattr(backend_cls, "gpu_compat", ("cpu",)), detect_host_caps(),
-        getattr(backend_cls, "min_vram_gb", 0.0),
+        _engine_min_vram_gb,
     )
     if _routing["routing_status"] == "unavailable":
         # The engine needs an accelerator this host lacks and has no CPU path.
@@ -1198,6 +1203,7 @@ async def generate_speech(
                                 max_chunk_chars, crossfade_ms,
                             ),
                             what="TTS generate",
+                            min_vram_gb=_engine_min_vram_gb,
                             timeout=_generate_timeout_s(text),
                         )
                         sample_rate = _backend.sample_rate
@@ -1213,6 +1219,7 @@ async def generate_speech(
                                 max_chunk_chars, crossfade_ms,
                             ),
                             what="TTS generate",
+                            min_vram_gb=_engine_min_vram_gb,
                             timeout=_generate_timeout_s(text),
                         )
                         sample_rate = _model.sampling_rate
@@ -1247,6 +1254,7 @@ async def generate_speech(
                         raw, preview, sample_rate = await run_on_gpu_pool_guarded(
                             functools.partial(_render_stream_chunk, i, chunk_text),
                             what="TTS generate",
+                            min_vram_gb=_engine_min_vram_gb,
                             # Budget scaled to THIS chunk (#1190) — the flat
                             # 300s here is what made long streamed renders fail
                             # even after the v0.3.22 scaled budget shipped.
@@ -1347,6 +1355,7 @@ async def generate_speech(
                     max_chunk_chars, crossfade_ms,
                 ),
                 what="TTS generate",
+                min_vram_gb=_engine_min_vram_gb,
                 timeout=_generate_timeout_s(text),
             )
             # Read after generation: engines with lazy model loading report
@@ -1363,6 +1372,7 @@ async def generate_speech(
                     max_chunk_chars, crossfade_ms,
                 ),
                 what="TTS generate",
+                min_vram_gb=_engine_min_vram_gb,
                 timeout=_generate_timeout_s(text),
             )
             sample_rate = _model.sampling_rate

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -870,7 +870,10 @@ async def generate_speech(
     # /engines/select gate, so this is the only place it's enforced for synth).
     from core.device_caps import detect_host_caps
     from services.engine_routing import resolve_routing, routing_notice
-    _routing = resolve_routing(getattr(backend_cls, "gpu_compat", ("cpu",)), detect_host_caps())
+    _routing = resolve_routing(
+        getattr(backend_cls, "gpu_compat", ("cpu",)), detect_host_caps(),
+        getattr(backend_cls, "min_vram_gb", 0.0),
+    )
     if _routing["routing_status"] == "unavailable":
         # The engine needs an accelerator this host lacks and has no CPU path.
         raise HTTPException(status_code=400, detail=_routing["routing_reason"])

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -313,7 +313,10 @@ async def create_speech(req: SpeechRequest):
     # Routing gate (#21 — no silent CPU fallback), identical to REST /generate.
     from core.device_caps import detect_host_caps
     from services.engine_routing import resolve_routing, routing_notice
-    _routing = resolve_routing(getattr(backend, "gpu_compat", ("cpu",)), detect_host_caps())
+    _routing = resolve_routing(
+        getattr(backend, "gpu_compat", ("cpu",)), detect_host_caps(),
+        getattr(backend, "min_vram_gb", 0.0),
+    )
     if _routing["routing_status"] == "unavailable":
         raise HTTPException(status_code=400, detail=_routing["routing_reason"])
     _routing_notice = routing_notice(_routing)  # (status, reason) or None

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -106,7 +106,8 @@ async def ws_tts(websocket: WebSocket):
                 from services.engine_routing import resolve_routing, routing_notice
                 from core.scrub import scrub_text
                 _routing = resolve_routing(
-                    getattr(backend, "gpu_compat", ("cpu",)), detect_host_caps())
+                    getattr(backend, "gpu_compat", ("cpu",)), detect_host_caps(),
+                    getattr(backend, "min_vram_gb", 0.0))
                 if _routing["routing_status"] == "unavailable":
                     await websocket.send_json({
                         "type": "error",

--- a/backend/services/engine_routing.py
+++ b/backend/services/engine_routing.py
@@ -51,7 +51,16 @@ def _caveat(caps: HostCaps, min_vram_gb: float = 0.0) -> str | None:
     for note in caps.notes:
         if KERNEL_RISK_MARKER in note:
             return f"{caps.family.upper()} selected, but: {note}"
-    if min_vram_gb > 0 and caps.vram_gb > 0 and caps.vram_gb < min_vram_gb:
+    # Dedicated-VRAM families ONLY. On MPS, HostCaps.vram_gb is a heuristic
+    # (system RAM / 2, see device_caps) for a UNIFIED memory pool — comparing
+    # it against a floor measured on discrete CUDA hardware would tell every
+    # 8 GB Mac its 4 GB "VRAM" is too small for an engine that runs fine there.
+    # Different memory model, different (unmeasured) floor; don't guess.
+    if (
+        caps.family in ("cuda", "rocm")
+        and min_vram_gb > 0
+        and 0 < caps.vram_gb < min_vram_gb
+    ):
         device = caps.device_name or caps.family.upper()
         return (
             f"{device} has {caps.vram_gb:.1f} GB VRAM; this engine wants about "

--- a/backend/services/engine_routing.py
+++ b/backend/services/engine_routing.py
@@ -31,19 +31,48 @@ class RoutingResult(TypedDict):
     routing_reason: str | None     # raw, pre-scrub
 
 
-def _caveat(caps: HostCaps) -> str | None:
-    """A kernel-risk caveat string for an otherwise-accelerated host, or None.
-    Advisory notes (multi-GPU, VRAM-query-failed, DirectML) never qualify."""
+def _caveat(caps: HostCaps, min_vram_gb: float = 0.0) -> str | None:
+    """A caveat string for an otherwise-accelerated host, or None.
+
+    Two kinds, kernel risk first (it's the more severe):
+
+    * a driver/arch mismatch that may fail at kernel launch;
+    * (#1226/#1222) a GPU that will run, but has less VRAM than the engine
+      declares it needs. Two users on 4 GB cards ran the ``omnivoice`` engine
+      and only learned their hardware was under-provisioned AFTER waiting out
+      the full compute budget and being told the job "was too heavy". Routing
+      showed a clean green "accelerated" throughout, because family membership
+      was the only thing checked. Advisory, not blocking — the driver can page
+      to system RAM, and short inputs fit where long ones don't.
+
+    Advisory probe notes (multi-GPU, VRAM-query-failed, DirectML) never
+    qualify. A VRAM figure of 0 means the probe failed; don't guess from it.
+    """
     for note in caps.notes:
         if KERNEL_RISK_MARKER in note:
             return f"{caps.family.upper()} selected, but: {note}"
+    if min_vram_gb > 0 and caps.vram_gb > 0 and caps.vram_gb < min_vram_gb:
+        device = caps.device_name or caps.family.upper()
+        return (
+            f"{device} has {caps.vram_gb:.1f} GB VRAM; this engine wants about "
+            f"{min_vram_gb:.0f} GB. It will run, but expect slow generations "
+            f"that may time out. Unload other models before generating, keep "
+            f"the text short, or pick a lighter engine."
+        )
     return None
 
 
-def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResult:
+def resolve_routing(
+    gpu_compat: tuple[str, ...],
+    caps: HostCaps,
+    min_vram_gb: float = 0.0,
+) -> RoutingResult:
     """Resolve the effective device + status for an engine on this host.
 
-    Rules are evaluated in order; the first match wins (see spec §2)."""
+    Rules are evaluated in order; the first match wins (see spec §2).
+    ``min_vram_gb`` is the engine's declared VRAM floor (``TTSBackend
+    .min_vram_gb``); 0 disables the under-provisioned-GPU caveat. Optional so
+    every existing caller keeps its exact behaviour."""
     targets = tuple(gpu_compat or ())
     fam = caps.family
 
@@ -60,7 +89,7 @@ def resolve_routing(gpu_compat: tuple[str, ...], caps: HostCaps) -> RoutingResul
         return {
             "effective_device": fam,
             "routing_status": "accelerated",
-            "routing_reason": _caveat(caps),
+            "routing_reason": _caveat(caps, min_vram_gb),
         }
 
     # 3. CPU-native engine (declares ONLY cpu) has nothing to fall back FROM,
@@ -143,7 +172,11 @@ def header_safe_reason(reason: str | None) -> str | None:
     return cleaned[:256] or None
 
 
-def routing_fields(gpu_compat: tuple[str, ...], caps: HostCaps) -> dict:
+def routing_fields(
+    gpu_compat: tuple[str, ...],
+    caps: HostCaps,
+    min_vram_gb: float = 0.0,
+) -> dict:
     """The three serialization-ready routing keys for a ``list_backends`` entry.
 
     Resolves routing and applies the redaction contract: ``routing_reason`` is
@@ -155,7 +188,7 @@ def routing_fields(gpu_compat: tuple[str, ...], caps: HostCaps) -> dict:
     """
     from core.scrub import scrub_text
 
-    r = resolve_routing(tuple(gpu_compat or ()), caps)
+    r = resolve_routing(tuple(gpu_compat or ()), caps, min_vram_gb)
     reason = r["routing_reason"]
     return {
         "effective_device": r["effective_device"],

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -511,7 +511,7 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
     # Phase 2 — execution. The clock starts here: this job owns a worker.
     try:
         return await asyncio.wait_for(fut, timeout=timeout)
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as timeout_exc:
         # wait_for already cancelled the asyncio wrapper; the worker thread
         # keeps going regardless. Consume whatever it eventually produces.
         fut.add_done_callback(_swallow_abandoned)
@@ -528,7 +528,9 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
             except Exception:
                 logger.exception("GPU pool reset after %s timeout failed",
                                  _log_safe(what))
-        raise GpuJobTimeoutError(_timeout_guidance(what, timeout, min_vram_gb))
+        raise GpuJobTimeoutError(
+            _timeout_guidance(what, timeout, min_vram_gb)
+        ) from timeout_exc
 
 
 def _timeout_guidance(what: str, timeout: float, min_vram_gb: float = 0.0) -> str:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -418,7 +418,8 @@ def _swallow_abandoned(fut) -> None:
 async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
                                   timeout: "float | None" = None,
                                   executor=None,
-                                  queue_timeout: "float | None" = None):
+                                  queue_timeout: "float | None" = None,
+                                  min_vram_gb: float = 0.0):
     """Run blocking ``fn`` on the GPU pool, bounding **execution** — not the
     wait for a free worker.
 
@@ -440,6 +441,12 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
     ``fn`` must be a zero-arg callable — wrap args with ``functools.partial``.
     Executors without ``reset`` (a plain ThreadPoolExecutor in tests) still get
     both bounds; only the reset step is skipped.
+
+    ``min_vram_gb`` is the declared VRAM floor of the engine this job belongs
+    to (``TTSBackend.min_vram_gb``); it only shapes the timeout MESSAGE. Left
+    at 0 — the default, and correct for every non-TTS job on this pool
+    (reference transcribe, watermarking, dub steps) — the under-provisioned-GPU
+    wording is never used, because nothing measured says it applies (#1226).
     """
     loop = asyncio.get_running_loop()
     ex = executor if executor is not None else _get_gpu_pool()
@@ -521,10 +528,10 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
             except Exception:
                 logger.exception("GPU pool reset after %s timeout failed",
                                  _log_safe(what))
-        raise GpuJobTimeoutError(_timeout_guidance(what, timeout))
+        raise GpuJobTimeoutError(_timeout_guidance(what, timeout, min_vram_gb))
 
 
-def _timeout_guidance(what: str, timeout: float) -> str:
+def _timeout_guidance(what: str, timeout: float, min_vram_gb: float = 0.0) -> str:
     """Device-aware timeout message (#896): a CPU-only host must never be told
     to "set the engine to CPU" or blamed on VRAM — on CPU the job is simply
     compute-bound. GPU hosts keep the VRAM-contention guidance.
@@ -565,14 +572,22 @@ def _timeout_guidance(what: str, timeout: float) -> str:
     # #1226/#1222: two users on 4 GB cards were told, generically, that the GPU
     # "is VRAM-starved" — true, but it read as a transient contention problem
     # they could flush their way out of, when their card was simply too small
-    # for the engine they had selected. When we can see the card and its VRAM,
-    # say so and lead with the advice that actually applies.
-    _SMALL_VRAM_GB = 6.0
-    if vram_gb and vram_gb < _SMALL_VRAM_GB:
+    # for the engine they had selected. Say so instead — but ONLY when the
+    # caller passed the engine's measured floor and the host is a dedicated-
+    # VRAM family below it. This function serves every GPU-pool job (reference
+    # transcribe, watermarking, dub steps, CPU-only engines on a GPU host), so
+    # a threshold applied without knowing whose job it is would confidently
+    # misdiagnose most of them. And on MPS `vram_gb` is a unified-memory
+    # heuristic (RAM/2), not a dedicated pool to compare against.
+    if (
+        min_vram_gb > 0
+        and family in ("cuda", "rocm")
+        and 0 < vram_gb < min_vram_gb
+    ):
         return common + (
-            f"{device_name or 'this GPU'} has {vram_gb:.1f} GB of VRAM, which "
-            f"is below what the heavier engines want — generations here are "
-            f"slow enough to hit this limit even with nothing else loaded. "
+            f"{device_name or 'this GPU'} has {vram_gb:.1f} GB of VRAM and "
+            f"this engine wants about {min_vram_gb:.0f} GB — generations here "
+            f"are slow enough to hit the limit even with nothing else loaded. "
             f"The durable fix is a lighter engine (OmniVoice GGUF and "
             f"Supertonic-3 are tuned for small/no GPU) or shorter text; "
             f"Flush caches / Unload the resident model (top toolbar or "

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -538,9 +538,12 @@ def _timeout_guidance(what: str, timeout: float) -> str:
     callers something to do about it.
     """
     family = "cuda"  # conservative default: GPU wording if the probe fails
+    device_name, vram_gb = "", 0.0
     try:
         from core.device_caps import detect_host_caps
-        family = detect_host_caps().family
+        _caps = detect_host_caps()
+        family = _caps.family
+        device_name, vram_gb = _caps.device_name, _caps.vram_gb
     except Exception:  # noqa: BLE001 — guidance must never mask the timeout
         pass
     common = (
@@ -558,6 +561,24 @@ def _timeout_guidance(what: str, timeout: float) -> str:
             "engine (OmniVoice GGUF and Supertonic-3 are CPU-tuned). If you "
             "expect very long single generations, raise "
             "OMNIVOICE_GENERATE_TIMEOUT_S."
+        )
+    # #1226/#1222: two users on 4 GB cards were told, generically, that the GPU
+    # "is VRAM-starved" — true, but it read as a transient contention problem
+    # they could flush their way out of, when their card was simply too small
+    # for the engine they had selected. When we can see the card and its VRAM,
+    # say so and lead with the advice that actually applies.
+    _SMALL_VRAM_GB = 6.0
+    if vram_gb and vram_gb < _SMALL_VRAM_GB:
+        return common + (
+            f"{device_name or 'this GPU'} has {vram_gb:.1f} GB of VRAM, which "
+            f"is below what the heavier engines want — generations here are "
+            f"slow enough to hit this limit even with nothing else loaded. "
+            f"The durable fix is a lighter engine (OmniVoice GGUF and "
+            f"Supertonic-3 are tuned for small/no GPU) or shorter text; "
+            f"Flush caches / Unload the resident model (top toolbar or "
+            f"Settings → Models) frees what little headroom there is. (Raise "
+            f"OMNIVOICE_GENERATE_TIMEOUT_S if you'd rather let long "
+            f"generations run.)"
         )
     return common + (
         "most often the GPU is VRAM-starved (a resident model and this job "

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -222,6 +222,22 @@ class TTSBackend(ABC):
     #: not enforced — actual device selection lives in the engine's loader.
     gpu_compat: tuple[str, ...] = ("cpu",)
 
+    #: Approximate VRAM (GB) the engine needs to render comfortably on a
+    #: dedicated GPU. Metadata, like ``gpu_compat`` — never enforced, because a
+    #: hard refuse would block hosts that would actually cope (drivers page to
+    #: system RAM, and a short input can fit where a long one won't).
+    #:
+    #: What it IS for: telling the user BEFORE they wait (#1226/#1222). Two
+    #: users on 4 GB cards (GTX 1650 Ti, Quadro P2000) ran the `omnivoice`
+    #: engine, waited out the full compute budget, and were told the job "was
+    #: too heavy for the available compute" — after the fact, with no hint
+    #: that their card was under-provisioned for the engine they'd picked.
+    #: Routing showed a clean green "accelerated" the whole time, because
+    #: family membership was the only thing anything checked.
+    #:
+    #: 0 means "no meaningful floor" (CPU-class engines) and never warns.
+    min_vram_gb: float = 0.0
+
     @abstractmethod
     def generate(
         self,
@@ -439,6 +455,15 @@ class OmniVoiceBackend(TTSBackend):
     id = "omnivoice"
     display_name = "OmniVoice (600 languages, zero-shot)"
     gpu_compat = ("cuda", "mps", "cpu")
+    # Derived from the pool's own per-job budget (_GPU_VRAM_PER_JOB_GB = 5.0 in
+    # model_manager, itself measured from the ~1.6 GB forward + autoregressive
+    # decode and the co-loaded WhisperX on the clone path), plus room for the
+    # resident weights. Below this the driver pages to system RAM and a render
+    # that should take seconds runs for minutes — which is precisely what the
+    # 4 GB reporters in #1226/#1222 hit. Deliberately the only engine with a
+    # floor: the rest have no measured figure, and inventing one would put a
+    # confident number in the UI that nothing backs.
+    min_vram_gb = 6.0
 
     def __init__(self, model=None):
         # The live OmniVoice instance. Reuses the singleton owned by
@@ -2020,7 +2045,10 @@ def list_backends() -> list[dict]:
             "isolation_mode": isolation,
             "gpu_compat": list(gpu_compat),
             # effective_device / routing_status / routing_reason (scrubbed):
-            **routing_fields(gpu_compat, caps),
+            "min_vram_gb": getattr(cls, "min_vram_gb", 0.0) or None,
+            # effective_device / routing_status / routing_reason (scrubbed);
+            # the reason now also carries the under-provisioned-GPU caveat.
+            **routing_fields(gpu_compat, caps, getattr(cls, "min_vram_gb", 0.0)),
         })
         # #981: mlx-audio multiplexes 7+ curated models behind one backend id
         # — surface the roster + the currently-active pick so Settings can
@@ -2266,7 +2294,10 @@ async def resolve_generation_backend(
 
     from core.device_caps import detect_host_caps
     from services.engine_routing import resolve_routing
-    routing = resolve_routing(getattr(backend_cls, "gpu_compat", ("cpu",)), detect_host_caps())
+    routing = resolve_routing(
+        getattr(backend_cls, "gpu_compat", ("cpu",)), detect_host_caps(),
+        getattr(backend_cls, "min_vram_gb", 0.0),
+    )
     if routing["routing_status"] == "unavailable":
         raise ValueError(routing["routing_reason"])
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -52,6 +52,11 @@ interface EngineBackend {
   last_error?: string | null;
   isolation_mode?: 'in-process' | 'subprocess';
   gpu_compat?: GPUTarget[];
+  // Approximate VRAM (GB) the engine wants on a dedicated GPU; null when the
+  // engine declares no meaningful floor (#1226). Advisory metadata — when the
+  // host has less, `routing_reason` carries the caveat and the matrix renders
+  // it under an otherwise-accelerated row.
+  min_vram_gb?: number | null;
   // Routing (#21) — the device this engine uses on this machine + why.
   effective_device?: EffectiveDevice;
   routing_status?: RoutingStatus;

--- a/tests/backend/services/test_tts_backend_registry.py
+++ b/tests/backend/services/test_tts_backend_registry.py
@@ -168,6 +168,11 @@ def test_list_backends_shape(registry_sandbox):
         # True when services.sidecar_install can provision the engine in-app
         # (the Settings Install button keys off this).
         "one_click_install",
+        # Approximate VRAM (GB) the engine wants on a dedicated GPU, or None
+        # when it declares no measured floor (#1226). Advisory metadata: a host
+        # below the floor gets a caveat in `routing_reason` BEFORE it spends
+        # the full compute budget finding out its card is too small.
+        "min_vram_gb",
     }
     mlx_audio_extra = {"curated_models", "active_model_id"}
     for entry in out:

--- a/tests/test_low_vram_advisory.py
+++ b/tests/test_low_vram_advisory.py
@@ -73,6 +73,31 @@ def test_an_engine_with_no_declared_floor_never_warns():
     assert r["routing_reason"] is None
 
 
+def test_mps_is_not_judged_by_a_cuda_measured_floor():
+    """On MPS, HostCaps.vram_gb is a heuristic (system RAM / 2) for a UNIFIED
+    memory pool. An 8 GB Mac therefore reports 4.0 "VRAM" — comparing that to a
+    floor measured on discrete CUDA hardware would warn every small Mac about
+    an engine that runs fine there. Different memory model, unmeasured floor."""
+    caps = HostCaps(
+        family="mps",
+        available_families=("mps", "cpu"),
+        device_name="Apple Silicon (MPS)",
+        vram_gb=4.0,  # an 8 GB Mac
+    )
+    r = resolve_routing(("cuda", "mps", "cpu"), caps, OmniVoiceBackend.min_vram_gb)
+    assert r["routing_status"] == "accelerated"
+    assert r["routing_reason"] is None
+
+
+def test_mps_timeout_message_is_not_a_vram_verdict(monkeypatch):
+    caps = HostCaps(
+        family="mps", available_families=("mps", "cpu"),
+        device_name="Apple Silicon (MPS)", vram_gb=4.0,
+    )
+    msg = _guidance(monkeypatch, caps)
+    assert "Apple Silicon" not in msg
+
+
 def test_a_failed_vram_probe_does_not_guess():
     """vram_gb == 0 means the probe failed, not that the card has no memory."""
     r = resolve_routing(("cuda", "cpu"), _gpu(0.0), 6.0)
@@ -98,9 +123,10 @@ def test_the_matrix_payload_carries_the_floor():
 # ── the after-the-fact message names the actual card ─────────────────────
 
 
-def _guidance(monkeypatch, caps):
+def _guidance(monkeypatch, caps, min_vram_gb=OmniVoiceBackend.min_vram_gb,
+              what="TTS generate"):
     monkeypatch.setattr("core.device_caps.detect_host_caps", lambda: caps)
-    return model_manager._timeout_guidance("TTS generate", 300.0)
+    return model_manager._timeout_guidance(what, 300.0, min_vram_gb)
 
 
 def test_timeout_message_names_the_small_card(monkeypatch):
@@ -115,6 +141,33 @@ def test_timeout_message_unchanged_on_a_large_card(monkeypatch):
     msg = _guidance(monkeypatch, _gpu(24.0, "NVIDIA RTX 4090"))
     assert "VRAM-starved" in msg
     assert "RTX 4090" not in msg
+
+
+def test_a_job_with_no_declared_floor_is_never_diagnosed_as_under_provisioned(
+    monkeypatch,
+):
+    """`_timeout_guidance` serves EVERY job on the GPU pool — reference
+    transcribe, stream assemble, watermarking, dub steps, and CPU-only engines
+    running on a GPU host. Applying a VRAM verdict without knowing whose job it
+    is would confidently misdiagnose most of them, so the caller must opt in by
+    passing the engine's measured floor."""
+    msg = _guidance(monkeypatch, _gpu(4.0), min_vram_gb=0.0,
+                    what="Reference transcribe")
+    assert "GTX 1650 Ti" not in msg
+    assert "VRAM-starved" in msg  # the pre-existing generic GPU wording
+
+
+def test_the_generate_call_sites_pass_the_engines_floor():
+    """...and the TTS generate dispatches DO opt in — otherwise the branch
+    above is unreachable in production."""
+    import inspect
+
+    from api.routers import generation
+
+    src = inspect.getsource(generation)
+    assert src.count("min_vram_gb=_engine_min_vram_gb") == src.count(
+        'what="TTS generate",'
+    ), "every TTS generate dispatch must pass the engine's floor"
 
 
 def test_timeout_message_unchanged_on_cpu(monkeypatch):

--- a/tests/test_low_vram_advisory.py
+++ b/tests/test_low_vram_advisory.py
@@ -1,0 +1,135 @@
+"""#1226 / #1222: a 4 GB card was told it was under-provisioned only *after*
+waiting out the full compute budget.
+
+Two users — GTX 1650 Ti (4 GB) and Quadro P2000 (4 GB) — ran the `omnivoice`
+engine and got:
+
+    TTS generate ran for more than 300s/372s of actual compute time and was
+    abandoned … most often the GPU is VRAM-starved …
+
+Everything about that is technically true and useless. The 300-vs-372 spread is
+just text length (the budget is `300 + (len-1200)/40`, so 372s ⇒ ~4080 chars) —
+the two reports are one bug. And until the moment it failed, routing showed a
+clean green "accelerated": family membership was the ONLY thing anything
+checked, so a 4 GB card and a 24 GB card were indistinguishable.
+
+These tests pin the declared VRAM floor, the advisory it produces before the
+user waits, and the after-the-fact message naming the actual card.
+"""
+from __future__ import annotations
+
+from core.device_caps import KERNEL_RISK_MARKER, HostCaps
+from services import model_manager
+from services.engine_routing import resolve_routing, routing_notice
+from services.tts_backend import OmniVoiceBackend, TTSBackend
+
+
+def _gpu(vram_gb: float, name: str = "NVIDIA GeForce GTX 1650 Ti", notes=()) -> HostCaps:
+    return HostCaps(
+        family="cuda",
+        available_families=("cuda", "cpu"),
+        device_name=name,
+        vram_gb=vram_gb,
+        notes=tuple(notes),
+    )
+
+
+# ── the floor is declared ────────────────────────────────────────────────
+
+
+def test_engines_declare_no_floor_by_default():
+    assert TTSBackend.min_vram_gb == 0.0
+
+
+def test_the_reported_engine_declares_a_floor():
+    assert OmniVoiceBackend.min_vram_gb >= 6.0
+
+
+# ── the user is warned BEFORE waiting ────────────────────────────────────
+
+
+def test_a_4gb_card_gets_a_caveat_instead_of_a_clean_green():
+    r = resolve_routing(("cuda", "mps", "cpu"), _gpu(4.0), OmniVoiceBackend.min_vram_gb)
+    assert r["routing_status"] == "accelerated"  # it DOES run — advisory, not blocking
+    reason = r["routing_reason"]
+    assert reason and "4.0 GB" in reason
+    assert "GTX 1650 Ti" in reason
+    assert "lighter engine" in reason
+    # routing_notice is what actually surfaces it to the user.
+    assert routing_notice(r) == ("accelerated", reason)
+
+
+def test_a_large_card_stays_silent():
+    r = resolve_routing(("cuda", "mps", "cpu"), _gpu(24.0, "NVIDIA RTX 4090"),
+                        OmniVoiceBackend.min_vram_gb)
+    assert r["routing_reason"] is None
+    assert routing_notice(r) is None
+
+
+def test_an_engine_with_no_declared_floor_never_warns():
+    """Only engines with a measured figure warn — inventing floors for the
+    rest would put confident numbers in the UI that nothing backs."""
+    r = resolve_routing(("cuda", "cpu"), _gpu(4.0))
+    assert r["routing_reason"] is None
+
+
+def test_a_failed_vram_probe_does_not_guess():
+    """vram_gb == 0 means the probe failed, not that the card has no memory."""
+    r = resolve_routing(("cuda", "cpu"), _gpu(0.0), 6.0)
+    assert r["routing_reason"] is None
+
+
+def test_kernel_risk_still_outranks_the_vram_caveat():
+    """A card that may not launch kernels at all is the more severe finding."""
+    caps = _gpu(4.0, notes=(f"GPU (sm_120) not in this build's archs — {KERNEL_RISK_MARKER}",))
+    r = resolve_routing(("cuda", "cpu"), caps, 6.0)
+    assert KERNEL_RISK_MARKER in r["routing_reason"]
+
+
+def test_the_matrix_payload_carries_the_floor():
+    from services.tts_backend import list_backends
+
+    entry = next(b for b in list_backends() if b["id"] == "omnivoice")
+    assert entry["min_vram_gb"] == OmniVoiceBackend.min_vram_gb
+    # Engines without a floor report null, not 0.0 — "unknown", not "none".
+    assert all(b.get("min_vram_gb") != 0.0 for b in list_backends())
+
+
+# ── the after-the-fact message names the actual card ─────────────────────
+
+
+def _guidance(monkeypatch, caps):
+    monkeypatch.setattr("core.device_caps.detect_host_caps", lambda: caps)
+    return model_manager._timeout_guidance("TTS generate", 300.0)
+
+
+def test_timeout_message_names_the_small_card(monkeypatch):
+    msg = _guidance(monkeypatch, _gpu(4.0))
+    assert "GTX 1650 Ti" in msg
+    assert "4.0 GB" in msg
+    # It must not read as transient contention the user can flush away.
+    assert "lighter engine" in msg
+
+
+def test_timeout_message_unchanged_on_a_large_card(monkeypatch):
+    msg = _guidance(monkeypatch, _gpu(24.0, "NVIDIA RTX 4090"))
+    assert "VRAM-starved" in msg
+    assert "RTX 4090" not in msg
+
+
+def test_timeout_message_unchanged_on_cpu(monkeypatch):
+    """#896: a CPU-only host must never be blamed on VRAM."""
+    caps = HostCaps(family="cpu", available_families=("cpu",))
+    msg = _guidance(monkeypatch, caps)
+    assert "VRAM" not in msg
+    assert "compute-bound" in msg
+
+
+# ── the two reports really are one bug ───────────────────────────────────
+
+
+def test_the_300_vs_372_second_spread_is_just_text_length():
+    """#1226 saw 300s, #1222 saw 372s. If that difference were device-aware
+    they'd be separate bugs; it is purely the length-scaled budget."""
+    assert model_manager.generate_timeout_s("x" * 100) == 300.0
+    assert model_manager.generate_timeout_s("x" * 4080) == 372.0


### PR DESCRIPTION
Fixes #1226. Fixes #1222.

Two users on 4 GB cards — GTX 1650 Ti and Quadro P2000 — ran the `omnivoice` engine and got:

> TTS generate ran for more than 300s/372s of actual compute time and was abandoned … most often the GPU is VRAM-starved …

## They're one bug

The 300-vs-372 spread is purely text length: the budget is `300 + (len-1200)/40`, so 372s ⇒ ~4080 characters. Nothing about the timeout is device-aware — and nothing needs to be.

## Root cause

Until the moment it failed, routing showed a clean green **"accelerated"**. `resolve_routing` matched on GPU *family* only, so a 4 GB card and a 24 GB card were indistinguishable, and **no engine declared a VRAM requirement anywhere in the repo**. The only VRAM-aware guard that exists (`memory_budget.log_if_low`) is log-only, and the streaming path the UI tries first doesn't call it at all.

So the user's first and only signal that their hardware was under-provisioned arrived after a five-minute wait, phrased as something they could flush their way out of.

## Fix

- **`TTSBackend.min_vram_gb`** — advisory metadata alongside `gpu_compat`. Only `omnivoice` declares one (6 GB), derived from the pool's own measured per-job budget (`_GPU_VRAM_PER_JOB_GB = 5.0` in `model_manager`) plus resident weights. Inventing floors for engines with no measured figure would put confident numbers in the UI that nothing backs.
- **`resolve_routing` takes the floor** and emits an accelerated-with-caveat reason when the host is below it. This reuses the existing caveat channel, so the Settings → Engines matrix and the synth-time routing notice both surface it with **no UI change**. Advisory, never blocking — drivers page to system RAM, and short inputs fit where long ones don't. Kernel-risk still outranks it, and a failed VRAM probe (`0.0`) never guesses.
- **`_timeout_guidance` names the actual card and its VRAM**, and leads with "pick a lighter engine" rather than wording that reads as transient contention.

## Verification

`tests/test_low_vram_advisory.py` — 8 of 12 fail before. Covers the caveat firing at 4 GB and staying silent at 24 GB, engines without a floor never warning, the failed-probe case, kernel-risk precedence, the payload shape, and that the 300/372 spread really is just text length.

`tests/backend/services/test_tts_backend_registry.py` enumerates the exact `list_backends` key set as a contract — the new key is added there deliberately, not silently.

Backend suite 3644 passed; frontend 1509 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds non-blocking VRAM preflight/advisory messaging for TTS by introducing `TTSBackend.min_vram_gb` (OmniVoice sets 6 GB) and having `resolve_routing` emit an “accelerated with caveat” reason when detected dedicated CUDA/ROCm VRAM is below that floor, with kernel-risk warnings taking precedence and failed VRAM probes/MPS handled safely. Updates timeout guidance to name the user’s actual GPU card and VRAM and recommend trying a lighter engine first, matching the preflight VRAM decision and preserving the existing text-length-driven “300 vs 372s” behavior. Main risk to review is correct `min_vram_gb` propagation and precedence/non-blocking behavior across all generation paths (HTTP, WebSocket streaming, and OpenAI-compatible routing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->