### PR TITLE
test: let a stock Windows checkout run the symlink tests (#1990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Windows contributors can run the test suite without Developer Mode: tests that create a symlink now skip instead of failing with `WinError 1314` (#1990)
+
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1952)
 - `bun desktop-prod` and `bun desktop-fresh` find Rust and uv from a terminal opened before they were installed, as `bun desktop` already did; a missing Rust toolchain fails up front with the install steps (#1952)
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1955)

--- a/tests/backend/services/test_audiocpp_backend.py
+++ b/tests/backend/services/test_audiocpp_backend.py
@@ -510,12 +510,14 @@ def test_package_filename_default_and_override(monkeypatch, app_modules):
     assert bootstrap.package_filename() == "breeze-tts-2-bf16.gguf"
 
 
-def test_materialize_hf_symlink_keeps_gguf_suffix_without_copy(tmp_path, app_modules):
+def test_materialize_hf_symlink_keeps_gguf_suffix_without_copy(
+    tmp_path, app_modules, symlink_or_skip,
+):
     bootstrap = app_modules.bootstrap
     blob = tmp_path / "content-addressed-blob"
     blob.write_bytes(b"GGUF test payload")
     snapshot = tmp_path / "breeze-tts-2-q8_0.gguf"
-    snapshot.symlink_to(blob)
+    symlink_or_skip(snapshot, blob)
 
     materialized = bootstrap._materialize_gguf_cache_path(snapshot)
 
@@ -533,16 +535,18 @@ def test_materialize_rejects_extensionless_model(tmp_path, app_modules):
         bootstrap._materialize_gguf_cache_path(model)
 
 
-def test_materialize_replaces_preexisting_symlink_alias(tmp_path, app_modules):
+def test_materialize_replaces_preexisting_symlink_alias(
+    tmp_path, app_modules, symlink_or_skip,
+):
     bootstrap = app_modules.bootstrap
     blob = tmp_path / "content-addressed-blob"
     blob.write_bytes(b"GGUF test payload")
     snapshot = tmp_path / "breeze-tts-2-q8_0.gguf"
-    snapshot.symlink_to(blob)
+    symlink_or_skip(snapshot, blob)
     alias = snapshot.with_name(
         f".{snapshot.stem}-{bootstrap.HF_MODEL_REVISION[:12]}.audiocpp.gguf"
     )
-    alias.symlink_to(blob)
+    symlink_or_skip(alias, blob)
 
     materialized = bootstrap._materialize_gguf_cache_path(snapshot)
 
@@ -552,7 +556,7 @@ def test_materialize_replaces_preexisting_symlink_alias(tmp_path, app_modules):
 
 
 def test_materialize_cross_filesystem_symlink_links_beside_target(
-    tmp_path, monkeypatch, app_modules,
+    tmp_path, monkeypatch, app_modules, symlink_or_skip,
 ):
     bootstrap = app_modules.bootstrap
     source_dir = tmp_path / "source"
