### PR TITLE
fix: surface IPA/CMU pronunciation entries as not-yet-applied (#1949)

### DIFF
--- a/backend/api/routers/pronunciation.py
+++ b/backend/api/routers/pronunciation.py
@@ -249,12 +249,13 @@ def test_substitution(req: PronTestRequest):
             "FROM pronunciation_entries"
         ).fetchall()
     substituted = apply_pronunciation(req.text, rows, req.language)
-    applied = entries_for_language(rows, req.language)
+    applied, skipped = entries_for_language(rows, req.language, include_skipped=True)
     return {
         "input": req.text,
         "substituted": substituted,
         "changed": substituted != req.text,
         "applied_terms": sorted(applied.keys(), key=len, reverse=True),
+        "skipped_terms": skipped,
     }
 
 

--- a/backend/services/pronunciation.py
+++ b/backend/services/pronunciation.py
@@ -176,7 +176,9 @@ def _lang_prefix(language: Optional[str]) -> Optional[str]:
     return s[:2]
 
 
-def entries_for_language(entries, language: Optional[str]) -> dict[str, str]:
+def entries_for_language(
+    entries, language: Optional[str], *, include_skipped: bool = False
+):
     """Collapse DB rows into a ``{term: replacement}`` map for ``apply_lexicon``.
 
     Filters to ``enabled`` rows whose scope is global (``*``) OR whose language
@@ -189,12 +191,18 @@ def entries_for_language(entries, language: Optional[str]) -> dict[str, str]:
 
     ``entries`` is any iterable of mappings/rows with ``term``, ``replacement``,
     ``type``, ``language``, ``enabled`` keys (a ``sqlite3.Row`` works directly).
+
+    If ``include_skipped`` is True, also returns a list of in-scope entries that
+    were dropped because their type isn't ``respelling`` yet (Phase 1 has no
+    substitution for them) — used by ``/pronunciation/test`` to report a
+    matching-but-inert entry instead of silently reporting no match at all.
     """
     req_prefix = _lang_prefix(language)
     # Two passes so language rows win over global rows on the same term: collect
     # global first, then overlay matching-language rows.
     glob: dict[str, str] = {}
     lang: dict[str, str] = {}
+    skipped: list[dict] = []
     for e in entries:
         try:
             if not int(e["enabled"]):
@@ -206,19 +214,26 @@ def entries_for_language(entries, language: Optional[str]) -> dict[str, str]:
             continue
         etype = (e["type"] or "respelling").strip().lower()
         replacement = e["replacement"] if e["replacement"] is not None else ""
+        scope = (e["language"] or _ALL_LANG).strip() or _ALL_LANG
+        scope_matches = scope == _ALL_LANG or (
+            req_prefix is not None and scope[:2].lower() == req_prefix
+        )
         # Phase 1: only respelling rows substitute text. IPA/CMU rows without a
         # respelling fall through (Phase 2 lowers them to engine markup); we do
-        # NOT feed a raw IPA string into the grapheme stream.
+        # NOT feed a raw IPA string into the grapheme stream. If the caller wants
+        # to know, record the skip instead of silently dropping it.
         if etype != "respelling":
+            if include_skipped and scope_matches:
+                skipped.append({"term": term, "type": etype, "language": scope})
             continue
-        scope = (e["language"] or _ALL_LANG).strip() or _ALL_LANG
         if scope == _ALL_LANG:
             glob[term] = str(replacement)
-        else:
-            if req_prefix is not None and scope[:2].lower() == req_prefix:
-                lang[term] = str(replacement)
+        elif scope_matches:
+            lang[term] = str(replacement)
     merged = dict(glob)
     merged.update(lang)  # language rows override global on the same term
+    if include_skipped:
+        return merged, skipped
     return merged
 
 

