### PR TITLE
fix(ci): allowlist Ed25519 type-name false positive

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,4 +25,6 @@ regexes = [
   '''^hf_QWERTYUIOPasdfghjklZXCVBNM0123456789xyzAB$''',
   # NLLB generation length argument, not the value of a credential.
   '''^max_length=400$''',
+  # cryptography's Ed25519 private-key type name, not key material.
+  '''^Ed25519PrivateKey$''',
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ the frozen-backend fallback mirror it for their toolchains.
 - "Ready" now requires the deep health probe (a working database-backed route), not just the identity probe — a backend whose install broke underneath can no longer be announced up while every real request fails (#1548)
 - Supervisor restarts after repeat crashes now back off (immediate, then 5s, then 15s) instead of respawning back-to-back, so a tight crash loop can't burn the whole restart budget in seconds (#1548)
 
+### CI
+- Weekly full-history secret scans no longer mistake the Ed25519 private-key type name for committed key material (#1591)
+
 ## [0.5.0] — 2026-08-13
 
 **Highlights**

--- a/tests/test_gitleaks_allowlist.py
+++ b/tests/test_gitleaks_allowlist.py
@@ -17,6 +17,7 @@ EXPECTED_EXACT_REGEXES = {
     "^hf_abcdefghijklmnopqrstuvwxyz0123456789ABCDEF$",
     "^hf_QWERTYUIOPasdfghjklZXCVBNM0123456789xyzAB$",
     "^max_length=400$",
+    "^Ed25519PrivateKey$",
 }
 
 


### PR DESCRIPTION
## Summary

Restore the weekly full-history Security scan after gitleaks 8.30.1 classified the cryptography type name Ed25519PrivateKey as a generic API key in historical commit 43de1c79.

Failed run: https://github.com/debpalash/VoiceStudio/actions/runs/32000724831

## Changes

- Allowlist only the exact non-secret value Ed25519PrivateKey.
- Extend the exact-value allowlist guard so broader path, rule, or regex exemptions remain forbidden.

## Type

- [x] 🔧 CI / Build

## Testing

- gitleaks 8.30.1 full-history scan: 1,414 commits scanned, no leaks found.
- Exact-value allowlist regression function passed under Python 3.11.
- git diff --check passed.

## Checklist

- [x] I have tested this locally
- [x] Documentation is not affected
- [x] No local machine paths, logs, or personal env details in this PR
- [x] No version bump
- [x] Runtime behavior is unchanged

## Release cadence

Continuous-to-main; no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The security scan now allowlists only the exact non-secret value `Ed25519PrivateKey`, preventing gitleaks 8.30.1 from flagging historical commits. This restores the weekly full-history scan and updates the regression test and changelog. The exact-value guard limits exemptions to the intended value, with no known merge risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->