### PR TITLE
fix(setup): offer the text-size control before first run, not after it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- First run asks about text size before the install, not after it (#1849)
 - A generation timeout now points at the compute-time budget in Settings rather than an environment variable (#1808)
 - An engine you have not installed now says so, instead of reporting a failed check (#1866)
 - The Accessibility prompt no longer floats over first-run setup and every other app until you grant it (#1845, #1886)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1272,18 +1272,19 @@ function App() {
       </div>
     );
   }
-  if (remoteFailure) {
-    return (
-      <div className="app-bootstrap-scale" style={{ '--ui-scale': effectiveUiScale }}>
-        <RemoteBackendRecovery
-          failure={remoteFailure}
-          onRetry={retryRemoteBackend}
-          onOpenSettings={openRemoteBackendSettings}
-        />
-      </div>
-    );
-  }
-  if (!uiScaleConfigured && backendReady) {
+
+  // Legibility comes before everything the backend gates. UiScaleSetup makes
+  // no backend calls at all — it is a client-side zoom — but it used to wait
+  // for `backendReady`, so on a clean first run the user watched the entire
+  // bootstrap (and answered the macOS Accessibility prompt) at whatever size
+  // the app guessed, and was offered the size control only once all of that
+  // had finished (#1849). Asking first costs one screen and makes the rest of
+  // first-run readable.
+  //
+  // Still after the hydration guard above: `uiScaleConfigured` lives in the
+  // store, and reading it before hydration would flash this screen at someone
+  // who had already set their scale.
+  if (!uiScaleConfigured) {
     return (
       <div className="app-wizard-wrap" style={{ '--ui-scale': effectiveUiScale }}>
         <div data-tauri-drag-region className="app-wizard-dragstrip" />
@@ -1295,6 +1296,17 @@ function App() {
             setUiScalePreviewed={setUiScalePreviewed}
           />
         </Suspense>
+      </div>
+    );
+  }
+  if (remoteFailure) {
+    return (
+      <div className="app-bootstrap-scale" style={{ '--ui-scale': effectiveUiScale }}>
+        <RemoteBackendRecovery
+          failure={remoteFailure}
+          onRetry={retryRemoteBackend}
+          onOpenSettings={openRemoteBackendSettings}
+        />
       </div>
     );
   }

--- a/frontend/src/test/uiScaleFirstRunOrder.test.js
+++ b/frontend/src/test/uiScaleFirstRunOrder.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * #1849 — the legibility control must come before the long first run.
+ *
+ * `UiScaleSetup` is a client-side zoom: it makes no backend calls at all. It
+ * was nonetheless gated on `backendReady`, so on a clean install the user
+ * watched the whole bootstrap — and answered the macOS Accessibility prompt —
+ * at whatever size the app had guessed, and was offered the size control only
+ * once all of that had finished. Someone who cannot comfortably read the UI
+ * had to get through the least readable part of the product first.
+ *
+ * Checked at the source level because the ordering lives in App.jsx's early
+ * returns, and rendering App in jsdom to observe it would need the whole
+ * backend, store and Tauri surface mocked — a test far more fragile than the
+ * two facts it would be pinning.
+ */
+const app = readFileSync(resolve(process.cwd(), 'src/App.jsx'), 'utf8');
+
+const gateIndex = app.indexOf('if (!uiScaleConfigured');
+const hydrationIndex = app.indexOf('if (!setupChecked || !storeHydrated)');
+// The brace matters: `if (!backendReady) return;` appears earlier inside an
+// effect, and matching that instead would compare against the wrong line.
+const backendGateIndex = app.indexOf('if (!backendReady) {');
+const wizardIndex = app.indexOf('if (setupNeeded && backendReady)');
+
+describe('first-run ordering: legibility before the backend gates', () => {
+  it('still has the gate at all', () => {
+    expect(gateIndex).toBeGreaterThan(-1);
+  });
+
+  it('does not wait for the backend', () => {
+    const gateLine = app.slice(gateIndex, app.indexOf('\n', gateIndex));
+    expect(gateLine).not.toContain('backendReady');
+  });
+
+  it('comes before the bootstrap progress screen and the setup wizard', () => {
+    expect(backendGateIndex).toBeGreaterThan(-1);
+    expect(wizardIndex).toBeGreaterThan(-1);
+    expect(gateIndex).toBeLessThan(backendGateIndex);
+    expect(gateIndex).toBeLessThan(wizardIndex);
+  });
+
+  it('still comes after store hydration', () => {
+    // Reading `uiScaleConfigured` before the store hydrates would flash this
+    // screen at someone who had already chosen a scale.
+    expect(hydrationIndex).toBeGreaterThan(-1);
+    expect(hydrationIndex).toBeLessThan(gateIndex);
+  });
+});


### PR DESCRIPTION
Closes #1849.

`UiScaleSetup` is a **client-side zoom**. It makes no backend calls at all — but it was gated on `backendReady`. So on a clean install the user watched the entire bootstrap, and answered the macOS Accessibility prompt, at whatever size the app had guessed, and was offered the size control only once all of that had finished.

Someone who cannot comfortably read the UI had to get through the least readable part of the product first.

## The change

The gate now runs as soon as the store has hydrated, which is its only real prerequisite: `uiScaleConfigured` lives in the store, and reading it earlier would flash the screen at someone who had already chosen a scale.

Ordering after the change: hydration guard → **text size** → remote-backend recovery → setup wizard → bootstrap progress.

## Verification

`frontend/src/test/uiScaleFirstRunOrder.test.js`, four cases: the gate exists, it no longer mentions `backendReady`, it precedes both the bootstrap progress screen and the setup wizard, and it still follows hydration.

Pinned at the source level deliberately. Rendering `App` in jsdom to observe the ordering would need the whole backend, store and Tauri surface mocked — a far more fragile test than the two facts it pins. One note in the test explains a trap I hit writing it: `if (!backendReady) return;` appears earlier inside an effect, so the index comparison has to match the render gate's brace or it compares against the wrong line and passes for the wrong reason.

Full frontend suite: 2836 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
`UiScaleSetup` now appears after store hydration and before backend-dependent recovery, setup, and bootstrap flows. This lets low-vision users set text size earlier during first run. Source-level tests verify the ordering and removal of the `backendReady` dependency; review should confirm hydration provides the required local preference state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->