### PR TITLE
feat(engines): add omnivoice-subprocess, a crash-isolated (killable) TTS engine

### DIFF
--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -931,6 +931,14 @@ async def generate_speech(
     except Exception:
         pass
 
+    # Free idle GPU before a warm, heavy generate (#730/#1190); no-op on a roomy
+    # machine or a short synth. Covers MCP generate_speech, which POSTs here.
+    # Run off the event loop: the eviction does gc.collect + cache drop + ASR
+    # teardown that can block for hundreds of ms when it trips.
+    from services.model_manager import make_room_before_generate
+    await asyncio.get_running_loop().run_in_executor(
+        None, make_room_before_generate, text)
+
     _model = None
     _backend = None
     if backend_cls is OmniVoiceBackend:

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -931,13 +931,8 @@ async def generate_speech(
     except Exception:
         pass
 
-    # Free idle GPU before a warm, heavy generate (#730/#1190); no-op on a roomy
-    # machine or a short synth. Covers MCP generate_speech, which POSTs here.
-    # Run off the event loop: the eviction does gc.collect + cache drop + ASR
-    # teardown that can block for hundreds of ms when it trips.
-    from services.model_manager import make_room_before_generate
-    await asyncio.get_running_loop().run_in_executor(
-        None, make_room_before_generate, text)
+    # VRAM eviction runs in get_model()'s warm-return path now, so every native
+    # TTS generate (this route, WS TTS, dub, batch, audiobook) is covered.
 
     _model = None
     _backend = None

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -385,6 +385,12 @@ async def create_speech(req: SpeechRequest):
     from services.text_normalization import normalize_for_tts
     text = normalize_for_tts(req.input, req.language)
 
+    # Free idle GPU before a warm, heavy generate (#730/#1190); no-op on a roomy
+    # machine or a short synth. Run off the event loop (gc.collect + cache drop).
+    from services.model_manager import make_room_before_generate
+    await asyncio.get_running_loop().run_in_executor(
+        None, make_room_before_generate, text)
+
     # ── #1033/#1037/#1014: warm the engine under the LOAD budget before the
     # generate clock starts. The T4 verification (#1014) measured a fresh
     # install's first /v1/audio/speech burning its whole 300s generate budget

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -385,11 +385,8 @@ async def create_speech(req: SpeechRequest):
     from services.text_normalization import normalize_for_tts
     text = normalize_for_tts(req.input, req.language)
 
-    # Free idle GPU before a warm, heavy generate (#730/#1190); no-op on a roomy
-    # machine or a short synth. Run off the event loop (gc.collect + cache drop).
-    from services.model_manager import make_room_before_generate
-    await asyncio.get_running_loop().run_in_executor(
-        None, make_room_before_generate, text)
+    # VRAM eviction runs in get_model()'s warm-return path now, covering every
+    # native TTS generate (this route, WS TTS, dub, batch, audiobook).
 
     # ── #1033/#1037/#1014: warm the engine under the LOAD budget before the
     # generate clock starts. The T4 verification (#1014) measured a fresh

--- a/backend/engines/omnivoice_subprocess/__init__.py
+++ b/backend/engines/omnivoice_subprocess/__init__.py
@@ -1,0 +1,105 @@
+"""omnivoice-subprocess: the resident OmniVoice TTS engine in a crash-isolated
+sidecar process (#730/#1190).
+
+The default ``omnivoice`` engine runs in-process on the GPU ``ThreadPoolExecutor``.
+When a generate or load there exceeds its execution budget the pool is "reset"
+but the abandoned worker *thread* cannot be killed (Python cannot interrupt a
+native torch/MPS call), so it holds the MPS device until it finishes on its
+own, and every later synth contends with the zombie and hangs.
+
+This engine runs the SAME OmniVoice model in a child process via
+:class:`SubprocessBackend`. A child process CAN be hard-killed: on a recv
+timeout the parent's watchdog calls ``proc.kill()``, reclaiming the child's
+VRAM/device, and the next request transparently respawns a fresh sidecar. That
+is the one thing the in-process engine structurally cannot do.
+
+OPT-IN (Settings -> Engines, or ``OMNIVOICE_TTS_BACKEND=omnivoice-subprocess``);
+the in-process ``omnivoice`` stays the default so existing users see no change.
+
+Tradeoff vs the in-process engine: identical model and quality, a little extra
+per-call overhead (one stdio round-trip), and it does not carry the native
+advanced-parameter surface (``t_shift`` / ``layer_penalty_factor`` /
+``position_temperature`` / ``class_temperature``) or parent-side seed
+determinism, because the generic ``backend.generate`` path does not forward
+those. Acceptable for unattended / reaction-triggered use where reliability
+matters more than those controls.
+
+Unlike IndexTTS / dots.tts / Supertonic-3, this sidecar runs under the PARENT
+interpreter (``venv_python() -> sys.executable``): the goal here is crash
+isolation, not dependency isolation, and the OmniVoice engine uses the host's
+own pins.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from services.subprocess_backend import SubprocessBackend
+
+if TYPE_CHECKING:
+    import torch  # noqa: F401
+
+logger = logging.getLogger("omnivoice.omnivoice_subprocess")
+
+
+class OmniVoiceSubprocessBackend(SubprocessBackend):
+    """The resident OmniVoice model in a killable sidecar process."""
+
+    id = "omnivoice-subprocess"
+    display_name = "OmniVoice (subprocess-isolated, killable on timeout)"
+    _DEFAULT_SAMPLE_RATE = 24000
+    gpu_compat = ("cuda", "mps", "cpu")
+    # Match OmniVoiceBackend: the measured floor below which a render that
+    # should take seconds runs for minutes (the #1226/#1222 4 GB reports).
+    min_vram_gb = 6.0
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        # Same probe as OmniVoiceBackend: the package must be importable. The
+        # interpreter is the parent's own (sys.executable), so there is no
+        # separate venv to validate.
+        try:
+            import omnivoice.models.omnivoice  # noqa: F401
+        except Exception as e:
+            return False, f"omnivoice package missing: {e}"
+        return True, "ready"
+
+    @classmethod
+    def venv_python(cls) -> Path:
+        # Same interpreter as the parent: this engine isolates for crash
+        # recovery, not dependency pins, so it needs no dedicated venv.
+        return Path(sys.executable)
+
+    @classmethod
+    def sidecar_script(cls) -> Path:
+        return Path(__file__).resolve().parent / "main.py"
+
+    @property
+    def recv_timeout_s(self) -> float:
+        """Override the base 60s recv timeout.
+
+        Aligns the kill deadline with the generate budget: a long-but-valid
+        OmniVoice synth (which can take tens of seconds) is not falsely killed,
+        while a genuinely wedged one is hard-killed and its VRAM reclaimed at
+        the deadline. That reclaim is the concrete behavior the in-process
+        engine lacks (it abandons but never frees the device).
+        """
+        try:
+            return max(30.0, float(os.environ.get("OMNIVOICE_SIDECAR_RECV_TIMEOUT_S", "300")))
+        except (ValueError, TypeError):
+            return 300.0
+
+    @property
+    def sample_rate(self) -> int:
+        return self._DEFAULT_SAMPLE_RATE
+
+    @property
+    def supported_languages(self) -> list[str]:
+        # OmniVoice advertises 600+ zero-shot; "multi" is the honest tag.
+        return ["multi"]
+
+
+__all__ = ["OmniVoiceSubprocessBackend"]

--- a/backend/engines/omnivoice_subprocess/main.py
+++ b/backend/engines/omnivoice_subprocess/main.py
@@ -1,0 +1,249 @@
+"""omnivoice-subprocess sidecar entry point (#730/#1190).
+
+Runs the resident OmniVoice TTS model in a child process under the parent's own
+interpreter (same pins), so a wedged generate can be hard-killed by the parent
+to reclaim VRAM/device, the thing the in-process ``ThreadPoolExecutor`` worker
+structurally cannot do.
+
+Wire protocol: length-prefixed JSON over stdin/stdout, byte-identical to
+``services/subprocess_backend.py`` and ``engines/dots_tts/main.py``::
+
+    [ 4-byte big-endian uint32 length ][ N bytes UTF-8 JSON ]
+
+Op flow:
+    1. sidecar -> parent: {"op":"ready","engine":"omnivoice-subprocess",
+                            "sample_rate":24000}
+    2. parent -> sidecar: {"op":"ping"} -> {"op":"pong","vram_mb":N}
+    3. parent -> sidecar: {"op":"synthesize","text":"...",
+                            "ref_audio":"/path","ref_text":"...",
+                            "language":"...","num_step":16,
+                            "guidance_scale":2.0,"speed":1.0,...}
+       -> {"op":"progress",...} (cold load) then
+       -> {"op":"audio","audio_pcm_b64":"...","sample_rate":24000,
+           "n_samples":N}
+    4. parent -> sidecar: {"op":"shutdown"} -> exit 0
+
+Stdlib-only at import time; torch + the OmniVoice model are imported lazily on
+the first synthesize so the ``ready`` frame fits the parent's 30s spawn
+handshake even on a cold filesystem.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import struct
+import sys
+import traceback
+
+# Mirrors backend/services/subprocess_backend.py::MAX_FRAME_BYTES (T-02-01).
+MAX_FRAME_BYTES = 64 * 1024 * 1024
+
+#: OmniVoice's canonical output rate. The real value is re-read from the loaded
+#: model on each generate.
+OMNIVOICE_SAMPLE_RATE = 24000
+
+#: kwargs model.generate accepts. The parent forwards JSON-safe kwargs from
+#: backend.generate(); allowlist the known surface so an unexpected key never
+#: reaches model.generate (it has an explicit signature and TypeErrors on
+#: unknown kwargs). cache_ref is a parent-side cache marker, not a model param.
+_GEN_KW_ALLOWLIST = (
+    "language", "instruct", "duration", "num_step", "guidance_scale",
+    "speed", "denoise", "postprocess_output", "preprocess_prompt",
+)
+
+_model = None
+
+
+# ── wire protocol ─────────────────────────────────────────────────────────
+
+
+def _send(stream, obj: dict) -> None:
+    body = json.dumps(obj, separators=(",", ":")).encode("utf-8")
+    stream.write(struct.pack("!I", len(body)))
+    stream.write(body)
+    stream.flush()
+
+
+def _recv(stream):
+    header = stream.read(4)
+    if len(header) < 4:
+        return None  # EOF
+    (n,) = struct.unpack("!I", header)
+    if n > MAX_FRAME_BYTES:
+        raise IOError(f"frame too large: {n}")
+    body = bytearray()
+    while len(body) < n:
+        chunk = stream.read(n - len(body))
+        if not chunk:
+            raise IOError("short read")
+        body.extend(chunk)
+    return json.loads(bytes(body).decode("utf-8"))
+
+
+def _measure_vram_mb() -> float:
+    """This sidecar's own GPU memory in MB. 0 on CPU. Never raises."""
+    try:
+        import torch
+        if torch.cuda.is_available():
+            return round(torch.cuda.memory_allocated() / (1024 ** 2), 1)
+        mps = getattr(torch.backends, "mps", None)
+        if mps is not None and mps.is_available():
+            return round(torch.mps.driver_allocated_memory() / (1024 ** 2), 1)
+    except Exception:
+        pass
+    return 0.0
+
+
+# ── model loading (lazy, on first synthesize) ─────────────────────────────
+
+
+def _ensure_backend_on_path() -> None:
+    """The sidecar is launched as ``<python> main.py``, so sys.path[0] is this
+    script's directory, not ``backend/``. Add ``backend/`` so ``services`` is
+    importable, letting us reuse the parent's load primitives verbatim."""
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    if root and root not in sys.path:
+        sys.path.insert(0, root)
+
+
+def _load_model(stdout):
+    """Cold-construct the OmniVoice model, reusing the parent's load path."""
+    global _model
+    if _model is not None:
+        return _model
+
+    _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 0})
+
+    _ensure_backend_on_path()
+    # Reuse the parent's own load primitives (same interpreter): the checkpoint
+    # resolver, device probe, and ASR-preload policy are exactly what the
+    # in-process engine uses, so this sidecar loads the identical model.
+    from services.model_manager import (  # noqa: PLC0415
+        _lazy_omnivoice,
+        _lazy_torch,
+        get_best_device,
+        resolve_omnivoice_checkpoint,
+        should_preload_tts_asr,
+    )
+    from utils.hf_progress import register_listener, unregister_listener  # noqa: PLC0415
+
+    # Forward real HF download/weight progress so the parent's recv loop keeps
+    # its watchdog alive across a slow cold load (the parent consumes these
+    # {"op": "progress"} frames and re-arms its deadline on each one).
+    def _on_progress(ev):
+        pct = ev.get("pct", 0.0)
+        if pct:
+            _send(stdout, {"op": "progress", "stage": "loading_model",
+                           "percent": min(round(pct * 100), 99)})
+
+    torch = _lazy_torch()
+    OmniVoice = _lazy_omnivoice()
+    checkpoint = resolve_omnivoice_checkpoint()
+    device = get_best_device()
+    preload_asr = should_preload_tts_asr()
+
+    lid = register_listener(_on_progress)
+    try:
+        _model = OmniVoice.from_pretrained(
+            checkpoint, device_map=device, dtype=torch.float16, load_asr=preload_asr,
+        )
+    finally:
+        unregister_listener(lid)
+    _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 100})
+    return _model
+
+
+def _tensor_to_pcm_b64(audio, sample_rate: int) -> tuple[str, int, int]:
+    """Convert a torch waveform tensor (1, N) in [-1, 1] to base64 int16 PCM."""
+    import numpy as np
+
+    arr = audio.detach().to("cpu").float().numpy()
+    arr = np.asarray(arr, dtype=np.float32).squeeze()
+    if arr.ndim > 1:
+        arr = arr.mean(axis=0)  # defensive downmix to mono
+    arr = np.clip(arr, -1.0, 1.0)
+    pcm = (arr * 32767.0).astype(np.int16).tobytes()
+    return base64.b64encode(pcm).decode("ascii"), int(sample_rate), int(arr.shape[0])
+
+
+def _handle_synthesize(msg: dict, stdout) -> None:
+    """Dispatch one synthesize request. Emits the audio frame or raises."""
+    text = msg.get("text")
+    if not text or not isinstance(text, str):
+        raise ValueError("synthesize: missing or non-string 'text'")
+
+    model = _load_model(stdout)
+
+    ref_audio = msg.get("ref_audio") or None
+    ref_text = msg.get("ref_text") or None
+    gen_kw = {k: msg[k] for k in _GEN_KW_ALLOWLIST if k in msg}
+
+    audios = model.generate(
+        text=text, ref_audio=ref_audio, ref_text=ref_text, **gen_kw
+    )
+    audio = audios[0] if isinstance(audios, (list, tuple)) else audios
+    sample_rate = int(getattr(model, "sampling_rate", OMNIVOICE_SAMPLE_RATE))
+
+    pcm_b64, sr, n_samples = _tensor_to_pcm_b64(audio, sample_rate)
+    _send(stdout, {
+        "op": "audio",
+        "audio_pcm_b64": pcm_b64,
+        "sample_rate": sr,
+        "n_samples": n_samples,
+    })
+
+
+# ── main loop ─────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    stdin = sys.stdin.buffer
+    stdout = sys.stdout.buffer
+
+    # Ready handshake fires BEFORE any heavy import.
+    _send(stdout, {
+        "op": "ready",
+        "engine": "omnivoice-subprocess",
+        "sample_rate": OMNIVOICE_SAMPLE_RATE,
+    })
+
+    while True:
+        try:
+            msg = _recv(stdin)
+        except Exception as exc:
+            _send(stdout, {
+                "op": "error",
+                "stage": "recv",
+                "message": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            })
+            return 1
+        if msg is None:
+            return 0
+
+        op = msg.get("op") if isinstance(msg, dict) else None
+        try:
+            if op == "ping":
+                _send(stdout, {"op": "pong", "vram_mb": _measure_vram_mb()})
+            elif op == "synthesize":
+                _handle_synthesize(msg, stdout)
+            elif op == "shutdown":
+                return 0
+            else:
+                _send(stdout, {
+                    "op": "error",
+                    "stage": "dispatch",
+                    "message": f"unknown op: {op!r}",
+                })
+        except Exception as exc:
+            _send(stdout, {
+                "op": "error",
+                "stage": op or "unknown",
+                "message": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc(),
+            })
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1684,6 +1684,13 @@ async def get_model():
         # contract unnecessary: a future unbalanced offload can no longer
         # strand the model, because the next generation moves it back.
         await _heal_tts_placement()
