### PR TITLE
fix(engines): show the under-provisioned-VRAM warning instead of discarding it

### DIFF
--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -579,7 +579,8 @@
     "routingUnknown": "غير معروف",
     "routingEffectiveChip": "يعمل على {{device}} على هذا الجهاز",
     "routingCaveatTitle": "تم تحديد وحدة معالجة الرسومات، ولكن: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: يعمل على المعالج المركزي — {{reason}}",
+    "selectWithCaveat": "تم التبديل إلى {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "تعمل مفاتيح التشغيل السريع العامة فقط في تطبيق سطح المكتب. تستخدم واجهة مستخدم الويب اختصارًا <1>Ctrl+Shift+Space</1> داخل الصفحة أثناء التركيز على النافذة.",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -578,7 +578,8 @@
     "routingRemote": "بعيد",
     "routingUnknown": "غير معروف",
     "routingEffectiveChip": "يعمل على {{device}} على هذا الجهاز",
-    "routingCaveatTitle": "تم تحديد وحدة معالجة الرسومات، ولكن: {{reason}}"
+    "routingCaveatTitle": "تم تحديد وحدة معالجة الرسومات، ولكن: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "تعمل مفاتيح التشغيل السريع العامة فقط في تطبيق سطح المكتب. تستخدم واجهة مستخدم الويب اختصارًا <1>Ctrl+Shift+Space</1> داخل الصفحة أثناء التركيز على النافذة.",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -104,7 +104,7 @@
     "update_check_failed": "فشل التحقق من التحديث: {{message}}",
     "save_failed": "فشل الحفظ: {{message}}",
     "clear_failed": "فشل المسح: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "تم تبديل {{family}} إلى {{engine}}",
     "channel_set_failed": "فشل تعيين القناة: {{message}}",
     "updater_downloading": "جارٍ التنزيل {{version}}…",
     "updater_installed": "تم التثبيت - إعادة التشغيل.",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Unbekannt",
     "routingEffectiveChip": "Läuft unter {{device}} auf diesem Computer",
     "routingCaveatTitle": "GPU ausgewählt, aber: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: läuft auf der CPU — {{reason}}",
