### PR TITLE
fix(ci): bind the preview manifest to its run, not to sibling upload times

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -979,22 +979,37 @@ jobs:
           gh release view preview --repo "$REPO" --json assets \
             -q '[.assets[] | {name, updatedAt}]' > /tmp/assets.json
 
-          # `created_at`, NOT `run_started_at`: the latter RESETS on every
-          # re-run, so re-running just this job would judge the macOS bundles
-          # its own earlier attempt uploaded as stale and refuse a healthy
-          # build. `created_at` is the first attempt and never moves.
+          # The anchor for "this upload belongs to this run" is the moment this
+          # run's FIRST JOB began executing. Two wrong answers were considered:
+          #
+          #   * `run_started_at` RESETS on re-run — re-running just this job
+          #     would judge the macOS bundles its own earlier attempt uploaded
+          #     as stale, and refuse a healthy build.
+          #   * the run's `created_at` is stamped when the run is QUEUED. With
+          #     the concurrency group above, a run can sit queued while the
+          #     previous one uploads — so the queued run's created_at predates
+          #     the OTHER run's macOS bundles and would accept them as its own
+          #     (coderabbit).
+          #
+          # The earliest job start is after the queue wait (concurrency holds
+          # the whole run, so no job of ours has started) and before any of our
+          # own uploads. Jobs that were not re-run keep their original
+          # timestamps, so taking the MINIMUM stays correct across partial
+          # re-runs too.
           #
           # Needs the job's `actions: read` scope. If it ever 403s anyway, do
           # not take the whole publish down with `set -e`: warn loudly and let
           # build_manifest fall back to its leg-to-leg comparison, which is
           # merely stricter than it should be, never laxer.
-          if ! RUN_CREATED_AT=$(gh api "repos/$REPO/actions/runs/${{ github.run_id }}" \
-                 --jq '.created_at' 2> /tmp/gh-run-err.txt); then
-            echo "::warning::Could not read this run's created_at (needs actions: read) — falling back to the stricter sibling-timestamp check, which can refuse a healthy build."
+          if ! RUN_CREATED_AT=$(gh api --paginate \
+                 "repos/$REPO/actions/runs/${{ github.run_id }}/jobs?filter=latest" \
+                 --jq '[.jobs[].started_at] | map(select(. != null)) | min // empty' \
+                 2> /tmp/gh-run-err.txt); then
+            echo "::warning::Could not read this run's job start times (needs actions: read) — falling back to the stricter sibling-timestamp check, which can refuse a healthy build."
             cat /tmp/gh-run-err.txt
             RUN_CREATED_AT=""
           fi
-          echo "This run was created at ${RUN_CREATED_AT:-<unknown>}"
+          echo "This run began executing at ${RUN_CREATED_AT:-<unknown>}"
           export RUN_CREATED_AT
 
           WORK=$(mktemp -d)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,19 @@ on:
 permissions:
   contents: write    # needed to attach artifacts + updater manifest to GH Release
 
+# Every preview build publishes to the SAME rolling `preview` release, and the
+# updater manifest is rebuilt from whatever assets are on it. Two overlapping
+# preview runs (the nightly schedule and a manual dispatch, say) would upload
+# into each other's asset set, and the version-less macOS tarballs carry
+# nothing saying which run produced them — so one run could publish a manifest
+# advertising its own version while serving the other run's macOS binaries
+# (greptile). Serialize instead. Keyed on the ref, so a `v*` tag push (which
+# builds its own release and never touches `preview`) is never queued behind a
+# nightly.
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   # Run all JavaScript actions on Node 24 (GH deprecates Node 20 in Sep 2026).
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -918,6 +931,11 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      # The manifest rebuild reads this run's `created_at` from the Actions
+      # Runs API to tie the version-less macOS bundles to this build. Without
+      # this scope the call 403s and, under `set -e`, takes the whole publish
+      # down (greptile).
+      actions: read
     steps:
       # Needed by the manifest rebuild + signature check below: the updater
       # pubkey lives in frontend/src-tauri/tauri.conf.json.
@@ -965,9 +983,18 @@ jobs:
           # re-run, so re-running just this job would judge the macOS bundles
           # its own earlier attempt uploaded as stale and refuse a healthy
           # build. `created_at` is the first attempt and never moves.
