### PR TITLE
fix(ci): prepare hosted Windows policy for non-admin MSI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,6 +464,9 @@ jobs:
       - name: Bundle canonical system and per-user templates with a tiny payload
         shell: pwsh
         run: ./scripts/diagnose-windows-wix.ps1
+      - name: Restore hosted Installer policy after failed standard-user installation
+        shell: powershell
+        run: ./scripts/test-msi-policy-cleanup.ps1
       - name: Preserve verbose linker output and rendered authoring
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -795,7 +795,7 @@ jobs:
           set -euo pipefail
           MSI=$(find frontend/src-tauri/target/${{ matrix.rust_target }}/release/bundle/msi -name '*Current*User*.msi' | head -1)
           powershell.exe -NoProfile -ExecutionPolicy Bypass \
-            -File scripts/smoke-per-user-msi.ps1 -MsiPath "$(cygpath -w "$MSI")"
+            -File scripts/smoke-per-user-msi.ps1 -MsiPath "$(cygpath -w "$MSI")" -PrepareHostedRunner
 
       # linuxdeploy re-links .DirIcon as an ABSOLUTE symlink into the build
       # machine AFTER tauri's files-map has placed the real icon bytes — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
+- Validate current-user Windows installers under a standard account on hosted runners (#1881)
+
 - The desktop app builds and opens from a fresh clone again (#1818) — thanks @flutterkage2k!
 - GPUs with less VRAM than the engine needs no longer get half the compute-time budget a CPU gets (#1806) — thanks @VishvakR!
 - Gallery voice previews play again — the quality guard was rejecting good renders as silent (#1819) — thanks @flutterkage2k!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
-- Validate current-user Windows installers under a standard account on hosted runners (#1881)
+- Validate current-user Windows installers under a standard account on hosted runners (#1883)
 
 - The desktop app builds and opens from a fresh clone again (#1818) — thanks @flutterkage2k!
 - GPUs with less VRAM than the engine needs no longer get half the compute-time budget a CPU gets (#1806) — thanks @VishvakR!

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -320,3 +320,12 @@ system build's resource snapshot. The Windows MSI authoring
 job runs after the test suite and preserves verbose WiX logs and rendered XML.
 For focused diagnosis, dispatch CI with `windows_wix_diagnostic=true`; it skips
 the other jobs and never signs, publishes, or installs the fixture bundles.
+
+The release smoke installs and removes the current-user MSI using a standard
+Windows account. On disposable GitHub-hosted Windows Server runners, it explicitly
+allows unmanaged MSI installations for the duration of this test, then restores
+the previous Installer policy value and type (or its absence), even on failure.
+This test-host preparation does not change installer privileges or user machines.
+Verbose MSI logs are printed if installation or removal fails. The Windows CI
+job also rejects an invalid MSI and verifies policy absence, value types, account
+cleanup, and verbose failure logs using Windows PowerShell 5.1.

--- a/scripts/smoke-per-user-msi.ps1
+++ b/scripts/smoke-per-user-msi.ps1
@@ -1,22 +1,50 @@
 param(
     [Parameter(Mandatory = $true)]
-    [string]$MsiPath
+    [string]$MsiPath,
+    [switch]$PrepareHostedRunner
 )
 
 $ErrorActionPreference = "Stop"
+if ($PrepareHostedRunner -and ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted')) {
+    throw 'Installer policy preparation is restricted to disposable GitHub-hosted runners'
+}
 $user = "VoiceStudioMsiTest"
-$password = "VsMsi-Test-42!"
+$password = 'Vs-' + [guid]::NewGuid().ToString('N') + '!'
 $secure = ConvertTo-SecureString $password -AsPlainText -Force
 $credential = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$user", $secure)
 $resolved = (Resolve-Path $MsiPath).Path
 $createdUser = $false
+$policyChanged = $false
+$policyPath = 'SOFTWARE\Policies\Microsoft\Windows\Installer'
+$policyKey = $null
+$logDirectory = Join-Path $env:PUBLIC ('VoiceStudioMsiSmoke-' + [guid]::NewGuid().ToString('N'))
 
 try {
-    net user $user $password /add | Out-Null
-    if ($LASTEXITCODE -ne 0) { throw "test-user creation exited $LASTEXITCODE" }
+    New-Item -ItemType Directory -Path $logDirectory | Out-Null
+    & icacls $logDirectory /grant '*S-1-5-32-545:(OI)(CI)M' | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "test-log directory permissions exited $LASTEXITCODE" }
+    if ($PrepareHostedRunner) {
+        # Windows Server defaults to blocking unmanaged per-user MSIs. Prepare
+        # only the disposable test host; the installer still runs without admin.
+        $policyKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($policyPath, $true)
+        $hadPolicyKey = $null -ne $policyKey
+        if (-not $hadPolicyKey) {
+            $policyKey = [Microsoft.Win32.Registry]::LocalMachine.CreateSubKey($policyPath)
+        }
+        $hadDisableMsi = $policyKey.GetValueNames() -contains 'DisableMSI'
+        if ($hadDisableMsi) {
+            $oldDisableMsi = $policyKey.GetValue('DisableMSI', $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            $oldDisableMsiKind = $policyKey.GetValueKind('DisableMSI')
+        }
+        $policyChanged = $true
+        $policyKey.SetValue('DisableMSI', 0, [Microsoft.Win32.RegistryValueKind]::DWord)
+    }
+    New-LocalUser -Name $user -Password $secure | Out-Null
     $createdUser = $true
+    Add-LocalGroupMember -SID 'S-1-5-32-545' -Member $user
     $install = Start-Process msiexec.exe -Credential $credential -LoadUserProfile -Wait -PassThru -ArgumentList @(
-        "/i", "`"$resolved`"", "/qn", "/norestart", "DISABLEWEBVIEW2BOOTSTRAP=1", "AUTOLAUNCHAPP=0"
+        "/i", "`"$resolved`"", "/qn", "/norestart", "DISABLEWEBVIEW2BOOTSTRAP=1", "AUTOLAUNCHAPP=0",
+        '/l*v', "`"$logDirectory\install.log`""
     )
     if ($install.ExitCode -ne 0) { throw "standard-user install exited $($install.ExitCode)" }
 
@@ -25,13 +53,32 @@ try {
     if (-not (Test-Path "$root\uv.exe")) { throw "per-user uv sidecar missing at $root" }
 
     $uninstall = Start-Process msiexec.exe -Credential $credential -LoadUserProfile -Wait -PassThru -ArgumentList @(
-        "/x", "`"$resolved`"", "/qn", "/norestart"
+        "/x", "`"$resolved`"", "/qn", "/norestart", '/l*v', "`"$logDirectory\uninstall.log`""
     )
     if ($uninstall.ExitCode -ne 0) { throw "standard-user uninstall exited $($uninstall.ExitCode)" }
     if (Test-Path "$root\omnivoice-studio.exe") { throw "per-user shell remains after uninstall" }
 }
+catch {
+    Get-ChildItem $logDirectory -Filter '*.log' -ErrorAction SilentlyContinue | ForEach-Object {
+        Write-Host "--- $($_.Name) ---"
+        Get-Content $_.FullName
+    }
+    throw
+}
 finally {
-    if ($createdUser) {
-        net user $user /delete 2>$null | Out-Null
+    try {
+        if ($policyChanged) {
+            if ($hadDisableMsi) { $policyKey.SetValue('DisableMSI', $oldDisableMsi, $oldDisableMsiKind) }
+            else { $policyKey.DeleteValue('DisableMSI', $false) }
+            $removeEmptyKey = -not $hadPolicyKey -and $policyKey.ValueCount -eq 0 -and $policyKey.SubKeyCount -eq 0
+            $policyKey.Dispose()
+            $policyKey = $null
+            if ($removeEmptyKey) { [Microsoft.Win32.Registry]::LocalMachine.DeleteSubKey($policyPath, $false) }
+        }
+    }
+    finally {
+        if ($null -ne $policyKey) { $policyKey.Dispose() }
+        if ($createdUser) { Remove-LocalUser -Name $user }
+        Write-Host "Installer smoke logs: $logDirectory"
     }
 }

--- a/scripts/test-msi-policy-cleanup.ps1
+++ b/scripts/test-msi-policy-cleanup.ps1
@@ -1,0 +1,58 @@
+# Windows PowerShell 5.1 regression: the disposable-host policy is restored on failure.
+$ErrorActionPreference = 'Stop'
+if ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted') {
+    throw 'This regression requires a disposable GitHub-hosted runner'
+}
+$path = 'SOFTWARE\Policies\Microsoft\Windows\Installer'
+$originalKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($path, $true)
+$hadKey = $null -ne $originalKey
+$hadValue = $hadKey -and ($originalKey.GetValueNames() -contains 'DisableMSI')
+if ($hadValue) {
+    $originalValue = $originalKey.GetValue('DisableMSI', $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+    $originalKind = $originalKey.GetValueKind('DisableMSI')
+}
+if ($hadKey -and ($originalKey.SubKeyCount -ne 0 -or @($originalKey.GetValueNames() | Where-Object { $_ -ne 'DisableMSI' }).Count -ne 0)) {
+    $originalKey.Dispose()
+    throw 'Refusing to alter a host with unrelated Installer policy'
+}
+if ($null -ne $originalKey) { $originalKey.Dispose() }
+$invalid = Join-Path $env:PUBLIC ('invalid-msi-' + [guid]::NewGuid().ToString('N') + '.msi')
+'Invalid MSI fixture' | Set-Content $invalid
+try {
+    foreach ($case in @('absent','dword','string')) {
+        [Microsoft.Win32.Registry]::LocalMachine.DeleteSubKeyTree($path, $false)
+        if ($case -ne 'absent') {
+            $key = [Microsoft.Win32.Registry]::LocalMachine.CreateSubKey($path)
+            if ($case -eq 'string') { $key.SetValue('DisableMSI', '1', [Microsoft.Win32.RegistryValueKind]::String) }
+            else { $key.SetValue('DisableMSI', 1, [Microsoft.Win32.RegistryValueKind]::DWord) }
+            $key.Dispose()
+        }
+        $logsBefore = @(Get-ChildItem $env:PUBLIC -Directory -Filter 'VoiceStudioMsiSmoke-*' | ForEach-Object FullName)
+        $failure = $null
+        try { & "$PSScriptRoot/smoke-per-user-msi.ps1" -MsiPath $invalid -PrepareHostedRunner }
+        catch { $failure = $_.Exception.Message }
+        if ($failure -notmatch 'standard-user install exited 1620') { throw "Unexpected invalid-MSI result: $failure" }
+        $key = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($path)
+        if ($case -eq 'absent') {
+            if ($null -ne $key) { $key.Dispose(); throw 'Absent policy key was not restored' }
+        } else {
+            if ($null -eq $key) { throw 'Original policy key missing' }
+            $expectedKind = if ($case -eq 'string') { [Microsoft.Win32.RegistryValueKind]::String } else { [Microsoft.Win32.RegistryValueKind]::DWord }
+            $valid = $key.GetValueKind('DisableMSI') -eq $expectedKind -and $key.GetValue('DisableMSI').ToString() -eq '1'
+            $key.Dispose()
+            if (-not $valid) { throw 'Policy value/type changed after failure' }
+        }
+        if (Get-LocalUser -Name VoiceStudioMsiTest -ErrorAction SilentlyContinue) { throw 'Test account survived failed install' }
+        $newLogs = @(Get-ChildItem $env:PUBLIC -Directory -Filter 'VoiceStudioMsiSmoke-*' | Where-Object { $_.FullName -notin $logsBefore })
+        if ($newLogs.Count -ne 1 -or -not (Test-Path (Join-Path $newLogs[0].FullName 'install.log'))) { throw 'Verbose failure log missing' }
+        Write-Host "PASS policy restoration after invalid MSI: $case"
+    }
+} finally {
+    [Microsoft.Win32.Registry]::LocalMachine.DeleteSubKeyTree($path, $false)
+    if ($hadKey) {
+        $key = [Microsoft.Win32.Registry]::LocalMachine.CreateSubKey($path)
+        if ($hadValue) { $key.SetValue('DisableMSI', $originalValue, $originalKind) }
+        $key.Dispose()
+    }
+    Remove-Item $invalid -ErrorAction SilentlyContinue
+}

--- a/tests/test_windows_per_user_installer.py
+++ b/tests/test_windows_per_user_installer.py
@@ -93,6 +93,8 @@ def test_release_builds_publishes_and_smokes_as_a_standard_user():
     assert "smoke-per-user-msi.ps1" in workflow
     assert "Start-Process msiexec.exe -Credential" in smoke
     assert "if ($LASTEXITCODE -ne 0)" in smoke
+    assert "-PrepareHostedRunner" in workflow
+    assert "New-LocalUser" in smoke
     assert "if ($createdUser)" in smoke
     assert "standard-user uninstall" in smoke
     assert "latest/download/latest-user.json" in updater


### PR DESCRIPTION
## Summary

Follow-up release validation fix #1883.

The full current-user MSI builds correctly, but the Windows Server release runner blocks its standard-user smoke with Installer policy error 1625. The smoke now explicitly prepares that disposable host and restores its original policy after success or failure.

## Changes

- Add a hosted-runner-only opt-in that temporarily allows unmanaged MSI installations, preserving the original registry value, type, or absence.
- Create the standard account noninteractively and capture verbose installation/removal logs on failure.
- Exercise failed-install policy restoration, account cleanup, and verbose logging under Windows PowerShell 5.1 in the existing Windows MSI CI job.
- Document the test-host behavior. Product installer privileges remain unchanged.

## Type

- [x] 🔧 CI / Build

## Testing

- 20 targeted installer and changelog tests pass; `git diff --check` passes.
- [Actual preview153 MSI policy experiment](https://github.com/debpalash/VoiceStudio/actions/runs/34123386242): baseline install exits1625; temporary policy preparation installs shell and uv successfully, then uninstalls successfully.
- [Exact production helper on Windows PowerShell 5.1](https://github.com/debpalash/VoiceStudio/actions/runs/34123793976): all four cases pass, including absent/DWORD/string policy restoration and rejected invalid MSI.
- [Exact permanent cleanup regression](https://github.com/debpalash/VoiceStudio/actions/runs/34123984841) passes on Windows PowerShell 5.1: absent/DWORD/string policy restoration, account cleanup, and fresh failure logs; actual installer cases also pass.

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync (no version bump)
- [x] App runtime behavior and project fixture format are unchanged

## Release cadence

Continuous to main after current-head CI and review; the next preview must build from the merged main commit.
