### PR TITLE
feat(ui): one support page, and tabs where there were toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Changed
 
+- Sponsoring, commercial licensing and getting in touch are one page now. They answered the same question between them and each used to live somewhere else, so they are three sections on a single scroll — the footer heart, the commercial-licence links and Contact all land on it, at the section you asked for.
+- Model Catalogue switches panes with tabs instead of a two-state toggle, and the Engine Compatibility Matrix's TTS / ASR / LLM switcher is now tabs too — arrow-key navigable, and each tab still shows the engine it would use.
 - Remote workers reads as a device list: status dot, address, latency, a live task meter, resident models and last-seen per machine, with housekeeping actions revealed on hover and a three-step empty state. (#1516)
 - The GPU picker and the new status-bar control paint their status dots and menu surfaces from themed tokens instead of fixed palette classes, so they stop showing Gruvbox colours on Midnight and Catppuccin. (#1516)
 - Dictation shows the pill again: a capture puts a small always-on-top capsule near the bottom of the screen you are working on — listening, transcribing, the result, and any error — and takes it away when the session ends. It never takes focus, so the text still lands in the app you were typing into. On Wayland the compositor decides where it sits; everywhere else it is bottom-centred.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,9 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Changed
 
-- Sponsoring, commercial licensing and getting in touch are one page now. They answered the same question between them and each used to live somewhere else, so they are three sections on a single scroll — the footer heart, the commercial-licence links and Contact all land on it, at the section you asked for.
-- Model Catalogue switches panes with tabs instead of a two-state toggle, and the Engine Compatibility Matrix's TTS / ASR / LLM switcher is now tabs too — arrow-key navigable, and each tab still shows the engine it would use.
+- Sponsoring, commercial licensing and getting in touch are one page now. They answered the same question between them and each used to live somewhere else, so they are three sections on a single scroll — the footer heart, the commercial-licence links and Contact all land on it, at the section you asked for. (#1522)
+- Model Catalogue switches panes with tabs instead of a two-state toggle, and the Engine Compatibility Matrix's TTS / ASR / LLM switcher is now tabs too — arrow-key navigable, and each tab still shows the engine it would use. (#1522)
+- Engines you can actually use sort to the top of the compatibility matrix, and an unavailable engine's name recedes instead of the whole row fading — the status badge and GPU chips that say *why* it is unavailable stay legible. (#1522)
 - Remote workers reads as a device list: status dot, address, latency, a live task meter, resident models and last-seen per machine, with housekeeping actions revealed on hover and a three-step empty state. (#1516)
 - The GPU picker and the new status-bar control paint their status dots and menu surfaces from themed tokens instead of fixed palette classes, so they stop showing Gruvbox colours on Midnight and Catppuccin. (#1516)
 - Dictation shows the pill again: a capture puts a small always-on-top capsule near the bottom of the screen you are working on — listening, transcribing, the result, and any error — and takes it away when the session ends. It never takes focus, so the text still lands in the app you were typing into. On Wayland the compositor decides where it sits; everywhere else it is bottom-centred.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,7 +31,6 @@ const LogsFooter = lazy(() => import('./components/LogsFooter'));
 const ProjectsPage = lazy(() => import('./pages/Projects'));
 const VoiceGallery = lazy(() => import('./pages/VoiceGallery'));
 const SupportPage = lazy(() => import('./pages/SupportPage'));
-const ContactPage = lazy(() => import('./pages/ContactPage'));
 const TranscriptionsPage = lazy(() => import('./pages/Transcriptions'));
 const StoriesEditor = lazy(() => import('./components/StoriesEditor'));
 const AudiobookTab = lazy(() => import('./pages/AudiobookTab'));
@@ -1539,7 +1538,9 @@ function App() {
         ) : mode === 'contact' ? (
           <ErrorBoundary name="contact">
             <Suspense fallback={<LazyFallback />}>
-              <ContactPage onBack={() => setMode('launchpad')} />
+              {/* Same page as donate / enterprise — it scrolls to the contact
+                  section. Three routes, one destination. */}
+              <SupportPage initialView="contact" onBack={() => setMode('launchpad')} />
             </Suspense>
           </ErrorBoundary>
         ) : mode === 'launchpad' ? (

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -329,7 +329,18 @@ export default function EngineCompatibilityMatrix({
   );
 
   const familyData = data?.[activeFamily];
-  const backends = useMemo(() => (familyData?.backends || []).map(normalizeEntry), [familyData]);
+  // Available engines first, unavailable after — the list is something you
+  // pick FROM, and burying a usable engine under four you cannot select makes
+  // you read the whole matrix to find it. Within each group the backend's own
+  // order is preserved (it is meaningful: registration order puts the defaults
+  // first), so this only lifts the rows you can act on.
+  const backends = useMemo(() => {
+    const rows = (familyData?.backends || []).map(normalizeEntry);
+    return rows
+      .map((row, index) => ({ row, index }))
+      .sort((a, b) => Number(b.row.available) - Number(a.row.available) || a.index - b.index)
+      .map(({ row }) => row);
+  }, [familyData]);
   const families = useMemo(
     () => Object.keys(FAMILY_META).filter((f) => data?.[f]?.backends),
     [data],
@@ -780,7 +791,12 @@ export default function EngineCompatibilityMatrix({
                     'mx-[var(--space-2)] rounded-[var(--chrome-radius-pill)] border border-[color-mix(in_srgb,var(--chrome-fg)_7%,transparent)] transition-colors duration-[120ms] hover:bg-[var(--chrome-hover-bg)]',
                     isActive &&
                       'bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)] shadow-[inset_2px_0_0_var(--chrome-accent)]',
-                    !b.available && 'opacity-[0.78]',
+                    // Dim the TEXT of an unavailable row, not the row: fading
+                    // the whole thing took the status badge and GPU chips down
+                    // with it, and those are exactly what tells you WHY it is
+                    // unavailable. Text recedes; the evidence stays legible.
+                    !b.available &&
+                      'engine-matrix__row--unavailable text-[color:var(--chrome-fg-muted)]',
                   )}
                 >
                   {/* Line 1: mark + name (truncated, never wraps) + badges.
@@ -793,9 +809,21 @@ export default function EngineCompatibilityMatrix({
                     )}
                   >
                     <span className="flex min-w-0 items-center gap-[6px]">
-                      <EngineMark id={b.id} size={18} className="shrink-0" />
+                      <EngineMark
+                        id={b.id}
+                        size={18}
+                        className={cn('shrink-0', !b.available && 'opacity-60')}
+                      />
                       <span
-                        className="engine-matrix__name min-w-0 truncate whitespace-nowrap font-semibold leading-[1.2] text-[length:var(--text-sm)] text-[color:var(--chrome-fg,currentColor)]"
+                        className={cn(
+                          'engine-matrix__name min-w-0 truncate whitespace-nowrap font-semibold leading-[1.2] text-[length:var(--text-sm)]',
+                          // The name pins its own colour, so the row-level dim
+                          // cannot reach it — it has to recede here or the row
+                          // reads as available at a glance.
+                          b.available
+                            ? 'text-[color:var(--chrome-fg,currentColor)]'
+                            : 'text-[color:color-mix(in_srgb,var(--chrome-fg)_58%,transparent)]',
+                        )}
                         title={b.display_name}
                       >
                         {b.display_name}

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -25,7 +25,7 @@ import {
 import { listLoadedModels, unloadLoadedModel } from '../api/system';
 import { copyText } from '../utils/copyText';
 import { ChevronRight } from 'lucide-react';
-import { Badge, Button, Segmented, Select, Table } from '../ui';
+import { Badge, Button, Select, Table, Tabs } from '../ui';
 import { cn } from '@/lib/utils';
 import EngineMark from './EngineMark';
 import SupertonicLicenseDialog from './SupertonicLicenseDialog';
@@ -82,7 +82,7 @@ function reasonMentionsLicense(reason) {
  *   - activeId?: string  the currently-active backend id for this
  *     family. Used to render the "active" badge.
  *   - showFamilyTabs?: boolean  default true. The TTS/ASR/LLM tab strip
- *     (Radix Segmented — roving tabindex + arrow keys) presents one family
+ *     (Radix Tabs — roving tabindex + arrow keys) presents one family
  *     at a time over the single shared GET /engines payload. The Model
  *     Catalogue mounts exactly one matrix in this mode. Pass false to pin
  *     the matrix to `family` (no switcher; the header names the family).
@@ -630,7 +630,7 @@ export default function EngineCompatibilityMatrix({
       </header>
 
       {showFamilyTabs && families.length > 1 && (
-        <Segmented
+        <Tabs
           size="sm"
           className="engine-matrix__tabs w-full [&>*]:flex-1"
           value={activeFamily}
@@ -641,7 +641,7 @@ export default function EngineCompatibilityMatrix({
           items={families.map((f) => {
             const FamilyIcon = FAMILY_META[f].icon;
             return {
-              value: f,
+              id: f,
               title: t('engines.activeEngine', {
                 family: FAMILY_META[f].label,
                 engine: data[f].active,

--- a/frontend/src/components/settings/EnginesTab.test.jsx
+++ b/frontend/src/components/settings/EnginesTab.test.jsx
@@ -62,13 +62,20 @@ const ENGINES = {
   llm: { active: 'off', backends: [entry('off', 'Off (test)')] },
 };
 
-/** Click the family tab whose label text is `label` (TTS / ASR / LLM). */
+/** Click the family tab whose label text is `label` (TTS / ASR / LLM).
+ *
+ * Radix Tabs activate on POINTER DOWN, not click — a bare fireEvent.click
+ * leaves the family unchanged, which reads as a matrix that ignores its own
+ * tabs. Drive it the way a pointer does. */
 function clickFamilyTab(label) {
   const tab = Array.from(document.querySelectorAll('.engine-matrix__tab-family')).find(
     (el) => el.textContent === label,
   );
   expect(tab).toBeTruthy();
-  fireEvent.click(tab.closest('button'));
+  const trigger = tab.closest('button');
+  fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerType: 'mouse' });
+  fireEvent.mouseDown(trigger, { button: 0 });
+  fireEvent.click(trigger);
 }
 
 describe('EnginesTab', () => {

--- a/frontend/src/pages/ContactPage.jsx
+++ b/frontend/src/pages/ContactPage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
-  ArrowLeft,
   ArrowRight,
   ExternalLink,
   MessageCircle,
@@ -18,7 +17,6 @@ import { Card } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button.tsx';
 import { cn } from '@/lib/utils';
 import { openExternal } from '../api/external';
-import { useAppStore } from '../store';
 import ReportBugButton from '../components/ReportBugButton';
 
 // One home for every outward channel. The repo/Discord/security URLs match the
@@ -160,28 +158,26 @@ function ExternalCta({
 
 // Small mono caption with a trailing hairline — matches the Support page's
 // SectionTitle so the two pages read as one family.
-function SectionCaption({ children }) {
-  return (
-    <div className="mb-3 flex items-center gap-3">
-      <span className="whitespace-nowrap font-mono text-[var(--chrome-label-size)] font-semibold uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">
-        {children}
-      </span>
-      <span className="h-px flex-1 bg-border" />
-    </div>
-  );
-}
-
 /**
- * ContactPage — a genuinely useful "Get in touch" page: each way to reach the
- * project is a card with an icon, a heading, and a sentence of guidance so
- * users pick the right channel (bug / feature / community / support / security)
- * instead of guessing from a flat link list. Reached via `mode === 'contact'`.
+ * The contact channels, as a SECTION rather than a page.
+ *
+ * Each way to reach the project is a card with an icon, a heading and a
+ * sentence of guidance, so people pick the right channel (bug / feature /
+ * community / support / security) instead of guessing from a flat link list.
+ *
+ * Sponsor, commercial licensing and contact were three separate destinations
+ * for one question — "how do I reach these people / support this" — so they
+ * now live together on SupportPage. This exports the body; the page shell
+ * (back button, aurora, scroll container) belongs to the host.
  */
-export default function ContactPage({ onBack }) {
+export function ContactSections() {
   const { t } = useTranslation();
-  // Support lives on its own page (donate mode) — link to it, never duplicate
-  // the Ko-fi/PayPal surface here.
-  const goSupport = () => useAppStore.getState().setMode?.('donate');
+
+  // "Support the project" stays INSIDE the app rather than linking out to
+  // Ko-fi: the support section is right above this one now, so sending people
+  // to a browser for something on the same page would be absurd.
+  const goSupport = () =>
+    document.getElementById('support-give')?.scrollIntoView({ block: 'start' });
 
   const renderCta = (s) => {
     const label = t(s.ctaKey, { defaultValue: s.ctaDefault });
@@ -197,98 +193,55 @@ export default function ContactPage({ onBack }) {
   };
 
   return (
-    <div className="relative isolate flex flex-1 flex-col overflow-y-auto bg-[var(--chrome-bg)]">
-      <div className="lp-aurora" aria-hidden="true">
-        <span className="lp-aurora__blob lp-aurora__blob--pink" />
-        <span className="lp-aurora__blob lp-aurora__blob--green" />
-        <span className="lp-aurora__blob lp-aurora__blob--amber" />
-      </div>
+    <>
+      <section
+        className="grid grid-cols-[repeat(auto-fit,minmax(248px,1fr))] gap-3"
+        aria-label={t('contact.channels_label', { defaultValue: 'Ways to get in touch' })}
+      >
+        {SECTIONS.map((s) => {
+          const Icon = s.icon;
+          return (
+            <Card
+              key={s.id}
+              style={{ '--card-hue': s.hue }}
+              className="h-full items-start gap-3 rounded-lg border-border bg-transparent p-5 shadow-none transition-colors hover:border-border-strong hover:bg-[var(--chrome-hover-bg)]"
+            >
+              <span className="flex size-11 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,var(--card-hue)_12%,transparent)] text-[var(--card-hue)]">
+                <Icon size={20} />
+              </span>
+              <h3 className="font-serif text-[1.2rem] font-medium leading-snug text-[var(--chrome-fg)]">
+                {t(s.titleKey, { defaultValue: s.titleDefault })}
+              </h3>
+              <p className="font-sans text-[0.82rem] leading-[1.6] text-[var(--chrome-fg-muted)]">
+                {t(s.descKey, { defaultValue: s.descDefault })}
+              </p>
+              <div className="mt-auto pt-1">{renderCta(s)}</div>
+            </Card>
+          );
+        })}
+      </section>
 
-      <div className="relative z-[2] flex items-center justify-between gap-3 px-11 pt-4">
-        <Button variant="subtle" size="sm" onClick={onBack} leading={<ArrowLeft size={14} />}>
-          {t('donate.back')}
-        </Button>
-        <span className="w-24 shrink-0" aria-hidden="true" />
-      </div>
-
-      <div className="relative z-[1] mx-auto flex w-full max-w-[820px] flex-1 flex-col gap-9 px-8 pb-14 pt-2">
-        {/* Friendly, generously-spaced header */}
-        <header className="text-center">
-          <span className="mx-auto mb-4 flex size-14 items-center justify-center rounded-lg border border-transparent bg-[color-mix(in_srgb,#d3869b_12%,transparent)]">
-            <MessageCircle
-              size={26}
-              className="text-[#f3a5b6] drop-shadow-[0_0_12px_rgba(243,165,182,0.5)]"
-            />
-          </span>
-          <h2 className="relative inline-block font-serif text-[2.4rem] font-normal leading-tight tracking-[-0.02em] text-[var(--chrome-fg)]">
-            {t('contact.hero_title', { defaultValue: 'We’d love to hear from you' })}
-            <span className="lp-hero__sweep" aria-hidden="true" />
-          </h2>
-          <p className="mx-auto mt-4 max-w-[560px] font-sans text-[0.9rem] leading-[1.7] text-[var(--chrome-fg-muted)]">
-            {t('contact.hero_desc', {
-              defaultValue:
-                'VoiceStudio is built in the open and shaped by the people who use it. Whether you’ve found a bug, have a feature in mind, need a hand getting set up, or just want to share what you made — there’s a channel below for it.',
-            })}
-          </p>
-        </header>
-
-        {/* Guidance cards — CSS-grid auto-fit reflows on the SHELL's own width
-            (2–3 across → 1), so it stays correct under --ui-scale zoom without
-            any viewport @media. */}
-        <section
-          className="grid grid-cols-[repeat(auto-fit,minmax(248px,1fr))] gap-3"
-          aria-label={t('contact.channels_label', { defaultValue: 'Ways to get in touch' })}
-        >
-          {SECTIONS.map((s) => {
-            const Icon = s.icon;
-            return (
-              <Card
-                key={s.id}
-                style={{ '--card-hue': s.hue }}
-                className="h-full items-start gap-3 rounded-lg border-border bg-transparent p-5 shadow-none transition-colors hover:border-border-strong hover:bg-[var(--chrome-hover-bg)]"
-              >
-                <span className="flex size-11 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,var(--card-hue)_12%,transparent)] text-[var(--card-hue)]">
-                  <Icon size={20} />
-                </span>
-                <h3 className="font-serif text-[1.2rem] font-medium leading-snug text-[var(--chrome-fg)]">
-                  {t(s.titleKey, { defaultValue: s.titleDefault })}
-                </h3>
-                <p className="font-sans text-[0.82rem] leading-[1.6] text-[var(--chrome-fg-muted)]">
-                  {t(s.descKey, { defaultValue: s.descDefault })}
-                </p>
-                <div className="mt-auto pt-1">{renderCta(s)}</div>
-              </Card>
-            );
+      <div className="flex flex-wrap items-center justify-center gap-2.5">
+        <ExternalCta
+          href={`mailto:${EMAIL}`}
+          label={t('contact.email', { defaultValue: 'Email' })}
+          ariaLabel={t('contact.email_desc', {
+            defaultValue: 'Email — licensing, partnerships, or anything private',
           })}
-        </section>
-
-        {/* Quieter, direct channels — kept from the previous page so email
-            (licensing / anything private) and the project site stay reachable. */}
-        <section>
-          <SectionCaption>
-            {t('contact.other_ways', { defaultValue: 'Other ways to reach me' })}
-          </SectionCaption>
-          <div className="flex flex-wrap items-center justify-center gap-2.5">
-            <ExternalCta
-              href={`mailto:${EMAIL}`}
-              label={t('contact.email', { defaultValue: 'Email' })}
-              ariaLabel={t('contact.email_desc', {
-                defaultValue: 'Email — licensing, partnerships, or anything private',
-              })}
-              leading={<Mail size={13} />}
-              trailing={null}
-            />
-            <ExternalCta
-              href={WEBSITE_URL}
-              label={t('contact.website', { defaultValue: 'Website' })}
-              ariaLabel={t('contact.website_desc', {
-                defaultValue: 'Website — more about the project and the maker',
-              })}
-              leading={<Globe size={13} />}
-            />
-          </div>
-        </section>
+          leading={<Mail size={13} />}
+          trailing={null}
+        />
+        <ExternalCta
+          href={WEBSITE_URL}
+          label={t('contact.website', { defaultValue: 'Website' })}
+          ariaLabel={t('contact.website_desc', {
+            defaultValue: 'Website — more about the project and the maker',
+          })}
+          leading={<Globe size={13} />}
+        />
       </div>
-    </div>
+    </>
   );
 }
+
+export default ContactSections;

--- a/frontend/src/pages/ModelCatalogue.jsx
+++ b/frontend/src/pages/ModelCatalogue.jsx
@@ -25,7 +25,7 @@ import { Boxes, CheckCircle, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import { useModelStatus, useSystemInfo } from '../api/hooks';
-import { Badge, Segmented } from '../ui';
+import { Badge, Tabs } from '../ui';
 import EnginesTab from '../components/settings/EnginesTab';
 import ModelStoreTab from '../components/settings/ModelStoreTab';
 
@@ -87,10 +87,14 @@ export default function ModelCatalogue() {
       <Badge tone="warn">{t('models.idle_badge')}</Badge>
     );
 
+  // Tabs, not a two-state Segmented: these are two workspaces of a catalogue,
+  // not one setting with an on/off reading, and the room to add a third pane
+  // later is free. Tabs also carry roving tabindex + role="tab" from the
+  // primitive, which the switch had to describe with an aria-label.
   const paneItems = useMemo(
     () => [
-      { value: 'engines', label: t('catalogue.tab_engines') },
-      { value: 'models', label: t('catalogue.tab_models') },
+      { id: 'engines', label: t('catalogue.tab_engines') },
+      { id: 'models', label: t('catalogue.tab_models') },
     ],
     [t],
   );
@@ -117,10 +121,11 @@ export default function ModelCatalogue() {
           <h1 className="m-0 min-w-0 flex-auto truncate [font-family:var(--font-sans)] text-[length:var(--text-lg)] font-semibold tracking-[-0.015em] text-[color:var(--chrome-fg)]">
             {t('catalogue.title')}
           </h1>
-          <Segmented
+          <Tabs
             items={paneItems}
             value={pane}
             onChange={setPane}
+            size="sm"
             aria-label={t('catalogue.title')}
             data-testid="catalogue-pane-switch"
           />

--- a/frontend/src/pages/ModelCatalogue.test.jsx
+++ b/frontend/src/pages/ModelCatalogue.test.jsx
@@ -21,6 +21,16 @@ vi.mock('../api/hooks', () => ({
 import { useAppStore } from '../store';
 import ModelCatalogue from './ModelCatalogue';
 
+// Radix Tabs activate on POINTER DOWN, not click — a bare fireEvent.click
+// leaves the pane unchanged and reads as a broken switcher. Drive the tab the
+// way a pointer does.
+const clickTab = (name) => {
+  const tab = screen.getByRole('tab', { name });
+  fireEvent.pointerDown(tab, { button: 0, ctrlKey: false, pointerType: 'mouse' });
+  fireEvent.mouseDown(tab, { button: 0 });
+  fireEvent.click(tab);
+};
+
 describe('ModelCatalogue', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -34,14 +44,14 @@ describe('ModelCatalogue', () => {
     expect(screen.getByTestId('stub-engines')).toBeInTheDocument();
     expect(screen.queryByTestId('stub-models')).toBeNull();
 
-    fireEvent.click(screen.getByRole('radio', { name: 'Models' }));
+    clickTab('Models');
     expect(screen.getByTestId('stub-models')).toBeInTheDocument();
     expect(screen.queryByTestId('stub-engines')).toBeNull();
   });
 
   it('remembers the pane across visits', () => {
     const first = render(<ModelCatalogue />);
-    fireEvent.click(screen.getByRole('radio', { name: 'Models' }));
+    clickTab('Models');
     first.unmount();
 
     render(<ModelCatalogue />);

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -26,6 +26,25 @@ import { KOFI_URL, PAYPAL_URL } from '../utils/donateLinks';
 // Sponsor roster + "become a sponsor" links — single source of truth in
 // config/sponsors.js (kept in lockstep with SPONSORS.md).
 import { SPONSORS, SPONSOR_TIERS, SPONSOR_CONTACT } from '../config/sponsors';
+import { ContactSections } from './ContactPage';
+
+/** Anchor ids the three legacy routes (donate / enterprise / contact) land on. */
+const SECTION_IDS = {
+  support: 'support-give',
+  license: 'support-license',
+  contact: 'support-contact',
+};
+
+/** A hairline, not a heading: the sections already headline themselves, and
+ *  the point of merging them was fewer edges, not more chrome. */
+function SectionDivider() {
+  return (
+    <hr
+      aria-hidden="true"
+      className="m-0 h-px border-0 bg-[color-mix(in_srgb,var(--chrome-fg)_8%,transparent)]"
+    />
+  );
+}
 // Suggested amounts — ladder starts at $10; middle ($20) is "most common".
 const SUGGESTED_AMOUNTS = [
   { value: 10, label: '$10' },
@@ -486,17 +505,27 @@ function LicenseView() {
  */
 export default function SupportPage({ onBack, initialView = 'support' }) {
   const { t } = useTranslation();
-  const [view, setView] = useState(initialView === 'license' ? 'license' : 'support');
 
-  // Literal class strings (no interpolation) so Tailwind's JIT can see them.
-  const TAB_BASE =
-    'inline-flex items-center justify-center gap-1.5 rounded-md border px-[18px] py-1.5 font-mono text-[0.72rem] font-semibold uppercase tracking-[var(--chrome-label-track)] whitespace-nowrap transition-colors';
-  const TAB_INACTIVE =
-    'border-transparent text-[var(--chrome-fg-muted)] hover:text-[var(--chrome-fg)]';
-  const TAB_SUPPORT_ACTIVE =
-    'border-transparent bg-[color-mix(in_srgb,var(--color-brand)_18%,transparent)] text-[var(--chrome-fg)]';
-  const TAB_LICENSE_ACTIVE =
-    'border-transparent bg-[color-mix(in_srgb,#83a598_18%,transparent)] text-[var(--chrome-fg)]';
+  // Sponsoring, buying a commercial licence and getting in touch were three
+  // destinations answering one question, and every one of them made you leave
+  // to find the others. They are one page now: three sections, in the order
+  // people actually need them, on a single scroll. `initialView` is kept —
+  // every existing entry point (footer heart, the dub/export "commercial
+  // licence" links, Contact) still passes it — but it now scrolls to a
+  // section instead of hiding the other two.
+  const sectionRef = React.useRef(null);
+  React.useEffect(() => {
+    if (initialView === 'support') return; // already at the top
+    const id = SECTION_IDS[initialView];
+    if (!id) return;
+    // rAF: the panel has to be laid out before an offset means anything.
+    const frame = requestAnimationFrame(() => {
+      sectionRef.current
+        ?.querySelector(`#${id}`)
+        ?.scrollIntoView({ block: 'start', behavior: 'auto' });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [initialView]);
 
   return (
     <div className="relative isolate flex flex-1 flex-col overflow-y-auto bg-[var(--chrome-bg)]">
@@ -507,50 +536,45 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
         <span className="lp-aurora__blob lp-aurora__blob--amber" />
       </div>
 
-      {/* Top bar: Back (left) · toggle (center) · spacer (right, balances Back) */}
       <div className="relative z-[2] flex items-center justify-between gap-3 px-11 pt-4">
         <Button variant="subtle" size="sm" onClick={onBack} leading={<ArrowLeft size={14} />}>
           {t('donate.back')}
         </Button>
-
-        <div
-          className="grid grid-cols-2 gap-1 rounded-md border border-border bg-[color-mix(in_srgb,var(--chrome-fg)_5%,transparent)] p-[3px]"
-          role="tablist"
-          aria-label={t('support.toggle_label')}
-        >
-          <button
-            type="button"
-            role="tab"
-            aria-selected={view === 'support'}
-            className={`${TAB_BASE} ${view === 'support' ? TAB_SUPPORT_ACTIVE : TAB_INACTIVE}`}
-            onClick={() => setView('support')}
-          >
-            <Heart size={13} /> {t('support.tab_support')}
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={view === 'license'}
-            className={`${TAB_BASE} ${view === 'license' ? TAB_LICENSE_ACTIVE : TAB_INACTIVE}`}
-            onClick={() => setView('license')}
-          >
-            <Building2 size={13} /> {t('support.tab_license')}
-          </button>
-        </div>
-
         <span className="w-24 shrink-0" aria-hidden="true" />
       </div>
 
-      {/* key={view} remounts the panel so its entry animations replay on toggle.
-          The Support panel is short, so it's centered vertically; License is
-          tall enough to fill on its own and stays top-aligned. */}
       <div
-        className={`relative z-[1] mx-auto flex w-full max-w-[640px] flex-col gap-6 px-8 pb-10 ${
-          view === 'support' ? 'flex-1 justify-center' : ''
-        }`}
-        key={view}
+        ref={sectionRef}
+        className="relative z-[1] mx-auto flex w-full max-w-[720px] flex-col gap-12 px-8 pb-16 pt-2"
       >
-        {view === 'support' ? <SupportView /> : <LicenseView />}
+        <section id={SECTION_IDS.support} aria-label={t('support.tab_support')}>
+          <SupportView />
+        </section>
+
+        <SectionDivider />
+
+        <section id={SECTION_IDS.license} aria-label={t('support.tab_license')}>
+          <LicenseView />
+        </section>
+
+        <SectionDivider />
+
+        <section
+          id={SECTION_IDS.contact}
+          aria-label={t('contact.channels_label', { defaultValue: 'Ways to get in touch' })}
+          className="flex flex-col gap-6"
+        >
+          <div className="text-center">
+            <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-md border border-transparent bg-[color-mix(in_srgb,#d3869b_12%,transparent)]">
+              <MessageCircle size={24} className="text-[#f3a5b6]" />
+            </span>
+            <h2 className="relative inline-block font-serif text-[2rem] font-normal leading-tight tracking-[-0.02em] text-[var(--chrome-fg)]">
+              {t('contact.hero_title', { defaultValue: 'We\u2019d love to hear from you' })}
+              <span className="lp-hero__sweep" aria-hidden="true" />
+            </h2>
+          </div>
+          <ContactSections />
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -515,9 +515,12 @@ export default function SupportPage({ onBack, initialView = 'support' }) {
   // section instead of hiding the other two.
   const sectionRef = React.useRef(null);
   React.useEffect(() => {
-    if (initialView === 'support') return; // already at the top
-    const id = SECTION_IDS[initialView];
-    if (!id) return;
+    // Every view scrolls, including 'support'. App.jsx renders SupportPage in
+    // the same tree position for donate / enterprise / contact, so React keeps
+    // ONE instance and only swaps props — treating 'support' as "already at the
+    // top" left the footer heart showing whichever section you were last on
+    // (CodeRabbit).
+    const id = SECTION_IDS[initialView] || SECTION_IDS.support;
     // rAF: the panel has to be laid out before an offset means anything.
     const frame = requestAnimationFrame(() => {
       sectionRef.current

--- a/frontend/src/test/ContactPage.test.jsx
+++ b/frontend/src/test/ContactPage.test.jsx
@@ -1,9 +1,13 @@
-// ContactPage — render-level coverage for the "Get in touch" page: the
-// friendly header, every guidance section (bug / feature / community /
-// support / security), each channel pointing at the right URL, the in-app
-// bug-report affordance, and the Support card routing to the donate page
-// (never duplicating the Ko-fi/PayPal surface here). openExternal is mocked so
-// no real browser/window navigation happens; the store is the real one.
+// Contact channels — render-level coverage for every guidance section
+// (bug / feature / community / support / security), each channel pointing at
+// the right URL, and the in-app bug-report affordance.
+//
+// Contact is a SECTION of SupportPage now, not a page of its own: sponsoring,
+// commercial licensing and getting in touch answered one question between them
+// and each used to be somewhere else. What is pinned here is the content and
+// its links — the page shell (header, back button) belongs to the host and is
+// covered by SupportPage's own suite. openExternal is mocked so no real
+// browser navigation happens; the store is the real one.
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -11,7 +15,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 const { openExternal } = vi.hoisted(() => ({ openExternal: vi.fn() }));
 vi.mock('../api/external', () => ({ openExternal }));
 
-import ContactPage from '../pages/ContactPage';
+import { ContactSections } from '../pages/ContactPage';
 import { useAppStore } from '../store';
 
 const REPO = 'https://github.com/debpalash/VoiceStudio';
@@ -21,10 +25,9 @@ beforeEach(() => {
   useAppStore.getState().setMode?.('launchpad');
 });
 
-describe('ContactPage', () => {
-  it('renders the friendly header and every guidance section', () => {
-    render(<ContactPage onBack={() => {}} />);
-    expect(screen.getByRole('heading', { name: /love to hear from you/i })).toBeInTheDocument();
+describe('contact sections', () => {
+  it('renders every guidance section', () => {
+    render(<ContactSections />);
     for (const name of [
       'Report a bug',
       'Request a feature or ask',
@@ -37,12 +40,12 @@ describe('ContactPage', () => {
   });
 
   it('exposes the in-app bug-report affordance', () => {
-    render(<ContactPage onBack={() => {}} />);
+    render(<ContactSections />);
     expect(screen.getByRole('button', { name: /open bug reporter/i })).toBeInTheDocument();
   });
 
   it('points each external channel at the right URL', () => {
-    render(<ContactPage onBack={() => {}} />);
+    render(<ContactSections />);
     const href = (name) => screen.getByRole('link', { name }).getAttribute('href');
     expect(href('Open GitHub Issues')).toBe(`${REPO}/issues`);
     expect(href('Join the Discord')).toBe('https://discord.gg/bzQavDfVV9');
@@ -53,7 +56,7 @@ describe('ContactPage', () => {
   });
 
   it('opens external links via the shared opener and marks them noreferrer', () => {
-    render(<ContactPage onBack={() => {}} />);
+    render(<ContactSections />);
     const link = screen.getByRole('link', { name: 'Join the Discord' });
     expect(link).toHaveAttribute('rel', 'noreferrer');
     expect(link).toHaveAttribute('target', '_blank');
@@ -61,9 +64,19 @@ describe('ContactPage', () => {
     expect(openExternal).toHaveBeenCalledWith('https://discord.gg/bzQavDfVV9');
   });
 
-  it('routes "Support the project" to the in-app Support page (no Ko-fi duplication)', () => {
-    render(<ContactPage onBack={() => {}} />);
+  it('sends "Support the project" to the support section, not out to Ko-fi', () => {
+    // The support surface is on this same page now, so the CTA scrolls rather
+    // than navigating — and must still never duplicate the Ko-fi/PayPal links.
+    const target = document.createElement('div');
+    target.id = 'support-give';
+    target.scrollIntoView = vi.fn();
+    document.body.appendChild(target);
+
+    render(<ContactSections />);
     fireEvent.click(screen.getByRole('button', { name: 'See ways to support' }));
-    expect(useAppStore.getState().mode).toBe('donate');
+
+    expect(target.scrollIntoView).toHaveBeenCalled();
+    expect(openExternal).not.toHaveBeenCalled();
+    target.remove();
   });
 });

--- a/frontend/src/test/EngineCompatibilityMatrix.test.jsx
+++ b/frontend/src/test/EngineCompatibilityMatrix.test.jsx
@@ -69,6 +69,46 @@ describe('EngineCompatibilityMatrix', () => {
     vi.useRealTimers();
   });
 
+  it('lists available engines first, keeping registration order inside each group', async () => {
+    // The fixture is deliberately interleaved (available, UNavailable,
+    // available). A matrix that renders it in payload order buries a usable
+    // engine under one you cannot select, which is the whole reason to sort:
+    // this list is something you pick FROM.
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        activeId="omnivoice"
+        apiListEngines={vi.fn().mockResolvedValue(makeEnginesResponse())}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await screen.findByText('OmniVoice (test)');
+
+    const order = Array.from(document.querySelectorAll('.engine-matrix__name')).map(
+      (el) => el.textContent,
+    );
+    expect(order).toEqual(['OmniVoice (test)', 'IndexTTS2 (test)', 'KittenTTS (test)']);
+  });
+
+  it("dims an unavailable engine's name without fading its evidence", async () => {
+    // Fading the whole row took the status badge and GPU chips with it — the
+    // two things that say WHY the engine is unavailable.
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        activeId="omnivoice"
+        apiListEngines={vi.fn().mockResolvedValue(makeEnginesResponse())}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    const unavailable = await screen.findByText('KittenTTS (test)');
+    const available = screen.getByText('IndexTTS2 (test)');
+
+    expect(unavailable.className).toContain('color-mix');
+    expect(available.className).not.toContain('color-mix');
+    expect(unavailable.closest('.engine-matrix__row').className).not.toContain('opacity-');
+  });
+
   it('renders one row per backend with the documented columns', async () => {
     const apiListEngines = vi.fn().mockResolvedValue(makeEnginesResponse());
     render(

--- a/frontend/src/test/SupportPageSections.test.jsx
+++ b/frontend/src/test/SupportPageSections.test.jsx
@@ -1,0 +1,72 @@
+// The merged support page — sponsor, commercial licence and contact are three
+// sections of one scroll now, and `initialView` decides which one you land on.
+//
+// The subtle part is that App.jsx renders SupportPage in the SAME tree position
+// for `donate`, `enterprise` and `contact`, so React keeps one instance alive
+// and only swaps props. A view change is therefore a prop change, not a mount —
+// which is exactly how "support scrolls to the top" got missed: the effect
+// treated 'support' as already-there and left you on whichever section you had
+// navigated from.
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../api/external', () => ({ openExternal: vi.fn() }));
+// Partial mock: only the network call is stubbed. GoalBar imports the real
+// progressPct / isGoalMet, and a hand-written module object would silently
+// drop whichever helper it gains next.
+vi.mock('../api/donation', async (importOriginal) => ({
+  ...(await importOriginal()),
+  loadDonationProgress: () => Promise.resolve({ raised: 0, goal: 100, sponsorCount: 0 }),
+}));
+
+import SupportPage from '../pages/SupportPage';
+
+/** Ids that were scrolled to, in order.
+ *
+ * `scrollIntoView` does not exist in this DOM environment, so it is stubbed on
+ * the prototype — before the first render, since the effect fires on mount. The
+ * stub records `this.id`, which is what makes "landed on the right section"
+ * assertable at all. */
+const scrolledTo = [];
+
+beforeEach(() => {
+  scrolledTo.length = 0;
+  Element.prototype.scrollIntoView = vi.fn(function scrollIntoViewStub() {
+    scrolledTo.push(this.id);
+  });
+  // The effect defers to rAF so layout has happened; run it synchronously.
+  vi.stubGlobal('requestAnimationFrame', (cb) => {
+    cb(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+});
+
+describe('the merged support page', () => {
+  it('carries all three sections on one scroll', () => {
+    render(<SupportPage onBack={() => {}} />);
+    for (const id of ['support-give', 'support-license', 'support-contact']) {
+      expect(document.getElementById(id)).toBeInTheDocument();
+    }
+    // Contact's channels came along with it, not just its heading.
+    expect(screen.getByRole('heading', { name: 'Report a bug' })).toBeInTheDocument();
+  });
+
+  it('lands on the section the route asked for', () => {
+    const { rerender } = render(<SupportPage onBack={() => {}} initialView="support" />);
+    rerender(<SupportPage onBack={() => {}} initialView="contact" />);
+    expect(scrolledTo).toContain('support-contact');
+  });
+
+  it('goes back to the top when the route returns to support', () => {
+    // THE REGRESSION: the same instance is reused across donate / enterprise /
+    // contact, so a 'support' view that skipped scrolling left the footer heart
+    // showing the contact section you were already on.
+    const { rerender } = render(<SupportPage onBack={() => {}} initialView="contact" />);
+    expect(scrolledTo).toEqual(['support-contact']);
+
+    rerender(<SupportPage onBack={() => {}} initialView="support" />);
+    expect(scrolledTo).toEqual(['support-contact', 'support-give']);
+  });
+});

--- a/frontend/src/test/SupportPageSections.test.jsx
+++ b/frontend/src/test/SupportPageSections.test.jsx
@@ -59,6 +59,15 @@ describe('the merged support page', () => {
     expect(scrolledTo).toContain('support-contact');
   });
 
+  it('lands on the licence section for the enterprise route', () => {
+    // `mode === 'enterprise'` passes initialView="license" — the third
+    // destination, and the one a broken mapping would hide: every section
+    // renders either way, so only the scroll target proves it.
+    const { rerender } = render(<SupportPage onBack={() => {}} initialView="support" />);
+    rerender(<SupportPage onBack={() => {}} initialView="license" />);
+    expect(scrolledTo).toContain('support-license');
+  });
+
   it('goes back to the top when the route returns to support', () => {
     // THE REGRESSION: the same instance is reused across donate / enterprise /
     // contact, so a 'support' view that skipped scrolling left the footer heart

--- a/frontend/src/ui/Tabs.jsx
+++ b/frontend/src/ui/Tabs.jsx
@@ -76,6 +76,7 @@ export default function Tabs({
               key={item.id}
               value={item.id}
               className={`ui-tabs__tab ${active ? 'is-active' : ''} ${tabClass}`}
+              title={item.title}
               style={active && item.accent ? { '--ui-tab-accent': item.accent } : undefined}
             >
               {Icon && <Icon size={12} className="ui-tabs__icon" />}


### PR DESCRIPTION
Two UI changes requested together.

## One support page

Sponsor, commercial licence and contact were three destinations for one question — *how do I support this / how do I reach these people* — and each made you leave to find the others. They are now three sections on a single scroll, separated by a hairline rather than more chrome:

1. **Support** — goal bar, amounts, Ko-fi/PayPal, sponsors
2. **Commercial licence**
3. **Contact** — bug, feature, community, security, email, website

Every existing entry point still works. `initialView` now *scrolls* to a section instead of hiding the other two, so the footer heart (`donate`), the dub/export commercial-licence links (`enterprise`) and Contact (`contact`) all land where they meant to.

`ContactPage` becomes `ContactSections` — the body without the shell. Its "Support the project" CTA scrolls up to the support section rather than navigating, because that surface is now on the same page, and it still never duplicates the Ko-fi/PayPal links.

## Tabs, not toggles

Model Catalogue's Engines/Models switch and the Engine Compatibility Matrix's TTS/ASR/LLM switch are both `Tabs` now. These pick between workspaces, not between the two states of one setting, and the primitive carries roving tabindex and `role="tab"` for free. The matrix tabs keep their active-engine chip, and keep their hover title too — `Tabs` passes `title` through now.

## Tests

The pane and family switches are driven by **pointer down**, not click: Radix activates on pointer down, so a bare `fireEvent.click` left the pane unchanged and read as a switcher that ignores itself. The contact suite now covers the section (its host owns the header) and asserts the support CTA scrolls without reaching for Ko-fi.

Full frontend suite: **2022 passed**. The single unhandled `window is not defined` rejection in the parallel run **predates this change** — same error and same count on the base commit, verified by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Consolidate support, commercial licensing, and contact content into one scrollable page, and replace catalogue and compatibility selectors with keyboard-navigable tabs. Existing routes remain functional, and `initialView` targets the corresponding section. Review the unchanged `window is not defined` test rejection before merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->