### PR TITLE
docs(docker): add product media to Docker Hub overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Settings → Performance & Device gains a compute-device override (Auto / CUDA / ROCm / XPU / MPS / CPU, or `OMNIVOICE_DEVICE`) — pin the device when auto-detect picks wrong; only devices your machine actually has are offered (#1557)
 
 ### Docs
+- The Docker Hub overview now shows the current engine-switching demo, Model Catalogue, and gallery voice workflow (#1593)
 - The Docker Hub overview and install guide now show the v0.5 tags and the built-in API-key/share-PIN security model instead of obsolete v0.4 and no-authentication guidance (#1592)
 - The READMEs now lead with download buttons and a three-step first-clone walkthrough, and a new benchmarks page anchors measured per-engine/per-device numbers on the in-repo harness (#1555)
 - Every engine now has its own guide — 21 new pages under docs/engines plus an index covering all 16 TTS and 11 ASR engines, linked from both READMEs (#1556)

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -30,6 +30,14 @@ weights + cache (20 GB+ comfortable), and optionally a GPU — 4 GB VRAM works
 the entire pipeline runs on CPU, just slower. Pull size: ~5 GB compressed
 (CUDA/CPU image), ~15 GB for the `:rocm` variant.
 
+## See it in action
+
+![Switching TTS engines from the VoiceStudio status bar](https://raw.githubusercontent.com/debpalash/VoiceStudio/main/docs/media/0.5.0/quick-switch.gif)
+
+| Model catalogue | Save a gallery voice |
+|---|---|
+| ![VoiceStudio Model Catalogue](https://raw.githubusercontent.com/debpalash/VoiceStudio/main/docs/media/0.5.0/catalogue.png) | ![Saving a gallery voice as a local profile](https://raw.githubusercontent.com/debpalash/VoiceStudio/main/docs/media/0.5.0/gallery-save.png) |
+
 ---
 
 ## Quick start (CPU)


### PR DESCRIPTION
## Summary
- add the current v0.5 engine-switching GIF to the Docker Hub overview
- add the Model Catalogue and gallery-save screenshots
- use absolute raw GitHub URLs so Docker Hub can render the media

## Testing
- `git diff --check`
- media URLs point to committed assets on `main`

## Release cadence
Documentation-only Docker Hub presentation update; no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds Docker Hub media for the v0.5 engine-switching demo, Model Catalogue, and gallery voice-saving workflow. The media improves product visibility in the Docker Hub overview. No code or version changes are included; reviewers should confirm that the absolute raw GitHub URLs remain valid for Docker Hub rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->