### PR TITLE
fix(errors): point a generation timeout at Settings, not an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- A generation timeout now points at the compute-time budget in Settings rather than an environment variable (#1808)
 - The last onboarding step offers to install a speech-to-text model instead of failing three times when none is installed (#1856)
 - A download that fails because the folder sits behind a mount point Windows will not cross now says so, and where to move it (#1957)
 - A GPU that is merely short on free memory is no longer told to reinstall its drivers (#1812) — thanks @michaelhuamanflores!

--- a/backend/services/model_manager.py
+++ b/backend/services/model_manager.py
@@ -1145,7 +1145,7 @@ def _timeout_guidance(
             "compute-bound. For a durable fix try shorter text or a lighter "
             "engine (OmniVoice GGUF and Supertonic-3 are CPU-tuned). If you "
             "expect very long single generations, raise "
-            "OMNIVOICE_GENERATE_TIMEOUT_S."
+            "the compute-time budget in Settings → Performance & Device."
         )
     # #1226/#1222: two users on 4 GB cards were told, generically, that the GPU
     # "is VRAM-starved" — true, but it read as a transient contention problem
@@ -1168,7 +1168,8 @@ def _timeout_guidance(
             f"Supertonic-3 are tuned for small/no GPU) or shorter text; "
             f"Flush caches / Unload the resident model (top toolbar or "
             f"Model Catalogue → Models) frees what little headroom there is. (Raise "
-            f"OMNIVOICE_GENERATE_TIMEOUT_S if you'd rather let long "
+            f"the compute-time budget in Settings → Performance & Device if "
+            f"you'd rather let long "
             f"generations run.)"
         )
     return common + (
@@ -1176,7 +1177,8 @@ def _timeout_guidance(
         "contend for memory). For a durable fix, Flush caches / Unload the "
         "resident model (top toolbar or Model Catalogue → Models) before retrying, "
         "try shorter text, a lighter engine, or set the engine to CPU in "
-        "Model Catalogue → Models. (Raise OMNIVOICE_GENERATE_TIMEOUT_S for very "
+        "Model Catalogue → Models. (Raise the compute-time budget in "
+        "Settings → Performance & Device for very "
         "long single generations.)"
     )
 

--- a/docs/hardware-notes-tesla-t4.md
+++ b/docs/hardware-notes-tesla-t4.md
@@ -31,7 +31,9 @@ request succeeds in ~1s (reproduced 5x: 1.574s / 1.034s / 1.065s / 0.995s / 0.91
   (`repo_id` is required — `InstallModelRequest` in `backend/api/schemas.py` rejects a bare/empty
   body — and must match one of the entries in `KNOWN_MODELS`, e.g. the default engine's
   `k2-fsa/OmniVoice`.) Progress streams over the existing `/setup/download-stream` SSE feed.
-- Or raise `OMNIVOICE_GENERATE_TIMEOUT_S` for the first request.
+- Or raise the compute-time budget in **Settings → Performance & Device** for the first
+  request (`OMNIVOICE_GENERATE_TIMEOUT_S` does the same thing from the environment, and
+  takes precedence over the setting when both are present).
 
 ## OpenAI-compatible endpoint doesn't expose `num_step` / `guidance_scale`
 

--- a/tests/test_generate_timeout_730.py
+++ b/tests/test_generate_timeout_730.py
@@ -320,7 +320,10 @@ def test_cpu_host_gets_compute_bound_guidance(monkeypatch):
     assert "VRAM" not in msg
     assert "set the engine to CPU" not in msg
     assert "compute-bound" in msg
-    assert "OMNIVOICE_GENERATE_TIMEOUT_S" in msg
+    # #1808: the budget moved into Settings → Performance & Device in #1797,
+    # so the remedy names that control now. The env var still works and still
+    # shadows the setting — only which one we point the user at changed.
+    assert "Settings → Performance & Device" in msg
 
 
 def test_gpu_host_keeps_vram_guidance(monkeypatch):

--- a/tests/test_gpu_pool_queue_accounting_1190.py
+++ b/tests/test_gpu_pool_queue_accounting_1190.py
@@ -205,7 +205,10 @@ def test_timeout_guidance_does_not_claim_capacity_was_restored(mm):
     assert "until it finishes" in msg
     # Actionable for interactive users AND scripted clients.
     assert "restart the backend" in msg
-    assert "OMNIVOICE_GENERATE_TIMEOUT_S" in msg
+    # #1808: the budget moved into Settings → Performance & Device in #1797,
+    # so the remedy names that control now. The env var still works and still
+    # shadows the setting — only which one we point the user at changed.
+    assert "Settings → Performance & Device" in msg
 
 
 # ── Defect 4: every dispatch uses the shared length-scaled budget ───────────

--- a/tests/test_timeout_guidance_1808.py
+++ b/tests/test_timeout_guidance_1808.py
@@ -1,0 +1,64 @@
+"""#1808 — timeout guidance must name the control the user actually has.
+
+#1797 moved the compute-time budget into Settings → Performance & Device, but
+three branches of `_timeout_guidance` still told the user to raise
+OMNIVOICE_GENERATE_TIMEOUT_S. That sends someone to set an environment variable
+for a value the app now exposes as a slider — and on Windows in particular,
+setting one durably is exactly the trap the project's own docs warn against.
+
+The env var still works and still shadows the setting; nothing about the
+mechanism changed. What changed is which of the two the message names.
+"""
+import re
+
+import pytest
+
+from services.model_manager import _timeout_guidance
+
+_ENV_VAR = "OMNIVOICE_GENERATE_TIMEOUT_S"
+_SETTINGS = "Settings → Performance & Device"
+
+
+@pytest.mark.parametrize("wedged", [False, True])
+@pytest.mark.parametrize("min_vram_gb", [0.0, 24.0])
+def test_no_branch_sends_the_user_to_an_environment_variable(wedged, min_vram_gb):
+    text = _timeout_guidance("generation", 300.0, min_vram_gb, wedged=wedged)
+    assert _ENV_VAR not in text
+
+
+@pytest.mark.parametrize("min_vram_gb", [0.0, 24.0])
+def test_the_advice_names_the_in_app_control(min_vram_gb):
+    text = _timeout_guidance("generation", 300.0, min_vram_gb)
+    assert _SETTINGS in text
+
+
+def test_the_message_still_says_what_happened():
+    # The rewrite must not cost the diagnosis — only the remedy changed.
+    text = _timeout_guidance("generation", 300.0)
+    assert "300" in text or "compute" in text.lower()
+
+
+def test_no_user_facing_string_in_the_module_names_the_env_var():
+    # The whole class, not the three instances: a new branch added later must
+    # not reintroduce it. Comments and the config read itself are exempt —
+    # those are how the variable is still honoured.
+    import inspect
+
+    import services.model_manager as mm
+
+    source = inspect.getsource(mm)
+    offenders = []
+    for line in source.splitlines():
+        if _ENV_VAR not in line:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("#") or "os.environ" in line:
+            continue
+        # A bare mention inside a docstring/comment-like policy note is fine;
+        # what matters is a quoted string handed to a user.
+        if re.search(r'["\'][^"\']*' + _ENV_VAR, line):
+            offenders.append(stripped)
+    assert offenders == [], (
+        "timeout guidance names an environment variable instead of "
+        f"{_SETTINGS}: {offenders}"
+    )


### PR DESCRIPTION
Closes #1808.

#1797 moved the compute-time budget into **Settings → Performance & Device**, but three branches of `_timeout_guidance` still told the user to raise `OMNIVOICE_GENERATE_TIMEOUT_S`. That sends someone off to set an environment variable for a value the app now exposes as a control — and on Windows, setting one durably is the exact trap this project's own guidance warns against.

Nothing about the mechanism changed. The variable still works and still takes precedence over the setting. Only which of the two the message names.

## Two existing tests had to change

`test_cpu_host_gets_compute_bound_guidance` and `test_timeout_guidance_does_not_claim_capacity_was_restored` both asserted the env var appears in that text. They predate #1797 and were pinning the behaviour this issue reports as wrong, so they now assert the control instead. Worth flagging explicitly rather than burying: these are assertion changes, not new coverage.

A third test guards the **class** rather than the three instances — it scans the module for any quoted user-facing string naming the variable, so a branch added later cannot quietly reintroduce it. Comments and the config read are exempt, since those are how the variable is still honoured.

## Docs

`docs/install/troubleshooting.md` already documents the env vars as the advanced tuning path and already names the Settings control, so it stays as is. The Tesla T4 hardware note offered only the variable; it now offers both and says which wins.

## Verification

266 passed across every timeout, budget and guidance test in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Timeout guidance now directs users to Settings → Performance & Device while retaining `OMNIVOICE_GENERATE_TIMEOUT_S` support and precedence. This fixes issue `#1808`, especially for Windows users who need an in-app control. Regression tests prevent the environment variable from reappearing in user-facing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->