### PR TITLE
fix(engines): path-aware GPU-pool slot in SubprocessBackend.generate() (on-pool skip + off-pool hold)

### DIFF
--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -107,9 +107,28 @@ def _pick_gpu_workers() -> int:
     return 1
 
 
+# thread_name_prefix for the GPU pool, centralised so the "am I on a gpu-pool
+# worker?" predicates (running_on_gpu_pool below; SubprocessBackend.generate's
+# on-pool skip) cannot drift from the pool's actual prefix. A drift would
+# silently re-introduce the 1-worker self-deadlock this couples against.
+_GPU_POOL_THREAD_PREFIX = "gpu-pool"
+
+
 def _build_gpu_pool() -> ThreadPoolExecutor:
     workers = _pick_gpu_workers()
-    return ThreadPoolExecutor(max_workers=workers, thread_name_prefix="gpu-pool")
+    return ThreadPoolExecutor(
+        max_workers=workers, thread_name_prefix=_GPU_POOL_THREAD_PREFIX)
+
+
+def running_on_gpu_pool() -> bool:
+    """True iff the calling thread is a gpu-pool worker (already holds a slot).
+
+    Routes that dispatch backend work via run_on_gpu_pool_guarded are already on
+    a pool worker; re-acquiring a slot there would self-deadlock on a 1-worker
+    pool (MPS). Used by SubprocessBackend.generate()'s on-pool skip and by
+    _heal_tts_placement.
+    """
+    return threading.current_thread().name.startswith(_GPU_POOL_THREAD_PREFIX)
 
 
 class _ResilientGpuPool(Executor):
@@ -2114,7 +2133,7 @@ async def _heal_tts_placement() -> None:
     """
     if _stranded_tts_target() is None:
         return
-    if threading.current_thread().name.startswith("gpu-pool"):
+    if running_on_gpu_pool():
         # Reached from a GPU-pool thread — OmniVoiceBackend._ensure_loaded()
         # bootstraps a fresh loop with asyncio.run(get_model()) from inside
         # generate(). We already hold the GPU slot, so we already have the

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -521,11 +521,13 @@ class SubprocessBackend(TTSBackend):
         # On-pool callers (every HTTP/dub/batch generate, dispatched via
         # run_on_gpu_pool_guarded) already own a pool slot; re-acquiring would
         # self-deadlock on a 1-worker (MPS) pool, so skip it. Off-pool callers
-        # (the engine self-test in engines.py, the diagnostic probe in
-        # diagnose.py) hold a real slot for the whole synthesis via _occupy so
-        # they serialize against pool jobs instead of over-subscribing the GPU.
+        # (the deep-synth diagnostic probe in diagnose.py; the Settings
+        # self-test rejects subprocess-isolated engines with a 400) hold a real
+        # slot for the whole synthesis via _occupy so they serialize against
+        # pool jobs instead of over-subscribing the GPU.
+        from services.model_manager import running_on_gpu_pool
         _held = None
-        if not threading.current_thread().name.startswith("gpu-pool"):
+        if not running_on_gpu_pool():
             # Lazy-import the GPU pool so importing this module doesn't pull in
             # the entire model_manager + torch ecosystem at registry-listing time.
             from services.model_manager import _get_gpu_pool

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -518,22 +518,31 @@ class SubprocessBackend(TTSBackend):
         sample rate. Decodes the int16 PCM the sidecar returns into float32
         in [-1, 1].
         """
-        # Lazy-import the GPU pool so importing this module doesn't pull in
-        # the entire model_manager + torch ecosystem at registry-listing time.
-        from services.model_manager import _get_gpu_pool
+        # On-pool callers (every HTTP/dub/batch generate, dispatched via
+        # run_on_gpu_pool_guarded) already own a pool slot; re-acquiring would
+        # self-deadlock on a 1-worker (MPS) pool, so skip it. Off-pool callers
+        # (the engine self-test in engines.py, the diagnostic probe in
+        # diagnose.py) hold a real slot for the whole synthesis via _occupy so
+        # they serialize against pool jobs instead of over-subscribing the GPU.
+        _held = None
+        if not threading.current_thread().name.startswith("gpu-pool"):
+            # Lazy-import the GPU pool so importing this module doesn't pull in
+            # the entire model_manager + torch ecosystem at registry-listing time.
+            from services.model_manager import _get_gpu_pool
+            pool = _get_gpu_pool()
+            _held = threading.Event()
+            _acquired = threading.Event()
 
