### PR TITLE
fix(setup): stop misreporting low-VRAM caveat as kernel-launch risk

### DIFF
--- a/backend/api/routers/setup/wizard.py
+++ b/backend/api/routers/setup/wizard.py
@@ -19,6 +19,7 @@ import sys
 from fastapi import APIRouter
 
 from api.schemas import SetupStatusResponse, PreflightResponse
+from core.device_caps import KERNEL_RISK_MARKER
 # MIN_FREE_GB + disk_free_bytes are single-sourced in ``.models`` (the lowest
 # module in the setup import graph) so the wizard gate, the /models header, and
 # the per-install disk guard can't drift apart.
@@ -498,10 +499,14 @@ def preflight():
         _why = gpu_routing.get("routing_reason")
         if _rs == "accelerated" and not _why:
             r_status, r_detail, r_fix = "pass", f"{_eng} → {_dev} (accelerated)", None
-        elif _rs == "accelerated":  # driver/arch caveat
+        elif _rs == "accelerated" and KERNEL_RISK_MARKER in (_why or ""):
             r_status, r_detail, r_fix = "warn", f"{_eng} → {_dev}: {_why}", (
                 "GPU selected but may fail at kernel launch — update drivers / "
                 "reinstall torch for this GPU architecture.")
+        elif _rs == "accelerated":  # low-VRAM caveat — not a driver/arch issue
+            r_status, r_detail, r_fix = "warn", f"{_eng} → {_dev}: {_why}", (
+                "Unload other models before generating, keep the text short, "
+                "or pick a lighter engine.")
         elif _rs == "cpu_fallback":
             r_status, r_detail, r_fix = "warn", (
                 f"{_eng} runs on CPU here: {_why or 'no GPU path for this host'}"), (

--- a/backend/core/diagnose.py
+++ b/backend/core/diagnose.py
@@ -28,6 +28,7 @@ import shutil
 import sys
 
 from core.config import DATA_DIR
+from core.device_caps import KERNEL_RISK_MARKER
 from core.scrub import scrub_text
 from core.version import APP_VERSION
 
@@ -230,11 +231,16 @@ def _check_gpu_routing() -> dict:
     host = v.get("host_family", "cpu")
 
     if status == "accelerated":
-        if reason:  # driver/arch caveat — accelerated but at risk
+        if reason and KERNEL_RISK_MARKER in reason:  # driver/arch caveat — at risk
             return _check("gpu_routing", "GPU routing", WARN,
                           f"{engine} -> {dev}: {reason}",
                           "The GPU is selected but may fail at kernel launch — "
                           "update drivers / reinstall torch for this GPU arch.")
+        if reason:  # low-VRAM caveat — not a driver/arch issue
+            return _check("gpu_routing", "GPU routing", WARN,
+                          f"{engine} -> {dev}: {reason}",
+                          "Unload other models before generating, keep the text "
+                          "short, or pick a lighter engine.")
         return _check("gpu_routing", "GPU routing", OK, f"{engine} -> {dev} (accelerated)")
     if status == "cpu_fallback":
         return _check("gpu_routing", "GPU routing", WARN,


### PR DESCRIPTION
## Summary
- The GPU routing "accelerated" caveat branch in `/setup/preflight` (`backend/api/routers/setup/wizard.py`) and `/system/diagnose` (`backend/core/diagnose.py`) always surfaced the driver/arch **"may fail at kernel launch — update drivers / reinstall torch"** fix hint whenever an accelerated engine had *any* routing caveat — even when the actual reason was the unrelated low-VRAM advisory (`low_vram_caveat` in `services/engine_routing.py`).
- This misleads users with GPUs that are simply a bit tight on VRAM (e.g. a 6GB RTX 3050 running an engine that wants ~6GB) into thinking they have a broken/mismatched torch install and should reinstall it, when the GPU is in fact fully CUDA-accelerated and working correctly.
- Fixed both call sites to gate the kernel-launch fix message on `KERNEL_RISK_MARKER` (already exported from `core.device_caps` for exactly this purpose) and show an accurate, VRAM-appropriate hint otherwise ("Unload other models before generating, keep the text short, or pick a lighter engine.").

## Test plan
- [x] Reproduced live: `curl http://127.0.0.1:3900/setup/preflight` on a Windows host with an RTX 3050 6GB showed `gpu_routing: warn` with the incorrect kernel-launch fix text despite `GPU acceleration: CUDA ready` (torch 2.8.0+cu128, `sm_86` present in `torch.cuda.get_arch_list()`, `device_caps.detect_host_caps().notes == ()`).
- [x] After the fix, the same low-VRAM condition now returns the correct VRAM-appropriate fix text; the kernel-launch message only fires when `KERNEL_RISK_MARKER` is actually present in the routing reason.
- [ ] No existing automated test covered this path — happy to add a regression test for `_check_gpu_routing` / the wizard preflight branch if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

GPU-routing guidance now distinguishes `KERNEL_RISK_MARKER` kernel-launch risks from low-VRAM caveats in `/setup/preflight` and `/system/diagnose`. Low-VRAM cases now advise unloading models, shortening text, or selecting a lighter engine instead of suggesting driver or Torch changes. Human review should confirm that routing reasons reliably include `KERNEL_RISK_MARKER` for all kernel-launch risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->