### PR TITLE
test(probe): make triage tests fork-tolerant

### DIFF
--- a/tests/probe/test_triage.py
+++ b/tests/probe/test_triage.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import urllib.parse
 
+import pytest
+
 from . import triage as T
 from .report import Report, SpecOutcome
 from .spec import JudgeResult
@@ -35,8 +37,15 @@ def test_detect_repo_from_origin():
     # detect_repo() parses owner/repo from the real git origin. The repo name is
     # stable across upstream and forks; the owner is not, so assert the shape and
     # the repo name rather than a hardcoded owner (the test ran only on upstream).
+    #
+    # It also documents its own None case — "the harness works without a GitHub
+    # remote, the report just omits the link" — which is a real checkout shape,
+    # not a broken one: a source tarball, a `git archive`, and the Docker build
+    # context all have no origin. Asserting non-None there would swap one
+    # environment assumption for another, so skip instead of fail.
     repo = T.detect_repo()
-    assert repo is not None
+    if repo is None:
+        pytest.skip("no GitHub origin remote here (tarball/archive checkout)")
     owner, name = repo
     assert isinstance(owner, str) and owner
     assert name == "OmniVoice-Studio"

--- a/tests/probe/test_triage.py
+++ b/tests/probe/test_triage.py
@@ -32,9 +32,14 @@ def test_sanitize_strips_home_and_secrets():
 
 
 def test_detect_repo_from_origin():
-    # This repo's origin is github.com/debpalash/OmniVoice-Studio.
+    # detect_repo() parses owner/repo from the real git origin. The repo name is
+    # stable across upstream and forks; the owner is not, so assert the shape and
+    # the repo name rather than a hardcoded owner (the test ran only on upstream).
     repo = T.detect_repo()
-    assert repo == ("debpalash", "OmniVoice-Studio")
+    assert repo is not None
+    owner, name = repo
+    assert isinstance(owner, str) and owner
+    assert name == "OmniVoice-Studio"
 
 
 def test_clustering_dedupes_and_excludes_nonblocking():
@@ -53,7 +58,11 @@ def test_build_issue_title_and_table():
     assert "`asr_wer_below`" in body and "| 2 |" in body
 
 
-def test_triage_builds_github_url():
+def test_triage_builds_github_url(monkeypatch):
+    # Pin detect_repo so the URL is deterministic on every fork: this test
+    # exercises URL construction, not the git origin (which is the fork owner on
+    # a contributor's checkout, not the upstream "debpalash").
+    monkeypatch.setattr(T, "detect_repo", lambda cwd=None: ("debpalash", "OmniVoice-Studio"))
     res = T.triage(_failing_report())
     assert res.owner == "debpalash" and res.repo == "OmniVoice-Studio"
     assert res.url and res.url.startswith(


### PR DESCRIPTION
## What
Two tests in `tests/probe/test_triage.py` hardcoded the upstream owner `debpalash`, so they failed on any fork (the fork's `git origin` resolves to its own owner, not `debpalash`). This kept the fork's CI red on every push and masked real failures.

- `test_detect_repo_from_origin` asserted `detect_repo() == ("debpalash", "OmniVoice-Studio")`. `detect_repo()` parses the real git origin, so on a fork it returns the fork owner.
- `test_triage_builds_github_url` asserted the triaged URL's owner `== "debpalash"`, same reason.

## Fix
- `test_detect_repo_from_origin`: assert the shape and the repo name (`OmniVoice-Studio`, stable across upstream and forks), not a hardcoded owner.
- `test_triage_builds_github_url`: pin `detect_repo` via `monkeypatch` to `("debpalash", "OmniVoice-Studio")` so the URL assertion is deterministic on every fork. The test exercises URL construction, not the git origin.

## Behavior unchanged
The triage still routes bug-report URLs to whatever `git origin` resolves to (route-to-origin). Only the tests stop assuming the upstream owner.

## Verification
On a fork: 2 failed before, 7 passed after (full `tests/probe/test_triage.py`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The triage tests now support repository forks and checkouts without a GitHub origin. The tests avoid hardcoded owners and mock `detect_repo()` for deterministic URL checks. Production-code risk is limited because no production files changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->