### PR TITLE
test(asr): guard the raw ASR selector across the whole backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The guard that keeps transcription on the degrading ASR loader now scans the whole backend, not just the routers — a service that transcribes on a request's behalf skipped `ensure_loaded()` just as thoroughly. (#1519) — thanks @ahov520!
 - The Linux app icon is no longer blank. Every AppImage since v0.4.2 shipped `.DirIcon` as an absolute symlink into the machine that built it (`/home/runner/work/…`), so the link dangled on every user's computer and file managers, app menus and desktop integration all drew nothing. The release build now verifies the icon resolves inside the bundle before publishing. (#1518)
 - The Linux desktop entry no longer ships an empty `Categories=`, which `desktop-file-validate` rejects and menu builders skip. (#1518)
 

--- a/backend/tests/test_asr_request_path_degrades.py
+++ b/backend/tests/test_asr_request_path_degrades.py
@@ -48,6 +48,7 @@ from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 _ROUTERS = Path(__file__).resolve().parents[1] / "api" / "routers"
+_BACKEND = Path(__file__).resolve().parents[1]
 
 # The exact failure this regression is built from: an ImportError raised by the
 # *deep* chain (dlopen of a CTranslate2 shared object), not a missing module.
@@ -224,4 +225,31 @@ def test_routers_use_the_degrading_loader():
         "probe passes but whose deep import chain is broken reaches "
         ".transcribe() and 500s the request (#1185, #1512).\n  "
         + "\n  ".join(offenders)
+    )
+
+
+# Routers are where the bug was found, but not the only place it can live: a
+# service or engine module that transcribes on a request's behalf skips
+# ensure_loaded() just as thoroughly. Scan the whole backend, so the guard
+# cannot be sidestepped by moving the call one module down the stack.
+# (Broader scan contributed on #1519 — thanks @ahov520!)
+_HOME_MODULE = "asr_backend.py"
+
+
+def test_no_module_outside_asr_backend_calls_the_raw_selector():
+    offenders = []
+    for path in sorted(_BACKEND.rglob("*.py")):
+        rel = path.relative_to(_BACKEND).as_posix()
+        if path.name == _HOME_MODULE or rel.startswith("tests/") or path.name in _SELECTOR_ALLOWED:
+            continue
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.lstrip()
+            if _CALL.search(line) and not stripped.startswith("#"):
+                offenders.append(f"{rel}:{i}: {line.strip()}")
+
+    assert not offenders, (
+        "Only services/asr_backend.py may call the raw get_active_asr_backend() "
+        "selector — everywhere else must use load_active_asr_backend(), which "
+        "runs ensure_loaded() and degrades past an engine whose deep import "
+        "chain is broken (#1185, #1512, #1519).\n  " + "\n  ".join(offenders)
     )


### PR DESCRIPTION
The recurrence guard added with #1512's fix scanned `api/routers/` only. A service or engine module that transcribes on a request's behalf skips `ensure_loaded()` just as thoroughly, so the guard could be sidestepped by moving the call one module down the stack.

Verified it fails before it passes: adding a `get_active_asr_backend()` call to `backend/services/tts_backend.py` sails through the router scan and trips this one.

```
E  services/tts_backend.py:2662: return get_active_asr_backend()
```

This is the one thing **#1519 did better** than the fix that landed in #1515 — absorbing it with credit rather than leaving it in a PR that now conflicts with `main`. Thanks @ahov520!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The ASR recurrence guard now scans the entire backend and blocks direct `get_active_asr_backend()` calls that bypass `ensure_loaded()`. This protects service and engine modules, including request-proxy transcription paths. Review the regression scan exclusions and allowlist for completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->