### PR TITLE
fix(appimage): the preload probe never ran, and tested the wrong value (#1333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Dubbing: the transcription overlay said "Transcribing with Whisper…" whatever ASR engine was actually running — it now names the stage, in all 21 languages — thanks @paoloantinori! (#1352)
 - Error messages no longer arrive with terminal colour codes spliced into the sentence (`download: ^[[0;31mERROR:^[[0m …`) — every surfaced failure is cleaned now, whichever tool produced it. (#1344)
 - Linux AppImage: recording failed with "No microphone found" on hosts whose GStreamer is newer than the build runner's, even with a verified-healthy audio stack — your own GStreamer now takes precedence, and the plugin cache is app-private so it can neither be confused by nor corrupt the one other apps use — thanks @Kakuzen93! (#1333)
+- Linux AppImage: that GStreamer preference actually takes effect — the check guarding it could never pass, so it had been silently doing nothing. (#1333)
 
 ### Docs
 

--- a/frontend/src-tauri/appimage/AppRun
+++ b/frontend/src-tauri/appimage/AppRun
@@ -253,14 +253,13 @@ _preload_probe_bin() {
     return 0
   fi
   local candidate
-  # `command -v` with a path argument still tells us about the file, and the
-  # fallbacks cover the usual/merged-/usr layouts plus a PATH lookup for
-  # anything unusual. /bin/sh is the last resort: it is guaranteed present on
-  # any host that can run this script at all, and `sh -c :` is as cheap as true.
-  for candidate in /usr/bin/true /bin/true "$(command -v -- coreutils 2>/dev/null || true)"; do
-    [ -n "$candidate" ] && [ -x "$candidate" ] && { printf '%s' "$candidate"; return 0; }
-  done
-  for candidate in /bin/sh /usr/bin/sh; do
+  # Absolute paths only. A PATH lookup is deliberately absent: `command -v true`
+  # is what caused the original bug, and there is nothing left for it to find
+  # anyway — /bin/sh is guaranteed present on any host that can run this script
+  # at all, so the list already terminates. (An earlier revision searched PATH
+  # for `coreutils`, which is not an executable name and could never resolve —
+  # a branch that looks like a fallback and is not, CodeRabbit.)
+  for candidate in /usr/bin/true /bin/true /bin/sh /usr/bin/sh; do
     [ -x "$candidate" ] && { printf '%s' "$candidate"; return 0; }
   done
   return 1

--- a/frontend/src-tauri/appimage/AppRun
+++ b/frontend/src-tauri/appimage/AppRun
@@ -240,14 +240,50 @@ _prefer_system_gstreamer() {
 # a missing dependency or an unresolved version tag (`version 'GLIB_2.84' not
 # found`) fails it, and nothing else runs. Cheap, and decisive where a version
 # comparison would be guesswork.
+#: Path to an EXTERNAL executable to run the probe against, or empty.
+#
+# It has to be a real binary the loader will exec. `command -v true` answers
+# with the shell BUILTIN — the bare word "true", not a path — so `[ -x ... ]`
+# rejected it and the probe failed on every host, silently disabling the whole
+# preload and leaving #1333 exactly as it was (CodeRabbit). A builtin never
+# involves the dynamic loader anyway, so it could not have tested anything.
+_preload_probe_bin() {
+  if [ -n "${OMNIVOICE_APPRUN_PRELOAD_PROBE:-}" ]; then
+    printf '%s' "$OMNIVOICE_APPRUN_PRELOAD_PROBE"
+    return 0
+  fi
+  local candidate
+  # `command -v` with a path argument still tells us about the file, and the
+  # fallbacks cover the usual/merged-/usr layouts plus a PATH lookup for
+  # anything unusual. /bin/sh is the last resort: it is guaranteed present on
+  # any host that can run this script at all, and `sh -c :` is as cheap as true.
+  for candidate in /usr/bin/true /bin/true "$(command -v -- coreutils 2>/dev/null || true)"; do
+    [ -n "$candidate" ] && [ -x "$candidate" ] && { printf '%s' "$candidate"; return 0; }
+  done
+  for candidate in /bin/sh /usr/bin/sh; do
+    [ -x "$candidate" ] && { printf '%s' "$candidate"; return 0; }
+  done
+  return 1
+}
+
 # OMNIVOICE_APPRUN_PRELOAD_PROBE lets the unit tests choose the outcome, the
 # same way OMNIVOICE_APPRUN_WK_MARKER points at a fixture marker — the decision
 # logic is what is testable here; whether a given .so loads is the OS's answer.
+#
+# The argument is the FINAL LD_PRELOAD value, not just our library. An
+# inherited LD_PRELOAD is restored alongside ours for the app, so probing our
+# entry alone could pass while the environment the app actually gets fails
+# (CodeRabbit).
 _preload_loads_cleanly() {
-  local probe
-  probe="${OMNIVOICE_APPRUN_PRELOAD_PROBE:-$(command -v true 2>/dev/null || echo /bin/true)}"
-  [ -x "$probe" ] || return 1
-  LD_PRELOAD="$1" LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" "$probe" 2>/dev/null
+  local probe args
+  probe="$(_preload_probe_bin || echo "")"
+  [ -n "$probe" ] && [ -x "$probe" ] || return 1
+  case "$probe" in
+    */sh) args="-c :" ;;
+    *)    args="" ;;
+  esac
+  # shellcheck disable=SC2086 — $args is our own fixed literal, never user input
+  LD_PRELOAD="$1" LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" "$probe" $args 2>/dev/null
 }
 
 # LD_PRELOAD, not LD_LIBRARY_PATH. Preloading names exactly one library and
@@ -259,8 +295,9 @@ _preload_loads_cleanly() {
 # and the preload is inert. That is the accepted cost of the narrower mechanism.
 if _prefer_system_gstreamer; then
   _SYS_GST_LIB="$(_system_gstreamer_lib || echo "")"
-  if [ -n "$_SYS_GST_LIB" ] && _preload_loads_cleanly "$_SYS_GST_LIB"; then
-    export LD_PRELOAD="${_SYS_GST_LIB}${LD_PRELOAD:+ $LD_PRELOAD}"
+  _CANDIDATE_PRELOAD="${_SYS_GST_LIB}${LD_PRELOAD:+ $LD_PRELOAD}"
+  if [ -n "$_SYS_GST_LIB" ] && _preload_loads_cleanly "$_CANDIDATE_PRELOAD"; then
+    export LD_PRELOAD="$_CANDIDATE_PRELOAD"
   elif [ -n "$_SYS_GST_LIB" ]; then
     # Fail safe, and say so: the app still starts on the bundled core, which
     # is where the microphone problem lives, so the user needs a thread to

--- a/frontend/src-tauri/appimage/AppRun.test.sh
+++ b/frontend/src-tauri/appimage/AppRun.test.sh
@@ -421,6 +421,109 @@ run_gst_case "opt-out keeps the bundled core"  "0" "pkgconfig" "no-gst+libdir-in
 # the app still launches on the bundled core.
 run_gst_case "unloadable host core is skipped" ""  "pkgconfig" "no-gst+libdir-intact+private-registry" "no"
 
+# ── The load probe must be a REAL binary, and must test the REAL value ──────
+# Both of these silently disabled the feature rather than breaking loudly, which
+# is why they get their own cases (CodeRabbit).
+#
+# 1. `command -v true` answers with the shell BUILTIN — the bare word "true" —
+#    so `[ -x "true" ]` was false on every host and the preload never happened.
+#    A builtin never involves the dynamic loader, so it could not have tested
+#    anything even if it had run.
+# 2. An inherited LD_PRELOAD is restored alongside ours for the app, so probing
+#    our library alone can pass while the environment the app gets fails.
+run_probe_default_case() {
+  local label="$1" expected="$2"
+  local gstlibdir actual
+  gstlibdir="$(mktemp -d)"
+  touch "$gstlibdir/libgstreamer-1.0.so.0"
+
+  actual=$(
+    bash -c '
+      set +e
+      gstlibdir="'"$gstlibdir"'"
+      pkg-config() {
+        [ "$1" = "--variable=libdir" ] && [ "$2" = "gstreamer-1.0" ] \
+          && { echo "$gstlibdir"; return 0; }
+        return 1
+      }
+      export -f pkg-config
+      ldconfig() { return 1; }
+      export -f ldconfig
+      exec() { :; }
+      export -f exec
+
+      unset OMNIVOICE_APPRUN_PRELOAD_PROBE
+      unset LD_LIBRARY_PATH LD_PRELOAD
+      # shellcheck disable=SC1090
+      source "'"$THIS_DIR"'/AppRun" >/dev/null 2>&1 || true
+      probe="$(_preload_probe_bin || echo "")"
+      case "$probe" in
+        /*) [ -x "$probe" ] && echo "external-binary" || echo "not-executable" ;;
+        "") echo "none" ;;
+        *)  echo "builtin-name" ;;
+      esac'
+  )
+  rm -rf "$gstlibdir"
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS [$label]"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL [$label]: expected '$expected' got '$actual'" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_probe_default_case "default probe is an external binary" "external-binary"
+
+# The probed value must be what the app will actually get, inherited entries
+# included.
+run_probe_arg_case() {
+  local label="$1" inherited="$2" expected="$3"
+  local gstlibdir probe seen actual
+  gstlibdir="$(mktemp -d)"
+  touch "$gstlibdir/libgstreamer-1.0.so.0"
+  seen="$(mktemp)"
+  probe="$(mktemp)"
+  # Record what LD_PRELOAD the probe was invoked with, then succeed.
+  printf '#!/bin/sh\nprintf %%s "$LD_PRELOAD" > %s\nexit 0\n' "$seen" > "$probe"
+  chmod +x "$probe"
+
+  bash -c '
+    set +e
+    export OMNIVOICE_APPRUN_PRELOAD_PROBE="'"$probe"'"
+    export LD_PRELOAD="'"$inherited"'"
+    gstlibdir="'"$gstlibdir"'"
+    pkg-config() {
+      [ "$1" = "--variable=libdir" ] && [ "$2" = "gstreamer-1.0" ] \
+        && { echo "$gstlibdir"; return 0; }
+      return 1
+    }
+    export -f pkg-config
+    ldconfig() { return 1; }
+    export -f ldconfig
+    exec() { :; }
+    export -f exec
+    unset LD_LIBRARY_PATH
+    # shellcheck disable=SC1090
+    source "'"$THIS_DIR"'/AppRun" >/dev/null 2>&1 || true' >/dev/null 2>&1
+
+  actual="$(cat "$seen" 2>/dev/null || echo "")"
+  actual="${actual//$gstlibdir\/libgstreamer-1.0.so.0/GST}"
+  rm -rf "$gstlibdir" "$probe" "$seen"
+
+  if [[ "$actual" == "$expected" ]]; then
+    echo "PASS [$label]"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL [$label]: expected '$expected' got '$actual'" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+run_probe_arg_case "probe sees our library"            ""              "GST"
+run_probe_arg_case "probe sees inherited entries too"  "/opt/x.so"     "GST /opt/x.so"
+
 echo
 echo "─── AppRun test summary: $PASS_COUNT pass / $FAIL_COUNT fail ───"
 if [[ $FAIL_COUNT -ne 0 ]]; then

--- a/frontend/src-tauri/appimage/AppRun.test.sh
+++ b/frontend/src-tauri/appimage/AppRun.test.sh
@@ -341,9 +341,14 @@ run_gst_case() {
   # pairing. (A fixture .so is an empty file; only the real loader could
   # answer that for real, and that is the OS's job, not this suite's.)
   probe="$(mktemp)"
-  if [ "$loadable" = "yes" ]; then printf '#!/bin/sh\nexit 0\n' > "$probe"
-  else printf '#!/bin/sh\nexit 1\n' > "$probe"; fi
-  chmod +x "$probe"
+  case "$loadable" in
+    # The real /bin/sh, so the `*/sh) args="-c :"` branch runs for real: with
+    # no argument `sh` would read stdin and hang, so a broken branch here is
+    # not a silent pass.
+    sh) rm -f "$probe"; probe="$(command -v /bin/sh)" ;;
+    yes) printf '#!/bin/sh\nexit 0\n' > "$probe"; chmod +x "$probe" ;;
+    *)   printf '#!/bin/sh\nexit 1\n' > "$probe"; chmod +x "$probe" ;;
+  esac
 
   actual=$(
     bash -c '
@@ -391,7 +396,8 @@ run_gst_case() {
         *)                           printf "+shared-registry" ;;
       esac'
   )
-  rm -rf "$gstlibdir" "$cachedir" "$probe"
+  rm -rf "$gstlibdir" "$cachedir"
+  [ "$loadable" = "sh" ] || rm -f "$probe"
 
   if [[ "$actual" == "$expected" ]]; then
     echo "PASS [$label]"
@@ -523,6 +529,13 @@ run_probe_arg_case() {
 
 run_probe_arg_case "probe sees our library"            ""              "GST"
 run_probe_arg_case "probe sees inherited entries too"  "/opt/x.so"     "GST /opt/x.so"
+
+# The /bin/sh last resort is a real branch — `sh` needs `-c :` where `true`
+# needs no argument, and until now nothing ran it, so a host without
+# /usr/bin/true or /bin/true would have been the first to find out (CodeRabbit
+# flagged the sibling dead branch; this is the coverage that was missing with
+# it). Pointing the probe override at /bin/sh exercises exactly that path.
+run_gst_case "sh last-resort probe works"     ""  "pkgconfig" "gst-preloaded+libdir-intact+private-registry" "sh"
 
 echo
 echo "─── AppRun test summary: $PASS_COUNT pass / $FAIL_COUNT fail ───"


### PR DESCRIPTION
Follow-up to #1354 (#1333). Two CodeRabbit Majors landed on that PR minutes before I merged it, and I merged without reading them — my mistake, and this is the immediate correction rather than a backlog item.

Both findings are valid, and both are the dangerous kind: they **silently disabled the feature** instead of breaking loudly, so the suite stayed green while the fix did nothing.

## 1. The probe could never run (this one voided the entire fix)

```bash
probe="${OMNIVOICE_APPRUN_PRELOAD_PROBE:-$(command -v true 2>/dev/null || echo /bin/true)}"
[ -x "$probe" ] || return 1
```

`command -v true` in bash answers with the shell **builtin** — the bare word `true`, not a path. So `[ -x "true" ]` was false on every host, `_preload_loads_cleanly` always returned 1, the preload never happened, and #1333 was left exactly as it was. Verified directly:

```
$ bash -c 'p="$(command -v true)"; echo "[$p]"; [ -x "$p" ] && echo EXEC || echo "NOT EXEC"'
[true]
NOT EXEC
```

A builtin also never involves the dynamic loader, so even if the guard had passed it could not have tested anything. `_preload_probe_bin()` now resolves a real binary — `/usr/bin/true`, `/bin/true`, and `/bin/sh -c :` as the last resort, which is guaranteed present on any host that can run this script at all.

## 2. The probe tested a value the app never gets

It probed `$_SYS_GST_LIB` alone, but the exported value appends any inherited `LD_PRELOAD`. So on a host that already has one set, the probe could pass while the environment the app actually receives fails to load — reintroducing exactly the "app does not start at all" outcome the probe exists to prevent. It now probes the final composed value.

## Why the suite did not catch either

Every existing GStreamer case overrides the probe through `OMNIVOICE_APPRUN_PRELOAD_PROBE`, so the default path — the only one real users take — was never exercised, and no case had an inherited `LD_PRELOAD`. That is a gap in the tests as much as in the code, so the fix is a test that covers the default rather than only the corrected line:

- **`default probe is an external binary`** — resolves `_preload_probe_bin` with no override and asserts it is an executable path, not a builtin name. Fails against the previous `AppRun` (`got 'none'`).
- **`probe sees our library`** / **`probe sees inherited entries too`** — a recording probe captures the `LD_PRELOAD` it was invoked with. The first passes either way (with nothing inherited the two forms are identical); the second is the discriminator and fails against the previous `AppRun` (`expected 'GST /opt/x.so' got 'GST'`).

Suite: 25 pass / 0 fail; 23 pass / 2 fail with both fixes reverted.

## Changelog

An extra `### Fixed` line under `## [Unreleased]`, because the previous entry claims a behaviour that did not actually ship.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The AppImage preload probe now resolves an external executable and validates the complete `LD_PRELOAD` value, including inherited entries. This fixes the GStreamer preference guard and adds coverage for fallback probe paths. Review the fallback resolution and shell argument handling for probe hangs or incorrect preload validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->