### PR TITLE
fix(macos): the app was dead on arrival on macOS 12 (Monterey) (#1245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A GPU too small for the chosen engine now says so up front, not after a five-minute wait
 - A port conflict now says so, instead of "Backend died (exit code 1)"
 - A model download that dies at 90% now resumes instead of failing the install
+- The app opens on macOS 12 (Monterey) again, instead of a dead window
 
 ### Docs
 
@@ -24,6 +25,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- macOS 12 (Monterey): the app died during its first render and never started the backend — it called a WebKit 16 method on a WebView we promise to support — thanks @singhrahat! (#1245)
 - AMD/ROCm: every ROCm host was silently force-routed to the CPU — the compatibility gate compared a CUDA `sm_` tag against a ROCm build's `gfx` list, which can never match — thanks @simmessa! (#1228)
 - AMD/ROCm: `torch.compile` was disabled on all AMD hosts by the same mismatched comparison (#1228)
 - AMD/ROCm: `HSA_OVERRIDE_GFX_VERSION` is auto-set only when your card genuinely needs it and the remap target exists in your build; gfx1150/gfx1151 (Strix Point/Halo) added to the map (#1228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A port conflict now says so, instead of "Backend died (exit code 1)"
 - A model download that dies at 90% now resumes instead of failing the install
 - First run: Continue and the Hugging Face token box no longer sit under the status bar
-- The app opens on macOS 12 (Monterey) again, instead of a dead window
+- macOS 12 (Monterey): the app launches again instead of dying on startup
 
 ### Changed
 
@@ -30,7 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- macOS 12 (Monterey): the app died during its first render and never started the backend — it called a WebKit 16 method on a WebView we promise to support — thanks @singhrahat! (#1245)
+- macOS 12 (Monterey): the app threw on startup and never started the backend — it called a Safari 16 method on the WebView that macOS ships. It launches and works now; some styling still needs a newer WebView (tracked in #1268) — thanks @singhrahat! (#1245)
 - AMD/ROCm: every ROCm host was silently force-routed to the CPU — the compatibility gate compared a CUDA `sm_` tag against a ROCm build's `gfx` list, which can never match — thanks @simmessa! (#1228)
 - AMD/ROCm: `torch.compile` was disabled on all AMD hosts by the same mismatched comparison (#1228)
 - AMD/ROCm: `HSA_OVERRIDE_GFX_VERSION` is auto-set only when your card genuinely needs it and the remap target exists in your build; gfx1150/gfx1151 (Strix Point/Halo) added to the map (#1228)

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,6 +6,12 @@ if (import.meta.env.DEV && !window.__vite_plugin_react_preamble_installed__) {
   window.__vite_plugin_react_preamble_installed__ = true;
 }
 
+// Web-platform gap fills for the oldest WebView we support (macOS 12 ships
+// WKWebView 15.6). MUST be first: these are touched during the first React
+// render, so a missing one throws mid-render and leaves a dead window rather
+// than a degraded feature (#1245).
+import './utils/webCompat.js';
+
 // AudioContext autoplay-policy unlock — MUST install before any module that
 // constructs an AudioContext (wavesurfer.js, the AEC tap, the dictation
 // capture, etc.). The side-effecting import patches `window.AudioContext`

--- a/frontend/src/test/webCompat.test.js
+++ b/frontend/src/test/webCompat.test.js
@@ -1,0 +1,173 @@
+/**
+ * #1245: the app was dead on arrival on macOS 12 (Monterey).
+ *
+ * The reporter's whole session was one line — `view:launchpad` — and
+ * "Last backend response: none this session — it may never have started".
+ * The stack is a React render throwing:
+ *
+ *     AbortSignal.timeout is not a function.
+ *     (In 'AbortSignal.timeout(2e3)', 'AbortSignal.timeout' is undefined)
+ *
+ * `useRealtimeEvents` polls backend health with `AbortSignal.timeout(2000)`
+ * on mount. That method arrived in Safari 16.0; `tauri.conf.json` declares
+ * `minimumSystemVersion: "12.0"` and `docs/install/macos.md` promises macOS 12,
+ * which ships WKWebView **15.6**. So this was not an exotic environment — it
+ * was the floor we advertise.
+ *
+ * Two halves are pinned:
+ *  1. the polyfill behaves like the real thing (aborts, and with TimeoutError);
+ *  2. no app module reaches for a post-floor API that nothing fills in — the
+ *     whole class, not just the one method that got reported.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { installAbortSignalTimeout } from '../utils/webCompat.js';
+
+const SRC = path.resolve(__dirname, '..');
+
+describe('AbortSignal.timeout polyfill', () => {
+  let original;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    original = AbortSignal.timeout;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    AbortSignal.timeout = original;
+  });
+
+  it('fills the method in when the WebView lacks it', () => {
+    // Reproduce Monterey: the method is simply absent.
+    delete AbortSignal.timeout;
+    expect(AbortSignal.timeout).toBeUndefined();
+
+    installAbortSignalTimeout();
+    expect(typeof AbortSignal.timeout).toBe('function');
+  });
+
+  it('aborts after the delay, with a TimeoutError reason', () => {
+    delete AbortSignal.timeout;
+    installAbortSignalTimeout();
+
+    const signal = AbortSignal.timeout(2000);
+    expect(signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(1999);
+    expect(signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(signal.aborted).toBe(true);
+    // `reason` is how a caller tells a timeout apart from a user cancel.
+    expect(signal.reason?.name).toBe('TimeoutError');
+  });
+
+  it('does not clobber a native implementation', () => {
+    const native = vi.fn(() => new AbortController().signal);
+    AbortSignal.timeout = native;
+
+    installAbortSignalTimeout();
+
+    expect(AbortSignal.timeout).toBe(native);
+  });
+
+  it('is installed before the app boots', () => {
+    // The gap fill is worthless if it loads after the chunk that throws.
+    const main = fs.readFileSync(path.join(SRC, 'main.jsx'), 'utf8');
+    const compat = main.indexOf('utils/webCompat');
+    const app = main.indexOf('main-app.jsx');
+    expect(compat).toBeGreaterThan(-1);
+    expect(app).toBeGreaterThan(-1);
+    expect(compat).toBeLessThan(app);
+  });
+});
+
+/**
+ * The recurrence guard. `AbortSignal.timeout` was not special — it was
+ * whichever post-floor API we happened to reach for first. Each entry is an
+ * API that does NOT exist in Safari 15.6 (our declared macOS floor) and that
+ * `webCompat.js` does not fill in, so using one would break Monterey exactly
+ * the way #1245 did.
+ *
+ * To use one of these: either fill it in inside `webCompat.js` and delete the
+ * entry, or guard the call site with a runtime check and a fallback.
+ */
+const POST_FLOOR_APIS = [
+  // Safari 17.4
+  { pattern: /\bAbortSignal\s*\.\s*any\b/, name: 'AbortSignal.any', since: 'Safari 17.4' },
+  { pattern: /\bObject\s*\.\s*groupBy\b/, name: 'Object.groupBy', since: 'Safari 17.4' },
+  { pattern: /\bMap\s*\.\s*groupBy\b/, name: 'Map.groupBy', since: 'Safari 17.4' },
+  {
+    pattern: /\bPromise\s*\.\s*withResolvers\b/,
+    name: 'Promise.withResolvers',
+    since: 'Safari 17.4',
+  },
+  // Safari 17.0
+  { pattern: /\bURL\s*\.\s*canParse\b/, name: 'URL.canParse', since: 'Safari 17.0' },
+  { pattern: /\.isWellFormed\s*\(/, name: 'String#isWellFormed', since: 'Safari 17.0' },
+  // Safari 16.4
+  { pattern: /\.toSorted\s*\(/, name: 'Array#toSorted', since: 'Safari 16.4' },
+  { pattern: /\.toReversed\s*\(/, name: 'Array#toReversed', since: 'Safari 16.4' },
+  { pattern: /\.toSpliced\s*\(/, name: 'Array#toSpliced', since: 'Safari 16.4' },
+  // Safari 16.0 — the one that actually bit us; listed so removing the
+  // polyfill without removing the call sites fails here too.
+  { pattern: /\bAbortSignal\s*\.\s*timeout\b/, name: 'AbortSignal.timeout', since: 'Safari 16.0' },
+];
+
+/** Entries `webCompat.js` fills in, so app code may use them freely. */
+const POLYFILLED = new Set(['AbortSignal.timeout']);
+
+const walk = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'test' || entry.name === 'node_modules') continue;
+      walk(full, out);
+    } else if (/\.(js|jsx|ts|tsx)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+describe('no app code depends on an API newer than the macOS floor', () => {
+  it('matches the floor tauri.conf.json and the install docs promise', () => {
+    const conf = JSON.parse(
+      fs.readFileSync(path.resolve(SRC, '..', 'src-tauri', 'tauri.conf.json'), 'utf8'),
+    );
+    // If the floor is ever raised, this list should be re-derived — the test
+    // is only as correct as the version it is written against.
+    expect(conf.bundle?.macOS?.minimumSystemVersion).toBe('12.0');
+  });
+
+  it('uses no unfilled post-Safari-15.6 API', () => {
+    const offenders = [];
+    for (const file of walk(SRC)) {
+      if (file.endsWith(path.join('utils', 'webCompat.js'))) continue;
+      const src = fs.readFileSync(file, 'utf8');
+      for (const api of POST_FLOOR_APIS) {
+        if (POLYFILLED.has(api.name)) continue;
+        if (api.pattern.test(src)) {
+          offenders.push(`${path.relative(SRC, file)} uses ${api.name} (${api.since})`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('still guards the API that broke Monterey', () => {
+    // Sanity: AbortSignal.timeout IS used by app code, so the exemption above
+    // is load-bearing — if the polyfill is deleted the exemption must go too.
+    const users = walk(SRC).filter(
+      (f) =>
+        !f.endsWith(path.join('utils', 'webCompat.js')) &&
+        /\bAbortSignal\s*\.\s*timeout\b/.test(fs.readFileSync(f, 'utf8')),
+    );
+    expect(users.length).toBeGreaterThan(0);
+
+    const compat = fs.readFileSync(path.join(SRC, 'utils', 'webCompat.js'), 'utf8');
+    expect(compat).toMatch(/AbortSignal\.timeout\s*=/);
+  });
+});

--- a/frontend/src/test/webCompat.test.js
+++ b/frontend/src/test/webCompat.test.js
@@ -87,14 +87,32 @@ describe('AbortSignal.timeout polyfill', () => {
 /**
  * The recurrence guard. `AbortSignal.timeout` was not special — it was
  * whichever post-floor API we happened to reach for first. Each entry is an
- * API that does NOT exist in Safari 15.6 (our declared macOS floor) and that
- * `webCompat.js` does not fill in, so using one would break Monterey exactly
- * the way #1245 did.
+ * API that does NOT exist in Safari 15.6 (the WebView shipped with the macOS
+ * version `tauri.conf.json` declares) and that `webCompat.js` does not fill
+ * in, so using one would break Monterey exactly the way #1245 did.
  *
  * To use one of these: either fill it in inside `webCompat.js` and delete the
  * entry, or guard the call site with a runtime check and a fallback.
+ *
+ * WHAT THIS DOES NOT COVER — deliberately stated so it is not over-trusted:
+ *
+ *  - **Syntax.** A post-floor *grammar* feature (RegExp lookbehind, Safari
+ *    16.4) is a parse-time SyntaxError that kills its whole chunk before a
+ *    line runs, and no polyfill can help. Text patterns here cannot see that.
+ *  - **Dependencies.** Only `frontend/src` is scanned. A bundled library using
+ *    a post-floor API or grammar is invisible here and ships anyway.
+ *  - **CSS.** Tailwind v4's own floor is Safari 16.4, and `index.css` uses
+ *    `color-mix()` (16.2) throughout, so the *rendering* floor is already
+ *    above macOS 12 regardless of what JavaScript does. See #1268.
+ *  - **Computed access.** `AbortSignal["timeout"]` or a destructured
+ *    reference evades every pattern below.
+ *
+ * This guard closes the class it can see — first-party source. The rest is
+ * tracked in #1268 rather than pretended away.
  */
 const POST_FLOOR_APIS = [
+  // Safari 18.0
+  { pattern: /\bURL\s*\.\s*parse\s*\(/, name: 'URL.parse', since: 'Safari 18.0' },
   // Safari 17.4
   { pattern: /\bAbortSignal\s*\.\s*any\b/, name: 'AbortSignal.any', since: 'Safari 17.4' },
   { pattern: /\bObject\s*\.\s*groupBy\b/, name: 'Object.groupBy', since: 'Safari 17.4' },
@@ -104,15 +122,23 @@ const POST_FLOOR_APIS = [
     name: 'Promise.withResolvers',
     since: 'Safari 17.4',
   },
+  { pattern: /\.checkVisibility\s*\(/, name: 'Element#checkVisibility', since: 'Safari 17.4' },
   // Safari 17.0
   { pattern: /\bURL\s*\.\s*canParse\b/, name: 'URL.canParse', since: 'Safari 17.0' },
-  { pattern: /\.isWellFormed\s*\(/, name: 'String#isWellFormed', since: 'Safari 17.0' },
   // Safari 16.4
-  { pattern: /\.toSorted\s*\(/, name: 'Array#toSorted', since: 'Safari 16.4' },
-  { pattern: /\.toReversed\s*\(/, name: 'Array#toReversed', since: 'Safari 16.4' },
-  { pattern: /\.toSpliced\s*\(/, name: 'Array#toSpliced', since: 'Safari 16.4' },
-  // Safari 16.0 — the one that actually bit us; listed so removing the
-  // polyfill without removing the call sites fails here too.
+  { pattern: /\.isWellFormed\s*\(/, name: 'String#isWellFormed', since: 'Safari 16.4' },
+  { pattern: /\.toWellFormed\s*\(/, name: 'String#toWellFormed', since: 'Safari 16.4' },
+  { pattern: /\bArray\s*\.\s*fromAsync\b/, name: 'Array.fromAsync', since: 'Safari 16.4' },
+  // Safari 16.0 — the change-by-copy family. `with` is the one most likely to
+  // be reached for in React state code (`arr.with(i, v)`), and it was missing
+  // from this list until review caught it.
+  { pattern: /\.toSorted\s*\(/, name: 'Array#toSorted', since: 'Safari 16.0' },
+  { pattern: /\.toReversed\s*\(/, name: 'Array#toReversed', since: 'Safari 16.0' },
+  { pattern: /\.toSpliced\s*\(/, name: 'Array#toSpliced', since: 'Safari 16.0' },
+  // `arr.with(i, v)` is the idiomatic immutable-state form in React code, so
+  // it is the sibling most likely to be reached for. It was missing from this
+  // list until review caught it.
+  { pattern: /\.with\s*\(/, name: 'Array#with', since: 'Safari 16.0' },
   { pattern: /\bAbortSignal\s*\.\s*timeout\b/, name: 'AbortSignal.timeout', since: 'Safari 16.0' },
 ];
 
@@ -133,12 +159,18 @@ const walk = (dir, out = []) => {
 };
 
 describe('no app code depends on an API newer than the macOS floor', () => {
-  it('matches the floor tauri.conf.json and the install docs promise', () => {
+  it('is written against the macOS version tauri.conf.json declares', () => {
     const conf = JSON.parse(
       fs.readFileSync(path.resolve(SRC, '..', 'src-tauri', 'tauri.conf.json'), 'utf8'),
     );
-    // If the floor is ever raised, this list should be re-derived — the test
-    // is only as correct as the version it is written against.
+    // The list above is derived from the WebView that ships with this macOS
+    // version (12.0 → WKWebView 15.6). If the floor moves, re-derive it — the
+    // test is only as correct as the version it is written against.
+    //
+    // Note this asserts what we DECLARE, not what we deliver: the CSS layer
+    // (Tailwind v4, color-mix) needs Safari 16.4, so 12.0 is currently a
+    // promise the frontend stack does not keep. Tracked in #1268; asserted
+    // here so raising the floor forces this list to be revisited.
     expect(conf.bundle?.macOS?.minimumSystemVersion).toBe('12.0');
   });
 

--- a/frontend/src/utils/webCompat.js
+++ b/frontend/src/utils/webCompat.js
@@ -1,0 +1,54 @@
+/**
+ * Web-platform gap fills for the OLDEST WebView we claim to support.
+ *
+ * `tauri.conf.json` declares `minimumSystemVersion: "12.0"` and the install
+ * docs promise macOS 12 (Monterey) — which ships Safari/WKWebView **15.6**.
+ * Anything newer than that is not present at runtime on a supported machine,
+ * and because our entry chunk touches these during the first React render, a
+ * single missing method is not a degraded feature: it throws mid-render, the
+ * tree unmounts, and the user gets a dead window with no backend ever started
+ * (#1245).
+ *
+ * This module must be imported for side effects as the FIRST thing in
+ * `main.jsx`, before any app chunk loads. `test/webCompat.test.js` keeps the
+ * list honest: it fails CI if app code reaches for a post-15.6 API that is not
+ * filled in here.
+ *
+ * Windows (evergreen WebView2) and Linux (WebKitGTK ≥ 2.44 on Ubuntu 24.04+)
+ * both clear the floor comfortably — macOS 12 is the binding constraint.
+ */
+
+/**
+ * `AbortSignal.timeout(ms)` — Safari 16.0. Used by the backend health poll on
+ * the very first render, so its absence took the whole app down on Monterey.
+ */
+export function installAbortSignalTimeout() {
+  if (typeof AbortSignal === 'undefined' || typeof AbortController === 'undefined') return;
+  if (typeof AbortSignal.timeout === 'function') return;
+
+  AbortSignal.timeout = function timeout(ms) {
+    const controller = new AbortController();
+    setTimeout(() => {
+      // The spec aborts with a DOMException named TimeoutError, which is how
+      // callers tell "we gave up" apart from "the user cancelled". Safari 15.6
+      // predates `abort(reason)`, so the argument is simply ignored there —
+      // the abort itself, which is what every call site actually branches on,
+      // still fires.
+      let reason;
+      try {
+        reason = new DOMException('signal timed out', 'TimeoutError');
+      } catch {
+        reason = new Error('signal timed out');
+        reason.name = 'TimeoutError';
+      }
+      controller.abort(reason);
+    }, ms);
+    return controller.signal;
+  };
+}
+
+export function installWebCompat() {
+  installAbortSignalTimeout();
+}
+
+installWebCompat();

--- a/frontend/src/utils/webCompat.js
+++ b/frontend/src/utils/webCompat.js
@@ -30,10 +30,11 @@ export function installAbortSignalTimeout() {
     const controller = new AbortController();
     setTimeout(() => {
       // The spec aborts with a DOMException named TimeoutError, which is how
-      // callers tell "we gave up" apart from "the user cancelled". Safari 15.6
-      // predates `abort(reason)`, so the argument is simply ignored there —
-      // the abort itself, which is what every call site actually branches on,
-      // still fires.
+      // callers tell "we gave up" apart from "the user cancelled". Pass it:
+      // `abort(reason)` has been supported since Safari 15.4, so it IS
+      // honoured on our 15.6 floor. Do not "simplify" this to a bare
+      // `controller.abort()` — that would silently turn every TimeoutError
+      // into an AbortError and break exactly the distinction it exists for.
       let reason;
       try {
         reason = new DOMException('signal timed out', 'TimeoutError');


### PR DESCRIPTION
Closes #1245.

## Root cause

`useRealtimeEvents` polls backend health with `AbortSignal.timeout(2000)` on mount. That method arrived in **Safari 16.0** — but `tauri.conf.json` sets `minimumSystemVersion: "12.0"` and `docs/install/macos.md` promises macOS 12 (Monterey), which ships **WKWebView 15.6**.

So this was not an exotic environment; it was the floor we advertise. The call happens during the first React render, so the method being missing is not a degraded feature — it throws mid-render, the tree unmounts, and the window is dead. The reporter's session bears that out: one action (`view:launchpad`) and *"Last backend response: none this session — it may never have started"*.

`splashWatchdog.js` already guarded this same method inline, which shows the gap was known but only patched where it had been noticed.

## Fix

- `frontend/src/utils/webCompat.js` — one place that fills in what the oldest supported WebView lacks. Spec-shaped: aborts after the delay with a `TimeoutError`, and never clobbers a native implementation.
- Imported for side effects as the **first** thing in `main.jsx`, before any app chunk loads.

## Recurrence guard

`AbortSignal.timeout` was not special — it was whichever post-floor API we happened to reach for first. `test/webCompat.test.js` scans app source for a list of APIs newer than Safari 15.6 and fails CI on any that nothing polyfills, and asserts the floor it is written against still matches `tauri.conf.json`.

Verified fail-before/pass-after on both halves: removing the polyfill fails the behaviour tests; adding a `.toSorted()` call anywhere in `frontend/src` fails the guard.

## Not affected

Windows (evergreen WebView2) and Linux (WebKitGTK ≥ 2.44 on Ubuntu 24.04+) both clear the floor — macOS 12 is the binding constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an early `frontend/src/utils/webCompat.js` import in `frontend/src/main.jsx` that polyfills `AbortSignal.timeout` for macOS 12 / WKWebView 15.6 without overriding any native implementation, preventing the first React render from throwing and leaving the backend unstarted; also updates `CHANGELOG.md` with the macOS 12 startup fix. Introduces Vitest coverage that validates the polyfill behavior and load ordering, plus a source scan/test that blocks use of post–Safari 15.6 Web APIs unless explicitly polyfilled and checks the supported floor against `src-tauri/tauri.conf.json`. Risk worth a human look: confirm the polyfill’s abort “reason”/`TimeoutError` semantics match what app/backend code expects and that the API allow/deny list doesn’t create false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->