### PR TITLE
feat(triage): crash-class recurrence report — the reliability metric

### DIFF
--- a/scripts/crash_class_report.py
+++ b/scripts/crash_class_report.py
@@ -53,13 +53,44 @@ def latest_release_date() -> str:
     return data["publishedAt"][:10]
 
 
+_FETCH_LIMIT = 500
+
+
 def fetch_issues(since: str) -> list[dict]:
     out = sh(
         "gh", "issue", "list", "--repo", REPO, "--state", "all",
-        "--search", f"created:>={since}", "--limit", "500",
+        "--search", f"created:>={since}", "--limit", str(_FETCH_LIMIT),
         "--json", "number,title,body,createdAt",
     )
-    return json.loads(out)
+    issues = json.loads(out)
+    # No silent caps: an understated metric is worse than a loud one.
+    if len(issues) >= _FETCH_LIMIT:
+        print(
+            f"WARNING: hit the {_FETCH_LIMIT}-issue fetch cap — results are "
+            "truncated and the metric UNDERSTATES. Narrow --since and merge "
+            "the windows.",
+            file=sys.stderr,
+        )
+    return issues
+
+
+def classify_build(body: str, version: "str | None") -> str:
+    """'current' / 'outdated' / 'unknown' for one issue body.
+
+    With a target version, the Environment Version line is authoritative: a
+    report stamped "current at filing time" during a DIFFERENT version's
+    window must not count toward this version's recurrence. Without one, the
+    reporter's Build-status stamp decides.
+    """
+    ver = VERSION_LINE.search(body)
+    base = ver.group(1).split("-")[0] if ver else None
+    if version and base:
+        return "current" if base == version else "outdated"
+    if OUTDATED.search(body):
+        return "outdated"
+    if CURRENT.search(body):
+        return "current"
+    return "unknown"
 
 
 def main() -> int:
@@ -79,15 +110,7 @@ def main() -> int:
         sub = next((k for k, rx in CRASH_CLASS.items() if rx.search(title)), None)
         if not sub:
             continue
-        if OUTDATED.search(body):
-            build = "outdated"
-        elif CURRENT.search(body):
-            build = "current"
-        elif args.version and (m := VERSION_LINE.search(body)) and m.group(1).split("-")[0] == args.version:
-            # Pre-deflection fallback: the Version line alone places it.
-            build = "current"
-        else:
-            build = "unknown"
+        build = classify_build(body, args.version)
         counts[sub][build] += 1
         matched.append((issue["number"], sub, build, title[:70]))
 

