### PR TITLE
fix(frontend): align backend startup stall budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The setup splash now waits through the backend's full startup budget instead of reporting slow Windows CUDA initialization as stuck after two minutes (#1749)
 - OmniVoice subprocess startup now allows slow packaged Windows Python runtimes to signal readiness before termination (#1711)
 - SRT files selected during source analysis now wait for speaker cloning, then replace transcript text without losing voices (#1709)
 - Windows MSI deployments can now prohibit WebView2 bootstrap with `DISABLEWEBVIEW2BOOTSTRAP=1`, and `AUTOLAUNCHAPP=0` reliably suppresses first launch (#1714)

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -938,7 +938,12 @@ export function useBootstrapStage(pollMs = 1000) {
     // person can leave.
     const stallBudgetMs = (stage) => {
       if (stage === 'awaiting_setup') return Infinity;
-      return stage === 'installing_deps' ? 20 * 60 * 1000 : 120 * 1000;
+      if (stage === 'installing_deps') return 20 * 60 * 1000;
+      // Rust owns the backend launch and waits up to five minutes so slow
+      // torch/CUDA imports can finish. Keep the splash alive beyond that
+      // window; otherwise it reports a false failure at two minutes while
+      // the supervised backend is still healthy and making progress (#1749).
+      return stage === 'starting_backend' ? 6 * 60 * 1000 : 120 * 1000;
     };
     const invoke = async () => {
       try {

--- a/frontend/src/test/BootstrapSplashAwaitingSetupStall.test.jsx
+++ b/frontend/src/test/BootstrapSplashAwaitingSetupStall.test.jsx
@@ -102,7 +102,7 @@ describe('useBootstrapStage — awaiting_setup is human-gated (#1376)', () => {
     expect(result.current.stage).toBe('installing_deps');
   });
 
-  it('a machine-owned stage that genuinely wedges still fails', async () => {
+  it('lets Rust finish its backend startup budget before declaring a wedge', async () => {
     // The other half of the contract. Exempting awaiting_setup must not
     // disarm the stall detector for stages nothing but the app can advance —
     // that would trade this bug for the info-less infinite spinner (#879).
@@ -114,8 +114,18 @@ describe('useBootstrapStage — awaiting_setup is human-gated (#1376)', () => {
     await act(async () => {});
     expect(result.current.stage).toBe('starting_backend');
 
+    // The shell waits five minutes for slow torch/CUDA imports. The splash
+    // must not replace that live launch with its old two-minute false failure.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+    });
+
+    expect(result.current.stage).toBe('starting_backend');
+    expect(result.current.message ?? '').not.toMatch(/stuck/i);
+
+    // A frontend-only deadlock remains bounded if the shell never advances.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
     });
 
     expect(result.current.stage).toBe('failed');

--- a/frontend/src/test/BootstrapSplashAwaitingSetupStall.test.jsx
+++ b/frontend/src/test/BootstrapSplashAwaitingSetupStall.test.jsx
@@ -123,9 +123,17 @@ describe('useBootstrapStage — awaiting_setup is human-gated (#1376)', () => {
     expect(result.current.stage).toBe('starting_backend');
     expect(result.current.message ?? '').not.toMatch(/stuck/i);
 
+    // Pin both sides of the six-minute fallback boundary.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3 * 60 * 1000 - 1_000);
+    });
+
+    expect(result.current.stage).toBe('starting_backend');
+    expect(result.current.message ?? '').not.toMatch(/stuck/i);
+
     // A frontend-only deadlock remains bounded if the shell never advances.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(2_000);
     });
 
     expect(result.current.stage).toBe('failed');


### PR DESCRIPTION
## Summary

Keep the setup splash alive through the desktop shell's authoritative five-minute backend startup window.

Closes #1749.

## Changes

- Give `starting_backend` six minutes before the frontend stall fallback fires.
- Preserve the existing two-minute fallback for other machine-owned stages.
- Add a regression proving a three-minute Windows CUDA startup remains active while a true frontend deadlock stays bounded.
- Document the fix in the Unreleased changelog.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- `bun run test -- src/test/BootstrapSplashAwaitingSetupStall.test.jsx` (3 passed)
- `pytest -q tests/test_changelog_style.py` (8 passed)
- `oxlint` on both changed frontend files (existing warnings only)
- `oxfmt --check` on both changed frontend files
- `git diff --check`

## Checklist

- [x] I have tested this locally
- [x] I have updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync; no version bump
- [x] OmniVoice fixture compatibility is unchanged; this only changes splash timing

## Release cadence

VoiceStudio ships **continuous-to-main**. Every merged PR is immediately part of the rolling preview. Versioned releases are tagged from `main`; users who want stability pin a release tag, Docker `:stable`, or the desktop Stable channel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The frontend splash now allows six minutes for `starting_backend`, matching the desktop shell’s backend startup window and preventing slow Windows CUDA startup from being marked as stalled. This addresses startup failures where the backend remained in `starting_backend` and related endpoints returned `503` responses. The longer timeout may delay detection of genuine backend deadlocks, but regression tests cover the timeout boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->