### PR TITLE
fix(dub): stop blaming the ASR model when the stream is cut by a proxy

### DIFF
--- a/frontend/src/hooks/useDubWorkflow.js
+++ b/frontend/src/hooks/useDubWorkflow.js
@@ -269,8 +269,13 @@ export default function useDubWorkflow({
           // forbids — so the backend PROCESS went away (on small GPUs, a VRAM
           // abort while loading ASR is the usual trigger). Ask the shell's crash
           // forensics rather than guessing "ASR failed to load" (#1062).
+          // The fallback no longer names a cause. streamDropError() checks the
+          // crash forensics AND whether the backend is still answering, and
+          // only this message survives when both are inconclusive — asserting
+          // "ASR failed to load" there sent #1242's reporter after a model
+          // that had loaded fine.
           streamDropError(
-            'Transcribe stream dropped before emitting any segments. Likely ASR backend failed to load — check backend log + Settings → Models.',
+            'Transcribe stream ended before any segments arrived, and the backend could not be reached to say why — check the backend log, and Settings → Models if the ASR model was still downloading.',
           ).then(reject, reject);
         });
       }),

--- a/frontend/src/test/streamDropError.test.ts
+++ b/frontend/src/test/streamDropError.test.ts
@@ -172,3 +172,59 @@ describe('crashCauseHint', () => {
     expect(crashCauseHint({ exit_code: 78, signal: null })).toMatch(/port 3900/);
   });
 });
+
+describe('stream drop with no crash marker (#1242)', () => {
+  const FB = 'fallback message with no cause asserted';
+
+  // The reporter was in `server` mode with the backend having answered 20 s
+  // earlier. No crash marker existed — correctly, since nothing had crashed —
+  // and the caller's fallback then asserted "Likely ASR backend failed to
+  // load" about a model that had loaded fine.
+  it('does not blame the ASR model when the backend is still answering', async () => {
+    const { streamDropError } = await import('../utils/backendCrash');
+    const err = await streamDropError(FB, async () => null, {
+      probeAlive: async () => true,
+      waitMs: 0,
+    });
+    expect(err.message).not.toBe(FB);
+    expect(err.message).toMatch(/still running|did not crash/i);
+    expect(err.message).not.toMatch(/ASR/i);
+  });
+
+  it('names the proxy as the likely cause in a served deployment', async () => {
+    const { streamDropError } = await import('../utils/backendCrash');
+    const err = await streamDropError(FB, async () => null, {
+      probeAlive: async () => true,
+      waitMs: 0,
+    });
+    expect(err.message).toMatch(/proxy|buffering/i);
+  });
+
+  it("keeps the caller's message when the backend is gone too", async () => {
+    const { streamDropError } = await import('../utils/backendCrash');
+    const err = await streamDropError(FB, async () => null, {
+      probeAlive: async () => false,
+      waitMs: 0,
+    });
+    expect(err.message).toBe(FB);
+  });
+
+  it('a real crash marker still wins over the liveness probe', async () => {
+    const { streamDropError } = await import('../utils/backendCrash');
+    const marker = {
+      ts: Math.floor(Date.now() / 1000) - 5,
+      exit_code: null,
+      signal: 9,
+      exit_desc: 'signal: 9',
+      backend_version: '0.4.2',
+      uptime_s: 30,
+      last_stderr: '',
+      acknowledged: false,
+    };
+    const err = await streamDropError(FB, async () => marker, {
+      probeAlive: async () => true,
+      waitMs: 0,
+    });
+    expect(err.message).toMatch(/memory \(RAM\)/);
+  });
+});

