### PR TITLE
test: patch the model_manager module main actually uses (#1269 residual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### CI
 
 - Windows smoke tests stopped silently passing a broken ffmpeg install, and every smoke leg is now budgeted for a cold dependency install. (#1290)
-- Test suites no longer leak config paths into one another, which had been failing unrelated pull requests. (#1269)
+- Test suites no longer leak config paths or model-manager shutdown state into one another, which had been failing unrelated pull requests. (#1269)
 
 ## [0.4.2] — 2026-07-28
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -112,7 +112,7 @@ def _clear_asr_installed_memo(request):
 
 
 @pytest.fixture(autouse=True)
-def _clean_model_manager_shutdown_state():
+def _clean_model_manager_shutdown_state(request):
     """Start every test with the model manager NOT in shutdown mode (#1269).
 
     ``model_manager._shutting_down`` is a module-global Event and the GPU pool is
@@ -132,8 +132,36 @@ def _clean_model_manager_shutdown_state():
 
     Reset before AND after: before so an inherited flag cannot decide this test,
     after so a test that legitimately shuts down does not hand the state on.
+
+    Cleans the module in ``sys.modules`` AND any module-typed alias the test
+    module holds (``import services.model_manager as mm`` at module scope) — the
+    same stale-alias class ``asr_model_installed`` above handles. Test modules
+    bind that alias at COLLECTION time; ``tests/backend/**`` purges
+    ``services.*`` from ``sys.modules`` after every test it owns, so in a
+    combined ``pytest tests/ backend/tests/`` run the alias and the live module
+    are two different objects. Cleaning only one of them means a test dirties
+    the alias and the next test reads it still dirty
+    (``test_shutdown_state_isolation.py::test_next_test_starts_clean``).
     """
-    import services.model_manager as _mm
+    import types
+
+    def _targets():
+        # Import rather than probe sys.modules: unchanged from the original
+        # fixture, and it guarantees a live module to reset even in a run where
+        # a sibling suite purged the name.
+        import services.model_manager as mod
+
+        # `import x.y as z` binds the PACKAGE ATTRIBUTE, which can diverge from
+        # the sys.modules entry after module surgery — take both.
+        found = {id(m): m for m in (mod, sys.modules.get("services.model_manager"))
+                 if m is not None}
+        test_module = getattr(request, "module", None)
+        if test_module is not None:
+            for val in vars(test_module).values():
+                if (isinstance(val, types.ModuleType)
+                        and getattr(val, "__name__", "") == "services.model_manager"):
+                    found[id(val)] = val
+        return found.values()
 
     def _clean():
         # Deliberately NOT wrapped in try/except. A reset that fails silently
@@ -142,8 +170,9 @@ def _clean_model_manager_shutdown_state():
         # swallowing the error would defeat the fixture while looking like it
         # worked (CodeRabbit). If either of these can raise, that is a real
         # problem in model_manager and it should be loud.
-        _mm.reset_shutdown_flag()
-        _mm._reset_gpu_pool()
+        for mod in _targets():
+            mod.reset_shutdown_flag()
+            mod._reset_gpu_pool()
 
     _clean()
     yield

--- a/backend/tests/test_model_load_shutdown.py
+++ b/backend/tests/test_model_load_shutdown.py
@@ -14,8 +14,10 @@ instead. See model_manager.py and main.py's lifespan wiring
 (``begin_shutdown``/``reset_shutdown_flag``).
 """
 import asyncio
+import contextlib
 import logging
 import os
+import sys
 import threading
 import types
 
@@ -26,6 +28,48 @@ from services.model_manager import (
     ModelLoadInterruptedByShutdown,
     _is_interpreter_shutdown_error,
 )
+
+_PURGED_PREFIXES = ("core.", "api.", "services.")
+_PURGED_NAMES = ("main", "core", "api", "services")
+
+
+@contextlib.contextmanager
+def _reimported_backend_modules():
+    """Run the block against FRESHLY imported ``main``/``core``/``api``/
+    ``services`` modules, then put the originals back.
+
+    The module-level ``import services.model_manager as mm`` above binds at
+    COLLECTION time. ``tests/backend/conftest.py`` purges exactly these names
+    from ``sys.modules`` after every test it owns, so in a combined
+    ``pytest tests/ backend/tests/`` run a later ``import main`` here builds its
+    lifespan on a NEW ``services.model_manager`` object — and the ``mm`` alias
+    is a stale copy whose globals nothing reads. ``monkeypatch.setattr(mm, ...)``
+    then patched nothing: the real ``preload_model`` ran, found no fake loader,
+    and the test failed on ``assert started.is_set()`` while passing alone
+    (#1269 residual).
+
+    Tests that only exercise model_manager stay self-consistent on the alias.
+    Any test that patches model_manager and then drives *main* must resolve the
+    live module — this context manager makes that path deterministic in
+    isolation, so the bug reproduces without needing the sibling suite.
+    """
+    saved = {
+        name: mod for name, mod in sys.modules.items()
+        if name in _PURGED_NAMES or name.startswith(_PURGED_PREFIXES)
+    }
+    def _purge():
+        for name in [n for n in sys.modules
+                     if n in _PURGED_NAMES or n.startswith(_PURGED_PREFIXES)]:
+            sys.modules.pop(name, None)
+    _purge()
+    try:
+        yield
+    finally:
+        # Drop whatever the block imported, then restore the originals — a
+        # half-restored tree (fresh submodule under a stale package) is exactly
+        # the split-import hazard this guards against.
+        _purge()
+        sys.modules.update(saved)
 
 
 @pytest.fixture(autouse=True)
@@ -273,64 +317,74 @@ def test_lifespan_shutdown_mid_load_is_clean_and_clears_sentinel(
     interaction the #1174 fix has to preserve)."""
     from fastapi import FastAPI
 
-    import main as main_mod
-    from core import run_sentinel
+    with _reimported_backend_modules():
+        import main as main_mod
+        from core import run_sentinel
 
-    monkeypatch.setattr(run_sentinel, "SENTINEL_PATH", str(tmp_path / "run_sentinel.json"))
-    monkeypatch.setattr(run_sentinel, "CRASH_RECORD_PATH", str(tmp_path / "last_run_crash.json"))
-    monkeypatch.setattr(run_sentinel, "LOG_PATH", str(tmp_path / "omnivoice.log"))
-    run_sentinel._reset_for_tests()
+        # The module object main's lifespan actually loads through — NOT the
+        # module-level `mm` alias, which a sibling suite's sys.modules purge can
+        # leave stale (see _reimported_backend_modules).
+        live_mm = sys.modules["services.model_manager"]
 
-    fake_torch = types.SimpleNamespace(
-        float16="f16",
-        cuda=types.SimpleNamespace(is_available=lambda: False),
-        backends=types.SimpleNamespace(),
-    )
-    monkeypatch.setattr(mm, "_lazy_torch", lambda: fake_torch)
-    monkeypatch.setattr(mm, "model", None)
-    monkeypatch.setattr(mm, "_model_lock", asyncio.Lock())
-    monkeypatch.setattr(mm, "_checkpoint_in_local_cache", lambda c: True)
-    monkeypatch.setenv("OMNIVOICE_PRELOAD_CAPTURE_ASR", "0")
-
-    started = threading.Event()
-    release = threading.Event()
-
-    def _wedged_load():
-        started.set()
-        release.wait(30)
-        raise RuntimeError("cannot schedule new futures after interpreter shutdown")
-
-    async def _fake_load_with_timeout():
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(mm._get_gpu_pool(), _wedged_load)
-
-    monkeypatch.setattr(mm, "_load_model_with_timeout", _fake_load_with_timeout)
-
-    async def scenario():
-        app = FastAPI()
-        async with main_mod.lifespan(app):
-            # The preload's load really is in flight on a pool thread. Poll
-            # asynchronously — a blocking Event.wait would starve the loop the
-            # preload task needs to reach run_in_executor.
-            for _ in range(200):
-                if started.is_set():
-                    break
-                await asyncio.sleep(0.05)
-            assert started.is_set()
-        # Lifespan shutdown completed while that thread was still wedged.
-
-    try:
-        asyncio.run(scenario())
-        # The clean shutdown retired the sentinel…
-        assert not os.path.exists(run_sentinel.SENTINEL_PATH)
-        # …so the next startup must NOT see a crash.
-        assert run_sentinel.detect_unclean_shutdown() is None
-        # And the model_manager was flipped into shutdown mode first, so the
-        # wedged load classifies executor rejections as benign.
-        assert mm.is_shutting_down() is True
-    finally:
-        release.set()
+        monkeypatch.setattr(run_sentinel, "SENTINEL_PATH", str(tmp_path / "run_sentinel.json"))
+        monkeypatch.setattr(run_sentinel, "CRASH_RECORD_PATH", str(tmp_path / "last_run_crash.json"))
+        monkeypatch.setattr(run_sentinel, "LOG_PATH", str(tmp_path / "omnivoice.log"))
         run_sentinel._reset_for_tests()
+
+        fake_torch = types.SimpleNamespace(
+            float16="f16",
+            cuda=types.SimpleNamespace(is_available=lambda: False),
+            backends=types.SimpleNamespace(),
+        )
+        monkeypatch.setattr(live_mm, "_lazy_torch", lambda: fake_torch)
+        monkeypatch.setattr(live_mm, "model", None)
+        monkeypatch.setattr(live_mm, "_model_lock", asyncio.Lock())
+        monkeypatch.setattr(live_mm, "_checkpoint_in_local_cache", lambda c: True)
+        monkeypatch.setenv("OMNIVOICE_PRELOAD_CAPTURE_ASR", "0")
+        # A fresh import inherits nothing from the previous lifespan, but an
+        # in-place one would: arm loads explicitly so a leaked shutdown flag
+        # can't make the preload bail before it starts.
+        live_mm.reset_shutdown_flag()
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _wedged_load():
+            started.set()
+            release.wait(30)
+            raise RuntimeError("cannot schedule new futures after interpreter shutdown")
+
+        async def _fake_load_with_timeout():
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(live_mm._get_gpu_pool(), _wedged_load)
+
+        monkeypatch.setattr(live_mm, "_load_model_with_timeout", _fake_load_with_timeout)
+
+        async def scenario():
+            app = FastAPI()
+            async with main_mod.lifespan(app):
+                # The preload's load really is in flight on a pool thread. Poll
+                # asynchronously — a blocking Event.wait would starve the loop the
+                # preload task needs to reach run_in_executor.
+                for _ in range(200):
+                    if started.is_set():
+                        break
+                    await asyncio.sleep(0.05)
+                assert started.is_set()
+            # Lifespan shutdown completed while that thread was still wedged.
+
+        try:
+            asyncio.run(scenario())
+            # The clean shutdown retired the sentinel…
+            assert not os.path.exists(run_sentinel.SENTINEL_PATH)
+            # …so the next startup must NOT see a crash.
+            assert run_sentinel.detect_unclean_shutdown() is None
+            # And the model_manager was flipped into shutdown mode first, so the
+            # wedged load classifies executor rejections as benign.
+            assert live_mm.is_shutting_down() is True
+        finally:
+            release.set()
+            run_sentinel._reset_for_tests()
 
 
 def test_request_during_shutdown_gets_503_not_a_crash_shaped_500():

--- a/backend/tests/test_shutdown_state_isolation.py
+++ b/backend/tests/test_shutdown_state_isolation.py
@@ -7,13 +7,25 @@ raising "cannot schedule new futures after shutdown" — swallowed by the preloa
 path as a benign shutdown, so the symptom is a load that silently never starts.
 
 A fixture with nothing asserting it is a fixture nobody notices breaking. The
-pair below is deliberately order-dependent (pytest runs tests in definition
-order within a file): the first test dirties exactly the state the lifespan
-dirties, the second asserts it arrived clean. Delete the fixture and the second
-test fails; that is the fail-before/pass-after this file exists to provide.
+two pairs below are deliberately order-dependent (pytest runs tests in
+definition order within a file): the first test of each pair dirties exactly the
+state the lifespan dirties, the second asserts it arrived clean. Delete the
+fixture and the second test fails; that is the fail-before/pass-after this file
+exists to provide.
+
+The second pair covers the stale-alias half of the fixture. Test modules bind
+``import services.model_manager as mm`` at COLLECTION time, and ``tests/backend/
+**`` purges ``services.*`` from ``sys.modules`` after every test it owns — so in
+a combined ``pytest tests/ backend/tests/`` run the alias and the live module
+are two different objects, and a fixture that cleans only ``sys.modules`` leaves
+the alias dirty. That is not hypothetical: it is how ``test_next_test_starts_
+clean`` below failed in combined runs while passing alone. The pair fabricates
+the duplicate module explicitly so the condition reproduces in isolation.
 """
 
+import importlib
 import os
+import sys
 
 import services.model_manager as mm
 
@@ -35,6 +47,47 @@ def test_next_test_starts_clean():
         "in backend/tests/conftest.py is not resetting it, and every executor "
         "submit in this test will now raise 'cannot schedule new futures after "
         "shutdown' and be misread as a benign cancellation (#1269)"
+    )
+
+
+# Bound by the test below to a SECOND copy of services.model_manager — the
+# stand-in for the alias a sibling suite's sys.modules purge strands. Module
+# scope on purpose: the fixture discovers cleanup targets by scanning this
+# module's globals, exactly as it discovers a real `import ... as mm` alias.
+stale_mm = None
+
+
+def test_dirty_a_stale_module_alias():
+    """Leave a *duplicate* model_manager module in the post-shutdown state."""
+    global stale_mm
+    live = sys.modules.pop("services.model_manager")
+    try:
+        stale_mm = importlib.import_module("services.model_manager")
+    finally:
+        sys.modules["services.model_manager"] = live
+        # Re-point the PACKAGE attribute too. `import services.model_manager as
+        # mod` reads it (not sys.modules) for the `as` binding, so leaving it on
+        # the duplicate would hand the fixture the very module this test just
+        # stranded — the guard would pass for the wrong reason.
+        setattr(sys.modules["services"], "model_manager", live)
+    assert stale_mm is not live, "expected a genuinely distinct module object"
+    assert importlib.import_module("services.model_manager") is live
+
+    stale_mm.begin_shutdown()
+    stale_mm._reset_gpu_pool()
+    assert stale_mm.is_shutting_down()
+
+
+def test_stale_module_alias_starts_clean():
+    """Runs immediately after the test above. The fixture has to reach the
+    alias, not just ``sys.modules["services.model_manager"]``."""
+    assert stale_mm is not None, "the previous test did not run — check ordering"
+    assert not stale_mm.is_shutting_down(), (
+        "the shutdown flag leaked on a stale duplicate of services.model_manager "
+        "— the autouse fixture in backend/tests/conftest.py is only cleaning the "
+        "module in sys.modules, so in a combined `pytest tests/ backend/tests/` "
+        "run every backend/tests module that holds an `import services."
+        "model_manager as mm` alias starts dirty (#1269)"
     )
 
 

--- a/backend/tests/test_shutdown_state_isolation.py
+++ b/backend/tests/test_shutdown_state_isolation.py
@@ -69,7 +69,7 @@ def test_dirty_a_stale_module_alias():
         # mod` reads it (not sys.modules) for the `as` binding, so leaving it on
         # the duplicate would hand the fixture the very module this test just
         # stranded — the guard would pass for the wrong reason.
-        setattr(sys.modules["services"], "model_manager", live)
+        sys.modules["services"].model_manager = live
     assert stale_mm is not live, "expected a genuinely distinct module object"
     assert importlib.import_module("services.model_manager") is live
 


### PR DESCRIPTION
Closes the residual of #1269.

`tests/backend/conftest.py` purges `main` / `core*` / `api*` / `services*` from `sys.modules` after every test it owns. Modules under `backend/tests/` bind `import services.model_manager as mm` at **collection** time, so in a combined `pytest tests/ backend/tests/` session the alias and the live module are two different objects. Two tests were reading the wrong one — and CI's split invocation hid both.

### Fixed

- `test_lifespan_shutdown_mid_load_is_clean_and_clears_sentinel` patched the stale alias, then drove `main`'s lifespan, which loads through the live module. The fakes were never applied: the real `preload_model` ran, the wedged loader never started, and the test failed on `assert started.is_set()`. It now runs inside a `_reimported_backend_modules()` context that purges and restores those names, and resolves the module from `sys.modules` after importing `main` — so the failure is deterministic **standalone**, not only in combined runs.
- Same class, second instance (found while checking for it): the autouse `_clean_model_manager_shutdown_state` fixture resolved from `sys.modules` while `test_shutdown_state_isolation.py` dirtied the alias, so `test_next_test_starts_clean` failed under the same ordering. The fixture now cleans the live module **and** any module-typed alias in the requesting test module — the idiom already used there for `asr_backend`. It takes both the `import x.y as z` binding (which reads the *package attribute*) and the `sys.modules` entry, since module surgery can separate the two.

### Added

- A fail-before/pass-after pair (`test_dirty_a_stale_module_alias` / `test_stale_module_alias_starts_clean`) fabricates the duplicate module explicitly, so the alias half of the fixture is guarded in isolation.

### Verification

| Run | Result |
| --- | --- |
| `pytest backend/tests/` | 220 passed |
| `pytest tests/ backend/tests/` | 3967 passed, 25 skipped, 2 xfailed, 6 xpassed |
| `pytest tests/backend/api/test_engines_route_shape.py backend/tests/test_model_load_shutdown.py` (the failing order) | green |

Each fix was confirmed fail-before independently by reverting just that hunk.

No production code touched; test-infrastructure only. CHANGELOG's existing `### CI` #1269 line was extended rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the pytest shutdown-state fixtures and related shutdown/lifespan tests to reliably reset and patch the live `services.model_manager` module even when stale module aliases linger after `sys.modules` cleanup. Added regression coverage for duplicate alias scenarios and shutdown-state isolation, and extended the CI CHANGELOG entry accordingly—no production code changes. Risk to review: test infrastructure now manipulates `sys.modules` and module instances more broadly, so fixture correctness and unintended cross-test coupling are the main concerns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->