### PR TITLE
fix(release): validate wrapped AppImage launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           bash frontend/src-tauri/appimage/AppRun.test.sh
           bash scripts/inject-apprun.test.sh
+          bash scripts/verify-apprun-bundle.test.sh
 
       # `backend/tests/` mounts routers on bare FastAPI apps (no heavy main
       # import chain) with a hermetic data dir from its conftest.py. It no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -751,17 +751,13 @@ jobs:
           "$APPIMAGE" --appimage-extract >/dev/null
           ROOT="$EXTRACT_DIR/squashfs-root"
           fail() { echo "FAIL — $1"; find "$ROOT" -maxdepth 5 -type f 2>/dev/null | head -40; exit 1; }
-          # Regression gate: beforeBundleCommand runs before Tauri creates the
-          # AppDir. The v0.4.2 artifact therefore silently shipped Tauri's
-          # stock AppRun and bypassed every WebKit/Mesa compatibility fix.
-          cmp -s "$ROOT/AppRun" "$GITHUB_WORKSPACE/frontend/src-tauri/appimage/AppRun" \
-            || fail "custom AppRun missing from final AppImage"
-          [ -s "$ROOT/usr/lib/.bundled-webkitgtk-version" ] \
-            || fail "bundled WebKitGTK version marker missing"
-          cmp -s \
-            "$ROOT/usr/lib/.bundled-webkitgtk-version" \
-            "$GITHUB_WORKSPACE/frontend/src-tauri/target/.tauri/bundled-webkitgtk-version" \
-            || fail "bundled WebKitGTK version marker is stale or mismatched"
+          # linuxdeploy's GTK/GStreamer hooks wrap the seeded launcher as
+          # AppRun.wrapped. Verify the complete launcher chain, not only the
+          # small hook runner installed at the AppImage root.
+          bash "$GITHUB_WORKSPACE/scripts/verify-apprun-bundle.sh" \
+            "$ROOT" \
+            "$GITHUB_WORKSPACE/frontend/src-tauri/appimage/AppRun" \
+            "$GITHUB_WORKSPACE/frontend/src-tauri/target/.tauri/bundled-webkitgtk-version"
           # Thin uv-venv installer: verify the AppImage carries the shell binary,
           # the bundled uv sidecar, and the backend source resources.
           { [ -f "$ROOT/AppRun" ] || find "$ROOT" -type f \( -name "VoiceStudio" -o -name "omnivoice-studio" \) | grep -q .; } || fail "shell binary / AppRun missing"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### CI
 
+- Linux release smoke now validates linuxdeploy's wrapped custom launcher instead of rejecting a healthy AppImage. (#1506)
 - The stdio wire protocol every engine sidecar speaks is now tested once across all nine of them, instead of against a single engine — a bug in any one sidecar's copy gets caught — thanks @paoloantinori! (#1408)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Changed
 
