### PR TITLE
fix(logs): avoid false all-clear state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The logs panel no longer reports “All clear” while backend, frontend, or desktop logs contain warnings or errors (#1854) — thanks @motodriver!
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- The logs panel no longer reports “All clear” while backend, frontend, or desktop logs contain warnings or errors (#1854) — thanks @motodriver!
+- The logs panel no longer reports “All clear” before log retrieval succeeds or while logs contain warnings or errors (#1870) — thanks @motodriver!
 
 
 ## [0.5.2] — 2026-09-02

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -772,7 +772,7 @@ export default function LogsFooter() {
 
       {!collapsed && active === 'notifications' && (
         <div className="logs-footer__body flex flex-col gap-[2px] px-[8px] py-[6px] flex-1 min-h-0 overflow-y-auto select-text">
-          {notifications.length === 0 ? (
+          {notifications.length === 0 && mergedCounts.error === 0 && mergedCounts.warn === 0 ? (
             <div className="p-[12px] [color:var(--chrome-fg-dim)] not-italic text-[11px] text-center">
               {t('logs.all_clear')}
             </div>

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -257,9 +257,10 @@ export default function LogsFooter() {
     return SOURCES.some((s) => s.id === v) ? v : 'backend';
   });
 
-  // Raw log state per source. Backend / Tauri come from HTTP; frontend
-  // comes from the in-process ring buffer in consoleBuffer.js.
-  const [lines, setLines] = useState({ backend: [], frontend: [], tauri: [] });
+  // Only the local console ring needs state; HTTP logs render from their query.
+  const [frontendLines, setFrontendLines] = useState(() =>
+    getFrontendLogs().map(formatFrontendLine),
+  );
   const [loading, setLoading] = useState(false);
   const scrollRef = useRef(null);
 
@@ -285,20 +286,16 @@ export default function LogsFooter() {
   const backendLogs = useSystemLogs(300, true, collapsed ? 45_000 : 10_000);
   const tauriLogs = useTauriLogs(300, true, collapsed ? 45_000 : 10_000);
 
-  // Sync query data into local state for the rendering pipeline
-  useEffect(() => {
-    if (backendLogs.data) {
-      setLines((prev) => ({ ...prev, backend: backendLogs.data.lines || [] }));
-    }
-  }, [backendLogs.data]);
+  const lines = useMemo(
+    () => ({
+      backend: backendLogs.data?.lines || [],
+      frontend: frontendLines,
+      tauri: tauriLogs.data?.lines || [],
+    }),
+    [backendLogs.data, tauriLogs.data, frontendLines],
+  );
 
-  useEffect(() => {
-    if (tauriLogs.data) {
-      setLines((prev) => ({ ...prev, tauri: tauriLogs.data.lines || [] }));
-    }
-  }, [tauriLogs.data]);
-
-  // Skip the setLines (and the re-render it forces) when the console ring
+  // Skip the state update (and the re-render it forces) when the console ring
   // buffer hasn't changed since the last pull — same length + same last
   // timestamp means nothing new arrived.
   const lastFrontendPull = useRef({ len: -1, t: 0 });
@@ -308,10 +305,7 @@ export default function LogsFooter() {
     const seen = lastFrontendPull.current;
     if (raw.length === seen.len && lastT === seen.t) return;
     lastFrontendPull.current = { len: raw.length, t: lastT };
-    setLines((prev) => ({
-      ...prev,
-      frontend: raw.map(formatFrontendLine),
-    }));
+    setFrontendLines(raw.map(formatFrontendLine));
   }, []);
 
   const refreshAll = useCallback(async () => {
@@ -331,7 +325,8 @@ export default function LogsFooter() {
 
   // ── Notifications (shared TanStack Query cache with the header bell) ────
   // Already filtered to what the user hasn't dismissed — badge and tab agree.
-  const { notifications } = useVisibleNotifications();
+  const { notifications, isSuccess: notificationsReady } = useVisibleNotifications();
+  const allSourcesReady = backendLogs.isSuccess && tauriLogs.isSuccess && notificationsReady;
   const dismissNotification = useAppStore((s) => s.dismissNotification);
 
   // ── Donation moment popover (see utils/donationMoments.js) ─────────────
@@ -422,10 +417,16 @@ export default function LogsFooter() {
   // ── Actions ─────────────────────────────────────────────────────────
   const onClear = async () => {
     try {
-      if (active === 'backend') await clearSystemLogs();
-      else if (active === 'tauri') await clearTauriLogs();
-      else if (active === 'frontend') clearFrontendLogs();
-      setLines((prev) => ({ ...prev, [active]: [] }));
+      if (active === 'backend') {
+        await clearSystemLogs();
+        await backendLogs.refetch();
+      } else if (active === 'tauri') {
+        await clearTauriLogs();
+        await tauriLogs.refetch();
+      } else if (active === 'frontend') {
+        clearFrontendLogs();
+        pullFrontend();
+      }
       toast.success(t('logs.log_cleared', { source: active }));
     } catch (e) {
       toast.error(t('logs.clear_failed', { message: e?.message || e }));
@@ -772,7 +773,10 @@ export default function LogsFooter() {
 
       {!collapsed && active === 'notifications' && (
         <div className="logs-footer__body flex flex-col gap-[2px] px-[8px] py-[6px] flex-1 min-h-0 overflow-y-auto select-text">
-          {notifications.length === 0 && mergedCounts.error === 0 && mergedCounts.warn === 0 ? (
+          {allSourcesReady &&
+          notifications.length === 0 &&
+          mergedCounts.error === 0 &&
+          mergedCounts.warn === 0 ? (
             <div className="p-[12px] [color:var(--chrome-fg-dim)] not-italic text-[11px] text-center">
               {t('logs.all_clear')}
             </div>

--- a/frontend/src/components/LogsFooter.jsx
+++ b/frontend/src/components/LogsFooter.jsx
@@ -419,10 +419,10 @@ export default function LogsFooter() {
     try {
       if (active === 'backend') {
         await clearSystemLogs();
-        await backendLogs.refetch();
+        await backendLogs.refetch({ throwOnError: true });
       } else if (active === 'tauri') {
         await clearTauriLogs();
-        await tauriLogs.refetch();
+        await tauriLogs.refetch({ throwOnError: true });
       } else if (active === 'frontend') {
         clearFrontendLogs();
         pullFrontend();

--- a/frontend/src/test/LogsFooterAllClear.test.jsx
+++ b/frontend/src/test/LogsFooterAllClear.test.jsx
@@ -1,7 +1,10 @@
 import React, { Profiler } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, QueryObserver } from '@tanstack/react-query';
+
+const toasts = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock('react-hot-toast', () => ({ default: Object.assign(vi.fn(), toasts) }));
 
 const queries = vi.hoisted(() => ({
   backend: {},
@@ -47,6 +50,8 @@ function footer(onRender = () => {}) {
 
 beforeEach(() => {
   localStorage.clear();
+  toasts.success.mockClear();
+  toasts.error.mockClear();
   queries.frontend = [];
   for (const source of ['backend', 'tauri']) {
     queries[source] = { data: { lines: [] }, isSuccess: true, refetch: vi.fn(async () => {}) };
@@ -123,3 +128,32 @@ describe('LogsFooter all-clear evidence', () => {
     },
   );
 });
+
+it.each(['backend', 'tauri'])(
+  'reports refresh failure after clearing %s without claiming success',
+  async (source) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const observer = new QueryObserver(client, {
+      queryKey: ['failed-refresh', source],
+      queryFn: async () => {
+        throw new Error('log refresh unavailable');
+      },
+    });
+    queries[source].refetch = (options) => observer.refetch(options);
+    const view = footer();
+    fireEvent.click(
+      screen.getByRole('button', { name: source === 'backend' ? /^Backend logs/ : /^Tauri logs/ }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+    await waitFor(() =>
+      expect(toasts.error).toHaveBeenCalledWith(expect.stringContaining('log refresh unavailable')),
+    );
+    expect(toasts.success).not.toHaveBeenCalled();
+    queries[source] = { ...queries[source], isSuccess: false, isError: true };
+    view.update();
+    act(() => window.dispatchEvent(new CustomEvent('omni:open-notifications')));
+    expect(screen.queryByText(ALL_CLEAR)).toBeNull();
+    observer.destroy();
+    client.clear();
+  },
+);

--- a/frontend/src/test/LogsFooterAllClear.test.jsx
+++ b/frontend/src/test/LogsFooterAllClear.test.jsx
@@ -1,0 +1,125 @@
+import React, { Profiler } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queries = vi.hoisted(() => ({
+  backend: {},
+  tauri: {},
+  notifications: {},
+  frontend: [],
+}));
+vi.mock('../utils/consoleBuffer', () => ({
+  getFrontendLogs: () => queries.frontend,
+  clearFrontendLogs: () => {
+    queries.frontend = [];
+  },
+}));
+vi.mock('../api/hooks', async (original) => ({
+  ...(await original()),
+  useSystemLogs: () => queries.backend,
+  useTauriLogs: () => queries.tauri,
+  useVisibleNotifications: () => queries.notifications,
+}));
+vi.mock('../api/system', async (original) => ({
+  ...(await original()),
+  clearSystemLogs: vi.fn(async () => {}),
+  clearTauriLogs: vi.fn(async () => {}),
+}));
+vi.mock('../components/NetworkToggle', () => ({ default: () => null }));
+
+import LogsFooter from '../components/LogsFooter';
+
+const ALL_CLEAR = /All clear/;
+function footer(onRender = () => {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const tree = () => (
+    <QueryClientProvider client={client}>
+      <Profiler id="logs" onRender={onRender}>
+        <LogsFooter />
+      </Profiler>
+    </QueryClientProvider>
+  );
+  const result = render(tree());
+  act(() => window.dispatchEvent(new CustomEvent('omni:open-notifications')));
+  return { ...result, update: () => result.rerender(tree()) };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  queries.frontend = [];
+  for (const source of ['backend', 'tauri']) {
+    queries[source] = { data: { lines: [] }, isSuccess: true, refetch: vi.fn(async () => {}) };
+  }
+  queries.notifications = { notifications: [], isSuccess: true };
+});
+
+describe('LogsFooter all-clear evidence', () => {
+  it('shows all clear only after every source succeeds without warnings', () => {
+    footer();
+    expect(screen.getByText(ALL_CLEAR)).toBeInTheDocument();
+  });
+
+  it.each(['backend', 'tauri', 'notifications'])(
+    'withholds all clear while %s is pending, then shows it on success',
+    (source) => {
+      queries[source].isSuccess = false;
+      queries[source].isPending = true;
+      const view = footer();
+      expect(screen.queryByText(ALL_CLEAR)).toBeNull();
+      queries[source] = { ...queries[source], isSuccess: true, isPending: false };
+      view.update();
+      expect(screen.getByText(ALL_CLEAR)).toBeInTheDocument();
+    },
+  );
+
+  it.each(['backend', 'tauri', 'notifications'])(
+    'withholds all clear when %s retrieval fails, even with cached empty data',
+    (source) => {
+      const view = footer();
+      expect(screen.getByText(ALL_CLEAR)).toBeInTheDocument();
+      queries[source] = { ...queries[source], isSuccess: false, isError: true };
+      view.update();
+      expect(screen.queryByText(ALL_CLEAR)).toBeNull();
+    },
+  );
+
+  it.each(['backend', 'tauri'])(
+    'never commits stale all-clear when %s gains a warning',
+    (source) => {
+      const commits = [];
+      const view = footer(() => commits.push(Boolean(screen.queryByText(ALL_CLEAR))));
+      expect(screen.getByText(ALL_CLEAR)).toBeInTheDocument();
+      commits.length = 0;
+      queries[source] = { ...queries[source], data: { lines: ['WARNING model unavailable'] } };
+      view.update();
+      expect(commits.length).toBeGreaterThan(0);
+      expect(commits).not.toContain(true);
+      expect(screen.queryByText(ALL_CLEAR)).toBeNull();
+    },
+  );
+
+  it('reads frontend warnings on mount and pulls the cleared ring immediately', () => {
+    queries.frontend = [{ t: 1, level: 'warn', msg: 'render warning' }];
+    footer();
+    expect(screen.queryByText(ALL_CLEAR)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /^Frontend logs/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+    act(() => window.dispatchEvent(new CustomEvent('omni:open-notifications')));
+    expect(screen.getByText(ALL_CLEAR)).toBeInTheDocument();
+  });
+
+  it.each(['backend', 'tauri'])(
+    'refreshes the authoritative %s query after clearing',
+    async (source) => {
+      footer();
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: source === 'backend' ? /^Backend logs/ : /^Tauri logs/,
+        }),
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+      await waitFor(() => expect(queries[source].refetch).toHaveBeenCalledOnce());
+    },
+  );
+});

--- a/frontend/src/test/LogsFooterNotifications.test.jsx
+++ b/frontend/src/test/LogsFooterNotifications.test.jsx
@@ -10,6 +10,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+const { backendData, notificationData } = vi.hoisted(() => ({
+  backendData: { lines: [] },
+  notificationData: { current: [] },
+}));
+
 const NOTES = [
   {
     id: 'gpu-unavailable',
@@ -40,7 +45,7 @@ vi.mock('../api/hooks', async (importOriginal) => {
   const real = await importOriginal();
   return {
     ...real,
-    useSystemLogs: () => ({ data: null, refetch: vi.fn() }),
+    useSystemLogs: () => ({ data: backendData, refetch: vi.fn() }),
     useTauriLogs: () => ({ data: null, refetch: vi.fn() }),
   };
 });
@@ -51,7 +56,7 @@ vi.mock('../api/system', async (importOriginal) => ({
   clearSystemLogs: vi.fn(),
   clearTauriLogs: vi.fn(),
   // The poll behind useNotifications — the filter under test runs REAL.
-  systemNotifications: vi.fn(async () => ({ notifications: NOTES })),
+  systemNotifications: vi.fn(async () => ({ notifications: notificationData.current })),
 }));
 // NetworkToggle fetches /system/network/state on mount — out of scope here.
 vi.mock('../components/NetworkToggle', () => ({ default: () => null }));
@@ -81,10 +86,24 @@ const dismissBtnIn = (row) => row.querySelector('button[aria-label]');
 
 beforeEach(() => {
   localStorage.clear();
+  backendData.lines = [];
+  notificationData.current = NOTES;
   useAppStore.setState({ dismissedNotificationIds: [] });
 });
 
 describe('LogsFooter notifications tab — dismissals', () => {
+  it('does not claim all clear when raw logs contain an error', async () => {
+    backendData.lines = ['ERROR failed to load the selected model'];
+    notificationData.current = [];
+    renderFooter();
+    openNotificationsTab();
+
+    expect(
+      await screen.findByRole('button', { name: 'Backend logs, 1 errors' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('✅ All clear — no issues detected')).toBeNull();
+  });
+
   it('shows both notes; only the info note offers a dismiss button', async () => {
     renderFooter();
     openNotificationsTab();


### PR DESCRIPTION
Closes #1854

## Summary

Prevents the Notifications tab from showing “All clear” while the existing backend, frontend, or Tauri log counters contain warnings or errors.

## Changes

- gate the existing all-clear empty state on both an empty notification feed and zero merged log warnings/errors
- add a fail-before/pass-after regression test for an empty notification feed with a backend error
- add the Unreleased changelog entry

## Testing

- `bun run test -- src/test/LogsFooterNotifications.test.jsx --maxWorkers=1` — 4 passed
- `bun run typecheck:ci` — passed
- `bun run build` — passed
- repository `bun run lint -- ...` — passed with one pre-existing max-lines warning for `LogsFooter.jsx`
- `git diff --check` — passed
- full frontend suite — 2,608 passed, 1 unrelated pre-existing failure: `initialLoadRetry.test.js` constructs a URL-encoded `%20` filesystem path when the checkout path contains spaces
- backend suite — not run: dependency setup failed because the host exports a Python 3.10 `PYTHONHOME` while `uv` selected Python 3.11, causing `docopt` build isolation to fail before tests

## Scope

No changes to log classification, mirrored-error deduplication, notification ingestion, or user-facing copy.

## AI disclosure

Implemented and reviewed with TRAE assistance. The issue was reproduced with a focused regression test, and the final diff received an independent P0-P2 review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The Notifications tab now shows “All clear” only when the notification feed and merged log warning/error counts are empty. This prevents contradictory status signals without changing log classification, deduplication, or notification ingestion. Focused validation passed, but the backend suite was not run because dependency setup failed due to a Python environment mismatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->