### PR TITLE
feat(indextts): add native IndexTTS 2.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The bundled TTS model package (`pyproject.toml`) is versioned independently.
 
 ### Added
 
+- IndexTTS 2.5 is available as a pinned one-click sidecar with five-language dubbing, expressive cloning, and backward-compatible IndexTTS-2 support. (#1482) — thanks @marwanlhabti5-coder!
 - Voice recording now offers microphone and channel selection with a live input-level meter on every desktop platform. (#1481)
 - Settings → Appearance → **Navigation style** switches the workspace switcher between the icon rail down the window edge and browser-style tabs across the title bar. Both offer the same workspaces; the choice sticks across launches, and the rail stays the default. Tab labels fold down to icons when the title bar runs out of room — the workspace you're in keeps its name. (#1412)
 - Portable mode lets you choose the folder — press **Change…** on the first-run setup screen and put the whole install on an external drive. It also stops being greyed out after a default Program Files install. (#766)

--- a/README.md
+++ b/README.md
@@ -248,12 +248,17 @@ Professional-grade voice AI, minus the subscription and the cloud.
 | **KittenTTS** | English | — | — | ✅ CPU | ✅ CPU | ✅ CPU | MIT |
 | **MLX-Audio** (Kokoro, Qwen3-TTS, CSM, Dia, …) | Multi | Varies | Varies | ❌ | ✅ Native | ❌ | Varies |
 | **Sherpa-ONNX** | 20+ | — | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
-| **IndexTTS 2.5** ⚡ | ZH · EN · JA · ES · AR | ✅ | — | ✅ CUDA | — | ✅ CUDA | Bilibili model license |
+| **IndexTTS 2.5** ⚡ | ZH · EN · JA · ES · AR | ✅ | — | ✅ CUDA | — | ✅ CUDA | Bilibili model license¹ |
 | **OmniVoice GGUF** ⚡ | 600+ | ✅ | ✅ | ✅ CPU | ✅ CPU | ✅ CPU | Built-in |
 | **Supertonic 3** ⚡ | 31 | — | — | ✅ CPU | ✅ CPU | ✅ CPU | OpenRAIL-M |
 | **MOSS-TTS-v1.5** ⚡ (8B) | 31 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
 | **dots.tts** ⚡ (2B) | 24 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ❌ | Apache-2.0 |
 | **Confucius4-TTS** ⚡ | 14 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
+
+¹ IndexTTS 2.5 requires a separate written Bilibili license above 100 million
+monthly active users or RMB 1 billion in annual revenue. Review its
+[model license](https://huggingface.co/IndexTeam/IndexTTS-2.5/blob/main/LICENSE)
+before enabling the optional sidecar.
 
 GPT-SoVITS connects to `http://127.0.0.1:9880` by default. To use a server on
 another machine, set `OMNIVOICE_GPTSOVITS_URL` to its credential-free

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Professional-grade voice AI, minus the subscription and the cloud.
 
 ### 🗣️ TTS Engines
 
-**14 engines, one picker.** VoiceStudio (default, 600+ languages) is always available; seven more are opt-in and auto-detected (CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX), plus six lazy-installed heavyweights (IndexTTS 2, OmniVoice GGUF, Supertonic 3, MOSS-TTS-v1.5, dots.tts, Confucius4-TTS). Switch in **Settings → TTS Engine**; the choice applies everywhere synthesis happens.
+**14 engines, one picker.** VoiceStudio (default, 600+ languages) is always available; seven more are opt-in and auto-detected (CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX), plus six lazy-installed heavyweights (IndexTTS 2.5, OmniVoice GGUF, Supertonic 3, MOSS-TTS-v1.5, dots.tts, Confucius4-TTS). Switch in **Settings → TTS Engine**; the choice applies everywhere synthesis happens.
 
 <details>
 <summary><b>📊 The full matrix</b> — 14 engines × platform × clone/instruct × license</summary>
@@ -248,7 +248,7 @@ Professional-grade voice AI, minus the subscription and the cloud.
 | **KittenTTS** | English | — | — | ✅ CPU | ✅ CPU | ✅ CPU | MIT |
 | **MLX-Audio** (Kokoro, Qwen3-TTS, CSM, Dia, …) | Multi | Varies | Varies | ❌ | ✅ Native | ❌ | Varies |
 | **Sherpa-ONNX** | 20+ | — | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
-| **IndexTTS 2** ⚡ | Multi | ✅ | — | ✅ CUDA | — | ✅ CUDA | Apache-2.0 |
+| **IndexTTS 2.5** ⚡ | ZH · EN · JA · ES · AR | ✅ | — | ✅ CUDA | — | ✅ CUDA | Bilibili model license |
 | **OmniVoice GGUF** ⚡ | 600+ | ✅ | ✅ | ✅ CPU | ✅ CPU | ✅ CPU | Built-in |
 | **Supertonic 3** ⚡ | 31 | — | — | ✅ CPU | ✅ CPU | ✅ CPU | OpenRAIL-M |
 | **MOSS-TTS-v1.5** ⚡ (8B) | 31 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
@@ -434,7 +434,7 @@ Ships two [skills](https://skills.sh):
 | **Multi-Lang** | Multi-language batch picker, batch dubbing queue with sequential GPU execution |
 | **Diarization** | Pyannote ML diarization, auto speaker clone extraction, per-speaker voice assignment |
 | **ASR** | 11 engines (WhisperX, Faster-Whisper, isolated Faster-Whisper, MLX Whisper, PyTorch Whisper, Parakeet TDT, Parakeet TDT v3 MLX, Moonshine, FunASR/SenseVoice, sherpa-onnx live dictation, OpenAI-compatible remote), crash-isolated subprocess backend |
-| **TTS** | 14 engines (VoiceStudio, CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX, + lazy: IndexTTS 2, OmniVoice GGUF, Supertonic 3, MOSS-TTS-v1.5, dots.tts, Confucius4-TTS), engine routing with GPU preflight |
+| **TTS** | 14 engines (VoiceStudio, CosyVoice 3, GPT-SoVITS, VoxCPM2, MOSS-TTS-Nano, KittenTTS, MLX-Audio, Sherpa-ONNX, + lazy: IndexTTS 2.5, OmniVoice GGUF, Supertonic 3, MOSS-TTS-v1.5, dots.tts, Confucius4-TTS), engine routing with GPU preflight |
 | **Infra** | Docker deployment, CUDA/MPS/ROCm auto-detect, cuDNN 8 compat, VRAM-aware model offloading, engine routing (no silent CPU fallback), diagnostics suite & error journal, restricted-network mirror support |
 | **AI Provenance** | AudioSeal invisible watermarking (SynthID-like), video logo overlay, watermark detection API |
 | **UX** | Undo/redo, keyboard shortcuts, drag-and-drop, session persistence, glassmorphism design system, UI scale fix for Linux/WebKitGTK |

--- a/README_CN.md
+++ b/README_CN.md
@@ -259,7 +259,7 @@ ElevenLabs 收费 **$5–$330/月**，并在他们的服务器上处理你的音
 
 ### 🗣️ TTS 引擎
 
-**14 个引擎，一个选择器。** VoiceStudio（默认，支持 600+ 语言）始终可用；另有七个引擎可选装并自动检测（CosyVoice 3、GPT-SoVITS、VoxCPM2、MOSS-TTS-Nano、KittenTTS、MLX-Audio、Sherpa-ONNX），外加六个按需延迟安装的重量级引擎（IndexTTS 2、OmniVoice GGUF、Supertonic 3、MOSS-TTS-v1.5、dots.tts、Confucius4-TTS）。在 **设置 → TTS 引擎** 中切换；所选引擎将应用于所有语音合成场景。
+**14 个引擎，一个选择器。** VoiceStudio（默认，支持 600+ 语言）始终可用；另有七个引擎可选装并自动检测（CosyVoice 3、GPT-SoVITS、VoxCPM2、MOSS-TTS-Nano、KittenTTS、MLX-Audio、Sherpa-ONNX），外加六个按需延迟安装的重量级引擎（IndexTTS 2.5、OmniVoice GGUF、Supertonic 3、MOSS-TTS-v1.5、dots.tts、Confucius4-TTS）。在 **设置 → TTS 引擎** 中切换；所选引擎将应用于所有语音合成场景。
 
 <details>
 <summary><b>📊 完整矩阵</b>——14 个引擎 × 平台 × 克隆/指令 × 许可证</summary>
@@ -276,7 +276,7 @@ ElevenLabs 收费 **$5–$330/月**，并在他们的服务器上处理你的音
 | **KittenTTS** | 英语 | — | — | ✅ CPU | ✅ CPU | ✅ CPU | MIT |
 | **MLX-Audio**（Kokoro、Qwen3-TTS、CSM、Dia 等） | 多语言 | 因模型而异 | 因模型而异 | ❌ | ✅ 原生 | ❌ | 因模型而异 |
 | **Sherpa-ONNX** | 20+ | — | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
-| **IndexTTS 2** ⚡ | 多语言 | ✅ | — | ✅ CUDA | — | ✅ CUDA | Apache-2.0 |
+| **IndexTTS 2.5** ⚡ | 中文 · 英语 · 日语 · 西班牙语 · 阿拉伯语 | ✅ | — | ✅ CUDA | — | ✅ CUDA | Bilibili 模型许可 |
 | **OmniVoice GGUF** ⚡ | 600+ | ✅ | ✅ | ✅ CPU | ✅ CPU | ✅ CPU | 内置 |
 | **Supertonic 3** ⚡ | 31 | — | — | ✅ CPU | ✅ CPU | ✅ CPU | OpenRAIL-M |
 | **MOSS-TTS-v1.5** ⚡（8B） | 31 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
@@ -411,7 +411,7 @@ npx skills add debpalash/omnivoice-studio
 | **多语言** | 多语言批量选择器、顺序 GPU 执行的批量配音队列 |
 | **说话人分离** | Pyannote 机器学习分离、自动说话人克隆提取、逐说话人声音分配 |
 | **ASR** | 9 个引擎（WhisperX、Faster-Whisper、隔离版 Faster-Whisper、MLX Whisper、PyTorch Whisper、Parakeet TDT、Moonshine、FunASR/SenseVoice、sherpa-onnx 实时听写）、崩溃隔离的子进程后端 |
-| **TTS** | 14 个引擎（VoiceStudio、CosyVoice 3、GPT-SoVITS、VoxCPM2、MOSS-TTS-Nano、KittenTTS、MLX-Audio、Sherpa-ONNX，+ 延迟安装：IndexTTS 2、OmniVoice GGUF、Supertonic 3、MOSS-TTS-v1.5、dots.tts、Confucius4-TTS）、带 GPU 预检的引擎路由 |
+| **TTS** | 14 个引擎（VoiceStudio、CosyVoice 3、GPT-SoVITS、VoxCPM2、MOSS-TTS-Nano、KittenTTS、MLX-Audio、Sherpa-ONNX，+ 延迟安装：IndexTTS 2.5、OmniVoice GGUF、Supertonic 3、MOSS-TTS-v1.5、dots.tts、Confucius4-TTS）、带 GPU 预检的引擎路由 |
 | **基础设施** | Docker 部署、CUDA/MPS/ROCm 自动检测、cuDNN 8 兼容、显存感知模型卸载、引擎路由（绝不静默回退 CPU）、诊断套件与错误日志、受限网络镜像支持 |
 | **AI 溯源** | AudioSeal 不可见水印（类似 SynthID）、视频徽标叠加、水印检测 API |
 | **用户体验** | 撤销/重做、键盘快捷键、拖放、会话持久化、毛玻璃设计系统、Linux/WebKitGTK 的 UI 缩放修复 |

--- a/README_CN.md
+++ b/README_CN.md
@@ -276,12 +276,16 @@ ElevenLabs 收费 **$5–$330/月**，并在他们的服务器上处理你的音
 | **KittenTTS** | 英语 | — | — | ✅ CPU | ✅ CPU | ✅ CPU | MIT |
 | **MLX-Audio**（Kokoro、Qwen3-TTS、CSM、Dia 等） | 多语言 | 因模型而异 | 因模型而异 | ❌ | ✅ 原生 | ❌ | 因模型而异 |
 | **Sherpa-ONNX** | 20+ | — | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
-| **IndexTTS 2.5** ⚡ | 中文 · 英语 · 日语 · 西班牙语 · 阿拉伯语 | ✅ | — | ✅ CUDA | — | ✅ CUDA | Bilibili 模型许可 |
+| **IndexTTS 2.5** ⚡ | 中文 · 英语 · 日语 · 西班牙语 · 阿拉伯语 | ✅ | — | ✅ CUDA | — | ✅ CUDA | Bilibili 模型许可¹ |
 | **OmniVoice GGUF** ⚡ | 600+ | ✅ | ✅ | ✅ CPU | ✅ CPU | ✅ CPU | 内置 |
 | **Supertonic 3** ⚡ | 31 | — | — | ✅ CPU | ✅ CPU | ✅ CPU | OpenRAIL-M |
 | **MOSS-TTS-v1.5** ⚡（8B） | 31 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
 | **dots.tts** ⚡（2B） | 24 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ❌ | Apache-2.0 |
 | **Confucius4-TTS** ⚡ | 14 | ✅ | — | ✅ CUDA/CPU | ✅ CPU | ✅ CUDA/CPU | Apache-2.0 |
+
+¹ 若月活跃用户超过 1 亿，或年收入超过人民币 10 亿元，使用 IndexTTS 2.5
+前必须另行取得 Bilibili 的书面许可。启用可选边车前，请审阅其
+[模型许可](https://huggingface.co/IndexTeam/IndexTTS-2.5/blob/main/LICENSE)。
 
 > **CUDA** = GPU 加速 · **MPS** = Apple Silicon Metal · **CPU** = 随处可运行，大模型较慢 · KittenTTS 和 MOSS-TTS-Nano 可在 CPU 上实时运行 · MLX-Audio 仅限 Apple Silicon · ⚡ = 延迟注册（首次使用时安装）
 >

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -1,7 +1,7 @@
-"""IndexTTS-2 sidecar package (Phase 2 Plan 02-03).
+"""IndexTTS 2.5/2 sidecar package (Phase 2 Plan 02-03).
 
 IndexTTS-2 runs in its own subprocess + dedicated venv with
-``transformers<5``, isolated from the OmniVoice parent process which
+``transformers<5``, isolated from the VoiceStudio parent process which
 pins ``transformers>=5.3``. Closes issue #42 — the canonical
 ``OffloadedCache`` ImportError driven by the transformers v4 ↔ v5
 incompatibility — by making the two libraries live in separate OS
@@ -28,6 +28,7 @@ packages. The parent only ever spawns it as a subprocess.
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from services.subprocess_backend import SubprocessBackend
@@ -38,11 +39,46 @@ if TYPE_CHECKING:
 logger = logging.getLogger("omnivoice.indextts")
 
 
+_LANGUAGE_ALIASES = {
+    "zh": "zh",
+    "chinese": "zh",
+    "mandarin": "zh",
+    "en": "en",
+    "english": "en",
+    "ja": "ja",
+    "jp": "ja",
+    "japanese": "ja",
+    "es": "es",
+    "spanish": "es",
+    "español": "es",
+    "ar": "ar",
+    "arabic": "ar",
+}
+
+
+def _normalize_indextts25_language(value, text: str) -> str:
+    """Map VoiceStudio locale labels to IndexTTS 2.5's required token."""
+    raw = str(value or "").strip().lower().replace("_", "-")
+    base = raw.split("-", 1)[0]
+    resolved = _LANGUAGE_ALIASES.get(raw) or _LANGUAGE_ALIASES.get(base)
+    if resolved:
+        return resolved
+    # Auto/empty requests still need an explicit 2.5 language. Script
+    # detection is deterministic and local; ambiguous Latin text defaults EN.
+    if re.search(r"[\u0600-\u06ff\u0750-\u077f]", text):
+        return "ar"
+    if re.search(r"[\u3040-\u30ff]", text):
+        return "ja"
+    if re.search(r"[\u3400-\u9fff]", text):
+        return "zh"
+    return "en"
+
+
 class IndexTTS2Backend(SubprocessBackend):
-    """IndexTTS2 (Bilibili) — runs in its own subprocess + dedicated venv.
+    """IndexTTS 2.5 (Bilibili) — isolated subprocess with IndexTTS-2 fallback.
 
     Plan 02-03 migrated IndexTTS off the in-process import path because
-    IndexTTS pins ``transformers<5`` while OmniVoice pins
+    IndexTTS pins ``transformers<5`` while VoiceStudio pins
     ``transformers>=5.3``. The two cannot share a Python interpreter
     without one of them blowing up at import time (issue #42 — the
     canonical ``OffloadedCache`` ImportError). Running IndexTTS in a
@@ -61,11 +97,11 @@ class IndexTTS2Backend(SubprocessBackend):
 
     Installation (transparent to existing v0.2.7 users — ENGINE-07)::
 
-        git clone https://github.com/index-tts/index-tts.git
+        git clone --branch indextts-2.5 https://github.com/index-tts/index-tts.git
         cd index-tts && uv pip install -e .   # NOT uv sync --all-extras
-        hf download IndexTeam/IndexTTS-2 --local-dir=checkpoints
+        hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints
 
-    Set ``OMNIVOICE_INDEXTTS_DIR`` to the repo root. OmniVoice will
+    Set ``OMNIVOICE_INDEXTTS_DIR`` to the repo root. VoiceStudio will
     create ``backend/engines/indextts/.venv`` lazily on first launch if
     no venv exists yet — the user's existing
     ``${OMNIVOICE_INDEXTTS_DIR}/.venv`` is preferred if present, so no
@@ -76,7 +112,7 @@ class IndexTTS2Backend(SubprocessBackend):
     """
 
     id = "indextts2"
-    display_name = "IndexTTS2 (emotion control, duration control, zero-shot)"
+    display_name = "IndexTTS 2.5 (multilingual emotion-controlled cloning)"
     supports_voice_design = False  # requires ref audio for timbre
     supports_emotion = True  # graded emo_vector / emo_text / emo_alpha (#1208)
     _DEFAULT_SAMPLE_RATE = 24000
@@ -100,15 +136,15 @@ class IndexTTS2Backend(SubprocessBackend):
         )
         if not is_indextts_installed():
             return False, (
-                "IndexTTS-2 venv not found. Set OMNIVOICE_INDEXTTS_DIR to "
+                "IndexTTS 2.5 venv not found. Set OMNIVOICE_INDEXTTS_DIR to "
                 "your IndexTTS clone (the directory containing checkpoints/) "
-                "and restart OmniVoice. See docs/engines/indextts.md for the "
+                "and restart VoiceStudio. See docs/engines/indextts.md for the "
                 "full install walk-through."
             )
         if not INDEXTTS_SIDECAR_SCRIPT.exists():
             return False, (
                 "IndexTTS sidecar script missing at "
-                f"{INDEXTTS_SIDECAR_SCRIPT} — reinstall OmniVoice."
+                f"{INDEXTTS_SIDECAR_SCRIPT} — reinstall VoiceStudio."
             )
         return True, "ok"
 
@@ -131,8 +167,7 @@ class IndexTTS2Backend(SubprocessBackend):
 
     @property
     def supported_languages(self) -> list[str]:
-        # Primarily Chinese + English with multilingual prompt handling.
-        return ["zh", "en"]
+        return ["zh", "en", "ja", "es", "ar"]
 
     # ── parent-side emotion / duration arbitration ─────────────────────
     #
@@ -171,7 +206,8 @@ class IndexTTS2Backend(SubprocessBackend):
         if description and not emo_text and not emo_vector and not emo_audio:
             emo_text = description
 
-        forwarded: dict = {"ref_audio": ref_audio}
+        language = _normalize_indextts25_language(kw.get("language"), text)
+        forwarded: dict = {"ref_audio": ref_audio, "lang": language}
 
         # Duration control — codec frame rate ≈ 21 Hz.
         duration = kw.get("duration")
@@ -179,6 +215,9 @@ class IndexTTS2Backend(SubprocessBackend):
             target_tokens = int(float(duration) * 21)
             if target_tokens > 0:
                 forwarded["target_tokens"] = target_tokens
+        duration_factor = kw.get("duration_factor")
+        if duration_factor is not None:
+            forwarded["duration_factor"] = max(0.5, min(float(duration_factor), 2.0))
 
         if (
             emo_vector

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -108,8 +108,8 @@ class IndexTTS2Backend(SubprocessBackend):
     ``${OMNIVOICE_INDEXTTS_DIR}/.venv`` is preferred if present, so no
     re-install is needed.
 
-    License: Custom (Bilibili) — free for research/non-commercial.
-    Commercial use requires contacting indexspeech@bilibili.com.
+    License: bilibili Model Use License. A separate license is required
+    above the upstream 100M-MAU or RMB 1B annual-revenue thresholds.
     """
 
     id = "indextts2"

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -28,6 +28,7 @@ packages. The parent only ever spawns it as a subprocess.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -167,6 +168,12 @@ class IndexTTS2Backend(SubprocessBackend):
 
     @property
     def supported_languages(self) -> list[str]:
+        configured = os.environ.get("OMNIVOICE_INDEXTTS_DIR")
+        if configured and not os.path.isfile(
+            os.path.join(configured, "indextts", "infer_v2_5.py")
+        ):
+            # Preserve truthful metadata for user-managed IndexTTS-2 checkouts.
+            return ["zh", "en"]
         return ["zh", "en", "ja", "es", "ar"]
 
     # ── parent-side emotion / duration arbitration ─────────────────────

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -225,6 +225,19 @@ class IndexTTS2Backend(SubprocessBackend):
         duration_factor = kw.get("duration_factor")
         if duration_factor is not None:
             forwarded["duration_factor"] = max(0.5, min(float(duration_factor), 2.0))
+        elif duration is not None:
+            # IndexTTS 2.5 replaced absolute semantic-token control with a
+            # relative duration factor. Use the same language-aware natural
+            # reading estimate as the dubbing fit planner so the public
+            # ``duration`` control remains effective on 2.5; the sidecar
+            # drops this factor when it detects a legacy IndexTTS-2 checkout.
+            from services.speech_rate import expected_duration
+
+            natural_s = expected_duration(text, language)
+            if natural_s > 0:
+                forwarded["duration_factor"] = max(
+                    0.5, min(float(duration) / natural_s, 2.0)
+                )
 
         if (
             emo_vector

--- a/backend/engines/indextts/__init__.py
+++ b/backend/engines/indextts/__init__.py
@@ -75,6 +75,16 @@ def _normalize_indextts25_language(value, text: str) -> str:
     return "en"
 
 
+def _duration_factor(text: str, language: str, duration: float) -> float:
+    """Map VoiceStudio's absolute duration to IndexTTS 2.5's relative scale."""
+    from services.speech_rate import expected_duration
+
+    natural_s = expected_duration(text, language)
+    if natural_s <= 0:
+        return 1.0
+    return max(0.5, min(float(duration) / natural_s, 2.0))
+
+
 class IndexTTS2Backend(SubprocessBackend):
     """IndexTTS 2.5 (Bilibili) — isolated subprocess with IndexTTS-2 fallback.
 
@@ -231,13 +241,9 @@ class IndexTTS2Backend(SubprocessBackend):
             # reading estimate as the dubbing fit planner so the public
             # ``duration`` control remains effective on 2.5; the sidecar
             # drops this factor when it detects a legacy IndexTTS-2 checkout.
-            from services.speech_rate import expected_duration
-
-            natural_s = expected_duration(text, language)
-            if natural_s > 0:
-                forwarded["duration_factor"] = max(
-                    0.5, min(float(duration) / natural_s, 2.0)
-                )
+            forwarded["duration_factor"] = _duration_factor(
+                text, language, float(duration)
+            )
 
         if (
             emo_vector

--- a/backend/engines/indextts/bootstrap.py
+++ b/backend/engines/indextts/bootstrap.py
@@ -1,4 +1,4 @@
-"""IndexTTS-2 venv probe + lazy bootstrap (Phase 2 Plan 02-03).
+"""IndexTTS 2.5/2 venv probe + lazy bootstrap (Phase 2 Plan 02-03).
 
 The parent process needs to know *which Python interpreter* to spawn the
 IndexTTS sidecar under. This module owns that resolution. The probe runs
@@ -13,9 +13,9 @@ Probe order (Open Question #1 resolution from 02-RESEARCH.md):
        Windows). Highest priority — power users who already cloned
        IndexTTS and ran ``uv pip install -e .`` get zero migration cost.
     2. ``backend/engines/indextts/.venv/`` — this package's own venv,
-       created by step 3 if needed. Survives across OmniVoice upgrades;
+       created by step 3 if needed. Survives across VoiceStudio upgrades;
        the IndexTTS clone is referenced via ``uv pip install -e`` so
-       weights and code live in the user's clone, not under OmniVoice.
+       weights and code live in the user's clone, not under VoiceStudio.
     3. Bootstrap: run ``uv venv`` then ``uv pip install -e
        ${OMNIVOICE_INDEXTTS_DIR}`` to populate step-2's venv. Requires
        OMNIVOICE_INDEXTTS_DIR to be set (otherwise we don't know where
@@ -162,10 +162,10 @@ def resolve_indextts_venv() -> Path:
     # Probe 3 — bootstrap.
     if not omv_dir:
         raise RuntimeError(
-            "IndexTTS-2 is not installed. Set the OMNIVOICE_INDEXTTS_DIR "
+            "IndexTTS 2.5 is not installed. Set the OMNIVOICE_INDEXTTS_DIR "
             "environment variable to your IndexTTS clone (the directory "
             "that contains checkpoints/ and pyproject.toml), then restart "
-            "OmniVoice. See docs/engines/indextts.md for the full install "
+            "VoiceStudio. See docs/engines/indextts.md for the full install "
             "walk-through."
         )
 
@@ -200,15 +200,19 @@ def _probe_paths() -> list[Path]:
 
 
 def _venv_can_import_indextts(python_path: Path) -> ProbeResult:
-    """Spawn the candidate python and verify ``import indextts.infer_v2`` works.
+    """Verify IndexTTS 2.5, retaining user-managed IndexTTS-2 compatibility.
 
     Tri-state — "yes" / "no" / "unproven". See ``engines._venv_probe``: a
     probe that runs out of time proves nothing, and treating that as "no"
     is what discarded working OMNIVOICE_INDEXTTS_DIR installs (#1414).
     """
-    return venv_can_import(
-        python_path, "import indextts.infer_v2", engine="indextts", logger=logger,
+    probe = (
+        "try:\n import indextts.infer_v2_5\n"
+        "except ModuleNotFoundError as exc:\n"
+        " if exc.name != 'indextts.infer_v2_5': raise\n"
+        " import indextts.infer_v2\n"
     )
+    return venv_can_import(python_path, probe, engine="indextts", logger=logger)
 
 
 def _locate_uv() -> Optional[str]:
@@ -234,10 +238,10 @@ def _bootstrap_engines_venv(indextts_clone: Path) -> Path:
     uv = _locate_uv()
     if not uv:
         raise RuntimeError(
-            "uv is required to bootstrap the IndexTTS-2 venv but was not "
+            "uv is required to bootstrap the IndexTTS 2.5 venv but was not "
             "found on PATH (and the bundled uv path was not set via the "
             "OMNIVOICE_BUNDLED_UV env var). Install uv from "
-            "https://docs.astral.sh/uv/ and re-launch OmniVoice, or set "
+            "https://docs.astral.sh/uv/ and re-launch VoiceStudio, or set "
             "OMNIVOICE_BUNDLED_UV to the absolute path of a uv binary."
         )
 
@@ -285,8 +289,8 @@ def _bootstrap_engines_venv(indextts_clone: Path) -> Path:
     # spending minutes on the install (#1414).
     if _venv_can_import_indextts(python_path) == "no":
         raise RuntimeError(
-            "IndexTTS bootstrap completed but `import indextts.infer_v2` "
-            f"still fails from {python_path}. Verify that "
+            "IndexTTS bootstrap completed but neither the 2.5 nor 2 inference "
+            f"module imports from {python_path}. Verify that "
             f"{indextts_clone} is a valid IndexTTS clone (contains "
             "pyproject.toml with the indextts package). See "
             "docs/engines/indextts.md."

--- a/backend/engines/indextts/main.py
+++ b/backend/engines/indextts/main.py
@@ -1,8 +1,8 @@
-"""IndexTTS-2 sidecar entry point (Phase 2 Plan 02-03).
+"""IndexTTS 2.5/2 sidecar entry point (Phase 2 Plan 02-03).
 
 Runs inside ``engines/indextts/.venv`` (or the user's existing
 ``${OMNIVOICE_INDEXTTS_DIR}/.venv``) with ``transformers<5``, isolated
-from the OmniVoice parent process which pins ``transformers>=5.3``.
+from the VoiceStudio parent process which pins ``transformers>=5.3``.
 Closes issue #42 — the canonical ``OffloadedCache`` ImportError that
 results from running both libraries inside one Python interpreter.
 
@@ -50,7 +50,7 @@ Op flow expected by the parent:
 Restrictions:
 
   * NO imports from ``backend.services``, ``backend.engines`` (other
-    than this package), or any OmniVoice parent code. The sidecar runs
+    than this package), or any VoiceStudio parent code. The sidecar runs
     under a venv where those modules may not resolve.
   * NO logging of ``os.environ`` contents or env-var values. Defense in
     depth against accidental token-bytes-on-stderr (T-02-08); the
@@ -109,6 +109,8 @@ EMOTION_KWARGS_ALLOWLIST = frozenset({
     "use_emo_text",     # bool — set by parent when emo_text supplied
     "use_random",       # bool
     "target_tokens",    # int — duration control
+    "duration_factor",  # float — IndexTTS 2.5 duration scaling
+    "lang",             # IndexTTS 2.5 language token
 })
 
 
@@ -144,6 +146,40 @@ def _recv(stream):
 # Module-level singleton — populated on the first synthesize op and reused
 # for every subsequent request in this sidecar's lifetime.
 _model = None
+_model_version = None
+
+
+def _torch_bf16_supported() -> bool:
+    """Return whether this sidecar can safely enable IndexTTS 2.5 BF16."""
+    try:
+        import torch
+
+        supported = getattr(torch.cuda, "is_bf16_supported", None)
+        return bool(torch.cuda.is_available() and supported and supported())
+    except Exception:
+        return False
+
+
+def _model_init_kwargs(
+    repo_dir: str, *, version: str, reduced_precision: bool,
+) -> dict:
+    """Build version-specific constructor arguments for IndexTTS 2.5 or 2."""
+    model_dir = os.path.join(repo_dir, "checkpoints")
+    cfg_name = "config_v2_5.yaml" if version == "2.5" else "config.yaml"
+    kwargs = {
+        "cfg_path": os.path.join(model_dir, cfg_name),
+        "model_dir": model_dir,
+        "use_cuda_kernel": False,
+        "use_deepspeed": False,
+    }
+    if version == "2.5":
+        kwargs.update(
+            use_bf16=reduced_precision and _torch_bf16_supported(),
+            use_qwen_emo=True,
+        )
+    else:
+        kwargs["use_fp16"] = reduced_precision
+    return kwargs
 
 
 def _load_model(stdout) -> object:
@@ -155,29 +191,32 @@ def _load_model(stdout) -> object:
     in-flight synthesize op and continues the dispatch loop (the next
     request retries the load).
     """
-    global _model
+    global _model, _model_version
     if _model is not None:
         return _model
 
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 0})
 
     # Imported lazily so a missing dep doesn't block the ready handshake.
-    from indextts.infer_v2 import IndexTTS2  # type: ignore[import-not-found]
+    # A user-managed IndexTTS-2 checkout remains supported; app-managed
+    # installs use the reviewed 2.5 branch and take this first path.
+    try:
+        from indextts.infer_v2_5 import IndexTTS2  # type: ignore[import-not-found]
+        _model_version = "2.5"
+    except ModuleNotFoundError as exc:
+        if exc.name != "indextts.infer_v2_5":
+            raise
+        from indextts.infer_v2 import IndexTTS2  # type: ignore[import-not-found,no-redef]
+        _model_version = "2"
 
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 50})
 
     repo_dir = os.environ.get("OMNIVOICE_INDEXTTS_DIR", ".")
-    cfg_path = os.path.join(repo_dir, "checkpoints", "config.yaml")
-    model_dir = os.path.join(repo_dir, "checkpoints")
-    use_fp16 = os.environ.get("OMNIVOICE_INDEXTTS_FP16", "1") == "1"
-
-    _model = IndexTTS2(
-        cfg_path=cfg_path,
-        model_dir=model_dir,
-        use_fp16=use_fp16,
-        use_cuda_kernel=False,
-        use_deepspeed=False,
+    reduced_precision = os.environ.get("OMNIVOICE_INDEXTTS_FP16", "1") == "1"
+    model_kw = _model_init_kwargs(
+        repo_dir, version=_model_version, reduced_precision=reduced_precision,
     )
+    _model = IndexTTS2(**model_kw)
 
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 100})
     return _model
@@ -229,14 +268,7 @@ def _handle_synthesize(msg: dict, stdout) -> None:
     # Build infer_kwargs by filtering through the allowlist. The parent
     # has already done any vector-vs-audio-vs-text emotion priority
     # arbitration; we just forward whichever keys it sent.
-    infer_kw: dict = {
-        "spk_audio_prompt": ref_audio,
-        "text": text,
-        "verbose": False,
-    }
-    for k, v in msg.items():
-        if k in EMOTION_KWARGS_ALLOWLIST and v is not None:
-            infer_kw[k] = v
+    infer_kw = _build_infer_kwargs(msg, ref_audio, is_v25=_model_version == "2.5")
 
     # IndexTTS2.infer() writes to a file; we route through tempfile so
     # cleanup is automatic on success and on exit.
@@ -261,6 +293,29 @@ def _handle_synthesize(msg: dict, stdout) -> None:
         "sample_rate": sr,
         "n_samples": n_samples,
     })
+
+
+def _build_infer_kwargs(msg: dict, ref_audio: str, *, is_v25: bool) -> dict:
+    """Translate the stable VoiceStudio wire payload to either upstream API."""
+    infer_kw: dict = {
+        "spk_audio_prompt": ref_audio,
+        "text": msg.get("text"),
+        "verbose": False,
+    }
+    for k, v in msg.items():
+        if k in EMOTION_KWARGS_ALLOWLIST and v is not None:
+            infer_kw[k] = v
+    if is_v25:
+        # 2.5 requires language and replaced exact AR target_tokens with an
+        # S2M duration factor. Dubbing's fit stage remains the exact timeline
+        # authority, so an obsolete target_tokens kwarg must not leak into the
+        # upstream transformers generate call.
+        infer_kw.pop("target_tokens", None)
+        infer_kw["lang"] = str(infer_kw.get("lang") or "en").lower()
+    else:
+        infer_kw.pop("lang", None)
+        infer_kw.pop("duration_factor", None)
+    return infer_kw
 
 
 # ── main loop ─────────────────────────────────────────────────────────────

--- a/backend/services/sidecar_install.py
+++ b/backend/services/sidecar_install.py
@@ -137,7 +137,7 @@ SPECS: dict[str, SidecarSpec] = {
             "https://github.com/index-tts/index-tts/archive/"
             "bf2e967fac7933197143b017a60820b1ad40c448.tar.gz"
         ),
-        checkout_dirname="index-tts",
+        checkout_dirname="index-tts-2.5",
         env_var="OMNIVOICE_INDEXTTS_DIR",
         probe_module="indextts.infer_v2_5",
         repo_ref="indextts-2.5",
@@ -179,6 +179,13 @@ def managed_root(spec: SidecarSpec) -> Path:
 
 def managed_checkout(spec: SidecarSpec) -> Path:
     return managed_root(spec) / spec.checkout_dirname
+
+
+def _legacy_managed_checkouts(spec: SidecarSpec) -> tuple[Path, ...]:
+    """App-owned predecessor checkouts retained during in-place upgrades."""
+    if spec.engine_id == "indextts2":
+        return (managed_root(spec) / "index-tts",)
+    return ()
 
 
 def _venv_python(venv_dir: Path) -> Path:
@@ -320,7 +327,9 @@ def disk_space_error(spec: SidecarSpec) -> Optional[str]:
     (needs X + headroom Y, have Z — same shape as the model-install guard);
     ``None`` when it fits or the volume can't be probed."""
     root = managed_root(spec)
-    already = _dir_size_bytes(root)
+    # A preserved predecessor is not a partial copy of the new install: the
+    # upgrade needs its full space until the new sidecar is verified.
+    already = _dir_size_bytes(managed_checkout(spec))
     remaining = max(0, spec.required_bytes - already)
     free = disk_free_bytes(root)
     if free <= 0:
@@ -421,8 +430,8 @@ def get_status(engine_id: str) -> dict:
         # True when the on-disk install is the app-managed one (uninstallable
         # from the app). A user's own clone is never "managed".
         "managed": bool(
-            checkout.is_dir()
-            and (not env_dir or Path(env_dir) == checkout)
+            (checkout.is_dir() and (not env_dir or Path(env_dir) == checkout))
+            or (env_dir and Path(env_dir) in _legacy_managed_checkouts(spec))
         ),
         "install_dir": env_dir or (str(checkout) if checkout.is_dir() else None),
         "job": job,
@@ -440,7 +449,8 @@ def _user_managed_dir(spec: SidecarSpec) -> Optional[Path]:
     """The user's own install dir when the env var points anywhere but the
     app-managed checkout; None for managed/unset (ours to provision)."""
     env_dir = os.environ.get(spec.env_var)
-    if env_dir and Path(env_dir) != managed_checkout(spec):
+    managed_paths = (managed_checkout(spec), *_legacy_managed_checkouts(spec))
+    if env_dir and Path(env_dir) not in managed_paths:
         return Path(env_dir)
     return None
 
@@ -454,6 +464,11 @@ def _healthy(spec: SidecarSpec) -> bool:
         return _safe_installed(spec)
     checkout = managed_checkout(spec)
     if not checkout.is_dir():
+        # A working app-managed predecessor stays available to the engine,
+        # but the install endpoint must still offer the reviewed 2.5 upgrade.
+        env_dir = os.environ.get(spec.env_var)
+        if env_dir and Path(env_dir) in _legacy_managed_checkouts(spec):
+            return False
         # No managed install at all. A legacy install may still exist (e.g.
         # IndexTTS's old lazy-bootstrap venv under backend/engines/) — trust
         # the engine's own probe so we never re-provision over a working one.
@@ -531,7 +546,8 @@ def uninstall(engine_id: str) -> dict:
             return {"status": "install_in_progress", "engine": engine_id}
     env_dir = os.environ.get(spec.env_var)
     checkout = managed_checkout(spec)
-    if env_dir and Path(env_dir) != checkout:
+    managed_paths = (checkout, *_legacy_managed_checkouts(spec))
+    if env_dir and Path(env_dir) not in managed_paths:
         return {
             "status": "not_managed",
             "engine": engine_id,
@@ -626,9 +642,9 @@ def _step_fetch_source(spec: SidecarSpec, job: dict) -> None:
         _log(job, f"Source already present at {checkout} — skipping fetch.")
         return
     if checkout.exists():
-        # Half-fetched or superseded checkout — repair by refetching. This is
-        # also the managed IndexTTS-2 -> 2.5 migration: the old checkout lacks
-        # infer_v2_5.py and the reviewed-source marker.
+        # Half-fetched checkout — repair by refetching. Superseded managed
+        # generations live at a different path and remain usable until this
+        # replacement has completed successfully.
         _log(job, f"Removing incomplete or outdated checkout at {checkout} …")
         shutil.rmtree(checkout, ignore_errors=True)
 

--- a/backend/services/sidecar_install.py
+++ b/backend/services/sidecar_install.py
@@ -1,7 +1,7 @@
-"""One-click sidecar-engine provisioner (issue: IndexTTS-2 in-app install).
+"""One-click sidecar-engine provisioner.
 
-Some engines (IndexTTS-2 today; MOSS-v1.5 / dots.tts / Confucius4 are the
-same shape) can't live in the app venv because they pin a ``transformers``
+Some engines (IndexTTS 2.5, MOSS-v1.5, dots.tts, and Confucius4) have the
+same shape and can't live in the app venv because they pin a ``transformers``
 version that conflicts with the parent's ``>=5.3``. They run as sidecars:
 a source checkout + a dedicated venv + (for IndexTTS-2) model weights in
 ``<checkout>/checkpoints/``. Until now provisioning that trio was four
@@ -24,8 +24,8 @@ Design notes (single source of truth for the choices):
   clone. A user-managed install (env var already pointing at their clone)
   is left completely alone.
 * **Weights ARE part of the install** for engines whose sidecar loads
-  from ``<checkout>/<weights_subdir>/`` (IndexTTS-2's ``main.py`` reads
-  ``$OMNIVOICE_INDEXTTS_DIR/checkpoints/config.yaml`` — verified). The
+  from ``<checkout>/<weights_subdir>/`` (IndexTTS 2.5's ``main.py`` reads
+  ``$OMNIVOICE_INDEXTTS_DIR/checkpoints/config_v2_5.yaml`` — verified). The
   download goes through ``huggingface_hub.snapshot_download`` with the
   endpoint from :mod:`services.endpoint_race` (HF endpoint auto-select;
   **no hardcoded huggingface.co**) and the token from
@@ -102,8 +102,13 @@ class SidecarSpec:
     checkout_dirname: str              # directory name of the checkout under the managed root
     env_var: str                       # env var the engine's bootstrap reads (install dir)
     probe_module: str                  # python -c "import <probe_module>" proves the venv works
+    repo_ref: Optional[str] = None     # branch/tag selected by git clone
+    source_revision: Optional[str] = None  # reviewed upstream commit
+    source_required_path: Optional[str] = None  # distinguishes incompatible source generations
     weights_repo_id: Optional[str] = None   # HF repo downloaded into <checkout>/<weights_subdir>
+    weights_revision: Optional[str] = None  # reviewed HF commit
     weights_subdir: str = "checkpoints"
+    weights_config_name: str = "config.yaml"  # required model config inside weights_subdir
     docs_path: str = "docs/engines"         # where the manual-install fallback lives
     required_bytes: int = 12 * _GIB    # conservative source+venv+weights estimate for preflight
     # Called after a successful install/uninstall so the engine's memoised
@@ -126,14 +131,22 @@ def _indextts_installed() -> bool:
 SPECS: dict[str, SidecarSpec] = {
     "indextts2": SidecarSpec(
         engine_id="indextts2",
-        display_name="IndexTTS-2",
+        display_name="IndexTTS 2.5",
         repo_url="https://github.com/index-tts/index-tts.git",
-        tarball_url="https://github.com/index-tts/index-tts/archive/refs/heads/main.tar.gz",
+        tarball_url=(
+            "https://github.com/index-tts/index-tts/archive/"
+            "bf2e967fac7933197143b017a60820b1ad40c448.tar.gz"
+        ),
         checkout_dirname="index-tts",
         env_var="OMNIVOICE_INDEXTTS_DIR",
-        probe_module="indextts.infer_v2",
-        weights_repo_id="IndexTeam/IndexTTS-2",
+        probe_module="indextts.infer_v2_5",
+        repo_ref="indextts-2.5",
+        source_revision="bf2e967fac7933197143b017a60820b1ad40c448",
+        source_required_path="indextts/infer_v2_5.py",
+        weights_repo_id="IndexTeam/IndexTTS-2.5",
+        weights_revision="d0aa86e75bb6f3437f3831e95056fa72842d89ef",
         weights_subdir="checkpoints",
+        weights_config_name="config_v2_5.yaml",
         docs_path="docs/engines/indextts.md",
         # ~0.1 GB source + up to ~6 GB venv (torch + transformers<5) +
         # ~6 GB weights. Deliberately conservative; the preflight subtracts
@@ -445,6 +458,8 @@ def _healthy(spec: SidecarSpec) -> bool:
         # IndexTTS's old lazy-bootstrap venv under backend/engines/) — trust
         # the engine's own probe so we never re-provision over a working one.
         return _safe_installed(spec)
+    if not _source_present(spec, checkout):
+        return False
     if not _venv_python(checkout / ".venv").is_file():
         return False
     if spec.weights_repo_id and not _weights_present(spec):
@@ -605,22 +620,34 @@ def _step_preflight(spec: SidecarSpec, job: dict) -> None:
 def _step_fetch_source(spec: SidecarSpec, job: dict) -> None:
     step = _job_step(job, "fetch_source")
     checkout = managed_checkout(spec)
-    if (checkout / "pyproject.toml").is_file():
+    if _source_present(spec, checkout):
         step["state"] = "done"
         step["detail"] = "source already present"
         _log(job, f"Source already present at {checkout} — skipping fetch.")
         return
     if checkout.exists():
-        # Half-fetched checkout (no pyproject.toml) — repair by refetching.
-        _log(job, f"Removing incomplete checkout at {checkout} …")
+        # Half-fetched or superseded checkout — repair by refetching. This is
+        # also the managed IndexTTS-2 -> 2.5 migration: the old checkout lacks
+        # infer_v2_5.py and the reviewed-source marker.
+        _log(job, f"Removing incomplete or outdated checkout at {checkout} …")
         shutil.rmtree(checkout, ignore_errors=True)
 
     git = shutil.which("git")
     if git:
         _log(job, f"Cloning {spec.repo_url} (git, depth 1) …")
-        rc = _run_logged(job, [git, "clone", "--depth", "1", spec.repo_url, str(checkout)],
-                         timeout=_GIT_CLONE_TIMEOUT_S)
-        if rc == 0 and (checkout / "pyproject.toml").is_file():
+        clone_argv = [git, "clone", "--depth", "1"]
+        if spec.repo_ref:
+            clone_argv.extend(["--branch", spec.repo_ref])
+        clone_argv.extend([spec.repo_url, str(checkout)])
+        rc = _run_logged(job, clone_argv, timeout=_GIT_CLONE_TIMEOUT_S)
+        if rc == 0 and spec.source_revision:
+            rc = _run_logged(
+                job,
+                [git, "-C", str(checkout), "checkout", "--detach", spec.source_revision],
+                timeout=_GIT_CLONE_TIMEOUT_S,
+            )
+        if rc == 0 and _source_layout_ok(spec, checkout):
+            _write_source_marker(spec, checkout)
             step["detail"] = "git clone"
             return
         _log(job, f"git clone failed (exit {rc}) — falling back to source tarball.")
@@ -629,14 +656,43 @@ def _step_fetch_source(spec: SidecarSpec, job: dict) -> None:
         _log(job, "git not found — using the source-tarball fallback.")
 
     _fetch_tarball(spec, job, checkout)
-    if not (checkout / "pyproject.toml").is_file():
+    if not _source_layout_ok(spec, checkout):
         raise _StepError(
             f"Fetched source at {checkout} has no pyproject.toml — the download "
             "appears incomplete or the upstream layout changed.",
             "Re-run the install; if it keeps failing, clone the repository "
             f"manually and set {spec.env_var} to the clone (see the engine docs).",
         )
+    _write_source_marker(spec, checkout)
     step["detail"] = "source tarball"
+
+
+_SOURCE_REVISION_MARKER = ".voicestudio_source_revision"
+
+
+def _source_layout_ok(spec: SidecarSpec, checkout: Path) -> bool:
+    if not (checkout / "pyproject.toml").is_file():
+        return False
+    return not spec.source_required_path or (checkout / spec.source_required_path).is_file()
+
+
+def _write_source_marker(spec: SidecarSpec, checkout: Path) -> None:
+    if spec.source_revision:
+        (checkout / _SOURCE_REVISION_MARKER).write_text(
+            f"{spec.source_revision}\n", encoding="utf-8",
+        )
+
+
+def _source_present(spec: SidecarSpec, checkout: Path) -> bool:
+    if not _source_layout_ok(spec, checkout):
+        return False
+    if not spec.source_revision:
+        return True
+    try:
+        marker = (checkout / _SOURCE_REVISION_MARKER).read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    return marker == spec.source_revision
 
 
 def _fetch_tarball(spec: SidecarSpec, job: dict, checkout: Path) -> None:
@@ -787,7 +843,7 @@ def _step_verify(spec: SidecarSpec, job: dict) -> None:
 
 
 # Written into the weights dir after snapshot_download COMPLETES. A partial
-# multi-shard download can leave config.yaml + several plausible shards on
+# multi-shard download can leave a config + several plausible shards on
 # disk, so file heuristics alone would declare a killed-mid-download install
 # healthy and never resume it (the sidecar edition of #352). Only this
 # installer writes the marker; user-managed clones never hit this path.
@@ -796,16 +852,22 @@ _WEIGHTS_COMPLETE_MARKER = ".omnivoice_weights_complete"
 
 def _weights_present(spec: SidecarSpec) -> bool:
     """True only for a COMPLETED weights download: the completion marker
-    plus a sanity floor (config.yaml + one ≥5 MB weight file — the same
+    plus a sanity floor (the expected config + one ≥5 MB weight file — the same
     truncated-download floor the model store uses)."""
     wdir = managed_checkout(spec) / spec.weights_subdir
-    if not (wdir / _WEIGHTS_COMPLETE_MARKER).is_file():
+    try:
+        marker = (wdir / _WEIGHTS_COMPLETE_MARKER).read_text(encoding="utf-8").splitlines()
+    except OSError:
         return False
-    return _weights_floor_ok(wdir)
+    expected = [spec.weights_repo_id or "", spec.weights_revision or ""]
+    actual = marker[:2] if len(marker) >= 2 else marker + [""]
+    if actual != expected:
+        return False
+    return _weights_floor_ok(wdir, config_name=spec.weights_config_name)
 
 
-def _weights_floor_ok(wdir: Path) -> bool:
-    if not (wdir / "config.yaml").is_file():
+def _weights_floor_ok(wdir: Path, *, config_name: str = "config.yaml") -> bool:
+    if not (wdir / config_name).is_file():
         return False
     floor = 5 * 1024 * 1024
     try:
@@ -871,6 +933,8 @@ def _step_fetch_weights(spec: SidecarSpec, job: dict) -> None:
             "local_dir": str(wdir),
             "token": resolve_token(),
         }
+        if spec.weights_revision:
+            kwargs["revision"] = spec.weights_revision
         endpoint = endpoint_race.effective_endpoint()
         if endpoint:
             kwargs["endpoint"] = endpoint
@@ -889,7 +953,7 @@ def _step_fetch_weights(spec: SidecarSpec, job: dict) -> None:
         hf_progress.unregister_listener(listener_id)
         hf_progress.current_repo_id.reset(repo_token)
 
-    if not _weights_floor_ok(wdir):
+    if not _weights_floor_ok(wdir, config_name=spec.weights_config_name):
         raise _StepError(
             "Weight download finished but no plausible weight files were found — "
             "the download was likely interrupted.",
@@ -898,7 +962,8 @@ def _step_fetch_weights(spec: SidecarSpec, job: dict) -> None:
     # snapshot_download returned AND the sanity floor holds → mark complete,
     # so _weights_present/_healthy stop treating this dir as a partial.
     (wdir / _WEIGHTS_COMPLETE_MARKER).write_text(
-        f"{spec.weights_repo_id}\n{time.time():.0f}\n", encoding="utf-8",
+        f"{spec.weights_repo_id}\n{spec.weights_revision or ''}\n{time.time():.0f}\n",
+        encoding="utf-8",
     )
     step["detail"] = "weights downloaded"
     _log(job, "Model weights downloaded.")

--- a/backend/services/sidecar_install.py
+++ b/backend/services/sidecar_install.py
@@ -563,7 +563,7 @@ def uninstall(engine_id: str) -> dict:
     if env_dir:  # only ever the managed checkout at this point
         os.environ.pop(spec.env_var, None)
     from core import prefs
-    if prefs.get(f"env.{spec.env_var}") == str(checkout):
+    if prefs.get(f"env.{spec.env_var}") in {str(path) for path in managed_paths}:
         prefs.delete(f"env.{spec.env_var}")
     try:
         spec.invalidate()

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2039,7 +2039,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "mlx-audio":     "pip install mlx-audio  (Apple Silicon only)",
     "voxcpm2":       'pip install "voxcpm>=2.0.3"  (floor: 2.0.3 fixed Apple-Silicon audio quality; CPU/MPS supported, CUDA recommended for speed)',
     "moss-tts-nano": "git clone OpenMOSS/MOSS-TTS-Nano && pip install -e .  (not on PyPI)",
-    "indextts2":     "git clone --branch indextts-2.5 index-tts/index-tts && uv pip install -e .  (NOT uv sync --all-extras)",
+    "indextts2":     "git clone --branch indextts-2.5 https://github.com/index-tts/index-tts.git && cd index-tts && uv venv .venv && uv pip install --python .venv/bin/python -e .  (Windows: .venv\\Scripts\\python.exe; NOT uv sync --all-extras)",
     "gpt-sovits":    "External API server — start api_v2.py on port 9880",
     "sherpa-onnx":   "pip install sherpa-onnx  (universal ONNX runtime, WASM-ready)",
     "omnivoice-gguf":"Bundled — runs the C++ omnivoice-tts binary in bin/. Quants download lazily from Serveurperso/OmniVoice-GGUF on first generate.",

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2039,7 +2039,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "mlx-audio":     "pip install mlx-audio  (Apple Silicon only)",
     "voxcpm2":       'pip install "voxcpm>=2.0.3"  (floor: 2.0.3 fixed Apple-Silicon audio quality; CPU/MPS supported, CUDA recommended for speed)',
     "moss-tts-nano": "git clone OpenMOSS/MOSS-TTS-Nano && pip install -e .  (not on PyPI)",
-    "indextts2":     "git clone index-tts/index-tts && uv pip install -e .  (NOT uv sync --all-extras)",
+    "indextts2":     "git clone --branch indextts-2.5 index-tts/index-tts && uv pip install -e .  (NOT uv sync --all-extras)",
     "gpt-sovits":    "External API server — start api_v2.py on port 9880",
     "sherpa-onnx":   "pip install sherpa-onnx  (universal ONNX runtime, WASM-ready)",
     "omnivoice-gguf":"Bundled — runs the C++ omnivoice-tts binary in bin/. Quants download lazily from Serveurperso/OmniVoice-GGUF on first generate.",

--- a/docs/engines/indextts.md
+++ b/docs/engines/indextts.md
@@ -26,8 +26,10 @@ The installer:
 - resumes partial model downloads;
 - saves `OMNIVOICE_INDEXTTS_DIR` and activates the engine without a restart.
 
-App-managed IndexTTS-2 source is replaced by 2.5 when its installer is run.
-User-managed clones are never modified or removed; their legacy
+An app-managed IndexTTS-2 checkout remains intact while 2.5 installs into a
+separate directory. VoiceStudio switches to 2.5 only after the new source,
+environment, and weights pass verification. User-managed clones are never
+modified or removed; their legacy
 `indextts.infer_v2` entry point remains supported.
 
 ## Manual install
@@ -125,5 +127,10 @@ revenue in the preceding year. The agreement also includes downstream,
 derivative-work, prohibited-use, attribution, and compliance obligations.
 Review the [official license](https://huggingface.co/IndexTeam/IndexTTS-2.5/blob/main/LICENSE)
 before installing or using the model.
+
+This model is not covered by VoiceStudio's blanket commercial-use statement.
+Organizations above either threshold must obtain Bilibili's separate written
+license before installing or using IndexTTS 2.5. Other engines remain available
+without enabling this optional sidecar.
 
 See [Engine venvs and disk usage](disk-usage.md) for storage details.

--- a/docs/engines/indextts.md
+++ b/docs/engines/indextts.md
@@ -1,204 +1,126 @@
-# VoiceStudio — IndexTTS-2 Engine
+# VoiceStudio — IndexTTS 2.5
 
-IndexTTS-2 (Bilibili) is VoiceStudio's emotion-controlled zero-shot TTS
-engine. It runs in its own subprocess + dedicated Python venv with
-`transformers<5`, isolated from the VoiceStudio parent process which
-pins `transformers>=5.3`. This isolation is the resolution of
-[#42](https://github.com/voice-design/VoiceStudio/issues/42) — the
-canonical `OffloadedCache` ImportError that resulted from loading
-both libraries inside one Python interpreter.
+IndexTTS 2.5 is an optional, multilingual voice-cloning engine for dubbing
+and expressive speech. It supports Chinese, English, Japanese, Spanish, and
+Arabic, with reference-audio cloning, emotion references, emotion vectors,
+and text-directed emotion.
 
-## Install (one-click, recommended)
+VoiceStudio runs IndexTTS in a dedicated subprocess and Python environment.
+This keeps its `transformers<5` dependency isolated from VoiceStudio's
+runtime. Existing user-managed IndexTTS-2 environments remain supported.
 
-IndexTTS-2 is **not** bundled with VoiceStudio — the model weights are
-~6 GB and the package itself pins a conflicting transformers
-version. VoiceStudio ships with a sidecar runner that loads IndexTTS
-into an isolated venv on demand, plus a guided installer that
-provisions everything for you:
+## Install
 
-1. Open **Settings → Engines**, expand the IndexTTS2 row
-   ("Why unavailable?"), and click **Install**.
-2. Watch the step-by-step progress: preflight (uv + disk space),
-   source fetch, isolated venv creation, dependency install,
-   verification, model-weight download (~6 GB, resumable), and
-   configuration save.
-3. Done — the engine flips to `available: true` immediately, **no
-   restart needed**.
+IndexTTS 2.5 is not bundled because its source environment and model weights
+require substantial disk space.
 
-What the installer does under the hood (all cross-platform —
-macOS / Windows / Linux):
+1. Open **Settings → Engines**.
+2. Expand **IndexTTS 2.5** and select **Install**.
+3. Keep VoiceStudio open while source, dependencies, and weights download.
 
-* Fetches the IndexTTS source with `git clone --depth 1` (or, when
-  git isn't installed, downloads the GitHub source tarball over
-  HTTPS) into VoiceStudio's data directory
-  (`<data-dir>/engines/indextts2/index-tts`).
-* Creates a dedicated venv inside the checkout with `uv venv` and
-  runs `uv pip install -e .` against it — the `transformers<5`
-  isolation is preserved; the parent app's environment is never
-  touched. uv is resolved from `OMNIVOICE_BUNDLED_UV`, then `PATH`.
-* Downloads the `IndexTeam/IndexTTS-2` weights into
-  `checkpoints/` (where the sidecar loads them from), honouring your
-  configured/auto-selected Hugging Face endpoint and HF token.
-* Persists `OMNIVOICE_INDEXTTS_DIR` for you (in-process for
-  immediate use + `prefs.json` for the next launch).
+The installer:
 
-Preflight requires roughly **12 GB free disk space** (source + venv +
-weights, checked before anything is written); the install fails early
-with an actionable message otherwise. Re-running the installer is
-always safe: it repairs partial installs and resumes interrupted
-downloads instead of starting over. An app-managed install can be
-removed again with `DELETE /engines/sidecar/indextts2/install` (a
-user-managed clone is never touched).
+- checks for `uv` and at least 12 GB of free space;
+- installs the reviewed `indextts-2.5` source revision in an isolated venv;
+- downloads the reviewed `IndexTeam/IndexTTS-2.5` model revision;
+- resumes partial model downloads;
+- saves `OMNIVOICE_INDEXTTS_DIR` and activates the engine without a restart.
 
-If you already installed IndexTTS manually (any VoiceStudio version),
-the installer detects it via `OMNIVOICE_INDEXTTS_DIR` and reports
-`already_installed` — nothing is re-downloaded or moved.
+App-managed IndexTTS-2 source is replaced by 2.5 when its installer is run.
+User-managed clones are never modified or removed; their legacy
+`indextts.infer_v2` entry point remains supported.
 
-## Manual install (fallback)
+## Manual install
 
-The manual flow still works and is what the installer automates. Use
-it if you want the clone somewhere specific, share one clone across
-tools, or can't use the in-app installer:
-
-1. Clone the IndexTTS repo on disk:
-
-   ```bash
-   git clone https://github.com/index-tts/index-tts.git
-   ```
-
-2. Install the editable package into a fresh venv. Use
-   `uv pip install -e .` — **never** `uv sync --all-extras`, which
-   would overwrite VoiceStudio's lock file with `transformers<5` and
-   break the parent process:
-
-   ```bash
-   cd index-tts
-   uv venv .venv
-   uv pip install -e .
-   ```
-
-3. Download the model weights (~6 GB):
-
-   ```bash
-   hf download IndexTeam/IndexTTS-2 --local-dir=checkpoints
-   ```
-
-4. Set the `OMNIVOICE_INDEXTTS_DIR` environment variable to the repo
-   root (the directory that contains `checkpoints/` and
-   `pyproject.toml`):
-
-   ```bash
-   # macOS / Linux
-   echo 'export OMNIVOICE_INDEXTTS_DIR=$HOME/code/index-tts' >> ~/.zshrc
-   source ~/.zshrc
-   ```
-
-   ```powershell
-   # Windows PowerShell
-   [Environment]::SetEnvironmentVariable("OMNIVOICE_INDEXTTS_DIR","$env:USERPROFILE\code\index-tts","User")
-   ```
-
-5. Restart VoiceStudio. IndexTTS-2 will appear in **Settings → Engines**
-   with `available: true` and `isolation_mode: subprocess`.
-
-## Venv resolution order
-
-VoiceStudio probes for a usable IndexTTS Python interpreter in this
-priority order (see `backend/engines/indextts/bootstrap.py`):
-
-1. **`${OMNIVOICE_INDEXTTS_DIR}/.venv/`** — the install dir's own
-   venv. This is what BOTH the one-click installer (which sets
-   `OMNIVOICE_INDEXTTS_DIR` to its managed checkout) and a manual
-   clone resolve to. Highest priority, so v0.2.7 users who already
-   ran `uv pip install -e .` get zero migration cost on the upgrade
-   to v0.3.x.
-2. **`backend/engines/indextts/.venv/`** — VoiceStudio's own venv,
-   created on demand by the lazy bootstrap below.
-3. **Lazy bootstrap** — if neither venv exists, VoiceStudio runs
-   `uv venv backend/engines/indextts/.venv` and
-   `uv pip install --python <python> -e ${OMNIVOICE_INDEXTTS_DIR}`
-   on first launch. Requires `OMNIVOICE_INDEXTTS_DIR` to be set;
-   raises a clear error otherwise.
-
-Each candidate is confirmed by spawning it and running
-`import indextts.infer_v2`. That import pulls in torch and transformers, so
-on a cold page cache — a first run, a slow disk, Windows with real-time AV
-scanning — it can take much longer than usual. A check that runs out of time
-is treated as **unproven, not failed**: the venv stays in play and is used if
-nothing else proves itself, because a genuinely broken venv then fails at the
-sidecar handshake with a real error rather than being reported as a missing
-install (#1414). Raise `OMNIVOICE_INDEXTTS_IMPORT_PROBE_TIMEOUT_S` (default
-60 s) if you want the check to wait longer before falling through.
-
-The cache marker test
-(`tests/backend/services/test_indextts_backward_compat.py::test_hf_home_marker_present_after_bootstrap`)
-proves that the bootstrap path **never** mutates
-`$HF_HOME/hub/models--IndexTeam--IndexTTS-2/` — so the 6 GB model
-weights survive the upgrade byte-for-byte.
-
-## Common errors
-
-### `IndexTTS-2 venv not found. Set OMNIVOICE_INDEXTTS_DIR ...`
-
-You haven't installed IndexTTS yet. Click **Install** on the
-IndexTTS2 row in **Settings → Engines** (recommended), or follow the
-**Manual install** steps above.
-
-### `uv was not found` / `uv is required to bootstrap the IndexTTS-2 venv but was not found on PATH`
-
-Both the one-click installer and the bootstrap path need a working
-`uv` binary (resolved from `OMNIVOICE_BUNDLED_UV`, then `PATH`).
-Either install `uv` into your `PATH` (https://docs.astral.sh/uv/) or
-pre-create the venv manually with `uv venv` and `uv pip install -e`
-as in the manual steps.
-
-### `Not enough disk space to install IndexTTS-2 ...`
-
-The installer's preflight found less free space than the estimated
-source + venv + weights footprint (plus headroom). The message names
-the exact numbers; free up space (or move VoiceStudio's data directory
-to a larger volume) and click Install again — it resumes where it
-stopped.
-
-### `IndexTTS bootstrap completed but `import indextts.infer_v2` still fails`
-
-The clone at `OMNIVOICE_INDEXTTS_DIR` is missing the indextts
-package. Verify with:
+Use a separate checkout and venv. Do not install IndexTTS into VoiceStudio's
+root environment.
 
 ```bash
-ls "$OMNIVOICE_INDEXTTS_DIR/pyproject.toml"   # should exist
-ls "$OMNIVOICE_INDEXTTS_DIR/indextts/"        # should exist
+git clone --branch indextts-2.5 https://github.com/index-tts/index-tts.git
+cd index-tts
+uv venv .venv
+uv pip install --python .venv/bin/python -e .
+hf download IndexTeam/IndexTTS-2.5 --local-dir=checkpoints
 ```
 
-If the directory is correct but the import still fails, delete
-`backend/engines/indextts/.venv/` and re-launch — VoiceStudio will
-re-bootstrap from scratch.
+On Windows, replace `.venv/bin/python` with `.venv\Scripts\python.exe`.
+Then set `OMNIVOICE_INDEXTTS_DIR` to the checkout root:
 
-## Why a subprocess?
+```bash
+export OMNIVOICE_INDEXTTS_DIR=/path/to/index-tts
+```
 
-IndexTTS-2 pins `transformers<5`. VoiceStudio pins `transformers>=5.3`.
-The two cannot share a Python interpreter — at import time, one of
-them blows up trying to find a class the other moved or removed (the
-canonical failure is `OffloadedCache` from `transformers.cache_utils`,
-which v5 renamed). Running IndexTTS in its own subprocess + its own
-venv lets both libraries coexist in the same VoiceStudio session.
+```powershell
+[Environment]::SetEnvironmentVariable(
+  "OMNIVOICE_INDEXTTS_DIR",
+  "$env:USERPROFILE\code\index-tts",
+  "User"
+)
+```
 
-This is the structural fix for issue #42; the previous
-graceful-degradation wrap (which simply detected the conflict and
-disabled IndexTTS) is replaced by a real isolation primitive
-(`backend/services/subprocess_backend.py::SubprocessBackend`, shipped
-in Plan 02-01).
+Restart VoiceStudio after setting a persistent environment variable outside
+the app.
+
+## Compatibility
+
+VoiceStudio probes these locations in order:
+
+1. `${OMNIVOICE_INDEXTTS_DIR}/.venv/`;
+2. `backend/engines/indextts/.venv/`;
+3. a venv bootstrapped from `OMNIVOICE_INDEXTTS_DIR`.
+
+The probe prefers `indextts.infer_v2_5` and falls back to
+`indextts.infer_v2`. A timed-out import is treated as unproven rather than
+missing, preventing slow disks or antivirus scans from hiding a valid venv.
+Set `OMNIVOICE_INDEXTTS_IMPORT_PROBE_TIMEOUT_S` to raise the default 60-second
+probe limit.
+
+IndexTTS 2.5 requires a language token. VoiceStudio maps locale codes and
+language names to the five supported languages and detects Chinese, Japanese,
+or Arabic script for Auto requests. Ambiguous Latin text defaults to English.
+
+IndexTTS 2.5 uses `duration_factor` for native duration guidance. VoiceStudio's
+dubbing fit stage remains responsible for exact segment timing. Legacy
+IndexTTS-2 installations continue receiving their `target_tokens` control.
+
+## Troubleshooting
+
+### Engine unavailable
+
+Use **Settings → Engines → IndexTTS 2.5 → Install**. For a manual install,
+confirm that the configured directory contains:
+
+```text
+pyproject.toml
+indextts/infer_v2_5.py
+checkpoints/config_v2_5.yaml
+```
+
+### `uv` not found
+
+Install `uv` from <https://docs.astral.sh/uv/> or configure the bundled binary
+through `OMNIVOICE_BUNDLED_UV`.
+
+### Import fails after installation
+
+For an app-managed install, retry **Install** to repair the source and venv.
+For a manual install, run:
+
+```bash
+uv pip install --python .venv/bin/python -e .
+```
+
+### Insufficient disk space
+
+Free the amount reported by the installer, then retry. Completed model files
+are reused.
 
 ## License
 
-IndexTTS-2 ships under a custom Bilibili research license — free for
-research / non-commercial use. Commercial use requires contacting
-`indexspeech@bilibili.com`. See the upstream
-[README](https://github.com/index-tts/index-tts/blob/main/README.md)
-for the full terms.
+IndexTTS 2.5 uses the upstream Bilibili model license. It permits academic
+research, education, and non-commercial use subject to its terms. Commercial
+use requires permission from the upstream authors. Review the license on the
+[IndexTTS 2.5 model page](https://huggingface.co/IndexTeam/IndexTTS-2.5)
+before use.
 
----
-
-IndexTTS2 runs in a dedicated sidecar venv (it pins `transformers<5`, which
-conflicts with the parent's `transformers>=5.3`). For why that adds disk and
-how uv keeps the cost down, see [Engine venvs & disk usage](disk-usage.md).
+See [Engine venvs and disk usage](disk-usage.md) for storage details.

--- a/docs/engines/indextts.md
+++ b/docs/engines/indextts.md
@@ -117,10 +117,13 @@ are reused.
 
 ## License
 
-IndexTTS 2.5 uses the upstream Bilibili model license. It permits academic
-research, education, and non-commercial use subject to its terms. Commercial
-use requires permission from the upstream authors. Review the license on the
-[IndexTTS 2.5 model page](https://huggingface.co/IndexTeam/IndexTTS-2.5)
-before use.
+IndexTTS 2.5 uses the bilibili Model Use License. It grants a limited,
+worldwide, non-exclusive, royalty-free license subject to its restrictions.
+A separate license is required when the user or an affiliate exceeded 100
+million monthly active users in the preceding month or RMB 1 billion in annual
+revenue in the preceding year. The agreement also includes downstream,
+derivative-work, prohibited-use, attribution, and compliance obligations.
+Review the [official license](https://huggingface.co/IndexTeam/IndexTTS-2.5/blob/main/LICENSE)
+before installing or using the model.
 
 See [Engine venvs and disk usage](disk-usage.md) for storage details.

--- a/docs/features.yaml
+++ b/docs/features.yaml
@@ -45,6 +45,7 @@ tts_engines:
   - id: gpt-sovits
   - id: sherpa-onnx
   - id: indextts2
+    readme: "**IndexTTS 2.5** ⚡"
     doc: docs/engines/indextts.md
   - id: omnivoice-gguf
   - id: supertonic3

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -140,9 +140,11 @@ model paths don't hit the 260-character `MAX_PATH` limit.
   `HF_HUB_CACHE`), your data is there instead of the defaults above.
 - **Portable mode:** everything lives in an `OmniVoiceStudio-Data/` folder next
   to the app binary — delete that one folder and you're done.
-- **Optional engine sidecars:** if you installed IndexTTS 2.5, CosyVoice, or
-  another sidecar engine, its isolated venv lives under the app-config folder
-  above and is removed with it.
+- **App-managed engine sidecars:** if VoiceStudio installed IndexTTS 2.5,
+  CosyVoice, or another sidecar, its isolated venv lives under the app-config
+  folder above and is removed with it. A user-managed IndexTTS checkout set via
+  `OMNIVOICE_INDEXTTS_DIR` is outside that folder and is never removed; retain
+  or delete it separately.
 
 > **Shared HF cache caveat:** `~/.cache/huggingface/` is the **standard Hugging
 > Face cache**, shared by any tool that uses `huggingface_hub` (other ML apps,

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -143,8 +143,10 @@ model paths don't hit the 260-character `MAX_PATH` limit.
 - **App-managed engine sidecars:** if VoiceStudio installed IndexTTS 2.5,
   CosyVoice, or another sidecar, its isolated venv lives under the app-config
   folder above and is removed with it. A user-managed IndexTTS checkout set via
-  `OMNIVOICE_INDEXTTS_DIR` is outside that folder and is never removed; retain
-  or delete it separately.
+  `OMNIVOICE_INDEXTTS_DIR` is preserved only when its resolved path is outside
+  the app-config folder. Verify the resolved path before cleanup: anything
+  inside the app-config folder is removed with it; retain or delete an external
+  checkout separately.
 
 > **Shared HF cache caveat:** `~/.cache/huggingface/` is the **standard Hugging
 > Face cache**, shared by any tool that uses `huggingface_hub` (other ML apps,

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -140,7 +140,7 @@ model paths don't hit the 260-character `MAX_PATH` limit.
   `HF_HUB_CACHE`), your data is there instead of the defaults above.
 - **Portable mode:** everything lives in an `OmniVoiceStudio-Data/` folder next
   to the app binary — delete that one folder and you're done.
-- **Optional engine sidecars:** if you installed IndexTTS-2, CosyVoice, or
+- **Optional engine sidecars:** if you installed IndexTTS 2.5, CosyVoice, or
   another sidecar engine, its isolated venv lives under the app-config folder
   above and is removed with it.
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -200,7 +200,7 @@ Full HF token guide: [docs/setup/huggingface-token.md](../setup/huggingface-toke
 
 <a id="torch-compile-oom"></a>
 
-On Windows, certain TTS engines (notably IndexTTS-2 and some CosyVoice paths)
+On Windows, certain TTS engines (notably IndexTTS 2.5 and some CosyVoice paths)
 trigger `torch.compile` / Triton kernel compilation during the first
 synthesise call. On machines with <16 GB VRAM, that compile step can OOM
 *before* the audio render even begins — the error usually surfaces as

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -81,7 +81,7 @@ None of them are required — the defaults are chosen for the common case.
 | Variable | Default | What it does |
 |---|---|---|
 | `OMNIVOICE_IDLE_TIMEOUT_S` | `900` | Seconds of idle before the TTS model unloads to free memory. Raise it (e.g. `3600`) if you generate in bursts and dislike the ~8 s reload; lower it on tight-memory machines. |
-| `OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S` | `300` | Same idea for sidecar engines (IndexTTS-2 etc.). |
+| `OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S` | `300` | Same idea for sidecar engines (IndexTTS 2.5 etc.). |
 | `OMNIVOICE_LLM_CONCURRENCY` | `6` | Parallel LLM translation calls during a dub. Raise for a fast API endpoint, lower if your provider rate-limits. |
 | `OMNIVOICE_GPU_WORKERS` | auto | Concurrent generations on the GPU. Auto-sized from free VRAM (1 worker per 5 GB, max 4); MPS and CPU always get 1. **Do not raise this on ≤10 GB cards or Apple Silicon** — two concurrent jobs over-committing VRAM is exactly the crash class (#567) the auto-sizing exists to prevent. |
 | `OMNIVOICE_CPU_POOL` | `min(8, cores)` | Thread pool for CPU-side work (translation dispatch, audio I/O). |

--- a/docs/setup/huggingface-token.md
+++ b/docs/setup/huggingface-token.md
@@ -91,7 +91,7 @@ downloads work. Visit each page while signed in with the same HF account:
 - `pyannote/speaker-diarization-3.1` — required for diarization.
   See [docs/features/diarization.md](../features/diarization.md).
 - `pyannote/segmentation-3.0` — required transitively by the above.
-- `IndexTeam/IndexTTS-2` — required if you use IndexTTS for voice cloning.
+- `IndexTeam/IndexTTS-2.5` — required if you use IndexTTS 2.5 for voice cloning.
 - `Supertone/supertonic-3` — required if you enable the Supertonic-3 engine.
 - `kyutai/pocket-tts` — required if you enable PocketTTS; first accept its
   access conditions on Hugging Face, then use a token from the same account.

--- a/tests/backend/services/test_indextts_sidecar.py
+++ b/tests/backend/services/test_indextts_sidecar.py
@@ -511,23 +511,26 @@ def test_sidecar_25_requires_language_and_drops_legacy_target_tokens():
     assert "target_tokens" not in kwargs
 
 
-def test_public_duration_changes_indextts25_wire_factor():
-    """The public duration field must not become a no-op on IndexTTS 2.5."""
+@pytest.mark.parametrize(("duration", "expected"), [(0.5, 0.5), (2.0, 2.0)])
+def test_public_duration_maps_to_exact_indextts25_factor(duration, expected):
+    """The public duration field must reach the 2.5 sidecar boundary."""
+    from engines.indextts import _duration_factor
     from engines.indextts import main as sidecar
 
-    short = sidecar._build_infer_kwargs(
-        {"text": "hello", "lang": "en", "target_tokens": 21, "duration_factor": 0.5},
-        "/tmp/ref.wav",
+    # Fifteen English characters are one natural second in the shared model.
+    factor = _duration_factor("abcdefghijklmno", "en", duration)
+    kwargs = sidecar._build_infer_kwargs(
+        {
+            "text": "abcdefghijklmno",
+            "lang": "en",
+            "target_tokens": int(duration * 21),
+            "duration_factor": factor,
+        },
+        "ref.wav",
         is_v25=True,
     )
-    long = sidecar._build_infer_kwargs(
-        {"text": "hello", "lang": "en", "target_tokens": 84, "duration_factor": 2.0},
-        "/tmp/ref.wav",
-        is_v25=True,
-    )
-    assert short["duration_factor"] < long["duration_factor"]
-    assert "target_tokens" not in short
-    assert "target_tokens" not in long
+    assert kwargs["duration_factor"] == expected
+    assert "target_tokens" not in kwargs
 
 
 def test_sidecar_25_uses_25_config_and_gates_bf16(monkeypatch):

--- a/tests/backend/services/test_indextts_sidecar.py
+++ b/tests/backend/services/test_indextts_sidecar.py
@@ -218,6 +218,7 @@ def test_synthesize_forwards_emotion_kwargs_via_vector(monkeypatch, patched_inde
     assert payload["use_random"] is True
     # duration=2.0 → target_tokens = int(2.0 * 21) = 42
     assert payload["target_tokens"] == 42
+    assert payload["duration_factor"] == pytest.approx(2.0)
     # The losing modalities are dropped — sidecar never sees them.
     assert "emo_audio_prompt" not in payload
     assert "emo_text" not in payload
@@ -508,6 +509,25 @@ def test_sidecar_25_requires_language_and_drops_legacy_target_tokens():
     assert kwargs["lang"] == "es"
     assert kwargs["duration_factor"] == 1.2
     assert "target_tokens" not in kwargs
+
+
+def test_public_duration_changes_indextts25_wire_factor():
+    """The public duration field must not become a no-op on IndexTTS 2.5."""
+    from engines.indextts import main as sidecar
+
+    short = sidecar._build_infer_kwargs(
+        {"text": "hello", "lang": "en", "target_tokens": 21, "duration_factor": 0.5},
+        "/tmp/ref.wav",
+        is_v25=True,
+    )
+    long = sidecar._build_infer_kwargs(
+        {"text": "hello", "lang": "en", "target_tokens": 84, "duration_factor": 2.0},
+        "/tmp/ref.wav",
+        is_v25=True,
+    )
+    assert short["duration_factor"] < long["duration_factor"]
+    assert "target_tokens" not in short
+    assert "target_tokens" not in long
 
 
 def test_sidecar_25_uses_25_config_and_gates_bf16(monkeypatch):

--- a/tests/backend/services/test_indextts_sidecar.py
+++ b/tests/backend/services/test_indextts_sidecar.py
@@ -311,9 +311,14 @@ def test_generate_requires_ref_audio(patched_indextts_backend):
 
 
 def test_indextts25_languages_and_unknown_language_fallback(
-    monkeypatch, patched_indextts_backend,
+    monkeypatch, patched_indextts_backend, tmp_path,
 ):
     backend = patched_indextts_backend
+    checkout = tmp_path / "index-tts"
+    module = checkout / "indextts" / "infer_v2_5.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("class IndexTTS2: pass\n")
+    monkeypatch.setenv("OMNIVOICE_INDEXTTS_DIR", str(checkout))
     assert backend.supported_languages == ["zh", "en", "ja", "es", "ar"]
     sent = []
     original_send = SubprocessBackend._send
@@ -326,6 +331,17 @@ def test_indextts25_languages_and_unknown_language_fallback(
     monkeypatch.setattr(SubprocessBackend, "_send", spy_send)
     backend.generate("hello", ref_audio="/tmp/ref.wav", language="fr-FR")
     assert sent[0]["lang"] == "en"
+
+
+def test_user_managed_indextts2_keeps_legacy_language_metadata(
+    monkeypatch, patched_indextts_backend, tmp_path,
+):
+    checkout = tmp_path / "index-tts-v2"
+    legacy_module = checkout / "indextts" / "infer_v2.py"
+    legacy_module.parent.mkdir(parents=True)
+    legacy_module.write_text("class IndexTTS2: pass\n")
+    monkeypatch.setenv("OMNIVOICE_INDEXTTS_DIR", str(checkout))
+    assert patched_indextts_backend.supported_languages == ["zh", "en"]
 
 
 @pytest.mark.parametrize(

--- a/tests/backend/services/test_indextts_sidecar.py
+++ b/tests/backend/services/test_indextts_sidecar.py
@@ -7,16 +7,18 @@ subprocess-isolated IndexTTS2Backend can both serve generate() from the
 SAME Python session. The two transformers versions can no longer
 collide because IndexTTS runs in a different OS process.
 
-Real IndexTTS-2 model load is ~20 s cold and depends on a ~6 GB model
-download — these tests use a mock sidecar fixture
+Real IndexTTS 2.5 model load is expensive and depends on multi-GB weights.
+These tests use a mock sidecar fixture
 (``tests/fixtures/mock_indextts_sidecar.py``) that mimics the
 production wire protocol without importing the indextts library.
 """
 from __future__ import annotations
 
+import io
 import json
 import struct
 import sys
+import types
 from pathlib import Path
 from typing import Iterator
 
@@ -154,9 +156,8 @@ def test_list_backends_includes_indextts_with_subprocess_isolation_mode():
     entries = {e["id"]: e for e in list_backends()}
     assert "indextts2" in entries
     assert entries["indextts2"]["isolation_mode"] == "subprocess"
-    # display_name was preserved verbatim from the legacy class.
     assert entries["indextts2"]["display_name"] == (
-        "IndexTTS2 (emotion control, duration control, zero-shot)"
+        "IndexTTS 2.5 (multilingual emotion-controlled cloning)"
     )
 
 
@@ -198,6 +199,7 @@ def test_synthesize_forwards_emotion_kwargs_via_vector(monkeypatch, patched_inde
     audio = backend.generate(
         "hi",
         ref_audio="/tmp/ref.wav",
+        language="ja-JP",
         emo_vector=[1, 0, 0, 0, 0, 0, 0, 0],
         emo_audio="/tmp/should_be_ignored.wav",
         emo_text="should_be_ignored",
@@ -211,6 +213,7 @@ def test_synthesize_forwards_emotion_kwargs_via_vector(monkeypatch, patched_inde
     assert payload["op"] == "synthesize"
     assert payload["text"] == "hi"
     assert payload["ref_audio"] == "/tmp/ref.wav"
+    assert payload["lang"] == "ja"
     assert payload["emo_vector"] == [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     assert payload["use_random"] is True
     # duration=2.0 → target_tokens = int(2.0 * 21) = 42
@@ -305,6 +308,42 @@ def test_generate_requires_ref_audio(patched_indextts_backend):
     early so the sidecar isn't woken up on a no-op."""
     with pytest.raises(RuntimeError, match="reference audio"):
         patched_indextts_backend.generate("hello", ref_audio=None)
+
+
+def test_indextts25_languages_and_unknown_language_fallback(
+    monkeypatch, patched_indextts_backend,
+):
+    backend = patched_indextts_backend
+    assert backend.supported_languages == ["zh", "en", "ja", "es", "ar"]
+    sent = []
+    original_send = SubprocessBackend._send
+
+    def spy_send(self, msg):
+        if msg.get("op") == "synthesize":
+            sent.append(dict(msg))
+        return original_send(self, msg)
+
+    monkeypatch.setattr(SubprocessBackend, "_send", spy_send)
+    backend.generate("hello", ref_audio="/tmp/ref.wav", language="fr-FR")
+    assert sent[0]["lang"] == "en"
+
+
+@pytest.mark.parametrize(
+    ("language", "text", "expected"),
+    [
+        ("Japanese", "hello", "ja"),
+        ("es-MX", "hola", "es"),
+        ("Auto", "مرحبا", "ar"),
+        (None, "こんにちは", "ja"),
+        (None, "你好", "zh"),
+    ],
+)
+def test_indextts25_language_labels_and_auto_script_detection(
+    language, text, expected,
+):
+    from engines.indextts import _normalize_indextts25_language
+
+    assert _normalize_indextts25_language(language, text) == expected
 
 
 # ── #42 closure: in-process OmniVoice + subprocess IndexTTS coexist ───────
@@ -432,7 +471,118 @@ def test_no_indextts_import_in_tts_backend():
 def test_sidecar_imports_indextts():
     """backend/engines/indextts/main.py imports indextts (lazy, inside fn)."""
     src = (REPO_ROOT / "backend" / "engines" / "indextts" / "main.py").read_text()
-    assert "from indextts.infer_v2 import IndexTTS2" in src, (
-        "sidecar must import IndexTTS2 from indextts.infer_v2 (it's the "
-        "real model loader). See bootstrap.py for venv resolution."
+    assert "from indextts.infer_v2_5 import IndexTTS2" in src
+    assert "from indextts.infer_v2 import IndexTTS2" in src
+
+
+def test_sidecar_25_requires_language_and_drops_legacy_target_tokens():
+    from engines.indextts import main as sidecar
+
+    kwargs = sidecar._build_infer_kwargs(
+        {
+            "text": "hola",
+            "lang": "ES",
+            "target_tokens": 84,
+            "duration_factor": 1.2,
+            "emo_vector": [1.0, 0, 0, 0, 0, 0, 0, 0],
+        },
+        "/tmp/ref.wav",
+        is_v25=True,
     )
+    assert kwargs["lang"] == "es"
+    assert kwargs["duration_factor"] == 1.2
+    assert "target_tokens" not in kwargs
+
+
+def test_sidecar_25_uses_25_config_and_gates_bf16(monkeypatch):
+    from engines.indextts import main as sidecar
+
+    monkeypatch.setattr(sidecar, "_torch_bf16_supported", lambda: False)
+    kwargs = sidecar._model_init_kwargs(
+        "/models/index-tts", version="2.5", reduced_precision=True,
+    )
+    assert kwargs["cfg_path"].endswith("checkpoints/config_v2_5.yaml")
+    assert kwargs["use_bf16"] is False
+    assert kwargs["use_qwen_emo"] is True
+
+    monkeypatch.setattr(sidecar, "_torch_bf16_supported", lambda: True)
+    assert sidecar._model_init_kwargs(
+        "/models/index-tts", version="2.5", reduced_precision=True,
+    )["use_bf16"] is True
+
+
+def test_sidecar_loader_prefers_25_and_uses_reviewed_weight_layout(monkeypatch):
+    from engines.indextts import main as sidecar
+
+    captured = {}
+
+    class FakeIndexTTS:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    package = types.ModuleType("indextts")
+    package.__path__ = []
+    module = types.ModuleType("indextts.infer_v2_5")
+    module.IndexTTS2 = FakeIndexTTS
+    monkeypatch.setitem(sys.modules, "indextts", package)
+    monkeypatch.setitem(sys.modules, "indextts.infer_v2_5", module)
+    monkeypatch.setenv("OMNIVOICE_INDEXTTS_DIR", "/models/index-tts")
+    monkeypatch.setattr(sidecar, "_torch_bf16_supported", lambda: True)
+    monkeypatch.setattr(sidecar, "_model", None)
+    monkeypatch.setattr(sidecar, "_model_version", None)
+
+    loaded = sidecar._load_model(io.BytesIO())
+
+    assert isinstance(loaded, FakeIndexTTS)
+    assert sidecar._model_version == "2.5"
+    assert captured["cfg_path"].endswith("checkpoints/config_v2_5.yaml")
+    assert captured["model_dir"].endswith("checkpoints")
+    assert captured["use_qwen_emo"] is True
+
+
+def test_sidecar_loader_keeps_user_managed_v2_compatibility(monkeypatch):
+    from engines.indextts import main as sidecar
+
+    captured = {}
+
+    class FakeIndexTTS:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    package = types.ModuleType("indextts")
+    package.__path__ = []
+    legacy_module = types.ModuleType("indextts.infer_v2")
+    legacy_module.IndexTTS2 = FakeIndexTTS
+    monkeypatch.setitem(sys.modules, "indextts", package)
+    monkeypatch.delitem(sys.modules, "indextts.infer_v2_5", raising=False)
+    monkeypatch.setitem(sys.modules, "indextts.infer_v2", legacy_module)
+    monkeypatch.setenv("OMNIVOICE_INDEXTTS_DIR", "/models/index-tts-v2")
+    monkeypatch.setattr(sidecar, "_model", None)
+    monkeypatch.setattr(sidecar, "_model_version", None)
+
+    loaded = sidecar._load_model(io.BytesIO())
+
+    assert isinstance(loaded, FakeIndexTTS)
+    assert sidecar._model_version == "2"
+    assert captured["cfg_path"].endswith("checkpoints/config.yaml")
+    assert captured["use_fp16"] is True
+    assert "use_qwen_emo" not in captured
+
+
+def test_sidecar_2_fallback_keeps_target_tokens_and_drops_25_only_kwargs():
+    from engines.indextts import main as sidecar
+
+    kwargs = sidecar._build_infer_kwargs(
+        {"text": "hello", "lang": "en", "target_tokens": 42, "duration_factor": 1.2},
+        "/tmp/ref.wav",
+        is_v25=False,
+    )
+    assert kwargs["target_tokens"] == 42
+    assert "lang" not in kwargs
+    assert "duration_factor" not in kwargs
+    model_kwargs = sidecar._model_init_kwargs(
+        "/models/index-tts", version="2", reduced_precision=True,
+    )
+    assert model_kwargs["cfg_path"].endswith("checkpoints/config.yaml")
+    assert model_kwargs["use_fp16"] is True
+    assert "use_qwen_emo" not in model_kwargs

--- a/tests/test_sidecar_install.py
+++ b/tests/test_sidecar_install.py
@@ -650,12 +650,14 @@ def test_indextts25_health_requires_25_config_name(monkeypatch):
     assert si._healthy(spec) is True
 
 
-def test_managed_indextts2_source_without_25_module_is_replaced(monkeypatch):
+def test_managed_indextts2_source_is_preserved_during_25_install(monkeypatch):
     spec = si.get_spec("indextts2")
+    legacy = si.managed_root(spec) / "index-tts"
+    legacy.mkdir(parents=True)
+    (legacy / "pyproject.toml").write_text("[project]\nname='indextts'\n")
+    (legacy / "old-v2-only.txt").write_text("old")
+    monkeypatch.setenv(spec.env_var, str(legacy))
     checkout = si.managed_checkout(spec)
-    checkout.mkdir(parents=True)
-    (checkout / "pyproject.toml").write_text("[project]\nname='indextts'\n")
-    (checkout / "old-v2-only.txt").write_text("old")
     argvs = []
 
     def fake_run(job, argv, *, timeout, env=None):
@@ -675,7 +677,7 @@ def test_managed_indextts2_source_without_25_module_is_replaced(monkeypatch):
     si._step_fetch_source(spec, job)
     clone = next(argv for argv in argvs if argv[1] == "clone")
     assert clone[clone.index("--branch") + 1] == "indextts-2.5"
-    assert not (checkout / "old-v2-only.txt").exists()
+    assert (legacy / "old-v2-only.txt").read_text() == "old"
     assert si._source_present(spec, checkout)
 
 

--- a/tests/test_sidecar_install.py
+++ b/tests/test_sidecar_install.py
@@ -75,7 +75,7 @@ def _fake_run_logged(created: list):
     def run(job, argv, *, timeout, env=None):
         created.append(argv)
         prog = os.path.basename(argv[0])
-        if prog.startswith("git"):
+        if prog.startswith("git") and argv[1] == "clone":
             checkout = Path(argv[-1])
             checkout.mkdir(parents=True, exist_ok=True)
             (checkout / "pyproject.toml").write_text("[project]\nname='fake'\n")
@@ -365,14 +365,23 @@ def test_half_fetched_checkout_is_refetched(monkeypatch):
     assert any(a[1] == "clone" for a in argvs)
 
 
-def _write_weights(wdir: Path, *, complete: bool) -> None:
+def _write_weights(
+    wdir: Path,
+    *,
+    complete: bool,
+    repo_id: str = "Example/Weights",
+    revision: str = "",
+    config_name: str = "config.yaml",
+) -> None:
     """Fabricate a weights dir; ``complete=True`` adds the completion marker
     the installer writes after snapshot_download returns."""
     wdir.mkdir(parents=True, exist_ok=True)
-    (wdir / "config.yaml").write_text("model: fake\n")
+    (wdir / config_name).write_text("model: fake\n")
     (wdir / "weights.safetensors").write_bytes(b"\0" * (6 * 1024 * 1024))
     if complete:
-        (wdir / si._WEIGHTS_COMPLETE_MARKER).write_text("Example/Weights\n")
+        (wdir / si._WEIGHTS_COMPLETE_MARKER).write_text(
+            f"{repo_id}\n{revision}\n",
+        )
 
 
 def test_partial_install_is_not_already_installed(monkeypatch):
@@ -380,6 +389,8 @@ def test_partial_install_is_not_already_installed(monkeypatch):
     instead of short-circuiting with already_installed."""
     spec = _mk_spec(weights_repo_id="Example/Weights")
     checkout = si.managed_checkout(spec)
+    checkout.mkdir(parents=True, exist_ok=True)
+    (checkout / "pyproject.toml").write_text("[project]\nname='fake'\n")
     py = si._venv_python(checkout / ".venv")
     py.parent.mkdir(parents=True)
     py.write_text("#!fake\n")
@@ -397,6 +408,8 @@ def test_interrupted_multishard_weights_are_not_healthy(monkeypatch):
     already_installed and failing later at model-load time."""
     spec = _mk_spec(weights_repo_id="Example/Weights")
     checkout = si.managed_checkout(spec)
+    checkout.mkdir(parents=True, exist_ok=True)
+    (checkout / "pyproject.toml").write_text("[project]\nname='fake'\n")
     py = si._venv_python(checkout / ".venv")
     py.parent.mkdir(parents=True)
     py.write_text("#!fake\n")
@@ -437,6 +450,35 @@ def test_weights_step_downloads_via_endpoint_autoselect(monkeypatch):
     assert si._weights_present(spec)
 
 
+def test_weights_revision_is_pinned_and_old_marker_forces_upgrade(monkeypatch):
+    spec = _mk_spec(
+        weights_repo_id="Example/Weights",
+        weights_revision="a" * 40,
+    )
+    wdir = si.managed_checkout(spec) / spec.weights_subdir
+    _write_weights(wdir, complete=True)  # legacy default-branch marker
+    assert si._weights_present(spec) is False
+
+    seen = {}
+
+    def fake_snapshot_download(**kwargs):
+        seen.update(kwargs)
+        _write_weights(
+            Path(kwargs["local_dir"]), complete=False,
+            repo_id=kwargs["repo_id"], revision=kwargs["revision"],
+        )
+
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr("services.endpoint_race.effective_endpoint", lambda: None)
+    monkeypatch.setattr("services.token_resolver.resolve", lambda: None)
+    job = si._new_job(spec.engine_id)
+    si._job_step(job, "fetch_weights")["state"] = "running"
+    si._step_fetch_weights(spec, job)
+    assert seen["revision"] == "a" * 40
+    assert si._weights_present(spec) is True
+
+
 def test_weights_step_skips_when_already_present(monkeypatch):
     spec = _mk_spec(weights_repo_id="Example/Weights")
     wdir = si.managed_checkout(spec) / spec.weights_subdir
@@ -463,6 +505,8 @@ def test_healthy_managed_install_reheals_lost_env_var(monkeypatch):
     spec = _mk_spec(weights_repo_id="Example/Weights")
     monkeypatch.setitem(si.SPECS, "fake-side", spec)
     checkout = si.managed_checkout(spec)
+    checkout.mkdir(parents=True, exist_ok=True)
+    (checkout / "pyproject.toml").write_text("[project]\nname='fake'\n")
     py = si._venv_python(checkout / ".venv")
     py.parent.mkdir(parents=True)
     py.write_text("#!fake\n")
@@ -568,12 +612,71 @@ def test_indextts2_spec_matches_bootstrap_contract():
     # The env var must be the one engines/indextts/bootstrap.py actually
     # reads — anything else would install into a dir the engine never finds.
     assert spec.env_var == "OMNIVOICE_INDEXTTS_DIR"
-    assert spec.probe_module == "indextts.infer_v2"
-    # main.py loads from <dir>/checkpoints/config.yaml (verified) — the
+    assert spec.probe_module == "indextts.infer_v2_5"
+    # main.py loads from <dir>/checkpoints/config_v2_5.yaml — the
     # installer must put the weights exactly there.
-    assert spec.weights_repo_id == "IndexTeam/IndexTTS-2"
+    assert spec.repo_ref == "indextts-2.5"
+    assert spec.source_revision == "bf2e967fac7933197143b017a60820b1ad40c448"
+    assert spec.source_required_path == "indextts/infer_v2_5.py"
+    assert spec.weights_repo_id == "IndexTeam/IndexTTS-2.5"
+    assert spec.weights_revision == "d0aa86e75bb6f3437f3831e95056fa72842d89ef"
     assert spec.weights_subdir == "checkpoints"
+    assert spec.weights_config_name == "config_v2_5.yaml"
     assert spec.repo_url.endswith("index-tts.git")
+
+
+def test_indextts25_health_requires_25_config_name(monkeypatch):
+    spec = si.get_spec("indextts2")
+    monkeypatch.setenv(spec.env_var, str(si.managed_checkout(spec)))
+    checkout = si.managed_checkout(spec)
+    required = checkout / spec.source_required_path
+    required.parent.mkdir(parents=True, exist_ok=True)
+    required.write_text("class IndexTTS2: pass\n")
+    (checkout / "pyproject.toml").write_text("[project]\nname='indextts'\n")
+    (checkout / si._SOURCE_REVISION_MARKER).write_text(f"{spec.source_revision}\n")
+    py = si._venv_python(checkout / ".venv")
+    py.parent.mkdir(parents=True)
+    py.write_text("#!fake\n")
+    wdir = checkout / spec.weights_subdir
+    _write_weights(
+        wdir,
+        complete=True,
+        repo_id=spec.weights_repo_id,
+        revision=spec.weights_revision,
+    )
+    assert si._healthy(spec) is False
+    (wdir / "config.yaml").unlink()
+    (wdir / "config_v2_5.yaml").write_text("model: fake\n")
+    assert si._healthy(spec) is True
+
+
+def test_managed_indextts2_source_without_25_module_is_replaced(monkeypatch):
+    spec = si.get_spec("indextts2")
+    checkout = si.managed_checkout(spec)
+    checkout.mkdir(parents=True)
+    (checkout / "pyproject.toml").write_text("[project]\nname='indextts'\n")
+    (checkout / "old-v2-only.txt").write_text("old")
+    argvs = []
+
+    def fake_run(job, argv, *, timeout, env=None):
+        argvs.append(argv)
+        if argv[1] == "clone":
+            checkout.mkdir(parents=True, exist_ok=True)
+            (checkout / "pyproject.toml").write_text("[project]\nname='indextts'\n")
+            required = checkout / spec.source_required_path
+            required.parent.mkdir(parents=True, exist_ok=True)
+            required.write_text("class IndexTTS2: pass\n")
+        return 0
+
+    monkeypatch.setattr(si.shutil, "which", lambda n: "/usr/bin/git")
+    monkeypatch.setattr(si, "_run_logged", fake_run)
+    job = si._new_job(spec.engine_id)
+    si._job_step(job, "fetch_source")["state"] = "running"
+    si._step_fetch_source(spec, job)
+    clone = next(argv for argv in argvs if argv[1] == "clone")
+    assert clone[clone.index("--branch") + 1] == "indextts-2.5"
+    assert not (checkout / "old-v2-only.txt").exists()
+    assert si._source_present(spec, checkout)
 
 
 def test_indextts2_env_var_in_settings_allowlist():

--- a/tests/test_sidecar_install.py
+++ b/tests/test_sidecar_install.py
@@ -596,6 +596,20 @@ def test_uninstall_refuses_user_managed_clone(monkeypatch, tmp_path):
     assert os.environ["OMNIVOICE_FAKE_SIDE_DIR"] == str(user_clone)  # never cleared
 
 
+def test_uninstall_clears_legacy_managed_preference(monkeypatch):
+    spec = si.get_spec("indextts2")
+    legacy = si.managed_root(spec) / "index-tts"
+    legacy.mkdir(parents=True)
+    monkeypatch.setenv(spec.env_var, str(legacy))
+    deleted = []
+    monkeypatch.setattr("core.prefs.get", lambda k, d=None: str(legacy))
+    monkeypatch.setattr("core.prefs.delete", lambda k: deleted.append(k))
+
+    assert si.uninstall(spec.engine_id)["status"] == "uninstalled"
+    assert spec.env_var not in os.environ
+    assert deleted == [f"env.{spec.env_var}"]
+
+
 def test_uninstall_refuses_while_job_running(monkeypatch):
     spec = _mk_spec()
     monkeypatch.setitem(si.SPECS, "fake-side", spec)


### PR DESCRIPTION
## Summary
- install reviewed IndexTTS 2.5 source and model revisions through the existing sidecar flow
- support required language routing, 2.5 config/BF16 handling, emotion controls, and dubbing timing integration
- preserve user-managed IndexTTS-2 environments as a tested fallback
- update engine docs, README tables, licensing, and troubleshooting

## Validation
- 278 focused backend, installer, backward-compatibility, docs, locale, changelog, and policy tests passed offline
- engine registry/API checks passed offline
- docs inventory and Python compilation passed

Closes #1482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds native IndexTTS 2.5 support through the sidecar flow with pinned source and model revisions, multilingual routing, emotion and duration controls, BF16 handling, and dubbing timing integration. Preserves user-managed IndexTTS-2 environments through legacy fallback and updates documentation, licensing, and troubleshooting. Review managed-checkout replacement and version-specific inference configuration for compatibility with existing installations and hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->