### PR TITLE
fix(errors): make an unclassified failure report say something true and specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- A failure with no stage attached no longer borrows another stage's advice, so a text-to-speech error stops telling you the video server dropped the download (#1943)
 - A generation failure that the app cannot classify now names the backend error class, so two unrelated faults stop arriving as the same untriageable report (#1800)
 
 - Validate current-user Windows installers under a standard account on hosted runners (#1883)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- A generation failure that the app cannot classify now names the backend error class, so two unrelated faults stop arriving as the same untriageable report (#1800)
 
 - Validate current-user Windows installers under a standard account on hosted runners (#1883)
 

--- a/backend/core/failure.py
+++ b/backend/core/failure.py
@@ -308,6 +308,13 @@ _CONTEXT_FREE_HINT_CLASSES = frozenset({
     # a Windows virtual-memory setting rather than a connectivity problem, and
     # the detailed hint we already had for it never reached them.
     "WINDOWS_PAGING_FILE_TOO_SMALL",
+    # Its trigger is a VoiceStudio-authored sentence — "the TTS model cache
+    # for … is incomplete" plus "could not be auto-repaired" / "weights
+    # missing" — so it cannot be produced by an unrelated library. The 500
+    # handler is the surface a corrupt cache actually reaches, and dropping
+    # its hint there would leave the user with no way to know a redownload
+    # is the fix.
+    "MODEL_CACHE_CORRUPT",
 })
 
 

--- a/backend/core/public_errors.py
+++ b/backend/core/public_errors.py
@@ -94,6 +94,16 @@ def stream_generation_failure(error: BaseException | object) -> dict[str, object
     replace the failure being diagnosed.
     """
     payload = stream_failure("generation_failed")
+    if isinstance(error, BaseException):
+        # The exception's TYPE NAME, never its message. Two failures that both
+        # render the floor message "Generation failed. Check the selected
+        # engine and try again." are indistinguishable in an auto-filed report,
+        # so every unclassified streaming failure arrives as the same issue and
+        # none of them can be triaged (#1800). A class name is VoiceStudio-safe
+        # by the same reasoning that already puts it on the wire as
+        # `error_class` in the dub routes and on the analytics allowlist: it is
+        # a Python type, not user text, and no substring of `error` is copied.
+        payload["error_class"] = type(error).__name__
     try:
         enriched = public_exception_response(error, fallback=str(payload["detail"]))
     except Exception:

--- a/backend/core/public_errors.py
+++ b/backend/core/public_errors.py
@@ -159,12 +159,31 @@ def public_exception_response(error: BaseException, *, fallback: str) -> dict[st
     Classification may inspect the private diagnostic locally, but response
     values come exclusively from VoiceStudio-owned constants. No substring of
     ``error`` is copied into the payload.
+
+    Every caller is a CONTEXT-FREE surface — the global 500 handler, the
+    streaming generate error frame, the dub GPU-OOM 503 — so the topic is
+    filtered through ``failure._CONTEXT_FREE_HINT_CLASSES`` before its hint is
+    attached. Without that filter a topic whose trigger is a generic phrase
+    stamps a confidently wrong remediation on an unrelated failure: #1943 is a
+    macOS mlx-audio TTS 500 that came back advising the user that "the
+    connection to the video server dropped mid-download", because
+    VIDEO_DOWNLOAD_NETWORK triggers on a bare "timed out" / "connection
+    reset". The allowlist already existed and already named that class as the
+    example of what must not appear here; only :func:`failure.append_hint`
+    honoured it, and this helper replaced ``append_hint`` on the 500 path
+    without carrying the rule across.
+
+    HF_MIRROR_UNREACHABLE is allowed alongside it: its hint is dynamic (it
+    names the configured mirror) and its trigger requires that a mirror is
+    configured at all, so it cannot fire on an unrelated failure (#874).
     """
-    from core.failure import classify, public_hint_for_topic
+    from core.failure import _CONTEXT_FREE_HINT_CLASSES, classify, public_hint_for_topic
 
     try:
         topic = classify(str(error))
-        hint = public_hint_for_topic(topic)
+        if topic and topic not in _CONTEXT_FREE_HINT_CLASSES and topic != "HF_MIRROR_UNREACHABLE":
+            topic = ""
+        hint = public_hint_for_topic(topic) if topic else ""
     except Exception:
         topic = ""
         hint = ""

--- a/frontend/src/test/streamingTts.test.js
+++ b/frontend/src/test/streamingTts.test.js
@@ -329,6 +329,31 @@ describe('streamGenerateSpeech', () => {
     expect(FakeAudioContext.instances[0].state).toBe('closed');
   });
 
+  it('carries the backend error class from the error frame (#1800)', async () => {
+    // Every unclassified engine failure renders the same floor message, so
+    // the auto-filed reports were byte-identical and none could be triaged.
+    // The class name is the only thing that separates them.
+    apiFetch.mockResolvedValue(
+      ndjsonResponse([
+        startEvent(3),
+        chunkEvent(0),
+        { type: 'error', detail: 'Generation failed.', error_class: 'MemoryError' },
+      ]),
+    );
+    await expect(streamGenerateSpeech(new FormData(), {})).rejects.toMatchObject({
+      errorClass: 'MemoryError',
+    });
+  });
+
+  it('leaves the error class null when the frame omits it', async () => {
+    apiFetch.mockResolvedValue(
+      ndjsonResponse([startEvent(3), chunkEvent(0), { type: 'error', detail: 'boom' }]),
+    );
+    await expect(streamGenerateSpeech(new FormData(), {})).rejects.toMatchObject({
+      errorClass: null,
+    });
+  });
+
   it('carries the retryable marker from a GPU-timeout error frame (#1190)', async () => {
     // A retryable failure means the backend already spent the full budget on
     // this text and the abandoned job still holds the device — useTTS uses

--- a/frontend/src/utils/bugReport.js
+++ b/frontend/src/utils/bugReport.js
@@ -362,11 +362,16 @@ export async function buildBugReportUrl({ title = '[Bug] ', error } = {}) {
       msg.length > MAX_MSG_CHARS ? `${msg.slice(0, MAX_MSG_CHARS)}\n… (truncated)` : msg;
     let stack = error?.stack ? scrubText(error.stack) : '';
     if (stack.length > MAX_STACK_CHARS) stack = `${stack.slice(0, MAX_STACK_CHARS)}\n… (truncated)`;
+    // A generic failure message plus a stack of minified bundle frames is
+    // the same report every time; the backend class name is what separates
+    // one unclassified engine failure from another (#1800).
+    const klass = typeof error?.errorClass === 'string' ? scrubText(error.errorClass) : '';
     errorSection.push(
       '## Error',
       '',
       '```',
       msgForBody,
+      ...(klass ? [`Backend error class: ${klass}`] : []),
       ...(stack && stack !== msgForBody ? [stack] : []),
       '```',
       '',

--- a/frontend/src/utils/bugReport.test.js
+++ b/frontend/src/utils/bugReport.test.js
@@ -117,6 +117,18 @@ describe('buildBugReportUrl', () => {
     expect(body).not.toContain('/Users/alice');
   });
 
+  it('records the backend error class so identical messages differ (#1800)', async () => {
+    const err = new Error('Generation failed. Check the selected engine and try again.');
+    err.errorClass = 'MemoryError';
+    const body = decodeURIComponent(await buildBugReportUrl({ error: err }));
+    expect(body).toContain('Backend error class: MemoryError');
+  });
+
+  it('omits the class line when the failure carries none', async () => {
+    const body = decodeURIComponent(await buildBugReportUrl({ error: new Error('plain failure') }));
+    expect(body).not.toContain('Backend error class');
+  });
+
   it('seeds the title with the error message', async () => {
     const url = await buildBugReportUrl({ error: new Error('synthesis exploded') });
     expect(decodeURIComponent(url)).toContain('[Bug] synthesis exploded');

--- a/frontend/src/utils/streamingTts.js
+++ b/frontend/src/utils/streamingTts.js
@@ -80,6 +80,11 @@ export class StreamingPreviewError extends Error {
     this.retryable = opts?.retryable === true;
     this.retryAfter = opts?.retryAfter ?? null;
     this.terminal = opts?.terminal === true;
+    // The backend exception TYPE behind an otherwise generic failure. The
+    // floor message is identical for every unclassified engine failure, so
+    // without this an auto-filed report cannot be told apart from any
+    // other (#1800). Never the exception message — only its class name.
+    this.errorClass = opts?.errorClass || null;
   }
 }
 
@@ -404,6 +409,7 @@ async function _streamGenerateSpeech(
           retryable: ev.retryable === true,
           retryAfter: ev.retry_after ?? null,
           terminal,
+          errorClass: ev.error_class || null,
         });
       }
     };

--- a/tests/test_context_free_hints_1943.py
+++ b/tests/test_context_free_hints_1943.py
@@ -1,0 +1,69 @@
+"""#1943 — a context-free surface must not attach a stage-specific hint.
+
+A macOS mlx-audio text-to-speech failure came back as a 500 reading "… The
+connection to the video server dropped mid-download (often a transient
+CDN/network blip …)". No video was involved. VIDEO_DOWNLOAD_NETWORK triggers
+on bare phrases like "timed out" and "connection reset", so any unrelated
+failure whose message contains one is handed a confidently wrong remediation.
+
+failure._CONTEXT_FREE_HINT_CLASSES already existed for this, and its own
+comment names VIDEO_DOWNLOAD_NETWORK as the class that must never appear on a
+context-free surface. Only append_hint honoured it; public_exception_response
+replaced append_hint on the 500 path without carrying the rule across.
+"""
+import pytest
+
+from core.failure import _CONTEXT_FREE_HINT_CLASSES, classify
+from core.public_errors import public_exception_response, stream_generation_failure
+
+# Phrases that really do classify as the video-download class but say nothing
+# about a video when they arrive from a model load or a synthesis run.
+_GENERIC_NETWORK_WORDING = [
+    "operation timed out",
+    "connection reset by peer",
+    "broken pipe",
+    "remote end closed connection without response",
+]
+
+
+@pytest.mark.parametrize("message", _GENERIC_NETWORK_WORDING)
+def test_no_video_hint_on_a_context_free_failure(message):
+    assert classify(message) == "VIDEO_DOWNLOAD_NETWORK"  # still classified...
+    payload = public_exception_response(RuntimeError(message), fallback="Internal error.")
+    # ...but its hint must not reach a surface that does not know the stage.
+    assert payload["detail"] == "Internal error."
+    assert "video server" not in payload["detail"]
+    assert "docs_topic" not in payload
+
+
+@pytest.mark.parametrize("message", _GENERIC_NETWORK_WORDING)
+def test_no_video_hint_on_the_streaming_generate_frame(message):
+    payload = stream_generation_failure(RuntimeError(message))
+    assert "video" not in str(payload["detail"]).lower()
+    assert "docs_topic" not in payload
+
+
+def test_allowlisted_classes_keep_their_hint():
+    payload = public_exception_response(
+        RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB"),
+        fallback="Internal error.",
+    )
+    assert payload.get("docs_topic") == "GPU_OOM"
+    assert payload["detail"] != "Internal error."
+
+
+def test_windows_paging_file_keeps_its_hint():
+    # An allowlisted class whose trigger is unmistakable — the regression guard
+    # for over-filtering, which would silently strip every useful remediation.
+    payload = public_exception_response(
+        OSError("[WinError 1455] The paging file is too small for this operation to complete"),
+        fallback="Internal error.",
+    )
+    assert payload.get("docs_topic") == "WINDOWS_PAGING_FILE_TOO_SMALL"
+
+
+def test_the_filter_matches_the_documented_allowlist():
+    # Pins the contract itself: the class the allowlist's own comment calls out
+    # as unsafe must not be a member.
+    assert "VIDEO_DOWNLOAD_NETWORK" not in _CONTEXT_FREE_HINT_CLASSES
+    assert "GPU_OOM" in _CONTEXT_FREE_HINT_CLASSES

--- a/tests/test_stream_error_class_1800.py
+++ b/tests/test_stream_error_class_1800.py
@@ -1,0 +1,53 @@
+"""#1800 — an unclassified streaming failure must carry its exception class.
+
+Every engine failure the taxonomy cannot classify renders the same floor
+message, "Generation failed. Check the selected engine and try again." The
+auto bug reporter puts that message and a stack of minified bundle frames into
+the issue, so roughly a dozen separate faults arrived as byte-identical,
+untriageable reports. The exception's TYPE NAME is what separates them.
+
+It is the type name only. No substring of the exception message is copied, so
+the response-safety contract in tests/test_response_safety.py still holds.
+"""
+import pytest
+
+from core.public_errors import stream_failure, stream_generation_failure
+
+
+def test_unclassified_failure_carries_its_exception_class():
+    payload = stream_generation_failure(RuntimeError("CUDA error: device-side assert"))
+    assert payload["code"] == "generation_failed"
+    assert payload["error_class"] == "RuntimeError"
+
+
+def test_two_unrelated_failures_are_distinguishable():
+    # The whole point: these used to be the same report.
+    a = stream_generation_failure(RuntimeError("boom"))
+    b = stream_generation_failure(MemoryError("out of memory"))
+    assert a["detail"] == b["detail"]
+    assert a["error_class"] != b["error_class"]
+
+
+def test_the_exception_message_is_never_copied():
+    secret = "C:/Users/someone/private-voice-sample.wav"
+    payload = stream_generation_failure(FileNotFoundError(secret))
+    assert payload["error_class"] == "FileNotFoundError"
+    for value in payload.values():
+        assert secret not in str(value)
+        assert "someone" not in str(value)
+
+
+def test_a_non_exception_gets_no_class():
+    # dict(...) of the plain floor payload, unchanged — nothing to name.
+    payload = stream_generation_failure("not an exception")
+    assert "error_class" not in payload
+    assert payload["detail"] == stream_failure("generation_failed")["detail"]
+
+
+@pytest.mark.parametrize("exc", [RuntimeError("x"), ValueError("y"), OSError("z")])
+def test_class_is_present_alongside_a_classified_hint(exc):
+    # Enrichment and the class name are independent: adding one must not drop
+    # the other, whichever branch the taxonomy takes.
+    payload = stream_generation_failure(exc)
+    assert payload["error_class"] == type(exc).__name__
+    assert payload["detail"]


### PR DESCRIPTION
Closes #1800. Closes #1943.

Two halves of the same problem: when VoiceStudio cannot classify a failure, the report it produces is both **indistinguishable** from every other one and sometimes **actively wrong**.

## #1800 — every unclassified failure files the same issue

Every engine failure the taxonomy cannot classify renders one floor message: *"Generation failed. Check the selected engine and try again."* The auto bug reporter embeds that message plus a stack of minified bundle frames, so unrelated faults arrive as byte-identical issues.

About twenty currently-open issues are that same report filed again — #1954, #1947, #1945, #1944, #1932, #1906, #1905, #1882, #1880, #1869, #1846, #1843, #1840, #1839, #1836, #1834, #1825, #1824, #1822, #1820. None can be told apart, let alone triaged.

The streaming error frame now carries the exception's **type name**. The frontend keeps it on `StreamingPreviewError`, and the report prints `Backend error class: …`. A `MemoryError` and a `FileNotFoundError` stop being the same issue.

Only the class name — no substring of the exception message is copied, so the response-safety contract holds, and a test pins that a path inside the exception never reaches the payload. This is the same datum the dub routes already put on the wire as `error_class` and that the analytics allowlist already treats as content-free. It is also what the classic 500 path already returns, so this closes a gap between the two paths rather than inventing a field.

## #1943 — a stageless failure borrowed another stage's advice

A macOS mlx-audio text-to-speech failure came back advising the user that *"the connection to the video server dropped mid-download"*. `VIDEO_DOWNLOAD_NETWORK` triggers on bare phrases like `timed out` and `connection reset`, so any unrelated failure carrying one gets a confidently wrong next step — worse than no hint.

`failure._CONTEXT_FREE_HINT_CLASSES` already existed for exactly this, and its own comment names `VIDEO_DOWNLOAD_NETWORK` as the class that must never appear on a stageless surface. Only `append_hint` honoured it; `public_exception_response` took over the 500 path without carrying the rule across, and the streaming frame then inherited the same gap through it. The filter now lives in `public_exception_response`, so every context-free caller gets it.

`MODEL_CACHE_CORRUPT` joins the allowlist: its trigger is a VoiceStudio-authored sentence no library can produce, and the 500 handler is the surface a corrupt cache actually reaches.

## Verification

- `tests/test_stream_error_class_1800.py` — 5 cases, including one asserting the exception message is never copied.
- `tests/test_context_free_hints_1943.py` — 8 cases, including regression guards that allowlisted classes keep their hints, so this cannot over-filter.
- All 184 existing hint/classification tests pass unchanged across 13 files, including `test_response_safety.py`.
- Frontend: 4 new cases; `streamingTts.test.js` + `bugReport.test.js` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Streaming failures now include the backend exception class without exposing exception messages, and bug reports display it. Context-free responses no longer attach unrelated stage-specific remediation hints. Human review should confirm that exposed class names do not reveal sensitive implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->