### PR TITLE
fix(audiobook): say why a chapter failed, and don't hang when an engine stops (#1321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - The watermark can be turned off in Settings, as the docs always said
 - macOS support now matches what the app actually delivers
 - Linux AppImage: a blank white window on rolling distros (Mesa 26.1+) now starts normally
+- A failed audiobook chapter says why, instead of turning red and saying nothing
 
 ### Changed
 
@@ -37,6 +38,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - macOS Preview updates work again — the updater bundle had been colliding with itself since early July. (#1281)
 - A dub whose transcription stream is cut by a reverse proxy now says so, instead of blaming the ASR model. (#1317)
 - The dev backend going quiet under `--reload` is named as auto-reload rather than reported as a crash. (#1261)
+- Audiobook: a chapter that fails to render now shows the reason in the chapter list and in the final error, instead of a red row whose cause existed only in the backend log — thanks @Reaksa-Cambodia! (#1321)
+- Audiobook: an engine that stops without producing audio no longer stalls the render forever with no error and no timeout. (#1321)
 - Linux AppImage: a permanently blank window on Mesa 26.1+ hosts (Arch/CachyOS and other rolling distros) — the bundled WebKit ran against a newer system Mesa than it was built for, and no environment variable could help because the failure precedes every rendering flag; the launcher now lets a newer system WebKitGTK take precedence — thanks @rvasilev and @HannaLovvold! (#1258, #1244)
 - Linux AppImage: `OMNIVOICE_PREFER_SYSTEM_WEBKIT=1` forces your own WebKitGTK for hosts where its version can't be read automatically (no `pkg-config`), and `=0` forces the bundled one (#1258)
 

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -760,6 +760,7 @@ async def _render_longform_sse(
     convergence point: one renderer, two front doors.
     """
     from core.config import OUTPUTS_DIR
+    from core.failure import build_failure, build_failure_event
     from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
     from services.model_manager import _gpu_pool
 
@@ -849,6 +850,9 @@ async def _render_longform_sse(
         chapters_meta: list[tuple[str, int]] = []
         cached_n = 0
         failed: list[int] = []
+        # Kept so the terminal "all chapters failed" event can name the cause
+        # instead of restating the symptom (#1321).
+        last_chapter_exc: Exception | None = None
         interrupted = False
         yield _emit({"type": "started", "job_id": job_id, "chapters": total})
 
@@ -878,12 +882,28 @@ async def _render_longform_sse(
                     chapter, synth, sr, engine_id, resolve, cache_dir, lexicon,
                     resolved_lang, opts, voice_map,
                 )
-            except Exception:  # isolate a bad chapter — keep going
+            except Exception as e:  # isolate a bad chapter — keep going
                 logger.warning("[%s] chapter %d (%s) failed to render",
                                job_id, i, chapter.title, exc_info=True)
                 failed.append(i)
+                # Carry the real reason (#1321). The old event said only
+                # "chapter failed to render", so a failed chapter was a red row
+                # and nothing else — the cause existed solely in the backend log,
+                # which is why the report for this arrived as a bare traceback.
+                # build_failure guarantees a non-empty reason even for exceptions
+                # whose str() is empty (a generator-based engine that yields
+                # nothing raises a bare StopIteration), sanitizes paths/tokens,
+                # and adds the docs deeplink + hint. `error` stays populated —
+                # build_failure mirrors reason into it — so older frontends and
+                # the Stories exporter keep working.
+                last_chapter_exc = e
                 yield _emit({"type": "chapter_error", "index": i, "total": total,
-                             "title": chapter.title, "error": "chapter failed to render"})
+                             "title": chapter.title,
+                             # No env diagnostic per chapter: a book can fail
+                             # hundreds of times and it is identical every time.
+                             # The terminal error below carries one.
+                             **build_failure(e, stage="audiobook_chapter",
+                                             include_diagnostic=False)})
                 continue
             chapter_files.append(wav_path)
             chapters_meta.append((chapter.title, int(round(dur * 1000))))
@@ -920,7 +940,19 @@ async def _render_longform_sse(
             return
 
         if not chapter_files:
-            yield _emit({"type": "error", "error": "all chapters failed to render"})
+            # Every chapter failed, so the render is over — this is the event the
+            # UI turns into a toast, and it used to carry only the symptom
+            # (#1321). Lead with the summary, then the cause; docs_topic/hint are
+            # classified from the raw exception text, so prefixing the reason
+            # afterwards cannot mis-route the deeplink.
+            if last_chapter_exc is not None:
+                ev = build_failure_event(last_chapter_exc, stage="audiobook_render")
+                ev["reason"] = f"all {total} chapters failed to render — {ev['reason']}"
+                ev["error"] = ev["reason"]
+            else:
+                ev = {"type": "error", "error": "all chapters failed to render",
+                      "reason": "all chapters failed to render"}
+            yield _emit(ev)
             return
 
         yield _emit({"type": "assembling"})

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -952,6 +952,19 @@ async def _render_longform_sse(
             else:
                 ev = {"type": "error", "error": "all chapters failed to render",
                       "reason": "all chapters failed to render"}
+            # Terminal failure — record it. This branch used to return without
+            # touching job history, so the row stayed `running` forever: the next
+            # startup read it as an interrupted job, and the retained manifest
+            # offered a render that had already failed every chapter as
+            # resumable (Greptile P1 on #1321). The manifest IS kept on purpose —
+            # a failure whose cause the user can now see (a missing voice, an
+            # engine that can't read the script) is worth retrying once fixed,
+            # and the chapter cache is empty here so a retry costs nothing extra.
+            if job_store is not None:
+                try:
+                    job_store.mark_failed(job_id, ev["reason"])
+                except Exception:
+                    pass  # best-effort job history; never block the stream
             yield _emit(ev)
             return
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -59,8 +59,52 @@ logger = logging.getLogger("omnivoice.model")
 _GPU_VRAM_PER_JOB_GB = 5.0
 _GPU_WORKER_CAP = 4
 
+class WorkerStopIteration(RuntimeError):
+    """A pool worker raised a bare ``StopIteration``.
+
+    asyncio refuses to put ``StopIteration`` into a Future — ``_copy_future_
+    state`` raises ``TypeError: StopIteration interacts badly with generators
+    and cannot be raised into a Future`` *inside the event loop's callback*, so
+    the ``run_in_executor`` future is never completed and the awaiting caller
+    waits **forever**. Not a theoretical edge: verified on the bundled CPython
+    3.11, and the failure has no error, no event and no timeout — a render just
+    stops, which is indistinguishable to the user from a wedged app.
+
+    Generator-driven engines reach it on ordinary bad input: VoxCPM's
+    ``next_and_close`` is a bare ``next(gen)``, so a generator that ends without
+    yielding (text the model normalises away to nothing, for instance) raises
+    exactly this out of ``backend.generate`` (#1321 class).
+
+    Translating it to a RuntimeError at the pool boundary — the one place every
+    dispatch funnels through — turns a silent hang into a normal failure that
+    the existing per-chapter / per-job error handling reports. Subclasses
+    RuntimeError so every `except Exception` site upstream keeps working.
+    """
+
+
+def _guard_stopiteration(fn):
+    """Wrap `fn` so a bare StopIteration can never escape into a Future."""
+    def _guarded(*a, **kw):
+        try:
+            return fn(*a, **kw)
+        except StopIteration as e:
+            raise WorkerStopIteration(
+                "the engine stopped without producing a result (StopIteration) — "
+                "its generator ended before yielding anything, which usually means "
+                "it could not handle this input"
+            ) from e
+    return _guarded
+
+
+class _GuardedCpuPool(ThreadPoolExecutor):
+    """CPU pool with the same StopIteration guard as the GPU pool."""
+
+    def submit(self, fn, /, *args, **kwargs):
+        return super().submit(_guard_stopiteration(fn), *args, **kwargs)
+
+
 _gpu_pool_singleton: "_ResilientGpuPool | None" = None
-_cpu_pool = ThreadPoolExecutor(max_workers=CPU_POOL_WORKERS)
+_cpu_pool = _GuardedCpuPool(max_workers=CPU_POOL_WORKERS)
 
 
 def _workers_for_free_vram(free_gb: float) -> int:
@@ -198,7 +242,9 @@ class _ResilientGpuPool(Executor):
                 self._running += 1
             t0 = time.monotonic()
             try:
-                return fn(*a, **kw)
+                # A bare StopIteration here would never reach the caller — it
+                # hangs the awaiting future instead (see WorkerStopIteration).
+                return _guard_stopiteration(fn)(*a, **kw)
             finally:
                 elapsed = time.monotonic() - t0
                 with self._stats_lock:

--- a/backend/tests/test_pool_stopiteration_guard.py
+++ b/backend/tests/test_pool_stopiteration_guard.py
@@ -1,0 +1,95 @@
+"""A bare ``StopIteration`` from a pool worker must fail, not hang (#1321).
+
+asyncio refuses to put ``StopIteration`` into a Future. The refusal does not
+raise where anyone can catch it: ``_copy_future_state`` raises ``TypeError:
+StopIteration interacts badly with generators and cannot be raised into a
+Future`` inside the event loop's *callback*, the ``run_in_executor`` future is
+left pending, and the awaiting coroutine waits forever. No error, no event, no
+timeout — an audiobook render simply stops emitting and the app looks wedged.
+
+This is reachable from ordinary user input. Engines that drive a generator hit
+it on text they cannot handle: VoxCPM's ``next_and_close`` is a bare
+``next(gen)``, so a generator that ends without yielding raises ``StopIteration``
+straight out of ``backend.generate`` and into the GPU-pool worker.
+
+Both tests below hang forever without the guard (hence the explicit
+``wait_for`` — a hang must fail the suite, not stall CI until the job timeout).
+"""
+import asyncio
+
+import pytest
+
+import services.model_manager as mm
+
+
+def _raise_bare_stopiteration():
+    raise StopIteration()
+
+
+def _run_on(executor):
+    async def _scenario():
+        loop = asyncio.get_running_loop()
+        # Bounded on purpose: the bug this guards against is an infinite wait.
+        return await asyncio.wait_for(
+            loop.run_in_executor(executor, _raise_bare_stopiteration), timeout=15
+        )
+
+    return asyncio.run(_scenario())
+
+
+def test_gpu_pool_translates_bare_stopiteration():
+    """The GPU pool is where every engine/model dispatch runs."""
+    with pytest.raises(mm.WorkerStopIteration):
+        _run_on(mm._get_gpu_pool())
+
+
+def test_cpu_pool_translates_bare_stopiteration():
+    """The CPU offload pool takes the same class of callable (dub_core parks
+    loads and mixes on it), so the guard has to cover it too."""
+    with pytest.raises(mm.WorkerStopIteration):
+        _run_on(mm._cpu_pool)
+
+
+def test_translated_error_is_a_runtimeerror():
+    """Upstream handlers catch ``Exception`` (and often ``RuntimeError``) — the
+    translation must not slip past them into a bare-except crash path."""
+    assert issubclass(mm.WorkerStopIteration, RuntimeError)
+
+
+def test_reason_is_non_empty_and_actionable():
+    """``str(StopIteration())`` is ``''``. A translation that kept an empty
+    message would trade a hang for "unknown error", which is the failure class
+    core.failure exists to prevent."""
+    with pytest.raises(mm.WorkerStopIteration) as ei:
+        _run_on(mm._get_gpu_pool())
+    text = str(ei.value)
+    assert text.strip()
+    assert "StopIteration" in text
+    # The original is kept as the cause, so the traceback still points at the
+    # engine frame that actually stopped.
+    assert isinstance(ei.value.__cause__, StopIteration)
+
+
+def test_normal_exceptions_are_untouched():
+    """The guard is narrow: only StopIteration is translated."""
+    def _boom():
+        raise ValueError("ordinary failure")
+
+    async def _scenario():
+        loop = asyncio.get_running_loop()
+        return await asyncio.wait_for(
+            loop.run_in_executor(mm._get_gpu_pool(), _boom), timeout=15
+        )
+
+    with pytest.raises(ValueError, match="ordinary failure"):
+        asyncio.run(_scenario())
+
+
+def test_return_values_pass_through():
+    async def _scenario():
+        loop = asyncio.get_running_loop()
+        return await asyncio.wait_for(
+            loop.run_in_executor(mm._get_gpu_pool(), lambda: 42), timeout=15
+        )
+
+    assert asyncio.run(_scenario()) == 42

--- a/frontend/src/components/audiobook/GenerationProgress.jsx
+++ b/frontend/src/components/audiobook/GenerationProgress.jsx
@@ -109,6 +109,10 @@ export default function GenerationProgress({ t, chapters = [], assembling = fals
           <li
             key={i}
             className={`audiobook-progress__row status-${c.status}`}
+            // A failed chapter used to be a red row with no reason anywhere in
+            // the UI (#1321). The row is single-line/ellipsised, so the full
+            // text lives in the native tooltip and the head of it renders inline.
+            title={c.status === 'failed' && c.error ? c.error : undefined}
             style={{
               display: 'flex',
               alignItems: 'center',
@@ -124,7 +128,15 @@ export default function GenerationProgress({ t, chapters = [], assembling = fals
               {c.title || t('audiobook.chapter_n', { n: i + 1 })}
             </span>
             {c.status === 'cached' && <span className="muted">· {t('audiobook.cached_tag')}</span>}
-            {c.status === 'failed' && <span className="muted">· {t('audiobook.failed_tag')}</span>}
+            {c.status === 'failed' && (
+              <span
+                className="muted"
+                style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+              >
+                · {t('audiobook.failed_tag')}
+                {c.error ? `: ${c.error}` : ''}
+              </span>
+            )}
           </li>
         ))}
       </ol>

--- a/frontend/src/components/audiobook/GenerationProgress.test.jsx
+++ b/frontend/src/components/audiobook/GenerationProgress.test.jsx
@@ -24,9 +24,7 @@ const CHAPTERS = [
 describe('GenerationProgress — failed chapter reason (#1321)', () => {
   it('shows the reason next to the failed chapter', () => {
     render(<GenerationProgress t={t} chapters={CHAPTERS} />);
-    expect(
-      screen.getByText(/the engine stopped without producing a result/i),
-    ).toBeTruthy();
+    expect(screen.getByText(/the engine stopped without producing a result/i)).toBeTruthy();
   });
 
   it('puts the full reason in the row tooltip, since the row is ellipsised', () => {

--- a/frontend/src/components/audiobook/GenerationProgress.test.jsx
+++ b/frontend/src/components/audiobook/GenerationProgress.test.jsx
@@ -1,0 +1,53 @@
+/**
+ * #1321: a failed chapter used to render as a red row with the word "failed"
+ * and nothing else. The reason existed only in the backend log, so the report
+ * for this arrived as a raw traceback pasted from a log file — the user had no
+ * way to see what the app already knew.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import GenerationProgress from './GenerationProgress.jsx';
+
+// `t` is a required prop (the panel takes the translator from its parent).
+const t = (key, vars) => (vars ? `${key} ${JSON.stringify(vars)}` : key);
+
+const CHAPTERS = [
+  { title: 'Good chapter', status: 'done' },
+  {
+    title: 'Bad chapter',
+    status: 'failed',
+    error: 'the engine stopped without producing a result (StopIteration)',
+  },
+];
+
+describe('GenerationProgress — failed chapter reason (#1321)', () => {
+  it('shows the reason next to the failed chapter', () => {
+    render(<GenerationProgress t={t} chapters={CHAPTERS} />);
+    expect(
+      screen.getByText(/the engine stopped without producing a result/i),
+    ).toBeTruthy();
+  });
+
+  it('puts the full reason in the row tooltip, since the row is ellipsised', () => {
+    const { container } = render(<GenerationProgress t={t} chapters={CHAPTERS} />);
+    const failedRow = container.querySelector('.status-failed');
+    expect(failedRow?.getAttribute('title')).toBe(CHAPTERS[1].error);
+  });
+
+  it('renders a failed chapter with no reason without printing "undefined"', () => {
+    const { container } = render(
+      <GenerationProgress t={t} chapters={[{ title: 'Bad', status: 'failed' }]} />,
+    );
+    const failedRow = container.querySelector('.status-failed');
+    expect(failedRow?.textContent).not.toMatch(/undefined/);
+    // No reason → no tooltip, rather than an empty one.
+    expect(failedRow?.getAttribute('title')).toBeNull();
+  });
+
+  it('leaves successful chapters untouched', () => {
+    const { container } = render(<GenerationProgress t={t} chapters={CHAPTERS} />);
+    const doneRow = container.querySelector('.status-done');
+    expect(doneRow?.getAttribute('title')).toBeNull();
+  });
+});

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -334,7 +334,12 @@ export default function AudiobookTab({ profiles = [] }) {
             setChapters((prev) =>
               prev.map((c, j) =>
                 j === evt.index
-                  ? { ...c, title: evt.title, status: 'failed', error: evt.reason || evt.error || '' }
+                  ? {
+                      ...c,
+                      title: evt.title,
+                      status: 'failed',
+                      error: evt.reason || evt.error || '',
+                    }
                   : j === evt.index + 1 && c.status === 'pending'
                     ? { ...c, status: 'rendering' }
                     : c,

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -334,7 +334,7 @@ export default function AudiobookTab({ profiles = [] }) {
             setChapters((prev) =>
               prev.map((c, j) =>
                 j === evt.index
-                  ? { ...c, title: evt.title, status: 'failed' }
+                  ? { ...c, title: evt.title, status: 'failed', error: evt.reason || evt.error || '' }
                   : j === evt.index + 1 && c.status === 'pending'
                     ? { ...c, status: 'rendering' }
                     : c,

--- a/tests/test_longform_e2e.py
+++ b/tests/test_longform_e2e.py
@@ -36,13 +36,15 @@ def _resolve(_voice_id):
     return {"ref_audio": None, "ref_text": None, "instruct": None, "seed": None}
 
 
-def _stub_build_synth(*, fail_on=None):
+def _stub_build_synth(*, fail_on=None, exc=None):
     """Return a drop-in for `audiobook._build_synth` whose `synth` emits 0.1s of
-    silence per span. `fail_on(text)` → raise, to exercise per-chapter faults."""
+    silence per span. `fail_on(text)` → raise, to exercise per-chapter faults;
+    `exc` overrides what is raised (an engine can fail with an exception whose
+    ``str()`` is empty — see the StopIteration case below)."""
     def _factory(default_voice=None, language=None, opts=None, voice_map=None):
         def synth(text, voice_id, speed=None):
             if fail_on is not None and fail_on(text):
-                raise RuntimeError("stub synth deliberately failed")
+                raise exc if exc is not None else RuntimeError("stub synth deliberately failed")
             return torch.zeros(2400)  # 0.1s @ 24k, 1-D float32
         return {"mode": "generic", "resolve": _resolve, "engine_id": "stub",
                 "synth": synth, "sample_rate": 24000}
@@ -58,11 +60,11 @@ def _plan(*chapters):
     ])
 
 
-def _collect_events(plan, monkeypatch, outputs_dir, *, fail_on=None, **kw):
+def _collect_events(plan, monkeypatch, outputs_dir, *, fail_on=None, exc=None, **kw):
     """Patch the synth + OUTPUTS_DIR, drive the real generator, return parsed
     SSE events (list of dicts)."""
     from api.routers import audiobook
-    monkeypatch.setattr(audiobook, "_build_synth", _stub_build_synth(fail_on=fail_on))
+    monkeypatch.setattr(audiobook, "_build_synth", _stub_build_synth(fail_on=fail_on, exc=exc))
     monkeypatch.setattr("core.config.OUTPUTS_DIR", str(outputs_dir))
 
     async def _run():
@@ -133,6 +135,17 @@ def test_partial_failure_isolates_bad_chapter(tmp_path, monkeypatch):
     assert "chapter_error" in types and "done" in types
     err = next(e for e in events if e["type"] == "chapter_error")
     assert err["index"] == 0
+    # #1321: the event has to name the cause. It used to say only "chapter
+    # failed to render", so the reason existed nowhere but the backend log and
+    # a user could not tell a bad voice from an engine that can't read their
+    # script. `error` keeps mirroring `reason` for older frontends.
+    assert "stub synth deliberately failed" in err["reason"]
+    assert err["error"] == err["reason"]
+    assert err["error_class"] == "RuntimeError"
+    assert err["stage"] == "audiobook_chapter"
+    # Per-chapter events carry no env diagnostic — it is identical for every
+    # chapter and a long book emits hundreds of these.
+    assert "diagnostic" not in err
     done = events[-1]
     assert done["chapters"] == 1 and done["failed_chapters"] == [0]
     assert (out / done["output"]).exists()  # the surviving chapter still muxed
@@ -145,9 +158,59 @@ def test_all_chapters_fail_emits_error_and_no_file(tmp_path, monkeypatch):
         _plan(("A", "x"), ("B", "y")), monkeypatch, out,
         fmt="m4b", fail_on=lambda t: True,
     )
-    assert events[-1] == {"type": "error", "error": "all chapters failed to render"}
+    err = events[-1]
+    assert err["type"] == "error"
+    # Summary first, then the cause (#1321) — the old event was the summary
+    # alone, which is the symptom the user already knew.
+    assert err["reason"].startswith("all 2 chapters failed to render — ")
+    assert "stub synth deliberately failed" in err["reason"]
+    assert err["error"] == err["reason"]
+    # Terminal event, so it does carry the env diagnostic the bug reporter reads.
+    assert err["diagnostic"]
     # No output file was produced.
     assert not any(p.suffix in (".m4b", ".mp3") for p in out.iterdir())
+
+
+def test_bare_stopiteration_from_an_engine_is_reported_not_hung(tmp_path, monkeypatch):
+    """#1321: a generator-based engine (VoxCPM's ``next_and_close`` is a bare
+    ``next(gen)``) raises ``StopIteration`` when its generator ends without
+    yielding. asyncio cannot put that into a Future, so before the pool guard
+    this call never returned at all — the render stopped emitting and waited
+    forever. It must come back as an ordinary chapter failure with a reason.
+
+    Without the guard in model_manager this test HANGS rather than fails, which
+    is exactly the user-visible symptom."""
+    out = tmp_path / "outputs"
+    out.mkdir()
+    events = _collect_events(
+        _plan(("A", "x")), monkeypatch, out,
+        fmt="m4b", fail_on=lambda t: True, exc=StopIteration(),
+    )
+    chapter_err = next(e for e in events if e["type"] == "chapter_error")
+    assert chapter_err["error_class"] == "WorkerStopIteration"
+    assert "StopIteration" in chapter_err["reason"]
+    assert chapter_err["error"] == chapter_err["reason"]
+    assert events[-1]["reason"].startswith("all 1 chapters failed to render — ")
+
+
+def test_chapter_error_names_an_exception_with_no_message(tmp_path, monkeypatch):
+    """An exception whose ``str()`` is empty must still produce a reason — any
+    emit site that formats ``str(e)`` would tell the user nothing at all. The
+    class name is the floor (#1252/#1253 class, re-asserted here for the
+    longform path)."""
+    class SilentEngineError(Exception):
+        pass
+
+    out = tmp_path / "outputs"
+    out.mkdir()
+    events = _collect_events(
+        _plan(("A", "x")), monkeypatch, out,
+        fmt="m4b", fail_on=lambda t: True, exc=SilentEngineError(),
+    )
+    chapter_err = next(e for e in events if e["type"] == "chapter_error")
+    assert chapter_err["reason"] == "SilentEngineError"
+    assert chapter_err["error"] == "SilentEngineError"
+    assert events[-1]["reason"] == "all 1 chapters failed to render — SilentEngineError"
 
 
 # ── degenerate / environment ────────────────────────────────────────────────

--- a/tests/test_longform_e2e.py
+++ b/tests/test_longform_e2e.py
@@ -60,9 +60,18 @@ def _plan(*chapters):
     ])
 
 
-def _collect_events(plan, monkeypatch, outputs_dir, *, fail_on=None, exc=None, **kw):
+def _collect_events(plan, monkeypatch, outputs_dir, *, fail_on=None, exc=None,
+                    timeout=120, **kw):
     """Patch the synth + OUTPUTS_DIR, drive the real generator, return parsed
-    SSE events (list of dicts)."""
+    SSE events (list of dicts).
+
+    Bounded on purpose. One of the failures this file covers — a bare
+    StopIteration from an engine, #1321 — does not raise, it WEDGES: asyncio
+    cannot put StopIteration into a Future, so the awaiting `run_in_executor`
+    never completes. Unbounded, a regression in that guard would stall CI until
+    the job timeout instead of failing the test. The bound is generous (real
+    ffmpeg muxes run under here) — it is a deadlock detector, not a perf budget.
+    """
     from api.routers import audiobook
     monkeypatch.setattr(audiobook, "_build_synth", _stub_build_synth(fail_on=fail_on, exc=exc))
     monkeypatch.setattr("core.config.OUTPUTS_DIR", str(outputs_dir))
@@ -74,7 +83,7 @@ def _collect_events(plan, monkeypatch, outputs_dir, *, fail_on=None, exc=None, *
             out.append(json.loads(frame[len("data:"):].strip()))
         return out
 
-    return asyncio.run(_run())
+    return asyncio.run(asyncio.wait_for(_run(), timeout=timeout))
 
 
 def _ffprobe(path):
@@ -169,6 +178,59 @@ def test_all_chapters_fail_emits_error_and_no_file(tmp_path, monkeypatch):
     assert err["diagnostic"]
     # No output file was produced.
     assert not any(p.suffix in (".m4b", ".mp3") for p in out.iterdir())
+
+
+def test_all_chapters_fail_marks_the_job_failed(tmp_path, monkeypatch):
+    """The all-failed branch used to return without touching job history, so the
+    row stayed `running`: the next startup's orphan sweep read it as an
+    interrupted job, and the retained resume manifest offered an already-hopeless
+    render as resumable (Greptile P1 on #1321).
+
+    Spies on job_store rather than reading the DB — this module never runs the
+    schema migration, so the real calls are swallowed by the renderer's
+    best-effort guard and nothing would be observable."""
+    from core import job_store
+
+    failed_calls = []
+    monkeypatch.setattr(job_store, "create", lambda *a, **k: None)
+    monkeypatch.setattr(job_store, "mark_running", lambda *a, **k: None)
+    monkeypatch.setattr(job_store, "mark_done", lambda *a, **k: None)
+    monkeypatch.setattr(
+        job_store, "mark_failed", lambda jid, err: failed_calls.append((jid, err))
+    )
+
+    out = tmp_path / "outputs"
+    out.mkdir()
+    events = _collect_events(
+        _plan(("A", "x"), ("B", "y")), monkeypatch, out,
+        fmt="m4b", fail_on=lambda t: True,
+    )
+
+    job_id = next(e for e in events if e["type"] == "started")["job_id"]
+    assert len(failed_calls) == 1, failed_calls
+    assert failed_calls[0][0] == job_id
+    # Records WHY, not just that it failed — this is what job history shows.
+    assert "stub synth deliberately failed" in failed_calls[0][1]
+
+
+def test_a_successful_render_is_not_marked_failed(tmp_path, monkeypatch):
+    """Guard the other side of the branch: the new mark_failed must not fire on
+    a render that produced output."""
+    from core import job_store
+
+    failed_calls = []
+    monkeypatch.setattr(job_store, "create", lambda *a, **k: None)
+    monkeypatch.setattr(job_store, "mark_running", lambda *a, **k: None)
+    monkeypatch.setattr(job_store, "mark_done", lambda *a, **k: None)
+    monkeypatch.setattr(
+        job_store, "mark_failed", lambda jid, err: failed_calls.append((jid, err))
+    )
+
+    out = tmp_path / "outputs"
+    out.mkdir()
+    events = _collect_events(_plan(("One", "Hi.")), monkeypatch, out, fmt="m4b")
+    assert events[-1]["type"] == "done"
+    assert failed_calls == []
 
 
 def test_bare_stopiteration_from_an_engine_is_reported_not_hung(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #1321.

The report arrived as a raw traceback pasted out of a log file — because that is the only place the reason existed.

## What the user saw

A failed chapter was a red row and the word "failed". The SSE event carried the literal string `"chapter failed to render"`: the symptom they could already see. When every chapter failed, the terminal event was `"all chapters failed to render"` — same problem.

## Fixed

**1. The reason now reaches the user.** Both events are built with the shared `core.failure` builder the rest of the pipeline already uses — sanitized text (no tokens, no home paths), a guaranteed non-empty `reason`, `error_class`, the docs deeplink and the hint. `error` keeps mirroring `reason`, so older frontends and the Stories exporter are unaffected. Per-chapter events omit the env diagnostic (identical for every chapter, and a book emits hundreds); the terminal event carries one. The chapter list shows the reason inline, with the full text in the row tooltip.

**2. A silent infinite hang on the same path.** Found while reproducing: asyncio refuses to put `StopIteration` into a Future. `_copy_future_state` raises `TypeError: StopIteration interacts badly with generators and cannot be raised into a Future` **inside the event loop's own callback**, so the `run_in_executor` future is never completed and the awaiting coroutine waits forever. No error, no event, no timeout — the render just stops, which from outside is a wedged app.

That is reachable from ordinary input. Engines that drive a generator raise it on text they cannot handle: VoxCPM's `next_and_close` is a bare `next(gen)`, so a generator that ends without yielding raises `StopIteration` straight out of `backend.generate` into a GPU-pool worker — the exact engine and the exact call path in this report. Reproduced on the bundled CPython 3.11: the first version of the new e2e test **hung** instead of failing.

Fixed at the pool boundary rather than per call site. `_ResilientGpuPool.submit` already wraps every dispatch (that is what makes the queue stats correct), so the guard lives in the same wrapper, and `_cpu_pool` gets a matching subclass. A bare `StopIteration` becomes `WorkerStopIteration(RuntimeError)` with a message that says what happened, keeping the original as `__cause__` so the traceback still points at the engine frame that stopped.

## Tests

- `backend/tests/test_pool_stopiteration_guard.py` — 6 tests; two of them **hang** without the fix (bounded with `wait_for` so a hang fails the suite instead of stalling CI).
- `tests/test_longform_e2e.py` — both event shapes carry a reason; a bare `StopIteration` from an engine comes back as a reported chapter failure; an exception whose `str()` is empty still yields a non-empty reason.
- `frontend/src/components/audiobook/GenerationProgress.test.jsx` — the reason renders, the tooltip carries the full text, and a failed chapter with no reason does not print `undefined`.

Full suite: 3975 passed, 25 skipped, 2 xfailed, 6 xpassed. Frontend vitest green.

## Note for the reporter

The traceback in the issue is cut off one line before the exception type, so this does not yet identify the specific VoxCPM2 failure on that Khmer chapter. After this change the app names it directly in the chapter list — I'll follow up on the issue asking for that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Audiobook rendering now emits sanitized, structured failure reasons in backend SSE/terminal events and propagates them to the chapter list, with the legacy `error` field mirroring `reason` and the frontend showing the reason via failed-row tooltip/labels (including cases like empty exception messages and “all chapters failed”). Rendering hangs are prevented by converting bare worker `StopIteration` into `WorkerStopIteration` (preserving the original as `__cause__`) across CPU/GPU pool submit paths, and when all chapters fail the job is marked failed in history. Main risk worth human review is the accuracy of reason/error classification and SSE→UI mapping—especially under real engine failure modes and the terminal all-chapters-failed path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->