### PR TITLE
feat(a11y): add an in-app Reduce motion switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- A Reduce motion switch in Settings, for calm without changing your whole system (#1857)
 - Generating from a one-character input now says the input was too short, instead of quoting a convolution error (#1826)
 - First run asks about text size before the install, not after it (#1849)
 - Cloning without a reference clip now says so, instead of naming library parameters you cannot set (#1879)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -188,6 +188,7 @@ function App() {
 
   const locale = useAppStore((s) => s.locale);
   const font = useAppStore((s) => s.font);
+  const reduceMotion = useAppStore((s) => s.reduceMotion);
 
   // Hydrate the theme, locale & font so persisted preferences take effect after
   // zustand persist rehydrates (async from localStorage) and when the user
@@ -198,6 +199,14 @@ function App() {
     } else {
       document.documentElement.removeAttribute('data-theme');
     }
+    // Same reason as the theme above: a persisted preference has to be
+    // re-applied after zustand rehydrates, or the toggle reads as on while
+    // the app animates (#1857).
+    if (reduceMotion) {
+      document.documentElement.setAttribute('data-motion', 'reduce');
+    } else {
+      document.documentElement.removeAttribute('data-motion');
+    }
     if (locale) {
       i18n.changeLanguage(locale);
     }
@@ -206,7 +215,7 @@ function App() {
     const fontStack = FONT_STACKS[font];
     if (fontStack) document.documentElement.style.setProperty('--font-sans', fontStack);
     else document.documentElement.style.removeProperty('--font-sans');
-  }, [locale, theme, font]);
+  }, [locale, theme, font, reduceMotion]);
   const mode = useAppStore((s) => s.mode);
   const setMode = useAppStore((s) => s.setMode);
   // "Define voice" method inside the Voice (studio) workspace — replaces the

--- a/frontend/src/components/settings/AppearancePanel.jsx
+++ b/frontend/src/components/settings/AppearancePanel.jsx
@@ -94,6 +94,8 @@ export default function AppearancePanel() {
   const setTheme = useAppStore((s) => s.setTheme);
   const font = useAppStore((s) => s.font);
   const setFont = useAppStore((s) => s.setFont);
+  const reduceMotion = useAppStore((s) => s.reduceMotion);
+  const setReduceMotion = useAppStore((s) => s.setReduceMotion);
   const autoPlayPreview = useAppStore((s) => s.autoPlayPreview);
   const setAutoPlayPreview = useAppStore((s) => s.setAutoPlayPreview);
   const showHeaderLiveStats = useAppStore((s) => s.showHeaderLiveStats);
@@ -277,6 +279,21 @@ export default function AppearancePanel() {
             aria-label={t('settings.header_live_stats', {
               defaultValue: 'Show live system metrics in header',
             })}
+          />
+        }
+      />
+
+      <SettingRow
+        title={t('settings.reduce_motion', { defaultValue: 'Reduce motion' })}
+        subtitle={t('settings.reduce_motion_desc', {
+          defaultValue:
+            'Stops background animation and transitions. Your system setting is honoured on its own; this adds to it.',
+        })}
+        control={
+          <SettingsToggle
+            checked={reduceMotion}
+            onChange={setReduceMotion}
+            aria-label={t('settings.reduce_motion', { defaultValue: 'Reduce motion' })}
           />
         }
       />

--- a/frontend/src/i18n/locales/ar.json
+++ b/frontend/src/i18n/locales/ar.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "لم يتم اختباره",
     "hf_source_app_label": "VoiceStudio (مشفّر، موصى به)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "متغير البيئة"
+    "hf_source_env_label": "متغير البيئة",
+    "reduce_motion": "تقليل الحركة",
+    "reduce_motion_desc": "يوقف الرسوم المتحركة في الخلفية والانتقالات. إعداد النظام يظل ساريًا بذاته؛ وهذا يضاف إليه."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Nicht getestet",
     "hf_source_app_label": "VoiceStudio (verschlüsselt, empfohlen)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Umgebungsvariable"
+    "hf_source_env_label": "Umgebungsvariable",
+    "reduce_motion": "Bewegung reduzieren",
+    "reduce_motion_desc": "Stoppt Hintergrundanimationen und Übergänge. Die Systemeinstellung gilt weiterhin für sich; dies kommt hinzu."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -956,7 +956,9 @@
     "generate_timeout_shadowed_badge": "Overridden externally",
     "generate_timeout_shadowed_note": "An environment variable outside VoiceStudio (shell, .env file, or container) is currently setting this — your saved value here is ignored until that variable is removed.",
     "generate_timeout_shadowed_toast": "Saved, but an environment variable outside VoiceStudio is currently setting this — it will keep being used until that variable is removed.",
-    "hf_token_not_checked": "Not tested"
+    "hf_token_not_checked": "Not tested",
+    "reduce_motion": "Reduce motion",
+    "reduce_motion_desc": "Stops background animation and transitions. Your system setting is honoured on its own; this adds to it."
   },
   "about": {
     "app": "App",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Sin probar",
     "hf_source_app_label": "VoiceStudio (cifrado, recomendado)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variable de entorno"
+    "hf_source_env_label": "Variable de entorno",
+    "reduce_motion": "Reducir movimiento",
+    "reduce_motion_desc": "Detiene las animaciones de fondo y las transiciones. Tu ajuste del sistema se respeta por sí solo; esto se suma."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Non testé",
     "hf_source_app_label": "VoiceStudio (chiffré, recommandé)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variable d’environnement"
+    "hf_source_env_label": "Variable d’environnement",
+    "reduce_motion": "Réduire les animations",
+    "reduce_motion_desc": "Arrête les animations d’arrière-plan et les transitions. Le réglage système reste actif de son côté ; ceci s’y ajoute."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "परीक्षण नहीं हुआ",
     "hf_source_app_label": "VoiceStudio (एन्क्रिप्ट किया गया, अनुशंसित)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "परिवेश चर"
+    "hf_source_env_label": "परिवेश चर",
+    "reduce_motion": "गति कम करें",
+    "reduce_motion_desc": "पृष्ठभूमि एनिमेशन और ट्रांज़िशन रोकता है। आपकी सिस्टम सेटिंग स्वयं लागू रहती है; यह उसमें जुड़ता है।"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/id.json
+++ b/frontend/src/i18n/locales/id.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Belum diuji",
     "hf_source_app_label": "VoiceStudio (terenkripsi, disarankan)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variabel lingkungan"
+    "hf_source_env_label": "Variabel lingkungan",
+    "reduce_motion": "Kurangi gerakan",
+    "reduce_motion_desc": "Menghentikan animasi latar dan transisi. Pengaturan sistem Anda tetap berlaku sendiri; ini menambahnya."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Non testato",
     "hf_source_app_label": "VoiceStudio (crittografato, consigliato)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variabile d’ambiente"
+    "hf_source_env_label": "Variabile d’ambiente",
+    "reduce_motion": "Riduci le animazioni",
+    "reduce_motion_desc": "Ferma le animazioni di sfondo e le transizioni. L’impostazione di sistema resta valida da sola; questa si aggiunge."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "未テスト",
     "hf_source_app_label": "VoiceStudio（暗号化済み、推奨）",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "環境変数"
+    "hf_source_env_label": "環境変数",
+    "reduce_motion": "視差効果を減らす",
+    "reduce_motion_desc": "背景アニメーションとトランジションを停止します。システム設定は単独で有効なままで、これはそれに加わります。"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -575,7 +575,9 @@
     "generate_timeout_shadowed_badge": "외부에서 재정의됨",
     "generate_timeout_shadowed_note": "VoiceStudio 외부의 환경 변수(셸, .env 파일 또는 컨테이너)가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 여기에 저장한 값은 무시됩니다.",
     "generate_timeout_shadowed_toast": "저장되었지만, VoiceStudio 외부의 환경 변수가 현재 이 값을 설정하고 있습니다 — 해당 변수가 제거될 때까지 계속 사용됩니다.",
-    "hf_token_not_checked": "테스트 안 함"
+    "hf_token_not_checked": "테스트 안 함",
+    "reduce_motion": "모션 줄이기",
+    "reduce_motion_desc": "배경 애니메이션과 전환을 중지합니다. 시스템 설정은 그대로 적용되며, 이 옵션은 거기에 더해집니다."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/nl.json
+++ b/frontend/src/i18n/locales/nl.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Niet getest",
     "hf_source_app_label": "VoiceStudio (versleuteld, aanbevolen)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Omgevingsvariabele"
+    "hf_source_env_label": "Omgevingsvariabele",
+    "reduce_motion": "Beweging verminderen",
+    "reduce_motion_desc": "Stopt achtergrondanimaties en overgangen. Je systeeminstelling blijft op zichzelf gelden; dit komt daarbij."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Nie przetestowano",
     "hf_source_app_label": "VoiceStudio (zaszyfrowane, zalecane)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Zmienna środowiskowa"
+    "hf_source_env_label": "Zmienna środowiskowa",
+    "reduce_motion": "Ogranicz ruch",
+    "reduce_motion_desc": "Zatrzymuje animacje tła i przejścia. Ustawienie systemowe działa samo z siebie; to je uzupełnia."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Não testado",
     "hf_source_app_label": "VoiceStudio (criptografado, recomendado)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Variável de ambiente"
+    "hf_source_env_label": "Variável de ambiente",
+    "reduce_motion": "Reduzir movimento",
+    "reduce_motion_desc": "Para as animações de fundo e as transições. A definição do sistema continua a ser respeitada; esta acrescenta-se."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Не проверен",
     "hf_source_app_label": "VoiceStudio (зашифровано, рекомендуется)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Переменная окружения"
+    "hf_source_env_label": "Переменная окружения",
+    "reduce_motion": "Уменьшить движение",
+    "reduce_motion_desc": "Останавливает фоновые анимации и переходы. Системная настройка действует сама по себе; эта добавляется к ней."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Inte testad",
     "hf_source_app_label": "VoiceStudio (krypterad, rekommenderas)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Miljövariabel"
+    "hf_source_env_label": "Miljövariabel",
+    "reduce_motion": "Minska rörelse",
+    "reduce_motion_desc": "Stoppar bakgrundsanimationer och övergångar. Systeminställningen gäller ändå; det här läggs till."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/th.json
+++ b/frontend/src/i18n/locales/th.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "ยังไม่ได้ทดสอบ",
     "hf_source_app_label": "VoiceStudio (เข้ารหัส แนะนำ)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "ตัวแปรสภาพแวดล้อม"
+    "hf_source_env_label": "ตัวแปรสภาพแวดล้อม",
+    "reduce_motion": "ลดการเคลื่อนไหว",
+    "reduce_motion_desc": "หยุดแอนิเมชันพื้นหลังและทรานซิชัน การตั้งค่าระบบยังมีผลด้วยตัวเอง ส่วนนี้เพิ่มเข้าไป"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/tr.json
+++ b/frontend/src/i18n/locales/tr.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Test edilmedi",
     "hf_source_app_label": "VoiceStudio (şifrelenmiş, önerilen)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Ortam değişkeni"
+    "hf_source_env_label": "Ortam değişkeni",
+    "reduce_motion": "Hareketi azalt",
+    "reduce_motion_desc": "Arka plan animasyonlarını ve geçişleri durdurur. Sistem ayarınız kendi başına geçerlidir; bu ona eklenir."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/uk.json
+++ b/frontend/src/i18n/locales/uk.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Не перевірено",
     "hf_source_app_label": "VoiceStudio (зашифровано, рекомендовано)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Змінна середовища"
+    "hf_source_env_label": "Змінна середовища",
+    "reduce_motion": "Зменшити рух",
+    "reduce_motion_desc": "Зупиняє фонові анімації та переходи. Системне налаштування діє саме по собі; це доповнює його."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "Chưa kiểm tra",
     "hf_source_app_label": "VoiceStudio (được mã hóa, khuyên dùng)",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "Biến môi trường"
+    "hf_source_env_label": "Biến môi trường",
+    "reduce_motion": "Giảm chuyển động",
+    "reduce_motion_desc": "Dừng hoạt ảnh nền và hiệu ứng chuyển tiếp. Cài đặt hệ thống vẫn có hiệu lực riêng; mục này bổ sung thêm."
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -840,7 +840,9 @@
     "generate_timeout_shadowed_badge": "已被外部覆盖",
     "generate_timeout_shadowed_note": "VoiceStudio 之外的一个环境变量（终端、.env 文件或容器）当前正在设置此值——在移除该变量之前，此处保存的值会被忽略。",
     "generate_timeout_shadowed_toast": "已保存，但 VoiceStudio 之外的一个环境变量当前正在设置此值——在移除该变量之前，将继续使用该值。",
-    "hf_token_not_checked": "未测试"
+    "hf_token_not_checked": "未测试",
+    "reduce_motion": "减少动效",
+    "reduce_motion_desc": "停止背景动画和过渡效果。系统设置本身仍然生效，此项在其基础上叠加。"
   },
   "about": {
     "app": "应用",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -353,7 +353,9 @@
     "hf_token_not_checked": "未測試",
     "hf_source_app_label": "VoiceStudio（已加密，建議）",
     "hf_source_cli_label": "HuggingFace CLI",
-    "hf_source_env_label": "環境變數"
+    "hf_source_env_label": "環境變數",
+    "reduce_motion": "減少動態效果",
+    "reduce_motion_desc": "停止背景動畫與轉場效果。系統設定本身仍然生效，此項在其基礎上疊加。"
   },
   "bootstrap": {
     "title": "VoiceStudio",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7630,3 +7630,27 @@ button.dub-stepper__action:focus-visible {
   overflow-wrap: anywhere;
   color: white;
 }
+
+/* ── In-app reduced motion (#1857) ─────────────────────────────────────
+   Settings → Appearance → Reduce motion sets `data-motion="reduce"` on the
+   root. This is the same blanket rule the `prefers-reduced-motion` blocks
+   above apply piecemeal, expressed once: it cannot miss an animation the way
+   a per-component list can, and the header status dot is exactly what that
+   list missed.
+
+   Deliberately NOT merged into the media query. The OS preference must keep
+   working on its own, so a user whose system asks for reduced motion still
+   gets it with this toggle off. The two are additive; either one is enough.
+
+   0.01ms rather than 0: a zero duration skips the `animationend` /
+   `transitionend` events some components wait on, which strands them. A
+   duration this short is imperceptible but still fires. */
+[data-motion='reduce'],
+[data-motion='reduce'] *,
+[data-motion='reduce'] *::before,
+[data-motion='reduce'] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -269,6 +269,20 @@ export interface PrefsSlice {
   langPromptSeen: boolean;
   setLangPromptSeen: (seen: boolean) => void;
 
+  /**
+   * Force reduced motion regardless of the OS setting.
+   *
+   * The CSS already honours `prefers-reduced-motion` in a dozen places, but
+   * that is the OS switch and nothing else. Someone who wants a calm app
+   * without turning motion off system-wide had no way to ask for it, and
+   * someone whose OS setting is not respected by their environment had no
+   * recourse at all (#1857). This is additive: the media query still applies
+   * on its own, so turning this off never re-enables motion for a user whose
+   * OS asked for less.
+   */
+  reduceMotion: boolean;
+  setReduceMotion: (on: boolean) => void;
+
   theme: ThemeId;
   setTheme: (id: ThemeId) => void;
 
@@ -418,6 +432,16 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
   localeChosen: false,
   langPromptSeen: false,
   setLangPromptSeen: (seen) => set({ langPromptSeen: seen }),
+
+  reduceMotion: false,
+  setReduceMotion: (on) => {
+    set({ reduceMotion: on });
+    if (on) {
+      document.documentElement.setAttribute('data-motion', 'reduce');
+    } else {
+      document.documentElement.removeAttribute('data-motion');
+    }
+  },
 
   theme: 'gruvbox',
   setTheme: (id) => {

--- a/frontend/src/test/reduceMotionToggle.test.jsx
+++ b/frontend/src/test/reduceMotionToggle.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * #1857 Part A — an in-app motion control.
+ *
+ * The CSS honours `prefers-reduced-motion` in about a dozen separate blocks,
+ * but that is the OS switch and nothing else. Someone who wants a calm app
+ * without turning motion off system-wide had no way to ask, and someone whose
+ * OS setting is not respected by their environment had no recourse at all.
+ *
+ * Two properties matter and both are pinned here: the toggle drives a single
+ * root attribute (so it cannot miss an animation the way a per-component list
+ * can — the header status dot is exactly what that list missed, Part B), and
+ * it is ADDITIVE, so turning it off never disables the OS media query.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { useAppStore } from '../store';
+
+const css = readFileSync(resolve(process.cwd(), 'src/index.css'), 'utf8');
+
+describe('reduce-motion toggle', () => {
+  beforeEach(() => {
+    useAppStore.getState().setReduceMotion(false);
+  });
+
+  it('sets and clears a single root attribute', () => {
+    useAppStore.getState().setReduceMotion(true);
+    expect(document.documentElement.getAttribute('data-motion')).toBe('reduce');
+    expect(useAppStore.getState().reduceMotion).toBe(true);
+
+    useAppStore.getState().setReduceMotion(false);
+    expect(document.documentElement.getAttribute('data-motion')).toBeNull();
+    expect(useAppStore.getState().reduceMotion).toBe(false);
+  });
+
+  it('is off by default', () => {
+    expect(useAppStore.getState().reduceMotion).toBe(false);
+  });
+
+  it('has a blanket rule that covers descendants and pseudo-elements', () => {
+    // A per-component list is what let the header dot keep pulsing. One rule
+    // over the whole tree cannot have that gap.
+    expect(css).toMatch(/\[data-motion='reduce'\] \*,/);
+    expect(css).toMatch(/\[data-motion='reduce'\] \*::before,/);
+    expect(css).toMatch(/\[data-motion='reduce'\] \*::after/);
+  });
+
+  it('does not fold the OS media query into the toggle', () => {
+    // The two must stay independent: the media query has to keep working for
+    // a user who never opens Settings.
+    const block = css.slice(css.indexOf("[data-motion='reduce'],"));
+    expect(block).not.toContain('prefers-reduced-motion');
+    expect(css).toContain('prefers-reduced-motion');
+  });
+
+  it('uses a near-zero duration rather than none, so end events still fire', () => {
+    // A zero duration skips animationend/transitionend, stranding anything
+    // that waits on them.
+    const block = css.slice(css.indexOf("[data-motion='reduce'],"));
+    expect(block).toContain('animation-duration: 0.01ms !important');
+    expect(block).not.toMatch(/animation:\s*none/);
+  });
+});


### PR DESCRIPTION
Closes #1857.

The CSS honours `prefers-reduced-motion` in about a dozen separate blocks — but that is the OS switch and nothing else. Someone who wants a calm app without turning motion off system-wide had no way to ask, and someone whose OS setting is not respected by their environment had no recourse at all.

## The change

**Settings → Appearance → Reduce motion** sets `data-motion="reduce"` on the root, and **one blanket rule** covers the whole tree including pseudo-elements.

That shape is deliberate. A per-component list is exactly what let the header status dot keep pulsing under Reduce Motion — Part B of this same issue, already fixed on `main` separately. One rule over the tree cannot have that gap.

**Additive by design.** The media query is untouched and keeps working on its own, so turning this off never re-enables motion for someone whose system asked for less. A test pins that the two stay independent, since folding them together is the obvious-looking simplification that would break the OS path.

**Durations go to `0.01ms`, not `none`.** A zero duration skips `animationend` / `transitionend`, stranding anything that waits on them. Imperceptible, still fires. Also pinned.

## Scope note

This covers Part A only. Part B was already fixed on `main` with its own test and a visual spec — I verified that before starting rather than assuming the issue was wholly open.

## Verification

5 new cases; full frontend suite 2841 passed; locale parity and hardcoded-CJK guards pass at 529 with the two new strings translated across all 21 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a Settings → Appearance → Reduce motion switch that applies an app-wide `data-motion="reduce"` rule while preserving additive OS-level motion preferences. This gives users per-app motion control without changing system settings, with localized strings for all 21 locales. Review the `0.01ms` animation and transition rule for lifecycle-event compatibility and unintended UI effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->