### PR TITLE
fix: close integration review findings

### DIFF
--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within
+from core.path_security import UnsafePath, resolve_within, safe_filename
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -662,9 +662,17 @@ async def dub_download(
             raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
         logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
 
-        base_name = os.path.splitext(job.get("filename", "output"))[0]
-        safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        # Response metadata must not become a second path-like sink for job or
+        # request data. Keep the user-selected format through explicit literal
+        # branches; source names and language keys never enter the label.
+        if fmt == "wav":
+            dl_name = f"dubbed_audio_{stamp}.wav"
+        elif fmt == "mp3":
+            dl_name = f"dubbed_audio_{stamp}.mp3"
+        elif fmt == "flac":
+            dl_name = f"dubbed_audio_{stamp}.flac"
+        else:
+            dl_name = f"dubbed_audio_{stamp}.m4a"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -610,7 +610,11 @@ async def dub_download(
     # A dub export should play the dub without requiring player-specific track
     # selection. Keep ``original`` as an explicit opt-in, but when callers omit
     # the preference choose the first generated dub consistently (#1575).
-    if not default_track and filtered_tracks:
+    if (
+        filtered_tracks
+        and not (default_track == "original" and include_original)
+        and default_track not in filtered_tracks
+    ):
         default_track = next(iter(filtered_tracks))
 
     if not filtered_tracks and not include_original:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -616,6 +616,8 @@ async def dub_download(
         and default_track not in filtered_tracks
     ):
         default_track = next(iter(filtered_tracks))
+    elif not filtered_tracks and include_original:
+        default_track = "original"
 
     if not filtered_tracks and not include_original:
         raise HTTPException(status_code=400, detail="No tracks selected for export")

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within, safe_filename
+from core.path_security import UnsafePath, resolve_within
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
+        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -641,12 +641,17 @@ async def dub_download(
         fmt = (out_format or "m4a").lower()
         if fmt not in _AUDIO_FORMAT_CODECS:
             fmt = "m4a"
-        # lang_code is already constrained to an existing track key, but
-        # allowlist-sanitize it before it reaches the output path so a path
-        # component can never carry separators/traversal (same pattern as
-        # safe_name below).
-        safe_lang = "".join(c for c in lang_code if c.isalnum() or c in "-_") or "track"
-        out_path = os.path.join(exports_dir, f"dubbed_audio_{safe_lang}_{stamp}.{fmt}")
+        # Keep route/job data out of the filesystem and logging trust boundary.
+        # The selected format reaches the path only through literal branches.
+        if fmt == "wav":
+            output_name = f"dubbed_audio_{stamp}.wav"
+        elif fmt == "mp3":
+            output_name = f"dubbed_audio_{stamp}.mp3"
+        elif fmt == "flac":
+            output_name = f"dubbed_audio_{stamp}.flac"
+        else:
+            output_name = f"dubbed_audio_{stamp}.m4a"
+        out_path = os.path.join(exports_dir, output_name)
         bg = _optional_dub_artifact(job.get("no_vocals_path"), job_id) if preserve_bg else None
         cmd = _build_audio_export_cmd(ffmpeg, track_info["path"], bg, out_path, fmt)
         try:
@@ -664,7 +669,7 @@ async def dub_download(
             )
         if not os.path.exists(out_path) or os.path.getsize(out_path) == 0:
             raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
-        logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
+        logger.info("Dub audio export completed (%d bytes)", os.path.getsize(out_path))
 
         # Response metadata must not become a second path-like sink for job or
         # request data. Keep the user-selected format through explicit literal

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { useAppStore, FONT_STACKS } from './store';
 import { NAV_ITEMS } from './components/navItems';
 import SearchableSelect from './components/SearchableSelect';
 import DirectionDialog from './components/DirectionDialog';
+import { resolveDubDefaultTrack } from './utils/dubDefaultTrack';
 
 // Lazy-load heavy/conditional components so they don't bloat the initial bundle.
 const AudioTrimmer = lazy(() => import('./components/AudioTrimmer'));
@@ -949,7 +950,7 @@ function App() {
     });
     const tracksParam = selected.join(',');
     const burnParam = burnSubs ? `&burn_subs=1&dual=${dualSubs ? 1 : 0}` : '';
-    const resolvedDefaultTrack = defaultTrack || dubLangCode || dubTracks[0] || '';
+    const resolvedDefaultTrack = resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks);
     triggerDownload(
       `${API}/dub/download/${dubJobId}/dubbed_video.mp4?preserve_bg=${preserveBg}&default_track=${resolvedDefaultTrack}&include_tracks=${encodeURIComponent(tracksParam)}${burnParam}`,
       'dubbed_video.mp4',

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -5,6 +5,7 @@ import GlossaryPanel from '../GlossaryPanel';
 import CheckpointBanner from '../CheckpointBanner';
 import { LANG_CODES } from '../../utils/languages';
 import { autoProfileId } from '../../utils/segments';
+import { resolveDubDefaultTrack } from '../../utils/dubDefaultTrack';
 
 const DubSegmentTable = lazy(() => import('../DubSegmentTable'));
 const DubPasteTranslationDialog = lazy(() => import('./DubPasteTranslationDialog'));
@@ -118,7 +119,7 @@ export default function DubRightColumn({
             {t('dub.default_track')}
             <select
               className="input-base !text-[0.6rem] !px-[4px] !py-[2px] !w-[120px]"
-              value={defaultTrack || dubLangCode || dubTracks[0] || 'original'}
+              value={resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks)}
               onChange={(e) => setDefaultTrack(e.target.value)}
             >
               <option value="original">{t('dub.original_track')}</option>

--- a/frontend/src/components/dub/DubRightColumn.test.jsx
+++ b/frontend/src/components/dub/DubRightColumn.test.jsx
@@ -8,7 +8,7 @@ import DubRightColumn from './DubRightColumn';
 
 const noop = () => {};
 
-function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop) {
+function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop, overrides = {}) {
   return (
     <DubRightColumn
       t={(key) => key}
@@ -46,6 +46,7 @@ function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop) {
       isTranslating={false}
       dubSegments={[]}
       dubStep="editing"
+      {...overrides}
     />
   );
 }
@@ -73,5 +74,17 @@ describe('DubRightColumn language targets', () => {
     });
     expect(setDubLang).toHaveBeenCalledWith('Spanish');
     expect(setDubLangCode).toHaveBeenCalledWith('es');
+  });
+
+  it('renders the first available dub when the saved default is stale', () => {
+    render(
+      column(false, noop, noop, {
+        defaultTrack: 'fr',
+        dubLangCode: 'bn',
+        dubTracks: ['es'],
+      }),
+    );
+
+    expect(screen.getByRole('combobox', { name: 'dub.default_track' })).toHaveValue('es');
   });
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -191,7 +191,12 @@ export const useAppStore = create<AppStore>()(
         if (version < 4) {
           // v1 → v2 added reviewMode; v2 → v3 added mode/sidebar/generate knobs;
           // v3 → v4 added timingStrategy. All of those have slice defaults, so
-          // passing through is sufficient — then fall through to the < 5 branch.
+          // v3 and earlier had no timingStrategy field and therefore behaved
+          // as concise. Preserve that historical behavior for existing
+          // envelopes; only fresh/v4+ records inherit today's strict default.
+          if (!Object.prototype.hasOwnProperty.call(p, 'timingStrategy')) {
+            p.timingStrategy = 'concise';
+          }
         }
         if (version < 5) {
           // #31: each saved Stories project becomes a LongformProject. Defaults

--- a/frontend/src/store/timingStrategyMigration.test.ts
+++ b/frontend/src/store/timingStrategyMigration.test.ts
@@ -24,6 +24,12 @@ describe('timing-strategy v8 migration', () => {
     expect(useAppStore.getState().timingStrategy).toBe('strict_slot');
   });
 
+  it('keeps the historical concise behavior for pre-v4 persisted installs', async () => {
+    await rehydrate({ translateQuality: 'fast' }, 3);
+
+    expect(useAppStore.getState().timingStrategy).toBe('concise');
+  });
+
   it('preserves every explicit timing choice from v7', async () => {
     for (const timingStrategy of ['concise', 'smart_fit', 'stretch_video', 'strict_slot']) {
       useAppStore.setState(useAppStore.getInitialState(), true);

--- a/frontend/src/test/initialLoadRetry.test.js
+++ b/frontend/src/test/initialLoadRetry.test.js
@@ -101,4 +101,51 @@ describe('loadLatest', () => {
     expect(apply).toHaveBeenCalledOnce();
     expect(apply).toHaveBeenCalledWith(['new']);
   });
+
+  it('retries when a stale initial success is discarded after a newer reload fails', async () => {
+    let resolveInitial;
+    let rejectReload;
+    const initial = new Promise((resolve) => {
+      resolveInitial = resolve;
+    });
+    const reload = new Promise((_resolve, reject) => {
+      rejectReload = reject;
+    });
+    const generations = {};
+    const apply = vi.fn();
+    const fetch = vi
+      .fn()
+      .mockReturnValueOnce(initial)
+      .mockReturnValueOnce(reload)
+      .mockResolvedValueOnce(['recovered']);
+
+    const initialLoad = retryInitialLoad(
+      () =>
+        loadLatest({
+          generations,
+          key: 'profiles',
+          fetch,
+          apply,
+          label: 'profiles',
+          rethrow: true,
+        }),
+      { baseDelayMs: 1 },
+    );
+    const websocketReload = loadLatest({
+      generations,
+      key: 'profiles',
+      fetch,
+      apply,
+      label: 'profiles',
+    });
+
+    rejectReload(new Error('reload failed'));
+    await websocketReload;
+    resolveInitial(['stale']);
+    await initialLoad;
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(apply).toHaveBeenCalledOnce();
+    expect(apply).toHaveBeenCalledWith(['recovered']);
+  });
 });

--- a/frontend/src/utils/dubDefaultTrack.js
+++ b/frontend/src/utils/dubDefaultTrack.js
@@ -1,0 +1,7 @@
+/** Resolve the effective export track against tracks that actually exist. */
+export function resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks = []) {
+  if (defaultTrack === 'original') return 'original';
+  if (dubTracks.includes(defaultTrack)) return defaultTrack;
+  if (dubTracks.includes(dubLangCode)) return dubLangCode;
+  return dubTracks[0] || 'original';
+}

--- a/frontend/src/utils/initialLoadRetry.js
+++ b/frontend/src/utils/initialLoadRetry.js
@@ -18,8 +18,8 @@ export async function retryInitialLoad(loader, opts = {}) {
   for (;;) {
     if (opts.cancelled) return;
     try {
-      await loader();
-      return;
+      const applied = await loader();
+      if (applied !== false) return;
     } catch {
       // transient — retry
     }
@@ -34,9 +34,12 @@ export async function loadLatest({ generations, key, fetch, apply, label, rethro
   generations[key] = generation;
   try {
     const data = await fetch();
-    if (generation === generations[key]) apply(data);
+    if (generation !== generations[key]) return false;
+    apply(data);
+    return true;
   } catch (error) {
     console.warn(`Failed to load ${label}:`, error);
     if (rethrow) throw error;
+    return false;
   }
 }

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -103,6 +103,31 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    def test_excluded_default_resolves_before_retime_and_subtitle_selection(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        selected = []
+
+        def capture_default(_job, lang):
+            selected.append(lang)
+            return None
+
+        with (
+            patch.object(dx, "_video_retime_plan_for", side_effect=capture_default),
+            patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)),
+        ):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={
+                    "preserve_bg": False,
+                    "default_track": "fr",
+                    "include_tracks": "original,es",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert selected == ["es"]
+
     @pytest.mark.skipif(
         shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
         reason="ffmpeg and ffprobe are required for the container regression",
@@ -112,7 +137,7 @@ class TestDubExportUniqueness:
         client, dc, _dx, tmp = app_client
         job_id, job_dir = _seed_job_with_tracks(dc, tmp)
         video_path = job_dir / "original.mp4"
-        subprocess.run(
+        subprocess.run(  # noqa: S603 -- fixed test binary and argument vector
             [
                 shutil.which("ffmpeg"), "-loglevel", "error", "-y",
                 "-f", "lavfi", "-i", "color=c=black:s=32x32:d=0.5",
@@ -129,7 +154,7 @@ class TestDubExportUniqueness:
         )
         assert response.status_code == 200, response.text
         exported = next((job_dir / "exports").glob("dubbed_video_*.mp4"))
-        probe = subprocess.run(
+        probe = subprocess.run(  # noqa: S603 -- fixed ffprobe inspection command
             [
                 shutil.which("ffprobe"), "-v", "error", "-select_streams", "a",
                 "-show_entries", "stream_tags=title:stream_disposition=default",

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -103,6 +103,25 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    def test_original_only_resolves_stale_default_before_retime(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        with (
+            patch.object(dx, "_video_retime_plan_for") as retime_for,
+            patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)),
+        ):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={
+                    "preserve_bg": False,
+                    "default_track": "fr",
+                    "include_tracks": "original",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        retime_for.assert_not_called()
+
     def test_excluded_default_resolves_before_retime_and_subtitle_selection(self, app_client):
         client, dc, dx, tmp = app_client
         job_id, _ = _seed_job_with_tracks(dc, tmp)

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -228,7 +228,7 @@ class TestAudioOnlyDubbing:
             )
 
         assert r.status_code == 200, r.text
-        audio_files = sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        audio_files = sorted(exports_dir.glob("dubbed_audio_*.m4a"))
         assert len(audio_files) == 1, [f.name for f in audio_files]
         # The video-mux path must NOT have run for an audio job.
         assert not list(exports_dir.glob("dubbed_video_*.mp4"))
@@ -244,7 +244,7 @@ class TestAudioOnlyDubbing:
             r = client.get(f"/dub/download/{job_id}", params={"preserve_bg": False, "out_format": "weird"})
 
         assert r.status_code == 200, r.text
-        assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        assert sorted(exports_dir.glob("dubbed_audio_*.m4a"))
 
     def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
         client, dc, _dx, tmp = app_client

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -221,6 +221,24 @@ class TestAudioOnlyDubbing:
         assert r.status_code == 200, r.text
         assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
 
+    def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
+        client, dc, _dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        dc._dub_jobs[job_id]["input_type"] = "audio"
+        dc._dub_jobs[job_id]["filename"] = "../evil\r\nX-Injected: yes.mp4"
+
+        with patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={"preserve_bg": False, "default_track": "es"},
+            )
+
+        assert response.status_code == 200, response.text
+        label = response.headers["content-disposition"]
+        assert ".." not in label
+        assert "\r" not in label and "\n" not in label
+        assert "X-Injected:" not in label
+
     def test_upload_rejects_video_ext_when_audio_mode(self, app_client):
         client, dc, dx, tmp = app_client
         r = client.post(


### PR DESCRIPTION
## Summary
- merge the updated #1599 safe-filename trust boundary and metadata regression
- preserve historical `concise` timing for pre-v4 persisted envelopes
- keep initial-load retries alive when a stale success is discarded after a newer WebSocket reload fails

## Tests
- backend security/export/changelog: 45 passed offline
- focused Vitest: 9 passed
- frontend `typecheck:ci`
- targeted `oxfmt --check`