--- a/scripts/crash_class_report.py
+++ b/scripts/crash_class_report.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Crash-class recurrence report — the reliability cycle's definition of done.
+
+The project's #1 lifetime failure class is "the backend died or never came
+up" (~1 in 5 of every issue ever filed). This script measures whether that
+class is actually shrinking, *filtered to reports from a given version* —
+because 6 in 10 sampled reports historically came from builds that were
+already obsolete when filed, and counting those as recurrence would judge
+the work against noise it can't fix.
+
+Reports are bucketed by the `**Build status:**` line the bug reporter stamps
+into every body (fix/stale-build-report-deflection): `OUTDATED` vs `current
+at filing time` vs absent (pre-deflection builds / freshness unknown).
+
+Usage:
+    uv run python scripts/crash_class_report.py            # since latest release
+    uv run python scripts/crash_class_report.py --since 2026-08-13
+    uv run python scripts/crash_class_report.py --version 0.5.0
+
+Needs the `gh` CLI authenticated for debpalash/VoiceStudio.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+REPO = "debpalash/VoiceStudio"
+
+# One pattern per sub-class, matched against issue TITLES (the auto-reporter
+# seeds titles from the error message, so titles are machine-stable).
+CRASH_CLASS = {
+    "unreachable": re.compile(r"can'?t reach the local .* backend|not answered|stopped responding", re.I),
+    "never-started": re.compile(r"still starting|abandoned before ready|failed to start", re.I),
+    "backend-died": re.compile(r"backend (died|ended uncleanly)|\[crash\]", re.I),
+}
+
+OUTDATED = re.compile(r"\*\*Build status:\*\* OUTDATED")
+CURRENT = re.compile(r"\*\*Build status:\*\* current at filing time")
+VERSION_LINE = re.compile(r"\*\*Version:\*\* `([^`]+)`")
+
+
+def sh(*args: str) -> str:
+    return subprocess.run(args, check=True, capture_output=True, text=True).stdout
+
+
+def latest_release_date() -> str:
+    data = json.loads(sh("gh", "release", "view", "--repo", REPO, "--json", "publishedAt,tagName"))
+    print(f"Window: since {data['tagName']} ({data['publishedAt'][:10]})", file=sys.stderr)
+    return data["publishedAt"][:10]
+
+
+def fetch_issues(since: str) -> list[dict]:
+    out = sh(
+        "gh", "issue", "list", "--repo", REPO, "--state", "all",
+        "--search", f"created:>={since}", "--limit", "500",
+        "--json", "number,title,body,createdAt",
+    )
+    return json.loads(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--since", help="count issues created on/after this date (default: latest release)")
+    ap.add_argument("--version", help="also split by the Environment Version line matching this version")
+    args = ap.parse_args()
+
+    since = args.since or latest_release_date()
+    issues = fetch_issues(since)
+
+    counts: dict[str, dict[str, int]] = {k: {"current": 0, "outdated": 0, "unknown": 0} for k in CRASH_CLASS}
+    matched: list[tuple[int, str, str, str]] = []
+
+    for issue in issues:
+        title, body = issue["title"], issue.get("body") or ""
+        sub = next((k for k, rx in CRASH_CLASS.items() if rx.search(title)), None)
+        if not sub:
+            continue
+        if OUTDATED.search(body):
+            build = "outdated"
+        elif CURRENT.search(body):
+            build = "current"
+        elif args.version and (m := VERSION_LINE.search(body)) and m.group(1).split("-")[0] == args.version:
+            # Pre-deflection fallback: the Version line alone places it.
+            build = "current"
+        else:
+            build = "unknown"
+        counts[sub][build] += 1
+        matched.append((issue["number"], sub, build, title[:70]))
+
+    total = sum(sum(b.values()) for b in counts.values())
+    print(f"\nCrash-class issues created since {since}: {total} of {len(issues)} total issues\n")
+    print(f"{'sub-class':<15} {'current':>8} {'outdated':>9} {'unknown':>8}")
+    for sub, b in counts.items():
+        print(f"{sub:<15} {b['current']:>8} {b['outdated']:>9} {b['unknown']:>8}")
+    current_total = sum(b["current"] for b in counts.values())
+    print(
+        f"\nRecurrence metric (current-version crash-class reports): {current_total}"
+        "\n  → this is the number the reliability work is judged on; 'outdated' is"
+        "\n    deflection-miss noise and 'unknown' is pre-deflection builds."
+    )
+    if matched:
+        print("\nMatched issues:")
+        for num, sub, build, title in matched:
+            print(f"  #{num:<6} [{sub}/{build}] {title}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_crash_class_report.py
+++ b/tests/scripts/test_crash_class_report.py
@@ -1,0 +1,65 @@
+"""Bucketing contract for scripts/crash_class_report.py — the reliability
+cycle's recurrence metric.
+
+Pins two things:
+- title → sub-class mapping matches the auto-reporter's real title shapes
+  (seeded from error messages, so titles are machine-stable), and
+- body → build bucket mapping matches the exact `**Build status:**` lines
+  the bug reporter stamps (frontend/src/utils/bugReport.js) — a drift in
+  either side silently zeroes the metric.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "crash_class_report.py"
+
+
+@pytest.fixture(scope="module")
+def report():
+    spec = importlib.util.spec_from_file_location("crash_class_report", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["crash_class_report"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        # The real title shapes from the historical corpus.
+        ("[Bug] Can't reach the local VoiceStudio backend. It has not answered", "unreachable"),
+        ("[Bug] Can't reach the local OmniVoice backend — it may still be starti", "unreachable"),
+        ("[Bug] It was answering 6 minutes ago and then stopped responding", "unreachable"),
+        ("[Crash] Backend died (exit code 1)", "backend-died"),
+        ("[Crash] Backend ended uncleanly (previous run)", "backend-died"),
+        ("[Backend] Backend failed to start", "never-started"),
+        # Non-class titles must not count toward the metric.
+        ("[Bug] Synthesize produced silence in Design mode", None),
+        ("[Feature] Add a voice changer", None),
+    ],
+)
+def test_title_bucketing(report, title, expected):
+    sub = next((k for k, rx in report.CRASH_CLASS.items() if rx.search(title)), None)
+    assert sub == expected
+
+
+def test_build_status_lines_match_the_reporter_stamps(report):
+    # These literals must stay in lockstep with frontend/src/utils/bugReport.js
+    # captureContext() — the stamps are the metric's only version signal.
+    assert report.OUTDATED.search("**Build status:** OUTDATED — `v0.5.0` was already out when this was filed")
+    assert report.CURRENT.search("**Build status:** current at filing time (latest `v0.5.0`)")
+    assert not report.OUTDATED.search("**Build status:** current at filing time (latest `v0.5.0`)")
+    assert report.VERSION_LINE.search("**Version:** `0.5.1-3`").group(1) == "0.5.1-3"
+
+
+def test_reporter_source_still_emits_the_stamps(report):
+    # Fail here (not in production silence) if bugReport.js rewords the marker.
+    src = (SCRIPT_PATH.parents[1] / "frontend/src/utils/bugReport.js").read_text(encoding="utf-8")
+    assert "**Build status:** OUTDATED" in src
+    assert "current at filing time" in src

--- a/tests/scripts/test_crash_class_report.py
+++ b/tests/scripts/test_crash_class_report.py
@@ -58,8 +58,27 @@ def test_build_status_lines_match_the_reporter_stamps(report):
     assert report.VERSION_LINE.search("**Version:** `0.5.1-3`").group(1) == "0.5.1-3"
 
 
+@pytest.mark.parametrize(
+    ("body", "version", "expected"),
+    [
+        # Stamp-based (no target version).
+        ("**Build status:** OUTDATED — `v0.5.0` was already out when this was filed", None, "outdated"),
+        ("**Build status:** current at filing time (latest `v0.5.0`)", None, "current"),
+        ("no stamp at all", None, "unknown"),
+        # With --version the Version line is authoritative: a report stamped
+        # "current" during ANOTHER version's window must not count here.
+        ("**Version:** `0.4.2`\n**Build status:** current at filing time (latest `v0.4.2`)", "0.5.0", "outdated"),
+        ("**Version:** `0.5.0`\n**Build status:** current at filing time (latest `v0.5.0`)", "0.5.0", "current"),
+        ("**Version:** `0.5.1-3`", "0.5.1", "current"),  # preview stamps match by base
+        ("no version line", "0.5.0", "unknown"),
+    ],
+)
+def test_classify_build(report, body, version, expected):
+    assert report.classify_build(body, version) == expected
+
+
 def test_reporter_source_still_emits_the_stamps(report):
     # Fail here (not in production silence) if bugReport.js rewords the marker.
     src = (SCRIPT_PATH.parents[1] / "frontend/src/utils/bugReport.js").read_text(encoding="utf-8")
     assert "**Build status:** OUTDATED" in src
-    assert "current at filing time" in src
+    assert "**Build status:** current at filing time" in src


### PR DESCRIPTION
## Why

The reliability cycle's definition of done: the "backend died / never came up" report rate, **filtered to the current version** — 61% of the historical class came from obsolete builds, and counting those judges the work against noise it can't fix.

## What

- `scripts/crash_class_report.py` — buckets crash-class issues (unreachable / never-started / backend-died, matched on the auto-reporter's stable title shapes) by the `**Build status:**` stamp from #1547: `current` / `outdated` / `unknown` (pre-deflection builds). Windows default to the latest release; `--since`/`--version` override. Validated against August's real corpus (14 crash-class issues, all bucketed correctly).
- `tests/scripts/test_crash_class_report.py` — pins title mapping against real historical titles and locks the stamp literals to `bugReport.js`, so a reworded marker fails CI instead of silently zeroing the metric.

Maintainer-side tooling only — no app behavior change, no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a CLI to measure crash-class issue recurrence by title, build freshness, and optional application version. Adds tests that lock historical title mappings and `bugReport.js` build-status markers. Review the hard `--limit 500` issue query because repositories with more matching issues can produce incomplete metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->