### PR TITLE
fix(windows): preserve frontend resources during per-user MSI build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Tilde-separated number ranges are spoken clearly without running their endpoints together (#1821) — thanks @flutterkage2k!
 - Voice modes use themed tabs, with Synthesize and Convert pinned below their scrolling forms (#1823)
 - Fix current-user Windows installer validation and nested resource cleanup (#1873)
+- Keep generated frontend assets available while building the current-user Windows installer (#1873)
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 - The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ the frozen-backend fallback mirror it for their toolchains.
 - Tilde-separated number ranges are spoken clearly without running their endpoints together (#1821) — thanks @flutterkage2k!
 - Voice modes use themed tabs, with Synthesize and Convert pinned below their scrolling forms (#1823)
 - Fix current-user Windows installer validation and nested resource cleanup (#1873)
-- Keep generated frontend assets available while building the current-user Windows installer (#1873)
+- Keep generated frontend assets available while building the current-user Windows installer (#1881)
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 - The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -308,8 +308,15 @@ stable per-user component identities, HKCU registry keypaths, and uninstall
 cleanup for nested resource folders. Missing or unrendered resources fail the
 build. The canonical system installer retains its per-machine authoring.
 
-CI bundles both scopes with a tiny executable, an external helper, and nested
-resources using the CLI version locked in `bun.lock`. The Windows MSI authoring
+The per-user build reuses the system build's frontend output: its config clears
+`beforeBuildCommand` so a second Vite build cannot replace the hashed files
+referenced by the rendered WiX template. Keep using `tauri build` for the
+per-user stage; it still recompiles the shell with its own product configuration.
+
+CI builds both scopes with a tiny executable, an external helper, and nested
+resources using the CLI version locked in `bun.lock`. Its frontend-like build
+hook rotates resource filenames, verifying the per-user build preserves the
+system build's resource snapshot. The Windows MSI authoring
 job runs after the test suite and preserves verbose WiX logs and rendered XML.
 For focused diagnosis, dispatch CI with `windows_wix_diagnostic=true`; it skips
 the other jobs and never signs, publishes, or installs the fixture bundles.

--- a/frontend/src-tauri/tauri.per-user.conf.json
+++ b/frontend/src-tauri/tauri.per-user.conf.json
@@ -1,6 +1,9 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "VoiceStudio (Current User)",
+  "build": {
+    "beforeBuildCommand": null
+  },
   "bundle": {
     "targets": ["msi"],
     "createUpdaterArtifacts": true,

--- a/scripts/diagnose-windows-wix.ps1
+++ b/scripts/diagnose-windows-wix.ps1
@@ -9,14 +9,33 @@ $lock = Get-Content "$repo/bun.lock" -Raw
 $cliMatch = [regex]::Match($lock, '"@tauri-apps/cli":\s*\["@tauri-apps/cli@([^"\s]+)"')
 if (-not $cliMatch.Success) { throw 'Cannot resolve the Tauri CLI version from bun.lock' }
 $cliPackage = '@tauri-apps/cli@' + $cliMatch.Groups[1].Value
-New-Item -ItemType Directory -Force -Path $fixture, $artifacts, "$fixture/src", "$fixture/resources/nested", "$fixture/binaries" | Out-Null
+New-Item -ItemType Directory -Force -Path $fixture, $artifacts, "$fixture/src", "$fixture/resources/nested", "$fixture/binaries", "$fixture/tauri-stub/src" | Out-Null
 @'
 [package]
 name = "wix-diagnostic"
 version = "0.0.0"
 edition = "2021"
+[dependencies]
+tauri = { path = "tauri-stub" }
 [workspace]
 '@ | Set-Content -Encoding utf8 "$fixture/Cargo.toml"
+@'
+[package]
+name = "tauri"
+version = "2.0.0"
+edition = "2021"
+[features]
+custom-protocol = []
+'@ | Set-Content -Encoding utf8 "$fixture/tauri-stub/Cargo.toml"
+'' | Set-Content -Encoding utf8 "$fixture/tauri-stub/src/lib.rs"
+@'
+from pathlib import Path
+import uuid
+root = Path(__file__).parent / "resources" / "nested"
+for previous in root.glob("asset-*.txt"):
+    previous.unlink()
+(root / f"asset-{uuid.uuid4().hex}.txt").write_text("changing frontend-like resource")
+'@ | Set-Content -Encoding utf8 "$fixture/build-assets.py"
 'fn main() { println!("MSI authoring diagnostic only"); }' | Set-Content -Encoding utf8 "$fixture/src/main.rs"
 'Nested resource payload' | Set-Content -Encoding utf8 "$fixture/resources/nested/payload.txt"
 'Root resource payload' | Set-Content -Encoding utf8 "$fixture/resources/readme.txt"
@@ -26,7 +45,7 @@ $config = @{
     productName = 'VoiceStudio MSI Diagnostic'
     version = '0.0.0'
     identifier = 'com.debpalash.voicestudio.wixdiagnostic'
-    build = @{}
+    build = @{ beforeBuildCommand = 'python build-assets.py' }
     bundle = @{
         active = $true
         targets = @('msi')
@@ -57,10 +76,14 @@ try {
             productName = "VoiceStudio MSI Diagnostic $scope"
             bundle = @{ windows = @{ wix = @{ template = "$scope.wxs" } } }
         }
+        if ($scope -eq 'per-user') {
+            $production = Get-Content "$repo/frontend/src-tauri/tauri.per-user.conf.json" -Raw | ConvertFrom-Json -AsHashtable
+            if ($production.ContainsKey('build')) { $scopeConfig.build = $production.build }
+        }
         $scopeConfig | ConvertTo-Json -Depth 20 | Set-Content -Encoding utf8 "$fixture/$scope.conf.json"
         $log = Join-Path $artifacts "$scope.log"
         $ErrorActionPreference = 'Continue'
-        & bun x --package $cliPackage tauri bundle -vv --target $target --bundles msi --config "$scope.conf.json" *> $log
+        & bun x --package $cliPackage tauri build -vv --target $target --bundles msi --config "$scope.conf.json" *> $log
         $results[$scope] = $LASTEXITCODE
         $ErrorActionPreference = 'Stop'
         Get-Content $log

--- a/scripts/diagnose-windows-wix.ps1
+++ b/scripts/diagnose-windows-wix.ps1
@@ -45,7 +45,7 @@ $config = @{
     productName = 'VoiceStudio MSI Diagnostic'
     version = '0.0.0'
     identifier = 'com.debpalash.voicestudio.wixdiagnostic'
-    build = @{ beforeBuildCommand = 'python build-assets.py' }
+    build = @{ beforeBuildCommand = @{ script = 'python build-assets.py'; cwd = $fixture } }
     bundle = @{
         active = $true
         targets = @('msi')

--- a/tests/test_windows_per_user_installer.py
+++ b/tests/test_windows_per_user_installer.py
@@ -52,6 +52,9 @@ def test_machine_and_per_user_templates_have_distinct_scopes_and_roots():
 def test_per_user_bundle_has_separate_identity_and_no_elevated_update_task():
     config = json.loads(CONFIG.read_text(encoding="utf-8"))
     assert config["productName"].endswith("(Current User)")
+    # The WiX resource snapshot comes from the preceding system build.
+    # Null deletes the inherited hook via Tauri's JSON Merge Patch.
+    assert config["build"]["beforeBuildCommand"] is None
     wix = config["bundle"]["windows"]["wix"]
     assert wix["upgradeCode"] == "f27de3a8-a9dc-4a3d-84bb-e98f1bf82393"
     assert wix["enableElevatedUpdateTask"] is False


### PR DESCRIPTION
## Summary

Fix the current-user Windows MSI linker failure caused by rebuilding frontend assets after capturing their filenames in the system WiX resource list (#1881).

## Changes

- Reuse the system build's frontend assets while still compiling the per-user shell with its own product configuration.
- Exercise both native Windows Tauri builds with a hook that replaces generated resource filenames.
- Document the required system-first build order.

## Type

- [x] 🐛 Bug fix

## Testing

- 20 installer/changelog tests pass; the configuration regression failed before the fix.
- The pinned Tauri CLI locally confirms the null override suppresses the frontend hook while Cargo still compiles.
- Native Windows regression fails before with LGHT0103 for a missing generated asset: https://github.com/debpalash/VoiceStudio/actions/runs/34115620257
- Both MSI scopes pass on exact head4486b479: https://github.com/debpalash/VoiceStudio/actions/runs/34115633983
- Full CI, all native platform checks, and both automated reviews pass on head4486b479. The full application diagnostic confirms the system MSI passes, the original per-user build fails with LGHT0103 for 63 replaced assets, and restoring the system resources passes: https://github.com/debpalash/VoiceStudio/actions/runs/34116980918

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- Version lockstep: unchanged; no version bump.
- Runtime fixture compatibility: unchanged; this only adjusts installer build sequencing.

## Release cadence

Continuous-to-main after review and green checks. Validate the full Windows preview installer from main after merging; no stable tag or version bump is part of this PR.
