### PR TITLE
fix(a11y): Add Solarized Light theme and wire OS auto-sync

### DIFF
--- a/frontend/src/components/settings/AppearancePanel.jsx
+++ b/frontend/src/components/settings/AppearancePanel.jsx
@@ -13,14 +13,14 @@ import { useAppStore, FONT_OPTIONS, FONT_STACKS } from '../../store';
 import { SettingsSection, SettingRow, InfoHint, SettingsToggle } from './primitives';
 
 const THEMES = [
-  { id: 'auto', label: 'System Auto', dot: 'linear-gradient(135deg, #fdf6e3 50%, #1d2021 50%)' },
+  { id: 'auto', labelKey: 'settings.theme_auto', defaultLabel: 'System Auto', dot: 'linear-gradient(135deg, #fdf6e3 50%, #1d2021 50%)' },
   { id: 'gruvbox', label: 'Gruvbox', dot: '#d3869b' },
   { id: 'midnight', label: 'Midnight', dot: '#8b5cf6' },
   { id: 'nord', label: 'Nord', dot: '#88c0d0' },
   { id: 'solarized', label: 'Solarized', dot: '#268bd2' },
   { id: 'rose-pine', label: 'Rosé Pine', dot: '#ebbcba' },
   { id: 'catppuccin', label: 'Catppuccin', dot: '#cba6f7' },
-  { id: 'light', label: 'Light', dot: '#1d6b9f' },
+  { id: 'light', labelKey: 'settings.theme_light', defaultLabel: 'Light', dot: '#1d6b9f' },
 ];
 
 /**
@@ -204,8 +204,8 @@ export default function AppearancePanel() {
                 style={{ '--dot-color': th.dot }}
                 onClick={() => setTheme(th.id)}
                 onKeyDown={(e) => radioGroupKeyDown(e, themeIds, theme, setTheme)}
-                title={th.label}
-                aria-label={th.label}
+                title={th.labelKey ? t(th.labelKey, { defaultValue: th.defaultLabel }) : th.label}
+                aria-label={th.labelKey ? t(th.labelKey, { defaultValue: th.defaultLabel }) : th.label}
                 aria-checked={theme === th.id}
                 role="radio"
                 tabIndex={radioTabIndex(themeIds, theme, th.id)}

--- a/frontend/src/components/settings/AppearancePanel.jsx
+++ b/frontend/src/components/settings/AppearancePanel.jsx
@@ -13,12 +13,14 @@ import { useAppStore, FONT_OPTIONS, FONT_STACKS } from '../../store';
 import { SettingsSection, SettingRow, InfoHint, SettingsToggle } from './primitives';
 
 const THEMES = [
+  { id: 'auto', label: 'System Auto', dot: 'linear-gradient(135deg, #fdf6e3 50%, #1d2021 50%)' },
   { id: 'gruvbox', label: 'Gruvbox', dot: '#d3869b' },
   { id: 'midnight', label: 'Midnight', dot: '#8b5cf6' },
   { id: 'nord', label: 'Nord', dot: '#88c0d0' },
   { id: 'solarized', label: 'Solarized', dot: '#268bd2' },
   { id: 'rose-pine', label: 'Rosé Pine', dot: '#ebbcba' },
   { id: 'catppuccin', label: 'Catppuccin', dot: '#cba6f7' },
+  { id: 'light', label: 'Light', dot: '#1d6b9f' },
 ];
 
 /**

--- a/frontend/src/components/settings/AppearancePanel.test.jsx
+++ b/frontend/src/components/settings/AppearancePanel.test.jsx
@@ -149,3 +149,21 @@ describe('AppearancePanel — navigation style picker', () => {
     useAppStore.getState().setNavStyle('rail');
   });
 });
+
+describe('AppearancePanel — theme selection', () => {
+  it('renders localized labels for the Auto and Light themes', () => {
+    render(<AppearancePanel />);
+    
+    // The test runner uses the `defaultValue` from our t() hooks.
+    // This verifies the labels are correctly exposed to screen readers via aria-label.
+    const autoTheme = screen.getByRole('radio', { name: 'System Auto' });
+    const lightTheme = screen.getByRole('radio', { name: 'Light' });
+    
+    expect(autoTheme).toBeInTheDocument();
+    expect(lightTheme).toBeInTheDocument();
+    
+    // Verify it generates the correct data attribute for the OS-sync theme
+    expect(autoTheme).toHaveAttribute('data-radio-value', 'auto');
+    expect(lightTheme).toHaveAttribute('data-radio-value', 'light');
+  });
+});

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "لم يتم اختباره",
     "hf_source_app_label": "VoiceStudio (مشفّر، موصى به)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "متغير البيئة"
+    "hf_source_env_label": "متغير البيئة",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (مشفّر، موصى به)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "متغير البيئة",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "تلقائي حسب النظام",
+    "theme_light": "فاتح"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (verschlüsselt, empfohlen)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Umgebungsvariable",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "System-Standard",
+    "theme_light": "Hell"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Nicht getestet",
     "hf_source_app_label": "VoiceStudio (verschlüsselt, empfohlen)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Umgebungsvariable"
+    "hf_source_env_label": "Umgebungsvariable",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -695,6 +695,8 @@
     "device": "Device & compute",
     "device_desc": "Live hardware and backend readouts.",
     "network_desc": "Proxy for downloads and model fetches.",
+    "theme_auto": "System Auto",
+    "theme_light": "Light",
     "translation_desc": "How dubbing translates dialogue, and which engine does it.",
     "translate_quality": "Translation quality",
     "translate_quality_desc": "Fast is literal and quick; Cinematic uses the LLM for natural phrasing.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Sin probar",
     "hf_source_app_label": "VoiceStudio (cifrado, recomendado)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variable de entorno"
+    "hf_source_env_label": "Variable de entorno",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (cifrado, recomendado)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Variable de entorno",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Automático del sistema",
+    "theme_light": "Claro"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (chiffré, recommandé)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Variable d’environnement",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Auto (Système)",
+    "theme_light": "Clair"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Non testé",
     "hf_source_app_label": "VoiceStudio (chiffré, recommandé)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variable d’environnement"
+    "hf_source_env_label": "Variable d’environnement",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (एन्क्रिप्ट किया गया, अनुशंसित)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "परिवेश चर",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "सिस्टम डिफ़ॉल्ट",
+    "theme_light": "लाइट"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "परीक्षण नहीं हुआ",
     "hf_source_app_label": "VoiceStudio (एन्क्रिप्ट किया गया, अनुशंसित)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "परिवेश चर"
+    "hf_source_env_label": "परिवेश चर",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (terenkripsi, disarankan)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Variabel lingkungan",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Otomatis Sistem",
+    "theme_light": "Terang"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Belum diuji",
     "hf_source_app_label": "VoiceStudio (terenkripsi, disarankan)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variabel lingkungan"
+    "hf_source_env_label": "Variabel lingkungan",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (crittografato, consigliato)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Variabile d’ambiente",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Automatico di sistema",
+    "theme_light": "Chiaro"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Non testato",
     "hf_source_app_label": "VoiceStudio (crittografato, consigliato)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variabile d’ambiente"
+    "hf_source_env_label": "Variabile d’ambiente",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio（暗号化済み、推奨）",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "環境変数",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "システム自動",
+    "theme_light": "ライト"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "未テスト",
     "hf_source_app_label": "VoiceStudio（暗号化済み、推奨）",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "環境変数"
+    "hf_source_env_label": "環境変数",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -576,8 +576,8 @@
     "generate_timeout_shadowed_note": "VoiceStudio 외부의 환경 변수(셸, .env 파일 또는 컨테이너)가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 여기에 저장한 값은 무시됩니다.",
     "generate_timeout_shadowed_toast": "저장되었지만, VoiceStudio 외부의 환경 변수가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 계속 사용됩니다.",
     "hf_token_not_checked": "테스트 안 함",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "시스템 자동",
+    "theme_light": "라이트"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -575,7 +575,9 @@
     "generate_timeout_shadowed_badge": "외부에서 재정의됨",
     "generate_timeout_shadowed_note": "VoiceStudio 외부의 환경 변수(셸, .env 파일 또는 컨테이너)가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 여기에 저장한 값은 무시됩니다.",
     "generate_timeout_shadowed_toast": "저장되었지만, VoiceStudio 외부의 환경 변수가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 계속 사용됩니다.",
-    "hf_token_not_checked": "테스트 안 함"
+    "hf_token_not_checked": "테스트 안 함",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (versleuteld, aanbevolen)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Omgevingsvariabele",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Systeem auto",
+    "theme_light": "Licht"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Niet getest",
     "hf_source_app_label": "VoiceStudio (versleuteld, aanbevolen)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Omgevingsvariabele"
+    "hf_source_env_label": "Omgevingsvariabele",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (zaszyfrowane, zalecane)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Zmienna środowiskowa",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Automatyczny systemowy",
+    "theme_light": "Jasny"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Nie przetestowano",
     "hf_source_app_label": "VoiceStudio (zaszyfrowane, zalecane)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Zmienna środowiskowa"
+    "hf_source_env_label": "Zmienna środowiskowa",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Não testado",
     "hf_source_app_label": "VoiceStudio (criptografado, recomendado)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variável de ambiente"
+    "hf_source_env_label": "Variável de ambiente",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (criptografado, recomendado)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Variável de ambiente",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Automático do Sistema",
+    "theme_light": "Claro"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (зашифровано, рекомендуется)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Переменная окружения",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Системный",
+    "theme_light": "Светлая"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Не проверен",
     "hf_source_app_label": "VoiceStudio (зашифровано, рекомендуется)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Переменная окружения"
+    "hf_source_env_label": "Переменная окружения",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Inte testad",
     "hf_source_app_label": "VoiceStudio (krypterad, rekommenderas)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Miljövariabel"
+    "hf_source_env_label": "Miljövariabel",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (krypterad, rekommenderas)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Miljövariabel",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Systemval",
+    "theme_light": "Ljust"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "ยังไม่ได้ทดสอบ",
     "hf_source_app_label": "VoiceStudio (เข้ารหัส แนะนำ)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "ตัวแปรสภาพแวดล้อม"
+    "hf_source_env_label": "ตัวแปรสภาพแวดล้อม",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (เข้ารหัส แนะนำ)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "ตัวแปรสภาพแวดล้อม",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "อัตโนมัติตามระบบ",
+    "theme_light": "สว่าง"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (şifrelenmiş, önerilen)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Ortam değişkeni",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Sistem Otomatik",
+    "theme_light": "Açık"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Test edilmedi",
     "hf_source_app_label": "VoiceStudio (şifrelenmiş, önerilen)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Ortam değişkeni"
+    "hf_source_env_label": "Ortam değişkeni",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (зашифровано, рекомендовано)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Змінна середовища",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Системний",
+    "theme_light": "Світла"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Не перевірено",
     "hf_source_app_label": "VoiceStudio (зашифровано, рекомендовано)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Змінна середовища"
+    "hf_source_env_label": "Змінна середовища",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Chưa kiểm tra",
     "hf_source_app_label": "VoiceStudio (được mã hóa, khuyên dùng)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Biến môi trường"
+    "hf_source_env_label": "Biến môi trường",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio (được mã hóa, khuyên dùng)",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "Biến môi trường",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "Tự động theo hệ thống",
+    "theme_light": "Sáng"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -841,8 +841,8 @@
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一个环境变量（终端、.env 文件或容器）当前正在设置此值——在移除该变量之前，此处保存的值会被忽略。",
     "generate_timeout_shadowed_toast": "已保存，但 VoiceStudio 之外的一个环境变量当前正在设置此值——在移除该变量之前，将继续使用该值。",
     "hf_token_not_checked": "未测试",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "系统自动",
+    "theme_light": "浅色"
   },
   "about": {
     "app": "应用",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -840,7 +840,9 @@
     "generate_timeout_shadowed_badge": "已被外部覆盖",
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一个环境变量（终端、.env 文件或容器）当前正在设置此值——在移除该变量之前，此处保存的值会被忽略。",
     "generate_timeout_shadowed_toast": "已保存，但 VoiceStudio 之外的一个环境变量当前正在设置此值——在移除该变量之前，将继续使用该值。",
-    "hf_token_not_checked": "未测试"
+    "hf_token_not_checked": "未测试",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "about": {
     "app": "应用",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "未測試",
     "hf_source_app_label": "VoiceStudio（已加密，建議）",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "環境變數"
+    "hf_source_env_label": "環境變數",
+    "theme_auto": "System Auto",
+    "theme_light": "Light"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -354,8 +354,8 @@
     "hf_source_app_label": "VoiceStudio（已加密，建議）",
     "hf_source_cli_label": "HuggingFace CLI",
     "hf_source_env_label": "環境變數",
-    "theme_auto": "System Auto",
-    "theme_light": "Light"
+    "theme_auto": "系統自動",
+    "theme_light": "淺色"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -563,18 +563,78 @@
   --select-caret: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%226%22%3E%3Cpath%20d%3D%22M1%201l4%204%204-4%22%20fill%3D%22none%22%20stroke%3D%22%23a6adc8%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
 }
 
+/* ── Light (Solarized Light) ───────────────────────────────────────── */
+[data-theme="light"] {
+  --color-fg:            #073642;
+  --color-fg-muted:      #586e75;
+  --color-fg-subtle:     #657b83;
+  --color-fg-inverse:    #fdf6e3;
+
+  --color-bg:            #fdf6e3;
+  --color-bg-elev-1:     rgba(238, 232, 213, 0.85);
+  --color-bg-elev-2:     rgba(238, 232, 213, 0.40);
+  --color-bg-elev-3:     rgba(238, 232, 213, 0.25);
+
+  --color-border:        rgba(7, 54, 66, 0.12);
+  --color-border-strong: rgba(7, 54, 66, 0.20);
+  --color-border-warm:   rgba(181, 137, 0, 0.15);
+
+  --color-brand:         #1d6b9f;
+  --color-brand-hover:   #144b70;
+  --color-brand-glow:    rgba(29, 107, 159, 0.25);
+
+  --color-accent:        #8c6b00;
+  --color-success:       #667500;
+  --color-warn:          #9c3a11;
+  --color-danger:        #a82624;
+  --color-info:          #515594;
+
+  --chrome-bg:           #eee8d5;
+  --chrome-fg:           #073642;
+  --chrome-fg-muted:     #586e75;
+  --chrome-fg-dim:       #657b83;
+  --chrome-border:       #d5ccb7;
+
+  color-scheme: light;
+  --select-caret: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%226%22%3E%3Cpath%20d%3D%22M1%201l4%204%204-4%22%20fill%3D%22none%22%20stroke%3D%22%23586e75%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
+}
+
 /* ── System-preference sync ────────────────────────────────────────── */
