### PR TITLE
feat(settings): compute-device override (auto / CUDA / ROCm / XPU / MPS / CPU)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Added
 - The bug reporter notices when you're on an outdated build and offers the latest release before filing — with a "File anyway" escape hatch — and stamps a `Build status` line into every report so up-to-date reports are tellable from stale ones (#1547)
-- Settings → Performance & Device gains a compute-device override (Auto / CUDA / ROCm / MPS / CPU, or `OMNIVOICE_DEVICE`) — pin the device when auto-detect picks wrong; only devices your machine actually has are offered (#1557)
+- Settings → Performance & Device gains a compute-device override (Auto / CUDA / ROCm / XPU / MPS / CPU, or `OMNIVOICE_DEVICE`) — pin the device when auto-detect picks wrong; only devices your machine actually has are offered (#1557)
 
 ### Docs
 - The READMEs now lead with download buttons and a three-step first-clone walkthrough, and a new benchmarks page anchors measured per-engine/per-device numbers on the in-repo harness (#1555)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Added
 - The bug reporter notices when you're on an outdated build and offers the latest release before filing — with a "File anyway" escape hatch — and stamps a `Build status` line into every report so up-to-date reports are tellable from stale ones (#1547)
+- Settings → Performance & Device gains a compute-device override (Auto / CUDA / ROCm / MPS / CPU, or `OMNIVOICE_DEVICE`) — pin the device when auto-detect picks wrong; only devices your machine actually has are offered (#1557)
 
 ### Docs
 - The READMEs now lead with download buttons and a three-step first-clone walkthrough, and a new benchmarks page anchors measured per-engine/per-device numbers on the in-repo harness (#1555)

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -158,6 +158,13 @@ def _compute_device_state() -> dict:
         "value": value,
         "applied": caps.requested_family,
         "restart_required": value != caps.requested_family,
+        # The running process asked for a family it doesn't have (env pin on
+        # the wrong machine, hardware removed): auto is in effect, and a
+        # restart would not change that — the panel says so instead of
+        # pretending the pick took.
+        "override_ignored": (
+            caps.requested_family not in ("auto", caps.family)
+        ),
         "effective_family": caps.family,
         "auto_family": auto_family,
         "available_families": list(caps.available_families),

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -133,6 +133,76 @@ def set_torch_compile_disabled(body: _TorchCompileBody):
     return _torch_compile_state()
 
 
+# ── Compute-device override (Settings → Performance) ──────────────────────
+
+
+class _ComputeDeviceBody(BaseModel):
+    value: str = Field(..., description="auto | cuda | rocm | xpu | mps | cpu")
+
+
+def _compute_device_state() -> dict:
+    """Everything the Performance panel needs to render the device control:
+    the resolved pick (env > prefs > auto), what this process actually applied
+    at probe time (differs after a change until restart — caps are immutable
+    per process), what auto would pick, and which families exist here."""
+    from core import device_caps
+
+    caps = device_caps.detect_host_caps()
+    env_pin = (os.environ.get("OMNIVOICE_DEVICE") or "").strip().lower()
+    auto_family = next(
+        (f for f in ("cuda", "rocm", "xpu", "mps") if f in caps.available_families),
+        "cpu",
+    )
+    value = device_caps.requested_device_override()
+    return {
+        "value": value,
+        "applied": caps.requested_family,
+        "restart_required": value != caps.requested_family,
+        "effective_family": caps.family,
+        "auto_family": auto_family,
+        "available_families": list(caps.available_families),
+        "env_pinned": env_pin in device_caps.DEVICE_OVERRIDE_CHOICES and env_pin != "",
+        "choices": list(device_caps.DEVICE_OVERRIDE_CHOICES),
+    }
+
+
+@router.get("/compute-device")
+def get_compute_device():
+    """Current compute-device override state (Settings → Performance)."""
+    return _compute_device_state()
+
+
+@router.put("/compute-device")
+def set_compute_device(body: _ComputeDeviceBody):
+    """Persist the compute-device pick. Applied by the capability probe at
+    the next backend start (host caps are immutable per process — same
+    restart contract as the rest of the Performance tab). ``OMNIVOICE_DEVICE``
+    always wins over this pick; the UI shows the pin instead of pretending."""
+    from core import device_caps, prefs
+
+    value = (body.value or "").strip().lower()
+    if value not in device_caps.DEVICE_OVERRIDE_CHOICES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown device '{value}'. Valid: {', '.join(device_caps.DEVICE_OVERRIDE_CHOICES)}",
+        )
+    caps = device_caps.detect_host_caps()
+    if value not in ("auto", "cpu") and value not in caps.available_families:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"'{value}' is not available on this host "
+                f"(have: {', '.join(caps.available_families)})"
+            ),
+        )
+    try:
+        prefs.set_("compute_device", value)
+    except Exception:
+        logger.exception("set_compute_device failed")
+        raise HTTPException(status_code=500, detail="Failed to persist setting")
+    return _compute_device_state()
+
+
 # ── Generation-history retention (Studio takes rail) ──────────────────────
 
 

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -374,6 +374,33 @@ class HostCaps:
     probe_ok: bool = True
     """``False`` only when torch could not be imported (degraded CPU-only)."""
 
+    requested_family: str = "auto"
+    """The user's compute-device override as requested — ``"auto"`` when none.
+    ``family`` reflects what was actually honored: an override that names a
+    family this host doesn't have is noted and ignored, never obeyed blindly."""
+
+
+#: Every value the compute-device override accepts. "auto" = today's
+#: priority pick; "cpu" is always honorable (invariant: cpu is always
+#: available); accelerator names are honored only when detected.
+DEVICE_OVERRIDE_CHOICES: tuple[str, ...] = ("auto", "cuda", "rocm", "xpu", "mps", "cpu")
+
+
+def requested_device_override() -> str:
+    """The user's compute-device pick: ``OMNIVOICE_DEVICE`` env > the Settings
+    choice (``compute_device`` in prefs.json) > ``"auto"``. Env wins so
+    power-users can pin a device without the UI silently undoing it (same
+    resolution order as engine selection, #981). Unknown values normalize to
+    ``"auto"`` — the probe must never raise."""
+    try:
+        from core import prefs
+
+        raw = prefs.resolve("compute_device", env="OMNIVOICE_DEVICE", default="auto")
+    except Exception:
+        raw = os.environ.get("OMNIVOICE_DEVICE", "auto")
+    val = str(raw or "auto").strip().lower()
+    return val if val in DEVICE_OVERRIDE_CHOICES else "auto"
+
 
 def _probe() -> HostCaps:
     """Run the probe once. Enumerates every failure branch from the spec's
@@ -386,6 +413,7 @@ def _probe() -> HostCaps:
             available_families=("cpu",),
             notes=("torch not importable; treating host as CPU-only",),
             probe_ok=False,
+            requested_family=requested_device_override(),
         )
 
     notes: list[str] = []
@@ -507,6 +535,26 @@ def _probe() -> HostCaps:
     # available_families: every detected accelerator + cpu, deduped, cpu last.
     available: tuple[DeviceFamily, ...] = tuple(dict.fromkeys([*detected, "cpu"]))
 
+    # User override (Settings → Performance, or OMNIVOICE_DEVICE): honored
+    # only when the named family actually exists on this host — an override
+    # can steer, it cannot invent hardware. Applied here, at the single
+    # choke point, so routing, model loads (get_best_device delegates its
+    # family decision here), and every badge inherit it for free.
+    requested = requested_device_override()
+    if requested != "auto":
+        if requested in available:
+            if requested != family:
+                notes.append(
+                    f"compute device pinned to '{requested}' by user override "
+                    f"(auto would pick '{family}')"
+                )
+            family = requested  # type: ignore[assignment]
+        else:
+            notes.append(
+                f"requested compute device '{requested}' is not available on "
+                f"this host (have: {', '.join(available)}) — using '{family}'"
+            )
+
     return HostCaps(
         family=family,
         available_families=available,
@@ -515,6 +563,7 @@ def _probe() -> HostCaps:
         driver=driver,
         notes=tuple(notes),
         probe_ok=True,
+        requested_family=requested,
     )
 
 

--- a/backend/engines/_asr_sidecar/main.py
+++ b/backend/engines/_asr_sidecar/main.py
@@ -96,10 +96,17 @@ def _get_model():
             or "large-v3"
         )
         try:
-            import torch
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+            # The probe honors the user compute-device override and the
+            # ROCm/CT2 incompatibility (#1529) — the child must agree with
+            # the parent's device decision, not re-derive its own.
+            from core.device_caps import detect_host_caps
+            device = "cuda" if detect_host_caps().family == "cuda" else "cpu"
         except Exception:
-            device = "cpu"
+            try:
+                import torch
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            except Exception:
+                device = "cpu"
         # Degrade fp16 → int8 rather than crash on GPUs without efficient fp16
         # (older Maxwell/Pascal, GTX 16xx, CTranslate2/cuDNN mismatch) (#551).
         last_err = None

--- a/backend/engines/_asr_sidecar/main.py
+++ b/backend/engines/_asr_sidecar/main.py
@@ -102,11 +102,11 @@ def _get_model():
             from core.device_caps import detect_host_caps
             device = "cuda" if detect_host_caps().family == "cuda" else "cpu"
         except Exception:
-            try:
-                import torch
-                device = "cuda" if torch.cuda.is_available() else "cpu"
-            except Exception:
-                device = "cpu"
+            # Fail SAFE: guessing "cuda" from torch here would bypass a cpu
+            # override and hand CTranslate2 HIP-flavoured cuda on ROCm
+            # (#1529). CPU always works; say why in the sidecar log.
+            print("asr-sidecar: device probe failed — using cpu", file=sys.stderr, flush=True)
+            device = "cpu"
         # Degrade fp16 → int8 rather than crash on GPUs without efficient fp16
         # (older Maxwell/Pascal, GTX 16xx, CTranslate2/cuDNN mismatch) (#551).
         last_err = None

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -2506,8 +2506,12 @@ def _ctranslate2_cuda_ok() -> bool:
 
         if detect_host_caps().family != "cuda":
             return False
-    except Exception:  # noqa: BLE001 — the probe never blocks ASR
-        pass
+    except Exception:  # noqa: BLE001 — fail SAFE, not fast
+        # Without a working probe we can't know whether an override or a
+        # ROCm build is in play — guessing "cuda" from torch here is exactly
+        # the #1529 crash. CPU always works.
+        logger.warning("device probe failed — CTranslate2 taking the CPU path", exc_info=True)
+        return False
     return _cuda_reported_available() and not _rocm_torch()
 
 

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -2495,7 +2495,19 @@ def _ctranslate2_cuda_ok() -> bool:
     CUDA runtime version" — the #1529 report, an AMD RX 7900 XTX in the
     :rocm Docker image. Real CUDA only; ROCm hosts take the CPU path here
     (auto-detect prefers pytorch-whisper there, which does use HIP).
+
+    Also honors the user compute-device override (Settings → Performance /
+    ``OMNIVOICE_DEVICE``): a host pinned to cpu (or any non-cuda family)
+    must not hand CTranslate2 a CUDA device — the probe applies the
+    override, so gating on its family covers every CT2 loader at once.
     """
+    try:
+        from core.device_caps import detect_host_caps
+
+        if detect_host_caps().family != "cuda":
+            return False
+    except Exception:  # noqa: BLE001 — the probe never blocks ASR
+        pass
     return _cuda_reported_available() and not _rocm_torch()
 
 

--- a/backend/tests/test_asr_oom_fallback.py
+++ b/backend/tests/test_asr_oom_fallback.py
@@ -125,6 +125,16 @@ def test_faster_whisper_float16_unsupported_falls_back_to_int8(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
 
+    # The compute-device override gate consults the capability probe before
+    # the torch mock above — pin it to a CUDA family so the fallback chain
+    # under test is reachable on a cpu-only CI host.
+    from core.device_caps import HostCaps
+
+    monkeypatch.setattr(
+        "core.device_caps.detect_host_caps",
+        lambda: HostCaps(family="cuda", available_families=("cuda", "cpu")),
+    )
+
     be = FasterWhisperBackend()
     be._ensure_model()
 

--- a/docs/engines/README.md
+++ b/docs/engines/README.md
@@ -5,6 +5,10 @@ quirks. Select engines in **Model Catalogue → Engines** (or quick-switch with
 <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>E</kbd>), or pin one with
 `OMNIVOICE_TTS_BACKEND` / `OMNIVOICE_ASR_BACKEND`.
 
+The compute device (CUDA/ROCm/MPS/CPU) is auto-detected; pin it under
+**Settings → Performance & Device** (or `OMNIVOICE_DEVICE`) if auto-detect
+picks wrong — see [performance](../performance.md).
+
 Measured speed/VRAM numbers live in [benchmarks](../benchmarks.md); what each
 engine can do expressively in [expressive-speech](../expressive-speech.md);
 sidecar disk footprints in [disk-usage](disk-usage.md); the bar a new engine

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -80,6 +80,7 @@ None of them are required — the defaults are chosen for the common case.
 
 | Variable | Default | What it does |
 |---|---|---|
+| `OMNIVOICE_DEVICE` | `auto` | Pin the compute device (`cuda` / `rocm` / `xpu` / `mps` / `cpu`) instead of auto-detect. Same control lives in **Settings → Performance & Device** (the env var wins over the UI pick). Honored only for devices the host actually has — a family that isn't detected is noted and ignored, never obeyed blindly. Applies at the next backend start. |
 | `OMNIVOICE_IDLE_TIMEOUT_S` | `900` | Seconds of idle before the TTS model unloads to free memory. Raise it (e.g. `3600`) if you generate in bursts and dislike the ~8 s reload; lower it on tight-memory machines. |
 | `OMNIVOICE_SIDECAR_IDLE_TIMEOUT_S` | `300` | Same idea for sidecar engines (IndexTTS 2.5 etc.). |
 | `OMNIVOICE_LLM_CONCURRENCY` | `6` | Parallel LLM translation calls during a dub. Raise for a fast API endpoint, lower if your provider rate-limits. |

--- a/frontend/src/components/settings/ComputeDevicePanel.jsx
+++ b/frontend/src/components/settings/ComputeDevicePanel.jsx
@@ -110,21 +110,28 @@ export default function ComputeDevicePanel() {
             <RestartBadge />
           </>
         }
-        subtitle={
-          state?.env_pinned
+        subtitle={(() => {
+          const pinned = state?.env_pinned
             ? t('settings.compute_device_env_pinned', {
                 defaultValue: 'Pinned by the OMNIVOICE_DEVICE environment variable',
               })
-            : state?.override_ignored
-              ? t('settings.compute_device_ignored', {
-                  defaultValue: 'That device was not detected on this machine — Auto is in effect',
-                })
-              : state?.restart_required
-                ? t('settings.compute_device_restart', {
-                    defaultValue: 'Takes effect after the app restarts',
-                  })
-                : undefined
-        }
+            : null;
+          const ignored = state?.override_ignored
+            ? t('settings.compute_device_ignored', {
+                defaultValue: 'That device was not detected on this machine — Auto is in effect',
+              })
+            : null;
+          // An env pin naming absent hardware needs BOTH facts: why the
+          // control is disabled, and that the pin is not actually in effect.
+          if (pinned && ignored) return `${pinned} · ${ignored}`;
+          if (pinned) return pinned;
+          if (ignored) return ignored;
+          return state?.restart_required
+            ? t('settings.compute_device_restart', {
+                defaultValue: 'Takes effect after the app restarts',
+              })
+            : undefined;
+        })()}
         note={t('settings.compute_device_note', {
           defaultValue:
             'Only devices detected on this machine are listed. CPU always works; pinning a device never invents hardware.',

--- a/frontend/src/components/settings/ComputeDevicePanel.jsx
+++ b/frontend/src/components/settings/ComputeDevicePanel.jsx
@@ -23,7 +23,9 @@ import { Select } from '../../ui';
 import { SettingsSection, SettingRow } from './primitives';
 import RestartBadge from './RestartBadge';
 
-const FAMILY_LABELS = {
+// English fallbacks; the rendered label comes from the locale files
+// (settings.device_family_*) so localized builds stay localized.
+const FAMILY_FALLBACKS = {
   cuda: 'NVIDIA GPU (CUDA)',
   rocm: 'AMD GPU (ROCm)',
   xpu: 'Intel GPU (XPU)',
@@ -70,7 +72,13 @@ export default function ComputeDevicePanel() {
       setError(
         err?.message || t('settings.perf_save_failed', { defaultValue: 'Failed to save setting' }),
       );
-      refresh(); // re-sync so the UI never shows a pick that didn't persist
+      // Re-sync so the UI never shows a pick that didn't persist — but keep
+      // the save error visible (refresh() would clear it).
+      try {
+        setState(await apiJson('/api/settings/compute-device'));
+      } catch {
+        /* the save error already on screen covers this */
+      }
     } finally {
       setSaving(false);
     }
@@ -78,6 +86,8 @@ export default function ComputeDevicePanel() {
 
   const label = t('settings.compute_device', { defaultValue: 'Compute device' });
   const families = state?.available_families || [];
+  const familyLabel = (f) =>
+    t(`settings.device_family_${f}`, { defaultValue: FAMILY_FALLBACKS[f] || f });
 
   return (
     <SettingsSection
@@ -105,11 +115,15 @@ export default function ComputeDevicePanel() {
             ? t('settings.compute_device_env_pinned', {
                 defaultValue: 'Pinned by the OMNIVOICE_DEVICE environment variable',
               })
-            : state?.restart_required
-              ? t('settings.compute_device_restart', {
-                  defaultValue: 'Takes effect after the app restarts',
+            : state?.override_ignored
+              ? t('settings.compute_device_ignored', {
+                  defaultValue: 'That device was not detected on this machine — Auto is in effect',
                 })
-              : undefined
+              : state?.restart_required
+                ? t('settings.compute_device_restart', {
+                    defaultValue: 'Takes effect after the app restarts',
+                  })
+                : undefined
         }
         note={t('settings.compute_device_note', {
           defaultValue:
@@ -128,11 +142,11 @@ export default function ComputeDevicePanel() {
               {t('settings.compute_device_auto', {
                 defaultValue: 'Auto (recommended)',
               })}
-              {state?.auto_family ? ` — ${FAMILY_LABELS[state.auto_family] || state.auto_family}` : ''}
+              {state?.auto_family ? ` — ${familyLabel(state.auto_family)}` : ''}
             </option>
             {families.map((f) => (
               <option key={f} value={f}>
-                {FAMILY_LABELS[f] || f}
+                {familyLabel(f)}
               </option>
             ))}
           </Select>

--- a/frontend/src/components/settings/ComputeDevicePanel.jsx
+++ b/frontend/src/components/settings/ComputeDevicePanel.jsx
@@ -1,0 +1,143 @@
+/**
+ * Settings → Performance: the compute-device override.
+ *
+ * Lets the user pin which device family the backend uses (auto / CUDA /
+ * ROCm / XPU / MPS / CPU) instead of trusting auto-detect — the fix for the
+ * "auto-detect picked wrong" issue class. Options are limited to families
+ * that actually exist on this host (plus Auto and CPU, which always do);
+ * the pick applies at the next backend start, same restart contract as the
+ * rest of this tab. `OMNIVOICE_DEVICE` pins the value and disables the
+ * control rather than pretending the UI choice would win.
+ *
+ * Endpoints:
+ *   GET /api/settings/compute-device
+ *     → {value, applied, restart_required, effective_family, auto_family,
+ *        available_families, env_pinned, choices}
+ *   PUT /api/settings/compute-device  body {"value": "auto"|family}
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { MonitorCog } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { apiJson, apiFetch } from '../../api/client';
+import { Select } from '../../ui';
+import { SettingsSection, SettingRow } from './primitives';
+import RestartBadge from './RestartBadge';
+
+const FAMILY_LABELS = {
+  cuda: 'NVIDIA GPU (CUDA)',
+  rocm: 'AMD GPU (ROCm)',
+  xpu: 'Intel GPU (XPU)',
+  mps: 'Apple GPU (MPS)',
+  cpu: 'CPU',
+};
+
+export default function ComputeDevicePanel() {
+  const { t } = useTranslation();
+  const [state, setState] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      setState(await apiJson('/api/settings/compute-device'));
+    } catch (e) {
+      setError(
+        e?.message ||
+          t('settings.device_load_failed', { defaultValue: 'Failed to load device setting' }),
+      );
+    }
+  }, [t]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const onChange = async (e) => {
+    const value = e.target.value;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/settings/compute-device', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value }),
+      });
+      const body = await res.json().catch(() => null);
+      if (body?.value) setState(body);
+      else refresh();
+    } catch (err) {
+      setError(
+        err?.message || t('settings.perf_save_failed', { defaultValue: 'Failed to save setting' }),
+      );
+      refresh(); // re-sync so the UI never shows a pick that didn't persist
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const label = t('settings.compute_device', { defaultValue: 'Compute device' });
+  const families = state?.available_families || [];
+
+  return (
+    <SettingsSection
+      icon={MonitorCog}
+      title={t('settings.compute_device_title', { defaultValue: 'Compute device' })}
+      description={t('settings.compute_device_desc', {
+        defaultValue: 'Which device the backend runs models on. Auto is right for almost everyone.',
+      })}
+    >
+      {error && (
+        <div className="perfpanel__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <SettingRow
+        title={
+          <>
+            {label}
+            <RestartBadge />
+          </>
+        }
+        subtitle={
+          state?.env_pinned
+            ? t('settings.compute_device_env_pinned', {
+                defaultValue: 'Pinned by the OMNIVOICE_DEVICE environment variable',
+              })
+            : state?.restart_required
+              ? t('settings.compute_device_restart', {
+                  defaultValue: 'Takes effect after the app restarts',
+                })
+              : undefined
+        }
+        note={t('settings.compute_device_note', {
+          defaultValue:
+            'Only devices detected on this machine are listed. CPU always works; pinning a device never invents hardware.',
+        })}
+        control={
+          <Select
+            size="sm"
+            value={state?.value ?? 'auto'}
+            onChange={onChange}
+            disabled={!state || saving || state?.env_pinned}
+            aria-label={label}
+            data-testid="compute-device-select"
+          >
+            <option value="auto">
+              {t('settings.compute_device_auto', {
+                defaultValue: 'Auto (recommended)',
+              })}
+              {state?.auto_family ? ` — ${FAMILY_LABELS[state.auto_family] || state.auto_family}` : ''}
+            </option>
+            {families.map((f) => (
+              <option key={f} value={f}>
+                {FAMILY_LABELS[f] || f}
+              </option>
+            ))}
+          </Select>
+        }
+      />
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/ComputeDevicePanel.test.jsx
+++ b/frontend/src/components/settings/ComputeDevicePanel.test.jsx
@@ -36,7 +36,9 @@ describe('ComputeDevicePanel', () => {
   it('offers only the detected families plus Auto', async () => {
     global.fetch = mockFetchSequence({ status: 200, body: CUDA_HOST });
     render(<ComputeDevicePanel />);
-    await waitFor(() => screen.getByTestId('compute-device-select'));
+    // Wait for the LOADED state (3 options), not just the select — it
+    // renders disabled with only Auto before the GET resolves.
+    await waitFor(() => expect(screen.getByTestId('compute-device-select').options.length).toBe(3));
     const options = [...screen.getByTestId('compute-device-select').options].map((o) => o.value);
     // No mps/rocm/xpu on a CUDA host — an override can steer, not invent.
     expect(options).toEqual(['auto', 'cuda', 'cpu']);
@@ -52,7 +54,7 @@ describe('ComputeDevicePanel', () => {
     );
     global.fetch = fetchMock;
     render(<ComputeDevicePanel />);
-    await waitFor(() => screen.getByTestId('compute-device-select'));
+    await waitFor(() => expect(screen.getByTestId('compute-device-select').options.length).toBe(3));
 
     fireEvent.change(screen.getByTestId('compute-device-select'), { target: { value: 'cpu' } });
 
@@ -77,15 +79,15 @@ describe('ComputeDevicePanel', () => {
     expect(screen.getByText(/OMNIVOICE_DEVICE/)).toBeInTheDocument();
   });
 
-  it('re-syncs from the server when the PUT fails', async () => {
+  it('re-syncs from the server when the PUT fails, keeping the error visible', async () => {
     const fetchMock = mockFetchSequence(
       { status: 200, body: CUDA_HOST }, // initial GET
       { status: 500, body: { detail: 'nope' } }, // PUT fails
-      { status: 200, body: CUDA_HOST }, // refresh GET
+      { status: 200, body: CUDA_HOST }, // re-sync GET
     );
     global.fetch = fetchMock;
     render(<ComputeDevicePanel />);
-    await waitFor(() => screen.getByTestId('compute-device-select'));
+    await waitFor(() => expect(screen.getByTestId('compute-device-select').options.length).toBe(3));
 
     fireEvent.change(screen.getByTestId('compute-device-select'), { target: { value: 'cpu' } });
 
@@ -95,5 +97,8 @@ describe('ComputeDevicePanel', () => {
       expect(fetchMock.mock.calls.length).toBe(3);
     });
     expect(screen.getByTestId('compute-device-select')).toHaveValue('auto');
+    // The save error must survive the re-sync — a silent snap-back reads
+    // as "the app ignored me".
+    expect(screen.getByRole('alert')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/settings/ComputeDevicePanel.test.jsx
+++ b/frontend/src/components/settings/ComputeDevicePanel.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+function mockFetchSequence(...responses) {
+  const fn = vi.fn();
+  for (const r of responses) {
+    fn.mockResolvedValueOnce({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+      text: async () => JSON.stringify(r.body),
+    });
+  }
+  return fn;
+}
+
+import ComputeDevicePanel from './ComputeDevicePanel';
+
+const CUDA_HOST = {
+  value: 'auto',
+  applied: 'auto',
+  restart_required: false,
+  effective_family: 'cuda',
+  auto_family: 'cuda',
+  available_families: ['cuda', 'cpu'],
+  env_pinned: false,
+  choices: ['auto', 'cuda', 'rocm', 'xpu', 'mps', 'cpu'],
+};
+
+describe('ComputeDevicePanel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('offers only the detected families plus Auto', async () => {
+    global.fetch = mockFetchSequence({ status: 200, body: CUDA_HOST });
+    render(<ComputeDevicePanel />);
+    await waitFor(() => screen.getByTestId('compute-device-select'));
+    const options = [...screen.getByTestId('compute-device-select').options].map((o) => o.value);
+    // No mps/rocm/xpu on a CUDA host — an override can steer, not invent.
+    expect(options).toEqual(['auto', 'cuda', 'cpu']);
+  });
+
+  it('changing the pick PUTs the value and shows the restart note', async () => {
+    const fetchMock = mockFetchSequence(
+      { status: 200, body: CUDA_HOST }, // initial GET
+      {
+        status: 200,
+        body: { ...CUDA_HOST, value: 'cpu', restart_required: true },
+      }, // PUT echo
+    );
+    global.fetch = fetchMock;
+    render(<ComputeDevicePanel />);
+    await waitFor(() => screen.getByTestId('compute-device-select'));
+
+    fireEvent.change(screen.getByTestId('compute-device-select'), { target: { value: 'cpu' } });
+
+    await waitFor(() => {
+      const put = fetchMock.mock.calls.find(([_u, opts]) => opts && opts.method === 'PUT');
+      expect(put).toBeTruthy();
+      expect(put[0]).toMatch(/\/api\/settings\/compute-device$/);
+      expect(JSON.parse(put[1].body)).toEqual({ value: 'cpu' });
+    });
+    expect(screen.getByText(/after the app restarts/i)).toBeInTheDocument();
+  });
+
+  it('an OMNIVOICE_DEVICE pin disables the control and says so', async () => {
+    global.fetch = mockFetchSequence({
+      status: 200,
+      body: { ...CUDA_HOST, value: 'cpu', applied: 'cpu', env_pinned: true },
+    });
+    render(<ComputeDevicePanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId('compute-device-select')).toBeDisabled();
+    });
+    expect(screen.getByText(/OMNIVOICE_DEVICE/)).toBeInTheDocument();
+  });
+
+  it('re-syncs from the server when the PUT fails', async () => {
+    const fetchMock = mockFetchSequence(
+      { status: 200, body: CUDA_HOST }, // initial GET
+      { status: 500, body: { detail: 'nope' } }, // PUT fails
+      { status: 200, body: CUDA_HOST }, // refresh GET
+    );
+    global.fetch = fetchMock;
+    render(<ComputeDevicePanel />);
+    await waitFor(() => screen.getByTestId('compute-device-select'));
+
+    fireEvent.change(screen.getByTestId('compute-device-select'), { target: { value: 'cpu' } });
+
+    await waitFor(() => {
+      // Three calls: GET, failed PUT, re-sync GET — the select ends on the
+      // server's truth (auto), never a pick that didn't persist.
+      expect(fetchMock.mock.calls.length).toBe(3);
+    });
+    expect(screen.getByTestId('compute-device-select')).toHaveValue('auto');
+  });
+});

--- a/frontend/src/components/settings/PerformanceDeviceTab.jsx
+++ b/frontend/src/components/settings/PerformanceDeviceTab.jsx
@@ -18,6 +18,7 @@ import { Badge } from '../../ui';
 import { SettingsSection } from './primitives';
 import Row from './Row';
 import PerformancePanel from './PerformancePanel';
+import ComputeDevicePanel from './ComputeDevicePanel';
 
 export default function PerformanceDeviceTab() {
   const { t } = useTranslation();
@@ -28,6 +29,8 @@ export default function PerformanceDeviceTab() {
   return (
     <>
       <PerformancePanel />
+
+      <ComputeDevicePanel />
 
       <SettingsSection
         icon={Gauge}

--- a/frontend/src/components/settings/settingsCategories.jsx
+++ b/frontend/src/components/settings/settingsCategories.jsx
@@ -196,6 +196,10 @@ export const GROUPS = [
           'vram',
           'compute',
           'platform',
+          'cuda',
+          'rocm',
+          'mps',
+          'cpu',
         ],
       },
       {

--- a/frontend/src/components/settings/settingsCategories.jsx
+++ b/frontend/src/components/settings/settingsCategories.jsx
@@ -200,6 +200,8 @@ export const GROUPS = [
           'rocm',
           'mps',
           'cpu',
+          'xpu',
+          'intel',
         ],
       },
       {

--- a/frontend/src/components/settings/settingsCategories.test.jsx
+++ b/frontend/src/components/settings/settingsCategories.test.jsx
@@ -67,6 +67,7 @@ describe('restart flag ↔ RestartBadge lockstep', () => {
     'RemoteBackendPanel.jsx': 'sharing',
     'AudioToolsPanel.jsx': 'audio-tools',
     'PerformancePanel.jsx': 'performance',
+    'ComputeDevicePanel.jsx': 'performance',
   };
 
   const panelsUsingRestartBadge = fs

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "تعذّر تحميل إعداد الجهاز",
+    "perf_save_failed": "تعذّر حفظ الإعداد"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} متصل",
     "workers_token_expired": "انتهت الصلاحية — أنشئ رمزًا جديدًا",
     "workers_token_expires_in": "تنتهي الصلاحية خلال {{time}}",
-    "workers_token_qr_hint": "على الجهاز الآخر: الإعدادات ← النظام ← العاملون البعيدون ← انضمام، ثم امسح أو الصق."
+    "workers_token_qr_hint": "على الجهاز الآخر: الإعدادات ← النظام ← العاملون البعيدون ← انضمام، ثم امسح أو الصق.",
+    "compute_device": "جهاز الحوسبة",
+    "compute_device_title": "جهاز الحوسبة",
+    "compute_device_desc": "الجهاز الذي يشغّل عليه الخادم النماذج. الوضع التلقائي مناسب للجميع تقريبًا.",
+    "compute_device_env_pinned": "مثبّت بواسطة متغيّر البيئة OMNIVOICE_DEVICE",
+    "compute_device_ignored": "لم يُكتشف هذا الجهاز على هذا الحاسوب — الوضع التلقائي هو المعمول به",
+    "compute_device_restart": "يسري بعد إعادة تشغيل التطبيق",
+    "compute_device_note": "تُعرض فقط الأجهزة المكتشفة على هذا الحاسوب. تعمل CPU دائمًا؛ تثبيت جهاز لا يخترع عتادًا أبدًا.",
+    "compute_device_auto": "تلقائي (مستحسن)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Abgelaufen — erzeugen Sie ein neues",
     "workers_token_expires_in": "Läuft ab in {{time}}",
-    "workers_token_qr_hint": "Auf dem anderen Rechner: Einstellungen → System → Remote-Worker → Beitreten, dann scannen oder einfügen."
+    "workers_token_qr_hint": "Auf dem anderen Rechner: Einstellungen → System → Remote-Worker → Beitreten, dann scannen oder einfügen.",
+    "compute_device": "Rechengerät",
+    "compute_device_title": "Rechengerät",
+    "compute_device_desc": "Auf welchem Gerät das Backend Modelle ausführt. Auto ist für fast alle richtig.",
+    "compute_device_env_pinned": "Durch die Umgebungsvariable OMNIVOICE_DEVICE festgelegt",
+    "compute_device_ignored": "Dieses Gerät wurde auf diesem Rechner nicht erkannt — Auto ist aktiv",
+    "compute_device_restart": "Wird nach dem Neustart der App wirksam",
+    "compute_device_note": "Es werden nur auf diesem Rechner erkannte Geräte angezeigt. CPU funktioniert immer; ein festgelegtes Gerät erfindet keine Hardware.",
+    "compute_device_auto": "Auto (empfohlen)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Geräteeinstellung konnte nicht geladen werden",
+    "perf_save_failed": "Einstellung konnte nicht gespeichert werden"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -903,7 +903,8 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Failed to load device setting"
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -890,7 +890,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Expired — generate a new one",
     "workers_token_expires_in": "Expires in {{time}}",
-    "workers_token_qr_hint": "On the other machine: Settings → System → Remote workers → Join, then scan or paste."
+    "workers_token_qr_hint": "On the other machine: Settings → System → Remote workers → Join, then scan or paste.",
+    "compute_device": "Compute device",
+    "compute_device_title": "Compute device",
+    "compute_device_desc": "Which device the backend runs models on. Auto is right for almost everyone.",
+    "compute_device_env_pinned": "Pinned by the OMNIVOICE_DEVICE environment variable",
+    "compute_device_ignored": "That device was not detected on this machine — Auto is in effect",
+    "compute_device_restart": "Takes effect after the app restarts",
+    "compute_device_note": "Only devices detected on this machine are listed. CPU always works; pinning a device never invents hardware.",
+    "compute_device_auto": "Auto (recommended)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} en línea",
     "workers_token_expired": "Caducado — genera uno nuevo",
     "workers_token_expires_in": "Caduca en {{time}}",
-    "workers_token_qr_hint": "En el otro equipo: Ajustes → Sistema → Trabajadores remotos → Unirse, y luego escanea o pega."
+    "workers_token_qr_hint": "En el otro equipo: Ajustes → Sistema → Trabajadores remotos → Unirse, y luego escanea o pega.",
+    "compute_device": "Dispositivo de cómputo",
+    "compute_device_title": "Dispositivo de cómputo",
+    "compute_device_desc": "En qué dispositivo ejecuta los modelos el backend. Auto es lo correcto para casi todos.",
+    "compute_device_env_pinned": "Fijado por la variable de entorno OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Ese dispositivo no se detectó en esta máquina — Auto está en efecto",
+    "compute_device_restart": "Surte efecto tras reiniciar la aplicación",
+    "compute_device_note": "Solo se listan los dispositivos detectados en esta máquina. La CPU siempre funciona; fijar un dispositivo nunca inventa hardware.",
+    "compute_device_auto": "Auto (recomendado)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "No se pudo cargar el ajuste del dispositivo",
+    "perf_save_failed": "No se pudo guardar el ajuste"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} en ligne",
     "workers_token_expired": "Expiré — générez-en un nouveau",
     "workers_token_expires_in": "Expire dans {{time}}",
-    "workers_token_qr_hint": "Sur l'autre machine : Paramètres → Système → Workers distants → Rejoindre, puis scannez ou collez."
+    "workers_token_qr_hint": "Sur l'autre machine : Paramètres → Système → Workers distants → Rejoindre, puis scannez ou collez.",
+    "compute_device": "Périphérique de calcul",
+    "compute_device_title": "Périphérique de calcul",
+    "compute_device_desc": "Sur quel périphérique le backend exécute les modèles. Auto convient à presque tout le monde.",
+    "compute_device_env_pinned": "Épinglé par la variable d'environnement OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Ce périphérique n'a pas été détecté sur cette machine — Auto est en vigueur",
+    "compute_device_restart": "Prend effet après le redémarrage de l'application",
+    "compute_device_note": "Seuls les périphériques détectés sur cette machine sont listés. Le CPU fonctionne toujours ; épingler un périphérique n'invente jamais de matériel.",
+    "compute_device_auto": "Auto (recommandé)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Impossible de charger le réglage du périphérique",
+    "perf_save_failed": "Impossible d'enregistrer le réglage"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} ऑनलाइन",
     "workers_token_expired": "समाप्त हो गया — नया बनाएँ",
     "workers_token_expires_in": "{{time}} में समाप्त होगा",
-    "workers_token_qr_hint": "दूसरी मशीन पर: सेटिंग्स → सिस्टम → रिमोट वर्कर → जुड़ें, फिर स्कैन या पेस्ट करें।"
+    "workers_token_qr_hint": "दूसरी मशीन पर: सेटिंग्स → सिस्टम → रिमोट वर्कर → जुड़ें, फिर स्कैन या पेस्ट करें।",
+    "compute_device": "कंप्यूट डिवाइस",
+    "compute_device_title": "कंप्यूट डिवाइस",
+    "compute_device_desc": "बैकएंड मॉडल किस डिवाइस पर चलाता है। लगभग सभी के लिए Auto सही है।",
+    "compute_device_env_pinned": "OMNIVOICE_DEVICE पर्यावरण चर द्वारा पिन किया गया",
+    "compute_device_ignored": "वह डिवाइस इस मशीन पर नहीं मिला — Auto प्रभावी है",
+    "compute_device_restart": "ऐप के पुनरारंभ के बाद प्रभावी होगा",
+    "compute_device_note": "केवल इस मशीन पर पाए गए डिवाइस सूचीबद्ध हैं। CPU हमेशा काम करता है; डिवाइस पिन करने से हार्डवेयर कभी नहीं बनता।",
+    "compute_device_auto": "Auto (अनुशंसित)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "डिवाइस सेटिंग लोड नहीं हो सकी",
+    "perf_save_failed": "सेटिंग सहेजी नहीं जा सकी"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Gagal memuat pengaturan perangkat",
+    "perf_save_failed": "Gagal menyimpan pengaturan"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Kedaluwarsa — buat yang baru",
     "workers_token_expires_in": "Kedaluwarsa dalam {{time}}",
-    "workers_token_qr_hint": "Di mesin yang lain: Pengaturan → Sistem → Pekerja jarak jauh → Gabung, lalu pindai atau tempelkan."
+    "workers_token_qr_hint": "Di mesin yang lain: Pengaturan → Sistem → Pekerja jarak jauh → Gabung, lalu pindai atau tempelkan.",
+    "compute_device": "Perangkat komputasi",
+    "compute_device_title": "Perangkat komputasi",
+    "compute_device_desc": "Di perangkat mana backend menjalankan model. Auto tepat untuk hampir semua orang.",
+    "compute_device_env_pinned": "Disematkan oleh variabel lingkungan OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Perangkat itu tidak terdeteksi di mesin ini — Auto yang berlaku",
+    "compute_device_restart": "Berlaku setelah aplikasi dimulai ulang",
+    "compute_device_note": "Hanya perangkat yang terdeteksi di mesin ini yang ditampilkan. CPU selalu berfungsi; menyematkan perangkat tidak pernah mengarang perangkat keras.",
+    "compute_device_auto": "Auto (disarankan)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Impossibile caricare l'impostazione del dispositivo",
+    "perf_save_failed": "Impossibile salvare l'impostazione"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Scaduto — generane uno nuovo",
     "workers_token_expires_in": "Scade tra {{time}}",
-    "workers_token_qr_hint": "Sull'altro computer: Impostazioni → Sistema → Worker remoti → Collegati, poi scansiona o incolla."
+    "workers_token_qr_hint": "Sull'altro computer: Impostazioni → Sistema → Worker remoti → Collegati, poi scansiona o incolla.",
+    "compute_device": "Dispositivo di calcolo",
+    "compute_device_title": "Dispositivo di calcolo",
+    "compute_device_desc": "Su quale dispositivo il backend esegue i modelli. Auto va bene per quasi tutti.",
+    "compute_device_env_pinned": "Bloccato dalla variabile d'ambiente OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Quel dispositivo non è stato rilevato su questa macchina — è attivo Auto",
+    "compute_device_restart": "Ha effetto dopo il riavvio dell'app",
+    "compute_device_note": "Sono elencati solo i dispositivi rilevati su questa macchina. La CPU funziona sempre; fissare un dispositivo non inventa mai hardware.",
+    "compute_device_auto": "Auto (consigliato)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} 台オンライン",
     "workers_token_expired": "期限切れ — 新しく生成してください",
     "workers_token_expires_in": "あと {{time}} で期限切れ",
-    "workers_token_qr_hint": "もう一方のマシンで: 設定 → システム → リモートワーカー → 参加 を開き、スキャンするか貼り付けてください。"
+    "workers_token_qr_hint": "もう一方のマシンで: 設定 → システム → リモートワーカー → 参加 を開き、スキャンするか貼り付けてください。",
+    "compute_device": "計算デバイス",
+    "compute_device_title": "計算デバイス",
+    "compute_device_desc": "バックエンドがモデルを実行するデバイス。ほとんどの場合は Auto が最適です。",
+    "compute_device_env_pinned": "環境変数 OMNIVOICE_DEVICE により固定されています",
+    "compute_device_ignored": "そのデバイスはこのマシンで検出されませんでした — Auto が適用されています",
+    "compute_device_restart": "アプリの再起動後に有効になります",
+    "compute_device_note": "このマシンで検出されたデバイスのみ表示されます。CPU は常に動作します。デバイスを固定してもハードウェアが増えることはありません。",
+    "compute_device_auto": "自動（推奨）",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -318,9 +318,9 @@
     "workers_token_qr_hint": "もう一方のマシンで: 設定 → システム → リモートワーカー → 参加 を開き、スキャンするか貼り付けてください。",
     "compute_device": "計算デバイス",
     "compute_device_title": "計算デバイス",
-    "compute_device_desc": "バックエンドがモデルを実行するデバイス。ほとんどの場合は Auto が最適です。",
+    "compute_device_desc": "バックエンドがモデルを実行するデバイス。ほとんどの場合は「自動」が最適です。",
     "compute_device_env_pinned": "環境変数 OMNIVOICE_DEVICE により固定されています",
-    "compute_device_ignored": "そのデバイスはこのマシンで検出されませんでした — Auto が適用されています",
+    "compute_device_ignored": "そのデバイスはこのマシンで検出されませんでした — 「自動」が適用されています",
     "compute_device_restart": "アプリの再起動後に有効になります",
     "compute_device_note": "このマシンで検出されたデバイスのみ表示されます。CPU は常に動作します。デバイスを固定してもハードウェアが増えることはありません。",
     "compute_device_auto": "自動（推奨）",
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "デバイス設定を読み込めませんでした",
+    "perf_save_failed": "設定を保存できませんでした"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -318,9 +318,9 @@
     "workers_token_qr_hint": "다른 컴퓨터에서: 설정 → 시스템 → 원격 워커 → 참여로 이동한 뒤 스캔하거나 붙여 넣으세요.",
     "compute_device": "연산 장치",
     "compute_device_title": "연산 장치",
-    "compute_device_desc": "백엔드가 모델을 실행할 장치입니다. 거의 모든 경우 Auto가 적합합니다.",
+    "compute_device_desc": "백엔드가 모델을 실행할 장치입니다. 거의 모든 경우 '자동'이 적합합니다.",
     "compute_device_env_pinned": "OMNIVOICE_DEVICE 환경 변수로 고정됨",
-    "compute_device_ignored": "이 컴퓨터에서 해당 장치를 찾지 못했습니다 — Auto가 적용 중입니다",
+    "compute_device_ignored": "이 컴퓨터에서 해당 장치를 찾지 못했습니다 — '자동'이 적용 중입니다",
     "compute_device_restart": "앱을 다시 시작한 후 적용됩니다",
     "compute_device_note": "이 컴퓨터에서 감지된 장치만 표시됩니다. CPU는 항상 작동하며, 장치를 고정해도 없는 하드웨어가 생기지는 않습니다.",
     "compute_device_auto": "자동 (권장)",
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "장치 설정을 불러오지 못했습니다",
+    "perf_save_failed": "설정을 저장하지 못했습니다"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}}대 온라인",
     "workers_token_expired": "만료됨 — 새로 생성하세요",
     "workers_token_expires_in": "{{time}} 후 만료",
-    "workers_token_qr_hint": "다른 컴퓨터에서: 설정 → 시스템 → 원격 워커 → 참여로 이동한 뒤 스캔하거나 붙여 넣으세요."
+    "workers_token_qr_hint": "다른 컴퓨터에서: 설정 → 시스템 → 원격 워커 → 참여로 이동한 뒤 스캔하거나 붙여 넣으세요.",
+    "compute_device": "연산 장치",
+    "compute_device_title": "연산 장치",
+    "compute_device_desc": "백엔드가 모델을 실행할 장치입니다. 거의 모든 경우 Auto가 적합합니다.",
+    "compute_device_env_pinned": "OMNIVOICE_DEVICE 환경 변수로 고정됨",
+    "compute_device_ignored": "이 컴퓨터에서 해당 장치를 찾지 못했습니다 — Auto가 적용 중입니다",
+    "compute_device_restart": "앱을 다시 시작한 후 적용됩니다",
+    "compute_device_note": "이 컴퓨터에서 감지된 장치만 표시됩니다. CPU는 항상 작동하며, 장치를 고정해도 없는 하드웨어가 생기지는 않습니다.",
+    "compute_device_auto": "자동 (권장)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Apparaatinstelling kon niet worden geladen",
+    "perf_save_failed": "Instelling kon niet worden opgeslagen"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Verlopen — genereer een nieuwe",
     "workers_token_expires_in": "Verloopt over {{time}}",
-    "workers_token_qr_hint": "Op de andere machine: Instellingen → Systeem → Externe workers → Koppelen, en scan of plak daar."
+    "workers_token_qr_hint": "Op de andere machine: Instellingen → Systeem → Externe workers → Koppelen, en scan of plak daar.",
+    "compute_device": "Rekenapparaat",
+    "compute_device_title": "Rekenapparaat",
+    "compute_device_desc": "Op welk apparaat de backend modellen draait. Auto is voor bijna iedereen juist.",
+    "compute_device_env_pinned": "Vastgezet door de omgevingsvariabele OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Dat apparaat is op deze machine niet gedetecteerd — Auto is van kracht",
+    "compute_device_restart": "Wordt van kracht na het herstarten van de app",
+    "compute_device_note": "Alleen op deze machine gedetecteerde apparaten worden getoond. CPU werkt altijd; een vastgezet apparaat verzint nooit hardware.",
+    "compute_device_auto": "Auto (aanbevolen)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Wygasł — wygeneruj nowy",
     "workers_token_expires_in": "Wygasa za {{time}}",
-    "workers_token_qr_hint": "Na drugim komputerze: Ustawienia → Systemu → Zdalne workery → Dołącz, potem zeskanuj albo wklej."
+    "workers_token_qr_hint": "Na drugim komputerze: Ustawienia → Systemu → Zdalne workery → Dołącz, potem zeskanuj albo wklej.",
+    "compute_device": "Urządzenie obliczeniowe",
+    "compute_device_title": "Urządzenie obliczeniowe",
+    "compute_device_desc": "Na którym urządzeniu backend uruchamia modele. Auto jest właściwe dla niemal wszystkich.",
+    "compute_device_env_pinned": "Przypięte przez zmienną środowiskową OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Tego urządzenia nie wykryto na tej maszynie — obowiązuje Auto",
+    "compute_device_restart": "Zacznie obowiązywać po ponownym uruchomieniu aplikacji",
+    "compute_device_note": "Wyświetlane są tylko urządzenia wykryte na tej maszynie. CPU zawsze działa; przypięcie urządzenia nigdy nie wymyśla sprzętu.",
+    "compute_device_auto": "Auto (zalecane)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Nie udało się wczytać ustawienia urządzenia",
+    "perf_save_failed": "Nie udało się zapisać ustawienia"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Falha ao carregar a configuração do dispositivo",
+    "perf_save_failed": "Falha ao salvar a configuração"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Expirado — gere um novo",
     "workers_token_expires_in": "Expira em {{time}}",
-    "workers_token_qr_hint": "Na outra máquina: Configurações → Sistema → Workers remotos → Associar, depois escaneie ou cole."
+    "workers_token_qr_hint": "Na outra máquina: Configurações → Sistema → Workers remotos → Associar, depois escaneie ou cole.",
+    "compute_device": "Dispositivo de computação",
+    "compute_device_title": "Dispositivo de computação",
+    "compute_device_desc": "Em qual dispositivo o backend executa os modelos. Auto é o certo para quase todos.",
+    "compute_device_env_pinned": "Fixado pela variável de ambiente OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Esse dispositivo não foi detectado nesta máquina — Auto está em vigor",
+    "compute_device_restart": "Entra em vigor após reiniciar o aplicativo",
+    "compute_device_note": "Apenas dispositivos detectados nesta máquina são listados. A CPU sempre funciona; fixar um dispositivo nunca inventa hardware.",
+    "compute_device_auto": "Auto (recomendado)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} в сети",
     "workers_token_expired": "Истёк — создайте новый",
     "workers_token_expires_in": "Истекает через {{time}}",
-    "workers_token_qr_hint": "На другой машине: Настройки → Система → Удалённые воркеры → Подключиться, затем отсканируйте или вставьте."
+    "workers_token_qr_hint": "На другой машине: Настройки → Система → Удалённые воркеры → Подключиться, затем отсканируйте или вставьте.",
+    "compute_device": "Устройство вычислений",
+    "compute_device_title": "Устройство вычислений",
+    "compute_device_desc": "На каком устройстве backend выполняет модели. Auto подходит почти всем.",
+    "compute_device_env_pinned": "Закреплено переменной окружения OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Это устройство не обнаружено на этой машине — действует Auto",
+    "compute_device_restart": "Вступит в силу после перезапуска приложения",
+    "compute_device_note": "Показаны только устройства, обнаруженные на этой машине. CPU работает всегда; закрепление устройства не создаёт несуществующее оборудование.",
+    "compute_device_auto": "Auto (рекомендуется)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Не удалось загрузить настройку устройства",
+    "perf_save_failed": "Не удалось сохранить настройку"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} online",
     "workers_token_expired": "Har gått ut — skapa en ny",
     "workers_token_expires_in": "Går ut om {{time}}",
-    "workers_token_qr_hint": "På den andra maskinen: Inställningar → System → Fjärrarbetare → Anslut, skanna eller klistra sedan in."
+    "workers_token_qr_hint": "På den andra maskinen: Inställningar → System → Fjärrarbetare → Anslut, skanna eller klistra sedan in.",
+    "compute_device": "Beräkningsenhet",
+    "compute_device_title": "Beräkningsenhet",
+    "compute_device_desc": "Vilken enhet backend kör modeller på. Auto är rätt för nästan alla.",
+    "compute_device_env_pinned": "Låst av miljövariabeln OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Den enheten hittades inte på den här datorn — Auto gäller",
+    "compute_device_restart": "Träder i kraft efter omstart av appen",
+    "compute_device_note": "Endast enheter som hittats på den här datorn visas. CPU fungerar alltid; att låsa en enhet hittar aldrig på hårdvara.",
+    "compute_device_auto": "Auto (rekommenderas)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Kunde inte läsa in enhetsinställningen",
+    "perf_save_failed": "Kunde inte spara inställningen"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "ออนไลน์ {{count}} เครื่อง",
     "workers_token_expired": "หมดอายุแล้ว — สร้างใหม่",
     "workers_token_expires_in": "หมดอายุใน {{time}}",
-    "workers_token_qr_hint": "บนเครื่องอีกเครื่อง: การตั้งค่า → ระบบ → ผู้ปฏิบัติงานระยะไกล → เข้าร่วม แล้วสแกนหรือวาง"
+    "workers_token_qr_hint": "บนเครื่องอีกเครื่อง: การตั้งค่า → ระบบ → ผู้ปฏิบัติงานระยะไกล → เข้าร่วม แล้วสแกนหรือวาง",
+    "compute_device": "อุปกรณ์ประมวลผล",
+    "compute_device_title": "อุปกรณ์ประมวลผล",
+    "compute_device_desc": "แบ็กเอนด์รันโมเดลบนอุปกรณ์ใด Auto เหมาะสำหรับเกือบทุกคน",
+    "compute_device_env_pinned": "ถูกกำหนดโดยตัวแปรสภาพแวดล้อม OMNIVOICE_DEVICE",
+    "compute_device_ignored": "ไม่พบอุปกรณ์นั้นบนเครื่องนี้ — ใช้ Auto แทน",
+    "compute_device_restart": "มีผลหลังจากรีสตาร์ตแอป",
+    "compute_device_note": "แสดงเฉพาะอุปกรณ์ที่ตรวจพบบนเครื่องนี้ CPU ใช้ได้เสมอ การกำหนดอุปกรณ์ไม่เคยสร้างฮาร์ดแวร์ที่ไม่มีอยู่",
+    "compute_device_auto": "อัตโนมัติ (แนะนำ)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -318,9 +318,9 @@
     "workers_token_qr_hint": "บนเครื่องอีกเครื่อง: การตั้งค่า → ระบบ → ผู้ปฏิบัติงานระยะไกล → เข้าร่วม แล้วสแกนหรือวาง",
     "compute_device": "อุปกรณ์ประมวลผล",
     "compute_device_title": "อุปกรณ์ประมวลผล",
-    "compute_device_desc": "แบ็กเอนด์รันโมเดลบนอุปกรณ์ใด Auto เหมาะสำหรับเกือบทุกคน",
+    "compute_device_desc": "แบ็กเอนด์รันโมเดลบนอุปกรณ์ใด อัตโนมัติ เหมาะสำหรับเกือบทุกคน",
     "compute_device_env_pinned": "ถูกกำหนดโดยตัวแปรสภาพแวดล้อม OMNIVOICE_DEVICE",
-    "compute_device_ignored": "ไม่พบอุปกรณ์นั้นบนเครื่องนี้ — ใช้ Auto แทน",
+    "compute_device_ignored": "ไม่พบอุปกรณ์นั้นบนเครื่องนี้ — ใช้ อัตโนมัติ แทน",
     "compute_device_restart": "มีผลหลังจากรีสตาร์ตแอป",
     "compute_device_note": "แสดงเฉพาะอุปกรณ์ที่ตรวจพบบนเครื่องนี้ CPU ใช้ได้เสมอ การกำหนดอุปกรณ์ไม่เคยสร้างฮาร์ดแวร์ที่ไม่มีอยู่",
     "compute_device_auto": "อัตโนมัติ (แนะนำ)",
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "โหลดการตั้งค่าอุปกรณ์ไม่สำเร็จ",
+    "perf_save_failed": "บันทึกการตั้งค่าไม่สำเร็จ"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} çevrimiçi",
     "workers_token_expired": "Süresi doldu — yenisini oluşturun",
     "workers_token_expires_in": "{{time}} içinde süresi dolacak",
-    "workers_token_qr_hint": "Diğer makinede: Ayarlar → Sistem → Uzak işçiler → Katıl, sonra tarayın veya yapıştırın."
+    "workers_token_qr_hint": "Diğer makinede: Ayarlar → Sistem → Uzak işçiler → Katıl, sonra tarayın veya yapıştırın.",
+    "compute_device": "Hesaplama aygıtı",
+    "compute_device_title": "Hesaplama aygıtı",
+    "compute_device_desc": "Backend'in modelleri hangi aygıtta çalıştıracağı. Auto neredeyse herkes için doğrudur.",
+    "compute_device_env_pinned": "OMNIVOICE_DEVICE ortam değişkeniyle sabitlendi",
+    "compute_device_ignored": "Bu aygıt bu makinede algılanmadı — Auto geçerli",
+    "compute_device_restart": "Uygulama yeniden başlatıldıktan sonra geçerli olur",
+    "compute_device_note": "Yalnızca bu makinede algılanan aygıtlar listelenir. CPU her zaman çalışır; bir aygıtı sabitlemek asla donanım uydurmaz.",
+    "compute_device_auto": "Auto (önerilen)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Aygıt ayarı yüklenemedi",
+    "perf_save_failed": "Ayar kaydedilemedi"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Не вдалося завантажити налаштування пристрою",
+    "perf_save_failed": "Не вдалося зберегти налаштування"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} у мережі",
     "workers_token_expired": "Сплив — створіть новий",
     "workers_token_expires_in": "Спливає через {{time}}",
-    "workers_token_qr_hint": "На іншій машині: Налаштування → система → Віддалені воркери → Підключитися, потім відскануйте або вставте."
+    "workers_token_qr_hint": "На іншій машині: Налаштування → система → Віддалені воркери → Підключитися, потім відскануйте або вставте.",
+    "compute_device": "Пристрій обчислень",
+    "compute_device_title": "Пристрій обчислень",
+    "compute_device_desc": "На якому пристрої backend виконує моделі. Auto підходить майже всім.",
+    "compute_device_env_pinned": "Закріплено змінною середовища OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Цей пристрій не виявлено на цій машині — діє Auto",
+    "compute_device_restart": "Набуде чинності після перезапуску застосунку",
+    "compute_device_note": "Показано лише пристрої, виявлені на цій машині. CPU працює завжди; закріплення пристрою ніколи не вигадує обладнання.",
+    "compute_device_auto": "Auto (рекомендовано)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} trực tuyến",
     "workers_token_expired": "Đã hết hạn — hãy tạo mã mới",
     "workers_token_expires_in": "Hết hạn sau {{time}}",
-    "workers_token_qr_hint": "Trên máy kia: Cài đặt → Hệ thống → Máy phụ từ xa → Tham gia, rồi quét hoặc dán."
+    "workers_token_qr_hint": "Trên máy kia: Cài đặt → Hệ thống → Máy phụ từ xa → Tham gia, rồi quét hoặc dán.",
+    "compute_device": "Thiết bị tính toán",
+    "compute_device_title": "Thiết bị tính toán",
+    "compute_device_desc": "Backend chạy mô hình trên thiết bị nào. Auto phù hợp với hầu hết mọi người.",
+    "compute_device_env_pinned": "Được ghim bởi biến môi trường OMNIVOICE_DEVICE",
+    "compute_device_ignored": "Không phát hiện thiết bị đó trên máy này — Auto đang có hiệu lực",
+    "compute_device_restart": "Có hiệu lực sau khi khởi động lại ứng dụng",
+    "compute_device_note": "Chỉ liệt kê các thiết bị được phát hiện trên máy này. CPU luôn hoạt động; ghim một thiết bị không bao giờ bịa ra phần cứng.",
+    "compute_device_auto": "Tự động (khuyên dùng)",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -318,9 +318,9 @@
     "workers_token_qr_hint": "Trên máy kia: Cài đặt → Hệ thống → Máy phụ từ xa → Tham gia, rồi quét hoặc dán.",
     "compute_device": "Thiết bị tính toán",
     "compute_device_title": "Thiết bị tính toán",
-    "compute_device_desc": "Backend chạy mô hình trên thiết bị nào. Auto phù hợp với hầu hết mọi người.",
+    "compute_device_desc": "Backend chạy mô hình trên thiết bị nào. Tự động phù hợp với hầu hết mọi người.",
     "compute_device_env_pinned": "Được ghim bởi biến môi trường OMNIVOICE_DEVICE",
-    "compute_device_ignored": "Không phát hiện thiết bị đó trên máy này — Auto đang có hiệu lực",
+    "compute_device_ignored": "Không phát hiện thiết bị đó trên máy này — Tự động đang có hiệu lực",
     "compute_device_restart": "Có hiệu lực sau khi khởi động lại ứng dụng",
     "compute_device_note": "Chỉ liệt kê các thiết bị được phát hiện trên máy này. CPU luôn hoạt động; ghim một thiết bị không bao giờ bịa ra phần cứng.",
     "compute_device_auto": "Tự động (khuyên dùng)",
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "Không tải được cài đặt thiết bị",
+    "perf_save_failed": "Không lưu được cài đặt"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -551,7 +551,20 @@
     "workers_summary_online": "{{count}} 台在线",
     "workers_token_expired": "已过期——请重新生成",
     "workers_token_expires_in": "{{time}} 后过期",
-    "workers_token_qr_hint": "在另一台机器上：设置 → 系统 → 远程工作机 → 加入，然后扫描或粘贴。"
+    "workers_token_qr_hint": "在另一台机器上：设置 → 系统 → 远程工作机 → 加入，然后扫描或粘贴。",
+    "compute_device": "计算设备",
+    "compute_device_title": "计算设备",
+    "compute_device_desc": "后端在哪个设备上运行模型。绝大多数情况下选 Auto 即可。",
+    "compute_device_env_pinned": "已被环境变量 OMNIVOICE_DEVICE 固定",
+    "compute_device_ignored": "本机未检测到该设备——当前实际使用 Auto",
+    "compute_device_restart": "重启应用后生效",
+    "compute_device_note": "仅列出本机检测到的设备。CPU 始终可用；固定设备不会凭空造出硬件。",
+    "compute_device_auto": "自动（推荐）",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "about": {
     "app": "应用",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -554,9 +554,9 @@
     "workers_token_qr_hint": "在另一台机器上：设置 → 系统 → 远程工作机 → 加入，然后扫描或粘贴。",
     "compute_device": "计算设备",
     "compute_device_title": "计算设备",
-    "compute_device_desc": "后端在哪个设备上运行模型。绝大多数情况下选 Auto 即可。",
+    "compute_device_desc": "后端在哪个设备上运行模型。绝大多数情况下选「自动」即可。",
     "compute_device_env_pinned": "已被环境变量 OMNIVOICE_DEVICE 固定",
-    "compute_device_ignored": "本机未检测到该设备——当前实际使用 Auto",
+    "compute_device_ignored": "本机未检测到该设备——当前实际使用「自动」",
     "compute_device_restart": "重启应用后生效",
     "compute_device_note": "仅列出本机检测到的设备。CPU 始终可用；固定设备不会凭空造出硬件。",
     "compute_device_auto": "自动（推荐）",
@@ -564,7 +564,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "无法加载设备设置",
+    "perf_save_failed": "无法保存设置"
   },
   "about": {
     "app": "应用",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -318,9 +318,9 @@
     "workers_token_qr_hint": "在另一台機器上：設定 → 系統 → 遠端工作機 → 加入，然後掃描或貼上。",
     "compute_device": "運算裝置",
     "compute_device_title": "運算裝置",
-    "compute_device_desc": "後端在哪個裝置上執行模型。絕大多數情況下選 Auto 即可。",
+    "compute_device_desc": "後端在哪個裝置上執行模型。絕大多數情況下選「自動」即可。",
     "compute_device_env_pinned": "已由環境變數 OMNIVOICE_DEVICE 固定",
-    "compute_device_ignored": "本機未偵測到該裝置——目前實際使用 Auto",
+    "compute_device_ignored": "本機未偵測到該裝置——目前實際使用「自動」",
     "compute_device_restart": "重新啟動應用程式後生效",
     "compute_device_note": "僅列出本機偵測到的裝置。CPU 永遠可用；固定裝置不會憑空生出硬體。",
     "compute_device_auto": "自動（建議）",
@@ -328,7 +328,9 @@
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
     "device_family_mps": "Apple GPU (MPS)",
-    "device_family_cpu": "CPU"
+    "device_family_cpu": "CPU",
+    "device_load_failed": "無法載入裝置設定",
+    "perf_save_failed": "無法儲存設定"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -315,7 +315,20 @@
     "workers_summary_online": "{{count}} 台上線",
     "workers_token_expired": "已過期——請重新產生",
     "workers_token_expires_in": "{{time}} 後過期",
-    "workers_token_qr_hint": "在另一台機器上：設定 → 系統 → 遠端工作機 → 加入，然後掃描或貼上。"
+    "workers_token_qr_hint": "在另一台機器上：設定 → 系統 → 遠端工作機 → 加入，然後掃描或貼上。",
+    "compute_device": "運算裝置",
+    "compute_device_title": "運算裝置",
+    "compute_device_desc": "後端在哪個裝置上執行模型。絕大多數情況下選 Auto 即可。",
+    "compute_device_env_pinned": "已由環境變數 OMNIVOICE_DEVICE 固定",
+    "compute_device_ignored": "本機未偵測到該裝置——目前實際使用 Auto",
+    "compute_device_restart": "重新啟動應用程式後生效",
+    "compute_device_note": "僅列出本機偵測到的裝置。CPU 永遠可用；固定裝置不會憑空生出硬體。",
+    "compute_device_auto": "自動（建議）",
+    "device_family_cuda": "NVIDIA GPU (CUDA)",
+    "device_family_rocm": "AMD GPU (ROCm)",
+    "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_mps": "Apple GPU (MPS)",
+    "device_family_cpu": "CPU"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/tests/backend/test_compute_device_settings.py
+++ b/tests/backend/test_compute_device_settings.py
@@ -1,0 +1,111 @@
+"""Tests for the compute-device override endpoints (Settings → Performance).
+
+Covers the API contract of GET/PUT /api/settings/compute-device:
+  - GET reports the resolved pick, what this process applied, and the host's
+    available families (the UI renders only those + Auto).
+  - PUT persists a valid pick to prefs.json and echoes the new state with
+    restart_required=True (caps are immutable per process).
+  - PUT rejects unknown values and accelerators this host doesn't have —
+    a silent no-op pick would read as "the setting doesn't work".
+  - An OMNIVOICE_DEVICE env pin is reported (env_pinned) and wins over PUT.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fresh_app(monkeypatch, tmp_path):
+    """Same isolation pattern as tests/backend/test_perf_settings.py."""
+    monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("OMNIVOICE_DEVICE", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+    for mod in list(sys.modules):
+        if (
+            mod == "core" or mod.startswith("core.")
+            or mod == "services" or mod.startswith("services.")
+            or mod == "api" or mod.startswith("api.")
+        ):
+            del sys.modules[mod]
+
+    from core import db as _db
+    _db.init_db()
+
+    from fastapi import FastAPI
+    from api.routers import settings as settings_router
+
+    app = FastAPI()
+    app.include_router(settings_router.router)
+    return app
+
+
+def _client(app):
+    from fastapi.testclient import TestClient
+    return TestClient(app, client=("127.0.0.1", 12345))
+
+
+def test_get_reports_state_and_families(fresh_app):
+    c = _client(fresh_app)
+    r = c.get("/api/settings/compute-device")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["value"] in body["choices"]
+    assert "cpu" in body["available_families"]  # invariant: cpu always present
+    assert body["effective_family"] in body["available_families"]
+    assert isinstance(body["env_pinned"], bool)
+
+
+def test_put_persists_and_flags_restart(fresh_app):
+    c = _client(fresh_app)
+    r = c.put("/api/settings/compute-device", json={"value": "cpu"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["value"] == "cpu"
+    # Caps are cached per process: the pick applies at next start, and the
+    # endpoint must say so instead of pretending it already did.
+    assert body["restart_required"] is True
+
+    from core import prefs
+    assert prefs.resolve("compute_device", default="auto") == "cpu"
+
+    # auto round-trips back
+    r = c.put("/api/settings/compute-device", json={"value": "auto"})
+    assert r.status_code == 200
+    assert r.json()["value"] == "auto"
+
+
+def test_put_rejects_unknown_and_unavailable_values(fresh_app):
+    c = _client(fresh_app)
+    r = c.put("/api/settings/compute-device", json={"value": "quantum"})
+    assert r.status_code == 400
+    assert "Valid:" in r.json()["detail"]
+
+    # Find an accelerator this host does NOT have (CI hosts are cpu-only,
+    # but don't assume — pick from the full choice list minus available).
+    state = c.get("/api/settings/compute-device").json()
+    missing = [
+        f for f in state["choices"]
+        if f not in ("auto", "cpu") and f not in state["available_families"]
+    ]
+    if missing:
+        r = c.put("/api/settings/compute-device", json={"value": missing[0]})
+        assert r.status_code == 400
+        assert "not available" in r.json()["detail"]
+
+
+def test_env_pin_is_reported_and_wins(fresh_app, monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_DEVICE", "cpu")
+    c = _client(fresh_app)
+    state = c.get("/api/settings/compute-device").json()
+    assert state["env_pinned"] is True
+    assert state["value"] == "cpu"
+
+    # A PUT still persists (for after the pin is removed) but the resolved
+    # value stays the env's — the UI disables the control and shows the pin.
+    r = c.put("/api/settings/compute-device", json={"value": "auto"})
+    assert r.status_code == 200
+    assert r.json()["value"] == "cpu"

--- a/tests/fixtures/api_routes.txt
+++ b/tests/fixtures/api_routes.txt
@@ -26,6 +26,7 @@ GET /api/mcp/bindings
 GET /api/settings/analytics
 GET /api/settings/asr-openai-compat
 GET /api/settings/changelog
+GET /api/settings/compute-device
 GET /api/settings/db-backup
 GET /api/settings/dictation-refinement
 GET /api/settings/hf-mirror
@@ -269,6 +270,7 @@ POST /workers/{worker_id}/resume
 PUT /api/mcp/bindings
 PUT /api/settings/analytics
 PUT /api/settings/asr-openai-compat
+PUT /api/settings/compute-device
 PUT /api/settings/dictation-refinement
 PUT /api/settings/hf-mirror
 PUT /api/settings/history-retention

--- a/tests/test_asr_device_aware_autodetect.py
+++ b/tests/test_asr_device_aware_autodetect.py
@@ -436,6 +436,15 @@ def test_real_cuda_is_untouched_by_the_rocm_branch(monkeypatch):
 
 def test_ctranslate2_never_gets_cuda_on_a_rocm_build(monkeypatch):
     """The crash itself: whisperx's device pick must refuse HIP-flavoured cuda."""
+    from core.device_caps import HostCaps
+
+    # The compute-device override gate consults the probe FIRST; pin it to a
+    # CUDA family so this test keeps exercising the ROCm-specific refusal
+    # (on a cpu-family CI host the gate would short-circuit before it).
+    monkeypatch.setattr(
+        "core.device_caps.detect_host_caps",
+        lambda: HostCaps(family="cuda", available_families=("cuda", "cpu")),
+    )
     monkeypatch.setattr(ab, "_rocm_torch", lambda: True)
     monkeypatch.setattr(ab, "_cuda_reported_available", lambda: True)
     assert ab._ctranslate2_cuda_ok() is False
@@ -444,3 +453,15 @@ def test_ctranslate2_never_gets_cuda_on_a_rocm_build(monkeypatch):
     monkeypatch.setattr(ab, "_rocm_torch", lambda: False)
     assert ab._ctranslate2_cuda_ok() is True
     assert ab.WhisperXBackend._pick_device() == ("cuda", "float16")
+
+
+def test_ctranslate2_gate_fails_safe_when_the_probe_breaks(monkeypatch):
+    """A broken capability probe must mean CPU, never a torch-derived guess —
+    guessing would bypass a cpu override and re-open #1529 on ROCm."""
+    def _boom():
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr("core.device_caps.detect_host_caps", _boom)
+    monkeypatch.setattr(ab, "_cuda_reported_available", lambda: True)
+    monkeypatch.setattr(ab, "_rocm_torch", lambda: False)
+    assert ab._ctranslate2_cuda_ok() is False

--- a/tests/test_device_override.py
+++ b/tests/test_device_override.py
@@ -45,6 +45,12 @@ def _probe_with(modules):
 
 def _cleanup():
     # Leave the process-wide cache in its no-override state for other tests.
+    # The env var must go FIRST: this runs inside the test (before
+    # monkeypatch teardown), so a refresh with OMNIVOICE_DEVICE still set
+    # would cache the overridden caps for every later test in the session.
+    import os
+
+    os.environ.pop("OMNIVOICE_DEVICE", None)
     device_caps.refresh()
 
 

--- a/tests/test_device_override.py
+++ b/tests/test_device_override.py
@@ -1,0 +1,141 @@
+"""The user compute-device override (Settings → Performance / OMNIVOICE_DEVICE).
+
+The override is applied at the single choke point — `_probe()`'s family
+selection — so routing, `get_best_device()`, and every UI badge inherit it.
+Contract pinned here: an override steers, it cannot invent hardware (a family
+this host lacks is noted and ignored); "cpu" is always honorable; env beats
+the persisted Settings pick; unknown values normalize to "auto"; and the
+running process reports what it actually applied (`requested_family`) so the
+Settings panel can show restart-required truthfully.
+"""
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+from core import device_caps
+
+
+def _torch_mock(*, cuda_available=False, mps_available=False):
+    """Minimal torch mock — just enough accelerator shape for the override
+    tests (test_device_caps.py owns the full degradation matrix)."""
+    cuda = types.SimpleNamespace(
+        is_available=lambda: cuda_available,
+        device_count=lambda: 1,
+        get_device_name=lambda i: "NVIDIA RTX 4090",
+        mem_get_info=lambda: (12 * 1024**3, 24 * 1024**3),
+        get_device_capability=lambda i: (8, 9),
+        _get_arch_list=lambda: [],
+    )
+    backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: mps_available)
+    )
+    xpu = types.SimpleNamespace(
+        is_available=lambda: False, get_device_name=lambda i: ""
+    )
+    return types.SimpleNamespace(
+        cuda=cuda, version=types.SimpleNamespace(), backends=backends, xpu=xpu
+    )
+
+
+def _probe_with(modules):
+    with patch.dict("sys.modules", modules):
+        return device_caps.refresh()
+
+
+def _cleanup():
+    # Leave the process-wide cache in its no-override state for other tests.
+    device_caps.refresh()
+
+
+def test_no_override_is_auto_and_keeps_priority_pick(monkeypatch):
+    monkeypatch.delenv("OMNIVOICE_DEVICE", raising=False)
+    monkeypatch.setattr("core.prefs.resolve", lambda key, **kw: kw.get("default"))
+    try:
+        caps = _probe_with({"torch": _torch_mock(cuda_available=True, mps_available=True)})
+        assert caps.family == "cuda"
+        assert caps.requested_family == "auto"
+    finally:
+        _cleanup()
+
+
+def test_cpu_override_forces_cpu_on_an_accelerated_host(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_DEVICE", "cpu")
+    try:
+        caps = _probe_with({"torch": _torch_mock(cuda_available=True)})
+        assert caps.family == "cpu"
+        assert caps.requested_family == "cpu"
+        # The pin is explained, not silent — a CUDA host showing CPU chips
+        # without a note reads as a broken install.
+        assert any("pinned" in n for n in caps.notes)
+    finally:
+        _cleanup()
+
+
+def test_override_for_a_missing_family_is_noted_and_ignored(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_DEVICE", "cuda")
+    try:
+        caps = _probe_with({"torch": _torch_mock(mps_available=True)})
+        assert caps.family == "mps"  # auto pick survives
+        assert caps.requested_family == "cuda"
+        assert any("not available" in n for n in caps.notes)
+    finally:
+        _cleanup()
+
+
+def test_override_matching_the_auto_pick_adds_no_note(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_DEVICE", "cuda")
+    try:
+        caps = _probe_with({"torch": _torch_mock(cuda_available=True)})
+        assert caps.family == "cuda"
+        assert not any("pinned" in n for n in caps.notes)
+    finally:
+        _cleanup()
+
+
+def test_env_beats_the_persisted_settings_pick(monkeypatch, tmp_path):
+    # Same resolution order as engine selection (#981): a power-user's env
+    # pin must not be silently undone by the UI's stored choice.
+    from core import prefs
+
+    monkeypatch.setattr(prefs, "_PREFS_PATH", tmp_path / "prefs.json")
+    prefs.set_("compute_device", "cuda")
+    try:
+        monkeypatch.setenv("OMNIVOICE_DEVICE", "cpu")
+        assert device_caps.requested_device_override() == "cpu"
+        monkeypatch.delenv("OMNIVOICE_DEVICE")
+        assert device_caps.requested_device_override() == "cuda"
+    finally:
+        _cleanup()
+
+
+def test_unknown_values_normalize_to_auto(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_DEVICE", "quantum")
+    try:
+        assert device_caps.requested_device_override() == "auto"
+    finally:
+        _cleanup()
+
+
+def test_torch_unimportable_still_reports_the_request(monkeypatch):
+    # Even a degraded CPU-only probe carries the requested family so the
+    # Settings panel renders the user's pick instead of resetting to auto.
+    monkeypatch.setenv("OMNIVOICE_DEVICE", "cpu")
+    real_import = __import__
+
+    def _no_torch(name, *a, **kw):
+        if name == "torch":
+            raise ImportError("no torch here")
+        return real_import(name, *a, **kw)
+
+    try:
+        with patch.dict("sys.modules"):
+            import sys
+
+            sys.modules.pop("torch", None)
+            with patch("builtins.__import__", side_effect=_no_torch):
+                caps = device_caps.refresh()
+        assert caps.probe_ok is False
+        assert caps.requested_family == "cpu"
+    finally:
+        _cleanup()


### PR DESCRIPTION
Task 4 of the unsloth teardown: an explicit device override ends the "auto-detect picked wrong" issue class.

- **One choke point**: the override is applied inside `_probe()`'s family selection, so `resolve_routing`, `get_best_device()` (which delegates its family decision to the probe), and every Model Catalogue badge inherit it with zero per-consumer changes.
- **Resolution** `OMNIVOICE_DEVICE` > Settings pick > auto — the engine-selection (#981) pattern. The env pin disables the UI control and says so.
- **Safety**: only detected families are selectable (UI + 400 from the API); CPU is always honorable; an honored pin and an ignored request both leave a note in `HostCaps.notes` so diagnostics explain why a CUDA host shows CPU chips.
- **Restart contract**: caps are immutable per process; the endpoint reports `applied` vs `value` so restart-required is shown truthfully (Performance tab is already `restart: true`).
- Parity: identical behavior on all 3 OSes; options varying by host hardware is the sanctioned performance/hardware variance.

Tests: 7 probe-contract tests (steer-not-invent, env-beats-prefs, degraded-probe), 4 API tests (validation, env pin, restart flag), 4 panel tests (families-only options, PUT + restart note, env-pin disable, failed-PUT re-sync), restart-badge lockstep updated. 121 backend device/routing/prefs tests + 241 settings-component tests green. Docs: performance.md knob row + engines-index pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds compute-device override support for Auto, CUDA, ROCm, XPU, MPS, and CPU through settings or `OMNIVOICE_DEVICE`, with API and UI state reporting, detection filtering, persistence, localization, and documentation. The selected family now controls routing, `get_best_device()`, Model Catalogue badges, CTranslate2 ASR, and the ASR sidecar, with changes applied after restart. Review fail-safe CPU behavior for broken probes and environment-variable precedence, because unavailable or pinned requests are ignored, reported, and recorded in `HostCaps.notes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->