### PR TITLE
fix(security): stabilize streamed failure responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Fixed
 
+- Streaming and provider failures now return stable recovery guidance without exposing exception details. (#1462)
 - Automatic model-mirror checks now reject untrusted URLs before opening a network connection. (#1447)
 - Sidecar engines no longer break when a library they load prints to the console. Those bytes landed in the middle of the engine's data stream, failing the generation and leaving the connection scrambled for every request after it. (#1428) — thanks @1335-Group!
 - A generation abandoned while stuck on an internal lock now says so, instead of blaming your hardware and suggesting shorter text. Nothing had been computed, so none of that advice applied. (#1416, #1419)

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -734,7 +734,7 @@ async def dub_transcribe_stream(
                             preflight_error = asr_model_missing_detail(e.payload)
                             preflight_payload = e.payload
                         except Exception as e:
-                            logger.exception("transcribe preflight: ASR load failed (job=%r)", job_id)
+                            logger.error("Transcription preflight ASR load failed")
                             from core.failure import build_failure
                             f = build_failure(e, stage="transcribe-preflight", include_diagnostic=False)
                             preflight_error = "ASR backend initialization failed: " + f["reason"] + (
@@ -765,9 +765,10 @@ async def dub_transcribe_stream(
 
         try:
             audio_np, sr = await loop.run_in_executor(_cpu_pool, _load)
-        except Exception as e:
+        except Exception:
             # Terminal error → always emit `done` (see preflight note, #578).
-            yield _sse_event("error", {"detail": f"audio load failed: {e}", "retryable": True})
+            from core.public_errors import stream_failure
+            yield _sse_event("error", stream_failure("transcription_failed"))
             yield _sse_event("done", {})
             return
 
@@ -867,9 +868,16 @@ async def dub_transcribe_stream(
                             continue
                         turns.append({"start": s0 + offset, "end": s1 + offset, "speaker": spk})
                     return {"chunks": shifted, "language": r.get("language"), "speaker_turns": turns}
-                except Exception as e:
-                    logger.exception("chunk transcribe failed (backend=%s)", _asr_backend.id)
-                    return {"chunks": [], "language": None, "error": str(e)}
+                except Exception:
+                    logger.error("Chunk transcription failed (backend=%s)", _asr_backend.id)
+                    from core.public_errors import stream_failure
+                    failure = stream_failure("transcription_failed")
+                    return {
+                        "chunks": [],
+                        "language": None,
+                        "error": failure["detail"],
+                        "error_code": failure["code"],
+                    }
 
             # Retry a failed/timed-out chunk once on a fresh pool before giving
             # up. Otherwise a transient wedge on the FIRST chunk (whisperx often
@@ -900,7 +908,7 @@ async def dub_transcribe_stream(
                     yield _sse_event("ping", {})
                 try:
                     part = task.result()
-                except ASRTimeoutError as e:
+                except ASRTimeoutError:
                     # The guard already reset the pool; keep the actionable
                     # message (it names the durable fixes, and — after repeated
                     # timeouts — the crash-isolated engine escape hatch).
@@ -910,7 +918,14 @@ async def dub_transcribe_stream(
                         i + 1, chunks_n, transcribe_timeout_s, _attempt,
                         _CHUNK_TRANSCRIBE_ATTEMPTS, job_id,
                     )
-                    part = {"chunks": [], "language": None, "error": str(e)}
+                    from core.public_errors import stream_failure
+                    failure = stream_failure("transcription_timeout")
+                    part = {
+                        "chunks": [],
+                        "language": None,
+                        "error": failure["detail"],
+                        "error_code": failure["code"],
+                    }
                 # Success → keep it. Failure/timeout → retry once on a fresh
                 # worker (the internal _transcribe_chunk except returns an
                 # error-part; the timeout path already reset the pool).
@@ -964,6 +979,7 @@ async def dub_transcribe_stream(
                 "segments": chunk_segs,
                 "progress": (i + 1) / chunks_n,
                 "error": part.get("error"),
+                "error_code": part.get("error_code"),
             })
 
         if job.get("aborted"):

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -1448,7 +1448,7 @@ async def dub_transcribe_stream(
             async for ev in _gen_body():
                 yield ev
         except Exception:  # noqa: BLE001 — last-resort stream finalizer
-            logger.exception("transcribe stream crashed (job=%r)", job_id)
+            logger.error("Transcription stream failed unexpectedly")
             from core.public_errors import stream_failure
             yield _sse_event("error", stream_failure("transcription_failed"))
             yield _sse_event("done", {})

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -1447,12 +1447,10 @@ async def dub_transcribe_stream(
         try:
             async for ev in _gen_body():
                 yield ev
-        except Exception as e:  # noqa: BLE001 — last-resort stream finalizer
+        except Exception:  # noqa: BLE001 — last-resort stream finalizer
             logger.exception("transcribe stream crashed (job=%r)", job_id)
-            from core.failure import build_failure
-            f = build_failure(e, stage="transcribe", include_diagnostic=False)
-            detail = f["reason"] + (f" — {f['hint']}" if f.get("hint") else "")
-            yield _sse_event("error", {"detail": detail, "retryable": True})
+            from core.public_errors import stream_failure
+            yield _sse_event("error", stream_failure("transcription_failed"))
             yield _sse_event("done", {})
         finally:
             # Last-resort VRAM release (see _loaded_asr above): covers crashes,

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -1548,7 +1548,7 @@ async def generate_speech(
                 from core.public_errors import stream_failure
                 yield _line({"type": "error", **stream_failure("invalid_request")})
             except Exception:
-                logger.exception("Streaming generation failed")
+                logger.error("Streaming generation failed unexpectedly")
                 from core.public_errors import stream_failure
                 yield _line({"type": "error", **stream_failure("generation_failed")})
             finally:

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -1538,17 +1538,19 @@ async def generate_speech(
                 # In-band error frame carries the machine-readable retryable
                 # marker (#1190) — an NDJSON consumer can back off instead of
                 # guessing from the prose.
-                logger.error("Streaming generate timed out: %s", e)
-                yield _line({
-                    "type": "error", "detail": str(e), "retryable": True,
-                    "retry_after": getattr(e, "retry_after", 30),
-                })
-            except ValueError as e:
-                logger.error("Streaming generate validation failed: %s", e)
-                yield _line({"type": "error", "detail": str(e)})
-            except Exception as e:
-                logger.error("Streaming generate failed: %s\n%s", e, traceback.format_exc())
-                yield _line({"type": "error", "detail": _safe_exc_text(e)})
+                logger.error("Streaming generation capacity unavailable")
+                from core.public_errors import stream_failure
+                failure = stream_failure("generation_busy")
+                failure["retry_after"] = getattr(e, "retry_after", 30)
+                yield _line({"type": "error", **failure})
+            except ValueError:
+                logger.error("Streaming generation request rejected")
+                from core.public_errors import stream_failure
+                yield _line({"type": "error", **stream_failure("invalid_request")})
+            except Exception:
+                logger.exception("Streaming generation failed")
+                from core.public_errors import stream_failure
+                yield _line({"type": "error", **stream_failure("generation_failed")})
             finally:
                 # Ownership of the temp reference clip moves to this generator
                 # in stream mode (the route returns before rendering starts).

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -445,42 +445,20 @@ def test_llm_provider(provider_id: str):
             "reply": reply[:80],
             "latency_ms": int((_time.monotonic() - t0) * 1000),
         }
-    except Exception as e:  # noqa: BLE001 — surface a clean, scrubbed error to the UI
+    except Exception as e:  # noqa: BLE001 — classify without exposing diagnostics
         kind = _classify_llm_error(e)
-        detail = _scrub_llm_detail(e, api_key)
-        # A 404 from a LOCAL server is almost never a wrong URL — the request
-        # reached it — it is a model name the server does not have loaded. The
-        # generic "check the model name and Base URL path" sends the user to
-        # audit a URL that works. Ask what IS loaded and say so (#1332).
+        from core.public_errors import provider_failure
+        failure = provider_failure(kind)
+        # A successful local catalog probe proves the cached model is stale.
+        # Invalidate it, but never include catalog or exception text in the
+        # response: both are controlled by the provider.
         if kind == "not_found" and p.local:
             available = _local_models(base_url, api_key)
-            asked = llm_providers.resolve_model(p)
-            if available:
-                detail = (
-                    f"{p.display_name} is running, but has no model named "
-                    f"{asked!r}. Loaded right now: {', '.join(available[:10])}"
-                    + (" …" if len(available) > 10 else "")
-                    + ". Pick one in the Model field above."
-                )
-                # The cached discovery, if any, produced a name this server
-                # rejects — most likely the user swapped the loaded model
-                # inside the local app. Drop it so the next attempt re-asks
-                # rather than repeating the same 404 until the TTL expires.
+            if available is not None:
                 llm_providers.forget_discovered_models(p.id)
-            elif available == []:
-                detail = (
-                    f"{p.display_name} is running, but reports no loaded models, "
-                    f"so {asked!r} cannot be served. Load a model in "
-                    f"{p.display_name} first, then test again."
-                )
-                llm_providers.forget_discovered_models(p.id)
-            # available is None: the model listing itself failed, so nothing
-            # here is established. Keep the generic 404 text rather than
-            # inventing a diagnosis the lookup did not support.
         return {
             "ok": False,
-            "kind": kind,
-            "detail": detail,
+            **failure,
             "latency_ms": int((_time.monotonic() - t0) * 1000),
         }
 
@@ -529,10 +507,10 @@ def list_llm_provider_models(provider_id: str):
         # can say "first 200 shown" rather than implying it's the full list.
         return {"ok": True, "models": ids[:200], "truncated": len(ids) > 200}
     except Exception as e:  # noqa: BLE001
+        from core.public_errors import provider_failure
         return {
             "ok": False,
-            "kind": _classify_llm_error(e),
-            "detail": _scrub_llm_detail(e, api_key),
+            **provider_failure(_classify_llm_error(e)),
             "models": [],
         }
 

--- a/backend/core/public_errors.py
+++ b/backend/core/public_errors.py
@@ -40,6 +40,14 @@ def stream_failure(code: str) -> dict[str, object]:
             "detail": "Transcription failed. Check the selected ASR engine and try again.",
             "retryable": True,
         },
+        "transcription_timeout": {
+            "code": "transcription_timeout",
+            "detail": (
+                "Transcription timed out while the backend is running. Increase "
+                "OMNIVOICE_TRANSCRIBE_CHUNK_TIMEOUT_S or select the "
+                "faster-whisper-isolated engine, then try again."
+            ),
+            "retryable": True,
+        },
     }
     return dict(failures.get(code, failures["generation_failed"]))
-

--- a/backend/core/public_errors.py
+++ b/backend/core/public_errors.py
@@ -1,0 +1,45 @@
+"""Data-independent error metadata safe for API and streaming responses."""
+from __future__ import annotations
+
+_PROVIDER_DETAILS = {
+    "auth": "Authentication failed. Check the provider API key.",
+    "not_found": "Provider or model not found. Check the model and Base URL.",
+    "rate_limit": "The provider rate limit was reached. Try again later.",
+    "network": "The provider could not be reached. Check the connection and Base URL.",
+    "config": "Configure the provider before using it.",
+    "error": "The provider request failed. Try again.",
+}
+
+
+def provider_failure(kind: str) -> dict[str, str]:
+    """Return a stable provider error class and remediation message."""
+    safe_kind = kind if kind in _PROVIDER_DETAILS else "error"
+    return {"kind": safe_kind, "detail": _PROVIDER_DETAILS[safe_kind]}
+
+
+def stream_failure(code: str) -> dict[str, object]:
+    """Return stable stream metadata selected only from an internal code."""
+    failures: dict[str, dict[str, object]] = {
+        "generation_busy": {
+            "code": "generation_busy",
+            "detail": "Generation capacity is busy. Try again shortly.",
+            "retryable": True,
+        },
+        "invalid_request": {
+            "code": "invalid_request",
+            "detail": "The generation request could not be processed.",
+            "retryable": False,
+        },
+        "generation_failed": {
+            "code": "generation_failed",
+            "detail": "Generation failed. Check the selected engine and try again.",
+            "retryable": True,
+        },
+        "transcription_failed": {
+            "code": "transcription_failed",
+            "detail": "Transcription failed. Check the selected ASR engine and try again.",
+            "retryable": True,
+        },
+    }
+    return dict(failures.get(code, failures["generation_failed"]))
+

--- a/backend/services/director.py
+++ b/backend/services/director.py
@@ -160,10 +160,10 @@ def parse(text: str) -> Direction:
 
     try:
         body = llm.chat(system=_LLM_PROMPT, user=text)
-    except Exception as e:
-        logger.warning("director LLM parse failed: %s", e)
+    except Exception:
+        logger.warning("director LLM parse failed; using heuristic parser")
         d = _heuristic_parse(text)
-        d.error = f"llm-parse-failed: {e}"
+        d.error = "llm-parse-failed"
         return d
 
     raw = body.strip()

--- a/backend/services/speech_rate.py
+++ b/backend/services/speech_rate.py
@@ -184,9 +184,12 @@ def adjust_for_slot(
                 system=system, user="\n".join(user_lines),
                 temperature=0.2,  # pinned like the Fast path — default 1.0 drifts/invents
             )
-        except Exception as e:
-            logger.warning("speech-rate attempt %d failed: %s", attempt, e)
-            return {"text": best[0], "rate_ratio": best[1], "attempts": attempt - 1, "error": str(e)}
+        except Exception:
+            logger.warning("speech-rate provider attempt %d failed", attempt)
+            return {
+                "text": best[0], "rate_ratio": best[1],
+                "attempts": attempt - 1, "error": "fit-provider-failed",
+            }
 
         if next_text and next_text.strip():
             candidate = next_text.strip()

--- a/tests/test_asr_model_missing.py
+++ b/tests/test_asr_model_missing.py
@@ -366,7 +366,8 @@ class TestEndpoints:
              _offline_asr_missing(cached=True):
             r = client.get("/dub/transcribe-stream/j4")
         assert r.status_code == 200
-        assert "audio load failed" in r.text
+        assert "Transcription failed. Check the selected ASR engine and try again." in r.text
+        assert str(wav) not in r.text
         backend.unload.assert_called_once()
 
 

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -160,7 +160,9 @@ def test_transcribe_stream_surfaces_model_load_failure(tmp_path, monkeypatch):
     assert "CUDA driver init failed: simulated" in body, body
 
 
-def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeypatch):
+def test_transcribe_stream_never_closes_without_terminal_event(
+    tmp_path, monkeypatch, caplog
+):
     """Regression #516: an unanticipated exception INSIDE the stream body (one
     that escapes the per-chunk handler, e.g. segmentation blowing up) must still
     end the stream with a terminal `error` then `done` — never a silent
@@ -203,7 +205,7 @@ def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeyp
     # Make the post-chunk segmentation (outside the per-chunk try/except) blow
     # up — the exact class of "unanticipated escape" the guard must catch.
     def _boom_segment(*a, **k):
-        raise RuntimeError("segmentation exploded: simulated")
+        raise RuntimeError("API_KEY=dub-secret /home/alice/private-video.mp4")
     monkeypatch.setattr(dc, "segment_transcript", _boom_segment)
     # Don't touch the GPU/TTS during the test.
     monkeypatch.setattr(dc, "offload_tts_for_asr", lambda *a, **k: None)
@@ -224,8 +226,10 @@ def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeyp
     assert "event: error" in body, body
     assert "transcription_failed" in body, body
     assert "Transcription failed. Check the selected ASR engine and try again." in body, body
-    assert "segmentation exploded: simulated" not in body, body
+    assert "dub-secret" not in body, body
     assert "Traceback" not in body, body
+    assert "dub-secret" not in caplog.text
+    assert "/home/alice/private-video.mp4" not in caplog.text
     err_idx = body.rfind("event: error")
     done_idx = body.rfind("event: done")
     assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -235,6 +235,68 @@ def test_transcribe_stream_never_closes_without_terminal_event(
     assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"
 
 
+def test_transcribe_chunk_failure_uses_stable_public_metadata(
+    tmp_path, monkeypatch, caplog
+):
+    """Inner ASR failures must not serialize provider secrets or local paths."""
+    import asyncio
+    from api.routers import dub_core as dc
+
+    job_id = "t_chunk_secret"
+    audio = tmp_path / "a.wav"
+    _make_wav(audio, seconds=1.0)
+    dc._dub_jobs[job_id] = {
+        "audio_path": str(audio), "vocals_path": None, "scene_cuts": [],
+    }
+
+    fake_model = MagicMock()
+    fake_model._asr_pipe = MagicMock()
+
+    async def _ok_model():
+        return fake_model
+
+    class _FailingASR:
+        id = "fake"
+
+        def ensure_loaded(self):
+            pass
+
+        def transcribe(self, path, *, word_timestamps=True):
+            raise RuntimeError("TOKEN=chunk-secret /home/alice/private-audio.wav")
+
+        def unload(self):
+            pass
+
+    monkeypatch.setattr(dc, "get_model", _ok_model)
+    monkeypatch.setattr(dc, "_CHUNK_TRANSCRIBE_ATTEMPTS", 1)
+    monkeypatch.setattr(dc, "offload_tts_for_asr", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "services.asr_backend.get_active_asr_backend",
+        lambda *a, **k: _FailingASR(),
+    )
+
+    async def _collect():
+        resp = await dc.dub_transcribe_stream(job_id)
+        parts = []
+        async for chunk in resp.body_iterator:
+            parts.append(
+                chunk.decode() if isinstance(chunk, (bytes, bytearray)) else str(chunk)
+            )
+        return "".join(parts)
+
+    try:
+        body = asyncio.run(_collect())
+    finally:
+        dc._dub_jobs.pop(job_id, None)
+
+    assert "transcription_failed" in body, body
+    assert "Transcription failed. Check the selected ASR engine and try again." in body
+    assert "chunk-secret" not in body
+    assert "/home/alice/private-audio.wav" not in body
+    assert "chunk-secret" not in caplog.text
+    assert "/home/alice/private-audio.wav" not in caplog.text
+
+
 def test_transcribe_stream_surfaces_asr_load_failure_at_preflight(tmp_path, monkeypatch):
     """Regression #578: the reported failure mode is the *ASR model* failing to
     load (WhisperX: faster-whisper weights / CTranslate2-cuDNN mismatch / the

--- a/tests/test_dub_transcribe.py
+++ b/tests/test_dub_transcribe.py
@@ -222,7 +222,10 @@ def test_transcribe_stream_never_closes_without_terminal_event(tmp_path, monkeyp
 
     # The stream must end with a terminal error followed by done.
     assert "event: error" in body, body
-    assert "segmentation exploded: simulated" in body, body
+    assert "transcription_failed" in body, body
+    assert "Transcription failed. Check the selected ASR engine and try again." in body, body
+    assert "segmentation exploded: simulated" not in body, body
+    assert "Traceback" not in body, body
     err_idx = body.rfind("event: error")
     done_idx = body.rfind("event: done")
     assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"
@@ -334,7 +337,10 @@ def test_transcribe_stream_preflight_crash_is_a_structured_error(monkeypatch):
     body = asyncio.run(_collect())
 
     assert "event: error" in body, body
-    assert "job store exploded: simulated" in body, body
+    assert "transcription_failed" in body, body
+    assert "Transcription failed. Check the selected ASR engine and try again." in body, body
+    assert "job store exploded: simulated" not in body, body
+    assert "Traceback" not in body, body
     err_idx = body.rfind("event: error")
     done_idx = body.rfind("event: done")
     assert done_idx > err_idx >= 0, f"error must precede the terminal done: {body}"

--- a/tests/test_generate_streaming.py
+++ b/tests/test_generate_streaming.py
@@ -294,7 +294,11 @@ def test_stream_midstream_error_yields_error_event(client, monkeypatch,
     assert "chunk" in types            # chunk 0 was delivered before the crash
     assert types[-1] == "error"
     assert "done" not in types
-    assert events[-1][0]["detail"]     # actionable message for the fallback log
+    error = events[-1][0]
+    assert error["code"] == "generation_failed"
+    assert error["detail"] == "Generation failed. Check the selected engine and try again."
+    assert "engine exploded" not in repr(error)
+    assert "Traceback" not in repr(error)
 
     after_ids = {h["id"] for h in client.get("/history").json()}
     assert after_ids == before_ids     # nothing was recorded for the failure

--- a/tests/test_generate_streaming.py
+++ b/tests/test_generate_streaming.py
@@ -111,7 +111,9 @@ def _make_deterministic_engine(engine_id="stream-fake", *, delay_s=0.0,
         def generate(self, text, **kw) -> torch.Tensor:
             type(self).calls.append((text, time.monotonic()))
             if fail_on_call is not None and len(type(self).calls) == fail_on_call:
-                raise RuntimeError("engine exploded mid-stream (test)")
+                raise RuntimeError(
+                    "TOKEN=stream-secret /home/alice/private-reference.wav"
+                )
             if delay_s:
                 time.sleep(delay_s)
             # Deterministic, text-dependent waveform (crc-seeded sine-ish ramp).
@@ -277,8 +279,9 @@ def test_stream_final_file_identical_to_classic_output(client, monkeypatch,
     assert done["duration"] > 0
 
 
-def test_stream_midstream_error_yields_error_event(client, monkeypatch,
-                                                   no_omnivoice_model):
+def test_stream_midstream_error_yields_error_event(
+    client, monkeypatch, no_omnivoice_model, caplog
+):
     """Chunk 2 blowing up must surface as an in-band error event AFTER the
     already-delivered chunk — no done, no history row, no saved file."""
     fake = _make_deterministic_engine(fail_on_call=2)
@@ -297,8 +300,10 @@ def test_stream_midstream_error_yields_error_event(client, monkeypatch,
     error = events[-1][0]
     assert error["code"] == "generation_failed"
     assert error["detail"] == "Generation failed. Check the selected engine and try again."
-    assert "engine exploded" not in repr(error)
+    assert "stream-secret" not in repr(error)
     assert "Traceback" not in repr(error)
+    assert "stream-secret" not in caplog.text
+    assert "/home/alice/private-reference.wav" not in caplog.text
 
     after_ids = {h["id"] for h in client.get("/history").json()}
     assert after_ids == before_ids     # nothing was recorded for the failure

--- a/tests/test_llm_providers_router.py
+++ b/tests/test_llm_providers_router.py
@@ -179,7 +179,9 @@ def test_probe_failure_detail_is_scrubbed(settings_mod, monkeypatch):
         "boom key=gsk-test-123 at /Users/someone/secret"))
     body = settings_mod.test_llm_provider("groq")
     assert body["ok"] is False
-    assert "gsk-test-123" not in body["detail"]
+    assert body["detail"] == "The provider request failed. Try again."
+    assert "gsk-test-123" not in repr(body)
+    assert "/Users/someone" not in repr(body)
 
 
 # ── /models discovery ───────────────────────────────────────────────────────
@@ -204,6 +206,17 @@ def test_models_failure_is_classified(settings_mod, monkeypatch):
     _fake_openai(monkeypatch, raise_exc=exc)
     body = settings_mod.list_llm_provider_models("groq")
     assert body["ok"] is False and body["kind"] == "auth" and body["models"] == []
+    assert body["detail"] == "Authentication failed. Check the provider API key."
+
+
+def test_models_failure_omits_trace_path_and_secret(settings_mod, monkeypatch):
+    _configure_groq(settings_mod)
+    private = "Traceback: key=gsk-test-123 at /home/alice/provider.py"
+    _fake_openai(monkeypatch, raise_exc=RuntimeError(private))
+    body = settings_mod.list_llm_provider_models("groq")
+    assert body["kind"] == "error"
+    assert body["detail"] == "The provider request failed. Try again."
+    assert private not in repr(body)
 
 
 def test_models_not_truncated_under_cap(settings_mod, monkeypatch):

--- a/tests/test_llm_skills.py
+++ b/tests/test_llm_skills.py
@@ -268,6 +268,24 @@ def test_disabled_direction_parse_uses_heuristic(skills, store, monkeypatch):
     assert d.tokens.get("energy") == ["urgent"]  # heuristic still delivers
 
 
+def test_direction_failure_returns_stable_error(skills, store, monkeypatch, caplog):
+    _activate_groq(store)
+    from services import director
+
+    private = "Traceback: token=private-value at /home/alice/director.py"
+
+    class _Fake:
+        id = "openai-compat"
+        def chat(self, **kw):
+            raise RuntimeError(private)
+
+    monkeypatch.setattr(director, "get_active_llm_backend", lambda: _Fake())
+    d = director.parse("urgent and surprised")
+    assert d.error == "llm-parse-failed"
+    assert private not in repr(d)
+    assert private not in caplog.text
+
+
 def test_disabled_slot_fitting_returns_no_llm_marker(skills, store, monkeypatch):
     _activate_groq(store)
     from services import speech_rate
@@ -285,6 +303,24 @@ def test_disabled_slot_fitting_returns_no_llm_marker(skills, store, monkeypatch)
     skills.configure_skill("slot_fitting", enabled=False)
     res = speech_rate.adjust_for_slot(long_text, slot_seconds=1.0, target_lang="en")
     assert res["error"] == "no-llm" and res["text"] == long_text
+
+
+def test_slot_fit_failure_returns_stable_error(skills, store, monkeypatch, caplog):
+    _activate_groq(store)
+    from services import speech_rate
+
+    private = "Traceback: token=private-value at /home/alice/rate.py"
+
+    class _Fake:
+        id = "openai-compat"
+        def chat(self, **kw):
+            raise RuntimeError(private)
+
+    monkeypatch.setattr(speech_rate, "get_active_llm_backend", lambda: _Fake())
+    res = speech_rate.adjust_for_slot("x" * 30, slot_seconds=1.0, target_lang="en")
+    assert res["error"] == "fit-provider-failed"
+    assert private not in repr(res)
+    assert private not in caplog.text
 
 
 def test_disabled_glossary_extract_503s(skills, store):


### PR DESCRIPTION
## Summary
- map streaming generation and transcription failures to stable error codes and recovery guidance
- return classified provider failures without exception-derived details
- keep director and speech-rate degradation useful without exposing raw provider errors

## Tests
- `uv run pytest -q tests/test_llm_providers_router.py tests/test_llm_skills.py tests/test_generate_streaming.py tests/test_dub_transcribe.py tests/test_phase4_services.py tests/test_router_smoke.py` (106 passed, 5 xfailed, 1 xpassed)

@coderabbitai review
@greptileai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The PR replaces raw provider, generation, and transcription exception details with stable error codes and recovery guidance. This prevents sensitive diagnostics from reaching clients while preserving director and speech-rate fallback behavior. Review unknown failure classification and fallback coverage; tests report 106 passed, 5 xfailed, and 1 xpassed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->