### PR TITLE
fix(dictation): pill window, card and stale model on Windows (#2009, #2012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ the frozen-backend fallback mirror it for their toolchains.
 
 ### Fixed
 
+- Closing the dictation pill on Windows removes it from the screen: an empty dark rectangle used to stay there, always on top, until the app was quit (#2009)
+
 - The remote-worker loop-responsiveness tests no longer turn a build red over milliseconds of scheduling noise on shared CI hardware (#1990)
 - Remote GPU workers work when the machine running VoiceStudio is on Windows: a staged input is now identified the same way on every operating system, instead of with a path only Windows can read (#2005)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ the frozen-backend fallback mirror it for their toolchains.
 ### Fixed
 
 - Closing the dictation pill on Windows removes it from the screen: an empty dark rectangle used to stay there, always on top, until the app was quit (#2009)
+- The dictation pill on Windows no longer sits inside a bordered card wider than the pill itself (#2009)
+- Dictation uses the model you picked instead of one remembered from before the backend started, so it stops reporting no speech-to-text model while one is installed — and when none is, the main window offers the download (#2012)
 
 - The remote-worker loop-responsiveness tests no longer turn a build red over milliseconds of scheduling noise on shared CI hardware (#1990)
 - Remote GPU workers work when the machine running VoiceStudio is on Windows: a staged input is now identified the same way on every operating system, instead of with a path only Windows can read (#2005)

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -831,15 +831,22 @@ pub(crate) fn show_pill_noactivate(win: &tauri::WebviewWindow) {
 ///
 /// Split out so a test can pin the contract that the bug broke: Tauri's own
 /// `show` must run, and it must run FIRST. A native-only show is what left an
-/// empty pill window stranded on the desktop, and neither half can be dropped
-/// — so neither half can be dropped silently either.
+/// empty pill window stranded on the desktop.
+///
+/// And when Tauri's show FAILS, the native show must not run at all (Greptile).
+/// Showing it natively anyway puts an always-on-top window on screen that
+/// Tauri believes is hidden — the exact stranded-window bug, reached by a
+/// different door. A pill that does not appear is the lesser failure: the
+/// tray's red dot still says the user is being recorded, and nothing is left
+/// behind that cannot be removed.
 pub(crate) fn show_pill_noactivate_with<T, N>(show_tauri: T, show_native: N)
 where
     T: FnOnce() -> Result<(), String>,
     N: FnOnce() -> Result<(), String>,
 {
     if let Err(error) = show_tauri() {
-        log::warn!("pill: Tauri show failed, visibility state may drift: {error}");
+        log::warn!("pill: Tauri show failed; not showing it natively either, or it could never be hidden: {error}");
+        return;
     }
     if let Err(error) = show_native() {
         log::warn!("pill: non-activating show failed ({error}) (#982)");
@@ -879,10 +886,12 @@ mod pill_noactivate_tests {
     }
 
     #[test]
-    fn a_failing_tauri_show_still_puts_the_pill_on_screen() {
-        // Degrading to the old behaviour beats not showing the pill at all:
-        // the user can still see they are being recorded. The drift is logged
-        // rather than silent.
+    fn a_failing_tauri_show_does_not_fall_back_to_a_native_one() {
+        // Greptile: a native-only show after Tauri's show failed puts an
+        // always-on-top window on screen that Tauri believes is hidden, so
+        // neither dismiss() nor the idle reconcile can ever remove it — the
+        // stranded-window bug again. A pill that does not appear is the lesser
+        // failure; the tray's red dot still signals recording.
         let mut native_ran = false;
         show_pill_noactivate_with(
             || Err("no window".to_string()),
@@ -891,7 +900,7 @@ mod pill_noactivate_tests {
                 Ok(())
             },
         );
-        assert!(native_ran, "the pill must still appear when Tauri's show fails");
+        assert!(!native_ran, "a native show after a failed Tauri show strands an unhidable window");
     }
 
     #[test]

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1221,6 +1221,15 @@ pub fn run() {
                 .resizable(false)
                 .transparent(true)
                 .decorations(false)
+                // No window shadow. On Windows, Tauri's default (`true`) gives
+                // an undecorated window a 1px white border and, on Windows 11,
+                // rounded corners — drawn around the WHOLE 460x164 window, not
+                // the pill inside it, which is at most 284px wide. The result
+                // is a visible card framing empty space around the capsule,
+                // there whether the pill is showing or not. The capsule draws
+                // its own edge and shadow in CSS; the window must draw nothing.
+                // (Unsupported on Linux, where it was never the problem.)
+                .shadow(false)
                 .always_on_top(true)
                 .visible(false)
                 .focused(false)

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -794,24 +794,105 @@ fn mark_pill_noactivate(win: &tauri::WebviewWindow) {
 
 /// Show the pill without granting it foreground activation.
 ///
-/// The only correct way to show it on Windows (#982): a plain `show()` steals
-/// foreground from the app being dictated into, and the paste then lands in the
-/// pill instead of the user's document. `show_dictation_pill` is the call site.
+/// Two steps, and both are load-bearing.
+///
+/// `win.show()` is what tells TAURI the window is visible. Raw `ShowWindow`
+/// alone puts it on screen behind Tauri's back, and Tauri goes on believing it
+/// is hidden — so `isVisible()` answers `false` while the user is looking at
+/// the thing, `hide()` becomes a no-op on a window it thinks is already
+/// hidden, and the capture widget's idle reconcile (which asks `isVisible()`
+/// before deciding to clean up) concludes there is nothing to clean up. The
+/// result is an empty dark rectangle stranded on the desktop after the pill is
+/// dismissed, with no way to remove it short of quitting the app.
+///
+/// `SW_SHOWNOACTIVATE` is what keeps the foreground where it belongs (#982): a
+/// pill that steals focus makes the paste land in the pill instead of the
+/// user's document. `WS_EX_NOACTIVATE` is already on the window from
+/// `mark_pill_noactivate` at creation, which is what makes the `show()` above
+/// safe — the style bit, not the show flag, is what actually refuses
+/// activation. The flag stays anyway: it costs nothing and holds even if the
+/// style bit could not be applied (`hwnd()` can fail).
 #[cfg(target_os = "windows")]
 pub(crate) fn show_pill_noactivate(win: &tauri::WebviewWindow) {
     use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_SHOWNOACTIVATE};
-    let Ok(hwnd) = win.hwnd() else {
-        log::warn!("pill: could not resolve HWND for non-activating show (#982)");
-        return;
-    };
-    unsafe {
-        let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+    show_pill_noactivate_with(
+        || win.show().map_err(|error| error.to_string()),
+        || {
+            let hwnd = win.hwnd().map_err(|_| "no HWND".to_string())?;
+            unsafe {
+                let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            }
+            Ok(())
+        },
+    )
+}
+
+/// The ordering itself, with both shows as parameters.
+///
+/// Split out so a test can pin the contract that the bug broke: Tauri's own
+/// `show` must run, and it must run FIRST. A native-only show is what left an
+/// empty pill window stranded on the desktop, and neither half can be dropped
+/// — so neither half can be dropped silently either.
+pub(crate) fn show_pill_noactivate_with<T, N>(show_tauri: T, show_native: N)
+where
+    T: FnOnce() -> Result<(), String>,
+    N: FnOnce() -> Result<(), String>,
+{
+    if let Err(error) = show_tauri() {
+        log::warn!("pill: Tauri show failed, visibility state may drift: {error}");
+    }
+    if let Err(error) = show_native() {
+        log::warn!("pill: non-activating show failed ({error}) (#982)");
     }
 }
 
 #[cfg(test)]
 mod pill_noactivate_tests {
-    use super::{with_noactivate_style, WS_EX_NOACTIVATE_BIT};
+    use super::{show_pill_noactivate_with, with_noactivate_style, WS_EX_NOACTIVATE_BIT};
+
+    #[test]
+    fn showing_the_pill_tells_tauri_before_it_tells_windows() {
+        // The bug: only the raw Win32 show ran, so the window went on screen
+        // behind Tauri's back. Tauri then answered `isVisible()` with false
+        // while the user was looking at it, `hide()` did nothing on a window
+        // it believed was already hidden, and the widget's idle reconcile —
+        // which asks `isVisible()` before cleaning up — concluded there was
+        // nothing to clean up. An empty rectangle stayed on the desktop until
+        // the app was quit.
+        use std::cell::RefCell;
+        let order = RefCell::new(Vec::new());
+        show_pill_noactivate_with(
+            || {
+                order.borrow_mut().push("tauri");
+                Ok(())
+            },
+            || {
+                order.borrow_mut().push("native");
+                Ok(())
+            },
+        );
+        assert_eq!(
+            order.into_inner(),
+            ["tauri", "native"],
+            "Tauri's own show must run, and run first"
+        );
+    }
+
+    #[test]
+    fn a_failing_tauri_show_still_puts_the_pill_on_screen() {
+        // Degrading to the old behaviour beats not showing the pill at all:
+        // the user can still see they are being recorded. The drift is logged
+        // rather than silent.
+        let mut native_ran = false;
+        show_pill_noactivate_with(
+            || Err("no window".to_string()),
+            || {
+                native_ran = true;
+                Ok(())
+            },
+        );
+        assert!(native_ran, "the pill must still appear when Tauri's show fails");
+    }
 
     #[test]
     fn adds_noactivate_bit_without_clobbering_existing_style() {

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -37,6 +37,7 @@
         "fullscreen": false,
         "transparent": true,
         "decorations": false,
+        "shadow": false,
         "alwaysOnTop": true,
         "visible": false,
         "skipTaskbar": true,

--- a/frontend/src-tauri/tauri.macos.conf.json
+++ b/frontend/src-tauri/tauri.macos.conf.json
@@ -27,6 +27,7 @@
         "fullscreen": false,
         "transparent": true,
         "decorations": false,
+        "shadow": false,
         "alwaysOnTop": true,
         "visible": false,
         "skipTaskbar": true,

--- a/frontend/src/components/CaptureWidget.jsx
+++ b/frontend/src/components/CaptureWidget.jsx
@@ -369,6 +369,10 @@ function errorLabel(t, info) {
       return t('capture.paste_error');
     case 'mic':
       return t('capture.mic_denied');
+    case 'asr_missing':
+      // Not "Transcription failed: …" — nothing was transcribed or failed; a
+      // model is absent, and the fix is to install one.
+      return t('asr_missing.message');
     default:
       return t('capture.transcription_failed', { message: info?.message || '' });
   }
@@ -421,6 +425,7 @@ export default function CaptureWidget({ onDismiss }) {
   // re-subscribing on every pref change.
   const modeRef = useRef(dictationMode);
   const enabledRef = useRef(dictationEnabled);
+  /** @type {React.MutableRefObject<null | { pending: boolean, ok: boolean, promise: Promise<void> | null }>} */
   const prefsHydrationRef = useRef(null);
   useEffect(() => {
     modeRef.current = dictationMode;
@@ -428,16 +433,42 @@ export default function CaptureWidget({ onDismiss }) {
   useEffect(() => {
     enabledRef.current = dictationEnabled;
   }, [dictationEnabled]);
-  const ensureDictationPrefsHydrated = useCallback(() => {
-    if (!prefsHydrationRef.current) {
-      prefsHydrationRef.current = Promise.resolve()
+  // Load the persisted dictation prefs into THIS window's store.
+  //
+  // The widget is its own window with its own store, created at app start —
+  // usually before the backend is listening. It used to hydrate exactly once
+  // and memoize the promise whether or not the load worked, so a startup
+  // failure pinned the store's seed model (`sherpa-whisper-tiny`) for the life
+  // of the app. The main window, which loaded fine, checked the model the user
+  // actually picked and said "ready"; the widget then asked the server for the
+  // seed, which was not installed, and the pill reported "No speech-to-text
+  // model is installed" with Parakeet sitting on disk. Nothing in the main
+  // window could tell, because the loader marked itself loaded either way.
+  //
+  // So: only a load the backend actually answered is kept. A failed one is
+  // retried by the next caller. And a capture start passes `fresh`, which
+  // re-reads even after a success — the model can be changed from the main
+  // window (Transcriptions, Settings) and this store is not the one that
+  // changed. An in-flight load is always shared rather than duplicated.
+  const ensureDictationPrefsHydrated = useCallback(
+    ({ fresh = false } = {}) => {
+      const current = prefsHydrationRef.current;
+      if (current && (current.pending || (current.ok && !fresh))) return current.promise;
+      const entry = { pending: true, ok: false, promise: null };
+      prefsHydrationRef.current = entry;
+      entry.promise = Promise.resolve()
         .then(() => loadDictationPrefs())
+        .then((loaded) => {
+          // A loader that predates the boolean resolves undefined on success.
+          entry.ok = loaded !== false;
+        })
         .catch((err) => {
           // The store keeps its cross-platform seeds when the backend is not
           // ready. Readiness must still resolve so the native hotkey can work.
           console.warn('dictation prefs hydration failed:', err);
         })
         .then(() => {
+          entry.pending = false;
           // Zustand updates before loadDictationPrefs resolves, but React's
           // selector effects may render later. Synchronise the long-lived
           // native listener refs now so its first event cannot use seed prefs.
@@ -449,9 +480,10 @@ export default function CaptureWidget({ onDismiss }) {
             modeRef.current = prefs.dictationMode;
           }
         });
-    }
-    return prefsHydrationRef.current;
-  }, [loadDictationPrefs]);
+      return entry.promise;
+    },
+    [loadDictationPrefs],
+  );
   // `state` follows the same rule, and for a sharper reason than the prefs do.
   // The tray listener used to depend on [state], so every single state change
   // tore the Tauri listener down and re-attached it through an `await import()`
@@ -787,7 +819,9 @@ export default function CaptureWidget({ onDismiss }) {
             await completeDelivery(event, 'Dictation output session is missing');
             return;
           }
-          await ensureDictationPrefsHydrated();
+          // Fresh: the model may have been changed from the main window
+          // since this store last loaded (see ensureDictationPrefsHydrated).
+          await ensureDictationPrefsHydrated({ fresh: true });
           if (!enabledRef.current) {
             // The hotkey is inert, but Rust has already shown the window.
             // Put it back rather than leaving an empty capsule on screen.
@@ -1708,8 +1742,14 @@ export default function CaptureWidget({ onDismiss }) {
                 stopCaptureGraph();
                 setTrayRecording(false);
                 setModelStatus(null);
-                toastAsrModelMissing(asrMissingPayload(msg));
-                setErrorInfo({ kind: 'transcription', message: t('asr_missing.message') });
+                const missing = asrMissingPayload(msg);
+                // In the desktop app this window has no <Toaster>, so a toast
+                // here rendered nowhere; the main window shows the install
+                // action instead (dictationNotice, kind 'asr_missing'). The
+                // browser build mounts this widget inside the main window,
+                // where the local toast IS the only one.
+                if (!inTauri()) toastAsrModelMissing(missing);
+                setErrorInfo({ kind: 'asr_missing', message: t('asr_missing.message'), missing });
                 setState('error');
                 void finishAttemptOutputSession();
               } else if (sherpaModeRef.current || aecModeRef.current || pcmModeRef.current) {
@@ -2087,8 +2127,8 @@ export default function CaptureWidget({ onDismiss }) {
         const missing = asrMissingPayload(err);
         if (missing) {
           // Typed 409: no ASR model installed → download CTA, not a dead end.
-          toastAsrModelMissing(missing);
-          setErrorInfo({ kind: 'transcription', message: t('asr_missing.message') });
+          if (!inTauri()) toastAsrModelMissing(missing);
+          setErrorInfo({ kind: 'asr_missing', message: t('asr_missing.message'), missing });
           setState('error');
           setTranscript('');
           await finishOutputSession(sessionId);
@@ -2220,6 +2260,9 @@ export default function CaptureWidget({ onDismiss }) {
       // user to the permissions pane sends them somewhere nothing is wrong —
       // the same condition the pill's own mic button carried.
       deniedByOs: !!errorInfo?.deniedByOs,
+      // The install recommendation, so the main window can offer the one-click
+      // download the pill has no room for.
+      missing: errorInfo?.missing,
     });
   }, [state, errorInfo, t]);
 

--- a/frontend/src/components/CaptureWidget.test.jsx
+++ b/frontend/src/components/CaptureWidget.test.jsx
@@ -297,6 +297,57 @@ describe('CaptureWidget', () => {
     expect(ws.url).toContain('model=sherpa-parakeet-tdt-v3');
   });
 
+  // The widget is its own window with its own store, created before the
+  // backend is listening. A failed first load used to be memoized, pinning the
+  // seed model for the life of the app: the main window checked the model the
+  // user picked and said "ready", while the pill asked the server for the seed
+  // and reported "No speech-to-text model is installed" with Parakeet on disk.
+  it('retries a failed prefs load instead of pinning the seed model', async () => {
+    mocks.state.dictationModelId = 'sherpa-whisper-tiny'; // the store's seed
+    let calls = 0;
+    mocks.state.loadDictationPrefs = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('backend not listening yet');
+      mocks.state.dictationModelId = 'sherpa-parakeet-tdt-v3';
+      return true;
+    };
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(withI18n(<CaptureWidget />));
+    await waitFor(() =>
+      expect(
+        mocks.holder.calls.some(([command]) => command === 'mark_dictation_capture_ready'),
+      ).toBe(true),
+    );
+
+    const ws = await startNativeSession('after-startup-failure');
+
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(ws.url).toContain('model=sherpa-parakeet-tdt-v3');
+    expect(ws.url).not.toContain('sherpa-whisper-tiny');
+  });
+
+  it('picks up a model changed in another window at the next capture', async () => {
+    mocks.state.dictationModelId = 'sherpa-whisper-tiny';
+    let persisted = 'sherpa-whisper-tiny';
+    mocks.state.loadDictationPrefs = async () => {
+      mocks.state.dictationModelId = persisted;
+      return true;
+    };
+    render(withI18n(<CaptureWidget />));
+    await waitFor(() =>
+      expect(
+        mocks.holder.calls.some(([command]) => command === 'mark_dictation_capture_ready'),
+      ).toBe(true),
+    );
+
+    // The user installs and selects Parakeet from Transcriptions, in the main
+    // window. This window's store is not the one that changed.
+    persisted = 'sherpa-parakeet-tdt-v3';
+
+    const ws = await startNativeSession('after-model-switch');
+    expect(ws.url).toContain('model=sherpa-parakeet-tdt-v3');
+  });
+
   it('releases the exact native listener registration on unmount', async () => {
     const view = render(withI18n(<CaptureWidget />));
     await waitFor(() =>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7705,6 +7705,17 @@ button.dub-stepper__action:focus-visible {
   color: white;
 }
 
+/* An error is a status line, not a transcript: two lines at most. A long
+   message used to wrap into a four-line block that spilled past the capsule's
+   edge. The label's `title` carries the full text, and anything the user must
+   act on also goes to the main window (utils/dictationNotice). */
+.capture-pill--error .capture-pill__preview > span {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* ── In-app reduced motion (#1857) ─────────────────────────────────────
    Settings → Appearance → Reduce motion sets `data-motion="reduce"` on the
    root. This is the same blanket rule the `prefers-reduced-motion` blocks

--- a/frontend/src/store/prefsSlice.ts
+++ b/frontend/src/store/prefsSlice.ts
@@ -235,7 +235,11 @@ export interface PrefsSlice {
   setDictationMode: (mode: DictationMode) => void;
   setDictationModelId: (id: string) => void;
   /** Hydrate from GET /dictation/prefs (called once on app init). */
-  loadDictationPrefs: () => Promise<void>;
+  /** Resolves true when the backend answered, false when the seeds were
+   *  kept because it did not. `dictationLoaded` is set either way (so the
+   *  Settings panel never spins forever); this is how a caller can tell
+   *  the two apart and retry. */
+  loadDictationPrefs: () => Promise<boolean>;
 
   /**
    * Auto-play the output preview as soon as a render finishes (Voice Clone /
@@ -387,11 +391,13 @@ export const createPrefsSlice: StateCreator<PrefsSlice, [], [], PrefsSlice> = (s
     try {
       const p = await apiJson<any>('/dictation/prefs');
       set({ ..._dictationFromPrefs(p), dictationLoaded: true });
+      return true;
     } catch {
       // Backend not ready / older build without the route — keep the seeds and
       // mark loaded so the panel renders defaults rather than a perpetual
       // spinner. A later manual interaction will retry the write-through.
       set({ dictationLoaded: true });
+      return false;
     }
   },
 

--- a/frontend/src/test/CaptureWidgetSetupRace.test.jsx
+++ b/frontend/src/test/CaptureWidgetSetupRace.test.jsx
@@ -34,6 +34,7 @@ vi.mock('@tauri-apps/api/event', () => ({
     eventUnlisteners.push(unlisten);
     return unlisten;
   }),
+  emit: emitMock,
 }));
 vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: () => ({ hide: async () => {} }),
@@ -46,7 +47,10 @@ vi.mock('../api/client', () => ({
 }));
 vi.mock('../pages/Transcriptions', () => ({ addTranscription: vi.fn() }));
 
-const { toastAsrMock } = vi.hoisted(() => ({ toastAsrMock: vi.fn() }));
+const { toastAsrMock, emitMock } = vi.hoisted(() => ({
+  toastAsrMock: vi.fn(),
+  emitMock: vi.fn(async () => {}),
+}));
 vi.mock('../utils/asrModelMissing', () => ({
   // Matches the real payload extraction for the WS frame shape.
   asrMissingPayload: (err) =>
@@ -301,7 +305,21 @@ describe('CaptureWidget — connect-time asr_model_missing during mic setup', ()
     await waitFor(() => {
       expect(screen.getByText(/No speech-to-text model/)).toBeInTheDocument();
     });
-    expect(toastAsrMock).toHaveBeenCalled();
+    // In the desktop app this window has no <Toaster>, so a local toast here
+    // rendered nowhere. The install action goes to the main window instead,
+    // carrying the recommendation so it can offer the one-click download.
+    expect(toastAsrMock).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(emitMock).toHaveBeenCalledWith(
+        'dictation-notice',
+        expect.objectContaining({
+          kind: 'asr_missing',
+          missing: expect.objectContaining({
+            recommended: expect.objectContaining({ repo_id: 'x/y' }),
+          }),
+        }),
+      ),
+    );
 
     // Mic graph setup completes AFTER the error — the tail must abort:
     // release the worklet, keep the error state, never flip the tray on.

--- a/frontend/src/utils/dictationNotice.jsx
+++ b/frontend/src/utils/dictationNotice.jsx
@@ -20,6 +20,7 @@
 import toast from 'react-hot-toast';
 import i18next from 'i18next';
 import { inTauri, openAccessibilitySettings, openMicrophoneSettings } from './permissions';
+import { toastAsrModelMissing } from './asrModelMissing';
 
 export const DICTATION_NOTICE_EVENT = 'dictation-notice';
 
@@ -51,6 +52,13 @@ export async function listenDictationNotice(handler) {
  * fixes it — the rest are informational, because there is nothing to click.
  */
 export function showDictationNotice(notice) {
+  // No speech model installed: the same one-click download toast every other
+  // ASR surface shows, not a bare label. The widget cannot show it itself —
+  // its window has no <Toaster> in the desktop app.
+  if (notice?.kind === 'asr_missing') {
+    toastAsrModelMissing(notice.missing || {});
+    return;
+  }
   const label = notice?.label;
   if (!label) return; // nothing worth interrupting the user for
   const opener =

--- a/frontend/src/utils/dictationNotice.test.jsx
+++ b/frontend/src/utils/dictationNotice.test.jsx
@@ -1,0 +1,57 @@
+/**
+ * dictationNotice — the main window's half of the widget's error bridge.
+ *
+ * A missing speech model used to arrive here as a bare label. The widget had
+ * already tried to show the install toast itself, but in the desktop app its
+ * window has no <Toaster>, so that toast rendered nowhere — and the main window
+ * showed "Transcription failed: No speech-to-text model is installed" with no
+ * way to install one.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  toastAsrModelMissing: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('./asrModelMissing', () => ({ toastAsrModelMissing: mocks.toastAsrModelMissing }));
+vi.mock('react-hot-toast', () => ({
+  default: Object.assign(vi.fn(), { error: mocks.toastError, dismiss: vi.fn() }),
+}));
+vi.mock('./permissions', () => ({
+  inTauri: () => true,
+  openAccessibilitySettings: vi.fn(),
+  openMicrophoneSettings: vi.fn(),
+}));
+
+import { showDictationNotice } from './dictationNotice';
+
+describe('showDictationNotice', () => {
+  beforeEach(() => {
+    mocks.toastAsrModelMissing.mockReset();
+    mocks.toastError.mockReset();
+  });
+
+  it('offers the model download for a missing speech model', () => {
+    const missing = { recommended: { repo_id: 'x/parakeet', label: 'Parakeet', size_gb: 0.6 } };
+
+    showDictationNotice({ kind: 'asr_missing', label: 'ignored', missing });
+
+    expect(mocks.toastAsrModelMissing).toHaveBeenCalledWith(missing);
+    // One toast, not the install toast plus a bare duplicate.
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it('still explains a missing model when no recommendation came with it', () => {
+    showDictationNotice({ kind: 'asr_missing' });
+
+    expect(mocks.toastAsrModelMissing).toHaveBeenCalledWith({});
+  });
+
+  it('keeps plain labels for everything else', () => {
+    showDictationNotice({ kind: 'transcription', label: 'Transcription failed: boom' });
+
+    expect(mocks.toastAsrModelMissing).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith('Transcription failed: boom', { duration: 8000 });
+  });
+});


### PR DESCRIPTION
Fixes #2009 and #2012. All three come from one live report on Windows: start dictation, see a bordered card around the pill, get "No speech-to-text model is installed" with Parakeet installed, close the pill and have an empty window stay on screen.

**1. Empty window stays after the pill closes (#2009).** `show_pill_noactivate` called the raw Win32 `ShowWindow(SW_SHOWNOACTIVATE)` and never Tauri's `win.show()`, so Tauri believed the window was hidden. `isVisible()` said false, `hide()` was a no-op, and the idle reconcile concluded there was nothing to clean up. Tauri's show now runs first, then the native flag. The `WS_EX_NOACTIVATE` style bit set at creation is what refuses focus (#982), so this is safe. Tests pin the order, and that a failing Tauri show still puts the pill on screen.

**2. The card around the pill (#2009).** Tauri's default window shadow on Windows draws a 1px border and Windows 11 rounded corners around the whole 460×164 window, which is far wider than the pill. The widget window now sets `shadow(false)` in the builder and in `tauri.conf.json`.

**3. The pill uses a stale model (#2012).** The widget is its own window with its own store, created before the backend listens. It hydrated prefs once and memoized the result even when the load failed, and the loader hid the failure. So it kept the seed model `sherpa-whisper-tiny`, while the main window correctly checked Parakeet and said ready. Now only a successful load is kept, a failed one is retried, and each capture start re-reads so a model chosen in the main window arrives.

On the same path, the widget's install toast rendered nowhere, because its window has no `<Toaster>` on desktop. The recommendation now travels through the dictation notice to the main window, which shows the one-click download. The browser build keeps its local toast. The pill says a model is missing rather than "Transcription failed", and error text is clamped to two lines.

**Verification**
- Both hydration tests fail against main's widget and pass here.
- Notice routing is covered by a new test, and the setup-race test now asserts the notice payload.
- 91 frontend tests, 256 Rust lib tests and `typecheck:ci` pass.
- The branch merges cleanly into current main.

**Not done here:** the localised `bootstrap.hint_port` text still gives the old port advice (noted on #1996).

Blocks v0.5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The Windows dictation pill now synchronizes Tauri and native visibility, removes its shadow, refreshes the selected model, and routes missing-model notices to the main window. These changes prevent stuck windows and stale-model failures during dictation. Review the Tauri show failure path and preference hydration race handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->