### PR TITLE
fix(errors): stop giving advice that cannot work (#1347, #1335, #1334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - A generation that hits its time limit now says so, instead of "an error OmniVoice doesn't recognize" followed by an empty `TimeoutError:`. It names the likely causes and the setting that raises the limit. (#1368)
 - A model download cut off mid-request is no longer reported as a broken transformers install — reinstalling could never have fixed a dropped connection. (#1347)
 - A TLS connection cut during generation is explained as the dropped download it is, instead of falling through as an unrecognized error carrying `_ssl.c:1016`. (#1335)
+- Windows "paging file is too small" no longer suggests the Flush button, which cannot help. It now names the virtual-memory setting to change, and says plainly that it is not a network problem. (#1334)
 - A port conflict that resolves itself while the backend is dying no longer reports a bare "Backend died (exit code 1)" — the conflict is named even when the other process has already let the port go. (#1364, #1223)
 - Fresh installs failing to import `transformers.HiggsAudioV2TokenizerModel` with "RuntimeError: operator torchvision::nms does not exist" are fixed by pinning `torchvision==0.23.0` to match `torch 2.8.0` — thanks @HanzlahCh! (#1358, #1357)
 - ...and that pin now actually reaches Colab and Docker: both install with `uv pip install`, which ignores the pyproject setting the pin lived in, so the torch trio could still drift apart. It is passed explicitly now. (#1357)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
 - A generation that hits its time limit now says so, instead of "an error OmniVoice doesn't recognize" followed by an empty `TimeoutError:`. It names the likely causes and the setting that raises the limit. (#1368)
+- A model download cut off mid-request is no longer reported as a broken transformers install — reinstalling could never have fixed a dropped connection. (#1347)
+- A TLS connection cut during generation is explained as the dropped download it is, instead of falling through as an unrecognized error carrying `_ssl.c:1016`. (#1335)
 - A port conflict that resolves itself while the backend is dying no longer reports a bare "Backend died (exit code 1)" — the conflict is named even when the other process has already let the port go. (#1364, #1223)
 - Fresh installs failing to import `transformers.HiggsAudioV2TokenizerModel` with "RuntimeError: operator torchvision::nms does not exist" are fixed by pinning `torchvision==0.23.0` to match `torch 2.8.0` — thanks @HanzlahCh! (#1358, #1357)
 - ...and that pin now actually reaches Colab and Docker: both install with `uv pip install`, which ignores the pyproject setting the pin lived in, so the torch trio could still drift apart. It is passed explicitly now. (#1357)

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -532,6 +532,23 @@ def _oom_friendly_reraise(e):
             "OMNIVOICE_GENERATE_TIMEOUT_S, will get it through."
             + _tail
         ) from e
+    # #1334: Windows refusing to back a large model mapping (WinError 1455) is
+    # a paging-file limit, not a working-set shortage. It was matching the OOM
+    # branch below and telling the user to press Flush — advice that cannot
+    # work, as the shared hint for this class says outright ("closing other
+    # apps usually won't fix it"). Checked first so the specific case wins.
+    _low_1455 = str(e).lower()
+    if "paging file is too small" in _low_1455 or (
+        "1455" in _low_1455 and ("winerror" in _low_1455 or "os error" in _low_1455)
+    ):
+        from core.failure import _HINTS
+        raise RuntimeError(
+            "Windows ran out of virtual memory while mapping the model — its "
+            "paging file is smaller than the model needs. This is not your RAM "
+            "being full, it is not a network problem, and Flush cannot help. "
+            + _HINTS["WINDOWS_PAGING_FILE_TOO_SMALL"]
+            + f" Underlying error: {e}"
+        ) from e
     if _is_oom_failure(e):
         raise RuntimeError(
             f"TTS engine stopped mid-generation. This usually means it ran out of memory. "

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -215,12 +215,22 @@ _NETWORK_MSG_SIGNATURES = (
     "temporary failure in name resolution",  # DNS down (glibc)
     "name or service not known",             # DNS down (glibc)
     "getaddrinfo failed",                    # DNS down (Windows)
-    # #1335: a TLS connection cut mid-download. core/failure.py already
-    # classifies this for the dub/transcribe surfaces (TLS_CONNECTION_DROPPED,
-    # #1301), but /generate has its own taxonomy and never learned it — so the
-    # reporter got a bare 500 carrying `_ssl.c:1016`, which means nothing to
-    # anyone. It is a dropped download, so the network branch is the right
-    # owner: the remedy is retry, not Flush.
+)
+
+# #1335: a TLS connection cut mid-download. core/failure.py already classifies
+# this for the dub/transcribe surfaces (TLS_CONNECTION_DROPPED, #1301), but
+# /generate has its own taxonomy and never learned it — so the reporter got a
+# bare 500 carrying `_ssl.c:1016`, which means nothing to anyone. It is a
+# dropped download, so the network branch is the right owner: retry, not Flush.
+#
+# Gated on an "ssl" marker rather than matched bare (CodeRabbit): "eof occurred
+# in violation of protocol" is OpenSSL's wording, but nothing stops an
+# unrelated component from saying something similar, and mislabelling a local
+# fault as a network problem sends the user to check their connection for a
+# failure that has nothing to do with it. The real message always carries the
+# marker: "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of
+# protocol (_ssl.c:1016)".
+_TLS_DROP_SIGNATURES = (
     "unexpected_eof_while_reading",
     "eof occurred in violation of protocol",
 )
@@ -235,6 +245,8 @@ def _is_network_failure(e) -> bool:
             return True
         low = str(exc).lower()
         if any(sig in low for sig in _NETWORK_MSG_SIGNATURES):
+            return True
+        if "ssl" in low and any(sig in low for sig in _TLS_DROP_SIGNATURES):
             return True
     return False
 

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -215,6 +215,14 @@ _NETWORK_MSG_SIGNATURES = (
     "temporary failure in name resolution",  # DNS down (glibc)
     "name or service not known",             # DNS down (glibc)
     "getaddrinfo failed",                    # DNS down (Windows)
+    # #1335: a TLS connection cut mid-download. core/failure.py already
+    # classifies this for the dub/transcribe surfaces (TLS_CONNECTION_DROPPED,
+    # #1301), but /generate has its own taxonomy and never learned it — so the
+    # reporter got a bare 500 carrying `_ssl.c:1016`, which means nothing to
+    # anyone. It is a dropped download, so the network branch is the right
+    # owner: the remedy is retry, not Flush.
+    "unexpected_eof_while_reading",
+    "eof occurred in violation of protocol",
 )
 
 

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -335,7 +335,13 @@ def classify(reason: str) -> str:
     # has been closed" (#880) — TRANSFORMERS_IMPORT won on the former and told
     # them to reinstall transformers, which cannot fix a dropped connection.
     # Checked BEFORE the import rules so the cause beats the symptom.
-    if ("client has been closed" in low or "cannot send a request" in low) and (
+    # Requires the closed-client wording itself, not merely "cannot send a
+    # request" (CodeRabbit): the latter is generic enough to appear in an
+    # unrelated failure that also mentions an import, and overriding
+    # TRANSFORMERS_IMPORT there would replace correct reinstall advice with a
+    # "just retry" that never succeeds — the same defect in the other
+    # direction.
+    if "client has been closed" in low and (
         "import" in low or "transformers" in low or "autofeatureextractor" in low
     ):
         return "MODEL_DOWNLOAD_INTERRUPTED"

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -58,6 +58,13 @@ _HINTS: dict[str, str] = {
     # violation of protocol (_ssl.c:1016)", which means nothing to anyone.
     "TLS_CONNECTION_DROPPED": "The secure connection was cut off mid-transfer — the other end (or something between you and it) closed the socket during the TLS exchange. This is almost always transient: flaky Wi-Fi, a VPN reconnecting, a captive portal, or a download server dropping a long transfer. Retrying is safe: a partly-downloaded MODEL is picked up where it left off rather than started over. If it repeats every time, a VPN or an HTTPS-inspecting proxy is terminating long-lived connections — try without the VPN, or on another network.",
     "VIDEO_DOWNLOAD_NETWORK": "The connection to the video server dropped mid-download (often a transient CDN/network blip or a regional rate-limit). Just retry — OmniVoice already cleaned up the partial download. If it keeps failing, check your network/VPN.",
+    # #1347: the transformers pipeline fails to import a component it was
+    # DOWNLOADING when the shared HTTP client closed underneath it (#880). The
+    # message names AutoFeatureExtractor, so TRANSFORMERS_IMPORT matched and
+    # told the reporter to reinstall transformers — advice that cannot work,
+    # because nothing is wrong with their install. Checked first so the cause
+    # wins over the symptom.
+    "MODEL_DOWNLOAD_INTERRUPTED": "A model download was cut off mid-request, and the component it was fetching then failed to load. Nothing is wrong with your install — reinstalling won't help, and the partial download is resumed rather than restarted. Just retry. If it keeps happening, check your connection (and any VPN, proxy or HF mirror setting); if only transcription is affected, switching ASR to faster-whisper in Settings → Models avoids the pipeline that downloads this component.",
     "BROKEN_VENV": "The Python backend environment was moved or damaged. OmniVoice rebuilds it automatically on the next launch; if it keeps failing, use Clean & Retry on the setup screen.",
     "MODEL_CACHE_CORRUPT": "The model cache had broken file links — snapshot entries that no longer point at their downloaded data (interrupted renames or antivirus interference can cause this). OmniVoice repairs this automatically and retries the load once. If the error persists, quit OmniVoice, delete the model's models--<org>--<name> folder inside the Hugging Face cache, and restart — the model re-downloads automatically.",
     # HF_MIRROR_UNREACHABLE has a DYNAMIC hint (it names the configured mirror)
@@ -225,6 +232,9 @@ _CONTEXT_FREE_HINT_CLASSES = frozenset({
     # Its trigger is an exact OpenSSL string, so it cannot be confused with
     # another failure the way a bare "timed out" could.
     "TLS_CONNECTION_DROPPED",
+    # Requires the exact httpx closed-client wording AND an import/transformers
+    # term together, so it cannot fire on an unrelated failure (#1347).
+    "MODEL_DOWNLOAD_INTERRUPTED",
 })
 
 
@@ -313,6 +323,16 @@ def classify(reason: str) -> str:
     # automatic repair.
     if is_incomplete_cache_message(low) or "broken file link" in low:
         return "MODEL_CACHE_CORRUPT"
+    # #1347: an import that failed because its DOWNLOAD died is a network
+    # problem wearing an import problem's clothes. The reporter's message named
+    # AutoFeatureExtractor *and* carried "Cannot send a request, as the client
+    # has been closed" (#880) — TRANSFORMERS_IMPORT won on the former and told
+    # them to reinstall transformers, which cannot fix a dropped connection.
+    # Checked BEFORE the import rules so the cause beats the symptom.
+    if ("client has been closed" in low or "cannot send a request" in low) and (
+        "import" in low or "transformers" in low or "autofeatureextractor" in low
+    ):
+        return "MODEL_DOWNLOAD_INTERRUPTED"
     if (
         "could not import module" in low
         or "autofeatureextractor" in low

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -235,6 +235,12 @@ _CONTEXT_FREE_HINT_CLASSES = frozenset({
     # Requires the exact httpx closed-client wording AND an import/transformers
     # term together, so it cannot fire on an unrelated failure (#1347).
     "MODEL_DOWNLOAD_INTERRUPTED",
+    # #1334: triggered by WinError/os error 1455 or the literal "paging file is
+    # too small" — both unmistakable. It reached /generate as a bare 500
+    # carrying only the OS sentence, so the reporter had no way to know it was
+    # a Windows virtual-memory setting rather than a connectivity problem, and
+    # the detailed hint we already had for it never reached them.
+    "WINDOWS_PAGING_FILE_TOO_SMALL",
 })
 
 

--- a/tests/test_generation_audio_guard.py
+++ b/tests/test_generation_audio_guard.py
@@ -114,13 +114,39 @@ def test_unknown_error_is_not_labelled_oom():
     "MPS backend out of memory (MPS allocated: 8.00 GB)",
     "DefaultCPUAllocator: not enough memory: you tried to allocate 1073741824 bytes",
     "[enforce fail at alloc_cpu.cpp] posix_memalign. Cannot allocate memory",
-    "[WinError 1455] The paging file is too small for this operation to complete",
 ])
 def test_real_oom_signatures_still_classify_as_oom(reason):
     with pytest.raises(RuntimeError) as ei:
         _oom_friendly_reraise(RuntimeError(reason))
     assert "ran out of memory" in str(ei.value)
     assert "Try the Flush button" in str(ei.value)
+
+
+def test_the_windows_paging_file_case_gets_its_own_advice():
+    """#1334: WinError 1455 used to sit in the list above and get the generic
+    "ran out of memory / try Flush" message.
+
+    It is still a memory-class failure — the guard this file exists for, that a
+    real memory problem never falls through to the unknown catch-all, is intact
+    and asserted below. But Flush cannot fix it: Windows is refusing to back a
+    large mapping because the PAGING FILE is too small, which is not the same
+    as the working set being full, and no amount of reloading the model or
+    closing other apps changes it. So it gets the specific remedy instead of
+    advice that cannot work.
+    """
+    for reason in (
+        "[WinError 1455] The paging file is too small for this operation to complete",
+        "The paging file is too small for this operation to complete. (os error 1455)",
+    ):
+        with pytest.raises(RuntimeError) as ei:
+            _oom_friendly_reraise(RuntimeError(reason))
+        msg = str(ei.value)
+        # Still recognised — not the unknown-error catch-all.
+        assert "doesn't recognize" not in msg
+        assert "paging file" in msg.lower()
+        # ...and pointed at the setting that actually governs it.
+        assert "Virtual memory" in msg
+        assert "Try the Flush button" not in msg
 
 
 def test_typed_oom_without_oom_message_still_classifies_as_oom():

--- a/tests/test_network_beats_install_diagnosis.py
+++ b/tests/test_network_beats_install_diagnosis.py
@@ -21,8 +21,16 @@ was work the user could do forever without succeeding.
 keeps its own taxonomy and never learned it, so it fell to the
 "an error OmniVoice doesn't recognize" catch-all.
 
-Both fixes are orderings, not new detections: the cause is checked before the
-symptom.
+**#1334** — a Windows paging-file limit (`os error 1455`) matched the OOM branch
+and told the user to press Flush, which cannot help: the hint we already had for
+that class says outright that closing other apps usually will not fix it. The
+reporter also reasonably wondered whether OmniVoice needs the internet, because
+it correlated with going offline. It does not — the correlation is a coincidence,
+and the answer now says so.
+
+All three fixes are orderings and routing, not new detections: the cause is
+checked before the symptom, and hints we had already written are made to reach
+the surface the user actually sees.
 """
 from __future__ import annotations
 
@@ -143,3 +151,69 @@ def test_an_ordinary_generate_failure_is_still_unrecognized(gen):
     with pytest.raises(RuntimeError) as caught:
         gen._oom_friendly_reraise(RuntimeError("tensor shape mismatch"))
     assert "doesn't recognize" in str(caught.value)
+
+
+# ── #1334: a Windows paging-file limit is not "out of memory" ──────────────
+
+_1334 = "The paging file is too small for this operation to complete. (os error 1455)"
+
+
+def test_the_paging_file_error_does_not_send_the_user_to_flush(gen):
+    """The reporter saw a bare 500 and reasonably wondered whether OmniVoice
+    needs the internet. It does not — this is a Windows virtual-memory setting.
+
+    The old path matched the OOM branch and said "Try the Flush button", which
+    cannot work: the hint we already had for this class says outright that
+    closing other apps usually will not fix it.
+    """
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError(_1334))
+    msg = str(caught.value)
+    assert "paging file" in msg.lower()
+    assert "Flush cannot help" in msg
+    assert "Try the Flush button" not in msg
+
+
+def test_the_paging_file_message_says_it_is_not_a_network_problem(gen):
+    """Directly answering what #1334 asked: it correlated with being offline,
+    and the correlation is a coincidence."""
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError(_1334))
+    assert "not a network problem" in str(caught.value).lower()
+
+
+def test_the_paging_file_message_carries_the_actual_instructions(gen):
+    """Naming the cause without the remedy would still leave them stuck."""
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError(_1334))
+    assert "Virtual memory" in str(caught.value)
+
+
+@pytest.mark.parametrize("text", [
+    _1334,
+    "[WinError 1455] The paging file is too small for this operation to complete",
+    "os error 1455",
+])
+def test_both_spellings_are_recognised(gen, text):
+    """Python (`WinError 1455`) and Rust (`os error 1455`, from the safetensors
+    mmap) word this differently."""
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError(text))
+    assert "Flush cannot help" in str(caught.value)
+
+
+def test_a_real_oom_still_gets_the_flush_hint(gen):
+    """The new branch runs first, so pin it did not swallow genuine OOM."""
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError("CUDA out of memory. Tried to allocate 2 GiB"))
+    assert "Try the Flush button" in str(caught.value)
+
+
+def test_the_raw_500_surface_now_carries_the_paging_file_hint():
+    """The reporter's message arrived as a bare 500 with only the OS sentence:
+    the class was classified correctly but its hint was never attached, because
+    it was absent from the context-free set."""
+    assert failure.classify(_1334) == "WINDOWS_PAGING_FILE_TOO_SMALL"
+    appended = failure.append_hint(_1334)
+    assert appended != _1334, "the raw-500 surface still gives the user nothing"
+    assert "Virtual memory" in appended

--- a/tests/test_network_beats_install_diagnosis.py
+++ b/tests/test_network_beats_install_diagnosis.py
@@ -45,7 +45,11 @@ os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
 
-from core import failure  # noqa: E402
+@pytest.fixture
+def failure():
+    """Resolve at call time — sibling suites reload/purge these modules, so a
+    module-level import would go stale and make these order-dependent."""
+    return importlib.import_module("core.failure")
 
 
 @pytest.fixture
@@ -64,11 +68,11 @@ _1347 = (
 )
 
 
-def test_the_reported_message_is_not_called_a_broken_install():
+def test_the_reported_message_is_not_called_a_broken_install(failure):
     assert failure.classify(_1347) == "MODEL_DOWNLOAD_INTERRUPTED"
 
 
-def test_the_hint_does_not_tell_them_to_reinstall():
+def test_the_hint_does_not_tell_them_to_reinstall(failure):
     """The specific harm: reinstalling transformers cannot fix a dropped
     connection, so the old advice was work that could never succeed."""
     hint = failure._HINTS["MODEL_DOWNLOAD_INTERRUPTED"]
@@ -77,13 +81,13 @@ def test_the_hint_does_not_tell_them_to_reinstall():
     assert "retry" in hint.lower()
 
 
-def test_the_hint_says_the_partial_download_is_kept():
+def test_the_hint_says_the_partial_download_is_kept(failure):
     """Otherwise a user on a slow link assumes retrying restarts a multi-GB
     download and gives up instead."""
     assert "resumed" in failure._HINTS["MODEL_DOWNLOAD_INTERRUPTED"].lower()
 
 
-def test_a_genuinely_broken_install_still_says_so():
+def test_a_genuinely_broken_install_still_says_so(failure):
     """The ordering must not swallow the case TRANSFORMERS_IMPORT exists for —
     no network signature here, so the install really is the problem."""
     assert failure.classify(
@@ -95,7 +99,7 @@ def test_a_genuinely_broken_install_still_says_so():
     ) == "TRANSFORMERS_IMPORT"
 
 
-def test_a_closed_client_without_an_import_is_left_alone():
+def test_a_closed_client_without_an_import_is_left_alone(failure):
     """The rule requires BOTH halves. A bare closed-client error elsewhere must
     not be given a transformers-flavoured explanation."""
     assert failure.classify("Cannot send a request, as the client has been closed") != (
@@ -103,7 +107,7 @@ def test_a_closed_client_without_an_import_is_left_alone():
     )
 
 
-def test_the_class_carries_a_hint_and_is_safe_context_free():
+def test_the_class_carries_a_hint_and_is_safe_context_free(failure):
     evt = failure.build_failure(_1347, stage="transcribe", include_diagnostic=False)
     assert evt["docs_topic"] == "MODEL_DOWNLOAD_INTERRUPTED"
     assert evt["hint"]
@@ -138,7 +142,7 @@ def test_the_generate_message_says_retry_not_flush(gen):
     assert "ran out of memory" not in msg
 
 
-def test_the_shared_taxonomy_still_names_it_precisely():
+def test_the_shared_taxonomy_still_names_it_precisely(failure):
     """core/failure.py distinguishes a CUT connection from a failed handshake —
     the certifi/proxy advice would send the user to fix working trust."""
     assert failure.classify(_1335) == "TLS_CONNECTION_DROPPED"
@@ -209,7 +213,7 @@ def test_a_real_oom_still_gets_the_flush_hint(gen):
     assert "Try the Flush button" in str(caught.value)
 
 
-def test_the_raw_500_surface_now_carries_the_paging_file_hint():
+def test_the_raw_500_surface_now_carries_the_paging_file_hint(failure):
     """The reporter's message arrived as a bare 500 with only the OS sentence:
     the class was classified correctly but its hint was never attached, because
     it was absent from the context-free set."""
@@ -217,3 +221,45 @@ def test_the_raw_500_surface_now_carries_the_paging_file_hint():
     appended = failure.append_hint(_1334)
     assert appended != _1334, "the raw-500 surface still gives the user nothing"
     assert "Virtual memory" in appended
+
+
+# ── the over-broad-match guards (CodeRabbit on #1374) ─────────────────────
+
+def test_a_non_tls_eof_is_not_called_a_network_failure(gen):
+    """The EOF wording is OpenSSL's, but nothing stops an unrelated component
+    from saying something similar. Mislabelling a local fault as a network
+    problem sends the user to check a connection that was never involved, so
+    the match is gated on an `ssl` marker."""
+    assert gen._is_network_failure(
+        RuntimeError("parser: EOF occurred in violation of protocol frame 3")
+    ) is False
+    assert gen._is_network_failure(
+        RuntimeError("codec reported unexpected_eof_while_reading the container")
+    ) is False
+
+
+def test_the_real_openssl_message_still_matches(gen):
+    """...and the gate must not cost us the case it exists for."""
+    assert gen._is_network_failure(RuntimeError(
+        "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of "
+        "protocol (_ssl.c:1016)"
+    )) is True
+
+
+@pytest.mark.parametrize("text", [
+    # "cannot send a request" without the closed-client half: too generic to
+    # override the reinstall advice, which would then never succeed either.
+    "Cannot send a request during import of transformers.models.whisper",
+    "import failed: cannot send a request to the local server",
+])
+def test_a_partial_closed_client_phrase_does_not_override_the_install_advice(
+    failure, text
+):
+    assert failure.classify(text) != "MODEL_DOWNLOAD_INTERRUPTED"
+
+
+def test_the_full_closed_client_signature_still_wins(failure):
+    assert failure.classify(
+        "AutoFeatureExtractor import failed. Cannot send a request, as the "
+        "client has been closed."
+    ) == "MODEL_DOWNLOAD_INTERRUPTED"

--- a/tests/test_network_beats_install_diagnosis.py
+++ b/tests/test_network_beats_install_diagnosis.py
@@ -1,0 +1,145 @@
+"""A failed download must not be diagnosed as a broken install (#1347, #1335).
+
+Two reports, one shape: the error text carried BOTH a network cause and a
+downstream symptom, the taxonomy matched the symptom first, and the user was
+sent to fix something that was never broken.
+
+**#1347** — transcription failed with:
+
+    transformers ASR pipeline failed to import (AutoFeatureExtractor) — your
+    transformers install is incomplete; reinstall with `uv pip install
+    --reinstall transformers` … Underlying: Cannot send a request, as the
+    client has been closed.
+
+The install is fine. The pipeline was *downloading* the feature extractor when
+the shared HTTP client closed underneath it (#880). Reinstalling transformers
+cannot fix a dropped connection, so the advice was not merely unhelpful — it
+was work the user could do forever without succeeding.
+
+**#1335** — a cut TLS connection reached /generate as a bare 500 carrying
+`_ssl.c:1016`. `core/failure.py` has classified that since #1301, but /generate
+keeps its own taxonomy and never learned it, so it fell to the
+"an error OmniVoice doesn't recognize" catch-all.
+
+Both fixes are orderings, not new detections: the cause is checked before the
+symptom.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+from core import failure  # noqa: E402
+
+
+@pytest.fixture
+def gen():
+    return importlib.import_module("api.routers.generation")
+
+
+# ── #1347: the download died, the install is fine ─────────────────────────
+
+#: The reporter's message, trimmed but structurally intact.
+_1347 = (
+    "transformers ASR pipeline failed to import (AutoFeatureExtractor) — your "
+    "transformers install is incomplete; reinstall with `uv pip install "
+    "--reinstall transformers`. Underlying: Cannot send a request, as the "
+    "client has been closed."
+)
+
+
+def test_the_reported_message_is_not_called_a_broken_install():
+    assert failure.classify(_1347) == "MODEL_DOWNLOAD_INTERRUPTED"
+
+
+def test_the_hint_does_not_tell_them_to_reinstall():
+    """The specific harm: reinstalling transformers cannot fix a dropped
+    connection, so the old advice was work that could never succeed."""
+    hint = failure._HINTS["MODEL_DOWNLOAD_INTERRUPTED"]
+    assert "reinstall" in hint.lower(), "the hint should address the old advice"
+    assert "won't help" in hint.lower() or "nothing is wrong" in hint.lower()
+    assert "retry" in hint.lower()
+
+
+def test_the_hint_says_the_partial_download_is_kept():
+    """Otherwise a user on a slow link assumes retrying restarts a multi-GB
+    download and gives up instead."""
+    assert "resumed" in failure._HINTS["MODEL_DOWNLOAD_INTERRUPTED"].lower()
+
+
+def test_a_genuinely_broken_install_still_says_so():
+    """The ordering must not swallow the case TRANSFORMERS_IMPORT exists for —
+    no network signature here, so the install really is the problem."""
+    assert failure.classify(
+        "Could not import module 'AutoFeatureExtractor'"
+    ) == "TRANSFORMERS_IMPORT"
+    assert failure.classify(
+        "[Errno 2] No such file or directory: "
+        "'/x/site-packages/transformers/models/qwen3/modeling_qwen3.py'"
+    ) == "TRANSFORMERS_IMPORT"
+
+
+def test_a_closed_client_without_an_import_is_left_alone():
+    """The rule requires BOTH halves. A bare closed-client error elsewhere must
+    not be given a transformers-flavoured explanation."""
+    assert failure.classify("Cannot send a request, as the client has been closed") != (
+        "MODEL_DOWNLOAD_INTERRUPTED"
+    )
+
+
+def test_the_class_carries_a_hint_and_is_safe_context_free():
+    evt = failure.build_failure(_1347, stage="transcribe", include_diagnostic=False)
+    assert evt["docs_topic"] == "MODEL_DOWNLOAD_INTERRUPTED"
+    assert evt["hint"]
+    # Its trigger needs two co-occurring strings, so it is safe on raw-string
+    # surfaces (the global 500 handler) where there is no stage.
+    assert "MODEL_DOWNLOAD_INTERRUPTED" in failure._CONTEXT_FREE_HINT_CLASSES
+    appended = failure.append_hint(_1347)
+    assert appended != _1347, "the raw-500 surface got no hint appended"
+    assert failure._HINTS["MODEL_DOWNLOAD_INTERRUPTED"] in appended
+
+
+# ── #1335: a cut TLS connection on the generate path ──────────────────────
+
+_1335 = (
+    "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol "
+    "(_ssl.c:1016)"
+)
+
+
+def test_a_cut_tls_connection_is_a_network_failure_on_generate(gen):
+    """It was falling through to the unrecognized-error catch-all, so the user
+    saw `_ssl.c:1016` and a suggestion to report it."""
+    assert gen._is_network_failure(RuntimeError(_1335)) is True
+
+
+def test_the_generate_message_says_retry_not_flush(gen):
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError(_1335))
+    msg = str(caught.value)
+    assert "network" in msg.lower()
+    assert "doesn't recognize" not in msg
+    assert "ran out of memory" not in msg
+
+
+def test_the_shared_taxonomy_still_names_it_precisely():
+    """core/failure.py distinguishes a CUT connection from a failed handshake —
+    the certifi/proxy advice would send the user to fix working trust."""
+    assert failure.classify(_1335) == "TLS_CONNECTION_DROPPED"
+    assert failure.classify(
+        "SSLCertVerificationError: certificate verify failed"
+    ) == "SSL_HANDSHAKE_FAILURE"
+
+
+def test_an_ordinary_generate_failure_is_still_unrecognized(gen):
+    with pytest.raises(RuntimeError) as caught:
+        gen._oom_friendly_reraise(RuntimeError("tensor shape mismatch"))
+    assert "doesn't recognize" in str(caught.value)


### PR DESCRIPTION
Fixes #1347, #1335 and #1334. Three reports, one class of defect: **the taxonomy gave the user advice that could not possibly work**, either because it matched a symptom instead of the cause, or because a hint we had already written never reached the surface they saw.

## #1347 — reinstall advice that could never work

```
transformers ASR pipeline failed to import (AutoFeatureExtractor) — your
transformers install is incomplete; reinstall with `uv pip install --reinstall
transformers` … Underlying: Cannot send a request, as the client has been closed.
```

The install is fine. The pipeline was **downloading** the feature extractor when the shared HTTP client closed underneath it (#880). Reinstalling transformers cannot fix a dropped connection — this was work the reporter could repeat forever without succeeding.

New `MODEL_DOWNLOAD_INTERRUPTED`, checked **before** the import rules, requiring the httpx closed-client wording **and** an import/transformers term together so a bare closed-client error elsewhere is untouched. The hint says the partial download resumes — otherwise someone on a slow link assumes retrying restarts a multi-GB fetch and gives up.

## #1335 — `_ssl.c:1016` on generate

A cut TLS connection reached `/generate` as a bare 500. `core/failure.py` has classified this since #1301, but `/generate` keeps its own taxonomy and never learned it, so it hit the unrecognized-error catch-all.

For triage: #1301 landed *after* v0.4.2, so the reporter's build had no classification on any surface. On `main` they would already get the appended hint — but the "an error OmniVoice doesn't recognize" framing was still wrong.

## #1334 — "does OmniVoice need the internet?"

The reporter asked directly, because generation failed only when they disconnected, with a bare 500 carrying `The paging file is too small for this operation to complete (os error 1455)`. Two defects made that unanswerable:

1. `/generate` matched it in `_is_oom_failure` and said **"Try the Flush button"**. Flush cannot help — the hint we had already written for this exact class says so outright ("closing other apps usually won't fix it"), but the generate path never consulted it.
2. `WINDOWS_PAGING_FILE_TOO_SMALL` was missing from `_CONTEXT_FREE_HINT_CLASSES`, so on the raw-500 surface `classify()` identified it correctly and then attached **nothing**. The user got the OS sentence and no next step, while the full remedy sat unused in `_HINTS`.

The answer to their question is no, and the message now says so: it names the virtual-memory setting and states plainly that this is not a network problem.

## Non-regressions, all asserted

- a genuinely broken transformers install still classifies as `TRANSFORMERS_IMPORT` (both the `ImportError` and missing-`site-packages`-file forms)
- a failed handshake is still distinguished from a cut connection, so nobody gets certifi/proxy advice for working trust
- a real CUDA OOM still gets the Flush hint
- both the Python (`WinError 1455`) and Rust (`os error 1455`, safetensors mmap) spellings are covered

## Tests

`tests/test_network_beats_install_diagnosis.py` — 18 cases, using the reported strings verbatim.

**Note on the full sweep:** `tests/test_capture_ws.py` fails 3 tests for me in a loaded full-suite run and passes in isolation. Not from this change — main's CI is green on the same suite, and those tests assert a 0.3 s budget against a 3 s sleep, which is timing-sensitive under load. Flagging it as a flake worth hardening separately rather than leaving it unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Classify interrupted model downloads before Transformers installation errors, including closed-client import failures, and classify TLS disconnects during `/generate` as network failures. Add Windows paging-file error handling so users receive virtual-memory guidance instead of OOM or network guidance. Preserve genuine installation, TLS handshake, and OOM classifications with regression tests; review the matching precedence for future error-string changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->