### PR TITLE
test(worker): root-cause the capacity-test race that flaked CI twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- The worker-capacity transport test no longer races its own setup: the 1-slot limit now goes through the enrollment handshake instead of mutating client config after connect, where the server's stream-open ConfigUpdate (carrying the registered capacity of 2) could overwrite it and fake an over-accept; failed CI twice on 2026-08-21 (#1630)
 - Moving words across a speaker boundary in a dub — merging two lines and splitting them again — no longer dubs the second half in the first speaker's voice; each half now keeps the speaker, voice, direction, gain, and language of whoever actually says it (#1612) — thanks @invio-a11y!
 - Dictation on a WebView that refuses a 16 kHz audio context (WKWebView) now low-passes before downsampling, so frequencies above 8 kHz stop folding into the speech the recognizer is fed (#1610)
 - A microphone context that cannot be resumed now reports a mic error instead of leaving the dictation pill on "Listening" while capturing nothing (#1610)

--- a/tests/test_worker_transport.py
+++ b/tests/test_worker_transport.py
@@ -343,7 +343,7 @@ class _Harness:
             private_key_pem=self.creds.private_key_pem,
         )
 
-    async def connect_worker(self, *, execute=None, capabilities=None):
+    async def connect_worker(self, *, execute=None, capabilities=None, max_concurrent_tasks=2):
         token = registry.create_enrollment(
             endpoint=f"localhost:{self.port}", cert_fingerprint=self.creds.fingerprint
         )
@@ -353,7 +353,7 @@ class _Harness:
             certificate_pem=self.creds.certificate_pem,
             keypair=WorkerKeypair.generate(),
             enrollment_token=token.encode(),
-            max_concurrent_tasks=2,
+            max_concurrent_tasks=max_concurrent_tasks,
             capabilities=capabilities or _capabilities(),
             host={"hostname": "test-worker", "os": "linux", "arch": "x86_64"},
         )
@@ -528,8 +528,15 @@ async def test_worker_at_capacity_rejects_without_penalty(harness):
         await release.wait()
         return {"meta": {}, "payload": b""}
 
-    await harness.connect_worker(execute=_block)
-    harness.client.config.max_concurrent_tasks = 1
+    # The limit goes through the handshake, not a post-connect mutation:
+    # the server's stream-open ConfigUpdate carries the REGISTERED capacity
+    # (from the hello), and a mutation racing that frame gets overwritten —
+    # the client then honours 2, accepts the second task, and this test
+    # reports over-concurrency that never existed (failed twice in CI on
+    # 2026-08-21). With 1 registered end-to-end there is no window.
+    await harness.connect_worker(execute=_block, max_concurrent_tasks=1)
+    registered = next(iter(harness.pool))
+    assert registered.capacity.max_concurrent_tasks == 1
 
     first = harness.scheduler.submit(operation=OP, engine=ENGINE, model_id=MODEL)
     await harness.servicer.dispatch(harness.scheduler.next_assignment())


### PR DESCRIPTION
Fixes the intermittent `test_worker_at_capacity_rejects_without_penalty` failure seen on PR #1627's first run and on main (2026-08-21).

## Root cause

`_Harness.connect_worker` registers the worker with `max_concurrent_tasks=2`; the test then set the client's limit to 1 *after* connect. But the server sends its stream-open `ConfigUpdate` **asynchronously** (`server.py:503-513`) carrying the *registered* capacity — and `client.py:555-556\) adopts it unconditionally. When the frame lands after the test's mutation (slow CI runners stretch exactly this window), the override is clobbered back to 2, the worker accepts a second assignment while the first is running, and the test reports over-concurrency that never existed.

## Fix

The limit now goes through the handshake: `connect_worker(..., max_concurrent_tasks=1)` → hello → server registration → ConfigUpdate all agree from the start. No window, no mutation. The test additionally asserts the **server-side registered capacity is 1** as the regression guard.

## Verification

- Fail-before: demonstrated deterministically — with the old pattern the server record stays at 2 and a delivered config frame reverts the client gate to 2
- Pass-after: fixed test 10/10 runs green; full `tests/test_worker_transport.py` 44/44 green

Test-only change; no production code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The test now sets `max_concurrent_tasks=1` during the worker handshake and verifies the server registration. This prevents asynchronous `ConfigUpdate` messages from restoring capacity 2 and causing false task acceptance. The change is limited to tests, with no known merge risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->