### PR TITLE
fix(asr): degrade past a broken engine on every transcription path (#1512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ### Fixed
 
 - The Linux app icon is no longer blank: the AppImage shipped `.DirIcon` as a symlink into the machine that built it, so file managers and app menus drew nothing. (#1518)
+- Transcription, dubbing, batch and QC now degrade to the next working speech-recognition engine when the auto-picked one fails to load, instead of failing the request while a healthy engine is installed. (#1512)
 - The Linux desktop entry no longer ships an empty `Categories=`, which `desktop-file-validate` rejects and menu builders skip. (#1518)
 - The Simplified Chinese (zh-CN) translation no longer mistranslates brand names and technical terms — Discord, Tailscale, Hugging Face, IPA, and LLM (Cinematic) were rendered as nonsensical literal translations, and ~250 more awkward machine-translation strings are now natural Chinese. (#1508) — thanks @anyingiit!
 - Worker restart coverage now waits for the registration response to persist its identity instead of racing the client callback in CI. (#1505)

--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -151,14 +151,20 @@ async def _run_batch_pipeline(job_id: str, job: dict):
     # ── 2. Transcribe ─────────────────────────────────────────────────
     _set_progress(job, "transcribe", 0)
 
-    from services.asr_backend import get_active_asr_backend
+    from services.asr_backend import load_active_asr_backend
     from services.model_manager import _gpu_pool, _cpu_pool, run_on_gpu_pool_guarded
     from services.segmentation import (
         segment_transcript, assign_speakers_heuristic,
     )
 
     def _transcribe():
-        backend = get_active_asr_backend()
+        # Loading selector (#1512): degrades past an engine whose deep import
+        # chain is broken instead of failing the job while a healthy engine
+        # works. An ASRModelMissingError from a weightless fallback propagates
+        # to _worker's structured job-failure handling, same as any other
+        # transcribe-stage error (the submit route already preflights the
+        # initial selection).
+        backend = load_active_asr_backend()
         result = backend.transcribe(audio_path, word_timestamps=True)
         detected_lang = result.get("language", "en")
         segments = segment_transcript(result, duration=duration)

--- a/backend/api/routers/capture.py
+++ b/backend/api/routers/capture.py
@@ -8,7 +8,7 @@ raw audio bytes and get back transcribed text immediately.  Used by:
     • The MCP server's future `transcribe_audio` tool
     • CLI consumers that just want speech-to-text
 
-The ASR engine is whatever `get_active_asr_backend()` returns — WhisperX
+The ASR engine is whatever `load_active_asr_backend()` returns — WhisperX
 by default, or MLX Whisper on Apple Silicon when configured.
 """
 from __future__ import annotations
@@ -97,8 +97,11 @@ async def transcribe_audio(
             if use_accurate:
                 # Accurate mode: full WhisperX with forced alignment —
                 # for when the user explicitly wants word-level timing.
-                from services.asr_backend import get_active_asr_backend
-                backend = get_active_asr_backend()
+                # Loading selector (#1512): degrades past an engine whose deep
+                # import chain is broken instead of 500ing the request while a
+                # healthy engine is next in line.
+                from services.asr_backend import load_active_asr_backend
+                backend = load_active_asr_backend()
                 result = backend.transcribe(tmp.name, word_timestamps=True)
             else:
                 # Fast mode (default): use the fastest available engine
@@ -110,11 +113,23 @@ async def transcribe_audio(
             return result, backend.id
 
         from services.model_manager import _gpu_pool
-        from services.asr_backend import ASRTimeoutError, run_transcribe_guarded
+        from services.asr_backend import (
+            ASRModelMissingError,
+            ASRTimeoutError,
+            run_transcribe_guarded,
+        )
         t0 = time.perf_counter()
         try:
             result, engine_id = await run_transcribe_guarded(
                 _gpu_pool, _run, what="Dictation",
+            )
+        except ASRModelMissingError as e:
+            # Accurate mode degraded past a broken engine to a fallback whose
+            # weights aren't installed (#1512) — same typed 409 + download CTA
+            # as the preflight above.
+            raise HTTPException(
+                status_code=409,
+                detail={**e.payload, "message": asr_model_missing_detail(e.payload)},
             )
         except ASRTimeoutError as e:
             # Backend is alive — ASR couldn't finish. 504 with guidance, not a

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -688,7 +688,7 @@ async def dub_transcribe_stream(
             preflight_error = "Job not found. It may have been cleaned up or was never created."
         else:
             # The TTS core model is loaded here for exactly one reason: to harvest a
-            # preloaded `_asr_pipe` off it (passed to get_active_asr_backend below).
+            # preloaded `_asr_pipe` off it (passed to load_active_asr_backend below).
             # That attribute is only ever set by VoiceStudio.from_pretrained under
             # OMNIVOICE_PRELOAD_TTS_ASR, which is off by default — so in the default
             # config this loaded ~3 GB, harvested None, and then offload_tts_for_asr()
@@ -1657,6 +1657,7 @@ async def dub_transcribe(job_id: str, num_speakers: Optional[int] = None):
     # a preloaded `_asr_pipe` only substitutes for the *pytorch-whisper*
     # backend (its sole consumer), so it only skips the preflight there.
     from services.asr_backend import (
+        ASRModelMissingError,
         active_backend_id,
         asr_model_missing_detail,
         asr_model_missing_error,
@@ -1687,8 +1688,11 @@ async def dub_transcribe(job_id: str, num_speakers: Optional[int] = None):
         # / mlx / pytorch based on what's installed + user preference. Works
         # identically on all platforms; the older mlx-vs-pytorch branching
         # here duplicated the logic in asr_backend.py and skipped WhisperX.
-        from services.asr_backend import get_active_asr_backend
-        _asr = get_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
+        # Loading selector (#1512): degrades past an engine whose deep import
+        # chain is broken instead of 500ing the request while a healthy engine
+        # is next in line — same loader the SSE endpoint already uses.
+        from services.asr_backend import load_active_asr_backend
+        _asr = load_active_asr_backend(asr_pipe=getattr(_model, "_asr_pipe", None))
         try:
             try:
                 logger.info("Transcribing full audio via %s ...", _asr.id)
@@ -1792,6 +1796,13 @@ async def dub_transcribe(job_id: str, num_speakers: Optional[int] = None):
         raise
     except asyncio.CancelledError:
         raise
+    except ASRModelMissingError as e:
+        # A broken primary degraded to a fallback whose weights aren't
+        # installed — same typed 409 + download CTA as the preflight above.
+        raise HTTPException(
+            status_code=409,
+            detail={**e.payload, "message": asr_model_missing_detail(e.payload)},
+        )
     except Exception as e:
         import traceback
         traceback.print_exc()

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -1434,16 +1434,29 @@ async def dub_qc_pass(job_id: str, lang: str = Query(None), drift_threshold: flo
         )
 
     def _recognize():
-        from services.asr_backend import get_active_asr_backend
-        backend = get_active_asr_backend()
+        # Loading selector (#1512): degrades past an engine whose deep import
+        # chain is broken instead of failing QC while a healthy engine works.
+        from services.asr_backend import load_active_asr_backend
+        backend = load_active_asr_backend()
         result = backend.transcribe(wav_path, word_timestamps=False)
         return result.get("segments", []), backend.id
 
     try:
-        from services.asr_backend import ASRTimeoutError, run_transcribe_guarded
+        from services.asr_backend import (
+            ASRModelMissingError,
+            ASRTimeoutError,
+            run_transcribe_guarded,
+        )
         from services.model_manager import _get_gpu_pool
         recognized, engine_id = await run_transcribe_guarded(
             _get_gpu_pool(), _recognize, what="QC",
+        )
+    except ASRModelMissingError as e:
+        # A broken primary degraded to a fallback whose weights aren't
+        # installed — same typed 409 + download CTA as the preflight above.
+        raise HTTPException(
+            status_code=409,
+            detail={**e.payload, "message": asr_model_missing_detail(e.payload)},
         )
     except ASRTimeoutError as e:
         # Backend is alive; ASR just couldn't finish in time. 504, not 500/connection.

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -517,9 +517,10 @@ async def create_transcription(
 ):
     """Transcribe audio to text. Compatible with OpenAI's POST /v1/audio/transcriptions."""
     from services.asr_backend import (
+        ASRModelMissingError,
         asr_model_missing_detail,
         asr_model_missing_error,
-        get_active_asr_backend,
+        load_active_asr_backend,
     )
 
     # TTS-only install: no ASR model on disk → actionable 409, BEFORE any
@@ -546,18 +547,21 @@ async def create_transcription(
         raise HTTPException(status_code=400, detail=f"Could not read audio file: {e}")
 
     try:
-        backend = get_active_asr_backend()
-
-        # Run transcription in the thread pool to avoid blocking the event loop,
-        # bounded so a stuck/starved ASR returns a 504 with guidance instead of
+        # Select + eagerly load the engine, then transcribe — all in the thread
+        # pool. The LOADING selector (not the pure, construct-only one)
+        # degrades past an engine whose deep import chain is broken instead of
+        # 500ing the request while a healthy engine is next in line (#1512),
+        # and a possibly minutes-long first load never blocks the event loop.
+        # Bounded so a stuck/starved ASR returns a 504 with guidance instead of
         # hanging the request forever (see run_transcribe_guarded).
         from services.asr_backend import run_transcribe_guarded
         word_ts = response_format == "verbose_json"
-        result = await run_transcribe_guarded(
-            _gpu_pool,
-            lambda: backend.transcribe(tmp_path, word_timestamps=word_ts),
-            what="OpenAI",
-        )
+
+        def _run():
+            backend = load_active_asr_backend()
+            return backend.transcribe(tmp_path, word_timestamps=word_ts)
+
+        result = await run_transcribe_guarded(_gpu_pool, _run, what="OpenAI")
 
         # Extract the full text from segments
         segments = result.get("segments", [])
@@ -625,6 +629,13 @@ async def create_transcription(
 
     except HTTPException:
         raise
+    except ASRModelMissingError as e:
+        # A broken primary degraded to a fallback whose weights aren't
+        # installed — same typed 409 + download CTA as the preflight above.
+        raise HTTPException(
+            status_code=409,
+            detail={**e.payload, "message": asr_model_missing_detail(e.payload)},
+        )
     except TimeoutError as e:
         # ASRTimeoutError (subclass): backend alive, ASR too heavy for compute.
         logger.warning("OpenAI transcription timed out: %s", e)

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -2697,6 +2697,18 @@ def transcribe_reference(audio_path: str) -> str | None:
         # model load it lazily rather than constructing a second copy here.
         return None
     try:
+        try:
+            backend.ensure_loaded()
+        except ImportError:
+            # Deep-import env rot (#1185): the loading selector records the
+            # broken engine and degrades to the next candidate, instead of
+            # giving up on the reference transcript while a healthy engine
+            # is installed (#1512).
+            backend = load_active_asr_backend()
+            if isinstance(backend, PyTorchWhisperBackend):
+                # Degraded all the way to the last resort — defer to the
+                # model-attached pipeline exactly as if it were picked first.
+                return None
         result = backend.transcribe(audio_path, word_timestamps=False)
     except Exception as e:  # noqa: BLE001 — degrade to the model fallback
         logger.warning(

--- a/backend/tests/test_asr_deep_import_fallback.py
+++ b/backend/tests/test_asr_deep_import_fallback.py
@@ -124,3 +124,24 @@ def test_every_candidate_broken_raises_instead_of_looping(monkeypatch):
     assert set(ab._DEEP_IMPORT_BROKEN) == {
         "whisperx", "faster-whisper", "pytorch-whisper",
     }
+
+
+def test_transcribe_reference_degrades_past_broken_engine(monkeypatch, tmp_path):
+    """#1512: the voice-clone reference transcript used the pure selector, so
+    a broken-import engine degraded it to None (silently skipping the
+    transcript) even with a healthy engine next in line. The loading selector
+    transcribes with the fallback instead."""
+    monkeypatch.setattr(ab.WhisperXBackend, "ensure_loaded", _broken("lightning_fabric"))
+    monkeypatch.setattr(ab.FasterWhisperBackend, "ensure_loaded", lambda self: None)
+    monkeypatch.setattr(
+        ab.FasterWhisperBackend, "transcribe",
+        lambda self, path, *, word_timestamps=True: {"text": "hello reference"},
+    )
+    clip = tmp_path / "ref-1512.wav"
+    clip.write_bytes(b"RIFF-1512-fake-audio")
+    with ab._ref_transcript_lock:
+        ab._ref_transcript_cache.clear()
+
+    assert ab.transcribe_reference(str(clip)) == "hello reference"
+    # The broken engine was recorded, same as every other loader path.
+    assert "lightning_fabric" in ab._DEEP_IMPORT_BROKEN["whisperx"]

--- a/backend/tests/test_asr_selector_stays_private.py
+++ b/backend/tests/test_asr_selector_stays_private.py
@@ -1,0 +1,40 @@
+"""Request/job paths must select ASR through ``load_active_asr_backend`` (#1512).
+
+``get_active_asr_backend`` is a PURE selector: it constructs the backend
+without ``ensure_loaded()``. An engine that passes the shallow
+``is_available()`` probe but dies on first real use (a broken deep import
+chain, #1185 — e.g. ctranslate2's native library refusing to load) therefore
+reaches ``.transcribe()`` and 500s the request, even with a healthy engine
+next in line. ``load_active_asr_backend`` is the loading selector that
+records the broken engine and degrades to the next candidate.
+
+Six call sites had drifted back to the pure selector after #1185 landed the
+loader; this guard keeps a seventh from reappearing. The selector stays
+private to ``services/asr_backend.py`` (the loader's own internals and the
+best-effort ``transcribe_reference`` fast path live there).
+"""
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+
+# The selector's home module: its definition, the loader's internal call, and
+# transcribe_reference's construct-only fast path.
+_ALLOWED = {BACKEND_DIR / "services" / "asr_backend.py"}
+
+
+def test_no_get_active_asr_backend_outside_its_home_module():
+    offenders = []
+    for path in sorted(BACKEND_DIR.rglob("*.py")):
+        if path in _ALLOWED or "tests" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "get_active_asr_backend" in line:
+                offenders.append(f"{path.relative_to(BACKEND_DIR)}:{lineno}")
+    assert not offenders, (
+        "Select ASR with load_active_asr_backend() — eager ensure_loaded(), "
+        "degrading past engines whose deep import chain is broken (#1512) — "
+        "not the pure selector get_active_asr_backend(), which lets a broken "
+        "engine reach .transcribe() and 500 the request: "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

- Six transcription paths (OpenAI-compat `POST /v1/audio/transcriptions`, dictation accurate mode, dub main transcribe, dub QC, the batch transcribe stage, and voice-clone reference transcripts) selected the ASR engine with `get_active_asr_backend()` — the pure selector — so an engine that passes the shallow `is_available()` probe but dies on first real use (broken deep import chain, the #1185 class) reached `.transcribe()` and 500'd the request even with a healthy engine next in line.
- All six call sites now go through `load_active_asr_backend()` (same `asr_pipe=` kwarg), with the possibly minutes-long load running inside the thread pool so it never blocks the event loop, and `ASRModelMissingError` from a weightless fallback mapped to the same typed 409 + download CTA the preflights already use.
- `transcribe_reference` keeps its construct-only fast path, the pytorch-whisper deferral, and the #1032 cache semantics; it falls into the degrading loader only when `ensure_loaded()` reports a broken import chain.
- A new CI guard (`backend/tests/test_asr_selector_stays_private.py`) keeps a seventh call site from reintroducing the pure selector outside `services/asr_backend.py`, and a fail-before/pass-after test covers the reference-transcript degrade.

Fixes #1512

## Test plan

- [x] `pytest backend/tests/` — 221 passed, 2 skipped
- [x] Affected suites: `tests/test_asr_model_missing.py`, `tests/test_transcribe_reference.py`, `tests/test_dub_transcribe.py`, `tests/test_speaker_hint.py`, `tests/test_funasr_global_speaker_chunking.py`, `tests/test_capture_refine.py`, `tests/test_engines.py`, `tests/test_tts_placement_self_heal.py`, `tests/test_asr_openai_compat_877.py` — all green
- [ ] CI full suite (backend + frontend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

All ASR transcription paths now use `load_active_asr_backend()` with thread-pool loading and structured 409 responses for missing models. This prevents 500 errors when an available engine fails during loading and adds regression coverage for fallback behavior and selector privacy. Review the fallback and error-handling paths for consistent behavior across transcription endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->