### PR TITLE
docs(docker): finish the ARM64 Compose guidance (#1987)

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -258,17 +258,30 @@ docker compose -f deploy/docker-compose.yml --profile rocm up -d
 
 > **ARM64 hosts:** Compose has no per-command `--platform` flag, so the
 > override that works for `docker pull` and `docker run` does not reach it.
-> Export `DOCKER_DEFAULT_PLATFORM=linux/amd64` for the shell you run Compose
-> from, or the image resolves to the ARM64 manifest that does not exist and
-> fails with `no matching manifest for linux/arm64/v8`:
+> Set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in the shell you run Compose from,
+> or the image resolves to the ARM64 manifest that does not exist and fails
+> with `no matching manifest for linux/arm64/v8`. Only the CPU profile makes
+> sense under emulation — it is not a GPU workaround.
 >
 > ```bash
 > export DOCKER_DEFAULT_PLATFORM=linux/amd64
+> docker compose -f deploy/docker-compose.yml --profile cpu pull
 > docker compose -f deploy/docker-compose.yml --profile cpu up -d
 > ```
 >
-> Same caveat as above — this is emulation, not native ARM64 support, and only
-> the CPU profile makes sense under it.
+> In PowerShell, set both the administrator key and the platform for the
+> session before running the same two commands:
+>
+> ```powershell
+> $env:OMNIVOICE_API_KEY = python -c "import secrets; print(secrets.token_urlsafe(32))"
+> $env:DOCKER_DEFAULT_PLATFORM = 'linux/amd64'
+> docker compose -f deploy/docker-compose.yml --profile cpu pull
+> docker compose -f deploy/docker-compose.yml --profile cpu up -d
+> ```
+>
+> Either way the setting lives only in that shell and the processes it starts.
+> The [architecture limits](#architecture) still apply: this is emulated CPU
+> inference, not native ARM64 support.
 
 The `docker-compose.yml` shipped in `deploy/` defaults to `127.0.0.1:3900`
 on the host. The backend inside the container binds to `0.0.0.0` so the


### PR DESCRIPTION
docs(docker): finish the ARM64 Compose guidance (#1987)

@yangfan-yf-yf pushed two more commits to #1987 after the first pass landed.
Two things in them were worth taking:

  - an explicit `compose pull` step, so the platform override is proven before
    `up -d` rather than discovered when the pull inside it fails; and
  - a PowerShell form. An ARM64 Windows host cannot use `export`, and the
    surrounding page only ever shows Bash — so the guidance did not actually
    reach the users most likely to need it.

Not taken: the same commits also moved `--platform linux/amd64` into the
default `docker pull` / `docker run` quick start. That is a no-op for the
amd64 majority and contradicts the Architecture section directly above, which
introduces the flag as the conditional ARM64 step. The canonical command stays
the one almost everyone should run.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The Docker ARM64 guidance now adds `docker compose pull` and a PowerShell form for `DOCKER_DEFAULT_PLATFORM=linux/amd64`. This helps ARM64 users prepare images before starting Compose while keeping `--platform linux/amd64` conditional. Review the emulated CPU inference limitation before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->