### PR TITLE
fix(omnivoice): route OmniVoice to ROCm GPUs (#1629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- OmniVoice and its crash-isolated subprocess now route to AMD ROCm GPUs instead of warning and falling back to CPU (#1629) — thanks @j4r3kb!
 - Dictation now cancels pending startup work, capture resources, sockets, and timers when the capture widget closes, preventing late work against a destroyed webview (#1645)
 - Streaming generation failures now show recognized recovery guidance and appear in Diagnostics instead of only returning a generic error (#1607)
 - The worker-capacity transport test no longer races its own setup: the 1-slot limit now goes through the enrollment handshake instead of mutating client config after connect, where the server's stream-open ConfigUpdate (carrying the registered capacity of 2) could overwrite it and fake an over-accept; failed CI twice on 2026-08-21 (#1630)

--- a/backend/engines/omnivoice_subprocess/__init__.py
+++ b/backend/engines/omnivoice_subprocess/__init__.py
@@ -51,7 +51,7 @@ class OmniVoiceSubprocessBackend(SubprocessBackend):
     id = "omnivoice-subprocess"
     display_name = "OmniVoice (subprocess-isolated, killable on timeout)"
     _DEFAULT_SAMPLE_RATE = 24000
-    gpu_compat = ("cuda", "mps", "cpu")
+    gpu_compat = ("cuda", "rocm", "mps", "cpu")
     # Match OmniVoiceBackend: the measured floor below which a render that
     # should take seconds runs for minutes (the #1226/#1222 4 GB reports).
     min_vram_gb = 6.0

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -669,7 +669,7 @@ class OmniVoiceBackend(TTSBackend):
 
     id = "omnivoice"
     display_name = "VoiceStudio (k2-fsa/OmniVoice, 600+ languages)"
-    gpu_compat = ("cuda", "mps", "cpu")
+    gpu_compat = ("cuda", "rocm", "mps", "cpu")
     # Derived from the pool's own per-job budget (_GPU_VRAM_PER_JOB_GB = 5.0 in
     # model_manager, itself measured from the ~1.6 GB forward + autoregressive
     # decode and the co-loaded WhisperX on the clone path), plus room for the

--- a/docs/engines/omnivoice-subprocess.md
+++ b/docs/engines/omnivoice-subprocess.md
@@ -40,7 +40,8 @@ see no change.
 
 ## Platform support
 
-- **CUDA, MPS, and CPU** (same as the in-process VoiceStudio engine).
+- **CUDA, AMD ROCm on Linux, MPS, and CPU** (same as the in-process
+  VoiceStudio engine).
 - **No extra install.** Unlike IndexTTS / dots.tts / Supertonic-3, this sidecar
   runs under VoiceStudio's own interpreter, because the goal here is crash
   isolation, not dependency isolation. If the default `omnivoice` engine works

--- a/docs/engines/omnivoice.md
+++ b/docs/engines/omnivoice.md
@@ -9,7 +9,8 @@ and dictation all run on it out of the box.
 
 - You want cloning plus the broadest language coverage (see
   [languages.md](../languages.md)).
-- You have a GPU (CUDA or Apple Silicon MPS) with ~6 GB VRAM or more.
+- You have a GPU (CUDA, AMD ROCm on Linux, or Apple Silicon MPS) with
+  ~6 GB VRAM or more.
 - You just installed VoiceStudio — it's already selected.
 
 For low-VRAM or CPU-only machines, the
@@ -18,7 +19,7 @@ quantized native binary with a much smaller memory footprint.
 
 ## Requirements
 
-- Runs on CUDA, MPS (Apple Silicon), or CPU — auto-detected.
+- Runs on CUDA, AMD ROCm (Linux), MPS (Apple Silicon), or CPU — auto-detected.
 - Recommended VRAM floor: **6 GB** on a dedicated GPU. This is the only
   engine with a measured floor: on 4 GB cards (GTX 1650 Ti, Quadro P2000 —
   issues [#1226](https://github.com/debpalash/VoiceStudio/issues/1226) /
@@ -43,8 +44,10 @@ The env var overrides the persisted UI choice.
 
 - Weights load lazily on first use and are shared with the rest of the app
   (dubbing, dictation) — the model is never double-loaded.
-- On CUDA the model runs fp16 with `torch.compile`; a speech recognizer is
-  co-loaded for the cloning path.
+- On CUDA and ROCm the model runs fp16 with `torch.compile`; PyTorch exposes
+  ROCm/HIP devices through its `cuda` API, while VoiceStudio's engine matrix
+  reports the hardware as ROCm. A speech recognizer is co-loaded for the
+  cloning path.
 - Output is 24 kHz mono; the shared mastering chain (highpass + compressor)
   is tuned for this rate and applied automatically.
 - Cloning takes a short reference clip (`ref_audio`); 3–10 seconds is the

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -120,6 +120,9 @@ ROCm container `omnivoice-studio-rocm` (CPU: `omnivoice-studio`, NVIDIA:
 (ROCm-built PyTorch reports through `torch.cuda.*` — `True` plus your card's
 name means torch can see the GPU.) That check alone isn't proof the app is
 using it: **Settings → System** shows the device VoiceStudio actually resolved.
+**Model Catalogue → Engines** should report both `omnivoice` and
+`omnivoice-subprocess` as accelerated on ROCm, rather than a CPU-fallback
+warning.
 If it reads `cpu` while the command above prints `True`, the backend log line
 starting `Falling back to CPU:` names the architecture mismatch it hit.
 

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -238,12 +238,14 @@ def test_omnivoice_entry_has_in_process_isolation_mode(fresh_app):
     assert by_id["omnivoice"]["isolation_mode"] == "in-process"
 
 
-def test_gpu_compat_omnivoice_has_cuda_mps_cpu(fresh_app):
-    """OmniVoice ships with CUDA/MPS/CPU paths — surface that in the matrix."""
+def test_gpu_compat_omnivoice_variants_include_rocm(fresh_app):
+    """Both OmniVoice paths use torch's HIP-backed CUDA device on ROCm."""
     client = _client(fresh_app)
     r = client.get("/engines")
     by_id = {b["id"]: b for b in r.json()["tts"]["backends"]}
-    assert set(by_id["omnivoice"]["gpu_compat"]) == {"cuda", "mps", "cpu"}
+    expected = {"cuda", "rocm", "mps", "cpu"}
+    assert set(by_id["omnivoice"]["gpu_compat"]) == expected
+    assert set(by_id["omnivoice-subprocess"]["gpu_compat"]) == expected
 
 
 # ── select_engine host-routing gate (no silent CPU fallback) ────────────────
@@ -260,6 +262,17 @@ def _force_host(monkeypatch, family="cpu"):
 
 def _force_cpu_host(monkeypatch):
     _force_host(monkeypatch, "cpu")
+
+
+def test_omnivoice_variants_route_to_rocm(fresh_app, monkeypatch):
+    _force_host(monkeypatch, "rocm")
+
+    body = _client(fresh_app).get("/engines").json()
+    by_id = {b["id"]: b for b in body["tts"]["backends"]}
+    for backend_id in ("omnivoice", "omnivoice-subprocess"):
+        assert by_id[backend_id]["effective_device"] == "rocm"
+        assert by_id[backend_id]["routing_status"] == "accelerated"
+        assert by_id[backend_id]["routing_reason"] is None
 
 
 def test_select_blocks_engine_unavailable_on_this_host(fresh_app, monkeypatch):


### PR DESCRIPTION
## Summary

- declare ROCm support for both OmniVoice runtime variants
- route mocked ROCm hosts to acceleration instead of CPU fallback
- document the Linux/ROCm engine and container behavior

Closes #1629

## Changes

- add `rocm` to both OmniVoice compatibility sets
- cover API metadata and host-aware routing for both variants
- update engine, Docker, and changelog documentation with reporter credit

## Type

- [x] 🐛 Bug fix
- [x] 📝 Documentation
- [x] 🧪 Tests

## Testing

- fail-before: both new API regressions failed against the previous compatibility declarations
- `141 passed`: engine route shape, routing, device capabilities, ROCm architecture gate, subprocess, changelog style
- `36 passed`: docs drift/install validation and changelog parsing/style
- no physical RX 9070 XT was available; ROCm discovery and routing are mocked

## Checklist

- [x] I have tested this locally
- [x] I have updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are unchanged
- [x] Runtime regression fixture remains covered by the cross-platform smoke gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

OmniVoice now declares and routes ROCm as an accelerated GPU target for both runtime variants, with updated documentation and tests. This enables AMD 9070 XT support instead of CPU fallback when ROCm is available. ROCm discovery and routing use mocks, so validation on physical AMD hardware remains a merge risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->