### PR TITLE
fix(lifecycle): clear the run sentinel before the slow shutdown work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 
 - Fast macOS process exits no longer turn a completed shutdown into a permission error (#1809)
+- A deliberate, clean quit killed by the desktop shell's short shutdown grace no longer gets reported as a crash on next launch — the run sentinel now clears before the slower shutdown steps instead of after (#1895)
 
 ## [0.5.2] — 2026-09-02
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1083,17 +1083,26 @@ async def lifespan(app: FastAPI):
     # Retire the run sentinel FIRST, before any bounded wait below (#1895):
     # once uvicorn has begun graceful shutdown the exit is deliberate by
     # definition, so the sentinel has already done its job. This is one
-    # os.remove — comfortably inside any shutdown deadline, including the
-    # desktop shell's 2s grace (bootstrap.rs terminate_process_tree) and
-    # Windows' effectively-zero one (tools.rs force_terminate with no
-    # graceful phase at all) — unlike the ~50s worst-case tail of the
-    # bounded waits and model unload/free_vram()/gc.collect() below. Putting
-    # the deadline-sensitive step first makes correctness independent of how
-    # much of that tail actually runs before a SIGKILL, instead of depending
-    # on the shell-side deadline being long enough to cover it. sentinel_
-    # cleared feeds the truthful "Shutdown: done."/degraded log at the end of
-    # this function; nothing below re-clears the sentinel, so a later
-    # failure can't mask this result.
+    # os.remove, against a ~50s worst-case tail of bounded waits plus model
+    # unload / free_vram() / gc.collect() below. Measured on macOS: a normal
+    # shutdown takes 5.25s end to end, while the desktop shell allows 2s
+    # (bootstrap.rs terminate_process_tree) before SIGKILL — so the old
+    # placement at the very end was killed every time on any run that had
+    # reached a working state. Doing the deadline-sensitive step first makes
+    # correctness independent of how much of that tail runs, instead of
+    # depending on the shell-side deadline being long enough to cover it.
+    #
+    # SCOPE, explicitly: this only helps platforms where lifespan teardown
+    # actually BEGINS. On Windows it does not — tools.rs terminates the job
+    # object with no graceful phase at all, so this line is never reached and
+    # a deliberate quit is still misreported as a crash there. That needs the
+    # shell to signal deliberate intent before the hard kill, which is a
+    # separate Rust-side change and is tracked separately; nothing here
+    # should be read as fixing Windows.
+    #
+    # sentinel_cleared feeds the truthful "Shutdown: done."/degraded log at
+    # the end of this function; nothing below re-clears the sentinel, so a
+    # later failure can't mask this result.
     try:
         sentinel_cleared = run_sentinel.clear_sentinel()
     except Exception:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1080,6 +1080,24 @@ async def lifespan(app: FastAPI):
         app.state.startup_task = asyncio.create_task(_deferred_startup(app))
     yield
     # ── Graceful shutdown (SIGTERM from Tauri, Ctrl+C, etc.) ────────────
+    # Retire the run sentinel FIRST, before any bounded wait below (#1895):
+    # once uvicorn has begun graceful shutdown the exit is deliberate by
+    # definition, so the sentinel has already done its job. This is one
+    # os.remove — comfortably inside any shutdown deadline, including the
+    # desktop shell's 2s grace (bootstrap.rs terminate_process_tree) and
+    # Windows' effectively-zero one (tools.rs force_terminate with no
+    # graceful phase at all) — unlike the ~50s worst-case tail of the
+    # bounded waits and model unload/free_vram()/gc.collect() below. Putting
+    # the deadline-sensitive step first makes correctness independent of how
+    # much of that tail actually runs before a SIGKILL, instead of depending
+    # on the shell-side deadline being long enough to cover it. sentinel_
+    # cleared feeds the truthful "Shutdown: done."/degraded log at the end of
+    # this function; nothing below re-clears the sentinel, so a later
+    # failure can't mask this result.
+    try:
+        sentinel_cleared = run_sentinel.clear_sentinel()
+    except Exception:
+        sentinel_cleared = False
     # May run after a startup that never finished (SIGTERM mid-Phase-A/B), so
     # every handle is read from app.state with a None default and every
     # deferred-phase name is guarded.
@@ -1206,13 +1224,9 @@ async def lifespan(app: FastAPI):
         await close_http_client()
     except Exception:
         pass
-    # Last thing on a clean shutdown: retire the run sentinel so the next
-    # startup doesn't misread this exit as a crash (#1164). If clearing fails,
-    # retain the sentinel and report a degraded shutdown truthfully.
-    try:
-        sentinel_cleared = run_sentinel.clear_sentinel()
-    except Exception:
-        sentinel_cleared = False
+    # Sentinel was already retired at the TOP of this block (#1895) — report
+    # truthfully using that result rather than clearing (or re-checking) it
+    # again here, so a failure in the steps above can't mask it as "done."
     if sentinel_cleared:
         logger.info("Shutdown: done.")
     else:

--- a/backend/tests/test_run_sentinel.py
+++ b/backend/tests/test_run_sentinel.py
@@ -113,6 +113,93 @@ def test_unclean_shutdown_yields_crash_record(sentinel_env, monkeypatch):
     assert acked is False, "a fresh crash record must be unacknowledged"
 
 
+def test_lifespan_clears_sentinel_even_if_later_shutdown_raises(monkeypatch, tmp_path):
+    """THE #1895 regression: before this fix, ``clear_sentinel()`` was the
+    LAST statement of ``main.py``'s lifespan shutdown, behind ~50s of bounded
+    waits plus model unload / ``free_vram()`` / ``gc.collect()`` / httpx
+    close. The desktop shell's quit path grants only a 2s grace before
+    SIGKILL (``frontend/src-tauri/src/bootstrap.rs``
+    ``terminate_process_tree``), and Windows grants no graceful phase at all
+    (``tools.rs``) — nowhere near enough, so a deliberate, clean quit
+    routinely got killed before reaching that last line, leaving the
+    sentinel behind for the NEXT startup to misreport as "did not shut down
+    cleanly... likely crashed".
+
+    Simulates that class of interruption without an actual SIGKILL: a later
+    shutdown step (``model_loads_begin_shutdown()``, called unguarded well
+    after the sentinel clear) raises, so nothing past it in the shutdown
+    body ever runs — for this purpose, the same effect as being killed
+    mid-teardown.
+
+    Fail-before/pass-after: with ``clear_sentinel()`` moved to the TOP of
+    the shutdown block (immediately after ``yield``), the sentinel is
+    already gone by the time this raise happens, so the next startup must
+    not fabricate a crash record.
+    """
+    import asyncio
+    from fastapi import FastAPI
+
+    # Fresh `main`/`core`/`api`/`services` import, mirroring
+    # tests/test_model_load_shutdown.py's `_reimported_backend_modules`: a
+    # sibling suite may have purged these names from sys.modules, leaving a
+    # collection-time alias stale. Purging and re-importing here makes this
+    # test self-consistent in isolation, not dependent on suite order.
+    purge_names = ("main", "core", "api", "services")
+    purge_prefixes = ("core.", "api.", "services.")
+    saved = {
+        name: mod for name, mod in sys.modules.items()
+        if name in purge_names or name.startswith(purge_prefixes)
+    }
+
+    def _purge():
+        for name in [
+            n for n in sys.modules
+            if n in purge_names or n.startswith(purge_prefixes)
+        ]:
+            sys.modules.pop(name, None)
+
+    _purge()
+    try:
+        import main as main_mod
+        from core import run_sentinel as fresh_run_sentinel
+
+        monkeypatch.setattr(
+            fresh_run_sentinel, "SENTINEL_PATH", str(tmp_path / "run_sentinel.json")
+        )
+        monkeypatch.setattr(
+            fresh_run_sentinel, "CRASH_RECORD_PATH", str(tmp_path / "last_run_crash.json")
+        )
+        monkeypatch.setattr(
+            fresh_run_sentinel, "LOG_PATH", str(tmp_path / "omnivoice.log")
+        )
+        fresh_run_sentinel._reset_for_tests()
+
+        def _boom():
+            raise RuntimeError("simulated kill: interrupted after the early clear")
+
+        monkeypatch.setattr(main_mod, "model_loads_begin_shutdown", _boom)
+
+        async def scenario():
+            app = FastAPI()
+            async with main_mod.lifespan(app):
+                pass
+
+        with pytest.raises(RuntimeError, match="simulated kill"):
+            asyncio.run(scenario())
+
+        assert not os.path.exists(fresh_run_sentinel.SENTINEL_PATH), (
+            "sentinel must already be cleared even though a later shutdown "
+            "step raised before ever reaching the old clear-sentinel line"
+        )
+        assert fresh_run_sentinel.detect_unclean_shutdown() is None, (
+            "a deliberate quit interrupted after the early clear must never "
+            "be reported as a crash on the next startup"
+        )
+    finally:
+        _purge()
+        sys.modules.update(saved)
+
+
 def test_live_pid_means_second_instance_not_a_crash(sentinel_env):
     """A sentinel owned by a LIVE process is a concurrent second instance
     sharing DATA_DIR — never a crash, and we must not take over or delete


### PR DESCRIPTION
## Problem

A deliberate, clean quit is reported to the user on next launch as "The backend did not shut down cleanly last run — it likely crashed or was killed (for example by the OS running out of memory)".

**Measured** on macOS, build 0.5.2-153:
- Backend given SIGTERM directly, no shell deadline: graceful shutdown completes in **5.25 s** and `clear_sentinel()` runs correctly, clearing `run_sentinel.json`.
- Backend killed by the desktop shell's quit path: `frontend/src-tauri/src/bootstrap.rs:388` calls `terminate_process_tree(child, tree, Duration::from_secs(2))` — a **2 s** grace, then `force_terminate()` + `child.kill()`. The shutdown is SIGKILLed before completing, the sentinel survives, and the next startup honestly reports a crash.
- `clear_sentinel()` was the LAST statement of the lifespan shutdown (`backend/main.py:1213`), behind bounded waits totalling ~50 s worst case (5 s deferred-startup cancel, 20 s Phase-A thread join, 5 s MCP stop, 20 s `_cancel_and_await_tasks`) plus model unload / `free_vram()` / `gc.collect()` / watermark drain / httpx close. ~4.8 s of that elapses before `logger.info("Shutdown: cleaning up...")` (`main.py:1114`) even on an idle backend.
- Windows is worse: `frontend/src-tauri/src/tools.rs:522-528` calls `tree.force_terminate()` immediately with **no graceful phase at all**, so the sentinel can never be cleared there today.

The class of bug: the shutdown deadline is set by the side (the desktop shell) that doesn't know how long shutdown actually takes.

## Fix

Move `clear_sentinel()` to the **top** of the lifespan shutdown block in `backend/main.py`, immediately after `yield` — before the deferred-startup cancel and every other bounded wait. Once uvicorn has begun graceful shutdown the exit is deliberate by definition, so the sentinel has already done its job. This fixes the measured macOS path and other platforms where lifespan teardown begins; it does **not** fix Windows, whose current force-termination path never enters lifespan teardown.

The old `clear_sentinel()` call at the bottom of the function is **removed, not duplicated** — a later shutdown step failing can no longer mask the early clear's result. The existing truthful reporting is preserved: `sentinel_cleared` (now captured at the top) still drives `logger.info("Shutdown: done.")` vs. `logger.warning("Shutdown completed, but the run sentinel could not be cleared")` at the end.

For platforms that begin graceful teardown, sentinel correctness is now independent of how long the later cleanup takes: the clear happens before the slow and failure-prone work. Windows remains tracked separately in #1898 because its zero-grace force-termination path does not run this code at all.

`clear_sentinel()` in `backend/core/run_sentinel.py` was not touched. It's already idempotent and ownership-guarded (`_state["owns"]`); moving the call earlier doesn't change the `foreign_live` second-instance path (an instance that never took ownership still no-ops on clear, regardless of when it's called).

## What I verified

- **Fail-before / pass-after**, explicitly: added `test_lifespan_clears_sentinel_even_if_later_shutdown_raises` in `backend/tests/test_run_sentinel.py`. It drives the real `main.lifespan()` end-to-end, forces a later shutdown step (`model_loads_begin_shutdown()`, called unguarded well after the sentinel clear) to raise — simulating a kill hitting mid-teardown — and asserts the sentinel file is gone and `detect_unclean_shutdown()` returns `None` afterward.
  - Ran against the **unmodified** `backend/main.py` (temporarily reverted, not committed): **FAILED** — `assert not os.path.exists(...)` failed, sentinel was still present.
  - Ran against the fix: **PASSED**.
- Full `backend/tests/test_run_sentinel.py` (15 tests) passes with the fix.
- `backend/tests/test_shutdown_state_isolation.py` (5 tests) passes with the fix.
- `backend/tests/test_model_load_shutdown.py`: 2 of 21 tests fail (`test_preload_interrupted_by_shutdown_logs_info_only`, `test_lifespan_shutdown_mid_load_is_clean_and_clears_sentinel`) — confirmed **pre-existing on unmodified `origin/main`**, identical failure mode, unrelated to this change (looks like a GPU-pool-thread timing flake on this machine). Not touched by this PR.
- `tests/test_changelog_style.py` passes with the new CHANGELOG entry.
- Ran with `HF_HUB_OFFLINE=1` and an empty `HF_HUB_CACHE`, per repo test conventions.

**What I did NOT verify:** actual behavior on Windows or under a real SIGKILL from the Tauri shell (simulated via a forced exception instead, since a real SIGKILL can't run assertions afterward by definition). No hardware/OS beyond local macOS was used.

## Deferred follow-ups (not in this PR, intentionally)

- The Rust-side 2 s shutdown grace in `bootstrap.rs` is unchanged. Moving the clear ahead of slow cleanup fixes the measured sentinel case once graceful teardown starts, but the short deadline can still truncate other cleanup.
- Windows still has no graceful shutdown phase at all (`tools.rs` calls `force_terminate()` immediately), so this backend-only change cannot clear the sentinel there. #1898 tracks the Windows implementation separately.

Fixes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Moves `clear_sentinel()` to the start of graceful shutdown so deliberate quits are not reported as crashes after slow cleanup or shutdown failure. Adds a regression test for failures during later shutdown steps. Windows remains uncovered because it force-terminates without starting graceful teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
