### PR TITLE
fix: keep healthy CPU synthesis past five minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- CPU-only synthesis now gets a bounded ten-minute execution budget, and a render that exhausts it is reported as a compute timeout instead of misleading "generation capacity is busy" queue pressure (#1588) — thanks @ChienNguyen1111!
 - Watermark embedding failures now log the full traceback instead of just the exception message, so a silently-unmarked-audio incident (audio passes through unmarked by design) is diagnosable from the log alone (#1576) — thanks @paoloantinori!
 - Dubbing now recovers rapid two-speaker exchanges when diarization collapses them, defaults new projects to lip sync without overwriting saved timing choices, and keeps the editor usable on narrow screens (#1584) — thanks @victordonat0!
 - `OMNIVOICE_ASR_BACKEND=omnivoice` now selects the PyTorch-native Whisper path, so the documented ROCm escape hatch no longer fails as an unknown engine (#1582) — thanks @patmansk!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The backend binds its port immediately and reports startup progress live — `/health` answers 503-with-step and a new `/startup/progress` endpoint lists every step while PyTorch, API routes, and database migrations load in the background, so "starting at step X" is never mistakable for "dead"; the desktop splash narrates each step (#1550)
 
 ### Added
-- The locally cached AudioSeal watermark generator warms on a background thread ~35s after boot (`OMNIVOICE_PRELOAD_WATERMARK=0` opts out; explicitly setting `=1` may download it), so the first synthesis no longer serializes the audioseal import + model load inline — measured at ~42s on a cold filesystem, 3s short of a 90s client timeout (#1576) — thanks @paoloantinoro!
+- The locally cached AudioSeal watermark generator warms on a background thread ~35s after boot (`OMNIVOICE_PRELOAD_WATERMARK=0` opts out; explicitly setting `=1` may download it), so the first synthesis no longer serializes the audioseal import + model load inline — measured at ~42s on a cold filesystem, 3s short of a 90s client timeout (#1576) — thanks @paoloantinori!
 - Voices you've cloned stay "warm" across restarts — encoded references now persist to disk (~10 KB each), so the first generation of a session skips the re-encode and any transcription pass; `OMNIVOICE_PROMPT_DISK_CACHE=0` opts out (#1565)
 - Optional FlashInfer acceleration for the default engine on CUDA (`OMNIVOICE_FLASHINFER=1`, ~2.2x measured) — needs the optional `flashinfer-python` package; missing package or kernel failure logs why and falls back to the standard path (#1565)
 - The bug reporter notices when you're on an outdated build and offers the latest release before filing — with a "File anyway" escape hatch — and stamps a `Build status` line into every report so up-to-date reports are tellable from stale ones (#1547)
@@ -32,7 +32,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
-- Watermark embedding failures now log the full traceback instead of just the exception message, so a silently-unmarked-audio incident (audio passes through unmarked by design) is diagnosable from the log alone (#1576) — thanks @paoloantinoro!
+- Watermark embedding failures now log the full traceback instead of just the exception message, so a silently-unmarked-audio incident (audio passes through unmarked by design) is diagnosable from the log alone (#1576) — thanks @paoloantinori!
 - Stored artifact subpaths now resolve after moving a data directory between Windows, macOS, Linux, and Docker, while traversal and symlink escapes remain blocked (#1559) — thanks @Eman-Yousaf!
 - A remote browser hitting an API-key-configured server's admin 403 now gets the API-key login form instead of endless console 403s, while desktop and PIN-only/no-key servers keep the plain loopback error so guests are never offered a login no key can satisfy (#1568) — thanks @paoloantinori!
 - The crash-isolated ASR sidecar and its download preflight now agree on which model to load — setting the shared faster-whisper model variable applies to both variants instead of the sidecar quietly using a different one (#1556)

--- a/backend/api/routers/archetypes.py
+++ b/backend/api/routers/archetypes.py
@@ -357,15 +357,11 @@ async def _render_archetype_wav(a: dict, out_path: Path) -> None:
     # Runs on the dedicated watermark pool (#1190): AudioSeal embedding is CPU
     # work that holds no VRAM, so it must not occupy a GPU worker ahead of the
     # next generate on 1-worker hosts.
-    from services.watermark import mark_synthetic
-    from services.model_manager import get_watermark_pool
-    import functools
-    audio_tensor = await run_on_gpu_pool_guarded(
-        functools.partial(mark_synthetic, audio_tensor, model.sampling_rate,
-                          context="archetypes.render"),
-        what="Archetype watermark",
+    from services.watermark import mark_synthetic_async
+    audio_tensor = await mark_synthetic_async(
+        audio_tensor, model.sampling_rate,
+        context="archetypes.render",
         timeout=generate_timeout_s(""),
-        executor=get_watermark_pool(),
     )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/api/routers/archetypes.py
+++ b/backend/api/routers/archetypes.py
@@ -330,7 +330,7 @@ async def _render_archetype_wav(a: dict, out_path: Path) -> None:
     # GPU pool and brick the backend (#730 class). Budget comes from the shared
     # length-scaled helper (#1190) instead of the flat 300s default.
     from services.model_manager import generate_timeout_s
-    _budget = generate_timeout_s(text)
+    _budget = generate_timeout_s(text, engine=model)
     audio_tensor = await run_on_gpu_pool_guarded(
         lambda: _infer(_PREVIEW_SEED), what="Archetype preview generate",
         timeout=_budget)

--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -358,7 +358,7 @@ async def _run_batch_pipeline(job_id: str, job: dict):
                 from services.model_manager import generate_timeout_s
                 audio_tensor = await run_on_gpu_pool_guarded(
                     _gen, what="Batch generate",
-                    timeout=generate_timeout_s(seg_text),
+                    timeout=generate_timeout_s(seg_text, engine=backend),
                 )
 
                 # Fit to slot

--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -413,19 +413,15 @@ async def _run_batch_pipeline(job_id: str, job: dict):
         # unmarked while the interactive dub pipeline marked every segment.
         # One whole-track embed (chunked internally, #1045) is equivalent to
         # dub_generate's per-segment marks: the 16-bit message repeats
-        # throughout. Runs in the GPU pool like generate's finalize; never
-        # raises (degrades to unmarked on failure, same as every producer).
+        # throughout. Never raises (degrades to unmarked on failure, same as
+        # every producer).
         # Dispatched to the dedicated watermark pool, not the GPU pool (#1190):
         # AudioSeal embedding is CPU work that holds no VRAM, and a whole-track
         # embed is long enough that occupying a GPU worker with it stalled the
         # next language's segments on 1-worker hosts.
-        from services.watermark import mark_synthetic
-        from services.model_manager import get_watermark_pool
-        import functools
-        full_audio = await loop.run_in_executor(
-            get_watermark_pool(),
-            functools.partial(mark_synthetic, full_audio, sr,
-                              context="batch.dub_track"),
+        from services.watermark import mark_synthetic_async
+        full_audio = await mark_synthetic_async(
+            full_audio, sr, context="batch.dub_track",
         )
 
         # Same assembly pattern as dub_generate.py:390 — `full_audio` is a

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within
+from core.path_security import UnsafePath, resolve_within, safe_filename
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within, safe_filename
+from core.path_security import UnsafePath, resolve_within
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
+        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_generate.py
+++ b/backend/api/routers/dub_generate.py
@@ -1091,7 +1091,7 @@ async def dub_generate(job_id: str, req: DubRequest):
                             _num_step, req.guidance_scale, seg_speed, seg_profile, seg_effect_preset,
                         ),
                         what="Dub generate",
-                        timeout=generate_timeout_s(seg.text),
+                        timeout=generate_timeout_s(seg.text, engine=backend),
                     )
                 _t_tts += time.perf_counter() - _t_tts_0
 
@@ -1798,7 +1798,7 @@ async def preview_segment(job_id: str, req: SegmentPreviewRequest):
     from services.model_manager import generate_timeout_s
     audio_tensor = await run_on_gpu_pool_guarded(
         _gen, what="Dub preview generate",
-        timeout=generate_timeout_s(req.text),
+        timeout=generate_timeout_s(req.text, engine=backend),
     )
 
     sr = backend.sample_rate

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -1890,7 +1890,7 @@ async def generate_speech(
                 # Client went away mid-stream — same semantics as aborting a
                 # classic /generate mid-render: nothing is saved.
                 raise
-            except (GpuJobTimeoutError, GpuPoolBusyError) as e:
+            except GpuPoolBusyError as e:
                 # In-band error frame carries the machine-readable retryable
                 # marker (#1190) — an NDJSON consumer can back off instead of
                 # guessing from the prose.
@@ -1898,6 +1898,14 @@ async def generate_speech(
                 from core.public_errors import stream_failure
                 failure = stream_failure("generation_busy")
                 failure["retry_after"] = getattr(e, "retry_after", 30)
+                yield _line({"type": "error", **failure})
+            except GpuJobTimeoutError:
+                # The worker started and spent its full execution budget. That
+                # is compute time, not queue pressure (#1588).
+                logger.error("Streaming generation exceeded its compute budget")
+                from core.public_errors import stream_failure
+                failure = stream_failure("generation_timeout")
+                failure["retry_after"] = 30
                 yield _line({"type": "error", **failure})
             except ValueError:
                 logger.error("Streaming generation request rejected")

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -596,7 +596,7 @@ def _oom_friendly_reraise(e):
     ) from e
 
 
-def _generate_timeout_s(text: str) -> float:
+def _generate_timeout_s(text: str, *, execution_device=None) -> float:
     """Wall-clock budget for one generate, scaled to the request.
 
     Thin alias for the canonical helper, which moved to
@@ -605,7 +605,7 @@ def _generate_timeout_s(text: str) -> float:
     as they did, silently keeping the flat 300s).
     """
     from services.model_manager import generate_timeout_s
-    return generate_timeout_s(text)
+    return generate_timeout_s(text, execution_device=execution_device)
 
 
 def _run_inference(
@@ -1402,7 +1402,7 @@ async def generate_speech(
                 # Floor budget (#1190): a reference clip is seconds of audio,
                 # so the length-scaled bonus never applies — but the timeout is
                 # explicit here too, so no dispatch relies on a hidden default.
-                timeout=_generate_timeout_s(""),
+                timeout=_generate_timeout_s("", execution_device=_routing["effective_device"]),
             )
         # TimeoutError covers both the execution bound and pool saturation:
         # this path is best-effort either way.
@@ -1519,7 +1519,7 @@ async def generate_speech(
             local=gpu_gateway.LocalCall(
                 _remote_only_local_call(_target_label),
                 what="TTS generate",
-                timeout=_generate_timeout_s(text),
+                timeout=_generate_timeout_s(text, execution_device=_routing["effective_device"]),
                 min_vram_gb=_engine_min_vram_gb,
             ),
             remote=_remote_call,
@@ -1785,7 +1785,7 @@ async def generate_speech(
                             ),
                             what="TTS generate",
                             min_vram_gb=_engine_min_vram_gb,
-                            timeout=_generate_timeout_s(text),
+                            timeout=_generate_timeout_s(text, execution_device=_routing["effective_device"]),
                         )
                         sample_rate = _backend.sample_rate
                     else:
@@ -1801,7 +1801,7 @@ async def generate_speech(
                             ),
                             what="TTS generate",
                             min_vram_gb=_engine_min_vram_gb,
-                            timeout=_generate_timeout_s(text),
+                            timeout=_generate_timeout_s(text, execution_device=_routing["effective_device"]),
                         )
                         sample_rate = _model.sampling_rate
                     yield _line({
@@ -1837,7 +1837,7 @@ async def generate_speech(
                             # Budget scaled to THIS chunk (#1190) — the flat
                             # 300s here is what made long streamed renders fail
                             # even after the v0.3.22 scaled budget shipped.
-                            timeout=_generate_timeout_s(chunk_text),
+                            timeout=_generate_timeout_s(chunk_text, execution_device=_routing["effective_device"]),
                         )
                         parts.append(raw)
                         # Provenance-mark the streamed copy off the GPU pool
@@ -1861,7 +1861,7 @@ async def generate_speech(
                     audio_tensor = await run_on_gpu_pool_guarded(
                         functools.partial(_assemble_stream_chunks, parts, sample_rate),
                         what="TTS assemble",
-                        timeout=_generate_timeout_s(text),
+                        timeout=_generate_timeout_s(text, execution_device=_routing["effective_device"]),
                     )
 
                 _, meta = await _finalize_generation(
@@ -1973,7 +1973,7 @@ async def generate_speech(
                 _REMOTE_OP,
                 local=gpu_gateway.LocalCall(
                     _local_render, what="TTS generate",
-                    timeout=_generate_timeout_s(text),
+                    timeout=_generate_timeout_s(text, execution_device=_routing["effective_device"]),
                     min_vram_gb=_engine_min_vram_gb,
                 ),
                 decision=_decision,

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -870,7 +870,6 @@ async def _finalize_generation(
     Returns ``(watermarked_tensor, meta)`` where ``meta`` carries
     ``id`` / ``filename`` / ``duration`` / ``gen_time``.
     """
-    loop = asyncio.get_running_loop()
     # Invisible AudioSeal provenance watermark on the final audio. Embedding
     # was previously only wired into the dub pipeline (dub_generate.py), so
     # plain TTS came out unmarked despite the setting being on — and the same
@@ -882,12 +881,9 @@ async def _finalize_generation(
     # AudioSeal embedding is CPU work that holds no VRAM, so occupying a GPU
     # worker with it only delays the next generate on 1-worker hosts.
     if not already_marked:
-        from services.watermark import mark_synthetic
-        from services.model_manager import get_watermark_pool
-        audio_tensor = await loop.run_in_executor(
-            get_watermark_pool(),
-            functools.partial(mark_synthetic, audio_tensor, sample_rate,
-                              context="generate.finalize"),
+        from services.watermark import mark_synthetic_async
+        audio_tensor = await mark_synthetic_async(
+            audio_tensor, sample_rate, context="generate.finalize",
         )
     gen_time = round(time.time() - start_time, 2)
 
@@ -1822,12 +1818,10 @@ async def generate_speech(
                     # (#1190): AudioSeal embedding is CPU work that owns no
                     # VRAM, and on a 1-worker host it used to serialize
                     # directly ahead of the next generate.
-                    from services.watermark import mark_synthetic
-                    from services.model_manager import get_watermark_pool
-                    _preview = await asyncio.get_running_loop().run_in_executor(
-                        get_watermark_pool(),
-                        functools.partial(mark_synthetic, audio_tensor, sample_rate,
-                                          context="generate.stream_preview"),
+                    from services.watermark import mark_synthetic_async
+                    _preview = await mark_synthetic_async(
+                        audio_tensor, sample_rate,
+                        context="generate.stream_preview",
                     )
                     yield _line({"type": "chunk", "seq": 0, "pcm": _pcm16_b64(_preview)})
                 else:
@@ -1849,12 +1843,10 @@ async def generate_speech(
                         # Provenance-mark the streamed copy off the GPU pool
                         # (#1169 mark, #1190 placement): CPU-only AudioSeal
                         # work must not occupy a GPU worker between chunks.
-                        from services.watermark import mark_synthetic
-                        from services.model_manager import get_watermark_pool
-                        preview = await asyncio.get_running_loop().run_in_executor(
-                            get_watermark_pool(),
-                            functools.partial(mark_synthetic, preview, sample_rate,
-                                              context="generate.stream_preview"),
+                        from services.watermark import mark_synthetic_async
+                        preview = await mark_synthetic_async(
+                            preview, sample_rate,
+                            context="generate.stream_preview",
                         )
                         if i == 0:
                             # After the first render so lazy-loading engines

--- a/backend/api/routers/openai_compat.py
+++ b/backend/api/routers/openai_compat.py
@@ -454,7 +454,7 @@ async def create_speech(req: SpeechRequest):
         from services.model_manager import generate_timeout_s
         wav, sr = await run_on_gpu_pool_guarded(
             lambda: _run_tts(backend, text, kw), what="OpenAI TTS generate",
-            timeout=generate_timeout_s(text))
+            timeout=generate_timeout_s(text, engine=backend))
     except Exception as e:
         # #1172/#1173: typed failures get their real status + actionable
         # message (400 bad input / 503 broken engine binary) instead of a

--- a/backend/api/routers/tts_stream.py
+++ b/backend/api/routers/tts_stream.py
@@ -297,7 +297,7 @@ async def ws_tts(websocket: WebSocket):
                     wav_tensor, sr = await run_on_gpu_pool_guarded(
                         functools.partial(_generate, sentence),
                         what="TTS generate",
-                        timeout=generate_timeout_s(sentence),
+                        timeout=generate_timeout_s(sentence, engine=backend),
                     )
 
                     if not started:

--- a/backend/core/event_bus.py
+++ b/backend/core/event_bus.py
@@ -64,29 +64,25 @@ def emit(kind: str, payload: dict[str, Any] | None = None) -> None:
         **(payload or {}),
     }
     event_str = json.dumps(event)
-    loop = asyncio.get_running_loop() if _on_event_loop() else _serving_loop
-    if loop is None:
+    try:
+        caller_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        caller_loop = None
+    target_loop = _serving_loop or caller_loop
+    if target_loop is None:
         # No serving loop yet — nobody to notify; dropping is correct.
         logger.debug("No event loop — event dropped: %s", kind)
         return
     try:
-        if _on_event_loop():
-            loop.create_task(_broadcast(event_str))
+        if caller_loop is target_loop:
+            target_loop.create_task(_broadcast(event_str))
         else:
-            # Threadpool worker (sync endpoint body): the only thread-safe way in.
-            loop.call_soon_threadsafe(_schedule_broadcast, event_str)
+            # Sync endpoints and async producers on a foreign loop must both
+            # hand off: the lock and listener queues belong to serving_loop.
+            target_loop.call_soon_threadsafe(_schedule_broadcast, event_str)
     except RuntimeError:
         # The serving loop closed between capture and use (app shutdown).
         logger.debug("Event loop closed — event dropped: %s", kind)
-
-
-def _on_event_loop() -> bool:
-    """True when called from the running event loop (async-context emit)."""
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return False
-    return True
 
 
 def _schedule_broadcast(event_str: str) -> None:

--- a/backend/core/public_errors.py
+++ b/backend/core/public_errors.py
@@ -28,6 +28,15 @@ def stream_failure(code: str) -> dict[str, object]:
             "detail": "Generation capacity is busy. Try again shortly.",
             "retryable": True,
         },
+        "generation_timeout": {
+            "code": "generation_timeout",
+            "detail": (
+                "Generation exceeded the compute-time limit. The backend is "
+                "still running; try a shorter passage or raise the generation "
+                "timeout."
+            ),
+            "retryable": True,
+        },
         "invalid_request": {
             "code": "invalid_request",
             "detail": "The generation request could not be processed.",

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -398,6 +398,7 @@ def __getattr__(name: str):
 # (generation.py, tts_stream.py) were the last unguarded dispatch — and the
 # residual on-main reports all fail on generate:start (audio). This is the same
 # guard generalised so every GPU dispatch shares one recovery path.
+_GENERATE_TIMEOUT_EXPLICIT = "OMNIVOICE_GENERATE_TIMEOUT_S" in os.environ
 GPU_JOB_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GENERATE_TIMEOUT_S", "300.0"))
 # CPU synthesis is healthy but substantially slower than accelerated inference.
 # Keep a separate, bounded floor so a short render on CPU is not abandoned at
@@ -524,8 +525,8 @@ def generate_timeout_s(text: "str | None") -> float:
     base = GPU_JOB_TIMEOUT_S
     try:
         from core.device_caps import detect_host_caps
-        if detect_host_caps().family == "cpu":
-            base = max(base, CPU_JOB_TIMEOUT_S)
+        if detect_host_caps().family == "cpu" and not _GENERATE_TIMEOUT_EXPLICIT:
+            base = CPU_JOB_TIMEOUT_S
     except Exception:
         # Device probing is advisory here; the configured universal bound is
         # still safe when a platform probe is unavailable during startup.

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1112,6 +1112,10 @@ class _WatermarkExecutor(Executor):
                 self._thread is None or not self._thread.is_alive()
             )
 
+    def is_shutdown(self) -> bool:
+        with self._lock:
+            return self._shutdown
+
     def shutdown(
         self,
         wait: bool = True,
@@ -1150,7 +1154,10 @@ def begin_watermark_pool_lifecycle() -> None:
             and _watermark_pool_singleton.is_stopped()
         ):
             _watermark_pool_singleton = None
-        _watermark_pool_accepting = _watermark_pool_singleton is None
+        _watermark_pool_accepting = (
+            _watermark_pool_singleton is None
+            or not _watermark_pool_singleton.is_shutdown()
+        )
 
 
 def get_watermark_pool() -> _WatermarkExecutor:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -400,6 +400,7 @@ def __getattr__(name: str):
 # guard generalised so every GPU dispatch shares one recovery path.
 _GENERATE_TIMEOUT_EXPLICIT = "OMNIVOICE_GENERATE_TIMEOUT_S" in os.environ
 GPU_JOB_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GENERATE_TIMEOUT_S", "300.0"))
+_CONFIGURED_GPU_JOB_TIMEOUT_S = GPU_JOB_TIMEOUT_S
 # CPU synthesis is healthy but substantially slower than accelerated inference.
 # Keep a separate, bounded floor so a short render on CPU is not abandoned at
 # the GPU-oriented five-minute deadline (#1588).
@@ -506,7 +507,9 @@ class GpuPoolBusyError(TimeoutError):
         self.retry_after = max(1, int(round(retry_after)))
 
 
-def generate_timeout_s(text: "str | None") -> float:
+def generate_timeout_s(
+    text: "str | None", *, engine: object = None, execution_device: "str | None" = None,
+) -> float:
     """THE wall-clock execution budget for one synthesis job, scaled to input.
 
     Single source of truth for every TTS dispatch (#1190/#1202). The
@@ -525,7 +528,24 @@ def generate_timeout_s(text: "str | None") -> float:
     base = GPU_JOB_TIMEOUT_S
     try:
         from core.device_caps import detect_host_caps
-        if detect_host_caps().family == "cpu" and not _GENERATE_TIMEOUT_EXPLICIT:
+        family = execution_device or detect_host_caps().family
+        if execution_device is None and engine is not None:
+            from services.engine_routing import resolve_routing
+            compat = getattr(engine, "gpu_compat", None)
+            if compat is None:
+                compat = getattr(type(engine), "gpu_compat", (family, "cpu"))
+            if tuple(compat) == ("cpu",):
+                family = "cpu"
+            else:
+                family = resolve_routing(
+                    compat, detect_host_caps(),
+                    float(getattr(engine, "min_vram_gb", 0.0) or 0.0),
+                )["effective_device"]
+        universal_override = (
+            _GENERATE_TIMEOUT_EXPLICIT
+            or GPU_JOB_TIMEOUT_S != _CONFIGURED_GPU_JOB_TIMEOUT_S
+        )
+        if family == "cpu" and not universal_override:
             base = CPU_JOB_TIMEOUT_S
     except Exception:
         # Device probing is advisory here; the configured universal bound is

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -399,6 +399,10 @@ def __getattr__(name: str):
 # residual on-main reports all fail on generate:start (audio). This is the same
 # guard generalised so every GPU dispatch shares one recovery path.
 GPU_JOB_TIMEOUT_S = float(os.environ.get("OMNIVOICE_GENERATE_TIMEOUT_S", "300.0"))
+# CPU synthesis is healthy but substantially slower than accelerated inference.
+# Keep a separate, bounded floor so a short render on CPU is not abandoned at
+# the GPU-oriented five-minute deadline (#1588).
+CPU_JOB_TIMEOUT_S = float(os.environ.get("OMNIVOICE_CPU_GENERATE_TIMEOUT_S", "600.0"))
 
 # Queue-wait budget — a SEPARATE, deliberately generous clock (#1190/#1202).
 # The execution bound above must never be spent waiting in line: a job queued
@@ -517,10 +521,16 @@ def generate_timeout_s(text: "str | None") -> float:
     CPU-class hardware, still bounded (a wedged job is caught in minutes, not
     hours).
     """
-    return max(
-        GPU_JOB_TIMEOUT_S,
-        GPU_JOB_TIMEOUT_S + (max(0, len(text or "") - 1200) / 40.0),
-    )
+    base = GPU_JOB_TIMEOUT_S
+    try:
+        from core.device_caps import detect_host_caps
+        if detect_host_caps().family == "cpu":
+            base = max(base, CPU_JOB_TIMEOUT_S)
+    except Exception:
+        # Device probing is advisory here; the configured universal bound is
+        # still safe when a platform probe is unavailable during startup.
+        pass
+    return base + (max(0, len(text or "") - 1200) / 40.0)
 
 
 def _retry_after_estimate(stats: dict) -> float:

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -286,6 +286,36 @@ def mark_synthetic(
     return marked
 
 
+async def mark_synthetic_async(
+    waveform: torch.Tensor,
+    sample_rate: int,
+    *,
+    context: str,
+    force: bool = False,
+    timeout: float | None = None,
+) -> torch.Tensor:
+    """Dispatch marking without letting a draining pool lose finished audio."""
+    import asyncio
+    import functools
+
+    from services.model_manager import get_watermark_pool, run_on_gpu_pool_guarded
+
+    try:
+        pool = get_watermark_pool()
+    except RuntimeError:
+        logger.warning("Watermark skipped while the prior worker is shutting down")
+        return waveform
+
+    job = functools.partial(
+        mark_synthetic, waveform, sample_rate, context=context, force=force
+    )
+    if timeout is not None:
+        return await run_on_gpu_pool_guarded(
+            job, what="Audio watermark", timeout=timeout, executor=pool
+        )
+    return await asyncio.get_running_loop().run_in_executor(pool, job)
+
+
 @torch.no_grad()
 def embed_watermark(
     waveform: torch.Tensor,

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -527,7 +527,7 @@ them to fail faster on a small machine.
 CPU-only hosts use a bounded 600-second generation floor because correct CPU
 synthesis can take longer than the accelerated five-minute budget. Override it
 with `OMNIVOICE_CPU_GENERATE_TIMEOUT_S`; an explicit higher
-`OMNIVOICE_GENERATE_TIMEOUT_S` still wins.
+or lower `OMNIVOICE_GENERATE_TIMEOUT_S` always wins.
 
 **Two things changed here** ([#1190](https://github.com/debpalash/VoiceStudio/issues/1190)):
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -524,6 +524,11 @@ and `OMNIVOICE_GENERATE_TIMEOUT_S` (generation) — both in seconds, default 300
 default 120). **Raise** them for very long single files/generations, **lower**
 them to fail faster on a small machine.
 
+CPU-only hosts use a bounded 600-second generation floor because correct CPU
+synthesis can take longer than the accelerated five-minute budget. Override it
+with `OMNIVOICE_CPU_GENERATE_TIMEOUT_S`; an explicit higher
+`OMNIVOICE_GENERATE_TIMEOUT_S` still wins.
+
 **Two things changed here** ([#1190](https://github.com/debpalash/VoiceStudio/issues/1190)):
 
 - **Waiting in line is no longer counted as compute.** The generate budget used

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -878,13 +878,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
 
     if destination.exists() {
         if backup.exists() {
-            // Both survived an unusual interruption. Keep the backup as the
-            // rollback copy until replacement succeeds; the destination is
-            // redundant while that verified backup exists.
-            fs::remove_dir_all(&destination)?;
-        } else {
-            fs::rename(&destination, &backup)?;
+            // An interrupted cleanup can leave an incomplete backup. Remove
+            // it before touching the known-working destination; if cleanup
+            // fails, abort with the live shell still intact.
+            fs::remove_dir_all(&backup)?;
         }
+        fs::rename(&destination, &backup)?;
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2217,6 +2216,31 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working backup shell"
+        );
+    }
+
+    #[test]
+    fn interrupted_backup_cleanup_failure_preserves_working_destination() {
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("index.html"), "working shell").unwrap();
+        // A non-directory at the interrupted backup path makes cleanup fail
+        // and would also prevent the live destination from being renamed.
+        fs::write(&backup, "partial backup").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working shell"
         );
     }
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -864,8 +864,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     if staging.exists() {
         fs::remove_dir_all(&staging)?;
     }
-    if backup.exists() {
-        fs::remove_dir_all(&backup)?;
+    // A previous process may have died after moving the live shell aside but
+    // before installing staging. Restore the only known-good SPA before doing
+    // any new work; never discard that recovery copy merely because startup
+    // retried.
+    if !destination.exists() && backup.exists() {
+        fs::rename(&backup, &destination)?;
     }
     if let Err(error) = copy_dir_recursive(&source, &staging) {
         let _ = fs::remove_dir_all(&staging);
@@ -873,7 +877,14 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     }
 
     if destination.exists() {
-        fs::rename(&destination, &backup)?;
+        if backup.exists() {
+            // Both survived an unusual interruption. Keep the backup as the
+            // rollback copy until replacement succeeds; the destination is
+            // redundant while that verified backup exists.
+            fs::remove_dir_all(&destination)?;
+        } else {
+            fs::rename(&destination, &backup)?;
+        }
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2180,6 +2191,32 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working shell"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interrupted_frontend_swap_recovers_backup_before_a_later_copy_failure() {
+        use std::os::unix::fs::symlink;
+
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(source.join("assets")).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+        symlink("missing-client.js", source.join("assets").join("client.js")).unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("index.html"), "working backup shell").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working backup shell"
         );
     }
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -191,7 +191,12 @@ export const useAppStore = create<AppStore>()(
         if (version < 4) {
           // v1 → v2 added reviewMode; v2 → v3 added mode/sidebar/generate knobs;
           // v3 → v4 added timingStrategy. All of those have slice defaults, so
-          // passing through is sufficient — then fall through to the < 5 branch.
+          // v3 and earlier had no timingStrategy field and therefore behaved
+          // as concise. Preserve that historical behavior for existing
+          // envelopes; only fresh/v4+ records inherit today's strict default.
+          if (!Object.prototype.hasOwnProperty.call(p, 'timingStrategy')) {
+            p.timingStrategy = 'concise';
+          }
         }
         if (version < 5) {
           // #31: each saved Stories project becomes a LongformProject. Defaults

--- a/frontend/src/store/timingStrategyMigration.test.ts
+++ b/frontend/src/store/timingStrategyMigration.test.ts
@@ -24,6 +24,12 @@ describe('timing-strategy v8 migration', () => {
     expect(useAppStore.getState().timingStrategy).toBe('strict_slot');
   });
 
+  it('keeps the historical concise behavior for pre-v4 persisted installs', async () => {
+    await rehydrate({ translateQuality: 'fast' }, 3);
+
+    expect(useAppStore.getState().timingStrategy).toBe('concise');
+  });
+
   it('preserves every explicit timing choice from v7', async () => {
     for (const timingStrategy of ['concise', 'smart_fit', 'stretch_video', 'strict_slot']) {
       useAppStore.setState(useAppStore.getInitialState(), true);

--- a/frontend/src/test/initialLoadRetry.test.js
+++ b/frontend/src/test/initialLoadRetry.test.js
@@ -101,4 +101,51 @@ describe('loadLatest', () => {
     expect(apply).toHaveBeenCalledOnce();
     expect(apply).toHaveBeenCalledWith(['new']);
   });
+
+  it('retries when a stale initial success is discarded after a newer reload fails', async () => {
+    let resolveInitial;
+    let rejectReload;
+    const initial = new Promise((resolve) => {
+      resolveInitial = resolve;
+    });
+    const reload = new Promise((_resolve, reject) => {
+      rejectReload = reject;
+    });
+    const generations = {};
+    const apply = vi.fn();
+    const fetch = vi
+      .fn()
+      .mockReturnValueOnce(initial)
+      .mockReturnValueOnce(reload)
+      .mockResolvedValueOnce(['recovered']);
+
+    const initialLoad = retryInitialLoad(
+      () =>
+        loadLatest({
+          generations,
+          key: 'profiles',
+          fetch,
+          apply,
+          label: 'profiles',
+          rethrow: true,
+        }),
+      { baseDelayMs: 1 },
+    );
+    const websocketReload = loadLatest({
+      generations,
+      key: 'profiles',
+      fetch,
+      apply,
+      label: 'profiles',
+    });
+
+    rejectReload(new Error('reload failed'));
+    await websocketReload;
+    resolveInitial(['stale']);
+    await initialLoad;
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(apply).toHaveBeenCalledOnce();
+    expect(apply).toHaveBeenCalledWith(['recovered']);
+  });
 });

--- a/frontend/src/utils/initialLoadRetry.js
+++ b/frontend/src/utils/initialLoadRetry.js
@@ -18,8 +18,8 @@ export async function retryInitialLoad(loader, opts = {}) {
   for (;;) {
     if (opts.cancelled) return;
     try {
-      await loader();
-      return;
+      const applied = await loader();
+      if (applied !== false) return;
     } catch {
       // transient — retry
     }
@@ -34,9 +34,12 @@ export async function loadLatest({ generations, key, fetch, apply, label, rethro
   generations[key] = generation;
   try {
     const data = await fetch();
-    if (generation === generations[key]) apply(data);
+    if (generation !== generations[key]) return false;
+    apply(data);
+    return true;
   } catch (error) {
     console.warn(`Failed to load ${label}:`, error);
     if (rethrow) throw error;
+    return false;
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,21 @@ import pytest
 import warnings as _warnings
 
 
+# App lifespans deliberately close watermark admission during shutdown. The
+# test process then keeps running and many route tests call handlers without
+# starting another lifespan, so restore the equivalent of a fresh lifespan at
+# every test boundary. ``begin_watermark_pool_lifecycle`` still refuses to
+# reopen while a timed-out worker is genuinely alive, preserving that race
+# signal instead of hiding it.
+@pytest.fixture(autouse=True)
+def _watermark_pool_lifecycle_baseline():
+    model_manager = sys.modules.get("services.model_manager")
+    begin = getattr(model_manager, "begin_watermark_pool_lifecycle", None)
+    if callable(begin):
+        begin()
+    yield
+
+
 # ── torch default-dtype isolation (CI flaky trio) ───────────────────────────
 # Three tests (test_effects_chain / test_generation_audio_guard /
 # test_persona_bundle) fail intermittently on CI — never locally — with

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -33,6 +33,37 @@ _APPIMAGE_PROCESSES = os.path.join(_ROOT, "scripts", "desktop_prod_processes.py"
 _RELAUNCH_SCRIPTS = ("desktop-prod:run", "desktop-prod:run:pill")
 
 
+def _supported_bash() -> str | None:
+    """Return a native shell capable of executing desktop-prod.sh."""
+    if os.name == "nt":
+        roots = filter(
+            None,
+            (
+                os.environ.get("ProgramFiles"),
+                os.environ.get("ProgramFiles(x86)"),
+                os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs"),
+            ),
+        )
+        for root in roots:
+            for relative in (("Git", "bin", "bash.exe"), ("Git", "usr", "bin", "bash.exe")):
+                candidate = os.path.join(root, *relative)
+                if os.path.isfile(candidate):
+                    return candidate
+
+    candidate = shutil.which("bash")
+    if candidate and not (os.name == "nt" and "\\system32\\" in candidate.lower()):
+        return candidate
+    return None
+
+
+def test_desktop_prod_execution_does_not_require_posix_bin_bash():
+    """The smoke seam must also collect on native Windows runners."""
+    with open(__file__, encoding="utf-8") as fh:
+        source = fh.read()
+    posix_only_invocation = '["' + "/bin/" + 'bash", fixture_script'
+    assert posix_only_invocation not in source
+
+
 def _scripts() -> dict:
     with open(_PKG, encoding="utf-8") as fh:
         return json.load(fh)["scripts"]
@@ -262,8 +293,11 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
             "PATH": f"{fake_bin}:/usr/bin:/bin",
         }
     )
+    bash = _supported_bash()
+    if bash is None:
+        pytest.skip("desktop-prod.sh smoke requires Bash (for example Git Bash on Windows)")
     result = subprocess.run(
-        ["/bin/bash", fixture_script, "--skip-build"],  # noqa: S603
+        [bash, fixture_script, "--skip-build"],  # noqa: S603
         cwd=fixture_root,
         env=env,
         capture_output=True,

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -221,6 +221,24 @@ class TestAudioOnlyDubbing:
         assert r.status_code == 200, r.text
         assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
 
+    def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
+        client, dc, _dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        dc._dub_jobs[job_id]["input_type"] = "audio"
+        dc._dub_jobs[job_id]["filename"] = "../evil\r\nX-Injected: yes.mp4"
+
+        with patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={"preserve_bg": False, "default_track": "es"},
+            )
+
+        assert response.status_code == 200, response.text
+        label = response.headers["content-disposition"]
+        assert ".." not in label
+        assert "\r" not in label and "\n" not in label
+        assert "X-Injected:" not in label
+
     def test_upload_rejects_video_ext_when_audio_mode(self, app_client):
         client, dc, dx, tmp = app_client
         r = client.post(

--- a/tests/test_event_bus_thread_emit.py
+++ b/tests/test_event_bus_thread_emit.py
@@ -66,6 +66,58 @@ def test_emit_from_thread_reaches_serving_loop(bus, tmp_path):
         loop.close()
 
 
+def test_emit_from_foreign_running_loop_reaches_serving_loop(bus):
+    """An async producer may run on a worker loop, but listener state belongs
+    to the WebSocket serving loop and must only be touched there."""
+    serving_loop = asyncio.new_event_loop()
+    serving_loop.set_debug(True)
+    received: list[str] = []
+    started = threading.Event()
+    done = threading.Event()
+
+    async def serve_with_waiter_ready():
+        q = await bus.subscribe()
+        waiter = asyncio.create_task(q.get())
+        await asyncio.sleep(0)  # q.get() has installed its serving-loop Future
+        started.set()
+        try:
+            received.append(await asyncio.wait_for(waiter, 0.5))
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            done.set()
+            await bus.unsubscribe(q)
+
+    def run_serving_loop():
+        asyncio.set_event_loop(serving_loop)
+        serving_loop.run_until_complete(serve_with_waiter_ready())
+
+    serving_thread = threading.Thread(
+        target=run_serving_loop, name="test-serving-loop"
+    )
+    serving_thread.start()
+    try:
+        assert started.wait(2.0), "serving loop never subscribed"
+
+        async def foreign_async_caller():
+            assert asyncio.get_running_loop() is not serving_loop
+            bus.emit("profiles", {"action": "updated", "id": "foreign-loop"})
+            await asyncio.sleep(0.05)
+
+        asyncio.run(foreign_async_caller())
+
+        assert done.wait(2.0), (
+            "emit() ran listener delivery on the caller's foreign loop"
+        )
+        assert received, "foreign-loop event never reached the serving loop"
+        payload = json.loads(received[0])
+        assert payload["id"] == "foreign-loop"
+    finally:
+        serving_loop.call_soon_threadsafe(done.set)
+        serving_thread.join(2.0)
+        serving_loop.close()
+
+
 async def _serve(bus, received: list[str], started: threading.Event, done: threading.Event):
     q = await bus.subscribe()
     started.set()

--- a/tests/test_generate_streaming.py
+++ b/tests/test_generate_streaming.py
@@ -327,6 +327,31 @@ def test_stream_short_text_single_chunk(client, monkeypatch, no_omnivoice_model)
     assert _saved_wav_bytes(done["audio_path"])  # file exists and is non-empty
 
 
+def test_stream_execution_timeout_is_not_reported_as_capacity_busy(
+    client, monkeypatch, no_omnivoice_model,
+):
+    """A render that started and expired is not a queue/admission failure."""
+    fake = _make_deterministic_engine()
+    monkeypatch.setitem(_tts_mod()._REGISTRY, "stream-fake", fake)
+
+    import api.routers.generation as gen_mod
+
+    async def _expired(fn, *, what="GPU job", **kwargs):
+        del fn, kwargs
+        if what == "TTS generate":
+            raise gen_mod.GpuJobTimeoutError("expired after 300 seconds")
+        raise AssertionError(f"unexpected guarded job: {what}")
+
+    monkeypatch.setattr(gen_mod, "run_on_gpu_pool_guarded", _expired)
+    events = _stream_events(
+        client, {"text": "Hello there.", "engine": "stream-fake"}
+    )
+
+    assert events[-1][0]["type"] == "error"
+    assert events[-1][0]["code"] == "generation_timeout"
+    assert events[-1][0]["code"] != "generation_busy"
+
+
 def test_stream_native_model_path(client, monkeypatch, tmp_path):
     """The native OmniVoice model path streams too (per-chunk generate calls
     with duration=None), and its saved take matches the classic render."""

--- a/tests/test_generate_timeout_730.py
+++ b/tests/test_generate_timeout_730.py
@@ -91,6 +91,33 @@ def test_guard_timeout_env_default(model_manager, monkeypatch):
         importlib.reload(mm)
 
 
+def test_cpu_host_gets_bounded_ten_minute_generate_budget(model_manager, monkeypatch):
+    """A healthy CPU render may exceed the GPU-oriented five-minute floor."""
+    import types
+    import core.device_caps as caps
+
+    monkeypatch.setattr(
+        caps, "detect_host_caps", lambda: types.SimpleNamespace(family="cpu")
+    )
+    monkeypatch.setattr(model_manager, "GPU_JOB_TIMEOUT_S", 300.0)
+    monkeypatch.setattr(model_manager, "CPU_JOB_TIMEOUT_S", 600.0)
+
+    assert model_manager.generate_timeout_s("A short CPU render") == 600.0
+
+
+def test_accelerated_host_keeps_five_minute_generate_budget(model_manager, monkeypatch):
+    import types
+    import core.device_caps as caps
+
+    monkeypatch.setattr(
+        caps, "detect_host_caps", lambda: types.SimpleNamespace(family="cuda")
+    )
+    monkeypatch.setattr(model_manager, "GPU_JOB_TIMEOUT_S", 300.0)
+    monkeypatch.setattr(model_manager, "CPU_JOB_TIMEOUT_S", 600.0)
+
+    assert model_manager.generate_timeout_s("A short CUDA render") == 300.0
+
+
 def test_guard_without_reset_still_bounds(model_manager):
     """A plain executor (no `reset`, e.g. in other call sites/tests) still gets
     the wall-clock bound + actionable error — reset is best-effort, not required.

--- a/tests/test_generate_timeout_730.py
+++ b/tests/test_generate_timeout_730.py
@@ -118,6 +118,28 @@ def test_accelerated_host_keeps_five_minute_generate_budget(model_manager, monke
     assert model_manager.generate_timeout_s("A short CUDA render") == 300.0
 
 
+def test_cpu_only_engine_gets_cpu_budget_on_cuda_host(model_manager, monkeypatch):
+    import types
+    import core.device_caps as caps
+    import services.engine_routing as routing
+
+    class CpuEngine:
+        gpu_compat = ("cpu",)
+
+    host = types.SimpleNamespace(family="cuda")
+    monkeypatch.setattr(caps, "detect_host_caps", lambda: host)
+    monkeypatch.setattr(
+        routing, "resolve_routing",
+        lambda *args, **kwargs: {"effective_device": "cpu"},
+    )
+    monkeypatch.setattr(model_manager, "GPU_JOB_TIMEOUT_S", 300.0)
+    monkeypatch.setattr(model_manager, "CPU_JOB_TIMEOUT_S", 600.0)
+
+    assert model_manager.generate_timeout_s(
+        "A CPU fallback render", engine=CpuEngine,
+    ) == 600.0
+
+
 def test_explicit_universal_generate_timeout_wins_on_cpu(model_manager, monkeypatch):
     """Operators can still lower the watchdog to fail faster on CPU."""
     import importlib

--- a/tests/test_generate_timeout_730.py
+++ b/tests/test_generate_timeout_730.py
@@ -118,6 +118,24 @@ def test_accelerated_host_keeps_five_minute_generate_budget(model_manager, monke
     assert model_manager.generate_timeout_s("A short CUDA render") == 300.0
 
 
+def test_explicit_universal_generate_timeout_wins_on_cpu(model_manager, monkeypatch):
+    """Operators can still lower the watchdog to fail faster on CPU."""
+    import importlib
+    import types
+    import core.device_caps as caps
+
+    monkeypatch.setenv("OMNIVOICE_GENERATE_TIMEOUT_S", "123.5")
+    mm = importlib.reload(model_manager)
+    monkeypatch.setattr(
+        caps, "detect_host_caps", lambda: types.SimpleNamespace(family="cpu")
+    )
+    try:
+        assert mm.generate_timeout_s("A short CPU render") == 123.5
+    finally:
+        monkeypatch.delenv("OMNIVOICE_GENERATE_TIMEOUT_S", raising=False)
+        importlib.reload(mm)
+
+
 def test_guard_without_reset_still_bounds(model_manager):
     """A plain executor (no `reset`, e.g. in other call sites/tests) still gets
     the wall-clock bound + actionable error — reset is best-effort, not required.

--- a/tests/test_watermark_prefetch_coldstart.py
+++ b/tests/test_watermark_prefetch_coldstart.py
@@ -274,7 +274,7 @@ def test_watermark_pool_shutdown_deadline_bounds_stuck_worker():
     pool._thread.join(timeout=1)
 
 
-def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
+def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive(watermark):
     """A producer racing bounded shutdown cannot create an undrained pool."""
     from services.model_manager import (
         begin_watermark_pool_lifecycle,
@@ -303,6 +303,18 @@ def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
         begin_watermark_pool_lifecycle()
         with pytest.raises(RuntimeError, match="shutting down"):
             get_watermark_pool()
+        # Finished synthesis must still be returned unchanged: pool admission
+        # is outside mark_synthetic's synchronous fail-open boundary.
+        import asyncio
+        import torch
+
+        audio = torch.zeros(1, 240)
+        marked = asyncio.run(
+            watermark.mark_synthetic_async(
+                audio, 24000, context="test.restart_during_shutdown"
+            )
+        )
+        assert marked is audio
     finally:
         release.set()
         pool._thread.join(timeout=1)

--- a/tests/test_watermark_prefetch_coldstart.py
+++ b/tests/test_watermark_prefetch_coldstart.py
@@ -210,7 +210,6 @@ def test_watermark_pool_rebuilds_after_shutdown_drain():
     assert get_watermark_pool().submit(lambda: "ok").result(timeout=5) == "ok"
     # Clean up the replacement so later tests start from a fresh pool too.
     shutdown_watermark_pool()
-    begin_watermark_pool_lifecycle()
 
 
 def test_watermark_pool_shutdown_waits_for_active_worker():
@@ -241,7 +240,6 @@ def test_watermark_pool_shutdown_waits_for_active_worker():
     release.set()
     shutdown_thread.join(timeout=2)
     assert shutdown_done.is_set()
-    begin_watermark_pool_lifecycle()
 
 
 def test_watermark_pool_shutdown_deadline_bounds_stuck_worker():
@@ -274,7 +272,6 @@ def test_watermark_pool_shutdown_deadline_bounds_stuck_worker():
     assert pool._thread is not None and pool._thread.daemon
     release.set()
     pool._thread.join(timeout=1)
-    begin_watermark_pool_lifecycle()
 
 
 def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
@@ -316,7 +313,6 @@ def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
     assert replacement is not pool
     assert replacement.submit(lambda: "ok").result(timeout=1) == "ok"
     shutdown_watermark_pool()
-    begin_watermark_pool_lifecycle()
 
 
 def test_prefetched_model_gets_one_extra_idle_window(monkeypatch, watermark):


### PR DESCRIPTION
## Summary
- give CPU-only hosts a bounded 600-second synthesis floor while accelerated hosts retain 300 seconds
- distinguish an execution timeout from queue saturation in streaming responses
- document the CPU override and credit @ChienNguyen1111

Closes #1588

## Tests
- `HF_HUB_OFFLINE=1 ... pytest -q tests/test_generate_timeout_730.py` (9 passed)
- `HF_HUB_OFFLINE=1 ... pytest -q tests/test_generate_streaming.py` (7 passed)