-        # Acquire a GPU pool worker for the duration of this generate. The
-        # try/finally guarantees the slot is released even if the sidecar
-        # dies mid-frame (T-02-02 / Pitfall 7).
-        pool = _get_gpu_pool()
-        slot_future = pool.submit(lambda: None)
-        try:
-            slot_future.result(timeout=10)  # wait for our turn
-        except Exception:
-            slot_future.cancel()
-            raise
+            def _occupy():
+                _acquired.set()
+                _held.wait()
+
+            slot_future = pool.submit(_occupy)
 
         try:
+            if _held is not None and not _acquired.wait(timeout=10):
+                slot_future.cancel()
+                raise TimeoutError("timed out waiting for a free GPU worker")
             with self._lock:
                 self._spawn()
                 msg = {"op": "synthesize", "text": text}
@@ -561,12 +570,11 @@ class SubprocessBackend(TTSBackend):
             tensor = torch.from_numpy(arr.copy()).unsqueeze(0)
             return tensor
         finally:
-            # Slot is released the instant this thread leaves the pool's
-            # task — by holding slot_future we kept one worker busy; nothing
-            # further to do. (ThreadPoolExecutor doesn't expose a manual
-            # release; the slot returns to the pool when our submitted no-op
-            # finishes, which happens immediately after .result() above.)
-            pass
+            # Release the held GPU-pool worker (off-pool path only). _occupy
+            # blocks the worker until this fires, so the slot is held for the
+            # whole synthesis even though this thread isn't the pool worker.
+            if _held is not None:
+                _held.set()
 
     # ── wire protocol ──────────────────────────────────────────────────────
 

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -527,6 +527,11 @@ class SubprocessBackend(TTSBackend):
         # pool jobs instead of over-subscribing the GPU.
         from services.model_manager import running_on_gpu_pool
         _held = None
+        # Bound before the branch: only the off-pool path assigns a real
+        # future, and `_held is not None` already implies that — but CodeQL
+        # (py/uninitialized-local-variable) reads the two as independent, and
+        # so would anyone adding a third exit path later.
+        slot_future = None
         if not running_on_gpu_pool():
             # Lazy-import the GPU pool so importing this module doesn't pull in
             # the entire model_manager + torch ecosystem at registry-listing time.
@@ -543,7 +548,8 @@ class SubprocessBackend(TTSBackend):
 
         try:
             if _held is not None and not _acquired.wait(timeout=10):
-                slot_future.cancel()
+                if slot_future is not None:
+                    slot_future.cancel()
                 raise TimeoutError("timed out waiting for a free GPU worker")
             with self._lock:
                 self._spawn()

--- a/backend/tests/test_off_pool_slot_hold.py
+++ b/backend/tests/test_off_pool_slot_hold.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,29 @@ def test_off_pool_generate_holds_slot_for_synthesis(tmp_path, monkeypatch):
 
     import services.model_manager as mm
     pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu-pool")
+
+    # Signalled the moment the slot-holding task actually STARTS on the worker.
+    # A sleep here is not synchronization: too short and the marker is enqueued
+    # before the generator has reserved anything (the assertion then passes for
+    # the wrong reason on a slow runner), too long and the test just idles.
+    occupying = threading.Event()
+    _real_submit = pool.submit
+    _wrapped = {"done": False}
+
+    def _tracking_submit(fn, *a, **k):
+        # Only the FIRST submit is the generator's slot claim; the marker below
+        # must go through untouched.
+        if _wrapped["done"]:
+            return _real_submit(fn, *a, **k)
+        _wrapped["done"] = True
+
+        def _seen(*aa, **kk):
+            occupying.set()
+            return fn(*aa, **kk)
+
+        return _real_submit(_seen, *a, **k)
+
+    monkeypatch.setattr(pool, "submit", _tracking_submit)
     monkeypatch.setattr(mm, "_get_gpu_pool", lambda: pool)
 
     b = _StubBackend()
@@ -111,19 +135,22 @@ def test_off_pool_generate_holds_slot_for_synthesis(tmp_path, monkeypatch):
             box["error"] = exc
 
     gen_thread = threading.Thread(target=_gen, name="off-pool-caller", daemon=True)
