### PR TITLE
fix(generate): a deadline is not an unrecognized error (#1368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
+- A generation that hits its time limit now says so, instead of "an error OmniVoice doesn't recognize" followed by an empty `TimeoutError:`. It names the likely causes and the setting that raises the limit. (#1368)
 - A port conflict that resolves itself while the backend is dying no longer reports a bare "Backend died (exit code 1)" — the conflict is named even when the other process has already let the port go. (#1364, #1223)
 - Fresh installs failing to import `transformers.HiggsAudioV2TokenizerModel` with "RuntimeError: operator torchvision::nms does not exist" are fixed by pinning `torchvision==0.23.0` to match `torch 2.8.0` — thanks @HanzlahCh! (#1358, #1357)
 - ...and that pin now actually reaches Colab and Docker: both install with `uv pip install`, which ignores the pyproject setting the pin lived in, so the torch trio could still drift apart. It is passed explicitly now. (#1357)

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -298,6 +298,46 @@ def _is_config_failure(e) -> bool:
     return False
 
 
+# Exception types that mean "the budget ran out", not "something broke".
+# asyncio.TimeoutError is an alias of the builtin on 3.11+, but the engines'
+# own wrappers are separate classes, so match by name across the chain.
+_TIMEOUT_EXC_NAMES = frozenset({
+    "TimeoutError", "GpuJobTimeoutError", "FuturesTimeoutError",
+})
+
+# Same class, stringified into a wrapper (all lowercase).
+_TIMEOUT_MSG_SIGNATURES = (
+    "timed out",
+    "timeout expired",
+    "exceeded its time budget",
+)
+
+
+def _is_timeout_failure(e) -> bool:
+    """True iff the generation ran out of *time* rather than failing (#1368).
+
+    A bare ``TimeoutError`` used to fall through to the unrecognized-error
+    catch-all, so the user was told to "retry once and report it with the full
+    trace" for the one failure mode whose cause is fully known and whose
+    message is usually EMPTY — ``TimeoutError:`` with nothing after the colon
+    tells them nothing at all.
+
+    Deliberately checked before the OOM branch: a job killed at its deadline is
+    not an allocation failure, and Flush is the wrong remedy for it.
+    """
+    for exc in _exception_chain(e):
+        if isinstance(exc, TimeoutError) or type(exc).__name__ in _TIMEOUT_EXC_NAMES:
+            return True
+        low = str(exc).lower()
+        if any(sig in low for sig in _TIMEOUT_MSG_SIGNATURES):
+            # "read timed out" is a download dying, which _is_network_failure
+            # owns and explains better; don't steal it.
+            if "read timed out" in low:
+                continue
+            return True
+    return False
+
+
 def _oom_friendly_reraise(e):
     """Best-effort cache flush + the user-facing OOM hint shared by both
     inference paths."""
@@ -462,6 +502,28 @@ def _oom_friendly_reraise(e):
     # never ran out of. Only claim OOM when something in the chain actually
     # looks like one; everything else surfaces as what it is — unrecognized —
     # with the real error front and center.
+    # #1368: a generate killed at its deadline is not an unrecognized fault.
+    # It arrived as a bare `TimeoutError:` with an EMPTY message, so the
+    # catch-all below asked the user to report a trace that says nothing.
+    # Checked before the OOM branch — a job that ran out of time did not run
+    # out of memory, and Flush is the wrong remedy.
+    if _is_timeout_failure(e):
+        # `TimeoutError` is routinely raised with no message, so the usual
+        # "Underlying error: …" tail rendered as a bare `TimeoutError:` —
+        # a sentence stopping mid-thought. Append it only when it says
+        # something (#1368).
+        # Test the MESSAGE, not _safe_exc_text() — that always prefixes the
+        # type name, so it is never empty and the check would never fire.
+        _tail = f" Underlying error: {_safe_exc_text(e)}" if str(e).strip() else ""
+        raise RuntimeError(
+            f"The engine hit its time limit before finishing, so generation was "
+            f"stopped. Nothing is broken and "
+            f"flushing memory won't help. The usual causes are a first-use model "
+            f"download still in progress (retry once it finishes — it resumes), "
+            f"a very long input, or an engine running on CPU. Shorter text, or "
+            f"raising OMNIVOICE_GENERATE_TIMEOUT_S, will get it through."
+            + _tail
+        ) from e
     if _is_oom_failure(e):
         raise RuntimeError(
             f"TTS engine stopped mid-generation. This usually means it ran out of memory. "

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -516,12 +516,12 @@ def _oom_friendly_reraise(e):
         # type name, so it is never empty and the check would never fire.
         _tail = f" Underlying error: {_safe_exc_text(e)}" if str(e).strip() else ""
         raise RuntimeError(
-            f"The engine hit its time limit before finishing, so generation was "
-            f"stopped. Nothing is broken and "
-            f"flushing memory won't help. The usual causes are a first-use model "
-            f"download still in progress (retry once it finishes — it resumes), "
-            f"a very long input, or an engine running on CPU. Shorter text, or "
-            f"raising OMNIVOICE_GENERATE_TIMEOUT_S, will get it through."
+            "The engine hit its time limit before finishing, so generation was "
+            "stopped. Nothing is broken and flushing memory won't help. The "
+            "usual causes are a first-use model download still in progress "
+            "(retry once it finishes — it resumes), a very long input, or an "
+            "engine running on CPU. Shorter text, or raising "
+            "OMNIVOICE_GENERATE_TIMEOUT_S, will get it through."
             + _tail
         ) from e
     if _is_oom_failure(e):

--- a/tests/test_generation_timeout_is_named.py
+++ b/tests/test_generation_timeout_is_named.py
@@ -1,0 +1,182 @@
+"""A generate that ran out of time must say so, not "an error we don't recognize".
+
+Reported in #1368 (macOS M3 Max, MPS, indextts2):
+
+    RuntimeError: TTS engine stopped mid-generation with an error OmniVoice
+    doesn't recognize. Retry once; if it keeps failing, please report it with
+    the full trace. Underlying error: TimeoutError:
+
+Note what follows the last colon: nothing. `TimeoutError` is routinely raised
+with an empty message, so the user was asked to report a trace that says
+nothing, about the one failure mode whose cause is entirely known.
+
+The classification chain (#880/#919) already refuses to blame VRAM for network
+and config failures. A deadline is the same kind of thing — a known class with
+a specific remedy — and it was falling through to the catch-all. Worse, had it
+carried an OOM-ish word it would have hit the memory branch and told the user
+to press Flush for memory they never ran out of, which is precisely the class
+bug #880 fixed.
+
+Ordering matters here and is asserted: timeout is checked BEFORE oom, and
+network keeps ownership of "read timed out" (a dying download, which it
+explains better than a generic deadline would).
+"""
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import importlib
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+
+@pytest.fixture
+def gen():
+    """Resolve at call time — sibling suites reload/purge ``services.*``."""
+    return importlib.import_module("api.routers.generation")
+
+
+# ── recognised as a timeout ───────────────────────────────────────────────
+
+def test_a_bare_timeout_error_is_recognised(gen):
+    """The reported case, message and all: there isn't one."""
+    assert gen._is_timeout_failure(TimeoutError()) is True
+
+
+def test_asyncio_timeout_is_recognised(gen):
+    assert gen._is_timeout_failure(asyncio.TimeoutError()) is True
+
+
+def test_a_futures_timeout_is_recognised(gen):
+    """What a pool job that overran its deadline raises."""
+    assert gen._is_timeout_failure(concurrent.futures.TimeoutError()) is True
+
+
+def test_the_gpu_pool_timeout_class_is_recognised(gen):
+    """`GpuJobTimeoutError` is the project's own wrapper and is not a
+    TimeoutError subclass, so it has to be matched by name."""
+    class GpuJobTimeoutError(Exception):
+        pass
+
+    assert gen._is_timeout_failure(GpuJobTimeoutError("job exceeded 300.0s")) is True
+
+
+def test_a_timeout_wrapped_in_another_exception_is_found(gen):
+    """Engines wrap the original error, which is why the whole chain is
+    walked rather than just the outermost type."""
+    try:
+        try:
+            raise TimeoutError()
+        except TimeoutError as inner:
+            raise RuntimeError("engine call failed") from inner
+    except RuntimeError as e:
+        assert gen._is_timeout_failure(e) is True
+
+
+def test_a_stringified_timeout_is_recognised(gen):
+    """Sidecars stringify the child's error into the parent's message, so the
+    type is gone by the time it reaches here."""
+    assert gen._is_timeout_failure(RuntimeError("sidecar timed out after 600s")) is True
+
+
+# ── NOT a timeout ─────────────────────────────────────────────────────────
+
+def test_a_download_read_timeout_stays_with_the_network_branch(gen):
+    """"read timed out" is a dying model download. The network branch names
+    that and tells the user to check their connection / mirror, which is
+    strictly more useful than a generic "it took too long"."""
+    e = RuntimeError("HTTPSConnectionPool: Read timed out. (read timeout=10)")
+    assert gen._is_timeout_failure(e) is False
+    assert gen._is_network_failure(e) is True
+
+
+def test_an_oom_is_not_a_timeout(gen):
+    e = RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB")
+    assert gen._is_timeout_failure(e) is False
+    assert gen._is_oom_failure(e) is True
+
+
+def test_an_ordinary_failure_is_not_a_timeout(gen):
+    assert gen._is_timeout_failure(RuntimeError("tensor shape mismatch")) is False
+    assert gen._is_timeout_failure(ValueError("bad speaker id")) is False
+
+
+def test_a_config_failure_is_not_a_timeout(gen):
+    assert gen._is_timeout_failure(
+        RuntimeError("OMNIVOICE_SHERPA_MODEL not set. Point it to the model dir")
+    ) is False
+
+
+# ── the message the user actually gets ────────────────────────────────────
+
+def _reraise(gen, exc):
+    """Run the shared classifier and return the RuntimeError it produces."""
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(exc)
+    return str(caught.value)
+
+
+def test_the_message_names_the_time_limit_not_a_mystery(gen):
+    msg = _reraise(gen, TimeoutError())
+    assert "time limit" in msg
+    assert "doesn't recognize" not in msg, (
+        "a deadline is not an unrecognized error — this is the #1368 report"
+    )
+
+
+def test_the_message_does_not_blame_memory(gen):
+    """The #880 class bug, in its newest disguise: never send someone to Flush
+    for a failure that has nothing to do with memory."""
+    msg = _reraise(gen, TimeoutError())
+    assert "Flush" not in msg or "won't help" in msg
+    assert "ran out of memory" not in msg
+
+
+def test_the_message_explains_the_first_run_download_case(gen):
+    """The most likely cause on a fresh install, and the one where "retry" is
+    genuinely the right advice — the download resumes (#1367)."""
+    msg = _reraise(gen, TimeoutError())
+    assert "download" in msg.lower()
+    assert "retry" in msg.lower()
+
+
+def test_the_message_names_the_override(gen):
+    """Someone on slow CPU-only hardware needs a way through, not just an
+    explanation."""
+    assert "OMNIVOICE_GENERATE_TIMEOUT_S" in _reraise(gen, TimeoutError())
+
+
+def test_an_empty_timeout_message_does_not_end_the_sentence_in_a_colon(gen):
+    """The literal reported output ended `Underlying error: TimeoutError:` —
+    a sentence that stops mid-thought. Whatever we append, the useful content
+    has to come before it."""
+    msg = _reraise(gen, TimeoutError())
+    assert not msg.rstrip().endswith(":"), msg
+    assert len(msg) > 120, "the message carries no information beyond the type"
+
+
+def test_oom_still_gets_the_flush_hint(gen):
+    """The timeout branch runs first, so pin that it did not swallow the case
+    the OOM branch exists for."""
+    msg = _reraise(gen, RuntimeError("CUDA out of memory. Tried to allocate 2 GiB"))
+    assert "Flush" in msg and "memory" in msg
+
+
+def test_an_unrecognized_error_still_says_so(gen):
+    """The catch-all must keep its job for genuinely unknown failures."""
+    assert "doesn't recognize" in _reraise(gen, RuntimeError("tensor shape mismatch"))
+
+
+def test_a_timeout_that_does_carry_a_message_keeps_it(gen):
+    """Dropping the tail is only right when it is empty. A sidecar that says
+    *which* deadline it blew is the most useful line in the report."""
+    msg = _reraise(gen, TimeoutError("sidecar recv exceeded 600s"))
+    assert "sidecar recv exceeded 600s" in msg
+    assert "Underlying error:" in msg


### PR DESCRIPTION
Fixes #1368.

## The report

macOS M3 Max, MPS, `indextts2`:

```
TTS engine stopped mid-generation with an error OmniVoice doesn't recognize.
Retry once; if it keeps failing, please report it with the full trace.
Underlying error: TimeoutError:
```

Nothing follows that last colon. `TimeoutError` is routinely raised with an empty message, so the user was asked to report a trace that says nothing — about the one failure mode whose cause is entirely known.

## Why it fell through

The classification chain already refuses to blame VRAM for network (#880) and config (#919) failures. A deadline is the same kind of thing — a known class with a specific remedy — and it was landing in the catch-all.

Worse: a timeout whose message happened to contain an OOM-ish word would have hit the memory branch and sent the user to press **Flush** for memory they never ran out of. That is precisely the class bug #880 fixed, reappearing through a gap in the taxonomy.

## The fix

`_is_timeout_failure()` matches:
- `TimeoutError` and the `asyncio` / `concurrent.futures` aliases
- `GpuJobTimeoutError` **by name** — it is the project's own wrapper and not a `TimeoutError` subclass
- stringified forms, since sidecars fold the child's error into the parent's message

Checked **before** the OOM branch. `"read timed out"` is deliberately left to the network branch — that is a dying model download, which it explains better than a generic deadline would.

The message names the time limit, the three usual causes, and `OMNIVOICE_GENERATE_TIMEOUT_S`, so someone on slow CPU-only hardware gets a way through rather than only an explanation.

The `Underlying error:` tail is appended only when the exception carries a message. Two things worth noting about that:

- My first attempt tested emptiness against `_safe_exc_text()`, which always prefixes the type name and so is **never** empty — the check silently never fired. It tests `str(e)` now.
- The test that caught it (`...does_not_end_the_sentence_in_a_colon`) was written before the code, and failed twice for two different real reasons.

## Relation to #1367

Very likely the in-the-wild face of it: `indextts2` is a subprocess engine, and a first-use weights download overrunning the 300 s generate budget produces exactly this. This PR makes that legible; #1367 is about the budget itself.

## Tests

`tests/test_generation_timeout_is_named.py` — 18 cases: what counts as a timeout, what must **not** (OOM, config, and the network branch keeping `read timed out`), the ordering, and the user-facing message. Plus `backend/tests/`: 236 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Generation failures now classify timeout errors, including wrapped and stringified variants, while preserving network and out-of-memory classifications. The user-facing message explains likely causes and the `OMNIVOICE_GENERATE_TIMEOUT_S` override, and avoids a bare `TimeoutError:` suffix. The main risk is maintaining correct precedence between timeout, network, and out-of-memory detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->