### PR TITLE
fix(bootstrap): stop showing first-run install steps on warm starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 
 - Fast macOS process exits no longer turn a completed shutdown into a permission error (#1809)
+- The bootstrap splash no longer shows fabricated first-run install steps on a warm start or repair sync — a step now renders done only once it was actually observed (#1894)
 
 ## [0.5.2] — 2026-09-02
 

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -127,6 +127,10 @@ const STEPS = [
 // journey chrome should already be armed by the time the step list appears.
 const INSTALL_STAGES = ['downloading_uv', 'creating_venv', 'installing_deps', 'awaiting_setup'];
 
+// Stages the bootstrap restarts *from*. Arriving at one of these from
+// anywhere else means a new attempt began (Retry, or a Rust-side restart).
+const RESTART_STAGES = new Set(['checking', 'awaiting_setup']);
+
 const MAX_LOG_LINES = 200;
 
 /** Scan logs + error message for known failure patterns and return i18n keys
@@ -452,13 +456,36 @@ export function BootstrapSplash({ stage, message }) {
   const [progress, setProgress] = useState(null);
   const [region, setRegionState] = useState('auto');
   const [retrying, setRetrying] = useState(false);
-  // Stages actually seen this session (sticky/monotonic — see the tracking
-  // effect below). Drives "done" ticks and journey visibility off observed
-  // reality instead of list position (#1894).
-  const [observedStages, setObservedStages] = useState(() => new Set([stage]));
+  // Stages actually seen during the CURRENT bootstrap attempt (see the
+  // tracking effect below). Drives "done" ticks and journey visibility off
+  // observed reality instead of list position (#1894).
+  const [polledStages, setPolledStages] = useState(() => new Set([stage]));
+  // Wall-clock start of the current attempt. A retry restarts the bootstrap;
+  // log lines from the previous attempt must not count toward this one.
+  const [attemptStart, setAttemptStart] = useState(0);
   const logRef = useRef(null);
+  const prevStageRef = useRef(stage); // previous stage, for restart detection
   const prevProgRef = useRef(null); // {bytes, t} — last progress event
   const rateRef = useRef(0); // EMA bytes/sec across events
+
+  // The union of what we polled and what actually logged.
+  //
+  // Neither source alone is complete. `bootstrap_status` is sampled ~1/s, so
+  // a stage that starts and finishes between samples is never polled — on a
+  // fast disk `creating_venv` routinely does. Stage-tagged `bootstrap-log`
+  // lines close that gap: the Rust side emits them as the work happens, so a
+  // line tagged with a stage is proof that stage ran, whether or not the
+  // poll ever saw it. Lines are filtered to the current attempt so a retry
+  // cannot inherit the previous one's evidence (the visible log is left
+  // alone — clearing it on a Rust-side restart would destroy the user's
+  // context, cf. #1847).
+  const observedStages = useMemo(() => {
+    const seen = new Set(polledStages);
+    for (const entry of logs) {
+      if (entry?.stage && (entry.t ?? 0) >= attemptStart) seen.add(entry.stage);
+    }
+    return seen;
+  }, [polledStages, logs, attemptStart]);
 
   const label = t(`bootstrap.${stage}`, STAGE_LABEL[stage]);
   const stepIndex = Math.max(0, STEPS.indexOf(stage));
@@ -501,13 +528,28 @@ export function BootstrapSplash({ stage, message }) {
     }
   };
 
-  // Record `stage` as observed the moment it's seen. Sticky/monotonic: the
-  // functional updater bails out (same Set reference) once a stage is
-  // already recorded, so this never un-observes anything and never loops.
-  // `bootstrap_status` is polled ~1/s by useBootstrapStage, so a stage that
-  // actually ran is guaranteed to land here at least once (#1894).
+  // Record `stage` as observed the moment it's seen, and reset when a new
+  // attempt begins.
+  //
+  // Sticky WITHIN an attempt: the functional updater bails out (same Set
+  // reference) once a stage is recorded, so it never un-observes and never
+  // loops. But NOT across attempts — a Retry restarts the bootstrap from
+  // `checking`, and what the previous attempt did says nothing about what
+  // this one will do. Without the reset, stages the new attempt skips would
+  // still render as completed, which is the very fabrication this change
+  // exists to remove. Keyed off the stage moving back to a restart stage
+  // rather than off our own Retry buttons, so a restart initiated on the
+  // Rust side resets it too.
   useEffect(() => {
-    setObservedStages((prev) => (prev.has(stage) ? prev : new Set(prev).add(stage)));
+    const prev = prevStageRef.current;
+    prevStageRef.current = stage;
+    const restarted = RESTART_STAGES.has(stage) && !RESTART_STAGES.has(prev);
+    if (restarted) {
+      setAttemptStart(Date.now());
+      setPolledStages(new Set([stage]));
+      return;
+    }
+    setPolledStages((p) => (p.has(stage) ? p : new Set(p).add(stage)));
   }, [stage]);
 
   // Load persisted region on mount.

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -465,6 +465,9 @@ export function BootstrapSplash({ stage, message }) {
   const [attemptStart, setAttemptStart] = useState(0);
   const logRef = useRef(null);
   const prevStageRef = useRef(stage); // previous stage, for restart detection
+  // True between a retry WE initiated and the poll catching up to it, so the
+  // fallback effect below doesn't re-stamp an already-exact attempt boundary.
+  const selfInitiatedRef = useRef(false);
   const prevProgRef = useRef(null); // {bytes, t} — last progress event
   const rateRef = useRef(0); // EMA bytes/sec across events
 
@@ -499,12 +502,25 @@ export function BootstrapSplash({ stage, message }) {
   // instead of fabricating completed work (#1894).
   const installWorkSeen = INSTALL_STAGES.some((s) => observedStages.has(s));
 
+  // Open a new bootstrap attempt. Called at the moment a retry is INITIATED,
+  // not when the ~1s status poll later reports `checking`: the Rust side
+  // starts emitting logs for the new attempt immediately, and a boundary
+  // stamped at detection time would sit *after* those lines and discard them
+  // as belonging to the old attempt — losing exactly the fast-stage evidence
+  // the log union exists to capture.
+  const beginAttempt = () => {
+    selfInitiatedRef.current = true;
+    setLogs([]);
+    setPolledStages(new Set());
+    setAttemptStart(Date.now());
+  };
+
   const handleRetry = async () => {
     if (retrying) return;
     setRetrying(true);
     try {
       const { invoke } = await import('@tauri-apps/api/core');
-      setLogs([]);
+      beginAttempt();
       await invoke('retry_bootstrap');
     } catch (e) {
       console.error('retry failed', e);
@@ -519,7 +535,7 @@ export function BootstrapSplash({ stage, message }) {
     setRetrying(true);
     try {
       const { invoke } = await import('@tauri-apps/api/core');
-      setLogs([]);
+      beginAttempt();
       await invoke('clean_and_retry_bootstrap');
     } catch (e) {
       console.error('clean retry failed', e);
@@ -537,15 +553,32 @@ export function BootstrapSplash({ stage, message }) {
   // `checking`, and what the previous attempt did says nothing about what
   // this one will do. Without the reset, stages the new attempt skips would
   // still render as completed, which is the very fabrication this change
-  // exists to remove. Keyed off the stage moving back to a restart stage
-  // rather than off our own Retry buttons, so a restart initiated on the
-  // Rust side resets it too.
+  // exists to remove.
+  //
+  // Retries we initiate call beginAttempt() directly, so their boundary is
+  // exact. This effect is the FALLBACK for a restart begun on the Rust side,
+  // where the stage poll is the only signal we get. There the boundary can
+  // land up to one poll interval late, and log lines from the new attempt in
+  // that window are discarded rather than counted. That is the deliberate
+  // direction to fail in: a discarded line can leave a step showing pending
+  // (conservative, and honest), whereas counting a stale line would render a
+  // step DONE for work this attempt never did — the bug this change exists to
+  // fix. Closing the window entirely needs a Rust-provided attempt id, which
+  // would be a new IPC surface and is deliberately out of scope here.
   useEffect(() => {
     const prev = prevStageRef.current;
     prevStageRef.current = stage;
     const restarted = RESTART_STAGES.has(stage) && !RESTART_STAGES.has(prev);
     if (restarted) {
-      setAttemptStart(Date.now());
+      if (selfInitiatedRef.current) {
+        // beginAttempt() already opened this attempt with an exact boundary.
+        // Re-stamping it here — a poll interval later — would discard the
+        // new attempt's own early log lines, which is the bug this guard
+        // exists to prevent.
+        selfInitiatedRef.current = false;
+      } else {
+        setAttemptStart(Date.now());
+      }
       setPolledStages(new Set([stage]));
       return;
     }

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -120,6 +120,13 @@ const STEPS = [
   'starting_backend',
 ];
 
+// Stages that only occur when there is actual first-run/repair work to do.
+// `awaiting_setup` renders its own screen (FirstRunSetup) rather than the
+// step list below, but it still counts as "install work observed" (#1894):
+// reaching it means Rust found no venv and is about to do real work, so the
+// journey chrome should already be armed by the time the step list appears.
+const INSTALL_STAGES = ['downloading_uv', 'creating_venv', 'installing_deps', 'awaiting_setup'];
+
 const MAX_LOG_LINES = 200;
 
 /** Scan logs + error message for known failure patterns and return i18n keys
@@ -445,6 +452,10 @@ export function BootstrapSplash({ stage, message }) {
   const [progress, setProgress] = useState(null);
   const [region, setRegionState] = useState('auto');
   const [retrying, setRetrying] = useState(false);
+  // Stages actually seen this session (sticky/monotonic — see the tracking
+  // effect below). Drives "done" ticks and journey visibility off observed
+  // reality instead of list position (#1894).
+  const [observedStages, setObservedStages] = useState(() => new Set([stage]));
   const logRef = useRef(null);
   const prevProgRef = useRef(null); // {bytes, t} — last progress event
   const rateRef = useRef(0); // EMA bytes/sec across events
@@ -454,6 +465,12 @@ export function BootstrapSplash({ stage, message }) {
   const isFailed = stage === 'failed';
   // Retrying an Intel-Mac install can never succeed — don't offer the dead end.
   const isUnrecoverable = isFailed && isUnrecoverableFailure(message, logs);
+  // True once any genuine install stage has been observed this session. On a
+  // warm start the Rust stage jumps straight from `checking` to
+  // `starting_backend` — nothing here ever fires — so the first-run install
+  // chrome (journey rail, "Installing" heading, step list) stays suppressed
+  // instead of fabricating completed work (#1894).
+  const installWorkSeen = INSTALL_STAGES.some((s) => observedStages.has(s));
 
   const handleRetry = async () => {
     if (retrying) return;
@@ -483,6 +500,15 @@ export function BootstrapSplash({ stage, message }) {
       setRetrying(false);
     }
   };
+
+  // Record `stage` as observed the moment it's seen. Sticky/monotonic: the
+  // functional updater bails out (same Set reference) once a stage is
+  // already recorded, so this never un-observes anything and never loops.
+  // `bootstrap_status` is polled ~1/s by useBootstrapStage, so a stage that
+  // actually ran is guaranteed to land here at least once (#1894).
+  useEffect(() => {
+    setObservedStages((prev) => (prev.has(stage) ? prev : new Set(prev).add(stage)));
+  }, [stage]);
 
   // Load persisted region on mount.
   useEffect(() => {
@@ -638,7 +664,10 @@ export function BootstrapSplash({ stage, message }) {
           data-tauri-drag-region
         >
           <Waveform />
-          <JourneyRail t={t} />
+          {/* Suppressed until real install work is observed — otherwise a
+              warm start (or a repair sync) shows "Setup done / Installing
+              active" for work that never happened (#1894). */}
+          {installWorkSeen && <JourneyRail t={t} />}
           <div className="mt-2 flex flex-wrap items-end justify-between gap-6">
             <div className="min-w-0">
               {/* Version rides beside the app name — same masthead across all
@@ -760,9 +789,16 @@ export function BootstrapSplash({ stage, message }) {
           </section>
         ) : (
           <section className="fr-rise flex flex-col gap-2.5" style={{ '--rise': 1 }}>
-            <h2 className="m-0 font-mono text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-fg-muted">
-              {t('firstrun.installing_title', 'Installing')}
-            </h2>
+            {/* Heading, step list and resume note only make sense once real
+                install work has actually been observed — otherwise a warm
+                start or a repair sync narrates a first-run install that
+                never happened (#1894). The live stage label in the masthead
+                and the progress meter below stay visible either way. */}
+            {installWorkSeen && (
+              <h2 className="m-0 font-mono text-[0.62rem] font-semibold uppercase tracking-[0.18em] text-fg-muted">
+                {t('firstrun.installing_title', 'Installing')}
+              </h2>
+            )}
             {/* Overall journey meter. */}
             <Progress
               value={overallPct}
@@ -770,61 +806,69 @@ export function BootstrapSplash({ stage, message }) {
               size="md"
               aria-valuenow={Math.round(overallPct)}
             />
-            <ol className="m-0 mt-1 flex list-none flex-col gap-2 p-0">
-              {STEPS.map((s, i) => {
-                const done = i < stepIndex;
-                const activeStep = i === stepIndex;
-                return (
-                  <li
-                    key={s}
-                    className={cn(
-                      'flex min-w-0 items-center gap-2 text-sm',
-                      !done && !activeStep && 'opacity-45',
-                    )}
-                  >
-                    <span
+            {installWorkSeen && (
+              <ol className="m-0 mt-1 flex list-none flex-col gap-2 p-0">
+                {STEPS.map((s, i) => {
+                  const activeStep = i === stepIndex;
+                  // Done only if this stage was actually observed AND it isn't
+                  // the one currently in progress — list POSITION alone lies on
+                  // a warm start or a repair sync, where earlier stages in the
+                  // fixed STEPS order are skipped by Rust entirely (#1894).
+                  const done = !activeStep && observedStages.has(s);
+                  return (
+                    <li
+                      key={s}
                       className={cn(
-                        'h-1.5 w-1.5 shrink-0 rounded-full',
-                        done
-                          ? 'bg-success shadow-[0_0_5px_1px_color-mix(in_srgb,var(--color-success)_50%,transparent)]'
-                          : activeStep
-                            ? 'bg-primary shadow-[0_0_6px_1px_var(--color-brand-glow)] fr-pulse'
-                            : 'bg-fg-subtle/40',
+                        'flex min-w-0 items-center gap-2 text-sm',
+                        !done && !activeStep && 'opacity-45',
                       )}
-                      aria-hidden="true"
-                    />
-                    <span className={cn(activeStep && 'font-semibold', done && 'text-fg-muted')}>
-                      {t(`bootstrap.${s}`, STAGE_LABEL[s])}
-                    </span>
-                    {activeStep && stageProgress && (
-                      <span className="ml-auto whitespace-nowrap font-mono text-[0.64rem] tabular-nums text-fg-muted">
-                        {formatBytes(stageProgress.bytes_done)}
-                        {stageProgress.bytes_total > 0
-                          ? ` / ${formatBytes(stageProgress.bytes_total)}`
-                          : ''}
-                        {pctFromBytes != null ? ` (${pctFromBytes}%)` : ''}
-                        {stageProgress.bytes_total > 0 &&
-                          rateRef.current > 0 &&
-                          stageProgress.bytes_done < stageProgress.bytes_total &&
-                          ` · ${t('firstrun.eta_left', {
-                            eta: formatEta(
-                              (stageProgress.bytes_total - stageProgress.bytes_done) /
-                                rateRef.current,
-                            ),
-                            defaultValue: '~{{eta}} left',
-                          })}`}
+                    >
+                      <span
+                        className={cn(
+                          'h-1.5 w-1.5 shrink-0 rounded-full',
+                          done
+                            ? 'bg-success shadow-[0_0_5px_1px_color-mix(in_srgb,var(--color-success)_50%,transparent)]'
+                            : activeStep
+                              ? 'bg-primary shadow-[0_0_6px_1px_var(--color-brand-glow)] fr-pulse'
+                              : 'bg-fg-subtle/40',
+                        )}
+                        aria-hidden="true"
+                      />
+                      <span className={cn(activeStep && 'font-semibold', done && 'text-fg-muted')}>
+                        {t(`bootstrap.${s}`, STAGE_LABEL[s])}
                       </span>
-                    )}
-                  </li>
-                );
-              })}
-            </ol>
-            <p className="m-0 text-xs text-fg-subtle">
-              {t(
-                'firstrun.resume_note',
-                'Interrupted downloads resume automatically — closing the app is safe.',
-              )}
-            </p>
+                      {activeStep && stageProgress && (
+                        <span className="ml-auto whitespace-nowrap font-mono text-[0.64rem] tabular-nums text-fg-muted">
+                          {formatBytes(stageProgress.bytes_done)}
+                          {stageProgress.bytes_total > 0
+                            ? ` / ${formatBytes(stageProgress.bytes_total)}`
+                            : ''}
+                          {pctFromBytes != null ? ` (${pctFromBytes}%)` : ''}
+                          {stageProgress.bytes_total > 0 &&
+                            rateRef.current > 0 &&
+                            stageProgress.bytes_done < stageProgress.bytes_total &&
+                            ` · ${t('firstrun.eta_left', {
+                              eta: formatEta(
+                                (stageProgress.bytes_total - stageProgress.bytes_done) /
+                                  rateRef.current,
+                              ),
+                              defaultValue: '~{{eta}} left',
+                            })}`}
+                        </span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+            {installWorkSeen && (
+              <p className="m-0 text-xs text-fg-subtle">
+                {t(
+                  'firstrun.resume_note',
+                  'Interrupted downloads resume automatically — closing the app is safe.',
+                )}
+              </p>
+            )}
           </section>
         )}
 

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -568,7 +568,17 @@ export function BootstrapSplash({ stage, message }) {
   useEffect(() => {
     const prev = prevStageRef.current;
     prevStageRef.current = stage;
-    const restarted = RESTART_STAGES.has(stage) && !RESTART_STAGES.has(prev);
+    // Two ways a new attempt shows up in the poll. Arriving at a restart
+    // stage is the common one. But the poll can also miss the restart stage
+    // entirely — `failed` -> (retry) -> `checking` -> `starting_backend`
+    // inside one ~1s sample window surfaces as `failed` -> `starting_backend`,
+    // and keying only off restart stages would leave the FAILED attempt's
+    // evidence in place and render its install chrome as this attempt's
+    // completed work. Leaving `failed` at all means a retry began, since
+    // retry_bootstrap/clean_and_retry_bootstrap are the only exits from it.
+    const restarted =
+      (RESTART_STAGES.has(stage) && !RESTART_STAGES.has(prev)) ||
+      (prev === 'failed' && stage !== 'failed');
     if (restarted) {
       if (selfInitiatedRef.current) {
         // beginAttempt() already opened this attempt with an exact boundary.

--- a/frontend/src/test/BootstrapSplashObservedStages.test.jsx
+++ b/frontend/src/test/BootstrapSplashObservedStages.test.jsx
@@ -205,4 +205,25 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
       expect(venvStep.className).toMatch(/text-fg-muted/);
     });
   });
+
+  it('a retry whose restart stage the poll never sampled still drops the old evidence', () => {
+    // CodeRabbit finding on 5e9538a0: a retry can go failed -> checking ->
+    // starting_backend inside one ~1s sample window, so the poll observes
+    // only failed -> starting_backend. Keying the reset solely off arriving
+    // at a restart stage would leave the FAILED attempt's stages in place and
+    // present them as this attempt's completed work.
+    const { rerender } = render(<BootstrapSplash stage="checking" message={null} />);
+    rerender(<BootstrapSplash stage="downloading_uv" message={null} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
+    rerender(<BootstrapSplash stage="failed" message="uv sync failed" />);
+
+    // Retry — and the poll misses `checking` entirely.
+    rerender(<BootstrapSplash stage="starting_backend" message={null} />);
+
+    expect(screen.getByText('Starting backend…')).toBeInTheDocument();
+    // Nothing from the failed attempt may be shown as this attempt's work.
+    expect(screen.queryByText('Downloading uv (Python package manager)…')).toBeNull();
+    expect(screen.queryByText(/first run, 5.10 min/)).toBeNull();
+    expect(screen.queryByText('Installing')).toBeNull();
+  });
 });

--- a/frontend/src/test/BootstrapSplashObservedStages.test.jsx
+++ b/frontend/src/test/BootstrapSplashObservedStages.test.jsx
@@ -12,13 +12,19 @@
  * but `downloading_uv`/`creating_venv` still rendered done), and `JourneyRail`
  * hardcoded Setup=done/Installing=active regardless of `stage`.
  *
- * The fix tracks which stages were actually observed (sticky, via the
- * `bootstrap_status` poll) and derives doneness + journey-chrome visibility
- * from that instead of list position.
+ * The fix tracks which stages were actually observed and derives doneness +
+ * journey-chrome visibility from that instead of list position.
+ *
+ * Two follow-up findings from bot review on PR #1896 are covered at the end:
+ *   - the ~1s `bootstrap_status` poll can miss a stage that starts and
+ *     finishes between samples, so stage-tagged `bootstrap-log` lines are
+ *     unioned in as independent proof a stage ran;
+ *   - a Retry restarts the bootstrap, so stages observed during the previous
+ *     attempt must not carry over and render as done in the new one.
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { BootstrapSplash } from '../components/BootstrapSplash';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -109,5 +115,50 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
         expect(stepLabel.className).toMatch(/text-fg-muted/);
       }
     }
+  });
+
+  it('a stage the 1s poll never sampled still counts as done when its logs prove it ran', async () => {
+    // Greptile finding on #1896: `bootstrap_status` is sampled ~1/s, so on a
+    // fast disk `creating_venv` can start and finish between two samples and
+    // never be polled. Stage-tagged bootstrap logs are emitted as the work
+    // happens, so they are independent proof the stage ran.
+    window.__TAURI_INTERNALS__ = {};
+    const { invoke } = await import('@tauri-apps/api/core');
+    invoke.mockImplementation(async (cmd) =>
+      cmd === 'get_bootstrap_logs'
+        ? [{ stage: 'creating_venv', line: 'Creating virtualenv at .venv' }]
+        : null,
+    );
+
+    // Poll sequence skips creating_venv entirely.
+    const { rerender } = render(<BootstrapSplash stage="downloading_uv" message={null} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
+
+    await waitFor(() => {
+      const venvStep = screen.getByText('Creating Python virtual environment…');
+      expect(venvStep.className).toMatch(/text-fg-muted/);
+    });
+  });
+
+  it('a retry drops stages observed during the previous attempt', () => {
+    // Greptile finding on #1896: the observed set was add-only and the splash
+    // stays mounted across a Retry, so a stage the FAILED attempt reached
+    // would still render done in the new attempt even if that attempt skips
+    // it. Arriving back at `checking` from elsewhere means a new attempt.
+    const { rerender } = render(<BootstrapSplash stage="checking" message={null} />);
+    rerender(<BootstrapSplash stage="downloading_uv" message={null} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
+    rerender(<BootstrapSplash stage="failed" message="uv sync failed" />);
+
+    // Retry: Rust goes back to `checking`, then this attempt finds the venv
+    // healthy and jumps straight to starting_backend.
+    rerender(<BootstrapSplash stage="checking" message={null} />);
+    rerender(<BootstrapSplash stage="starting_backend" message={null} />);
+
+    // Nothing from the previous attempt may be presented as this attempt's
+    // completed work — so the install chrome is gone entirely again.
+    expect(screen.queryByText('Downloading uv (Python package manager)…')).toBeNull();
+    expect(screen.queryByText(/first run, 5.10 min/)).toBeNull();
+    expect(screen.getByText('Starting backend…')).toBeInTheDocument();
   });
 });

--- a/frontend/src/test/BootstrapSplashObservedStages.test.jsx
+++ b/frontend/src/test/BootstrapSplashObservedStages.test.jsx
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for #1894 — the first-run INSTALLING journey was shown on
+ * every launch, with green ticks for work that never ran.
+ *
+ * `BootstrapSplash` used to derive "done" purely from `STEPS.indexOf(stage)`
+ * (BootstrapSplash.jsx:453/774 pre-fix): on a warm start Rust jumps straight
+ * from `checking` to `starting_backend` (bootstrap.rs finds the venv healthy
+ * and returns early), so `downloading_uv`, `creating_venv` and
+ * `installing_deps` — including the "first run, 5–10 min." label — all
+ * rendered with a green DONE tick for work that never happened. The same
+ * fabrication hit a repair sync (venv exists, only `installing_deps` runs,
+ * but `downloading_uv`/`creating_venv` still rendered done), and `JourneyRail`
+ * hardcoded Setup=done/Installing=active regardless of `stage`.
+ *
+ * The fix tracks which stages were actually observed (sticky, via the
+ * `bootstrap_status` poll) and derives doneness + journey-chrome visibility
+ * from that instead of list position.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BootstrapSplash } from '../components/BootstrapSplash';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => null),
+}));
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+beforeEach(() => {
+  // Not in a Tauri context: the log/progress subscription effects no-op.
+  delete window.__TAURI_INTERNALS__;
+});
+
+describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
+  it('warm start (checking -> starting_backend): no fabricated done ticks, no "first run" chrome', () => {
+    const { rerender } = render(<BootstrapSplash stage="checking" message={null} />);
+
+    // The journey rail and "Installing" heading must not appear before any
+    // real install stage has ever been observed.
+    expect(screen.queryByText('Installing')).toBeNull();
+    expect(screen.queryByText('Setup')).toBeNull();
+    expect(screen.queryByText('Models & engines')).toBeNull();
+
+    rerender(<BootstrapSplash stage="starting_backend" message={null} />);
+
+    // Live stage label still shows — this is not a blank screen.
+    expect(screen.getByText('Starting backend…')).toBeInTheDocument();
+    // The install journey never appeared: bootstrap.rs never entered any of
+    // downloading_uv/creating_venv/installing_deps on this run.
+    expect(screen.queryByText('Installing')).toBeNull();
+    expect(screen.queryByText('Downloading uv (Python package manager)…')).toBeNull();
+    expect(screen.queryByText('Creating Python virtual environment…')).toBeNull();
+    expect(screen.queryByText(/first run, 5.10 min/)).toBeNull();
+  });
+
+  it('repair sync (checking -> installing_deps): installing_deps active, earlier steps not fabricated done', () => {
+    const { rerender } = render(<BootstrapSplash stage="checking" message={null} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
+
+    // Real install work observed: the journey chrome comes back (both the
+    // JourneyRail item and the section heading render the same "Installing"
+    // string, so there are two matches).
+    expect(screen.getAllByText('Installing').length).toBeGreaterThan(0);
+    // The live stage label (masthead) and the step-list item both render the
+    // "first run, 5-10 min" text; scope to the step-list one inside the <ol>.
+    const activeLabel = screen.getAllByText(/first run, 5.10 min/).find((el) => el.closest('ol'));
+    expect(activeLabel).toBeInTheDocument();
+    // The active step renders semibold, not the muted "done" styling.
+    expect(activeLabel.className).toMatch(/font-semibold/);
+    expect(activeLabel.className).not.toMatch(/text-fg-muted/);
+
+    // downloading_uv/creating_venv were never entered by Rust on a repair
+    // sync — they must render as pending, not done.
+    const uvStep = screen.getByText('Downloading uv (Python package manager)…');
+    const venvStep = screen.getByText('Creating Python virtual environment…');
+    expect(uvStep.className).not.toMatch(/text-fg-muted/);
+    expect(venvStep.className).not.toMatch(/text-fg-muted/);
+  });
+
+  it('genuine first run walks all five stages: every step is marked done as it passes (no regression)', () => {
+    const stages = [
+      'checking',
+      'downloading_uv',
+      'creating_venv',
+      'installing_deps',
+      'starting_backend',
+    ];
+    const { rerender } = render(<BootstrapSplash stage={stages[0]} message={null} />);
+
+    for (let i = 1; i < stages.length; i += 1) {
+      rerender(<BootstrapSplash stage={stages[i]} message={null} />);
+      // Every stage strictly before the current one must show as done
+      // (muted styling), since this run genuinely walked through each one.
+      for (let j = 0; j < i; j += 1) {
+        const stepLabel = screen.getByText(
+          {
+            checking: 'Checking environment…',
+            downloading_uv: 'Downloading uv (Python package manager)…',
+            creating_venv: 'Creating Python virtual environment…',
+            installing_deps: /first run, 5.10 min/,
+            starting_backend: 'Starting backend…',
+          }[stages[j]],
+        );
+        expect(stepLabel.className).toMatch(/text-fg-muted/);
+      }
+    }
+  });
+});