-    gen_thread.start()
-    time.sleep(0.8)  # let it acquire the slot and reach the stub's sleep
+    try:
+        gen_thread.start()
+        assert occupying.wait(timeout=30), "off-pool generate never claimed a slot"
 
-    # A second pool job must NOT run while the off-pool generate holds the
-    # 1-worker pool's slot. Pre-fix (bare no-op), the worker was already free
-    # and this would complete immediately.
-    marker = pool.submit(lambda: "ran")
-    time.sleep(0.5)
-    assert not marker.done(), "pool job ran during the off-pool synth (slot was not held)"
+        # A second pool job must NOT run while the off-pool generate holds the
+        # 1-worker pool's slot. Pre-fix (bare no-op), the worker was already
+        # free and this would complete immediately.
+        marker = pool.submit(lambda: "ran")
+        with pytest.raises(FuturesTimeoutError):
+            marker.result(timeout=1.0)
 
-    gen_thread.join(timeout=30)
-    assert "error" not in box, f"generate failed: {box.get('error')}"
-    assert marker.result(timeout=5) == "ran"  # ran once the slot was released
-
-    b.shutdown()
-    pool.shutdown(wait=False)
+        gen_thread.join(timeout=30)
+        assert "error" not in box, f"generate failed: {box.get('error')}"
+        assert marker.result(timeout=10) == "ran"  # ran once the slot released
+    finally:
+        # Runs even when an assertion above fails — otherwise a red test leaks
+        # a sidecar process and a pool thread into the rest of the session.
+        b.shutdown()
+        pool.shutdown(wait=False)

--- a/backend/tests/test_off_pool_slot_hold.py
+++ b/backend/tests/test_off_pool_slot_hold.py
@@ -1,0 +1,129 @@
+"""Regression: an off-pool SubprocessBackend.generate() must HOLD its GPU-pool
+slot for the whole synthesis, not just queue-wait.
+
+Pre-fix, the slot was a bare no-op that completed the instant a worker picked
+it up, releasing the worker before _spawn(). So an off-pool caller (engine
+self-test, diagnostics) could synthesize concurrently with an in-flight pool
+job and over-subscribe a 1-worker GPU. This test reproduces that: while an
+off-pool generate is mid-synthesis, a second pool job must stay blocked.
+"""
+import base64
+import json
+import math
+import array
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from services.subprocess_backend import SubprocessBackend
+
+# Stub sidecar that SLEEPS during synthesize so the test can observe whether
+# the slot is held for the synth duration.
+STUB_SIDECAR = r'''
+import sys, json, struct, math, array, base64, time
+
+def _send(o):
+    b = json.dumps(o, separators=(",", ":")).encode()
+    sys.stdout.buffer.write(struct.pack("!I", len(b)) + b)
+    sys.stdout.buffer.flush()
+
+def _recv():
+    h = sys.stdin.buffer.read(4)
+    if len(h) < 4:
+        return None
+    (n,) = struct.unpack("!I", h)
+    body = bytearray()
+    while len(body) < n:
+        c = sys.stdin.buffer.read(n - len(body))
+        if not c:
+            return None
+        body.extend(c)
+    return json.loads(bytes(body).decode())
+
+_send({"op": "ready", "engine": "stub", "sample_rate": 24000})
+while True:
+    m = _recv()
+    if m is None:
+        sys.exit(0)
+    op = m.get("op")
+    if op == "ping":
+        _send({"op": "pong", "vram_mb": 0.0})
+    elif op == "shutdown":
+        sys.exit(0)
+    elif op == "synthesize":
+        time.sleep(2)  # hold the synth so the test can inspect the held slot
+        sr = 24000
+        pcm = array.array("h", (int(32767 * math.sin(2 * math.pi * 440 * i / sr)) for i in range(sr)))
+        _send({"op": "audio", "audio_pcm_b64": base64.b64encode(pcm.tobytes()).decode(),
+               "sample_rate": sr, "n_samples": sr})
+    else:
+        _send({"op": "error", "stage": "dispatch", "message": "unknown op %r" % op})
+'''
+
+
+class _StubBackend(SubprocessBackend):
+    id = "stub-hold"
+    display_name = "stub"
+    gpu_compat = ("cuda", "mps", "cpu")
+
+    @classmethod
+    def is_available(cls):
+        return True, "ok"
+
+    @classmethod
+    def venv_python(cls):
+        return Path(sys.executable)
+
+    @classmethod
+    def sidecar_script(cls):
+        raise NotImplementedError  # patched per-test
+
+    @property
+    def sample_rate(self):
+        return 24000
+
+    @property
+    def supported_languages(self):
+        return ["multi"]
+
+
+def test_off_pool_generate_holds_slot_for_synthesis(tmp_path, monkeypatch):
+    stub = tmp_path / "stub_sidecar.py"
+    stub.write_text(STUB_SIDECAR)
+    monkeypatch.setattr(_StubBackend, "sidecar_script",
+                        classmethod(lambda cls: stub))
+
+    import services.model_manager as mm
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu-pool")
+    monkeypatch.setattr(mm, "_get_gpu_pool", lambda: pool)
+
+    b = _StubBackend()
+    box = {}
+
+    def _gen():
+        try:
+            b.generate("off-pool")
+        except Exception as exc:  # noqa: BLE001
+            box["error"] = exc
+
+    gen_thread = threading.Thread(target=_gen, name="off-pool-caller", daemon=True)
+    gen_thread.start()
+    time.sleep(0.8)  # let it acquire the slot and reach the stub's sleep
+
+    # A second pool job must NOT run while the off-pool generate holds the
+    # 1-worker pool's slot. Pre-fix (bare no-op), the worker was already free
+    # and this would complete immediately.
+    marker = pool.submit(lambda: "ran")
+    time.sleep(0.5)
+    assert not marker.done(), "pool job ran during the off-pool synth (slot was not held)"
+
+    gen_thread.join(timeout=30)
+    assert "error" not in box, f"generate failed: {box.get('error')}"
+    assert marker.result(timeout=5) == "ran"  # ran once the slot was released
+
+    b.shutdown()
+    pool.shutdown(wait=False)

