### PR TITLE
fix(security): require API key for remote admin mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
-- Remote Docker clients can no longer change executable paths or filesystem settings unless they present the admin API key; local desktop behavior is unchanged. (#1448)
+- Server-mode settings mutations require the admin API key, while host destinations and executable paths can only be selected through the native desktop app. (#1448)
 - Sidecar engines no longer break when a library they load prints to the console. Those bytes landed in the middle of the engine's data stream, failing the generation and leaving the connection scrambled for every request after it. (#1428) — thanks @1335-Group!
 - A generation abandoned while stuck on an internal lock now says so, instead of blaming your hardware and suggesting shorter text. Nothing had been computed, so none of that advice applied. (#1416, #1419)
 - A machine with a GPU that ends up on CPU now says why — a missing device node, a permissions problem, a card newer than the installed ROCm, an `HSA_OVERRIDE_GFX_VERSION` that is doing more harm than good, or an NVIDIA driver the container can't reach each read differently. Before, all of them looked identical to having no GPU at all. (#1274, #1228)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Remote Docker clients can no longer change executable paths or filesystem settings unless they present the admin API key; local desktop behavior is unchanged. (#1448)
 - Sidecar engines no longer break when a library they load prints to the console. Those bytes landed in the middle of the engine's data stream, failing the generation and leaving the connection scrambled for every request after it. (#1428) — thanks @1335-Group!
 - A generation abandoned while stuck on an internal lock now says so, instead of blaming your hardware and suggesting shorter text. Nothing had been computed, so none of that advice applied. (#1416, #1419)
 - A machine with a GPU that ends up on CPU now says why — a missing device node, a permissions problem, a card newer than the installed ROCm, an `HSA_OVERRIDE_GFX_VERSION` that is doing more harm than good, or an NVIDIA driver the container can't reach each read differently. Before, all of them looked identical to having no GPU at all. (#1274, #1228)

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -205,11 +205,24 @@ def require_admin(request: Request) -> None:
     if _server_mode():
         method = str(getattr(request, "method", "GET")).upper()
         read_only = method in {"GET", "HEAD", "OPTIONS"}
-        if read_only and not _admin_credential_configured(request):
+        if read_only and not os.environ.get("OMNIVOICE_API_KEY", "").strip():
             return
         if _request_presents_admin_credential(request):
             return
     raise HTTPException(status_code=403, detail="loopback origin or admin API key required")
+
+
+def require_desktop(request: Request) -> None:
+    """Gate capabilities that may select or execute host filesystem paths.
+
+    An API key authorizes remote administration, not access to the desktop
+    shell's native file-picker boundary.  These capabilities therefore remain
+    strictly loopback-only even when server mode is enabled.
+    """
+    host = request.client.host if request.client else None
+    if is_loopback(host):
+        return
+    raise HTTPException(status_code=403, detail="desktop origin required")
 
 
 def require_local(request: Request) -> None:

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -186,6 +186,32 @@ def require_loopback(request: Request) -> None:
     raise HTTPException(status_code=403, detail="loopback origin required")
 
 
+def require_admin(request: Request) -> None:
+    """Gate RCE/filesystem-capable admin routers.
+
+    Desktop callers keep the loopback-only contract. Docker cannot reliably
+    observe the host operator as loopback, so authenticated remote admin stays
+    available there, but every state-changing request must present the long API
+    key. An unconfigured server must never expose executable-path or filesystem
+    settings to every client that can reach its published port.
+
+    Read-only requests retain the bare-Docker bootstrap behaviour until an API
+    key is configured. Share PINs and trusted CIDRs are consumption credentials;
+    neither authorizes this gate.
+    """
+    host = request.client.host if request.client else None
+    if is_loopback(host):
+        return
+    if _server_mode():
+        method = str(getattr(request, "method", "GET")).upper()
+        read_only = method in {"GET", "HEAD", "OPTIONS"}
+        if read_only and not _admin_credential_configured(request):
+            return
+        if _request_presents_admin_credential(request):
+            return
+    raise HTTPException(status_code=403, detail="loopback origin or admin API key required")
+
+
 def require_local(request: Request) -> None:
     """Reject any request whose client.host is not loopback OR on a configured
     trusted network. The consumption-tier companion to :func:`require_loopback`:

--- a/backend/api/routers/media_tools.py
+++ b/backend/api/routers/media_tools.py
@@ -19,7 +19,7 @@ router = APIRouter(dependencies=[Depends(require_loopback)])
 
 
 class CustomPathRequest(BaseModel):
-    path: str
+    authorization: str
 
 
 def _svc():
@@ -61,8 +61,13 @@ def media_tools_ytdlp_restore():
 
 @router.post("/media-tools/{tool}/custom-path")
 def media_tools_custom_path(tool: str, body: CustomPathRequest):
+    from core.path_authorization import PathAuthorizationError, consume
+
     try:
-        return _svc().set_custom_path(tool, body.path)
+        path = consume(body.authorization, tool)
+        return _svc().set_custom_path(tool, path)
+    except PathAuthorizationError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -1,11 +1,10 @@
 """Settings API — HF token save/clear/state endpoints (Phase 1 AUTH-03 backend half).
 
 These endpoints are the backend half of the Wave 2 Settings → API Keys
-panel. Threat T-01-03 mitigation: every write endpoint is gated by the
-router-level `require_loopback` dep, so non-loopback origins get 403
-before the handler runs. Reads are loopback-gated too — the masked
-token preview is useful telemetry that we still don't want exposed on
-the LAN.
+panel. Threat T-01-03 mitigation: the router-level `require_admin` dependency
+keeps desktop callers loopback-only and requires the long API key for every
+remote server-mode mutation. Read-only bare-Docker discovery remains available
+until an API key is configured; once configured, reads require it too.
 
 The state endpoint duplicates `/system/hf-token/state` (which lives on
 `system.py` for legacy-router compatibility); both return the same shape.
@@ -20,14 +19,14 @@ from dataclasses import asdict
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.dependencies import require_loopback
+from api.dependencies import require_admin
 
 logger = logging.getLogger("omnivoice.api.settings")
 
 router = APIRouter(
     prefix="/api/settings",
     tags=["settings"],
-    dependencies=[Depends(require_loopback)],
+    dependencies=[Depends(require_admin)],
 )
 
 

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -19,7 +19,7 @@ from dataclasses import asdict
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.dependencies import require_admin
+from api.dependencies import require_admin, require_desktop
 
 logger = logging.getLogger("omnivoice.api.settings")
 
@@ -703,7 +703,7 @@ def get_models_dir():
     }
 
 
-@router.put("/storage/models-dir")
+@router.put("/storage/models-dir", dependencies=[Depends(require_desktop)])
 def set_models_dir(body: _ModelsDirBody):
     """Set (or clear, with an empty path) the models download directory.
 

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -19,7 +19,7 @@ from dataclasses import asdict
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.dependencies import require_admin, require_desktop
+from api.dependencies import require_admin
 
 logger = logging.getLogger("omnivoice.api.settings")
 
@@ -684,7 +684,7 @@ def _effective_models_dir() -> str:
 
 
 class _ModelsDirBody(BaseModel):
-    path: str = Field(default="", description="Absolute directory; empty clears → default cache")
+    authorization: str = Field(description="One-shot native desktop authorization")
 
 
 @router.get("/storage/models-dir")
@@ -703,7 +703,7 @@ def get_models_dir():
     }
 
 
-@router.put("/storage/models-dir", dependencies=[Depends(require_desktop)])
+@router.put("/storage/models-dir")
 def set_models_dir(body: _ModelsDirBody):
     """Set (or clear, with an empty path) the models download directory.
 
@@ -713,17 +713,18 @@ def set_models_dir(body: _ModelsDirBody):
     saved. Returns restart_required=True.
     """
     from core import user_env
+    from core.path_authorization import PathAuthorizationError, consume
 
-    raw = (body.path or "").strip()
+    try:
+        raw = consume(body.authorization, "models_dir").strip()
+    except PathAuthorizationError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     if not raw:
         user_env.unset_user_env(_MODELS_DIR_ENV)
         return {"configured": None, "default": _default_models_dir(), "restart_required": True}
 
-    # Reject control characters / NUL before touching the filesystem: an
-    # embedded NUL makes os.makedirs raise ValueError (→ 500). This is also
-    # the input-validation barrier for the path before it reaches any fs call
-    # (the dir is user-chosen by design — this is a loopback-gated, same-user
-    # local file picker, not a cross-privilege boundary).
+    # Tauri already validates this before issuing the capability. Keep the
+    # backend checks as defense in depth against a corrupt capability file.
     if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in raw):
         raise HTTPException(status_code=400, detail="Path contains invalid control characters")
 

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -11,7 +11,7 @@ from core.prefs import set_ as prefs_set, delete as prefs_delete
 from services import network_share
 from services import tailscale as _tailscale
 from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse
-from api.dependencies import require_admin, require_desktop
+from api.dependencies import require_admin
 from fastapi.responses import FileResponse, StreamingResponse
 import torch
 import shutil
@@ -805,7 +805,6 @@ async def ack_crash():
 PERSISTENT_KEYS = {
     "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
     "http_proxy", "https_proxy", "all_proxy",
-    "FFMPEG_PATH", "FFPROBE_PATH",
     "TRANSLATE_BASE_URL", "TRANSLATE_API_KEY", "TRANSLATE_MODEL",
     "DEEPL_API_KEY", "DEEPL_BASE_URL",
     "MICROSOFT_API_KEY", "MICROSOFT_BASE_URL",
@@ -831,7 +830,7 @@ except Exception:  # pragma: no cover — defensive: env panel > installer wirin
 _PORT_KEYS = {"OMNIVOICE_PORT", "OMNIVOICE_SHARE_PORT", "OMNIVOICE_UI_PORT"}
 
 
-@router.post("/system/set-env", dependencies=[Depends(require_desktop)])
+@router.post("/system/set-env")
 async def set_env_var(body: dict):
     """Set an environment variable at runtime, persisted across restarts.
 
@@ -857,23 +856,6 @@ async def set_env_var(body: dict):
         )
 
     if value:
-        # Validate executable paths if the user is setting them manually.
-        # Reject control characters / null bytes (defense-in-depth against
-        # path-injection), then require an existing regular file. NOTE: this
-        # endpoint is loopback-only and MUST remain so — a remote caller able
-        # to set FFMPEG_PATH/FFPROBE_PATH could point it at an arbitrary
-        # binary (RCE). Network sharing must never expose /system/set-env.
-        if key in ("FFMPEG_PATH", "FFPROBE_PATH"):
-            if any(ord(c) < 0x20 or ord(c) == 0x7F for c in value):
-                raise HTTPException(
-                    status_code=400,
-                    detail="Invalid path: control characters are not allowed",
-                )
-            if not os.path.isfile(value):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"File not found: {value}",
-                )
         # Port keys must be a numeric string in the unprivileged range so a
         # typo can't drop the backend onto a privileged port (<1024) or an
         # out-of-range value uvicorn would reject at bind time.

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -11,7 +11,7 @@ from core.prefs import set_ as prefs_set, delete as prefs_delete
 from services import network_share
 from services import tailscale as _tailscale
 from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse
-from api.dependencies import require_admin
+from api.dependencies import is_loopback, require_admin
 from fastapi.responses import FileResponse, StreamingResponse
 import torch
 import shutil
@@ -1082,12 +1082,21 @@ def quarantine_status():
 # ── Network sharing (loopback-only control surface) ──────────────────────────
 
 @router.get("/system/network/state")
-async def network_state():
+async def network_state(request: Request):
     st = network_share.get_state()
+    # PIN-only server mode permits unauthenticated read-only discovery, but the
+    # PIN is itself a consumption credential. Reveal it only to the native
+    # loopback UI or to a remote caller that already passed the configured
+    # long API-key gate. The boolean lets headless dashboards remain useful.
+    host = request.client.host if request.client else None
+    may_reveal_pin = is_loopback(host) or bool(
+        os.environ.get("OMNIVOICE_API_KEY", "").strip()
+    )
     return {
         "enabled": st.enabled,
         "share_port": st.share_port,
-        "pin": st.pin,
+        "pin": st.pin if may_reveal_pin else None,
+        "pin_required": bool(st.pin),
         "lan_addresses": st.lan_addresses,
     }
 

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -11,7 +11,7 @@ from core.prefs import set_ as prefs_set, delete as prefs_delete
 from services import network_share
 from services import tailscale as _tailscale
 from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse
-from api.dependencies import require_admin
+from api.dependencies import require_admin, require_desktop
 from fastapi.responses import FileResponse, StreamingResponse
 import torch
 import shutil
@@ -831,7 +831,7 @@ except Exception:  # pragma: no cover — defensive: env panel > installer wirin
 _PORT_KEYS = {"OMNIVOICE_PORT", "OMNIVOICE_SHARE_PORT", "OMNIVOICE_UI_PORT"}
 
 
-@router.post("/system/set-env")
+@router.post("/system/set-env", dependencies=[Depends(require_desktop)])
 async def set_env_var(body: dict):
     """Set an environment variable at runtime, persisted across restarts.
 

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -11,7 +11,7 @@ from core.prefs import set_ as prefs_set, delete as prefs_delete
 from services import network_share
 from services import tailscale as _tailscale
 from api.schemas import SysinfoResponse, SystemInfoResponse, ModelStatusResponse
-from api.dependencies import require_loopback
+from api.dependencies import require_admin
 from fastapi.responses import FileResponse, StreamingResponse
 import torch
 import shutil
@@ -21,17 +21,16 @@ from core.version import APP_VERSION
 from services.model_manager import get_model_status, get_best_device, resolve_omnivoice_checkpoint
 from services.ffmpeg_utils import find_ffmpeg, run_ffmpeg
 
-# Router-level loopback gate. Every route mounted on `router` (GET + POST,
-# present and future) is gated by `require_loopback`, which 403s any request
-# whose `client.host` is not a loopback address. This closes the same trust
+# Router-level admin gate. Every route mounted on `router` (GET + POST,
+# present and future) is gated by `require_admin`: desktop requests must be
+# loopback; server-mode mutations require the long API key. This closes the trust
 # boundary that PR #81 only patched on `/system/set-env` and that the
 # 260518-ivy deferred-items file enumerated for follow-up: /model/unload/*,
 # /system/logs/clear, /system/logs/tauri/clear, /system/flush-memory,
 # /clean-audio (POSTs) plus the read-side info-disclosure routes
 # /system/info, /system/logs, /system/logs/tauri, /system/logs/stream.
-# This router only ever serves the local Tauri shell and the dev frontend
-# at http://127.0.0.1:3901 — both are loopback origins.
-router = APIRouter(dependencies=[Depends(require_loopback)])
+# Native Tauri/dev callers remain loopback and need no credential.
+router = APIRouter(dependencies=[Depends(require_admin)])
 logger = logging.getLogger("omnivoice.api")
 
 # Cache device checks at module load — they don't change at runtime
@@ -843,7 +842,7 @@ async def set_env_var(body: dict):
     are set on ``os.environ`` for the running process.
 
     The loopback-origin gate that previously lived inline here is now applied
-    at the router level via `dependencies=[Depends(require_loopback)]` on
+    at the router level via `dependencies=[Depends(require_admin)]` on
     `router` — see the top of this file. Every route on this router is
     gated, including this one. The 403 body and behavior are unchanged.
     """

--- a/backend/core/path_authorization.py
+++ b/backend/core/path_authorization.py
@@ -1,0 +1,67 @@
+"""Consume one-shot host paths authorized by the native Tauri process.
+
+The web API never accepts a filesystem destination or executable path. Tauri
+validates the user's native IPC request, writes a private capability file, and
+only the unguessable capability token crosses loopback HTTP.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+
+_TOKEN_RE = re.compile(r"[0-9a-f]{64}\Z")
+_KINDS = {"models_dir", "ffmpeg", "ffprobe"}
+
+
+class PathAuthorizationError(ValueError):
+    pass
+
+
+def consume(token: str, expected_kind: str) -> str:
+    """Consume and return a single Tauri-authorized path.
+
+    Capability files are one-shot and opened without following symlinks. The
+    containing directory is supplied only to the desktop-spawned backend; a
+    source/Docker backend has no path-authority channel by design.
+    """
+    if expected_kind not in _KINDS or not _TOKEN_RE.fullmatch(token or ""):
+        raise PathAuthorizationError("Invalid or expired desktop authorization")
+    root = os.environ.get("OMNIVOICE_PATH_AUTH_DIR", "")
+    if not root:
+        raise PathAuthorizationError("This path can only be selected in the desktop app")
+    candidate = os.path.join(root, f"{token}.json")
+    claimed = os.path.join(root, f".{token}.consuming")
+    try:
+        os.replace(candidate, claimed)
+    except OSError as exc:
+        raise PathAuthorizationError("Invalid or expired desktop authorization") from exc
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(claimed, flags)
+    except OSError as exc:
+        raise PathAuthorizationError("Invalid or expired desktop authorization") from exc
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_size > 16_384:
+            raise PathAuthorizationError("Invalid desktop authorization")
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            fd = -1
+            payload = json.load(handle)
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as exc:
+        raise PathAuthorizationError("Invalid desktop authorization") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(claimed)
+        except OSError:
+            pass
+    if not isinstance(payload, dict):
+        raise PathAuthorizationError("Invalid desktop authorization")
+    if payload.get("kind") != expected_kind or not isinstance(payload.get("path"), str):
+        raise PathAuthorizationError("Desktop authorization does not match this setting")
+    return payload["path"]

--- a/backend/core/path_authorization.py
+++ b/backend/core/path_authorization.py
@@ -78,7 +78,7 @@ def consume(token: str, expected_kind: str) -> str:
         try:
             os.unlink(claimed)
         except OSError:
-            pass
+            pass  # Best-effort cleanup; the random claimed name cannot be reused.
     if not isinstance(payload, dict):
         raise PathAuthorizationError("Invalid desktop authorization")
     if not secrets.compare_digest(str(payload.get("token", "")), token):

--- a/backend/core/path_authorization.py
+++ b/backend/core/path_authorization.py
@@ -9,10 +9,14 @@ from __future__ import annotations
 import json
 import os
 import re
+import secrets
 import stat
+
+from core.config import DATA_DIR
 
 _TOKEN_RE = re.compile(r"[0-9a-f]{64}\Z")
 _KINDS = {"models_dir", "ffmpeg", "ffprobe"}
+_AUTH_DIR = os.path.join(DATA_DIR, ".path-authorizations")
 
 
 class PathAuthorizationError(ValueError):
@@ -22,18 +26,33 @@ class PathAuthorizationError(ValueError):
 def consume(token: str, expected_kind: str) -> str:
     """Consume and return a single Tauri-authorized path.
 
-    Capability files are one-shot and opened without following symlinks. The
-    containing directory is supplied only to the desktop-spawned backend; a
-    source/Docker backend has no path-authority channel by design.
+    Capability files are one-shot and opened without following symlinks. Tauri
+    writes them into the app's private data directory; source/Docker callers
+    cannot mint a valid token through HTTP.
     """
     if expected_kind not in _KINDS or not _TOKEN_RE.fullmatch(token or ""):
         raise PathAuthorizationError("Invalid or expired desktop authorization")
-    root = os.environ.get("OMNIVOICE_PATH_AUTH_DIR", "")
-    if not root:
-        raise PathAuthorizationError("This path can only be selected in the desktop app")
-    candidate = os.path.join(root, f"{token}.json")
-    claimed = os.path.join(root, f".{token}.consuming")
+    root = _AUTH_DIR
+    candidate = None
     try:
+        for entry in os.scandir(root):
+            if not _TOKEN_RE.fullmatch(entry.name.removesuffix(".json")):
+                continue
+            if not entry.is_file(follow_symlinks=False):
+                continue
+            try:
+                with open(entry.path, "r", encoding="utf-8") as handle:
+                    probe = json.load(handle)
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                continue  # Ignore corrupt/stale capabilities; they authorize nothing.
+            if isinstance(probe, dict) and secrets.compare_digest(
+                str(probe.get("token", "")), token
+            ):
+                candidate = entry.path
+                break
+        if candidate is None:
+            raise OSError("capability not found")
+        claimed = os.path.join(root, f".consuming-{os.getpid()}-{secrets.token_hex(16)}")
         os.replace(candidate, claimed)
     except OSError as exc:
         raise PathAuthorizationError("Invalid or expired desktop authorization") from exc
@@ -61,6 +80,8 @@ def consume(token: str, expected_kind: str) -> str:
         except OSError:
             pass
     if not isinstance(payload, dict):
+        raise PathAuthorizationError("Invalid desktop authorization")
+    if not secrets.compare_digest(str(payload.get("token", "")), token):
         raise PathAuthorizationError("Invalid desktop authorization")
     if payload.get("kind") != expected_kind or not isinstance(payload.get("path"), str):
         raise PathAuthorizationError("Desktop authorization does not match this setting")

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -21,7 +21,8 @@ tools keep working unchanged whichever gate is set.
 > VoiceStudio separates **consumption** (TTS, dictation, voices) from
 > **administration** (`/system/*`, `/api/settings/*` — RCE-class). The PIN and
 > trusted networks are *consumption* credentials; the **admin surface is only
-> ever reached from loopback or with the API key** (see [Admin routes](#admin-routes-and-server-mode)).
+> ever reached from loopback or with the API key**. Host-path capabilities stay
+> desktop-only even with a key (see [Admin routes](#admin-routes-and-server-mode)).
 
 > Both gates can be active at once. The PIN and the API key are independent; when
 > both are set, each is checked on the paths it covers.
@@ -214,6 +215,11 @@ requirement is dropped (issue #261, else the operator is 403'd out of their own
   share PIN does not gate admin** (it is brute-forceable), and trusted-network
   membership never does either. So a **PIN-only** server-mode deployment keeps
   admin loopback-only; remote admin requires the long API key.
+
+Two host-path capabilities are never remote: `/system/set-env` and
+`PUT /api/settings/storage/models-dir`. They can select executable or writable
+filesystem paths, so only a genuine loopback desktop caller may use them;
+server mode and an API key do not weaken that boundary.
 
 This is the fix for a real escalation (#1213): before it, server mode made the
 admin gate a no-op, so with an API key set *and* a trusted CIDR configured, a LAN

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -215,7 +215,8 @@ requirement is dropped (issue #261, else the operator is 403'd out of their own
   share PIN does not gate admin** (it is brute-forceable), and trusted-network
   membership never does either. A **PIN-only** server-mode deployment therefore
   allows remote read-only discovery but blocks remote mutations; remote writes
-  require the long API key.
+  require the long API key. Discovery never returns the share PIN itself; only
+  loopback or a caller already authenticated with the API key can read it.
 
 Host paths are never selected through HTTP. The native Tauri process validates
 model-cache destinations and custom FFmpeg/FFprobe binaries, writes a private

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -206,8 +206,9 @@ origin is unenforceable — NAT rewrites the source and even a
 requirement is dropped (issue #261, else the operator is 403'd out of their own
 `/system/*`). It is replaced by a **credential rule**, not removed:
 
-- **No credential configured** (no API key, no PIN) → admin is open. The bare
-  Docker flow; exposure rests entirely on your port mapping / firewall.
+- **No API key configured** → read-only admin discovery remains available for
+  the bare Docker bootstrap flow, but `POST`/`PUT`/`PATCH`/`DELETE` requests are
+  denied. Set `OMNIVOICE_API_KEY` before changing settings remotely.
 - **A credential is configured** → admin requires the **API key** (`Authorization:
   Bearer` / `?api_key` / `ov_key` cookie), or genuine loopback. The **6-digit
   share PIN does not gate admin** (it is brute-forceable), and trusted-network

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -213,13 +213,15 @@ requirement is dropped (issue #261, else the operator is 403'd out of their own
 - **A credential is configured** → admin requires the **API key** (`Authorization:
   Bearer` / `?api_key` / `ov_key` cookie), or genuine loopback. The **6-digit
   share PIN does not gate admin** (it is brute-forceable), and trusted-network
-  membership never does either. So a **PIN-only** server-mode deployment keeps
-  admin loopback-only; remote admin requires the long API key.
+  membership never does either. A **PIN-only** server-mode deployment therefore
+  allows remote read-only discovery but blocks remote mutations; remote writes
+  require the long API key.
 
-Two host-path capabilities are never remote: `/system/set-env` and
-`PUT /api/settings/storage/models-dir`. They can select executable or writable
-filesystem paths, so only a genuine loopback desktop caller may use them;
-server mode and an API key do not weaken that boundary.
+Host paths are never selected through HTTP. The native Tauri process validates
+model-cache destinations and custom FFmpeg/FFprobe binaries, writes a private
+one-shot capability, and only that opaque authorization reaches the backend.
+`/system/set-env` does not accept executable-path keys at all. Server mode and
+an API key do not weaken that native boundary.
 
 This is the fix for a real escalation (#1213): before it, server mode made the
 admin gate a no-op, so with an API key set *and* a trusted CIDR configured, a LAN

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2947,6 +2947,7 @@ dependencies = [
  "dirs-next",
  "enigo",
  "fs4",
+ "getrandom 0.3.4",
  "libc",
  "log",
  "reqwest",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-build = { version = "2.6.0", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+getrandom = "0.3"
 log = "0.4"
 tauri = { version = "2.11.0", features = ["macos-private-api", "protocol-asset", "tray-icon", "image-png"] }
 tauri-plugin-log = "2"

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -387,10 +387,6 @@ pub fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Opt
     // pass below — otherwise a user-set OMNIVOICE_PORT would change the
     // LAN-share/Tailscale target while the listener stayed on the Rust port.
     env.push(("OMNIVOICE_PORT".into(), backend_port().to_string()));
-    env.push((
-        "OMNIVOICE_PATH_AUTH_DIR".into(),
-        crate::commands::path_authorization_dir(app).to_string_lossy().into(),
-    ));
     if cfg!(target_os = "windows") {
         env.push(("TORCHDYNAMO_DISABLE".into(), "1".into()));
         env.push(("HF_HUB_DISABLE_SYMLINKS_WARNING".into(), "1".into()));

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -387,6 +387,10 @@ pub fn spawn_backend<R: tauri::Runtime>(app: &tauri::AppHandle<R>, progress: Opt
     // pass below — otherwise a user-set OMNIVOICE_PORT would change the
     // LAN-share/Tailscale target while the listener stayed on the Rust port.
     env.push(("OMNIVOICE_PORT".into(), backend_port().to_string()));
+    env.push((
+        "OMNIVOICE_PATH_AUTH_DIR".into(),
+        crate::commands::path_authorization_dir(app).to_string_lossy().into(),
+    ));
     if cfg!(target_os = "windows") {
         env.push(("TORCHDYNAMO_DISABLE".into(), "1".into()));
         env.push(("HF_HUB_DISABLE_SYMLINKS_WARNING".into(), "1".into()));

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -5,12 +5,118 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::image::Image;
+use tauri::Manager;
 
 use crate::{AppFlags, TrayHandle, DictationShortcutState};
 use crate::{TRAY_ICON_DEFAULT, TRAY_ICON_RECORDING};
 use crate::config::{load_config, save_config};
+
+// ── Native host-path authorization ───────────────────────────────────────
+
+#[derive(Serialize, Deserialize)]
+struct AuthorizedHostPath {
+    kind: String,
+    path: String,
+}
+
+pub fn path_authorization_dir<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> PathBuf {
+    app.path()
+        .app_local_data_dir()
+        .unwrap_or_default()
+        .join("path-authorizations")
+}
+
+fn validate_host_path(kind: &str, raw: &str) -> Result<PathBuf, String> {
+    if !matches!(kind, "models_dir" | "ffmpeg" | "ffprobe") {
+        return Err("Unsupported host-path capability".into());
+    }
+    if raw.chars().any(|c| c.is_control()) {
+        return Err("Path contains invalid control characters".into());
+    }
+    if kind == "models_dir" && raw.is_empty() {
+        return Ok(PathBuf::new()); // explicit reset to the platform default
+    }
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err("Path must be absolute".into());
+    }
+    if kind == "models_dir" {
+        fs::create_dir_all(&path).map_err(|e| format!("Directory is not writable: {e}"))?;
+        let probe = path.join(".voicestudio-write-test");
+        fs::write(&probe, b"ok").map_err(|e| format!("Directory is not writable: {e}"))?;
+        let _ = fs::remove_file(probe);
+    } else {
+        if !path.is_file() {
+            return Err("Selected media tool is not a file".into());
+        }
+        let status = crate::tools::no_window(
+            std::process::Command::new(&path)
+                .arg("-version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null()),
+        )
+        .status()
+        .map_err(|e| format!("Selected media tool could not run: {e}"))?;
+        if !status.success() {
+            return Err("Selected media tool failed its version check".into());
+        }
+    }
+    Ok(path)
+}
+
+#[tauri::command]
+pub fn authorize_host_path(
+    app: tauri::AppHandle,
+    kind: String,
+    path: String,
+) -> Result<String, String> {
+    let validated = validate_host_path(&kind, path.trim())?;
+    let mut random = [0_u8; 32];
+    getrandom::fill(&mut random).map_err(|e| format!("Secure randomness unavailable: {e}"))?;
+    let token: String = random.iter().map(|b| format!("{b:02x}")).collect();
+    let dir = path_authorization_dir(&app);
+    fs::create_dir_all(&dir).map_err(|e| format!("Could not create authorization store: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("Could not protect authorization store: {e}"))?;
+    }
+    let target = dir.join(format!("{token}.json"));
+    let payload = AuthorizedHostPath {
+        kind,
+        path: validated.to_string_lossy().into_owned(),
+    };
+    fs::write(&target, serde_json::to_vec(&payload).map_err(|e| e.to_string())?)
+        .map_err(|e| format!("Could not authorize path: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("Could not protect authorization: {e}"))?;
+    }
+    Ok(token)
+}
+
+#[cfg(test)]
+mod host_path_authorization_tests {
+    use super::validate_host_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn rejects_unknown_relative_and_control_character_paths() {
+        assert!(validate_host_path("shell", "/tmp/tool").is_err());
+        assert!(validate_host_path("models_dir", "relative/models").is_err());
+        assert!(validate_host_path("models_dir", "/tmp/bad\npath").is_err());
+    }
+
+    #[test]
+    fn empty_models_path_is_the_authorized_default_reset() {
+        assert_eq!(validate_host_path("models_dir", "").unwrap(), PathBuf::new());
+    }
+}
 
 // ── System metrics ────────────────────────────────────────────────────────
 

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tauri::image::Image;
-use tauri::Manager;
 
 use crate::{AppFlags, TrayHandle, DictationShortcutState};
 use crate::{TRAY_ICON_DEFAULT, TRAY_ICON_RECORDING};
@@ -17,15 +16,15 @@ use crate::config::{load_config, save_config};
 
 #[derive(Serialize, Deserialize)]
 struct AuthorizedHostPath {
+    token: String,
     kind: String,
     path: String,
 }
 
 pub fn path_authorization_dir<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> PathBuf {
-    app.path()
-        .app_local_data_dir()
-        .unwrap_or_default()
-        .join("path-authorizations")
+    crate::setup::resolved_data_dir(app)
+        .unwrap_or_else(crate::setup::default_data_dir)
+        .join(".path-authorizations")
 }
 
 fn validate_host_path(kind: &str, raw: &str) -> Result<PathBuf, String> {
@@ -86,6 +85,7 @@ pub fn authorize_host_path(
     }
     let target = dir.join(format!("{token}.json"));
     let payload = AuthorizedHostPath {
+        token: token.clone(),
         kind,
         path: validated.to_string_lossy().into_owned(),
     };

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -422,6 +422,7 @@ pub fn run() {
             updater_channel::install_update,
             updater_channel::list_releases,
             commands::get_sysinfo,
+            commands::authorize_host_path,
             commands::read_log_tail,
             commands::hf_cache_scan,
             commands::simulate_paste,

--- a/frontend/src/components/settings/AudioToolsPanel.jsx
+++ b/frontend/src/components/settings/AudioToolsPanel.jsx
@@ -267,7 +267,27 @@ export default function AudioToolsPanel() {
 
   const onToolAction = useCallback(
     async (path, body) => {
-      const ok = await post(path, body);
+      let requestBody = body;
+      if (path.endsWith('/custom-path')) {
+        try {
+          const { invoke } = await import('@tauri-apps/api/core');
+          const tool = path.includes('/ffprobe/') ? 'ffprobe' : 'ffmpeg';
+          const authorization = await invoke('authorize_host_path', {
+            kind: tool,
+            path: body?.path || '',
+          });
+          requestBody = { authorization };
+        } catch (e) {
+          toast.error(
+            t('settings.audio_tools_path_failed', {
+              message: e.message || String(e),
+              defaultValue: "Couldn't set path: {{message}}",
+            }),
+          );
+          return;
+        }
+      }
+      const ok = await post(path, requestBody);
       if (ok && (path.endsWith('/custom-path') || path.endsWith('/use-system'))) {
         toast.success(
           t('settings.audio_tools_path_set', {

--- a/frontend/src/components/settings/AudioToolsPanel.test.jsx
+++ b/frontend/src/components/settings/AudioToolsPanel.test.jsx
@@ -11,6 +11,8 @@ vi.mock('../../api/client', () => ({
   apiJson: vi.fn(),
   apiFetch: vi.fn(),
 }));
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args) => invoke(...args) }));
 
 import { toast } from 'react-hot-toast';
 import { apiJson, apiFetch } from '../../api/client';
@@ -57,6 +59,7 @@ describe('AudioToolsPanel — power-user surface for the media tools', () => {
     vi.clearAllMocks();
     apiJson.mockResolvedValue(JSON.parse(JSON.stringify(STATUS)));
     apiFetch.mockResolvedValue(okResponse);
+    invoke.mockResolvedValue('c'.repeat(64));
   });
 
   it('renders one row per tool with version, path, and origin badge', async () => {
@@ -83,6 +86,26 @@ describe('AudioToolsPanel — power-user surface for the media tools', () => {
       expect(apiFetch).toHaveBeenCalledWith('/media-tools/ffmpeg/use-system', expect.anything()),
     );
     await waitFor(() => expect(toast.success).toHaveBeenCalled());
+  });
+
+  it('sends only a native one-shot authorization for a custom executable', async () => {
+    render(<AudioToolsPanel />);
+    fireEvent.click(await screen.findByLabelText('FFmpeg: Choose file…'));
+    const input = await screen.findByLabelText('FFmpeg binary path');
+    fireEvent.change(input, { target: { value: '/opt/tools/ffmpeg' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('authorize_host_path', {
+        kind: 'ffmpeg',
+        path: '/opt/tools/ffmpeg',
+      }),
+    );
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/media-tools/ffmpeg/custom-path',
+      expect.objectContaining({ body: JSON.stringify({ authorization: 'c'.repeat(64) }) }),
+    );
+    expect(apiFetch.mock.calls.flat().join(' ')).not.toContain('/opt/tools/ffmpeg');
   });
 
   it('Restore bundled is per-tool and always available (safe revert)', async () => {

--- a/frontend/src/components/settings/StoragePanel.jsx
+++ b/frontend/src/components/settings/StoragePanel.jsx
@@ -9,7 +9,7 @@
  * Endpoints:
  *   GET /api/settings/storage/models-dir
  *     → {configured, effective, default, restart_required}
- *   PUT /api/settings/storage/models-dir  body {path}  (empty path clears)
+ *   Native IPC authorizes the path, then PUT sends only the one-shot token.
  */
 import React, { useCallback, useEffect, useState } from 'react';
 import { HardDrive } from 'lucide-react';
@@ -52,10 +52,12 @@ export default function StoragePanel() {
     setSaving(true);
     setError(null);
     try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      const authorization = await invoke('authorize_host_path', { kind: 'models_dir', path });
       const res = await apiFetch('/api/settings/storage/models-dir', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path }),
+        body: JSON.stringify({ authorization }),
       });
       if (!res.ok) {
         const b = await res.json().catch(() => ({}));

--- a/frontend/src/components/settings/StoragePanel.test.jsx
+++ b/frontend/src/components/settings/StoragePanel.test.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn() } }));
+const apiJson = vi.fn();
+const apiFetch = vi.fn();
+vi.mock('../../api/client', () => ({
+  apiJson: (...args) => apiJson(...args),
+  apiFetch: (...args) => apiFetch(...args),
+}));
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args) => invoke(...args) }));
+
+import StoragePanel from './StoragePanel';
+
+describe('StoragePanel native path boundary', () => {
+  it('never sends the selected models directory through HTTP', async () => {
+    apiJson.mockResolvedValue({ configured: '', effective: '/cache', default: '/default' });
+    apiFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ configured: '/private/models', restart_required: true }),
+    });
+    invoke.mockResolvedValue('d'.repeat(64));
+    render(<StoragePanel />);
+
+    const input = await screen.findByTestId('models-dir-input');
+    fireEvent.change(input, { target: { value: '/private/models' } });
+    fireEvent.click(screen.getByTestId('models-dir-save'));
+
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith('authorize_host_path', {
+        kind: 'models_dir',
+        path: '/private/models',
+      }),
+    );
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/settings/storage/models-dir',
+      expect.objectContaining({ body: JSON.stringify({ authorization: 'd'.repeat(64) }) }),
+    );
+    expect(apiFetch.mock.calls.flat().join(' ')).not.toContain('/private/models');
+  });
+});

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -624,6 +624,31 @@ def test_server_mode_remote_without_api_key_cannot_set_executable_path(monkeypat
             os.environ["FFMPEG_PATH"] = original
 
 
+def test_server_mode_remote_api_key_cannot_set_executable_path(monkeypatch, tmp_path):
+    """An admin key does not grant the desktop file-picker capability."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    executable = tmp_path / "ffmpeg"
+    executable.write_bytes(b"not actually executable")
+    original = os.environ.get("FFMPEG_PATH")
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    try:
+        response = TestClient(app, client=("172.17.0.1", 50000)).post(
+            "/system/set-env",
+            headers={"authorization": "Bearer s3cret"},
+            json={"key": "FFMPEG_PATH", "value": str(executable)},
+        )
+        assert response.status_code == 403
+        assert os.environ.get("FFMPEG_PATH") == original
+    finally:
+        if original is None:
+            os.environ.pop("FFMPEG_PATH", None)
+        else:
+            os.environ["FFMPEG_PATH"] = original
+
+
 def test_set_env_loopback_still_validates_allowlist():
     """Even on the loopback path, keys outside the allow-list must return 400 —
     the new guard must NOT bypass the existing allow-list enforcement."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -624,8 +624,8 @@ def test_server_mode_remote_without_api_key_cannot_set_executable_path(monkeypat
             os.environ["FFMPEG_PATH"] = original
 
 
-def test_server_mode_remote_api_key_cannot_set_executable_path(monkeypatch, tmp_path):
-    """An admin key does not grant the desktop file-picker capability."""
+def test_set_env_never_accepts_executable_path_even_with_admin_key(monkeypatch, tmp_path):
+    """Executable selection exists only behind native IPC, never this API."""
     from fastapi.testclient import TestClient
     from main import app
 
@@ -640,7 +640,7 @@ def test_server_mode_remote_api_key_cannot_set_executable_path(monkeypatch, tmp_
             headers={"authorization": "Bearer s3cret"},
             json={"key": "FFMPEG_PATH", "value": str(executable)},
         )
-        assert response.status_code == 403
+        assert response.status_code == 400
         assert os.environ.get("FFMPEG_PATH") == original
     finally:
         if original is None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -600,6 +600,30 @@ def test_set_env_allows_loopback():
             os.environ["HF_TOKEN"] = original
 
 
+def test_server_mode_remote_without_api_key_cannot_set_executable_path(monkeypatch, tmp_path):
+    """GHAS #506: bare Docker exposure must not become an executable setter."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    executable = tmp_path / "ffmpeg"
+    executable.write_bytes(b"not actually executable")
+    original = os.environ.get("FFMPEG_PATH")
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    try:
+        response = TestClient(app, client=("172.17.0.1", 50000)).post(
+            "/system/set-env",
+            json={"key": "FFMPEG_PATH", "value": str(executable)},
+        )
+        assert response.status_code == 403
+        assert os.environ.get("FFMPEG_PATH") == original
+    finally:
+        if original is None:
+            os.environ.pop("FFMPEG_PATH", None)
+        else:
+            os.environ["FFMPEG_PATH"] = original
+
+
 def test_set_env_loopback_still_validates_allowlist():
     """Even on the loopback path, keys outside the allow-list must return 400 —
     the new guard must NOT bypass the existing allow-list enforcement."""
@@ -686,4 +710,3 @@ def test_static_audio_served_with_canonical_mime():
         )
     finally:
         tmp_wav.unlink(missing_ok=True)
