### PR TITLE
fix(security): make user-controlled validators linear-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Custom MLX model IDs and saved voice instructions are now validated in bounded time, so malformed input cannot stall the backend. (#1446)
 - Sidecar engines no longer break when a library they load prints to the console. Those bytes landed in the middle of the engine's data stream, failing the generation and leaving the connection scrambled for every request after it. (#1428) — thanks @1335-Group!
 - A generation abandoned while stuck on an internal lock now says so, instead of blaming your hardware and suggesting shorter text. Nothing had been computed, so none of that advice applied. (#1416, #1419)
 - A machine with a GPU that ends up on CPU now says why — a missing device node, a permissions problem, a card newer than the installed ROCm, an `HSA_OVERRIDE_GFX_VERSION` that is doing more harm than good, or an NVIDIA driver the container can't reach each read differently. Before, all of them looked identical to having no GPU at all. (#1274, #1228)

--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -37,7 +37,7 @@ _FAMILIES = {
     "llm": (llm_backend, "llm_backend"),
 }
 
-_HF_REPO_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,95}\Z")
+_HF_REPO_COMPONENT = re.compile(r"[A-Za-z0-9_][A-Za-z0-9._-]{0,95}\Z")
 
 
 def _is_hf_repo_id(value: str) -> bool:

--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -37,6 +37,16 @@ _FAMILIES = {
     "llm": (llm_backend, "llm_backend"),
 }
 
+_HF_REPO_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,95}\Z")
+
+
+def _is_hf_repo_id(value: str) -> bool:
+    """Validate ``owner/repo`` in bounded, linear time."""
+    if len(value) > 193 or value.count("/") != 1:
+        return False
+    owner, repo = value.split("/", 1)
+    return bool(_HF_REPO_COMPONENT.fullmatch(owner) and _HF_REPO_COMPONENT.fullmatch(repo))
+
 
 @router.get("/engines")
 def list_all_engines():
@@ -579,7 +589,7 @@ def select_engine(req: SelectEngineRequest):
         # Anything else (typo'd key, malformed id) is rejected outright
         # rather than silently persisted as a "custom repo" that then fails
         # to resolve at load time.
