### PR TITLE
feat(engines): add quick switching controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Changed
 
+- Support amount choices now use every theme's shared card, accent and focus tokens. (#1530)
 - Sponsoring, commercial licensing and getting in touch are one page now. They answered the same question between them and each used to live somewhere else, so they are three sections on a single scroll — the footer heart, the commercial-licence links and Contact all land on it, at the section you asked for. (#1522)
 - Model Catalogue switches panes with tabs instead of a two-state toggle, and the Engine Compatibility Matrix's TTS / ASR / LLM switcher is now tabs too — arrow-key navigable, and each tab still shows the engine it would use. (#1522)
 - Engines you can actually use sort to the top of the compatibility matrix, and an unavailable engine's name recedes instead of the whole row fading — the status badge and GPU chips that say *why* it is unavailable stay legible. (#1522)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
+- Switch TTS, ASR and LLM engines from the status bar or workspace, with ready-only choices, memory status and environment-pin protection. (#1530)
 - Docker/server mode now requires an API key for remote changes and side-effectful admin checks across workers, engines, media tools, MCP, pronunciation, diagnostics, and LLM providers. (#1525)
 - The unified Support page no longer throws while opening a section in browsers or test environments without `scrollIntoView`. (#1525)
 - A faster, cleaner Dub workspace for multilingual production (#1489)

--- a/backend/api/routers/engines.py
+++ b/backend/api/routers/engines.py
@@ -41,6 +41,15 @@ _FAMILIES = {
     "llm": (llm_backend, "llm_backend"),
 }
 
+
+def _family_payload(family: str, module):
+    """Public inventory plus whether an environment pin owns this family."""
+    return {
+        "active": module.active_backend_id(),
+        "env_override": bool(os.environ.get(f"OMNIVOICE_{family.upper()}_BACKEND")),
+        "backends": public_backends(module.list_backends()),
+    }
+
 def _is_hf_repo_id(value: str) -> bool:
     """Validate the route's ``owner/repo`` contract in bounded time."""
     if not isinstance(value, str) or len(value) > 96 or value.count("/") != 1:
@@ -55,34 +64,25 @@ def _is_hf_repo_id(value: str) -> bool:
 @router.get("/engines")
 def list_all_engines():
     return {
-        "tts": {
-            "active": tts_backend.active_backend_id(),
-            "backends": public_backends(tts_backend.list_backends()),
-        },
-        "asr": {
-            "active": asr_backend.active_backend_id(),
-            "backends": public_backends(asr_backend.list_backends()),
-        },
-        "llm": {
-            "active": llm_backend.active_backend_id(),
-            "backends": public_backends(llm_backend.list_backends()),
-        },
+        "tts": _family_payload("tts", tts_backend),
+        "asr": _family_payload("asr", asr_backend),
+        "llm": _family_payload("llm", llm_backend),
     }
 
 
 @router.get("/engines/tts")
 def list_tts_backends():
-    return {"active": tts_backend.active_backend_id(), "backends": public_backends(tts_backend.list_backends())}
+    return _family_payload("tts", tts_backend)
 
 
 @router.get("/engines/asr")
 def list_asr_backends():
-    return {"active": asr_backend.active_backend_id(), "backends": public_backends(asr_backend.list_backends())}
+    return _family_payload("asr", asr_backend)
 
 
 @router.get("/engines/llm")
 def list_llm_backends():
-    return {"active": llm_backend.active_backend_id(), "backends": public_backends(llm_backend.list_backends())}
+    return _family_payload("llm", llm_backend)
 
 
 @router.get("/engines/effects/presets", response_model=EffectPresetsResponse)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -806,7 +806,7 @@ function App() {
     const handler = (e) => {
       // In-webview navigation only: using DOM keydown keeps this identical in
       // browser, macOS, Windows and Linux builds (unlike OS-level hotkeys).
-      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
         const key = e.key.toLowerCase();
         if (key === 'e') {
           e.preventDefault();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import './index.css';
 import { useAppStore, FONT_STACKS } from './store';
+import { NAV_ITEMS } from './components/navItems';
 import SearchableSelect from './components/SearchableSelect';
 import DirectionDialog from './components/DirectionDialog';
 
@@ -803,6 +804,22 @@ function App() {
   // ── KEYBOARD SHORTCUTS ──
   useEffect(() => {
     const handler = (e) => {
+      // In-webview navigation only: using DOM keydown keeps this identical in
+      // browser, macOS, Windows and Linux builds (unlike OS-level hotkeys).
+      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+        const key = e.key.toLowerCase();
+        if (key === 'e') {
+          e.preventDefault();
+          window.dispatchEvent(new Event('engine-quick-switch'));
+          return;
+        }
+        const index = Number(key);
+        if (index >= 1 && index <= NAV_ITEMS.length) {
+          e.preventDefault();
+          setMode(NAV_ITEMS[index - 1].id);
+          return;
+        }
+      }
       // ⌘+Enter or Ctrl+Enter → Generate
       if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
         e.preventDefault();

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -14,6 +14,8 @@ import * as archetypesApi from './archetypes';
 import type { ArchetypeFilters } from './archetypes';
 import * as communityApi from './community';
 import type { CommunityFilters } from './community';
+import * as enginesApi from './engines';
+import type { AllEnginesResponse, EngineFamily } from './types';
 
 // ── Keys (prevents typos, enables targeted invalidation) ─────────────────
 export const queryKeys = {
@@ -26,6 +28,7 @@ export const queryKeys = {
   models: ['models'] as const,
   recommendations: ['recommendations'] as const,
   preflight: ['preflight'] as const,
+  engines: ['engines'] as const,
   setupStatus: ['setup-status'] as const,
   galleryVoices: (params?: any) => ['gallery-voices', params] as const,
   galleryCategories: ['gallery-categories'] as const,
@@ -171,6 +174,39 @@ export function usePreflight() {
   });
 }
 
+/**
+ * The app-wide engine inventory.  Engine selection affects more than the
+ * catalogue (for example Audiobook's expressive controls), so every consumer
+ * must share this cache rather than take its own one-off snapshot.
+ *
+ * `queryFn` is injectable for the compatibility-matrix test seam.
+ */
+export function useEngines(queryFn: () => Promise<AllEnginesResponse> = enginesApi.listEngines) {
+  return useQuery({
+    queryKey: queryKeys.engines,
+    queryFn,
+    staleTime: 30_000,
+    retry: 1,
+  });
+}
+
+/** Select an engine and invalidate every view derived from `/engines`. */
+export function useSelectEngine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      family,
+      backendId,
+      modelId,
+    }: {
+      family: EngineFamily;
+      backendId: string;
+      modelId?: string;
+    }) => enginesApi.selectEngine(family, backendId, modelId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.engines }),
+  });
+}
+
 export function useSetupStatus() {
   return useQuery({
     queryKey: queryKeys.setupStatus,
@@ -230,6 +266,9 @@ export function useInstallModel() {
       qc.invalidateQueries({ queryKey: queryKeys.models });
       qc.invalidateQueries({ queryKey: queryKeys.setupStatus });
       qc.invalidateQueries({ queryKey: queryKeys.recommendations });
+      // Some model installs make an engine selectable; refresh every engine
+      // indicator rather than leaving a stale unavailable snapshot behind.
+      qc.invalidateQueries({ queryKey: queryKeys.engines });
     },
   });
 }
@@ -242,6 +281,7 @@ export function useDeleteModel() {
       qc.invalidateQueries({ queryKey: queryKeys.models });
       qc.invalidateQueries({ queryKey: queryKeys.setupStatus });
       qc.invalidateQueries({ queryKey: queryKeys.recommendations });
+      qc.invalidateQueries({ queryKey: queryKeys.engines });
     },
   });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -24,7 +24,7 @@ type EffectiveDevice = GPUTarget | 'network';
 // `n/a` is LLM-only; resolve_routing only ever returns the first four.
 type RoutingStatus = 'accelerated' | 'cpu_fallback' | 'cpu_only' | 'unavailable' | 'n/a';
 
-interface EngineBackend {
+export interface EngineBackend {
   id: string;
   display_name: string;
   available: boolean;
@@ -76,8 +76,10 @@ export interface CuratedModel {
   repo_id: string;
 }
 
-interface EngineFamilyResponse {
+export interface EngineFamilyResponse {
   active: string;
+  /** A process environment pin wins over a saved UI selection. */
+  env_override?: boolean;
   backends: EngineBackend[];
 }
 

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -226,6 +226,10 @@ export default function EngineCompatibilityMatrix({
   showFamilyTabs = true,
   onFamilyChange = null,
   reloadToken = 0,
+  // The catalogue passes its app-wide query here. Keeping the standalone
+  // fallback preserves the matrix's injectable API seam for isolated hosts
+  // and its extensive focused test suite.
+  sharedEngines = null,
   // Injectable API layer — lets the RTL suite mock it without module-level
   // vi.mock incantations, and keeps the "one GET /engines per Settings open"
   // contract overridable by hosts.
@@ -242,9 +246,14 @@ export default function EngineCompatibilityMatrix({
   apiInstallStatus = getSidecarInstallStatus,
 }) {
   const { t } = useTranslation();
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [localData, setLocalData] = useState(null);
+  const [localLoading, setLocalLoading] = useState(true);
+  const [localError, setLocalError] = useState(null);
+  const sharedRefetch = sharedEngines?.refetch;
+  const isShared = Boolean(sharedEngines);
+  const data = sharedEngines?.data ?? localData;
+  const loading = isShared ? sharedEngines.isLoading : localLoading;
+  const error = sharedEngines?.error ?? localError;
   const [activeFamily, setActiveFamily] = useState(family);
   // Phase 3 Plan 03-01 / TTS-05: which engine has its license dialog
   // currently open, or null. Only one dialog is ever open at a time.
@@ -288,26 +297,37 @@ export default function EngineCompatibilityMatrix({
   }, [apiListLoadedModels]);
 
   const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const fresh = await apiListEngines();
-      setData(fresh);
-    } catch (e) {
-      const msg = e?.message || String(e);
-      setError(msg);
-      toastErrorWithReport(t('engines.loadFailed', { message: msg }), e);
-    } finally {
-      setLoading(false);
+    if (sharedRefetch) {
+      const result = await sharedRefetch();
+      if (result.error) {
+        const message = result.error?.message || String(result.error);
+        toastErrorWithReport(t('engines.loadFailed', { message }), result.error);
+      }
+    } else {
+      setLocalLoading(true);
+      setLocalError(null);
+      try {
+        setLocalData(await apiListEngines());
+      } catch (requestError) {
+        const message = requestError?.message || String(requestError);
+        setLocalError(requestError);
+        toastErrorWithReport(t('engines.loadFailed', { message }), requestError);
+      } finally {
+        setLocalLoading(false);
+      }
     }
     refreshResidency();
-  }, [apiListEngines, refreshResidency, t]);
+  }, [apiListEngines, refreshResidency, sharedRefetch, t]);
 
   useEffect(() => {
-    reload();
+    if (isShared) {
+      refreshResidency();
+      return;
+    }
+    void reload();
     // reloadToken: an external bump (e.g. the ASR config panel just saved a
     // server URL) refetches so availability + "Use" reflect the new config.
-  }, [reload, reloadToken]);
+  }, [reload, reloadToken, refreshResidency, isShared]);
 
   // Unload a resident engine's model/sidecar by its /model/loaded id. Safe by
   // contract: the model reloads lazily on the next generation.
@@ -598,7 +618,8 @@ export default function EngineCompatibilityMatrix({
         className="engine-matrix engine-matrix--error flex flex-col gap-[8px] items-center p-[16px]"
         role="alert"
       >
-        <AlertTriangle size={14} /> {t('engines.couldNotLoad', { message: error })}
+        <AlertTriangle size={14} />{' '}
+        {t('engines.couldNotLoad', { message: error.message || String(error) })}
         <Button size="sm" variant="subtle" onClick={reload} leading={<RefreshCw size={11} />}>
           {t('engines.retry')}
         </Button>
@@ -726,7 +747,7 @@ export default function EngineCompatibilityMatrix({
           data-testid="engine-list-scroll"
           aria-label={t('engines.engineCompatLabel', { family: activeFamily })}
         >
-          {backends.map((b) => {
+          {backends.map((b, index) => {
             const isActive = b.id === activeBackendId;
             const health = healthByEngine[b.id];
             const selfTest = selfTestByEngine[b.id];
@@ -781,6 +802,16 @@ export default function EngineCompatibilityMatrix({
             ) : null;
             return (
               <React.Fragment key={b.id}>
+                {(index === 0 || (backends[index - 1]?.available && !b.available)) && (
+                  <div
+                    className={cn(
+                      'px-[var(--space-2)] pt-[4px] font-mono text-[10px] font-semibold uppercase tracking-[0.08em]',
+                      MUTED,
+                    )}
+                  >
+                    {b.available ? t('engines.available') : t('engines.notInstalled')}
+                  </div>
+                )}
                 <div
                   role="row"
                   data-engine-id={b.id}

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -251,6 +251,7 @@ export default function EngineCompatibilityMatrix({
   const [localError, setLocalError] = useState(null);
   const sharedRefetch = sharedEngines?.refetch;
   const isShared = Boolean(sharedEngines);
+  const sharedReloadToken = useRef(reloadToken);
   const data = sharedEngines?.data ?? localData;
   const loading = isShared ? sharedEngines.isLoading : localLoading;
   const error = sharedEngines?.error ?? localError;
@@ -321,6 +322,11 @@ export default function EngineCompatibilityMatrix({
 
   useEffect(() => {
     if (isShared) {
+      if (sharedReloadToken.current !== reloadToken) {
+        sharedReloadToken.current = reloadToken;
+        void reload();
+        return;
+      }
       refreshResidency();
       return;
     }

--- a/frontend/src/components/EngineQuickSwitch.jsx
+++ b/frontend/src/components/EngineQuickSwitch.jsx
@@ -6,6 +6,7 @@ import { listLoadedModels } from '../api/system';
 import { useEngines, useSelectEngine } from '../api/hooks';
 import { notifyEngineSelected } from '../utils/engineSelectToast';
 import { useAppStore } from '../store';
+import { MENU_SURFACE } from './computeTarget';
 
 /**
  * A compact TTS/ASR/LLM picker for chrome that needs to expose the active
@@ -16,6 +17,10 @@ export default function EngineQuickSwitch({
   family = 'tts',
   className = '',
   shortcutTarget = false,
+  // The footer chip opens upward (nothing below the last row on screen);
+  // workspace-header chips must open downward or the popover clips off the
+  // top of the viewport.
+  dropUp = false,
 }) {
   const { t } = useTranslation();
   const rootRef = useRef(null);
@@ -120,7 +125,9 @@ export default function EngineQuickSwitch({
         <div
           role="dialog"
           aria-label={t('engines.engineCompatLabel', { family: family.toUpperCase() })}
-          className="absolute bottom-[calc(100%+8px)] right-0 z-[60] flex w-[272px] flex-col gap-[4px] rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[var(--chrome-bg-elevated,var(--chrome-bg))] p-[8px] shadow-xl"
+          className={`absolute right-0 z-[60] flex w-[272px] flex-col gap-[4px] p-[8px] ${
+            dropUp ? 'bottom-[calc(100%+8px)]' : 'top-[calc(100%+8px)]'
+          } ${MENU_SURFACE}`}
         >
           {locked && (
             <p className="m-[4px] text-[11px] leading-[1.4] text-[color:var(--chrome-fg-muted)]">

--- a/frontend/src/components/EngineQuickSwitch.jsx
+++ b/frontend/src/components/EngineQuickSwitch.jsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Check, ChevronRight, Cpu } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { listLoadedModels } from '../api/system';
+import { useEngines, useSelectEngine } from '../api/hooks';
+import { notifyEngineSelected } from '../utils/engineSelectToast';
+import { useAppStore } from '../store';
+
+/**
+ * A compact TTS/ASR/LLM picker for chrome that needs to expose the active
+ * engine without growing a second engine-management surface. The matrix stays
+ * the detailed view; this lists only engines that are ready to be used.
+ */
+export default function EngineQuickSwitch({ family = 'tts', className = '' }) {
+  const { t } = useTranslation();
+  const rootRef = useRef(null);
+  const [open, setOpen] = useState(false);
+  const [switchError, setSwitchError] = useState('');
+  const { data: engines } = useEngines();
+  const selectMutation = useSelectEngine();
+  const { data: residency } = useQuery({
+    queryKey: ['loaded-models'],
+    queryFn: listLoadedModels,
+    staleTime: 10_000,
+    retry: false,
+    enabled: open,
+  });
+
+  const familyData = engines?.[family];
+  const active = familyData?.backends?.find((engine) => engine.id === familyData.active);
+  const available = useMemo(
+    () => (familyData?.backends || []).filter((engine) => engine.available),
+    [familyData],
+  );
+  const residentIds = useMemo(
+    () =>
+      new Set(
+        (residency?.models || []).flatMap((model) => (model.engine_id ? [model.engine_id] : [])),
+      ),
+    [residency],
+  );
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const close = (event) => {
+      if (rootRef.current && !rootRef.current.contains(event.target)) setOpen(false);
+    };
+    const escape = (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', close);
+    document.addEventListener('keydown', escape);
+    return () => {
+      document.removeEventListener('mousedown', close);
+      document.removeEventListener('keydown', escape);
+    };
+  }, [open]);
+
+  // In-webview shortcut bridge. This stays a DOM event (not a Tauri global
+  // shortcut), so every desktop and browser build behaves the same way.
+  useEffect(() => {
+    const show = () => {
+      setSwitchError('');
+      setOpen(true);
+    };
+    window.addEventListener('engine-quick-switch', show);
+    return () => window.removeEventListener('engine-quick-switch', show);
+  }, []);
+
+  if (!active || available.length === 0) return null;
+
+  const locked = Boolean(familyData.env_override);
+  const choose = async (backendId) => {
+    if (backendId === familyData.active || locked) return;
+    setSwitchError('');
+    try {
+      const result = await selectMutation.mutateAsync({ family, backendId });
+      if (result.env_override) {
+        setSwitchError(t('settings.llmp_env_override'));
+        return;
+      }
+      notifyEngineSelected(result, t, family);
+      setOpen(false);
+    } catch (error) {
+      setSwitchError(error?.message || t('engines.switch_failed'));
+    }
+  };
+
+  return (
+    <div className={`relative inline-flex shrink-0 items-center ${className}`} ref={rootRef}>
+      <button
+        type="button"
+        onClick={() => {
+          setSwitchError('');
+          setOpen((value) => !value);
+        }}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={t('engines.activeEngine', {
+          family: family.toUpperCase(),
+          engine: active.display_name,
+        })}
+        aria-label={t('engines.activeEngine', {
+          family: family.toUpperCase(),
+          engine: active.display_name,
+        })}
+        className="inline-flex h-[20px] items-center gap-[5px] rounded-sm border-0 bg-transparent px-[7px] text-[11px] font-medium text-[color:var(--chrome-fg-muted)] transition-[background,color] hover:bg-[var(--chrome-hover-bg)] hover:text-[color:var(--chrome-fg)]"
+      >
+        <Cpu size={13} aria-hidden="true" />
+        <span className="max-w-[124px] truncate">{active.display_name}</span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label={t('engines.engineCompatLabel', { family: family.toUpperCase() })}
+          className="absolute bottom-[calc(100%+8px)] right-0 z-[60] flex w-[272px] flex-col gap-[4px] rounded-[var(--chrome-radius)] border border-[color:var(--chrome-border)] bg-[var(--chrome-bg-elevated,var(--chrome-bg))] p-[8px] shadow-xl"
+        >
+          {locked && (
+            <p className="m-[4px] text-[11px] leading-[1.4] text-[color:var(--chrome-fg-muted)]">
+              {t('settings.llmp_env_override')}
+            </p>
+          )}
+          {available.map((engine) => {
+            const isActive = engine.id === familyData.active;
+            const warm = residentIds.has(engine.id);
+            return (
+              <button
+                key={engine.id}
+                type="button"
+                disabled={isActive || locked || selectMutation.isPending}
+                onClick={() => choose(engine.id)}
+                className="flex w-full items-center gap-[8px] rounded-[5px] border-0 bg-transparent px-[7px] py-[6px] text-left text-[11px] text-[color:var(--chrome-fg)] hover:bg-[var(--chrome-hover-bg)] disabled:cursor-default disabled:opacity-60"
+              >
+                <span className="w-[12px] shrink-0">
+                  {isActive && <Check size={12} aria-label={t('engines.active')} />}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{engine.display_name}</span>
+                <span className="shrink-0 text-[10px] text-[color:var(--chrome-fg-muted)]">
+                  {warm ? t('engines.inMemory') : t('engines.available')}
+                </span>
+              </button>
+            );
+          })}
+          {switchError && (
+            <p
+              role="alert"
+              className="m-[4px] text-[11px] leading-[1.4] text-[color:var(--chrome-severity-err)]"
+            >
+              {switchError}
+            </p>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              useAppStore.getState().openCatalogue({ pane: 'engines', family });
+            }}
+            className="mt-[3px] flex items-center gap-[3px] border-0 bg-transparent px-[7px] py-[5px] text-left text-[11px] text-[color:var(--chrome-fg-muted)] hover:text-[color:var(--chrome-fg)]"
+          >
+            {t('settings.engines')} <ChevronRight size={12} aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/EngineQuickSwitch.jsx
+++ b/frontend/src/components/EngineQuickSwitch.jsx
@@ -12,7 +12,11 @@ import { useAppStore } from '../store';
  * engine without growing a second engine-management surface. The matrix stays
  * the detailed view; this lists only engines that are ready to be used.
  */
-export default function EngineQuickSwitch({ family = 'tts', className = '' }) {
+export default function EngineQuickSwitch({
+  family = 'tts',
+  className = '',
+  shortcutTarget = false,
+}) {
   const { t } = useTranslation();
   const rootRef = useRef(null);
   const [open, setOpen] = useState(false);
@@ -60,13 +64,14 @@ export default function EngineQuickSwitch({ family = 'tts', className = '' }) {
   // In-webview shortcut bridge. This stays a DOM event (not a Tauri global
   // shortcut), so every desktop and browser build behaves the same way.
   useEffect(() => {
+    if (!shortcutTarget) return undefined;
     const show = () => {
       setSwitchError('');
       setOpen(true);
     };
     window.addEventListener('engine-quick-switch', show);
     return () => window.removeEventListener('engine-quick-switch', show);
-  }, []);
+  }, [shortcutTarget]);
 
   if (!active || available.length === 0) return null;
 

--- a/frontend/src/components/EngineQuickSwitch.test.jsx
+++ b/frontend/src/components/EngineQuickSwitch.test.jsx
@@ -29,11 +29,11 @@ const inventory = (env_override = false) => ({
   llm: { active: 'off', backends: [] },
 });
 
-function renderPicker() {
+function renderPicker(props = {}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <EngineQuickSwitch />
+      <EngineQuickSwitch {...props} />
     </QueryClientProvider>,
   );
 }
@@ -70,5 +70,21 @@ describe('EngineQuickSwitch', () => {
 
     expect(screen.getByText(/set via an environment variable/i)).toBeInTheDocument();
     expect(screen.getByText('IndexTTS 2').closest('button')).toBeDisabled();
+  });
+
+  it('opens only the designated picker from the global shortcut bridge', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <EngineQuickSwitch />
+        <EngineQuickSwitch shortcutTarget />
+      </QueryClientProvider>,
+    );
+    await screen.findAllByRole('button', { name: /active tts: omnivoice/i });
+
+    fireEvent(window, new Event('engine-quick-switch'));
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getAllByRole('dialog')).toHaveLength(1);
   });
 });

--- a/frontend/src/components/EngineQuickSwitch.test.jsx
+++ b/frontend/src/components/EngineQuickSwitch.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('react-hot-toast', () => ({ toast: { success: vi.fn() } }));
+
+const { listEngines, selectEngine, listLoadedModels } = vi.hoisted(() => ({
+  listEngines: vi.fn(),
+  selectEngine: vi.fn(),
+  listLoadedModels: vi.fn(),
+}));
+vi.mock('../api/engines', () => ({ listEngines, selectEngine }));
+vi.mock('../api/system', () => ({ listLoadedModels }));
+
+import EngineQuickSwitch from './EngineQuickSwitch';
+
+const inventory = (env_override = false) => ({
+  tts: {
+    active: 'omnivoice',
+    env_override,
+    backends: [
+      { id: 'omnivoice', display_name: 'OmniVoice', available: true },
+      { id: 'indextts2', display_name: 'IndexTTS 2', available: true },
+      { id: 'offline', display_name: 'Offline', available: false },
+    ],
+  },
+  asr: { active: 'whisper', backends: [] },
+  llm: { active: 'off', backends: [] },
+});
+
+function renderPicker() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <EngineQuickSwitch />
+    </QueryClientProvider>,
+  );
+}
+
+describe('EngineQuickSwitch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listEngines.mockResolvedValue(inventory());
+    listLoadedModels.mockResolvedValue({ models: [{ engine_id: 'omnivoice' }] });
+  });
+
+  it('lists only available engines and annotates residency', async () => {
+    renderPicker();
+    fireEvent.click(await screen.findByRole('button', { name: /active tts: omnivoice/i }));
+
+    expect(screen.getByText('IndexTTS 2')).toBeInTheDocument();
+    expect(screen.queryByText('Offline')).not.toBeInTheDocument();
+    expect(await screen.findByText('In memory')).toBeInTheDocument();
+  });
+
+  it('selects through the shared mutation', async () => {
+    selectEngine.mockResolvedValue({ family: 'tts', active: 'indextts2', env_override: false });
+    renderPicker();
+    fireEvent.click(await screen.findByRole('button', { name: /active tts: omnivoice/i }));
+    fireEvent.click(screen.getByText('IndexTTS 2'));
+
+    await waitFor(() => expect(selectEngine).toHaveBeenCalledWith('tts', 'indextts2', undefined));
+  });
+
+  it('locks a family owned by an environment variable', async () => {
+    listEngines.mockResolvedValue(inventory(true));
+    renderPicker();
+    fireEvent.click(await screen.findByRole('button', { name: /active tts: omnivoice/i }));
+
+    expect(screen.getByText(/set via an environment variable/i)).toBeInTheDocument();
+    expect(screen.getByText('IndexTTS 2').closest('button')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/KeyboardCheatsheet.jsx
+++ b/frontend/src/components/KeyboardCheatsheet.jsx
@@ -19,8 +19,8 @@ export default function KeyboardCheatsheet({ open, onClose }) {
       title: t('keyboard.nav'),
       items: [
         ['?', t('keyboard.nav_cheatsheet')],
-        ['Cmd/Ctrl+E', t('engines.matrixTitle')],
-        ['Cmd/Ctrl+1–9', t('keyboard.nav')],
+        [t('keyboard.nav_enginePickerKey'), t('engines.matrixTitle')],
+        [t('keyboard.nav_workspacesKey'), t('keyboard.nav')],
         ['Esc', t('keyboard.nav_closeModal')],
         ['Cmd/Ctrl+S', t('keyboard.nav_save')],
       ],

--- a/frontend/src/components/KeyboardCheatsheet.jsx
+++ b/frontend/src/components/KeyboardCheatsheet.jsx
@@ -19,6 +19,8 @@ export default function KeyboardCheatsheet({ open, onClose }) {
       title: t('keyboard.nav'),
       items: [
         ['?', t('keyboard.nav_cheatsheet')],
+        ['Cmd/Ctrl+E', t('engines.matrixTitle')],
+        ['Cmd/Ctrl+1–9', t('keyboard.nav')],
         ['Esc', t('keyboard.nav_closeModal')],
         ['Cmd/Ctrl+S', t('keyboard.nav_save')],
       ],

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -640,7 +640,7 @@ export default function LogsFooter() {
             )}
           </button>
           <ComputeQuickSettings />
-          <EngineQuickSwitch shortcutTarget />
+          <EngineQuickSwitch shortcutTarget dropUp />
           <NetworkToggle />
           <button
             type="button"

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -640,7 +640,7 @@ export default function LogsFooter() {
             )}
           </button>
           <ComputeQuickSettings />
-          <EngineQuickSwitch />
+          <EngineQuickSwitch shortcutTarget />
           <NetworkToggle />
           <button
             type="button"

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import NetworkToggle from './NetworkToggle';
 import ComputeQuickSettings from './ComputeQuickSettings';
+import EngineQuickSwitch from './EngineQuickSwitch';
 import { APP_VERSION, whatsNewPending } from '../utils/appVersion';
 import DonateMomentPopover, { DONATE_POPOVER_AUTO_DISMISS_MS } from './DonateMomentPopover';
 import { DONATION_MOMENT_EVENT, optOutOfDonationMoments } from '../utils/donationMoments';
@@ -639,6 +640,7 @@ export default function LogsFooter() {
             )}
           </button>
           <ComputeQuickSettings />
+          <EngineQuickSwitch />
           <NetworkToggle />
           <button
             type="button"

--- a/frontend/src/components/WizardLibrary.jsx
+++ b/frontend/src/components/WizardLibrary.jsx
@@ -22,9 +22,8 @@ import { useTranslation } from 'react-i18next';
 import { toast } from 'react-hot-toast';
 import { Check, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useModels, useInstallModel } from '../api/hooks';
+import { useEngines, useModels, useInstallModel, useSelectEngine } from '../api/hooks';
 import { setupDownloadStreamUrl } from '../api/setup';
-import { listEngines, selectEngine } from '../api/engines';
 import { notifyEngineSelected } from '../utils/engineSelectToast';
 import MirrorRescue from './MirrorRescue';
 import { Badge, Button } from '../ui';
@@ -237,7 +236,9 @@ export default function WizardLibrary() {
   const { t } = useTranslation();
   const modelsQuery = useModels();
   const installMutation = useInstallModel();
-  const [engines, setEngines] = useState(null);
+  const { data: engineInventory } = useEngines();
+  const selectMutation = useSelectEngine();
+  const engines = engineInventory?.tts ?? null;
   const [progress, setProgress] = useState({}); // { repo_id: { phase, files } }
   const [showTail, setShowTail] = useState(false);
   const [switching, setSwitching] = useState(null);
@@ -254,22 +255,6 @@ export default function WizardLibrary() {
     const d = modelsQuery.data;
     return Array.isArray(d) ? [] : (d?.platform_tags ?? []);
   }, [modelsQuery.data]);
-
-  // Engines: TTS family only on first run — the family the studio speaks with.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const all = await listEngines();
-        if (!cancelled) setEngines(all?.tts ?? null);
-      } catch {
-        /* backend mid-boot — the wizard polls models anyway */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   // One SSE stream for all rows (same channel the Settings store uses).
   useEffect(() => {
@@ -312,8 +297,7 @@ export default function WizardLibrary() {
   const useEngine = async (id) => {
     setSwitching(id);
     try {
-      const r = await selectEngine('tts', id);
-      setEngines((e) => (e ? { ...e, active: r.active } : e));
+      const r = await selectMutation.mutateAsync({ family: 'tts', backendId: id });
       // Consume the routing echo: warn when the pick lands on a CPU fallback
       // on this host, otherwise confirm the switch. See notifyEngineSelected.
       notifyEngineSelected(r, t, 'tts');

--- a/frontend/src/components/audiobook/AudiobookHero.jsx
+++ b/frontend/src/components/audiobook/AudiobookHero.jsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { BookMarked, BookOpen, FileUp, ListTree, Loader, Sparkles, Square } from 'lucide-react';
 
 import { Button } from '../../ui';
+import EngineQuickSwitch from '../EngineQuickSwitch';
 
 /** The inviting front door for the long-form workflow: context, path, and actions. */
 export default function AudiobookHero({
@@ -32,6 +33,7 @@ export default function AudiobookHero({
           <h2 className="m-0 [font-family:var(--font-serif)] text-[var(--text-lg)] font-semibold text-fg">
             {t('audiobook.title')}
           </h2>
+          <EngineQuickSwitch />
         </div>
 
         <div className="flex flex-wrap items-center justify-end gap-[4px]">

--- a/frontend/src/components/dub/DubHeader.jsx
+++ b/frontend/src/components/dub/DubHeader.jsx
@@ -12,6 +12,7 @@ import { Button } from '../../ui';
 import FooterBtn from './FooterBtn';
 import DubPipelineStepper from './DubPipelineStepper';
 import { formatTime } from '../../utils/format';
+import EngineQuickSwitch from '../EngineQuickSwitch';
 
 export default function DubHeader({
   t,
@@ -89,6 +90,7 @@ export default function DubHeader({
 
       <div className="dub-command-bar__actions [.shell-mini_&]:col-[1/-1] [.shell-mini_&]:row-start-3 [.shell-mini_&]:w-full [.shell-mini_&]:flex-wrap">
         <div className="dub-command-bar__utilities">
+          <EngineQuickSwitch />
           <Button
             variant="subtle"
             size="sm"

--- a/frontend/src/components/dub/DubHeader.test.jsx
+++ b/frontend/src/components/dub/DubHeader.test.jsx
@@ -6,8 +6,11 @@ import i18n from '../../i18n';
 import DubHeader from './DubHeader';
 
 // DubHeader mounts EngineQuickSwitch, whose useEngines query needs a client.
+// One client at module scope: an inline `new QueryClient()` would be a fresh
+// client on every wrapper render, so a rerender() drops the query cache.
+const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
 describe('DubHeader command bar', () => {

--- a/frontend/src/components/dub/DubHeader.test.jsx
+++ b/frontend/src/components/dub/DubHeader.test.jsx
@@ -1,8 +1,14 @@
 import { render, screen, within } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi } from 'vitest';
 import i18n from '../../i18n';
 import DubHeader from './DubHeader';
+
+// DubHeader mounts EngineQuickSwitch, whose useEngines query needs a client.
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
 
 describe('DubHeader command bar', () => {
   it('keeps project identity, compact pipeline, and batch action in one production bar', () => {
@@ -32,6 +38,7 @@ describe('DubHeader command bar', () => {
           onPipelineStep={vi.fn()}
         />
       </I18nextProvider>,
+      { wrapper },
     );
 
     const bar = screen.getByTestId('dub-command-bar');

--- a/frontend/src/components/settings/EnginesTab.jsx
+++ b/frontend/src/components/settings/EnginesTab.jsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import { addBreadcrumb } from '../../utils/breadcrumbs';
-import { selectEngine } from '../../api/engines';
+import { useEngines, useSelectEngine } from '../../api/hooks';
 import { notifyEngineSelected } from '../../utils/engineSelectToast';
 import EngineCompatibilityMatrix from '../EngineCompatibilityMatrix';
 import AsrOpenAICompatPanel from './AsrOpenAICompatPanel';
@@ -17,22 +17,23 @@ import { SETTINGS_SECTION_SURFACE } from './primitives';
  *  tabindex + arrow keys, active engine named in each tab caption) now
  *  presents one family at a time instead, over compact fixed-height rows.
  *
- *  Data contract is unchanged: the single mounted matrix issues exactly one
- *  GET /engines + one GET /model/loaded per Settings open (switching tabs
- *  re-slices the same payload — no refetch), `openSettingsTab('engines')`
- *  still lands here, and `OMNIVOICE_*_BACKEND` env vars still win over any
- *  pick made in the UI.
+ *  The mounted matrix reads the app-wide `/engines` cache and issues one
+ *  `/model/loaded` probe. Switching tabs only re-slices that shared payload;
+ *  selection and installs invalidate it for every consumer.
  *
  *  The ASR tab additionally mounts the OpenAI-compatible remote ASR config
  *  panel below the matrix — configure server URL / model / key, test the
  *  connection, then activate with the engine's own "Use" button. Saving in
  *  the panel bumps `configVersion`, which refetches the matrix so the
  *  engine's row flips unavailable → available without a manual Refresh. */
-export default function EnginesTab() {
+export default function EnginesTab({ initialFamily = 'tts', onFamilyChange }) {
   const { t } = useTranslation();
-  const [family, setFamily] = useState('tts');
+  const [family, setFamily] = useState(initialFamily);
   const [configVersion, setConfigVersion] = useState(0);
+  const enginesQuery = useEngines();
+  const selectMutation = useSelectEngine();
   const onAsrConfigSaved = useCallback(() => setConfigVersion((v) => v + 1), []);
+  useEffect(() => setFamily(initialFamily), [initialFamily]);
 
   // Plan 02-04 / ENGINE-06 — engine selection is wired through the
   // matrix component's optional onSelect callback so the matrix doubles
@@ -46,7 +47,7 @@ export default function EnginesTab() {
     async (family, backendId, modelId) => {
       try {
         addBreadcrumb(`engine:${family}=${backendId}`);
-        const r = await selectEngine(family, backendId, modelId);
+        const r = await selectMutation.mutateAsync({ family, backendId, modelId });
         // Consume the routing echo: warn (not a bare success) when the pick
         // lands on a CPU fallback on this host. See notifyEngineSelected.
         notifyEngineSelected(r, t, family);
@@ -54,7 +55,7 @@ export default function EnginesTab() {
         toast.error(e.message || t('engines.switch_failed'));
       }
     },
-    [t],
+    [selectMutation, t],
   );
 
   return (
@@ -65,9 +66,13 @@ export default function EnginesTab() {
         aria-label={t('settings.engines')}
       >
         <EngineCompatibilityMatrix
-          family="tts"
+          family={family}
+          sharedEngines={enginesQuery}
           onSelect={onSelect}
-          onFamilyChange={setFamily}
+          onFamilyChange={(next) => {
+            setFamily(next);
+            onFamilyChange?.(next);
+          }}
           reloadToken={configVersion}
         />
       </section>

--- a/frontend/src/components/settings/EnginesTab.test.jsx
+++ b/frontend/src/components/settings/EnginesTab.test.jsx
@@ -28,9 +28,10 @@ vi.mock('../../api/system', () => ({
 // The ASR tab mounts AsrOpenAICompatPanel, which loads its config over the
 // api client — mocked so switching tabs never hits the network here.
 const apiJson = vi.fn();
+const apiFetch = vi.fn();
 vi.mock('../../api/client', () => ({
   apiJson: (...a) => apiJson(...a),
-  apiFetch: vi.fn(),
+  apiFetch: (...a) => apiFetch(...a),
   apiPost: vi.fn(),
 }));
 
@@ -93,6 +94,13 @@ describe('EnginesTab', () => {
     vi.clearAllMocks();
     listEngines.mockResolvedValue(ENGINES);
     listLoadedModels.mockResolvedValue({ models: [], count: 0 });
+    apiFetch.mockResolvedValue({
+      json: async () => ({
+        base_url: 'http://localhost:8000/v1',
+        model: 'qwen3-asr',
+        has_key: false,
+      }),
+    });
     // AsrOpenAICompatPanel's GET on mount (ASR tab only).
     apiJson.mockResolvedValue({ base_url: '', model: 'whisper-1', has_key: false });
   });
@@ -142,6 +150,20 @@ describe('EnginesTab', () => {
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
     await waitFor(() => expect(listLoadedModels).toHaveBeenCalled());
     expect(listLoadedModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches the shared inventory after saving OpenAI-compatible ASR config', async () => {
+    renderEnginesTab();
+    await screen.findByText('VoiceStudio (test)');
+    clickFamilyTab('ASR');
+    await screen.findByTestId('asr-openai-compat-model');
+
+    fireEvent.change(screen.getByTestId('asr-openai-compat-model'), {
+      target: { value: 'qwen3-asr' },
+    });
+    fireEvent.click(screen.getByTestId('asr-openai-compat-save'));
+
+    await waitFor(() => expect(listEngines).toHaveBeenCalledTimes(2));
   });
 
   it('clicking Use on an ASR engine selects it with family="asr"', async () => {

--- a/frontend/src/components/settings/EnginesTab.test.jsx
+++ b/frontend/src/components/settings/EnginesTab.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // Keep toast side-channels out of the test (timers, portals).
 vi.mock('react-hot-toast', () => ({
@@ -36,6 +37,15 @@ vi.mock('../../api/client', () => ({
 import { listEngines, selectEngine } from '../../api/engines';
 import { listLoadedModels } from '../../api/system';
 import EnginesTab from './EnginesTab';
+
+function renderEnginesTab() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <EnginesTab />
+    </QueryClientProvider>,
+  );
+}
 
 function entry(id, name) {
   return {
@@ -88,7 +98,7 @@ describe('EnginesTab', () => {
   });
 
   it('renders ONE tabbed section — TTS/ASR/LLM tab strip, one family at a time', async () => {
-    render(<EnginesTab />);
+    renderEnginesTab();
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
 
     // One settings card, not three stacked per-family matrices.
@@ -110,7 +120,7 @@ describe('EnginesTab', () => {
   });
 
   it('switching to the ASR tab shows ASR engines without refetching /engines', async () => {
-    render(<EnginesTab />);
+    renderEnginesTab();
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
 
     clickFamilyTab('ASR');
@@ -122,13 +132,13 @@ describe('EnginesTab', () => {
   });
 
   it('fetches GET /engines exactly once on mount', async () => {
-    render(<EnginesTab />);
+    renderEnginesTab();
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
     expect(listEngines).toHaveBeenCalledTimes(1);
   });
 
   it('probes GET /model/loaded exactly once on mount', async () => {
-    render(<EnginesTab />);
+    renderEnginesTab();
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
     await waitFor(() => expect(listLoadedModels).toHaveBeenCalled());
     expect(listLoadedModels).toHaveBeenCalledTimes(1);
@@ -143,7 +153,7 @@ describe('EnginesTab', () => {
       effective_device: 'cpu',
       routing_reason: null,
     });
-    render(<EnginesTab />);
+    renderEnginesTab();
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
 
     clickFamilyTab('ASR');
@@ -156,7 +166,7 @@ describe('EnginesTab', () => {
   });
 
   it('mounts the OpenAI-compatible ASR config panel on the ASR tab only', async () => {
-    render(<EnginesTab />);
+    renderEnginesTab();
     await waitFor(() => screen.getByText('VoiceStudio (test)'));
     // TTS tab: no ASR config panel.
     expect(screen.queryByTestId('asr-openai-compat-base-url')).not.toBeInTheDocument();

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -1596,6 +1596,8 @@
     "or": "أو",
     "nav": "الملاحة",
     "nav_cheatsheet": "عرض ورقة الغش هذه",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "إغلاق مشروط / إلغاء",
     "nav_save": "حفظ المشروع/الالتزام بالقطع",
     "segmentEditor": "محرر المقطع",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1596,6 +1596,8 @@
     "or": "oder",
     "nav": "Navigation",
     "nav_cheatsheet": "Zeige diesen Spickzettel",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Modal schließen / abbrechen",
     "nav_save": "Projekt speichern / Trimmen festschreiben",
     "segmentEditor": "Segmenteditor",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -2133,6 +2133,8 @@
     "or": "or",
     "nav": "Navigation",
     "nav_cheatsheet": "Show this cheatsheet",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Close modal / cancel",
     "nav_save": "Save project / commit trim",
     "segmentEditor": "Segment editor",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1596,6 +1596,8 @@
     "or": "o",
     "nav": "Navegación",
     "nav_cheatsheet": "Mostrar esta hoja de trucos",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Cerrar modal/cancelar",
     "nav_save": "Guardar proyecto/comprobar recorte",
     "segmentEditor": "editor de segmentos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1596,6 +1596,8 @@
     "or": "ou",
     "nav": "Navigation",
     "nav_cheatsheet": "Afficher cette aide-mémoire",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Fermer modal / annuler",
     "nav_save": "Enregistrer le projet/commettre le trim",
     "segmentEditor": "Editeur de segments",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -1596,6 +1596,8 @@
     "or": "या",
     "nav": "नेविगेशन",
     "nav_cheatsheet": "यह चीटशीट दिखाओ",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "मोडल बंद करें / रद्द करें",
     "nav_save": "प्रोजेक्ट सहेजें/कमिट ट्रिम करें",
     "segmentEditor": "खंड संपादक",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -1596,6 +1596,8 @@
     "or": "atau",
     "nav": "Navigasi",
     "nav_cheatsheet": "Tunjukkan lembar contekan ini",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Tutup modal / batalkan",
     "nav_save": "Simpan proyek/komit trim",
     "segmentEditor": "Editor segmen",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -1596,6 +1596,8 @@
     "or": "o",
     "nav": "Navigazione",
     "nav_cheatsheet": "Mostra questo foglietto illustrativo",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Chiudi modale/annulla",
     "nav_save": "Salva progetto / conferma ritaglio",
     "segmentEditor": "Redattore di segmenti",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1596,6 +1596,8 @@
     "or": "または",
     "nav": "ナビゲーション",
     "nav_cheatsheet": "このチートシートを表示する",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "モーダルを閉じる/キャンセル",
     "nav_save": "プロジェクトの保存 / トリムのコミット",
     "segmentEditor": "セグメントエディター",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1596,6 +1596,8 @@
     "or": "또는",
     "nav": "네비게이션",
     "nav_cheatsheet": "이 치트시트를 보여주세요",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "모달 닫기/취소",
     "nav_save": "프로젝트 저장/트림 커밋",
     "segmentEditor": "세그먼트 편집기",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -1596,6 +1596,8 @@
     "or": "of",
     "nav": "Navigatie",
     "nav_cheatsheet": "Laat dit spiekbriefje zien",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Modaal sluiten / annuleren",
     "nav_save": "Project opslaan / trimmen vastleggen",
     "segmentEditor": "Segmenteditor",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -1596,6 +1596,8 @@
     "or": "lub",
     "nav": "Nawigacja",
     "nav_cheatsheet": "Pokaż tę ściągawkę",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Zamknij modalne / anuluj",
     "nav_save": "Zapisz projekt / zatwierdź przycięcie",
     "segmentEditor": "Edytor segmentów",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1596,6 +1596,8 @@
     "or": "ou",
     "nav": "Navegação",
     "nav_cheatsheet": "Mostrar esta folha de dicas",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Fechar modal/cancelar",
     "nav_save": "Salvar projeto/comprometer corte",
     "segmentEditor": "Editor de segmento",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1596,6 +1596,8 @@
     "or": "или",
     "nav": "Навигация",
     "nav_cheatsheet": "Показать эту шпаргалку",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Закрыть модально/отменить",
     "nav_save": "Сохранить проект/зафиксировать обрезку",
     "segmentEditor": "Редактор сегментов",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -1596,6 +1596,8 @@
     "or": "eller",
     "nav": "Navigering",
     "nav_cheatsheet": "Visa detta cheatsheet",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Stäng modal / avbryt",
     "nav_save": "Spara projekt / commit trim",
     "segmentEditor": "Segmentredigerare",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -1596,6 +1596,8 @@
     "or": "หรือ",
     "nav": "การนำทาง",
     "nav_cheatsheet": "แสดงสูตรโกงนี้",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "ปิดกิริยา / ยกเลิก",
     "nav_save": "บันทึกโปรเจ็กต์ / คอมมิตการตัดแต่ง",
     "segmentEditor": "ตัวแก้ไขส่วน",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -1596,6 +1596,8 @@
     "or": "veya",
     "nav": "Navigasyon",
     "nav_cheatsheet": "Bu kopya sayfasını göster",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Modu kapat / iptal et",
     "nav_save": "Projeyi kaydet/kesmeyi tamamla",
     "segmentEditor": "Segment düzenleyici",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -1596,6 +1596,8 @@
     "or": "або",
     "nav": "Навігація",
     "nav_cheatsheet": "Покажіть цю шпаргалку",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Закрити режим / скасувати",
     "nav_save": "Зберегти проект / зафіксувати обрізку",
     "segmentEditor": "Редактор сегментів",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -1596,6 +1596,8 @@
     "or": "hoặc",
     "nav": "Điều hướng",
     "nav_cheatsheet": "Hiển thị bảng cheat này",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "Đóng phương thức / hủy",
     "nav_save": "Lưu dự án / cam kết cắt",
     "segmentEditor": "Trình chỉnh sửa phân đoạn",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1602,6 +1602,8 @@
     "or": "或",
     "nav": "导航",
     "nav_cheatsheet": "显示此备忘单",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "关闭模式/取消",
     "nav_save": "保存项目 / 提交裁剪",
     "segmentEditor": "段编辑器",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1596,6 +1596,8 @@
     "or": "或",
     "nav": "導航",
     "nav_cheatsheet": "顯示此備忘單",
+    "nav_enginePickerKey": "Cmd/Ctrl+E",
+    "nav_workspacesKey": "Cmd/Ctrl+1–9",
     "nav_closeModal": "關閉模式/取消",
     "nav_save": "保存項目/提交修剪",
     "segmentEditor": "段編輯器",

--- a/frontend/src/pages/AudiobookTab.jsx
+++ b/frontend/src/pages/AudiobookTab.jsx
@@ -8,7 +8,7 @@ import {
   audiobookImport,
 } from '../api/audiobook';
 import { audioUrl } from '../api/generate';
-import { listEngines } from '../api/engines';
+import { useEngines } from '../api/hooks';
 import { consumeLongformStream } from '../utils/longformStream';
 import { useAppStore } from '../store';
 import { overridesToRequest } from '../components/audiobook/AudiobookOverrides';
@@ -61,23 +61,12 @@ export default function AudiobookTab({ profiles = [] }) {
   const setLanguage = (v) => setOutputPrefs({ language: v || 'Auto' });
   const overrides = useAppStore((s) => s.overrides);
   const setLongformOverrides = useAppStore((s) => s.setLongformOverrides);
-  // Show emotion controls only when the active engine understands them
-  // (IndexTTS2). Fetched once on mount; degrades to hidden if the probe fails.
-  const [emotionSupported, setEmotionSupported] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    listEngines()
-      .then((r) => {
-        if (!alive) return;
-        const active = r?.tts?.active;
-        const b = (r?.tts?.backends || []).find((x) => x.id === active);
-        setEmotionSupported(!!b?.supports_emotion);
-      })
-      .catch(() => {});
-    return () => {
-      alive = false;
-    };
-  }, []);
+  // Derived from the shared engine cache so a switch elsewhere updates these
+  // controls immediately instead of leaving a stale mount-time snapshot.
+  const { data: engines } = useEngines();
+  const activeTts = engines?.tts?.active;
+  const emotionSupported = !!engines?.tts?.backends?.find((engine) => engine.id === activeTts)
+    ?.supports_emotion;
   const [plan, setPlan] = useState(null);
   const [planLoading, setPlanLoading] = useState(false);
   const [generating, setGenerating] = useState(false);

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -7,12 +7,13 @@ import { Segmented } from '../ui';
 import { useAppStore } from '../store';
 import { API, apiPost, apiFetch } from '../api/client';
 import { mergeDescribedAttrs } from '../utils/voiceInstruct';
-import { listEngines } from '../api/engines';
+import { useEngines } from '../api/hooks';
 import { claimPlayback, stopActivePlayback, usePlaybackSource } from '../utils/playback';
 import ScriptPanel from '../components/clone/ScriptPanel';
 import AudioMethodPanel from '../components/clone/AudioMethodPanel';
 import DesignMethodPanel from '../components/clone/DesignMethodPanel';
 import ActionBar from '../components/clone/ActionBar';
+import EngineQuickSwitch from '../components/EngineQuickSwitch';
 
 export default function CloneDesignTab(props) {
   const {
@@ -174,15 +175,10 @@ export default function CloneDesignTab(props) {
     setVdStates(resetVd);
   };
 
-  // Engine readiness — used by the demo "Hear demo" fallback. Polls every
-  // 15s so a freshly-finished model download flips the button back to live
-  // synthesis without a manual refresh.
-  const { data: enginesData } = useQuery({
-    queryKey: ['engines-readiness'],
-    queryFn: listEngines,
-    refetchInterval: 15000,
-    staleTime: 5000,
-  });
+  // Engine readiness for the demo fallback. Model installs invalidate this
+  // shared query, so a newly-ready engine replaces the demo without a stale
+  // local snapshot or a second poller.
+  const { data: enginesData } = useEngines();
   const anyTtsReady = !!(enginesData?.tts?.backends || []).some((b) => b.available);
 
   // Demo coach-mark: when the user is on the "From audio" method with the
@@ -328,21 +324,24 @@ export default function CloneDesignTab(props) {
                 <Volume2 className="label-icon" size={14} />{' '}
                 {t('clone.voice_kicker', { defaultValue: 'Voice' })}
               </span>
-              <Segmented
-                size="sm"
-                value={defineMethod}
-                onChange={setDefineMethod}
-                items={[
-                  {
-                    value: 'audio',
-                    label: t('clone.define_from_audio', { defaultValue: 'From audio' }),
-                  },
-                  {
-                    value: 'design',
-                    label: t('clone.define_by_design', { defaultValue: 'By design' }),
-                  },
-                ]}
-              />
+              <div className="flex items-center gap-[6px]">
+                <EngineQuickSwitch />
+                <Segmented
+                  size="sm"
+                  value={defineMethod}
+                  onChange={setDefineMethod}
+                  items={[
+                    {
+                      value: 'audio',
+                      label: t('clone.define_from_audio', { defaultValue: 'From audio' }),
+                    },
+                    {
+                      value: 'design',
+                      label: t('clone.define_by_design', { defaultValue: 'By design' }),
+                    },
+                  ]}
+                />
+              </div>
             </div>
 
             {defineMethod === 'audio' ? (

--- a/frontend/src/pages/ModelCatalogue.jsx
+++ b/frontend/src/pages/ModelCatalogue.jsx
@@ -13,8 +13,8 @@
  * Deliberately a COMPOSITION, not a rewrite: the panes mount the existing
  * `EnginesTab` (engine matrix + the OpenAI-compatible ASR config) and
  * `ModelStoreTab` unchanged, so their data contracts, tests and behaviour carry
- * over untouched — one GET /engines + one GET /model/loaded per open, the same
- * install/delete flows, the same env-var-wins semantics.
+ * over untouched — the shared engine cache, the same install/delete flows, and
+ * the same env-var-wins semantics.
  *
  * `pendingCatalogueTab` is the one-shot deep-link hand-off (mirrors Settings'
  * `pendingSettingsTab`): a caller sets the pane and navigates here, this page
@@ -31,7 +31,9 @@ import ModelStoreTab from '../components/settings/ModelStoreTab';
 
 /** Persisted across visits so the workspace reopens where you left it. */
 const PANE_KEY = 'omnivoice.catalogue.pane';
+const FAMILY_KEY = 'omnivoice.catalogue.engine-family';
 const PANES = ['engines', 'models'];
+const FAMILIES = ['tts', 'asr', 'llm'];
 
 function readStoredPane() {
   try {
@@ -42,14 +44,28 @@ function readStoredPane() {
   }
 }
 
+function readStoredFamily() {
+  try {
+    const stored = localStorage.getItem(FAMILY_KEY);
+    return FAMILIES.includes(stored) ? stored : 'tts';
+  } catch {
+    return 'tts';
+  }
+}
+
 export default function ModelCatalogue() {
   const { t } = useTranslation();
   const pendingCatalogueTab = useAppStore((s) => s.pendingCatalogueTab);
+  const pendingCatalogueFamily = useAppStore((s) => s.pendingCatalogueFamily);
   const setPendingCatalogueTab = useAppStore((s) => s.setPendingCatalogueTab);
+  const setPendingCatalogueFamily = useAppStore((s) => s.setPendingCatalogueFamily);
   // Seed from the deep-link so the first paint is already the requested pane —
   // seeding from storage and correcting in an effect would flash the wrong one.
   const [pane, setPaneRaw] = useState(() =>
     PANES.includes(pendingCatalogueTab) ? pendingCatalogueTab : readStoredPane(),
+  );
+  const [family, setFamilyRaw] = useState(() =>
+    FAMILIES.includes(pendingCatalogueFamily) ? pendingCatalogueFamily : readStoredFamily(),
   );
 
   const setPane = useCallback((next) => {
@@ -60,14 +76,31 @@ export default function ModelCatalogue() {
       /* private mode / quota — the pane still switches, it just won't persist */
     }
   }, []);
+  const setFamily = useCallback((next) => {
+    setFamilyRaw(next);
+    try {
+      localStorage.setItem(FAMILY_KEY, next);
+    } catch {
+      /* private mode / quota — the family still switches */
+    }
+  }, []);
 
   // Consume the one-shot deep-link (including a repeat request for the pane
   // we're already on, which must still clear).
   useEffect(() => {
     if (!pendingCatalogueTab) return;
     if (PANES.includes(pendingCatalogueTab)) setPane(pendingCatalogueTab);
+    if (FAMILIES.includes(pendingCatalogueFamily)) setFamily(pendingCatalogueFamily);
     setPendingCatalogueTab(null);
-  }, [pendingCatalogueTab, setPendingCatalogueTab, setPane]);
+    setPendingCatalogueFamily(null);
+  }, [
+    pendingCatalogueTab,
+    pendingCatalogueFamily,
+    setPendingCatalogueFamily,
+    setPendingCatalogueTab,
+    setFamily,
+    setPane,
+  ]);
 
   const { data: info } = useSystemInfo();
   const { data: status } = useModelStatus();
@@ -141,7 +174,7 @@ export default function ModelCatalogue() {
           className="min-w-0 [&>*:first-child]:mt-0 @min-[760px]/catalogue-shell:min-h-0 @min-[760px]/catalogue-shell:flex-1 @min-[760px]/catalogue-shell:overflow-y-auto @min-[760px]/catalogue-shell:overscroll-contain"
         >
           {pane === 'engines' ? (
-            <EnginesTab />
+            <EnginesTab initialFamily={family} onFamilyChange={setFamily} />
           ) : (
             <ModelStoreTab info={info} modelBadge={modelBadge} />
           )}

--- a/frontend/src/pages/ModelCatalogue.test.jsx
+++ b/frontend/src/pages/ModelCatalogue.test.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 
 vi.mock('../components/settings/EnginesTab', () => ({
-  default: () => <div data-testid="stub-engines" />,
+  default: ({ initialFamily }) => <div data-testid="stub-engines">{initialFamily}</div>,
 }));
 vi.mock('../components/settings/ModelStoreTab', () => ({
   default: ({ modelBadge }) => <div data-testid="stub-models">{modelBadge}</div>,
@@ -35,7 +35,11 @@ describe('ModelCatalogue', () => {
   beforeEach(() => {
     localStorage.clear();
     act(() => {
-      useAppStore.setState({ mode: 'catalogue', pendingCatalogueTab: null });
+      useAppStore.setState({
+        mode: 'catalogue',
+        pendingCatalogueTab: null,
+        pendingCatalogueFamily: null,
+      });
     });
   });
 
@@ -78,6 +82,15 @@ describe('ModelCatalogue', () => {
     expect(useAppStore.getState().pendingCatalogueTab).toBeNull();
   });
 
+  it('honours an engine-family deep link and clears it after hand-off', () => {
+    act(() => {
+      useAppStore.getState().openCatalogue({ pane: 'engines', family: 'asr' });
+    });
+    render(<ModelCatalogue />);
+    expect(screen.getByTestId('stub-engines')).toHaveTextContent('asr');
+    expect(useAppStore.getState().pendingCatalogueFamily).toBeNull();
+  });
+
   it('passes the loaded-model badge down to the model store pane', () => {
     act(() => {
       useAppStore.setState({ pendingCatalogueTab: 'models' });
@@ -104,5 +117,13 @@ describe('openCatalogue', () => {
       useAppStore.getState().openCatalogue();
     });
     expect(useAppStore.getState().pendingCatalogueTab).toBe('engines');
+  });
+
+  it('accepts an object deep link with a family', () => {
+    act(() => {
+      useAppStore.getState().openCatalogue({ pane: 'engines', family: 'llm' });
+    });
+    expect(useAppStore.getState().pendingCatalogueTab).toBe('engines');
+    expect(useAppStore.getState().pendingCatalogueFamily).toBe('llm');
   });
 });

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -313,10 +313,10 @@ function SupportView() {
                 type="button"
                 aria-pressed={selected}
                 onClick={() => setAmount(selected ? null : a.value)}
-                className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border px-1.5 py-2 transition-colors ${
+                className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border bg-[var(--chrome-bg-elevated,var(--chrome-bg))] px-1.5 py-2 transition-[background,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--chrome-accent)] ${
                   selected
-                    ? 'border-[var(--chrome-accent)] bg-[var(--chrome-accent-bg)]'
-                    : `${a.common ? 'border-transparent' : 'border-border'} hover:border-transparent hover:bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)]`
+                    ? 'border-[var(--chrome-accent-border)] bg-[var(--chrome-accent-bg)] shadow-[inset_0_0_0_1px_var(--chrome-accent-border)]'
+                    : `${a.common ? 'border-[color-mix(in_srgb,var(--chrome-accent)_28%,var(--chrome-border))] bg-[color-mix(in_srgb,var(--chrome-accent)_5%,var(--chrome-bg-elevated,var(--chrome-bg)))]' : 'border-[var(--chrome-border)]'} hover:border-[var(--chrome-accent-border)] hover:bg-[var(--chrome-accent-bg)]`
                 }`}
               >
                 <span className="font-serif text-[1.05rem] font-medium text-[var(--chrome-fg)]">
@@ -334,10 +334,10 @@ function SupportView() {
             type="button"
             aria-pressed={amount === 'custom'}
             onClick={() => setAmount(amount === 'custom' ? null : 'custom')}
-            className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border px-1.5 py-2 transition-colors ${
+            className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border bg-[var(--chrome-bg-elevated,var(--chrome-bg))] px-1.5 py-2 transition-[background,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--chrome-accent)] ${
               amount === 'custom'
-                ? 'border-[var(--chrome-accent)] bg-[var(--chrome-accent-bg)]'
-                : 'border-border hover:border-transparent hover:bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)]'
+                ? 'border-[var(--chrome-accent-border)] bg-[var(--chrome-accent-bg)] shadow-[inset_0_0_0_1px_var(--chrome-accent-border)]'
+                : 'border-[var(--chrome-border)] hover:border-[var(--chrome-accent-border)] hover:bg-[var(--chrome-accent-bg)]'
             }`}
           >
             <span className="font-mono text-[0.78rem] uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">

--- a/frontend/src/pages/SupportPage.jsx
+++ b/frontend/src/pages/SupportPage.jsx
@@ -313,10 +313,10 @@ function SupportView() {
                 type="button"
                 aria-pressed={selected}
                 onClick={() => setAmount(selected ? null : a.value)}
-                className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border bg-[var(--chrome-bg-elevated,var(--chrome-bg))] px-1.5 py-2 transition-[background,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--chrome-accent)] ${
+                className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border-0 bg-[color-mix(in_srgb,var(--chrome-fg)_5%,transparent)] px-1.5 py-2 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-fg-muted)_18%,transparent)] transition-[background,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--chrome-accent)] ${
                   selected
-                    ? 'border-[var(--chrome-accent-border)] bg-[var(--chrome-accent-bg)] shadow-[inset_0_0_0_1px_var(--chrome-accent-border)]'
-                    : `${a.common ? 'border-[color-mix(in_srgb,var(--chrome-accent)_28%,var(--chrome-border))] bg-[color-mix(in_srgb,var(--chrome-accent)_5%,var(--chrome-bg-elevated,var(--chrome-bg)))]' : 'border-[var(--chrome-border)]'} hover:border-[var(--chrome-accent-border)] hover:bg-[var(--chrome-accent-bg)]`
+                    ? 'bg-[var(--chrome-accent-bg)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-accent)_45%,transparent)]'
+                    : `${a.common ? 'bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-accent)_30%,transparent)]' : ''} hover:bg-[var(--chrome-accent-bg)] hover:shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-accent)_35%,transparent)]`
                 }`}
               >
                 <span className="font-serif text-[1.05rem] font-medium text-[var(--chrome-fg)]">
@@ -334,10 +334,10 @@ function SupportView() {
             type="button"
             aria-pressed={amount === 'custom'}
             onClick={() => setAmount(amount === 'custom' ? null : 'custom')}
-            className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border bg-[var(--chrome-bg-elevated,var(--chrome-bg))] px-1.5 py-2 transition-[background,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--chrome-accent)] ${
+            className={`flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border-0 bg-[color-mix(in_srgb,var(--chrome-fg)_5%,transparent)] px-1.5 py-2 shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-fg-muted)_18%,transparent)] transition-[background,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--chrome-accent)] ${
               amount === 'custom'
-                ? 'border-[var(--chrome-accent-border)] bg-[var(--chrome-accent-bg)] shadow-[inset_0_0_0_1px_var(--chrome-accent-border)]'
-                : 'border-[var(--chrome-border)] hover:border-[var(--chrome-accent-border)] hover:bg-[var(--chrome-accent-bg)]'
+                ? 'bg-[var(--chrome-accent-bg)] shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-accent)_45%,transparent)]'
+                : 'hover:bg-[var(--chrome-accent-bg)] hover:shadow-[inset_0_0_0_1px_color-mix(in_srgb,var(--chrome-accent)_35%,transparent)]'
             }`}
           >
             <span className="font-mono text-[0.78rem] uppercase tracking-[var(--chrome-label-track)] text-[var(--chrome-fg-muted)]">

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -11,6 +11,7 @@ import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Mic, Copy, Trash2, Search, Clock, Languages, FileText, Download } from 'lucide-react';
 import { Button } from '../ui';
+import EngineQuickSwitch from '../components/EngineQuickSwitch';
 import { toast } from 'react-hot-toast';
 import { toMillis } from '../utils/relativeTime';
 import { useEffectiveDictationShortcut } from '../hooks/useEffectiveDictationShortcut';
@@ -159,6 +160,7 @@ export default function TranscriptionsPage() {
           </span>
         </div>
         <div className="txn-header__right flex items-center gap-[6px]">
+          <EngineQuickSwitch family="asr" />
           <Button size="sm" variant="primary" onClick={startCapture}>
             <Mic size={13} /> {t('transcriptions.capture')}
           </Button>

--- a/frontend/src/pages/Transcriptions.test.jsx
+++ b/frontend/src/pages/Transcriptions.test.jsx
@@ -7,6 +7,7 @@ const { requestDictationCapture, toast } = vi.hoisted(() => ({
 }));
 
 vi.mock('../utils/dictationCapture', () => ({ requestDictationCapture }));
+vi.mock('../components/EngineQuickSwitch', () => ({ default: () => null }));
 vi.mock('../hooks/useEffectiveDictationShortcut', () => ({
   useEffectiveDictationShortcut: () => ({
     info: {

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -12,6 +12,7 @@
  * to the launchpad rather than half-load a stale project state.
  */
 import type { StateCreator } from 'zustand';
+import type { EngineFamily } from '../api/types';
 
 export type AppMode =
   | 'launchpad'
@@ -33,6 +34,7 @@ export type AppMode =
 
 /** Which pane the Model Catalogue workspace opens on. */
 export type CatalogueTab = 'engines' | 'models';
+export type CatalogueTarget = CatalogueTab | { pane?: CatalogueTab; family?: EngineFamily };
 
 /**
  * The Voice workspace's "Define voice" method (was the Clone/Design tab
@@ -79,6 +81,8 @@ export interface UiSlice {
    * replaced the old Engines / Model Store panels.
    */
   pendingCatalogueTab: CatalogueTab | null;
+  /** Optional engine family to focus after entering the catalogue. */
+  pendingCatalogueFamily: EngineFamily | null;
   isSidebarCollapsed: boolean;
   isSidebarProjectsCollapsed: boolean;
   sidebarTab: SidebarTab;
@@ -98,10 +102,11 @@ export interface UiSlice {
   setPendingProfileId: (id: string | null) => void;
   setPendingSettingsTab: (tab: string | null) => void;
   setPendingCatalogueTab: (tab: CatalogueTab | null) => void;
+  setPendingCatalogueFamily: (family: EngineFamily | null) => void;
   /** Navigate to Settings on a specific tab in one call. */
   openSettingsTab: (tab: string) => void;
   /** Navigate to the Model Catalogue on a specific pane in one call. */
-  openCatalogue: (tab?: CatalogueTab) => void;
+  openCatalogue: (target?: CatalogueTarget) => void;
   setIsSidebarCollapsed: (collapsed: boolean) => void;
   setIsSidebarProjectsCollapsed: (collapsed: boolean) => void;
   setSidebarTab: (tab: SidebarTab) => void;
@@ -127,6 +132,7 @@ export const createUiSlice: StateCreator<UiSlice, [], [], UiSlice> = (set, get) 
   pendingProfileId: null,
   pendingSettingsTab: null,
   pendingCatalogueTab: null,
+  pendingCatalogueFamily: null,
   isSidebarCollapsed: false,
   isSidebarProjectsCollapsed: false,
   sidebarTab: 'projects',
@@ -148,8 +154,13 @@ export const createUiSlice: StateCreator<UiSlice, [], [], UiSlice> = (set, get) 
   setPendingProfileId: (id) => set({ pendingProfileId: id }),
   setPendingSettingsTab: (tab) => set({ pendingSettingsTab: tab }),
   setPendingCatalogueTab: (tab) => set({ pendingCatalogueTab: tab }),
+  setPendingCatalogueFamily: (family) => set({ pendingCatalogueFamily: family }),
   openSettingsTab: (tab) => set({ pendingSettingsTab: tab, mode: 'settings' }),
-  openCatalogue: (tab = 'engines') => set({ pendingCatalogueTab: tab, mode: 'catalogue' }),
+  openCatalogue: (target = 'engines') => {
+    const { pane = 'engines', family = null } =
+      typeof target === 'string' ? { pane: target } : target;
+    set({ pendingCatalogueTab: pane, pendingCatalogueFamily: family, mode: 'catalogue' });
+  },
   setIsSidebarCollapsed: (collapsed) => set({ isSidebarCollapsed: collapsed }),
   setIsSidebarProjectsCollapsed: (collapsed) => set({ isSidebarProjectsCollapsed: collapsed }),
   setSidebarTab: (tab) => set({ sidebarTab: tab }),

--- a/frontend/src/test/DubHeaderActions.test.jsx
+++ b/frontend/src/test/DubHeaderActions.test.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import i18n from '../i18n';
 
 import DubHeader from '../components/dub/DubHeader';
 
 const t = i18n.t.bind(i18n);
+
+// DubHeader mounts EngineQuickSwitch, whose useEngines query needs a client.
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
 
 function makeProps(overrides = {}) {
   return {
@@ -37,7 +43,7 @@ function makeProps(overrides = {}) {
 describe('DubHeader — polished workflow actions', () => {
   it('keeps all three actions visible, ordered, accessible, and wired', () => {
     const props = makeProps();
-    render(<DubHeader {...props} />);
+    render(<DubHeader {...props} />, { wrapper });
 
     const group = screen.getByTestId('dub-primary-actions');
     const buttons = within(group).getAllByRole('button');
@@ -67,7 +73,7 @@ describe('DubHeader — polished workflow actions', () => {
   });
 
   it('wraps and stretches actions in mini shells without changing their labels', () => {
-    render(<DubHeader {...makeProps()} />);
+    render(<DubHeader {...makeProps()} />, { wrapper });
 
     const group = screen.getByTestId('dub-primary-actions');
     expect(group).toHaveClass('flex-wrap', '[.shell-mini_&]:w-full');
@@ -77,7 +83,7 @@ describe('DubHeader — polished workflow actions', () => {
   });
 
   it('exposes verification progress and preserves disabled action guards', () => {
-    const { rerender } = render(<DubHeader {...makeProps({ qcRunning: true })} />);
+    const { rerender } = render(<DubHeader {...makeProps({ qcRunning: true })} />, { wrapper });
     const verify = screen.getByRole('button', { name: t('dub.qc_btn') });
     expect(verify).toBeDisabled();
     expect(verify).toHaveAttribute('aria-busy', 'true');

--- a/frontend/src/test/DubHeaderActions.test.jsx
+++ b/frontend/src/test/DubHeaderActions.test.jsx
@@ -9,8 +9,11 @@ import DubHeader from '../components/dub/DubHeader';
 const t = i18n.t.bind(i18n);
 
 // DubHeader mounts EngineQuickSwitch, whose useEngines query needs a client.
+// One client at module scope: an inline `new QueryClient()` would be a fresh
+// client on every wrapper render, so a rerender() drops the query cache.
+const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
 function makeProps(overrides = {}) {

--- a/frontend/src/test/LogsFooterClearFailure.test.jsx
+++ b/frontend/src/test/LogsFooterClearFailure.test.jsx
@@ -9,11 +9,17 @@ const { clearTauriLogs, toastError, toastSuccess } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
 }));
 
-vi.mock('../api/system', () => ({
+// Partial mocks: only what the test drives is stubbed. The footer renders
+// more consumers of these modules than this test cares about (engine quick
+// switch, compute chip), and a hand-written module object silently drops
+// whichever export they gain next.
+vi.mock('../api/system', async (importOriginal) => ({
+  ...(await importOriginal()),
   clearSystemLogs: vi.fn(),
   clearTauriLogs,
 }));
-vi.mock('../api/hooks', () => ({
+vi.mock('../api/hooks', async (importOriginal) => ({
+  ...(await importOriginal()),
   useSystemLogs: () => ({ data: null, refetch: vi.fn() }),
   useTauriLogs: () => ({ data: null, refetch: vi.fn() }),
   useVisibleNotifications: () => ({ notifications: [] }),

--- a/frontend/src/test/LogsFooterDonatePopover.test.jsx
+++ b/frontend/src/test/LogsFooterDonatePopover.test.jsx
@@ -8,14 +8,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-vi.mock('../api/hooks', () => ({
+// Partial mocks: the footer's other chrome (engine quick switch, compute
+// chip) keeps whatever these modules gain next without this file tracking it.
+vi.mock('../api/hooks', async (importOriginal) => ({
+  ...(await importOriginal()),
   useSystemLogs: () => ({ data: null, refetch: vi.fn() }),
   useTauriLogs: () => ({ data: null, refetch: vi.fn() }),
   useNotifications: () => ({ data: null }),
   useVisibleNotifications: () => ({ data: null, notifications: [] }),
   isDismissibleNotification: () => false,
 }));
-vi.mock('../api/system', () => ({
+vi.mock('../api/system', async (importOriginal) => ({
+  ...(await importOriginal()),
   clearSystemLogs: vi.fn(),
   clearTauriLogs: vi.fn(),
 }));

--- a/frontend/src/test/LogsFooterNotifications.test.jsx
+++ b/frontend/src/test/LogsFooterNotifications.test.jsx
@@ -44,7 +44,10 @@ vi.mock('../api/hooks', async (importOriginal) => {
     useTauriLogs: () => ({ data: null, refetch: vi.fn() }),
   };
 });
-vi.mock('../api/system', () => ({
+vi.mock('../api/system', async (importOriginal) => ({
+  // Partial: the footer's other chrome (engine quick switch, compute chip)
+  // keeps whatever it imports from here without this file tracking it.
+  ...(await importOriginal()),
   clearSystemLogs: vi.fn(),
   clearTauriLogs: vi.fn(),
   // The poll behind useNotifications — the filter under test runs REAL.

--- a/frontend/src/test/audiobookHero.test.jsx
+++ b/frontend/src/test/audiobookHero.test.jsx
@@ -8,8 +8,11 @@ import AudiobookHero from '../components/audiobook/AudiobookHero';
 const t = (key) => key;
 
 // AudiobookHero mounts EngineQuickSwitch, whose useEngines query needs a client.
+// One client at module scope: an inline `new QueryClient()` would be a fresh
+// client on every wrapper render, so a rerender() drops the query cache.
+const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
 function renderHero(overrides = {}) {

--- a/frontend/src/test/audiobookHero.test.jsx
+++ b/frontend/src/test/audiobookHero.test.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import AudiobookHero from '../components/audiobook/AudiobookHero';
 
 const t = (key) => key;
+
+// AudiobookHero mounts EngineQuickSwitch, whose useEngines query needs a client.
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
 
 function renderHero(overrides = {}) {
   return render(
@@ -22,6 +28,7 @@ function renderHero(overrides = {}) {
       onStop={vi.fn()}
       {...overrides}
     />,
+    { wrapper },
   );
 }
 

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -100,6 +100,14 @@ def test_engines_response_includes_new_fields(fresh_app):
         assert entry["isolation_mode"] in {"in-process", "subprocess"}
 
 
+def test_engines_response_marks_environment_pinned_families(fresh_app, monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_ASR_BACKEND", "pytorch-whisper")
+    body = _client(fresh_app).get("/engines").json()
+
+    assert body["asr"]["env_override"] is True
+    assert body["tts"]["env_override"] is False
+
+
 def test_all_families_share_the_11_key_shape(fresh_app):
     client = _client(fresh_app)
     body = client.get("/engines").json()


### PR DESCRIPTION
## Summary
- Share engine inventory and selection invalidation across engine-aware surfaces.
- Add footer and workspace engine quick switching with environment-pin protection.
- Add catalogue family deep-links and in-webview keyboard navigation.

## Validation
- Frontend targeted tests: 75 passing.
- Backend engine API contract tests: 57 passing.
- Frontend format check and CI typecheck passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added shared engine inventory and selection hooks with quick-switch controls for TTS, ASR, and LLM surfaces. Added keyboard shortcuts, catalogue family deep links, residency status, and environment-pin protection to keep engine selection consistent. Risk: verify cache invalidation and environment overrides across engine-aware views; 75 frontend targeted tests and 57 backend contract tests passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->