### PR TITLE
release: v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 Versions track the desktop app (`tauri.conf.json` + `frontend/src-tauri/Cargo.toml`).
 The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
-## [Unreleased]
+## [0.4.2] — 2026-07-28
 
 **Highlights**
 
 - The update prompt is a small toast with buttons, not a screenful of release notes
+- Installing an update no longer throws away work that is still running
+- Quitting the app mid-generate stops reporting itself as a crash
+- A half-downloaded model repairs itself instead of dead-ending
+- "Dismiss" no longer reads as "terminate an employee" in five languages
 
 ### Changed
 
@@ -18,11 +22,12 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Installing an update no longer relaunches the app while work is running. The check only knew about dub synthesis, so a restart could silently discard an upload, a transcription, a translation, an export or a standalone synth — and two overlapping synths used to cancel each other's protection. Install is now greyed out while anything is in flight (#1272)
 - A half-downloaded model now repairs itself instead of failing with a raw 500. The automatic repair recognised only one of the two ways the loader reports missing weights, so an interrupted download whose subfolder failed to load got neither the repair nor a hint about what to do (#1273)
-- Quitting the app with a generate queued reported "500 Internal Server Error: model load skipped: backend shutting down" and offered to file a bug for it. A shutdown is not a fault: the backend now answers 503 with what to do, and no error toast offers a bug report for a 503 (#1276)
-- Installing an update no longer relaunches the app while work is running. The check only knew about dub synthesis, so a restart could silently discard an upload, a transcription, a translation, an export or a standalone synth (#1272)
+- Quitting the app with a generate queued reported "500 Internal Server Error: model load skipped: backend shutting down" and offered to file a bug for it. A shutdown is not a fault: the backend now answers 503 with what to do, and no bug report is offered for it (#1276)
 - Dub history: clearing a large history while a render was running could still resurrect the deleted job — which markers survived depended on the process hash seed, and an oversized purge could discard a live one (#1252)
 - German, Japanese, Russian and both Chinese locales rendered "Dismiss" as the employment sense — "terminate an employee" — on close buttons (#1272)
+- The "wait for the current job to finish" message named dubbing specifically, though it now covers uploads, transcription, translation, exports and synthesis; reworded across all 21 languages (#1272)
 
 ## [0.4.1] — 2026-07-27
 

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.4.1"
+_FALLBACK_VERSION = "0.4.2"
 
 
 def _fallback_version() -> str:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnivoice-studio"
-version = "0.4.1"
+version = "0.4.2"
 description = "OmniVoice Studio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.4.1"
+version = "0.4.2"
 description = "OmniVoice: Towards Omnilingual Zero-Shot Text-to-Speech with Diffusion Language Models"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/uv.lock
+++ b/uv.lock
@@ -3233,7 +3233,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
Cuts **v0.4.2** from main.

## Version sources

All five moved in lockstep, plus both lockfiles:

- `frontend/package.json` (source of truth)
- `frontend/src-tauri/Cargo.toml` + `Cargo.lock`
- `pyproject.toml` + `uv.lock`
- `backend/core/version.py` (`_FALLBACK_VERSION`)

`tests/test_app_version.py` and `tests/test_changelog_style.py` pass. `bun install --frozen-lockfile` passes against the root `bun.lock` (the Docker-build check that plain `bun install` in ci.yml would tolerate).

## What ships

| Fix | Issue |
|---|---|
| Update prompt is a toast with actions, not a wall of text | #1272 |
| Installing an update no longer discards in-flight work | #1272 |
| Quitting mid-generate no longer reports itself as a crash | #1276 |
| Half-downloaded model repairs itself instead of dead-ending | #1273 |
| Dub-history purge ordering / live-marker eviction | #1252 |
| "Dismiss" mistranslated as "terminate an employee" in 5 locales | #1272 |

## After merge

Tag `v0.4.2` from main, then verify every channel per `docs/RELEASING.md` §5b — GitHub Release with 4-platform installers + signed `latest.json`, the preview channel, GHCR **and** Docker Hub in both CUDA and ROCm flavours, and the Docker Hub overview sync (whose step is `continue-on-error` and 403s silently, so the step log needs reading rather than the job status).

Per the owner's `AUTO_VERSION_BUMP=off` rule, main stays at 0.4.2 after tagging — no automatic post-release bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Released v0.4.2 by updating version sources and lockfiles, renaming the changelog release section, and documenting fixes for updates, model downloads, shutdowns, dub history, and translations. This coordinates the release across project metadata and user-facing behavior. Human review should verify release-channel publishing and tagging after merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->