### PR TITLE
fix(release): allow retrying partially uploaded installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -604,6 +604,21 @@ jobs:
             fi
           done < /tmp/stale.txt
 
+      # A retried job reuses its version and can collide with installers it
+      # uploaded before a later step failed. Keep other versions/arches intact;
+      # macOS versionless updater archives are scoped by release tag and arch.
+      - name: Clear this target's installer assets on retry
+        if: github.run_attempt > 1
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ (needs.preview-gate.outputs.is_preview == 'true') && 'preview' || github.ref_name }}
+          RELEASE_TARGET: ${{ matrix.rust_target }}
+        run: |
+          VERSION=$(python -c 'import json; print(json.load(open("frontend/package.json"))["version"])')
+          python scripts/clear-release-rerun-assets.py \
+            --tag "$RELEASE_TAG" --version "$VERSION" --target "$RELEASE_TARGET"
+
       - name: Build + release (Tauri)
         uses: tauri-apps/tauri-action@v0
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Release retries replace their own partially uploaded installers without colliding with existing assets (#1871)
 
 ## [0.5.2] — 2026-09-02
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -147,3 +147,12 @@ There's no "revert update" flow for clients — they'll only see a *newer* versi
 3. Clients auto-update to the "new" v0.2.1 which is actually the old code.
 
 Ugly but it works. Better plan: test with Option B above before publishing the draft.
+
+## Retrying a partially published build
+
+Use GitHub Actions **Re-run failed jobs** for the same release run. On retries,
+the workflow removes only the current version's installers for that job's target
+before Tauri uploads them again. A macOS retry also replaces that architecture's
+versionless updater archive. Other versions, sibling platforms, and updater
+manifests remain intact. Inventory or deletion permission/network failures stop
+the job instead of hiding an upload collision.

--- a/scripts/clear-release-rerun-assets.py
+++ b/scripts/clear-release-rerun-assets.py
@@ -1,0 +1,52 @@
+"""Remove only this build/target's colliding installers before a release retry."""
+import argparse
+import json
+import re
+import subprocess
+
+
+def matching_assets(names, version, target):
+    versions = [version]
+    updater = None
+    if target == "x86_64-pc-windows-msvc":
+        versions.append(version.replace("-", "."))
+        suffix = r"x64(?:_[A-Za-z-]+\.msi(?:\.zip)?|-setup\.(?:exe|nsis\.zip))(?:\.sig)?"
+    elif target == "aarch64-apple-darwin":
+        suffix = r"aarch64\.dmg(?:\.sig)?"
+        updater = re.compile(r"VoiceStudio_aarch64\.app\.tar\.gz(?:\.sig)?")
+    elif target == "x86_64-apple-darwin":
+        suffix = r"x64\.dmg(?:\.sig)?"
+        updater = re.compile(r"VoiceStudio_x64\.app\.tar\.gz(?:\.sig)?")
+    elif target == "x86_64-unknown-linux-gnu":
+        suffix = r"amd64\.(?:AppImage(?:\.tar\.gz)?|deb)(?:\.sig)?"
+    else:
+        raise ValueError(f"Unsupported release target: {target}")
+    pattern = re.compile(r"VoiceStudio_(?:" + "|".join(map(re.escape, versions)) + ")_" + suffix)
+    # macOS updater archives have no version in their names. The release tag
+    # scopes their version; only this target's architecture may be replaced.
+    return [name for name in names if pattern.fullmatch(name) or (updater and updater.fullmatch(name))]
+
+
+def clear_assets(tag, version, target):
+    result = subprocess.run(["gh", "release", "view", tag, "--json", "assets"],
+                            capture_output=True, text=True)
+    if result.returncode:
+        if "HTTP 404" in result.stderr or "release not found" in result.stderr.lower():
+            return
+        raise RuntimeError(result.stderr)
+    names = [asset["name"] for asset in json.loads(result.stdout)["assets"]]
+    for name in matching_assets(names, version, target):
+        result = subprocess.run(["gh", "release", "delete-asset", tag, name, "--yes"],
+                                capture_output=True, text=True)
+        if result.returncode and "HTTP 404" not in result.stderr:
+            raise RuntimeError(result.stderr)
+        print(f"Cleared retry asset: {name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--target", required=True)
+    args = parser.parse_args()
+    clear_assets(args.tag, args.version, args.target)

--- a/tests/test_release_rerun_assets.py
+++ b/tests/test_release_rerun_assets.py
@@ -1,0 +1,138 @@
+"""Release retries retain other targets, versions, and updater manifests."""
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+spec = importlib.util.spec_from_file_location("rerun_assets", Path(__file__).parents[1] / "scripts/clear-release-rerun-assets.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+@pytest.mark.parametrize("target,suffix", [
+    ("x86_64-pc-windows-msvc", "x64_en-US.msi"),
+    ("aarch64-apple-darwin", "aarch64.dmg"),
+    ("x86_64-apple-darwin", "x64.dmg"),
+    ("x86_64-unknown-linux-gnu", "amd64.AppImage"),
+])
+def test_retry_selects_only_its_own_installers(target, suffix):
+    own = f"VoiceStudio_0.5.2-150_{suffix}"
+    others = ["latest.json", "VoiceStudio_universal.app.tar.gz", "VoiceStudio_0.5.2-149_" + suffix,
+              "VoiceStudio_Current_User_0.5.2-150_x64_en-US.msi", "Other_0.5.2-150_" + suffix]
+    assert module.matching_assets([*others, own, own + ".sig"], "0.5.2-150", target) == [own, own + ".sig"]
+
+
+def test_windows_retry_does_not_touch_mac_x64_dmg():
+    assert module.matching_assets(["VoiceStudio_0.5.2-150_x64.dmg", "VoiceStudio_0.5.2.150_x64_en-US.msi"],
+                                 "0.5.2-150", "x86_64-pc-windows-msvc") == ["VoiceStudio_0.5.2.150_x64_en-US.msi"]
+
+@pytest.mark.parametrize("error", ["HTTP 403", "HTTP 429", "network failure"])
+def test_failed_inventory_cannot_silently_continue(monkeypatch, error):
+    monkeypatch.setattr(module.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1, stderr=error))
+    with pytest.raises(RuntimeError, match=error):
+        module.clear_assets("preview", "0.5.2-150", "x86_64-pc-windows-msvc")
+
+
+def test_retry_step_runs_before_tauri_upload():
+    text = (Path(__file__).parents[1] / ".github/workflows/release.yml").read_text()
+    start = text.index("- name: Clear this target's installer assets on retry")
+    end = text.index("- name: Build + release (Tauri)")
+    assert start < end
+    assert "if: github.run_attempt > 1" in text[start:end]
+    assert "scripts/clear-release-rerun-assets.py" in text[start:end]
+
+
+@pytest.mark.parametrize("target,arch,sibling", [
+    ("aarch64-apple-darwin", "aarch64", "x64"),
+    ("x86_64-apple-darwin", "x64", "aarch64"),
+])
+def test_macos_retry_clears_only_its_versionless_updater(target, arch, sibling):
+    own = f"VoiceStudio_{arch}.app.tar.gz"
+    names = [own, own + ".sig", f"VoiceStudio_{sibling}.app.tar.gz", "latest.json"]
+    assert module.matching_assets(names, "0.5.2", target) == [own, own + ".sig"]
+
+
+def test_deletion_invocation_keeps_nonmatching_assets(monkeypatch):
+    own = "VoiceStudio_0.5.2-150_x64_en-US.msi"
+    calls = []
+    def run(args, **kwargs):
+        calls.append(args)
+        assert kwargs == {"capture_output": True, "text": True}
+        if args[2] == "view":
+            return SimpleNamespace(returncode=0, stdout=module.json.dumps({"assets": [
+                {"name": own}, {"name": own + ".sig"}, {"name": "latest.json"},
+                {"name": "VoiceStudio_0.5.2-149_x64_en-US.msi"},
+            ]}), stderr="")
+        return SimpleNamespace(returncode=0, stderr="")
+    monkeypatch.setattr(module.subprocess, "run", run)
+    module.clear_assets("preview", "0.5.2-150", "x86_64-pc-windows-msvc")
+    assert calls == [
+        ["gh", "release", "view", "preview", "--json", "assets"],
+        ["gh", "release", "delete-asset", "preview", own, "--yes"],
+        ["gh", "release", "delete-asset", "preview", own + ".sig", "--yes"],
+    ]
+
+
+@pytest.mark.parametrize("error", ["HTTP 403", "HTTP 429", "network failure"])
+def test_deletion_failure_stops_retry(monkeypatch, error):
+    calls = []
+    def run(args, **kwargs):
+        calls.append(args)
+        if args[2] == "view":
+            return SimpleNamespace(returncode=0, stdout=module.json.dumps({"assets": [
+                {"name": "VoiceStudio_0.5.2_x64_en-US.msi"},
+                {"name": "VoiceStudio_0.5.2_x64_en-US.msi.sig"},
+            ]}), stderr="")
+        return SimpleNamespace(returncode=1, stderr=error)
+    monkeypatch.setattr(module.subprocess, "run", run)
+    with pytest.raises(RuntimeError, match=error):
+        module.clear_assets("v0.5.2", "0.5.2", "x86_64-pc-windows-msvc")
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize("error", ["HTTP 404", "release not found"])
+def test_absent_release_needs_no_deletion(monkeypatch, error):
+    calls = []
+    def run(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=1, stderr=error)
+    monkeypatch.setattr(module.subprocess, "run", run)
+    module.clear_assets("preview", "0.5.2-150", "x86_64-pc-windows-msvc")
+    assert len(calls) == 1
+
+
+def test_concurrent_missing_asset_is_benign(monkeypatch):
+    def run(args, **kwargs):
+        if args[2] == "view":
+            return SimpleNamespace(returncode=0, stdout='{"assets":[{"name":"VoiceStudio_0.5.2_x64_en-US.msi"}]}')
+        return SimpleNamespace(returncode=1, stderr="HTTP 404")
+    monkeypatch.setattr(module.subprocess, "run", run)
+    module.clear_assets("v0.5.2", "0.5.2", "x86_64-pc-windows-msvc")
+
+
+def test_cleanup_uses_stamped_package_version():
+    text = (Path(__file__).parents[1] / ".github/workflows/release.yml").read_text()
+    stamp = text.index("- name: Stamp preview version")
+    clear = text.index("- name: Clear this target's installer assets on retry")
+    build = text.index("- name: Build + release (Tauri)")
+    assert stamp < clear < build
+    assert 'frontend/package.json' in text[clear:build]
+    assert '--version "$VERSION"' in text[clear:build]
+    assert "github.run_number" not in text[clear:build]
+
+
+def test_stable_floor_stamp_selects_new_patch_not_source_package_version(tmp_path):
+    import json
+    import subprocess
+    import sys
+
+    package = tmp_path / "package.json"
+    package.write_text(json.dumps({"version": "0.5.2"}))
+    script = Path(__file__).parents[1] / "scripts/stamp-preview-version.py"
+    subprocess.run([
+        sys.executable, str(script), "--package-json", str(package),
+        "--stable-tag", "v0.5.2", "--run-number", "150",
+    ], check=True, capture_output=True, text=True)
+    version = json.loads(package.read_text())["version"]
+    assert version == "0.5.3-150"
+    names = ["VoiceStudio_0.5.2-150_x64_en-US.msi", "VoiceStudio_0.5.3-150_x64_en-US.msi"]
+    assert module.matching_assets(names, version, "x86_64-pc-windows-msvc") == [names[1]]

