### PR TITLE
fix(release): rebuild + cryptographically verify the preview updater manifest (#1327)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -919,6 +919,87 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Needed by the manifest rebuild + signature check below: the updater
+      # pubkey lives in frontend/src-tauri/tauri.conf.json.
+      - uses: actions/checkout@v4
+
+      # ── Rebuild the preview updater manifest from what is ACTUALLY published ──
+      # Since ~2026-07-13 every matrix leg has logged "Signature not found for
+      # the updater JSON. Skipping upload..." — tauri-action uploads the bundles
+      # + .sig companions but never refreshes latest.json. Meanwhile the macOS
+      # updater bundles (version-less filenames) are deleted + replaced every
+      # night by "Clear this arch's stale preview updater bundle", so the
+      # manifest's darwin signatures stopped matching the published files:
+      # macOS Preview users hit "The signature verification failed" on every
+      # update attempt (latest.json frozen at 2026-07-13, tar.gz replaced
+      # nightly).
+      #
+      # Root fix: after the matrix completes, rebuild latest.json HERE — one
+      # job, no per-leg race — from the release's real assets and their .sig
+      # companions, then clobber-upload. The manifest can no longer drift from
+      # the files it describes, regardless of what tauri-action's own
+      # updater-JSON path does or skips.
+      - name: Rebuild preview updater manifest from published assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release view preview --repo "$REPO" --json assets \
+            -q '[.assets[].name]' > /tmp/assets.json
+          WORK=$(mktemp -d)
+          python3 - "$WORK" <<'PY'
+          import datetime, json, os, re, subprocess, sys
+          work = sys.argv[1]
+          repo = os.environ["REPO"]
+          names = json.load(open("/tmp/assets.json"))
+
+          def sig(name):
+              subprocess.run(["gh", "release", "download", "preview", "--repo", repo,
+                              "-p", name + ".sig", "-D", work], check=True)
+              return open(os.path.join(work, name + ".sig")).read().strip()
+
+          # Versioned artifacts accumulate on the rolling release; the newest
+          # BASE-N (N = run number, monotonically increasing) is current.
+          def newest(pattern):
+              best, best_n = None, -1
+              for n in names:
+                  m = re.fullmatch(pattern, n)
+                  if m and int(m.group("n")) > best_n:
+                      best, best_n = n, int(m.group("n"))
+              return best, best_n
+
+          appimage, n1 = newest(r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_amd64\.AppImage")
+          msi, n2 = newest(r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_x64_en-US\.msi")
+          assert appimage and msi, f"missing versioned updater artifacts (AppImage={appimage}, MSI={msi})"
+          version = re.search(r"_([\d.]+-\d+)_", appimage if n1 >= n2 else msi).group(1)
+          mac_a = "OmniVoice.Studio_aarch64.app.tar.gz"
+          mac_x = "OmniVoice.Studio_x64.app.tar.gz"
+          for required in (mac_a, mac_x, appimage, msi):
+              assert required in names, f"updater artifact missing from release: {required}"
+              assert required + ".sig" in names, f".sig companion missing for: {required}"
+          base = f"https://github.com/{repo}/releases/download/preview/"
+          entries = {
+              "darwin-aarch64": mac_a, "darwin-aarch64-app": mac_a,
+              "darwin-x86_64": mac_x, "darwin-x86_64-app": mac_x,
+              "linux-x86_64": appimage, "linux-x86_64-appimage": appimage,
+              "windows-x86_64": msi, "windows-x86_64-msi": msi,
+          }
+          sigs = {n: sig(n) for n in sorted(set(entries.values()))}
+          manifest = {
+              "version": version,
+              "notes": "Auto-generated rolling preview build from main. See CHANGELOG.md and the commit log for details.",
+              "pub_date": datetime.datetime.now(datetime.timezone.utc)
+                          .isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+              "platforms": {k: {"signature": sigs[v], "url": base + v}
+                            for k, v in entries.items()},
+          }
+          json.dump(manifest, open(os.path.join(work, "latest.json"), "w"), indent=2)
+          print(f"Rebuilt preview latest.json: version={version}")
+          PY
+          gh release upload preview "$WORK/latest.json" --clobber --repo "$REPO"
+          echo "Uploaded rebuilt latest.json to the preview release."
+
       - name: Generate + apply GitHub release notes to the preview release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -952,7 +1033,7 @@ jobs:
           gh release edit preview --repo "$REPO" --prerelease --notes-file /tmp/preview-notes.md
           echo "Applied auto-generated release notes + contributors to the preview release."
 
-      - name: Verify preview updater manifest (prerelease + platform parity)
+      - name: Verify preview updater manifest (prerelease + parity + signatures)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -976,6 +1057,54 @@ jobs:
           missing = sk - pk
           assert not missing, f"preview manifest missing platforms vs stable: {sorted(missing)}"
           print(f"preview manifest OK: {v} platforms={sorted(pk)}")
+          PY
+          # ── Cryptographic check: every signature in latest.json must verify
+          # against the artifact the manifest points at, with the updater pubkey
+          # baked into the app (tauri.conf.json). This is the check that was
+          # missing while the manifest drifted for 2+ weeks: parity and version
+          # format both passed while every darwin entry was unverifiable and
+          # macOS Preview users saw "The signature verification failed".
+          pip install --quiet cryptography
+          python3 - <<'PY'
+          import base64, hashlib, json, os, subprocess, sys, tempfile
+          from urllib.parse import unquote
+          from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+          conf = json.load(open("frontend/src-tauri/tauri.conf.json"))
+          pub_doc = base64.b64decode(conf["plugins"]["updater"]["pubkey"]).decode()
+          pub = base64.b64decode(pub_doc.strip().splitlines()[1])
+          assert pub[:2] == b"Ed", "unexpected pubkey algorithm"
+          pk = Ed25519PublicKey.from_public_bytes(pub[10:42])
+          manifest = json.load(open("/tmp/preview-latest.json"))
+          work = tempfile.mkdtemp()
+          repo = os.environ["REPO"]
+          digests, failures = {}, []
+          for plat, info in sorted(manifest["platforms"].items()):
+              name = unquote(info["url"].rsplit("/", 1)[-1])
+              path = os.path.join(work, name)
+              if name not in digests:
+                  subprocess.run(["gh", "release", "download", "preview",
+                                  "--repo", repo, "-p", name, "-D", work],
+                                 check=True)
+                  h = hashlib.blake2b(digest_size=64)
+                  with open(path, "rb") as f:
+                      for chunk in iter(lambda: f.read(1 << 20), b""):
+                          h.update(chunk)
+                  digests[name] = h.digest()
+              lines = base64.b64decode(info["signature"]).decode().splitlines()
+              sig = base64.b64decode(lines[1])
+              tc = lines[2].split("trusted comment: ", 1)[1]
+              gsig = base64.b64decode(lines[3])
+              try:
+                  pk.verify(sig[10:74], digests[name])
+                  pk.verify(gsig, sig[10:74] + tc.encode())
+                  print(f"OK   {plat}: signature matches {name}")
+              except Exception:
+                  failures.append(plat)
+                  print(f"FAIL {plat}: signature in latest.json does NOT match {name}")
+          if failures:
+              sys.exit("Updater manifest is broken for: " + ", ".join(failures)
+                       + " — clients on Preview would hit 'signature verification failed'.")
+          print("All preview updater manifest signatures verified.")
           PY
 
   # ── Post-release version bump (OWNER-GATED as of 2026-07-01) ──────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -945,83 +945,93 @@ jobs:
       # companions, then clobber-upload. The manifest can no longer drift from
       # the files it describes, regardless of what tauri-action's own
       # updater-JSON path does or skips.
-      - name: Rebuild preview updater manifest from published assets
+      - name: Rebuild + verify the preview updater manifest, then publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Floor-pinned, matching docs-drift.yml's `pyyaml>=6`: this step
+          # decides whether a signed release manifest is trustworthy, so it is
+          # the one dependency worth a bound. Only Ed25519 verify is used.
+          pip install --quiet "cryptography>=42"
+
+          # name + updatedAt: the timestamp is how the version-less darwin
+          # tarballs get tied to this run — see scripts/build_preview_manifest.py.
           gh release view preview --repo "$REPO" --json assets \
-            -q '[.assets[].name]' > /tmp/assets.json
+            -q '[.assets[] | {name, updatedAt}]' > /tmp/assets.json
+
           WORK=$(mktemp -d)
           python3 - "$WORK" <<'PY'
-          import datetime, json, os, re, subprocess, sys
-          work = sys.argv[1]
-          repo = os.environ["REPO"]
-          names = json.load(open("/tmp/assets.json"))
+          import base64, hashlib, json, os, subprocess, sys
+          from urllib.parse import unquote
+          from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-          def sig(name):
+          sys.path.insert(0, "scripts")
+          from build_preview_manifest import ManifestRefused, build_manifest, required_assets
+
+          work, repo = sys.argv[1], os.environ["REPO"]
+          assets = json.load(open("/tmp/assets.json"))
+
+          def fetch(pattern):
               subprocess.run(["gh", "release", "download", "preview", "--repo", repo,
-                              "-p", name + ".sig", "-D", work], check=True)
-              return open(os.path.join(work, name + ".sig")).read().strip()
+                              "-p", pattern, "-D", work], check=True)
 
-          # Versioned artifacts accumulate on the rolling release; the newest
-          # BASE-N (N = run number, monotonically increasing) is current.
-          def newest(pattern):
-              best, best_n = None, -1
-              for n in names:
-                  m = re.fullmatch(pattern, n)
-                  if m and int(m.group("n")) > best_n:
-                      best, best_n = n, int(m.group("n"))
-              return best, best_n
+          signatures = {}
+          for name in required_assets(assets):
+              fetch(name + ".sig")
+              signatures[name] = open(os.path.join(work, name + ".sig")).read()
 
-          appimage, n1 = newest(r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_amd64\.AppImage")
-          msi, n2 = newest(r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_x64_en-US\.msi")
-          assert appimage and msi, f"missing versioned updater artifacts (AppImage={appimage}, MSI={msi})"
-          # Both legs must come from the SAME run. Picking each independently and
-          # then taking whichever N is larger publishes a manifest that advertises
-          # X.Y.Z-5 while handing Windows users the -4 MSI — the exact class of
-          # manifest/artifact drift this whole job exists to end (CodeRabbit).
-          # Failing loudly leaves the previous manifest in place, which is a
-          # visible, already-understood state; shipping a mismatched one is not.
-          assert n1 == n2, (
-              f"preview updater artifacts are from different runs — AppImage is "
-              f"run {n1} ({appimage}) but MSI is run {n2} ({msi}). One leg failed "
-              f"or was re-run; refusing to publish a manifest whose version "
-              f"describes only some of the files it points at. Re-run the failed "
-              f"leg so both artifacts come from one run."
-          )
-          version = re.search(r"_([\d.]+-\d+)_", appimage).group(1)
-          # The darwin tarballs carry no run number in their names (they are
-          # clobbered every run), so they cannot be checked this way — the
-          # signature verification in the later step is what pins them to the
-          # bytes actually published.
-          mac_a = "OmniVoice.Studio_aarch64.app.tar.gz"
-          mac_x = "OmniVoice.Studio_x64.app.tar.gz"
-          for required in (mac_a, mac_x, appimage, msi):
-              assert required in names, f"updater artifact missing from release: {required}"
-              assert required + ".sig" in names, f".sig companion missing for: {required}"
-          base = f"https://github.com/{repo}/releases/download/preview/"
-          entries = {
-              "darwin-aarch64": mac_a, "darwin-aarch64-app": mac_a,
-              "darwin-x86_64": mac_x, "darwin-x86_64-app": mac_x,
-              "linux-x86_64": appimage, "linux-x86_64-appimage": appimage,
-              "windows-x86_64": msi, "windows-x86_64-msi": msi,
-          }
-          sigs = {n: sig(n) for n in sorted(set(entries.values()))}
-          manifest = {
-              "version": version,
-              "notes": "Auto-generated rolling preview build from main. See CHANGELOG.md and the commit log for details.",
-              "pub_date": datetime.datetime.now(datetime.timezone.utc)
-                          .isoformat(timespec="milliseconds").replace("+00:00", "Z"),
-              "platforms": {k: {"signature": sigs[v], "url": base + v}
-                            for k, v in entries.items()},
-          }
+          try:
+              manifest = build_manifest(assets, repo, signatures=signatures)
+          except ManifestRefused as e:
+              sys.exit(f"Refusing to publish a preview manifest: {e}")
+          print(f"Built preview latest.json: version={manifest['version']}")
+
+          # ── Verify BEFORE publishing ──────────────────────────────────────
+          # Order is the whole point (greptile). Uploading first and checking
+          # afterwards leaves a manifest that fails the check live and served:
+          # the job goes red, and every macOS Preview user is broken until
+          # someone notices. Verify the file we are about to publish.
+          conf = json.load(open("frontend/src-tauri/tauri.conf.json"))
+          pub_doc = base64.b64decode(conf["plugins"]["updater"]["pubkey"]).decode()
+          pub = base64.b64decode(pub_doc.strip().splitlines()[1])
+          assert pub[:2] == b"Ed", "unexpected pubkey algorithm"
+          pk = Ed25519PublicKey.from_public_bytes(pub[10:42])
+
+          digests, failures = {}, []
+          for plat, info in sorted(manifest["platforms"].items()):
+              name = unquote(info["url"].rsplit("/", 1)[-1])
+              path = os.path.join(work, name)
+              if name not in digests:
+                  fetch(name)
+                  h = hashlib.blake2b(digest_size=64)
+                  with open(path, "rb") as f:
+                      for chunk in iter(lambda: f.read(1 << 20), b""):
+                          h.update(chunk)
+                  digests[name] = h.digest()
+              lines = base64.b64decode(info["signature"]).decode().splitlines()
+              sig = base64.b64decode(lines[1])
+              tc = lines[2].split("trusted comment: ", 1)[1]
+              gsig = base64.b64decode(lines[3])
+              try:
+                  pk.verify(sig[10:74], digests[name])
+                  pk.verify(gsig, sig[10:74] + tc.encode())
+                  print(f"OK   {plat}: signature matches {name}")
+              except Exception:
+                  failures.append(plat)
+                  print(f"FAIL {plat}: signature does NOT match {name}")
+          if failures:
+              sys.exit("Refusing to publish: manifest is broken for "
+                       + ", ".join(failures)
+                       + ". The previously published manifest is left in place.")
+
           json.dump(manifest, open(os.path.join(work, "latest.json"), "w"), indent=2)
-          print(f"Rebuilt preview latest.json: version={version}")
+          print("All signatures verified — safe to publish.")
           PY
+
           gh release upload preview "$WORK/latest.json" --clobber --repo "$REPO"
-          echo "Uploaded rebuilt latest.json to the preview release."
+          echo "Uploaded verified latest.json to the preview release."
 
       - name: Generate + apply GitHub release notes to the preview release
         env:
@@ -1056,7 +1066,7 @@ jobs:
           gh release edit preview --repo "$REPO" --prerelease --notes-file /tmp/preview-notes.md
           echo "Applied auto-generated release notes + contributors to the preview release."
 
-      - name: Verify preview updater manifest (prerelease + parity + signatures)
+      - name: Verify the published preview manifest (prerelease + parity + served bytes)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -1081,58 +1091,24 @@ jobs:
           assert not missing, f"preview manifest missing platforms vs stable: {sorted(missing)}"
           print(f"preview manifest OK: {v} platforms={sorted(pk)}")
           PY
-          # ── Cryptographic check: every signature in latest.json must verify
-          # against the artifact the manifest points at, with the updater pubkey
-          # baked into the app (tauri.conf.json). This is the check that was
-          # missing while the manifest drifted for 2+ weeks: parity and version
-          # format both passed while every darwin entry was unverifiable and
-          # macOS Preview users saw "The signature verification failed".
-          # Floor-pinned, matching docs-drift.yml's `pyyaml>=6`: this step is the
-          # gate that decides whether a signed release manifest is trustworthy,
-          # so an unbounded install is the one dependency worth naming a version
-          # for. Only Ed25519 verify is used, stable since 2.6.
-          pip install --quiet "cryptography>=42"
+          # The signatures were verified BEFORE publishing (see the rebuild
+          # step). What is worth checking here is different: that the file
+          # actually being SERVED is the one that passed. A CDN or a partial
+          # upload can leave something else at that URL, and the whole class of
+          # bug this job addresses is "the manifest does not describe what is
+          # published".
           python3 - <<'PY'
-          import base64, hashlib, json, os, subprocess, sys, tempfile
-          from urllib.parse import unquote
-          from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-          conf = json.load(open("frontend/src-tauri/tauri.conf.json"))
-          pub_doc = base64.b64decode(conf["plugins"]["updater"]["pubkey"]).decode()
-          pub = base64.b64decode(pub_doc.strip().splitlines()[1])
-          assert pub[:2] == b"Ed", "unexpected pubkey algorithm"
-          pk = Ed25519PublicKey.from_public_bytes(pub[10:42])
-          manifest = json.load(open("/tmp/preview-latest.json"))
-          work = tempfile.mkdtemp()
-          repo = os.environ["REPO"]
-          digests, failures = {}, []
-          for plat, info in sorted(manifest["platforms"].items()):
-              name = unquote(info["url"].rsplit("/", 1)[-1])
-              path = os.path.join(work, name)
-              if name not in digests:
-                  subprocess.run(["gh", "release", "download", "preview",
-                                  "--repo", repo, "-p", name, "-D", work],
-                                 check=True)
-                  h = hashlib.blake2b(digest_size=64)
-                  with open(path, "rb") as f:
-                      for chunk in iter(lambda: f.read(1 << 20), b""):
-                          h.update(chunk)
-                  digests[name] = h.digest()
-              lines = base64.b64decode(info["signature"]).decode().splitlines()
-              sig = base64.b64decode(lines[1])
-              tc = lines[2].split("trusted comment: ", 1)[1]
-              gsig = base64.b64decode(lines[3])
-              try:
-                  pk.verify(sig[10:74], digests[name])
-                  pk.verify(gsig, sig[10:74] + tc.encode())
-                  print(f"OK   {plat}: signature matches {name}")
-              except Exception:
-                  failures.append(plat)
-                  print(f"FAIL {plat}: signature in latest.json does NOT match {name}")
-          if failures:
-              sys.exit("Updater manifest is broken for: " + ", ".join(failures)
-                       + " — clients on Preview would hit 'signature verification failed'.")
-          print("All preview updater manifest signatures verified.")
+          import hashlib, json, sys
+          served = open("/tmp/preview-latest.json", "rb").read()
+          m = json.loads(served)
+          plats = sorted(m.get("platforms", {}))
+          print(f"served manifest: version={m.get('version')} platforms={plats}")
+          print(f"served sha256={hashlib.sha256(served).hexdigest()}")
+          missing = [p for p in plats if not m["platforms"][p].get("signature")]
+          if missing:
+              sys.exit(f"served manifest has empty signatures for: {missing}")
           PY
+
 
   # ── Post-release version bump (OWNER-GATED as of 2026-07-01) ──────────────
   # Previously auto-ran after every stable v* tag to keep main = release + 1.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -921,7 +921,13 @@ jobs:
     steps:
       # Needed by the manifest rebuild + signature check below: the updater
       # pubkey lives in frontend/src-tauri/tauri.conf.json.
+      #
+      # persist-credentials: false — nothing in this job pushes to git, and the
+      # steps that follow shell out to `gh` and install from PyPI, so leaving a
+      # token in .git/config only widens the blast radius (CodeRabbit).
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # ── Rebuild the preview updater manifest from what is ACTUALLY published ──
       # Since ~2026-07-13 every matrix leg has logged "Signature not found for
@@ -972,7 +978,24 @@ jobs:
           appimage, n1 = newest(r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_amd64\.AppImage")
           msi, n2 = newest(r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_x64_en-US\.msi")
           assert appimage and msi, f"missing versioned updater artifacts (AppImage={appimage}, MSI={msi})"
-          version = re.search(r"_([\d.]+-\d+)_", appimage if n1 >= n2 else msi).group(1)
+          # Both legs must come from the SAME run. Picking each independently and
+          # then taking whichever N is larger publishes a manifest that advertises
+          # X.Y.Z-5 while handing Windows users the -4 MSI — the exact class of
+          # manifest/artifact drift this whole job exists to end (CodeRabbit).
+          # Failing loudly leaves the previous manifest in place, which is a
+          # visible, already-understood state; shipping a mismatched one is not.
+          assert n1 == n2, (
+              f"preview updater artifacts are from different runs — AppImage is "
+              f"run {n1} ({appimage}) but MSI is run {n2} ({msi}). One leg failed "
+              f"or was re-run; refusing to publish a manifest whose version "
+              f"describes only some of the files it points at. Re-run the failed "
+              f"leg so both artifacts come from one run."
+          )
+          version = re.search(r"_([\d.]+-\d+)_", appimage).group(1)
+          # The darwin tarballs carry no run number in their names (they are
+          # clobbered every run), so they cannot be checked this way — the
+          # signature verification in the later step is what pins them to the
+          # bytes actually published.
           mac_a = "OmniVoice.Studio_aarch64.app.tar.gz"
           mac_x = "OmniVoice.Studio_x64.app.tar.gz"
           for required in (mac_a, mac_x, appimage, msi):
@@ -1064,7 +1087,11 @@ jobs:
           # missing while the manifest drifted for 2+ weeks: parity and version
           # format both passed while every darwin entry was unverifiable and
           # macOS Preview users saw "The signature verification failed".
-          pip install --quiet cryptography
+          # Floor-pinned, matching docs-drift.yml's `pyyaml>=6`: this step is the
+          # gate that decides whether a signed release manifest is trustworthy,
+          # so an unbounded install is the one dependency worth naming a version
+          # for. Only Ed25519 verify is used, stable since 2.6.
+          pip install --quiet "cryptography>=42"
           python3 - <<'PY'
           import base64, hashlib, json, os, subprocess, sys, tempfile
           from urllib.parse import unquote

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A cut TLS connection is explained in words rather than as `_ssl.c:1016`. (#1301)
 - `torch.compile` is skipped when the torch library path contains a space, instead of failing in the linker on every load. (#1266)
 - macOS Preview updates work again — the updater bundle had been colliding with itself since early July. (#1281)
+- macOS Preview updates no longer fail signature verification — the preview manifest is rebuilt from the published assets and every signature in it is verified against the file it points at — thanks @Pinkers01! (#1327)
 - A dub whose transcription stream is cut by a reverse proxy now says so, instead of blaming the ASR model. (#1317)
 - The dev backend going quiet under `--reload` is named as auto-reload rather than reported as a crash. (#1261)
 - Building from source: `bun run desktop-prod:run`, documented as a re-launch, wiped the app's data every time — voice profiles, projects and outputs included. It now keeps them — thanks @Kakuzen93! (#1333)

--- a/scripts/build_preview_manifest.py
+++ b/scripts/build_preview_manifest.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Rebuild the rolling preview release's updater manifest from what is published.
+
+Why this exists (#1327): since ~2026-07-13 every matrix leg logged "Signature
+not found for the updater JSON. Skipping upload…" — ``tauri-action`` uploaded
+the bundles and their ``.sig`` companions but never refreshed ``latest.json``.
+Meanwhile the version-less macOS updater bundles are deleted and replaced every
+night by the stale-bundle cleanup, so the manifest's darwin signatures stopped
+matching the published files and every macOS Preview update failed signature
+verification — for over two weeks, with CI green throughout, because parity and
+version-format checks do not look at a signature.
+
+The selection rules live here rather than in a YAML heredoc because they are
+the part that keeps being subtly wrong: three separate review findings on
+#1327/#1362 were about *which* artifacts may be described together. A heredoc
+can only be tested by extracting it and stubbing a shell; a module can be
+imported and called.
+
+``build_manifest`` is pure — assets in, manifest out, exceptions on anything it
+refuses to describe. Signature fetching and publishing stay in the workflow.
+"""
+from __future__ import annotations
+
+import datetime
+import re
+
+#: The two version-less macOS updater bundles, clobbered on every run.
+MAC_AARCH64 = "OmniVoice.Studio_aarch64.app.tar.gz"
+MAC_X86_64 = "OmniVoice.Studio_x64.app.tar.gz"
+
+_APPIMAGE_RE = r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_amd64\.AppImage"
+_MSI_RE = r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_x64_en-US\.msi"
+
+#: How far a darwin bundle's upload time may precede the versioned artifacts of
+#: the same run. The matrix legs finish minutes apart, so some slack is
+#: required; it only has to be far smaller than the gap between two runs.
+FRESHNESS_SLACK = datetime.timedelta(minutes=2)
+
+NOTES = ("Auto-generated rolling preview build from main. "
+         "See CHANGELOG.md and the commit log for details.")
+
+
+class ManifestRefused(Exception):
+    """The published assets do not describe one coherent build.
+
+    Raised rather than returning a best-effort manifest: leaving the previous
+    manifest in place is a visible, already-understood state, whereas
+    publishing one that misdescribes its own payload is the failure this whole
+    job exists to end.
+    """
+
+
+def _newest(names, pattern):
+    """``(name, run_number)`` for the highest-numbered match, else ``(None, -1)``.
+
+    Versioned artifacts accumulate on the rolling release, so "current" means
+    the highest run number rather than the only one present.
+    """
+    best, best_n = None, -1
+    for name in names:
+        m = re.fullmatch(pattern, name)
+        if m and int(m.group("n")) > best_n:
+            best, best_n = name, int(m.group("n"))
+    return best, best_n
+
+
+def _parse_ts(value):
+    return datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def build_manifest(assets, repo: str, *, signatures, pub_date=None) -> dict:
+    """Build the updater manifest, or raise :class:`ManifestRefused`.
+
+    ``assets`` is ``[{"name": …, "updatedAt": …}, …]`` as ``gh release view``
+    returns it. ``signatures`` maps an asset name to its ``.sig`` contents;
+    it is passed in so this function needs no network.
+    """
+    names = [a["name"] for a in assets]
+    updated_at = {a["name"]: a.get("updatedAt") for a in assets}
+
+    appimage, n1 = _newest(names, _APPIMAGE_RE)
+    msi, n2 = _newest(names, _MSI_RE)
+    if not appimage or not msi:
+        raise ManifestRefused(
+            f"missing versioned updater artifacts (AppImage={appimage}, MSI={msi})"
+        )
+
+    # Both legs must come from the SAME run. Picking each independently and
+    # taking whichever N is larger publishes a manifest advertising X.Y.Z-5
+    # while handing Windows users the -4 MSI — the exact drift this job exists
+    # to end, reintroduced by the fix for it (CodeRabbit on #1327).
+    if n1 != n2:
+        raise ManifestRefused(
+            f"preview updater artifacts are from different runs — AppImage is run "
+            f"{n1} ({appimage}) but MSI is run {n2} ({msi}). One leg failed or was "
+            f"re-run; refusing to publish a manifest whose version describes only "
+            f"some of the files it points at. Re-run the failed leg."
+        )
+
+    version = re.search(r"_([\d.]+-\d+)_", appimage).group(1)
+
+    for required in (MAC_AARCH64, MAC_X86_64, appimage, msi):
+        if required not in names:
+            raise ManifestRefused(f"updater artifact missing from release: {required}")
+        if required + ".sig" not in names:
+            raise ManifestRefused(f".sig companion missing for: {required}")
+
+    # The darwin tarballs carry no run number, so nothing in their NAMES ties
+    # them to this build — and signature verification cannot help, because a
+    # stale tarball and its stale .sig match each other perfectly. A run whose
+    # macOS legs never uploaded would advertise this version while serving Mac
+    # users the previous build; they would keep reporting the old version and
+    # be re-offered the update forever (CodeRabbit on #1362).
+    #
+    # Bind them by upload time instead.
+    try:
+        newest_versioned = max(_parse_ts(updated_at[appimage]), _parse_ts(updated_at[msi]))
+        mac_times = {n: _parse_ts(updated_at[n]) for n in (MAC_AARCH64, MAC_X86_64)}
+    except (TypeError, ValueError) as e:
+        raise ManifestRefused(
+            f"cannot read asset upload times, so the macOS bundles cannot be tied "
+            f"to this run: {e}"
+        ) from e
+
+    stale = sorted(n for n, t in mac_times.items() if t < newest_versioned - FRESHNESS_SLACK)
+    if stale:
+        raise ManifestRefused(
+            f"the macOS updater bundle(s) {stale} were last uploaded before this "
+            f"run's versioned artifacts ({newest_versioned.isoformat()}), so they "
+            f"are from an EARLIER build. Publishing would advertise {version} while "
+            f"serving Mac users the previous one — and because they would keep "
+            f"reporting the old version, the updater would re-offer it forever. "
+            f"Re-run the macOS legs."
+        )
+
+    entries = {
+        "darwin-aarch64": MAC_AARCH64, "darwin-aarch64-app": MAC_AARCH64,
+        "darwin-x86_64": MAC_X86_64, "darwin-x86_64-app": MAC_X86_64,
+        "linux-x86_64": appimage, "linux-x86_64-appimage": appimage,
+        "windows-x86_64": msi, "windows-x86_64-msi": msi,
+    }
+    missing_sigs = sorted({v for v in entries.values() if not signatures.get(v)})
+    if missing_sigs:
+        raise ManifestRefused(f"no signature content for: {missing_sigs}")
+
+    base = f"https://github.com/{repo}/releases/download/preview/"
+    when = pub_date or datetime.datetime.now(datetime.timezone.utc)
+    return {
+        "version": version,
+        "notes": NOTES,
+        "pub_date": when.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "platforms": {
+            k: {"signature": signatures[v].strip(), "url": base + v}
+            for k, v in entries.items()
+        },
+    }
+
+
+def required_assets(assets) -> list:
+    """The asset names a manifest built from ``assets`` would reference.
+
+    Lets the caller fetch exactly the ``.sig`` files it needs before calling
+    :func:`build_manifest`, without duplicating the selection rules.
+    """
+    names = [a["name"] for a in assets]
+    appimage, _ = _newest(names, _APPIMAGE_RE)
+    msi, _ = _newest(names, _MSI_RE)
+    return [n for n in (MAC_AARCH64, MAC_X86_64, appimage, msi) if n]

--- a/tests/test_release_preview_manifest_rebuild.py
+++ b/tests/test_release_preview_manifest_rebuild.py
@@ -1,174 +1,205 @@
-"""The rebuilt preview updater manifest must never describe files it isn't shipping.
+"""The rebuilt preview manifest must never describe a build it isn't shipping.
 
-`Rebuild preview updater manifest from published assets` (release.yml) exists
-because tauri-action stopped refreshing `latest.json` while the nightly job kept
-replacing the version-less macOS tarballs — so the manifest's darwin signatures
-described bytes that no longer existed and every macOS Preview update failed
-verification (#1327).
+`Rebuild + verify the preview updater manifest, then publish` (release.yml)
+exists because tauri-action stopped refreshing `latest.json` while the nightly
+job kept replacing the version-less macOS tarballs — so the manifest's darwin
+signatures described bytes that no longer existed and every macOS Preview update
+failed verification for two weeks, with CI green throughout (#1327).
 
-Rebuilding from the release's *real* assets closes that. But the rebuild picks
-the AppImage and the MSI independently, by highest run number, and a matrix
-where one leg failed or was re-run leaves those at different numbers. Taking
-whichever is larger as *the* version then publishes a manifest advertising
-`X.Y.Z-5` that hands Windows users the `-4` MSI — the same manifest/artifact
-drift, reintroduced by the fix for it (CodeRabbit).
+Rebuilding from the release's *real* assets closes that. What these tests cover
+is the part that kept being subtly wrong — three separate review findings were
+all about **which artifacts may be described together**:
 
-These tests run the step's real embedded Python (extracted from release.yml, so
-it cannot drift) against synthetic asset lists, with the parts that talk to
-GitHub stubbed out.
+* the AppImage and MSI are picked independently by run number, so a matrix
+  where one leg failed leaves them at different numbers and the manifest would
+  advertise a version that describes only some of its own payload;
+* the darwin tarballs carry no run number at all, and signature verification
+  cannot save them, because a stale tarball and its stale `.sig` match each
+  other perfectly.
+
+The selection rules live in ``scripts/build_preview_manifest.py`` rather than a
+YAML heredoc precisely so they can be called directly here — a heredoc can only
+be tested by extracting it and stubbing a shell, which is how the earlier
+version of this file ended up asserting against `gh` stubs instead of against
+the rules.
 """
-
-import json
+import datetime
 import os
-import shutil
-import stat
-import subprocess
 import sys
 
 import pytest
-import yaml
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="the step is a bash+python heredoc using POSIX /tmp paths",
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts"))
+
+from build_preview_manifest import (  # noqa: E402
+    MAC_AARCH64,
+    MAC_X86_64,
+    ManifestRefused,
+    build_manifest,
+    required_assets,
 )
 
-_WORKFLOW = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    ".github", "workflows", "release.yml",
-)
-_STEP = "Rebuild preview updater manifest from published assets"
-
-_MAC = ["OmniVoice.Studio_aarch64.app.tar.gz", "OmniVoice.Studio_x64.app.tar.gz"]
+REPO = "debpalash/OmniVoice-Studio"
+_T0 = datetime.datetime(2026, 8, 4, 12, 0, tzinfo=datetime.timezone.utc)
 
 
-def _assets(appimage_n, msi_n, version="0.4.3"):
-    """A published-asset list, plus the `.sig` companion each entry needs."""
-    names = _MAC + [
-        f"OmniVoice.Studio_{version}-{appimage_n}_amd64.AppImage",
-        f"OmniVoice.Studio_{version}-{msi_n}_x64_en-US.msi",
-    ]
-    return names + [n + ".sig" for n in names]
+def _iso(minutes_after=0):
+    return (_T0 + datetime.timedelta(minutes=minutes_after)).isoformat().replace("+00:00", "Z")
 
 
-def _step_script():
-    with open(_WORKFLOW, encoding="utf-8") as fh:
-        wf = yaml.safe_load(fh)
-    for job in wf["jobs"].values():
-        for step in job.get("steps", []):
-            if step.get("name") == _STEP:
-                return step["run"]
-    raise AssertionError(f"step {_STEP!r} not found in release.yml")
+def _assets(appimage_n=7, msi_n=7, version="0.4.3", mac_offset=0, versioned_offset=0):
+    """A published-asset list, with each artifact's `.sig` companion."""
+    appimage = f"OmniVoice.Studio_{version}-{appimage_n}_amd64.AppImage"
+    msi = f"OmniVoice.Studio_{version}-{msi_n}_x64_en-US.msi"
+    rows = []
+    for name in (appimage, msi):
+        rows.append({"name": name, "updatedAt": _iso(versioned_offset)})
+    for name in (MAC_AARCH64, MAC_X86_64):
+        rows.append({"name": name, "updatedAt": _iso(mac_offset)})
+    rows += [{"name": r["name"] + ".sig", "updatedAt": r["updatedAt"]} for r in list(rows)]
+    return rows
 
 
-def _run(tmp_path, names):
-    """Run the step with `gh` stubbed; return (CompletedProcess, manifest|None).
-
-    The stub answers `release view` from the supplied asset list, writes a
-    placeholder for every `release download`, and records `release upload` by
-    copying the manifest somewhere the test can read it.
-    """
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    uploaded = tmp_path / "uploaded-latest.json"
-    gh = bin_dir / "gh"
-    gh.write_text(
-        "#!/usr/bin/env bash\n"
-        'if [ "$2" = "view" ]; then\n'
-        f"  cat {str(tmp_path / 'assets.json')!r}\n"
-        "  exit 0\n"
-        "fi\n"
-        # `gh release download preview --repo R -p NAME -D DIR`
-        'if [ "$2" = "download" ]; then\n'
-        "  pat=\"\"; dir=\"\"\n"
-        '  while [ $# -gt 0 ]; do\n'
-        '    case "$1" in -p) pat="$2"; shift 2 ;; -D) dir="$2"; shift 2 ;; *) shift ;; esac\n'
-        "  done\n"
-        # A minisign signature file: comment, sig line, trusted comment, global sig.
-        '  printf "untrusted comment: sig\\nUlN%s\\ntrusted comment: t\\nUlN%s\\n" "$pat" "$pat" > "$dir/$pat"\n'
-        "  exit 0\n"
-        "fi\n"
-        'if [ "$2" = "upload" ]; then\n'
-        f'  cp "$4" {str(uploaded)!r}\n'
-        "  exit 0\n"
-        "fi\n"
-        "exit 0\n"
-    )
-    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
-    (tmp_path / "assets.json").write_text(json.dumps(names))
-
-    script = tmp_path / "step.sh"
-    script.write_text(_step_script())
-    env = dict(
-        os.environ,
-        PATH=f"{bin_dir}:{os.environ['PATH']}",
-        GH_TOKEN="x",
-        REPO="debpalash/OmniVoice-Studio",
-    )
-    proc = subprocess.run(
-        [shutil.which("bash") or "/bin/bash", str(script)],
-        capture_output=True, text=True, env=env, timeout=120,
-    )
-    manifest = json.loads(uploaded.read_text()) if uploaded.exists() else None
-    return proc, manifest
+def _sigs(assets):
+    return {n: f"sig-for-{n}\n" for n in required_assets(assets)}
 
 
-def test_matched_run_numbers_produce_a_manifest(tmp_path):
-    """The happy path: both versioned legs from run 7 → version 0.4.3-7."""
-    proc, manifest = _run(tmp_path, _assets(7, 7))
-    assert proc.returncode == 0, proc.stdout + proc.stderr
-    assert manifest is not None, "step succeeded without uploading a manifest"
+def _build(assets, **kw):
+    return build_manifest(assets, REPO, signatures=_sigs(assets), pub_date=_T0, **kw)
+
+
+def test_a_coherent_release_produces_a_manifest():
+    assets = _assets()
+    manifest = _build(assets)
     assert manifest["version"] == "0.4.3-7"
-    # Every platform stable serves must be present, and each must point at a
-    # file that was actually in the release.
+    # Every platform the stable channel serves must be present, or those users
+    # silently stop getting preview updates.
     assert set(manifest["platforms"]) == {
         "darwin-aarch64", "darwin-aarch64-app",
         "darwin-x86_64", "darwin-x86_64-app",
         "linux-x86_64", "linux-x86_64-appimage",
         "windows-x86_64", "windows-x86_64-msi",
     }
-    published = set(_assets(7, 7))
+    published = {a["name"] for a in assets}
     for plat, info in manifest["platforms"].items():
         assert info["url"].rsplit("/", 1)[-1] in published, plat
         assert info["signature"], plat
 
 
 @pytest.mark.parametrize("appimage_n,msi_n", [(8, 7), (7, 8)])
-def test_mismatched_run_numbers_fail_loudly(tmp_path, appimage_n, msi_n):
-    """One leg failed or was re-run — refuse rather than publish a lie.
+def test_mismatched_run_numbers_are_refused(appimage_n, msi_n):
+    """One leg failed or was re-run. Taking the larger N would advertise a
+    version that describes only one of the two artifacts it points at — the
+    same drift this job exists to end, reintroduced by the fix for it."""
+    with pytest.raises(ManifestRefused, match="different runs"):
+        _build(_assets(appimage_n=appimage_n, msi_n=msi_n))
 
-    Taking the larger N would advertise a version that describes only one of
-    the two artifacts the manifest points at, which is exactly the drift this
-    job exists to end. Leaving the previous manifest in place is the safer
-    outcome: it is a visible, already-understood state.
+
+def test_a_stale_macos_bundle_is_refused():
+    """The darwin case, which no signature check can catch.
+
+    A run whose macOS legs never uploaded leaves the PREVIOUS build's tarball
+    and its matching `.sig` in place — they verify against each other perfectly.
+    The manifest would advertise this version while serving Mac users the old
+    build, and because those clients keep reporting the old version, the updater
+    re-offers the same update forever.
     """
-    proc, manifest = _run(tmp_path, _assets(appimage_n, msi_n))
-    assert proc.returncode != 0, (
-        "step published a manifest from artifacts of two different runs:\n"
-        + proc.stdout
-    )
-    assert manifest is None, "a mismatched manifest was uploaded anyway"
-    assert "different runs" in (proc.stdout + proc.stderr)
+    with pytest.raises(ManifestRefused, match="EARLIER build"):
+        _build(_assets(mac_offset=-90, versioned_offset=0))
 
 
-def test_missing_signature_companion_fails(tmp_path):
-    """A `.sig` that never got uploaded means the artifact is unverifiable —
-    publishing its entry would hand every client a signature check it cannot
-    pass, which is the #1327 outage in a different costume."""
-    names = [n for n in _assets(7, 7)
-             if n != "OmniVoice.Studio_aarch64.app.tar.gz.sig"]
-    proc, manifest = _run(tmp_path, names)
-    assert proc.returncode != 0, proc.stdout
-    assert manifest is None
-    assert "sig companion missing" in (proc.stdout + proc.stderr)
+def test_macos_bundles_uploaded_slightly_earlier_are_accepted():
+    """The matrix legs finish minutes apart; the check must tolerate that or it
+    fails every healthy run."""
+    assert _build(_assets(mac_offset=-1, versioned_offset=0))["version"] == "0.4.3-7"
 
 
-def test_missing_darwin_tarball_fails(tmp_path):
+def test_macos_bundles_uploaded_later_are_fine():
+    """Ordering within a run is not fixed — the macOS legs often finish last."""
+    assert _build(_assets(mac_offset=5))["version"] == "0.4.3-7"
+
+
+def test_unreadable_timestamps_are_refused_not_ignored():
+    """Missing `updatedAt` means the freshness check cannot run. Proceeding
+    would silently drop the only thing tying the darwin bundles to this run."""
+    assets = _assets()
+    for row in assets:
+        if row["name"] == MAC_AARCH64:
+            row["updatedAt"] = None
+    with pytest.raises(ManifestRefused, match="upload times"):
+        _build(assets)
+
+
+def test_a_missing_signature_companion_is_refused():
+    """A `.sig` that never uploaded means the artifact is unverifiable —
+    publishing its entry hands every client a check it cannot pass."""
+    assets = [a for a in _assets() if a["name"] != MAC_AARCH64 + ".sig"]
+    with pytest.raises(ManifestRefused, match="sig companion missing"):
+        _build(assets)
+
+
+def test_a_missing_darwin_tarball_is_refused():
     """Intel Mac silently dropping out of the manifest is how those users stop
     getting preview updates without anyone noticing."""
-    names = [n for n in _assets(7, 7)
-             if not n.startswith("OmniVoice.Studio_x64.app.tar.gz")]
-    proc, manifest = _run(tmp_path, names)
-    assert proc.returncode != 0, proc.stdout
-    assert manifest is None
-    assert "updater artifact missing" in (proc.stdout + proc.stderr)
+    assets = [a for a in _assets() if not a["name"].startswith(MAC_X86_64)]
+    with pytest.raises(ManifestRefused, match="artifact missing"):
+        _build(assets)
+
+
+def test_no_versioned_artifacts_at_all_is_refused():
+    assets = [a for a in _assets() if "amd64.AppImage" not in a["name"]]
+    with pytest.raises(ManifestRefused, match="missing versioned"):
+        _build(assets)
+
+
+def test_empty_signature_content_is_refused():
+    """An empty `.sig` file is present-but-useless; it must not become an empty
+    `signature` field that every client fails on."""
+    assets = _assets()
+    sigs = {n: "" for n in required_assets(assets)}
+    with pytest.raises(ManifestRefused, match="no signature content"):
+        build_manifest(assets, REPO, signatures=sigs, pub_date=_T0)
+
+
+def test_required_assets_matches_what_the_manifest_references():
+    """The caller fetches `.sig` files from this list; if it disagreed with the
+    selection, the build would fail on a signature it was never asked to get."""
+    assets = _assets()
+    manifest = _build(assets)
+    referenced = {i["url"].rsplit("/", 1)[-1] for i in manifest["platforms"].values()}
+    assert referenced == set(required_assets(assets))
+
+
+def _preview_step():
+    import yaml
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    with open(os.path.join(root, ".github", "workflows", "release.yml"), encoding="utf-8") as fh:
+        wf = yaml.safe_load(fh)
+    for job in wf["jobs"].values():
+        for step in job.get("steps", []):
+            if "build_preview_manifest" in step.get("run", ""):
+                return step
+    return None
+
+
+def test_the_workflow_still_calls_this_module():
+    """The rules are only worth testing where they are used. A workflow that
+    grew its own inline copy would pass every test above and ship the old bug."""
+    assert _preview_step() is not None, (
+        "release.yml no longer imports build_preview_manifest — check it has not "
+        "reinlined the selection rules these tests cover"
+    )
+
+
+def test_the_workflow_verifies_before_it_uploads():
+    """Order is load-bearing (greptile): uploading first and checking afterwards
+    leaves a manifest that failed the check live and served, with the job merely
+    red. Pin that the upload comes last."""
+    body = _preview_step()["run"]
+    upload = body.index("gh release upload preview")
+    verify = body.index("Refusing to publish: manifest is broken")
+    assert verify < upload, (
+        "the signature verification runs after the upload, so a broken manifest "
+        "is published and stays served while the job goes red"
+    )

--- a/tests/test_release_preview_manifest_rebuild.py
+++ b/tests/test_release_preview_manifest_rebuild.py
@@ -1,0 +1,174 @@
+"""The rebuilt preview updater manifest must never describe files it isn't shipping.
+
+`Rebuild preview updater manifest from published assets` (release.yml) exists
+because tauri-action stopped refreshing `latest.json` while the nightly job kept
+replacing the version-less macOS tarballs — so the manifest's darwin signatures
+described bytes that no longer existed and every macOS Preview update failed
+verification (#1327).
+
+Rebuilding from the release's *real* assets closes that. But the rebuild picks
+the AppImage and the MSI independently, by highest run number, and a matrix
+where one leg failed or was re-run leaves those at different numbers. Taking
+whichever is larger as *the* version then publishes a manifest advertising
+`X.Y.Z-5` that hands Windows users the `-4` MSI — the same manifest/artifact
+drift, reintroduced by the fix for it (CodeRabbit).
+
+These tests run the step's real embedded Python (extracted from release.yml, so
+it cannot drift) against synthetic asset lists, with the parts that talk to
+GitHub stubbed out.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the step is a bash+python heredoc using POSIX /tmp paths",
+)
+
+_WORKFLOW = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    ".github", "workflows", "release.yml",
+)
+_STEP = "Rebuild preview updater manifest from published assets"
+
+_MAC = ["OmniVoice.Studio_aarch64.app.tar.gz", "OmniVoice.Studio_x64.app.tar.gz"]
+
+
+def _assets(appimage_n, msi_n, version="0.4.3"):
+    """A published-asset list, plus the `.sig` companion each entry needs."""
+    names = _MAC + [
+        f"OmniVoice.Studio_{version}-{appimage_n}_amd64.AppImage",
+        f"OmniVoice.Studio_{version}-{msi_n}_x64_en-US.msi",
+    ]
+    return names + [n + ".sig" for n in names]
+
+
+def _step_script():
+    with open(_WORKFLOW, encoding="utf-8") as fh:
+        wf = yaml.safe_load(fh)
+    for job in wf["jobs"].values():
+        for step in job.get("steps", []):
+            if step.get("name") == _STEP:
+                return step["run"]
+    raise AssertionError(f"step {_STEP!r} not found in release.yml")
+
+
+def _run(tmp_path, names):
+    """Run the step with `gh` stubbed; return (CompletedProcess, manifest|None).
+
+    The stub answers `release view` from the supplied asset list, writes a
+    placeholder for every `release download`, and records `release upload` by
+    copying the manifest somewhere the test can read it.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    uploaded = tmp_path / "uploaded-latest.json"
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$2" = "view" ]; then\n'
+        f"  cat {str(tmp_path / 'assets.json')!r}\n"
+        "  exit 0\n"
+        "fi\n"
+        # `gh release download preview --repo R -p NAME -D DIR`
+        'if [ "$2" = "download" ]; then\n'
+        "  pat=\"\"; dir=\"\"\n"
+        '  while [ $# -gt 0 ]; do\n'
+        '    case "$1" in -p) pat="$2"; shift 2 ;; -D) dir="$2"; shift 2 ;; *) shift ;; esac\n'
+        "  done\n"
+        # A minisign signature file: comment, sig line, trusted comment, global sig.
+        '  printf "untrusted comment: sig\\nUlN%s\\ntrusted comment: t\\nUlN%s\\n" "$pat" "$pat" > "$dir/$pat"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$2" = "upload" ]; then\n'
+        f'  cp "$4" {str(uploaded)!r}\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+    (tmp_path / "assets.json").write_text(json.dumps(names))
+
+    script = tmp_path / "step.sh"
+    script.write_text(_step_script())
+    env = dict(
+        os.environ,
+        PATH=f"{bin_dir}:{os.environ['PATH']}",
+        GH_TOKEN="x",
+        REPO="debpalash/OmniVoice-Studio",
+    )
+    proc = subprocess.run(
+        [shutil.which("bash") or "/bin/bash", str(script)],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+    manifest = json.loads(uploaded.read_text()) if uploaded.exists() else None
+    return proc, manifest
+
+
+def test_matched_run_numbers_produce_a_manifest(tmp_path):
+    """The happy path: both versioned legs from run 7 → version 0.4.3-7."""
+    proc, manifest = _run(tmp_path, _assets(7, 7))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert manifest is not None, "step succeeded without uploading a manifest"
+    assert manifest["version"] == "0.4.3-7"
+    # Every platform stable serves must be present, and each must point at a
+    # file that was actually in the release.
+    assert set(manifest["platforms"]) == {
+        "darwin-aarch64", "darwin-aarch64-app",
+        "darwin-x86_64", "darwin-x86_64-app",
+        "linux-x86_64", "linux-x86_64-appimage",
+        "windows-x86_64", "windows-x86_64-msi",
+    }
+    published = set(_assets(7, 7))
+    for plat, info in manifest["platforms"].items():
+        assert info["url"].rsplit("/", 1)[-1] in published, plat
+        assert info["signature"], plat
+
+
+@pytest.mark.parametrize("appimage_n,msi_n", [(8, 7), (7, 8)])
+def test_mismatched_run_numbers_fail_loudly(tmp_path, appimage_n, msi_n):
+    """One leg failed or was re-run — refuse rather than publish a lie.
+
+    Taking the larger N would advertise a version that describes only one of
+    the two artifacts the manifest points at, which is exactly the drift this
+    job exists to end. Leaving the previous manifest in place is the safer
+    outcome: it is a visible, already-understood state.
+    """
+    proc, manifest = _run(tmp_path, _assets(appimage_n, msi_n))
+    assert proc.returncode != 0, (
+        "step published a manifest from artifacts of two different runs:\n"
+        + proc.stdout
+    )
+    assert manifest is None, "a mismatched manifest was uploaded anyway"
+    assert "different runs" in (proc.stdout + proc.stderr)
+
+
+def test_missing_signature_companion_fails(tmp_path):
+    """A `.sig` that never got uploaded means the artifact is unverifiable —
+    publishing its entry would hand every client a signature check it cannot
+    pass, which is the #1327 outage in a different costume."""
+    names = [n for n in _assets(7, 7)
+             if n != "OmniVoice.Studio_aarch64.app.tar.gz.sig"]
+    proc, manifest = _run(tmp_path, names)
+    assert proc.returncode != 0, proc.stdout
+    assert manifest is None
+    assert "sig companion missing" in (proc.stdout + proc.stderr)
+
+
+def test_missing_darwin_tarball_fails(tmp_path):
+    """Intel Mac silently dropping out of the manifest is how those users stop
+    getting preview updates without anyone noticing."""
+    names = [n for n in _assets(7, 7)
+             if not n.startswith("OmniVoice.Studio_x64.app.tar.gz")]
+    proc, manifest = _run(tmp_path, names)
+    assert proc.returncode != 0, proc.stdout
+    assert manifest is None
+    assert "updater artifact missing" in (proc.stdout + proc.stderr)


### PR DESCRIPTION
Supersedes #1327, which is @Pinkers01's work — their commit is preserved here with authorship intact, and my three review fixes sit on top. I could not push to their fork despite `maintainerCanModify`, and the PR had gone six hours without a response, so this unblocks it rather than leaving a real outage fix sitting.

**@Pinkers01 — the credit is yours.** If you'd rather push the fixes to your own branch and land #1327 instead, say so and I'll close this.

## The outage

Since ~2026-07-13 every matrix leg logged *"Signature not found for the updater JSON. Skipping upload…"* — `tauri-action` uploaded the bundles and their `.sig` companions but never refreshed `latest.json`. Meanwhile the version-less macOS updater bundles are deleted and replaced every night by the stale-bundle cleanup step, so the manifest's darwin signatures stopped matching the published files.

Net effect: macOS Preview users hit *"The signature verification failed"* on **every** update attempt, for over two weeks, while CI stayed green. Parity and version-format checks both passed the whole time, because neither one looks at a signature.

## The fix (Pinkers01)

Rebuild `latest.json` **after** the matrix completes — one job, no per-leg race — from the release's real assets and their `.sig` companions, then clobber-upload. The manifest can no longer drift from the files it describes regardless of what `tauri-action`'s own updater-JSON path does or skips.

Plus the check that was missing: every signature in the manifest is verified with the updater pubkey baked into `tauri.conf.json`, against the bytes actually published. That is the gate that would have caught this on day one.

## My three fixes on top

1. **The manifest could still describe artifacts from two different runs (blocking).** `newest()` picked the AppImage and the MSI independently by run number, then took whichever `-N` was larger as *the* version. A matrix where one leg failed or was re-run would publish a manifest advertising `X.Y.Z-5` while handing Windows users the `-4` MSI — the same manifest/artifact drift this job exists to end, reintroduced by the fix for it. Now requires `n1 == n2` and fails loudly: leaving the previous manifest in place is a visible, already-understood state; shipping a mismatched one is not. (The darwin tarballs carry no run number, so they cannot be checked this way — the signature verification in the next step is what pins those.)
2. **`persist-credentials: false`** on the checkout — nothing here pushes to git, and the following steps shell out to `gh` and install from PyPI.
3. **Floor-pinned the `cryptography` install** (`>=42`, matching `docs-drift.yml`'s `pyyaml>=6`). This step decides whether a signed release manifest is trustworthy; it is the one dependency here worth a bound.

## Tests

`tests/test_release_preview_manifest_rebuild.py` extracts the step body from `release.yml` — so it cannot drift from the workflow — and runs it against a stubbed `gh` with synthetic asset lists:

- matched run numbers produce the expected manifest, with every platform stable serves;
- mismatched run numbers fail and upload **nothing** (fails against the pre-fix version);
- a missing `.sig` companion fails rather than publishing an entry no client can verify;
- a missing darwin tarball fails rather than silently dropping Intel Mac from the manifest.

One thing I checked and it is correct as written: the verify step re-downloads `latest.json` over HTTP *after* the rebuild, so it validates the new manifest rather than a cached one.

## After merge

This only takes effect on the next preview build. Worth watching that run's **step log** rather than just job-green, since the whole failure mode here was a step that skipped its work and said so quietly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The preview workflow now rebuilds `latest.json` from published assets and signatures, verifies each signature with the updater public key, and rejects mismatched runs, stale macOS assets, or missing artifacts before upload. This fixes stale or mismatched manifests that caused macOS Preview update verification failures. Review platform asset selection, freshness checks, and signature verification edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->