-

--- a/tests/test_loopback_server_mode.py
+++ b/tests/test_loopback_server_mode.py
@@ -10,7 +10,13 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from api.dependencies import is_loopback, is_local_host, require_local, require_loopback
+from api.dependencies import (
+    is_loopback,
+    is_local_host,
+    require_admin,
+    require_local,
+    require_loopback,
+)
 
 
 def _req(host):
@@ -134,7 +140,7 @@ def test_require_local_rejects_untrusted_non_loopback(monkeypatch):
     assert exc.value.status_code == 403
 
 
-def _req_full(host, *, headers=None, query=None, cookies=None, pin=None):
+def _req_full(host, *, headers=None, query=None, cookies=None, pin=None, method="GET"):
     """Richer stub carrying the channels the admin-credential check reads:
     headers, query params, cookies, and app.state.network_share.pin."""
     ns = SimpleNamespace(pin=pin) if pin is not None else None
@@ -145,6 +151,7 @@ def _req_full(host, *, headers=None, query=None, cookies=None, pin=None):
         query_params=query or {},
         cookies=cookies or {},
         app=app,
+        method=method,
     )
 
 
@@ -229,6 +236,43 @@ def test_server_mode_loopback_admin_never_needs_credential(monkeypatch):
     monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
     monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
     require_loopback(_req_full("127.0.0.1"))  # must not raise
