### PR TITLE
fix(engines): stop SubprocessBackend.generate() self-deadlock on 1-worker (MPS) pools

### DIFF
--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -518,20 +518,24 @@ class SubprocessBackend(TTSBackend):
         sample rate. Decodes the int16 PCM the sidecar returns into float32
         in [-1, 1].
         """
-        # Lazy-import the GPU pool so importing this module doesn't pull in
-        # the entire model_manager + torch ecosystem at registry-listing time.
-        from services.model_manager import _get_gpu_pool
-
-        # Acquire a GPU pool worker for the duration of this generate. The
-        # try/finally guarantees the slot is released even if the sidecar
-        # dies mid-frame (T-02-02 / Pitfall 7).
-        pool = _get_gpu_pool()
-        slot_future = pool.submit(lambda: None)
-        try:
-            slot_future.result(timeout=10)  # wait for our turn
-        except Exception:
-            slot_future.cancel()
-            raise
+        # The HTTP routes, audiobook, dub, and batch all dispatch generate() via
+        # run_on_gpu_pool_guarded, i.e. already on a gpu-pool worker. On a
+        # 1-worker pool (MPS) a second slot submit would queue behind this very
+        # job and self-deadlock (.result(timeout=10) fires, no sidecar spawns),
+        # so skip the slot when already on the pool. The off-pool callers (the
+        # engine self-test and the diagnostic probe) still take a slot as a
+        # queue wait, so they yield to an in-flight pool job instead of racing.
+        if not threading.current_thread().name.startswith("gpu-pool"):
+            # Lazy-import the GPU pool so importing this module doesn't pull in
+            # the entire model_manager + torch ecosystem at registry-listing time.
+            from services.model_manager import _get_gpu_pool
+            pool = _get_gpu_pool()
+            slot_future = pool.submit(lambda: None)
+            try:
+                slot_future.result(timeout=10)  # wait for our turn
+            except Exception:
+                slot_future.cancel()
+                raise
 
         try:
             with self._lock:

--- a/backend/tests/test_subprocess_slot_deadlock.py
+++ b/backend/tests/test_subprocess_slot_deadlock.py
@@ -1,0 +1,109 @@
+"""Regression: SubprocessBackend.generate() must not self-deadlock when called
+from a gpu-pool worker.
+
+/v1/audio/speech and /generate dispatch backend.generate() via
+run_on_gpu_pool_guarded, i.e. already ON a gpu-pool worker. generate() used to
+unconditionally submit a no-op to the same pool to "acquire a slot"; on a
+1-worker pool (MPS) that submit queued behind the very job running it and
+result(timeout=10) raised before the sidecar spawned. This test reproduces that
+dispatch shape (generate on a pool worker) against a stub sidecar.
+"""
+import base64
+import json
+import math
+import array
+import sys
+from pathlib import Path
+
+import pytest
+
+from services.model_manager import _get_gpu_pool
+from services.subprocess_backend import SubprocessBackend
+
+# Model-free stub sidecar: speaks the length-prefixed-JSON protocol and returns
+# a 1s sine wave for any synthesize.
+STUB_SIDECAR = r'''
+import sys, json, struct, math, array, base64
+
+def _send(o):
+    b = json.dumps(o, separators=(",", ":")).encode()
+    sys.stdout.buffer.write(struct.pack("!I", len(b)) + b)
+    sys.stdout.buffer.flush()
+
+def _recv():
+    h = sys.stdin.buffer.read(4)
+    if len(h) < 4:
+        return None
+    (n,) = struct.unpack("!I", h)
+    body = bytearray()
+    while len(body) < n:
+        c = sys.stdin.buffer.read(n - len(body))
+        if not c:
+            return None
+        body.extend(c)
+    return json.loads(bytes(body).decode())
+
+_send({"op": "ready", "engine": "stub", "sample_rate": 24000})
+while True:
+    m = _recv()
+    if m is None:
+        sys.exit(0)
+    op = m.get("op")
+    if op == "ping":
+        _send({"op": "pong", "vram_mb": 0.0})
+    elif op == "shutdown":
+        sys.exit(0)
+    elif op == "synthesize":
+        sr = 24000
+        pcm = array.array("h", (int(32767 * math.sin(2 * math.pi * 440 * i / sr)) for i in range(sr)))
+        _send({"op": "audio", "audio_pcm_b64": base64.b64encode(pcm.tobytes()).decode(),
+               "sample_rate": sr, "n_samples": sr})
+    else:
+        _send({"op": "error", "stage": "dispatch", "message": "unknown op %r" % op})
+'''
+
+
+class _StubSubprocessBackend(SubprocessBackend):
+    """Minimal concrete SubprocessBackend pointing at the stub sidecar."""
+    id = "stub-subprocess"
+    display_name = "stub"
+    gpu_compat = ("cuda", "mps", "cpu")
+
+    @classmethod
+    def is_available(cls):
+        return True, "ok"
+
+    @classmethod
+    def venv_python(cls):
+        return Path(sys.executable)
+
+    @classmethod
+    def sidecar_script(cls):
+        raise NotImplementedError  # patched per-test
+
+    @property
+    def sample_rate(self):
+        return 24000
+
+    @property
+    def supported_languages(self):
+        return ["multi"]
+
+
+def test_generate_on_pool_worker_does_not_deadlock(tmp_path, monkeypatch):
+    # Mirror /v1/audio/speech + /generate: dispatch generate() ON a gpu-pool
+    # worker. Pre-fix: the inner pool.submit queued behind this job and
+    # slot_future.result(timeout=10) raised at ~10s, before the sidecar spawned.
+    stub = tmp_path / "stub_sidecar.py"
+    stub.write_text(STUB_SIDECAR)
+    monkeypatch.setattr(_StubSubprocessBackend, "sidecar_script",
+                        classmethod(lambda cls: stub))
+
+    b = _StubSubprocessBackend()
+    pool = _get_gpu_pool()
+    try:
+        fut = pool.submit(lambda: b.generate("on-pool"))
+        tensor = fut.result(timeout=30)  # pre-fix: raised ~10s slot timeout
+        assert tensor.shape[1] == 24000
+    finally:
+        b.shutdown()

--- a/backend/tests/test_subprocess_slot_deadlock.py
+++ b/backend/tests/test_subprocess_slot_deadlock.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import pytest
 
-from services.model_manager import _get_gpu_pool
 from services.subprocess_backend import SubprocessBackend
 
 # Model-free stub sidecar: speaks the length-prefixed-JSON protocol and returns
@@ -92,18 +91,26 @@ class _StubSubprocessBackend(SubprocessBackend):
 
 def test_generate_on_pool_worker_does_not_deadlock(tmp_path, monkeypatch):
     # Mirror /v1/audio/speech + /generate: dispatch generate() ON a gpu-pool
-    # worker. Pre-fix: the inner pool.submit queued behind this job and
-    # slot_future.result(timeout=10) raised at ~10s, before the sidecar spawned.
+    # worker. Force a 1-worker pool so the self-deadlock reproduces
+    # deterministically regardless of host (the ambient pool may have >1
+    # worker): pre-fix, generate()'s inner slot-submit queued behind this very
+    # job and slot_future.result(timeout=10) raised at ~10s, before the sidecar
+    # spawned.
     stub = tmp_path / "stub_sidecar.py"
     stub.write_text(STUB_SIDECAR)
     monkeypatch.setattr(_StubSubprocessBackend, "sidecar_script",
                         classmethod(lambda cls: stub))
 
+    from concurrent.futures import ThreadPoolExecutor
+    import services.model_manager as mm
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu-pool")
+    monkeypatch.setattr(mm, "_get_gpu_pool", lambda: pool)
+
     b = _StubSubprocessBackend()
-    pool = _get_gpu_pool()
     try:
         fut = pool.submit(lambda: b.generate("on-pool"))
         tensor = fut.result(timeout=30)  # pre-fix: raised ~10s slot timeout
         assert tensor.shape[1] == 24000
     finally:
         b.shutdown()
+        pool.shutdown(wait=False)


### PR DESCRIPTION
Closes #1295.

`SubprocessBackend.generate()` acquires a GPU-pool slot for accounting, but `/v1/audio/speech` and `/generate` (and audiobook / dub / batch) dispatch `backend.generate()` via `run_on_gpu_pool_guarded`, already ON a pool worker. On a 1-worker pool (MPS) the inner `pool.submit` queues behind the very job running it and `result(timeout=10)` raises before the sidecar spawns, so every subprocess engine (IndexTTS-2, Supertonic-3, dots.tts, MOSS-TTS-v1.5, Confucius4) surfaces the in-process 300s-abandon instead of synthesizing.

### Changed
- `generate()` skips the slot acquisition when `current_thread()` is already a gpu-pool worker; the outer `run_on_gpu_pool_guarded` already accounts for the slot (it holds `_running` for the whole sidecar exchange via `_tracked`). Direct off-pool callers (the engine self-test in `engines.py`, the diagnostic probe in `diagnose.py`) still take a slot as a queue wait.

### Tests / verification
- New regression test: `backend/tests/test_subprocess_slot_deadlock.py` (generate dispatched on a pool worker; pre-fix it raised the ~10s slot timeout before the sidecar spawned).
- Verified end-to-end on a live MPS server: `/v1/audio/speech` returns HTTP 200 with real audio, sidecar spawns.

### Notes
- Independent of #1292 (the omnivoice-subprocess feature, which carries the same fix at `e9a15d53`). This PR is the standalone general bug fix; if it merges first, #1292 rebases onto it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `SubprocessBackend.generate()` to skip the inner GPU-pool “slot” acquisition when the call already runs on a `gpu-pool` worker thread, preventing self-deadlock on one-worker pools (including MPS) while keeping slot accounting for direct off-pool callers. Added a regression test that monkeypatches `_get_gpu_pool` to a deterministic one-worker `gpu-pool` thread pool and uses a stub sidecar to assert `generate()` completes and returns the expected audio length without timing out. Risk is mainly the thread-name-based `gpu-pool` detection, which should be reviewed for brittleness across pool implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->