### PR TITLE
fix(tests): synchronize worker identity persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Worker restart coverage now waits for the registration response to persist its identity instead of racing the client callback in CI. (#1505)
 - Dub language and export selections now restore without false schema warnings, and remote-worker port 7443 is identified instead of reported as a generic timeout. (#1504)
 - A configured remote backend now bypasses local first-run setup, verifies itself before app requests begin, and shows recovery instead of leaving the desktop stuck on Setup. (#1503)
 - An idle voice model now actually hands its memory back. The unload emptied the GPU cache a moment before releasing the model, so it freed nothing while reporting success — a GPU machine lending its card sat on 3.6 GB indefinitely. (#1495)

--- a/tests/test_worker_transport.py
+++ b/tests/test_worker_transport.py
@@ -949,6 +949,15 @@ async def test_a_restarted_worker_reconnects_without_a_new_token(harness, tmp_pa
         await agent.start(token_text=token.encode())
         await harness._await_connection()
         first_id = registry.list_workers()[0].id
+        # The server publishes its session before the registration response
+        # reaches the client. Wait for that response callback to persist the
+        # id instead of racing its filesystem write.
+        deadline = asyncio.get_running_loop().time() + 2.0
+        while (
+            worker_agent.load_worker_id(monkey_paths["worker_id"]) != first_id
+            and asyncio.get_running_loop().time() < deadline
+        ):
+            await asyncio.sleep(0.01)
         assert worker_agent.load_worker_id(monkey_paths["worker_id"]) == first_id
 
         # The process goes away.

--- a/tests/test_worker_transport.py
+++ b/tests/test_worker_transport.py
@@ -919,7 +919,9 @@ def test_certificate_regenerates_when_an_explicit_listener_host_is_added(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_a_restarted_worker_reconnects_without_a_new_token(harness, tmp_path):
+async def test_a_restarted_worker_reconnects_without_a_new_token(
+    harness, tmp_path, monkeypatch
+):
     """Key-based identity is pointless if a restart needs a fresh token.
 
     The challenge signature binds to the worker id, so a worker that does not
@@ -939,6 +941,14 @@ async def test_a_restarted_worker_reconnects_without_a_new_token(harness, tmp_pa
     }
     original_paths = worker_agent._paths
     worker_agent._paths = lambda: monkey_paths
+    persisted = asyncio.Event()
+    original_save_worker_id = worker_agent.save_worker_id
+
+    def save_worker_id(path, worker_id):
+        original_save_worker_id(path, worker_id)
+        persisted.set()
+
+    monkeypatch.setattr(worker_agent, "save_worker_id", save_worker_id)
     try:
         # First run: enroll with a token, exactly as a new machine would.
         token = registry.create_enrollment(
@@ -952,12 +962,7 @@ async def test_a_restarted_worker_reconnects_without_a_new_token(harness, tmp_pa
         # The server publishes its session before the registration response
         # reaches the client. Wait for that response callback to persist the
         # id instead of racing its filesystem write.
-        deadline = asyncio.get_running_loop().time() + 2.0
-        while (
-            worker_agent.load_worker_id(monkey_paths["worker_id"]) != first_id
-            and asyncio.get_running_loop().time() < deadline
-        ):
-            await asyncio.sleep(0.01)
+        await asyncio.wait_for(persisted.wait(), timeout=2.0)
         assert worker_agent.load_worker_id(monkey_paths["worker_id"]) == first_id
 
         # The process goes away.


### PR DESCRIPTION
Fixes the post-merge main CI race where the server session became visible before the worker processed the registration response and persisted its assigned identity. The regression now waits boundedly for that client-side persistence boundary.\n\nValidation: 43 worker transport tests pass offline with an empty Hugging Face cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The worker restart test now waits up to two seconds for persisted worker identity after registration. This removes the CI race between session publication and client-side persistence. The bounded wait may need review if registration can exceed two seconds in slow environments; 43 offline worker transport tests pass with an empty Hugging Face cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->