### PR TITLE
chore(agents): install project development skills

### DIFF
--- a/.agents/skills/fastapi-python/SKILL.md
+++ b/.agents/skills/fastapi-python/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: fastapi-python
+description: Expert in FastAPI Python development with best practices for APIs and async operations
+---
+
+# FastAPI Python
+
+You are an expert in FastAPI and Python backend development.
+
+## Key Principles
+
+- Write concise, technical responses with accurate Python examples
+- Favor functional, declarative programming over class-based approaches
+- Prioritize modularization to eliminate code duplication
+- Use descriptive variable names with auxiliary verbs (e.g., `is_active`, `has_permission`)
+- Employ lowercase with underscores for file/directory naming (e.g., `routers/user_routes.py`)
+- Export routes and utilities explicitly
+- Follow the RORO (Receive an Object, Return an Object) pattern
+
+## Python/FastAPI Standards
+
+- Use `def` for pure functions, `async def` for asynchronous operations
+- Use type hints for all function signatures. Prefer Pydantic models over raw dictionaries
+- Structure: exported router, sub-routes, utilities, static content, types (models, schemas)
+- Use ordinary Python control flow; prefer readability over compressed one-line conditionals
+
+## Error Handling
+
+- Handle edge cases at function entry points
+- Employ early returns for error conditions
+- Place happy path logic last
+- Avoid unnecessary else statements; use if-return patterns
+- Implement guard clauses for preconditions
+- Provide proper error logging and user-friendly messaging
+
+## FastAPI-Specific Guidelines
+
+- Use functional components (plain functions) and Pydantic models for input validation
+- Declare routes with clear return type annotations
+- Prefer lifespan context managers for managing startup and shutdown events
+- Leverage middleware for logging, error monitoring, and optimization
+- Use HTTPException for expected errors and model them as specific HTTP responses
+- Apply Pydantic's BaseModel consistently for validation
+
+## Performance Optimization
+
+- Minimize blocking I/O. In `async def` handlers, use awaitable database/API clients; put synchronous SQLite or other blocking work in synchronous routes or explicitly offload it
+- Implement caching with Redis or in-memory stores
+- Optimize Pydantic serialization/deserialization
+- Use lazy loading for large datasets
+
+## Key Conventions
+
+1. Rely on FastAPI's dependency injection system
+2. Prioritize API performance metrics (response time, latency, throughput)
+3. Structure routes and dependencies for readability and maintainability
+
+## Dependencies
+
+FastAPI, Pydantic v2, asyncpg/aiomysql, SQLAlchemy 2.0

