### PR TITLE
fix(setup): stop pitching an HF token when one is already active

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,8 +428,8 @@ jobs:
           PY
 
       - name: Run smoke tests
-        if: matrix.backend_supported
         # Exercise credential paths on native Windows as well as POSIX hosts.
+        if: matrix.backend_supported
         run: uv run --no-sync pytest tests/smoke/ tests/test_hf_token_cache_paths.py -q --tb=short
         env:
           HF_HUB_OFFLINE: "1"  # same no-silent-downloads guard as the main pytest job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,8 @@ jobs:
 
       - name: Run smoke tests
         if: matrix.backend_supported
-        run: uv run --no-sync pytest tests/smoke/ -q --tb=short
+        # Exercise credential paths on native Windows as well as POSIX hosts.
+        run: uv run --no-sync pytest tests/smoke/ tests/test_hf_token_cache_paths.py -q --tb=short
         env:
           HF_HUB_OFFLINE: "1"  # same no-silent-downloads guard as the main pytest job
           HF_HUB_CACHE: ${{ runner.temp }}/pockettts-empty-hf-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- First-run "Models & engines" no longer pitches a Hugging Face token when one is already active and validated — it names the source instead, and replacing it now takes an explicit "Replace…" click rather than a blind paste-and-Save (#1851)
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- Onboarding recognizes local Hugging Face tokens without network checks, preserves Windows CLI logins, and clears saved token files explicitly (#1852) — thanks @psiberfunk!
+- Onboarding reads Hugging Face tokens locally, preserves Windows CLI logins, and requires successful discovery before replacing saved credentials (#1852) — thanks @psiberfunk!
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- First-run "Models & engines" no longer pitches a Hugging Face token when one is already active and validated — it names the source instead, and replacing it now takes an explicit "Replace…" click rather than a blind paste-and-Save (#1851)
+- Onboarding recognizes locally saved Hugging Face tokens without contacting Hugging Face, and replacing one requires an explicit click (#1852) — thanks @psiberfunk!
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- Onboarding recognizes locally saved Hugging Face tokens without network checks, localizes source labels, and requires a click to replace a token (#1852) — thanks @psiberfunk!
+- Onboarding recognizes local Hugging Face tokens without network checks, preserves Windows CLI logins, and clears saved token files explicitly (#1852) — thanks @psiberfunk!
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- Onboarding recognizes locally saved Hugging Face tokens without contacting Hugging Face, and replacing one requires an explicit click (#1852) — thanks @psiberfunk!
+- Onboarding recognizes locally saved Hugging Face tokens without network checks, localizes source labels, and requires a click to replace a token (#1852) — thanks @psiberfunk!
 
 
 ## [0.5.2] — 2026-09-02

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -35,11 +35,11 @@ class _HFTokenBody(BaseModel):
     token: str = Field(..., min_length=1, description="HuggingFace access token")
 
 
-def _state_response() -> dict:
+def _state_response(*, validate: bool = False) -> dict:
     """Return the same shape the React panel renders. Never includes raw token."""
     from services import token_resolver
 
-    s = token_resolver.state()
+    s = token_resolver.state(validate=validate)
     return {
         "active": s["active"],
         "sources": [asdict(row) for row in s["sources"]],
@@ -82,13 +82,12 @@ def get_hf_token_state(fresh: bool = Query(False)):
 
     ``fresh=1`` drops the resolver's whoami validation cache first so the
     response re-runs whoami for every source — this is what the panel's
-    "Test now" button sends. Plain GETs (panel mounts) keep the 300s cache
-    so repeat Settings visits don't hammer the HF API.
+    "Test now" button sends. Plain GETs only inspect local token presence.
     """
     from services import token_resolver
     if fresh:
         token_resolver.invalidate_cache()
-    return _state_response()
+    return _state_response(validate=fresh)
 
 
 # ── Performance settings (INST-12) ────────────────────────────────────────

--- a/backend/api/routers/settings.py
+++ b/backend/api/routers/settings.py
@@ -65,8 +65,7 @@ def save_hf_token(body: _HFTokenBody):
 
 @router.delete("/hf-token")
 def clear_hf_token(also_clear_hf_cli: bool = Query(False)):
-    """Clear the App-source token. Optionally also call huggingface_hub.logout
-    to clear the canonical HF file. Returns the updated cascade state."""
+    """Clear the App token and optionally recognized local Hub token files."""
     from services import token_resolver
     try:
         token_resolver.clear_app_token(also_clear_hf_cli=also_clear_hf_cli)

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -910,7 +910,7 @@ async def set_env_var(body: dict):
     Persistent keys (proxy, FFMPEG_PATH, translation provider keys, …) are
     saved to ``prefs.json`` so they survive backend restarts (restored at
     startup in ``main.py``). HF_TOKEN is persisted via
-    ``huggingface_hub.login()`` (and cleared via ``logout()``). Other keys
+    ``huggingface_hub.login()`` (and cleared with the shared token-file helper). Other keys
     are set on ``os.environ`` for the running process.
 
     The loopback-origin gate that previously lived inline here is now applied
@@ -985,14 +985,14 @@ async def set_env_var(body: dict):
         # Mirror the persistence on clear — wipe the saved token file too.
         if key == "HF_TOKEN":
             try:
-                from huggingface_hub import logout as _hf_logout
-                _hf_logout()
-                logger.info("HF token cleared from $HF_HOME/token via logout()")
-            except Exception as e:
-                logger.warning("Could not clear HF token file: %s", e)
+                from services.token_resolver import clear_hf_cli_tokens
+                clear_hf_cli_tokens()
+                logger.info("Local Hugging Face token files cleared")
+            except Exception:
+                raise HTTPException(status_code=500, detail="Could not clear local Hugging Face token files") from None
 
     # HF_TOKEN persistence is handled above via huggingface_hub.login()/
-    # logout() — it never touches prefs.json. Everything else in
+    # clear_hf_cli_tokens() — it never touches prefs.json. Everything else in
     # PERSISTENT_KEYS (proxy, FFMPEG_PATH, translation provider keys, …) is
     # saved to prefs.json so it survives backend restarts (restored at
     # startup in main.py). Non-persistent keys stay process-local.

--- a/backend/api/routers/system.py
+++ b/backend/api/routers/system.py
@@ -1100,7 +1100,7 @@ def asr_backends():
 def hf_token_state():
     """Return the 3-source HF token cascade state for the Settings UI
     (Wave 2 React panel consumes this). Never returns the raw token —
-    only a masked preview, whoami username, and per-source validity.
+    only a masked preview and local presence; no outbound validation.
     """
     from dataclasses import asdict
     from services import token_resolver

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -15,6 +15,18 @@ def get_app_data_dir():
         return os.path.expanduser("~/.omnivoice")
 
 
+def _configured_hf_token_path():
+    """Match Hub's token location without importing or refreshing credentials."""
+    default_cache = os.path.join(os.path.expanduser("~"), ".cache")
+    hf_home = os.environ.get("HF_HOME", os.path.join(os.environ.get("XDG_CACHE_HOME", default_cache), "huggingface"))
+    return os.path.expandvars(os.path.expanduser(os.environ.get("HF_TOKEN_PATH", os.path.join(hf_home, "token"))))
+
+
+# Snapshot recognized locations before automatic model-cache redirection.
+# Explicit cache/token overrides restrict clearing to their selected location.
+HF_CLI_TOKEN_PATHS = (_configured_hf_token_path(),)
+
+
 def _ensure_short_hf_cache_on_windows():
     """Redirect HuggingFace cache to a short path on Windows.
 
@@ -38,6 +50,14 @@ def _ensure_short_hf_cache_on_windows():
         return
     short_cache = os.path.join(local_app, "OmniVoice", "hf_cache")
     os.makedirs(short_cache, exist_ok=True)
+    if "HF_TOKEN_PATH" not in os.environ:
+        global HF_CLI_TOKEN_PATHS
+        canonical = HF_CLI_TOKEN_PATHS[0]
+        legacy = os.path.join(short_cache, "token")
+        HF_CLI_TOKEN_PATHS = tuple(dict.fromkeys((canonical, legacy)))
+        # Keep existing app-written logins usable without copying credentials.
+        selected = canonical if os.path.exists(canonical) or not os.path.exists(legacy) else legacy
+        os.environ.setdefault("HF_TOKEN_PATH", selected)
     os.environ["HF_HOME"] = short_cache
     os.environ["HF_HUB_CACHE"] = short_cache
 

--- a/backend/services/token_resolver.py
+++ b/backend/services/token_resolver.py
@@ -46,7 +46,7 @@ class SourceState:
     set: bool
     masked: Optional[str]
     whoami_user: Optional[str]
-    whoami_ok: bool
+    whoami_ok: Optional[bool]
 
 
 # ── module-level cache ────────────────────────────────────────────────────
@@ -184,17 +184,17 @@ def on_401(active_source: Source) -> Optional[ResolvedToken]:
     return resolve(skip=frozenset({active_source}))
 
 
-def state() -> dict:
+def state(*, validate: bool = False) -> dict:
     """Return one SourceState per priority position so the Settings UI can
     render the cascade table. Includes a masked token + whoami result;
-    never includes the raw token."""
+    never includes the raw token. Reads are local unless validation is explicitly requested."""
     rows: list[SourceState] = []
     active: Optional[Source] = None
     for source in _PRIORITY:
         token = _READERS[source]()
         if token:
-            username = _validate(source, token)
-            ok = username is not None
+            username = _validate(source, token) if validate else None
+            ok = (username is not None) if validate else None
             rows.append(SourceState(
                 source=source,
                 set=True,

--- a/backend/services/token_resolver.py
+++ b/backend/services/token_resolver.py
@@ -4,7 +4,7 @@ Resolution priority (highest → lowest):
 
   1. app    — `settings_store.get_hf_token()` (encrypted in SQLite)
   2. env    — `HF_TOKEN` or the legacy `HUGGING_FACE_HUB_TOKEN` env var
-  3. hf-cli — `huggingface_hub.get_token()` (canonical ~/.cache/huggingface/token)
+  3. hf-cli — the selected local Hub token file (`HF_TOKEN_PATH`)
 
 For each candidate, the resolver calls `huggingface_hub.whoami(token=...)`
 to verify the token is live; any HTTP error (401, 403, network) skips to
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+from pathlib import Path
 import threading
 import time
 from dataclasses import dataclass
@@ -79,19 +80,26 @@ def _read_app() -> Optional[str]:
         return None
 
 
+def _clean_token(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    return value.replace("\r", "").replace("\n", "").strip() or None
+
+
 def _read_env() -> Optional[str]:
     # HF docs explicitly accept either name; user may have either exported.
     val = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    return val or None
+    return _clean_token(val)
 
 
 def _read_hf_cli() -> Optional[str]:
     try:
-        import huggingface_hub
-        tok = huggingface_hub.get_token()
-        return tok or None
+        from huggingface_hub import constants
+        return _clean_token(Path(constants.HF_TOKEN_PATH).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
     except Exception:
-        logger.exception("huggingface_hub.get_token failed")
+        logger.warning("Could not read the local Hugging Face token file")
         return None
 
 
@@ -249,15 +257,30 @@ def save_app_token(token: str) -> None:
     invalidate_cache()
 
 
+def clear_hf_cli_tokens() -> None:
+    """Remove recognized Hub token files without refreshing or revoking tokens."""
+    from core.config import HF_CLI_TOKEN_PATHS
+    from huggingface_hub import constants
+
+    # Hub's active path remains authoritative if imported before app config.
+    paths = set(HF_CLI_TOKEN_PATHS) | {constants.HF_TOKEN_PATH}
+    failed = False
+    for token_path in paths:
+        path = Path(token_path)
+        for target in (path, path.parent / "stored_tokens"):
+            try:
+                target.unlink(missing_ok=True)
+            except OSError:
+                failed = True
+    invalidate_cache()
+    if failed:
+        raise OSError("Could not clear all local Hugging Face token files")
+
+
 def clear_app_token(also_clear_hf_cli: bool = False) -> None:
-    """Remove from the encrypted settings store; optionally also call
-    `huggingface_hub.logout()` to clear the canonical HF file."""
+    """Clear the encrypted app token, optionally recognized local Hub files."""
     from services import settings_store
     settings_store.clear_hf_token()
     if also_clear_hf_cli:
-        try:
-            import huggingface_hub
-            huggingface_hub.logout()
-        except Exception:
-            logger.exception("huggingface_hub.logout failed (non-fatal)")
+        clear_hf_cli_tokens()
     invalidate_cache()

--- a/docs/setup/huggingface-token.md
+++ b/docs/setup/huggingface-token.md
@@ -122,3 +122,6 @@ Opening onboarding or Settings only reads local token presence and masked previe
 Windows automatically shortens the model cache path while keeping the normal CLI token location. If only a previous VoiceStudio short-cache token exists, the app continues using that file. An existing normal CLI token takes priority; explicit token or cache overrides remain authoritative. Credentials are never copied between these locations.
 
 The CLI row reads only the selected local file, without OAuth refresh or environment-token fallback. **Also clear saved HuggingFace CLI token files** removes both active and stored-token files at recognized automatic locations, so an older app token cannot reappear on restart. Explicit overrides limit clearing to their selected location. Clearing only the app token preserves CLI files; neither action revokes tokens on Hugging Face or changes Git credentials. A file permission failure is reported instead of claiming the files were cleared.
+
+
+If onboarding cannot read token state, it shows an error and **Retry**, keeping token entry hidden until discovery succeeds. **Replace token** writes the encrypted app token through the same endpoint as Settings, so it replaces the highest-priority app credential even when an older one exists. The success message confirms saving only; validation remains a separate explicit action.

--- a/docs/setup/huggingface-token.md
+++ b/docs/setup/huggingface-token.md
@@ -14,7 +14,7 @@ call wins:
    Set via the in-app **Settings → API Keys** panel.
 2. **Env** — `HF_TOKEN` (or the legacy `HUGGING_FACE_HUB_TOKEN`) environment
    variable visible to the VoiceStudio process.
-3. **HF CLI** — the canonical `~/.cache/huggingface/token` file written by
+3. **HF CLI** — the local `HF_TOKEN_PATH` file (normally `~/.cache/huggingface/token`) written by
    `huggingface-cli login`.
 
 Source labels in onboarding and Settings follow the selected UI language;
@@ -81,8 +81,8 @@ huggingface-cli login
 # paste token at the prompt
 ```
 
-That writes to `~/.cache/huggingface/token`. VoiceStudio reads via
-`huggingface_hub.get_token()` and picks it up automatically — you'll see the
+That normally writes to `~/.cache/huggingface/token`. VoiceStudio reads the
+selected local token file directly — you'll see the
 **HF CLI** row in **Settings → API Keys** flip to "set".
 
 ## Accepting model licenses
@@ -117,3 +117,8 @@ process).
   working as intended (App is highest priority).
 
 Opening onboarding or Settings only reads local token presence and masked previews; it does not contact Hugging Face. Untested tokens are shown as **Not tested**, and onboarding reports where a token was found without claiming it is valid. **Test now** explicitly contacts Hugging Face. Replacing a saved token does not revoke the previous token on Hugging Face.
+
+
+Windows automatically shortens the model cache path while keeping the normal CLI token location. If only a previous VoiceStudio short-cache token exists, the app continues using that file. An existing normal CLI token takes priority; explicit token or cache overrides remain authoritative. Credentials are never copied between these locations.
+
+The CLI row reads only the selected local file, without OAuth refresh or environment-token fallback. **Also clear saved HuggingFace CLI token files** removes both active and stored-token files at recognized automatic locations, so an older app token cannot reappear on restart. Explicit overrides limit clearing to their selected location. Clearing only the app token preserves CLI files; neither action revokes tokens on Hugging Face or changes Git credentials. A file permission failure is reported instead of claiming the files were cleared.

--- a/docs/setup/huggingface-token.md
+++ b/docs/setup/huggingface-token.md
@@ -17,6 +17,9 @@ call wins:
 3. **HF CLI** — the canonical `~/.cache/huggingface/token` file written by
    `huggingface-cli login`.
 
+Source labels in onboarding and Settings follow the selected UI language;
+product names such as HuggingFace CLI remain unchanged.
+
 On opening **Settings → API Keys**, each row shows local set/unset state and
 a masked preview (`hf_…3jw`). Tokens remain **Not tested** until you select
 **Test now**. That explicit check displays the `whoami` username and a green

--- a/docs/setup/huggingface-token.md
+++ b/docs/setup/huggingface-token.md
@@ -1,7 +1,7 @@
 # Hugging Face Token Setup
 
 VoiceStudio uses a single HF token for every model download, license-gate
-check, and `whoami` ping. This page covers the three places VoiceStudio will
+check, and an explicit **Test now** action. This page covers the three places VoiceStudio will
 look for a token and the recommended path for v0.3+.
 
 ## Three sources (cascade)
@@ -17,10 +17,10 @@ call wins:
 3. **HF CLI** — the canonical `~/.cache/huggingface/token` file written by
    `huggingface-cli login`.
 
-The active source is surfaced live in **Settings → API Keys**: each row shows
-set/unset, a masked preview (`hf_…3jw`), the `whoami` username + green check
-when valid, and an **"Active"** badge on whichever source is currently
-serving the cascade.
+On opening **Settings → API Keys**, each row shows local set/unset state and
+a masked preview (`hf_…3jw`). Tokens remain **Not tested** until you select
+**Test now**. That explicit check displays the `whoami` username and a green
+check for valid sources, with an **Active** badge on the highest-priority valid source.
 
 ## Setting via the app (recommended)
 
@@ -32,8 +32,7 @@ serving the cascade.
    key derived per-install from machine-id) and also written to the
    canonical `huggingface_hub` token location so subprocess engines pick it
    up automatically.
-4. The row's `whoami` indicator flips green and the **Active** badge moves to
-   "App".
+4. Select **Test now** to validate the token with Hugging Face. A successful test turns the indicator green and moves the **Active** badge to "App".
 
 > **Known limitation (honest disclosure):** the encryption key is derived
 > per-install from the machine identifier. If you copy `omnivoice_data/`
@@ -105,7 +104,7 @@ process).
 - **HF 401 even though a token is set** — visit the model's HuggingFace page
   and accept the license (see above). The token is fine; the *license* gate
   is separate.
-- **Token row stays red after Save** — the `whoami` call failed. Check the
+- **Token row stays red after Test now** — the `whoami` call failed. Check the
   token is valid at
   [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
   and has at least the "read" scope.
@@ -113,3 +112,5 @@ process).
   the App row. If it's empty, the SQLite store may have been wiped — re-save.
   If it's set but the active source is "Env" or "HF CLI", that's the cascade
   working as intended (App is highest priority).
+
+Opening onboarding or Settings only reads local token presence and masked previews; it does not contact Hugging Face. Untested tokens are shown as **Not tested**, and onboarding reports where a token was found without claiming it is valid. **Test now** explicitly contacts Hugging Face. Replacing a saved token does not revoke the previous token on Hugging Face.

--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -1,17 +1,26 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { openExternal } from '../api/external';
+import { apiJson } from '../api/client';
 import { Button, Input } from '../ui';
 
 /**
  * HfTokenCard — a compact, single-line Hugging Face token input that lives in
  * the wizard's pinned action area, right by the "Waiting for required models…"
- * / Continue button. It takes only the HF token: paste it, Save, done. A free
- * token gives authenticated downloads (faster, higher rate limits, fewer
- * stalls) and unlocks gated models (pyannote diarization). Persisted via the
- * same `set-env` endpoint Settings uses, so it survives restarts.
+ * / Continue button. A free token gives authenticated downloads (faster,
+ * higher rate limits, fewer stalls) and unlocks gated models (pyannote
+ * diarization). Persisted via the same `set-env` endpoint Settings uses, so
+ * it survives restarts.
+ *
+ * Before pitching a token, it checks the resolver state (same endpoint the
+ * Settings → API Keys panel uses, `ApiKeysPanel.jsx`) so a user who already
+ * has a validated token — from the app store, an env var, or `huggingface-cli
+ * login` — sees that instead of a blind "add a token" prompt (#FR-006).
+ * Replacing an already-active token is gated behind an explicit "Replace…"
+ * click rather than being one blind paste-and-Save away, since Save persists
+ * via `huggingface_hub.login()`, which overwrites `$HF_HOME/token` outright.
  *
  * @param {string=} className extra class on the root (e.g. layout pinning).
  */
@@ -19,6 +28,31 @@ export default function HfTokenCard({ className = '' }) {
   const { t } = useTranslation();
   const [hfToken, setHfToken] = useState('');
   const [hfState, setHfState] = useState('idle'); // idle | saving | saved | error
+
+  // Resolver state (mirrors ApiKeysPanel's `state`/`refresh` pair): null while
+  // the first GET is in flight, 'error' when it fails — either way we never
+  // want to flash a false "you have no token" pitch before we actually know.
+  const [tokenState, setTokenState] = useState(null);
+  const [checkFailed, setCheckFailed] = useState(false);
+  // Explicit gate: revealing the paste-a-token form when a token is already
+  // active requires this deliberate click, so Save can never blind-clobber a
+  // working token.
+  const [replacing, setReplacing] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await apiJson('/system/hf-token/state');
+        if (!cancelled) setTokenState(data);
+      } catch {
+        if (!cancelled) setCheckFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const saveHfToken = async () => {
     const value = hfToken.trim();
@@ -54,6 +88,66 @@ export default function HfTokenCard({ className = '' }) {
     );
   }
 
+  // Still checking — never flash the "add a token" pitch before we know
+  // whether one is already active.
+  if (tokenState == null && !checkFailed) {
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-md border border-transparent bg-primary/[0.07] px-3 py-2 text-sm text-fg-muted',
+          className,
+        )}
+      >
+        <Zap size={16} className="shrink-0 text-primary" aria-hidden="true" />
+        {t('firstrun.checking', 'checking…')}
+      </div>
+    );
+  }
+
+  const SOURCE_LABELS = {
+    app: t('settings.hf_source_app_label', {
+      defaultValue: 'VoiceStudio (encrypted, recommended)',
+    }),
+    env: t('settings.hf_source_env_label', { defaultValue: 'Environment variable' }),
+    'hf-cli': t('settings.hf_source_cli_label', { defaultValue: 'HuggingFace CLI' }),
+  };
+  const activeRow =
+    tokenState && tokenState.active
+      ? tokenState.sources?.find((r) => r.source === tokenState.active)
+      : null;
+
+  // A validated token is already active and the user hasn't asked to replace
+  // it — show the satisfied state, not the pitch (#FR-006).
+  if (activeRow && !replacing) {
+    return (
+      <div
+        className={cn(
+          'flex flex-wrap items-center gap-2 rounded-md border border-transparent bg-success/[0.09] px-3 py-2 text-sm',
+          className,
+        )}
+      >
+        <Check size={16} className="shrink-0 text-success" aria-hidden="true" />
+        <span className="font-semibold text-success">
+          {t('firstrun.hf_token_active_using', {
+            source: SOURCE_LABELS[tokenState.active] || tokenState.active,
+            masked: activeRow.masked || '',
+            defaultValue: 'Using your Hugging Face token from {{source}} — {{masked}}',
+          })}
+        </span>
+        <button
+          type="button"
+          className="cursor-pointer appearance-none whitespace-nowrap border-0 bg-transparent p-0 text-[0.76rem] text-primary underline hover:no-underline"
+          onClick={() => setReplacing(true)}
+        >
+          {t('firstrun.hf_token_replace', 'Replace token…')}
+        </button>
+      </div>
+    );
+  }
+
+  // No active token (or the state check failed — fail toward the pre-fix
+  // behavior rather than hiding the card), or the user explicitly chose to
+  // replace an active one.
   return (
     <div
       className={cn(
@@ -63,7 +157,12 @@ export default function HfTokenCard({ className = '' }) {
     >
       <Zap size={16} className="shrink-0 text-primary" aria-hidden="true" />
       <span className="font-semibold max-[560px]:hidden">
-        {t('firstrun.hf_token_inline_prompt', 'Speed up downloads with a free Hugging Face token')}
+        {replacing && activeRow
+          ? t(
+              'firstrun.hf_token_replace_warning',
+              'This replaces the token above — the old one stops working.',
+            )
+          : t('firstrun.hf_token_inline_prompt', 'Speed up downloads with a free Hugging Face token')}
       </span>
       <Input
         size="sm"
@@ -94,6 +193,19 @@ export default function HfTokenCard({ className = '' }) {
           ? t('firstrun.hf_token_saving', 'saving…')
           : t('firstrun.hf_token_save', 'Save')}
       </Button>
+      {replacing && activeRow && (
+        <button
+          type="button"
+          className="cursor-pointer appearance-none whitespace-nowrap border-0 bg-transparent p-0 text-[0.76rem] text-fg-muted underline hover:no-underline"
+          onClick={() => {
+            setReplacing(false);
+            setHfToken('');
+            setHfState('idle');
+          }}
+        >
+          {t('common.cancel', 'Cancel')}
+        </button>
+      )}
       <button
         type="button"
         className="cursor-pointer appearance-none whitespace-nowrap border-0 bg-transparent p-0 text-[0.76rem] text-primary underline hover:no-underline"

--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -156,7 +156,9 @@ export default function HfTokenCard({ className = '' }) {
       )}
     >
       <Zap size={16} className="shrink-0 text-primary" aria-hidden="true" />
-      <span className="font-semibold max-[560px]:hidden">
+      <span
+        className={cn('font-semibold', !(replacing && activeRow) && 'max-[560px]:hidden')}
+      >
         {replacing && activeRow
           ? t(
               'firstrun.hf_token_replace_warning',

--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Check, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { openExternal } from '../api/external';
-import { apiJson } from '../api/client';
+import { apiJson, apiPost } from '../api/client';
 import { Button, Input } from '../ui';
 
 /**
@@ -11,7 +11,7 @@ import { Button, Input } from '../ui';
  * the wizard's pinned action area, right by the "Waiting for required models…"
  * / Continue button. A free token gives authenticated downloads (faster,
  * higher rate limits, fewer stalls) and unlocks gated models (pyannote
- * diarization). Persisted via the same `set-env` endpoint Settings uses, so
+ * diarization). Persisted via the same encrypted-app-token endpoint Settings uses, so
  * it survives restarts.
  *
  * Before pitching a token, it checks the resolver state (same endpoint the
@@ -20,7 +20,7 @@ import { Button, Input } from '../ui';
  * login` — sees that instead of a blind "add a token" prompt (#FR-006).
  * Replacing an already-active token is gated behind an explicit "Replace…"
  * click rather than being one blind paste-and-Save away, since Save persists
- * via `huggingface_hub.login()`, which overwrites `$HF_HOME/token` outright.
+ * in the app store and the selected local Hub token file.
  *
  * @param {string=} className extra class on the root (e.g. layout pinning).
  */
@@ -34,6 +34,7 @@ export default function HfTokenCard({ className = '' }) {
   // want to flash a false "you have no token" pitch before we actually know.
   const [tokenState, setTokenState] = useState(null);
   const [checkFailed, setCheckFailed] = useState(false);
+  const [checkAttempt, setCheckAttempt] = useState(0);
   // Explicit gate: revealing the paste-a-token form when a token is already
   // active requires this deliberate click, so Save can never blind-clobber a
   // working token.
@@ -44,6 +45,14 @@ export default function HfTokenCard({ className = '' }) {
     (async () => {
       try {
         const data = await apiJson('/system/hf-token/state');
+        if (
+          !Array.isArray(data?.sources) ||
+          data.sources.length !== 3 ||
+          !['app', 'env', 'hf-cli'].every((source) =>
+            data.sources.some((row) => row?.source === source && typeof row.set === 'boolean'),
+          )
+        )
+          throw new Error('Invalid token state');
         if (!cancelled) setTokenState(data);
       } catch {
         if (!cancelled) setCheckFailed(true);
@@ -52,19 +61,14 @@ export default function HfTokenCard({ className = '' }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [checkAttempt]);
 
   const saveHfToken = async () => {
     const value = hfToken.trim();
-    if (!value || hfState === 'saving') return;
+    if (!value || hfState === 'saving' || tokenState == null || checkFailed) return;
     setHfState('saving');
     try {
-      const { apiFetch } = await import('../api/client');
-      await apiFetch('/system/set-env', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: 'HF_TOKEN', value }),
-      });
+      await apiPost('/api/settings/hf-token', { token: value });
       setHfState('saved');
       setHfToken('');
     } catch {
@@ -82,15 +86,41 @@ export default function HfTokenCard({ className = '' }) {
       >
         <span className="inline-flex items-center gap-1.5 font-semibold text-success">
           <Check size={14} aria-hidden="true" />
-          {t('firstrun.hf_token_saved_fast', 'Hugging Face token saved — downloads are now faster')}
+          {t('firstrun.hf_token_saved', 'Hugging Face token saved')}
         </span>
+      </div>
+    );
+  }
+
+  if (checkFailed) {
+    return (
+      <div
+        className={cn(
+          'flex flex-wrap items-center gap-2 rounded-md bg-danger/10 px-3 py-2 text-sm',
+          className,
+        )}
+      >
+        <span role="alert" className="text-danger">
+          {t('common.error', 'Something went wrong')}
+        </span>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            setCheckFailed(false);
+            setTokenState(null);
+            setCheckAttempt((attempt) => attempt + 1);
+          }}
+        >
+          {t('bootstrap.retry', 'Retry')}
+        </Button>
       </div>
     );
   }
 
   // Still checking — never flash the "add a token" pitch before we know
   // whether one is already active.
-  if (tokenState == null && !checkFailed) {
+  if (tokenState == null) {
     return (
       <div
         className={cn(
@@ -108,8 +138,12 @@ export default function HfTokenCard({ className = '' }) {
     app: t('settings.hf_source_app_label', {
       defaultValue: 'VoiceStudio (encrypted, recommended)',
     }),
-    env: t('settings.hf_source_env_label', { defaultValue: 'Environment variable' }),
-    'hf-cli': t('settings.hf_source_cli_label', { defaultValue: 'HuggingFace CLI' }),
+    env: t('settings.hf_source_env_label', {
+      defaultValue: 'Environment variable',
+    }),
+    'hf-cli': t('settings.hf_source_cli_label', {
+      defaultValue: 'HuggingFace CLI',
+    }),
   };
   const activeRow = tokenState?.sources?.find((row) => row.set);
 
@@ -142,9 +176,7 @@ export default function HfTokenCard({ className = '' }) {
     );
   }
 
-  // No active token (or the state check failed — fail toward the pre-fix
-  // behavior rather than hiding the card), or the user explicitly chose to
-  // replace an active one.
+  // A successful state read found no token, or replacement was explicit.
   return (
     <div
       className={cn(
@@ -171,7 +203,9 @@ export default function HfTokenCard({ className = '' }) {
         placeholder={t('firstrun.hf_token_inline_ph', 'Paste hf_… token (optional)')}
         value={hfToken}
         autoComplete="off"
+        disabled={hfState === 'saving'}
         onChange={(e) => {
+          if (hfState === 'saving') return;
           setHfToken(e.target.value);
           if (hfState !== 'idle') setHfState('idle');
         }}
@@ -197,6 +231,7 @@ export default function HfTokenCard({ className = '' }) {
         <button
           type="button"
           className="cursor-pointer appearance-none whitespace-nowrap border-0 bg-transparent p-0 text-[0.76rem] text-fg-muted underline hover:no-underline"
+          disabled={hfState === 'saving'}
           onClick={() => {
             setReplacing(false);
             setHfToken('');

--- a/frontend/src/components/HfTokenCard.jsx
+++ b/frontend/src/components/HfTokenCard.jsx
@@ -16,7 +16,7 @@ import { Button, Input } from '../ui';
  *
  * Before pitching a token, it checks the resolver state (same endpoint the
  * Settings → API Keys panel uses, `ApiKeysPanel.jsx`) so a user who already
- * has a validated token — from the app store, an env var, or `huggingface-cli
+ * has a locally configured token — from the app store, an env var, or `huggingface-cli
  * login` — sees that instead of a blind "add a token" prompt (#FR-006).
  * Replacing an already-active token is gated behind an explicit "Replace…"
  * click rather than being one blind paste-and-Save away, since Save persists
@@ -111,12 +111,9 @@ export default function HfTokenCard({ className = '' }) {
     env: t('settings.hf_source_env_label', { defaultValue: 'Environment variable' }),
     'hf-cli': t('settings.hf_source_cli_label', { defaultValue: 'HuggingFace CLI' }),
   };
-  const activeRow =
-    tokenState && tokenState.active
-      ? tokenState.sources?.find((r) => r.source === tokenState.active)
-      : null;
+  const activeRow = tokenState?.sources?.find((row) => row.set);
 
-  // A validated token is already active and the user hasn't asked to replace
+  // A token is already configured locally and the user hasn't asked to replace
   // it — show the satisfied state, not the pitch (#FR-006).
   if (activeRow && !replacing) {
     return (
@@ -129,9 +126,9 @@ export default function HfTokenCard({ className = '' }) {
         <Check size={16} className="shrink-0 text-success" aria-hidden="true" />
         <span className="font-semibold text-success">
           {t('firstrun.hf_token_active_using', {
-            source: SOURCE_LABELS[tokenState.active] || tokenState.active,
+            source: SOURCE_LABELS[activeRow.source] || activeRow.source,
             masked: activeRow.masked || '',
-            defaultValue: 'Using your Hugging Face token from {{source}} — {{masked}}',
+            defaultValue: 'Hugging Face token found in {{source}} — {{masked}}',
           })}
         </span>
         <button
@@ -156,15 +153,16 @@ export default function HfTokenCard({ className = '' }) {
       )}
     >
       <Zap size={16} className="shrink-0 text-primary" aria-hidden="true" />
-      <span
-        className={cn('font-semibold', !(replacing && activeRow) && 'max-[560px]:hidden')}
-      >
+      <span className={cn('font-semibold', !(replacing && activeRow) && 'max-[560px]:hidden')}>
         {replacing && activeRow
           ? t(
               'firstrun.hf_token_replace_warning',
-              'This replaces the token above — the old one stops working.',
+              'This replaces the token saved for this app. It does not revoke the old token.',
             )
-          : t('firstrun.hf_token_inline_prompt', 'Speed up downloads with a free Hugging Face token')}
+          : t(
+              'firstrun.hf_token_inline_prompt',
+              'Speed up downloads with a free Hugging Face token',
+            )}
       </span>
       <Input
         size="sm"

--- a/frontend/src/components/HfTokenCard.test.jsx
+++ b/frontend/src/components/HfTokenCard.test.jsx
@@ -92,6 +92,19 @@ describe('HfTokenCard', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps the overwrite warning visible on narrow screens (unlike the dismissable pitch)', async () => {
+    global.fetch = mockFetchOnce(STATE_HF_CLI_ACTIVE);
+    render(<HfTokenCard />);
+    await waitFor(() => expect(screen.getByText(/hf_…Sfb/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /replace/i }));
+
+    const warning = await screen.findByText(/replaces the token above.*old one stops working/i);
+    // The default pitch is allowed to hide at <=560px; the overwrite safety
+    // warning must not carry that same responsive-hide class, or a user on a
+    // narrow viewport can replace a working token without ever seeing it.
+    expect(warning.className).not.toMatch(/max-\[560px\]:hidden/);
+  });
+
   it('shows a neutral checking placeholder while state is loading, never the pitch', async () => {
     let resolveFetch;
     global.fetch = vi.fn(

--- a/frontend/src/components/HfTokenCard.test.jsx
+++ b/frontend/src/components/HfTokenCard.test.jsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import HfTokenCard from './HfTokenCard';
+
+const STATE_NONE_ACTIVE = {
+  active: null,
+  sources: [
+    { source: 'app', set: false, masked: null, whoami_user: null, whoami_ok: false },
+    { source: 'env', set: false, masked: null, whoami_user: null, whoami_ok: false },
+    { source: 'hf-cli', set: false, masked: null, whoami_user: null, whoami_ok: false },
+  ],
+};
+
+// Mirrors the live report (#FR-006): `hf-cli` already resolved and validated.
+const STATE_HF_CLI_ACTIVE = {
+  active: 'hf-cli',
+  sources: [
+    { source: 'app', set: false, masked: null, whoami_user: null, whoami_ok: false },
+    { source: 'env', set: false, masked: null, whoami_user: null, whoami_ok: false },
+    {
+      source: 'hf-cli',
+      set: true,
+      masked: 'hf_…Sfb',
+      whoami_user: 'alice',
+      whoami_ok: true,
+    },
+  ],
+};
+
+function mockFetchOnce(payload, status = 200) {
+  return vi.fn().mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  });
+}
+
+function mockFetchSequence(...responses) {
+  const fn = vi.fn();
+  for (const r of responses) {
+    fn.mockResolvedValueOnce({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.body,
+      text: async () => JSON.stringify(r.body),
+    });
+  }
+  return fn;
+}
+
+describe('HfTokenCard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the add-token pitch when no token is active anywhere', async () => {
+    global.fetch = mockFetchOnce(STATE_NONE_ACTIVE);
+    render(<HfTokenCard />);
+    await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
+    expect(screen.getByText(/Speed up downloads with a free Hugging Face token/)).toBeInTheDocument();
+  });
+
+  it('does NOT pitch a new token once one is already active and validated (#FR-006)', async () => {
+    global.fetch = mockFetchOnce(STATE_HF_CLI_ACTIVE);
+    render(<HfTokenCard />);
+
+    // The satisfied state names the masked value; the blind "paste a token"
+    // input must never appear alongside it.
+    await waitFor(() => expect(screen.getByText(/hf_…Sfb/)).toBeInTheDocument());
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+    expect(screen.queryByText(/Speed up downloads with a free Hugging Face token/)).toBeNull();
+  });
+
+  it('replacing an active token requires an explicit "Replace…" click, not a blind paste-and-Save', async () => {
+    global.fetch = mockFetchOnce(STATE_HF_CLI_ACTIVE);
+    render(<HfTokenCard />);
+    await waitFor(() => expect(screen.getByText(/hf_…Sfb/)).toBeInTheDocument());
+
+    // Still no paste field until the user opts in.
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /replace/i }));
+
+    // Now the field appears, alongside a warning that this overwrites the
+    // token above — the deliberate-action gate the fix adds.
+    await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
+    expect(
+      screen.getByText(/replaces the token above.*old one stops working/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a neutral checking placeholder while state is loading, never the pitch', async () => {
+    let resolveFetch;
+    global.fetch = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    render(<HfTokenCard />);
+
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+    expect(screen.queryByText(/Speed up downloads with a free Hugging Face token/)).toBeNull();
+    expect(screen.getByText(/checking/i)).toBeInTheDocument();
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledOnce());
+    resolveFetch({
+      ok: true,
+      status: 200,
+      json: async () => STATE_NONE_ACTIVE,
+      text: async () => JSON.stringify(STATE_NONE_ACTIVE),
+    });
+    await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
+  });
+
+  it('falls back to the pitch (pre-fix behavior) when the state check fails, rather than hiding the card', async () => {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error('network error'));
+    render(<HfTokenCard />);
+    await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
+  });
+
+  it('Save still POSTs HF_TOKEN via /system/set-env when no token was active', async () => {
+    const fetchMock = mockFetchSequence(
+      { status: 200, body: STATE_NONE_ACTIVE }, // GET state
+      { status: 200, body: { key: 'HF_TOKEN', set: true, shadowed: false } }, // POST set-env
+    );
+    global.fetch = fetchMock;
+
+    render(<HfTokenCard />);
+    const input = await screen.findByPlaceholderText(/hf_/);
+    fireEvent.change(input, { target: { value: 'hf_newtoken123' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      const postCall = fetchMock.mock.calls.find(([, opts]) => opts?.method === 'POST');
+      expect(postCall).toBeTruthy();
+      expect(postCall[0]).toMatch(/\/system\/set-env$/);
+      expect(JSON.parse(postCall[1].body)).toEqual({ key: 'HF_TOKEN', value: 'hf_newtoken123' });
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Hugging Face token saved/)).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/HfTokenCard.test.jsx
+++ b/frontend/src/components/HfTokenCard.test.jsx
@@ -7,9 +7,27 @@ import HfTokenCard from './HfTokenCard';
 const STATE_NONE_ACTIVE = {
   active: null,
   sources: [
-    { source: 'app', set: false, masked: null, whoami_user: null, whoami_ok: false },
-    { source: 'env', set: false, masked: null, whoami_user: null, whoami_ok: false },
-    { source: 'hf-cli', set: false, masked: null, whoami_user: null, whoami_ok: false },
+    {
+      source: 'app',
+      set: false,
+      masked: null,
+      whoami_user: null,
+      whoami_ok: false,
+    },
+    {
+      source: 'env',
+      set: false,
+      masked: null,
+      whoami_user: null,
+      whoami_ok: false,
+    },
+    {
+      source: 'hf-cli',
+      set: false,
+      masked: null,
+      whoami_user: null,
+      whoami_ok: false,
+    },
   ],
 };
 
@@ -17,8 +35,20 @@ const STATE_NONE_ACTIVE = {
 const STATE_HF_CLI_ACTIVE = {
   active: null,
   sources: [
-    { source: 'app', set: false, masked: null, whoami_user: null, whoami_ok: false },
-    { source: 'env', set: false, masked: null, whoami_user: null, whoami_ok: false },
+    {
+      source: 'app',
+      set: false,
+      masked: null,
+      whoami_user: null,
+      whoami_ok: false,
+    },
+    {
+      source: 'env',
+      set: false,
+      masked: null,
+      whoami_user: null,
+      whoami_ok: false,
+    },
     {
       source: 'hf-cli',
       set: true,
@@ -129,16 +159,30 @@ describe('HfTokenCard', () => {
     await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
   });
 
-  it('falls back to the pitch (pre-fix behavior) when the state check fails, rather than hiding the card', async () => {
-    global.fetch = vi.fn().mockRejectedValueOnce(new Error('network error'));
+  it('keeps Save hidden after a failed state read until Retry discovers the existing token', async () => {
+    const failed = mockFetchOnce({ detail: 'private server failure' }, 503);
+    failed.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => STATE_HF_CLI_ACTIVE,
+    });
+    global.fetch = failed;
     render(<HfTokenCard />);
-    await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
+    const retry = await screen.findByRole('button', { name: 'Retry' });
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /^save$/i })).toBeNull();
+    expect(screen.queryByText(/private server failure/)).toBeNull();
+    fireEvent.click(retry);
+    await screen.findByText(/hf_…Sfb/);
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /replace/i }));
+    expect(screen.getByText(/replaces the token saved for this app/i)).toBeInTheDocument();
   });
 
-  it('Save still POSTs HF_TOKEN via /system/set-env when no token was active', async () => {
+  it('saves an app token through the canonical Settings endpoint without claiming validation', async () => {
     const fetchMock = mockFetchSequence(
       { status: 200, body: STATE_NONE_ACTIVE }, // GET state
-      { status: 200, body: { key: 'HF_TOKEN', set: true, shadowed: false } }, // POST set-env
+      { status: 200, body: STATE_HF_CLI_ACTIVE }, // POST app token
     );
     global.fetch = fetchMock;
 
@@ -150,9 +194,122 @@ describe('HfTokenCard', () => {
     await waitFor(() => {
       const postCall = fetchMock.mock.calls.find(([, opts]) => opts?.method === 'POST');
       expect(postCall).toBeTruthy();
-      expect(postCall[0]).toMatch(/\/system\/set-env$/);
-      expect(JSON.parse(postCall[1].body)).toEqual({ key: 'HF_TOKEN', value: 'hf_newtoken123' });
+      expect(postCall[0]).toMatch(/\/api\/settings\/hf-token$/);
+      expect(JSON.parse(postCall[1].body)).toEqual({ token: 'hf_newtoken123' });
     });
-    await waitFor(() => expect(screen.getByText(/Hugging Face token saved/)).toBeInTheDocument());
+    await screen.findByText('Hugging Face token saved');
+    expect(screen.queryByText(/downloads are now faster/)).toBeNull();
+  });
+  it.each(['app', 'env', 'hf-cli'])(
+    'replaces the used token from %s through the app source',
+    async (source) => {
+      const state = {
+        active: null,
+        sources: STATE_NONE_ACTIVE.sources.map((row) => ({
+          ...row,
+          set: row.source === source,
+          masked: row.source === source ? 'hf_…old' : null,
+        })),
+      };
+      global.fetch = mockFetchSequence(
+        { status: 200, body: state },
+        { status: 200, body: STATE_NONE_ACTIVE },
+      );
+      render(<HfTokenCard />);
+      await screen.findByText(/hf_…old/);
+      expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+      fireEvent.click(screen.getByRole('button', { name: /replace/i }));
+      fireEvent.change(screen.getByPlaceholderText(/hf_/), {
+        target: { value: ' hf_replacement ' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+      await screen.findByText('Hugging Face token saved');
+      const [url, options] = global.fetch.mock.calls.find(([, opts]) => opts?.method === 'POST');
+      expect(url).toMatch(/\/api\/settings\/hf-token$/);
+      expect(JSON.parse(options.body)).toEqual({ token: 'hf_replacement' });
+    },
+  );
+
+  it('retains the replacement warning and token after a failed save so it can be retried', async () => {
+    global.fetch = mockFetchSequence(
+      { status: 200, body: STATE_HF_CLI_ACTIVE },
+      { status: 500, body: { detail: 'private server failure' } },
+      { status: 200, body: STATE_NONE_ACTIVE },
+    );
+    render(<HfTokenCard />);
+    await screen.findByText(/hf_…Sfb/);
+    fireEvent.click(screen.getByRole('button', { name: /replace/i }));
+    fireEvent.change(screen.getByPlaceholderText(/hf_/), {
+      target: { value: 'hf_replacement' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await screen.findByText(/Could not save the token/);
+    expect(screen.getByPlaceholderText(/hf_/)).toHaveValue('hf_replacement');
+    expect(screen.getByText(/replaces the token saved for this app/i)).toBeInTheDocument();
+    expect(screen.queryByText(/private server failure/)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await screen.findByText('Hugging Face token saved');
+  });
+  it.each([
+    null,
+    {},
+    { sources: [] },
+    { sources: [null] },
+    { sources: [...STATE_NONE_ACTIVE.sources, null] },
+  ])('keeps malformed token state gated: %j', async (state) => {
+    global.fetch = mockFetchOnce(state);
+    render(<HfTokenCard />);
+    await screen.findByRole('button', { name: 'Retry' });
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /^save$/i })).toBeNull();
+  });
+
+  it('waits for Retry to finish before showing the empty-state form', async () => {
+    let resolveRetry;
+    global.fetch = mockFetchOnce({ detail: 'failed' }, 503);
+    global.fetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    render(<HfTokenCard />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+    expect(screen.getByText(/checking/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/hf_/)).toBeNull();
+    await waitFor(() => expect(resolveRetry).toBeTypeOf('function'));
+    resolveRetry({
+      ok: true,
+      status: 200,
+      json: async () => STATE_NONE_ACTIVE,
+    });
+    await screen.findByPlaceholderText(/hf_/);
+  });
+
+  it('does not issue duplicate saves or cancel an in-flight replacement', async () => {
+    let resolveSave;
+    global.fetch = mockFetchOnce(STATE_HF_CLI_ACTIVE);
+    global.fetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    render(<HfTokenCard />);
+    fireEvent.click(await screen.findByRole('button', { name: /replace/i }));
+    fireEvent.change(screen.getByPlaceholderText(/hf_/), {
+      target: { value: 'hf_replacement' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+    expect(screen.getByPlaceholderText(/hf_/)).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText(/hf_/), { target: { value: 'hf_racing_edit' } });
+    expect(screen.getByPlaceholderText(/hf_/)).toHaveValue('hf_replacement');
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+    fireEvent.keyDown(screen.getByPlaceholderText(/hf_/), { key: 'Enter' });
+    await waitFor(() => expect(resolveSave).toBeTypeOf('function'));
+    expect(global.fetch.mock.calls.filter(([, opts]) => opts?.method === 'POST')).toHaveLength(1);
+    resolveSave({ ok: true, status: 200, json: async () => STATE_NONE_ACTIVE });
+    await screen.findByText('Hugging Face token saved');
   });
 });

--- a/frontend/src/components/HfTokenCard.test.jsx
+++ b/frontend/src/components/HfTokenCard.test.jsx
@@ -15,7 +15,7 @@ const STATE_NONE_ACTIVE = {
 
 // Mirrors the live report (#FR-006): `hf-cli` already resolved and validated.
 const STATE_HF_CLI_ACTIVE = {
-  active: 'hf-cli',
+  active: null,
   sources: [
     { source: 'app', set: false, masked: null, whoami_user: null, whoami_ok: false },
     { source: 'env', set: false, masked: null, whoami_user: null, whoami_ok: false },
@@ -23,8 +23,8 @@ const STATE_HF_CLI_ACTIVE = {
       source: 'hf-cli',
       set: true,
       masked: 'hf_…Sfb',
-      whoami_user: 'alice',
-      whoami_ok: true,
+      whoami_user: null,
+      whoami_ok: null,
     },
   ],
 };
@@ -60,10 +60,12 @@ describe('HfTokenCard', () => {
     global.fetch = mockFetchOnce(STATE_NONE_ACTIVE);
     render(<HfTokenCard />);
     await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
-    expect(screen.getByText(/Speed up downloads with a free Hugging Face token/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Speed up downloads with a free Hugging Face token/),
+    ).toBeInTheDocument();
   });
 
-  it('does NOT pitch a new token once one is already active and validated (#FR-006)', async () => {
+  it('does NOT pitch a new token once one is locally configured without validation (#FR-006)', async () => {
     global.fetch = mockFetchOnce(STATE_HF_CLI_ACTIVE);
     render(<HfTokenCard />);
 
@@ -87,9 +89,7 @@ describe('HfTokenCard', () => {
     // Now the field appears, alongside a warning that this overwrites the
     // token above — the deliberate-action gate the fix adds.
     await waitFor(() => expect(screen.getByPlaceholderText(/hf_/)).toBeInTheDocument());
-    expect(
-      screen.getByText(/replaces the token above.*old one stops working/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/replaces the token saved for this app/i)).toBeInTheDocument();
   });
 
   it('keeps the overwrite warning visible on narrow screens (unlike the dismissable pitch)', async () => {
@@ -98,7 +98,7 @@ describe('HfTokenCard', () => {
     await waitFor(() => expect(screen.getByText(/hf_…Sfb/)).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: /replace/i }));
 
-    const warning = await screen.findByText(/replaces the token above.*old one stops working/i);
+    const warning = await screen.findByText(/replaces the token saved for this app/i);
     // The default pitch is allowed to hide at <=560px; the overwrite safety
     // warning must not carry that same responsive-hide class, or a user on a
     // narrow viewport can replace a working token without ever seeing it.
@@ -153,8 +153,6 @@ describe('HfTokenCard', () => {
       expect(postCall[0]).toMatch(/\/system\/set-env$/);
       expect(JSON.parse(postCall[1].body)).toEqual({ key: 'HF_TOKEN', value: 'hf_newtoken123' });
     });
-    await waitFor(() =>
-      expect(screen.getByText(/Hugging Face token saved/)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Hugging Face token saved/)).toBeInTheDocument());
   });
 });

--- a/frontend/src/components/settings/ApiKeysPanel.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.jsx
@@ -55,9 +55,9 @@ export default function ApiKeysPanel() {
   const [alsoClearCli, setAlsoClearCli] = useState(false);
   const [error, setError] = useState(null);
 
-  // `fresh` busts the backend's 300s whoami cache — used by "Test now" so it
+  // Ordinary reads are local. `fresh` explicitly validates tokens for "Test now" so it
   // really re-runs whoami instead of echoing a cached (possibly stale) verdict.
-  // Plain mounts/refreshes keep the cache so Settings visits stay cheap.
+  // Plain mounts/refreshes read local presence without contacting Hugging Face.
   const refresh = useCallback(
     async ({ fresh = false } = {}) => {
       setLoading(true);
@@ -208,7 +208,9 @@ export default function ApiKeysPanel() {
                           {row.masked}
                         </code>
                       )}
-                      {row.whoami_ok ? (
+                      {row.whoami_ok == null ? (
+                        <span>{t('settings.hf_token_not_checked')}</span>
+                      ) : row.whoami_ok ? (
                         <span className="inline-flex items-center gap-[4px] text-[var(--chrome-severity-ok)]">
                           <CheckCircle2 size={12} />{' '}
                           {row.whoami_user ||

--- a/frontend/src/components/settings/ApiKeysPanel.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.jsx
@@ -112,10 +112,8 @@ export default function ApiKeysPanel() {
       setClearOpen(false);
       setAlsoClearCli(false);
       await refresh();
-    } catch (e) {
-      setError(
-        e?.message || t('settings.hf_token_clear_error', { defaultValue: 'Failed to clear token' }),
-      );
+    } catch {
+      setError(t('settings.hf_token_clear_error', { defaultValue: 'Failed to clear token' }));
     } finally {
       setSaving(false);
     }
@@ -291,8 +289,9 @@ export default function ApiKeysPanel() {
               checked={alsoClearCli}
               onChange={(e) => setAlsoClearCli(e.target.checked)}
             />{' '}
-            {t('settings.hf_token_also_clear', { defaultValue: 'Also clear' })}{' '}
-            <code>~/.cache/huggingface/token</code>
+            {t('settings.hf_token_also_clear', {
+              defaultValue: 'Also clear saved HuggingFace CLI token files',
+            })}
           </label>
           <div className="flex justify-end gap-[var(--space-3)]">
             <button

--- a/frontend/src/components/settings/ApiKeysPanel.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.jsx
@@ -113,7 +113,7 @@ export default function ApiKeysPanel() {
       setAlsoClearCli(false);
       await refresh();
     } catch {
-      setError(t('settings.hf_token_clear_error', { defaultValue: 'Failed to clear token' }));
+      setError(t('common.error', { defaultValue: 'Something went wrong' }));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/settings/ApiKeysPanel.test.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import i18n from '../../i18n';
 
 const STATE_THREE_UNSET = {
   active: null,
@@ -167,6 +168,45 @@ describe('ApiKeysPanel', () => {
       // also_clear_hf_cli default is false → no query string
       expect(del[0]).not.toMatch(/also_clear_hf_cli=true/);
     });
+  });
+
+  it('keeps failed clear open for retry and shows the localized error', async () => {
+    const previousLanguage = i18n.language;
+    await i18n.changeLanguage('ko');
+    await waitFor(() => expect(i18n.hasResourceBundle('ko', 'translation')).toBe(true));
+    expect(i18n.t('settings.hf_token_clear_error')).not.toBe('Failed to clear token');
+    const fetchMock = mockFetchSequence(
+      { status: 200, body: STATE_APP_ACTIVE },
+      { status: 500, body: { detail: 'Failed to clear local Hugging Face token files' } },
+      { status: 200, body: STATE_THREE_UNSET },
+      { status: 200, body: STATE_THREE_UNSET },
+    );
+    global.fetch = fetchMock;
+    const { unmount } = render(<ApiKeysPanel />);
+    try {
+      fireEvent.click(
+        await screen.findByRole('button', { name: i18n.t('settings.hf_token_clear_short') }),
+      );
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+      const confirm = screen.getByRole('button', { name: i18n.t('settings.hf_token_clear_btn') });
+      fireEvent.click(confirm);
+      expect(await screen.findByText(i18n.t('settings.hf_token_clear_error'))).toBeInTheDocument();
+      expect(
+        screen.queryByText('Failed to clear local Hugging Face token files'),
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(checkbox).toBeChecked();
+      expect(confirm).toBeEnabled();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      fireEvent.click(confirm);
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+      expect(fetchMock.mock.calls[2][0]).toContain('also_clear_hf_cli=true');
+      expect(screen.queryByText(i18n.t('settings.hf_token_clear_error'))).not.toBeInTheDocument();
+    } finally {
+      unmount();
+      await i18n.changeLanguage(previousLanguage);
+    }
   });
 
   it('"Test now" busts the whoami cache (?fresh=1); plain mounts stay cached', async () => {

--- a/frontend/src/components/settings/ApiKeysPanel.test.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.test.jsx
@@ -58,6 +58,25 @@ describe('ApiKeysPanel', () => {
     vi.restoreAllMocks();
   });
 
+  it('shows local token presence as untested until Test now is selected', async () => {
+    const local = {
+      active: null,
+      sources: [
+        { source: 'app', set: true, masked: 'hf_…abc', whoami_ok: null, whoami_user: null },
+      ],
+    };
+    const fetchMock = mockFetchSequence(
+      { status: 200, body: local },
+      { status: 200, body: STATE_APP_ACTIVE },
+    );
+    global.fetch = fetchMock;
+    render(<ApiKeysPanel />);
+    expect(await screen.findByText('Not tested')).toBeInTheDocument();
+    expect(screen.queryByText('whoami failed')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Test now' }));
+    await waitFor(() => expect(fetchMock.mock.calls.at(-1)[0]).toContain('?fresh=1'));
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+  });
   it('renders 3 source rows after mount', async () => {
     global.fetch = mockFetchOnce(STATE_THREE_UNSET);
     const { container } = render(<ApiKeysPanel />);

--- a/frontend/src/components/settings/ApiKeysPanel.test.jsx
+++ b/frontend/src/components/settings/ApiKeysPanel.test.jsx
@@ -174,7 +174,7 @@ describe('ApiKeysPanel', () => {
     const previousLanguage = i18n.language;
     await i18n.changeLanguage('ko');
     await waitFor(() => expect(i18n.hasResourceBundle('ko', 'translation')).toBe(true));
-    expect(i18n.t('settings.hf_token_clear_error')).not.toBe('Failed to clear token');
+    expect(i18n.t('common.error')).not.toBe('Something went wrong');
     const fetchMock = mockFetchSequence(
       { status: 200, body: STATE_APP_ACTIVE },
       { status: 500, body: { detail: 'Failed to clear local Hugging Face token files' } },
@@ -191,7 +191,7 @@ describe('ApiKeysPanel', () => {
       fireEvent.click(checkbox);
       const confirm = screen.getByRole('button', { name: i18n.t('settings.hf_token_clear_btn') });
       fireEvent.click(confirm);
-      expect(await screen.findByText(i18n.t('settings.hf_token_clear_error'))).toBeInTheDocument();
+      expect(await screen.findByText(i18n.t('common.error'))).toBeInTheDocument();
       expect(
         screen.queryByText('Failed to clear local Hugging Face token files'),
       ).not.toBeInTheDocument();
@@ -202,7 +202,7 @@ describe('ApiKeysPanel', () => {
       fireEvent.click(confirm);
       await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
       expect(fetchMock.mock.calls[2][0]).toContain('also_clear_hf_cli=true');
-      expect(screen.queryByText(i18n.t('settings.hf_token_clear_error'))).not.toBeInTheDocument();
+      expect(screen.queryByText(i18n.t('common.error'))).not.toBeInTheDocument();
     } finally {
       unmount();
       await i18n.changeLanguage(previousLanguage);

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "تم حفظ رمز Hugging Face - أصبحت التنزيلات الآن أسرع",
     "hf_token_inline_prompt": "قم بتسريع التنزيلات باستخدام رمز Hugging Face المميز المجاني",
     "hf_token_inline_ph": "الصق hf_... الرمز المميز (اختياري)",
-    "hf_token_get_short": "احصل على واحدة مجانًا →"
+    "hf_token_get_short": "احصل على واحدة مجانًا →",
+    "hf_token_active_using": "تستخدم رمز Hugging Face المميز الخاص بك من {{source}} — {{masked}}",
+    "hf_token_replace": "استبدال الرمز المميز…",
+    "hf_token_replace_warning": "سيؤدي هذا إلى استبدال الرمز المميز أعلاه — سيتوقف القديم عن العمل."
   },
   "history": {
     "dub_meta": "{{segments}} مقطعًا · {{duration}} ث",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "تم تجاوزها خارجيًا",
     "generate_timeout_shadowed_note": "يوجد متغيّر بيئة خارج VoiceStudio (الصدفة، ملف .env، أو الحاوية) يُحدّد هذه القيمة حاليًا — القيمة المحفوظة هنا تُتجاهل إلى أن تتم إزالة ذلك المتغيّر.",
     "generate_timeout_shadowed_toast": "تم الحفظ، لكن متغيّر بيئة خارج VoiceStudio يُحدّد هذه القيمة حاليًا — سيستمر استخدامه إلى أن تتم إزالة ذلك المتغيّر.",
-    "hf_token_not_checked": "لم يتم اختباره"
+    "hf_token_not_checked": "لم يتم اختباره",
+    "hf_source_app_label": "VoiceStudio (مشفّر، موصى به)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "متغير البيئة"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "فشلت إعادة التعيين: {{message}}",
     "reset_longform_failed": "تعذّر على VoiceStudio مسح المشاريع المحفوظة بأمان. بقيت بيانات مشاريعك دون تغيير؛ حرّر بعض مساحة التخزين أو أعد تشغيل التطبيق، ثم حاول مرة أخرى.",
     "cancel": "إلغاء",
-    "hf_token_also_clear": "امسح أيضًا",
+    "hf_token_also_clear": "احذف أيضًا ملفات الرموز المحفوظة لـ HuggingFace CLI",
     "hf_token_clear_btn": "مسح الرمز",
     "hf_token_clear_confirm": "هل تريد مسح رمز HuggingFace المحفوظ من التطبيق؟",
     "hf_token_clear_dialog": "مسح الرمز",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "تم الحفظ. أعد تشغيل VoiceStudio لتفعيل الميزانية الجديدة.",
     "generate_timeout_shadowed_badge": "تم تجاوزها خارجيًا",
     "generate_timeout_shadowed_note": "يوجد متغيّر بيئة خارج VoiceStudio (الصدفة، ملف .env، أو الحاوية) يُحدّد هذه القيمة حاليًا — القيمة المحفوظة هنا تُتجاهل إلى أن تتم إزالة ذلك المتغيّر.",
-    "generate_timeout_shadowed_toast": "تم الحفظ، لكن متغيّر بيئة خارج VoiceStudio يُحدّد هذه القيمة حاليًا — سيستمر استخدامه إلى أن تتم إزالة ذلك المتغيّر."
+    "generate_timeout_shadowed_toast": "تم الحفظ، لكن متغيّر بيئة خارج VoiceStudio يُحدّد هذه القيمة حاليًا — سيستمر استخدامه إلى أن تتم إزالة ذلك المتغيّر.",
+    "hf_token_not_checked": "لم يتم اختباره"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "قم بتسريع التنزيلات باستخدام رمز Hugging Face المميز المجاني",
     "hf_token_inline_ph": "الصق hf_... الرمز المميز (اختياري)",
     "hf_token_get_short": "احصل على واحدة مجانًا →",
-    "hf_token_active_using": "تستخدم رمز Hugging Face المميز الخاص بك من {{source}} — {{masked}}",
+    "hf_token_active_using": "تم العثور على رمز Hugging Face في {{source}} — {{masked}}",
     "hf_token_replace": "استبدال الرمز المميز…",
-    "hf_token_replace_warning": "سيؤدي هذا إلى استبدال الرمز المميز أعلاه — سيتوقف القديم عن العمل."
+    "hf_token_replace_warning": "يستبدل هذا الرمز المحفوظ لهذا التطبيق، ولا يُلغي الرمز القديم."
   },
   "history": {
     "dub_meta": "{{segments}} مقطعًا · {{duration}} ث",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Hugging Face-Token gespeichert – Downloads sind jetzt schneller",
     "hf_token_inline_prompt": "Beschleunigen Sie Downloads mit einem kostenlosen Hugging Face-Token",
     "hf_token_inline_ph": "HF_…-Token einfügen (optional)",
-    "hf_token_get_short": "Holen Sie sich eins gratis →"
+    "hf_token_get_short": "Holen Sie sich eins gratis →",
+    "hf_token_active_using": "Verwendet Ihr Hugging-Face-Token von {{source}} — {{masked}}",
+    "hf_token_replace": "Token ersetzen…",
+    "hf_token_replace_warning": "Dies ersetzt das obige Token — das alte funktioniert danach nicht mehr."
   },
   "history": {
     "dub_meta": "{{segments}} Segmente · {{duration}} s",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Zurücksetzen fehlgeschlagen: {{message}}",
     "reset_longform_failed": "VoiceStudio konnte die gespeicherten Projekte nicht sicher löschen. Deine Projektdaten wurden nicht verändert; gib Speicherplatz frei oder starte die App neu und versuche es erneut.",
     "cancel": "Abbrechen",
-    "hf_token_also_clear": "Ebenfalls löschen",
+    "hf_token_also_clear": "Auch gespeicherte HuggingFace-CLI-Tokendateien löschen",
     "hf_token_clear_btn": "Token löschen",
     "hf_token_clear_confirm": "Das HuggingFace-Token aus der App-Quelle löschen?",
     "hf_token_clear_dialog": "Token löschen",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Extern überschrieben",
     "generate_timeout_shadowed_note": "Eine Umgebungsvariable außerhalb von VoiceStudio (Shell, .env-Datei oder Container) legt diesen Wert derzeit fest — der hier gespeicherte Wert wird ignoriert, bis diese Variable entfernt wird.",
     "generate_timeout_shadowed_toast": "Gespeichert, aber eine Umgebungsvariable außerhalb von VoiceStudio legt diesen Wert derzeit fest — sie wird weiter verwendet, bis diese Variable entfernt wird.",
-    "hf_token_not_checked": "Nicht getestet"
+    "hf_token_not_checked": "Nicht getestet",
+    "hf_source_app_label": "VoiceStudio (verschlüsselt, empfohlen)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Umgebungsvariable"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Gespeichert. Starte VoiceStudio neu, damit das neue Budget wirksam wird.",
     "generate_timeout_shadowed_badge": "Extern überschrieben",
     "generate_timeout_shadowed_note": "Eine Umgebungsvariable außerhalb von VoiceStudio (Shell, .env-Datei oder Container) legt diesen Wert derzeit fest — der hier gespeicherte Wert wird ignoriert, bis diese Variable entfernt wird.",
-    "generate_timeout_shadowed_toast": "Gespeichert, aber eine Umgebungsvariable außerhalb von VoiceStudio legt diesen Wert derzeit fest — sie wird weiter verwendet, bis diese Variable entfernt wird."
+    "generate_timeout_shadowed_toast": "Gespeichert, aber eine Umgebungsvariable außerhalb von VoiceStudio legt diesen Wert derzeit fest — sie wird weiter verwendet, bis diese Variable entfernt wird.",
+    "hf_token_not_checked": "Nicht getestet"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Beschleunigen Sie Downloads mit einem kostenlosen Hugging Face-Token",
     "hf_token_inline_ph": "HF_…-Token einfügen (optional)",
     "hf_token_get_short": "Holen Sie sich eins gratis →",
-    "hf_token_active_using": "Verwendet Ihr Hugging-Face-Token von {{source}} — {{masked}}",
+    "hf_token_active_using": "Hugging-Face-Token in {{source}} gefunden — {{masked}}",
     "hf_token_replace": "Token ersetzen…",
-    "hf_token_replace_warning": "Dies ersetzt das obige Token — das alte funktioniert danach nicht mehr."
+    "hf_token_replace_warning": "Dies ersetzt das für diese App gespeicherte Token. Das alte Token wird nicht widerrufen."
   },
   "history": {
     "dub_meta": "{{segments}} Segmente · {{duration}} s",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -3099,7 +3099,10 @@
     "hf_token_error": "Could not save the token — try again or set it later in Settings → Credentials.",
     "hf_token_inline_prompt": "Speed up downloads with a free Hugging Face token",
     "hf_token_inline_ph": "Paste hf_… token (optional)",
-    "hf_token_get_short": "Get one free →"
+    "hf_token_get_short": "Get one free →",
+    "hf_token_active_using": "Using your Hugging Face token from {{source}} — {{masked}}",
+    "hf_token_replace": "Replace token…",
+    "hf_token_replace_warning": "This replaces the token above — the old one stops working."
   },
   "history": {
     "dub_meta": "{{segments}} segs · {{duration}}s",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -939,7 +939,8 @@
     "device_load_failed": "Failed to load device setting",
     "generate_timeout_shadowed_badge": "Overridden externally",
     "generate_timeout_shadowed_note": "An environment variable outside VoiceStudio (shell, .env file, or container) is currently setting this — your saved value here is ignored until that variable is removed.",
-    "generate_timeout_shadowed_toast": "Saved, but an environment variable outside VoiceStudio is currently setting this — it will keep being used until that variable is removed."
+    "generate_timeout_shadowed_toast": "Saved, but an environment variable outside VoiceStudio is currently setting this — it will keep being used until that variable is removed.",
+    "hf_token_not_checked": "Not tested"
   },
   "about": {
     "app": "App",
@@ -3100,9 +3101,9 @@
     "hf_token_inline_prompt": "Speed up downloads with a free Hugging Face token",
     "hf_token_inline_ph": "Paste hf_… token (optional)",
     "hf_token_get_short": "Get one free →",
-    "hf_token_active_using": "Using your Hugging Face token from {{source}} — {{masked}}",
+    "hf_token_active_using": "Hugging Face token found in {{source}} — {{masked}}",
     "hf_token_replace": "Replace token…",
-    "hf_token_replace_warning": "This replaces the token above — the old one stops working."
+    "hf_token_replace_warning": "This replaces the token saved for this app. It does not revoke the old token."
   },
   "history": {
     "dub_meta": "{{segments}} segs · {{duration}}s",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -600,7 +600,7 @@
     "shortcut_reset_failed": "Reset failed: {{message}}",
     "reset_longform_failed": "VoiceStudio couldn’t safely clear saved projects. Your project data was left intact; free some storage or restart the app, then try again.",
     "cancel": "Cancel",
-    "hf_token_also_clear": "Also clear",
+    "hf_token_also_clear": "Also clear saved HuggingFace CLI token files",
     "hf_token_clear_btn": "Clear token",
     "hf_token_clear_confirm": "Clear the App-source HuggingFace token?",
     "hf_token_clear_dialog": "Clear token",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Token de Hugging Face guardado: las descargas ahora son más rápidas",
     "hf_token_inline_prompt": "Acelere las descargas con un token Hugging Face gratuito",
     "hf_token_inline_ph": "Pegue el token hf_… (opcional)",
-    "hf_token_get_short": "Consigue uno gratis →"
+    "hf_token_get_short": "Consigue uno gratis →",
+    "hf_token_active_using": "Usando tu token de Hugging Face de {{source}} — {{masked}}",
+    "hf_token_replace": "Reemplazar token…",
+    "hf_token_replace_warning": "Esto reemplazará el token anterior — el antiguo dejará de funcionar."
   },
   "history": {
     "dub_meta": "{{segments}} segmentos · {{duration}} s",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Error al restablecer: {{message}}",
     "reset_longform_failed": "VoiceStudio no pudo borrar de forma segura los proyectos guardados. Los datos de tus proyectos no se modificaron; libera espacio de almacenamiento o reinicia la aplicación y vuelve a intentarlo.",
     "cancel": "Cancelar",
-    "hf_token_also_clear": "Borrar también",
+    "hf_token_also_clear": "Borrar también los archivos de tokens guardados de HuggingFace CLI",
     "hf_token_clear_btn": "Borrar token",
     "hf_token_clear_confirm": "¿Borrar el token de HuggingFace guardado por la aplicación?",
     "hf_token_clear_dialog": "Borrar token",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Anulado externamente",
     "generate_timeout_shadowed_note": "Una variable de entorno externa a VoiceStudio (shell, archivo .env o contenedor) está estableciendo este valor actualmente — el valor guardado aquí se ignora hasta que se elimine esa variable.",
     "generate_timeout_shadowed_toast": "Guardado, pero una variable de entorno externa a VoiceStudio está estableciendo este valor actualmente — seguirá usándose hasta que se elimine esa variable.",
-    "hf_token_not_checked": "Sin probar"
+    "hf_token_not_checked": "Sin probar",
+    "hf_source_app_label": "VoiceStudio (cifrado, recomendado)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Variable de entorno"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Guardado. Reinicia VoiceStudio para que el nuevo presupuesto surta efecto.",
     "generate_timeout_shadowed_badge": "Anulado externamente",
     "generate_timeout_shadowed_note": "Una variable de entorno externa a VoiceStudio (shell, archivo .env o contenedor) está estableciendo este valor actualmente — el valor guardado aquí se ignora hasta que se elimine esa variable.",
-    "generate_timeout_shadowed_toast": "Guardado, pero una variable de entorno externa a VoiceStudio está estableciendo este valor actualmente — seguirá usándose hasta que se elimine esa variable."
+    "generate_timeout_shadowed_toast": "Guardado, pero una variable de entorno externa a VoiceStudio está estableciendo este valor actualmente — seguirá usándose hasta que se elimine esa variable.",
+    "hf_token_not_checked": "Sin probar"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Acelere las descargas con un token Hugging Face gratuito",
     "hf_token_inline_ph": "Pegue el token hf_… (opcional)",
     "hf_token_get_short": "Consigue uno gratis →",
-    "hf_token_active_using": "Usando tu token de Hugging Face de {{source}} — {{masked}}",
+    "hf_token_active_using": "Token de Hugging Face encontrado en {{source}} — {{masked}}",
     "hf_token_replace": "Reemplazar token…",
-    "hf_token_replace_warning": "Esto reemplazará el token anterior — el antiguo dejará de funcionar."
+    "hf_token_replace_warning": "Esto reemplaza el token guardado para esta aplicación. No revoca el token anterior."
   },
   "history": {
     "dub_meta": "{{segments}} segmentos · {{duration}} s",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Jeton Hugging Face enregistré – les téléchargements sont désormais plus rapides",
     "hf_token_inline_prompt": "Accélérez les téléchargements avec un jeton Hugging Face gratuit",
     "hf_token_inline_ph": "Coller le jeton hf_… (facultatif)",
-    "hf_token_get_short": "Obtenez-en un gratuitement →"
+    "hf_token_get_short": "Obtenez-en un gratuitement →",
+    "hf_token_active_using": "Utilisation de votre jeton Hugging Face depuis {{source}} — {{masked}}",
+    "hf_token_replace": "Remplacer le jeton…",
+    "hf_token_replace_warning": "Cela remplacera le jeton ci-dessus — l'ancien cessera de fonctionner."
   },
   "history": {
     "dub_meta": "{{segments}} segments · {{duration}} s",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Enregistré. Redémarrez VoiceStudio pour que le nouveau budget prenne effet.",
     "generate_timeout_shadowed_badge": "Remplacé de l'extérieur",
     "generate_timeout_shadowed_note": "Une variable d'environnement extérieure à VoiceStudio (shell, fichier .env ou conteneur) définit actuellement cette valeur — la valeur enregistrée ici est ignorée tant que cette variable n'est pas supprimée.",
-    "generate_timeout_shadowed_toast": "Enregistré, mais une variable d'environnement extérieure à VoiceStudio définit actuellement cette valeur — elle continuera d'être utilisée tant que cette variable ne sera pas supprimée."
+    "generate_timeout_shadowed_toast": "Enregistré, mais une variable d'environnement extérieure à VoiceStudio définit actuellement cette valeur — elle continuera d'être utilisée tant que cette variable ne sera pas supprimée.",
+    "hf_token_not_checked": "Non testé"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Accélérez les téléchargements avec un jeton Hugging Face gratuit",
     "hf_token_inline_ph": "Coller le jeton hf_… (facultatif)",
     "hf_token_get_short": "Obtenez-en un gratuitement →",
-    "hf_token_active_using": "Utilisation de votre jeton Hugging Face depuis {{source}} — {{masked}}",
+    "hf_token_active_using": "Jeton Hugging Face trouvé dans {{source}} — {{masked}}",
     "hf_token_replace": "Remplacer le jeton…",
-    "hf_token_replace_warning": "Cela remplacera le jeton ci-dessus — l'ancien cessera de fonctionner."
+    "hf_token_replace_warning": "Cela remplace le jeton enregistré pour cette application, sans révoquer l’ancien jeton."
   },
   "history": {
     "dub_meta": "{{segments}} segments · {{duration}} s",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Échec de la réinitialisation : {{message}}",
     "reset_longform_failed": "VoiceStudio n’a pas pu effacer les projets enregistrés en toute sécurité. Les données de vos projets sont restées intactes ; libérez de l’espace ou redémarrez l’application, puis réessayez.",
     "cancel": "Annuler",
-    "hf_token_also_clear": "Effacer aussi",
+    "hf_token_also_clear": "Supprimer aussi les fichiers de jetons enregistrés de HuggingFace CLI",
     "hf_token_clear_btn": "Effacer le jeton",
     "hf_token_clear_confirm": "Effacer le jeton HuggingFace de la source App ?",
     "hf_token_clear_dialog": "Effacer le jeton",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Remplacé de l'extérieur",
     "generate_timeout_shadowed_note": "Une variable d'environnement extérieure à VoiceStudio (shell, fichier .env ou conteneur) définit actuellement cette valeur — la valeur enregistrée ici est ignorée tant que cette variable n'est pas supprimée.",
     "generate_timeout_shadowed_toast": "Enregistré, mais une variable d'environnement extérieure à VoiceStudio définit actuellement cette valeur — elle continuera d'être utilisée tant que cette variable ne sera pas supprimée.",
-    "hf_token_not_checked": "Non testé"
+    "hf_token_not_checked": "Non testé",
+    "hf_source_app_label": "VoiceStudio (chiffré, recommandé)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Variable d’environnement"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "हगिंग फेस टोकन सहेजा गया - डाउनलोड अब तेज़ हैं",
     "hf_token_inline_prompt": "निःशुल्क हगिंग फेस टोकन के साथ डाउनलोड की गति बढ़ाएं",
     "hf_token_inline_ph": "hf_...टोकन चिपकाएँ (वैकल्पिक)",
-    "hf_token_get_short": "एक निःशुल्क प्राप्त करें →"
+    "hf_token_get_short": "एक निःशुल्क प्राप्त करें →",
+    "hf_token_active_using": "आपका Hugging Face टोकन {{source}} से उपयोग हो रहा है — {{masked}}",
+    "hf_token_replace": "टोकन बदलें…",
+    "hf_token_replace_warning": "इससे ऊपर दिया गया टोकन बदल जाएगा — पुराना काम करना बंद कर देगा।"
   },
   "history": {
     "dub_meta": "{{segments}} खंड · {{duration}} सेकंड",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "रीसेट विफल: {{message}}",
     "reset_longform_failed": "VoiceStudio सेव किए गए प्रोजेक्ट सुरक्षित रूप से साफ़ नहीं कर सका। आपका प्रोजेक्ट डेटा नहीं बदला गया; कुछ स्टोरेज खाली करें या ऐप को फिर से शुरू करके दोबारा कोशिश करें।",
     "cancel": "रद्द करें",
-    "hf_token_also_clear": "साथ ही साफ़ करें",
+    "hf_token_also_clear": "HuggingFace CLI की सहेजी गई टोकन फ़ाइलें भी हटाएँ",
     "hf_token_clear_btn": "टोकन साफ़ करें",
     "hf_token_clear_confirm": "ऐप-स्रोत HuggingFace टोकन साफ़ करें?",
     "hf_token_clear_dialog": "टोकन साफ़ करें",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "बाहरी रूप से ओवरराइड किया गया",
     "generate_timeout_shadowed_note": "VoiceStudio के बाहर का एक एनवायरनमेंट वेरिएबल (शेल, .env फ़ाइल, या कंटेनर) फ़िलहाल यह मान सेट कर रहा है — यहाँ सेव किया गया मान तब तक अनदेखा किया जाएगा जब तक वह वेरिएबल हटाया न जाए।",
     "generate_timeout_shadowed_toast": "सेव हो गया, लेकिन VoiceStudio के बाहर का एक एनवायरनमेंट वेरिएबल फ़िलहाल यह मान सेट कर रहा है — जब तक वह वेरिएबल हटाया नहीं जाता, वही इस्तेमाल होता रहेगा।",
-    "hf_token_not_checked": "परीक्षण नहीं हुआ"
+    "hf_token_not_checked": "परीक्षण नहीं हुआ",
+    "hf_source_app_label": "VoiceStudio (एन्क्रिप्ट किया गया, अनुशंसित)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "परिवेश चर"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "सेव हो गया। नया बजट लागू करने के लिए VoiceStudio को पुनः आरंभ करें।",
     "generate_timeout_shadowed_badge": "बाहरी रूप से ओवरराइड किया गया",
     "generate_timeout_shadowed_note": "VoiceStudio के बाहर का एक एनवायरनमेंट वेरिएबल (शेल, .env फ़ाइल, या कंटेनर) फ़िलहाल यह मान सेट कर रहा है — यहाँ सेव किया गया मान तब तक अनदेखा किया जाएगा जब तक वह वेरिएबल हटाया न जाए।",
-    "generate_timeout_shadowed_toast": "सेव हो गया, लेकिन VoiceStudio के बाहर का एक एनवायरनमेंट वेरिएबल फ़िलहाल यह मान सेट कर रहा है — जब तक वह वेरिएबल हटाया नहीं जाता, वही इस्तेमाल होता रहेगा।"
+    "generate_timeout_shadowed_toast": "सेव हो गया, लेकिन VoiceStudio के बाहर का एक एनवायरनमेंट वेरिएबल फ़िलहाल यह मान सेट कर रहा है — जब तक वह वेरिएबल हटाया नहीं जाता, वही इस्तेमाल होता रहेगा।",
+    "hf_token_not_checked": "परीक्षण नहीं हुआ"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "निःशुल्क हगिंग फेस टोकन के साथ डाउनलोड की गति बढ़ाएं",
     "hf_token_inline_ph": "hf_...टोकन चिपकाएँ (वैकल्पिक)",
     "hf_token_get_short": "एक निःशुल्क प्राप्त करें →",
-    "hf_token_active_using": "आपका Hugging Face टोकन {{source}} से उपयोग हो रहा है — {{masked}}",
+    "hf_token_active_using": "{{source}} में Hugging Face टोकन मिला — {{masked}}",
     "hf_token_replace": "टोकन बदलें…",
-    "hf_token_replace_warning": "इससे ऊपर दिया गया टोकन बदल जाएगा — पुराना काम करना बंद कर देगा।"
+    "hf_token_replace_warning": "यह इस ऐप के लिए सहेजे गए टोकन को बदलता है। पुराना टोकन रद्द नहीं होता।"
   },
   "history": {
     "dub_meta": "{{segments}} खंड · {{duration}} सेकंड",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Token Hugging Face disimpan — pengunduhan kini lebih cepat",
     "hf_token_inline_prompt": "Percepat pengunduhan dengan token Hugging Face gratis",
     "hf_token_inline_ph": "Tempel hf_… token (opsional)",
-    "hf_token_get_short": "Dapatkan satu gratis →"
+    "hf_token_get_short": "Dapatkan satu gratis →",
+    "hf_token_active_using": "Menggunakan token Hugging Face Anda dari {{source}} — {{masked}}",
+    "hf_token_replace": "Ganti token…",
+    "hf_token_replace_warning": "Ini akan mengganti token di atas — token lama akan berhenti berfungsi."
   },
   "history": {
     "dub_meta": "{{segments}} segmen · {{duration}} dtk",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Penyetelan ulang gagal: {{message}}",
     "reset_longform_failed": "VoiceStudio tidak dapat menghapus proyek tersimpan dengan aman. Data proyek Anda tidak diubah; kosongkan sebagian ruang penyimpanan atau mulai ulang aplikasi, lalu coba lagi.",
     "cancel": "Batalkan",
-    "hf_token_also_clear": "Hapus juga",
+    "hf_token_also_clear": "Hapus juga berkas token HuggingFace CLI yang tersimpan",
     "hf_token_clear_btn": "Hapus token",
     "hf_token_clear_confirm": "Hapus token HuggingFace dari sumber Aplikasi?",
     "hf_token_clear_dialog": "Hapus token",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Tersimpan. Mulai ulang VoiceStudio agar anggaran baru berlaku.",
     "generate_timeout_shadowed_badge": "Ditimpa secara eksternal",
     "generate_timeout_shadowed_note": "Variabel lingkungan di luar VoiceStudio (shell, file .env, atau kontainer) saat ini sedang mengatur nilai ini — nilai yang disimpan di sini diabaikan sampai variabel tersebut dihapus.",
-    "generate_timeout_shadowed_toast": "Tersimpan, tetapi variabel lingkungan di luar VoiceStudio saat ini sedang mengatur nilai ini — nilai itu akan terus digunakan sampai variabel tersebut dihapus."
+    "generate_timeout_shadowed_toast": "Tersimpan, tetapi variabel lingkungan di luar VoiceStudio saat ini sedang mengatur nilai ini — nilai itu akan terus digunakan sampai variabel tersebut dihapus.",
+    "hf_token_not_checked": "Belum diuji"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Percepat pengunduhan dengan token Hugging Face gratis",
     "hf_token_inline_ph": "Tempel hf_… token (opsional)",
     "hf_token_get_short": "Dapatkan satu gratis →",
-    "hf_token_active_using": "Menggunakan token Hugging Face Anda dari {{source}} — {{masked}}",
+    "hf_token_active_using": "Token Hugging Face ditemukan di {{source}} — {{masked}}",
     "hf_token_replace": "Ganti token…",
-    "hf_token_replace_warning": "Ini akan mengganti token di atas — token lama akan berhenti berfungsi."
+    "hf_token_replace_warning": "Ini mengganti token yang disimpan untuk aplikasi ini. Token lama tidak dicabut."
   },
   "history": {
     "dub_meta": "{{segments}} segmen · {{duration}} dtk",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Ditimpa secara eksternal",
     "generate_timeout_shadowed_note": "Variabel lingkungan di luar VoiceStudio (shell, file .env, atau kontainer) saat ini sedang mengatur nilai ini — nilai yang disimpan di sini diabaikan sampai variabel tersebut dihapus.",
     "generate_timeout_shadowed_toast": "Tersimpan, tetapi variabel lingkungan di luar VoiceStudio saat ini sedang mengatur nilai ini — nilai itu akan terus digunakan sampai variabel tersebut dihapus.",
-    "hf_token_not_checked": "Belum diuji"
+    "hf_token_not_checked": "Belum diuji",
+    "hf_source_app_label": "VoiceStudio (terenkripsi, disarankan)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Variabel lingkungan"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Token del volto abbracciato salvato: i download ora sono più veloci",
     "hf_token_inline_prompt": "Velocizza i download con un token Hugging Face gratuito",
     "hf_token_inline_ph": "Incolla il token hf_… (facoltativo)",
-    "hf_token_get_short": "Ottienine uno gratis →"
+    "hf_token_get_short": "Ottienine uno gratis →",
+    "hf_token_active_using": "Utilizzo del tuo token Hugging Face da {{source}} — {{masked}}",
+    "hf_token_replace": "Sostituisci token…",
+    "hf_token_replace_warning": "Questo sostituirà il token sopra — quello vecchio smetterà di funzionare."
   },
   "history": {
     "dub_meta": "{{segments}} segmenti · {{duration}} s",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Salvato. Riavvia VoiceStudio affinché il nuovo budget abbia effetto.",
     "generate_timeout_shadowed_badge": "Sovrascritto esternamente",
     "generate_timeout_shadowed_note": "Una variabile d'ambiente esterna a VoiceStudio (shell, file .env o container) sta attualmente impostando questo valore — il valore salvato qui viene ignorato finché quella variabile non viene rimossa.",
-    "generate_timeout_shadowed_toast": "Salvato, ma una variabile d'ambiente esterna a VoiceStudio sta attualmente impostando questo valore — continuerà a essere usato finché quella variabile non viene rimossa."
+    "generate_timeout_shadowed_toast": "Salvato, ma una variabile d'ambiente esterna a VoiceStudio sta attualmente impostando questo valore — continuerà a essere usato finché quella variabile non viene rimossa.",
+    "hf_token_not_checked": "Non testato"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Velocizza i download con un token Hugging Face gratuito",
     "hf_token_inline_ph": "Incolla il token hf_… (facoltativo)",
     "hf_token_get_short": "Ottienine uno gratis →",
-    "hf_token_active_using": "Utilizzo del tuo token Hugging Face da {{source}} — {{masked}}",
+    "hf_token_active_using": "Token Hugging Face trovato in {{source}} — {{masked}}",
     "hf_token_replace": "Sostituisci token…",
-    "hf_token_replace_warning": "Questo sostituirà il token sopra — quello vecchio smetterà di funzionare."
+    "hf_token_replace_warning": "Questo sostituisce il token salvato per questa app. Non revoca il vecchio token."
   },
   "history": {
     "dub_meta": "{{segments}} segmenti · {{duration}} s",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Reimpostazione non riuscita: {{message}}",
     "reset_longform_failed": "VoiceStudio non ha potuto cancellare in modo sicuro i progetti salvati. I dati dei progetti non sono stati modificati; libera spazio di archiviazione o riavvia l’app, quindi riprova.",
     "cancel": "Annulla",
-    "hf_token_also_clear": "Cancella anche",
+    "hf_token_also_clear": "Elimina anche i file dei token salvati di HuggingFace CLI",
     "hf_token_clear_btn": "Cancella token",
     "hf_token_clear_confirm": "Cancellare il token HuggingFace della sorgente App?",
     "hf_token_clear_dialog": "Cancella token",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Sovrascritto esternamente",
     "generate_timeout_shadowed_note": "Una variabile d'ambiente esterna a VoiceStudio (shell, file .env o container) sta attualmente impostando questo valore — il valore salvato qui viene ignorato finché quella variabile non viene rimossa.",
     "generate_timeout_shadowed_toast": "Salvato, ma una variabile d'ambiente esterna a VoiceStudio sta attualmente impostando questo valore — continuerà a essere usato finché quella variabile non viene rimossa.",
-    "hf_token_not_checked": "Non testato"
+    "hf_token_not_checked": "Non testato",
+    "hf_source_app_label": "VoiceStudio (crittografato, consigliato)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Variabile d’ambiente"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "ハグフェイストークンが保存されました — ダウンロードが速くなりました",
     "hf_token_inline_prompt": "無料の Hugging Face トークンでダウンロードを高速化",
     "hf_token_inline_ph": "hf_… トークンを貼り付けます (オプション)",
-    "hf_token_get_short": "1 つ無料で入手 →"
+    "hf_token_get_short": "1 つ無料で入手 →",
+    "hf_token_active_using": "{{source}} からの Hugging Face トークンを使用中 — {{masked}}",
+    "hf_token_replace": "トークンを置き換える…",
+    "hf_token_replace_warning": "これにより上記のトークンが置き換えられます。古いトークンは使用できなくなります。"
   },
   "history": {
     "dub_meta": "{{segments}} セグメント · {{duration}} 秒",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "保存しました。新しい予算を適用するには VoiceStudio を再起動してください。",
     "generate_timeout_shadowed_badge": "外部から上書きされています",
     "generate_timeout_shadowed_note": "VoiceStudio の外部にある環境変数（シェル、.env ファイル、またはコンテナ）が現在この値を設定しています — その変数が削除されるまで、ここで保存した値は無視されます。",
-    "generate_timeout_shadowed_toast": "保存しましたが、VoiceStudio の外部にある環境変数が現在この値を設定しています — その変数が削除されるまで、その値が使われ続けます。"
+    "generate_timeout_shadowed_toast": "保存しましたが、VoiceStudio の外部にある環境変数が現在この値を設定しています — その変数が削除されるまで、その値が使われ続けます。",
+    "hf_token_not_checked": "未テスト"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "無料の Hugging Face トークンでダウンロードを高速化",
     "hf_token_inline_ph": "hf_… トークンを貼り付けます (オプション)",
     "hf_token_get_short": "1 つ無料で入手 →",
-    "hf_token_active_using": "{{source}} からの Hugging Face トークンを使用中 — {{masked}}",
+    "hf_token_active_using": "{{source}} に Hugging Face トークンがあります — {{masked}}",
     "hf_token_replace": "トークンを置き換える…",
-    "hf_token_replace_warning": "これにより上記のトークンが置き換えられます。古いトークンは使用できなくなります。"
+    "hf_token_replace_warning": "このアプリに保存されたトークンを置き換えます。古いトークンは失効しません。"
   },
   "history": {
     "dub_meta": "{{segments}} セグメント · {{duration}} 秒",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "リセットに失敗しました: {{message}}",
     "reset_longform_failed": "VoiceStudio は保存済みプロジェクトを安全に消去できませんでした。プロジェクトデータは変更されていません。ストレージの空き容量を増やすかアプリを再起動して、もう一度お試しください。",
     "cancel": "キャンセル",
-    "hf_token_also_clear": "あわせてクリア",
+    "hf_token_also_clear": "保存済みの HuggingFace CLI トークンファイルも削除する",
     "hf_token_clear_btn": "トークンをクリア",
     "hf_token_clear_confirm": "アプリに保存された HuggingFace トークンをクリアしますか?",
     "hf_token_clear_dialog": "トークンをクリア",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "外部から上書きされています",
     "generate_timeout_shadowed_note": "VoiceStudio の外部にある環境変数（シェル、.env ファイル、またはコンテナ）が現在この値を設定しています — その変数が削除されるまで、ここで保存した値は無視されます。",
     "generate_timeout_shadowed_toast": "保存しましたが、VoiceStudio の外部にある環境変数が現在この値を設定しています — その変数が削除されるまで、その値が使われ続けます。",
-    "hf_token_not_checked": "未テスト"
+    "hf_token_not_checked": "未テスト",
+    "hf_source_app_label": "VoiceStudio（暗号化済み、推奨）",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "環境変数"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -2788,6 +2788,9 @@
     "hf_token_inline_prompt": "무료 Hugging Face 토큰으로 다운로드 속도를 높이세요",
     "hf_token_inline_ph": "hf_… 토큰 붙여넣기(선택 사항)",
     "hf_token_get_short": "하나를 무료로 받으세요 →",
+    "hf_token_active_using": "{{source}}의 Hugging Face 토큰을 사용 중입니다 — {{masked}}",
+    "hf_token_replace": "토큰 교체…",
+    "hf_token_replace_warning": "위의 토큰을 교체합니다 — 이전 토큰은 더 이상 작동하지 않습니다.",
     "lib_install_failed": "설치 실패: {{error}}",
     "lib_retry": "다시 시도"
   },

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -573,7 +573,8 @@
     "generate_timeout_saved": "저장되었습니다. 새 예산을 적용하려면 VoiceStudio를 재시작하세요.",
     "generate_timeout_shadowed_badge": "외부에서 재정의됨",
     "generate_timeout_shadowed_note": "VoiceStudio 외부의 환경 변수(셸, .env 파일 또는 컨테이너)가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 여기에 저장한 값은 무시됩니다.",
-    "generate_timeout_shadowed_toast": "저장되었지만, VoiceStudio 외부의 환경 변수가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 계속 사용됩니다."
+    "generate_timeout_shadowed_toast": "저장되었지만, VoiceStudio 외부의 환경 변수가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 계속 사용됩니다.",
+    "hf_token_not_checked": "테스트 안 함"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2788,9 +2789,9 @@
     "hf_token_inline_prompt": "무료 Hugging Face 토큰으로 다운로드 속도를 높이세요",
     "hf_token_inline_ph": "hf_… 토큰 붙여넣기(선택 사항)",
     "hf_token_get_short": "하나를 무료로 받으세요 →",
-    "hf_token_active_using": "{{source}}의 Hugging Face 토큰을 사용 중입니다 — {{masked}}",
+    "hf_token_active_using": "{{source}}에서 Hugging Face 토큰 발견 — {{masked}}",
     "hf_token_replace": "토큰 교체…",
-    "hf_token_replace_warning": "위의 토큰을 교체합니다 — 이전 토큰은 더 이상 작동하지 않습니다.",
+    "hf_token_replace_warning": "이 앱에 저장된 토큰을 교체합니다. 기존 토큰은 폐기되지 않습니다.",
     "lib_install_failed": "설치 실패: {{error}}",
     "lib_retry": "다시 시도"
   },

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "재설정 실패: {{message}}",
     "reset_longform_failed": "VoiceStudio에서 저장된 프로젝트를 안전하게 지우지 못했습니다. 프로젝트 데이터는 변경되지 않았습니다. 저장 공간을 확보하거나 앱을 다시 시작한 후 다시 시도하세요.",
     "cancel": "취소",
-    "hf_token_also_clear": "함께 지우기",
+    "hf_token_also_clear": "저장된 HuggingFace CLI 토큰 파일도 삭제",
     "hf_token_clear_btn": "토큰 지우기",
     "hf_token_clear_confirm": "앱 소스 HuggingFace 토큰을 지우시겠습니까?",
     "hf_token_clear_dialog": "토큰 지우기",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Knuffelgezicht-token opgeslagen — downloads zijn nu sneller",
     "hf_token_inline_prompt": "Versnel downloads met een gratis Hugging Face-token",
     "hf_token_inline_ph": "Plak het hf_…-token (optioneel)",
-    "hf_token_get_short": "Ontvang er één gratis →"
+    "hf_token_get_short": "Ontvang er één gratis →",
+    "hf_token_active_using": "Gebruikt uw Hugging Face-token van {{source}} — {{masked}}",
+    "hf_token_replace": "Token vervangen…",
+    "hf_token_replace_warning": "Dit vervangt de token hierboven — de oude werkt daarna niet meer."
   },
   "history": {
     "dub_meta": "{{segments}} segmenten · {{duration}} s",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Extern overschreven",
     "generate_timeout_shadowed_note": "Een omgevingsvariabele buiten VoiceStudio (shell, .env-bestand of container) stelt deze waarde momenteel in — de hier opgeslagen waarde wordt genegeerd totdat die variabele wordt verwijderd.",
     "generate_timeout_shadowed_toast": "Opgeslagen, maar een omgevingsvariabele buiten VoiceStudio stelt deze waarde momenteel in — die blijft gebruikt worden totdat die variabele wordt verwijderd.",
-    "hf_token_not_checked": "Niet getest"
+    "hf_token_not_checked": "Niet getest",
+    "hf_source_app_label": "VoiceStudio (versleuteld, aanbevolen)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Omgevingsvariabele"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Reset mislukt: {{message}}",
     "reset_longform_failed": "VoiceStudio kon de opgeslagen projecten niet veilig wissen. Je projectgegevens zijn niet gewijzigd; maak opslagruimte vrij of start de app opnieuw en probeer het nogmaals.",
     "cancel": "Annuleer",
-    "hf_token_also_clear": "Ook wissen",
+    "hf_token_also_clear": "Ook opgeslagen HuggingFace CLI-tokenbestanden verwijderen",
     "hf_token_clear_btn": "Token wissen",
     "hf_token_clear_confirm": "De HuggingFace-token uit de app-bron wissen?",
     "hf_token_clear_dialog": "Token wissen",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Opgeslagen. Herstart VoiceStudio om het nieuwe budget toe te passen.",
     "generate_timeout_shadowed_badge": "Extern overschreven",
     "generate_timeout_shadowed_note": "Een omgevingsvariabele buiten VoiceStudio (shell, .env-bestand of container) stelt deze waarde momenteel in — de hier opgeslagen waarde wordt genegeerd totdat die variabele wordt verwijderd.",
-    "generate_timeout_shadowed_toast": "Opgeslagen, maar een omgevingsvariabele buiten VoiceStudio stelt deze waarde momenteel in — die blijft gebruikt worden totdat die variabele wordt verwijderd."
+    "generate_timeout_shadowed_toast": "Opgeslagen, maar een omgevingsvariabele buiten VoiceStudio stelt deze waarde momenteel in — die blijft gebruikt worden totdat die variabele wordt verwijderd.",
+    "hf_token_not_checked": "Niet getest"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Versnel downloads met een gratis Hugging Face-token",
     "hf_token_inline_ph": "Plak het hf_…-token (optioneel)",
     "hf_token_get_short": "Ontvang er één gratis →",
-    "hf_token_active_using": "Gebruikt uw Hugging Face-token van {{source}} — {{masked}}",
+    "hf_token_active_using": "Hugging Face-token gevonden in {{source}} — {{masked}}",
     "hf_token_replace": "Token vervangen…",
-    "hf_token_replace_warning": "Dit vervangt de token hierboven — de oude werkt daarna niet meer."
+    "hf_token_replace_warning": "Dit vervangt het token dat voor deze app is opgeslagen. Het oude token wordt niet ingetrokken."
   },
   "history": {
     "dub_meta": "{{segments}} segmenten · {{duration}} s",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Token Przytulonej Twarzy został zapisany — pobieranie jest teraz szybsze",
     "hf_token_inline_prompt": "Przyspiesz pobieranie dzięki darmowemu tokenowi Przytulająca Twarz",
     "hf_token_inline_ph": "Wklej token hf_… (opcjonalnie)",
-    "hf_token_get_short": "Zdobądź jeden za darmo →"
+    "hf_token_get_short": "Zdobądź jeden za darmo →",
+    "hf_token_active_using": "Używa Twojego tokenu Hugging Face z {{source}} — {{masked}}",
+    "hf_token_replace": "Zastąp token…",
+    "hf_token_replace_warning": "To zastąpi powyższy token — stary przestanie działać."
   },
   "history": {
     "dub_meta": "{{segments}} segmentów · {{duration}} s",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Nadpisane zewnętrznie",
     "generate_timeout_shadowed_note": "Zmienna środowiskowa spoza VoiceStudio (powłoka, plik .env lub kontener) obecnie ustawia tę wartość — zapisana tu wartość jest ignorowana, dopóki ta zmienna nie zostanie usunięta.",
     "generate_timeout_shadowed_toast": "Zapisano, ale zmienna środowiskowa spoza VoiceStudio obecnie ustawia tę wartość — będzie nadal używana, dopóki ta zmienna nie zostanie usunięta.",
-    "hf_token_not_checked": "Nie przetestowano"
+    "hf_token_not_checked": "Nie przetestowano",
+    "hf_source_app_label": "VoiceStudio (zaszyfrowane, zalecane)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Zmienna środowiskowa"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Resetowanie nie powiodło się: {{message}}",
     "reset_longform_failed": "VoiceStudio nie mógł bezpiecznie usunąć zapisanych projektów. Dane projektów nie zostały zmienione; zwolnij miejsce lub uruchom aplikację ponownie i spróbuj jeszcze raz.",
     "cancel": "Anuluj",
-    "hf_token_also_clear": "Wyczyść również",
+    "hf_token_also_clear": "Usuń również zapisane pliki tokenów HuggingFace CLI",
     "hf_token_clear_btn": "Wyczyść token",
     "hf_token_clear_confirm": "Wyczyścić token HuggingFace ze źródła „Aplikacja”?",
     "hf_token_clear_dialog": "Wyczyść token",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Zapisano. Uruchom ponownie VoiceStudio, aby nowy budżet zaczął obowiązywać.",
     "generate_timeout_shadowed_badge": "Nadpisane zewnętrznie",
     "generate_timeout_shadowed_note": "Zmienna środowiskowa spoza VoiceStudio (powłoka, plik .env lub kontener) obecnie ustawia tę wartość — zapisana tu wartość jest ignorowana, dopóki ta zmienna nie zostanie usunięta.",
-    "generate_timeout_shadowed_toast": "Zapisano, ale zmienna środowiskowa spoza VoiceStudio obecnie ustawia tę wartość — będzie nadal używana, dopóki ta zmienna nie zostanie usunięta."
+    "generate_timeout_shadowed_toast": "Zapisano, ale zmienna środowiskowa spoza VoiceStudio obecnie ustawia tę wartość — będzie nadal używana, dopóki ta zmienna nie zostanie usunięta.",
+    "hf_token_not_checked": "Nie przetestowano"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Przyspiesz pobieranie dzięki darmowemu tokenowi Przytulająca Twarz",
     "hf_token_inline_ph": "Wklej token hf_… (opcjonalnie)",
     "hf_token_get_short": "Zdobądź jeden za darmo →",
-    "hf_token_active_using": "Używa Twojego tokenu Hugging Face z {{source}} — {{masked}}",
+    "hf_token_active_using": "Znaleziono token Hugging Face w {{source}} — {{masked}}",
     "hf_token_replace": "Zastąp token…",
-    "hf_token_replace_warning": "To zastąpi powyższy token — stary przestanie działać."
+    "hf_token_replace_warning": "To zastępuje token zapisany dla tej aplikacji. Nie unieważnia starego tokena."
   },
   "history": {
     "dub_meta": "{{segments}} segmentów · {{duration}} s",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Token Hugging Face salvo – downloads agora são mais rápidos",
     "hf_token_inline_prompt": "Acelere os downloads com um token Hugging Face gratuito",
     "hf_token_inline_ph": "Cole o token hf_… (opcional)",
-    "hf_token_get_short": "Ganhe um grátis →"
+    "hf_token_get_short": "Ganhe um grátis →",
+    "hf_token_active_using": "Usando seu token do Hugging Face de {{source}} — {{masked}}",
+    "hf_token_replace": "Substituir token…",
+    "hf_token_replace_warning": "Isso substituirá o token acima — o antigo deixará de funcionar."
   },
   "history": {
     "dub_meta": "{{segments}} segmentos · {{duration}} s",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Substituído externamente",
     "generate_timeout_shadowed_note": "Uma variável de ambiente externa ao VoiceStudio (shell, arquivo .env ou contêiner) está definindo este valor no momento — o valor salvo aqui é ignorado até que essa variável seja removida.",
     "generate_timeout_shadowed_toast": "Salvo, mas uma variável de ambiente externa ao VoiceStudio está definindo este valor no momento — ele continuará sendo usado até que essa variável seja removida.",
-    "hf_token_not_checked": "Não testado"
+    "hf_token_not_checked": "Não testado",
+    "hf_source_app_label": "VoiceStudio (criptografado, recomendado)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Variável de ambiente"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Salvo. Reinicie o VoiceStudio para que o novo orçamento tenha efeito.",
     "generate_timeout_shadowed_badge": "Substituído externamente",
     "generate_timeout_shadowed_note": "Uma variável de ambiente externa ao VoiceStudio (shell, arquivo .env ou contêiner) está definindo este valor no momento — o valor salvo aqui é ignorado até que essa variável seja removida.",
-    "generate_timeout_shadowed_toast": "Salvo, mas uma variável de ambiente externa ao VoiceStudio está definindo este valor no momento — ele continuará sendo usado até que essa variável seja removida."
+    "generate_timeout_shadowed_toast": "Salvo, mas uma variável de ambiente externa ao VoiceStudio está definindo este valor no momento — ele continuará sendo usado até que essa variável seja removida.",
+    "hf_token_not_checked": "Não testado"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Acelere os downloads com um token Hugging Face gratuito",
     "hf_token_inline_ph": "Cole o token hf_… (opcional)",
     "hf_token_get_short": "Ganhe um grátis →",
-    "hf_token_active_using": "Usando seu token do Hugging Face de {{source}} — {{masked}}",
+    "hf_token_active_using": "Token do Hugging Face encontrado em {{source}} — {{masked}}",
     "hf_token_replace": "Substituir token…",
-    "hf_token_replace_warning": "Isso substituirá o token acima — o antigo deixará de funcionar."
+    "hf_token_replace_warning": "Isso substitui o token salvo para este aplicativo. Não revoga o token antigo."
   },
   "history": {
     "dub_meta": "{{segments}} segmentos · {{duration}} s",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Falha na reinicialização: {{message}}",
     "reset_longform_failed": "O VoiceStudio não conseguiu limpar com segurança os projetos salvos. Os dados dos seus projetos não foram alterados; libere espaço de armazenamento ou reinicie o aplicativo e tente novamente.",
     "cancel": "Cancelar",
-    "hf_token_also_clear": "Limpar também",
+    "hf_token_also_clear": "Excluir também os arquivos de tokens salvos do HuggingFace CLI",
     "hf_token_clear_btn": "Limpar token",
     "hf_token_clear_confirm": "Limpar o token HuggingFace da fonte App?",
     "hf_token_clear_dialog": "Limpar token",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Токен Hugging Face сохранен — загрузка теперь происходит быстрее",
     "hf_token_inline_prompt": "Ускорьте загрузку с помощью бесплатного токена Hugging Face.",
     "hf_token_inline_ph": "Вставьте токен hf_… (необязательно)",
-    "hf_token_get_short": "Получите один бесплатно →"
+    "hf_token_get_short": "Получите один бесплатно →",
+    "hf_token_active_using": "Используется ваш токен Hugging Face из источника {{source}} — {{masked}}",
+    "hf_token_replace": "Заменить токен…",
+    "hf_token_replace_warning": "Это заменит указанный выше токен — старый перестанет работать."
   },
   "history": {
     "dub_meta": "{{segments}} сегментов · {{duration}} с",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Сохранено. Перезапустите VoiceStudio, чтобы новый бюджет вступил в силу.",
     "generate_timeout_shadowed_badge": "Переопределено извне",
     "generate_timeout_shadowed_note": "Переменная окружения вне VoiceStudio (оболочка, файл .env или контейнер) сейчас задаёт это значение — сохранённое здесь значение игнорируется, пока эта переменная не будет удалена.",
-    "generate_timeout_shadowed_toast": "Сохранено, но переменная окружения вне VoiceStudio сейчас задаёт это значение — оно будет использоваться, пока эта переменная не будет удалена."
+    "generate_timeout_shadowed_toast": "Сохранено, но переменная окружения вне VoiceStudio сейчас задаёт это значение — оно будет использоваться, пока эта переменная не будет удалена.",
+    "hf_token_not_checked": "Не проверен"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Ускорьте загрузку с помощью бесплатного токена Hugging Face.",
     "hf_token_inline_ph": "Вставьте токен hf_… (необязательно)",
     "hf_token_get_short": "Получите один бесплатно →",
-    "hf_token_active_using": "Используется ваш токен Hugging Face из источника {{source}} — {{masked}}",
+    "hf_token_active_using": "Токен Hugging Face найден в {{source}} — {{masked}}",
     "hf_token_replace": "Заменить токен…",
-    "hf_token_replace_warning": "Это заменит указанный выше токен — старый перестанет работать."
+    "hf_token_replace_warning": "Это заменяет токен, сохранённый для приложения. Старый токен не отзывается."
   },
   "history": {
     "dub_meta": "{{segments}} сегментов · {{duration}} с",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Переопределено извне",
     "generate_timeout_shadowed_note": "Переменная окружения вне VoiceStudio (оболочка, файл .env или контейнер) сейчас задаёт это значение — сохранённое здесь значение игнорируется, пока эта переменная не будет удалена.",
     "generate_timeout_shadowed_toast": "Сохранено, но переменная окружения вне VoiceStudio сейчас задаёт это значение — оно будет использоваться, пока эта переменная не будет удалена.",
-    "hf_token_not_checked": "Не проверен"
+    "hf_token_not_checked": "Не проверен",
+    "hf_source_app_label": "VoiceStudio (зашифровано, рекомендуется)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Переменная окружения"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Сброс не удался: {{message}}",
     "reset_longform_failed": "VoiceStudio не удалось безопасно удалить сохранённые проекты. Данные проектов не изменены; освободите место или перезапустите приложение и повторите попытку.",
     "cancel": "Отмена",
-    "hf_token_also_clear": "Также очистить",
+    "hf_token_also_clear": "Также удалить сохранённые файлы токенов HuggingFace CLI",
     "hf_token_clear_btn": "Очистить токен",
     "hf_token_clear_confirm": "Очистить токен HuggingFace, заданный в приложении?",
     "hf_token_clear_dialog": "Очистить токен",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Hugging Face-token har sparats — nedladdningar går nu snabbare",
     "hf_token_inline_prompt": "Snabba upp nedladdningarna med ett gratis Hugging Face-token",
     "hf_token_inline_ph": "Klistra in hf_… token (valfritt)",
-    "hf_token_get_short": "Få en gratis →"
+    "hf_token_get_short": "Få en gratis →",
+    "hf_token_active_using": "Använder din Hugging Face-token från {{source}} — {{masked}}",
+    "hf_token_replace": "Ersätt token…",
+    "hf_token_replace_warning": "Detta ersätter token ovan — den gamla slutar fungera."
   },
   "history": {
     "dub_meta": "{{segments}} segment · {{duration}} s",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Åsidosatt externt",
     "generate_timeout_shadowed_note": "En miljövariabel utanför VoiceStudio (skal, .env-fil eller container) anger just nu detta värde — värdet som sparats här ignoreras tills den variabeln tas bort.",
     "generate_timeout_shadowed_toast": "Sparat, men en miljövariabel utanför VoiceStudio anger just nu detta värde — det kommer fortsätta användas tills den variabeln tas bort.",
-    "hf_token_not_checked": "Inte testad"
+    "hf_token_not_checked": "Inte testad",
+    "hf_source_app_label": "VoiceStudio (krypterad, rekommenderas)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Miljövariabel"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Återställning misslyckades: {{message}}",
     "reset_longform_failed": "VoiceStudio kunde inte rensa de sparade projekten på ett säkert sätt. Dina projektdata ändrades inte; frigör lagringsutrymme eller starta om appen och försök igen.",
     "cancel": "Avbryt",
-    "hf_token_also_clear": "Rensa också",
+    "hf_token_also_clear": "Radera även sparade tokenfiler för HuggingFace CLI",
     "hf_token_clear_btn": "Rensa token",
     "hf_token_clear_confirm": "Rensa HuggingFace-token från App-källan?",
     "hf_token_clear_dialog": "Rensa token",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Sparat. Starta om VoiceStudio för att den nya budgeten ska gälla.",
     "generate_timeout_shadowed_badge": "Åsidosatt externt",
     "generate_timeout_shadowed_note": "En miljövariabel utanför VoiceStudio (skal, .env-fil eller container) anger just nu detta värde — värdet som sparats här ignoreras tills den variabeln tas bort.",
-    "generate_timeout_shadowed_toast": "Sparat, men en miljövariabel utanför VoiceStudio anger just nu detta värde — det kommer fortsätta användas tills den variabeln tas bort."
+    "generate_timeout_shadowed_toast": "Sparat, men en miljövariabel utanför VoiceStudio anger just nu detta värde — det kommer fortsätta användas tills den variabeln tas bort.",
+    "hf_token_not_checked": "Inte testad"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Snabba upp nedladdningarna med ett gratis Hugging Face-token",
     "hf_token_inline_ph": "Klistra in hf_… token (valfritt)",
     "hf_token_get_short": "Få en gratis →",
-    "hf_token_active_using": "Använder din Hugging Face-token från {{source}} — {{masked}}",
+    "hf_token_active_using": "Hugging Face-token hittades i {{source}} — {{masked}}",
     "hf_token_replace": "Ersätt token…",
-    "hf_token_replace_warning": "Detta ersätter token ovan — den gamla slutar fungera."
+    "hf_token_replace_warning": "Detta ersätter token som sparats för denna app. Den gamla token återkallas inte."
   },
   "history": {
     "dub_meta": "{{segments}} segment · {{duration}} s",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "บันทึกโทเค็น Hugging Face แล้ว - ตอนนี้การดาวน์โหลดเร็วขึ้น",
     "hf_token_inline_prompt": "เร่งความเร็วการดาวน์โหลดด้วยโทเค็น Hugging Face ฟรี",
     "hf_token_inline_ph": "วางโทเค็น hf_… (ไม่บังคับ)",
-    "hf_token_get_short": "รับฟรีหนึ่งรายการ →"
+    "hf_token_get_short": "รับฟรีหนึ่งรายการ →",
+    "hf_token_active_using": "กำลังใช้โทเค็น Hugging Face ของคุณจาก {{source}} — {{masked}}",
+    "hf_token_replace": "แทนที่โทเค็น…",
+    "hf_token_replace_warning": "การดำเนินการนี้จะแทนที่โทเค็นด้านบน — โทเค็นเดิมจะใช้งานไม่ได้อีกต่อไป"
   },
   "history": {
     "dub_meta": "{{segments}} เซกเมนต์ · {{duration}} วินาที",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "ถูกแทนที่จากภายนอก",
     "generate_timeout_shadowed_note": "มีตัวแปรสภาพแวดล้อมภายนอก VoiceStudio (เชลล์, ไฟล์ .env หรือคอนเทนเนอร์) กำลังตั้งค่านี้อยู่ — ค่าที่บันทึกไว้ที่นี่จะถูกละเว้นจนกว่าตัวแปรนั้นจะถูกลบออก",
     "generate_timeout_shadowed_toast": "บันทึกแล้ว แต่มีตัวแปรสภาพแวดล้อมภายนอก VoiceStudio กำลังตั้งค่านี้อยู่ — ค่านั้นจะยังคงถูกใช้งานจนกว่าตัวแปรนั้นจะถูกลบออก",
-    "hf_token_not_checked": "ยังไม่ได้ทดสอบ"
+    "hf_token_not_checked": "ยังไม่ได้ทดสอบ",
+    "hf_source_app_label": "VoiceStudio (เข้ารหัส แนะนำ)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "ตัวแปรสภาพแวดล้อม"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "บันทึกแล้ว รีสตาร์ท VoiceStudio เพื่อให้งบใหม่มีผล",
     "generate_timeout_shadowed_badge": "ถูกแทนที่จากภายนอก",
     "generate_timeout_shadowed_note": "มีตัวแปรสภาพแวดล้อมภายนอก VoiceStudio (เชลล์, ไฟล์ .env หรือคอนเทนเนอร์) กำลังตั้งค่านี้อยู่ — ค่าที่บันทึกไว้ที่นี่จะถูกละเว้นจนกว่าตัวแปรนั้นจะถูกลบออก",
-    "generate_timeout_shadowed_toast": "บันทึกแล้ว แต่มีตัวแปรสภาพแวดล้อมภายนอก VoiceStudio กำลังตั้งค่านี้อยู่ — ค่านั้นจะยังคงถูกใช้งานจนกว่าตัวแปรนั้นจะถูกลบออก"
+    "generate_timeout_shadowed_toast": "บันทึกแล้ว แต่มีตัวแปรสภาพแวดล้อมภายนอก VoiceStudio กำลังตั้งค่านี้อยู่ — ค่านั้นจะยังคงถูกใช้งานจนกว่าตัวแปรนั้นจะถูกลบออก",
+    "hf_token_not_checked": "ยังไม่ได้ทดสอบ"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "เร่งความเร็วการดาวน์โหลดด้วยโทเค็น Hugging Face ฟรี",
     "hf_token_inline_ph": "วางโทเค็น hf_… (ไม่บังคับ)",
     "hf_token_get_short": "รับฟรีหนึ่งรายการ →",
-    "hf_token_active_using": "กำลังใช้โทเค็น Hugging Face ของคุณจาก {{source}} — {{masked}}",
+    "hf_token_active_using": "พบโทเค็น Hugging Face ใน {{source}} — {{masked}}",
     "hf_token_replace": "แทนที่โทเค็น…",
-    "hf_token_replace_warning": "การดำเนินการนี้จะแทนที่โทเค็นด้านบน — โทเค็นเดิมจะใช้งานไม่ได้อีกต่อไป"
+    "hf_token_replace_warning": "การดำเนินการนี้แทนที่โทเค็นที่บันทึกไว้สำหรับแอปนี้ แต่ไม่เพิกถอนโทเค็นเก่า"
   },
   "history": {
     "dub_meta": "{{segments}} เซกเมนต์ · {{duration}} วินาที",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "การรีเซ็ตล้มเหลว: {{message}}",
     "reset_longform_failed": "VoiceStudio ไม่สามารถล้างโปรเจกต์ที่บันทึกไว้ได้อย่างปลอดภัย ข้อมูลโปรเจกต์ของคุณไม่ได้ถูกเปลี่ยนแปลง โปรดเพิ่มพื้นที่ว่างหรือเริ่มแอปใหม่แล้วลองอีกครั้ง",
     "cancel": "ยกเลิก",
-    "hf_token_also_clear": "ล้างด้วย",
+    "hf_token_also_clear": "ลบไฟล์โทเค็น HuggingFace CLI ที่บันทึกไว้ด้วย",
     "hf_token_clear_btn": "ล้างโทเค็น",
     "hf_token_clear_confirm": "ล้างโทเค็น HuggingFace ที่ตั้งจากแอปหรือไม่",
     "hf_token_clear_dialog": "ล้างโทเค็น",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Hugging Face jetonu kaydedildi; indirme işlemleri artık daha hızlı",
     "hf_token_inline_prompt": "Ücretsiz Hugging Face belirteci ile indirmeleri hızlandırın",
     "hf_token_inline_ph": "hf_… jetonunu yapıştırın (isteğe bağlı)",
-    "hf_token_get_short": "Ücretsiz bir tane alın →"
+    "hf_token_get_short": "Ücretsiz bir tane alın →",
+    "hf_token_active_using": "{{source}} kaynağından Hugging Face jetonunuz kullanılıyor — {{masked}}",
+    "hf_token_replace": "Jetonu değiştir…",
+    "hf_token_replace_warning": "Bu, yukarıdaki jetonun yerini alır — eski jeton çalışmayı durdurur."
   },
   "history": {
     "dub_meta": "{{segments}} segment · {{duration}} sn",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Dışarıdan geçersiz kılındı",
     "generate_timeout_shadowed_note": "VoiceStudio dışındaki bir ortam değişkeni (kabuk, .env dosyası veya konteyner) şu anda bu değeri ayarlıyor — o değişken kaldırılana kadar burada kaydedilen değer yok sayılır.",
     "generate_timeout_shadowed_toast": "Kaydedildi, ancak VoiceStudio dışındaki bir ortam değişkeni şu anda bu değeri ayarlıyor — o değişken kaldırılana kadar kullanılmaya devam edecek.",
-    "hf_token_not_checked": "Test edilmedi"
+    "hf_token_not_checked": "Test edilmedi",
+    "hf_source_app_label": "VoiceStudio (şifrelenmiş, önerilen)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Ortam değişkeni"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Sıfırlama başarısız oldu: {{message}}",
     "reset_longform_failed": "VoiceStudio kaydedilmiş projeleri güvenli bir şekilde temizleyemedi. Proje verileriniz değiştirilmedi; depolama alanı açın veya uygulamayı yeniden başlatıp tekrar deneyin.",
     "cancel": "İptal",
-    "hf_token_also_clear": "Ayrıca temizle",
+    "hf_token_also_clear": "Kaydedilmiş HuggingFace CLI belirteç dosyalarını da sil",
     "hf_token_clear_btn": "Belirteci temizle",
     "hf_token_clear_confirm": "Uygulama kaynaklı HuggingFace belirteci temizlensin mi?",
     "hf_token_clear_dialog": "Belirteci temizle",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Kaydedildi. Yeni bütçenin geçerli olması için VoiceStudio'yu yeniden başlatın.",
     "generate_timeout_shadowed_badge": "Dışarıdan geçersiz kılındı",
     "generate_timeout_shadowed_note": "VoiceStudio dışındaki bir ortam değişkeni (kabuk, .env dosyası veya konteyner) şu anda bu değeri ayarlıyor — o değişken kaldırılana kadar burada kaydedilen değer yok sayılır.",
-    "generate_timeout_shadowed_toast": "Kaydedildi, ancak VoiceStudio dışındaki bir ortam değişkeni şu anda bu değeri ayarlıyor — o değişken kaldırılana kadar kullanılmaya devam edecek."
+    "generate_timeout_shadowed_toast": "Kaydedildi, ancak VoiceStudio dışındaki bir ortam değişkeni şu anda bu değeri ayarlıyor — o değişken kaldırılana kadar kullanılmaya devam edecek.",
+    "hf_token_not_checked": "Test edilmedi"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Ücretsiz Hugging Face belirteci ile indirmeleri hızlandırın",
     "hf_token_inline_ph": "hf_… jetonunu yapıştırın (isteğe bağlı)",
     "hf_token_get_short": "Ücretsiz bir tane alın →",
-    "hf_token_active_using": "{{source}} kaynağından Hugging Face jetonunuz kullanılıyor — {{masked}}",
+    "hf_token_active_using": "{{source}} içinde Hugging Face belirteci bulundu — {{masked}}",
     "hf_token_replace": "Jetonu değiştir…",
-    "hf_token_replace_warning": "Bu, yukarıdaki jetonun yerini alır — eski jeton çalışmayı durdurur."
+    "hf_token_replace_warning": "Bu uygulama için kaydedilen belirteci değiştirir. Eski belirteci iptal etmez."
   },
   "history": {
     "dub_meta": "{{segments}} segment · {{duration}} sn",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Токен Hugging Face збережено — завантаження тепер відбуваються швидше",
     "hf_token_inline_prompt": "Прискоріть завантаження за допомогою безкоштовного маркера Hugging Face",
     "hf_token_inline_ph": "Вставте маркер hf_… (необов’язково)",
-    "hf_token_get_short": "Отримайте один безкоштовно →"
+    "hf_token_get_short": "Отримайте один безкоштовно →",
+    "hf_token_active_using": "Використовується ваш токен Hugging Face із джерела {{source}} — {{masked}}",
+    "hf_token_replace": "Замінити токен…",
+    "hf_token_replace_warning": "Це замінить токен вище — старий перестане працювати."
   },
   "history": {
     "dub_meta": "{{segments}} сегментів · {{duration}} с",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Збережено. Перезапустіть VoiceStudio, щоб новий бюджет набув чинності.",
     "generate_timeout_shadowed_badge": "Перевизначено ззовні",
     "generate_timeout_shadowed_note": "Змінна середовища поза VoiceStudio (оболонка, файл .env або контейнер) наразі задає це значення — збережене тут значення ігнорується, доки цю змінну не видалять.",
-    "generate_timeout_shadowed_toast": "Збережено, але змінна середовища поза VoiceStudio наразі задає це значення — воно продовжуватиме використовуватися, доки цю змінну не видалять."
+    "generate_timeout_shadowed_toast": "Збережено, але змінна середовища поза VoiceStudio наразі задає це значення — воно продовжуватиме використовуватися, доки цю змінну не видалять.",
+    "hf_token_not_checked": "Не перевірено"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Прискоріть завантаження за допомогою безкоштовного маркера Hugging Face",
     "hf_token_inline_ph": "Вставте маркер hf_… (необов’язково)",
     "hf_token_get_short": "Отримайте один безкоштовно →",
-    "hf_token_active_using": "Використовується ваш токен Hugging Face із джерела {{source}} — {{masked}}",
+    "hf_token_active_using": "Токен Hugging Face знайдено в {{source}} — {{masked}}",
     "hf_token_replace": "Замінити токен…",
-    "hf_token_replace_warning": "Це замінить токен вище — старий перестане працювати."
+    "hf_token_replace_warning": "Це замінює токен, збережений для цього застосунку. Старий токен не відкликається."
   },
   "history": {
     "dub_meta": "{{segments}} сегментів · {{duration}} с",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Перевизначено ззовні",
     "generate_timeout_shadowed_note": "Змінна середовища поза VoiceStudio (оболонка, файл .env або контейнер) наразі задає це значення — збережене тут значення ігнорується, доки цю змінну не видалять.",
     "generate_timeout_shadowed_toast": "Збережено, але змінна середовища поза VoiceStudio наразі задає це значення — воно продовжуватиме використовуватися, доки цю змінну не видалять.",
-    "hf_token_not_checked": "Не перевірено"
+    "hf_token_not_checked": "Не перевірено",
+    "hf_source_app_label": "VoiceStudio (зашифровано, рекомендовано)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Змінна середовища"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Помилка скидання: {{message}}",
     "reset_longform_failed": "VoiceStudio не вдалося безпечно видалити збережені проєкти. Дані проєктів не змінено; звільніть місце або перезапустіть застосунок і повторіть спробу.",
     "cancel": "Скасувати",
-    "hf_token_also_clear": "Також очистити",
+    "hf_token_also_clear": "Також видалити збережені файли токенів HuggingFace CLI",
     "hf_token_clear_btn": "Очистити токен",
     "hf_token_clear_confirm": "Очистити токен HuggingFace із джерела App?",
     "hf_token_clear_dialog": "Очистити токен",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "Đã lưu mã thông báo Ôm Mặt - tải xuống hiện nhanh hơn",
     "hf_token_inline_prompt": "Tăng tốc độ tải xuống với mã thông báo Ôm mặt miễn phí",
     "hf_token_inline_ph": "Dán mã thông báo hf_… (tùy chọn)",
-    "hf_token_get_short": "Nhận một cái miễn phí →"
+    "hf_token_get_short": "Nhận một cái miễn phí →",
+    "hf_token_active_using": "Đang sử dụng token Hugging Face của bạn từ {{source}} — {{masked}}",
+    "hf_token_replace": "Thay thế token…",
+    "hf_token_replace_warning": "Thao tác này sẽ thay thế token ở trên — token cũ sẽ ngừng hoạt động."
   },
   "history": {
     "dub_meta": "{{segments}} phân đoạn · {{duration}} giây",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "Đặt lại không thành công: {{message}}",
     "reset_longform_failed": "VoiceStudio không thể xóa an toàn các dự án đã lưu. Dữ liệu dự án của bạn không bị thay đổi; hãy giải phóng dung lượng hoặc khởi động lại ứng dụng rồi thử lại.",
     "cancel": "Hủy",
-    "hf_token_also_clear": "Đồng thời xóa",
+    "hf_token_also_clear": "Đồng thời xóa các tệp mã thông báo HuggingFace CLI đã lưu",
     "hf_token_clear_btn": "Xóa token",
     "hf_token_clear_confirm": "Xóa token HuggingFace từ nguồn Ứng dụng?",
     "hf_token_clear_dialog": "Xóa token",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "Bị ghi đè từ bên ngoài",
     "generate_timeout_shadowed_note": "Một biến môi trường bên ngoài VoiceStudio (shell, tệp .env hoặc container) hiện đang đặt giá trị này — giá trị đã lưu ở đây sẽ bị bỏ qua cho đến khi biến đó được gỡ bỏ.",
     "generate_timeout_shadowed_toast": "Đã lưu, nhưng một biến môi trường bên ngoài VoiceStudio hiện đang đặt giá trị này — giá trị đó sẽ tiếp tục được dùng cho đến khi biến đó được gỡ bỏ.",
-    "hf_token_not_checked": "Chưa kiểm tra"
+    "hf_token_not_checked": "Chưa kiểm tra",
+    "hf_source_app_label": "VoiceStudio (được mã hóa, khuyên dùng)",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "Biến môi trường"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "Đã lưu. Khởi động lại VoiceStudio để ngân sách mới có hiệu lực.",
     "generate_timeout_shadowed_badge": "Bị ghi đè từ bên ngoài",
     "generate_timeout_shadowed_note": "Một biến môi trường bên ngoài VoiceStudio (shell, tệp .env hoặc container) hiện đang đặt giá trị này — giá trị đã lưu ở đây sẽ bị bỏ qua cho đến khi biến đó được gỡ bỏ.",
-    "generate_timeout_shadowed_toast": "Đã lưu, nhưng một biến môi trường bên ngoài VoiceStudio hiện đang đặt giá trị này — giá trị đó sẽ tiếp tục được dùng cho đến khi biến đó được gỡ bỏ."
+    "generate_timeout_shadowed_toast": "Đã lưu, nhưng một biến môi trường bên ngoài VoiceStudio hiện đang đặt giá trị này — giá trị đó sẽ tiếp tục được dùng cho đến khi biến đó được gỡ bỏ.",
+    "hf_token_not_checked": "Chưa kiểm tra"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "Tăng tốc độ tải xuống với mã thông báo Ôm mặt miễn phí",
     "hf_token_inline_ph": "Dán mã thông báo hf_… (tùy chọn)",
     "hf_token_get_short": "Nhận một cái miễn phí →",
-    "hf_token_active_using": "Đang sử dụng token Hugging Face của bạn từ {{source}} — {{masked}}",
+    "hf_token_active_using": "Đã tìm thấy token Hugging Face trong {{source}} — {{masked}}",
     "hf_token_replace": "Thay thế token…",
-    "hf_token_replace_warning": "Thao tác này sẽ thay thế token ở trên — token cũ sẽ ngừng hoạt động."
+    "hf_token_replace_warning": "Thao tác này thay thế token đã lưu cho ứng dụng này. Token cũ không bị thu hồi."
   },
   "history": {
     "dub_meta": "{{segments}} phân đoạn · {{duration}} giây",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -2376,7 +2376,10 @@
     "hf_token_saved_fast": "Hugging Face 令牌已保存——下载速度更快",
     "hf_token_inline_prompt": "使用免费的 Hugging Face 令牌加快下载速度",
     "hf_token_inline_ph": "粘贴 hf_… 令牌（可选）",
-    "hf_token_get_short": "免费获得一份 →"
+    "hf_token_get_short": "免费获得一份 →",
+    "hf_token_active_using": "正在使用来自 {{source}} 的 Hugging Face 令牌 — {{masked}}",
+    "hf_token_replace": "更换令牌…",
+    "hf_token_replace_warning": "这将替换上面的令牌——旧令牌将停止工作。"
   },
   "history": {
     "dub_meta": "{{segments}} 个片段 · {{duration}} 秒",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -600,7 +600,8 @@
     "generate_timeout_saved": "已保存。重启 VoiceStudio 以使新预算生效。",
     "generate_timeout_shadowed_badge": "已被外部覆盖",
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一个环境变量（终端、.env 文件或容器）当前正在设置此值——在移除该变量之前，此处保存的值会被忽略。",
-    "generate_timeout_shadowed_toast": "已保存，但 VoiceStudio 之外的一个环境变量当前正在设置此值——在移除该变量之前，将继续使用该值。"
+    "generate_timeout_shadowed_toast": "已保存，但 VoiceStudio 之外的一个环境变量当前正在设置此值——在移除该变量之前，将继续使用该值。",
+    "hf_token_not_checked": "未测试"
   },
   "about": {
     "app": "应用",
@@ -2377,9 +2378,9 @@
     "hf_token_inline_prompt": "使用免费的 Hugging Face 令牌加快下载速度",
     "hf_token_inline_ph": "粘贴 hf_… 令牌（可选）",
     "hf_token_get_short": "免费获得一份 →",
-    "hf_token_active_using": "正在使用来自 {{source}} 的 Hugging Face 令牌 — {{masked}}",
+    "hf_token_active_using": "在 {{source}} 中找到 Hugging Face 令牌 — {{masked}}",
     "hf_token_replace": "更换令牌…",
-    "hf_token_replace_warning": "这将替换上面的令牌——旧令牌将停止工作。"
+    "hf_token_replace_warning": "这会替换为此应用保存的令牌，但不会撤销旧令牌。"
   },
   "history": {
     "dub_meta": "{{segments}} 个片段 · {{duration}} 秒",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -601,7 +601,10 @@
     "generate_timeout_shadowed_badge": "已被外部覆盖",
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一个环境变量（终端、.env 文件或容器）当前正在设置此值——在移除该变量之前，此处保存的值会被忽略。",
     "generate_timeout_shadowed_toast": "已保存，但 VoiceStudio 之外的一个环境变量当前正在设置此值——在移除该变量之前，将继续使用该值。",
-    "hf_token_not_checked": "未测试"
+    "hf_token_not_checked": "未测试",
+    "hf_source_app_label": "VoiceStudio（已加密，推荐）",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "环境变量"
   },
   "about": {
     "app": "应用",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -411,7 +411,7 @@
     "shortcut_reset_failed": "重置失败：{{message}}",
     "reset_longform_failed": "VoiceStudio 无法安全清除已保存的项目。您的项目数据未被更改；请释放一些存储空间或重启应用后再试。",
     "cancel": "取消",
-    "hf_token_also_clear": "同时清除",
+    "hf_token_also_clear": "同时清除已保存的 HuggingFace CLI 令牌文件",
     "hf_token_clear_btn": "清除令牌",
     "hf_token_clear_confirm": "清除“应用”来源的 HuggingFace 令牌？",
     "hf_token_clear_dialog": "清除令牌",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -2369,7 +2369,10 @@
     "hf_token_saved_fast": "擁抱臉部令牌已儲存 — 下載速度更快",
     "hf_token_inline_prompt": "使用免費的 Hugging Face 令牌加快下載速度",
     "hf_token_inline_ph": "貼上 hf_… 令牌（可選）",
-    "hf_token_get_short": "免費獲得一份 →"
+    "hf_token_get_short": "免費獲得一份 →",
+    "hf_token_active_using": "正在使用來自 {{source}} 的 Hugging Face 權杖 — {{masked}}",
+    "hf_token_replace": "更換權杖…",
+    "hf_token_replace_warning": "這將取代上方的權杖——舊權杖將停止運作。"
   },
   "history": {
     "dub_meta": "{{segments}} 個片段 · {{duration}} 秒",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -159,7 +159,7 @@
     "shortcut_reset_failed": "重置失敗：{{message}}",
     "reset_longform_failed": "VoiceStudio 無法安全清除已儲存的專案。您的專案資料未被變更；請釋放一些儲存空間或重新啟動應用程式後再試。",
     "cancel": "取消",
-    "hf_token_also_clear": "一併清除",
+    "hf_token_also_clear": "同時清除已儲存的 HuggingFace CLI 權杖檔案",
     "hf_token_clear_btn": "清除代幣",
     "hf_token_clear_confirm": "確定要清除 App 來源的 HuggingFace 代幣嗎？",
     "hf_token_clear_dialog": "清除代幣",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -349,7 +349,10 @@
     "generate_timeout_shadowed_badge": "已被外部覆寫",
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一個環境變數（終端機、.env 檔案或容器）目前正在設定此值 — 在移除該變數之前，此處儲存的值會被忽略。",
     "generate_timeout_shadowed_toast": "已儲存，但 VoiceStudio 之外的一個環境變數目前正在設定此值 — 在移除該變數之前，將持續使用該值。",
-    "hf_token_not_checked": "未測試"
+    "hf_token_not_checked": "未測試",
+    "hf_source_app_label": "VoiceStudio（已加密，建議）",
+    "hf_source_cli_label": "HuggingFace CLI",
+    "hf_source_env_label": "環境變數"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -348,7 +348,8 @@
     "generate_timeout_saved": "已儲存。重新啟動 VoiceStudio 以套用新的預算。",
     "generate_timeout_shadowed_badge": "已被外部覆寫",
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一個環境變數（終端機、.env 檔案或容器）目前正在設定此值 — 在移除該變數之前，此處儲存的值會被忽略。",
-    "generate_timeout_shadowed_toast": "已儲存，但 VoiceStudio 之外的一個環境變數目前正在設定此值 — 在移除該變數之前，將持續使用該值。"
+    "generate_timeout_shadowed_toast": "已儲存，但 VoiceStudio 之外的一個環境變數目前正在設定此值 — 在移除該變數之前，將持續使用該值。",
+    "hf_token_not_checked": "未測試"
   },
   "bootstrap": {
     "title": "VoiceStudio",
@@ -2370,9 +2371,9 @@
     "hf_token_inline_prompt": "使用免費的 Hugging Face 令牌加快下載速度",
     "hf_token_inline_ph": "貼上 hf_… 令牌（可選）",
     "hf_token_get_short": "免費獲得一份 →",
-    "hf_token_active_using": "正在使用來自 {{source}} 的 Hugging Face 權杖 — {{masked}}",
+    "hf_token_active_using": "在 {{source}} 中找到 Hugging Face 權杖 — {{masked}}",
     "hf_token_replace": "更換權杖…",
-    "hf_token_replace_warning": "這將取代上方的權杖——舊權杖將停止運作。"
+    "hf_token_replace_warning": "這會取代為此應用程式儲存的權杖，但不會撤銷舊權杖。"
   },
   "history": {
     "dub_meta": "{{segments}} 個片段 · {{duration}} 秒",

--- a/tests/backend/services/test_token_resolver.py
+++ b/tests/backend/services/test_token_resolver.py
@@ -5,6 +5,7 @@ the state() shape consumed by the Settings UI, and the save/clear API the
 React panel will call.
 """
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,6 +20,10 @@ CLI_TOKEN = "hf_clicli00000000000000000000000000000000ghi"
 def fresh_resolver(monkeypatch, tmp_path):
     """Fresh import of services.token_resolver + a tmp DB-backed settings
     store. Also clears HF env vars so the env source is empty by default."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
@@ -54,9 +59,13 @@ def _mock_whoami(monkeypatch, mapping):
     monkeypatch.setattr(huggingface_hub, "whoami", _fake_whoami)
 
 
-def _mock_get_token(monkeypatch, value):
-    import huggingface_hub
-    monkeypatch.setattr(huggingface_hub, "get_token", lambda: value)
+def _set_cli_token(monkeypatch, value):
+    from huggingface_hub import constants
+    path = Path(constants.HF_TOKEN_PATH)
+    if value is None:
+        path.unlink(missing_ok=True)
+    else:
+        path.write_text(value, encoding="utf-8")
 
 
 def test_resolve_priority_app_wins(fresh_resolver, monkeypatch):
@@ -65,7 +74,7 @@ def test_resolve_priority_app_wins(fresh_resolver, monkeypatch):
     from services import settings_store
     settings_store.set_hf_token(APP_TOKEN)
     monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
-    _mock_get_token(monkeypatch, CLI_TOKEN)
+    _set_cli_token(monkeypatch, CLI_TOKEN)
     _mock_whoami(monkeypatch, {
         APP_TOKEN: {"name": "alice"},
         ENV_TOKEN: {"name": "bob"},
@@ -83,7 +92,7 @@ def test_resolve_skips_empty_falls_to_env(fresh_resolver, monkeypatch):
     """No app token, env set, no CLI → Env wins."""
     tr = fresh_resolver
     monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
-    _mock_get_token(monkeypatch, None)
+    _set_cli_token(monkeypatch, None)
     _mock_whoami(monkeypatch, {ENV_TOKEN: {"name": "bob"}})
     tr.invalidate_cache()
     result = tr.resolve()
@@ -94,7 +103,7 @@ def test_resolve_skips_empty_falls_to_env(fresh_resolver, monkeypatch):
 
 def test_resolve_returns_none_when_all_empty(fresh_resolver, monkeypatch):
     tr = fresh_resolver
-    _mock_get_token(monkeypatch, None)
+    _set_cli_token(monkeypatch, None)
     _mock_whoami(monkeypatch, {})
     tr.invalidate_cache()
     assert tr.resolve() is None
@@ -109,7 +118,7 @@ def test_resolve_skips_401_app_falls_to_env(fresh_resolver, monkeypatch):
 
     settings_store.set_hf_token(APP_TOKEN)
     monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
-    _mock_get_token(monkeypatch, None)
+    _set_cli_token(monkeypatch, None)
     err = HfHubHTTPError("401 Unauthorized", response=MagicMock(status_code=401))
     _mock_whoami(monkeypatch, {
         APP_TOKEN: err,
@@ -128,7 +137,7 @@ def test_on_401_cascade(fresh_resolver, monkeypatch):
     from services import settings_store
     settings_store.set_hf_token(APP_TOKEN)
     monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
-    _mock_get_token(monkeypatch, None)
+    _set_cli_token(monkeypatch, None)
     _mock_whoami(monkeypatch, {
         APP_TOKEN: {"name": "alice"},
         ENV_TOKEN: {"name": "bob"},
@@ -149,7 +158,7 @@ def test_state_returns_three_rows(fresh_resolver, monkeypatch):
     from services import settings_store
     settings_store.set_hf_token(APP_TOKEN)
     monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
-    _mock_get_token(monkeypatch, None)
+    _set_cli_token(monkeypatch, None)
     _mock_whoami(monkeypatch, {
         APP_TOKEN: {"name": "alice"},
         ENV_TOKEN: {"name": "bob"},
@@ -227,16 +236,17 @@ def test_clear_app_token_removes_from_store(fresh_resolver, monkeypatch):
     assert settings_store.get_hf_token() is None
 
 
-def test_clear_app_token_also_logs_out_when_requested(fresh_resolver, monkeypatch):
-    tr = fresh_resolver
-    import huggingface_hub
-    monkeypatch.setattr(huggingface_hub, "login", lambda **kw: None)
-    logout_calls = []
-    monkeypatch.setattr(huggingface_hub, "logout", lambda: logout_calls.append(True))
-
-    tr.save_app_token(APP_TOKEN)
-    tr.clear_app_token(also_clear_hf_cli=True)
-    assert logout_calls == [True]
+def test_clear_app_token_also_clears_files_when_requested(fresh_resolver, monkeypatch):
+    from huggingface_hub import constants
+    from services import settings_store
+    settings_store.set_hf_token(APP_TOKEN)
+    _set_cli_token(monkeypatch, CLI_TOKEN)
+    stored = Path(constants.HF_STORED_TOKENS_PATH)
+    stored.write_text("synthetic stored tokens", encoding="utf-8")
+    fresh_resolver.clear_app_token(also_clear_hf_cli=True)
+    assert settings_store.get_hf_token() is None
+    assert not Path(constants.HF_TOKEN_PATH).exists()
+    assert not stored.exists()
 
 
 def test_resolve_accepts_hugging_face_hub_token_alias(fresh_resolver, monkeypatch):
@@ -245,7 +255,7 @@ def test_resolve_accepts_hugging_face_hub_token_alias(fresh_resolver, monkeypatc
     tr = fresh_resolver
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", ENV_TOKEN)
-    _mock_get_token(monkeypatch, None)
+    _set_cli_token(monkeypatch, None)
     _mock_whoami(monkeypatch, {ENV_TOKEN: {"name": "bob"}})
     tr.invalidate_cache()
     result = tr.resolve()
@@ -267,3 +277,83 @@ def test_state_is_local_by_default(fresh_resolver, monkeypatch):
     assert result["sources"][0].set
     assert result["sources"][0].whoami_ok is None
     assert APP_TOKEN not in repr(result)
+
+
+def test_local_cli_reader_never_uses_environment_or_refresh(fresh_resolver, monkeypatch):
+    import huggingface_hub
+    monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
+    monkeypatch.setattr(huggingface_hub, "get_token", lambda: pytest.fail("must not refresh credentials"))
+    _set_cli_token(monkeypatch, " \r\n" + CLI_TOKEN + "\n ")
+    assert fresh_resolver._read_hf_cli() == CLI_TOKEN
+    rows = {row.source: row for row in fresh_resolver.state()["sources"]}
+    assert rows["env"].masked != rows["hf-cli"].masked
+    assert all(row.whoami_ok is None for row in rows.values() if row.set)
+
+
+def test_invalid_environment_falls_back_to_distinct_cli_file(fresh_resolver, monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", ENV_TOKEN)
+    _set_cli_token(monkeypatch, CLI_TOKEN)
+    _mock_whoami(monkeypatch, {ENV_TOKEN: RuntimeError("invalid"), CLI_TOKEN: {"name": "cli-user"}})
+    assert fresh_resolver.resolve().source == "hf-cli"
+
+
+def test_environment_normalization_retains_correct_source(fresh_resolver, monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", " \r\n" + ENV_TOKEN + "\n ")
+    _mock_whoami(monkeypatch, {ENV_TOKEN: {"name": "env-user"}})
+    assert fresh_resolver.resolve().source == "env"
+    assert fresh_resolver._read_hf_cli() is None
+
+
+def test_save_and_clear_use_the_same_real_hub_files(fresh_resolver, monkeypatch):
+    from huggingface_hub import constants, hf_api
+    monkeypatch.setattr(hf_api, "whoami", lambda token: {"name": "test", "auth": {"accessToken": {"role": "read", "displayName": "synthetic"}}})
+    fresh_resolver.save_app_token(APP_TOKEN)
+    assert Path(constants.HF_TOKEN_PATH).read_text() == APP_TOKEN
+    assert Path(constants.HF_STORED_TOKENS_PATH).exists()
+    assert fresh_resolver._read_hf_cli() == APP_TOKEN
+    fresh_resolver.clear_app_token()
+    assert fresh_resolver._read_hf_cli() == APP_TOKEN
+    fresh_resolver.clear_app_token(also_clear_hf_cli=True)
+    assert fresh_resolver._read_hf_cli() is None
+    assert not Path(constants.HF_STORED_TOKENS_PATH).exists()
+
+
+@pytest.mark.parametrize("value", ["", " \r\n "])
+def test_blank_cli_file_is_not_a_source(fresh_resolver, monkeypatch, value):
+    _set_cli_token(monkeypatch, value)
+    assert fresh_resolver._read_hf_cli() is None
+
+
+def test_cli_read_failure_does_not_expose_credentials(fresh_resolver, monkeypatch, caplog):
+    def fail(*args, **kwargs):
+        raise PermissionError("synthetic-secret-must-not-appear")
+    monkeypatch.setattr(Path, "read_text", fail)
+    assert fresh_resolver._read_hf_cli() is None
+    assert "synthetic-secret-must-not-appear" not in caplog.text
+
+
+def test_clear_attempts_all_files_and_reports_failure(fresh_resolver, monkeypatch):
+    from core import config
+    from huggingface_hub import constants
+    selected = Path(constants.HF_TOKEN_PATH)
+    legacy = selected.parent / "legacy" / "token"
+    monkeypatch.setattr(config, "HF_CLI_TOKEN_PATHS", (str(selected), str(legacy)))
+    for path in (selected, legacy):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(CLI_TOKEN)
+        path.with_name("stored_tokens").write_text("synthetic")
+    original_unlink = Path.unlink
+    def unlink(path, *args, **kwargs):
+        if path == selected:
+            raise PermissionError("synthetic-secret-not-for-logs")
+        return original_unlink(path, *args, **kwargs)
+    monkeypatch.setattr(Path, "unlink", unlink)
+    fresh_resolver._VALIDATION_CACHE[("hf-cli", "test")] = (0, "user")
+    with pytest.raises(OSError, match="Could not clear all local Hugging Face token files") as error:
+        fresh_resolver.clear_hf_cli_tokens()
+    assert "synthetic-secret" not in str(error.value)
+    assert selected.exists()
+    assert not legacy.exists()
+    assert not selected.with_name("stored_tokens").exists()
+    assert not legacy.with_name("stored_tokens").exists()
+    assert not fresh_resolver._VALIDATION_CACHE

--- a/tests/backend/services/test_token_resolver.py
+++ b/tests/backend/services/test_token_resolver.py
@@ -155,7 +155,7 @@ def test_state_returns_three_rows(fresh_resolver, monkeypatch):
         ENV_TOKEN: {"name": "bob"},
     })
     tr.invalidate_cache()
-    s = tr.state()
+    s = tr.state(validate=True)
     assert "sources" in s
     assert "active" in s
     assert [r.source for r in s["sources"]] == ["app", "env", "hf-cli"]
@@ -252,3 +252,18 @@ def test_resolve_accepts_hugging_face_hub_token_alias(fresh_resolver, monkeypatc
     assert result is not None
     assert result.source == "env"
     assert result.token == ENV_TOKEN
+
+
+def test_state_is_local_by_default(fresh_resolver, monkeypatch):
+    tr = fresh_resolver
+    monkeypatch.setattr(tr, "_READERS", {
+        "app": lambda: APP_TOKEN, "env": lambda: ENV_TOKEN, "hf-cli": lambda: None,
+    })
+    def unexpected_validation(*args):
+        raise AssertionError("local state must never validate against Hugging Face")
+    monkeypatch.setattr(tr, "_validate", unexpected_validation)
+    result = tr.state()
+    assert result["active"] is None
+    assert result["sources"][0].set
+    assert result["sources"][0].whoami_ok is None
+    assert APP_TOKEN not in repr(result)

--- a/tests/backend/test_engine_spawn_token.py
+++ b/tests/backend/test_engine_spawn_token.py
@@ -160,14 +160,14 @@ def test_get_hf_token_state_fresh_busts_whoami_cache(fresh_app, monkeypatch):
     # An explicit test fails; ordinary reads must never revalidate.
     r = c.get("/api/settings/hf-token/state?fresh=1")
     env_row = next(s for s in r.json()["sources"] if s["source"] == "env")
-    assert env_row["set"] and not env_row["whoami_ok"]
+    assert env_row["set"] and env_row["whoami_ok"] is False
     first_calls = calls["n"]
 
-    # Network recovers, but a plain GET still serves the cached failure.
+    # Network recovers, but a plain GET only reports unvalidated local presence.
     verdict["ok"] = True
     r = c.get("/api/settings/hf-token/state")
     env_row = next(s for s in r.json()["sources"] if s["source"] == "env")
-    assert not env_row["whoami_ok"], "plain GET must keep the cache (no re-run)"
+    assert env_row["whoami_ok"] is None, "plain GET must not validate"
     assert calls["n"] == first_calls
 
     # "Test now" (fresh=1) drops the cache and re-runs whoami → verified.
@@ -305,3 +305,21 @@ def test_token_state_reads_never_contact_hugging_face(fresh_app, monkeypatch, en
     row = next(row for row in response.json()["sources"] if row["source"] == "env")
     assert row["set"] and row["whoami_ok"] is None
     whoami.assert_not_called()
+
+
+def test_canonical_save_replaces_the_existing_app_source(fresh_app, monkeypatch):
+    import huggingface_hub
+    from services import settings_store, token_resolver
+    settings_store.set_hf_token("hf_old_app")
+    monkeypatch.setenv("HF_TOKEN", "hf_old_env")
+    monkeypatch.setattr(huggingface_hub, "login", lambda **kwargs: None)
+    monkeypatch.setattr(huggingface_hub, "whoami", lambda token: {"name": token})
+    response = _client(fresh_app).post("/api/settings/hf-token", json={"token": SAMPLE_TOKEN})
+    assert response.status_code == 200
+    assert settings_store.get_hf_token() == SAMPLE_TOKEN
+    resolved = token_resolver.resolve()
+    assert resolved.source == "app"
+    assert resolved.token == SAMPLE_TOKEN
+    app_row = next(row for row in response.json()["sources"] if row["source"] == "app")
+    assert app_row["set"] is True
+    assert app_row["whoami_ok"] is None

--- a/tests/backend/test_engine_spawn_token.py
+++ b/tests/backend/test_engine_spawn_token.py
@@ -19,6 +19,10 @@ def fresh_app(monkeypatch, tmp_path):
     The Settings router is mounted manually because the full main.py app
     factory imports the entire backend stack (torch, whisperx, demucs, …)
     which is too heavy for a unit test."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
@@ -206,6 +210,10 @@ def test_subprocess_env_includes_hf_token_when_resolved(monkeypatch, tmp_path):
     to a Popen-style subprocess launcher contains HF_TOKEN=<that token>.
     This is the AUTH-04 invariant; the SoniTranslate launcher (and any
     future subprocess launcher) MUST follow this exact pattern."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("HF_TOKEN", raising=False)
     for mod in list(sys.modules):
@@ -233,6 +241,10 @@ def test_subprocess_env_unchanged_when_no_token(monkeypatch, tmp_path):
     contain an injected HF_TOKEN. (If the parent had one in os.environ
     it would still be in the copy — but the launcher does not _add_ an
     empty string, which would clobber any child-set default.)"""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
@@ -259,6 +271,10 @@ def test_sonitranslate_module_uses_resolver(monkeypatch, tmp_path):
     launcher block contains the canonical resolver import. This guards
     against future refactors silently reverting the AUTH-04 wiring."""
     import inspect
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     for mod in list(sys.modules):
         if (

--- a/tests/backend/test_engine_spawn_token.py
+++ b/tests/backend/test_engine_spawn_token.py
@@ -70,9 +70,9 @@ def test_post_hf_token_loopback_succeeds(fresh_app, monkeypatch):
     from services import settings_store
     assert settings_store.get_hf_token() == SAMPLE_TOKEN
 
-    # Response contains the masked active source.
+    # Response reports masked local presence without asserting remote validity.
     body = r.json()
-    assert body["active"] == "app"
+    assert body["active"] is None
     assert any(s["source"] == "app" and s["set"] for s in body["sources"])
 
 
@@ -153,8 +153,8 @@ def test_get_hf_token_state_fresh_busts_whoami_cache(fresh_app, monkeypatch):
 
     c = _client(fresh_app)
 
-    # First load: whoami fails → env row set but not verified; failure cached.
-    r = c.get("/api/settings/hf-token/state")
+    # An explicit test fails; ordinary reads must never revalidate.
+    r = c.get("/api/settings/hf-token/state?fresh=1")
     env_row = next(s for s in r.json()["sources"] if s["source"] == "env")
     assert env_row["set"] and not env_row["whoami_ok"]
     first_calls = calls["n"]
@@ -272,3 +272,20 @@ def test_sonitranslate_module_uses_resolver(monkeypatch, tmp_path):
     assert "token_resolver.resolve" in src
     # And the env injection assigns HF_TOKEN explicitly.
     assert 'env["HF_TOKEN"]' in src or "env['HF_TOKEN']" in src
+
+
+@pytest.mark.parametrize("endpoint", ["/system/hf-token/state", "/api/settings/hf-token/state"])
+def test_token_state_reads_never_contact_hugging_face(fresh_app, monkeypatch, endpoint):
+    import huggingface_hub
+    monkeypatch.setenv("HF_TOKEN", SAMPLE_TOKEN)
+    monkeypatch.setattr(huggingface_hub, "get_token", lambda: None)
+    whoami = MagicMock(side_effect=AssertionError("unexpected outbound validation"))
+    monkeypatch.setattr(huggingface_hub, "whoami", whoami)
+    if endpoint == "/system/hf-token/state":
+        from api.routers.system import router
+        fresh_app.include_router(router)
+    response = _client(fresh_app).get(endpoint)
+    assert response.status_code == 200
+    row = next(row for row in response.json()["sources"] if row["source"] == "env")
+    assert row["set"] and row["whoami_ok"] is None
+    whoami.assert_not_called()

--- a/tests/backend/test_perf_settings.py
+++ b/tests/backend/test_perf_settings.py
@@ -19,6 +19,10 @@ import pytest
 def fresh_app(monkeypatch, tmp_path):
     """Same isolation pattern as tests/backend/test_engine_spawn_token.py —
     new tmp DB + a fresh settings router instance per test."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     monkeypatch.delenv("HF_TOKEN", raising=False)
     monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
@@ -97,6 +101,10 @@ def test_value_round_trips_via_settings_store(fresh_app, monkeypatch):
 
 def test_env_injection_when_enabled_on_windows(monkeypatch, tmp_path):
     """build_engine_env injects TORCH_COMPILE_DISABLE=1 on win32 + flag true."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     for mod in list(sys.modules):
         if mod == "core" or mod.startswith("core.") or mod == "services" or mod.startswith("services."):
@@ -118,6 +126,10 @@ def test_env_injection_when_enabled_on_windows(monkeypatch, tmp_path):
 
 def test_no_env_injection_on_non_windows(monkeypatch, tmp_path):
     """On macOS/Linux the var is never injected, even when the flag is set."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     for mod in list(sys.modules):
         if mod == "core" or mod.startswith("core.") or mod == "services" or mod.startswith("services."):
@@ -140,6 +152,10 @@ def test_no_env_injection_on_non_windows(monkeypatch, tmp_path):
 
 def test_no_env_injection_when_disabled(monkeypatch, tmp_path):
     """Flag false on win32 → var not injected."""
+    from huggingface_hub import constants
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(tmp_path / "hf-token"))
+    monkeypatch.setattr(constants, "HF_STORED_TOKENS_PATH", str(tmp_path / "stored_tokens"))
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "hf-token"))
     monkeypatch.setenv("OMNIVOICE_DATA_DIR", str(tmp_path))
     for mod in list(sys.modules):
         if mod == "core" or mod.startswith("core.") or mod == "services" or mod.startswith("services."):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -738,3 +738,37 @@ def test_static_audio_served_with_canonical_mime():
         )
     finally:
         tmp_wav.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("fail_clear", [False, True])
+def test_system_hf_clear_uses_shared_token_file_cleanup(monkeypatch, tmp_path, fail_clear):
+    from pathlib import Path
+    from fastapi.testclient import TestClient
+    from main import app
+    from core import config
+    from huggingface_hub import constants
+    selected = tmp_path / "selected" / "token"
+    legacy = tmp_path / "legacy" / "token"
+    for path in (selected, legacy):
+        path.parent.mkdir()
+        path.write_text("synthetic-cli-token")
+        path.with_name("stored_tokens").write_text("synthetic-stored")
+    monkeypatch.setattr(constants, "HF_TOKEN_PATH", str(selected))
+    monkeypatch.setattr(config, "HF_CLI_TOKEN_PATHS", (str(selected), str(legacy)))
+    monkeypatch.setenv("HF_TOKEN", "synthetic-env")
+    if fail_clear:
+        original = Path.unlink
+        def unlink(path, *args, **kwargs):
+            if path == selected:
+                raise PermissionError("synthetic-private-content")
+            return original(path, *args, **kwargs)
+        monkeypatch.setattr(Path, "unlink", unlink)
+    response = TestClient(app, client=("127.0.0.1", 12345)).post(
+        "/system/set-env", json={"key": "HF_TOKEN", "value": ""}
+    )
+    assert response.status_code == (500 if fail_clear else 200)
+    assert "synthetic-private-content" not in response.text
+    assert not legacy.exists()
+    assert not legacy.with_name("stored_tokens").exists()
+    assert selected.exists() == fail_clear
+    assert "HF_TOKEN" not in os.environ

--- a/tests/test_hf_token_cache_paths.py
+++ b/tests/test_hf_token_cache_paths.py
@@ -1,0 +1,85 @@
+"""Fresh imports exercise Windows cache setup before Hub freezes token paths."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.parametrize("scenario", ["empty", "default", "legacy", "both", "explicit_token", "explicit_home", "explicit_cache", "explicit_app_cache", "xdg"])
+def test_windows_token_path_matches_hub_and_preserves_existing_login(tmp_path, scenario):
+    script = r'''
+import json, os, sys
+from pathlib import Path
+root = Path(sys.argv[1]); scenario = sys.argv[2]
+home = root / "user"
+original_expanduser = os.path.expanduser
+os.path.expanduser = lambda value: str(home) + value[1:] if value.startswith("~") else value
+canonical = home / ".cache" / "huggingface" / "token"
+legacy = root / "local" / "OmniVoice" / "hf_cache" / "token"
+expected = canonical
+if scenario in ("legacy", "both"):
+    legacy.parent.mkdir(parents=True); legacy.write_text("synthetic-legacy")
+    expected = legacy
+if scenario in ("default", "both"):
+    canonical.parent.mkdir(parents=True); canonical.write_text("synthetic-canonical")
+    expected = canonical
+if scenario == "explicit_token":
+    os.environ["HF_TOKEN_PATH"] = "~/custom/token"; expected = home / "custom" / "token"
+if scenario == "explicit_home":
+    os.environ["HF_HOME"] = str(root / "custom-home"); expected = root / "custom-home" / "token"
+if scenario == "explicit_cache":
+    os.environ["HF_HUB_CACHE"] = str(root / "custom-cache")
+if scenario == "explicit_app_cache":
+    os.environ["OMNIVOICE_CACHE_DIR"] = str(root / "app-cache")
+    # main.py applies the explicit app setting before importing core.config.
+    os.environ["HF_HOME"] = os.environ["OMNIVOICE_CACHE_DIR"]
+    os.environ["HF_HUB_CACHE"] = os.environ["OMNIVOICE_CACHE_DIR"]
+    expected = root / "app-cache" / "token"
+if scenario == "xdg":
+    os.environ["XDG_CACHE_HOME"] = "~/xdg"; expected = home / "xdg" / "huggingface" / "token"
+host = sys.platform; sys.platform = "win32"
+from core import config
+sys.platform = host
+from huggingface_hub import constants
+assert Path(constants.HF_TOKEN_PATH) == expected, (constants.HF_TOKEN_PATH, str(expected))
+assert Path(constants.HF_STORED_TOKENS_PATH) == expected.parent / "stored_tokens"
+# Real Hub persistence with only its remote identity request stubbed.
+from huggingface_hub import hf_api
+hf_api.whoami = lambda token: {"name": "test", "auth": {"accessToken": {"role": "read", "displayName": "synthetic"}}}
+from core import db
+db.init_db()
+from services import token_resolver as resolver
+# Populate an unrelated old app location even for explicit overrides.
+legacy.parent.mkdir(parents=True, exist_ok=True)
+if not legacy.exists(): legacy.write_text("synthetic-old")
+legacy.with_name("stored_tokens").write_text("[old]\nhf_token = synthetic-old\n")
+resolver.save_app_token("hf_synthetic_saved")
+assert expected.read_text() == "hf_synthetic_saved"
+resolver.clear_app_token()
+assert expected.exists(), "App-only clear must preserve CLI login"
+resolver.clear_app_token(also_clear_hf_cli=True)
+assert not expected.exists()
+assert not expected.with_name("stored_tokens").exists()
+if scenario.startswith("explicit_"):
+    assert legacy.exists(), "Explicit override must not clear unrelated token files"
+else:
+    assert not canonical.exists() and not legacy.exists()
+    assert not legacy.with_name("stored_tokens").exists()
+    # Reinitialize the next startup's automatic selection after explicit clear.
+    for key in ("HF_HOME", "HF_HUB_CACHE", "HF_TOKEN_PATH"):
+        os.environ.pop(key, None)
+    import importlib
+    sys.platform = "win32"
+    importlib.reload(config)
+    sys.platform = host
+    assert os.environ["HF_TOKEN_PATH"] != str(legacy), "Cleared legacy login must not resurrect"
+print(json.dumps({"selected": str(expected)}))
+'''
+    env = {key: value for key, value in os.environ.items() if not key.startswith(("HF_", "HUGGING_FACE_", "OMNIVOICE_CACHE", "XDG_CACHE"))}
+    env.update(HF_HUB_OFFLINE="1", OMNIVOICE_DATA_DIR=str(tmp_path / "app"), LOCALAPPDATA=str(tmp_path / "local"), PYTHONPATH=str(Path(__file__).resolve().parents[1] / "backend"))
+    result = subprocess.run([sys.executable, "-c", script, str(tmp_path), scenario], env=env, capture_output=True, text=True, timeout=20)
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["selected"]

--- a/tests/test_locale_parity.py
+++ b/tests/test_locale_parity.py
@@ -99,10 +99,10 @@ _ENGINE_AGNOSTIC_KEYS = (
 # Never raise one: if this fails after adding en.json keys, add the keys to
 # every locale (translated) in the same change instead.
 _MISSING_BASELINE = {
-    "ar": 493, "de": 493, "es": 493, "fr": 493, "hi": 493, "id": 493,
-    "it": 493, "ja": 493, "ko": 0, "nl": 493, "pl": 493, "pt": 493,
-    "ru": 493, "sv": 493, "th": 493, "tr": 493, "uk": 493, "vi": 493,
-    "zh-CN": 486, "zh-TW": 493,
+    "ar": 490, "de": 490, "es": 490, "fr": 490, "hi": 490, "id": 490,
+    "it": 490, "ja": 490, "ko": 0, "nl": 490, "pl": 490, "pt": 490,
+    "ru": 490, "sv": 490, "th": 490, "tr": 490, "uk": 490, "vi": 490,
+    "zh-CN": 483, "zh-TW": 490,
 }
 
 #: Keys every locale must carry regardless of the aggregate ratchet above.
@@ -116,6 +116,9 @@ _REQUIRED_IN_EVERY_LOCALE = (
     "capture.copied",
     "capture.inserted",
     "capture.pasted",
+    "settings.hf_source_app_label",
+    "settings.hf_source_cli_label",
+    "settings.hf_source_env_label",
 )
 
 
@@ -427,7 +430,8 @@ def test_every_locale_carries_the_user_facing_dictation_status(locale, key):
         f"{locale}.json is missing {key!r} — users on that locale see the raw key "
         f"or the English string"
     )
-    assert value != english, (
+    # Standard model acronyms and product/CLI names are shared across locales.
+    assert key in {"models.role_llm", "settings.hf_source_cli_label"} or value != english, (
         f"{locale}.json copies the English {key!r} verbatim ({english!r}); "
         f"translate it or the ratchet is measuring nothing"
     )

--- a/tests/test_locale_parity.py
+++ b/tests/test_locale_parity.py
@@ -113,6 +113,9 @@ _MISSING_BASELINE = {
 #: delivery IS the Wayland default, so leaving it English broke that path for
 #: every non-English Linux user (#1610 review).
 _REQUIRED_IN_EVERY_LOCALE = (
+    "common.error",
+    "bootstrap.retry",
+    "firstrun.hf_token_saved",
     "capture.copied",
     "capture.inserted",
     "capture.pasted",


### PR DESCRIPTION
Onboarding recognizes existing Hugging Face tokens from the app, environment, or CLI and shows their source and masked preview. Failed or malformed token discovery keeps entry hidden until an explicit Retry succeeds. Replacing a token requires an explicit action and writes the highest-priority encrypted app source; replacement does not revoke the old token. Settings distinguishes untested tokens from failed validation, and **Test now** explicitly validates them remotely.

Ordinary token-state reads inspect local files without `whoami`, OAuth refresh, or environment tokens being mislabeled as CLI credentials. Windows keeps standard CLI logins visible when shortening its model cache, preserves existing app-cache logins, and honors explicit cache/token paths. Saving and clearing use the same selected Hub path. Explicit CLI clearing removes recognized token files, reports permission failures, and prevents old credentials reappearing on restart; app-only clearing preserves CLI files. Copy is translated across all 21 locales, with matching documentation and contributor credit.

Validation: targeted source, fresh-process Windows path, real Hub persistence, cleanup failure, API, cache, locale, changelog, and CJK regressions pass. Source/path and onboarding replacement cases failed before the fix; tests isolate credential files and mock remote identity checks. Frontend coverage verifies loading/error/retry, app/environment/CLI replacement, pending-save edit protection, saved-only confirmation, and translated cleanup errors with retry. Latest targeted validation: 29 frontend and 384 backend/locale/CI/style checks, plus typecheck and lint.

Fixes #1851.