+    "selectWithCaveat": "Zu {{engine}} gewechselt — {{reason}}"
   },
   "capture": {
     "desc": "Globale Hotkeys funktionieren nur in der Desktop-App. Die Web-Benutzeroberfläche verwendet eine In-Page-Verknüpfung <1>Strg+Umschalt+Leertaste</1>, während das Fenster den Fokus hat.",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -578,7 +578,8 @@
     "routingRemote": "Fernbedienung",
     "routingUnknown": "Unbekannt",
     "routingEffectiveChip": "Läuft unter {{device}} auf diesem Computer",
-    "routingCaveatTitle": "GPU ausgewählt, aber: {{reason}}"
+    "routingCaveatTitle": "GPU ausgewählt, aber: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Globale Hotkeys funktionieren nur in der Desktop-App. Die Web-Benutzeroberfläche verwendet eine In-Page-Verknüpfung <1>Strg+Umschalt+Leertaste</1>, während das Fenster den Fokus hat.",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Update-Prüfung fehlgeschlagen: {{message}}",
     "save_failed": "Speichern fehlgeschlagen: {{message}}",
     "clear_failed": "Löschen fehlgeschlagen: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} auf {{engine}} umgestellt",
     "channel_set_failed": "Kanal konnte nicht festgelegt werden: {{message}}",
     "updater_downloading": "{{version}} wird heruntergeladen…",
     "updater_installed": "Installiert – Neustart.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1905,7 +1905,8 @@
     "installStep_verify": "Verifying the environment",
     "installStep_fetch_weights": "Downloading model weights",
     "installStep_persist": "Saving configuration",
-    "installAria": "Install {{engine}}"
+    "installAria": "Install {{engine}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "errors": {
     "title": "This tab hit a snag.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -523,7 +523,7 @@
     "update_check_failed": "Update check failed: {{message}}",
     "save_failed": "Save failed: {{message}}",
     "clear_failed": "Clear failed: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "Switched {{family}} to {{engine}}",
     "channel_set_failed": "Failed to set channel: {{message}}",
     "updater_downloading": "Downloading {{version}}…",
     "updater_installed": "Installed — relaunching.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1906,7 +1906,7 @@
     "installStep_fetch_weights": "Downloading model weights",
     "installStep_persist": "Saving configuration",
     "installAria": "Install {{engine}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectWithCaveat": "Switched to {{engine}} — {{reason}}"
   },
   "errors": {
     "title": "This tab hit a snag.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Error en la verificación de actualización: {{message}}",
     "save_failed": "Error al guardar: {{message}}",
     "clear_failed": "Borrado fallido: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} cambiado a {{engine}}",
     "channel_set_failed": "No se pudo configurar el canal: {{message}}",
     "updater_downloading": "Descargando {{version}}…",
     "updater_installed": "Instalado - relanzando.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -578,7 +578,8 @@
     "routingRemote": "Remoto",
     "routingUnknown": "Desconocido",
     "routingEffectiveChip": "Se ejecuta en {{device}} en esta máquina",
-    "routingCaveatTitle": "GPU seleccionada, pero: {{reason}}"
+    "routingCaveatTitle": "GPU seleccionada, pero: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Las teclas de acceso rápido globales solo funcionan en la aplicación de escritorio. La interfaz de usuario web utiliza un acceso directo <1>Ctrl+Shift+Espacio</1> en la página mientras la ventana tiene el foco.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Desconocido",
     "routingEffectiveChip": "Se ejecuta en {{device}} en esta máquina",
     "routingCaveatTitle": "GPU seleccionada, pero: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: ejecutándose en la CPU — {{reason}}",
+    "selectWithCaveat": "Se cambió a {{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Las teclas de acceso rápido globales solo funcionan en la aplicación de escritorio. La interfaz de usuario web utiliza un acceso directo <1>Ctrl+Shift+Espacio</1> en la página mientras la ventana tiene el foco.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Inconnu",
     "routingEffectiveChip": "Fonctionne le {{device}} sur cette machine",
     "routingCaveatTitle": "GPU sélectionné, mais : {{reason}}",
-    "selectWithCaveat": "{{engine}} : {{reason}}"
+    "selectCpuFallback": "{{engine}} : fonctionne sur le processeur — {{reason}}",
+    "selectWithCaveat": "Basculé vers {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Les raccourcis clavier globaux ne fonctionnent que dans l'application de bureau. L'interface utilisateur Web utilise un raccourci <1>Ctrl+Shift+Espace</1> sur la page lorsque la fenêtre a le focus.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -578,7 +578,8 @@
     "routingRemote": "À distance",
     "routingUnknown": "Inconnu",
     "routingEffectiveChip": "Fonctionne le {{device}} sur cette machine",
-    "routingCaveatTitle": "GPU sélectionné, mais : {{reason}}"
+    "routingCaveatTitle": "GPU sélectionné, mais : {{reason}}",
+    "selectWithCaveat": "{{engine}} : {{reason}}"
   },
   "capture": {
     "desc": "Les raccourcis clavier globaux ne fonctionnent que dans l'application de bureau. L'interface utilisateur Web utilise un raccourci <1>Ctrl+Shift+Espace</1> sur la page lorsque la fenêtre a le focus.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Échec de la vérification de la mise à jour : {{message}}",
     "save_failed": "Échec de l'enregistrement : {{message}}",
     "clear_failed": "Échec de la suppression : {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} basculé vers {{engine}}",
     "channel_set_failed": "Échec de la définition du canal : {{message}}",
     "updater_downloading": "Téléchargement de {{version}}…",
     "updater_installed": "Installé — relance.",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -578,7 +578,8 @@
     "routingRemote": "रिमोट",
     "routingUnknown": "अज्ञात",
     "routingEffectiveChip": "इस मशीन पर {{device}} पर चलता है",
-    "routingCaveatTitle": "GPU चयनित, लेकिन: {{reason}}"
+    "routingCaveatTitle": "GPU चयनित, लेकिन: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "ग्लोबल हॉटकीज़ केवल डेस्कटॉप ऐप में काम करती हैं। वेब यूआई इन-पेज <1>Ctrl+Shift+Space</1> शॉर्टकट का उपयोग करता है जबकि विंडो पर फोकस होता है।",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -104,7 +104,7 @@
     "update_check_failed": "अद्यतन जाँच विफल: {{message}}",
     "save_failed": "सहेजना विफल: {{message}}",
     "clear_failed": "साफ़ विफल: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} को {{engine}} में बदला गया",
     "channel_set_failed": "चैनल सेट करने में विफल: {{message}}",
     "updater_downloading": "डाउनलोड हो रहा है {{version}}…",
     "updater_installed": "इंस्टॉल किया गया - पुनः लॉन्च किया जा रहा है।",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -579,7 +579,8 @@
     "routingUnknown": "अज्ञात",
     "routingEffectiveChip": "इस मशीन पर {{device}} पर चलता है",
     "routingCaveatTitle": "GPU चयनित, लेकिन: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: CPU पर चल रहा है — {{reason}}",
+    "selectWithCaveat": "{{engine}} पर स्विच किया गया — {{reason}}"
   },
   "capture": {
     "desc": "ग्लोबल हॉटकीज़ केवल डेस्कटॉप ऐप में काम करती हैं। वेब यूआई इन-पेज <1>Ctrl+Shift+Space</1> शॉर्टकट का उपयोग करता है जबकि विंडो पर फोकस होता है।",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Pemeriksaan pembaruan gagal: {{message}}",
     "save_failed": "Gagal menyimpan: {{message}}",
     "clear_failed": "Hapus gagal: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} dialihkan ke {{engine}}",
     "channel_set_failed": "Gagal menyetel saluran: {{message}}",
     "updater_downloading": "Mengunduh {{version}}…",
     "updater_installed": "Dipasang — diluncurkan kembali.",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Tidak diketahui",
     "routingEffectiveChip": "Berjalan pada {{device}} di mesin ini",
     "routingCaveatTitle": "GPU dipilih, tetapi: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: berjalan di CPU — {{reason}}",
+    "selectWithCaveat": "Beralih ke {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Tombol pintas global hanya berfungsi di aplikasi desktop. UI web menggunakan pintasan <1>Ctrl+Shift+Space</1> dalam halaman saat jendela memiliki fokus.",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -578,7 +578,8 @@
     "routingRemote": "Terpencil",
     "routingUnknown": "Tidak diketahui",
     "routingEffectiveChip": "Berjalan pada {{device}} di mesin ini",
-    "routingCaveatTitle": "GPU dipilih, tetapi: {{reason}}"
+    "routingCaveatTitle": "GPU dipilih, tetapi: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Tombol pintas global hanya berfungsi di aplikasi desktop. UI web menggunakan pintasan <1>Ctrl+Shift+Space</1> dalam halaman saat jendela memiliki fokus.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -578,7 +578,8 @@
     "routingRemote": "Remoto",
     "routingUnknown": "Sconosciuto",
     "routingEffectiveChip": "Funziona su {{device}} su questa macchina",
-    "routingCaveatTitle": "GPU selezionata, ma: {{reason}}"
+    "routingCaveatTitle": "GPU selezionata, ma: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "I tasti di scelta rapida globali funzionano solo nell'app desktop. L'interfaccia utente Web utilizza una scorciatoia <1>Ctrl+Shift+Spazio</1> nella pagina mentre la finestra è attiva.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Sconosciuto",
     "routingEffectiveChip": "Funziona su {{device}} su questa macchina",
     "routingCaveatTitle": "GPU selezionata, ma: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: in esecuzione sulla CPU — {{reason}}",
+    "selectWithCaveat": "Passato a {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "I tasti di scelta rapida globali funzionano solo nell'app desktop. L'interfaccia utente Web utilizza una scorciatoia <1>Ctrl+Shift+Spazio</1> nella pagina mentre la finestra è attiva.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Controllo aggiornamento non riuscito: {{message}}",
     "save_failed": "Salvataggio non riuscito: {{message}}",
     "clear_failed": "Cancellazione non riuscita: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} passato a {{engine}}",
     "channel_set_failed": "Impossibile impostare il canale: {{message}}",
     "updater_downloading": "Download in corso di {{version}}...",
     "updater_installed": "Installato: riavvio.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -104,7 +104,7 @@
     "update_check_failed": "更新チェックに失敗しました: {{message}}",
     "save_failed": "保存に失敗しました: {{message}}",
     "clear_failed": "クリアに失敗しました: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} を {{engine}} に切り替えました",
     "channel_set_failed": "チャネルの設定に失敗しました: {{message}}",
     "updater_downloading": "{{version}} をダウンロード中…",
     "updater_installed": "インストール済み — 再起動中。",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -578,7 +578,8 @@
     "routingRemote": "リモート",
     "routingUnknown": "不明",
     "routingEffectiveChip": "このマシンの {{device}} で実行されます",
-    "routingCaveatTitle": "GPU が選択されましたが: {{reason}}"
+    "routingCaveatTitle": "GPU が選択されましたが: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "グローバル ホットキーはデスクトップ アプリでのみ機能します。 Web UI は、ウィンドウにフォーカスがある間、ページ内 <1>Ctrl+Shift+Space</1> ショートカットを使用します。",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -579,7 +579,8 @@
     "routingUnknown": "不明",
     "routingEffectiveChip": "このマシンの {{device}} で実行されます",
     "routingCaveatTitle": "GPU が選択されましたが: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: CPU で実行中 — {{reason}}",
+    "selectWithCaveat": "{{engine}} に切り替えました — {{reason}}"
   },
   "capture": {
     "desc": "グローバル ホットキーはデスクトップ アプリでのみ機能します。 Web UI は、ウィンドウにフォーカスがある間、ページ内 <1>Ctrl+Shift+Space</1> ショートカットを使用します。",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -579,7 +579,8 @@
     "routingUnknown": "알 수 없음",
     "routingEffectiveChip": "이 머신의 {{device}}에서 실행됩니다.",
     "routingCaveatTitle": "GPU가 선택되었지만: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: CPU에서 실행 중 — {{reason}}",
+    "selectWithCaveat": "{{engine}}(으)로 전환했습니다 — {{reason}}"
   },
   "capture": {
     "desc": "전역 단축키는 데스크톱 앱에서만 작동합니다. 웹 UI는 창에 포커스가 있는 동안 페이지 내 <1>Ctrl+Shift+Space</1> 단축키를 사용합니다.",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -104,7 +104,7 @@
     "update_check_failed": "업데이트 확인 실패: {{message}}",
     "save_failed": "저장 실패: {{message}}",
     "clear_failed": "지우기 실패: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}}을(를) {{engine}}(으)로 전환했습니다",
     "channel_set_failed": "채널 설정 실패: {{message}}",
     "updater_downloading": "{{version}} 다운로드 중…",
     "updater_installed": "설치됨 - 다시 시작하는 중입니다.",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -578,7 +578,8 @@
     "routingRemote": "원격",
     "routingUnknown": "알 수 없음",
     "routingEffectiveChip": "이 머신의 {{device}}에서 실행됩니다.",
-    "routingCaveatTitle": "GPU가 선택되었지만: {{reason}}"
+    "routingCaveatTitle": "GPU가 선택되었지만: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "전역 단축키는 데스크톱 앱에서만 작동합니다. 웹 UI는 창에 포커스가 있는 동안 페이지 내 <1>Ctrl+Shift+Space</1> 단축키를 사용합니다.",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Onbekend",
     "routingEffectiveChip": "Draait op {{device}} op deze machine",
     "routingCaveatTitle": "GPU geselecteerd, maar: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: draait op de CPU — {{reason}}",
+    "selectWithCaveat": "Overgeschakeld naar {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Globale sneltoetsen werken alleen in de desktop-app. De webinterface gebruikt een sneltoets <1>Ctrl+Shift+Spatie</1> op de pagina terwijl het venster focus heeft.",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Updatecontrole mislukt: {{message}}",
     "save_failed": "Opslaan mislukt: {{message}}",
     "clear_failed": "Wissen mislukt: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} overgeschakeld naar {{engine}}",
     "channel_set_failed": "Kan kanaal niet instellen: {{message}}",
     "updater_downloading": "{{version}} downloaden…",
     "updater_installed": "Geïnstalleerd - opnieuw gestart.",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -578,7 +578,8 @@
     "routingRemote": "Op afstand",
     "routingUnknown": "Onbekend",
     "routingEffectiveChip": "Draait op {{device}} op deze machine",
-    "routingCaveatTitle": "GPU geselecteerd, maar: {{reason}}"
+    "routingCaveatTitle": "GPU geselecteerd, maar: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Globale sneltoetsen werken alleen in de desktop-app. De webinterface gebruikt een sneltoets <1>Ctrl+Shift+Spatie</1> op de pagina terwijl het venster focus heeft.",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Sprawdzanie aktualizacji nie powiodło się: {{message}}",
     "save_failed": "Zapis nie powiódł się: {{message}}",
     "clear_failed": "Wyczyszczenie nie powiodło się: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "Przełączono {{family}} na {{engine}}",
     "channel_set_failed": "Nie udało się ustawić kanału: {{message}}",
     "updater_downloading": "Pobieranie {{version}}…",
     "updater_installed": "Zainstalowano — uruchamiam ponownie.",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Nieznany",
     "routingEffectiveChip": "Działa na {{device}} na tym komputerze",
     "routingCaveatTitle": "Wybrano procesor graficzny, ale: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: działa na CPU — {{reason}}",
+    "selectWithCaveat": "Przełączono na {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Globalne skróty klawiszowe działają tylko w aplikacji komputerowej. Interfejs WWW korzysta ze skrótu <1>Ctrl+Shift+Spacja</1> znajdującego się na stronie, gdy okno jest aktywne.",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -578,7 +578,8 @@
     "routingRemote": "Zdalny",
     "routingUnknown": "Nieznany",
     "routingEffectiveChip": "Działa na {{device}} na tym komputerze",
-    "routingCaveatTitle": "Wybrano procesor graficzny, ale: {{reason}}"
+    "routingCaveatTitle": "Wybrano procesor graficzny, ale: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Globalne skróty klawiszowe działają tylko w aplikacji komputerowej. Interfejs WWW korzysta ze skrótu <1>Ctrl+Shift+Spacja</1> znajdującego się na stronie, gdy okno jest aktywne.",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Falha na verificação de atualização: {{message}}",
     "save_failed": "Falha ao salvar: {{message}}",
     "clear_failed": "Falha na limpeza: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} alterado para {{engine}}",
     "channel_set_failed": "Falha ao definir canal: {{message}}",
     "updater_downloading": "Baixando {{version}}…",
     "updater_installed": "Instalado – relançando.",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -578,7 +578,8 @@
     "routingRemote": "Remoto",
     "routingUnknown": "Desconhecido",
     "routingEffectiveChip": "Funciona em {{device}} nesta máquina",
-    "routingCaveatTitle": "GPU selecionada, mas: {{reason}}"
+    "routingCaveatTitle": "GPU selecionada, mas: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "As teclas de atalho globais funcionam apenas no aplicativo de desktop. A IU da web usa um atalho <1>Ctrl+Shift+Space</1> na página enquanto a janela está em foco.",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Desconhecido",
     "routingEffectiveChip": "Funciona em {{device}} nesta máquina",
     "routingCaveatTitle": "GPU selecionada, mas: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: em execução na CPU — {{reason}}",
+    "selectWithCaveat": "Alterado para {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "As teclas de atalho globais funcionam apenas no aplicativo de desktop. A IU da web usa um atalho <1>Ctrl+Shift+Space</1> na página enquanto a janela está em foco.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Неизвестный",
     "routingEffectiveChip": "Работает на {{device}} на этом компьютере",
     "routingCaveatTitle": "Графический процессор выбран, но: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: работает на CPU — {{reason}}",
+    "selectWithCaveat": "Переключено на {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Глобальные горячие клавиши работают только в настольном приложении. Веб-интерфейс использует внутристраничный ярлык <1>Ctrl+Shift+Space</1>, пока окно находится в фокусе.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Проверка обновлений не удалась: {{message}}",
     "save_failed": "Не удалось сохранить: {{message}}",
     "clear_failed": "Очистить не удалось: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} переключён на {{engine}}",
     "channel_set_failed": "Не удалось установить канал: {{message}}.",
     "updater_downloading": "Загрузка {{version}}…",
     "updater_installed": "Установил — перезапускаю.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -578,7 +578,8 @@
     "routingRemote": "Удаленный",
     "routingUnknown": "Неизвестный",
     "routingEffectiveChip": "Работает на {{device}} на этом компьютере",
-    "routingCaveatTitle": "Графический процессор выбран, но: {{reason}}"
+    "routingCaveatTitle": "Графический процессор выбран, но: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Глобальные горячие клавиши работают только в настольном приложении. Веб-интерфейс использует внутристраничный ярлык <1>Ctrl+Shift+Space</1>, пока окно находится в фокусе.",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Okänd",
     "routingEffectiveChip": "Körs på {{device}} på den här maskinen",
     "routingCaveatTitle": "GPU vald, men: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: körs på CPU — {{reason}}",
+    "selectWithCaveat": "Bytte till {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Globala snabbtangenter fungerar bara i skrivbordsappen. Webbgränssnittet använder en genväg <1>Ctrl+Skift+Mellanslag</1> på sidan medan fönstret har fokus.",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -578,7 +578,8 @@
     "routingRemote": "Fjärrkontroll",
     "routingUnknown": "Okänd",
     "routingEffectiveChip": "Körs på {{device}} på den här maskinen",
-    "routingCaveatTitle": "GPU vald, men: {{reason}}"
+    "routingCaveatTitle": "GPU vald, men: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Globala snabbtangenter fungerar bara i skrivbordsappen. Webbgränssnittet använder en genväg <1>Ctrl+Skift+Mellanslag</1> på sidan medan fönstret har fokus.",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Uppdateringskontrollen misslyckades: {{message}}",
     "save_failed": "Det gick inte att spara: {{message}}",
     "clear_failed": "Rensa misslyckades: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} bytt till {{engine}}",
     "channel_set_failed": "Det gick inte att ställa in kanal: {{message}}",
     "updater_downloading": "Laddar ner {{version}}...",
     "updater_installed": "Installerad — omstart.",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -578,7 +578,8 @@
     "routingRemote": "ระยะไกล",
     "routingUnknown": "ไม่ทราบ",
     "routingEffectiveChip": "ทำงานบน {{device}} บนเครื่องนี้",
-    "routingCaveatTitle": "เลือก GPU แล้ว แต่: {{reason}}"
+    "routingCaveatTitle": "เลือก GPU แล้ว แต่: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "ปุ่มลัดส่วนกลางใช้งานได้ในแอปเดสก์ท็อปเท่านั้น UI ของเว็บใช้ทางลัด <1>Ctrl+Shift+Space</1> ในเพจในขณะที่หน้าต่างมีโฟกัส",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -579,7 +579,8 @@
     "routingUnknown": "ไม่ทราบ",
     "routingEffectiveChip": "ทำงานบน {{device}} บนเครื่องนี้",
     "routingCaveatTitle": "เลือก GPU แล้ว แต่: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: กำลังทำงานบน CPU — {{reason}}",
+    "selectWithCaveat": "สลับไปที่ {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "ปุ่มลัดส่วนกลางใช้งานได้ในแอปเดสก์ท็อปเท่านั้น UI ของเว็บใช้ทางลัด <1>Ctrl+Shift+Space</1> ในเพจในขณะที่หน้าต่างมีโฟกัส",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -104,7 +104,7 @@
     "update_check_failed": "การตรวจสอบการอัปเดตล้มเหลว: {{message}}",
     "save_failed": "บันทึกล้มเหลว: {{message}}",
     "clear_failed": "การเคลียร์ล้มเหลว: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "สลับ {{family}} ไปที่ {{engine}}",
     "channel_set_failed": "ไม่สามารถตั้งค่าช่อง: {{message}}",
     "updater_downloading": "กำลังดาวน์โหลด {{version}}…",
     "updater_installed": "ติดตั้งแล้ว — เปิดตัวใหม่",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -578,7 +578,8 @@
     "routingRemote": "Uzaktan",
     "routingUnknown": "Bilinmiyor",
     "routingEffectiveChip": "Bu makinede {{device}} tarihinde çalışıyor",
-    "routingCaveatTitle": "GPU seçildi, ancak: {{reason}}"
+    "routingCaveatTitle": "GPU seçildi, ancak: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Genel kısayol tuşları yalnızca masaüstü uygulamasında çalışır. Web kullanıcı arayüzü, pencere odaktayken sayfa içi <1>Ctrl+Shift+Space</1> kısayolunu kullanır.",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Bilinmiyor",
     "routingEffectiveChip": "Bu makinede {{device}} tarihinde çalışıyor",
     "routingCaveatTitle": "GPU seçildi, ancak: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: CPU üzerinde çalışıyor — {{reason}}",
+    "selectWithCaveat": "{{engine}} motoruna geçildi — {{reason}}"
   },
   "capture": {
     "desc": "Genel kısayol tuşları yalnızca masaüstü uygulamasında çalışır. Web kullanıcı arayüzü, pencere odaktayken sayfa içi <1>Ctrl+Shift+Space</1> kısayolunu kullanır.",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Güncelleme kontrolü başarısız oldu: {{message}}",
     "save_failed": "Kaydetme başarısız oldu: {{message}}",
     "clear_failed": "Temizleme başarısız oldu: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} motoru {{engine}} olarak değiştirildi",
     "channel_set_failed": "Kanal ayarlanamadı: {{message}}",
     "updater_downloading": "{{version}} indiriliyor…",
     "updater_installed": "Yüklendi - yeniden başlatılıyor.",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Невідомий",
     "routingEffectiveChip": "Працює на {{device}} на цій машині",
     "routingCaveatTitle": "Графічний процесор вибрано, але: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: працює на CPU — {{reason}}",
+    "selectWithCaveat": "Перемкнено на {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Глобальні гарячі клавіші працюють лише в настільній програмі. Веб-інтерфейс використовує ярлик <1>Ctrl+Shift+Пробіл</1> на сторінці, коли вікно має фокус.",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -578,7 +578,8 @@
     "routingRemote": "Дистанційний",
     "routingUnknown": "Невідомий",
     "routingEffectiveChip": "Працює на {{device}} на цій машині",
-    "routingCaveatTitle": "Графічний процесор вибрано, але: {{reason}}"
+    "routingCaveatTitle": "Графічний процесор вибрано, але: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Глобальні гарячі клавіші працюють лише в настільній програмі. Веб-інтерфейс використовує ярлик <1>Ctrl+Shift+Пробіл</1> на сторінці, коли вікно має фокус.",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Не вдалося перевірити оновлення: {{message}}",
     "save_failed": "Не вдалося зберегти: {{message}}",
     "clear_failed": "Помилка очищення: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "{{family}} перемкнено на {{engine}}",
     "channel_set_failed": "Не вдалося встановити канал: {{message}}",
     "updater_downloading": "Завантаження {{version}}…",
     "updater_installed": "Встановлено — перезапуск.",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -104,7 +104,7 @@
     "update_check_failed": "Kiểm tra cập nhật không thành công: {{message}}",
     "save_failed": "Lưu không thành công: {{message}}",
     "clear_failed": "Xóa không thành công: {{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "Đã chuyển {{family}} sang {{engine}}",
     "channel_set_failed": "Không đặt được kênh: {{message}}",
     "updater_downloading": "Đang tải xuống {{version}}…",
     "updater_installed": "Đã cài đặt - khởi chạy lại.",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -579,7 +579,8 @@
     "routingUnknown": "Không xác định",
     "routingEffectiveChip": "Chạy trên {{device}} trên máy này",
     "routingCaveatTitle": "Đã chọn GPU nhưng: {{reason}}",
-    "selectWithCaveat": "{{engine}}: {{reason}}"
+    "selectCpuFallback": "{{engine}}: đang chạy trên CPU — {{reason}}",
+    "selectWithCaveat": "Đã chuyển sang {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "Phím nóng chung chỉ hoạt động trong ứng dụng máy tính để bàn. Giao diện người dùng web sử dụng phím tắt <1>Ctrl+Shift+Space</1> trong trang trong khi cửa sổ đang có tiêu điểm.",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -578,7 +578,8 @@
     "routingRemote": "Từ xa",
     "routingUnknown": "Không xác định",
     "routingEffectiveChip": "Chạy trên {{device}} trên máy này",
-    "routingCaveatTitle": "Đã chọn GPU nhưng: {{reason}}"
+    "routingCaveatTitle": "Đã chọn GPU nhưng: {{reason}}",
+    "selectWithCaveat": "{{engine}}: {{reason}}"
   },
   "capture": {
     "desc": "Phím nóng chung chỉ hoạt động trong ứng dụng máy tính để bàn. Giao diện người dùng web sử dụng phím tắt <1>Ctrl+Shift+Space</1> trong trang trong khi cửa sổ đang có tiêu điểm.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -325,7 +325,7 @@
     "update_check_failed": "更新检查失败：{{message}}",
     "save_failed": "保存失败：{{message}}",
     "clear_failed": "清除失败：{{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "已将 {{family}} 切换到 {{engine}}",
     "channel_set_failed": "无法设置频道：{{message}}",
     "updater_downloading": "正在下载 {{version}}...",
     "updater_installed": "已安装 - 重新启动。",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -538,7 +538,8 @@
     "routingCaveatTitle": "已选择 GPU，但是：{{reason}}",
     "curatedModelLabel": "模型",
     "curatedModelAria": "{{engine}} 的模型",
-    "selectWithCaveat": "{{engine}}：{{reason}}"
+    "selectCpuFallback": "{{engine}}：正在 CPU 上运行 — {{reason}}",
+    "selectWithCaveat": "已切换到 {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "全局热键仅在桌面应用中有效。网页界面使用页面内快捷键 <1>Ctrl+Shift+Space</1>（窗口聚焦时可用）。",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -537,7 +537,8 @@
     "routingEffectiveChip": "在此机器上的 {{device}} 上运行",
     "routingCaveatTitle": "已选择 GPU，但是：{{reason}}",
     "curatedModelLabel": "模型",
-    "curatedModelAria": "{{engine}} 的模型"
+    "curatedModelAria": "{{engine}} 的模型",
+    "selectWithCaveat": "{{engine}}：{{reason}}"
   },
   "capture": {
     "desc": "全局热键仅在桌面应用中有效。网页界面使用页面内快捷键 <1>Ctrl+Shift+Space</1>（窗口聚焦时可用）。",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -579,7 +579,8 @@
     "routingUnknown": "未知",
     "routingEffectiveChip": "在此機器上的 {{device}} 上執行",
     "routingCaveatTitle": "已選擇 GPU，但是：{{reason}}",
-    "selectWithCaveat": "{{engine}}：{{reason}}"
+    "selectCpuFallback": "{{engine}}：正在 CPU 上執行 — {{reason}}",
+    "selectWithCaveat": "已切換至 {{engine}} — {{reason}}"
   },
   "capture": {
     "desc": "全域熱鍵僅適用於桌面應用程式。當視窗具有焦點時，Web UI 使用頁內 <1>Ctrl+Shift+Space</1> 快速鍵。",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -104,7 +104,7 @@
     "update_check_failed": "更新檢查失敗：{{message}}",
     "save_failed": "儲存失敗：{{message}}",
     "clear_failed": "清除失敗：{{message}}",
-    "engine_switched": "{{family}} → {{engine}}",
+    "engine_switched": "已將 {{family}} 切換至 {{engine}}",
     "channel_set_failed": "無法設定頻道：{{message}}",
     "updater_downloading": "正在下載 {{version}}...",
     "updater_installed": "已安裝 - 重新啟動。",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -578,7 +578,8 @@
     "routingRemote": "遠端",
     "routingUnknown": "未知",
     "routingEffectiveChip": "在此機器上的 {{device}} 上執行",
-    "routingCaveatTitle": "已選擇 GPU，但是：{{reason}}"
+    "routingCaveatTitle": "已選擇 GPU，但是：{{reason}}",
+    "selectWithCaveat": "{{engine}}：{{reason}}"
   },
   "capture": {
     "desc": "全域熱鍵僅適用於桌面應用程式。當視窗具有焦點時，Web UI 使用頁內 <1>Ctrl+Shift+Space</1> 快速鍵。",

--- a/frontend/src/test/engineSelectToast.test.js
+++ b/frontend/src/test/engineSelectToast.test.js
@@ -114,8 +114,8 @@ describe('notifyEngineSelected (routing echo → toast)', () => {
         active: 'kittentts',
         routing_status: 'cpu_only',
         routing_reason:
-          'DirectML GPU present; engine routes via torch CPU path '
-          + '(DirectML acceleration not wired into routing)',
+          'DirectML GPU present; engine routes via torch CPU path ' +
+          '(DirectML acceleration not wired into routing)',
       },
       t,
       'tts',

--- a/frontend/src/test/engineSelectToast.test.js
+++ b/frontend/src/test/engineSelectToast.test.js
@@ -103,6 +103,41 @@ describe('notifyEngineSelected (routing echo → toast)', () => {
     expect(toastFn).toHaveBeenCalledTimes(1);
   });
 
+  // Greptile P1: a bare `routing_reason` test also fires on benign verdicts.
+  // Routing rule 5 gives a Windows DirectML host a cpu_only + reason on a
+  // perfectly normal pick, and rule 6 attaches one to `unavailable` — neither
+  // is a hardware warning. routing_notice() in engine_routing.py is the
+  // canonical predicate: cpu_fallback always, accelerated only with a reason.
+  it('stays silent for a benign cpu_only pick that carries a reason', () => {
+    notifyEngineSelected(
+      {
+        active: 'kittentts',
+        routing_status: 'cpu_only',
+        routing_reason:
+          'DirectML GPU present; engine routes via torch CPU path '
+          + '(DirectML acceleration not wired into routing)',
+      },
+      t,
+      'tts',
+    );
+    expect(toastFn).not.toHaveBeenCalled();
+    expect(toastFn.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn on an unavailable verdict either', () => {
+    notifyEngineSelected(
+      {
+        active: 'gpt-sovits',
+        routing_status: 'unavailable',
+        routing_reason: 'requires cuda; this host has cpu',
+      },
+      t,
+      'tts',
+    );
+    expect(toastFn).not.toHaveBeenCalled();
+    expect(toastFn.success).toHaveBeenCalledTimes(1);
+  });
+
   it('shows a plain success toast for a legacy response with no routing_status', () => {
     notifyEngineSelected({ active: 'legacy' }, t, 'asr');
     expect(toastFn).not.toHaveBeenCalled();

--- a/frontend/src/test/engineSelectToast.test.js
+++ b/frontend/src/test/engineSelectToast.test.js
@@ -63,6 +63,46 @@ describe('notifyEngineSelected (routing echo → toast)', () => {
     expect(toastFn.success).toHaveBeenCalledTimes(1);
   });
 
+  // #1226's under-provisioned-VRAM caveat rides on an ACCELERATED verdict, so
+  // it used to fall through to the green "switched" toast and vanish. Four of
+  // the low-VRAM reports (#1240, #1246, #1248 on 4 GB; #1277 on 6 GB) learned
+  // their card was too small only after waiting out the full 300s budget —
+  // the warning existed the whole time and was thrown away here.
+  it('warns when an accelerated pick carries a VRAM caveat', () => {
+    const reason =
+      'NVIDIA GeForce GTX 1650 Ti has 4.0 GB VRAM; this engine wants about ' +
+      '6 GB. It will run, but expect slow generations that may time out.';
+    notifyEngineSelected(
+      { active: 'omnivoice', routing_status: 'accelerated', routing_reason: reason },
+      t,
+      'tts',
+    );
+
+    expect(toastFn.success).not.toHaveBeenCalled();
+    expect(toastFn).toHaveBeenCalledTimes(1);
+    const [msg, opts] = toastFn.mock.calls[0];
+    expect(msg).toContain('engines.selectWithCaveat');
+    expect(msg).toContain('omnivoice');
+    expect(msg).toContain('4.0 GB VRAM');
+    expect(opts).toMatchObject({ icon: expect.any(String) });
+    // Long enough to actually read — it names the limit and the ways around it.
+    expect(opts.duration).toBeGreaterThanOrEqual(8000);
+  });
+
+  it('warns on a kernel-risk caveat too, not just the VRAM one', () => {
+    notifyEngineSelected(
+      {
+        active: 'omnivoice',
+        routing_status: 'accelerated',
+        routing_reason: "CUDA selected, but: GPU (sm_61) not in this torch build's archs",
+      },
+      t,
+      'tts',
+    );
+    expect(toastFn.success).not.toHaveBeenCalled();
+    expect(toastFn).toHaveBeenCalledTimes(1);
+  });
+
   it('shows a plain success toast for a legacy response with no routing_status', () => {
     notifyEngineSelected({ active: 'legacy' }, t, 'asr');
     expect(toastFn).not.toHaveBeenCalled();

--- a/frontend/src/utils/engineSelectToast.js
+++ b/frontend/src/utils/engineSelectToast.js
@@ -9,7 +9,21 @@
  * downgraded to CPU on this machine (backend note: engines.py select echo).
  *
  *   - routing_status === 'cpu_fallback' → warn-tone toast naming the reason.
- *   - everything else (accelerated / cpu_only / n/a / legacy) → plain success.
+ *   - accelerated BUT carrying a caveat → warn-tone toast naming the reason.
+ *   - everything else → plain success.
+ *
+ * That middle case is #1226's under-provisioned-VRAM caveat, and dropping it
+ * is what made the low-VRAM reports so bad (#1240, #1246, #1248, #1277 — four
+ * on 4 GB cards, one on 6 GB). Routing computes the warning ("this engine
+ * wants about 6 GB"), returns it in routing_reason, and this function used to
+ * throw it away for anything that wasn't a CPU fallback: the pick returned a
+ * green "switched" success, and the user only learned their card was
+ * under-provisioned after waiting out the entire 300s compute budget.
+ *
+ * Advisory, not blocking — matching the routing layer's deliberate contract
+ * (the driver can page to system RAM, and short inputs fit where long ones
+ * don't). The engine still gets selected; the user just finds out now instead
+ * of five minutes from now.
  *
  * Shared by Settings → Engines and the first-run WizardLibrary so both paths
  * consume the echo identically.
@@ -24,6 +38,19 @@ export function notifyEngineSelected(r, t, family = 'tts') {
         reason: r.routing_reason || '',
       }),
       { icon: '⚠️' },
+    );
+    return;
+  }
+  // Accelerated, but routing attached a caveat worth hearing before the first
+  // generate rather than after it times out. Longer duration than a success
+  // toast: it names the hardware limit and the ways around it.
+  if (r?.routing_reason) {
+    toast(
+      t('engines.selectWithCaveat', {
+        engine: r.active,
+        reason: r.routing_reason,
+      }),
+      { icon: '⚠️', duration: 10000 },
     );
     return;
   }

--- a/frontend/src/utils/engineSelectToast.js
+++ b/frontend/src/utils/engineSelectToast.js
@@ -44,7 +44,13 @@ export function notifyEngineSelected(r, t, family = 'tts') {
   // Accelerated, but routing attached a caveat worth hearing before the first
   // generate rather than after it times out. Longer duration than a success
   // toast: it names the hardware limit and the ways around it.
-  if (r?.routing_reason) {
+  //
+  // Mirrors routing_notice() in backend/services/engine_routing.py: ONLY
+  // `accelerated` + reason warrants a warning. A bare `routing_reason` test
+  // also catches benign `cpu_only` — a Windows DirectML host carries an
+  // explanatory reason on a perfectly normal pick (routing rule 5) — and
+  // `unavailable`, turning neutral information into a 10s hardware warning.
+  if (r?.routing_status === 'accelerated' && r?.routing_reason) {
     toast(
       t('engines.selectWithCaveat', {
         engine: r.active,

--- a/tests/test_locale_parity.py
+++ b/tests/test_locale_parity.py
@@ -39,6 +39,15 @@ _PLACEHOLDER = re.compile(r"\{\{\s*(\w+)\s*\}\}")
 # and ar.json's `__الخامس_0__` ("{{n}}" with the V literally translated).
 _CORRUPTED_TOKEN = re.compile(r"_V_\d+__|__\w+_\d+__")
 
+# Keys whose value may legitimately be nothing but placeholders + punctuation.
+# Keep this list tiny: each entry is a string no translator can influence.
+_PLACEHOLDER_ONLY_ALLOWLIST = {
+    # en: "{{family}} → {{engine}}" — the engine-switch success toast is a bare
+    # "TTS → omnivoice" confirmation by design. There is no sentence here to
+    # translate, and inventing one would make a quiet confirmation shouty.
+    "settings.engine_switched",
+}
+
 # Keys whose translations may deliberately omit en's placeholders.
 _PLACEHOLDER_ALLOWLIST = {
     # en: "Switch to {{lang}}?" — each locale bakes its own language name into
@@ -53,10 +62,10 @@ _PLACEHOLDER_ALLOWLIST = {
 # Never raise one: if this fails after adding en.json keys, add the keys to
 # every locale (translated) in the same change instead.
 _MISSING_BASELINE = {
-    "ar": 518, "de": 518, "es": 518, "fr": 518, "hi": 518, "id": 518,
-    "it": 518, "ja": 518, "ko": 518, "nl": 518, "pl": 518, "pt": 518,
-    "ru": 518, "sv": 518, "th": 518, "tr": 518, "uk": 518, "vi": 518,
-    "zh-CN": 511, "zh-TW": 518,
+    "ar": 517, "de": 517, "es": 517, "fr": 517, "hi": 517, "id": 517,
+    "it": 517, "ja": 517, "ko": 517, "nl": 517, "pl": 517, "pt": 517,
+    "ru": 517, "sv": 517, "th": 517, "tr": 517, "uk": 517, "vi": 517,
+    "zh-CN": 510, "zh-TW": 517,
 }
 
 
@@ -175,6 +184,39 @@ def test_placeholders_match_en(locale):
     assert not problems, (
         f"{locale}.json placeholder drift against en.json "
         f"({len(problems)} key(s)):\n" + "\n".join(problems[:25])
+    )
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_no_placeholder_only_values(locale):
+    """A value made of nothing but {{placeholders}} and punctuation is not a
+    translation — it is a missing string.
+
+    #1280 shipped ``engines.selectWithCaveat`` as ``"{{engine}}: {{reason}}"``
+    in all 21 files. The review read that as 20 untranslated locales, but
+    en.json said the same thing: the English string had never been written, so
+    every "translation" faithfully copied a non-sentence. Users in all 21
+    languages would have seen a bare ``omnivoice: <English backend text>``.
+
+    Parity tests cannot catch this — the key is present everywhere and the
+    placeholders match perfectly. Only the absence of prose gives it away, and
+    en.json is checked too because that is where this one started.
+    """
+    bad = []
+    for key, value in sorted(_flatten(_load(locale)).items()):
+        if not isinstance(value, str) or key in _PLACEHOLDER_ONLY_ALLOWLIST:
+            continue
+        if not _PLACEHOLDER.search(value):
+            continue
+        # \w is unicode-aware: CJK, Thai, Devanagari and Arabic all count as
+        # prose, so a real translation never trips this.
+        if not re.search(r"\w", _PLACEHOLDER.sub("", value)):
+            bad.append(f"  {key}: {value!r}")
+    assert not bad, (
+        f"{locale}.json has {len(bad)} placeholder-only value(s) — write the "
+        f"sentence around the placeholders (in en.json first, then translate "
+        f"it), or allowlist the key in _PLACEHOLDER_ONLY_ALLOWLIST with a "
+        f"reason:\n" + "\n".join(bad[:25])
     )
 
 

--- a/tests/test_locale_parity.py
+++ b/tests/test_locale_parity.py
@@ -40,13 +40,12 @@ _PLACEHOLDER = re.compile(r"\{\{\s*(\w+)\s*\}\}")
 _CORRUPTED_TOKEN = re.compile(r"_V_\d+__|__\w+_\d+__")
 
 # Keys whose value may legitimately be nothing but placeholders + punctuation.
-# Keep this list tiny: each entry is a string no translator can influence.
-_PLACEHOLDER_ONLY_ALLOWLIST = {
-    # en: "{{family}} → {{engine}}" — the engine-switch success toast is a bare
-    # "TTS → omnivoice" confirmation by design. There is no sentence here to
-    # translate, and inventing one would make a quiet confirmation shouty.
-    "settings.engine_switched",
-}
+# EMPTY, and worth keeping that way: the one candidate (settings.engine_switched,
+# "{{family}} → {{engine}}") turned out to be shipping the same untranslated
+# arrow in all 21 files, which is the bug this test exists to catch rather than
+# an exception to it (CodeRabbit, #1280). Add an entry only for a string no
+# translator could influence, with the reason inline.
+_PLACEHOLDER_ONLY_ALLOWLIST: set[str] = set()
 
 # Keys whose translations may deliberately omit en's placeholders.
 _PLACEHOLDER_ALLOWLIST = {


### PR DESCRIPTION
Four open low-VRAM reports share one shape:

| Issue | GPU |
|---|---|
| #1240 | GTX 1650 Ti — 4 GB |
| #1246 | GTX 1650 Ti — 4 GB |
| #1248 | RTX 2050 — 4 GB |
| #1277 | RTX 3060 Laptop — 6 GB |

The user generates, waits out the **entire 300 s** compute budget, and is then told the job "was too heavy for the available compute".

## The warning already existed

#1226 added exactly the right message in `engine_routing._caveat`:

> `NVIDIA GeForce GTX 1650 Ti has 4.0 GB VRAM; this engine wants about 6 GB. It will run, but expect slow generations that may time out. Unload other models before generating, keep the text short, or pick a lighter engine.`

`/engines/select` echoes it in `routing_reason`. But `notifyEngineSelected` surfaced a reason **only** when `routing_status === 'cpu_fallback'` — and the VRAM caveat rides on an `accelerated` verdict. So it fell through to the plain green "switched" success toast and was discarded. The user was told everything was fine, then waited five minutes to learn it wasn't.

## Change

Any caveat on the echo now raises a warn-tone toast naming it (longer duration, since it lists the ways around the limit). Also covers the kernel-risk caveat, which took the same path.

**Still advisory, not blocking** — matching the routing layer's documented contract: the driver can page to system RAM, and short inputs fit where long ones don't. The engine is still selected. This is the first-run path too, since the wizard's library step shares `notifyEngineSelected`.

## Verification

- Fail-before: both new tests fail against the previous version.
- `engines.selectWithCaveat` added to all 21 locales; locale-parity + CJK suites green.
- Frontend 1592 passing, lint 0 errors, typecheck clean.

## Known remaining gap

A user whose engine is **already selected** sees this only when they re-pick. A generate-time preflight would close that, but it needs a "once per session, not once per generate" design — flagging rather than guessing at it here.

Refs #1226, #1240, #1246, #1248, #1277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated engine-selection toasts so accelerated routing caveats (including VRAM limits and kernel-risk) surface as longer, advisory warning toasts using the new `engines.selectWithCaveat`/`selectCpuFallback` i18n strings, and the selection remains unchanged. This extends the first-run wizard flow and adds/adjusts `engine_switched` copy across all 21 locales, along with frontend tests and stricter locale-parity checks to prevent placeholder-only translations. Main risk to review: users with an already-selected engine may only see the warning upon reselecting it, since generate-time preflight is deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->