### PR TITLE
docs(readme): enrich with audio samples, hardware guide, and doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <div align="center">
-  <a href="https://trendshift.io/repositories/28176?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-28176" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/28176" alt="VoiceStudio ranking on Trendshift" width="250" height="55" /></a>
-
-  <img src="docs/logo.png" alt="VoiceStudio logo" width="120" height="120" />
+  <p><img src="docs/logo.png" alt="VoiceStudio logo" width="120" height="120" /></p>
   <h1>VoiceStudio</h1>
+  <p>
+    <a href="https://trendshift.io/repositories/28176?utm_source=repository-badge&amp;utm_medium=badge&amp;utm_campaign=badge-repository-28176" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/28176" alt="VoiceStudio ranking on Trendshift" width="220" height="48" /></a>
+  </p>
   <p><sub>Previously OmniVoice-Studio</sub></p>
   <h3>Clone voices, dub video, dictate, and produce long-form audio on your own hardware.</h3>
   <p>16 TTS engines · 11 ASR engines · 646-language catalogue · macOS, Windows, Linux, and Docker</p>

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ with client.audio.speech.with_streaming_response.create(
 # Quick test via cURL
 curl http://localhost:3900/v1/audio/speech \
   -H "Content-Type: application/json" \
-  -d '{"model": "tts-1", "input": "Made on my own hardware.", "voice": "default"}' \
+  -d '{"model": "tts-1", "input": "Made on my own hardware.", "voice": "default", "response_format": "wav"}' \
   --output speech.wav
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ First launch creates a managed Python environment and downloads the default mode
 ### Quick Docker run
 
 ```bash
-docker run -d -p 127.0.0.1:3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
+docker run -d -p 127.0.0.1:3900:3900 -v omnivoice-data:/app/omnivoice_data --name voicestudio palashdeb/omnivoice-studio:stable
 ```
 
 ### First voice

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ First launch creates a managed Python environment and downloads the default mode
 ### Quick Docker run
 
 ```bash
-docker run -d -p 3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
+docker run -d -p 127.0.0.1:3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
 ```
 
 ### First voice
@@ -358,8 +358,21 @@ VoiceStudio mounts an MCP server at `http://localhost:3900/mcp` for Claude Deskt
 {
   "mcpServers": {
     "voicestudio": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "http://localhost:3900/mcp"]
+      "url": "http://localhost:3900/mcp"
+    }
+  }
+}
+```
+
+For clients requiring stdio transport, use the bundled local shim (`docs/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "voicestudio": {
+      "command": "python",
+      "args": ["-m", "backend.mcp_shim"],
+      "cwd": "/path/to/VoiceStudio"
     }
   }
 }
