### PR TITLE
fix(ui): reflow workspaces after bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - The OmniVoice guide now covers combining style attributes with a reference clip (consistent instruct stabilizes cloning; the reference wins conflicts), inline pronunciation control (pinyin / CMU phonemes), and corrects the claim that the default engine can't do voice design — it can, from attributes (#1565)
 
 ### Fixed
+- Workspaces now measure their responsive width when the post-bootstrap shell actually mounts, so native UI scaling reflows Projects and History instead of crushing the Dubbing demo into unreadable columns (#1683)
 - Dubbing keeps the source-language selector visible after a local file is chosen, so ASR can be pinned before transcription starts (#1678) — thanks @Lonki-lomki-cloud!
 - First-run media-engine downloads become available to TTS immediately without a restart, and missing media-process failures now point to repair controls (#1677) — thanks @farhataligpt-dev!
 - Source installs on AMD GPUs honour `OMNIVOICE_TORCH_VARIANT=rocm`: `bun run desktop` now swaps in the ROCm torch wheel after `uv sync` and launches the backend without re-syncing, instead of silently reverting to the CPU-only CUDA build on every start (#1665) — thanks @uberclokr!

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -78,7 +78,7 @@ import { listenDictationNotice, showDictationNotice } from './utils/dictationNot
 import { addBreadcrumb } from './utils/breadcrumbs';
 import { appShellClasses } from './utils/appShellClasses';
 import { configuredRemoteBackend, probeRemoteBackend } from './utils/remoteBackendProbe';
-import { applyUiScale } from './utils/uiScaleEngine';
+import { applyUiScale, responsiveShellWidth } from './utils/uiScaleEngine';
 import { resolveUiScale, suggestUiScale } from './utils/uiScaleSuggestion';
 import { recordValueMoment } from './utils/donationMoments';
 import {
@@ -164,6 +164,9 @@ function App() {
     selected: uiScale,
     suggested: startupSuggestedScale,
   });
+  const [uiScaleEngine, setUiScaleEngine] = useState(() =>
+    typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window ? 'native' : 'css',
+  );
 
   // Responsive shell breakpoints driven off the app-container's OWN width, not
   // the viewport. The shell is sized `width: calc(100vw / --ui-scale)` then
@@ -173,15 +176,20 @@ function App() {
   // `100vw` and so collapse at the wrong threshold whenever the UI scale ≠ 1,
   // cramming the content into a sliver. ResizeObserver fires on both window
   // resize and scale change (the calc width changes), so this stays correct.
-  const shellRef = useRef(null);
+  const shellObserverRef = useRef(/** @type {ResizeObserver | null} */ (null));
   const [shellWidth, setShellWidth] = useState(Infinity);
-  useEffect(() => {
-    const el = shellRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return undefined;
-    const ro = new ResizeObserver(() => setShellWidth(el.clientWidth));
-    ro.observe(el);
-    setShellWidth(el.clientWidth);
-    return () => ro.disconnect();
+  const observeShell = useCallback((node) => {
+    shellObserverRef.current?.disconnect();
+    shellObserverRef.current = null;
+    if (!node) return;
+
+    const measure = () => setShellWidth(node.clientWidth);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    shellObserverRef.current = observer;
   }, []);
 
   // Desktop UI scale belongs at the webview boundary. A CSS `zoom` probe can
@@ -189,10 +197,17 @@ function App() {
   // still occupies only the upper-left of the window. Tauri's native zoom keeps
   // layout and paint in agreement; browser/dev sessions retain the CSS path.
   useLayoutEffect(() => {
-    void applyUiScale(effectiveUiScale);
+    let cancelled = false;
+    void applyUiScale(effectiveUiScale).then((engine) => {
+      if (!cancelled) setUiScaleEngine(engine);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [effectiveUiScale]);
+  const visibleShellWidth = responsiveShellWidth(shellWidth, effectiveUiScale, uiScaleEngine);
   const shellSizeClass =
-    shellWidth <= 600 ? 'shell-mini' : shellWidth <= 1100 ? 'shell-narrow' : '';
+    visibleShellWidth <= 600 ? 'shell-mini' : visibleShellWidth <= 1100 ? 'shell-narrow' : '';
   const theme = useAppStore((s) => s.theme);
 
   const locale = useAppStore((s) => s.locale);
@@ -1363,7 +1378,7 @@ function App() {
 
   return (
     <div
-      ref={shellRef}
+      ref={observeShell}
       className={appShellClasses({
         navStyle,
         navRailSide,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -78,9 +78,10 @@ import { listenDictationNotice, showDictationNotice } from './utils/dictationNot
 import { addBreadcrumb } from './utils/breadcrumbs';
 import { appShellClasses } from './utils/appShellClasses';
 import { configuredRemoteBackend, probeRemoteBackend } from './utils/remoteBackendProbe';
-import { applyUiScale, responsiveShellWidth } from './utils/uiScaleEngine';
+import { applyUiScale } from './utils/uiScaleEngine';
 import { resolveUiScale, suggestUiScale } from './utils/uiScaleSuggestion';
 import { recordValueMoment } from './utils/donationMoments';
+import useResponsiveShellSize from './hooks/useResponsiveShellSize';
 import {
   POPULAR_LANGS,
   POPULAR_ISO,
@@ -168,30 +169,6 @@ function App() {
     typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window ? 'native' : 'css',
   );
 
-  // Responsive shell breakpoints driven off the app-container's OWN width, not
-  // the viewport. The shell is sized `width: calc(100vw / --ui-scale)` then
-  // `zoom: --ui-scale` (#504; the WebKitGTK no-op case is handled by the
-  // data-zoom-layout probe below), so the grid lays out against `100vw/scale` —
-  // which `el.clientWidth` reports. Viewport `@media` queries fire on raw
-  // `100vw` and so collapse at the wrong threshold whenever the UI scale ≠ 1,
-  // cramming the content into a sliver. ResizeObserver fires on both window
-  // resize and scale change (the calc width changes), so this stays correct.
-  const shellObserverRef = useRef(/** @type {ResizeObserver | null} */ (null));
-  const [shellWidth, setShellWidth] = useState(Infinity);
-  const observeShell = useCallback((node) => {
-    shellObserverRef.current?.disconnect();
-    shellObserverRef.current = null;
-    if (!node) return;
-
-    const measure = () => setShellWidth(node.clientWidth);
-    measure();
-    if (typeof ResizeObserver === 'undefined') return;
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(node);
-    shellObserverRef.current = observer;
-  }, []);
-
   // Desktop UI scale belongs at the webview boundary. A CSS `zoom` probe can
   // report the expected bounding box on WebKitGTK even when the painted shell
   // still occupies only the upper-left of the window. Tauri's native zoom keeps
@@ -205,9 +182,7 @@ function App() {
       cancelled = true;
     };
   }, [effectiveUiScale]);
-  const visibleShellWidth = responsiveShellWidth(shellWidth, effectiveUiScale, uiScaleEngine);
-  const shellSizeClass =
-    visibleShellWidth <= 600 ? 'shell-mini' : visibleShellWidth <= 1100 ? 'shell-narrow' : '';
+  const { observeShell, shellSizeClass } = useResponsiveShellSize(effectiveUiScale, uiScaleEngine);
   const theme = useAppStore((s) => s.theme);
 
   const locale = useAppStore((s) => s.locale);

--- a/frontend/src/hooks/useResponsiveShellSize.js
+++ b/frontend/src/hooks/useResponsiveShellSize.js
@@ -1,0 +1,39 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { responsiveShellWidth } from '../utils/uiScaleEngine';
+
+export function shellSizeClassForWidth(width) {
+  if (width <= 600) return 'shell-mini';
+  if (width <= 1100) return 'shell-narrow';
+  return '';
+}
+
+/**
+ * Observe the real app shell rather than the viewport. The callback ref is
+ * intentional: App mounts bootstrap/setup screens before `.app-container`, so
+ * an effect that runs only on the first render never sees the shell at all.
+ */
+export default function useResponsiveShellSize(scale, engine) {
+  const observerRef = useRef(/** @type {ResizeObserver | null} */ (null));
+  const [shellWidth, setShellWidth] = useState(Infinity);
+
+  const observeShell = useCallback((node) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) return;
+
+    const measure = () => setShellWidth(node.clientWidth);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+
+  const visibleShellWidth = responsiveShellWidth(shellWidth, scale, engine);
+  return {
+    observeShell,
+    shellSizeClass: shellSizeClassForWidth(visibleShellWidth),
+  };
+}

--- a/frontend/src/hooks/useResponsiveShellSize.test.jsx
+++ b/frontend/src/hooks/useResponsiveShellSize.test.jsx
@@ -1,0 +1,76 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import useResponsiveShellSize from './useResponsiveShellSize';
+
+let activeObserver;
+let originalClientWidth;
+
+class ResizeObserverMock {
+  constructor(callback) {
+    this.callback = callback;
+    activeObserver = this;
+  }
+
+  observe() {}
+
+  disconnect() {}
+
+  trigger() {
+    this.callback([]);
+  }
+}
+
+function Harness({ mounted, width }) {
+  const { observeShell, shellSizeClass } = useResponsiveShellSize(1, 'native');
+  return (
+    <>
+      <output data-testid="shell-class">{shellSizeClass || 'wide'}</output>
+      {mounted && <div ref={observeShell} data-test-width={width} />}
+    </>
+  );
+}
+
+describe('useResponsiveShellSize', () => {
+  beforeEach(() => {
+    activeObserver = undefined;
+    originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return Number(this.dataset.testWidth || 0);
+      },
+    });
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalClientWidth) {
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, 'clientWidth');
+    }
+  });
+
+  it('measures a shell mounted after bootstrap and follows both breakpoints', () => {
+    const view = render(<Harness mounted={false} width={1200} />);
+    expect(screen.getByTestId('shell-class')).toHaveTextContent('wide');
+
+    view.rerender(<Harness mounted width={1200} />);
+    expect(screen.getByTestId('shell-class')).toHaveTextContent('wide');
+    expect(activeObserver).toBeInstanceOf(ResizeObserverMock);
+
+    view.rerender(<Harness mounted width={1100} />);
+    act(() => activeObserver.trigger());
+    expect(screen.getByTestId('shell-class')).toHaveTextContent('shell-narrow');
+
+    view.rerender(<Harness mounted width={600} />);
+    act(() => activeObserver.trigger());
+    expect(screen.getByTestId('shell-class')).toHaveTextContent('shell-mini');
+
+    view.rerender(<Harness mounted width={1101} />);
+    act(() => activeObserver.trigger());
+    expect(screen.getByTestId('shell-class')).toHaveTextContent('wide');
+  });
+});

--- a/frontend/src/test/appShellScale.test.js
+++ b/frontend/src/test/appShellScale.test.js
@@ -20,6 +20,7 @@ import { resolve } from 'node:path';
 // patterns.
 const raw = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
 const css = raw.replace(/\/\*[\s\S]*?\*\//g, '');
+const app = readFileSync(resolve(process.cwd(), 'src/App.jsx'), 'utf8');
 
 describe('app shell scale (black-band + clipping regression guard)', () => {
   it('does NOT scale the shell via transform: scale(--ui-scale)', () => {
@@ -51,5 +52,18 @@ describe('app shell scale (black-band + clipping regression guard)', () => {
     expect(css).toMatch(
       /\[data-ui-scale-engine=['"]?native['"]?\][^{]*\.app-container\s*\{[^}]*width:\s*100vw[^}]*height:\s*100vh[^}]*zoom:\s*1/,
     );
+  });
+
+  it('drives responsive shell classes from the visible native-zoom width', () => {
+    expect(app).toMatch(
+      /responsiveShellWidth\(\s*shellWidth,\s*effectiveUiScale,\s*uiScaleEngine,?\s*\)/,
+    );
+    expect(app).toMatch(/visibleShellWidth <= 600[\s\S]*visibleShellWidth <= 1100/);
+  });
+
+  it('starts observing when the studio shell mounts after bootstrap', () => {
+    expect(app).toMatch(/const observeShell = useCallback\(\(node\) =>/);
+    expect(app).toMatch(/ref=\{observeShell\}/);
+    expect(app).toMatch(/const measure = \(\) => setShellWidth\(node\.clientWidth\)/);
   });
 });

--- a/frontend/src/test/appShellScale.test.js
+++ b/frontend/src/test/appShellScale.test.js
@@ -20,7 +20,6 @@ import { resolve } from 'node:path';
 // patterns.
 const raw = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
 const css = raw.replace(/\/\*[\s\S]*?\*\//g, '');
-const app = readFileSync(resolve(process.cwd(), 'src/App.jsx'), 'utf8');
 
 describe('app shell scale (black-band + clipping regression guard)', () => {
   it('does NOT scale the shell via transform: scale(--ui-scale)', () => {
@@ -52,18 +51,5 @@ describe('app shell scale (black-band + clipping regression guard)', () => {
     expect(css).toMatch(
       /\[data-ui-scale-engine=['"]?native['"]?\][^{]*\.app-container\s*\{[^}]*width:\s*100vw[^}]*height:\s*100vh[^}]*zoom:\s*1/,
     );
-  });
-
-  it('drives responsive shell classes from the visible native-zoom width', () => {
-    expect(app).toMatch(
-      /responsiveShellWidth\(\s*shellWidth,\s*effectiveUiScale,\s*uiScaleEngine,?\s*\)/,
-    );
-    expect(app).toMatch(/visibleShellWidth <= 600[\s\S]*visibleShellWidth <= 1100/);
-  });
-
-  it('starts observing when the studio shell mounts after bootstrap', () => {
-    expect(app).toMatch(/const observeShell = useCallback\(\(node\) =>/);
-    expect(app).toMatch(/ref=\{observeShell\}/);
-    expect(app).toMatch(/const measure = \(\) => setShellWidth\(node\.clientWidth\)/);
   });
 });

--- a/frontend/src/utils/uiScaleEngine.js
+++ b/frontend/src/utils/uiScaleEngine.js
@@ -1,6 +1,17 @@
 const loadTauriWebview = () => import('@tauri-apps/api/webview');
 
 /**
+ * Native Tauri zoom scales the painted webview without shrinking the DOM's
+ * reported container width. Responsive breakpoints need the width in visible
+ * CSS pixels, while the browser fallback has already shrunk its layout box via
+ * CSS and must not be divided a second time.
+ */
+export function responsiveShellWidth(shellWidth, scale, engine) {
+  const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+  return engine === 'native' ? shellWidth / safeScale : shellWidth;
+}
+
+/**
  * Apply the user's UI scale at the webview boundary when Tauri is available.
  * Native zoom keeps the CSS viewport equal to the visible window on every
  * platform; CSS zoom remains the browser/dev fallback.

--- a/frontend/src/utils/uiScaleEngine.js
+++ b/frontend/src/utils/uiScaleEngine.js
@@ -1,4 +1,9 @@
 const loadTauriWebview = () => import('@tauri-apps/api/webview');
+let scaleApplicationQueue = Promise.resolve();
+
+/**
+ * @typedef {() => Promise<{ getCurrentWebview: () => { setZoom: (scale: number) => Promise<void> } }>} WebviewLoader
+ */
 
 /**
  * Native Tauri zoom scales the painted webview without shrinking the DOM's
@@ -12,14 +17,10 @@ export function responsiveShellWidth(shellWidth, scale, engine) {
 }
 
 /**
- * Apply the user's UI scale at the webview boundary when Tauri is available.
- * Native zoom keeps the CSS viewport equal to the visible window on every
- * platform; CSS zoom remains the browser/dev fallback.
- *
  * @param {number} scale
- * @param {() => Promise<{ getCurrentWebview: () => { setZoom: (scale: number) => Promise<void> } }>} [loadWebview]
+ * @param {WebviewLoader} loadWebview
  */
-export async function applyUiScale(scale, loadWebview = loadTauriWebview) {
+async function applyUiScaleNow(scale, loadWebview) {
   const root = document.documentElement;
   if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) {
     root.dataset.uiScaleEngine = 'css';
@@ -37,4 +38,24 @@ export async function applyUiScale(scale, loadWebview = loadTauriWebview) {
     root.dataset.uiScaleEngine = 'css';
     return 'css';
   }
+}
+
+/**
+ * Apply the user's UI scale at the webview boundary when Tauri is available.
+ * Native zoom keeps the CSS viewport equal to the visible window on every
+ * platform; CSS zoom remains the browser/dev fallback.
+ *
+ * @param {number} scale
+ * @param {WebviewLoader} [loadWebview]
+ */
+export function applyUiScale(scale, loadWebview = loadTauriWebview) {
+  // Webview.setZoom is asynchronous. Keep applications ordered so a slower
+  // older request cannot finish after a newer one and restore stale native
+  // zoom while React holds the newer engine/scale state.
+  const application = scaleApplicationQueue.then(() => applyUiScaleNow(scale, loadWebview));
+  scaleApplicationQueue = application.then(
+    () => undefined,
+    () => undefined,
+  );
+  return application;
 }

--- a/frontend/src/utils/uiScaleEngine.test.js
+++ b/frontend/src/utils/uiScaleEngine.test.js
@@ -1,6 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { applyUiScale } from './uiScaleEngine';
+import { applyUiScale, responsiveShellWidth } from './uiScaleEngine';
+
+describe('responsiveShellWidth', () => {
+  it('uses visible CSS pixels for native Tauri zoom', () => {
+    expect(responsiveShellWidth(1412, 1.75, 'native')).toBeCloseTo(806.86, 2);
+  });
+
+  it('does not normalize the already-shrunk CSS zoom layout twice', () => {
+    expect(responsiveShellWidth(807, 1.75, 'css')).toBe(807);
+  });
+
+  it('treats an invalid scale as 1', () => {
+    expect(responsiveShellWidth(900, 0, 'native')).toBe(900);
+  });
+});
 
 describe('applyUiScale', () => {
   beforeEach(() => {

--- a/frontend/src/utils/uiScaleEngine.test.js
+++ b/frontend/src/utils/uiScaleEngine.test.js
@@ -54,4 +54,31 @@ describe('applyUiScale', () => {
 
     expect(document.documentElement.dataset.uiScaleEngine).toBe('css');
   });
+
+  it('serializes overlapping native zoom changes so the latest scale wins', async () => {
+    window.__TAURI_INTERNALS__ = {};
+    /** @type {(() => void) | undefined} */
+    let finishFirst;
+    const setZoom = vi.fn((/** @type {number} */ scale) => {
+      if (scale === 0.85) {
+        return new Promise((resolve) => {
+          finishFirst = () => resolve(undefined);
+        });
+      }
+      return Promise.resolve();
+    });
+    const loadWebview = async () => ({ getCurrentWebview: () => ({ setZoom }) });
+
+    const first = applyUiScale(0.85, loadWebview);
+    const latest = applyUiScale(1.2, loadWebview);
+    await vi.waitFor(() => expect(setZoom).toHaveBeenCalledTimes(1));
+    expect(setZoom).toHaveBeenLastCalledWith(0.85);
+
+    expect(finishFirst).toBeTypeOf('function');
+    finishFirst?.();
+    await Promise.all([first, latest]);
+
+    expect(setZoom.mock.calls.map(([scale]) => scale)).toEqual([0.85, 1.2]);
+    expect(document.documentElement.dataset.uiScaleEngine).toBe('native');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes responsive workspace breakpoints that never activated after the desktop bootstrap splash, which crushed the Dubbing demo between fixed Projects and History rails.

Closes #1683.

## Changes

- Start shell measurement from a callback ref when the post-bootstrap app container actually mounts
- Normalize responsive width for Tauri native UI zoom without double-normalizing CSS zoom
- Add regression coverage for bootstrap mount timing and both scale engines
- Document the fix in the changelog

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- 20 targeted Vitest checks pass
- 8 changelog-style checks pass
- Frontend lint completes with no errors
- Live Tauri verification at the reported 1.2 UI scale: Dubbing demo renders full-width with readable side-by-side players; Projects and History reflow below

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync (no version bump)
- [x] Runtime fixture coverage remains delegated to the smoke-matrix CI job

## Release cadence

VoiceStudio ships continuous-to-main; this fix will enter the rolling preview after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The responsive shell now measures its post-bootstrap container and applies native UI-scale normalization without double-normalizing CSS zoom. This reflows the Dubbing workspace before fixed Projects and History rails make the center pane unreadable. Review the asynchronous native zoom queue and delayed shell measurement for race conditions during remounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->