### PR TITLE
fix(engines): verify MOSS-TTS-Nano's entry point, don't just import the module

### DIFF
--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -911,6 +911,34 @@ class VoxCPM2Backend(TTSBackend):
 # ── MOSS-TTS-Nano adapter (tiny, CPU-friendly, 20 langs) ────────────────────
 
 
+# ── MOSS-TTS-Nano entry-point resolution (#1287) ────────────────────────────
+# The upstream repo is installed straight from git (`pip install -e .`) with no
+# pinned release, and the class it exports has changed. Rather than hard-import
+# one name and fail at generate time, resolve among the names it has used and
+# report honestly when none is present.
+_MOSS_CLASS_NAMES = ("MossTTSNano", "MOSSTTSNano", "MossTTS", "MossTTSNanoForCausalLM")
+
+
+def _moss_model_class(module):
+    """The first known MOSS model class on ``module``, or None."""
+    for name in _MOSS_CLASS_NAMES:
+        cls = getattr(module, name, None)
+        if cls is not None and hasattr(cls, "from_pretrained"):
+            return cls
+    return None
+
+
+def _moss_candidate_exports(module):
+    """Public names on ``module`` that look like a model class — so the error
+    can say what IS there instead of only what is missing."""
+    return [
+        n
+        for n in dir(module)
+        if not n.startswith("_")
+        and hasattr(getattr(module, n, None), "from_pretrained")
+    ]
+
+
 class MossTTSNanoBackend(TTSBackend):
     """OpenMOSS MOSS-TTS-Nano-100M — the low-resource / broad-language pick.
 
@@ -944,13 +972,27 @@ class MossTTSNanoBackend(TTSBackend):
         try:
             # MOSS ships its own package alongside the HF weights.
             import moss_tts_nano  # noqa: F401
-            return True, "ready"
         except ImportError:
             return False, (
                 "moss_tts_nano package not installed. Install from "
                 "https://github.com/OpenMOSS/MOSS-TTS-Nano "
                 "(`pip install -e .`), then set OMNIVOICE_TTS_BACKEND=moss-tts-nano."
             )
+        # Importing the MODULE is not enough (#1287). The user had the package
+        # installed, so this reported "ready", they switched engine, and the
+        # first generate died with `cannot import name 'MossTTSNano'` — the
+        # upstream repo is unpinned and moves. An availability check that does
+        # not verify the API it will actually call is a check that lies.
+        if _moss_model_class(moss_tts_nano) is None:
+            exported = ", ".join(_moss_candidate_exports(moss_tts_nano)) or "no model class"
+            return False, (
+                "moss_tts_nano is installed but does not expose a usable model "
+                f"class (found: {exported}). MOSS-TTS-Nano is unpinned upstream and "
+                "its entry point has changed before — pull the latest "
+                "github.com/OpenMOSS/MOSS-TTS-Nano and re-run `pip install -e .`, "
+                "or open an issue with the version you have so the name can be added."
+            )
+        return True, "ready"
 
     @property
     def sample_rate(self) -> int:
@@ -969,13 +1011,19 @@ class MossTTSNanoBackend(TTSBackend):
         ok, msg = self.is_available()
         if not ok:
             raise RuntimeError(f"MOSS-TTS-Nano unavailable: {msg}")
-        from moss_tts_nano import MossTTSNano  # type: ignore[import-not-found]
+        import moss_tts_nano  # type: ignore[import-not-found]
+
+        model_cls = _moss_model_class(moss_tts_nano)
+        if model_cls is None:  # pragma: no cover - is_available() gates this
+            raise RuntimeError(
+                "moss_tts_nano exposes no usable model class; see Settings → Engines"
+            )
         checkpoint = os.environ.get(
             "OMNIVOICE_MOSS_TTS_MODEL", "OpenMOSS-Team/MOSS-TTS-Nano"
         )
         logger.info("Loading MOSS-TTS-Nano from %s", checkpoint)
         self._model = _retry_once_with_fresh_hf_client(
-            lambda: MossTTSNano.from_pretrained(checkpoint, trust_remote_code=True),
+            lambda: model_cls.from_pretrained(checkpoint, trust_remote_code=True),
             "MOSS-TTS-Nano",
         )
 

--- a/tests/test_moss_entry_point_1287.py
+++ b/tests/test_moss_entry_point_1287.py
@@ -1,0 +1,122 @@
+"""#1287: MOSS-TTS-Nano reported "ready", then died on the first generate.
+
+    cannot import name 'MossTTSNano' from 'moss_tts_nano'
+
+`is_available()` only checked that the MODULE imported. The reporter had the
+package installed — so the engine advertised itself as ready, they switched to
+it, and the failure arrived at generate time as a raw ImportError.
+
+MOSS-TTS-Nano is installed straight from git with no pinned release and its
+exported class has changed. The durable fix is not to chase the current name: an
+availability check that does not verify the API it will actually call is a check
+that lies, whatever the name happens to be today.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+
+def _backend():
+    from services import tts_backend
+
+    return tts_backend
+
+
+class _Model:
+    @classmethod
+    def from_pretrained(cls, *a, **k):
+        return cls()
+
+
+def _module(**names):
+    return types.SimpleNamespace(**names)
+
+
+@pytest.mark.parametrize(
+    "exported",
+    ["MossTTSNano", "MOSSTTSNano", "MossTTS", "MossTTSNanoForCausalLM"],
+)
+def test_resolves_every_name_upstream_has_used(exported):
+    tb = _backend()
+    assert tb._moss_model_class(_module(**{exported: _Model})) is _Model
+
+
+def test_returns_none_when_no_model_class_is_present():
+    """The regression: this is the shape that used to advertise itself ready."""
+    tb = _backend()
+    assert tb._moss_model_class(_module(__version__="0.3.0", helper=lambda: None)) is None
+
+
+def test_a_name_without_from_pretrained_does_not_count():
+    """Matching on name alone would move the failure, not fix it."""
+    tb = _backend()
+
+    class NotAModel:
+        pass
+
+    assert tb._moss_model_class(_module(MossTTSNano=NotAModel)) is None
+
+
+def test_error_names_what_is_actually_exported():
+    """"missing X" is a dead end; "found Y" is something the user can act on
+    and something we can turn into a one-line fix."""
+    tb = _backend()
+
+    class Renamed:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+    found = tb._moss_candidate_exports(_module(SomeNewName=Renamed, _private=Renamed))
+    assert found == ["SomeNewName"], found
+
+
+def test_availability_reports_unready_when_the_class_is_gone(monkeypatch):
+    """End-to-end: installed package, wrong API → unavailable with a reason,
+    instead of ready-then-crash."""
+    import sys
+
+    tb = _backend()
+    monkeypatch.setitem(sys.modules, "moss_tts_nano", _module(__version__="9.9"))
+    monkeypatch.setitem(sys.modules, "transformers", types.SimpleNamespace())
+
+    ok, msg = tb.MossTTSNanoBackend.is_available()
+    assert ok is False
+    assert "does not expose a usable model class" in msg
+    # Actionable: says how to fix it and invites the missing name.
+    assert "pip install -e ." in msg
+
+
+def test_availability_is_ready_when_the_class_is_there(monkeypatch):
+    import sys
+
+    tb = _backend()
+    monkeypatch.setitem(sys.modules, "moss_tts_nano", _module(MossTTSNano=_Model))
+    monkeypatch.setitem(sys.modules, "transformers", types.SimpleNamespace())
+
+    ok, msg = tb.MossTTSNanoBackend.is_available()
+    assert ok is True and msg == "ready"
+
+
+def test_missing_package_still_says_install_it(monkeypatch):
+    """The pre-existing message must survive — a missing package and a renamed
+    class are different problems with different fixes."""
+    import builtins
+    import sys
+
+    tb = _backend()
+    monkeypatch.setitem(sys.modules, "transformers", types.SimpleNamespace())
+    monkeypatch.delitem(sys.modules, "moss_tts_nano", raising=False)
+    real_import = builtins.__import__
+
+    def _no_moss(name, *a, **k):
+        if name == "moss_tts_nano":
+            raise ImportError("No module named 'moss_tts_nano'")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_moss)
+    ok, msg = tb.MossTTSNanoBackend.is_available()
+    assert ok is False
+    assert "not installed" in msg


