### PR TITLE
fix(asr): ROCm torch is not CUDA — keep CTranslate2 off the HIP GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- AMD/ROCm hosts no longer crash ASR with "CUDA driver version is insufficient": ROCm torch reports itself as CUDA, but whisperx/faster-whisper run on CTranslate2, which is NVIDIA-only — they now take the CPU path there, and auto-detect prefers pytorch-whisper, which genuinely uses the HIP GPU. (#1529)
 - Crash reports now carry the crashed run's own stderr: the shared error log is append-only with per-run offsets, so a restart can no longer overwrite the dying process's final output with the replacement's healthy startup. (#1510)
 - Wayland: a stale portal identity no longer kills the dictation shortcut for the whole session. The desktop entry the app writes for the GlobalShortcuts portal could point at a binary that has since moved (a `cargo clean`, a relocated AppImage) — GNOME then refuses the bind with "App info not found" and the hotkey silently dies. The entry is validated and rewritten at startup now. (#1526)
 - The guard that keeps transcription on the degrading ASR loader now scans the whole backend, not just the routers — a service that transcribes on a request's behalf skipped `ensure_loaded()` just as thoroughly. (#1519) — thanks @ahov520!

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -520,12 +520,10 @@ class WhisperXBackend(ASRBackend):
     def _pick_device() -> tuple[str, str]:
         # CUDA fp16 when available; otherwise CPU int8 (fastest CPU path,
         # negligible WER regression vs fp32 for whisper-large-v3).
-        try:
-            import torch
-            if torch.cuda.is_available():
-                return "cuda", "float16"
-        except Exception:
-            pass
+        # _ctranslate2_cuda_ok, not torch.cuda.is_available: ROCm torch also
+        # answers True there, and CTranslate2 has no HIP backend (#1529).
+        if _ctranslate2_cuda_ok():
+            return "cuda", "float16"
         return "cpu", "int8"
 
     # Peak VRAM (GB) to load *and transcribe* whisper large-v3 per CTranslate2
@@ -981,12 +979,10 @@ class FasterWhisperBackend(ASRBackend):
         #   - Apple Silicon / CPU → CPU int8 (fastest on CPU, negligible
         #     WER regression vs fp32 for whisper-large-v3)
         device, compute_type = "cpu", "int8"
-        try:
-            import torch
-            if torch.cuda.is_available():
-                device, compute_type = "cuda", "float16"
-        except Exception:
-            pass
+        # _ctranslate2_cuda_ok, not torch.cuda.is_available: ROCm torch also
+        # answers True there, and CTranslate2 has no HIP backend (#1529).
+        if _ctranslate2_cuda_ok():
+            device, compute_type = "cuda", "float16"
         logger.info(
             "faster-whisper loading %s on %s (%s)",
             self._model_name, device, compute_type,
@@ -2464,6 +2460,45 @@ def _mps_available() -> bool:
         return False
 
 
+def _cuda_reported_available() -> bool:
+    """``torch.cuda.is_available()`` verbatim — True on real CUDA *and* HIP."""
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available())
+    except Exception:  # noqa: BLE001 — no torch
+        return False
+
+
+def _rocm_torch() -> bool:
+    """True when torch is the ROCm (HIP) build.
+
+    ROCm torch masquerades as CUDA: ``torch.cuda.is_available()`` answers True
+    and tensors live on ``"cuda"`` devices, but the CUDA *runtime libraries*
+    other packages ship are still NVIDIA-only. ``torch.version.hip`` is the
+    one honest tell.
+    """
+    try:
+        import torch
+
+        return getattr(torch.version, "hip", None) is not None
+    except Exception:  # noqa: BLE001 — no torch
+        return False
+
+
+def _ctranslate2_cuda_ok() -> bool:
+    """Whether CTranslate2 (whisperx / faster-whisper) may use ``"cuda"``.
+
+    CTranslate2 has NO HIP backend. On a ROCm host torch says cuda is
+    available (HIP), the device string is handed to CTranslate2, and its
+    NVIDIA CUDA runtime dies with "CUDA driver version is insufficient for
+    CUDA runtime version" — the #1529 report, an AMD RX 7900 XTX in the
+    :rocm Docker image. Real CUDA only; ROCm hosts take the CPU path here
+    (auto-detect prefers pytorch-whisper there, which does use HIP).
+    """
+    return _cuda_reported_available() and not _rocm_torch()
+
+
 def _auto_detect() -> str:
     """Pick the best available ASR engine **for this hardware**.
 
@@ -2495,6 +2530,14 @@ def _auto_detect() -> str:
     """
     if _mps_available() and _probe_available(MLXWhisperBackend):
         return "mlx-whisper"
+    # Same class as the Apple case, on the ROCm axis (#1529): whisperx and
+    # faster-whisper are CTranslate2, which has no HIP backend — on a ROCm
+    # host they run on the CPU while the GPU sits idle (and before
+    # _ctranslate2_cuda_ok they died outright trying NVIDIA's runtime).
+    # pytorch-whisper is a pure transformers pipeline riding torch itself,
+    # so it genuinely uses the HIP GPU there.
+    if _rocm_torch() and _cuda_reported_available() and _probe_available(PyTorchWhisperBackend):
+        return "pytorch-whisper"
     if _probe_available(WhisperXBackend):
         return "whisperx"
     if _probe_available(FasterWhisperBackend):

--- a/tests/test_asr_device_aware_autodetect.py
+++ b/tests/test_asr_device_aware_autodetect.py
@@ -394,3 +394,53 @@ def test_parakeet_mlx_real_transcribe_smoke(tmp_path):
             assert w["word"] and w["start"] <= w["end"]
     for chunk in out["chunks"]:
         assert chunk["text"] and len(chunk["timestamp"]) == 2
+
+
+# ── ROCm (#1529): the Apple lesson repeated on the AMD axis ─────────────────
+# ROCm torch masquerades as CUDA (torch.cuda.is_available() is True, devices
+# are "cuda"), but CTranslate2 has no HIP backend — whisperx handed "cuda" to
+# NVIDIA's runtime on an RX 7900 XTX and died with "CUDA driver version is
+# insufficient for CUDA runtime version". pytorch-whisper rides torch itself,
+# so it is the engine that actually uses the HIP GPU.
+
+
+def test_rocm_host_picks_pytorch_whisper_not_ctranslate2(monkeypatch):
+    """The #1529 regression: before the fix this returned "whisperx"."""
+    monkeypatch.setattr(ab, "_mps_available", lambda: False)
+    monkeypatch.setattr(ab, "_rocm_torch", lambda: True)
+    monkeypatch.setattr(ab, "_cuda_reported_available", lambda: True)
+    monkeypatch.setattr(
+        ab, "_probe_available", _probe({"whisperx", "faster-whisper", "pytorch-whisper"})
+    )
+    assert ab._auto_detect() == "pytorch-whisper"
+
+
+def test_rocm_host_without_transformers_still_degrades_to_whisperx_on_cpu(monkeypatch):
+    """pytorch-whisper unavailable → whisperx is still correct, on the CPU."""
+    monkeypatch.setattr(ab, "_mps_available", lambda: False)
+    monkeypatch.setattr(ab, "_rocm_torch", lambda: True)
+    monkeypatch.setattr(ab, "_cuda_reported_available", lambda: True)
+    monkeypatch.setattr(ab, "_probe_available", _probe({"whisperx", "faster-whisper"}))
+    assert ab._auto_detect() == "whisperx"
+
+
+def test_real_cuda_is_untouched_by_the_rocm_branch(monkeypatch):
+    monkeypatch.setattr(ab, "_mps_available", lambda: False)
+    monkeypatch.setattr(ab, "_rocm_torch", lambda: False)
+    monkeypatch.setattr(ab, "_cuda_reported_available", lambda: True)
+    monkeypatch.setattr(
+        ab, "_probe_available", _probe({"whisperx", "faster-whisper", "pytorch-whisper"})
+    )
+    assert ab._auto_detect() == "whisperx"
+
+
+def test_ctranslate2_never_gets_cuda_on_a_rocm_build(monkeypatch):
+    """The crash itself: whisperx's device pick must refuse HIP-flavoured cuda."""
+    monkeypatch.setattr(ab, "_rocm_torch", lambda: True)
+    monkeypatch.setattr(ab, "_cuda_reported_available", lambda: True)
+    assert ab._ctranslate2_cuda_ok() is False
+    assert ab.WhisperXBackend._pick_device() == ("cpu", "int8")
+
+    monkeypatch.setattr(ab, "_rocm_torch", lambda: False)
+    assert ab._ctranslate2_cuda_ok() is True
+    assert ab.WhisperXBackend._pick_device() == ("cuda", "float16")


### PR DESCRIPTION
Closes #1529.

An AMD RX 7900 XTX running the `:rocm` Docker image crashed ASR init with **"CUDA driver version is insufficient for CUDA runtime version"**. Root cause: ROCm torch masquerades as CUDA (`torch.cuda.is_available()` → True, devices are `"cuda"`), so whisperx/faster-whisper handed `device="cuda"` to **CTranslate2 — which has no HIP backend** and died inside NVIDIA's CUDA runtime. Same class as the Apple Silicon lesson (#1127), on the AMD axis.

- `_ctranslate2_cuda_ok()` gates both CTranslate2 device picks: `"cuda"` only on a real CUDA build (`torch.version.hip` is the honest tell); ROCm hosts take CPU int8 instead of a native crash
- `_auto_detect()` on a ROCm-GPU host prefers **pytorch-whisper** — a pure transformers pipeline riding torch itself, so it genuinely uses the HIP GPU while CTranslate2 engines would idle on CPU
- explicit `OMNIVOICE_ASR_BACKEND` / prefs picks still win, unchanged

4 regression tests fail-before/pass-after (verified by stashing the source); full `tests/` (minus environmental probe) 5458 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR prevents CTranslate2 from selecting CUDA on ROCm systems and routes those systems to CPU `int8`, while automatic detection prefers `pytorch-whisper` for HIP GPU inference. It preserves explicit backend and preference overrides and adds regression tests for ROCm and CUDA behavior. Review the backend-selection logic for compatibility with other PyTorch accelerator builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->