### PR TITLE
fix(engines): warn about under-provisioned hardware before the synth, not after

### DIFF
--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -1,5 +1,6 @@
 import { API, apiUrl, apiFetch, apiJson } from './client';
 import { useAppStore } from '../store';
+import { warnIfEngineUnderProvisioned } from '../utils/generatePreflight';
 
 export async function generateSpeech(
   formData: FormData,
@@ -17,6 +18,11 @@ export async function generateSpeech(
   // cleared by whichever request settled first while the rest were still
   // running. `finally` so an abort or a network error releases it too.
   useAppStore.getState().addTtsInflight?.(1);
+  // Same chokepoint argument as the in-flight count: every synth path reaches
+  // /generate through here, so the under-provisioned-hardware warning fires
+  // whether or not the user ever re-picked an engine. Intentionally not
+  // awaited — the toast must not delay the request it is warning about.
+  void warnIfEngineUnderProvisioned();
   try {
     // Returns the full Response so callers can stream the WAV blob + read headers.
     return await apiFetch('/generate', { method: 'POST', body: formData, signal });

--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -2,6 +2,25 @@ import { API, apiUrl, apiFetch, apiJson } from './client';
 import { useAppStore } from '../store';
 import { warnIfEngineUnderProvisioned } from '../utils/generatePreflight';
 
+/**
+ * Hold the in-flight count for the duration of `fn`.
+ *
+ * Safe to nest, and streaming relies on that: generateSpeech releases its
+ * claim when the Response resolves — i.e. when the HEADERS arrive — but a
+ * streaming synth reads the body for as long as it takes to generate. Wrapping
+ * the whole stream in an outer claim keeps the count above zero throughout;
+ * the inner one just bumps it to 2 and back. This only works because the store
+ * tracks a COUNT, not a boolean (Greptile P1, #1288).
+ */
+export async function withTtsInflight<T>(fn: () => Promise<T>): Promise<T> {
+  useAppStore.getState().addTtsInflight?.(1);
+  try {
+    return await fn();
+  } finally {
+    useAppStore.getState().addTtsInflight?.(-1);
+  }
+}
+
 export async function generateSpeech(
   formData: FormData,
   { signal }: { signal?: AbortSignal } = {},

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "يعمل على {{device}} على هذا الجهاز",
     "routingCaveatTitle": "تم تحديد وحدة معالجة الرسومات، ولكن: {{reason}}",
     "selectCpuFallback": "{{engine}}: يعمل على المعالج المركزي — {{reason}}",
-    "selectWithCaveat": "تم التبديل إلى {{engine}} — {{reason}}"
+    "selectWithCaveat": "تم التبديل إلى {{engine}} — {{reason}}",
+    "generateCaveat": "قد يكون {{engine}} بطيئًا على هذا الجهاز — {{reason}}"
   },
   "capture": {
     "desc": "تعمل مفاتيح التشغيل السريع العامة فقط في تطبيق سطح المكتب. تستخدم واجهة مستخدم الويب اختصارًا <1>Ctrl+Shift+Space</1> داخل الصفحة أثناء التركيز على النافذة.",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Läuft unter {{device}} auf diesem Computer",
     "routingCaveatTitle": "GPU ausgewählt, aber: {{reason}}",
     "selectCpuFallback": "{{engine}}: läuft auf der CPU — {{reason}}",
-    "selectWithCaveat": "Zu {{engine}} gewechselt — {{reason}}"
+    "selectWithCaveat": "Zu {{engine}} gewechselt — {{reason}}",
+    "generateCaveat": "{{engine}} ist auf diesem Rechner möglicherweise langsam — {{reason}}"
   },
   "capture": {
     "desc": "Globale Hotkeys funktionieren nur in der Desktop-App. Die Web-Benutzeroberfläche verwendet eine In-Page-Verknüpfung <1>Strg+Umschalt+Leertaste</1>, während das Fenster den Fokus hat.",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1906,7 +1906,8 @@
     "installStep_fetch_weights": "Downloading model weights",
     "installStep_persist": "Saving configuration",
     "installAria": "Install {{engine}}",
-    "selectWithCaveat": "Switched to {{engine}} — {{reason}}"
+    "selectWithCaveat": "Switched to {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} may be slow on this machine — {{reason}}"
   },
   "errors": {
     "title": "This tab hit a snag.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Se ejecuta en {{device}} en esta máquina",
     "routingCaveatTitle": "GPU seleccionada, pero: {{reason}}",
     "selectCpuFallback": "{{engine}}: ejecutándose en la CPU — {{reason}}",
-    "selectWithCaveat": "Se cambió a {{engine}}: {{reason}}"
+    "selectWithCaveat": "Se cambió a {{engine}}: {{reason}}",
+    "generateCaveat": "{{engine}} puede ir lento en este equipo: {{reason}}"
   },
   "capture": {
     "desc": "Las teclas de acceso rápido globales solo funcionan en la aplicación de escritorio. La interfaz de usuario web utiliza un acceso directo <1>Ctrl+Shift+Espacio</1> en la página mientras la ventana tiene el foco.",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Fonctionne le {{device}} sur cette machine",
     "routingCaveatTitle": "GPU sélectionné, mais : {{reason}}",
     "selectCpuFallback": "{{engine}} : fonctionne sur le processeur — {{reason}}",
-    "selectWithCaveat": "Basculé vers {{engine}} — {{reason}}"
+    "selectWithCaveat": "Basculé vers {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} risque d'être lent sur cette machine — {{reason}}"
   },
   "capture": {
     "desc": "Les raccourcis clavier globaux ne fonctionnent que dans l'application de bureau. L'interface utilisateur Web utilise un raccourci <1>Ctrl+Shift+Espace</1> sur la page lorsque la fenêtre a le focus.",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "इस मशीन पर {{device}} पर चलता है",
     "routingCaveatTitle": "GPU चयनित, लेकिन: {{reason}}",
     "selectCpuFallback": "{{engine}}: CPU पर चल रहा है — {{reason}}",
-    "selectWithCaveat": "{{engine}} पर स्विच किया गया — {{reason}}"
+    "selectWithCaveat": "{{engine}} पर स्विच किया गया — {{reason}}",
+    "generateCaveat": "इस मशीन पर {{engine}} धीमा हो सकता है — {{reason}}"
   },
   "capture": {
     "desc": "ग्लोबल हॉटकीज़ केवल डेस्कटॉप ऐप में काम करती हैं। वेब यूआई इन-पेज <1>Ctrl+Shift+Space</1> शॉर्टकट का उपयोग करता है जबकि विंडो पर फोकस होता है।",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Berjalan pada {{device}} di mesin ini",
     "routingCaveatTitle": "GPU dipilih, tetapi: {{reason}}",
     "selectCpuFallback": "{{engine}}: berjalan di CPU — {{reason}}",
-    "selectWithCaveat": "Beralih ke {{engine}} — {{reason}}"
+    "selectWithCaveat": "Beralih ke {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} mungkin lambat di komputer ini — {{reason}}"
   },
   "capture": {
     "desc": "Tombol pintas global hanya berfungsi di aplikasi desktop. UI web menggunakan pintasan <1>Ctrl+Shift+Space</1> dalam halaman saat jendela memiliki fokus.",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Funziona su {{device}} su questa macchina",
     "routingCaveatTitle": "GPU selezionata, ma: {{reason}}",
     "selectCpuFallback": "{{engine}}: in esecuzione sulla CPU — {{reason}}",
-    "selectWithCaveat": "Passato a {{engine}} — {{reason}}"
+    "selectWithCaveat": "Passato a {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} potrebbe essere lento su questo computer — {{reason}}"
   },
   "capture": {
     "desc": "I tasti di scelta rapida globali funzionano solo nell'app desktop. L'interfaccia utente Web utilizza una scorciatoia <1>Ctrl+Shift+Spazio</1> nella pagina mentre la finestra è attiva.",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "このマシンの {{device}} で実行されます",
     "routingCaveatTitle": "GPU が選択されましたが: {{reason}}",
     "selectCpuFallback": "{{engine}}: CPU で実行中 — {{reason}}",
-    "selectWithCaveat": "{{engine}} に切り替えました — {{reason}}"
+    "selectWithCaveat": "{{engine}} に切り替えました — {{reason}}",
+    "generateCaveat": "このマシンでは {{engine}} の生成が遅くなる可能性があります — {{reason}}"
   },
   "capture": {
     "desc": "グローバル ホットキーはデスクトップ アプリでのみ機能します。 Web UI は、ウィンドウにフォーカスがある間、ページ内 <1>Ctrl+Shift+Space</1> ショートカットを使用します。",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "이 머신의 {{device}}에서 실행됩니다.",
     "routingCaveatTitle": "GPU가 선택되었지만: {{reason}}",
     "selectCpuFallback": "{{engine}}: CPU에서 실행 중 — {{reason}}",
-    "selectWithCaveat": "{{engine}}(으)로 전환했습니다 — {{reason}}"
+    "selectWithCaveat": "{{engine}}(으)로 전환했습니다 — {{reason}}",
+    "generateCaveat": "이 컴퓨터에서는 {{engine}}이(가) 느릴 수 있습니다 — {{reason}}"
   },
   "capture": {
     "desc": "전역 단축키는 데스크톱 앱에서만 작동합니다. 웹 UI는 창에 포커스가 있는 동안 페이지 내 <1>Ctrl+Shift+Space</1> 단축키를 사용합니다.",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Draait op {{device}} op deze machine",
     "routingCaveatTitle": "GPU geselecteerd, maar: {{reason}}",
     "selectCpuFallback": "{{engine}}: draait op de CPU — {{reason}}",
-    "selectWithCaveat": "Overgeschakeld naar {{engine}} — {{reason}}"
+    "selectWithCaveat": "Overgeschakeld naar {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} kan traag zijn op deze machine — {{reason}}"
   },
   "capture": {
     "desc": "Globale sneltoetsen werken alleen in de desktop-app. De webinterface gebruikt een sneltoets <1>Ctrl+Shift+Spatie</1> op de pagina terwijl het venster focus heeft.",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Działa na {{device}} na tym komputerze",
     "routingCaveatTitle": "Wybrano procesor graficzny, ale: {{reason}}",
     "selectCpuFallback": "{{engine}}: działa na CPU — {{reason}}",
-    "selectWithCaveat": "Przełączono na {{engine}} — {{reason}}"
+    "selectWithCaveat": "Przełączono na {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} może działać wolno na tym komputerze — {{reason}}"
   },
   "capture": {
     "desc": "Globalne skróty klawiszowe działają tylko w aplikacji komputerowej. Interfejs WWW korzysta ze skrótu <1>Ctrl+Shift+Spacja</1> znajdującego się na stronie, gdy okno jest aktywne.",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Funciona em {{device}} nesta máquina",
     "routingCaveatTitle": "GPU selecionada, mas: {{reason}}",
     "selectCpuFallback": "{{engine}}: em execução na CPU — {{reason}}",
-    "selectWithCaveat": "Alterado para {{engine}} — {{reason}}"
+    "selectWithCaveat": "Alterado para {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} pode ficar lento nesta máquina — {{reason}}"
   },
   "capture": {
     "desc": "As teclas de atalho globais funcionam apenas no aplicativo de desktop. A IU da web usa um atalho <1>Ctrl+Shift+Space</1> na página enquanto a janela está em foco.",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Работает на {{device}} на этом компьютере",
     "routingCaveatTitle": "Графический процессор выбран, но: {{reason}}",
     "selectCpuFallback": "{{engine}}: работает на CPU — {{reason}}",
-    "selectWithCaveat": "Переключено на {{engine}} — {{reason}}"
+    "selectWithCaveat": "Переключено на {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} может работать медленно на этом компьютере — {{reason}}"
   },
   "capture": {
     "desc": "Глобальные горячие клавиши работают только в настольном приложении. Веб-интерфейс использует внутристраничный ярлык <1>Ctrl+Shift+Space</1>, пока окно находится в фокусе.",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Körs på {{device}} på den här maskinen",
     "routingCaveatTitle": "GPU vald, men: {{reason}}",
     "selectCpuFallback": "{{engine}}: körs på CPU — {{reason}}",
-    "selectWithCaveat": "Bytte till {{engine}} — {{reason}}"
+    "selectWithCaveat": "Bytte till {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} kan vara långsam på den här datorn — {{reason}}"
   },
   "capture": {
     "desc": "Globala snabbtangenter fungerar bara i skrivbordsappen. Webbgränssnittet använder en genväg <1>Ctrl+Skift+Mellanslag</1> på sidan medan fönstret har fokus.",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "ทำงานบน {{device}} บนเครื่องนี้",
     "routingCaveatTitle": "เลือก GPU แล้ว แต่: {{reason}}",
     "selectCpuFallback": "{{engine}}: กำลังทำงานบน CPU — {{reason}}",
-    "selectWithCaveat": "สลับไปที่ {{engine}} — {{reason}}"
+    "selectWithCaveat": "สลับไปที่ {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} อาจทำงานช้าบนเครื่องนี้ — {{reason}}"
   },
   "capture": {
     "desc": "ปุ่มลัดส่วนกลางใช้งานได้ในแอปเดสก์ท็อปเท่านั้น UI ของเว็บใช้ทางลัด <1>Ctrl+Shift+Space</1> ในเพจในขณะที่หน้าต่างมีโฟกัส",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Bu makinede {{device}} tarihinde çalışıyor",
     "routingCaveatTitle": "GPU seçildi, ancak: {{reason}}",
     "selectCpuFallback": "{{engine}}: CPU üzerinde çalışıyor — {{reason}}",
-    "selectWithCaveat": "{{engine}} motoruna geçildi — {{reason}}"
+    "selectWithCaveat": "{{engine}} motoruna geçildi — {{reason}}",
+    "generateCaveat": "{{engine}} bu bilgisayarda yavaş çalışabilir — {{reason}}"
   },
   "capture": {
     "desc": "Genel kısayol tuşları yalnızca masaüstü uygulamasında çalışır. Web kullanıcı arayüzü, pencere odaktayken sayfa içi <1>Ctrl+Shift+Space</1> kısayolunu kullanır.",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Працює на {{device}} на цій машині",
     "routingCaveatTitle": "Графічний процесор вибрано, але: {{reason}}",
     "selectCpuFallback": "{{engine}}: працює на CPU — {{reason}}",
-    "selectWithCaveat": "Перемкнено на {{engine}} — {{reason}}"
+    "selectWithCaveat": "Перемкнено на {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} може працювати повільно на цьому комп'ютері — {{reason}}"
   },
   "capture": {
     "desc": "Глобальні гарячі клавіші працюють лише в настільній програмі. Веб-інтерфейс використовує ярлик <1>Ctrl+Shift+Пробіл</1> на сторінці, коли вікно має фокус.",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "Chạy trên {{device}} trên máy này",
     "routingCaveatTitle": "Đã chọn GPU nhưng: {{reason}}",
     "selectCpuFallback": "{{engine}}: đang chạy trên CPU — {{reason}}",
-    "selectWithCaveat": "Đã chuyển sang {{engine}} — {{reason}}"
+    "selectWithCaveat": "Đã chuyển sang {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} có thể chạy chậm trên máy này — {{reason}}"
   },
   "capture": {
     "desc": "Phím nóng chung chỉ hoạt động trong ứng dụng máy tính để bàn. Giao diện người dùng web sử dụng phím tắt <1>Ctrl+Shift+Space</1> trong trang trong khi cửa sổ đang có tiêu điểm.",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -539,7 +539,8 @@
     "curatedModelLabel": "模型",
     "curatedModelAria": "{{engine}} 的模型",
     "selectCpuFallback": "{{engine}}：正在 CPU 上运行 — {{reason}}",
-    "selectWithCaveat": "已切换到 {{engine}} — {{reason}}"
+    "selectWithCaveat": "已切换到 {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} 在这台机器上可能较慢 — {{reason}}"
   },
   "capture": {
     "desc": "全局热键仅在桌面应用中有效。网页界面使用页面内快捷键 <1>Ctrl+Shift+Space</1>（窗口聚焦时可用）。",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -580,7 +580,8 @@
     "routingEffectiveChip": "在此機器上的 {{device}} 上執行",
     "routingCaveatTitle": "已選擇 GPU，但是：{{reason}}",
     "selectCpuFallback": "{{engine}}：正在 CPU 上執行 — {{reason}}",
-    "selectWithCaveat": "已切換至 {{engine}} — {{reason}}"
+    "selectWithCaveat": "已切換至 {{engine}} — {{reason}}",
+    "generateCaveat": "{{engine}} 在這台機器上可能較慢 — {{reason}}"
   },
   "capture": {
     "desc": "全域熱鍵僅適用於桌面應用程式。當視窗具有焦點時，Web UI 使用頁內 <1>Ctrl+Shift+Space</1> 快速鍵。",

--- a/frontend/src/test/generatePreflight.test.js
+++ b/frontend/src/test/generatePreflight.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { toastFn, listEnginesMock } = vi.hoisted(() => {
+  const fn = vi.fn();
+  fn.success = vi.fn();
+  fn.error = vi.fn();
+  return { toastFn: fn, listEnginesMock: vi.fn() };
+});
+vi.mock('react-hot-toast', () => ({ default: toastFn, toast: toastFn }));
+vi.mock('../api/engines', () => ({ listEngines: listEnginesMock }));
+vi.mock('i18next', () => ({
+  default: { t: (key, vars) => `${key}:${JSON.stringify(vars || {})}` },
+}));
+
+import { warnIfEngineUnderProvisioned, _resetPreflight } from '../utils/generatePreflight';
+
+const VRAM_CAVEAT =
+  'NVIDIA GeForce RTX 2060 has 6.0 GB VRAM; this engine wants about 6 GB. ' +
+  'It will run, but expect slow generations that may time out.';
+
+function engines(active, backends) {
+  return { tts: { active, backends } };
+}
+
+describe('warnIfEngineUnderProvisioned (generate-time preflight)', () => {
+  beforeEach(() => {
+    toastFn.mockClear();
+    listEnginesMock.mockReset();
+    _resetPreflight();
+  });
+
+  // The whole point of #1240/#1246/#1248/#1277/#1283/#1284: the caveat existed
+  // the entire time, but only the engine-PICK path showed it. Users whose
+  // engine was already selected waited out 300s to learn their card was small.
+  it('warns when the already-selected engine carries a VRAM caveat', async () => {
+    listEnginesMock.mockResolvedValue(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: VRAM_CAVEAT },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+
+    expect(toastFn).toHaveBeenCalledTimes(1);
+    const [msg, opts] = toastFn.mock.calls[0];
+    expect(msg).toContain('engines.generateCaveat');
+    expect(msg).toContain('omnivoice');
+    expect(msg).toContain('6.0 GB VRAM');
+    // Long enough to read a sentence about hardware.
+    expect(opts.duration).toBeGreaterThanOrEqual(8000);
+  });
+
+  it('warns only once per engine+reason, not on every synth', async () => {
+    listEnginesMock.mockResolvedValue(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: VRAM_CAVEAT },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+    await warnIfEngineUnderProvisioned();
+    await warnIfEngineUnderProvisioned();
+
+    expect(toastFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent for a healthy accelerated engine', async () => {
+    listEnginesMock.mockResolvedValue(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: null },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+    expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  // Benign verdicts carry reasons too — routing rule 5 (DirectML) and rule 6.
+  it('stays silent for a benign cpu_only reason', async () => {
+    listEnginesMock.mockResolvedValue(
+      engines('kittentts', [
+        {
+          id: 'kittentts',
+          routing_status: 'cpu_only',
+          routing_reason: 'DirectML GPU present; engine routes via torch CPU path',
+        },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+    expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  it('warns on a cpu_fallback engine', async () => {
+    listEnginesMock.mockResolvedValue(
+      engines('indextts2', [
+        {
+          id: 'indextts2',
+          routing_status: 'cpu_fallback',
+          routing_reason: 'engine has no CUDA path; running on CPU',
+        },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+    expect(toastFn).toHaveBeenCalledTimes(1);
+  });
+
+  // A warning must never be able to break the thing it warns about.
+  it('never throws when the engine list is unreachable', async () => {
+    listEnginesMock.mockRejectedValue(new Error('backend down'));
+    await expect(warnIfEngineUnderProvisioned()).resolves.toBeUndefined();
+    expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a response with no active engine', async () => {
+    listEnginesMock.mockResolvedValue({ tts: { active: null, backends: [] } });
+    await expect(warnIfEngineUnderProvisioned()).resolves.toBeUndefined();
+    expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  it('fetches the engine list once, not once per synth', async () => {
+    listEnginesMock.mockResolvedValue(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: null },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+    await warnIfEngineUnderProvisioned();
+
+    expect(listEnginesMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/generatePreflight.test.js
+++ b/frontend/src/test/generatePreflight.test.js
@@ -12,7 +12,11 @@ vi.mock('i18next', () => ({
   default: { t: (key, vars) => `${key}:${JSON.stringify(vars || {})}` },
 }));
 
-import { warnIfEngineUnderProvisioned, _resetPreflight } from '../utils/generatePreflight';
+import {
+  warnIfEngineUnderProvisioned,
+  onEngineSelected,
+  _resetPreflight,
+} from '../utils/generatePreflight';
 
 const VRAM_CAVEAT =
   'NVIDIA GeForce RTX 2060 has 6.0 GB VRAM; this engine wants about 6 GB. ' +
@@ -130,5 +134,67 @@ describe('warnIfEngineUnderProvisioned (generate-time preflight)', () => {
     await warnIfEngineUnderProvisioned();
 
     expect(listEnginesMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('preflight cache invalidation', () => {
+  beforeEach(() => {
+    toastFn.mockClear();
+    listEnginesMock.mockReset();
+    _resetPreflight();
+  });
+
+  // Greptile P1: with a 60s TTL, switching engines and generating immediately
+  // warned about the engine you just LEFT — or stayed silent about the one you
+  // just chose.
+  it('refetches after an engine change instead of serving the old engine', async () => {
+    listEnginesMock.mockResolvedValueOnce(
+      engines('kittentts', [{ id: 'kittentts', routing_status: 'cpu_only', routing_reason: null }]),
+    );
+    await warnIfEngineUnderProvisioned();
+    expect(toastFn).not.toHaveBeenCalled();
+
+    onEngineSelected('omnivoice', null);
+
+    listEnginesMock.mockResolvedValueOnce(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: VRAM_CAVEAT },
+      ]),
+    );
+    await warnIfEngineUnderProvisioned();
+
+    expect(listEnginesMock).toHaveBeenCalledTimes(2);
+    expect(toastFn).toHaveBeenCalledTimes(1);
+    expect(toastFn.mock.calls[0][0]).toContain('omnivoice');
+  });
+
+  it('does not repeat a caveat the select toast just showed', async () => {
+    onEngineSelected('omnivoice', VRAM_CAVEAT);
+    listEnginesMock.mockResolvedValue(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: VRAM_CAVEAT },
+      ]),
+    );
+
+    await warnIfEngineUnderProvisioned();
+    expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  // A rejected promise cached for the full TTL silences the caveat for a
+  // minute after the backend comes back.
+  it('retries after a transient engine-list failure', async () => {
+    listEnginesMock.mockRejectedValueOnce(new Error('backend restarting'));
+    await warnIfEngineUnderProvisioned();
+    expect(toastFn).not.toHaveBeenCalled();
+
+    listEnginesMock.mockResolvedValueOnce(
+      engines('omnivoice', [
+        { id: 'omnivoice', routing_status: 'accelerated', routing_reason: VRAM_CAVEAT },
+      ]),
+    );
+    await warnIfEngineUnderProvisioned();
+
+    expect(listEnginesMock).toHaveBeenCalledTimes(2);
+    expect(toastFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/test/streamingPreflight.test.js
+++ b/frontend/src/test/streamingPreflight.test.js
@@ -1,0 +1,86 @@
+/**
+ * Streaming synthesis must go through the same door as every other synth.
+ *
+ * `streamGenerateSpeech` used to POST /generate via `apiFetch` directly — a
+ * second, parallel entrance. Everything bolted onto "the one call every synth
+ * path shares" therefore did not apply to it: the in-flight count that stops
+ * the updater relaunching mid-synthesis, and the under-provisioned-hardware
+ * preflight (Greptile P1, #1288). A chokepoint with two doors is not a
+ * chokepoint, and the second door is invisible until someone on a 4 GB card
+ * uses the streaming path and gets no warning.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { apiFetch, preflight, state } = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  preflight: vi.fn(),
+  state: { ttsInflight: 0, max: 0 },
+}));
+
+vi.mock('../api/client', () => ({
+  API: '',
+  apiUrl: (p) => p,
+  apiFetch: (...a) => apiFetch(...a),
+  apiJson: vi.fn(),
+}));
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    getState: () => ({
+      ...state,
+      addTtsInflight: (d) => {
+        state.ttsInflight = Math.max(0, state.ttsInflight + d);
+        state.max = Math.max(state.max, state.ttsInflight);
+      },
+    }),
+  },
+}));
+
+vi.mock('../utils/generatePreflight', () => ({
+  warnIfEngineUnderProvisioned: (...a) => preflight(...a),
+  onEngineSelected: vi.fn(),
+}));
+
+vi.mock('../utils/playback', () => ({ claimTrackedPlayback: vi.fn() }));
+
+import { streamGenerateSpeech } from '../utils/streamingTts';
+
+describe('streaming synthesis shares the generate chokepoint', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    preflight.mockReset();
+    state.ttsInflight = 0;
+    state.max = 0;
+  });
+
+  it('runs the under-provisioned preflight before streaming', async () => {
+    // Fail the stream immediately — this test is about what happens BEFORE the
+    // first byte, and the streaming machinery past that point is covered by
+    // streamingTts.test.js.
+    apiFetch.mockResolvedValue({ body: null, headers: new Map() });
+
+    await streamGenerateSpeech(new FormData(), {}).catch(() => {});
+
+    expect(preflight).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts the streaming synth as in flight', async () => {
+    apiFetch.mockResolvedValue({ body: null, headers: new Map() });
+
+    await streamGenerateSpeech(new FormData(), {}).catch(() => {});
+
+    expect(state.max).toBeGreaterThanOrEqual(1);
+  });
+
+  it('still posts to /generate with the stream flag', async () => {
+    apiFetch.mockResolvedValue({ body: null, headers: new Map() });
+
+    await streamGenerateSpeech(new FormData(), {}).catch(() => {});
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    const [path, opts] = apiFetch.mock.calls[0];
+    expect(path).toBe('/generate');
+    expect(opts.method).toBe('POST');
+    expect(opts.body.get('stream')).toBe('true');
+  });
+});

--- a/frontend/src/test/streamingPreflight.test.js
+++ b/frontend/src/test/streamingPreflight.test.js
@@ -84,3 +84,45 @@ describe('streaming synthesis shares the generate chokepoint', () => {
     expect(opts.body.get('stream')).toBe('true');
   });
 });
+
+describe('in-flight count spans the whole stream', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    preflight.mockReset();
+    state.ttsInflight = 0;
+    state.max = 0;
+  });
+
+  // Greptile P1: generateSpeech releases its claim when the Response resolves
+  // (headers), but the audio is generated while the BODY is read. The updater
+  // would see "idle" for the entire synthesis and could relaunch mid-stream.
+  it('is still in flight while the body is being consumed', async () => {
+    const seen = [];
+    apiFetch.mockResolvedValue({
+      headers: new Map(),
+      body: {
+        getReader: () => ({
+          read: async () => {
+            seen.push(state.ttsInflight);
+            return { done: true, value: undefined };
+          },
+        }),
+      },
+    });
+
+    await streamGenerateSpeech(new FormData(), {}).catch(() => {});
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(Math.min(...seen)).toBeGreaterThan(0);
+  });
+
+  it('releases the claim once the stream finishes', async () => {
+    apiFetch.mockResolvedValue({
+      headers: new Map(),
+      body: { getReader: () => ({ read: async () => ({ done: true }) }) },
+    });
+
+    await streamGenerateSpeech(new FormData(), {}).catch(() => {});
+    expect(state.ttsInflight).toBe(0);
+  });
+});

--- a/frontend/src/utils/engineSelectToast.js
+++ b/frontend/src/utils/engineSelectToast.js
@@ -29,35 +29,28 @@
  * consume the echo identically.
  */
 import { toast } from 'react-hot-toast';
+import { routingNotice } from './routingNotice';
 
 export function notifyEngineSelected(r, t, family = 'tts') {
-  if (r?.routing_status === 'cpu_fallback') {
-    toast(
-      t('engines.selectCpuFallback', {
-        engine: r.active,
-        reason: r.routing_reason || '',
-      }),
-      { icon: '⚠️' },
-    );
+  // routingNotice() is the shared mirror of the backend's routing_notice():
+  // cpu_fallback always, accelerated only when it carries a caveat. Everything
+  // else — benign cpu_only (a DirectML host explains itself on a normal pick)
+  // and unavailable — is information, not a warning.
+  const notice = routingNotice(r);
+  if (notice?.status === 'cpu_fallback') {
+    toast(t('engines.selectCpuFallback', { engine: r.active, reason: notice.reason }), {
+      icon: '⚠️',
+    });
     return;
   }
   // Accelerated, but routing attached a caveat worth hearing before the first
   // generate rather than after it times out. Longer duration than a success
   // toast: it names the hardware limit and the ways around it.
-  //
-  // Mirrors routing_notice() in backend/services/engine_routing.py: ONLY
-  // `accelerated` + reason warrants a warning. A bare `routing_reason` test
-  // also catches benign `cpu_only` — a Windows DirectML host carries an
-  // explanatory reason on a perfectly normal pick (routing rule 5) — and
-  // `unavailable`, turning neutral information into a 10s hardware warning.
-  if (r?.routing_status === 'accelerated' && r?.routing_reason) {
-    toast(
-      t('engines.selectWithCaveat', {
-        engine: r.active,
-        reason: r.routing_reason,
-      }),
-      { icon: '⚠️', duration: 10000 },
-    );
+  if (notice) {
+    toast(t('engines.selectWithCaveat', { engine: r.active, reason: notice.reason }), {
+      icon: '⚠️',
+      duration: 10000,
+    });
     return;
   }
   toast.success(

--- a/frontend/src/utils/engineSelectToast.js
+++ b/frontend/src/utils/engineSelectToast.js
@@ -30,6 +30,7 @@
  */
 import { toast } from 'react-hot-toast';
 import { routingNotice } from './routingNotice';
+import { onEngineSelected } from './generatePreflight';
 
 export function notifyEngineSelected(r, t, family = 'tts') {
   // routingNotice() is the shared mirror of the backend's routing_notice():
@@ -37,6 +38,12 @@ export function notifyEngineSelected(r, t, family = 'tts') {
   // else — benign cpu_only (a DirectML host explains itself on a normal pick)
   // and unavailable — is information, not a warning.
   const notice = routingNotice(r);
+  // Every engine pick lands here (Settings → Engines and the first-run
+  // WizardLibrary both call it), which makes it the one place that reliably
+  // knows the active engine just changed: drop the preflight's cached
+  // /engines response, and hand it whatever caveat we are about to show so it
+  // does not repeat the same sentence on the next synth.
+  onEngineSelected(r?.active, notice?.reason ?? null);
   if (notice?.status === 'cpu_fallback') {
     toast(t('engines.selectCpuFallback', { engine: r.active, reason: notice.reason }), {
       icon: '⚠️',

--- a/frontend/src/utils/generatePreflight.js
+++ b/frontend/src/utils/generatePreflight.js
@@ -37,9 +37,33 @@ let cache = null; // { at: number, promise: Promise }
 function enginesCached() {
   const now = Date.now();
   if (!cache || now - cache.at > TTL_MS) {
-    cache = { at: now, promise: listEngines() };
+    const entry = { at: now, promise: null };
+    // A rejected promise must NOT sit in the cache for the full TTL, or a
+    // single blip while the backend restarts silences the caveat for the next
+    // minute of synths. Drop it — but only if this entry is still the current
+    // one, so a newer fetch that raced past us isn't evicted.
+    entry.promise = listEngines().catch((e) => {
+      if (cache === entry) cache = null;
+      throw e;
+    });
+    cache = entry;
   }
   return cache.promise;
+}
+
+/**
+ * Called after an engine pick. The cached /engines response now describes the
+ * PREVIOUS engine, and with a 60s TTL a user who switches engines and
+ * immediately generates would be warned about the engine they just left — or
+ * not warned about the one they just chose (Greptile P1, #1288).
+ *
+ * `alreadyWarnedFor` is the notice the select toast just showed, if any:
+ * recording it here stops the preflight repeating the same sentence seconds
+ * later. Different engine or different reason still gets through.
+ */
+export function onEngineSelected(engineId, alreadyWarnedFor = null) {
+  cache = null;
+  if (engineId && alreadyWarnedFor) warned.add(`${engineId}|${alreadyWarnedFor}`);
 }
 
 /** Test seam — drop the memoized /engines response and the warned-once set. */

--- a/frontend/src/utils/generatePreflight.js
+++ b/frontend/src/utils/generatePreflight.js
@@ -1,0 +1,77 @@
+/**
+ * Warn about an under-provisioned engine BEFORE the synth runs, not after.
+ *
+ * The routing layer has always known that a 4 GB card running an engine that
+ * wants 6 GB will be slow enough to hit the 300s compute budget. Until now the
+ * only place that knowledge surfaced was the engine-*pick* toast — so it fired
+ * for people who changed engines, and never for the much larger group whose
+ * engine was already selected (persisted from a previous session, or the
+ * default). Those users' first contact with the fact was a 300s wait ending in
+ * "this job was too heavy": #1240, #1246, #1248, #1277, #1283, #1284.
+ *
+ * The generate response already carries `X-OmniVoice-Routing`, but a response
+ * header arrives when the job ends — five minutes too late to be a warning.
+ * So the check runs at the chokepoint every synth path shares, before the POST.
+ *
+ * Deliberately NOT blocking, matching the routing layer's contract: the driver
+ * can page to system RAM and short inputs fit where long ones don't. It is also
+ * deliberately NOT awaited by the caller — a warning must never add latency to
+ * the request it is warning about.
+ */
+import { toast } from 'react-hot-toast';
+import i18next from 'i18next';
+import { listEngines } from '../api/engines';
+import { routingNotice } from './routingNotice';
+
+// Once per (engine, reason) per session. The caveat is a property of the
+// hardware, so repeating it on every synth would be nagging, but keying on the
+// reason too means a genuinely different problem still gets through.
+const warned = new Set();
+
+// One /engines round-trip is cheap, but one per synth is not. Engine picks are
+// rare and hardware does not change mid-session; a short TTL keeps a fresh
+// install's just-installed engine from being judged on stale data.
+const TTL_MS = 60_000;
+let cache = null; // { at: number, promise: Promise }
+
+function enginesCached() {
+  const now = Date.now();
+  if (!cache || now - cache.at > TTL_MS) {
+    cache = { at: now, promise: listEngines() };
+  }
+  return cache.promise;
+}
+
+/** Test seam — drop the memoized /engines response and the warned-once set. */
+export function _resetPreflight() {
+  cache = null;
+  warned.clear();
+}
+
+/**
+ * Fire-and-forget. Never throws, never blocks the synth: an engine list we
+ * could not fetch is a reason to stay quiet, not a reason to fail a generate.
+ */
+export async function warnIfEngineUnderProvisioned() {
+  try {
+    const data = await enginesCached();
+    const tts = data?.tts;
+    const active = tts?.active;
+    if (!active) return;
+    const entry = (tts.backends || []).find((b) => b.id === active);
+    const notice = routingNotice(entry);
+    if (!notice) return;
+
+    const key = `${active}|${notice.reason}`;
+    if (warned.has(key)) return;
+    warned.add(key);
+
+    toast(i18next.t('engines.generateCaveat', { engine: active, reason: notice.reason }), {
+      id: `generate-caveat-${active}`,
+      icon: '⚠️',
+      duration: 12000,
+    });
+  } catch {
+    // Offline, backend restarting, shape changed — all fine. This is advice.
+  }
+}

--- a/frontend/src/utils/routingNotice.js
+++ b/frontend/src/utils/routingNotice.js
@@ -1,0 +1,31 @@
+/**
+ * routingNotice — the single frontend mirror of `routing_notice()` in
+ * backend/services/engine_routing.py.
+ *
+ * A routing verdict carries `routing_reason` on plenty of BENIGN outcomes:
+ * a Windows DirectML host gets `cpu_only` + an explanatory note on a
+ * perfectly normal pick (routing rule 5), and `unavailable` always carries
+ * one (rule 6). Only two shapes are worth interrupting the user for:
+ *
+ *   - `cpu_fallback` — always; the engine silently lost its accelerator.
+ *   - `accelerated` WITH a reason — a driver/arch risk or the #1226
+ *     under-provisioned-VRAM caveat.
+ *
+ * This lived inline in engineSelectToast as `if (r?.routing_reason)`, which
+ * warned on the benign cases too (Greptile P1, #1280). Now that a second
+ * caller needs the same question answered (the generate-time preflight), it
+ * is one exported predicate — two copies of this rule would drift, and the
+ * drift is invisible until someone on the wrong hardware complains.
+ */
+
+/**
+ * @param {{routing_status?: string, routing_reason?: string|null}|null} r
+ * @returns {{status: string, reason: string}|null} the notice worth showing.
+ */
+export function routingNotice(r) {
+  const status = r?.routing_status;
+  const reason = r?.routing_reason;
+  if (status === 'cpu_fallback') return { status, reason: reason || '' };
+  if (status === 'accelerated' && reason) return { status, reason };
+  return null;
+}

--- a/frontend/src/utils/streamingTts.js
+++ b/frontend/src/utils/streamingTts.js
@@ -25,7 +25,7 @@
  * their ApiError identity (they would fail the classic flow identically, so
  * falling back would only duplicate the failure).
  */
-import { apiFetch } from '../api/client';
+import { generateSpeech } from '../api/generate';
 import { claimTrackedPlayback } from './playback';
 
 /** True when the webview can progressively play PCM chunks (Web Audio). */
@@ -297,7 +297,13 @@ export async function streamGenerateSpeech(
 
   // Pre-stream failures (400/503/transport) throw ApiError here — identical
   // to the classic flow, so they are NOT wrapped for fallback.
-  const response = await apiFetch('/generate', { method: 'POST', body: fd, signal });
+  //
+  // Routed through generateSpeech() rather than apiFetch() directly: this used
+  // to be a second, parallel door onto POST /generate, so everything attached
+  // to the "one chokepoint every synth shares" — the in-flight count and the
+  // under-provisioned-hardware preflight — silently did not apply to streaming
+  // synthesis (Greptile P1, #1288). One door, or it is not a chokepoint.
+  const response = await generateSpeech(fd, { signal });
   onHeaders?.(response);
 
   let player = null;

--- a/frontend/src/utils/streamingTts.js
+++ b/frontend/src/utils/streamingTts.js
@@ -25,7 +25,7 @@
  * their ApiError identity (they would fail the classic flow identically, so
  * falling back would only duplicate the failure).
  */
-import { generateSpeech } from '../api/generate';
+import { generateSpeech, withTtsInflight } from '../api/generate';
 import { claimTrackedPlayback } from './playback';
 
 /** True when the webview can progressively play PCM chunks (Web Audio). */
@@ -287,7 +287,18 @@ export const createStreamingChunkPlayer = ({ label, sampleRate, crossfadeMs = 0,
  * @throws {StreamingPreviewError} on any mid-stream failure (fall back to the
  *         classic flow); ApiError/AbortError propagate untouched.
  */
-export async function streamGenerateSpeech(
+export async function streamGenerateSpeech(formData, opts = {}) {
+  // The claim has to span the whole stream, not just the request. Routing this
+  // through generateSpeech() gave streaming an in-flight count for the first
+  // time, but that claim is released when the Response resolves — when the
+  // HEADERS arrive — while the audio is still being generated and read below.
+  // The updater would have seen "idle" for the entire synthesis and been free
+  // to relaunch mid-stream (Greptile P1, #1288). Nesting is fine: the store
+  // counts rather than flags.
+  return withTtsInflight(() => _streamGenerateSpeech(formData, opts));
+}
+
+async function _streamGenerateSpeech(
   formData,
   { signal, label, finalLabel, onHeaders, onProgress } = {},
 ) {


### PR DESCRIPTION
Closes #1240, #1246, #1248, #1277, #1283, #1284.

## The pattern

Six reports, one story: a 4 GB or 6 GB card running an engine that declares a 6 GB floor, each user waiting out the full 300s compute budget to be told the job "was too heavy".

The routing layer knew the whole time — the timeout text even names the card and the figure ("RTX 2060 has 6.0 GB of VRAM and this engine wants about 6 GB"). The diagnosis was never the problem. The **timing** was.

## Why nobody saw it

The caveat surfaced only on the engine-**pick** toast. That reaches users who change engines, and nobody whose engine was already selected — the default, or one persisted from a previous session. That is most users.

`/generate` does return `X-OmniVoice-Routing`, but a response header arrives when the job ends. Five minutes too late to be a warning, and the frontend never read it anyway.

## The fix

Preflight at the chokepoint every synth path shares (`api/generate.ts` — the same argument as the in-flight count, and the same seven call sites).

- **Never awaited** — a warning must not add latency to the request it warns about.
- **Never throws** — an unreachable backend costs a warning, not a generate.
- **Once per engine+reason per session** — informs instead of nags; keying on the reason means a genuinely different problem still gets through.
- **Advisory, not blocking** — matches the routing layer's deliberate contract (#1226): the driver can page to system RAM, and short inputs fit where long ones don't.

Extracts `routingNotice()` as the single frontend mirror of the backend's `routing_notice()`. Two callers now ask "is this verdict worth interrupting for", and two inline copies would drift — invisibly, until someone on DirectML or an `unavailable` engine gets a hardware warning for a perfectly normal pick. That exact bug was Greptile's P1 on #1280.

## Tests

8 new cases: fires on the already-selected engine, once-only, silent on healthy, silent on benign `cpu_only` (DirectML rule 5), fires on `cpu_fallback`, never throws when the backend is down, tolerates no active engine, fetches `/engines` once rather than per synth.

`engines.generateCaveat` added in all 21 locales with real prose.

Full frontend suite: 1602 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a non-blocking, fire-and-forget “under-provisioned hardware” preflight warning before the `/generate` chokepoint (including streaming), wired through shared routing/caveat detection (`routingNotice()`) and guarded by per-session dedup with TTL-cached engine-list fetching and correct invalidation/seeding on engine selection (plus `withTtsInflight` to keep inflight tracking active for the full streamed response). This ensures users see advisory notices up front (with new localized `engines.generateCaveat` strings across all locales) instead of encountering synthesis timeouts/500s, while routing streaming through the same generate path and avoiding extra `/engines` calls. Risk to review: that the warning truly never delays or blocks generation, and that the dedup/cache/inflight lifecycles behave correctly across engine changes, transient engine-list failures, and stream consumption/release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->