### PR TITLE
fix(tts-engines): select device via torch.accelerator in confucius4 and dots_tts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Confucius accelerator routing matches device selection, and dots.tts keeps safe CPU precision on non-CUDA accelerators (#1831) — thanks @li-lizhe!
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- Confucius accelerator routing matches device selection, and dots.tts keeps safe CPU precision on non-CUDA accelerators (#1831) — thanks @li-lizhe!
+- Confucius accelerator routing tolerates failed device probes, and dots.tts keeps safe default precision on non-CUDA hosts (#1831) — thanks @li-lizhe!
 
 
 ## [0.5.2] — 2026-09-02

--- a/backend/engines/confucius4/__init__.py
+++ b/backend/engines/confucius4/__init__.py
@@ -62,9 +62,9 @@ class Confucius4Backend(SubprocessBackend):
     # Upstream vocoder rate (config target_sample_rate) — confirmed 22 050 Hz by
     # a live run (2026-07-02); still re-read from the sidecar's ready/audio frames.
     _DEFAULT_SAMPLE_RATE = 22050
-    # CUDA fast path + CPU fallback, both exercised (CPU end-to-end validated).
-    # No MPS claim — upstream has no Metal path.
-    gpu_compat = ("cuda", "cpu")
+    # Match device propagation into upstream .to(device). XPU/NPU routing is
+    # contract-tested, not a claim of physical-hardware synthesis validation.
+    gpu_compat = ("cuda", "rocm", "xpu", "npu", "cpu")
 
     @classmethod
     def is_available(cls) -> tuple[bool, str]:

--- a/backend/engines/confucius4/__init__.py
+++ b/backend/engines/confucius4/__init__.py
@@ -56,7 +56,7 @@ class Confucius4Backend(SubprocessBackend):
 
     id = "confucius4-tts"
     display_name = (
-        "Confucius4-TTS (LLM, 14 langs, cross-lingual zero-shot clone, CUDA/CPU, Apache-2.0)"
+        "Confucius4-TTS (LLM, 14 langs, cross-lingual zero-shot clone, Apache-2.0)"
     )
     supports_voice_design = False  # timbre comes from a reference clip
     # Upstream vocoder rate (config target_sample_rate) — confirmed 22 050 Hz by

--- a/backend/engines/confucius4/main.py
+++ b/backend/engines/confucius4/main.py
@@ -115,7 +115,9 @@ def _load_model(stdout):
     import torch
     from confuciustts.cli.inference import ConfuciusTTS  # type: ignore[import-not-found]
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = torch.accelerator.current_accelerator().type  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
+    if device == "mps":
+        device = "cpu"  # ConfuciusTTS is untested on MPS; fall back to CPU for safety
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 50})
 
     _model = ConfuciusTTS(config_path=_config_path(), device=device)

--- a/backend/engines/confucius4/main.py
+++ b/backend/engines/confucius4/main.py
@@ -115,7 +115,8 @@ def _load_model(stdout):
     import torch
     from confuciustts.cli.inference import ConfuciusTTS  # type: ignore[import-not-found]
 
-    device = torch.accelerator.current_accelerator().type  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
+    device = torch.accelerator.current_accelerator(check_available=True)
+    device = device.type if device is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
     if device == "mps":
         device = "cpu"  # ConfuciusTTS is untested on MPS; fall back to CPU for safety
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 50})

--- a/backend/engines/confucius4/main.py
+++ b/backend/engines/confucius4/main.py
@@ -115,7 +115,12 @@ def _load_model(stdout):
     import torch
     from confuciustts.cli.inference import ConfuciusTTS  # type: ignore[import-not-found]
 
-    device = torch.accelerator.current_accelerator(check_available=True)
+    # Existing manually provisioned venvs may predate torch.accelerator.
+    current_accelerator = getattr(getattr(torch, "accelerator", None), "current_accelerator", None)
+    if current_accelerator is None:
+        device = torch.device("cuda") if torch.cuda.is_available() else None
+    else:
+        device = current_accelerator(check_available=True)
     device = device.type if device is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
     if device == "mps":
         device = "cpu"  # MPS was slower than CPU in the existing validation run