+        # Free idle GPU memory before this warm generate reuses the resident
+        # model. The cold-load path already evicts (_make_room_before_tts_load);
+        # this closes the WARM path for every native TTS generate (/generate, WS
+        # TTS, dub, batch, audiobook), not just a couple of routes. No-op on a
+        # roomy machine. Off the event loop because the eviction does gc.collect
+        # + cache drop + ASR teardown that can block for hundreds of ms.
+        await asyncio.get_running_loop().run_in_executor(None, make_room_before_generate)
         return model
 
     async with _model_lock:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1750,46 +1750,32 @@ def _release_idle_tts_memory(stage):
         logger.debug("pre-%s memory reclaim skipped", stage, exc_info=True)
 
 
-def _should_make_room_for_generate(text):
+def _should_make_room_for_generate():
     """Decide whether to free idle GPU memory before a generate (#730/#1190).
-    Resolved at CALL time, not def time, so it is env-tunable and reaches every
-    call site without a module reload.
 
     Modes (OMNIVOICE_FREE_VRAM_BEFORE_GENERATE):
-      auto (default): free when free system RAM is below a headroom. Long text
-        raises the headroom (a heavier generate is more likely to contend), but
-        a genuinely roomy machine still pays nothing, mirroring
-        _make_room_before_tts_load. This is the starvation case behind the
-        #730/#1190 abandon cascade.
-      always: free before every generate (maximum headroom, small per-call cost
-        from gc.collect + cache drop).
-      never: opt out (legacy warm-generate behavior).
+      auto (default): free when free system RAM is below the unified headroom,
+        mirroring _make_room_before_tts_load. A roomy machine pays nothing.
+      always: free before every generate (small per-call cost from gc.collect +
+        cache drop).
+      never: opt out.
     """
     mode = os.environ.get("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", "auto").strip().lower()
     if mode == "never":
         return False
     if mode == "always":
         return True