--- a/.agents/skills/vite/SKILL.md
+++ b/.agents/skills/vite/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: vite
+description: Expert guidance for Vite development with modern build tooling, HMR, framework integrations, and performance optimization
+---
+
+# Vite Development
+
+You are an expert in Vite, modern JavaScript/TypeScript build tooling, and frontend development.
+
+## Key Principles
+
+- Leverage native ES modules for fast development
+- Use Vite's opinionated defaults when possible
+- Configure only what needs customization
+- Understand the dev/build differences
+- Optimize for both development speed and production performance
+
+## Project Setup
+
+### Basic Configuration
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    open: true,
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});
+```
+
+### Path Aliases
+```typescript
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname,
+      '@components': new URL('./src/components', import.meta.url).pathname,
+      '@utils': new URL('./src/utils', import.meta.url).pathname,
+    },
+  },
+});
+```
+
+## Environment Variables
+
+### Usage
+```typescript
+// .env
+VITE_API_URL=https://api.example.com
+VITE_APP_TITLE=My App
+
+// In code
+const apiUrl = import.meta.env.VITE_API_URL;
+const isDev = import.meta.env.DEV;
+const isProd = import.meta.env.PROD;
+const mode = import.meta.env.MODE;
+```
+
+### Type Definitions
+```typescript
+// src/vite-env.d.ts
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_APP_TITLE: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+```
+
+## Hot Module Replacement
+
+### Manual HMR
+```typescript
+// For libraries without HMR support
+if (import.meta.hot) {
+  import.meta.hot.accept('./module.ts', (newModule) => {
+    // Handle the updated module
+    console.log('Module updated:', newModule);
+  });
+
+  import.meta.hot.dispose(() => {
+    // Cleanup before module is replaced
+  });
+}
+```
+
+## Asset Handling
+
+### Static Assets
+```typescript
+// Import as URL
+import imageUrl from './image.png';
+// <img src={imageUrl} />
+
+// Import as string (raw)
+import shaderCode from './shader.glsl?raw';
+
+// Import as worker
+import Worker from './worker.ts?worker';
+const worker = new Worker();
+```
+
+### Public Directory
+```
+public/
+├── favicon.ico      # Served at /favicon.ico
+├── robots.txt       # Served at /robots.txt
+└── images/          # Served at /images/
+```
+
+## Framework Integrations
+
+### React
+```typescript
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    react({
+      // Babel plugins
+      babel: {
+        plugins: ['@emotion/babel-plugin'],
+      },
+    }),
+  ],
+});
+```
+
+### Vue
+```typescript
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});
+```
+
+### Svelte
+```typescript
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+});
+```
+
+## Build Optimization
+
+### Code Splitting
+```typescript
+// Dynamic imports create separate chunks
+const AdminPanel = lazy(() => import('./AdminPanel'));
+
+// Manual chunks
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+          utils: ['lodash', 'date-fns'],
+        },
+      },
+    },
+  },
+});
+```
+
+### Chunk Size Optimization
+```typescript
+export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 500,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            return id.split('node_modules/')[1].split('/')[0];
+          }
+        },
+      },
+    },
+  },
+});
+```
+
+## CSS Handling
+
+### CSS Modules
+```typescript
+// styles.module.css is auto-detected
+import styles from './styles.module.css';
+
+// <div className={styles.container}>
+```
+
+### PostCSS
+```javascript
+// postcss.config.js
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
+### Preprocessors
+```typescript
+// Automatically handled with package installed
+// npm install -D sass
+import './styles.scss';
+```
+
+## Proxy Configuration
+
+```typescript
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+      '/socket.io': {
+        target: 'ws://localhost:4000',
+        ws: true,
+      },
+    },
+  },
+});
+```
+
+## Plugin Development
+
+```typescript
+// my-vite-plugin.ts
+import type { Plugin } from 'vite';
+
+export function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+
+    // Hook: modify config
+    config(config, { mode }) {
+      return {
+        define: {
+          __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+        },
+      };
+    },
+
+    // Hook: transform code
+    transform(code, id) {
+      if (id.endsWith('.md')) {
+        return {
+          code: `export default ${JSON.stringify(code)}`,
+          map: null,
+        };
+      }
+    },
+
+    // Hook: configure dev server
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        // Custom middleware
+        next();
+      });
+    },
+  };
+}
+```
+
+## Testing with Vitest
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});
+```
+
+## SSR Configuration
+
+```typescript
+export default defineConfig({
+  build: {
+    ssr: true,
+    rollupOptions: {
+      input: './src/entry-server.ts',
+    },
+  },
+  ssr: {
+    external: ['express'],
+    noExternal: ['my-ui-library'],
+  },
+});
+```
+
+## Library Mode
+
+```typescript
+export default defineConfig({
+  build: {
+    lib: {
+      entry: './src/index.ts',
+      name: 'MyLib',
+      fileName: (format) => `my-lib.${format}.js`,
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
+    },
+  },
+});
+```
+
+## Best Practices
+
+- Use `vite preview` to test production builds locally
+- Keep dependencies that support ESM in regular deps
+- Use `optimizeDeps.include` for CommonJS dependencies
+- Enable `build.sourcemap` for debugging production
+- Use `server.warmup` for faster dev server starts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ Binding for every AI agent (Claude, Codex, Cursor, review bots, …). CLAUDE.md 
 
 ## Agent skills
 
+Project development skills are pinned in `skills-lock.json` and installed under
+`.agents/skills/`: Vite and FastAPI.
+Repository rules and tracker mappings override generic skill guidance.
+
 ### Issue tracker
 
 GitHub Issues on `debpalash/VoiceStudio`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Supervisor restarts after repeat crashes now back off (immediate, then 5s, then 15s) instead of respawning back-to-back, so a tight crash loop can't burn the whole restart budget in seconds (#1548)
 
 ### CI
+- Project agents now share pinned Vite and FastAPI skills from skills.sh (#1594)
 - Weekly full-history secret scans no longer mistake the Ed25519 private-key type name for committed key material (#1591)
 
 ## [0.5.0] — 2026-08-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,10 @@ Architecture not yet mapped. Follow existing patterns found in the codebase.
 <!-- GSD:skills-start source:skills/ -->
 ## Project Skills
 
-No project skills found. Add skills to any of: `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.github/skills/`, or `.codex/skills/` with a `SKILL.md` index file.
+- `vite` — Vite configuration, assets, HMR, builds, and Vitest guidance.
+- `fastapi-python` — FastAPI and Pydantic implementation patterns.
+
+Canonical copies live under `.agents/skills/`; `skills-lock.json` pins their sources and hashes. Claude should follow these paths directly, avoiding cross-platform symlinks.
 <!-- GSD:skills-end -->
 
 <!-- GSD:workflow-start source:GSD defaults -->

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "skills": {
+    "fastapi-python": {
+      "source": "mindrally/skills",
+      "sourceType": "github",
+      "skillPath": "fastapi-python/SKILL.md",
+      "computedHash": "cd9c84b3bf2e4cf55f4a3f97b102d3affad2682680eb3d8ec8d2f68020ba5c8d"
+    },
+    "vite": {
+      "source": "mindrally/skills",
+      "sourceType": "github",
+      "skillPath": "vite/SKILL.md",
+      "computedHash": "8995600ea3cf7c18208105011f65b9098a547a19dff446fb774e42ac726d36b1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- install two audited, project-scoped skills: Vite and FastAPI
- pin their upstream sources and reviewed content hashes in `skills-lock.json`
- document repository-rule precedence and use cross-platform canonical `.agents/skills` paths

## Changes
- rejected Playwright after secret scanning found credential-shaped examples
- rejected Tauri after its installer reported critical risk
- rejected broad React/triage/TDD bundles after review found unsafe or compile-broken guidance
- corrected Vite ESM alias, React plugin, and Vitest examples plus FastAPI async/blocking guidance

## Testing
- skill-creator validation passes for both skills
- gitleaks pattern audit clean
- `git diff --check`

## Type
- agent development tooling only; no runtime behavior or dependencies change

## Checklist
- [x] Upstream reputation and install counts reviewed
- [x] Skill contents reviewed
- [x] Cross-platform symlinks avoided
- [x] Changelog updated

## Release cadence
No application release required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds audited, hash-pinned Vite and FastAPI development skills under `.agents/skills/` and documents their installation and rule precedence. This gives project agents consistent guidance without changing runtime behavior, dependencies, or releases. Review the pinned upstream content and lock hashes for security and integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->