### PR TITLE
test(worker): stop spinning the loop the awaited work needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- A remote-worker test no longer fails at random on Windows CI: it waited for a background thread by spinning the event loop that thread's work needed (#1990)
+
 - The isolated backend test session passes on a stock Windows checkout, and CI now runs it there so it stays that way (#1990)
 
 - Windows contributors can run the test suite without Developer Mode: tests that create a symlink now skip instead of failing with `WinError 1314` (#1990)

--- a/tests/test_worker_upload_server.py
+++ b/tests/test_worker_upload_server.py
@@ -38,6 +38,22 @@ from worker.transport.server import REQUIRED_FEATURES, SESSION_METADATA_KEY, Wor
 ENGINE, MODEL, OP = "indextts", "IndexTTS-2", "tts"
 
 
+async def _await_event(event, what, timeout=15.0):
+    """Block on a threading.Event without spinning the event loop.
+
+    The obvious `while not event.is_set(): await asyncio.sleep(0)` yields to
+    the loop but never sleeps, so it runs the loop flat out on the same thread
+    the awaited work needs to make progress. On a loaded Windows runner that
+    starves the task setting the event and the wait times out with nothing
+    actually wrong — a flake with no signal in it. `to_thread` parks the wait
+    on a worker thread and leaves the loop free, which is both faster and
+    deterministic.
+    """
+    assert await asyncio.to_thread(event.wait, timeout), (
+        f"{what} did not happen within {timeout}s"
+    )
+
+
 def test_artifact_fsync_uses_a_windows_compatible_descriptor(tmp_path, monkeypatch):
     artifact = tmp_path / "artifact.wav"
     artifact.write_bytes(b"audio")
@@ -713,11 +729,7 @@ async def test_revocation_during_result_barrier_cannot_ack_published_bytes(
         plane.upload(_chunks(_ref(plane, task, attempt, payload=payload), payload))
     )
 
-    async def wait_for_barrier():
-        while not barrier_finished.is_set():
-            await asyncio.sleep(0)
-
-    await asyncio.wait_for(wait_for_barrier(), timeout=1)
+    await _await_event(barrier_finished, "the durability barrier")
     assert os.path.isfile(final)
     assert plane.servicer.revoke_worker_sessions(plane.worker_id) == 1
     release_barrier.set()


### PR DESCRIPTION
`Smoke (Windows)` fails intermittently in `test_revocation_during_result_barrier_cannot_ack_published_bytes` with a bare `TimeoutError`. It hit two PRs in a row today, one of them documentation-only, which rules out any change under review.

**The wait is a busy loop.**

```python
while not barrier_finished.is_set():
    await asyncio.sleep(0)
```

`asyncio.sleep(0)` yields to the loop but never sleeps, so this runs the loop flat out on the one thread the upload task also needs to reach `_durable_replace` and set the event. On a loaded Windows runner the waiter starves the worker it is waiting for, and the 1 s cap fires with nothing actually wrong. A failure with no signal in it is worse than no test.

`_await_event` parks the wait on a worker thread with `asyncio.to_thread`, leaving the loop free. Deterministic, and faster: the test drops from a full second of spinning to the time the work actually takes.

**Deliberately narrow.** The other spin-waits in this file sit inside `assert elapsed < 0.2` blocks that exist to prove the gRPC loop stayed *responsive* during a blocking call. Spinning is the measurement there, and converting them would delete the assertion's meaning.

123 tests across both worker files pass; the target test passes three runs in a row locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ypcgSsh5j2PEonSJiAU1S


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `_await_event` to use `asyncio.to_thread` when waiting for `threading.Event`. This prevents event-loop starvation that caused intermittent `TimeoutError` failures on loaded Windows runners. Other spin-waits remain unchanged because they test gRPC loop responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->