### PR TITLE
fix(dub): deleting a dub no longer resurrects it (#1252, #1253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A model download that dies at 90% now resumes instead of failing the install
 - First run: Continue and the Hugging Face token box no longer sit under the status bar
 - macOS 12 (Monterey): the app launches again instead of dying on startup
+- Deleting a dub no longer un-deletes itself when the job it belonged to finishes
 
 ### Changed
 
@@ -34,6 +35,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Deleting a dub while it was still importing crashed the import with the toast `ingest: 'mgw39lx3'` — a dict key and nothing else — and the delete could then be undone by the job's own pending write, in history or mid-render; both are fixed, and no failure can present itself as a bare value again — thanks @dustmaker124-ui! (#1252, #1253)
 - macOS 12 (Monterey): the app threw on startup and never started the backend — it called a Safari 16 method on the WebView that macOS ships. It launches and works now; some styling still needs a newer WebView (tracked in #1268) — thanks @singhrahat! (#1245)
 - AMD/ROCm: every ROCm host was silently force-routed to the CPU — the compatibility gate compared a CUDA `sm_` tag against a ROCm build's `gfx` list, which can never match — thanks @simmessa! (#1228)
 - AMD/ROCm: `torch.compile` was disabled on all AMD hosts by the same mismatched comparison (#1228)

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -229,7 +229,16 @@ def clear_dub_history():
     """Delete persisted dub rows and their on-disk dirs (scoped to known IDs)."""
     with db_conn() as conn:
         ids = [r["id"] for r in conn.execute("SELECT id FROM dub_history").fetchall()]
-        conn.execute("DELETE FROM dub_history")
+
+    def _delete_rows():
+        with db_conn() as conn:
+            conn.execute("DELETE FROM dub_history")
+
+    # Row-delete + in-memory evict together, so an ingest finishing right now
+    # can't re-save a job the user just cleared (#1252 review). This path
+    # never evicted from memory at all before, so an in-flight job survived
+    # "clear history" outright.
+    dub_pipeline.purge_jobs(ids, delete_rows=_delete_rows, include_inflight=True)
     for jid in ids:
         safe = _safe_job_dir(jid)
         if safe and os.path.isdir(safe):
@@ -239,12 +248,15 @@ def clear_dub_history():
 
 @router.delete("/dub/history/{history_id}")
 def delete_single_dub_history(history_id: str):
-    with db_conn() as conn:
-        conn.execute("DELETE FROM dub_history WHERE id=?", (history_id,))
+    def _delete_row():
+        with db_conn() as conn:
+            conn.execute("DELETE FROM dub_history WHERE id=?", (history_id,))
+
+    # Atomic with the evict — see purge_jobs (#1252 review).
+    dub_pipeline.purge_jobs([history_id], delete_rows=_delete_row)
     safe = _safe_job_dir(history_id)
     if safe and os.path.isdir(safe):
         shutil.rmtree(safe, ignore_errors=True)
-    _dub_jobs.pop(history_id, None)
     event_bus.emit("dub_history", {"action": "deleted", "id": history_id})
     return {"deleted": True}
 

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -516,6 +516,33 @@ def describe_path_target(path: str) -> str:
     return "; ".join(facts)
 
 
+#: Exception types whose ``str()`` is a bare VALUE rather than a sentence, so
+#: showing it alone tells the user nothing about what went wrong.
+#: ``str(KeyError("mgw39lx3"))`` is ``"'mgw39lx3'"`` — the repr of the key.
+_VALUE_ONLY_STR_EXCEPTIONS = (KeyError,)
+
+
+def describe_exception(exc: BaseException) -> str:
+    """``str(exc)`` in a form a human can act on.
+
+    #1252/#1253: a dub ingest failed with the toast ``ingest: 'mgw39lx3'`` and
+    nothing else — the entire user-facing reason was the repr of a dict key,
+    because ``str(KeyError)`` does not mention that a lookup failed, or that it
+    was an exception at all. The reporter's ``'mgw39lx3'`` was their own job id
+    reflected back at them with no context.
+
+    Naming the class is the floor, not the goal: a failure that reaches here at
+    all is one nobody wrote a message for. It keeps the report diagnosable
+    instead of cryptic while the specific path gets its own handling.
+    """
+    text = str(exc).strip()
+    if not text:
+        return type(exc).__name__
+    if isinstance(exc, _VALUE_ONLY_STR_EXCEPTIONS):
+        return f"{type(exc).__name__}: {text}"
+    return text
+
+
 def build_failure(
     exc_or_msg: Any,
     *,
@@ -529,7 +556,7 @@ def build_failure(
     """
     if isinstance(exc_or_msg, BaseException):
         error_class = type(exc_or_msg).__name__
-        raw = str(exc_or_msg).strip() or error_class
+        raw = describe_exception(exc_or_msg)
     else:
         error_class = "Error"
         raw = str(exc_or_msg).strip() or "Unknown failure"

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -88,13 +88,25 @@ _inflight_jobs: set[str] = set()
 #: many times, so the realistic delete lands during a RENDER, long after its
 #: ingest ended — and a render's save would then write the row straight back.
 #:
-#: Bounded rather than cleared on completion, because there is no moment at
+#: Retained rather than cleared on completion, because there is no moment at
 #: which a delete stops mattering: any operation still holding that job can
-#: persist it. An LRU keeps the window generous (well past a long render) while
-#: the set stays small; ``begin_ingest`` drops an id explicitly, since
-#: re-importing is a deliberate revival.
-_WITHDRAWN_MAX = 256
-_withdrawn_jobs: "OrderedDict[str, None]" = OrderedDict()
+#: persist it. ``begin_ingest`` drops an id explicitly, since re-importing is a
+#: deliberate revival.
+#:
+#: Expired by AGE, not by count. A count-bounded LRU is evictable by ordinary
+#: use: ``DELETE /dub/history`` purges every row with no limit, so a user
+#: clearing a large history mid-render would push the rendering job's own
+#: marker out and the render would then write it back (#1252 review). Age
+#: cannot be gamed that way — what matters is how long ago the delete happened,
+#: not how many others followed it.
+#:
+#: The count cap is a memory backstop only, set far above any real history:
+#: ~4096 short ids is a few hundred KB. Reaching it needs 4096 deletions inside
+#: one TTL window, at which point the oldest markers are the least likely to
+#: still be held.
+_WITHDRAWN_TTL_S = 6 * 3600   # outlives any realistic render or transcribe
+_WITHDRAWN_MAX = 4096         # memory backstop, not the eviction policy
+_withdrawn_jobs: "OrderedDict[str, float]" = OrderedDict()
 
 _DUB_DIR_REAL = os.path.realpath(DUB_DIR)
 _HASH_BUF_SIZE = 1 << 18  # 256 KB chunks for hashing
@@ -245,6 +257,22 @@ def merge_job(job_id: str, updates: dict) -> bool:
         return True
 
 
+def _expire_withdrawn(now: float) -> None:
+    """Drop withdrawal markers that are too old to still matter.
+
+    Caller must hold ``_dub_jobs_lock``. Age first — that is the policy — then
+    the count cap purely so the mapping cannot grow without bound.
+    """
+    cutoff = now - _WITHDRAWN_TTL_S
+    while _withdrawn_jobs:
+        _, deleted_at = next(iter(_withdrawn_jobs.items()))
+        if deleted_at >= cutoff:
+            break
+        _withdrawn_jobs.popitem(last=False)
+    while len(_withdrawn_jobs) > _WITHDRAWN_MAX:
+        _withdrawn_jobs.popitem(last=False)
+
+
 def begin_ingest(job_id: str) -> None:
     """Mark an ingest as running.
 
@@ -344,12 +372,12 @@ def purge_jobs(job_ids, *, delete_rows, include_inflight: bool = False) -> None:
             # "Clear history" means everything, including a job whose first row
             # hasn't been written yet — it wouldn't appear in `job_ids` at all.
             targets |= _inflight_jobs
+        now = time.monotonic()
         for job_id in targets:
             _dub_jobs.pop(job_id, None)
             _withdrawn_jobs.pop(job_id, None)
-            _withdrawn_jobs[job_id] = None  # most-recent last
-        while len(_withdrawn_jobs) > _WITHDRAWN_MAX:
-            _withdrawn_jobs.popitem(last=False)
+            _withdrawn_jobs[job_id] = now  # most-recent last
+        _expire_withdrawn(now)
 
 
 def save_job(job_id: str, job: dict, filename: str = "", duration: float = 0.0, content_hash: str = "") -> None:

--- a/backend/services/dub_pipeline.py
+++ b/backend/services/dub_pipeline.py
@@ -37,6 +37,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections import OrderedDict
 from typing import AsyncIterator, Optional
 
 import soundfile as sf
@@ -67,7 +68,33 @@ logger = logging.getLogger("omnivoice.dub_pipeline")
 # backward compat during the transition.
 
 _dub_jobs: dict[str, dict] = {}
-_dub_jobs_lock = threading.Lock()
+# Re-entrant: `save_job` takes this lock itself (see below), and the atomic
+# helpers call it while already holding it.
+_dub_jobs_lock = threading.RLock()
+
+#: Ingests currently running. Used only so "clear history" can also sweep a job
+#: that has no row yet — it would appear in no id list otherwise.
+_inflight_jobs: set[str] = set()
+
+#: Recently-deleted job ids, most-recent last. Guarded by ``_dub_jobs_lock``.
+#:
+#: Dict membership alone cannot express "the user withdrew this job" (#1252
+#: review): a job's FIRST persistence creates the entry, so an absent key means
+#: "not written yet" for a new job and "deleted" for an established one — two
+#: opposite instructions from one signal.
+#:
+#: Scoped to DELETED, not to in-flight ingests. Scoping it to ingests looked
+#: right and closed nothing that mattered: a dub is imported once and rendered
+#: many times, so the realistic delete lands during a RENDER, long after its
+#: ingest ended — and a render's save would then write the row straight back.
+#:
+#: Bounded rather than cleared on completion, because there is no moment at
+#: which a delete stops mattering: any operation still holding that job can
+#: persist it. An LRU keeps the window generous (well past a long render) while
+#: the set stays small; ``begin_ingest`` drops an id explicitly, since
+#: re-importing is a deliberate revival.
+_WITHDRAWN_MAX = 256
+_withdrawn_jobs: "OrderedDict[str, None]" = OrderedDict()
 
 _DUB_DIR_REAL = os.path.realpath(DUB_DIR)
 _HASH_BUF_SIZE = 1 << 18  # 256 KB chunks for hashing
@@ -197,6 +224,134 @@ def put_job(job_id: str, job: dict) -> None:
         _dub_jobs[job_id] = job
 
 
+def merge_job(job_id: str, updates: dict) -> bool:
+    """Merge *updates* into an existing in-memory job. Does NOT persist.
+
+    Returns ``False`` when the job is gone — which is a real, reachable state,
+    not a defensive nicety: ingest runs for minutes (demucs, scene detection,
+    thumbnailing) and ``DELETE /dub/history/{id}`` pops the entry out from
+    under it. The pipeline used to finish with a bare
+    ``_dub_jobs[job_id].update(...)``, so deleting an in-flight dub surfaced as
+    the toast ``ingest: 'mgw39lx3'`` — ``str(KeyError)`` is the repr of the
+    key, nothing more (#1252/#1253). Callers treat ``False`` as "the user
+    withdrew this job" and stop, rather than resurrecting a record that was
+    deliberately deleted.
+    """
+    with _dub_jobs_lock:
+        job = _dub_jobs.get(job_id)
+        if job is None:
+            return False
+        job.update(updates)
+        return True
+
+
+def begin_ingest(job_id: str) -> None:
+    """Mark an ingest as running.
+
+    Re-importing an id is a deliberate revival, so this clears any tombstone —
+    the only thing that legitimately un-deletes a job.
+    """
+    with _dub_jobs_lock:
+        _inflight_jobs.add(job_id)
+        _withdrawn_jobs.pop(job_id, None)
+
+
+def end_ingest(job_id: str) -> None:
+    """Mark an ingest as finished, however it ended.
+
+    Deliberately does NOT clear the tombstone: the ingest ending is not the
+    user un-deleting anything, and a render started before the delete can still
+    be holding that job.
+    """
+    with _dub_jobs_lock:
+        _inflight_jobs.discard(job_id)
+
+
+def put_and_save_job(
+    job_id: str,
+    job: dict,
+    *,
+    filename: str = "",
+    duration: float = 0.0,
+    content_hash: str = "",
+) -> bool:
+    """:func:`put_job` and :func:`save_job` as ONE atomic step.
+
+    Returns ``False`` when the job was withdrawn — the user deleted or cleared
+    its history while this ingest was running — in which case nothing is
+    written. Gating on the tombstone rather than on dict membership is what
+    makes this correct for a job's FIRST write, where an absent key is normal
+    (#1252 review).
+    """
+    with _dub_jobs_lock:
+        if job_id in _withdrawn_jobs:
+            return False
+        _dub_jobs[job_id] = job
+        save_job(job_id, job, filename, duration, content_hash)
+        return True
+
+
+def merge_and_save_job(
+    job_id: str,
+    updates: dict,
+    *,
+    filename: str = "",
+    duration: float = 0.0,
+    content_hash: str = "",
+) -> bool:
+    """:func:`merge_job` and :func:`save_job` as ONE atomic step.
+
+    Splitting them leaves a window that resurrects deleted work (#1252 review):
+    merge succeeds, the user deletes the dub — removing the row *and* the
+    in-memory entry — and the pending ``save_job`` then UPSERTs the row straight
+    back, so a dub the user deleted reappears in history. The delete endpoints
+    take this same lock around their own row-delete + evict, so the two
+    sequences cannot interleave at all.
+
+    Returns ``False`` when the job is already gone; the caller stops there.
+
+    The ``save_job`` write happens INSIDE the lock deliberately. That serialises
+    dub job-state access against one SQLite UPSERT — normally microseconds under
+    WAL, but up to sqlite3's 5 s default busy timeout if another writer is
+    holding the write lock. The alternative — releasing the lock before the
+    write — is the resurrection race this exists to close, so a rare latency
+    blip is the better trade. No locked region here calls another locked
+    function, so the plain (non-reentrant) ``_dub_jobs_lock`` cannot deadlock.
+    """
+    with _dub_jobs_lock:
+        job = _dub_jobs.get(job_id)
+        if job is None or job_id in _withdrawn_jobs:
+            return False
+        job.update(updates)
+        save_job(job_id, job, filename, duration, content_hash)
+        return True
+
+
+def purge_jobs(job_ids, *, delete_rows, include_inflight: bool = False) -> None:
+    """Delete history rows and evict the in-memory records as ONE atomic step.
+
+    ``delete_rows`` is called with the lock held, so a concurrent
+    :func:`merge_and_save_job` cannot slip between the row-delete and the
+    evict and write the job straight back (#1252 review). Both delete
+    endpoints go through here; ``DELETE /dub/history`` previously never evicted
+    from memory at all, so an in-flight job survived "clear history" entirely
+    and re-saved itself on completion.
+    """
+    with _dub_jobs_lock:
+        delete_rows()
+        targets = set(job_ids)
+        if include_inflight:
+            # "Clear history" means everything, including a job whose first row
+            # hasn't been written yet — it wouldn't appear in `job_ids` at all.
+            targets |= _inflight_jobs
+        for job_id in targets:
+            _dub_jobs.pop(job_id, None)
+            _withdrawn_jobs.pop(job_id, None)
+            _withdrawn_jobs[job_id] = None  # most-recent last
+        while len(_withdrawn_jobs) > _WITHDRAWN_MAX:
+            _withdrawn_jobs.popitem(last=False)
+
+
 def save_job(job_id: str, job: dict, filename: str = "", duration: float = 0.0, content_hash: str = "") -> None:
     """Persist dub job state to SQLite so it survives restarts. Uses UPSERT
     on `id` so repeated saves in a session keep the latest snapshot.
@@ -209,6 +364,22 @@ def save_job(job_id: str, job: dict, filename: str = "", duration: float = 0.0, 
     keys history restore off language_code, so a frozen "" hid finished
     tracks until the user re-picked a language.
     """
+    with _dub_jobs_lock:
+        # The withdrawal gate lives HERE, not in the callers (#1252 review).
+        # Eight call sites across generate / translate / export / core persist
+        # jobs directly, so gating only the ingest helpers left every
+        # post-ingest save able to resurrect a dub the user deleted mid-render.
+        # One choke point closes the class and the ninth caller inherits it.
+        if job_id in _withdrawn_jobs:
+            logger.info(
+                "Dub job %s was deleted while it was still running — not persisting", job_id,
+            )
+            return
+        _persist_job(job_id, job, filename, duration, content_hash)
+
+
+def _persist_job(job_id: str, job: dict, filename: str, duration: float, content_hash: str) -> None:
+    """The actual write. Callers go through :func:`save_job`, which gates it."""
     try:
         segments = job.get("segments") or []
         tracks = list((job.get("dubbed_tracks") or {}).keys())
@@ -837,6 +1008,9 @@ async def ingest_pipeline(
     # Audio-only jobs (#119) skip scene detection + thumbnailing below; the
     # transcribe → translate → TTS core is identical.
     input_type = (source.get("input_type") or "video").lower()
+    # Declare the run so a "clear history" arriving before this job's first
+    # persistence can still withdraw it (#1252 review).
+    begin_ingest(job_id)
     try:
         if source.get("kind") == "url":
             url = source["url"]
@@ -1005,8 +1179,12 @@ async def ingest_pipeline(
                 "youtube_subs": youtube_subs_by_lang or None,
                 "input_type": input_type,
             }
-            put_job(job_id, full_job)
-            save_job(job_id, full_job, filename, dur, content_hash)
+            if not put_and_save_job(
+                job_id, full_job, filename=filename, duration=dur, content_hash=content_hash,
+            ):
+                logger.info("Dub job %s was deleted during ingest — discarding its result", job_id)
+                yield prep_event("cancelled")
+                return
             yield prep_event("extract_done", job_id=job_id, duration=round(dur, 2), filename=filename)
             yield prep_event("cached",
                              has_bg=bool(no_vocals_path and os.path.exists(no_vocals_path)),
@@ -1029,8 +1207,12 @@ async def ingest_pipeline(
                 "youtube_subs": youtube_subs_by_lang or None,
                 "input_type": input_type,
             }
-            put_job(job_id, partial)
-            save_job(job_id, partial, filename, dur, content_hash)
+            if not put_and_save_job(
+                job_id, partial, filename=filename, duration=dur, content_hash=content_hash,
+            ):
+                logger.info("Dub job %s was deleted during ingest — discarding its result", job_id)
+                yield prep_event("cancelled")
+                return
             yield prep_event("extract_done", job_id=job_id, duration=round(dur, 2), filename=filename)
 
             vocals_path = os.path.join(job_dir, "vocals.wav")
@@ -1122,13 +1304,30 @@ async def ingest_pipeline(
                     logger.warning("Thumbnail extraction failed for %s: %s", job_id, e)
                     yield prep_event("warning", **failure.build_failure(e, stage="thumbnail", include_diagnostic=False))
 
-            _dub_jobs[job_id].update({
-                "vocals_path": vocals_path,
-                "no_vocals_path": no_vocals_path,
-                "thumb_path": thumb_path if (thumb_path and os.path.exists(thumb_path)) else None,
-                "scene_cuts": scene_cuts,
-            })
-            save_job(job_id, _dub_jobs[job_id], filename, dur, content_hash)
+            # The job can legitimately be gone by now — everything above takes
+            # minutes and `DELETE /dub/history/{id}` pops the record. Deleting
+            # an in-flight dub used to raise KeyError here and surface as the
+            # toast `ingest: 'mgw39lx3'` (#1252/#1253). A withdrawn job is not
+            # an error: stop quietly rather than re-persisting what the user
+            # just deleted.
+            # Merge and persist as one step: a delete landing BETWEEN them
+            # would remove the row and then have it written straight back, so
+            # the dub the user deleted reappears in history (#1252 review).
+            if not merge_and_save_job(
+                job_id,
+                {
+                    "vocals_path": vocals_path,
+                    "no_vocals_path": no_vocals_path,
+                    "thumb_path": thumb_path if (thumb_path and os.path.exists(thumb_path)) else None,
+                    "scene_cuts": scene_cuts,
+                },
+                filename=filename,
+                duration=dur,
+                content_hash=content_hash,
+            ):
+                logger.info("Dub job %s was deleted during ingest — discarding its result", job_id)
+                yield prep_event("cancelled")
+                return
             yield prep_event("ready", job_id=job_id, duration=round(dur, 2), filename=filename)
 
     except asyncio.CancelledError:
@@ -1148,5 +1347,6 @@ async def ingest_pipeline(
         yield prep_event("error", **failure.build_failure(e, stage="ingest"))
         return
     finally:
+        end_ingest(job_id)
         with _active_procs_lock:
             _active_procs.pop(job_id, None)

--- a/tests/test_dub_job_deleted_mid_ingest.py
+++ b/tests/test_dub_job_deleted_mid_ingest.py
@@ -372,15 +372,59 @@ def test_re_importing_the_same_id_revives_it(monkeypatch):
     assert written == ["job1"]
 
 
-def test_the_tombstone_set_is_bounded():
-    """Kept for the life of the process, so it must not grow without limit."""
-    for i in range(dub_pipeline._WITHDRAWN_MAX + 50):
+def test_clearing_a_large_history_mid_render_does_not_evict_the_running_job(
+    monkeypatch,
+):
+    """Review finding (#1252, Greptile P1): a count-bounded LRU is evictable by
+    ordinary use.
+
+    `DELETE /dub/history` selects every row with no limit, so a user with a
+    large history clearing it while a render is running would push that very
+    job's marker out — and the render would then write it straight back. Age is
+    the honest policy: what matters is how long ago the delete happened, not how
+    many others happened to follow it.
+    """
+    written = []
+    monkeypatch.setattr(
+        dub_pipeline, "_persist_job", lambda *a, **kw: written.append(a[0]),
+    )
+
+    # One dub is mid-render; the user clears a history far larger than any
+    # count cap would keep.
+    everything = ["rendering"] + [f"old{i}" for i in range(5000)]
+    dub_pipeline.purge_jobs(everything, delete_rows=lambda: None)
+
+    dub_pipeline.save_job("rendering", {"filename": "a.mp4"})
+    assert written == [], "the running job's withdrawal must survive the sweep"
+
+
+def test_markers_expire_by_age(monkeypatch):
+    """They are held for the life of the process otherwise, so something has to
+    let them go — but it must be time, not volume."""
+    import time as _time
+
+    base = _time.monotonic()
+    monkeypatch.setattr(dub_pipeline.time, "monotonic", lambda: base)
+    dub_pipeline.purge_jobs(["old"], delete_rows=lambda: None)
+    assert "old" in dub_pipeline._withdrawn_jobs
+
+    # Well past the TTL, a later delete sweeps the stale one out.
+    monkeypatch.setattr(
+        dub_pipeline.time, "monotonic",
+        lambda: base + dub_pipeline._WITHDRAWN_TTL_S + 1,
+    )
+    dub_pipeline.purge_jobs(["fresh"], delete_rows=lambda: None)
+
+    assert "old" not in dub_pipeline._withdrawn_jobs
+    assert "fresh" in dub_pipeline._withdrawn_jobs
+
+
+def test_the_marker_map_cannot_grow_without_bound():
+    """The count cap is a memory backstop, not the policy."""
+    for i in range(dub_pipeline._WITHDRAWN_MAX + 100):
         dub_pipeline.purge_jobs([f"job{i}"], delete_rows=lambda: None)
 
-    assert len(dub_pipeline._withdrawn_jobs) == dub_pipeline._WITHDRAWN_MAX
-    # The most recent deletions are the ones that still matter.
-    assert f"job{dub_pipeline._WITHDRAWN_MAX + 49}" in dub_pipeline._withdrawn_jobs
-    assert "job0" not in dub_pipeline._withdrawn_jobs
+    assert len(dub_pipeline._withdrawn_jobs) <= dub_pipeline._WITHDRAWN_MAX
 
 
 def test_the_pipeline_registers_and_releases_its_run():

--- a/tests/test_dub_job_deleted_mid_ingest.py
+++ b/tests/test_dub_job_deleted_mid_ingest.py
@@ -1,0 +1,460 @@
+"""#1252/#1253: a dub ingest failed with the toast ``ingest: 'mgw39lx3'``.
+
+Two reports, same reporter, same session, four `dub:upload` actions in a row.
+The entire user-facing error was eight characters of their own job id:
+
+    ingest: 'mgw39lx3'
+    Error: ingest: 'mgw39lx3'
+
+That is ``str(KeyError("mgw39lx3"))`` — the repr of a dict key. ``KeyError``
+does not put "a lookup failed" in its message, so `build_failure` faithfully
+reported a value with no explanation attached to it.
+
+The lookup that failed: ``ingest_pipeline`` finished with a bare
+``_dub_jobs[job_id].update(...)``. Everything before it — demucs, scene
+detection, thumbnailing — takes minutes, and ``DELETE /dub/history/{id}`` pops
+the entry. Deleting an in-flight dub therefore raised ``KeyError`` from a
+pipeline that was, by then, doing exactly what it was told.
+
+Both halves are covered: the crash no longer happens, and no exception whose
+``str()`` is a bare value can present itself to a user that way again.
+"""
+from __future__ import annotations
+
+import pytest
+
+import time
+
+from core.failure import build_failure, describe_exception
+from services import dub_pipeline
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    dub_pipeline._dub_jobs.clear()
+    yield
+    dub_pipeline._dub_jobs.clear()
+
+
+# ── the crash ────────────────────────────────────────────────────────────
+
+
+def test_merging_into_a_live_job_updates_it():
+    dub_pipeline.put_job("job1", {"filename": "a.mp4", "scene_cuts": []})
+
+    assert dub_pipeline.merge_job("job1", {"scene_cuts": [1.0, 2.0]}) is True
+    assert dub_pipeline._dub_jobs["job1"]["scene_cuts"] == [1.0, 2.0]
+    assert dub_pipeline._dub_jobs["job1"]["filename"] == "a.mp4", "a merge, not a replace"
+
+
+def test_merging_into_a_deleted_job_reports_it_instead_of_raising():
+    """The #1252 moment: the user deleted the dub while it was still ingesting."""
+    dub_pipeline.put_job("mgw39lx3", {"filename": "a.mp4"})
+    dub_pipeline._dub_jobs.pop("mgw39lx3")  # DELETE /dub/history/{id}
+
+    assert dub_pipeline.merge_job("mgw39lx3", {"scene_cuts": []}) is False
+
+
+def test_a_deleted_job_is_not_resurrected():
+    """`False` must mean "stop", not "insert it back" — the user deleted this
+    on purpose, and re-adding it would put a phantom row back in history."""
+    assert dub_pipeline.merge_job("gone", {"scene_cuts": []}) is False
+    assert "gone" not in dub_pipeline._dub_jobs
+
+
+def test_the_ingest_pipeline_no_longer_blind_subscripts_the_job():
+    """The call site itself. A direct `_dub_jobs[job_id].update(` anywhere in
+    the pipeline reintroduces exactly this KeyError."""
+    import inspect
+
+    src = inspect.getsource(dub_pipeline.ingest_pipeline)
+    assert "_dub_jobs[job_id].update(" not in src
+    assert "merge_and_save_job(" in src
+
+
+# ── the message ──────────────────────────────────────────────────────────
+
+
+def test_a_keyerror_no_longer_presents_as_a_bare_key():
+    """The exact reason string the reporter saw."""
+    failure = build_failure(KeyError("mgw39lx3"), stage="ingest")
+
+    assert failure["reason"] != "'mgw39lx3'"
+    assert failure["error_class"] == "KeyError"
+    assert "KeyError" in failure["reason"], "name what happened, not just the value"
+    assert "mgw39lx3" in failure["reason"], "but keep the value — it is the only clue"
+
+
+def test_an_exception_with_no_message_at_all_still_names_itself():
+    assert describe_exception(RuntimeError()) == "RuntimeError"
+    assert describe_exception(ValueError("   ")) == "ValueError"
+
+
+def test_a_real_message_is_left_exactly_alone():
+    """The fix must not prefix class names onto errors that already read fine —
+    every existing hint and classification matches on message text."""
+    assert describe_exception(RuntimeError("CUDA out of memory")) == "CUDA out of memory"
+    assert describe_exception(
+        OSError("[Errno 28] No space left on device")
+    ) == "[Errno 28] No space left on device"
+
+
+def test_classification_still_works_through_the_wrapper():
+    """`build_failure` classifies on the raw text; adding a class prefix must
+    not break the hint lookup for messages that do classify."""
+    failure = build_failure(RuntimeError("No module named 'omnivoice'"), stage="startup")
+    assert failure["docs_topic"] == "BROKEN_VENV"
+    assert failure["hint"]
+
+
+# ── the delete race the first fix left open ──────────────────────────────
+
+
+def test_merge_and_save_are_one_step(monkeypatch):
+    """Review finding (#1252): merging and persisting as two steps leaves a
+    window where the user deletes the dub in between — and the pending save
+    then UPSERTs the row straight back, so a dub they deleted reappears."""
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job",
+        lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+    dub_pipeline.put_job("job1", {"filename": "a.mp4"})
+
+    assert dub_pipeline.merge_and_save_job("job1", {"scene_cuts": [1.0]}) is True
+    assert saved == ["job1"]
+    assert dub_pipeline._dub_jobs["job1"]["scene_cuts"] == [1.0]
+
+
+def test_a_deleted_job_is_never_persisted(monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job",
+        lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+
+    assert dub_pipeline.merge_and_save_job("gone", {"scene_cuts": []}) is False
+    assert saved == [], "a withdrawn job must not reach the database"
+
+
+def test_a_delete_landing_mid_save_cannot_be_overtaken(monkeypatch):
+    """The race itself — asserted on ORDER, which is the only thing that
+    distinguishes it.
+
+    Two earlier versions of this test were not tests. The first deleted the job
+    before calling `merge_and_save_job`, so it merely re-checked the absent-job
+    case. The second interleaved a real thread but asserted only *what*
+    happened, not *when* — so splitting merge from save (the exact bug) still
+    passed, because a save landing AFTER the delete looks identical to one
+    landing before if you only check that both occurred.
+
+    The resurrection is precisely `save` completing after `delete`. So record
+    the order and assert on it: with merge+save atomic under the lock, the
+    purge cannot start until the save has finished, and the sequence is always
+    save-then-delete. Split them and the purge is free to run first.
+    """
+    import threading
+
+    order = []
+    order_lock = threading.Lock()
+    entered_save = threading.Event()
+    purge_attempted = threading.Event()
+
+    def _slow_save(job_id, job, *a, **kw):
+        entered_save.set()
+        # Wait until the purge thread has actually reached its purge call, so
+        # the two are genuinely in flight together, then hold a moment.
+        purge_attempted.wait(timeout=2.0)
+        time.sleep(0.05)
+        with order_lock:
+            order.append("save")
+
+    monkeypatch.setattr(dub_pipeline, "save_job", _slow_save)
+    dub_pipeline.put_job("job1", {"filename": "a.mp4"})
+
+    def _delete_rows():
+        with order_lock:
+            order.append("delete")
+
+    def _purge():
+        entered_save.wait(timeout=2.0)
+        purge_attempted.set()
+        dub_pipeline.purge_jobs(["job1"], delete_rows=_delete_rows)
+
+    purger = threading.Thread(target=_purge)
+    purger.start()
+    merged = dub_pipeline.merge_and_save_job("job1", {"scene_cuts": [1.0]})
+    purge_attempted.set()  # release the save if the purge never got that far
+    purger.join(timeout=5.0)
+
+    assert merged is True, "the save started first, so it must complete"
+    assert order == ["save", "delete"], (
+        f"the write must never land after the delete — got {order}. "
+        "'delete' first means the row was resurrected."
+    )
+    assert "job1" not in dub_pipeline._dub_jobs
+
+
+def test_a_purge_that_wins_the_race_stops_the_save_entirely(monkeypatch):
+    """The other ordering: purge first, then the pipeline reaches its save."""
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job", lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+    dub_pipeline.put_job("job1", {"filename": "a.mp4"})
+
+    dub_pipeline.purge_jobs(["job1"], delete_rows=lambda: None)
+
+    assert dub_pipeline.merge_and_save_job("job1", {"scene_cuts": []}) is False
+    assert saved == [], "a withdrawn job must never reach the database"
+
+
+def test_the_create_checkpoints_are_atomic_too(monkeypatch):
+    """Review finding (#1252): the mid-pipeline put_job + save_job pairs were
+    still unlocked, so a clear-history landing between them left a ghost row
+    behind the purge."""
+    import inspect
+
+    src = inspect.getsource(dub_pipeline.ingest_pipeline)
+    assert "put_and_save_job(" in src
+    assert "put_job(job_id," not in src, "the unlocked pair is the race"
+
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job", lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+    dub_pipeline.put_and_save_job("job2", {"filename": "b.mp4"})
+    assert saved == ["job2"]
+    assert dub_pipeline._dub_jobs["job2"]["filename"] == "b.mp4"
+
+
+def test_clear_history_also_evicts_in_memory_jobs(monkeypatch):
+    """`DELETE /dub/history` deleted every row but evicted nothing from memory,
+    so an in-flight job survived "clear history" outright and re-saved itself
+    on completion."""
+    import inspect
+
+    from api.routers import dub_core
+
+    src = inspect.getsource(dub_core.clear_dub_history)
+    assert "purge_jobs" in src, "clear-all must evict memory too, not just rows"
+
+
+def test_the_ingest_pipeline_persists_atomically():
+    import inspect
+
+    src = inspect.getsource(dub_pipeline.ingest_pipeline)
+    assert "merge_and_save_job(" in src
+    # The two-step form is what the race lived in.
+    assert "save_job(job_id, get_job(" not in src
+
+
+# ── withdrawal survives a job's FIRST write ──────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clean_tombstones():
+    dub_pipeline._inflight_jobs.clear()
+    dub_pipeline._withdrawn_jobs.clear()
+    yield
+    dub_pipeline._inflight_jobs.clear()
+    dub_pipeline._withdrawn_jobs.clear()
+
+
+def test_clearing_history_mid_ingest_is_not_undone_by_the_next_checkpoint(monkeypatch):
+    """Review finding (#1252): dict membership can't express "withdrawn".
+
+    An ingest's FIRST persistence CREATES the entry, so an absent key means
+    "not written yet" for a new job and "deleted" for an established one — two
+    opposite instructions from one signal. A clear-history landing before that
+    first checkpoint was therefore silently undone by the checkpoint recreating
+    the row, and the run went on to persist its result into history the user
+    had just cleared.
+    """
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job", lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+
+    dub_pipeline.begin_ingest("job1")
+    # Clear history BEFORE the job has ever been written. It appears in no row,
+    # so `job_ids` is empty — only the in-flight sweep can catch it.
+    dub_pipeline.purge_jobs([], delete_rows=lambda: None, include_inflight=True)
+
+    assert dub_pipeline.put_and_save_job("job1", {"filename": "a.mp4"}) is False
+    assert saved == [], "the checkpoint must not recreate a cleared job"
+    # ...and the terminal write stays refused too.
+    assert dub_pipeline.merge_and_save_job("job1", {"scene_cuts": []}) is False
+
+
+def test_a_single_delete_also_withdraws_an_inflight_job(monkeypatch):
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job", lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+    dub_pipeline.begin_ingest("job1")
+    dub_pipeline.put_and_save_job("job1", {"filename": "a.mp4"})
+    saved.clear()
+
+    dub_pipeline.purge_jobs(["job1"], delete_rows=lambda: None)
+
+    assert dub_pipeline.put_and_save_job("job1", {"filename": "a.mp4"}) is False
+    assert saved == []
+
+
+def test_a_normal_ingest_is_unaffected(monkeypatch):
+    """The gate must be invisible when nobody deletes anything — this runs on
+    every import."""
+    saved = []
+    monkeypatch.setattr(
+        dub_pipeline, "save_job", lambda job_id, job, *a, **kw: saved.append(job_id),
+    )
+    dub_pipeline.begin_ingest("job1")
+
+    assert dub_pipeline.put_and_save_job("job1", {"filename": "a.mp4"}) is True
+    assert dub_pipeline.merge_and_save_job("job1", {"scene_cuts": [1.0]}) is True
+    assert saved == ["job1", "job1"]
+
+
+def test_a_delete_during_a_RENDER_is_honoured(monkeypatch):
+    """The case Greptile actually reported, and the one an earlier version of
+    this fix did not close.
+
+    A dub is imported ONCE and rendered many times, so the realistic delete
+    lands during a render — long after its ingest ended. Scoping the tombstone
+    to in-flight ingests looked right and protected almost nothing: the render's
+    own `save_job` wrote the row straight back.
+    """
+    written = []
+    monkeypatch.setattr(
+        dub_pipeline, "_persist_job", lambda *a, **kw: written.append(a[0]),
+    )
+
+    # An ordinary saved dub whose import finished long ago.
+    dub_pipeline.begin_ingest("old1")
+    dub_pipeline.put_and_save_job("old1", {"filename": "a.mp4"})
+    dub_pipeline.end_ingest("old1")
+    written.clear()
+
+    # Deleted from history while a render is still running.
+    dub_pipeline.purge_jobs(["old1"], delete_rows=lambda: None)
+    # The render completes and persists, exactly as dub_generate.py does.
+    dub_pipeline.save_job("old1", {"filename": "a.mp4", "dubbed_tracks": {"en": {}}})
+
+    assert written == [], "a render finishing after the delete must not revive it"
+
+
+def test_the_ingest_ending_is_not_an_un_delete(monkeypatch):
+    """`end_ingest` used to clear the tombstone, which is what opened the gap
+    above — the ingest finishing is not the user un-deleting anything."""
+    monkeypatch.setattr(dub_pipeline, "_persist_job", lambda *a, **kw: None)
+    dub_pipeline.begin_ingest("job1")
+    dub_pipeline.purge_jobs(["job1"], delete_rows=lambda: None)
+
+    dub_pipeline.end_ingest("job1")
+
+    assert "job1" in dub_pipeline._withdrawn_jobs
+    assert dub_pipeline._inflight_jobs == set()
+
+
+def test_re_importing_the_same_id_revives_it(monkeypatch):
+    """The one thing that legitimately un-deletes a job."""
+    written = []
+    monkeypatch.setattr(
+        dub_pipeline, "_persist_job", lambda *a, **kw: written.append(a[0]),
+    )
+    dub_pipeline.purge_jobs(["job1"], delete_rows=lambda: None)
+    assert dub_pipeline.save_job("job1", {"filename": "a.mp4"}) is None
+    assert written == []
+
+    dub_pipeline.begin_ingest("job1")  # a deliberate re-import
+    assert dub_pipeline.put_and_save_job("job1", {"filename": "a.mp4"}) is True
+    assert written == ["job1"]
+
+
+def test_the_tombstone_set_is_bounded():
+    """Kept for the life of the process, so it must not grow without limit."""
+    for i in range(dub_pipeline._WITHDRAWN_MAX + 50):
+        dub_pipeline.purge_jobs([f"job{i}"], delete_rows=lambda: None)
+
+    assert len(dub_pipeline._withdrawn_jobs) == dub_pipeline._WITHDRAWN_MAX
+    # The most recent deletions are the ones that still matter.
+    assert f"job{dub_pipeline._WITHDRAWN_MAX + 49}" in dub_pipeline._withdrawn_jobs
+    assert "job0" not in dub_pipeline._withdrawn_jobs
+
+
+def test_the_pipeline_registers_and_releases_its_run():
+    import inspect
+
+    src = inspect.getsource(dub_pipeline.ingest_pipeline)
+    assert "begin_ingest(job_id)" in src
+    assert "end_ingest(job_id)" in src, "a leaked tombstone would block a later run"
+    # Released in `finally`, so a crash or cancel can't leak it.
+    finally_block = src[src.rindex("finally:"):]
+    assert "end_ingest(job_id)" in finally_block
+
+
+def test_clear_history_sweeps_inflight_jobs():
+    import inspect
+
+    from api.routers import dub_core
+
+    src = inspect.getsource(dub_core.clear_dub_history)
+    assert "include_inflight=True" in src, (
+        "an ingest with no row yet appears in no id list — only the in-flight "
+        "sweep can clear it"
+    )
+
+
+# ── the gate is at the choke point, not in the callers ───────────────────
+
+
+def test_every_direct_save_path_honours_a_withdrawal(monkeypatch):
+    """Review finding (#1252, Greptile P1): gating only the ingest helpers left
+    eight direct `save_job` call sites — across dub generate, translate, export
+    and core — able to resurrect a dub the user deleted *mid-render*. Deleting
+    during generation is at least as likely as deleting during import.
+
+    The gate now lives in `save_job` itself, so every caller inherits it and
+    the ninth one cannot forget."""
+    written = []
+    monkeypatch.setattr(
+        dub_pipeline, "_persist_job", lambda *a, **kw: written.append(a[0]),
+    )
+
+    dub_pipeline.begin_ingest("job1")
+    dub_pipeline.purge_jobs(["job1"], delete_rows=lambda: None)
+
+    # The shape every router uses: a bare save_job, no lock, no helper.
+    dub_pipeline.save_job("job1", {"filename": "a.mp4"})
+
+    assert written == [], "a post-ingest save must not resurrect a deleted dub"
+
+
+def test_a_normal_save_still_writes(monkeypatch):
+    written = []
+    monkeypatch.setattr(
+        dub_pipeline, "_persist_job", lambda *a, **kw: written.append(a[0]),
+    )
+    dub_pipeline.save_job("job1", {"filename": "a.mp4"})
+    assert written == ["job1"]
+
+
+def test_the_lock_is_reentrant():
+    """`save_job` acquires the lock, and the atomic helpers call it while
+    already holding it — a plain Lock would deadlock the backend here."""
+    import threading
+
+    assert isinstance(dub_pipeline._dub_jobs_lock, type(threading.RLock()))
+
+
+def test_the_atomic_helpers_still_work_through_the_reentrant_path(monkeypatch):
+    """Guards the deadlock directly: if this hangs, the RLock regressed."""
+    written = []
+    monkeypatch.setattr(
+        dub_pipeline, "_persist_job", lambda *a, **kw: written.append(a[0]),
+    )
+    dub_pipeline.begin_ingest("job1")
+    assert dub_pipeline.put_and_save_job("job1", {"filename": "a.mp4"}) is True
+    assert dub_pipeline.merge_and_save_job("job1", {"scene_cuts": [1.0]}) is True
+    assert written == ["job1", "job1"]


### PR DESCRIPTION
Closes #1252. Closes #1253.

Split out of #1264 so the six independent error-message fixes there aren't held up by this one.

## Why it's separate

The other fixes in #1264 needed zero corrections. This one needed **five rounds**, and every round found something real in work that was already reviewed, tested, and CI-green:

1. **Review:** merge and save were split, so a delete landing between them had the row UPSERTed straight back.
2. **Review:** dict membership can't express "withdrawn" — an absent key means *"not written yet"* for a new job and *"deleted"* for an established one, two opposite instructions from one signal.
3. **Fail-before check:** the race test wasn't testing the race. It asserted *what* happened (save ran, row deleted) but never *when* — and "save lands after delete" **is** the resurrection. Splitting merge from save passed all 22 tests.
4. **Review:** the gate sat in the two ingest helpers while **eight** direct `save_job` call sites across generate / translate / export / core bypassed it entirely.
5. **Direct check of the reported scenario:** the fix for (4) didn't fix it. The tombstone covered in-flight *ingests*, but a dub is imported once and rendered many times — so the realistic delete lands during a **render**, long after the ingest ended, and `end_ingest` was clearing the tombstone at exactly that point. CI green, 26 tests passing, and the reported bug still reproduced.

Riding a release on that record isn't a good trade.

## The bug

`ingest_pipeline` ended with a bare `_dub_jobs[job_id].update(...)`. Everything before it — demucs, scene detection, thumbnailing — takes minutes, and `DELETE /dub/history/{id}` pops the entry. So deleting an in-flight dub raised `KeyError`, and since `str(KeyError("mgw39lx3"))` is the repr of the key, the user's entire error message was eight characters of their own job id:

```
ingest: 'mgw39lx3'
```

Behind that sat a second, quieter bug: the delete could be *undone*. Any pending write would put the row back.

## The fix

- **Withdrawal is recorded when a job is deleted**, not while an ingest runs — that scoping is what step 5 got wrong.
- **Held in a bounded LRU** rather than cleared on completion. There is no moment at which a delete stops mattering: any operation still holding that job can persist it. Bounded so it can't grow without limit.
- **Checked inside `save_job`**, so all nine call sites inherit it and the tenth can't forget.
- **Re-importing an id is the only thing that revives it** — a deliberate act, unlike an ingest merely finishing.
- `_dub_jobs_lock` is now re-entrant, since the atomic helpers call `save_job` while already holding it. A plain `Lock` would deadlock the backend; a test pins the type, and I walked every locked region to confirm none calls another.
- `DELETE /dub/history` (clear-all) never evicted from memory at all, so an in-flight job survived it outright and re-saved itself. It now sweeps in-flight jobs too — one with no row yet appears in no id list.

Also carries #1252's message half: no exception whose `str()` is a bare value can present itself to a user that way again.

## Verification

Every claim above is fail-before verified — reverting each hunk fails specific tests, including the ordering assertion (`got ['delete', 'save']`) that the earlier version couldn't make.

Backend suite: **3656 passed**.

## What I'd still want

This is intricate concurrency and its defect rate has been high. A reviewer specifically hunting for a sixth thing would be worth more than my saying it's ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Dub job deletion is now enforced against concurrent ingestion/render via re-entrant, lock-protected lifecycle state with age-expiring withdrawal tombstones checked in `save_job`, plus centralized purge/clear-history that evicts in-flight/in-memory jobs so only a later re-import can revive a purged ID. The ingest pipeline was refactored to use atomic save/merge helpers (with begin/end ingest tracking) so deletes cancel cleanly instead of allowing pending writes to resurrect jobs, and failure formatting was hardened to avoid “bare” exception strings (e.g., job IDs). Biggest risk worth a human look is the tombstone/expiry and purge `include_inflight` semantics to ensure deleted IDs aren’t accidentally suppressed indefinitely or resurrected through any remaining persistence path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->