### PR TITLE
feat(design): simplify the Voice Design panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Changed
 
-- Voice Design simplified: the 12-row fine-grained block collapses to one summary line with a five-field editor, English accent and Chinese dialect merge into a single field, and the starting-point chips now show 5 with an overflow toggle
+- Voice Design simplified: the 12-row fine-grained block collapses to one summary line with a five-field editor, English accent and Chinese dialect merge into a single field, and the starting-point chips now show 5 with an overflow toggle (#1793)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Changed
 
+- Voice Design simplified: the 12-row fine-grained block collapses to one summary line with a five-field editor, English accent and Chinese dialect merge into a single field, and the starting-point chips now show 5 with an overflow toggle
+
 ### Added
 
 - The audiobook result is now a synced-lyrics player: chapter text follows playback with the current word highlighted and click-to-seek, timed from the render's own chapter durations with a karaoke-style even split — no ASR pass, fully local (#1766) — thanks @mvanhorn!

--- a/frontend/src/components/clone/ActionBar.jsx
+++ b/frontend/src/components/clone/ActionBar.jsx
@@ -198,11 +198,19 @@ export default function ActionBar({
             onChange={setLanguage}
           />
         </div>
+        {/* Inference/sampling steps (#1771 follow-up): this slider used to
+            carry only a hover title, so its value ("16") read as an
+            unlabelled control sitting between the language picker and
+            Production Overrides — give it the same visible label treatment
+            as everything else in the bar. */}
         <label
           className="flex items-center gap-[6px] flex-[1_1_160px] min-w-[120px] [&_input]:flex-1 [&_input]:min-w-[60px]"
           title={t('clone.steps')}
         >
           <SlidersHorizontal size={12} className="label-icon" />
+          <span className="text-[0.7rem] text-[var(--chrome-fg-muted)] whitespace-nowrap">
+            {t('clone.steps')}
+          </span>
           <input
             type="range"
             min="8"

--- a/frontend/src/components/clone/DesignMethodPanel.jsx
+++ b/frontend/src/components/clone/DesignMethodPanel.jsx
@@ -307,7 +307,11 @@ export default function DesignMethodPanel({
                     one as a reusable profile (0005): the backend renders a
                     deterministic identity sample (seed 42) and stores the
                     slider picks for later re-editing. */}
-          <div className="mt-[10px] pt-[10px] border-t border-[var(--chrome-border)] flex items-center justify-between gap-[var(--space-3)] flex-wrap">
+          {/* Separated by space alone, never a rule: the app-wide border
+                    removal (tests/test_no_literal_borders.py) took every
+                    decorative divider out, so a token hairline here would
+                    reintroduce exactly the class that guard protects. */}
+          <div className="mt-[var(--space-4)] flex items-center justify-between gap-[var(--space-3)] flex-wrap">
             <Button variant="ghost" size="sm" onClick={resetToDescription}>
               {t('clone.reset_to_description', { defaultValue: 'Reset to description' })}
             </Button>

--- a/frontend/src/components/clone/DesignMethodPanel.jsx
+++ b/frontend/src/components/clone/DesignMethodPanel.jsx
@@ -201,7 +201,7 @@ export default function DesignMethodPanel({
                 data-chip-nav="true"
                 className={`${PCHIP_BASE} ${checked ? PCHIP_ACTIVE : PCHIP_INACTIVE}`}
                 onClick={() => selectChip(chip.uid)}
-                onKeyDown={(e) => onChipKeyDown(e, visibleUids, activeUid, selectChip)}
+                onKeyDown={(e) => onChipKeyDown(e, visibleUids, i)}
               >
                 <span className="inline-flex items-center">
                   <Icon size={13} />

--- a/frontend/src/components/clone/DesignMethodPanel.jsx
+++ b/frontend/src/components/clone/DesignMethodPanel.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { ChevronUp, ChevronDown, Save } from 'lucide-react';
 import { Button, Input } from '../../ui';
 import { PRESETS, CATEGORIES } from '../../utils/constants';
@@ -27,8 +28,26 @@ const PCHIP_ACTIVE =
 const CHIP_BASE = `font-[var(--font-sans)] font-medium text-[0.68rem] px-[10px] py-[3px] rounded-[var(--chrome-radius-pill)] border bg-transparent whitespace-nowrap cursor-pointer transition-colors duration-[120ms] ${CHIP_FOCUS}`;
 const CHIP_INACTIVE =
   'border-transparent text-[var(--chrome-fg-muted)] hover:text-[var(--chrome-fg)] hover:bg-[var(--chrome-hover-bg)] hover:border-transparent';
-const CHIP_ACTIVE =
-  'bg-[var(--chrome-accent-bg)] border-[var(--chrome-accent-border)] text-[var(--chrome-accent)]';
+
+// Voice-design redesign (#1771 follow-up): Gender/Age/Pitch/Style are each a
+// single-value pick, so a <select> is the honest control (was a 12-row
+// always-open chip block that printed every value three times over). Laid
+// out as a 2x2 grid; kept as one array so the grid and its labels stay in
+// sync if a category is ever added/removed.
+const SELECT_CATEGORIES = ['Gender', 'Age', 'Pitch', 'Style'];
+// English accent and Chinese dialect are two independent CATEGORIES entries
+// (the engine's exclusivity rule lives in voiceInstruct.js's EXCLUSIVE_GROUPS)
+// but only one can ever apply, so the picker merges them into ONE <select>
+// with two <optgroup>s. onAccentDialectChange below decides which CATEGORIES
+// key a picked value belongs to and routes the change through the shared
+// onVdChange -> applyVdState path — it never reimplements the exclusivity
+// rule itself.
+const ACCENT_OPTIONS = CATEGORIES.EnglishAccent.filter((opt) => opt !== 'Auto');
+const DIALECT_OPTIONS = CATEGORIES.ChineseDialect.filter((opt) => opt !== 'Auto');
+// "Starting points" personality chips (#1771 follow-up item 5): only the
+// first N show by default — the rest reveal in place via a dynamic
+// "{{count}} more…" chip, so the row never hardcodes names or a count.
+const VISIBLE_PERSONALITY_COUNT = 5;
 
 export default function DesignMethodPanel({
   t,
@@ -46,6 +65,7 @@ export default function DesignMethodPanel({
   vdStates,
   onVdChange,
   onChipKeyDown,
+  resetToDescription,
   showSaveProfile,
   setShowSaveProfile,
   profileName,
@@ -54,6 +74,45 @@ export default function DesignMethodPanel({
   instruct,
   language,
 }) {
+  const [chipsExpanded, setChipsExpanded] = useState(false);
+
+  // #983: a profile/localStorage-restored vdStates can carry a partial shape
+  // (missing category keys), and a saved profile's ChineseDialect value can
+  // be any of the ~600 CosyVoice speaker-id style entries, not just the
+  // curated CATEGORIES list — guard before .replace() rather than crash;
+  // 'Auto' matches how the rest of the component treats an unset category.
+  const optLabel = (val) => {
+    if (typeof val !== 'string' || !val) return t('clone.opt_Auto');
+    const tKey = `clone.opt_${val.replace(/[ -]/g, '_')}`;
+    const tl = t(tKey);
+    return tl !== tKey ? tl : val;
+  };
+
+  const accentValue = vdStates.EnglishAccent;
+  const dialectValue = vdStates.ChineseDialect;
+  const accentDialectValue =
+    accentValue && accentValue !== 'Auto'
+      ? accentValue
+      : dialectValue && dialectValue !== 'Auto'
+        ? dialectValue
+        : 'Auto';
+
+  const onAccentDialectChange = (value) => {
+    if (value === 'Auto') {
+      // Clear whichever side is currently set — there is at most one.
+      if (accentValue && accentValue !== 'Auto') onVdChange('EnglishAccent', 'Auto');
+      else if (dialectValue && dialectValue !== 'Auto') onVdChange('ChineseDialect', 'Auto');
+      return;
+    }
+    onVdChange(ACCENT_OPTIONS.includes(value) ? 'EnglishAccent' : 'ChineseDialect', value);
+  };
+
+  const visiblePersonalities = chipsExpanded
+    ? chipPersonalities
+    : chipPersonalities.slice(0, VISIBLE_PERSONALITY_COUNT);
+  const overflowCount = chipPersonalities.length - visiblePersonalities.length;
+  const visibleIds = visiblePersonalities.map((p) => p.id);
+
   return (
     <div>
       {/* ── Describe your voice (#317) — free text drives the controls.
@@ -82,22 +141,43 @@ export default function DesignMethodPanel({
       </div>
 
       {/* ONE preset system (10x §1.3): personalities + the old PROMPT
-                presets share a single scrollable "Starting points" lane —
-                both set vdStates + instruct; two widgets for one slot was
-                the confusion. */}
+                presets share a single "Starting points" lane — both set
+                vdStates + instruct. Personality chips beyond the first 5
+                (#1771 follow-up) reveal in place via a dynamic "N more…"
+                chip so the row never hardcodes names or a count. */}
       <div className="mt-[8px] mr-0 mb-[12px] ml-0">
         <div className="font-[var(--chrome-font-mono)] text-[0.62rem] uppercase tracking-[0.06em] text-[var(--chrome-fg-muted)] mb-[6px]">
           {t('clone.starting_points', { defaultValue: 'Starting points' })}
         </div>
-        <div className="flex flex-nowrap gap-[6px] mb-[10px] overflow-x-auto pb-[2px] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [-webkit-mask-image:linear-gradient(90deg,transparent,#000_12px,#000_calc(100%-18px),transparent)] [mask-image:linear-gradient(90deg,transparent,#000_12px,#000_calc(100%-18px),transparent)]">
-          {chipPersonalities.map((p) => {
+        <div
+          className="flex flex-wrap gap-[6px] mb-[10px]"
+          role="group"
+          aria-label={t('clone.starting_points', { defaultValue: 'Starting points' })}
+        >
+          {visiblePersonalities.map((p, i) => {
             const Icon = PERSONALITY_ICONS[p.id] || FALLBACK_PERSONALITY_ICON;
+            const checked = activePersonality === p.id;
+            // Roving tabindex (WAI-ARIA toolbar pattern): the active chip is
+            // the group's single tab stop (first chip if nothing matches).
+            // This is a toggle strip, not a true radio group — clicking the
+            // active chip again clears it (applyPersonality) — so it uses
+            // aria-pressed rather than role="radio"/aria-checked.
+            const roving = checked || (!visibleIds.includes(activePersonality) && i === 0);
             return (
               <button
                 key={p.id}
                 type="button"
-                className={`${PCHIP_BASE} ${activePersonality === p.id ? PCHIP_ACTIVE : PCHIP_INACTIVE}`}
+                aria-pressed={checked}
+                tabIndex={roving ? 0 : -1}
+                data-chip-nav="true"
+                className={`${PCHIP_BASE} ${checked ? PCHIP_ACTIVE : PCHIP_INACTIVE}`}
                 onClick={() => applyPersonality(p)}
+                onKeyDown={(e) =>
+                  onChipKeyDown(e, visibleIds, activePersonality, (id) => {
+                    const next = chipPersonalities.find((x) => x.id === id);
+                    if (next) applyPersonality(next);
+                  })
+                }
               >
                 <span className="inline-flex items-center">
                   <Icon size={13} />
@@ -106,6 +186,18 @@ export default function DesignMethodPanel({
               </button>
             );
           })}
+          {overflowCount > 0 && (
+            <button
+              type="button"
+              className={`${CHIP_BASE} ${CHIP_INACTIVE}`}
+              onClick={() => setChipsExpanded(true)}
+            >
+              {t('clone.chips_more', {
+                count: overflowCount,
+                defaultValue: `${overflowCount} more…`,
+              })}
+            </button>
+          )}
           {PRESETS.map((p) => {
             const Icon = PRESET_ICONS[p.id] || FALLBACK_VOICE_ICON;
             return (
@@ -124,150 +216,131 @@ export default function DesignMethodPanel({
           })}
         </div>
       </div>
-      {/* Identity recipe (10x §1.5): once any category is set, the
-                chip groups collapse to one quiet line — the current voice
-                recipe — and the describe box rewrites it live. All-Auto
-                (first run) starts expanded. */}
+      {/* Details summary (10x §1.5, #1771 follow-up): the whole fine-grained
+                block collapses to ONE recipe line — the only place any picked
+                value is printed. Expanding it REPLACES this line's content
+                area with the five fields; the recipe is never shown twice.
+                All-Auto (first run) starts expanded. */}
       <button
         type="button"
         className="flex items-center gap-[8px] w-full mt-[4px] mb-[8px] px-[10px] py-[6px] bg-[var(--chrome-hover-bg)] border border-transparent rounded-[8px] cursor-pointer text-left transition-[border-color] duration-[var(--dur-fast)] hover:border-transparent focus-visible:[outline:2px_solid_var(--chrome-accent)] focus-visible:[outline-offset:1px]"
         onClick={() => setIdentityOpen((o) => !o)}
         aria-expanded={identityOpen}
+        aria-controls="design-details-fields"
       >
         <span className="font-[var(--chrome-font-mono)] text-[0.62rem] uppercase tracking-[0.06em] text-[var(--chrome-fg-muted)] flex-none">
-          {t('clone.identity', { defaultValue: 'Identity' })}
+          {t('clone.details', { defaultValue: 'Details' })}
         </span>
         <span className="flex-1 min-w-0 text-[0.74rem] text-[var(--chrome-fg)] truncate">
           {identityRecipe}
         </span>
-        {identityOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        <span className="flex items-center gap-[3px] text-[0.62rem] text-[var(--chrome-fg-muted)] flex-none">
+          {t('clone.edit', { defaultValue: 'Edit' })}
+          {identityOpen ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        </span>
       </button>
       {identityOpen && (
-        <div className="grid grid-cols-[1fr_1fr] gap-x-[12px] gap-y-[8px]">
-          {Object.entries(CATEGORIES).map(([key, options]) => {
-            const many = options.length > 6;
-            const optLabel = (val) => {
-              // #983: a profile/localStorage-restored vdStates can carry a
-              // partial shape (missing category keys) — val is then undefined
-              // here even though the 'Auto' check above only catches the
-              // literal sentinel. Guard before .replace() rather than crash;
-              // 'Auto' matches how the rest of the component (the ternary
-              // above, the chip/select fallbacks) treats an unset category.
-              if (typeof val !== 'string' || !val) return 'Auto';
-              const tKey = `clone.opt_${val.replace(/[ -]/g, '_')}`;
-              const tl = t(tKey);
-              return tl !== tKey ? tl : val;
-            };
-            return (
-              <div key={key} className={many ? 'min-w-0 max-[1100px]:col-[1/-1]' : 'col-[1/-1]'}>
-                <div className="label-row text-[0.7rem]">
+        <div id="design-details-fields">
+          <div className="grid grid-cols-2 gap-x-[12px] gap-y-[8px]">
+            {SELECT_CATEGORIES.map((key) => (
+              <div key={key} className="min-w-0">
+                <label htmlFor={`vd-${key}`} className="label-row text-[0.7rem]">
                   {t(`clone.cat_${key}`)}
-                  <span className="ml-[6px] text-[0.58rem] text-[var(--chrome-fg-muted)] font-medium">
-                    {vdStates[key] === 'Auto'
-                      ? t('clone.auto_kicker')
-                      : `· ${optLabel(vdStates[key])}`}
-                  </span>
-                </div>
-                {many ? (
-                  <select
-                    className="input-base"
-                    value={vdStates[key]}
-                    onChange={(e) => onVdChange(key, e.target.value)}
-                  >
-                    {options.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
-                  </select>
-                ) : (
-                  <div
-                    className="chip-group flex flex-wrap gap-1"
-                    role="radiogroup"
-                    aria-label={t(`clone.cat_${key}`)}
-                  >
-                    {options.map((opt, i) => {
-                      // `opt` is always a hardcoded CATEGORIES string today,
-                      // never undefined — guarded anyway for consistency with
-                      // the identical pattern above (#983).
-                      const safeOpt = typeof opt === 'string' && opt ? opt : 'Auto';
-                      const optTKey = `clone.opt_${safeOpt.replace(/[ -]/g, '_')}`;
-                      const optTl = t(optTKey);
-                      const optLabel = optTl !== optTKey ? optTl : safeOpt;
-                      const checked = vdStates[key] === opt;
-                      // Roving tabindex: the checked chip is the group's
-                      // single tab stop (first chip if nothing matches).
-                      const roving = checked || (!options.includes(vdStates[key]) && i === 0);
-                      return (
-                        <button
-                          key={opt}
-                          type="button"
-                          role="radio"
-                          aria-checked={checked}
-                          tabIndex={roving ? 0 : -1}
-                          className={`${CHIP_BASE} ${checked ? CHIP_ACTIVE : CHIP_INACTIVE}`}
-                          onClick={() => onVdChange(key, opt)}
-                          onKeyDown={(e) => onChipKeyDown(e, key, options)}
-                        >
-                          {opt === 'Auto' ? (
-                            <span className="chip-auto">
-                              <FALLBACK_VOICE_ICON size={11} />{' '}
-                              {stripVoiceEmoji(t('clone.opt_Auto'))}
-                            </span>
-                          ) : (
-                            optLabel
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
+                </label>
+                <select
+                  id={`vd-${key}`}
+                  className="input-base"
+                  value={vdStates[key] || 'Auto'}
+                  onChange={(e) => onVdChange(key, e.target.value)}
+                >
+                  {CATEGORIES[key].map((opt) => (
+                    <option key={opt} value={opt}>
+                      {optLabel(opt)}
+                    </option>
+                  ))}
+                </select>
               </div>
-            );
-          })}
+            ))}
+            <div className="col-[1/-1] min-w-0">
+              <label htmlFor="vd-AccentDialect" className="label-row text-[0.7rem]">
+                {t('clone.cat_AccentDialect', { defaultValue: 'Accent or Dialect' })}
+                <span className="ml-[6px] text-[0.58rem] text-[var(--chrome-fg-muted)] font-medium">
+                  {t('clone.accent_dialect_hint', {
+                    defaultValue: 'one or the other, never both',
+                  })}
+                </span>
+              </label>
+              <select
+                id="vd-AccentDialect"
+                className="input-base"
+                value={accentDialectValue}
+                onChange={(e) => onAccentDialectChange(e.target.value)}
+              >
+                <option value="Auto">{optLabel('Auto')}</option>
+                <optgroup label={t('clone.cat_EnglishAccent')}>
+                  {ACCENT_OPTIONS.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {optLabel(opt)}
+                    </option>
+                  ))}
+                </optgroup>
+                <optgroup label={t('clone.cat_ChineseDialect')}>
+                  {DIALECT_OPTIONS.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {optLabel(opt)}
+                    </option>
+                  ))}
+                </optgroup>
+              </select>
+            </div>
+          </div>
+
+          {/* Reset to the description's implied recipe, or save the current
+                    one as a reusable profile (0005): the backend renders a
+                    deterministic identity sample (seed 42) and stores the
+                    slider picks for later re-editing. */}
+          <div className="mt-[10px] pt-[10px] border-t border-[var(--chrome-border)] flex items-center justify-between gap-[var(--space-3)] flex-wrap">
+            <Button variant="ghost" size="sm" onClick={resetToDescription}>
+              {t('clone.reset_to_description', { defaultValue: 'Reset to description' })}
+            </Button>
+            {!showSaveProfile ? (
+              <Button
+                variant="subtle"
+                size="sm"
+                onClick={() => setShowSaveProfile(true)}
+                leading={<Save size={12} />}
+              >
+                {t('clone.save_design_as_profile', { defaultValue: 'Save design as profile' })}
+              </Button>
+            ) : (
+              <div className="flex gap-[var(--space-3)] items-center [&>:first-child]:flex-1">
+                <Input
+                  size="sm"
+                  placeholder={t('clone.profile_name')}
+                  value={profileName}
+                  onChange={(e) => setProfileName(e.target.value)}
+                />
+                <Button
+                  variant="subtle"
+                  size="sm"
+                  onClick={() =>
+                    handleSaveDesignProfile(
+                      vdStates,
+                      buildDesignInstruct(vdStates, instruct).instruct,
+                      language,
+                    )
+                  }
+                >
+                  {t('clone.save')}
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setShowSaveProfile(false)}>
+                  {t('clone.cancel')}
+                </Button>
+              </div>
+            )}
+          </div>
         </div>
       )}
-
-      {/* Save the current design as a reusable profile (0005): the
-                backend renders a deterministic identity sample (seed 42)
-                and stores the slider picks for later re-editing. */}
-      <div className="mt-[var(--space-4)]">
-        {!showSaveProfile ? (
-          <Button
-            variant="subtle"
-            size="sm"
-            onClick={() => setShowSaveProfile(true)}
-            leading={<Save size={12} />}
-          >
-            {t('clone.save_design_as_profile', { defaultValue: 'Save design as profile' })}
-          </Button>
-        ) : (
-          <div className="flex gap-[var(--space-3)] items-center [&>:first-child]:flex-1">
-            <Input
-              size="sm"
-              placeholder={t('clone.profile_name')}
-              value={profileName}
-              onChange={(e) => setProfileName(e.target.value)}
-            />
-            <Button
-              variant="subtle"
-              size="sm"
-              onClick={() =>
-                handleSaveDesignProfile(
-                  vdStates,
-                  buildDesignInstruct(vdStates, instruct).instruct,
-                  language,
-                )
-              }
-            >
-              {t('clone.save')}
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => setShowSaveProfile(false)}>
-              {t('clone.cancel')}
-            </Button>
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/clone/DesignMethodPanel.jsx
+++ b/frontend/src/components/clone/DesignMethodPanel.jsx
@@ -44,10 +44,15 @@ const SELECT_CATEGORIES = ['Gender', 'Age', 'Pitch', 'Style'];
 // rule itself.
 const ACCENT_OPTIONS = CATEGORIES.EnglishAccent.filter((opt) => opt !== 'Auto');
 const DIALECT_OPTIONS = CATEGORIES.ChineseDialect.filter((opt) => opt !== 'Auto');
-// "Starting points" personality chips (#1771 follow-up item 5): only the
-// first N show by default — the rest reveal in place via a dynamic
-// "{{count}} more…" chip, so the row never hardcodes names or a count.
-const VISIBLE_PERSONALITY_COUNT = 5;
+// "Starting points" chips (#1771 follow-up item 5): only the first N of the
+// COMBINED lane show by default — the rest reveal in place via a dynamic
+// "{{count}} more…" chip, so the row never hardcodes names or a count. The
+// lane renders two sources (personalities from the backend + the hardcoded
+// PRESETS below) sharing one row, so both must be sliced together — slicing
+// only chipPersonalities left PRESETS permanently visible after the overflow
+// chip and made the "N more…" count wrong (only counted the hidden
+// personalities, not the hidden presets too).
+const VISIBLE_CHIP_COUNT = 5;
 
 export default function DesignMethodPanel({
   t,
@@ -107,11 +112,26 @@ export default function DesignMethodPanel({
     onVdChange(ACCENT_OPTIONS.includes(value) ? 'EnglishAccent' : 'ChineseDialect', value);
   };
 
-  const visiblePersonalities = chipsExpanded
-    ? chipPersonalities
-    : chipPersonalities.slice(0, VISIBLE_PERSONALITY_COUNT);
-  const overflowCount = chipPersonalities.length - visiblePersonalities.length;
-  const visibleIds = visiblePersonalities.map((p) => p.id);
+  // ONE preset system (10x §1.3): personalities + the old PROMPT presets
+  // share a single "Starting points" lane, so the 5-visible slice and its
+  // overflow count are computed over the COMBINED list, not chipPersonalities
+  // alone. `uid` is namespaced (personality ids and PRESETS ids can collide —
+  // e.g. both have a 'narrator') so it's safe as both the React key and the
+  // roving-tabindex nav id.
+  const allChips = [
+    ...chipPersonalities.map((p) => ({ ...p, kind: 'personality', uid: `personality:${p.id}` })),
+    ...PRESETS.map((p) => ({ ...p, kind: 'preset', uid: `preset:${p.id}` })),
+  ];
+  const visibleChips = chipsExpanded ? allChips : allChips.slice(0, VISIBLE_CHIP_COUNT);
+  const overflowCount = allChips.length - visibleChips.length;
+  const visibleUids = visibleChips.map((c) => c.uid);
+  const activeUid = activePersonality ? `personality:${activePersonality}` : null;
+  const selectChip = (uid) => {
+    const chip = allChips.find((c) => c.uid === uid);
+    if (!chip) return;
+    if (chip.kind === 'personality') applyPersonality(chip);
+    else applyPreset(chip);
+  };
 
   return (
     <div>
@@ -142,9 +162,9 @@ export default function DesignMethodPanel({
 
       {/* ONE preset system (10x §1.3): personalities + the old PROMPT
                 presets share a single "Starting points" lane — both set
-                vdStates + instruct. Personality chips beyond the first 5
-                (#1771 follow-up) reveal in place via a dynamic "N more…"
-                chip so the row never hardcodes names or a count. */}
+                vdStates + instruct. Chips beyond the first 5 of that COMBINED
+                lane (#1771 follow-up) reveal in place via a dynamic "N
+                more…" chip so the row never hardcodes names or a count. */}
       <div className="mt-[8px] mr-0 mb-[12px] ml-0">
         <div className="font-[var(--chrome-font-mono)] text-[0.62rem] uppercase tracking-[0.06em] text-[var(--chrome-fg-muted)] mb-[6px]">
           {t('clone.starting_points', { defaultValue: 'Starting points' })}
@@ -154,35 +174,39 @@ export default function DesignMethodPanel({
           role="group"
           aria-label={t('clone.starting_points', { defaultValue: 'Starting points' })}
         >
-          {visiblePersonalities.map((p, i) => {
-            const Icon = PERSONALITY_ICONS[p.id] || FALLBACK_PERSONALITY_ICON;
-            const checked = activePersonality === p.id;
-            // Roving tabindex (WAI-ARIA toolbar pattern): the active chip is
-            // the group's single tab stop (first chip if nothing matches).
-            // This is a toggle strip, not a true radio group — clicking the
-            // active chip again clears it (applyPersonality) — so it uses
-            // aria-pressed rather than role="radio"/aria-checked.
-            const roving = checked || (!visibleIds.includes(activePersonality) && i === 0);
+          {visibleChips.map((chip, i) => {
+            const isPersonality = chip.kind === 'personality';
+            const Icon = isPersonality
+              ? PERSONALITY_ICONS[chip.id] || FALLBACK_PERSONALITY_ICON
+              : PRESET_ICONS[chip.id] || FALLBACK_VOICE_ICON;
+            // Only personalities track an "active" pick — PRESETS never did
+            // (applying one rewrites vdStates directly with no selection
+            // memory). Roving tabindex (WAI-ARIA toolbar pattern): the active
+            // chip is the group's single tab stop (first chip if nothing
+            // matches). This is a toggle strip, not a true radio group —
+            // clicking the active personality chip again clears it
+            // (applyPersonality) — so it uses aria-pressed rather than
+            // role="radio"/aria-checked.
+            const checked = isPersonality && activePersonality === chip.id;
+            const roving = checked || (!visibleUids.includes(activeUid) && i === 0);
+            const label = isPersonality
+              ? t(`clone.personality_${chip.id}`, { defaultValue: chip.name })
+              : t(`clone.preset_${chip.id}`, { defaultValue: chip.name });
             return (
               <button
-                key={p.id}
+                key={chip.uid}
                 type="button"
                 aria-pressed={checked}
                 tabIndex={roving ? 0 : -1}
                 data-chip-nav="true"
                 className={`${PCHIP_BASE} ${checked ? PCHIP_ACTIVE : PCHIP_INACTIVE}`}
-                onClick={() => applyPersonality(p)}
-                onKeyDown={(e) =>
-                  onChipKeyDown(e, visibleIds, activePersonality, (id) => {
-                    const next = chipPersonalities.find((x) => x.id === id);
-                    if (next) applyPersonality(next);
-                  })
-                }
+                onClick={() => selectChip(chip.uid)}
+                onKeyDown={(e) => onChipKeyDown(e, visibleUids, activeUid, selectChip)}
               >
                 <span className="inline-flex items-center">
                   <Icon size={13} />
                 </span>
-                {stripVoiceEmoji(t(`clone.personality_${p.id}`, { defaultValue: p.name }))}
+                {stripVoiceEmoji(label)}
               </button>
             );
           })}
@@ -198,22 +222,6 @@ export default function DesignMethodPanel({
               })}
             </button>
           )}
-          {PRESETS.map((p) => {
-            const Icon = PRESET_ICONS[p.id] || FALLBACK_VOICE_ICON;
-            return (
-              <button
-                key={p.id}
-                type="button"
-                className={`${PCHIP_BASE} ${PCHIP_INACTIVE}`}
-                onClick={() => applyPreset(p)}
-              >
-                <span className="inline-flex items-center">
-                  <Icon size={13} />
-                </span>
-                {stripVoiceEmoji(t(`clone.preset_${p.id}`, { defaultValue: p.name }))}
-              </button>
-            );
-          })}
         </div>
       </div>
       {/* Details summary (10x §1.5, #1771 follow-up): the whole fine-grained

--- a/frontend/src/components/clone/DesignMethodPanel.test.jsx
+++ b/frontend/src/components/clone/DesignMethodPanel.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import DesignMethodPanel from './DesignMethodPanel';
+import { PRESETS } from '../../utils/constants';
 
 // #983: "Cannot read properties of undefined (reading 'replace')" — the
 // identity panel crashed whenever vdStates was missing one of the 6
@@ -154,34 +155,50 @@ describe('DesignMethodPanel — merged accent/dialect field', () => {
   });
 });
 
-// #1771 follow-up item 5: only the first 5 personality chips show by
-// default; the rest reveal in place via a dynamic "{{count}} more…" chip.
-describe('DesignMethodPanel — starting-points chip overflow', () => {
+// #1771 follow-up item 5: only the first 5 chips of the COMBINED lane show
+// by default — the lane renders personalities (chipPersonalities, dynamic)
+// AND the hardcoded PRESETS together (the "ONE preset system" comment in
+// DesignMethodPanel.jsx), so both sources must be sliced as one list and the
+// overflow count must cover whatever's hidden from EITHER source. Slicing
+// only chipPersonalities left PRESETS always fully visible after the
+// overflow toggle and undercounted "N more…" by PRESETS.length.
+describe('DesignMethodPanel — starting-points chip overflow (combined personalities + PRESETS)', () => {
   const chipPersonalities = Array.from({ length: 7 }, (_, i) => ({
     id: `p${i}`,
     name: `Personality ${i}`,
   }));
+  const totalChips = chipPersonalities.length + PRESETS.length;
+  const overflow = totalChips - 5;
 
-  it('shows only the first 5 chips plus a "more" chip', () => {
+  it('shows only the first 5 combined chips, with PRESETS not yet visible', () => {
     setup({}, { chipPersonalities });
     for (let i = 0; i < 5; i++) {
       expect(screen.getByText(`Personality ${i}`)).toBeInTheDocument();
     }
     expect(screen.queryByText('Personality 5')).toBeNull();
-    expect(screen.getByText('2 more…')).toBeInTheDocument();
+    expect(screen.queryByText('Personality 6')).toBeNull();
+    expect(screen.queryByText(/Authoritative/)).toBeNull(); // first PRESETS chip
   });
 
-  it('reveals the rest in place when the overflow chip is clicked', () => {
+  it('counts the overflow across BOTH sources, not just the hidden personalities', () => {
     setup({}, { chipPersonalities });
-    fireEvent.click(screen.getByText('2 more…'));
+    // 7 personalities + 6 PRESETS = 13 total, 5 visible -> 8 hidden.
+    expect(screen.getByText(`${overflow} more…`)).toBeInTheDocument();
+  });
+
+  it('reveals every remaining chip from both sources when the overflow chip is clicked', () => {
+    setup({}, { chipPersonalities });
+    fireEvent.click(screen.getByText(`${overflow} more…`));
     for (let i = 0; i < 7; i++) {
       expect(screen.getByText(`Personality ${i}`)).toBeInTheDocument();
     }
-    expect(screen.queryByText('2 more…')).toBeNull();
+    expect(screen.getByText(/Authoritative/)).toBeInTheDocument();
+    expect(screen.queryByText(/more…/)).toBeNull();
   });
 
-  it('does not show a "more" chip when there are 5 or fewer personalities', () => {
-    setup({}, { chipPersonalities: chipPersonalities.slice(0, 5) });
-    expect(screen.queryByText(/more…/)).toBeNull();
+  it('counts PRESETS into the overflow even with zero personalities', () => {
+    setup({}, { chipPersonalities: [] });
+    // PRESETS alone (6) already exceed the 5-visible slice.
+    expect(screen.getByText(`${PRESETS.length - 5} more…`)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/clone/DesignMethodPanel.test.jsx
+++ b/frontend/src/components/clone/DesignMethodPanel.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DesignMethodPanel from './DesignMethodPanel';
 
 // #983: "Cannot read properties of undefined (reading 'replace')" — the
@@ -34,6 +34,7 @@ function setup(vdStates, props = {}) {
       vdStates={vdStates}
       onVdChange={vi.fn()}
       onChipKeyDown={vi.fn()}
+      resetToDescription={vi.fn()}
       showSaveProfile={false}
       setShowSaveProfile={vi.fn()}
       profileName=""
@@ -49,8 +50,7 @@ function setup(vdStates, props = {}) {
 describe('DesignMethodPanel — #983 partial vdStates crash', () => {
   it('does not throw when vdStates is missing 5 of the 6 CATEGORIES keys', () => {
     // Only Gender is set — Age, Pitch, Style, EnglishAccent, ChineseDialect
-    // are all undefined, exercising both the chip-based and <select>-based
-    // ("many" options) render paths.
+    // are all undefined, exercising the select-based render path.
     expect(() => setup({ Gender: 'male' })).not.toThrow();
   });
 
@@ -61,8 +61,127 @@ describe('DesignMethodPanel — #983 partial vdStates crash', () => {
   it('still renders category labels and the identity recipe with a partial shape', () => {
     const { container } = setup({ Gender: 'male' });
     expect(screen.getByText('test recipe')).toBeInTheDocument();
-    // The label text sits alongside a sibling <span> kicker, so assert via
-    // textContent rather than getByText's exact-node matching.
     expect(container.textContent).toContain('clone.cat_Gender');
+  });
+});
+
+// #1771 follow-up: the 12-row always-open chip block became one collapsed
+// "Details" summary line that expands to a 5-field editor.
+describe('DesignMethodPanel — Details collapse/expand', () => {
+  it('hides the field editor when collapsed and shows it when expanded', () => {
+    const { rerender } = setup({ Gender: 'Auto' }, { identityOpen: false });
+    expect(document.getElementById('design-details-fields')).toBeNull();
+
+    rerender(
+      <DesignMethodPanel
+        t={t}
+        describeText=""
+        onDescribeChange={vi.fn()}
+        describeMatchedAny={false}
+        describeUnmatched={[]}
+        chipPersonalities={[]}
+        activePersonality={null}
+        applyPersonality={vi.fn()}
+        applyPreset={vi.fn()}
+        identityOpen={true}
+        setIdentityOpen={vi.fn()}
+        identityRecipe="test recipe"
+        vdStates={{ Gender: 'Auto' }}
+        onVdChange={vi.fn()}
+        onChipKeyDown={vi.fn()}
+        resetToDescription={vi.fn()}
+        showSaveProfile={false}
+        setShowSaveProfile={vi.fn()}
+        profileName=""
+        setProfileName={vi.fn()}
+        handleSaveDesignProfile={vi.fn()}
+        instruct=""
+        language="Auto"
+      />,
+    );
+    expect(document.getElementById('design-details-fields')).not.toBeNull();
+  });
+
+  it('toggles identityOpen via the summary button', () => {
+    const setIdentityOpen = vi.fn();
+    setup({ Gender: 'Auto' }, { identityOpen: false, setIdentityOpen });
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(setIdentityOpen).toHaveBeenCalledTimes(1);
+    // The handler is a functional updater — verify it flips the boolean.
+    expect(setIdentityOpen.mock.calls[0][0](false)).toBe(true);
+  });
+
+  it('never prints the recipe value a second time inside a category header', () => {
+    const { container } = setup({ Gender: 'male' }, { identityRecipe: 'male' });
+    // The old markup suffixed every header with "· VALUE" (e.g. "· male").
+    expect(container.textContent).not.toMatch(/·\s*male/i);
+  });
+});
+
+// #1771 follow-up item 3: English accent and Chinese dialect merge into one
+// <select>, but must still route through the shared onVdChange (-> the real
+// applyVdState exclusivity guard in CloneDesignTab) per CATEGORIES key.
+describe('DesignMethodPanel — merged accent/dialect field', () => {
+  it('routes an English accent pick through onVdChange for EnglishAccent', () => {
+    const onVdChange = vi.fn();
+    setup({ EnglishAccent: 'Auto', ChineseDialect: 'Auto' }, { identityOpen: true, onVdChange });
+    const select = document.getElementById('vd-AccentDialect');
+    fireEvent.change(select, { target: { value: 'british accent' } });
+    expect(onVdChange).toHaveBeenCalledWith('EnglishAccent', 'british accent');
+  });
+
+  it('routes a Chinese dialect pick through onVdChange for ChineseDialect', () => {
+    const onVdChange = vi.fn();
+    setup({ EnglishAccent: 'Auto', ChineseDialect: 'Auto' }, { identityOpen: true, onVdChange });
+    const select = document.getElementById('vd-AccentDialect');
+    fireEvent.change(select, { target: { value: '四川话' } });
+    expect(onVdChange).toHaveBeenCalledWith('ChineseDialect', '四川话');
+  });
+
+  it('picking "Auto" clears whichever side is currently set, not both blindly', () => {
+    const onVdChange = vi.fn();
+    setup({ EnglishAccent: 'Auto', ChineseDialect: '四川话' }, { identityOpen: true, onVdChange });
+    const select = document.getElementById('vd-AccentDialect');
+    fireEvent.change(select, { target: { value: 'Auto' } });
+    expect(onVdChange).toHaveBeenCalledWith('ChineseDialect', 'Auto');
+    expect(onVdChange).not.toHaveBeenCalledWith('EnglishAccent', expect.anything());
+  });
+
+  it('shows the currently-set dialect as the merged select value', () => {
+    setup({ EnglishAccent: 'Auto', ChineseDialect: '四川话' }, { identityOpen: true });
+    const select = document.getElementById('vd-AccentDialect');
+    expect(select.value).toBe('四川话');
+  });
+});
+
+// #1771 follow-up item 5: only the first 5 personality chips show by
+// default; the rest reveal in place via a dynamic "{{count}} more…" chip.
+describe('DesignMethodPanel — starting-points chip overflow', () => {
+  const chipPersonalities = Array.from({ length: 7 }, (_, i) => ({
+    id: `p${i}`,
+    name: `Personality ${i}`,
+  }));
+
+  it('shows only the first 5 chips plus a "more" chip', () => {
+    setup({}, { chipPersonalities });
+    for (let i = 0; i < 5; i++) {
+      expect(screen.getByText(`Personality ${i}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByText('Personality 5')).toBeNull();
+    expect(screen.getByText('2 more…')).toBeInTheDocument();
+  });
+
+  it('reveals the rest in place when the overflow chip is clicked', () => {
+    setup({}, { chipPersonalities });
+    fireEvent.click(screen.getByText('2 more…'));
+    for (let i = 0; i < 7; i++) {
+      expect(screen.getByText(`Personality ${i}`)).toBeInTheDocument();
+    }
+    expect(screen.queryByText('2 more…')).toBeNull();
+  });
+
+  it('does not show a "more" chip when there are 5 or fewer personalities', () => {
+    setup({}, { chipPersonalities: chipPersonalities.slice(0, 5) });
+    expect(screen.queryByText(/more…/)).toBeNull();
   });
 });

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -599,7 +599,7 @@
     "stop_playback": "إيقاف التشغيل",
     "describe_label": "صِف صوتك",
     "describe_placeholder": "مثال: a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "وصفك (بالإنجليزية) يضبط عناصر التحكم أدناه — ويمكنك تعديلها يدويًا لاحقًا.",
+    "describe_hint": "صِف الصوت، أو اختر نقطة بداية. أيٌّ منهما يملأ التفاصيل أدناه.",
     "describe_unmatched": "تعذّر التعيين: {{items}}",
     "describe_no_match": "لم يتم التعرف على سمات صوتية بعد — جرّب كلمات مثل deep أو elderly أو British.",
     "define_by_design": "بالتصميم",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -620,7 +620,13 @@
     "seed_keep": "احتفظ بهذه البذرة",
     "seed_reroll": "بذرة جديدة",
     "seed_reroll_hint": "قم بلف بذرة عشوائية جديدة واحتفظ بها",
-    "define_convert": "تحويل"
+    "define_convert": "تحويل",
+    "details": "التفاصيل",
+    "edit": "تعديل",
+    "cat_AccentDialect": "لكنة أو لهجة",
+    "accent_dialect_hint": "أحدهما فقط، لا كلاهما",
+    "reset_to_description": "إعادة الضبط حسب الوصف",
+    "chips_more": "{{count}} أخرى…"
   },
   "about": {
     "app": "التطبيق",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -620,7 +620,13 @@
     "seed_keep": "Behalte diesen Samen",
     "seed_reroll": "Neues Saatgut",
     "seed_reroll_hint": "Würfeln Sie einen neuen zufälligen Samen und behalten Sie ihn",
-    "define_convert": "Konvertieren"
+    "define_convert": "Konvertieren",
+    "details": "Details",
+    "edit": "Bearbeiten",
+    "cat_AccentDialect": "Akzent oder Dialekt",
+    "accent_dialect_hint": "eins von beiden, nie beides",
+    "reset_to_description": "Auf Beschreibung zurücksetzen",
+    "chips_more": "{{count}} weitere…"
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -599,7 +599,7 @@
     "stop_playback": "Wiedergabe stoppen",
     "describe_label": "Beschreibe deine Stimme",
     "describe_placeholder": "z. B. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Deine Beschreibung (auf Englisch) stellt die Regler unten ein — du kannst sie danach weiter anpassen.",
+    "describe_hint": "Beschreibe die Stimme oder wähle einen Ausgangspunkt. Beides füllt die Details unten aus.",
     "describe_unmatched": "Nicht zuordenbar: {{items}}",
     "describe_no_match": "Noch keine Stimmmerkmale erkannt — versuche Wörter wie deep, elderly oder British.",
     "define_by_design": "Per Design",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -393,7 +393,13 @@
     "script": "Script",
     "starting_points": "Starting points",
     "voice_kicker": "Voice",
-    "define_convert": "Convert"
+    "define_convert": "Convert",
+    "details": "Details",
+    "edit": "Edit",
+    "cat_AccentDialect": "Accent or Dialect",
+    "accent_dialect_hint": "one or the other, never both",
+    "reset_to_description": "Reset to description",
+    "chips_more": "{{count}} more…"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -349,7 +349,7 @@
     "design_placeholder": "Describe the voice, then type what it says…",
     "describe_label": "Describe your voice",
     "describe_placeholder": "e.g. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Your description sets the controls below — you can still fine-tune them afterwards.",
+    "describe_hint": "Describe the voice, or pick a starting point. Either one fills in the details below.",
     "describe_unmatched": "Couldn't map: {{items}}",
     "describe_no_match": "No voice traits recognized yet — try words like deep, elderly, or British.",
     "speed": "Speed",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -620,7 +620,13 @@
     "seed_keep": "Mantén esta semilla",
     "seed_reroll": "Nueva semilla",
     "seed_reroll_hint": "Enrolla una nueva semilla aleatoria y guárdala.",
-    "define_convert": "Convertir"
+    "define_convert": "Convertir",
+    "details": "Detalles",
+    "edit": "Editar",
+    "cat_AccentDialect": "Acento o dialecto",
+    "accent_dialect_hint": "uno u otro, nunca ambos",
+    "reset_to_description": "Restablecer según la descripción",
+    "chips_more": "{{count}} más…"
   },
   "about": {
     "app": "Aplicación",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -599,7 +599,7 @@
     "stop_playback": "Detener reproducción",
     "describe_label": "Describe tu voz",
     "describe_placeholder": "p. ej. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Tu descripción (en inglés) ajusta los controles de abajo; puedes afinarlos después.",
+    "describe_hint": "Describe la voz, o elige un punto de partida. Cualquiera de los dos completa los detalles de abajo.",
     "describe_unmatched": "No se pudo asignar: {{items}}",
     "describe_no_match": "Aún no se reconocen rasgos de voz; prueba palabras como deep, elderly o British.",
     "define_by_design": "Por diseño",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -620,7 +620,13 @@
     "seed_keep": "Gardez cette graine",
     "seed_reroll": "Nouvelle graine",
     "seed_reroll_hint": "Lancez une nouvelle graine aléatoire et conservez-la",
-    "define_convert": "Convertir"
+    "define_convert": "Convertir",
+    "details": "Détails",
+    "edit": "Modifier",
+    "cat_AccentDialect": "Accent ou dialecte",
+    "accent_dialect_hint": "l'un ou l'autre, jamais les deux",
+    "reset_to_description": "Réinitialiser selon la description",
+    "chips_more": "{{count}} de plus…"
   },
   "about": {
     "app": "Application",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -599,7 +599,7 @@
     "stop_playback": "Arrêter la lecture",
     "describe_label": "Décrivez votre voix",
     "describe_placeholder": "p. ex. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Votre description (en anglais) règle les contrôles ci-dessous — vous pouvez encore les ajuster après.",
+    "describe_hint": "Décrivez la voix, ou choisissez un point de départ. L'un ou l'autre renseigne les détails ci-dessous.",
     "describe_unmatched": "Impossible d'associer : {{items}}",
     "describe_no_match": "Aucun trait vocal reconnu pour l'instant — essayez des mots comme deep, elderly ou British.",
     "define_by_design": "Par conception",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -620,7 +620,13 @@
     "seed_keep": "इस बीज को अपने पास रखें",
     "seed_reroll": "नया बीज",
     "seed_reroll_hint": "एक नये यादृच्छिक बीज को रोल करके रख लें",
-    "define_convert": "कन्वर्ट"
+    "define_convert": "कन्वर्ट",
+    "details": "विवरण",
+    "edit": "संपादित करें",
+    "cat_AccentDialect": "एक्सेंट या बोली",
+    "accent_dialect_hint": "इनमें से एक ही, दोनों नहीं",
+    "reset_to_description": "विवरण के अनुसार रीसेट करें",
+    "chips_more": "{{count}} और…"
   },
   "about": {
     "app": "ऐप",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -599,7 +599,7 @@
     "stop_playback": "प्लेबैक रोकें",
     "describe_label": "अपनी आवाज़ का वर्णन करें",
     "describe_placeholder": "उदा. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "आपका विवरण (अंग्रेज़ी में) नीचे के नियंत्रण सेट करता है — आप बाद में इन्हें बदल सकते हैं।",
+    "describe_hint": "आवाज़ का वर्णन करें, या कोई शुरुआती बिंदु चुनें। दोनों में से कोई भी नीचे के विवरण भर देगा।",
     "describe_unmatched": "मैप नहीं हो सका: {{items}}",
     "describe_no_match": "अभी कोई आवाज़ विशेषता पहचानी नहीं गई — deep, elderly या British जैसे शब्द आज़माएँ।",
     "define_by_design": "डिज़ाइन से",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -620,7 +620,13 @@
     "seed_keep": "Simpan benih ini",
     "seed_reroll": "Benih baru",
     "seed_reroll_hint": "Gulung benih acak baru dan simpan",
-    "define_convert": "Konversi"
+    "define_convert": "Konversi",
+    "details": "Detail",
+    "edit": "Edit",
+    "cat_AccentDialect": "Aksen atau dialek",
+    "accent_dialect_hint": "salah satu saja, tidak keduanya",
+    "reset_to_description": "Setel ulang sesuai deskripsi",
+    "chips_more": "{{count}} lainnya…"
   },
   "about": {
     "app": "Aplikasi",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -599,7 +599,7 @@
     "stop_playback": "Hentikan pemutaran",
     "describe_label": "Deskripsikan suara Anda",
     "describe_placeholder": "mis. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Deskripsi Anda (dalam bahasa Inggris) mengatur kontrol di bawah — Anda tetap bisa menyetelnya setelahnya.",
+    "describe_hint": "Deskripsikan suaranya, atau pilih titik awal. Keduanya akan mengisi detail di bawah.",
     "describe_unmatched": "Tidak dapat dipetakan: {{items}}",
     "describe_no_match": "Belum ada ciri suara yang dikenali — coba kata seperti deep, elderly, atau British.",
     "define_by_design": "Lewat desain",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -620,7 +620,13 @@
     "seed_keep": "Conserva questo seme",
     "seed_reroll": "Nuovo seme",
     "seed_reroll_hint": "Lancia un nuovo seme casuale e conservalo",
-    "define_convert": "Converti"
+    "define_convert": "Converti",
+    "details": "Dettagli",
+    "edit": "Modifica",
+    "cat_AccentDialect": "Accento o dialetto",
+    "accent_dialect_hint": "uno o l'altro, mai entrambi",
+    "reset_to_description": "Reimposta in base alla descrizione",
+    "chips_more": "altri {{count}}…"
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -599,7 +599,7 @@
     "stop_playback": "Interrompi riproduzione",
     "describe_label": "Descrivi la tua voce",
     "describe_placeholder": "es. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "La tua descrizione (in inglese) imposta i controlli qui sotto — puoi comunque regolarli dopo.",
+    "describe_hint": "Descrivi la voce, oppure scegli un punto di partenza. In entrambi i casi i dettagli qui sotto si compilano automaticamente.",
     "describe_unmatched": "Impossibile mappare: {{items}}",
     "describe_no_match": "Nessun tratto vocale riconosciuto — prova parole come deep, elderly o British.",
     "define_by_design": "Tramite progettazione",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -620,7 +620,13 @@
     "seed_keep": "この種を保管しておいてください",
     "seed_reroll": "新しい種",
     "seed_reroll_hint": "新しいランダムシードをロールして保持します",
-    "define_convert": "変換"
+    "define_convert": "変換",
+    "details": "詳細",
+    "edit": "編集",
+    "cat_AccentDialect": "アクセントまたは方言",
+    "accent_dialect_hint": "どちらか一方のみ、両方は不可",
+    "reset_to_description": "説明に基づいてリセット",
+    "chips_more": "他{{count}}件…"
   },
   "about": {
     "app": "アプリ",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -599,7 +599,7 @@
     "stop_playback": "再生を停止",
     "describe_label": "声を言葉で説明",
     "describe_placeholder": "例: a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "説明（英語）が下のコントロールを設定します。後から微調整もできます。",
+    "describe_hint": "声を説明するか、起点を選んでください。どちらでも下の詳細が自動入力されます。",
     "describe_unmatched": "対応付けできません: {{items}}",
     "describe_no_match": "まだ声の特徴を認識できていません。deep、elderly、British などの単語を試してください。",
     "define_by_design": "デザインで",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -856,7 +856,13 @@
     "seed_keep": "이 시드를 유지하세요",
     "seed_reroll": "새 시드",
     "seed_reroll_hint": "새로운 무작위 시드를 굴려 유지하세요.",
-    "define_convert": "변환"
+    "define_convert": "변환",
+    "details": "세부 정보",
+    "edit": "편집",
+    "cat_AccentDialect": "억양 또는 방언",
+    "accent_dialect_hint": "둘 중 하나만, 동시에는 불가",
+    "reset_to_description": "설명에 따라 재설정",
+    "chips_more": "{{count}}개 더 보기…"
   },
   "about": {
     "app": "앱",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -835,7 +835,7 @@
     "stop_playback": "재생 중지",
     "describe_label": "목소리를 설명하세요",
     "describe_placeholder": "예: a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "설명(영어)이 아래 컨트롤을 설정합니다. 이후에 직접 조정할 수도 있습니다.",
+    "describe_hint": "목소리를 설명하거나 시작점을 선택하세요. 둘 중 무엇을 해도 아래 세부 정보가 채워집니다.",
     "describe_unmatched": "매핑할 수 없음: {{items}}",
     "describe_no_match": "아직 인식된 목소리 특징이 없습니다. deep, elderly, British 같은 단어를 사용해 보세요.",
     "define_by_design": "디자인으로",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -599,7 +599,7 @@
     "stop_playback": "Afspelen stoppen",
     "describe_label": "Beschrijf je stem",
     "describe_placeholder": "bijv. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Je beschrijving (in het Engels) stelt de regelaars hieronder in — je kunt ze daarna bijstellen.",
+    "describe_hint": "Beschrijf de stem, of kies een startpunt. Beide vullen de details hieronder in.",
     "describe_unmatched": "Kon niet toewijzen: {{items}}",
     "describe_no_match": "Nog geen stemkenmerken herkend — probeer woorden als deep, elderly of British.",
     "define_by_design": "Via ontwerp",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -620,7 +620,13 @@
     "script": "Script",
     "starting_points": "Startpunten",
     "voice_kicker": "Stem",
-    "define_convert": "Converteren"
+    "define_convert": "Converteren",
+    "details": "Details",
+    "edit": "Bewerken",
+    "cat_AccentDialect": "Accent of dialect",
+    "accent_dialect_hint": "het een of het ander, nooit beide",
+    "reset_to_description": "Terugzetten naar beschrijving",
+    "chips_more": "nog {{count}}…"
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -599,7 +599,7 @@
     "stop_playback": "Zatrzymaj odtwarzanie",
     "describe_label": "Opisz swój głos",
     "describe_placeholder": "np. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Twój opis (po angielsku) ustawia poniższe kontrolki — możesz je potem doprecyzować.",
+    "describe_hint": "Opisz głos albo wybierz punkt wyjścia. Każde z tych działań wypełni szczegóły poniżej.",
     "describe_unmatched": "Nie udało się dopasować: {{items}}",
     "describe_no_match": "Nie rozpoznano jeszcze cech głosu — spróbuj słów takich jak deep, elderly lub British.",
     "define_by_design": "Według projektu",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -620,7 +620,13 @@
     "script": "Skrypt",
     "starting_points": "Punkty wyjścia",
     "voice_kicker": "Głos",
-    "define_convert": "Konwertuj"
+    "define_convert": "Konwertuj",
+    "details": "Szczegóły",
+    "edit": "Edytuj",
+    "cat_AccentDialect": "Akcent lub dialekt",
+    "accent_dialect_hint": "jedno albo drugie, nigdy oba",
+    "reset_to_description": "Przywróć na podstawie opisu",
+    "chips_more": "jeszcze {{count}}…"
   },
   "about": {
     "app": "Aplikacja",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -599,7 +599,7 @@
     "stop_playback": "Parar reprodução",
     "describe_label": "Descreva a sua voz",
     "describe_placeholder": "ex.: a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "A sua descrição (em inglês) define os controlos abaixo — pode afiná-los depois.",
+    "describe_hint": "Descreva a voz, ou escolha um ponto de partida. Qualquer um dos dois preenche os detalhes abaixo.",
     "describe_unmatched": "Não foi possível mapear: {{items}}",
     "describe_no_match": "Ainda não foram reconhecidos traços de voz — experimente palavras como deep, elderly ou British.",
     "define_by_design": "Por design",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -620,7 +620,13 @@
     "seed_keep": "Guarde esta semente",
     "seed_reroll": "Nova semente",
     "seed_reroll_hint": "Role uma nova semente aleatória e guarde-a",
-    "define_convert": "Converter"
+    "define_convert": "Converter",
+    "details": "Detalhes",
+    "edit": "Editar",
+    "cat_AccentDialect": "Sotaque ou dialeto",
+    "accent_dialect_hint": "um ou outro, nunca os dois",
+    "reset_to_description": "Redefinir conforme a descrição",
+    "chips_more": "mais {{count}}…"
   },
   "about": {
     "app": "Aplicativo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -599,7 +599,7 @@
     "stop_playback": "Остановить воспроизведение",
     "describe_label": "Опишите свой голос",
     "describe_placeholder": "напр. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Ваше описание (на английском) задаёт настройки ниже — их можно подправить вручную.",
+    "describe_hint": "Опишите голос или выберите отправную точку — в любом случае детали ниже заполнятся автоматически.",
     "describe_unmatched": "Не удалось сопоставить: {{items}}",
     "describe_no_match": "Голосовые черты пока не распознаны — попробуйте слова deep, elderly или British.",
     "define_by_design": "По дизайну",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -620,7 +620,13 @@
     "script": "Скрипт",
     "starting_points": "Отправные точки",
     "voice_kicker": "Голос",
-    "define_convert": "Преобразовать"
+    "define_convert": "Преобразовать",
+    "details": "Детали",
+    "edit": "Изменить",
+    "cat_AccentDialect": "Акцент или диалект",
+    "accent_dialect_hint": "одно из двух, никогда оба сразу",
+    "reset_to_description": "Сбросить по описанию",
+    "chips_more": "ещё {{count}}…"
   },
   "about": {
     "app": "Приложение",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -620,7 +620,13 @@
     "script": "Manus",
     "starting_points": "Utgångspunkter",
     "voice_kicker": "Röst",
-    "define_convert": "Konvertera"
+    "define_convert": "Konvertera",
+    "details": "Detaljer",
+    "edit": "Redigera",
+    "cat_AccentDialect": "Accent eller dialekt",
+    "accent_dialect_hint": "det ena eller det andra, aldrig båda",
+    "reset_to_description": "Återställ till beskrivning",
+    "chips_more": "{{count}} till…"
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -599,7 +599,7 @@
     "stop_playback": "Stoppa uppspelning",
     "describe_label": "Beskriv din röst",
     "describe_placeholder": "t.ex. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Din beskrivning (på engelska) ställer in kontrollerna nedan — du kan finjustera dem efteråt.",
+    "describe_hint": "Beskriv rösten, eller välj en utgångspunkt. Endera fyller i detaljerna nedan.",
     "describe_unmatched": "Kunde inte mappa: {{items}}",
     "describe_no_match": "Inga röstdrag har känts igen ännu — prova ord som deep, elderly eller British.",
     "define_by_design": "Via design",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -599,7 +599,7 @@
     "stop_playback": "หยุดเล่น",
     "describe_label": "อธิบายเสียงของคุณ",
     "describe_placeholder": "เช่น a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "คำอธิบายของคุณ (ภาษาอังกฤษ) จะตั้งค่าตัวควบคุมด้านล่าง และคุณยังปรับเองได้ภายหลัง",
+    "describe_hint": "อธิบายเสียงพูด หรือเลือกจุดเริ่มต้น อย่างใดอย่างหนึ่งจะกรอกรายละเอียดด้านล่างให้อัตโนมัติ",
     "describe_unmatched": "จับคู่ไม่ได้: {{items}}",
     "describe_no_match": "ยังไม่พบลักษณะเสียง ลองใช้คำอย่าง deep, elderly หรือ British",
     "define_by_design": "โดยการออกแบบ",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -620,7 +620,13 @@
     "seed_keep": "เก็บเมล็ดพันธุ์นี้ไว้",
     "seed_reroll": "เมล็ดพันธุ์ใหม่",
     "seed_reroll_hint": "สุ่มเมล็ดใหม่แบบสุ่มแล้วเก็บไว้",
-    "define_convert": "แปลง"
+    "define_convert": "แปลง",
+    "details": "รายละเอียด",
+    "edit": "แก้ไข",
+    "cat_AccentDialect": "สำเนียงหรือภาษาถิ่น",
+    "accent_dialect_hint": "เลือกได้อย่างใดอย่างหนึ่ง ไม่ใช่ทั้งสองอย่าง",
+    "reset_to_description": "รีเซ็ตตามคำอธิบาย",
+    "chips_more": "อีก {{count}} รายการ…"
   },
   "about": {
     "app": "แอพ",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -599,7 +599,7 @@
     "stop_playback": "Oynatmayı durdur",
     "describe_label": "Sesinizi tarif edin",
     "describe_placeholder": "örn. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Açıklamanız (İngilizce) aşağıdaki denetimleri ayarlar — sonradan ince ayar yapabilirsiniz.",
+    "describe_hint": "Sesi tanımlayın veya bir başlangıç noktası seçin. Her ikisi de aşağıdaki ayrıntıları doldurur.",
     "describe_unmatched": "Eşlenemedi: {{items}}",
     "describe_no_match": "Henüz ses özelliği tanınmadı — deep, elderly veya British gibi kelimeler deneyin.",
     "define_by_design": "Tasarımla",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -620,7 +620,13 @@
     "seed_keep": "Bu tohumu sakla",
     "seed_reroll": "Yeni tohum",
     "seed_reroll_hint": "Yeni bir rastgele tohum yuvarlayın ve saklayın",
-    "define_convert": "Dönüştür"
+    "define_convert": "Dönüştür",
+    "details": "Ayrıntılar",
+    "edit": "Düzenle",
+    "cat_AccentDialect": "Aksan veya lehçe",
+    "accent_dialect_hint": "yalnızca biri, asla ikisi birden",
+    "reset_to_description": "Açıklamaya göre sıfırla",
+    "chips_more": "{{count}} tane daha…"
   },
   "about": {
     "app": "Uygulama",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -620,7 +620,13 @@
     "script": "Сценарій",
     "starting_points": "Відправні точки",
     "voice_kicker": "Голос",
-    "define_convert": "Перетворити"
+    "define_convert": "Перетворити",
+    "details": "Деталі",
+    "edit": "Редагувати",
+    "cat_AccentDialect": "Акцент або діалект",
+    "accent_dialect_hint": "одне з двох, ніколи обидва",
+    "reset_to_description": "Скинути за описом",
+    "chips_more": "ще {{count}}…"
   },
   "about": {
     "app": "додаток",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -599,7 +599,7 @@
     "stop_playback": "Зупинити відтворення",
     "describe_label": "Опишіть свій голос",
     "describe_placeholder": "напр. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Ваш опис (англійською) налаштовує елементи нижче — їх можна підлаштувати вручну.",
+    "describe_hint": "Опишіть голос або виберіть відправну точку — в обох випадках деталі нижче заповняться автоматично.",
     "describe_unmatched": "Не вдалося зіставити: {{items}}",
     "describe_no_match": "Голосові риси ще не розпізнано — спробуйте слова deep, elderly або British.",
     "define_by_design": "За дизайном",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -620,7 +620,13 @@
     "seed_keep": "Giữ hạt giống này",
     "seed_reroll": "Hạt giống mới",
     "seed_reroll_hint": "Cuộn một hạt giống ngẫu nhiên mới và giữ nó",
-    "define_convert": "Chuyển đổi"
+    "define_convert": "Chuyển đổi",
+    "details": "Chi tiết",
+    "edit": "Chỉnh sửa",
+    "cat_AccentDialect": "Giọng hoặc phương ngữ",
+    "accent_dialect_hint": "chỉ một trong hai, không cả hai",
+    "reset_to_description": "Đặt lại theo mô tả",
+    "chips_more": "{{count}} mục khác…"
   },
   "about": {
     "app": "ứng dụng",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -599,7 +599,7 @@
     "stop_playback": "Dừng phát",
     "describe_label": "Mô tả giọng nói của bạn",
     "describe_placeholder": "vd. a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "Mô tả của bạn (bằng tiếng Anh) sẽ thiết lập các điều khiển bên dưới — bạn vẫn có thể tinh chỉnh sau.",
+    "describe_hint": "Mô tả giọng nói, hoặc chọn một điểm khởi đầu. Cả hai cách đều tự điền chi tiết bên dưới.",
     "describe_unmatched": "Không thể ánh xạ: {{items}}",
     "describe_no_match": "Chưa nhận ra đặc điểm giọng nói nào — hãy thử các từ như deep, elderly hoặc British.",
     "define_by_design": "Theo thiết kế",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -258,7 +258,7 @@
     "stop_playback": "停止播放",
     "describe_label": "描述你想要的声音",
     "describe_placeholder": "例如：中年男性，低音调，四川话",
-    "describe_hint": "你的描述会自动设置下方的控件，之后仍可手动微调。（也支持英文描述）",
+    "describe_hint": "描述这个声音，或选择一个起点——两者都会自动填好下方的详情。",
     "describe_unmatched": "无法识别：{{items}}",
     "describe_no_match": "尚未识别出声音特征——试试 deep、elderly、British 或「中年」「低音调」等词。",
     "define_by_design": "通过设计",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -279,7 +279,13 @@
     "seed_keep": "保留这个种子",
     "seed_reroll": "新种子",
     "seed_reroll_hint": "滚动一个新的随机种子并保留它",
-    "define_convert": "转换"
+    "define_convert": "转换",
+    "details": "详情",
+    "edit": "编辑",
+    "cat_AccentDialect": "口音或方言",
+    "accent_dialect_hint": "二选一，不能同时选择",
+    "reset_to_description": "按描述重置",
+    "chips_more": "还有 {{count}} 个…"
   },
   "settings": {
     "remote_backend_test": "测试连接",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -599,7 +599,7 @@
     "stop_playback": "停止播放",
     "describe_label": "描述你想要的聲音",
     "describe_placeholder": "例如：a warm elderly British storyteller, slightly raspy",
-    "describe_hint": "你的描述（英文）會自動設定下方的控制項，之後仍可手動微調。",
+    "describe_hint": "描述這個聲音，或選擇一個起點——兩者都會自動填好下方的詳情。",
     "describe_unmatched": "無法辨識：{{items}}",
     "describe_no_match": "尚未辨識出聲音特徵——試試 deep、elderly 或 British 等詞。",
     "define_by_design": "以設計",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -620,7 +620,13 @@
     "seed_keep": "保留這個種子",
     "seed_reroll": "新種子",
     "seed_reroll_hint": "滾動一個新的隨機種子並保留它",
-    "define_convert": "轉換"
+    "define_convert": "轉換",
+    "details": "詳情",
+    "edit": "編輯",
+    "cat_AccentDialect": "口音或方言",
+    "accent_dialect_hint": "二選一，不能同時選擇",
+    "reset_to_description": "依描述重設",
+    "chips_more": "還有 {{count}} 個…"
   },
   "about": {
     "app": "應用程式",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1824,10 +1824,13 @@ select.input-base:focus-visible,
 }
 /* .tag-btn → Tailwind utilities inline in clone/ScriptPanel.jsx (P4). */
 
-/* .chip-group / .chip-group .chip → Tailwind utilities inline in
-   clone/DesignMethodPanel.jsx (P4). The `chip-group` class name is kept on the
-   container purely as a JS hook (CloneDesignTab's roving-tabindex keyboard nav
-   does `closest('.chip-group')`); its layout is now flex utilities on the div. */
+/* Chip strips → Tailwind utilities inline in clone/DesignMethodPanel.jsx
+   (P4). The Gender/Age/Pitch/Style/Accent-or-Dialect chip radiogroups moved
+   to native <select>s in the #1771 voice-design redesign; the "Starting
+   points" personality row is the only chip strip left. Its buttons carry a
+   `data-chip-nav` attribute purely as a JS hook — CloneDesignTab's
+   roving-tabindex keyboard nav does `closest('[role="group"]')
+   .querySelectorAll('[data-chip-nav]')`; layout is flex utilities on the div. */
 
 /* Textarea — flat chrome surface for design/clone prompt box */
 textarea.input-base {

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -126,26 +126,43 @@ export default function CloneDesignTab(props) {
     }
   };
 
+  // Shared "description -> vdStates" path: the debounced live-typing effect
+  // below and the Details editor's "Reset to description" button (#1771
+  // follow-up) both drive the category picks from describeText, so this is
+  // the ONE place that does it — resetToDescription must never grow a
+  // second, divergent implementation of the same mapping.
+  const applyDescribeToVdStates = async (q) => {
+    if (!q) {
+      // No description to reset to: every category goes back to Auto.
+      setVdStates(Object.fromEntries(Object.keys(CATEGORIES).map((k) => [k, 'Auto'])));
+      setDescribeUnmatched([]);
+      setDescribeMatchedAny(true);
+      setActivePersonality('');
+      setInstruct('');
+      return;
+    }
+    try {
+      const res = await apiPost('/design/describe', { description: q });
+      setVdStates(mergeDescribedAttrs(res.attrs));
+      setDescribeUnmatched(res.unmatched || []);
+      setDescribeMatchedAny((res.matched || []).length > 0);
+      // The description now owns the design parameters — clear any stale
+      // personality instruct so the synthesize path can't merge conflicting
+      // tokens from two sources (the issue-#114 failure mode).
+      setActivePersonality('');
+      setInstruct('');
+    } catch {
+      // Backend unreachable — leave the controls untouched; the live-typing
+      // path retries on the next keystroke, the reset button on the next click.
+    }
+  };
+
   useEffect(() => {
     const q = describeText.trim();
     if (!q) return undefined;
     let cancelled = false;
-    const id = setTimeout(async () => {
-      try {
-        const res = await apiPost('/design/describe', { description: q });
-        if (cancelled) return;
-        setVdStates(mergeDescribedAttrs(res.attrs));
-        setDescribeUnmatched(res.unmatched || []);
-        setDescribeMatchedAny((res.matched || []).length > 0);
-        // The description now owns the design parameters — clear any stale
-        // personality instruct so the synthesize path can't merge conflicting
-        // tokens from two sources (the issue-#114 failure mode).
-        setActivePersonality('');
-        setInstruct('');
-      } catch {
-        // Backend unreachable mid-typing — leave the controls untouched;
-        // the next keystroke retries.
-      }
+    const id = setTimeout(() => {
+      if (!cancelled) applyDescribeToVdStates(q);
     }, 450);
     return () => {
       cancelled = true;
@@ -153,6 +170,11 @@ export default function CloneDesignTab(props) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [describeText]);
+
+  // "Reset to description" (#1771 follow-up): returns every category to what
+  // the current description implies, or all-Auto when there is none —
+  // without waiting for the 450ms debounce or requiring a fresh keystroke.
+  const resetToDescription = () => applyDescribeToVdStates(describeText.trim());
 
   // Fetch personality presets from backend
   const { data: personalities = [] } = useQuery({
@@ -275,16 +297,22 @@ export default function CloneDesignTab(props) {
     }
   };
 
-  // 10x P4 a11y (spec §3): category chip groups are radiogroups with a
-  // roving tabindex — ArrowLeft/ArrowRight move focus AND selection within
-  // the group, per the WAI-ARIA radio-group pattern.
-  const onChipKeyDown = (e, key, options) => {
+  // 10x P4 a11y (spec §3): chip strips get a roving tabindex —
+  // ArrowLeft/ArrowRight move focus AND selection within the group, per the
+  // WAI-ARIA toolbar pattern. Gender/Age/Pitch/Style/Accent-or-Dialect moved
+  // to native <select>s in the #1771 follow-up (which get this navigation
+  // for free from the browser), so the only remaining chip strip is the
+  // "Starting points" personality row — including chips currently hidden
+  // behind its overflow toggle, once revealed. Generic over (ids, currentId,
+  // onSelect) rather than a vdStates category, since that's no longer the
+  // only chip consumer.
+  const onChipKeyDown = (e, ids, currentId, onSelect) => {
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
     e.preventDefault();
-    const cur = Math.max(0, options.indexOf(vdStates[key]));
-    const next = (cur + (e.key === 'ArrowRight' ? 1 : -1) + options.length) % options.length;
-    handleVdChange(key, options[next]);
-    e.currentTarget.closest('.chip-group')?.querySelectorAll('[role="radio"]')[next]?.focus();
+    const cur = Math.max(0, ids.indexOf(currentId));
+    const next = (cur + (e.key === 'ArrowRight' ? 1 : -1) + ids.length) % ids.length;
+    onSelect(ids[next]);
+    e.currentTarget.closest('[role="group"]')?.querySelectorAll('[data-chip-nav]')[next]?.focus();
   };
 
   // 10x P4 a11y (spec §3): once a generation has run, the persistent status
@@ -434,6 +462,7 @@ export default function CloneDesignTab(props) {
                 vdStates={vdStates}
                 onVdChange={handleVdChange}
                 onChipKeyDown={onChipKeyDown}
+                resetToDescription={resetToDescription}
                 showSaveProfile={showSaveProfile}
                 setShowSaveProfile={setShowSaveProfile}
                 profileName={profileName}

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -97,15 +97,17 @@ export default function CloneDesignTab(props) {
   const [activePersonality, setActivePersonality] = useState('');
   const [insertOpen, setInsertOpen] = useState(false);
 
-  // Identity recipe line (10x §1.5): the non-Auto category picks as one
-  // readable string. All-Auto (nothing chosen yet) starts the chips expanded.
+  // Details recipe line (10x §1.5, #1771 follow-up): the non-Auto category
+  // picks as one readable string, shown on the collapsed summary.
   const identityPicks = Object.values(vdStates || {}).filter((v) => v && v !== 'Auto');
   const identityRecipe = identityPicks.length
     ? identityPicks.join(' · ')
     : t('clone.identity_auto', { defaultValue: 'Auto — the model decides' });
-  const [identityOpen, setIdentityOpen] = useState(
-    () => !Object.values(vdStates || {}).some((v) => v && v !== 'Auto'),
-  );
+  // #1771 follow-up: the whole point of collapsing the 12-row block to one
+  // line is that it STAYS collapsed until asked — it must never start open,
+  // including on first run (the old design opened it whenever every category
+  // was still Auto; that behavior does not carry over).
+  const [identityOpen, setIdentityOpen] = useState(false);
 
   // ── "Describe your voice" (#317): free-text → design parameters ──────────
   // Debounced call to the local deterministic mapper (POST /design/describe);
@@ -353,7 +355,14 @@ export default function CloneDesignTab(props) {
 
   return (
     <div className="flex-1 flex flex-col min-h-0 min-w-0">
-      <div className="flex-1 flex flex-col gap-[6px] min-h-0 overflow-y-auto">
+      {/* #1771 follow-up (item 6): NOT flex-1 — the old always-open 12-row
+          Design block was tall enough that this area routinely filled the
+          full column height on its own. Now that Details defaults collapsed,
+          forcing this to grow-fill would strand a dead gap between it and
+          ActionBar below. Sizing to content (min-h-0 + overflow-y-auto still
+          in play) lets it shrink for short content and still scroll when
+          content genuinely exceeds the available height. */}
+      <div className="flex flex-col gap-[6px] min-h-0 overflow-y-auto">
         {/* ═══ SCRIPT — what should it say ═══
             Hidden for Convert: the source clip IS the script (the backend
             transcribes it), so a text panel would only mislead. */}

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -118,11 +118,37 @@ export default function CloneDesignTab(props) {
   const [describeUnmatched, setDescribeUnmatched] = useState([]);
   const [describeMatchedAny, setDescribeMatchedAny] = useState(true);
 
+  // describeRequestRef guards a describe response landing after it's been
+  // superseded. It fires on every keystroke's debounce AND on-demand from
+  // the reset button, so two /design/describe calls can be in flight
+  // together, and whichever resolves LAST used to always win regardless of
+  // which was actually issued last (the original inline effect closed over
+  // its own `cancelled` flag per call, which extracting it into
+  // applyDescribeToVdStates dropped — greptile caught it in review).
+  //
+  // That first fix only ordered describe-vs-describe correctly — it left a
+  // second, worse hole greptile found on the next pass: describe-vs-MANUAL
+  // races. A describe request can still be in flight when the user picks a
+  // category by hand, clicks a personality/preset chip, or clears the
+  // description entirely; none of those bumped the token, so a describe
+  // response landing afterwards silently overwrote the user's manual pick
+  // (or re-applied attributes for a description that no longer exists).
+  // invalidateDescribe() is the one place that bumps it — call it from
+  // EVERY path that should beat an in-flight describe response, not just
+  // from inside applyDescribeToVdStates itself.
+  const describeRequestRef = useRef(0);
+  const invalidateDescribe = () => {
+    describeRequestRef.current += 1;
+  };
+
   const onDescribeChange = (e) => {
     const value = e.target.value;
     setDescribeText(value);
     if (!value.trim()) {
-      // Cleared: drop stale feedback immediately (controls stay as they are).
+      // Cleared: an in-flight response for the old (now-gone) description
+      // must never land and re-apply attributes for text that no longer
+      // exists — bump the token so it's discarded on arrival.
+      invalidateDescribe();
       setDescribeUnmatched([]);
       setDescribeMatchedAny(true);
     }
@@ -133,17 +159,6 @@ export default function CloneDesignTab(props) {
   // follow-up) both drive the category picks from describeText, so this is
   // the ONE place that does it — resetToDescription must never grow a
   // second, divergent implementation of the same mapping.
-  //
-  // describeRequestRef guards the await: this fires on every keystroke's
-  // debounce AND on-demand from the reset button, so two calls can be in
-  // flight together, and whichever `apiPost` resolves LAST used to always
-  // win regardless of which was actually issued last (the original inline
-  // effect closed over its own `cancelled` flag per call, which this
-  // extraction dropped — greptile caught it in review). Each call claims the
-  // next token and only commits state if it's still the most recent one when
-  // its response lands, so a slow, superseded response can never clobber a
-  // faster, newer one.
-  const describeRequestRef = useRef(0);
   const applyDescribeToVdStates = async (q) => {
     const requestId = ++describeRequestRef.current;
     if (!q) {
@@ -199,6 +214,9 @@ export default function CloneDesignTab(props) {
   });
 
   const applyPersonality = (p) => {
+    // A manual pick always beats an in-flight describe response (greptile,
+    // PR #1793 second pass) — bump the token before touching state.
+    invalidateDescribe();
     if (activePersonality === p.id) {
       setActivePersonality('');
       return;
@@ -303,6 +321,9 @@ export default function CloneDesignTab(props) {
   // never both be set from the form. When picking one clears the other, say
   // so instead of a silent reset.
   const handleVdChange = (key, value) => {
+    // A manual pick always beats an in-flight describe response (greptile,
+    // PR #1793 second pass) — bump the token before touching state.
+    invalidateDescribe();
     const { vdStates: next, clearedCategory } = applyVdState(vdStates, key, value);
     setVdStates(next);
     if (clearedCategory) {
@@ -358,6 +379,9 @@ export default function CloneDesignTab(props) {
   // highlight the chip equivalent. After this fires, the user can hit
   // Synthesize Audio immediately — no further input needed.
   const applyDemoPreset = (p) => {
+    // A manual pick always beats an in-flight describe response (greptile,
+    // PR #1793 second pass) — bump the token before touching state.
+    invalidateDescribe();
     if (p.script) setText(p.script);
     if (p.attrs) {
       // #1771: apply one category at a time through the same exclusivity
@@ -373,6 +397,18 @@ export default function CloneDesignTab(props) {
     setInstruct('');
     if (p.language) setLanguage(p.language);
     setActivePersonality(p.id);
+  };
+
+  // `applyPreset` is owned by useTTS.js (it writes straight to the global
+  // store), not this component — but the "Starting points" PRESETS chips
+  // still fire it from inside DesignMethodPanel, and a manual pick always
+  // beats an in-flight describe response (greptile, PR #1793 second pass).
+  // Wrap it here so invalidateDescribe fires before the prop's own logic
+  // runs, rather than reaching into useTTS.js for a second describe-aware
+  // implementation.
+  const applyPresetAndInvalidate = (p) => {
+    invalidateDescribe();
+    applyPreset(p);
   };
 
   return (
@@ -486,7 +522,7 @@ export default function CloneDesignTab(props) {
                 chipPersonalities={chipPersonalities}
                 activePersonality={activePersonality}
                 applyPersonality={applyPersonality}
-                applyPreset={applyPreset}
+                applyPreset={applyPresetAndInvalidate}
                 identityOpen={identityOpen}
                 setIdentityOpen={setIdentityOpen}
                 identityRecipe={identityRecipe}

--- a/frontend/src/pages/CloneDesignTab.jsx
+++ b/frontend/src/pages/CloneDesignTab.jsx
@@ -133,7 +133,19 @@ export default function CloneDesignTab(props) {
   // follow-up) both drive the category picks from describeText, so this is
   // the ONE place that does it — resetToDescription must never grow a
   // second, divergent implementation of the same mapping.
+  //
+  // describeRequestRef guards the await: this fires on every keystroke's
+  // debounce AND on-demand from the reset button, so two calls can be in
+  // flight together, and whichever `apiPost` resolves LAST used to always
+  // win regardless of which was actually issued last (the original inline
+  // effect closed over its own `cancelled` flag per call, which this
+  // extraction dropped — greptile caught it in review). Each call claims the
+  // next token and only commits state if it's still the most recent one when
+  // its response lands, so a slow, superseded response can never clobber a
+  // faster, newer one.
+  const describeRequestRef = useRef(0);
   const applyDescribeToVdStates = async (q) => {
+    const requestId = ++describeRequestRef.current;
     if (!q) {
       // No description to reset to: every category goes back to Auto.
       setVdStates(Object.fromEntries(Object.keys(CATEGORIES).map((k) => [k, 'Auto'])));
@@ -145,6 +157,7 @@ export default function CloneDesignTab(props) {
     }
     try {
       const res = await apiPost('/design/describe', { description: q });
+      if (requestId !== describeRequestRef.current) return; // superseded — discard
       setVdStates(mergeDescribedAttrs(res.attrs));
       setDescribeUnmatched(res.unmatched || []);
       setDescribeMatchedAny((res.matched || []).length > 0);
@@ -300,20 +313,29 @@ export default function CloneDesignTab(props) {
   };
 
   // 10x P4 a11y (spec §3): chip strips get a roving tabindex —
-  // ArrowLeft/ArrowRight move focus AND selection within the group, per the
-  // WAI-ARIA toolbar pattern. Gender/Age/Pitch/Style/Accent-or-Dialect moved
-  // to native <select>s in the #1771 follow-up (which get this navigation
-  // for free from the browser), so the only remaining chip strip is the
-  // "Starting points" personality row — including chips currently hidden
-  // behind its overflow toggle, once revealed. Generic over (ids, currentId,
-  // onSelect) rather than a vdStates category, since that's no longer the
-  // only chip consumer.
-  const onChipKeyDown = (e, ids, currentId, onSelect) => {
+  // ArrowLeft/ArrowRight move FOCUS ONLY, per the WAI-ARIA toolbar pattern
+  // (a native <button> already activates on Enter/Space/click, so the
+  // handler never needs to fire selection itself). Gender/Age/Pitch/Style/
+  // Accent-or-Dialect moved to native <select>s in the #1771 follow-up
+  // (free keyboard nav from the browser), so the only remaining chip strip
+  // is the "Starting points" row — including chips currently hidden behind
+  // its overflow toggle, once revealed.
+  //
+  // This USED to also apply the newly-focused option (`onSelect`), which was
+  // correct for the old CATEGORIES radiogroups (a true single-value pick,
+  // where "arrow lands on X" and "X is now selected" are the same thing) but
+  // wrong for this toggle strip — CodeRabbit caught it in review: every
+  // arrow press was calling applyPersonality, which resets every vdStates
+  // category, so merely traversing the row with the keyboard destroyed the
+  // user's Details recipe. `currentIndex` is the target button's OWN index
+  // (from the render loop), not a lookup by "currently active id" — the old
+  // lookup-based `cur` silently reset to 0 whenever nothing was active
+  // (activePersonality can be '' most of the time), so it never advanced
+  // past the first two chips.
+  const onChipKeyDown = (e, ids, currentIndex) => {
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
     e.preventDefault();
-    const cur = Math.max(0, ids.indexOf(currentId));
-    const next = (cur + (e.key === 'ArrowRight' ? 1 : -1) + ids.length) % ids.length;
-    onSelect(ids[next]);
+    const next = (currentIndex + (e.key === 'ArrowRight' ? 1 : -1) + ids.length) % ids.length;
     e.currentTarget.closest('[role="group"]')?.querySelectorAll('[data-chip-nav]')[next]?.focus();
   };
 

--- a/frontend/src/pages/CloneDesignTab.test.jsx
+++ b/frontend/src/pages/CloneDesignTab.test.jsx
@@ -1,0 +1,142 @@
+// #1771 follow-up regressions (coordinator-verified in a real browser run):
+// the test suite passed while both of these were live, because DesignMethodPanel's
+// own unit tests take identityOpen/chipPersonalities as PROPS rather than
+// exercising CloneDesignTab's real initial-state computation and its real
+// "personalities + PRESETS share one lane" data flow. These tests mount the
+// actual CloneDesignTab so both bugs would fail here.
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import CloneDesignTab from './CloneDesignTab';
+import { useAppStore } from '../store';
+import { CATEGORIES } from '../utils/constants';
+
+vi.mock('../api/hooks', () => ({
+  useEngines: () => ({ data: { tts: { backends: [] }, asr: { backends: [] } } }),
+  useSelectEngine: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// Real personality ids/names — matches the six clone.personality_* locale
+// keys, so the component's real t() lookups render the exact chip labels
+// the coordinator saw in the browser repro (Narrator, Casual, News Anchor,
+// Storyteller, Corporate, Energetic).
+const PERSONALITIES = [
+  { id: 'narrator', name: 'Narrator', is_demo: false },
+  { id: 'casual', name: 'Casual', is_demo: false },
+  { id: 'news_anchor', name: 'News Anchor', is_demo: false },
+  { id: 'storyteller', name: 'Storyteller', is_demo: false },
+  { id: 'corporate', name: 'Corporate', is_demo: false },
+  { id: 'energetic', name: 'Energetic', is_demo: false },
+];
+
+vi.mock('../api/client', () => ({
+  API: '',
+  apiFetch: vi.fn(() => Promise.resolve({ json: () => Promise.resolve(PERSONALITIES) })),
+  apiPost: vi.fn(() => Promise.resolve({})),
+}));
+
+const NOOP = () => {};
+
+function renderDesignTab() {
+  // Default defineMethod is 'audio' — jump straight to the Design method so
+  // DesignMethodPanel (not AudioMethodPanel) mounts.
+  useAppStore.getState().setDefineMethod('design');
+  const queryClient = new QueryClient();
+  const vdStates = Object.fromEntries(Object.keys(CATEGORIES).map((k) => [k, 'Auto']));
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CloneDesignTab
+        textAreaRef={{ current: null }}
+        text=""
+        setText={NOOP}
+        language="en"
+        setLanguage={NOOP}
+        steps={16}
+        setSteps={NOOP}
+        cfg={2}
+        setCfg={NOOP}
+        speed={1}
+        setSpeed={NOOP}
+        tShift={0}
+        setTShift={NOOP}
+        posTemp={0}
+        setPosTemp={NOOP}
+        classTemp={0}
+        setClassTemp={NOOP}
+        layerPenalty={0}
+        setLayerPenalty={NOOP}
+        duration=""
+        setDuration={NOOP}
+        denoise={false}
+        setDenoise={NOOP}
+        postprocess={false}
+        setPostprocess={NOOP}
+        showOverrides={false}
+        setShowOverrides={NOOP}
+        profiles={[]}
+        selectedProfile=""
+        setSelectedProfile={NOOP}
+        refAudio={null}
+        refText=""
+        setRefText={NOOP}
+        instruct=""
+        setInstruct={NOOP}
+        profileName=""
+        setProfileName={NOOP}
+        showSaveProfile={false}
+        setShowSaveProfile={NOOP}
+        isRecording={false}
+        isCleaning={false}
+        recordingTime={0}
+        audioInputs={[]}
+        selectedAudioInputId=""
+        setSelectedAudioInputId={NOOP}
+        channelMode="mono"
+        setChannelMode={NOOP}
+        inputLevelStore={undefined}
+        vdStates={vdStates}
+        setVdStates={NOOP}
+        isGenerating={false}
+        generationTime={0}
+        applyPreset={NOOP}
+        insertTag={NOOP}
+        handleSaveProfile={NOOP}
+        handleSaveDesignProfile={NOOP}
+        handleGenerate={NOOP}
+        startRecording={NOOP}
+        stopRecording={NOOP}
+        ingestRefAudio={NOOP}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('CloneDesignTab — Voice Design panel redesign regressions', () => {
+  it('starts the Details summary collapsed, not expanded', () => {
+    renderDesignTab();
+    const summary = screen.getByRole('button', { name: /details/i });
+    expect(summary).toHaveAttribute('aria-expanded', 'false');
+    expect(document.getElementById('design-details-fields')).toBeNull();
+  });
+
+  it('shows exactly 5 combined starting-point chips, with the overflow count covering BOTH personalities and PRESETS', async () => {
+    renderDesignTab();
+    await screen.findByText('Narrator');
+    expect(screen.getByText('Casual')).toBeInTheDocument();
+    expect(screen.getByText('News Anchor')).toBeInTheDocument();
+    expect(screen.getByText('Storyteller')).toBeInTheDocument();
+    expect(screen.getByText('Corporate')).toBeInTheDocument();
+
+    // Hidden behind the toggle: the 6th personality (Energetic) + all 6
+    // hardcoded PRESETS (12 total - 5 visible = 7).
+    expect(screen.queryByText('Energetic')).toBeNull();
+    expect(screen.queryByText(/Authoritative/)).toBeNull();
+    const more = screen.getByText('7 more…');
+
+    fireEvent.click(more);
+    expect(screen.getByText('Energetic')).toBeInTheDocument();
+    expect(screen.getByText(/Authoritative/)).toBeInTheDocument();
+    expect(screen.queryByText(/more…/)).toBeNull();
+  });
+});

--- a/frontend/src/pages/CloneDesignTab.test.jsx
+++ b/frontend/src/pages/CloneDesignTab.test.jsx
@@ -182,6 +182,11 @@ describe('CloneDesignTab — Voice Design panel redesign regressions', () => {
 describe('CloneDesignTab — stale /design/describe response race guard', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // apiPost is a module-level mock shared across every test in this file —
+    // clear its call history (not its queued mockImplementationOnce, which
+    // each test sets up fresh) so `toHaveBeenCalledTimes` counts THIS test's
+    // calls only.
+    apiPost.mockClear();
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -230,5 +235,76 @@ describe('CloneDesignTab — stale /design/describe response race guard', () => 
       resolveFirst({ attrs: { Gender: 'male' }, matched: ['male'], unmatched: [] });
     });
     expect(setVdStates).toHaveBeenCalledTimes(1); // still just the one, newer call
+  });
+
+  // Greptile's second-pass finding on PR #1793: the sequence-token fix above
+  // only orders describe-vs-describe correctly. It missed describe-vs-MANUAL
+  // races — a describe request can still be in flight when the user hand-
+  // picks a category, and the response landing afterward used to silently
+  // discard the manual pick because nothing bumped the token except another
+  // describe call. invalidateDescribe() must fire from every manual
+  // mutation path.
+  it('a manual vdStates edit made while a describe is in flight is never overwritten by that response', async () => {
+    let resolveDescribe;
+    apiPost.mockImplementationOnce(() => new Promise((resolve) => (resolveDescribe = resolve)));
+
+    const setVdStates = vi.fn();
+    renderDesignTab({ setVdStates });
+    const textarea = screen.getByPlaceholderText(
+      'e.g. a warm elderly British storyteller, slightly raspy',
+    );
+
+    // A describe request is in flight (not yet resolved).
+    fireEvent.change(textarea, { target: { value: 'a deep male voice' } });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(apiPost).toHaveBeenCalledTimes(1);
+
+    // The user hand-picks Gender before that response lands.
+    fireEvent.click(screen.getByRole('button', { name: /details/i }));
+    const genderSelect = document.getElementById('vd-Gender');
+    fireEvent.change(genderSelect, { target: { value: 'male' } });
+    expect(setVdStates).toHaveBeenCalledTimes(1);
+    expect(setVdStates).toHaveBeenLastCalledWith(expect.objectContaining({ Gender: 'male' }));
+
+    // The in-flight describe response finally lands with a DIFFERENT
+    // Gender — it must not clobber the manual pick that came after it was
+    // issued.
+    await act(async () => {
+      resolveDescribe({ attrs: { Gender: 'female' }, matched: ['female'], unmatched: [] });
+    });
+    expect(setVdStates).toHaveBeenCalledTimes(1); // still just the manual edit
+  });
+
+  // The second shape of the same bug: clearing the description entirely.
+  // `onDescribeChange`'s cleared branch never scheduled a NEW describe call
+  // (there's nothing to describe), but it also never invalidated the OLD
+  // one already in flight — so a response for text that no longer exists
+  // could still land and re-apply its attributes.
+  it('clearing the description discards an in-flight response for the old text', async () => {
+    let resolveDescribe;
+    apiPost.mockImplementationOnce(() => new Promise((resolve) => (resolveDescribe = resolve)));
+
+    const setVdStates = vi.fn();
+    renderDesignTab({ setVdStates });
+    const textarea = screen.getByPlaceholderText(
+      'e.g. a warm elderly British storyteller, slightly raspy',
+    );
+
+    fireEvent.change(textarea, { target: { value: 'a deep male voice' } });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(apiPost).toHaveBeenCalledTimes(1);
+
+    // Cleared before the request resolves.
+    fireEvent.change(textarea, { target: { value: '' } });
+
+    await act(async () => {
+      resolveDescribe({ attrs: { Gender: 'male' }, matched: ['male'], unmatched: [] });
+    });
+    // A description that no longer exists must never re-apply its attrs.
+    expect(setVdStates).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/CloneDesignTab.test.jsx
+++ b/frontend/src/pages/CloneDesignTab.test.jsx
@@ -5,12 +5,13 @@
 // "personalities + PRESETS share one lane" data flow. These tests mount the
 // actual CloneDesignTab so both bugs would fail here.
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CloneDesignTab from './CloneDesignTab';
 import { useAppStore } from '../store';
 import { CATEGORIES } from '../utils/constants';
+import { apiPost } from '../api/client';
 
 vi.mock('../api/hooks', () => ({
   useEngines: () => ({ data: { tts: { backends: [] }, asr: { backends: [] } } }),
@@ -38,76 +39,81 @@ vi.mock('../api/client', () => ({
 
 const NOOP = () => {};
 
-function renderDesignTab() {
+function baseProps(overrides = {}) {
+  const vdStates = Object.fromEntries(Object.keys(CATEGORIES).map((k) => [k, 'Auto']));
+  return {
+    textAreaRef: { current: null },
+    text: '',
+    setText: NOOP,
+    language: 'en',
+    setLanguage: NOOP,
+    steps: 16,
+    setSteps: NOOP,
+    cfg: 2,
+    setCfg: NOOP,
+    speed: 1,
+    setSpeed: NOOP,
+    tShift: 0,
+    setTShift: NOOP,
+    posTemp: 0,
+    setPosTemp: NOOP,
+    classTemp: 0,
+    setClassTemp: NOOP,
+    layerPenalty: 0,
+    setLayerPenalty: NOOP,
+    duration: '',
+    setDuration: NOOP,
+    denoise: false,
+    setDenoise: NOOP,
+    postprocess: false,
+    setPostprocess: NOOP,
+    showOverrides: false,
+    setShowOverrides: NOOP,
+    profiles: [],
+    selectedProfile: '',
+    setSelectedProfile: NOOP,
+    refAudio: null,
+    refText: '',
+    setRefText: NOOP,
+    instruct: '',
+    setInstruct: NOOP,
+    profileName: '',
+    setProfileName: NOOP,
+    showSaveProfile: false,
+    setShowSaveProfile: NOOP,
+    isRecording: false,
+    isCleaning: false,
+    recordingTime: 0,
+    audioInputs: [],
+    selectedAudioInputId: '',
+    setSelectedAudioInputId: NOOP,
+    channelMode: 'mono',
+    setChannelMode: NOOP,
+    inputLevelStore: undefined,
+    vdStates,
+    setVdStates: NOOP,
+    isGenerating: false,
+    generationTime: 0,
+    applyPreset: NOOP,
+    insertTag: NOOP,
+    handleSaveProfile: NOOP,
+    handleSaveDesignProfile: NOOP,
+    handleGenerate: NOOP,
+    startRecording: NOOP,
+    stopRecording: NOOP,
+    ingestRefAudio: NOOP,
+    ...overrides,
+  };
+}
+
+function renderDesignTab(overrides = {}) {
   // Default defineMethod is 'audio' — jump straight to the Design method so
   // DesignMethodPanel (not AudioMethodPanel) mounts.
   useAppStore.getState().setDefineMethod('design');
   const queryClient = new QueryClient();
-  const vdStates = Object.fromEntries(Object.keys(CATEGORIES).map((k) => [k, 'Auto']));
   return render(
     <QueryClientProvider client={queryClient}>
-      <CloneDesignTab
-        textAreaRef={{ current: null }}
-        text=""
-        setText={NOOP}
-        language="en"
-        setLanguage={NOOP}
-        steps={16}
-        setSteps={NOOP}
-        cfg={2}
-        setCfg={NOOP}
-        speed={1}
-        setSpeed={NOOP}
-        tShift={0}
-        setTShift={NOOP}
-        posTemp={0}
-        setPosTemp={NOOP}
-        classTemp={0}
-        setClassTemp={NOOP}
-        layerPenalty={0}
-        setLayerPenalty={NOOP}
-        duration=""
-        setDuration={NOOP}
-        denoise={false}
-        setDenoise={NOOP}
-        postprocess={false}
-        setPostprocess={NOOP}
-        showOverrides={false}
-        setShowOverrides={NOOP}
-        profiles={[]}
-        selectedProfile=""
-        setSelectedProfile={NOOP}
-        refAudio={null}
-        refText=""
-        setRefText={NOOP}
-        instruct=""
-        setInstruct={NOOP}
-        profileName=""
-        setProfileName={NOOP}
-        showSaveProfile={false}
-        setShowSaveProfile={NOOP}
-        isRecording={false}
-        isCleaning={false}
-        recordingTime={0}
-        audioInputs={[]}
-        selectedAudioInputId=""
-        setSelectedAudioInputId={NOOP}
-        channelMode="mono"
-        setChannelMode={NOOP}
-        inputLevelStore={undefined}
-        vdStates={vdStates}
-        setVdStates={NOOP}
-        isGenerating={false}
-        generationTime={0}
-        applyPreset={NOOP}
-        insertTag={NOOP}
-        handleSaveProfile={NOOP}
-        handleSaveDesignProfile={NOOP}
-        handleGenerate={NOOP}
-        startRecording={NOOP}
-        stopRecording={NOOP}
-        ingestRefAudio={NOOP}
-      />
+      <CloneDesignTab {...baseProps(overrides)} />
     </QueryClientProvider>,
   );
 }
@@ -138,5 +144,91 @@ describe('CloneDesignTab — Voice Design panel redesign regressions', () => {
     expect(screen.getByText('Energetic')).toBeInTheDocument();
     expect(screen.getByText(/Authoritative/)).toBeInTheDocument();
     expect(screen.queryByText(/more…/)).toBeNull();
+  });
+
+  // CodeRabbit (PR #1793 review): the Starting Points chip strip is a toggle
+  // group, not a true radio group — clicking the active chip again clears
+  // it (applyPersonality). Arrow-key navigation must move focus ONLY; it
+  // used to also re-apply the newly-focused chip on every press, which
+  // reset every vdStates category to Auto just from tabbing through with
+  // the keyboard, and (since nothing is "active" most of the time) got
+  // stuck re-selecting index 0→1 instead of actually advancing.
+  it('ArrowRight only moves focus across chips — it never re-applies a personality/preset', async () => {
+    const setVdStates = vi.fn();
+    const setInstruct = vi.fn();
+    renderDesignTab({ setVdStates, setInstruct });
+    const narrator = await screen.findByRole('button', { name: /narrator/i });
+    const casual = screen.getByRole('button', { name: /casual/i });
+
+    narrator.focus();
+    expect(document.activeElement).toBe(narrator);
+
+    fireEvent.keyDown(narrator, { key: 'ArrowRight' });
+
+    expect(document.activeElement).toBe(casual);
+    expect(setVdStates).not.toHaveBeenCalled();
+    expect(setInstruct).not.toHaveBeenCalled();
+  });
+});
+
+// Bot review on PR #1793 (greptile + coderabbit, independently): extracting
+// the debounced describe→vdStates body into applyDescribeToVdStates() (so
+// the live-typing effect and the "Reset to description" button share it)
+// dropped the original inline effect's `if (cancelled) return;` guard AFTER
+// the await. Two overlapping /design/describe calls can resolve out of
+// order (a slow first request racing a fast, newer second one); the fix is
+// a describeRequestRef sequence token that discards a response once a newer
+// call has started.
+describe('CloneDesignTab — stale /design/describe response race guard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('a slow, superseded response never overwrites a faster, newer one', async () => {
+    let resolveFirst;
+    let resolveSecond;
+    apiPost
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)));
+
+    const setVdStates = vi.fn();
+    renderDesignTab({ setVdStates });
+    const textarea = screen.getByPlaceholderText(
+      'e.g. a warm elderly British storyteller, slightly raspy',
+    );
+
+    // First description — its debounce fires and its (slow) apiPost call
+    // starts, but nothing has resolved yet.
+    fireEvent.change(textarea, { target: { value: 'a deep male voice' } });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(apiPost).toHaveBeenCalledTimes(1);
+
+    // A second, different description supersedes it before the first
+    // request resolves.
+    fireEvent.change(textarea, { target: { value: 'a bright female voice' } });
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(apiPost).toHaveBeenCalledTimes(2);
+
+    // The NEWER request resolves first (plausible under real network
+    // jitter) — its result must be applied.
+    await act(async () => {
+      resolveSecond({ attrs: { Gender: 'female' }, matched: ['female'], unmatched: [] });
+    });
+    expect(setVdStates).toHaveBeenCalledTimes(1);
+    expect(setVdStates).toHaveBeenLastCalledWith(expect.objectContaining({ Gender: 'female' }));
+
+    // The OLDER, now-stale request finally resolves — it must be discarded,
+    // not silently overwrite the newer state that already landed.
+    await act(async () => {
+      resolveFirst({ attrs: { Gender: 'male' }, matched: ['male'], unmatched: [] });
+    });
+    expect(setVdStates).toHaveBeenCalledTimes(1); // still just the one, newer call
   });
 });


### PR DESCRIPTION
## Summary

Redesign of Studio → Voice → "By design" per the approved mock in the task brief — a UI simplification only, no synthesis behavior change.

**Before:** a 12-row, always-open block that printed every picked value three times (Identity summary line, per-category header `GENDER · MALE`, and a highlighted pill), plus separate English-accent and Chinese-dialect pickers that the engine rejects if both are set, plus an unbounded horizontally-scrolling "Starting points" chip lane.

**After:**
1. **Kill the triple printing** — dropped the `· VALUE` suffix from every category header. The collapsed "Details" summary line (renamed from "Identity", new `clone.details` key, old key left in place) is now the only place a picked value is printed.
2. **Collapse the details** — the 12-row block is one summary line (`identityOpen`/`setIdentityOpen`/`identityRecipe` props, unchanged) that expands to a 5-field editor.
3. **Merge English accent + Chinese dialect** into one `<select>` with two `<optgroup>`s. It still writes to the two separate `EnglishAccent`/`ChineseDialect` `vdStates` categories — picking one forces the other to `Auto` — routed through the existing `onVdChange` → `applyVdState` (#1788) helper, so the exclusivity rule stays single-sourced. `EXCLUSIVE_GROUPS`, the `conflicts` bucket in `buildDesignInstruct`, and the `errorToast.jsx` backstop are untouched (presets/imported projects/saved profiles still need them).
4. **Gender/Age/Pitch/Style become `<select>`s** instead of pill rows.
5. **Starting points show the first 5** personality chips (from the dynamic `chipPersonalities` prop) plus a `{{count}} more…` chip that reveals the rest in place — nothing hardcoded.
6. **The panel ends where its content ends** — "Save design as profile" moves into the expanded editor's footer, paired with a new **"Reset to description"** button (reuses the existing `/design/describe` → `mergeDescribedAttrs` path, extracted into a shared `applyDescribeToVdStates` so the debounced live-typing effect and the reset button never diverge). Nothing is reserved below the controls when collapsed.

**Bottom-bar slider:** the unlabelled slider showing `16` between the language dropdown and "Production Overrides" is the **inference/sampling steps** control (`ActionBar.jsx`, `steps` state, default `16`) — it already had a hover `title={t('clone.steps')}` but no visible label. Added a visible `{t('clone.steps')}` span next to its icon.

**Keyboard:** `onChipKeyDown` generalized from a `vdStates`-category signature `(e, key, options)` to `(e, ids, currentId, onSelect)`, since Gender/Age/Pitch/Style/Accent-or-Dialect are now native `<select>`s (keyboard nav for free) and its only remaining consumer is the Starting Points personality chip row, including chips revealed by the overflow toggle.

**Localization:** added `clone.details`, `clone.edit`, `clone.cat_AccentDialect`, `clone.accent_dialect_hint`, `clone.reset_to_description`, `clone.chips_more` to all 21 locale files with real (non-English) translations.

## Test plan

- [x] `cd frontend && bun run test` — 305 files / 2575 tests passed (2565 baseline + 10 new)
- [x] `cd frontend && bun run format:check` — clean
- [x] `cd frontend && bun run lint` — no new warnings in changed files
- [x] `.venv/bin/python -m pytest tests/test_locale_parity.py tests/test_no_hardcoded_cjk.py tests/test_changelog_style.py -q` — 257 passed
- [x] New coverage in `DesignMethodPanel.test.jsx`: collapsed↔expanded toggle, merged accent field routing to the correct category (both directions + Auto-clears-whichever-side), chip overflow reveal

## Changelog

Added a one-liner under `## [0.5.2]`'s `### Changed` — will add the `(#NNN)` ref once this PR number is known, per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HR6J9zKQop9TGGVUwjypnF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The Voice Design panel now uses a collapsed details editor, merged accent/dialect select, five visible combined starting-point chips, and a “Reset to description” action without changing synthesis behavior. Request sequencing prevents stale `/design/describe` responses from overwriting newer state, and chip keyboard navigation moves focus without changing selection. Review select routing and reset behavior for state-update regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->