### PR TITLE
docs(readme): polish hero hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <div align="center">
-  <a href="https://trendshift.io/repositories/28176?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-28176" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/28176" alt="VoiceStudio ranking on Trendshift" width="250" height="55" /></a>
-
-  <img src="docs/logo.png" alt="VoiceStudio logo" width="120" height="120" />
+  <p><img src="docs/logo.png" alt="VoiceStudio logo" width="120" height="120" /></p>
   <h1>VoiceStudio</h1>
+  <p>
+    <a href="https://trendshift.io/repositories/28176?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-28176" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/28176" alt="VoiceStudio ranking on Trendshift" width="220" height="48" /></a>
+  </p>
   <p><sub>Previously OmniVoice-Studio</sub></p>
   <h3>Clone voices, dub video, dictate, and produce long-form audio on your own hardware.</h3>
   <p>16 TTS engines · 11 ASR engines · 646-language catalogue · macOS, Windows, Linux, and Docker</p>


### PR DESCRIPTION
## Summary

Place the Trendshift ranking beneath the VoiceStudio logo and name so the product identity leads the README hero.

## Changes

- Put the logo and ranking badge on separate centered rows.
- Reduce the ranking badge from 250×55 to 220×48.
- Preserve the existing link, alt text, product copy, and documentation structure.

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [ ] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- Branding assertions passed.
- Canonical documentation inventory passed for all 50 tracked entries.
- All 58 local README references and navigation anchors resolve.
- `git diff --check` passed.

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation
- [x] No local machine paths, logs, or personal environment details are included
- [x] Version files are unchanged
- [x] Runtime behavior is unchanged

## Release cadence

VoiceStudio ships continuous-to-main. This documentation-only change will enter the rolling preview after merge; version files remain unchanged.