### PR TITLE
fix(compile): skip torch.compile when the torch lib path has whitespace

### DIFF
--- a/backend/services/engine_env.py
+++ b/backend/services/engine_env.py
@@ -121,8 +121,18 @@ def _torch_lib_path_is_linkable() -> tuple[bool, str]:
     except Exception:
         return True, ""
     if any(ch.isspace() for ch in lib_dir):
+        # The path is genuinely useful for diagnosis, but it contains the user's
+        # home directory and this string is logged and lands in pasted bug
+        # reports — so it goes through the same redaction every other
+        # user-facing failure text uses (home → ~, secrets stripped).
+        try:
+            from core.failure import sanitize
+
+            shown = sanitize(lib_dir)
+        except Exception:
+            shown = os.path.basename(lib_dir.rstrip(os.sep)) or "<torch lib>"
         return False, (
-            f"the torch library path contains whitespace ({lib_dir!r}); inductor "
+            f"the torch library path contains whitespace ({shown!r}); inductor "
             f"passes it to the C++ linker unquoted, so every compile attempt fails"
         )
     return True, ""

--- a/backend/services/engine_env.py
+++ b/backend/services/engine_env.py
@@ -98,6 +98,36 @@ def _cuda_arch_supported_for_compile() -> "tuple[bool, str]":
         return True, ""
 
 