-    # Long text raises the bar (heavier generate, more likely to contend), but
-    # never bypasses the memory check, so a roomy machine pays nothing. The
-    # threshold + multiplier parse defensively at call time, so a malformed value
-    # falls back (with a warning) instead of disabling the whole auto path.
-    threshold = _UNIFIED_OFFLOAD_HEADROOM_GB
-    if text is not None and len(text) >= _env_float(
-        "OMNIVOICE_FREE_VRAM_LONG_TEXT_CHARS", 800.0
-    ):
-        threshold *= _env_float("OMNIVOICE_FREE_VRAM_LONG_TEXT_HEADROOM_MULT", 2.0)
     try:
         from services.memory_budget import available_memory
         free_gb = (available_memory() or {}).get("ram_available_gb")
-        if free_gb is not None and free_gb < threshold:
+        if free_gb is not None and free_gb < _UNIFIED_OFFLOAD_HEADROOM_GB:
             return True
     except Exception:  # noqa: BLE001 -- a probe failure must never block a generate
-        pass
+        logger.debug("make_room memory probe failed", exc_info=True)
     return False
 
 
-def make_room_before_generate(text=None):
+def make_room_before_generate():
     """Free idle GPU memory before a warm, heavy generate (#730/#1190).
 
     The cold LOAD path already evicts (``_make_room_before_tts_load`` runs inside
@@ -1807,7 +1793,7 @@ def make_room_before_generate(text=None):
     abandoned worker; only a crash-isolated subprocess engine can (see
     services.subprocess_backend).
     """
-    if not _should_make_room_for_generate(text):
+    if not _should_make_room_for_generate():
         return
     _release_idle_tts_memory("generate")
 
@@ -2013,20 +1999,6 @@ def _has_dedicated_vram():
 _UNIFIED_OFFLOAD_HEADROOM_GB = float(
     os.environ.get("OMNIVOICE_UNIFIED_OFFLOAD_HEADROOM_GB", "6.0")
 )
-
-def _env_float(name: str, default: float) -> float:
-    """Parse a float env var at CALL time, falling back to ``default`` (with a
-    warning) on a missing or non-numeric value. Used by the make-room policy so
-    a typo in one knob cannot silently disable the whole auto path (#730/#1190).
-    Resolved at call time so it is live-tunable without a module reload."""
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    try:
-        return float(raw)
-    except (TypeError, ValueError):
-        logger.warning("%s=%r is not a number; using default %s", name, raw, default)
-        return default
 
 
 def _offload_unified_memory() -> bool:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1718,18 +1718,91 @@ def _make_room_before_tts_load() -> None:
         if free_gb is None or free_gb >= _UNIFIED_OFFLOAD_HEADROOM_GB:
             return
         logger.info(
-            "Memory tight before TTS load (%.1f GB free) — releasing idle "
+            "Memory tight before TTS load (%.1f GB free), releasing idle "
             "models first.", free_gb,
         )
+        _release_idle_tts_memory("load")
+    except Exception:  # noqa: BLE001 -- making room must never break loading
+        logger.debug("pre-load memory reclaim skipped", exc_info=True)
+
+
+def _release_idle_tts_memory(stage):
+    """Drop capture-ASR, TTS side caches, and allocator caches. Best-effort;
+    never raises (a cleanup failure must not break the load/generate that called
+    it). Shared by the cold-load and warm-generate make-room paths so the
+    eviction recipe cannot drift between them (#730/#1190)."""
+    try:
         try:
             from services.asr_backend import release_idle_capture_backend
             release_idle_capture_backend(0.0)  # 0s idle = release if unleased
-        except Exception:  # noqa: BLE001 — best-effort, never block the load
-            logger.debug("capture-ASR pre-load release failed", exc_info=True)
+        except Exception:  # noqa: BLE001 -- best-effort, never blocks the caller
+            logger.debug("capture-ASR pre-%s release failed", stage, exc_info=True)
         release_tts_side_caches()
         free_vram()