-          RUN_CREATED_AT=$(gh api "repos/$REPO/actions/runs/${{ github.run_id }}" \
-            --jq '.created_at')
-          echo "This run was created at $RUN_CREATED_AT"
+          #
+          # Needs the job's `actions: read` scope. If it ever 403s anyway, do
+          # not take the whole publish down with `set -e`: warn loudly and let
+          # build_manifest fall back to its leg-to-leg comparison, which is
+          # merely stricter than it should be, never laxer.
+          if ! RUN_CREATED_AT=$(gh api "repos/$REPO/actions/runs/${{ github.run_id }}" \
+                 --jq '.created_at' 2> /tmp/gh-run-err.txt); then
+            echo "::warning::Could not read this run's created_at (needs actions: read) — falling back to the stricter sibling-timestamp check, which can refuse a healthy build."
+            cat /tmp/gh-run-err.txt
+            RUN_CREATED_AT=""
+          fi
+          echo "This run was created at ${RUN_CREATED_AT:-<unknown>}"
           export RUN_CREATED_AT
 
           WORK=$(mktemp -d)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -961,6 +961,15 @@ jobs:
           gh release view preview --repo "$REPO" --json assets \
             -q '[.assets[] | {name, updatedAt}]' > /tmp/assets.json
 
+          # `created_at`, NOT `run_started_at`: the latter RESETS on every
+          # re-run, so re-running just this job would judge the macOS bundles
+          # its own earlier attempt uploaded as stale and refuse a healthy
+          # build. `created_at` is the first attempt and never moves.
+          RUN_CREATED_AT=$(gh api "repos/$REPO/actions/runs/${{ github.run_id }}" \
+            --jq '.created_at')
+          echo "This run was created at $RUN_CREATED_AT"
+          export RUN_CREATED_AT
+
           WORK=$(mktemp -d)
           python3 - "$WORK" <<'PY'
           import base64, hashlib, json, os, subprocess, sys
@@ -983,7 +992,10 @@ jobs:
               signatures[name] = open(os.path.join(work, name + ".sig")).read()
 
           try:
