### PR TITLE
fix(asr): stop a missing cuDNN 8 from killing the backend process (#1371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Transcription on an NVIDIA machine whose cuDNN 8 libraries are missing no longer kills the backend outright. The app checks the library before picking a transcription engine and falls back to PyTorch Whisper, instead of handing off to a component that aborts the process with no error and restarts into the same crash. (#1371)
 - Text ending in punctuation no longer wastes a whole synthesis pass on it. A chunk boundary could leave a trailing fragment with nothing speakable in it, which the engine renders as nothing at all. (#1330)
 - A take that is missing part of your text now says so instead of coming back quietly short. When the engine renders a sentence to nothing, the app names the missing text and suggests re-generating — until now the only way to notice was to read along. (#1330)
 - A long render on modest hardware is no longer abandoned as "too heavy for the available compute" while it is visibly working. A generate that keeps finishing chunks now extends its own deadline (bounded), the way a model download already could; one that stops producing anything still fails on time. (#1338, #1348, #1391)

--- a/backend/core/cudnn8.py
+++ b/backend/core/cudnn8.py
@@ -50,6 +50,9 @@ _LIB_GLOB = "cudnn*64_8.dll" if sys.platform == "win32" else "libcudnn*.so.8"
 
 _preloaded: bool = False
 _status: tuple[bool, str] | None = None
+# Handles from os.add_dll_directory (Windows). Held for the process lifetime —
+# dropping one un-registers its directory. See preload().
+_dll_dir_cookies: list = []
 
 
 def _project_root() -> str:
@@ -106,10 +109,16 @@ def preload() -> None:
             # Make the directory searchable by *name* as well, so a CTranslate2
             # LoadLibrary for a dependent library we did not preload explicitly
             # still resolves instead of aborting the process.
+            #
+            # The returned cookie must be KEPT: it is a context manager whose
+            # close/__del__ removes the directory again, so discarding it makes
+            # the call a silent no-op — the exact failure this module exists to
+            # prevent, reintroduced one line lower (CodeRabbit, #1401). Hold it
+            # for the life of the process.
             try:
-                os.add_dll_directory(lib_dir)
-            except (OSError, AttributeError):
-                pass
+                _dll_dir_cookies.append(os.add_dll_directory(lib_dir))
+            except (OSError, AttributeError) as e:
+                logger.debug("cuDNN 8 DLL directory not added (%s): %s", lib_dir, e)
         for so in sorted(glob.glob(os.path.join(lib_dir, _LIB_GLOB))):
             try:
                 ctypes.CDLL(so, mode=mode)

--- a/backend/core/cudnn8.py
+++ b/backend/core/cudnn8.py
@@ -1,0 +1,209 @@
+"""cuDNN 8 side-load, and — the point of this module — a *probe* for it.
+
+CTranslate2 (pinned at 4.4.0; the engine under WhisperX and faster-whisper)
+links against **cuDNN 8**, while PyTorch 2.8+ ships cuDNN 9. The two coexist:
+the Rust bootstrap side-loads ``nvidia-cudnn-cu12==8.9.7.29`` into a
+``cudnn8_compat/`` directory beside the venv's real site-packages (#827/#869),
+and we ``ctypes``-preload those libraries at startup so CTranslate2's own
+``LoadLibrary``/``dlopen`` finds them already resident in the process.
+
+When that side-load is missing, CTranslate2 does not raise. It prints
+
+    Could not locate cudnn_ops_infer64_8.dll. Please make sure it is in your
+    library path!
+
+and calls ``__fastfail`` — killing the **whole backend process** with
+``0xC0000409`` (STATUS_STACK_BUFFER_OVERRUN, surfaced as exit code
+``-1073740791``). Python never gets a frame, so there is no traceback, no
+fallback, and nothing for the crash notice to classify. The desktop shell
+restarts the backend, the user retries, and it dies again — #1371.
+
+The bug was never that the preload could fail. It is that we **computed the
+answer and threw it away**: the old inline preload in ``main.py`` silently
+``pass``-ed on a missing directory and on every ``OSError``, then handed
+control to a native library that treats the same condition as fatal. So this
+module keeps the outcome and exposes :func:`ctranslate2_cudnn_status`, letting
+``asr_backend`` route around a doomed engine *before* calling into it —
+exactly how the CTranslate2 exec-stack failure (#692) is already handled.
+
+Deliberately stdlib-only: ``engines/_asr_sidecar/main.py`` runs in a child
+process with a clean import path and must not drag in the heavy ``services``
+package to get this.
+"""
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+# The library CTranslate2 names in its own failure message. Probing the exact
+# one the error cites keeps the diagnosis honest — and because the probe runs
+# in the same process, through the same OS loader, a failure here is the same
+# failure CTranslate2 is about to hit.
+_SENTINEL_LIB = (
+    "cudnn_ops_infer64_8.dll" if sys.platform == "win32" else "libcudnn_ops_infer.so.8"
+)
+_LIB_GLOB = "cudnn*64_8.dll" if sys.platform == "win32" else "libcudnn*.so.8"
+
+_preloaded: bool = False
+_status: tuple[bool, str] | None = None
+
+
+def _project_root() -> str:
+    # backend/core/cudnn8.py → backend/core → backend → <project root>
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def compat_dirs() -> list[str]:
+    """Every plausible ``cudnn8_compat`` location, most specific first.
+
+    The old inline preload hardcoded ``<project root>/.venv``. That is right
+    for the managed desktop install and wrong everywhere else — a differently
+    named venv, ``uv run`` from a checkout, Docker, or a system Python all
+    resolve to a directory that does not exist, so the preload silently did
+    nothing and the process died later anyway. ``sys.prefix`` is where the
+    *running* interpreter actually lives, so it is checked too.
+    """
+    pyver = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    if sys.platform == "win32":
+        tail = (("Lib", "site-packages"), ("nvidia", "cudnn", "bin"))
+    else:
+        tail = (("lib", pyver, "site-packages"), ("nvidia", "cudnn", "lib"))
+    site_tail, lib_tail = tail
+
+    roots = [os.path.join(_project_root(), ".venv"), sys.prefix]
+    out: list[str] = []
+    for root in roots:
+        path = os.path.join(root, *site_tail, "cudnn8_compat", *lib_tail)
+        if path not in out:
+            out.append(path)
+    return out
+
+
+def preload() -> None:
+    """Load the side-loaded cuDNN 8 libraries into this process. Idempotent.
+
+    Best-effort by design — a host with no side-load is not an error here, it
+    is a fact :func:`ctranslate2_cudnn_status` reports later.
+    """
+    global _preloaded
+    if _preloaded:
+        return
+    _preloaded = True
+    if sys.platform == "darwin":  # no CUDA on macOS
+        return
+
+    import ctypes
+
+    mode = 0 if sys.platform == "win32" else ctypes.RTLD_GLOBAL
+    for lib_dir in compat_dirs():
+        if not os.path.isdir(lib_dir):
+            continue
+        if sys.platform == "win32":
+            # Make the directory searchable by *name* as well, so a CTranslate2
+            # LoadLibrary for a dependent library we did not preload explicitly
+            # still resolves instead of aborting the process.
+            try:
+                os.add_dll_directory(lib_dir)
+            except (OSError, AttributeError):
+                pass
+        for so in sorted(glob.glob(os.path.join(lib_dir, _LIB_GLOB))):
+            try:
+                ctypes.CDLL(so, mode=mode)
+            except OSError as e:
+                logger.debug("cuDNN 8 preload skipped %s: %s", so, e)
+        return  # first directory that exists wins
+
+
+def _torch_wants_cudnn8() -> tuple[bool, str]:
+    """Whether CTranslate2 will reach for cuDNN 8 *on this host at all*.
+
+    cuDNN is a CUDA library: with no CUDA device, CTranslate2 runs on the CPU
+    and never touches it, so a missing side-load is harmless and must not
+    disqualify the engine. ROCm is excluded for the same reason and one more —
+    ``torch.cuda.is_available()`` is True on a HIP build, but CTranslate2 has
+    no ROCm backend, so it is CPU-only there regardless. Without this branch a
+    Windows/CUDA fix would silently downgrade every ROCm user's ASR engine.
+    Mirrors ``bootstrap.rs::classify_cuda_probe``, which likewise declines to
+    install cuDNN 8 on HIP hosts (#124).
+    """
+    try:
+        import torch
+    except Exception as e:  # noqa: BLE001 — no torch: nothing will run anyway
+        return False, f"torch unavailable ({type(e).__name__})"
+    if getattr(getattr(torch, "version", None), "hip", None):
+        return False, "ROCm build — CTranslate2 has no ROCm backend, runs on CPU"
+    try:
+        if not torch.cuda.is_available():
+            return False, "no CUDA device — CTranslate2 runs on CPU"
+    except Exception as e:  # noqa: BLE001
+        return False, f"CUDA probe failed ({type(e).__name__})"
+    return True, "CUDA device present"
+
+
+def ctranslate2_cudnn_status() -> tuple[bool, str]:
+    """``(usable, reason)`` — can CTranslate2 load cuDNN 8 in this process?
+
+    Cached: the answer cannot change within a process, and it is consulted on
+    every ASR engine selection.
+
+    Conservative on purpose. A false negative costs a user WhisperX's forced
+    alignment (and so lip-sync accuracy), so this returns True whenever cuDNN 8
+    is not actually required, and only reports False for the one condition it
+    can prove: the library the failure message names will not load, here, now,
+    through the same loader CTranslate2 is about to use.
+    """
+    global _status
+    if _status is not None:
+        return _status
+    _status = _compute_status()
+    if not _status[0]:
+        logger.warning("CTranslate2 ASR engines unavailable: %s", _status[1])
+    return _status
+
+
+def _try_load(name: str) -> None:
+    """Load a shared library by *bare name*, raising OSError if it will not.
+
+    Deliberately its own seam: this runs in the same process and through the
+    same OS loader CTranslate2 is about to use, which is what makes the probe
+    faithful — and it gives tests a way to simulate a missing library without
+    replacing ``ctypes.CDLL`` process-wide (which would break torch's own load).
+    """
+    import ctypes
+
+    ctypes.CDLL(name)
+
+
+def _compute_status() -> tuple[bool, str]:
+    # No separate macOS branch: there is no CUDA there, so `_torch_wants_cudnn8`
+    # already answers "not required". One gate, testable on any platform.
+    needed, why = _torch_wants_cudnn8()
+    if not needed:
+        return True, f"cuDNN 8 not required ({why})"
+
+    preload()
+    try:
+        _try_load(_SENTINEL_LIB)
+    except OSError as e:
+        return False, (
+            f"CUDA is active but {_SENTINEL_LIB} cannot be loaded ({e}). "
+            f"WhisperX and faster-whisper are CTranslate2, which requires "
+            f"cuDNN 8; loading it is not optional and its absence aborts the "
+            f"backend process outright rather than raising (#1371). Reinstall "
+            f"the compat libraries with "
+            f"`uv pip install --target <venv>/{'Lib/site-packages' if sys.platform == 'win32' else 'lib/pythonX.Y/site-packages'}/cudnn8_compat "
+            f"nvidia-cudnn-cu12==8.9.7.29`, or pin a non-CTranslate2 engine "
+            f"with OMNIVOICE_ASR_BACKEND=pytorch-whisper."
+        )
+    return True, "cuDNN 8 loadable"
+
+
+def reset_cache_for_tests() -> None:
+    """Clear the memoised probe. Tests only."""
+    global _status, _preloaded
+    _status = None
+    _preloaded = False

--- a/backend/engines/_asr_sidecar/main.py
+++ b/backend/engines/_asr_sidecar/main.py
@@ -26,6 +26,21 @@ import traceback
 MAX_FRAME_BYTES = 64 * 1024 * 1024
 _model = None
 
+# The parent's cuDNN 8 preload lives in the parent PROCESS, and this is a child
+# with its own clean import path — so without this, an install whose side-loaded
+# cuDNN 8 makes the in-process engine work still had the isolated engine die on
+# every transcribe (#1371). Crash isolation turns that into a failed job rather
+# than a dead backend, which is why it went unnoticed: it fails quietly forever.
+# core.cudnn8 is stdlib-only, so importing it does not undo the cheap-startup
+# rule the module docstring sets out (unlike the heavy `services` package).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+try:
+    from core.cudnn8 import preload as _preload_cudnn8
+
+    _preload_cudnn8()
+except Exception:  # noqa: BLE001 — best-effort; never block the ready handshake
+    pass
+
 
 def _send(stream, obj):
     body = json.dumps(obj, separators=(",", ":")).encode("utf-8")

--- a/backend/main.py
+++ b/backend/main.py
@@ -96,35 +96,17 @@ except ImportError:
 
 # ── cuDNN 8 library preload ─────────────────────────────────────────────
 # CTranslate2 (used by faster-whisper / WhisperX) requires cuDNN 8, but
-# PyTorch 2.8+ pulls cuDNN 9. scripts/setup.py installs cuDNN 8
-# side-by-side into cudnn8_compat/ (survives `uv sync`). We preload all
-# cuDNN 8 libs via ctypes so CTranslate2's dlopen/LoadLibrary finds them.
-if sys.platform != "darwin":  # macOS has no CUDA
-    _project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    _pyver = f"python{sys.version_info.major}.{sys.version_info.minor}"
-    if sys.platform == "win32":
-        _cudnn8_lib = os.path.join(
-            _project_root, ".venv", "Lib", "site-packages",
-            "cudnn8_compat", "nvidia", "cudnn", "bin",
-        )
-        _cudnn8_glob = "cudnn*64_8.dll"
-    else:
-        _cudnn8_lib = os.path.join(
-            _project_root, ".venv", "lib", _pyver, "site-packages",
-            "cudnn8_compat", "nvidia", "cudnn", "lib",
-        )
-        _cudnn8_glob = "libcudnn*.so.8"
-    if os.path.isdir(_cudnn8_lib):
-        try:
-            import ctypes, glob
-            _mode = 0 if sys.platform == "win32" else ctypes.RTLD_GLOBAL
-            for _so in sorted(glob.glob(os.path.join(_cudnn8_lib, _cudnn8_glob))):
-                try:
-                    ctypes.CDLL(_so, mode=_mode)
-                except OSError:
-                    pass
-        except Exception:
-            pass
+# PyTorch 2.8+ pulls cuDNN 9, so the bootstrap side-loads cuDNN 8 into
+# cudnn8_compat/ and we preload it here for CTranslate2's dlopen/LoadLibrary.
+# Lives in core.cudnn8 so the ASR sidecar — a child process with its own clean
+# import path — gets the same preload, and so `asr_backend` can ASK whether it
+# worked instead of walking into a native __fastfail (#1371).
+try:
+    from core.cudnn8 import preload as _preload_cudnn8
+
+    _preload_cudnn8()
+except Exception:  # noqa: BLE001 — never block startup on a best-effort preload
+    pass
 
 # Route HF/Torch caches to a single external directory when requested.
 _cache_dir = os.environ.get("OMNIVOICE_CACHE_DIR")

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -212,6 +212,30 @@ def _is_compute_type_error(msg: str) -> bool:
     return "compute type" in low or "efficient float16" in low
 
 
+def _ctranslate2_cudnn_ok() -> tuple[bool, str]:
+    """Availability gate for the two CTranslate2 engines (WhisperX, faster-whisper).
+
+    Importing them proves nothing about cuDNN 8: CTranslate2 only reaches for it
+    when it builds a CUDA model, and if it is missing the library prints
+    ``Could not locate cudnn_ops_infer64_8.dll`` and ``__fastfail``s — taking the
+    whole backend down with 0xC0000409, no exception, no traceback, nothing to
+    fall back from (#1371). The shell restarts the backend, the user retries,
+    and it dies again.
+
+    So ask *before* selecting the engine, and let ``_auto_detect`` fall through
+    to pytorch-whisper — which runs on torch's own cuDNN 9 stack and exists for
+    exactly this case. Same shape as the #692 exec-stack handling: a native
+    library we cannot load makes the engine unavailable, not fatal.
+    """
+    try:
+        from core.cudnn8 import ctranslate2_cudnn_status
+
+        return ctranslate2_cudnn_status()
+    except Exception as e:  # noqa: BLE001 — a broken probe must not block ASR
+        logger.debug("cuDNN 8 probe unavailable (%s) — assuming usable", e)
+        return True, "ready"
+
+
 def _decode_audio_16k_mono(audio_path: str):
     """Decode `audio_path` to a 16 kHz mono float32 waveform using VoiceStudio's
     *validated* ffmpeg, instead of whisperx.load_audio's bare ``"ffmpeg"`` PATH
@@ -576,7 +600,6 @@ class WhisperXBackend(ASRBackend):
     def is_available(cls) -> tuple[bool, str]:
         try:
             import whisperx  # noqa: F401
-            return True, "ready"
         except ImportError as e:
             return False, f"whisperx not installed: {e}"
         except Exception as e:  # noqa: BLE001
@@ -586,6 +609,7 @@ class WhisperXBackend(ASRBackend):
             # availability probe must REPORT 'unusable here', never raise, so
             # engine selection falls back instead of crashing the ASR preflight.
             return False, f"whisperx failed to load ({type(e).__name__}): {e}"
+        return _ctranslate2_cudnn_ok()
 
     def ensure_loaded(self) -> None:
         # Surface a whisperx/CTranslate2/torch load failure at preflight (once,
@@ -939,7 +963,6 @@ class FasterWhisperBackend(ASRBackend):
     def is_available(cls) -> tuple[bool, str]:
         try:
             import faster_whisper  # noqa: F401
-            return True, "ready"
         except ImportError as e:
             return False, f"faster-whisper not installed: {e}"
         except Exception as e:  # noqa: BLE001
@@ -947,6 +970,7 @@ class FasterWhisperBackend(ASRBackend):
             # hardened kernels / newer glibc ("cannot enable executable stack",
             # #692) — an OSError. Report unavailable so we fall back, not crash.
             return False, f"faster-whisper failed to load ({type(e).__name__}): {e}"
+        return _ctranslate2_cudnn_ok()
 
     def _ensure_model(self):
         if self._model is not None:

--- a/backend/services/subprocess_asr.py
+++ b/backend/services/subprocess_asr.py
@@ -161,7 +161,13 @@ class IsolatedFasterWhisperBackend(SubprocessASRBackend):
             return False, f"faster-whisper not installed: {e}"
         if not cls.sidecar_script().is_file():
             return False, f"ASR sidecar script missing at {cls.sidecar_script()}"
-        return True, "ready"
+        # Same CTranslate2 engine, same cuDNN 8 requirement (#1371). Crash
+        # isolation means a missing cuDNN 8 kills only the child — so instead of
+        # a dead backend the user gets a sidecar that fails every transcribe
+        # with no explanation. Report it here, where Settings → Engines shows it.
+        from services.asr_backend import _ctranslate2_cudnn_ok
+
+        return _ctranslate2_cudnn_ok()
 
     @classmethod
     def venv_python(cls) -> Path:

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -280,6 +280,16 @@ Intel-Mac wheels, so this entry only applies to historical installs (see
 log shows `Could not locate cudnn_ops_infer64_8.dll`. Settings → Models shows
 WhisperX or faster-whisper selected.
 
+On builds before this was fixed, the failure looked much worse than a failed
+transcribe: CTranslate2 aborts the **process** rather than raising, so the whole
+backend died with `exit code -1073740791` (`0xC0000409`) and no error, the app
+restarted it, and the next attempt killed it again
+([#1371](https://github.com/debpalash/VoiceStudio/issues/1371)). VoiceStudio now
+checks whether cuDNN 8 will load *before* selecting a CTranslate2 engine and
+falls back to PyTorch Whisper instead, so a missing library costs you WhisperX's
+word-level alignment — not the backend. The repair below is still worth doing to
+get WhisperX back.
+
 **Cause:** WhisperX and faster-whisper run on **CTranslate2**, which needs
 **cuDNN 8**, but PyTorch 2.8 ships cuDNN 9. VoiceStudio side-loads a cuDNN-8 copy
 from `.venv\Lib\site-packages\cudnn8_compat\` — but the step that installs that

--- a/tests/test_cudnn8_hard_crash_1371.py
+++ b/tests/test_cudnn8_hard_crash_1371.py
@@ -22,6 +22,7 @@ crash it set out to fix.
 
 import importlib
 import importlib.util
+import os
 import sys
 
 import pytest
@@ -207,3 +208,34 @@ def test_the_asr_sidecar_preloads_cudnn8(monkeypatch, ab, cudnn8):
     finally:
         sys.path[:] = saved
     assert called, "the sidecar did not preload cuDNN 8 on startup"
+
+
+def test_the_windows_dll_directory_handle_is_retained(monkeypatch, tmp_path, cudnn8):
+    """`os.add_dll_directory` returns a context-manager cookie whose close (or
+    garbage collection) UN-registers the directory again.
+
+    Discarding it therefore makes the call a silent no-op — reintroducing, one
+    line lower, the exact failure this module exists to prevent: CTranslate2
+    does a bare-name LoadLibrary, misses, and aborts the process
+    (CodeRabbit, #1401).
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(cudnn8, "compat_dirs", lambda: [str(tmp_path)])
+    monkeypatch.setattr(cudnn8, "_dll_dir_cookies", [])
+
+    class Cookie:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    cookie = Cookie()
+    monkeypatch.setattr(os, "add_dll_directory", lambda d: cookie, raising=False)
+
+    cudnn8.preload()
+
+    assert cookie in cudnn8._dll_dir_cookies, (
+        "the add_dll_directory cookie was dropped, so the directory is "
+        "un-registered as soon as it is collected and the call does nothing"
+    )
+    assert cookie.closed is False

--- a/tests/test_cudnn8_hard_crash_1371.py
+++ b/tests/test_cudnn8_hard_crash_1371.py
@@ -1,0 +1,209 @@
+"""#1371 — a missing cuDNN 8 must not kill the backend process.
+
+CTranslate2 4.4.0 (the engine under WhisperX and faster-whisper) requires
+cuDNN 8 while torch ships cuDNN 9. When the side-loaded cuDNN 8 is absent,
+CTranslate2 does not raise — it prints ``Could not locate
+cudnn_ops_infer64_8.dll`` and ``__fastfail``s, taking the whole backend down
+with ``0xC0000409`` (exit code ``-1073740791``). There is no traceback to
+classify and no exception to fall back from, so the shell restarts the backend
+and the next transcribe kills it again.
+
+The backend already *knew*: ``main.py`` probed for the libraries and threw the
+answer away. These tests pin the fix — the answer is kept, and the two
+CTranslate2 engines report themselves unavailable so ``_auto_detect`` routes to
+pytorch-whisper (torch's own cuDNN 9 stack) instead of walking into the abort.
+
+The conservative half matters as much as the strict half: a false positive here
+costs a user WhisperX's forced alignment, and therefore lip-sync accuracy. So
+the "not gated" cases below (no CUDA, ROCm, macOS) are not padding — a fix that
+disqualified CTranslate2 on those hosts would be a worse regression than the
+crash it set out to fix.
+"""
+
+import importlib
+import importlib.util
+import sys
+
+import pytest
+
+_CUDA_PRESENT = (True, "CUDA device present")
+
+
+@pytest.fixture
+def cudnn8():
+    """Resolved per test, never bound at collection time.
+
+    Other suites re-import ``core.cudnn8`` (they stub ``builtins.__import__``
+    to exercise import fallbacks), which rebinds ``sys.modules`` to a fresh
+    module object. A module-level ``from core import cudnn8`` would then have
+    monkeypatches land on a stale copy that nothing under test consults — the
+    tests pass alone and fail in the full suite.
+    """
+    mod = importlib.import_module("core.cudnn8")
+    mod.reset_cache_for_tests()
+    yield mod
+    mod.reset_cache_for_tests()
+
+
+@pytest.fixture
+def ab():
+    """Ditto for the module under test."""
+    return importlib.import_module("services.asr_backend")
+
+
+@pytest.fixture
+def cudnn8_missing(monkeypatch, cudnn8):
+    """A CUDA host whose cuDNN 8 will not load — the #1371 machine."""
+    monkeypatch.setattr(cudnn8, "_preloaded", True)  # nothing to preload
+    monkeypatch.setattr(cudnn8, "_torch_wants_cudnn8", lambda: _CUDA_PRESENT)
+
+    def _no_lib(name):
+        raise OSError(f"Could not locate {name}")
+
+    monkeypatch.setattr(cudnn8, "_try_load", _no_lib)
+
+
+@pytest.fixture
+def ctranslate2_importable(monkeypatch):
+    """Make ``import whisperx`` / ``import faster_whisper`` succeed regardless of
+    what is installed, so these tests exercise the cuDNN gate rather than the
+    host's package set."""
+    for name in ("whisperx", "faster_whisper"):
+        monkeypatch.setitem(sys.modules, name, type(sys)(name))
+
+
+# ── the probe ──────────────────────────────────────────────────────────────
+
+
+def test_missing_cudnn8_on_a_cuda_host_is_reported_not_swallowed(cudnn8, cudnn8_missing):
+    ok, reason = cudnn8.ctranslate2_cudnn_status()
+    assert ok is False
+    # The message is the only thing standing between the user and a silent
+    # restart loop, so it must name the library and a way out.
+    assert "cudnn_ops_infer" in reason
+    assert "pytorch-whisper" in reason
+
+
+def test_the_probe_is_cached(monkeypatch, cudnn8, cudnn8_missing):
+    calls = []
+    real = cudnn8._compute_status
+    monkeypatch.setattr(cudnn8, "_compute_status", lambda: (calls.append(1), real())[1])
+    cudnn8.ctranslate2_cudnn_status()
+    cudnn8.ctranslate2_cudnn_status()
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    [
+        (False, "no CUDA device — CTranslate2 runs on CPU"),
+        (False, "ROCm build — CTranslate2 has no ROCm backend, runs on CPU"),
+        (False, "torch unavailable (ImportError)"),
+    ],
+)
+def test_hosts_that_never_need_cudnn8_are_not_disqualified(monkeypatch, cudnn8, verdict):
+    """cuDNN is a CUDA library. On a CPU box, a ROCm box, or one where torch is
+    missing entirely, CTranslate2 never loads it — gating there would downgrade
+    working installs for no reason. ROCm is the sharp edge:
+    ``torch.cuda.is_available()`` is True on a HIP build."""
+    monkeypatch.setattr(cudnn8, "_preloaded", True)
+    monkeypatch.setattr(cudnn8, "_torch_wants_cudnn8", lambda: verdict)
+
+    def _boom(*a, **kw):
+        raise AssertionError("probed for cuDNN 8 on a host that does not need it")
+
+    monkeypatch.setattr(cudnn8, "_try_load", _boom)
+    ok, reason = cudnn8.ctranslate2_cudnn_status()
+    assert ok is True
+    assert "not required" in reason
+
+
+def test_rocm_is_detected_from_torch_version_hip(monkeypatch, cudnn8):
+    """The HIP branch reads ``torch.version.hip`` *before* ``cuda.is_available()``
+    — which is True on ROCm — so pin the ordering, not just the outcome."""
+    torch = type(sys)("torch")
+    torch.version = type(sys)("version")
+    torch.version.hip = "6.2.0"
+    torch.cuda = type(sys)("cuda")
+    torch.cuda.is_available = lambda: True
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    needed, why = cudnn8._torch_wants_cudnn8()
+    assert needed is False
+    assert "ROCm" in why
+
+
+# ── the engines route around it ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("engine", ["WhisperXBackend", "FasterWhisperBackend"])
+def test_ctranslate2_engines_report_unavailable(engine, ab, cudnn8_missing, ctranslate2_importable):
+    """Before the fix both returned ``(True, "ready")`` here — the import
+    succeeds, because CTranslate2 only reaches for cuDNN when it builds a CUDA
+    model. That is precisely why the failure landed as a process kill."""
+    ok, reason = getattr(ab, engine).is_available()
+    assert ok is False
+    assert "cudnn_ops_infer" in reason
+
+
+def test_auto_detect_falls_back_to_pytorch_whisper(
+    monkeypatch, ab, cudnn8_missing, ctranslate2_importable
+):
+    monkeypatch.setattr(
+        ab.MLXWhisperBackend, "is_available", classmethod(lambda cls: (False, "n/a"))
+    )
+    assert ab._auto_detect() == "pytorch-whisper"
+
+
+def test_the_isolated_sidecar_engine_reports_the_same_reason(cudnn8_missing, ctranslate2_importable):
+    """Crash isolation makes the missing library a failed job instead of a dead
+    backend — which is worse than it sounds: it fails on every transcribe, with
+    nothing explaining why. Settings → Engines gets the reason."""
+    from services import subprocess_asr
+
+    ok, reason = subprocess_asr.IsolatedFasterWhisperBackend.is_available()
+    assert ok is False
+    assert "cudnn_ops_infer" in reason
+
+
+def test_a_broken_probe_never_blocks_asr(monkeypatch, ab, cudnn8, ctranslate2_importable):
+    """The gate is a safety net, not a new single point of failure."""
+    def _explode():
+        raise RuntimeError("probe itself is broken")
+
+    monkeypatch.setattr(cudnn8, "ctranslate2_cudnn_status", _explode)
+    assert ab._ctranslate2_cudnn_ok() == (True, "ready")
+    assert ab.WhisperXBackend.is_available()[0] is True
+
+
+# ── the preload reaches the venv that is actually running ──────────────────
+
+
+def test_compat_dirs_covers_the_running_interpreter(cudnn8):
+    """The old inline preload hardcoded ``<project root>/.venv``, so a
+    differently named venv, a Docker image or a system Python resolved to a
+    directory that does not exist — the preload silently did nothing and the
+    process died anyway."""
+    dirs = cudnn8.compat_dirs()
+    assert any(d.startswith(sys.prefix) for d in dirs), dirs
+    assert all("cudnn8_compat" in d for d in dirs)
+
+
+def test_the_asr_sidecar_preloads_cudnn8(monkeypatch, ab, cudnn8):
+    """The sidecar is a *child process* with a clean import path, so the
+    parent's preload does not reach it. An install whose side-load made the
+    in-process engine work still had the isolated engine fail every transcribe.
+    """
+    called = []
+    monkeypatch.setattr(cudnn8, "preload", lambda: called.append(1))
+    path = (
+        pytest.importorskip("pathlib").Path(ab.__file__).resolve().parents[1]
+        / "engines" / "_asr_sidecar" / "main.py"
+    )
+    spec = importlib.util.spec_from_file_location("_sidecar_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    saved = list(sys.path)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = saved
+    assert called, "the sidecar did not preload cuDNN 8 on startup"


### PR DESCRIPTION
Closes #1371.

## What happens today

On Windows + NVIDIA, `#1371`'s log ends with the diagnosis on its last line:

```
Could not locate cudnn_ops_infer64_8.dll. Please make sure it is in your library path!
```

CTranslate2 4.4.0 (the engine under WhisperX and faster-whisper) links against **cuDNN 8**; torch ships cuDNN 9. When the side-loaded cuDNN 8 is missing, CTranslate2 does not raise — it `__fastfail`s. The backend dies with `0xC0000409` (`exit code -1073740791`), no traceback, nothing for the crash notice to classify. The shell restarts it, the user retries, it dies again.

## Root cause

Not that the preload could fail — that it **computed the answer and threw it away**. The inline preload in `main.py` silently `pass`-ed on a missing directory and on every `OSError`, then handed control to a library that treats the same condition as fatal.

## Fix

`backend/core/cudnn8.py` owns the side-load and exposes a probe. The two CTranslate2 engines consult it in `is_available()`, so the existing `_auto_detect` falls through to `pytorch-whisper` — torch's own cuDNN 9 stack, already documented as the escape hatch for exactly this. Same shape as the #692 exec-stack handling.

Three call sites, because the class is wider than the report:

| | |
|---|---|
| **ASR sidecar** | a child process with a clean import path — it never preloaded at all, so an install whose side-load made the in-process engine work still had the isolated engine fail *every* transcribe. Crash isolation is why nobody noticed: it fails quietly forever instead of loudly once. |
| **Preload path** | hardcoded `<project root>/.venv`, so a differently named venv, Docker, or a system Python resolved to a directory that does not exist. Now also checks `sys.prefix`. |
| **Isolated engine** | reports the same reason, so Settings → Engines explains itself. |

## The conservative half is load-bearing

A false positive costs a user WhisperX's forced alignment, and so lip-sync accuracy. The probe reports unusable only for the one condition it can prove: the library the error names will not load, *in this process, through the same loader CTranslate2 is about to use*. Hosts that never need cuDNN 8 are left alone — and **ROCm is checked via `torch.version.hip` before `cuda.is_available()`, which is `True` on a HIP build**. Without that ordering this fix would have silently downgraded every ROCm user's ASR engine.

## Tests

13 regression tests, **6 fail before the fix**. They resolve `core.cudnn8` per test rather than at collection — other suites stub `builtins.__import__` and rebind the module, so a collection-time binding passes alone and fails in the full suite.

Backend suite: **4373 passed, 25 skipped**.

## Docs

`docs/install/troubleshooting.md` §10 updated: the crash-loop symptom is named, and the section now says the app falls back rather than dying (the manual repair still applies to get WhisperX back).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The backend now preloads and probes cuDNN 8 before selecting CTranslate2 ASR engines on Windows/NVIDIA hosts. If cuDNN 8 is unavailable, it reports the failure and falls back to `pytorch-whisper` instead of triggering a hard crash. Native DLL loading and retained directory handles remain the main risks, with regression tests covering these paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->