### PR TITLE
fix(crash): say what the exit code means in the crash details (#1927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The crash details dialog now says what the exit code means and what to try, instead of showing a raw number and a log (#1927)
+
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1952)
 - `bun desktop-prod` and `bun desktop-fresh` find Rust and uv from a terminal opened before they were installed, as `bun desktop` already did; a missing Rust toolchain fails up front with the install steps (#1952)
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1955)

--- a/frontend/src/components/BackendCrashNotice.jsx
+++ b/frontend/src/components/BackendCrashNotice.jsx
@@ -6,6 +6,7 @@ import { Button, Dialog } from '../ui';
 import {
   acknowledgeBackendCrash,
   crashAge,
+  crashCauseHint,
   describeCrashExit,
   getUnacknowledgedBackendCrash,
   hasCrashEvidence,
@@ -77,6 +78,16 @@ export default function BackendCrashNotice() {
   // backend log instead; a real crash (exit code, signal, or a captured tail)
   // keeps the one-click path.
   const reportable = hasCrashEvidence(marker);
+  // What the exit code and the captured tail actually mean, and what to do
+  // about it (#1927). The classifier already knew — a native fault points at a
+  // GPU driver that disagrees with the bundled CUDA runtime, exit 78 at a port
+  // conflict, an import traceback at a half-built environment — but until now
+  // the only surface that showed it was a dropped stream. A user who opened
+  // this dialog after "Backend died (exit code -1073741819)" got a raw number,
+  // a timestamp and a log they cannot read, with nothing to try. A sentinel
+  // marker is excluded on purpose: it does not know a crash happened at all,
+  // so it has no cause to explain.
+  const cause = sentinel ? '' : crashCauseHint(marker);
 
   return (
     <>
@@ -156,6 +167,7 @@ export default function BackendCrashNotice() {
               ? t('crash.details_intro_unclean', { ago })
               : t('crash.details_intro', { exit, ago })}
           </p>
+          {cause && <p className="m-0 text-[length:var(--text-sm)] text-fg">{cause}</p>}
           {!reportable && (
             <p className="m-0 text-[length:var(--text-sm)] text-fg-muted">
               {t('crash.report_needs_log')}

--- a/frontend/src/components/BackendCrashNotice.test.jsx
+++ b/frontend/src/components/BackendCrashNotice.test.jsx
@@ -155,4 +155,57 @@ describe('BackendCrashNotice — sentinel evidence gate (#1375)', () => {
     // so the report path stays even with an empty tail.
     expect(await screen.findByText('Report this bug')).toBeInTheDocument();
   });
+
+  // #1927: the crash details dialog named the exit code and dumped the log,
+  // and stopped there. A Windows access violation reads as
+  // "exit code -1073741819" — a number that means nothing to the person it is
+  // shown to — and the report filed against it had no cause and no next step.
+  // The classifier already knew what it meant; nothing rendered it outside a
+  // dropped stream.
+  it('explains what the exit code means and what to try', async () => {
+    getUnacknowledgedBackendCrash.mockResolvedValue({
+      ...MARKER,
+      exit_code: -1073741819, // STATUS_ACCESS_VIOLATION
+      last_stderr: 'INFO [omnivoice.model] Loading VoiceStudio model on device: cuda',
+    });
+    render(<BackendCrashNotice />);
+    fireEvent.click(await screen.findByRole('button', { name: /view crash details/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    // A native fault is not a memory problem, and the guidance says so.
+    expect(dialog.textContent).toMatch(/compute stack/i);
+    expect(dialog.textContent).toMatch(/GPU driver/i);
+  });
+
+  it('gives a port conflict its own explanation, not the GPU one', async () => {
+    getUnacknowledgedBackendCrash.mockResolvedValue({
+      ...MARKER,
+      exit_code: 78, // EX_CONFIG — the port was already held
+      last_stderr: '',
+    });
+    render(<BackendCrashNotice />);
+    fireEvent.click(await screen.findByRole('button', { name: /view crash details/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.textContent).toMatch(/already in use/i);
+    expect(dialog.textContent).not.toMatch(/GPU driver/i);
+  });
+
+  it('offers no cause for a sentinel marker, which cannot know there was one', async () => {
+    getUnacknowledgedBackendCrash.mockResolvedValue({
+      ...MARKER,
+      exit_code: null,
+      signal: null,
+      exit_desc: 'process ended uncleanly (previous run)',
+      uptime_s: 0,
+      last_stderr: '',
+    });
+    render(<BackendCrashNotice />);
+    fireEvent.click(await screen.findByRole('button', { name: /view crash details/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    // Sleep, force-quit and a stopped VM leave this same trace. Explaining a
+    // crash that may not have happened is the #1375 fabrication.
+    expect(dialog.textContent).not.toMatch(/VRAM|GPU driver|compute stack/i);
+  });
 });


### PR DESCRIPTION
Fixes #1927.

The report is a Windows access violation 13 seconds after `Loading VoiceStudio model on device: cuda` — a native fault inside the compute stack, which produces no Python traceback because the process is executing bad machine code. What the user saw was `Backend died (exit code -1073741819)`, a timestamp, an uptime, and a log that stops mid-startup. The issue they filed has an empty description, which is the honest response to being handed a number and no next step.

**The guidance already existed.** `crashCauseHint` distinguishes a native fault (a GPU driver disagreeing with the bundled CUDA runtime, or a partially downloaded weight file), an exit-78 port conflict, an OOM kill, and a half-built Python environment — and names concrete actions, including the crash-isolated engines. It never reached this surface: the only place it rendered was the error on a stream dropped by a crash, and a crash with no request in flight has no stream to drop.

So the details dialog renders it.

A sentinel marker is deliberately excluded. It cannot know a crash happened at all — sleep, force-quit and a stopped VM leave the same trace — so it has no cause to explain, and asserting one would be the #1375 fabrication in a new place.

**Verification.** Three tests: the access violation gets the compute-stack guidance, a port conflict gets its own rather than the GPU one, and a sentinel gets none. The first two fail against the previous component. 2853 vitest tests green, 345 files.

Related: #1994 fixes why crash logs like this one stop before the death they explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The crash details dialog now explains recognized backend exit codes and recommended actions, including CUDA/GPU guidance, port conflicts, and incomplete Python environments. This helps users diagnose crashes such as Windows exit code `-1073741819` directly from the dialog. Review the classification logic to ensure guidance remains accurate and sentinel markers continue to show no cause explanation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->