-/* When theme is "auto", the light theme activates on light-mode OS.
-   Currently we don't ship a light theme; this is scaffolding for
-   community contributions. */
+/* When theme is "auto", the light theme activates on light-mode OS. */
 @media (prefers-color-scheme: light) {
   [data-theme="auto"] {
-    /* Future light theme tokens go here. NOTE: no light theme ships yet, so
-       "auto" still renders the dark default tokens even on a light-mode OS —
-       which is why `color-scheme` is intentionally left at the :root `dark`
-       here (a `light` value would make native form chrome mismatch the still
-       -dark surface). When a real light theme lands, set `color-scheme: light`
-       and its own --select-caret in this block. */
+    --color-fg:            #073642;
+    --color-fg-muted:      #586e75;
+    --color-fg-subtle:     #657b83;
+    --color-fg-inverse:    #fdf6e3;
+
+    --color-bg:            #fdf6e3;
+    --color-bg-elev-1:     rgba(238, 232, 213, 0.85);
+    --color-bg-elev-2:     rgba(238, 232, 213, 0.40);
+    --color-bg-elev-3:     rgba(238, 232, 213, 0.25);
+
+    --color-border:        rgba(7, 54, 66, 0.12);
+    --color-border-strong: rgba(7, 54, 66, 0.20);
+    --color-border-warm:   rgba(181, 137, 0, 0.15);
+
+    --color-brand:         #1d6b9f;
+    --color-brand-hover:   #144b70;
+    --color-brand-glow:    rgba(29, 107, 159, 0.25);
+
+    --color-accent:        #8c6b00;
+    --color-success:       #667500;
+    --color-warn:          #9c3a11;
+    --color-danger:        #a82624;
+    --color-info:          #515594;
+
+    --chrome-bg:           #eee8d5;
+    --chrome-fg:           #073642;
+    --chrome-fg-muted:     #586e75;
+    --chrome-fg-dim:       #657b83;
+    --chrome-border:       #d5ccb7;
+
+    color-scheme: light;
+    --select-caret: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2210%22%20height%3D%226%22%3E%3Cpath%20d%3D%22M1%201l4%204%204-4%22%20fill%3D%22none%22%20stroke%3D%22%23586e75%22%20stroke-width%3D%221.5%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -567,7 +567,7 @@
 [data-theme="light"] {
   --color-fg:            #073642;
   --color-fg-muted:      #586e75;
-  --color-fg-subtle:     #657b83;
+  --color-fg-subtle:     #4a5a60;
   --color-fg-inverse:    #fdf6e3;
 
   --color-bg:            #fdf6e3;
@@ -592,7 +592,7 @@
   --chrome-bg:           #eee8d5;
   --chrome-fg:           #073642;
   --chrome-fg-muted:     #586e75;
-  --chrome-fg-dim:       #657b83;
+  --chrome-fg-dim:       #4a5a60;
   --chrome-border:       #d5ccb7;
 
   color-scheme: light;
@@ -605,7 +605,7 @@
   [data-theme="auto"] {
     --color-fg:            #073642;
     --color-fg-muted:      #586e75;
-    --color-fg-subtle:     #657b83;
+    --color-fg-subtle:     #4a5a60;
     --color-fg-inverse:    #fdf6e3;
 
     --color-bg:            #fdf6e3;
@@ -630,7 +630,7 @@
     --chrome-bg:           #eee8d5;
     --chrome-fg:           #073642;
     --chrome-fg-muted:     #586e75;
-    --chrome-fg-dim:       #657b83;
+    --chrome-fg-dim:       #4a5a60;
     --chrome-border:       #d5ccb7;
 
     color-scheme: light;
@@ -7289,6 +7289,20 @@ button.dub-stepper__action:focus-visible {
   white-space: nowrap;
   pointer-events: none;
   max-width: 240px;
+}
+
+/* Override header gradient for light modes */
+[data-theme="light"] .header-area h1 {
+  background: linear-gradient(135deg, var(--chrome-fg) 0%, var(--chrome-fg-muted) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+@media (prefers-color-scheme: light) {
+  [data-theme="auto"] .header-area h1 {
+    background: linear-gradient(135deg, var(--chrome-fg) 0%, var(--chrome-fg-muted) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
 }
 
 /* ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Resolves #1973. Addresses eye strain halation by adding a WCAG AA compliant light theme and exposing the Auto preference.

## Summary

This PR addresses an accessibility issue (split from #1946) where users with astigmatism experienced eye strain and halation due to the app being strictly dark-mode. It introduces a mathematically WCAG AA compliant "Solarized Light" theme and wires the OS-level `prefers-color-scheme` media query so the "System Auto" preference functions correctly.

## Changes

- Added a `[data-theme="light"]` block to `frontend/src/index.css` using a custom, WCAG AA compliant Solarized Light palette.
- Populated the existing `@media (prefers-color-scheme: light)` scaffolding in `index.css` with the light tokens, `color-scheme: light;`, and a dark-grey `--select-caret` so `auto` resolves correctly on a light-mode OS.
- Added `auto` and `light` to the `THEMES` array in `frontend/src/components/settings/AppearancePanel.jsx`, strictly utilizing the existing mechanism as an additive change rather than a refactor.

## Type

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- Ran `bun run dev` and verified the new "Light" and "System Auto" dots appear in the Appearance settings.
- Verified that selecting "Light" successfully applies the Solarized Light tokens.
- Cleared local browser storage, selected "System Auto", and verified that toggling the Windows OS theme between Light and Dark mode instantly switches the app's tokens via the CSS media query.
- Used browser DevTools to verify that the foreground text and background token hex codes pass the WCAG AA 4.5:1 contrast ratio requirement.

## Checklist

- [x] I've tested this locally
- [ ] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [ ] Version files are in sync (if version bump): `pyproject.toml`, `package.json`, `tauri.conf.json`, `Cargo.toml`
- [x] If this PR changes runtime behavior, the regression fixture at `tests/fixtures/omnivoice_data/` still loads green on the `smoke-matrix` CI job (macOS + Windows + Linux)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a WCAG AA light theme and makes `auto` follow the OS light-mode preference. Adds localized, accessible `light` and `auto` options with theme-selection tests. Review the duplicated light tokens to prevent drift between explicit `light` and OS-synchronized `auto` modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->