### PR TITLE
fix(first-run): the wrapper could grow to the model list's full height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 ### Fixed
 
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
-- First-run wizard: with UI scale above 100%, the Continue button and the Hugging Face token box were pushed below the window edge with no way to scroll to them. The wizard now sizes itself by the same rule as the main app, so the pinned row stays on screen at every scale. (#1382)
+- First-run wizard: the Continue button and the Hugging Face token box were pushed below the window with no way to scroll to them — a layout container grew to the full model list's height, defeating every scroll clamp inside it. The pinned row now stays on screen at every UI scale, with the model list scrolling under it. (#1382, #1383)
 - Dubbing the same video twice no longer ties the second job's cloned voices to the first job's files — deleting the older dub from history was silently turning the newer one's single-segment regens into a default voice. (#1331)
 - ...and deleting a dub whose files an existing saved dub still renders from now keeps those files on disk (the history entry still disappears) — protecting dubs created before this fix, whose references already cross directories. (#1331)
 - An unclean previous shutdown is no longer announced as a crash: the notice says what it actually knows, names the benign causes (sleep, force-quit, a stopped VM), and the one-click bug report is only offered when there is evidence to put in it — an empty report helps nobody. (#1375)

--- a/frontend/src/pages/SetupWizard.jsx
+++ b/frontend/src/pages/SetupWizard.jsx
@@ -300,7 +300,16 @@ export default function SetupWizard({ onReady }) {
     // bar, off the bottom of the window. `pb-4` keeps the pinned row off the
     // very edge now that it really is the last thing on screen.
     <div className="absolute inset-0 flex flex-col items-center overflow-hidden bg-bg px-6 pb-4 pt-12 font-sans text-fg">
-      <div className="flex w-full max-w-[1100px] flex-1 flex-col">
+      {/* min-h-0 is THE fix for the pushed-off-screen Continue button: without
+          it this wrapper's automatic minimum height is its CONTENT height (per
+          flex spec, min-height:auto on a column-flex item resolves to
+          min-content, and the step's flex-basis:auto contributes its full
+          content) — so the wrapper silently grows past the root, the root's
+          overflow-hidden clips everything below the window, and no inner
+          min-h-0/overflow-y-auto clamp further down can ever engage. Measured
+          in a real engine (Chromium): footer at y=3078 in a 900px window
+          without this class; y=884 and the list scrolling with it. */}
+      <div className="flex w-full min-h-0 max-w-[1100px] flex-1 flex-col">
         {/* ── Masthead: identical identity to setup + install acts ────────── */}
         <header
           className="fr-rise flex flex-col gap-3 pb-1"

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -70,6 +70,40 @@ describe('SetupWizard — the pinned action row stays on screen', () => {
     // thing on screen — flush against the window edge is the same bug's
     // cosmetic tail.
     expect(root.className).toMatch(/\bpb-\d/);
+  });
+
+  it('every flex ancestor of the model-list scroller can actually shrink', async () => {
+    // The bug that survived TWO earlier fixes (and shipped in 0.4.2): the
+    // max-w-[1100px] wrapper was `flex-1 flex-col` WITHOUT min-h-0. Per the
+    // flex spec, min-height:auto on a column-flex item resolves to its
+    // min-content height — the full model list — so the wrapper grew past
+    // the root, overflow-hidden clipped everything below the window, and the
+    // inner overflow-y-auto clamp never engaged: Continue and the HF-token
+    // card were simply unreachable. jsdom does no layout, so this pins the
+    // CLASS RULE the layout depends on: every growable flex ancestor between
+    // the scroller and the wizard root must also be allowed to shrink.
+    // Measured for real in Chromium: footer at y=3078 in a 900px window
+    // without min-h-0 on the wrapper; y=884 with it.
+    const { container } = render(withI18n(<SetupWizard onReady={() => {}} />));
+    fireEvent.click(await screen.findByText(/All good — continue/i));
+
+    const scroller = await waitFor(() => {
+      const el = [...container.querySelectorAll('[class*="overflow-y-auto"]')].pop();
+      expect(el).toBeTruthy();
+      return el;
+    });
+    const root = container.firstElementChild;
+    let el = scroller.parentElement;
+    while (el && el !== root) {
+      const cls = el.className || '';
+      if (/\bflex-(1|auto)\b/.test(cls)) {
+        expect(
+          cls,
+          `growable ancestor lacks min-h-0: <${el.tagName.toLowerCase()} class="${cls}">`,
+        ).toMatch(/\bmin-h-0\b/);
+      }
+      el = el.parentElement;
+    }
   });
 
   it('keeps Continue and the HF-token card OUT of the scrolling region', async () => {

--- a/frontend/src/test/SetupWizardChrome.test.jsx
+++ b/frontend/src/test/SetupWizardChrome.test.jsx
@@ -94,9 +94,11 @@ describe('SetupWizard — the pinned action row stays on screen', () => {
     });
     const root = container.firstElementChild;
     let el = scroller.parentElement;
+    let checked = 0;
     while (el && el !== root) {
       const cls = el.className || '';
       if (/\bflex-(1|auto)\b/.test(cls)) {
+        checked += 1;
         expect(
           cls,
           `growable ancestor lacks min-h-0: <${el.tagName.toLowerCase()} class="${cls}">`,
@@ -104,6 +106,12 @@ describe('SetupWizard — the pinned action row stays on screen', () => {
       }
       el = el.parentElement;
     }
+    // The walk must terminate AT the root, not fall off the document — and it
+    // must actually have inspected the growable chain it exists for, or a
+    // refactor that reparents the scroller silently turns this test into a
+    // no-op (CodeRabbit).
+    expect(el).toBe(root);
+    expect(checked).toBeGreaterThanOrEqual(2);
   });
 
   it('keeps Continue and the HF-token card OUT of the scrolling region', async () => {


### PR DESCRIPTION
The owner re-tested after #1382: still broken — at UI scale 1, which the zoom fix doesn't touch. That fix addressed a real hazard, not the bug in the screenshot. Third generation of this defect, so this time it's measured, not reasoned.

## Root cause, measured

The `max-w-[1100px]` wrapper between the wizard root and the step content was `flex-1 flex-col` **without `min-h-0`**. Per the flex spec, `min-height: auto` on a column-flex item resolves to its min-content height, and the step's `flex-basis: auto` contributes its full content — so the wrapper silently grew to the height of the entire model list, the root's `overflow-hidden` clipped everything below the window, and the inner `min-h-0`/`overflow-y-auto` clamps (added by two earlier fixes, #1241 and the wizard scroll-clamp) never had a bounded box to clamp against. Continue + HF token unreachable at any scale.

Verified in a real engine (Playwright/Chromium, DOM replica of the exact class structure):

| | footer bottom | window | scroller scrolls |
|---|---|---|---|
| without `min-h-0` | **3078** | 900 | no |
| with `min-h-0` | 884 | 900 | yes |

The fix is one class.

## Why the guard is a rule, not a pin

All three generations of this bug violated the same invariant in a different place. The new test walks from the models-step scroller up to the wizard root and requires every growable flex ancestor (`flex-1`/`flex-auto`) to also carry `min-h-0` — so the next container inserted into this chain inherits the rule instead of reintroducing the class. Fails against the previous source.

Honest limitation, stated in the test: jsdom checks classes, not layout — which is exactly how the previous two fixes tested green while the screen stayed broken. The Chromium measurement above is the ground truth for this one; the class-rule test is the recurrence tripwire.

All three frontend gates run locally: tests (1650), `typecheck:ci`, `format:check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added `min-h-0` to the first-run wizard flex wrapper so the model list scrolls within the viewport and pinned controls remain visible. Added a regression test that verifies the required flex-ancestor sizing. The fix has low risk; frontend tests, type checking, and formatting checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->