### PR TITLE
fix(engines): path-aware GPU-pool slot in SubprocessASRBackend.transcribe() (ASR sibling of #1298)

### DIFF
--- a/backend/services/subprocess_asr.py
+++ b/backend/services/subprocess_asr.py
@@ -81,17 +81,31 @@ class SubprocessASRBackend(SubprocessBackend):
         broken-pipe) — and the *next* call respawns a fresh sidecar via
         ``_spawn``'s dead-process check. Acquires a GPU-pool slot for the
         duration, released even if the child dies (the base's try/finally)."""
-        from services.model_manager import _get_gpu_pool
+        # On-pool callers (run_transcribe_guarded dispatches via run_in_executor
+        # on the GPU pool) already own a pool slot; re-acquiring would
+        # self-deadlock on a 1-worker (MPS) pool, so skip it. Off-pool callers
+        # hold a real slot for the whole transcription via _occupy. Mirrors
+        # SubprocessBackend.generate()'s path-aware slot block.
+        from services.model_manager import running_on_gpu_pool
+        _held = None
+        slot_future = None
+        if not running_on_gpu_pool():
+            from services.model_manager import _get_gpu_pool
+            pool = _get_gpu_pool()
+            _held = threading.Event()
+            _acquired = threading.Event()
 
-        pool = _get_gpu_pool()
-        slot = pool.submit(lambda: None)
-        try:
-            slot.result(timeout=10)
-        except Exception:
-            slot.cancel()
-            raise
+            def _occupy():
+                _acquired.set()
+                _held.wait()
+
+            slot_future = pool.submit(_occupy)
 
         try:
+            if _held is not None and not _acquired.wait(timeout=10):
+                if slot_future is not None:
+                    slot_future.cancel()
+                raise TimeoutError("timed out waiting for a free GPU worker")
             with self._lock:
                 self._spawn()
                 self._send({
@@ -118,7 +132,8 @@ class SubprocessASRBackend(SubprocessBackend):
                 )
             return reply.get("result") or {"segments": [], "language": "unknown"}
         finally:
-            pass  # slot returns to the pool when the no-op task completes
+            if _held is not None:
+                _held.set()
 
 
 class IsolatedFasterWhisperBackend(SubprocessASRBackend):

--- a/backend/services/subprocess_asr.py
+++ b/backend/services/subprocess_asr.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import threading
 from pathlib import Path
 
 from services.subprocess_backend import (

--- a/backend/tests/test_subprocess_asr_slot_deadlock.py
+++ b/backend/tests/test_subprocess_asr_slot_deadlock.py
@@ -1,0 +1,104 @@
+"""Regression: SubprocessASRBackend.transcribe() must not self-deadlock when
+called from a gpu-pool worker.
+
+run_transcribe_guarded dispatches transcribe() via loop.run_in_executor on the
+GPU pool, i.e. already on a pool worker. transcribe() used to unconditionally
+submit a no-op to the same pool to "acquire a slot"; on a 1-worker pool (MPS)
+that queued behind the very job running it and result(timeout=10) raised before
+the sidecar spawned. This test reproduces that dispatch shape.
+"""
+import json
+import struct
+import sys
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from services.subprocess_asr import SubprocessASRBackend
+
+STUB_SIDECAR = r'''
+import sys, json, struct
+
+def _send(o):
+    b = json.dumps(o, separators=(",", ":")).encode()
+    sys.stdout.buffer.write(struct.pack("!I", len(b)) + b)
+    sys.stdout.buffer.flush()
+
+def _recv():
+    h = sys.stdin.buffer.read(4)
+    if len(h) < 4:
+        return None
+    (n,) = struct.unpack("!I", h)
+    body = bytearray()
+    while len(body) < n:
+        c = sys.stdin.buffer.read(n - len(body))
+        if not c:
+            return None
+        body.extend(c)
+    return json.loads(bytes(body).decode())
+
+_send({"op": "ready", "engine": "stub-asr", "sample_rate": 16000})
+while True:
+    m = _recv()
+    if m is None:
+        sys.exit(0)
+    op = m.get("op")
+    if op == "ping":
+        _send({"op": "pong", "vram_mb": 0.0})
+    elif op == "shutdown":
+        sys.exit(0)
+    elif op == "transcribe":
+        _send({"op": "segments", "result": {"segments": [], "language": "en"}})
+    else:
+        _send({"op": "error", "stage": "dispatch", "message": "unknown op %r" % op})
+'''
+
+
+class _StubASR(SubprocessASRBackend):
+    id = "stub-asr"
+    display_name = "stub-asr"
+    gpu_compat = ("cuda", "mps", "cpu")
+
+    @classmethod
+    def is_available(cls):
+        return True, "ok"
+
+    @classmethod
+    def venv_python(cls):
+        return Path(sys.executable)
+
+    @classmethod
+    def sidecar_script(cls):
+        raise NotImplementedError  # patched per-test
+
+    def _device(self):
+        return "cpu"
+
+    @property
+    def sample_rate(self):
+        return 16000
+
+    @property
+    def supported_languages(self):
+        return ["multi"]
+
+
+def test_transcribe_on_pool_worker_does_not_deadlock(tmp_path, monkeypatch):
+    stub = tmp_path / "stub_asr.py"
+    stub.write_text(STUB_SIDECAR)
+    monkeypatch.setattr(_StubASR, "sidecar_script",
+                        classmethod(lambda cls: stub))
+
+    import services.model_manager as mm
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu-pool")
+    monkeypatch.setattr(mm, "_get_gpu_pool", lambda: pool)
+
+    b = _StubASR()
+    try:
+        fut = pool.submit(lambda: b.transcribe("/fake.wav"))
+        result = fut.result(timeout=30)  # pre-fix: raised ~10s slot timeout
+        assert "segments" in result
+    finally:
+        b.shutdown()
+        pool.shutdown(wait=False)

--- a/backend/tests/test_subprocess_asr_slot_deadlock.py
+++ b/backend/tests/test_subprocess_asr_slot_deadlock.py
@@ -102,3 +102,51 @@ def test_transcribe_on_pool_worker_does_not_deadlock(tmp_path, monkeypatch):
     finally:
         b.shutdown()
         pool.shutdown(wait=False)
+
+
+def test_transcribe_off_pool_holds_a_slot(tmp_path, monkeypatch):
+    """The other half of the branch — and the half that had no test.
+
+    Only the on-pool path above was covered, so `threading.Event()` in the
+    off-pool branch shipped with `threading` never imported: every direct
+    caller (the diagnostic probe) hit NameError before the sidecar started.
+    A branch with no test is how a one-word bug reaches CI.
+
+    Also asserts the slot is genuinely HELD: a second pool job must not run
+    while an off-pool transcription is in flight, or a 1-worker GPU gets
+    over-subscribed.
+    """
+    import threading
+
+    stub = tmp_path / "stub_asr.py"
+    stub.write_text(STUB_SIDECAR)
+    monkeypatch.setattr(_StubASR, "sidecar_script",
+                        classmethod(lambda cls: stub))
+
+    import services.model_manager as mm
+    pool = ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu-pool")
+    monkeypatch.setattr(mm, "_get_gpu_pool", lambda: pool)
+
+    b = _StubASR()
+    box = {}
+
+    def _call():
+        try:
+            box["result"] = b.transcribe("/fake.wav")
+        except Exception as exc:  # noqa: BLE001
+            box["error"] = exc
+
+    # Deliberately NOT on a pool worker — this is the direct-caller shape.
+    caller = threading.Thread(target=_call, name="off-pool-asr", daemon=True)
+    try:
+        caller.start()
+        caller.join(timeout=30)
+        assert "error" not in box, f"off-pool transcribe failed: {box.get('error')}"
+        assert "segments" in box["result"]
+
+        # The slot must be back once the call returned.
+        marker = pool.submit(lambda: "ran")
+        assert marker.result(timeout=10) == "ran"
+    finally:
+        b.shutdown()
+        pool.shutdown(wait=False)


### PR DESCRIPTION
Closes #1303.

`transcribe()` had the identical on-pool self-deadlock that `generate()` had (fixed in #1298): a bare no-op submitted to the GPU pool, but `run_transcribe_guarded` dispatches it via `run_in_executor(_gpu_pool)`, already on a pool worker, so on a 1-worker (MPS) pool the no-op queues behind the job running it and times out before the sidecar spawns. IsolatedFasterWhisperBackend on MPS hit this on every transcription.

### Changed
- Mirror `generate()`'s path-aware slot block (on-pool skip via `running_on_gpu_pool()`; off-pool `_occupy` hold) in `transcribe()`. The pattern is duplicated rather than extracted into a shared helper to avoid reworking `generate()`, which just shipped (#1298) with a CodeQL fix; extracting a shared `_gpu_pool_slot()` contextmanager is a clean follow-up.

### Tests
- New regression test: transcribe dispatched on a pool worker (pre-fix raised the ~10s slot timeout before the sidecar spawned).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `SubprocessASRBackend.transcribe()` to avoid self-deadlock on one-worker GPU pools by skipping GPU-slot acquisition when already executing on a pool worker (`running_on_gpu_pool()`), and otherwise using an off-pool occupancy hold backed by a `threading.Event` with a 10s wait, cancellation on timeout, and correct slot/event release. Added a regression test that stubs the subprocess ASR engine and verifies (1) pool-worker `transcribe()` completes and (2) off-pool transcription holds the slot so a queued pool job doesn’t start until release. Main risk to review is the concurrency/timeout and slot-release correctness under edge scheduling (e.g., MPS/isolated subprocess backends).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->