--- a/frontend/src/components/settings/PronunciationPanel.jsx
+++ b/frontend/src/components/settings/PronunciationPanel.jsx
@@ -304,8 +304,13 @@ export default function PronunciationPanel() {
                 aria-label={t('pronunciation.enable_entry', { term: e.term })}
                 data-testid={`pron-toggle-${e.id}`}
               />
-              <Badge tone="neutral">{typeLabel(e.type)}</Badge>
+                            <Badge tone="neutral">{typeLabel(e.type)}</Badge>
               <Badge tone="neutral">{scopeLabel(e.scope || e.language)}</Badge>
+              {e.type !== 'respelling' && (
+                <Badge tone="warning" data-testid={`pron-not-applied-${e.id}`}>
+                  {t('pronunciation.not_applied_badge')}
+                </Badge>
+              )}
               <Button
                 variant="danger"
                 size="sm"
@@ -414,7 +419,7 @@ export default function PronunciationPanel() {
           </>
         }
       />
-      {testOut && (
+            {testOut && (
         <p className="perfpanel__help" data-testid="pron-test-out">
           {testOut.changed ? (
             <>
@@ -423,6 +428,13 @@ export default function PronunciationPanel() {
           ) : (
             t('pronunciation.test_nochange')
           )}
+        </p>
+      )}
+      {testOut?.skipped_terms?.length > 0 && (
+        <p className="perfpanel__help" data-testid="pron-test-skipped">
+          {t('pronunciation.test_skipped', {
+            terms: testOut.skipped_terms.map((s) => s.term).join(', '),
+          })}
         </p>
       )}
       {testError && (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -26,6 +26,8 @@
     "test_placeholder": "Type a sentence to preview the substitution…",
     "test_result": "Will be spoken as:",
     "test_nochange": "No entries match — spoken as written.",
+    "test_skipped": "Note: {{terms}} matched an IPA/CMU entry, but those aren't applied yet — only Respelling entries take effect.",
+    "not_applied_badge": "Not yet applied",
     "load_error": "Couldn't load the pronunciation dictionary.",
     "save_error": "Couldn't save that entry.",
     "lang_label": "Language code (e.g. en, de) or leave blank for Global",

--- a/frontend/src/test/PronunciationPanel.test.jsx
+++ b/frontend/src/test/PronunciationPanel.test.jsx
@@ -68,6 +68,31 @@ describe('PronunciationPanel', () => {
     expect(screen.getAllByText('Global').some((el) => el.tagName !== 'OPTION')).toBe(true);
   });
 
+  it('badges an IPA/CMU entry as not yet applied', async () => {
+    apiJson.mockResolvedValueOnce([
+      {
+        id: 'e3',
+        term: 'Nevada',
+        replacement: 'N AH0 V AE1 D AH0',
+        type: 'cmu',
+        language: 'en',
+        scope: 'en',
+        enabled: true,
+      },
+    ]);
+    render(withI18n(<PronunciationPanel />));
+    expect(await screen.findByText('Nevada')).toBeInTheDocument();
+    expect(screen.getByTestId('pron-not-applied-e3')).toBeInTheDocument();
+  });
+
+  it('does not badge a respelling entry as not yet applied', async () => {
+    apiJson.mockResolvedValueOnce(ENTRIES);
+    render(withI18n(<PronunciationPanel />));
+    await screen.findByText('GIF');
+    expect(screen.queryByTestId('pron-not-applied-e1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pron-not-applied-e2')).not.toBeInTheDocument();
+  });
+
   it('shows the empty hint when there are no entries', async () => {
     apiJson.mockResolvedValueOnce([]);
     render(withI18n(<PronunciationPanel />));
@@ -163,6 +188,39 @@ describe('PronunciationPanel', () => {
     await screen.findByTestId('pron-test-input');
     fireEvent.change(screen.getByTestId('pron-test-input'), { target: { value: 'a GIF' } });
     expect(await screen.findByTestId('pron-test-out')).toHaveTextContent('a jiff');
+  });
+
+  it('surfaces skipped IPA/CMU terms from the test preview', async () => {
+    apiJson.mockImplementation((path) => {
+      if (path === '/pronunciation/test') {
+        return Promise.resolve({
+          input: 'Nevada',
+          substituted: 'Nevada',
+          changed: false,
+          applied_terms: [],
+          skipped_terms: [{ term: 'Nevada', type: 'cmu', language: 'en' }],
+        });
+      }
+      return Promise.resolve(ENTRIES);
+    });
+    render(withI18n(<PronunciationPanel />));
+    await screen.findByTestId('pron-test-input');
+    fireEvent.change(screen.getByTestId('pron-test-input'), { target: { value: 'Nevada' } });
+    expect(await screen.findByTestId('pron-test-skipped')).toHaveTextContent('Nevada');
+  });
+
+  it('shows no skipped-terms note when nothing was skipped', async () => {
+    apiJson.mockImplementation((path) => {
+      if (path === '/pronunciation/test') {
+        return Promise.resolve({ substituted: 'a jiff', changed: true, skipped_terms: [] });
+      }
+      return Promise.resolve(ENTRIES);
+    });
+    render(withI18n(<PronunciationPanel />));
+    await screen.findByTestId('pron-test-input');
+    fireEvent.change(screen.getByTestId('pron-test-input'), { target: { value: 'a GIF' } });
+    await screen.findByTestId('pron-test-out');
+    expect(screen.queryByTestId('pron-test-skipped')).not.toBeInTheDocument();
   });
 
   it('sends the selected preview language so language-scoped entries apply', async () => {


### PR DESCRIPTION
Addresses #1949, scoped to the minimum fix as discussed in my claim comment.

## What this does
- `entries_for_language()` now optionally returns which IPA/CMU entries matched but were skipped (Phase 1 only substitutes respelling rows)
- `/pronunciation/test` surfaces this as a new `skipped_terms` field, additive to the existing response shape
- Settings → Pronunciation now badges IPA/CMU entries as "Not yet applied" and notes it in the test preview

## What this doesn't do
Phase 2 (actual CMU/IPA lowering to engine markup) is intentionally out of scope here — happy to look at that separately once this lands.

## Testing
- All 39 existing tests in `tests/test_pronunciation.py` pass unmodified, including `test_ipa_row_never_enters_the_grapheme_stream`
- Added 4 new frontend tests covering the badge and the preview message (21/21 passing in `PronunciationPanel.test.jsx`)
- Manually verified via the backend API that a CMU entry now reports `skipped_terms` instead of silently reporting no match