### PR TITLE
fix(asr): an ffmpeg the app already bundles is not a missing prerequisite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Workspace tabs in the title bar, if you prefer them to the icon rail (#1412)
 - macOS support now matches what the app actually delivers
 - Linux AppImage: a blank white window on rolling distros (Mesa 26.1+) now starts normally
+- Apple Silicon: transcription no longer needs a system ffmpeg, as the docs always said (#1426)
 - A failed audiobook chapter says why, instead of turning red and saying nothing
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Workspace tabs in the title bar, if you prefer them to the icon rail (#1412)
 - macOS support now matches what the app actually delivers
 - Linux AppImage: a blank white window on rolling distros (Mesa 26.1+) now starts normally
-- Apple Silicon: transcription no longer needs a system ffmpeg, as the docs always said (#1426)
+- Apple Silicon: transcription no longer needs a system ffmpeg, as the docs always said (#1436)
 - A failed audiobook chapter says why, instead of turning red and saying nothing
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 - Workspace tabs in the title bar, if you prefer them to the icon rail (#1412)
 - macOS support now matches what the app actually delivers
 - Linux AppImage: a blank white window on rolling distros (Mesa 26.1+) now starts normally
-- Apple Silicon: transcription no longer needs a system ffmpeg, as the docs always said (#1436)
+- Apple Silicon: transcription no longer needs a system ffmpeg, as the docs always said — thanks @gambletan! (#1436)
 - A failed audiobook chapter says why, instead of turning red and saying nothing
 
 ### Changed

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -1156,8 +1156,20 @@ class MLXWhisperBackend(ASRBackend):
             "MLX Whisper transcribing %s (model=%s, word_timestamps=%s)",
             audio_path, self._model_name, word_timestamps,
         )
+        # Decode once here, rather than handing mlx_whisper a path. Given a
+        # path it calls whisper.audio.load_audio, which shells out to a bare
+        # "ffmpeg" PATH lookup -- the same lookup the WhisperX backend was
+        # moved off in #479, and one that cannot find the bundled
+        # imageio-ffmpeg binary because that is named ffmpeg-<plat>-vN. On a
+        # clean from-source install with no system ffmpeg this fails the whole
+        # request with [Errno 2] No such file or directory: fmpeg\.
+        #
+        # The aligner below already used the validated decoder, so this was one
+        # call site out of two in the same method. Reusing that decode also
+        # stops the file being decoded twice per transcription.
+        audio = _decode_audio_16k_mono(audio_path)
         result = mlx_whisper.transcribe(
-            audio_path,
+            audio,
             path_or_hf_repo=self._model_name,
             word_timestamps=word_timestamps,
         )
@@ -1172,7 +1184,7 @@ class MLXWhisperBackend(ASRBackend):
         if word_timestamps and result.get("segments"):
             result["segments"] = forced_align(
                 result["segments"],
-                _decode_audio_16k_mono(audio_path),
+                audio,
                 result.get("language", "en"),
             )
         # Normalise to the `chunks` shape the rest of the pipeline expects.

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -1162,7 +1162,7 @@ class MLXWhisperBackend(ASRBackend):
         # moved off in #479, and one that cannot find the bundled
         # imageio-ffmpeg binary because that is named ffmpeg-<plat>-vN. On a
         # clean from-source install with no system ffmpeg this fails the whole
-        # request with [Errno 2] No such file or directory: fmpeg\.
+        # request with [Errno 2] No such file or directory: ffmpeg.
         #
         # The aligner below already used the validated decoder, so this was one
         # call site out of two in the same method. Reusing that decode also

--- a/backend/tests/test_asr_mlx_validated_ffmpeg.py
+++ b/backend/tests/test_asr_mlx_validated_ffmpeg.py
@@ -2,12 +2,8 @@ import sys
 import types
 import wave
 
-import pytest
-
 # conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
 # throwaway tmpdir before this module imports the REAL core.config.
-pytest.importorskip("mlx_whisper")
-
 from services.asr_backend import MLXWhisperBackend  # noqa: E402
 
 
@@ -36,15 +32,23 @@ def test_mlx_decodes_the_audio_instead_of_handing_over_a_path(monkeypatch, tmp_p
 
     def fake_transcribe(audio, **kw):
         seen["audio"] = audio
-        return {"language": "en", "segments": []}
+        return {
+            "language": "en",
+            "segments": [{"text": "test", "start": 0.0, "end": 0.2}],
+        }
+
+    def fake_forced_align(segments, audio, language_code, device=None):
+        seen["aligned_audio"] = audio
+        return segments
 
     monkeypatch.setitem(
         sys.modules, "mlx_whisper", types.SimpleNamespace(transcribe=fake_transcribe)
     )
+    monkeypatch.setattr("services.asr_backend.forced_align", fake_forced_align)
 
     backend = MLXWhisperBackend.__new__(MLXWhisperBackend)
     backend._model_name = "mlx-community/whisper-large-v3-mlx"
-    backend.transcribe(_silent_wav(tmp_path / "a.wav"), word_timestamps=False)
+    backend.transcribe(_silent_wav(tmp_path / "a.wav"), word_timestamps=True)
 
     audio = seen["audio"]
     assert not isinstance(audio, (str, bytes)), (
@@ -52,3 +56,4 @@ def test_mlx_decodes_the_audio_instead_of_handing_over_a_path(monkeypatch, tmp_p
         "bare PATH lookup instead of the validated binary find_ffmpeg() returns"
     )
     assert hasattr(audio, "__len__") and len(audio) > 0, "decoded audio is empty"
+    assert seen["aligned_audio"] is audio

--- a/backend/tests/test_asr_mlx_validated_ffmpeg.py
+++ b/backend/tests/test_asr_mlx_validated_ffmpeg.py
@@ -1,0 +1,54 @@
+import sys
+import types
+import wave
+
+import pytest
+
+# conftest.py puts `backend/` on sys.path and points OMNIVOICE_DATA_DIR at a
+# throwaway tmpdir before this module imports the REAL core.config.
+pytest.importorskip("mlx_whisper")
+
+from services.asr_backend import MLXWhisperBackend  # noqa: E402
+
+
+def _silent_wav(path, seconds=0.2, rate=16000):
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(b"\x00\x00" * int(rate * seconds))
+    return str(path)
+
+
+def test_mlx_decodes_the_audio_instead_of_handing_over_a_path(monkeypatch, tmp_path):
+    """A path sends mlx_whisper to a bare "ffmpeg" that need not exist.
+
+    Given a path, mlx_whisper calls whisper.audio.load_audio, which shells out
+    to a literal "ffmpeg" on PATH. That is the lookup WhisperX was moved off in
+    #479: it cannot find the bundled imageio-ffmpeg binary, whose filename is
+    ffmpeg-<plat>-vN. On a from-source install with no system ffmpeg the whole
+    request fails with [Errno 2] No such file or directory: ffmpeg -- even
+    though the app ships a working binary and resolves it everywhere else.
+
+    Before the fix this asserted on a str and failed.
+    """
+    seen = {}
+
+    def fake_transcribe(audio, **kw):
+        seen["audio"] = audio
+        return {"language": "en", "segments": []}
+
+    monkeypatch.setitem(
+        sys.modules, "mlx_whisper", types.SimpleNamespace(transcribe=fake_transcribe)
+    )
+
+    backend = MLXWhisperBackend.__new__(MLXWhisperBackend)
+    backend._model_name = "mlx-community/whisper-large-v3-mlx"
+    backend.transcribe(_silent_wav(tmp_path / "a.wav"), word_timestamps=False)
+
+    audio = seen["audio"]
+    assert not isinstance(audio, (str, bytes)), (
+        "mlx_whisper was handed a path, so it will resolve ffmpeg itself via a "
+        "bare PATH lookup instead of the validated binary find_ffmpeg() returns"
+    )
+    assert hasattr(audio, "__len__") and len(audio) > 0, "decoded audio is empty"


### PR DESCRIPTION
## Summary

On Apple Silicon — where MLX Whisper is the **default** ASR engine — a clean from-source install fails every transcription with:

```
[Errno 2] No such file or directory: 'ffmpeg'
```

including through the OpenAI-compatible `/v1/audio/transcriptions` route. The docs promise the opposite:

> FFmpeg/FFprobe and yt-dlp are not prerequisites on any install path: the app resolves them itself.

The app *does* resolve them. `imageio-ffmpeg` installs with the backend, its binary is present and runnable, and `find_ffmpeg()` locates it. `MLXWhisperBackend` simply never asked: it handed `mlx_whisper` a path, and given a path `mlx_whisper` calls `whisper.audio.load_audio`, which shells out to a literal `"ffmpeg"` on PATH — the same bare lookup WhisperX was moved off in #479, and one that cannot find the bundled binary because that file is named `ffmpeg-<plat>-vN`.

This was **one call site out of two in the same method**: the forced-alignment step a few lines below already used `_decode_audio_16k_mono`. Decoding once up front and passing the array to both fixes the failure and stops the file being decoded twice per transcription.

## Changes

- `MLXWhisperBackend.transcribe` decodes via the validated ffmpeg once and reuses the array for both `mlx_whisper.transcribe` and `forced_align`
- Regression test asserting `mlx_whisper` is handed decoded audio, not a path
- CHANGELOG entry

## Type

- [x] 🐛 Bug fix

## Testing

Reproduced and verified on a Mac mini M4 Pro (macOS 15, 64 GB), clean from-source install, no system ffmpeg:

**Before** — `POST /v1/audio/transcriptions`, 35.8 s WAV:
```
HTTP 500  {"detail":"[Errno 2] No such file or directory: 'ffmpeg'"}
```

**After** — same request, same machine:
```
HTTP 200  4s cold (model load), 2s warm
{"text":"Hi, I'd like to buy a Chromecast. ..."}
```

The bundled binary was present the whole time:
```
.venv/lib/python3.11/site-packages/imageio_ffmpeg/binaries/ffmpeg-macos-aarch64-v7.1
```

Fail-before / pass-after on the regression test:

```
# on the previous code
FAILED backend/tests/test_asr_mlx_validated_ffmpeg.py::test_mlx_decodes_the_audio_instead_of_handing_over_a_path
E  AssertionError: mlx_whisper was handed a path, so it will resolve ffmpeg itself
   via a bare PATH lookup instead of the validated binary find_ffmpeg() returns

# with this change
1 passed
```

I also wrote a second test asserting transcription survives an empty `PATH`, then deleted it: with `mlx_whisper` mocked it passed both before and after, so it asserted nothing. Not worth carrying.

## Checklist

- Smallest correct change; fixes the class (a decode path that bypasses `find_ffmpeg()`), not just the symptom
- No behaviour change on Windows/Linux — this call site is MLX-only, and MLX is Apple-Silicon-only
- No new network calls; the binary is the one already installed with the backend
- No user-facing strings, so no i18n changes
- CHANGELOG `Unreleased` one-liner added

Happy to adjust the wording or split the double-decode cleanup into its own commit if you'd rather keep the fix minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
MLX Whisper now uses the validated bundled `ffmpeg` binary to decode audio once and reuses the waveform for transcription and forced alignment, removing the system `ffmpeg` requirement on Apple Silicon. A regression test verifies that `mlx_whisper.transcribe` receives decoded audio instead of a file path. Reviewers should verify forced alignment behavior with real audio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->