### PR TITLE
docs(docker): refresh Docker Hub overview for v0.5 authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Settings → Performance & Device gains a compute-device override (Auto / CUDA / ROCm / XPU / MPS / CPU, or `OMNIVOICE_DEVICE`) — pin the device when auto-detect picks wrong; only devices your machine actually has are offered (#1557)
 
 ### Docs
+- The Docker Hub overview and install guide now show the v0.5 tags and the built-in API-key/share-PIN security model instead of obsolete v0.4 and no-authentication guidance (#1592)
 - The READMEs now lead with download buttons and a three-step first-clone walkthrough, and a new benchmarks page anchors measured per-engine/per-device numbers on the in-repo harness (#1555)
 - Every engine now has its own guide — 21 new pages under docs/engines plus an index covering all 16 TTS and 11 ASR engines, linked from both READMEs (#1556)
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -1,7 +1,7 @@
 # VoiceStudio
 
 **The open-source ElevenLabs alternative.** Real-time dictation, zero-shot voice
-cloning, and cinematic video dubbing — fully local, no API keys, no accounts.
+cloning, and cinematic video dubbing — fully local, with no cloud API keys or accounts.
 **646 languages.**
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/palashdeb/omnivoice-studio?logo=docker&color=2496ED)](https://hub.docker.com/r/palashdeb/omnivoice-studio)
@@ -90,12 +90,12 @@ There's also a Compose file in the repo with `cpu` / `gpu` / `rocm` profiles
 |-----|--------------|
 | `:latest` | **Rolling preview** — latest commit on `main`, at or ahead of the last release. This is the preview channel; pin `:stable` for production. |
 | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-| `:0.4.1` | Exact release version |
-| `:0.4` | Latest patch within the `0.4` minor |
+| `:0.5.0` | Exact release version |
+| `:0.5` | Latest patch within the `0.5` minor |
 | `:main` | Alias of the same rolling `main` build as `:latest` |
 | `:sha-xxxxxxx` | A specific commit (produced by manual workflow dispatch) |
 | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
-| `:stable-rocm`, `:0.4.1-rocm`, `:0.4-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
+| `:stable-rocm`, `:0.5.0-rocm`, `:0.5-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
 
 Preview builds always come from `main` and never version-sort below `:stable`,
 so upgrades flow naturally. The same images and tags
@@ -143,11 +143,15 @@ more), auto-detected and selectable in Settings.
 - The image ships with `OMNIVOICE_SERVER_MODE=1`, which relaxes the desktop-only
   loopback-origin gate so the admin UI works through Docker's NAT. Set it to `0`
   if you front the container with your own loopback auth proxy.
+- For LAN or internet-facing deployments, set a long random
+  `OMNIVOICE_API_KEY` and pass the same key through the browser's login prompt.
+  A six-digit share PIN is also available for casual LAN access, but it does
+  not authorize administration or dictation; see the
+  [API authentication guide](https://github.com/debpalash/VoiceStudio/blob/main/docs/api-auth.md).
 
-> **Security:** VoiceStudio ships **no authentication**. Anything that can reach the
-> URL can use the app. Before exposing it beyond localhost, put it behind a
-> reverse proxy with auth (Caddy `basic_auth`, nginx + htpasswd) or a private
-> overlay (Tailscale, ZeroTier).
+> **Security:** Loopback-only publishing is the safe default. Before exposing
+> VoiceStudio beyond localhost, configure `OMNIVOICE_API_KEY`; for public access,
+> also use a TLS reverse proxy or private overlay such as Tailscale/ZeroTier.
 
 ---
 

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -150,8 +150,10 @@ more), auto-detected and selectable in Settings.
   [API authentication guide](https://github.com/debpalash/VoiceStudio/blob/main/docs/api-auth.md).
 
 > **Security:** Loopback-only publishing is the safe default. Before exposing
-> VoiceStudio beyond localhost, configure `OMNIVOICE_API_KEY`; for public access,
-> also use a TLS reverse proxy or private overlay such as Tailscale/ZeroTier.
+> VoiceStudio on a trusted LAN, configure `OMNIVOICE_API_KEY`. On any untrusted
+> network, plain HTTP is not safe for the API key or session cookie: TLS through
+> a reverse proxy or an encrypted private overlay such as Tailscale/ZeroTier is
+> required.
 
 ---
 

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -151,9 +151,9 @@ more), auto-detected and selectable in Settings.
 
 > **Security:** Loopback-only publishing is the safe default. Before exposing
 > VoiceStudio on a trusted LAN, configure `OMNIVOICE_API_KEY`. On any untrusted
-> network, plain HTTP is not safe for the API key or session cookie: TLS through
-> a reverse proxy or an encrypted private overlay such as Tailscale/ZeroTier is
-> required.
+> network, plain HTTP is not safe for the API key or session cookie. Keep the
+> backend on an encrypted private overlay such as Tailscale/ZeroTier; do not
+> expose it directly to the public internet.
 
 ---
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -13,12 +13,12 @@ and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palash
 > |-----|--------------|
 > | `:latest` | **Rolling preview** — latest commit on `main`, at or ahead of the last release. This is the preview channel; pin `:stable` for production. |
 > | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-> | `:0.4.1` | Exact release version |
-> | `:0.4` | Latest patch within the 0.4 minor |
+> | `:0.5.0` | Exact release version |
+> | `:0.5` | Latest patch within the 0.5 minor |
 > | `:main` | Alias of the same rolling `main` build as `:latest` |
 > | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |
 > | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
-> | `:stable-rocm`, `:0.4.1-rocm`, `:0.4-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
+> | `:stable-rocm`, `:0.5.0-rocm`, `:0.5-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
 >
 > Versioning rule: preview builds always come from `main` and never
 > version-sort below `:stable` — upgrades flow naturally.
@@ -89,7 +89,7 @@ PublishPort=127.0.0.1:3900:3900
 Volume=omnivoice-data:/app/omnivoice_data
 ```
 
-Release pins exist too: `:stable-rocm`, `:0.4.1-rocm`, `:0.4-rocm` mirror
+Release pins exist too: `:stable-rocm`, `:0.5.0-rocm`, `:0.5-rocm` mirror
 the CUDA tags exactly.
 
 > **Consumer cards and APUs (RX 6000/7000, Strix Point/Halo):** the backend
@@ -192,10 +192,12 @@ docker run -e OMNIVOICE_PUBLIC_API_BASE=https://api.your-host.example \
 > may instead bake `VITE_OMNIVOICE_API` at build time, but the runtime var above
 > is simpler and image-agnostic.
 
-> **Security:** VoiceStudio ships no authentication. Anything on your LAN with
-> the URL can use the app. Put it behind a reverse proxy with `basic_auth`
-> (Caddy / nginx + htpasswd) or a private network overlay (Tailscale, ZeroTier)
-> before exposing publicly.
+> **Security:** Loopback-only publishing is the safe default. For LAN or remote
+> access, set a long random `OMNIVOICE_API_KEY` with `docker run -e` or Compose;
+> the browser will prompt for it. The optional six-digit share PIN permits
+> casual consumption access but does not authorize administration or dictation.
+> For public access, also use a TLS reverse proxy or private network overlay.
+> See [API authentication](../api-auth.md) for the complete access model.
 
 ## Volume mounts
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -196,9 +196,10 @@ docker run -e OMNIVOICE_PUBLIC_API_BASE=https://api.your-host.example \
 > set a long random `OMNIVOICE_API_KEY` with `docker run -e` or Compose; the
 > browser will prompt for it. The optional six-digit share PIN permits casual
 > consumption access but does not authorize administration or dictation. On any
-> untrusted network, plain HTTP is not safe for the API key or session cookie:
-> TLS through a reverse proxy or an encrypted private overlay is required. See
-> [API authentication](../api-auth.md) for the complete access model.
+> untrusted network, plain HTTP is not safe for the API key or session cookie.
+> Keep the backend on an encrypted private overlay such as Tailscale/ZeroTier;
+> do not expose it directly to the public internet. See [API
+> authentication](../api-auth.md) for the complete access model.
 
 ## Volume mounts
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -192,12 +192,13 @@ docker run -e OMNIVOICE_PUBLIC_API_BASE=https://api.your-host.example \
 > may instead bake `VITE_OMNIVOICE_API` at build time, but the runtime var above
 > is simpler and image-agnostic.
 
-> **Security:** Loopback-only publishing is the safe default. For LAN or remote
-> access, set a long random `OMNIVOICE_API_KEY` with `docker run -e` or Compose;
-> the browser will prompt for it. The optional six-digit share PIN permits
-> casual consumption access but does not authorize administration or dictation.
-> For public access, also use a TLS reverse proxy or private network overlay.
-> See [API authentication](../api-auth.md) for the complete access model.
+> **Security:** Loopback-only publishing is the safe default. On a trusted LAN,
+> set a long random `OMNIVOICE_API_KEY` with `docker run -e` or Compose; the
+> browser will prompt for it. The optional six-digit share PIN permits casual
+> consumption access but does not authorize administration or dictation. On any
+> untrusted network, plain HTTP is not safe for the API key or session cookie:
+> TLS through a reverse proxy or an encrypted private overlay is required. See
+> [API authentication](../api-auth.md) for the complete access model.
 
 ## Volume mounts
 


### PR DESCRIPTION
## Summary
- update Docker Hub tag examples from v0.4.1 to v0.5.0
- replace the obsolete no-authentication warning with the current API-key/share-PIN model
- keep the canonical Docker guide in sync

## Testing
- `git diff --check`
- stale v0.4.1 and no-authentication claims absent from both documents

## Release cadence
Documentation-only correction for the current v0.5.0 release; no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated Docker documentation for v0.5.0 with current image tags and API-key/share-PIN security guidance. This removes obsolete v0.4.1 and no-authentication instructions. Human review should verify that the security model and access recommendations match the current implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->