### PR TITLE
fix(sharing): ship LAN web UI in desktop installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- Network Sharing from Windows MSI/portable installs now serves the bundled web interface to LAN devices instead of redirecting them to their own `localhost` (#1589) — thanks @TWIISTED-STUDIOS!
 - A remote browser hitting an API-key-configured server's admin 403 now gets the API-key login form instead of endless console 403s, while desktop and PIN-only/no-key servers keep the plain loopback error so guests are never offered a login no key can satisfy (#1568) — thanks @paoloantinori!
 - The crash-isolated ASR sidecar and its download preflight now agree on which model to load — setting the shared faster-whisper model variable applies to both variants instead of the sidecar quietly using a different one (#1556)
 - "Ready" now requires the deep health probe (a working database-backed route), not just the identity probe — a backend whose install broke underneath can no longer be announced up while every real request fails (#1548)

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -16,6 +16,10 @@ For another device on the same network — e.g. opening the web UI on your phone
 
 You can also drive this from **Settings → Sharing & Remote Access**.
 
+Desktop installers include the web interface used by the LAN address; another
+device does not need VoiceStudio installed and the host does not need a source
+checkout or a separate frontend development server.
+
 ### How the PIN works
 - A fresh 6-digit PIN is generated each time you enable sharing; it is never written to disk.
 - The QR encodes the PIN (`…/?pin=######`) so scanning connects in one step. Typing the bare URL instead prompts for the PIN.

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -845,6 +845,27 @@ pub fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
     Ok(())
 }
 
+/// Install the production SPA beside `backend/`, where the Python server's
+/// static-file mount resolves it for Network Sharing clients.
+fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Result<()> {
+    let source = resource_root.join("frontend").join("dist");
+    if !source.join("index.html").is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "bundled frontend is missing {}",
+                source.join("index.html").display()
+            ),
+        ));
+    }
+
+    let destination = project_dir.join("frontend").join("dist");
+    if destination.exists() {
+        fs::remove_dir_all(&destination)?;
+    }
+    copy_dir_recursive(&source, &destination)
+}
+
 /// Refresh `pyproject.toml` + `uv.lock` in the project dir from the bundled
 /// resources, so an upgraded app never runs freshly-synced backend code against
 /// the stale dependency manifests from when the venv was first created (#307 —
