### PR TITLE
fix(firstrun): stop the setup screen timing out while it waits for you (#1376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- The first-run setup screen no longer times out while it waits for you. Taking more than two minutes to choose an install location, region or mirror made the app declare "Setup failed", and Retry landed back on the same screen with the same clock — so a first install could never be completed. (#1376)
 - Transcription on an NVIDIA machine whose cuDNN 8 libraries are missing no longer kills the backend outright. The app checks the library before picking a transcription engine and falls back to PyTorch Whisper, instead of handing off to a component that aborts the process with no error and restarts into the same crash. (#1371)
 - The dictation model picker now tells the truth about download size. Every one of the seven models was wrong: Parakeet TDT v3, the recommended default, said 180 MB and actually downloads 670 MB, while the small low-RAM fallbacks were advertised as three times bigger than they are. (#1398)
 - Dictation with the 0.6B Parakeet models is steadier under load — they now decode on more threads (still capped by your CPU, still overridable with `OMNIVOICE_SHERPA_ASR_THREADS`). The small models are unchanged. (#1398)

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -913,7 +913,21 @@ export function useBootstrapStage(pollMs = 1000) {
     // (stage,message) change resets the clock so a live install never trips it.
     let lastChangeTs = Date.now();
     let lastKey = '';
-    const stallBudgetMs = (stage) => (stage === 'installing_deps' ? 20 * 60 * 1000 : 120 * 1000);
+    // `awaiting_setup` is gated on a HUMAN, not on work. Rust parks there
+    // deliberately ("nothing downloads or installs in this stage —
+    // complete_setup is the only way out of it") and waits for the install
+    // plan: mode, storage locations, region, mirrors. That is a screen built
+    // for deliberation, and a person reading it routinely takes longer than
+    // any machine stage — so a stall budget there fires on a perfectly healthy
+    // first run, replaces the setup screen with "Setup failed", and stops the
+    // IPC poll. Retry re-enters the bootstrap, which parks at awaiting_setup
+    // again, and it fails again on the same clock: an unescapable loop on the
+    // very first thing a new user sees (#1376). No budget for a stage only a
+    // person can leave.
+    const stallBudgetMs = (stage) => {
+      if (stage === 'awaiting_setup') return Infinity;
+      return stage === 'installing_deps' ? 20 * 60 * 1000 : 120 * 1000;
+    };
     const invoke = async () => {
       try {
         const { invoke: tauriInvoke } = await import('@tauri-apps/api/core');

--- a/frontend/src/test/BootstrapSplashAwaitingSetupStall.test.jsx
+++ b/frontend/src/test/BootstrapSplashAwaitingSetupStall.test.jsx
@@ -1,0 +1,124 @@
+/**
+ * #1376 — the first-run setup screen must not time out while it waits for you.
+ *
+ * The splash flips any stage that sits still past a budget to `failed`, so a
+ * genuinely wedged bootstrap surfaces Retry and logs instead of an info-less
+ * spinner. That is right for every stage the MACHINE owns.
+ *
+ * `awaiting_setup` is not one of them. Rust parks there on purpose — "nothing
+ * downloads or installs in this stage, complete_setup is the only way out of
+ * it" (bootstrap.rs) — and waits for a human to choose install mode, storage
+ * locations, region and mirrors. That screen is built for deliberation, so
+ * taking longer than a machine stage is the NORMAL case, not a fault.
+ *
+ * With the default 120 s budget applied to it, reading the setup screen for
+ * two minutes replaced it with "Setup failed — the backend never reported
+ * ready" and stopped the IPC poll. Retry re-enters the bootstrap, which parks
+ * at awaiting_setup again, and fails again on the same clock — an unescapable
+ * loop on the very first screen a new user ever sees.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBootstrapStage } from '../components/BootstrapSplash';
+
+const invokeMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args) => invokeMock(...args),
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+let warnSpy;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  invokeMock.mockReset();
+  vi.useFakeTimers();
+  window.__TAURI_INTERNALS__ = {};
+  // The hook early-returns 'ready' in dev builds; force the packaged path.
+  vi.stubEnv('DEV', false);
+  // Backend genuinely is not up during first-run setup — nothing to fall back
+  // to over HTTP, which is also what keeps the #879 watchdog out of the way.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  warnSpy.mockRestore();
+  delete window.__TAURI_INTERNALS__;
+});
+
+describe('useBootstrapStage — awaiting_setup is human-gated (#1376)', () => {
+  it('stays on the setup screen no matter how long the user takes', async () => {
+    invokeMock.mockImplementation(async (cmd) =>
+      cmd === 'bootstrap_status' ? { stage: 'awaiting_setup' } : undefined,
+    );
+
+    const { result } = renderHook(() => useBootstrapStage());
+    await act(async () => {});
+    expect(result.current.stage).toBe('awaiting_setup');
+
+    // Well past the old 120 s budget — a user reading the install plan.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    });
+
+    expect(result.current.stage).toBe('awaiting_setup');
+    expect(result.current.message ?? '').not.toMatch(/stuck/i);
+  });
+
+  it('still leaves for the install once complete_setup advances the stage', async () => {
+    // The exemption must not strand the user the other way: when the plan is
+    // submitted and Rust moves on, the normal progress UI has to take over.
+    let stage = 'awaiting_setup';
+    invokeMock.mockImplementation(async (cmd) =>
+      cmd === 'bootstrap_status' ? { stage } : undefined,
+    );
+
+    const { result } = renderHook(() => useBootstrapStage());
+    await act(async () => {});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    });
+    expect(result.current.stage).toBe('awaiting_setup');
+
+    stage = 'installing_deps';
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(result.current.stage).toBe('installing_deps');
+  });
+
+  it('a machine-owned stage that genuinely wedges still fails', async () => {
+    // The other half of the contract. Exempting awaiting_setup must not
+    // disarm the stall detector for stages nothing but the app can advance —
+    // that would trade this bug for the info-less infinite spinner (#879).
+    invokeMock.mockImplementation(async (cmd) =>
+      cmd === 'bootstrap_status' ? { stage: 'starting_backend' } : undefined,
+    );
+
+    const { result } = renderHook(() => useBootstrapStage());
+    await act(async () => {});
+    expect(result.current.stage).toBe('starting_backend');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+    });
+
+    expect(result.current.stage).toBe('failed');
+    expect(result.current.message).toMatch(/stuck/i);
+  });
+});


### PR DESCRIPTION
Closes #1376.

## The bug

`BootstrapSplash.jsx` flips any stage that sits still past a budget to `failed`, so a wedged bootstrap surfaces Retry and logs instead of an info-less spinner (#879). That is correct for every stage the **machine** owns.

`awaiting_setup` is not one of them:

> First run with nothing installed: parked on the setup screen waiting for the user to confirm an install plan (mode, storage, mirrors). **Nothing downloads or installs in this stage — `complete_setup` is the only way out of it.**
> — `bootstrap.rs:24`

It is the screen where you pick install mode, storage locations, region and mirrors. Built for deliberation — and given the default **120-second** fuse.

```js
const stallBudgetMs = (stage) => (stage === 'installing_deps' ? 20 * 60 * 1000 : 120 * 1000);
```

Read the setup screen for two minutes and the app declares **"Setup failed — the backend never reported ready"**, replaces the setup screen, and `return`s out of the IPC poll. Retry re-enters the bootstrap, which parks at `awaiting_setup` again and fails again on the same clock.

**There is no way out by retrying**, and it lands on the first screen a new install ever shows.

## Reproduced live

On a clean `bun desktop-prod` install, at the moment of failure:

- `tauri.log` ends at `First run — awaiting setup screen confirmation before installing`
- the app data dir is **completely empty** — no venv, no attempt
- `complete_setup`'s own `"Setup complete (…) — starting bootstrap"` log line **never appears**

Nothing was ever attempted. The UI gave up on the user, then blamed the backend.

## Fix

A stage only a person can leave cannot be judged stalled, so `awaiting_setup` gets no budget. `AwaitingSetup` is the only human-gated stage in the enum; every other one is bounded machine work and keeps its budget unchanged.

## Tests

Three, in `BootstrapSplashAwaitingSetupStall.test.jsx`:

1. the setup screen survives ten minutes — **fails before** (`expected 'failed' to be 'awaiting_setup'`)
2. it still hands off the moment the plan is submitted — **fails before**
3. a genuinely wedged `starting_backend` **still** fails — passes before and after, so this does not trade #1376 back for #879

Frontend suite: **1703 passed**. Typecheck, format and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The setup screen no longer times out while users select an installation plan because `awaiting_setup` is excluded from bootstrap stall detection. Machine-controlled stages retain their existing timeout limits, with tests covering prolonged setup, submission handoff, and stalled `starting_backend` detection. Review the timer exemption because setup can now remain active indefinitely if user input or setup progress never occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->