### PR TITLE
chore(release): prepare v0.5.1

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.3.x (latest release + `main` previews) | ✅ Current — all fixes land here |
+| 0.5.x (latest release + `main` previews) | ✅ Current — all fixes land here |
 | 0.2.7 | ⚠️ Legacy stable — security fixes only, upgrade recommended |
 | < 0.2.7 | ❌ No longer supported |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 `frontend/package.json` is the app-version source of truth; Cargo, Python, and
 the frozen-backend fallback mirror it for their toolchains.
 
-## [Unreleased]
+## [0.5.1] — 2026-08-28
 
 **Highlights**
 
@@ -51,6 +51,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Opt-in 24-layer PocketTTS checkpoints via `OMNIVOICE_POCKETTTS_24L` — better prosody for it/de/es/pt at roughly 2x render time (still faster than real-time); the fast 6-layer model stays the default (#1613) — thanks @paoloantinori!
 
 ### Docs
+- Supported-version and install guidance now identifies 0.5.1 as the stable desktop and container release (#1687)
 - The Docker Hub overview now shows the current engine-switching demo, Model Catalogue, and gallery voice workflow (#1593)
 - The Docker Hub overview and install guide now show the v0.5 tags and the built-in API-key/share-PIN security model instead of obsolete v0.4 and no-authentication guidance (#1592)
 - The READMEs now lead with download buttons and a three-step first-clone walkthrough, and a new benchmarks page anchors measured per-engine/per-device numbers on the in-repo harness (#1555)

--- a/backend/core/version.py
+++ b/backend/core/version.py
@@ -24,7 +24,7 @@ from pathlib import Path
 # tests/test_app_version.py::test_all_version_files_in_lockstep and bumped by
 # release.yml's version-bump job, so it stays equal to
 # pyproject/tauri.conf/Cargo/package.json.
-_FALLBACK_VERSION = "0.5.0"
+_FALLBACK_VERSION = "0.5.1"
 
 
 def _fallback_version() -> str:

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "frontend": {
       "name": "omnivoice-studio",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@fontsource-variable/source-serif-4": "^5.3.0",

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -111,12 +111,12 @@ publishing the web UI — see the [Docker install guide](https://github.com/debp
 |-----|--------------|
 | `:latest` | **Rolling preview** — latest commit on `main`, at or ahead of the last release. This is the preview channel; pin `:stable` for production. |
 | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-| `:0.5.0` | Exact release version |
+| `:0.5.1` | Exact release version |
 | `:0.5` | Latest patch within the `0.5` minor |
 | `:main` | Alias of the same rolling `main` build as `:latest` |
 | `:sha-xxxxxxx` | A specific commit (produced by manual workflow dispatch) |
 | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
-| `:stable-rocm`, `:0.5.0-rocm`, `:0.5-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
+| `:stable-rocm`, `:0.5.1-rocm`, `:0.5-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding tags above |
 
 Preview builds always come from `main` and never version-sort below `:stable`,
 so upgrades flow naturally. The same images and tags

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -13,12 +13,12 @@ and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palash
 > |-----|--------------|
 > | `:latest` | **Rolling preview** — latest commit on `main`, at or ahead of the last release. This is the preview channel; pin `:stable` for production. |
 > | `:stable` | Most recent versioned release (updated on every `v*` git tag) |
-> | `:0.5.0` | Exact release version |
+> | `:0.5.1` | Exact release version |
 > | `:0.5` | Latest patch within the 0.5 minor |
 > | `:main` | Alias of the same rolling `main` build as `:latest` |
 > | `:sha-xxxxxxx` | Specific commit (produced by manual workflow dispatch) |
 > | `:rocm` | **AMD GPU (ROCm) build** of the rolling preview — the ROCm analogue of `:latest` |
-> | `:stable-rocm`, `:0.5.0-rocm`, `:0.5-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
+> | `:stable-rocm`, `:0.5.1-rocm`, `:0.5-rocm`, `:sha-xxxxxxx-rocm` | ROCm builds of the corresponding CUDA tags above |
 >
 > Versioning rule: preview builds always come from `main` and never
 > version-sort below `:stable` — upgrades flow naturally.
@@ -137,7 +137,7 @@ Volume=omnivoice-data:/app/omnivoice_data
 Environment=OMNIVOICE_API_KEY=replace-with-a-long-random-key
 ```
 
-Release pins exist too: `:stable-rocm`, `:0.5.0-rocm`, `:0.5-rocm` mirror
+Release pins exist too: `:stable-rocm`, `:0.5.1-rocm`, `:0.5-rocm` mirror
 the CUDA tags exactly.
 
 > **Consumer cards and APUs (RX 6000/7000, Strix Point/Halo):** the backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnivoice-studio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "type": "module",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "omnivoice-studio"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arboard",
  "dirs-next",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@
 # launcher's pkill matches `omnivoice-studio` and must never match a user's
 # installed app. Renaming it would collapse that distinction.
 name = "omnivoice-studio"
-version = "0.5.0"
+version = "0.5.1"
 description = "VoiceStudio – AI voice cloning & dubbing desktop app"
 authors = ["Debpalash"]
 license = "AGPL-3.0-only"

--- a/infra/install-redirect/worker.js
+++ b/infra/install-redirect/worker.js
@@ -34,7 +34,7 @@ const HTML = `<!doctype html>
   <p>macOS / Linux / WSL (prebuilt app):</p>
   <code>curl -fsSL https://voicestudio.sh/install | sh</code>
   <p>Pick a version, or build from source:</p>
-  <code>curl -fsSL https://voicestudio.sh/install | sh -s -- --version 0.5.0<br>curl -fsSL https://voicestudio.sh/install | sh -s -- --source</code>
+  <code>curl -fsSL https://voicestudio.sh/install | sh -s -- --version 0.5.1<br>curl -fsSL https://voicestudio.sh/install | sh -s -- --source</code>
   <p>Windows PowerShell:</p>
   <code>irm https://voicestudio.sh/install | iex</code>
   <p class="dim">PowerShell source mode: set $env:VOICESTUDIO_INSTALL_MODE = "source" first.</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnivoice"
-version = "0.5.0"
+version = "0.5.1"
 description = "VoiceStudio — a private, local-first studio for voice cloning, speech generation, dubbing, transcription, and audiobooks"
 readme = "README.md"
 # Free and open-source under the GNU Affero General Public License v3 (see

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,7 +9,7 @@
 #   powershell -ExecutionPolicy Bypass -File scripts\install.ps1 -Source
 #
 # Overrides (set before running):
-#   $env:VOICESTUDIO_VERSION = "0.5.0"  # release version in binary mode
+#   $env:VOICESTUDIO_VERSION = "0.5.1"  # release version in binary mode
 #   $env:VOICESTUDIO_INSTALL_MODE = "source"  # same as -Source when piped
 #   $env:OMNIVOICE_PYTHON = "3.12"      # Python version (source mode)
 #   $env:OMNIVOICE_REGION = "china"     # route Python downloads through a mirror

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,7 @@
 #   curl -fsSL https://voicestudio.sh/install | sh
 #       Install the latest prebuilt app (macOS dmg / Linux AppImage).
 #
-#   curl -fsSL https://voicestudio.sh/install | sh -s -- --version 0.5.0
+#   curl -fsSL https://voicestudio.sh/install | sh -s -- --version 0.5.1
 #       Install a specific release.
 #
 #   curl -fsSL https://voicestudio.sh/install | sh -s -- --source

--- a/tests/test_voicestudio_branding.py
+++ b/tests/test_voicestudio_branding.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_VERSION = "0.5.0"
+CURRENT_VERSION = "0.5.1"
 
 
 def test_current_version_is_in_lockstep_everywhere() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3777,7 +3777,7 @@ wheels = [
 
 [[package]]
 name = "omnivoice"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## Summary

Prepare the tested main branch for the v0.5.1 patch release.

## Changes

- finalize the accumulated Unreleased notes as 0.5.1 dated 2026-08-28
- bump package.json, Cargo/Python mirrors, frozen fallback, and all lockfiles in lockstep
- update supported-version, installer, Docker, and Docker Hub release references to 0.5.1

## Validation

- 56 version, branding, changelog, docs-drift, install-doc, and Docker-auth tests
- 30 release preview/manifest workflow tests
- uv lock --check
- bun install --frozen-lockfile
- cargo metadata --locked
- git diff --check

Closes #1687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates all package, toolchain, fallback, lockfile, installer, Docker, and documentation references to v0.5.1 and finalizes the changelog for the 2026-08-28 patch release. This prepares tested `main` for the v0.5.1 release and closes `#1687`. A human should verify release artifacts, updater manifests, container images, preview-channel output, and release notes before tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->