### PR TITLE
docs: refresh STRUCTURE.md to match the current tree

### DIFF
--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -151,12 +151,13 @@ VoiceStudio/
 
 ## Where tests live
 
-Three homes, each with its own runner and its own CI job. The split is deliberate, not drift:
+Three homes, each with its own runner. CI runs all three inside the single `test` job in
+`ci.yml`, as separate steps. The split is deliberate, not drift:
 
 | Home | Runner | Why it's separate |
 |---|---|---|
 | `tests/` | `pytest tests/` — the `testpaths` default | The main suite. Its `conftest.py` points `OMNIVOICE_DATA_DIR` at a throwaway dir so a run can never touch the developer's real app state (#878). |
-| `backend/tests/` | `pytest backend/tests/` — its own CI job | Runs as an isolated session against `backend/`'s bare imports. Its `conftest.py` sets the same hermetic data dir; **never** reintroduce module-level `sys.modules` stubs there — they leak process-wide at collection time and poison mixed runs. |
+| `backend/tests/` | `pytest backend/tests/` — its own pytest session (the `Run pytest (backend/tests, isolated)` step) | Runs as an isolated session against `backend/`'s bare imports. Its `conftest.py` sets the same hermetic data dir; **never** reintroduce module-level `sys.modules` stubs there — they leak process-wide at collection time and poison mixed runs. |
 | `frontend/src/**/*.test.{js,jsx,ts,tsx}` | `bun run test` (vitest, jsdom) | Co-located with the component under test. `frontend/e2e*/` hold the Playwright suites; `tests/frontend/` is the older `node:test` set. |
 
 ## What lives where
@@ -235,6 +236,6 @@ Migrate when adding the second `apps/*` or the second `packages/*`. Not before.
 ## Conventions
 
 - **Filenames:** snake_case for Python, kebab-case or PascalCase for JS/TS components, lowercase for Markdown.