--- a/backend/engines/confucius4/main.py
+++ b/backend/engines/confucius4/main.py
@@ -115,13 +115,16 @@ def _load_model(stdout):
     import torch
     from confuciustts.cli.inference import ConfuciusTTS  # type: ignore[import-not-found]
 
-    # Existing manually provisioned venvs may predate torch.accelerator.
-    current_accelerator = getattr(getattr(torch, "accelerator", None), "current_accelerator", None)
-    if current_accelerator is None:
-        device = torch.device("cuda") if torch.cuda.is_available() else None
-    else:
-        device = current_accelerator(check_available=True)
-    device = device.type if device is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
+    try:
+        # Existing manually provisioned venvs may predate torch.accelerator.
+        current_accelerator = getattr(getattr(torch, "accelerator", None), "current_accelerator", None)
+        if current_accelerator is None:
+            device = torch.device("cuda") if torch.cuda.is_available() else None
+        else:
+            device = current_accelerator(check_available=True)
+        device = device.type if device is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
+    except Exception:
+        device = "cpu"  # Broken accelerator drivers must not block CPU loading.
     if device == "mps":
         device = "cpu"  # MPS was slower than CPU in the existing validation run
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 50})

--- a/backend/engines/confucius4/main.py
+++ b/backend/engines/confucius4/main.py
@@ -104,7 +104,7 @@ def _ensure_clone_on_sys_path() -> None:
 
 
 def _load_model(stdout):
-    """Cold-construct the Confucius4 model (CUDA, else CPU — both validated)."""
+    """Cold-construct using an available torch accelerator, with CPU fallback."""
     global _model
     if _model is not None:
         return _model
@@ -118,7 +118,7 @@ def _load_model(stdout):
     device = torch.accelerator.current_accelerator(check_available=True)
     device = device.type if device is not None else "cpu"  # 'cuda', 'npu', 'mps', 'xpu', 'cpu'
     if device == "mps":
-        device = "cpu"  # ConfuciusTTS is untested on MPS; fall back to CPU for safety
+        device = "cpu"  # MPS was slower than CPU in the existing validation run
     _send(stdout, {"op": "progress", "stage": "loading_model", "percent": 50})
 
     _model = ConfuciusTTS(config_path=_config_path(), device=device)

--- a/backend/engines/dots_tts/main.py
+++ b/backend/engines/dots_tts/main.py
@@ -115,7 +115,11 @@ def _load_runtime(stdout):
     from dots_tts.runtime import DotsTtsRuntime  # type: ignore[import-not-found]
 
     repo = os.environ.get("OMNIVOICE_DOTS_TTS_MODEL", _DEFAULT_REPO)
-    default_precision = "bfloat16" if torch.accelerator.current_accelerator().type != "cpu" else "float32"
+    # current_accelerator() returns None on CPU-only builds; MPS is also
+    # excluded because DotsTtsRuntime is untested on MPS (use fp32).
+    accel = torch.accelerator.current_accelerator(check_available=True)
+    accel_type = accel.type if accel is not None else "cpu"
+    default_precision = "bfloat16" if accel_type not in ("cpu", "mps") else "float32"
     precision = os.environ.get("OMNIVOICE_DOTS_TTS_PRECISION", default_precision)
     optimize = os.environ.get("OMNIVOICE_DOTS_TTS_OPTIMIZE", "0") == "1"
 

--- a/backend/engines/dots_tts/main.py
+++ b/backend/engines/dots_tts/main.py
@@ -115,7 +115,7 @@ def _load_runtime(stdout):
     from dots_tts.runtime import DotsTtsRuntime  # type: ignore[import-not-found]
 
     repo = os.environ.get("OMNIVOICE_DOTS_TTS_MODEL", _DEFAULT_REPO)
