### PR TITLE
chore(release): finalize v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 `frontend/package.json` is the app-version source of truth; Cargo, Python, and
 the frozen-backend fallback mirror it for their toolchains.
 
-## [Unreleased]
+## [0.5.1] — 2026-08-28
 
 **Highlights**
 
@@ -15,11 +15,6 @@ the frozen-backend fallback mirror it for their toolchains.
 - Source-mode development now restarts an isolated backend crash without tearing down the UI, while repeated crash loops still stop loudly with diagnostics (#1690)
 - Dubbing playback now keeps an audible companion source when a WebView can render the preview picture but cannot decode its audio (#1692)
 - Model Catalogue engine rows now use the available desktop width and keep identity, runtime state, and actions from crowding one another (#1689)
-
-## [0.5.1] — 2026-08-28
-
-**Highlights**
-
 - VoiceStudio now acts as a local speech platform: other apps can trigger its native dictation or connect through versioned HTTP, WebSocket, JSON-RPC, CLI, and MCP transports (#1646)
 - A timed-out in-process dub transcription no longer starts a second WhisperX/CTranslate2 call over the abandoned native worker, preventing the overlapping access that preceded Windows `0xC0000005` exits (#1669)
 - Windows debugger termination code `0x40010004` is no longer misreported as a backend crash or charged against automatic restart recovery (#1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 `frontend/package.json` is the app-version source of truth; Cargo, Python, and
 the frozen-backend fallback mirror it for their toolchains.
 
+## [Unreleased]
+
+**Highlights**
+
+### Changed
+
+### Added
+
+### Docs
+
+### Fixed
+
 ## [0.5.1] — 2026-08-28
 
 **Highlights**


### PR DESCRIPTION
Finalizes the held v0.5.1 changelog after the post-tag fixes landed. All version mirrors are already at 0.5.1.\n\nValidation: uv run --no-sync pytest tests/test_app_version.py tests/test_changelog_style.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Finalizes the v0.5.1 changelog after post-tag fixes. It preserves the unreleased structure and removes the duplicate 0.5.1 heading and highlights marker. Targeted version and changelog tests passed; review the release date for correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->