### PR TITLE
test: stop the load-budget test racing the AudioSeal cold start

### DIFF
--- a/tests/test_load_budget_split_1033.py
+++ b/tests/test_load_budget_split_1033.py
@@ -84,9 +84,23 @@ def test_base_ensure_ready_dispatches_to_lazy_loader():
 def test_speech_survives_a_load_slower_than_the_generate_budget(client, monkeypatch):
     """The #1033/#1037 class, end to end: load (0.8s) > generate budget
     (0.2s) but < load budget — must succeed. Before the fix the generate
-    guard killed the request mid-'download' with the misleading 503."""
+    guard killed the request mid-'download' with the misleading 503.
+
+    Watermarking is disabled for the duration. It runs INSIDE the generate
+    budget, and its first call in a process loads the AudioSeal model — which
+    on a cold run takes longer than the 0.2s budget this test deliberately
+    sets, so the request 503'd on the watermark rather than on anything to do
+    with the load/generate split. That made the file pass in a full session
+    (AudioSeal already warm from an earlier test) and fail when run alone,
+    which is the wrong way round for a regression test: the isolated run is
+    the honest one. The budget asymmetry is what is under test; the watermark
+    is an unrelated cold start riding in the same window.
+    """
     import services.model_manager as mm
     import api.routers.openai_compat as oc
+    import services.watermark as wm
+
+    monkeypatch.setattr(wm, "is_enabled", lambda: False)
 
     fake_cls = _make_slow_loading_engine("slow-load-engine", 0.8)
     monkeypatch.setitem(_tts_mod()._REGISTRY, "slow-load-engine", fake_cls)


### PR DESCRIPTION
Pre-existing on `main`, found while running related suites for #1338.

## Symptom

`tests/test_load_budget_split_1033.py::test_speech_survives_a_load_slower_than_the_generate_budget` **passes in a full session and fails when the file is run alone.** That is the wrong way round — the isolated run is the honest one, so the suite was green for a reason unrelated to what the test asserts.

## Cause

Not ordering as such. Watermarking runs **inside** the generate budget, and its first call in a process loads the AudioSeal model. The test deliberately sets a 0.2s generate budget (the whole point: load 0.8s > generate budget > actual synthesis), and a cold AudioSeal load does not fit in it — so the request 503'd on the watermark, not on anything to do with the load/generate split.

In a full session an earlier test had already warmed AudioSeal, so it fit. The test was passing by accident of neighbours.

```
E   AssertionError: {"detail":"OpenAI TTS generate ran for more than 0s of actual compute time…"}
    WARNING  Audioseal:models.py:27 …
```

## Fix

Disable watermarking for the duration of that test. The budget asymmetry is what is under test; the watermark is an unrelated cold start that happened to ride in the same window, and leaving it in means the test measures whichever of the two is slower on the day.

Not raising the budget instead: any fixed value still races a model load whose cost depends on the machine, which is how this got here.

## Verified

- isolated: 3 passed (was 1 failed);
- with its sibling timeout suites (`test_generate_timeout_730`, `test_gpu_pool_queue_accounting_1190`): 25 passed;
- three consecutive isolated runs, to check it is not merely flaky in the other direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The test disables watermarking before the request and documents the cold-start interaction. This isolates model-load timeout behavior from AudioSeal’s generate-budget cost. Review whether disabling watermarking still covers the intended regression path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->