### PR TITLE
fix(firstrun): stop sending free-text instruct prose on first sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The first-run welcome line no longer sends a hardcoded prose `instruct` that always failed validation and left onboarding silent (#1853)
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the frozen-backend fallback mirror it for their toolchains.
 **Highlights**
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
+- The first-run welcome line no longer sends a hardcoded prose `instruct` that always failed validation and left onboarding silent (#1853) — thanks @psiberfunk!
 
 ### Changed
 
@@ -20,7 +21,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- The first-run welcome line no longer sends a hardcoded prose `instruct` that always failed validation and left onboarding silent (#1853)
+- The first-run welcome line no longer sends a hardcoded prose `instruct` that always failed validation and left onboarding silent (#1853) — thanks @psiberfunk!
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ the frozen-backend fallback mirror it for their toolchains.
 **Highlights**
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
-- The first-run welcome line no longer sends a hardcoded prose `instruct` that always failed validation and left onboarding silent (#1853) — thanks @psiberfunk!
+- The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!
 
 ### Changed
 
@@ -21,7 +21,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- The first-run welcome line no longer sends a hardcoded prose `instruct` that always failed validation and left onboarding silent (#1853) — thanks @psiberfunk!
+- The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!
 
 
 ## [0.5.2] — 2026-09-02

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -701,13 +701,19 @@ function App() {
       try {
         const fd = new FormData();
         fd.append('text', i18n.t('firstrun.first_sound_text'));
-        // No `instruct`: it only validates against a fixed per-engine
-        // vocabulary (OmniVoice's `_resolve_instruct`), so free-text prose
-        // like the old hardcoded string can never pass — it 400ed on every
-        // first run and the catch below swallowed it into silence (#1853).
-        // Omitting the field is also the same thing every other call site
-        // does for an empty/no instruct (`if (instruct) fd.append(...)`),
-        // and it degrades identically no matter which engine is active.
+        // Functional model prompt (not user-facing copy). Free-text prose
+        // like the old hardcoded string 400ed on every first run: OmniVoice's
+        // `_resolve_instruct` only accepts comma-separated taxonomy tokens
+        // (#1853). Omitting `instruct` isn't safe either — the mlx-audio
+        // Qwen3 VoiceDesign backend *requires* a truthy instruct and raises
+        // when it's missing (`_is_voice_design()` in tts_backend.py), so a
+        // user who picked that engine during onboarding would still get
+        // silence. "middle-aged, low pitch" is the same taxonomy string the
+        // built-in "Narrator" personality uses (backend/core/personalities.py)
+        // — valid vocabulary for OmniVoice, and a non-empty description for
+        // any voice-design engine — so it degrades identically no matter
+        // which engine is active.
+        fd.append('instruct', 'middle-aged, low pitch');
         fd.append('num_step', '16');
         const res = await apiFetch(`${API}/generate`, {
           method: 'POST',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -701,9 +701,13 @@ function App() {
       try {
         const fd = new FormData();
         fd.append('text', i18n.t('firstrun.first_sound_text'));
-        // Functional model prompt (not user-facing copy) — keeps the demo
-        // voice warm without depending on seeded profiles.
-        fd.append('instruct', 'A warm, friendly narrator voice, medium pace');
+        // No `instruct`: it only validates against a fixed per-engine
+        // vocabulary (OmniVoice's `_resolve_instruct`), so free-text prose
+        // like the old hardcoded string can never pass — it 400ed on every
+        // first run and the catch below swallowed it into silence (#1853).
+        // Omitting the field is also the same thing every other call site
+        // does for an empty/no instruct (`if (instruct) fd.append(...)`),
+        // and it degrades identically no matter which engine is active.
         fd.append('num_step', '16');
         const res = await apiFetch(`${API}/generate`, {
           method: 'POST',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,4 @@
+import { firstSoundRequest } from './utils/firstSound';
 import React, {
   useState,
   useRef,
@@ -699,26 +700,10 @@ function App() {
     if (!pending) return;
     (async () => {
       try {
-        const fd = new FormData();
-        fd.append('text', i18n.t('firstrun.first_sound_text'));
-        // Functional model prompt (not user-facing copy). Free-text prose
-        // like the old hardcoded string 400ed on every first run: OmniVoice's
-        // `_resolve_instruct` only accepts comma-separated taxonomy tokens
-        // (#1853). Omitting `instruct` isn't safe either — the mlx-audio
-        // Qwen3 VoiceDesign backend *requires* a truthy instruct and raises
-        // when it's missing (`_is_voice_design()` in tts_backend.py), so a
-        // user who picked that engine during onboarding would still get
-        // silence. "middle-aged, low pitch" is the same taxonomy string the
-        // built-in "Narrator" personality uses (backend/core/personalities.py)
-        // — valid vocabulary for OmniVoice, and a non-empty description for
-        // any voice-design engine — so it degrades identically no matter
-        // which engine is active.
-        fd.append('instruct', 'middle-aged, low pitch');
-        fd.append('num_step', '16');
-        const res = await apiFetch(`${API}/generate`, {
-          method: 'POST',
-          body: fd,
-        });
+        const res = await apiFetch(
+          `${API}/generate`,
+          firstSoundRequest(i18n.t('firstrun.first_sound_text')),
+        );
         const blob = await res.blob();
         await playBlobAudio(blob, { label: i18n.t('player.generated_audio') });
         toast.success(i18n.t('firstrun.first_sound_done'), { duration: 7000 });

--- a/frontend/src/test/firstSoundInstruct.test.js
+++ b/frontend/src/test/firstSoundInstruct.test.js
@@ -1,0 +1,55 @@
+/**
+ * The first-sound request (App.jsx, fired once right after onboarding) used
+ * to send `instruct: 'A warm, friendly narrator voice, medium pace'`. Every
+ * engine's `instruct` is a controlled vocabulary, not free text — OmniVoice's
+ * `_resolve_instruct` (omnivoice/models/omnivoice.py) rejects anything
+ * outside a fixed token list, so that prose 400ed on every single first run.
+ * The catch block around the request is deliberately silent (a first
+ * impression must never surface an error), so the user just got no audio and
+ * no explanation (#1853).
+ *
+ * Exercised through the source text rather than a full App render: App.jsx
+ * pulls in the whole shell (Header, NavRail, a dozen lazy pages, Tauri APIs,
+ * the audio player, …), none of which this regression depends on — only the
+ * literal FormData built for this one request.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const appSrc = fs.readFileSync(
+  path.resolve(__dirname, '..', 'App.jsx'),
+  'utf8'
+);
+
+const firstSoundBlock = (() => {
+  const start = appSrc.indexOf('── First sound ──');
+  const end = appSrc.indexOf('── Tauri auto-updater ──', start);
+  expect(start, 'First sound section marker moved or was removed').toBeGreaterThan(-1);
+  expect(end, 'Tauri auto-updater section marker moved or was removed').toBeGreaterThan(start);
+  return appSrc.slice(start, end);
+})();
+
+describe('the first-sound request cannot send free-text instruct prose', () => {
+  it('never reintroduces the old hardcoded narrator prose anywhere in App.jsx', () => {
+    expect(appSrc).not.toMatch(/warm,\s*friendly narrator voice/i);
+  });
+
+  it('does not append an `instruct` field to the first-sound FormData at all', () => {
+    // Omitting it entirely — not swapping in a vocabulary string — matches
+    // every other call site in the app (`if (instruct) fd.append('instruct', ...)`
+    // in useTTS.js, useProfiles.js, VoicePreview.jsx, CompareModal.jsx,
+    // VoiceProfile.jsx) and is proven safe: the backend's per-engine instruct
+    // resolvers all treat a missing/empty instruct as "no styling", never as
+    // a required field, so this degrades identically no matter which TTS
+    // engine is active.
+    expect(firstSoundBlock).not.toMatch(/fd\.append\(\s*['"]instruct['"]/);
+  });
+
+  it('still builds the rest of the first-sound request (text + num_step)', () => {
+    // Sanity check that the slice targets the right block and the fix didn't
+    // collaterally remove anything else the request needs.
+    expect(firstSoundBlock).toMatch(/fd\.append\(\s*['"]text['"]/);
+    expect(firstSoundBlock).toMatch(/fd\.append\(\s*['"]num_step['"]/);
+  });
+});

--- a/frontend/src/test/firstSoundInstruct.test.js
+++ b/frontend/src/test/firstSoundInstruct.test.js
@@ -8,6 +8,15 @@
  * impression must never surface an error), so the user just got no audio and
  * no explanation (#1853).
  *
+ * Omitting `instruct` entirely isn't safe either: the mlx-audio Qwen3
+ * VoiceDesign backend (`backend/services/tts_backend.py`, `_is_voice_design`)
+ * *requires* a truthy instruct and raises `ValueError` without one, so a user
+ * who picked that engine during onboarding would still get silence — the
+ * same failure class, just a different engine. The fix instead sends the
+ * same taxonomy-token instruct the built-in "Narrator" personality uses:
+ * valid vocabulary for OmniVoice, and a non-empty description for any
+ * voice-design engine.
+ *
  * Exercised through the source text rather than a full App render: App.jsx
  * pulls in the whole shell (Header, NavRail, a dozen lazy pages, Tauri APIs,
  * the audio player, …), none of which this regression depends on — only the
@@ -30,20 +39,51 @@ const firstSoundBlock = (() => {
   return appSrc.slice(start, end);
 })();
 
-describe('the first-sound request cannot send free-text instruct prose', () => {
+// The exact instruct string the first-sound request appends.
+const instructMatch = firstSoundBlock.match(
+  /fd\.append\(\s*['"]instruct['"]\s*,\s*['"]([^'"]*)['"]\s*\)/,
+);
+
+// Cross-check against the backend's own "Narrator" personality preset so the
+// two can never silently drift apart — the whole point is reusing a value
+// the backend has already vetted as valid taxonomy vocabulary.
+const personalitiesSrc = fs.readFileSync(
+  path.resolve(__dirname, '..', '..', '..', 'backend', 'core', 'personalities.py'),
+  'utf8',
+);
+const narratorMatch = personalitiesSrc.match(
+  /"id":\s*"narrator"[\s\S]*?"instruct":\s*"([^"]*)"/,
+);
+
+describe('the first-sound request sends an engine-safe instruct', () => {
   it('never reintroduces the old hardcoded narrator prose anywhere in App.jsx', () => {
     expect(appSrc).not.toMatch(/warm,\s*friendly narrator voice/i);
   });
 
-  it('does not append an `instruct` field to the first-sound FormData at all', () => {
-    // Omitting it entirely — not swapping in a vocabulary string — matches
-    // every other call site in the app (`if (instruct) fd.append('instruct', ...)`
-    // in useTTS.js, useProfiles.js, VoicePreview.jsx, CompareModal.jsx,
-    // VoiceProfile.jsx) and is proven safe: the backend's per-engine instruct
-    // resolvers all treat a missing/empty instruct as "no styling", never as
-    // a required field, so this degrades identically no matter which TTS
-    // engine is active.
-    expect(firstSoundBlock).not.toMatch(/fd\.append\(\s*['"]instruct['"]/);
+  it('appends a non-empty `instruct` field to the first-sound FormData', () => {
+    // Must be present (not omitted) and non-empty: a voice-design engine
+    // (mlx-audio's Qwen3 VoiceDesign) raises on a missing/empty instruct
+    // (`_is_voice_design()` in tts_backend.py), so omitting it just trades
+    // one silent failure for another.
+    expect(instructMatch, 'expected fd.append("instruct", "...") in the first-sound block').not.toBeNull();
+    expect(instructMatch[1].trim().length).toBeGreaterThan(0);
+  });
+
+  it('only sends comma-separated taxonomy tokens, never free-text prose', () => {
+    // OmniVoice's `_resolve_instruct` splits on commas and validates each
+    // item against a fixed vocabulary — sentence-shaped text (articles,
+    // "voice"/"pace"/"like a ...") can never pass. A taxonomy string is
+    // short, lowercase-ish, comma-separated tokens only.
+    const value = instructMatch[1];
+    expect(value).not.toMatch(/\b(a|voice|pace|like)\b/i);
+    for (const token of value.split(',')) {
+      expect(token.trim()).toMatch(/^[a-z-]+(?: [a-z-]+)*$/);
+    }
+  });
+
+  it('matches the backend\'s own "Narrator" personality instruct exactly', () => {
+    expect(narratorMatch, 'expected a "narrator" personality with an instruct in personalities.py').not.toBeNull();
+    expect(instructMatch[1]).toBe(narratorMatch[1]);
   });
 
   it('still builds the rest of the first-sound request (text + num_step)', () => {

--- a/frontend/src/test/firstSoundInstruct.test.js
+++ b/frontend/src/test/firstSoundInstruct.test.js
@@ -1,95 +1,15 @@
-/**
- * The first-sound request (App.jsx, fired once right after onboarding) used
- * to send `instruct: 'A warm, friendly narrator voice, medium pace'`. Every
- * engine's `instruct` is a controlled vocabulary, not free text — OmniVoice's
- * `_resolve_instruct` (omnivoice/models/omnivoice.py) rejects anything
- * outside a fixed token list, so that prose 400ed on every single first run.
- * The catch block around the request is deliberately silent (a first
- * impression must never surface an error), so the user just got no audio and
- * no explanation (#1853).
- *
- * Omitting `instruct` entirely isn't safe either: the mlx-audio Qwen3
- * VoiceDesign backend (`backend/services/tts_backend.py`, `_is_voice_design`)
- * *requires* a truthy instruct and raises `ValueError` without one, so a user
- * who picked that engine during onboarding would still get silence — the
- * same failure class, just a different engine. The fix instead sends the
- * same taxonomy-token instruct the built-in "Narrator" personality uses:
- * valid vocabulary for OmniVoice, and a non-empty description for any
- * voice-design engine.
- *
- * Exercised through the source text rather than a full App render: App.jsx
- * pulls in the whole shell (Header, NavRail, a dozen lazy pages, Tauri APIs,
- * the audio player, …), none of which this regression depends on — only the
- * literal FormData built for this one request.
- */
 import { describe, it, expect } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
+import { firstSoundRequest } from '../utils/firstSound';
 
-const appSrc = fs.readFileSync(
-  path.resolve(__dirname, '..', 'App.jsx'),
-  'utf8'
-);
-
-const firstSoundBlock = (() => {
-  const start = appSrc.indexOf('── First sound ──');
-  const end = appSrc.indexOf('── Tauri auto-updater ──', start);
-  expect(start, 'First sound section marker moved or was removed').toBeGreaterThan(-1);
-  expect(end, 'Tauri auto-updater section marker moved or was removed').toBeGreaterThan(start);
-  return appSrc.slice(start, end);
-})();
-
-// The exact instruct string the first-sound request appends.
-const instructMatch = firstSoundBlock.match(
-  /fd\.append\(\s*['"]instruct['"]\s*,\s*['"]([^'"]*)['"]\s*\)/,
-);
-
-// Cross-check against the backend's own "Narrator" personality preset so the
-// two can never silently drift apart — the whole point is reusing a value
-// the backend has already vetted as valid taxonomy vocabulary.
-const personalitiesSrc = fs.readFileSync(
-  path.resolve(__dirname, '..', '..', '..', 'backend', 'core', 'personalities.py'),
-  'utf8',
-);
-const narratorMatch = personalitiesSrc.match(
-  /"id":\s*"narrator"[\s\S]*?"instruct":\s*"([^"]*)"/,
-);
-
-describe('the first-sound request sends an engine-safe instruct', () => {
-  it('never reintroduces the old hardcoded narrator prose anywhere in App.jsx', () => {
-    expect(appSrc).not.toMatch(/warm,\s*friendly narrator voice/i);
-  });
-
-  it('appends a non-empty `instruct` field to the first-sound FormData', () => {
-    // Must be present (not omitted) and non-empty: a voice-design engine
-    // (mlx-audio's Qwen3 VoiceDesign) raises on a missing/empty instruct
-    // (`_is_voice_design()` in tts_backend.py), so omitting it just trades
-    // one silent failure for another.
-    expect(instructMatch, 'expected fd.append("instruct", "...") in the first-sound block').not.toBeNull();
-    expect(instructMatch[1].trim().length).toBeGreaterThan(0);
-  });
-
-  it('only sends comma-separated taxonomy tokens, never free-text prose', () => {
-    // OmniVoice's `_resolve_instruct` splits on commas and validates each
-    // item against a fixed vocabulary — sentence-shaped text (articles,
-    // "voice"/"pace"/"like a ...") can never pass. A taxonomy string is
-    // short, lowercase-ish, comma-separated tokens only.
-    const value = instructMatch[1];
-    expect(value).not.toMatch(/\b(a|voice|pace|like)\b/i);
-    for (const token of value.split(',')) {
-      expect(token.trim()).toMatch(/^[a-z-]+(?: [a-z-]+)*$/);
-    }
-  });
-
-  it('matches the backend\'s own "Narrator" personality instruct exactly', () => {
-    expect(narratorMatch, 'expected a "narrator" personality with an instruct in personalities.py').not.toBeNull();
-    expect(instructMatch[1]).toBe(narratorMatch[1]);
-  });
-
-  it('still builds the rest of the first-sound request (text + num_step)', () => {
-    // Sanity check that the slice targets the right block and the fix didn't
-    // collaterally remove anything else the request needs.
-    expect(firstSoundBlock).toMatch(/fd\.append\(\s*['"]text['"]/);
-    expect(firstSoundBlock).toMatch(/fd\.append\(\s*['"]num_step['"]/);
+describe('onboarding first-sound request', () => {
+  it('posts localized text and a nonempty voice-design instruction as multipart form data', () => {
+    const request = firstSoundRequest('Welcome to VoiceStudio');
+    expect(request.method).toBe('POST');
+    expect(request.body).toBeInstanceOf(FormData);
+    expect(Object.fromEntries(request.body)).toEqual({
+      text: 'Welcome to VoiceStudio',
+      instruct: 'middle-aged, low pitch',
+      num_step: '16',
+    });
   });
 });

--- a/frontend/src/utils/firstSound.js
+++ b/frontend/src/utils/firstSound.js
@@ -1,0 +1,10 @@
+import defaults from './firstSound.json';
+
+// Taxonomy tokens also provide the nonempty description VoiceDesign requires.
+export function firstSoundRequest(text) {
+  const body = new FormData();
+  body.append('text', text);
+  body.append('instruct', defaults.instruct);
+  body.append('num_step', String(defaults.num_step));
+  return { method: 'POST', body };
+}

--- a/frontend/src/utils/firstSound.json
+++ b/frontend/src/utils/firstSound.json
@@ -1,0 +1,4 @@
+{
+  "instruct": "middle-aged, low pitch",
+  "num_step": 16
+}

--- a/tests/test_first_sound_instruct.py
+++ b/tests/test_first_sound_instruct.py
@@ -12,4 +12,4 @@ def test_first_sound_instruction_passes_runtime_taxonomy_validation():
     # VoiceDesign requires a nonempty description; OmniVoice validates tokens.
     assert instruct.strip()
     assert _resolve_instruct(instruct) == instruct
-    assert _resolve_instruct(instruct, use_zh=True)
+    assert _resolve_instruct(instruct, use_zh=True) == "中年，低音调"

--- a/tests/test_first_sound_instruct.py
+++ b/tests/test_first_sound_instruct.py
@@ -1,0 +1,16 @@
+"""The actual onboarding defaults must pass the runtime engine validator."""
+import json
+from pathlib import Path
+
+from omnivoice.models.omnivoice import _resolve_instruct
+
+
+def test_first_sound_instruction_passes_runtime_taxonomy_validation():
+    defaults = json.loads(
+        (Path(__file__).parents[1] / "frontend/src/utils/firstSound.json").read_text()
+    )
+    instruct = defaults["instruct"]
+    # VoiceDesign requires a nonempty description; OmniVoice validates tokens.
+    assert instruct.strip()
+    assert _resolve_instruct(instruct) == instruct
+    assert _resolve_instruct(instruct, use_zh=True)

--- a/tests/test_first_sound_instruct.py
+++ b/tests/test_first_sound_instruct.py
@@ -2,10 +2,9 @@
 import json
 from pathlib import Path
 
-from omnivoice.models.omnivoice import _resolve_instruct
-
-
 def test_first_sound_instruction_passes_runtime_taxonomy_validation():
+    from omnivoice.models.omnivoice import _resolve_instruct
+
     defaults = json.loads(
         (Path(__file__).parents[1] / "frontend/src/utils/firstSound.json").read_text()
     )


### PR DESCRIPTION
The first-run welcome request sent free-form narrator prose that OmniVoice rejects, leaving onboarding silent. It now sends the nonempty taxonomy instruction `middle-aged, low pitch`, which also satisfies VoiceDesign's requirement for a description.

The app uses a tested multipart request builder. Shared request defaults are checked against the actual backend `_resolve_instruct` validator in both English and Chinese modes. The original prose fails that regression; the corrected request and targeted backend checks pass.

Fixes #1853.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The first-sound request now uses the valid OmniVoice instruction `middle-aged, low pitch` through a shared request helper. This prevents onboarding audio generation from failing on unsupported prose and verifies the instruction with OmniVoice validation in English and Chinese modes. Review the default instruction if VoiceDesign requires different non-empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->