-- **Tests mirror source paths** where a mirror exists: `backend/services/dub_pipeline.py` → `tests/backend/services/test_dub_pipeline*.py` (`tests/backend/` mirrors `api/ core/ engines/ services/`). Cross-cutting suites stay flat as `tests/test_*.py`. A React component's test sits next to the component.
+- **Tests mirror source paths** where a mirror exists: `tests/backend/` mirrors `api/ core/ engines/ services/`, so `backend/services/ffmpeg_utils.py` → `tests/backend/services/test_ffmpeg_utils.py`. Everything else stays flat — `tests/backend/test_*.py` for backend-wide cases, `tests/test_*.py` for cross-cutting ones. A React component's test sits next to the component.
 - **One-off scripts** go into `scripts/` with a descriptive name, not `test_*.py` at the root.
 - **New top-level directories** require a PR that updates *this file*.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -7,39 +7,71 @@ Every folder has a single job. Every file at the root earns its place.
 ```
 VoiceStudio/
 │
-├── README.md                    ⟵ user-facing overview
-├── CHANGELOG.md                 ⟵ release history
-├── LICENSE
+├── README.md / README_CN.md     ⟵ user-facing overview (EN / 中文)
+├── CHANGELOG.md                 ⟵ release history; release.yml extracts the tag's section verbatim
+├── CLAUDE.md / AGENTS.md        ⟵ the working contract for AI agents — keep the two in sync
+├── LICENSE, LICENSE-NOTICE.md, SPONSORS.md
 │
-├── pyproject.toml               ⟵ Python project manifest
+├── pyproject.toml               ⟵ Python project manifest (+ pytest / lint config)
 ├── uv.lock                      ⟵ Python lockfile
 ├── package.json                 ⟵ monorepo manifest (Bun workspaces + Turborepo)
-├── bun.lock                     ⟵ JS lockfile
+├── bun.lock                     ⟵ JS lockfile — repo-root, covers frontend/ too
 ├── turbo.json                   ⟵ turborepo pipeline
 │
+├── .coderabbit.yaml             ⟵ CodeRabbit PR review config (fed CLAUDE.md)
+├── greptile.json                ⟵ Greptile PR review config (fed CLAUDE.md)
+├── skills-lock.json             ⟵ pins the sources + hashes of .agents/skills/
+├── .gitleaks.toml               ⟵ secret-scan config
+├── .gitmodules                  ⟵ omnivoice-gallery submodule
+├── .python-version
 ├── .dockerignore                ⟵ Docker build context filter
 ├── backend.spec                 ⟵ pyinstaller spec (stays at root by pyinstaller convention)
 ├── alembic.ini                  ⟵ DB migration config (stays at root by alembic convention)
 │
-├── .env                         ⟵ user config; gitignored, .env.example is the template
-├── .gitignore
+├── .gitignore                   ⟵ a repo-local .env stays ignored, but user config is NOT
+│                                   kept here: the durable env file is ~/.config/omnivoice/env
+│                                   (backend/core/user_env.py), written by the Settings panel
 │
 ├── backend/                     ⟵ FastAPI server
-│   ├── main.py
-│   ├── api/routers/             HTTP endpoints (thin)
-│   ├── core/                    config, db, task queue, metrics
-│   ├── services/                business logic
-│   └── schemas/                 pydantic request/response shapes
+│   ├── main.py                  the one entry point; its boot order is load-bearing —
+│   │                            read the comments before reordering anything
+│   ├── api/routers/             39 routers, auto-included; thin HTTP/WS surface
+│   │   └── setup/               first-run wizard, model download
+│   ├── core/                    config, db, job queue, event bus, auth/CSRF, path security,
+│   │                            opt-in analytics, version, diagnostics
+│   ├── services/                79 modules of business logic — TTS, dubbing pipeline,
+│   │                            audio DSP, GPU gateway, engine routing, model lifecycle
+│   ├── engines/                 per-engine adapters: indextts, supertonic3, confucius4,
+│   │                            dots_tts, moss_tts_v15, pockettts, audiocpp,
+│   │                            omnivoice_gguf, omnivoice_subprocess, _asr_sidecar, _echo
+│   ├── worker/                  remote / distributed workers — scheduler, pool, routing,
+│   │                            breaker, capacity, plus protocol/ and inbound/
+│   ├── mcp_shim/                MCP server entry point (docs/mcp.md)
+│   ├── speech_client/           speech sidecar client entry point
+│   ├── schemas/                 pydantic request/response shapes
+│   ├── migrations/versions/     alembic revisions — every schema change goes through here
+│   ├── plugins/                 plugin drop-in point (see services/plugin_sdk.py)
+│   ├── hooks/                   pyinstaller runtime hooks
+│   ├── config/models.yaml       model catalogue
+│   └── tests/                   the isolated pytest session — see "Where tests live"
 │
 ├── frontend/                    ⟵ React 19 + Vite + Tauri desktop
+│   ├── package.json             THE app version — every other version file mirrors it
 │   ├── src/
 │   │   ├── pages/               one file per top-level view
-│   │   ├── components/          reusable UI
-│   │   ├── api/                 typed API clients
-│   │   ├── store/               Zustand slices
+│   │   ├── components/          reusable UI (+ audiobook/ clone/ dub/ gallery/ settings/ …)
+│   │   ├── ui/, lib/            shared primitives and helpers
+│   │   ├── api/                 typed API clients, one per router group
+│   │   ├── store/               Zustand slices (+ persisted-state migrations)
 │   │   ├── hooks/               custom React hooks
-│   │   └── utils/
-│   ├── src-tauri/               Rust desktop shell
+│   │   ├── i18n/locales/        the ONLY home for user-facing strings
+│   │   ├── config/, data/, assets/, utils/
+│   │   └── test/                vitest setup + visual-test helpers
+│   ├── e2e/, e2e-perf/, e2e-prod/   Playwright suites: functional, perf, packaged bundle
+│   ├── src-tauri/               Rust desktop shell — backend spawn/bootstrap, updater
+│   │   │                        channel, dictation shortcut, crash/reset/uninstall
+│   │   ├── capabilities/, icons/, wix/, debian/, appimage/   packaging inputs
+│   │   └── tests/
 │   └── public/
 │
 ├── omnivoice/                   ⟵ the underlying TTS model package
@@ -51,46 +83,59 @@ VoiceStudio/
 │   ├── training/
 │   └── utils/
 │
-├── tests/                       ⟵ all tests live here, no exceptions
-│   ├── conftest.py
-│   ├── test_api.py
-│   ├── test_dub_*.py
-│   ├── test_job_queue.py
-│   ├── test_segmentation.py
-│   └── frontend/                Node-based frontend tests
+├── tests/                       ⟵ the main pytest session (testpaths in pyproject.toml)
+│   ├── conftest.py              hermetic OMNIVOICE_DATA_DIR — never touches real app state
+│   ├── backend/, scripts/       mirrors of the source trees they cover
+│   ├── smoke/                   fast end-to-end checks (own CI job, HF_HUB_OFFLINE=1)
+│   ├── evals/                   quality evals (evals.yml)
+│   ├── probe/, fixtures/
+│   └── frontend/                Node-based frontend tests (legacy; vitest is the default)
 │
-├── scripts/                     ⟵ dev / build / release shell + python scripts
-│   ├── install.sh               universal installer (macOS/Linux/WSL)
-│   ├── install.ps1              universal installer (Windows)
-│   ├── run.sh                   universal launcher
+├── scripts/                     ⟵ dev / build / release scripts (shell, python, mjs)
+│   ├── install.sh / install.ps1 universal installers
+│   ├── desktop-*.mjs            dev, prod and fresh desktop launchers
 │   ├── smoke-test.sh            end-to-end validation
-│   └── desktop-prod.sh          production desktop build
-
+│   ├── check-docs-drift.py      the docs-drift.yml checker (docs/features.yaml is canonical)
+│   └── build-omnivoice-tts.sh   builds the bin/ sidecars
+│
+├── bin/                         ⟵ prebuilt omnivoice-tts sidecars, one per platform
+│
+├── .agents/skills/              ⟵ canonical skill copies (vite, fastapi-python), pinned by
+│                                   skills-lock.json — followed by path, never symlinked
+├── skills/                      ⟵ skills this repo publishes (omnivoice, oss-maintainer)
+│
 ├── infra/                       ⟵ edge/deploy workers (not the Docker deploy path)
 │   └── install-redirect/        voicestudio.sh/install — UA-sniffing installer worker
 │
 ├── deploy/                      ⟵ Docker deployment configs
-│   ├── Dockerfile               single-stage CUDA image
-│   └── docker-compose.yml       one-click local deployment
+│   ├── Dockerfile               CUDA by default; CI builds the ROCm variant from the same
+│   │                            file via BASE_IMAGE / GPU_FLAVOR overrides
+│   ├── docker-compose.yml       one-click local deployment
+│   ├── torch-constraints.txt    pinned torch resolution for the image
+│   └── dockerhub-overview.md    synced to the Docker Hub overview page at release
 │
 ├── docs/                        ⟵ developer docs, screenshots, branding
 │   ├── ROADMAP.md               where this project is going
 │   ├── STRUCTURE.md             you are here
-│   ├── mcp.json                 MCP config template
-│   ├── preview.png              README hero image
-│   ├── logo.png, logo.svg       branding assets
-│   ├── screenshot-*.png         feature screenshots
-│   ├── languages.md
-│   ├── training.md
-│   ├── data_preparation.md
-│   ├── evaluation.md
-│   └── voice-design.md
+│   ├── RELEASING.md             the release checklist — every deployment channel
+│   ├── features.yaml            canonical feature inventory (drives docs-drift.yml)
+│   ├── adr/                     architecture decision records
+│   ├── agents/                  agent-facing docs (issue tracker, triage labels, domain)
+│   ├── engines/, dubbing/, install/, setup/, migration/, features/, playbooks/, specs/
+│   ├── media/, screenshot-*.png, preview.png, logo.*
+│   └── languages.md, training.md, data_preparation.md, evaluation.md, voice-design.md
 │
-├── examples/                    ⟵ runnable demos + sample inputs
+├── examples/                    ⟵ runnable demos + sample inputs (agentic/, speech-platform/)
+│
+├── notebooks/                   ⟵ OmniVoice_Studio_Colab.ipynb
+│
+├── omnivoice-gallery/           ⟵ git submodule — the published voice gallery
 │
 ├── omnivoice_data/              ⟵ Docker bind-mount target (gitignored)
 │                                   DB + HF cache live here when running via compose
 │
+├── .github/workflows/           ⟵ ci, docker, release, security, docs-drift, evals,
+│                                   install-smoke, build-omnivoice-tts
 └── .git/
 ```
 