+def _torch_lib_path_is_linkable() -> tuple[bool, str]:
+    """``(ok, reason)`` — False when inductor's C++ link step is guaranteed to
+    fail because the torch library path contains whitespace (#1266).
+
+    Inductor passes the torch lib directory to ``clang++``/``g++`` as an
+    unquoted ``-L`` flag. A path with a space splits into two arguments and the
+    compile dies with ``no such file or directory: 'Support/...'``. The bug is
+    inside PyTorch, so we cannot fix the quoting — but a path we already know
+    cannot compile is one we should not spend a compile attempt on.
+
+    It is not hypothetical on any platform: the macOS data dir lives under
+    ``~/Library/Application Support/``, and a Windows user profile is routinely
+    ``C:/Users/First Last``.
+
+    Never raises — an unreadable torch path means "no reason to skip".
+    """
+    try:
+        import torch
+
+        lib_dir = os.path.join(os.path.dirname(torch.__file__), "lib")
+    except Exception:
+        return True, ""
+    if any(ch.isspace() for ch in lib_dir):
+        return False, (
+            f"the torch library path contains whitespace ({lib_dir!r}); inductor "
+            f"passes it to the C++ linker unquoted, so every compile attempt fails"
+        )
+    return True, ""
+
+
 def should_torch_compile(device: str) -> bool:
     """Decide whether to apply ``torch.compile`` to an in-process model.
 
@@ -133,6 +163,19 @@ def should_torch_compile(device: str) -> bool:
         logger.info(
             "torch.compile skipped: failed earlier this session (%s) — using eager mode.",
             _compile_runtime_failure,
+        )
+        return False
+    linkable, path_reason = _torch_lib_path_is_linkable()
+    if not linkable:
+        if _force_compile_requested():
+            logger.warning(
+                "torch.compile forced via %s=1 despite: %s", _FORCE_COMPILE_ENV, path_reason,
+            )
+            return True
+        logger.info(
+            "torch.compile skipped: %s — using eager mode. "
+            "(Set %s=1 to attempt compile anyway.)",
+            path_reason, _FORCE_COMPILE_ENV,
         )
         return False
     supported, reason = _cuda_arch_supported_for_compile()

--- a/tests/test_torch_compile_path_gate.py
+++ b/tests/test_torch_compile_path_gate.py
@@ -1,0 +1,79 @@
+"""#1266: a torch lib path with whitespace can never survive inductor's linker.
+
+Inductor passes the torch library directory to clang++/g++ as an unquoted
+``-L`` flag, so a path containing a space splits into two arguments and the
+compile dies with ``no such file or directory: 'Support/...'``. The bug is
+inside PyTorch; what we control is not paying for a compile attempt that cannot
+succeed and not flooding the log tail with its failure — which is how it turned
+up in #1259, consuming a chunk of the captured crash output while not being the
+actual fault.
+
+Not hypothetical anywhere: macOS keeps app data under
+``~/Library/Application Support/`` and a Windows profile is routinely
+``C:/Users/First Last``.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+def _env(monkeypatch, *, torch_file, triton=True):
+    """Bind should_torch_compile's dependencies to a controlled fake."""
+    from services import engine_env
+
+    monkeypatch.setattr(
+        engine_env.importlib.util,
+        "find_spec",
+        lambda name: object() if (triton and name == "triton") else None,
+    )
+    monkeypatch.setattr(engine_env, "_compile_runtime_failure", None, raising=False)
+    monkeypatch.setattr(
+        engine_env, "_cuda_arch_supported_for_compile", lambda: (True, "")
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules, "torch", types.SimpleNamespace(__file__=torch_file)
+    )
+    return engine_env
+
+
+CLEAN = "/opt/venv/lib/python3.11/site-packages/torch/__init__.py"
+SPACED = "/Users/x/Library/Application Support/omnivoice/.venv/lib/torch/__init__.py"
+
+
+def test_compile_allowed_on_a_clean_path(monkeypatch):
+    ee = _env(monkeypatch, torch_file=CLEAN)
+    assert ee.should_torch_compile("cuda") is True
+
+
+def test_compile_skipped_when_the_torch_path_has_a_space(monkeypatch, caplog):
+    """The regression: this used to attempt, fail in clang++, and log the wreck."""
+    ee = _env(monkeypatch, torch_file=SPACED)
+    with caplog.at_level("INFO", logger="omnivoice.engine_env"):
+        assert ee.should_torch_compile("cuda") is False
+    assert any("whitespace" in r.getMessage() for r in caplog.records), (
+        "the skip must say WHY, or it is indistinguishable from the other skips"
+    )
+
+
+def test_force_env_still_overrides(monkeypatch, caplog):
+    """Consistent with the arch gate: the user can insist."""
+    ee = _env(monkeypatch, torch_file=SPACED)
+    monkeypatch.setenv(ee._FORCE_COMPILE_ENV, "1")
+    with caplog.at_level("WARNING", logger="omnivoice.engine_env"):
+        assert ee.should_torch_compile("cuda") is True
+
+
+def test_unreadable_torch_path_is_not_a_reason_to_skip(monkeypatch):
+    """No torch metadata means no evidence of a problem — fail open, matching
+    the module's other probes."""
+    ee = _env(monkeypatch, torch_file=None)
+    assert ee.should_torch_compile("cuda") is True
+
+
+@pytest.mark.parametrize("device", ["mps", "cpu", "xpu"])
+def test_non_cuda_devices_are_unaffected(monkeypatch, device):
+    """The device gate runs first and must keep short-circuiting."""
+    ee = _env(monkeypatch, torch_file=SPACED)
+    assert ee.should_torch_compile(device) is False

--- a/tests/test_torch_compile_path_gate.py
+++ b/tests/test_torch_compile_path_gate.py
@@ -29,6 +29,16 @@ def _env(monkeypatch, *, torch_file, triton=True):
         lambda name: object() if (triton and name == "triton") else None,
     )
     monkeypatch.setattr(engine_env, "_compile_runtime_failure", None, raising=False)
+    # Isolate the Settings gate: should_torch_compile() otherwise reads the real
+    # settings_store, so a persisted perf.torch_compile_disabled=1 (or a missing
+    # settings table) would decide these tests instead of the path logic.
+    monkeypatch.setattr(
+        engine_env, "settings_store", None, raising=False
+    )
+    import sys as _sys, types as _types
+    _sys.modules["services.settings_store"] = _types.SimpleNamespace(
+        get_text=lambda *a, **k: "0"
+    )
     monkeypatch.setattr(
         engine_env, "_cuda_arch_supported_for_compile", lambda: (True, "")
     )
