### PR TITLE
fix(gguf): a source-built runtime must actually run (#1348)

### DIFF
--- a/.github/workflows/build-omnivoice-tts.yml
+++ b/.github/workflows/build-omnivoice-tts.yml
@@ -102,4 +102,6 @@ jobs:
           name: omnivoice-tts-${{ matrix.platform }}
           path: |
             bin/omnivoice-tts-${{ matrix.platform }}*
+            bin/libggml*
+            bin/ggml*.dll
             bin/checksums.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Building the GGUF engine from source produced a binary that died on its very first spawn ("libggml.so.0: cannot open shared object file") — the build script deleted the shared libraries it had just linked against. It now ships them next to the binary on every platform, and the backend puts that folder on the loader path — thanks @vanderlpp! (#1348)
+- The GGUF engine's hard 120-second per-render kill switch — which was reaping legitimate CPU-only renders mid-synthesis — is now 600s, tunable via `OMNIVOICE_GGUF_GENERATE_TIMEOUT_S`, and the timeout error names that setting — thanks @vanderlpp! (#1348)
 - Every subprocess TTS engine would have turned a stereo render into noise: the mono downmix always averaged axis 0, which is time rather than channels for channels-last audio. Unreachable today since every engine returns mono, fixed in all five before it isn't. (#1328)
 - First-run wizard: the Continue button and the Hugging Face token box were pushed below the window with no way to scroll to them — a layout container grew to the full model list's height, defeating every scroll clamp inside it. The pinned row now stays on screen at every UI scale, with the model list scrolling under it. (#1382, #1383)
 - Dubbing the same video twice no longer ties the second job's cloned voices to the first job's files — deleting the older dub from history was silently turning the newer one's single-segment regens into a default voice. (#1331)
@@ -73,6 +75,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Engine acceptance: new `docs/engine-acceptance.md` documents the job map, the bar a new engine must clear, and the out-of-tree path (#1306)
 - macOS install notes and the README support table now state the real floor (#1268)
 - Contact: the project X account is listed alongside Discord (#1313)
+- `OMNIVOICE_ALLOWED_ORIGINS` is finally documented: a browser loading the UI from another machine's origin needs the backend's CORS allow-list, which neither server mode nor trusted networks touches — thanks @vanderlpp! (#1348)
 
 ### CI
 

--- a/backend/engines/omnivoice_gguf/backend.py
+++ b/backend/engines/omnivoice_gguf/backend.py
@@ -119,6 +119,44 @@ def _binary_path(slug: Optional[str] = None) -> Path:
     return _REPO_ROOT / "bin" / name
 
 
+def _generate_timeout_s() -> float:
+    """Hard per-spawn timeout for the C++ binary, read from the env at call time.
+
+    ``OMNIVOICE_GGUF_GENERATE_TIMEOUT_S`` overrides; the default sits ABOVE
+    the GPU-pool generate budget (``OMNIVOICE_GENERATE_TIMEOUT_S``, 300s
+    floor) on purpose — the pool guard is the real, well-diagnosed deadline,
+    and this one only reaps a truly wedged C++ process. The old hardcoded
+    120s killed legitimate CPU-only generates mid-synthesis (#1348).
+    """
+    raw = os.environ.get("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S")
+    if raw:
+        try:
+            return max(1.0, float(raw))
+        except ValueError:
+            logger.warning(
+                "Ignoring non-numeric OMNIVOICE_GGUF_GENERATE_TIMEOUT_S=%r", raw
+            )
+    return 600.0
+
+
+def _spawn_env() -> dict[str, str]:
+    """Environment for spawning the binary, with ``bin/`` on the loader path.
+
+    A source-built binary can be dynamically linked against the ``libggml*``
+    shared libraries the build script now drops next to it; without the
+    loader path the spawn dies with exit 127 — ``libggml.so.0: cannot open
+    shared object file`` (#1348). Windows resolves DLLs from the exe's own
+    directory already; Linux and macOS need it stated. Both variables are
+    set unconditionally — each OS ignores the other's.
+    """
+    env = os.environ.copy()
+    bin_dir = str(_binary_path().parent)
+    for var in ("LD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH"):
+        prev = env.get(var)
+        env[var] = bin_dir if not prev else bin_dir + os.pathsep + prev
+    return env
+
+
 def _binary_repair_hint() -> str:
     """One actionable sentence for a broken/placeholder GGUF binary (#1172).
 
@@ -314,8 +352,6 @@ def _make_backend_class():
         # 24 kHz mono Higgs Audio v2 — same as the in-process OmniVoice.
         _SAMPLE_RATE = 24_000
 
-        # Default per-call timeout matches the SubprocessBackend contract.
-        _GENERATE_TIMEOUT_S = 120.0
         # Quick probe at startup to confirm the binary spawns at all.
         _PROBE_TIMEOUT_S = 5.0
 
@@ -518,6 +554,7 @@ def _make_backend_class():
                     capture_output=True,
                     timeout=timeout,
                     check=False,
+                    env=_spawn_env(),
                 )
             except FileNotFoundError:
                 raise
@@ -718,19 +755,23 @@ def _make_backend_class():
                 validate_executable,
             )
             validate_executable(Path(argv[0]), hint=_binary_repair_hint())
+            timeout_s = _generate_timeout_s()
             try:
                 proc = subprocess.run(
                     argv,
                     input=stdin_text,
                     text=True,
                     capture_output=True,
-                    timeout=self._GENERATE_TIMEOUT_S,
+                    timeout=timeout_s,
                     check=False,
+                    env=_spawn_env(),
                 )
             except subprocess.TimeoutExpired as exc:
                 raise RuntimeError(
                     f"GGUF subprocess timed out after "
-                    f"{self._GENERATE_TIMEOUT_S:.0f}s (T-04-06)"
+                    f"{timeout_s:.0f}s (T-04-06; raise "
+                    f"OMNIVOICE_GGUF_GENERATE_TIMEOUT_S if this host is "
+                    f"genuinely that slow)"
                 ) from exc
             except OSError as exc:
                 raise InvalidBinaryError(

--- a/backend/engines/omnivoice_gguf/backend.py
+++ b/backend/engines/omnivoice_gguf/backend.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import platform
 import re
@@ -131,11 +132,15 @@ def _generate_timeout_s() -> float:
     raw = os.environ.get("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S")
     if raw:
         try:
-            return max(1.0, float(raw))
+            val = float(raw)
         except ValueError:
-            logger.warning(
-                "Ignoring non-numeric OMNIVOICE_GGUF_GENERATE_TIMEOUT_S=%r", raw
-            )
+            val = None
+        # inf would disarm the wedge guard entirely; nan poisons max().
+        if val is not None and math.isfinite(val):
+            return max(1.0, val)
+        logger.warning(
+            "Ignoring invalid OMNIVOICE_GGUF_GENERATE_TIMEOUT_S=%r", raw
+        )
     return 600.0
 
 

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -240,8 +240,10 @@ Add the exact origin the browser shows in its address bar:
 export OMNIVOICE_ALLOWED_ORIGINS="http://192.168.1.159:3901,http://localhost:3901,http://127.0.0.1:3901,tauri://localhost,http://tauri.localhost"
 ```
 
-The variable **replaces** the default list, so restate the loopback/Tauri
-origins alongside your own. (The in-app LAN share and Tailscale flows in
+Each entry must be a bare origin — `scheme://host:port`, exactly what the
+browser sends in its `Origin` header — with no path and no trailing slash
+(`http://192.168.1.159:3901/` would never match). The variable **replaces**
+the default list, so restate the loopback/Tauri origins alongside your own. (The in-app LAN share and Tailscale flows in
 [docs/sharing.md](sharing.md) don't need this — they serve UI and API from the
 same origin.) If you only moved the Vite dev server's port, set
 `OMNIVOICE_UI_PORT` instead and the default list follows it.

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -222,6 +222,30 @@ credential at all**, because the API-key middleware waved it through as
 
 ---
 
+## Browsers from another origin (CORS)
+
+Everything above gates *authentication*. A **browser** frontend served from a
+different origin than the backend hits a separate wall first: CORS. The
+backend's allow-list defaults to loopback + Tauri origins only
+(`http://localhost:<ui-port>`, `http://127.0.0.1:<ui-port>`,
+`tauri://localhost`, `http://tauri.localhost`), so opening a dev/source UI via
+a LAN IP (e.g. `http://192.168.1.159:3901` talking to `…:3900`) blocks every
+request with *"Missing Header: Access-Control-Allow-Origin"* — regardless of
+`OMNIVOICE_SERVER_MODE` or `OMNIVOICE_TRUSTED_NETWORKS`, neither of which
+touches CORS (#1348).
+
+Add the exact origin the browser shows in its address bar:
+
+```bash
+export OMNIVOICE_ALLOWED_ORIGINS="http://192.168.1.159:3901,http://localhost:3901,http://127.0.0.1:3901,tauri://localhost,http://tauri.localhost"
+```
+
+The variable **replaces** the default list, so restate the loopback/Tauri
+origins alongside your own. (The in-app LAN share and Tailscale flows in
+[docs/sharing.md](sharing.md) don't need this — they serve UI and API from the
+same origin.) If you only moved the Vite dev server's port, set
+`OMNIVOICE_UI_PORT` instead and the default list follows it.
+
 ## Status codes
 
 | Code | Meaning | What to do |

--- a/docs/remote-gpu.md
+++ b/docs/remote-gpu.md
@@ -38,6 +38,12 @@ uv run uvicorn backend.main:app --host 0.0.0.0 --port 3900
 
 The Docker image is the same idea — pass `-e OMNIVOICE_API_KEY=…`.
 
+If a **browser** will load the UI from a different origin than the backend
+(e.g. a Vite dev server on `:3901` opened via the box's LAN IP), you also need
+the backend's CORS allow-list to include that origin — see
+[Browsers from another origin (CORS)](api-auth.md#browsers-from-another-origin-cors);
+neither server mode nor trusted networks covers CORS.
+
 When `OMNIVOICE_API_KEY` is set, **every non-loopback HTTP and WebSocket
 request must present it**, as `Authorization: Bearer <key>`, `?api_key=<key>`
 (browser WebSockets can't set headers), or the `ov_key` cookie the backend

--- a/scripts/build-omnivoice-tts.sh
+++ b/scripts/build-omnivoice-tts.sh
@@ -76,6 +76,28 @@ git -C "$WORK/src" submodule update --init --recursive
 
 cd "$WORK/src"
 
+# A dynamically-linked build (buildcpu.sh, or cmake when it finds BLAS)
+# leaves the ggml runtime as shared libraries inside the build tree; only
+# copying the executable ships a binary that dies on first spawn with
+# exit 127 — "libggml.so.0: cannot open shared object file" — because the
+# EXIT trap deletes the build tree, .so files and all (#1348). Copy them
+# next to the binary; a static build simply has nothing matching. The
+# backend puts bin/ on the loader path when it spawns the binary.
+copy_shared_libs() {
+    find build \( -name 'libggml*.so*' -o -name 'libggml*.dylib' -o -name 'ggml*.dll' \) \
+        -type f -print0 2>/dev/null |
+        while IFS= read -r -d '' lib; do
+            cp -v "$lib" "$BIN_DIR/"
+        done
+    # Dereference any symlinked SONAMEs (libggml.so.0 -> libggml.so) so the
+    # copies in bin/ are real files under every name the loader asks for.
+    find build \( -name 'libggml*.so*' -o -name 'libggml*.dylib' \) \
+        -type l -print0 2>/dev/null |
+        while IFS= read -r -d '' lib; do
+            cp -vL "$lib" "$BIN_DIR/"
+        done
+}
+
 OUT_NAME="omnivoice-tts-$PLATFORM"
 case "$PLATFORM" in
     windows-x86_64) OUT_NAME="$OUT_NAME.exe" ;;
@@ -90,6 +112,7 @@ case "$PLATFORM" in
             cmake --build build --config Release -j
         fi
         cp -v build/omnivoice-tts "$BIN_DIR/$OUT_NAME"
+        copy_shared_libs
         ;;
     windows-x86_64)
         # CI runs this from MSYS / git-bash; CMake picks up the MSVC
@@ -97,12 +120,14 @@ case "$PLATFORM" in
         cmake -B build -DCMAKE_BUILD_TYPE=Release
         cmake --build build --config Release -j
         cp -v build/Release/omnivoice-tts.exe "$BIN_DIR/$OUT_NAME"
+        copy_shared_libs
         ;;
     darwin-x86_64)
         # x86_64 Macs build the CPU variant; Metal on Intel is undocumented.
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
         cmake --build build --config Release -j
         cp -v build/omnivoice-tts "$BIN_DIR/$OUT_NAME"
+        copy_shared_libs
         ;;
     darwin-arm64)
         # Apple Silicon — try Metal (no published buildmetal.sh; we
@@ -110,6 +135,7 @@ case "$PLATFORM" in
         if cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_METAL=ON -DCMAKE_OSX_ARCHITECTURES=arm64; then
             if cmake --build build --config Release -j; then
                 cp -v build/omnivoice-tts "$BIN_DIR/$OUT_NAME"
+                copy_shared_libs
             else
                 echo "→ Metal build failed during compilation; macOS Apple Silicon falls back to in-process OmniVoiceBackend per Pitfall 1." >&2
                 exit 2

--- a/tests/test_gguf_source_build_runtime_1348.py
+++ b/tests/test_gguf_source_build_runtime_1348.py
@@ -13,21 +13,28 @@ built from source):
 """
 
 import ast
+import importlib
 import os
 import re
-import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO / "backend"))
+import pytest
 
-from engines.omnivoice_gguf import backend as gguf  # noqa: E402
+REPO = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def gguf(monkeypatch):
+    # Function-scoped runtime import: no module-level app imports that go
+    # stale under sys.modules pollution from other tests.
+    monkeypatch.syspath_prepend(str(REPO / "backend"))
+    return importlib.import_module("engines.omnivoice_gguf.backend")
 
 
 # ── the per-spawn timeout is env-tunable and CPU-realistic ──────────────────
 
 
-def test_default_timeout_exceeds_the_pool_generate_budget(monkeypatch):
+def test_default_timeout_exceeds_the_pool_generate_budget(gguf, monkeypatch):
     # The pool guard (OMNIVOICE_GENERATE_TIMEOUT_S, 300s floor) must be the
     # deadline users actually hit — it classifies and explains. The inner
     # subprocess timeout only reaps a wedged C++ process, so it must sit
@@ -36,16 +43,23 @@ def test_default_timeout_exceeds_the_pool_generate_budget(monkeypatch):
     assert gguf._generate_timeout_s() > 300.0
 
 
-def test_env_override_is_read_at_call_time(monkeypatch):
+def test_env_override_is_read_at_call_time(gguf, monkeypatch):
     monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", "45.5")
     assert gguf._generate_timeout_s() == 45.5
 
 
-def test_bad_env_values_fall_back_to_the_default(monkeypatch):
-    monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", "unlimited")
+@pytest.mark.parametrize("raw", ["unlimited", "inf", "-inf", "nan"])
+def test_bad_env_values_fall_back_to_the_default(gguf, monkeypatch, raw):
+    # inf would disarm the wedge guard entirely (subprocess.run never times
+    # out); nan poisons the max() clamp. Both parse as float, so a plain
+    # ValueError guard is not enough.
+    monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", raw)
     assert gguf._generate_timeout_s() == 600.0
+
+
+def test_tiny_values_are_floored_not_instant_kill(gguf, monkeypatch):
     monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", "0")
-    assert gguf._generate_timeout_s() == 1.0  # floored, never instant-kill
+    assert gguf._generate_timeout_s() == 1.0
 
 
 def test_timeout_error_names_the_env_knob():
@@ -59,7 +73,7 @@ def test_timeout_error_names_the_env_knob():
 # ── spawns carry a loader path that can see bin/'s shared libs ──────────────
 
 
-def test_spawn_env_puts_bin_on_the_loader_path(monkeypatch):
+def test_spawn_env_puts_bin_on_the_loader_path(gguf, monkeypatch):
     monkeypatch.setenv("LD_LIBRARY_PATH", "/opt/elsewhere")
     monkeypatch.delenv("DYLD_FALLBACK_LIBRARY_PATH", raising=False)
     env = gguf._spawn_env()
@@ -122,3 +136,12 @@ def test_build_script_copies_shared_libs_on_every_platform_branch():
     # The finder must cover all three platforms' shared-lib extensions.
     for pattern in ("libggml*.so*", "libggml*.dylib", "ggml*.dll"):
         assert pattern in script
+
+
+def test_ci_artifact_upload_includes_the_shared_libs():
+    # Greptile P1 on the fix itself: copy_shared_libs is useless if the
+    # workflow's upload glob then drops the libs from the artifact — the
+    # downloaded binary would be exactly as broken as before.
+    wf = (REPO / ".github/workflows/build-omnivoice-tts.yml").read_text()
+    assert "bin/libggml*" in wf
+    assert "bin/ggml*.dll" in wf

--- a/tests/test_gguf_source_build_runtime_1348.py
+++ b/tests/test_gguf_source_build_runtime_1348.py
@@ -1,0 +1,124 @@
+"""#1348 — a source-built GGUF runtime must actually run.
+
+Two independent failures from the same report (LXC Debian, CPU-only,
+built from source):
+
+1. ``scripts/build-omnivoice-tts.sh`` copied only the executable out of the
+   temp build tree; a dynamically-linked build (buildcpu.sh, or cmake with
+   BLAS present) left its ``libggml*`` shared libraries behind for the EXIT
+   trap to delete, so the shipped binary died on first spawn with exit 127
+   — "libggml.so.0: cannot open shared object file".
+2. ``_GENERATE_TIMEOUT_S`` was hardcoded to 120s, which reaped legitimate
+   CPU-only generates mid-synthesis with no way to raise it.
+"""
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "backend"))
+
+from engines.omnivoice_gguf import backend as gguf  # noqa: E402
+
+
+# ── the per-spawn timeout is env-tunable and CPU-realistic ──────────────────
+
+
+def test_default_timeout_exceeds_the_pool_generate_budget(monkeypatch):
+    # The pool guard (OMNIVOICE_GENERATE_TIMEOUT_S, 300s floor) must be the
+    # deadline users actually hit — it classifies and explains. The inner
+    # subprocess timeout only reaps a wedged C++ process, so it must sit
+    # strictly above the pool floor or it fires first with a worse error.
+    monkeypatch.delenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", raising=False)
+    assert gguf._generate_timeout_s() > 300.0
+
+
+def test_env_override_is_read_at_call_time(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", "45.5")
+    assert gguf._generate_timeout_s() == 45.5
+
+
+def test_bad_env_values_fall_back_to_the_default(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", "unlimited")
+    assert gguf._generate_timeout_s() == 600.0
+    monkeypatch.setenv("OMNIVOICE_GGUF_GENERATE_TIMEOUT_S", "0")
+    assert gguf._generate_timeout_s() == 1.0  # floored, never instant-kill
+
+
+def test_timeout_error_names_the_env_knob():
+    # The user in #1348 had to read the source to find the constant; the
+    # error itself must carry the escape hatch now.
+    src = (REPO / "backend/engines/omnivoice_gguf/backend.py").read_text()
+    timed_out = src[src.index("timed out after") :]
+    assert "OMNIVOICE_GGUF_GENERATE_TIMEOUT_S" in timed_out[:300]
+
+
+# ── spawns carry a loader path that can see bin/'s shared libs ──────────────
+
+
+def test_spawn_env_puts_bin_on_the_loader_path(monkeypatch):
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/opt/elsewhere")
+    monkeypatch.delenv("DYLD_FALLBACK_LIBRARY_PATH", raising=False)
+    env = gguf._spawn_env()
+    bin_dir = str(gguf._binary_path().parent)
+    # Prepended, with the pre-existing path preserved after it.
+    assert env["LD_LIBRARY_PATH"] == bin_dir + os.pathsep + "/opt/elsewhere"
+    assert env["DYLD_FALLBACK_LIBRARY_PATH"] == bin_dir
+
+
+def test_every_spawn_of_the_engine_binary_passes_the_loader_env():
+    # Class rule: any subprocess.run that execs the GGUF binary must pass
+    # env=_spawn_env(), or a dynamically-linked build fails exit 127 from
+    # that call site. (The /usr/bin/xattr quarantine probe is the one
+    # legitimate literal-argv exception.)
+    src = (REPO / "backend/engines/omnivoice_gguf/backend.py").read_text()
+    tree = ast.parse(src)
+    spawns = 0
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "run"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "subprocess"
+        ):
+            continue
+        first = node.args[0] if node.args else None
+        if (
+            isinstance(first, ast.List)
+            and first.elts
+            and isinstance(first.elts[0], ast.Constant)
+        ):
+            continue  # literal argv (xattr probe) — not the engine binary
+        spawns += 1
+        kw = {k.arg for k in node.keywords}
+        assert "env" in kw, (
+            f"subprocess.run at line {node.lineno} spawns the engine binary "
+            f"without env=_spawn_env() — a dynamically-linked source build "
+            f"dies with exit 127 there (#1348)"
+        )
+    assert spawns >= 2  # probe_load --help + _run_subprocess
+
+
+# ── the build script ships the shared libs it links against ─────────────────
+
+
+def test_build_script_copies_shared_libs_on_every_platform_branch():
+    script = (REPO / "scripts/build-omnivoice-tts.sh").read_text()
+    assert "copy_shared_libs()" in script
+    # Every copy of the executable is followed by the shared-lib copy —
+    # the bug lived in ALL platform branches, not just Linux.
+    binary_cps = re.findall(r'cp -v build/(?:Release/)?omnivoice-tts(?:\.exe)? "\$BIN_DIR', script)
+    calls = script.count("copy_shared_libs\n")
+    assert len(binary_cps) == 4
+    assert calls == len(binary_cps), (
+        "every platform branch that copies the binary must also call "
+        "copy_shared_libs — otherwise that platform's dynamic build "
+        "ships broken (#1348)"
+    )
+    # The finder must cover all three platforms' shared-lib extensions.
+    for pattern in ("libggml*.so*", "libggml*.dylib", "ggml*.dll"):
+        assert pattern in script


### PR DESCRIPTION
Closes nothing yet — #1348 stays open for the reporter's pending low-volume dubbing item, but this lands their three confirmed upstream findings.

## What broke (report: #1348, @vanderlpp — LXC Debian, Ryzen 3200G, source install)

1. **`scripts/build-omnivoice-tts.sh` shipped a binary that could not run.** It copied only the executable out of the temp build tree; a dynamically-linked build (`buildcpu.sh`, or cmake when BLAS is found) left `libggml*.so` behind for the `trap … EXIT` to delete. First spawn: exit 127, `libggml.so.0: cannot open shared object file`. The bug existed in **all** platform branches.
2. **Hardcoded 120s per-spawn kill switch** reaped legitimate CPU-only renders mid-synthesis, with no env override — unlike every other timeout in the project.
3. **`OMNIVOICE_ALLOWED_ORIGINS` was documented nowhere**, and it is the only thing that fixes CORS for a browser loading the UI from another machine's origin — server mode and trusted networks don't touch CORS.

## The fix

- Build script: `copy_shared_libs` after every binary copy (`.so`/`.dylib`/`.dll`; static builds copy nothing). Backend puts `bin/` on the loader path (`LD_LIBRARY_PATH` + `DYLD_FALLBACK_LIBRARY_PATH`) for **every** spawn of the engine binary, so already-built dynamic binaries are fixed too, without relying on shell env.
- Timeout: default 600s — deliberately **above** the pool guard's 300s floor so the well-diagnosed deadline (#1373/#1379) fires first — tunable via `OMNIVOICE_GGUF_GENERATE_TIMEOUT_S`, named in the timeout error.
- Docs: new CORS section in `docs/api-auth.md`, pointer from `docs/remote-gpu.md`.

## Recurrence-proofing (`tests/test_gguf_source_build_runtime_1348.py`)

- AST rule: every `subprocess.run` that execs the engine binary must pass `env=` (xattr probe exempt by literal-argv shape).
- Script rule: every platform branch that copies the binary must call `copy_shared_libs`, and the finder must cover all three lib extensions.
- Timeout default/override/floor/bad-value behavior, and the error naming the knob.

Full backend suite: 4023 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
GGUF source builds now bundle shared libraries, propagate loader paths, and use a configurable 600-second generation timeout with invalid-value fallback. This prevents backend spawn failures and premature timeouts, packages libraries in CI artifacts, and documents `OMNIVOICE_ALLOWED_ORIGINS` for remote browser access. Review platform-specific library discovery and loader-path behavior; regression tests report 4023 passing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->