--- a/frontend/src/test/BootstrapSplashObservedStages.test.jsx
+++ b/frontend/src/test/BootstrapSplashObservedStages.test.jsx
@@ -24,7 +24,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { BootstrapSplash } from '../components/BootstrapSplash';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -160,5 +160,49 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
     expect(screen.queryByText('Downloading uv (Python package manager)…')).toBeNull();
     expect(screen.queryByText(/first run, 5.10 min/)).toBeNull();
     expect(screen.getByText('Starting backend…')).toBeInTheDocument();
+  });
+
+  it('logs arriving after Retry but before the next poll are not discarded', async () => {
+    // Greptile finding on ece08bd7: the attempt boundary was stamped when the
+    // ~1s poll first reported `checking`, which lands AFTER the Rust side has
+    // already emitted the new attempt's first log lines — so that evidence was
+    // filtered out as "previous attempt" and a fast stage missed by polling
+    // stayed pending. The boundary must open when the retry is initiated.
+    window.__TAURI_INTERNALS__ = {};
+    const { invoke } = await import('@tauri-apps/api/core');
+    const { listen } = await import('@tauri-apps/api/event');
+    const handlers = {};
+    listen.mockImplementation(async (name, cb) => {
+      handlers[name] = cb;
+      return () => {};
+    });
+    invoke.mockImplementation(async () => null);
+
+    const { rerender } = render(<BootstrapSplash stage="failed" message="uv sync failed" />);
+    await waitFor(() => expect(handlers['bootstrap-log']).toBeTypeOf('function'));
+
+    // User clicks Retry — this opens the new attempt.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Retry$/ }));
+    });
+
+    // Rust immediately emits the new attempt's logs, still before the poll
+    // has reported `checking`.
+    await act(async () => {
+      handlers['bootstrap-log']({
+        payload: { stage: 'creating_venv', line: 'Creating virtualenv at .venv' },
+      });
+    });
+
+    // Only now does the poll catch up, and it never samples creating_venv.
+    rerender(<BootstrapSplash stage="checking" message={null} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
+
+    // The log line proved creating_venv ran in THIS attempt; it must not have
+    // been discarded by a boundary stamped after it arrived.
+    await waitFor(() => {
+      const venvStep = screen.getByText('Creating Python virtual environment…');
+      expect(venvStep.className).toMatch(/text-fg-muted/);
+    });
   });
 });


