### PR TITLE
docs(docker): clarify image architecture requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Docs
 
+- Docker quick starts now explain the AMD64-only images and direct Apple Silicon users to the native macOS app (#1921) — thanks @yangfan-yf-yf!
 - audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, explicit GGUF download, voice modes, and the weights' research/non-commercial terms (#1891)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Download a package from the [latest release](https://github.com/debpalash/VoiceS
 | macOS 13.3+ | Apple Silicon DMG | [Install on macOS](docs/install/macos.md) |
 | Windows 10/11 | x64 MSI; choose the current-user build when listed to install without admin access | [Install on Windows](docs/install/windows.md#install-pre-built-msi) |
 | Linux | AppImage, x86_64 with glibc 2.39+ | [Install on Linux](docs/install/linux.md) |
-| Docker | CUDA, ROCm, CPU, and worker-only GPU profiles | [Run with Docker](docs/install/docker.md) |
+| Docker | Linux/AMD64 images; CUDA, ROCm, CPU, and worker-only GPU profiles | [Run with Docker](docs/install/docker.md) |
 
 First launch creates a managed Python environment and downloads the default model. Later launches reuse both.
 
@@ -86,6 +86,11 @@ First launch creates a managed Python environment and downloads the default mode
 > On macOS, first launch needs a one-time right-click, then **Open** approval. Intel Macs cannot run the local Python backend; use a [remote backend](docs/install/macos.md) instead.
 
 ### Quick Docker run
+
+The published images are **`linux/amd64` only**. On Apple Silicon, use the
+[native macOS app](docs/install/macos.md) for GPU acceleration. ARM64 hosts
+should read the [architecture requirements](docs/install/docker.md#architecture)
+before pulling an image.
 
 ```bash
 docker run -d -p 127.0.0.1:3900:3900 -v omnivoice-data:/app/omnivoice_data --name voicestudio palashdeb/omnivoice-studio:stable

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ should read the [architecture requirements](docs/install/docker.md#architecture)
 before pulling an image.
 
 ```bash
-docker run -d -p 127.0.0.1:3900:3900 -v omnivoice-data:/app/omnivoice_data --name voicestudio palashdeb/omnivoice-studio:stable
+docker run -d --platform linux/amd64 -p 127.0.0.1:3900:3900 -v omnivoice-data:/app/omnivoice_data --name voicestudio palashdeb/omnivoice-studio:stable
 ```
 
 ### First voice

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -54,7 +54,7 @@ the entire pipeline runs on CPU, just slower. Pull size: ~5 GB compressed
 ```bash
 export OMNIVOICE_API_KEY="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
 
-docker run -d --name omnivoice \
+docker run -d --name omnivoice --platform linux/amd64 \
   -p 127.0.0.1:3900:3900 \
   -e OMNIVOICE_API_KEY="$OMNIVOICE_API_KEY" \
   -v omnivoice-data:/app/omnivoice_data \

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -14,11 +14,20 @@ cloning, and cinematic video dubbing — fully local, with no cloud API keys or 
 
 ![VoiceStudio — the open-source ElevenLabs alternative](https://raw.githubusercontent.com/debpalash/VoiceStudio/main/.github/assets/social-preview.png)
 
-VoiceStudio runs entirely on your own hardware (CUDA / MPS / ROCm / CPU
+VoiceStudio runs entirely on your own hardware (CUDA / ROCm / CPU
 auto-detect) — nothing is sent to the cloud. This image is the **headless
 web-server build**: a FastAPI backend serving a pre-built React UI over HTTP, so
-you can run it on a homelab box, a GPU server, or anywhere Docker runs and open
+you can run it on an AMD64 homelab box or GPU server and open
 the UI in a browser.
+
+**Architecture:** published images are **`linux/amd64` only**; there is no
+native ARM64 image. On Apple Silicon, use the
+[native macOS app](https://github.com/debpalash/VoiceStudio/blob/main/docs/install/macos.md)
+for Apple GPU acceleration; the Linux container cannot access the Mac's Apple
+GPU through MPS or MLX. Other ARM64 hosts need an AMD64 server or CPU emulation,
+which can be much slower. See the
+[architecture requirements](https://github.com/debpalash/VoiceStudio/blob/main/docs/install/docker.md#architecture)
+before pulling an image.
 
 > The Tauri desktop app's auto-updater and update-channel toggle are
 > **desktop-only** and do not apply to this image — to update, pull a newer tag
@@ -136,7 +145,7 @@ are mirrored on GHCR at
 - **📦 Batch Queue** — drop 50 videos and walk away; per-job progress.
 - **🤖 MCP Server** — drive VoiceStudio from Claude, Cursor, or any MCP client.
 - **🛡️ AI Watermark** — invisible AudioSeal (Meta) marking that survives compression.
-- **⚡ GPU Auto-Detect** — CUDA · MPS · ROCm · CPU, with auto-offload on ≤8 GB cards.
+- **⚡ GPU Auto-Detect** — CUDA · ROCm · CPU, with auto-offload on ≤8 GB cards.
 - **🧩 Extensible** — subclass `TTSBackend` to add any engine in ~50 lines.
 
 Multiple TTS engines ship out of the box (IndexTTS, CosyVoice, Supertonic-3, and

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -60,9 +60,9 @@ master key.
 ## Pull and run (CPU)
 
 ```bash
-docker pull ghcr.io/debpalash/omnivoice-studio:latest
+docker pull --platform linux/amd64 ghcr.io/debpalash/omnivoice-studio:latest
 
-docker run -d --name omnivoice \
+docker run -d --name omnivoice --platform linux/amd64 \
   -p 127.0.0.1:3900:3900 \
   -e OMNIVOICE_API_KEY="$OMNIVOICE_API_KEY" \
   -v omnivoice-data:/app/omnivoice_data \
@@ -267,7 +267,20 @@ DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose \
   -f deploy/docker-compose.yml --profile cpu up -d
 ```
 
-The override applies only to each command. The [architecture limitations](#architecture)
+In Bash, the override applies only to each command.
+
+For PowerShell, open a separate session in the repository root and set the
+administrator key and platform before running the same CPU profile:
+
+```powershell
+$env:OMNIVOICE_API_KEY = python -c "import secrets; print(secrets.token_urlsafe(32))"
+$env:DOCKER_DEFAULT_PLATFORM = 'linux/amd64'
+docker compose -f deploy/docker-compose.yml --profile cpu pull
+docker compose -f deploy/docker-compose.yml --profile cpu up -d
+```
+
+These environment settings apply only to that PowerShell session and its
+child processes; close the session when finished. The [architecture limitations](#architecture)
 still apply; emulation does not enable GPU acceleration.
 
 The `docker-compose.yml` shipped in `deploy/` defaults to `127.0.0.1:3900`

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -256,6 +256,20 @@ docker compose -f deploy/docker-compose.yml --profile gpu up -d
 docker compose -f deploy/docker-compose.yml --profile rocm up -d
 ```
 
+On an ARM64 host with AMD64 emulation available, use these **CPU-only**
+commands instead. Set `DOCKER_DEFAULT_PLATFORM` for both pulling and starting
+the service:
+
+```bash
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose \
+  -f deploy/docker-compose.yml --profile cpu pull
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose \
+  -f deploy/docker-compose.yml --profile cpu up -d
+```
+
+The override applies only to each command. The [architecture limitations](#architecture)
+still apply; emulation does not enable GPU acceleration.
+
 The `docker-compose.yml` shipped in `deploy/` defaults to `127.0.0.1:3900`
 on the host. The backend inside the container binds to `0.0.0.0` so the
 host port mapping can forward — the host-side `127.0.0.1` binding is what

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -7,6 +7,25 @@ it in a normal browser.
 **Official images:** [`ghcr.io/debpalash/omnivoice-studio`](https://github.com/debpalash/VoiceStudio/pkgs/container/omnivoice-studio)
 and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palashdeb/omnivoice-studio) — same images, same tags.
 
+## Architecture
+
+The published images are **`linux/amd64` (x86-64) only**, including `:stable`,
+`:latest`, and the ROCm variants. There is no native `linux/arm64` image.
+On an ARM64 host, pulling without an explicit platform can fail with
+`no matching manifest for linux/arm64/v8 in the manifest list entries`.
+
+- **Apple Silicon (M-series Macs):** use the [native macOS app](macos.md),
+  which supports Apple GPU acceleration. The Linux container cannot access
+  the Mac's Apple GPU through MPS or MLX.
+- **AMD64 emulation on ARM64 (including Apple Silicon):** if your Docker
+  installation supports it, place `--platform linux/amd64` **before the image
+  name** in both `docker pull` and `docker run` from the CPU instructions
+  below. This is an emulated CPU option, not native
+  ARM64 support; inference can be much slower and is not a GPU workaround.
+  Without emulation, use an AMD64 server for this Docker deployment.
+
+## Image tags
+
 > **Image ↔ version mapping**
 >
 > | Tag | What you get |


### PR DESCRIPTION
## Summary

Fixes #1921.

The Docker quick start currently reaches image resolution before ARM64 users learn that the published images are AMD64-only. I added that requirement before the commands and linked Apple Silicon users to the native macOS app.

## Changes

- Keep the README, Docker installation guide, and Docker Hub overview consistent about `linux/amd64` support.
- Include `--platform linux/amd64` directly in the CPU quick-start commands, with the performance limits of emulation and lack of access to the Mac's Apple GPU.
- Add Bash and PowerShell Compose CPU emulation examples with `DOCKER_DEFAULT_PLATFORM=linux/amd64` for both `pull` and `up`.
- Remove MPS from the Docker image's acceleration list and add an Unreleased documentation entry.

## Type

- [x] 📝 Documentation

## Testing

- Queried Docker Hub metadata for `stable`, `latest`, `rocm`, and `stable-rocm`: each currently lists only `linux/amd64`. The `stable` digest matches the one reported in #1921.
- Checked the publishing workflow and the existing macOS installation guidance.
- `python -m pytest --noconftest -o addopts='' -p no:cacheprovider tests/test_changelog_style.py tests/test_docker_admin_auth_docs.py -k 'not server_mode' -q`: 13 passed, 2 deselected. These are static documentation checks; backend fixtures and the two server-mode runtime tests were excluded.
- `git diff --check` passed.
- I did not build or run containers, run the full backend suite, or build the frontend for this documentation-only change. The emulation runtime result remains the reporter's evidence in #1921.

## Checklist

- [x] I've tested this locally (documentation checks listed above)
- [x] I've updated relevant documentation
- [x] No local machine paths, logs, or personal env details in this PR
- Version synchronization: not applicable; no version changes.
- Runtime regression fixture and release smoke matrix: not applicable; no runtime changes.

## Release cadence

No release or version bump requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Documentation now states that published Docker images support `linux/amd64` only and directs Apple Silicon users to the native macOS app. It documents `--platform linux/amd64` and Compose emulation as CPU-only workarounds for ARM64 hosts. Review the performance and lack of MPS acceleration before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->