### PR TITLE
fix(windows): validate per-user MSI components and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      windows_wix_diagnostic:
+        description: Run only the tiny nonpublishing Windows MSI authoring diagnostic
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -21,6 +26,7 @@ env:
 
 jobs:
   test:
+    if: ${{ !inputs.windows_wix_diagnostic }}
     name: Tests (backend + frontend)
     runs-on: ubuntu-22.04
     env:
@@ -189,6 +195,7 @@ jobs:
   # and `cargo test --lib` runs the shell's unit tests natively on each OS.
   # Full bundling stays in release.yml on tag push.
   tauri-cross-platform:
+    if: ${{ !inputs.windows_wix_diagnostic }}
     name: Tauri shell check (${{ matrix.label }})
     needs: test
     strategy:
@@ -289,6 +296,7 @@ jobs:
   # job above misses. Narrow scope (tests/smoke/ only) — full pytest stays
   # on Linux until Phase 1's INST-01 lands setuptools for WhisperX.
   smoke-matrix:
+    if: ${{ !inputs.windows_wix_diagnostic }}
     name: Smoke (${{ matrix.label }})
     needs: test
     strategy:
@@ -442,3 +450,24 @@ jobs:
         env:
           HF_HUB_OFFLINE: "1"
           HF_HUB_CACHE: ${{ runner.temp }}/worker-artifact-empty-hf-cache
+
+  windows-wix-diagnostic:
+    name: Windows MSI authoring (no publishing)
+    needs: test
+    if: ${{ !cancelled() && (inputs.windows_wix_diagnostic || needs.test.result == 'success') }}
+    runs-on: windows-2022
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - name: Bundle canonical system and per-user templates with a tiny payload
+        shell: pwsh
+        run: ./scripts/diagnose-windows-wix.ps1
+      - name: Preserve verbose linker output and rendered authoring
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-wix-diagnostic
+          path: wix-diagnostic-artifacts/
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,6 +659,7 @@ jobs:
           set -euo pipefail
           python ../scripts/render-per-user-wix.py \
             --source src-tauri/wix/main.wxs \
