### PR TITLE
test(desktop): isolate cleanup script artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ the frozen-backend fallback mirror it for their toolchains.
 - The crash-isolated ASR sidecar and its download preflight now agree on which model to load — setting the shared faster-whisper model variable applies to both variants instead of the sidecar quietly using a different one (#1556)
 - "Ready" now requires the deep health probe (a working database-backed route), not just the identity probe — a backend whose install broke underneath can no longer be announced up while every real request fails (#1548)
 - Supervisor restarts after repeat crashes now back off (immediate, then 5s, then 15s) instead of respawning back-to-back, so a tight crash loop can't burn the whole restart budget in seconds (#1548)
+- The Linux desktop cleanup regression test now isolates build artifacts, so an existing developer build can no longer change its result (#1566)
 
 ### CI
-- The Linux desktop cleanup regression test now isolates build artifacts, so an existing developer build can no longer change its result (#1566)
 - Weekly full-history secret scans no longer mistake the Ed25519 private-key type name for committed key material (#1591)
 
 ## [0.5.0] — 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Supervisor restarts after repeat crashes now back off (immediate, then 5s, then 15s) instead of respawning back-to-back, so a tight crash loop can't burn the whole restart budget in seconds (#1548)
 
 ### CI
+- The Linux desktop cleanup regression test now isolates build artifacts, so an existing developer build can no longer change its result (#1566)
 - Weekly full-history secret scans no longer mistake the Ed25519 private-key type name for committed key material (#1591)
 
 ## [0.5.0] — 2026-08-13

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -33,6 +33,37 @@ _APPIMAGE_PROCESSES = os.path.join(_ROOT, "scripts", "desktop_prod_processes.py"
 _RELAUNCH_SCRIPTS = ("desktop-prod:run", "desktop-prod:run:pill")
 
 
+def _supported_bash() -> str | None:
+    """Return a native shell capable of executing desktop-prod.sh."""
+    if os.name == "nt":
+        roots = filter(
+            None,
+            (
+                os.environ.get("ProgramFiles"),
+                os.environ.get("ProgramFiles(x86)"),
+                os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs"),
+            ),
+        )
+        for root in roots:
+            for relative in (("Git", "bin", "bash.exe"), ("Git", "usr", "bin", "bash.exe")):
+                candidate = os.path.join(root, *relative)
+                if os.path.isfile(candidate):
+                    return candidate
+
+    candidate = shutil.which("bash")
+    if candidate and not (os.name == "nt" and "\\system32\\" in candidate.lower()):
+        return candidate
+    return None
+
+
+def test_desktop_prod_execution_does_not_require_posix_bin_bash():
+    """The smoke seam must also collect on native Windows runners."""
+    with open(__file__, encoding="utf-8") as fh:
+        source = fh.read()
+    posix_only_invocation = '["' + "/bin/" + 'bash", fixture_script'
+    assert posix_only_invocation not in source
+
+
 def _scripts() -> dict:
     with open(_PKG, encoding="utf-8") as fh:
         return json.load(fh)["scripts"]
@@ -262,8 +293,11 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
             "PATH": f"{fake_bin}:/usr/bin:/bin",
         }
     )
+    bash = _supported_bash()
+    if bash is None:
+        pytest.skip("desktop-prod.sh smoke requires Bash (for example Git Bash on Windows)")
     result = subprocess.run(
-        ["/bin/bash", fixture_script, "--skip-build"],  # noqa: S603
+        [bash, fixture_script, "--skip-build"],  # noqa: S603
         cwd=fixture_root,
         env=env,
         capture_output=True,

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -18,8 +18,8 @@ to remember belongs in a test, not in anyone's head.
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
-import sys
 
 import pytest
 
@@ -211,9 +211,23 @@ def test_linux_extracted_appimage_and_backend_are_stopped_before_wipe(tmp_path):
     assert [pid for pid, _ in opened] == [101, 102, 201, 202, 203]
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="Linux AppImage process contract")
 def test_linux_process_stop_executes_before_data_wipe(tmp_path):
     """Execute the shell with controlled commands and record the true order."""
+    fixture_root = tmp_path / "repo"
+    fixture_scripts = fixture_root / "scripts"
+    fixture_scripts.mkdir(parents=True)
+    fixture_script = fixture_scripts / "desktop-prod.sh"
+    shutil.copy2(_SH, fixture_script)
+    shutil.copy2(
+        _APPIMAGE_PROCESSES,
+        fixture_scripts / "desktop_prod_processes.py",
+    )
+    # Let the AppImage lookup complete normally, then exercise the intended
+    # no-artifact launch failure without consulting this checkout's target/.
+    (fixture_root / "frontend/src-tauri/target/debug/bundle/appimage").mkdir(
+        parents=True
+    )
+
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     order_log = tmp_path / "order.log"
@@ -230,6 +244,9 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
         'printf "stop-before-wipe\\n" >> "$ORDER_LOG"\n'
     )
     fake_python.chmod(0o755)
+    fake_uname = fake_bin / "uname"
+    fake_uname.write_text("#!/bin/sh\nprintf 'Linux\\n'\n")
+    fake_uname.chmod(0o755)
     for command in ("pgrep", "lsof"):
         stub = fake_bin / command
         stub.write_text("#!/bin/sh\nexit 1\n")
@@ -246,8 +263,8 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
         }
     )
     result = subprocess.run(
-        ["/bin/bash", _SH, "--skip-build"],  # noqa: S603
-        cwd=_ROOT,
+        ["/bin/bash", fixture_script, "--skip-build"],  # noqa: S603
+        cwd=fixture_root,
         env=env,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

Makes the Linux desktop cleanup regression test independent of build artifacts already present in a developer checkout. Closes #1566.

## Changes

- Run `desktop-prod.sh --skip-build` from a temporary checkout fixture.
- Stub Linux platform detection so the public script seam runs on every CI host.
- Preserve the stop-before-wipe and no-artifact launch assertions.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests
- [x] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- `uv run pytest -q tests/test_desktop_prod_scripts.py tests/test_changelog_style.py` (17 passed)

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync (no version bump)
- [x] Runtime behavior is unchanged; the smoke fixture is unaffected

## Release cadence

VoiceStudio ships continuous-to-main; this test-only fix is ready for the rolling preview after review and green CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The regression test now runs `desktop-prod.sh --skip-build` from an isolated temporary checkout with stubbed Linux detection. This prevents developer build artifacts from affecting the stop-before-wipe and no-artifact launch assertions. The change adds no public API changes; 17 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->