### PR TITLE
fix(api): answer 422 for malformed requests instead of 500ing and logging the body (#1513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Posting a binary body to a JSON endpoint now returns a proper 422 validation error instead of a 500, and the request body no longer lands in `omnivoice.log`. (#1513)
 - The Linux app icon is no longer blank: the AppImage shipped `.DirIcon` as a symlink into the machine that built it, so file managers and app menus drew nothing. (#1518)
 - The Linux desktop entry no longer ships an empty `Categories=`, which `desktop-file-validate` rejects and menu builders skip. (#1518)
 - The Simplified Chinese (zh-CN) translation no longer mistranslates brand names and technical terms — Discord, Tailscale, Hugging Face, IPA, and LLM (Cinematic) were rendered as nonsensical literal translations, and ~250 more awkward machine-translation strings are now natural Chinese. (#1508) — thanks @anyingiit!

--- a/backend/main.py
+++ b/backend/main.py
@@ -346,6 +346,7 @@ import time
 import threading
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
@@ -920,6 +921,103 @@ def _cors_headers_for(request: Request) -> "dict[str, str]":
             "Vary": "Origin",
         }
     return {}
+
+
+# Longest raw value a validation error may echo back. Long enough to show what
+# was wrong with a field, far too short to replay a pasted document.
+_VALIDATION_VALUE_MAX_CHARS = 200
+# Containers are echoed shallowly — a handful of items identifies the payload
+# shape without replaying a whole segments table.
+_VALIDATION_MAX_ITEMS = 10
+_VALIDATION_MAX_DEPTH = 3
+
+
+def _scrub_validation_value(value, _depth: int = 0):
+    """A jsonable, size-bounded stand-in for a validation error's ``input``.
+
+    ``jsonable_encoder`` (what FastAPI's default handler runs the raw value
+    through) decodes ``bytes`` as strict UTF-8, so any binary body raises
+    UnicodeDecodeError *inside the error handler* (#1513). Binary is reported
+    by size only, long strings are truncated, containers are walked shallowly,
+    and anything else (UploadFile, the exception objects pydantic parks in
+    ``ctx``) becomes a bounded ``repr`` — always encodable, never the body.
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return f"<{len(value)} bytes of binary data>"
+    if isinstance(value, str):
+        if len(value) <= _VALIDATION_VALUE_MAX_CHARS:
+            return value
+        return (
+            value[:_VALIDATION_VALUE_MAX_CHARS]
+            + f"… (+{len(value) - _VALIDATION_VALUE_MAX_CHARS} more chars)"
+        )
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if _depth < _VALIDATION_MAX_DEPTH:
+        if isinstance(value, dict):
+            items = list(value.items())
+            out = {
+                str(k): _scrub_validation_value(v, _depth + 1)
+                for k, v in items[:_VALIDATION_MAX_ITEMS]
+            }
+            if len(items) > _VALIDATION_MAX_ITEMS:
+                out["…"] = f"(+{len(items) - _VALIDATION_MAX_ITEMS} more keys)"
+            return out
+        if isinstance(value, (list, tuple, set, frozenset)):
+            items = list(value)
+            out = [
+                _scrub_validation_value(v, _depth + 1)
+                for v in items[:_VALIDATION_MAX_ITEMS]
+            ]
+            if len(items) > _VALIDATION_MAX_ITEMS:
+                out.append(f"… (+{len(items) - _VALIDATION_MAX_ITEMS} more items)")
+            return out
+    text = repr(value)
+    if len(text) > _VALIDATION_VALUE_MAX_CHARS:
+        text = text[:_VALIDATION_VALUE_MAX_CHARS] + "…"
+    return text
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+):
+    """422 with a sanitized ``detail`` for malformed requests (#1513).
+
+    Without this handler FastAPI's default one runs — it jsonable-encodes
+    ``exc.errors()``, and for a body-level failure ``errors()[i]["input"]``
+    holds the RAW request body. Strict UTF-8 decoding of a binary body (an
+    audio upload posted to a JSON route — one wrong path in an MCP or
+    OpenAI-compat client) then raised UnicodeDecodeError *inside the error
+    handler*: the client got a 500 instead of a 422, and the escaping
+    traceback carried the whole request body into omnivoice.log — user audio
+    on disk, in the very file bug reports ask people to paste.
+    """
+    errors = []
+    for err in exc.errors():
+        clean = {
+            "type": err.get("type"),
+            "loc": _scrub_validation_value(err.get("loc", ())),
+            "msg": err.get("msg"),
+        }
+        if "input" in err:
+            clean["input"] = _scrub_validation_value(err["input"])
+        ctx = err.get("ctx")
+        if ctx:
+            clean["ctx"] = {
+                str(k): _scrub_validation_value(v) for k, v in ctx.items()
+            }
+        errors.append(clean)
+    # `.path`, not the full URL — a query string can carry tokens (same rule
+    # as the shutdown handler below); the body itself stays out entirely.
+    logger.info(
+        "422 validation error for %s: %d error(s)", request.url.path, len(errors)
+    )
+    return JSONResponse(
+        status_code=422,
+        content={"detail": errors},
+        headers=_cors_headers_for(request),
+    )
 
 
 @app.exception_handler(Exception)

--- a/backend/tests/test_request_validation_422.py
+++ b/backend/tests/test_request_validation_422.py
@@ -1,0 +1,139 @@
+"""A binary body to a JSON endpoint answers 422 — and never lands on disk (#1513).
+
+Fail-before/pass-after: without ``main.request_validation_exception_handler``
+FastAPI's default RequestValidationError handler runs. It jsonable-encodes the
+error's ``input`` — the raw request body — and strict UTF-8 decoding of binary
+raises UnicodeDecodeError *inside the handler*: the client sees a 500 instead
+of a 422, and the escaping traceback (caught by the global Exception handler)
+writes the whole request body into the crash log / error journal — user audio
+on disk, in the very file bug reports ask people to paste.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+import main as main_mod
+
+BINARY_BODY = b"\x80\x81\x82\xff" * 64  # not valid UTF-8, recognisably long
+
+
+def _app():
+    """A JSON-body route wired to main's REAL exception handlers — the same
+    pair production registers, so the 500-inside-the-error-handler failure
+    mode reproduces exactly when the validation handler is absent."""
+    app = FastAPI()
+
+    class _Body(BaseModel):
+        text: str
+
+    @app.post("/json-route")
+    async def _json_route(body: _Body):  # pragma: no cover — never reached
+        return {"ok": True}
+
+    app.add_exception_handler(
+        RequestValidationError, main_mod.request_validation_exception_handler
+    )
+    app.add_exception_handler(Exception, main_mod.global_exception_handler)
+    return app
+
+
+@pytest.fixture
+def client():
+    with TestClient(_app(), raise_server_exceptions=False) as c:
+        yield c
+
+
+def test_binary_multipart_body_returns_422_not_500(client):
+    resp = client.post(
+        "/json-route", files={"f": ("bin.dat", BINARY_BODY, "application/octet-stream")}
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert detail, "detail must still carry the validation errors"
+    # The body is reported by size, never echoed.
+    assert BINARY_BODY not in resp.content
+    assert any("bytes of binary data" in str(err.get("input", "")) for err in detail)
+
+
+def test_binary_body_never_reaches_crash_log_or_journal(tmp_path, monkeypatch, client):
+    """The 500 path wrote the escaping UnicodeDecodeError — request body and
+    all — through the crash log and error journal. A handled 422 must not."""
+    from core import error_journal
+
+    crash_log = tmp_path / "crash.log"
+    monkeypatch.setattr(main_mod, "CRASH_LOG_PATH", str(crash_log))
+    recorded = []
+    monkeypatch.setattr(
+        error_journal, "record", lambda *a, **k: recorded.append(a) or {}
+    )
+
+    resp = client.post(
+        "/json-route", files={"f": ("clip.wav", BINARY_BODY, "audio/wav")}
+    )
+
+    assert resp.status_code == 422
+    assert not crash_log.exists()
+    assert recorded == []
+
+
+def test_text_validation_error_still_answers_422_with_loc_and_msg(client):
+    resp = client.post("/json-route", json={"wrong_field": 1})
+    assert resp.status_code == 422
+    err = resp.json()["detail"][0]
+    assert err["loc"], "loc survives sanitization"
+    assert err["msg"], "msg survives sanitization"
+
+
+def test_allowed_origin_gets_cors_headers_on_422(client):
+    """Hand-built error responses must go through _cors_headers_for — without
+    it the browser reports a bare CORS failure instead of the 422 detail."""
+    resp = client.post(
+        "/json-route",
+        json={"wrong_field": 1},
+        headers={"Origin": "tauri://localhost"},
+    )
+    assert resp.status_code == 422
+    assert resp.headers.get("Access-Control-Allow-Origin") == "tauri://localhost"
+
+
+# ── _scrub_validation_value: the sanitizer itself ───────────────────────────
+
+
+def test_scrub_reports_binary_by_size_only():
+    out = main_mod._scrub_validation_value(b"\x80" * 145_000)
+    assert out == "<145000 bytes of binary data>"
+
+
+def test_scrub_truncates_long_strings():
+    out = main_mod._scrub_validation_value("x" * 10_000)
+    assert len(out) < 300
+    assert out.startswith("x" * main_mod._VALIDATION_VALUE_MAX_CHARS)
+    assert "more chars" in out
+
+
+def test_scrub_walks_containers_shallowly_and_bounds_them():
+    value = {"clip": b"\x80\x81", "rows": list(range(100)), "note": "ok"}
+    out = main_mod._scrub_validation_value(value)
+    assert out["clip"] == "<2 bytes of binary data>"
+    assert len(out["rows"]) == main_mod._VALIDATION_MAX_ITEMS + 1  # + ellipsis
+    assert out["note"] == "ok"
+
+
+def test_scrub_stringifies_non_jsonable_ctx_values():
+    # pydantic parks exception objects in ctx["error"]; they must come out as
+    # bounded text, not explode jsonable_encoder.
+    out = main_mod._scrub_validation_value(ValueError("boom"))
+    assert isinstance(out, str)
+    assert "boom" in out
+
+
+def test_scrub_bounds_depth_without_decoding_nested_bytes():
+    nested = {"a": {"b": {"c": {"d": {"clip": b"\x80" * 1000}}}}}
+    out = main_mod._scrub_validation_value(nested)
+    # Beyond max depth everything is a bounded repr — escaped, never decoded.
+    import json
+
+    text = json.dumps(out)
+    assert len(text) < 2_000


### PR DESCRIPTION
## Summary

- `backend/main.py` registered an `Exception` handler but none for `RequestValidationError`, so FastAPI's default handler ran `jsonable_encoder(exc.errors())`. For a body-level failure `errors()[i]["input"]` holds the raw request body, and `jsonable_encoder` decodes bytes as strict UTF-8 — any binary body (e.g. an audio upload posted to a JSON route by an MCP / OpenAI-compat client) raised `UnicodeDecodeError` *inside the error handler*: the client got a 500 instead of a 422, and the escaping traceback carried the whole request body into `omnivoice.log`.
- A new `RequestValidationError` handler sanitizes every error's `input` before encoding — binary reported by size only, long strings truncated, containers walked shallowly, `ctx` values (including the exception objects pydantic parks there) stringified with a bound — and answers 422 through `_cors_headers_for(request)` like every other hand-built error response in the module.
- Tests cover the 422 contract, the "body never reaches the crash log / error journal" guarantee, CORS headers on the handled response, and the sanitizer itself.

Fixes #1513

## Test plan

- [x] `pytest backend/tests/` — 228 passed, 2 skipped (includes the 9 new tests driving main's real handlers via TestClient)
- [x] `tests/test_changelog_style.py`
- [ ] CI full suite (backend + frontend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a FastAPI `RequestValidationError` handler that sanitizes invalid inputs and returns 422 responses with CORS headers. This prevents malformed binary requests from causing `UnicodeDecodeError`, 500 responses, or raw body logging. Review the bounded sanitizer behavior for nested and non-JSONable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->