+- Linux release smoke now validates linuxdeploy's wrapped custom launcher instead of rejecting a healthy AppImage. (#1506)
 - Remote GPU workers render audiobooks chapter by chapter, with automatic per-chapter local fallback and one combined notice if the worker drops out. (#1478)
 - Remote GPU workers can now run a job to completion: long renders no longer die at two minutes, a worker that drops and reconnects mid-render keeps its work, and a timed-out job no longer takes the worker offline for good. Placing a job still needs the development-only `POST /workers/tasks`; wiring the app's own Synthesize button to it comes next.
 - Voice, Stories, Audiobook, Gallery, Settings, profiles, and Launchpad now use compact, responsive layouts with accessible controls. (#1491)
@@ -58,7 +59,6 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### CI
 
-- Linux release smoke now validates linuxdeploy's wrapped custom launcher instead of rejecting a healthy AppImage. (#1506)
 - The stdio wire protocol every engine sidecar speaks is now tested once across all nine of them, instead of against a single engine — a bug in any one sidecar's copy gets caught — thanks @paoloantinori! (#1408)
 
 ### Fixed

--- a/frontend/src-tauri/src/reset.rs
+++ b/frontend/src-tauri/src/reset.rs
@@ -386,7 +386,7 @@ pub async fn reset_purge(app: tauri::AppHandle, scopes: Vec<String>) -> Result<R
         .filter(|s| DISK_SCOPES.contains(&s.as_str()))
         .collect();
 
-    let mut report = ResetReport::default();
+    let report = ResetReport::default();
     if wanted.is_empty() {
         return Ok(report);
     }

--- a/scripts/verify-apprun-bundle.sh
+++ b/scripts/verify-apprun-bundle.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:?AppDir root is required}"
+EXPECTED_APPRUN="${2:?expected AppRun is required}"
+EXPECTED_MARKER="${3:?expected WebKitGTK marker is required}"
+
+fail() {
+  echo "FAIL — $1" >&2
+  exit 1
+}
+
+[ -x "$ROOT/AppRun" ] || fail "final AppImage launcher is missing or not executable"
+
+if cmp -s "$ROOT/AppRun" "$EXPECTED_APPRUN"; then
+  : # linuxdeploy did not install launcher hooks.
+elif [ -x "$ROOT/AppRun.wrapped" ] \
+  && cmp -s "$ROOT/AppRun.wrapped" "$EXPECTED_APPRUN" \
+  && grep -Fq 'exec "$this_dir"/AppRun.wrapped "$@"' "$ROOT/AppRun"; then
+  : # GTK/GStreamer hooks wrap the custom launcher by design.
+else
+  fail "custom AppRun missing from final AppImage launcher chain"
+fi
+
+[ -s "$ROOT/usr/lib/.bundled-webkitgtk-version" ] \
+  || fail "bundled WebKitGTK version marker missing"
+cmp -s "$ROOT/usr/lib/.bundled-webkitgtk-version" "$EXPECTED_MARKER" \
+  || fail "bundled WebKitGTK version marker is stale or mismatched"
+
+echo "OK — AppImage uses the custom launcher and current WebKitGTK marker"

--- a/scripts/verify-apprun-bundle.test.sh
+++ b/scripts/verify-apprun-bundle.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERIFY="$REPO_ROOT/scripts/verify-apprun-bundle.sh"
+EXPECTED="$REPO_ROOT/frontend/src-tauri/appimage/AppRun"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+make_root() {
+  local root="$1"
+  mkdir -p "$root/usr/lib"
+  printf '%s\n' '2.52.3' > "$root/usr/lib/.bundled-webkitgtk-version"
+}
+
+printf '%s\n' '2.52.3' > "$TMP/expected-marker"
+
+make_root "$TMP/direct"
+install -m 755 "$EXPECTED" "$TMP/direct/AppRun"
+bash "$VERIFY" "$TMP/direct" "$EXPECTED" "$TMP/expected-marker"
+
+make_root "$TMP/wrapped"
+install -m 755 "$EXPECTED" "$TMP/wrapped/AppRun.wrapped"
+cat > "$TMP/wrapped/AppRun" <<'WRAPPER'
+#!/usr/bin/env bash
+this_dir="$(dirname "$(readlink -f "${0}")")"
+exec "$this_dir"/AppRun.wrapped "$@"
+WRAPPER
+chmod 755 "$TMP/wrapped/AppRun"
+bash "$VERIFY" "$TMP/wrapped" "$EXPECTED" "$TMP/expected-marker"
+
+make_root "$TMP/broken"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$TMP/broken/AppRun"
+chmod 755 "$TMP/broken/AppRun"
+if bash "$VERIFY" "$TMP/broken" "$EXPECTED" "$TMP/expected-marker" >/dev/null 2>&1; then
+  echo "FAIL: stock launcher was accepted without the custom launcher" >&2
+  exit 1
+fi
+
+echo "PASS: direct, wrapped, and broken AppImage launcher chains classified"


### PR DESCRIPTION
Fixes the false-negative Linux installer smoke in Desktop Release run 31574128771. linuxdeploy intentionally places VoiceStudio's custom launcher at AppRun.wrapped and installs a delegating root AppRun; the old smoke compared only the wrapper.\n\nThis adds a tested verifier for direct and wrapped launcher layouts, exercises it in CI/release, and removes the observed Rust reset warning. The exact failed-run AppImage and a fresh local release AppImage both pass the verifier. Version remains 0.4.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
AppImage release validation now accepts direct and wrapped `AppRun` layouts and verifies the bundled WebKitGTK marker. CI and release workflows use the shared verifier, with regression tests for valid and broken launcher chains. Human review should confirm coverage of all supported packaging layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->