### PR TITLE
fix(Transcriptions): guard null seg.start/end in .toFixed() (fixes #1798)

### DIFF
--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -1496,7 +1496,8 @@
     "exported": "النسخ المصدرة",
     "just_now": "الآن فقط",
     "m_ago": "{{count}}م مضت",
-    "h_ago": "{{count}}h منذ"
+    "h_ago": "{{count}}h منذ",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "مرحبًا",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1496,7 +1496,8 @@
     "exported": "Exportierte Transkriptionen",
     "just_now": "Gerade eben",
     "m_ago": "Vor {{count}}m",
-    "h_ago": "Vor {{count}}h"
+    "h_ago": "Vor {{count}}h",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Willkommen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1772,7 +1772,8 @@
     "exported": "Exported transcriptions",
     "just_now": "Just now",
     "m_ago": "{{count}}m ago",
-    "h_ago": "{{count}}h ago"
+    "h_ago": "{{count}}h ago",
+    "timestamp_unavailable": "–"
   },
   "transcriptionPicker": {
     "title": "Import from a transcription",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1496,7 +1496,8 @@
     "exported": "Transcripciones exportadas",
     "just_now": "Justo ahora",
     "m_ago": "Hace {{count}}m",
-    "h_ago": "Hace {{count}}h"
+    "h_ago": "Hace {{count}}h",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Bienvenido",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1496,7 +1496,8 @@
     "exported": "Transcriptions exportées",
     "just_now": "Juste maintenant",
     "m_ago": "il y a {{count}} m",
-    "h_ago": "Il y a {{count}}h"
+    "h_ago": "Il y a {{count}}h",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Bienvenue",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -1496,7 +1496,8 @@
     "exported": "निर्यातित प्रतिलेखन",
     "just_now": "अभी अभी",
     "m_ago": "{{count}}m पहले",
-    "h_ago": "{{count}}h पहले"
+    "h_ago": "{{count}}h पहले",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "स्वागत है",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -1496,7 +1496,8 @@
     "exported": "Transkripsi yang diekspor",
     "just_now": "Baru saja",
     "m_ago": "{{count}}m yang lalu",
-    "h_ago": "{{count}}jam yang lalu"
+    "h_ago": "{{count}}jam yang lalu",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Selamat datang",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -1496,7 +1496,8 @@
     "exported": "Trascrizioni esportate",
     "just_now": "Proprio adesso",
     "m_ago": "{{count}}m fa",
-    "h_ago": "{{count}}h fa"
+    "h_ago": "{{count}}h fa",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Benvenuto",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1496,7 +1496,8 @@
     "exported": "エクスポートされた文字起こし",
     "just_now": "たった今",
     "m_ago": "{{count}}分前",
-    "h_ago": "{{count}}時間前"
+    "h_ago": "{{count}}時間前",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "ようこそ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1812,7 +1812,8 @@
     "exported": "내보낸 녹취록",
     "just_now": "지금 막",
     "m_ago": "{{count}}분 전",
-    "h_ago": "{{count}}시간 전"
+    "h_ago": "{{count}}시간 전",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "환영합니다",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -1496,7 +1496,8 @@
     "exported": "Geëxporteerde transcripties",
     "just_now": "Zojuist",
     "m_ago": "{{count}}m geleden",
-    "h_ago": "{{count}}u geleden"
+    "h_ago": "{{count}}u geleden",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Welkom",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -1496,7 +1496,8 @@
     "exported": "Eksportowane transkrypcje",
     "just_now": "Właśnie teraz",
     "m_ago": "{{count}}m temu",
-    "h_ago": "{{count}}h temu"
+    "h_ago": "{{count}}h temu",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Witamy",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1496,7 +1496,8 @@
     "exported": "Transcrições exportadas",
     "just_now": "Agora mesmo",
     "m_ago": "{{count}}m atrás",
-    "h_ago": "{{count}}h atrás"
+    "h_ago": "{{count}}h atrás",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Bem vindo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1496,7 +1496,8 @@
     "exported": "Экспортированные транскрипции",
     "just_now": "Прямо сейчас",
     "m_ago": "{{count}}м назад",
-    "h_ago": "{{count}}ч назад"
+    "h_ago": "{{count}}ч назад",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Добро пожаловать",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -1496,7 +1496,8 @@
     "exported": "Exporterade transkriptioner",
     "just_now": "Just nu",
     "m_ago": "{{count}}m sedan",
-    "h_ago": "{{count}}h sedan"
+    "h_ago": "{{count}}h sedan",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Välkommen",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -1496,7 +1496,8 @@
     "exported": "การถอดเสียงที่ส่งออก",
     "just_now": "แค่ตอนนี้",
     "m_ago": "{{count}}นาทีที่แล้ว",
-    "h_ago": "{{count}}ชม. ที่แล้ว"
+    "h_ago": "{{count}}ชม. ที่แล้ว",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "ยินดีต้อนรับ",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -1496,7 +1496,8 @@
     "exported": "Dışa aktarılan transkripsiyonlar",
     "just_now": "Az önce",
     "m_ago": "{{count}}m önce",
-    "h_ago": "{{count}}sa önce"
+    "h_ago": "{{count}}sa önce",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Hoş geldiniz",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -1496,7 +1496,8 @@
     "exported": "Експортовані транскрипції",
     "just_now": "Просто зараз",
     "m_ago": "{{count}}хв тому",
-    "h_ago": "{{count}} год тому"
+    "h_ago": "{{count}} год тому",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Ласкаво просимо",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -1496,7 +1496,8 @@
     "exported": "Bản chép lời đã xuất",
     "just_now": "Vừa rồi",
     "m_ago": "{{count}}phút trước",
-    "h_ago": "{{count}}giờ trước"
+    "h_ago": "{{count}}giờ trước",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "Chào mừng",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1455,7 +1455,8 @@
     "exported": "已导出转录记录",
     "just_now": "刚刚",
     "m_ago": "{{count}} 分钟前",
-    "h_ago": "{{count}} 小时前"
+    "h_ago": "{{count}} 小时前",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "欢迎",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1496,7 +1496,8 @@
     "exported": "匯出的轉錄內容",
     "just_now": "剛才",
     "m_ago": "{{count}}分鐘前",
-    "h_ago": "{{count}} 小時前"
+    "h_ago": "{{count}} 小時前",
+    "timestamp_unavailable": "–"
   },
   "setup": {
     "welcome": "歡迎",

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -288,7 +288,7 @@ export default function TranscriptionsPage() {
                     className="txn-detail__seg flex gap-[8px] py-[3px] text-[var(--text-xs)]"
                   >
                     <span className="txn-detail__seg-time shrink-0 font-mono text-fg-subtle min-w-[80px]">
-                      {seg.start != null ? `${seg.start.toFixed(1)}s` : '-'} – {seg.end != null ? `${seg.end.toFixed(1)}s` : '-'}
+                      {seg.start != null ? `${seg.start.toFixed(1)}s` : t('transcriptions.timestamp_unavailable')} – {seg.end != null ? `${seg.end.toFixed(1)}s` : t('transcriptions.timestamp_unavailable')}
                     </span>
                     <span className="txn-detail__seg-text text-fg">{seg.text}</span>
                   </div>

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -288,7 +288,7 @@ export default function TranscriptionsPage() {
                     className="txn-detail__seg flex gap-[8px] py-[3px] text-[var(--text-xs)]"
                   >
                     <span className="txn-detail__seg-time shrink-0 font-mono text-fg-subtle min-w-[80px]">
-                      {seg.start.toFixed(1)}s – {seg.end.toFixed(1)}s
+                      {seg.start != null ? `${seg.start.toFixed(1)}s` : '-'} – {seg.end != null ? `${seg.end.toFixed(1)}s` : '-'}
                     </span>
                     <span className="txn-detail__seg-text text-fg">{seg.text}</span>
                   </div>

--- a/frontend/src/pages/Transcriptions.test.jsx
+++ b/frontend/src/pages/Transcriptions.test.jsx
@@ -66,4 +66,23 @@ describe('Transcriptions capture entry point', () => {
 
     expect(await screen.findByText('The shared capture path works.')).toBeInTheDocument();
   });
+
+  it('renders translated timestamp fallback for segments with null start/end', () => {
+    act(() => {
+      addTranscription({
+        text: 'Partial transcription',
+        segments: [
+          { start: null, end: null, text: 'first word' },
+          { start: 1.5, end: null, text: 'second word' },
+          { start: null, end: 3.0, text: 'third word' },
+        ],
+      });
+    });
+
+    fireEvent.click(screen.getByText('Partial transcription'));
+
+    // en.json: timestamp_unavailable = "–"
+    const fallback = screen.getByText('–');
+    expect(fallback).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Fixes #1798. Segments from the transcription backend may arrive with null `start`/`end` timestamps during dictation startup. Calling `.toFixed()` on null crashes the app with `null is not an object (evaluating 'e.end.toFixed')`.

Added null checks that render `-` when start/end is unavailable, preventing the crash while keeping the display consistent.

Root cause: `loadTranscriptions` stores the transcription entry, and segments from the backend can have `start=null`/`end=null` when dictation is just starting. The rendering at line 291 assumed both were always numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The Transcriptions view now handles null `start` or `end` timestamps without calling `.toFixed()`. It displays the translated `transcriptions.timestamp_unavailable` fallback and adds this key to all 21 locale files. Regression tests cover missing start, end, or both timestamps; risk is low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->