### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.4.1] — 2026-07-23
 
 **Highlights**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [0.4.1] — 2026-07-23
+## [0.4.1] — 2026-07-27
 
 **Highlights**
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.4.0"
+_FALLBACK_VERSION = "0.4.1"
 
 
 def _fallback_version() -> str:

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -90,12 +90,12 @@ There's also a Compose file in the repo with `cpu` / `gpu` / `rocm` profiles
 |-----|--------------|
 | `:latest` | **Rolling preview** — latest commit on `main`, at or ahead of the last release. This is the preview channel; pin `:stable` for production. |
 | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-| `:0.4.0` | Exact release version |
+| `:0.4.1` | Exact release version |
 | `:0.4` | Latest patch within the `0.4` minor |
 | `:main` | Alias of the same rolling `main` build as `:latest` |
 | `:sha-xxxxxxx` | A specific commit (produced by manual workflow dispatch) |
 | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
-| `:stable-rocm`, `:0.4.0-rocm`, `:0.4-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
+| `:stable-rocm`, `:0.4.1-rocm`, `:0.4-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
 
 Preview builds always come from `main` and never version-sort below `:stable`,
 so upgrades flow naturally. The same images and tags

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -13,12 +13,12 @@ and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palash
 > |-----|--------------|
 > | `:latest` | **Rolling preview** — latest commit on `main`, at or ahead of the last release. This is the preview channel; pin `:stable` for production. |
 > | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-> | `:0.4.0` | Exact release version |
+> | `:0.4.1` | Exact release version |
 > | `:0.4` | Latest patch within the 0.4 minor |
 > | `:main` | Alias of the same rolling `main` build as `:latest` |
 > | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |
 > | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
-> | `:stable-rocm`, `:0.4.0-rocm`, `:0.4-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
+> | `:stable-rocm`, `:0.4.1-rocm`, `:0.4-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
 >
 > Versioning rule: preview builds always come from `main` and never
 > version-sort below `:stable` — upgrades flow naturally.
@@ -89,7 +89,7 @@ PublishPort=127.0.0.1:3900:3900
 Volume=omnivoice-data:/app/omnivoice_data
 ```
 
-Release pins exist too: `:stable-rocm`, `:0.4.0-rocm`, `:0.4-rocm` mirror
+Release pins exist too: `:stable-rocm`, `:0.4.1-rocm`, `:0.4-rocm` mirror
 the CUDA tags exactly.
 
 > **Consumer cards and APUs (RX 6000/7000, Strix Point/Halo):** the backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.4.0"
+version = "0.4.1"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.4.0"
+version = "0.4.1"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3233,7 +3233,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Cuts **v0.4.1** — seven user-reported issues fixed since v0.4.0.

| Issue | Fix |
|---|---|
| #1228 | ROCm hosts were **all** silently force-routed to CPU (`sm_` tag vs `gfx` list) |
| #1229 | One eager `transformers` import killed the whole backend at startup |
| #1227 | Windows Smart App Control / WDAC block now named, with the setting to change |
| #1221 | `LibsndfileError: System error.` now names the file, folder and free space |
| #1225 | Dub disk error pointed users at the wrong folder |
| #1223 | Port conflict reported as "Backend died (exit code 1)" |
| #1224 | A model download truncated at 90% aborted the whole install |
| #1226, #1222 | 4 GB cards showed green "accelerated" until the job timed out |

## Version

`frontend/package.json` 0.4.0 → 0.4.1, plus the three toolchain mirrors (`Cargo.toml`, `pyproject.toml`, `_FALLBACK_VERSION`) — `tests/test_app_version.py` passes. `uv.lock` regenerated; `bun install --frozen-lockfile` clean.

`## [Unreleased]` renamed to `## [0.4.1] — 2026-07-23`, which `release.yml` extracts verbatim as the Release body.

## Docs

Docker tag examples updated to 0.4.1 in `docs/install/docker.md` and `deploy/dockerhub-overview.md` (docs-sync rule).

## After merge

Tag `v0.4.1` from main → 4-platform installers, signed `latest.json`, GHCR + Docker Hub in CUDA and ROCm flavours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Releases v0.4.1 and syncs version metadata across backend, frontend, Tauri, Python packaging, changelog, `uv.lock`, plus Docker tag/documentation examples, including updating the version fallback to `0.4.1`. This keeps release downloads/routing consistent while bundling user-facing fixes (ROCm routing, startup imports, Windows security messaging, disk/storage and port-conflict reporting, truncated model downloads, and incorrect acceleration status on 4 GB GPUs), with `tests/test_app_version.py` passing and dependency installation reported clean. Human review is worth a spot-check to ensure the regenerated lockfile and the 0.4.1 Docker/CUDA/ROCm tags don’t drift across platforms and don’t reintroduce download/routing mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->