### PR TITLE
fix: stop extracted AppImage before prod reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Linux production test launches now stop their own extracted AppImage before resetting SQLite and logs. (#1494)
 - Restored the pre-release version to 0.4.2 while the next release remains in preparation. (#1488)
 - Large multi-language dubbing batches now use compact searchable language and track managers instead of overflowing the editor. (#1492)
 - Multi-language dubbing now translates, edits, generates, retains, and exports every selected language, and its language picker stays visible at viewport edges. (#1486)

--- a/scripts/desktop-prod.sh
+++ b/scripts/desktop-prod.sh
@@ -29,10 +29,15 @@ set -euo pipefail
 # …) is repo-root-relative, so invoking the script from any other directory
 # used to mis-resolve them (#962 hardening).
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+REPO_ROOT="$(pwd -P)"
 
 APP_ID="com.debpalash.omnivoice-studio"
 TAURI_DIR="frontend/src-tauri"
 APP_NAME="VoiceStudio"
+TAURI_BUILD_ROOT="$REPO_ROOT/$TAURI_DIR/target/debug"
+if [ -d "$TAURI_BUILD_ROOT" ]; then
+  TAURI_BUILD_ROOT="$(cd "$TAURI_BUILD_ROOT" && pwd -P)"
+fi
 
 # ── Detect platform ───────────────────────────────────────────────────────
 OS="$(uname -s)"
@@ -170,6 +175,18 @@ kill_running_instances() {
   # both live under `${TAURI_DIR}/target/debug/`, and `pgrep -f` sees the
   # absolute path, of which that is a substring.
   pids="$(pgrep -f "${TAURI_DIR}/target/debug/.*omnivoice-studio" 2>/dev/null || true)"
+  # APPIMAGE_EXTRACT_AND_RUN replaces the command with a /tmp extraction path,
+  # so pgrep cannot connect the live shell (or its inherited backend) to this
+  # checkout. APPIMAGE remains in both processes' environments and is the
+  # stable ownership proof. Missing this case let a fresh run delete the live
+  # SQLite/log directory, then single-instance merely refocused the broken app.
+  if [ "$PLATFORM" = "linux" ]; then
+    local appimage_pids
+    appimage_pids="$(python3 scripts/desktop_prod_processes.py "$TAURI_BUILD_ROOT")"
+    if [ -n "$appimage_pids" ]; then
+      echo "🔪 Terminated extracted VoiceStudio AppImage processes: $(echo "$appimage_pids" | tr '\n' ' ')"
+    fi
+  fi
   warn_installed_instance
   local port_pid
   for port_pid in $(lsof -nP -iTCP:3900 -sTCP:LISTEN -t 2>/dev/null || true); do

--- a/scripts/desktop_prod_processes.py
+++ b/scripts/desktop_prod_processes.py
@@ -32,11 +32,18 @@ def appimage_belongs_to_build(raw: bytes, build_root: Path) -> bool:
     )
 
 
+def _process_start_time(process_dir: Path) -> str:
+    """Return Linux /proc stat field 22 without splitting a spaced comm field."""
+    fields_after_comm = (process_dir / "stat").read_text().rsplit(") ", 1)[1].split()
+    return fields_after_comm[19]
+
+
 def open_owned_processes(
     build_root: Path,
     proc_root: Path = Path("/proc"),
     *,
     pidfd_open: Callable[[int, int], int] | None = None,
+    read_start_time: Callable[[Path], str] = _process_start_time,
 ) -> list[tuple[int, int]]:
     """Open identity-bound handles before inspecting each candidate process."""
     if pidfd_open is None:
@@ -49,15 +56,17 @@ def open_owned_processes(
             continue
         pid = int(process_dir.name)
         try:
+            start_before = read_start_time(process_dir)
             pidfd = pidfd_open(pid, 0)
         except (OSError, ProcessLookupError):
             continue
         try:
             raw = (process_dir / "environ").read_bytes()
+            start_after = read_start_time(process_dir)
         except (OSError, PermissionError):
             os.close(pidfd)
             continue
-        if appimage_belongs_to_build(raw, build_root):
+        if start_before == start_after and appimage_belongs_to_build(raw, build_root):
             owned.append((pid, pidfd))
             continue
         os.close(pidfd)
@@ -71,6 +80,14 @@ def _signal_process(pidfd: int, sig: signal.Signals) -> None:
         return
 
 
+def _poll_exited(poller: select.poll, pending: set[int], deadline: float) -> set[int]:
+    exited: set[int] = set()
+    while time.monotonic() < deadline and exited != pending:
+        remaining_ms = max(0, int((deadline - time.monotonic()) * 1000))
+        exited.update(fd for fd, _ in poller.poll(min(remaining_ms, 100)))
+    return exited
+
+
 def stop_owned_processes(build_root: Path, timeout_s: float = 5.0) -> list[int]:
     """Stop only processes held by pidfds, preventing PID-reuse termination."""
     owned = open_owned_processes(build_root)
@@ -82,16 +99,19 @@ def stop_owned_processes(build_root: Path, timeout_s: float = 5.0) -> list[int]:
         poller.register(pidfd, select.POLLIN)
         _signal_process(pidfd, signal.SIGTERM)
 
-    deadline = time.monotonic() + timeout_s
-    exited: set[int] = set()
-    while time.monotonic() < deadline and len(exited) < len(owned):
-        remaining_ms = max(0, int((deadline - time.monotonic()) * 1000))
-        exited.update(fd for fd, _ in poller.poll(min(remaining_ms, 100)))
+    pending = {pidfd for _, pidfd in owned}
+    exited = _poll_exited(poller, pending, time.monotonic() + timeout_s)
+    killed = pending - exited
+    for pidfd in killed:
+        _signal_process(pidfd, signal.SIGKILL)
+
+    if killed:
+        exited.update(_poll_exited(poller, killed, time.monotonic() + timeout_s))
 
     for _, pidfd in owned:
-        if pidfd not in exited:
-            _signal_process(pidfd, signal.SIGKILL)
         os.close(pidfd)
+    if exited != pending:
+        raise RuntimeError("VoiceStudio processes did not exit; refusing to reset app data")
     return [pid for pid, _ in owned]
 
 

--- a/scripts/desktop_prod_processes.py
+++ b/scripts/desktop_prod_processes.py
@@ -54,13 +54,21 @@ def open_owned_processes(
             continue
         try:
             raw = (process_dir / "environ").read_bytes()
-            if appimage_belongs_to_build(raw, build_root):
-                owned.append((pid, pidfd))
-                continue
         except (OSError, PermissionError):
-            pass
+            os.close(pidfd)
+            continue
+        if appimage_belongs_to_build(raw, build_root):
+            owned.append((pid, pidfd))
+            continue
         os.close(pidfd)
     return owned
+
+
+def _signal_process(pidfd: int, sig: signal.Signals) -> None:
+    try:
+        signal.pidfd_send_signal(pidfd, sig)
+    except ProcessLookupError:
+        return
 
 
 def stop_owned_processes(build_root: Path, timeout_s: float = 5.0) -> list[int]:
@@ -72,10 +80,7 @@ def stop_owned_processes(build_root: Path, timeout_s: float = 5.0) -> list[int]:
     poller = select.poll()
     for _, pidfd in owned:
         poller.register(pidfd, select.POLLIN)
-        try:
-            signal.pidfd_send_signal(pidfd, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
+        _signal_process(pidfd, signal.SIGTERM)
 
     deadline = time.monotonic() + timeout_s
     exited: set[int] = set()
@@ -85,10 +90,7 @@ def stop_owned_processes(build_root: Path, timeout_s: float = 5.0) -> list[int]:
 
     for _, pidfd in owned:
         if pidfd not in exited:
-            try:
-                signal.pidfd_send_signal(pidfd, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+            _signal_process(pidfd, signal.SIGKILL)
         os.close(pidfd)
     return [pid for pid, _ in owned]
 

--- a/scripts/desktop_prod_processes.py
+++ b/scripts/desktop_prod_processes.py
@@ -1,0 +1,106 @@
+"""Safely stop Linux AppImage processes owned by this checkout."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import select
+import signal
+import time
+from typing import Callable
+
+
+def _appimage_from_environ(raw: bytes) -> str | None:
+    for item in raw.split(b"\0"):
+        if item.startswith(b"APPIMAGE="):
+            return os.fsdecode(item.removeprefix(b"APPIMAGE="))
+    return None
+
+
+def appimage_belongs_to_build(raw: bytes, build_root: Path) -> bool:
+    """Require an exact debug AppImage directory and VoiceStudio filename."""
+    value = _appimage_from_environ(raw)
+    if not value:
+        return False
+    image = Path(os.path.normpath(value))
+    expected_dir = build_root / "bundle" / "appimage"
+    return (
+        image.parent == expected_dir
+        and image.name.startswith("VoiceStudio_")
+        and image.name.endswith(".AppImage")
+    )
+
+
+def open_owned_processes(
+    build_root: Path,
+    proc_root: Path = Path("/proc"),
+    *,
+    pidfd_open: Callable[[int, int], int] | None = None,
+) -> list[tuple[int, int]]:
+    """Open identity-bound handles before inspecting each candidate process."""
+    if pidfd_open is None:
+        pidfd_open = getattr(os, "pidfd_open", None)
+        if pidfd_open is None:
+            raise RuntimeError("Linux pidfd support is required")
+    owned: list[tuple[int, int]] = []
+    for process_dir in sorted(proc_root.iterdir(), key=lambda path: path.name):
+        if not process_dir.name.isdecimal():
+            continue
+        pid = int(process_dir.name)
+        try:
+            pidfd = pidfd_open(pid, 0)
+        except (OSError, ProcessLookupError):
+            continue
+        try:
+            raw = (process_dir / "environ").read_bytes()
+            if appimage_belongs_to_build(raw, build_root):
+                owned.append((pid, pidfd))
+                continue
+        except (OSError, PermissionError):
+            pass
+        os.close(pidfd)
+    return owned
+
+
+def stop_owned_processes(build_root: Path, timeout_s: float = 5.0) -> list[int]:
+    """Stop only processes held by pidfds, preventing PID-reuse termination."""
+    owned = open_owned_processes(build_root)
+    if not owned:
+        return []
+
+    poller = select.poll()
+    for _, pidfd in owned:
+        poller.register(pidfd, select.POLLIN)
+        try:
+            signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+    deadline = time.monotonic() + timeout_s
+    exited: set[int] = set()
+    while time.monotonic() < deadline and len(exited) < len(owned):
+        remaining_ms = max(0, int((deadline - time.monotonic()) * 1000))
+        exited.update(fd for fd, _ in poller.poll(min(remaining_ms, 100)))
+
+    for _, pidfd in owned:
+        if pidfd not in exited:
+            try:
+                signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        os.close(pidfd)
+    return [pid for pid, _ in owned]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build_root", type=Path)
+    args = parser.parse_args()
+    for pid in stop_owned_processes(args.build_root):
+        print(pid)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -18,6 +18,7 @@ to remember belongs in a test, not in anyone's head.
 import importlib.util
 import json
 import os
+import subprocess
 
 import pytest
 
@@ -208,10 +209,54 @@ def test_linux_extracted_appimage_and_backend_are_stopped_before_wipe(tmp_path):
     assert found == ["101", "102"]
     assert [pid for pid, _ in opened] == [101, 102, 201, 202, 203]
 
-    src = open(_SH, encoding="utf-8").read()
-    call = 'python3 scripts/desktop_prod_processes.py "$TAURI_BUILD_ROOT"'
-    assert call in src
-    assert src.index(call) < src.index('if [ "$KEEP_DATA" = false ]; then')
+
+
+def test_linux_process_stop_executes_before_data_wipe(tmp_path):
+    """Execute the shell with controlled commands and record the true order."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    order_log = tmp_path / "order.log"
+    backend_data = tmp_path / "home" / ".omnivoice"
+    backend_data.mkdir(parents=True)
+    marker = backend_data / "order-marker"
+    marker.write_text("live backend data")
+
+    fake_python = fake_bin / "python3"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        '[ "$1" = scripts/desktop_prod_processes.py ] || exit 90\n'
+        '[ -f "$ORDER_MARKER" ] || exit 91\n'
+        'printf "stop-before-wipe\\n" >> "$ORDER_LOG"\n'
+    )
+    fake_python.chmod(0o755)
+    for command in ("pgrep", "lsof"):
+        stub = fake_bin / command
+        stub.write_text("#!/bin/sh\nexit 1\n")
+        stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "XDG_DATA_HOME": str(tmp_path / "xdg"),
+            "ORDER_LOG": str(order_log),
+            "ORDER_MARKER": str(marker),
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+        }
+    )
+    result = subprocess.run(
+        ["bash", _SH, "--skip-build"],
+        cwd=_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    # No build artifact exists in this fixture, so launch fails only after the
+    # stop and wipe steps have both executed.
+    assert result.returncode != 0
+    assert order_log.read_text().splitlines() == ["stop-before-wipe"]
+    assert not backend_data.exists()
 
 
 def test_linux_pid_reuse_is_rejected_after_environment_read(tmp_path):

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -19,6 +19,8 @@ import importlib.util
 import json
 import os
 
+import pytest
+
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _PKG = os.path.join(_ROOT, "package.json")
 _SH = os.path.join(_ROOT, "scripts", "desktop-prod.sh")
@@ -168,6 +170,10 @@ def test_linux_extracted_appimage_and_backend_are_stopped_before_wipe(tmp_path):
         (process_dir / "environ").write_bytes(
             ("\0".join(environment) + "\0").encode()
         )
+        # field 22 (starttime) is index 19 after the closing comm parenthesis.
+        (process_dir / "stat").write_text(
+            f"{pid} (VoiceStudio worker) S " + " ".join(["0"] * 18 + [str(pid)])
+        )
 
     owned = build_root / "bundle" / "appimage" / "VoiceStudio_0.4.2_amd64.AppImage"
     process(101, f"APPIMAGE={owned}", "HOME=/home/test")
@@ -206,3 +212,68 @@ def test_linux_extracted_appimage_and_backend_are_stopped_before_wipe(tmp_path):
     call = 'python3 scripts/desktop_prod_processes.py "$TAURI_BUILD_ROOT"'
     assert call in src
     assert src.index(call) < src.index('if [ "$KEEP_DATA" = false ]; then')
+
+
+def test_linux_pid_reuse_is_rejected_after_environment_read(tmp_path):
+    build_root = tmp_path / "repo" / "frontend" / "src-tauri" / "target" / "debug"
+    proc_root = tmp_path / "proc"
+    process_dir = proc_root / "101"
+    process_dir.mkdir(parents=True)
+    owned = build_root / "bundle" / "appimage" / "VoiceStudio_0.4.2_amd64.AppImage"
+    (process_dir / "environ").write_bytes(f"APPIMAGE={owned}\0".encode())
+
+    spec = importlib.util.spec_from_file_location(
+        "desktop_prod_processes_reuse", _APPIMAGE_PROCESSES
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    identities = iter(["old-start", "replacement-start"])
+    opened_fds = []
+
+    def fake_pidfd_open(pid: int, flags: int) -> int:
+        fd = os.open(os.devnull, os.O_RDONLY)
+        opened_fds.append(fd)
+        return fd
+
+    found = module.open_owned_processes(
+        build_root,
+        proc_root,
+        pidfd_open=fake_pidfd_open,
+        read_start_time=lambda _path: next(identities),
+    )
+
+    assert found == []
+    for fd in opened_fds:
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+
+def test_reset_waits_for_killed_process_exit_or_fails(monkeypatch, tmp_path):
+    spec = importlib.util.spec_from_file_location(
+        "desktop_prod_processes_exit", _APPIMAGE_PROCESSES
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def run(exits_after_kill: bool) -> tuple[list[int] | None, list[int]]:
+        fd = os.open(os.devnull, os.O_RDONLY)
+        monkeypatch.setattr(module, "open_owned_processes", lambda _root: [(101, fd)])
+        polls = iter([set(), {fd} if exits_after_kill else set()])
+        monkeypatch.setattr(module, "_poll_exited", lambda *_args: next(polls))
+        sent = []
+        monkeypatch.setattr(module, "_signal_process", lambda _fd, sig: sent.append(sig))
+        try:
+            return module.stop_owned_processes(tmp_path), sent
+        except RuntimeError:
+            return None, sent
+
+    result, sent = run(True)
+    assert result == [101]
+    assert sent == [module.signal.SIGTERM, module.signal.SIGKILL]
+
+    result, sent = run(False)
+    assert result is None
+    assert sent == [module.signal.SIGTERM, module.signal.SIGKILL]

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -19,6 +19,7 @@ import importlib.util
 import json
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -210,7 +211,7 @@ def test_linux_extracted_appimage_and_backend_are_stopped_before_wipe(tmp_path):
     assert [pid for pid, _ in opened] == [101, 102, 201, 202, 203]
 
 
-
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux AppImage process contract")
 def test_linux_process_stop_executes_before_data_wipe(tmp_path):
     """Execute the shell with controlled commands and record the true order."""
     fake_bin = tmp_path / "bin"
@@ -245,7 +246,7 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
         }
     )
     result = subprocess.run(
-        ["bash", _SH, "--skip-build"],
+        ["/bin/bash", _SH, "--skip-build"],  # noqa: S603
         cwd=_ROOT,
         env=env,
         capture_output=True,

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -15,12 +15,14 @@ have to opt out of it.
 Mechanical on purpose (token-economy convention): a rule a reviewer would have
 to remember belongs in a test, not in anyone's head.
 """
+import importlib.util
 import json
 import os
 
 _ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _PKG = os.path.join(_ROOT, "package.json")
 _SH = os.path.join(_ROOT, "scripts", "desktop-prod.sh")
+_APPIMAGE_PROCESSES = os.path.join(_ROOT, "scripts", "desktop_prod_processes.py")
 
 # Scripts whose NAME promises a re-launch of an existing build rather than a
 # fresh-install emulation. Add new aliases here when they appear.
@@ -148,3 +150,59 @@ def test_kill_is_scoped_to_this_checkouts_build():
         "an installed instance is neither killed nor mentioned; single-instance "
         "will swallow the launch and the developer gets no explanation"
     )
+
+
+def test_linux_extracted_appimage_and_backend_are_stopped_before_wipe(tmp_path):
+    """Extraction hides the checkout path from argv, but APPIMAGE survives.
+
+    Reproduce the production failure with a fake procfs: the Tauri process and
+    backend inherit the same owned APPIMAGE, while a similarly named build from
+    another checkout and an unrelated process must remain untouched.
+    """
+    build_root = tmp_path / "repo" / "frontend" / "src-tauri" / "target" / "debug"
+    proc_root = tmp_path / "proc"
+
+    def process(pid: int, *environment: str) -> None:
+        process_dir = proc_root / str(pid)
+        process_dir.mkdir(parents=True)
+        (process_dir / "environ").write_bytes(
+            ("\0".join(environment) + "\0").encode()
+        )
+
+    owned = build_root / "bundle" / "appimage" / "VoiceStudio_0.4.2_amd64.AppImage"
+    process(101, f"APPIMAGE={owned}", "HOME=/home/test")
+    process(102, f"APPIMAGE={owned}", "ROLE=backend")
+    process(
+        201,
+        f"APPIMAGE={build_root}-other/bundle/appimage/VoiceStudio_0.4.2_amd64.AppImage",
+    )
+    process(202, f"APPIMAGE={owned}.untrusted")
+    process(203, "HOME=/home/test")
+
+    spec = importlib.util.spec_from_file_location(
+        "desktop_prod_processes", _APPIMAGE_PROCESSES
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    opened = []
+
+    def fake_pidfd_open(pid: int, flags: int) -> int:
+        opened.append((pid, flags))
+        return os.open(os.devnull, os.O_RDONLY)
+
+    owned = module.open_owned_processes(
+        build_root, proc_root, pidfd_open=fake_pidfd_open
+    )
+    found = [str(pid) for pid, _ in owned]
+    for _, pidfd in owned:
+        os.close(pidfd)
+
+    assert found == ["101", "102"]
+    assert [pid for pid, _ in opened] == [101, 102, 201, 202, 203]
+
+    src = open(_SH, encoding="utf-8").read()
+    call = 'python3 scripts/desktop_prod_processes.py "$TAURI_BUILD_ROOT"'
+    assert call in src
+    assert src.index(call) < src.index('if [ "$KEEP_DATA" = false ]; then')


### PR DESCRIPTION
## Summary
- identify Linux AppImage shells and inherited backend workers from the checkout-owned APPIMAGE path
- stop them through pidfds before desktop-prod resets data, preventing PID-reuse kills
- regress the exact extracted-command and inherited-backend failure

## Validation
- 33 targeted launcher/changelog/identity tests passed
- real AppImage two-relaunch test stopped the first shell/backend tree and launched the second
- packaged AppImage completed DB migrations and returned health/settings routes without SQLite or logger errors

CodeRabbit review required. No Greptile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Linux `desktop-prod` now stops checkout-owned extracted AppImage shells and inherited backend workers with pidfds before resetting desktop data. This prevents PID-reuse kills and covers extracted-command and inherited-backend failures. Risk: Linux cleanup depends on pidfd support and correct build-root matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->