-    default_precision = "bfloat16" if torch.cuda.is_available() else "float32"
+    default_precision = "bfloat16" if torch.accelerator.current_accelerator().type != "cpu" else "float32"
     precision = os.environ.get("OMNIVOICE_DOTS_TTS_PRECISION", default_precision)
     optimize = os.environ.get("OMNIVOICE_DOTS_TTS_OPTIMIZE", "0") == "1"
 

--- a/backend/engines/dots_tts/main.py
+++ b/backend/engines/dots_tts/main.py
@@ -115,11 +115,9 @@ def _load_runtime(stdout):
     from dots_tts.runtime import DotsTtsRuntime  # type: ignore[import-not-found]
 
     repo = os.environ.get("OMNIVOICE_DOTS_TTS_MODEL", _DEFAULT_REPO)
-    # current_accelerator() returns None on CPU-only builds; MPS is also
-    # excluded because DotsTtsRuntime is untested on MPS (use fp32).
-    accel = torch.accelerator.current_accelerator(check_available=True)
-    accel_type = accel.type if accel is not None else "cpu"
-    default_precision = "bfloat16" if accel_type not in ("cpu", "mps") else "float32"
+    # Match DotsTtsRuntime's own CUDA/CPU selection. Its _check_torch_env
+    # rejects half precision without CUDA, even when an XPU/NPU is available.
+    default_precision = "bfloat16" if torch.cuda.is_available() else "float32"
     precision = os.environ.get("OMNIVOICE_DOTS_TTS_PRECISION", default_precision)
     optimize = os.environ.get("OMNIVOICE_DOTS_TTS_OPTIMIZE", "0") == "1"
 

--- a/backend/engines/dots_tts/main.py
+++ b/backend/engines/dots_tts/main.py
@@ -117,7 +117,10 @@ def _load_runtime(stdout):
     repo = os.environ.get("OMNIVOICE_DOTS_TTS_MODEL", _DEFAULT_REPO)
     # Match DotsTtsRuntime's own CUDA/CPU selection. Its _check_torch_env
     # rejects half precision without CUDA, even when an XPU/NPU is available.
-    default_precision = "bfloat16" if torch.cuda.is_available() else "float32"
+    try:
+        default_precision = "bfloat16" if torch.cuda.is_available() else "float32"
+    except Exception:
+        default_precision = "float32"  # Probe failure must not force half precision.
     precision = os.environ.get("OMNIVOICE_DOTS_TTS_PRECISION", default_precision)
     optimize = os.environ.get("OMNIVOICE_DOTS_TTS_OPTIMIZE", "0") == "1"
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2300,7 +2300,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "pockettts":     "uv sync --extra pockettts  (Kyutai, CPU-only, ~100 MB model on first use; MIT code + CC-BY-4.0 weights; HF-gated, review terms and set HF_TOKEN)",
     "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
-    "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/CPU, no MPS; Apache-2.0)",
+    "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; matching PyTorch accelerator runtime or CPU, no MPS; Apache-2.0)",
 }
 
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2300,7 +2300,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "pockettts":     "uv sync --extra pockettts  (Kyutai, CPU-only, ~100 MB model on first use; MIT code + CC-BY-4.0 weights; HF-gated, review terms and set HF_TOKEN)",
     "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
-    "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; matching PyTorch accelerator runtime or CPU, no MPS; Apache-2.0)",
+    "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
 }
 
 

--- a/docs/engines/confucius4-tts.md
+++ b/docs/engines/confucius4-tts.md
@@ -93,7 +93,7 @@ sr = model.sample_rate  # 22050
 
 The sidecar passes a runtime-available CUDA/ROCm, XPU, or registered NPU
 through upstream's device-aware model loading. The engine venv needs a matching
-PyTorch/vendor runtime. XPU/NPU selection is covered by mocked loader and routing
+PyTorch/vendor runtime, also noted in the catalogue install hint. XPU/NPU selection is covered by mocked loader and routing
 tests; this change does not certify synthesis on physical XPU/NPU hardware.
 MPS keeps the existing CPU fallback described in the validation record above.
 If modern accelerator detection or the legacy CUDA probe raises, loading falls

