### PR TITLE
fix(desktop): handle Dock-icon reopen on macOS

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -654,7 +654,13 @@ fn show_and_focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
 /// tests — `#[allow(dead_code)]` elsewhere, same treatment as `is_app_origin`
 /// and `with_noactivate_style` above.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn should_restore_on_reopen(main_window_visible: bool) -> bool {
+fn should_restore_on_reopen(main_window_visible: bool, _cocoa_has_visible_windows: bool) -> bool {
+    // Cocoa's aggregate flag is accepted and deliberately ignored. Taking it
+    // as a parameter rather than dropping it at the call site is what lets
+    // the tests below pin the contract: `(main: false, cocoa: true)` — the
+    // pill up, the main window closed — must still restore. An earlier
+    // revision decided on the aggregate alone and left the Dock icon dead in
+    // exactly that state.
     !main_window_visible
 }
 
@@ -664,12 +670,12 @@ mod reopen_tests {
 
     #[test]
     fn restores_when_the_main_window_is_hidden() {
-        assert!(should_restore_on_reopen(false));
+        assert!(should_restore_on_reopen(false, false));
     }
 
     #[test]
     fn does_nothing_when_the_main_window_is_already_visible() {
-        assert!(!should_restore_on_reopen(true));
+        assert!(!should_restore_on_reopen(true, true));
     }
 
     /// Regression guard: the dictation pill is a separate always-on-top
@@ -681,8 +687,11 @@ mod reopen_tests {
     /// The decision must depend only on the main window.
     #[test]
     fn restores_even_when_another_window_such_as_the_pill_is_visible() {
-        let main_window_visible = false;
-        assert!(should_restore_on_reopen(main_window_visible));
+        // Cocoa reports a visible window (the pill) while the main window is
+        // hidden. Passing both values separately is the point: this case is
+        // what distinguishes the main-window rule from the aggregate one, and
+        // it fails if the body ever goes back to `!cocoa_has_visible_windows`.
+        assert!(should_restore_on_reopen(false, true));
     }
 }
 
@@ -1269,7 +1278,10 @@ pub fn run() {
         // is the same sequence that item runs, so both paths behave
         // identically.
         #[cfg(target_os = "macos")]
-        tauri::RunEvent::Reopen { .. } => {
+        tauri::RunEvent::Reopen {
+            has_visible_windows,
+            ..
+        } => {
             // Cocoa's `has_visible_windows` is deliberately NOT used: the
             // dictation pill is a separate always-on-top window that sets it
             // to `true` on its own. Ask the main window directly instead.
@@ -1280,7 +1292,7 @@ pub fn run() {
                 .get_webview_window("main")
                 .map(|win| win.is_visible().unwrap_or(false))
                 .unwrap_or(false);
-            if should_restore_on_reopen(main_visible) {
+            if should_restore_on_reopen(main_visible, has_visible_windows) {
                 show_and_focus_main_window(app_handle);
             }
         }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -611,6 +611,62 @@ pub fn shutdown_backend_for_exit<R: tauri::Runtime>(app_handle: &tauri::AppHandl
     }
 }
 
+/// Show, unminimize and focus the main window. Shared by the tray's "Show
+/// VoiceStudio" menu item and the macOS `RunEvent::Reopen` handler below (Dock
+/// icon clicked while the main window is hidden), so the two recovery paths
+/// behave identically instead of drifting apart over time.
+fn show_and_focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.show();
+        #[cfg(not(target_os = "macos"))]
+        let _ = win.set_skip_taskbar(false);
+        let _ = win.unminimize();
+        let _ = win.set_focus();
+        // Self-recovery: if the webview failed to load the dev/prod URL
+        // earlier (Vite restarted, backend not up yet at first show, etc.)
+        // the window shows a blank `<body></body>` with a "Could not connect
+        // to the server" console error. Reload only when the body is empty
+        // so a healthy window doesn't blink on every show.
+        let _ = win.eval(
+            "if (document.body && document.body.childElementCount === 0) { location.reload(); }",
+        );
+    }
+}
+
+/// Whether a macOS `RunEvent::Reopen` (Dock icon clicked with no visible
+/// windows — Cocoa's `applicationShouldHandleReopen:hasVisibleWindows:`)
+/// should restore the main window. Pure so it's unit-testable — the actual
+/// event only fires inside the real Cocoa event loop and can't be
+/// synthesized under `cargo test` (see the `with_noactivate_style` comment
+/// above for the same rationale). `CloseRequested` (see `on_window_event`
+/// below) hides the main window rather than destroying it, so Cocoa reports
+/// `has_visible_windows: false` once the user has closed it — exactly when
+/// the Dock icon should bring it back. When some window is already visible,
+/// defer to Cocoa's default handling instead of stealing focus.
+///
+/// Only called from the macOS-gated `RunEvent::Reopen` arm below outside of
+/// tests — `#[allow(dead_code)]` elsewhere, same treatment as `is_app_origin`
+/// and `with_noactivate_style` above.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn should_restore_on_reopen(has_visible_windows: bool) -> bool {
+    !has_visible_windows
+}
+
+#[cfg(test)]
+mod reopen_tests {
+    use super::should_restore_on_reopen;
+
+    #[test]
+    fn restores_when_no_window_is_visible() {
+        assert!(should_restore_on_reopen(false));
+    }
+
+    #[test]
+    fn defers_to_cocoa_when_a_window_is_already_visible() {
+        assert!(!should_restore_on_reopen(true));
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // #879: if the previous run requested a WebView cache repair (splash
@@ -983,23 +1039,7 @@ pub fn run() {
                 .on_menu_event(move |app, event| {
                     match event.id().as_ref() {
                         "show" => {
-                            if let Some(win) = app.get_webview_window("main") {
-                                let _ = win.show();
-                                #[cfg(not(target_os = "macos"))]
-                                let _ = win.set_skip_taskbar(false);
-                                let _ = win.set_focus();
-                                // Self-recovery: if the webview failed to load
-                                // the dev/prod URL earlier (Vite restarted,
-                                // backend not up yet at first show, etc.) the
-                                // window shows a blank `<body></body>` with a
-                                // "Could not connect to the server" console
-                                // error. Reload only when the body is empty
-                                // so a healthy window doesn't blink on every
-                                // tray click.
-                                let _ = win.eval(
-                                    "if (document.body && document.body.childElementCount === 0) { location.reload(); }",
-                                );
-                            }
+                            show_and_focus_main_window(app);
                         }
                         "open_studio" => {
                             // Persist the preference (so next launch is studio, not pill)
@@ -1193,12 +1233,31 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app_handle, event| {
-        if let tauri::RunEvent::ExitRequested { code, api, .. } = event {
+    app.run(|app_handle, event| match event {
+        tauri::RunEvent::ExitRequested { code, api, .. } => {
             if !persistence_exit::handle_exit_requested(app_handle, code, &api) {
                 return;
             }
             shutdown_backend_for_exit(app_handle);
         }
+        // macOS: clicking the Dock icon while the app has no visible windows
+        // fires this (instead of relaunching) via Cocoa's
+        // `applicationShouldHandleReopen:hasVisibleWindows:`. CloseRequested
+        // (see `on_window_event` above) hides the main window rather than
+        // destroying it, so without this arm the click did nothing — the
+        // process stayed alive with a live Dock icon and the only way back
+        // was the tray's "Show VoiceStudio" item. `show_and_focus_main_window`
+        // is the same sequence that item runs, so both paths behave
+        // identically.
+        #[cfg(target_os = "macos")]
+        tauri::RunEvent::Reopen {
+            has_visible_windows,
+            ..
+        } => {
+            if should_restore_on_reopen(has_visible_windows) {
+                show_and_focus_main_window(app_handle);
+            }
+        }
+        _ => {}
     });
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -633,23 +633,29 @@ fn show_and_focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     }
 }
 
-/// Whether a macOS `RunEvent::Reopen` (Dock icon clicked with no visible
-/// windows — Cocoa's `applicationShouldHandleReopen:hasVisibleWindows:`)
-/// should restore the main window. Pure so it's unit-testable — the actual
-/// event only fires inside the real Cocoa event loop and can't be
-/// synthesized under `cargo test` (see the `with_noactivate_style` comment
-/// above for the same rationale). `CloseRequested` (see `on_window_event`
-/// below) hides the main window rather than destroying it, so Cocoa reports
-/// `has_visible_windows: false` once the user has closed it — exactly when
-/// the Dock icon should bring it back. When some window is already visible,
-/// defer to Cocoa's default handling instead of stealing focus.
+/// Whether a macOS `RunEvent::Reopen` (Dock icon clicked — Cocoa's
+/// `applicationShouldHandleReopen:hasVisibleWindows:`) should restore the
+/// main window. Pure so it's unit-testable — the actual event only fires
+/// inside the real Cocoa event loop and can't be synthesized under
+/// `cargo test` (see the `with_noactivate_style` comment above for the same
+/// rationale). `CloseRequested` (see `on_window_event` below) hides the main
+/// window rather than destroying it, so it is merely invisible once the user
+/// has closed it — exactly when the Dock icon should bring it back.
+///
+/// Keyed on the MAIN window specifically, not on Cocoa's `has_visible_windows`
+/// flag. This app owns a second window: the always-on-top dictation pill
+/// (`widget`, built below), which is shown and hidden independently and can
+/// sit on screen for a long time on its own — the Accessibility-setup state
+/// persists until the permission is granted. Keying on "any window visible"
+/// would report `true` from the pill alone and leave the Dock icon dead in
+/// precisely the case this handler exists to fix.
 ///
 /// Only called from the macOS-gated `RunEvent::Reopen` arm below outside of
 /// tests — `#[allow(dead_code)]` elsewhere, same treatment as `is_app_origin`
 /// and `with_noactivate_style` above.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn should_restore_on_reopen(has_visible_windows: bool) -> bool {
-    !has_visible_windows
+fn should_restore_on_reopen(main_window_visible: bool) -> bool {
+    !main_window_visible
 }
 
 #[cfg(test)]
@@ -657,13 +663,26 @@ mod reopen_tests {
     use super::should_restore_on_reopen;
 
     #[test]
-    fn restores_when_no_window_is_visible() {
+    fn restores_when_the_main_window_is_hidden() {
         assert!(should_restore_on_reopen(false));
     }
 
     #[test]
-    fn defers_to_cocoa_when_a_window_is_already_visible() {
+    fn does_nothing_when_the_main_window_is_already_visible() {
         assert!(!should_restore_on_reopen(true));
+    }
+
+    /// Regression guard: the dictation pill is a separate always-on-top
+    /// window that can be visible while the main window is closed — the
+    /// Accessibility-setup state stays up until the permission is granted.
+    /// An earlier revision keyed this decision on Cocoa's
+    /// `has_visible_windows`, which the pill alone sets to `true`, leaving
+    /// the Dock icon dead in exactly the situation this handler is for.
+    /// The decision must depend only on the main window.
+    #[test]
+    fn restores_even_when_another_window_such_as_the_pill_is_visible() {
+        let main_window_visible = false;
+        assert!(should_restore_on_reopen(main_window_visible));
     }
 }
 
@@ -1250,11 +1269,18 @@ pub fn run() {
         // is the same sequence that item runs, so both paths behave
         // identically.
         #[cfg(target_os = "macos")]
-        tauri::RunEvent::Reopen {
-            has_visible_windows,
-            ..
-        } => {
-            if should_restore_on_reopen(has_visible_windows) {
+        tauri::RunEvent::Reopen { .. } => {
+            // Cocoa's `has_visible_windows` is deliberately NOT used: the
+            // dictation pill is a separate always-on-top window that sets it
+            // to `true` on its own. Ask the main window directly instead.
+            // `is_visible()` errors only if the window has gone away, and a
+            // redundant show is harmless next to a Dock icon that stays dead,
+            // so treat an error as "not visible" and restore.
+            let main_visible = app_handle
+                .get_webview_window("main")
+                .map(|win| win.is_visible().unwrap_or(false))
+                .unwrap_or(false);
+            if should_restore_on_reopen(main_visible) {
                 show_and_focus_main_window(app_handle);
             }
         }


### PR DESCRIPTION
Fixes #1887.

### Build under test

Packaged preview **0.5.2-153**, Desktop Release **run #153**, source commit `bd84169f`, macOS 15.6 Apple Silicon.

### The bug

Closing the main window with the traffic light hides it — `CloseRequested` calls `prevent_close()` + `window.hide()` and never destroys the window, by design (background dictation). But `app.run(...)`'s event loop only handled `RunEvent::ExitRequested`; there was no `RunEvent::Reopen` arm anywhere in the crate. On macOS, clicking a running app's Dock icon with no visible windows fires `Reopen` (Cocoa's `applicationShouldHandleReopen:hasVisibleWindows:`). With nothing handling it, the click did nothing — the process stayed alive with a live Dock icon (studio mode never hides it) and the window was only recoverable via the tray's "Show VoiceStudio" item or a full quit/relaunch.

### The fix

- Added a `RunEvent::Reopen` arm to the `app.run(...)` closure, gated `#[cfg(target_os = "macos")]` — `Reopen` is itself a macOS-only variant in tauri 2.11, so this restores a platform convention that doesn't exist on the other platforms; it is not a divergent default per CLAUDE.md's cross-platform rule (platform-specific *implementation* of an OS affordance, not a feature the user can see/use differently across OSes).
- Factored the tray's existing "Show VoiceStudio" body into a shared `show_and_focus_main_window()` and call it from both the tray handler and the new `Reopen` arm, so the two recovery paths can't drift apart. This is a pure refactor of the tray path plus one addition: `unminimize()`, which the tray handler didn't call before (the single-instance relaunch handler a few lines up already does — this makes all three "bring the window back" call sites consistent).
- Split the restore decision into a pure `should_restore_on_reopen(main_window_visible: bool) -> bool` helper (skip restoring only when the **main** window is already visible) so it's unit-testable outside the real event loop, following this file's existing `with_noactivate_style`/`is_app_origin` pattern (`#[cfg_attr(not(target_os = "macos"), allow(dead_code))]` on non-macOS builds, same treatment).

### Explicitly out of scope

- `CloseRequested`'s hide-instead-of-close behavior is untouched — deliberate, not this issue.
- No multi-window support. Reopening the single existing window is the minimal correct fix; multi-window is a much larger feature and belongs in its own proposal.
- Windows/Linux: the same `CloseRequested` handler calls `set_skip_taskbar(true)`, so the tray is likewise the only way back there today. Flagged in #1887 for the maintainer as a possibly-related gap; not fixed here (different platform, different recovery affordance, no `Reopen`-equivalent event to hook).

### Testing

- `cargo test` / `cargo build` (or `cargo check`) in `frontend/src-tauri`: **could not be run** — this sandbox has no Rust toolchain installed (no `cargo`/`rustc`/`rustup`), and installing one was out of scope for this task. Verified instead by: reading tauri 2.11.0's actual `RunEvent` definition from `github.com/tauri-apps/tauri` at tag `tauri-v2.11.0` (`Reopen { has_visible_windows: bool }`, `#[non_exhaustive]`, `#[cfg(target_os = "macos")]`) to get the exact shape right, manual brace/paren balance check, and close reading against the file's own established idioms (`with_noactivate_style` comment block, `is_app_origin` dead_code pattern). A reviewer with a macOS Rust toolchain should run `cargo test` and `cargo build` in `frontend/src-tauri` before merge — flagging this plainly rather than claiming a pass I didn't observe.
- New tests: `reopen_tests::restores_when_no_window_is_visible` and `reopen_tests::defers_to_cocoa_when_a_window_is_already_visible`, covering `should_restore_on_reopen`'s two branches (this is the fail-before/pass-after regression coverage for the bug — the function didn't exist before this change, so "fail-before" is the absence of any handling, verified by grepping the crate for `Reopen` and finding no match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### Revised after review — the guard now keys on the main window

The first revision of this branch gated the restore on Cocoa's `has_visible_windows`. Review caught that as too coarse for this app, and the second commit fixes it.

This app owns a second window: the dictation pill (`widget`), built `.always_on_top(true)`, shown and hidden independently of `main`. Its Accessibility-setup state stays on screen until the permission is granted. So with the main window closed and the pill up, Cocoa reports `has_visible_windows: true`, the guard returned `false`, and the Dock click still did nothing — the exact failure this PR exists to fix, and a state reproduced on a real machine.

The handler now asks the main window directly via `is_visible()`, treating an error as "not visible" (a redundant show is harmless next to a Dock icon that stays dead; the rationale is in a comment at the call site). `restores_even_when_another_window_such_as_the_pill_is_visible` is the regression guard for it.

The no-toolchain caveat above still stands for both commits: this branch has never been compiled here. Please run `cargo test` and `cargo build` in `frontend/src-tauri` before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds macOS `RunEvent::Reopen` handling to restore, unminimize, and focus the hidden main window when users click the Dock icon. Shares this logic with the tray action and uses the main window’s visibility, so the dictation pill does not block restoration. Rust tests and builds were not run because the environment lacked a Rust toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->