### PR TITLE
docs: classify RX 6700 XT WSL2 path as unverified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 - The CosyVoice guide now states that packaged builds have no one-click runtime installer and records the exact readiness checks exposed by [Discussion 1631](https://github.com/debpalash/VoiceStudio/discussions/1631).
 - A production private-API guide now covers pinned containers, root credentials, network isolation, streaming proxies, health checks, upgrades, and benchmark evidence (#1720)
+- RX 6700 XT/gfx1031 over WSL2 ROCDXG is now explicitly unverified until a published end-to-end GPU workload proves the mapped path (#1716)
 
 ### Fixed
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -123,6 +123,31 @@ on `127.0.0.1` and do not run untrusted workloads in this container. See AMD's
 [`librocdxg` WSL container instructions](https://github.com/ROCm/librocdxg#4-container-launch--wsl-specific-flags)
 for the driver/runtime compatibility matrix.
 
+#### WSL2 architecture compatibility matrix
+
+VoiceStudio classifies the architecture result separately from device-node
+visibility. `/dev/dxg` alone is not proof of acceleration; a supported claim
+also needs the runtime probe, application routing, a completed workload, and
+GPU-utilization evidence.
+
+| Classification | Evidence required | VoiceStudio behavior |
+|---|---|---|
+| **Supported** | The native GFX tag is in the shipped PyTorch architecture list, and the named hardware has a published successful workload with GPU-utilization evidence. | Report the measured provider and device from Settings and diagnostics. |
+| **Best-effort override** | The native tag is absent, a mapped target is present in the PyTorch build, and `HSA_OVERRIDE_GFX_VERSION` is applied. No hardware validation is implied. | Attempt the mapped kernels; capture execution evidence and treat failures as unsupported for that host. |
+| **Unverified** | The bridge or override is configured, but no published end-to-end result exists for the named card and stack. | Do not advertise the card as supported; run the checks below before relying on it. |
+| **Unsupported** | Neither the native tag nor a usable mapped target is present, or the runtime/workload rejects the device. | Use an intentional CPU route or a different supported accelerator. |
+
+| Hardware / architecture | Current classification | Detail |
+|---|---|---|
+| AMD Radeon RX 6700 XT / `gfx1031` through WSL2 ROCDXG | **Unverified** | VoiceStudio can map `gfx1031` to `gfx1030` when that target exists in the PyTorch build, but no RX 6700 XT end-to-end validation has been published. |
+
+For an RX 6700 XT result to move out of **Unverified**, record the Windows AMD
+driver, WSL kernel/distribution, image and ROCDXG/ROCm versions,
+`torch.version.hip`, device name/count and compiled architecture list, effective
+HSA override, `rocminfo`, VoiceStudio self-check and engine-routing output, and
+one successful PyTorch TTS and ASR workload with utilization plus cold/warm
+latency. A silent CPU completion does not qualify.
+
 The same flags work with **Podman** (`podman run --device /dev/kfd
 --device /dev/dri …`); in a **Quadlet** unit that's two `AddDevice=` lines:
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -146,7 +146,9 @@ driver, WSL kernel/distribution, image and ROCDXG/ROCm versions,
 `torch.version.hip`, device name/count and compiled architecture list, effective
 HSA override, `rocminfo`, VoiceStudio self-check and engine-routing output, and
 one successful PyTorch TTS and ASR workload with utilization plus cold/warm
-latency. A silent CPU completion does not qualify.
+latency. Record whether either workload fell back to CPU and, when it did, the
+CPU fallback stage and reason reported by VoiceStudio. A CPU-only completion
+does not qualify as successful GPU validation.
 
 The same flags work with **Podman** (`podman run --device /dev/kfd
 --device /dev/dri …`); in a **Quadlet** unit that's two `AddDevice=` lines:

--- a/tests/test_docker_admin_auth_docs.py
+++ b/tests/test_docker_admin_auth_docs.py
@@ -72,3 +72,24 @@ def test_wsl_rocm_command_carries_the_complete_dxg_bridge():
         "--security-opt seccomp=unconfined",
     ):
         assert required in section
+
+
+def test_wsl_rocm_matrix_marks_rx_6700_xt_unverified():
+    text = (ROOT / "docs/install/docker.md").read_text(encoding="utf-8")
+    section = text.split("#### WSL2 architecture compatibility matrix", 1)[1].split(
+        "###", 1
+    )[0]
+
+    for classification in (
+        "Supported",
+        "Best-effort override",
+        "Unverified",
+        "Unsupported",
+    ):
+        assert f"| **{classification}** |" in section
+
+    rx_row = next(line for line in section.splitlines() if "RX 6700 XT" in line)
+    assert "`gfx1031`" in rx_row
+    assert "**Unverified**" in rx_row
+    assert "`gfx1030`" in rx_row
+    assert "`/dev/dxg` alone is not proof of acceleration" in section

--- a/tests/test_docker_admin_auth_docs.py
+++ b/tests/test_docker_admin_auth_docs.py
@@ -93,3 +93,6 @@ def test_wsl_rocm_matrix_marks_rx_6700_xt_unverified():
     assert "**Unverified**" in rx_row
     assert "`gfx1030`" in rx_row
     assert "`/dev/dxg` alone is not proof of acceleration" in section
+    assert "CPU fallback stage and reason" in section
+    assert "CPU-only completion" in section
+    assert "successful GPU validation" in section


### PR DESCRIPTION
## Summary

Classify RX 6700 XT `gfx1031` through WSL2 ROCDXG as unverified until end-to-end workload evidence exists.

Closes #1716.

## Changes

- Define Supported, Best-effort override, Unverified, and Unsupported architecture states.
- Clarify that `/dev/dxg` visibility alone does not prove GPU acceleration.
- Record the evidence required to change the RX 6700 XT classification.
- Add a regression test for the documentation contract.
- Document the classification in the Unreleased changelog.

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- `HF_HUB_OFFLINE=1 pytest -q tests/test_docker_admin_auth_docs.py tests/test_rocm_arch_gate.py tests/test_why_no_gpu_1274.py tests/test_changelog_style.py` (54 passed)

## Checklist

- [x] I have tested this locally
- [x] I have updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync; no version bump
- [x] Runtime behavior is unchanged

## Release cadence

VoiceStudio ships **continuous-to-main**. Every merged PR is immediately part of the rolling preview. Versioned releases are tagged from `main`; users who want stability pin a release tag, Docker `:stable`, or the desktop Stable channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The documentation now classifies RX 6700 XT/gfx1031 WSL2 ROCDXG acceleration as unverified and requires evidence that separates GPU validation from CPU fallback. A regression test enforces this documentation contract, and the changelog records the classification. Runtime behavior is unchanged; human review should confirm that the documented fallback evidence supports the unverified status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->