### PR TITLE
fix: accept ASR-detected dub source codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Dubbing jobs can now reuse every source-language code produced by automatic ASR detection without a 400 error on the next upload (#1737)
 - OmniVoice subprocess startup now allows slow packaged Windows Python runtimes to signal readiness before termination (#1711)
 - SRT files selected during source analysis now wait for speaker cloning, then replace transcript text without losing voices (#1709)
 - Windows MSI deployments can now prohibit WebView2 bootstrap with `DISABLEWEBVIEW2BOOTSTRAP=1`, and `AUTOLAUNCHAPP=0` reliably suppresses first launch (#1714)

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -518,9 +518,12 @@ _ingest_gen       = dub_pipeline.ingest_pipeline
 #: container so a mislabelled video can't slip past the video-skipping branch.
 _AUDIO_EXTS = {".wav", ".mp3", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma"}
 
-# Source-language choices exposed by the first-party dub UI. Keeping this an
-# allow-list rejects language names and private-use BCP-47 tags before they are
-# persisted as ASR overrides. Values are normalized to lowercase below.
+# Source-language choices exposed by the first-party dub UI, plus every
+# two-letter code Whisper can write back after auto-detection. A restored job
+# may reuse that detected value as the next upload's override, so rejecting our
+# own persisted codes strands otherwise valid dubbing sessions (#1737).
+# Keeping this an allow-list still rejects language names and private-use
+# BCP-47 tags. Values are normalized to lowercase below.
 _DUB_SOURCE_LANG_CODES = frozenset({
     "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn", "bs", "bg",
     "my", "ca", "cmn-hans", "cmn-hant", "hr", "cs", "da", "nl", "en",
@@ -531,6 +534,8 @@ _DUB_SOURCE_LANG_CODES = frozenset({
     "ru", "sm", "gd", "sr", "sn", "sd", "si", "sk", "sl", "so", "es",
     "su", "sw", "sv", "tg", "ta", "te", "th", "tr", "uk", "ur", "uz",
     "vi", "cy", "xh", "yi", "yo", "zu",
+    "as", "ba", "bo", "br", "fo", "lb", "ln", "mg", "nn", "oc", "sa",
+    "tk", "tl", "tt", "yue", "zh",
 })
 
 

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -549,6 +549,15 @@ def _source_lang_override(value: str | None) -> str | None:
     return code
 
 
+def _detected_source_lang(value: str | None) -> str:
+    """Normalize an ASR language without truncating valid three-letter codes."""
+    code = (value or "en").split("_", 1)[0].strip().lower()
+    if code in _DUB_SOURCE_LANG_CODES:
+        return code
+    short = code[:2]
+    return short if short in _DUB_SOURCE_LANG_CODES else "en"
+
+
 @router.post("/dub/upload")
 async def dub_upload(
     video: UploadFile = File(...),
@@ -1814,9 +1823,9 @@ async def dub_transcribe_stream(
         except Exception as e:
             logger.warning("speaker_clone extraction skipped: %s", e)
 
-        job["source_lang"] = job.get("source_lang_override") or (
-            (detected_lang or "en").split("_")[0][:2] or "en"
-        ).lower()
+        job["source_lang"] = job.get("source_lang_override") or _detected_source_lang(
+            detected_lang
+        )
         job["full_transcript"] = " ".join(s.get("text", "") for s in final_segs)
         _save_job(job_id, job)
 
@@ -2013,9 +2022,9 @@ async def dub_transcribe(job_id: str, num_speakers: Optional[int] = None):
             except Exception as e:
                 logger.warning("Failed to unload ASR backend: %s", e)
 
-        job["source_lang"] = job.get("source_lang_override") or (
-            (detected_lang or "en").split("_")[0][:2] or "en"
-        ).lower()
+        job["source_lang"] = job.get("source_lang_override") or _detected_source_lang(
+            detected_lang
+        )
 
         scene_cuts = job.get("scene_cuts") or []
         segments = segment_transcript(result, duration=job.get("duration", 0.0), scene_cuts=scene_cuts)

--- a/backend/api/routers/dub_core.py
+++ b/backend/api/routers/dub_core.py
@@ -519,7 +519,7 @@ _ingest_gen       = dub_pipeline.ingest_pipeline
 _AUDIO_EXTS = {".wav", ".mp3", ".m4a", ".aac", ".flac", ".ogg", ".opus", ".wma"}
 
 # Source-language choices exposed by the first-party dub UI, plus every
-# two-letter code Whisper can write back after auto-detection. A restored job
+# language code Whisper can write back after auto-detection. A restored job
 # may reuse that detected value as the next upload's override, so rejecting our
 # own persisted codes strands otherwise valid dubbing sessions (#1737).
 # Keeping this an allow-list still rejects language names and private-use

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -347,4 +347,12 @@ class TestAudioOnlyDubbing:
             "sa", "tk", "tl", "tt", "yue", "zh",
         }
 
-        assert {dc._source_lang_override(code) for code in detected_codes} == detected_codes
+        for code in detected_codes:
+            assert dc._source_lang_override(code) == code
+
+    def test_asr_detected_cantonese_code_is_not_truncated(self, app_client):
+        _client, dc, _dx, _tmp = app_client
+
+        assert dc._detected_source_lang("yue") == "yue"
+        assert dc._detected_source_lang("es_ES") == "es"
+        assert dc._detected_source_lang("unknown-language") == "en"

--- a/tests/test_dub_export_unique.py
+++ b/tests/test_dub_export_unique.py
@@ -339,3 +339,12 @@ class TestAudioOnlyDubbing:
 
         assert response.status_code == 202
         assert queued[0][5]["source_lang"] == "fr"
+
+    def test_asr_detected_source_languages_can_be_reused_as_overrides(self, app_client):
+        _client, dc, _dx, _tmp = app_client
+        detected_codes = {
+            "as", "ba", "bo", "br", "fo", "lb", "ln", "mg", "nn", "oc",
+            "sa", "tk", "tl", "tt", "yue", "zh",
+        }
+
+        assert {dc._source_lang_override(code) for code in detected_codes} == detected_codes


### PR DESCRIPTION
## Summary

Allow a restored dubbing job to reuse every source-language code produced by automatic ASR detection.

Closes #1737.

## Changes

- Extend the source-language allow-list with the 16 Whisper codes missing from the first-party picker.
- Continue rejecting language names and private-use tags.
- Add a regression covering every newly accepted detected code.
- Document the fix in the Unreleased changelog.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- `HF_HUB_OFFLINE=1 HF_HUB_CACHE=$(mktemp -d) pytest -q tests/test_dub_export_unique.py tests/test_changelog_style.py` (22 passed)
- `git diff --check`

## Checklist

- [x] I have tested this locally
- [x] I have updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync; no version bump
- [x] OmniVoice fixture compatibility is unchanged; this only validates dubbing metadata

## Release cadence

VoiceStudio ships **continuous-to-main**. Every merged PR is immediately part of the rolling preview. Versioned releases are tagged from `main`; users who want stability pin a release tag, Docker `:stable`, or the desktop Stable channel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Dubbing validation now accepts all 16 additional source-language codes produced by automatic ASR detection when restoring jobs. This prevents the `400 Bad Request: Invalid source language code` error reported in issue `#1737` and adds regression coverage plus an Unreleased changelog entry. The allow-list change has low risk because language names and private-use tags remain rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->