### PR TITLE
feat(audiocpp): add CPU Breeze-TTS-2 backend and responsive catalogue rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 - The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!
-- audio.cpp joins the engine lineup as an opt-in native backend for Breeze-TTS-2 (English + Chinese, clone + voice design, no Python venv) (#1891)
+- audio.cpp joins the engine lineup as an opt-in CPU backend for Breeze-TTS-2 (English + Chinese, clone + voice design, no Python venv) (#1891)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 - The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!
+- audio.cpp joins the engine lineup as an opt-in native backend for Breeze-TTS-2 (English + Chinese, clone + voice design, no Python venv)
 
 ### Changed
 
@@ -47,6 +48,8 @@ the frozen-backend fallback mirror it for their toolchains.
 ### Added
 
 ### Docs
+
+- audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, GGUF download, voice modes, and the weights' research/non-commercial terms
 
 ### Fixed
 
@@ -91,6 +94,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 
 - Fast macOS process exits no longer turn a completed shutdown into a permission error (#1809)
+- Model Catalogue engine rows stack into one column on narrow shells instead of clipping actions off-screen (#1841)
+
 
 ## [0.5.2] — 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 - The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!
-- audio.cpp joins the engine lineup as an opt-in native backend for Breeze-TTS-2 (English + Chinese, clone + voice design, no Python venv)
+- audio.cpp joins the engine lineup as an opt-in native backend for Breeze-TTS-2 (English + Chinese, clone + voice design, no Python venv) (#1891)
 
 ### Changed
 
@@ -49,7 +49,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Docs
 
-- audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, GGUF download, voice modes, and the weights' research/non-commercial terms
+- audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, GGUF download, voice modes, and the weights' research/non-commercial terms (#1891)
 
 ### Fixed
 
@@ -94,7 +94,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 
 - Fast macOS process exits no longer turn a completed shutdown into a permission error (#1809)
-- Model Catalogue engine rows stack into one column on narrow shells instead of clipping actions off-screen (#1841)
+- Model Catalogue engine rows stack into one column on narrow shells instead of clipping actions off-screen (#1891)
 
 
 ## [0.5.2] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 - Voice cloning now starts with a clear upload-or-record choice, reveals recording and reference details only when needed, and keeps sampling controls under Production Overrides (#1817)
 - The first-run welcome line uses an instruction accepted by OmniVoice and VoiceDesign engines (#1861) — thanks @psiberfunk!
-- audio.cpp joins the engine lineup as an opt-in CPU backend for Breeze-TTS-2 (English + Chinese, clone + voice design, no Python venv) (#1891)
+- audio.cpp joins the engine lineup as an opt-in CPU backend for Breeze-TTS-2 (English + Chinese, clone + voice design, explicit Model Catalogue install, no Python venv) (#1891)
 
 ### Changed
 
@@ -49,7 +49,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Docs
 
-- audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, GGUF download, voice modes, and the weights' research/non-commercial terms (#1891)
+- audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, explicit GGUF download, voice modes, and the weights' research/non-commercial terms (#1891)
 
 ### Fixed
 

--- a/backend/api/routers/setup/download.py
+++ b/backend/api/routers/setup/download.py
@@ -385,7 +385,11 @@ def _is_retryable_download_error(exc: BaseException) -> bool:
 async def install_model(req: InstallModelRequest):
     """Download one HF repo snapshot; progress goes through the shared
     ``/setup/download-stream`` SSE feed."""
-    if req.repo_id not in [m["repo_id"] for m in KNOWN_MODELS]:
+    model_spec = next(
+        (model for model in KNOWN_MODELS if model["repo_id"] == req.repo_id),
+        None,
+    )
+    if model_spec is None:
         raise HTTPException(
             status_code=400,
             detail=(
@@ -393,6 +397,7 @@ async def install_model(req: InstallModelRequest):
                 + ", ".join(m["repo_id"] for m in KNOWN_MODELS)
             ),
         )
+    allow_patterns = list(model_spec.get("allow_patterns") or []) or None
     target = (req.target or "").strip()
     if target != "local":
         from services import gpu_gateway  # noqa: PLC0415
@@ -450,6 +455,8 @@ async def install_model(req: InstallModelRequest):
                 "revision": revision_for(req.repo_id),
                 "max_workers": _download_max_workers(),
             }
+            if allow_patterns:
+                dl_kwargs["allow_patterns"] = allow_patterns
             _tqdm_cls = hf_progress.tracked_tqdm_class()
             if _tqdm_cls is not None:
                 dl_kwargs["tqdm_class"] = _tqdm_cls
@@ -493,6 +500,8 @@ async def install_model(req: InstallModelRequest):
                 "revision": dl_kwargs["revision"],
                 "dry_run": True,
             }
+            if allow_patterns:
+                _preflight_kwargs["allow_patterns"] = allow_patterns
             if _endpoint:
                 _preflight_kwargs["endpoint"] = _endpoint
             try:
@@ -559,7 +568,12 @@ async def install_model(req: InstallModelRequest):
                     # snapshot_download — the accelerator can never compromise a
                     # correct install.
                     _snapshot_path = None
-                    if _attempt == 1 and _segmented_enabled() and not _xet_active():
+                    if (
+                        _attempt == 1
+                        and not allow_patterns
+                        and _segmented_enabled()
+                        and not _xet_active()
+                    ):
                         try:
                             _snapshot_path = _segmented_snapshot(
                                 req.repo_id,

--- a/backend/config/models.yaml
+++ b/backend/config/models.yaml
@@ -28,6 +28,9 @@
 #                            their own (weights live in referenced sub-repos). Such
 #                            a cache is legitimately tiny, so the truncated-download
 #                            (weights-missing) detector must NOT flag it incomplete.
+#   allow_patterns (optional) — restrict installation to these repository paths.
+#                               Use for multi-package repos so an explicit install
+#                               never downloads unrelated model variants.
 # ─────────────────────────────────────────────────────────────────────────
 
 models:
@@ -39,6 +42,14 @@ models:
     size_gb: 2.4
     required: true
     curated_on: [all]
+
+  - repo_id: "audio-cpp/audio.cpp-gguf"
+    label: "Breeze-TTS-2 Q8_0 for audio.cpp (English + Chinese, clone + design)"
+    role: TTS
+    size_gb: 4.73
+    allow_patterns:
+      - "Breeze-TTS-2-GGUF/breeze-tts-2-q8_0.gguf"
+    note: "Optional audio.cpp model. Research/non-commercial weights and self-hosted outputs; install only after reviewing the license."
 
   # ── ASR (optional — curated per platform) ─────────────────────────────
   # No ASR model is required to boot: TTS-only installs work. Dubbing,

--- a/backend/engines/audiocpp/__init__.py
+++ b/backend/engines/audiocpp/__init__.py
@@ -203,6 +203,7 @@ class AudioCPPBackend(TTSBackend):
 
         try:
             bootstrap.resolve_server_binary()
+            bootstrap.resolve_model_file()
         except RuntimeError as exc:
             return False, str(exc)
         return True, "ready"

--- a/backend/engines/audiocpp/__init__.py
+++ b/backend/engines/audiocpp/__init__.py
@@ -8,7 +8,7 @@ audio.cpp (0xShug0/audio.cpp) is a pure-C++ ggml runtime: prebuilt
 
 1. resolves the binary + GGUF model (``bootstrap.py``),
 2. spawns ONE long-lived ``audiocpp_server`` on 127.0.0.1 (lazy model load,
-   so VRAM is only held after the first generate), and
+   so model memory is only held after the first generate), and
 3. speaks its OpenAI-style ``POST /v1/audio/speech`` per generate.
 
 v1 serves the ``breeze_tts`` family only (Breeze-TTS-2, en+zh, voice clone
@@ -32,18 +32,22 @@ import io
 import json
 import logging
 import os
-import subprocess
+import secrets
+
+# Used only for stream constants; spawn_owned performs the process launch.
+import subprocess  # nosec B404
 import threading
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
+from core.contained_subprocess import spawn_owned
 from services.tts_backend import TTSBackend, TTSInputError
 
 if TYPE_CHECKING:
-    import torch  # noqa: F401
+    import torch
 
 logger = logging.getLogger("omnivoice.audiocpp")
 
@@ -54,29 +58,46 @@ ENGINE_ID = "audiocpp"
 #: extracts nothing heavy — the model loads lazily on first generate).
 _HEALTH_TIMEOUT_S = 120.0
 
-#: Per-generate HTTP timeout. Deliberately generous — the GPU-pool generate
-#: budget is the real deadline; this only reaps a wedged server. The first
-#: generate also cold-loads ~3 GB of GGUF.
-_GENERATE_TIMEOUT_S = 900.0
+#: Finish the inner HTTP request before the canonical generation guard can
+#: abandon its worker thread. This leaves enough time to terminate the owned
+#: native process and release its model memory synchronously.
+_TERMINATE_GRACE_S = 5.0
+_TERMINATE_KILL_S = 5.0
+_GENERATE_TIMEOUT_MARGIN_S = (
+    _TERMINATE_GRACE_S + _TERMINATE_KILL_S + 5.0
+)
 
 
 # ── pure request/config builders (unit-tested, no I/O) ──────────────────────
 
 
+def _cpu_thread_count() -> int:
+    """Use up to 16 physical cores, with a stdlib fallback."""
+    try:
+        import psutil
+
+        cores = psutil.cpu_count(logical=False)
+    except (ImportError, OSError):
+        cores = None
+    return min(16, max(1, cores or os.cpu_count() or 1))
+
+
 def build_server_config(
-    *, model_id: str, family: str, model_path: str, backend: str, port: int,
+    *, model_id: str, family: str, model_path: str, port: int,
 ) -> dict:
     """``server.json`` dict for the managed ``audiocpp_server``.
 
-    ``lazy_load`` defers the ~3 GB GGUF load to the first generate;
+    ``lazy_load`` defers the ~4.73 GiB GGUF load to the first generate;
     ``max_loaded_models: 1`` bounds residency to the one model we serve.
     """
     return {
         "host": "127.0.0.1",
         "port": port,
-        "backend": backend,
+        "backend": "cpu",
         "device": 0,
-        "threads": 1,
+        # The pinned CPU runtime scales strongly through 16 workers while
+        # producing byte-identical audio.
+        "threads": _cpu_thread_count(),
         "lazy_load": True,
         "max_loaded_models": 1,
         "models": [
@@ -92,9 +113,9 @@ def build_server_config(
 
 
 def build_speech_payload(
-    *, model_id: str, text: str, ref_audio: Optional[str] = None,
-    ref_text: Optional[str] = None, instructions: Optional[str] = None,
-    guidance_scale: Optional[float] = None, seed: Optional[int] = None,
+    *, model_id: str, text: str, ref_audio: str | None = None,
+    ref_text: str | None = None, instructions: str | None = None,
+    guidance_scale: float | None = None, seed: int | None = None,
 ) -> dict:
     """``POST /v1/audio/speech`` JSON body.
 
@@ -124,11 +145,11 @@ def build_speech_payload(
     return payload
 
 
-def decode_speech_json(obj: dict) -> tuple[int, "object"]:
+def decode_speech_json(obj: dict) -> tuple[int, object]:
     """``(sample_rate, mono float32 numpy)`` from a ``response_format=json``
     speech body. Raises ``ValueError`` on a server error payload."""
     if not isinstance(obj, dict):
-        raise ValueError(f"audio.cpp speech reply is not JSON: {obj!r:.120}")
+        raise TypeError(f"audio.cpp speech reply is not JSON: {obj!r:.120}")
     if "audio" not in obj:
         raise ValueError(f"audio.cpp speech failed: {obj.get('error', obj)!r:.300}")
     import numpy as np
@@ -155,25 +176,24 @@ class AudioCPPBackend(TTSBackend):
     )
     supports_voice_design = True
     applies_own_mastering = True  # model-decoded 24 kHz studio output
-    # audio.cpp maps our accelerator families to CUDA, HIP, Metal, or Vulkan.
-    # Intel GPUs use Vulkan; NPUs have no supported backend.
-    gpu_compat = ("cuda", "rocm", "mps", "xpu", "cpu")
+    # GPU backends remain outside this initial integration until each packaged
+    # runtime path has been measured and proven on its target platform.
+    gpu_compat = ("cpu",)
     runs_out_of_process = True
     # Same marker SubprocessBackend sets: this engine lives in another OS
     # process. Consumers only branch the matrix label and the self-test
     # route (spawn-and-ping instead of in-process synth) — both correct
     # here; nothing assumes the stdio protocol from it.
     _is_subprocess_isolated = True
-    min_vram_gb = 6.0  # 4.73 GiB Q8_0 file plus graph/session workspace
-
     _DEFAULT_SAMPLE_RATE = 24000  # Breeze-TTS-2 native rate
 
     def __init__(self) -> None:
-        self._proc: Optional[subprocess.Popen] = None
-        self._port: Optional[int] = None
+        self._proc: Any | None = None
+        self._port: int | None = None
+        self._server_model_id: str | None = None
         self._sr = self._DEFAULT_SAMPLE_RATE
         self._lock = threading.RLock()
-        self._server_json: Optional[Path] = None
+        self._server_json: Path | None = None
 
     # ── availability ────────────────────────────────────────────────────
 
@@ -181,22 +201,10 @@ class AudioCPPBackend(TTSBackend):
     def is_available(cls) -> tuple[bool, str]:
         from engines.audiocpp import bootstrap
 
-        if not bootstrap.is_installed():
-            slug_asset = bootstrap.default_asset()
-            if slug_asset is None:
-                return False, (
-                    "audio.cpp ships no prebuilt binary for this platform. "
-                    "Build from https://github.com/0xShug0/audio.cpp and set "
-                    f"{bootstrap.BIN_ENV}. See docs/engines/audio-cpp.md."
-                )
-            return False, (
-                "audiocpp_server not installed. Download "
-                f"https://github.com/{bootstrap.GH_REPO}/releases/download/"
-                f"{bootstrap.VERSION}/{slug_asset[0]}, extract it, and set "
-                f"{bootstrap.BIN_ENV} to the audiocpp_server binary "
-                f"(~3 GB Breeze-TTS-2 GGUF downloads on first generate). "
-                "See docs/engines/audio-cpp.md."
-            )
+        try:
+            bootstrap.resolve_server_binary()
+        except RuntimeError as exc:
+            return False, str(exc)
         return True, "ready"
 
     # ── TTSBackend protocol ─────────────────────────────────────────────
@@ -209,7 +217,7 @@ class AudioCPPBackend(TTSBackend):
     def supported_languages(self) -> list[str]:
         return ["en", "zh"]
 
-    def model_identity(self) -> Optional[str]:
+    def model_identity(self) -> str | None:
         from engines.audiocpp import bootstrap
 
         return f"{bootstrap.FAMILY}/{bootstrap.package_filename()}"
@@ -229,13 +237,16 @@ class AudioCPPBackend(TTSBackend):
 
             binary = bootstrap.resolve_server_binary()
             model_file = bootstrap.resolve_model_file()
-            backend = bootstrap.default_backend()
             self._port = bootstrap.server_port()
+            # The random model id is a per-launch challenge. Before sending
+            # speech text or a reference path, _verify_server_identity asks
+            # /v1/models to prove this is the child configured by this process,
+            # not an unrelated listener that pre-bound the loopback port.
+            self._server_model_id = f"{bootstrap.MODEL_ID}-{secrets.token_hex(16)}"
             config = build_server_config(
-                model_id=bootstrap.MODEL_ID,
+                model_id=self._server_model_id,
                 family=bootstrap.FAMILY,
                 model_path=str(model_file),
-                backend=backend,
                 port=self._port,
             )
             from core.config import DATA_DIR
@@ -243,53 +254,57 @@ class AudioCPPBackend(TTSBackend):
             workdir = Path(str(DATA_DIR)) / "audiocpp"
             workdir.mkdir(parents=True, exist_ok=True)
             self._server_json = workdir / "server.json"
-            self._server_json.write_text(json.dumps(config, indent=2))
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            config_fd = os.open(self._server_json, flags, 0o600)
+            try:
+                if os.name != "nt":
+                    os.fchmod(config_fd, 0o600)
+                with os.fdopen(config_fd, "w", encoding="utf-8") as config_fh:
+                    config_fd = -1
+                    json.dump(config, config_fh, indent=2)
+            finally:
+                if config_fd >= 0:
+                    os.close(config_fd)
             log_path = workdir / "server.log"
             logger.info(
-                "audio.cpp: starting %s (backend=%s, port=%d, model=%s)",
-                binary, backend, self._port, model_file.name,
+                "audio.cpp: starting %s (backend=cpu, port=%d, model=%s)",
+                binary.name, self._port, model_file.name,
             )
-            log_fh = open(log_path, "ab")
-            try:
-                self._proc = subprocess.Popen(
+            with open(log_path, "ab") as log_fh:
+                self._proc = spawn_owned(
                     [str(binary), "--config", str(self._server_json)],
                     stdout=log_fh,
                     stderr=subprocess.STDOUT,
                     stdin=subprocess.DEVNULL,
-                    start_new_session=(os.name != "nt"),
                 )
-            except Exception:
-                log_fh.close()
-                raise
-            # Popen owns the fd now; the parent handle can close.
-            log_fh.close()
             atexit.register(self._terminate_server)
             self._wait_for_health()
 
     def _wait_for_health(self) -> None:
-        assert self._proc is not None and self._port is not None
+        if self._proc is None or self._port is None:
+            raise RuntimeError("managed audio.cpp server was not started")
         deadline = time.monotonic() + _HEALTH_TIMEOUT_S
         last_err = "unknown"
         url = self._base_url() + "/health"
         while time.monotonic() < deadline:
             if self._proc.poll() is not None:
-                from engines.audiocpp.bootstrap import BACKEND_ENV
-
                 raise RuntimeError(
                     "audiocpp_server exited during startup "
                     f"(code {self._proc.returncode}). See the server log next "
                     "to server.json under the app data audiocpp/ directory — "
-                    "common cause: requested backend not in this binary, or "
-                    "the port is taken. "
-                    f"Set {BACKEND_ENV} to cpu as a fallback."
+                    "the managed port may already be in use."
                 )
             try:
                 # ``url`` is always the hard-coded loopback host plus a
                 # validated integer port; arbitrary schemes are impossible.
                 with urllib.request.urlopen(url, timeout=5) as resp:  # nosec B310
                     if resp.status == 200:
-                        logger.info("audio.cpp: server healthy on %s", self._base_url())
-                        return
+                        self._verify_server_identity()
+                        if self._proc.poll() is None:
+                            logger.info(
+                                "audio.cpp: managed server is healthy on loopback"
+                            )
+                            return
                     last_err = f"HTTP {resp.status}"
             except Exception as exc:  # noqa: BLE001 — still starting; retry
                 last_err = f"{type(exc).__name__}: {exc}"
@@ -300,9 +315,42 @@ class AudioCPPBackend(TTSBackend):
             f"{_HEALTH_TIMEOUT_S:.0f}s (last: {last_err})."
         )
 
+    def _get_json(self, path: str, timeout: float = 5.0) -> dict:
+        """GET one loopback JSON endpoint without sending request content."""
+        if self._port is None:
+            raise RuntimeError("managed audio.cpp server port is missing")
+        req = urllib.request.Request(self._base_url() + path, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
+            obj = json.loads(resp.read().decode("utf-8"))
+        if not isinstance(obj, dict):
+            raise TypeError("audio.cpp returned an invalid JSON response")
+        return obj
+
+    def _verify_server_identity(self) -> None:
+        """Prove the loopback listener owns this launch's random model id."""
+        if self._proc is None or self._proc.poll() is not None:
+            raise RuntimeError("managed audio.cpp server is not running")
+        expected = self._server_model_id
+        if not expected:
+            raise RuntimeError("managed audio.cpp server identity is missing")
+        obj = self._get_json("/v1/models")
+        data = obj.get("data", [])
+        if not isinstance(data, list):
+            raise TypeError("managed audio.cpp server identity is invalid")
+        model_ids = {
+            item.get("id") for item in data
+            if isinstance(item, dict)
+        }
+        if expected not in model_ids or self._proc.poll() is not None:
+            raise RuntimeError(
+                "loopback listener did not prove managed audio.cpp ownership"
+            )
+
     def _post_json(self, path: str, payload: dict, timeout: float) -> dict:
-        """POST JSON to the managed server, return the decoded JSON body."""
-        assert self._port is not None
+        """Verify child ownership, then POST JSON to the managed server."""
+        if self._port is None:
+            raise RuntimeError("managed audio.cpp server port is missing")
+        self._verify_server_identity()
         body = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
             self._base_url() + path,
@@ -320,24 +368,35 @@ class AudioCPPBackend(TTSBackend):
             raise RuntimeError(
                 f"audio.cpp {path} failed (HTTP {exc.code}): {detail}"
             ) from exc
+        except urllib.error.URLError as exc:
+            if isinstance(exc.reason, TimeoutError):
+                raise TimeoutError("audio.cpp request timed out") from exc
+            raise
 
     def _terminate_server(self) -> None:
         proc, self._proc = self._proc, None
+        self._server_model_id = None
         if proc is None:
             return
         try:
             proc.terminate()
-            proc.wait(timeout=15)
+            proc.wait(timeout=_TERMINATE_GRACE_S)
         except Exception:  # noqa: BLE001 — kill as last resort, never raise
             try:
                 proc.kill()
+                proc.wait(timeout=_TERMINATE_KILL_S)
             except Exception as exc:  # noqa: BLE001 — process is already failing
                 logger.debug("audio.cpp: final server kill failed: %s", exc)
 
     # ── generate ────────────────────────────────────────────────────────
 
-    def generate(self, text: str, **kw) -> "torch.Tensor":
+    def generate(self, text: str, **kw) -> torch.Tensor:
         import torch
+        from services.model_manager import (
+            GENERATE_PROGRESS_GRACE_S,
+            generate_timeout_s,
+            report_generate_progress,
+        )
 
         if not text or not text.strip():
             raise TTSInputError(
@@ -368,12 +427,15 @@ class AudioCPPBackend(TTSBackend):
         if kw.get("speed", 1.0) != 1.0:
             logger.info("audio.cpp: speed is not supported; ignoring.")
 
-        from engines.audiocpp import bootstrap
+        request_started = time.monotonic()
+        request_budget = generate_timeout_s(text, execution_device="cpu")
 
         with self._lock:
             self._ensure_loaded()
+            if not self._server_model_id:
+                raise RuntimeError("managed audio.cpp server identity is missing")
             payload = build_speech_payload(
-                model_id=bootstrap.MODEL_ID,
+                model_id=self._server_model_id,
                 text=text,
                 ref_audio=str(ref_audio) if ref_audio else None,
                 ref_text=ref_text,
@@ -381,9 +443,31 @@ class AudioCPPBackend(TTSBackend):
                 guidance_scale=kw.get("guidance_scale", 1.0),
                 seed=kw.get("seed"),
             )
-            obj = self._post_json(
-                "/v1/audio/speech", payload, timeout=_GENERATE_TIMEOUT_S,
+            # A first-use HF download can legitimately consume the soft CPU
+            # budget. Its progress heartbeats keep the outer guard alive; this
+            # fresh synthesis lease then gives the lazy model load + request a
+            # bounded window. The inner request always expires early enough to
+            # reap the owned server before the outer guard can abandon us.
+            report_generate_progress()
+            soft_remaining = request_budget - (time.monotonic() - request_started)
+            timeout = (
+                max(soft_remaining, GENERATE_PROGRESS_GRACE_S)
+                - _GENERATE_TIMEOUT_MARGIN_S
             )
+            if timeout <= 0:
+                self._terminate_server()
+                raise TimeoutError(
+                    "audio.cpp startup exhausted the generation time budget"
+                )
+            try:
+                obj = self._post_json(
+                    "/v1/audio/speech", payload, timeout=timeout,
+                )
+            except TimeoutError:
+                self._terminate_server()
+                raise RuntimeError(
+                    "audio.cpp generation timed out; its managed server was reset"
+                ) from None
         sr, wav_np = decode_speech_json(obj)
         self._sr = sr
         wav = torch.from_numpy(wav_np).float()

--- a/backend/engines/audiocpp/__init__.py
+++ b/backend/engines/audiocpp/__init__.py
@@ -331,8 +331,8 @@ class AudioCPPBackend(TTSBackend):
         except Exception:  # noqa: BLE001 — kill as last resort, never raise
             try:
                 proc.kill()
-            except Exception:
-                pass
+            except Exception as exc:  # noqa: BLE001 — process is already failing
+                logger.debug("audio.cpp: final server kill failed: %s", exc)
 
     # ── generate ────────────────────────────────────────────────────────
 

--- a/backend/engines/audiocpp/__init__.py
+++ b/backend/engines/audiocpp/__init__.py
@@ -1,0 +1,410 @@
+"""audio.cpp TTS backend — Breeze-TTS-2 via a managed native server.
+
+audio.cpp (0xShug0/audio.cpp) is a pure-C++ ggml runtime: prebuilt
+``audiocpp_server`` binaries for Windows/macOS/Linux, no Python venv, no
+``transformers`` pin — so this engine needs neither the venv-isolation
+(``engines.dots_tts``) nor the per-generate CLI-spawn (``engines
+.omnivoice_gguf``) patterns. The parent instead:
+
+1. resolves the binary + GGUF model (``bootstrap.py``),
+2. spawns ONE long-lived ``audiocpp_server`` on 127.0.0.1 (lazy model load,
+   so VRAM is only held after the first generate), and
+3. speaks its OpenAI-style ``POST /v1/audio/speech`` per generate.
+
+v1 serves the ``breeze_tts`` family only (Breeze-TTS-2, en+zh, voice clone
++ voice design + voice direction). The server is task-agnostic on the
+speech route — reference-audio presence selects clone/direction vs design —
+so a single ``task: tts`` model entry covers all three modes.
+
+License honesty: Breeze-TTS-2 weights (``BreezeBlue/Breeze-TTS-2`` and the
+audio.cpp GGUF repack) are RESEARCH AND NON-COMMERCIAL ONLY
+(``BreezeBlue Research and Non-Commercial License``); only the audio.cpp
+code is Apache-2.0. There is no in-tree acceptance dialog for this engine
+yet (settings ``/license`` allow-list), so the restriction is surfaced in
+the display name, the install hint, and ``docs/engines/audio-cpp.md`` —
+not silently.
+"""
+from __future__ import annotations
+
+import atexit
+import base64
+import io
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from services.tts_backend import TTSBackend, TTSInputError
+
+if TYPE_CHECKING:
+    import torch  # noqa: F401
+
+logger = logging.getLogger("omnivoice.audiocpp")
+
+#: Engine id in the TTS registry.
+ENGINE_ID = "audiocpp"
+
+#: How long to wait for ``/health`` after spawning the server (first spawn
+#: extracts nothing heavy — the model loads lazily on first generate).
+_HEALTH_TIMEOUT_S = 120.0
+
+#: Per-generate HTTP timeout. Deliberately generous — the GPU-pool generate
+#: budget is the real deadline; this only reaps a wedged server. The first
+#: generate also cold-loads ~3 GB of GGUF.
+_GENERATE_TIMEOUT_S = 900.0
+
+
+# ── pure request/config builders (unit-tested, no I/O) ──────────────────────
+
+
+def build_server_config(
+    *, model_id: str, family: str, model_path: str, backend: str, port: int,
+) -> dict:
+    """``server.json`` dict for the managed ``audiocpp_server``.
+
+    ``lazy_load`` defers the ~3 GB GGUF load to the first generate;
+    ``max_loaded_models: 1`` bounds residency to the one model we serve.
+    """
+    return {
+        "host": "127.0.0.1",
+        "port": port,
+        "backend": backend,
+        "device": 0,
+        "threads": 1,
+        "lazy_load": True,
+        "max_loaded_models": 1,
+        "models": [
+            {
+                "id": model_id,
+                "family": family,
+                "path": model_path,
+                "task": "tts",
+                "mode": "offline",
+            }
+        ],
+    }
+
+
+def build_speech_payload(
+    *, model_id: str, text: str, ref_audio: Optional[str] = None,
+    ref_text: Optional[str] = None, instructions: Optional[str] = None,
+    guidance_scale: Optional[float] = None, seed: Optional[int] = None,
+) -> dict:
+    """``POST /v1/audio/speech`` JSON body.
+
+    Field spellings verified against ``app/server/runtime.cpp``
+    (``build_speech_request``): ``instructions`` (plural, OpenAI spelling)
+    feeds the ``instruction`` request option; ``reference_text`` and
+    ``guidance_scale``/``seed`` pass through top-level; ``voice_ref`` takes
+    a ``{"type": "path", ...}`` object so the reference stays on disk
+    (the 5 MiB base64 cap never bites). ``response_format: json`` returns
+    the WAV base64-in-JSON — one round trip, no binary framing.
+    """
+    payload: dict[str, Any] = {
+        "model": model_id,
+        "input": text,
+        "response_format": "json",
+    }
+    if instructions:
+        payload["instructions"] = instructions
+    if ref_audio:
+        payload["voice_ref"] = {"type": "path", "path": str(ref_audio)}
+        if ref_text:
+            payload["reference_text"] = ref_text
+    if guidance_scale is not None:
+        payload["guidance_scale"] = float(guidance_scale)
+    if seed is not None:
+        payload["seed"] = int(seed)
+    return payload
+
+
+def decode_speech_json(obj: dict) -> tuple[int, "object"]:
+    """``(sample_rate, mono float32 numpy)`` from a ``response_format=json``
+    speech body. Raises ``ValueError`` on a server error payload."""
+    if not isinstance(obj, dict):
+        raise ValueError(f"audio.cpp speech reply is not JSON: {obj!r:.120}")
+    if "audio" not in obj:
+        raise ValueError(f"audio.cpp speech failed: {obj.get('error', obj)!r:.300}")
+    import numpy as np
+    import soundfile as sf
+
+    wav_bytes = base64.b64decode(obj["audio"])
+    wav, sr = sf.read(io.BytesIO(wav_bytes), dtype="float32", always_2d=False)
+    wav = np.asarray(wav, dtype=np.float32)
+    if wav.ndim > 1:
+        wav = wav.mean(axis=-1)
+    return int(sr), wav
+
+
+# ── backend ─────────────────────────────────────────────────────────────────
+
+
+class AudioCPPBackend(TTSBackend):
+    """Breeze-TTS-2 through a parent-managed ``audiocpp_server``."""
+
+    id = ENGINE_ID
+    display_name = (
+        "audio.cpp · Breeze-TTS-2 (native GGUF, en+zh, clone+design; "
+        "weights research/non-commercial)"
+    )
+    supports_voice_design = True
+    applies_own_mastering = True  # model-decoded 24 kHz studio output
+    gpu_compat = ("cuda", "cpu")
+    runs_out_of_process = True
+    # Same marker SubprocessBackend sets: this engine lives in another OS
+    # process. Consumers only branch the matrix label and the self-test
+    # route (spawn-and-ping instead of in-process synth) — both correct
+    # here; nothing assumes the stdio protocol from it.
+    _is_subprocess_isolated = True
+    min_vram_gb = 4.0  # Q8_0 3B GGUF ≈ 3.2 GB weights + session workspace
+
+    _DEFAULT_SAMPLE_RATE = 24000  # Breeze-TTS-2 native rate
+
+    def __init__(self) -> None:
+        self._proc: Optional[subprocess.Popen] = None
+        self._port: Optional[int] = None
+        self._sr = self._DEFAULT_SAMPLE_RATE
+        self._lock = threading.RLock()
+        self._server_json: Optional[Path] = None
+
+    # ── availability ────────────────────────────────────────────────────
+
+    @classmethod
+    def is_available(cls) -> tuple[bool, str]:
+        from engines.audiocpp import bootstrap
+
+        if not bootstrap.is_installed():
+            slug_asset = bootstrap.default_asset()
+            if slug_asset is None:
+                return False, (
+                    "audio.cpp ships no prebuilt binary for this platform. "
+                    "Build from https://github.com/0xShug0/audio.cpp and set "
+                    f"{bootstrap.BIN_ENV}. See docs/engines/audio-cpp.md."
+                )
+            return False, (
+                "audiocpp_server not installed. Download "
+                f"https://github.com/{bootstrap.GH_REPO}/releases/download/"
+                f"{bootstrap.VERSION}/{slug_asset[0]}, extract it, and set "
+                f"{bootstrap.BIN_ENV} to the audiocpp_server binary "
+                f"(~3 GB Breeze-TTS-2 GGUF downloads on first generate). "
+                "See docs/engines/audio-cpp.md."
+            )
+        return True, "ready"
+
+    # ── TTSBackend protocol ─────────────────────────────────────────────
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sr
+
+    @property
+    def supported_languages(self) -> list[str]:
+        return ["en", "zh"]
+
+    def model_identity(self) -> Optional[str]:
+        from engines.audiocpp import bootstrap
+
+        return f"{bootstrap.FAMILY}/{bootstrap.package_filename()}"
+
+    # ── server lifecycle ────────────────────────────────────────────────
+
+    def _base_url(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    def _ensure_loaded(self) -> None:
+        """Spawn the server (once) and wait for ``/health``. Idempotent."""
+        with self._lock:
+            if self._proc is not None and self._proc.poll() is None:
+                return
+            self._proc = None  # stale handle — respawn below
+            from engines.audiocpp import bootstrap
+
+            binary = bootstrap.resolve_server_binary()
+            model_file = bootstrap.resolve_model_file()
+            backend = bootstrap.default_backend()
+            self._port = bootstrap.server_port()
+            config = build_server_config(
+                model_id=bootstrap.MODEL_ID,
+                family=bootstrap.FAMILY,
+                model_path=str(model_file),
+                backend=backend,
+                port=self._port,
+            )
+            from core.config import DATA_DIR
+
+            workdir = Path(str(DATA_DIR)) / "audiocpp"
+            workdir.mkdir(parents=True, exist_ok=True)
+            self._server_json = workdir / "server.json"
+            self._server_json.write_text(json.dumps(config, indent=2))
+            log_path = workdir / "server.log"
+            logger.info(
+                "audio.cpp: starting %s (backend=%s, port=%d, model=%s)",
+                binary, backend, self._port, model_file.name,
+            )
+            log_fh = open(log_path, "ab")
+            try:
+                self._proc = subprocess.Popen(
+                    [str(binary), "--config", str(self._server_json)],
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                    start_new_session=(os.name != "nt"),
+                )
+            except Exception:
+                log_fh.close()
+                raise
+            # Popen owns the fd now; the parent handle can close.
+            log_fh.close()
+            atexit.register(self._terminate_server)
+            self._wait_for_health()
+
+    def _wait_for_health(self) -> None:
+        assert self._proc is not None and self._port is not None
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        last_err = "unknown"
+        url = self._base_url() + "/health"
+        while time.monotonic() < deadline:
+            if self._proc.poll() is not None:
+                from engines.audiocpp.bootstrap import BACKEND_ENV
+
+                raise RuntimeError(
+                    "audiocpp_server exited during startup "
+                    f"(code {self._proc.returncode}). See the server log next "
+                    "to server.json under the app data audiocpp/ directory — "
+                    "common cause: requested backend not in this binary, or "
+                    "the port is taken. "
+                    f"Set {BACKEND_ENV} to cpu as a fallback."
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=5) as resp:
+                    if resp.status == 200:
+                        logger.info("audio.cpp: server healthy on %s", self._base_url())
+                        return
+                    last_err = f"HTTP {resp.status}"
+            except Exception as exc:  # noqa: BLE001 — still starting; retry
+                last_err = f"{type(exc).__name__}: {exc}"
+            time.sleep(1.0)
+        self._terminate_server()
+        raise RuntimeError(
+            f"audiocpp_server did not become healthy within "
+            f"{_HEALTH_TIMEOUT_S:.0f}s (last: {last_err})."
+        )
+
+    def _post_json(self, path: str, payload: dict, timeout: float) -> dict:
+        """POST JSON to the managed server, return the decoded JSON body."""
+        assert self._port is not None
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self._base_url() + path,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            raise RuntimeError(
+                f"audio.cpp {path} failed (HTTP {exc.code}): {detail}"
+            ) from exc
+
+    def _terminate_server(self) -> None:
+        proc, self._proc = self._proc, None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=15)
+        except Exception:  # noqa: BLE001 — kill as last resort, never raise
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    # ── generate ────────────────────────────────────────────────────────
+
+    def generate(self, text: str, **kw) -> "torch.Tensor":
+        import torch
+
+        if not text or not text.strip():
+            raise TTSInputError(
+                "audio.cpp: the input contains no speakable text — "
+                "send at least one word."
+            )
+        ref_audio = kw.get("ref_audio")
+        ref_text = kw.get("ref_text")
+        if ref_text and not ref_audio:
+            logger.info(
+                "audio.cpp: ref_text supplied without ref_audio; ignoring."
+            )
+            ref_text = None
+
+        # Voice design: our `description=` (no ref) and voice direction
+        # (`instruct=` + ref) both ride the server's `instructions` field —
+        # verified spelling against app/server/runtime.cpp.
+        instruct = kw.get("instruct") or kw.get("description") or None
+
+        language = kw.get("language")
+        if language and str(language).strip().lower() not in {
+            "auto", "en", "english", "zh", "chinese",
+        }:
+            logger.info(
+                "audio.cpp (Breeze-TTS-2) is en+zh only; ignoring "
+                "language=%r.", language,
+            )
+        if kw.get("speed", 1.0) != 1.0:
+            logger.info("audio.cpp: speed is not supported; ignoring.")
+
+        from engines.audiocpp import bootstrap
+
+        with self._lock:
+            self._ensure_loaded()
+            payload = build_speech_payload(
+                model_id=bootstrap.MODEL_ID,
+                text=text,
+                ref_audio=str(ref_audio) if ref_audio else None,
+                ref_text=ref_text,
+                instructions=instruct,
+                guidance_scale=kw.get("guidance_scale", 1.0),
+                seed=kw.get("seed"),
+            )
+            obj = self._post_json(
+                "/v1/audio/speech", payload, timeout=_GENERATE_TIMEOUT_S,
+            )
+        sr, wav_np = decode_speech_json(obj)
+        self._sr = sr
+        wav = torch.from_numpy(wav_np).float()
+        if wav.ndim == 0:
+            raise RuntimeError("audio.cpp produced empty audio")
+        return wav.unsqueeze(0)
+
+    # ── lifecycle ───────────────────────────────────────────────────────
+
+    def unload(self) -> None:
+        """Free the model server-side, then stop it. Idempotent."""
+        with self._lock:
+            if self._port is not None and self._proc is not None \
+                    and self._proc.poll() is None:
+                try:
+                    self._post_json("/v1/tasks/unload_all_models", {}, timeout=30)
+                except Exception as exc:  # noqa: BLE001 — best effort
+                    logger.warning("audio.cpp: server unload failed: %s", exc)
+            self._port = None
+            self._terminate_server()
+        super().unload()
+
+
+__all__ = [
+    "ENGINE_ID",
+    "AudioCPPBackend",
+    "build_server_config",
+    "build_speech_payload",
+    "decode_speech_json",
+]

--- a/backend/engines/audiocpp/__init__.py
+++ b/backend/engines/audiocpp/__init__.py
@@ -155,14 +155,16 @@ class AudioCPPBackend(TTSBackend):
     )
     supports_voice_design = True
     applies_own_mastering = True  # model-decoded 24 kHz studio output
-    gpu_compat = ("cuda", "cpu")
+    # audio.cpp maps our accelerator families to CUDA, HIP, Metal, or Vulkan.
+    # Intel GPUs use Vulkan; NPUs have no supported backend.
+    gpu_compat = ("cuda", "rocm", "mps", "xpu", "cpu")
     runs_out_of_process = True
     # Same marker SubprocessBackend sets: this engine lives in another OS
     # process. Consumers only branch the matrix label and the self-test
     # route (spawn-and-ping instead of in-process synth) — both correct
     # here; nothing assumes the stdio protocol from it.
     _is_subprocess_isolated = True
-    min_vram_gb = 4.0  # Q8_0 3B GGUF ≈ 3.2 GB weights + session workspace
+    min_vram_gb = 6.0  # 4.73 GiB Q8_0 file plus graph/session workspace
 
     _DEFAULT_SAMPLE_RATE = 24000  # Breeze-TTS-2 native rate
 
@@ -282,7 +284,9 @@ class AudioCPPBackend(TTSBackend):
                     f"Set {BACKEND_ENV} to cpu as a fallback."
                 )
             try:
-                with urllib.request.urlopen(url, timeout=5) as resp:
+                # ``url`` is always the hard-coded loopback host plus a
+                # validated integer port; arbitrary schemes are impossible.
+                with urllib.request.urlopen(url, timeout=5) as resp:  # nosec B310
                     if resp.status == 200:
                         logger.info("audio.cpp: server healthy on %s", self._base_url())
                         return
@@ -307,7 +311,9 @@ class AudioCPPBackend(TTSBackend):
             method="POST",
         )
         try:
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            # ``req`` targets only ``_base_url()`` (127.0.0.1 + validated
+            # integer port), never a caller-provided URL.
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")[:500]

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -23,6 +23,7 @@ VoiceStudio never downloads executable code for this engine.
 """
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import platform
@@ -224,22 +225,37 @@ def _materialize_gguf_cache_path(model_file: Path) -> Path:
     if model_file.suffix.lower() != ".gguf":
         raise RuntimeError(f"audio.cpp model must be a .gguf file: {model_file}")
 
+    def _link(alias: Path) -> Path:
+        try:
+            os.link(resolved, alias)
+        except FileExistsError:
+            if not os.path.samefile(resolved, alias):
+                raise RuntimeError(
+                    f"audio.cpp model alias points at a different file: {alias}"
+                ) from None
+        return alias
+
     alias = model_file.with_name(
         f".{model_file.stem}-{HF_MODEL_REVISION[:12]}.audiocpp.gguf"
     )
     try:
-        os.link(resolved, alias)
-    except FileExistsError:
-        if not os.path.samefile(resolved, alias):
-            raise RuntimeError(
-                f"audio.cpp model alias points at a different file: {alias}"
-            ) from None
+        return _link(alias)
     except OSError as exc:
+        if exc.errno == errno.EXDEV:
+            # An explicit symlink may live on a different filesystem from its
+            # target. Put the suffix-preserving hard link beside the resolved
+            # file so no multi-gigabyte copy is needed.
+            target_alias = resolved.with_name(
+                f".{resolved.name}-{HF_MODEL_REVISION[:12]}.audiocpp.gguf"
+            )
+            try:
+                return _link(target_alias)
+            except OSError as target_exc:
+                exc = target_exc
         raise RuntimeError(
             "audio.cpp cannot materialize the Hugging Face cache symlink as "
             f"a .gguf hard link: {exc}"
         ) from exc
-    return alias
 
 
 def _download_progress_class() -> type:

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -226,14 +226,24 @@ def _materialize_gguf_cache_path(model_file: Path) -> Path:
         raise RuntimeError(f"audio.cpp model must be a .gguf file: {model_file}")
 
     def _link(alias: Path) -> Path:
-        try:
-            os.link(resolved, alias)
-        except FileExistsError:
-            if not os.path.samefile(resolved, alias):
+        for attempt in range(2):
+            try:
+                os.link(resolved, alias)
+            except FileExistsError:
+                if (
+                    not alias.is_symlink()
+                    and alias.is_file()
+                    and os.path.samefile(resolved, alias)
+                ):
+                    return alias
+                if attempt == 0 and alias.is_symlink():
+                    alias.unlink()
+                    continue
                 raise RuntimeError(
                     f"audio.cpp model alias points at a different file: {alias}"
                 ) from None
-        return alias
+            return alias
+        raise RuntimeError(f"audio.cpp model alias could not be created: {alias}")
 
     alias = model_file.with_name(
         f".{model_file.stem}-{HF_MODEL_REVISION[:12]}.audiocpp.gguf"

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -1,0 +1,362 @@
+"""audio.cpp binary probe + model resolution.
+
+audio.cpp (0xShug0/audio.cpp) is a pure-C++ ggml inference engine with
+prebuilt release binaries — no Python venv, no ``transformers`` pin, so
+none of the dependency-isolation machinery in ``engines._venv_probe`` or
+``services.subprocess_backend`` applies. The parent instead:
+
+1. locates ``audiocpp_server`` (env var, user dir, or this package's
+   ``bin/`` populated by :func:`install_default_asset`), and
+2. resolves the GGUF model file (explicit path, or a first-use download
+   from ``audio-cpp/audio.cpp-gguf`` into the shared HF cache).
+
+Probe order for the server binary (existing installs win, zero migration):
+
+    1. ``${OMNIVOICE_AUDIOCPP_BIN}`` — absolute path to the binary itself.
+    2. ``${OMNIVOICE_AUDIOCPP_DIR}/audiocpp_server[.exe]`` — a user-managed
+       install dir (e.g. an extracted release zip, or a self-built tree).
+    3. ``backend/engines/audiocpp/bin/audiocpp_server[.exe]`` — VoiceStudio's
+       own copy, populated by :func:`install_default_asset`.
+
+Security: release-asset SHA-256 pins are verified on every install
+(download → hash → compare → extract). ``is_installed()`` is a cheap
+file-existence check — no spawn, no network.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import platform
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("omnivoice.audiocpp.bootstrap")
+
+#: Pinned audio.cpp release. BreezeTTS-2 support landed in 0.7.2 — older
+#: binaries have no ``breeze_tts`` family, so the floor is also the pin.
+VERSION = "v0.7.2"
+
+#: GitHub repo serving the prebuilt binaries.
+GH_REPO = "0xShug0/audio.cpp"
+
+#: HuggingFace repo serving the GGUF model packages (not gated).
+HF_MODEL_REPO = "audio-cpp/audio.cpp-gguf"
+
+#: Model id used in the generated ``server.json`` and in speech requests.
+MODEL_ID = "breeze-tts-2"
+
+#: audio.cpp family name for BreezeTTS 2 (``--family`` / server ``family``).
+FAMILY = "breeze_tts"
+
+#: GGUF package directory inside :data:`HF_MODEL_REPO`.
+PACKAGE_DIR = "Breeze-TTS-2-GGUF"
+
+#: Default package (Q8_0, the upstream-recommended GGUF). ``bf16`` is
+#: available via ``OMNIVOICE_AUDIOCPP_PACKAGE``.
+DEFAULT_PACKAGE = "breeze-tts-2-q8_0.gguf"
+
+#: Env var pointing directly at the ``audiocpp_server`` binary.
+BIN_ENV = "OMNIVOICE_AUDIOCPP_BIN"
+
+#: Env var pointing at a directory containing ``audiocpp_server``.
+DIR_ENV = "OMNIVOICE_AUDIOCPP_DIR"
+
+#: Env var overriding the GGUF package filename (e.g. the bf16 package).
+PACKAGE_ENV = "OMNIVOICE_AUDIOCPP_PACKAGE"
+
+#: Env var overriding the server compute backend
+#: (``cuda`` | ``vulkan`` | ``metal`` | ``cpu``).
+BACKEND_ENV = "OMNIVOICE_AUDIOCPP_BACKEND"
+
+#: Env var overriding the release asset filename (power users, e.g. the
+#: Windows CUDA build — which additionally needs the matching cudart
+#: archive extracted next to the binary).
+ASSET_ENV = "OMNIVOICE_AUDIOCPP_ASSET"
+
+#: Env var overriding the loopback port the managed server binds.
+PORT_ENV = "OMNIVOICE_AUDIOCPP_PORT"
+
+#: Default loopback port. High and engine-specific to avoid clashing with
+#: the app itself or a user-run ``audiocpp_server`` (default 8080).
+DEFAULT_PORT = 17860
+
+#: This package's owned binary dir (probe 3).
+_PKG_BIN_DIR: Path = Path(__file__).parent / "bin"
+
+# (asset filename, sha256) per platform slug, from the v0.7.2 release.
+# No Linux-CUDA prebuilt exists upstream — Linux CUDA users self-build and
+# point OMNIVOICE_AUDIOCPP_BIN at their binary; the Vulkan prebuilt is the
+# default because it runs on NVIDIA/AMD/Intel GPUs with no cudart sidecar.
+# No linux-aarch64 prebuilt either — that platform is unavailable in v1.
+_ASSETS: dict[str, tuple[str, str]] = {
+    "windows-x64": (
+        "audio-v0.7.2-bin-windows-x64-vulkan.zip",
+        "15b8232eae740e21e507d87f827a89966de9451b085a45932d9e214e032962c1",
+    ),
+    "linux-x64": (
+        "audio-v0.7.2-bin-ubuntu-x64-vulkan.tar.gz",
+        "fee1f978cee76453cf17f00196554bc2ee294645739538af0726a143b6c20de9451b085a45932d9e214e032962c1",
+    ),
+    "darwin-arm64": (
+        "audio-v0.7.2-bin-macos-arm64-metal.tar.gz",
+        "c01e4f82971bedbe341697e63a9cebd5a5d1f72d5a9bcb51a3191f95ddab7a95",
+    ),
+    "darwin-x64": (
+        "audio-v0.7.2-bin-macos-x64-metal.tar.gz",
+        "3862270f33439077225324169313f727064f727305b54d8ce920244d75ddcc24",
+    ),
+}
+
+#: Binary filename per platform.
+_BINARY_NAMES = {"windows-x64": "audiocpp_server.exe"}
+
+
+def _platform_slug() -> str:
+    system = sys.platform
+    machine = platform.machine().lower()
+    if system == "win32":
+        return "windows-x64"
+    if system == "darwin":
+        return "darwin-arm64" if machine in ("arm64", "aarch64") else "darwin-x64"
+    if machine in ("x86_64", "amd64"):
+        return "linux-x64"
+    return f"linux-{machine}"
+
+
+def binary_name(slug: Optional[str] = None) -> str:
+    """``audiocpp_server`` filename for ``slug`` (``.exe`` on Windows)."""
+    return _BINARY_NAMES.get(slug or _platform_slug(), "audiocpp_server")
+
+
+def _probe_paths() -> list[Path]:
+    out: list[Path] = []
+    direct = os.environ.get(BIN_ENV, "").strip()
+    if direct:
+        out.append(Path(direct))
+    user_dir = os.environ.get(DIR_ENV, "").strip()
+    if user_dir:
+        out.append(Path(user_dir) / binary_name())
+    out.append(_PKG_BIN_DIR / binary_name())
+    return out
+
+
+def is_installed() -> bool:
+    """Cheap file-existence check for a usable server binary."""
+    return any(p.is_file() for p in _probe_paths())
+
+
+def resolve_server_binary() -> Path:
+    """Resolve the ``audiocpp_server`` binary. Raises ``RuntimeError`` with
+    install instructions when none is found."""
+    for cand in _probe_paths():
+        if cand.is_file():
+            return cand
+    slug = _platform_slug()
+    asset = _ASSETS.get(slug)
+    if asset is None:
+        raise RuntimeError(
+            f"audio.cpp ships no prebuilt binary for this platform ({slug}). "
+            "Build from https://github.com/0xShug0/audio.cpp and set "
+            f"{BIN_ENV} to your audiocpp_server binary. See "
+            "docs/engines/audio-cpp.md."
+        )
+    raise RuntimeError(
+        "audiocpp_server not found. Download "
+        f"https://github.com/{GH_REPO}/releases/download/{VERSION}/{asset[0]} "
+        f"({asset[1][:12]}…), extract it, and set {BIN_ENV} to the "
+        "audiocpp_server binary (or "
+        f"{DIR_ENV} to its directory). See docs/engines/audio-cpp.md."
+    )
+
+
+def invalidate() -> None:
+    """No-op cache hook — resolution is env + filesystem, nothing memoised.
+
+    Present so tests can treat this module like the other engine
+    bootstraps (``engines.dots_tts.bootstrap.invalidate``).
+    """
+
+
+def default_asset() -> Optional[tuple[str, str]]:
+    """``(filename, sha256)`` of the release asset for this host, or None
+    when upstream ships no prebuilt for it."""
+    return _ASSETS.get(_platform_slug())
+
+
+def default_backend() -> str:
+    """Compute backend for the managed server.
+
+    Env override wins; otherwise Metal on macOS, Vulkan on Windows/Linux
+    (matching the default prebuilt asset — the release matrix has no Linux
+    CUDA binary), CPU when nothing else applies.
+    """
+    override = os.environ.get(BACKEND_ENV, "").strip().lower()
+    if override:
+        return override
+    if sys.platform == "darwin":
+        return "metal"
+    if sys.platform == "win32" or sys.platform.startswith("linux"):
+        return "vulkan"
+    return "cpu"
+
+
+def server_port() -> int:
+    """Loopback port for the managed server (env override or default)."""
+    raw = os.environ.get(PORT_ENV, "").strip()
+    if raw:
+        try:
+            port = int(raw)
+            if 1 <= port <= 65535:
+                return port
+            logger.warning("Ignoring %s=%r: out of range.", PORT_ENV, raw)
+        except ValueError:
+            logger.warning("Ignoring %s=%r: not a number.", PORT_ENV, raw)
+    return DEFAULT_PORT
+
+
+def _download_url(asset: str) -> str:
+    return f"https://github.com/{GH_REPO}/releases/download/{VERSION}/{asset}"
+
+
+def install_default_asset(dest_dir: Optional[Path] = None) -> Path:
+    """Download + SHA-verify + extract the platform release asset into
+    ``dest_dir`` (default: this package's ``bin/``) and return the server
+    binary path. Explicit user action only — never called implicitly."""
+    slug = _platform_slug()
+    asset = _ASSETS.get(slug)
+    if asset is None:
+        raise RuntimeError(
+            f"audio.cpp ships no prebuilt binary for {slug}; build from "
+            f"https://github.com/{GH_REPO} and set {BIN_ENV} instead."
+        )
+    filename, want_sha = asset
+    target = Path(dest_dir) if dest_dir else _PKG_BIN_DIR
+    target.mkdir(parents=True, exist_ok=True)
+    logger.info("audio.cpp: downloading %s (%s)", _download_url(filename), slug)
+    with tempfile.NamedTemporaryFile(
+        prefix="audiocpp_", suffix=Path(filename).suffix, delete=False
+    ) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        urllib.request.urlretrieve(_download_url(filename), tmp_path)
+        digest = hashlib.sha256(tmp_path.read_bytes()).hexdigest()
+        if digest != want_sha:
+            raise RuntimeError(
+                f"audio.cpp asset SHA-256 mismatch for {filename}: "
+                f"got {digest}, want {want_sha}. Refusing to extract."
+            )
+        if filename.endswith(".zip"):
+            with zipfile.ZipFile(tmp_path) as zf:
+                zf.extractall(target)
+        else:
+            with tarfile.open(tmp_path, "r:gz") as tf:
+                tf.extractall(target, filter="data")
+    finally:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+    found = _locate_binary(target)
+    if found is None:
+        raise RuntimeError(
+            f"extracted {filename} but found no {binary_name()} under "
+            f"{target} — layout changed upstream; set {BIN_ENV} manually."
+        )
+    if os.name != "nt":
+        found.chmod(found.stat().st_mode | 0o111)
+    logger.info("audio.cpp: installed %s", found)
+    return found
+
+
+def _locate_binary(root: Path) -> Optional[Path]:
+    """Find the server binary under ``root`` (release zips nest it)."""
+    want = binary_name()
+    direct = root / want
+    if direct.is_file():
+        return direct
+    for cand in sorted(root.rglob(want)):
+        if cand.is_file():
+            return cand
+    return None
+
+
+def package_filename() -> str:
+    """GGUF package filename (env override or the Q8_0 default)."""
+    return os.environ.get(PACKAGE_ENV, "").strip() or DEFAULT_PACKAGE
+
+
+def resolve_model_file() -> Path:
+    """Resolve the Breeze-TTS-2 GGUF file, downloading it on first use.
+
+    An explicit ``OMNIVOICE_AUDIOCPP_MODEL`` path wins (file or directory
+    containing the package file). Otherwise the package file is fetched
+    from :data:`HF_MODEL_REPO` into the shared HF cache — resumable and
+    hash-verified by ``huggingface_hub``.
+    """
+    from services.tts_backend import _retry_once_with_fresh_hf_client
+
+    override = os.environ.get("OMNIVOICE_AUDIOCPP_MODEL", "").strip()
+    if override:
+        cand = Path(override)
+        if cand.is_file():
+            return cand
+        if cand.is_dir():
+            inner = cand / package_filename()
+            if inner.is_file():
+                return inner
+        raise RuntimeError(
+            f"OMNIVOICE_AUDIOCPP_MODEL={override} is not a GGUF file or a "
+            "directory containing one."
+        )
+
+    def _download() -> str:
+        from huggingface_hub import snapshot_download
+
+        return snapshot_download(
+            repo_id=HF_MODEL_REPO,
+            allow_patterns=[f"{PACKAGE_DIR}/{package_filename()}"],
+        )
+
+    cached = Path(
+        _retry_once_with_fresh_hf_client(_download, "audio.cpp Breeze-TTS-2")
+    )
+    model_file = cached / PACKAGE_DIR / package_filename()
+    if not model_file.is_file():
+        raise RuntimeError(
+            f"Breeze-TTS-2 package {package_filename()} missing after "
+            f"download from {HF_MODEL_REPO} — layout changed upstream."
+        )
+    return model_file
+
+
+__all__ = [
+    "BACKEND_ENV",
+    "BIN_ENV",
+    "DEFAULT_PACKAGE",
+    "DEFAULT_PORT",
+    "DIR_ENV",
+    "FAMILY",
+    "HF_MODEL_REPO",
+    "MODEL_ID",
+    "PACKAGE_DIR",
+    "PACKAGE_ENV",
+    "PORT_ENV",
+    "VERSION",
+    "binary_name",
+    "default_asset",
+    "default_backend",
+    "install_default_asset",
+    "invalidate",
+    "is_installed",
+    "package_filename",
+    "resolve_model_file",
+    "resolve_server_binary",
+    "server_port",
+]

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -28,7 +28,6 @@ import logging
 import os
 import platform
 import sys
-import threading
 from pathlib import Path
 
 logger = logging.getLogger("omnivoice.audiocpp.bootstrap")
@@ -268,39 +267,14 @@ def _materialize_gguf_cache_path(model_file: Path) -> Path:
         ) from exc
 
 
-def _download_progress_class() -> type:
-    """Return a per-download tqdm class that heartbeats the owning job."""
-    from services.model_manager import report_model_load_activity
-    from utils import hf_progress
-
-    owner_ident = threading.get_ident()
-    hf_progress.install()
-    base = hf_progress.tracked_tqdm_class()
-    if base is None:
-        from huggingface_hub.utils.tqdm import tqdm as base
-
-    class ModelDownloadProgress(base):
-        def update(self, n=1):
-            report_model_load_activity(owner_ident)
-            return super().update(n)
-
-        def display(self, msg=None, pos=None):
-            report_model_load_activity(owner_ident)
-            return super().display(msg=msg, pos=pos)
-
-    return ModelDownloadProgress
-
-
 def resolve_model_file() -> Path:
-    """Resolve the Breeze-TTS-2 GGUF file, downloading it on first use.
+    """Resolve an explicitly installed Breeze-TTS-2 GGUF file.
 
     An explicit ``OMNIVOICE_AUDIOCPP_MODEL`` path wins (file or directory
-    containing the package file). Otherwise the package file is fetched
-    from :data:`HF_MODEL_REPO` into the shared HF cache — resumable and
-    hash-verified by ``huggingface_hub``.
+    containing the package file). Otherwise only the local Hugging Face cache
+    is inspected. Downloads must be started explicitly from Model Catalogue →
+    Models, so generation can never silently transfer the 4.73 GiB package.
     """
-    from services.tts_backend import _retry_once_with_fresh_hf_client
-
     override = os.environ.get("OMNIVOICE_AUDIOCPP_MODEL", "").strip()
     if override:
         cand = Path(override)
@@ -315,28 +289,31 @@ def resolve_model_file() -> Path:
             "directory containing one."
         )
 
-    def _download() -> str:
-        from huggingface_hub import snapshot_download
-        from services.model_manager import report_model_load_activity
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.utils import LocalEntryNotFoundError
 
-        report_model_load_activity()
-        return snapshot_download(
-            repo_id=HF_MODEL_REPO,
-            # Full immutable commit SHA declared above; Bandit cannot follow
-            # the module constant through this nested callback.
-            revision=HF_MODEL_REVISION,  # nosec B615
-            allow_patterns=[f"{PACKAGE_DIR}/{package_filename()}"],
-            tqdm_class=_download_progress_class(),
+    try:
+        cached = Path(
+            snapshot_download(
+                repo_id=HF_MODEL_REPO,
+                # Full immutable commit SHA declared above; Bandit cannot follow
+                # the module constant through this call.
+                revision=HF_MODEL_REVISION,  # nosec B615
+                allow_patterns=[f"{PACKAGE_DIR}/{package_filename()}"],
+                local_files_only=True,
+            )
         )
-
-    cached = Path(
-        _retry_once_with_fresh_hf_client(_download, "audio.cpp Breeze-TTS-2")
-    )
+    except (LocalEntryNotFoundError, OSError) as exc:
+        raise RuntimeError(
+            "Breeze-TTS-2 is not installed. Install the audio.cpp Breeze-TTS-2 "
+            "model from Model Catalogue → Models, or set "
+            "OMNIVOICE_AUDIOCPP_MODEL to an existing GGUF file."
+        ) from exc
     model_file = cached / PACKAGE_DIR / package_filename()
     if not model_file.is_file():
         raise RuntimeError(
-            f"Breeze-TTS-2 package {package_filename()} missing after "
-            f"download from {HF_MODEL_REPO} — layout changed upstream."
+            f"Breeze-TTS-2 package {package_filename()} is not completely "
+            "installed. Reinstall it from Model Catalogue → Models."
         )
     return _materialize_gguf_cache_path(model_file)
 
@@ -354,7 +331,6 @@ __all__ = [
     "PACKAGE_ENV",
     "PORT_ENV",
     "VERSION",
-    "_download_progress_class",
     "_materialize_gguf_cache_path",
     "binary_name",
     "default_asset",

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -5,8 +5,8 @@ prebuilt release binaries — no Python venv, no ``transformers`` pin, so
 none of the dependency-isolation machinery in ``engines._venv_probe`` or
 ``services.subprocess_backend`` applies. The parent instead:
 
-1. locates ``audiocpp_server`` (env var, user dir, or this package's
-   ``bin/`` populated by :func:`install_default_asset`), and
+1. locates a user-installed ``audiocpp_server`` (env var, user dir, or this
+   package's ``bin/``), and
 2. resolves the GGUF model file (explicit path, or a first-use download
    from ``audio-cpp/audio.cpp-gguf`` into the shared HF cache).
 
@@ -15,26 +15,20 @@ Probe order for the server binary (existing installs win, zero migration):
     1. ``${OMNIVOICE_AUDIOCPP_BIN}`` — absolute path to the binary itself.
     2. ``${OMNIVOICE_AUDIOCPP_DIR}/audiocpp_server[.exe]`` — a user-managed
        install dir (e.g. an extracted release zip, or a self-built tree).
-    3. ``backend/engines/audiocpp/bin/audiocpp_server[.exe]`` — VoiceStudio's
-       own copy, populated by :func:`install_default_asset`.
+    3. ``backend/engines/audiocpp/bin/audiocpp_server[.exe]`` — an explicitly
+       installed local copy.
 
-Security: release-asset SHA-256 pins are verified on every install
-(download → hash → compare → extract). ``is_installed()`` is a cheap
-file-existence check — no spawn, no network.
+``is_installed()`` is a cheap file-existence check — no spawn, no network.
+VoiceStudio never downloads executable code for this engine.
 """
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import platform
 import sys
-import tarfile
-import tempfile
-import urllib.request
-import zipfile
+import threading
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger("omnivoice.audiocpp.bootstrap")
 
@@ -75,10 +69,6 @@ DIR_ENV = "OMNIVOICE_AUDIOCPP_DIR"
 #: Env var overriding the GGUF package filename (e.g. the bf16 package).
 PACKAGE_ENV = "OMNIVOICE_AUDIOCPP_PACKAGE"
 
-#: Env var overriding the server compute backend
-#: (``cuda`` | ``vulkan`` | ``metal`` | ``cpu``).
-BACKEND_ENV = "OMNIVOICE_AUDIOCPP_BACKEND"
-
 #: Env var overriding the loopback port the managed server binds.
 PORT_ENV = "OMNIVOICE_AUDIOCPP_PORT"
 
@@ -90,18 +80,18 @@ DEFAULT_PORT = 17860
 _PKG_BIN_DIR: Path = Path(__file__).parent / "bin"
 
 # (asset filename, sha256) per platform slug, from the v0.7.2 release.
-# No Linux-CUDA prebuilt exists upstream — Linux CUDA users self-build and
-# point OMNIVOICE_AUDIOCPP_BIN at their binary; the Vulkan prebuilt is the
-# default because it runs on NVIDIA/AMD/Intel GPUs with no cudart sidecar.
-# No linux-aarch64 prebuilt either — that platform is unavailable in v1.
+# VoiceStudio's first integration is CPU-only, so Windows and Linux use the
+# upstream CPU archives. Upstream publishes macOS binaries under the Metal
+# package name; those builds retain the CPU backend selected by VoiceStudio.
+# No linux-aarch64 prebuilt exists, so that platform is unavailable in v1.
 _ASSETS: dict[str, tuple[str, str]] = {
     "windows-x64": (
-        "audio-v0.7.2-bin-windows-x64-vulkan.zip",
-        "15b8232eae740e21e507d87f827a89966de9451b085a45932d9e214e032962c1",
+        "audio-v0.7.2-bin-windows-x64-cpu-portable.zip",
+        "0b1f4bd78c5226ee3fa0eb24d95d603a429439cdf5dab45872d44a87412dd8c1",
     ),
     "linux-x64": (
-        "audio-v0.7.2-bin-ubuntu-x64-vulkan.tar.gz",
-        "fee1f978cee76453cf17f00196554bc2ee294645739538af0726a143b6a69a23",
+        "audio-v0.7.2-bin-ubuntu-x64-cpu.tar.gz",
+        "6f5e43dd7b80e8ddf688ef84b411fadcd1f934d2c83963178bc4e2d9c4f07736",
     ),
     "darwin-arm64": (
         "audio-v0.7.2-bin-macos-arm64-metal.tar.gz",
@@ -129,7 +119,7 @@ def _platform_slug() -> str:
     return f"linux-{machine}"
 
 
-def binary_name(slug: Optional[str] = None) -> str:
+def binary_name(slug: str | None = None) -> str:
     """``audiocpp_server`` filename for ``slug`` (``.exe`` on Windows)."""
     return _BINARY_NAMES.get(slug or _platform_slug(), "audiocpp_server")
 
@@ -147,8 +137,12 @@ def _probe_paths() -> list[Path]:
 
 
 def is_installed() -> bool:
-    """Cheap file-existence check for a usable server binary."""
-    return any(p.is_file() for p in _probe_paths())
+    """Cheap precedence-aware check for a usable server binary."""
+    try:
+        resolve_server_binary()
+    except RuntimeError:
+        return False
+    return True
 
 
 def resolve_server_binary() -> Path:
@@ -156,7 +150,13 @@ def resolve_server_binary() -> Path:
     install instructions when none is found."""
     for cand in _probe_paths():
         if cand.is_file():
-            return cand
+            if os.name == "nt" or os.access(cand, os.X_OK):
+                return cand
+            raise RuntimeError(
+                "audiocpp_server is not executable. Run `chmod +x "
+                "audiocpp_server` on the configured binary, then restart "
+                "VoiceStudio. See docs/engines/audio-cpp.md."
+            )
     slug = _platform_slug()
     asset = _ASSETS.get(slug)
     if asset is None:
@@ -169,7 +169,7 @@ def resolve_server_binary() -> Path:
     raise RuntimeError(
         "audiocpp_server not found. Download "
         f"https://github.com/{GH_REPO}/releases/download/{VERSION}/{asset[0]} "
-        f"({asset[1][:12]}…), extract it, and set {BIN_ENV} to the "
+        f"(SHA-256 {asset[1]}), verify and extract it, and set {BIN_ENV} to the "
         "audiocpp_server binary (or "
         f"{DIR_ENV} to its directory). See docs/engines/audio-cpp.md."
     )
@@ -183,27 +183,10 @@ def invalidate() -> None:
     """
 
 
-def default_asset() -> Optional[tuple[str, str]]:
+def default_asset() -> tuple[str, str] | None:
     """``(filename, sha256)`` of the release asset for this host, or None
     when upstream ships no prebuilt for it."""
     return _ASSETS.get(_platform_slug())
-
-
-def default_backend() -> str:
-    """Compute backend for the managed server.
-
-    Env override wins; otherwise Metal on macOS, Vulkan on Windows/Linux
-    (matching the default prebuilt asset — the release matrix has no Linux
-    CUDA binary), CPU when nothing else applies.
-    """
-    override = os.environ.get(BACKEND_ENV, "").strip().lower()
-    if override:
-        return override
-    if sys.platform == "darwin":
-        return "metal"
-    if sys.platform == "win32" or sys.platform.startswith("linux"):
-        return "vulkan"
-    return "cpu"
 
 
 def server_port() -> int:
@@ -218,104 +201,6 @@ def server_port() -> int:
         except ValueError:
             logger.warning("Ignoring %s=%r: not a number.", PORT_ENV, raw)
     return DEFAULT_PORT
-
-
-def _download_url(asset: str) -> str:
-    return f"https://github.com/{GH_REPO}/releases/download/{VERSION}/{asset}"
-
-
-def _safe_archive_destination(root: Path, member_name: str) -> Path:
-    """Resolve one archive member below ``root`` or reject traversal."""
-    root = root.resolve()
-    destination = (root / member_name).resolve()
-    if destination != root and root not in destination.parents:
-        raise RuntimeError(f"unsafe audio.cpp archive member: {member_name!r}")
-    return destination
-
-
-def _extract_release_archive(archive: Path, filename: str, target: Path) -> None:
-    """Extract an upstream release without links, devices, or traversal."""
-    if filename.endswith(".zip"):
-        with zipfile.ZipFile(archive) as zf:
-            for member in zf.infolist():
-                _safe_archive_destination(target, member.filename)
-                # Unix symlinks are encoded in the upper mode bits.
-                if (member.external_attr >> 16) & 0o170000 == 0o120000:
-                    raise RuntimeError(
-                        f"unsafe audio.cpp archive symlink: {member.filename!r}"
-                    )
-            # Every member was validated for containment and link type above.
-            zf.extractall(target)  # nosec B202
-        return
-
-    with tarfile.open(archive, "r:gz") as tf:
-        members = tf.getmembers()
-        for member in members:
-            _safe_archive_destination(target, member.name)
-            if not (member.isfile() or member.isdir()):
-                raise RuntimeError(
-                    f"unsafe audio.cpp archive member type: {member.name!r}"
-                )
-        tf.extractall(target, members=members, filter="data")
-
-
-def install_default_asset(dest_dir: Optional[Path] = None) -> Path:
-    """Download + SHA-verify + extract the platform release asset into
-    ``dest_dir`` (default: this package's ``bin/``) and return the server
-    binary path. Explicit user action only — never called implicitly."""
-    slug = _platform_slug()
-    asset = _ASSETS.get(slug)
-    if asset is None:
-        raise RuntimeError(
-            f"audio.cpp ships no prebuilt binary for {slug}; build from "
-            f"https://github.com/{GH_REPO} and set {BIN_ENV} instead."
-        )
-    filename, want_sha = asset
-    target = Path(dest_dir) if dest_dir else _PKG_BIN_DIR
-    target.mkdir(parents=True, exist_ok=True)
-    logger.info("audio.cpp: downloading %s (%s)", _download_url(filename), slug)
-    with tempfile.NamedTemporaryFile(
-        prefix="audiocpp_", suffix=Path(filename).suffix, delete=False
-    ) as tmp:
-        tmp_path = Path(tmp.name)
-    try:
-        # URL is assembled only from pinned constants and an allow-listed
-        # release asset name selected above.
-        urllib.request.urlretrieve(_download_url(filename), tmp_path)  # nosec B310
-        digest = hashlib.sha256(tmp_path.read_bytes()).hexdigest()
-        if digest != want_sha:
-            raise RuntimeError(
-                f"audio.cpp asset SHA-256 mismatch for {filename}: "
-                f"got {digest}, want {want_sha}. Refusing to extract."
-            )
-        _extract_release_archive(tmp_path, filename, target)
-    finally:
-        try:
-            tmp_path.unlink()
-        except OSError as exc:
-            logger.debug("Could not remove temporary audio.cpp archive: %s", exc)
-    found = _locate_binary(target)
-    if found is None:
-        raise RuntimeError(
-            f"extracted {filename} but found no {binary_name()} under "
-            f"{target} — layout changed upstream; set {BIN_ENV} manually."
-        )
-    if os.name != "nt":
-        found.chmod(found.stat().st_mode | 0o111)
-    logger.info("audio.cpp: installed %s", found)
-    return found
-
-
-def _locate_binary(root: Path) -> Optional[Path]:
-    """Find the server binary under ``root`` (release zips nest it)."""
-    want = binary_name()
-    direct = root / want
-    if direct.is_file():
-        return direct
-    for cand in sorted(root.rglob(want)):
-        if cand.is_file():
-            return cand
-    return None
 
 
 def package_filename() -> str:
@@ -357,6 +242,29 @@ def _materialize_gguf_cache_path(model_file: Path) -> Path:
     return alias
 
 
+def _download_progress_class() -> type:
+    """Return a per-download tqdm class that heartbeats the owning job."""
+    from services.model_manager import report_model_load_activity
+    from utils import hf_progress
+
+    owner_ident = threading.get_ident()
+    hf_progress.install()
+    base = hf_progress.tracked_tqdm_class()
+    if base is None:
+        from huggingface_hub.utils.tqdm import tqdm as base
+
+    class ModelDownloadProgress(base):
+        def update(self, n=1):
+            report_model_load_activity(owner_ident)
+            return super().update(n)
+
+        def display(self, msg=None, pos=None):
+            report_model_load_activity(owner_ident)
+            return super().display(msg=msg, pos=pos)
+
+    return ModelDownloadProgress
+
+
 def resolve_model_file() -> Path:
     """Resolve the Breeze-TTS-2 GGUF file, downloading it on first use.
 
@@ -371,11 +279,11 @@ def resolve_model_file() -> Path:
     if override:
         cand = Path(override)
         if cand.is_file():
-            return cand
+            return _materialize_gguf_cache_path(cand)
         if cand.is_dir():
             inner = cand / package_filename()
             if inner.is_file():
-                return inner
+                return _materialize_gguf_cache_path(inner)
         raise RuntimeError(
             f"OMNIVOICE_AUDIOCPP_MODEL={override} is not a GGUF file or a "
             "directory containing one."
@@ -383,13 +291,16 @@ def resolve_model_file() -> Path:
 
     def _download() -> str:
         from huggingface_hub import snapshot_download
+        from services.model_manager import report_model_load_activity
 
+        report_model_load_activity()
         return snapshot_download(
             repo_id=HF_MODEL_REPO,
             # Full immutable commit SHA declared above; Bandit cannot follow
             # the module constant through this nested callback.
             revision=HF_MODEL_REVISION,  # nosec B615
             allow_patterns=[f"{PACKAGE_DIR}/{package_filename()}"],
+            tqdm_class=_download_progress_class(),
         )
 
     cached = Path(
@@ -405,7 +316,6 @@ def resolve_model_file() -> Path:
 
 
 __all__ = [
-    "BACKEND_ENV",
     "BIN_ENV",
     "DEFAULT_PACKAGE",
     "DEFAULT_PORT",
@@ -418,13 +328,12 @@ __all__ = [
     "PACKAGE_ENV",
     "PORT_ENV",
     "VERSION",
+    "_download_progress_class",
+    "_materialize_gguf_cache_path",
     "binary_name",
     "default_asset",
-    "default_backend",
-    "install_default_asset",
     "invalidate",
     "is_installed",
-    "_materialize_gguf_cache_path",
     "package_filename",
     "resolve_model_file",
     "resolve_server_binary",

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -49,6 +49,11 @@ GH_REPO = "0xShug0/audio.cpp"
 #: HuggingFace repo serving the GGUF model packages (not gated).
 HF_MODEL_REPO = "audio-cpp/audio.cpp-gguf"
 
+# Immutable repository revision used for the v0.7.2 Breeze-TTS-2 package.
+# Pinning prevents a later upstream file replacement from silently changing
+# the model exercised by this backend.
+HF_MODEL_REVISION = "dc6fecccc2b0c6bdda0a8b2f38fa61394fee0b9c"
+
 #: Model id used in the generated ``server.json`` and in speech requests.
 MODEL_ID = "breeze-tts-2"
 
@@ -102,7 +107,7 @@ _ASSETS: dict[str, tuple[str, str]] = {
     ),
     "linux-x64": (
         "audio-v0.7.2-bin-ubuntu-x64-vulkan.tar.gz",
-        "fee1f978cee76453cf17f00196554bc2ee294645739538af0726a143b6c20de9451b085a45932d9e214e032962c1",
+        "fee1f978cee76453cf17f00196554bc2ee294645739538af0726a143b6a69a23",
     ),
     "darwin-arm64": (
         "audio-v0.7.2-bin-macos-arm64-metal.tar.gz",
@@ -225,6 +230,41 @@ def _download_url(asset: str) -> str:
     return f"https://github.com/{GH_REPO}/releases/download/{VERSION}/{asset}"
 
 
+def _safe_archive_destination(root: Path, member_name: str) -> Path:
+    """Resolve one archive member below ``root`` or reject traversal."""
+    root = root.resolve()
+    destination = (root / member_name).resolve()
+    if destination != root and root not in destination.parents:
+        raise RuntimeError(f"unsafe audio.cpp archive member: {member_name!r}")
+    return destination
+
+
+def _extract_release_archive(archive: Path, filename: str, target: Path) -> None:
+    """Extract an upstream release without links, devices, or traversal."""
+    if filename.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zf:
+            for member in zf.infolist():
+                _safe_archive_destination(target, member.filename)
+                # Unix symlinks are encoded in the upper mode bits.
+                if (member.external_attr >> 16) & 0o170000 == 0o120000:
+                    raise RuntimeError(
+                        f"unsafe audio.cpp archive symlink: {member.filename!r}"
+                    )
+            # Every member was validated for containment and link type above.
+            zf.extractall(target)  # nosec B202
+        return
+
+    with tarfile.open(archive, "r:gz") as tf:
+        members = tf.getmembers()
+        for member in members:
+            _safe_archive_destination(target, member.name)
+            if not (member.isfile() or member.isdir()):
+                raise RuntimeError(
+                    f"unsafe audio.cpp archive member type: {member.name!r}"
+                )
+        tf.extractall(target, members=members, filter="data")
+
+
 def install_default_asset(dest_dir: Optional[Path] = None) -> Path:
     """Download + SHA-verify + extract the platform release asset into
     ``dest_dir`` (default: this package's ``bin/``) and return the server
@@ -245,19 +285,16 @@ def install_default_asset(dest_dir: Optional[Path] = None) -> Path:
     ) as tmp:
         tmp_path = Path(tmp.name)
     try:
-        urllib.request.urlretrieve(_download_url(filename), tmp_path)
+        # URL is assembled only from pinned constants and an allow-listed
+        # release asset name selected above.
+        urllib.request.urlretrieve(_download_url(filename), tmp_path)  # nosec B310
         digest = hashlib.sha256(tmp_path.read_bytes()).hexdigest()
         if digest != want_sha:
             raise RuntimeError(
                 f"audio.cpp asset SHA-256 mismatch for {filename}: "
                 f"got {digest}, want {want_sha}. Refusing to extract."
             )
-        if filename.endswith(".zip"):
-            with zipfile.ZipFile(tmp_path) as zf:
-                zf.extractall(target)
-        else:
-            with tarfile.open(tmp_path, "r:gz") as tf:
-                tf.extractall(target, filter="data")
+        _extract_release_archive(tmp_path, filename, target)
     finally:
         try:
             tmp_path.unlink()
@@ -292,6 +329,40 @@ def package_filename() -> str:
     return os.environ.get(PACKAGE_ENV, "").strip() or DEFAULT_PACKAGE
 
 
+def _materialize_gguf_cache_path(model_file: Path) -> Path:
+    """Return a real ``.gguf`` path when the HF snapshot is a symlink.
+
+    audio.cpp canonicalizes model paths before inspecting the suffix. The
+    Hugging Face cache points the friendly ``.gguf`` snapshot name at an
+    extensionless content-addressed blob, so passing that symlink makes the
+    server reject a valid model. A hard link beside the snapshot keeps the
+    required suffix without copying a multi-gigabyte model or escaping the
+    snapshot's cleanup lifecycle.
+    """
+    resolved = model_file.resolve()
+    if resolved.suffix.lower() == ".gguf":
+        return model_file
+    if model_file.suffix.lower() != ".gguf":
+        raise RuntimeError(f"audio.cpp model must be a .gguf file: {model_file}")
+
+    alias = model_file.with_name(
+        f".{model_file.stem}-{HF_MODEL_REVISION[:12]}.audiocpp.gguf"
+    )
+    try:
+        os.link(resolved, alias)
+    except FileExistsError:
+        if not os.path.samefile(resolved, alias):
+            raise RuntimeError(
+                f"audio.cpp model alias points at a different file: {alias}"
+            ) from None
+    except OSError as exc:
+        raise RuntimeError(
+            "audio.cpp cannot materialize the Hugging Face cache symlink as "
+            f"a .gguf hard link: {exc}"
+        ) from exc
+    return alias
+
+
 def resolve_model_file() -> Path:
     """Resolve the Breeze-TTS-2 GGUF file, downloading it on first use.
 
@@ -321,6 +392,7 @@ def resolve_model_file() -> Path:
 
         return snapshot_download(
             repo_id=HF_MODEL_REPO,
+            revision=HF_MODEL_REVISION,
             allow_patterns=[f"{PACKAGE_DIR}/{package_filename()}"],
         )
 
@@ -333,7 +405,7 @@ def resolve_model_file() -> Path:
             f"Breeze-TTS-2 package {package_filename()} missing after "
             f"download from {HF_MODEL_REPO} — layout changed upstream."
         )
-    return model_file
+    return _materialize_gguf_cache_path(model_file)
 
 
 __all__ = [
@@ -344,6 +416,7 @@ __all__ = [
     "DIR_ENV",
     "FAMILY",
     "HF_MODEL_REPO",
+    "HF_MODEL_REVISION",
     "MODEL_ID",
     "PACKAGE_DIR",
     "PACKAGE_ENV",
@@ -355,6 +428,7 @@ __all__ = [
     "install_default_asset",
     "invalidate",
     "is_installed",
+    "_materialize_gguf_cache_path",
     "package_filename",
     "resolve_model_file",
     "resolve_server_binary",

--- a/backend/engines/audiocpp/bootstrap.py
+++ b/backend/engines/audiocpp/bootstrap.py
@@ -28,7 +28,6 @@ import hashlib
 import logging
 import os
 import platform
-import shutil
 import sys
 import tarfile
 import tempfile
@@ -79,11 +78,6 @@ PACKAGE_ENV = "OMNIVOICE_AUDIOCPP_PACKAGE"
 #: Env var overriding the server compute backend
 #: (``cuda`` | ``vulkan`` | ``metal`` | ``cpu``).
 BACKEND_ENV = "OMNIVOICE_AUDIOCPP_BACKEND"
-
-#: Env var overriding the release asset filename (power users, e.g. the
-#: Windows CUDA build — which additionally needs the matching cudart
-#: archive extracted next to the binary).
-ASSET_ENV = "OMNIVOICE_AUDIOCPP_ASSET"
 
 #: Env var overriding the loopback port the managed server binds.
 PORT_ENV = "OMNIVOICE_AUDIOCPP_PORT"
@@ -298,8 +292,8 @@ def install_default_asset(dest_dir: Optional[Path] = None) -> Path:
     finally:
         try:
             tmp_path.unlink()
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("Could not remove temporary audio.cpp archive: %s", exc)
     found = _locate_binary(target)
     if found is None:
         raise RuntimeError(
@@ -392,7 +386,9 @@ def resolve_model_file() -> Path:
 
         return snapshot_download(
             repo_id=HF_MODEL_REPO,
-            revision=HF_MODEL_REVISION,
+            # Full immutable commit SHA declared above; Bandit cannot follow
+            # the module constant through this nested callback.
+            revision=HF_MODEL_REVISION,  # nosec B615
             allow_patterns=[f"{PACKAGE_DIR}/{package_filename()}"],
         )
 

--- a/backend/services/engine_disk_usage.py
+++ b/backend/services/engine_disk_usage.py
@@ -33,10 +33,20 @@ _ESTIMATES: dict[str, dict] = {
         "destination": "hf_model_cache",
         "deduplication": None,
     },
+    "audiocpp": {
+        "package_download_bytes": None,
+        "unique_installed_bytes": None,
+        "potentially_shared_bytes": None,
+        "temporary_free_bytes": None,
+        "confidence": "estimated",
+        "destination": "hf_model_cache",
+        "deduplication": None,
+    },
 }
 _MODEL_REPOS = {
     "omnivoice": "k2-fsa/OmniVoice",
     "kittentts": "KittenML/kitten-tts-mini-0.8",
+    "audiocpp": "audio-cpp/audio.cpp-gguf",
 }
 
 

--- a/backend/services/hf_revisions.py
+++ b/backend/services/hf_revisions.py
@@ -15,6 +15,7 @@ _SHA = re.compile(r"[0-9a-f]{40}\Z")
 CURATED_REVISIONS: dict[str, str] = {
     "facebook/nllb-200-distilled-600M": "f8d333a098d19b4fd9a8b18f94170487ad3f821d",
     "k2-fsa/OmniVoice": "c5fdb5ccb189668d56333f77ba2629f4cd7535f4",
+    "audio-cpp/audio.cpp-gguf": "dc6fecccc2b0c6bdda0a8b2f38fa61394fee0b9c",
     "Systran/faster-whisper-large-v3": "edaa852ec7e145841d8ffdb056a99866b5f0a478",
     "mlx-community/whisper-large-v3-mlx": "49e6aa286ad60c14352c404340ded53710378a11",
     "mlx-community/whisper-large-v3-turbo": "a4aaeec0636e6fef84abdcbe3544cb2bf7e9f6fb",

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -470,17 +470,15 @@ GENERATE_PROGRESS_GRACE_S = float(
 _MODEL_LOAD_ACTIVITY: dict = {}
 
 
-def report_model_load_activity(thread_ident: "int | None" = None) -> None:
-    """Record that a pool job is making model-load progress.
+def report_model_load_activity() -> None:
+    """Record that the CURRENT THREAD's job is making model-load progress.
 
     Called by engine code that can prove liveness — e.g. SubprocessBackend
     each time a sidecar progress frame arrives during a cold load. The
     guarded waiter uses it to extend the execution deadline (bounded by
     MODEL_LOAD_EXTRA_TIMEOUT_S) instead of abandoning a healthy download.
-    Callers whose downloader emits progress from helper threads pass the
-    owning pool thread's ident explicitly.
     """
-    _MODEL_LOAD_ACTIVITY[thread_ident or threading.get_ident()] = (
+    _MODEL_LOAD_ACTIVITY[threading.get_ident()] = (
         time.monotonic(), MODEL_LOAD_HEARTBEAT_GRACE_S,
     )
 

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -470,15 +470,17 @@ GENERATE_PROGRESS_GRACE_S = float(
 _MODEL_LOAD_ACTIVITY: dict = {}
 
 
-def report_model_load_activity() -> None:
-    """Record that the CURRENT THREAD's job is making model-load progress.
+def report_model_load_activity(thread_ident: "int | None" = None) -> None:
+    """Record that a pool job is making model-load progress.
 
     Called by engine code that can prove liveness — e.g. SubprocessBackend
     each time a sidecar progress frame arrives during a cold load. The
     guarded waiter uses it to extend the execution deadline (bounded by
     MODEL_LOAD_EXTRA_TIMEOUT_S) instead of abandoning a healthy download.
+    Callers whose downloader emits progress from helper threads pass the
+    owning pool thread's ident explicitly.
     """
-    _MODEL_LOAD_ACTIVITY[threading.get_ident()] = (
+    _MODEL_LOAD_ACTIVITY[thread_ident or threading.get_ident()] = (
         time.monotonic(), MODEL_LOAD_HEARTBEAT_GRACE_S,
     )
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2346,7 +2346,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
     "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
-    "audiocpp":     "download audio.cpp v0.7.2 prebuilt + set OMNIVOICE_AUDIOCPP_BIN  (native GGUF server, no Python; Breeze-TTS-2 en+zh clone+design; ~3 GB GGUF on first use; weights research/non-commercial only)",
+    "audiocpp":     "download audio.cpp v0.7.2 prebuilt + set OMNIVOICE_AUDIOCPP_BIN  (native GGUF server, no Python; Breeze-TTS-2 en+zh clone+design; ~4.73 GiB GGUF on first use; weights research/non-commercial only)",
 }
 
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2346,7 +2346,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
     "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
-    "audiocpp":     "download audio.cpp v0.7.2 CPU prebuilt + set OMNIVOICE_AUDIOCPP_BIN  (native GGUF server, no Python; Breeze-TTS-2 en+zh clone+design; ~4.73 GiB GGUF on first use; weights research/non-commercial only)",
+    "audiocpp":     "download audio.cpp v0.7.2 CPU prebuilt + set OMNIVOICE_AUDIOCPP_BIN, then explicitly install Breeze-TTS-2 in Model Catalogue → Models  (native GGUF server, no Python; en+zh clone+design; ~4.73 GiB; weights research/non-commercial only)",
 }
 
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2346,7 +2346,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
     "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
-    "audiocpp":     "download audio.cpp v0.7.2 prebuilt + set OMNIVOICE_AUDIOCPP_BIN  (native GGUF server, no Python; Breeze-TTS-2 en+zh clone+design; ~4.73 GiB GGUF on first use; weights research/non-commercial only)",
+    "audiocpp":     "download audio.cpp v0.7.2 CPU prebuilt + set OMNIVOICE_AUDIOCPP_BIN  (native GGUF server, no Python; Breeze-TTS-2 en+zh clone+design; ~4.73 GiB GGUF on first use; weights research/non-commercial only)",
 }
 
 

--- a/backend/services/tts_backend.py
+++ b/backend/services/tts_backend.py
@@ -2235,6 +2235,13 @@ _LAZY_REGISTRY: dict[str, tuple[str, str]] = {
     # 2026-07-02 (CPU, Apple Silicon; 22.05 kHz output). Gated behind
     # OMNIVOICE_CONFUCIUS4_TTS_DIR so it's inert until enabled.
     "confucius4-tts": ("engines.confucius4", "Confucius4Backend"),
+    # audio.cpp (0xShug0/audio.cpp) — pure-C++ ggml runtime, no Python venv.
+    # v1 serves Breeze-TTS-2 (en+zh, clone+design) through a parent-managed
+    # audiocpp_server over loopback HTTP. Gated behind a server binary
+    # (OMNIVOICE_AUDIOCPP_BIN) so it's inert until enabled. Lazy for the
+    # same import-cycle reason as the entries above (engines.audiocpp
+    # imports services.tts_backend for TTSBackend).
+    "audiocpp": ("engines.audiocpp", "AudioCPPBackend"),
 }
 
 
@@ -2339,6 +2346,7 @@ _INSTALL_HINTS: dict[str, str] = {
     "moss-tts-v15":  "git clone OpenMOSS/MOSS-TTS + set OMNIVOICE_MOSS_TTS_V15_DIR  (own venv, transformers==5.0; 8B, ~16 GB weights; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
     "dots-tts":      "git clone rednote-hilab/dots.tts + set OMNIVOICE_DOTS_TTS_DIR  (own venv, transformers==4.57; 2B, ~9 GB weights; CUDA/CPU, Linux/macOS only — no Windows; Apache-2.0)",
     "confucius4-tts":"git clone netease-youdao/Confucius4-TTS + set OMNIVOICE_CONFUCIUS4_TTS_DIR  (own Python 3.10 venv; 14-lang cross-lingual zero-shot clone; ~5 GB weights auto-download; CUDA/ROCm/XPU/NPU/CPU, no MPS; Apache-2.0)",
+    "audiocpp":     "download audio.cpp v0.7.2 prebuilt + set OMNIVOICE_AUDIOCPP_BIN  (native GGUF server, no Python; Breeze-TTS-2 en+zh clone+design; ~3 GB GGUF on first use; weights research/non-commercial only)",
 }
 
 
@@ -2973,4 +2981,6 @@ def __getattr__(name: str):  # pragma: no cover - exercised via tests
         return _REGISTRY[name if name in _REGISTRY else None]
     if name == "IndexTTS2Backend":
         return _REGISTRY["indextts2"]
+    if name == "AudioCPPBackend":
+        return _REGISTRY["audiocpp"]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/docs/engine-acceptance.md
+++ b/docs/engine-acceptance.md
@@ -19,6 +19,7 @@ Every engine in the tree owns at least one job. A job has exactly one holder.
 | Fastest CPU render / lowest latency | *open — see #1306* |
 | Best Chinese/Japanese expressiveness | `cosyvoice`, `indextts2` |
 | CPU-realtime English, tiny footprint | `kittentts`, `supertonic3` |
+| Bilingual reference-free voice design and direction | `audiocpp` |
 | Best transcription accuracy | `whisperx`, `faster-whisper` |
 | Fastest Apple-Silicon transcription | `parakeet-mlx`, `mlx-whisper` |
 | Crash isolation for transcription | `faster-whisper-isolated` |
@@ -35,8 +36,11 @@ which is a property of the bar, not a judgement of the contributor.
    does not cover it. Latency, language, hardware envelope or quality tier —
    something a user would choose it *for*.
 2. **Licence clean for commercial use.** Model weights *and* code. No
-   research-only weights, no ambiguous provenance. This is the one that most
-   often ends a proposal, so check it first.
+   research-only weights or ambiguous provenance. The single approved
+   exception is `audiocpp` with Breeze-TTS-2 research/non-commercial weights,
+   approved by the owner on 2026-09-08 for its requested bilingual voice-design
+   and direction workflow. It remains opt-in and discloses the restriction
+   before selection and download; `@debpalash` is its named steward.
 3. **Every platform, or explicitly opt-in.** macOS (Apple Silicon and Intel),
    Windows, Linux. A CPU path is required — an engine that only runs on one
    accelerator is fine, but it must degrade rather than break, and a

--- a/docs/engines/README.md
+++ b/docs/engines/README.md
@@ -39,6 +39,7 @@ approval), [Windows](../install/windows.md), [Linux](../install/linux.md),
 | OmniVoice (subprocess) | [omnivoice-subprocess](omnivoice-subprocess.md) | CUDA · MPS · CPU | ✅ | opt-in pick, no install |
 | PocketTTS (Kyutai) | [pockettts](pockettts.md) | CPU (not Intel Mac) | ✅ | `uv sync --extra pockettts` + license |
 | Confucius4-TTS | [confucius4-tts](confucius4-tts.md) | CUDA · CPU | ✅ | clone + env var |
+| audio.cpp (Breeze-TTS-2) | [audio-cpp](audio-cpp.md) | GPU · CPU (Win/Linux/macOS) | ✅ + voice design | prebuilt binary + env var (weights research/non-commercial) |
 
 ## Speech-to-text
 

--- a/docs/engines/README.md
+++ b/docs/engines/README.md
@@ -39,7 +39,7 @@ approval), [Windows](../install/windows.md), [Linux](../install/linux.md),
 | OmniVoice (subprocess) | [omnivoice-subprocess](omnivoice-subprocess.md) | CUDA · MPS · CPU | ✅ | opt-in pick, no install |
 | PocketTTS (Kyutai) | [pockettts](pockettts.md) | CPU (not Intel Mac) | ✅ | `uv sync --extra pockettts` + license |
 | Confucius4-TTS | [confucius4-tts](confucius4-tts.md) | CUDA · CPU | ✅ | clone + env var |
-| audio.cpp (Breeze-TTS-2) | [audio-cpp](audio-cpp.md) | GPU · CPU (Win/Linux/macOS) | ✅ + voice design | prebuilt binary + env var (weights research/non-commercial) |
+| audio.cpp (Breeze-TTS-2) | [audio-cpp](audio-cpp.md) | CPU (Win/Linux/macOS) | ✅ + voice design | prebuilt binary + env var (weights research/non-commercial) |
 
 ## Speech-to-text
 

--- a/docs/engines/audio-cpp.md
+++ b/docs/engines/audio-cpp.md
@@ -65,9 +65,10 @@ The Q8_0 GGUF is approximately 4.73 GiB, plus CPU runtime memory.
    ```
 
    Alternatively set `OMNIVOICE_AUDIOCPP_DIR` to the directory containing it.
-3. Restart VoiceStudio. The ~4.73 GiB `breeze-tts-2-q8_0.gguf` downloads from
-   `audio-cpp/audio.cpp-gguf` (not gated) into the shared HF cache on first
-   generate — resumable, hash-verified.
+3. Restart VoiceStudio, open **Model Catalogue → Models**, find
+   **Breeze-TTS-2 Q8_0 for audio.cpp**, review its research/non-commercial
+   license note, and click **Install**. Generation never starts this ~4.73 GiB
+   download automatically.
 4. Pick `audiocpp` in **Model Catalogue → Engines**. The server starts
    lazily on first generate (`server.json` + `server.log` live under the app
    data `audiocpp/` directory).
@@ -89,7 +90,7 @@ All three go through the one speech endpoint — reference presence selects:
 |----------|---------|---------|
 | `OMNIVOICE_AUDIOCPP_BIN` | — | Absolute path to `audiocpp_server`. |
 | `OMNIVOICE_AUDIOCPP_DIR` | — | Directory containing `audiocpp_server`. |
-| `OMNIVOICE_AUDIOCPP_MODEL` | pinned auto-download | GGUF file or directory override. |
+| `OMNIVOICE_AUDIOCPP_MODEL` | Model Catalogue cache | GGUF file or directory override. |
 | `OMNIVOICE_AUDIOCPP_PACKAGE` | `breeze-tts-2-q8_0.gguf` | Package filename (`…-bf16.gguf` for full precision). |
 | `OMNIVOICE_AUDIOCPP_PORT` | `17860` | Loopback port. |
 
@@ -106,10 +107,11 @@ The managed loopback port may be taken. Check `server.log` next to
 `server.json` in the app data `audiocpp/` directory, or set a different
 `OMNIVOICE_AUDIOCPP_PORT` and restart VoiceStudio.
 
-### `Breeze-TTS-2 package ... missing after download`
+### `Breeze-TTS-2 ... not installed` or `package ... not completely installed`
 
-The upstream `audio.cpp-gguf` layout changed. File an issue with the
-package listing — the allow-list in `bootstrap.py` needs updating.
+Install the model from **Model Catalogue → Models**. If an interrupted install
+left it incomplete, use **Reinstall** there. If the error persists after a
+complete reinstall, file an issue with the package listing.
 
 ---
 

--- a/docs/engines/audio-cpp.md
+++ b/docs/engines/audio-cpp.md
@@ -82,7 +82,6 @@ All three go through the one speech endpoint — reference presence selects:
 | `OMNIVOICE_AUDIOCPP_PACKAGE` | `breeze-tts-2-q8_0.gguf` | Package filename (`…-bf16.gguf` for full precision). |
 | `OMNIVOICE_AUDIOCPP_BACKEND` | `metal` (macOS), `vulkan` (Win/Linux), `cpu` | Server compute backend. |
 | `OMNIVOICE_AUDIOCPP_PORT` | `17860` | Loopback port. |
-| `OMNIVOICE_AUDIOCPP_ASSET` | — | Reserved: release-asset override (not yet wired to auto-install). |
 
 ## Common errors
 

--- a/docs/engines/audio-cpp.md
+++ b/docs/engines/audio-cpp.md
@@ -1,8 +1,9 @@
 # VoiceStudio — audio.cpp Engine (Breeze-TTS-2)
 
 [audio.cpp](https://github.com/0xShug0/audio.cpp) is a pure-C++ ggml audio
-inference framework (prebuilt binaries for Windows/macOS/Linux, CUDA / HIP /
-Vulkan / Metal / CPU, no Python dependency). VoiceStudio drives its
+inference framework with prebuilt binaries for Windows, macOS, and Linux and
+no Python dependency. VoiceStudio's initial integration runs it on **CPU**.
+VoiceStudio drives its
 `audiocpp_server` over loopback HTTP — v1 serves the **`breeze_tts`**
 family: **Breeze-TTS-2** (BreezeBlue, 3B params, English + Chinese, voice
 clone + voice design + voice direction, 24 kHz).
@@ -24,26 +25,36 @@ clone + voice design + voice direction, 24 kHz).
 
 | Host | Binary | Compute |
 |---|---|---|
-| Windows x64 | prebuilt (Vulkan default; CUDA 12.4/13.3 opt-in) | GPU · CPU |
-| Linux x64 | prebuilt (Vulkan default) | GPU · CPU |
-| macOS arm64 / x64 | prebuilt (Metal) | GPU · CPU |
+| Windows x64 | portable CPU prebuilt | CPU |
+| Linux x64 | CPU prebuilt | CPU |
+| macOS arm64 / x64 | upstream macOS prebuilt | CPU |
 | Linux aarch64 | none upstream | unavailable in v1 |
 
-Notes:
-
-- Upstream ships **no Linux-CUDA prebuilt**. The Vulkan prebuilt runs on
-  NVIDIA/AMD/Intel GPUs; for maximum CUDA speed, self-build audio.cpp with
-  `ENGINE_ENABLE_CUDA=ON` and point `OMNIVOICE_AUDIOCPP_BIN` at it.
-- The Windows CUDA zips additionally need the matching `cudart` archive
-  extracted next to the binaries (upstream packaging, not VoiceStudio).
-- **VRAM:** Q8_0 GGUF is ≈ 4.73 GiB plus graph/session workspace; 6 GB+
-  GPU memory is required.
+GPU acceleration is outside this first integration. It will be enabled only
+after backend selection and physical-device routing are verified per platform.
+The Q8_0 GGUF is approximately 4.73 GiB, plus CPU runtime memory.
 
 ## Install
 
 1. Download the v0.7.2 prebuilt for your platform from
    [audio.cpp releases](https://github.com/0xShug0/audio.cpp/releases/tag/v0.7.2)
-   (CPU/Vulkan ≈ 20–70 MB; Windows CUDA ≈ 270 MB + cudart) and extract it.
+   (use the CPU archive on Windows or Linux) and extract it. VoiceStudio does
+   not download executable code for this engine. The Linux archive does not
+   preserve the executable bit, so run `chmod +x audiocpp_server` after
+   extracting it.
+
+   Verify the archive before extracting it. The pinned SHA-256 checksums are:
+
+   | Archive | SHA-256 |
+   |---|---|
+   | `audio-v0.7.2-bin-windows-x64-cpu-portable.zip` | `0b1f4bd78c5226ee3fa0eb24d95d603a429439cdf5dab45872d44a87412dd8c1` |
+   | `audio-v0.7.2-bin-ubuntu-x64-cpu.tar.gz` | `6f5e43dd7b80e8ddf688ef84b411fadcd1f934d2c83963178bc4e2d9c4f07736` |
+   | `audio-v0.7.2-bin-macos-arm64-metal.tar.gz` | `c01e4f82971bedbe341697e63a9cebd5a5d1f72d5a9bcb51a3191f95ddab7a95` |
+   | `audio-v0.7.2-bin-macos-x64-metal.tar.gz` | `3862270f33439077225324169313f727064f727305b54d8ce920244d75ddcc24` |
+
+   Run `sha256sum <archive>` on Linux, `shasum -a 256 <archive>` on macOS,
+   or `Get-FileHash <archive> -Algorithm SHA256` in PowerShell and compare the
+   complete result with the table.
 2. Set `OMNIVOICE_AUDIOCPP_BIN` to the `audiocpp_server` binary
    (`audiocpp_server.exe` on Windows):
 
@@ -80,7 +91,6 @@ All three go through the one speech endpoint — reference presence selects:
 | `OMNIVOICE_AUDIOCPP_DIR` | — | Directory containing `audiocpp_server`. |
 | `OMNIVOICE_AUDIOCPP_MODEL` | pinned auto-download | GGUF file or directory override. |
 | `OMNIVOICE_AUDIOCPP_PACKAGE` | `breeze-tts-2-q8_0.gguf` | Package filename (`…-bf16.gguf` for full precision). |
-| `OMNIVOICE_AUDIOCPP_BACKEND` | `metal` (macOS), `vulkan` (Win/Linux), `cpu` | Server compute backend. |
 | `OMNIVOICE_AUDIOCPP_PORT` | `17860` | Loopback port. |
 
 ## Common errors
@@ -92,9 +102,9 @@ exact release URL and SHA for your platform.
 
 ### `audiocpp_server exited during startup ...`
 
-Usually a backend the binary wasn't built with, or a taken port. Check the
-`server.log` next to `server.json` in the app data `audiocpp/` directory;
-set `OMNIVOICE_AUDIOCPP_BACKEND=cpu` as a fallback.
+The managed loopback port may be taken. Check `server.log` next to
+`server.json` in the app data `audiocpp/` directory, or set a different
+`OMNIVOICE_AUDIOCPP_PORT` and restart VoiceStudio.
 
 ### `Breeze-TTS-2 package ... missing after download`
 

--- a/docs/engines/audio-cpp.md
+++ b/docs/engines/audio-cpp.md
@@ -36,8 +36,8 @@ Notes:
   `ENGINE_ENABLE_CUDA=ON` and point `OMNIVOICE_AUDIOCPP_BIN` at it.
 - The Windows CUDA zips additionally need the matching `cudart` archive
   extracted next to the binaries (upstream packaging, not VoiceStudio).
-- **VRAM:** Q8_0 GGUF ≈ 3.2 GB weights + session workspace; 6 GB+ GPU
-  recommended, 4 GB minimum.
+- **VRAM:** Q8_0 GGUF is ≈ 4.73 GiB plus graph/session workspace; 6 GB+
+  GPU memory is required.
 
 ## Install
 
@@ -54,7 +54,7 @@ Notes:
    ```
 
    Alternatively set `OMNIVOICE_AUDIOCPP_DIR` to the directory containing it.
-3. Restart VoiceStudio. The ~3 GB `breeze-tts-2-q8_0.gguf` downloads from
+3. Restart VoiceStudio. The ~4.73 GiB `breeze-tts-2-q8_0.gguf` downloads from
    `audio-cpp/audio.cpp-gguf` (not gated) into the shared HF cache on first
    generate — resumable, hash-verified.
 4. Pick `audiocpp` in **Model Catalogue → Engines**. The server starts
@@ -78,7 +78,7 @@ All three go through the one speech endpoint — reference presence selects:
 |----------|---------|---------|
 | `OMNIVOICE_AUDIOCPP_BIN` | — | Absolute path to `audiocpp_server`. |
 | `OMNIVOICE_AUDIOCPP_DIR` | — | Directory containing `audiocpp_server`. |
-| `OMNIVOICE_AUDIOCPP_MODEL` | auto-download | GGUF file or directory override. |
+| `OMNIVOICE_AUDIOCPP_MODEL` | pinned auto-download | GGUF file or directory override. |
 | `OMNIVOICE_AUDIOCPP_PACKAGE` | `breeze-tts-2-q8_0.gguf` | Package filename (`…-bf16.gguf` for full precision). |
 | `OMNIVOICE_AUDIOCPP_BACKEND` | `metal` (macOS), `vulkan` (Win/Linux), `cpu` | Server compute backend. |
 | `OMNIVOICE_AUDIOCPP_PORT` | `17860` | Loopback port. |

--- a/docs/engines/audio-cpp.md
+++ b/docs/engines/audio-cpp.md
@@ -1,0 +1,109 @@
+# VoiceStudio — audio.cpp Engine (Breeze-TTS-2)
+
+[audio.cpp](https://github.com/0xShug0/audio.cpp) is a pure-C++ ggml audio
+inference framework (prebuilt binaries for Windows/macOS/Linux, CUDA / HIP /
+Vulkan / Metal / CPU, no Python dependency). VoiceStudio drives its
+`audiocpp_server` over loopback HTTP — v1 serves the **`breeze_tts`**
+family: **Breeze-TTS-2** (BreezeBlue, 3B params, English + Chinese, voice
+clone + voice design + voice direction, 24 kHz).
+
+> **Opt-in, and never a default.** Select `audiocpp` explicitly in **Model
+> Catalogue → Engines** (or `OMNIVOICE_TTS_BACKEND=audiocpp`).
+
+## License — read before enabling
+
+- **audio.cpp code:** Apache-2.0.
+- **Breeze-TTS-2 weights** (upstream `BreezeBlue/Breeze-TTS-2` and the
+  `audio-cpp/audio.cpp-gguf` GGUF repack): **research and non-commercial
+  use only** under the [BreezeBlue Research and Non-Commercial License](
+  https://huggingface.co/BreezeBlue/Breeze-TTS-2/blob/main/LICENSE).
+  Self-hosted outputs inherit the restriction; a BreezeBlue paid
+  subscription covers hosted-platform outputs only, not this engine.
+
+## Platform support
+
+| Host | Binary | Compute |
+|---|---|---|
+| Windows x64 | prebuilt (Vulkan default; CUDA 12.4/13.3 opt-in) | GPU · CPU |
+| Linux x64 | prebuilt (Vulkan default) | GPU · CPU |
+| macOS arm64 / x64 | prebuilt (Metal) | GPU · CPU |
+| Linux aarch64 | none upstream | unavailable in v1 |
+
+Notes:
+
+- Upstream ships **no Linux-CUDA prebuilt**. The Vulkan prebuilt runs on
+  NVIDIA/AMD/Intel GPUs; for maximum CUDA speed, self-build audio.cpp with
+  `ENGINE_ENABLE_CUDA=ON` and point `OMNIVOICE_AUDIOCPP_BIN` at it.
+- The Windows CUDA zips additionally need the matching `cudart` archive
+  extracted next to the binaries (upstream packaging, not VoiceStudio).
+- **VRAM:** Q8_0 GGUF ≈ 3.2 GB weights + session workspace; 6 GB+ GPU
+  recommended, 4 GB minimum.
+
+## Install
+
+1. Download the v0.7.2 prebuilt for your platform from
+   [audio.cpp releases](https://github.com/0xShug0/audio.cpp/releases/tag/v0.7.2)
+   (CPU/Vulkan ≈ 20–70 MB; Windows CUDA ≈ 270 MB + cudart) and extract it.
+2. Set `OMNIVOICE_AUDIOCPP_BIN` to the `audiocpp_server` binary
+   (`audiocpp_server.exe` on Windows):
+
+   ```bash
+   # macOS / Linux
+   echo 'export OMNIVOICE_AUDIOCPP_BIN=$HOME/apps/audio.cpp/audiocpp_server' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+   Alternatively set `OMNIVOICE_AUDIOCPP_DIR` to the directory containing it.
+3. Restart VoiceStudio. The ~3 GB `breeze-tts-2-q8_0.gguf` downloads from
+   `audio-cpp/audio.cpp-gguf` (not gated) into the shared HF cache on first
+   generate — resumable, hash-verified.
+4. Pick `audiocpp` in **Model Catalogue → Engines**. The server starts
+   lazily on first generate (`server.json` + `server.log` live under the app
+   data `audiocpp/` directory).
+
+## Voice modes
+
+All three go through the one speech endpoint — reference presence selects:
+
+- **Clone:** `ref_audio` + `ref_text` (exact transcript, as upstream).
+- **Direction:** `ref_audio` + `ref_text` + `instruct`
+  (e.g. "Speak slowly with a restrained, serious tone").
+- **Design:** `description` (or `instruct`) with no `ref_audio`
+  (e.g. "A warm, thoughtful young woman…"). Upstream strengthens
+  instruction-following with `guidance_scale` ≈ 4.
+
+## Optional env knobs
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OMNIVOICE_AUDIOCPP_BIN` | — | Absolute path to `audiocpp_server`. |
+| `OMNIVOICE_AUDIOCPP_DIR` | — | Directory containing `audiocpp_server`. |
+| `OMNIVOICE_AUDIOCPP_MODEL` | auto-download | GGUF file or directory override. |
+| `OMNIVOICE_AUDIOCPP_PACKAGE` | `breeze-tts-2-q8_0.gguf` | Package filename (`…-bf16.gguf` for full precision). |
+| `OMNIVOICE_AUDIOCPP_BACKEND` | `metal` (macOS), `vulkan` (Win/Linux), `cpu` | Server compute backend. |
+| `OMNIVOICE_AUDIOCPP_PORT` | `17860` | Loopback port. |
+| `OMNIVOICE_AUDIOCPP_ASSET` | — | Reserved: release-asset override (not yet wired to auto-install). |
+
+## Common errors
+
+### `audiocpp_server not found ...`
+
+The binary isn't installed. Follow **Install** — the message carries the
+exact release URL and SHA for your platform.
+
+### `audiocpp_server exited during startup ...`
+
+Usually a backend the binary wasn't built with, or a taken port. Check the
+`server.log` next to `server.json` in the app data `audiocpp/` directory;
+set `OMNIVOICE_AUDIOCPP_BACKEND=cpu` as a fallback.
+
+### `Breeze-TTS-2 package ... missing after download`
+
+The upstream `audio.cpp-gguf` layout changed. File an issue with the
+package listing — the allow-list in `bootstrap.py` needs updating.
+
+---
+
+audio.cpp runs as a managed native server (no Python venv, no
+`transformers` conflict). Only the downloaded GGUF counts toward
+[sidecar disk usage](disk-usage.md).

--- a/docs/features.yaml
+++ b/docs/features.yaml
@@ -60,6 +60,8 @@ tts_engines:
     readme: "**Confucius4-TTS**"
     doc: docs/engines/confucius4-tts.md
   - id: pockettts
+  - id: audiocpp
+    doc: docs/engines/audio-cpp.md
 
 # Same contract against backend/services/asr_backend.py _REGISTRY.
 asr_engines:

--- a/frontend/src/components/EngineCompatibilityMatrix.jsx
+++ b/frontend/src/components/EngineCompatibilityMatrix.jsx
@@ -186,9 +186,11 @@ const ROW_GRID =
 // groups instead of carrying the Settings panel's compressed tracks across a
 // large canvas. The wider action track also lets its controls wrap naturally
 // without clipping. Collapse earlier than the compact matrix because these
-// tracks deliberately have larger minimums.
+// tracks deliberately have larger minimums. `[&>*]:min-w-0` lets every cell
+// shrink below content size so mid-width shells squeeze instead of clipping;
+// phones (<=640px) stack via the `catalogue-row` @container tier in index.css.
 const CATALOGUE_ROW_GRID =
-  'catalogue-row-grid grid items-center gap-x-[16px] px-[16px] ' +
+  'catalogue-row-grid grid items-center gap-x-[16px] px-[16px] [&>*]:min-w-0 ' +
   'grid-cols-[minmax(300px,1.45fr)_128px_minmax(230px,1fr)_112px_minmax(292px,auto)] ' +
   '@max-[1230px]/catalogue-shell:grid-cols-[max-content_max-content_minmax(0,1fr)_max-content]';
 // Per-cell placement for the collapsed (narrow) layout.
@@ -1175,7 +1177,7 @@ export default function EngineCompatibilityMatrix({
                   <div
                     role="cell"
                     className={cn(
-                      'engine-matrix__cell engine-matrix__cell--gpu flex min-w-0 flex-col justify-center gap-[4px]',
+                      'engine-matrix__cell engine-matrix__cell--gpu flex min-w-0 max-w-full flex-col justify-center gap-[4px]',
                       catalogueLayout ? 'overflow-visible' : 'overflow-hidden',
                       cellNarrow.gpu,
                     )}
@@ -1280,7 +1282,7 @@ export default function EngineCompatibilityMatrix({
                   <div
                     role="cell"
                     className={cn(
-                      'engine-matrix__cell engine-matrix__cell--actions flex h-full max-h-full flex-wrap content-center items-center justify-end justify-self-end',
+                      'engine-matrix__cell engine-matrix__cell--actions flex h-full max-h-full min-w-0 max-w-full flex-wrap content-center items-center justify-end justify-self-end',
                       catalogueLayout
                         ? 'gap-[8px] overflow-visible py-[8px]'
                         : 'gap-[4px] overflow-hidden py-[4px]',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7179,3 +7179,43 @@ button.dub-stepper__action:focus-visible {
     max-height: 260px;
   }
 }
+
+/* Model Catalogue engines list — phone tier. The Tailwind collapse at 1230px
+   keeps four columns (status / gpu / isolation / actions side by side), which
+   still overflows ~360px shells: the actions cell alone is 250px+ of buttons
+   and the table clips horizontal overflow. Below 640px stack each catalogue
+   row into one column — identity first, meta chips next, actions last and
+   left-aligned so every control stays reachable without sideways scrolling.
+   Unlayered, so it wins over the layered grid utilities deterministically. */
+@container catalogue-shell (max-width: 640px) {
+  .engine-matrix__table .catalogue-row-grid.catalogue-row {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 8px;
+    align-items: start;
+    padding-inline: 12px;
+  }
+  .engine-matrix__table .catalogue-row > [role='cell'] {
+    grid-column: 1 / -1;
+    max-width: 100%;
+  }
+  .engine-matrix__table .catalogue-row > .engine-matrix__cell--name {
+    grid-row: 1;
+  }
+  .engine-matrix__table .catalogue-row > .engine-matrix__cell--status {
+    grid-row: 2;
+    justify-self: start;
+  }
+  .engine-matrix__table .catalogue-row > .engine-matrix__cell--gpu {
+    grid-row: 3;
+    justify-self: start;
+  }
+  .engine-matrix__table .catalogue-row > .engine-matrix__cell--isolation {
+    grid-row: 4;
+    justify-self: start;
+  }
+  .engine-matrix__table .catalogue-row > .engine-matrix__cell--actions {
+    grid-row: 5;
+    justify-self: stretch;
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/test/EngineCompatibilityMatrix.test.jsx
+++ b/frontend/src/test/EngineCompatibilityMatrix.test.jsx
@@ -1401,6 +1401,42 @@ describe('EngineCompatibilityMatrix', () => {
     }
   });
 
+  it('exposes the phone-tier stacking hooks so narrow shells never clip Catalogue rows', async () => {
+    // jsdom cannot evaluate @container queries, so this guards the contract
+    // the index.css phone tier depends on: every catalogue row carries the
+    // `catalogue-row` marker, each of the five cells carries its
+    // `engine-matrix__cell--*` modifier, the grid lets children shrink below
+    // content size, and the actions cell wraps instead of forcing overflow.
+    render(
+      <EngineCompatibilityMatrix
+        family="tts"
+        catalogueLayout
+        apiListEngines={vi.fn().mockResolvedValue(makeEnginesResponse())}
+        apiGetEngineHealth={vi.fn()}
+      />,
+    );
+    await screen.findByText('OmniVoice (test)');
+
+    for (const row of document.querySelectorAll('[data-engine-id]')) {
+      expect(row).toHaveClass('catalogue-row-grid');
+      expect(row).toHaveClass('catalogue-row');
+      expect(row.className).toContain('[&>*]:min-w-0');
+      for (const modifier of [
+        'engine-matrix__cell--name',
+        'engine-matrix__cell--status',
+        'engine-matrix__cell--gpu',
+        'engine-matrix__cell--isolation',
+        'engine-matrix__cell--actions',
+      ]) {
+        expect(row.querySelector(`.${modifier}`)).not.toBeNull();
+      }
+      const actions = row.querySelector('.engine-matrix__cell--actions');
+      expect(actions.className).toMatch(/\bflex-wrap\b/);
+      expect(actions).toHaveClass('min-w-0');
+      expect(actions).toHaveClass('max-w-full');
+    }
+  });
+
   it('header and every row share identical grid column tracks', async () => {
     const apiListEngines = vi.fn().mockResolvedValue(makeEnginesResponse());
     render(

--- a/frontend/src/test/backendCrash.http.test.ts
+++ b/frontend/src/test/backendCrash.http.test.ts
@@ -39,14 +39,15 @@ function okResponse(rec: LastRunCrashRecord | null, acknowledged = false) {
 
 describe('_adaptLastRunCrash — run-sentinel record → CrashMarker shape', () => {
   it('maps the record so the existing crash UI can render it', () => {
-    const marker = _adaptLastRunCrash(record(), false);
+    const sourceRecord = record();
+    const marker = _adaptLastRunCrash(sourceRecord, false);
     expect(marker.exit_code).toBeNull();
     expect(marker.signal).toBeNull();
     // describeCrashExit falls through to exit_desc on a null code+signal.
     expect(describeCrashExit(marker)).toBe('process ended uncleanly (previous run)');
     expect(marker.backend_version).toBe('0.3.23');
     expect(marker.uptime_s).toBe(510);
-    expect(marker.ts).toBe(record().detected_at);
+    expect(marker.ts).toBe(sourceRecord.detected_at);
     expect(marker.acknowledged).toBe(false);
     // The "stderr" evidence carries the last activity + the scrubbed log tail.
     expect(marker.last_stderr).toContain('last activity before the death: transcribe (dub)');

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -8,23 +8,33 @@ host env is scrubbed of ``OMNIVOICE_AUDIOCPP_*`` overrides per test.
 from __future__ import annotations
 
 import base64
-import string
+import importlib
 import io
+import json
 import os
-import tarfile
-import zipfile
+import stat
+import string
+import subprocess
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
-# tests/conftest.py prepends ./backend to sys.path so these resolve.
-from engines.audiocpp import (
-    AudioCPPBackend,
-    build_server_config,
-    build_speech_payload,
-    decode_speech_json,
-)
-from engines.audiocpp import bootstrap
-from services.tts_backend import TTSInputError, get_backend_class
+
+def _resolve_app_modules():
+    """Resolve application modules per test after isolation has been applied."""
+    audiocpp = importlib.import_module("engines.audiocpp")
+    return SimpleNamespace(
+        audiocpp=audiocpp,
+        bootstrap=importlib.import_module("engines.audiocpp.bootstrap"),
+        tts_backend=importlib.import_module("services.tts_backend"),
+    )
+
+
+@pytest.fixture
+def app_modules():
+    return _resolve_app_modules()
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +44,6 @@ def scrub_audiocpp_env(monkeypatch):
         "OMNIVOICE_AUDIOCPP_DIR",
         "OMNIVOICE_AUDIOCPP_MODEL",
         "OMNIVOICE_AUDIOCPP_PACKAGE",
-        "OMNIVOICE_AUDIOCPP_BACKEND",
         "OMNIVOICE_AUDIOCPP_PORT",
         "OMNIVOICE_AUDIOCPP_ASSET",
     ):
@@ -44,17 +53,18 @@ def scrub_audiocpp_env(monkeypatch):
 # ── server config builder ──────────────────────────────────────────────────
 
 
-def test_build_server_config_is_loopback_lazy_single_model():
-    cfg = build_server_config(
+def test_build_server_config_is_loopback_lazy_single_model(monkeypatch, app_modules):
+    monkeypatch.setattr(app_modules.audiocpp, "_cpu_thread_count", lambda: 16)
+    cfg = app_modules.audiocpp.build_server_config(
         model_id="breeze-tts-2",
         family="breeze_tts",
         model_path="/models/breeze-tts-2-q8_0.gguf",
-        backend="vulkan",
         port=17860,
     )
     assert cfg["host"] == "127.0.0.1"
     assert cfg["port"] == 17860
-    assert cfg["backend"] == "vulkan"
+    assert cfg["backend"] == "cpu"
+    assert cfg["threads"] == 16
     assert cfg["lazy_load"] is True
     assert cfg["max_loaded_models"] == 1
     assert cfg["models"] == [
@@ -71,8 +81,10 @@ def test_build_server_config_is_loopback_lazy_single_model():
 # ── speech payload builder ─────────────────────────────────────────────────
 
 
-def test_build_speech_payload_minimal_design():
-    payload = build_speech_payload(model_id="breeze-tts-2", text="Hello.")
+def test_build_speech_payload_minimal_design(app_modules):
+    payload = app_modules.audiocpp.build_speech_payload(
+        model_id="breeze-tts-2", text="Hello.",
+    )
     assert payload == {
         "model": "breeze-tts-2",
         "input": "Hello.",
@@ -80,8 +92,8 @@ def test_build_speech_payload_minimal_design():
     }
 
 
-def test_build_speech_payload_clone_maps_verified_fields():
-    payload = build_speech_payload(
+def test_build_speech_payload_clone_maps_verified_fields(app_modules):
+    payload = app_modules.audiocpp.build_speech_payload(
         model_id="breeze-tts-2",
         text="Read this.",
         ref_audio="/voices/alice.wav",
@@ -97,8 +109,8 @@ def test_build_speech_payload_clone_maps_verified_fields():
     assert payload["seed"] == 42
 
 
-def test_build_speech_payload_reference_text_needs_ref_audio():
-    payload = build_speech_payload(
+def test_build_speech_payload_reference_text_needs_ref_audio(app_modules):
+    payload = app_modules.audiocpp.build_speech_payload(
         model_id="breeze-tts-2", text="Hi.", ref_text="stray transcript",
     )
     assert "reference_text" not in payload
@@ -117,46 +129,51 @@ def _wav_json_bytes(mono, sr):
     return {"audio": base64.b64encode(buf.getvalue()).decode("ascii")}
 
 
-def test_decode_speech_json_roundtrip_mono():
+def test_decode_speech_json_roundtrip_mono(app_modules):
     obj = _wav_json_bytes([0.0, 0.5, -0.5, 0.25], 24000)
-    sr, wav = decode_speech_json(obj)
+    sr, wav = app_modules.audiocpp.decode_speech_json(obj)
     assert sr == 24000
     assert wav.ndim == 1 and len(wav) == 4
     assert abs(float(wav[1]) - 0.5) < 1e-4
 
 
-def test_decode_speech_json_downmixes_stereo():
+def test_decode_speech_json_downmixes_stereo(app_modules):
     import numpy as np
 
     stereo = np.array([[0.5, -0.5], [0.5, -0.5]], dtype=np.float32)
     obj = _wav_json_bytes(stereo, 24000)
-    sr, wav = decode_speech_json(obj)
+    sr, wav = app_modules.audiocpp.decode_speech_json(obj)
     assert sr == 24000
     assert wav.ndim == 1 and len(wav) == 2
 
 
-def test_decode_speech_json_error_payload_raises():
+def test_decode_speech_json_error_payload_raises(app_modules):
     with pytest.raises(ValueError, match="audio.cpp speech failed"):
-        decode_speech_json({"error": "model not loaded"})
+        app_modules.audiocpp.decode_speech_json({"error": "model not loaded"})
 
 
 # ── bootstrap resolution ───────────────────────────────────────────────────
 
 
-def test_binary_name_exe_on_windows_only():
+def test_binary_name_exe_on_windows_only(app_modules):
+    bootstrap = app_modules.bootstrap
     assert bootstrap.binary_name("windows-x64") == "audiocpp_server.exe"
     assert bootstrap.binary_name("linux-x64") == "audiocpp_server"
     assert bootstrap.binary_name("darwin-arm64") == "audiocpp_server"
 
 
-def test_release_assets_have_complete_sha256_pins():
+def test_release_assets_have_complete_sha256_pins(app_modules):
+    bootstrap = app_modules.bootstrap
     for filename, digest in bootstrap._ASSETS.values():
         assert filename
         assert len(digest) == 64
         assert set(digest) <= set(string.hexdigits)
+    assert "cpu-portable" in bootstrap._ASSETS["windows-x64"][0]
+    assert "ubuntu-x64-cpu" in bootstrap._ASSETS["linux-x64"][0]
 
 
-def test_server_port_default_and_overrides(monkeypatch):
+def test_server_port_default_and_overrides(monkeypatch, app_modules):
+    bootstrap = app_modules.bootstrap
     assert bootstrap.server_port() == bootstrap.DEFAULT_PORT
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PORT", "18081")
     assert bootstrap.server_port() == 18081
@@ -164,13 +181,15 @@ def test_server_port_default_and_overrides(monkeypatch):
     assert bootstrap.server_port() == bootstrap.DEFAULT_PORT
 
 
-def test_package_filename_default_and_override(monkeypatch):
+def test_package_filename_default_and_override(monkeypatch, app_modules):
+    bootstrap = app_modules.bootstrap
     assert bootstrap.package_filename() == bootstrap.DEFAULT_PACKAGE
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PACKAGE", "breeze-tts-2-bf16.gguf")
     assert bootstrap.package_filename() == "breeze-tts-2-bf16.gguf"
 
 
-def test_materialize_hf_symlink_keeps_gguf_suffix_without_copy(tmp_path):
+def test_materialize_hf_symlink_keeps_gguf_suffix_without_copy(tmp_path, app_modules):
+    bootstrap = app_modules.bootstrap
     blob = tmp_path / "content-addressed-blob"
     blob.write_bytes(b"GGUF test payload")
     snapshot = tmp_path / "breeze-tts-2-q8_0.gguf"
@@ -183,7 +202,8 @@ def test_materialize_hf_symlink_keeps_gguf_suffix_without_copy(tmp_path):
     assert os.path.samefile(materialized, blob)
 
 
-def test_materialize_rejects_extensionless_model(tmp_path):
+def test_materialize_rejects_extensionless_model(tmp_path, app_modules):
+    bootstrap = app_modules.bootstrap
     model = tmp_path / "model-blob"
     model.write_bytes(b"GGUF test payload")
 
@@ -191,98 +211,334 @@ def test_materialize_rejects_extensionless_model(tmp_path):
         bootstrap._materialize_gguf_cache_path(model)
 
 
-def test_default_backend_env_override(monkeypatch):
-    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BACKEND", "cpu")
-    assert bootstrap.default_backend() == "cpu"
+def test_file_override_materializes_hf_style_symlink(
+    tmp_path, monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
+    blob = tmp_path / "blob"
+    blob.write_bytes(b"GGUF test payload")
+    model = tmp_path / "custom.gguf"
+    model.symlink_to(blob)
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_MODEL", str(model))
+
+    resolved = bootstrap.resolve_model_file()
+
+    assert resolved.suffix == ".gguf"
+    assert not resolved.is_symlink()
+    assert os.path.samefile(resolved, blob)
 
 
-def test_resolve_server_binary_missing_gives_install_hint(tmp_path, monkeypatch):
+def test_directory_override_materializes_hf_style_symlink(
+    tmp_path, monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
+    blob = tmp_path / "blob"
+    blob.write_bytes(b"GGUF test payload")
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    model = model_dir / bootstrap.DEFAULT_PACKAGE
+    model.symlink_to(blob)
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_MODEL", str(model_dir))
+
+    resolved = bootstrap.resolve_model_file()
+
+    assert resolved.suffix == ".gguf"
+    assert not resolved.is_symlink()
+    assert os.path.samefile(resolved, blob)
+
+
+def test_resolve_server_binary_missing_gives_install_hint(
+    tmp_path, monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
     # Point both env probes at nothing; the package bin/ is unpopulated in
     # a source checkout, so this must fail with guidance, not a bare error.
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(tmp_path / "nope"))
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_DIR", str(tmp_path / "nodir"))
-    with pytest.raises(RuntimeError, match="docs/engines/audio-cpp.md"):
+    with pytest.raises(RuntimeError, match="docs/engines/audio-cpp.md") as exc:
         bootstrap.resolve_server_binary()
+    assert bootstrap.default_asset()[1] in str(exc.value)
 
 
-def test_resolve_server_binary_prefers_env_bin(tmp_path, monkeypatch):
+def test_resolve_server_binary_prefers_env_bin(tmp_path, monkeypatch, app_modules):
+    bootstrap = app_modules.bootstrap
     fake = tmp_path / "audiocpp_server"
     fake.write_bytes(b"#!/bin/sh\n")
+    if os.name != "nt":
+        fake.chmod(0o755)
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(fake))
     assert bootstrap.resolve_server_binary() == fake
 
 
-def test_release_zip_rejects_path_traversal(tmp_path):
-    archive = tmp_path / "bad.zip"
-    with zipfile.ZipFile(archive, "w") as zf:
-        zf.writestr("../escape", b"nope")
+def test_resolve_server_binary_rejects_non_executable_posix(
+    tmp_path, monkeypatch, app_modules,
+):
+    if os.name == "nt":
+        pytest.skip("POSIX executable bits do not apply on Windows")
+    bootstrap = app_modules.bootstrap
+    fake = tmp_path / "audiocpp_server"
+    fake.write_bytes(b"binary")
+    fake.chmod(0o644)
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(fake))
 
-    with pytest.raises(RuntimeError, match="unsafe audio.cpp archive member"):
-        bootstrap._extract_release_archive(archive, archive.name, tmp_path / "out")
-    assert not (tmp_path / "escape").exists()
+    with pytest.raises(RuntimeError, match=r"chmod \+x audiocpp_server"):
+        bootstrap.resolve_server_binary()
+
+    assert bootstrap.is_installed() is False
 
 
-def test_release_tar_rejects_links(tmp_path):
-    archive = tmp_path / "bad.tar.gz"
-    with tarfile.open(archive, "w:gz") as tf:
-        member = tarfile.TarInfo("server-link")
-        member.type = tarfile.SYMTYPE
-        member.linkname = "/etc/passwd"
-        tf.addfile(member)
+def test_non_executable_explicit_binary_does_not_fall_through(
+    tmp_path, monkeypatch, app_modules,
+):
+    if os.name == "nt":
+        pytest.skip("POSIX executable bits do not apply on Windows")
+    bootstrap = app_modules.bootstrap
+    explicit = tmp_path / "explicit" / "audiocpp_server"
+    explicit.parent.mkdir()
+    explicit.write_bytes(b"binary")
+    explicit.chmod(0o644)
+    fallback_dir = tmp_path / "fallback"
+    fallback_dir.mkdir()
+    fallback = fallback_dir / "audiocpp_server"
+    fallback.write_bytes(b"#!/bin/sh\n")
+    fallback.chmod(0o755)
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(explicit))
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_DIR", str(fallback_dir))
 
-    with pytest.raises(RuntimeError, match="unsafe audio.cpp archive member type"):
-        bootstrap._extract_release_archive(archive, archive.name, tmp_path / "out")
+    with pytest.raises(RuntimeError, match=r"chmod \+x audiocpp_server"):
+        bootstrap.resolve_server_binary()
+    assert bootstrap.is_installed() is False
+
+
+def test_model_download_progress_heartbeats_owning_pool_thread(
+    monkeypatch, app_modules,
+):
+    model_manager = importlib.import_module("services.model_manager")
+    heartbeats = []
+    monkeypatch.setattr(
+        model_manager,
+        "report_model_load_activity",
+        lambda thread_ident=None: heartbeats.append(thread_ident),
+    )
+
+    progress_cls = app_modules.bootstrap._download_progress_class()
+    progress = progress_cls(total=1, disable=True)
+    progress.update(1)
+    progress.close()
+
+    assert heartbeats
+    assert set(heartbeats) == {threading.get_ident()}
 
 
 # ── backend protocol + registry ────────────────────────────────────────────
 
 
-def test_backend_metadata():
+def test_app_modules_are_resolved_at_test_time(monkeypatch):
+    real_import = importlib.import_module
+    imported = []
+
+    def recording_import(name):
+        imported.append(name)
+        return real_import(name)
+
+    monkeypatch.setattr(importlib, "import_module", recording_import)
+
+    resolved = _resolve_app_modules()
+
+    assert resolved.audiocpp is real_import("engines.audiocpp")
+    assert imported == [
+        "engines.audiocpp",
+        "engines.audiocpp.bootstrap",
+        "services.tts_backend",
+    ]
+
+
+def test_backend_metadata(app_modules):
+    AudioCPPBackend = app_modules.audiocpp.AudioCPPBackend
     assert AudioCPPBackend.id == "audiocpp"
     assert AudioCPPBackend.supports_voice_design is True
     assert AudioCPPBackend.supports_cloning is True
     assert AudioCPPBackend.runs_out_of_process is True
     assert AudioCPPBackend._is_subprocess_isolated is True
+    assert AudioCPPBackend.gpu_compat == ("cpu",)
+    assert AudioCPPBackend.min_vram_gb == 0.0
     backend = AudioCPPBackend()
     assert backend.sample_rate == 24000
     assert backend.supported_languages == ["en", "zh"]
     assert "breeze_tts" in (backend.model_identity() or "")
 
 
-def test_generate_rejects_empty_text_without_spawning():
+def test_server_identity_rejects_unrelated_loopback_listener(
+    monkeypatch, app_modules,
+):
+    backend = app_modules.audiocpp.AudioCPPBackend()
+    backend._proc = Mock()
+    backend._proc.poll.return_value = None
+    backend._port = 17860
+    backend._server_model_id = "breeze-tts-2-private-launch"
+    monkeypatch.setattr(
+        backend,
+        "_get_json",
+        lambda path: {"data": [{"id": "someone-elses-model"}]},
+    )
+
+    with pytest.raises(RuntimeError, match="did not prove"):
+        backend._verify_server_identity()
+
+
+def test_server_spawn_uses_contained_owner(tmp_path, monkeypatch, app_modules):
+    backend = app_modules.audiocpp.AudioCPPBackend()
+    binary = tmp_path / "audiocpp_server"
+    binary.write_bytes(b"binary")
+    model = tmp_path / "model.gguf"
+    model.write_bytes(b"GGUF")
+    monkeypatch.setattr(app_modules.bootstrap, "resolve_server_binary", lambda: binary)
+    monkeypatch.setattr(app_modules.bootstrap, "resolve_model_file", lambda: model)
+    monkeypatch.setattr(app_modules.bootstrap, "server_port", lambda: 17860)
+    monkeypatch.setattr(
+        importlib.import_module("core.config"), "DATA_DIR", tmp_path / "data",
+    )
+    proc = Mock()
+    proc.poll.return_value = None
+    spawn = Mock(return_value=proc)
+    monkeypatch.setattr(app_modules.audiocpp, "spawn_owned", spawn)
+    monkeypatch.setattr(backend, "_wait_for_health", lambda: None)
+
+    backend._ensure_loaded()
+
+    spawn.assert_called_once()
+    config = json.loads(backend._server_json.read_text())
+    assert config["backend"] == "cpu"
+    assert config["models"][0]["id"].startswith("breeze-tts-2-")
+    assert config["models"][0]["id"] != "breeze-tts-2"
+    if os.name != "nt":
+        assert stat.S_IMODE(backend._server_json.stat().st_mode) == 0o600
+    backend._proc = None
+
+
+def test_generate_timeout_terminates_owned_server(monkeypatch, app_modules):
+    backend = app_modules.audiocpp.AudioCPPBackend()
+
+    def mark_loaded():
+        backend._port = 17860
+        backend._server_model_id = "breeze-tts-2-private-launch"
+
+    monkeypatch.setattr(backend, "_ensure_loaded", mark_loaded)
+    monkeypatch.setattr(
+        backend, "_post_json", Mock(side_effect=TimeoutError("wedged")),
+    )
+    terminate = Mock()
+    monkeypatch.setattr(backend, "_terminate_server", terminate)
+    model_manager = importlib.import_module("services.model_manager")
+    monkeypatch.setattr(
+        model_manager, "generate_timeout_s",
+        lambda text, execution_device: 100.0,
+    )
+    monkeypatch.setattr(model_manager, "GENERATE_PROGRESS_GRACE_S", 40.0)
+    progress = Mock()
+    monkeypatch.setattr(model_manager, "report_generate_progress", progress)
+    monotonic = iter((10.0, 30.0))
+    monkeypatch.setattr(
+        app_modules.audiocpp.time, "monotonic", lambda: next(monotonic),
+    )
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        backend.generate("Hello from the timeout test.")
+
+    assert backend._post_json.call_args.kwargs["timeout"] == 65.0
+    progress.assert_called_once_with()
+    terminate.assert_called_once_with()
+
+
+def test_generate_uses_progress_lease_after_first_download(
+    monkeypatch, app_modules,
+):
+    backend = app_modules.audiocpp.AudioCPPBackend()
+
+    def mark_loaded():
+        enter = next(monotonic)
+        assert enter == 20.0
+        backend._port = 17860
+        backend._server_model_id = "breeze-tts-2-private-launch"
+
+    monotonic = iter((10.0, 20.0, 130.0))
+    monkeypatch.setattr(backend, "_ensure_loaded", mark_loaded)
+    monkeypatch.setattr(
+        backend, "_post_json", Mock(side_effect=TimeoutError("wedged")),
+    )
+    monkeypatch.setattr(backend, "_terminate_server", Mock())
+    model_manager = importlib.import_module("services.model_manager")
+    monkeypatch.setattr(
+        model_manager, "generate_timeout_s",
+        lambda text, execution_device: 100.0,
+    )
+    monkeypatch.setattr(model_manager, "GENERATE_PROGRESS_GRACE_S", 40.0)
+    progress = Mock()
+    monkeypatch.setattr(model_manager, "report_generate_progress", progress)
+    monkeypatch.setattr(
+        app_modules.audiocpp.time, "monotonic", lambda: next(monotonic),
+    )
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        backend.generate("Hello after a slow first download.")
+
+    assert backend._post_json.call_args.kwargs["timeout"] == 25.0
+    progress.assert_called_once_with()
+
+
+def test_terminate_server_reaps_after_forced_kill(app_modules):
+    backend = app_modules.audiocpp.AudioCPPBackend()
+    proc = Mock()
+    proc.wait.side_effect = [
+        subprocess.TimeoutExpired("audiocpp_server", 5.0),
+        0,
+    ]
+    backend._proc = proc
+
+    backend._terminate_server()
+
+    proc.terminate.assert_called_once_with()
+    proc.kill.assert_called_once_with()
+    assert proc.wait.call_count == 2
+    assert backend._proc is None
+
+
+def test_generate_rejects_empty_text_without_spawning(app_modules):
+    AudioCPPBackend = app_modules.audiocpp.AudioCPPBackend
     backend = AudioCPPBackend()
-    with pytest.raises(TTSInputError):
+    with pytest.raises(app_modules.audiocpp.TTSInputError):
         backend.generate("   ")
 
 
-def test_unload_before_load_is_safe():
-    AudioCPPBackend().unload()  # must never raise (idempotent contract)
+def test_unload_before_load_is_safe(app_modules):
+    app_modules.audiocpp.AudioCPPBackend().unload()
 
 
-def test_registry_resolves_audiocpp():
-    assert get_backend_class("audiocpp") is AudioCPPBackend
+def test_registry_resolves_audiocpp(app_modules):
+    assert (
+        app_modules.tts_backend.get_backend_class("audiocpp")
+        is app_modules.audiocpp.AudioCPPBackend
+    )
 
 
-def test_is_available_false_without_binary_gives_reason():
-    ok, msg = AudioCPPBackend.is_available()
+def test_is_available_false_without_binary_gives_reason(app_modules):
+    ok, msg = app_modules.audiocpp.AudioCPPBackend.is_available()
     if ok:
         pytest.skip("audiocpp_server installed on this host")
     assert "audiocpp_server" in msg
     assert "audio-cpp.md" in msg
 
 
-def test_install_hint_present():
-    from services import tts_backend
-
-    assert "audiocpp" in tts_backend._INSTALL_HINTS
+def test_install_hint_present(app_modules):
+    assert "audiocpp" in app_modules.tts_backend._INSTALL_HINTS
 
 
-def test_no_hf_token_in_module_source():
+def test_no_hf_token_in_module_source(app_modules):
     # The bootstrap downloads from GitHub + ungated HF; no token may ever be
     # interpolated into an error string this module surfaces to the UI.
     import pathlib
 
     for name in ("__init__.py", "bootstrap.py"):
-        src = pathlib.Path(bootstrap.__file__).parent.joinpath(name).read_text()
+        src = pathlib.Path(app_modules.bootstrap.__file__).parent.joinpath(name).read_text()
         assert "HF_TOKEN" not in src
         assert "Authorization" not in src

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -605,6 +605,36 @@ def test_is_available_false_without_binary_gives_reason(app_modules):
     assert "audio-cpp.md" in msg
 
 
+def test_is_available_requires_explicitly_installed_model(
+    tmp_path, monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
+    binary = tmp_path / "audiocpp_server"
+    monkeypatch.setattr(bootstrap, "resolve_server_binary", lambda: binary)
+
+    def missing_model():
+        raise RuntimeError(
+            "Breeze-TTS-2 is not installed. Install it from Model Catalogue → Models."
+        )
+
+    monkeypatch.setattr(bootstrap, "resolve_model_file", missing_model)
+
+    ok, msg = app_modules.audiocpp.AudioCPPBackend.is_available()
+
+    assert ok is False
+    assert "Model Catalogue → Models" in msg
+
+
+def test_is_available_requires_binary_and_model(tmp_path, monkeypatch, app_modules):
+    bootstrap = app_modules.bootstrap
+    binary = tmp_path / "audiocpp_server"
+    model = tmp_path / "breeze-tts-2-q8_0.gguf"
+    monkeypatch.setattr(bootstrap, "resolve_server_binary", lambda: binary)
+    monkeypatch.setattr(bootstrap, "resolve_model_file", lambda: model)
+
+    assert app_modules.audiocpp.AudioCPPBackend.is_available() == (True, "ready")
+
+
 def test_install_hint_present(app_modules):
     assert "audiocpp" in app_modules.tts_backend._INSTALL_HINTS
 

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -8,6 +8,7 @@ host env is scrubbed of ``OMNIVOICE_AUDIOCPP_*`` overrides per test.
 from __future__ import annotations
 
 import base64
+import errno
 import importlib
 import io
 import json
@@ -209,6 +210,37 @@ def test_materialize_rejects_extensionless_model(tmp_path, app_modules):
 
     with pytest.raises(RuntimeError, match="must be a .gguf file"):
         bootstrap._materialize_gguf_cache_path(model)
+
+
+def test_materialize_cross_filesystem_symlink_links_beside_target(
+    tmp_path, monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    blob = source_dir / "content-addressed-blob"
+    blob.write_bytes(b"GGUF test payload")
+    link_dir = tmp_path / "link"
+    link_dir.mkdir()
+    snapshot = link_dir / "custom.gguf"
+    snapshot.symlink_to(blob)
+    real_link = os.link
+    calls = 0
+
+    def cross_filesystem_once(source, destination):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError(errno.EXDEV, "cross-device link")
+        return real_link(source, destination)
+
+    monkeypatch.setattr(bootstrap.os, "link", cross_filesystem_once)
+
+    materialized = bootstrap._materialize_gguf_cache_path(snapshot)
+
+    assert materialized.parent == blob.parent
+    assert materialized.suffix == ".gguf"
+    assert os.path.samefile(materialized, blob)
 
 
 def test_file_override_materializes_hf_style_symlink(

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -8,8 +8,11 @@ host env is scrubbed of ``OMNIVOICE_AUDIOCPP_*`` overrides per test.
 from __future__ import annotations
 
 import base64
+import string
 import io
 import os
+import tarfile
+import zipfile
 
 import pytest
 
@@ -146,6 +149,13 @@ def test_binary_name_exe_on_windows_only():
     assert bootstrap.binary_name("darwin-arm64") == "audiocpp_server"
 
 
+def test_release_assets_have_complete_sha256_pins():
+    for filename, digest in bootstrap._ASSETS.values():
+        assert filename
+        assert len(digest) == 64
+        assert set(digest) <= set(string.hexdigits)
+
+
 def test_server_port_default_and_overrides(monkeypatch):
     assert bootstrap.server_port() == bootstrap.DEFAULT_PORT
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PORT", "18081")
@@ -158,6 +168,27 @@ def test_package_filename_default_and_override(monkeypatch):
     assert bootstrap.package_filename() == bootstrap.DEFAULT_PACKAGE
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PACKAGE", "breeze-tts-2-bf16.gguf")
     assert bootstrap.package_filename() == "breeze-tts-2-bf16.gguf"
+
+
+def test_materialize_hf_symlink_keeps_gguf_suffix_without_copy(tmp_path):
+    blob = tmp_path / "content-addressed-blob"
+    blob.write_bytes(b"GGUF test payload")
+    snapshot = tmp_path / "breeze-tts-2-q8_0.gguf"
+    snapshot.symlink_to(blob)
+
+    materialized = bootstrap._materialize_gguf_cache_path(snapshot)
+
+    assert materialized.suffix == ".gguf"
+    assert not materialized.is_symlink()
+    assert os.path.samefile(materialized, blob)
+
+
+def test_materialize_rejects_extensionless_model(tmp_path):
+    model = tmp_path / "model-blob"
+    model.write_bytes(b"GGUF test payload")
+
+    with pytest.raises(RuntimeError, match="must be a .gguf file"):
+        bootstrap._materialize_gguf_cache_path(model)
 
 
 def test_default_backend_env_override(monkeypatch):
@@ -179,6 +210,28 @@ def test_resolve_server_binary_prefers_env_bin(tmp_path, monkeypatch):
     fake.write_bytes(b"#!/bin/sh\n")
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(fake))
     assert bootstrap.resolve_server_binary() == fake
+
+
+def test_release_zip_rejects_path_traversal(tmp_path):
+    archive = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("../escape", b"nope")
+
+    with pytest.raises(RuntimeError, match="unsafe audio.cpp archive member"):
+        bootstrap._extract_release_archive(archive, archive.name, tmp_path / "out")
+    assert not (tmp_path / "escape").exists()
+
+
+def test_release_tar_rejects_links(tmp_path):
+    archive = tmp_path / "bad.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        member = tarfile.TarInfo("server-link")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "/etc/passwd"
+        tf.addfile(member)
+
+    with pytest.raises(RuntimeError, match="unsafe audio.cpp archive member type"):
+        bootstrap._extract_release_archive(archive, archive.name, tmp_path / "out")
 
 
 # ── backend protocol + registry ────────────────────────────────────────────

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -1,0 +1,235 @@
+"""Tests for the audio.cpp TTS backend (Breeze-TTS-2 over loopback HTTP).
+
+Hermetic by design: every test exercises pure builders, env-driven
+resolution, or registry wiring. No binary, no network, no model download —
+``resolve_server_binary`` is only asserted on its failure message, and the
+host env is scrubbed of ``OMNIVOICE_AUDIOCPP_*`` overrides per test.
+"""
+from __future__ import annotations
+
+import base64
+import io
+import os
+
+import pytest
+
+# tests/conftest.py prepends ./backend to sys.path so these resolve.
+from engines.audiocpp import (
+    AudioCPPBackend,
+    build_server_config,
+    build_speech_payload,
+    decode_speech_json,
+)
+from engines.audiocpp import bootstrap
+from services.tts_backend import TTSInputError, get_backend_class
+
+
+@pytest.fixture(autouse=True)
+def scrub_audiocpp_env(monkeypatch):
+    for var in (
+        "OMNIVOICE_AUDIOCPP_BIN",
+        "OMNIVOICE_AUDIOCPP_DIR",
+        "OMNIVOICE_AUDIOCPP_MODEL",
+        "OMNIVOICE_AUDIOCPP_PACKAGE",
+        "OMNIVOICE_AUDIOCPP_BACKEND",
+        "OMNIVOICE_AUDIOCPP_PORT",
+        "OMNIVOICE_AUDIOCPP_ASSET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ── server config builder ──────────────────────────────────────────────────
+
+
+def test_build_server_config_is_loopback_lazy_single_model():
+    cfg = build_server_config(
+        model_id="breeze-tts-2",
+        family="breeze_tts",
+        model_path="/models/breeze-tts-2-q8_0.gguf",
+        backend="vulkan",
+        port=17860,
+    )
+    assert cfg["host"] == "127.0.0.1"
+    assert cfg["port"] == 17860
+    assert cfg["backend"] == "vulkan"
+    assert cfg["lazy_load"] is True
+    assert cfg["max_loaded_models"] == 1
+    assert cfg["models"] == [
+        {
+            "id": "breeze-tts-2",
+            "family": "breeze_tts",
+            "path": "/models/breeze-tts-2-q8_0.gguf",
+            "task": "tts",
+            "mode": "offline",
+        }
+    ]
+
+
+# ── speech payload builder ─────────────────────────────────────────────────
+
+
+def test_build_speech_payload_minimal_design():
+    payload = build_speech_payload(model_id="breeze-tts-2", text="Hello.")
+    assert payload == {
+        "model": "breeze-tts-2",
+        "input": "Hello.",
+        "response_format": "json",
+    }
+
+
+def test_build_speech_payload_clone_maps_verified_fields():
+    payload = build_speech_payload(
+        model_id="breeze-tts-2",
+        text="Read this.",
+        ref_audio="/voices/alice.wav",
+        ref_text="Exact transcript.",
+        instructions="Speak slowly.",
+        guidance_scale=4.0,
+        seed=42,
+    )
+    assert payload["instructions"] == "Speak slowly."
+    assert payload["voice_ref"] == {"type": "path", "path": "/voices/alice.wav"}
+    assert payload["reference_text"] == "Exact transcript."
+    assert payload["guidance_scale"] == 4.0
+    assert payload["seed"] == 42
+
+
+def test_build_speech_payload_reference_text_needs_ref_audio():
+    payload = build_speech_payload(
+        model_id="breeze-tts-2", text="Hi.", ref_text="stray transcript",
+    )
+    assert "reference_text" not in payload
+    assert "voice_ref" not in payload
+
+
+# ── speech reply decoder ───────────────────────────────────────────────────
+
+
+def _wav_json_bytes(mono, sr):
+    import numpy as np
+    import soundfile as sf
+
+    buf = io.BytesIO()
+    sf.write(buf, np.asarray(mono, dtype=np.float32), sr, format="WAV")
+    return {"audio": base64.b64encode(buf.getvalue()).decode("ascii")}
+
+
+def test_decode_speech_json_roundtrip_mono():
+    obj = _wav_json_bytes([0.0, 0.5, -0.5, 0.25], 24000)
+    sr, wav = decode_speech_json(obj)
+    assert sr == 24000
+    assert wav.ndim == 1 and len(wav) == 4
+    assert abs(float(wav[1]) - 0.5) < 1e-4
+
+
+def test_decode_speech_json_downmixes_stereo():
+    import numpy as np
+
+    stereo = np.array([[0.5, -0.5], [0.5, -0.5]], dtype=np.float32)
+    obj = _wav_json_bytes(stereo, 24000)
+    sr, wav = decode_speech_json(obj)
+    assert sr == 24000
+    assert wav.ndim == 1 and len(wav) == 2
+
+
+def test_decode_speech_json_error_payload_raises():
+    with pytest.raises(ValueError, match="audio.cpp speech failed"):
+        decode_speech_json({"error": "model not loaded"})
+
+
+# ── bootstrap resolution ───────────────────────────────────────────────────
+
+
+def test_binary_name_exe_on_windows_only():
+    assert bootstrap.binary_name("windows-x64") == "audiocpp_server.exe"
+    assert bootstrap.binary_name("linux-x64") == "audiocpp_server"
+    assert bootstrap.binary_name("darwin-arm64") == "audiocpp_server"
+
+
+def test_server_port_default_and_overrides(monkeypatch):
+    assert bootstrap.server_port() == bootstrap.DEFAULT_PORT
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PORT", "18081")
+    assert bootstrap.server_port() == 18081
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PORT", "bogus")
+    assert bootstrap.server_port() == bootstrap.DEFAULT_PORT
+
+
+def test_package_filename_default_and_override(monkeypatch):
+    assert bootstrap.package_filename() == bootstrap.DEFAULT_PACKAGE
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_PACKAGE", "breeze-tts-2-bf16.gguf")
+    assert bootstrap.package_filename() == "breeze-tts-2-bf16.gguf"
+
+
+def test_default_backend_env_override(monkeypatch):
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BACKEND", "cpu")
+    assert bootstrap.default_backend() == "cpu"
+
+
+def test_resolve_server_binary_missing_gives_install_hint(tmp_path, monkeypatch):
+    # Point both env probes at nothing; the package bin/ is unpopulated in
+    # a source checkout, so this must fail with guidance, not a bare error.
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(tmp_path / "nope"))
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_DIR", str(tmp_path / "nodir"))
+    with pytest.raises(RuntimeError, match="docs/engines/audio-cpp.md"):
+        bootstrap.resolve_server_binary()
+
+
+def test_resolve_server_binary_prefers_env_bin(tmp_path, monkeypatch):
+    fake = tmp_path / "audiocpp_server"
+    fake.write_bytes(b"#!/bin/sh\n")
+    monkeypatch.setenv("OMNIVOICE_AUDIOCPP_BIN", str(fake))
+    assert bootstrap.resolve_server_binary() == fake
+
+
+# ── backend protocol + registry ────────────────────────────────────────────
+
+
+def test_backend_metadata():
+    assert AudioCPPBackend.id == "audiocpp"
+    assert AudioCPPBackend.supports_voice_design is True
+    assert AudioCPPBackend.supports_cloning is True
+    assert AudioCPPBackend.runs_out_of_process is True
+    assert AudioCPPBackend._is_subprocess_isolated is True
+    backend = AudioCPPBackend()
+    assert backend.sample_rate == 24000
+    assert backend.supported_languages == ["en", "zh"]
+    assert "breeze_tts" in (backend.model_identity() or "")
+
+
+def test_generate_rejects_empty_text_without_spawning():
+    backend = AudioCPPBackend()
+    with pytest.raises(TTSInputError):
+        backend.generate("   ")
+
+
+def test_unload_before_load_is_safe():
+    AudioCPPBackend().unload()  # must never raise (idempotent contract)
+
+
+def test_registry_resolves_audiocpp():
+    assert get_backend_class("audiocpp") is AudioCPPBackend
+
+
+def test_is_available_false_without_binary_gives_reason():
+    ok, msg = AudioCPPBackend.is_available()
+    if ok:
+        pytest.skip("audiocpp_server installed on this host")
+    assert "audiocpp_server" in msg
+    assert "audio-cpp.md" in msg
+
+
+def test_install_hint_present():
+    from services import tts_backend
+
+    assert "audiocpp" in tts_backend._INSTALL_HINTS
+
+
+def test_no_hf_token_in_module_source():
+    # The bootstrap downloads from GitHub + ungated HF; no token may ever be
+    # interpolated into an error string this module surfaces to the UI.
+    import pathlib
+
+    for name in ("__init__.py", "bootstrap.py"):
+        src = pathlib.Path(bootstrap.__file__).parent.joinpath(name).read_text()
+        assert "HF_TOKEN" not in src
+        assert "Authorization" not in src

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -16,7 +16,6 @@ import os
 import stat
 import string
 import subprocess
-import threading
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -173,6 +172,13 @@ def test_release_assets_have_complete_sha256_pins(app_modules):
     assert "ubuntu-x64-cpu" in bootstrap._ASSETS["linux-x64"][0]
 
 
+def test_model_catalog_and_backend_share_immutable_revision(app_modules):
+    from services.hf_revisions import revision_for
+
+    bootstrap = app_modules.bootstrap
+    assert revision_for(bootstrap.HF_MODEL_REPO) == bootstrap.HF_MODEL_REVISION
+
+
 def test_server_port_default_and_overrides(monkeypatch, app_modules):
     bootstrap = app_modules.bootstrap
     assert bootstrap.server_port() == bootstrap.DEFAULT_PORT
@@ -298,6 +304,45 @@ def test_directory_override_materializes_hf_style_symlink(
     assert os.path.samefile(resolved, blob)
 
 
+def test_cached_model_resolution_is_strictly_offline(
+    tmp_path, monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
+    package_dir = tmp_path / bootstrap.PACKAGE_DIR
+    package_dir.mkdir()
+    model = package_dir / bootstrap.DEFAULT_PACKAGE
+    model.write_bytes(b"GGUF test payload")
+    calls = []
+
+    def cached_snapshot(**kwargs):
+        calls.append(kwargs)
+        return str(tmp_path)
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", cached_snapshot)
+
+    assert bootstrap.resolve_model_file() == model
+    assert calls == [{
+        "repo_id": bootstrap.HF_MODEL_REPO,
+        "revision": bootstrap.HF_MODEL_REVISION,
+        "allow_patterns": [f"{bootstrap.PACKAGE_DIR}/{bootstrap.DEFAULT_PACKAGE}"],
+        "local_files_only": True,
+    }]
+
+
+def test_missing_cached_model_requires_explicit_install(
+    monkeypatch, app_modules,
+):
+    bootstrap = app_modules.bootstrap
+
+    def cache_miss(**_kwargs):
+        raise OSError("not cached")
+
+    monkeypatch.setattr("huggingface_hub.snapshot_download", cache_miss)
+
+    with pytest.raises(RuntimeError, match="Model Catalogue → Models"):
+        bootstrap.resolve_model_file()
+
+
 def test_resolve_server_binary_missing_gives_install_hint(
     tmp_path, monkeypatch, app_modules,
 ):
@@ -359,26 +404,6 @@ def test_non_executable_explicit_binary_does_not_fall_through(
     with pytest.raises(RuntimeError, match=r"chmod \+x audiocpp_server"):
         bootstrap.resolve_server_binary()
     assert bootstrap.is_installed() is False
-
-
-def test_model_download_progress_heartbeats_owning_pool_thread(
-    monkeypatch, app_modules,
-):
-    model_manager = importlib.import_module("services.model_manager")
-    heartbeats = []
-    monkeypatch.setattr(
-        model_manager,
-        "report_model_load_activity",
-        lambda thread_ident=None: heartbeats.append(thread_ident),
-    )
-
-    progress_cls = app_modules.bootstrap._download_progress_class()
-    progress = progress_cls(total=1, disable=True)
-    progress.update(1)
-    progress.close()
-
-    assert heartbeats
-    assert set(heartbeats) == {threading.get_ident()}
 
 
 # ── backend protocol + registry ────────────────────────────────────────────

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -212,6 +212,24 @@ def test_materialize_rejects_extensionless_model(tmp_path, app_modules):
         bootstrap._materialize_gguf_cache_path(model)
 
 
+def test_materialize_replaces_preexisting_symlink_alias(tmp_path, app_modules):
+    bootstrap = app_modules.bootstrap
+    blob = tmp_path / "content-addressed-blob"
+    blob.write_bytes(b"GGUF test payload")
+    snapshot = tmp_path / "breeze-tts-2-q8_0.gguf"
+    snapshot.symlink_to(blob)
+    alias = snapshot.with_name(
+        f".{snapshot.stem}-{bootstrap.HF_MODEL_REVISION[:12]}.audiocpp.gguf"
+    )
+    alias.symlink_to(blob)
+
+    materialized = bootstrap._materialize_gguf_cache_path(snapshot)
+
+    assert materialized == alias
+    assert not materialized.is_symlink()
+    assert os.path.samefile(materialized, blob)
+
+
 def test_materialize_cross_filesystem_symlink_links_beside_target(
     tmp_path, monkeypatch, app_modules,
 ):
@@ -240,6 +258,7 @@ def test_materialize_cross_filesystem_symlink_links_beside_target(
 
     assert materialized.parent == blob.parent
     assert materialized.suffix == ".gguf"
+    assert not materialized.is_symlink()
     assert os.path.samefile(materialized, blob)
 
 

--- a/tests/test_engine_disk_usage.py
+++ b/tests/test_engine_disk_usage.py
@@ -31,6 +31,14 @@ def test_lightweight_optional_engine_has_weight_estimate_not_fake_package_zero(m
     assert usage["estimate"]["package_download_bytes"] is None
 
 
+def test_audiocpp_exposes_its_filtered_model_download_size(monkeypatch, disk_modules):
+    engine_disk_usage, _ = disk_modules
+    monkeypatch.setattr(engine_disk_usage, "_measure_model_cache", lambda _engine_id: None)
+    usage = engine_disk_usage.disk_usage_for("audiocpp")
+    assert usage["estimate"]["model_download_bytes"] == round(4.73 * 1024**3)
+    assert usage["estimate"]["package_download_bytes"] is None
+
+
 def test_separate_torch_sidecar_uses_installer_build_metadata(monkeypatch, tmp_path, disk_modules):
     engine_disk_usage, SPECS = disk_modules
     spec = SPECS["indextts2"]

--- a/tests/test_install_disk_space.py
+++ b/tests/test_install_disk_space.py
@@ -162,3 +162,48 @@ def test_install_preflight_download_and_repair_marker_share_revision(models_mod,
     assert calls[0]["dry_run"] is True
     assert "dry_run" not in calls[1]
     assert remembered and remembered[0][0:2] == (repo_id, expected)
+
+
+def test_install_honors_catalog_allow_patterns(models_mod, monkeypatch, tmp_path):
+    """A multi-package repo downloads only the model variant shown in its row."""
+    download = importlib.import_module("api.routers.setup.download")
+    import asyncio
+    import huggingface_hub
+    from services import hf_revisions
+
+    repo_id = "audio-cpp/audio.cpp-gguf"
+    spec = next(m for m in download.KNOWN_MODELS if m["repo_id"] == repo_id)
+    expected_patterns = spec["allow_patterns"]
+    calls = []
+
+    def fake_snapshot(**kwargs):
+        calls.append(kwargs)
+        return [] if kwargs.get("dry_run") else str(tmp_path)
+
+    def segmented_must_not_run(*_args, **_kwargs):
+        raise AssertionError("filtered model installs must skip whole-repo segmented download")
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot)
+    monkeypatch.setattr(download, "compute_plan", lambda _plan: {
+        "total_bytes": 1, "cached_bytes": 0, "to_download_bytes": 1,
+        "n_files": 1, "n_cached": 0,
+    })
+    monkeypatch.setattr(download, "disk_space_error", lambda *_a, **_k: None)
+    monkeypatch.setattr(download, "_segmented_enabled", lambda: True)
+    monkeypatch.setattr(download, "_xet_active", lambda: False)
+    monkeypatch.setattr(download, "_segmented_snapshot", segmented_must_not_run)
+    monkeypatch.setattr(download, "_validate_snapshot_has_weights", lambda *_a: None)
+    monkeypatch.setattr(hf_revisions, "remember_revision", lambda *_args: None)
+
+    async def run_install():
+        await download.install_model(download.InstallModelRequest(repo_id=repo_id))
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if pending:
+            await asyncio.gather(*pending)
+
+    asyncio.run(run_install())
+
+    assert len(calls) == 2
+    assert all(call["allow_patterns"] == expected_patterns for call in calls)
+    assert calls[0]["dry_run"] is True
+    assert "dry_run" not in calls[1]


### PR DESCRIPTION
Adds an opt-in, CPU-only audio.cpp backend for Breeze-TTS-2 and preserves the responsive Model Catalogue controls recovered from local work.

The backend supports English and Chinese voice cloning, voice design, and voice direction through the official v0.7.2 CPU runtime. It pins the model revision and release checksums, handles Hugging Face's extensionless cache blobs without copying the 4.73 GiB model, verifies the managed loopback server before sending text or reference paths, owns and reaps the native process, and uses up to 16 physical CPU cores.

The Q8_0 model is listed in Model Catalogue → Models. It downloads only after the user clicks Install, and the installer fetches only that package from the multi-model repository. Generation is strictly cache-only and gives an actionable install message when the model is absent or incomplete.

Breeze-TTS-2 weights and self-hosted outputs are research/non-commercial. The engine is opt-in, the restriction is shown in its catalogue name and install hint before download, and the owner-approved named exception is recorded in `docs/engine-acceptance.md` with `@debpalash` as steward.

Linux x64 validation used the SHA-verified official CPU archive and pinned Q8_0 model:

- Real `AudioCPPBackend` voice design: 3.36 s of 24 kHz mono audio in 12.16 s, followed by clean process shutdown.
- Offline Whisper recovered the requested sentence exactly.
- CPU tuning on Ryzen 9 7950X: 24.62 s warm at 1 thread versus 6.94 s at 16 physical cores; all outputs were byte-identical.
- The upstream Linux archive's missing executable bit is detected with actionable `chmod +x` guidance.
- Cache-only resolution was verified against the real 5,079,668,352-byte model.

Validation:

- Backend full suite: 7,099 passed, 31 skipped, 8 xfailed, 1 xpassed.
- Frontend Vitest: 2,731 passed; legacy node tests: 84 passed.
- Latest focused CPU, install, catalogue, disk-usage, revision, and changelog checks: 66 passed.
- Typecheck, frontend formatting, compile checks, install-doc validation, and security scans passed.