+
+
+# GHAS #506/#440/#441: require_loopback permits an unconfigured bare Docker
+# server for compatibility. RCE/filesystem-capable routers use the stricter,
+# method-aware admin gate instead.
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_server_mode_admin_mutation_requires_api_key_when_unconfigured(monkeypatch, method):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        require_admin(_req_full("172.17.0.1", method=method))
+    assert exc.value.status_code == 403
+
+
+def test_server_mode_admin_read_keeps_bare_docker_bootstrap(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    require_admin(_req_full("172.17.0.1", method="GET"))
+
+
+def test_server_mode_admin_mutation_allows_api_key(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    require_admin(_req_full(
+        "172.17.0.1",
+        method="POST",
+        headers={"authorization": "Bearer s3cret"},
+    ))
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])
+def test_loopback_admin_never_needs_api_key(monkeypatch, method):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    require_admin(_req_full("127.0.0.1", method=method))
 
 
 def test_is_local_host_unwraps_ipv4_mapped_ipv6(monkeypatch):

--- a/tests/test_loopback_server_mode.py
+++ b/tests/test_loopback_server_mode.py
@@ -14,6 +14,7 @@ from api.dependencies import (
     is_loopback,
     is_local_host,
     require_admin,
+    require_desktop,
     require_local,
     require_loopback,
 )
