### PR TITLE
docs(docker): generate PowerShell keys without Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Docs
 
+- PowerShell Docker setup now generates the administrator key without requiring Python on the host (#1993) — thanks @yangfan-yf-yf!
 - Docker quick starts now explain the AMD64-only images and direct Apple Silicon users to the native macOS app (#1921) — thanks @yangfan-yf-yf!
 - audio.cpp (Breeze-TTS-2) is now a documented opt-in engine: prebuilt binary install, explicit GGUF download, voice modes, and the weights' research/non-commercial terms (#1891)
 - `docs/STRUCTURE.md` describes the tree as it is today, and a test now keeps its counts honest (#1981) — thanks @Dawcraft!

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -273,7 +273,15 @@ docker compose -f deploy/docker-compose.yml --profile rocm up -d
 > session before running the same two commands:
 >
 > ```powershell
-> $env:OMNIVOICE_API_KEY = python -c "import secrets; print(secrets.token_urlsafe(32))"
+> $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+> try {
+>     $keyBytes = New-Object byte[] 32
+>     $rng.GetBytes($keyBytes)
+>     $env:OMNIVOICE_API_KEY = [Convert]::ToBase64String($keyBytes)
+> }
+> finally {
+>     $rng.Dispose()
+> }
 > $env:DOCKER_DEFAULT_PLATFORM = 'linux/amd64'
 > docker compose -f deploy/docker-compose.yml --profile cpu pull
 > docker compose -f deploy/docker-compose.yml --profile cpu up -d


### PR DESCRIPTION
## Summary

The PowerShell Docker Compose example added in #1993 requires Python on the host to generate the administrator key. On a Windows host without Python, that step fails before Compose can start.

I replaced the key-generation line with built-in .NET cryptography APIs that work in Windows PowerShell 5.1.

## Changes

- Generate 32 random bytes, encode them as Base64, and dispose of the random-number generator in `finally`.
- Keep the platform override and both Compose commands unchanged.
- Add a short changelog entry.

Follow-up to the [review discussion on #1993](https://github.com/debpalash/VoiceStudio/pull/1993#discussion_r3976308121).

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [ ] 🧪 Tests
- [ ] 🔧 CI / Build
- [ ] 🚀 Release prep

## Testing

- I extracted the updated example from the documentation and parsed the complete block in Windows PowerShell 5.1 with zero syntax errors.
- I ran only its key-generation portion twice with `PATH` unset and Python unavailable: both outputs were 44-character Base64 strings decoding to 32 bytes, and the outputs differed. The previous Python command failed in that environment. No generated key was printed.
- `python -m pytest --noconftest -o addopts= -p no:cacheprovider tests/test_changelog_style.py tests/test_docker_admin_auth_docs.py -k 'not server_mode' -q`: 13 passed, 2 deselected. The two backend server-mode tests are outside this documentation change.
- `python scripts/validate-install-docs.py`: 3 installation documentation blocks passed.
- `git diff --check` passed.

I did not start containers or run a model; this verifies the PowerShell example and documentation checks.

## Checklist

- [x] I've tested this locally
- [x] I've updated relevant documentation (if applicable)
- [x] No local machine paths, logs, or personal env details in this PR
- [ ] Version files are in sync (if version bump): `pyproject.toml`, `package.json`, `tauri.conf.json`, `Cargo.toml`
- [ ] If this PR changes runtime behavior, the regression fixture at `tests/fixtures/omnivoice_data/` still loads green on the `smoke-matrix` CI job (macOS + Windows + Linux)

The version-bump and runtime-fixture items do not apply to this documentation-only change.

## Release cadence

VoiceStudio ships **continuous-to-main** — no release candidates, no soak windows.
Every merged PR is immediately part of the rolling preview (`main`, Docker
`:latest`, the desktop Preview channel). Versioned releases are tagged from
`main` when it's ready; `main` then bumps to the next patch automatically.
Users who want stability pin a release tag / Docker `:stable` / the desktop
Stable channel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the PowerShell Docker Compose example to generate `OMNIVOICE_API_KEY` with .NET cryptography APIs, removing the host Python requirement. This supports Windows PowerShell 5.1 while preserving the existing Compose commands. No additional merge risk was identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->