-              manifest = build_manifest(assets, repo, signatures=signatures)
+              manifest = build_manifest(
+                  assets, repo, signatures=signatures,
+                  run_started_at=os.environ.get("RUN_CREATED_AT") or None,
+              )
           except ManifestRefused as e:
               sys.exit(f"Refusing to publish a preview manifest: {e}")
           print(f"Built preview latest.json: version={manifest['version']}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 - Windows smoke tests stopped silently passing a broken ffmpeg install, and every smoke leg is now budgeted for a cold dependency install. (#1290)
 - Test suites no longer leak config paths or model-manager shutdown state into one another, which had been failing unrelated pull requests. (#1269)
+- The nightly preview build stopped refusing to publish its own healthy updater manifest when the macOS legs finished a few minutes ahead of the slowest one — Preview-channel users were silently left without new builds.
 
 ## [0.4.2] — 2026-07-28
 

--- a/scripts/build_preview_manifest.py
+++ b/scripts/build_preview_manifest.py
@@ -31,10 +31,18 @@ MAC_X86_64 = "OmniVoice.Studio_x64.app.tar.gz"
 _APPIMAGE_RE = r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_amd64\.AppImage"
 _MSI_RE = r"OmniVoice\.Studio_[\d.]+-(?P<n>\d+)_x64_en-US\.msi"
 
-#: How far a darwin bundle's upload time may precede the versioned artifacts of
-#: the same run. The matrix legs finish minutes apart, so some slack is
-#: required; it only has to be far smaller than the gap between two runs.
+#: Fallback only (no ``run_started_at`` given): how far a darwin bundle's
+#: upload time may precede the versioned artifacts of the same run. This
+#: binding is inherently flaky — the matrix legs routinely finish more than
+#: two minutes apart (the fast Apple-Silicon leg uploads long before a slow
+#: Windows leg), which is exactly how the 2026-08-05 nightly refused its own
+#: healthy build. The workflow therefore passes ``run_started_at`` and this
+#: window governs only direct/manual invocations.
 FRESHNESS_SLACK = datetime.timedelta(minutes=2)
+
+#: Clock slack for the ``run_started_at`` binding: GitHub's asset timestamps
+#: and the run's start time come from different services.
+RUN_START_SLACK = datetime.timedelta(minutes=2)
 
 NOTES = ("Auto-generated rolling preview build from main. "
          "See CHANGELOG.md and the commit log for details.")
@@ -68,12 +76,21 @@ def _parse_ts(value):
     return datetime.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
 
 
-def build_manifest(assets, repo: str, *, signatures, pub_date=None) -> dict:
+def build_manifest(assets, repo: str, *, signatures, pub_date=None,
+                   run_started_at=None) -> dict:
     """Build the updater manifest, or raise :class:`ManifestRefused`.
 
     ``assets`` is ``[{"name": …, "updatedAt": …}, …]`` as ``gh release view``
     returns it. ``signatures`` maps an asset name to its ``.sig`` contents;
     it is passed in so this function needs no network.
+
+    ``run_started_at`` — ISO timestamp of the workflow run's FIRST attempt.
+    When given, it is the binding for the version-less darwin tarballs: any
+    upload after it belongs to this run (only one preview run touches the
+    release at a time), regardless of how far apart the matrix legs finish
+    or which attempt re-uploaded what. Without it, the fallback compares
+    against the versioned artifacts' upload times with a slack that cannot
+    tell "slow sibling leg" from "stale" reliably.
     """
     names = [a["name"] for a in assets]
     updated_at = {a["name"]: a.get("updatedAt") for a in assets}
@@ -116,21 +133,32 @@ def build_manifest(assets, repo: str, *, signatures, pub_date=None) -> dict:
     try:
         newest_versioned = max(_parse_ts(updated_at[appimage]), _parse_ts(updated_at[msi]))
         mac_times = {n: _parse_ts(updated_at[n]) for n in (MAC_AARCH64, MAC_X86_64)}
+        run_start = _parse_ts(run_started_at) if run_started_at else None
     except (TypeError, ValueError) as e:
         raise ManifestRefused(
-            f"cannot read asset upload times, so the macOS bundles cannot be tied "
-            f"to this run: {e}"
+            f"cannot read the asset upload times (or this run's start time), so "
+            f"the macOS bundles cannot be tied to this run: {e}"
         ) from e
 
-    stale = sorted(n for n, t in mac_times.items() if t < newest_versioned - FRESHNESS_SLACK)
+    if run_start is not None:
+        # Anything uploaded after this run began is this run's. Comparing the
+        # legs to EACH OTHER instead (the fallback below) refuses a healthy
+        # build whenever the macOS legs finish more than the slack ahead of
+        # the slowest versioned leg — which is normal, and is what failed the
+        # 2026-08-05 nightly with all four builds green.
+        cutoff = run_start - RUN_START_SLACK
+        stale = sorted(n for n, t in mac_times.items() if t < cutoff)
+        reference = f"this run started at {run_start.isoformat()}"
+    else:
+        stale = sorted(n for n, t in mac_times.items() if t < newest_versioned - FRESHNESS_SLACK)
+        reference = f"this run's versioned artifacts ({newest_versioned.isoformat()})"
     if stale:
         raise ManifestRefused(
-            f"the macOS updater bundle(s) {stale} were last uploaded before this "
-            f"run's versioned artifacts ({newest_versioned.isoformat()}), so they "
-            f"are from an EARLIER build. Publishing would advertise {version} while "
-            f"serving Mac users the previous one — and because they would keep "
-            f"reporting the old version, the updater would re-offer it forever. "
-            f"Re-run the macOS legs."
+            f"the macOS updater bundle(s) {stale} were last uploaded before "
+            f"{reference}, so they are from an EARLIER build. Publishing would "
+            f"advertise {version} while serving Mac users the previous one — and "
+            f"because they would keep reporting the old version, the updater would "
+            f"re-offer it forever. Re-run the macOS legs."
         )
 
     entries = {

--- a/tests/test_release_preview_manifest_rebuild.py
+++ b/tests/test_release_preview_manifest_rebuild.py
@@ -175,10 +175,19 @@ def test_the_workflow_binds_the_manifest_to_the_run_that_built_it():
         "darwin bundles fall back to the leg-to-leg comparison that refused a "
         "healthy nightly"
     )
-    assert "'.created_at'" in body, (
-        "release.yml must read the run's `created_at` (first attempt), not "
-        "`run_started_at`, which resets on every re-run"
+    # The API field `run_started_at` RESETS on re-run; reading it would make a
+    # re-run of this job alone judge its own earlier attempt's uploads stale.
+    assert ".run_started_at" not in body, (
+        "release.yml must not read the API's `run_started_at`, which resets on "
+        "every re-run"
     )
+    assert "/jobs?filter=latest" in body and ".started_at" in body, (
+        "the anchor must be this run's earliest JOB start: the run's own "
+        "`created_at` is stamped while it is still QUEUED, so a run waiting on "
+        "the concurrency group would accept the run ahead of it uploading macOS "
+        "bundles as its own"
+    )
+    assert "| min" in body, "taking anything but the earliest job start reintroduces the false refusal"
 
 
 def test_the_preview_job_can_actually_read_its_run_metadata():
@@ -209,6 +218,12 @@ def test_preview_runs_cannot_overlap():
     with open(os.path.join(root, ".github", "workflows", "release.yml"), encoding="utf-8") as fh:
         wf = yaml.safe_load(fh)
     assert "concurrency" in wf, "release.yml has no concurrency group — preview runs can overlap"
+    # Per-REF, or a `v*` tag release queues behind a nightly (and a group that
+    # lost its ref scoping would still pass a bare existence check).
+    assert "${{ github.ref }}" in wf["concurrency"]["group"], (
+        "the concurrency group must be scoped per ref, or unrelated releases "
+        "serialize against each other"
+    )
     assert wf["concurrency"].get("cancel-in-progress") is False, (
         "cancelling an in-flight preview mid-upload would leave a half-uploaded "
         "asset set for the next run to describe"

--- a/tests/test_release_preview_manifest_rebuild.py
+++ b/tests/test_release_preview_manifest_rebuild.py
@@ -181,6 +181,40 @@ def test_the_workflow_binds_the_manifest_to_the_run_that_built_it():
     )
 
 
+def test_the_preview_job_can_actually_read_its_run_metadata():
+    """`contents: write` alone 403s the Actions Runs API (greptile), which
+    under `set -e` would take the whole publish down — the outage this change
+    exists to end, with a different cause."""
+    import yaml
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    with open(os.path.join(root, ".github", "workflows", "release.yml"), encoding="utf-8") as fh:
+        wf = yaml.safe_load(fh)
+    perms = wf["jobs"]["preview-notes"]["permissions"]
+    assert perms.get("actions") == "read", (
+        "preview-notes reads repos/…/actions/runs/<id>; without `actions: read` "
+        "that call 403s"
+    )
+
+
+def test_preview_runs_cannot_overlap():
+    """Two preview runs publish to the SAME rolling release, and the
+    version-less macOS tarballs carry nothing identifying their run — so an
+    overlap lets one run's manifest describe another run's Mac binaries
+    (greptile). Serialization is what makes 'uploaded after this run started'
+    mean 'belongs to this run'."""
+    import yaml
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    with open(os.path.join(root, ".github", "workflows", "release.yml"), encoding="utf-8") as fh:
+        wf = yaml.safe_load(fh)
+    assert "concurrency" in wf, "release.yml has no concurrency group — preview runs can overlap"
+    assert wf["concurrency"].get("cancel-in-progress") is False, (
+        "cancelling an in-flight preview mid-upload would leave a half-uploaded "
+        "asset set for the next run to describe"
+    )
+
+
 def test_unreadable_timestamps_are_refused_not_ignored():
     """Missing `updatedAt` means the freshness check cannot run. Proceeding
     would silently drop the only thing tying the darwin bundles to this run."""

--- a/tests/test_release_preview_manifest_rebuild.py
+++ b/tests/test_release_preview_manifest_rebuild.py
@@ -119,6 +119,68 @@ def test_macos_bundles_uploaded_later_are_fine():
     assert _build(_assets(mac_offset=5))["version"] == "0.4.3-7"
 
 
+class TestBindingByRunStart:
+    """Tying the darwin tarballs to the RUN rather than to their siblings.
+
+    The 2026-08-05 nightly refused its own healthy build: all four matrix legs
+    were green, but the macOS bundles had uploaded ~3 minutes before the last
+    versioned artifact, and the leg-to-leg comparison reads that as "from an
+    earlier build". Legs finishing minutes apart is normal — the fast
+    Apple-Silicon leg routinely beats a slow Windows leg by more than any
+    slack worth allowing — so the comparison itself was the bug. Everything
+    uploaded after the run began is this run's.
+    """
+
+    def test_a_healthy_build_whose_mac_legs_finished_early_is_accepted(self):
+        # Exactly the 2026-08-05 shape: mac legs 3 minutes ahead of the
+        # slowest versioned leg, both well after the run started.
+        assets = _assets(mac_offset=0, versioned_offset=3)
+        manifest = _build(assets, run_started_at=_iso(-20))
+        assert manifest["version"] == "0.4.3-7"
+
+    def test_the_genuinely_stale_case_is_still_refused(self):
+        # macOS legs never uploaded: their bundles are last night's, i.e.
+        # from before this run existed. This is what the check is for.
+        assets = _assets(mac_offset=-600, versioned_offset=0)
+        with pytest.raises(ManifestRefused, match="EARLIER build"):
+            _build(assets, run_started_at=_iso(-20))
+
+    def test_clock_skew_at_the_boundary_does_not_refuse(self):
+        # Asset timestamps and run timestamps come from different services;
+        # a bundle stamped a minute "before" the run started is skew, not a
+        # stale artifact from a run that would have been hours earlier.
+        assets = _assets(mac_offset=-1, versioned_offset=0)
+        assert _build(assets, run_started_at=_iso(0))["version"] == "0.4.3-7"
+
+    def test_without_a_run_timestamp_the_old_comparison_still_applies(self):
+        # Direct/manual invocation has no run context; the fallback must keep
+        # catching the stale case rather than silently accepting anything.
+        with pytest.raises(ManifestRefused, match="EARLIER build"):
+            _build(_assets(mac_offset=-90, versioned_offset=0))
+
+    def test_an_unreadable_run_timestamp_is_refused_not_ignored(self):
+        # Falling back silently would hide that the binding never ran.
+        with pytest.raises(ManifestRefused, match="upload times"):
+            _build(_assets(), run_started_at="not-a-timestamp")
+
+
+def test_the_workflow_binds_the_manifest_to_the_run_that_built_it():
+    """The rule above is only worth having if release.yml actually passes the
+    timestamp — and passes `created_at`, not `run_started_at`: the latter
+    resets on re-run, so re-running this job alone would judge the bundles its
+    own earlier attempt uploaded as stale and refuse a healthy build."""
+    body = _preview_step()["run"]
+    assert "run_started_at=" in body, (
+        "release.yml no longer passes a run timestamp to build_manifest, so the "
+        "darwin bundles fall back to the leg-to-leg comparison that refused a "
+        "healthy nightly"
+    )
+    assert "'.created_at'" in body, (
+        "release.yml must read the run's `created_at` (first attempt), not "
+        "`run_started_at`, which resets on every re-run"
+    )
+
+
 def test_unreadable_timestamps_are_refused_not_ignored():
     """Missing `updatedAt` means the freshness check cannot run. Proceeding
     would silently drop the only thing tying the darwin bundles to this run."""


### PR DESCRIPTION
The 2026-08-05 nightly preview build **refused to publish its own healthy build**, and has been failing since. All four matrix legs were green:

```
Refusing to publish a preview manifest: the macOS updater bundle(s)
['OmniVoice.Studio_aarch64.app.tar.gz'] were last uploaded before this run's
versioned artifacts (2026-08-05T08:08:24+00:00), so they are from an EARLIER build.
```

## Why it was wrong

The version-less darwin tarballs carry nothing in their names tying them to a build, so #1362 tied them to the **sibling versioned artifacts' upload times**, with 2 minutes of slack. But matrix legs finishing minutes apart is *normal* — the fast Apple-Silicon leg routinely beats a slow Windows leg by more than any slack worth allowing. The check reads that as "stale" and refuses. Preview-channel users quietly stop getting builds; the failure looks like a build problem when nothing was built wrong.

## The fix

Bind the tarballs to the **run**: anything uploaded after the run was created belongs to it, since only one preview run touches the rolling release at a time. That margin is hours, not minutes, so leg skew can't trip it — while the case the check exists for (macOS legs never uploaded, last night's tarball still sitting there) is still refused.

`release.yml` passes the run's `created_at`, **not** `run_started_at` — the latter resets on every re-run, so re-running just this job would judge the bundles its own earlier attempt uploaded as stale and reproduce the same false refusal. The old leg-to-leg comparison stays as the fallback when no run timestamp is supplied (direct/manual invocation).

## Tests

New `TestBindingByRunStart` covers the exact 2026-08-05 shape (mac legs 3 min early → accepted), the genuinely stale case (→ still refused), boundary clock skew, the no-timestamp fallback, and an unreadable timestamp being refused rather than silently ignored. Plus a workflow-level test that `release.yml` passes the timestamp **and** reads `created_at` rather than `run_started_at`. 28 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Preview manifest validation now binds macOS updater tarballs to the workflow run’s earliest job start time and serializes preview runs per ref without cancellation. This prevents queued runs from accepting artifacts from a preceding run while allowing normal matrix-leg completion skew and rejecting stale or unreadable artifacts. Review run metadata lookup and manifest wiring because failures could reject valid builds or accept stale tarballs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->