### PR TITLE
ci(windows): make the ffmpeg retry test the outcome, not choco's exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,11 +298,20 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          # The community chocolatey feed 504s intermittently (broke a PR run
-          # on 2026-07-20) — retry with backoff before failing the job.
+          # The community chocolatey feed 50x's intermittently (broke PR runs on
+          # 2026-07-20 and 2026-07-28) — retry with backoff before failing.
+          #
+          # Test the OUTCOME, not choco's exit code. On 2026-07-28 the feed
+          # returned 503, choco reported "Unable to find package 'ffmpeg'" and
+          # "installed 0/0 packages" — and still exited 0. The `&& break` that
+          # was supposed to guard this fired on the first attempt, no retry ran,
+          # and the job died one line later on `ffmpeg: command not found`.
+          # A retry that trusts a lying exit code is not a retry.
           for i in 1 2 3; do
-            choco install ffmpeg -y --no-progress && break
-            echo "choco attempt $i failed — retrying in $((i * 30))s"
+            choco install ffmpeg -y --no-progress || true
+            hash -r 2>/dev/null || true
+            if command -v ffmpeg >/dev/null 2>&1; then break; fi
+            echo "choco attempt $i did not produce ffmpeg — retrying in $((i * 30))s"
             sleep $((i * 30))
           done
           ffmpeg -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,12 @@ jobs:
             choco install ffmpeg -y --no-progress || true
             hash -r 2>/dev/null || true
             if command -v ffmpeg >/dev/null 2>&1; then break; fi
+            # No backoff after the last attempt — there is no fourth try to
+            # wait for, and sleeping 90s only delays an already-doomed job.
+            if [ "$i" -eq 3 ]; then
+              echo "choco failed to produce ffmpeg after 3 attempts"
+              break
+            fi
             echo "choco attempt $i did not produce ffmpeg — retrying in $((i * 30))s"
             sleep $((i * 30))
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,12 +262,24 @@ jobs:
         include:
           - os: macos-14
             label: macOS
+            timeout: 10
           - os: windows-2022
             label: Windows
+            # Windows needs its own budget, and the old shared 10 was a
+            # self-perpetuating failure: the leg times out mid-`uv sync`, so the
+            # post-step never saves the uv cache, so the next run is cold too
+            # and times out again. Measured on run 30385710466 — Linux 65s,
+            # macOS 65s, Windows still installing torch at 10m08s when the job
+            # was killed. Priced for one COLD install to finish and prime the
+            # cache; warm runs land nowhere near this.
+            timeout: 25
           - os: ubuntu-22.04
             label: Linux
+            timeout: 10
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    # Per-leg, not shared: a genuine hang on Linux/macOS should still fail fast
+    # rather than inherit the allowance Windows needs.
+    timeout-minutes: ${{ matrix.timeout }}
     env:
       # Restricted-network resilience (RESEARCH Pitfall #6) — keeps uv from
       # giving up on the first slow PyPI / python-build-standalone fetch.

