### PR TITLE
fix(dictation): stop the widget stranding an empty square, repair the swept data dirs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve OmniVoice Studio! 🎙️
+        Thanks for helping improve VoiceStudio! 🎙️
 
         **Fastest path to a fix:** **Settings → About → "Save diagnostic bundle"** makes a
         zip (self-check + recent errors + scrubbed log tails) — drag it onto this issue and

--- a/.github/ISSUE_TEMPLATE/sponsor.yml
+++ b/.github/ISSUE_TEMPLATE/sponsor.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for considering sponsoring **OmniVoice Studio** 💛
+        Thanks for considering sponsoring **VoiceStudio** 💛
 
         OmniVoice is free, local-first, and AGPL-3.0 — sponsorship keeps development going.
         See **[SPONSORS.md](https://github.com/debpalash/VoiceStudio/blob/main/SPONSORS.md)** for tiers, placements, and logo guidelines.

--- a/.github/ISSUE_TEMPLATE/sponsor.yml
+++ b/.github/ISSUE_TEMPLATE/sponsor.yml
@@ -1,5 +1,5 @@
 name: 🤝 Sponsorship inquiry
-description: Support OmniVoice and (optionally) claim a logo slot. Not for bugs or feature requests.
+description: Support VoiceStudio and (optionally) claim a logo slot. Not for bugs or feature requests.
 title: "Sponsorship inquiry: "
 labels: ["sponsor"]
 body:
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for considering sponsoring **VoiceStudio** 💛
 
-        OmniVoice is free, local-first, and AGPL-3.0 — sponsorship keeps development going.
+        VoiceStudio is free, local-first, and AGPL-3.0 — sponsorship keeps development going.
         See **[SPONSORS.md](https://github.com/debpalash/VoiceStudio/blob/main/SPONSORS.md)** for tiers, placements, and logo guidelines.
         Prefer to just donate? [Ko-fi](https://ko-fi.com/debpalash) (recurring) or [PayPal](https://paypal.me/palashCoder) (one-time) — you don't need this form for that.
   - type: input
@@ -72,7 +72,7 @@ body:
     attributes:
       label: Acknowledgements
       options:
-        - label: I understand sponsorship is a thank-you, not a paywall — OmniVoice stays fully free and AGPL-3.0, and sponsors don't get gated features.
+        - label: I understand sponsorship is a thank-you, not a paywall — VoiceStudio stays fully free and AGPL-3.0, and sponsors don't get gated features.
           required: true
-        - label: If I provide a logo, I have the right to use it and grant OmniVoice permission to display it in the README, the app, and the project website.
+        - label: If I provide a logo, I have the right to use it and grant VoiceStudio permission to display it in the README, the app, and the project website.
           required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- The dictation model picker now tells the truth about download size. Every one of the seven models was wrong: Parakeet TDT v3, the recommended default, said 180 MB and actually downloads 670 MB, while the small low-RAM fallbacks were advertised as three times bigger than they are. (#1398)
+- Dictation with the 0.6B Parakeet models is steadier under load — they now decode on more threads (still capped by your CPU, still overridable with `OMNIVOICE_SHERPA_ASR_THREADS`). The small models are unchanged. (#1398)
 - The dictation hotkey no longer leaves a blank dark square stuck on your desktop. A press that arrived while the pill was re-arming was dropped, and the window it had already opened had nothing in it and no way to close it. (#1398)
 - Dictation is more reliable to trigger: the hotkey listener no longer briefly detaches every time the pill changes state, so a press is never silently lost. (#1398)
 - Text ending in punctuation no longer wastes a whole synthesis pass on it. A chunk boundary could leave a trailing fragment with nothing speakable in it, which the engine renders as nothing at all. (#1330)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- The dictation hotkey no longer leaves a blank dark square stuck on your desktop. A press that arrived while the pill was re-arming was dropped, and the window it had already opened had nothing in it and no way to close it. (#1398)
+- Dictation is more reliable to trigger: the hotkey listener no longer briefly detaches every time the pill changes state, so a press is never silently lost. (#1398)
 - Text ending in punctuation no longer wastes a whole synthesis pass on it. A chunk boundary could leave a trailing fragment with nothing speakable in it, which the engine renders as nothing at all. (#1330)
 - A take that is missing part of your text now says so instead of coming back quietly short. When the engine renders a sentence to nothing, the app names the missing text and suggests re-generating — until now the only way to notice was to read along. (#1330)
 - A long render on modest hardware is no longer abandoned as "too heavy for the available compute" while it is visibly working. A generate that keeps finishing chunks now extends its own deadline (bounded), the way a model download already could; one that stops producing anything still fails on time. (#1338, #1348, #1391)

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,4 +1,4 @@
-# Alembic configuration for OmniVoice Studio.
+# Alembic configuration for VoiceStudio.
 # Run from the repo root:  alembic -c alembic.ini <command>
 # Default commands:
 #   alembic upgrade head         — apply all pending migrations

--- a/backend.spec
+++ b/backend.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-# PyInstaller spec for OmniVoice Studio backend.
+# PyInstaller spec for VoiceStudio backend.
 #
 # Produces a one-folder bundle at dist/omnivoice-backend/ that Tauri launches
 # as a sidecar binary. Kept intentionally permissive with collect_all(...)

--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -1,4 +1,4 @@
-# ── OmniVoice Studio — Model Catalog ─────────────────────────────────────
+# ── VoiceStudio — Model Catalog ─────────────────────────────────────
 #
 # This file is the source of truth for all known HuggingFace models.
 # The backend loads it at startup via `load_model_catalog()`.

--- a/backend/engines/omnivoice_gguf/backend.py
+++ b/backend/engines/omnivoice_gguf/backend.py
@@ -172,7 +172,7 @@ def _binary_repair_hint() -> str:
     return (
         f"the bundled GGUF runtime is not usable on this machine — build it "
         f"with `scripts/build-omnivoice-tts.sh --platform {_platform_slug()}`, "
-        f"reinstall OmniVoice Studio, or switch to the default in-process "
+        f"reinstall VoiceStudio, or switch to the default in-process "
         f"OmniVoice engine (Settings → Engines)"
     )
 
@@ -405,7 +405,7 @@ def _make_backend_class():
                         f"zero-byte placeholders until a real binary is "
                         f"built — run `scripts/build-omnivoice-tts.sh "
                         f"--platform {_platform_slug()}`, reinstall "
-                        f"OmniVoice Studio, or use the default in-process "
+                        f"VoiceStudio, or use the default in-process "
                         f"OmniVoice engine (Settings → Engines)."
                     )
                 # Manifest-based SHA-256 verification (T-04-01).
@@ -425,7 +425,7 @@ def _make_backend_class():
                     return False, (
                         f"GGUF binary {bin_path.name} is quarantined by "
                         f"macOS Gatekeeper. Run:\n\n"
-                        f"    xattr -cr '/Applications/OmniVoice Studio.app'\n\n"
+                        f"    xattr -cr '/Applications/VoiceStudio.app'\n\n"
                         f"This clears the quarantine on the .app and its "
                         f"bundled binaries. See docs/install/macos.md."
                     )

--- a/backend/services/sherpa_dictation.py
+++ b/backend/services/sherpa_dictation.py
@@ -33,6 +33,31 @@ logger = logging.getLogger("omnivoice.asr.sherpa")
 _PROVIDER = os.environ.get("OMNIVOICE_SHERPA_ASR_PROVIDER", "cpu")
 _NUM_THREADS = int(os.environ.get("OMNIVOICE_SHERPA_ASR_THREADS", "2"))
 
+# The 0.6B models need more than the 2-thread default to hold a comfortable
+# real-time factor. At 2 threads Parakeet measures RTF ~0.33 on older x64 —
+# it keeps up, but with almost no headroom, so a background compile or a
+# browser tab pushes decode behind the speaker and the pill visibly lags.
+# The small zipformers do not need it and are the fallback for exactly the
+# machines where spending cores is a bad trade, so this is per-model rather
+# than a global bump.
+#
+# Capped at the host's core count (and never below the base default) so a
+# 2-core laptop is not told to run 4 ASR threads, which costs more in
+# contention than it buys. This is a PERFORMANCE knob, not behaviour: every
+# platform runs the same models with the same results, so tuning it against
+# the host is inside the parity rule, not an exception to it.
+_LARGE_MODEL_THREADS = 4
+
+
+def _threads_for(spec: "SherpaModelSpec") -> int:
+    """Thread count for this model, honouring the env override verbatim."""
+    if "OMNIVOICE_SHERPA_ASR_THREADS" in os.environ:
+        return _NUM_THREADS
+    if not getattr(spec, "heavy", False):
+        return _NUM_THREADS
+    cores = os.cpu_count() or 1
+    return max(_NUM_THREADS, min(_LARGE_MODEL_THREADS, cores))
+
 
 def _endpoint_rules() -> tuple[float, float]:
     """Trailing-silence endpoint rules (seconds) for streaming recognizers.
@@ -65,10 +90,11 @@ class SherpaModelSpec:
     label: str
     tag: str            # "offline" | "streaming"
     kind: str           # recognizer factory selector
-    size_gb: float
+    size_gb: float     # on-disk download size, measured — see _MODELS header
     languages: str
     files: dict[str, str]
     recommended: bool = False
+    heavy: bool = False             # 0.6B-class: more decode threads (_threads_for)
     model_type: str = ""           # offline transducer only (nemo_transducer)
     extra: dict = field(default_factory=dict)
 
@@ -79,6 +105,21 @@ class SherpaModelSpec:
 
 # ── The 7 models (HF repo ids under csukuangfj/, filenames VERIFIED against the
 #    live HF /api/models/<repo>/tree/main on 2026-06-25; int8 variants pinned).
+#
+#    `size_gb` is the sum of the pinned `files` for each repo, MEASURED from
+#    the same HF tree API on 2026-08-07 — not estimated. Every one of the seven
+#    was wrong before, and in both directions, which is worse than uniformly
+#    optimistic: the two Parakeets under-reported by ~3.8x (0.18 -> 0.67 GB),
+#    so the recommended default quietly downloaded four times what the picker
+#    promised on a metered or small-disk machine; but the two low-RAM
+#    zipformers OVER-reported by ~3x (0.128 -> 0.044), making the fallback
+#    models look bulkier than the heavyweights they exist to rescue users
+#    from. tests/test_sherpa_model_sizes.py pins these against the manifest.
+#
+#    Note this is DISK. Peak RSS is substantially higher for the 0.6B models
+#    because onnxruntime's arena allocator does not return freed blocks
+#    (sherpa-onnx#2626); the picker labels the figure as download size rather
+#    than implying it is the memory cost.
 _MODELS: dict[str, SherpaModelSpec] = {
     "sherpa-parakeet-tdt-v3": SherpaModelSpec(
         id="sherpa-parakeet-tdt-v3",
@@ -86,9 +127,10 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Parakeet TDT v3",
         tag="offline",
         kind="offline-transducer",
-        size_gb=0.18,
+        size_gb=0.67,
         languages="25 European languages",
         recommended=True,
+        heavy=True,
         model_type="nemo_transducer",
         files={
             "encoder": "encoder.int8.onnx",
@@ -103,8 +145,9 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Parakeet TDT v2",
         tag="offline",
         kind="offline-transducer",
-        size_gb=0.17,
+        size_gb=0.66,
         languages="English",
+        heavy=True,
         model_type="nemo_transducer",
         files={
             "encoder": "encoder.int8.onnx",
@@ -119,7 +162,7 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Zipformer Bilingual",
         tag="streaming",
         kind="online-transducer",
-        size_gb=0.13,
+        size_gb=0.2,
         languages="Chinese + English",
         files={
             "encoder": "encoder-epoch-99-avg-1.int8.onnx",
@@ -134,7 +177,7 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Paraformer Bilingual",
         tag="streaming",
         kind="online-paraformer",
-        size_gb=0.115,
+        size_gb=0.24,
         languages="Chinese + English",
         files={
             "encoder": "encoder.int8.onnx",
@@ -148,7 +191,7 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Zipformer Streaming EN",
         tag="streaming",
         kind="online-transducer",
-        size_gb=0.128,
+        size_gb=0.044,
         languages="English",
         files={
             "encoder": "encoder-epoch-99-avg-1.int8.onnx",
@@ -163,7 +206,7 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Zipformer Streaming ZH",
         tag="streaming",
         kind="online-transducer",
-        size_gb=0.074,
+        size_gb=0.025,
         languages="Chinese",
         files={
             "encoder": "encoder-epoch-99-avg-1.int8.onnx",
@@ -178,7 +221,7 @@ _MODELS: dict[str, SherpaModelSpec] = {
         label="Whisper Tiny",
         tag="offline",
         kind="offline-whisper",
-        size_gb=0.116,
+        size_gb=0.104,
         languages="90+ languages (auto-detect)",
         files={
             "encoder": "tiny-encoder.int8.onnx",
@@ -271,7 +314,7 @@ def build_offline_recognizer(spec: SherpaModelSpec, *, download: bool = True):
             decoder=p("decoder"),
             joiner=p("joiner"),
             tokens=p("tokens"),
-            num_threads=_NUM_THREADS,
+            num_threads=_threads_for(spec),
             provider=_PROVIDER,
             decoding_method="greedy_search",
             model_type=spec.model_type or "nemo_transducer",
@@ -281,7 +324,7 @@ def build_offline_recognizer(spec: SherpaModelSpec, *, download: bool = True):
             encoder=p("encoder"),
             decoder=p("decoder"),
             tokens=p("tokens"),
-            num_threads=_NUM_THREADS,
+            num_threads=_threads_for(spec),
             provider=_PROVIDER,
             language="",          # auto-detect
             task="transcribe",
@@ -310,7 +353,7 @@ def build_online_recognizer(spec: SherpaModelSpec, *, download: bool = True):
             encoder=p("encoder"),
             decoder=p("decoder"),
             joiner=p("joiner"),
-            num_threads=_NUM_THREADS,
+            num_threads=_threads_for(spec),
             provider=_PROVIDER,
             decoding_method="greedy_search",
             enable_endpoint_detection=True,
@@ -323,7 +366,7 @@ def build_online_recognizer(spec: SherpaModelSpec, *, download: bool = True):
             tokens=p("tokens"),
             encoder=p("encoder"),
             decoder=p("decoder"),
-            num_threads=_NUM_THREADS,
+            num_threads=_threads_for(spec),
             provider=_PROVIDER,
             decoding_method="greedy_search",
             enable_endpoint_detection=True,

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,5 @@
 # ──────────────────────────────────────────────────────────────
-#  OmniVoice Studio — Docker Compose
+#  VoiceStudio — Docker Compose
 #
 #  Quick start:
 #    docker compose -f deploy/docker-compose.yml --profile cpu up    # CPU mode

--- a/docs/mcp.json
+++ b/docs/mcp.json
@@ -1,11 +1,11 @@
 {
-  "_comment": "MCP client config for OmniVoice Studio. See docs/mcp.md for both connection modes.",
+  "_comment": "MCP client config for VoiceStudio. See docs/mcp.md for both connection modes.",
   "_streamable_http": "If your MCP client speaks Streamable HTTP, point it directly at the running app: http://localhost:3900/mcp — no separate process needed (the server is mounted on the backend). Send an X-OmniVoice-Client-Id header to bind this agent to a specific voice.",
   "mcpServers": {
     "omnivoice": {
       "command": "python",
       "args": ["-m", "backend.mcp_shim"],
-      "cwd": "/path/to/OmniVoice-Studio",
+      "cwd": "/path/to/VoiceStudio",
       "env": {
         "OMNIVOICE_PORT": "3900",
         "OMNIVOICE_CLIENT_ID": "claude-code"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OmniVoice Studio</title>
+    <title>VoiceStudio</title>
   </head>
   <body style="background:#1d2021">
     <div id="root"></div>

--- a/frontend/src-tauri/appimage/AppRun
+++ b/frontend/src-tauri/appimage/AppRun
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# OmniVoice Studio — AppImage launcher
+# VoiceStudio — AppImage launcher
 #
 # Issue #56: AppImage shows a white screen on Fedora 44 / Ubuntu 24.04.
 # Root cause: WebKitGTK 2.44.x / 2.46.x has a compositing-path regression on

--- a/frontend/src-tauri/debian/postinst
+++ b/frontend/src-tauri/debian/postinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# OmniVoice Studio — .deb post-install hook.
+# VoiceStudio — .deb post-install hook.
 #
 # Issue #76: prior versions placed bundled ffprobe at /usr/bin/ffprobe via
 # Tauri's externalBin, overwriting the system ffprobe on Ubuntu 26.04 + others.

--- a/frontend/src-tauri/debian/postrm
+++ b/frontend/src-tauri/debian/postrm
@@ -1,5 +1,5 @@
 #!/bin/sh
-# OmniVoice Studio — .deb post-remove hook.
+# VoiceStudio — .deb post-remove hook.
 #
 # Cleans up the relocated ffprobe directory tree on purge/remove. We only
 # remove our own files — never the parent /usr/lib if other packages share it.

--- a/frontend/src-tauri/debian/preinst
+++ b/frontend/src-tauri/debian/preinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# OmniVoice Studio — .deb pre-install hook.
+# VoiceStudio — .deb pre-install hook.
 #
 # Ensure the target directory exists before dpkg writes the bundled ffprobe to
 # /usr/lib/omnivoice-studio/bin/. dpkg creates parent dirs for files in the

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -91,6 +91,13 @@ const ERROR_AUTO_DISMISS_MS = 8000;
 // that a user who sees an empty capsule does not have to live with it.
 const IDLE_VISIBLE_GRACE_MS = 1200;
 
+// How often we re-check that invariant while idle. The window is shown by the
+// Rust side, so there is no React state change to key off when a press is
+// dropped — only polling catches a window that became visible while we were
+// already idle. One `isVisible()` IPC per tick, skipped entirely whenever the
+// document reports itself hidden (the overwhelmingly common case).
+const IDLE_VISIBLE_POLL_MS = 600;
+
 // A dictation model id is a sherpa-onnx live model when it carries the
 // `sherpa-` prefix the backend assigns (see services/sherpa_dictation.py). Only
 // then do we open the low-latency raw-PCM streaming path; anything else (or no
@@ -1245,27 +1252,57 @@ export default function CaptureWidget({ onDismiss }) {
   // Rather than patch each call site, converge on the invariant itself: if we
   // are idle and the window is still visible a beat later, hide it. One effect
   // covers every path that exists now and every one added later.
+  // A one-shot timer keyed on the transition into `idle` is not enough: the
+  // window is shown by the Rust side, and `state` does not change when a press
+  // is dropped. So a press arriving while we are ALREADY idle shows the window
+  // without re-running this effect, and the square strands exactly as before —
+  // the same bug, one path over. Poll instead, so the invariant holds no matter
+  // who made the window visible or when (CodeRabbit, #1399).
   useEffect(() => {
-    if (state !== 'idle' || !inTauri()) return;
+    if (state !== 'idle' || !inTauri()) return undefined;
     let cancelled = false;
-    const t = setTimeout(async () => {
+    // Grace is measured from when the window was first SEEN visible-while-idle,
+    // not from the effect mounting: a real dictation shows the window a beat
+    // before React flips out of `idle`, and hiding it in that gap would cancel
+    // the very session the user just started.
+    let visibleSince = 0;
+
+    const reconcile = async () => {
+      // A positively-hidden document cannot be a stranded pill, and skipping
+      // the IPC keeps the common case free. Platforms that never report hidden
+      // just pay for the check — correct either way.
+      if (typeof document !== 'undefined' && document.hidden) {
+        visibleSince = 0;
+        return;
+      }
       try {
         const { getCurrentWindow } = await import('@tauri-apps/api/window');
         const win = getCurrentWindow();
         // Only the standalone widget window owns its own visibility; the
         // in-app pill is just a DOM node in the main window.
         if (cancelled || win.label !== 'widget') return;
-        if (await win.isVisible()) {
-          console.warn('capture: widget window visible while idle — hiding it');
-          await win.hide();
+        if (!(await win.isVisible())) {
+          visibleSince = 0;
+          return;
         }
+        const now = Date.now();
+        if (!visibleSince) {
+          visibleSince = now;
+          return;
+        }
+        if (now - visibleSince < IDLE_VISIBLE_GRACE_MS) return;
+        console.warn('capture: widget window visible while idle — hiding it');
+        await win.hide();
+        visibleSince = 0;
       } catch (err) {
         console.warn('capture: idle-visibility reconcile failed:', err);
       }
-    }, IDLE_VISIBLE_GRACE_MS);
+    };
+
+    const id = setInterval(reconcile, IDLE_VISIBLE_POLL_MS);
     return () => {
       cancelled = true;
-      clearTimeout(t);
+      clearInterval(id);
     };
   }, [state]);
 

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -85,6 +85,12 @@ const WAVE_BARS = 12;
 // failed session can't leave the widget parked on screen indefinitely.
 const ERROR_AUTO_DISMISS_MS = 8000;
 
+// How long the widget window may stay visible while the pill is idle before we
+// treat it as stranded and hide it. Long enough that the normal show → emit →
+// startRecording() handshake (a few frames) is never interrupted, short enough
+// that a user who sees an empty capsule does not have to live with it.
+const IDLE_VISIBLE_GRACE_MS = 1200;
+
 // A dictation model id is a sherpa-onnx live model when it carries the
 // `sherpa-` prefix the backend assigns (see services/sherpa_dictation.py). Only
 // then do we open the low-latency raw-PCM streaming path; anything else (or no
@@ -299,6 +305,25 @@ export default function CaptureWidget({ onDismiss }) {
   useEffect(() => {
     enabledRef.current = dictationEnabled;
   }, [dictationEnabled]);
+  // `state` follows the same rule, and for a sharper reason than the prefs do.
+  // The tray listener used to depend on [state], so every single state change
+  // tore the Tauri listener down and re-attached it through an `await import()`
+  // + `await listen()` — a gap with NOTHING listening. A shortcut press that
+  // landed in that gap was lost, and because the Rust side shows the widget
+  // window BEFORE it emits `tray-dictate` (lib.rs), a lost press left the
+  // window visible with the pill stuck in `idle` — which renders null, so all
+  // the user saw was an empty square that Esc could not clear (the widget
+  // deliberately never takes focus on macOS/Windows, #287/#982). Reading state
+  // through a ref lets the listener attach exactly once, for the lifetime of
+  // the component, so there is no gap to lose a press in.
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+  // Same reason: the trigger callbacks are defined further down and change
+  // identity, but the listener must not re-subscribe to follow them.
+  const startRecordingRef = useRef(null);
+  const stopRecordingRef = useRef(null);
 
   // Sherpa live-streaming session refs. `sherpaModeRef` flips on at start when a
   // sherpa model is selected; `committedRef` accumulates per-utterance finals so
@@ -406,35 +431,48 @@ export default function CaptureWidget({ onDismiss }) {
   useEffect(() => {
     if (!inTauri()) return; // browser webui — the keyboard fallback below runs
     let unlistenStart, unlistenStop;
+    let cancelled = false;
     (async () => {
       try {
         const { listen } = await import('@tauri-apps/api/event');
         unlistenStart = await listen('tray-dictate', () => {
-          if (!enabledRef.current) return;
-          if (state === 'setup') {
+          if (!enabledRef.current) {
+            // The hotkey is inert, but Rust has already shown the window.
+            // Put it back rather than leaving an empty capsule on screen.
+            hideWidgetWindow();
+            return;
+          }
+          const s = stateRef.current;
+          if (s === 'setup') {
             // Re-probe on each press — the user may have just granted access
             // in System Settings; if so, flow straight into recording.
             checkAccessibility().then((ok) => {
-              if (ok) startRecording();
+              if (ok) startRecordingRef.current?.();
             });
             return;
           }
-          const idle = state === 'idle' || state === 'done' || state === 'error';
+          const idle = s === 'idle' || s === 'done' || s === 'error';
           if (modeRef.current === 'toggle') {
             // Press once to start, again to stop.
-            if (idle) startRecording();
-            else if (state === 'recording') stopRecording();
+            if (idle) startRecordingRef.current?.();
+            else if (s === 'recording') stopRecordingRef.current?.();
           } else if (idle) {
             // Hold mode: keydown → start.
-            startRecording();
+            startRecordingRef.current?.();
           }
         });
         unlistenStop = await listen('tray-dictate-stop', () => {
           // Only hold mode acts on release; toggle ignores it.
-          if (modeRef.current === 'hold' && state === 'recording') {
-            stopRecording();
+          if (modeRef.current === 'hold' && stateRef.current === 'recording') {
+            stopRecordingRef.current?.();
           }
         });
+        // Unmounted while the dynamic import was in flight — drop the
+        // subscriptions we just created rather than leaking them.
+        if (cancelled) {
+          unlistenStart?.();
+          unlistenStop?.();
+        }
       } catch (err) {
         // Hotkey wiring failed inside Tauri — dictation still works via the
         // in-page shortcut, but say so in the console for bug reports.
@@ -442,10 +480,14 @@ export default function CaptureWidget({ onDismiss }) {
       }
     })();
     return () => {
+      cancelled = true;
       if (unlistenStart) unlistenStart();
       if (unlistenStop) unlistenStop();
     };
-  }, [state]);
+    // Attach ONCE — see stateRef above. Adding a dependency here reintroduces
+    // the dropped-press window that stranded the widget.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Keyboard fallback (web UI / Docker — no global tray hotkey). Mirrors the
   // tray semantics so the DEFAULT dictation behaviour is identical with or
@@ -1179,6 +1221,53 @@ export default function CaptureWidget({ onDismiss }) {
       setTranscript('');
     }
   }, [captureMode, applyResult, t]);
+
+  // Keep the trigger refs pointing at the current callbacks. No dep array: it
+  // must run after every render so the once-attached tray listener above never
+  // calls into a stale closure.
+  useEffect(() => {
+    startRecordingRef.current = startRecording;
+    stopRecordingRef.current = stopRecording;
+  });
+
+  // Safety net: the widget window must never sit on screen with nothing in it.
+  //
+  // Visibility is decided in Rust (lib.rs shows the window on the global
+  // shortcut, before emitting `tray-dictate`) but content is decided here, and
+  // nothing kept the two in agreement. Any path that shows the window without
+  // the pill reaching a drawing state — a dropped event, a hotkey pressed
+  // while dictation is disabled, a startRecording() that bails early — left an
+  // empty capsule stranded on the desktop. It could not be dismissed either:
+  // `idle` renders null so there is no X button, and the Esc handler never
+  // fires because the widget deliberately refuses focus on macOS and Windows
+  // (#287, #982).
+  //
+  // Rather than patch each call site, converge on the invariant itself: if we
+  // are idle and the window is still visible a beat later, hide it. One effect
+  // covers every path that exists now and every one added later.
+  useEffect(() => {
+    if (state !== 'idle' || !inTauri()) return;
+    let cancelled = false;
+    const t = setTimeout(async () => {
+      try {
+        const { getCurrentWindow } = await import('@tauri-apps/api/window');
+        const win = getCurrentWindow();
+        // Only the standalone widget window owns its own visibility; the
+        // in-app pill is just a DOM node in the main window.
+        if (cancelled || win.label !== 'widget') return;
+        if (await win.isVisible()) {
+          console.warn('capture: widget window visible while idle — hiding it');
+          await win.hide();
+        }
+      } catch (err) {
+        console.warn('capture: idle-visibility reconcile failed:', err);
+      }
+    }, IDLE_VISIBLE_GRACE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [state]);
 
   // Idle: render nothing — pill is hold-to-talk only (Whisper-Flow / Ghost-Pepper
   // style). The tray-dictate listener above stays mounted, so the shortcut still

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -1281,7 +1281,14 @@ export default function CaptureWidget({ onDismiss }) {
         // Only the standalone widget window owns its own visibility; the
         // in-app pill is just a DOM node in the main window.
         if (cancelled || win.label !== 'widget') return;
-        if (!(await win.isVisible())) {
+        const visible = await win.isVisible();
+        // Re-check AFTER the IPC. The thing that tears this effect down is
+        // recording starting — so a continuation resuming here is, precisely,
+        // the case where hiding would take the pill off screen at the moment
+        // the user began speaking. One check covers the rest of the function:
+        // nothing below awaits again before `hide()` (CodeRabbit, #1399).
+        if (cancelled) return;
+        if (!visible) {
           visibleSince = 0;
           return;
         }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -668,6 +668,34 @@ samp,
   overflow: hidden;
 }
 
+/* ═══ DICTATION WIDGET WINDOW ═══
+   The widget (`label: "widget"`, tauri.conf.json) is declared
+   `transparent: true` + `decorations: false` so the dictation pill floats as
+   a rounded capsule over whatever the user is dictating into. But it loads
+   the same index.html as the main window, so the chrome background above
+   applied to it too and painted an opaque, square-cornered rectangle across
+   the whole 300x64 window — visible as a dark block sitting on the desktop
+   whenever the pill itself wasn't drawing (see CaptureWidget's idle state).
+   Window transparency only shows through if every ancestor box is
+   transparent, so all three of html/body/#root have to opt out.
+   `data-window` is set in main-app.jsx once the window label is known. */
+html[data-window='widget'],
+html[data-window='widget'] body,
+html[data-window='widget'] #root {
+  background: transparent;
+  background-color: transparent;
+}
+
+html[data-window='widget'] #root {
+  /* Let clicks through the empty area around the capsule rather than
+     swallowing them on an invisible full-window box. */
+  pointer-events: none;
+}
+
+html[data-window='widget'] #root > * {
+  pointer-events: auto;
+}
+
 /* ═══ LAYOUT ═══ */
 .app-container {
   /* UI scale (#504 clipping fix + #21 black-band fix): the layout box is

--- a/frontend/src/main-app.jsx
+++ b/frontend/src/main-app.jsx
@@ -58,6 +58,16 @@ async function detectIsWidget() {
 export async function bootstrapApp() {
   const isWidget = await detectIsWidget();
 
+  // The widget window is `transparent: true` (tauri.conf.json), but it loads
+  // the SAME index.html as the main window — so `body { background-color:
+  // var(--chrome-bg) }` painted an opaque rectangle across all 300x64 of it,
+  // defeating the transparency and showing a hard-edged dark square wherever
+  // the pill happened to sit. Mark the document so index.css can scope the
+  // chrome background away for this window only. Set before the first render;
+  // the window is created hidden and only shown on a dictation trigger, so
+  // there is no window in which an unstyled frame can be seen.
+  if (isWidget) document.documentElement.dataset.window = 'widget';
+
   createRoot(document.getElementById('root')).render(
     <StrictMode>
       {/* Root error boundary — the missing layer between App's own render and

--- a/frontend/src/test/CaptureWidgetStrandedPill.test.jsx
+++ b/frontend/src/test/CaptureWidgetStrandedPill.test.jsx
@@ -157,6 +157,18 @@ describe('the widget window never strands empty', () => {
     expect(mocks.holder.hide).toHaveBeenCalled();
   });
 
+  // Advance fake timers in SMALL steps, flushing microtasks after each.
+  // `advanceTimersByTime` fires every due interval tick synchronously before any
+  // of their async bodies run, so a single big jump leaves all ticks observing
+  // the same frozen `Date.now()` — the grace period could never elapse and the
+  // reconcile would look broken when it is not.
+  const settle = async (ms) => {
+    await act(async () => {
+      vi.advanceTimersByTime(ms);
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+  };
+
   it('reconciles a visible-but-idle widget window to hidden', async () => {
     vi.useFakeTimers();
     renderWidget();
@@ -167,11 +179,10 @@ describe('the widget window never strands empty', () => {
     });
     expect(mocks.holder.hide).not.toHaveBeenCalled();
 
-    await act(async () => {
-      vi.advanceTimersByTime(2000);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    await settle(700); // first sighting — starts the grace clock
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+    await settle(700);
+    await settle(700); // grace elapsed
 
     expect(mocks.holder.isVisible).toHaveBeenCalled();
     expect(mocks.holder.hide).toHaveBeenCalled();
@@ -189,6 +200,45 @@ describe('the widget window never strands empty', () => {
     });
 
     expect(mocks.holder.isVisible).toHaveBeenCalled();
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+  });
+
+  it('reconciles a window that becomes visible LATER, while already idle', async () => {
+    // The hole in the first version of this fix: the reconcile was a one-shot
+    // timer keyed on the transition into `idle`. But the window is shown by the
+    // Rust side and a dropped press changes no React state — so a press
+    // arriving while we are already idle showed the window with no effect
+    // re-run, and the square stranded exactly as before. Same bug, one path
+    // over (CodeRabbit, #1399).
+    vi.useFakeTimers();
+    mocks.holder.isVisible.mockImplementation(async () => false);
+    renderWidget();
+
+    // Settle well past the grace period with the window hidden — the one-shot
+    // timer would have fired and been spent by now.
+    for (let i = 0; i < 5; i += 1) await settle(700);
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+
+    // Now something shows the window without any state change.
+    mocks.holder.isVisible.mockImplementation(async () => true);
+    for (let i = 0; i < 3; i += 1) await settle(700);
+
+    expect(mocks.holder.hide).toHaveBeenCalled();
+  });
+
+  it('does not hide a window that has only just become visible', async () => {
+    // The other half: a real dictation shows the window a beat BEFORE React
+    // leaves `idle`. Hiding inside that gap would cancel the session the user
+    // just started, so the grace runs from first-seen-visible, not from mount.
+    vi.useFakeTimers();
+    mocks.holder.isVisible.mockImplementation(async () => false);
+    renderWidget();
+
+    for (let i = 0; i < 5; i += 1) await settle(700);
+
+    mocks.holder.isVisible.mockImplementation(async () => true);
+    // One tick: seen visible for the first time — inside the grace period.
+    await settle(700);
     expect(mocks.holder.hide).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/test/CaptureWidgetStrandedPill.test.jsx
+++ b/frontend/src/test/CaptureWidgetStrandedPill.test.jsx
@@ -242,6 +242,41 @@ describe('the widget window never strands empty', () => {
     expect(mocks.holder.hide).not.toHaveBeenCalled();
   });
 
+  it('does not hide the widget when the effect is torn down mid-check', async () => {
+    // `isVisible()` is an IPC round-trip. The thing that tears this effect down
+    // is recording STARTING — so a continuation that resumes after the await is
+    // exactly the case where hiding would take the pill off screen at the
+    // instant the user began speaking (CodeRabbit, #1399).
+    vi.useFakeTimers();
+    const { unmount } = renderWidget();
+
+    // Get past the grace period so the next tick is the one that would hide.
+    await settle(700);
+    await settle(700);
+
+    let release;
+    mocks.holder.isVisible.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    );
+    // Fire a tick; it parks on the pending isVisible().
+    await settle(700);
+    expect(release).toBeTypeOf('function');
+
+    // Recording starts — the effect is cleaned up while the IPC is in flight.
+    unmount();
+
+    // Now the IPC answers "yes, visible". The stale continuation must stop.
+    await act(async () => {
+      release(true);
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+  });
+
   it('never hides the main window — only the standalone widget owns visibility', async () => {
     // The same component also renders as an in-app pill inside the main
     // window, where hiding the window would take the whole app off screen.

--- a/frontend/src/test/CaptureWidgetStrandedPill.test.jsx
+++ b/frontend/src/test/CaptureWidgetStrandedPill.test.jsx
@@ -1,0 +1,210 @@
+/**
+ * The dictation widget must never sit on screen with nothing in it.
+ *
+ * Visibility is decided in Rust — `lib.rs` shows the `widget` window on the
+ * global shortcut and *then* emits `tray-dictate` — while the content is
+ * decided in CaptureWidget. Nothing kept the two in agreement, and three
+ * defects compounded into one very visible bug:
+ *
+ *   1. The tray listener's effect depended on `[state]`, so every state change
+ *      tore the Tauri subscription down and re-attached it across an
+ *      `await import()` + `await listen()`. A shortcut press landing in that
+ *      gap was simply lost.
+ *   2. `state === 'idle'` renders null, so a window shown for a lost press had
+ *      no pill in it — and `body`'s opaque chrome background (index.css) made
+ *      the empty window a hard-edged dark square rather than nothing at all.
+ *   3. `dismiss()` was the only path that hid the window, and it is reachable
+ *      only from the X button, Esc, or a post-session timer. None of those can
+ *      fire for a session that never started — the X isn't rendered, and Esc
+ *      never arrives because the widget refuses focus on macOS/Windows
+ *      (#287, #982). The square was unrecoverable.
+ *
+ * These tests pin the two invariants that make the class impossible: the tray
+ * listener subscribes exactly once for the component's lifetime, and an idle
+ * widget window reconciles itself to hidden.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n';
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    dictationEnabled: true,
+    dictationMode: 'toggle',
+    dictationModelId: 'sherpa-parakeet-tdt-v3',
+    aecEnabled: false,
+    loadDictationPrefs: () => {},
+  };
+  const holder = {
+    a11y: true,
+    // Handlers captured from `listen()`, keyed by event name.
+    handlers: {},
+    listenCalls: [],
+    hide: vi.fn(async () => {}),
+    isVisible: vi.fn(async () => true),
+    label: 'widget',
+  };
+  return { state, holder };
+});
+
+vi.mock('../store', () => ({
+  useAppStore: Object.assign((sel) => sel(mocks.state), { getState: () => mocks.state }),
+}));
+vi.mock('../api/client', () => ({
+  wsUrl: (p) => `ws://test${p}`,
+  apiFetch: vi.fn(async () => ({ json: async () => ({}) })),
+}));
+vi.mock('../pages/Transcriptions', () => ({ addTranscription: vi.fn() }));
+vi.mock('../utils/copyText', () => ({ copyText: vi.fn(async () => {}) }));
+vi.mock('react-hot-toast', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: async (cmd) => {
+    if (cmd === 'check_accessibility') return mocks.holder.a11y;
+    return undefined;
+  },
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (name, fn) => {
+    mocks.holder.listenCalls.push(name);
+    mocks.holder.handlers[name] = fn;
+    return () => {};
+  }),
+}));
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    get label() {
+      return mocks.holder.label;
+    },
+    hide: mocks.holder.hide,
+    isVisible: mocks.holder.isVisible,
+  }),
+}));
+vi.mock('../utils/aec/micCapture', () => ({
+  startMicCapture: async () => async () => {},
+}));
+
+import CaptureWidget from '../components/CaptureWidget';
+
+const renderWidget = () =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <CaptureWidget />
+    </I18nextProvider>,
+  );
+
+beforeEach(() => {
+  window.__TAURI_INTERNALS__ = {};
+  mocks.holder.handlers = {};
+  mocks.holder.listenCalls = [];
+  mocks.holder.hide.mockClear();
+  mocks.holder.isVisible.mockClear();
+  mocks.holder.isVisible.mockImplementation(async () => true);
+  mocks.holder.a11y = true;
+  mocks.holder.label = 'widget';
+  mocks.state.dictationEnabled = true;
+  mocks.state.dictationMode = 'toggle';
+});
+
+afterEach(() => {
+  delete window.__TAURI_INTERNALS__;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('tray listener stability', () => {
+  it('subscribes exactly once even after the pill changes state', async () => {
+    // A denied Accessibility probe drives state idle → 'setup' on mount, which
+    // is a real state transition. With the old `[state]` dependency this tore
+    // the subscription down and re-listened, doubling the counts — and leaving
+    // a window with no listener attached in between, which is where presses
+    // were lost.
+    mocks.holder.a11y = false;
+    renderWidget();
+
+    await waitFor(() => {
+      expect(mocks.holder.handlers['tray-dictate']).toBeTypeOf('function');
+    });
+    // Let the state transition settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const starts = mocks.holder.listenCalls.filter((n) => n === 'tray-dictate');
+    const stops = mocks.holder.listenCalls.filter((n) => n === 'tray-dictate-stop');
+    expect(starts).toHaveLength(1);
+    expect(stops).toHaveLength(1);
+  });
+});
+
+describe('the widget window never strands empty', () => {
+  it('hides itself when a press arrives while dictation is disabled', async () => {
+    // Rust shows the window before it emits, and the emit is unconditional —
+    // it does not know the toggle is off. If the handler just returns, the
+    // window stays up with an idle (null-rendering) pill in it.
+    mocks.state.dictationEnabled = false;
+    renderWidget();
+
+    await waitFor(() => {
+      expect(mocks.holder.handlers['tray-dictate']).toBeTypeOf('function');
+    });
+    await act(async () => {
+      mocks.holder.handlers['tray-dictate']();
+      await Promise.resolve();
+    });
+
+    expect(mocks.holder.hide).toHaveBeenCalled();
+  });
+
+  it('reconciles a visible-but-idle widget window to hidden', async () => {
+    vi.useFakeTimers();
+    renderWidget();
+
+    // Nothing has happened yet — the grace period must not have elapsed.
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.holder.isVisible).toHaveBeenCalled();
+    expect(mocks.holder.hide).toHaveBeenCalled();
+  });
+
+  it('leaves an already-hidden window alone', async () => {
+    vi.useFakeTimers();
+    mocks.holder.isVisible.mockImplementation(async () => false);
+    renderWidget();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.holder.isVisible).toHaveBeenCalled();
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+  });
+
+  it('never hides the main window — only the standalone widget owns visibility', async () => {
+    // The same component also renders as an in-app pill inside the main
+    // window, where hiding the window would take the whole app off screen.
+    vi.useFakeTimers();
+    mocks.holder.label = 'main';
+    renderWidget();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.holder.hide).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/test/widgetWindowTransparency.test.jsx
+++ b/frontend/src/test/widgetWindowTransparency.test.jsx
@@ -1,0 +1,82 @@
+/**
+ * The dictation widget window must not paint the app's opaque chrome.
+ *
+ * The `widget` window is declared `transparent: true` + `decorations: false`
+ * in tauri.conf.json so the pill floats as a rounded capsule over whatever the
+ * user is dictating into. But it loads the SAME index.html as the main window,
+ * so `body { background-color: var(--chrome-bg) }` applied to it too and
+ * painted an opaque, square-cornered rectangle across the whole 300x64 window.
+ * With the pill idle (which renders null) the result was a bare dark square
+ * sitting on the desktop.
+ *
+ * The fix is a `data-window="widget"` marker on <html>, set from the window
+ * label before the first render, that index.css scopes the opt-out to. This
+ * pins the marker (the part logic can regress) and the CSS contract that
+ * consumes it — window transparency only shows through if EVERY ancestor box
+ * is transparent, so html, body and #root all have to be covered.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+vi.mock('../App.jsx', () => ({ default: () => null }));
+
+const setLabel = (label) =>
+  vi.doMock('@tauri-apps/api/window', () => ({
+    getCurrentWindow: () => ({ label }),
+  }));
+
+describe('the widget window marks itself on <html>', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+    delete document.documentElement.dataset.window;
+  });
+
+  afterEach(() => {
+    document.getElementById('root')?.remove();
+    delete document.documentElement.dataset.window;
+    vi.doUnmock('@tauri-apps/api/window');
+    vi.restoreAllMocks();
+  });
+
+  it('sets data-window="widget" when rendering in the widget window', async () => {
+    setLabel('widget');
+    const { bootstrapApp } = await import('../main-app.jsx');
+    await bootstrapApp();
+    expect(document.documentElement.dataset.window).toBe('widget');
+  });
+
+  it('leaves the main window unmarked, so it keeps the opaque chrome', async () => {
+    setLabel('main');
+    const { bootstrapApp } = await import('../main-app.jsx');
+    await bootstrapApp();
+    expect(document.documentElement.dataset.window).toBeUndefined();
+  });
+});
+
+describe('index.css honours the marker', () => {
+  const css = fs.readFileSync(
+    path.join(import.meta.dirname, '..', 'index.css'),
+    'utf8',
+  );
+
+  it('clears the background on html, body AND #root', () => {
+    // Any one of the three left opaque defeats the window transparency, so
+    // the selector list is the contract — not just "the file mentions it".
+    const marker = "html[data-window='widget']";
+    const start = css.indexOf(`${marker},`);
+    expect(start).toBeGreaterThan(-1);
+    const rule = css.slice(start, css.indexOf('}', start));
+    for (const sel of [marker, `${marker} body`, `${marker} #root`]) {
+      expect(rule).toContain(sel);
+    }
+    expect(rule).toContain('background: transparent');
+  });
+
+  it('does not disturb the main window background', () => {
+    expect(css).toContain('background-color: var(--chrome-bg)');
+  });
+});

--- a/frontend/src/test/widgetWindowTransparency.test.jsx
+++ b/frontend/src/test/widgetWindowTransparency.test.jsx
@@ -58,10 +58,7 @@ describe('the widget window marks itself on <html>', () => {
 });
 
 describe('index.css honours the marker', () => {
-  const css = fs.readFileSync(
-    path.join(import.meta.dirname, '..', 'index.css'),
-    'utf8',
-  );
+  const css = fs.readFileSync(path.join(import.meta.dirname, '..', 'index.css'), 'utf8');
 
   it('clears the background on html, body AND #root', () => {
     // Any one of the three left opaque defeats the window transparency, so

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -63,10 +63,10 @@ elif [ "$PLATFORM" = "windows" ]; then
   # (backend/core/config.py::get_app_data_dir) and relocates the HF cache to
   # %LOCALAPPDATA%\OmniVoice\hf_cache. Tauri keys its data by APP_ID under
   # LOCALAPPDATA; WebView2 state lives in EBWebView. All paths are APP_ID/
-  # VoiceStudio-scoped, and each rm is guarded by `[ -d ]`, so a slightly-off
+  # data-dir-scoped, and each rm is guarded by `[ -d ]`, so a slightly-off
   # path is a no-op, never a wrong delete.
   APP_DATA="${LOCALAPPDATA}/${APP_ID}"
-  BACKEND_DATA="${APPDATA}/VoiceStudio"
+  BACKEND_DATA="${APPDATA}/OmniVoice"
   TAURI_LOGS="${LOCALAPPDATA}/${APP_ID}/logs"
   WEBKIT_DATA="${LOCALAPPDATA}/${APP_ID}/EBWebView"
   HF_CACHE="${HF_HOME:-${LOCALAPPDATA}/OmniVoice/hf_cache}"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -86,11 +86,12 @@ if [ "$PLATFORM" = "macos" ]; then
 elif [ "$PLATFORM" = "windows" ]; then
   # Git Bash exposes Windows env vars; match backend/core/config.py paths.
   APP_DATA="${LOCALAPPDATA}/${APP_ID}"
-  OV_DATA="${APPDATA}/VoiceStudio"
+  OV_DATA="${APPDATA}/OmniVoice"
   HF_CACHE="${HF_HOME:-${LOCALAPPDATA}/OmniVoice/hf_cache}"
 else
   APP_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/${APP_ID}"
-  OV_DATA="${XDG_DATA_HOME:-$HOME/.local/share}/VoiceStudio"
+  # Linux: the backend uses ~/.omnivoice, NOT XDG (backend/core/config.py).
+  OV_DATA="$HOME/.omnivoice"
   HF_CACHE="${HF_HOME:-$HOME/.cache/huggingface}"
 fi
 

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   VoiceStudio — clean uninstaller (Windows).
 

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-  OmniVoice Studio — clean uninstaller (Windows).
+  VoiceStudio — clean uninstaller (Windows).
 
 .DESCRIPTION
-  Finds every folder OmniVoice wrote (app data, the managed Python env, config,
+  Finds every folder VoiceStudio wrote (app data, the managed Python env, config,
   logs) and — separately, because it's a SHARED cache — the Hugging Face model
   cache, prints each with its size, and removes them. Dry-run by default: it
   prints what it WOULD delete and stops, so you always see the plan first.
@@ -72,10 +72,10 @@ foreach ($p in @($dataDir, $configDefault, $logsDefault, $userEnvDir)) {
   if (Test-Path -LiteralPath $p) { $appTargets += $p }
 }
 
-Write-Host 'OmniVoice Studio uninstaller (Windows)'
-Write-Host '--------------------------------------'
+Write-Host 'VoiceStudio uninstaller (Windows)'
+Write-Host '---------------------------------'
 if ($appTargets.Count -eq 0) {
-  Write-Host 'No OmniVoice app data / env / config folders found at the default or'
+  Write-Host 'No VoiceStudio app data / env / config folders found at the default or'
   Write-Host 'env-configured locations. Nothing to remove.'
 } else {
   Write-Host 'App data, managed Python env, config, and logs:'
@@ -94,7 +94,8 @@ Write-Host ''
 if (-not $Yes) {
   Write-Host 'DRY RUN — nothing deleted. Re-run with -Yes to remove the app folders'
   if ($modelsPresent) { Write-Host '         (add -Models to also remove the shared model cache).' }
-  Write-Host 'To remove the app itself: Settings > Apps > OmniVoice Studio > Uninstall.'
+  Write-Host 'To remove the app itself: Settings > Apps > VoiceStudio > Uninstall'
+  Write-Host '(listed as "OmniVoice Studio" if you have not updated since the rename).'
   exit 0
 }
 
@@ -148,4 +149,5 @@ if ($Models -and $modelsPresent) {
 
 Write-Host ''
 Write-Host "Done — removed $deleted folder(s)."
-Write-Host 'To remove the app itself: Settings > Apps > OmniVoice Studio > Uninstall.'
+Write-Host 'To remove the app itself: Settings > Apps > VoiceStudio > Uninstall'
+Write-Host '(listed as "OmniVoice Studio" if you have not updated since the rename).'

--- a/tests/probe/__init__.py
+++ b/tests/probe/__init__.py
@@ -1,4 +1,4 @@
-"""probe — a spec-driven test harness for OmniVoice Studio (and reusable beyond it).
+"""probe — a spec-driven test harness for VoiceStudio (and reusable beyond it).
 
 Design spine: **separate the Actor from the Judge.**
 

--- a/tests/scripts/test_uninstall_ping.py
+++ b/tests/scripts/test_uninstall_ping.py
@@ -170,3 +170,32 @@ def test_shellcheck_clean_if_available():
         ["shellcheck", "-S", "error", SH], capture_output=True, text=True
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_shipped_powershell_scripts_with_non_ascii_carry_a_utf8_bom():
+    """A BOM-less UTF-8 .ps1 is decoded with the ANSI code page by Windows
+    PowerShell 5.1 — still the default shell on Windows 10/11.
+
+    `uninstall.ps1` prints em-dashes in `Write-Host` output ("Model cache
+    (Hugging Face weights — SHARED …)"), so without a BOM the user running the
+    uninstaller sees mojibake in the very messages that explain what is about
+    to be deleted. Pinned rather than left to review: the BOM is invisible in a
+    diff, so an editor that "helpfully" strips it would go unnoticed until a
+    Windows user reported garbled output (CodeRabbit, #1399).
+
+    Scoped to `scripts/` — the vendored trees under `research/` are not ours.
+    """
+    scripts_dir = os.path.join(REPO, "scripts")
+    offenders = []
+    for name in sorted(os.listdir(scripts_dir)):
+        if not name.endswith(".ps1"):
+            continue
+        raw = open(os.path.join(scripts_dir, name), "rb").read()
+        if raw.startswith(b"\xef\xbb\xbf"):
+            continue
+        if any(ord(ch) > 127 for ch in raw.decode("utf-8")):
+            offenders.append(name)
+    assert not offenders, (
+        f"these shipped PowerShell scripts contain non-ASCII text but have no "
+        f"UTF-8 BOM, so Windows PowerShell 5.1 will mis-decode them: {offenders}"
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,5 @@
 """
-OmniVoice Studio API — Unit Test Suite
+VoiceStudio API — Unit Test Suite
 Tests all roadmap features: TaskManager, scene detection, lip-sync scoring,
 export endpoints (VTT, SRT, MP3, segments ZIP, stems ZIP), streaming TTS.
 

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -115,7 +115,7 @@ def test_kill_is_scoped_to_this_checkouts_build():
 
     Now that ``kill_running_instances`` runs on EVERY invocation rather than
     only on wipe runs, its pattern matters in a way it did not before. A bare
-    ``"OmniVoice Studio.app"`` matches the installed release app too, so a
+    ``"VoiceStudio.app"`` matches the installed release app too, so a
     developer running ``desktop-prod:run`` while using the shipped app would
     have it killed underneath them — losing unsaved work in a session this
     script never started. Previously that was masked: the kill only ran when
@@ -139,7 +139,7 @@ def test_kill_is_scoped_to_this_checkouts_build():
         f"build output, so it can match an installed app: {pgrep}"
     )
     assert "${APP_NAME}.app" not in pgrep, (
-        "kill_running_instances matches any 'OmniVoice Studio.app', including "
+        "kill_running_instances matches any 'VoiceStudio.app', including "
         f"the installed one in /Applications: {pgrep}"
     )
     # The installed copy still has to be surfaced — single-instance keys on the

--- a/tests/test_identity_paths_survive_the_rename.py
+++ b/tests/test_identity_paths_survive_the_rename.py
@@ -120,6 +120,43 @@ def test_no_windows_path_fixture_points_at_the_brand():
             assert bad not in rust, f"{rel} fixture points at a brand-named dir. {WHY}"
 
 
+@pytest.mark.parametrize(
+    "rel,var",
+    [
+        ("scripts/smoke-test.sh", "OV_DATA"),
+        ("scripts/desktop-prod.sh", "BACKEND_DATA"),
+    ],
+)
+def test_no_dev_script_resolves_a_brand_named_data_dir(rel, var):
+    """The shell scripts resolve the backend's data dir per platform.
+
+    They were missed by the first pass of this guard and the rename sweep
+    duly repointed the Windows and Linux branches at ``VoiceStudio`` — so
+    ``smoke-test.sh`` verified a directory the backend never writes (a smoke
+    test that passes while nothing was produced) and ``desktop-prod.sh``'s
+    wipe silently stopped clearing backend state on Windows. Both are
+    invisible on macOS, which is where they are usually run.
+
+    Assert on the assignment specifically: these files legitimately mention
+    the brand elsewhere (banners, comments), so a file-wide substring check
+    is exactly the too-weak assertion that let this through before.
+    """
+    src = _read(rel)
+    assignments = re.findall(rf"(?m)^\s*{var}=.*$", src)
+    assert assignments, f"no {var} assignment found in {rel}"
+    for line in assignments:
+        assert "VoiceStudio" not in line, (
+            f"{rel} resolves the backend data dir from the brand name: "
+            f"{line.strip()}. {WHY}"
+        )
+    joined = "\n".join(assignments)
+    for expected in ("Application Support/OmniVoice", "OmniVoice", ".omnivoice"):
+        assert expected in joined, (
+            f"{rel} lost the {expected!r} branch — it no longer agrees with "
+            f"backend/core/config.py. {WHY}"
+        )
+
+
 def test_the_uninstall_allowlist_still_recognises_our_paths():
     # is_recognizably_ours() refuses to delete anything it does not recognise.
     # If the paths were renamed but this list was not, uninstall and reset stop

--- a/tests/test_sherpa_dictation.py
+++ b/tests/test_sherpa_dictation.py
@@ -205,7 +205,12 @@ def test_recognizer_kind_constructs_and_transcribes(
     cls = fake_sherpa.OnlineRecognizer if is_online else fake_sherpa.OfflineRecognizer
     assert cls.factory == factory
     assert cls.last_kwargs["provider"] == "cpu"
-    assert cls.last_kwargs["num_threads"] == 2
+    # The thread count is per-model now (the 0.6B Parakeets get more than the
+    # 2-thread base default, capped at the host's cores). What this test owns
+    # is that the recognizer is built with whatever the policy resolved — the
+    # policy's own rules are pinned in tests/test_sherpa_model_sizes.py.
+    assert cls.last_kwargs["num_threads"] == sd._threads_for(spec)
+    assert cls.last_kwargs["num_threads"] >= 2
     if kind == "offline-transducer":
         assert cls.last_kwargs["model_type"] == "nemo_transducer"
     if kind == "offline-whisper":

--- a/tests/test_sherpa_model_sizes.py
+++ b/tests/test_sherpa_model_sizes.py
@@ -21,6 +21,7 @@ Re-measure with:
 
     RUN_NETWORK_TESTS=1 uv run pytest tests/test_sherpa_model_sizes.py -q
 """
+import importlib
 import json
 import os
 import sys
@@ -32,12 +33,18 @@ sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"
 ))
 
-from services.sherpa_dictation import (  # noqa: E402
-    _LARGE_MODEL_THREADS,
-    _MODELS,
-    _NUM_THREADS,
-    _threads_for,
-)
+
+@pytest.fixture
+def sd():
+    """Resolve `services.sherpa_dictation` per test, never at collection.
+
+    Other suites stub `builtins.__import__` to exercise import fallbacks, which
+    rebinds the module in `sys.modules`. A module-level import would leave this
+    file holding a stale copy — monkeypatches would land on an object nothing
+    under test consults, and the tests would pass alone while silently going
+    vacuous in the full run (CodeRabbit, #1399).
+    """
+    return importlib.import_module("services.sherpa_dictation")
 
 # Measured 2026-08-07 by summing each spec's pinned `files` from
 # https://huggingface.co/api/models/<repo>/tree/main?recursive=1
@@ -57,17 +64,17 @@ MEASURED_GB = {
 TOLERANCE = 0.15  # 15%
 
 
-def test_every_model_is_covered():
+def test_every_model_is_covered(sd):
     """A new model must arrive with a measured size, not an estimate."""
-    assert set(_MODELS) == set(MEASURED_GB), (
+    assert set(sd._MODELS) == set(MEASURED_GB), (
         "the model list and the measured-size table have drifted; measure the "
         "new repo from the HF tree API rather than estimating it"
     )
 
 
 @pytest.mark.parametrize("model_id", sorted(MEASURED_GB))
-def test_declared_size_is_within_tolerance_of_the_measurement(model_id):
-    declared = _MODELS[model_id].size_gb
+def test_declared_size_is_within_tolerance_of_the_measurement(sd, model_id):
+    declared = sd._MODELS[model_id].size_gb
     actual = MEASURED_GB[model_id]
     assert actual * (1 - TOLERANCE) <= declared <= actual * (1 + TOLERANCE), (
         f"{model_id} advertises {declared} GB but the pinned files measure "
@@ -76,7 +83,7 @@ def test_declared_size_is_within_tolerance_of_the_measurement(model_id):
     )
 
 
-def test_the_small_fallbacks_are_smaller_than_the_heavy_models():
+def test_the_small_fallbacks_are_smaller_than_the_heavy_models(sd):
     """The property that made the old numbers actively misleading.
 
     The low-RAM zipformers exist to rescue users whose machine cannot carry a
@@ -84,10 +91,10 @@ def test_the_small_fallbacks_are_smaller_than_the_heavy_models():
     (0.128) as comparable to nothing it was smaller than — the ordering that
     users actually reason about was broken, not just the absolute figures.
     """
-    heavy = [s.size_gb for s in _MODELS.values() if s.heavy]
+    heavy = [m.size_gb for m in sd._MODELS.values() if m.heavy]
     fallbacks = [
-        _MODELS["sherpa-zipformer-en-20m"].size_gb,
-        _MODELS["sherpa-zipformer-zh-14m"].size_gb,
+        sd._MODELS["sherpa-zipformer-en-20m"].size_gb,
+        sd._MODELS["sherpa-zipformer-zh-14m"].size_gb,
     ]
     assert heavy, "no model is marked heavy"
     assert max(fallbacks) < min(heavy), (
@@ -98,43 +105,60 @@ def test_the_small_fallbacks_are_smaller_than_the_heavy_models():
 # ── thread policy ──────────────────────────────────────────────────────────
 
 
-def test_only_the_large_models_ask_for_extra_threads():
-    for spec in _MODELS.values():
-        threads = _threads_for(spec)
+def test_only_the_large_models_ask_for_extra_threads(sd):
+    for spec in sd._MODELS.values():
+        threads = sd._threads_for(spec)
         if spec.heavy:
-            assert threads >= _NUM_THREADS
+            assert threads >= sd._NUM_THREADS
         else:
-            assert threads == _NUM_THREADS, (
+            assert threads == sd._NUM_THREADS, (
                 f"{spec.id} is not a 0.6B model but asks for {threads} threads; "
                 f"the small models are the fallback for machines where spending "
                 f"cores is the wrong trade"
             )
 
 
-def test_the_thread_bump_never_exceeds_the_host_core_count(monkeypatch):
+def test_a_heavy_model_actually_reaches_the_larger_thread_count(monkeypatch, sd):
+    """The branch every other thread test only implies.
+
+    `test_only_the_large_models_ask_for_extra_threads` asserts `>= _NUM_THREADS`
+    for heavy models, which is satisfied by equality — so a regression that
+    quietly returned the base default for everything would pass the whole file
+    and the 0.6B models would silently lose their threads again. Pin the actual
+    value on a host with cores to spare (CodeRabbit, #1399).
+    """
+    monkeypatch.delenv("OMNIVOICE_SHERPA_ASR_THREADS", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 8)
+    heavy = [m for m in sd._MODELS.values() if m.heavy]
+    assert heavy, "no model is marked heavy"
+    for spec in heavy:
+        assert sd._threads_for(spec) == sd._LARGE_MODEL_THREADS
+
+
+def test_the_thread_bump_never_exceeds_the_host_core_count(monkeypatch, sd):
     monkeypatch.setattr(os, "cpu_count", lambda: 2)
-    heavy = next(s for s in _MODELS.values() if s.heavy)
-    assert _threads_for(heavy) <= 2
+    heavy = next(m for m in sd._MODELS.values() if m.heavy)
+    assert sd._threads_for(heavy) <= 2
 
 
-def test_a_single_core_host_still_gets_the_base_default(monkeypatch):
+def test_a_single_core_host_still_gets_the_base_default(monkeypatch, sd):
     # min() alone would hand back 1 thread; the floor keeps behaviour no worse
     # than it was before this policy existed.
     monkeypatch.setattr(os, "cpu_count", lambda: 1)
-    heavy = next(s for s in _MODELS.values() if s.heavy)
-    assert _threads_for(heavy) == _NUM_THREADS
+    heavy = next(m for m in sd._MODELS.values() if m.heavy)
+    assert sd._threads_for(heavy) == sd._NUM_THREADS
 
 
-def test_the_env_override_still_wins_for_every_model(monkeypatch):
+def test_the_env_override_still_wins_for_every_model(monkeypatch, sd):
     """`OMNIVOICE_SHERPA_ASR_THREADS` is a documented power-user override; the
     per-model policy must not quietly outrank what the user asked for."""
     monkeypatch.setenv("OMNIVOICE_SHERPA_ASR_THREADS", "1")
-    for spec in _MODELS.values():
-        assert _threads_for(spec) == _NUM_THREADS
+    for spec in sd._MODELS.values():
+        assert sd._threads_for(spec) == sd._NUM_THREADS
 
 
-def test_the_large_model_target_is_above_the_base_default():
-    assert _LARGE_MODEL_THREADS > _NUM_THREADS
+def test_the_large_model_target_is_above_the_base_default(sd):
+    assert sd._LARGE_MODEL_THREADS > sd._NUM_THREADS
 
 
 # ── the live check ─────────────────────────────────────────────────────────
@@ -145,8 +169,8 @@ def test_the_large_model_target_is_above_the_base_default():
     reason="hits huggingface.co; set RUN_NETWORK_TESTS=1 to re-measure",
 )
 @pytest.mark.parametrize("model_id", sorted(MEASURED_GB))
-def test_declared_sizes_match_the_published_repos(model_id):
-    spec = _MODELS[model_id]
+def test_declared_sizes_match_the_published_repos(sd, model_id):
+    spec = sd._MODELS[model_id]
     url = (
         f"https://huggingface.co/api/models/{spec.repo_id}"
         f"/tree/main?recursive=1"

--- a/tests/test_sherpa_model_sizes.py
+++ b/tests/test_sherpa_model_sizes.py
@@ -1,0 +1,171 @@
+"""The dictation model picker must not lie about download size.
+
+Every one of the seven `size_gb` values was wrong, and — unusually — in both
+directions, which is worse than being uniformly optimistic:
+
+  * the two 0.6B Parakeets under-reported by ~3.8x (0.18 -> 0.67 GB). The
+    recommended default therefore downloaded four times what the picker
+    promised, which matters on a metered connection or a small SSD.
+  * the two small zipformers OVER-reported by ~3x (0.128 -> 0.044 GB). Those
+    are the low-RAM fallbacks — the models a user drops to when the 0.6B one
+    is too heavy for their machine — and they were advertised as bulkier than
+    they are, discouraging exactly the choice that would have helped.
+
+`test_declared_sizes_match_the_published_repos` is the real check: it sums the
+pinned files from the HuggingFace tree API and compares. It needs the network,
+so it is opt-in via RUN_NETWORK_TESTS=1 and skipped in ordinary CI. The offline
+tests below hold the line without it — they encode the measurement taken on
+2026-08-07 so a hand-edit or a stale copy-paste fails locally and in CI.
+
+Re-measure with:
+
+    RUN_NETWORK_TESTS=1 uv run pytest tests/test_sherpa_model_sizes.py -q
+"""
+import json
+import os
+import sys
+import urllib.request
+
+import pytest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"
+))
+
+from services.sherpa_dictation import (  # noqa: E402
+    _LARGE_MODEL_THREADS,
+    _MODELS,
+    _NUM_THREADS,
+    _threads_for,
+)
+
+# Measured 2026-08-07 by summing each spec's pinned `files` from
+# https://huggingface.co/api/models/<repo>/tree/main?recursive=1
+MEASURED_GB = {
+    "sherpa-parakeet-tdt-v3": 0.670,
+    "sherpa-parakeet-tdt-v2": 0.661,
+    "sherpa-zipformer-bilingual-zh-en": 0.198,
+    "sherpa-paraformer-bilingual-zh-en": 0.237,
+    "sherpa-zipformer-en-20m": 0.044,
+    "sherpa-zipformer-zh-14m": 0.025,
+    "sherpa-whisper-tiny": 0.104,
+}
+
+# How far a declared value may sit from the measurement. Generous enough to
+# allow a rounded, human-readable number; tight enough that the 3-4x errors
+# this test exists to prevent can never pass.
+TOLERANCE = 0.15  # 15%
+
+
+def test_every_model_is_covered():
+    """A new model must arrive with a measured size, not an estimate."""
+    assert set(_MODELS) == set(MEASURED_GB), (
+        "the model list and the measured-size table have drifted; measure the "
+        "new repo from the HF tree API rather than estimating it"
+    )
+
+
+@pytest.mark.parametrize("model_id", sorted(MEASURED_GB))
+def test_declared_size_is_within_tolerance_of_the_measurement(model_id):
+    declared = _MODELS[model_id].size_gb
+    actual = MEASURED_GB[model_id]
+    assert actual * (1 - TOLERANCE) <= declared <= actual * (1 + TOLERANCE), (
+        f"{model_id} advertises {declared} GB but the pinned files measure "
+        f"{actual} GB. The picker is what a user decides on before spending "
+        f"their bandwidth and disk."
+    )
+
+
+def test_the_small_fallbacks_are_smaller_than_the_heavy_models():
+    """The property that made the old numbers actively misleading.
+
+    The low-RAM zipformers exist to rescue users whose machine cannot carry a
+    0.6B model. While they over-reported, the picker showed the 20M fallback
+    (0.128) as comparable to nothing it was smaller than — the ordering that
+    users actually reason about was broken, not just the absolute figures.
+    """
+    heavy = [s.size_gb for s in _MODELS.values() if s.heavy]
+    fallbacks = [
+        _MODELS["sherpa-zipformer-en-20m"].size_gb,
+        _MODELS["sherpa-zipformer-zh-14m"].size_gb,
+    ]
+    assert heavy, "no model is marked heavy"
+    assert max(fallbacks) < min(heavy), (
+        "a low-RAM fallback is advertised as larger than a 0.6B model"
+    )
+
+
+# ── thread policy ──────────────────────────────────────────────────────────
+
+
+def test_only_the_large_models_ask_for_extra_threads():
+    for spec in _MODELS.values():
+        threads = _threads_for(spec)
+        if spec.heavy:
+            assert threads >= _NUM_THREADS
+        else:
+            assert threads == _NUM_THREADS, (
+                f"{spec.id} is not a 0.6B model but asks for {threads} threads; "
+                f"the small models are the fallback for machines where spending "
+                f"cores is the wrong trade"
+            )
+
+
+def test_the_thread_bump_never_exceeds_the_host_core_count(monkeypatch):
+    monkeypatch.setattr(os, "cpu_count", lambda: 2)
+    heavy = next(s for s in _MODELS.values() if s.heavy)
+    assert _threads_for(heavy) <= 2
+
+
+def test_a_single_core_host_still_gets_the_base_default(monkeypatch):
+    # min() alone would hand back 1 thread; the floor keeps behaviour no worse
+    # than it was before this policy existed.
+    monkeypatch.setattr(os, "cpu_count", lambda: 1)
+    heavy = next(s for s in _MODELS.values() if s.heavy)
+    assert _threads_for(heavy) == _NUM_THREADS
+
+
+def test_the_env_override_still_wins_for_every_model(monkeypatch):
+    """`OMNIVOICE_SHERPA_ASR_THREADS` is a documented power-user override; the
+    per-model policy must not quietly outrank what the user asked for."""
+    monkeypatch.setenv("OMNIVOICE_SHERPA_ASR_THREADS", "1")
+    for spec in _MODELS.values():
+        assert _threads_for(spec) == _NUM_THREADS
+
+
+def test_the_large_model_target_is_above_the_base_default():
+    assert _LARGE_MODEL_THREADS > _NUM_THREADS
+
+
+# ── the live check ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    os.environ.get("RUN_NETWORK_TESTS") != "1",
+    reason="hits huggingface.co; set RUN_NETWORK_TESTS=1 to re-measure",
+)
+@pytest.mark.parametrize("model_id", sorted(MEASURED_GB))
+def test_declared_sizes_match_the_published_repos(model_id):
+    spec = _MODELS[model_id]
+    url = (
+        f"https://huggingface.co/api/models/{spec.repo_id}"
+        f"/tree/main?recursive=1"
+    )
+    req = urllib.request.Request(url, headers={"User-Agent": "voicestudio-tests"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        entries = {e["path"]: e for e in json.load(resp) if e["type"] == "file"}
+
+    total = 0
+    for role, fname in spec.files.items():
+        entry = entries.get(fname)
+        assert entry is not None, (
+            f"{spec.repo_id} no longer publishes {fname} (role {role}) — the "
+            f"pinned filename is stale, which breaks the download itself"
+        )
+        total += entry.get("size") or entry.get("lfs", {}).get("size") or 0
+
+    actual = total / 1e9
+    assert abs(actual - MEASURED_GB[model_id]) < 0.02, (
+        f"{model_id} now measures {actual:.3f} GB upstream; MEASURED_GB says "
+        f"{MEASURED_GB[model_id]}. Update both it and the spec's size_gb."
+    )


### PR DESCRIPTION
Closes #1398.

Two related fixes: the dictation bug the screenshot showed, and a data-dir regression the brand sweep introduced that I found while auditing the rename leftovers.

## The stranded square (#1398)

Three defects compounded into one unrecoverable artefact.

| # | Defect | Effect |
|---|---|---|
| 1 | `body { background-color: var(--chrome-bg) }` applies to the widget window, which loads the same `index.html` | `transparent: true` is defeated — an opaque, square-cornered rect |
| 2 | The `tray-dictate` listener effect depended on `[state]`, re-attaching across `await import()` + `await listen()` | A press landing in that gap is lost |
| 3 | Rust shows the window **before** emitting; `dismiss()` is the only hide path | A lost press strands the window |

Defect 3 is why it was unrecoverable: `idle` renders `null`, so there is no X button, and Esc never arrives because the widget deliberately refuses focus on macOS/Windows (#287, #982).

Rather than patch each call site, the third fix enforces the invariant itself — idle plus a visible widget window reconciles to hidden. That covers a press while dictation is disabled, a dropped event, and any path added later. It is scoped to the window labelled `widget`, so the in-app pill can never hide the main window.

## The data dirs the sweep broke

The rename rewrote three path literals that had to stay `OmniVoice`, because they name where the backend actually writes:

- `smoke-test.sh` resolved `%APPDATA%/VoiceStudio` on Windows and an XDG path on Linux — it verified a directory the backend never writes, so it can pass while nothing was produced.
- `desktop-prod.sh` wiped `%APPDATA%/VoiceStudio`, silently no longer clearing backend state on Windows.

Both are invisible on macOS, which is where they are normally run. The Linux branch of `smoke-test.sh` was independently wrong *before* the rename too (XDG vs `~/.omnivoice`), so all three platforms now match `backend/core/config.py` rather than only the two that were noticed.

The identity guard missed these because it covered only the Rust resolvers and the Windows fixtures. It now pins the shell scripts too, asserting on the **assignment lines** specifically — these files legitimately mention the brand in banners and comments, and a file-wide substring check is exactly the too-weak assertion that let this through.

Two remaining rebrand leftovers were factually wrong rather than merely stale: the GGUF engine told macOS users to `xattr -cr /Applications/OmniVoice Studio.app`, which no longer exists, and `uninstall.ps1` named the wrong Add/Remove Programs entry.

## Verification

- New tests fail before, pass after: 4/5 in `CaptureWidgetStrandedPill`, both halves of `widgetWindowTransparency`, and the new shell-script guard (verified by re-introducing the regression).
- Backend: 4362 passed, 25 skipped.
- Frontend: 210 files, 1685 tests passed. `typecheck:ci`, `format:check` clean; `lint` exits 0 and this change **reduces** CaptureWidget warnings 9 → 8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The PR prevents stranded dictation widget windows, stabilizes tray listeners, scopes transparency to the widget, restores `OmniVoice` data paths, and updates model sizes and threading. These changes address lost or disabled dictation events that could leave an opaque, empty window with no dismissal method. Human review should focus on widget visibility, cross-platform path assignments, and model thread-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->