### PR TITLE
fix(audiobook): scale chapter synthesis timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Long audiobook chapters now use the same device- and text-length-aware synthesis timeout as other TTS routes (#1910) — thanks @psiberfunk!
+
 - Install documentation help now prints correctly on Windows consoles using legacy encodings (#1815) — thanks @dajiaohuang!
 - Saved transcriptions with missing or invalid timestamps now remain readable (#1799) — thanks @yunaremaia and @tvbht!
 - Copying a saved transcription now uses the shared clipboard helper and reports failed copies accurately (#1803) — thanks @tvbht!

--- a/backend/api/routers/audiobook.py
+++ b/backend/api/routers/audiobook.py
@@ -718,6 +718,10 @@ def _remote_chapter_call(chapter, *, engine_id, default_voice, voice_map,
         "expressive": opts.to_manifest(), "watermark": bool(watermark_enabled()),
     }
     signature = hashlib.sha256(json.dumps(params, sort_keys=True, default=str).encode()).hexdigest()
+    # The worker synthesizes from ``spans``, but the gateway and scheduler read
+    # top-level ``text`` to scale the remote execution deadline. Add this after
+    # the signature so existing content-addressed remote cache keys still hit.
+    params["text"] = "\n".join(row["text"] for row in rows)
     wav_path = os.path.join(cache_dir, f"remote-{signature}.wav")
 
     def decode(result):
@@ -739,7 +743,7 @@ async def _run_chapter(chapter, *, operation="audiobook", decision, job, default
                        voice_map, lexicon, cache_dir):
     """Run one chapter through the gateway; local preparation stays lazy."""
     from services import gpu_gateway
-    from services.tts_backend import active_backend_id
+    from services.tts_backend import active_backend_id, get_backend_class
 
     engine_id = active_backend_id()
     remote, remote_cache = _remote_chapter_call(
@@ -753,15 +757,27 @@ async def _run_chapter(chapter, *, operation="audiobook", decision, job, default
         return remote_cache, float(info.duration), True, None
 
     async def prepare_local():
+        from services.model_manager import generate_timeout_s
+
         synth, sr, resolve, local_engine = await _prepare_synth(
             default_voice, language=language, opts=opts, voice_map=voice_map
         )
+        try:
+            timeout_engine = get_backend_class(local_engine)
+        except ValueError:
+            # Tests and third-party integrations may inject a synth under a
+            # non-catalogue id. Keep the canonical host/text policy available;
+            # registered production engines still add their routing metadata.
+            timeout_engine = None
         return gpu_gateway.LocalCall(
             fn=lambda: _render_chapter_cached(
                 chapter, synth, sr, local_engine, resolve, cache_dir, lexicon,
                 language, opts, voice_map,
             ),
             what="Audiobook chapter",
+            timeout=generate_timeout_s(
+                remote.params["text"], engine=timeout_engine
+            ),
         )
 
     return await gpu_gateway.run(

--- a/tests/test_audiobook_remote.py
+++ b/tests/test_audiobook_remote.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 
 
 def test_remote_chapter_does_not_prepare_local_model(tmp_path, monkeypatch):
@@ -20,6 +19,7 @@ def test_remote_chapter_does_not_prepare_local_model(tmp_path, monkeypatch):
     async def fake_run(op, *, local, remote, decision, job):
         assert op == remote.operation == "audiobook"
         assert local.prepare is not None
+        assert remote.params["text"] == "hello"
         out = tmp_path / "remote.wav"
         out.write_bytes(b"wav")
         return str(out), 1.0, False, None
@@ -32,6 +32,55 @@ def test_remote_chapter_does_not_prepare_local_model(tmp_path, monkeypatch):
         lexicon=None, cache_dir=str(tmp_path),
     ))
     assert result[0].endswith("remote.wav")
+
+
+def test_local_chapter_uses_canonical_text_scaled_timeout(tmp_path, monkeypatch):
+    from api.routers import audiobook
+    from services import gpu_gateway, model_manager
+    from services.audiobook import Chapter, ExpressiveOptions, Span
+    from worker.routing import Decision
+
+    class Backend:
+        gpu_compat = ("mps", "cpu")
+
+    chapter = Chapter("One", [Span(None, "a" * 900), Span(None, "b" * 901)])
+    expected_text = f"{'a' * 900}\n{'b' * 901}"
+    calls = []
+
+    monkeypatch.setattr(audiobook, "_resolve_voice", lambda _id: {
+        "ref_audio": None, "ref_text": None, "instruct": None, "seed": None,
+    })
+    monkeypatch.setattr(audiobook, "_voice_profile_exists", lambda _id: False)
+    monkeypatch.setattr("services.tts_backend.active_backend_id", lambda: "test")
+    monkeypatch.setattr("services.tts_backend.get_backend_class", lambda _id: Backend)
+
+    async def fake_prepare(*_args, **_kwargs):
+        return lambda *_args, **_kwargs: None, 24_000, lambda _id: {}, "test"
+
+    def fake_timeout(text, *, engine=None, **_kwargs):
+        calls.append((text, engine))
+        return 315.05
+
+    async def fake_run(op, *, local, remote, decision, job):
+        prepared = await local.prepare()
+        assert op == "audiobook"
+        assert prepared.timeout == 315.05
+        assert remote.params["text"] == expected_text
+        return "local.wav", 1.0, False, None
+
+    monkeypatch.setattr(audiobook, "_prepare_synth", fake_prepare)
+    monkeypatch.setattr(model_manager, "generate_timeout_s", fake_timeout)
+    monkeypatch.setattr(gpu_gateway, "run", fake_run)
+
+    result = asyncio.run(audiobook._run_chapter(
+        chapter,
+        decision=Decision(False, "local"), job=gpu_gateway.JobRun("audiobook"),
+        default_voice=None, language=None, opts=ExpressiveOptions(), voice_map=None,
+        lexicon=None, cache_dir=str(tmp_path),
+    ))
+
+    assert result[0] == "local.wav"
+    assert calls == [(expected_text, Backend)]
 
 
 def test_audiobook_worker_marks_and_encodes_chapter(monkeypatch):


### PR DESCRIPTION
## Summary

Audiobook chapter dispatch bypassed the canonical text-scaled TTS deadline. Long local chapters therefore inherited the flat 300-second gateway default, and remote workers could not derive a scaled deadline because their payload exposed only `spans`.

Closes #1910.

![Sanitized source reproduction and expected contract](https://github.com/user-attachments/assets/41d51b19-c440-444b-9450-19446965ff1d)

## Changes

- expose normalized chapter text to gateway/worker deadline calculation without changing existing remote cache signatures
- set local chapter execution timeouts through `generate_timeout_s()` using the resolved backend class
- add fail-before/pass-after coverage for local and remote chapter dispatch
- document the fix in the Unreleased changelog

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- fail-before: both regression assertions failed against unmodified `main` (`RemoteCall.params` lacked `text`; prepared local `LocalCall.timeout` was `None`)
- pass-after: `57 passed` — `tests/test_audiobook_remote.py`, `tests/test_worker_deadlines.py`, `tests/test_gpu_gateway.py`
- `537 passed` — changelog style, locale parity, and hard-coded CJK guard suites
- Ruff undefined-name/import checks, `git diff --check`, and Python byte-compilation pass

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [x] Version files are in sync (if version bump): `pyproject.toml`, `package.json`, `tauri.conf.json`, `Cargo.toml`
- [x] If this PR changes runtime behavior, the regression fixture at `tests/fixtures/omnivoice_data/` still loads green on the `smoke-matrix` CI job (macOS + Windows + Linux)

## Release cadence

VoiceStudio ships **continuous-to-main** — no release candidates, no soak windows.
Every merged PR is immediately part of the rolling preview (`main`, Docker
`:latest`, the desktop Preview channel). Versioned releases are tagged from
`main` when it's ready; `main` then bumps to the next patch automatically.
Users who want stability pin a release tag / Docker `:stable` / the desktop
Stable channel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Audiobook chapters now use text-scaled synthesis timeouts for local and remote execution, preventing valid long chapters from hitting the flat 300-second watchdog. The change preserves remote cache signatures and existing pool recovery, with regression tests covering both timeout paths. Human review should verify the backend-class fallback used for local timeout calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->