### PR TITLE
docs: add private production API deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ### Docs
 
 - The CosyVoice guide now states that packaged builds have no one-click runtime installer and records the exact readiness checks exposed by [Discussion 1631](https://github.com/debpalash/VoiceStudio/discussions/1631).
+- A production private-API guide now covers pinned containers, root credentials, network isolation, streaming proxies, health checks, upgrades, and benchmark evidence (#1720)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The [notebook](notebooks/OmniVoice_Studio_Colab.ipynb) runs the app and web UI o
 | Fix setup | [Troubleshooting](docs/install/troubleshooting.md) · [model downloads](docs/downloading-models.md) · [Hugging Face token](docs/setup/huggingface-token.md) |
 | Choose an engine | [Engine guides](docs/engines/README.md) · [benchmarks](docs/benchmarks.md) · [expressive speech](docs/expressive-speech.md) |
 | Tune hardware | [Performance](docs/performance.md) · [remote workers](docs/remote-workers.md) |
-| Build integrations | [Speech platform](docs/speech-platform.md) · [API auth](docs/api-auth.md) · [MCP](docs/mcp.md) · [examples](examples/README.md) |
+| Build integrations | [Speech platform](docs/speech-platform.md) · [Private production API](docs/production-private-api.md) · [API auth](docs/api-auth.md) · [MCP](docs/mcp.md) · [examples](examples/README.md) |
 | Build VoiceStudio | [Contributing](.github/CONTRIBUTING.md) · [engine acceptance](docs/engine-acceptance.md) |
 | Track changes | [Changelog](CHANGELOG.md) · [roadmap](docs/ROADMAP.md) · [latest release](https://github.com/debpalash/VoiceStudio/releases/latest) |
 | Remove everything | [Uninstall guide](docs/install/uninstall.md) |

--- a/docs/api-auth.md
+++ b/docs/api-auth.md
@@ -1,5 +1,8 @@
 # Authenticating the local API
 
+For an application backend consuming a pinned, private VoiceStudio deployment,
+start with the [production private API pattern](production-private-api.md).
+
 VoiceStudio's backend is **loopback-only and unauthenticated by default** — a
 script running on the same machine as `http://localhost:3900` needs no key, no
 PIN, no header. Everything on this page only matters once you reach the backend

--- a/docs/production-private-api.md
+++ b/docs/production-private-api.md
@@ -48,11 +48,14 @@ matching `:0.5.1-rocm` image and the device mapping documented in
 
 Prefer a private container network with no published VoiceStudio port when the
 calling backend runs in the same Compose or Kubernetes deployment. Otherwise,
-bind to `127.0.0.1` and put a TLS reverse proxy or an encrypted private overlay
-network in front of it. Plain HTTP is appropriate only across loopback or an
-isolated container network; a Bearer key must not cross a host or network in
-plaintext. The six-digit share PIN is intended for casual LAN access; use the
-API key for an application service.
+keep the published port on `127.0.0.1` when a reverse proxy runs on the same
+host. For cross-host access through Tailscale or another encrypted overlay,
+publish port 3900 only on the host's private-overlay address, or attach both
+services to a private container network, and restrict it with the host firewall.
+Plain HTTP is appropriate only across loopback or an isolated container
+network; a Bearer key must not cross a host or network in plaintext. The
+six-digit share PIN is intended for casual LAN access; use the API key for an
+application service.
 
 If a reverse proxy is used:
 
@@ -96,13 +99,13 @@ paths through the same authenticated network route InterviewAce will use:
 curl https://voicestudio.internal/v1/audio/speech \
   -H "Authorization: Bearer $OMNIVOICE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model":"tts-1","voice":"alloy","input":"Production check.","response_format":"wav"}' \
+  -d '{"model":"<resolved-tts-engine-id>","voice":"alloy","input":"Production check.","response_format":"wav"}' \
   --output check.wav
 
 curl https://voicestudio.internal/v1/audio/transcriptions \
   -H "Authorization: Bearer $OMNIVOICE_API_KEY" \
   -F "file=@check.wav" \
-  -F "model=whisper-1"
+  -F "model=<resolved-asr-engine-id>"
 ```
 
 Use the actual selected engine id instead of an alias when validating routing.
@@ -135,11 +138,13 @@ secret, validate an authenticated request through InterviewAce, then restore
 traffic. The service accepts one configured root key, so changing only one side
 temporarily produces `401 Unauthorized`.
 
-The API key also authorizes server-mode administration. Use a separate
-VoiceStudio instance or network policy if the calling application should have
-consumption access without administrative access; the current API key is a
-root credential, not a per-route service token. Full credential, session,
-WebSocket, trusted-network, admin-route, and CORS behavior is in
+The API key also authorizes server-mode administration. If the calling
+application should have consumption access only, use a separate VoiceStudio
+instance or a route-aware reverse proxy with a default-deny allowlist limited
+to the required speech routes. L3/L4 network policy alone cannot distinguish
+generation from administration. The current API key is a root credential, not
+a per-route service token. Full credential, session, WebSocket,
+trusted-network, admin-route, and CORS behavior is in
 [API authentication](api-auth.md).
 
 ## Engine and model obligations

--- a/docs/production-private-api.md
+++ b/docs/production-private-api.md
@@ -1,0 +1,93 @@
+# Production private API service
+
+For a private application backend calling VoiceStudio, run the versioned Docker
+image as an internal service. Do not expose port 3900 directly to the public
+internet.
+
+## Recommended baseline
+
+```yaml
+services:
+  voicestudio:
+    image: ghcr.io/debpalash/omnivoice-studio:0.5.1
+    restart: unless-stopped
+    environment:
+      OMNIVOICE_API_KEY: ${OMNIVOICE_API_KEY:?set a long random key}
+    ports:
+      - "127.0.0.1:3900:3900"
+    volumes:
+      - voicestudio-data:/app/omnivoice_data
+      - voicestudio-models:/root/.cache/huggingface
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:3900/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 120s
+
+volumes:
+  voicestudio-data:
+  voicestudio-models:
+```
+
+Generate `OMNIVOICE_API_KEY` with a password manager or
+`python3 -c 'import secrets; print(secrets.token_urlsafe(32))'`. Keep it in the
+deployment platform's secret store, not in the Compose file or source control.
+Send it from InterviewAce as `Authorization: Bearer <key>`.
+
+Pin an exact release tag. `:latest` and `:main` are rolling previews;
+`:stable` moves whenever a stable release is published. AMD hosts use the
+matching `:0.5.1-rocm` image and the device mapping documented in
+[Docker installation](install/docker.md#pull-and-run-amd-gpu--rocm).
+
+## Network boundary
+
+Prefer a private container network with no published VoiceStudio port when the
+calling backend runs in the same Compose or Kubernetes deployment. Otherwise,
+bind to `127.0.0.1` and put a TLS reverse proxy or private overlay network in
+front of it. The six-digit share PIN is intended for casual LAN access; use the
+API key for an application service.
+
+If a reverse proxy is used:
+
+- forward the `Authorization` header;
+- disable response buffering for streaming generation;
+- set its read timeout above VoiceStudio's generation timeout;
+- preserve the client address only through a trusted proxy configuration;
+- set `OMNIVOICE_ALLOWED_ORIGINS` only when a browser on another origin must
+  call VoiceStudio directly.
+
+InterviewAce's browser should normally call the InterviewAce backend, which
+then calls VoiceStudio. This keeps the VoiceStudio credential and API surface
+out of the customer browser.
+
+## Operations
+
+- Persist both `/app/omnivoice_data` and the Hugging Face cache. Back up the
+  data volume; treat the model cache as replaceable unless download time is
+  operationally significant.
+- Warm and validate the selected engines after deployment before admitting
+  traffic. `/engines` reports availability and the resolved execution device;
+  `/health` proves service readiness.
+- Keep request concurrency bounded. A capacity response is a backpressure
+  signal; honor `Retry-After` instead of starting parallel retries.
+- Drain callers, recreate the container with a newly pinned tag, run the engine
+  checks, then restore traffic. Do not update model/runtime dependencies inside
+  a running production container.
+- For a failed benchmark or production request, capture `/system/info`, the
+  selected `/engines` entry, response routing headers, container logs, and a
+  diagnostic bundle before restarting.
+
+The API key also authorizes server-mode administration. Use a separate
+VoiceStudio instance or network policy if the calling application should have
+consumption access without administrative access; the current API key is a
+root credential, not a per-route service token. Full credential, session,
+WebSocket, trusted-network, admin-route, and CORS behavior is in
+[API authentication](api-auth.md).
+
+## Engine and model obligations
+
+Deploying VoiceStudio does not settle the licenses of optional engines or model
+weights. Record the exact engine, model revision, and accepted terms alongside
+the deployment, and review generated-output restrictions for that combination.
+See [Engine licences](engines/index.md) before enabling an engine.

--- a/docs/production-private-api.md
+++ b/docs/production-private-api.md
@@ -68,6 +68,21 @@ If a reverse proxy is used:
 - set `OMNIVOICE_ALLOWED_ORIGINS` only when a browser on another origin must
   call VoiceStudio directly.
 
+For example, if the proxy has the fixed container address `172.30.0.2`, add
+this to VoiceStudio's environment:
+
+```yaml
+FORWARDED_ALLOW_IPS: 172.30.0.2
+```
+
+Assign that address with a Compose network `ipam` block or the equivalent
+orchestrator network policy. `FORWARDED_ALLOW_IPS=*`, a subnet, and a mutable
+service-name lookup are not equivalent to trusting the proxy's exact address.
+Configure the proxy itself to clear inbound `Forwarded`, `X-Forwarded-For`,
+`X-Forwarded-Host`, and `X-Forwarded-Proto` before setting fresh values. Without
+both halves, keep proxy-header trust disabled; a spoofed forwarded loopback
+address can otherwise receive loopback privileges.
+
 InterviewAce's browser should normally call the InterviewAce backend, which
 then calls VoiceStudio. This keeps the VoiceStudio credential and API surface
 out of the customer browser.

--- a/docs/production-private-api.md
+++ b/docs/production-private-api.md
@@ -14,6 +14,7 @@ services:
     environment:
       OMNIVOICE_API_KEY: ${OMNIVOICE_API_KEY:?set a long random key}
       OMNIVOICE_BIND_HOST: 0.0.0.0
+      OMNIVOICE_DATA_DIR: /app/omnivoice_data
     ports:
       - "127.0.0.1:3900:3900"
     volumes:
@@ -38,6 +39,8 @@ Send it from InterviewAce as `Authorization: Bearer <key>`.
 
 `OMNIVOICE_BIND_HOST=0.0.0.0` is required inside the container; the host-side
 `127.0.0.1` port binding still prevents LAN or public access.
+`OMNIVOICE_DATA_DIR=/app/omnivoice_data` keeps application state on the named
+volume across container recreation.
 
 Pin an exact release tag. `:latest` and `:main` are rolling previews;
 `:stable` moves whenever a stable release is published. AMD hosts use the

--- a/docs/production-private-api.md
+++ b/docs/production-private-api.md
@@ -13,11 +13,12 @@ services:
     restart: unless-stopped
     environment:
       OMNIVOICE_API_KEY: ${OMNIVOICE_API_KEY:?set a long random key}
+      OMNIVOICE_BIND_HOST: 0.0.0.0
     ports:
       - "127.0.0.1:3900:3900"
     volumes:
       - voicestudio-data:/app/omnivoice_data
-      - voicestudio-models:/root/.cache/huggingface
+      - voicestudio-models:/app/omnivoice_data/huggingface
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:3900/health"]
       interval: 30s
@@ -35,6 +36,9 @@ Generate `OMNIVOICE_API_KEY` with a password manager or
 deployment platform's secret store, not in the Compose file or source control.
 Send it from InterviewAce as `Authorization: Bearer <key>`.
 
+`OMNIVOICE_BIND_HOST=0.0.0.0` is required inside the container; the host-side
+`127.0.0.1` port binding still prevents LAN or public access.
+
 Pin an exact release tag. `:latest` and `:main` are rolling previews;
 `:stable` moves whenever a stable release is published. AMD hosts use the
 matching `:0.5.1-rocm` image and the device mapping documented in
@@ -44,8 +48,10 @@ matching `:0.5.1-rocm` image and the device mapping documented in
 
 Prefer a private container network with no published VoiceStudio port when the
 calling backend runs in the same Compose or Kubernetes deployment. Otherwise,
-bind to `127.0.0.1` and put a TLS reverse proxy or private overlay network in
-front of it. The six-digit share PIN is intended for casual LAN access; use the
+bind to `127.0.0.1` and put a TLS reverse proxy or an encrypted private overlay
+network in front of it. Plain HTTP is appropriate only across loopback or an
+isolated container network; a Bearer key must not cross a host or network in
+plaintext. The six-digit share PIN is intended for casual LAN access; use the
 API key for an application service.
 
 If a reverse proxy is used:
@@ -53,7 +59,12 @@ If a reverse proxy is used:
 - forward the `Authorization` header;
 - disable response buffering for streaming generation;
 - set its read timeout above VoiceStudio's generation timeout;
-- preserve the client address only through a trusted proxy configuration;
+- discard client-supplied `Forwarded` and `X-Forwarded-*` headers, then set
+  forwarding headers from the proxy's observed connection;
+- configure VoiceStudio/Uvicorn to trust forwarding headers only from that
+  proxy's exact address. Never make authorization decisions from an untrusted
+  forwarded address: a same-host proxy otherwise lets a remote caller appear
+  loopback-local and bypass the key gate;
 - set `OMNIVOICE_ALLOWED_ORIGINS` only when a browser on another origin must
   call VoiceStudio directly.
 
@@ -61,14 +72,39 @@ InterviewAce's browser should normally call the InterviewAce backend, which
 then calls VoiceStudio. This keeps the VoiceStudio credential and API surface
 out of the customer browser.
 
+## Validate the integration
+
+After selecting and installing an engine, exercise both OpenAI-compatible
+paths through the same authenticated network route InterviewAce will use:
+
+```bash
+curl https://voicestudio.internal/v1/audio/speech \
+  -H "Authorization: Bearer $OMNIVOICE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"tts-1","voice":"alloy","input":"Production check.","response_format":"wav"}' \
+  --output check.wav
+
+curl https://voicestudio.internal/v1/audio/transcriptions \
+  -H "Authorization: Bearer $OMNIVOICE_API_KEY" \
+  -F "file=@check.wav" \
+  -F "model=whisper-1"
+```
+
+Use the actual selected engine id instead of an alias when validating routing.
+More SDK and authentication examples are in [API authentication](api-auth.md).
+
 ## Operations
 
 - Persist both `/app/omnivoice_data` and the Hugging Face cache. Back up the
   data volume; treat the model cache as replaceable unless download time is
   operationally significant.
-- Warm and validate the selected engines after deployment before admitting
-  traffic. `/engines` reports availability and the resolved execution device;
-  `/health` proves service readiness.
+- Before admitting traffic, list the selected engine's checkpoint with
+  `GET /models`, pre-fetch its `repo_id` with authenticated
+  `POST /models/install`, and wait for `/setup/download-stream` to finish.
+  Lazy first-request downloads can exceed an otherwise healthy request
+  timeout. Then warm the engine with a representative request. `/engines`
+  reports availability and the resolved execution device; `/health` proves
+  service readiness.
 - Keep request concurrency bounded. A capacity response is a backpressure
   signal; honor `Retry-After` instead of starting parallel retries.
 - Drain callers, recreate the container with a newly pinned tag, run the engine
@@ -77,6 +113,12 @@ out of the customer browser.
 - For a failed benchmark or production request, capture `/system/info`, the
   selected `/engines` entry, response routing headers, container logs, and a
   diagnostic bundle before restarting.
+
+Rotate the root key as a coordinated deployment: drain requests, update the
+secret store, recreate VoiceStudio with the new key, update InterviewAce's
+secret, validate an authenticated request through InterviewAce, then restore
+traffic. The service accepts one configured root key, so changing only one side
+temporarily produces `401 Unauthorized`.
 
 The API key also authorizes server-mode administration. Use a separate
 VoiceStudio instance or network policy if the calling application should have


### PR DESCRIPTION
## Summary
- document the recommended authenticated, private server-side deployment
- cover pinned images, secret handling, network isolation, streaming proxies, health checks, upgrades, and diagnostic capture
- link the guide from the README and authentication reference

Closes #1720

## Tests
- Changelog style: 8 passed
- git diff whitespace check: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added a production guide for a private, authenticated VoiceStudio server and linked it from the README and API authentication reference. The guide covers deployment, secret handling, network isolation, route boundaries, health checks, persistence, upgrades, diagnostics, and client usage. Human review should verify the documented proxy trust and consumption-versus-administration controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->