--- a/tests/test_release_rerun_assets.py
+++ b/tests/test_release_rerun_assets.py
@@ -4,9 +4,14 @@ from pathlib import Path
 from types import SimpleNamespace
 import pytest
 
-spec = importlib.util.spec_from_file_location("rerun_assets", Path(__file__).parents[1] / "scripts/clear-release-rerun-assets.py")
-module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(module)
+@pytest.fixture
+def module():
+    spec = importlib.util.spec_from_file_location(
+        "rerun_assets", Path(__file__).parents[1] / "scripts/clear-release-rerun-assets.py"
+    )
+    runtime = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(runtime)
+    return runtime
 
 @pytest.mark.parametrize("target,suffix", [
     ("x86_64-pc-windows-msvc", "x64_en-US.msi"),
@@ -14,19 +19,19 @@ spec.loader.exec_module(module)
     ("x86_64-apple-darwin", "x64.dmg"),
     ("x86_64-unknown-linux-gnu", "amd64.AppImage"),
 ])
-def test_retry_selects_only_its_own_installers(target, suffix):
+def test_retry_selects_only_its_own_installers(module, target, suffix):
     own = f"VoiceStudio_0.5.2-150_{suffix}"
     others = ["latest.json", "VoiceStudio_universal.app.tar.gz", "VoiceStudio_0.5.2-149_" + suffix,
               "VoiceStudio_Current_User_0.5.2-150_x64_en-US.msi", "Other_0.5.2-150_" + suffix]
     assert module.matching_assets([*others, own, own + ".sig"], "0.5.2-150", target) == [own, own + ".sig"]
 
 
