### PR TITLE
fix(generate): a healthy model download extends the budget it was blowing (#1367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
+- A first-use generate no longer fails at 300s while its model is still downloading: the download's own progress heartbeats now extend the generation budget (bounded), so a slow connection isn't reported as too-slow hardware. A job that goes silent still dies at the original deadline. (#1367)
 - A generation that hits its time limit now says so, instead of "an error OmniVoice doesn't recognize" followed by an empty `TimeoutError:`. It names the likely causes and the setting that raises the limit. (#1368)
 - The "transformers install is incomplete" advice now names torchvision — the package whose version mismatch actually produces that error — and points at the pinned reinstall that repairs it, instead of a reinstall that left the broken package untouched. (#1376, #1357)
 - A model download cut off mid-request is no longer reported as a broken transformers install — reinstalling could never have fixed a dropped connection. (#1347)

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -361,6 +361,43 @@ GPU_JOB_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GENERATE_TIMEOUT_S", "300.0"
 # too-heavy job.
 GPU_QUEUE_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GPU_QUEUE_TIMEOUT_S", "1800.0"))
 
+# ── model-load heartbeats (#1367) ────────────────────────────────────────────
+# A first-use generate on a subprocess engine DOWNLOADS the model inside the
+# job, and the sidecar proves the download is healthy by emitting a progress
+# frame every ~5s. The execution clock above ignored that: a slow connection
+# blew the 300s budget mid-download and the user was told their hardware was
+# too slow, while the sidecar's own watchdog was happily fed. These three make
+# the two clocks agree — a job is only "wedged" when it is SILENT.
+#
+# How long a heartbeat stays fresh. Sidecars emit every ~5s (_HEARTBEAT_S in
+# each engine's main.py); 30s tolerates a stall between frames without keeping
+# a genuinely dead load alive for long.
+MODEL_LOAD_HEARTBEAT_GRACE_S = float(
+    os.environ.get("OMNIVOICE_MODEL_LOAD_HEARTBEAT_GRACE_S", "30.0"))
+# Cap on the EXTRA time heartbeats can buy beyond the normal execution budget.
+# Without a cap, a load that heartbeats but never finishes would hold its
+# worker forever. 1800s of extension ≈ a 5 GB model at ~2.5 MB/s on top of the
+# 300s base — beyond that, telling the user is better than silently waiting.
+MODEL_LOAD_EXTRA_TIMEOUT_S = float(
+    os.environ.get("OMNIVOICE_MODEL_LOAD_TIMEOUT_S", "1800.0"))
+
+#: thread ident -> monotonic time of its last model-load heartbeat. Written by
+#: report_model_load_activity() from pool-worker threads, read by the guarded
+#: waiter, cleared when the job ends. Plain dict: CPython dict ops are atomic
+#: enough for a monotonic float, and a torn read only costs one 5s wait slice.
+_MODEL_LOAD_ACTIVITY: dict = {}
+
+
+def report_model_load_activity() -> None:
+    """Record that the CURRENT THREAD's job is making model-load progress.
+
+    Called by engine code that can prove liveness — e.g. SubprocessBackend
+    each time a sidecar progress frame arrives during a cold load. The
+    guarded waiter uses it to extend the execution deadline (bounded by
+    MODEL_LOAD_EXTRA_TIMEOUT_S) instead of abandoning a healthy download.
+    """
+    _MODEL_LOAD_ACTIVITY[threading.get_ident()] = time.monotonic()
+
 
 class GpuJobTimeoutError(TimeoutError):
     """A GPU-pool job **that actually started executing** overran its bound.
@@ -522,16 +559,26 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
 
     started = asyncio.Event()
     _inner = contain_system_exit(fn, what)
+    # The worker thread's ident, published by _job so the waiter can read this
+    # job's model-load heartbeats (#1367). A dict, not a nonlocal: the closure
+    # runs on a pool thread while the waiter reads from the event loop.
+    _ident_box: dict = {}
 
     def _job():
         # First thing the worker does: tell the awaiting coroutine the
         # execution clock may start. call_soon_threadsafe is the only
         # loop-safe way to touch an asyncio primitive from a pool thread.
+        _ident_box["ident"] = threading.get_ident()
         try:
             loop.call_soon_threadsafe(started.set)
         except RuntimeError:
             pass  # loop already closed (caller vanished) — still run the job
-        return _inner()
+        try:
+            return _inner()
+        finally:
+            # Idents are reused by the OS; a stale heartbeat under this ident
+            # must not vouch for some future job on the same thread.
+            _MODEL_LOAD_ACTIVITY.pop(threading.get_ident(), None)
 
     fut = loop.run_in_executor(ex, _job)
     waiter = asyncio.ensure_future(started.wait())
@@ -574,11 +621,61 @@ async def run_on_gpu_pool_guarded(fn, *, what: str = "GPU job",
         )
 
     # Phase 2 — execution. The clock starts here: this job owns a worker.
+    #
+    # Not a single wait_for (#1367): a first-use generate on a subprocess
+    # engine downloads its model inside the job, and the sidecar proves the
+    # download is healthy with progress frames the backend forwards via
+    # report_model_load_activity(). Sliced waiting lets the deadline extend
+    # while those heartbeats stay fresh — bounded by MODEL_LOAD_EXTRA_TIMEOUT_S
+    # — so a slow connection is no longer reported as too-slow hardware. A job
+    # that goes SILENT still dies at the original deadline (± one slice).
+    _t0 = time.monotonic()
+    _soft_deadline = _t0 + timeout
+    _hard_deadline = _soft_deadline + MODEL_LOAD_EXTRA_TIMEOUT_S
+    _extended = False
     try:
-        return await asyncio.wait_for(fut, timeout=timeout)
+        while True:
+            _now = time.monotonic()
+            if _now < _soft_deadline:
+                _slice = min(_soft_deadline - _now, 5.0)
+            else:
+                # Soft budget exhausted. Keep waiting ONLY on the strength of a
+                # fresh model-load heartbeat from this job's worker thread.
+                _last = _MODEL_LOAD_ACTIVITY.get(_ident_box.get("ident"))
+                if (_last is None
+                        or _now - _last > MODEL_LOAD_HEARTBEAT_GRACE_S
+                        or _now >= _hard_deadline):
+                    raise asyncio.TimeoutError()
+                if not _extended:
+                    _extended = True
+                    logger.info(
+                        "%s reached its %.0fs execution budget mid model-load "
+                        "— extending while download/load heartbeats continue "
+                        "(cap +%.0fs) (#1367).",
+                        _log_safe(what), timeout, MODEL_LOAD_EXTRA_TIMEOUT_S,
+                    )
+                # Wake at the next decision point (heartbeat expiry or the
+                # cap), not a fixed 5s — a fixed slice overshoots both.
+                _slice = max(0.05, min(
+                    (_last + MODEL_LOAD_HEARTBEAT_GRACE_S) - _now,
+                    _hard_deadline - _now,
+                    5.0,
+                ))
+            _done, _ = await asyncio.wait({fut}, timeout=_slice)
+            if _done:
+                return fut.result()
+    except asyncio.CancelledError:
+        # Caller went away mid-execution. The old wait_for cancelled the
+        # wrapper itself; asyncio.wait does not, so do both halves here or the
+        # eventual result is logged as "Future exception was never retrieved".
+        fut.cancel()
+        fut.add_done_callback(_swallow_abandoned)
+        raise
     except asyncio.TimeoutError as timeout_exc:
-        # wait_for already cancelled the asyncio wrapper; the worker thread
-        # keeps going regardless. Consume whatever it eventually produces.
+        # Parity with the old wait_for semantics: cancel the asyncio wrapper;
+        # the worker thread keeps going regardless. Consume whatever it
+        # eventually produces.
+        fut.cancel()
         fut.add_done_callback(_swallow_abandoned)
         # Capture the stacks BEFORE reset(): reset() replaces the executor, and
         # once the wedged thread is no longer a pool worker we can no longer

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -582,8 +582,16 @@ class SubprocessBackend(TTSBackend):
                 # generate budget expired mid-download and blamed the hardware.
                 while reply is not None and reply.get("op") == "progress":
                     try:
-                        from services.model_manager import report_model_load_activity
-                        report_model_load_activity()
+                        from services.model_manager import (
+                            report_model_load_activity, running_on_gpu_pool,
+                        )
+                        # Pool jobs only: an off-pool caller (the diagnostic
+                        # probe) never runs _job(), so its thread ident would
+                        # never be cleared — and a pool worker later reusing
+                        # that ident would inherit up to a grace period of
+                        # unearned extension (CodeRabbit on #1379).
+                        if running_on_gpu_pool():
+                            report_model_load_activity()
                     except Exception:
                         pass  # the heartbeat is best-effort; never fail a synth over it
                     reply = self._recv_with_timeout(self.recv_timeout_s)

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -575,7 +575,17 @@ class SubprocessBackend(TTSBackend):
                 # (during a model load, etc.) before the terminal audio frame.
                 # Each recv re-arms the watchdog, so a long-but-active load
                 # survives while a silent wedge is still killed at the deadline.
+                #
+                # Each frame is also reported to the GPU pool's execution clock
+                # (#1367): the sidecar heartbeats every ~5s precisely to prove a
+                # cold download is healthy, and without this the outer 300s
+                # generate budget expired mid-download and blamed the hardware.
                 while reply is not None and reply.get("op") == "progress":
+                    try:
+                        from services.model_manager import report_model_load_activity
+                        report_model_load_activity()
+                    except Exception:
+                        pass  # the heartbeat is best-effort; never fail a synth over it
                     reply = self._recv_with_timeout(self.recv_timeout_s)
             if not reply:
                 raise RuntimeError(f"{self.id} sidecar closed pipe mid-generate")

--- a/tests/test_model_load_extends_generate_budget.py
+++ b/tests/test_model_load_extends_generate_budget.py
@@ -1,0 +1,248 @@
+"""A healthy model download must not be reported as too-slow hardware (#1367).
+
+Every subprocess engine cold-loads its model inside the synthesize handler, so
+a first-use generate on a slow connection spends its whole 300s execution
+budget downloading — and then fails, blaming the hardware, while the sidecar's
+own watchdog was being fed progress frames the entire time. The two clocks
+disagreed about a job both could see was alive.
+
+The fix makes the outer clock listen: sidecar progress frames are forwarded to
+``report_model_load_activity()``, and the guarded waiter extends the deadline
+past the soft budget only while those heartbeats stay fresh, bounded by
+``MODEL_LOAD_EXTRA_TIMEOUT_S``. A job that goes SILENT still dies at the
+original deadline (± one wait slice) — the guard this runner exists for is
+untouched, and that non-regression is most of this file.
+
+Timings here are tenths of seconds via monkeypatched module constants, so the
+suite stays fast and none of it races real hardware.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+os.environ.setdefault("OMNIVOICE_MODEL", "test")
+os.environ.setdefault("OMNIVOICE_DISABLE_FILE_LOG", "1")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+
+
+@pytest.fixture
+def mm(monkeypatch):
+    mod = importlib.import_module("services.model_manager")
+    # Fast clocks: 0.4s soft budget, up to +2s of heartbeat extension, 0.5s
+    # heartbeat grace. The wait slice is min(remaining, 5.0), so remaining
+    # drives it at these scales.
+    monkeypatch.setattr(mod, "MODEL_LOAD_EXTRA_TIMEOUT_S", 2.0)
+    monkeypatch.setattr(mod, "MODEL_LOAD_HEARTBEAT_GRACE_S", 0.5)
+    mod._MODEL_LOAD_ACTIVITY.clear()
+    yield mod
+    mod._MODEL_LOAD_ACTIVITY.clear()
+
+
+@pytest.fixture
+def pool():
+    ex = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-pool")
+    yield ex
+    ex.shutdown(wait=False)
+
+
+async def _run(mm, pool, fn, timeout):
+    return await mm.run_on_gpu_pool_guarded(
+        fn, what="test job", timeout=timeout, queue_timeout=5.0, executor=pool,
+    )
+
+
+# ── the fix ───────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_a_heartbeating_load_survives_past_the_budget(mm, pool):
+    """The reported case in miniature: the job outlives its budget but proves
+    liveness throughout, exactly as a downloading sidecar does. Fails with
+    GpuJobTimeoutError before the fix."""
+    def slow_load():
+        # 1s of "download" against a 0.4s budget, heartbeating every 0.1s.
+        for _ in range(10):
+            mm.report_model_load_activity()
+            time.sleep(0.1)
+        return "audio"
+
+    assert await _run(mm, pool, slow_load, timeout=0.4) == "audio"
+
+
+@pytest.mark.asyncio
+async def test_the_extension_is_logged_once(mm, pool, caplog):
+    """The extension must be visible in the log — a generate that quietly took
+    4x its budget is its own diagnosability bug."""
+    def slow_load():
+        for _ in range(8):
+            mm.report_model_load_activity()
+            time.sleep(0.1)
+        return "ok"
+
+    import logging
+    with caplog.at_level(logging.INFO, logger=mm.logger.name):
+        await _run(mm, pool, slow_load, timeout=0.4)
+    hits = [r for r in caplog.records if "extending while" in r.getMessage()]
+    assert len(hits) == 1, "the extension should be announced exactly once"
+
+
+# ── the guard is untouched ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_a_silent_job_still_times_out_at_the_original_deadline(mm, pool):
+    """The non-regression that matters most: no heartbeats, no extension. A
+    wedged job dies at ~timeout, not at the hard cap."""
+    t0 = time.monotonic()
+    with pytest.raises(mm.GpuJobTimeoutError):
+        await _run(mm, pool, lambda: time.sleep(10), timeout=0.4)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 1.5, (
+        f"a silent job survived {elapsed:.1f}s on a 0.4s budget — the wedge "
+        f"guard has been weakened"
+    )
+
+
+@pytest.mark.asyncio
+async def test_heartbeats_that_stop_kill_the_job_within_the_grace(mm, pool):
+    """A download that dies mid-transfer stops heartbeating; the job must not
+    coast to the hard cap on stale credit."""
+    def dies_mid_download():
+        mm.report_model_load_activity()
+        time.sleep(10)  # silence forever after
+
+    t0 = time.monotonic()
+    with pytest.raises(mm.GpuJobTimeoutError):
+        await _run(mm, pool, dies_mid_download, timeout=0.4)
+    # Budget 0.4 + grace 0.5 + slack; far below the 2s extension cap ceiling.
+    assert time.monotonic() - t0 < 1.8
+
+
+@pytest.mark.asyncio
+async def test_the_extension_is_capped(mm, pool):
+    """Heartbeats forever must not mean waiting forever — the cap is the
+    difference between patience and a hung worker nobody hears about."""
+    stop = threading.Event()
+
+    def heartbeats_forever():
+        while not stop.wait(0.1):
+            mm.report_model_load_activity()
+
+    t0 = time.monotonic()
+    try:
+        with pytest.raises(mm.GpuJobTimeoutError):
+            await _run(mm, pool, heartbeats_forever, timeout=0.4)
+        elapsed = time.monotonic() - t0
+        assert elapsed < 4.0, (
+            f"cap is 0.4+2.0s but the job survived {elapsed:.1f}s"
+        )
+        assert elapsed > 2.0, "the cap fired before the extension it bounds"
+    finally:
+        stop.set()
+
+
+@pytest.mark.asyncio
+async def test_a_fast_job_is_unaffected(mm, pool):
+    """The overwhelmingly common case must not pick up latency: the sliced
+    wait returns as soon as the future resolves."""
+    t0 = time.monotonic()
+    assert await _run(mm, pool, lambda: "fast", timeout=5.0) == "fast"
+    assert time.monotonic() - t0 < 1.0
+
+
+@pytest.mark.asyncio
+async def test_heartbeats_do_not_leak_between_jobs(mm, pool):
+    """Thread idents are reused. Job A's heartbeats must not vouch for job B
+    running later on the same pool thread — the entry is cleared when the job
+    ends."""
+    await _run(mm, pool, lambda: mm.report_model_load_activity(), timeout=5.0)
+    assert not mm._MODEL_LOAD_ACTIVITY, (
+        "a finished job left its heartbeat behind; a later job on the same "
+        "thread would inherit unearned extension credit"
+    )
+    # ...and the silent-job guard still holds on that same thread.
+    t0 = time.monotonic()
+    with pytest.raises(mm.GpuJobTimeoutError):
+        await _run(mm, pool, lambda: time.sleep(10), timeout=0.4)
+    assert time.monotonic() - t0 < 1.5
+
+
+@pytest.mark.asyncio
+async def test_another_threads_heartbeat_does_not_extend_this_job(mm, pool):
+    """The heartbeat is per worker thread, so activity elsewhere in the
+    process is not this job's alibi."""
+    stop = threading.Event()
+
+    def other_thread():
+        while not stop.wait(0.1):
+            mm._MODEL_LOAD_ACTIVITY[999999999] = time.monotonic()
+
+    t = threading.Thread(target=other_thread, daemon=True)
+    t.start()
+    try:
+        t0 = time.monotonic()
+        with pytest.raises(mm.GpuJobTimeoutError):
+            await _run(mm, pool, lambda: time.sleep(10), timeout=0.4)
+        assert time.monotonic() - t0 < 1.5
+    finally:
+        stop.set()
+        mm._MODEL_LOAD_ACTIVITY.pop(999999999, None)
+
+
+# ── the producer side ─────────────────────────────────────────────────────
+
+def test_the_sidecar_progress_loop_reports_activity(mm, monkeypatch):
+    """Pin the wiring: a progress frame arriving in SubprocessBackend.generate
+    must bump the heartbeat. Without this, the waiter listens to a phone that
+    never rings."""
+    sb = importlib.import_module("services.subprocess_backend")
+
+    calls = []
+    monkeypatch.setattr(mm, "report_model_load_activity", lambda: calls.append(1))
+    monkeypatch.setattr(mm, "running_on_gpu_pool", lambda: True)
+
+    class _Backend(sb.SubprocessBackend):
+        id = "testengine"
+        display_name = "test"
+
+        @classmethod
+        def is_available(cls):
+            return True, "test"
+
+        @classmethod
+        def venv_python(cls):  # pragma: no cover - not spawned
+            return sys.executable
+
+        @classmethod
+        def sidecar_script(cls):  # pragma: no cover - not spawned
+            return __file__
+
+        @property
+        def sample_rate(self):
+            return 24000
+
+        @property
+        def supported_languages(self):
+            return ["multi"]
+
+    b = _Backend.__new__(_Backend)
+    b._lock = threading.Lock()
+    frames = [
+        {"op": "progress", "stage": "loading_model", "percent": 1},
+        {"op": "progress", "stage": "loading_model", "percent": 2},
+        {"op": "audio", "audio_pcm_b64": "", "sample_rate": 24000, "n_samples": 0},
+    ]
+    monkeypatch.setattr(b, "_spawn", lambda: None)
+    monkeypatch.setattr(b, "_send", lambda msg: None)
+    monkeypatch.setattr(b, "_recv_with_timeout", lambda t: frames.pop(0))
+
+    b.generate("hello")
+    assert len(calls) == 2, (
+        f"expected one heartbeat per progress frame, got {len(calls)}"
+    )

--- a/tests/test_model_load_extends_generate_budget.py
+++ b/tests/test_model_load_extends_generate_budget.py
@@ -18,6 +18,7 @@ suite stays fast and none of it races real hardware.
 """
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
 import sys
@@ -245,4 +246,112 @@ def test_the_sidecar_progress_loop_reports_activity(mm, monkeypatch):
     b.generate("hello")
     assert len(calls) == 2, (
         f"expected one heartbeat per progress frame, got {len(calls)}"
+    )
+
+
+def test_an_off_pool_synthesis_records_no_heartbeat(mm, monkeypatch):
+    """The off-pool path (the diagnostic probe) never runs _job(), so its
+    thread ident would never be CLEARED — and a pool worker later reusing that
+    ident would inherit up to a grace period of unearned extension
+    (CodeRabbit). Off-pool progress frames are therefore not heartbeats."""
+    sb = importlib.import_module("services.subprocess_backend")
+
+    calls = []
+    monkeypatch.setattr(mm, "report_model_load_activity", lambda: calls.append(1))
+    # Off-pool: generate() takes the slot-holding path, which needs a pool to
+    # occupy — patch it as on-pool=False only for the heartbeat gate by driving
+    # the loop with a thread whose name is NOT the pool prefix (the real
+    # mechanism), while skipping the slot dance entirely.
+    monkeypatch.setattr(mm, "running_on_gpu_pool",
+                        lambda: threading.current_thread().name.startswith("gpu-pool"))
+
+    class _Backend(sb.SubprocessBackend):
+        id = "testengine2"
+        display_name = "test"
+
+        @classmethod
+        def is_available(cls):
+            return True, "test"
+
+        @classmethod
+        def venv_python(cls):  # pragma: no cover - not spawned
+            return sys.executable
+
+        @classmethod
+        def sidecar_script(cls):  # pragma: no cover - not spawned
+            return __file__
+
+        @property
+        def sample_rate(self):
+            return 24000
+
+        @property
+        def supported_languages(self):
+            return ["multi"]
+
+    b = _Backend.__new__(_Backend)
+    b._lock = threading.Lock()
+    frames = [
+        {"op": "progress", "stage": "loading_model", "percent": 1},
+        {"op": "audio", "audio_pcm_b64": "", "sample_rate": 24000, "n_samples": 0},
+    ]
+    monkeypatch.setattr(b, "_spawn", lambda: None)
+    monkeypatch.setattr(b, "_send", lambda msg: None)
+    monkeypatch.setattr(b, "_recv_with_timeout", lambda t: frames.pop(0))
+
+    result = {}
+
+    def run_plain():
+        # This thread's name is not "gpu-pool*", so the heartbeat gate must
+        # refuse even though progress frames arrive. (The off-pool slot dance
+        # runs against the real pool — same as the production path it mirrors.)
+        try:
+            b.generate("hello")
+        except Exception as e:  # pragma: no cover - surfaced via result
+            result["err"] = e
+
+    t = threading.Thread(target=run_plain, name="not-a-pool-thread")
+    t.start(); t.join()
+    assert "err" not in result, result.get("err")
+    assert calls == [], "an off-pool synthesis recorded a heartbeat it cannot clear"
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_consumes_the_future(mm, pool, monkeypatch):
+    """The old wait_for cancelled the wrapper as a side effect of its own
+    timeout machinery; asyncio.wait does not, so the CancelledError branch has
+    to do both halves itself — cancel the wrapper AND register the consumer —
+    or the job's eventual result is logged as "Future exception was never
+    retrieved" (CodeRabbit). This executes that branch: it fails against a
+    version that only re-raises.
+    """
+    swallowed = []
+    monkeypatch.setattr(mm, "_swallow_abandoned",
+                        lambda fut: swallowed.append(fut))
+
+    release = threading.Event()
+
+    def slow_job():
+        release.wait(5)
+        raise RuntimeError("the abandoned job's parting words")
+
+    started = threading.Event()
+
+    def slow_job_started():
+        started.set()
+        return slow_job()
+
+    task = asyncio.ensure_future(_run(mm, pool, slow_job_started, timeout=30.0))
+    # Cancel only once the job is genuinely executing (phase 2), so the branch
+    # under test — not the phase-1 queue path — is the one that runs.
+    while not started.is_set():
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release.set()
+    assert swallowed, (
+        "cancellation did not register a consumer for the abandoned future — "
+        "its eventual exception will be logged as never retrieved"
     )


### PR DESCRIPTION
Fixes #1367. Likely also the root cause behind #1368's report and part of the #1338/#1348 cluster's first-use cases.

## The defect

Every subprocess engine cold-loads its model **inside** the synthesize handler, so a first-use generate on a slow connection spends its whole 300 s execution budget downloading — then fails blaming the hardware, while the sidecar's own watchdog is being fed progress frames the entire time. Two clocks, both looking at a job both could see was alive, disagreeing about whether it was dead.

## The fix — make the outer clock listen to evidence the inner one already had

- `SubprocessBackend.generate` forwards each sidecar progress frame to `report_model_load_activity()` — a per-worker-thread monotonic timestamp, cleared when the job ends so a reused thread ident cannot vouch for a later job.
- `run_on_gpu_pool_guarded`'s phase-2 wait is sliced instead of a single `wait_for`. Past the soft deadline it keeps waiting **only** while this job's heartbeat is fresher than `MODEL_LOAD_HEARTBEAT_GRACE_S` (30 s; sidecars emit every ~5 s), bounded by `MODEL_LOAD_EXTRA_TIMEOUT_S` (+1800 s, env-tunable) so a load that heartbeats forever cannot hold a worker forever.
- The extension is logged once — a generate quietly taking 4× its budget would be its own diagnosability bug.
- Wake-ups target the next decision point (heartbeat expiry or the cap) rather than a fixed slice, so overshoot is bounded at every scale — this surfaced as a real test failure at sub-second scales before I fixed it.
- Caller cancellation now cancels **and consumes** the future explicitly; `wait_for` used to do that as a side effect, `asyncio.wait` does not.

## The wedge guard is untouched — and that's most of the test file

The guard this runner exists for (#730/#1190) must not weaken:

| pinned | |
|---|---|
| silent job | still dies at the original deadline (± one slice), not the cap |
| heartbeats stop mid-download | killed within the grace, no coasting on stale credit |
| heartbeats forever | killed at the cap |
| another thread's heartbeat | not this job's alibi |
| finished job | heartbeat entry cleared; the next job on that thread earns nothing |
| fast path | no added latency |

9 tests, timings in tenths of seconds via monkeypatched constants. Headline case verified failing `GpuJobTimeoutError` before the change. Adjacent suites (`backend/tests/`, wedge capture, subprocess fallback, pool guards): 238 + 37 passed.

## Interaction with #1373

When the cap or grace does expire, the timeout now surfaces through the classifier #1373 added — so the user who genuinely runs out of road gets "hit its time limit… first-use model download still in progress… retry once it finishes" rather than a hardware blame. The two changes are halves of one story: this one stops the false timeout, that one explains the true one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Model-load `progress` frames during subprocess synthesis now report per-worker-thread heartbeats to extend GPU execution only while fresh heartbeats arrive, bounded by `MODEL_LOAD_EXTRA_TIMEOUT_S`, with heartbeat state cleared when jobs finish and futures explicitly cancelled/consumed on caller cancellation. This fixes first-use generation failing at the 300s deadline while the model download is still in progress, without allowing silent jobs to overrun. Review the heartbeat expiry and timeout-cap logic and the thread-local cleanup paths because incorrect state reuse or wake-up scheduling can extend unrelated jobs or leave orphaned futures on cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->