### PR TITLE
fix: isolate workspace DOM during rapid navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- Rapid Launchpad ↔ Dub navigation now replaces the workspace DOM owner cleanly, so late media/waveform cleanup cannot trigger React's `insertBefore` crash (#1590) — thanks @nicolas-jacques!
 - Watermark embedding failures now log the full traceback instead of just the exception message, so a silently-unmarked-audio incident (audio passes through unmarked by design) is diagnosable from the log alone (#1576) — thanks @paoloantinori!
 - Dubbing now recovers rapid two-speaker exchanges when diarization collapses them, defaults new projects to lip sync without overwriting saved timing choices, and keeps the editor usable on narrow screens (#1584) — thanks @victordonat0!
 - `OMNIVOICE_ASR_BACKEND=omnivoice` now selects the PyTorch-native Whisper path, so the documented ROCm escape hatch no longer fails as an unknown engine (#1582) — thanks @patmansk!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The backend binds its port immediately and reports startup progress live — `/health` answers 503-with-step and a new `/startup/progress` endpoint lists every step while PyTorch, API routes, and database migrations load in the background, so "starting at step X" is never mistakable for "dead"; the desktop splash narrates each step (#1550)
 
 ### Added
-- The locally cached AudioSeal watermark generator warms on a background thread ~35s after boot (`OMNIVOICE_PRELOAD_WATERMARK=0` opts out; explicitly setting `=1` may download it), so the first synthesis no longer serializes the audioseal import + model load inline — measured at ~42s on a cold filesystem, 3s short of a 90s client timeout (#1576) — thanks @paoloantinoro!
+- The locally cached AudioSeal watermark generator warms on a background thread ~35s after boot (`OMNIVOICE_PRELOAD_WATERMARK=0` opts out; explicitly setting `=1` may download it), so the first synthesis no longer serializes the audioseal import + model load inline — measured at ~42s on a cold filesystem, 3s short of a 90s client timeout (#1576) — thanks @paoloantinori!
 - Voices you've cloned stay "warm" across restarts — encoded references now persist to disk (~10 KB each), so the first generation of a session skips the re-encode and any transcription pass; `OMNIVOICE_PROMPT_DISK_CACHE=0` opts out (#1565)
 - Optional FlashInfer acceleration for the default engine on CUDA (`OMNIVOICE_FLASHINFER=1`, ~2.2x measured) — needs the optional `flashinfer-python` package; missing package or kernel failure logs why and falls back to the standard path (#1565)
 - The bug reporter notices when you're on an outdated build and offers the latest release before filing — with a "File anyway" escape hatch — and stamps a `Build status` line into every report so up-to-date reports are tellable from stale ones (#1547)
@@ -32,7 +32,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
-- Watermark embedding failures now log the full traceback instead of just the exception message, so a silently-unmarked-audio incident (audio passes through unmarked by design) is diagnosable from the log alone (#1576) — thanks @paoloantinoro!
+- Watermark embedding failures now log the full traceback instead of just the exception message, so a silently-unmarked-audio incident (audio passes through unmarked by design) is diagnosable from the log alone (#1576) — thanks @paoloantinori!
 - Stored artifact subpaths now resolve after moving a data directory between Windows, macOS, Linux, and Docker, while traversal and symlink escapes remain blocked (#1559) — thanks @Eman-Yousaf!
 - A remote browser hitting an API-key-configured server's admin 403 now gets the API-key login form instead of endless console 403s, while desktop and PIN-only/no-key servers keep the plain loopback error so guests are never offered a login no key can satisfy (#1568) — thanks @paoloantinori!
 - The crash-isolated ASR sidecar and its download preflight now agree on which model to load — setting the shared faster-whisper model variable applies to both variants instead of the sidecar quietly using a different one (#1556)

--- a/backend/api/routers/archetypes.py
+++ b/backend/api/routers/archetypes.py
@@ -357,15 +357,11 @@ async def _render_archetype_wav(a: dict, out_path: Path) -> None:
     # Runs on the dedicated watermark pool (#1190): AudioSeal embedding is CPU
     # work that holds no VRAM, so it must not occupy a GPU worker ahead of the
     # next generate on 1-worker hosts.
-    from services.watermark import mark_synthetic
-    from services.model_manager import get_watermark_pool
-    import functools
-    audio_tensor = await run_on_gpu_pool_guarded(
-        functools.partial(mark_synthetic, audio_tensor, model.sampling_rate,
-                          context="archetypes.render"),
-        what="Archetype watermark",
+    from services.watermark import mark_synthetic_async
+    audio_tensor = await mark_synthetic_async(
+        audio_tensor, model.sampling_rate,
+        context="archetypes.render",
         timeout=generate_timeout_s(""),
-        executor=get_watermark_pool(),
     )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/api/routers/batch.py
+++ b/backend/api/routers/batch.py
@@ -413,19 +413,15 @@ async def _run_batch_pipeline(job_id: str, job: dict):
         # unmarked while the interactive dub pipeline marked every segment.
         # One whole-track embed (chunked internally, #1045) is equivalent to
         # dub_generate's per-segment marks: the 16-bit message repeats
-        # throughout. Runs in the GPU pool like generate's finalize; never
-        # raises (degrades to unmarked on failure, same as every producer).
+        # throughout. Never raises (degrades to unmarked on failure, same as
+        # every producer).
         # Dispatched to the dedicated watermark pool, not the GPU pool (#1190):
         # AudioSeal embedding is CPU work that holds no VRAM, and a whole-track
         # embed is long enough that occupying a GPU worker with it stalled the
         # next language's segments on 1-worker hosts.
-        from services.watermark import mark_synthetic
-        from services.model_manager import get_watermark_pool
-        import functools
-        full_audio = await loop.run_in_executor(
-            get_watermark_pool(),
-            functools.partial(mark_synthetic, full_audio, sr,
-                              context="batch.dub_track"),
+        from services.watermark import mark_synthetic_async
+        full_audio = await mark_synthetic_async(
+            full_audio, sr, context="batch.dub_track",
         )
 
         # Same assembly pattern as dub_generate.py:390 — `full_audio` is a

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within
+from core.path_security import UnsafePath, resolve_within, safe_filename
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -662,9 +662,17 @@ async def dub_download(
             raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
         logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
 
-        base_name = os.path.splitext(job.get("filename", "output"))[0]
-        safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
+        # Response metadata must not become a second path-like sink for job or
+        # request data. Keep the user-selected format through explicit literal
+        # branches; source names and language keys never enter the label.
+        if fmt == "wav":
+            dl_name = f"dubbed_audio_{stamp}.wav"
+        elif fmt == "mp3":
+            dl_name = f"dubbed_audio_{stamp}.mp3"
+        elif fmt == "flac":
+            dl_name = f"dubbed_audio_{stamp}.flac"
+        else:
+            dl_name = f"dubbed_audio_{stamp}.m4a"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -610,7 +610,11 @@ async def dub_download(
     # A dub export should play the dub without requiring player-specific track
     # selection. Keep ``original`` as an explicit opt-in, but when callers omit
     # the preference choose the first generated dub consistently (#1575).
-    if not default_track and filtered_tracks:
+    if (
+        filtered_tracks
+        and not (default_track == "original" and include_original)
+        and default_track not in filtered_tracks
+    ):
         default_track = next(iter(filtered_tracks))
 
     if not filtered_tracks and not include_original:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -616,6 +616,8 @@ async def dub_download(
         and default_track not in filtered_tracks
     ):
         default_track = next(iter(filtered_tracks))
+    elif not filtered_tracks and include_original:
+        default_track = "original"
 
     if not filtered_tracks and not include_original:
         raise HTTPException(status_code=400, detail="No tracks selected for export")

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -13,7 +13,7 @@ from typing import Optional
 from core.config import DUB_DIR
 from core.http_headers import content_disposition
 from core.logging_utils import log_safe
-from core.path_security import UnsafePath, resolve_within, safe_filename
+from core.path_security import UnsafePath, resolve_within
 from core.tasks import task_manager
 from fastapi import APIRouter, Header, HTTPException, Query, Response
 from fastapi.responses import FileResponse, StreamingResponse
@@ -664,7 +664,7 @@ async def dub_download(
 
         base_name = os.path.splitext(job.get("filename", "output"))[0]
         safe_name = "".join(c for c in base_name if c.isalnum() or c in "-_ ").strip() or "output"
-        dl_name = safe_filename(f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}")
+        dl_name = f"dubbed_{safe_name}_{safe_lang}_{stamp}.{fmt}"
         media_type = _MEDIA_TYPES.get(f".{fmt}", "audio/mp4")
         save_path = _consume_native_save(save_authorization)
         if save_path:

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -641,12 +641,17 @@ async def dub_download(
         fmt = (out_format or "m4a").lower()
         if fmt not in _AUDIO_FORMAT_CODECS:
             fmt = "m4a"
-        # lang_code is already constrained to an existing track key, but
-        # allowlist-sanitize it before it reaches the output path so a path
-        # component can never carry separators/traversal (same pattern as
-        # safe_name below).
-        safe_lang = "".join(c for c in lang_code if c.isalnum() or c in "-_") or "track"
-        out_path = os.path.join(exports_dir, f"dubbed_audio_{safe_lang}_{stamp}.{fmt}")
+        # Keep route/job data out of the filesystem and logging trust boundary.
+        # The selected format reaches the path only through literal branches.
+        if fmt == "wav":
+            output_name = f"dubbed_audio_{stamp}.wav"
+        elif fmt == "mp3":
+            output_name = f"dubbed_audio_{stamp}.mp3"
+        elif fmt == "flac":
+            output_name = f"dubbed_audio_{stamp}.flac"
+        else:
+            output_name = f"dubbed_audio_{stamp}.m4a"
+        out_path = os.path.join(exports_dir, output_name)
         bg = _optional_dub_artifact(job.get("no_vocals_path"), job_id) if preserve_bg else None
         cmd = _build_audio_export_cmd(ffmpeg, track_info["path"], bg, out_path, fmt)
         try:
@@ -664,7 +669,7 @@ async def dub_download(
             )
         if not os.path.exists(out_path) or os.path.getsize(out_path) == 0:
             raise HTTPException(status_code=500, detail="ffmpeg audio export produced no output file")
-        logger.info("Dub audio export wrote %s (%d bytes)", out_path, os.path.getsize(out_path))
+        logger.info("Dub audio export completed (%d bytes)", os.path.getsize(out_path))
 
         # Response metadata must not become a second path-like sink for job or
         # request data. Keep the user-selected format through explicit literal

--- a/backend/api/routers/generation.py
+++ b/backend/api/routers/generation.py
@@ -870,7 +870,6 @@ async def _finalize_generation(
     Returns ``(watermarked_tensor, meta)`` where ``meta`` carries
     ``id`` / ``filename`` / ``duration`` / ``gen_time``.
     """
-    loop = asyncio.get_running_loop()
     # Invisible AudioSeal provenance watermark on the final audio. Embedding
     # was previously only wired into the dub pipeline (dub_generate.py), so
     # plain TTS came out unmarked despite the setting being on — and the same
@@ -882,12 +881,9 @@ async def _finalize_generation(
     # AudioSeal embedding is CPU work that holds no VRAM, so occupying a GPU
     # worker with it only delays the next generate on 1-worker hosts.
     if not already_marked:
-        from services.watermark import mark_synthetic
-        from services.model_manager import get_watermark_pool
-        audio_tensor = await loop.run_in_executor(
-            get_watermark_pool(),
-            functools.partial(mark_synthetic, audio_tensor, sample_rate,
-                              context="generate.finalize"),
+        from services.watermark import mark_synthetic_async
+        audio_tensor = await mark_synthetic_async(
+            audio_tensor, sample_rate, context="generate.finalize",
         )
     gen_time = round(time.time() - start_time, 2)
 
@@ -1822,12 +1818,10 @@ async def generate_speech(
                     # (#1190): AudioSeal embedding is CPU work that owns no
                     # VRAM, and on a 1-worker host it used to serialize
                     # directly ahead of the next generate.
-                    from services.watermark import mark_synthetic
-                    from services.model_manager import get_watermark_pool
-                    _preview = await asyncio.get_running_loop().run_in_executor(
-                        get_watermark_pool(),
-                        functools.partial(mark_synthetic, audio_tensor, sample_rate,
-                                          context="generate.stream_preview"),
+                    from services.watermark import mark_synthetic_async
+                    _preview = await mark_synthetic_async(
+                        audio_tensor, sample_rate,
+                        context="generate.stream_preview",
                     )
                     yield _line({"type": "chunk", "seq": 0, "pcm": _pcm16_b64(_preview)})
                 else:
@@ -1849,12 +1843,10 @@ async def generate_speech(
                         # Provenance-mark the streamed copy off the GPU pool
                         # (#1169 mark, #1190 placement): CPU-only AudioSeal
                         # work must not occupy a GPU worker between chunks.
-                        from services.watermark import mark_synthetic
-                        from services.model_manager import get_watermark_pool
-                        preview = await asyncio.get_running_loop().run_in_executor(
-                            get_watermark_pool(),
-                            functools.partial(mark_synthetic, preview, sample_rate,
-                                              context="generate.stream_preview"),
+                        from services.watermark import mark_synthetic_async
+                        preview = await mark_synthetic_async(
+                            preview, sample_rate,
+                            context="generate.stream_preview",
                         )
                         if i == 0:
                             # After the first render so lazy-loading engines

--- a/backend/core/event_bus.py
+++ b/backend/core/event_bus.py
@@ -64,29 +64,25 @@ def emit(kind: str, payload: dict[str, Any] | None = None) -> None:
         **(payload or {}),
     }
     event_str = json.dumps(event)
-    loop = asyncio.get_running_loop() if _on_event_loop() else _serving_loop
-    if loop is None:
+    try:
+        caller_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        caller_loop = None
+    target_loop = _serving_loop or caller_loop
+    if target_loop is None:
         # No serving loop yet — nobody to notify; dropping is correct.
         logger.debug("No event loop — event dropped: %s", kind)
         return
     try:
-        if _on_event_loop():
-            loop.create_task(_broadcast(event_str))
+        if caller_loop is target_loop:
+            target_loop.create_task(_broadcast(event_str))
         else:
-            # Threadpool worker (sync endpoint body): the only thread-safe way in.
-            loop.call_soon_threadsafe(_schedule_broadcast, event_str)
+            # Sync endpoints and async producers on a foreign loop must both
+            # hand off: the lock and listener queues belong to serving_loop.
+            target_loop.call_soon_threadsafe(_schedule_broadcast, event_str)
     except RuntimeError:
         # The serving loop closed between capture and use (app shutdown).
         logger.debug("Event loop closed — event dropped: %s", kind)
-
-
-def _on_event_loop() -> bool:
-    """True when called from the running event loop (async-context emit)."""
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return False
-    return True
 
 
 def _schedule_broadcast(event_str: str) -> None:

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1112,6 +1112,10 @@ class _WatermarkExecutor(Executor):
                 self._thread is None or not self._thread.is_alive()
             )
 
+    def is_shutdown(self) -> bool:
+        with self._lock:
+            return self._shutdown
+
     def shutdown(
         self,
         wait: bool = True,
@@ -1150,7 +1154,10 @@ def begin_watermark_pool_lifecycle() -> None:
             and _watermark_pool_singleton.is_stopped()
         ):
             _watermark_pool_singleton = None
-        _watermark_pool_accepting = _watermark_pool_singleton is None
+        _watermark_pool_accepting = (
+            _watermark_pool_singleton is None
+            or not _watermark_pool_singleton.is_shutdown()
+        )
 
 
 def get_watermark_pool() -> _WatermarkExecutor:

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -286,6 +286,36 @@ def mark_synthetic(
     return marked
 
 
+async def mark_synthetic_async(
+    waveform: torch.Tensor,
+    sample_rate: int,
+    *,
+    context: str,
+    force: bool = False,
+    timeout: float | None = None,
+) -> torch.Tensor:
+    """Dispatch marking without letting a draining pool lose finished audio."""
+    import asyncio
+    import functools
+
+    from services.model_manager import get_watermark_pool, run_on_gpu_pool_guarded
+
+    try:
+        pool = get_watermark_pool()
+    except RuntimeError:
+        logger.warning("Watermark skipped while the prior worker is shutting down")
+        return waveform
+
+    job = functools.partial(
+        mark_synthetic, waveform, sample_rate, context=context, force=force
+    )
+    if timeout is not None:
+        return await run_on_gpu_pool_guarded(
+            job, what="Audio watermark", timeout=timeout, executor=pool
+        )
+    return await asyncio.get_running_loop().run_in_executor(pool, job)
+
+
 @torch.no_grad()
 def embed_watermark(
     waveform: torch.Tensor,

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -807,6 +807,15 @@ VoiceStudio now tries, in order: the default GitHub host → a gh-proxy mirror �
 
 **Linked issues:** [#130](https://github.com/debpalash/VoiceStudio/issues/130), [#60](https://github.com/debpalash/VoiceStudio/issues/60), [#57](https://github.com/debpalash/VoiceStudio/issues/57)
 
+## Workspace navigation crashes with `insertBefore` / `NotFoundError`
+
+This was a `v0.5.0` workspace-lifecycle bug exposed by rapid Launchpad ↔ Dub
+navigation while media renderers were cleaning up. Current builds isolate each
+workspace under its own DOM owner. Update VoiceStudio; no model or project data
+repair is required.
+
+**Linked issue:** [#1590](https://github.com/debpalash/VoiceStudio/issues/1590)
+
 ## Uninstalling / removing all of VoiceStudio's data
 
 VoiceStudio is fully local — no accounts, no services, nothing to deactivate. To

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -878,13 +878,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
 
     if destination.exists() {
         if backup.exists() {
-            // Both survived an unusual interruption. Keep the backup as the
-            // rollback copy until replacement succeeds; the destination is
-            // redundant while that verified backup exists.
-            fs::remove_dir_all(&destination)?;
-        } else {
-            fs::rename(&destination, &backup)?;
+            // An interrupted cleanup can leave an incomplete backup. Remove
+            // it before touching the known-working destination; if cleanup
+            // fails, abort with the live shell still intact.
+            fs::remove_dir_all(&backup)?;
         }
+        fs::rename(&destination, &backup)?;
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2217,6 +2216,31 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working backup shell"
+        );
+    }
+
+    #[test]
+    fn interrupted_backup_cleanup_failure_preserves_working_destination() {
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&installed).unwrap();
+        fs::write(installed.join("index.html"), "working shell").unwrap();
+        // A non-directory at the interrupted backup path makes cleanup fail
+        // and would also prevent the live destination from being renamed.
+        fs::write(&backup, "partial backup").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working shell"
         );
     }
 

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -864,8 +864,12 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     if staging.exists() {
         fs::remove_dir_all(&staging)?;
     }
-    if backup.exists() {
-        fs::remove_dir_all(&backup)?;
+    // A previous process may have died after moving the live shell aside but
+    // before installing staging. Restore the only known-good SPA before doing
+    // any new work; never discard that recovery copy merely because startup
+    // retried.
+    if !destination.exists() && backup.exists() {
+        fs::rename(&backup, &destination)?;
     }
     if let Err(error) = copy_dir_recursive(&source, &staging) {
         let _ = fs::remove_dir_all(&staging);
@@ -873,7 +877,14 @@ fn sync_packaged_frontend(resource_root: &Path, project_dir: &Path) -> io::Resul
     }
 
     if destination.exists() {
-        fs::rename(&destination, &backup)?;
+        if backup.exists() {
+            // Both survived an unusual interruption. Keep the backup as the
+            // rollback copy until replacement succeeds; the destination is
+            // redundant while that verified backup exists.
+            fs::remove_dir_all(&destination)?;
+        } else {
+            fs::rename(&destination, &backup)?;
+        }
     }
     if let Err(error) = fs::rename(&staging, &destination) {
         if backup.exists() {
@@ -2180,6 +2191,32 @@ mod tests {
         assert_eq!(
             fs::read_to_string(installed.join("index.html")).unwrap(),
             "working shell"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interrupted_frontend_swap_recovers_backup_before_a_later_copy_failure() {
+        use std::os::unix::fs::symlink;
+
+        let resources = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let source = resources.path().join("frontend").join("dist");
+        fs::create_dir_all(source.join("assets")).unwrap();
+        fs::write(source.join("index.html"), "new shell").unwrap();
+        symlink("missing-client.js", source.join("assets").join("client.js")).unwrap();
+
+        let frontend = project.path().join("frontend");
+        let installed = frontend.join("dist");
+        let backup = frontend.join(".dist-backup");
+        fs::create_dir_all(&backup).unwrap();
+        fs::write(backup.join("index.html"), "working backup shell").unwrap();
+
+        sync_packaged_frontend(resources.path(), project.path()).unwrap_err();
+
+        assert_eq!(
+            fs::read_to_string(installed.join("index.html")).unwrap(),
+            "working backup shell"
         );
     }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { useAppStore, FONT_STACKS } from './store';
 import { NAV_ITEMS } from './components/navItems';
 import SearchableSelect from './components/SearchableSelect';
 import DirectionDialog from './components/DirectionDialog';
+import { resolveDubDefaultTrack } from './utils/dubDefaultTrack';
 
 // Lazy-load heavy/conditional components so they don't bloat the initial bundle.
 const AudioTrimmer = lazy(() => import('./components/AudioTrimmer'));
@@ -949,7 +950,7 @@ function App() {
     });
     const tracksParam = selected.join(',');
     const burnParam = burnSubs ? `&burn_subs=1&dual=${dualSubs ? 1 : 0}` : '';
-    const resolvedDefaultTrack = defaultTrack || dubLangCode || dubTracks[0] || '';
+    const resolvedDefaultTrack = resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks);
     triggerDownload(
       `${API}/dub/download/${dubJobId}/dubbed_video.mp4?preserve_bg=${preserveBg}&default_track=${resolvedDefaultTrack}&include_tracks=${encodeURIComponent(tracksParam)}${burnParam}`,
       'dubbed_video.mp4',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import { useAppStore, FONT_STACKS } from './store';
 import { NAV_ITEMS } from './components/navItems';
 import SearchableSelect from './components/SearchableSelect';
 import DirectionDialog from './components/DirectionDialog';
+import ModeLifecycleBoundary from './components/ModeLifecycleBoundary';
 import { resolveDubDefaultTrack } from './utils/dubDefaultTrack';
 
 // Lazy-load heavy/conditional components so they don't bloat the initial bundle.
@@ -1451,7 +1452,7 @@ function App() {
         <NavRail mode={mode} setMode={setMode} side={navRailSide} onFlipSide={flipNavRailSide} />
       )}
 
-      <div className="main-content">
+      <ModeLifecycleBoundary mode={mode}>
         {/* ═══ LAUNCHPAD TAB ═══ */}
         {mode === 'settings' ? (
           <ErrorBoundary name="settings">
@@ -1779,7 +1780,7 @@ function App() {
             </div>
           </div>
         )}
-      </div>
+      </ModeLifecycleBoundary>
 
       {/* ── SIDEBAR ── */}
       <Suspense fallback={<LazyFallback />}>

--- a/frontend/src/components/ModeLifecycleBoundary.jsx
+++ b/frontend/src/components/ModeLifecycleBoundary.jsx
@@ -1,0 +1,17 @@
+/**
+ * Owns the DOM subtree for one top-level workspace.
+ *
+ * Some workspaces host imperative renderers (WaveSurfer, media elements, and
+ * portals). Replacing the host when navigation changes prevents a late
+ * renderer cleanup from mutating the next workspace's React-owned DOM.
+ */
+export default function ModeLifecycleBoundary({ mode, children }) {
+  return (
+    <Fragment>
+      <div key={mode} className="main-content" data-mode={mode}>
+        {children}
+      </div>
+    </Fragment>
+  );
+}
+import { Fragment } from 'react';

--- a/frontend/src/components/ModeLifecycleBoundary.test.jsx
+++ b/frontend/src/components/ModeLifecycleBoundary.test.jsx
@@ -1,16 +1,22 @@
 import { useLayoutEffect, useRef } from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import ModeLifecycleBoundary from './ModeLifecycleBoundary';
 
 function ImperativeWorkspace({ name }) {
   const hostRef = useRef(null);
 
   useLayoutEffect(() => {
+    const host = hostRef.current;
     const owned = document.createElement('div');
     owned.dataset.owner = name;
-    hostRef.current.appendChild(owned);
-    return () => owned.remove();
+    host.appendChild(owned);
+    return () => {
+      // Model a renderer whose asynchronous destroy completes after React has
+      // committed the next route. If the DOM host were reused, this would
+      // erase that route's children and recreate the reported ownership race.
+      setTimeout(() => host.replaceChildren(), 0);
+    };
   }, [name]);
 
   return <section ref={hostRef}>{name}</section>;
@@ -18,6 +24,7 @@ function ImperativeWorkspace({ name }) {
 
 describe('ModeLifecycleBoundary', () => {
   it('replaces the DOM owner throughout the reported rapid navigation loop', () => {
+    vi.useFakeTimers();
     const sequence = ['launchpad', 'dub', 'dub', 'launchpad', 'dub'];
     const view = render(
       <ModeLifecycleBoundary mode={sequence[0]}>
@@ -41,8 +48,12 @@ describe('ModeLifecycleBoundary', () => {
         expect(nextHost).toBe(previousHost);
       }
       expect(nextHost.querySelector('[data-owner]')?.dataset.owner).toBe(mode);
+      vi.runAllTimers();
+      expect(nextHost.textContent).toContain(mode);
+      expect(nextHost.querySelector('[data-owner]')?.dataset.owner).toBe(mode);
       previousHost = nextHost;
       previousMode = mode;
     }
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/components/ModeLifecycleBoundary.test.jsx
+++ b/frontend/src/components/ModeLifecycleBoundary.test.jsx
@@ -1,0 +1,48 @@
+import { useLayoutEffect, useRef } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ModeLifecycleBoundary from './ModeLifecycleBoundary';
+
+function ImperativeWorkspace({ name }) {
+  const hostRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const owned = document.createElement('div');
+    owned.dataset.owner = name;
+    hostRef.current.appendChild(owned);
+    return () => owned.remove();
+  }, [name]);
+
+  return <section ref={hostRef}>{name}</section>;
+}
+
+describe('ModeLifecycleBoundary', () => {
+  it('replaces the DOM owner throughout the reported rapid navigation loop', () => {
+    const sequence = ['launchpad', 'dub', 'dub', 'launchpad', 'dub'];
+    const view = render(
+      <ModeLifecycleBoundary mode={sequence[0]}>
+        <ImperativeWorkspace name={sequence[0]} />
+      </ModeLifecycleBoundary>,
+    );
+    let previousHost = view.container.firstElementChild;
+    let previousMode = sequence[0];
+
+    for (const mode of sequence.slice(1)) {
+      view.rerender(
+        <ModeLifecycleBoundary mode={mode}>
+          <ImperativeWorkspace name={mode} />
+        </ModeLifecycleBoundary>,
+      );
+      const nextHost = view.container.firstElementChild;
+      if (mode !== previousMode) {
+        expect(nextHost).not.toBe(previousHost);
+        expect(previousHost.isConnected).toBe(false);
+      } else {
+        expect(nextHost).toBe(previousHost);
+      }
+      expect(nextHost.querySelector('[data-owner]')?.dataset.owner).toBe(mode);
+      previousHost = nextHost;
+      previousMode = mode;
+    }
+  });
+});

--- a/frontend/src/components/dub/DubRightColumn.jsx
+++ b/frontend/src/components/dub/DubRightColumn.jsx
@@ -5,6 +5,7 @@ import GlossaryPanel from '../GlossaryPanel';
 import CheckpointBanner from '../CheckpointBanner';
 import { LANG_CODES } from '../../utils/languages';
 import { autoProfileId } from '../../utils/segments';
+import { resolveDubDefaultTrack } from '../../utils/dubDefaultTrack';
 
 const DubSegmentTable = lazy(() => import('../DubSegmentTable'));
 const DubPasteTranslationDialog = lazy(() => import('./DubPasteTranslationDialog'));
@@ -118,7 +119,7 @@ export default function DubRightColumn({
             {t('dub.default_track')}
             <select
               className="input-base !text-[0.6rem] !px-[4px] !py-[2px] !w-[120px]"
-              value={defaultTrack || dubLangCode || dubTracks[0] || 'original'}
+              value={resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks)}
               onChange={(e) => setDefaultTrack(e.target.value)}
             >
               <option value="original">{t('dub.original_track')}</option>

--- a/frontend/src/components/dub/DubRightColumn.test.jsx
+++ b/frontend/src/components/dub/DubRightColumn.test.jsx
@@ -8,7 +8,7 @@ import DubRightColumn from './DubRightColumn';
 
 const noop = () => {};
 
-function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop) {
+function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop, overrides = {}) {
   return (
     <DubRightColumn
       t={(key) => key}
@@ -46,6 +46,7 @@ function column(multiBatchBusy, setDubLang = noop, setDubLangCode = noop) {
       isTranslating={false}
       dubSegments={[]}
       dubStep="editing"
+      {...overrides}
     />
   );
 }
@@ -73,5 +74,17 @@ describe('DubRightColumn language targets', () => {
     });
     expect(setDubLang).toHaveBeenCalledWith('Spanish');
     expect(setDubLangCode).toHaveBeenCalledWith('es');
+  });
+
+  it('renders the first available dub when the saved default is stale', () => {
+    render(
+      column(false, noop, noop, {
+        defaultTrack: 'fr',
+        dubLangCode: 'bn',
+        dubTracks: ['es'],
+      }),
+    );
+
+    expect(screen.getByRole('combobox', { name: 'dub.default_track' })).toHaveValue('es');
   });
 });

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -191,7 +191,12 @@ export const useAppStore = create<AppStore>()(
         if (version < 4) {
           // v1 → v2 added reviewMode; v2 → v3 added mode/sidebar/generate knobs;
           // v3 → v4 added timingStrategy. All of those have slice defaults, so
-          // passing through is sufficient — then fall through to the < 5 branch.
+          // v3 and earlier had no timingStrategy field and therefore behaved
+          // as concise. Preserve that historical behavior for existing
+          // envelopes; only fresh/v4+ records inherit today's strict default.
+          if (!Object.prototype.hasOwnProperty.call(p, 'timingStrategy')) {
+            p.timingStrategy = 'concise';
+          }
         }
         if (version < 5) {
           // #31: each saved Stories project becomes a LongformProject. Defaults

--- a/frontend/src/store/timingStrategyMigration.test.ts
+++ b/frontend/src/store/timingStrategyMigration.test.ts
@@ -24,6 +24,12 @@ describe('timing-strategy v8 migration', () => {
     expect(useAppStore.getState().timingStrategy).toBe('strict_slot');
   });
 
+  it('keeps the historical concise behavior for pre-v4 persisted installs', async () => {
+    await rehydrate({ translateQuality: 'fast' }, 3);
+
+    expect(useAppStore.getState().timingStrategy).toBe('concise');
+  });
+
   it('preserves every explicit timing choice from v7', async () => {
     for (const timingStrategy of ['concise', 'smart_fit', 'stretch_video', 'strict_slot']) {
       useAppStore.setState(useAppStore.getInitialState(), true);

--- a/frontend/src/test/initialLoadRetry.test.js
+++ b/frontend/src/test/initialLoadRetry.test.js
@@ -101,4 +101,51 @@ describe('loadLatest', () => {
     expect(apply).toHaveBeenCalledOnce();
     expect(apply).toHaveBeenCalledWith(['new']);
   });
+
+  it('retries when a stale initial success is discarded after a newer reload fails', async () => {
+    let resolveInitial;
+    let rejectReload;
+    const initial = new Promise((resolve) => {
+      resolveInitial = resolve;
+    });
+    const reload = new Promise((_resolve, reject) => {
+      rejectReload = reject;
+    });
+    const generations = {};
+    const apply = vi.fn();
+    const fetch = vi
+      .fn()
+      .mockReturnValueOnce(initial)
+      .mockReturnValueOnce(reload)
+      .mockResolvedValueOnce(['recovered']);
+
+    const initialLoad = retryInitialLoad(
+      () =>
+        loadLatest({
+          generations,
+          key: 'profiles',
+          fetch,
+          apply,
+          label: 'profiles',
+          rethrow: true,
+        }),
+      { baseDelayMs: 1 },
+    );
+    const websocketReload = loadLatest({
+      generations,
+      key: 'profiles',
+      fetch,
+      apply,
+      label: 'profiles',
+    });
+
+    rejectReload(new Error('reload failed'));
+    await websocketReload;
+    resolveInitial(['stale']);
+    await initialLoad;
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(apply).toHaveBeenCalledOnce();
+    expect(apply).toHaveBeenCalledWith(['recovered']);
+  });
 });

--- a/frontend/src/utils/dubDefaultTrack.js
+++ b/frontend/src/utils/dubDefaultTrack.js
@@ -1,0 +1,7 @@
+/** Resolve the effective export track against tracks that actually exist. */
+export function resolveDubDefaultTrack(defaultTrack, dubLangCode, dubTracks = []) {
+  if (defaultTrack === 'original') return 'original';
+  if (dubTracks.includes(defaultTrack)) return defaultTrack;
+  if (dubTracks.includes(dubLangCode)) return dubLangCode;
+  return dubTracks[0] || 'original';
+}

--- a/frontend/src/utils/initialLoadRetry.js
+++ b/frontend/src/utils/initialLoadRetry.js
@@ -18,8 +18,8 @@ export async function retryInitialLoad(loader, opts = {}) {
   for (;;) {
     if (opts.cancelled) return;
     try {
-      await loader();
-      return;
+      const applied = await loader();
+      if (applied !== false) return;
     } catch {
       // transient — retry
     }
@@ -34,9 +34,12 @@ export async function loadLatest({ generations, key, fetch, apply, label, rethro
   generations[key] = generation;
   try {
     const data = await fetch();
-    if (generation === generations[key]) apply(data);
+    if (generation !== generations[key]) return false;
+    apply(data);
+    return true;
   } catch (error) {
     console.warn(`Failed to load ${label}:`, error);
     if (rethrow) throw error;
+    return false;
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,21 @@ import pytest
 import warnings as _warnings
 
 
+# App lifespans deliberately close watermark admission during shutdown. The
+# test process then keeps running and many route tests call handlers without
+# starting another lifespan, so restore the equivalent of a fresh lifespan at
+# every test boundary. ``begin_watermark_pool_lifecycle`` still refuses to
+# reopen while a timed-out worker is genuinely alive, preserving that race
+# signal instead of hiding it.
+@pytest.fixture(autouse=True)
+def _watermark_pool_lifecycle_baseline():
+    model_manager = sys.modules.get("services.model_manager")
+    begin = getattr(model_manager, "begin_watermark_pool_lifecycle", None)
+    if callable(begin):
+        begin()
+    yield
+
+
 # ── torch default-dtype isolation (CI flaky trio) ───────────────────────────
 # Three tests (test_effects_chain / test_generation_audio_guard /
 # test_persona_bundle) fail intermittently on CI — never locally — with

--- a/tests/test_desktop_prod_scripts.py
+++ b/tests/test_desktop_prod_scripts.py
@@ -33,6 +33,37 @@ _APPIMAGE_PROCESSES = os.path.join(_ROOT, "scripts", "desktop_prod_processes.py"
 _RELAUNCH_SCRIPTS = ("desktop-prod:run", "desktop-prod:run:pill")
 
 
+def _supported_bash() -> str | None:
+    """Return a native shell capable of executing desktop-prod.sh."""
+    if os.name == "nt":
+        roots = filter(
+            None,
+            (
+                os.environ.get("ProgramFiles"),
+                os.environ.get("ProgramFiles(x86)"),
+                os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs"),
+            ),
+        )
+        for root in roots:
+            for relative in (("Git", "bin", "bash.exe"), ("Git", "usr", "bin", "bash.exe")):
+                candidate = os.path.join(root, *relative)
+                if os.path.isfile(candidate):
+                    return candidate
+
+    candidate = shutil.which("bash")
+    if candidate and not (os.name == "nt" and "\\system32\\" in candidate.lower()):
+        return candidate
+    return None
+
+
+def test_desktop_prod_execution_does_not_require_posix_bin_bash():
+    """The smoke seam must also collect on native Windows runners."""
+    with open(__file__, encoding="utf-8") as fh:
+        source = fh.read()
+    posix_only_invocation = '["' + "/bin/" + 'bash", fixture_script'
+    assert posix_only_invocation not in source
+
+
 def _scripts() -> dict:
     with open(_PKG, encoding="utf-8") as fh:
         return json.load(fh)["scripts"]
@@ -262,8 +293,11 @@ def test_linux_process_stop_executes_before_data_wipe(tmp_path):
             "PATH": f"{fake_bin}:/usr/bin:/bin",
         }
     )
+    bash = _supported_bash()
+    if bash is None:
+        pytest.skip("desktop-prod.sh smoke requires Bash (for example Git Bash on Windows)")
     result = subprocess.run(
-        ["/bin/bash", fixture_script, "--skip-build"],  # noqa: S603
+        [bash, fixture_script, "--skip-build"],  # noqa: S603
         cwd=fixture_root,
         env=env,
         capture_output=True,

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -103,6 +103,31 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    def test_excluded_default_resolves_before_retime_and_subtitle_selection(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        selected = []
+
+        def capture_default(_job, lang):
+            selected.append(lang)
+            return None
+
+        with (
+            patch.object(dx, "_video_retime_plan_for", side_effect=capture_default),
+            patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)),
+        ):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={
+                    "preserve_bg": False,
+                    "default_track": "fr",
+                    "include_tracks": "original,es",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        assert selected == ["es"]
+
     @pytest.mark.skipif(
         shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
         reason="ffmpeg and ffprobe are required for the container regression",
@@ -112,7 +137,7 @@ class TestDubExportUniqueness:
         client, dc, _dx, tmp = app_client
         job_id, job_dir = _seed_job_with_tracks(dc, tmp)
         video_path = job_dir / "original.mp4"
-        subprocess.run(
+        subprocess.run(  # noqa: S603 -- fixed test binary and argument vector
             [
                 shutil.which("ffmpeg"), "-loglevel", "error", "-y",
                 "-f", "lavfi", "-i", "color=c=black:s=32x32:d=0.5",
@@ -129,7 +154,7 @@ class TestDubExportUniqueness:
         )
         assert response.status_code == 200, response.text
         exported = next((job_dir / "exports").glob("dubbed_video_*.mp4"))
-        probe = subprocess.run(
+        probe = subprocess.run(  # noqa: S603 -- fixed ffprobe inspection command
             [
                 shutil.which("ffprobe"), "-v", "error", "-select_streams", "a",
                 "-show_entries", "stream_tags=title:stream_disposition=default",

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -103,6 +103,25 @@ _SUBPROC_ATTR = "create_subprocess_" + "exec"  # dodge overzealous code-scan hoo
 
 
 class TestDubExportUniqueness:
+    def test_original_only_resolves_stale_default_before_retime(self, app_client):
+        client, dc, dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        with (
+            patch.object(dx, "_video_retime_plan_for") as retime_for,
+            patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)),
+        ):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={
+                    "preserve_bg": False,
+                    "default_track": "fr",
+                    "include_tracks": "original",
+                },
+            )
+
+        assert response.status_code == 200, response.text
+        retime_for.assert_not_called()
+
     def test_excluded_default_resolves_before_retime_and_subtitle_selection(self, app_client):
         client, dc, dx, tmp = app_client
         job_id, _ = _seed_job_with_tracks(dc, tmp)

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -228,7 +228,7 @@ class TestAudioOnlyDubbing:
             )
 
         assert r.status_code == 200, r.text
-        audio_files = sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        audio_files = sorted(exports_dir.glob("dubbed_audio_*.m4a"))
         assert len(audio_files) == 1, [f.name for f in audio_files]
         # The video-mux path must NOT have run for an audio job.
         assert not list(exports_dir.glob("dubbed_video_*.mp4"))
@@ -244,7 +244,7 @@ class TestAudioOnlyDubbing:
             r = client.get(f"/dub/download/{job_id}", params={"preserve_bg": False, "out_format": "weird"})
 
         assert r.status_code == 200, r.text
-        assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
+        assert sorted(exports_dir.glob("dubbed_audio_*.m4a"))
 
     def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
         client, dc, _dx, tmp = app_client

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -221,6 +221,24 @@ class TestAudioOnlyDubbing:
         assert r.status_code == 200, r.text
         assert sorted(exports_dir.glob("dubbed_audio_es_*.m4a"))
 
+    def test_audio_only_download_label_rejects_traversal_and_control_chars(self, app_client):
+        client, dc, _dx, tmp = app_client
+        job_id, _ = _seed_job_with_tracks(dc, tmp)
+        dc._dub_jobs[job_id]["input_type"] = "audio"
+        dc._dub_jobs[job_id]["filename"] = "../evil\r\nX-Injected: yes.mp4"
+
+        with patch.object(_asyncio, _SUBPROC_ATTR, side_effect=_fake_ffmpeg_factory(True)):
+            response = client.get(
+                f"/dub/download/{job_id}",
+                params={"preserve_bg": False, "default_track": "es"},
+            )
+
+        assert response.status_code == 200, response.text
+        label = response.headers["content-disposition"]
+        assert ".." not in label
+        assert "\r" not in label and "\n" not in label
+        assert "X-Injected:" not in label
+
     def test_upload_rejects_video_ext_when_audio_mode(self, app_client):
         client, dc, dx, tmp = app_client
         r = client.post(

--- a/tests/test_event_bus_thread_emit.py
+++ b/tests/test_event_bus_thread_emit.py
@@ -66,6 +66,58 @@ def test_emit_from_thread_reaches_serving_loop(bus, tmp_path):
         loop.close()
 
 
+def test_emit_from_foreign_running_loop_reaches_serving_loop(bus):
+    """An async producer may run on a worker loop, but listener state belongs
+    to the WebSocket serving loop and must only be touched there."""
+    serving_loop = asyncio.new_event_loop()
+    serving_loop.set_debug(True)
+    received: list[str] = []
+    started = threading.Event()
+    done = threading.Event()
+
+    async def serve_with_waiter_ready():
+        q = await bus.subscribe()
+        waiter = asyncio.create_task(q.get())
+        await asyncio.sleep(0)  # q.get() has installed its serving-loop Future
+        started.set()
+        try:
+            received.append(await asyncio.wait_for(waiter, 0.5))
+        except asyncio.TimeoutError:
+            pass
+        finally:
+            done.set()
+            await bus.unsubscribe(q)
+
+    def run_serving_loop():
+        asyncio.set_event_loop(serving_loop)
+        serving_loop.run_until_complete(serve_with_waiter_ready())
+
+    serving_thread = threading.Thread(
+        target=run_serving_loop, name="test-serving-loop"
+    )
+    serving_thread.start()
+    try:
+        assert started.wait(2.0), "serving loop never subscribed"
+
+        async def foreign_async_caller():
+            assert asyncio.get_running_loop() is not serving_loop
+            bus.emit("profiles", {"action": "updated", "id": "foreign-loop"})
+            await asyncio.sleep(0.05)
+
+        asyncio.run(foreign_async_caller())
+
+        assert done.wait(2.0), (
+            "emit() ran listener delivery on the caller's foreign loop"
+        )
+        assert received, "foreign-loop event never reached the serving loop"
+        payload = json.loads(received[0])
+        assert payload["id"] == "foreign-loop"
+    finally:
+        serving_loop.call_soon_threadsafe(done.set)
+        serving_thread.join(2.0)
+        serving_loop.close()
+
+
 async def _serve(bus, received: list[str], started: threading.Event, done: threading.Event):
     q = await bus.subscribe()
     started.set()

--- a/tests/test_watermark_prefetch_coldstart.py
+++ b/tests/test_watermark_prefetch_coldstart.py
@@ -274,7 +274,7 @@ def test_watermark_pool_shutdown_deadline_bounds_stuck_worker():
     pool._thread.join(timeout=1)
 
 
-def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
+def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive(watermark):
     """A producer racing bounded shutdown cannot create an undrained pool."""
     from services.model_manager import (
         begin_watermark_pool_lifecycle,
@@ -303,6 +303,18 @@ def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
         begin_watermark_pool_lifecycle()
         with pytest.raises(RuntimeError, match="shutting down"):
             get_watermark_pool()
+        # Finished synthesis must still be returned unchanged: pool admission
+        # is outside mark_synthetic's synchronous fail-open boundary.
+        import asyncio
+        import torch
+
+        audio = torch.zeros(1, 240)
+        marked = asyncio.run(
+            watermark.mark_synthetic_async(
+                audio, 24000, context="test.restart_during_shutdown"
+            )
+        )
+        assert marked is audio
     finally:
         release.set()
         pool._thread.join(timeout=1)

--- a/tests/test_watermark_prefetch_coldstart.py
+++ b/tests/test_watermark_prefetch_coldstart.py
@@ -210,7 +210,6 @@ def test_watermark_pool_rebuilds_after_shutdown_drain():
     assert get_watermark_pool().submit(lambda: "ok").result(timeout=5) == "ok"
     # Clean up the replacement so later tests start from a fresh pool too.
     shutdown_watermark_pool()
-    begin_watermark_pool_lifecycle()
 
 
 def test_watermark_pool_shutdown_waits_for_active_worker():
@@ -241,7 +240,6 @@ def test_watermark_pool_shutdown_waits_for_active_worker():
     release.set()
     shutdown_thread.join(timeout=2)
     assert shutdown_done.is_set()
-    begin_watermark_pool_lifecycle()
 
 
 def test_watermark_pool_shutdown_deadline_bounds_stuck_worker():
@@ -274,7 +272,6 @@ def test_watermark_pool_shutdown_deadline_bounds_stuck_worker():
     assert pool._thread is not None and pool._thread.daemon
     release.set()
     pool._thread.join(timeout=1)
-    begin_watermark_pool_lifecycle()
 
 
 def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
@@ -316,7 +313,6 @@ def test_watermark_pool_cannot_be_replaced_while_timed_out_worker_is_alive():
     assert replacement is not pool
     assert replacement.submit(lambda: "ok").result(timeout=1) == "ok"
     shutdown_watermark_pool()
-    begin_watermark_pool_lifecycle()
 
 
 def test_prefetched_model_gets_one_extra_idle_window(monkeypatch, watermark):


### PR DESCRIPTION
Fixes #1590.\n\nRapid Launchpad ↔ Dub navigation now replaces the top-level workspace DOM owner, isolating React from late cleanup by imperative media renderers. Includes the reported transition loop regression, troubleshooting docs, and changelog credit.