### PR TITLE
fix(dub): say when a clone reference is gone instead of rendering a default voice (#1331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A TTS job abandoned for exceeding its compute budget now records where it was actually stuck, so a hang stops being reported as a machine that is merely too slow. (#1338, #1329, #1348)
 - Translation through LM Studio works. The built-in model name was the placeholder `local-model`, which LM Studio rejects because it serves whatever you have loaded — OmniVoice now asks it, and a 404 from a local server names the models that ARE loaded instead of telling you to check a URL that was fine — thanks @biga73! (#1332)
 - Generation that silently dropped the end of the input now says so. When an engine returns no audio for part of the text the result sounds clean and is simply short, so the only way to notice was to read along; the backend log now names the sentences that produced nothing. (#1330)
+- Dubbing: a re-rendered line that quietly came back in a default voice instead of the cloned one now says why in the backend log — the clone clips are extracted per job and a saved dub outlives them, so regenerating after cleanup loses the reference with no error. (#1331)
 
 ### Docs
 

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -203,6 +203,63 @@ def _speaker_key_for_segment(job: dict, sid) -> str | None:
     return None
 
 
+#: Segment ids already warned about, per job, so a 300-segment dub whose clip
+#: directory was cleaned logs once per segment rather than once per retry.
+_MISSING_REF_WARNED: dict = {}
+
+
+def warn_if_ref_missing(ref_audio, *, job_id: str = "", seg_id="", where: str = "dub"):
+    """Say so when a clone reference points at a file that is gone (#1331).
+
+    Reported as: re-dubbing a single sentence loses the cloned voice, while
+    re-dubbing everything keeps it.
+
+    Clone references are FILE PATHS into the job's extracted-clip directory,
+    and the whole job dict — those paths included — is persisted to
+    ``dub_history.job_data`` so saved projects reopen after a restart. The job
+    therefore outlives its clips. Reopen a saved dub once the clip directory
+    has been cleaned, regenerate one line, and every resolution branch hands
+    the engine a path that is no longer there. An engine given a missing
+    reference renders *uncloned* rather than failing, so the line comes back in
+    a default voice matching nothing else in the dub, with no error anywhere.
+    Re-running the full dub re-extracts the clips — which is exactly why that
+    appears to fix it, and is the workaround the reporter found unaided.
+
+    Deliberately DIAGNOSTIC ONLY: ``ref_audio`` is returned unchanged. Nulling
+    it would not change what the user hears (the engine already falls back),
+    and it would decide on the engine's behalf that a reference it cannot
+    ``stat`` is unusable — untrue for anything resolved inside a sidecar's own
+    namespace. The defect here is the silence, not the fallback.
+    """
+    if not ref_audio:
+        return ref_audio
+    try:
+        if os.path.exists(ref_audio):
+            return ref_audio
+    except OSError:  # unreadable path (permissions, dead mount) — same symptom
+        pass
+    seen = _MISSING_REF_WARNED.setdefault(str(job_id), set())
+    key = str(seg_id)
+    if key not in seen:
+        seen.add(key)
+        logger.warning(
+            "%s: the voice reference for segment %s is gone (%s), so this line "
+            "will most likely render in a DEFAULT voice instead of the cloned "
+            "one, with no error of its own. Clone clips are extracted per job "
+            "and the job outlives them, so a saved dub regenerated after "
+            "cleanup loses them — re-running the full dub re-extracts the "
+            "clips, which is why that appears to fix it (#1331).",
+            where, seg_id, ref_audio,
+        )
+    return ref_audio
+
+
+def forget_missing_ref_warnings(job_id: str) -> None:
+    """Drop the once-per-segment warning memo for a job (a fresh render should
+    warn again if the clips are still gone)."""
+    _MISSING_REF_WARNED.pop(str(job_id), None)
+
+
 def resolve_consistent_ref(job: dict, speaker_key: str, memo: dict | None = None):
     """ONE clone reference for every segment of `speaker_key`.
 
@@ -661,6 +718,12 @@ async def dub_generate(job_id: str, req: DubRequest):
 
                 if used_seed is not None:
                     torch.manual_seed(used_seed)
+
+                # Last gate before the engine: every resolution branch above
+                # produces a PATH, and none of them can know it still exists.
+                ref_audio = warn_if_ref_missing(
+                    ref_audio, job_id=job_id, seg_id=seg_id, where="dub render",
+                )
 
                 try:
                     audio_out = backend.generate(
@@ -1475,6 +1538,9 @@ async def preview_segment(job_id: str, req: SegmentPreviewRequest):
                 if not instruct_str and row["instruct"]:
                     instruct_str = row["instruct"]
 
+        ref_audio = warn_if_ref_missing(
+            ref_audio, job_id=job_id, seg_id="preview", where="dub preview",
+        )
         lang = req.language if req.language != "Auto" else None
         # Same normalization as the full dub render above, so a preview
         # sounds exactly like the final segment. Pref-gated, never raises.

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -203,8 +203,17 @@ def _speaker_key_for_segment(job: dict, sid) -> str | None:
     return None
 
 
-#: Segment ids already warned about, per job, so a 300-segment dub whose clip
-#: directory was cleaned logs once per segment rather than once per retry.
+#: ``job_id -> {(segment, path)}`` already warned about, so a 300-segment dub
+#: whose clip directory was cleaned logs once per segment rather than once per
+#: retry.
+#:
+#: Keyed on the PATH as well as the segment, not the segment alone. The
+#: single-segment preview endpoint has no segment identity to pass — it is a
+#: "render this text" call — so every preview shared one key and only the first
+#: missing reference in a job was ever reported, silencing the rest (greptile).
+#: A distinct path is distinct information wherever it comes from, and on the
+#: render path this also means a segment whose binding was changed to a second
+#: missing clip is not mistaken for the one already reported.
 _MISSING_REF_WARNED: dict = {}
 
 
@@ -239,7 +248,7 @@ def warn_if_ref_missing(ref_audio, *, job_id: str = "", seg_id="", where: str = 
     except OSError:  # unreadable path (permissions, dead mount) — same symptom
         pass
     seen = _MISSING_REF_WARNED.setdefault(str(job_id), set())
-    key = str(seg_id)
+    key = (str(seg_id), str(ref_audio))
     if key not in seen:
         seen.add(key)
         logger.warning(
@@ -1477,6 +1486,11 @@ import io
 
 
 class SegmentPreviewRequest(BaseModel):
+    # Optional, and only used to label diagnostics: a preview is a "render this
+    # text" call, so it has never needed segment identity. Supplying it makes a
+    # missing-clone warning name the line the user was editing instead of a
+    # bare "preview" (greptile).
+    segment_id: Optional[str] = None
     text: str
     language: str = "Auto"
     instruct: Optional[str] = None
@@ -1539,7 +1553,8 @@ async def preview_segment(job_id: str, req: SegmentPreviewRequest):
                     instruct_str = row["instruct"]
 
         ref_audio = warn_if_ref_missing(
-            ref_audio, job_id=job_id, seg_id="preview", where="dub preview",
+            ref_audio, job_id=job_id,
+            seg_id=req.segment_id or "preview", where="dub preview",
         )
         lang = req.language if req.language != "Auto" else None
         # Same normalization as the full dub render above, so a preview

--- a/tests/test_missing_clone_ref_is_not_silent.py
+++ b/tests/test_missing_clone_ref_is_not_silent.py
@@ -1,0 +1,151 @@
+"""A clone reference whose file is gone must not silently become a default voice.
+
+Reported on Discord (in Russian):
+
+    если переозвучивать отдельные предложения то голос не берется из видео,
+    приходится все переозвучивать чтобы клон голоса сработал
+
+    "If you re-dub individual sentences, the voice isn't taken from the video —
+     you have to re-dub everything for the voice clone to work."
+
+Clone references are FILE PATHS into the job's extracted-clip directory, and the
+whole job dict — those paths included — is persisted to ``dub_history.job_data``
+so saved projects reopen after a restart. The job therefore outlives its clips.
+Reopen a saved dub once the clip directory has been cleaned, regenerate one
+line, and every resolution branch happily hands the engine a path that is no
+longer there.
+
+Nothing checked it, and an engine given a missing reference renders **uncloned**
+rather than failing — so the line comes back in a default voice, matching
+nothing else in the dub, with no error anywhere. Re-running the full dub
+re-extracts the clips, which is exactly why that appears to fix it and is the
+workaround the reporter found on their own.
+
+The change is diagnostic only: the reference is passed to the engine unchanged.
+Nulling it would not alter what the user hears, and would decide on the
+engine's behalf that a path it cannot ``stat`` is unusable. The defect is the
+silence, not the fallback — so this does not change what happens, it changes
+whether anyone can find out why.
+"""
+import importlib
+import logging
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+
+@pytest.fixture
+def dg():
+    """Resolve at call time — sibling suites reload/purge ``services.*``."""
+    mod = importlib.import_module("api.routers.dub_generate")
+    mod._MISSING_REF_WARNED.clear()
+    yield mod
+    mod._MISSING_REF_WARNED.clear()
+
+
+def test_an_existing_reference_passes_through(dg, tmp_path):
+    clip = tmp_path / "speaker1.wav"
+    clip.write_bytes(b"RIFF....WAVE")
+    assert dg.warn_if_ref_missing(str(clip), job_id="j", seg_id=1) == str(clip)
+
+
+def test_a_missing_reference_is_still_passed_to_the_engine(dg, tmp_path):
+    """Diagnostic only, on purpose.
+
+    Nulling it would not change what the user hears — the engine already falls
+    back — and it would decide on the engine`s behalf that a reference it
+    cannot ``stat`` is unusable, which is untrue for anything resolved inside a
+    sidecar`s own namespace. The defect is the silence, not the fallback.
+    """
+    gone = str(tmp_path / "gone.wav")
+    assert dg.warn_if_ref_missing(gone, job_id="j", seg_id=1) == gone
+
+
+def test_a_missing_reference_is_logged(dg, tmp_path, caplog):
+    """The reported case: the path survived in the saved job, the file did not."""
+    gone = str(tmp_path / "cleaned-up" / "speaker1.wav")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        dg.warn_if_ref_missing(gone, job_id="job7", seg_id=42)
+    assert "segment 42" in caplog.text, caplog.text
+    assert gone in caplog.text, "the log must name the path that vanished"
+    assert "DEFAULT voice" in caplog.text, (
+        "the log has to say what the user will actually hear, or it reads as "
+        "housekeeping rather than as the explanation for their bug"
+    )
+
+
+def test_no_reference_at_all_is_not_a_warning(dg, caplog):
+    """A segment with no clone binding is the ordinary case — designed voices,
+    preset voices, plain TTS. Warning there would bury the real one."""
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        assert dg.warn_if_ref_missing(None, job_id="j", seg_id=1) is None
+        assert dg.warn_if_ref_missing("", job_id="j", seg_id=2) == ""
+    assert caplog.text == ""
+
+
+def test_each_segment_warns_once(dg, tmp_path, caplog):
+    """A 300-segment dub whose clip directory was cleaned should produce one
+    line per segment, not one per retry of that segment."""
+    gone = str(tmp_path / "gone.wav")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        for _ in range(5):
+            dg.warn_if_ref_missing(gone, job_id="job7", seg_id=42)
+    assert caplog.text.count("segment 42") == 1
+
+
+def test_different_segments_each_warn(dg, tmp_path, caplog):
+    """...but per-segment, since which lines lost their reference is the
+    diagnostic — "some of them" is not actionable."""
+    gone = str(tmp_path / "gone.wav")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        dg.warn_if_ref_missing(gone, job_id="job7", seg_id=1)
+        dg.warn_if_ref_missing(gone, job_id="job7", seg_id=2)
+    assert "segment 1" in caplog.text and "segment 2" in caplog.text
+
+
+def test_jobs_do_not_share_the_warning_memo(dg, tmp_path, caplog):
+    """Two dubs can legitimately use the same segment ids."""
+    gone = str(tmp_path / "gone.wav")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        dg.warn_if_ref_missing(gone, job_id="jobA", seg_id=1)
+        dg.warn_if_ref_missing(gone, job_id="jobB", seg_id=1)
+    assert caplog.text.count("segment 1") == 2
+
+
+def test_forgetting_a_job_lets_it_warn_again(dg, tmp_path, caplog):
+    gone = str(tmp_path / "gone.wav")
+    dg.warn_if_ref_missing(gone, job_id="job7", seg_id=1)
+    dg.forget_missing_ref_warnings("job7")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        dg.warn_if_ref_missing(gone, job_id="job7", seg_id=1)
+    assert "segment 1" in caplog.text
+
+
+def test_an_unreadable_path_is_treated_as_missing(dg, monkeypatch, caplog):
+    """A dead network mount or a permissions failure reaches the engine the
+    same way a deleted file does, so it must not escape through an OSError."""
+    monkeypatch.setattr(dg.os.path, "exists",
+                        lambda p: (_ for _ in ()).throw(OSError("stale NFS handle")))
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        dg.warn_if_ref_missing("/mnt/gone/clip.wav", job_id="j", seg_id=3)
+    assert "segment 3" in caplog.text
+
+
+def test_the_render_path_actually_calls_the_gate(dg):
+    """The check is only worth having where the paths are used. Pin that both
+    call sites route through it, since a resolution branch added later would
+    otherwise quietly bypass it."""
+    import inspect
+
+    src = inspect.getsource(dg)
+    # Once in the full render, once in the single-segment preview.
+    assert src.count("warn_if_ref_missing(") >= 3, (
+        "expected the definition plus both call sites; a generate path that "
+        "does not verify its reference is the bug this file exists for"
+    )

--- a/tests/test_missing_clone_ref_is_not_silent.py
+++ b/tests/test_missing_clone_ref_is_not_silent.py
@@ -149,3 +149,38 @@ def test_the_render_path_actually_calls_the_gate(dg):
         "expected the definition plus both call sites; a generate path that "
         "does not verify its reference is the bug this file exists for"
     )
+
+
+def test_distinct_paths_each_warn_even_under_one_segment_key(dg, tmp_path, caplog):
+    """The single-segment preview endpoint has no segment identity to pass — it
+    is a "render this text" call — so every preview shared the key "preview"
+    and only the FIRST missing reference in a job was ever reported. Every
+    later one, with a different path, was silenced (greptile).
+
+    A distinct path is distinct information wherever it comes from.
+    """
+    a = str(tmp_path / "speaker1.wav")
+    b = str(tmp_path / "speaker2.wav")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        dg.warn_if_ref_missing(a, job_id="job7", seg_id="preview")
+        dg.warn_if_ref_missing(b, job_id="job7", seg_id="preview")
+    assert a in caplog.text and b in caplog.text, (
+        "a second missing reference under the same key was swallowed:\n" + caplog.text
+    )
+
+
+def test_the_same_path_under_one_key_still_warns_once(dg, tmp_path, caplog):
+    """...without giving up the de-duplication it exists for."""
+    same = str(tmp_path / "speaker1.wav")
+    with caplog.at_level(logging.WARNING, logger="omnivoice.dub"):
+        for _ in range(4):
+            dg.warn_if_ref_missing(same, job_id="job7", seg_id="preview")
+    assert caplog.text.count(same) == 1
+
+
+def test_the_preview_request_can_carry_a_segment_id(dg):
+    """Optional and diagnostic-only, so old callers are unaffected — but a
+    caller that supplies it gets the line named instead of a bare "preview"."""
+    req = dg.SegmentPreviewRequest(text="hello")
+    assert req.segment_id is None
+    assert dg.SegmentPreviewRequest(text="hello", segment_id="42").segment_id == "42"


### PR DESCRIPTION
Addresses #1331. Explains the reported behaviour and makes it visible; does **not** stop the clips being cleaned up.

## What the report actually describes

> если переозвучивать отдельные предложения то голос не берется из видео, приходится все переозвучивать чтобы клон голоса сработал
>
> "If you re-dub **individual sentences**, the voice isn't taken from the video — you have to re-dub **everything** for the voice clone to work."

That last clause is the clue, and it points somewhere specific: re-dubbing everything is not a different *code path* — the UI regenerates a subset through the same `/dub/generate` with `regen_only`, so the resolution logic is shared. What a full re-dub does differently is **re-extract the clips**.

## Mechanism

Clone references are **file paths** into the job's extracted-clip directory (`speaker_clones`, `segment_clones`). The entire job dict — those paths included — is persisted to `dub_history.job_data` so saved projects reopen after a restart.

So the job outlives its clips. Reopen a saved dub after the clip directory has been cleaned, regenerate one line, and every resolution branch in `dub_generate.py` happily produces a path that is no longer there. **Nothing checked it**, and an engine handed a missing reference renders *uncloned* rather than failing — so the line comes back in a default voice, matching nothing else in the dub, with no error anywhere.

Re-running the full dub re-extracts the clips. Which is precisely why that "works", and why the reporter found that workaround on their own without knowing the cause.

## The change: diagnostic only

`warn_if_ref_missing()` is called immediately before the engine call in both the full render and the single-segment preview — the last point where every resolution branch has converged on a path. It logs which segment lost its reference and to what path, and it **returns the reference unchanged**.

That restraint is deliberate, and I got it wrong first:

- Nulling the reference would not alter what the user hears. The engine already falls back; that is the entire problem.
- It would decide, on the engine's behalf, that a path OmniVoice cannot `stat` is unusable — untrue for anything resolved inside a sidecar's own namespace.
- My first cut did null it, and broke **7 existing tests** in `test_dub_voice_match.py` that legitimately assert a synthetic path reaches the engine. That was the right signal, not a test problem.

The defect is the silence, not the fallback.

Warns **once per segment per job**: a 300-segment dub whose clips were cleaned should name which lines lost their reference, not repeat itself on every retry of one line. "Some of them" is not actionable.

## Tests

`tests/test_missing_clone_ref_is_not_silent.py`, 10 cases:

- an existing reference passes through untouched;
- a missing one is **still passed to the engine** — the restraint above, pinned so a later "cleanup" cannot quietly turn this into a behaviour change;
- the log names the segment, the path, and what the user will actually hear (`DEFAULT voice`) — a message that only said "reference missing" reads as housekeeping rather than as the explanation for their bug;
- **no** warning when there is no reference at all — designed voices, presets and plain TTS are the ordinary case and would bury the real one;
- once per segment, but per-segment, and not shared between jobs that reuse segment ids;
- an unreadable path (dead mount, permissions) is treated the same as a deleted one rather than escaping through an `OSError`;
- both call sites route through the helper, so a resolution branch added later cannot bypass it.

Full dub suite: 326 passed.

## What is still open

Why the clips go missing — whether that is temp-dir cleanup, a job-cleanup path, or the user clearing storage. That needs a reproduction, and this is what makes one useful: the next report will carry the segment ids and the paths instead of "the voice isn't taken from the video".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added warnings for missing or unreadable voice-clone references during full renders and segment previews, with per-job, segment, and path deduplication. The engine still receives the original path and falls back to the default voice when the reference is unavailable. The underlying clip-cleanup issue remains unresolved and requires human review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->