@@ -452,7 +465,7 @@ VoiceStudio is free and has no paid tier. Donations fund development and infrast
 VoiceStudio enables zero-shot voice cloning and speech generation on personal hardware. Please use it responsibly:
 - **Consent:** Only clone or synthesize voices with explicit permission from the speaker.
 - **Audio provenance:** VoiceStudio integrates [AudioSeal](https://github.com/facebookresearch/audioseal) imperceptible watermarking by default to detect and identify synthetic speech without altering sound quality.
-- **Local privacy:** Audio recordings, transcripts, voices, and projects remain strictly on your local disk.
+- **Local privacy:** For the default local workflow, audio recordings, transcripts, voices, and projects remain strictly on your local disk; data leaves your device only when you explicitly configure remote workers or external ASR endpoints.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,17 @@
     <a href="#features">Features</a> ·
     <a href="#comparison">Compare</a> ·
     <a href="#requirements">Requirements</a> ·
+    <a href="#hardware-recommendations">Hardware</a> ·
     <a href="#engines">Engines</a> ·
     <a href="#architecture">Architecture</a> ·
     <a href="#api">API</a> ·
     <a href="#documentation">Docs</a> ·
+    <a href="#faq">FAQ</a> ·
     <a href="README_CN.md"><strong>简体中文</strong></a>
   </p>
 
   <p>
+    <a href="https://github.com/debpalash/VoiceStudio/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/debpalash/VoiceStudio/ci.yml?branch=main&style=flat-square&label=CI" alt="CI status" /></a>
     <a href="https://github.com/debpalash/VoiceStudio/stargazers"><img src="https://img.shields.io/github/stars/debpalash/VoiceStudio?style=flat-square&color=f59e0b" alt="GitHub stars" /></a>
     <a href="https://github.com/debpalash/VoiceStudio/releases"><img src="https://img.shields.io/github/downloads/debpalash/VoiceStudio/total?style=flat-square&color=8b5cf6&label=downloads" alt="Total downloads" /></a>
     <a href="https://github.com/debpalash/VoiceStudio/releases/latest"><img src="https://img.shields.io/github/v/release/debpalash/VoiceStudio?style=flat-square&color=10b981" alt="Latest release" /></a>
@@ -72,15 +75,35 @@ First launch creates a managed Python environment and downloads the default mode
 > [!NOTE]
 > On macOS, first launch needs a one-time right-click, then **Open** approval. Intel Macs cannot run the local Python backend; use a [remote backend](docs/install/macos.md) instead.
 
+### Quick Docker run
+
+```bash
+docker run -d -p 3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
+```
+
 ### First voice
 
 1. Launch VoiceStudio and open **Voice Cloning**.
 2. Add a clean voice sample. Three seconds works; 5 to 15 seconds usually gives a better prompt.
 3. Enter text, choose a language, then select **Generate**.
 
+> [!TIP]
+> **Try without installing:** Run VoiceStudio in the cloud via the [Google Colab notebook](https://colab.research.google.com/github/debpalash/VoiceStudio/blob/main/notebooks/OmniVoice_Studio_Colab.ipynb). Explore audio quality comparisons in [benchmarks](docs/benchmarks.md) and prompt design tips in [expressive speech](docs/expressive-speech.md).
+
+### Audio samples
+
+Listen to sample outputs produced locally with VoiceStudio:
+
+| Workflow | Prompt / Reference Audio | Generated Audio |
+|---|---|---|
+| **Voice Cloning** | [demo_voice.wav](backend/assets/samples/demo_voice.wav) | [demo_clone_output.wav](backend/assets/samples/demo_clone_output.wav) |
+| **Voice Design** (US News Anchor) | *"Clear, authoritative American broadcast tone"* | [demo_voice_design_us_news_anchor.wav](backend/assets/samples/voice_design/demo_voice_design_us_news_anchor.wav) |
+| **Voice Design** (UK Audiobook) | *"Warm, expressive British storytelling voice"* | [demo_voice_design_audiobook_uk_narrator.wav](backend/assets/samples/voice_design/demo_voice_design_audiobook_uk_narrator.wav) |
+| **Video Dubbing** (Multilingual) | [source.src.wav](backend/assets/samples/demo/dubbing/source.src.wav) | [Spanish](backend/assets/samples/demo/dubbing/dubbed_es.src.wav) · [French](backend/assets/samples/demo/dubbing/dubbed_fr.src.wav) · [Japanese](backend/assets/samples/demo/dubbing/dubbed_ja.src.wav) · [Chinese](backend/assets/samples/demo/dubbing/dubbed_zh.src.wav) |
+
 ### Run from source
 
-Install the [development prerequisites](.github/CONTRIBUTING.md#development-setup), then:
+Install the [development prerequisites](.github/CONTRIBUTING.md#development-setup) (Node 20+/Bun and Python 3.11+), then:
 
 ```bash
 git clone https://github.com/debpalash/VoiceStudio.git
@@ -89,7 +112,7 @@ bun install
 bun run desktop
 ```
 
-Use `bun run dev` for the browser UI. See [Contributing](.github/CONTRIBUTING.md) for services, tests, and platform packages.
+The desktop launcher configures Python dependencies on first run via `uv` automatically. Use `bun run dev` for the browser UI. See [Contributing](.github/CONTRIBUTING.md) for services, tests, and platform packages.
 
 ### If setup fails
 
@@ -104,22 +127,22 @@ Use `bun run dev` for the browser UI. See [Contributing](.github/CONTRIBUTING.md
 
 | Area | Included |
 |---|---|
-| **Voice Cloning** | Zero-shot synthesis from a short reference clip |
-| **Voice Design** | Create a voice from age, accent, pitch, style, and delivery instructions |
-| **Video Dubbing** | Transcribe, translate, preserve speakers, synthesize, and export video |
+| **Voice Cloning** | Zero-shot synthesis from a short reference clip ([guide](docs/engines/README.md)) |
+| **Voice Design** | Create a voice from age, accent, pitch, style, and delivery instructions ([expressive speech](docs/expressive-speech.md)) |
+| **Video Dubbing** | Transcribe, translate, preserve speakers, synthesize, and export video ([export guide](docs/dubbing/export.md)) |
 | **Stories and audiobooks** | Multi-voice scripts · EPUB/PDF import · chapter rendering · `.m4b` export |
 | **[Dictation Widget](docs/features/dictation.md)** | System-wide shortcut, live transcription, optional local-LLM cleanup |
 | **Vocal Isolation** | Demucs speech/background separation |
-| **Speaker Diarization** | Pyannote and WhisperX speaker assignment |
+| **Speaker Diarization** | Pyannote and WhisperX speaker assignment ([guide](docs/features/diarization.md)) |
 | **Batch Queue** | Queue large sets of audio and video jobs with per-job progress |
-| **Model Catalogue** | Install, remove, select, and route TTS, ASR, and LLM models |
-| **Remote Model Downloads** | Install models on enrolled remote workers with live progress |
-| **GPU Auto-Detect** | CUDA, MPS, ROCm, and CPU routing with per-engine checks |
+| **Model Catalogue** | Install, remove, select, and route TTS, ASR, and LLM models ([catalogue](docs/engines/README.md)) |
+| **Remote Model Downloads** | Install models on enrolled remote workers with live progress ([guide](docs/downloading-models.md)) |
+| **GPU Auto-Detect** | CUDA, MPS, ROCm, and CPU routing with per-engine checks ([performance](docs/performance.md)) |
 | **AI Watermark** | AudioSeal embedding and detection |
-| **MCP Server** | Synthesis and transcription tools for MCP clients |
-| **Diagnostics** | Self-checks, error journal, logs, and scrubbed support bundles |
+| **MCP Server** | Synthesis and transcription tools for MCP clients ([guide](docs/mcp.md)) |
+| **Diagnostics** | Self-checks, error journal, logs, and scrubbed support bundles ([troubleshooting](docs/install/troubleshooting.md)) |
 | **Local-first** | Core creation stays local; network-backed features are explicit opt-ins |
-| **Extensible** | Registry-based TTS, ASR, and plugin interfaces |
+| **Extensible** | Registry-based TTS, ASR, and plugin interfaces ([acceptance](docs/engine-acceptance.md)) |
 
 <table>
 <tr>
@@ -166,6 +189,16 @@ Requirements vary by engine. These values cover the default local workflow.
 
 ROCm is Linux-only and opt-in. Windows AMD/Ryzen AI uses CPU. Systems with limited VRAM offload work to CPU when required. See [performance](docs/performance.md), [benchmarks](docs/benchmarks.md), and [engine disk usage](docs/engines/disk-usage.md).
 
+<a id="hardware-recommendations"></a>
+
+### Recommended stack by hardware
+
+| Hardware | Recommended TTS | Recommended ASR | Why |
+|---|---|---|---|
+| **Apple Silicon (M1–M4)** | [MLX-Audio](docs/engines/mlx-audio.md) · [OmniVoice](docs/engines/omnivoice.md) (MPS) | [MLX Whisper](docs/engines/mlx-whisper.md) · [Parakeet MLX](docs/engines/parakeet-mlx.md) | Native unified memory, lowest latency on macOS |
+| **NVIDIA GPU (8 GB+ VRAM)** | [OmniVoice](docs/engines/omnivoice.md) · [CosyVoice 3](docs/engines/cosyvoice.md) | [WhisperX](docs/engines/whisperx.md) | High-fidelity zero-shot cloning, word timestamps, diarization |
+| **Low VRAM / CPU-only** | [PocketTTS](docs/engines/pockettts.md) · [Sherpa-ONNX](docs/engines/sherpa-onnx.md) · [KittenTTS](docs/engines/kittentts.md) | [Moonshine](docs/engines/moonshine.md) · [Faster-Whisper](docs/engines/faster-whisper.md) (`int8`) | Low memory footprint, optimized CPU inference |
+
 <a id="engines"></a>
 
 ## Engines
@@ -178,22 +211,22 @@ Engine support is capability-specific. Check cloning, language, platform, memory
 
 | Engine | Languages | Clone | Instruct | Linux | macOS ARM | Windows | License |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|---|
-| **VoiceStudio** (default, powered by k2-fsa/OmniVoice) | 600+ | Yes | Yes | CUDA/CPU | MPS | CUDA/CPU | [AGPL-3.0](LICENSE) app · [Apache-2.0 code, CC-BY-NC weights](https://huggingface.co/k2-fsa/OmniVoice#license)³ |
-| **CosyVoice 3** | 9 + 18 dialects | Yes | Yes | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
-| **GPT-SoVITS** | 5 | Yes | No | CUDA/CPU | No | CUDA/CPU | MIT |
-| **VoxCPM2** | 30 | Yes | Yes | CUDA/CPU | MPS | CUDA/CPU | Apache-2.0 |
-| **MOSS-TTS-Nano** | 20 | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
-| **KittenTTS** | English | No | No | CPU | CPU | CPU | MIT |
-| **MLX-Audio** | Model-dependent | Varies | Varies | No | MLX | No | Varies |
-| **Sherpa-ONNX** | 20+ | No | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
-| **IndexTTS 2.5** ⚡ | ZH · EN · JA · ES · AR | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Bilibili model license¹ |
-| **OmniVoice GGUF** ⚡ | 600+ | Yes | Yes | CUDA/CPU | MPS/CPU | CUDA/CPU | [AGPL-3.0](LICENSE) app · [review the derivative model terms](https://huggingface.co/Serveurperso/OmniVoice-GGUF#license)³ |
-| **OmniVoice (subprocess)** ⚡ | 600+ | Yes | Yes | CUDA/CPU | MPS | CUDA/CPU | [AGPL-3.0](LICENSE) app · [Apache-2.0 code, CC-BY-NC weights](https://huggingface.co/k2-fsa/OmniVoice#license)³ |
-| **PocketTTS** ⚡ | EN · FR · DE · PT · IT · ES | Yes | No | CPU | CPU | CPU | CC-BY-4.0, gated² |
-| **Supertonic 3** ⚡ | 31 | No | No | CPU | CPU | CPU | OpenRAIL-M |
-| **MOSS-TTS-v1.5** ⚡ | 31 | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
-| **dots.tts** ⚡ | 24 | Yes | No | CUDA/CPU | CPU | No | Apache-2.0 |
-| **Confucius4-TTS** ⚡ | 14 | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
+| [**VoiceStudio** (default, powered by k2-fsa/OmniVoice)](docs/engines/omnivoice.md) | 600+ | Yes | Yes | CUDA/CPU | MPS | CUDA/CPU | [AGPL-3.0](LICENSE) app · [Apache-2.0 code, CC-BY-NC weights](https://huggingface.co/k2-fsa/OmniVoice#license)³ |
+| [**CosyVoice 3**](docs/engines/cosyvoice.md) | 9 + 18 dialects | Yes | Yes | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
+| [**GPT-SoVITS**](docs/engines/gpt-sovits.md) | 5 | Yes | No | CUDA/CPU | No | CUDA/CPU | MIT |
+| [**VoxCPM2**](docs/engines/voxcpm2.md) | 30 | Yes | Yes | CUDA/CPU | MPS | CUDA/CPU | Apache-2.0 |
+| [**MOSS-TTS-Nano**](docs/engines/moss-tts-nano.md) | 20 | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
+| [**KittenTTS**](docs/engines/kittentts.md) | English | No | No | CPU | CPU | CPU | MIT |
+| [**MLX-Audio**](docs/engines/mlx-audio.md) | Model-dependent | Varies | Varies | No | MLX | No | Varies |
+| [**Sherpa-ONNX**](docs/engines/sherpa-onnx.md) | 20+ | No | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
+| [**IndexTTS 2.5** ⚡](docs/engines/indextts.md) | ZH · EN · JA · ES · AR | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Bilibili model license¹ |
+| [**OmniVoice GGUF** ⚡](docs/engines/omnivoice-gguf.md) | 600+ | Yes | Yes | CUDA/CPU | MPS/CPU | CUDA/CPU | [AGPL-3.0](LICENSE) app · [review the derivative model terms](https://huggingface.co/Serveurperso/OmniVoice-GGUF#license)³ |
+| [**OmniVoice (subprocess)** ⚡](docs/engines/omnivoice-subprocess.md) | 600+ | Yes | Yes | CUDA/CPU | MPS | CUDA/CPU | [AGPL-3.0](LICENSE) app · [Apache-2.0 code, CC-BY-NC weights](https://huggingface.co/k2-fsa/OmniVoice#license)³ |
+| [**PocketTTS** ⚡](docs/engines/pockettts.md) | EN · FR · DE · PT · IT · ES | Yes | No | CPU | CPU | CPU | CC-BY-4.0, gated² |
+| [**Supertonic 3** ⚡](docs/engines/supertonic3.md) | 31 | No | No | CPU | CPU | CPU | OpenRAIL-M |
+| [**MOSS-TTS-v1.5** ⚡](docs/engines/moss-tts-v15.md) | 31 | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
+| [**dots.tts** ⚡](docs/engines/dots-tts.md) | 24 | Yes | No | CUDA/CPU | CPU | No | Apache-2.0 |
+| [**Confucius4-TTS** ⚡](docs/engines/confucius4-tts.md) | 14 | Yes | No | CUDA/CPU | CPU | CUDA/CPU | Apache-2.0 |
 
 ⚡ Installed or registered on demand.
 
@@ -211,17 +244,17 @@ Clone-less engines cannot preserve a reference speaker in dubbing or pinned-voic
 
 | Engine | ID | Languages | Best fit |
 |---|---|:---:|---|
-| **WhisperX** (default) | `whisperx` | ~100 | Dubbing, subtitles, word-level timing |
-| **Faster-Whisper** | `faster-whisper` | ~100 | General cross-platform transcription |
-| **Faster-Whisper (isolated)** | `faster-whisper-isolated` | ~100 | Crash-isolated batch transcription |
-| **MLX Whisper** | `mlx-whisper` | ~100 | Apple Silicon |
-| **PyTorch Whisper** | `pytorch-whisper` | ~100 | CUDA, MPS, and CPU fallback |
-| **Parakeet TDT** | `nemo-parakeet` | English + 25 EU | Fast CPU/CUDA transcription |
-| **Parakeet TDT v3 (MLX)** | `parakeet-mlx` | 25 EU | Apple Silicon dictation and word timestamps |
-| **Moonshine** | `moonshine` | English | Low-power, low-latency ONNX |
-| **FunASR** | `funasr` | 50+ | VAD and inline diarization |
-| **sherpa-onnx** (live dictation) | `sherpa-onnx-asr` | Model-dependent | Streaming CPU dictation |
-| **OpenAI-compatible** ⚠️ configured server | `openai-compat-asr` | Server-dependent | Local gigastt/Qwen3-ASR or a remote endpoint; audio goes only to that server |
+| [**WhisperX** (default)](docs/engines/whisperx.md) | `whisperx` | ~100 | Dubbing, subtitles, word-level timing |
+| [**Faster-Whisper**](docs/engines/faster-whisper.md) | `faster-whisper` | ~100 | General cross-platform transcription |
+| [**Faster-Whisper (isolated)**](docs/engines/faster-whisper-isolated.md) | `faster-whisper-isolated` | ~100 | Crash-isolated batch transcription |
+| [**MLX Whisper**](docs/engines/mlx-whisper.md) | `mlx-whisper` | ~100 | Apple Silicon |
+| [**PyTorch Whisper**](docs/engines/pytorch-whisper.md) | `pytorch-whisper` | ~100 | CUDA, MPS, and CPU fallback |
+| [**Parakeet TDT**](docs/engines/nemo-parakeet.md) | `nemo-parakeet` | English + 25 EU | Fast CPU/CUDA transcription |
+| [**Parakeet TDT v3 (MLX)**](docs/engines/parakeet-mlx.md) | `parakeet-mlx` | 25 EU | Apple Silicon dictation and word timestamps |
+| [**Moonshine**](docs/engines/moonshine.md) | `moonshine` | English | Low-power, low-latency ONNX |
+| [**FunASR**](docs/engines/funasr.md) | `funasr` | 50+ | VAD and inline diarization |
+| [**sherpa-onnx** (live dictation)](docs/engines/sherpa-onnx-asr.md) | `sherpa-onnx-asr` | Model-dependent | Streaming CPU dictation |
+| [**OpenAI-compatible** ⚠️ configured server](docs/engines/openai-compatible-asr.md) | `openai-compat-asr` | Server-dependent | Local gigastt/Qwen3-ASR or a remote endpoint; audio goes only to that server |
 
 WhisperX and Faster-Whisper retry with `int8` when efficient `float16` is unavailable. Pin `ASR_COMPUTE_TYPE=int8` or `float32` only if automatic selection still fails.
 
@@ -292,6 +325,14 @@ with client.audio.speech.with_streaming_response.create(
     response.stream_to_file("speech.wav")
 ```
 
+```bash
+# Quick test via cURL
+curl http://localhost:3900/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model": "tts-1", "input": "Made on my own hardware.", "voice": "default"}' \
+  --output speech.wav
+```
+
 The bundled Rust control sidecar lets Herdr, coding agents, VS Code, desktop apps,
 and TUIs trigger the system-wide dictation flow or reuse its native text
 insertion. See the [speech platform guide](docs/speech-platform.md). The full API
@@ -308,6 +349,23 @@ npx skills add debpalash/VoiceStudio
 
 - `omnivoice`: synthesize speech and transcribe audio through local VoiceStudio.
 - `oss-maintainer`: the repository's open-source maintenance workflow.
+
+### Model Context Protocol (MCP)
+
+VoiceStudio mounts an MCP server at `http://localhost:3900/mcp` for Claude Desktop, Cursor, and AI agents:
+
+```json
+{
+  "mcpServers": {
+    "voicestudio": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:3900/mcp"]
+    }
+  }
+}
+```
+
+See the [MCP guide](docs/mcp.md) for tools (`generate_speech`, `clone_voice`, `transcribe`), file streaming modes, and client bindings.
 
 ### Google Colab
 
@@ -329,6 +387,8 @@ The [notebook](notebooks/OmniVoice_Studio_Colab.ipynb) runs the app and web UI o
 | Build VoiceStudio | [Contributing](.github/CONTRIBUTING.md) · [engine acceptance](docs/engine-acceptance.md) |
 | Track changes | [Changelog](CHANGELOG.md) · [roadmap](docs/ROADMAP.md) · [latest release](https://github.com/debpalash/VoiceStudio/releases/latest) |
 | Remove everything | [Uninstall guide](docs/install/uninstall.md) |
+
+<a id="faq"></a>
 
 ## FAQ
 
@@ -375,11 +435,24 @@ Use `scripts/uninstall.sh` on macOS/Linux or `scripts\uninstall.ps1` on Windows.
 - [Good first issues](https://github.com/debpalash/VoiceStudio/labels/good%20first%20issue) for a scoped starting point.
 - [Contributing guide](.github/CONTRIBUTING.md) for setup, tests, and pull requests.
 
+<p align="center">
+  <a href="https://star-history.com/#debpalash/VoiceStudio&Date">
+    <img src="https://api.star-history.com/svg?repos=debpalash/VoiceStudio&type=Date" alt="Star History Chart" width="100%" />
+  </a>
+</p>
+
 ## Support development
 
 VoiceStudio is free and has no paid tier. Donations fund development and infrastructure.
 
 [Ko-fi](https://ko-fi.com/debpalash) · [PayPal](https://paypal.me/palashCoder) · [Sponsorship details](SPONSORS.md)
+
+## Responsible use and safety
+
+VoiceStudio enables zero-shot voice cloning and speech generation on personal hardware. Please use it responsibly:
+- **Consent:** Only clone or synthesize voices with explicit permission from the speaker.
+- **Audio provenance:** VoiceStudio integrates [AudioSeal](https://github.com/facebookresearch/audioseal) imperceptible watermarking by default to detect and identify synthetic speech without altering sound quality.
+- **Local privacy:** Audio recordings, transcripts, voices, and projects remain strictly on your local disk.
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -75,7 +75,7 @@ docker run -d -p 127.0.0.1:3900:3900 --name voicestudio palashdeb/omnivoice-stud
 
 1. **安装并启动。** 首次启动会自动搭建 Python 运行环境并下载模型权重——启动画面会逐步显示进度（仅首次，需要几分钟；之后即开即用）。
 2. 从启动台打开**语音克隆**，拖入任意声音的 **3 秒音频**。
-3. **输入一句话，点击生成。** 音频完全属于你——在你的设备上生成和保存，支持 646 种语言。
+3. **输入一句话，点击生成。** 音频在你的设备上生成并保存，支持 646 种语言（商业使用前请审阅所选模型与分词器的许可条款）。
 
 ### 🎧 音频示例
 
@@ -365,9 +365,9 @@ print(result.text)
 
 ### 📓 在 Google Colab 上运行
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/debpalash/VoiceStudio/blob/main/notebooks/VoiceStudio_Studio_Colab.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/debpalash/VoiceStudio/blob/main/notebooks/OmniVoice_Studio_Colab.ipynb)
 
-没有本地 GPU？官方笔记本（[notebooks/VoiceStudio_Studio_Colab.ipynb](notebooks/VoiceStudio_Studio_Colab.ipynb)）可在免费的 Colab T4 上启动完整应用（包含 Web 界面）：在笔记本内直接构建前端，用 uv 安装后端（复用 Colab 预装的 CUDA PyTorch），并通过 Colab 内置端口代理打开界面。无需第三方隧道，也无需任何 API 密钥。随后还有一套覆盖全部主要功能的 API 导览，全部可在笔记本内直接播放：多语言 TTS、声音克隆与声音设计、已保存的声音档案、语音转写、AI 水印检测、OpenAI 兼容 API、多角色故事、带章节的 m4b 有声书，以及一个附带人声分离音轨的迷你视频配音。
+没有本地 GPU？官方笔记本（[notebooks/OmniVoice_Studio_Colab.ipynb](notebooks/OmniVoice_Studio_Colab.ipynb)）可在免费的 Colab T4 上启动完整应用（包含 Web 界面）：在笔记本内直接构建前端，用 uv 安装后端（复用 Colab 预装的 CUDA PyTorch），并通过 Colab 内置端口代理打开界面。无需第三方隧道，也无需任何 API 密钥。随后还有一套覆盖全部主要功能的 API 导览，全部可在笔记本内直接播放：多语言 TTS、声音克隆与声音设计、已保存的声音档案、语音转写、AI 水印检测、OpenAI 兼容 API、多角色故事、带章节的 m4b 有声书，以及一个附带人声分离音轨的迷你视频配音。
 
 ### 🤝 智能体技能（Agent Skills）
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -20,6 +20,7 @@
   </p>
 
   <p>
+    <a href="https://github.com/debpalash/VoiceStudio/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/debpalash/VoiceStudio/ci.yml?branch=main&style=flat-square&label=CI" alt="CI 状态" /></a>
     <a href="https://github.com/debpalash/VoiceStudio/stargazers"><img src="https://img.shields.io/github/stars/debpalash/VoiceStudio?style=flat-square&color=f59e0b" alt="Star 数" /></a>
     <a href="https://github.com/debpalash/VoiceStudio/releases/latest"><img src="https://img.shields.io/github/v/release/debpalash/VoiceStudio?style=flat-square&color=10b981" alt="版本" /></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="许可证" /></a>
@@ -65,11 +66,27 @@
 - 🐧 **Linux** — [docs/install/linux.md](docs/install/linux.md)
 - 🐳 **Docker** — [docs/install/docker.md](docs/install/docker.md) · [Docker Hub: `palashdeb/omnivoice-studio`](https://hub.docker.com/r/palashdeb/omnivoice-studio)
 
+```bash
+# Docker 快速运行 (CPU / 本地环回模式)
+docker run -d -p 3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
+```
+
 **三步克隆出你的第一个声音：**
 
 1. **安装并启动。** 首次启动会自动搭建 Python 运行环境并下载模型权重——启动画面会逐步显示进度（仅首次，需要几分钟；之后即开即用）。
 2. 从启动台打开**语音克隆**，拖入任意声音的 **3 秒音频**。
 3. **输入一句话，点击生成。** 音频完全属于你——在你的设备上生成和保存，支持 646 种语言。
+
+### 🎧 音频示例
+
+在线试听 VoiceStudio 本地生成的实际音频样例：
+
+| 工作流 | 提示词 / 参考音频 | 生成音频 |
+|---|---|---|
+| **声音克隆** | [demo_voice.wav](backend/assets/samples/demo_voice.wav) | [demo_clone_output.wav](backend/assets/samples/demo_clone_output.wav) |
+| **声音设计** (美语新闻主播) | *"清晰、权威的美国广播级音色"* | [demo_voice_design_us_news_anchor.wav](backend/assets/samples/voice_design/demo_voice_design_us_news_anchor.wav) |
+| **声音设计** (英式有声书) | *"温暖生动的英式故事讲述音色"* | [demo_voice_design_audiobook_uk_narrator.wav](backend/assets/samples/voice_design/demo_voice_design_audiobook_uk_narrator.wav) |
+| **视频配音** (多语种) | [source.src.wav](backend/assets/samples/demo/dubbing/source.src.wav) | [西班牙语](backend/assets/samples/demo/dubbing/dubbed_es.src.wav) · [法语](backend/assets/samples/demo/dubbing/dubbed_fr.src.wav) · [日语](backend/assets/samples/demo/dubbing/dubbed_ja.src.wav) · [中文](backend/assets/samples/demo/dubbing/dubbed_zh.src.wav) |
 
 觉得慢？[docs/performance.md](docs/performance.md) 讲清了生成时间到底花在哪里、有哪些调优开关，以及“它变慢了”的三个经典原因。各引擎/设备的实测数据见 [docs/benchmarks.md](docs/benchmarks.md)。
 
@@ -217,6 +234,16 @@ Hugging Face Token 的配置见
 > [!IMPORTANT]
 > **macOS Intel（x86_64）不支持本地后端：** 应用 UI 可以安装，但 Python 后端无法运行，因为 PyTorch 已不再发布 Intel Mac 轮子（[#889](https://github.com/debpalash/VoiceStudio/issues/889)）。Intel Mac 用户仍可让 UI 指向另一台机器上的远程后端——参见 [docs/install/macos.md](docs/install/macos.md)。
 
+<a id="hardware-recommendations"></a>
+
+### 💡 按硬件推荐引擎配置
+
+| 硬件配置 | 推荐 TTS 引擎 | 推荐 ASR 语音识别 | 优势 |
+|---|---|---|---|
+| **Apple Silicon (M1–M4)** | [MLX-Audio](docs/engines/mlx-audio.md) · [OmniVoice](docs/engines/omnivoice.md) (MPS) | [MLX Whisper](docs/engines/mlx-whisper.md) · [Parakeet MLX](docs/engines/parakeet-mlx.md) | 原生统一内存，macOS 上延迟最低、性能最强 |
+| **NVIDIA 显卡 (8 GB+ 显存)** | [OmniVoice](docs/engines/omnivoice.md) · [CosyVoice 3](docs/engines/cosyvoice.md) | [WhisperX](docs/engines/whisperx.md) | 极致零样本克隆品质、字级时间戳对齐与说话人分离 |
+| **低显存 / 仅 CPU 设备** | [PocketTTS](docs/engines/pockettts.md) · [Sherpa-ONNX](docs/engines/sherpa-onnx.md) · [KittenTTS](docs/engines/kittentts.md) | [Moonshine](docs/engines/moonshine.md) · [Faster-Whisper](docs/engines/faster-whisper.md) (`int8`) | 超低内存占用，针对 CPU 指令集深度优化 |
+
 <a id="tts-engines"></a>
 
 ### 🗣️ TTS 引擎
@@ -351,6 +378,23 @@ npx skills add debpalash/omnivoice-studio
 ```
 
 内含两个 [skills](https://skills.sh)：**`omnivoice`**——让任何智能体通过你的本地安装进行语音合成与转录（包括你克隆的声音），免费且离线；以及 **`oss-maintainer`**——本项目所遵循的维护者方法论，适合任何用智能体运营自己开源项目的人。
+
+### 🔌 模型上下文协议（MCP 服务器）
+
+VoiceStudio 在 `http://localhost:3900/mcp` 挂载了 MCP 服务，可供 Claude Desktop、Cursor 与自主智能体调用：
+
+```json
+{
+  "mcpServers": {
+    "voicestudio": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:3900/mcp"]
+    }
+  }
+}
+```
+
+支持 `generate_speech`、`clone_voice`、`transcribe` 等工具与流式文件输出模式，详见 [docs/mcp.md](docs/mcp.md)。
 
 ---
 
@@ -541,6 +585,13 @@ VoiceStudio **免费**且采用 **AGPL-3.0** 许可——没有付费版，没�
 <br/>
 VoiceStudio 完全本地运行——卸载就是删除应用及其写入的文件夹（模型缓存、Python 环境、你的声音/项目、配置）。运行 <code>scripts/uninstall.sh</code>（macOS/Linux）或 <code>scripts\uninstall.ps1</code>（Windows）——它会先以干跑方式列出每个文件夹及其大小，加 <code>--yes</code> 才会真正删除。完整的各平台路径列表和应用移除步骤见 <a href="docs/install/uninstall.md"><b>docs/install/uninstall.md</b></a>。
 </details>
+
+## 🛡️ 负责任使用与安全
+
+VoiceStudio 在个人硬件上提供零样本语音克隆与语音创作能力。我们提倡负责任的技术使用：
+- **明确授权：** 严禁在未经说话人本人知情并明确授权的情况下克隆其声音。
+- **AI 溯源：** VoiceStudio 默认集成 [AudioSeal](https://github.com/facebookresearch/audioseal) 不可见神经音频水印，在完全不影响听感音质的前提下精准标记合成语音。
+- **本地隐私：** 你的所有音频、声音档案、项目与转录文本始终严格保存在你的本地设备上。
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@
 
 ```bash
 # Docker 快速运行 (CPU / 本地环回模式)
-docker run -d -p 127.0.0.1:3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
+docker run -d -p 127.0.0.1:3900:3900 -v omnivoice-data:/app/omnivoice_data --name voicestudio palashdeb/omnivoice-studio:stable
 ```
 
 **三步克隆出你的第一个声音：**

--- a/README_CN.md
+++ b/README_CN.md
@@ -68,7 +68,7 @@
 
 ```bash
 # Docker 快速运行 (CPU / 本地环回模式)
-docker run -d -p 3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
+docker run -d -p 127.0.0.1:3900:3900 --name voicestudio palashdeb/omnivoice-studio:latest
 ```
 
 **三步克隆出你的第一个声音：**
@@ -387,8 +387,21 @@ VoiceStudio 在 `http://localhost:3900/mcp` 挂载了 MCP 服务，可供 Claude
 {
   "mcpServers": {
     "voicestudio": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "http://localhost:3900/mcp"]
+      "url": "http://localhost:3900/mcp"
+    }
+  }
+}
+```
+
+对于需要 stdio 管道传输的客户端，请使用内置的本地桥接脚本（`docs/mcp.json`）：
+
+```json
+{
+  "mcpServers": {
+    "voicestudio": {
+      "command": "python",
+      "args": ["-m", "backend.mcp_shim"],
+      "cwd": "/path/to/VoiceStudio"
     }
   }
 }
@@ -591,7 +604,7 @@ VoiceStudio 完全本地运行——卸载就是删除应用及其写入的文�
 VoiceStudio 在个人硬件上提供零样本语音克隆与语音创作能力。我们提倡负责任的技术使用：
 - **明确授权：** 严禁在未经说话人本人知情并明确授权的情况下克隆其声音。
 - **AI 溯源：** VoiceStudio 默认集成 [AudioSeal](https://github.com/facebookresearch/audioseal) 不可见神经音频水印，在完全不影响听感音质的前提下精准标记合成语音。
-- **本地隐私：** 你的所有音频、声音档案、项目与转录文本始终严格保存在你的本地设备上。
+- **本地隐私：** 默认本地工作流下，所有音频、声音档案、项目与转录文本始终保存在你的本地设备上；仅当你主动配置远程工作节点或第三方 ASR 端点时，相应数据才会传输到对应服务。
 
 ---
 


### PR DESCRIPTION
## Summary
- Added interactive Audio Samples showcase linking bundled audio samples in `backend/assets/samples/`.
- Added "Recommended stack by hardware" decision table (Apple Silicon, NVIDIA GPU, CPU-only/Low VRAM).
- Added direct doc links across the Features table and all 16 TTS / 11 ASR engines in the tables.
- Added 1-line Docker quick-start, `curl` test command, and Claude Desktop/Cursor MCP server configuration.
- Added Responsible Use & Provenance note detailing speaker consent, AudioSeal watermarking, and local data isolation.
- Added CI status badge and Star History chart.
- Synchronized parity with `README_CN.md`.

## Verification
- `python3 scripts/check-docs-drift.py` (OK - 50 inventory entries verified)
- `python3 scripts/validate-install-docs.py` (OK - 3 blocks validated)
- `uv run pytest tests/test_locale_parity.py tests/test_no_hardcoded_cjk.py tests/test_app_version.py` (255 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the English and Chinese READMEs with audio samples, hardware recommendations, documentation links, Docker and MCP setup, and responsible-use guidance. The changes improve setup clarity and keep both README files aligned without changing code behavior. Reviewers should verify external links and Docker/MCP configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->