### PR TITLE
docs(engines): publish the engine-acceptance bar

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,6 +13,12 @@ Thanks for your interest in improving OmniVoice Studio! This guide covers everyt
 
 ---
 
+## Adding a TTS or ASR engine
+
+New engines are hired for a **named job**, not added to a list — the bar, the current job map,
+and the out-of-tree path are in [docs/engine-acceptance.md](../docs/engine-acceptance.md).
+Read it before opening a proposal; the licence check in particular ends most of them.
+
 ## Development Setup
 
 ### Prerequisites

--- a/docs/engine-acceptance.md
+++ b/docs/engine-acceptance.md
@@ -1,0 +1,69 @@
+# Adding a TTS or ASR engine
+
+OmniVoice ships a lot of engines. That breadth is only an asset while every one
+of them still works on every platform — otherwise it is a pile of support
+queues, and the project's actual promise (*a first run that works*) is what pays
+for it.
+
+So new engines are **hired for a job**, not added to a list.
+
+## The job map
+
+Every engine in the tree owns at least one job. A job has exactly one holder.
+
+| Job | Held by |
+| --- | --- |
+| Best zero-shot clone quality | `omnivoice` |
+| Widest language coverage | `omnivoice` |
+| Crash isolation for the default model | `omnivoice-subprocess` |
+| Fastest CPU render / lowest latency | *open — see #1306* |
+| Best Chinese/Japanese expressiveness | `cosyvoice`, `indextts2` |
+| CPU-realtime English, tiny footprint | `kittentts`, `supertonic3` |
+| Best transcription accuracy | `whisperx`, `faster-whisper` |
+| Fastest Apple-Silicon transcription | `parakeet-mlx`, `mlx-whisper` |
+| Crash isolation for transcription | `faster-whisper-isolated` |
+
+A proposal must either **take a job from its current holder** (with numbers) or
+**claim a job nothing covers**. "It benchmarks well" is not a job.
+
+## The bar
+
+A new engine is accepted when all of these hold. Miss one and the answer is no —
+which is a property of the bar, not a judgement of the contributor.
+
+1. **A job, named.** Which row above it takes or adds, and why the incumbent
+   does not cover it. Latency, language, hardware envelope or quality tier —
+   something a user would choose it *for*.
+2. **Licence clean for commercial use.** Model weights *and* code. No
+   research-only weights, no ambiguous provenance. This is the one that most
+   often ends a proposal, so check it first.
+3. **Every platform, or explicitly opt-in.** macOS (Apple Silicon and Intel),
+   Windows, Linux. A CPU path is required — an engine that only runs on one
+   accelerator is fine, but it must degrade rather than break, and a
+   platform-only engine goes behind an opt-in (see CLAUDE.md's parity rule).
+4. **Fits the existing adapter.** `TTSBackend` / `SubprocessBackend` with no
+   changes to core pipelines. A dependency profile that conflicts with ours
+   means a sidecar (`SubprocessBackend`), which is a solved shape — see
+   `docs/engines/omnivoice-subprocess.md`.
+5. **A CI smoke test in the same PR.** It does not need a GPU: stub the sidecar,
+   assert the adapter contract. An integration with no test is an integration
+   nobody will notice breaking.
+6. **A named steward.** The proposer commits to being the point of contact for
+   that engine's issues for 12 months. No steward, no merge — this is the
+   difference between breadth and debt.
+7. **Demand evidence.** A real request, a real workflow, a real user. Ideally
+   someone already working around its absence.
+
+## Deprecation
+
+Breadth is only worth carrying while it is alive. An engine is archived when,
+for two consecutive releases, it has **no steward** and **no passing smoke
+test**. Archiving is not a judgement either — it is how the remaining engines
+stay trustworthy.
+
+## If it doesn't clear the bar
+
+The adapter interface is public. An engine can live out-of-tree, be installed
+alongside, and be selected by id — you do not need our merge to use your engine,
+and we would rather link a good external engine than carry a half-maintained
+internal one.


### PR DESCRIPTION
Context: #1306 proposes a 15th TTS engine. Rather than decide it by mood, this writes down the bar — so "no" becomes a property of the bar rather than a judgement of the contributor, and "yes" can be fast.

## The framing

The project carries **14 TTS + 11 ASR engines across 4 platforms with one maintainer**. That breadth is an asset only while every one of them still works; otherwise it is a pile of support queues, and the first-run promise is what pays for it.

So engines are **hired for a named job**, not added to a list. Each job has exactly one holder, and a proposal must either take a job from the incumbent (with numbers) or claim a job nothing covers. "It benchmarks well" is not a job.

The doc includes the current job map — which also makes visible that **"fastest CPU render / lowest latency" is currently unheld**. That is the gap #1306 is claiming.

## The seven conditions

Named job · licence clean for commercial use (weights *and* code) · every platform or explicit opt-in · fits the existing adapter with no core changes · CI smoke test in the same PR · **a named steward for 12 months** · demand evidence.

The steward requirement is the one that separates breadth from debt.

## Deprecation

An engine is archived after two consecutive releases with no steward *and* no passing smoke test. Not a judgement — it is how the remaining engines stay trustworthy.

## Out-of-tree

The adapter interface is public. An engine can live outside the repo and still be selected by id: nobody needs our merge to use their engine, and linking a well-maintained external engine beats carrying a half-maintained internal one.

Linked from `.github/CONTRIBUTING.md` in the same PR (docs-sync).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added documentation defining the acceptance criteria and lifecycle for new TTS/ASR engines, including named job ownership, licensing, platform support, compatibility, CI coverage, stewardship, and demand evidence. Linked the guidance from the contributor documentation to make the proposal workflow discoverable. The main risk is ensuring the criteria and deprecation policy are practical and consistently enforceable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->