-    except Exception:  # noqa: BLE001 — making room must never break loading
-        logger.debug("pre-load memory reclaim skipped", exc_info=True)
+    except Exception:  # noqa: BLE001 -- a cleanup failure must never break the caller
+        logger.debug("pre-%s memory reclaim skipped", stage, exc_info=True)
+
+
+def _should_make_room_for_generate(text):
+    """Decide whether to free idle GPU memory before a generate (#730/#1190).
+    Resolved at CALL time, not def time, so it is env-tunable and reaches every
+    call site without a module reload.
+
+    Modes (OMNIVOICE_FREE_VRAM_BEFORE_GENERATE):
+      auto (default): free when free system RAM is below a headroom. Long text
+        raises the headroom (a heavier generate is more likely to contend), but
+        a genuinely roomy machine still pays nothing, mirroring
+        _make_room_before_tts_load. This is the starvation case behind the
+        #730/#1190 abandon cascade.
+      always: free before every generate (maximum headroom, small per-call cost
+        from gc.collect + cache drop).
+      never: opt out (legacy warm-generate behavior).
+    """
+    mode = os.environ.get("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", "auto").strip().lower()
+    if mode == "never":
+        return False
+    if mode == "always":
+        return True
+    # Long text raises the bar (heavier generate, more likely to contend), but
+    # never bypasses the memory check, so a roomy machine pays nothing. The
+    # threshold + multiplier parse defensively at call time, so a malformed value
+    # falls back (with a warning) instead of disabling the whole auto path.
+    threshold = _UNIFIED_OFFLOAD_HEADROOM_GB
+    if text is not None and len(text) >= _env_float(
+        "OMNIVOICE_FREE_VRAM_LONG_TEXT_CHARS", 800.0
+    ):
+        threshold *= _env_float("OMNIVOICE_FREE_VRAM_LONG_TEXT_HEADROOM_MULT", 2.0)
+    try:
+        from services.memory_budget import available_memory
+        free_gb = (available_memory() or {}).get("ram_available_gb")
+        if free_gb is not None and free_gb < threshold:
+            return True
+    except Exception:  # noqa: BLE001 -- a probe failure must never block a generate
+        pass
+    return False
+
+
+def make_room_before_generate(text=None):
+    """Free idle GPU memory before a warm, heavy generate (#730/#1190).
+
+    The cold LOAD path already evicts (``_make_room_before_tts_load`` runs inside
+    ``_load_model_with_timeout``), but the warm path (model already resident,
+    ``get_model`` returns early at the cache check) skipped it. A long generate
+    on a VRAM-tight MPS box then contended with capture-ASR and the clone-prompt
+    side cache until it exceeded the execution budget and was abandoned, which is
+    exactly how one slow synth cascaded into a stuck, device-holding backend.
+    This runs the same fail-safe eviction the load path uses, just before a
+    generate the policy says is likely to starve.
+
+    Deliberately NOT admission control and NOT a device reclaim. It only drops
+    things the app already releases on idle, just now instead of later, so a
+    roomy machine or a short synth pays nothing. It cannot kill an already
+    abandoned worker; only a crash-isolated subprocess engine can (see
+    services.subprocess_backend).
+    """
+    if not _should_make_room_for_generate(text):
+        return
+    _release_idle_tts_memory("generate")
 
 
 def _checkpoint_in_local_cache(checkpoint: str) -> bool:
