### PR TITLE
fix(tts): a chunk that renders to nothing is no longer dropped in silence (#1330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Linux AppImage: recording failed with "No microphone found" on hosts whose GStreamer is newer than the build runner's, even with a verified-healthy audio stack — your own GStreamer now takes precedence, and the plugin cache is app-private so it can neither be confused by nor corrupt the one other apps use — thanks @Kakuzen93! (#1333)
 - Linux AppImage: that GStreamer preference actually takes effect — the check guarding it could never pass, so it had been silently doing nothing. (#1333)
 - A TTS job abandoned for exceeding its compute budget now records where it was actually stuck, so a hang stops being reported as a machine that is merely too slow. (#1338, #1329, #1348)
+- Generation that silently dropped the end of the input now says so. When an engine returns no audio for part of the text the result sounds clean and is simply short, so the only way to notice was to read along; the backend log now names the sentences that produced nothing. (#1330)
 
 ### Docs
 

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -551,7 +551,8 @@ def _run_inference(
                     if used_seed is not None:
                         torch.manual_seed(used_seed + i)
                     parts.append(_gen(chunk_text, None)[0])
-                audio_out = concatenate_audio_chunks(parts, sr, _xfade_ms)
+                audio_out = concatenate_audio_chunks(parts, sr, _xfade_ms,
+                                                     texts=text_chunks)
             else:
                 audio_out = _gen(text, duration)[0]
 
@@ -623,7 +624,8 @@ def _run_backend_inference(
                     if used_seed is not None:
                         torch.manual_seed(used_seed + i)
                     parts.append(backend.generate(chunk_text, duration=None, **gen_kwargs))
-                audio_out = concatenate_audio_chunks(parts, sr, _xfade_ms)
+                audio_out = concatenate_audio_chunks(parts, sr, _xfade_ms,
+                                                     texts=text_chunks)
             else:
                 audio_out = backend.generate(text, duration=duration, **gen_kwargs)
 
@@ -1266,7 +1268,8 @@ async def generate_speech(
             non-streaming multi-chunk loop runs, as one pool job."""
             from services.chunked_tts import concatenate_audio_chunks
             try:
-                audio_out = concatenate_audio_chunks(parts, sr, crossfade_ms)
+                audio_out = concatenate_audio_chunks(parts, sr, crossfade_ms,
+                                                     texts=_text_chunks)
                 skip = (getattr(_backend, "applies_own_mastering", False)
                         if _backend is not None else False)
                 return _apply_effect_chain(audio_out, sr, effect_preset, skip_mastering=skip)

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -287,11 +287,19 @@ def synthesize_chapter(
             if audio is None:
                 chunks = split_text_into_chunks(apply_lexicon(span.text, lexicon))
                 rendered = [synth(c, span.voice_id, span.speed) for c in chunks]
-                rendered = [r for r in rendered if r is not None and getattr(r, "numel", lambda: 0)()]
-                if len(rendered) == 1:
-                    audio = rendered[0]
-                elif rendered:
-                    audio = concatenate_audio_chunks(rendered, sample_rate, crossfade_ms=crossfade_ms)
+                # Deliberately NOT pre-filtered (#1330). Dropping the empties
+                # here both hid them — a chapter would come back short with
+                # nothing said about it — and misaligned `rendered` from
+                # `chunks`, so the concat could not name which text was lost.
+                # It reports and skips them; this only needs the count.
+                _nonempty = [r for r in rendered
+                             if r is not None and getattr(r, "numel", lambda: 0)()]
+                if len(_nonempty) == 1:
+                    audio = _nonempty[0]
+                elif _nonempty:
+                    audio = concatenate_audio_chunks(rendered, sample_rate,
+                                                    crossfade_ms=crossfade_ms,
+                                                    texts=chunks)
                 if audio is not None and segment_cache is not None:
                     segment_cache.store(span, audio, nonce=occ)
             if audio is not None:

--- a/backend/services/audiobook.py
+++ b/backend/services/audiobook.py
@@ -268,7 +268,9 @@ def synthesize_chapter(
     imported lazily so this module stays import-light for the pure parser path.
     """
     import torch
-    from services.chunked_tts import concatenate_audio_chunks, split_text_into_chunks
+    from services.chunked_tts import (concatenate_audio_chunks,
+                                      join_rendered_chunks,
+                                      split_text_into_chunks)
     from services.pronunciation import apply_lexicon
 
     items: list = []  # ("a", tensor) for audio, ("s", n_samples) for silence
@@ -291,15 +293,9 @@ def synthesize_chapter(
                 # here both hid them — a chapter would come back short with
                 # nothing said about it — and misaligned `rendered` from
                 # `chunks`, so the concat could not name which text was lost.
-                # It reports and skips them; this only needs the count.
-                _nonempty = [r for r in rendered
-                             if r is not None and getattr(r, "numel", lambda: 0)()]
-                if len(_nonempty) == 1:
-                    audio = _nonempty[0]
-                elif _nonempty:
-                    audio = concatenate_audio_chunks(rendered, sample_rate,
-                                                    crossfade_ms=crossfade_ms,
-                                                    texts=chunks)
+                audio = join_rendered_chunks(rendered, sample_rate,
+                                             crossfade_ms=crossfade_ms,
+                                             texts=chunks)
                 if audio is not None and segment_cache is not None:
                     segment_cache.store(span, audio, nonce=occ)
             if audio is not None:

--- a/backend/services/chunked_tts.py
+++ b/backend/services/chunked_tts.py
@@ -211,8 +211,41 @@ def _normalize_chunk_shapes(chunks: list) -> list:
     return chunks
 
 
+def _report_dropped_chunks(dropped: list, total: int, texts=None) -> None:
+    """Log the sentences that produced no audio. Never raises.
+
+    Deliberately WARNING, not debug: this is missing output the user paid
+    compute for, and the log is the only place it can surface — the waveform
+    itself looks perfectly clean.
+    """
+    try:
+        detail = ""
+        if texts:
+            named = [
+                repr(str(texts[i])[:80]) for i in dropped
+                if 0 <= i < len(texts)
+            ]
+            if named:
+                detail = " — no audio for: " + "; ".join(named)
+        logger.warning(
+            "Dropped %d of %d rendered chunk(s): the engine returned no audio "
+            "for them, so the output is missing that text%s. This is silent in "
+            "the waveform — the result sounds clean and is simply short (#1330).",
+            len(dropped), total, detail,
+        )
+    except Exception:  # noqa: BLE001 — a diagnostic must not break the join
+        # The fallback cannot assume logging works either: whatever broke the
+        # report above may be the logger. Losing the diagnostic is acceptable;
+        # turning missing audio into a failed render is not.
+        try:
+            logger.exception("Could not report dropped audio chunks")
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def concatenate_audio_chunks(chunks: list, sample_rate: int,
-                             crossfade_ms: int = DEFAULT_CROSSFADE_MS):
+                             crossfade_ms: int = DEFAULT_CROSSFADE_MS,
+                             texts=None):
     """Join per-chunk waveforms with a linear crossfade on the sample axis.
 
     ``chunks`` are torch tensors as returned by the engine (1-D, or N-D with
@@ -220,10 +253,28 @@ def concatenate_audio_chunks(chunks: list, sample_rate: int,
     Mixed ranks / mono-vs-multichannel chunks are normalized to one shape
     first (#897), so no producer can crash the concat. Crossfade overlap is
     clamped to the shorter neighbor; ``crossfade_ms=0`` is a hard concat.
+
+    **Empty chunks are dropped, and that is now said out loud (#1330).** A
+    chunk arrives empty when the engine returned nothing for that slice of
+    text; skipping it is still the right joining behaviour, because the
+    alternative is a crash or a gap. What was wrong was doing it in silence:
+    the audio came back clean and simply missing a sentence, so the only way a
+    user could notice was by reading along — which is exactly how it was
+    reported ("this app dosent generate me the last few sentences"). The count
+    now reaches the log, and callers that know the text can pass ``texts`` to
+    have the dropped slices named.
     """
     import torch
 
-    chunks = [c for c in chunks if c is not None and c.shape[-1] > 0]
+    kept, dropped = [], []
+    for i, c in enumerate(chunks):
+        if c is not None and c.shape[-1] > 0:
+            kept.append(c)
+        else:
+            dropped.append(i)
+    if dropped:
+        _report_dropped_chunks(dropped, len(chunks), texts)
+    chunks = kept
     if not chunks:
         return torch.zeros(1, dtype=torch.float32)
     if len(chunks) == 1:

--- a/backend/services/chunked_tts.py
+++ b/backend/services/chunked_tts.py
@@ -211,7 +211,7 @@ def _normalize_chunk_shapes(chunks: list) -> list:
     return chunks
 
 
-def _report_dropped_chunks(dropped: list, total: int, texts=None) -> None:
+def report_dropped_chunks(dropped: list, total: int, texts=None) -> None:
     """Log the sentences that produced no audio. Never raises.
 
     Deliberately WARNING, not debug: this is missing output the user paid
@@ -241,6 +241,38 @@ def _report_dropped_chunks(dropped: list, total: int, texts=None) -> None:
             logger.exception("Could not report dropped audio chunks")
         except Exception:  # noqa: BLE001
             pass
+
+
+def join_rendered_chunks(rendered: list, sample_rate: int, *,
+                         crossfade_ms: int = DEFAULT_CROSSFADE_MS,
+                         texts=None):
+    """Join what a multi-chunk render produced, reporting whatever it lost.
+
+    ``None`` when nothing rendered — the caller's dead-render handling owns
+    that case, and returning a silence buffer instead would hide it.
+
+    This exists because the "obvious" inline version has a hole that shipped:
+    a span that splits into several chunks where only ONE renders was returned
+    directly, skipping the join and therefore skipping the reporting the join
+    does. The chapter came back short and said nothing about it — the same
+    silent-truncation bug (#1330) one branch over. Keeping the decision in one
+    function means there is one place that can be wrong, and it is testable.
+    """
+    dropped = [i for i, r in enumerate(rendered)
+               if r is None or getattr(r, "shape", (0,))[-1] == 0]
+    kept = [r for i, r in enumerate(rendered) if i not in set(dropped)]
+    if not kept:
+        if dropped:
+            report_dropped_chunks(dropped, len(rendered), texts)
+        return None
+    if len(kept) == 1:
+        # concatenate_audio_chunks short-circuits a single chunk without
+        # reporting, so the report has to happen here.
+        if dropped:
+            report_dropped_chunks(dropped, len(rendered), texts)
+        return kept[0]
+    return concatenate_audio_chunks(rendered, sample_rate,
+                                    crossfade_ms=crossfade_ms, texts=texts)
 
 
 def concatenate_audio_chunks(chunks: list, sample_rate: int,
@@ -273,7 +305,7 @@ def concatenate_audio_chunks(chunks: list, sample_rate: int,
         else:
             dropped.append(i)
     if dropped:
-        _report_dropped_chunks(dropped, len(chunks), texts)
+        report_dropped_chunks(dropped, len(chunks), texts)
     chunks = kept
     if not chunks:
         return torch.zeros(1, dtype=torch.float32)

--- a/tests/test_dropped_chunk_is_not_silent.py
+++ b/tests/test_dropped_chunk_is_not_silent.py
@@ -110,12 +110,28 @@ def test_all_chunks_empty_still_returns_a_tensor(ct, caplog):
     assert "Dropped 2 of 2" in caplog.text
 
 
-def test_reporting_never_breaks_the_join(ct, caplog, monkeypatch):
+def test_reporting_never_breaks_the_join(ct, monkeypatch):
     """The diagnostic runs inside the join. One that throws would turn missing
-    audio into a failed render — strictly worse than the bug."""
-    monkeypatch.setattr(ct, "logger", None)  # any use of it now raises
+    audio into a failed render — strictly worse than the bug.
+
+    Asserts the report was *attempted*, not merely that nothing blew up:
+    without that, this would pass on a build where the reporting does not
+    exist at all (CodeRabbit).
+    """
+    attempted = []
+
+    class _Exploding:
+        def warning(self, *a, **k):
+            attempted.append(a)
+            raise RuntimeError("logging is broken")
+
+        def exception(self, *a, **k):
+            raise RuntimeError("still broken")
+
+    monkeypatch.setattr(ct, "logger", _Exploding())
     out = ct.concatenate_audio_chunks([_tone(), _empty()], 24000, 0)
-    assert out.shape[-1] == 1000
+    assert out.shape[-1] == 1000, "a broken logger cost us the audio"
+    assert attempted, "the drop was never reported, so there was nothing to survive"
 
 
 def test_mismatched_texts_do_not_break_the_report(ct, caplog):
@@ -128,9 +144,15 @@ def test_mismatched_texts_do_not_break_the_report(ct, caplog):
 
 
 def test_chunking_itself_loses_no_text(ct):
-    """Guards the hypothesis this investigation eliminated, so a future change
-    to the splitter cannot quietly reintroduce it. Every non-whitespace
-    character of the input must survive into some chunk."""
+    """Pins an eliminated hypothesis rather than a fixed defect.
+
+    Kept deliberately, and it does NOT fail before this change — the splitter
+    was already correct. The value is that "the chunker drops the tail" was the
+    first and most plausible explanation for #1330, ruling it out took a probe,
+    and without this the next person to read the issue has to redo that work.
+    A future splitter change that did start losing the tail would produce
+    exactly the reported symptom again, and this is what would catch it.
+    """
     import re
 
     cases = [
@@ -148,3 +170,55 @@ def test_chunking_itself_loses_no_text(ct):
         assert joined == re.sub(r"\s+", "", text), (
             f"chunking lost text for input starting {text[:40]!r}"
         )
+
+
+# ── join_rendered_chunks: the decision the audiobook path used to inline ────
+# Both reviewers caught the same hole in the inline version: a span split into
+# several chunks where only ONE renders returned that chunk directly, skipping
+# the join and therefore skipping the reporting the join does. It lives in one
+# testable function now.
+
+def test_one_survivor_of_several_is_reported(ct, caplog):
+    """The branch that shipped broken."""
+    texts = ["kept", "lost one", "lost two"]
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.join_rendered_chunks([_tone(), _empty(), _empty()], 24000, texts=texts)
+    assert out is not None and out.shape[-1] == 1000, "the survivor must still be used"
+    assert "Dropped 2 of 3" in caplog.text, caplog.text
+    assert "lost one" in caplog.text
+
+
+def test_nothing_rendered_returns_none_and_reports(ct, caplog):
+    """None rather than a silence buffer: the caller's dead-render handling
+    owns that case, and handing back silence would hide it from them."""
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.join_rendered_chunks([_empty(), _empty()], 24000, texts=["a", "b"])
+    assert out is None
+    assert "Dropped 2 of 2" in caplog.text
+
+
+def test_a_clean_multi_chunk_join_says_nothing(ct, caplog):
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.join_rendered_chunks([_tone(), _tone()], 24000, crossfade_ms=0)
+    assert out.shape[-1] == 2000
+    assert "Dropped" not in caplog.text
+
+
+def test_a_single_chunk_that_rendered_says_nothing(ct, caplog):
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.join_rendered_chunks([_tone()], 24000)
+    assert out.shape[-1] == 1000
+    assert "Dropped" not in caplog.text
+
+
+def test_audiobook_uses_the_shared_helper(ct):
+    """A second inline copy of this decision is how the hole appeared the first
+    time, so pin that the audiobook path routes through the one function."""
+    import inspect
+
+    ab = importlib.import_module("services.audiobook")
+    src = inspect.getsource(ab)
+    assert "join_rendered_chunks(" in src, (
+        "audiobook no longer uses the shared join — check it has not grown its "
+        "own branch that skips the dropped-chunk reporting again"
+    )

--- a/tests/test_dropped_chunk_is_not_silent.py
+++ b/tests/test_dropped_chunk_is_not_silent.py
@@ -1,0 +1,150 @@
+"""A chunk that renders to nothing must not vanish quietly (#1330).
+
+Reported from Discord:
+
+    "also when i make voices this app dosent generate me the last few
+     sentences. for rest this app is a banger"
+
+The audio that comes back is clean — it is just missing the end of the input.
+That shape is the worst one available: nothing errors, nothing looks wrong, and
+the only way to notice is to read along while listening.
+
+Ruled out first, by direct probe rather than by reading:
+
+* ``split_text_into_chunks`` preserves every non-whitespace character across a
+  range of inputs, including text with no terminal punctuation;
+* ``concatenate_audio_chunks`` joins everything it is given;
+* ``trim_trailing_silence`` cuts only from the last *voiced* sample, so it
+  cannot remove speech.
+
+What was left is the line that filtered the chunk list before joining it:
+``[c for c in chunks if c is not None and c.shape[-1] > 0]``. When an engine
+returns nothing for one slice of text, skipping it is still the right joining
+behaviour — the alternative is a crash or a gap. Doing it in silence is not.
+These tests pin that the drop is now reported, that the report names the text,
+and that skipping still happens so the join never regresses into a crash.
+"""
+import importlib
+import logging
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+torch = pytest.importorskip("torch")
+
+
+@pytest.fixture
+def ct():
+    """Resolve at call time — sibling suites reload/purge ``services.*``."""
+    return importlib.import_module("services.chunked_tts")
+
+
+def _tone(n=1000):
+    return torch.ones(n, dtype=torch.float32) * 0.5
+
+
+def _empty():
+    return torch.zeros(0, dtype=torch.float32)
+
+
+def test_a_dropped_chunk_is_logged(ct, caplog):
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.concatenate_audio_chunks([_tone(), _empty(), _tone()], 24000, 0)
+    assert out.shape[-1] == 2000, "the non-empty chunks must still be joined"
+    assert "Dropped 1 of 3" in caplog.text, (
+        "a rendered chunk produced no audio and nothing was logged — the user "
+        f"gets clean-sounding output that is simply short:\n{caplog.text}"
+    )
+
+
+def test_the_log_names_the_text_that_was_lost(ct, caplog):
+    """A count alone tells a maintainer that something went missing. The text
+    tells them which sentence to try to reproduce with."""
+    texts = ["First sentence.", "The one that failed.", "Third sentence."]
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        ct.concatenate_audio_chunks([_tone(), _empty(), _tone()], 24000, 0, texts=texts)
+    assert "The one that failed." in caplog.text, caplog.text
+    # ...and not the ones that rendered fine.
+    assert "First sentence." not in caplog.text
+
+
+def test_the_tail_case_specifically(ct, caplog):
+    """The reported shape: it is the LAST chunk that comes back empty, so the
+    output ends early and everything before it sounds perfect."""
+    texts = ["Body of the text.", "and the last few sentences"]
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.concatenate_audio_chunks([_tone(), _empty()], 24000, 0, texts=texts)
+    assert out.shape[-1] == 1000
+    assert "and the last few sentences" in caplog.text
+
+
+def test_nothing_is_logged_when_every_chunk_rendered(ct, caplog):
+    """The overwhelmingly common case. A warning on every healthy render would
+    train everyone to ignore the one that matters."""
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        ct.concatenate_audio_chunks([_tone(), _tone()], 24000, 0)
+    assert "Dropped" not in caplog.text
+
+
+def test_none_entries_count_as_dropped(ct, caplog):
+    """An engine that returns None rather than an empty tensor loses the same
+    text, so it must not be treated as a different, quieter case."""
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.concatenate_audio_chunks([_tone(), None], 24000, 0)
+    assert out.shape[-1] == 1000
+    assert "Dropped 1 of 2" in caplog.text
+
+
+def test_all_chunks_empty_still_returns_a_tensor(ct, caplog):
+    """The total-failure path is owned by the downstream dead-render guards;
+    this must keep handing them something rather than raising here."""
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        out = ct.concatenate_audio_chunks([_empty(), _empty()], 24000, 0)
+    assert out.numel() >= 1
+    assert "Dropped 2 of 2" in caplog.text
+
+
+def test_reporting_never_breaks_the_join(ct, caplog, monkeypatch):
+    """The diagnostic runs inside the join. One that throws would turn missing
+    audio into a failed render — strictly worse than the bug."""
+    monkeypatch.setattr(ct, "logger", None)  # any use of it now raises
+    out = ct.concatenate_audio_chunks([_tone(), _empty()], 24000, 0)
+    assert out.shape[-1] == 1000
+
+
+def test_mismatched_texts_do_not_break_the_report(ct, caplog):
+    """A caller that passes a shorter list than it rendered must still get the
+    count — an IndexError here would lose the whole diagnostic."""
+    with caplog.at_level(logging.WARNING, logger="omnivoice.chunked_tts"):
+        ct.concatenate_audio_chunks([_tone(), _empty(), _empty()], 24000, 0,
+                                    texts=["only one"])
+    assert "Dropped 2 of 3" in caplog.text
+
+
+def test_chunking_itself_loses_no_text(ct):
+    """Guards the hypothesis this investigation eliminated, so a future change
+    to the splitter cannot quietly reintroduce it. Every non-whitespace
+    character of the input must survive into some chunk."""
+    import re
+
+    cases = [
+        "One. Two. Three.",
+        "A sentence without a terminator at the end",
+        "Long text. " * 60 + "The final sentence has no period",
+        "x" * 500 + " end",
+        "First para.\n\nSecond para.\n\nTrailing line without punctuation",
+        ("word " * 300) + "FINALWORD",
+    ]
+    for text in cases:
+        chunks = ct.split_text_into_chunks(text)
+        assert chunks, text[:40]
+        joined = re.sub(r"\s+", "", "".join(chunks))
+        assert joined == re.sub(r"\s+", "", text), (
+            f"chunking lost text for input starting {text[:40]!r}"
+        )


### PR DESCRIPTION
Addresses #1330. Makes the failure findable; does **not** fix whatever makes the engine return nothing.

## Narrowing it

The report is the hardest shape to chase:

> also when i make voices this app dosent generate me the last few sentences. for rest this app is a banger

Clean audio, correct voice, just short. The issue listed four hypotheses; three are eliminated here by probe rather than by reading, and each elimination is now a test so nobody has to redo it:

- **`split_text_into_chunks` loses nothing.** Every non-whitespace character survives into some chunk, across text with no terminal punctuation, text ending mid-word, 500-char runs and multi-paragraph input.
- **`concatenate_audio_chunks` joins everything it is given.**
- **`trim_trailing_silence` cannot remove speech** — it cuts only from the last *voiced* sample, keeping 0.3 s past it.

That leaves one line, at the top of the join:

```python
chunks = [c for c in chunks if c is not None and c.shape[-1] > 0]
```

## The defect

When an engine returns nothing for one slice of text, skipping it is still the **right joining behaviour** — the alternative is a crash or a gap in the middle of a sentence. Doing it **silently** is not.

The waveform comes back clean and simply short. Nothing errors, nothing looks wrong, and the only way to notice is to read along while listening — which is precisely how it was reported, and why it went unnoticed long enough to reach Discord as a compliment with a complaint attached.

If the empty chunk is the **last** one, the output ends early: "doesn't generate me the last few sentences", exactly.

## Change

The join now counts the drops, logs at **WARNING** — this is output the user spent compute on, and the log is the only place it can surface — and names the lost text when the caller can supply it. Wired through all three generation call sites and the audiobook renderer.

Audiobook additionally pre-filtered before calling:

```python
rendered = [r for r in rendered if r is not None and ...]
```

which hid the same drop a second time **and** misaligned `rendered` from `chunks`, so the concat could not have named what was lost even with the text in hand. It passes the full list now and uses a separate count for its own branching.

The reporting cannot break the join — including when the logger itself is what broke, since turning missing audio into a failed render would be strictly worse than the bug.

## Tests

`tests/test_dropped_chunk_is_not_silent.py`, 9 cases, 6 failing before this change:

- a dropped chunk is logged, and the surviving chunks are still joined;
- the log names the lost text, and **not** the chunks that rendered fine;
- the tail case specifically (last chunk empty → short output);
- **nothing is logged on a healthy render** — a warning on every render would train everyone to ignore the one that matters;
- `None` counts the same as an empty tensor, so an engine returning either does not get a quieter path;
- all-empty still returns a tensor, leaving the total-failure case to the downstream dead-render guards;
- a caller passing fewer texts than chunks still gets the count, rather than losing the diagnostic to an `IndexError`;
- the reporting cannot break the join;
- the chunking-loses-nothing property, so a future splitter change cannot quietly reintroduce the hypothesis this ruled out.

Related suites: 234 passed.

## What is still open

Why an engine returns no audio for a chunk. That needs a reproducing input, and this is what makes one obtainable — the next report of #1330 will carry the sentence that failed instead of "the last few sentences".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
TTS concatenation now reports dropped `None` or empty chunks with source text while preserving rendered audio. Generation and audiobook paths use `join_rendered_chunks` to maintain chunk alignment and report one-survivor and zero-survivor cases consistently. The underlying empty-audio engine issue remains unresolved, so review diagnostic behavior when chunk metadata is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->