--- a/backend/tests/test_subprocess_slot_deadlock.py
+++ b/backend/tests/test_subprocess_slot_deadlock.py
@@ -1,0 +1,116 @@
+"""Regression: SubprocessBackend.generate() must not self-deadlock when called
+from a gpu-pool worker.
+
+/v1/audio/speech and /generate dispatch backend.generate() via
+run_on_gpu_pool_guarded, i.e. already ON a gpu-pool worker. generate() used to
+unconditionally submit a no-op to the same pool to "acquire a slot"; on a
+1-worker pool (MPS) that submit queued behind the very job running it and
+result(timeout=10) raised before the sidecar spawned. This test reproduces that
+dispatch shape (generate on a pool worker) against a stub sidecar.
+"""
+import base64
+import json
+import math
+import array
+import sys
+from pathlib import Path
+
+import pytest
+
+from services.subprocess_backend import SubprocessBackend
+
+# Model-free stub sidecar: speaks the length-prefixed-JSON protocol and returns
+# a 1s sine wave for any synthesize.
+STUB_SIDECAR = r'''
+import sys, json, struct, math, array, base64
+
+def _send(o):
+    b = json.dumps(o, separators=(",", ":")).encode()
+    sys.stdout.buffer.write(struct.pack("!I", len(b)) + b)
+    sys.stdout.buffer.flush()
+
+def _recv():
+    h = sys.stdin.buffer.read(4)
+    if len(h) < 4:
+        return None
+    (n,) = struct.unpack("!I", h)
+    body = bytearray()
+    while len(body) < n:
+        c = sys.stdin.buffer.read(n - len(body))
+        if not c:
+            return None
+        body.extend(c)
+    return json.loads(bytes(body).decode())
+
+_send({"op": "ready", "engine": "stub", "sample_rate": 24000})
+while True:
+    m = _recv()
+    if m is None:
+        sys.exit(0)
+    op = m.get("op")
+    if op == "ping":
+        _send({"op": "pong", "vram_mb": 0.0})
+    elif op == "shutdown":
+        sys.exit(0)
+    elif op == "synthesize":
+        sr = 24000
+        pcm = array.array("h", (int(32767 * math.sin(2 * math.pi * 440 * i / sr)) for i in range(sr)))
+        _send({"op": "audio", "audio_pcm_b64": base64.b64encode(pcm.tobytes()).decode(),
+               "sample_rate": sr, "n_samples": sr})
+    else:
+        _send({"op": "error", "stage": "dispatch", "message": "unknown op %r" % op})
+'''
+
+
+class _StubSubprocessBackend(SubprocessBackend):
+    """Minimal concrete SubprocessBackend pointing at the stub sidecar."""
+    id = "stub-subprocess"
+    display_name = "stub"
+    gpu_compat = ("cuda", "mps", "cpu")
+
+    @classmethod
+    def is_available(cls):
+        return True, "ok"
+
+    @classmethod
+    def venv_python(cls):
+        return Path(sys.executable)
+
+    @classmethod
+    def sidecar_script(cls):
+        raise NotImplementedError  # patched per-test
+
+    @property
+    def sample_rate(self):
+        return 24000
+
+    @property
+    def supported_languages(self):
+        return ["multi"]
+
+
+def test_generate_on_pool_worker_does_not_deadlock(tmp_path, monkeypatch):
+    # Mirror /v1/audio/speech + /generate: dispatch generate() ON a gpu-pool
+    # worker. Force a 1-worker pool so the self-deadlock reproduces
+    # deterministically regardless of host (the ambient pool may have >1
+    # worker): pre-fix, generate()'s inner slot-submit queued behind this very
+    # job and slot_future.result(timeout=10) raised at ~10s, before the sidecar
+    # spawned.
+    stub = tmp_path / "stub_sidecar.py"
+    stub.write_text(STUB_SIDECAR)
+    monkeypatch.setattr(_StubSubprocessBackend, "sidecar_script",
+                        classmethod(lambda cls: stub))
+
+    from concurrent.futures import ThreadPoolExecutor
+    import services.model_manager as mm
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu-pool")
+    monkeypatch.setattr(mm, "_get_gpu_pool", lambda: pool)
+
+    b = _StubSubprocessBackend()
+    try:
+        fut = pool.submit(lambda: b.generate("on-pool"))
+        tensor = fut.result(timeout=30)  # pre-fix: raised ~10s slot timeout
+        assert tensor.shape[1] == 24000
+    finally:
+        b.shutdown()
+        pool.shutdown(wait=False)


