### PR TITLE
fix(startup): explain a lost port race instead of exiting 1 in silence (#1364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
+- A port conflict that resolves itself while the backend is dying no longer reports a bare "Backend died (exit code 1)" — the conflict is named even when the other process has already let the port go. (#1364, #1223)
 - Fresh installs failing to import `transformers.HiggsAudioV2TokenizerModel` with "RuntimeError: operator torchvision::nms does not exist" are fixed by pinning `torchvision==0.23.0` to match `torch 2.8.0` — thanks @HanzlahCh! (#1358, #1357)
 - Every RTX 40-series card (4060–4090) was declared unsupported and silently run on the CPU. The compatibility gate demanded an exact `sm_89` match, but PyTorch ships `sm_86` kernels that already cover Ada. (#1285)
 - Under-provisioned hardware is now flagged **before** a synthesis starts instead of after the full compute budget expires. (#1240, #1246, #1248, #1277, #1283, #1284)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1412,6 +1412,28 @@ if __name__ == "__main__":
         )
         sys.exit(_EXIT_PORT_IN_USE)
 
+    class _BindErrorWatcher(logging.Filter):
+        """Remembers the EADDRINUSE uvicorn logged on its way out (#1364).
+
+        uvicorn's startup does ``logger.error(exc); sys.exit(1)`` with the
+        OSError itself as the record's message, so the errno is available as an
+        object — no locale-dependent string matching. Passing every record
+        through untouched; this only observes.
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.bind_error: "OSError | None" = None
+
+        def filter(self, record: logging.LogRecord) -> bool:
+            msg = record.msg
+            if isinstance(msg, OSError) and (
+                msg.errno in (48, 98, 10048)
+                or getattr(msg, "winerror", None) == 10048
+            ):
+                self.bind_error = msg
+            return True
+
     # #1223: uvicorn does NOT let a bind failure reach the caller — it logs the
     # raw errno and raises SystemExit(1) from inside its startup, so an
     # `except OSError` around uvicorn.run() never fires (verified, not assumed).
@@ -1422,13 +1444,32 @@ if __name__ == "__main__":
     # Windows) — and exit with a code the shell can recognise.
     if (_bind_err := _port_taken(_bind_host, _port)) is not None:
         _fail_port_in_use(_bind_err)
+
+    _watcher = _BindErrorWatcher()
+    _uvicorn_log = logging.getLogger("uvicorn.error")
+    # A filter only runs on records the logger actually emits, so a level above
+    # ERROR would drop the bind failure before we ever see it and silently
+    # restore the unexplained exit 1. uvicorn's default is INFO and nothing
+    # here raises it, so this is a no-op today — it keeps the mechanism from
+    # being disarmed at a distance by a future log-level change.
+    if _uvicorn_log.level > logging.ERROR:
+        _uvicorn_log.setLevel(logging.ERROR)
+    _uvicorn_log.addFilter(_watcher)
     try:
         uvicorn.run(app, host=_bind_host, port=_port)
     except SystemExit:
         # Lost the race between the probe above and uvicorn's own bind (a
-        # competing process grabbed the port in between). Re-probe: if the port
-        # is taken now, that is what killed us, whatever exit code uvicorn
-        # chose.
+        # competing process grabbed the port in between).
+        #
+        # Re-probing alone is not enough (#1364): if the process that took the
+        # port was itself exiting — an orphaned backend from the previous
+        # session, which is the common case — the port is free again by the
+        # time we look, so the probe says "fine" and the user gets a bare
+        # `exit code 1` with no explanation for a crash we fully understood.
+        # uvicorn already told us the errno on its way out; believe that first
+        # and fall back to the probe.
+        if _watcher.bind_error is not None:
+            _fail_port_in_use(_watcher.bind_error)
         if _port_taken(_bind_host, _port) is not None:
             _fail_port_in_use(None)
         raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -1446,15 +1446,19 @@ if __name__ == "__main__":
         _fail_port_in_use(_bind_err)
 
     _watcher = _BindErrorWatcher()
-    _uvicorn_log = logging.getLogger("uvicorn.error")
-    # A filter only runs on records the logger actually emits, so a level above
-    # ERROR would drop the bind failure before we ever see it and silently
-    # restore the unexplained exit 1. uvicorn's default is INFO and nothing
-    # here raises it, so this is a no-op today — it keeps the mechanism from
-    # being disarmed at a distance by a future log-level change.
-    if _uvicorn_log.level > logging.ERROR:
-        _uvicorn_log.setLevel(logging.ERROR)
-    _uvicorn_log.addFilter(_watcher)
+    # Attached BEFORE uvicorn.run because uvicorn configures logging during
+    # startup, well after we lose control. Two properties this depends on, both
+    # measured against the installed uvicorn rather than assumed, and both
+    # pinned by tests in tests/test_port_in_use_exit.py:
+    #
+    #  1. uvicorn's `configure_logging()` runs `dictConfig`, which replaces the
+    #     logger's HANDLERS but leaves its FILTERS in place — so this survives.
+    #  2. it does reset the logger's LEVEL to the configured log_level, which
+    #     would overwrite anything we set here. A filter only runs on records
+    #     the logger actually emits, so a `log_level` above ERROR would blind
+    #     this watcher. We therefore pass no log_level to uvicorn.run() at all
+    #     (its default is INFO); the test asserts we never start.
+    logging.getLogger("uvicorn.error").addFilter(_watcher)
     try:
         uvicorn.run(app, host=_bind_host, port=_port)
     except SystemExit:

--- a/tests/test_port_in_use_exit.py
+++ b/tests/test_port_in_use_exit.py
@@ -267,3 +267,96 @@ def test_the_watcher_ignores_unrelated_errors(tmp_path):
     )
     proc = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
     assert proc.stdout.split() == ["CLEAN", "CAUGHT"], (proc.stdout, proc.stderr)
+
+
+# ── the properties the watcher depends on, measured not assumed ───────────
+
+def test_uvicorn_logging_config_preserves_filters(tmp_path):
+    """greptile on #1370 argued uvicorn's logging setup removes the filter,
+    which would make the whole mechanism inert.
+
+    It does not: `dictConfig` replaces a logger's HANDLERS and leaves its
+    FILTERS alone. Measured here against the installed uvicorn so a future
+    version that *does* start clearing filters fails loudly, rather than
+    silently restoring the unexplained exit 1.
+    """
+    script = tmp_path / "filters.py"
+    script.write_text(
+        "import logging\n"
+        "from uvicorn.config import Config\n"
+        "class F(logging.Filter):\n"
+        "    def filter(self, r): return True\n"
+        "log = logging.getLogger('uvicorn.error')\n"
+        "f = F(); log.addFilter(f)\n"
+        "Config(app=None).configure_logging()\n"
+        "print('KEPT' if f in log.filters else 'DROPPED')\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    assert proc.stdout.strip() == "KEPT", (
+        "uvicorn now drops filters when it configures logging — the bind "
+        f"watcher in main.py is inert.\n{proc.stdout}{proc.stderr}"
+    )
+
+
+def test_uvicorn_owns_the_logger_level(tmp_path):
+    """The other half, and the reason main.py must not set `log_level`.
+
+    uvicorn resets `uvicorn.error`'s level from its config during startup —
+    after any level we set. A level above ERROR drops the bind record before
+    filters run, so the watcher would go blind. Documenting the behaviour is
+    what makes the next test's rule non-arbitrary.
+    """
+    script = tmp_path / "level.py"
+    script.write_text(
+        "import logging\n"
+        "from uvicorn.config import Config\n"
+        "log = logging.getLogger('uvicorn.error')\n"
+        "log.setLevel(logging.ERROR)\n"
+        "Config(app=None, log_level='critical').configure_logging()\n"
+        "print('OVERRIDDEN' if log.level > logging.ERROR else 'PRESERVED')\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    assert proc.stdout.strip() == "OVERRIDDEN", (
+        "uvicorn no longer overrides the logger level, so main.py could set it "
+        "defensively again — verify before relying on that"
+    )
+
+
+def test_main_does_not_raise_the_uvicorn_log_level():
+    """Given the two facts above, this is the actual precondition of the fix:
+    `log_level` must stay at uvicorn's INFO default so ERROR records reach the
+    filter. Someone quietening the backend later would otherwise silently
+    disarm the #1364 diagnosis."""
+    src = _read("backend", "main.py")
+    # Scope to the GUARDED serve call. main.py has a second uvicorn.run() on
+    # the --health-check smoke path, which sets log_level="warning" to quieten
+    # the access log; that is below ERROR and irrelevant here.
+    guarded = src[src.index('logging.getLogger("uvicorn.error").addFilter('):]
+    call = re.search(r"uvicorn\.run\((.*?)\)\n", guarded, re.DOTALL)
+    assert call, "the guarded uvicorn.run() call was not found after the watcher"
+
+    level = re.search(r"log_level\s*=\s*[\"'](\w+)[\"']", call.group(1))
+    if level is not None:
+        # A filter only runs on records the logger emits, so anything above
+        # ERROR drops the bind failure before the watcher can see it.
+        assert level.group(1).lower() in ("debug", "info", "warning", "error"), (
+            f"the guarded uvicorn.run() sets log_level={level.group(1)!r}, which "
+            f"suppresses the ERROR record the #1364 watcher reads"
+        )
+
+
+def test_main_actually_wires_the_watcher():
+    """The end-to-end tests above rebuild the guard from extracted source, so
+    they would still pass if main.py stopped installing the filter or stopped
+    consulting it (CodeRabbit). Pin the production wiring itself."""
+    src = _read("backend", "main.py")
+    assert "class _BindErrorWatcher(" in src
+    assert 'logging.getLogger("uvicorn.error").addFilter(' in src, (
+        "the watcher is defined but never attached"
+    )
+    assert "_watcher.bind_error is not None" in src, (
+        "the watcher is attached but never consulted, so a lost race still "
+        "exits 1 with no explanation"
+    )

--- a/tests/test_port_in_use_exit.py
+++ b/tests/test_port_in_use_exit.py
@@ -326,25 +326,51 @@ def test_uvicorn_owns_the_logger_level(tmp_path):
 
 def test_main_does_not_raise_the_uvicorn_log_level():
     """Given the two facts above, this is the actual precondition of the fix:
-    `log_level` must stay at uvicorn's INFO default so ERROR records reach the
+    `log_level` must stay at or below ERROR so the bind record reaches the
     filter. Someone quietening the backend later would otherwise silently
-    disarm the #1364 diagnosis."""
-    src = _read("backend", "main.py")
-    # Scope to the GUARDED serve call. main.py has a second uvicorn.run() on
-    # the --health-check smoke path, which sets log_level="warning" to quieten
-    # the access log; that is below ERROR and irrelevant here.
-    guarded = src[src.index('logging.getLogger("uvicorn.error").addFilter('):]
-    call = re.search(r"uvicorn\.run\((.*?)\)\n", guarded, re.DOTALL)
-    assert call, "the guarded uvicorn.run() call was not found after the watcher"
+    disarm the #1364 diagnosis.
 
-    level = re.search(r"log_level\s*=\s*[\"'](\w+)[\"']", call.group(1))
-    if level is not None:
-        # A filter only runs on records the logger emits, so anything above
-        # ERROR drops the bind failure before the watcher can see it.
-        assert level.group(1).lower() in ("debug", "info", "warning", "error"), (
-            f"the guarded uvicorn.run() sets log_level={level.group(1)!r}, which "
-            f"suppresses the ERROR record the #1364 watcher reads"
-        )
+    AST rather than a regex (CodeRabbit): a pattern that only recognises string
+    literals silently passes on `log_level=settings.level` or any other
+    computed value — the check would look present and verify nothing, which is
+    the same class of bug as the pin in #1357 that did not apply.
+    """
+    import ast
+
+    src = _read("backend", "main.py")
+    tree = ast.parse(src)
+
+    # Scope to the GUARDED serve call: the one after the watcher is attached.
+    # main.py has a second uvicorn.run() on the --health-check smoke path which
+    # sets log_level="warning" (below ERROR, irrelevant here).
+    attach = next(
+        n.lineno for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute) and n.func.attr == "addFilter"
+    )
+    guarded = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute) and n.func.attr == "run"
+        and getattr(n.func.value, "id", None) == "uvicorn"
+        and n.lineno > attach
+    ]
+    assert guarded, "the guarded uvicorn.run() call was not found after the watcher"
+
+    _ALLOWED = {"debug", "info", "warning", "error"}
+    for call in guarded:
+        for kw in call.keywords:
+            if kw.arg != "log_level":
+                continue
+            assert isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str), (
+                "the guarded uvicorn.run() computes log_level, so this test "
+                "cannot verify it stays at or below ERROR — the #1364 watcher "
+                "would go blind with no warning. Use a literal."
+            )
+            assert kw.value.value.lower() in _ALLOWED, (
+                f"the guarded uvicorn.run() sets log_level={kw.value.value!r}, "
+                f"which suppresses the ERROR record the #1364 watcher reads"
+            )
 
 
 def test_main_actually_wires_the_watcher():

--- a/tests/test_port_in_use_exit.py
+++ b/tests/test_port_in_use_exit.py
@@ -121,7 +121,7 @@ def test_real_bind_conflict_exits_with_the_dedicated_code(tmp_path):
 
         script = tmp_path / "guarded.py"
         script.write_text(
-            "import socket, sys\n"
+            "import logging, socket, sys\n"
             "import uvicorn\n"
             "from fastapi import FastAPI\n"
             f"_EXIT_PORT_IN_USE = {_EXPECTED_EXIT}\n"
@@ -172,3 +172,98 @@ def test_the_probe_does_not_false_positive_on_a_free_port(tmp_path):
     )
     proc = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
     assert proc.stdout.strip() == "FREE", proc.stderr
+
+
+def test_a_lost_bind_race_is_explained_even_if_the_port_is_free_again(tmp_path):
+    """#1364: the same crash, still unexplained, when the squatter exits too.
+
+    The #1223 guard handles the race by re-probing after uvicorn dies. That
+    only helps while the other process is still holding the port. The common
+    case is an orphaned backend from the previous session which is *itself*
+    shutting down — it releases the port between uvicorn's failed bind and our
+    re-probe, the probe reports "free", and the user gets a bare `exit code 1`
+    for a crash we had already diagnosed.
+
+    Reported on Windows with the tell-tale ordering: `Application startup
+    complete` (uvicorn's lifespan runs before the bind), then
+    `[Errno 10048] error while attempting to bind`, then a plain exit 1.
+
+    Simulated deterministically by making both probes report the port free
+    while it is genuinely held, which is precisely the state the race leaves
+    us in. Fails before the watcher: exit 1, no message.
+    """
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    holder.bind(("127.0.0.1", 0))
+    holder.listen(1)
+    port = holder.getsockname()[1]
+    try:
+        guard = _read("backend", "main.py")
+        start = guard.index("    def _port_taken(")
+        end = guard.index("    # #1223: uvicorn does NOT")
+        body = "\n".join(line[4:] for line in guard[start:end].splitlines())
+
+        script = tmp_path / "raced.py"
+        script.write_text(
+            "import logging, socket, sys\n"
+            "import uvicorn\n"
+            "from fastapi import FastAPI\n"
+            f"_EXIT_PORT_IN_USE = {_EXPECTED_EXIT}\n"
+            f"_port = {port}\n"
+            "app = FastAPI()\n"
+            + body
+            + "\n"
+            # Both probes lie: the port looks free, exactly as it does when the
+            # process that held it has since exited.
+            "_port_taken = lambda *a, **k: None\n"
+            "_watcher = _BindErrorWatcher()\n"
+            "logging.getLogger('uvicorn.error').addFilter(_watcher)\n"
+            "try:\n"
+            "    uvicorn.run(app, host='127.0.0.1', port=_port)\n"
+            "except SystemExit:\n"
+            "    if _watcher.bind_error is not None:\n"
+            "        _fail_port_in_use(_watcher.bind_error)\n"
+            "    if _port_taken('127.0.0.1', _port) is not None:\n"
+            "        _fail_port_in_use(None)\n"
+            "    raise\n",
+            encoding="utf-8",
+        )
+        proc = subprocess.run(
+            [sys.executable, str(script)], capture_output=True, text=True
+        )
+        assert proc.returncode == _EXPECTED_EXIT, (
+            f"a lost bind race still exits {proc.returncode} with no explanation; "
+            f"expected {_EXPECTED_EXIT}\n{proc.stderr}"
+        )
+        # Our wording, not uvicorn's. `already in use` is also what macOS/Linux
+        # strerror puts in uvicorn's own log line, so asserting on that would
+        # pass against the unfixed build -- and would be the exact
+        # locale-dependent match #1223 exists to avoid.
+        assert "FATAL: port" in proc.stderr and "orphaned backend" in proc.stderr
+    finally:
+        holder.close()
+
+
+def test_the_watcher_ignores_unrelated_errors(tmp_path):
+    """It must not turn every logged OSError into "port in use" — a permission
+    failure or an unreachable bind host is a different problem with different
+    advice."""
+    guard = _read("backend", "main.py")
+    start = guard.index("    class _BindErrorWatcher(")
+    end = guard.index("    # #1223: uvicorn does NOT")
+    body = "\n".join(line[4:] for line in guard[start:end].splitlines())
+
+    script = tmp_path / "watcher.py"
+    script.write_text(
+        "import errno, logging\n" + body + "\n"
+        "w = _BindErrorWatcher()\n"
+        "log = logging.getLogger('probe'); log.addFilter(w)\n"
+        "log.error(OSError(errno.EACCES, 'permission denied'))\n"
+        "log.error(OSError(errno.ECONNREFUSED, 'refused'))\n"
+        "log.error('a plain string message')\n"
+        "print('CLEAN' if w.bind_error is None else 'FALSE_POSITIVE')\n"
+        "log.error(OSError(98, 'address already in use'))\n"
+        "print('CAUGHT' if w.bind_error is not None else 'MISSED')\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    assert proc.stdout.split() == ["CLEAN", "CAUGHT"], (proc.stdout, proc.stderr)


### PR DESCRIPTION
Fixes #1364. Follow-up to #1223 — same crash, still unexplained in one case.

## What #1223 left open

#1223 gave a port conflict a dedicated exit code (78) and handles the race between our pre-probe and uvicorn's real bind by **re-probing** after uvicorn dies.

That only helps while the other process is *still* holding the port. The common case is an orphaned backend from the previous session which is itself shutting down: it releases the port between uvicorn's failed bind and our re-probe, the probe says "free", and the user gets a bare `exit code 1` — for a crash we had already fully diagnosed.

The report shows the tell-tale ordering:

```
INFO:     Application startup complete.          <- uvicorn's lifespan runs BEFORE the bind
ERROR:    [Errno 10048] error while attempting to bind on address ('127.0.0.1', 3900)
INFO:     Waiting for application shutdown.
```

...then `Backend died (exit code 1)`.

## The fix

uvicorn already hands us the answer. Its startup does `logger.error(exc); sys.exit(1)` with the **OSError itself** as the record's message, so the errno is available as an object — no locale-dependent string matching, which is precisely the trap #1223 exists to avoid (that report was in Russian). Observe that record, believe it first, keep the re-probe as the fallback.

The watcher also pins `uvicorn.error` to at most `ERROR`: a filter only runs on records the logger actually emits, so a higher level would drop the bind failure and silently restore the unexplained exit 1. No-op today — uvicorn defaults to INFO and nothing here raises it — it just stops the mechanism being disarmed at a distance later.

## Tests

Two regressions, both driving the **real** uvicorn:

- The race, simulated deterministically by making both probes report the port free while it is genuinely held — exactly the state the race leaves us in. Verified: **exit 1 without the watcher, 78 with it.**
- The watcher ignores unrelated `OSError`s (EACCES, ECONNREFUSED) and plain string messages, so a permission failure doesn't get mislabelled as a port conflict.

Two things worth flagging in how these are written:

1. The assertion is on **our** wording, not `"already in use"`. I checked: that phrase is also in uvicorn's own English log line, so asserting on it passes against the *unfixed* build — and it would be the very locale-dependent match #1223 forbids.
2. The pre-existing extraction test needed `import logging` added to its generated script, since the guard region it copies out of `main.py` now defines a `logging.Filter`.

`tests/test_port_in_use_exit.py`: 11 passed. `backend/tests/`: 237 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The backend now detects locale-independent `EADDRINUSE` failures from `uvicorn.error` and reports the dedicated port-conflict error when a bind race frees the port before re-probing. Regression tests cover bind races, unrelated errors, uvicorn logging behavior, and production wiring, with 11 port-conflict tests and 237 backend tests passing. Human review should verify that the guarded `uvicorn.run()` keeps a log level no higher than `ERROR`, because the watcher depends on that behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->