### PR TITLE
fix(desktop): harden packaged frontend recovery

### DIFF
--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -878,13 +878,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
 
     if destination.exists() {
         if backup.exists() {
-            // Both survived an unusual interruption. Keep the backup as the
-            // rollback copy until replacement succeeds; the destination is
-            // redundant while that verified backup exists.
-            fs::remove_dir_all(&destination)?;
-        } else {
-            fs::rename(&destination, &backup)?;
+            // An interrupted cleanup can leave an incomplete backup. Remove
+            // it before touching the known-working destination; if cleanup
+            // fails, abort with the live shell still intact.
+            fs::remove_dir_all(&backup)?;
         }
+        fs::rename(&destination, &backup)?;
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2217,6 +2216,31 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working backup shell"
+        );
+    }
+
+    #[test]
+    fn interrupted_backup_cleanup_failure_preserves_working_destination() {
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("index.html"), "working shell").unwrap();
+        // A non-directory at the interrupted backup path makes cleanup fail
+        // and would also prevent the live destination from being renamed.
+        fs::write(&backup, "partial backup").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working shell"
         );
     }
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -864,8 +864,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     if staging.exists() {
         fs::remove_dir_all(&staging)?;
     }
-    if backup.exists() {
-        fs::remove_dir_all(&backup)?;
+    // A previous process may have died after moving the live shell aside but
+    // before installing staging. Restore the only known-good SPA before doing
+    // any new work; never discard that recovery copy merely because startup
+    // retried.
+    if !destination.exists() && backup.exists() {
+        fs::rename(&backup, &destination)?;
     }
     if let Err(error) = copy_dir_recursive(&source, &staging) {
         let _ = fs::remove_dir_all(&staging);
@@ -873,7 +877,14 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     }
 
     if destination.exists() {
-        fs::rename(&destination, &backup)?;
+        if backup.exists() {
+            // Both survived an unusual interruption. Keep the backup as the
+            // rollback copy until replacement succeeds; the destination is
+            // redundant while that verified backup exists.
+            fs::remove_dir_all(&destination)?;
+        } else {
+            fs::rename(&destination, &backup)?;
+        }
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2180,6 +2191,32 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working shell"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interrupted_frontend_swap_recovers_backup_before_a_later_copy_failure() {
+        use std::os::unix::fs::symlink;
+
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(source.join("assets")).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+        symlink("missing-client.js", source.join("assets").join("client.js")).unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("index.html"), "working backup shell").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working backup shell"
         );
     }
 

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -33,6 +33,37 @@ _APPIMAGE_PROCESSES = os.path.join(_ROOT, "scripts", "desktop_prod_processes.py"
 _RELAUNCH_SCRIPTS = ("desktop-prod:run", "desktop-prod:run:pill")
 
 
+def _supported_bash() -> str | None:
+    """Return a native shell capable of executing desktop-prod.sh."""
+    if os.name == "nt":
+        roots = filter(
+            None,
+            (
+                os.environ.get("ProgramFiles"),
+                os.environ.get("ProgramFiles(x86)"),
+                os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs"),
+            ),
+        )
+        for root in roots:
+            for relative in (("Git", "bin", "bash.exe"), ("Git", "usr", "bin", "bash.exe")):
+                candidate = os.path.join(root, *relative)
+                if os.path.isfile(candidate):
+                    return candidate
+
+    candidate = shutil.which("bash")
+    if candidate and not (os.name == "nt" and "\\system32\\" in candidate.lower()):
+        return candidate
+    return None
+
+
+def test_desktop_prod_execution_does_not_require_posix_bin_bash():
+    """The smoke seam must also collect on native Windows runners."""
+    with open(__file__, encoding="utf-8") as fh:
+        source = fh.read()
+    posix_only_invocation = '["' + "/bin/" + 'bash", fixture_script'
+    assert posix_only_invocation not in source
+
+
 def _scripts() -> dict:
     with open(_PKG, encoding="utf-8") as fh:
         return json.load(fh)["scripts"]
@@ -262,8 +293,11 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
             "PATH": f"{fake_bin}:/usr/bin:/bin",
         }
     )
+    bash = _supported_bash()
+    if bash is None:
+        pytest.skip("desktop-prod.sh smoke requires Bash (for example Git Bash on Windows)")
     result = subprocess.run(
-        ["/bin/bash", fixture_script, "--skip-build"],  # noqa: S603
+        [bash, fixture_script, "--skip-build"],  # noqa: S603
         cwd=fixture_root,
         env=env,
         capture_output=True,


### PR DESCRIPTION
## Summary
- recover an interrupted packaged-frontend swap when the backup is the only working SPA
- preserve the backup until its replacement has been copied successfully
- resolve a supported Bash for desktop production tests and skip explicitly when unavailable

## Tests
- `cargo check --lib`
- `cargo test --lib interrupted_frontend_swap`
- `cargo test --lib packaged_frontend`
- `uv run pytest tests/test_desktop_prod_scripts.py tests/test_changelog_style.py tests/test_packaged_lan_frontend.py -q` (19 passed)
- `git diff --check`

`cargo fmt --check` reports existing repository-wide formatting drift outside these commits.