### PR TITLE
fix(dictation): make Transcriptions capture actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Transcriptions dictation wakes the desktop recorder, presents one contextual start action, and centers its microphone icon with the label (#1902)
 - Install documentation help now prints correctly on Windows consoles using legacy encodings (#1815) — thanks @dajiaohuang!
 - Saved transcriptions with missing or invalid timestamps now remain readable (#1799) — thanks @yunaremaia and @tvbht!
 - Copying a saved transcription now uses the shared clipboard helper and reports failed copies accurately (#1803) — thanks @tvbht!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 
+- Transcriptions dictation wakes the desktop recorder, presents one contextual start action, and centers its microphone icon with the label (#1902)
 - Validate current-user Windows installers under a standard account on hosted runners (#1883)
 
 - The desktop app builds and opens from a fresh clone again (#1818) — thanks @flutterkage2k!
@@ -50,7 +51,6 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
-- Transcriptions dictation wakes the desktop recorder, presents one contextual start action, and centers its microphone icon with the label (#1902)
 - Install documentation help now prints correctly on Windows consoles using legacy encodings (#1815) — thanks @dajiaohuang!
 - Saved transcriptions with missing or invalid timestamps now remain readable (#1799) — thanks @yunaremaia and @tvbht!
 - Copying a saved transcription now uses the shared clipboard helper and reports failed copies accurately (#1803) — thanks @tvbht!

--- a/docs/features/dictation.md
+++ b/docs/features/dictation.md
@@ -19,8 +19,8 @@ own microphone audio to the versioned WebSocket API. See the
 
 The **Transcriptions** page offers the same recorder as one contextual
 **Start dictation** action: it appears in the empty state before the first
-transcript and moves to the page header once history exists. Desktop starts
-wake the recorder window before dispatch, so a hidden WebView cannot silently
+transcript and moves to the page header once history exists. A desktop start
+wakes the recorder window before dispatch, so a hidden WebView cannot silently
 miss the request. The in-app action confirms listener receipt, then resolves
 only after microphone startup is accepted. Disabled, rejected, timed-out, or
 failed starts are reported back on the page.

--- a/docs/features/dictation.md
+++ b/docs/features/dictation.md
@@ -17,6 +17,13 @@ own microphone audio to the versioned WebSocket API. See the
 3. Put the cursor in a text field, press the shortcut, speak, then release or
    press again.
 
+The **Transcriptions** page offers the same recorder as one contextual
+**Start dictation** action: it appears in the empty state before the first
+transcript and moves to the page header once history exists. Desktop starts
+wake the recorder window before dispatch, so a hidden WebView cannot silently
+miss the request. The in-app action resolves only after the recorder
+acknowledges delivery; otherwise the page reports the failed start.
+
 Whisper Tiny is the recommended default on macOS, Windows, and Linux. It
 auto-detects more than 90 languages. Parakeet TDT v3 remains available for its
 25 supported European languages, but it is not selected automatically.

--- a/docs/features/dictation.md
+++ b/docs/features/dictation.md
@@ -21,8 +21,9 @@ The **Transcriptions** page offers the same recorder as one contextual
 **Start dictation** action: it appears in the empty state before the first
 transcript and moves to the page header once history exists. Desktop starts
 wake the recorder window before dispatch, so a hidden WebView cannot silently
-miss the request. The in-app action resolves only after the recorder
-acknowledges delivery; otherwise the page reports the failed start.
+miss the request. The in-app action confirms listener receipt, then resolves
+only after microphone startup is accepted. Disabled, rejected, timed-out, or
+failed starts are reported back on the page.
 
 Whisper Tiny is the recommended default on macOS, Windows, and Linux. It
 auto-detects more than 90 languages. Parakeet TDT v3 remains available for its

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -1006,12 +1006,96 @@ pub fn get_effective_dictation_shortcut(
 }
 
 #[tauri::command]
-pub fn request_dictation_capture(app: tauri::AppHandle, action: String) -> Result<(), String> {
+pub async fn request_dictation_capture(
+    app: tauri::AppHandle,
+    action: String,
+) -> Result<(), String> {
     if action != "start" && action != "stop" && action != "toggle" {
         return Err("capture action must be start, stop, or toggle".into());
     }
-    crate::dispatch_dictation_capture(&app, &action);
-    Ok(())
+    let delivery_id = crate::request_dictation_capture_delivery(&app, &action)
+        .ok_or_else(|| "capture request could not be queued".to_string())?;
+    let wait_app = app.clone();
+    let acknowledged = tauri::async_runtime::spawn_blocking(move || {
+        wait_for_capture_delivery(
+            || {
+                let flags = wait_app.state::<AppFlags>();
+                let capture = flags
+                    .capture
+                    .lock()
+                    .map_err(|_| "Dictation capture state lock poisoned".to_string())?;
+                Ok(capture.delivery_pending(delivery_id))
+            },
+            CAPTURE_DELIVERY_TIMEOUT,
+        )
+    })
+    .await
+    .map_err(|error| format!("capture acknowledgement worker failed: {error}"))??;
+    if acknowledged {
+        return Ok(());
+    }
+
+    let flags = app.state::<AppFlags>();
+    let cancelled = flags
+        .capture
+        .lock()
+        .map_err(|_| "Dictation capture state lock poisoned".to_string())?
+        .cancel_delivery(delivery_id);
+    if let Some(event) = cancelled.filter(|event| event.name == "tray-dictate") {
+        flags.output.finish_session(event.payload.session_id);
+    }
+    Err("capture window did not acknowledge the request".into())
+}
+
+const CAPTURE_DELIVERY_TIMEOUT: Duration = Duration::from_secs(2);
+const CAPTURE_DELIVERY_POLL: Duration = Duration::from_millis(20);
+
+fn wait_for_capture_delivery<F>(mut pending: F, timeout: Duration) -> Result<bool, String>
+where
+    F: FnMut() -> Result<bool, String>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if !pending()? {
+            return Ok(true);
+        }
+        if Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(CAPTURE_DELIVERY_POLL);
+    }
+}
+
+#[cfg(test)]
+mod capture_request_tests {
+    use super::wait_for_capture_delivery;
+    use std::time::Duration;
+
+    #[test]
+    fn listener_acknowledgement_completes_the_request() {
+        let mut polls = 0;
+        let acknowledged = wait_for_capture_delivery(
+            || {
+                polls += 1;
+                Ok(polls < 2)
+            },
+            Duration::from_millis(50),
+        )
+        .expect("poll succeeds");
+
+        assert!(acknowledged);
+    }
+
+    #[test]
+    fn missing_listener_acknowledgement_times_out() {
+        let acknowledged = wait_for_capture_delivery(
+            || Ok(true),
+            Duration::from_millis(0),
+        )
+        .expect("poll succeeds");
+
+        assert!(!acknowledged);
+    }
 }
 
 /// Distance from the bottom edge of the work area, in logical pixels — clear of

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -1031,23 +1031,68 @@ pub async fn request_dictation_capture(
     })
     .await
     .map_err(|error| format!("capture acknowledgement worker failed: {error}"))??;
-    if acknowledged {
-        return Ok(());
+    if !acknowledged {
+        let flags = app.state::<AppFlags>();
+        let cancelled = flags
+            .capture
+            .lock()
+            .map_err(|_| "Dictation capture state lock poisoned".to_string())?
+            .cancel_delivery(delivery_id);
+        if let Some(event) = cancelled.filter(|event| event.name == "tray-dictate") {
+            flags.output.finish_session(event.payload.session_id);
+        }
+        return Err("capture window did not acknowledge the request".into());
     }
 
+    let outcome_app = app.clone();
+    let completed = tauri::async_runtime::spawn_blocking(move || {
+        wait_for_capture_delivery(
+            || {
+                let flags = outcome_app.state::<AppFlags>();
+                let capture = flags
+                    .capture
+                    .lock()
+                    .map_err(|_| "Dictation capture state lock poisoned".to_string())?;
+                Ok(!capture.completion_ready(delivery_id))
+            },
+            CAPTURE_ACCEPTANCE_TIMEOUT,
+        )
+    })
+    .await
+    .map_err(|error| format!("capture acceptance worker failed: {error}"))??;
+
     let flags = app.state::<AppFlags>();
-    let cancelled = flags
+    if completed {
+        let completion = flags
+            .capture
+            .lock()
+            .map_err(|_| "Dictation capture state lock poisoned".to_string())?
+            .take_completion(delivery_id);
+        return completion
+            .unwrap_or_else(|| Err("capture request completed without an outcome".into()));
+    }
+    if let Some(completion) = flags
         .capture
         .lock()
         .map_err(|_| "Dictation capture state lock poisoned".to_string())?
-        .cancel_delivery(delivery_id);
-    if let Some(event) = cancelled.filter(|event| event.name == "tray-dictate") {
+        .take_completion(delivery_id)
+    {
+        return completion;
+    }
+    if let Some(event) = flags
+        .capture
+        .lock()
+        .map_err(|_| "Dictation capture state lock poisoned".to_string())?
+        .cancel_delivery(delivery_id)
+        .filter(|event| event.name == "tray-dictate")
+    {
         flags.output.finish_session(event.payload.session_id);
     }
-    Err("capture window did not acknowledge the request".into())
+    Err("dictation capture did not start in time".into())
 }
 
 const CAPTURE_DELIVERY_TIMEOUT: Duration = Duration::from_secs(2);
+const CAPTURE_ACCEPTANCE_TIMEOUT: Duration = Duration::from_secs(60);
 const CAPTURE_DELIVERY_POLL: Duration = Duration::from_millis(20);
 
 fn wait_for_capture_delivery<F>(mut pending: F, timeout: Duration) -> Result<bool, String>
@@ -1253,6 +1298,21 @@ pub fn acknowledge_dictation_capture_delivery(
         return;
     };
     capture.acknowledge(registration_id, delivery_id);
+}
+
+#[tauri::command]
+pub fn complete_dictation_capture_delivery(
+    app: tauri::AppHandle,
+    registration_id: u64,
+    delivery_id: u64,
+    error: Option<String>,
+) {
+    let flags = app.state::<AppFlags>();
+    let Ok(mut capture) = flags.capture.lock() else {
+        log::warn!("Dictation capture state lock poisoned");
+        return;
+    };
+    capture.complete(registration_id, delivery_id, error);
 }
 
 #[tauri::command]

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use tauri_plugin_dialog::DialogExt;
 
 use crate::config::{load_config, save_config};
 use crate::dictation_shortcut::{update_tray_hint, DictationShortcutManager, ShortcutInfo};
-use crate::{AppFlags, CaptureReceiptCancellation, TrayHandle};
+use crate::{AppFlags, CaptureAcceptanceTimeout, CaptureReceiptCancellation, TrayHandle};
 use crate::{TRAY_ICON_DEFAULT, TRAY_ICON_RECORDING};
 
 // ── Native host-path authorization ───────────────────────────────────────
@@ -1080,22 +1080,17 @@ pub async fn request_dictation_capture(
         return completion
             .unwrap_or_else(|| Err("capture request completed without an outcome".into()));
     }
-    let (completion, cancelled) = {
-        let mut capture = flags
-            .capture
-            .lock()
-            .map_err(|_| "Dictation capture state lock poisoned".to_string())?;
-        if let Some(completion) = capture.take_completion(delivery_id) {
-            (Some(completion), None)
-        } else {
-            (None, capture.cancel_delivery(delivery_id))
+    let timeout_outcome = flags
+        .capture
+        .lock()
+        .map_err(|_| "Dictation capture state lock poisoned".to_string())?
+        .take_completion_or_cancel(delivery_id);
+    match timeout_outcome {
+        CaptureAcceptanceTimeout::Completed(completion) => return completion,
+        CaptureAcceptanceTimeout::Cancelled(event) if event.name == "tray-dictate" => {
+            flags.output.finish_session(event.payload.session_id);
         }
-    };
-    if let Some(completion) = completion {
-        return completion;
-    }
-    if let Some(event) = cancelled.filter(|event| event.name == "tray-dictate") {
-        flags.output.finish_session(event.payload.session_id);
+        CaptureAcceptanceTimeout::Cancelled(_) | CaptureAcceptanceTimeout::Missing => {}
     }
     Err("dictation capture did not start in time".into())
 }

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use tauri_plugin_dialog::DialogExt;
 
 use crate::config::{load_config, save_config};
 use crate::dictation_shortcut::{update_tray_hint, DictationShortcutManager, ShortcutInfo};
-use crate::{AppFlags, TrayHandle};
+use crate::{AppFlags, CaptureReceiptCancellation, TrayHandle};
 use crate::{TRAY_ICON_DEFAULT, TRAY_ICON_RECORDING};
 
 // ── Native host-path authorization ───────────────────────────────────────
@@ -1016,7 +1016,7 @@ pub async fn request_dictation_capture(
     let delivery_id = crate::request_dictation_capture_delivery(&app, &action)
         .ok_or_else(|| "capture request could not be queued".to_string())?;
     let wait_app = app.clone();
-    let acknowledged = tauri::async_runtime::spawn_blocking(move || {
+    let mut acknowledged = tauri::async_runtime::spawn_blocking(move || {
         wait_for_capture_delivery(
             || {
                 let flags = wait_app.state::<AppFlags>();
@@ -1033,16 +1033,25 @@ pub async fn request_dictation_capture(
     .map_err(|error| format!("capture acknowledgement worker failed: {error}"))??;
     if !acknowledged {
         let flags = app.state::<AppFlags>();
-        let cancelled = flags
+        let timeout_outcome = flags
             .capture
             .lock()
             .map_err(|_| "Dictation capture state lock poisoned".to_string())?
-            .cancel_delivery(delivery_id);
-        if let Some(event) = cancelled.filter(|event| event.name == "tray-dictate") {
-            flags.output.finish_session(event.payload.session_id);
+            .cancel_unreceived_delivery(delivery_id);
+        match timeout_outcome {
+            CaptureReceiptCancellation::Received => acknowledged = true,
+            CaptureReceiptCancellation::Cancelled(event) => {
+                if event.name == "tray-dictate" {
+                    flags.output.finish_session(event.payload.session_id);
+                }
+                return Err("capture window did not acknowledge the request".into());
+            }
+            CaptureReceiptCancellation::Missing => {
+                return Err("capture request disappeared before acknowledgement".into());
+            }
         }
-        return Err("capture window did not acknowledge the request".into());
     }
+    debug_assert!(acknowledged);
 
     let outcome_app = app.clone();
     let completed = tauri::async_runtime::spawn_blocking(move || {
@@ -1071,21 +1080,21 @@ pub async fn request_dictation_capture(
         return completion
             .unwrap_or_else(|| Err("capture request completed without an outcome".into()));
     }
-    if let Some(completion) = flags
-        .capture
-        .lock()
-        .map_err(|_| "Dictation capture state lock poisoned".to_string())?
-        .take_completion(delivery_id)
-    {
+    let (completion, cancelled) = {
+        let mut capture = flags
+            .capture
+            .lock()
+            .map_err(|_| "Dictation capture state lock poisoned".to_string())?;
+        if let Some(completion) = capture.take_completion(delivery_id) {
+            (Some(completion), None)
+        } else {
+            (None, capture.cancel_delivery(delivery_id))
+        }
+    };
+    if let Some(completion) = completion {
         return completion;
     }
-    if let Some(event) = flags
-        .capture
-        .lock()
-        .map_err(|_| "Dictation capture state lock poisoned".to_string())?
-        .cancel_delivery(delivery_id)
-        .filter(|event| event.name == "tray-dictate")
-    {
+    if let Some(event) = cancelled.filter(|event| event.name == "tray-dictate") {
         flags.output.finish_session(event.payload.session_id);
     }
     Err("dictation capture did not start in time".into())
@@ -1291,13 +1300,13 @@ pub fn acknowledge_dictation_capture_delivery(
     app: tauri::AppHandle,
     registration_id: u64,
     delivery_id: u64,
-) {
+) -> bool {
     let flags = app.state::<AppFlags>();
     let Ok(mut capture) = flags.capture.lock() else {
         log::warn!("Dictation capture state lock poisoned");
-        return;
+        return false;
     };
-    capture.acknowledge(registration_id, delivery_id);
+    capture.acknowledge(registration_id, delivery_id)
 }
 
 #[tauri::command]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -115,6 +115,12 @@ struct CaptureInFlight {
     outcome: Option<Result<(), String>>,
 }
 
+pub(crate) enum CaptureReceiptCancellation {
+    Received,
+    Cancelled(CaptureEvent),
+    Missing,
+}
+
 struct CaptureEnqueue {
     delivery_id: u64,
     event: Option<CaptureEvent>,
@@ -176,9 +182,9 @@ impl CaptureDispatchState {
         }
     }
 
-    pub(crate) fn acknowledge(&mut self, registration_id: u64, delivery_id: u64) {
+    pub(crate) fn acknowledge(&mut self, registration_id: u64, delivery_id: u64) -> bool {
         if self.active_registration != Some(registration_id) {
-            return;
+            return false;
         }
         if let Some(index) = self
             .pending
@@ -195,8 +201,10 @@ impl CaptureDispatchState {
                         },
                     );
                 }
+                return true;
             }
         }
+        false
     }
 
     pub(crate) fn complete(
@@ -231,6 +239,25 @@ impl CaptureDispatchState {
         self.pending
             .iter()
             .any(|event| event.payload.delivery_id == delivery_id)
+    }
+
+    pub(crate) fn cancel_unreceived_delivery(
+        &mut self,
+        delivery_id: u64,
+    ) -> CaptureReceiptCancellation {
+        if self.in_flight.contains_key(&delivery_id) {
+            return CaptureReceiptCancellation::Received;
+        }
+        let Some(index) = self
+            .pending
+            .iter()
+            .position(|event| event.payload.delivery_id == delivery_id)
+        else {
+            return CaptureReceiptCancellation::Missing;
+        };
+        self.pending
+            .remove(index)
+            .map_or(CaptureReceiptCancellation::Missing, CaptureReceiptCancellation::Cancelled)
     }
 
     pub(crate) fn cancel_delivery(&mut self, delivery_id: u64) -> Option<CaptureEvent> {
@@ -358,7 +385,8 @@ fn dispatch_dictation_capture_from(
 #[cfg(test)]
 mod dictation_capture_tests {
     use super::{
-        dictation_capture_event, CaptureDispatchState, CaptureEvent, DictationCapturePayload,
+        dictation_capture_event, CaptureDispatchState, CaptureEvent, CaptureReceiptCancellation,
+        DictationCapturePayload,
     };
 
     fn capture_event(name: &'static str) -> CaptureEvent {
@@ -403,10 +431,10 @@ mod dictation_capture_tests {
         assert_eq!(retried[0].payload.delivery_id, delivery_id);
         assert_eq!(retried[0].payload.registration_id, current);
 
-        state.acknowledge(stale, delivery_id);
+        assert!(!state.acknowledge(stale, delivery_id));
         assert_eq!(state.pending.len(), 1);
         assert!(state.delivery_pending(delivery_id));
-        state.acknowledge(current, delivery_id);
+        assert!(state.acknowledge(current, delivery_id));
         assert!(state.pending.is_empty());
         assert!(!state.delivery_pending(delivery_id));
     }
@@ -434,7 +462,7 @@ mod dictation_capture_tests {
         event.await_result = true;
         let delivery_id = state.enqueue(event).delivery_id;
 
-        state.acknowledge(registration_id, delivery_id);
+        assert!(state.acknowledge(registration_id, delivery_id));
         assert!(!state.completion_ready(delivery_id));
         state.complete(
             registration_id,
@@ -448,6 +476,42 @@ mod dictation_capture_tests {
             Some(Err("Dictation is disabled".into()))
         );
         assert_eq!(state.take_completion(delivery_id), None);
+    }
+
+    #[test]
+    fn cancellation_suppresses_an_event_cloned_for_ready_emission() {
+        let mut state = CaptureDispatchState::default();
+        let registration_id = state.begin_registration();
+        state.mark_registration_ready(registration_id);
+        let mut event = capture_event("tray-dictate");
+        event.await_result = true;
+        let enqueued = state.enqueue(event);
+        let emitted = enqueued.event.expect("ready event was cloned");
+
+        assert!(matches!(
+            state.cancel_unreceived_delivery(enqueued.delivery_id),
+            CaptureReceiptCancellation::Cancelled(_)
+        ));
+        assert!(!state.acknowledge(
+            emitted.payload.registration_id,
+            emitted.payload.delivery_id
+        ));
+    }
+
+    #[test]
+    fn listener_receipt_wins_atomically_over_timeout_cancellation() {
+        let mut state = CaptureDispatchState::default();
+        let registration_id = state.begin_registration();
+        state.mark_registration_ready(registration_id);
+        let mut event = capture_event("tray-dictate");
+        event.await_result = true;
+        let delivery_id = state.enqueue(event).delivery_id;
+
+        assert!(state.acknowledge(registration_id, delivery_id));
+        assert!(matches!(
+            state.cancel_unreceived_delivery(delivery_id),
+            CaptureReceiptCancellation::Received
+        ));
     }
 
     #[test]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -26,7 +26,7 @@ pub mod watch_folder;
 #[cfg(target_os = "linux")]
 pub mod wayland_shortcut;
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::process::Child;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -107,6 +107,12 @@ pub struct CaptureDispatchState {
     registration_counter: u64,
     delivery_counter: u64,
     active_registration: Option<u64>,
+    in_flight: HashMap<u64, CaptureInFlight>,
+}
+
+struct CaptureInFlight {
+    event: CaptureEvent,
+    outcome: Option<Result<(), String>>,
 }
 
 struct CaptureEnqueue {
@@ -122,6 +128,7 @@ impl Default for CaptureDispatchState {
             registration_counter: 0,
             delivery_counter: 0,
             active_registration: None,
+            in_flight: HashMap::new(),
         }
     }
 }
@@ -178,8 +185,46 @@ impl CaptureDispatchState {
             .iter()
             .position(|event| event.payload.delivery_id == delivery_id)
         {
-            self.pending.remove(index);
+            if let Some(event) = self.pending.remove(index) {
+                if event.await_result {
+                    self.in_flight.insert(
+                        delivery_id,
+                        CaptureInFlight {
+                            event,
+                            outcome: None,
+                        },
+                    );
+                }
+            }
         }
+    }
+
+    pub(crate) fn complete(
+        &mut self,
+        registration_id: u64,
+        delivery_id: u64,
+        error: Option<String>,
+    ) {
+        if self.active_registration != Some(registration_id) {
+            return;
+        }
+        if let Some(delivery) = self.in_flight.get_mut(&delivery_id) {
+            delivery.outcome = Some(error.map_or_else(|| Ok(()), Err));
+        }
+    }
+
+    pub(crate) fn completion_ready(&self, delivery_id: u64) -> bool {
+        self.in_flight
+            .get(&delivery_id)
+            .is_some_and(|delivery| delivery.outcome.is_some())
+    }
+
+    pub(crate) fn take_completion(&mut self, delivery_id: u64) -> Option<Result<(), String>> {
+        let ready = self.completion_ready(delivery_id);
+        ready
+            .then(|| self.in_flight.remove(&delivery_id))
+            .flatten()
+            .and_then(|delivery| delivery.outcome)
     }
 
     pub(crate) fn delivery_pending(&self, delivery_id: u64) -> bool {
@@ -189,11 +234,16 @@ impl CaptureDispatchState {
     }
 
     pub(crate) fn cancel_delivery(&mut self, delivery_id: u64) -> Option<CaptureEvent> {
-        let index = self
+        if let Some(index) = self
             .pending
             .iter()
-            .position(|event| event.payload.delivery_id == delivery_id)?;
-        self.pending.remove(index)
+            .position(|event| event.payload.delivery_id == delivery_id)
+        {
+            return self.pending.remove(index);
+        }
+        self.in_flight
+            .remove(&delivery_id)
+            .map(|delivery| delivery.event)
     }
 
     pub(crate) fn end_registration(&mut self, registration_id: u64) {
@@ -216,6 +266,7 @@ pub(crate) struct DictationCapturePayload {
 pub(crate) struct CaptureEvent {
     pub(crate) name: &'static str,
     pub(crate) payload: DictationCapturePayload,
+    await_result: bool,
 }
 
 pub struct TrayHandle {
@@ -232,20 +283,21 @@ fn dictation_capture_event(action: &str, dictating: bool) -> &'static str {
 }
 
 pub fn dispatch_dictation_capture(app: &tauri::AppHandle, action: &str) {
-    let _ = dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut);
+    let _ = dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut, false);
 }
 
 pub(crate) fn request_dictation_capture_delivery(
     app: &tauri::AppHandle,
     action: &str,
 ) -> Option<u64> {
-    dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut)
+    dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut, true)
 }
 
 fn dispatch_dictation_capture_from(
     app: &tauri::AppHandle,
     action: &str,
     origin: CaptureOrigin,
+    await_result: bool,
 ) -> Option<u64> {
     let flags = app.state::<AppFlags>();
     let event = dictation_capture_event(action, flags.dictating.load(Ordering::SeqCst));
@@ -277,6 +329,7 @@ fn dispatch_dictation_capture_from(
             delivery_id: 0,
             registration_id: 0,
         },
+        await_result,
     };
     let Ok(mut capture) = flags.capture.lock() else {
         log::warn!("Dictation capture state lock poisoned");
@@ -316,6 +369,7 @@ mod dictation_capture_tests {
                 delivery_id: 0,
                 registration_id: 0,
             },
+            await_result: false,
         }
     }
 
@@ -369,6 +423,31 @@ mod dictation_capture_tests {
         assert_eq!(cancelled.payload.session_id, 7);
         assert!(!state.delivery_pending(first_id));
         assert!(state.delivery_pending(second_id));
+    }
+
+    #[test]
+    fn awaited_delivery_preserves_frontend_rejection_for_the_requester() {
+        let mut state = CaptureDispatchState::default();
+        let registration_id = state.begin_registration();
+        state.mark_registration_ready(registration_id);
+        let mut event = capture_event("tray-dictate");
+        event.await_result = true;
+        let delivery_id = state.enqueue(event).delivery_id;
+
+        state.acknowledge(registration_id, delivery_id);
+        assert!(!state.completion_ready(delivery_id));
+        state.complete(
+            registration_id,
+            delivery_id,
+            Some("Dictation is disabled".into()),
+        );
+        assert!(state.completion_ready(delivery_id));
+
+        assert_eq!(
+            state.take_completion(delivery_id),
+            Some(Err("Dictation is disabled".into()))
+        );
+        assert_eq!(state.take_completion(delivery_id), None);
     }
 
     #[test]
@@ -797,6 +876,7 @@ pub fn run() {
             commands::begin_dictation_capture_registration,
             commands::mark_dictation_capture_ready,
             commands::acknowledge_dictation_capture_delivery,
+            commands::complete_dictation_capture_delivery,
             commands::end_dictation_capture_registration,
             commands::show_dictation_pill,
             commands::get_launch_as_widget,
@@ -1104,12 +1184,14 @@ pub fn run() {
                                     app,
                                     "stop",
                                     CaptureOrigin::Tray,
+                                    false,
                                 );
                             } else {
                                 let _ = dispatch_dictation_capture_from(
                                     app,
                                     "start",
                                     CaptureOrigin::Tray,
+                                    false,
                                 );
                             }
                         }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -109,6 +109,11 @@ pub struct CaptureDispatchState {
     active_registration: Option<u64>,
 }
 
+struct CaptureEnqueue {
+    delivery_id: u64,
+    event: Option<CaptureEvent>,
+}
+
 impl Default for CaptureDispatchState {
     fn default() -> Self {
         Self {
@@ -147,13 +152,21 @@ impl CaptureDispatchState {
             .collect()
     }
 
-    pub(crate) fn enqueue(&mut self, mut event: CaptureEvent) -> Option<CaptureEvent> {
+    fn enqueue(&mut self, mut event: CaptureEvent) -> CaptureEnqueue {
         self.delivery_counter = self.delivery_counter.wrapping_add(1).max(1);
         event.payload.delivery_id = self.delivery_counter;
         self.pending.push_back(event.clone());
-        let registration_id = self.active_registration.filter(|_| self.ready)?;
-        event.payload.registration_id = registration_id;
-        Some(event)
+        let ready_event = self
+            .active_registration
+            .filter(|_| self.ready)
+            .map(|registration_id| {
+                event.payload.registration_id = registration_id;
+                event
+            });
+        CaptureEnqueue {
+            delivery_id: self.delivery_counter,
+            event: ready_event,
+        }
     }
 
     pub(crate) fn acknowledge(&mut self, registration_id: u64, delivery_id: u64) {
@@ -167,6 +180,20 @@ impl CaptureDispatchState {
         {
             self.pending.remove(index);
         }
+    }
+
+    pub(crate) fn delivery_pending(&self, delivery_id: u64) -> bool {
+        self.pending
+            .iter()
+            .any(|event| event.payload.delivery_id == delivery_id)
+    }
+
+    pub(crate) fn cancel_delivery(&mut self, delivery_id: u64) -> Option<CaptureEvent> {
+        let index = self
+            .pending
+            .iter()
+            .position(|event| event.payload.delivery_id == delivery_id)?;
+        self.pending.remove(index)
     }
 
     pub(crate) fn end_registration(&mut self, registration_id: u64) {
@@ -205,10 +232,21 @@ fn dictation_capture_event(action: &str, dictating: bool) -> &'static str {
 }
 
 pub fn dispatch_dictation_capture(app: &tauri::AppHandle, action: &str) {
-    dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut);
+    let _ = dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut);
 }
 
-fn dispatch_dictation_capture_from(app: &tauri::AppHandle, action: &str, origin: CaptureOrigin) {
+pub(crate) fn request_dictation_capture_delivery(
+    app: &tauri::AppHandle,
+    action: &str,
+) -> Option<u64> {
+    dispatch_dictation_capture_from(app, action, CaptureOrigin::Shortcut)
+}
+
+fn dispatch_dictation_capture_from(
+    app: &tauri::AppHandle,
+    action: &str,
+    origin: CaptureOrigin,
+) -> Option<u64> {
     let flags = app.state::<AppFlags>();
     let event = dictation_capture_event(action, flags.dictating.load(Ordering::SeqCst));
     let session_id = if event == "tray-dictate" {
@@ -217,8 +255,21 @@ fn dispatch_dictation_capture_from(app: &tauri::AppHandle, action: &str, origin:
         session_id
     } else {
         log::warn!("Dictation capture '{action}' ignored — no active output session");
-        return;
+        return None;
     };
+
+    // The recorder lives in the widget WebView. WebKit can suspend that
+    // document while its window is hidden, so an event cannot be relied on to
+    // wake the very listener that must receive it. Preserve the output target
+    // first, then show the non-activating pill before enqueueing/emitting the
+    // start event. The widget's idle reconcile hides it again if capture is
+    // disabled or startup exits early.
+    if event == "tray-dictate" {
+        if let Err(error) = commands::show_dictation_pill(app.clone()) {
+            log::warn!("Dictation capture '{action}' could not wake the capture window: {error}");
+        }
+    }
+
     let capture_event = CaptureEvent {
         name: event,
         payload: DictationCapturePayload {
@@ -229,9 +280,11 @@ fn dispatch_dictation_capture_from(app: &tauri::AppHandle, action: &str, origin:
     };
     let Ok(mut capture) = flags.capture.lock() else {
         log::warn!("Dictation capture state lock poisoned");
-        return;
+        return None;
     };
-    if let Some(capture_event) = capture.enqueue(capture_event) {
+    let enqueued = capture.enqueue(capture_event);
+    let delivery_id = enqueued.delivery_id;
+    if let Some(capture_event) = enqueued.event {
         drop(capture);
         // A press that reaches Rust but produces no recording is otherwise
         // indistinguishable from one the compositor never delivered, so say
@@ -246,6 +299,7 @@ fn dispatch_dictation_capture_from(app: &tauri::AppHandle, action: &str, origin:
             "Dictation capture '{action}' queued — the capture window has not registered yet"
         );
     }
+    Some(delivery_id)
 }
 
 #[cfg(test)]
@@ -297,8 +351,24 @@ mod dictation_capture_tests {
 
         state.acknowledge(stale, delivery_id);
         assert_eq!(state.pending.len(), 1);
+        assert!(state.delivery_pending(delivery_id));
         state.acknowledge(current, delivery_id);
         assert!(state.pending.is_empty());
+        assert!(!state.delivery_pending(delivery_id));
+    }
+
+    #[test]
+    fn timed_out_delivery_can_be_cancelled_without_touching_others() {
+        let mut state = CaptureDispatchState::default();
+        state.enqueue(capture_event("tray-dictate"));
+        state.enqueue(capture_event("tray-dictate-stop"));
+        let first_id = state.pending[0].payload.delivery_id;
+        let second_id = state.pending[1].payload.delivery_id;
+
+        let cancelled = state.cancel_delivery(first_id).expect("delivery exists");
+        assert_eq!(cancelled.payload.session_id, 7);
+        assert!(!state.delivery_pending(first_id));
+        assert!(state.delivery_pending(second_id));
     }
 
     #[test]
@@ -879,12 +949,8 @@ pub fn run() {
                             match event.state {
                                 ShortcutState::Pressed => {
                                     log::info!("Global shortcut pressed: dictation start");
-                                    // The widget window stays hidden until the
-                                    // capture itself reaches a state worth
-                                    // showing — the widget calls
-                                    // `show_dictation_pill` then, so a press
-                                    // that bails early never strands an empty
-                                    // capsule on the desktop.
+                                    // Dispatch preserves the focused target,
+                                    // wakes the recorder WebView, then emits.
                                     dispatch_dictation_capture(app_handle, "start");
                                 }
                                 ShortcutState::Released => {
@@ -1034,9 +1100,17 @@ pub fn run() {
                             // current by the frontend's existing
                             // `set_tray_recording` call on every start and stop.
                             if app.state::<AppFlags>().dictating.load(Ordering::SeqCst) {
-                                dispatch_dictation_capture_from(app, "stop", CaptureOrigin::Tray);
+                                let _ = dispatch_dictation_capture_from(
+                                    app,
+                                    "stop",
+                                    CaptureOrigin::Tray,
+                                );
                             } else {
-                                dispatch_dictation_capture_from(app, "start", CaptureOrigin::Tray);
+                                let _ = dispatch_dictation_capture_from(
+                                    app,
+                                    "start",
+                                    CaptureOrigin::Tray,
+                                );
                             }
                         }
                         "settings" => {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -121,6 +121,12 @@ pub(crate) enum CaptureReceiptCancellation {
     Missing,
 }
 
+pub(crate) enum CaptureAcceptanceTimeout {
+    Completed(Result<(), String>),
+    Cancelled(CaptureEvent),
+    Missing,
+}
+
 struct CaptureEnqueue {
     delivery_id: u64,
     event: Option<CaptureEvent>,
@@ -273,6 +279,20 @@ impl CaptureDispatchState {
             .map(|delivery| delivery.event)
     }
 
+    pub(crate) fn take_completion_or_cancel(
+        &mut self,
+        delivery_id: u64,
+    ) -> CaptureAcceptanceTimeout {
+        if let Some(completion) = self.take_completion(delivery_id) {
+            CaptureAcceptanceTimeout::Completed(completion)
+        } else {
+            self.cancel_delivery(delivery_id).map_or(
+                CaptureAcceptanceTimeout::Missing,
+                CaptureAcceptanceTimeout::Cancelled,
+            )
+        }
+    }
+
     pub(crate) fn end_registration(&mut self, registration_id: u64) {
         if self.active_registration == Some(registration_id) {
             self.active_registration = None;
@@ -385,8 +405,8 @@ fn dispatch_dictation_capture_from(
 #[cfg(test)]
 mod dictation_capture_tests {
     use super::{
-        dictation_capture_event, CaptureDispatchState, CaptureEvent, CaptureReceiptCancellation,
-        DictationCapturePayload,
+        dictation_capture_event, CaptureAcceptanceTimeout, CaptureDispatchState, CaptureEvent,
+        CaptureReceiptCancellation, DictationCapturePayload,
     };
 
     fn capture_event(name: &'static str) -> CaptureEvent {
@@ -511,6 +531,27 @@ mod dictation_capture_tests {
         assert!(matches!(
             state.cancel_unreceived_delivery(delivery_id),
             CaptureReceiptCancellation::Received
+        ));
+    }
+
+    #[test]
+    fn completion_at_the_timeout_boundary_wins_over_cancellation() {
+        let mut state = CaptureDispatchState::default();
+        let registration_id = state.begin_registration();
+        state.mark_registration_ready(registration_id);
+        let mut event = capture_event("tray-dictate");
+        event.await_result = true;
+        let delivery_id = state.enqueue(event).delivery_id;
+        state.acknowledge(registration_id, delivery_id);
+        state.complete(registration_id, delivery_id, None);
+
+        assert!(matches!(
+            state.take_completion_or_cancel(delivery_id),
+            CaptureAcceptanceTimeout::Completed(Ok(()))
+        ));
+        assert!(matches!(
+            state.take_completion_or_cancel(delivery_id),
+            CaptureAcceptanceTimeout::Missing
         ));
     }
 

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -717,8 +717,9 @@ export default function CaptureWidget({ onDismiss }) {
         })
           .catch((err) => {
             console.warn('dictation delivery acknowledgement failed:', err);
+            return false;
           })
-          .then(() => true);
+          .then((acknowledged) => acknowledged !== false);
       }
       return true;
     };

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -711,12 +711,29 @@ export default function CaptureWidget({ onDismiss }) {
       const eventRegistrationId = event?.payload?.registrationId;
       if (eventRegistrationId != null && eventRegistrationId !== registrationId) return false;
       if (deliveryId != null) {
-        void tauriInvoke('acknowledge_dictation_capture_delivery', {
+        return tauriInvoke('acknowledge_dictation_capture_delivery', {
           registrationId,
           deliveryId,
-        }).catch((err) => console.warn('dictation delivery acknowledgement failed:', err));
+        })
+          .catch((err) => {
+            console.warn('dictation delivery acknowledgement failed:', err);
+          })
+          .then(() => true);
       }
       return true;
+    };
+    const completeDelivery = async (event, error = null) => {
+      const deliveryId = event?.payload?.deliveryId;
+      if (deliveryId == null) return;
+      try {
+        await tauriInvoke('complete_dictation_capture_delivery', {
+          registrationId,
+          deliveryId,
+          error,
+        });
+      } catch (err) {
+        console.warn('dictation delivery completion failed:', err);
+      }
     };
     (async () => {
       try {
@@ -727,13 +744,19 @@ export default function CaptureWidget({ onDismiss }) {
         }
         const { listen } = await import('@tauri-apps/api/event');
         unlistenStart = await listen('tray-dictate', async (event) => {
-          if (!acknowledgeDelivery(event)) return;
+          const acknowledgement = acknowledgeDelivery(event);
+          if (acknowledgement === false) return;
+          if (acknowledgement !== true) await acknowledgement;
           const now = Date.now();
-          if (now - nativeEventAtRef.current.start < 150) return;
+          if (now - nativeEventAtRef.current.start < 150) {
+            await completeDelivery(event, 'Duplicate dictation start ignored');
+            return;
+          }
           nativeEventAtRef.current.start = now;
           const sessionId = event?.payload?.sessionId;
           if (!sessionId) {
             hideWidgetWindow();
+            await completeDelivery(event, 'Dictation output session is missing');
             return;
           }
           await ensureDictationPrefsHydrated();
@@ -741,7 +764,8 @@ export default function CaptureWidget({ onDismiss }) {
             // The hotkey is inert, but Rust has already shown the window.
             // Put it back rather than leaving an empty capsule on screen.
             hideWidgetWindow();
-            finishOutputSession(sessionId);
+            await finishOutputSession(sessionId);
+            await completeDelivery(event, 'Dictation is disabled');
             return;
           }
           const sequence = ++nativeStartSequenceRef.current;
@@ -757,6 +781,7 @@ export default function CaptureWidget({ onDismiss }) {
             } catch (err) {
               console.warn('reject dictation output session failed:', err);
             }
+            await completeDelivery(event, 'Dictation is already active');
             return;
           }
           const trackHold = modeRef.current === 'hold';
@@ -781,11 +806,13 @@ export default function CaptureWidget({ onDismiss }) {
             clearPendingHold();
             await finishOutputSession(sessionId);
             hideWidgetWindow();
+            await completeDelivery(event, `Could not activate dictation output: ${err}`);
             return;
           }
           if (cancelled || sequence !== nativeStartSequenceRef.current || !enabledRef.current) {
             clearPendingHold();
             await finishOutputSession(sessionId);
+            await completeDelivery(event, 'Dictation start was cancelled');
             return;
           }
           if (startupWasInFlight) {
@@ -793,8 +820,10 @@ export default function CaptureWidget({ onDismiss }) {
             if (startInFlightRef.current) {
               outputSessionIdRef.current = sessionId;
               pendingNativeStartRef.current = { sessionId, trackHold, sequence };
+              await completeDelivery(event, 'Another dictation start is already in progress');
             } else if (current === 'recording' || current === 'transcribing') {
               outputSessionIdRef.current = sessionId;
+              await completeDelivery(event);
             } else if (
               current === 'idle' ||
               current === 'done' ||
@@ -802,10 +831,14 @@ export default function CaptureWidget({ onDismiss }) {
               current === 'setup'
             ) {
               outputSessionIdRef.current = sessionId;
-              startRecordingRef.current?.(trackHold, sessionId);
+              void Promise.resolve(startRecordingRef.current?.(trackHold, sessionId)).then(
+                (accepted) =>
+                  completeDelivery(event, accepted ? null : 'Dictation could not start'),
+              );
             } else {
               clearPendingHold();
               await finishOutputSession(sessionId);
+              await completeDelivery(event, 'Dictation could not accept this start');
             }
             return;
           }
@@ -814,34 +847,65 @@ export default function CaptureWidget({ onDismiss }) {
             // in System Settings. A missing grant no longer blocks capture:
             // native delivery can truthfully fall back to clipboard-only.
             outputSessionIdRef.current = sessionId;
-            checkAccessibility().then(() => {
-              if (outputSessionIdRef.current !== sessionId) return;
-              startRecordingRef.current?.(modeRef.current === 'hold', sessionId);
+            void checkAccessibility().then(async () => {
+              if (outputSessionIdRef.current !== sessionId) {
+                await completeDelivery(event, 'Dictation output session changed before startup');
+                return;
+              }
+              const accepted = await startRecordingRef.current?.(
+                modeRef.current === 'hold',
+                sessionId,
+              );
+              await completeDelivery(event, accepted ? null : 'Dictation could not start');
             });
             return;
           }
           const idle = s === 'idle' || s === 'done' || s === 'error';
           if (modeRef.current === 'toggle') {
             // Press once to start, again to stop.
-            if (idle) startRecordingRef.current?.(false, sessionId);
-            else if (s === 'recording') stopRecordingRef.current?.();
+            if (idle) {
+              void Promise.resolve(startRecordingRef.current?.(false, sessionId)).then((accepted) =>
+                completeDelivery(event, accepted ? null : 'Dictation could not start'),
+              );
+              return;
+            } else if (s === 'recording') {
+              stopRecordingRef.current?.();
+              await completeDelivery(event);
+              return;
+            }
           } else if (idle) {
             // Hold mode: keydown → start.
-            startRecordingRef.current?.(true, sessionId);
+            void Promise.resolve(startRecordingRef.current?.(true, sessionId)).then((accepted) =>
+              completeDelivery(event, accepted ? null : 'Dictation could not start'),
+            );
+            return;
           }
+          await completeDelivery(event, 'Dictation could not start');
         });
         unlistenStop = await listen('tray-dictate-stop', async (event) => {
-          if (!acknowledgeDelivery(event)) return;
+          const acknowledgement = acknowledgeDelivery(event);
+          if (acknowledgement === false) return;
+          if (acknowledgement !== true) await acknowledgement;
           const now = Date.now();
-          if (now - nativeEventAtRef.current.stop < 150) return;
+          if (now - nativeEventAtRef.current.stop < 150) {
+            await completeDelivery(event, 'Duplicate dictation stop ignored');
+            return;
+          }
           nativeEventAtRef.current.stop = now;
           await ensureDictationPrefsHydrated();
           // Only hold mode acts on release; toggle ignores it.
+          let accepted = false;
           if (modeRef.current === 'hold' && stateRef.current === 'recording') {
             stopRecordingRef.current?.();
+            accepted = true;
           } else if (modeRef.current === 'hold' && holdStartRef.current === 'starting') {
             holdStartRef.current = 'released';
+            accepted = true;
           }
+          await completeDelivery(
+            event,
+            accepted ? null : 'Dictation is not recording in hold mode',
+          );
         });
         await ensureDictationPrefsHydrated();
         if (cancelled) {
@@ -1856,11 +1920,11 @@ export default function CaptureWidget({ onDismiss }) {
           // newer non-empty lease without launching a second microphone graph.
           outputSessionIdRef.current = sessionId;
         }
-        return;
+        return false;
       }
       if (inTauri() && !sessionId) {
         hideWidgetWindow();
-        return;
+        return false;
       }
       startInFlightRef.current = true;
       if (sessionId) outputSessionIdRef.current = sessionId;
@@ -1893,6 +1957,7 @@ export default function CaptureWidget({ onDismiss }) {
           }
         }
       }
+      return stateRef.current === 'recording' || stateRef.current === 'transcribing';
     },
     [startRecordingImpl],
   );

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -745,9 +745,10 @@ export default function CaptureWidget({ onDismiss }) {
         }
         const { listen } = await import('@tauri-apps/api/event');
         unlistenStart = await listen('tray-dictate', async (event) => {
-          const acknowledgement = acknowledgeDelivery(event);
+          let acknowledgement = acknowledgeDelivery(event);
           if (acknowledgement === false) return;
-          if (acknowledgement !== true) await acknowledgement;
+          if (acknowledgement !== true) acknowledgement = await acknowledgement;
+          if (!acknowledgement) return;
           const now = Date.now();
           if (now - nativeEventAtRef.current.start < 150) {
             await completeDelivery(event, 'Duplicate dictation start ignored');
@@ -884,9 +885,10 @@ export default function CaptureWidget({ onDismiss }) {
           await completeDelivery(event, 'Dictation could not start');
         });
         unlistenStop = await listen('tray-dictate-stop', async (event) => {
-          const acknowledgement = acknowledgeDelivery(event);
+          let acknowledgement = acknowledgeDelivery(event);
           if (acknowledgement === false) return;
-          if (acknowledgement !== true) await acknowledgement;
+          if (acknowledgement !== true) acknowledgement = await acknowledgement;
+          if (!acknowledgement) return;
           const now = Date.now();
           if (now - nativeEventAtRef.current.stop < 150) {
             await completeDelivery(event, 'Duplicate dictation stop ignored');

--- a/frontend/src/pages/Transcriptions.jsx
+++ b/frontend/src/pages/Transcriptions.jsx
@@ -180,9 +180,11 @@ export default function TranscriptionsPage() {
           </span>
         </div>
         <div className="txn-header__right flex items-center gap-[6px]">
-          <Button size="sm" variant="primary" onClick={startCapture}>
-            <Mic size={13} /> {t('transcriptions.capture')}
-          </Button>
+          {transcriptions.length > 0 && (
+            <Button size="sm" variant="primary" leading={<Mic size={13} />} onClick={startCapture}>
+              {t('transcriptions.capture')}
+            </Button>
+          )}
           <div className="txn-search relative flex items-center">
             <Search
               size={13}
@@ -235,8 +237,13 @@ export default function TranscriptionsPage() {
                 {normalizedSearch ? t('transcriptions.empty_search_desc') : emptyDescription}
               </p>
               {!normalizedSearch && (
-                <Button size="sm" variant="primary" onClick={startCapture}>
-                  <Mic size={13} /> {t('transcriptions.capture')}
+                <Button
+                  size="sm"
+                  variant="primary"
+                  leading={<Mic size={13} />}
+                  onClick={startCapture}
+                >
+                  {t('transcriptions.capture')}
                 </Button>
               )}
             </div>

--- a/frontend/src/pages/Transcriptions.test.jsx
+++ b/frontend/src/pages/Transcriptions.test.jsx
@@ -34,14 +34,14 @@ describe('Transcriptions capture entry point', () => {
     render(<TranscriptionsPage />);
     expect(screen.getByText(/Super\+Shift\+V/)).toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Start dictation' }).at(-1));
+    fireEvent.click(screen.getByRole('button', { name: 'Start dictation' }));
     await waitFor(() => expect(requestDictationCapture).toHaveBeenCalledWith('start'));
   });
 
   it('reports a capture-controller failure', async () => {
     requestDictationCapture.mockRejectedValueOnce(new Error('event channel unavailable'));
     render(<TranscriptionsPage />);
-    fireEvent.click(screen.getAllByRole('button', { name: 'Start dictation' }).at(-1));
+    fireEvent.click(screen.getByRole('button', { name: 'Start dictation' }));
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
@@ -56,8 +56,20 @@ describe('Transcriptions capture entry point', () => {
       target: { value: '   ' },
     });
 
-    expect(screen.getAllByRole('button', { name: 'Start dictation' })).toHaveLength(2);
+    const button = screen.getByRole('button', { name: 'Start dictation' });
+    expect(button.querySelector(':scope > svg')).toBeInTheDocument();
+    expect(button.querySelector(':scope > span')).toHaveTextContent('Start dictation');
     expect(screen.getByText('No transcriptions yet')).toBeInTheDocument();
+  });
+
+  it('moves the single capture action to the header once history exists', () => {
+    addTranscription({ text: 'Existing transcript.', language: 'en' });
+    render(<TranscriptionsPage />);
+
+    const button = screen.getByRole('button', { name: 'Start dictation' });
+    expect(button.querySelector(':scope > svg')).toBeInTheDocument();
+    expect(button.querySelector(':scope > span')).toHaveTextContent('Start dictation');
+    expect(screen.queryByText('No transcriptions yet')).not.toBeInTheDocument();
   });
 
   it('shows a successful transcript emitted by the shared recorder', async () => {

--- a/frontend/src/pages/Transcriptions.test.jsx
+++ b/frontend/src/pages/Transcriptions.test.jsx
@@ -67,6 +67,7 @@ describe('Transcriptions capture entry point', () => {
     render(<TranscriptionsPage />);
 
     const button = screen.getByRole('button', { name: 'Start dictation' });
+    expect(button.closest('.txn-header__right')).toBeInTheDocument();
     expect(button.querySelector(':scope > svg')).toBeInTheDocument();
     expect(button.querySelector(':scope > span')).toHaveTextContent('Start dictation');
     expect(screen.queryByText('No transcriptions yet')).not.toBeInTheDocument();

--- a/frontend/src/test/CaptureWidgetSetupRace.test.jsx
+++ b/frontend/src/test/CaptureWidgetSetupRace.test.jsx
@@ -112,8 +112,11 @@ class FakeWS {
 
 function pressShortcut() {
   const handler = eventHandlers['tray-dictate'];
-  if (handler) handler({ payload: { sessionId: 'setup-race-session' } });
-  else eventState.pendingStart = true;
+  if (handler) {
+    handler({
+      payload: { sessionId: 'setup-race-session', deliveryId: 9, registrationId: 1 },
+    });
+  } else eventState.pendingStart = true;
 }
 
 let realWebSocket;
@@ -128,7 +131,7 @@ beforeEach(() => {
     if (cmd === 'mark_dictation_capture_ready' && eventState.pendingStart) {
       eventState.pendingStart = false;
       return eventHandlers['tray-dictate']?.({
-        payload: { sessionId: 'setup-race-session' },
+        payload: { sessionId: 'setup-race-session', deliveryId: 9, registrationId: 1 },
       });
     }
     return undefined;
@@ -136,6 +139,7 @@ beforeEach(() => {
   eventState.pendingStart = false;
   eventUnlisteners.length = 0;
   FakeWS.instances = [];
+  storeState.dictationEnabled = true;
   storeState.dictationModelId = 'sherpa-parakeet-v3';
   realWebSocket = globalThis.WebSocket;
   globalThis.WebSocket = FakeWS;
@@ -192,6 +196,47 @@ describe('CaptureWidget — connect-time asr_model_missing during mic setup', ()
     });
   });
 
+  it('completes an in-page delivery only after microphone startup is accepted', async () => {
+    render(<CaptureWidget />);
+    await waitFor(() => expect(eventHandlers['tray-dictate']).toBeTypeOf('function'));
+
+    await eventHandlers['tray-dictate']({
+      payload: { sessionId: 7, deliveryId: 9, registrationId: 1 },
+    });
+    await waitFor(() => expect(FakeWS.instances.length).toBe(1));
+    expect(invokeMock).not.toHaveBeenCalledWith('complete_dictation_capture_delivery', {
+      registrationId: 1,
+      deliveryId: 9,
+      error: null,
+    });
+
+    micControl.resolve(micStop);
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('complete_dictation_capture_delivery', {
+        registrationId: 1,
+        deliveryId: 9,
+        error: null,
+      }),
+    );
+  });
+
+  it('rejects an in-page delivery when dictation is disabled', async () => {
+    storeState.dictationEnabled = false;
+    render(<CaptureWidget />);
+    await waitFor(() => expect(eventHandlers['tray-dictate']).toBeTypeOf('function'));
+
+    await eventHandlers['tray-dictate']({
+      payload: { sessionId: 7, deliveryId: 9, registrationId: 1 },
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('complete_dictation_capture_delivery', {
+      registrationId: 1,
+      deliveryId: 9,
+      error: 'Dictation is disabled',
+    });
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+  });
+
   it('turns a PCM-fallback socket failure into a terminal error', async () => {
     storeState.dictationModelId = 'whisperx';
     render(<CaptureWidget />);
@@ -238,6 +283,11 @@ describe('CaptureWidget — connect-time asr_model_missing during mic setup', ()
     expect(screen.getByText(/No speech-to-text model/)).toBeInTheDocument();
     expect(screen.queryByText(/Listening/)).not.toBeInTheDocument();
     expect(invokeMock).not.toHaveBeenCalledWith('set_tray_recording', { recording: true });
+    expect(invokeMock).toHaveBeenCalledWith('complete_dictation_capture_delivery', {
+      registrationId: 1,
+      deliveryId: 9,
+      error: 'Dictation could not start',
+    });
   });
 
   it('setup REJECTION after the terminal frame must not clobber it with a mic error', async () => {

--- a/frontend/src/test/CaptureWidgetSetupRace.test.jsx
+++ b/frontend/src/test/CaptureWidgetSetupRace.test.jsx
@@ -196,6 +196,33 @@ describe('CaptureWidget — connect-time asr_model_missing during mic setup', ()
     });
   });
 
+  it('does not start capture when native receipt acknowledgement fails', async () => {
+    invokeMock.mockImplementation(async (cmd) => {
+      if (cmd === 'begin_dictation_capture_registration') return 1;
+      if (cmd === 'check_microphone') return 'granted';
+      if (cmd === 'check_accessibility') return true;
+      if (cmd === 'acknowledge_dictation_capture_delivery') {
+        throw new Error('receipt state unavailable');
+      }
+      return undefined;
+    });
+    render(<CaptureWidget />);
+    await waitFor(() => expect(eventHandlers['tray-dictate']).toBeTypeOf('function'));
+
+    await eventHandlers['tray-dictate']({
+      payload: { sessionId: 7, deliveryId: 9, registrationId: 1 },
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalledWith('activate_dictation_output_session', {
+      sessionId: 7,
+    });
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      'complete_dictation_capture_delivery',
+      expect.anything(),
+    );
+  });
+
   it('completes an in-page delivery only after microphone startup is accepted', async () => {
     render(<CaptureWidget />);
     await waitFor(() => expect(eventHandlers['tray-dictate']).toBeTypeOf('function'));

--- a/tests/test_dictation_no_pill_window.py
+++ b/tests/test_dictation_no_pill_window.py
@@ -87,8 +87,7 @@ def test_in_page_capture_waits_for_listener_acceptance(commands_rs: str) -> None
     assert "request_dictation_capture_delivery" in body
     assert "wait_for_capture_delivery" in body
     assert "completion_ready" in body
-    assert "take_completion" in body
-    assert "cancel_delivery" in body
+    assert "take_completion_or_cancel" in body
     assert "capture window did not acknowledge the request" in body
     assert "dictation capture did not start in time" in body
 

--- a/tests/test_dictation_no_pill_window.py
+++ b/tests/test_dictation_no_pill_window.py
@@ -78,7 +78,7 @@ def test_capture_dispatch_wakes_widget_before_emitting_start(lib_rs: str) -> Non
     )
 
 
-def test_in_page_capture_waits_for_listener_acknowledgement(commands_rs: str) -> None:
+def test_in_page_capture_waits_for_listener_acceptance(commands_rs: str) -> None:
     request = re.search(
         r"pub async fn request_dictation_capture\(.*?\n\}", commands_rs, re.S
     )
@@ -86,8 +86,11 @@ def test_in_page_capture_waits_for_listener_acknowledgement(commands_rs: str) ->
     body = request.group(0)
     assert "request_dictation_capture_delivery" in body
     assert "wait_for_capture_delivery" in body
+    assert "completion_ready" in body
+    assert "take_completion" in body
     assert "cancel_delivery" in body
     assert "capture window did not acknowledge the request" in body
+    assert "dictation capture did not start in time" in body
 
 
 def test_no_computed_window_target_can_resolve_to_the_widget(lib_rs: str) -> None:

--- a/tests/test_dictation_no_pill_window.py
+++ b/tests/test_dictation_no_pill_window.py
@@ -1,9 +1,9 @@
-"""The dictation widget window must stay hidden, and must stamp its identity.
+"""The dictation widget must stay safe while hidden and wake before capture.
 
 The widget window hosts the recorder (`getUserMedia` + `MediaRecorder` + the
-transcription WebSocket all live in `CaptureWidget.jsx`), so it has to exist —
-but it is never shown (owner decision, 2026-08-07): dictation gives no
-on-screen pill.
+transcription WebSocket all live in `CaptureWidget.jsx`), so it has to exist
+while idle. Some WebView engines suspend that hidden document, however, so a
+start request must wake it before emitting the event it needs to record.
 
 Two things keep that safe, and both are easy to undo by accident:
 
@@ -14,8 +14,9 @@ Two things keep that safe, and both are easy to undo by accident:
    300x64, with an opaque background and no CaptureWidget to hide it again:
    the dark rectangle that could only be cleared by killing the app.
 
-2. Nothing calls `.show()` on it. A re-added show would put that rectangle
-   back on screen for anyone whose window lost the identity race.
+2. Capture dispatch wakes it only through the non-activating pill command,
+   after preserving the output target and before emitting the start event.
+   The widget owns hiding itself again when it is idle.
 
 The frontend half is pinned by
 `frontend/src/test/DictationNoPillWindow.test.jsx`.
@@ -27,11 +28,19 @@ from pathlib import Path
 import pytest
 
 _LIB_RS = Path(__file__).resolve().parents[1] / "frontend" / "src-tauri" / "src" / "lib.rs"
+_COMMANDS_RS = (
+    Path(__file__).resolve().parents[1] / "frontend" / "src-tauri" / "src" / "commands.rs"
+)
 
 
 @pytest.fixture
 def lib_rs() -> str:
     return _LIB_RS.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def commands_rs() -> str:
+    return _COMMANDS_RS.read_text(encoding="utf-8")
 
 
 def test_widget_window_stamps_its_identity_before_page_scripts(lib_rs: str) -> None:
@@ -47,24 +56,38 @@ def test_widget_window_stamps_its_identity_before_page_scripts(lib_rs: str) -> N
     )
 
 
-def test_nothing_shows_the_widget_window(lib_rs: str) -> None:
-    """No `.show()` may be reachable from a widget window handle.
-
-    Scoped to blocks that bind the widget handle, so an unrelated
-    `main_win.show()` elsewhere in the file doesn't trip this.
-    """
-    offenders = []
-    for match in re.finditer(r'get_webview_window\("widget"\)', lib_rs):
-        # The handle's usable scope: to the end of the enclosing block. Take a
-        # generous window and look for a show on it — cheap and hard to fool.
-        block = lib_rs[match.start() : match.start() + 1200]
-        for show in re.finditer(r"\b(\w+)\.show\(\)|show_pill_noactivate\(", block):
-            offenders.append(show.group(0))
-    assert not offenders, (
-        f"Something shows the dictation widget window again: {offenders}. "
-        "It is a hidden recorder host — showing it is what put an empty "
-        "rectangle on the user's desktop."
+def test_capture_dispatch_wakes_widget_before_emitting_start(lib_rs: str) -> None:
+    """A hidden WebView cannot receive the event that tells it to show itself."""
+    dispatch = re.search(
+        r"fn dispatch_dictation_capture_from\(.*?\n\}", lib_rs, re.S
     )
+    assert dispatch, "Could not locate dictation capture dispatch."
+    body = dispatch.group(0)
+    begin = body.find("begin_session")
+    wake_guard = body.find('if event == "tray-dictate"', begin)
+    wake = body.find("commands::show_dictation_pill")
+    emit = body.find("app.emit")
+    assert -1 not in (begin, wake_guard, wake, emit), (
+        "Capture dispatch must preserve the output target, wake the hidden "
+        "widget, then emit the start event."
+    )
+    assert begin < wake_guard < wake < emit, (
+        "Wake the hidden recorder after preserving the output target and "
+        "before emitting only a start; otherwise macOS can silently drop the "
+        "request or a stop can reopen the pill."
+    )
+
+
+def test_in_page_capture_waits_for_listener_acknowledgement(commands_rs: str) -> None:
+    request = re.search(
+        r"pub async fn request_dictation_capture\(.*?\n\}", commands_rs, re.S
+    )
+    assert request, "The in-page capture command must remain asynchronous."
+    body = request.group(0)
+    assert "request_dictation_capture_delivery" in body
+    assert "wait_for_capture_delivery" in body
+    assert "cancel_delivery" in body
+    assert "capture window did not acknowledge the request" in body
 
 
 def test_no_computed_window_target_can_resolve_to_the_widget(lib_rs: str) -> None:


### PR DESCRIPTION
## Summary

- wake the hidden recorder WebView before native start delivery, after preserving the focused output target
- wait for listener receipt and microphone-start acceptance on in-app requests, surfacing disabled, rejected, failed, or timed-out starts
- show one contextual Start dictation CTA and render its icon through the shared Button leading slot for true flex centering
- update dictation documentation, CHANGELOG, and regression coverage

## Root cause

The packaged macOS app accepted the Tauri command and logged `Dictation capture 'start' emitted as tray-dictate`, but its hidden widget WebView did not consume the event. The control API remained `recording=false` and the output session stayed open. The dispatcher now wakes the non-activating widget before delivery. The in-page command first confirms atomic listener receipt, then resolves only when microphone startup is accepted; cancellation wins over an already-cloned event, while a receipt that wins the race continues to the acceptance result.

The duplicate CTA was explicit: the zero-entry state rendered both the header action and empty-state action. The alignment defect came from placing `<Mic />` inside the legacy child span instead of passing it through `Button.leading`, so the SVG used the inline text baseline instead of the button's flex alignment.

## Screenshots

Before:

![Duplicate, inert, misaligned Start dictation actions](https://github.com/user-attachments/assets/4191fa2c-f5c2-4a11-b5b0-10f747a5cab1)

After:

![One centered Start dictation action](https://github.com/user-attachments/assets/0b73bd83-8239-4116-8939-237226799164)

The after render has one matching CTA; its button, 12.8 px icon, and label all measured the same vertical center (`521.46875`).

## Verification

- fail-before: Transcriptions test found two matching buttons and the icon nested in the text span; pass-after: 10/10 page tests
- fail-before: dispatcher source guard found no widget wake before emit; pass-after: 5/5 native dispatch source guards
- 67/67 targeted page/widget tests
- 2,734/2,734 frontend tests
- 542/542 dictation, CHANGELOG, CJK, and all-21-locale parity checks
- `oxlint`, `oxfmt --check`, TypeScript check, production Vite build, and `git diff --check`
- Current-head CI passed: required backend/frontend tests; Rust `cargo check` and unit tests on macOS, Linux, and Windows; platform smoke jobs; MSI authoring; and security checks

Fixes #1902
