### PR TITLE
fix(dub): restore audio when the media preview falls back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
+- Dubbing playback now keeps an audible companion source when a WebView can render the preview picture but cannot decode its audio (#1692)
 - Model Catalogue engine rows now use the available desktop width and keep identity, runtime state, and actions from crowding one another (#1689)
 
 ## [0.5.1] — 2026-08-28

--- a/backend/api/routers/dub_export.py
+++ b/backend/api/routers/dub_export.py
@@ -1599,7 +1599,10 @@ async def dub_download_audio(
         return _native_save(wav_path, save_path, dl_name, media_type="audio/wav")
     return FileResponse(
         wav_path, media_type="audio/wav",
-        headers={"Content-Disposition": content_disposition(dl_name)},
+        headers={
+            "Cache-Control": "no-store",
+            "Content-Disposition": content_disposition(dl_name),
+        },
     )
 
 

--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -151,6 +151,7 @@ function WaveformTimeline(
     let videoRetryTimer = null;
     let fallbackAudioEl = null;
     let fallbackSyncCleanup = null;
+    let recoveryAttempted = false;
     if (videoSrc && videoContainerRef.current) {
       // Remove prior children + detach listeners explicitly to avoid leaks.
       const c = videoContainerRef.current;
@@ -358,8 +359,8 @@ function WaveformTimeline(
     // URL on every recovery load. When video decoding caused the failure,
     // move playback to the known-good companion audio and keep the visual
     // video muted + time-synchronised.
+    const fallbackSource = playbackFallbackSrc || audioSrc || videoSrc;
     const loadRecoveredPeaks = (peaks, fallbackDuration) => {
-      const fallbackSource = playbackFallbackSrc || audioSrc || videoSrc;
       if (videoEl && fallbackSource && fallbackSource !== videoSrc) {
         if (!fallbackAudioEl) {
           fallbackAudioEl = document.createElement('audio');
@@ -406,6 +407,13 @@ function WaveformTimeline(
       return Promise.resolve(ws.load(fallbackSource, peaks, fallbackDuration));
     };
 
+    const failRecovery = (error, { missing = false } = {}) => {
+      console.warn('Audio fallback failed:', error);
+      setReady(false);
+      setSourceMissing(missing);
+      setLoadError(true);
+    };
+
     // Handle errors (like Safari refusing to decode .mov in WebAudio)
     ws.on('error', (err) => {
       const errStr =
@@ -414,29 +422,19 @@ function WaveformTimeline(
       if (errName === 'AbortError' || errStr.includes('abort')) {
         return; // Ignore React cleanup aborts
       }
-      // WebKit NotSupportedError — skip decode, load with empty peaks so media element still works
-      if (errName === 'NotSupportedError' || errStr.includes('not supported')) {
-        console.warn('WebKit audio decode not supported, using media element directly');
-        try {
-          const emptyPeaks = new Float32Array(1000).fill(0);
-          // Don't rely solely on the 'ready' event firing again for this
-          // recovery load — the play button stayed permanently disabled
-          // when it didn't (the waveform still rendered from the peaks, so
-          // there was no visible sign anything was wrong). Confirm
-          // readiness explicitly once this load settles either way.
-          loadRecoveredPeaks([emptyPeaks], mediaEl.duration || 60)
-            .then(() => setReady(true))
-            .catch(() => setReady(true));
-        } catch (_) {
-          setReady(true);
-        }
+      // A failed companion must not recursively enter this handler forever.
+      // One recovery attempt is enough; a second media error is terminal.
+      if (recoveryAttempted) {
+        failRecovery(err);
         return;
       }
+      recoveryAttempted = true;
 
-      // If WaveSurfer failed to decode the media element stream (e.g. 404, .mov on MacOS, or pure .wav files failing to emit peaks),
-      // we manually fetch the companion `audioSrc`, decode it, and supply raw peaks.
-      if (audioSrc) {
-        fetch(audioSrc)
+      // Decode the exact source recovery will play. Using original-audio
+      // peaks with a dubbed companion made its waveform and range controls
+      // drift whenever the generated track had different timing.
+      if (fallbackSource) {
+        fetch(fallbackSource)
           .then((res) => {
             if (!res.ok) throw new Error('HTTP ' + res.status);
             return res.arrayBuffer();
@@ -452,7 +450,7 @@ function WaveformTimeline(
             // manually-decoded recovery load.
             loadRecoveredPeaks([channelData], audioBuffer.duration)
               .then(() => setReady(true))
-              .catch(() => setReady(true));
+              .catch((loadErr) => failRecovery(loadErr));
           })
           .catch((decodeErr) => {
             // HTTP 404 on the companion audio means the source file is
@@ -463,9 +461,15 @@ function WaveformTimeline(
             // to empty peaks so the media element can still play.
             const isMissing = /\bHTTP 404\b/.test(String(decodeErr?.message || decodeErr));
             if (isMissing) {
-              console.warn('Audio source missing (HTTP 404):', audioSrc);
-              setSourceMissing(true);
-              setLoadError(true);
+              failRecovery(decodeErr, { missing: true });
+              return;
+            }
+            // If this is the same timeline as audioSrc, the media element may
+            // still play even though WebAudio cannot decode it. A dubbed
+            // companion is a different timeline, so never fake its duration
+            // from the original media.
+            if (fallbackSource !== audioSrc) {
+              failRecovery(decodeErr);
               return;
             }
             console.warn('Audio decode fallback failed, loading with empty peaks:', decodeErr);
@@ -473,13 +477,13 @@ function WaveformTimeline(
               const emptyPeaks = new Float32Array(1000).fill(0);
               loadRecoveredPeaks([emptyPeaks], mediaEl.duration || 60)
                 .then(() => setReady(true))
-                .catch(() => setReady(true));
-            } catch (_) {
-              setLoadError(true);
+                .catch((loadErr) => failRecovery(loadErr));
+            } catch (loadErr) {
+              failRecovery(loadErr);
             }
           });
       } else {
-        setLoadError(true);
+        failRecovery(err);
       }
     });
 

--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -151,7 +151,7 @@ function WaveformTimeline(
     let videoRetryTimer = null;
     let fallbackAudioEl = null;
     let fallbackSyncCleanup = null;
-    let recoveryAttempted = false;
+    let recoveryState = 'idle';
     if (videoSrc && videoContainerRef.current) {
       // Remove prior children + detach listeners explicitly to avoid leaks.
       const c = videoContainerRef.current;
@@ -404,14 +404,20 @@ function WaveformTimeline(
           mediaElRef.current = fallbackAudioEl;
         }
       }
+      recoveryState = 'loading';
       return Promise.resolve(ws.load(fallbackSource, peaks, fallbackDuration));
     };
 
     const failRecovery = (error, { missing = false } = {}) => {
+      recoveryState = 'failed';
       console.warn('Audio fallback failed:', error);
       setReady(false);
       setSourceMissing(missing);
       setLoadError(true);
+    };
+    const finishRecovery = () => {
+      recoveryState = 'ready';
+      setReady(true);
     };
 
     // Handle errors (like Safari refusing to decode .mov in WebAudio)
@@ -422,13 +428,16 @@ function WaveformTimeline(
       if (errName === 'AbortError' || errStr.includes('abort')) {
         return; // Ignore React cleanup aborts
       }
-      // A failed companion must not recursively enter this handler forever.
-      // One recovery attempt is enough; a second media error is terminal.
-      if (recoveryAttempted) {
+      // Repeated errors from the original video can arrive while its companion
+      // is still being fetched/decoded. They do not say anything about that
+      // replacement, so let the in-flight attempt settle. Once WaveSurfer has
+      // switched to loading the companion, any further error is terminal.
+      if (recoveryState === 'decoding' || recoveryState === 'failed') return;
+      if (recoveryState === 'loading' || recoveryState === 'ready') {
         failRecovery(err);
         return;
       }
-      recoveryAttempted = true;
+      recoveryState = 'decoding';
 
       // Decode the exact source recovery will play. Using original-audio
       // peaks with a dubbed companion made its waveform and range controls
@@ -449,7 +458,7 @@ function WaveformTimeline(
             // above — don't depend on the 'ready' event re-firing for this
             // manually-decoded recovery load.
             loadRecoveredPeaks([channelData], audioBuffer.duration)
-              .then(() => setReady(true))
+              .then(finishRecovery)
               .catch((loadErr) => failRecovery(loadErr));
           })
           .catch((decodeErr) => {
@@ -476,7 +485,7 @@ function WaveformTimeline(
             try {
               const emptyPeaks = new Float32Array(1000).fill(0);
               loadRecoveredPeaks([emptyPeaks], mediaEl.duration || 60)
-                .then(() => setReady(true))
+                .then(finishRecovery)
                 .catch((loadErr) => failRecovery(loadErr));
             } catch (loadErr) {
               failRecovery(loadErr);

--- a/frontend/src/components/WaveformTimeline.jsx
+++ b/frontend/src/components/WaveformTimeline.jsx
@@ -44,6 +44,7 @@ const WF_BTN_PLAY = `${WF_BTN_BASE} bg-[var(--chrome-accent-bg)] text-[color:var
  * Props:
  *   audioSrc        – URL / blob URL for audio (WaveSurfer media + waveform source)
  *   videoSrc        – URL / blob URL for the video preview (optional, shown above waveform)
+ *   playbackFallbackSrc – audible companion used if the video transport cannot decode
  *   segments        – Array<{ id, start, end, text }>
  *   disabled        – locks drag/resize of segment boxes
  *   overlayContent  – React node rendered as a translucent overlay on the waveform
@@ -59,6 +60,7 @@ function WaveformTimeline(
   {
     audioSrc,
     videoSrc,
+    playbackFallbackSrc = audioSrc,
     segments = [],
     disabled = false,
     overlayContent,
@@ -147,6 +149,8 @@ function WaveformTimeline(
     // ── 1. Create the video element imperatively (stable, no React re-renders) ──
     let videoEl = null;
     let videoRetryTimer = null;
+    let fallbackAudioEl = null;
+    let fallbackSyncCleanup = null;
     if (videoSrc && videoContainerRef.current) {
       // Remove prior children + detach listeners explicitly to avoid leaks.
       const c = videoContainerRef.current;
@@ -162,6 +166,7 @@ function WaveformTimeline(
         c.removeChild(child);
       }
       videoEl = document.createElement('video');
+      videoEl.crossOrigin = 'anonymous';
       videoEl.src = videoSrc;
       videoEl.muted = false;
       videoEl.playsInline = true;
@@ -215,6 +220,13 @@ function WaveformTimeline(
         }
         if (code === 3 || code === 4) {
           console.warn('[WaveformTimeline] video element rejected source', videoSrc, 'code', code);
+          // A valid companion WAV can still make this an audio editor. Keep
+          // WaveSurfer mounted so its error recovery can swap transports;
+          // only the unusable visual surface needs to disappear.
+          if (playbackFallbackSrc) {
+            videoEl.style.display = 'none';
+            return;
+          }
           setSourceMissing(code === 4);
           setLoadError(true);
         }
@@ -229,6 +241,7 @@ function WaveformTimeline(
       videoEl ??
       (() => {
         const a = document.createElement('audio');
+        a.crossOrigin = 'anonymous';
         a.src = audioSrc;
         a.preload = 'auto';
         return a;
@@ -338,6 +351,61 @@ function WaveformTimeline(
     });
     ws.on('finish', () => setIsPlaying(false));
 
+    // WaveSurfer 7's load(undefined, peaks, duration) clears the attached
+    // media element's src. The old recovery path therefore rendered fallback
+    // peaks but silently disconnected the video transport — exactly the
+    // visible-waveform/no-audio failure reported in #1692. Preserve an actual
+    // URL on every recovery load. When video decoding caused the failure,
+    // move playback to the known-good companion audio and keep the visual
+    // video muted + time-synchronised.
+    const loadRecoveredPeaks = (peaks, fallbackDuration) => {
+      const fallbackSource = playbackFallbackSrc || audioSrc || videoSrc;
+      if (videoEl && fallbackSource && fallbackSource !== videoSrc) {
+        if (!fallbackAudioEl) {
+          fallbackAudioEl = document.createElement('audio');
+          fallbackAudioEl.crossOrigin = 'anonymous';
+          fallbackAudioEl.preload = 'auto';
+          fallbackAudioEl.src = fallbackSource;
+          fallbackAudioEl.muted = false;
+          fallbackAudioEl.volume = 1;
+
+          const syncVideoTime = (force = false) => {
+            if (!videoEl || !fallbackAudioEl) return;
+            const next = fallbackAudioEl.currentTime || 0;
+            if (force || Math.abs((videoEl.currentTime || 0) - next) > 0.25) {
+              try {
+                videoEl.currentTime = next;
+              } catch (_) {
+                /* visual sync is best-effort; audio remains authoritative */
+              }
+            }
+          };
+          const playVideo = () => {
+            syncVideoTime(true);
+            videoEl.muted = true;
+            videoEl.play().catch(() => {});
+          };
+          const pauseVideo = () => videoEl.pause();
+          const seekVideo = () => syncVideoTime(true);
+          const trackVideo = () => syncVideoTime(false);
+          fallbackAudioEl.addEventListener('play', playVideo);
+          fallbackAudioEl.addEventListener('pause', pauseVideo);
+          fallbackAudioEl.addEventListener('seeking', seekVideo);
+          fallbackAudioEl.addEventListener('timeupdate', trackVideo);
+          fallbackSyncCleanup = () => {
+            fallbackAudioEl?.removeEventListener('play', playVideo);
+            fallbackAudioEl?.removeEventListener('pause', pauseVideo);
+            fallbackAudioEl?.removeEventListener('seeking', seekVideo);
+            fallbackAudioEl?.removeEventListener('timeupdate', trackVideo);
+          };
+
+          ws.setMediaElement(fallbackAudioEl);
+          mediaElRef.current = fallbackAudioEl;
+        }
+      }
+      return Promise.resolve(ws.load(fallbackSource, peaks, fallbackDuration));
+    };
+
     // Handle errors (like Safari refusing to decode .mov in WebAudio)
     ws.on('error', (err) => {
       const errStr =
@@ -356,7 +424,7 @@ function WaveformTimeline(
           // when it didn't (the waveform still rendered from the peaks, so
           // there was no visible sign anything was wrong). Confirm
           // readiness explicitly once this load settles either way.
-          Promise.resolve(ws.load(undefined, [emptyPeaks], mediaEl.duration || 60))
+          loadRecoveredPeaks([emptyPeaks], mediaEl.duration || 60)
             .then(() => setReady(true))
             .catch(() => setReady(true));
         } catch (_) {
@@ -382,7 +450,7 @@ function WaveformTimeline(
             // Same explicit-readiness guard as the NotSupportedError branch
             // above — don't depend on the 'ready' event re-firing for this
             // manually-decoded recovery load.
-            Promise.resolve(ws.load(undefined, [channelData], audioBuffer.duration))
+            loadRecoveredPeaks([channelData], audioBuffer.duration)
               .then(() => setReady(true))
               .catch(() => setReady(true));
           })
@@ -403,7 +471,7 @@ function WaveformTimeline(
             console.warn('Audio decode fallback failed, loading with empty peaks:', decodeErr);
             try {
               const emptyPeaks = new Float32Array(1000).fill(0);
-              Promise.resolve(ws.load(undefined, [emptyPeaks], mediaEl.duration || 60))
+              loadRecoveredPeaks([emptyPeaks], mediaEl.duration || 60)
                 .then(() => setReady(true))
                 .catch(() => setReady(true));
             } catch (_) {
@@ -427,6 +495,14 @@ function WaveformTimeline(
       try {
         ws.cancelAudioFetch?.();
       } catch (_) {}
+      fallbackSyncCleanup?.();
+      if (fallbackAudioEl) {
+        try {
+          fallbackAudioEl.pause();
+          fallbackAudioEl.removeAttribute('src');
+          fallbackAudioEl.load?.();
+        } catch (_) {}
+      }
       // Empty the media source before destroy so any in-flight fetch
       // resolves its AbortController without a stale reference.
       if (mediaEl && !videoEl) {
@@ -459,7 +535,7 @@ function WaveformTimeline(
       setReady(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [audioSrc, videoSrc]);
+  }, [audioSrc, videoSrc, playbackFallbackSrc]);
 
   // ── Alignment metrics — the single {pxPerSec, scrollLeft} source ────────────
   // Everything the SegmentTrack draws derives from these two numbers, read

--- a/frontend/src/components/WaveformTimeline.readyFallback.test.js
+++ b/frontend/src/components/WaveformTimeline.readyFallback.test.js
@@ -76,6 +76,13 @@ describe('WaveformTimeline audible error recovery (#1692)', () => {
   });
 
   it('loads unequal-duration peaks from the selected dub and synchronizes its video', async () => {
+    let releaseFetch;
+    fetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFetch = () => resolve({ ok: true, arrayBuffer: async () => new ArrayBuffer(16) });
+        }),
+    );
     const { container } = render(
       React.createElement(WaveformTimeline, {
         audioSrc: 'http://localhost/original.wav',
@@ -88,6 +95,10 @@ describe('WaveformTimeline audible error recovery (#1692)', () => {
 
     act(() => emitWave('error', new DOMException('video decode failed', 'NotSupportedError')));
 
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    act(() => emitWave('error', new Error('duplicate original-video error')));
+    expect(container.querySelector('.wfm-error')).not.toBeInTheDocument();
+    await act(async () => releaseFetch());
     await waitFor(() => expect(wave.instance.setMediaElement).toHaveBeenCalledOnce());
     const fallbackAudio = wave.instance.setMediaElement.mock.calls[0][0];
     expect(fallbackAudio).toBeInstanceOf(HTMLAudioElement);

--- a/frontend/src/components/WaveformTimeline.readyFallback.test.js
+++ b/frontend/src/components/WaveformTimeline.readyFallback.test.js
@@ -1,57 +1,131 @@
-import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
+import React from 'react';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Regression guard: the dub editor's play button stayed permanently disabled
-// (disabled={!ready}) whenever the initial WaveSurfer decode failed and the
-// component fell back to a peaks-only ws.load(undefined, peaks, duration)
-// call. WaveSurfer 7 clears the attached media element's src for that call,
-// so the waveform rendered while the transport became silent (#1692).
-// Recovery must retain a concrete source, switch a failed video transport to
-// companion audio, and explicitly confirm readiness once loading settles.
-//
-// Driving WaveSurfer + a real decode-failure/recovery sequence through jsdom
-// is brittle (see WaveformTimeline.unlock.test.js), so this is a
-// source-level contract guard, same house pattern: every `ws.load(undefined,
-// ...)` recovery call inside the `ws.on('error', ...)` handler must be
-// followed by an explicit setReady(true) confirmation.
+const wave = vi.hoisted(() => ({ handlers: {}, instance: null }));
 
-const src = readFileSync(
-  path.resolve(process.cwd(), 'src/components/WaveformTimeline.jsx'),
-  'utf8',
-);
+vi.mock('wavesurfer.js', () => ({
+  default: {
+    create: vi.fn(() => {
+      const parent = document.createElement('div');
+      const wrapper = document.createElement('div');
+      parent.appendChild(wrapper);
+      Object.defineProperty(wrapper, 'scrollWidth', { configurable: true, value: 2300 });
+      wave.handlers = {};
+      wave.instance = {
+        on: vi.fn((event, handler) => {
+          (wave.handlers[event] ||= []).push(handler);
+          return () => {};
+        }),
+        un: vi.fn(),
+        load: vi.fn(() => Promise.resolve()),
+        setMediaElement: vi.fn(),
+        getDuration: vi.fn(() => 23),
+        getWrapper: vi.fn(() => wrapper),
+        zoom: vi.fn(),
+        pause: vi.fn(),
+        destroy: vi.fn(),
+        cancelAudioFetch: vi.fn(),
+      };
+      return wave.instance;
+    }),
+  },
+}));
 
-describe('WaveformTimeline audible error recovery', () => {
-  it('never clears the media src while loading recovered peaks', () => {
-    expect(src).not.toContain('ws.load(undefined');
-    expect(src).toMatch(/ws\.load\(fallbackSource, peaks, fallbackDuration\)/);
+vi.mock('wavesurfer.js/dist/plugins/minimap.esm.js', () => ({
+  default: { create: vi.fn(() => ({})) },
+}));
+vi.mock('wavesurfer.js/dist/plugins/timeline.esm.js', () => ({
+  default: { create: vi.fn(() => ({})) },
+}));
+
+import WaveformTimeline from './WaveformTimeline';
+
+class ResizeObserverStub {
+  observe() {}
+  disconnect() {}
+}
+
+function emitWave(event, value) {
+  for (const handler of wave.handlers[event] || []) handler(value);
+}
+
+describe('WaveformTimeline audible error recovery (#1692)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(16) })),
+    );
+    const decoded = {
+      duration: 23,
+      getChannelData: () => new Float32Array([0, 0.5, -0.5, 0]),
+    };
+    vi.stubGlobal(
+      'AudioContext',
+      class {
+        async decodeAudioData() {
+          return decoded;
+        }
+      },
+    );
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
   });
 
-  it('moves playback to companion audio and synchronizes the visual video', () => {
-    expect(src).toContain('ws.setMediaElement(fallbackAudioEl)');
-    expect(src).toContain('mediaElRef.current = fallbackAudioEl');
-    expect(src).toContain("fallbackAudioEl.addEventListener('play', playVideo)");
-    expect(src).toContain("fallbackAudioEl.addEventListener('seeking', seekVideo)");
-    expect(src).toContain("fallbackAudioEl.addEventListener('timeupdate', trackVideo)");
+  it('loads unequal-duration peaks from the selected dub and synchronizes its video', async () => {
+    const { container } = render(
+      React.createElement(WaveformTimeline, {
+        audioSrc: 'http://localhost/original.wav',
+        videoSrc: 'http://localhost/dubbed.mp4',
+        playbackFallbackSrc: 'http://localhost/dubbed-es.wav',
+      }),
+    );
+    const video = container.querySelector('video');
+    Object.defineProperty(video, 'duration', { configurable: true, value: 61 });
+
+    act(() => emitWave('error', new DOMException('video decode failed', 'NotSupportedError')));
+
+    await waitFor(() => expect(wave.instance.setMediaElement).toHaveBeenCalledOnce());
+    const fallbackAudio = wave.instance.setMediaElement.mock.calls[0][0];
+    expect(fallbackAudio).toBeInstanceOf(HTMLAudioElement);
+    expect(fallbackAudio.src).toBe('http://localhost/dubbed-es.wav');
+    expect(fetch).toHaveBeenCalledWith('http://localhost/dubbed-es.wav');
+    expect(wave.instance.load).toHaveBeenCalledWith(
+      'http://localhost/dubbed-es.wav',
+      [expect.any(Float32Array)],
+      23,
+    );
+    expect(wave.instance.load.mock.calls[0][0]).not.toBeUndefined();
+
+    fallbackAudio.currentTime = 7;
+    act(() => fallbackAudio.dispatchEvent(new Event('seeking')));
+    expect(video.currentTime).toBe(7);
+
+    act(() => fallbackAudio.dispatchEvent(new Event('play')));
+    expect(video.muted).toBe(true);
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+
+    act(() => fallbackAudio.dispatchEvent(new Event('pause')));
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
   });
 
-  it('decodes the same source it recovers and prevents recursive fallback loads', () => {
-    expect(src).toContain('fetch(fallbackSource)');
-    expect(src).not.toContain('fetch(audioSrc)');
-    expect(src).toMatch(/if \(recoveryAttempted\) \{\s+failRecovery\(err\)/);
-    expect(src).toContain('recoveryAttempted = true');
-  });
+  it('makes a rejected companion terminal instead of recursively reloading it', async () => {
+    render(
+      React.createElement(WaveformTimeline, {
+        audioSrc: 'http://localhost/original.wav',
+        videoSrc: 'http://localhost/dubbed.mp4',
+        playbackFallbackSrc: 'http://localhost/missing-dub.wav',
+      }),
+    );
+    wave.instance.load.mockRejectedValueOnce(new Error('companion rejected'));
 
-  it("confirms readiness explicitly after every fallback ws.load() call, not just via the 'ready' event", () => {
-    const errorHandler = /ws\.on\('error', \(err\) => \{([\s\S]*?)\n    \}\);/.exec(src)?.[1];
-    expect(errorHandler, "ws.on('error', ...) handler not found").toBeTruthy();
+    act(() => emitWave('error', new Error('initial decode failed')));
 
-    const loadCalls = [...errorHandler.matchAll(/loadRecoveredPeaks\([^;]+/g)];
-    expect(loadCalls.length).toBeGreaterThanOrEqual(2);
-
-    for (const match of loadCalls) {
-      const tail = errorHandler.slice(match.index, match.index + 220);
-      expect(tail, `no readiness confirmation after: ${match[0]}`).toMatch(/setReady\(true\)/);
-    }
+    await waitFor(() => expect(document.querySelector('.wfm-error')).toBeInTheDocument());
+    act(() => emitWave('error', new Error('companion rejected')));
+    expect(wave.instance.load).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/WaveformTimeline.readyFallback.test.js
+++ b/frontend/src/components/WaveformTimeline.readyFallback.test.js
@@ -4,12 +4,11 @@ import path from 'node:path';
 
 // Regression guard: the dub editor's play button stayed permanently disabled
 // (disabled={!ready}) whenever the initial WaveSurfer decode failed and the
-// component fell back to a peaks-only ws.load(undefined, [peaks], duration)
-// call — the waveform still rendered from those peaks (so nothing looked
-// visibly broken), but `ready` was only ever set from the 'ready' event
-// re-firing on that recovery load, which this component's own error-handling
-// code never actually confirmed. Each fallback load must now explicitly
-// confirm readiness once it settles, instead of assuming the event fires.
+// component fell back to a peaks-only ws.load(undefined, peaks, duration)
+// call. WaveSurfer 7 clears the attached media element's src for that call,
+// so the waveform rendered while the transport became silent (#1692).
+// Recovery must retain a concrete source, switch a failed video transport to
+// companion audio, and explicitly confirm readiness once loading settles.
 //
 // Driving WaveSurfer + a real decode-failure/recovery sequence through jsdom
 // is brittle (see WaveformTimeline.unlock.test.js), so this is a
@@ -22,17 +21,25 @@ const src = readFileSync(
   'utf8',
 );
 
-describe('WaveformTimeline error-recovery ready confirmation', () => {
+describe('WaveformTimeline audible error recovery', () => {
+  it('never clears the media src while loading recovered peaks', () => {
+    expect(src).not.toContain('ws.load(undefined');
+    expect(src).toMatch(/ws\.load\(fallbackSource, peaks, fallbackDuration\)/);
+  });
+
+  it('moves playback to companion audio and synchronizes the visual video', () => {
+    expect(src).toContain('ws.setMediaElement(fallbackAudioEl)');
+    expect(src).toContain('mediaElRef.current = fallbackAudioEl');
+    expect(src).toContain("fallbackAudioEl.addEventListener('play', playVideo)");
+    expect(src).toContain("fallbackAudioEl.addEventListener('seeking', seekVideo)");
+    expect(src).toContain("fallbackAudioEl.addEventListener('timeupdate', trackVideo)");
+  });
+
   it("confirms readiness explicitly after every fallback ws.load() call, not just via the 'ready' event", () => {
     const errorHandler = /ws\.on\('error', \(err\) => \{([\s\S]*?)\n    \}\);/.exec(src)?.[1];
     expect(errorHandler, "ws.on('error', ...) handler not found").toBeTruthy();
 
-    // Every recovery load in this handler passes peaks explicitly
-    // (`ws.load(undefined, [...], ...)`) — each occurrence must be
-    // immediately confirmed ready via a .then()/.catch() pair (or an
-    // unconditional setReady in a synchronous catch), not left to hope the
-    // 'ready' event re-fires on its own.
-    const loadCalls = [...errorHandler.matchAll(/ws\.load\(undefined, \[[^\]]*\][^)]*\)/g)];
+    const loadCalls = [...errorHandler.matchAll(/loadRecoveredPeaks\([^;]+/g)];
     expect(loadCalls.length).toBeGreaterThanOrEqual(3);
 
     for (const match of loadCalls) {

--- a/frontend/src/components/WaveformTimeline.readyFallback.test.js
+++ b/frontend/src/components/WaveformTimeline.readyFallback.test.js
@@ -35,12 +35,19 @@ describe('WaveformTimeline audible error recovery', () => {
     expect(src).toContain("fallbackAudioEl.addEventListener('timeupdate', trackVideo)");
   });
 
+  it('decodes the same source it recovers and prevents recursive fallback loads', () => {
+    expect(src).toContain('fetch(fallbackSource)');
+    expect(src).not.toContain('fetch(audioSrc)');
+    expect(src).toMatch(/if \(recoveryAttempted\) \{\s+failRecovery\(err\)/);
+    expect(src).toContain('recoveryAttempted = true');
+  });
+
   it("confirms readiness explicitly after every fallback ws.load() call, not just via the 'ready' event", () => {
     const errorHandler = /ws\.on\('error', \(err\) => \{([\s\S]*?)\n    \}\);/.exec(src)?.[1];
     expect(errorHandler, "ws.on('error', ...) handler not found").toBeTruthy();
 
     const loadCalls = [...errorHandler.matchAll(/loadRecoveredPeaks\([^;]+/g)];
-    expect(loadCalls.length).toBeGreaterThanOrEqual(3);
+    expect(loadCalls.length).toBeGreaterThanOrEqual(2);
 
     for (const match of loadCalls) {
       const tail = errorHandler.slice(match.index, match.index + 220);

--- a/frontend/src/components/dub/DubLeftColumn.jsx
+++ b/frontend/src/components/dub/DubLeftColumn.jsx
@@ -57,6 +57,7 @@ export default function DubLeftColumn({
   setPreviewMode,
   dubTracks,
   videoSrc,
+  playbackAudioSrc,
   waveformRef,
   dubJobId,
   dubSegments,
@@ -296,6 +297,7 @@ export default function DubLeftColumn({
         ref={waveformRef}
         audioSrc={`${API}/dub/audio/${dubJobId}`}
         videoSrc={videoSrc}
+        playbackFallbackSrc={playbackAudioSrc}
         segments={dubSegments}
         onsets={timelineOnsets}
         selectedSegId={timelineSelSegId}

--- a/frontend/src/pages/DubTab.jsx
+++ b/frontend/src/pages/DubTab.jsx
@@ -551,6 +551,13 @@ export default function DubTab(props) {
   const videoSrc = previewIsDub
     ? `${API}/dub/preview-video/${dubJobId}?lang=${encodeURIComponent(previewMode)}&preserve_bg=${preserveBg ? 1 : 0}&v=${dubGenNonce}`
     : `${API}/dub/media/${dubJobId}`;
+  // The video is the normal transport, but WaveSurfer can fall back to a
+  // companion audio element when a WebView decodes the picture without its
+  // audio. Keep that fallback language-aware so a dubbed preview never
+  // silently swaps back to the original track (#1692).
+  const playbackAudioSrc = previewIsDub
+    ? `${API}/dub/download-audio/${dubJobId}?lang=${encodeURIComponent(previewMode)}&preserve_bg=${preserveBg ? 1 : 0}`
+    : `${API}/dub/audio/${dubJobId}`;
   // When a dub finishes, jump the preview to the freshly-dubbed language so the
   // result plays immediately — the user can tap back to Original any time.
   // Membership guard: only jump to a language that actually has a track,
@@ -733,6 +740,7 @@ export default function DubTab(props) {
               setPreviewMode={setPreviewMode}
               dubTracks={dubTracks}
               videoSrc={videoSrc}
+              playbackAudioSrc={playbackAudioSrc}
               waveformRef={waveformRef}
               dubJobId={dubJobId}
               dubSegments={dubSegments}

--- a/frontend/src/test/DubTrackTabsRestore.test.jsx
+++ b/frontend/src/test/DubTrackTabsRestore.test.jsx
@@ -167,6 +167,7 @@ describe('DubTab — completed tracks always show their tabs (restore P0)', () =
     expect(left.hasDubbedTrack).toBe(true);
     // Auto-jump falls back to the only real track — never a lang without one.
     expect(left.previewMode).toBe('bn');
+    expect(left.playbackAudioSrc).toContain('/dub/download-audio/job1?lang=bn');
   });
 
   it("membership guard: dubLangCode 'en' with tracks ['bn'] previews tracks[0], not the 404 lang", () => {
@@ -188,6 +189,7 @@ describe('DubTab — completed tracks always show their tabs (restore P0)', () =
     // switcher appeared trackless and the auto-jump 404'd the preview.
     expect(left.hasDubbedTrack).toBe(false);
     expect(left.previewMode).toBe('original');
+    expect(left.playbackAudioSrc).toContain('/dub/audio/job1');
   });
 
   it('clears a selected cookie export when a completed dub is reset', () => {

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -220,6 +220,18 @@ class TestDubExportUniqueness:
         assert len(mp3s) == 3, f"expected 3 mp3 exports, got {[f.name for f in mp3s]}"
         assert len({f.name for f in mp3s}) == 3
 
+    def test_wav_export_is_not_cached_across_regeneration(self, app_client):
+        client, dc, _dx, tmp = app_client
+        job_id, _job_dir = _seed_job_with_tracks(dc, tmp)
+
+        response = client.get(
+            f"/dub/download-audio/{job_id}",
+            params={"lang": "es", "preserve_bg": False},
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.headers["cache-control"] == "no-store"
+
     def test_mp4_export_refuses_when_ffmpeg_writes_nothing(self, app_client):
         client, dc, dx, tmp = app_client
         job_id, _ = _seed_job_with_tracks(dc, tmp)


### PR DESCRIPTION
Closes #1692.

## Summary
- preserve a concrete media source when WaveSurfer loads recovery peaks
- switch failed video playback to a synchronized companion audio element
- keep dubbed fallback audio aligned with the selected language

## Validation
- `bunx vitest run src/components/WaveformTimeline.readyFallback.test.js src/components/WaveformTimeline.unlock.test.js src/test/DubTrackTabsRestore.test.jsx` (12 passed)
- `bun run typecheck:ci`
- `bun run build`
- `HF_HUB_OFFLINE=1 HF_HUB_CACHE=$(mktemp -d) pytest -q tests/test_changelog_style.py` (8 passed)
- `bunx oxfmt --check` on changed frontend files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
When preview video audio decoding fails, `WaveformTimeline` now switches to a synchronized companion audio source while preserving the video or cover visualization. `DubTab` selects the original or dubbed-language audio source, and regression tests cover recovery, track restoration, and uncached audio exports. Review media-element synchronization and cleanup for regressions in play, pause, seek, and segment playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->