@@ -1539,11 +1560,13 @@ manually, then relaunch.",
             if let Some(ref res) = resource_dir {
                 let flat = res.clone();
                 let up2  = res.join("_up_").join("_up_");
-                let (res_omni, res_backend) = if flat.join("pyproject.toml").is_file() {
-                    (flat.join("omnivoice"), flat.join("backend"))
+                let res_root = if flat.join("pyproject.toml").is_file() {
+                    flat
                 } else {
-                    (up2.join("omnivoice"), up2.join("backend"))
+                    up2
                 };
+                let res_omni = res_root.join("omnivoice");
+                let res_backend = res_root.join("backend");
                 if res_omni.is_dir() {
                     let omnivoice_dir = project_dir.join("omnivoice");
                     let _ = fs::remove_dir_all(&omnivoice_dir);
@@ -1561,6 +1584,11 @@ manually, then relaunch.",
                     }
                     log::info!("Synced backend/ from bundle");
                 }
+                if let Err(e) = sync_packaged_frontend(&res_root, &project_dir) {
+                    fail(progress, &format!("Failed to sync frontend/dist: {}", e));
+                    return None;
+                }
+                log::info!("Synced frontend/dist from bundle");
                 // #307: the source dirs above track the bundle, so the
                 // dependency manifests must too — otherwise an upgrade runs
                 // new code against a venv that predates newly added deps.
@@ -1659,6 +1687,17 @@ the existing venv; newly added dependencies may be missing (#307)",
         // copies from when the venv was first created.
         if let Ok(res) = app.path().resource_dir() {
             let _ = refresh_project_manifests(&res, &project_dir);
+            let flat = res.clone();
+            let up2 = res.join("_up_").join("_up_");
+            let res_root = if flat.join("pyproject.toml").is_file() {
+                flat
+            } else {
+                up2
+            };
+            if let Err(e) = sync_packaged_frontend(&res_root, &project_dir) {
+                fail(progress, &format!("Failed to sync frontend/dist: {}", e));
+                return None;
+            }
         }
         let mut repair_cmd = Command::new(&uv_path);
         scrub_python_env(&mut repair_cmd); // #144: don't inherit AppImage's bundled Python
@@ -1763,16 +1802,22 @@ the existing venv; newly added dependencies may be missing (#307)",
     let flat = resource_dir.clone();
     let up2  = resource_dir.join("_up_").join("_up_");
 
-    let (resource_pyproject, resource_uvlock, resource_readme, resource_changelog, resource_omnivoice, resource_backend) = if flat.join("pyproject.toml").is_file() {
-        (flat.join("pyproject.toml"), flat.join("uv.lock"), flat.join("README.md"), flat.join("CHANGELOG.md"), flat.join("omnivoice"), flat.join("backend"))
+    let resource_root = if flat.join("pyproject.toml").is_file() {
+        flat
     } else if up2.join("pyproject.toml").is_file() {
-        (up2.join("pyproject.toml"), up2.join("uv.lock"), up2.join("README.md"), up2.join("CHANGELOG.md"), up2.join("omnivoice"), up2.join("backend"))
+        up2
     } else {
         fail(progress, &format!(
             "Missing bootstrap resources — checked flat={} and _up_={}",
             flat.display(), up2.display()));
         return None;
     };
+    let resource_pyproject = resource_root.join("pyproject.toml");
+    let resource_uvlock = resource_root.join("uv.lock");
+    let resource_readme = resource_root.join("README.md");
+    let resource_changelog = resource_root.join("CHANGELOG.md");
+    let resource_omnivoice = resource_root.join("omnivoice");
+    let resource_backend = resource_root.join("backend");
 
     if !resource_pyproject.is_file() || !resource_backend.is_dir() {
         fail(progress, &format!(
@@ -1819,6 +1864,10 @@ the existing venv; newly added dependencies may be missing (#307)",
     }
     if let Err(e) = copy_dir_recursive(&resource_backend, &backend_dir) {
         fail(progress, &format!("copy backend/: {}", e));
+        return None;
+    }
+    if let Err(e) = sync_packaged_frontend(&resource_root, &project_dir) {
+        fail(progress, &format!("copy frontend/dist: {}", e));
         return None;
     }
 
@@ -2050,6 +2099,31 @@ See docs/install/linux.md (AMD GPU) to install the ROCm wheel manually.",
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn packaged_frontend_is_installed_for_the_lan_server() {
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(source.join("assets")).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+        fs::write(source.join("assets").join("client.js"), "new client").unwrap();
+
+        let installed = project.path().join("frontend").join("dist");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("index.html"), "stale shell").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "new shell"
+        );
+        assert_eq!(
+            fs::read_to_string(installed.join("assets").join("client.js")).unwrap(),
+            "new client"
+        );
+    }
 
     #[test]
     fn update_drift_sync_preserves_user_installed_engines() {

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -878,13 +878,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
 
     if destination.exists() {
         if backup.exists() {
-            // Both survived an unusual interruption. Keep the backup as the
-            // rollback copy until replacement succeeds; the destination is
-            // redundant while that verified backup exists.
-            fs::remove_dir_all(&destination)?;
-        } else {
-            fs::rename(&destination, &backup)?;
+            // An interrupted cleanup can leave an incomplete backup. Remove
+            // it before touching the known-working destination; if cleanup
+            // fails, abort with the live shell still intact.
+            fs::remove_dir_all(&backup)?;
         }
+        fs::rename(&destination, &backup)?;
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2217,6 +2216,31 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working backup shell"
+        );
+    }
+
+    #[test]
+    fn interrupted_backup_cleanup_failure_preserves_working_destination() {
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("index.html"), "working shell").unwrap();
+        // A non-directory at the interrupted backup path makes cleanup fail
+        // and would also prevent the live destination from being renamed.
+        fs::write(&backup, "partial backup").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working shell"
         );
     }
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -864,8 +864,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     if staging.exists() {
         fs::remove_dir_all(&staging)?;
     }
-    if backup.exists() {
-        fs::remove_dir_all(&backup)?;
+    // A previous process may have died after moving the live shell aside but
+    // before installing staging. Restore the only known-good SPA before doing
+    // any new work; never discard that recovery copy merely because startup
+    // retried.
+    if !destination.exists() && backup.exists() {
+        fs::rename(&backup, &destination)?;
     }
     if let Err(error) = copy_dir_recursive(&source, &staging) {
         let _ = fs::remove_dir_all(&staging);
@@ -873,7 +877,14 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     }
 
     if destination.exists() {
-        fs::rename(&destination, &backup)?;
+        if backup.exists() {
+            // Both survived an unusual interruption. Keep the backup as the
+            // rollback copy until replacement succeeds; the destination is
+            // redundant while that verified backup exists.
+            fs::remove_dir_all(&destination)?;
+        } else {
+            fs::rename(&destination, &backup)?;
+        }
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2180,6 +2191,32 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working shell"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interrupted_frontend_swap_recovers_backup_before_a_later_copy_failure() {
+        use std::os::unix::fs::symlink;
+
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(source.join("assets")).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+        symlink("missing-client.js", source.join("assets").join("client.js")).unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("index.html"), "working backup shell").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working backup shell"
         );
     }
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -852,18 +852,40 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     if !source.join("index.html").is_file() {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
-            format!(
-                "bundled frontend is missing {}",
-                source.join("index.html").display()
-            ),
+            "bundled frontend is missing index.html",
         ));
     }
 
     let destination = project_dir.join("frontend").join("dist");