### PR DESCRIPTION
## Root cause

`bootstrap.rs` (`ensure_environment`, ~line 2664) finds a healthy venv on a warm start and returns early, so the Rust stage goes `Checking` -> `StartingBackend`; `DownloadingUv`, `CreatingVenv`, `InstallingDeps` are never entered. `frontend/src/components/BootstrapSplash.jsx` derived step "done" purely from list position:

- `frontend/src/components/BootstrapSplash.jsx:453` — `const stepIndex = Math.max(0, STEPS.indexOf(stage));`
- `frontend/src/components/BootstrapSplash.jsx:774` — `const done = i < stepIndex;`

So on every routine relaunch, steps 0-3 rendered green DONE ticks for work that never ran — including the `installing_deps` label, "Installing dependencies — first run, 5-10 min." The same fabrication occurred during a repair sync (venv exists, `InstallingDeps` runs, but `downloading_uv`/`creating_venv` still rendered done). `JourneyRail` (`BootstrapSplash.jsx:231`) also hardcoded `Setup=done, Installing=active, Models=pending` and never read `stage` at all.

## What changed

`frontend/src/components/BootstrapSplash.jsx`:

- Added `observedStages`, a sticky `Set` of every stage actually seen this session (a `useEffect` keyed on `stage` adds to it via a functional updater that returns the same reference — and therefore no re-render — when the stage is already recorded, so it's monotonic and loop-safe).
- `done` for a step is now `!activeStep && observedStages.has(s)` instead of `i < stepIndex`, so a step only shows its green tick if it was actually polled as the current stage at some point — this fixes both the warm-start and the repair-sync case.
- Added `installWorkSeen`: true once any of `downloading_uv`, `creating_venv`, `installing_deps`, or `awaiting_setup` has been observed. When false, the `JourneyRail`, the "Installing" heading, the step list, and the resume note are suppressed — the masthead, live stage label, progress meter, and activity log remain visible. The moment a genuine install stage is observed, the full journey UI appears.
- New hook state/effect were placed following the file's existing hooks-before-derived-consts convention (see the comment at `BootstrapSplash.jsx:427-448`, from the #1159 TDZ minifier bug) — no derived `const` sits between hook calls.

No new user-facing strings: `bootstrap.starting_backend`/`bootstrap.checking` already existed, so no i18n changes were needed across the 21 locales.

## Tests

Added `frontend/src/test/BootstrapSplashObservedStages.test.jsx`, covering:

1. Warm start (`checking` -> `starting_backend`): no green tick on `downloading_uv`/`creating_venv`/`installing_deps`, no "first run, 5-10 min" text, journey rail/"Installing" heading absent.
2. Repair sync (`checking` -> `installing_deps`): `installing_deps` renders active (semibold, not muted), `downloading_uv`/`creating_venv` do not render with the "done" (muted) styling.
3. Genuine first run walking all five stages: every step is marked done as it's passed — no regression of existing correct behavior.

**Fail-before/pass-after**, verified by hand: swapped in the unpatched `origin/main` copy of `BootstrapSplash.jsx`, ran the new test file — 2 of 3 tests failed (test 1 threw on a duplicate "Installing" match since the chrome always rendered; test 2 failed asserting `text-fg-muted` was absent from `downloading_uv`/`creating_venv`, which it wasn't). Restored the fix — all 3 pass.

Ran the full frontend suite before pushing: 329 files / 2733 tests, all passing.

## Verified

- Fail-before/pass-after on the new test file (see above).
- All existing `BootstrapSplash*.test.jsx` files (6 files, 21 tests) still pass.
- Full `bunx vitest run`: 329 files, 2733 tests, all green.
- `oxlint`/`oxfmt --check` clean on the changed files (pre-existing `max-lines` / `only-export-components` warnings on this file are unrelated to this change).
- Changelog tests (`tests/test_changelog_style.py`, `tests/test_changelog_parse.py`) pass against the new `CHANGELOG.md` entry.
- Checked `README.md`/`docs/**` for any description of the splash's step-list/journey-rail visual behavior — found none (only unrelated mentions of the "Installing dependencies" stage name in troubleshooting text), so no docs-sync change was needed.

## Not verified

- Not manually tested in a real packaged Tauri build (macOS/Windows/Linux) against a real warm start / repair sync / first run — verification is via the jsdom-rendered component tests above only, driven by directly-supplied `stage` prop transitions rather than a live `bootstrap_status` poll loop or real `bootstrap.rs` events.
- Did not audit every other consumer of `BootstrapSplash`/`useBootstrapStage` beyond the existing test files found via grep (`splashWatchdog.test.js`, `portInUseHint.test.js`, `BackendStartFailureNotice.jsx`, `FirstRunSetup.jsx`) for indirect effects; those existing tests still pass unchanged.

Fixes #1894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The bootstrap splash now uses observed stages to hide installation-only UI during warm starts and non-installing repairs. It marks steps complete only after the current attempt observes them and resets this state after retries. Review the attempt-reset and log-timing logic for missed or stale stage evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->