### PR TITLE
fix(backend): stop Windows desktop launches freezing at "Loading ML runtime"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1955)
 - Install documentation help now prints correctly on Windows consoles using legacy encodings (#1815) — thanks @dajiaohuang!
 - Saved transcriptions with missing or invalid timestamps now remain readable (#1799) — thanks @yunaremaia and @tvbht!
 - Copying a saved transcription now uses the shared clipboard helper and reports failed copies accurately (#1803) — thanks @tvbht!

--- a/backend/core/parent_liveness.py
+++ b/backend/core/parent_liveness.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 import os
 import sys
 import threading
-from typing import BinaryIO, Callable
+import time
+from typing import Any, BinaryIO, Callable, Optional
+
+# Poll cadence for the Windows pipe watcher. Exit latency after the desktop
+# closes its end is bounded by this; the desktop's own kill-on-close Job is the
+# hard backstop, so a quarter second is plenty and costs nothing measurable.
+WINDOWS_PIPE_POLL_INTERVAL_S = 0.25
+_FILE_TYPE_PIPE = 3  # winbase.h FILE_TYPE_PIPE
 
 
 def _watch_parent_pipe(reader: BinaryIO, exit_process: Callable[[int], None]) -> None:
@@ -18,6 +25,64 @@ def _watch_parent_pipe(reader: BinaryIO, exit_process: Callable[[int], None]) ->
     exit_process(0)
 
 
+def _watch_parent_pipe_handle(
+    handle: int,
+    exit_process: Callable[[int], None],
+    *,
+    peek: Optional[Callable[[int], Any]] = None,
+    read_file: Optional[Callable[[int, int], Any]] = None,
+    sleep: Callable[[float], None] = time.sleep,
+    interval: float = WINDOWS_PIPE_POLL_INTERVAL_S,
+) -> None:
+    """Windows twin of :func:`_watch_parent_pipe` that never leaves a read
+    pending on the pipe.
+
+    A synchronous ``ReadFile`` parked on the stdin pipe — whether issued through
+    the C runtime's ``read()`` or straight to the kernel — deadlocks the
+    OpenBLAS DLL initializer that ``import torch`` reaches (numpy's
+    ``_multiarray_umath``) in the startup worker: every desktop-spawned backend
+    on Windows froze at "Loading ML runtime (PyTorch)" while the identical
+    command from a terminal, with no stdin pipe and no watchdog, started in
+    seconds. A thread that merely sleeps does not trigger it; only the pending
+    read on that pipe does. So instead of blocking in a read, poll with
+    ``PeekNamedPipe``: it returns immediately, holds no I/O on the file object,
+    drains any keepalive bytes the desktop might write, and fails with
+    ``ERROR_BROKEN_PIPE`` the moment the desktop closes its end — which is the
+    same EOF signal the POSIX reader gets.
+    """
+    if peek is None or read_file is None:
+        import _winapi  # Windows-only stdlib module; the caller gates on the platform
+
+        peek = peek or _winapi.PeekNamedPipe
+        read_file = read_file or _winapi.ReadFile
+    try:
+        while True:
+            available, _ = peek(handle)
+            if available:
+                # Bytes are already buffered, so this read cannot block.
+                read_file(handle, available)
+            else:
+                sleep(interval)
+    except OSError:
+        # ERROR_BROKEN_PIPE (109) is how the closed parent end surfaces here.
+        pass
+    exit_process(0)
+
+
+def _windows_pipe_handle(reader: Any) -> Optional[int]:
+    """The OS handle behind ``reader`` when it is a pipe, else None."""
+    try:
+        import msvcrt
+        import _winapi
+
+        handle = msvcrt.get_osfhandle(reader.fileno())
+        if _winapi.GetFileType(handle) != _FILE_TYPE_PIPE:
+            return None
+        return handle
+    except (OSError, ValueError, AttributeError, ImportError):
+        return None
+
+
 def arm_desktop_parent_watchdog() -> bool:
     """Use stdin EOF as an unforgeable parent-liveness signal for desktop runs."""
     if os.environ.get("OMNIVOICE_DESKTOP_CONTAINED") != "1":
@@ -25,9 +90,18 @@ def arm_desktop_parent_watchdog() -> bool:
     reader = getattr(sys.stdin, "buffer", None)
     if reader is None:
         return False
+    target: Callable[..., None] = _watch_parent_pipe
+    args: tuple = (reader, os._exit)
+    if os.name == "nt":
+        handle = _windows_pipe_handle(reader)
+        if handle is not None:
+            target = _watch_parent_pipe_handle
+            args = (handle, os._exit)
+        # A non-pipe stdin (file, NUL) cannot have a read pending against a
+        # pipe file object, so the blocking reader stays correct there.
     threading.Thread(
-        target=_watch_parent_pipe,
-        args=(reader, os._exit),
+        target=target,
+        args=args,
         name="desktop-parent-watchdog",
         daemon=True,
     ).start()

--- a/tests/backend/core/test_parent_liveness.py
+++ b/tests/backend/core/test_parent_liveness.py
@@ -53,3 +53,126 @@ def test_desktop_child_exits_when_parent_closes_stdin():
         if child.poll() is None:
             child.kill()
             child.wait()
+
+
+# ── Windows: the watchdog must never leave a read pending on the stdin pipe ──
+# A synchronous ReadFile parked on the desktop-owned stdin pipe (via the C
+# runtime's read() or straight to the kernel) deadlocked the OpenBLAS DLL
+# initializer that `import torch` reaches in the startup worker: every
+# desktop-spawned backend on Windows froze at "Loading ML runtime" while the
+# same command from a terminal (no stdin pipe, no watchdog) started in seconds.
+# A thread that only sleeps is harmless; the pending read is the trigger. The
+# Windows watcher therefore polls PeekNamedPipe and reads only bytes that are
+# already buffered, so no I/O is ever outstanding on that file object.
+
+
+def _peek_sequence(events):
+    """`events` items: int → bytes available; OSError → broken pipe."""
+    it = iter(events)
+
+    def peek(handle):
+        ev = next(it)
+        if isinstance(ev, BaseException):
+            raise ev
+        return (ev, 0)
+
+    return peek
+
+
+def test_windows_watcher_exits_on_broken_pipe_without_blocking_reads():
+    from core.parent_liveness import _watch_parent_pipe_handle
+
+    reads, sleeps, exits = [], [], []
+    _watch_parent_pipe_handle(
+        7,
+        exits.append,
+        peek=_peek_sequence([0, 0, OSError(109, "The pipe has been ended")]),
+        read_file=lambda h, n: reads.append((h, n)),
+        sleep=sleeps.append,
+        interval=0.01,
+    )
+    assert exits == [0]
+    assert reads == []  # nothing buffered → never a read, let alone a pending one
+    assert sleeps == [0.01, 0.01]
+
+
+def test_windows_watcher_drains_only_buffered_bytes_until_eof():
+    from core.parent_liveness import _watch_parent_pipe_handle
+
+    reads, exits = [], []
+    _watch_parent_pipe_handle(
+        7,
+        exits.append,
+        peek=_peek_sequence([3, 0, 1, OSError(109, "The pipe has been ended")]),
+        read_file=lambda h, n: reads.append((h, n)) or (b"x" * n, 0),
+        sleep=lambda s: None,
+    )
+    assert exits == [0]
+    # Reads are sized to exactly what PeekNamedPipe reported, so they return
+    # immediately instead of parking on the pipe.
+    assert reads == [(7, 3), (7, 1)]
+
+
+def test_windows_watchdog_arms_pipe_poller_on_pipe_stdin(monkeypatch):
+    import types
+    import core.parent_liveness as pl
+
+    monkeypatch.setenv("OMNIVOICE_DESKTOP_CONTAINED", "1")
+    monkeypatch.setattr(pl.os, "name", "nt")
+
+    class FakeBuffer:
+        def fileno(self):
+            return 0
+
+    monkeypatch.setattr(pl.sys, "stdin", types.SimpleNamespace(buffer=FakeBuffer()))
+    monkeypatch.setitem(sys.modules, "msvcrt", types.SimpleNamespace(get_osfhandle=lambda fd: 0xABC))
+    monkeypatch.setitem(sys.modules, "_winapi", types.SimpleNamespace(GetFileType=lambda h: 3))
+
+    started = {}
+
+    class FakeThread:
+        def __init__(self, *, target, args, name, daemon):
+            started.update(target=target, args=args, daemon=daemon)
+
+        def start(self):
+            started["started"] = True
+
+    monkeypatch.setattr(pl.threading, "Thread", FakeThread)
+    assert pl.arm_desktop_parent_watchdog() is True
+    assert started["started"] is True
+    assert started["target"] is pl._watch_parent_pipe_handle
+    assert started["args"] == (0xABC, os._exit)
+    assert started["daemon"] is True
+
+
+def test_windows_watchdog_keeps_blocking_reader_for_non_pipe_stdin(monkeypatch):
+    """A file/NUL stdin has no pipe file object to deadlock against, and a
+    blocking read on it returns EOF promptly — keep the shared reader there."""
+    import types
+    import core.parent_liveness as pl
+
+    monkeypatch.setenv("OMNIVOICE_DESKTOP_CONTAINED", "1")
+    monkeypatch.setattr(pl.os, "name", "nt")
+
+    class FakeBuffer:
+        def fileno(self):
+            return 0
+
+    fake_stdin = types.SimpleNamespace(buffer=FakeBuffer())
+    monkeypatch.setattr(pl.sys, "stdin", fake_stdin)
+    monkeypatch.setitem(sys.modules, "msvcrt", types.SimpleNamespace(get_osfhandle=lambda fd: 0xABC))
+    monkeypatch.setitem(sys.modules, "_winapi", types.SimpleNamespace(GetFileType=lambda h: 1))  # FILE_TYPE_DISK
+
+    started = {}
+
+    class FakeThread:
+        def __init__(self, *, target, args, name, daemon):
+            started.update(target=target, args=args)
+
+        def start(self):
+            started["started"] = True
+
+    monkeypatch.setattr(pl.threading, "Thread", FakeThread)
+    assert pl.arm_desktop_parent_watchdog() is True
+    assert started["target"] is pl._watch_parent_pipe
+    assert started["args"] == (fake_stdin.buffer, os._exit)

--- a/tests/backend/core/test_parent_liveness.py
+++ b/tests/backend/core/test_parent_liveness.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 def test_parent_pipe_eof_exits_cleanly():
     from core.parent_liveness import _watch_parent_pipe
 
@@ -176,3 +178,75 @@ def test_windows_watchdog_keeps_blocking_reader_for_non_pipe_stdin(monkeypatch):
     assert pl.arm_desktop_parent_watchdog() is True
     assert started["target"] is pl._watch_parent_pipe
     assert started["args"] == (fake_stdin.buffer, os._exit)
+
+
+# ── Windows integration: the real backend must get past the ML import ────────
+# The deadlock needs the real startup: numpy's OpenBLAS DLL loaded through
+# `import torch` in the startup worker while the desktop watchdog is armed on a
+# piped stdin. Smaller reproductions (a pending read + `import torch` in a bare
+# child) do not trigger it, so this spawns the actual backend exactly as the
+# desktop shell does. It fails on the pre-fix watchdog by timing out in the
+# "ml_imports" step and passes in well under a minute on the fix. Windows-only:
+# CI's backend job runs on Linux, so this is exercised on Windows dev machines.
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="desktop stdin-pipe watchdog deadlock is Windows-only")
+def test_desktop_spawned_backend_gets_past_ml_imports_on_windows(tmp_path):
+    pytest.importorskip("torch")
+    pytest.importorskip("uvicorn")
+    import json
+    import socket
+    import threading
+    import time
+    import urllib.request
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+
+    root = Path(__file__).parents[3]
+    env = os.environ.copy()
+    env.update(
+        {
+            "OMNIVOICE_DESKTOP_CONTAINED": "1",  # arms the watchdog on the stdin pipe
+            "OMNIVOICE_PORT": str(port),
+            "OMNIVOICE_DATA_DIR": str(tmp_path / "data"),
+            "OMNIVOICE_CACHE_DIR": str(tmp_path / "hf_cache"),
+            "HF_HUB_OFFLINE": "1",
+            "PYTHONUNBUFFERED": "1",
+            "PYTHONUTF8": "1",
+        }
+    )
+    env.pop("PYTHONPATH", None)
+    child = subprocess.Popen(
+        [sys.executable, "-m", "uvicorn", "main:app", "--app-dir", "backend",
+         "--host", "127.0.0.1", "--port", str(port)],
+        cwd=root,
+        env=env,
+        stdin=subprocess.PIPE,   # the desktop shell keeps this open and never writes
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    for stream in (child.stdout, child.stderr):
+        threading.Thread(target=lambda s=stream: s.read(), daemon=True).start()
+    seen = []
+    try:
+        deadline = time.time() + 180
+        while time.time() < deadline:
+            if child.poll() is not None:
+                pytest.fail(f"backend exited early with {child.returncode}; progress seen: {seen[-3:]}")
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/startup/progress", timeout=2) as resp:
+                    progress = json.load(resp)
+            except (OSError, ValueError):
+                time.sleep(1)
+                continue
+            seen.append((progress.get("status"), progress.get("step")))
+            done = {s["id"] for s in progress.get("steps", []) if s.get("state") == "done"}
+            if progress.get("status") != "starting" or "ml_imports" in done:
+                return
+            time.sleep(1)
+        pytest.fail(f"backend never got past ml_imports in 180s (deadlocked watchdog?); last progress: {seen[-3:]}")
+    finally:
+        child.kill()
+        child.wait()

--- a/tests/backend/core/test_parent_liveness.py
+++ b/tests/backend/core/test_parent_liveness.py
@@ -212,6 +212,7 @@ def test_desktop_spawned_backend_gets_past_ml_imports_on_windows(tmp_path):
             "OMNIVOICE_PORT": str(port),
             "OMNIVOICE_DATA_DIR": str(tmp_path / "data"),
             "OMNIVOICE_CACHE_DIR": str(tmp_path / "hf_cache"),
+            "HF_HUB_CACHE": str(tmp_path / "hf_cache"),  # never the developer's populated cache
             "HF_HUB_OFFLINE": "1",
             "PYTHONUNBUFFERED": "1",
             "PYTHONUTF8": "1",
@@ -241,10 +242,18 @@ def test_desktop_spawned_backend_gets_past_ml_imports_on_windows(tmp_path):
             except (OSError, ValueError):
                 time.sleep(1)
                 continue
-            seen.append((progress.get("status"), progress.get("step")))
+            status = progress.get("status")
+            seen.append((status, progress.get("step")))
             done = {s["id"] for s in progress.get("steps", []) if s.get("state") == "done"}
-            if progress.get("status") != "starting" or "ml_imports" in done:
+            # Positive evidence only: the ML import step finished, or startup is
+            # ready. Any other terminal state is the failure this test exists for.
+            if "ml_imports" in done or status == "ready":
                 return
+            if status != "starting" or progress.get("error"):
+                pytest.fail(
+                    f"backend startup reported status={status!r} error={progress.get('error')!r}; "
+                    f"progress seen: {seen[-3:]}"
+                )
             time.sleep(1)
         pytest.fail(f"backend never got past ml_imports in 180s (deadlocked watchdog?); last progress: {seen[-3:]}")
     finally:


### PR DESCRIPTION
## Problem

Every backend spawned by the Windows desktop shell froze at **"Loading ML runtime (PyTorch)"** and never became ready (`bun desktop-prod`, and any installer build from current `main`). The same `uvicorn` command from a terminal starts in seconds.

## Root cause

The desktop parent-liveness watchdog (0a20aeb0, 2026-08-30, not in v0.5.1) parks a synchronous read on the stdin pipe the shell hands the backend. That pending read deadlocks the initializer of numpy's OpenBLAS DLL, reached through `import torch` in the startup worker.

Bisected by spawning the backend outside the app with the shell's exact env, pipes, creation flags and kill-on-close Job:

| Variant | Result |
|---|---|
| shell env + pipes + flags + job | hangs in `ml_imports` |
| shell env + pipes, watchdog disabled | ready in 3 s |
| shell env + pipes, watchdog thread that only sleeps | ready in 3 s |
| shell env + pipes, watchdog blocked in `ReadFile` (CRT or kernel) | hangs |

`py-spy dump --native` on the hung process: the watchdog is in `NtReadFile`; the importer is inside `LdrLoadDll` → OpenBLAS init → `RtlEnterCriticalSection`/`SleepConditionVariableCS`.

## Fix

On Windows the watchdog polls `PeekNamedPipe` and reads only bytes already buffered, so no I/O is ever outstanding on the pipe. It still exits the instant the desktop closes its end (`ERROR_BROKEN_PIPE`). A non-pipe stdin keeps the shared blocking reader. POSIX is untouched.

## Verification

- App-style spawn (env + pipes + flags + job): indefinite hang → ready in ~3 s.
- `bun desktop-prod` build boots, backend reaches ready, TTS model loads.
- `tests/backend/core/test_parent_liveness.py`: 8 pass (4 new: EOF/broken-pipe handling, buffered-only reads, Windows arms the poller for pipe stdin, blocking reader kept for non-pipe stdin). The existing subprocess EOF test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCDZcBpP6QQa4dzUa8z6rh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The Windows parent-liveness watchdog now polls pipe input with `PeekNamedPipe` instead of blocking during `import torch`; non-pipe and POSIX behavior remains unchanged. This prevents OpenBLAS initialization from deadlocking and resolves the Windows startup freeze. Review the Windows API error handling and pipe detection as the main risks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->