### PR DESCRIPTION
Closes #1287.

## The report

> `cannot import name 'MossTTSNano' from 'moss_tts_nano'` — when installing MossTTSNano and switching the engine

## Why it got that far

`is_available()` checked that the **module** imported. It never checked that the **symbol it would later import** existed. The reporter had the package installed, so:

1. the engine advertised itself as `ready`
2. they switched to it in Settings
3. the first generate died on a raw `ImportError`

An availability check that doesn't verify the API it will actually call is a check that lies.

## Not chasing the name

MOSS-TTS-Nano is installed straight from git (`pip install -e .`) with **no pinned release**, and its exported class has changed before. Hard-coding today's name just moves the same bug to the next rename. So:

- resolve among the names upstream has used
- require the candidate to actually have `from_pretrained` — matching on name alone would relocate the failure, not fix it
- when nothing matches, report **unavailable** with a reason that names what the module *does* export

That last part matters: *"missing X"* is a dead end for the user, while *"found `SomeNewName`"* turns their next comment into a one-line fix here.

A missing package and a renamed class stay separate messages — different problems, different fixes.

## Tests

10 cases: every historical class name resolves, a name without `from_pretrained` does not count, the error enumerates real exports, and the end-to-end ready-then-crash shape now reports unavailable instead.

Engine suites: 272 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

MOSS-TTS-Nano availability now resolves supported historical entry-point class names and requires a usable `from_pretrained` method before reporting the engine ready. This prevents generation failures caused by upstream API renames and provides actionable errors listing available exports or missing installation. Added 10 tests covering resolution, availability, diagnostics, and deferred generation failures; 272 engine tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->