### PR TITLE
fix(desktop): preflight Linux runtime dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,7 @@ sudo apt-get install -y \
   libwebkit2gtk-4.1-dev libgtk-3-dev libpango1.0-dev libcairo2-dev \
   libsoup-3.0-dev libgdk-pixbuf-2.0-dev \
   libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev \
+  gstreamer1.0-plugins-good \
   libasound2-dev build-essential curl wget file
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Dub subtitles can be retimed, inserted, and merged in either direction from the segment table (#1612) — thanks @invio-a11y!
 
 ### Changed
+- Linux source launchers now catch missing libxdo and GStreamer audio plugins before they can cause a linker error or an aborted, blank WebKit renderer (#1680, #1682)
 - Dictation now carries one native output session from shortcut-down through final delivery, restores text, HTML, image, or file-list clipboards only when untouched, keeps Wayland copy-safe unless current-focus insertion is explicitly enabled, and retries silent Sherpa speech only through an already-installed local ASR model (#1175)
 - The backend binds its port immediately and reports startup progress live — `/health` answers 503-with-step and a new `/startup/progress` endpoint lists every step while PyTorch, API routes, and database migrations load in the background, so "starting at step X" is never mistakable for "dead"; the desktop splash narrates each step (#1550)
 

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -38,13 +38,14 @@ Everything above, plus the toolchain:
     libwebkit2gtk-4.1-dev libgtk-3-dev libpango1.0-dev libcairo2-dev \
     libsoup-3.0-dev libgdk-pixbuf-2.0-dev \
     libayatana-appindicator3-dev librsvg2-dev libssl-dev libxdo-dev \
+    gstreamer1.0-plugins-good \
     libasound2-dev build-essential curl wget file
 
   # Fedora
-  sudo dnf install webkit2gtk4.1-devel libappindicator-gtk3-devel librsvg2-devel openssl-devel
+  sudo dnf install webkit2gtk4.1-devel libappindicator-gtk3-devel librsvg2-devel openssl-devel libxdo-devel gstreamer1-plugins-good
 
   # Arch
-  sudo pacman -S --needed base-devel webkit2gtk-4.1 libayatana-appindicator librsvg openssl xdotool
+  sudo pacman -S --needed base-devel webkit2gtk-4.1 libayatana-appindicator librsvg openssl xdotool gst-plugins-good
   ```
 
 - Optional: a **Hugging Face token** for diarization + the larger TTS engines
@@ -85,6 +86,13 @@ pkg-config --exists \
   gdk-3.0 pango cairo libsoup-3.0 javascriptcoregtk-4.1 gdk-pixbuf-2.0 \
   && echo "Tauri system libraries are ready"
 ```
+
+`bun desktop` also checks the native `libxdo` linker input and GStreamer's
+`autoaudiosink` before starting. The latter is required even if you do not plan
+to record: WebKitGTK 2.52 aborts its renderer when a page creates an audio
+element without that plugin, which otherwise turns a running app blank. The
+launcher prints one distro-specific install command when either dependency is
+missing.
 
 The first app launch downloads model weights on demand. Subsequent launches
 reuse the Rust build, Python environment, and installed models.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "wait:frontend": "wait-on -t 120000 http://localhost:5173",
     "predev": "bun install && bun scripts/clear-dev-ports.mjs 3900 3901",
     "dev": "bun run setup:api && concurrently -n api,fe -c green,cyan --kill-others-on-fail \"bun run dev:api\" \"bun run dev:frontend\"",
-    "predesktop": "bun install && bun scripts/clear-dev-ports.mjs 3900 3901",
+    "predesktop": "bun install && bun scripts/desktop-runtime-preflight.mjs && bun scripts/clear-dev-ports.mjs 3900 3901",
     "desktop": "bun run setup:api && concurrently -n api,app -c green,magenta --kill-others-on-fail \"bun run dev:api\" \"bun run dev:desktop\"",
     "desktop-prod": "bun scripts/desktop-prod.mjs",
     "desktop-prod:run": "bun scripts/desktop-prod.mjs --skip-build --keep-data",

--- a/scripts/desktop-dev.mjs
+++ b/scripts/desktop-dev.mjs
@@ -24,6 +24,7 @@ import { homedir } from "node:os";
 import process from "node:process";
 import { DEV_APP_PROCESS_NAME } from "./desktop-common.mjs";
 import { launchTauriDev } from "./desktop-dev-launch.mjs";
+import { desktopRuntimeReady } from "./desktop-runtime-preflight.mjs";
 
 /** The env's PATH key — Windows uses "Path", others "PATH"; match case-insensitively. */
 function pathKeyOf(env) {
@@ -81,6 +82,7 @@ function killStaleDevApp() {
   }
 }
 
+if (!desktopRuntimeReady()) process.exit(1);
 killStaleDevApp();
 
 // Start from the real environment; heal a stale PATH into a *copy* (mutating

--- a/scripts/desktop-prod.mjs
+++ b/scripts/desktop-prod.mjs
@@ -24,11 +24,14 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import process from "node:process";
+import { desktopRuntimeReady } from "./desktop-runtime-preflight.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const shellScript = join(scriptDir, "desktop-prod.sh");
 const args = process.argv.slice(2);
 const isWindows = process.platform === "win32";
+
+if (!desktopRuntimeReady()) process.exit(1);
 
 /** WSL's bash.exe lives under System32 — running the script there would
  *  detect "Linux" and wipe/launch the wrong paths. Never use it. */

--- a/scripts/desktop-runtime-preflight.mjs
+++ b/scripts/desktop-runtime-preflight.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Linux WebKitGTK aborts its renderer when an <audio> element is created
+// without autoaudiosink. Enigo's default Linux backend also links libxdo.
+// Catch both before starting the backend or opening a window (#1680, #1682).
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+/** Read Linux distro metadata without making it a prerequisite elsewhere. */
+function systemOsRelease() {
+  try {
+    return readFileSync("/etc/os-release", "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/** Return the package-manager command for the detected Linux family. */
+export function linuxDesktopDependencyCommand(osRelease) {
+  const ids = new Set();
+  for (const line of osRelease.split(/\r?\n/)) {
+    const match = /^(ID|ID_LIKE)=(.*)$/.exec(line);
+    if (!match) continue;
+    for (const id of match[2].replace(/^['"]|['"]$/g, "").toLowerCase().split(/\s+/)) {
+      if (id) ids.add(id);
+    }
+  }
+  if (["arch", "cachyos", "endeavouros", "manjaro"].some((id) => ids.has(id))) {
+    return "sudo pacman -S --needed xdotool gst-plugins-good";
+  }
+  if (["debian", "ubuntu", "linuxmint", "pop"].some((id) => ids.has(id))) {
+    return "sudo apt-get install libxdo-dev gstreamer1.0-plugins-good";
+  }
+  if (["fedora", "rhel", "centos"].some((id) => ids.has(id))) {
+    return "sudo dnf install libxdo-devel gstreamer1-plugins-good";
+  }
+  return "install libxdo development files and the GStreamer 'good' plugins with your package manager";
+}
+
+/** Diagnose missing Linux-only linker/runtime pieces; return null when ready. */
+export function desktopRuntimeProblem({
+  platform = process.platform,
+  run = spawnSync,
+  osRelease = systemOsRelease(),
+} = {}) {
+  if (platform !== "linux") return null;
+
+  const missing = [];
+  const xdo = run("cc", ["-print-file-name=libxdo.so"], { encoding: "utf8" });
+  if (xdo.status !== 0 || !xdo.stdout?.trim() || xdo.stdout.trim() === "libxdo.so") {
+    missing.push("libxdo (required by Enigo at link time)");
+  }
+
+  const audioSink = run("gst-inspect-1.0", ["autoaudiosink"], { stdio: "ignore" });
+  if (audioSink.status !== 0) {
+    missing.push("GStreamer autoaudiosink (required by WebKit audio)");
+  }
+  if (missing.length === 0) return null;
+
+  return [
+    "",
+    `❌ Linux desktop prerequisite${missing.length === 1 ? " is" : "s are"} missing:`,
+    ...missing.map((item) => `   • ${item}`),
+    "",
+    "   Without autoaudiosink, WebKitGTK can abort its renderer when the UI",
+    "   creates an audio element, leaving a blank window.",
+    "",
+    "   Install the required packages:",
+    `     ${linuxDesktopDependencyCommand(osRelease)}`,
+    "",
+    "   Then rerun: bun desktop",
+    "",
+  ].join("\n");
+}
+
+/** Print an actionable diagnosis and report whether desktop launch may continue. */
+export function desktopRuntimeReady(options) {
+  const problem = desktopRuntimeProblem(options);
+  if (!problem) return true;
+  console.error(problem);
+  return false;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(desktopRuntimeReady() ? 0 : 1);
+}

--- a/tests/test_desktop_runtime_preflight.py
+++ b/tests/test_desktop_runtime_preflight.py
@@ -1,0 +1,85 @@
+"""Source desktop launchers must catch Linux native/runtime gaps up front."""
+
+import json
+import subprocess
+from pathlib import Path
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_PREFLIGHT = (_ROOT / "scripts" / "desktop-runtime-preflight.mjs").as_uri()
+
+
+def _probe(platform: str, os_release: str, *, xdo: bool, audio_sink: bool):
+    """Run the JavaScript preflight against injected platform probe results."""
+    script = f"""
+      import {{ desktopRuntimeProblem }} from {json.dumps(_PREFLIGHT)};
+      const calls = [];
+      const problem = desktopRuntimeProblem({{
+        platform: {json.dumps(platform)},
+        osRelease: {json.dumps(os_release)},
+        run: (command, args) => {{
+          calls.push([command, args]);
+          if (command === "cc") return {{ status: 0, stdout: {json.dumps('/usr/lib/libxdo.so' if xdo else 'libxdo.so')} }};
+          return {{ status: {0 if audio_sink else 1} }};
+        }},
+      }});
+      console.log(JSON.stringify({{ calls, problem }}));
+    """
+    completed = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_non_linux_skips_native_probes() -> None:
+    assert _probe("darwin", "", xdo=False, audio_sink=False) == {
+        "calls": [],
+        "problem": None,
+    }
+
+
+def test_arch_diagnosis_combines_linker_and_webkit_runtime_packages() -> None:
+    observed = _probe("linux", 'ID="cachyos"\nID_LIKE="arch"', xdo=False, audio_sink=False)
+    assert observed["calls"] == [
+        ["cc", ["-print-file-name=libxdo.so"]],
+        ["gst-inspect-1.0", ["autoaudiosink"]],
+    ]
+    assert "libxdo (required by Enigo at link time)" in observed["problem"]
+    assert "GStreamer autoaudiosink (required by WebKit audio)" in observed["problem"]
+    assert "sudo pacman -S --needed xdotool gst-plugins-good" in observed["problem"]
+    assert "blank window" in observed["problem"]
+
+
+def test_debian_diagnosis_names_only_the_missing_audio_runtime() -> None:
+    observed = _probe("linux", "ID=ubuntu\nID_LIKE=debian", xdo=True, audio_sink=False)
+    assert "libxdo (required by Enigo at link time)" not in observed["problem"]
+    assert "gstreamer1.0-plugins-good" in observed["problem"]
+
+
+def test_ready_linux_host_has_no_problem() -> None:
+    assert _probe("linux", "ID=fedora", xdo=True, audio_sink=True)["problem"] is None
+
+
+def test_every_source_launcher_runs_the_preflight() -> None:
+    for relative_path in ("scripts/desktop-dev.mjs", "scripts/desktop-prod.mjs"):
+        launcher = (_ROOT / relative_path).read_text()
+        assert 'from "./desktop-runtime-preflight.mjs"' in launcher
+        assert "if (!desktopRuntimeReady()) process.exit(1);" in launcher
+
+    package = json.loads((_ROOT / "package.json").read_text())
+    predesktop = package["scripts"]["predesktop"]
+    assert "desktop-runtime-preflight.mjs" in predesktop
+    assert predesktop.index("desktop-runtime-preflight.mjs") < predesktop.index("clear-dev-ports.mjs")
+
+
+def test_linux_install_docs_name_the_required_runtime_packages() -> None:
+    docs = (_ROOT / "docs/install/linux.md").read_text()
+    for package in (
+        "gstreamer1.0-plugins-good",
+        "gstreamer1-plugins-good",
+        "gst-plugins-good",
+    ):
+        assert package in docs


### PR DESCRIPTION
## Summary

Prevent green CI from being followed by a cryptic Linux linker error or a WebKit blank window on an incompletely provisioned source host.

## Changes

- preflight Enigo’s libxdo linker input and WebKit’s GStreamer `autoaudiosink` before ports, backend, or windows start
- print one distro-specific install command for Debian/Ubuntu, Fedora, or Arch families
- add GStreamer good plugins to every Linux source-build guide and deterministic regression coverage
- preserve Enigo’s existing backend and cross-platform behavior

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [x] 🧪 Tests
- [x] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- `bun desktop` now exits before startup with the exact Arch packages on this intentionally incomplete host
- core PID 3486584 symbolized to `MediaPlayerPrivateGStreamer::createAudioSink` → `WTFCrashWithInfo`
- targeted pytest: 25 passed

## Checklist

- [x] I’ve tested this locally
- [x] I’ve updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync (no version bump)
- [x] Runtime fixture remains covered by smoke-matrix CI

## Release cadence

VoiceStudio ships continuous-to-main; this fix enters the rolling preview immediately after merge.

Closes #1680
Closes #1682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The desktop launchers now run a Linux preflight that checks `libxdo` and GStreamer `autoaudiosink`, reports distro-specific install commands, and blocks startup when dependencies are missing. Regression tests cover platform probes, launcher gating, npm ordering, and documentation. Please verify the intended scope: this change still documents and checks `libxdo`, rather than replacing Enigo with its pure-Rust x11rb backend and removing the dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->