### PR TITLE
fix(first-run): keep Continue + the HF token box on screen; no status bar yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A GPU too small for the chosen engine now says so up front, not after a five-minute wait
 - A port conflict now says so, instead of "Backend died (exit code 1)"
 - A model download that dies at 90% now resumes instead of failing the install
+- First run: Continue and the Hugging Face token box no longer sit under the status bar
+
+### Changed
+
+- First run: the status bar (Logs, version, Sponsors) appears once you reach the studio, instead of overlaying the setup steps (#1240)
 
 ### Docs
 
@@ -36,6 +41,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Colab notebook: the install cell now catches a broken environment with the real error, instead of a 5-minute health timeout two cells later — thanks @Navdeep-Chauhan-777! (#1229)
 - A GPU with less VRAM than the chosen engine needs is flagged in Settings → Engines before you generate, instead of showing a clean green "accelerated" until the job times out — thanks @AdityaHemantBhat and @beingavais! (#1226, #1222)
 - A generation timeout now names your actual card and its VRAM and recommends a lighter engine (#1226, #1222)
+- First run: Continue and the Hugging Face token box rendered underneath the status bar, off the bottom of the window — the wizard laid itself out against the viewport instead of its own frame (#1240)
 - A busy port 3900 now reports a port conflict instead of "Backend died (exit code 1)", in every language — thanks @xipb14! (#1223)
 - The app verifies it actually freed the port before starting the backend, rather than assuming the kill worked (#1223)
 - A model download truncated near the end is now retried and resumed instead of aborting the whole install — thanks @Reaksa-Cambodia! (#1224)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Changed
 
-- First run: the status bar (Logs, version, Sponsors) appears once you reach the studio, instead of overlaying the setup steps (#1240)
+- First run: the status bar (Logs, version, Sponsors) appears once you reach the studio, instead of overlaying the setup steps (#1241)
 
 ### Docs
 
@@ -41,7 +41,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Colab notebook: the install cell now catches a broken environment with the real error, instead of a 5-minute health timeout two cells later — thanks @Navdeep-Chauhan-777! (#1229)
 - A GPU with less VRAM than the chosen engine needs is flagged in Settings → Engines before you generate, instead of showing a clean green "accelerated" until the job times out — thanks @AdityaHemantBhat and @beingavais! (#1226, #1222)
 - A generation timeout now names your actual card and its VRAM and recommends a lighter engine (#1226, #1222)
-- First run: Continue and the Hugging Face token box rendered underneath the status bar, off the bottom of the window — the wizard laid itself out against the viewport instead of its own frame (#1240)
+- First run: Continue and the Hugging Face token box rendered underneath the status bar, off the bottom of the window — the wizard laid itself out against the viewport instead of its own frame (#1241)
 - A busy port 3900 now reports a port conflict instead of "Backend died (exit code 1)", in every language — thanks @xipb14! (#1223)
 - The app verifies it actually freed the port before starting the backend, rather than assuming the kill worked (#1223)
 - A model download truncated near the end is now retried and resumed instead of aborting the whole install — thanks @Reaksa-Cambodia! (#1224)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1165,9 +1165,6 @@ function App() {
     return (
       <div style={{ zoom: uiScale }}>
         <BootstrapSplash stage={bootstrapStage} message={bootstrapMessage} />
-        <Suspense fallback={null}>
-          <LogsFooter />
-        </Suspense>
       </div>
     );
   }
@@ -1203,9 +1200,6 @@ function App() {
               setSetupNeeded(false);
             }}
           />
-        </Suspense>
-        <Suspense fallback={null}>
-          <LogsFooter />
         </Suspense>
       </div>
     );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2533,12 +2533,16 @@ input[type="file"]::file-selector-button:hover {
 }
 .app-startup__title { font-size: 18px; color: #ebdbb2; }
 .app-wizard-wrap {
-  /* Fill viewport above the fixed LogsFooter */
+  /* Fills the WHOLE viewport: the first-run wizard deliberately renders no
+     LogsFooter (studio chrome belongs to the studio), so there is nothing to
+     reserve space for. While it did reserve 28px, the wizard's own root was
+     `fixed inset-0` and escaped this box anyway — its pinned Continue / HF
+     token row rendered underneath the status bar and was unreachable. */
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  bottom: var(--logs-footer-height, 28px);
+  bottom: 0;
   overflow: hidden;
   background: var(--color-bg, #1d2021);
   display: flex;

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -294,7 +294,12 @@ export default function SetupWizard({ onReady }) {
   };
 
   return (
-    <div className="fixed inset-0 flex flex-col items-center overflow-hidden bg-bg px-6 pt-12 font-sans text-fg">
+    // `absolute`, not `fixed`: this mounts inside `.app-wizard-wrap`, and a
+    // fixed root would ignore that box and lay its pinned footer out against
+    // the viewport — putting Continue and the HF-token card behind the status
+    // bar, off the bottom of the window. `pb-4` keeps the pinned row off the
+    // very edge now that it really is the last thing on screen.
+    <div className="absolute inset-0 flex flex-col items-center overflow-hidden bg-bg px-6 pb-4 pt-12 font-sans text-fg">
       <div className="flex w-full max-w-[1100px] flex-1 flex-col">
         {/* ── Masthead: identical identity to setup + install acts ────────── */}
         <header

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -66,6 +66,10 @@ describe('SetupWizard — the pinned action row stays on screen', () => {
     // `fixed` ignores .app-wizard-wrap's box; `absolute` fills it.
     expect(root.className).not.toMatch(/\bfixed\b/);
     expect(root.className).toMatch(/\babsolute\b/);
+    // ...and the pinned row needs clearance now that it really is the last
+    // thing on screen — flush against the window edge is the same bug's
+    // cosmetic tail.
+    expect(root.className).toMatch(/\bpb-\d/);
   });
 
   it('keeps Continue and the HF-token card OUT of the scrolling region', async () => {
@@ -93,16 +97,21 @@ describe('SetupWizard — the pinned action row stays on screen', () => {
 describe('studio chrome does not appear before the studio', () => {
   it('renders no LogsFooter in the first-run wizard or the pre-wizard splash', () => {
     const app = readSrc('App.jsx');
-    // One render site remains: the studio itself.
-    const mounts = app.match(/<LogsFooter\s*\/>/g) || [];
-    expect(mounts).toHaveLength(1);
 
-    // ...and it is not inside either pre-home branch.
-    const wizardBranch = app.slice(
-      app.indexOf('className="app-wizard-wrap"'),
-      app.indexOf('// Block the main UI until Rust reports the backend is ready'),
+    // Split App.jsx at the last pre-studio early return. Everything above is a
+    // screen the user sees BEFORE the studio (awaiting_setup splash,
+    // !setupChecked splash, the wizard); everything below is the studio.
+    const split = app.indexOf(
+      '// Block the main UI until Rust reports the backend is ready',
     );
-    expect(wizardBranch).not.toContain('<LogsFooter />');
+    expect(split).toBeGreaterThan(0);
+    const preStudio = app.slice(app.indexOf("if (bootstrapStage === 'awaiting_setup')"), split);
+    const studio = app.slice(split);
+
+    // Asserted per-branch rather than as a global count: a bare count of 1
+    // would still pass if the mount MOVED from the studio into the splash.
+    expect(preStudio).not.toContain('LogsFooter');
+    expect(studio.match(/<LogsFooter\s*\/>/g) || []).toHaveLength(1);
   });
 
   it('gives the wizard the whole viewport, since nothing is reserved below it', () => {

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -101,9 +101,7 @@ describe('studio chrome does not appear before the studio', () => {
     // Split App.jsx at the last pre-studio early return. Everything above is a
     // screen the user sees BEFORE the studio (awaiting_setup splash,
     // !setupChecked splash, the wizard); everything below is the studio.
-    const split = app.indexOf(
-      '// Block the main UI until Rust reports the backend is ready',
-    );
+    const split = app.indexOf('// Block the main UI until Rust reports the backend is ready');
     expect(split).toBeGreaterThan(0);
     const preStudio = app.slice(app.indexOf("if (bootstrapStage === 'awaiting_setup')"), split);
     const studio = app.slice(split);

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -1,0 +1,118 @@
+/**
+ * First-run wizard chrome: the pinned action row must stay on screen, and the
+ * studio's status bar must not appear before the user reaches the studio.
+ *
+ * The bug: `SetupWizard`'s root was `fixed inset-0`, so it laid itself out
+ * against the VIEWPORT rather than `.app-wizard-wrap` — the box App.jsx sizes
+ * to stop above the fixed `LogsFooter`. Its pinned footer (Continue, Back, and
+ * the "set a Hugging Face token" card) therefore rendered underneath the status
+ * bar, clipped off the bottom of the window: on the Models & engines step the
+ * Continue button was simply unreachable.
+ *
+ * Both halves are pinned here — the root must not be `fixed`, and the wizard
+ * branch must render no `LogsFooter` — because either one alone reintroduces
+ * the clip.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import fs from 'node:fs';
+import path from 'node:path';
+import i18n from '../i18n';
+
+vi.mock('../components/WizardLibrary', () => ({ default: () => null }));
+vi.mock('../components/MediaEngineCard', () => ({ default: () => null }));
+vi.mock('../components/MirrorRescue', () => ({ default: () => null }));
+vi.mock('../components/DictationDemo', () => ({ default: () => null }));
+vi.mock('../components/HfTokenCard', () => ({
+  default: ({ className }) => <div data-testid="hf-token-card" className={className} />,
+}));
+vi.mock('../api/external', () => ({ openExternal: vi.fn(() => Promise.resolve()) }));
+
+vi.mock('../api/hooks', () => ({
+  useSetupStatus: () => ({
+    data: { models_ready: true, missing: [], hf_cache_dir: '/tmp/hf' },
+    refetch: vi.fn(),
+  }),
+  usePreflight: () => ({
+    data: { ok: true, has_warnings: false, checks: [] },
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('../api/client', () => ({
+  apiJson: vi.fn(() => Promise.resolve({ available: false, prompted: true })),
+  apiFetch: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })),
+  API: '',
+}));
+
+import SetupWizard from '../pages/SetupWizard';
+
+const withI18n = (node) => <I18nextProvider i18n={i18n}>{node}</I18nextProvider>;
+
+const readSrc = (rel) =>
+  fs.readFileSync(path.resolve(__dirname, '..', rel), 'utf8');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('SetupWizard — the pinned action row stays on screen', () => {
+  it('does not position its root against the viewport', () => {
+    const { container } = render(withI18n(<SetupWizard onReady={() => {}} />));
+    const root = container.firstElementChild;
+
+    // `fixed` ignores .app-wizard-wrap's box; `absolute` fills it.
+    expect(root.className).not.toMatch(/\bfixed\b/);
+    expect(root.className).toMatch(/\babsolute\b/);
+  });
+
+  it('keeps Continue and the HF-token card OUT of the scrolling region', async () => {
+    render(withI18n(<SetupWizard onReady={() => {}} />));
+    fireEvent.click(await screen.findByText(/All good — continue/i));
+
+    // Models step: the token card and the action row are siblings of the
+    // scroller, not children of it — otherwise they scroll away instead of
+    // staying pinned.
+    const card = await screen.findByTestId('hf-token-card');
+    expect(card.className).toMatch(/shrink-0/);
+
+    const cta = await screen.findByText(/Required models ready/i);
+    const row = cta.closest('div');
+    expect(row.className).toMatch(/shrink-0/);
+
+    let el = card;
+    while (el) {
+      expect(el.className || '').not.toMatch(/overflow-y-auto/);
+      el = el.parentElement;
+    }
+  });
+});
+
+describe('studio chrome does not appear before the studio', () => {
+  it('renders no LogsFooter in the first-run wizard or the pre-wizard splash', () => {
+    const app = readSrc('App.jsx');
+    // One render site remains: the studio itself.
+    const mounts = app.match(/<LogsFooter\s*\/>/g) || [];
+    expect(mounts).toHaveLength(1);
+
+    // ...and it is not inside either pre-home branch.
+    const wizardBranch = app.slice(
+      app.indexOf('className="app-wizard-wrap"'),
+      app.indexOf('// Block the main UI until Rust reports the backend is ready'),
+    );
+    expect(wizardBranch).not.toContain('<LogsFooter />');
+  });
+
+  it('gives the wizard the whole viewport, since nothing is reserved below it', () => {
+    const css = readSrc('index.css');
+    const rule = css.slice(css.indexOf('.app-wizard-wrap {'));
+    const body = rule.slice(0, rule.indexOf('}'));
+    // A leftover `bottom: var(--logs-footer-height)` would strand a dead 28px
+    // gap under the wizard now that no footer is rendered there.
+    expect(body).not.toContain('--logs-footer-height');
+    expect(body).toMatch(/bottom:\s*0;/);
+  });
+});

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -52,8 +52,7 @@ import SetupWizard from '../pages/SetupWizard';
 
 const withI18n = (node) => <I18nextProvider i18n={i18n}>{node}</I18nextProvider>;
 
-const readSrc = (rel) =>
-  fs.readFileSync(path.resolve(__dirname, '..', rel), 'utf8');
+const readSrc = (rel) => fs.readFileSync(path.resolve(__dirname, '..', rel), 'utf8');
 
 beforeEach(() => {
   document.body.innerHTML = '';


### PR DESCRIPTION
Reported with a screenshot: on **Models & engines** the "Set token" card was clipped at the window edge and **Continue was off-screen entirely** — unreachable without resizing.

## Root cause — one bug, both halves of the report

`App.jsx` sizes `.app-wizard-wrap` to stop above the fixed `LogsFooter`. But `SetupWizard`'s own root was `fixed inset-0`, so it laid itself out against the **viewport**, escaped that box, and put its pinned footer row underneath the status bar.

The row was already correctly pinned (`shrink-0`, outside the scroller) — it was simply being painted over.

## Fix

- `SetupWizard`'s root is `absolute inset-0`, filling the frame it's given, plus `pb-4` so the pinned row clears the window edge.
- The wizard **and** the pre-wizard splash render no `LogsFooter`: it's studio chrome, and the rule is that it appears once you land on home.
- `.app-wizard-wrap` reserves nothing below it any more, so no dead 28px gap is left behind.

## Verification

Driven in real Chromium against a stub backend — not only jsdom:

| | `.logs-footer` | action row |
|---|---|---|
| before | present, overlapping | clipped |
| after | absent | fully within viewport (bottom 841 of 900) |

`frontend/src/test/SetupWizardChrome.test.jsx` pins both halves (3 of 4 fail before) — either one alone reintroduces the clip.

Frontend suite: 1526 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed first-run wizard layout by switching `SetupWizard` from `fixed inset-0` to `absolute inset-0`, adding bottom padding, and removing `LogsFooter` from the setup/wizard and pre-studio splash so the Hugging Face token card and Continue action row no longer clip or end up unreachable under the status bar/viewport edge; `.app-wizard-wrap` also stops reserving space via `--logs-footer-height`. Added regression coverage to enforce the footer/action-row “chrome” invariants and verified in Chromium with a stub backend (1,526 frontend tests passing). Risk worth a human look: these positioning and conditional-footer rendering changes could unintentionally affect other first-run vs in-studio layout states and reserved spacing across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->