### PR TITLE
fix(first-run): UI scale no longer pushes Continue + HF token off screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
+- First-run wizard: with UI scale above 100%, the Continue button and the Hugging Face token box were pushed below the window edge with no way to scroll to them. The wizard now sizes itself by the same rule as the main app, so the pinned row stays on screen at every scale. (#1382)
 - Dubbing the same video twice no longer ties the second job's cloned voices to the first job's files — deleting the older dub from history was silently turning the newer one's single-segment regens into a default voice. (#1331)
 - ...and deleting a dub whose files an existing saved dub still renders from now keeps those files on disk (the history entry still disappears) — protecting dubs created before this fix, whose references already cross directories. (#1331)
 - An unclean previous shutdown is no longer announced as a crash: the notice says what it actually knows, names the benign causes (sleep, force-quit, a stopped VM), and the one-click bug report is only offered when there is evidence to put in it — an empty report helps nobody. (#1375)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1176,7 +1176,11 @@ function App() {
     // awaiting_setup racing the first poll), the wizard must not steal the
     // mount from the install-plan screen.
     return (
-      <div className="app-wizard-wrap" style={{ zoom: uiScale }}>
+      {/* `--ui-scale`, NOT a bare inline `zoom`: the CSS shrinks the box by
+          the scale and zooms it back (#504 contract, same as .app-container).
+          An inline zoom on top of a full-viewport box pushed the pinned
+          Continue/HF-token row below the window at any scale > 1. */}
+      <div className="app-wizard-wrap" style={{ '--ui-scale': uiScale }}>
         {/* Invisible drag strip across the top 28 px of the wizard —
             matches the macOS traffic-light zone so the window can be
             dragged / double-click-zoomed from anywhere along the top. */}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1175,11 +1175,11 @@ function App() {
     // bootstrap being 'ready': while the stage is still settling (checking /
     // awaiting_setup racing the first poll), the wizard must not steal the
     // mount from the install-plan screen.
+    // `--ui-scale`, NOT a bare inline `zoom`: the CSS shrinks the box by the
+    // scale and zooms it back (#504 contract, same as .app-container). An
+    // inline zoom on top of a full-viewport box pushed the pinned
+    // Continue/HF-token row below the window at any scale > 1.
     return (
-      {/* `--ui-scale`, NOT a bare inline `zoom`: the CSS shrinks the box by
-          the scale and zooms it back (#504 contract, same as .app-container).
-          An inline zoom on top of a full-viewport box pushed the pinned
-          Continue/HF-token row below the window at any scale > 1. */}
       <div className="app-wizard-wrap" style={{ '--ui-scale': uiScale }}>
         {/* Invisible drag strip across the top 28 px of the wizard —
             matches the macOS traffic-light zone so the window can be

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2537,16 +2537,34 @@ input[type="file"]::file-selector-button:hover {
      LogsFooter (studio chrome belongs to the studio), so there is nothing to
      reserve space for. While it did reserve 28px, the wizard's own root was
      `fixed inset-0` and escaped this box anyway — its pinned Continue / HF
-     token row rendered underneath the status bar and was unreachable. */
+     token row rendered underneath the status bar and was unreachable.
+
+     UI scale: SAME contract as .app-container (#504) — the box is shrunk to
+     `100vw/100vh ÷ scale`, then `zoom` magnifies it back to exactly the
+     viewport. The previous shape (`inset: 0` + inline `zoom` on the mount)
+     zoomed a FULL-viewport box, so at any scale > 1 the bottom
+     `(1 − 1/scale)` of the wizard — the pinned Continue button and the HF
+     token card — rendered past the window edge with no scrollbar to reach
+     them (overflow: hidden). At scale 1 nothing showed, which is how it
+     shipped. Guarded by src/test/SetupWizardChrome.test.jsx. */
   position: fixed;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
+  width: calc(100vw / var(--ui-scale, 1));
+  height: calc(100vh / var(--ui-scale, 1));
+  zoom: var(--ui-scale, 1);
   overflow: hidden;
   background: var(--color-bg, #1d2021);
   display: flex;
   flex-direction: column;
+}
+/* Older WebKitGTK (Linux) where `zoom` is a layout no-op (same probe +
+   rationale as the .app-container override above): the shrunk box can't be
+   magnified back, so render at 1.0 filling the window instead. */
+html[data-zoom-layout='off'] .app-wizard-wrap {
+  width: 100vw;
+  height: 100vh;
+  zoom: 1;
 }
 .app-wizard-dragstrip {
   position: fixed; top: 0; left: 0; right: 0;

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -119,6 +119,51 @@ describe('studio chrome does not appear before the studio', () => {
     // A leftover `bottom: var(--logs-footer-height)` would strand a dead 28px
     // gap under the wizard now that no footer is rendered there.
     expect(body).not.toContain('--logs-footer-height');
-    expect(body).toMatch(/bottom:\s*0;/);
+    // The full-viewport promise is now expressed as the #504 scale contract
+    // (viewport ÷ scale, zoomed back) rather than `bottom: 0` — asserted in
+    // detail below.
+    expect(body).toMatch(/height:\s*calc\(100vh/);
+  });
+
+  // The UI-scale regression that shipped in 0.4.2: the wrap was `inset: 0`
+  // (full-viewport box) with a bare inline `zoom` on the mount, so at any
+  // UI scale > 1 the zoomed content overran the window and the pinned
+  // Continue button + HF-token card were pushed below the visible edge —
+  // unreachable, since overflow: hidden means no scrollbar. At scale 1
+  // nothing showed, which is how it survived. The fix is the exact
+  // .app-container contract (#504): shrink the box by the scale, zoom back.
+  describe('UI scale cannot push the pinned row off screen', () => {
+    it('the wrap is shrunk by --ui-scale and zoomed back, like .app-container', () => {
+      const css = readSrc('index.css');
+      const rule = css.slice(css.indexOf('.app-wizard-wrap {'));
+      const body = rule.slice(0, rule.indexOf('}'));
+      expect(body).toMatch(/width:\s*calc\(100vw\s*\/\s*var\(--ui-scale, 1\)\)/);
+      expect(body).toMatch(/height:\s*calc\(100vh\s*\/\s*var\(--ui-scale, 1\)\)/);
+      expect(body).toMatch(/zoom:\s*var\(--ui-scale, 1\)/);
+      // `inset`-style pinning of the bottom edge is the broken shape: a
+      // full-viewport box that zoom then magnifies past the window.
+      expect(body).not.toMatch(/bottom:\s*0/);
+      expect(body).not.toMatch(/right:\s*0/);
+    });
+
+    it('keeps the WebKitGTK zoom-no-op fallback, same as the studio shell', () => {
+      // On engines where `zoom` does not lay out (older WebKitGTK), the
+      // shrunk box cannot be magnified back — without this override the
+      // wizard renders at 1/scale size with a black band around it.
+      const css = readSrc('index.css');
+      expect(css).toMatch(
+        /html\[data-zoom-layout='off'\] \.app-wizard-wrap \{[^}]*zoom:\s*1/,
+      );
+    });
+
+    it('the mount passes --ui-scale and never a bare inline zoom', () => {
+      const app = readSrc('App.jsx');
+      const mount = app.slice(app.indexOf('className="app-wizard-wrap"'));
+      const tag = mount.slice(0, mount.indexOf('>'));
+      expect(tag).toContain("'--ui-scale': uiScale");
+      // An inline `zoom:` on top of the CSS contract double-applies the
+      // scale — the CSS zooms once, this would zoom again.
+      expect(tag).not.toMatch(/zoom:\s*uiScale/);
+    });
   });
 });

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -151,9 +151,7 @@ describe('studio chrome does not appear before the studio', () => {
       // shrunk box cannot be magnified back — without this override the
       // wizard renders at 1/scale size with a black band around it.
       const css = readSrc('index.css');
-      expect(css).toMatch(
-        /html\[data-zoom-layout='off'\] \.app-wizard-wrap \{[^}]*zoom:\s*1/,
-      );
+      expect(css).toMatch(/html\[data-zoom-layout='off'\] \.app-wizard-wrap \{[^}]*zoom:\s*1/);
     });
 
     it('the mount passes --ui-scale and never a bare inline zoom', () => {


### PR DESCRIPTION
Reported with a screenshot: on the Models & Engines step, the model list runs past the window and the pinned Continue button + HF token card sit below the visible edge — unreachable, since `overflow: hidden` means there is no scrollbar.

## Root cause — not the sticky layout

The sticky structure was already correct (#1241 + the wizard scroll-clamp) and is untouched: list scrolls, token card + Continue are `shrink-0` siblings outside the scroller. What defeats it is **UI scale**: `.app-wizard-wrap` was `position: fixed; inset: 0` — a full-viewport box — with a bare inline `zoom: uiScale` on the mount. Zoom magnifies the content of that full-size box, so at any scale > 1 the bottom `(1 − 1/scale)` of the wizard renders past the window edge. At scale 1 nothing shows, which is how it survived both earlier fixes.

## The fix — the contract the app shell already uses

Exactly `.app-container`'s #504 rule: shrink the box to `100vw/100vh ÷ scale`, then `zoom` back to the viewport — plus the same `html[data-zoom-layout='off']` fallback for older WebKitGTK where zoom is a layout no-op (without it, those engines would get a 1/scale-sized wizard in a black band). The mount passes `--ui-scale` as a CSS variable; an inline `zoom` on top would double-apply.

## The "don't break this again" guard

`SetupWizardChrome.test.jsx`, which already pins the sticky structure, gains three cases (**4 of 7 fail against the previous source**):

- the wrap carries the shrink+zoom contract and no `bottom`/`right` pinning (the broken shape)
- the WebKitGTK fallback exists
- the mount passes the variable and never a bare inline `zoom`

Full frontend suite: 1649 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The first-run wizard now uses the app shell’s shrink-and-zoom contract, with a WebKitGTK fallback, so controls remain reachable when `--ui-scale` exceeds 1. The mount passes `--ui-scale` as a CSS variable and avoids double scaling; regression tests cover the layout contract and mount behavior. Review the WebKitGTK fallback for compatibility risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->