### PR TITLE
feat(mcp): OMNIVOICE_MCP_ALLOWED_HOSTS — configurable host allowlist for MCP transport security (#1249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
+### Added
+
+- `OMNIVOICE_MCP_ALLOWED_HOSTS` — comma-separated host patterns (e.g. `host.containers.internal:*,192.168.1.5:*`) that extend the MCP SDK's DNS-rebinding allowlist, so AI agents running in Docker containers or on other machines can reach the `/mcp` endpoint. The SDK default is localhost-only; this env var is opt-in (#1249)
+
 **Highlights**
 
 - AMD GPUs are used again — every ROCm host was silently running on the CPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ## [Unreleased]
 
-### Added
-
-- `OMNIVOICE_MCP_ALLOWED_HOSTS` — comma-separated host patterns (e.g. `host.containers.internal:*,192.168.1.5:*`) that extend the MCP SDK's DNS-rebinding allowlist, so AI agents running in Docker containers or on other machines can reach the `/mcp` endpoint. The SDK default is localhost-only; this env var is opt-in (#1249)
-
 **Highlights**
 
 - AMD GPUs are used again — every ROCm host was silently running on the CPU
@@ -21,6 +17,10 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A GPU too small for the chosen engine now says so up front, not after a five-minute wait
 - A port conflict now says so, instead of "Backend died (exit code 1)"
 - A model download that dies at 90% now resumes instead of failing the install
+
+### Added
+
+- `OMNIVOICE_MCP_ALLOWED_HOSTS` — comma-separated host patterns (e.g. `host.containers.internal:*,192.168.1.5:*`) that extend the MCP SDK's DNS-rebinding allowlist, so AI agents running in Docker containers or on other machines can reach the `/mcp` endpoint. The SDK default is localhost-only; this env var is opt-in (#1249)
 
 ### Docs
 

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -122,11 +122,13 @@ def create_mcp_server():
         hosts = [h.strip() for h in _mcp_hosts.split(",") if h.strip()]
         try:
             mcp.settings.transport_security.allowed_hosts.extend(hosts)
-            # Also extend origins (browser-based MCP clients behind a proxy send
-            # an Origin header — agent clients typically don't).
-            mcp.settings.transport_security.allowed_origins.extend(
-                f"http://{h}" for h in hosts
-            )
+            # Also extend origins for both http and https (browser-based MCP
+            # clients behind a proxy send an Origin header — agent clients
+            # typically don't, but a reverse proxy may use either scheme).
+            origins = [
+                f"{scheme}://{h}" for h in hosts for scheme in ("http", "https")
+            ]
+            mcp.settings.transport_security.allowed_origins.extend(origins)
         except Exception as e:
             logger.warning("OMNIVOICE_MCP_ALLOWED_HOSTS not applied (%s)", e)
 

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -114,6 +114,22 @@ def create_mcp_server():
     except Exception:
         pass
 
+    # Extend the MCP SDK's DNS-rebinding allowlist so agents on non-localhost
+    # hosts (Docker's host.containers.internal, a LAN IP, a reverse proxy) can
+    # reach the /mcp endpoint. The SDK default is localhost-only.
+    _mcp_hosts = os.environ.get("OMNIVOICE_MCP_ALLOWED_HOSTS", "")
+    if _mcp_hosts.strip():
+        hosts = [h.strip() for h in _mcp_hosts.split(",") if h.strip()]
+        try:
+            mcp.settings.transport_security.allowed_hosts.extend(hosts)
+            # Also extend origins (browser-based MCP clients behind a proxy send
+            # an Origin header — agent clients typically don't).
+            mcp.settings.transport_security.allowed_origins.extend(
+                f"http://{h}" for h in hosts
+            )
+        except Exception as e:
+            logger.warning("OMNIVOICE_MCP_ALLOWED_HOSTS not applied (%s)", e)
+
     # ── Helpers ─────────────────────────────────────────────────────────
 
     def _api_base() -> str:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -33,7 +33,10 @@ To bind this agent to a specific voice, send an
 **Agents in Docker or on another machine:** the MCP SDK rejects non-localhost
 Host headers by default (DNS-rebinding guard). Set
 `OMNIVOICE_MCP_ALLOWED_HOSTS` to a comma-separated list of host patterns the
-agent connects from (e.g. `host.containers.internal:*,192.168.1.50:*`):
+agent connects from (e.g. `host.containers.internal:*,192.168.1.50:*`).
+Keep this on a trusted LAN or behind TLS (Tailscale Serve, a reverse proxy
+with HTTPS) — the MCP transport is not authenticated, so don't expose it on
+the open internet.
 
 ### stdio (clients that only speak stdio)
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -30,6 +30,11 @@ To bind this agent to a specific voice, send an
 `X-OmniVoice-Client-Id` header (e.g. `claude-code`). See
 [per-agent voices](#per-agent-voices).
 
+**Agents in Docker or on another machine:** the MCP SDK rejects non-localhost
+Host headers by default (DNS-rebinding guard). Set
+`OMNIVOICE_MCP_ALLOWED_HOSTS` to a comma-separated list of host patterns the
+agent connects from (e.g. `host.containers.internal:*,192.168.1.50:*`):
+
 ### stdio (clients that only speak stdio)
 
 Use the bundled shim — it proxies stdio ↔ the mounted HTTP endpoint. Drop

--- a/tests/test_mcp_mount.py
+++ b/tests/test_mcp_mount.py
@@ -103,3 +103,16 @@ def test_decode_ref_audio_rejects_garbage_without_raising():
 def test_sniff_audio_ext_matches_magic_bytes(raw, ext):
     from mcp_server import _sniff_audio_ext
     assert _sniff_audio_ext(raw) == ext
+
+
+def test_mcp_allowed_hosts_env_extends_allowlist(monkeypatch):
+    """OMNIVOICE_MCP_ALLOWED_HOSTS must extend the transport-security allowlist."""
+    from mcp_server import create_mcp_server
+
+    monkeypatch.setenv("OMNIVOICE_MCP_ALLOWED_HOSTS", "host.containers.internal:*,10.0.0.1:*")
+    server = create_mcp_server()
+    allowed = server.settings.transport_security.allowed_hosts
+    assert "host.containers.internal:*" in allowed
+    assert "10.0.0.1:*" in allowed
+    origins = server.settings.transport_security.allowed_origins
+    assert "http://host.containers.internal:*" in origins

--- a/tests/test_mcp_mount.py
+++ b/tests/test_mcp_mount.py
@@ -116,3 +116,4 @@ def test_mcp_allowed_hosts_env_extends_allowlist(monkeypatch):
     assert "10.0.0.1:*" in allowed
     origins = server.settings.transport_security.allowed_origins
     assert "http://host.containers.internal:*" in origins
+    assert "https://host.containers.internal:*" in origins


### PR DESCRIPTION
Closes #1249.

## What

Agents in Docker containers (or on other machines) connect via `host.containers.internal`, which the MCP SDK rejects with 421 (DNS-rebinding guard). Add `OMNIVOICE_MCP_ALLOWED_HOSTS` (comma-separated host patterns) that extends both `allowed_hosts` AND `allowed_origins` — so agents and browser-based MCP clients behind a proxy both work.

Default empty → zero behavior change. Same opt-in pattern as `OMNIVOICE_TRUSTED_NETWORKS`.

## Review

/simplify (4 angles): reuse/simplification/efficiency clean. Altitude: bare `except: pass` should log (applied — operator's opted-in setting shouldn't fail silently).
/code-review high (correctness + conventions): found Origin-header gap (applied — now extends origins too), fix-quality test gap (applied — test added), docs-sync (applied — docs/mcp.md updated), bare except (applied).

## Files
- `backend/mcp_server.py` — read env var, extend allowed_hosts + allowed_origins, log on failure
- `tests/test_mcp_mount.py` — test the env var extends both lists
- `docs/mcp.md` — document the env var for Docker/LAN agents
- `CHANGELOG.md` — ### Added entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds the opt-in `OMNIVOICE_MCP_ALLOWED_HOSTS` environment variable to extend the MCP SDK transport-security `allowed_hosts` and corresponding `allowed_origins` for both `http://` and `https://` from a comma-separated list of host patterns; default remains empty to preserve the current localhost-only behavior. This enables agents in Docker/LAN/proxied setups to reach the `/mcp` endpoint using non-local Host headers while keeping operators in control via allowlisting. A human should review the host-pattern parsing and the warning-only failure path to ensure malformed input or SDK exceptions can’t leave transport security misconfigured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->