+            --system-wxs src-tauri/target/${{ matrix.rust_target }}/release/wix/x64/main.wxs \
             --output src-tauri/target/wix-per-user/main.wxs
           bunx tauri build --target ${{ matrix.rust_target }} --bundles msi \
             --config src-tauri/tauri.per-user.conf.json

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ bin/omnivoice-tts-linux-aarch64
 # committed (they ship with the app); the per-language source WAVs are just the
 # inputs scripts/render_dub_demo_audio.py hands to scripts/build_dub_demo.sh.
 backend/assets/samples/demo/dubbing/*.src.wav
+
+# Generated Windows MSI diagnostic logs and installer payloads
+/wix-diagnostic-artifacts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
+- Fix current-user Windows installer validation and nested resource cleanup (#730)
+
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
-- Fix current-user Windows installer validation and nested resource cleanup (#730)
+- Fix current-user Windows installer validation and nested resource cleanup (#1873)
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -297,3 +297,13 @@ See [docs/setup/huggingface-token.md](../setup/huggingface-token.md).
 ## Troubleshooting
 
 Hit a wall? See [docs/install/troubleshooting.md](troubleshooting.md).
+
+### Building the current-user MSI
+
+Build the system MSI first. `scripts/render-per-user-wix.py` requires
+`--system-wxs` pointing to its fully rendered `release/wix/x64/main.wxs`,
+in addition to the canonical `--source` template and `--output` destination.
+The renderer preserves Tauri resource destinations while assigning distinct,
+stable per-user component identities, HKCU registry keypaths, and uninstall
+cleanup for nested resource folders. Missing or unrendered resources fail the
+build. The canonical system installer retains its per-machine authoring.

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -307,3 +307,9 @@ The renderer preserves Tauri resource destinations while assigning distinct,
 stable per-user component identities, HKCU registry keypaths, and uninstall
 cleanup for nested resource folders. Missing or unrendered resources fail the
 build. The canonical system installer retains its per-machine authoring.
+
+CI bundles both scopes with a tiny executable, an external helper, and nested
+resources using the CLI version locked in `bun.lock`. The Windows MSI authoring
+job runs after the test suite and preserves verbose WiX logs and rendered XML.
+For focused diagnosis, dispatch CI with `windows_wix_diagnostic=true`; it skips
+the other jobs and never signs, publishes, or installs the fixture bundles.

--- a/frontend/src-tauri/wix/main.wxs
+++ b/frontend/src-tauri/wix/main.wxs
@@ -177,7 +177,9 @@
                 <File Id="UpdateTaskUninstaller" Source="uninstall-task.ps1" KeyPath="yes" Checksum="yes"/>
             </Component>
             {{/if}}
+            <!-- BEGIN BUNDLED_RESOURCES -->
             {{resources}}
+            <!-- END BUNDLED_RESOURCES -->
             <Component Id="CMP_UninstallShortcut" Guid="*">
 
                 <Shortcut Id="UninstallShortcut"

--- a/scripts/diagnose-windows-wix.ps1
+++ b/scripts/diagnose-windows-wix.ps1
@@ -1,0 +1,79 @@
+# Nonpublishing diagnostic: compile a tiny executable and bundle both MSI scopes.
+# Uses the actual repository template/renderer and Tauri's generated resources.
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path -Parent $PSScriptRoot
+$fixture = Join-Path $env:RUNNER_TEMP 'voicestudio-wix-diagnostic'
+$artifacts = Join-Path $repo 'wix-diagnostic-artifacts'
+$target = 'x86_64-pc-windows-msvc'
+$lock = Get-Content "$repo/bun.lock" -Raw
+$cliMatch = [regex]::Match($lock, '"@tauri-apps/cli":\s*\["@tauri-apps/cli@([^"\s]+)"')
+if (-not $cliMatch.Success) { throw 'Cannot resolve the Tauri CLI version from bun.lock' }
+$cliPackage = '@tauri-apps/cli@' + $cliMatch.Groups[1].Value
+New-Item -ItemType Directory -Force -Path $fixture, $artifacts, "$fixture/src", "$fixture/resources/nested", "$fixture/binaries" | Out-Null
+@'
+[package]
+name = "wix-diagnostic"
+version = "0.0.0"
+edition = "2021"
+[workspace]
+'@ | Set-Content -Encoding utf8 "$fixture/Cargo.toml"
+'fn main() { println!("MSI authoring diagnostic only"); }' | Set-Content -Encoding utf8 "$fixture/src/main.rs"
+'Nested resource payload' | Set-Content -Encoding utf8 "$fixture/resources/nested/payload.txt"
+'Root resource payload' | Set-Content -Encoding utf8 "$fixture/resources/readme.txt"
+Copy-Item "$repo/frontend/src-tauri/wix/main.wxs" "$fixture/system.wxs"
+Copy-Item "$repo/frontend/src-tauri/icons/icon.ico" "$fixture/icon.ico"
+$config = @{
+    productName = 'VoiceStudio MSI Diagnostic'
+    version = '0.0.0'
+    identifier = 'com.debpalash.voicestudio.wixdiagnostic'
+    build = @{}
+    bundle = @{
+        active = $true
+        targets = @('msi')
+        createUpdaterArtifacts = $false
+        icon = @('icon.ico')
+        resources = @('resources/**/*')
+        externalBin = @('binaries/helper')
+        windows = @{
+            webviewInstallMode = @{ type = 'skip' }
+            wix = @{ template = 'system.wxs'; enableElevatedUpdateTask = $false }
+        }
+    }
+}
+$config | ConvertTo-Json -Depth 20 | Set-Content -Encoding utf8 "$fixture/tauri.conf.json"
+Push-Location $fixture
+try {
+    & cargo build --release --target $target
+    if ($LASTEXITCODE -ne 0) { throw 'Tiny diagnostic executable build failed' }
+    Copy-Item "$fixture/target/$target/release/wix-diagnostic.exe" "$fixture/binaries/helper-$target.exe"
+    $results = @{}
+    foreach ($scope in @('system', 'per-user')) {
+        if ($scope -eq 'per-user') {
+            & python "$repo/scripts/render-per-user-wix.py" --source "$fixture/system.wxs" --system-wxs "$fixture/target/$target/release/wix/x64/main.wxs" --output "$fixture/per-user.wxs"
+            if ($LASTEXITCODE -ne 0) { throw 'Per-user template rendering failed' }
+            Remove-Item "$fixture/target/$target/release/wix", "$fixture/target/$target/release/bundle" -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        $scopeConfig = @{
+            productName = "VoiceStudio MSI Diagnostic $scope"
+            bundle = @{ windows = @{ wix = @{ template = "$scope.wxs" } } }
+        }
+        $scopeConfig | ConvertTo-Json -Depth 20 | Set-Content -Encoding utf8 "$fixture/$scope.conf.json"
+        $log = Join-Path $artifacts "$scope.log"
+        $ErrorActionPreference = 'Continue'
+        & bun x --package $cliPackage tauri bundle -vv --target $target --bundles msi --config "$scope.conf.json" *> $log
+        $results[$scope] = $LASTEXITCODE
+        $ErrorActionPreference = 'Stop'
+        Get-Content $log
+        $capture = Join-Path $artifacts $scope
+        New-Item -ItemType Directory -Force -Path $capture | Out-Null
+        Get-ChildItem "$fixture/target" -Recurse -File |
+            Where-Object { $_.Extension -in @('.wxs', '.wxl', '.wixobj', '.wixpdb', '.msi') } |
+            Copy-Item -Destination $capture -Force
+    }
+    $results | ConvertTo-Json | Set-Content -Encoding utf8 "$artifacts/results.json"
+    if ($results.Values | Where-Object { $_ -ne 0 }) {
+        throw "MSI authoring failure; inspect wix-diagnostic-artifacts logs and rendered WiX"
+    }
+} finally {
+    Pop-Location
+}

--- a/scripts/diagnose-windows-wix.ps1
+++ b/scripts/diagnose-windows-wix.ps1
@@ -69,6 +69,29 @@ try {
         Get-ChildItem "$fixture/target" -Recurse -File |
             Where-Object { $_.Extension -in @('.wxs', '.wxl', '.wixobj', '.wixpdb', '.msi') } |
             Copy-Item -Destination $capture -Force
+        if ($results[$scope] -eq 0) {
+            $rendered = Get-Content "$capture/main.wxs" -Raw
+            if ($rendered.Contains('{{')) { throw "$scope WiX contains unresolved template variables" }
+            [xml]$authoring = $rendered
+            $ns = New-Object System.Xml.XmlNamespaceManager($authoring.NameTable)
+            $ns.AddNamespace('w', 'http://schemas.microsoft.com/wix/2006/wi')
+            $expectedScope = if ($scope -eq 'per-user') { 'perUser' } else { 'perMachine' }
+            if ($authoring.SelectSingleNode('//w:Package', $ns).InstallScope -ne $expectedScope) {
+                throw "$scope MSI has the wrong installation scope"
+            }
+            if ($scope -eq 'per-user') {
+                foreach ($component in $authoring.SelectNodes('//w:Component[w:File]', $ns)) {
+                    $key = $component.SelectSingleNode('w:RegistryValue[@KeyPath="yes"]', $ns)
+                    if ($null -eq $key -or $key.Root -ne 'HKCU' -or -not $key.Key.StartsWith('Software\')) {
+                        throw "Per-user file component lacks a resolved HKCU registry keypath: $($component.Id)"
+                    }
+                    $componentGuid = [guid]::Empty
+                    if (-not [guid]::TryParse($component.Guid, [ref]$componentGuid)) {
+                        throw "Per-user file component lacks an explicit GUID: $($component.Id)"
+                    }
+                }
+            }
+        }
     }
     $results | ConvertTo-Json | Set-Content -Encoding utf8 "$artifacts/results.json"
     if ($results.Values | Where-Object { $_ -ne 0 }) {

--- a/scripts/render-per-user-wix.py
+++ b/scripts/render-per-user-wix.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
+import xml.etree.ElementTree as ET
+from uuid import UUID, uuid5
 
 
 WEBVIEW_ACTIONS_START = "        <!-- BEGIN WEBVIEW_INSTALL_ACTIONS -->"
@@ -50,7 +52,80 @@ TRANSFORMS = (
 )
 
 
-def render(source: str) -> str:
+RESOURCE_START = "<!-- BEGIN BUNDLED_RESOURCES -->"
+RESOURCE_END = "<!-- END BUNDLED_RESOURCES -->"
+USER_NAMESPACE = UUID("f27de3a8-a9dc-4a3d-84bb-e98f1bf82393")
+
+
+def registry_key(name: str) -> ET.Element:
+    return ET.Element("RegistryValue", {
+        "Root": "HKCU", "Key": r"Software\{{@root.manufacturer}}\{{@root.product_name}}\Components",
+        "Name": name, "Type": "integer", "Value": "1", "KeyPath": "yes",
+    })
+
+
+def resource_authoring(system_wxs: str) -> tuple[str, str]:
+    """Reuse Tauri's resolved resource destinations, never its random component IDs."""
+    if system_wxs.count(RESOURCE_START) != 1 or system_wxs.count(RESOURCE_END) != 1:
+        raise ValueError("system WiX source must contain exactly one marked bundled resource block")
+    fragment = system_wxs.split(RESOURCE_START, 1)[1].split(RESOURCE_END, 1)[0]
+    if "{{" in fragment:
+        raise ValueError("system WiX resources must already be rendered by Tauri")
+    tree = ET.fromstring("<Resources>" + fragment + "</Resources>")
+    refs = []
+    directories = []
+    destinations = set()
+
+    def visit(node: ET.Element, path: tuple[str, ...]) -> None:
+        for child in node:
+            if child.tag == "Directory":
+                destination = (*path, child.attrib["Name"])
+                identity = uuid5(USER_NAMESPACE, "directory:" + "/".join(destination).casefold()).hex
+                child.set("Id", "UserDir" + identity)
+                directories.append(child.attrib["Id"])
+                visit(child, destination)
+            elif child.tag == "Component":
+                files = child.findall("File")
+                if len(files) != 1:
+                    raise ValueError("expected exactly one file per Tauri resource component")
+                file = files[0]
+                name = file.get("Name") or PureWindowsPath(file.attrib["Source"]).name
+                destination = "/".join((*path, name)).casefold()
+                if destination in destinations:
+                    raise ValueError(f"duplicate resource destination: {destination}")
+                destinations.add(destination)
+                identity = uuid5(USER_NAMESPACE, "file:" + destination)
+                component_id = "UserResource" + identity.hex
+                child.set("Id", component_id)
+                child.set("Guid", str(identity))
+                child.attrib.pop("KeyPath", None)
+                file.attrib.pop("KeyPath", None)
+                file.set("Id", "UserFile" + identity.hex)
+                child.append(registry_key(component_id))
+                refs.append(component_id)
+            else:
+                raise ValueError(f"unexpected Tauri resource element: {child.tag}")
+
+    visit(tree, ())
+    if directories:
+        cleanup = ET.SubElement(tree, "Component", {
+            "Id": "UserResourceDirectoryCleanup",
+            "Guid": str(uuid5(USER_NAMESPACE, "resource-directory-cleanup")),
+            "Win64": "$(var.Win64)",
+        })
+        cleanup.append(registry_key("UserResourceDirectoryCleanup"))
+        for directory in directories:
+            ET.SubElement(cleanup, "RemoveFolder", {
+                "Id": "Remove" + directory, "Directory": directory, "On": "uninstall",
+            })
+        refs.append(cleanup.attrib["Id"])
+    return (
+        "\n".join(ET.tostring(node, encoding="unicode") for node in tree),
+        "\n".join(f'<ComponentRef Id="{ref}" />' for ref in refs),
+    )
+
+
+def render(source: str, system_wxs: str) -> str:
     rendered = source
     for old, new in TRANSFORMS:
         count = rendered.count(old)
@@ -72,6 +147,23 @@ def render(source: str) -> str:
         + "        <!-- WebView2 is a prerequisite for current-user installs. -->"
         + rendered[end:]
     )
+    resources, references = resource_authoring(system_wxs)
+    rendered = rendered.replace("{{resources}}", resources)
+    resource_refs = '{{#each resource_file_ids as |resource_file_id| ~}}\n                <ComponentRef Id="{{ resource_file_id }}"/>\n            {{/each~}}'
+    if rendered.count(resource_refs) != 1:
+        raise ValueError("expected exactly one Tauri resource reference block")
+    rendered = rendered.replace(resource_refs, references)
+    rendered = rendered.replace('Guid="41f6d598-8908-4004-9332-291b64fd38be"',
+                                f'Guid="{uuid5(USER_NAMESPACE, "main-binary-registry-keypath")}"')
+    rendered = rendered.replace('Guid="{{bin.guid}}"', 'Guid="*"')
+    for file_token, key_name in (
+        ('<File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>', "MainBinary"),
+        ('<File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>', "Binary_{{ bin.id }}"),
+    ):
+        if rendered.count(file_token) != 1:
+            raise ValueError(f"expected exactly one binary file token: {file_token}")
+        rendered = rendered.replace(file_token, file_token.replace(' KeyPath="yes"', '')
+                                    + ET.tostring(registry_key(key_name), encoding="unicode"))
     return rendered
 
 
@@ -79,9 +171,12 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--system-wxs", type=Path, required=True,
+                        help="Fully rendered system MSI main.wxs from the preceding Tauri bundle")
     args = parser.parse_args()
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(render(args.source.read_text(encoding="utf-8")), encoding="utf-8")
+    args.output.write_text(render(args.source.read_text(encoding="utf-8"),
+                                       args.system_wxs.read_text(encoding="utf-8")), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/render-per-user-wix.py
+++ b/scripts/render-per-user-wix.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import xml.etree.ElementTree as ET
 from pathlib import Path, PureWindowsPath
 from uuid import UUID, uuid5
@@ -181,7 +182,34 @@ def render(source: str, system_wxs: str) -> str:
         'Guid="41f6d598-8908-4004-9332-291b64fd38be"',
         f'Guid="{uuid5(USER_NAMESPACE, "main-binary-registry-keypath")}"',
     )
-    rendered = rendered.replace('Guid="{{bin.guid}}"', 'Guid="*"')
+    # WiX cannot auto-generate GUIDs for components containing both a file and
+    # a registry keypath. Tauri binary IDs are sanitized installed filenames;
+    # retain the dynamic bin.path while supplying stable, per-user GUIDs.
+    system_tree = ET.fromstring(system_wxs)
+    binary_guids = []
+    for component in system_tree.iter():
+        if component.tag.rsplit("}", 1)[-1] != "Component":
+            continue
+        for file in component:
+            if file.tag.rsplit("}", 1)[-1] != "File" or not file.get(
+                "Id", ""
+            ).startswith("Bin_"):
+                continue
+            binary_id = component.attrib["Id"]
+            installed_name = (
+                file.get("Name") or PureWindowsPath(file.attrib["Source"]).name
+            )
+            guid = uuid5(USER_NAMESPACE, "binary:" + installed_name.casefold())
+            binary_guids.append(
+                "{{#if (eq bin.id "
+                + json.dumps(binary_id)
+                + ")}}"
+                + str(guid)
+                + "{{/if}}"
+            )
+    rendered = rendered.replace(
+        'Guid="{{bin.guid}}"', 'Guid="' + "".join(binary_guids) + '"'
+    )
     for file_token, key_name in (
         (
             '<File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>',

--- a/scripts/render-per-user-wix.py
+++ b/scripts/render-per-user-wix.py
@@ -64,7 +64,7 @@ def registry_key(name: str) -> ET.Element:
         "RegistryValue",
         {
             "Root": "HKCU",
-            "Key": r"Software\{{@root.manufacturer}}\{{@root.product_name}}\Components",
+            "Key": r"Software\\{{@root.manufacturer}}\\{{@root.product_name}}\Components",
             "Name": name,
             "Type": "integer",
             "Value": "1",

--- a/scripts/render-per-user-wix.py
+++ b/scripts/render-per-user-wix.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path, PureWindowsPath
 import xml.etree.ElementTree as ET
+from pathlib import Path, PureWindowsPath
 from uuid import UUID, uuid5
-
 
 WEBVIEW_ACTIONS_START = "        <!-- BEGIN WEBVIEW_INSTALL_ACTIONS -->"
 WEBVIEW_ACTIONS_END = "        <!-- END WEBVIEW_INSTALL_ACTIONS -->"
@@ -40,10 +39,12 @@ TRANSFORMS = (
         r'<RegistryKey Root="HKCU" Key="Software\Classes\\{{protocol}}">',
     ),
     (
-        '        <!-- Managed-deployment switches. Explicit allow is required for network bootstrap. -->\n'
-        '        <Property Id="ALLOWWEBVIEW2BOOTSTRAP" Secure="yes" />\n'
-        '        <Property Id="DISABLEWEBVIEW2BOOTSTRAP" Secure="yes" />',
-        '        <!-- The current-user bundle never installs or updates WebView2. -->',
+        (
+            "        <!-- Managed-deployment switches. Explicit allow is required for network bootstrap. -->\n"
+            '        <Property Id="ALLOWWEBVIEW2BOOTSTRAP" Secure="yes" />\n'
+            '        <Property Id="DISABLEWEBVIEW2BOOTSTRAP" Secure="yes" />'
+        ),
+        "        <!-- The current-user bundle never installs or updates WebView2. -->",
     ),
     (
         '        <Condition Message="Microsoft Edge WebView2 Runtime is required. Install the Evergreen Standalone Runtime first, or explicitly set ALLOWWEBVIEW2BOOTSTRAP=1."><![CDATA[Installed OR REMOVE OR INSTALLED_WEBVIEW2_VERSION OR (ALLOWWEBVIEW2BOOTSTRAP = "1" AND DISABLEWEBVIEW2BOOTSTRAP <> "1")]]></Condition>',
@@ -58,16 +59,25 @@ USER_NAMESPACE = UUID("f27de3a8-a9dc-4a3d-84bb-e98f1bf82393")
 
 
 def registry_key(name: str) -> ET.Element:
-    return ET.Element("RegistryValue", {
-        "Root": "HKCU", "Key": r"Software\{{@root.manufacturer}}\{{@root.product_name}}\Components",
-        "Name": name, "Type": "integer", "Value": "1", "KeyPath": "yes",
-    })
+    return ET.Element(
+        "RegistryValue",
+        {
+            "Root": "HKCU",
+            "Key": r"Software\{{@root.manufacturer}}\{{@root.product_name}}\Components",
+            "Name": name,
+            "Type": "integer",
+            "Value": "1",
+            "KeyPath": "yes",
+        },
+    )
 
 
 def resource_authoring(system_wxs: str) -> tuple[str, str]:
     """Reuse Tauri's resolved resource destinations, never its random component IDs."""
     if system_wxs.count(RESOURCE_START) != 1 or system_wxs.count(RESOURCE_END) != 1:
-        raise ValueError("system WiX source must contain exactly one marked bundled resource block")
+        raise ValueError(
+            "system WiX source must contain exactly one marked bundled resource block"
+        )
     fragment = system_wxs.split(RESOURCE_START, 1)[1].split(RESOURCE_END, 1)[0]
     if "{{" in fragment:
         raise ValueError("system WiX resources must already be rendered by Tauri")
@@ -80,14 +90,18 @@ def resource_authoring(system_wxs: str) -> tuple[str, str]:
         for child in node:
             if child.tag == "Directory":
                 destination = (*path, child.attrib["Name"])
-                identity = uuid5(USER_NAMESPACE, "directory:" + "/".join(destination).casefold()).hex
+                identity = uuid5(
+                    USER_NAMESPACE, "directory:" + "/".join(destination).casefold()
+                ).hex
                 child.set("Id", "UserDir" + identity)
                 directories.append(child.attrib["Id"])
                 visit(child, destination)
             elif child.tag == "Component":
                 files = child.findall("File")
                 if len(files) != 1:
-                    raise ValueError("expected exactly one file per Tauri resource component")
+                    raise ValueError(
+                        "expected exactly one file per Tauri resource component"
+                    )
                 file = files[0]
                 name = file.get("Name") or PureWindowsPath(file.attrib["Source"]).name
                 destination = "/".join((*path, name)).casefold()
@@ -108,16 +122,26 @@ def resource_authoring(system_wxs: str) -> tuple[str, str]:
 
     visit(tree, ())
     if directories:
-        cleanup = ET.SubElement(tree, "Component", {
-            "Id": "UserResourceDirectoryCleanup",
-            "Guid": str(uuid5(USER_NAMESPACE, "resource-directory-cleanup")),
-            "Win64": "$(var.Win64)",
-        })
+        cleanup = ET.SubElement(
+            tree,
+            "Component",
+            {
+                "Id": "UserResourceDirectoryCleanup",
+                "Guid": str(uuid5(USER_NAMESPACE, "resource-directory-cleanup")),
+                "Win64": "$(var.Win64)",
+            },
+        )
         cleanup.append(registry_key("UserResourceDirectoryCleanup"))
         for directory in directories:
-            ET.SubElement(cleanup, "RemoveFolder", {
-                "Id": "Remove" + directory, "Directory": directory, "On": "uninstall",
-            })
+            ET.SubElement(
+                cleanup,
+                "RemoveFolder",
+                {
+                    "Id": "Remove" + directory,
+                    "Directory": directory,
+                    "On": "uninstall",
+                },
+            )
         refs.append(cleanup.attrib["Id"])
     return (
         "\n".join(ET.tostring(node, encoding="unicode") for node in tree),
@@ -153,17 +177,28 @@ def render(source: str, system_wxs: str) -> str:
     if rendered.count(resource_refs) != 1:
         raise ValueError("expected exactly one Tauri resource reference block")
     rendered = rendered.replace(resource_refs, references)
-    rendered = rendered.replace('Guid="41f6d598-8908-4004-9332-291b64fd38be"',
-                                f'Guid="{uuid5(USER_NAMESPACE, "main-binary-registry-keypath")}"')
+    rendered = rendered.replace(
+        'Guid="41f6d598-8908-4004-9332-291b64fd38be"',
+        f'Guid="{uuid5(USER_NAMESPACE, "main-binary-registry-keypath")}"',
+    )
     rendered = rendered.replace('Guid="{{bin.guid}}"', 'Guid="*"')
     for file_token, key_name in (
-        ('<File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>', "MainBinary"),
-        ('<File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>', "Binary_{{ bin.id }}"),
+        (
+            '<File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>',
+            "MainBinary",
+        ),
+        (
+            '<File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>',
+            "Binary_{{ bin.id }}",
+        ),
     ):
         if rendered.count(file_token) != 1:
             raise ValueError(f"expected exactly one binary file token: {file_token}")
-        rendered = rendered.replace(file_token, file_token.replace(' KeyPath="yes"', '')
-                                    + ET.tostring(registry_key(key_name), encoding="unicode"))
+        rendered = rendered.replace(
+            file_token,
+            file_token.replace(' KeyPath="yes"', "")
+            + ET.tostring(registry_key(key_name), encoding="unicode"),
+        )
     return rendered
 
 
@@ -171,12 +206,21 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
-    parser.add_argument("--system-wxs", type=Path, required=True,
-                        help="Fully rendered system MSI main.wxs from the preceding Tauri bundle")
+    parser.add_argument(
+        "--system-wxs",
+        type=Path,
+        required=True,
+        help="Fully rendered system MSI main.wxs from the preceding Tauri bundle",
+    )
     args = parser.parse_args()
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(render(args.source.read_text(encoding="utf-8"),
-                                       args.system_wxs.read_text(encoding="utf-8")), encoding="utf-8")
+    args.output.write_text(
+        render(
+            args.source.read_text(encoding="utf-8"),
+            args.system_wxs.read_text(encoding="utf-8"),
+        ),
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_windows_per_user_installer.py
+++ b/tests/test_windows_per_user_installer.py
@@ -11,11 +11,11 @@ SCRIPT = ROOT / "scripts/render-per-user-wix.py"
 CONFIG = ROOT / "frontend/src-tauri/tauri.per-user.conf.json"
 
 
-RESOURCE_FIXTURE = """<!-- BEGIN BUNDLED_RESOURCES -->
+RESOURCE_FIXTURE = """<Wix><Component Id="helper.exe" Guid="random"><File Id="Bin_helper.exe" Source="C:/build/helper.exe" /></Component><!-- BEGIN BUNDLED_RESOURCES -->
 <Component Id="randomRoot" Guid="00000000-0000-0000-0000-000000000001" KeyPath="yes" Win64="$(var.Win64)"><File Id="rootFile" Source="C:/build/README.md" /></Component>
 <Directory Id="randomDir" Name="backend"><Directory Id="nestedDir" Name="data">
 <Component Id="randomNested" Guid="00000000-0000-0000-0000-000000000002" KeyPath="yes" Win64="$(var.Win64)"><File Id="nestedFile" Source="C:/build/a&amp;b.json" /></Component>
-</Directory></Directory><!-- END BUNDLED_RESOURCES -->"""
+</Directory></Directory><!-- END BUNDLED_RESOURCES --></Wix>"""
 
 
 def _renderer():
@@ -150,3 +150,19 @@ def test_main_and_helper_files_use_registry_keypaths():
         'Name="Binary_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes"' in rendered
     )
     assert 'Guid="{{bin.guid}}"' not in rendered
+
+
+def test_external_binary_guid_is_explicit_and_stable_across_builds():
+    renderer = _renderer()
+    first = renderer.render(SOURCE.read_text(), RESOURCE_FIXTURE)
+    second = renderer.render(
+        SOURCE.read_text(),
+        RESOURCE_FIXTURE.replace("C:/build/", "D:/runner/").replace(
+            'Guid="random"', 'Guid="another"'
+        ),
+    )
+    marker = '<Component Id="{{ bin.id }}" Guid="'
+    first_guid = first.split(marker)[1].split(" Win64=")[0]
+    assert first_guid == second.split(marker)[1].split(" Win64=")[0]
+    assert '(eq bin.id "helper.exe")' in first_guid
+    assert 'Guid="*"' not in marker + first_guid

--- a/tests/test_windows_per_user_installer.py
+++ b/tests/test_windows_per_user_installer.py
@@ -1,5 +1,7 @@
 import importlib.util
 import json
+import xml.etree.ElementTree as ET
+import pytest
 from pathlib import Path
 
 
@@ -7,6 +9,13 @@ ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "frontend/src-tauri/wix/main.wxs"
 SCRIPT = ROOT / "scripts/render-per-user-wix.py"
 CONFIG = ROOT / "frontend/src-tauri/tauri.per-user.conf.json"
+
+
+RESOURCE_FIXTURE = """<!-- BEGIN BUNDLED_RESOURCES -->
+<Component Id="randomRoot" Guid="00000000-0000-0000-0000-000000000001" KeyPath="yes" Win64="$(var.Win64)"><File Id="rootFile" Source="C:/build/README.md" /></Component>
+<Directory Id="randomDir" Name="backend"><Directory Id="nestedDir" Name="data">
+<Component Id="randomNested" Guid="00000000-0000-0000-0000-000000000002" KeyPath="yes" Win64="$(var.Win64)"><File Id="nestedFile" Source="C:/build/a&amp;b.json" /></Component>
+</Directory></Directory><!-- END BUNDLED_RESOURCES -->"""
 
 
 def _renderer():
@@ -19,7 +28,7 @@ def _renderer():
 
 def test_machine_and_per_user_templates_have_distinct_scopes_and_roots():
     machine = SOURCE.read_text(encoding="utf-8")
-    user = _renderer().render(machine)
+    user = _renderer().render(machine, RESOURCE_FIXTURE)
 
     assert 'InstallScope="perMachine"' in machine
     assert 'InstallScope="perUser"' in user
@@ -34,7 +43,7 @@ def test_machine_and_per_user_templates_have_distinct_scopes_and_roots():
     assert '<RegistryKey Root="HKCU" Key="Software\\\\{{manufacturer}}\\\\{{product_name}}">' in user
     assert '<RegistryKey Root="HKCU" Key="Software\\Classes\\\\{{protocol}}">' in user
     assert 'Guid="{{path_component_guid}}"' in machine
-    assert 'Guid="41f6d598-8908-4004-9332-291b64fd38be"' in user
+    assert 'Guid="41f6d598-8908-4004-9332-291b64fd38be"' not in user
 
 
 def test_per_user_bundle_has_separate_identity_and_no_elevated_update_task():
@@ -48,7 +57,7 @@ def test_per_user_bundle_has_separate_identity_and_no_elevated_update_task():
 
 def test_per_user_template_never_contains_webview_install_actions():
     machine = SOURCE.read_text(encoding="utf-8")
-    user = _renderer().render(machine)
+    user = _renderer().render(machine, RESOURCE_FIXTURE)
 
     assert "https://go.microsoft.com/fwlink/p/?LinkId=2124703" in machine
     assert "ALLOWWEBVIEW2BOOTSTRAP" in machine
@@ -80,3 +89,46 @@ def test_release_builds_publishes_and_smokes_as_a_standard_user():
     assert "standard-user uninstall" in smoke
     assert "latest/download/latest-user.json" in updater
     assert "releases/download/preview/latest-user.json" in updater
+
+
+def test_resource_components_use_hkcu_keypaths_and_remove_nested_folders():
+    fragment, refs = _renderer().resource_authoring(RESOURCE_FIXTURE)
+    tree = ET.fromstring("<Root>" + fragment + "</Root>")
+    components = tree.findall(".//Component")
+    for component in components:
+        assert "KeyPath" not in component.attrib
+        registry = component.find("RegistryValue")
+        assert registry is not None
+        assert registry.get("Root") == "HKCU"
+        assert registry.get("KeyPath") == "yes"
+        for file in component.findall("File"):
+            assert file.get("KeyPath") != "yes"
+    assert {node.get("Directory") for node in tree.findall(".//RemoveFolder")} == {
+        node.get("Id") for node in tree.findall(".//Directory")
+    }
+    assert {node.get("Id") for node in ET.fromstring("<Root>" + refs + "</Root>")} == {
+        component.get("Id") for component in components
+    }
+    assert any(file.get("Source") == "C:/build/a&b.json" for file in tree.findall(".//File"))
+
+
+def test_resource_identity_depends_on_destination_not_random_tauri_ids_or_build_root():
+    renderer = _renderer()
+    first, first_refs = renderer.resource_authoring(RESOURCE_FIXTURE)
+    second, second_refs = renderer.resource_authoring(RESOURCE_FIXTURE.replace("random", "other").replace("C:/build/", "D:/runner/"))
+    assert first.replace("C:/build/", "D:/runner/") == second
+    assert first_refs == second_refs
+
+
+@pytest.mark.parametrize("source", ["", "{{resources}}", "<!-- BEGIN BUNDLED_RESOURCES -->{{resources}}<!-- END BUNDLED_RESOURCES -->"])
+def test_missing_or_unrendered_system_resources_fail_closed(source):
+    with pytest.raises(ValueError):
+        _renderer().render(SOURCE.read_text(), source)
+
+
+def test_main_and_helper_files_use_registry_keypaths():
+    rendered = _renderer().render(SOURCE.read_text(), RESOURCE_FIXTURE)
+    assert '<File Id="Path" Source="{{main_binary_path}}" Checksum="yes"/>' in rendered
+    assert '<File Id="Bin_{{ bin.id }}" Source="{{bin.path}}"/>' in rendered
+    assert 'Name="Binary_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes"' in rendered
+    assert 'Guid="{{bin.guid}}"' not in rendered

--- a/tests/test_windows_per_user_installer.py
+++ b/tests/test_windows_per_user_installer.py
@@ -1,9 +1,9 @@
 import importlib.util
 import json
 import xml.etree.ElementTree as ET
-import pytest
 from pathlib import Path
 
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "frontend/src-tauri/wix/main.wxs"
@@ -40,7 +40,10 @@ def test_machine_and_per_user_templates_have_distinct_scopes_and_roots():
     assert 'Id="PrevInstallDirNoName" Root="HKCU"' in user
     assert 'Id="PrevInstallDirWithName" Root="HKLM"' in machine
     assert 'Id="PrevInstallDirWithName" Root="HKCU"' in user
-    assert '<RegistryKey Root="HKCU" Key="Software\\\\{{manufacturer}}\\\\{{product_name}}">' in user
+    assert (
+        '<RegistryKey Root="HKCU" Key="Software\\\\{{manufacturer}}\\\\{{product_name}}">'
+        in user
+    )
     assert '<RegistryKey Root="HKCU" Key="Software\\Classes\\\\{{protocol}}">' in user
     assert 'Guid="{{path_component_guid}}"' in machine
     assert 'Guid="41f6d598-8908-4004-9332-291b64fd38be"' not in user
@@ -76,16 +79,18 @@ def test_per_user_template_never_contains_webview_install_actions():
 def test_release_builds_publishes_and_smokes_as_a_standard_user():
     workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     smoke = (ROOT / "scripts/smoke-per-user-msi.ps1").read_text(encoding="utf-8")
-    updater = (ROOT / "frontend/src-tauri/src/updater_channel.rs").read_text(encoding="utf-8")
+    updater = (ROOT / "frontend/src-tauri/src/updater_channel.rs").read_text(
+        encoding="utf-8"
+    )
 
     assert "render-per-user-wix.py" in workflow
     assert "tauri.per-user.conf.json" in workflow
-    assert 'artifact// (Current User)/_Current_User' in workflow
+    assert "artifact// (Current User)/_Current_User" in workflow
     assert "latest-user.json" in workflow
     assert "smoke-per-user-msi.ps1" in workflow
     assert "Start-Process msiexec.exe -Credential" in smoke
-    assert 'if ($LASTEXITCODE -ne 0)' in smoke
-    assert 'if ($createdUser)' in smoke
+    assert "if ($LASTEXITCODE -ne 0)" in smoke
+    assert "if ($createdUser)" in smoke
     assert "standard-user uninstall" in smoke
     assert "latest/download/latest-user.json" in updater
     assert "releases/download/preview/latest-user.json" in updater
@@ -109,18 +114,29 @@ def test_resource_components_use_hkcu_keypaths_and_remove_nested_folders():
     assert {node.get("Id") for node in ET.fromstring("<Root>" + refs + "</Root>")} == {
         component.get("Id") for component in components
     }
-    assert any(file.get("Source") == "C:/build/a&b.json" for file in tree.findall(".//File"))
+    assert any(
+        file.get("Source") == "C:/build/a&b.json" for file in tree.findall(".//File")
+    )
 
 
 def test_resource_identity_depends_on_destination_not_random_tauri_ids_or_build_root():
     renderer = _renderer()
     first, first_refs = renderer.resource_authoring(RESOURCE_FIXTURE)
-    second, second_refs = renderer.resource_authoring(RESOURCE_FIXTURE.replace("random", "other").replace("C:/build/", "D:/runner/"))
+    second, second_refs = renderer.resource_authoring(
+        RESOURCE_FIXTURE.replace("random", "other").replace("C:/build/", "D:/runner/")
+    )
     assert first.replace("C:/build/", "D:/runner/") == second
     assert first_refs == second_refs
 
 
-@pytest.mark.parametrize("source", ["", "{{resources}}", "<!-- BEGIN BUNDLED_RESOURCES -->{{resources}}<!-- END BUNDLED_RESOURCES -->"])
+@pytest.mark.parametrize(
+    "source",
+    [
+        "",
+        "{{resources}}",
+        "<!-- BEGIN BUNDLED_RESOURCES -->{{resources}}<!-- END BUNDLED_RESOURCES -->",
+    ],
+)
 def test_missing_or_unrendered_system_resources_fail_closed(source):
     with pytest.raises(ValueError):
         _renderer().render(SOURCE.read_text(), source)
@@ -130,5 +146,7 @@ def test_main_and_helper_files_use_registry_keypaths():
     rendered = _renderer().render(SOURCE.read_text(), RESOURCE_FIXTURE)
     assert '<File Id="Path" Source="{{main_binary_path}}" Checksum="yes"/>' in rendered
     assert '<File Id="Bin_{{ bin.id }}" Source="{{bin.path}}"/>' in rendered
-    assert 'Name="Binary_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes"' in rendered
+    assert (
+        'Name="Binary_{{ bin.id }}" Type="integer" Value="1" KeyPath="yes"' in rendered
+    )
     assert 'Guid="{{bin.guid}}"' not in rendered

--- a/tests/test_windows_per_user_installer.py
+++ b/tests/test_windows_per_user_installer.py
@@ -166,3 +166,10 @@ def test_external_binary_guid_is_explicit_and_stable_across_builds():
     assert first_guid == second.split(marker)[1].split(" Win64=")[0]
     assert '(eq bin.id "helper.exe")' in first_guid
     assert 'Guid="*"' not in marker + first_guid
+
+
+def test_registry_key_template_does_not_escape_handlebars_expressions():
+    key = _renderer().registry_key("MainBinary").attrib["Key"]
+    # A single backslash escapes the opening Handlebars delimiter. The canonical
+    # WiX template doubles it so the installed key uses resolved product names.
+    assert key == r"Software\\{{@root.manufacturer}}\\{{@root.product_name}}\Components"


### PR DESCRIPTION
Windows per-user MSI builds failed during WiX linking while system MSI builds succeeded. Components installed under the user profile lacked HKCU registry keypaths, and nested resource folders lacked uninstall cleanup (ICE38/ICE64).

The per-user renderer now authors valid registry-backed file components with stable, distinct GUIDs and folder cleanup, using Tauri's rendered resource layout. The system installer remains the canonical source. A native Windows CI smoke job bundles a tiny application with helper binaries and nested resources, exercising real candle/light validation on every PR; an explicit diagnostic dispatch can run it independently.

Validation: 56 local installer/release/changelog tests pass. Native Windows reproduced the original errors, then built both installer scopes successfully after the fix: https://github.com/debpalash/VoiceStudio/actions/runs/34090538406. No release artifacts were published by the diagnostic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Per-user Windows MSI rendering now reuses Tauri’s rendered resources, assigns stable HKCU-backed component identities, and cleans nested resource folders. This fixes WiX ICE38/ICE64 failures and adds native Windows CI validation for both installer scopes. Review the resource transformation and diagnostic coverage for compatibility with future Tauri WiX layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->