### PR TITLE
fix(startup): guard the torchaudio API removed in 2.9, and document the Blackwell path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- Upgrading torch for an RTX 50-series card no longer trades one startup crash for another, and the upgrade is documented (#1931)
 - The Accessibility prompt no longer floats over first-run setup and every other app until you grant it (#1845, #1886)
 - The last onboarding step offers to install a speech-to-text model instead of failing three times when none is installed (#1856)
 - A download that fails because the folder sits behind a mount point Windows will not cross now says so, and where to move it (#1957)

--- a/backend/main.py
+++ b/backend/main.py
@@ -624,7 +624,19 @@ def _phase_a_build_inner() -> None:
     _startup_progress.begin_step("ml_imports")
     import torchaudio
     warnings.filterwarnings("ignore", category=UserWarning)
-    torchaudio.set_audio_backend("soundfile")
+    # torchaudio 2.9 REMOVED set_audio_backend(); soundfile has been the only
+    # backend since 2.0, so the call was already a no-op there and is simply
+    # absent now. Unguarded it raises AttributeError inside `ml_imports`, and a
+    # failure in that phase takes the whole backend down — the desktop app sits
+    # on "starting backend" forever and /health stays 503.
+    #
+    # That is not a hypothetical version: RTX 50-series (Blackwell, sm_120)
+    # users have no choice but to move off the pinned torch 2.8.0, which has no
+    # sm_120 kernels, and the torch 2.9.x they land on brings torchaudio 2.9
+    # with it. So the one group forced to upgrade hit a hard startup crash for
+    # a line that does nothing (#1931).
+    if hasattr(torchaudio, "set_audio_backend"):
+        torchaudio.set_audio_backend("soundfile")
     from utils import hf_progress
     # HF tqdm patch before any library import that can trigger
     # hf_hub_download (transformers, mlx_whisper, …).

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -963,6 +963,46 @@ repair is required.
 
 **Linked issue:** [#1590](https://github.com/debpalash/VoiceStudio/issues/1590)
 
+## RTX 50-series (Blackwell, `sm_120`): backend never starts
+
+**Symptom.** The desktop app stays on "starting backend", `/health` returns 503,
+and the backend log ends inside the `ml_imports` phase — often with a native
+crash (exit code `0xffffffff` / `-1073741819`) rather than a Python traceback.
+
+**Cause.** VoiceStudio pins `torch 2.8.0+cu128`, which ships no `sm_120`
+kernels. On an RTX 50-series card `import torch` dies natively, before any
+VoiceStudio code can classify it — which is why the app can only say the
+backend did not start. This is a property of the pinned build, not of your
+driver or your install.
+
+**Fix.** Move to a torch build that has Blackwell kernels. From a source
+checkout, in the project folder:
+
+1. Edit `pyproject.toml` → `[tool.uv] constraint-dependencies` and raise the
+   torch constraint to `torch==2.9.1+cu128` (matching `torchaudio` /
+   `torchvision` for that release).
+2. `uv lock`
+3. `uv sync --all-extras`
+
+Then confirm the card is actually visible:
+
+```bash
+uv run python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_capability())"
+```
+
+`True (12, 0)` means Blackwell is working.
+
+**Note.** torchaudio 2.9 removed `set_audio_backend()`. VoiceStudio's call is
+guarded, so the upgrade above no longer trades one startup crash for another —
+but if you are on a build older than that guard you will see
+`AttributeError: module 'torchaudio' has no attribute 'set_audio_backend'`
+in the same phase. Update VoiceStudio, or delete that line in
+`backend/main.py`.
+
+**Why the pin has not moved.** Raising it for everyone changes the CUDA build
+on every platform, in Docker, and in CI, so it is a deliberate decision rather
+than a patch. Track it in [#1931](https://github.com/debpalash/VoiceStudio/issues/1931).
+
 ## Uninstalling / removing all of VoiceStudio's data
 
 VoiceStudio is fully local — no accounts, no services, nothing to deactivate. To

--- a/tests/test_torchaudio_legacy_backend_1931.py
+++ b/tests/test_torchaudio_legacy_backend_1931.py
@@ -1,0 +1,59 @@
+"""#1931 — a removed torchaudio API must not take startup down.
+
+torchaudio 2.9 removed ``set_audio_backend()``. soundfile has been the only
+backend since 2.0, so the call was already a no-op — but unguarded it raises
+AttributeError inside the ``ml_imports`` startup phase, and a failure there
+takes the whole backend with it: the desktop app sits on "starting backend"
+forever and /health stays 503.
+
+The group that hits this is not hypothetical. RTX 50-series (Blackwell, sm_120)
+cards have no kernels in the pinned torch 2.8.0, so those users must move to
+torch 2.9.x, which brings torchaudio 2.9 with it. Being forced to upgrade and
+then crashing on a line that does nothing is the whole bug.
+
+Checked at the source level because reproducing it needs a real torchaudio 2.9
+in the environment, which the pinned test env does not have. Guarding the
+class, not the instance: any future call into a version-dependent torchaudio
+attribute during ml_imports has to be defensive.
+"""
+import inspect
+import pathlib
+import re
+
+_MAIN = pathlib.Path(__file__).resolve().parents[1] / "backend" / "main.py"
+
+
+def test_the_legacy_backend_call_is_guarded():
+    source = _MAIN.read_text(encoding="utf-8")
+    calls = [
+        line.strip()
+        for line in source.splitlines()
+        if "set_audio_backend(" in line and not line.strip().startswith("#")
+    ]
+    assert calls, "the call vanished — drop this test with it"
+    for call in calls:
+        assert call.startswith("torchaudio.set_audio_backend") or "hasattr" in call, call
+    assert 'hasattr(torchaudio, "set_audio_backend")' in source, (
+        "torchaudio.set_audio_backend() must be guarded: it does not exist in "
+        "torchaudio 2.9+, and an AttributeError in ml_imports is a fatal "
+        "startup failure rather than a degraded feature"
+    )
+
+
+def test_the_guard_actually_wraps_the_call():
+    # A guard that sits somewhere else in the file would pass a naive substring
+    # check while the real call stays unprotected.
+    source = _MAIN.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r'if hasattr\(torchaudio, "set_audio_backend"\):\s*\n\s+'
+        r'torchaudio\.set_audio_backend\('
+    )
+    assert pattern.search(source), "the hasattr guard does not wrap the call"
+
+
+def test_soundfile_is_importable_so_the_no_op_is_safe():
+    # The call only ever selected soundfile. If that backend were missing,
+    # dropping the call would be a behaviour change rather than a no-op.
+    import soundfile  # noqa: F401
+
+    assert inspect.ismodule(soundfile)


### PR DESCRIPTION
Refs #1931. Deliberately does **not** close it — see below.

## What this fixes

torchaudio 2.9 removed `set_audio_backend()`. soundfile has been the only backend since 2.0, so the call was already a no-op — but unguarded it raises `AttributeError` inside the `ml_imports` startup phase, and a failure there takes the whole backend down. The desktop app sits on "starting backend" forever and `/health` stays 503.

The group hitting this is not hypothetical. RTX 50-series (Blackwell, `sm_120`) cards have **no kernels** in the pinned `torch 2.8.0`, so those users must move to torch 2.9.x — which brings torchaudio 2.9 with it. Being forced to upgrade and then crashing on a line that does nothing is the whole defect.

## What this deliberately does not do

**It does not raise the torch pin.** That changes the CUDA build on every platform, in Docker, and in CI, so it is your call rather than something to slip into a bug fix. #1931 stays open for that decision.

What lands here is the half that is safe, plus a documented path so an affected user is unblocked today: a troubleshooting section with the exact upgrade recipe (`constraint-dependencies` → `uv lock` → `uv sync`), the command to confirm the card is actually visible, and a note on why the pin has not moved.

Worth knowing: on Blackwell, `import torch` dies *natively* before any VoiceStudio code runs. The arch-mismatch detection in `device_caps` — which would otherwise say exactly the right thing — never gets the chance. That is why the app can only report that the backend did not start.

## Verification

Tested at the source level, because reproducing it needs a real torchaudio 2.9 in the environment and the pinned test env does not have one. Three cases: the guard exists, the guard actually **wraps** the call (a `hasattr` elsewhere in the file would satisfy a naive substring check while the real call stayed bare), and soundfile is importable so dropping the call really is a no-op rather than a behaviour change.

`scripts/validate-install-docs.py` passes, as do the engine-docs, changelog-style and hardcoded-CJK guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Guard `torchaudio.set_audio_backend()` to prevent torchaudio 2.9 from blocking backend startup. Add RTX 50-series troubleshooting steps for torch 2.9.1+cu128 without changing the global torch pin. RTX 50-series users still require the documented manual override until issue `#1931` is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->