-def test_windows_retry_does_not_touch_mac_x64_dmg():
+def test_windows_retry_does_not_touch_mac_x64_dmg(module):
     assert module.matching_assets(["VoiceStudio_0.5.2-150_x64.dmg", "VoiceStudio_0.5.2.150_x64_en-US.msi"],
                                  "0.5.2-150", "x86_64-pc-windows-msvc") == ["VoiceStudio_0.5.2.150_x64_en-US.msi"]
 
 @pytest.mark.parametrize("error", ["HTTP 403", "HTTP 429", "network failure"])
-def test_failed_inventory_cannot_silently_continue(monkeypatch, error):
+def test_failed_inventory_cannot_silently_continue(module, monkeypatch, error):
     monkeypatch.setattr(module.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=1, stderr=error))
     with pytest.raises(RuntimeError, match=error):
         module.clear_assets("preview", "0.5.2-150", "x86_64-pc-windows-msvc")
@@ -45,13 +50,13 @@ def test_retry_step_runs_before_tauri_upload():
     ("aarch64-apple-darwin", "aarch64", "x64"),
     ("x86_64-apple-darwin", "x64", "aarch64"),
 ])
-def test_macos_retry_clears_only_its_versionless_updater(target, arch, sibling):
+def test_macos_retry_clears_only_its_versionless_updater(module, target, arch, sibling):
     own = f"VoiceStudio_{arch}.app.tar.gz"
     names = [own, own + ".sig", f"VoiceStudio_{sibling}.app.tar.gz", "latest.json"]
     assert module.matching_assets(names, "0.5.2", target) == [own, own + ".sig"]
 
 