--- a/frontend/src/utils/backendCrash.ts
+++ b/frontend/src/utils/backendCrash.ts
@@ -313,10 +313,36 @@ export function crashAge(marker: Pick<BackendCrashMarker, 'ts'>, nowMs = Date.no
  * `getCrash` is an injectable seam (same idea as services/endpoint_race's
  * injectable probers) so the branch logic is unit-testable without a shell.
  */
+/** Is the backend answering right now? Short timeout — this runs on a failure
+ *  path and must not add a visible stall. Any error means "cannot tell". */
+async function _probeBackendAlive(): Promise<boolean> {
+  try {
+    const { apiUrl } = await import('../api/client.ts');
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 2000);
+    try {
+      const res = await fetch(apiUrl('/system/info'), {
+        signal: controller.signal,
+        headers: _fallbackHeaders(),
+      });
+      return res.ok;
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return false;
+  }
+}
+
 export async function streamDropError(
   fallbackMessage: string,
   getCrash: () => Promise<BackendCrashMarker | null> = getUnacknowledgedBackendCrash,
-  opts: { waitMs?: number; intervalMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+  opts: {
+    waitMs?: number;
+    intervalMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+    probeAlive?: () => Promise<boolean>;
+  } = {},
 ): Promise<Error> {
   // #1119: the shell learns the backend died from a ~2 s POLL — it must notice
   // the child exit and write the crash marker. Asking for that marker ONCE, at
@@ -346,7 +372,35 @@ export async function streamDropError(
     if (Date.now() >= deadline) break;
     await sleep(intervalMs);
   }
-  if (!crash) return new Error(fallbackMessage);
+  if (!crash) {
+    // No crash marker — but "no marker" is not "the backend died and we missed
+    // it". Outside the Tauri shell there is no death watcher at all, so this
+    // branch is where every browser/Docker user lands, and the caller's
+    // fallback used to assert a cause on their behalf ("Likely ASR backend
+    // failed to load"). #1242 reported exactly that, in `server` mode, with the
+    // backend having answered 20 s earlier — so nothing had crashed and nothing
+    // had failed to load.
+    //
+    // Ask instead of assuming. If the backend is still answering, the process
+    // did not go away, which rules the caller's guess out: in a served
+    // deployment a stream that dies while the server is healthy is
+    // characteristically a reverse proxy or load balancer buffering or timing
+    // out the SSE connection.
+    const probeAlive = opts.probeAlive ?? _probeBackendAlive;
+    if (await probeAlive()) {
+      return new Error(
+        i18next.t('errors.stream_cut_backend_alive', {
+          defaultValue:
+            'The stream ended early, but the backend is still running — so it did not crash. ' +
+            'In a served or containerised setup this is usually a reverse proxy or load balancer ' +
+            'buffering or timing out the connection: disable response buffering for this route ' +
+            '(nginx: proxy_buffering off; X-Accel-Buffering: no) and raise its read timeout. ' +
+            'Running the desktop app directly, or on localhost without a proxy, will confirm it.',
+        }),
+      );
+    }
+    return new Error(fallbackMessage);
+  }
   try {
     window.dispatchEvent(new CustomEvent('ov:backend-crashed', { detail: crash }));
   } catch {


### PR DESCRIPTION
Closes #1242.

## The report

> Transcribe stream dropped before emitting any segments. **Likely ASR backend failed to load** — check backend log + Settings → Models.

With, from the same report:

```
Deployment mode:       server
Last backend response: 20 s before this report
Recent actions:        engine:asr=faster-whisper → view:studio → view:dub → dub:upload
```

The backend was alive. Nothing crashed. The ASR model had loaded. The message sent them after a model that was fine.

## Why the existing forensics didn't catch it

`streamDropError()` already consults the crash marker (#941/#1062/#1119) — but **"no crash marker" is not "the backend died and we missed it."** Outside the Tauri shell there is no death watcher at all, so that branch is where *every* browser and Docker user lands, and there the caller's fallback string stood unchallenged.

## Ask, don't assume

If the backend is **still answering**, the process did not go away — which rules the caller's guess out. And in a served or containerised deployment, a stream that dies while the server is healthy is characteristically a reverse proxy or load balancer buffering or timing out SSE.

So that case now says so, and names the two settings that actually fix it (`proxy_buffering off` / `X-Accel-Buffering: no`, and the read timeout).

Precedence is unchanged where it was already right:

| Signal | Message |
|---|---|
| Crash marker found | The real crash story (wins over the probe) |
| No marker, backend answering | Proxy/transport, with the fix |
| No marker, backend gone | Caller's message |

The dub fallback no longer names a cause either — it is only reached when both signals are inconclusive, and that is the one situation where we genuinely do not know.

## Tests

4 new cases on the no-marker branch: does not mention ASR when the backend is alive, names the proxy, keeps the caller's message when the backend is gone, and a real crash marker still takes precedence over a live probe.

Full frontend suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Improved dubbing stream-drop errors by probing backend liveness, preserving crash-marker precedence, and reporting likely proxy or timeout issues instead of blaming the ASR model. Unavailable backends retain caller fallback messages, while dub fallback wording is less causal and proxy-buffering/read-timeout guidance is included. Added four tests covering live backends, proxy failures, unavailable backends, and real crashes; human review should verify probe timeout and deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->