--- a/tests/test_ci_windows_ffmpeg_retry.py
+++ b/tests/test_ci_windows_ffmpeg_retry.py
@@ -1,0 +1,124 @@
+"""A retry that trusts a lying exit code is not a retry.
+
+On 2026-07-28 the chocolatey community feed returned 503. `choco install
+ffmpeg` printed "Unable to find package 'ffmpeg'" and "installed 0/0 packages"
+— then exited **0**. The retry loop added on 2026-07-20 was written as
+`choco install ... && break`, so it broke out on the first attempt, no backoff
+ran, and the job died one line later on `ffmpeg: command not found`.
+
+This runs the real loop body from ci.yml against a stubbed `choco` that
+reproduces that behaviour, so the guard is pinned to what actually happened
+rather than to what the exit code claimed.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="the step is bash; exercised here on POSIX"
+)
+
+_WORKFLOW = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ".github", "workflows", "ci.yml",
+)
+_STEP = "System deps (Windows)"
+
+
+def _step_script():
+    with open(_WORKFLOW, encoding="utf-8") as fh:
+        wf = yaml.safe_load(fh)
+    for job in wf["jobs"].values():
+        for step in job.get("steps", []):
+            if step.get("name") == _STEP:
+                return step["run"]
+    raise AssertionError(f"step {_STEP!r} not found in ci.yml")
+
+
+def _run(tmp_path, *, choco_exit, succeed_on_attempt=None):
+    """Run the step with stub `choco`/`ffmpeg`/`sleep` on PATH.
+
+    `succeed_on_attempt` is the 1-based attempt on which choco finally puts
+    ffmpeg on PATH; None means it never does.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    counter = tmp_path / "attempts"
+    ffmpeg_path = bin_dir / "ffmpeg"
+
+    # ffmpeg must be genuinely ABSENT from PATH until a "successful" install
+    # creates it — `command -v` tests existence, so a stub that merely exits
+    # 127 would look installed and the retry would never be exercised.
+    (bin_dir / "choco").write_text(
+        "#!/usr/bin/env bash\n"
+        f"n=$(cat {str(counter)!r} 2>/dev/null || echo 0); n=$((n+1));"
+        f" echo $n > {str(counter)!r}\n"
+        + (
+            f'if [ "$n" -ge {succeed_on_attempt} ]; then\n'
+            f"  printf '%s\\n' '#!/usr/bin/env bash'"
+            f" \"echo 'ffmpeg version 8.1.2'\" > {str(ffmpeg_path)!r}\n"
+            f"  chmod +x {str(ffmpeg_path)!r}\n"
+            f"fi\n"
+            if succeed_on_attempt
+            else ""
+        )
+        + 'echo "Chocolatey installed 0/0 packages."\n'
+        f"exit {choco_exit}\n"
+    )
+    # Keep the backoff from actually sleeping 90s in the test.
+    (bin_dir / "sleep").write_text("#!/usr/bin/env bash\nexit 0\n")
+    for name in ("choco", "sleep"):
+        p = bin_dir / name
+        p.chmod(p.stat().st_mode | stat.S_IEXEC)
+
+    script = tmp_path / "step.sh"
+    script.write_text(_step_script())
+    # A minimal PATH on purpose: inheriting the dev machine's would let a real
+    # /opt/homebrew/bin/ffmpeg satisfy `command -v` and silently neuter every
+    # assertion here. The stub dir plus the base system dirs is all the step
+    # needs (`cat`, and bash builtins for the rest).
+    env = dict(os.environ, PATH=f"{bin_dir}:/usr/bin:/bin")
+    proc = subprocess.run(
+        [shutil.which("bash") or "/bin/bash", str(script)],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+    attempts = int(counter.read_text().strip()) if counter.exists() else 0
+    return proc, attempts
+
+
+def test_retries_when_choco_lies_about_success(tmp_path):
+    """The 2026-07-28 regression: exit 0, nothing installed, no retry."""
+    proc, attempts = _run(tmp_path, choco_exit=0, succeed_on_attempt=2)
+    assert attempts >= 2, (
+        "choco exited 0 without installing ffmpeg and the loop moved on — "
+        "the retry must test whether ffmpeg exists, not what choco returned"
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_retries_on_a_normal_nonzero_failure(tmp_path):
+    proc, attempts = _run(tmp_path, choco_exit=1, succeed_on_attempt=3)
+    assert attempts >= 3
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_gives_up_loudly_when_ffmpeg_never_arrives(tmp_path):
+    """Exhausting the retries must fail the job — a silent pass would push a
+    broken toolchain into the test run."""
+    proc, attempts = _run(tmp_path, choco_exit=0, succeed_on_attempt=None)
+    assert attempts == 3
+    assert proc.returncode != 0
+
+
+def test_does_not_retry_when_the_first_attempt_works(tmp_path):
+    """Backoff is 30s+60s; burning it when nothing is wrong is its own bug."""
+    proc, attempts = _run(tmp_path, choco_exit=0, succeed_on_attempt=1)
+    assert attempts == 1
+    assert proc.returncode == 0, proc.stderr

--- a/tests/test_ci_windows_ffmpeg_retry.py
+++ b/tests/test_ci_windows_ffmpeg_retry.py
@@ -42,6 +42,9 @@ def _step_script():
     raise AssertionError(f"step {_STEP!r} not found in ci.yml")
 
 
+_BASH = shutil.which("bash") or "/bin/bash"
+
+
 def _run(tmp_path, *, choco_exit, succeed_on_attempt=None):
     """Run the step with stub `choco`/`ffmpeg`/`sleep` on PATH.
 
@@ -53,44 +56,79 @@ def _run(tmp_path, *, choco_exit, succeed_on_attempt=None):
     counter = tmp_path / "attempts"
     ffmpeg_path = bin_dir / "ffmpeg"
 
-    # ffmpeg must be genuinely ABSENT from PATH until a "successful" install
-    # creates it — `command -v` tests existence, so a stub that merely exits
-    # 127 would look installed and the retry would never be exercised.
+    # The binary a "successful" install drops onto PATH. Staged outside bin_dir
+    # and already executable, so the choco stub only has to copy it — building
+    # a shell script from inside another shell script is how the quoting in
+    # this harness went wrong the first time.
+    staged = tmp_path / "ffmpeg-staged"
+    staged.write_text(f"#!{_BASH}\necho 'ffmpeg version 8.1.2'\n")
+    staged.chmod(staged.stat().st_mode | stat.S_IEXEC)
+
+    # ffmpeg must be genuinely ABSENT from PATH until that copy happens —
+    # `command -v` tests existence, so a stub that merely exits 127 would look
+    # installed and the retry would never be exercised.
+    install_line = (
+        f'if [ "$n" -ge {succeed_on_attempt} ]; then '
+        f"cp {str(staged)!r} {str(ffmpeg_path)!r}; fi\n"
+        if succeed_on_attempt
+        else ""
+    )
     (bin_dir / "choco").write_text(
-        "#!/usr/bin/env bash\n"
+        f"#!{_BASH}\n"
         f"n=$(cat {str(counter)!r} 2>/dev/null || echo 0); n=$((n+1));"
         f" echo $n > {str(counter)!r}\n"
-        + (
-            f'if [ "$n" -ge {succeed_on_attempt} ]; then\n'
-            f"  printf '%s\\n' '#!/usr/bin/env bash'"
-            f" \"echo 'ffmpeg version 8.1.2'\" > {str(ffmpeg_path)!r}\n"
-            f"  chmod +x {str(ffmpeg_path)!r}\n"
-            f"fi\n"
-            if succeed_on_attempt
-            else ""
-        )
+        + install_line
         + 'echo "Chocolatey installed 0/0 packages."\n'
         f"exit {choco_exit}\n"
     )
     # Keep the backoff from actually sleeping 90s in the test.
-    (bin_dir / "sleep").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (bin_dir / "sleep").write_text(f"#!{_BASH}\nexit 0\n")
     for name in ("choco", "sleep"):
         p = bin_dir / name
         p.chmod(p.stat().st_mode | stat.S_IEXEC)
 
+    # PATH is ONLY this directory (see below), so the few real tools the stubs
+    # shell out to have to be reachable from inside it.
+    for tool in ("cat", "cp"):
+        real = shutil.which(tool)
+        if real:
+            (bin_dir / tool).symlink_to(real)
+
     script = tmp_path / "step.sh"
     script.write_text(_step_script())
-    # A minimal PATH on purpose: inheriting the dev machine's would let a real
-    # /opt/homebrew/bin/ffmpeg satisfy `command -v` and silently neuter every
-    # assertion here. The stub dir plus the base system dirs is all the step
-    # needs (`cat`, and bash builtins for the rest).
-    env = dict(os.environ, PATH=f"{bin_dir}:/usr/bin:/bin")
+    # PATH is the stub dir and NOTHING else. Any system directory on it can
+    # carry a real ffmpeg that satisfies `command -v`, which silently neuters
+    # every assertion below — that false-green happened twice while writing
+    # this: /opt/homebrew/bin locally, then /usr/bin on the Linux runner.
+    env = dict(os.environ, PATH=str(bin_dir))
     proc = subprocess.run(
         [shutil.which("bash") or "/bin/bash", str(script)],
         capture_output=True, text=True, env=env, timeout=120,
     )
     attempts = int(counter.read_text().strip()) if counter.exists() else 0
     return proc, attempts
+
+
+def test_harness_actually_hides_ffmpeg(tmp_path):
+    """Guard the guard.
+
+    Every assertion here depends on ffmpeg being genuinely absent until a stub
+    install creates it. If a real ffmpeg leaks onto PATH, the loop exits on the
+    first attempt and all four tests below pass against a broken workflow —
+    which is exactly what happened twice: /opt/homebrew/bin locally, /usr/bin
+    on the Linux runner. So assert the sandbox is a sandbox.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    probe = subprocess.run(
+        [shutil.which("bash") or "/bin/bash", "-c", "command -v ffmpeg"],
+        capture_output=True, text=True,
+        env=dict(os.environ, PATH=str(bin_dir)),
+    )
+    assert probe.returncode != 0, (
+        f"ffmpeg is visible at {probe.stdout.strip()!r} with PATH pinned to the "
+        f"stub dir — the retry tests would pass against a broken loop"
+    )
 
 
 def test_retries_when_choco_lies_about_success(tmp_path):

--- a/tests/test_ci_windows_ffmpeg_retry.py
+++ b/tests/test_ci_windows_ffmpeg_retry.py
@@ -134,7 +134,9 @@ def test_harness_actually_hides_ffmpeg(tmp_path):
 def test_retries_when_choco_lies_about_success(tmp_path):
     """The 2026-07-28 regression: exit 0, nothing installed, no retry."""
     proc, attempts = _run(tmp_path, choco_exit=0, succeed_on_attempt=2)
-    assert attempts >= 2, (
+    # Exactly 2, not ">= 2": the loop must also STOP once ffmpeg appears, or a
+    # regression that keeps going would still satisfy a lower bound.
+    assert attempts == 2, (
         "choco exited 0 without installing ffmpeg and the loop moved on — "
         "the retry must test whether ffmpeg exists, not what choco returned"
     )
@@ -143,7 +145,7 @@ def test_retries_when_choco_lies_about_success(tmp_path):
 
 def test_retries_on_a_normal_nonzero_failure(tmp_path):
     proc, attempts = _run(tmp_path, choco_exit=1, succeed_on_attempt=3)
-    assert attempts >= 3
+    assert attempts == 3
     assert proc.returncode == 0, proc.stderr
 
 
@@ -153,6 +155,16 @@ def test_gives_up_loudly_when_ffmpeg_never_arrives(tmp_path):
     proc, attempts = _run(tmp_path, choco_exit=0, succeed_on_attempt=None)
     assert attempts == 3
     assert proc.returncode != 0
+
+
+def test_no_backoff_after_the_final_attempt(tmp_path):
+    """There is no fourth try to wait for; sleeping 90s only delays a job that
+    has already failed."""
+    proc, _ = _run(tmp_path, choco_exit=0, succeed_on_attempt=None)
+    assert "retrying in 90s" not in proc.stdout, (
+        "the loop announced a retry after its last attempt:\n" + proc.stdout
+    )
+    assert proc.stdout.count("retrying in") == 2
 
 
 def test_does_not_retry_when_the_first_attempt_works(tmp_path):


### PR DESCRIPTION
This is what just took #1281 red on an unrelated change.

## What happened

The chocolatey community feed returned 503. `choco install ffmpeg` printed:

```
Unable to find package 'ffmpeg'. Existing packages must be restored before ...
Chocolatey installed 0/0 packages.
```

…and exited **0**.

The retry loop added on 2026-07-20 for exactly this class was written as `choco install ... && break`. It broke out on the first attempt, no backoff ran, and the job died one line later on `ffmpeg: command not found`. The log proves it: no `choco attempt 1 failed` line, no 30s gap.

A retry that trusts a lying exit code is not a retry.

## Fix

Test the outcome — `command -v ffmpeg` — instead of `$?`. Same 3 attempts, same backoff, but the loop exits only when ffmpeg is genuinely on PATH, and still fails the job loudly when it never arrives (a silent pass would push a broken toolchain into the test run).

## Tests

`tests/test_ci_windows_ffmpeg_retry.py` extracts the real step body from `ci.yml` (so it cannot drift) and runs it against a stubbed `choco`:

| Case | Expected |
|---|---|
| exit 0 + nothing installed | **retries** (the regression) |
| ordinary non-zero failure | retries |
| never installs | job fails after 3 attempts |
| first attempt works | exactly 1 attempt, no wasted backoff |

2 of the 4 fail against the previous loop.

One harness note worth keeping: the test pins a minimal `PATH`. Inheriting the developer's let a real `/opt/homebrew/bin/ffmpeg` satisfy `command -v` and silently neuter every assertion — which it did, on my first run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the Windows CI dependency-install smoke job to use a per-OS timeout budget (Windows 25 minutes vs 10 for others) and changed the Windows `ffmpeg` install retry loop to retry based on `command -v ffmpeg` (with `hash -r` and up to three attempts/backoff) instead of Chocolatey’s exit code, which could falsely report success. Added regression tests that extract and execute the exact `System deps (Windows)` step from `ci.yml` with stubbed `choco`, `sleep`, and a pinned `PATH` so they exercise false-success, non-zero failure, persistent failure, and first-attempt success—including verifying there’s no backoff announcement after the final attempt. Human review is most important around the `hash -r` + `command -v ffmpeg` control flow and the test harness’s PATH isolation to ensure a real system `ffmpeg` can’t mask failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->