### PR TITLE
fix(sidecars): finish timeout cleanup before retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- Timed-out voice engines finish process cleanup before retrying, and old timeout callbacks cannot kill replacement engines (#730)
+- Timed-out voice engines finish process cleanup before retrying, and old timeout callbacks cannot kill replacement engines (#1872)
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Timed-out voice engines finish process cleanup before retrying, and old timeout callbacks cannot kill replacement engines (#730)
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -777,28 +777,30 @@ class SubprocessBackend(TTSBackend):
         return msg
 
     def _recv_with_timeout(self, timeout_s: float) -> Optional[dict]:
-        """Recv that aborts if the sidecar goes silent.
+        """Read one frame, finishing timeout cleanup before the caller can retry.
 
-        Implemented by polling the proc for liveness with a deadline. We
-        don't block on a `select` of the pipe because Windows can't select
-        on subprocess pipes — keeping the implementation cross-platform
-        means a simpler polling loop here.
+        A watchdog closes the pipe on timeout; Windows cannot select on pipes.
+        EOF alone does not prove the owned process/supervisor has exited.
         """
         # On Unix we could use selectors; on Windows the pipe is not
         # selectable. Use a watchdog thread that kills the sidecar on
         # timeout — that triggers EOF on stdout, so _recv returns None
         # and the caller raises.
-        watchdog = threading.Timer(timeout_s, self._timeout_kill)
+        proc = self._proc
+        watchdog = threading.Timer(timeout_s, self._timeout_kill, args=(proc,))
         watchdog.daemon = True
         watchdog.start()
         try:
             return self._recv()
         finally:
             watchdog.cancel()
+            # cancel() cannot stop an already-running callback. Finish its
+            # bounded reap before another receive or generation starts.
+            watchdog.join()
             self._touch()  # any reply (or attempt) counts as recent activity
 
-    def _timeout_kill(self) -> None:
-        proc = self._proc
+    def _timeout_kill(self, proc: Optional[subprocess.Popen]) -> None:
+        """Kill only the child this receive captured, then reap its owner."""
         if proc is None:
             return
         try:
@@ -807,6 +809,7 @@ class SubprocessBackend(TTSBackend):
                 self.id,
             )
             proc.kill()
+            proc.wait(timeout=2)
         except Exception:
             pass
 

--- a/backend/services/subprocess_backend.py
+++ b/backend/services/subprocess_backend.py
@@ -385,6 +385,10 @@ class SubprocessBackend(TTSBackend):
 
     def __init__(self) -> None:
         self._proc: Optional[subprocess.Popen] = None
+        # A failed bounded reap must retain ownership and forbid reuse. This
+        # lock is separate from _lock: the receive owner joins its watchdog.
+        self._timeout_quarantine: list[subprocess.Popen] = []
+        self._timeout_quarantine_lock = threading.Lock()
         # Single lock serialises spawn + every send/recv pair so two threads
         # can't interleave half-frames on the same pipe.
         self._lock = threading.Lock()
@@ -451,6 +455,10 @@ class SubprocessBackend(TTSBackend):
     def _spawn(self) -> None:
         """Launch the sidecar if not already running. Blocks on the ready
         handshake. Caller must hold self._lock."""
+        if not self._retry_timeout_cleanup():
+            raise RuntimeError(
+                f"{self.id} sidecar is still stopping after a timeout; retry once it exits"
+            )
         if self._proc is not None and self._proc.poll() is None:
             return  # already up
 
@@ -542,6 +550,7 @@ class SubprocessBackend(TTSBackend):
         """Idempotent. Sends {op:shutdown}; falls back to terminate/kill."""
         proc = self._proc
         if proc is None:
+            self._retry_timeout_cleanup()
             return
         try:
             try:
@@ -577,6 +586,7 @@ class SubprocessBackend(TTSBackend):
                         pass
         finally:
             self._proc = None
+            self._retry_timeout_cleanup()
 
     def _force_kill(self) -> None:
         """Internal: kill a sidecar that never reached the ready state."""
@@ -803,15 +813,33 @@ class SubprocessBackend(TTSBackend):
         """Kill only the child this receive captured, then reap its owner."""
         if proc is None:
             return
+        logger.error("[%s] sidecar exceeded recv timeout; killing", self.id)
         try:
-            logger.error(
-                "[%s] sidecar exceeded recv timeout; killing",
-                self.id,
-            )
             proc.kill()
+        except Exception:
+            # A raced exit can make kill fail, but its owner still needs reaping.
+            pass
+        try:
             proc.wait(timeout=2)
         except Exception:
-            pass
+            # Do not discard a possibly live owner, or replace a newer _proc.
+            with self._timeout_quarantine_lock:
+                if not any(item is proc for item in self._timeout_quarantine):
+                    self._timeout_quarantine.append(proc)
+        else:
+            with self._timeout_quarantine_lock:
+                self._timeout_quarantine = [
+                    item for item in self._timeout_quarantine if item is not proc
+                ]
+
+    def _retry_timeout_cleanup(self) -> bool:
+        """Retry bounded cleanup, retaining every owner that could still be live."""
+        with self._timeout_quarantine_lock:
+            pending = tuple(self._timeout_quarantine)
+        for proc in pending:
+            self._timeout_kill(proc)
+        with self._timeout_quarantine_lock:
+            return not self._timeout_quarantine
 
     # ── stderr drain ───────────────────────────────────────────────────────
 

--- a/backend/tests/test_omnivoice_subprocess.py
+++ b/backend/tests/test_omnivoice_subprocess.py
@@ -523,3 +523,97 @@ def test_generation_proxy_forwards_native_controls_and_seed():
         "class_temperature": 0.8,
         "seed": 321,
     })]
+
+
+def test_timeout_reaps_captured_process_before_recv_returns(monkeypatch):
+    import threading
+
+    class Process:
+        def __init__(self):
+            self.killed = threading.Event()
+            self.reaped = False
+            self.wait_entered = threading.Event()
+            self.release_wait = threading.Event()
+
+        def kill(self):
+            self.killed.set()  # EOF may arrive before the process is reaped.
+
+        def wait(self, timeout):
+            assert timeout is not None
+            self.wait_entered.set()
+            assert self.release_wait.wait(2)
+            self.reaped = True
+            return -9
+
+    proc = Process()
+    backend = OmniVoiceSubprocessBackend()
+    backend._proc = proc
+
+    def recv():
+        assert proc.killed.wait(2)
+        return None
+
+    monkeypatch.setattr(backend, '_recv', recv)
+    returned = threading.Event()
+    results = []
+
+    def receive():
+        results.append(backend._recv_with_timeout(0.01))
+        returned.set()
+
+    reader = threading.Thread(target=receive)
+    reader.start()
+    try:
+        assert proc.wait_entered.wait(2)
+        assert not returned.wait(0.05), "EOF must not release the caller before process cleanup"
+    finally:
+        proc.release_wait.set()
+        reader.join(2)
+        backend._proc = None
+    assert not reader.is_alive()
+    assert returned.is_set()
+    assert results == [None]
+    assert proc.reaped
+
+
+def test_timeout_never_kills_a_replacement_process(monkeypatch):
+    from unittest.mock import Mock
+    import services.subprocess_backend as module
+
+    class ManualTimer:
+        def __init__(self, _timeout, callback, args=()):
+            self.callback = lambda: callback(*args)
+            self.daemon = False
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass
+
+        def join(self):
+            pass
+
+    timers = []
+    def timer(*args, **kwargs):
+        result = ManualTimer(*args, **kwargs)
+        timers.append(result)
+        return result
+
+    monkeypatch.setattr(module.threading, 'Timer', timer)
+    backend = OmniVoiceSubprocessBackend()
+    original, replacement = Mock(), Mock()
+    backend._proc = original
+
+    def recv():
+        backend._proc = replacement
+        timers[0].callback()
+        return None
+
+    monkeypatch.setattr(backend, '_recv', recv)
+    try:
+        backend._recv_with_timeout(1)
+        original.kill.assert_called_once()
+        replacement.kill.assert_not_called()
+    finally:
+        backend._proc = None

--- a/backend/tests/test_omnivoice_subprocess.py
+++ b/backend/tests/test_omnivoice_subprocess.py
@@ -617,3 +617,69 @@ def test_timeout_never_kills_a_replacement_process(monkeypatch):
         replacement.kill.assert_not_called()
     finally:
         backend._proc = None
+
+
+@pytest.mark.parametrize("failure", ["wait", "kill"])
+def test_timeout_quarantine_blocks_reuse_and_retains_cleanup_handle(failure):
+    class StuckProcess:
+        stdin = None
+        def __init__(self):
+            self.exited = False
+            self.kill_calls = 0
+        def poll(self):
+            return 0 if self.exited else None
+        def kill(self):
+            self.kill_calls += 1
+            if failure == "kill" and not self.exited:
+                raise PermissionError("kill failed")
+        def terminate(self):
+            pass
+        def wait(self, timeout):
+            if not self.exited:
+                raise subprocess.TimeoutExpired("stuck-sidecar", timeout)
+            return 0
+
+    backend = OmniVoiceSubprocessBackend()
+    proc = StuckProcess()
+    backend._proc = proc
+    try:
+        backend._timeout_kill(proc)
+        with pytest.raises(RuntimeError, match="still stopping"):
+            backend._spawn()
+        backend.shutdown()
+        # Even after shutdown clears the current slot, ownership survives;
+        # retry must not silently start a second process next to this one.
+        before = proc.kill_calls
+        with pytest.raises(RuntimeError, match="still stopping"):
+            backend._spawn()
+        assert proc.kill_calls > before
+    finally:
+        proc.exited = True
+        backend.shutdown()
+
+
+def test_timeout_quarantine_does_not_clear_or_kill_replacement():
+    from unittest.mock import Mock
+    backend = OmniVoiceSubprocessBackend()
+    original = Mock()
+    original.wait.side_effect = subprocess.TimeoutExpired("old-sidecar", 2)
+    replacement = Mock()
+    replacement.poll.return_value = None
+    backend._proc = replacement
+    try:
+        backend._timeout_kill(original)
+        with pytest.raises(RuntimeError, match="still stopping"):
+            backend._spawn()
+        assert backend._proc is replacement
+        replacement.kill.assert_not_called()
+        # Once the captured owner is reaped, reuse of the healthy replacement
+        # is allowed without starting or terminating another process.
+        original.wait.side_effect = None
+        original.wait.return_value = 0
+        backend._spawn()
+        assert backend._proc is replacement
+        replacement.kill.assert_not_called()
+    finally:
+        original.wait.side_effect = None
+        backend._proc = None
+        backend.shutdown()

--- a/docs/engines/omnivoice.md
+++ b/docs/engines/omnivoice.md
@@ -106,3 +106,7 @@ See also: [benchmarks.md](../benchmarks.md),
 [performance.md](../performance.md),
 [expressive-speech.md](../expressive-speech.md),
 [disk usage](disk-usage.md).
+
+A timed-out subprocess is killed and given a bounded wait to exit before the
+request returns, so retrying cannot reuse its closing process. Timeout cleanup
+remains tied to the original child and cannot kill a replacement sidecar.

--- a/docs/engines/omnivoice.md
+++ b/docs/engines/omnivoice.md
@@ -110,3 +110,6 @@ See also: [benchmarks.md](../benchmarks.md),
 A timed-out subprocess is killed and given a bounded wait to exit before the
 request returns, so retrying cannot reuse its closing process. Timeout cleanup
 remains tied to the original child and cannot kill a replacement sidecar.
+If that wait cannot confirm exit, VoiceStudio retains the process for cleanup
+and blocks another attempt until it can be reaped, rather than starting a second
+engine alongside it. A later retry or shutdown retries the bounded cleanup.

--- a/tests/test_resolve_heartbeat_1414.py
+++ b/tests/test_resolve_heartbeat_1414.py
@@ -210,8 +210,7 @@ def test_spawn_wraps_the_resolution(sb, monkeypatch):
             raise _StopAfterResolution
 
     monkeypatch.setattr(sb, "_heartbeat_while_resolving", _recording_heartbeat)
-    backend = _Backend.__new__(_Backend)
-    backend._proc = None
+    backend = _Backend()
     with pytest.raises(_StopAfterResolution):
         backend._spawn()
     assert resolved_inside.is_set()


### PR DESCRIPTION
A sidecar timeout could return after stdout closed but before its owning process exited. A fast retry could reuse that dying process; an already-running watchdog could also target a replacement through mutable state.

The watchdog now captures its original child, kills and waits for that child with a bounded reap, and receive cleanup joins the watchdog before allowing recovery. The implementation uses the same process APIs on all supported platforms.

Validation: two deterministic regressions failed before the fix; 109 focused cross-engine tests and all 336 backend tests pass with offline, empty Hugging Face caches. Documentation updated.