@@ -258,6 +259,13 @@ def test_server_mode_admin_read_keeps_bare_docker_bootstrap(monkeypatch):
     require_admin(_req_full("172.17.0.1", method="GET"))
 
 
+def test_server_mode_admin_read_keeps_pin_only_discovery(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    monkeypatch.setenv("OMNIVOICE_SHARE_PIN", "123456")
+    require_admin(_req_full("172.17.0.1", method="GET"))
+
+
 def test_server_mode_admin_mutation_allows_api_key(monkeypatch):
     monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
     monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
@@ -266,6 +274,18 @@ def test_server_mode_admin_mutation_allows_api_key(monkeypatch):
         method="POST",
         headers={"authorization": "Bearer s3cret"},
     ))
+
+
+def test_server_mode_desktop_capability_rejects_remote_api_key(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    with pytest.raises(HTTPException) as exc:
+        require_desktop(_req_full(
+            "172.17.0.1",
+            method="POST",
+            headers={"authorization": "Bearer s3cret"},
+        ))
+    assert exc.value.status_code == 403
 
 
 @pytest.mark.parametrize("method", ["GET", "POST", "PUT", "DELETE"])

--- a/tests/test_loopback_server_mode.py
+++ b/tests/test_loopback_server_mode.py
@@ -10,14 +10,36 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
-from api.dependencies import (
-    is_loopback,
-    is_local_host,
-    require_admin,
-    require_desktop,
-    require_local,
-    require_loopback,
-)
+def _dependency(name):
+    # Resolve at test execution time: other suites intentionally replace
+    # ``api.*`` modules in sys.modules while probing cold-start behavior.
+    from api import dependencies
+
+    return getattr(dependencies, name)
+
+
+def is_loopback(*args, **kwargs):
+    return _dependency("is_loopback")(*args, **kwargs)
+
+
+def is_local_host(*args, **kwargs):
+    return _dependency("is_local_host")(*args, **kwargs)
+
+
+def require_admin(*args, **kwargs):
+    return _dependency("require_admin")(*args, **kwargs)
+
+
+def require_desktop(*args, **kwargs):
+    return _dependency("require_desktop")(*args, **kwargs)
+
+
+def require_local(*args, **kwargs):
+    return _dependency("require_local")(*args, **kwargs)
+
+
+def require_loopback(*args, **kwargs):
+    return _dependency("require_loopback")(*args, **kwargs)
 
 
 def _req(host):

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -30,7 +30,8 @@ def mt(monkeypatch, tmp_path):
     monkeypatch.setattr(mt_mod, "media_tools_dir", lambda: str(tmp_path / "media_tools"))
     auth_dir = tmp_path / "path-authorizations"
     auth_dir.mkdir()
-    monkeypatch.setenv("OMNIVOICE_PATH_AUTH_DIR", str(auth_dir))
+    from core import path_authorization
+    monkeypatch.setattr(path_authorization, "_AUTH_DIR", str(auth_dir))
     for op in mt_mod._ops.values():
         op.update(state="idle", progress=0.0, error=None)
     mt_mod._version_cache.clear()
@@ -397,9 +398,10 @@ def test_router_custom_path_consumes_native_authorization(mt, monkeypatch, tmp_p
     binary.write_bytes(b"native-authorized")
     monkeypatch.setattr(mt, "_binary_runs", lambda _path: True)
     token = "b" * 64
-    auth_file = os.path.join(os.environ["OMNIVOICE_PATH_AUTH_DIR"], f"{token}.json")
+    from core import path_authorization
+    auth_file = os.path.join(path_authorization._AUTH_DIR, f"{token}.json")
     with open(auth_file, "w", encoding="utf-8") as handle:
-        json.dump({"kind": "ffmpeg", "path": str(binary)}, handle)
+        json.dump({"token": token, "kind": "ffmpeg", "path": str(binary)}, handle)
     c = _client()
     response = c.post(
         "/media-tools/ffmpeg/custom-path", json={"authorization": token}

--- a/tests/test_media_tools.py
+++ b/tests/test_media_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 import os
 import zipfile
 from unittest.mock import patch
@@ -27,6 +28,9 @@ def mt(monkeypatch, tmp_path):
 
     monkeypatch.setattr(prefs, "_PREFS_PATH", str(tmp_path / "prefs.json"))
     monkeypatch.setattr(mt_mod, "media_tools_dir", lambda: str(tmp_path / "media_tools"))
+    auth_dir = tmp_path / "path-authorizations"
+    auth_dir.mkdir()
+    monkeypatch.setenv("OMNIVOICE_PATH_AUTH_DIR", str(auth_dir))
     for op in mt_mod._ops.values():
         op.update(state="idle", progress=0.0, error=None)
     mt_mod._version_cache.clear()
@@ -382,11 +386,27 @@ def test_router_status_and_acquire_endpoints(mt, monkeypatch):
     assert r.json()["state"] == "running"
 
 
-def test_router_custom_path_maps_validation_to_400(mt):
+def test_router_custom_path_rejects_raw_http_path(mt):
     c = _client()
     r = c.post("/media-tools/ffmpeg/custom-path", json={"path": "/no/such/binary"})
-    assert r.status_code == 400
-    assert "not found" in r.json()["detail"].lower()
+    assert r.status_code == 422
+
+
+def test_router_custom_path_consumes_native_authorization(mt, monkeypatch, tmp_path):
+    binary = tmp_path / "ffmpeg"
+    binary.write_bytes(b"native-authorized")
+    monkeypatch.setattr(mt, "_binary_runs", lambda _path: True)
+    token = "b" * 64
+    auth_file = os.path.join(os.environ["OMNIVOICE_PATH_AUTH_DIR"], f"{token}.json")
+    with open(auth_file, "w", encoding="utf-8") as handle:
+        json.dump({"kind": "ffmpeg", "path": str(binary)}, handle)
+    c = _client()
+    response = c.post(
+        "/media-tools/ffmpeg/custom-path", json={"authorization": token}
+    )
+    assert response.status_code == 200
+    assert os.environ["FFMPEG_PATH"] == str(binary)
+    assert not os.path.exists(auth_file)
 
 
 def test_router_use_system_maps_lookup_to_404(mt, monkeypatch):

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -59,6 +59,23 @@ def test_rejects_path_with_null_byte(env):
     assert ei.value.status_code == 400
 
 
+def test_server_mode_remote_without_api_key_cannot_create_models_dir(env, monkeypatch, tmp_path):
+    """GHAS #440/#441: a published bare Docker port is not filesystem auth."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    target = tmp_path / "must-not-exist"
+    app = fastapi.FastAPI()
+    app.include_router(s.router)
+    response = TestClient(app, client=("172.17.0.1", 50000)).put(
+        "/api/settings/storage/models-dir",
+        json={"path": str(target)},
+    )
+    assert response.status_code == 403
+    assert not target.exists()
+
+
 def test_clear_reverts_to_default(env):
     user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/old")
     res = s.set_models_dir(s._ModelsDirBody(path=""))

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -76,6 +76,24 @@ def test_server_mode_remote_without_api_key_cannot_create_models_dir(env, monkey
     assert not target.exists()
 
 
+def test_server_mode_remote_api_key_cannot_create_models_dir(env, monkeypatch, tmp_path):
+    """An admin key does not grant the desktop file-picker capability."""
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.setenv("OMNIVOICE_API_KEY", "s3cret")
+    target = tmp_path / "must-not-exist"
+    app = fastapi.FastAPI()
+    app.include_router(s.router)
+    response = TestClient(app, client=("172.17.0.1", 50000)).put(
+        "/api/settings/storage/models-dir",
+        headers={"authorization": "Bearer s3cret"},
+        json={"path": str(target)},
+    )
+    assert response.status_code == 403
+    assert not target.exists()
+
+
 def test_clear_reverts_to_default(env):
     user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/old")
     res = s.set_models_dir(s._ModelsDirBody(path=""))

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -27,15 +27,17 @@ def env(tmp_path, monkeypatch):
     monkeypatch.setenv("OMNIVOICE_ENV_FILE", envfile)
     auth_dir = tmp_path / "authorizations"
     auth_dir.mkdir()
-    monkeypatch.setenv("OMNIVOICE_PATH_AUTH_DIR", str(auth_dir))
+    from core import path_authorization
+    monkeypatch.setattr(path_authorization, "_AUTH_DIR", str(auth_dir))
     return envfile
 
 
 def _body(path, kind="models_dir"):
-    auth_dir = os.environ["OMNIVOICE_PATH_AUTH_DIR"]
+    from core import path_authorization
+    auth_dir = path_authorization._AUTH_DIR
     token = "a" * 64
     with open(os.path.join(auth_dir, f"{token}.json"), "w", encoding="utf-8") as f:
-        json.dump({"kind": kind, "path": path}, f)
+        json.dump({"token": token, "kind": kind, "path": path}, f)
     return s._ModelsDirBody(authorization=token)
 
 

--- a/tests/test_models_dir_setting.py
+++ b/tests/test_models_dir_setting.py
@@ -8,6 +8,7 @@ second store to diverge from.
 from __future__ import annotations
 
 import os
+import json
 
 import fastapi
 import pytest
@@ -24,12 +25,23 @@ def env(tmp_path, monkeypatch):
     # module object — a setattr monkeypatch wouldn't reach the endpoint's copy.
     envfile = str(tmp_path / "env")
     monkeypatch.setenv("OMNIVOICE_ENV_FILE", envfile)
+    auth_dir = tmp_path / "authorizations"
+    auth_dir.mkdir()
+    monkeypatch.setenv("OMNIVOICE_PATH_AUTH_DIR", str(auth_dir))
     return envfile
+
+
+def _body(path, kind="models_dir"):
+    auth_dir = os.environ["OMNIVOICE_PATH_AUTH_DIR"]
+    token = "a" * 64
+    with open(os.path.join(auth_dir, f"{token}.json"), "w", encoding="utf-8") as f:
+        json.dump({"kind": kind, "path": path}, f)
+    return s._ModelsDirBody(authorization=token)
 
 
 def test_set_persists_and_writes_durable_env(env, tmp_path):
     target = str(tmp_path / "models")
-    res = s.set_models_dir(s._ModelsDirBody(path=target))
+    res = s.set_models_dir(_body(target))
     abs_target = os.path.abspath(target)
     assert res["configured"] == abs_target
     assert res["restart_required"] is True
@@ -47,7 +59,7 @@ def test_rejects_unwritable_dir(env, monkeypatch, tmp_path):
 
     monkeypatch.setattr(os, "makedirs", boom)
     with pytest.raises(fastapi.HTTPException) as ei:
-        s.set_models_dir(s._ModelsDirBody(path=str(tmp_path / "ro")))
+        s.set_models_dir(_body(str(tmp_path / "ro")))
     assert ei.value.status_code == 400
 
 
@@ -55,7 +67,7 @@ def test_rejects_path_with_null_byte(env):
     # An embedded NUL would otherwise blow up os.makedirs with a ValueError
     # (→ 500). Validate up front and return a clean 400 instead.
     with pytest.raises(fastapi.HTTPException) as ei:
-        s.set_models_dir(s._ModelsDirBody(path="/tmp/mo\x00dels"))
+        s.set_models_dir(_body("/tmp/mo\x00dels"))
     assert ei.value.status_code == 400
 
 
@@ -76,8 +88,8 @@ def test_server_mode_remote_without_api_key_cannot_create_models_dir(env, monkey
     assert not target.exists()
 
 
-def test_server_mode_remote_api_key_cannot_create_models_dir(env, monkeypatch, tmp_path):
-    """An admin key does not grant the desktop file-picker capability."""
+def test_server_mode_admin_key_cannot_supply_raw_models_path(env, monkeypatch, tmp_path):
+    """An admin key is not a native path authorization."""
     from fastapi.testclient import TestClient
 
     monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
@@ -90,13 +102,34 @@ def test_server_mode_remote_api_key_cannot_create_models_dir(env, monkeypatch, t
         headers={"authorization": "Bearer s3cret"},
         json={"path": str(target)},
     )
-    assert response.status_code == 403
+    assert response.status_code == 422
     assert not target.exists()
+
+
+def test_loopback_raw_path_is_not_a_models_directory_authorization(env, tmp_path):
+    from fastapi.testclient import TestClient
+
+    target = tmp_path / "must-not-exist"
+    app = fastapi.FastAPI()
+    app.include_router(s.router)
+    response = TestClient(app, client=("127.0.0.1", 50000)).put(
+        "/api/settings/storage/models-dir", json={"path": str(target)}
+    )
+    assert response.status_code == 422
+    assert not target.exists()
+
+
+def test_models_directory_authorization_is_one_shot(env, tmp_path):
+    body = _body(str(tmp_path / "models"))
+    assert s.set_models_dir(body)["configured"]
+    with pytest.raises(fastapi.HTTPException) as exc:
+        s.set_models_dir(body)
+    assert exc.value.status_code == 403
 
 
 def test_clear_reverts_to_default(env):
     user_env.set_user_env("OMNIVOICE_CACHE_DIR", "/old")
-    res = s.set_models_dir(s._ModelsDirBody(path=""))
+    res = s.set_models_dir(_body(""))
     assert res["configured"] is None
     assert res["restart_required"] is True
     assert user_env.get_user_env("OMNIVOICE_CACHE_DIR") is None
@@ -119,7 +152,7 @@ def test_path_with_spaces_survives_the_full_persistence_chain(env, tmp_path, mon
     still shows the chosen folder. Pin the whole chain byte-for-byte:
     endpoint → env file → load_into_environ → os.environ → GET."""
     target = str(tmp_path / "Program Data" / "OmniVoice" / "Model Cache")
-    res = s.set_models_dir(s._ModelsDirBody(path=target))
+    res = s.set_models_dir(_body(target))
     abs_target = os.path.abspath(target)
     assert res["configured"] == abs_target
     assert user_env.get_user_env("OMNIVOICE_CACHE_DIR") == abs_target

--- a/tests/test_network_share.py
+++ b/tests/test_network_share.py
@@ -76,14 +76,21 @@ def test_network_state_endpoint_defaults_disabled():
 
 
 def test_pin_only_remote_discovery_never_returns_share_pin(monkeypatch):
+    import importlib
+
     from main import app
+
+    # Resolve the exact module instance held by the live router. The full suite
+    # deliberately replaces app modules in sys.modules, so the module-level
+    # ``ns`` test helper may no longer be the endpoint's dependency.
+    live_network_share = importlib.import_module("api.routers.system").network_share
 
     monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
     monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
     monkeypatch.setattr(
-        ns,
+        live_network_share,
         "_state",
-        ns.ShareState(True, 3901, "123456", ["192.168.1.10"]),
+        live_network_share.ShareState(True, 3901, "123456", ["192.168.1.10"]),
     )
     # Keep the consumption middleware inert: this endpoint is testing the
     # intentional admin read-only exception itself, before a PIN is supplied.

--- a/tests/test_network_share.py
+++ b/tests/test_network_share.py
@@ -75,6 +75,28 @@ def test_network_state_endpoint_defaults_disabled():
     assert r.json()["enabled"] is False
 
 
+def test_pin_only_remote_discovery_never_returns_share_pin(monkeypatch):
+    from main import app
+
+    monkeypatch.setenv("OMNIVOICE_SERVER_MODE", "1")
+    monkeypatch.delenv("OMNIVOICE_API_KEY", raising=False)
+    monkeypatch.setattr(
+        ns,
+        "_state",
+        ns.ShareState(True, 3901, "123456", ["192.168.1.10"]),
+    )
+    # Keep the consumption middleware inert: this endpoint is testing the
+    # intentional admin read-only exception itself, before a PIN is supplied.
+    monkeypatch.setattr(app.state, "network_share", None, raising=False)
+    response = TestClient(app, client=("172.17.0.1", 50000)).get(
+        "/system/network/state"
+    )
+    assert response.status_code == 200
+    assert response.json()["pin"] is None
+    assert response.json()["pin_required"] is True
+    assert "123456" not in response.text
+
+
 def test_network_control_rejects_non_loopback():
     from main import app
     c = TestClient(app, client=("10.0.0.5", 9999))


### PR DESCRIPTION
## Summary
- require the long API key for every non-loopback server-mode mutation on `/system/*` and `/api/settings/*`
- preserve credential-free loopback behavior and read-only bare-Docker discovery
- prevent executable-path and models-directory mutations before handlers run

Closes GHAS CodeQL alerts #506, #440, and #441 by removing the remotely reachable filesystem/executable mutation flow.

## Security impact
A bare `OMNIVOICE_SERVER_MODE=1` deployment previously treated the admin gate as open when no credential was configured. A remote client reaching the published port could set `FFMPEG_PATH`/`FFPROBE_PATH` to an existing executable or make/persist an arbitrary models directory. Mutations now require `OMNIVOICE_API_KEY`; the share PIN and trusted CIDRs remain consumption-only.

## Validation
- `HF_HUB_OFFLINE=1` with an empty `HF_HUB_CACHE`
- `62 passed` across `tests/test_loopback_server_mode.py`, `tests/test_models_dir_setting.py`, the new server-mode `/system/set-env` regression, and loopback compatibility
- remote no-key tests assert 403 and prove neither environment nor filesystem mutation occurred

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Remote `/system/*` and `/api/settings/*` mutations now require `OMNIVOICE_API_KEY`, while loopback access and read-only bare-Docker discovery remain available. Host-path mutations remain desktop-only to prevent remote changes to executable paths and the models directory. Review the authorization dependency coverage for endpoint omissions or unintended access changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->