### PR TITLE
test: make the isolated backend session pass on Windows, and gate it there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,20 @@ jobs:
           HF_HUB_OFFLINE: "1"  # same no-silent-downloads guard as the main pytest job
           HF_HUB_CACHE: ${{ runner.temp }}/pockettts-empty-hf-cache
 
+      # The isolated backend session, on Windows. The `test` job runs it on
+      # Linux only, which is how four tests that CANNOT pass on Windows shipped
+      # unnoticed: two reach for os.WNOHANG and os.waitid (POSIX-only, an
+      # AttributeError before the first assertion), one asserts a RuntimeError
+      # that `backend_drain_fd` returns None instead of raising off POSIX, and
+      # one raced the OS reaping a crashed child — a race Linux won and Windows
+      # lost every time. All four were invisible to CI and hit every Windows
+      # contributor on their first `pytest` run. Forty seconds closes the class.
+      - name: Isolated backend session (Windows)
+        if: runner.os == 'Windows' && matrix.backend_supported
+        run: uv run --no-sync pytest backend/tests/ -q --tb=short
+        env:
+          HF_HUB_OFFLINE: "1"
+
       # Artifact commits depend on native Windows rename/replace semantics;
       # Linux emulation cannot exercise sharing rules or path parsing.
       - name: Remote-worker artifact paths (Windows)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- The isolated backend test session passes on a stock Windows checkout, and CI now runs it there so it stays that way (#1990)
+
 - Windows contributors can run the test suite without Developer Mode: tests that create a symlink now skip instead of failing with `WinError 1314` (#1990)
 
 - Windows desktop launches no longer freeze at "Loading ML runtime (PyTorch)": the parent-liveness watchdog polls the stdin pipe instead of leaving a read pending, which deadlocked numpy's OpenBLAS initializer (#1952)

--- a/backend/tests/test_contained_subprocess.py
+++ b/backend/tests/test_contained_subprocess.py
@@ -120,6 +120,7 @@ def test_drain_fd_is_explicitly_inherited_by_wrapper_but_not_operation(monkeypat
             proc.wait(timeout=5)
 
 
+@pytest.mark.skipif(os.name != "posix", reason="Unix drain pipe contract")
 def test_invalid_or_missing_desktop_drain_fd_fails_safe(monkeypatch):
     monkeypatch.setenv("OMNIVOICE_DESKTOP_CONTAINED", "1")
     monkeypatch.setenv("OMNIVOICE_DESKTOP_DRAIN_FD", "not-an-fd")

--- a/backend/tests/test_contained_subprocess_waitid_fallback.py
+++ b/backend/tests/test_contained_subprocess_waitid_fallback.py
@@ -15,6 +15,15 @@ import pytest
 
 from core import contained_subprocess as owned
 
+# This module simulates macOS by deleting os.waitid, then drives the fallback
+# with os.waitpid/os.WNOHANG and start_new_session — POSIX-only APIs that
+# Windows does not have at all (os.WNOHANG raises AttributeError before the
+# first assertion). CI runs this suite on Linux, so nothing is lost by
+# skipping; what is gained is a Windows contributor whose checkout runs green.
+pytestmark = pytest.mark.skipif(
+    os.name != "posix", reason="simulates a POSIX platform without os.waitid"
+)
+
 
 def _make_owned(argv):
     cr, cw = os.pipe()

--- a/backend/tests/test_omnivoice_subprocess.py
+++ b/backend/tests/test_omnivoice_subprocess.py
@@ -472,7 +472,17 @@ def test_mps_proxy_survives_fatal_child_exit_and_recovers(stub_sidecar, monkeypa
     try:
         with pytest.raises(RuntimeError, match="backend is still running"):
             b.generate("CRASH")
-        assert b._proc is not None and b._proc.poll() is not None
+        assert b._proc is not None
+        # The child called os._exit; the parent raised the moment its pipe hit
+        # EOF, which is BEFORE the OS has reaped the process. Asserting poll()
+        # on the next line is a race the test happened to win on Linux and lost
+        # every time on Windows. Wait for the death instead of assuming it has
+        # already been observed — the claim is that the child is gone, not that
+        # it is gone within one instruction.
+        deadline = time.monotonic() + 5
+        while b._proc.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert b._proc.poll() is not None, "the crashed sidecar never died"
         assert b.generate("ok").shape[1] == 24000
     finally:
         b.shutdown()


### PR DESCRIPTION
Same class as #1990, found while verifying current main on Windows.

Four tests in `backend/tests/` cannot pass on a stock Windows checkout. The `test` job runs that session on Linux only, so all four were invisible to CI and hit every Windows contributor on their first `pytest` run, with failures that have nothing to do with whatever they changed.

- **`test_contained_subprocess_waitid_fallback.py`** simulates macOS by deleting `os.waitid`, then drives the fallback with `os.waitpid` / `os.WNOHANG` and `start_new_session`. Windows has none of those; `os.WNOHANG` is an `AttributeError` before the first assertion. The module is POSIX-only by premise, so it now says so.
- **`test_invalid_or_missing_desktop_drain_fd_fails_safe`** asserts a `RuntimeError` that cannot be raised off POSIX: `backend_drain_fd` returns `None` there before it ever reads the environment. The file already carried this exact skipif on its sibling.
- **`test_mps_proxy_survives_fatal_child_exit_and_recovers`** raced the OS. The child calls `os._exit` and the parent raises the moment its pipe hits EOF, which is *before* the process is reaped. Asserting `poll()` on the next line is a race Linux won and Windows lost every time. It waits for the death now, which is what the test actually claims.

**Then the reason all four survived.** Nothing runs this session on Windows. The smoke matrix already does a full `uv sync` there, so the session costs forty seconds and now runs as a step in it.

Verified green on Windows before adding the gate — 355 passed, 8 skipped — so this cannot break main.

Kept to Windows deliberately: that is the platform I can verify here, and adding the gate blind on macOS would be a guess about a host I cannot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The isolated backend session now passes on Windows by skipping POSIX-only tests and waiting for child-process reaping before status checks. CI runs this session in the Windows smoke matrix and reports 355 passed and 8 skipped. Review the skipped tests to confirm the reduced Windows coverage is intentional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->