### PR TITLE
fix(report): keep the root cause when a crash log is trimmed (#1376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- An auto-captured crash report now keeps the error that actually caused the crash. Python prints a chained traceback oldest-first, so trimming the log to its newest end kept the generic wrapper and cut the real cause — the reports that needed the detail most were the ones that arrived without it. (#1376)
 - Text ending in punctuation no longer wastes a whole synthesis pass on it. A chunk boundary could leave a trailing fragment with nothing speakable in it, which the engine renders as nothing at all. (#1330)
 - A take that is missing part of your text now says so instead of coming back quietly short. When the engine renders a sentence to nothing, the app names the missing text and suggests re-generating — until now the only way to notice was to read along. (#1330)
 - A long render on modest hardware is no longer abandoned as "too heavy for the available compute" while it is visibly working. A generate that keeps finishing chunks now extends its own deadline (bounded), the way a model download already could; one that stops producing anything still fails on time. (#1338, #1348, #1391)

--- a/frontend/src/utils/bugReport.js
+++ b/frontend/src/utils/bugReport.js
@@ -115,6 +115,54 @@ async function captureContext() {
   return lines.join('\n');
 }
 
+// Python prints a CHAINED traceback root-cause-FIRST: the original error, then
+// "The above exception was the direct cause of…", then the wrapper. So keeping
+// only the newest end of stderr — right for a plain log — throws away the one
+// line that explains the crash and keeps the least informative one.
+//
+// #1376 is the case in point. The report arrived carrying
+//
+//     ModuleNotFoundError: Could not import module 'GenerationMixin'.
+//     Are this object's requirements defined correctly?
+//
+// which is transformers' lazy-import wrapper and says nothing about what
+// actually failed; the real cause had been cut. Triage had to guess it from
+// the shape of the pair. The whole point of auto-capturing stderr is to avoid
+// that round-trip, so recover the root-cause line out of the discarded head.
+const CHAIN_MARKERS = [
+  'The above exception was the direct cause of the following exception',
+  'During handling of the above exception, another exception occurred',
+];
+
+/** The error line that ends the FIRST block of a chained traceback — i.e. the
+ *  original cause. Empty string when `text` is not a chained traceback. */
+export function rootCauseLine(text) {
+  const idx = CHAIN_MARKERS.map((m) => text.indexOf(m))
+    .filter((i) => i > 0)
+    .sort((a, b) => a - b)[0];
+  if (idx === undefined) return '';
+  const before = text.slice(0, idx).trimEnd().split('\n');
+  // Walk back past the marker's blank line to the last non-indented line —
+  // traceback frames are indented, the exception line is not.
+  for (let i = before.length - 1; i >= 0; i -= 1) {
+    const line = before[i];
+    if (line.trim() && !/^\s/.test(line)) return line.trim();
+  }
+  return '';
+}
+
+/** Bound the crash stderr to its budget, keeping the newest end AND — for a
+ *  chained traceback — the root cause that would otherwise be cut. */
+export function clampCrashTail(text, max = MAX_CRASH_TAIL_CHARS) {
+  if (text.length <= max) return text;
+  const root = rootCauseLine(text);
+  const kept = text.slice(-max);
+  // Only prepend when the root cause is genuinely among the discarded head;
+  // if it survived in `kept`, repeating it is noise.
+  if (!root || kept.includes(root)) return `… (truncated)\n${kept}`;
+  return `${root}\n… (truncated — chained traceback; the line above is the original cause)\n${kept}`;
+}
+
 /** "## Last backend crash" section from the desktop shell's crash marker
  * (#941): exit code/signal + scrubbed stderr tail, so a "backend became
  * unreachable" report arrives WITH the evidence instead of needing a
@@ -129,10 +177,7 @@ async function captureCrashSection() {
     /* shell forensics unavailable */
   }
   if (!marker) return [];
-  let tail = scrubText(marker.last_stderr || '').trim();
-  if (tail.length > MAX_CRASH_TAIL_CHARS) {
-    tail = `… (truncated)\n${tail.slice(-MAX_CRASH_TAIL_CHARS)}`;
-  }
+  const tail = clampCrashTail(scrubText(marker.last_stderr || '').trim());
   return [
     '## Last backend crash (auto-captured — may predate this bug)',
     '',

--- a/frontend/src/utils/bugReport.js
+++ b/frontend/src/utils/bugReport.js
@@ -129,38 +129,56 @@ async function captureContext() {
 // actually failed; the real cause had been cut. Triage had to guess it from
 // the shape of the pair. The whole point of auto-capturing stderr is to avoid
 // that round-trip, so recover the root-cause line out of the discarded head.
-const CHAIN_MARKERS = [
-  'The above exception was the direct cause of the following exception',
-  'During handling of the above exception, another exception occurred',
-];
+// Python emits these as their own line. Anchored rather than searched as a
+// substring: stderr routinely QUOTES tracebacks (a logged exception, a
+// subprocess's captured output), and a bare `indexOf` would treat the quoted
+// text as a real chain and prepend a "root cause" from the wrong exception.
+const CHAIN_MARKER_RE =
+  /^(?:The above exception was the direct cause of the following exception|During handling of the above exception, another exception occurred):?$/;
 
 /** The error line that ends the FIRST block of a chained traceback — i.e. the
  *  original cause. Empty string when `text` is not a chained traceback. */
 export function rootCauseLine(text) {
-  const idx = CHAIN_MARKERS.map((m) => text.indexOf(m))
-    .filter((i) => i > 0)
-    .sort((a, b) => a - b)[0];
-  if (idx === undefined) return '';
-  const before = text.slice(0, idx).trimEnd().split('\n');
+  const lines = text.split('\n');
+  const marker = lines.findIndex((l) => CHAIN_MARKER_RE.test(l.trim()));
+  if (marker <= 0) return '';
   // Walk back past the marker's blank line to the last non-indented line —
   // traceback frames are indented, the exception line is not.
-  for (let i = before.length - 1; i >= 0; i -= 1) {
-    const line = before[i];
+  for (let i = marker - 1; i >= 0; i -= 1) {
+    const line = lines[i];
     if (line.trim() && !/^\s/.test(line)) return line.trim();
   }
   return '';
 }
 
-/** Bound the crash stderr to its budget, keeping the newest end AND — for a
- *  chained traceback — the root cause that would otherwise be cut. */
+// Below this much room for actual log output, the root-cause header stops being
+// worth its cost — a labelled line with almost nothing under it is harder to
+// act on than the raw newest output.
+const MIN_TAIL_CHARS = 400;
+
+/** Bound the crash stderr to `max` characters, keeping the newest end AND — for
+ *  a chained traceback — the root cause that would otherwise be cut.
+ *
+ *  The result never exceeds `max`: the prefix is budgeted for BEFORE slicing,
+ *  not added on top of a full-size tail. */
 export function clampCrashTail(text, max = MAX_CRASH_TAIL_CHARS) {
   if (text.length <= max) return text;
+
+  const PLAIN = '… (truncated)';
+  const plainTail = () => `${PLAIN}\n${text.slice(-Math.max(0, max - PLAIN.length - 1))}`;
+
   const root = rootCauseLine(text);
-  const kept = text.slice(-max);
-  // Only prepend when the root cause is genuinely among the discarded head;
-  // if it survived in `kept`, repeating it is noise.
-  if (!root || kept.includes(root)) return `… (truncated)\n${kept}`;
-  return `${root}\n… (truncated — chained traceback; the line above is the original cause)\n${kept}`;
+  if (!root) return plainTail();
+
+  const prefix = `${root}\n… (truncated — chained traceback; the line above is the original cause)\n`;
+  const room = max - prefix.length;
+  if (room < MIN_TAIL_CHARS) return plainTail();
+
+  const kept = text.slice(-room);
+  // Already visible in what we keep — repeating it is noise, and the budget is
+  // better spent on more log.
+  if (kept.includes(root)) return plainTail();
+  return prefix + kept;
 }
 
 /** "## Last backend crash" section from the desktop shell's crash marker

--- a/frontend/src/utils/bugReport.test.js
+++ b/frontend/src/utils/bugReport.test.js
@@ -217,15 +217,44 @@ describe('clampCrashTail / rootCauseLine (#1376)', () => {
   });
 
   it('does not repeat a root cause that survived inside the kept tail', () => {
-    const text = [
-      'ValueError: the original',
-      '',
-      'The above exception was the direct cause of the following exception:',
-      '',
-      'RuntimeError: the wrapper',
-    ].join('\n');
-    const out = clampCrashTail(text, text.length - 1);
+    // Boot noise first, so a budget exists that keeps the root cause inside the
+    // tail — that is the case where prepending it would duplicate the line.
+    const text =
+      'boot\n'.repeat(200) +
+      'ValueError: the original\n\n' +
+      'The above exception was the direct cause of the following exception:\n\n' +
+      '  frame\n'.repeat(40) +
+      'RuntimeError: the wrapper';
+    const out = clampCrashTail(text, 600);
+    expect(out).toContain('ValueError: the original');
     expect(out.match(/ValueError: the original/g)).toHaveLength(1);
+  });
+
+  it('never returns more than the budget, chained or not', () => {
+    const chained = [
+      'ImportError: a fairly long original cause line to eat into the budget',
+      '',
+      'During handling of the above exception, another exception occurred:',
+      '',
+      `${'  frame line\n'.repeat(500)}`,
+      'RuntimeError: wrapper',
+    ].join('\n');
+    for (const max of [300, 600, 1200]) {
+      expect(clampCrashTail(chained, max).length).toBeLessThanOrEqual(max);
+      expect(clampCrashTail('x'.repeat(9000), max).length).toBeLessThanOrEqual(max);
+    }
+  });
+
+  it('ignores a marker that is only QUOTED inside an error message', () => {
+    // stderr routinely quotes tracebacks (a logged exception, a subprocess's
+    // captured output). A substring match would treat the quotation as a real
+    // chain and attribute a root cause from the wrong exception.
+    const text = [
+      `${'noise\n'.repeat(300)}`,
+      'RuntimeError: parser saw "The above exception was the direct cause of the following exception" in the input',
+    ].join('\n');
+    expect(rootCauseLine(text)).toBe('');
+    expect(clampCrashTail(text, 400).startsWith('… (truncated)')).toBe(true);
   });
 
   it('picks the exception line, not an indented frame', () => {

--- a/frontend/src/utils/bugReport.test.js
+++ b/frontend/src/utils/bugReport.test.js
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { scrubText, buildBugReportUrl, ISSUES_URL, REDACTED } from './bugReport';
+import {
+  scrubText,
+  buildBugReportUrl,
+  ISSUES_URL,
+  REDACTED,
+  clampCrashTail,
+  rootCauseLine,
+} from './bugReport';
 import { getLastBackendCrash } from './backendCrash';
 
 // #941: keep the real crashAge/describeCrashExit helpers; only the shell
@@ -162,6 +169,81 @@ describe('buildBugReportUrl — crash-marker enrichment (#941)', () => {
     const body = decodeURIComponent(url);
     expect(body).toContain('THE REAL TRACEBACK LINE'); // tail kept, head dropped
     expect(url.length).toBeLessThan(8000);
+  });
+
+  it('rescues the root cause of a chained traceback from the dropped head (#1376)', async () => {
+    // The #1376 shape: transformers' lazy-import wrapper is what survives at
+    // the END of stderr, and it says nothing. The real cause is at the TOP,
+    // which is exactly what a tail-only clamp discards — so the report arrived
+    // with the useless half and triage had to guess the useful one.
+    const stderr = [
+      'Traceback (most recent call last):',
+      '  File "transformers/utils/import_utils.py", line 2184, in __getattr__',
+      'ImportError: operator torchvision::nms does not exist',
+      '',
+      'The above exception was the direct cause of the following exception:',
+      '',
+      `${'  frame noise\n'.repeat(400)}`,
+      "ModuleNotFoundError: Could not import module 'GenerationMixin'.",
+    ].join('\n');
+    getLastBackendCrash.mockResolvedValue({
+      ts: Math.floor(Date.now() / 1000),
+      exit_code: 1,
+      signal: null,
+      exit_desc: 'exit status: 1',
+      backend_version: '0.4.2',
+      uptime_s: 28,
+      last_stderr: stderr,
+      acknowledged: false,
+    });
+    const url = await buildBugReportUrl();
+    const body = decodeURIComponent(url);
+    expect(body).toContain('operator torchvision::nms does not exist');
+    expect(body).toContain('the line above is the original cause');
+    expect(body).toContain("Could not import module 'GenerationMixin'"); // tail still kept
+    expect(url.length).toBeLessThan(8000);
+  });
+});
+
+describe('clampCrashTail / rootCauseLine (#1376)', () => {
+  it('leaves a tail that fits completely alone', () => {
+    expect(clampCrashTail('short traceback', 100)).toBe('short traceback');
+  });
+
+  it('falls back to plain tail-keeping when there is no chain', () => {
+    const out = clampCrashTail(`${'x'.repeat(500)}\nRuntimeError: boom`, 40);
+    expect(out.startsWith('… (truncated)')).toBe(true);
+    expect(out).toContain('RuntimeError: boom');
+  });
+
+  it('does not repeat a root cause that survived inside the kept tail', () => {
+    const text = [
+      'ValueError: the original',
+      '',
+      'The above exception was the direct cause of the following exception:',
+      '',
+      'RuntimeError: the wrapper',
+    ].join('\n');
+    const out = clampCrashTail(text, text.length - 1);
+    expect(out.match(/ValueError: the original/g)).toHaveLength(1);
+  });
+
+  it('picks the exception line, not an indented frame', () => {
+    const text = [
+      'Traceback (most recent call last):',
+      '  File "a.py", line 1, in <module>',
+      '    import thing',
+      'ImportError: no thing',
+      '',
+      'During handling of the above exception, another exception occurred:',
+      '',
+      'RuntimeError: wrapper',
+    ].join('\n');
+    expect(rootCauseLine(text)).toBe('ImportError: no thing');
+  });
+
+  it('returns nothing for an unchained traceback', () => {
+    expect(rootCauseLine('Traceback…\nValueError: solo')).toBe('');
   });
 });
 


### PR DESCRIPTION
Auto-captured crash reports clamp the backend's stderr to a 1200-char budget by keeping the **newest end**. That's right for a plain log — the head is uvicorn boot noise, the abort is at the bottom.

It is exactly wrong for a **chained Python traceback**, which prints root-cause-first:

```
ImportError: operator torchvision::nms does not exist          ← cut
The above exception was the direct cause of the following exception:
ModuleNotFoundError: Could not import module 'GenerationMixin'.
Are this object's requirements defined correctly?               ← kept
```

So the section built to carry the cause reliably **discarded it**, keeping transformers' lazy-import wrapper — which names no dependency and no version.

[#1376](https://github.com/debpalash/VoiceStudio/issues/1376) arrived in exactly that state: triage had to *infer* the torch/torchvision mismatch from the shape of the pair rather than read it. And the failure is worst where it hurts most — the bigger the traceback, the more certain the cause is to be cut, so the reports that most needed the detail were the least likely to carry it.

## Fix

`clampCrashTail` recovers the first chain segment's exception line out of the discarded head and prepends it above the truncation marker:

```
ImportError: operator torchvision::nms does not exist
… (truncated — chained traceback; the line above is the original cause)
<newest 1200 chars>
```

- Non-chained logs keep the existing tail-only behaviour, byte for byte.
- A root cause that survived inside the kept tail is not repeated.
- `rootCauseLine` walks back past the marker's blank line to the last **non-indented** line — traceback frames are indented, exception lines are not.
- Both `During handling of…` and `The above exception was the direct cause of…` are recognised.

## Tests

6 new tests, **all failing before the fix**. Frontend suite: **209 files, 1686 tests passed**; typecheck, format and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
`clampCrashTail` now preserves the root cause from chained Python tracebacks when crash stderr is truncated. The implementation retains existing tail behavior, prevents duplicate causes, and enforces the character budget. Review the traceback-marker parsing for unusual formats that the supported patterns may not match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->