--- a/docs/engines/confucius4-tts.md
+++ b/docs/engines/confucius4-tts.md
@@ -96,3 +96,5 @@ through upstream's device-aware model loading. The engine venv needs a matching
 PyTorch/vendor runtime. XPU/NPU selection is covered by mocked loader and routing
 tests; this change does not certify synthesis on physical XPU/NPU hardware.
 MPS keeps the existing CPU fallback described in the validation record above.
+If modern accelerator detection or the legacy CUDA probe raises, loading falls
+back to CPU instead of aborting before model construction.

--- a/docs/engines/confucius4-tts.md
+++ b/docs/engines/confucius4-tts.md
@@ -88,3 +88,11 @@ sr = model.sample_rate  # 22050
 - ✅ **Sidecar logic unit-tested** (`tests/test_confucius4_sidecar.py`):
   language normalization, tensor→PCM (mono/stereo/clip), config-path
   resolution, clone sys.path injection, wire framing, synthesize dispatch.
+
+## Accelerator routing
+
+The sidecar passes a runtime-available CUDA/ROCm, XPU, or registered NPU
+through upstream's device-aware model loading. The engine venv needs a matching
+PyTorch/vendor runtime. XPU/NPU selection is covered by mocked loader and routing
+tests; this change does not certify synthesis on physical XPU/NPU hardware.
+MPS keeps the existing CPU fallback described in the validation record above.

--- a/docs/engines/dots-tts.md
+++ b/docs/engines/dots-tts.md
@@ -119,4 +119,5 @@ disk and how uv keeps the cost down, see
 The upstream runtime selects CUDA or CPU internally. Automatic precision follows
 that selection: bfloat16 on CUDA, float32 otherwise, including XPU/NPU/MPS hosts
 where this runtime executes on CPU. `OMNIVOICE_DOTS_TTS_PRECISION` remains an
-explicit override.
+explicit override. If the CUDA availability probe raises, the automatic precision
+default stays float32; upstream remains responsible for its device selection.

