### PR TITLE
fix(asr): accept omnivoice alias on ROCm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- `OMNIVOICE_ASR_BACKEND=omnivoice` now selects the PyTorch-native Whisper path, so the documented ROCm escape hatch no longer fails as an unknown engine (#1582) — thanks @patmansk!
 - Stored artifact subpaths now resolve after moving a data directory between Windows, macOS, Linux, and Docker, while traversal and symlink escapes remain blocked (#1559) — thanks @Eman-Yousaf!
 - A remote browser hitting an API-key-configured server's admin 403 now gets the API-key login form instead of endless console 403s, while desktop and PIN-only/no-key servers keep the plain loopback error so guests are never offered a login no key can satisfy (#1568) — thanks @paoloantinori!
 - The crash-isolated ASR sidecar and its download preflight now agree on which model to load — setting the shared faster-whisper model variable applies to both variants instead of the sidecar quietly using a different one (#1556)

--- a/backend/services/asr_backend.py
+++ b/backend/services/asr_backend.py
@@ -2564,7 +2564,10 @@ def _auto_detect() -> str:
 def active_backend_id() -> str:
     explicit = os.environ.get("OMNIVOICE_ASR_BACKEND")
     if explicit:
-        return explicit
+        # #1582's public spelling predates the registry name. Keep it as a
+        # compatibility alias for the PyTorch-native Whisper implementation
+        # that can use ROCm/HIP; every ASR consumer resolves through here.
+        return "pytorch-whisper" if explicit == "omnivoice" else explicit
     from core import prefs
     picked = prefs.get("asr_backend")
     if picked:

--- a/docs/engines/pytorch-whisper.md
+++ b/docs/engines/pytorch-whisper.md
@@ -11,6 +11,8 @@ genuinely uses **AMD ROCm** GPUs, so auto-detect picks it on ROCm hosts
 
 - **Model Catalogue → Engines**, ASR tab → **Use** on the PyTorch Whisper
   row, or `OMNIVOICE_ASR_BACKEND=pytorch-whisper`.
+- `OMNIVOICE_ASR_BACKEND=omnivoice` is accepted as a compatibility alias and
+  selects this same PyTorch-native ASR path on ROCm hosts.
 - Auto-detect picks it on ROCm, and as the last resort everywhere else.
 
 ## Best at

--- a/tests/test_asr_device_aware_autodetect.py
+++ b/tests/test_asr_device_aware_autodetect.py
@@ -84,6 +84,22 @@ def test_an_explicitly_pinned_backend_still_wins(monkeypatch):
     assert ab.active_backend_id() == "faster-whisper"
 
 
+def test_explicit_omnivoice_alias_routes_shared_asr_to_pytorch(monkeypatch):
+    """The public env spelling requested by #1582 reaches the shared backend.
+
+    Dubbing, cloning, batch transcription, and the transcription API all use
+    this selector/load seam; accepting the alias here keeps those consumers
+    on the PyTorch-native Whisper path that can use ROCm/HIP.
+    """
+    attached_pipeline = object()
+    monkeypatch.setenv("OMNIVOICE_ASR_BACKEND", "omnivoice")
+
+    selected = ab.get_active_asr_backend(asr_pipe=attached_pipeline)
+
+    assert isinstance(selected, ab.PyTorchWhisperBackend)
+    assert selected._pipe is attached_pipeline
+
+
 # ── we did not buy speed with lip-sync accuracy ─────────────────────────────
 
 


### PR DESCRIPTION
Closes #1582

Accepts the reported `OMNIVOICE_ASR_BACKEND=omnivoice` spelling as a compatibility alias for the existing PyTorch Whisper backend, which is the shared ROCm/HIP-capable ASR route. This intentionally does not add whisper.cpp.

Regression coverage exercises the public shared selector used by dubbing, cloning, batch, and transcription consumers.

Tests: `HF_HUB_OFFLINE=1` with an empty cache; 48 passed, 1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`OMNIVOICE_ASR_BACKEND=omnivoice` now selects the existing PyTorch-native Whisper backend. This supports ROCm ASR for cloning, dubbing, batch, and transcription without adding whisper.cpp. Regression tests passed with `HF_HUB_OFFLINE=1` and an empty cache: 48 passed and 1 skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->