### PR TITLE
fix(gpu): record WHERE a wedged job was stuck when its budget expires (#1338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Linux AppImage: `OMNIVOICE_PREFER_SYSTEM_WEBKIT=1` forces your own WebKitGTK for hosts where its version can't be read automatically (no `pkg-config`), and `=0` forces the bundled one (#1258)
 - Dubbing: the transcription overlay said "Transcribing with Whisper…" whatever ASR engine was actually running — it now names the stage, in all 21 languages — thanks @paoloantinori! (#1352)
 - Error messages no longer arrive with terminal colour codes spliced into the sentence (`download: ^[[0;31mERROR:^[[0m …`) — every surfaced failure is cleaned now, whichever tool produced it. (#1344)
+- A TTS job abandoned for exceeding its compute budget now records where it was actually stuck, so a hang stops being reported as a machine that is merely too slow. (#1338, #1329, #1348)
 
 ### Docs
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -583,7 +583,7 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
         # Capture the stacks BEFORE reset(): reset() replaces the executor, and
         # once the wedged thread is no longer a pool worker we can no longer
         # tell it apart from any other thread in the process.
-        log_gpu_pool_worker_stacks(what, timeout)
+        log_gpu_pool_worker_stacks(what, timeout, executor=ex)
         _reset = getattr(ex, "reset", None)
         if callable(_reset):
             try:
@@ -608,7 +608,32 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
 _WEDGE_STACK_DEPTH = 25
 
 
-def log_gpu_pool_worker_stacks(what: str, timeout: float) -> str:
+def _live_pool_thread_idents(executor) -> "set | None":
+    """Thread idents belonging to ``executor``'s CURRENT inner pool, or None
+    when they can't be established.
+
+    Needed because a wedged worker survives ``reset()`` — it cannot be
+    cancelled, so it keeps running under the same ``gpu-pool`` name the
+    replacement pool also uses. Without this, the second timeout in a session
+    logs the stale thread alongside the live one with nothing to tell them
+    apart, and the stale stack is the more misleading of the two: it names an
+    operation that is no longer the one that just failed (greptile).
+
+    ``ThreadPoolExecutor._threads`` is private but has been the storage for its
+    worker set since 3.2 and is stable across every version we support; None
+    here is a soft degrade to "label nothing", never an error.
+    """
+    pool = getattr(executor, "_pool", executor)  # unwrap _ResilientGpuPool
+    threads = getattr(pool, "_threads", None)
+    if not threads:
+        return None
+    try:
+        return {t.ident for t in threads if t.ident is not None}
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def log_gpu_pool_worker_stacks(what: str, timeout: float, executor=None) -> str:
     """Log where every GPU-pool worker is currently executing. Never raises.
 
     The gap this closes (#1338/#1329/#1348): when a job overran its execution
@@ -638,17 +663,41 @@ def log_gpu_pool_worker_stacks(what: str, timeout: float) -> str:
         }
         if not names:
             return ""
+        live = _live_pool_thread_idents(executor) if executor is not None else None
         frames = _sys._current_frames()
         blocks = []
         for ident, name in sorted(names.items(), key=lambda kv: kv[1]):
             frame = frames.get(ident)
             if frame is None:
                 continue
+            if live is None:
+                label = name
+            elif ident in live:
+                label = f"{name} (current pool)"
+            else:
+                label = (
+                    f"{name} (STALE — a worker abandoned by an earlier timeout, "
+                    f"still running; not the job that just failed)"
+                )
             stack = "".join(_traceback.format_stack(frame, limit=_WEDGE_STACK_DEPTH))
-            blocks.append(f"--- {name} ---\n{stack.rstrip()}")
+            blocks.append(f"--- {label} ---\n{stack.rstrip()}")
         if not blocks:
             return ""
-        text = "\n".join(blocks)
+        # Stack frames carry absolute source paths, and on a user's machine
+        # those start with their home directory — i.e. their account name. This
+        # log lands in backend.log, which goes into diagnostic bundles and
+        # prefilled bug reports, so it must be sanitized like every other
+        # surfaced text (CWE-532; CodeRabbit). core.failure.sanitize also
+        # redacts HF tokens and *TOKEN*/*KEY*/*SECRET* env values, which a
+        # frame's local-variable-free repr should never contain — but "should
+        # never" is not a reason to log it unredacted.
+        try:
+            from core.failure import sanitize as _sanitize
+            text = _sanitize("\n".join(blocks))
+        except Exception:  # noqa: BLE001 — never lose the diagnostic to this
+            logger.exception("Could not sanitize GPU-pool worker stacks; "
+                             "omitting them rather than logging raw paths")
+            return ""
         logger.warning(
             "%s exceeded %.0fs — stack of every GPU-pool worker at the moment "
             "it was abandoned. The deepest frame is where it is stuck; if that "

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -580,6 +580,10 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
         # wait_for already cancelled the asyncio wrapper; the worker thread
         # keeps going regardless. Consume whatever it eventually produces.
         fut.add_done_callback(_swallow_abandoned)
+        # Capture the stacks BEFORE reset(): reset() replaces the executor, and
+        # once the wedged thread is no longer a pool worker we can no longer
+        # tell it apart from any other thread in the process.
+        log_gpu_pool_worker_stacks(what, timeout)
         _reset = getattr(ex, "reset", None)
         if callable(_reset):
             try:
@@ -596,6 +600,66 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
         raise GpuJobTimeoutError(
             _timeout_guidance(what, timeout, min_vram_gb)
         ) from timeout_exc
+
+
+#: Frames to keep per wedged worker. Deep enough to cross the engine adapter
+#: into the model's own call stack, shallow enough that a 1-worker and an
+#: 8-worker host both produce a log a human will actually read.
+_WEDGE_STACK_DEPTH = 25
+
+
+def log_gpu_pool_worker_stacks(what: str, timeout: float) -> str:
+    """Log where every GPU-pool worker is currently executing. Never raises.
+
+    The gap this closes (#1338/#1329/#1348): when a job overran its execution
+    budget we logged *that* it had, reset the pool, and returned a message
+    about the machine being too slow — with no record of what the abandoned
+    thread was actually doing. So every report of this class arrived
+    undiagnosable, and the only way forward was to ask the user to reproduce it
+    under a debugger. On an RTX 3060 rendering one sentence, "too heavy for the
+    available compute" is almost certainly the wrong story, and nothing in the
+    log could contradict it.
+
+    ``sys._current_frames()`` reads the frame of every live thread, including
+    one wedged inside a C call — which is exactly the case here, since the
+    worker cannot be cancelled and keeps running after we abandon it. Filtered
+    to gpu-pool workers so the log names the stuck job, not the web server.
+
+    Returns the formatted text (also for tests); empty when nothing matched.
+    """
+    try:
+        import sys as _sys
+        import threading as _threading
+        import traceback as _traceback
+
+        names = {
+            t.ident: t.name for t in _threading.enumerate()
+            if t.ident is not None and t.name.startswith(_GPU_POOL_THREAD_PREFIX)
+        }
+        if not names:
+            return ""
+        frames = _sys._current_frames()
+        blocks = []
+        for ident, name in sorted(names.items(), key=lambda kv: kv[1]):
+            frame = frames.get(ident)
+            if frame is None:
+                continue
+            stack = "".join(_traceback.format_stack(frame, limit=_WEDGE_STACK_DEPTH))
+            blocks.append(f"--- {name} ---\n{stack.rstrip()}")
+        if not blocks:
+            return ""
+        text = "\n".join(blocks)
+        logger.warning(
+            "%s exceeded %.0fs — stack of every GPU-pool worker at the moment "
+            "it was abandoned. The deepest frame is where it is stuck; if that "
+            "is inside the model rather than a data copy, this is a hang and "
+            "not an under-provisioned machine (#1338):\n%s",
+            _log_safe(what), timeout, text,
+        )
+        return text
+    except Exception:  # noqa: BLE001 — diagnostics must never mask the timeout
+        logger.exception("Could not capture GPU-pool worker stacks")
+        return ""
 
 
 def _timeout_guidance(what: str, timeout: float, min_vram_gb: float = 0.0) -> str:

--- a/tests/test_gpu_wedge_stack_capture.py
+++ b/tests/test_gpu_wedge_stack_capture.py
@@ -1,0 +1,165 @@
+"""A GPU job that overruns its budget must leave evidence of WHERE it stuck.
+
+#1338 / #1329 / #1348: three reporters on v0.4.2 hit "TTS generate ran for more
+than 300s of actual compute time and was abandoned" — two of them on an RTX 3050
+and an RTX 3060, rendering a *single sentence*. That is not a machine too slow
+for the job; the message says "too heavy for the available compute" because it
+is the only story the timeout path can tell.
+
+And nothing in the log could contradict it. The timeout branch logged *that* the
+budget was exceeded, reset the pool, and returned. The worker thread cannot be
+cancelled, so it was still running, still on a real stack — and we threw that
+away. Every report of this class therefore arrived undiagnosable.
+
+``log_gpu_pool_worker_stacks`` closes that: ``sys._current_frames()`` reads the
+frame of every live thread, including one wedged inside a C call, which is
+exactly the case that matters here. These tests pin the two things a future
+change could quietly break — that it runs at all, and that it runs *before*
+``reset()`` replaces the pool and makes the wedged thread unidentifiable.
+"""
+import asyncio
+import importlib
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+
+@pytest.fixture
+def mm():
+    """Resolve the module at call time — sibling suites reload/purge
+    ``services.*``, so an import-time alias can go stale (#1269)."""
+    return importlib.import_module("services.model_manager")
+
+
+def _wedged_pool(mm, release: threading.Event):
+    """A pool whose single worker parks until ``release`` is set, named exactly
+    as the real GPU pool so the capture's filter applies."""
+    return ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix=mm._GPU_POOL_THREAD_PREFIX
+    )
+
+
+def test_capture_names_the_function_the_worker_is_stuck_in(mm):
+    release = threading.Event()
+    ex = _wedged_pool(mm, release)
+    entered = threading.Event()
+
+    def a_deliberately_wedged_generate():
+        entered.set()
+        release.wait(10)
+
+    fut = ex.submit(a_deliberately_wedged_generate)
+    assert entered.wait(5), "worker never started"
+    try:
+        text = mm.log_gpu_pool_worker_stacks("TTS generate", 300.0)
+        assert mm._GPU_POOL_THREAD_PREFIX in text, text
+        # The whole point: the frame that names the stuck call must be present.
+        assert "a_deliberately_wedged_generate" in text, (
+            "the capture did not reach the frame the worker is actually in — "
+            "which is the only part of it a maintainer reads:\n" + text
+        )
+    finally:
+        release.set()
+        fut.result(timeout=5)
+        ex.shutdown(wait=True)
+
+
+def test_capture_ignores_threads_that_are_not_pool_workers(mm):
+    """The process has a web server, a watchdog and a watermark pool in it. A
+    dump of everything is a dump nobody reads."""
+    release = threading.Event()
+    entered = threading.Event()
+
+    def not_a_gpu_worker():
+        entered.set()
+        release.wait(10)
+
+    other = ThreadPoolExecutor(max_workers=1, thread_name_prefix="watermark")
+    fut = other.submit(not_a_gpu_worker)
+    assert entered.wait(5)
+    try:
+        text = mm.log_gpu_pool_worker_stacks("TTS generate", 300.0)
+        assert "not_a_gpu_worker" not in text, text
+    finally:
+        release.set()
+        fut.result(timeout=5)
+        other.shutdown(wait=True)
+
+
+def test_capture_is_empty_when_no_pool_worker_exists(mm):
+    """Nothing to report is not an error — the timeout path must not depend on
+    this having found anything."""
+    assert mm.log_gpu_pool_worker_stacks("TTS generate", 300.0) == ""
+
+
+def test_capture_never_raises(mm, monkeypatch):
+    """Diagnostics run inside the timeout handler. One that throws would
+    replace a real GpuJobTimeoutError with an unrelated crash."""
+    monkeypatch.setattr(
+        mm.threading, "enumerate", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert mm.log_gpu_pool_worker_stacks("TTS generate", 300.0) == ""
+
+
+def test_timeout_captures_stacks_before_resetting_the_pool(mm):
+    """Ordering is load-bearing, so it is asserted rather than assumed.
+
+    ``reset()`` swaps in a fresh executor. Once that happens the wedged thread
+    is no longer named as a pool worker, so the capture would find nothing —
+    the diagnostic would still "run", still log, and still be empty, which is
+    the worst of both worlds because it looks like it worked.
+    """
+    order = []
+    release = threading.Event()
+    entered = threading.Event()
+
+    def wedged():
+        entered.set()
+        release.wait(10)
+
+    inner = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix=mm._GPU_POOL_THREAD_PREFIX
+    )
+
+    class _Pool:
+        def submit(self, fn, *a, **kw):
+            return inner.submit(fn, *a, **kw)
+
+        def reset(self):
+            order.append("reset")
+
+    captured = {}
+
+    def _spy(what, timeout):
+        order.append("capture")
+        captured["text"] = real(what, timeout)
+        return captured["text"]
+
+    real = mm.log_gpu_pool_worker_stacks
+    mm.log_gpu_pool_worker_stacks = _spy
+    try:
+        async def _run():
+            return await mm.run_on_gpu_pool_guarded(
+                wedged, what="TTS generate", executor=_Pool(), timeout=0.4,
+            )
+
+        with pytest.raises(mm.GpuJobTimeoutError):
+            asyncio.run(_run())
+    finally:
+        mm.log_gpu_pool_worker_stacks = real
+        release.set()
+        inner.shutdown(wait=True)
+
+    assert order == ["capture", "reset"], (
+        f"stacks must be captured before reset() replaces the pool: {order}"
+    )
+    assert "wedged" in captured.get("text", ""), captured

--- a/tests/test_gpu_wedge_stack_capture.py
+++ b/tests/test_gpu_wedge_stack_capture.py
@@ -147,9 +147,9 @@ def test_timeout_captures_stacks_before_resetting_the_pool(mm):
 
     captured = {}
 
-    def _spy(what, timeout):
+    def _spy(what, timeout, executor=None):
         order.append("capture")
-        captured["text"] = real(what, timeout)
+        captured["text"] = real(what, timeout, executor=executor)
         return captured["text"]
 
     real = mm.log_gpu_pool_worker_stacks
@@ -171,3 +171,129 @@ def test_timeout_captures_stacks_before_resetting_the_pool(mm):
         f"stacks must be captured before reset() replaces the pool: {order}"
     )
     assert "wedged" in captured.get("text", ""), captured
+
+
+def test_home_paths_are_redacted_from_the_captured_stack(mm):
+    """Stack frames carry absolute source paths, which on a user's machine
+    begin with their home directory — their account name.
+
+    This log lands in ``backend.log``, which goes into diagnostic bundles and
+    prefilled bug reports, so an unredacted capture would leak the account name
+    of everyone who ever hits a timeout (CWE-532). The repo already has one
+    answer for that — ``core.failure.sanitize`` — and the point here is that
+    this path uses it rather than inventing a second one.
+    """
+    release = threading.Event()
+    entered = threading.Event()
+
+    def wedged_in_a_home_path():
+        entered.set()
+        release.wait(10)
+
+    ex = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix=mm._GPU_POOL_THREAD_PREFIX
+    )
+    fut = ex.submit(wedged_in_a_home_path)
+    assert entered.wait(5)
+    try:
+        text = mm.log_gpu_pool_worker_stacks("TTS generate", 300.0)
+        home = os.path.expanduser("~")
+        # This test file lives under the developer's home on any dev machine
+        # and under the runner's home in CI, so the raw frame necessarily
+        # contains it — which is what makes this a real check rather than a
+        # tautology.
+        assert home and home != "~", "cannot verify redaction without a home dir"
+        assert home not in text, (
+            "the captured stack still contains the absolute home path, so the "
+            "log (and every diagnostic bundle built from it) carries the "
+            "user's account name:\n" + text
+        )
+        assert "wedged_in_a_home_path" in text, (
+            "redaction must not cost the diagnostic its content:\n" + text
+        )
+    finally:
+        release.set()
+        fut.result(timeout=5)
+        ex.shutdown(wait=True)
+
+
+def test_stale_workers_are_labelled_apart_from_the_live_pool(mm):
+    """A wedged worker survives ``reset()`` — it cannot be cancelled, so it
+    keeps running under the same ``gpu-pool`` name the replacement pool uses.
+
+    The second timeout in a session would then log both, with nothing to tell
+    them apart, and the stale stack is the more misleading of the two: it names
+    an operation that is not the one that just failed (greptile).
+    """
+    release = threading.Event()
+    stale_entered = threading.Event()
+    live_entered = threading.Event()
+
+    def a_stale_abandoned_job():
+        stale_entered.set()
+        release.wait(10)
+
+    def the_job_that_just_failed():
+        live_entered.set()
+        release.wait(10)
+
+    stale_ex = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix=mm._GPU_POOL_THREAD_PREFIX
+    )
+    live_ex = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix=mm._GPU_POOL_THREAD_PREFIX
+    )
+    f1 = stale_ex.submit(a_stale_abandoned_job)
+    f2 = live_ex.submit(the_job_that_just_failed)
+    assert stale_entered.wait(5) and live_entered.wait(5)
+    try:
+        text = mm.log_gpu_pool_worker_stacks("TTS generate", 300.0, executor=live_ex)
+        live_block = text.split("--- ")
+        current = [b for b in live_block if "the_job_that_just_failed" in b]
+        stale = [b for b in live_block if "a_stale_abandoned_job" in b]
+        assert current and "current pool" in current[0], (
+            "the live pool's worker is not marked as current:\n" + text
+        )
+        assert stale and "STALE" in stale[0], (
+            "a worker from an already-abandoned job is presented as though it "
+            "were the current hang:\n" + text
+        )
+    finally:
+        release.set()
+        f1.result(timeout=5)
+        f2.result(timeout=5)
+        stale_ex.shutdown(wait=True)
+        live_ex.shutdown(wait=True)
+
+
+def test_unknown_pool_internals_degrade_to_no_label(mm):
+    """``ThreadPoolExecutor._threads`` is private. If a future Python renames
+    it, the capture must lose the *label* and keep the *stacks* — a diagnostic
+    that disappears because an attribute moved is worse than an unlabelled one.
+    """
+    release = threading.Event()
+    entered = threading.Event()
+
+    def wedged():
+        entered.set()
+        release.wait(10)
+
+    ex = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix=mm._GPU_POOL_THREAD_PREFIX
+    )
+    fut = ex.submit(wedged)
+    assert entered.wait(5)
+
+    class _Opaque:
+        pass
+
+    try:
+        text = mm.log_gpu_pool_worker_stacks("TTS generate", 300.0, executor=_Opaque())
+        assert "wedged" in text, text
+        assert "current pool" not in text and "STALE" not in text, (
+            "labels were invented without knowing the live thread set:\n" + text
+        )
+    finally:
+        release.set()
+        fut.result(timeout=5)
+        ex.shutdown(wait=True)


