### PR TITLE
fix: restore dub tracks and identify worker ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Dub language and export selections now restore without false schema warnings, and remote-worker port 7443 is identified instead of reported as a generic timeout. (#1504)
 - A configured remote backend now bypasses local first-run setup, verifies itself before app requests begin, and shows recovery instead of leaving the desktop stuck on Setup. (#1503)
 - An idle voice model now actually hands its memory back. The unload emptied the GPU cache a moment before releasing the model, so it freed nothing while reporting success — a GPU machine lending its card sat on 3.6 GB indefinitely. (#1495)
 - Unloading a model on an NVIDIA GPU now returns the last ~770 MB too. A single 8.5 MB cuBLAS workspace sat inside the model's memory block and kept the whole block reserved, so an idle machine held 1.2 GB instead of 470 MB no matter how often you pressed Flush Memory. (#1495)

--- a/frontend/src/test/omniUiSchema.test.js
+++ b/frontend/src/test/omniUiSchema.test.js
@@ -39,13 +39,27 @@ describe('sanitizeOmniUi', () => {
       language: 'en',
       isSidebarCollapsed: false,
       dubSegments: [{ id: '1', text: 'x' }],
+      dubTracks: ['es', 'fr'],
       dubStep: 'editing',
+      exportTracks: { original: true, es: false },
       preserveBg: true,
       speed: 1,
       steps: 16,
       cfg: 2,
     };
     expect(sanitizeOmniUi({ ...good })).toEqual(good);
+  });
+
+  it('rejects swapped persisted track shapes without dropping valid track state', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(
+      sanitizeOmniUi({
+        dubTracks: ['es'],
+        exportTracks: { original: true, es: false },
+      }),
+    ).toEqual({ dubTracks: ['es'], exportTracks: { original: true, es: false } });
+    expect(sanitizeOmniUi({ dubTracks: {}, exportTracks: [] })).toEqual({});
+    warn.mockRestore();
   });
 
   it('schema covers every field the restore path reads', () => {

--- a/frontend/src/utils/omniUiSchema.js
+++ b/frontend/src/utils/omniUiSchema.js
@@ -39,10 +39,10 @@ export const OMNI_UI_SCHEMA = {
   dubSegments: isArrOfObj,
   dubLang: isStr,
   dubLangCode: isStr,
-  dubTracks: isObj,
+  dubTracks: isArr,
   dubStep: isStr, // additionally clamped by clampRestoredDubStep (#1067)
   dubTranscript: isStr,
-  exportTracks: isArr,
+  exportTracks: isObj,
   preserveBg: isBool,
   defaultTrack: isStr,
   exportHistory: isArr,

--- a/frontend/src/utils/remoteBackendProbe.test.ts
+++ b/frontend/src/utils/remoteBackendProbe.test.ts
@@ -41,6 +41,7 @@ describe('remote backend probe', () => {
     ['https://gpu-box:3900', new TypeError('blocked by CORS policy'), 'cors'],
     ['http://gpu-box:3900', new TypeError('Failed to fetch'), 'network'],
     ['https://gpu-box:7443', new TypeError('Failed to fetch'), 'wrong_port'],
+    ['https://gpu-box:7443', new DOMException('aborted', 'AbortError'), 'wrong_port'],
   ])('classifies %s transport failures as %s', async (url, error, kind) => {
     const result = await probeRemoteBackend(url, '', {
       fetchImpl: vi.fn().mockRejectedValue(error),

--- a/frontend/src/utils/remoteBackendProbe.ts
+++ b/frontend/src/utils/remoteBackendProbe.ts
@@ -28,8 +28,8 @@ export function disableRemoteBackend(reload: () => void): void {
 
 function transportKind(url: URL, error: unknown): RemoteProbeKind {
   const text = String((error as Error)?.message || error).toLowerCase();
-  if ((error as Error)?.name === 'AbortError') return 'timeout';
   if (url.port === '7443') return 'wrong_port';
+  if ((error as Error)?.name === 'AbortError') return 'timeout';
   if (/certificate|cert_|ssl|tls/.test(text)) return 'tls';
   if (/cors|cross-origin/.test(text)) return 'cors';
   // Browser fetch deliberately hides DNS, connection, CORS, and TLS details


### PR DESCRIPTION
Fixes two persisted UI validators that rejected valid dub/export track state, and reports port 7443 as the remote-worker control port even when its HTTP probe times out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Corrects persisted UI validation so `dubTracks` arrays and `exportTracks` objects are restored without discarding other valid state. Classifies port `7443` as `wrong_port` before timeout handling, including `AbortError` probes, to identify remote-worker control ports correctly. Review validator compatibility with persisted state and port-specific probe precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->