@@ -562,7 +566,7 @@ def test_materialize_cross_filesystem_symlink_links_beside_target(
     link_dir = tmp_path / "link"
     link_dir.mkdir()
     snapshot = link_dir / "custom.gguf"
-    snapshot.symlink_to(blob)
+    symlink_or_skip(snapshot, blob)
     real_link = os.link
     calls = 0
 
@@ -584,13 +588,13 @@ def test_materialize_cross_filesystem_symlink_links_beside_target(
 
 
 def test_file_override_materializes_hf_style_symlink(
-    tmp_path, monkeypatch, app_modules,
+    tmp_path, monkeypatch, app_modules, symlink_or_skip,
 ):
     bootstrap = app_modules.bootstrap
     blob = tmp_path / "blob"
     blob.write_bytes(b"GGUF test payload")
     model = tmp_path / "custom.gguf"
-    model.symlink_to(blob)
+    symlink_or_skip(model, blob)
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_MODEL", str(model))
 
     resolved = bootstrap.resolve_model_file()
@@ -601,7 +605,7 @@ def test_file_override_materializes_hf_style_symlink(
 
 
 def test_directory_override_materializes_hf_style_symlink(
-    tmp_path, monkeypatch, app_modules,
+    tmp_path, monkeypatch, app_modules, symlink_or_skip,
 ):
     bootstrap = app_modules.bootstrap
     blob = tmp_path / "blob"
@@ -609,7 +613,7 @@ def test_directory_override_materializes_hf_style_symlink(
     model_dir = tmp_path / "models"
     model_dir.mkdir()
     model = model_dir / bootstrap.DEFAULT_PACKAGE
-    model.symlink_to(blob)
+    symlink_or_skip(model, blob)
     monkeypatch.setenv("OMNIVOICE_AUDIOCPP_MODEL", str(model_dir))
 
     resolved = bootstrap.resolve_model_file()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,3 +570,23 @@ def _restore_config_paths_after_reload():
             for const, value in before.items():
                 if isinstance(getattr(mod, const, None), str) and getattr(mod, const) != value:
                     setattr(mod, const, value)
+
+
+# ── Symlinks on a stock Windows checkout ───────────────────────────────────
+# Creating a symlink on Windows needs SeCreateSymbolicLinkPrivilege, which a
+# normal user account does not hold unless Developer Mode is on. Hosted CI
+# runs elevated, so unguarded `Path.symlink_to` / `os.symlink` calls pass
+# there and hand a Windows contributor a suite that fails on their machine
+# for reasons that have nothing to do with their change (WinError 1314). Tests
+# that need a real symlink take this fixture, so the environment that cannot
+# make one skips instead of erroring. Coverage still holds: the full pytest
+# job runs on Linux.
+@pytest.fixture
+def symlink_or_skip():
+    def _make(link, target, *, target_is_directory: bool = False):
+        try:
+            os.symlink(target, link, target_is_directory=target_is_directory)
+        except (OSError, NotImplementedError) as exc:  # pragma: no cover - Windows-only
+            pytest.skip(f"symlinks unavailable in this environment: {exc}")
+
+    return _make

--- a/tests/test_exports_api.py
+++ b/tests/test_exports_api.py
@@ -209,13 +209,13 @@ def test_export_404_when_source_gone(client, outputs_dir, tmp_path, authorize_de
 
 
 def test_export_symlink_inside_outputs_pointing_outside_is_rejected(
-    client, outputs_dir, tmp_path, authorize_destination
+    client, outputs_dir, tmp_path, authorize_destination, symlink_or_skip
 ):
     # A symlink planted in OUTPUTS_DIR must not let /export read arbitrary
     # files: realpath resolves it outside the root, failing containment.
     secret = tmp_path / "secret.txt"
     secret.write_bytes(b"credentials")
-    (outputs_dir / "innocent.wav").symlink_to(secret)
+    symlink_or_skip(outputs_dir / "innocent.wav", secret)
 
     r = client.post("/export", json={
         "source_filename": "innocent.wav",

--- a/tests/test_storage_report.py
+++ b/tests/test_storage_report.py
@@ -334,12 +334,12 @@ def test_clear_temp_removes_only_app_owned_entries(tmp_path):
     assert (tmp / "keep.txt").exists()
 
 
-def test_clear_temp_unlinks_symlinks_without_following(tmp_path):
+def test_clear_temp_unlinks_symlinks_without_following(tmp_path, symlink_or_skip):
     tmp = tmp_path / "tmp"
     target = tmp_path / "precious"
     _write(str(target / "data.bin"), 50)
     os.makedirs(tmp, exist_ok=True)
-    os.symlink(str(target), str(tmp / "omnivoice_link"))
+    symlink_or_skip(str(tmp / "omnivoice_link"), str(target), target_is_directory=True)
 
     res = storage_report.clear_temp(str(tmp))
 

--- a/tests/test_symlink_guards.py
+++ b/tests/test_symlink_guards.py
@@ -1,0 +1,114 @@
+"""Every symlink a test creates must be able to skip instead of erroring.
+
+Creating a symlink on Windows requires SeCreateSymbolicLinkPrivilege, which a
+normal account does not hold without Developer Mode. Hosted CI runs elevated,
+so an unguarded `Path.symlink_to` / `os.symlink` passes there and fails only
+on a contributor's Windows checkout, with `WinError 1314` and no connection to
+their change. Five tests in `test_audiocpp_backend.py` plus one each in
+`test_exports_api.py` and `test_storage_report.py` shipped exactly that.
+
+`tests/conftest.py` provides the `symlink_or_skip` fixture. This test keeps new
+call sites on it — a mechanical rule, so it lives in CI rather than in reviewer
+attention (CLAUDE.md token economy).
+
+Guarded means one of: the `symlink_or_skip` fixture, a call inside a `try`
+(the module already handles the failure), or a helper that skips on its own.
+"""
+
+import ast
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+
+# Helpers that already skip on failure themselves; calls inside them are the
+# guard, not a violation.
+GUARD_FUNCTIONS = {"_symlink_or_skip", "_make", "symlink_or_skip"}
+
+
+def _creates_symlink(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr == "symlink_to":
+            return True
+        if func.attr == "symlink" and isinstance(func.value, ast.Name) and func.value.id == "os":
+            return True
+    return False
+
+
+def _has_skipif(decorators) -> bool:
+    for decorator in decorators:
+        for node in ast.walk(decorator):
+            if isinstance(node, ast.Attribute) and node.attr in ("skipif", "skip"):
+                return True
+    return False
+
+
+def _module_is_skippable(tree: ast.Module) -> bool:
+    """A module-level `pytestmark = pytest.mark.skipif(...)` guards every test
+    in the file, so a symlink call inside one is already conditional."""
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = {t.id for t in node.targets if isinstance(t, ast.Name)}
+        if "pytestmark" in names and _has_skipif([node.value]):
+            return True
+    return False
+
+
+def _calls_a_guard(function: ast.AST) -> bool:
+    """The test already ran a skipping helper, so reaching a later raw call
+    means the environment demonstrably supports symlinks."""
+    for node in ast.walk(function):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in GUARD_FUNCTIONS:
+                return True
+    return False
+
+
+def _unguarded(path: Path) -> list:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    if _module_is_skippable(tree):
+        return []
+    parents = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    bad = []
+    for node in ast.walk(tree):
+        if not _creates_symlink(node):
+            continue
+        cursor = node
+        guarded = False
+        while cursor in parents:
+            cursor = parents[cursor]
+            if isinstance(cursor, ast.Try):
+                guarded = True
+                break
+            if isinstance(cursor, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if cursor.name in GUARD_FUNCTIONS or _has_skipif(cursor.decorator_list):
+                    guarded = True
+                    break
+                if cursor.name.startswith("test_") and _calls_a_guard(cursor):
+                    guarded = True
+                    break
+        if not guarded:
+            bad.append(node.lineno)
+    return bad
+
+
+def test_no_unguarded_symlink_creation_in_tests():
+    offenders = {}
+    for path in sorted(TESTS.rglob("test_*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        lines = _unguarded(path)
+        if lines:
+            offenders[str(path.relative_to(TESTS.parent))] = lines
+    assert not offenders, (
+        "These tests create a symlink without a way to skip, so they fail with "
+        "WinError 1314 on a stock Windows checkout. Take the `symlink_or_skip` "
+        f"fixture from tests/conftest.py instead: {offenders}"
+    )


### PR DESCRIPTION
Fixes #1990.

Seven tests fail on a stock Windows checkout — normal account, Developer Mode off — before they test anything:

```
OSError: [WinError 1314] A required privilege is not held by the client
```

Five in `tests/backend/services/test_audiocpp_backend.py`, one each in `tests/test_exports_api.py` and `tests/test_storage_report.py`. Hosted Windows runners hold `SeCreateSymbolicLinkPrivilege`, so CI is green and this only ever lands on a contributor's machine, with an error that has nothing to do with their change.

**The class, not the instance.** The repo already knew: `tests/test_hf_cache_repair.py` carries a private `_symlink_or_skip` helper whose docstring describes this exact failure. The pattern never reached the other files, and nothing would have told anyone. A convention parked in one module's private helper gets forgotten at the next call site.

So it becomes a `symlink_or_skip` fixture in `tests/conftest.py`, plus `tests/test_symlink_guards.py`, which walks the AST of every test module and fails on a raw `symlink_to` / `os.symlink` with no way to skip. It recognises the three legitimate patterns already in the tree rather than forcing a rewrite: a `try`, a `skipif` marker (module-level `pytestmark` included), and a test that has already called a skipping helper.

Coverage is unchanged — the full pytest job runs on Linux, where nothing skips.

Fails before, passes after: reverting one conversion makes the guard name the file and line; the seven tests error before the fixture and skip after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a reusable `symlink_or_skip` fixture and updates seven symlink tests to skip when Windows lacks symlink privileges. Adds an AST guard test to detect future unguarded symlink calls while preserving Linux coverage. The guard logic warrants review because missed call patterns could allow new Windows failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->