### PR TITLE
fix(dev): recover backend worker crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
+- Source-mode development now restarts an isolated backend crash without tearing down the UI, while repeated crash loops still stop loudly with diagnostics (#1690)
 - Dubbing playback now keeps an audible companion source when a WebView can render the preview picture but cannot decode its audio (#1692)
 - Model Catalogue engine rows now use the available desktop width and keep identity, runtime state, and actions from crowding one another (#1689)
 

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -652,8 +652,8 @@ or files (#1635).
 stack (`bun run dev`), a Docker deployment, or a shared/remote backend — and
 requests fail with a "can't reach the backend" error.
 
-These deployments have no desktop shell to supervise the backend, so newer
-builds make the backend **self-forensicate** instead:
+These deployments have no desktop shell to supervise the backend. Newer builds
+make the backend **self-forensicate**, and the dev runner adds bounded recovery:
 
 - **The error tells you what it knows.** It now says whether the backend *was
   answering and stopped* ("it was answering 12 s ago … likely crashed or was
@@ -663,11 +663,15 @@ builds make the backend **self-forensicate** instead:
   dev, `docker logs <container>` / `journalctl` on a server. (If Docker
   serves the page itself, the page can go down together with the backend —
   check the container first.)
-- **Dev exit banner.** `bun run dev`'s backend runs through
-  `scripts/dev-backend.mjs`: when uvicorn dies with a non-zero exit, a boxed
+- **Dev crash recovery and exit banner.** `bun run dev`'s backend runs through
+  `scripts/dev-backend.mjs`, which owns Python-file reloads directly so a dead
+  server cannot hide behind a still-running uvicorn reload parent. When the
+  backend dies with a non-zero exit, a boxed
   banner prints the exit code/signal, the last 20 lines of `omnivoice.log`,
-  and an OOM-check hint (`journalctl -k | grep -i oom` on Linux) before
-  `concurrently` tears the stack down.
+  and an OOM-check hint (`journalctl -k | grep -i oom` on Linux), then restarts
+  it after one second. Three restarts are allowed in a rolling 60-second
+  window; a fourth crash exits and lets `concurrently` tear down the broken
+  stack. Ctrl+C and other deliberate shutdowns never restart it.
 - **Crash notice on the next start.** The backend keeps a **run sentinel**
   (`run_sentinel.json` in its data folder) while running and clears it on a
   clean shutdown. If a start finds a stale sentinel whose process is gone,

--- a/scripts/dev-backend.mjs
+++ b/scripts/dev-backend.mjs
@@ -236,8 +236,11 @@ export function createBackendSupervisor({
 
       if (reloadRequested) {
         reloadRequested = false;
-        start();
-        return;
+        const expectedReloadExit = code === 0 || signal === "SIGTERM";
+        if (expectedReloadExit) {
+          start();
+          return;
+        }
       }
 
       const crashed = Boolean(signal) || (code !== 0 && code != null);

--- a/scripts/dev-backend.mjs
+++ b/scripts/dev-backend.mjs
@@ -2,33 +2,34 @@
 // dev-backend.mjs — `bun run dev:api` wrapper that makes a backend death
 // LOUD instead of silent (#1164).
 //
-// In dev, the backend has no supervisor: concurrently's --kill-others-on-fail
-// tears the whole dev stack down the moment uvicorn exits, and the only
-// trace of WHY was whatever scrolled past in the terminal — the browser tab
-// just showed "Can't reach the local VoiceStudio backend". This wrapper spawns
-// the exact same uvicorn command (args identical to the old dev:api script)
-// with inherited stdio, and when the child dies with a non-zero exit — and
-// the developer didn't Ctrl+C — it prints a boxed banner with:
+// In dev, concurrently's --kill-others-on-fail used to tear the whole stack
+// down the moment uvicorn exited, and the only trace of WHY was whatever
+// scrolled past in the terminal — the browser tab just showed "Can't reach
+// the local VoiceStudio backend". This wrapper launches uvicorn directly,
+// owns Python source reloads, restarts isolated crashes with a bounded backoff,
+// and prints a boxed banner with:
 //   - the exit code / signal,
 //   - the last 20 lines of omnivoice.log (resolved like
 //     backend/core/config.py::get_app_data_dir),
 //   - an OOM-check hint on Linux (journalctl -k), and
 //   - a pointer to the crash notice the run sentinel will raise on the next
 //     backend start.
-// It exits with the child's own code so --kill-others-on-fail still works.
+// Repeated crashes still exit non-zero so --kill-others-on-fail can tear down
+// the broken stack instead of hiding an infinite crash loop.
 //
 // Runs under bun and node alike; cross-platform (uv resolves to uv.exe via
 // the Windows CreateProcess PATH search — no shell needed).
 // ──────────────────────────────────────────────────────────────────────────
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, watch } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-// Keep these args byte-identical to the previous root package.json dev:api.
+// The wrapper owns Python source reloads so uvicorn's reload parent cannot stay
+// alive after its server worker dies (#1690).
 export const UVICORN_ARGS = [
   "run",
   "uvicorn",
@@ -39,10 +40,16 @@ export const UVICORN_ARGS = [
   "0.0.0.0",
   "--port",
   "3900",
-  "--reload",
-  "--reload-dir",
-  "backend",
 ];
+
+export const CRASH_RESTART_DELAY_MS = 1_000;
+export const CRASH_RESTART_LIMIT = 3;
+export const CRASH_RESTART_WINDOW_MS = 60_000;
+export const SOURCE_RELOAD_DEBOUNCE_MS = 250;
+
+export function isBackendSourceChange(filename) {
+  return typeof filename === "string" && filename.toLowerCase().endsWith(".py");
+}
 
 /** Mirror backend/core/config.py::get_app_data_dir() so the banner reads the
  *  same omnivoice.log the backend writes. Pure — testable with fake inputs. */
@@ -80,12 +87,13 @@ export function buildExitBanner({ code, signal, logTail, logPath, platform = pro
   if (logTail) {
     lines.push(`Last 20 lines of ${logPath}:`, "─".repeat(76), logTail, "─".repeat(76), "");
   } else {
-    lines.push(`(no omnivoice.log found at ${logPath} — the backend may have died before logging)`, "");
+    lines.push(
+      `(no omnivoice.log found at ${logPath} — the backend may have died before logging)`,
+      "",
+    );
   }
   if (signal === "SIGKILL" || code === 137) {
-    lines.push(
-      "SIGKILL usually means the operating system's out-of-memory killer stopped it.",
-    );
+    lines.push("SIGKILL usually means the operating system's out-of-memory killer stopped it.");
   }
   if (platform === "linux") {
     lines.push("If you suspect an OOM kill, check:  journalctl -k | grep -i oom", "");
@@ -107,44 +115,183 @@ export function uvRunArgs(env = process.env) {
   return rocm ? [UVICORN_ARGS[0], "--no-sync", ...UVICORN_ARGS.slice(1)] : UVICORN_ARGS;
 }
 
-function main() {
-  const child = spawn("uv", uvRunArgs(), { stdio: "inherit" });
-
-  // A Ctrl+C / concurrently teardown is a DELIBERATE stop — no scary banner.
+/**
+ * Supervise the dev backend without hiding a persistent crash loop. Dependencies
+ * are injectable so crash/restart/signal behavior is deterministic in tests.
+ */
+export function createBackendSupervisor({
+  spawnBackend = () => spawn("uv", uvRunArgs(), { stdio: "inherit" }),
+  watchBackend = (onChange) =>
+    watch("backend", { recursive: true }, (_event, filename) => onChange(filename?.toString())),
+  schedule = setTimeout,
+  cancelSchedule = clearTimeout,
+  now = Date.now,
+  exit = (code) => process.exit(code),
+  report = (message) => console.error(message),
+  dataDir = () => resolveDataDir(),
+} = {}) {
   let interrupted = false;
+  let child = null;
+  let restartTimer = null;
+  let reloadTimer = null;
+  let reloadRequested = false;
+  let watcher = null;
+  let crashTimes = [];
+  let requestedExitCode = null;
+
+  function closeWatcher() {
+    if (!watcher) return;
+    watcher.close();
+    watcher = null;
+  }
+
+  function stop(sig, exitCode = null) {
+    if (interrupted) return;
+    interrupted = true;
+    requestedExitCode = exitCode;
+    closeWatcher();
+    if (reloadTimer !== null) {
+      cancelSchedule(reloadTimer);
+      reloadTimer = null;
+    }
+    if (restartTimer !== null) {
+      cancelSchedule(restartTimer);
+      restartTimer = null;
+      exit(requestedExitCode ?? 0);
+      return;
+    }
+    if (!child) {
+      exit(requestedExitCode ?? 0);
+      return;
+    }
+    try {
+      child.kill(sig);
+    } catch {
+      exit(requestedExitCode ?? 0);
+    }
+  }
+
+  function requestReload(filename) {
+    if (interrupted || reloadRequested || !isBackendSourceChange(filename)) return;
+    if (reloadTimer !== null) cancelSchedule(reloadTimer);
+    reloadTimer = schedule(() => {
+      reloadTimer = null;
+      if (!child || restartTimer !== null) return;
+      reloadRequested = true;
+      report(`[dev-backend] ${filename} changed; reloading backend…`);
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        reloadRequested = false;
+      }
+    }, SOURCE_RELOAD_DEBOUNCE_MS);
+  }
+
+  function start() {
+    if (interrupted) return;
+
+    if (!watcher) {
+      try {
+        watcher = watchBackend(requestReload);
+      } catch (err) {
+        report(`[dev-backend] could not watch backend sources: ${err.message}`);
+        exit(1);
+        return;
+      }
+      watcher.on?.("error", (err) => {
+        if (interrupted) return;
+        report(`[dev-backend] backend source watcher failed: ${err.message}`);
+        stop("SIGTERM", 1);
+      });
+    }
+
+    let current;
+    try {
+      current = spawnBackend();
+    } catch (err) {
+      report(`[dev-backend] could not start uv: ${err.message}`);
+      exit(1);
+      return;
+    }
+    child = current;
+    let settled = false;
+
+    current.once("error", (err) => {
+      if (settled) return;
+      settled = true;
+      if (child === current) child = null;
+      report(`[dev-backend] could not start uv: ${err.message}`);
+      exit(1);
+    });
+
+    current.once("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      if (child === current) child = null;
+
+      if (interrupted) {
+        exit(requestedExitCode ?? (signal ? 1 : (code ?? 0)));
+        return;
+      }
+
+      if (reloadRequested) {
+        reloadRequested = false;
+        start();
+        return;
+      }
+
+      const crashed = Boolean(signal) || (code !== 0 && code != null);
+      if (!crashed) {
+        exit(code ?? 0);
+        return;
+      }
+
+      const dir = dataDir();
+      const logPath = path.join(dir, "omnivoice.log");
+      report(buildExitBanner({ code, signal, logTail: tailFile(logPath, 20), logPath }));
+
+      const timestamp = now();
+      crashTimes = crashTimes.filter(
+        (crashTime) => timestamp - crashTime < CRASH_RESTART_WINDOW_MS,
+      );
+      if (crashTimes.length >= CRASH_RESTART_LIMIT) {
+        report(
+          `[dev-backend] stopped after ${CRASH_RESTART_LIMIT} restarts in ` +
+            `${CRASH_RESTART_WINDOW_MS / 1_000}s; fix the crash above, then run bun run dev again.`,
+        );
+        exit(signal ? 1 : (code ?? 1));
+        return;
+      }
+
+      crashTimes.push(timestamp);
+      report(
+        `[dev-backend] restarting in ${CRASH_RESTART_DELAY_MS / 1_000}s ` +
+          `(${crashTimes.length}/${CRASH_RESTART_LIMIT})…`,
+      );
+      restartTimer = schedule(() => {
+        restartTimer = null;
+        start();
+      }, CRASH_RESTART_DELAY_MS);
+    });
+  }
+
+  return { start, stop };
+}
+
+function main() {
+  const supervisor = createBackendSupervisor();
+
+  // A Ctrl+C / concurrently teardown is a DELIBERATE stop — no scary banner
+  // and no restart.
   for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
     try {
-      process.on(sig, () => {
-        interrupted = true;
-        try {
-          child.kill(sig);
-        } catch {
-          /* already gone */
-        }
-      });
+      process.on(sig, () => supervisor.stop(sig));
     } catch {
       /* signal unsupported on this platform (e.g. SIGHUP on Windows) */
     }
   }
 
-  child.on("error", (err) => {
-    console.error(`[dev-backend] could not start uv: ${err.message}`);
-    process.exit(1);
-  });
-
-  child.on("exit", (code, signal) => {
-    if (!interrupted && (signal || (code !== 0 && code != null))) {
-      const dataDir = resolveDataDir();
-      const logPath = path.join(dataDir, "omnivoice.log");
-      console.error(
-        buildExitBanner({ code, signal, logTail: tailFile(logPath, 20), logPath }),
-      );
-    }
-    // Preserve concurrently's --kill-others-on-fail semantics: propagate the
-    // child's outcome exactly (128+n is the conventional signal-death code).
-    if (signal) process.exit(1);
-    process.exit(code ?? 0);
-  });
+  supervisor.start();
 }
 
 // Import-safe: tests import the pure helpers without spawning anything.

--- a/tests/frontend/devBackend.test.mjs
+++ b/tests/frontend/devBackend.test.mjs
@@ -1,9 +1,9 @@
 // Unit tests for scripts/dev-backend.mjs — the dev:api wrapper that turns a
-// silent backend death into a loud, diagnosable exit banner (#1164).
+// silent backend death into a loud, recoverable exit banner (#1164, #1690).
 //
 // Load-bearing guarantees:
-//   * the uvicorn invocation is byte-identical to the old dev:api script —
-//     the wrapper adds forensics, never changes how the backend runs;
+//   * the wrapper launches uvicorn directly and owns Python source reloads, so
+//     a dead server cannot hide behind a still-live uvicorn reload parent;
 //   * the data-dir resolution mirrors backend/core/config.py, so the banner
 //     tails the same omnivoice.log the backend writes;
 //   * the banner names the exit code/signal, carries the log tail, flags the
@@ -11,21 +11,93 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
   UVICORN_ARGS,
   buildExitBanner,
+  createBackendSupervisor,
+  isBackendSourceChange,
   resolveDataDir,
   tailFile,
 } from '../../scripts/dev-backend.mjs';
 
-test('uvicorn args stay byte-identical to the historical dev:api command', () => {
+function supervisorHarness() {
+  const children = [];
+  const timers = [];
+  const exits = [];
+  const reports = [];
+  const watchers = [];
+  let timestamp = 1_000;
+
+  const supervisor = createBackendSupervisor({
+    spawnBackend: () => {
+      const child = new EventEmitter();
+      child.killedWith = null;
+      child.kill = (signal) => {
+        child.killedWith = signal;
+      };
+      children.push(child);
+      return child;
+    },
+    watchBackend: (onChange) => {
+      const watcher = new EventEmitter();
+      watcher.closed = false;
+      watcher.close = () => {
+        watcher.closed = true;
+      };
+      watcher.onChange = onChange;
+      watchers.push(watcher);
+      return watcher;
+    },
+    schedule: (callback, delay) => {
+      const timer = { callback, delay, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    cancelSchedule: (timer) => {
+      timer.cancelled = true;
+    },
+    now: () => timestamp,
+    exit: (code) => exits.push(code),
+    report: (message) => reports.push(message),
+    dataDir: () => '/missing-test-data',
+  });
+
+  return {
+    children,
+    exits,
+    reports,
+    supervisor,
+    timers,
+    watchers,
+    advance(ms) {
+      timestamp += ms;
+    },
+    runNextTimer() {
+      const timer = timers.find((candidate) => !candidate.cancelled && !candidate.ran);
+      assert.ok(timer, 'expected a pending restart timer');
+      timer.ran = true;
+      timer.callback();
+    },
+  };
+}
+
+test('uvicorn runs directly because the wrapper owns source reloads', () => {
   assert.equal(
     ['uv', ...UVICORN_ARGS].join(' '),
-    'uv run uvicorn main:app --app-dir backend --host 0.0.0.0 --port 3900 --reload --reload-dir backend',
+    'uv run uvicorn main:app --app-dir backend --host 0.0.0.0 --port 3900',
   );
+  assert.equal(UVICORN_ARGS.includes('--reload'), false);
+});
+
+test('only Python source changes trigger backend reloads', () => {
+  assert.equal(isBackendSourceChange('api/router.py'), true);
+  assert.equal(isBackendSourceChange('API/ROUTER.PY'), true);
+  assert.equal(isBackendSourceChange('api/__pycache__/router.pyc'), false);
+  assert.equal(isBackendSourceChange(null), false);
 });
 
 test('resolveDataDir mirrors backend/core/config.py::get_app_data_dir', () => {
@@ -85,4 +157,108 @@ test('banner flags OOM-kill shapes and adds the Linux journalctl hint', () => {
     platform: 'linux',
   });
   assert.match(oom137, /out-of-memory killer/);
+});
+
+test('an unexpected backend death is restarted instead of tearing down dev', () => {
+  const harness = supervisorHarness();
+  harness.supervisor.start();
+
+  harness.children[0].emit('exit', 1, null);
+
+  assert.deepEqual(harness.exits, []);
+  assert.equal(harness.timers[0].delay, 1_000);
+  assert.match(harness.reports.at(-1), /restarting in 1s \(1\/3\)/);
+
+  harness.runNextTimer();
+  assert.equal(harness.children.length, 2);
+});
+
+test('Python edits reload the direct worker without counting as crashes', () => {
+  const harness = supervisorHarness();
+  harness.supervisor.start();
+
+  harness.watchers[0].onChange('api/router.py');
+  assert.equal(harness.timers[0].delay, 250);
+  harness.runNextTimer();
+  assert.equal(harness.children[0].killedWith, 'SIGTERM');
+
+  harness.children[0].emit('exit', null, 'SIGTERM');
+
+  assert.equal(harness.children.length, 2);
+  assert.deepEqual(harness.exits, []);
+  assert.doesNotMatch(harness.reports.join('\n'), /BACKEND DIED|restarting in/);
+});
+
+test('the supervisor stops after three restarts inside the crash window', () => {
+  const harness = supervisorHarness();
+  harness.supervisor.start();
+
+  for (let crash = 0; crash < 3; crash += 1) {
+    harness.children.at(-1).emit('exit', 1, null);
+    harness.runNextTimer();
+  }
+  harness.children.at(-1).emit('exit', 7, null);
+
+  assert.deepEqual(harness.exits, [7]);
+  assert.match(harness.reports.at(-1), /stopped after 3 restarts in 60s/);
+  assert.equal(harness.children.length, 4);
+});
+
+test('old crashes expire from the bounded restart window', () => {
+  const harness = supervisorHarness();
+  harness.supervisor.start();
+
+  for (let crash = 0; crash < 3; crash += 1) {
+    harness.children.at(-1).emit('exit', 1, null);
+    harness.runNextTimer();
+  }
+  harness.advance(60_000);
+  harness.children.at(-1).emit('exit', 1, null);
+
+  assert.deepEqual(harness.exits, []);
+  assert.match(harness.reports.at(-1), /restarting in 1s \(1\/3\)/);
+});
+
+test('a deliberate stop never restarts the backend', () => {
+  const harness = supervisorHarness();
+  harness.supervisor.start();
+
+  harness.supervisor.stop('SIGTERM');
+  assert.equal(harness.children[0].killedWith, 'SIGTERM');
+  assert.equal(harness.watchers[0].closed, true);
+  harness.children[0].emit('exit', null, 'SIGTERM');
+
+  assert.deepEqual(harness.exits, [1]);
+  assert.equal(harness.timers.length, 0);
+  assert.doesNotMatch(harness.reports.join('\n'), /restarting/);
+});
+
+test('a source watcher failure tears down dev with a failing exit', () => {
+  const harness = supervisorHarness();
+  harness.supervisor.start();
+
+  harness.watchers[0].emit('error', new Error('watch handle closed'));
+  assert.equal(harness.children[0].killedWith, 'SIGTERM');
+  harness.children[0].emit('exit', 0, null);
+
+  assert.deepEqual(harness.exits, [1]);
+  assert.match(harness.reports.at(-1), /source watcher failed: watch handle closed/);
+});
+
+test('failure to spawn uv exits immediately instead of looping', () => {
+  const exits = [];
+  const reports = [];
+  const supervisor = createBackendSupervisor({
+    spawnBackend: () => {
+      throw new Error('uv is missing');
+    },
+    exit: (code) => exits.push(code),
+    report: (message) => reports.push(message),
+    watchBackend: () => ({ close() {}, on() {} }),
+  });
+
+  supervisor.start();
+
+  assert.deepEqual(exits, [1]);
+  assert.match(reports[0], /could not start uv: uv is missing/);
 });

--- a/tests/frontend/devBackend.test.mjs
+++ b/tests/frontend/devBackend.test.mjs
@@ -189,6 +189,26 @@ test('Python edits reload the direct worker without counting as crashes', () => 
   assert.doesNotMatch(harness.reports.join('\n'), /BACKEND DIED|restarting in/);
 });
 
+test('a crash racing a requested reload still uses crash recovery', () => {
+  for (const [code, signal] of [
+    [1, null],
+    [null, 'SIGKILL'],
+  ]) {
+    const harness = supervisorHarness();
+    harness.supervisor.start();
+    harness.watchers[0].onChange('api/router.py');
+    harness.runNextTimer();
+
+    harness.children[0].emit('exit', code, signal);
+
+    assert.deepEqual(harness.exits, []);
+    assert.match(harness.reports.join('\n'), /BACKEND DIED/);
+    assert.match(harness.reports.at(-1), /restarting in 1s \(1\/3\)/);
+    harness.runNextTimer();
+    assert.equal(harness.children.length, 2);
+  }
+});
+
 test('the supervisor stops after three restarts inside the crash window', () => {
   const harness = supervisorHarness();
   harness.supervisor.start();


### PR DESCRIPTION
Closes #1690

## Summary

Make source-mode backend crashes recover without letting uvicorn's reload parent hide a dead worker.

## Changes

- run uvicorn directly and preserve Python source reloads in the dev wrapper
- restart isolated crashes with a bounded 3-per-60-second policy
- retain loud diagnostics and stop persistent crash loops
- cover reload/crash races and lifecycle failure paths

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- `bun test tests/frontend` (79 passed before review fix)
- `bun test tests/frontend/devBackend.test.mjs` (14 passed after review fix)
- offline changelog/install-doc tests (24 passed)
- real `bun run dev:api` Python reload and verified SIGKILL recovery

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync (no version bump)
- [x] Runtime fixture remains covered by the cross-platform smoke matrix

## Release cadence

VoiceStudio ships continuous-to-main; this change remains Unreleased until the held release is resumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The development wrapper now runs Uvicorn directly, performs debounced Python source reloads, and restarts isolated backend crashes up to three times within 60 seconds while preserving diagnostics and deliberate shutdown behavior. This prevents dead workers from remaining hidden behind a reload parent and improves recovery from local development crashes. Review the supervisor lifecycle and crash-window logic for edge cases during rapid source changes or repeated failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->