### PR DESCRIPTION
Closes #1295, #1297. Supersedes #1296.

`SubprocessBackend.generate()`'s GPU-pool slot handling had two bugs, both fixed here in one path-aware slot block:

1. **On-pool self-deadlock** (#1295): `/v1/audio/speech` and `/generate` (and audiobook/dub/batch) dispatch `generate()` via `run_on_gpu_pool_guarded`, already on a pool worker, so the inner slot submit queued behind the very job running it on a 1-worker (MPS) pool and timed out before the sidecar spawned. Every subprocess engine surfaced the in-process 300s-abandon instead of synthesizing.
2. **Off-pool no hold** (#1297): the off-pool slot was a bare no-op that released the worker before `_spawn()`, so off-pool callers (engine self-test, diagnostics) could synthesize concurrently with a pool job and over-subscribe the GPU.

### Changed
- `generate()` is now path-aware: on-pool callers skip the slot (the outer `run_on_gpu_pool_guarded` already holds `_running` for the whole sidecar exchange); off-pool callers hold a real slot for the whole synthesis via an `_occupy` task that blocks the worker until `_held` is set in the `finally`. Single release point in the `finally`.

### Tests / verification
- generate dispatched on a pool worker (on-pool skip): pre-fix raised the ~10s slot timeout before the sidecar spawned.
- a concurrent pool job blocked during an off-pool generate (off-pool hold): pre-fix the marker ran during the synth (slot not held).
- Both verified fail-before / pass-after.

### Notes
- Supersedes #1296 (on-pool-skip-only): this PR includes the skip plus the off-pool hold, so #1296 can be closed.
- The sibling `services/subprocess_asr.py` has the same no-op-reserve pattern; extracting a `reserve_worker()` helper on `_ResilientGpuPool` (used by both) is a clean follow-up, out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `SubprocessBackend.generate()` to avoid GPU-pool self-deadlocks by skipping nested slot acquisition when `running_on_gpu_pool()` is true, while off-pool callers now submit a blocking `_occupy` task that holds the single pool slot for the entire sidecar synthesis and releases it in a unified `finally` (with a 10s wait/`TimeoutError` if the slot can’t be acquired). Centralized detection of GPU pool worker threads in `model_manager` via `running_on_gpu_pool()`. Added regression coverage ensuring (1) on-pool invocation on a 1-worker pool completes without hanging and (2) off-pool generation keeps a second pool job blocked until synthesis finishes; main risk to review is the `_occupy` wait/timeout and future cancellation/cleanup correctness on all exit paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->