--- a/docs/engines/dots-tts.md
+++ b/docs/engines/dots-tts.md
@@ -115,3 +115,8 @@ dots.tts runs in a dedicated sidecar venv (it pins `transformers==4.57`,
 which conflicts with the parent's `transformers>=5.3`). For why that adds
 disk and how uv keeps the cost down, see
 [Engine venvs & disk usage](disk-usage.md).
+
+The upstream runtime selects CUDA or CPU internally. Automatic precision follows
+that selection: bfloat16 on CUDA, float32 otherwise, including XPU/NPU/MPS hosts
+where this runtime executes on CPU. `OMNIVOICE_DOTS_TTS_PRECISION` remains an
+explicit override.

--- a/tests/test_confucius4_scaffold.py
+++ b/tests/test_confucius4_scaffold.py
@@ -42,3 +42,12 @@ def test_resolve_raises_actionable_without_clone(monkeypatch):
     import pytest
     with pytest.raises(RuntimeError, match="OMNIVOICE_CONFUCIUS4_TTS_DIR"):
         bootstrap.resolve_confucius4_venv()
+
+
+def test_catalog_metadata_does_not_exclude_supported_accelerators():
+    from engines.confucius4 import Confucius4Backend
+    from services.tts_backend import _INSTALL_HINTS
+
+    assert "CUDA/CPU" not in Confucius4Backend.display_name
+    assert "CUDA/CPU" not in _INSTALL_HINTS[Confucius4Backend.id]
+    assert "matching" in _INSTALL_HINTS[Confucius4Backend.id]

--- a/tests/test_confucius4_scaffold.py
+++ b/tests/test_confucius4_scaffold.py
@@ -6,6 +6,7 @@ on a default install — never importing the (unvalidated) upstream package, nev
 reporting available without a clone. These tests pin exactly that.
 """
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "backend"))
@@ -48,7 +49,12 @@ def test_catalog_metadata_does_not_exclude_supported_accelerators():
     from engines.confucius4 import Confucius4Backend
     from services.tts_backend import _INSTALL_HINTS
 
-    assert "CUDA/CPU" not in Confucius4Backend.display_name
+    # The catalog label is device-neutral; routing metadata owns hardware claims.
+    assert not re.search(
+        r"\b(?:cuda|rocm|xpu|npu|cpu|mps)\b",
+        Confucius4Backend.display_name,
+        re.IGNORECASE,
+    )
     assert "CUDA/CPU" not in _INSTALL_HINTS[Confucius4Backend.id]
     for family in Confucius4Backend.gpu_compat:
         assert family in _INSTALL_HINTS[Confucius4Backend.id].lower()

--- a/tests/test_confucius4_scaffold.py
+++ b/tests/test_confucius4_scaffold.py
@@ -50,4 +50,5 @@ def test_catalog_metadata_does_not_exclude_supported_accelerators():
 
     assert "CUDA/CPU" not in Confucius4Backend.display_name
     assert "CUDA/CPU" not in _INSTALL_HINTS[Confucius4Backend.id]
-    assert "matching" in _INSTALL_HINTS[Confucius4Backend.id]
+    for family in Confucius4Backend.gpu_compat:
+        assert family in _INSTALL_HINTS[Confucius4Backend.id].lower()

--- a/tests/test_confucius4_scaffold.py
+++ b/tests/test_confucius4_scaffold.py
@@ -19,7 +19,7 @@ def test_registered_in_lazy_registry():
 def test_backend_class_metadata():
     from engines.confucius4 import Confucius4Backend
     assert Confucius4Backend.id == "confucius4-tts"
-    assert Confucius4Backend.gpu_compat == ("cuda", "cpu")    # CPU validated E2E; no MPS claim
+    assert Confucius4Backend.gpu_compat == ("cuda", "rocm", "xpu", "npu", "cpu")
     assert Confucius4Backend.supports_voice_design is False
 
 

--- a/tests/test_confucius4_sidecar.py
+++ b/tests/test_confucius4_sidecar.py
@@ -210,3 +210,24 @@ def test_load_model_matches_routing(sc, monkeypatch, family, legacy):
         accelerator.assert_called_once_with(check_available=True)
     caps = HostCaps(family=family or 'cpu', available_families=(family, 'cpu') if family else ('cpu',))
     assert resolve_routing(Confucius4Backend.gpu_compat, caps)['effective_device'] == expected
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_load_model_falls_back_when_accelerator_probe_raises(sc, monkeypatch, legacy):
+    import sys
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    probe = Mock(side_effect=RuntimeError("accelerator driver unavailable"))
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(
+        accelerator=SimpleNamespace() if legacy else SimpleNamespace(current_accelerator=probe),
+        cuda=SimpleNamespace(is_available=probe),
+    ))
+    constructor = Mock()
+    monkeypatch.setitem(sys.modules, "confuciustts.cli.inference", SimpleNamespace(ConfuciusTTS=constructor))
+    monkeypatch.setattr(sc, "_model", None)
+    monkeypatch.setattr(sc, "_config_path", lambda: "fixture.yaml")
+    monkeypatch.setattr(sc, "_ensure_clone_on_sys_path", lambda: None)
+    sc._load_model(io.BytesIO())
+    constructor.assert_called_once_with(config_path="fixture.yaml", device="cpu")
+    assert probe.call_count == 1

--- a/tests/test_confucius4_sidecar.py
+++ b/tests/test_confucius4_sidecar.py
@@ -183,8 +183,8 @@ def test_synthesize_rejects_empty_text(sc):
         sc._handle_synthesize({"text": ""}, io.BytesIO())
 
 
-@pytest.mark.parametrize('family', [None, 'cuda', 'xpu', 'npu', 'mps'])
-def test_load_model_matches_routing(sc, monkeypatch, family):
+@pytest.mark.parametrize('family,legacy', [(None, False), ('cuda', False), ('xpu', False), ('npu', False), ('mps', False), (None, True), ('cuda', True)])
+def test_load_model_matches_routing(sc, monkeypatch, family, legacy):
     import sys
     from types import SimpleNamespace
     from unittest.mock import Mock
@@ -194,7 +194,9 @@ def test_load_model_matches_routing(sc, monkeypatch, family):
 
     accelerator = Mock(return_value=SimpleNamespace(type=family) if family else None)
     monkeypatch.setitem(sys.modules, 'torch', SimpleNamespace(
-        accelerator=SimpleNamespace(current_accelerator=accelerator),
+        accelerator=SimpleNamespace() if legacy else SimpleNamespace(current_accelerator=accelerator),
+        cuda=SimpleNamespace(is_available=lambda: family == 'cuda'),
+        device=lambda value: SimpleNamespace(type=value),
     ))
     constructor = Mock()
     monkeypatch.setitem(sys.modules, 'confuciustts.cli.inference', SimpleNamespace(ConfuciusTTS=constructor))
@@ -204,6 +206,7 @@ def test_load_model_matches_routing(sc, monkeypatch, family):
     sc._load_model(io.BytesIO())
     expected = family if family not in (None, 'mps') else 'cpu'
     constructor.assert_called_once_with(config_path='fixture.yaml', device=expected)
-    accelerator.assert_called_once_with(check_available=True)
+    if not legacy:
+        accelerator.assert_called_once_with(check_available=True)
     caps = HostCaps(family=family or 'cpu', available_families=(family, 'cpu') if family else ('cpu',))
     assert resolve_routing(Confucius4Backend.gpu_compat, caps)['effective_device'] == expected

--- a/tests/test_confucius4_sidecar.py
+++ b/tests/test_confucius4_sidecar.py
@@ -181,3 +181,29 @@ def test_synthesize_calls_generate_and_emits_audio(sc, monkeypatch):
 def test_synthesize_rejects_empty_text(sc):
     with pytest.raises(ValueError, match="text"):
         sc._handle_synthesize({"text": ""}, io.BytesIO())
+
+
+@pytest.mark.parametrize('family', [None, 'cuda', 'xpu', 'npu', 'mps'])
+def test_load_model_matches_routing(sc, monkeypatch, family):
+    import sys
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from core.device_caps import HostCaps
+    from services.engine_routing import resolve_routing
+    from engines.confucius4 import Confucius4Backend
+
+    accelerator = Mock(return_value=SimpleNamespace(type=family) if family else None)
+    monkeypatch.setitem(sys.modules, 'torch', SimpleNamespace(
+        accelerator=SimpleNamespace(current_accelerator=accelerator),
+    ))
+    constructor = Mock()
+    monkeypatch.setitem(sys.modules, 'confuciustts.cli.inference', SimpleNamespace(ConfuciusTTS=constructor))
+    monkeypatch.setattr(sc, '_model', None)
+    monkeypatch.setattr(sc, '_config_path', lambda: 'fixture.yaml')
+    monkeypatch.setattr(sc, '_ensure_clone_on_sys_path', lambda: None)
+    sc._load_model(io.BytesIO())
+    expected = family if family not in (None, 'mps') else 'cpu'
+    constructor.assert_called_once_with(config_path='fixture.yaml', device=expected)
+    accelerator.assert_called_once_with(check_available=True)
+    caps = HostCaps(family=family or 'cpu', available_families=(family, 'cpu') if family else ('cpu',))
+    assert resolve_routing(Confucius4Backend.gpu_compat, caps)['effective_device'] == expected

--- a/tests/test_dots_tts_accelerator_precision.py
+++ b/tests/test_dots_tts_accelerator_precision.py
@@ -1,0 +1,24 @@
+"""DOTS picks CUDA/CPU internally; another accelerator must not imply bf16."""
+import io
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.parametrize('family', [None, 'cuda', 'xpu', 'npu', 'mps'])
+def test_precision_matches_runtime_device(monkeypatch, family):
+    from engines.dots_tts import main
+
+    accelerator = Mock(return_value=SimpleNamespace(type=family) if family else None)
+    monkeypatch.setitem(sys.modules, 'torch', SimpleNamespace(
+        accelerator=SimpleNamespace(current_accelerator=accelerator),
+        cuda=SimpleNamespace(is_available=lambda: family == 'cuda'),
+    ))
+    loader = Mock()
+    monkeypatch.setitem(sys.modules, 'dots_tts.runtime', SimpleNamespace(DotsTtsRuntime=loader))
+    monkeypatch.setattr(main, '_runtime', None)
+    monkeypatch.delenv('OMNIVOICE_DOTS_TTS_PRECISION', raising=False)
+    main._load_runtime(io.BytesIO())
+    assert loader.from_pretrained.call_args.kwargs['precision'] == ('bfloat16' if family == 'cuda' else 'float32')

--- a/tests/test_dots_tts_accelerator_precision.py
+++ b/tests/test_dots_tts_accelerator_precision.py
@@ -22,3 +22,20 @@ def test_precision_matches_runtime_device(monkeypatch, family):
     monkeypatch.delenv('OMNIVOICE_DOTS_TTS_PRECISION', raising=False)
     main._load_runtime(io.BytesIO())
     assert loader.from_pretrained.call_args.kwargs['precision'] == ('bfloat16' if family == 'cuda' else 'float32')
+
+
+@pytest.mark.parametrize("override", [None, "float16"])
+def test_precision_probe_failure_uses_safe_default_or_explicit_override(monkeypatch, override):
+    from engines.dots_tts import main
+
+    probe = Mock(side_effect=RuntimeError("CUDA driver unavailable"))
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(cuda=SimpleNamespace(is_available=probe)))
+    loader = Mock()
+    monkeypatch.setitem(sys.modules, "dots_tts.runtime", SimpleNamespace(DotsTtsRuntime=loader))
+    monkeypatch.setattr(main, "_runtime", None)
+    if override is None:
+        monkeypatch.delenv("OMNIVOICE_DOTS_TTS_PRECISION", raising=False)
+    else:
+        monkeypatch.setenv("OMNIVOICE_DOTS_TTS_PRECISION", override)
+    main._load_runtime(io.BytesIO())
+    assert loader.from_pretrained.call_args.kwargs["precision"] == (override or "float32")


### PR DESCRIPTION
## Problem

Both Confucius4 and DOTS-TTS engine sidecars hardcode device selection via
`torch.cuda.is_available()`:

- `confucius4/main.py`: `device = "cuda" if torch.cuda.is_available() else "cpu"`
- `dots_tts/main.py`: `default_precision = "bfloat16" if torch.cuda.is_available() else "float32"`

On an Ascend NPU (torch_npu) host, `torch.cuda.is_available()` is **False**,
so the Confucius4 model runs on CPU (ignoring NPU) and DOTS-TTS defaults to
fp32 instead of bf16.

The same bug affects any non-CUDA accelerator: Intel XPU, AMD ROCm, etc.

## Root cause

`torch.cuda.is_available()` is CUDA-specific and does not detect NPU, XPU,
or other backends. The correct device-agnostic API is
`torch.accelerator.current_accelerator()`.

## Fix

- **confucius4/main.py**: Use `torch.accelerator.current_accelerator().type`
  for device selection. MPS is excluded (upstream untested on Apple Silicon).
- **dots_tts/main.py**: Use the same accelerator API for precision selection.
  bf16 on any GPU-class accelerator, fp32 on CPU.

## Verification

Verified on Ascend 910B (torch 2.14, torch_npu, 4 NPU):

| Engine       | Before                     | After                        |
|-------------|----------------------------|------------------------------|
| confucius4  | device="cpu" (wrong)       | device="npu" (correct)       |
| dots_tts    | precision="float32" (slow) | precision="bfloat16" (fast)  |
| cuda_avail  | False                      | False                        |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Confucius4 now detects CUDA, ROCm, XPU, and NPU accelerators with CPU fallback when detection fails or no accelerator is available. DOTS-TTS uses `bfloat16` on CUDA, NPU, and XPU, and `float32` on CPU and MPS, while preserving explicit precision overrides. Verify runtime support for non-CUDA `bfloat16` before deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->