### PR TITLE
test: stop config-path leakage across test modules (#1269)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -507,8 +507,16 @@ def _restore_config_paths_after_reload():
     import sys
 
     def _snapshot():
-        cfg = sys.modules.get("core.config")
-        if cfg is None:
+        # IMPORT rather than only reading sys.modules. If this module is the
+        # first to import core.config, a sys.modules-only probe returns {} —
+        # and then the empty-snapshot guard below skips restoration entirely,
+        # so the very module most likely to reload config is the one least
+        # protected (Greptile P1). Importing is cheap and idempotent, and
+        # tests/conftest.py has already pointed OMNIVOICE_DATA_DIR at a
+        # throwaway dir by the time any fixture runs, so the values are right.
+        try:
+            import core.config as cfg  # noqa: PLC0415
+        except Exception:
             return {}
         return {
             c: getattr(cfg, c)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -487,49 +487,54 @@ _CONFIG_PATH_CONSTANTS = (
 )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _config_baseline():
-    """Pristine core.config paths, captured once before any test runs.
+@pytest.fixture(scope="module", autouse=True)
+def _restore_config_paths_after_reload():
+    """Undo cross-MODULE leakage of core.config's path constants.
 
-    Must be session-scoped. A per-test snapshot cannot work: several of these
-    reload fixtures are module- or session-scoped themselves, so by the time
-    the second test in that module is set up the pollution is already in place
-    and a per-test snapshot faithfully restores it. (Observed: every module
-    agreed on `unified-profiles-data0/voices` — consistent, and wrong.)
+    Module scope, not function scope, and that boundary is the whole design.
+
+    Deliberate re-pointing is normal and must survive: tests/smoke/
+    test_boot_smoke.py has a module-scoped fixture that aims core.config at a
+    frozen fixture directory for the length of that file. A per-test restore
+    reset it between that module's own tests and broke it — the fixture cannot
+    tell a deliberate setup from a leak *within* a module.
+
+    Across modules there is no such ambiguity: whatever a module pointed
+    core.config at is that module's business, and the next one is entitled to
+    the paths it started with. Restoring at module teardown lets each file keep
+    its own arrangement and hands the next file a clean slate.
     """
     import sys
 
-    cfg = sys.modules.get("core.config")
-    if cfg is None:
-        import core.config as cfg  # noqa: PLC0415
-    return {c: getattr(cfg, c) for c in _CONFIG_PATH_CONSTANTS if isinstance(getattr(cfg, c, None), str)}
+    def _snapshot():
+        cfg = sys.modules.get("core.config")
+        if cfg is None:
+            return {}
+        return {
+            c: getattr(cfg, c)
+            for c in _CONFIG_PATH_CONSTANTS
+            if isinstance(getattr(cfg, c, None), str)
+        }
 
-
-@pytest.fixture(autouse=True)
-def _restore_config_paths_after_reload(_config_baseline):
-    """Undo cross-test leakage of core.config's path constants."""
-    import sys
-
+    before = _snapshot()
     try:
         yield
     finally:
         cfg = sys.modules.get("core.config")
-        if cfg is None:
+        if cfg is None or not before:
             return
-        # 1. Put core.config itself back to the session baseline.
-        for const, value in _config_baseline.items():
+        # 1. core.config itself back to what this module inherited.
+        for const, value in before.items():
             if getattr(cfg, const, None) != value:
                 setattr(cfg, const, value)
         # 2. Re-sync every module that copied a value out of it. A reload
         #    fixture typically imports the router under test for the first
         #    time, so it has no earlier value to restore — which is how
         #    api.routers.profiles kept a tmp_path VOICES_DIR while core.config
-        #    was already correct. Runs after monkeypatch teardown (autouse =>
-        #    set up first, torn down last), so it reconciles against real
-        #    values rather than a patch that is about to vanish.
+        #    was already correct.
         for name, mod in list(sys.modules.items()):
             if mod is None or not name.startswith(("api.routers.", "services.", "core.")):
                 continue
-            for const, value in _config_baseline.items():
+            for const, value in before.items():
                 if isinstance(getattr(mod, const, None), str) and getattr(mod, const) != value:
                     setattr(mod, const, value)


### PR DESCRIPTION
Fixes 3 of the 4 failures in #1269.

## What leaks

Ten test modules share a fixture shape: monkeypatch `OMNIVOICE_DATA_DIR` to a `tmp_path`, then `importlib.reload(core.config)` (plus `core.db`, a router, `main`). monkeypatch faithfully restores the **env var** at teardown — and nothing reloads the modules back, so every path constant keeps pointing at that test's `tmp_path` for the rest of the session.

Instrumenting a combined `pytest tests/ backend/tests/` run gave three different answers to "where is the voices directory":

```
OMNIVOICE_DATA_DIR      .../omnivoice-test-data-vna0ywre        (correct)
core.config.VOICES_DIR  .../test_fitted_srt_last_cue_withi0/…   (leaked)
profiles.VOICES_DIR     .../test_clone_profile_save_saniti0/…   (leaked)
```

Two *different* tests, each having overwritten a *different* module. That is why the personas import tests wrote a file to one directory and then asserted it existed in another.

## Why module scope

Function scope was my first attempt and it was wrong. `tests/smoke/test_boot_smoke.py` has a module-scoped fixture that deliberately aims `core.config` at a frozen fixture directory for the length of that file; a per-test restore reset it between that module's own tests and broke it.

Within a module, a fixture cannot distinguish deliberate setup from a leak. Across modules there is no ambiguity — whatever a module pointed `core.config` at is that module's business, and the next file is entitled to the paths it started with.

A session-scoped baseline was also wrong, in the other direction: several of these reload fixtures are module-scoped themselves, so a per-test snapshot captured the pollution as truth and restored it faithfully. Every module then agreed on `unified-profiles-data0/voices` — consistent, and wrong.

## Why snapshot/restore, not reload

Re-reloading would re-register FastAPI routes and rebuild module state as a side effect. A `setattr` is inert, runs only for values that actually changed, and fixes all ten modules without editing any of them — new reload fixtures are covered automatically.

It also re-syncs modules that copied a value *out* of `core.config`. A snapshot alone is not enough: a reload fixture typically imports the router under test for the first time, so that module did not exist when the snapshot was taken and has no earlier value to put back. That is exactly how `api.routers.profiles` kept a `tmp_path` VOICES_DIR while `core.config` was already correct.

## Honest scope

`test_lifespan_shutdown_mid_load_is_clean_and_clears_sentinel` **still fails** in a combined run, for an unrelated reason — its preload never reaches `run_in_executor`, so `started` is never set. That is a different leak and #1269 stays open for it.

Combined run: **4 failures → 1**, 3924 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added module-scoped snapshot/restore logic for `core.config`’s string-valued path constants (and re-synchronization into already-imported dependent modules) to prevent temporary `OMNIVOICE_DATA_DIR` paths from leaking after `core.config` reloads across test modules. This avoids FastAPI and other state-rebuild side effects from reloading while improving the suite from four failures to one (3,924 tests passing). Risk worth a human look: module-scoped restoration timing/coverage could miss late imports or other modules not included in the synchronization set, so changes in import order could reintroduce leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->