### PR TITLE
fix(dictation): give the setup-state pill label a hover tooltip

### DIFF
--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -2176,7 +2176,7 @@ export default function CaptureWidget({ onDismiss }) {
       <div className="min-w-0 flex-1 overflow-hidden">
         <span
           className="block overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] font-medium tracking-[0.01em]"
-          title={state === 'error' ? errorInfo?.message || undefined : undefined}
+          title={state === 'error' ? errorInfo?.message || label || undefined : label || undefined}
         >
           {emoji} {label}
         </span>

--- a/frontend/src/components/CaptureWidget.test.jsx
+++ b/frontend/src/components/CaptureWidget.test.jsx
@@ -1429,6 +1429,14 @@ describe('CaptureWidget', () => {
     expect(screen.queryByText(/Listening/)).not.toBeInTheDocument();
   });
 
+  it('exposes the full setup label as a title, since the 300px pill clips it', async () => {
+    mocks.holder.a11y = false;
+    render(withI18n(<CaptureWidget />));
+
+    const labelEl = await screen.findByText(/Allow Accessibility/);
+    expect(labelEl.title).toBe(i18n.t('capture.a11y_setup'));
+  });
+
   it('clears the Accessibility setup pill after the native grant changes', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/test/CaptureWidgetMicPreflight.test.jsx
+++ b/frontend/src/test/CaptureWidgetMicPreflight.test.jsx
@@ -126,6 +126,25 @@ describe('CaptureWidget — mic permission pre-flight (Tauri)', () => {
     window.__TAURI_INTERNALS__ = {};
   });
 
+  // #1884: the pill clips its label, so every state that can clip needs a
+  // hover title. This covers the error branch that carries a message — the
+  // title is the detailed message, which is strictly more than the clipped
+  // label shows. The no-message branch falls through to the label and is
+  // covered by the setup-state test in CaptureWidget.test.jsx.
+  it('uses the error detail as the title, not just the clipped label', async () => {
+    stubInvoke({ mic: 'denied' });
+    installGum(async () => {
+      throw notFound();
+    });
+    render(<CaptureWidget />);
+    pressShortcut();
+
+    const labelEl = await screen.findByText(/Mic access denied/);
+    expect(labelEl.title).toBeTruthy();
+    // Strictly more information than the visible, clipped text.
+    expect(labelEl.title).not.toBe(labelEl.textContent.trim());
+  });
+
   it('OS-denied → guided error pill with Open Settings, getUserMedia never called', async () => {
     stubInvoke({ mic: 'denied' });
     const gum = installGum(async () => {

--- a/frontend/src/test/CaptureWidgetMicPreflight.test.jsx
+++ b/frontend/src/test/CaptureWidgetMicPreflight.test.jsx
@@ -140,9 +140,11 @@ describe('CaptureWidget — mic permission pre-flight (Tauri)', () => {
     pressShortcut();
 
     const labelEl = await screen.findByText(/Mic access denied/);
-    expect(labelEl.title).toBeTruthy();
-    // Strictly more information than the visible, clipped text.
-    expect(labelEl.title).not.toBe(labelEl.textContent.trim());
+    // Assert the detail itself, not merely "some different string". This
+    // phrase lives only in `errorInfo.message` (capture.mic_hint_linux) and
+    // never in the label, so a regression that fell back to the label — or
+    // any unrelated tooltip — fails here.
+    expect(labelEl.title).toMatch(/audio group/);
   });
 
   it('OS-denied → guided error pill with Open Settings, getUserMedia never called', async () => {


### PR DESCRIPTION
## Summary

Fixes #1884.

The dictation pill's label `<span>` only set `title` when `state === 'error'`. In every other state — including `setup`, shown while Accessibility has not been granted — `title` was `undefined`, so text clipped by the pill's `overflow-hidden`/`text-ellipsis` had no way to be read on hover. In `setup`, the label is the 46-character `capture.a11y_setup` string, which clips to "Allow Acc…" inside the 300x64 widget window.

## Fix

`frontend/src/components/CaptureWidget.jsx` (~line 2179): the tooltip now falls back to the already-localized `label` for every state, keeping the richer `errorInfo?.message` first when one exists:

```jsx
title={state === 'error' ? errorInfo?.message || label || undefined : label || undefined}
```

No new user-facing strings — reuses the existing i18n key. No locale files touched. `.capture-pill`'s `max-width` left as-is (flagged as an adjacent observation on the issue, not part of this diff).

## Test plan

- [x] Added a regression test in `frontend/src/components/CaptureWidget.test.jsx` asserting the pill's label element exposes a `title` carrying the full `capture.a11y_setup` text in the `setup` state. Verified it fails against pre-fix code (`title` was `''`) and passes after the fix.
- [x] `bunx vitest run src/components/CaptureWidget.test.jsx src/test/CaptureWidgetPillVisible.test.jsx` — 53 passed, 0 failed.
- [x] `bunx vitest run src/test/CaptureWidgetSetupRace.test.jsx src/test/CaptureWidgetStrandedPill.test.jsx src/test/CaptureWidgetMicPreflight.test.jsx` — 20 passed, 0 failed (no regressions in adjacent pill suites).
- [x] `bunx oxlint` on both touched files — no new warnings/errors.

Built and tested against packaged preview **0.5.2-153** (Desktop Release run **#153**), source commit `bd84169f`, macOS 15.6 Apple Silicon, `device=mps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The dictation capture pill now shows a native tooltip with the localized label in all states, while error messages retain priority. This fixes clipped setup-state labels without adding locale strings or changing `.capture-pill` sizing. Regression tests cover setup and error tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->