@@ -1933,6 +2006,20 @@ def _has_dedicated_vram():
 _UNIFIED_OFFLOAD_HEADROOM_GB = float(
     os.environ.get("OMNIVOICE_UNIFIED_OFFLOAD_HEADROOM_GB", "6.0")
 )
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var at CALL time, falling back to ``default`` (with a
+    warning) on a missing or non-numeric value. Used by the make-room policy so
+    a typo in one knob cannot silently disable the whole auto path (#730/#1190).
+    Resolved at call time so it is live-tunable without a module reload."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning("%s=%r is not a number; using default %s", name, raw, default)
+        return default
 
 
 def _offload_unified_memory() -> bool:

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -531,16 +531,22 @@ class SubprocessBackend(TTSBackend):
         # the entire model_manager + torch ecosystem at registry-listing time.
         from services.model_manager import _get_gpu_pool
 
-        # Acquire a GPU pool worker for the duration of this generate. The
-        # try/finally guarantees the slot is released even if the sidecar
-        # dies mid-frame (T-02-02 / Pitfall 7).
+        # Acquire a GPU pool worker for the duration of this generate, UNLESS we
+        # are already running on one: the /v1/audio/speech and /generate routes
+        # dispatch backend.generate() via run_on_gpu_pool_guarded, so this call
+        # already holds a slot. On a 1-worker pool (MPS) a second submit would
+        # queue behind this very job and self-deadlock (.result(timeout=10)
+        # fires, no sidecar ever spawns). The outer guard accounts for the slot.
         pool = _get_gpu_pool()
-        slot_future = pool.submit(lambda: None)
-        try:
-            slot_future.result(timeout=10)  # wait for our turn
-        except Exception:
-            slot_future.cancel()
-            raise
+        if threading.current_thread().name.startswith("gpu-pool"):
+            slot_future = None  # already on a pool worker
+        else:
+            slot_future = pool.submit(lambda: None)
+            try:
+                slot_future.result(timeout=10)  # wait for our turn
+            except Exception:
+                slot_future.cancel()
+                raise
 
         try:
             with self._lock:

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -280,6 +280,15 @@ class SubprocessBackend(TTSBackend):
     # Default sample rate; subclasses override.
     _DEFAULT_SAMPLE_RATE = 24000
 
+    # Per-engine recv timeout for generate(): how long the parent waits for the
+    # sidecar's audio frame before the watchdog hard-kills the child and reclaims
+    # its VRAM/device. Default is the conservative RECV_TIMEOUT_S (60s). A
+    # subclass whose legitimate generates run longer overrides it (or exposes it
+    # as a property) so a slow-but-valid synth is not falsely killed, while a
+    # genuinely wedged one is still reclaimed. health_check() keeps using
+    # RECV_TIMEOUT_S directly, since a ping must stay fast.
+    recv_timeout_s: float = RECV_TIMEOUT_S
+
     # ── instance state (initialised in __init__) ───────────────────────────
 
     def __init__(self) -> None:
@@ -544,7 +553,13 @@ class SubprocessBackend(TTSBackend):
                     if _is_jsonable(v):
                         msg[k] = v
                 self._send(msg)
-                reply = self._recv_with_timeout(RECV_TIMEOUT_S)
+                reply = self._recv_with_timeout(self.recv_timeout_s)
+                # A cold sidecar may emit non-terminal {"op": "progress"} frames
+                # (during a model load, etc.) before the terminal audio frame.
+                # Each recv re-arms the watchdog, so a long-but-active load
+                # survives while a silent wedge is still killed at the deadline.
+                while reply is not None and reply.get("op") == "progress":
+                    reply = self._recv_with_timeout(self.recv_timeout_s)
             if not reply:
                 raise RuntimeError(f"{self.id} sidecar closed pipe mid-generate")
             if reply.get("op") == "error":

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -529,18 +529,16 @@ class SubprocessBackend(TTSBackend):
         """
         # Lazy-import the GPU pool so importing this module doesn't pull in
         # the entire model_manager + torch ecosystem at registry-listing time.
-        from services.model_manager import _get_gpu_pool
-
-        # Acquire a GPU pool worker for the duration of this generate, UNLESS we
-        # are already running on one: the /v1/audio/speech and /generate routes
-        # dispatch backend.generate() via run_on_gpu_pool_guarded, so this call
-        # already holds a slot. On a 1-worker pool (MPS) a second submit would
-        # queue behind this very job and self-deadlock (.result(timeout=10)
-        # fires, no sidecar ever spawns). The outer guard accounts for the slot.
-        pool = _get_gpu_pool()
-        if threading.current_thread().name.startswith("gpu-pool"):
-            slot_future = None  # already on a pool worker
-        else:
+        # The HTTP routes, audiobook, dub, and batch all dispatch generate() via
+        # run_on_gpu_pool_guarded, i.e. already on a gpu-pool worker. On a
+        # 1-worker pool (MPS) a second slot submit would queue behind this very
+        # job and self-deadlock (.result(timeout=10) fires, no sidecar spawns),
+        # so skip the slot when already on the pool. The off-pool callers (the
+        # engine self-test and the diagnostic probe) still take a slot as a
+        # queue wait, so they yield to an in-flight pool job instead of racing.
+        if not threading.current_thread().name.startswith("gpu-pool"):
+            from services.model_manager import _get_gpu_pool
+            pool = _get_gpu_pool()
             slot_future = pool.submit(lambda: None)
             try:
                 slot_future.result(timeout=10)  # wait for our turn

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1848,6 +1848,12 @@ _LAZY_REGISTRY: dict[str, tuple[str, str]] = {
     # IndexTTS2. Lazy for the same import-cycle reason as the entries above.
     "moss-tts-v15": ("engines.moss_tts_v15", "MossTTSV15Backend"),
     "dots-tts": ("engines.dots_tts", "DotsTTSBackend"),
+    # The resident OmniVoice model in a crash-isolated sidecar (#730/#1190):
+    # same model and quality as the in-process "omnivoice" engine, but a wedged
+    # generate can be hard-killed to reclaim VRAM/device. Opt-in (the in-process
+    # engine stays the default). Unlike the entries above it runs under the
+    # parent interpreter (crash isolation, not dependency isolation).
+    "omnivoice-subprocess": ("engines.omnivoice_subprocess", "OmniVoiceSubprocessBackend"),
     # Issue #590: Confucius4-TTS (netease-youdao) — LLM-based, 14-language
     # cross-lingual zero-shot cloning, Apache-2.0. Opt-in + subprocess-isolated
     # (own Python 3.10 venv) like the entries above. Validated end-to-end

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1949,6 +1949,7 @@ _LAST_ERRORS: dict[str, str] = {}
 # Helps users understand what pip package to install and where.
 _INSTALL_HINTS: dict[str, str] = {
     "omnivoice":     "pip install omnivoice  (bundled — no extra install needed)",
+    "omnivoice-subprocess": "No extra install; uses the host OmniVoice install. Opt in with OMNIVOICE_TTS_BACKEND=omnivoice-subprocess (same model in a killable sidecar, for unattended reliability).",
     "cosyvoice":     "git clone --recursive FunAudioLLM/CosyVoice + pip install -r requirements.txt + SoX",
     "kittentts":     "pip install kittentts  (ONNX, CPU-only, ~80 MB)",
     "mlx-audio":     "pip install mlx-audio  (Apple Silicon only)",

--- a/backend/tests/test_make_room_before_generate.py
+++ b/backend/tests/test_make_room_before_generate.py
@@ -1,0 +1,105 @@
+"""A warm, heavy generate must free idle GPU memory first (#730/#1190).
+
+The cold LOAD path already evicts via _make_room_before_tts_load (it runs inside
+_load_model_with_timeout). The warm path (model already resident, get_model
+returns early at the cache check) skipped it, so a long generate on a
+VRAM-tight MPS box contended with capture-ASR and the clone-prompt side cache
+until it exceeded the execution budget and was abandoned, which is exactly how
+one slow synth cascaded into a stuck, device-holding backend.
+make_room_before_generate closes that gap, behind a policy that is the one real
+reliability-vs-latency knob.
+"""
+import services.model_manager as mm
+from services.model_manager import make_room_before_generate
+
+
+def _count(monkeypatch):
+    """Patch the three eviction primitives and count how often each runs."""
+    calls = {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
+
+    monkeypatch.setattr(mm, "free_vram", lambda: calls.__setitem__("free_vram", calls["free_vram"] + 1))
+    monkeypatch.setattr(
+        mm, "release_tts_side_caches",
+        lambda: calls.__setitem__("side_caches", calls["side_caches"] + 1),
+    )
+    import services.asr_backend as ab
+    monkeypatch.setattr(
+        ab, "release_idle_capture_backend",
+        lambda _idle_s: calls.__setitem__("capture_asr", calls["capture_asr"] + 1),
+    )
+    return calls
+
+
+def _ram(monkeypatch, gb):
+    import services.memory_budget as mb
+    monkeypatch.setattr(mb, "available_memory", lambda: {"ram_available_gb": gb})
+
+
+def test_never_mode_frees_nothing(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", "never")
+    calls = _count(monkeypatch)
+    make_room_before_generate("a" * 5000)  # long text, but mode wins
+    assert calls == {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
+
+
+def test_always_mode_frees_all(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", "always")
+    calls = _count(monkeypatch)
+    make_room_before_generate("hi")
+    assert calls == {"free_vram": 1, "side_caches": 1, "capture_asr": 1}
+
+
+def test_auto_frees_on_long_text_when_ram_moderate(monkeypatch):
+    # Long text RAISES the headroom (6 -> 12 GB). At 8 GB free, a short synth
+    # would skip (8 >= 6) but a long one trips the raised bar (8 < 12).
+    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
+    _ram(monkeypatch, 8.0)
+    calls = _count(monkeypatch)
+    make_room_before_generate("a" * 1000)  # >= default 800-char threshold
+    assert calls["free_vram"] == 1 and calls["side_caches"] == 1
+
+
+def test_auto_long_text_skips_on_roomy_machine(monkeypatch):
+    # A genuinely roomy machine pays nothing even for long text (the docstring
+    # promise): 999 GB free is above even the raised 12 GB bar.
+    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
+    _ram(monkeypatch, 999.0)
+    calls = _count(monkeypatch)
+    make_room_before_generate("a" * 1000)
+    assert calls == {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
+
+
+def test_auto_skips_on_short_text_with_ample_ram(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
+    _ram(monkeypatch, 999.0)
+    calls = _count(monkeypatch)
+    make_room_before_generate("short text")
+    assert calls == {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
+
+
+def test_auto_frees_on_tight_ram(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
+    _ram(monkeypatch, 0.5)  # below the 6.0 GB unified headroom
+    calls = _count(monkeypatch)
+    make_room_before_generate("short text")
+    assert calls["free_vram"] == 1
+
+
+def test_malformed_long_text_env_does_not_disable_auto(monkeypatch):
+    # A non-numeric OMNIVOICE_FREE_VRAM_LONG_TEXT_CHARS must fall back, not
+    # silently disable the whole auto path (#730/#1190).
+    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
+    monkeypatch.setenv("OMNIVOICE_FREE_VRAM_LONG_TEXT_CHARS", "not-a-number")
+    _ram(monkeypatch, 0.5)  # tight RAM -> auto must still free despite the bad env
+    calls = _count(monkeypatch)
+    make_room_before_generate("short text")
+    assert calls["free_vram"] == 1
+
+
+def test_default_mode_is_auto(monkeypatch):
+    # No env set at all must behave as auto: long text at moderate RAM triggers.
+    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
+    _ram(monkeypatch, 8.0)
+    calls = _count(monkeypatch)
+    make_room_before_generate("a" * 1000)
+    assert calls["free_vram"] == 1

--- a/backend/tests/test_make_room_before_generate.py
+++ b/backend/tests/test_make_room_before_generate.py
@@ -1,12 +1,13 @@
-"""A warm, heavy generate must free idle GPU memory first (#730/#1190).
+"""A warm generate must free idle GPU memory first when the box is tight
+(#730/#1190).
 
-The cold LOAD path already evicts via _make_room_before_tts_load (it runs inside
+The cold LOAD path already evicts via _make_room_before_tts_load (inside
 _load_model_with_timeout). The warm path (model already resident, get_model
-returns early at the cache check) skipped it, so a long generate on a
-VRAM-tight MPS box contended with capture-ASR and the clone-prompt side cache
-until it exceeded the execution budget and was abandoned, which is exactly how
-one slow synth cascaded into a stuck, device-holding backend.
-make_room_before_generate closes that gap, behind a policy that is the one real
+returns early at the cache check) skipped it, so a generate on a VRAM-tight
+MPS box contended with capture-ASR and the clone-prompt side cache until it
+exceeded the execution budget and was abandoned (#730/#1190).
+make_room_before_generate, called from get_model()'s warm-return path, closes
+that gap for every native TTS generate; the policy is the one real
 reliability-vs-latency knob.
 """
 import services.model_manager as mm
@@ -38,42 +39,22 @@ def _ram(monkeypatch, gb):
 def test_never_mode_frees_nothing(monkeypatch):
     monkeypatch.setenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", "never")
     calls = _count(monkeypatch)
-    make_room_before_generate("a" * 5000)  # long text, but mode wins
+    make_room_before_generate()
     assert calls == {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
 
 
 def test_always_mode_frees_all(monkeypatch):
     monkeypatch.setenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", "always")
     calls = _count(monkeypatch)
-    make_room_before_generate("hi")
-    assert calls == {"free_vram": 1, "side_caches": 1, "capture_asr": 1}
+    make_room_before_generate()
+    assert calls["free_vram"] == 1 and calls["side_caches"] == 1 and calls["capture_asr"] == 1
 
 
-def test_auto_frees_on_long_text_when_ram_moderate(monkeypatch):
-    # Long text RAISES the headroom (6 -> 12 GB). At 8 GB free, a short synth
-    # would skip (8 >= 6) but a long one trips the raised bar (8 < 12).
+def test_auto_skips_on_roomy_machine(monkeypatch):
     monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
-    _ram(monkeypatch, 8.0)
+    _ram(monkeypatch, 999.0)  # ample RAM -> a roomy machine pays nothing
     calls = _count(monkeypatch)
-    make_room_before_generate("a" * 1000)  # >= default 800-char threshold
-    assert calls["free_vram"] == 1 and calls["side_caches"] == 1
-
-
-def test_auto_long_text_skips_on_roomy_machine(monkeypatch):
-    # A genuinely roomy machine pays nothing even for long text (the docstring
-    # promise): 999 GB free is above even the raised 12 GB bar.
-    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
-    _ram(monkeypatch, 999.0)
-    calls = _count(monkeypatch)
-    make_room_before_generate("a" * 1000)
-    assert calls == {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
-
-
-def test_auto_skips_on_short_text_with_ample_ram(monkeypatch):
-    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
-    _ram(monkeypatch, 999.0)
-    calls = _count(monkeypatch)
-    make_room_before_generate("short text")
+    make_room_before_generate()
     assert calls == {"free_vram": 0, "side_caches": 0, "capture_asr": 0}
 
 
@@ -81,25 +62,14 @@ def test_auto_frees_on_tight_ram(monkeypatch):
     monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
     _ram(monkeypatch, 0.5)  # below the 6.0 GB unified headroom
     calls = _count(monkeypatch)
-    make_room_before_generate("short text")
-    assert calls["free_vram"] == 1
-
-
-def test_malformed_long_text_env_does_not_disable_auto(monkeypatch):
-    # A non-numeric OMNIVOICE_FREE_VRAM_LONG_TEXT_CHARS must fall back, not
-    # silently disable the whole auto path (#730/#1190).
-    monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
-    monkeypatch.setenv("OMNIVOICE_FREE_VRAM_LONG_TEXT_CHARS", "not-a-number")
-    _ram(monkeypatch, 0.5)  # tight RAM -> auto must still free despite the bad env
-    calls = _count(monkeypatch)
-    make_room_before_generate("short text")
-    assert calls["free_vram"] == 1
+    make_room_before_generate()
+    assert calls["free_vram"] == 1 and calls["side_caches"] == 1
 
 
 def test_default_mode_is_auto(monkeypatch):
-    # No env set at all must behave as auto: long text at moderate RAM triggers.
+    # No env set at all must behave as auto (tight RAM triggers).
     monkeypatch.delenv("OMNIVOICE_FREE_VRAM_BEFORE_GENERATE", raising=False)
-    _ram(monkeypatch, 8.0)
+    _ram(monkeypatch, 0.5)
     calls = _count(monkeypatch)
-    make_room_before_generate("a" * 1000)
+    make_room_before_generate()
     assert calls["free_vram"] == 1

--- a/backend/tests/test_omnivoice_subprocess.py
+++ b/backend/tests/test_omnivoice_subprocess.py
@@ -1,0 +1,205 @@
+"""omnivoice-subprocess engine: registry wiring, recv-timeout override, and the
+hard-kill-on-timeout recovery that is the whole point of the engine (#730/#1190).
+
+The in-process engine's abandoned worker thread cannot be killed and holds the
+MPS device; a subprocess engine's child CAN be hard-killed (proc.kill() in
+SubprocessBackend._timeout_kill), reclaiming VRAM/device, and the next request
+respawns a fresh sidecar. The hard-kill test below is the deterministic proof,
+the direct counterpart to the in-process ThreadPoolExecutor reproducer where
+the zombie outlives the reset.
+
+CI stays model-free: the roundtrip/hard-kill tests spawn a stub sidecar that
+speaks the wire protocol and either returns a sine wave or wedges forever
+(text == "HANG"), instead of loading the multi-GB OmniVoice model.
+"""
+import struct
+import json
+import math
+import array
+import base64
+
+import pytest
+
+from services.subprocess_backend import SubprocessBackend, RECV_TIMEOUT_S
+from services.tts_backend import get_backend_class
+from engines.omnivoice_subprocess import OmniVoiceSubprocessBackend
+
+
+# ── stub sidecar (model-free) ──────────────────────────────────────────────
+
+STUB_SIDECAR = r'''
+import sys, json, struct, time, math, array, base64
+
+def _send(o):
+    b = json.dumps(o, separators=(",", ":")).encode()
+    sys.stdout.buffer.write(struct.pack("!I", len(b)) + b)
+    sys.stdout.buffer.flush()
+
+def _recv():
+    h = sys.stdin.buffer.read(4)
+    if len(h) < 4:
+        return None
+    (n,) = struct.unpack("!I", h)
+    body = bytearray()
+    while len(body) < n:
+        c = sys.stdin.buffer.read(n - len(body))
+        if not c:
+            return None
+        body.extend(c)
+    return json.loads(bytes(body).decode())
+
+_send({"op": "ready", "engine": "omnivoice-subprocess", "sample_rate": 24000})
+while True:
+    m = _recv()
+    if m is None:
+        sys.exit(0)
+    op = m.get("op")
+    if op == "ping":
+        _send({"op": "pong", "vram_mb": 0.0})
+    elif op == "shutdown":
+        sys.exit(0)
+    elif op == "synthesize":
+        t = m.get("text", "")
+        if t == "HANG":
+            while True:  # wedge forever; the parent must hard-kill us
+                time.sleep(1)
+        # Emit progress frames before the audio when asked, to exercise the
+        # parent's progress-consuming recv loop (the cold-load fix).
+        if t.startswith("PROG:"):
+            for p in (10, 50, 90):
+                _send({"op": "progress", "stage": "loading_model", "percent": p})
+        sr = 24000
+        pcm = array.array("h", (int(32767 * math.sin(2 * math.pi * 440 * i / sr)) for i in range(sr)))
+        _send({"op": "audio", "audio_pcm_b64": base64.b64encode(pcm.tobytes()).decode(),
+               "sample_rate": sr, "n_samples": sr})
+    else:
+        _send({"op": "error", "stage": "dispatch", "message": "unknown op %r" % op})
+'''
+
+
+@pytest.fixture
+def stub_sidecar(tmp_path):
+    p = tmp_path / "stub_sidecar.py"
+    p.write_text(STUB_SIDECAR)
+    return p
+
+
+def _use_stub(monkeypatch, stub_path):
+    monkeypatch.setattr(
+        OmniVoiceSubprocessBackend, "sidecar_script",
+        classmethod(lambda cls: stub_path),
+    )
+
+
+# ── registry + isolation ───────────────────────────────────────────────────
+
+
+def test_registry_resolves_to_subprocess_backend():
+    assert get_backend_class("omnivoice-subprocess") is OmniVoiceSubprocessBackend
+
+
+def test_is_marked_subprocess_isolated():
+    # list_backends() detects isolation via this duck-typed marker, not issubclass.
+    assert getattr(OmniVoiceSubprocessBackend, "_is_subprocess_isolated", False) is True
+
+
+def test_is_available_returns_tuple():
+    ok, msg = OmniVoiceSubprocessBackend.is_available()
+    assert isinstance(ok, bool)
+    assert isinstance(msg, str)
+
+
+# ── recv-timeout override (the F1-1 base-class hook) ───────────────────────
+
+
+class _PlainBackend(SubprocessBackend):
+    """Minimal concrete subclass that does NOT override recv_timeout_s."""
+    id = "plain"
+
+    @classmethod
+    def is_available(cls):
+        return True, "ok"
+
+    @property
+    def sample_rate(self):
+        return 24000
+
+    @property
+    def supported_languages(self):
+        return ["multi"]
+
+
+def test_base_default_recv_timeout_is_60s():
+    # A subclass that does NOT override keeps the conservative default, so the
+    # existing subprocess engines (IndexTTS, dots.tts, ...) are byte-identical.
+    assert SubprocessBackend.recv_timeout_s == RECV_TIMEOUT_S == 60.0
+    assert _PlainBackend().recv_timeout_s == 60.0
+
+
+def test_omnivoice_subprocess_recv_timeout_overrides_default():
+    b = OmniVoiceSubprocessBackend()
+    assert b.recv_timeout_s == 300.0  # aligns with the generate budget
+
+
+def test_omnivoice_subprocess_recv_timeout_env_override(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SIDECAR_RECV_TIMEOUT_S", "120")
+    assert OmniVoiceSubprocessBackend().recv_timeout_s == 120.0
+
+
+def test_omnivoice_subprocess_recv_timeout_floors_at_30s(monkeypatch):
+    # A misconfigured tiny value must still leave time for a real handshake.
+    monkeypatch.setenv("OMNIVOICE_SIDECAR_RECV_TIMEOUT_S", "1")
+    assert OmniVoiceSubprocessBackend().recv_timeout_s == 30.0
+
+
+# ── roundtrip via the stub sidecar ─────────────────────────────────────────
+
+
+def test_roundtrip_synthesize_returns_audio_tensor(stub_sidecar, monkeypatch):
+    _use_stub(monkeypatch, stub_sidecar)
+    b = OmniVoiceSubprocessBackend()
+    try:
+        tensor = b.generate("hello")
+        assert tensor.shape[0] == 1              # (1, n_samples)
+        assert tensor.shape[1] == 24000          # 1s of 24 kHz from the stub
+        assert tensor.abs().max() > 0.0          # non-silent sine
+    finally:
+        b.shutdown()
+
+
+def test_generate_consumes_progress_frames_before_audio(stub_sidecar, monkeypatch):
+    # Regression for the cold-load bug: a sidecar that emits {"op": "progress"}
+    # frames (as the real one does during a model load) before the audio frame
+    # must NOT make generate() raise "unexpected op". The base loops on progress.
+    _use_stub(monkeypatch, stub_sidecar)
+    b = OmniVoiceSubprocessBackend()
+    try:
+        tensor = b.generate("PROG:hello")  # stub emits 3 progress frames first
+        assert tensor.shape[1] == 24000    # got the audio despite the progress
+    finally:
+        b.shutdown()
+
+
+# ── hard-kill on timeout + recovery (the load-bearing regression) ──────────
+
+
+def test_wedged_sidecar_is_hard_killed_and_recovers(stub_sidecar, monkeypatch):
+    _use_stub(monkeypatch, stub_sidecar)
+    # Short effective timeout so the test is fast. The property floors env at
+    # 30s, so drive the watchdog directly via the class attribute the base reads.
+    monkeypatch.setattr(OmniVoiceSubprocessBackend, "recv_timeout_s",
+                        property(lambda self: 2.0))
+    b = OmniVoiceSubprocessBackend()
+    try:
+        # 1. A wedged generate raises (the watchdog kills the child at 2s, the
+        #    pipe closes, _recv returns None -> "closed pipe").
+        with pytest.raises(RuntimeError):
+            b.generate("HANG")
+        # 2. The child is actually dead, the thing the in-process engine cannot do.
+        assert b._proc is not None
+        assert b._proc.poll() is not None
+        # 3. Recovery: the next generate respawns a fresh sidecar and succeeds.
+        tensor = b.generate("ok")
+        assert tensor.shape[1] == 24000
+    finally:
+        b.shutdown()

--- a/backend/tests/test_omnivoice_subprocess.py
+++ b/backend/tests/test_omnivoice_subprocess.py
@@ -203,3 +203,22 @@ def test_wedged_sidecar_is_hard_killed_and_recovers(stub_sidecar, monkeypatch):
         assert tensor.shape[1] == 24000
     finally:
         b.shutdown()
+
+
+def test_generate_does_not_deadlock_when_called_on_gpu_pool_worker(stub_sidecar, monkeypatch):
+    # Regression: /v1/audio/speech and /generate dispatch backend.generate() via
+    # run_on_gpu_pool_guarded, i.e. ON a gpu-pool worker. generate() must NOT
+    # acquire a second slot from the same 1-worker pool (self-deadlock on MPS):
+    # before the fix, the inner pool.submit queued behind this very job and
+    # slot_future.result(timeout=10) raised before the sidecar ever spawned.
+    _use_stub(monkeypatch, stub_sidecar)
+    from services.model_manager import _get_gpu_pool
+    b = OmniVoiceSubprocessBackend()
+    pool = _get_gpu_pool()
+    try:
+        # Mirror run_on_gpu_pool_guarded: run generate() on a pool worker thread.
+        fut = pool.submit(lambda: b.generate("on-pool"))
+        tensor = fut.result(timeout=30)  # pre-fix: raised ~10s slot timeout
+        assert tensor.shape[1] == 24000
+    finally:
+        b.shutdown()

--- a/docs/engines/omnivoice-subprocess.md
+++ b/docs/engines/omnivoice-subprocess.md
@@ -1,0 +1,72 @@
+# OmniVoice (subprocess-isolated) Engine
+
+The `omnivoice-subprocess` engine runs the **same resident OmniVoice model** as
+the default `omnivoice` engine, but in a **crash-isolated child process** so a
+wedged generation can be hard-killed and its VRAM/device reclaimed.
+
+## Why this engine exists
+
+The default `omnivoice` engine runs in-process on the GPU worker pool. On
+VRAM-tight machines (Apple Silicon MPS especially) a heavy generation or model
+load can exceed its execution budget. When that happens the worker is
+"abandoned" but **cannot be killed** (Python cannot interrupt a native torch /
+MPS call), so it keeps holding the GPU device until it finishes on its own, and
+every later synth queues behind it and hangs (#730 / #1190).
+
+`omnivoice-subprocess` runs the model in a child process spawned via the same
+`SubprocessBackend` primitive used by IndexTTS, Supertonic-3, and dots.tts. A
+child process **can** be hard-killed: on a timeout the parent kills it
+(`proc.kill()`), freeing its VRAM/device, and the next request transparently
+respawns a fresh sidecar. That is the one thing the in-process engine
+structurally cannot do.
+
+## When to use it
+
+- **Unattended / scheduled / reaction-triggered synthesis** where a stuck job
+  must recover on its own instead of hanging until a manual restart.
+- **VRAM-starved MPS hosts** that hit the abandoned-worker cascade.
+
+For interactive single-shot use on a machine with comfortable VRAM, the default
+in-process `omnivoice` engine is faster (no stdio round-trip) and remains the
+default.
+
+## Selecting it
+
+- **Settings -> Engines**, or
+- `OMNIVOICE_TTS_BACKEND=omnivoice-subprocess`
+
+It is **opt-in**; the in-process engine stays the default, so existing setups
+see no change.
+
+## Platform support
+
+- **CUDA, MPS, and CPU** (same as the in-process OmniVoice engine).
+- **No extra install.** Unlike IndexTTS / dots.tts / Supertonic-3, this sidecar
+  runs under OmniVoice's own interpreter, because the goal here is crash
+  isolation, not dependency isolation. If the default `omnivoice` engine works
+  for you, this one is ready too.
+
+## Tradeoffs vs the in-process `omnivoice` engine
+
+- **Identical model and output quality.**
+- Slightly higher per-call latency (one stdio round-trip per synth).
+- A wedged generation is **killed and recovered** at the recv-timeout deadline
+  (`OMNIVOICE_SIDECAR_RECV_TIMEOUT_S`, default 300s, aligned with the generate
+  budget) instead of hanging indefinitely.
+- It does **not** carry the native advanced-parameter surface
+  (`t_shift` / `layer_penalty_factor` / `position_temperature` /
+  `class_temperature`) or parent-side seed determinism, because the generic
+  engine path does not forward those. For plain voice-clone and design
+  synthesis this is a non-issue.
+- The recv-timeout deadline is per call and assumes the route's text chunking:
+  `/generate` and `/v1/audio/speech` split long text into pieces of at most
+  `max_chunk_chars` before calling the engine, so each call stays short. A
+  single very long unchunked `generate()` can exceed the deadline and be killed;
+  that is the watchdog working as intended, not a hang.
+
+## Tuning
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `OMNIVOICE_SIDECAR_RECV_TIMEOUT_S` | `300` | Seconds to wait for a synth frame before hard-killing the sidecar (floored at 30s). |
+| `OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S` | `300` | Idle seconds before the sidecar is reaped to free its VRAM (shared with all subprocess engines). |

--- a/docs/features.yaml
+++ b/docs/features.yaml
@@ -29,6 +29,8 @@ features:
 tts_engines:
   - id: omnivoice
     readme: "**OmniVoice** (default)"
+  - id: omnivoice-subprocess
+    doc: docs/engines/omnivoice-subprocess.md
   - id: cosyvoice
     readme: CosyVoice 3
     doc: docs/engines/cosyvoice.md


### PR DESCRIPTION
Closes #1291.

## Why

#730 and #1190 are closed, but the residual root cause remains: the GPU worker is a `ThreadPoolExecutor` thread, and on a timeout the pool reset can't kill it (Python can't interrupt a native torch/MPS call). The abandoned worker holds the device until it finishes on its own, so an immediate retry still contends with the zombie, and on a VRAM-tight MPS box one slow synth can cascade into a stuck backend until a manual restart.

## What

Adds an **opt-in** `omnivoice-subprocess` engine that runs the same model in a child process via the existing `SubprocessBackend`. A child process can be hard-killed: on a recv-timeout the parent's watchdog calls `proc.kill()`, reclaiming VRAM/device, and the next request transparently respawns a fresh sidecar. The in-process `omnivoice` engine stays the default, so there is no behavior change for existing users; this targets unattended / scheduled / reaction-triggered use where a stuck job must self-recover.

### Changed
- **New engine** `omnivoice-subprocess` (`backend/engines/omnivoice_subprocess/`): the sidecar loads the model via the parent's own `from_pretrained` path (`venv_python` = `sys.executable`, isolating for crash recovery rather than dependency pins). Opt-in via `OMNIVOICE_TTS_BACKEND=omnivoice-subprocess` or Settings -> Engines.
- **`SubprocessBackend.generate()`** now consumes non-terminal `{"op":"progress"}` frames a sidecar emits during a cold load (previously the first cold generate after spawn failed, then worked on retry). Additive: engines that reply with audio directly are unaffected.
- **`recv_timeout_s`** is overridable per engine (default 60s unchanged); the new engine aligns it with the generate budget so a long-but-valid synth is not falsely killed while a wedged one still is.
- **`make_room_before_generate()`**: free idle GPU memory before a warm, heavy generate (the cold-load path already evicted; the warm path skipped it). Env-tunable, no-op on a roomy machine.

### Tests / verification
- Unit: `test_omnivoice_subprocess.py` (registry, recv-timeout override, roundtrip, **hard-kill + recovery**, progress-loop) and `test_make_room_before_generate.py` (policy incl. malformed-env). 18 new tests; the repo's version-lockstep / CJK / analytics / docs-drift gates also green.
- End-to-end on the live model (cold / warm / recovery-after-kill) and a sustained + concurrent-pressure soak: killed-worker recovery 5/5, chunked long text 9/9, no memory leak.
- Docs: `docs/engines/omnivoice-subprocess.md` + a `docs/features.yaml` entry.

### Notes
- Same model and output quality as the default engine; slightly higher per-call overhead (one stdio round-trip). Does not carry the native advanced-param surface (`t_shift` etc.) or parent-side seed determinism, since the generic engine path doesn't forward those. Fine for clone/design synthesis.
- A complement to the existing reset/messaging mitigations, not a replacement.

Happy to split the PR (engine vs `make_room`) or rename if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds an opt-in `omnivoice-subprocess` TTS engine that runs OmniVoice in a crash-isolated child process via `SubprocessBackend`, hard-killing/respawning on receive timeouts and correctly handling cold-load progress frames and per-engine (env-overridable) receive-timeout settings. Centralizes VRAM/idle GPU memory “make room” behavior into `get_model()` with an `OMNIVOICE_FREE_VRAM_BEFORE_GENERATE` (auto/always/never) policy, and updates docs/tests to cover registration, protocol roundtrips, progress consumption, timeout recovery, and the warm-path memory policy. Main risk to review: subprocess stdio protocol/lifecycle correctness under progress + wedged-process timeout recovery, and the RAM-probe decisioning that gates VRAM eviction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->