### PR TITLE
fix(watermark): run AudioSeal eagerly instead of through torch.compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The backend now answers within a second of launch and narrates its startup step by step
 - Reporting a bug from an outdated build now offers the latest release first
 - The backend is only announced ready once it can actually serve, and crash-loop restarts now pace themselves
+- Invisible watermarking no longer stalls — or silently skips — the first take of a session
 
 ### Changed
 - The backend binds its port immediately and reports startup progress live — `/health` answers 503-with-step and a new `/startup/progress` endpoint lists every step while PyTorch, API routes, and database migrations load in the background, so "starting at step X" is never mistakable for "dead"; the desktop splash narrates each step (#1550)
@@ -32,6 +33,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- Invisible watermarking now runs eagerly instead of through `torch.compile` — AudioSeal's lazy compile sent the first embed of every session into Inductor's C++ codegen, which failed outright on macOS hosts whose toolchain couldn't serve it and shipped the audio unmarked after a 30-40s wait; first embed drops from 9.70s to 0.26s (#1615) — thanks @paoloantinori!
 - The dubbing editor's video and transcript columns can now be resized by pointer or keyboard, and the chosen split persists across launches (#1571) — thanks @invio-a11y!
 - CPU-only synthesis now gets a bounded ten-minute execution budget, and a render that exhausts it is reported as a compute timeout instead of misleading "generation capacity is busy" queue pressure (#1588) — thanks @ChienNguyen1111!
 - Rapid Launchpad ↔ Dub navigation now replaces the workspace DOM owner cleanly, so late media/waveform cleanup cannot trigger React's `insertBefore` crash (#1590) — thanks @nicolas-jacques!

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -96,8 +96,10 @@ def _moshi_compile_module():
 
 
 _eager_lock = threading.Lock()
-_eager_depth = 0
-_eager_saved: Optional[bool] = None
+#: Depth of nested/concurrent eager scopes, and the switch value to put back
+#: when the last one exits. One dict rather than two module scalars: the
+#: fields are only meaningful together, and only under _eager_lock.
+_eager_state: dict = {"depth": 0, "saved": None}
 _eager_guard_warned = False
 
 
@@ -126,7 +128,6 @@ def _eager_audioseal():
     (``tests/test_watermark_no_torch_compile_1615.py`` fails loudly on that
     upgrade rather than letting the compile creep back in).
     """
-    global _eager_depth, _eager_saved
     moshi = _moshi_compile_module()
     if moshi is None:
         if not _eager_guard_warned:
@@ -134,18 +135,18 @@ def _eager_audioseal():
         yield
         return
     with _eager_lock:
-        if _eager_depth == 0:
-            _eager_saved = moshi._compile_disabled
-        _eager_depth += 1
+        if _eager_state["depth"] == 0:
+            _eager_state["saved"] = moshi._compile_disabled
+        _eager_state["depth"] += 1
         moshi._compile_disabled = True
     try:
         yield
     finally:
         with _eager_lock:
-            _eager_depth -= 1
-            if _eager_depth == 0:
-                moshi._compile_disabled = _eager_saved
-                _eager_saved = None
+            _eager_state["depth"] -= 1
+            if _eager_state["depth"] == 0:
+                moshi._compile_disabled = _eager_state["saved"]
+                _eager_state["saved"] = None
 
 
 def _iter_chunks(audio: torch.Tensor, sample_rate: int):

--- a/backend/services/watermark.py
+++ b/backend/services/watermark.py
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import math
 import os
@@ -66,6 +67,64 @@ OMNI_MESSAGE = [0, 1, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1]
 # 30 s bounds each call to tens of MB; the 16-bit message repeats throughout
 # the audio, so per-chunk embedding/detection is equivalent.
 _CHUNK_SECONDS = 30
+
+
+# AudioSeal vendors moshi's ``@torch_compile_lazy`` on SEANetEncoder.forward,
+# so the first EMBED — not the model load, which prefetch already warms —
+# calls torch.compile and drops into Inductor's C++ codegen. On hosts whose
+# C++ toolchain can't serve Inductor that compile raises CppCompileError, the
+# embed fail-opens, and audio ships unmarked: a macOS arm64 deployment lost
+# provenance marking on 10/10 takes while paying 30-40 s for the first failed
+# compile and 5-8 s for each later one (#1615).
+#
+# The compile is pure cost even where it succeeds. Measured on an M3 (5 s of
+# 24 kHz audio, three consecutive embeds): compiled 9.70 / 0.26 / 0.23 s vs
+# eager 0.30 / 0.28 / 0.27 s — a ~10 s first-embed tax to save ~0.03 s per
+# later embed, on CPU work that is already bounded by the 30 s chunk loop.
+# So watermarking runs eager on every platform.
+def _moshi_no_compile():
+    """AudioSeal's vendored ``no_compile`` context manager, or None.
+
+    Resolved per call rather than at import: ``_check_available()`` is what
+    guarantees audioseal is importable, and it runs later than this module.
+    """
+    try:
+        from audioseal.libs.moshi.utils.compile import no_compile
+    except Exception:  # noqa: BLE001 — any import shape change degrades, not crashes
+        return None
+    return no_compile
+
+
+@contextlib.contextmanager
+def _eager_audioseal():
+    """Run the AudioSeal model eagerly, restoring the switch on the way out.
+
+    ``no_compile`` flips a process-global in the vendored moshi module, so it
+    must not stay latched past this block — other models in the backend are
+    entitled to torch.compile. Degrades to a plain call if a future audioseal
+    drops the helper (``tests/test_watermark_no_torch_compile_1615.py`` fails
+    loudly on that upgrade rather than letting the compile creep back in).
+    """
+    no_compile = _moshi_no_compile()
+    if no_compile is None:
+        if not _eager_guard_warned:
+            _warn_missing_eager_guard()
+        yield
+        return
+    with no_compile():
+        yield
+
+
+_eager_guard_warned = False
+
+
+def _warn_missing_eager_guard() -> None:
+    global _eager_guard_warned
+    _eager_guard_warned = True
+    logger.info(
+        "audioseal's no_compile switch is unavailable — watermarking may run "
+        "through torch.compile and pay (or fail) an Inductor C++ compile (#1615)."
+    )
 
 
 def _iter_chunks(audio: torch.Tensor, sample_rate: int):
@@ -385,13 +444,14 @@ def embed_watermark(
 
         # AudioSeal operates at 16kHz internally; it handles resampling, but
         # we need to inform it of the source rate for correct embedding.
-        watermarked = torch.cat(
-            [
-                generator(seg, sample_rate=sample_rate, message=msg)
-                for seg in _iter_chunks(audio, sample_rate)
-            ],
-            dim=-1,
-        )
+        with _eager_audioseal():
+            watermarked = torch.cat(
+                [
+                    generator(seg, sample_rate=sample_rate, message=msg)
+                    for seg in _iter_chunks(audio, sample_rate)
+                ],
+                dim=-1,
+            )
 
         # Restore original shape
         if len(original_shape) == 2:
@@ -449,12 +509,13 @@ def detect_watermark(
         # embedding does, and a splice where only part of the file is
         # VoiceStudio audio still registers (a whole-file average would dilute it).
         best_conf, decoded_msg = -1.0, None
-        for seg in _iter_chunks(audio, sample_rate):
-            result = detector.detect_watermark(seg, sample_rate=sample_rate, message_threshold=0.5)
-            seg_conf = float(result[0]) if isinstance(result, tuple) else 0.0
-            if seg_conf > best_conf:
-                best_conf = seg_conf
-                decoded_msg = result[1] if isinstance(result, tuple) and len(result) > 1 else None
+        with _eager_audioseal():
+            for seg in _iter_chunks(audio, sample_rate):
+                result = detector.detect_watermark(seg, sample_rate=sample_rate, message_threshold=0.5)
+                seg_conf = float(result[0]) if isinstance(result, tuple) else 0.0
+                if seg_conf > best_conf:
+                    best_conf = seg_conf
+                    decoded_msg = result[1] if isinstance(result, tuple) and len(result) > 1 else None
         confidence = max(best_conf, 0.0)
 
         # Decode message bits

--- a/tests/test_watermark_no_torch_compile_1615.py
+++ b/tests/test_watermark_no_torch_compile_1615.py
@@ -84,8 +84,7 @@ def fakes(monkeypatch, watermark, moshi_compile):
     monkeypatch.setattr(watermark, "_detector", det)
     monkeypatch.setattr(watermark, "_audioseal_available", True)
     monkeypatch.setattr(watermark, "is_enabled", lambda: True)
-    monkeypatch.setattr(watermark, "_eager_depth", 0)
-    monkeypatch.setattr(watermark, "_eager_saved", None)
+    monkeypatch.setattr(watermark, "_eager_state", {"depth": 0, "saved": None})
     return gen, det
 
 
@@ -164,7 +163,8 @@ def test_overlapping_embeds_never_hand_compile_back(fakes, watermark, moshi_comp
             first_out.set()                      # closes while `second` is open
         except BaseException as exc:  # noqa: BLE001 — surfaced via the assert below
             errors.append(exc)
-            first_in.set(); first_out.set()
+            first_in.set()
+            first_out.set()
 
     def second():
         try:
@@ -179,10 +179,12 @@ def test_overlapping_embeds_never_hand_compile_back(fakes, watermark, moshi_comp
 
     t1 = threading.Thread(target=first, name="eager-first")
     t2 = threading.Thread(target=second, name="eager-second")
-    t1.start(); t2.start()
-    t1.join(timeout=15); t2.join(timeout=15)
+    t1.start()
+    t2.start()
+    t1.join(timeout=15)
+    t2.join(timeout=15)
 
     assert not errors, errors
     assert seen == [True], "compile was handed back mid-embed by the other scope's exit"
     assert moshi_compile._compile_disabled is False, "guard stayed latched after both exits"
-    assert watermark._eager_depth == 0
+    assert watermark._eager_state["depth"] == 0

--- a/tests/test_watermark_no_torch_compile_1615.py
+++ b/tests/test_watermark_no_torch_compile_1615.py
@@ -1,0 +1,130 @@
+"""AudioSeal must watermark eagerly — never through torch.compile (#1615).
+
+AudioSeal vendors moshi's ``@torch_compile_lazy`` on ``SEANetEncoder.forward``,
+so the FIRST embed (not the model load — #1577's prefetch loads fine) calls
+``torch.compile`` and drops into Inductor's C++ codegen. On a macOS arm64
+deployment that compile fails outright with ``CppCompileError`` on 10/10
+attempts: embedding then fail-opens, so audio ships UNMARKED — an EU AI Act
+Art. 50(2) provenance gap — after burning 30-40 s on the first take and 5-8 s
+on later ones.
+
+The compile is pure cost even where it succeeds. Measured on an M3 (5 s of
+24 kHz audio, three consecutive embeds):
+
+    compiled:  9.70 s, 0.26 s, 0.23 s
+    eager:     0.30 s, 0.28 s, 0.27 s
+
+A ~10 s first-embed tax to save 0.03 s per later embed — and a hard failure
+wherever the host's C++ toolchain can't serve Inductor. Watermarking is small
+CPU work behind a 30 s chunk loop; it runs eager.
+
+Fail-before/pass-after: on the pre-fix code the fakes below observe
+``_compile_disabled`` False while the generator/detector run.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from services import watermark
+from services.watermark import detect_watermark, embed_watermark
+
+SR = 24000
+
+
+def _moshi_compile_module():
+    """AudioSeal's vendored moshi compile switch, or None when unavailable."""
+    try:
+        from audioseal.libs.moshi.utils import compile as moshi_compile
+    except Exception:  # pragma: no cover — exercised via the skip below
+        return None
+    return moshi_compile
+
+
+class RecordingGenerator:
+    """Records whether compile was disabled at the moment it was called."""
+
+    def __init__(self, moshi_compile):
+        self._moshi = moshi_compile
+        self.compile_disabled: list[bool] = []
+
+    def __call__(self, audio, sample_rate, message=None):
+        self.compile_disabled.append(bool(self._moshi._compile_disabled))
+        return audio
+
+
+class RecordingDetector:
+    def __init__(self, moshi_compile):
+        self._moshi = moshi_compile
+        self.compile_disabled: list[bool] = []
+
+    def detect_watermark(self, audio, sample_rate, message_threshold=0.5):
+        self.compile_disabled.append(bool(self._moshi._compile_disabled))
+        return (0.9, torch.tensor(watermark.OMNI_MESSAGE))
+
+
+@pytest.fixture
+def moshi_compile():
+    mod = _moshi_compile_module()
+    if mod is None:
+        pytest.skip("audioseal not installed in this environment")
+    return mod
+
+
+@pytest.fixture
+def fakes(monkeypatch, moshi_compile):
+    gen = RecordingGenerator(moshi_compile)
+    det = RecordingDetector(moshi_compile)
+    monkeypatch.setattr(watermark, "_generator", gen)
+    monkeypatch.setattr(watermark, "_detector", det)
+    monkeypatch.setattr(watermark, "_audioseal_available", True)
+    monkeypatch.setattr(watermark, "is_enabled", lambda: True)
+    return gen, det
+
+
+def test_the_upstream_eager_switch_still_exists(moshi_compile):
+    """An audioseal bump that moves this seam must fail here, loudly, rather
+    than silently restoring the 30-40 s compile on every user's first take."""
+    assert hasattr(moshi_compile, "no_compile")
+    assert hasattr(moshi_compile, "_compile_disabled")
+
+
+def test_embedding_runs_the_generator_eagerly(fakes):
+    gen, _ = fakes
+    embed_watermark(torch.zeros(1, SR), SR)
+    assert gen.compile_disabled == [True]
+
+
+def test_detection_runs_the_detector_eagerly(fakes):
+    _, det = fakes
+    detect_watermark(torch.zeros(1, SR), SR)
+    assert det.compile_disabled == [True]
+
+
+def test_the_eager_guard_is_restored_after_the_call(fakes, moshi_compile):
+    """The switch is a process-global; leaving it latched would silently
+    disable compile for every other model in the backend."""
+    embed_watermark(torch.zeros(1, SR), SR)
+    assert moshi_compile._compile_disabled is False
+
+
+def test_the_eager_guard_is_restored_when_embedding_raises(monkeypatch, moshi_compile):
+    def boom(*_a, **_k):
+        raise RuntimeError("C++ compile error")
+
+    monkeypatch.setattr(watermark, "_generator", boom)
+    monkeypatch.setattr(watermark, "_audioseal_available", True)
+    monkeypatch.setattr(watermark, "is_enabled", lambda: True)
+    wave = torch.zeros(1, SR)
+    assert embed_watermark(wave, SR) is wave  # fail-open contract holds
+    assert moshi_compile._compile_disabled is False
+
+
+def test_embedding_still_works_without_the_upstream_switch(monkeypatch, fakes):
+    """A future audioseal without the moshi helper must degrade to a plain
+    call, not crash the provenance chokepoint."""
+    gen, _ = fakes
+    monkeypatch.setattr(watermark, "_moshi_no_compile", lambda: None)
+    out = embed_watermark(torch.zeros(1, SR), SR)
+    assert out.shape == (1, SR)
+    assert gen.compile_disabled == [False]


### PR DESCRIPTION
Fixes #1615.

## Root cause

AudioSeal vendors moshi's `@torch_compile_lazy` on `SEANetEncoder.forward` (`audioseal/libs/moshi/modules/seanet.py:246`). The decorator calls `torch.compile` on **first invocation**, not at construction — which is exactly why the reporter saw the generator *load* cleanly under #1576's startup prefetch (`AudioSeal generator loaded (16-bit message mode)`) and only the first **embed** blow up. Inductor's C++ codegen then raised `CppCompileError` on his macOS arm64 host, the embed fail-opened, and audio shipped **unmarked** — an EU AI Act Art. 50(2) provenance gap — after ~30-40s on the first take and 5-8s on each later one.

Windows was already immune: `backend/main.py` sets `TORCH_COMPILE_DISABLE`/`TORCHDYNAMO_DISABLE`/`TORCHINDUCTOR_DISABLE` there because Triton is unavailable. macOS and Linux had no such guard.

## Why eager, rather than making the compile work

The compile is pure cost even where it succeeds. Measured on an M3, 5s of 24kHz audio, three consecutive embeds:

| | embed #1 | #2 | #3 |
|---|---|---|---|
| compiled (before) | **9.70s** | 0.26s | 0.23s |
| eager (after) | **0.30s** | 0.28s | 0.27s |

A ~10s first-embed tax to save ~0.03s per later embed, on CPU work already bounded by the 30s chunk loop — and a hard failure wherever the host's C++ toolchain can't serve Inductor. So both `embed_watermark` and `detect_watermark` now run inside audioseal's own `no_compile()` switch.

That switch flips a process global in the vendored moshi module, so `_eager_audioseal()` restores it on the way out (including when the embed raises) — other models in the backend stay entitled to `torch.compile`.

## Verification

End-to-end against the real model: first embed **9.70s → 0.26s**, and the watermark still round-trips at confidence **1.0** with the OmniVoice message intact.

- New `tests/test_watermark_no_torch_compile_1615.py` — 6 tests, fail-before/pass-after (3 of 6 fail on the pre-fix code). Covers eager embed, eager detect, guard restored on success *and* on exception, and graceful degradation if a future audioseal drops the helper.
- One test asserts the upstream `no_compile` seam still exists, so an audioseal bump that moves it fails CI loudly instead of silently restoring the compile.
- `pytest -k "watermark or synthetic"`: **76 passed, 1 skipped**.
- Changelog style/parse: 14 passed.

## Note on the issue's other ask

The full-traceback logging the reporter asked for (`exc_info` on the swallowed failure) already landed on `main` in #1576 — his run predates it. Nothing further needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
AudioSeal watermark embedding and detection now run eagerly through `no_compile()`, avoiding macOS arm64 `CppCompileError` failures and first-use latency. The process-wide guard restores the compile setting after success, failure, and overlapping operations while preserving fail-open and missing-helper behavior. Review the process-wide guard because incorrect restoration could affect other backend models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->