-    if destination.exists() {
-        fs::remove_dir_all(&destination)?;
+    let frontend_dir = destination.parent().expect("frontend dist has a parent");
+    let staging = frontend_dir.join(".dist-staging");
+    let backup = frontend_dir.join(".dist-backup");
+    fs::create_dir_all(frontend_dir)?;
+    if staging.exists() {
+        fs::remove_dir_all(&staging)?;
     }
-    copy_dir_recursive(&source, &destination)
+    if backup.exists() {
+        fs::remove_dir_all(&backup)?;
+    }
+    if let Err(error) = copy_dir_recursive(&source, &staging) {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+
+    if destination.exists() {
+        fs::rename(&destination, &backup)?;
+    }
+    if let Err(error) = fs::rename(&staging, &destination) {
+        if backup.exists() {
+            let _ = fs::rename(&backup, &destination);
+        }
+        let _ = fs::remove_dir_all(&staging);
+        return Err(error);
+    }
+    if backup.exists() {
+        fs::remove_dir_all(backup)?;
+    }
+    Ok(())
 }
 
 /// Refresh `pyproject.toml` + `uv.lock` in the project dir from the bundled
@@ -2122,6 +2144,42 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("assets").join("client.js")).unwrap(),
             "new client"
+        );
+    }
+
+    #[test]
+    fn packaged_frontend_error_does_not_expose_resource_path() {
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+
+        let error = sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert_eq!(error.to_string(), "bundled frontend is missing index.html");
+        assert!(!error.to_string().contains(&resources.path().display().to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_packaged_frontend_copy_preserves_installed_shell() {
+        use std::os::unix::fs::symlink;
+
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(source.join("assets")).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+        symlink("missing-client.js", source.join("assets").join("client.js")).unwrap();
+
+        let installed = project.path().join("frontend").join("dist");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("index.html"), "working shell").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working shell"
         );
     }
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -79,7 +79,8 @@
       "../../README.md",
       "../../CHANGELOG.md",
       "../../omnivoice",
-      "../../backend"
+      "../../backend",
+      "../../frontend/dist"
     ],
     "externalBin": [
       "binaries/uv",

--- a/tests/test_packaged_lan_frontend.py
+++ b/tests/test_packaged_lan_frontend.py
@@ -1,0 +1,20 @@
+"""Packaged desktop builds must carry the SPA used by Network Sharing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_desktop_bundle_carries_the_lan_frontend() -> None:
+    """The backend cannot serve LAN clients from Tauri's embedded WebView assets."""
+    config = json.loads((ROOT / "frontend/src-tauri/tauri.conf.json").read_text())
+    resources = config["bundle"]["resources"]
+
+    assert "../../frontend/dist" in resources, (
+        "frontend/dist must be a filesystem bundle resource so the packaged "
+        "Python backend can serve Network Sharing clients"
+    )


### PR DESCRIPTION
Fixes #1589

## Summary
- bundle the production SPA as a filesystem resource in every desktop package
- install it beside the packaged backend on first setup, upgrades, and repair paths
- keep the documented source-free LAN sharing behavior true for MSI/portable installs

## Root cause
Tauri embedded `frontend/dist` for its own WebView, but the separate Python LAN server runs from the installed `project/backend` tree and can only serve a sibling `project/frontend/dist`. That filesystem tree was neither a bundle resource nor copied by bootstrap, so `/` fell through to the development-only `localhost:3901` redirect.

## Tests
- fail-before/pass-after bundle resource contract: `tests/test_packaged_lan_frontend.py`
- fail-before/pass-after Rust bootstrap copy/update regression
- `cargo check --lib`
- `cargo test --lib packaged_frontend_is_installed_for_the_lan_server`
- 22 targeted Python docs/changelog/version/resource tests
- full `cargo test --lib`: 139 passed; one existing parallel-sensitive setup test failed, then passed in isolation

## Type
Bug fix; Windows packaging report, implemented through the shared macOS/Windows/Linux Tauri resource/bootstrap path.

## Release cadence
Continuous to `main`; no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Desktop packages now bundle and install `frontend/dist` beside the packaged backend during setup, upgrades, and repair. This lets the Python LAN server serve the production SPA to remote devices without a source checkout or development server. Review resource-root resolution and replacement of existing frontend files for packaging-path or bootstrap failure risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->