-def test_deletion_invocation_keeps_nonmatching_assets(monkeypatch):
+def test_deletion_invocation_keeps_nonmatching_assets(module, monkeypatch):
     own = "VoiceStudio_0.5.2-150_x64_en-US.msi"
     calls = []
     def run(args, **kwargs):
@@ -73,7 +78,7 @@ def test_deletion_invocation_keeps_nonmatching_assets(monkeypatch):
 
 
 @pytest.mark.parametrize("error", ["HTTP 403", "HTTP 429", "network failure"])
-def test_deletion_failure_stops_retry(monkeypatch, error):
+def test_deletion_failure_stops_retry(module, monkeypatch, error):
     calls = []
     def run(args, **kwargs):
         calls.append(args)
@@ -90,7 +95,7 @@ def test_deletion_failure_stops_retry(monkeypatch, error):
 
 
 @pytest.mark.parametrize("error", ["HTTP 404", "release not found"])
-def test_absent_release_needs_no_deletion(monkeypatch, error):
+def test_absent_release_needs_no_deletion(module, monkeypatch, error):
     calls = []
     def run(args, **kwargs):
         calls.append(args)
@@ -100,7 +105,7 @@ def test_absent_release_needs_no_deletion(monkeypatch, error):
     assert len(calls) == 1
 
 
-def test_concurrent_missing_asset_is_benign(monkeypatch):
+def test_concurrent_missing_asset_is_benign(module, monkeypatch):
     def run(args, **kwargs):
         if args[2] == "view":
             return SimpleNamespace(returncode=0, stdout='{"assets":[{"name":"VoiceStudio_0.5.2_x64_en-US.msi"}]}')
@@ -120,7 +125,7 @@ def test_cleanup_uses_stamped_package_version():
     assert "github.run_number" not in text[clear:build]
 
 
-def test_stable_floor_stamp_selects_new_patch_not_source_package_version(tmp_path):
+def test_stable_floor_stamp_selects_new_patch_not_source_package_version(module, tmp_path):
     import json
     import subprocess
     import sys


### PR DESCRIPTION
Landed in main via #1874 (33ce88e4); complete PR head preserved.

A release job can upload an installer and then fail later. Retrying that job previously failed with `ReleaseAsset already_exists` because the version stayed the same. Main's Windows preview run 34018049439 reproduced this after its per-user MSI step failed.

Retry runs now clear only the current version and target's installer assets before uploading. macOS retries also replace their own versionless updater archive. Other targets, versions, and manifests remain intact; permission and network failures stop the job.

Validation: 28 regression tests pass, including real mocked gh deletion calls, missing assets, failed API operations, sibling preservation, and stamped preview versions. Release recovery documentation updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Release retries now delete only the current version’s target installer assets before re-uploading, including the macOS versionless updater archive. This prevents `ReleaseAsset already_exists` failures while preserving other targets, versions, and manifests. Permission, network, or asset inventory failures stop the job and require review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