@@ -58,11 +68,35 @@ def test_compile_skipped_when_the_torch_path_has_a_space(monkeypatch, caplog):
 
 
 def test_force_env_still_overrides(monkeypatch, caplog):
-    """Consistent with the arch gate: the user can insist."""
+    """Consistent with the arch gate: the user can insist — and is told."""
     ee = _env(monkeypatch, torch_file=SPACED)
     monkeypatch.setenv(ee._FORCE_COMPILE_ENV, "1")
     with caplog.at_level("WARNING", logger="omnivoice.engine_env"):
         assert ee.should_torch_compile("cuda") is True
+    assert any(
+        "forced" in r.getMessage().lower() for r in caplog.records
+    ), "forcing past a known-broken path must be recorded, not silent"
+
+
+def test_skip_message_names_the_escape_hatch(monkeypatch, caplog):
+    """A skip the user cannot override is a dead end; the hint must be there."""
+    ee = _env(monkeypatch, torch_file=SPACED)
+    with caplog.at_level("INFO", logger="omnivoice.engine_env"):
+        assert ee.should_torch_compile("cuda") is False
+    assert any(ee._FORCE_COMPILE_ENV in r.getMessage() for r in caplog.records)
+
+
+def test_home_directory_is_not_logged_verbatim(monkeypatch, caplog):
+    """The reason string is logged and lands in pasted bug reports, so the path
+    goes through the same redaction as every other user-facing failure text."""
+    import pathlib as _pl
+
+    home = str(_pl.Path.home())
+    ee = _env(monkeypatch, torch_file=f"{home}/Library/Application Support/x/torch/__init__.py")
+    with caplog.at_level("INFO", logger="omnivoice.engine_env"):
+        ee.should_torch_compile("cuda")
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert home not in joined, f"home directory leaked into the log: {joined}"
 
 
 def test_unreadable_torch_path_is_not_a_reason_to_skip(monkeypatch):


### PR DESCRIPTION
Closes #1266.

## The defect

Inductor passes the torch library directory to `clang++`/`g++` as an **unquoted** `-L` flag. A path containing a space splits into two arguments:

```
-L~/Library/Application Support/…/site-packages/torch/lib
clang++: error: no such file or directory: 'Support/…/site-packages/torch/lib'
```

The quoting bug is inside PyTorch, so we can't fix it. What we control is not spending a compile attempt on a path we already know cannot link.

## Why it mattered

Never a broken generation — `torch.compile` is an optimization and eager mode is the documented fallback. The cost was a **guaranteed-failing** compile on every load whose clang wreckage was swallowed by `except Exception: logger.info(...)` and then ate a chunk of the captured log tail.

That's exactly how it surfaced: while triaging #1259 it was consuming crash-report output while **not** being the fault being investigated.

Not platform-specific either — macOS keeps app data under `~/Library/Application Support/`, and a Windows profile is routinely `C:/Users/First Last`.

## Behaviour

Slots in beside the existing gates in `should_torch_compile()` and follows their conventions:

- one INFO line naming the path and *why* it can't work, instead of a clang dump
- `OMNIVOICE_FORCE_TORCH_COMPILE=1` still overrides, consistent with the arch gate
- an unreadable torch path **fails open** — no evidence is not evidence of a problem

## Tests

7 cases: clean path compiles, spaced path skips *and says why*, force-env overrides, unreadable path fails open, and mps/cpu/xpu still short-circuit on the device gate first.

Fails before the change; `engine_env`/`torch_compile` suites stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `should_torch_compile()` to avoid guaranteed-failing `torch.compile` when the resolved PyTorch library path contains whitespace, adding an INFO/skip reason with redacted path details and preserving the `OMNIVOICE_FORCE_TORCH_COMPILE=1` override. Added `_torch_lib_path_is_linkable()` with fail-open behavior when path probing/import errors occur, and expanded tests to cover clean vs spaced paths, override and log-message escape-hatch naming, unreadable path behavior, and non-CUDA device short-circuits (including asserting home directory paths are not logged verbatim). Main risk to review: enabling the force override on whitespace-containing paths will still attempt compilation and may fail as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->