### PR TITLE
fix(mlx): pass the voice description the design model requires (#1405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- The voice-design model on Apple Silicon works again. Its description was being dropped before it reached the engine, so every generation failed with a raw 400 no matter what you typed. (#1405)
 - The first-run setup screen no longer times out while it waits for you. Taking more than two minutes to choose an install location, region or mirror made the app declare "Setup failed", and Retry landed back on the same screen with the same clock — so a first install could never be completed. (#1376)
 - Transcription on an NVIDIA machine whose cuDNN 8 libraries are missing no longer kills the backend outright. The app checks the library before picking a transcription engine and falls back to PyTorch Whisper, instead of handing off to a component that aborts the process with no error and restarts into the same crash. (#1371)
 - The dictation model picker now tells the truth about download size. Every one of the seven models was wrong: Parakeet TDT v3, the recommended default, said 180 MB and actually downloads 670 MB, while the small low-RAM fallbacks were advertised as three times bigger than they are. (#1398)

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1434,7 +1434,8 @@ class MLXAudioBackend(TTSBackend):
         # mlx-audio refuses to run without one — so the engine was unusable no
         # matter what the user typed, and the reported failure was a bare
         # 400 quoting a library message (#1405).
-        if instruct: kwargs["instruct"] = instruct
+        if instruct:
+            kwargs["instruct"] = instruct
         elif self._is_voice_design():
             raise ValueError(
                 "This model builds a voice from a written description, so it "

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -1398,6 +1398,19 @@ class MLXAudioBackend(TTSBackend):
         logger.info("Loading mlx-audio model %s", self._model_id)
         self._model = load_model(self._model_id)
 
+    def _is_voice_design(self) -> bool:
+        """Whether the loaded model builds a voice from a text description.
+
+        Asks the model's own config — `tts_model_type`, the exact field
+        mlx-audio branches on — so this cannot drift from the library's own
+        behaviour. Falls back to the model id, which carries `VoiceDesign` by
+        naming convention, when a config doesn't expose the field.
+        """
+        kind = getattr(getattr(self._model, "config", None), "tts_model_type", None)
+        if kind:
+            return kind == "voice_design"
+        return "voicedesign" in (self._model_id or "").lower()
+
     def generate(self, text: str, **kw) -> torch.Tensor:
         import numpy as np
         self._ensure_loaded()
@@ -1406,6 +1419,7 @@ class MLXAudioBackend(TTSBackend):
         ref_audio = kw.get("ref_audio")
         ref_text  = kw.get("ref_text")
         language  = kw.get("language")
+        instruct  = kw.get("instruct")
         speed     = float(kw.get("speed", 1.0))
 
         # mlx-audio's generate(...) returns an iterator of result objects,
@@ -1415,6 +1429,20 @@ class MLXAudioBackend(TTSBackend):
         kwargs = {"text": text, "speed": speed}
         if voice:     kwargs["voice"] = voice
         if ref_audio: kwargs["ref_audio"] = ref_audio
+        # The comment above claimed instruct was passed "for Qwen3"; it never
+        # was. The curated `qwen3-tts` model IS the VoiceDesign variant, which
+        # mlx-audio refuses to run without one — so the engine was unusable no
+        # matter what the user typed, and the reported failure was a bare
+        # 400 quoting a library message (#1405).
+        if instruct: kwargs["instruct"] = instruct
+        elif self._is_voice_design():
+            raise ValueError(
+                "This model builds a voice from a written description, so it "
+                "needs one — for example \"a warm, low-pitched British "
+                "narrator\". Pick a designed voice (those carry a "
+                "description), or choose a cloning model and supply a "
+                "reference clip instead."
+            )
         # CSM (sesame.py) only builds its cloning context when BOTH ref_audio
         # AND ref_text are present — with ref_text missing, its context list
         # stays empty and indexing into it raises an opaque

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -515,5 +515,10 @@ def test_mlx_audio_generate_non_kokoro_model_ignores_kokoro_validation():
         return iter([types.SimpleNamespace(audio=[0.0, 0.0, 0.0, 0.0])])
 
     backend._model = types.SimpleNamespace(generate=_fake_generate)
-    backend.generate("hello", language="Dutch")  # must not raise
+    # The curated qwen3-tts model is the VoiceDesign variant, which cannot
+    # generate without a description — mlx-audio raises outright. This test
+    # passed without one only because `instruct` was being dropped before it
+    # ever reached the library (#1405); supply one so the scenario is real.
+    backend.generate("hello", language="Dutch", instruct="a warm narrator")  # must not raise
     assert seen_kwargs.get("lang_code") == "du"
+    assert seen_kwargs.get("instruct") == "a warm narrator"

--- a/tests/test_mlx_audio_instruct_1405.py
+++ b/tests/test_mlx_audio_instruct_1405.py
@@ -1,0 +1,105 @@
+"""#1405 — the VoiceDesign model never received the description it requires.
+
+`MLXAudioBackend.generate` builds its kwargs by hand and forwards `voice`,
+`ref_audio`, `ref_text` and `lang_code`. It did **not** forward `instruct`,
+even though the comment directly above the block said it did:
+
+    # Different engines accept different kwargs (voice for Kokoro, ref_audio
+    # for CSM, instruct for Qwen3) — we pass them all …
+
+The curated `qwen3-tts` model IS the VoiceDesign variant
+(`Qwen3-TTS-12Hz-1.7B-VoiceDesign-4bit`), and mlx-audio raises outright when
+that variant is generated without an `instruct`. So the engine could not
+produce audio no matter what the user typed, and the report was a bare
+`400 Bad Request` quoting a library message the app never explains.
+
+Two things are pinned here: the description actually reaches the library, and
+its absence produces an error a user can act on rather than the raw internal
+one.
+"""
+import sys
+import types
+
+import pytest
+
+from services import tts_backend
+
+
+class _FakeConfig:
+    def __init__(self, kind):
+        self.tts_model_type = kind
+
+
+class _FakeResult:
+    def __init__(self):
+        import numpy as np
+
+        self.audio = np.zeros(16, dtype="float32")
+
+
+class _FakeModel:
+    """Stands in for a loaded mlx-audio model, recording its call kwargs."""
+
+    def __init__(self, kind="voice_design"):
+        self.config = _FakeConfig(kind)
+        self.calls = []
+
+    def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        yield _FakeResult()
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    """An MLXAudioBackend with the model pre-loaded, so no mlx import happens."""
+    be = tts_backend.MLXAudioBackend.__new__(tts_backend.MLXAudioBackend)
+    be._model_id = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-4bit"
+    be._model = _FakeModel()
+    monkeypatch.setattr(be, "_ensure_loaded", lambda: None)
+    return be
+
+
+def test_the_description_reaches_the_model(backend):
+    """Fail-before: `instruct` was silently dropped, so the library saw None."""
+    backend.generate("hello", instruct="a warm, low-pitched British narrator")
+    assert backend._model.calls, "the model was never called"
+    assert backend._model.calls[0].get("instruct") == "a warm, low-pitched British narrator"
+
+
+def test_a_voice_design_model_without_a_description_says_what_to_do(backend):
+    with pytest.raises(ValueError) as excinfo:
+        backend.generate("hello")
+    msg = str(excinfo.value)
+    # The user's next step must be in the message — the library's own wording
+    # ("VoiceDesign model requires 'instruct' …") names an internal parameter
+    # and no action, which is what reached the reporter as a raw 400.
+    assert "description" in msg.lower()
+    assert "instruct" not in msg.lower(), "don't surface the internal parameter name"
+    assert "designed voice" in msg.lower() or "cloning" in msg.lower()
+
+
+def test_a_normal_model_without_a_description_is_untouched(backend):
+    """The guard must not block every other mlx-audio model, none of which
+    take an instruct at all."""
+    backend._model = _FakeModel(kind="base")
+    backend.generate("hello")
+    assert backend._model.calls
+    assert "instruct" not in backend._model.calls[0]
+
+
+def test_voice_design_is_detected_from_the_id_when_config_is_silent(backend):
+    """Configs that don't expose `tts_model_type` still have to be caught —
+    the id carries `VoiceDesign` by naming convention."""
+    backend._model = _FakeModel(kind=None)
+    assert backend._is_voice_design() is True
+
+    backend._model_id = "mlx-community/Kokoro-82M-4bit"
+    assert backend._is_voice_design() is False
+
+
+def test_detection_prefers_the_models_own_config_over_the_name(backend):
+    """The config field is the one mlx-audio itself branches on, so it wins —
+    otherwise a renamed or re-tagged checkpoint would drift from the library."""
+    backend._model = _FakeModel(kind="base")
+    backend._model_id = "some/Thing-VoiceDesign-4bit"  # name says design
+    assert backend._is_voice_design() is False

--- a/tests/test_mlx_audio_instruct_1405.py
+++ b/tests/test_mlx_audio_instruct_1405.py
@@ -17,12 +17,22 @@ Two things are pinned here: the description actually reaches the library, and
 its absence produces an error a user can act on rather than the raw internal
 one.
 """
-import sys
-import types
+import importlib
 
 import pytest
 
-from services import tts_backend
+
+@pytest.fixture
+def tts_backend():
+    """Resolve the app module per test rather than binding it at collection.
+
+    A module-level `from services import tts_backend` keeps whatever object
+    was in `sys.modules` when this file was imported. Other suites in this
+    repo rebind that name, so the binding can go stale and leave these tests
+    exercising a different implementation than the one under test — passing
+    in isolation and quietly proving nothing in the full run.
+    """
+    return importlib.import_module("services.tts_backend")
 
 
 class _FakeConfig:
@@ -50,7 +60,7 @@ class _FakeModel:
 
 
 @pytest.fixture
-def backend(monkeypatch):
+def backend(monkeypatch, tts_backend):
     """An MLXAudioBackend with the model pre-loaded, so no mlx import happens."""
     be = tts_backend.MLXAudioBackend.__new__(tts_backend.MLXAudioBackend)
     be._model_id = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-4bit"


### PR DESCRIPTION
Closes #1405.

Reported on macOS / M4 Pro with the `mlx-audio` engine: generating returned

```
400 Bad Request: VoiceDesign model requires 'instruct' to describe the voice
(e.g., 'A cheerful young female voice with high pitch')
```

## Root cause

`MLXAudioBackend.generate` assembles its kwargs by hand:

```python
kwargs = {"text": text, "speed": speed}
if voice:     kwargs["voice"] = voice
if ref_audio: kwargs["ref_audio"] = ref_audio
if ref_audio and ref_text: kwargs["ref_text"] = ref_text
if language ...: kwargs["lang_code"] = ...
```

`instruct` is never forwarded — while the comment **immediately above that block** asserts that it is:

> Different engines accept different kwargs (voice for Kokoro, ref_audio for CSM, **instruct for Qwen3**) — we pass them all and let the engine ignore what it doesn't use.

The curated `qwen3-tts` model **is** the VoiceDesign variant (`Qwen3-TTS-12Hz-1.7B-VoiceDesign-4bit`), and `mlx_audio/tts/models/qwen3_tts/qwen3_tts.py:919` raises when that variant runs without an instruct.

So the engine could not produce audio under **any** input, and the user got a raw 400 quoting a library message that names an internal parameter and no action. The comment is why it went unnoticed — it documented behaviour the code was missing.

## Fix

- forward `instruct` to the library;
- when a design model has no description, fail with something actionable instead of the library's wording.

Detection asks the model's own `tts_model_type` — the exact field mlx-audio branches on, so it cannot drift — and falls back to the `VoiceDesign` id convention only when a config doesn't expose the field.

## One pre-existing test changed

`test_mlx_audio_generate_non_kokoro_model_ignores_kokoro_validation` generated with the VoiceDesign model and **no** description while asserting `lang_code` behaviour. That scenario could never have worked against the real library; it passed only because `instruct` was dropped before reaching it. It now supplies one, and additionally asserts the forwarding — so the gap that hid this bug is itself covered.

## Tests

5 new, **4 fail before** — including the core one, that the description reaches the model at all.

Backend suite: **4397 passed, 32 skipped**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The MLX audio backend now forwards voice descriptions as `instruct` for Qwen3 VoiceDesign models and raises an actionable error when the description is missing. Model detection uses `tts_model_type` with a model-ID fallback, fixing speech generation on Apple Silicon. Tests cover forwarding, validation, and detection behavior; human review should verify compatibility with model configurations that omit or misreport `tts_model_type`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->