### PR DESCRIPTION
Makes #1338 / #1329 / #1348 diagnosable. Does **not** fix the underlying hang — see "What this is not" below.

## The problem with the reports

Three reporters on v0.4.2 hit *"TTS generate ran for more than 300s of actual compute time and was abandoned"*. Two of them were on an **RTX 3050** and an **RTX 3060**, rendering a **single sentence**. `GpuJobTimeoutError` is only raised once a worker has picked the job up — queue wait is bounded separately and surfaces as a retryable 503 — so that is 300+ seconds of *execution*, not of waiting in line.

On a 12 GB card, one sentence is not a workload. But the message says "too heavy for the available compute", because that is the only story the timeout path is able to tell.

And nothing in the log could contradict it. The timeout branch logged *that* the budget was exceeded, reset the pool, and returned. The worker thread cannot be cancelled, so it was still running, still on a real stack — and we discarded it. Every report of this class therefore arrives undiagnosable, and the only advice available is "reproduce it under a debugger", which is not a reasonable thing to ask of someone who just wanted to dub a video.

## The change

`log_gpu_pool_worker_stacks()` — at timeout, before abandoning the job, dump the current frame of every GPU-pool worker.

`sys._current_frames()` reads the frame of every live thread *including one wedged inside a C call*, which is precisely the case that matters: the worker is stuck somewhere in the model, and it is the one thing we cannot ask it about.