-        if req.model_id not in known_keys and not re.fullmatch(r"[\w.-]+/[\w.-]+", req.model_id):
+        if req.model_id not in known_keys and not _is_hf_repo_id(req.model_id):
             raise HTTPException(
                 400,
                 f"Unknown mlx-audio model: {req.model_id!r}. Expected one of "

--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -16,11 +16,12 @@ Environment variables (`OMNIVOICE_TTS_BACKEND`, `OMNIVOICE_ASR_BACKEND`,
 a backend without Settings silently undoing it.
 """
 import os
-import re
 import threading
 from time import perf_counter
 
 from fastapi import APIRouter, Depends, HTTPException
+from huggingface_hub import utils as hf_utils
+from huggingface_hub.errors import HFValidationError
 from pydantic import BaseModel
 
 from api.dependencies import require_loopback
@@ -37,15 +38,15 @@ _FAMILIES = {
     "llm": (llm_backend, "llm_backend"),
 }
 
-_HF_REPO_COMPONENT = re.compile(r"[A-Za-z0-9_][A-Za-z0-9._-]{0,95}\Z")
-
-
 def _is_hf_repo_id(value: str) -> bool:
-    """Validate ``owner/repo`` in bounded, linear time."""
-    if len(value) > 193 or value.count("/") != 1:
+    """Validate the route's ``owner/repo`` contract in bounded time."""
+    if not isinstance(value, str) or len(value) > 96 or value.count("/") != 1:
         return False
-    owner, repo = value.split("/", 1)
-    return bool(_HF_REPO_COMPONENT.fullmatch(owner) and _HF_REPO_COMPONENT.fullmatch(repo))
+    try:
+        hf_utils.validate_repo_id(value)
+    except (HFValidationError, TypeError):
+        return False
+    return True
 
 
 @router.get("/engines")
@@ -592,8 +593,8 @@ def select_engine(req: SelectEngineRequest):
         if req.model_id not in known_keys and not _is_hf_repo_id(req.model_id):
             raise HTTPException(
                 400,
-                f"Unknown mlx-audio model: {req.model_id!r}. Expected one of "
-                f"{sorted(known_keys)} or a HF repo id like 'owner/name'.",
+                "Unknown mlx-audio model. Expected a curated model key or a "
+                "Hugging Face repo ID like 'owner/name'.",
             )
         prefs.set_("mlx_audio_model_id", req.model_id)
     prefs.set_(pref_key, req.backend_id)

--- a/omnivoice/utils/voice_design.py
+++ b/omnivoice/utils/voice_design.py
@@ -108,7 +108,12 @@ def sanitize_instruct(raw):
     """
     if not raw:
         return ""
-    return _valid_instruct_from_items(re.split(r"\s*[,，]\s*", str(raw).strip()))
+    # Strip each comma-delimited item after splitting.  A pattern with ``\s*``
+    # on both sides of the delimiter backtracks quadratically when a poisoned
+    # stored value contains a long whitespace run without a comma (GHAS #778).
+    return _valid_instruct_from_items(
+        item.strip() for item in re.split(r"[,，]", str(raw).strip())
+    )
 
 
 def instruct_from_vd_states(vd_states):

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -421,6 +421,18 @@ def test_select_mlx_audio_raw_repo_id_accepted(fresh_app, monkeypatch):
     assert _prefs.get("mlx_audio_model_id") == "mlx-community/Some-Other-Model-4bit"
 
 
+def test_select_mlx_audio_repo_id_accepts_underscore_prefixes(fresh_app, monkeypatch):
+    _make_mlx_audio_available(monkeypatch)
+    r = _client(fresh_app).post(
+        "/engines/select",
+        json={
+            "family": "tts", "backend_id": "mlx-audio",
+            "model_id": "_owner/_repo",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
 @pytest.mark.parametrize(
     "model_id",
     [

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -439,6 +439,10 @@ def test_select_mlx_audio_repo_id_accepts_underscore_prefixes(fresh_app, monkeyp
         "owner/repo/extra",
         "-owner/repo",
         "owner/.repo",
+        "owner/repo--name",
+        "owner/repo..name",
+        "owner/repo.",
+        "owner/repo.git",
         f"owner/{'a' * 97}",
         "-" * 100_000,
     ],
@@ -452,6 +456,8 @@ def test_select_mlx_audio_rejects_malformed_repo_ids(fresh_app, monkeypatch, mod
     )
     assert r.status_code == 400
     assert perf_counter() - started < 0.5
+    assert len(r.content) < 256
+    assert model_id[:100] not in r.text
 
 
 def test_select_mlx_audio_without_model_id_does_not_touch_pref(fresh_app, monkeypatch):

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import re
 import sys
+from time import perf_counter
 
 import pytest
 
@@ -418,6 +419,27 @@ def test_select_mlx_audio_raw_repo_id_accepted(fresh_app, monkeypatch):
     )
     assert r.status_code == 200, r.text
     assert _prefs.get("mlx_audio_model_id") == "mlx-community/Some-Other-Model-4bit"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "owner/repo/extra",
+        "-owner/repo",
+        "owner/.repo",
+        f"owner/{'a' * 97}",
+        "-" * 100_000,
+    ],
+)
+def test_select_mlx_audio_rejects_malformed_repo_ids(fresh_app, monkeypatch, model_id):
+    _make_mlx_audio_available(monkeypatch)
+    started = perf_counter()
+    r = _client(fresh_app).post(
+        "/engines/select",
+        json={"family": "tts", "backend_id": "mlx-audio", "model_id": model_id},
+    )
+    assert r.status_code == 400
+    assert perf_counter() - started < 0.5
 
 
 def test_select_mlx_audio_without_model_id_does_not_touch_pref(fresh_app, monkeypatch):

--- a/tests/test_voice_design_instruct_heal.py
+++ b/tests/test_voice_design_instruct_heal.py
@@ -7,6 +7,7 @@ strip poison ("[object Object]", freeform prose) down to whitelist tags,
 recovering a design from ``vd_states`` when the stored value is unusable.
 """
 import json
+from statistics import median
 import time
 
 import pytest
@@ -59,10 +60,24 @@ def test_sanitize_handles_empty_and_poison(bad):
 
 
 def test_sanitize_long_whitespace_run_is_linear_time():
-    poisoned = "female" + (" " * 10_000) + "not-a-tag"
-    started = time.perf_counter()
-    assert sanitize_instruct(poisoned) == ""
-    assert time.perf_counter() - started < 0.1
+    sizes = (2_000, 8_000, 32_000)
+    timings = []
+    for size in sizes:
+        poisoned = "female" + (" " * size) + "not-a-tag"
+        assert sanitize_instruct(poisoned) == ""  # warm timer/cache paths
+        samples = []
+        for _ in range(5):
+            started = time.perf_counter_ns()
+            assert sanitize_instruct(poisoned) == ""
+            samples.append(time.perf_counter_ns() - started)
+        timings.append(median(samples))
+
+    # Input grows 4x per step and 16x overall. Generous multipliers and a
+    # 20 ms scheduling floor tolerate noisy shared runners while still
+    # separating linear split/strip behavior from the former quadratic regex.
+    for smaller, larger in zip(timings, timings[1:]):
+        assert larger <= max(smaller * 10, 20_000_000)
+    assert timings[-1] <= max(timings[0] * 48, 20_000_000)
 
 
 def test_instruct_from_vd_states_dict_drops_auto():

--- a/tests/test_voice_design_instruct_heal.py
+++ b/tests/test_voice_design_instruct_heal.py
@@ -7,6 +7,7 @@ strip poison ("[object Object]", freeform prose) down to whitelist tags,
 recovering a design from ``vd_states`` when the stored value is unusable.
 """
 import json
+import time
 
 import pytest
 
@@ -55,6 +56,13 @@ def test_sanitize_normalises_case_and_blank_items():
 @pytest.mark.parametrize("bad", [None, "", "   ", "[object Object]"])
 def test_sanitize_handles_empty_and_poison(bad):
     assert sanitize_instruct(bad) == ""
+
+
+def test_sanitize_long_whitespace_run_is_linear_time():
+    poisoned = "female" + (" " * 10_000) + "not-a-tag"
+    started = time.perf_counter()
+    assert sanitize_instruct(poisoned) == ""
+    assert time.perf_counter() - started < 0.1
 
 
 def test_instruct_from_vd_states_dict_drops_auto():


### PR DESCRIPTION
## Summary
- replace the ambiguous whitespace-delimiter regex in stored voice instructions with a linear split-and-strip path
- validate custom MLX Hugging Face repository IDs as two bounded components
- cover adversarial whitespace, oversized input, malformed IDs, and valid repository IDs

Closes code-scanning alerts #901 and #778.

## Fail-before / pass-after
- old voice-instruction regex: 10,000 embedded spaces took ~0.28s locally and grows quadratically; regression now completes below 0.1s
- old model validator accepted malformed leading-dot/leading-hyphen components; new parameterized test rejects the full malformed class and bounds input before regex evaluation

## Validation
`PYTHONPATH=$PWD:$PWD/backend pytest -q tests/test_voice_design_instruct_heal.py tests/backend/api/test_engines_route_shape.py` — 63 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Validation now uses linear-time parsing for saved voice instructions and bounded Hugging Face repository IDs, including underscore-prefixed components. This prevents malformed or oversized user input from causing excessive backend processing and adds regression coverage for valid, invalid, and adversarial inputs. Human review should confirm that the repository ID bounds match all supported Hugging Face IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->