### PR TITLE
fix(dubbing): default exports to dubbed audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- Exported dubbed videos now mark the dubbed language as the default audio stream while keeping Original available as an explicit choice (#1575) — thanks @invio-a11y!
 - Stored artifact subpaths now resolve after moving a data directory between Windows, macOS, Linux, and Docker, while traversal and symlink escapes remain blocked (#1559) — thanks @Eman-Yousaf!
 - A remote browser hitting an API-key-configured server's admin 403 now gets the API-key login form instead of endless console 403s, while desktop and PIN-only/no-key servers keep the plain loopback error so guests are never offered a login no key can satisfy (#1568) — thanks @paoloantinori!
 - The crash-isolated ASR sidecar and its download preflight now agree on which model to load — setting the shared faster-whisper model variable applies to both variants instead of the sidecar quietly using a different one (#1556)

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within
+from core.path_security import UnsafePath, resolve_within, safe_filename
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -662,9 +662,17 @@ async def dub_download(
             raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
         logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
 
-        base_name = os.path.splitext(job.get("filename", "output"))[0]
-        safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        # Response metadata must not become a second path-like sink for job or
+        # request data. Keep the user-selected format through explicit literal
+        # branches; source names and language keys never enter the label.
+        if fmt == "wav":
+            dl_name = f"dubbed_audio_{stamp}.wav"
+        elif fmt == "mp3":
+            dl_name = f"dubbed_audio_{stamp}.mp3"
+        elif fmt == "flac":
+            dl_name = f"dubbed_audio_{stamp}.flac"
+        else:
+            dl_name = f"dubbed_audio_{stamp}.m4a"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -610,7 +610,11 @@ async def dub_download(
     # A dub export should play the dub without requiring player-specific track
     # selection. Keep ``original`` as an explicit opt-in, but when callers omit
     # the preference choose the first generated dub consistently (#1575).
-    if not default_track and filtered_tracks:
+    if (
+        filtered_tracks
+        and not (default_track == "original" and include_original)
+        and default_track not in filtered_tracks
+    ):
         default_track = next(iter(filtered_tracks))
 
     if not filtered_tracks and not include_original:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -668,7 +668,12 @@ async def dub_download(
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:
-            return _native_save(out_path, save_path, dl_name, media_type=media_type)
+            # Keep the request-derived download label out of the filesystem
+            # trust boundary. It is response metadata, not a source or
+            # destination path (CodeQL, #1575).
+            result = _native_save(out_path, save_path, "dubbed_audio", media_type=media_type)
+            result["display_name"] = dl_name
+            return result
         return FileResponse(
             out_path, media_type=media_type,
             headers={"Content-Disposition": content_disposition(dl_name)},

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -616,6 +616,8 @@ async def dub_download(
         and default_track not in filtered_tracks
     ):
         default_track = next(iter(filtered_tracks))
+    elif not filtered_tracks and include_original:
+        default_track = "original"
 
     if not filtered_tracks and not include_original:
         raise HTTPException(status_code=400, detail="No tracks selected for export")

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -572,7 +572,7 @@ def _build_audio_export_cmd(
 async def dub_download(
     job_id: str,
     preserve_bg: bool = Query(True, description="Mix background noise into dubbed tracks"),
-    default_track: str = Query("original"),
+    default_track: str = Query("", description="Default audio track; omitted selects the first dubbed track"),
     include_tracks: str = Query("", description="Comma-separated list of tracks to include (e.g. 'original,de,es'). Empty = include all."),
     save_authorization: str = Header("", alias="X-VoiceStudio-Path-Authorization"),
     burn_subs: bool = Query(False, description="Burn subtitles into the video stream (forces re-encode). Uses dual-subtitle layout when dual=1."),
@@ -606,6 +606,12 @@ async def dub_download(
         }
         for key, value in filtered_tracks.items()
     }
+
+    # A dub export should play the dub without requiring player-specific track
+    # selection. Keep ``original`` as an explicit opt-in, but when callers omit
+    # the preference choose the first generated dub consistently (#1575).
+    if not default_track and filtered_tracks:
+        default_track = next(iter(filtered_tracks))
 
     if not filtered_tracks and not include_original:
         raise HTTPException(status_code=400, detail="No tracks selected for export")
@@ -887,7 +893,10 @@ async def dub_download(
     if default_track == "original" and include_original:
         cmd += ["-disposition:a:0", "default"]
     else:
-        target_idx = 0
+        # A stale/missing language preference still means "play a dub", not
+        # "silently fall back to the source". The first processed dub is the
+        # deterministic fallback; ``original`` above remains explicit.
+        target_idx = tracks_to_process[0]["stream_idx"] if tracks_to_process else 0
         for t in tracks_to_process:
             if t['lang_code'] == default_track:
                 target_idx = t["stream_idx"]

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within, safe_filename
+from core.path_security import UnsafePath, resolve_within
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
+        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -641,12 +641,17 @@ async def dub_download(
         fmt = (out_format or "m4a").lower()
         if fmt not in _AUDIO_FORMAT_CODECS:
             fmt = "m4a"
-        # lang_code is already constrained to an existing track key, but
-        # allowlist-sanitize it before it reaches the output path so a path
-        # component can never carry separators/traversal (same pattern as
-        # safe_name below).
-        safe_lang = "".join(c for c in lang_code if c.isalnum() or c in "-_") or "track"
-        out_path = os.path.join(exports_dir, f"dubbed_audio_{safe_lang}_{stamp}.{fmt}")
+        # Keep route/job data out of the filesystem and logging trust boundary.
+        # The selected format reaches the path only through literal branches.
+        if fmt == "wav":
+            output_name = f"dubbed_audio_{stamp}.wav"
+        elif fmt == "mp3":
+            output_name = f"dubbed_audio_{stamp}.mp3"
+        elif fmt == "flac":
+            output_name = f"dubbed_audio_{stamp}.flac"
+        else:
+            output_name = f"dubbed_audio_{stamp}.m4a"
+        out_path = os.path.join(exports_dir, output_name)
         bg = _optional_dub_artifact(job.get("no_vocals_path"), job_id) if preserve_bg else None
         cmd = _build_audio_export_cmd(ffmpeg, track_info["path"], bg, out_path, fmt)
         try:
@@ -664,7 +669,7 @@ async def dub_download(
             )
         if not os.path.exists(out_path) or os.path.getsize(out_path) == 0:
             raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
-        logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
+        logger.info("Dub audio export completed (%d bytes)", os.path.getsize(out_path))
 
         # Response metadata must not become a second path-like sink for job or
         # request data. Keep the user-selected format through explicit literal

--- a/docs/dubbing/export.md
+++ b/docs/dubbing/export.md
@@ -1,0 +1,6 @@
+# Exporting dubbed video
+
+Video exports can contain both the source audio and one or more dubbed tracks.
+VoiceStudio marks the selected dubbed language as the default so ordinary video
+players and messaging apps play the dub immediately. Choose **Original** in the
+Default Track control when the source audio should play first instead.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { useAppStore, FONT_STACKS } from './store';
 import { NAV_ITEMS } from './components/navItems';
 import SearchableSelect from './components/SearchableSelect';
 import DirectionDialog from './components/DirectionDialog';
+import { resolveDubDefaultTrack } from './utils/dubDefaultTrack';
 
 // Lazy-load heavy/conditional components so they don't bloat the initial bundle.
 const AudioTrimmer = lazy(() => import('./components/AudioTrimmer'));
@@ -949,7 +950,7 @@ function App() {
     });
     const tracksParam = selected.join(',');
     const burnParam = burnSubs ? `&burn_subs=1&dual=${dualSubs ? 1 : 0}` : '';
-    const resolvedDefaultTrack = defaultTrack || dubLangCode || dubTracks[0] || '';
+    const resolvedDefaultTrack = resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks);
     triggerDownload(
       `${API}/dub/download/${dubJobId}/dubbed_video.mp4?preserve_bg=${preserveBg}&default_track=${resolvedDefaultTrack}&include_tracks=${encodeURIComponent(tracksParam)}${burnParam}`,
       'dubbed_video.mp4',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -949,8 +949,9 @@ function App() {
     });
     const tracksParam = selected.join(',');
     const burnParam = burnSubs ? `&burn_subs=1&dual=${dualSubs ? 1 : 0}` : '';
+    const resolvedDefaultTrack = defaultTrack || dubLangCode || dubTracks[0] || '';
     triggerDownload(
-      `${API}/dub/download/${dubJobId}/dubbed_video.mp4?preserve_bg=${preserveBg}&default_track=${defaultTrack}&include_tracks=${encodeURIComponent(tracksParam)}${burnParam}`,
+      `${API}/dub/download/${dubJobId}/dubbed_video.mp4?preserve_bg=${preserveBg}&default_track=${resolvedDefaultTrack}&include_tracks=${encodeURIComponent(tracksParam)}${burnParam}`,
       'dubbed_video.mp4',
     );
   };
@@ -1063,7 +1064,7 @@ function App() {
       setDubTracks(s.dubTracks || []);
       setDubTranscript(s.dubTranscript || '');
       setPreserveBg(s.preserveBg !== undefined ? s.preserveBg : true);
-      setDefaultTrack(s.defaultTrack !== undefined ? s.defaultTrack : 'original');
+      setDefaultTrack(s.defaultTrack !== undefined ? s.defaultTrack : '');
       setDubStep(s.dubStep === 'done' ? 'done' : s.dubSegments?.length ? 'editing' : 'idle');
       // Phase 4.5 — rehydrate per-segment fingerprints. The incremental plan
       // immediately shows "N segments changed" for any segments edited after

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -118,7 +118,7 @@ export default function DubRightColumn({
             {t('dub.default_track')}
             <select
               className="input-base !text-[0.6rem] !px-[4px] !py-[2px] !w-[120px]"
-              value={defaultTrack}
+              value={defaultTrack || dubLangCode || dubTracks[0] || 'original'}
               onChange={(e) => setDefaultTrack(e.target.value)}
             >
               <option value="original">{t('dub.original_track')}</option>

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -5,6 +5,7 @@ import GlossaryPanel from '../GlossaryPanel';
 import CheckpointBanner from '../CheckpointBanner';
 import { LANG_CODES } from '../../utils/languages';
 import { autoProfileId } from '../../utils/segments';
+import { resolveDubDefaultTrack } from '../../utils/dubDefaultTrack';
 
 const DubSegmentTable = lazy(() => import('../DubSegmentTable'));
 const DubPasteTranslationDialog = lazy(() => import('./DubPasteTranslationDialog'));
@@ -118,7 +119,7 @@ export default function DubRightColumn({
             {t('dub.default_track')}
             <select
               className="input-base !text-[0.6rem] !px-[4px] !py-[2px] !w-[120px]"
-              value={defaultTrack || dubLangCode || dubTracks[0] || 'original'}
+              value={resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks)}
               onChange={(e) => setDefaultTrack(e.target.value)}
             >
               <option value="original">{t('dub.original_track')}</option>

--- a/frontend/src/components/dub/DubRightColumn.test.jsx
+++ b/frontend/src/components/dub/DubRightColumn.test.jsx
@@ -8,7 +8,7 @@ import DubRightColumn from './DubRightColumn';
 
 const noop = () => {};
 
-function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop) {
+function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop, overrides = {}) {
   return (
     <DubRightColumn
       t={(key) => key}
@@ -46,6 +46,7 @@ function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop) {
       isTranslating={false}
       dubSegments={[]}
       dubStep="editing"
+      {...overrides}
     />
   );
 }
@@ -73,5 +74,17 @@ describe('DubRightColumn language targets', () => {
     });
     expect(setDubLang).toHaveBeenCalledWith('Spanish');
     expect(setDubLangCode).toHaveBeenCalledWith('es');
+  });
+
+  it('renders the first available dub when the saved default is stale', () => {
+    render(
+      column(false, noop, noop, {
+        defaultTrack: 'fr',
+        dubLangCode: 'bn',
+        dubTracks: ['es'],
+      }),
+    );
+
+    expect(screen.getByRole('combobox', { name: 'dub.default_track' })).toHaveValue('es');
   });
 });

--- a/frontend/src/store/dubSlice.ts
+++ b/frontend/src/store/dubSlice.ts
@@ -256,7 +256,9 @@ const INITIAL: Omit<
   multiLangs: [],
   dubInstruct: '',
   preserveBg: true,
-  defaultTrack: 'original',
+  // Empty means "the selected/first dubbed language". Original remains an
+  // explicit choice in the export controls (#1575).
+  defaultTrack: '',
   exportTracks: { original: true },
   previewSegIds: [],
   speakerClones: {},

--- a/frontend/src/utils/dubDefaultTrack.js
+++ b/frontend/src/utils/dubDefaultTrack.js
@@ -1,0 +1,7 @@
+/** Resolve the effective export track against tracks that actually exist. */
+export function resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks = []) {
+  if (defaultTrack === 'original') return 'original';
+  if (dubTracks.includes(defaultTrack)) return defaultTrack;
+  if (dubTracks.includes(dubLangCode)) return dubLangCode;
+  return dubTracks[0] || 'original';
+}

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import asyncio as _asyncio
 import importlib
+import json
 import os
+import shutil
 import struct
+import subprocess
 import uuid
 import wave
 from pathlib import Path
@@ -100,6 +103,46 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    @pytest.mark.skipif(
+        shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+        reason="ffmpeg and ffprobe are required for the container regression",
+    )
+    def test_default_export_marks_dubbed_audio_as_default(self, app_client):
+        """#1575: players that honor MP4 disposition must choose the dub."""
+        client, dc, _dx, tmp = app_client
+        job_id, job_dir = _seed_job_with_tracks(dc, tmp)
+        video_path = job_dir / "original.mp4"
+        subprocess.run(
+            [
+                shutil.which("ffmpeg"), "-loglevel", "error", "-y",
+                "-f", "lavfi", "-i", "color=c=black:s=32x32:d=0.5",
+                "-f", "lavfi", "-i", "sine=frequency=220:duration=0.5",
+                "-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "aac",
+                "-shortest", str(video_path),
+            ],
+            check=True,
+        )
+
+        response = client.get(
+            f"/dub/download/{job_id}",
+            params={"preserve_bg": False},
+        )
+        assert response.status_code == 200, response.text
+        exported = next((job_dir / "exports").glob("dubbed_video_*.mp4"))
+        probe = subprocess.run(
+            [
+                shutil.which("ffprobe"), "-v", "error", "-select_streams", "a",
+                "-show_entries", "stream_tags=title:stream_disposition=default",
+                "-of", "json", str(exported),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        streams = json.loads(probe.stdout)["streams"]
+        defaults = [index for index, stream in enumerate(streams) if stream["disposition"]["default"]]
+        assert defaults == [1], "the dubbed stream follows the original and must be the sole default"
+
     def test_mp4_export_produces_unique_file_each_call(self, app_client):
         client, dc, dx, tmp = app_client
         job_id, job_dir = _seed_job_with_tracks(dc, tmp)

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -103,6 +103,31 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    def test_excluded_default_resolves_before_retime_and_subtitle_selection(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        selected = []
+
+        def capture_default(_job, lang):
+            selected.append(lang)
+            return None
+
+        with (
+            patch.object(dx, "_video_retime_plan_for", side_effect=capture_default),
+            patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)),
+        ):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={
+                    "preserve_bg": False,
+                    "default_track": "fr",
+                    "include_tracks": "original,es",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert selected == ["es"]
+
     @pytest.mark.skipif(
         shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
         reason="ffmpeg and ffprobe are required for the container regression",
@@ -112,7 +137,7 @@ class TestDubExportUniqueness:
         client, dc, _dx, tmp = app_client
         job_id, job_dir = _seed_job_with_tracks(dc, tmp)
         video_path = job_dir / "original.mp4"
-        subprocess.run(
+        subprocess.run(  # noqa: S603 -- fixed test binary and argument vector
             [
                 shutil.which("ffmpeg"), "-loglevel", "error", "-y",
                 "-f", "lavfi", "-i", "color=c=black:s=32x32:d=0.5",
@@ -129,7 +154,7 @@ class TestDubExportUniqueness:
         )
         assert response.status_code == 200, response.text
         exported = next((job_dir / "exports").glob("dubbed_video_*.mp4"))
-        probe = subprocess.run(
+        probe = subprocess.run(  # noqa: S603 -- fixed ffprobe inspection command
             [
                 shutil.which("ffprobe"), "-v", "error", "-select_streams", "a",
                 "-show_entries", "stream_tags=title:stream_disposition=default",

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -103,6 +103,25 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    def test_original_only_resolves_stale_default_before_retime(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        with (
+            patch.object(dx, "_video_retime_plan_for") as retime_for,
+            patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)),
+        ):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={
+                    "preserve_bg": False,
+                    "default_track": "fr",
+                    "include_tracks": "original",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        retime_for.assert_not_called()
+
     def test_excluded_default_resolves_before_retime_and_subtitle_selection(self, app_client):
         client, dc, dx, tmp = app_client
         job_id, _ = _seed_job_with_tracks(dc, tmp)

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -228,7 +228,7 @@ class TestAudioOnlyDubbing:
             )
 
         assert r.status_code == 200, r.text
-        audio_files = sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        audio_files = sorted(exports_dir.glob("dubbed_audio_*.m4a"))
         assert len(audio_files) == 1, [f.name for f in audio_files]
         # The video-mux path must NOT have run for an audio job.
         assert not list(exports_dir.glob("dubbed_video_*.mp4"))
@@ -244,7 +244,7 @@ class TestAudioOnlyDubbing:
             r = client.get(f"/dub/download/{job_id}", params={"preserve_bg": False, "out_format": "weird"})
 
         assert r.status_code == 200, r.text
-        assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        assert sorted(exports_dir.glob("dubbed_audio_*.m4a"))
 
     def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
         client, dc, _dx, tmp = app_client

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -221,6 +221,24 @@ class TestAudioOnlyDubbing:
         assert r.status_code == 200, r.text
         assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
 
+    def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
+        client, dc, _dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        dc._dub_jobs[job_id]["input_type"] = "audio"
+        dc._dub_jobs[job_id]["filename"] = "../evil\r\nX-Injected: yes.mp4"
+
+        with patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={"preserve_bg": False, "default_track": "es"},
+            )
+
+        assert response.status_code == 200, response.text
+        label = response.headers["content-disposition"]
+        assert ".." not in label
+        assert "\r" not in label and "\n" not in label
+        assert "X-Injected:" not in label
+
     def test_upload_rejects_video_ext_when_audio_mode(self, app_client):
         client, dc, dx, tmp = app_client
         r = client.post(


### PR DESCRIPTION
## Summary
- make omitted/stale export preferences select the first dubbed track while keeping Original explicit
- align new-project export controls with the dubbed-first default
- verify the real MP4 disposition using ffmpeg + ffprobe

Fixes #1575.

## Tests
- `HF_HUB_OFFLINE=1 ... pytest -q tests/test_dub_export_unique.py tests/test_changelog_style.py` (15 passed)
- `bun run --cwd frontend test --run src/components/dub/DubRightColumn.test.jsx src/test/dubMultiLangWorkflow.integration.test.jsx src/test/dubMultiLangGenerate.test.jsx` (10 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Dubbing exports now select the first dubbed audio track when the preference is omitted or stale, while preserving explicit `Original` selection and aligning new-project controls. This fixes workflows that otherwise select the original language by default and adds `ffmpeg`/`ffprobe` coverage for MP4 audio disposition. Review the environment-dependent regression test because it skips when either tool is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->