@@ -98,11 +143,21 @@ VoiceStudio/
 
 1. **Nothing at the root is a runtime artifact.** Outputs, temp files, local DBs, crash logs — all go to `~/Library/Application Support/OmniVoice/` (or the OS equivalent), *never* into the repo. The one exception is `omnivoice_data/`, which exists as a bind-mount anchor for Docker.
 
-2. **No ad-hoc scripts at the root.** One-off debug scripts live in `scripts/`. Tests live in `tests/`. Benchmarks live in `scripts/benchmarks/` (when we create them).
+2. **No ad-hoc scripts at the root.** One-off debug scripts live in `scripts/`. Tests live in one of the three homes below, never at the root.
 
 3. **Each subdirectory owns one concern.** If you can't describe what goes in a directory in one sentence, it's wrong.
 
-4. **Every package has a manifest.** `backend/`, `frontend/`, `omnivoice/` each have their own deps declared via `pyproject.toml` / `package.json` — they are independently testable.
+4. **Every package has a manifest.** `backend/`, `frontend/`, `omnivoice/` each have their own deps declared via `pyproject.toml` / `package.json` — they are independently testable. The JS lockfile is the **repo-root** `bun.lock` (Bun workspace), and `deploy/Dockerfile` installs from it with `--frozen-lockfile`.
+
+## Where tests live
+
+Three homes, each with its own runner and its own CI job. The split is deliberate, not drift:
+
+| Home | Runner | Why it's separate |
+|---|---|---|
+| `tests/` | `pytest tests/` — the `testpaths` default | The main suite. Its `conftest.py` points `OMNIVOICE_DATA_DIR` at a throwaway dir so a run can never touch the developer's real app state (#878). |
+| `backend/tests/` | `pytest backend/tests/` — its own CI job | Runs as an isolated session against `backend/`'s bare imports. Its `conftest.py` sets the same hermetic data dir; **never** reintroduce module-level `sys.modules` stubs there — they leak process-wide at collection time and poison mixed runs. |
+| `frontend/src/**/*.test.{js,jsx,ts,tsx}` | `bun run test` (vitest, jsdom) | Co-located with the component under test. `frontend/e2e*/` hold the Playwright suites; `tests/frontend/` is the older `node:test` set. |
 
 ## What lives where
 
