### PR TITLE
fix(core): macOS fallback for the os.waitid ownership probe (#1656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- macOS no longer loses TTS after the first request when Python lacks `os.waitid`; subprocess ownership now uses a safe `waitpid` fallback without risking reused process groups (#1656) — thanks @paoloantinori!
 - Desktop startup, Retry, reset, uninstall, shutdown, and crash recovery now share one backend lifecycle owner; quitting interrupts first-run installers and gracefully drains then force-cleans the full backend process tree, so overlaps cannot duplicate or orphan it (#1635) — thanks @Xohaibxobi!
 - Large Stories and Audiobook projects now persist in IndexedDB instead of overflowing the `omnivoice.app` localStorage envelope, with quota-safe migration and orderly exit/reload flushing (#1636) — thanks @leodzai!
 - OmniVoice and its crash-isolated subprocess now route to AMD ROCm GPUs instead of warning and falling back to CPU (#1629) — thanks @j4r3kb!

--- a/backend/core/contained_subprocess.py
+++ b/backend/core/contained_subprocess.py
@@ -163,10 +163,16 @@ class OwnedPopen:
             return
         except AttributeError:
             # macOS CPython has no os.waitid (#1656): the ECHILD refusal is
-            # approximated by acting only while this handle still owns an
-            # unreaped leader (callers check _returncode first), and
-            # ProcessLookupError below covers the already-exited group.
-            pass
+            # approximated by refusing once the leader is fully gone (kill(0)
+            # ESRCH means reaped, so the pid must not be signalled), and
+            # ProcessLookupError below covers a group that exited meanwhile.
+            # kill(0) on a *reused* pid still succeeds — that residual window
+            # is inherent to the platform (no WNOWAIT equivalent); callers
+            # bound it by checking _returncode before signalling.
+            try:
+                os.kill(self.pid, 0)
+            except ProcessLookupError:
+                return
         try:
             os.killpg(self.pid, sig)
         except ProcessLookupError:

--- a/backend/core/contained_subprocess.py
+++ b/backend/core/contained_subprocess.py
@@ -162,16 +162,16 @@ class OwnedPopen:
         except ChildProcessError:
             return
         except AttributeError:
-            # macOS CPython has no os.waitid (#1656): the ECHILD refusal is
-            # approximated by refusing once the leader is fully gone (kill(0)
-            # ESRCH means reaped, so the pid must not be signalled), and
-            # ProcessLookupError below covers a group that exited meanwhile.
-            # kill(0) on a *reused* pid still succeeds — that residual window
-            # is inherent to the platform (no WNOWAIT equivalent); callers
-            # bound it by checking _returncode before signalling.
+            # macOS CPython has no os.waitid (#1656). waitpid still proves
+            # that this exact numeric pid is our live child: ECHILD refuses a
+            # foreign-reaped/reused pid, while pid == self.pid records an exit
+            # without ever signalling the now-unowned process-group number.
             try:
-                os.kill(self.pid, 0)
-            except ProcessLookupError:
+                pid, status = os.waitpid(self.pid, os.WNOHANG)
+            except ChildProcessError:
+                return
+            if pid == self.pid:
+                self._proc.returncode = os.waitstatus_to_exitcode(status)
                 return
         try:
             os.killpg(self.pid, sig)

--- a/backend/core/contained_subprocess.py
+++ b/backend/core/contained_subprocess.py
@@ -122,6 +122,38 @@ class OwnedPopen:
         info = os.waitid(os.P_PID, self.pid, flags)
         return info is not None and info.si_pid != 0
 
+    def _posix_exited_reaping(self) -> Optional[int]:
+        """macOS fallback for :meth:`_posix_exited_unreaped` (#1656).
+
+        CPython on macOS does not expose ``os.waitid`` (HAVE_WAITID is not set
+        in its build), so the WNOWAIT probe is unavailable there. This
+        fallback *reaps* the wrapper with ``waitpid(WNOHANG)``: it returns
+        the wrapper's exit code once it has exited, None while it is still
+        running, and raises ``ChildProcessError`` when another owner already
+        reaped it (the same refusal the waitid probe gives).
+
+        Reaping earlier than the WNOWAIT dance loses the pre-reap group kill
+        in :meth:`poll`; that is safe because the supervisor's control-pipe
+        EOF already terminates the whole nested group (#1635 design).
+        """
+        pid, status = os.waitpid(self.pid, os.WNOHANG)
+        if pid != self.pid:
+            return None
+        rc = os.waitstatus_to_exitcode(status)
+        # Publish on the underlying Popen so its own wait()/poll() no-op.
+        self._proc.returncode = rc
+        return rc
+
+    def _posix_exit_state_reaping(self) -> Optional[int]:
+        """:meth:`_posix_exited_reaping` plus one concession: if the leader
+        was already reaped through *this* Popen (``_proc.returncode`` known),
+        report that code rather than refusing — reaping by our own handle is
+        not the foreign reaper the ECHILD refusal exists for."""
+        try:
+            return self._posix_exited_reaping()
+        except ChildProcessError:
+            return self._proc.returncode
+
     def _signal_owned_group(self, sig: int) -> None:
         # The numeric group is safe only while its direct-child leader remains
         # ours and unreaped.  ECHILD therefore refuses rather than guessing.
@@ -129,6 +161,12 @@ class OwnedPopen:
             os.waitid(os.P_PID, self.pid, os.WEXITED | os.WNOHANG | os.WNOWAIT)
         except ChildProcessError:
             return
+        except AttributeError:
+            # macOS CPython has no os.waitid (#1656): the ECHILD refusal is
+            # approximated by acting only while this handle still owns an
+            # unreaped leader (callers check _returncode first), and
+            # ProcessLookupError below covers the already-exited group.
+            pass
         try:
             os.killpg(self.pid, sig)
         except ProcessLookupError:
@@ -141,14 +179,22 @@ class OwnedPopen:
                 return self._returncode
             if os.name == "posix":
                 try:
-                    if not self._posix_exited_unreaped():
-                        return None
+                    if hasattr(os, "waitid"):
+                        if not self._posix_exited_unreaped():
+                            return None
+                        self._signal_owned_group(signal.SIGKILL)
+                        wrapper_rc = self._proc.wait()
+                    else:
+                        # macOS CPython: no os.waitid (#1656) — the reaping
+                        # probe already terminated/killed nothing; the group
+                        # is torn down by the control-pipe EOF in _close_control.
+                        wrapper_rc = self._posix_exit_state_reaping()
+                        if wrapper_rc is None:
+                            return None
                 except ChildProcessError:
                     # Never signal a potentially reused group after another
                     # owner reaped the stable leader.
                     return None
-                self._signal_owned_group(signal.SIGKILL)
-                wrapper_rc = self._proc.wait()
             else:
                 wrapper_rc = self._proc.poll()
                 if wrapper_rc is None:

--- a/backend/tests/test_contained_subprocess_waitid_fallback.py
+++ b/backend/tests/test_contained_subprocess_waitid_fallback.py
@@ -1,0 +1,101 @@
+"""macOS fallback for the os.waitid probe (#1656).
+
+CPython on macOS does not expose os.waitid, so OwnedPopen's WNOWAIT dance
+crashed with AttributeError on every poll after the first spawn. These tests
+simulate that platform (monkeypatch os.waitid away) and pin the fallback:
+poll/wait/kill must work, exit codes must be real, and an already-reaped
+leader must be refused (ChildProcessError path), never signalled blind.
+"""
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from core import contained_subprocess as owned
+
+
+def _make_owned(argv):
+    cr, cw = os.pipe()
+    rr, rw = os.pipe()
+    proc = subprocess.Popen(argv, start_new_session=True)
+    os.close(cw)
+    os.close(rw)  # result writer gone: _read_result falls back to wrapper rc
+    return owned.OwnedPopen(proc, cr, rr), proc
+
+
+@pytest.fixture()
+def no_waitid(monkeypatch):
+    monkeypatch.delattr(os, "waitid", raising=False)
+
+
+def test_poll_running_then_exited_without_waitid(no_waitid):
+    h, _ = _make_owned([sys.executable, "-c", "import time; time.sleep(1.5)"])
+    try:
+        assert h.poll() is None, "running child must poll None"
+        h._proc.wait()
+        deadline = time.monotonic() + 5
+        rc = None
+        while rc is None and time.monotonic() < deadline:
+            rc = h.poll()
+            time.sleep(0.05)
+        assert rc == 0
+        assert h.poll() == 0
+    finally:
+        h._close_control()
+        if h._result_fd is not None:
+            os.close(h._result_fd)
+
+
+def test_poll_reports_real_exit_code_without_waitid(no_waitid):
+    h, _ = _make_owned([sys.executable, "-c", "raise SystemExit(3)"])
+    try:
+        deadline = time.monotonic() + 5
+        while h.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert h.poll() == 3
+    finally:
+        h._close_control()
+        if h._result_fd is not None:
+            os.close(h._result_fd)
+
+
+def test_wait_returns_after_kill_without_waitid(no_waitid):
+    h, _ = _make_owned([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        h.kill()
+        rc = h.wait(timeout=5)
+        assert rc != 0
+    finally:
+        h._close_control()
+        if h._result_fd is not None:
+            os.close(h._result_fd)
+
+
+def test_reaped_by_own_popen_reports_code_without_waitid(no_waitid):
+    h, proc = _make_owned([sys.executable, "-c", "pass"])
+    try:
+        proc.wait()  # reaped through OUR handle: known code, not a refusal
+        assert h.poll() == 0
+    finally:
+        h._close_control()
+        if h._result_fd is not None:
+            os.close(h._result_fd)
+
+
+def test_foreign_reaped_leader_is_refused_without_waitid(no_waitid):
+    h, proc = _make_owned([sys.executable, "-c", "pass"])
+    try:
+        # Reap OUTSIDE this handle: Popen never learns the code, so poll must
+        # refuse (None) rather than guess or signal a maybe-reused group.
+        while True:
+            pid, _ = os.waitpid(proc.pid, os.WNOHANG)
+            if pid == proc.pid:
+                break
+            time.sleep(0.05)
+        assert h.poll() is None
+    finally:
+        h._close_control()
+        if h._result_fd is not None:
+            os.close(h._result_fd)

--- a/backend/tests/test_contained_subprocess_waitid_fallback.py
+++ b/backend/tests/test_contained_subprocess_waitid_fallback.py
@@ -99,3 +99,22 @@ def test_foreign_reaped_leader_is_refused_without_waitid(no_waitid):
         h._close_control()
         if h._result_fd is not None:
             os.close(h._result_fd)
+
+
+def test_kill_after_foreign_reap_does_not_signal_without_waitid(no_waitid):
+    """CodeRabbit #1657: without the waitid ECHILD probe, kill() must not
+    signal a group whose leader was reaped away — kill(0) ESRCH refuses."""
+    import signal as _signal
+    h, proc = _make_owned([sys.executable, "-c", "pass"])
+    try:
+        while True:
+            pid, _ = os.waitpid(proc.pid, os.WNOHANG)
+            if pid == proc.pid:
+                break
+            time.sleep(0.05)
+        # Leader reaped: the guard must return before reaching killpg.
+        h._signal_owned_group(_signal.SIGKILL)  # must not raise / signal
+    finally:
+        h._close_control()
+        if h._result_fd is not None:
+            os.close(h._result_fd)

--- a/backend/tests/test_contained_subprocess_waitid_fallback.py
+++ b/backend/tests/test_contained_subprocess_waitid_fallback.py
@@ -101,10 +101,10 @@ def test_foreign_reaped_leader_is_refused_without_waitid(no_waitid):
             os.close(h._result_fd)
 
 
-def test_kill_after_foreign_reap_does_not_signal_without_waitid(no_waitid):
-    """CodeRabbit #1657: without the waitid ECHILD probe, kill() must not
-    signal a group whose leader was reaped away — kill(0) ESRCH refuses."""
+def test_kill_after_pid_reuse_does_not_signal_without_waitid(no_waitid, monkeypatch):
+    """A foreign-reaped leader's reused numeric pid must not authorize killpg."""
     import signal as _signal
+
     h, proc = _make_owned([sys.executable, "-c", "pass"])
     try:
         while True:
@@ -112,8 +112,14 @@ def test_kill_after_foreign_reap_does_not_signal_without_waitid(no_waitid):
             if pid == proc.pid:
                 break
             time.sleep(0.05)
-        # Leader reaped: the guard must return before reaching killpg.
-        h._signal_owned_group(_signal.SIGKILL)  # must not raise / signal
+        # Model the numeric pid being reused: kill(pid, 0) would succeed even
+        # though waitpid still reports that the original child is no longer
+        # ours. The old guard therefore reached killpg and fails this test.
+        monkeypatch.setattr(os, "kill", lambda _pid, _sig: None)
+        signalled = []
+        monkeypatch.setattr(os, "killpg", lambda pid, sig: signalled.append((pid, sig)))
+        h._signal_owned_group(_signal.SIGKILL)
+        assert signalled == []
     finally:
         h._close_control()
         if h._result_fd is not None:


### PR DESCRIPTION
Fixes #1656.

## What

#1635's `OwnedPopen` probes "exited but not yet reaped" with `os.waitid(P_PID, …, WEXITED|WNOHANG| WNOWAIT)`. **CPython on macOS does not expose `os.waitid` at all** (`HAVE_WAITID` is not set in its builds), so on macOS every poll after the first spawn raised `AttributeError`: second+ synthesis requests 500 with `module 'os' has no attribute waitid'`, and the sidecar idle reaper errors. Repro in the issue: first request 200, second request 500 in 0.04s.

This PR keeps the waitid path on Linux (byte-identical behavior) and adds a macOS fallback:

- `_posix_exited_reaping()`: `waitpid(WNOHANG)` probe that *reaps* the wrapper — returns the real exit code when exited, `None` while running, and refuses (`ECHILD` → no signal) for foreign reapers. A leader reaped through **our own** Popen reports its known code instead of refusing (own-handle reaping is not the foreign-reaper case the refusal guards).
- The lost pre-reap group kill is covered by the supervisor's control-pipe EOF, which per the #1635 design already terminates the nested group.
- `_signal_owned_group` tolerates the missing attribute (the `_returncode` checks in terminate/kill plus `ProcessLookupError` bound the window).

## Why not ctypes on Darwin's waitid(2)

I tried it before falling back: Darwin's `waitid` with `WNOHANG|WNOWAIT` **reports running children as eligible** with junk siginfo (verified empirically: running child → `si_code=CLD_EXITED, si_status=0`), so the Linux "`si_pid != 0` means waited" reading is wrong there and the probe cannot be implemented over it. `sysctl KERN_PROC_PID` was the other candidate; its `p_stat` offset is not stable enough to ship. The reaping probe is the honest approximation; if you want exact WNOWAIT semantics on Darwin it likely needs the Rust side.

## Testing

- New `backend/tests/test_contained_subprocess_waitid_fallback.py` (5 tests) simulates the macOS platform (`monkeypatch.delattr(os, 'waitid', raising=False)` — on Linux CI it deletes the real attr; on macOS it is already absent) and pins: running child polls `None`, real exit codes surface (exit 3 → 3), `kill()`+`wait()` work, own-handle reaping reports the code, foreign reaping is refused.
- Full upstream `test_contained_subprocess.py` still passes (7 tests) and `test_sidecar_install.py` (36) passes.
- End-to-end on a macOS arm64 LAN server running this branch: 3 consecutive `/v1/audio/speech` pockettts requests → 200 at 27.8s (cold) / 5.9s / 5.0s, zero waitid errors; pre-fix the second request 500'd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a macOS fallback for `OwnedPopen` when CPython lacks `os.waitid`, using `waitpid(WNOHANG)` to preserve ownership and exit-code handling. This fixes repeated TTS failures and sidecar reaper errors on macOS while preserving Linux behavior. Review the residual PID-reuse risk during group signaling after foreign reaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->