### PR TITLE
test: stop streamDropError's tests depending on a live local backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ marketing.md
 .specify/
 .claude/skills/speckit-*/
 .antigravitycli/
+# `backlog` (the CLI task tracker) writes a config + one markdown file per task
+# into the repo root. A contributor running it locally had those three files
+# swept into a PR that was otherwise a single script (#1322 / #1306).
+backlog/
 
 # Locally-installed third-party skill packs (marketingskills, hallmark,
 # mattpocock/skills, …) — ignore every skill dir by default; a skill that

--- a/frontend/src/test/streamDropError.test.ts
+++ b/frontend/src/test/streamDropError.test.ts
@@ -10,6 +10,16 @@ import { streamDropError } from '../utils/backendCrash';
 
 const FALLBACK = 'Transcribe stream dropped before emitting any segments.';
 
+// `streamDropError`'s no-marker branch asks whether the backend is still
+// answering (#1242): a live process rules the caller's "it crashed" guess out.
+// Its default probe is a REAL `fetch` at the configured API origin, so a test
+// that leaves it unstubbed asserts against whatever happens to be listening on
+// the developer's machine — three of the tests below passed in CI (nothing
+// there) and failed for anyone running the app locally. Every test states which
+// answer it wants.
+const DEAD = async () => false;
+const ALIVE = async () => true;
+
 function marker(overrides = {}) {
   return {
     ts: Math.floor(Date.now() / 1000) - 12,
@@ -47,8 +57,16 @@ describe('streamDropError (#1062)', () => {
   });
 
   it('keeps the caller message when there is no crash marker', async () => {
-    const err = await streamDropError(FALLBACK, async () => null);
+    const err = await streamDropError(FALLBACK, async () => null, { probeAlive: DEAD });
     expect(err.message).toBe(FALLBACK);
+  });
+
+  it('says a live backend was not the crash it looked like (#1242)', async () => {
+    const err = await streamDropError(FALLBACK, async () => null, { probeAlive: ALIVE });
+    // The caller's guess is dropped: the process answered, so it did not die.
+    expect(err.message).not.toContain(FALLBACK);
+    expect(err.message).toMatch(/still running/i);
+    expect(err.message).toMatch(/proxy|buffering/i);
   });
 
   it('never masks the caller message when the forensics lookup itself fails', async () => {
@@ -95,6 +113,7 @@ describe('streamDropError — waits for the shell to notice the death (#1119)', 
         waitMs: 5,
         intervalMs: 1,
         sleep: async () => {},
+        probeAlive: DEAD,
       });
       expect(err.message).toBe(FALLBACK);
     } finally {
@@ -104,10 +123,14 @@ describe('streamDropError — waits for the shell to notice the death (#1119)', 
 
   it('does not stall a browser/Docker user — no shell means no marker, ever', async () => {
     let calls = 0;
-    const err = await streamDropError(FALLBACK, async () => {
-      calls += 1;
-      return null;
-    });
+    const err = await streamDropError(
+      FALLBACK,
+      async () => {
+        calls += 1;
+        return null;
+      },
+      { probeAlive: DEAD },
+    );
     expect(err.message).toBe(FALLBACK);
     expect(calls).toBe(1); // asked once, then stopped — no 8 s wait
   });


### PR DESCRIPTION
Three tests in `frontend/src/test/streamDropError.test.ts` fail on any machine that happens to be running OmniVoice, and pass in CI.

They exercise the no-crash-marker branch, which since #1242 asks whether the backend is still answering before it repeats the caller's "it crashed" guess — and they left that probe unstubbed. `_probeBackendAlive` does a real `fetch` at the configured API origin, so the assertion was really *"is anything listening on port 3900 right now"*: nothing in CI, the developer's own app locally.

```
FAIL  streamDropError (#1062) > keeps the caller message when there is no crash marker
Expected: "Transcribe stream dropped before emitting any segments."
Received: "The stream ended early, but the backend is still running — so it did not crash. …"
```

Green on `main`, red on a laptop — the same fails-locally/passes-in-CI shape as #1269.

### Changed

- Every test in that branch now states which answer it wants (`DEAD` / `ALIVE`) instead of inheriting one from the environment.
- The previously uncovered side — a **live** backend, where the #1242 proxy-buffering message replaces the caller's guess — gets a test of its own, rather than being asserted by accident on developer machines that had the app open.

### Added

- `backlog/` to `.gitignore`. The `backlog` CLI task tracker writes a config plus one markdown file per task into the repo root, and a contributor running it locally had three of those swept into a PR that was otherwise a single script (#1322 / #1306).

### Verification

| | before | after |
|---|---|---|
| `bun run test` with the app running locally | 1 file / 3 tests fail | **208 files / 1643 tests pass** |
| `bun run test` with nothing on :3900 (CI) | pass | pass |

Test-infrastructure only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `streamDropError` tests to stub backend liveness deterministically, including coverage for the live-backend proxy-buffering message path and preventing network-dependent waits. Added `backlog/` to `.gitignore` to keep local task-tracker files out of commits. No production code changes; frontend tests pass, with low risk limited to test coverage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->