@@ -110,10 +165,14 @@ VoiceStudio/
 |---|---|
 | User-facing product code | `backend/`, `frontend/` |
 | The TTS model (independent of the studio) | `omnivoice/` |
+| A new TTS/ASR engine adapter | `backend/engines/<engine>/` |
 | Everything executable but not user-facing | `scripts/` |
-| Tests | `tests/` |
+| Prebuilt platform sidecars | `bin/` |
+| Python tests | `tests/` (or `backend/tests/` when the isolated session is required) |
+| Frontend unit tests | next to the component, as `*.test.jsx` |
 | Developer + user docs (Markdown) | `docs/` |
 | Architecture decision records (ADRs) | `docs/adr/` |
+| Agent-facing docs | `docs/agents/` |
 | Runnable demos and sample data | `examples/` |
 | Runtime data (never committed) | `~/Library/Application Support/OmniVoice/` on Mac |
 
@@ -137,10 +196,10 @@ Removed in the 2026-07-12 cleanup pass (all preserved in git history):
 | Dir | Why it was there | Where it went |
 |---|---|---|
 | `.planning/` (74 files) | GSD-era planning archive: phases, quick plans, issue clusters. The GSD workflow was retired 2026-07-08. | Deleted; the four load-bearing decision docs moved to `docs/adr/`. |
-| `specs/` | spec-kit specs for features 001–007 — all shipped. | Deleted. |
+| `specs/` | spec-kit specs for features 001–007 — all shipped. | Deleted; `docs/specs/` is the current home. |
 | `design/` | ASCII mockups of the pre-React target UX, superseded by the shipped app. | Deleted. |
 | `research/` | Archived legacy Gradio UI + April-2026 competitor notes. | Deleted. |
-| `.agents/` | Rules for a third-party agent tool no longer in use. | Deleted. |
+| `.agents/` | Rules for a third-party agent tool no longer in use. | Deleted — then reintroduced with a different job: `.agents/skills/` now holds the canonical skill copies pinned by `skills-lock.json`. |
 
 ## Scaling path (proposed, not yet executed)
 
@@ -169,12 +228,13 @@ VoiceStudio/
 - `backend.spec` (`['backend/main.py']`, `pathex=['.']`)
 - `frontend/src-tauri/tauri.*.conf.json` sidecar paths
 - every import that reads `from backend.main import …` (tests, scripts)
