### PR TITLE
fix(moss_tts_v15): select device via torch.accelerator instead of CUDA hardcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- MOSS accelerator routing now matches runtime device selection, including native XPU and registered NPU detection (#1830) — thanks @li-lizhe!
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- MOSS accelerator routing now matches runtime device selection, including native XPU and registered NPU detection (#1830) — thanks @li-lizhe!
+- MOSS accelerator routing and status match runtime selection, with CPU fallback when device probing fails (#1830) — thanks @li-lizhe!
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ### Fixed
 
 - MOSS accelerator routing and status match runtime selection, with CPU fallback when device probing fails (#1830) — thanks @li-lizhe!
+- Fast macOS process exits no longer turn a completed shutdown into a permission error (#1809)
 
 
 ## [0.5.2] — 2026-09-02

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -150,7 +150,7 @@ def _compute_device_state() -> dict:
     caps = device_caps.detect_host_caps()
     env_pin = (os.environ.get("OMNIVOICE_DEVICE") or "").strip().lower()
     auto_family = next(
-        (f for f in ("cuda", "rocm", "xpu", "mps") if f in caps.available_families),
+        (f for f in device_caps.ACCELERATOR_PRIORITY if f in caps.available_families),
         "cpu",
     )
     value = device_caps.requested_device_override()

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -538,6 +538,7 @@ def _probe() -> HostCaps:
     try:
         import intel_extension_for_pytorch  # noqa: F401
     except Exception:
+        # Optional IPEX may be absent or incompatible; still probe native torch XPU.
         pass
     try:
         if hasattr(torch, "xpu") and torch.xpu.is_available():
@@ -562,9 +563,11 @@ def _probe() -> HostCaps:
                 try:
                     device_name = torch.npu.get_device_name(0)
                 except Exception:
+                    # An unavailable display name does not invalidate a usable NPU.
                     pass
             notes.append("NPU VRAM not queried")
     except Exception:
+        # Missing or broken vendor backends mean no usable NPU; continue probing.
         pass
 
     # ── Apple Silicon MPS ────────────────────────────────────────────────

--- a/backend/core/device_caps.py
+++ b/backend/core/device_caps.py
@@ -35,7 +35,8 @@ import sys
 from dataclasses import dataclass
 from typing import Literal
 
-DeviceFamily = Literal["cuda", "rocm", "mps", "xpu", "cpu"]
+DeviceFamily = Literal["cuda", "rocm", "mps", "xpu", "npu", "cpu"]
+ACCELERATOR_PRIORITY = ("cuda", "rocm", "xpu", "npu", "mps")
 
 # Stable substring stamped onto notes that represent a real kernel-launch risk
 # (arch/driver mismatch) — as opposed to advisory notes (multi-GPU, VRAM query
@@ -533,9 +534,12 @@ def _probe() -> HostCaps:
         # is the whole truth in that case (CodeRabbit, #1425).
         notes.extend(why_no_gpu(torch))
 
-    # ── Intel XPU via IPEX ───────────────────────────────────────────────
+    # Older builds register XPU through IPEX; modern torch exposes it directly.
     try:
         import intel_extension_for_pytorch  # noqa: F401
+    except Exception:
+        pass
+    try:
         if hasattr(torch, "xpu") and torch.xpu.is_available():
             detected.append("xpu")
             if not device_name:
@@ -546,7 +550,21 @@ def _probe() -> HostCaps:
                     pass
             notes.append("XPU VRAM not queried (unreliable across IPEX versions)")
     except Exception:
-        # IPEX absent or XPU probe failed — no XPU on this host.
+        # XPU probe failed — no usable XPU on this host.
+        pass
+
+    # Vendor extensions may register an NPU with torch. Probe only an already
+    # registered backend; never install or import an optional vendor package.
+    try:
+        if hasattr(torch, "npu") and torch.npu.is_available():
+            detected.append("npu")
+            if not device_name:
+                try:
+                    device_name = torch.npu.get_device_name(0)
+                except Exception:
+                    pass
+            notes.append("NPU VRAM not queried")
+    except Exception:
         pass
 
     # ── Apple Silicon MPS ────────────────────────────────────────────────
@@ -579,7 +597,7 @@ def _probe() -> HostCaps:
 
     # Preferred family by priority; cpu when nothing accelerated was detected.
     family: DeviceFamily = "cpu"
-    for pref in ("cuda", "rocm", "xpu", "mps"):
+    for pref in ACCELERATOR_PRIORITY:
         if pref in detected:
             family = pref  # type: ignore[assignment]
             break

--- a/backend/engines/moss_tts_v15/__init__.py
+++ b/backend/engines/moss_tts_v15/__init__.py
@@ -81,12 +81,12 @@ class MossTTSV15Backend(SubprocessBackend):
 
     id = "moss-tts-v15"
     display_name = (
-        "MOSS-TTS-v1.5 (8B, 31 langs, zero-shot clone, CUDA/CPU, Apache-2.0)"
+        "MOSS-TTS-v1.5 (8B, 31 langs, zero-shot clone, Apache-2.0)"
     )
     supports_voice_design = False  # requires ref audio for timbre cloning
     _DEFAULT_SAMPLE_RATE = 24000
-    # Honest hardware surface: upstream documents CUDA + CPU only. MPS is
-    # undocumented / untested, so we do NOT claim it (cross-platform rule).
+    # Accelerator routing requires its matching runtime in the isolated venv.
+    # MPS remains untested and is deliberately excluded.
     gpu_compat = ("cuda", "rocm", "xpu", "npu", "cpu")
 
     # ── availability ───────────────────────────────────────────────────────
@@ -107,7 +107,7 @@ class MossTTSV15Backend(SubprocessBackend):
             return False, (
                 "MOSS-TTS-v1.5 venv not found. Set OMNIVOICE_MOSS_TTS_V15_DIR "
                 "to your MOSS-TTS clone (the directory containing pyproject.toml) "
-                "and restart VoiceStudio. CUDA or CPU only (no MPS). See "
+                "and restart VoiceStudio. Install the matching PyTorch runtime. See "
                 "docs/engines/moss-tts-v15.md for the full install walk-through."
             )
         if not MOSS_TTS_V15_SIDECAR_SCRIPT.exists():
@@ -115,7 +115,7 @@ class MossTTSV15Backend(SubprocessBackend):
                 "MOSS-TTS-v1.5 sidecar script missing at "
                 f"{MOSS_TTS_V15_SIDECAR_SCRIPT} — reinstall VoiceStudio."
             )
-        return True, "ok (CUDA when present, else CPU)"
+        return True, "ok (runtime-available accelerator or CPU; no MPS)"
 
     @classmethod
     def venv_python(cls):

--- a/backend/engines/moss_tts_v15/__init__.py
+++ b/backend/engines/moss_tts_v15/__init__.py
@@ -29,15 +29,11 @@ Do NOT import ``main.py`` from the parent process — it runs under a
 different venv (``transformers==5.0.0``) and importing it in-process would
 re-introduce the exact conflict this isolation exists to avoid.
 
-Hardware honesty (cross-platform rule): MOSS-TTS-v1.5's upstream documents
-only CUDA and CPU. There is **no documented or tested MPS path** — the
-custom ``trust_remote_code`` modelling code and the separate audio
-tokenizer are unverified on Apple Silicon. We therefore advertise
-``gpu_compat = ("cuda", "cpu")`` and the sidecar selects ``cuda`` when
-present else ``cpu`` — it never silently routes to MPS where it might
-crash. On Apple Silicon the engine honestly resolves to CPU (slow but
-correct), and the engine is opt-in regardless, so it never becomes a
-broken default on any platform.
+Hardware routing follows the sidecar's runtime-available PyTorch accelerator:
+CUDA/ROCm, XPU, or a registered NPU. MPS remains excluded; CPU is the fallback.
+XPU/NPU routing is covered with mocked device contracts, not physical-hardware
+synthesis certification; users need a compatible torch/vendor runtime in the
+isolated engine venv.
 """
 from __future__ import annotations
 
@@ -91,7 +87,7 @@ class MossTTSV15Backend(SubprocessBackend):
     _DEFAULT_SAMPLE_RATE = 24000
     # Honest hardware surface: upstream documents CUDA + CPU only. MPS is
     # undocumented / untested, so we do NOT claim it (cross-platform rule).
-    gpu_compat = ("cuda", "cpu")
+    gpu_compat = ("cuda", "rocm", "xpu", "npu", "cpu")
 
     # ── availability ───────────────────────────────────────────────────────
 

--- a/backend/engines/moss_tts_v15/main.py
+++ b/backend/engines/moss_tts_v15/main.py
@@ -138,11 +138,12 @@ _state = None
 def _load_model(stdout):
     """Cold-construct the MOSS-TTS-v1.5 processor + model.
 
-    Device selection is CUDA-or-CPU only — MOSS's upstream documents no MPS
-    path and the custom ``trust_remote_code`` modelling code is untested on
-    Apple Silicon, so we never route to MPS where it might crash. dtype is
-    bf16 on CUDA, fp32 on CPU (bf16 CPU ops are spotty). Emits progress
-    frames so the parent can surface the multi-GB cold-load latency.
+    Device selection uses the torch.accelerator API to support any backend
+    (CUDA, NPU, XPU, etc.) automatically. MPS is excluded — MOSS's upstream
+    ``trust_remote_code`` modelling code is untested on Apple Silicon. dtype is
+    bf16 on GPU-class accelerators, fp32 on CPU (bf16 CPU ops are spotty).
+    Emits progress frames so the parent can surface the multi-GB cold-load
+    latency.
     """
     global _state
     if _state is not None:
@@ -154,8 +155,11 @@ def _load_model(stdout):
     from transformers import AutoModel, AutoProcessor
 
     repo, revision = _model_source()
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    accel = torch.accelerator.current_accelerator()
+    device = accel.type  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
+    if device == "mps":
+        device = "cpu"  # MOSS is untested on MPS; fall back to CPU for safety
+    dtype = torch.bfloat16 if device != "cpu" else torch.float32
     # "sdpa" works on CUDA + CPU and needs no extra dep. flash_attention_2
     # (Ampere+ CUDA, optional flash-attn) is opt-in via env.
     attn = os.environ.get("OMNIVOICE_MOSS_TTS_V15_ATTN", "sdpa")

--- a/backend/engines/moss_tts_v15/main.py
+++ b/backend/engines/moss_tts_v15/main.py
@@ -155,8 +155,10 @@ def _load_model(stdout):
     from transformers import AutoModel, AutoProcessor
 
     repo, revision = _model_source()
-    accel = torch.accelerator.current_accelerator()
-    device = accel.type  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
+    # current_accelerator() returns None on CPU-only builds (no accelerator
+    # compiled in) or when no accelerator is available; fall back to "cpu".
+    accel = torch.accelerator.current_accelerator(check_available=True)
+    device = accel.type if accel is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
     if device == "mps":
         device = "cpu"  # MOSS is untested on MPS; fall back to CPU for safety
     dtype = torch.bfloat16 if device != "cpu" else torch.float32

--- a/backend/engines/moss_tts_v15/main.py
+++ b/backend/engines/moss_tts_v15/main.py
@@ -159,10 +159,14 @@ def _load_model(stdout):
     # compiled in) or when no accelerator is available; fall back to "cpu".
     # Existing manually provisioned venvs may predate torch.accelerator.
     current_accelerator = getattr(getattr(torch, "accelerator", None), "current_accelerator", None)
-    if current_accelerator is None:
-        accel = torch.device("cuda") if torch.cuda.is_available() else None
-    else:
-        accel = current_accelerator(check_available=True)
+    try:
+        if current_accelerator is None:
+            accel = torch.device("cuda") if torch.cuda.is_available() else None
+        else:
+            accel = current_accelerator(check_available=True)
+    except Exception:
+        # Optional drivers can fail during probing; CPU loading remains usable.
+        accel = None
     device = accel.type if accel is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
     if device == "mps":
         device = "cpu"  # MOSS is untested on MPS; fall back to CPU for safety

--- a/backend/engines/moss_tts_v15/main.py
+++ b/backend/engines/moss_tts_v15/main.py
@@ -157,7 +157,12 @@ def _load_model(stdout):
     repo, revision = _model_source()
     # current_accelerator() returns None on CPU-only builds (no accelerator
     # compiled in) or when no accelerator is available; fall back to "cpu".
-    accel = torch.accelerator.current_accelerator(check_available=True)
+    # Existing manually provisioned venvs may predate torch.accelerator.
+    current_accelerator = getattr(getattr(torch, "accelerator", None), "current_accelerator", None)
+    if current_accelerator is None:
+        accel = torch.device("cuda") if torch.cuda.is_available() else None
+    else:
+        accel = current_accelerator(check_available=True)
     device = accel.type if accel is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
     if device == "mps":
         device = "cpu"  # MOSS is untested on MPS; fall back to CPU for safety

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1506,14 +1506,16 @@ def get_best_device():
     # ── DirectML — universal Windows GPU (probe reports this as "cpu") ─
     # Reached only when no torch family was detected (family == "cpu"), which is
     # exactly the DirectML case — the probe classifies DirectML hosts as cpu.
-    try:
-        import torch_directml
-        if torch_directml.device_count() > 0:
-            logger.info("Using DirectML device (GPU %d)", 0)
-            return str(torch_directml.device(0))
-    except ImportError:
-        pass
+    if family == "cpu":
+        try:
+            import torch_directml
+            if torch_directml.device_count() > 0:
+                logger.info("Using DirectML device (GPU %d)", 0)
+                return str(torch_directml.device(0))
+        except ImportError:
+            pass
 
+    # Other families need an explicitly compatible loader (e.g. NPU sidecars).
     return "cpu"
 
 _COMPILE_ERR_MODULE_PREFIXES = ("torch._dynamo", "torch._inductor", "torch.fx", "triton")

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1513,6 +1513,7 @@ def get_best_device():
                 logger.info("Using DirectML device (GPU %d)", 0)
                 return str(torch_directml.device(0))
         except ImportError:
+            # DirectML is optional; an absent package leaves CPU available.
             pass
 
     # Other families need an explicitly compatible loader (e.g. NPU sidecars).

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2371,7 +2371,7 @@ def list_backends() -> list[dict]:
           "one_click_install": bool,                # services.sidecar_install can provision it in-app
           "last_error":     Optional[str],          # cached most-recent failure
           "isolation_mode": "in-process" | "subprocess",
-          "gpu_compat":     list[str],              # subset of {cuda, rocm, mps, xpu, cpu}
+          "gpu_compat":     list[str],              # subset of {cuda, rocm, mps, xpu, npu, cpu}
           "supports_cloning": Optional[bool],       # True/False from the class attr; None when
                                                     #   model-dependent (property, e.g. mlx-audio)
           "effective_device": str,                  # device this engine uses on THIS host

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2298,7 +2298,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "omnivoice-gguf":"Bundled — runs the C++ omnivoice-tts binary in bin/. Quants download lazily from Serveurperso/OmniVoice-GGUF on first generate.",
     "supertonic3":   "uv sync --extra supertonic  (CPU-only ONNX, 31 langs, ~400 MB model on first use; OpenRAIL-M model license)",
     "pockettts":     "uv sync --extra pockettts  (Kyutai, CPU-only, ~100 MB model on first use; MIT code + CC-BY-4.0 weights; HF-gated, review terms and set HF_TOKEN)",
-    "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/CPU, no MPS; Apache-2.0)",
+    "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; runtime-available accelerator or CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
     "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/CPU, no MPS; Apache-2.0)",
 }

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2298,7 +2298,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "omnivoice-gguf":"Bundled — runs the C++ omnivoice-tts binary in bin/. Quants download lazily from Serveurperso/OmniVoice-GGUF on first generate.",
     "supertonic3":   "uv sync --extra supertonic  (CPU-only ONNX, 31 langs, ~400 MB model on first use; OpenRAIL-M model license)",
     "pockettts":     "uv sync --extra pockettts  (Kyutai, CPU-only, ~100 MB model on first use; MIT code + CC-BY-4.0 weights; HF-gated, review terms and set HF_TOKEN)",
-    "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; runtime-available accelerator or CPU, no MPS; Apache-2.0)",
+    "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
     "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/CPU, no MPS; Apache-2.0)",
 }

--- a/docs/engines/moss-tts-v15.md
+++ b/docs/engines/moss-tts-v15.md
@@ -25,7 +25,8 @@ interpreter, so MOSS runs behind
   **CPU** (fp32) — correct but slow.
 - **Device:** the sidecar uses a runtime-available PyTorch CUDA/ROCm, XPU,
   or registered NPU backend, otherwise CPU. The isolated engine venv needs the
-  matching torch/vendor integration. MPS still uses CPU. XPU/NPU routing is
+  matching torch/vendor integration. A failed accelerator probe falls back to
+  CPU, including in older venvs without the unified accelerator API. MPS still uses CPU. XPU/NPU routing is
   covered by mocked loader tests; physical-device synthesis has not been
   validated by this change.
 

--- a/docs/engines/moss-tts-v15.md
+++ b/docs/engines/moss-tts-v15.md
@@ -23,10 +23,11 @@ interpreter, so MOSS runs behind
   8 GB GPUs when quantized; the bf16 Transformers path used here is ~16 GB
   of weights, so a 16 GB+ GPU is the realistic CUDA target. It also runs on
   **CPU** (fp32) — correct but slow.
-- **Device:** CUDA when present, else CPU. **There is no MPS path** —
-  upstream documents only CUDA/CPU and the custom modelling code is
-  untested on Apple Silicon, so VoiceStudio never routes MOSS to MPS. On a
-  Mac it runs on CPU.
+- **Device:** the sidecar uses a runtime-available PyTorch CUDA/ROCm, XPU,
+  or registered NPU backend, otherwise CPU. The isolated engine venv needs the
+  matching torch/vendor integration. MPS still uses CPU. XPU/NPU routing is
+  covered by mocked loader tests; physical-device synthesis has not been
+  validated by this change.
 
 ## Install
 

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -190,3 +190,10 @@ Hit a wall? See [docs/install/troubleshooting.md](troubleshooting.md).
 The in-app error UI (the React error boundary that fires on backend errors)
 includes an **"Open docs for this error"** button — that button deeplinks
 back into this docs tree at the right section for the error class.
+
+### Fast process shutdown
+
+A process that exits while shutdown is signalling it can report a macOS
+permission error. VoiceStudio accepts this only after confirming the original
+process exited without being reaped, then still waits for nested operations to
+drain. Live-process permission errors and lost process ownership remain failures.

--- a/frontend/src-tauri/src/tools.rs
+++ b/frontend/src-tauri/src/tools.rs
@@ -73,6 +73,33 @@ pub struct OwnedProcessTree {
     job: std::os::windows::io::OwnedHandle,
 }
 
+// Keep the delivery and post-error ownership probe together: the root may
+// exit between any earlier liveness check and either TERM or KILL delivery.
+#[cfg(unix)]
+fn signal_process_group_with(
+    signal: libc::c_int,
+    darwin: bool,
+    send: impl FnOnce(libc::c_int) -> io::Result<()>,
+    root_exited_unreaped: impl FnOnce() -> io::Result<bool>,
+) -> io::Result<()> {
+    match send(signal) {
+        Ok(()) => Ok(()),
+        Err(error) if error.raw_os_error() == Some(libc::ESRCH) => Ok(()),
+        Err(error) if darwin && error.raw_os_error() == Some(libc::EPERM) => {
+            // Darwin can report EPERM when the last signalable member exited
+            // during delivery. Accept only a newly verified unreaped root:
+            // live roots, lost identity and probe failures remain errors.
+            // Callers must still join nested drain before reaping that root.
+            if root_exited_unreaped()? {
+                Ok(())
+            } else {
+                Err(error)
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
 impl OwnedProcessTree {
     #[cfg(unix)]
     fn root_exited_unreaped(&self) -> io::Result<bool> {
@@ -141,15 +168,18 @@ impl OwnedProcessTree {
 
     #[cfg(unix)]
     fn signal_group(&self, signal: libc::c_int) -> io::Result<()> {
-        if unsafe { libc::kill(-self.process_group, signal) } == 0 {
-            return Ok(());
-        }
-        let error = io::Error::last_os_error();
-        if error.raw_os_error() == Some(libc::ESRCH) {
-            Ok(())
-        } else {
-            Err(error)
-        }
+        signal_process_group_with(
+            signal,
+            cfg!(target_os = "macos"),
+            |signal| {
+                if unsafe { libc::kill(-self.process_group, signal) } == 0 {
+                    Ok(())
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            },
+            || self.root_exited_unreaped(),
+        )
     }
 
     fn force_terminate(&mut self) -> io::Result<()> {
@@ -168,27 +198,6 @@ impl OwnedProcessTree {
                 TerminateJobObject(HANDLE(self.job.as_raw_handle()), 1)
                     .map_err(windows_error)?;
             }
-        }
-        self.terminated = true;
-        Ok(())
-    }
-
-    #[cfg(unix)]
-    fn force_terminate_after_root_exit(&mut self) -> io::Result<()> {
-        if self.terminated {
-            return Ok(());
-        }
-        match self.signal_group(libc::SIGKILL) {
-            Ok(()) => {}
-            #[cfg(target_os = "macos")]
-            Err(error) if error.raw_os_error() == Some(libc::EPERM) => {
-                // XNU excludes zombies when iterating an explicit process
-                // group, then reports EPERM when it found no signalable live
-                // member. The unreaped root still reserves this exact group;
-                // the nested-drain join that follows catches any descendant
-                // which actually survived the signal attempt.
-            }
-            Err(error) => return Err(error),
         }
         self.terminated = true;
         Ok(())
@@ -446,7 +455,7 @@ pub fn contained_child_exit(
             Ok(true) => {
                 // Do not reap the root until group cleanup succeeds: the
                 // zombie is what keeps this process-group ID non-reusable.
-                tree.force_terminate_after_root_exit()?;
+                tree.force_terminate()?;
                 tree.wait_nested_drain(nested_drain_timeout())?;
                 let status = child.try_wait()?;
                 return Ok(status);
@@ -495,7 +504,7 @@ pub fn terminate_process_tree(
     #[cfg(unix)]
     match tree.root_exited_unreaped() {
         Ok(true) => {
-            tree.force_terminate_after_root_exit()?;
+            tree.force_terminate()?;
             tree.wait_nested_drain(nested_drain_timeout())?;
             return child.wait();
         }
@@ -522,7 +531,7 @@ pub fn terminate_process_tree(
     while std::time::Instant::now() < deadline {
         #[cfg(unix)]
         if tree.root_exited_unreaped()? {
-            tree.force_terminate_after_root_exit()?;
+            tree.force_terminate()?;
             tree.wait_nested_drain(nested_drain_timeout())?;
             return child.wait();
         }
@@ -1206,6 +1215,64 @@ fn redact_home_prefix(text: &str, home: &str) -> String {
 mod uv_tests {
     use super::*;
     use std::ffi::OsStr;
+
+    #[cfg(unix)]
+    #[test]
+    fn darwin_group_signal_recovers_exit_during_term_or_kill_delivery() {
+        for signal in [libc::SIGTERM, libc::SIGKILL] {
+            let exited = std::cell::Cell::new(false);
+            signal_process_group_with(
+                signal,
+                true,
+                |delivered| {
+                    assert_eq!(delivered, signal);
+                    assert!(!exited.replace(true));
+                    Err(io::Error::from_raw_os_error(libc::EPERM))
+                },
+                || {
+                    assert!(exited.get(), "ownership must be checked after failed delivery");
+                    Ok(true)
+                },
+            )
+            .expect("an exited unreaped root keeps its group reserved until drain completes");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn darwin_group_signal_rejects_live_reaped_or_unverifiable_roots() {
+        for signal in [libc::SIGTERM, libc::SIGKILL] {
+            for (probe, expected) in [
+                (Ok(false), libc::EPERM),
+                (Err(libc::ECHILD), libc::ECHILD),
+                (Err(libc::EIO), libc::EIO),
+            ] {
+                let error = signal_process_group_with(
+                    signal,
+                    true,
+                    |_| Err(io::Error::from_raw_os_error(libc::EPERM)),
+                    || probe.map_err(io::Error::from_raw_os_error),
+                )
+                .expect_err("only a confirmed unreaped exit can explain Darwin EPERM");
+                assert_eq!(error.raw_os_error(), Some(expected));
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn group_signal_preserves_other_permission_errors_and_platforms() {
+        for (darwin, errno) in [(false, libc::EPERM), (true, libc::EACCES)] {
+            let error = signal_process_group_with(
+                libc::SIGKILL,
+                darwin,
+                |_| Err(io::Error::from_raw_os_error(errno)),
+                || panic!("unrelated errors must not use the Darwin exit exception"),
+            )
+            .unwrap_err();
+            assert_eq!(error.raw_os_error(), Some(errno));
+        }
+    }
 
     #[cfg(unix)]
     #[test]

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "تعذّر تحميل إعداد الجهاز",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Geräteeinstellung konnte nicht geladen werden",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -934,6 +934,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Failed to load device setting",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "No se pudo cargar el ajuste del dispositivo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Impossible de charger le réglage du périphérique",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "डिवाइस सेटिंग लोड नहीं हो सकी",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Gagal memuat pengaturan perangkat",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Impossibile caricare l'impostazione del dispositivo",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "デバイス設定を読み込めませんでした",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "장치 설정을 불러오지 못했습니다",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Apparaatinstelling kon niet worden geladen",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Nie udało się wczytać ustawienia urządzenia",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Falha ao carregar a configuração do dispositivo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Не удалось загрузить настройку устройства",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Kunde inte läsa in enhetsinställningen",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "โหลดการตั้งค่าอุปกรณ์ไม่สำเร็จ",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Aygıt ayarı yüklenemedi",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Не вдалося завантажити налаштування пристрою",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "Không tải được cài đặt thiết bị",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -586,6 +586,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "无法加载设备设置",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -334,6 +334,7 @@
     "device_family_cuda": "NVIDIA GPU (CUDA)",
     "device_family_rocm": "AMD GPU (ROCm)",
     "device_family_xpu": "Intel GPU (XPU)",
+    "device_family_npu": "NPU",
     "device_family_mps": "Apple GPU (MPS)",
     "device_family_cpu": "CPU",
     "device_load_failed": "無法載入裝置設定",

--- a/tests/backend/api/test_engines_route_shape.py
+++ b/tests/backend/api/test_engines_route_shape.py
@@ -82,7 +82,7 @@ _REQUIRED_KEYS = {
     "effective_device", "routing_status", "routing_reason",
 }
 _TTS_ASR_STATUSES = {"accelerated", "cpu_fallback", "cpu_only", "unavailable"}
-_VALID_FAMILIES = {"cuda", "rocm", "mps", "xpu", "cpu"}
+_VALID_FAMILIES = {"cuda", "rocm", "mps", "xpu", "npu", "cpu"}
 
 
 def test_engines_response_includes_new_fields(fresh_app):

--- a/tests/backend/test_compute_device_settings.py
+++ b/tests/backend/test_compute_device_settings.py
@@ -109,3 +109,14 @@ def test_env_pin_is_reported_and_wins(fresh_app, monkeypatch):
     r = c.put("/api/settings/compute-device", json={"value": "auto"})
     assert r.status_code == 200
     assert r.json()["value"] == "cpu"
+
+
+def test_auto_summary_reports_registered_npu(fresh_app, monkeypatch):
+    from core import device_caps
+    monkeypatch.setattr(device_caps, 'detect_host_caps', lambda: device_caps.HostCaps(
+        family='npu', available_families=('npu', 'cpu'),
+    ))
+    body = _client(fresh_app).get('/api/settings/compute-device').json()
+    assert body['auto_family'] == body['effective_family'] == 'npu'
+    # Detection does not globally opt unrelated engines into NPU execution.
+    assert 'npu' not in body['choices']

--- a/tests/test_asr_gpu_compat.py
+++ b/tests/test_asr_gpu_compat.py
@@ -34,7 +34,7 @@ _EXPECTED = {
 # is_available — e.g. parakeet-mlx gates on Apple Silicon via mlx_supported()).
 _GPU_ONLY: set[str] = {"parakeet-mlx"}
 
-_VALID = {"cuda", "rocm", "mps", "xpu", "cpu"}
+_VALID = {"cuda", "rocm", "mps", "xpu", "npu", "cpu"}
 
 
 def _cls(engine_id):

--- a/tests/test_device_caps.py
+++ b/tests/test_device_caps.py
@@ -274,7 +274,10 @@ def test_generic_directml_loader_respects_selected_family(monkeypatch, npu_avail
         "torch_directml": types.SimpleNamespace(device_count=lambda: 1, device=lambda i: "privateuseone:0"),
     }
     with patch.dict("sys.modules", modules):
-        caps = live_caps.refresh()
+        try:
+            caps = live_caps.refresh()
+        finally:
+            live_caps.detect_host_caps.cache_clear()
     assert caps.family == ("npu" if npu_available else "cpu")
     monkeypatch.setattr(live_caps, "detect_host_caps", lambda: caps)
     monkeypatch.setattr(model_manager, "_lazy_torch", lambda: torch)

--- a/tests/test_device_caps.py
+++ b/tests/test_device_caps.py
@@ -235,3 +235,24 @@ def test_result_is_cached_until_refresh():
 def teardown_module(_module):
     # Drop any cached mock-derived result so other test modules re-probe clean.
     device_caps.detect_host_caps.cache_clear()
+
+
+def test_builtin_xpu_does_not_require_ipex():
+    caps = _probe_with({'torch': _torch_mock(xpu_available=True), 'intel_extension_for_pytorch': None})
+    assert caps.family == 'xpu'
+
+
+def test_registered_npu_is_reported_without_importing_vendor_packages():
+    torch = _torch_mock()
+    torch.npu = types.SimpleNamespace(is_available=lambda: True, get_device_name=lambda i: 'Ascend')
+    caps = _probe_with({'torch': torch, 'intel_extension_for_pytorch': None})
+    assert caps.family == 'npu'
+    assert caps.available_families == ('npu', 'cpu')
+    assert caps.device_name == 'Ascend'
+
+
+def test_unavailable_npu_does_not_claim_acceleration():
+    torch = _torch_mock()
+    torch.npu = types.SimpleNamespace(is_available=lambda: False)
+    caps = _probe_with({'torch': torch, 'intel_extension_for_pytorch': None})
+    assert caps.family == 'cpu'

--- a/tests/test_device_caps.py
+++ b/tests/test_device_caps.py
@@ -262,17 +262,21 @@ def test_unavailable_npu_does_not_claim_acceleration():
 
 @pytest.mark.parametrize("npu_available,expected", [(True, "cpu"), (False, "privateuseone:0")])
 def test_generic_directml_loader_respects_selected_family(monkeypatch, npu_available, expected):
+    import importlib
     from services import model_manager
 
+    # Other tests reload core modules; patch the same module the loader imports.
+    live_caps = importlib.import_module("core.device_caps")
     torch = _torch_mock()
     torch.npu = types.SimpleNamespace(is_available=lambda: npu_available, get_device_name=lambda i: "NPU")
     modules = {
         "torch": torch,
         "torch_directml": types.SimpleNamespace(device_count=lambda: 1, device=lambda i: "privateuseone:0"),
     }
-    caps = _probe_with(modules)
+    with patch.dict("sys.modules", modules):
+        caps = live_caps.refresh()
     assert caps.family == ("npu" if npu_available else "cpu")
-    monkeypatch.setattr(device_caps, "detect_host_caps", lambda: caps)
+    monkeypatch.setattr(live_caps, "detect_host_caps", lambda: caps)
     monkeypatch.setattr(model_manager, "_lazy_torch", lambda: torch)
     with patch.dict("sys.modules", modules):
         assert model_manager.get_best_device() == expected

--- a/tests/test_device_caps.py
+++ b/tests/test_device_caps.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import types
 from unittest.mock import patch
 
+import pytest
+
 from core import device_caps
 from core.device_caps import DIRECTML_MARKER, KERNEL_RISK_MARKER
 
@@ -256,3 +258,21 @@ def test_unavailable_npu_does_not_claim_acceleration():
     torch.npu = types.SimpleNamespace(is_available=lambda: False)
     caps = _probe_with({'torch': torch, 'intel_extension_for_pytorch': None})
     assert caps.family == 'cpu'
+
+
+@pytest.mark.parametrize("npu_available,expected", [(True, "cpu"), (False, "privateuseone:0")])
+def test_generic_directml_loader_respects_selected_family(monkeypatch, npu_available, expected):
+    from services import model_manager
+
+    torch = _torch_mock()
+    torch.npu = types.SimpleNamespace(is_available=lambda: npu_available, get_device_name=lambda i: "NPU")
+    modules = {
+        "torch": torch,
+        "torch_directml": types.SimpleNamespace(device_count=lambda: 1, device=lambda i: "privateuseone:0"),
+    }
+    caps = _probe_with(modules)
+    assert caps.family == ("npu" if npu_available else "cpu")
+    monkeypatch.setattr(device_caps, "detect_host_caps", lambda: caps)
+    monkeypatch.setattr(model_manager, "_lazy_torch", lambda: torch)
+    with patch.dict("sys.modules", modules):
+        assert model_manager.get_best_device() == expected

--- a/tests/test_engine_routing.py
+++ b/tests/test_engine_routing.py
@@ -132,7 +132,7 @@ def test_empty_compat_is_defensive_cpu_only():
 
 # ── Contract guarantees ───────────────────────────────────────────────────
 def test_never_emits_n_a():
-    for fam in ("cuda", "rocm", "mps", "xpu", "cpu"):
+    for fam in ("cuda", "rocm", "mps", "xpu", "npu", "cpu"):
         for compat in ((), ("cpu",), ("cuda",), ("cuda", "cpu"), ("mps", "cpu")):
             assert resolve_routing(compat, _caps(fam))["routing_status"] != "n/a"
 

--- a/tests/test_engine_routing.py
+++ b/tests/test_engine_routing.py
@@ -133,7 +133,7 @@ def test_empty_compat_is_defensive_cpu_only():
 # ── Contract guarantees ───────────────────────────────────────────────────
 def test_never_emits_n_a():
     for fam in ("cuda", "rocm", "mps", "xpu", "npu", "cpu"):
-        for compat in ((), ("cpu",), ("cuda",), ("cuda", "cpu"), ("mps", "cpu")):
+        for compat in ((), ("cpu",), ("cuda",), ("cuda", "cpu"), ("mps", "cpu"), ("npu", "cpu")):
             assert resolve_routing(compat, _caps(fam))["routing_status"] != "n/a"
 
 
@@ -197,3 +197,9 @@ def test_header_reason_capped_at_256():
 def test_header_reason_scrubs_home_path():
     out = header_safe_reason("failed at /home/alice/model")
     assert "/home/alice" not in out and "~" in out
+
+
+def test_npu_compatible_engine_uses_accelerated_route():
+    assert resolve_routing(("npu", "cpu"), _caps("npu")) == {
+        "effective_device": "npu", "routing_status": "accelerated", "routing_reason": None,
+    }

--- a/tests/test_moss_tts_v15.py
+++ b/tests/test_moss_tts_v15.py
@@ -106,12 +106,12 @@ def test_audited_custom_remote_code_requires_both_opt_ins(monkeypatch):
 # ── hardware honesty (cross-platform rule) ─────────────────────────────────
 
 
-def test_gpu_compat_cuda_cpu_no_mps():
+def test_gpu_compat_matches_accelerator_paths_without_mps():
     """MPS is undocumented/untested upstream — we must not claim it."""
     from engines.moss_tts_v15 import MossTTSV15Backend
 
-    assert MossTTSV15Backend.gpu_compat == ("cuda", "cpu"), (
-        f"expected ('cuda', 'cpu'), got {MossTTSV15Backend.gpu_compat!r}"
+    assert MossTTSV15Backend.gpu_compat == ("cuda", "rocm", "xpu", "npu", "cpu"), (
+        f"unexpected device targets: {MossTTSV15Backend.gpu_compat!r}"
     )
 
 
@@ -199,3 +199,41 @@ def test_generate_without_ref_audio_omits_reference(monkeypatch):
     MossTTSV15Backend().generate("just text")
     assert "ref_audio" not in captured
     assert "tokens" not in captured
+
+
+@pytest.mark.parametrize('family', [None, 'cuda', 'xpu', 'npu', 'mps'])
+def test_loader_device_matches_routing(monkeypatch, family):
+    """Exercise model + tokenizer placement without importing optional weights."""
+    import io
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from engines.moss_tts_v15 import main, MossTTSV15Backend
+    from core.device_caps import HostCaps
+    from services.engine_routing import resolve_routing
+
+    expected = family if family not in (None, 'mps') else 'cpu'
+    accelerator = Mock(return_value=SimpleNamespace(type=family) if family else None)
+    monkeypatch.setitem(sys.modules, 'torch', SimpleNamespace(
+        accelerator=SimpleNamespace(current_accelerator=accelerator),
+        bfloat16='bf16', float32='fp32',
+    ))
+    processor = Mock()
+    processor.model_config.sampling_rate = 24000
+    tokenizer = processor.audio_tokenizer
+    model = Mock()
+    model.to.return_value = model
+    factory = Mock()
+    factory.from_pretrained.return_value = model
+    monkeypatch.setitem(sys.modules, 'transformers', SimpleNamespace(
+        AutoModel=factory,
+        AutoProcessor=SimpleNamespace(from_pretrained=lambda *a, **kw: processor),
+    ))
+    monkeypatch.setattr(main, '_state', None)
+    monkeypatch.setattr(main, '_model_source', lambda: ('local-fixture', 'a' * 40))
+    state = main._load_model(io.BytesIO())
+    accelerator.assert_called_once_with(check_available=True)
+    model.to.assert_called_once_with(expected)
+    tokenizer.to.assert_called_once_with(expected)
+    assert factory.from_pretrained.call_args.kwargs['torch_dtype'] == ('fp32' if expected == 'cpu' else 'bf16')
+    caps = HostCaps(family=family or 'cpu', available_families=(family, 'cpu') if family else ('cpu',))
+    assert resolve_routing(MossTTSV15Backend.gpu_compat, caps)['effective_device'] == state[2]

--- a/tests/test_moss_tts_v15.py
+++ b/tests/test_moss_tts_v15.py
@@ -201,8 +201,8 @@ def test_generate_without_ref_audio_omits_reference(monkeypatch):
     assert "tokens" not in captured
 
 
-@pytest.mark.parametrize('family', [None, 'cuda', 'xpu', 'npu', 'mps'])
-def test_loader_device_matches_routing(monkeypatch, family):
+@pytest.mark.parametrize('family,legacy', [(None, False), ('cuda', False), ('xpu', False), ('npu', False), ('mps', False), (None, True), ('cuda', True)])
+def test_loader_device_matches_routing(monkeypatch, family, legacy):
     """Exercise model + tokenizer placement without importing optional weights."""
     import io
     from types import SimpleNamespace
@@ -214,7 +214,9 @@ def test_loader_device_matches_routing(monkeypatch, family):
     expected = family if family not in (None, 'mps') else 'cpu'
     accelerator = Mock(return_value=SimpleNamespace(type=family) if family else None)
     monkeypatch.setitem(sys.modules, 'torch', SimpleNamespace(
-        accelerator=SimpleNamespace(current_accelerator=accelerator),
+        accelerator=SimpleNamespace() if legacy else SimpleNamespace(current_accelerator=accelerator),
+        cuda=SimpleNamespace(is_available=lambda: family == 'cuda'),
+        device=lambda value: SimpleNamespace(type=value),
         bfloat16='bf16', float32='fp32',
     ))
     processor = Mock()
@@ -231,7 +233,8 @@ def test_loader_device_matches_routing(monkeypatch, family):
     monkeypatch.setattr(main, '_state', None)
     monkeypatch.setattr(main, '_model_source', lambda: ('local-fixture', 'a' * 40))
     state = main._load_model(io.BytesIO())
-    accelerator.assert_called_once_with(check_available=True)
+    if not legacy:
+        accelerator.assert_called_once_with(check_available=True)
     model.to.assert_called_once_with(expected)
     tokenizer.to.assert_called_once_with(expected)
     assert factory.from_pretrained.call_args.kwargs['torch_dtype'] == ('fp32' if expected == 'cpu' else 'bf16')

--- a/tests/test_moss_tts_v15.py
+++ b/tests/test_moss_tts_v15.py
@@ -54,7 +54,9 @@ def test_install_hint_present():
     assert "OMNIVOICE_MOSS_TTS_V15_DIR" in hint
     assert "OpenMOSS" in hint
     assert "CUDA/CPU" not in hint
-    assert "runtime-available accelerator or CPU" in hint
+    backend = importlib.import_module("engines.moss_tts_v15").MossTTSV15Backend
+    for family in backend.gpu_compat:
+        assert ("ROCm" if family == "rocm" else family.upper()) in hint
 
 
 def test_sidecar_script_ships():

--- a/tests/test_moss_tts_v15.py
+++ b/tests/test_moss_tts_v15.py
@@ -201,8 +201,12 @@ def test_generate_without_ref_audio_omits_reference(monkeypatch):
     assert "tokens" not in captured
 
 
-@pytest.mark.parametrize('family,legacy', [(None, False), ('cuda', False), ('xpu', False), ('npu', False), ('mps', False), (None, True), ('cuda', True)])
-def test_loader_device_matches_routing(monkeypatch, family, legacy):
+@pytest.mark.parametrize('family,legacy,probe_raises', [
+    (None, False, False), ('cuda', False, False), ('xpu', False, False),
+    ('npu', False, False), ('mps', False, False), (None, True, False),
+    ('cuda', True, False), (None, False, True), (None, True, True),
+])
+def test_loader_device_matches_routing(monkeypatch, family, legacy, probe_raises):
     """Exercise model + tokenizer placement without importing optional weights."""
     import io
     from types import SimpleNamespace
@@ -213,9 +217,13 @@ def test_loader_device_matches_routing(monkeypatch, family, legacy):
 
     expected = family if family not in (None, 'mps') else 'cpu'
     accelerator = Mock(return_value=SimpleNamespace(type=family) if family else None)
+    cuda_available = Mock(return_value=family == 'cuda')
+    if probe_raises:
+        accelerator.side_effect = RuntimeError('driver initialization failed')
+        cuda_available.side_effect = RuntimeError('driver initialization failed')
     monkeypatch.setitem(sys.modules, 'torch', SimpleNamespace(
         accelerator=SimpleNamespace() if legacy else SimpleNamespace(current_accelerator=accelerator),
-        cuda=SimpleNamespace(is_available=lambda: family == 'cuda'),
+        cuda=SimpleNamespace(is_available=cuda_available),
         device=lambda value: SimpleNamespace(type=value),
         bfloat16='bf16', float32='fp32',
     ))
@@ -240,3 +248,15 @@ def test_loader_device_matches_routing(monkeypatch, family, legacy):
     assert factory.from_pretrained.call_args.kwargs['torch_dtype'] == ('fp32' if expected == 'cpu' else 'bf16')
     caps = HostCaps(family=family or 'cpu', available_families=(family, 'cpu') if family else ('cpu',))
     assert resolve_routing(MossTTSV15Backend.gpu_compat, caps)['effective_device'] == state[2]
+
+
+def test_availability_text_does_not_exclude_declared_devices(monkeypatch):
+    from engines.moss_tts_v15 import MossTTSV15Backend, bootstrap
+
+    assert "CUDA/CPU" not in MossTTSV15Backend.display_name
+    for installed in (False, True):
+        monkeypatch.setattr(bootstrap, "is_moss_tts_v15_installed", lambda: installed)
+        available, reason = MossTTSV15Backend.is_available()
+        assert available is installed
+        assert "CUDA or CPU only" not in reason
+        assert "CUDA when present, else CPU" not in reason

--- a/tests/test_moss_tts_v15.py
+++ b/tests/test_moss_tts_v15.py
@@ -53,6 +53,8 @@ def test_install_hint_present():
     hint = _INSTALL_HINTS.get("moss-tts-v15", "")
     assert "OMNIVOICE_MOSS_TTS_V15_DIR" in hint
     assert "OpenMOSS" in hint
+    assert "CUDA/CPU" not in hint
+    assert "runtime-available accelerator or CPU" in hint
 
 
 def test_sidecar_script_ships():

--- a/tests/test_setup_preflight.py
+++ b/tests/test_setup_preflight.py
@@ -145,7 +145,7 @@ def test_preflight_device_summary(client):
     assert d["gpu_backend"] in {"cuda", "rocm", "mps", "cpu"}
     assert d["gpu_vendor"] in {"nvidia", "amd", "apple", "intel", "unknown", "none"}
     # #21: canonical-probe family + VRAM joined the device summary.
-    assert d["gpu_family"] in {"cuda", "rocm", "mps", "xpu", "cpu"}
+    assert d["gpu_family"] in {"cuda", "rocm", "mps", "xpu", "npu", "cpu"}
     assert isinstance(d["vram_gb"], (int, float))
 
 


### PR DESCRIPTION
## Problem

The MOSS-TTS-v1.5 engine hardcodes device selection to:

```python
device = "cuda" if torch.cuda.is_available() else "cpu"
dtype = torch.bfloat16 if device == "cuda" else torch.float32
```

On an Ascend NPU (torch_npu) host, `torch.cuda.is_available()` is **False**, so the entire model silently falls back to CPU inference in fp32 — never using the NPU accelerator — even though the accelerator is available and bf16 is supported.

The same bug affects any non-CUDA accelerator: Intel XPU, AMD ROCm, etc.

## Root cause

`torch.cuda.is_available()` is CUDA-specific and does not detect other accelerators. The correct device-agnostic API is `torch.accelerator.current_accelerator()` which returns the active backend regardless of type.

## Fix

Replace the CUDA-or-CPU hardcode with `torch.accelerator.current_accelerator().type`:

- Use `torch.accelerator.current_accelerator()` to detect the active device (CUDA / NPU / XPU / MPS / CPU)
- MPS is still excluded (MOSS is untested on Apple Silicon per the comment)
- dtype is bf16 for any GPU-class accelerator, fp32 on CPU

## Verification

Verified on Ascend 910B (torch 2.14, torch_npu, 4 NPU):

|          | Before (CUDA hardcode) | After (accelerator API) |
|----------|----------------------|------------------------|
| device   | `"cpu"` (wrong)      | `"npu"` (correct)      |
| dtype    | `float32` (slow)     | `bfloat16` (fast)      |
| CUDA_avail | `False`            | `False`                |

No changes to the MPS exclusion or the existing bf16-on-CPU-safe logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
MOSS-TTS-v1.5 and device routing now support CUDA, ROCm, XPU, and registered NPU accelerators, with CPU fallback for unavailable or failed probes and MPS. Accelerators use bfloat16, while CPU uses float32; older PyTorch environments without `torch.accelerator` remain supported. Verify optional driver failures and non-CUDA backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->