### PR TITLE
fix(bootstrap): emit an attempt id so the splash stops guessing (#1900)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The first-run setup screen no longer mislabels a step when the bootstrap restarts itself: Rust now says which attempt each stage and log line belongs to, instead of the screen guessing from a once-a-second poll (#1900)
+
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1952)
 - `bun desktop-prod` and `bun desktop-fresh` find Rust and uv from a terminal opened before they were installed, as `bun desktop` already did; a missing Rust toolchain fails up front with the install steps (#1952)
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1955)

--- a/frontend/src-tauri/src/backend.rs
+++ b/frontend/src-tauri/src/backend.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use tauri::Manager;
 
 use crate::bootstrap::{
-    BootstrapStage, emit_log, ensure_venv_ready, set_stage,
+    BootstrapStage, current_attempt, emit_log_for_attempt, ensure_venv_ready, set_stage,
 };
 use crate::config::load_config;
 use crate::tools::{resolve_ffmpeg, resolve_ffprobe};
@@ -887,6 +887,11 @@ pub(crate) fn spawn_backend<R: tauri::Runtime>(
         }
     };
 
+    // The attempt these pumps drain, captured up front: the threads outlive
+    // the run, and a restart must not relabel its trailing output as the new
+    // attempt's evidence (#1900).
+    let pump_attempt = current_attempt();
+
     if let Some(stdout_pipe) = contained.child.stdout.take() {
         let app_clone = app.clone();
         let mut out_file = stdout_file;
@@ -895,7 +900,7 @@ pub(crate) fn spawn_backend<R: tauri::Runtime>(
             let reader = BufReader::new(stdout_pipe);
             for line in reader.lines().flatten() {
                 log::info!("[backend_stdout] {}", line);
-                emit_log(&app_clone, "starting_backend", &line);
+                emit_log_for_attempt(&app_clone, pump_attempt, "starting_backend", &line);
                 if let Some(ref mut f) = out_file {
                     let _ = writeln!(f, "{}", line);
                 }
@@ -913,7 +918,7 @@ pub(crate) fn spawn_backend<R: tauri::Runtime>(
             let mut log_file = err_log_file;
             for line in reader.lines().flatten() {
                 log::info!("[backend_stderr] {}", line);
-                emit_log(&app_clone, "starting_backend", &line);
+                emit_log_for_attempt(&app_clone, pump_attempt, "starting_backend", &line);
                 if let Some(ref mut f) = log_file {
                     let _ = writeln!(f, "{}", line);
                 }

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -48,6 +48,37 @@ pub struct BootstrapState {
     pub logs: Arc<Mutex<Vec<LogPayload>>>,
 }
 
+/// Which bootstrap attempt the current stage and log lines belong to (#1900).
+///
+/// The splash used to *infer* attempt boundaries from the ~1 s status poll:
+/// arriving at `checking`/`awaiting_setup`, or leaving `failed`, meant a new
+/// attempt had begun. Inference from a sampled signal cannot be airtight — a
+/// restart begun on this side, which the UI did not initiate, can be sampled
+/// up to a full interval late, and the new attempt's earliest stage-tagged log
+/// lines are then discarded as the previous attempt's. The consequence was
+/// cosmetic and deliberately conservative (a fast stage shows *pending* though
+/// it ran), but it was a guess.
+///
+/// The producer knows the answer exactly, so it says so: every
+/// `bootstrap_status` reply and every `bootstrap-log` line carries the attempt
+/// it belongs to, and the frontend scopes evidence by equality, not by clock.
+///
+/// Starts at 1 so 0 is never a live attempt — a payload carrying no attempt at
+/// all deserializes to 0 and stays distinguishable from the first one.
+static ATTEMPT: AtomicU64 = AtomicU64::new(1);
+
+/// The attempt now in progress.
+pub fn current_attempt() -> u64 {
+    ATTEMPT.load(Ordering::SeqCst)
+}
+
+/// Open a new attempt and return its id. Called wherever the bootstrap really
+/// restarts: both retry commands funnel through `respawn_backend`, and the
+/// supervisor's automatic venv rebuild re-enters `Checking` on its own.
+pub fn begin_attempt() -> u64 {
+    ATTEMPT.fetch_add(1, Ordering::SeqCst) + 1
+}
+
 /// The last `Failed { message }` diagnosis this session, retained after the
 /// stage itself has moved on (#1177).
 ///
@@ -115,6 +146,9 @@ pub fn already_diagnosed(state: &Arc<Mutex<BootstrapStage>>) -> bool {
 
 #[derive(Clone, Serialize)]
 pub struct LogPayload {
+    /// The attempt this line was produced during (#1900). A stage-tagged line
+    /// proves its stage ran — but only for the attempt that emitted it.
+    pub attempt: u64,
     pub stage: String,
     pub line: String,
 }
@@ -158,7 +192,11 @@ fn append_bootstrap_log(stage: &str, line: &str) {
 }
 
 pub fn emit_log<R: tauri::Runtime>(app: &tauri::AppHandle<R>, stage: &str, line: &str) {
-    let payload = LogPayload { stage: stage.to_string(), line: line.to_string() };
+    let payload = LogPayload {
+        attempt: current_attempt(),
+        stage: stage.to_string(),
+        line: line.to_string(),
+    };
     // Buffer the log so the frontend can backfill on mount.
     if let Some(state) = app.try_state::<BootstrapState>() {
         if let Ok(mut logs) = state.logs.lock() {
@@ -242,13 +280,31 @@ pub fn run_streaming<R: tauri::Runtime>(
 
 // ── Tauri commands ────────────────────────────────────────────────────────
 
+/// A stage together with the attempt that produced it (#1900).
+///
+/// `BootstrapStage` is internally tagged, so flattening it here keeps the wire
+/// shape the frontend already reads — `{ "stage": "checking" }` plus whatever
+/// fields the variant carries — and only adds a sibling `attempt`.
+#[derive(Clone, Serialize, Debug)]
+pub struct BootstrapStatus {
+    pub attempt: u64,
+    #[serde(flatten)]
+    pub stage: BootstrapStage,
+}
+
 #[tauri::command]
-pub fn bootstrap_status(state: tauri::State<'_, BootstrapState>) -> BootstrapStage {
-    state
+pub fn bootstrap_status(state: tauri::State<'_, BootstrapState>) -> BootstrapStatus {
+    // Read the stage first, the counter second. A restart bumps the attempt and
+    // only then sets `Checking`, so this order can pair a stage with an attempt
+    // at or after its own, never with one that had not begun when the stage was
+    // written — the direction that would let the previous attempt's evidence be
+    // claimed by this one.
+    let stage = state
         .stage
         .lock()
         .map(|g| g.clone())
-        .unwrap_or(BootstrapStage::Checking)
+        .unwrap_or(BootstrapStage::Checking);
+    BootstrapStatus { attempt: current_attempt(), stage }
 }
 
 #[tauri::command]
@@ -309,6 +365,9 @@ pub fn respawn_backend<R: tauri::Runtime>(
     // Before anything reaches for lifecycle ownership: a readiness wait may be
     // holding it while a slow backend starts (#1791).
     preempt_backend_wait();
+    // Open the new attempt BEFORE the stage moves, so no log line and no polled
+    // stage of the new attempt can still be stamped with the one that ended.
+    begin_attempt();
     if let Ok(mut guard) = stage.lock() {
         *guard = BootstrapStage::Checking;
     }
@@ -875,6 +934,11 @@ fn spawn_backend_until_ready<R: tauri::Runtime>(
                             "Backend failed because the Python environment is broken — rebuilding it automatically",
                         );
                         if quarantine_broken_venv(&venv_dir) {
+                            // A restart nobody clicked. Rebuilding the venv
+                            // re-runs the whole bootstrap, so it opens a new
+                            // attempt and says so, instead of leaving the
+                            // splash to infer the boundary from the poll.
+                            begin_attempt();
                             set_stage(stage_handle, BootstrapStage::Checking);
                             continue 'bootstrap;
                         }
@@ -4315,14 +4379,17 @@ UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 11: illegal m
     fn failed_command_message_carries_the_newest_relevant_output() {
         let logs = vec![
             LogPayload {
+                attempt: 1,
                 stage: "downloading_uv".into(),
                 line: "unrelated".into(),
             },
             LogPayload {
+                attempt: 1,
                 stage: "installing_deps".into(),
                 line: "resolver context".into(),
             },
             LogPayload {
+                attempt: 1,
                 stage: "installing_deps".into(),
                 line: "actual dependency conflict".into(),
             },
@@ -4591,5 +4658,63 @@ mod code_fingerprint_tests {
         retire_run_sentinel(59_999);
 
         assert!(sentinel.exists(), "an unreachable backend must not erase the sentinel");
+    }
+
+    // ── #1900: the attempt id the splash scopes evidence by ────────────────
+
+    #[test]
+    fn a_status_reply_carries_the_stage_and_its_attempt() {
+        // The wire shape the frontend already reads must survive: `stage` stays
+        // a sibling key at the top level (serde flatten on an internally tagged
+        // enum), with `attempt` added beside it — not nested under it.
+        let status = BootstrapStatus {
+            attempt: 4,
+            stage: BootstrapStage::InstallingDeps,
+        };
+
+        let json = serde_json::to_value(&status).unwrap();
+
+        assert_eq!(json["stage"], "installing_deps");
+        assert_eq!(json["attempt"], 4);
+    }
+
+    #[test]
+    fn a_failed_status_keeps_its_message_alongside_the_attempt() {
+        // The variant's own fields flatten up too, so `message` does not move
+        // and the failure card keeps rendering.
+        let status = BootstrapStatus {
+            attempt: 2,
+            stage: BootstrapStage::Failed { message: "uv sync failed".into() },
+        };
+
+        let json = serde_json::to_value(&status).unwrap();
+
+        assert_eq!(json["stage"], "failed");
+        assert_eq!(json["message"], "uv sync failed");
+        assert_eq!(json["attempt"], 2);
+    }
+
+    #[test]
+    fn beginning_an_attempt_moves_the_counter_forward() {
+        // Monotonic and never reused: the frontend scopes by equality, so a
+        // repeated id would let a previous attempt's log lines count toward
+        // the current one — the misattribution this exists to remove.
+        let before = current_attempt();
+
+        let first = begin_attempt();
+        let second = begin_attempt();
+
+        assert!(first > before, "an attempt must not reuse an earlier id");
+        assert!(second > first, "attempts must keep moving forward");
+        assert_eq!(current_attempt(), second);
+    }
+
+    #[test]
+    fn an_attempt_is_never_zero() {
+        // 0 is reserved for "no attempt stated" — a payload from a build that
+        // predates this field deserializes to it, and must never collide with
+        // a real attempt.
+        assert!(current_attempt() >= 1);
+        assert!(begin_attempt() >= 1);
     }
 }

--- a/frontend/src-tauri/src/bootstrap.rs
+++ b/frontend/src-tauri/src/bootstrap.rs
@@ -63,20 +63,34 @@ pub struct BootstrapState {
 /// `bootstrap_status` reply and every `bootstrap-log` line carries the attempt
 /// it belongs to, and the frontend scopes evidence by equality, not by clock.
 ///
+/// **Guarded by the stage mutex.** Every write happens while that lock is held
+/// (`begin_attempt_with`), and `bootstrap_status` reads stage and attempt under
+/// it. Without that discipline a restart landing between the two reads returns
+/// the PREVIOUS attempt's stage stamped with the new attempt's id — and the
+/// splash records `installing_deps` as work this attempt did, which is exactly
+/// the #1894 fabrication the attempt id exists to remove (Greptile).
+///
 /// Starts at 1 so 0 is never a live attempt — a payload carrying no attempt at
 /// all deserializes to 0 and stays distinguishable from the first one.
 static ATTEMPT: AtomicU64 = AtomicU64::new(1);
 
-/// The attempt now in progress.
+/// The attempt now in progress. Read without the stage lock by log emission,
+/// which only needs the current value, never a pair.
 pub fn current_attempt() -> u64 {
     ATTEMPT.load(Ordering::SeqCst)
 }
 
-/// Open a new attempt and return its id. Called wherever the bootstrap really
-/// restarts: both retry commands funnel through `respawn_backend`, and the
-/// supervisor's automatic venv rebuild re-enters `Checking` on its own.
-pub fn begin_attempt() -> u64 {
-    ATTEMPT.fetch_add(1, Ordering::SeqCst) + 1
+/// Open a new attempt and move the stage into it, atomically.
+///
+/// Called wherever the bootstrap really restarts: both retry commands funnel
+/// through `respawn_backend`, and the supervisor's automatic venv rebuild
+/// re-enters `Checking` on its own. Taking the stage lock across both writes is
+/// what makes the pair a reader observes always self-consistent.
+pub fn begin_attempt_with(stage: &Arc<Mutex<BootstrapStage>>, next: BootstrapStage) -> u64 {
+    let mut guard = stage.lock().unwrap_or_else(|e| e.into_inner());
+    let id = ATTEMPT.fetch_add(1, Ordering::SeqCst) + 1;
+    *guard = next;
+    id
 }
 
 /// The last `Failed { message }` diagnosis this session, retained after the
@@ -191,9 +205,32 @@ fn append_bootstrap_log(stage: &str, line: &str) {
     }
 }
 
+/// Emit a stage-tagged log line for the attempt in progress.
+///
+/// Correct for every caller that runs inside the attempt it is describing —
+/// which is all of them except the output pumps, whose thread outlives the run
+/// it is draining. Those use [`emit_log_for_attempt`].
 pub fn emit_log<R: tauri::Runtime>(app: &tauri::AppHandle<R>, stage: &str, line: &str) {
+    emit_log_for_attempt(app, current_attempt(), stage, line)
+}
+
+/// Emit a log line stamped with the attempt that PRODUCED it, not the one
+/// running when it happened to be read (#1900, CodeRabbit).
+///
+/// An output pump is a thread reading a pipe: it lives as long as the process
+/// it drains, which can outlive the attempt that started it. A restart bumps
+/// the counter, and the dying run's remaining lines — read a moment later —
+/// would be stamped with the NEW attempt and counted as its evidence. The pump
+/// captures its attempt when it starts, so a line is labelled by the work that
+/// wrote it.
+pub fn emit_log_for_attempt<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    attempt: u64,
+    stage: &str,
+    line: &str,
+) {
     let payload = LogPayload {
-        attempt: current_attempt(),
+        attempt,
         stage: stage.to_string(),
         line: line.to_string(),
     };
@@ -236,11 +273,15 @@ pub fn run_streaming<R: tauri::Runtime>(
     let app_err = app.clone();
     let stage_out = stage.to_string();
     let stage_err = stage.to_string();
+    // The attempt these pumps are draining, captured before either can outlive
+    // it: a restart during a long `uv sync` must not relabel this run's
+    // remaining output as the next attempt's work.
+    let attempt = current_attempt();
     let h_out = std::thread::spawn(move || {
         if let Some(s) = stdout {
             for line in BufReader::new(s).lines().flatten() {
                 log::info!("[{}] {}", stage_out, line);
-                emit_log(&app_out, &stage_out, &line);
+                emit_log_for_attempt(&app_out, attempt, &stage_out, &line);
             }
         }
     });
@@ -248,7 +289,7 @@ pub fn run_streaming<R: tauri::Runtime>(
         if let Some(s) = stderr {
             for line in BufReader::new(s).lines().flatten() {
                 log::info!("[{}] {}", stage_err, line);
-                emit_log(&app_err, &stage_err, &line);
+                emit_log_for_attempt(&app_err, attempt, &stage_err, &line);
             }
         }
     });
@@ -294,17 +335,18 @@ pub struct BootstrapStatus {
 
 #[tauri::command]
 pub fn bootstrap_status(state: tauri::State<'_, BootstrapState>) -> BootstrapStatus {
-    // Read the stage first, the counter second. A restart bumps the attempt and
-    // only then sets `Checking`, so this order can pair a stage with an attempt
-    // at or after its own, never with one that had not begun when the stage was
-    // written — the direction that would let the previous attempt's evidence be
-    // claimed by this one.
-    let stage = state
-        .stage
-        .lock()
-        .map(|g| g.clone())
-        .unwrap_or(BootstrapStage::Checking);
-    BootstrapStatus { attempt: current_attempt(), stage }
+    // Both reads under the stage lock, which every attempt bump also holds
+    // (`begin_attempt_with`). Sampling them separately lets a restart land in
+    // between and return the PREVIOUS attempt's stage stamped with the new
+    // attempt's id — the splash then records `installing_deps` as work this
+    // attempt did, which is the fabrication the id exists to remove.
+    match state.stage.lock() {
+        Ok(guard) => BootstrapStatus { attempt: current_attempt(), stage: guard.clone() },
+        Err(poisoned) => BootstrapStatus {
+            attempt: current_attempt(),
+            stage: poisoned.into_inner().clone(),
+        },
+    }
 }
 
 #[tauri::command]
@@ -365,12 +407,9 @@ pub fn respawn_backend<R: tauri::Runtime>(
     // Before anything reaches for lifecycle ownership: a readiness wait may be
     // holding it while a slow backend starts (#1791).
     preempt_backend_wait();
-    // Open the new attempt BEFORE the stage moves, so no log line and no polled
-    // stage of the new attempt can still be stamped with the one that ended.
-    begin_attempt();
-    if let Ok(mut guard) = stage.lock() {
-        *guard = BootstrapStage::Checking;
-    }
+    // One lock across the bump and the stage write, so no poll can observe the
+    // old stage paired with the new attempt.
+    begin_attempt_with(&stage, BootstrapStage::Checking);
     if let Ok(mut logs) = logs.lock() {
         logs.clear();
     }
@@ -938,8 +977,7 @@ fn spawn_backend_until_ready<R: tauri::Runtime>(
                             // re-runs the whole bootstrap, so it opens a new
                             // attempt and says so, instead of leaving the
                             // splash to infer the boundary from the poll.
-                            begin_attempt();
-                            set_stage(stage_handle, BootstrapStage::Checking);
+                            begin_attempt_with(stage_handle, BootstrapStage::Checking);
                             continue 'bootstrap;
                         }
                         log::error!(
@@ -4694,15 +4732,27 @@ mod code_fingerprint_tests {
         assert_eq!(json["attempt"], 2);
     }
 
+    /// `ATTEMPT` is one process-global counter and cargo runs tests in
+    /// threads. Without this the three below interleave: one reads the counter
+    /// another just advanced, and asserts on a value it never owned
+    /// (CodeRabbit).
+    static ATTEMPT_LOCK: Mutex<()> = Mutex::new(());
+
+    fn a_stage_slot() -> Arc<Mutex<BootstrapStage>> {
+        Arc::new(Mutex::new(BootstrapStage::InstallingDeps))
+    }
+
     #[test]
     fn beginning_an_attempt_moves_the_counter_forward() {
         // Monotonic and never reused: the frontend scopes by equality, so a
         // repeated id would let a previous attempt's log lines count toward
         // the current one — the misattribution this exists to remove.
+        let _g = ATTEMPT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let slot = a_stage_slot();
         let before = current_attempt();
 
-        let first = begin_attempt();
-        let second = begin_attempt();
+        let first = begin_attempt_with(&slot, BootstrapStage::Checking);
+        let second = begin_attempt_with(&slot, BootstrapStage::Checking);
 
         assert!(first > before, "an attempt must not reuse an earlier id");
         assert!(second > first, "attempts must keep moving forward");
@@ -4714,7 +4764,26 @@ mod code_fingerprint_tests {
         // 0 is reserved for "no attempt stated" — a payload from a build that
         // predates this field deserializes to it, and must never collide with
         // a real attempt.
+        let _g = ATTEMPT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         assert!(current_attempt() >= 1);
-        assert!(begin_attempt() >= 1);
+        assert!(begin_attempt_with(&a_stage_slot(), BootstrapStage::Checking) >= 1);
+    }
+
+    #[test]
+    fn a_new_attempt_never_carries_the_previous_stage() {
+        // Greptile P1: the bump and the stage write have to be one atomic
+        // move. Sampled separately, a restart landing between them returns
+        // `installing_deps` stamped with the NEW attempt, and the splash
+        // records an install this attempt never ran.
+        let _g = ATTEMPT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let slot = a_stage_slot();
+
+        let opened = begin_attempt_with(&slot, BootstrapStage::Checking);
+
+        // Whatever a reader sees after the call, the pair is consistent: the
+        // new attempt's id can only ever come with the new attempt's stage.
+        let stage = slot.lock().unwrap().clone();
+        assert!(matches!(stage, BootstrapStage::Checking), "{stage:?}");
+        assert_eq!(current_attempt(), opened);
     }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -122,7 +122,11 @@ function App() {
   // publishes progress via the `bootstrap_status` Tauri command. Hook below
   // polls every 1 s; until `ready`, we render BootstrapSplash instead of the
   // normal app shell, so the user sees real progress instead of a hung UI.
-  const { stage: bootstrapStage, message: bootstrapMessage } = useBootstrapStage();
+  const {
+    stage: bootstrapStage,
+    message: bootstrapMessage,
+    attempt: bootstrapAttempt,
+  } = useBootstrapStage();
   // Read once, like api/client.ts. Saving or disabling a remote backend reloads
   // the app, so this value and API's module-level base always move together.
   const [remoteBackend] = useState(() => configuredRemoteBackend());
@@ -1264,7 +1268,11 @@ function App() {
   if (!remoteBackend && bootstrapStage === 'awaiting_setup') {
     return (
       <div className="app-bootstrap-scale" style={{ '--ui-scale': effectiveUiScale }}>
-        <BootstrapSplash stage={bootstrapStage} message={bootstrapMessage} />
+        <BootstrapSplash
+          stage={bootstrapStage}
+          message={bootstrapMessage}
+          attempt={bootstrapAttempt}
+        />
       </div>
     );
   }
@@ -1277,7 +1285,11 @@ function App() {
   if (!setupChecked || !storeHydrated) {
     return (
       <div className="app-bootstrap-scale" style={{ '--ui-scale': effectiveUiScale }}>
-        <BootstrapSplash stage={bootstrapStage} message={bootstrapMessage} />
+        <BootstrapSplash
+          stage={bootstrapStage}
+          message={bootstrapMessage}
+          attempt={bootstrapAttempt}
+        />
       </div>
     );
   }
@@ -1365,7 +1377,11 @@ function App() {
   if (!backendReady) {
     return (
       <div className="app-bootstrap-scale" style={{ '--ui-scale': effectiveUiScale }}>
-        <BootstrapSplash stage={bootstrapStage} message={bootstrapMessage} />
+        <BootstrapSplash
+          stage={bootstrapStage}
+          message={bootstrapMessage}
+          attempt={bootstrapAttempt}
+        />
       </div>
     );
   }

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -670,7 +670,13 @@ export function BootstrapSplash({ stage, message, attempt = 0 }) {
           // guessing for the rest of the run.
           if (!handoverDoneRef.current) {
             const seam = allLogsRef.current.slice(-5);
-            if (seam.some((l) => l.stage === s && l.line === line)) return;
+            // The attempt is part of the identity (#1900, CodeRabbit): the
+            // same stage and the same text from a DIFFERENT attempt is not a
+            // replay of a buffered line, it is this attempt's own evidence.
+            // Matching on stage+line alone dropped it, which can remove the
+            // only proof for a stage the poll never sampled.
+            if (seam.some((l) => l.attempt === (a ?? 0) && l.stage === s && l.line === line))
+              return;
             handoverDoneRef.current = true;
           }
           const entry = { attempt: a ?? 0, stage: s, line, t: Date.now() };

--- a/frontend/src/components/BootstrapSplash.jsx
+++ b/frontend/src/components/BootstrapSplash.jsx
@@ -127,10 +127,6 @@ const STEPS = [
 // journey chrome should already be armed by the time the step list appears.
 const INSTALL_STAGES = ['downloading_uv', 'creating_venv', 'installing_deps', 'awaiting_setup'];
 
-// Stages the bootstrap restarts *from*. Arriving at one of these from
-// anywhere else means a new attempt began (Retry, or a Rust-side restart).
-const RESTART_STAGES = new Set(['checking', 'awaiting_setup']);
-
 // How many log lines the <pre> shows. `logs` state holds exactly this tail and
 // nothing more, so the per-event array copy stays bounded no matter how long a
 // bootstrap runs.
@@ -416,7 +412,7 @@ function ErrorBox({ children }) {
   );
 }
 
-export function BootstrapSplash({ stage, message }) {
+export function BootstrapSplash({ stage, message, attempt = 0 }) {
   const { t } = useTranslation();
   const locale = useAppStore((s) => s.locale);
   const setLocale = useAppStore((s) => s.setLocale);
@@ -471,9 +467,6 @@ export function BootstrapSplash({ stage, message }) {
   // tracking effect below). Drives "done" ticks and journey visibility off
   // observed reality instead of list position (#1894).
   const [polledStages, setPolledStages] = useState(() => new Set([stage]));
-  // Wall-clock start of the current attempt. A retry restarts the bootstrap;
-  // log lines from the previous attempt must not count toward this one.
-  const [attemptStart, setAttemptStart] = useState(0);
   // Every line of this bootstrap. `logs` above is only the rendered tail.
   const [totalLines, setTotalLines] = useState(0);
   const allLogsRef = useRef([]);
@@ -481,10 +474,7 @@ export function BootstrapSplash({ stage, message }) {
   // Dedup guards that seam and nothing else — see the listener.
   const handoverDoneRef = useRef(false);
   const logRef = useRef(null);
-  const prevStageRef = useRef(stage); // previous stage, for restart detection
-  // True between a retry WE initiated and the poll catching up to it, so the
-  // fallback effect below doesn't re-stamp an already-exact attempt boundary.
-  const selfInitiatedRef = useRef(false);
+  const prevAttemptRef = useRef(attempt); // last attempt id Rust reported
   const prevProgRef = useRef(null); // {bytes, t} — last progress event
   const rateRef = useRef(0); // EMA bytes/sec across events
 
@@ -495,14 +485,18 @@ export function BootstrapSplash({ stage, message }) {
   // fast disk `creating_venv` routinely does. Stage-tagged `bootstrap-log`
   // lines close that gap: the Rust side emits them as the work happens, so a
   // line tagged with a stage is proof that stage ran, whether or not the
-  // poll ever saw it. Lines are filtered to the current attempt so a retry
-  // cannot inherit the previous one's evidence (the visible log is left
-  // alone — clearing it on a Rust-side restart would destroy the user's
-  // context, cf. #1847).
+  // poll ever saw it.
+  //
+  // Lines are scoped to the current attempt so a retry cannot inherit the
+  // previous one's evidence. The attempt is the id Rust stamps on both the
+  // status reply and every log line (#1900) — an exact match, rather than a
+  // clock comparison against a boundary this side had to guess at. (The
+  // VISIBLE log is left alone: clearing it on a restart nobody asked for
+  // would destroy the user's context, cf. #1847.)
   const observedStages = useMemo(() => {
     const seen = new Set(polledStages);
     for (const entry of allLogsRef.current) {
-      if (entry?.stage && (entry.t ?? 0) >= attemptStart) seen.add(entry.stage);
+      if (entry?.stage && entry.attempt === attempt) seen.add(entry.stage);
     }
     return seen;
     // totalLines is the render signal for allLogsRef, which is a ref and so
@@ -510,7 +504,7 @@ export function BootstrapSplash({ stage, message }) {
     // rendered tail is the point: a stage whose only evidence scrolled out of
     // the capped tail would otherwise read as never having run (#1847).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [polledStages, totalLines, attemptStart]);
+  }, [polledStages, totalLines, attempt]);
 
   const label = t(`bootstrap.${stage}`, STAGE_LABEL[stage]);
   const stepIndex = Math.max(0, STEPS.indexOf(stage));
@@ -536,18 +530,15 @@ export function BootstrapSplash({ stage, message }) {
   // instead of fabricating completed work (#1894).
   const installWorkSeen = INSTALL_STAGES.some((s) => observedStages.has(s));
 
-  // Open a new bootstrap attempt. Called at the moment a retry is INITIATED,
-  // not when the ~1s status poll later reports `checking`: the Rust side
-  // starts emitting logs for the new attempt immediately, and a boundary
-  // stamped at detection time would sit *after* those lines and discard them
-  // as belonging to the old attempt — losing exactly the fast-stage evidence
-  // the log union exists to capture. resetLogs() clears the full-run ref too,
-  // so a retry cannot inherit the previous attempt's lines (#1847 + #1894).
+  // Clear the splash for a retry the user just asked for. The attempt
+  // BOUNDARY is no longer this side's business (#1900) — Rust bumps its
+  // attempt id inside `respawn_backend`, before the stage moves, and the
+  // reset effect below follows that. What is left here is presentation: empty
+  // the visible log and the polled-stage set so the user watches a fresh run
+  // start, instead of the failed one's output sitting under a spinner.
   const beginAttempt = () => {
-    selfInitiatedRef.current = true;
     resetLogs();
     setPolledStages(new Set());
-    setAttemptStart(Date.now());
   };
 
   const handleRetry = async () => {
@@ -590,45 +581,22 @@ export function BootstrapSplash({ stage, message }) {
   // still render as completed, which is the very fabrication this change
   // exists to remove.
   //
-  // Retries we initiate call beginAttempt() directly, so their boundary is
-  // exact. This effect is the FALLBACK for a restart begun on the Rust side,
-  // where the stage poll is the only signal we get. There the boundary can
-  // land up to one poll interval late, and log lines from the new attempt in
-  // that window are discarded rather than counted. That is the deliberate
-  // direction to fail in: a discarded line can leave a step showing pending
-  // (conservative, and honest), whereas counting a stale line would render a
-  // step DONE for work this attempt never did — the bug this change exists to
-  // fix. Closing the window entirely needs a Rust-provided attempt id, which
-  // would be a new IPC surface and is deliberately out of scope here.
+  // A new attempt is a fact Rust reports, not something this side infers from
+  // a sampled stage (#1900). Every real restart bumps the id — both retry
+  // commands via `respawn_backend`, and the supervisor's own venv rebuild — so
+  // the id changing IS the boundary, whether or not the poll ever sampled the
+  // restart stage. The heuristics this replaces (arriving at
+  // `checking`/`awaiting_setup`, leaving `failed`) could miss a Rust-initiated
+  // restart by up to a poll interval and discard that attempt's earliest
+  // evidence. Equality on an id cannot.
   useEffect(() => {
-    const prev = prevStageRef.current;
-    prevStageRef.current = stage;
-    // Two ways a new attempt shows up in the poll. Arriving at a restart
-    // stage is the common one. But the poll can also miss the restart stage
-    // entirely — `failed` -> (retry) -> `checking` -> `starting_backend`
-    // inside one ~1s sample window surfaces as `failed` -> `starting_backend`,
-    // and keying only off restart stages would leave the FAILED attempt's
-    // evidence in place and render its install chrome as this attempt's
-    // completed work. Leaving `failed` at all means a retry began, since
-    // retry_bootstrap/clean_and_retry_bootstrap are the only exits from it.
-    const restarted =
-      (RESTART_STAGES.has(stage) && !RESTART_STAGES.has(prev)) ||
-      (prev === 'failed' && stage !== 'failed');
-    if (restarted) {
-      if (selfInitiatedRef.current) {
-        // beginAttempt() already opened this attempt with an exact boundary.
-        // Re-stamping it here — a poll interval later — would discard the
-        // new attempt's own early log lines, which is the bug this guard
-        // exists to prevent.
-        selfInitiatedRef.current = false;
-      } else {
-        setAttemptStart(Date.now());
-      }
+    if (prevAttemptRef.current !== attempt) {
+      prevAttemptRef.current = attempt;
       setPolledStages(new Set([stage]));
       return;
     }
     setPolledStages((p) => (p.has(stage) ? p : new Set(p).add(stage)));
-  }, [stage]);
+  }, [stage, attempt]);
 
   // Load persisted region on mount.
   useEffect(() => {
@@ -674,7 +642,8 @@ export function BootstrapSplash({ stage, message }) {
         try {
           const buffered = await invoke('get_bootstrap_logs');
           if (!cancelled && Array.isArray(buffered) && buffered.length > 0) {
-            const entries = buffered.map(({ stage: s, line }) => ({
+            const entries = buffered.map(({ attempt: a, stage: s, line }) => ({
+              attempt: a ?? 0,
               stage: s,
               line,
               t: Date.now(),
@@ -689,7 +658,7 @@ export function BootstrapSplash({ stage, message }) {
 
         // Subscribe to live events for anything new from here on.
         unlistenLog = await listen('bootstrap-log', (e) => {
-          const { stage: s, line } = e.payload || {};
+          const { attempt: a, stage: s, line } = e.payload || {};
           if (!line) return;
           noteBootstrapLogActivity();
           // Dedup ONLY across the backfill→live seam. The overlap it exists
@@ -704,7 +673,7 @@ export function BootstrapSplash({ stage, message }) {
             if (seam.some((l) => l.stage === s && l.line === line)) return;
             handoverDoneRef.current = true;
           }
-          const entry = { stage: s, line, t: Date.now() };
+          const entry = { attempt: a ?? 0, stage: s, line, t: Date.now() };
           allLogsRef.current.push(entry);
           setTotalLines(allLogsRef.current.length);
           setLogs((prev) => {
@@ -1061,19 +1030,21 @@ export function BootstrapSplash({ stage, message }) {
  * returns 'ready' immediately so the splash never mounts.
  */
 export function useBootstrapStage(pollMs = 1000) {
-  const [state, setState] = useState({ stage: 'checking', message: null });
+  // `attempt` is Rust's bootstrap-attempt id (#1900). 0 means "none reported",
+  // which is where the non-Tauri and dev-web short-circuits below settle.
+  const [state, setState] = useState({ stage: 'checking', message: null, attempt: 0 });
 
   useEffect(() => {
     if (typeof window === 'undefined') {
-      setState({ stage: 'ready', message: null });
+      setState({ stage: 'ready', message: null, attempt: 0 });
       return;
     }
     if (!('__TAURI_INTERNALS__' in window)) {
-      setState({ stage: 'ready', message: null });
+      setState({ stage: 'ready', message: null, attempt: 0 });
       return;
     }
     if (import.meta.env.DEV) {
-      setState({ stage: 'ready', message: null });
+      setState({ stage: 'ready', message: null, attempt: 0 });
       return;
     }
 
@@ -1093,7 +1064,7 @@ export function useBootstrapStage(pollMs = 1000) {
         healthUrl: `${getApiBase()}/health`,
         onHealthy: () => {
           if (cancelled) return;
-          setState({ stage: 'ready', message: null });
+          setState({ stage: 'ready', message: null, attempt: 0 });
         },
       });
     };
@@ -1113,11 +1084,11 @@ export function useBootstrapStage(pollMs = 1000) {
       onReadyViaHttp: () => {
         if (cancelled) return;
         httpForcedReady = true;
-        setState({ stage: 'ready', message: null });
+        setState({ stage: 'ready', message: null, attempt: 0 });
       },
       onStuck: () => {
         if (cancelled || httpForcedReady) return;
-        setState({ stage: 'ipc_lost', message: null });
+        setState({ stage: 'ipc_lost', message: null, attempt: 0 });
       },
     });
     // Stall watchdog (#474): if the backend hangs in a non-terminal stage and
@@ -1162,7 +1133,7 @@ export function useBootstrapStage(pollMs = 1000) {
       const tauriInvoke = await invoke();
       if (!tauriInvoke) {
         watchdog.cancel();
-        setState({ stage: 'ready', message: null });
+        setState({ stage: 'ready', message: null, attempt: 0 });
         return;
       }
       const tick = async () => {
@@ -1179,6 +1150,9 @@ export function useBootstrapStage(pollMs = 1000) {
           misses = 0;
           const stage = res.stage || 'ready';
           const message = res.message || null;
+          // Rust's bootstrap-attempt id (#1900). A build that predates the
+          // field reports nothing, which reads as 0 — never a live attempt.
+          const attempt = typeof res.attempt === 'number' ? res.attempt : 0;
           // Reset the stall clock whenever something actually changes.
           const key = `${stage}|${message || ''}`;
           if (key !== lastKey) {
@@ -1191,6 +1165,7 @@ export function useBootstrapStage(pollMs = 1000) {
             if (Date.now() - lastActivity > stallBudgetMs(stage)) {
               // Stuck — surface it as a failure so Retry/logs/hints appear.
               setState({
+                attempt,
                 stage: 'failed',
                 message:
                   (message ? message + '\n\n' : '') +
@@ -1201,10 +1176,10 @@ export function useBootstrapStage(pollMs = 1000) {
               startFailedRecovery();
               return; // stop IPC polling — only /health recovery remains
             }
-            setState({ stage, message });
+            setState({ attempt, stage, message });
             timer = setTimeout(tick, pollMs);
           } else {
-            setState({ stage, message });
+            setState({ attempt, stage, message });
             if (stage === 'failed') startFailedRecovery();
           }
         } catch {
@@ -1221,7 +1196,7 @@ export function useBootstrapStage(pollMs = 1000) {
             // HTTP watchdog too, so it can't flip to 'ipc_lost' underneath
             // the already-mounted main UI (#879).
             watchdog.cancel();
-            setState({ stage: 'ready', message: null });
+            setState({ stage: 'ready', message: null, attempt: 0 });
           }
         }
       };

--- a/frontend/src/test/BootstrapSplashObservedStages.test.jsx
+++ b/frontend/src/test/BootstrapSplashObservedStages.test.jsx
@@ -21,6 +21,14 @@
  *     unioned in as independent proof a stage ran;
  *   - a Retry restarts the bootstrap, so stages observed during the previous
  *     attempt must not carry over and render as done in the new one.
+ *
+ * #1900 replaced the attempt-boundary GUESS with a fact. The splash used to
+ * infer a restart from the ~1 s stage poll (arriving at `checking`, or leaving
+ * `failed`), which cannot see a restart that begins and passes those stages
+ * inside one sample window — and cannot see a Rust-side restart that never
+ * passes them at all. Rust now stamps an attempt id on the status reply and on
+ * every log line, and the splash scopes evidence by equality on it. The last
+ * three tests here pin that contract.
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -144,16 +152,16 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
     // Greptile finding on #1896: the observed set was add-only and the splash
     // stays mounted across a Retry, so a stage the FAILED attempt reached
     // would still render done in the new attempt even if that attempt skips
-    // it. Arriving back at `checking` from elsewhere means a new attempt.
-    const { rerender } = render(<BootstrapSplash stage="checking" message={null} />);
-    rerender(<BootstrapSplash stage="downloading_uv" message={null} />);
-    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
-    rerender(<BootstrapSplash stage="failed" message="uv sync failed" />);
+    // it. The restart is Rust's attempt id changing (#1900).
+    const { rerender } = render(<BootstrapSplash stage="checking" message={null} attempt={1} />);
+    rerender(<BootstrapSplash stage="downloading_uv" message={null} attempt={1} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} attempt={1} />);
+    rerender(<BootstrapSplash stage="failed" message="uv sync failed" attempt={1} />);
 
-    // Retry: Rust goes back to `checking`, then this attempt finds the venv
-    // healthy and jumps straight to starting_backend.
-    rerender(<BootstrapSplash stage="checking" message={null} />);
-    rerender(<BootstrapSplash stage="starting_backend" message={null} />);
+    // Retry: Rust opens attempt 2, then this attempt finds the venv healthy
+    // and jumps straight to starting_backend.
+    rerender(<BootstrapSplash stage="checking" message={null} attempt={2} />);
+    rerender(<BootstrapSplash stage="starting_backend" message={null} attempt={2} />);
 
     // Nothing from the previous attempt may be presented as this attempt's
     // completed work — so the install chrome is gone entirely again.
@@ -178,25 +186,27 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
     });
     invoke.mockImplementation(async () => null);
 
-    const { rerender } = render(<BootstrapSplash stage="failed" message="uv sync failed" />);
+    const { rerender } = render(
+      <BootstrapSplash stage="failed" message="uv sync failed" attempt={1} />,
+    );
     await waitFor(() => expect(handlers['bootstrap-log']).toBeTypeOf('function'));
 
-    // User clicks Retry — this opens the new attempt.
+    // User clicks Retry. Rust bumps to attempt 2 inside respawn_backend.
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /^Retry$/ }));
     });
 
     // Rust immediately emits the new attempt's logs, still before the poll
-    // has reported `checking`.
+    // has reported anything — but they are already stamped attempt 2.
     await act(async () => {
       handlers['bootstrap-log']({
-        payload: { stage: 'creating_venv', line: 'Creating virtualenv at .venv' },
+        payload: { attempt: 2, stage: 'creating_venv', line: 'Creating virtualenv at .venv' },
       });
     });
 
     // Only now does the poll catch up, and it never samples creating_venv.
-    rerender(<BootstrapSplash stage="checking" message={null} />);
-    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
+    rerender(<BootstrapSplash stage="checking" message={null} attempt={2} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} attempt={2} />);
 
     // The log line proved creating_venv ran in THIS attempt; it must not have
     // been discarded by a boundary stamped after it arrived.
@@ -209,21 +219,92 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
   it('a retry whose restart stage the poll never sampled still drops the old evidence', () => {
     // CodeRabbit finding on 5e9538a0: a retry can go failed -> checking ->
     // starting_backend inside one ~1s sample window, so the poll observes
-    // only failed -> starting_backend. Keying the reset solely off arriving
-    // at a restart stage would leave the FAILED attempt's stages in place and
-    // present them as this attempt's completed work.
-    const { rerender } = render(<BootstrapSplash stage="checking" message={null} />);
-    rerender(<BootstrapSplash stage="downloading_uv" message={null} />);
-    rerender(<BootstrapSplash stage="installing_deps" message={null} />);
-    rerender(<BootstrapSplash stage="failed" message="uv sync failed" />);
+    // only failed -> starting_backend. The attempt id is stamped by the
+    // producer, so it survives a sample window that swallows the stage.
+    const { rerender } = render(<BootstrapSplash stage="checking" message={null} attempt={1} />);
+    rerender(<BootstrapSplash stage="downloading_uv" message={null} attempt={1} />);
+    rerender(<BootstrapSplash stage="installing_deps" message={null} attempt={1} />);
+    rerender(<BootstrapSplash stage="failed" message="uv sync failed" attempt={1} />);
 
     // Retry — and the poll misses `checking` entirely.
-    rerender(<BootstrapSplash stage="starting_backend" message={null} />);
+    rerender(<BootstrapSplash stage="starting_backend" message={null} attempt={2} />);
 
     expect(screen.getByText('Starting backend…')).toBeInTheDocument();
     // Nothing from the failed attempt may be shown as this attempt's work.
     expect(screen.queryByText('Downloading uv (Python package manager)…')).toBeNull();
     expect(screen.queryByText(/first run, 5.10 min/)).toBeNull();
     expect(screen.queryByText('Installing')).toBeNull();
+  });
+
+  it('a Rust-side restart the poll cannot see at all drops the old evidence', () => {
+    // #1900, the case no amount of stage inference reaches. The supervisor
+    // rebuilds a broken venv on its own: it re-enters `checking` and runs the
+    // whole bootstrap again, with no `failed` stage and no UI-initiated retry.
+    // If the poll samples `installing_deps` on either side of that window, the
+    // stage sequence is `installing_deps` -> `installing_deps` — literally no
+    // signal that anything restarted. The old heuristics kept the previous
+    // attempt's `downloading_uv` and rendered it done for work this attempt
+    // never did. The attempt id changing is the whole signal.
+    const { rerender } = render(
+      <BootstrapSplash stage="downloading_uv" message={null} attempt={1} />,
+    );
+    rerender(<BootstrapSplash stage="installing_deps" message={null} attempt={1} />);
+
+    // Attempt 1 really did download uv, so its step reads as done.
+    expect(screen.getByText('Downloading uv (Python package manager)…').className).toMatch(
+      /text-fg-muted/,
+    );
+
+    // Venv turns out to be broken; Rust quarantines it and starts over. The
+    // poll happens to sample the new attempt at the same stage name, so the
+    // stage sequence carries no evidence of the restart at all.
+    rerender(<BootstrapSplash stage="installing_deps" message={null} attempt={2} />);
+
+    // This attempt has not downloaded uv. Claiming otherwise is the #1894
+    // fabrication, arriving by a route stage inference cannot close.
+    expect(screen.getByText('Downloading uv (Python package manager)…').className).not.toMatch(
+      /text-fg-muted/,
+    );
+  });
+
+  it('a log line from the previous attempt is not counted as this attempt evidence', async () => {
+    // Log lines are the second evidence source, and the one that closes the
+    // poll's blind spot — so they carry the attempt too. A `creating_venv`
+    // line emitted during attempt 1 must not make attempt 2's step list claim
+    // a venv was created, no matter how recently it arrived.
+    window.__TAURI_INTERNALS__ = {};
+    const { listen } = await import('@tauri-apps/api/event');
+    const handlers = {};
+    listen.mockImplementation(async (name, cb) => {
+      handlers[name] = cb;
+      return () => {};
+    });
+
+    const { rerender } = render(
+      <BootstrapSplash stage="installing_deps" message={null} attempt={1} />,
+    );
+    await waitFor(() => expect(handlers['bootstrap-log']).toBeTypeOf('function'));
+
+    await act(async () => {
+      handlers['bootstrap-log']({
+        payload: { attempt: 1, stage: 'creating_venv', line: 'Creating virtualenv at .venv' },
+      });
+    });
+
+    // Proof for attempt 1: the step reads as done.
+    await waitFor(() => {
+      expect(screen.getByText('Creating Python virtual environment…').className).toMatch(
+        /text-fg-muted/,
+      );
+    });
+
+    // Attempt 2 starts, and skips straight past venv creation.
+    rerender(<BootstrapSplash stage="installing_deps" message={null} attempt={2} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Creating Python virtual environment…').className).not.toMatch(
+        /text-fg-muted/,
+      );
+    });
   });
 });

--- a/frontend/src/test/BootstrapSplashObservedStages.test.jsx
+++ b/frontend/src/test/BootstrapSplashObservedStages.test.jsx
@@ -267,6 +267,44 @@ describe('BootstrapSplash — observed-stage tracking (#1894)', () => {
     );
   });
 
+  it('keeps a repeated line that belongs to a different attempt', async () => {
+    // CodeRabbit: the backfill→live seam is deduplicated on stage + text, and
+    // installer output repeats itself constantly. Across a restart the same
+    // stage and the same text is not a replayed line — it is the new attempt's
+    // own evidence, and dropping it can remove the only proof for a stage the
+    // poll never samples. The attempt is part of the identity.
+    window.__TAURI_INTERNALS__ = {};
+    const { invoke } = await import('@tauri-apps/api/core');
+    const { listen } = await import('@tauri-apps/api/event');
+    const handlers = {};
+    listen.mockImplementation(async (name, cb) => {
+      handlers[name] = cb;
+      return () => {};
+    });
+    // Attempt 1 already logged this exact line; it is in the backfill buffer.
+    invoke.mockImplementation(async (cmd) =>
+      cmd === 'get_bootstrap_logs'
+        ? [{ attempt: 1, stage: 'creating_venv', line: 'Creating virtualenv at .venv' }]
+        : null,
+    );
+
+    render(<BootstrapSplash stage="installing_deps" message={null} attempt={2} />);
+    await waitFor(() => expect(handlers['bootstrap-log']).toBeTypeOf('function'));
+
+    // Attempt 2 does the same work and says the same thing.
+    await act(async () => {
+      handlers['bootstrap-log']({
+        payload: { attempt: 2, stage: 'creating_venv', line: 'Creating virtualenv at .venv' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Creating Python virtual environment…').className).toMatch(
+        /text-fg-muted/,
+      );
+    });
+  });
+
   it('a log line from the previous attempt is not counted as this attempt evidence', async () => {
     // Log lines are the second evidence source, and the one that closes the
     // poll's blind spot — so they carry the attempt too. A `creating_venv`


### PR DESCRIPTION
Fixes #1900.

The first-run splash worked out which bootstrap attempt a piece of evidence belonged to by inferring attempt boundaries from the `bootstrap_status` stage, sampled about once a second. Both CodeRabbit and Greptile independently reached the same remedy while reviewing #1896: have the producer emit an attempt id and scope evidence to it.

**Two routes slipped through the inference**

- A retry that goes `failed` → `checking` → `starting_backend` inside one sample window: the poll never sees a restart stage.
- The supervisor's own venv rebuild. It re-enters `checking` with no `failed` stage and no click behind it, and if the poll samples the same stage name on either side, the sequence is `installing_deps` → `installing_deps`. There is literally no signal that anything restarted, so the previous attempt's completed steps stayed on screen as this attempt's work. That is the #1894 fabrication arriving by a route no amount of stage inference can close.

**What changed**

Rust keeps a monotonic `ATTEMPT` counter, bumped wherever the bootstrap really restarts: `respawn_backend` (both retry commands and the scoped reset funnel through it) and the automatic venv rebuild. `bootstrap_status` returns it beside the stage as a flattened `BootstrapStatus`, so the wire shape the frontend already reads is unchanged and only gains a sibling key. Every `bootstrap-log` line carries it too.

The splash scopes stage evidence by equality on that id, and the guesswork is deleted: the restart-stage set, the leaving-`failed` rule, the wall-clock boundary, and the ref that existed only to stop the poll re-stamping a boundary the UI had already opened. Clearing the log on Retry is now presentation, nothing more.

**Verification**

Two new frontend tests cover what only an id can carry — a Rust-side restart the poll cannot see at all, and a log line from the previous attempt that must not count toward this one. Both fail against the previous component and pass now.

- Rust: 240 lib tests green, including four new ones on the counter and the serialized status shape.
- Frontend: 2847 vitest tests green, 344 files.
- `cargo check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Rust now emits a monotonic bootstrap attempt ID with status and log events, and the splash scopes stage evidence to that ID. This removes unreliable frontend boundary inference and covers Rust-initiated restarts, including late backend log output. Review mocked `bootstrap_status` responses and IPC consumers for compatibility with the updated payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->