+- `frontend/package.json` as the version source of truth, and the mirrors that track it
 
 Migrate when adding the second `apps/*` or the second `packages/*`. Not before.
 
 ## Conventions
 
 - **Filenames:** snake_case for Python, kebab-case or PascalCase for JS/TS components, lowercase for Markdown.
-- **Tests mirror source paths.** `backend/services/dub_pipeline.py` → `tests/services/test_dub_pipeline.py`.
+- **Tests mirror source paths** where a mirror exists: `backend/services/dub_pipeline.py` → `tests/backend/services/test_dub_pipeline*.py` (`tests/backend/` mirrors `api/ core/ engines/ services/`). Cross-cutting suites stay flat as `tests/test_*.py`. A React component's test sits next to the component.
 - **One-off scripts** go into `scripts/` with a descriptive name, not `test_*.py` at the root.
 - **New top-level directories** require a PR that updates *this file*.

--- a/scripts/seo-backlink-wave2.sh
+++ b/scripts/seo-backlink-wave2.sh
@@ -274,7 +274,7 @@ submit "Hacker News"                    "https://news.ycombinator.com/submitlink
 echo ""
 echo "${YELLOW}━━━ 12. Extended Wayback Machine Archives ━━━${NC}"
 EXTRA_PAGES=(
-  "https://github.com/debpalash/VoiceStudio/blob/main/STRUCTURE.md"
+  "https://github.com/debpalash/VoiceStudio/blob/main/docs/STRUCTURE.md"
   "https://github.com/debpalash/VoiceStudio/blob/main/LICENSE"
   "https://github.com/debpalash/VoiceStudio/graphs/contributors"
   "https://github.com/debpalash/VoiceStudio/network/dependents"


### PR DESCRIPTION
`docs/STRUCTURE.md` had drifted from the tree it documents. Stale docs are bugs, so this brings it back in line with what's actually on disk today.

### Missing entries added
- `backend/`: `engines/`, `worker/`, `mcp_shim/`, `speech_client/`, `migrations/`, `plugins/`, `hooks/`, `config/`
- `frontend/`: the three Playwright suites (`e2e/`, `e2e-perf/`, `e2e-prod/`), `i18n/locales/`, `ui/`, `lib/`, `test/`, and the `src-tauri/` packaging inputs (`wix/`, `debian/`, `appimage/`, `capabilities/`)
- top level: `bin/`, `skills/`, `.agents/skills/`, `notebooks/`, `omnivoice-gallery/` (submodule), `.github/workflows/`, and the review-bot / lock config files

### Corrections
- **"all tests live here, no exceptions" was wrong.** There are three homes and the split is deliberate, so the claim is replaced by a table that records *why* each exists: `tests/` (the `testpaths` default), `backend/tests/` (its own CI job — and its `conftest.py` documents why module-level `sys.modules` stubs must never come back), and co-located vitest files under `frontend/src/`.
- **`.env.example` does not exist** and the app never reads a repo-local `.env`. The durable user env file is `~/.config/omnivoice/env` (`backend/core/user_env.py`), written by the Settings panel.
- **`.agents/` was listed as deleted**, but it's back with a different job: the canonical skill copies pinned by `skills-lock.json`.
- The test-mirroring convention now points at the mirror that exists (`tests/backend/{api,core,engines,services}/`) instead of a `tests/services/` path that doesn't.
- `deploy/Dockerfile` is described as CUDA-by-default with the ROCm variant built from the same file via `BASE_IMAGE` / `GPU_FLAVOR` overrides.

### Also
Fixes a dead link in `scripts/seo-backlink-wave2.sh` — it archived `blob/main/STRUCTURE.md`, but the file has lived in `docs/` since the cleanup pass.

### Verification
Docs-only; no runtime code touched. `scripts/validate-install-docs.py` passes. `scripts/check-docs-drift.py` diffs `docs/features.yaml` against README / docs / engine registries and does not read `STRUCTURE.md`, and no test or workflow gates this file. Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `docs/STRUCTURE.md` to match the current repository layout and corrected its link in `scripts/seo-backlink-wave2.sh`. The changes clarify repository structure, test locations, environment files, `.agents/`, and Docker GPU image variants. The documentation-only changes pass `scripts/validate-install-docs.py`; review should confirm that the documented paths remain current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->