### PR TITLE
chore(agents): record issue tracker, triage labels and domain-doc layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,17 @@ Binding for every AI agent (Claude, Codex, Cursor, review bots, …). CLAUDE.md 
 - Versioning: `frontend/package.json` is the single source of truth; never bump without the owner asking.
 - `frontend/package.json` dep changes require regenerating root `bun.lock` (Docker runs `--frozen-lockfile`).
 - Issues: absorb or decline — never defer to a future version. Check the open-PR queue before implementing community-reported fixes.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `debpalash/VoiceStudio`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,17 @@ Direct repo edits are authorized (owner decision, 2026-07-08). The GSD command g
 > Profile not yet configured. Run `/gsd-profile-user` to generate your developer profile.
 > This section is managed by `generate-claude-profile` -- do not edit manually.
 <!-- GSD:profile-end -->
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues on `debpalash/VoiceStudio`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,54 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — does not exist yet; see below.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+`CLAUDE.md` is the de-facto context document today — it carries the project
+constraints, the versioning/docs-sync/changelog/fix-quality rules, and the
+local-first guarantee. Read it as context alongside anything here.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,7 +4,7 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root — does not exist yet; see below.
+- **`CONTEXT.md`** at the repo root — read it whenever it exists. It has not been created yet, so today this usually resolves to nothing; see below.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in.
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
@@ -17,7 +17,7 @@ local-first guarantee. Read it as context alongside anything here.
 
 Single-context repo (most repos):
 
-```
+```text
 /
 ├── CONTEXT.md
 ├── docs/adr/
@@ -28,7 +28,7 @@ Single-context repo (most repos):
 
 Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
 
-```
+```text
 /
 ├── CONTEXT-MAP.md
 ├── docs/adr/                          ← system-wide decisions

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,65 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on
+[`debpalash/VoiceStudio`](https://github.com/debpalash/VoiceStudio). Use the `gh`
+CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## Repo rules that override the generic flow
+
+These come from `CLAUDE.md` and apply to anything a skill opens or merges here:
+
+- **Harvest bot reviews before merging.** CodeRabbit and Greptile auto-review every
+  PR. Read their inline comments — `gh api repos/debpalash/VoiceStudio/pulls/<n>/comments`
+  filtered by bot login — and triage them before merge. Never merge with an unread
+  Critical/P1. This applies to PRs a skill opened, not just human ones.
+- **Never merge with known findings outstanding.** Fix them on the PR branch; don't
+  merge-then-fix and don't leave them as comments for someone else.
+- **Gate every merge** on the "Tests (backend + frontend)" check passing and the PR
+  being `MERGEABLE`.
+- **Always pass an explicit `--body` to `gh pr merge --squash`.** Letting it
+  auto-generate injects `Co-authored-by:` trailers, which this repo forbids
+  (see the no-AI-attribution rule).
+- **Check the open-PR queue** before implementing any community-reported fix — a
+  contributor may already have submitted one.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,32 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Repo notes
+
+`wontfix` and `needs-info` **pre-date this file** — they were already in use on
+`debpalash/VoiceStudio` with exactly these names, which is why the mapping is an
+identity mapping rather than an alias table. Reuse them; do not create variants
+(`won't-fix`, `needs-information`) alongside them.
+
+`needs-triage`, `ready-for-agent` and `ready-for-human` were created for this
+vocabulary on 2026-08-07.
+
+This repo also carries labels outside the triage vocabulary — `bug`,
+`enhancement`, `documentation`, `question`, `duplicate`, `invalid`,
+`good first issue`, `help wanted`, `roadmap`, `from-discord`,
+`v0.3.0-investigate`. They classify *what* an issue is; the five above track
+*where it is in the queue*. The two sets are orthogonal — applying a triage
+label never means removing a type label.


### PR DESCRIPTION
Scaffolds the per-repo configuration the engineering skills (`to-tickets`, `triage`, `to-spec`, `qa`, `wayfinder`) expect. Without it each one guesses where issues live and what the label strings are.

- **`docs/agents/issue-tracker.md`** — GitHub Issues via `gh`, plus the repo rules that override the generic flow: harvest CodeRabbit/Greptile before merging, never merge with known findings, and always pass an explicit `--body` to `gh pr merge` (auto-generated bodies inject `Co-authored-by` trailers, which this repo forbids).
- **`docs/agents/triage-labels.md`** — the five canonical roles as an identity mapping. `wontfix` and `needs-info` already existed here with exactly these names, so `triage` reuses them rather than creating near-duplicates; `needs-triage`, `ready-for-agent` and `ready-for-human` were created to match.
- **`docs/agents/domain.md`** — single-context (`CONTEXT.md` + `docs/adr/`). The root `package.json` workspace has a single member, so the multi-context `CONTEXT-MAP.md` layout does not apply.

The `## Agent skills` block is mirrored into both `CLAUDE.md` and `AGENTS.md`, per the existing keep-the-two-in-sync convention.

Docs-only; no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds repository-specific guidance for GitHub issue tracking, triage labels, domain documentation, and synchronized agent skills. This gives engineering skills a consistent source for ticket workflows, context, ADRs, and merge rules. Human review should verify that the documented labels and repository workflows match current practice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->