- **Filtered to gpu-pool workers**, by the existing `_GPU_POOL_THREAD_PREFIX`. The process also holds a web server, a watchdog, and a watermark pool; a dump of everything is a dump nobody reads.
- **Capped at 25 frames** — deep enough to cross the engine adapter into the model's own stack, shallow enough that a 1-worker and an 8-worker host both produce something a human will read.
- **Can never raise.** It runs inside the timeout handler, so a diagnostic that throws would replace a real `GpuJobTimeoutError` with an unrelated crash.
- **Runs before `reset()`,** and that ordering is asserted rather than assumed. `reset()` swaps in a fresh executor, and once the wedged thread is no longer named as a pool worker the capture finds nothing — it would still run, still log, and be empty, which is worse than not having it because it looks like it worked.

It logs at WARNING, so it lands in `backend.log` and therefore in diagnostic bundles and auto-filed bug reports without the user doing anything.

## What this is not

This does not fix the hang. It makes the *next* report of it carry the one fact needed to fix it: which frame the job died in. If the deepest frame is inside the model's forward pass, it is a hang and the "too heavy for the available compute" wording is actively misleading; if it is in a host-to-device copy, the VRAM story was right after all. Right now we cannot tell those apart, which is why #1338 has been stuck on "please attach a log" for a week.

## Tests

`tests/test_gpu_wedge_stack_capture.py` — 5 tests, all failing before this change:

- the capture reaches the frame the worker is actually parked in (asserted by function name, since that is the only part a maintainer reads);
- non-pool threads are excluded;
- no pool worker at all returns empty rather than erroring — the timeout path must not depend on it finding anything;
- it never raises, even when thread enumeration itself throws;
- end-to-end through `run_on_gpu_pool_guarded`: the capture happens *before* `reset()`, and the captured text names the wedged function.

Related suites green: `test_generate_timeout_730`, `test_gpu_pool_queue_accounting_1190`, `test_recurrence_hardening`.

One thing I noticed while running these and did **not** touch here: `tests/test_load_budget_split_1033.py::test_speech_survives_a_load_slower_than_the_generate_budget` fails when the file is run on its own and passes in the full suite, on clean `main` as well as on this branch. That is order-dependence in the opposite direction from #1269 and belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
When a GPU job exceeds its execution-time budget, the timeout path logs up to 25 sanitized stack frames for each GPU-pool worker before resetting the pool. The capture filters unrelated and stale workers, supports C calls, and suppresses diagnostic failures so timeout handling continues. Reviewers should assess WARNING-level log volume and confirm sanitization remains fail-closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->