### PR TITLE
fix(engines): give every sidecar a private fd for its frames (#1428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Sidecar engines no longer break when a library they load prints to the console. Those bytes landed in the middle of the engine's data stream, failing the generation and leaving the connection scrambled for every request after it. (#1428) — thanks @1335-Group!
 - A generation abandoned while stuck on an internal lock now says so, instead of blaming your hardware and suggesting shorter text. Nothing had been computed, so none of that advice applied. (#1416, #1419)
 - A slow machine is no longer told its IndexTTS-2 install isn't there. The check that confirms an engine's virtualenv gave up after 10 seconds and counted that as a broken install, so a cold first run 500'd; it now waits longer and treats slow as unproven, not broken. (#1414) — thanks @OracleNightmare!
 - A broken Python environment now says so, instead of blaming the app's own install. A missing or mismatched torch/transformers surfaced as "omnivoice not importable" and sent people reinstalling the wrong thing. (#1415)

--- a/backend/engines/_asr_sidecar/main.py
+++ b/backend/engines/_asr_sidecar/main.py
@@ -129,7 +129,25 @@ def _transcribe(audio_path, word_timestamps):
 
 
 def main() -> int:
-    stdin, stdout = sys.stdin.buffer, sys.stdout.buffer
+    stdin = sys.stdin.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
     _send(stdout, {"op": "ready", "engine": "faster-whisper-isolated"})
     while True:
         try:

--- a/backend/engines/_echo/main.py
+++ b/backend/engines/_echo/main.py
@@ -78,7 +78,24 @@ def _silence_pcm_b64(sample_rate: int) -> tuple[str, int]:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     test_mode = os.environ.get("OMNIVOICE_ECHO_TEST_MODE") == "1"
     crash_after_one = os.environ.get("OMNIVOICE_ECHO_CRASH") == "1"

--- a/backend/engines/confucius4/main.py
+++ b/backend/engines/confucius4/main.py
@@ -176,7 +176,24 @@ def _handle_synthesize(msg: dict, stdout) -> None:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     _send(stdout, {
         "op": "ready",

--- a/backend/engines/dots_tts/main.py
+++ b/backend/engines/dots_tts/main.py
@@ -209,7 +209,24 @@ def _handle_synthesize(msg: dict, stdout) -> None:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     # Ready handshake fires BEFORE any heavy import.
     _send(stdout, {

--- a/backend/engines/indextts/main.py
+++ b/backend/engines/indextts/main.py
@@ -268,7 +268,24 @@ def _handle_synthesize(msg: dict, stdout) -> None:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     # The ready handshake fires BEFORE any heavy import. SubprocessBackend's
     # SPAWN_READY_TIMEOUT_S is 30 s; we comfortably make that even on a

--- a/backend/engines/moss_tts_v15/main.py
+++ b/backend/engines/moss_tts_v15/main.py
@@ -253,7 +253,24 @@ def _handle_synthesize(msg: dict, stdout) -> None:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     # Ready handshake fires BEFORE any heavy import — nothing above this line
     # touches transformers/torch, so we make the 30 s spawn window even cold.

--- a/backend/engines/omnivoice_subprocess/main.py
+++ b/backend/engines/omnivoice_subprocess/main.py
@@ -203,7 +203,24 @@ def _handle_synthesize(msg: dict, stdout) -> None:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     # Ready handshake fires BEFORE any heavy import.
     _send(stdout, {

--- a/backend/engines/pockettts/main.py
+++ b/backend/engines/pockettts/main.py
@@ -260,7 +260,24 @@ def _handle_synthesize(msg: dict, stdout) -> None:
 
 def main() -> int:
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     # Ready handshake fires BEFORE any heavy import.
     _send(stdout, {

--- a/backend/engines/supertonic3/sidecar.py
+++ b/backend/engines/supertonic3/sidecar.py
@@ -327,7 +327,24 @@ def main(argv: list[str] | None = None) -> int:
         return _run_selftest()
 
     stdin = sys.stdin.buffer
-    stdout = sys.stdout.buffer
+    # Frames go down a PRIVATE fd, and fd 1 is pointed at stderr (#1428).
+    #
+    # This sidecar's protocol is length-prefixed binary on stdout, but it is
+    # not the only thing writing there: the libraries it loads print freely to
+    # fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch
+    # and ONNX runtime. Those bytes interleave with frames, and the parent
+    # then reads four bytes of log text as a length prefix, which is how a
+    # generation dies with `OSError: frame too large: 1044258881` (that number
+    # is ASCII). Worse, it desyncs the stream, so every later request on the
+    # same sidecar reads stale bytes and no retry can recover.
+    #
+    # Duplicating fd 1 first keeps a clean channel only this module can write
+    # to; redirecting fd 1 to fd 2 sends the library noise to stderr, which
+    # the parent already drains into its own log (through the HF-token
+    # redactor). Nothing is lost and the frame stream cannot be corrupted.
+    _frame_fd = os.dup(1)
+    os.dup2(2, 1)
+    stdout = os.fdopen(_frame_fd, "wb")
 
     # Detect SDK version for the ready frame so the parent's compat table
     # can surface it without re-importing the SDK in-process.

--- a/tests/test_sidecar_stdout_isolation_1428.py
+++ b/tests/test_sidecar_stdout_isolation_1428.py
@@ -37,11 +37,23 @@ SIDECARS = sorted(
     p for p in list(ENGINES.glob("*/main.py")) + list(ENGINES.glob("*/sidecar.py"))
 )
 
+EXPECTED_SIDECARS = {
+    ENGINES / "_asr_sidecar" / "main.py",
+    ENGINES / "_echo" / "main.py",
+    ENGINES / "confucius4" / "main.py",
+    ENGINES / "dots_tts" / "main.py",
+    ENGINES / "indextts" / "main.py",
+    ENGINES / "moss_tts_v15" / "main.py",
+    ENGINES / "omnivoice_subprocess" / "main.py",
+    ENGINES / "pockettts" / "main.py",
+    ENGINES / "supertonic3" / "sidecar.py",
+}
+
 
 def test_the_scan_finds_the_sidecars_it_is_meant_to_guard():
     """A guard that silently matched nothing would pass while protecting
     nothing."""
-    assert len(SIDECARS) >= 8, [str(p) for p in SIDECARS]
+    assert set(SIDECARS) == EXPECTED_SIDECARS, [str(p) for p in SIDECARS]
 
 
 @pytest.mark.parametrize("path", SIDECARS, ids=lambda p: p.parent.name)

--- a/tests/test_sidecar_stdout_isolation_1428.py
+++ b/tests/test_sidecar_stdout_isolation_1428.py
@@ -1,0 +1,126 @@
+"""A sidecar's frame channel must not be shared with library logging (#1428).
+
+Every sidecar speaks a length-prefixed binary protocol on stdout. It is not
+the only thing writing there: the libraries it loads print freely to fd 1 —
+wetextprocessing's FST logs, tqdm bars, native prints from torch and ONNX
+runtime. Those bytes interleave with frames, the parent reads four bytes of
+log text as a length prefix, and the generation dies with
+
+    OSError: frame too large: 1044258881
+
+(that number is ASCII text). The worse half is what it leaves behind: the
+stream is now desynced, so every later request on the same sidecar reads
+stale bytes and no retry can recover — which is why the reporter saw
+alternating failures rather than a clean one.
+
+Reported by @1335-Group against IndexTTS-2 with a tested fix. The defect is
+not IndexTTS's: all nine sidecars wrote frames to `sys.stdout.buffer` and none
+protected fd 1, so any of them breaks the moment a dependency prints.
+
+These tests are the deterministic guard — a new sidecar copied from an old one
+must not be able to reintroduce it.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ENGINES = Path("backend/engines")
+
+#: Every sidecar entry point: the script `SubprocessBackend` spawns.
+SIDECARS = sorted(
+    p for p in list(ENGINES.glob("*/main.py")) + list(ENGINES.glob("*/sidecar.py"))
+)
+
+
+def test_the_scan_finds_the_sidecars_it_is_meant_to_guard():
+    """A guard that silently matched nothing would pass while protecting
+    nothing."""
+    assert len(SIDECARS) >= 8, [str(p) for p in SIDECARS]
+
+
+@pytest.mark.parametrize("path", SIDECARS, ids=lambda p: p.parent.name)
+def test_frames_do_not_go_to_the_shared_stdout(path):
+    src = path.read_text(encoding="utf-8")
+    assert "sys.stdout.buffer" not in src, (
+        f"{path} writes frames to the shared stdout — any library that prints "
+        "to fd 1 will corrupt the protocol (#1428)"
+    )
+
+
+@pytest.mark.parametrize("path", SIDECARS, ids=lambda p: p.parent.name)
+def test_fd_one_is_redirected_to_stderr(path):
+    """Both halves are required. `os.dup(1)` alone keeps a private channel but
+    leaves library output going to the parent's frame reader; `os.dup2(2, 1)`
+    alone sends frames to stderr."""
+    src = path.read_text(encoding="utf-8")
+    assert re.search(r"_frame_fd\s*=\s*os\.dup\(1\)", src), (
+        f"{path} does not keep a private fd for frames (#1428)"
+    )
+    assert re.search(r"os\.dup2\(2,\s*1\)", src), (
+        f"{path} does not redirect fd 1 to stderr, so library output still "
+        "lands in the frame stream (#1428)"
+    )
+    # Ordering is load-bearing: dup2 before dup would duplicate stderr.
+    assert src.index("os.dup(1)") < src.index("os.dup2(2, 1)"), (
+        f"{path} redirects fd 1 before duplicating it — the 'private' frame "
+        "channel is then just stderr"
+    )
+
+
+def test_a_printing_library_cannot_corrupt_the_frame_stream(tmp_path):
+    """End-to-end proof, with a real subprocess and a real print().
+
+    Fail-before: with `stdout = sys.stdout.buffer`, the `print()` below lands
+    between the frames and the reader takes `b'nois'` as a length prefix.
+    """
+    script = tmp_path / "fake_sidecar.py"
+    script.write_text(
+        "import json, os, struct, sys\n"
+        "_frame_fd = os.dup(1)\n"
+        "os.dup2(2, 1)\n"
+        "stdout = os.fdopen(_frame_fd, 'wb')\n"
+        "\n"
+        "def send(msg):\n"
+        "    body = json.dumps(msg).encode()\n"
+        "    stdout.write(struct.pack('!I', len(body)))\n"
+        "    stdout.write(body)\n"
+        "    stdout.flush()\n"
+        "\n"
+        "send({'op': 'ready'})\n"
+        "print('noisy library banner on fd 1')\n"          # the whole point
+        "sys.stdout.write('and another one\\n')\n"
+        "os.write(1, b'native print straight to fd 1\\n')\n"
+        "send({'op': 'audio', 'n': 1})\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [sys.executable, str(script)], capture_output=True, timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr.decode()
+
+    # The frame channel must contain exactly the two frames and nothing else.
+    import json
+    import struct
+
+    buf, frames = proc.stdout, []
+    while buf:
+        (n,) = struct.unpack("!I", buf[:4])
+        assert n < 10_000, (
+            f"read a {n}-byte length prefix — log text was parsed as a frame "
+            "header, which is the #1428 failure exactly"
+        )
+        frames.append(json.loads(buf[4:4 + n]))
+        buf = buf[4 + n:]
+    assert [f["op"] for f in frames] == ["ready", "audio"]
+
+    # And the noise is on stderr, where the parent already drains it.
+    err = proc.stderr.decode()
+    assert "noisy library banner" in err
+    assert "native print straight to fd 1" in err


### PR DESCRIPTION
Closes #1428 — bug 2. Reported by @1335-Group with a diagnosis, a tested fix, and a verified end-to-end result. Both the analysis and the patch shape are theirs; this generalises it.

## Bug 2 — library output corrupts the framed protocol

Sidecars speak a length-prefixed binary protocol on stdout. They are not the only thing writing there: the libraries they load print freely to fd 1 — wetextprocessing's FST logs, tqdm bars, native prints from torch and ONNX runtime. Those bytes interleave with frames, and the parent reads four bytes of log text as a length prefix:

```
OSError: frame too large: 1044258881
```

That number is ASCII. And the crash is the better half of the outcome — the stream is now **desynced**, so every later request on the same sidecar reads stale bytes and no retry can recover. That is why the reporter saw alternating failures rather than one clean one.

## Not an IndexTTS bug

All **nine** sidecar entry points wrote frames to `sys.stdout.buffer`, and none protected fd 1:

`indextts`, `confucius4`, `dots_tts`, `moss_tts_v15`, `pockettts`, `omnivoice_subprocess`, `supertonic3`, `_asr_sidecar`, `_echo`.

IndexTTS surfaced it because wetextprocessing is loud. Any of the others breaks the moment one of its dependencies prints — a dependency upgrade away, with no code change of ours.

Each now keeps a private fd for frames and points fd 1 at stderr, which the parent **already** drains into its own log (through the HF-token redactor). Nothing is lost; the noise just goes where the noise already goes.

Ordering is load-bearing and tested: `os.dup(1)` must come before `os.dup2(2, 1)`, or the "private" channel is just stderr.

## Bug 1 — already fixed, unreleased

The parent's single-frame read is fixed on `main`: `subprocess_backend.py:583` drains interim `progress` frames until the terminal one, with each frame also reporting liveness to the execution clock. `git tag --contains` on that commit is empty, so it is in **no released build** — which is why 0.4.0 hits it. Their proposed fix and the one on `main` are the same shape.

## Regression cover

`tests/test_sidecar_stdout_isolation_1428.py`, 20 cases:

- a parametrised scan asserting no sidecar writes frames to the shared stdout, that each keeps a private fd **and** redirects fd 1, and that the two happen in that order;
- a "the scan found something" guard, since a scan that silently matched nothing would pass while protecting nothing;
- an end-to-end case that spawns a real subprocess which prints three ways (`print`, `sys.stdout.write`, `os.write(1, …)`) between two frames, then parses the frame channel and asserts the length prefix is sane — fail-before, that read is `b'nois'` as a 4-byte integer, the exact reported failure.

520 sidecar/engine tests pass, including the wire-protocol suite that spawns the echo sidecar for real.

## Their other two notes

- **`project/backend/` is re-synced from the bundle on every spawn**, so patches to the live project dir revert — a genuinely useful thing to have written down; worth a docs line for engine contributors.
- **`CUDA_VISIBLE_DEVICES` / GPU selection isn't surfaced in Settings** on a multi-GPU host. That's a real gap and its own feature request, not folded in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
All nine sidecars now isolate framed protocol output on a duplicated stdout descriptor and redirect fd 1 to stderr. This prevents library, Python, progress-bar, and native output from corrupting protocol frames and subsequent requests. Regression tests cover descriptor ordering, isolation, redirection, and end-to-end subprocess behavior; review the shared fd-handling pattern for platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->