### PR TITLE
docs(docker): document the amd64-only images and the ARM64 workaround (#1987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Docs
 
+- Docker quick starts now explain the AMD64-only images and direct Apple Silicon users to the native macOS app (#1921) — thanks @yangfan-yf-yf!
 - audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, explicit GGUF download, voice modes, and the weights' research/non-commercial terms (#1891)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Download a package from the [latest release](https://github.com/debpalash/VoiceS
 | macOS 13.3+ | Apple Silicon DMG | [Install on macOS](docs/install/macos.md) |
 | Windows 10/11 | x64 MSI; choose the current-user build when listed to install without admin access | [Install on Windows](docs/install/windows.md#install-pre-built-msi) |
 | Linux | AppImage, x86_64 with glibc 2.39+ | [Install on Linux](docs/install/linux.md) |
-| Docker | CUDA, ROCm, CPU, and worker-only GPU profiles | [Run with Docker](docs/install/docker.md) |
+| Docker | Linux/AMD64 images; CUDA, ROCm, CPU, and worker-only GPU profiles | [Run with Docker](docs/install/docker.md) |
 
 First launch creates a managed Python environment and downloads the default model. Later launches reuse both.
 
@@ -86,6 +86,11 @@ First launch creates a managed Python environment and downloads the default mode
 > On macOS, first launch needs a one-time right-click, then **Open** approval. Intel Macs cannot run the local Python backend; use a [remote backend](docs/install/macos.md) instead.
 
 ### Quick Docker run
+
+The published images are **`linux/amd64` only**. On Apple Silicon, use the
+[native macOS app](docs/install/macos.md) for GPU acceleration. ARM64 hosts
+should read the [architecture requirements](docs/install/docker.md#architecture)
+before pulling an image.
 
 ```bash
 docker run -d -p 127.0.0.1:3900:3900 -v omnivoice-data:/app/omnivoice_data --name voicestudio palashdeb/omnivoice-studio:stable

--- a/deploy/dockerhub-overview.md
+++ b/deploy/dockerhub-overview.md
@@ -14,11 +14,20 @@ cloning, and cinematic video dubbing — fully local, with no cloud API keys or 
 
 ![VoiceStudio — the open-source ElevenLabs alternative](https://raw.githubusercontent.com/debpalash/VoiceStudio/main/.github/assets/social-preview.png)
 
-VoiceStudio runs entirely on your own hardware (CUDA / MPS / ROCm / CPU
+VoiceStudio runs entirely on your own hardware (CUDA / ROCm / CPU
 auto-detect) — nothing is sent to the cloud. This image is the **headless
 web-server build**: a FastAPI backend serving a pre-built React UI over HTTP, so
-you can run it on a homelab box, a GPU server, or anywhere Docker runs and open
+you can run it on an AMD64 homelab box or GPU server and open
 the UI in a browser.
+
+**Architecture:** published images are **`linux/amd64` only**; there is no
+native ARM64 image. On Apple Silicon, use the
+[native macOS app](https://github.com/debpalash/VoiceStudio/blob/main/docs/install/macos.md)
+for Apple GPU acceleration; the Linux container cannot access the Mac's Apple
+GPU through MPS or MLX. Other ARM64 hosts need an AMD64 server or CPU emulation,
+which can be much slower. See the
+[architecture requirements](https://github.com/debpalash/VoiceStudio/blob/main/docs/install/docker.md#architecture)
+before pulling an image.
 
 > The Tauri desktop app's auto-updater and update-channel toggle are
 > **desktop-only** and do not apply to this image — to update, pull a newer tag
@@ -136,7 +145,7 @@ are mirrored on GHCR at
 - **📦 Batch Queue** — drop 50 videos and walk away; per-job progress.
 - **🤖 MCP Server** — drive VoiceStudio from Claude, Cursor, or any MCP client.
 - **🛡️ AI Watermark** — invisible AudioSeal (Meta) marking that survives compression.
-- **⚡ GPU Auto-Detect** — CUDA · MPS · ROCm · CPU, with auto-offload on ≤8 GB cards.
+- **⚡ GPU Auto-Detect** — CUDA · ROCm · CPU, with auto-offload on ≤8 GB cards.
 - **🧩 Extensible** — subclass `TTSBackend` to add any engine in ~50 lines.
 
 Multiple TTS engines ship out of the box (IndexTTS, CosyVoice, Supertonic-3, and

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -256,6 +256,20 @@ docker compose -f deploy/docker-compose.yml --profile gpu up -d
 docker compose -f deploy/docker-compose.yml --profile rocm up -d
 ```
 
+> **ARM64 hosts:** Compose has no per-command `--platform` flag, so the
+> override that works for `docker pull` and `docker run` does not reach it.
+> Export `DOCKER_DEFAULT_PLATFORM=linux/amd64` for the shell you run Compose
+> from, or the image resolves to the ARM64 manifest that does not exist and
+> fails with `no matching manifest for linux/arm64/v8`:
+>
+> ```bash
+> export DOCKER_DEFAULT_PLATFORM=linux/amd64
+> docker compose -f deploy/docker-compose.yml --profile cpu up -d
+> ```
+>
+> Same caveat as above — this is emulation, not native ARM64 support, and only
+> the CPU profile makes sense under it.
+
 The `docker-compose.yml` shipped in `deploy/` defaults to `127.0.0.1:3900`
 on the host. The backend inside the container binds to `0.0.0.0` so the
 host port mapping can forward — the host-side `127.0.0.1` binding is what

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -7,6 +7,25 @@ it in a normal browser.
 **Official images:** [`ghcr.io/debpalash/omnivoice-studio`](https://github.com/debpalash/VoiceStudio/pkgs/container/omnivoice-studio)
 and [`palashdeb/omnivoice-studio` on Docker Hub](https://hub.docker.com/r/palashdeb/omnivoice-studio) — same images, same tags.
 
+## Architecture
+
+The published images are **`linux/amd64` (x86-64) only**, including `:stable`,
+`:latest`, and the ROCm variants. There is no native `linux/arm64` image.
+On an ARM64 host, pulling without an explicit platform can fail with
+`no matching manifest for linux/arm64/v8 in the manifest list entries`.
+
+- **Apple Silicon (M-series Macs):** use the [native macOS app](macos.md),
+  which supports Apple GPU acceleration. The Linux container cannot access
+  the Mac's Apple GPU through MPS or MLX.
+- **AMD64 emulation on ARM64 (including Apple Silicon):** if your Docker
+  installation supports it, place `--platform linux/amd64` **before the image
+  name** in both `docker pull` and `docker run` from the CPU instructions
+  below. This is an emulated CPU option, not native
+  ARM64 support; inference can be much slower and is not a GPU workaround.
+  Without emulation, use an AMD64 server for this Docker deployment.
+
+## Image tags
+
 > **Image ↔ version mapping**
 >
 > | Tag | What you get |


### PR DESCRIPTION
Lands #1987 by @yangfan-yf-yf. Closes #1921.

The published images are `linux/amd64` only — `.github/workflows/docker.yml` says so in its own comment ("Skipped for now — only building linux/amd64"). The Docker quick start reached image resolution before mentioning it, so an ARM64 user (Apple Silicon, Ampere, Graviton) met `no matching manifest for linux/arm64/v8` with nothing explaining why.

**What the contributor added:** an architecture note up front, the `--platform linux/amd64` override for `docker pull` / `docker run`, and an honest caveat that this is emulation, not native ARM64 support.

**What I added on top (Greptile P1, verified real):** Compose has no per-command `--platform` flag, so the override the section documents does not reach the recommended `docker compose ... up -d` line — an ARM64 user following the page still hit the same failure at the step they were most likely to use. `DOCKER_DEFAULT_PLATFORM=linux/amd64` exported for the shell covers it, with the same emulation caveat and a note that only the CPU profile makes sense under it.

Verified: `scripts/validate-install-docs.py` OK, `tests/test_changelog_style.py` + `tests/test_docker_admin_auth_docs.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The Docker documentation now identifies published images as `linux/amd64` only and documents `--platform linux/amd64` and `DOCKER_DEFAULT_PLATFORM=linux/amd64` for ARM64 emulation. It directs Apple Silicon users to the native macOS app for GPU acceleration and limits emulated Docker use to the CPU profile. The main risk is reduced performance under emulation because native ARM64 images and macOS MPS support remain unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->