### PR TITLE
feat(ui): give Model Catalogue room to breathe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Dub subtitles can be retimed, inserted, and merged in either direction from the segment table (#1612) — thanks @invio-a11y!
 
 ### Changed
+- Model Catalogue now uses one breathable workspace canvas with simpler pane and engine-family navigation instead of nested cards and scroll regions (#1685)
 - Linux source launchers now catch missing libxdo and GStreamer audio plugins before they can cause a linker error or an aborted, blank WebKit renderer (#1680, #1682)
 - Dictation now carries one native output session from shortcut-down through final delivery, restores text, HTML, image, or file-list clipboards only when untouched, keeps Wayland copy-safe unless current-focus insertion is explicitly enabled, and retries silent Sherpa speech only through an already-installed local ASR model (#1175)
 - The backend binds its port immediately and reports startup progress live — `/health` answers 503-with-step and a new `/startup/progress` endpoint lists every step while PyTorch, API routes, and database migrations load in the background, so "starting at step X" is never mistakable for "dead"; the desktop splash narrates each step (#1550)

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -93,6 +93,8 @@ function reasonMentionsLicense(reason) {
  *   - reloadToken?: any  bump to force a data refetch without remounting —
  *     lets a companion config panel flip a row from unavailable → available
  *     (and refresh the "Use" button) right after a save.
+ *   - catalogueLayout?: boolean  opens the matrix into the page's single
+ *     scroll plane and removes the compact Settings-within-Settings chrome.
  */
 const FAMILY_META = {
   tts: { label: 'TTS', icon: Cpu },
@@ -227,6 +229,7 @@ export default function EngineCompatibilityMatrix({
   showFamilyTabs = true,
   onFamilyChange = null,
   reloadToken = 0,
+  catalogueLayout = false,
   // The catalogue passes its app-wide query here. Keeping the standalone
   // fallback preserves the matrix's injectable API seam for isolated hosts
   // and its extensive focused test suite.
@@ -643,20 +646,31 @@ export default function EngineCompatibilityMatrix({
   // no switcher to say which family this table is.
   const familyMeta = FAMILY_META[activeFamily] || FAMILY_META.tts;
   const TitleIcon = showFamilyTabs ? Layers : familyMeta.icon;
+  const TitleHeading = catalogueLayout ? 'h2' : 'h3';
 
   return (
-    <section className="engine-matrix flex min-h-0 flex-1 flex-col gap-[8px]">
-      <header className="engine-matrix__head flex flex-wrap items-center justify-between gap-[8px] rounded-[10px] bg-[var(--chrome-bg)] px-[10px] py-[7px]">
-        <h3 className="engine-matrix__title m-0 inline-flex min-w-0 items-center gap-[8px] text-[length:var(--text-sm)] font-semibold text-[color:var(--chrome-fg,currentColor)]">
-          <span className="inline-flex h-[24px] w-[24px] shrink-0 items-center justify-center rounded-[7px] bg-[color-mix(in_srgb,var(--chrome-accent)_11%,transparent)] text-[var(--chrome-accent)]">
-            <TitleIcon size={13} aria-hidden="true" />
+    <section
+      className={`engine-matrix flex min-h-0 flex-col ${catalogueLayout ? 'gap-[18px]' : 'flex-1 gap-[8px]'}`}
+    >
+      <header
+        className={`engine-matrix__head flex flex-wrap items-center justify-between gap-[12px] ${
+          catalogueLayout ? 'px-[2px]' : 'rounded-[10px] bg-[var(--chrome-bg)] px-[10px] py-[7px]'
+        }`}
+      >
+        <TitleHeading
+          className={`engine-matrix__title m-0 inline-flex min-w-0 items-center gap-[10px] font-semibold text-[color:var(--chrome-fg,currentColor)] ${catalogueLayout ? 'text-[length:var(--text-lg)]' : 'text-[length:var(--text-sm)]'}`}
+        >
+          <span
+            className={`inline-flex shrink-0 items-center justify-center bg-[color-mix(in_srgb,var(--chrome-accent)_11%,transparent)] text-[var(--chrome-accent)] ${catalogueLayout ? 'h-[30px] w-[30px] rounded-[10px]' : 'h-[24px] w-[24px] rounded-[7px]'}`}
+          >
+            <TitleIcon size={catalogueLayout ? 15 : 13} aria-hidden="true" />
           </span>
           <span>
             {showFamilyTabs
               ? t('engines.matrixTitle')
               : t('engines.familyMatrixTitle', { family: familyMeta.label })}
           </span>
-        </h3>
+        </TitleHeading>
         <Button
           size="sm"
           variant="ghost"
@@ -671,7 +685,12 @@ export default function EngineCompatibilityMatrix({
       {showFamilyTabs && families.length > 1 && (
         <Tabs
           size="sm"
-          className="engine-matrix__tabs w-full [&>*]:flex-1"
+          variant={catalogueLayout ? 'underline' : 'pill'}
+          className={
+            catalogueLayout
+              ? 'engine-matrix__tabs w-fit gap-[28px]'
+              : 'engine-matrix__tabs w-full [&>*]:flex-1'
+          }
           value={activeFamily}
           onChange={(f) => {
             setActiveFamily(f);
@@ -691,12 +710,14 @@ export default function EngineCompatibilityMatrix({
                   <span className="engine-matrix__tab-family text-[11px] font-bold tracking-[0.03em]">
                     {FAMILY_META[f].label}
                   </span>
-                  <span
-                    className="engine-matrix__tab-active max-w-[120px] truncate rounded-[5px] bg-black/[0.09] px-[5px] py-[3px] font-mono text-[9px] lowercase tracking-[0] opacity-70"
-                    translate="no"
-                  >
-                    {data[f].active}
-                  </span>
+                  {!catalogueLayout && (
+                    <span
+                      className="engine-matrix__tab-active max-w-[120px] truncate rounded-[5px] bg-black/[0.09] px-[5px] py-[3px] font-mono text-[9px] lowercase tracking-[0] opacity-70"
+                      translate="no"
+                    >
+                      {data[f].active}
+                    </span>
+                  )}
                 </span>
               ),
             };
@@ -709,7 +730,10 @@ export default function EngineCompatibilityMatrix({
           tabbed and pinned modes, always for the family on screen. */}
       <p
         className={cn(
-          'engine-matrix__family-desc m-0 rounded-[8px] bg-[color-mix(in_srgb,var(--chrome-accent)_5%,transparent)] px-[10px] py-[6px] text-[11px] leading-[1.4]',
+          'engine-matrix__family-desc m-0 text-[11px] leading-[1.55]',
+          catalogueLayout
+            ? 'max-w-[720px] px-[2px]'
+            : 'rounded-[8px] bg-[color-mix(in_srgb,var(--chrome-accent)_5%,transparent)] px-[10px] py-[6px]',
           MUTED,
         )}
         data-testid={`family-desc-${activeFamily}`}
@@ -718,7 +742,11 @@ export default function EngineCompatibilityMatrix({
       </p>
 
       <Table
-        className="engine-matrix__table flex min-h-0 flex-1 flex-col overflow-hidden rounded-[10px] bg-[var(--chrome-bg)] shadow-[0_5px_18px_color-mix(in_srgb,black_10%,transparent)]"
+        className={`engine-matrix__table flex min-h-0 flex-col overflow-hidden ${
+          catalogueLayout
+            ? 'rounded-[14px] bg-[color-mix(in_srgb,var(--chrome-fg)_2.5%,transparent)] ring-1 ring-[color-mix(in_srgb,var(--chrome-fg)_7%,transparent)]'
+            : 'flex-1 rounded-[10px] bg-[var(--chrome-bg)] shadow-[0_5px_18px_color-mix(in_srgb,black_10%,transparent)]'
+        }`}
         role="table"
         aria-label={t('engines.engineCompatLabel', { family: activeFamily })}
       >
@@ -748,7 +776,11 @@ export default function EngineCompatibilityMatrix({
           </span>
         </div>
         <div
-          className="settings-list-scroll flex min-h-0 flex-1 flex-col gap-[var(--space-2)] overflow-y-auto overscroll-contain py-[var(--space-2)] [scrollbar-gutter:stable] focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_var(--chrome-accent)]"
+          className={`settings-list-scroll flex min-h-0 flex-col focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_var(--chrome-accent)] ${
+            catalogueLayout
+              ? 'py-[var(--space-2)]'
+              : 'flex-1 gap-[var(--space-2)] overflow-y-auto overscroll-contain py-[var(--space-2)] [scrollbar-gutter:stable]'
+          }`}
           role="rowgroup"
           tabIndex={0}
           data-testid="engine-list-scroll"
@@ -830,7 +862,9 @@ export default function EngineCompatibilityMatrix({
                     'engine-matrix__row',
                     ROW_GRID,
                     ROW_SHELL,
-                    'mx-[var(--space-2)] rounded-[var(--chrome-radius-pill)] border border-[color-mix(in_srgb,var(--chrome-fg)_7%,transparent)] transition-colors duration-[120ms] hover:bg-[var(--chrome-hover-bg)]',
+                    catalogueLayout
+                      ? 'mx-[var(--space-2)] border-b border-[color-mix(in_srgb,var(--chrome-fg)_7%,transparent)] transition-colors duration-[120ms] hover:bg-[var(--chrome-hover-bg)]'
+                      : 'mx-[var(--space-2)] rounded-[var(--chrome-radius-pill)] border border-[color-mix(in_srgb,var(--chrome-fg)_7%,transparent)] transition-colors duration-[120ms] hover:bg-[var(--chrome-hover-bg)]',
                     isActive &&
                       'bg-[color-mix(in_srgb,var(--chrome-accent)_7%,transparent)] shadow-[inset_2px_0_0_var(--chrome-accent)]',
                     // Dim the TEXT of an unavailable row, not the row: fading

--- a/frontend/src/components/settings/EnginesTab.jsx
+++ b/frontend/src/components/settings/EnginesTab.jsx
@@ -26,7 +26,11 @@ import { SETTINGS_SECTION_SURFACE } from './primitives';
  *  connection, then activate with the engine's own "Use" button. Saving in
  *  the panel bumps `configVersion`, which refetches the matrix so the
  *  engine's row flips unavailable → available without a manual Refresh. */
-export default function EnginesTab({ initialFamily = 'tts', onFamilyChange }) {
+export default function EnginesTab({
+  initialFamily = 'tts',
+  onFamilyChange = null,
+  catalogueLayout = false,
+}) {
   const { t } = useTranslation();
   const [family, setFamily] = useState(initialFamily);
   const [configVersion, setConfigVersion] = useState(0);
@@ -59,9 +63,17 @@ export default function EnginesTab({ initialFamily = 'tts', onFamilyChange }) {
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div
+      className={
+        catalogueLayout ? 'flex min-h-0 flex-col gap-[32px]' : 'flex h-full min-h-0 flex-col'
+      }
+    >
       <section
-        className={`${SETTINGS_SECTION_SURFACE} flex min-h-[500px] flex-1 flex-col`}
+        className={
+          catalogueLayout
+            ? 'flex min-h-0 flex-col'
+            : `${SETTINGS_SECTION_SURFACE} flex min-h-[500px] flex-1 flex-col`
+        }
         data-slot="settings-section"
         aria-label={t('settings.engines')}
       >
@@ -74,6 +86,7 @@ export default function EnginesTab({ initialFamily = 'tts', onFamilyChange }) {
             onFamilyChange?.(next);
           }}
           reloadToken={configVersion}
+          catalogueLayout={catalogueLayout}
         />
       </section>
       {family === 'asr' && <AsrOpenAICompatPanel onSaved={onAsrConfigSaved} />}

--- a/frontend/src/components/settings/ModelStoreTab.jsx
+++ b/frontend/src/components/settings/ModelStoreTab.jsx
@@ -30,7 +30,7 @@ import VoicePreviewsPanel from './VoicePreviewsPanel';
  * platform-incompatible rows collapse behind a per-section toggle. Per-model
  * download progress is pulled from the shared /setup/download-stream SSE.
  */
-export default function ModelStoreTab({ info, modelBadge }) {
+export default function ModelStoreTab({ info, modelBadge, catalogueLayout = false }) {
   const { t } = useTranslation();
   // Role labels — localized (diarization is an on-disk spelling alias for
   // diarisation; both map to the same label).
@@ -367,6 +367,13 @@ export default function ModelStoreTab({ info, modelBadge }) {
   );
 
   if (loading && !data) {
+    if (catalogueLayout) {
+      return (
+        <div className="px-[2px] py-[24px] font-sans text-[var(--text-md)] text-[var(--chrome-fg-dim)]">
+          {t('common.loading')}
+        </div>
+      );
+    }
     return (
       <SettingsSection icon={Cpu} title={t('settings.models')}>
         <div className="settings-muted font-sans text-[var(--text-md)] text-[var(--chrome-fg-dim)]">
@@ -380,11 +387,21 @@ export default function ModelStoreTab({ info, modelBadge }) {
   return (
     <>
       <section
-        className={`${SETTINGS_SECTION_SURFACE} flex min-h-[95%] flex-col`}
+        className={
+          catalogueLayout
+            ? 'flex min-h-0 flex-col'
+            : `${SETTINGS_SECTION_SURFACE} flex min-h-[95%] flex-col`
+        }
         data-slot="settings-section"
         data-testid="model-list-panel"
       >
-        <div className="flex flex-wrap items-center justify-between gap-[var(--space-3)] px-[2px] pb-[6px] pt-[2px] font-[family-name:var(--chrome-font-mono)] text-[length:var(--text-xs)] text-[var(--chrome-fg-muted)] max-[580px]:flex-col max-[580px]:items-start">
+        <div
+          className={`flex flex-wrap items-center justify-between gap-[var(--space-3)] font-[family-name:var(--chrome-font-mono)] text-[length:var(--text-xs)] text-[var(--chrome-fg-muted)] max-[580px]:flex-col max-[580px]:items-start ${
+            catalogueLayout
+              ? 'mb-[24px] border-b border-[color-mix(in_srgb,var(--chrome-fg)_8%,transparent)] px-[2px] pb-[18px]'
+              : 'px-[2px] pb-[6px] pt-[2px]'
+          }`}
+        >
           <div className="inline-flex flex-wrap items-center gap-[var(--space-2)]">
             <span>
               <strong className="font-semibold text-[var(--chrome-fg)]">
@@ -500,7 +517,9 @@ export default function ModelStoreTab({ info, modelBadge }) {
           diskFreeGb={data.disk_free_gb}
         />
 
-        <div className="my-[var(--space-2)] flex items-center gap-[var(--space-2)] max-[580px]:flex-col max-[580px]:items-stretch">
+        <div
+          className={`${catalogueLayout ? 'my-[24px]' : 'my-[var(--space-2)]'} flex items-center gap-[var(--space-2)] max-[580px]:flex-col max-[580px]:items-stretch`}
+        >
           <SettingsInput
             type="search"
             className="max-w-none flex-1 text-[length:var(--text-xs)] min-w-[120px]"

--- a/frontend/src/pages/ModelCatalogue.jsx
+++ b/frontend/src/pages/ModelCatalogue.jsx
@@ -159,6 +159,7 @@ export default function ModelCatalogue() {
             value={pane}
             onChange={setPane}
             variant="underline"
+            idPrefix="catalogue-pane"
             aria-label={t('catalogue.title')}
             data-testid="catalogue-pane-switch"
           />
@@ -169,9 +170,10 @@ export default function ModelCatalogue() {
             scrolling inside them. */}
         <div
           key={pane}
+          id={`catalogue-pane-panel-${pane}`}
           data-testid={`catalogue-pane-${pane}`}
           role="tabpanel"
-          aria-label={t(pane === 'models' ? 'catalogue.tab_models' : 'catalogue.tab_engines')}
+          aria-labelledby={`catalogue-pane-tab-${pane}`}
           className="min-w-0 [&>*:first-child]:mt-0"
         >
           {pane === 'engines' ? (

--- a/frontend/src/pages/ModelCatalogue.jsx
+++ b/frontend/src/pages/ModelCatalogue.jsx
@@ -21,7 +21,7 @@
  * consumes it once and clears it so a later plain visit reopens the last pane.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Boxes, CheckCircle, RefreshCw } from 'lucide-react';
+import { Boxes, CheckCircle, Cpu, HardDriveDownload, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../store';
 import { useModelStatus, useSystemInfo } from '../api/hooks';
@@ -126,8 +126,8 @@ export default function ModelCatalogue() {
   // primitive, which the switch had to describe with an aria-label.
   const paneItems = useMemo(
     () => [
-      { id: 'engines', label: t('catalogue.tab_engines') },
-      { id: 'models', label: t('catalogue.tab_models') },
+      { id: 'engines', label: t('catalogue.tab_engines'), icon: Cpu },
+      { id: 'models', label: t('catalogue.tab_models'), icon: HardDriveDownload },
     ],
     [t],
   );
@@ -136,29 +136,29 @@ export default function ModelCatalogue() {
     // Same container-query shell as Settings: the app is zoom-scaled, so
     // viewport media queries fire at the wrong logical width under Tauri.
     <div
-      className="h-full min-h-0 w-full [container-type:inline-size] [container-name:catalogue-shell]"
+      className="h-full min-h-0 w-full overflow-y-auto overscroll-contain bg-[var(--chrome-bg)] [container-type:inline-size] [container-name:catalogue-shell]"
       data-testid="model-catalogue"
     >
-      <div className="flex h-full min-h-0 w-full box-border flex-col overflow-y-auto bg-[var(--chrome-bg)] p-[var(--space-4)_var(--space-5)_var(--space-5)] font-sans @min-[760px]/catalogue-shell:overflow-hidden">
-        {/* One line of chrome: what this is, and which half of it you're on.
-            Both panes already headline themselves (the matrix names the active
-            engine, the model store carries disk/cache status), so a subtitle
-            here would only repeat what the content says better. */}
-        <header className="z-10 mb-[var(--space-4)] flex shrink-0 flex-wrap items-center gap-x-[var(--space-3)] gap-y-[var(--space-2)] border-b border-[color-mix(in_srgb,var(--chrome-fg)_7%,transparent)] bg-[var(--chrome-bg)] pb-[var(--space-3)]">
-          <span
-            className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-[var(--chrome-radius-pill)] bg-[color-mix(in_srgb,var(--chrome-accent)_12%,var(--chrome-bg))] text-[color:var(--chrome-accent)]"
-            aria-hidden="true"
-          >
-            <Boxes size={14} />
-          </span>
-          <h1 className="m-0 min-w-0 flex-auto truncate [font-family:var(--font-sans)] text-[length:var(--text-lg)] font-semibold tracking-[-0.015em] text-[color:var(--chrome-fg)]">
-            {t('catalogue.title')}
-          </h1>
+      <div className="mx-auto box-border w-full max-w-[1320px] px-[44px] pb-[56px] pt-[34px] font-sans @max-[900px]/catalogue-shell:px-[24px] @max-[900px]/catalogue-shell:pb-[36px] @max-[900px]/catalogue-shell:pt-[26px] @max-[560px]/catalogue-shell:px-[14px]">
+        {/* Treat this as a workspace, not a Settings card: one editorial title,
+            one quiet navigation line, then the data surface. */}
+        <header className="mb-[24px] flex flex-wrap items-end justify-between gap-x-[32px] gap-y-[18px] border-b border-[color-mix(in_srgb,var(--chrome-fg)_9%,transparent)] pb-[18px] @max-[560px]/catalogue-shell:flex-col @max-[560px]/catalogue-shell:items-start">
+          <div className="flex items-center gap-[12px]">
+            <span
+              className="inline-flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[12px] bg-[color-mix(in_srgb,var(--chrome-accent)_11%,transparent)] text-[color:var(--chrome-accent)]"
+              aria-hidden="true"
+            >
+              <Boxes size={17} strokeWidth={1.6} />
+            </span>
+            <h1 className="m-0 min-w-0 [font-family:var(--font-serif)] text-[2rem] font-normal leading-none tracking-[-0.025em] text-[color:var(--chrome-fg)] @max-[560px]/catalogue-shell:text-[1.55rem]">
+              {t('catalogue.title')}
+            </h1>
+          </div>
           <Tabs
             items={paneItems}
             value={pane}
             onChange={setPane}
-            size="sm"
+            variant="underline"
             aria-label={t('catalogue.title')}
             data-testid="catalogue-pane-switch"
           />
@@ -170,13 +170,14 @@ export default function ModelCatalogue() {
         <div
           key={pane}
           data-testid={`catalogue-pane-${pane}`}
+          role="tabpanel"
           aria-label={t(pane === 'models' ? 'catalogue.tab_models' : 'catalogue.tab_engines')}
-          className="min-w-0 [&>*:first-child]:mt-0 @min-[760px]/catalogue-shell:min-h-0 @min-[760px]/catalogue-shell:flex-1 @min-[760px]/catalogue-shell:overflow-y-auto @min-[760px]/catalogue-shell:overscroll-contain"
+          className="min-w-0 [&>*:first-child]:mt-0"
         >
           {pane === 'engines' ? (
-            <EnginesTab initialFamily={family} onFamilyChange={setFamily} />
+            <EnginesTab initialFamily={family} onFamilyChange={setFamily} catalogueLayout />
           ) : (
-            <ModelStoreTab info={info} modelBadge={modelBadge} />
+            <ModelStoreTab info={info} modelBadge={modelBadge} catalogueLayout />
           )}
         </div>
       </div>

--- a/frontend/src/pages/ModelCatalogue.test.jsx
+++ b/frontend/src/pages/ModelCatalogue.test.jsx
@@ -65,6 +65,20 @@ describe('ModelCatalogue', () => {
     expect(screen.queryByTestId('stub-engines')).toBeNull();
   });
 
+  it('associates each tab with its labelled panel', () => {
+    render(<ModelCatalogue />);
+    const enginesTab = screen.getByRole('tab', { name: 'Engines' });
+    const enginesPanel = screen.getByRole('tabpanel', { name: 'Engines' });
+    expect(enginesTab).toHaveAttribute('aria-controls', enginesPanel.id);
+    expect(enginesPanel).toHaveAttribute('aria-labelledby', enginesTab.id);
+
+    const modelsTab = screen.getByRole('tab', { name: 'Models' });
+    clickTab('Models');
+    const modelsPanel = screen.getByRole('tabpanel', { name: 'Models' });
+    expect(modelsTab).toHaveAttribute('aria-controls', modelsPanel.id);
+    expect(modelsPanel).toHaveAttribute('aria-labelledby', modelsTab.id);
+  });
+
   it('remembers the pane across visits', () => {
     const first = render(<ModelCatalogue />);
     clickTab('Models');

--- a/frontend/src/pages/ModelCatalogue.test.jsx
+++ b/frontend/src/pages/ModelCatalogue.test.jsx
@@ -8,10 +8,18 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 
 vi.mock('../components/settings/EnginesTab', () => ({
-  default: ({ initialFamily }) => <div data-testid="stub-engines">{initialFamily}</div>,
+  default: ({ initialFamily, catalogueLayout }) => (
+    <div data-testid="stub-engines" data-catalogue-layout={catalogueLayout || undefined}>
+      {initialFamily}
+    </div>
+  ),
 }));
 vi.mock('../components/settings/ModelStoreTab', () => ({
-  default: ({ modelBadge }) => <div data-testid="stub-models">{modelBadge}</div>,
+  default: ({ modelBadge, catalogueLayout }) => (
+    <div data-testid="stub-models" data-catalogue-layout={catalogueLayout || undefined}>
+      {modelBadge}
+    </div>
+  ),
 }));
 vi.mock('../api/hooks', () => ({
   useSystemInfo: () => ({ data: { has_hf_token: false } }),
@@ -46,10 +54,14 @@ describe('ModelCatalogue', () => {
   it('opens on the Engines pane and switches to Models', () => {
     render(<ModelCatalogue />);
     expect(screen.getByTestId('stub-engines')).toBeInTheDocument();
+    expect(screen.getByRole('tabpanel', { name: 'Engines' })).toBeInTheDocument();
+    expect(screen.getByTestId('stub-engines')).toHaveAttribute('data-catalogue-layout', 'true');
     expect(screen.queryByTestId('stub-models')).toBeNull();
 
     clickTab('Models');
     expect(screen.getByTestId('stub-models')).toBeInTheDocument();
+    expect(screen.getByRole('tabpanel', { name: 'Models' })).toBeInTheDocument();
+    expect(screen.getByTestId('stub-models')).toHaveAttribute('data-catalogue-layout', 'true');
     expect(screen.queryByTestId('stub-engines')).toBeNull();
   });
 

--- a/frontend/src/ui/Tabs.jsx
+++ b/frontend/src/ui/Tabs.jsx
@@ -77,8 +77,12 @@ export default function Tabs({
             <TabsTrigger
               key={item.id}
               value={item.id}
-              id={idPrefix ? `${idPrefix}-tab-${item.id}` : undefined}
-              aria-controls={idPrefix ? `${idPrefix}-panel-${item.id}` : undefined}
+              {...(idPrefix
+                ? {
+                    id: `${idPrefix}-tab-${item.id}`,
+                    'aria-controls': `${idPrefix}-panel-${item.id}`,
+                  }
+                : {})}
               className={`ui-tabs__tab ${active ? 'is-active' : ''} ${tabClass}`}
               title={item.title}
               style={active && item.accent ? { '--ui-tab-accent': item.accent } : undefined}

--- a/frontend/src/ui/Tabs.jsx
+++ b/frontend/src/ui/Tabs.jsx
@@ -14,6 +14,7 @@ import { Tabs as ShadcnTabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
  * @param size      'sm' | 'md'
  * @param variant   'pill' (default) | 'underline'
  * @param idPrefix  optional prefix used to associate triggers with external panels
+ * @param children  optional Radix TabsContent elements associated by value
  */
 export default function Tabs({
   items = [],
@@ -22,6 +23,7 @@ export default function Tabs({
   size = 'md',
   variant = 'pill',
   idPrefix,
+  children,
   className = '',
   ...rest
 }) {
@@ -93,6 +95,7 @@ export default function Tabs({
           );
         })}
       </TabsList>
+      {children}
     </ShadcnTabs>
   );
 }

--- a/frontend/src/ui/Tabs.jsx
+++ b/frontend/src/ui/Tabs.jsx
@@ -13,6 +13,7 @@ import { Tabs as ShadcnTabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
  * @param onChange  (id) => void
  * @param size      'sm' | 'md'
  * @param variant   'pill' (default) | 'underline'
+ * @param idPrefix  optional prefix used to associate triggers with external panels
  */
 export default function Tabs({
   items = [],
@@ -20,6 +21,7 @@ export default function Tabs({
   onChange,
   size = 'md',
   variant = 'pill',
+  idPrefix,
   className = '',
   ...rest
 }) {
@@ -75,6 +77,8 @@ export default function Tabs({
             <TabsTrigger
               key={item.id}
               value={item.id}
+              id={idPrefix ? `${idPrefix}-tab-${item.id}` : undefined}
+              aria-controls={idPrefix ? `${idPrefix}-panel-${item.id}` : undefined}
               className={`ui-tabs__tab ${active ? 'is-active' : ''} ${tabClass}`}
               title={item.title}
               style={active && item.accent ? { '--ui-tab-accent': item.accent } : undefined}

--- a/frontend/src/ui/Tabs.test.jsx
+++ b/frontend/src/ui/Tabs.test.jsx
@@ -1,14 +1,20 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { TabsContent } from '@/components/ui/tabs';
 import Tabs from './Tabs';
 
 describe('Tabs', () => {
   it('preserves Radix trigger associations when no ID prefix is supplied', () => {
-    render(<Tabs items={[{ id: 'first', label: 'First' }]} value="first" onChange={vi.fn()} />);
+    render(
+      <Tabs items={[{ id: 'first', label: 'First' }]} value="first" onChange={vi.fn()}>
+        <TabsContent value="first">First panel</TabsContent>
+      </Tabs>,
+    );
 
     const trigger = screen.getByRole('tab', { name: 'First' });
-    expect(trigger.id).toBeTruthy();
-    expect(trigger.getAttribute('aria-controls')).toBeTruthy();
+    const panel = screen.getByRole('tabpanel');
+    expect(panel.id).toBe(trigger.getAttribute('aria-controls'));
+    expect(panel).toHaveAttribute('aria-labelledby', trigger.id);
   });
 });

--- a/frontend/src/ui/Tabs.test.jsx
+++ b/frontend/src/ui/Tabs.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Tabs from './Tabs';
+
+describe('Tabs', () => {
+  it('preserves Radix trigger associations when no ID prefix is supplied', () => {
+    render(<Tabs items={[{ id: 'first', label: 'First' }]} value="first" onChange={vi.fn()} />);
+
+    const trigger = screen.getByRole('tab', { name: 'First' });
+    expect(trigger.id).toBeTruthy();
+    expect(trigger.getAttribute('aria-controls')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Rebuilds Model Catalogue as one responsive workspace canvas instead of stacked Settings cards and nested scroll regions.

Closes #1685.

## Changes

- Put the page title and Engines/Models navigation on one responsive wide-screen row, stacking only when space is genuinely tight
- Give the workspace one primary scroll owner and a centered 1320px content measure
- Flatten Engines and Models out of their inherited Settings surfaces
- Simplify family navigation, keep active context in the engine rows, and replace boxed rows with quieter dividers
- Preserve pane/family persistence, deep links, selection, model installs, and keyboard tabs
- Add executable tabpanel/layout hand-off coverage and update the changelog

## Testing

- 85 targeted frontend tests pass across Catalogue, Engines, compatibility matrix, and model grouping
- 256 changelog/locale policy tests pass offline with an empty HF cache
- Frontend lint has no errors; changed files pass formatting
- Live Tauri verification at 940×702 with 1.2× native UI scale and at wide desktop width, on Engines (TTS/LLM) and Models

## Checklist

- [x] Existing behavior preserved
- [x] Responsive/native-scale layout verified
- [x] User-facing strings remain localized (no new strings)
- [x] Changelog updated
- [x] No dependency or version changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Rebuilt the Model Catalogue as a responsive workspace with one primary scroll surface and clearer Engines/Models navigation. This improves hierarchy at narrow and wide desktop sizes while preserving selection, persistence, deep links, installation actions, keyboard behavior, and tabpanel associations. Human review should verify that `catalogueLayout` does not regress the existing Settings presentation or responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->