### PR TITLE
fix(engines): say when a license or the platform is what blocks an engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the frozen-backend fallback mirror it for their toolchains.
 ## [Unreleased]
 
 **Highlights**
+- Supertonic-3 and PocketTTS show their license Accept button again, so they can be enabled (#2017)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)
 - A rejected dubbing source language now names the code it rejected (#1960)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the frozen-backend fallback mirror it for their toolchains.
 
 **Highlights**
 - Supertonic-3 and PocketTTS show their license Accept button again, so they can be enabled (#2017)
+- An engine that can't run on your platform says so, instead of telling you to install it (#2018)
 - A pronunciation entry that is stored but not applied yet says so, instead of looking like it did not match (#1949)
 - A bare 500 report now names the backend error class, so two unrelated faults stop filing the same issue (#1773)
 - A rejected dubbing source language now names the code it rejected (#1960)

--- a/backend/api/public_engine_metadata.py
+++ b/backend/api/public_engine_metadata.py
@@ -43,6 +43,15 @@ _UNAVAILABLE_NOT_INSTALLED = (
     "This engine's package isn't installed yet. Install it from "
     "Model Catalogue → Engines."
 )
+# An engine gated behind an in-app license review (Supertonic-3, PocketTTS).
+# The Model Catalogue shows its Accept button only when the reason matches
+# /license not accepted/i (EngineCompatibilityMatrix.reasonMentionsLicense), so
+# this sentence must keep those words: collapsing it into the generic line hid
+# the only way to enable those engines.
+_UNAVAILABLE_LICENSE = (
+    "License not accepted yet. Review and accept it in "
+    "Model Catalogue → Engines to enable this engine."
+)
 _UNAVAILABLE_NEEDS_CONFIG = (
     "This engine needs to be configured before it can run. Open "
     "Model Catalogue → Engines to finish setting it up."
@@ -56,6 +65,9 @@ _UNAVAILABLE_FILE_MISSING = (
 # missing file often also says "not installed", and the file case has the more
 # useful remedy of the two.
 _UNAVAILABLE_SIGNATURES = (
+    # First: its probe text also says "Open Model Catalogue", and the
+    # license is the one gap only the user can close.
+    (_UNAVAILABLE_LICENSE, ("license not accepted",)),
     (_UNAVAILABLE_FILE_MISSING, (
         "file is missing", "file is empty", "file is unreadable",
         "script missing", "binary", "not found at",

--- a/backend/api/public_engine_metadata.py
+++ b/backend/api/public_engine_metadata.py
@@ -59,6 +59,13 @@ _UNAVAILABLE_PLATFORM = (
     "This engine doesn't run on this computer's platform. Its guide lists "
     "the platforms it supports."
 )
+# Apple Silicon whose PyTorch cannot use the GPU (MPS): the platform is
+# right, the installation is not. MLX-Audio / MLX-Whisper need MPS (#390).
+_UNAVAILABLE_NO_MPS = (
+    "This engine needs Apple's GPU (MPS), and this installation's PyTorch "
+    "can't use it. Updating macOS or reinstalling VoiceStudio usually "
+    "restores it."
+)
 _UNAVAILABLE_NEEDS_CONFIG = (
     "This engine needs to be configured before it can run. Open "
     "Model Catalogue → Engines to finish setting it up."
@@ -84,6 +91,7 @@ _UNAVAILABLE_SIGNATURES = (
         "unavailable on intel macs", "no macos x86_64 wheel",
         "no windows install", "not supported on windows",
     )),
+    (_UNAVAILABLE_NO_MPS, ("torch mps unavailable",)),
     (_UNAVAILABLE_FILE_MISSING, (
         "file is missing", "file is empty", "file is unreadable",
         "script missing", "binary", "not found at",

--- a/backend/api/public_engine_metadata.py
+++ b/backend/api/public_engine_metadata.py
@@ -52,6 +52,13 @@ _UNAVAILABLE_LICENSE = (
     "License not accepted yet. Review and accept it in "
     "Model Catalogue → Engines to enable this engine."
 )
+# An engine that cannot run on this machine at all: Apple-Silicon-only MLX,
+# PyTorch with no Intel Mac build. "Isn't installed yet" or "check
+# installation" sent people after an install that could never work.
+_UNAVAILABLE_PLATFORM = (
+    "This engine doesn't run on this computer's platform. Its guide lists "
+    "the platforms it supports."
+)
 _UNAVAILABLE_NEEDS_CONFIG = (
     "This engine needs to be configured before it can run. Open "
     "Model Catalogue → Engines to finish setting it up."
@@ -68,6 +75,15 @@ _UNAVAILABLE_SIGNATURES = (
     # First: its probe text also says "Open Model Catalogue", and the
     # license is the one gap only the user can close.
     (_UNAVAILABLE_LICENSE, ("license not accepted",)),
+    # Before the install and file checks: a platform reason often also says
+    # "unavailable" or names a missing wheel, and no install can fix it. Not
+    # "apple silicon only": mlx-audio says that on an M-series Mac too, when
+    # the package is merely missing and installing does help.
+    (_UNAVAILABLE_PLATFORM, (
+        "requires apple silicon", "not supported on this platform",
+        "unavailable on intel macs", "no macos x86_64 wheel",
+        "no windows install", "not supported on windows",
+    )),
     (_UNAVAILABLE_FILE_MISSING, (
         "file is missing", "file is empty", "file is unreadable",
         "script missing", "binary", "not found at",

--- a/tests/test_engine_unavailable_reason_1866.py
+++ b/tests/test_engine_unavailable_reason_1866.py
@@ -150,6 +150,7 @@ def test_a_license_gate_keeps_the_words_the_accept_button_needs(diagnostic, one_
         "mlx-whisper unavailable: not supported on this platform",
         "PocketTTS is unavailable on Intel Macs because its required PyTorch "
         "version has no macOS x86_64 wheel.",
+        "dots.tts is not supported on Windows — upstream targets Linux and macOS.",
     ],
 )
 @pytest.mark.parametrize("one_click", [None, False])

--- a/tests/test_engine_unavailable_reason_1866.py
+++ b/tests/test_engine_unavailable_reason_1866.py
@@ -106,3 +106,38 @@ def test_the_input_row_is_not_mutated():
     original = {"id": "e", "reason": "voxcpm package not installed."}
     public_backends([original])
     assert original["reason"] == "voxcpm package not installed."
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        # The engines' own wording (Supertonic3Backend / PocketTTSBackend).
+        "Supertonic-3 license not accepted. Open Model Catalogue → Engines → "
+        "Supertonic-3 and click Accept to enable. (MIT code license + OpenRAIL-M "
+        "model license.)",
+        "PocketTTS license not accepted. Open Model Catalogue → Engines → "
+        "PocketTTS and review the MIT code license, CC-BY-4.0 model license, "
+        "and gated-access conditions before enabling it.",
+    ],
+)
+@pytest.mark.parametrize("one_click", [None, True, False])
+def test_a_license_gate_keeps_the_words_the_accept_button_needs(diagnostic, one_click):
+    """The Accept button renders only when the reason matches the matrix's
+    /license not accepted/i. Collapsing the reason into the generic line left
+    Supertonic-3 and PocketTTS with no way to be enabled."""
+    import re
+    from pathlib import Path
+
+    row = {"id": "e", "reason": diagnostic}
+    if one_click is not None:
+        row["one_click_install"] = one_click
+    reason = public_backends([row])[0]["reason"]
+
+    matrix = (
+        Path(__file__).resolve().parents[1]
+        / "frontend/src/components/EngineCompatibilityMatrix.jsx"
+    ).read_text(encoding="utf-8")
+    m = re.search(r"function reasonMentionsLicense\(reason\)[^}]*?return /([^/]+)/(\w*)\.test", matrix, re.S)
+    assert m, "EngineCompatibilityMatrix.reasonMentionsLicense changed shape"
+    flags = re.I if "i" in m.group(2) else 0
+    assert re.search(m.group(1), reason, flags), reason

--- a/tests/test_engine_unavailable_reason_1866.py
+++ b/tests/test_engine_unavailable_reason_1866.py
@@ -30,7 +30,6 @@ def _reason(diagnostic):
         "funasr not installed. Install with: uv pip install funasr",
         "kittentts not installed: No module named 'kittentts'",
         "omnivoice package missing: cannot import name",
-        "mlx-whisper unavailable: not supported on this platform",
     ],
 )
 def test_a_missing_package_says_so(diagnostic):
@@ -141,3 +140,44 @@ def test_a_license_gate_keeps_the_words_the_accept_button_needs(diagnostic, one_
     assert m, "EngineCompatibilityMatrix.reasonMentionsLicense changed shape"
     flags = re.I if "i" in m.group(2) else 0
     assert re.search(m.group(1), reason, flags), reason
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        "MLX requires Apple Silicon; this host is win32/AMD64",
+        "MLX requires Apple Silicon; this Mac is Intel",
+        "mlx-whisper unavailable: not supported on this platform",
+        "PocketTTS is unavailable on Intel Macs because its required PyTorch "
+        "version has no macOS x86_64 wheel.",
+    ],
+)
+@pytest.mark.parametrize("one_click", [None, False])
+def test_a_platform_gap_is_not_reported_as_an_install_gap(diagnostic, one_click):
+    """No install can fix these, so neither "isn't installed yet" nor "check
+    installation" is true."""
+    row = {"id": "e", "reason": diagnostic}
+    if one_click is not None:
+        row["one_click_install"] = one_click
+    reason = public_backends([row])[0]["reason"]
+    assert "platform" in reason
+    assert "install" not in reason.lower()
+
+
+def test_the_real_mlx_gate_is_classified_as_a_platform_gap():
+    from core import device_caps
+
+    ok, why = device_caps.mlx_supported()
+    if ok:
+        pytest.skip("this host runs MLX")
+    assert "platform" in _reason(why)
+
+
+def test_a_missing_mlx_package_on_apple_silicon_is_still_an_install_gap():
+    # The same engine on a Mac it does support: there, installing does help.
+    diagnostic = (
+        "mlx-audio unavailable: No module named 'mlx_audio'. This backend is "
+        "Apple Silicon only — available on mac-ARM dev installs; not shipped on "
+        "Linux/Windows/mac-Intel."
+    )
+    assert "isn't installed yet" in _reason(diagnostic)

--- a/tests/test_engine_unavailable_reason_1866.py
+++ b/tests/test_engine_unavailable_reason_1866.py
@@ -169,9 +169,23 @@ def test_the_real_mlx_gate_is_classified_as_a_platform_gap():
     from core import device_caps
 
     ok, why = device_caps.mlx_supported()
-    if ok:
-        pytest.skip("this host runs MLX")
+    # Only the non-Apple branch is a platform gap. Apple Silicon without MPS,
+    # or without torch, is not; the literal cases below cover those anywhere.
+    if ok or not why.startswith("MLX requires Apple Silicon"):
+        pytest.skip("this host is Apple Silicon")
     assert "platform" in _reason(why)
+
+
+def test_apple_silicon_without_mps_is_told_what_is_missing():
+    """The platform is right here; the installation's PyTorch is not. Neither
+    the platform sentence nor the generic line says that."""
+    reason = _reason(
+        "Apple Silicon detected but torch MPS unavailable; "
+        "reinstall torch with MPS support"
+    )
+    assert "MPS" in reason
+    assert "platform" not in reason
+    assert "Check installation and configuration" not in reason
 
 
 def test_a_missing_mlx_package_on_apple_silicon_is_still_an_install_gap():


### PR DESCRIPTION
Fixes #2017.

The Model Catalogue's reason sanitizer, `public_backends()`, turns an engine's probe text into owned sentences. Two categories were missing, and both misled people.

## License gate (#2017)

- **What broke:** Supertonic-3 and PocketTTS could not be enabled.
  - Their license **Accept** button renders only when the reason matches `/license not accepted/i`.
  - Every license reason was rewritten into the generic "Engine unavailable" line.
  - v0.5.1's catch-all did the same.
- **What changes:**
  - A license category now comes first. Its sentence, "License not accepted yet. Review and accept it in Model Catalogue → Engines to enable this engine.", keeps the words the button keys on.
  - The test reads the regex out of `EngineCompatibilityMatrix.jsx`, so a wording change on either side fails CI.

## Platform gap

- **What broke:** a reason about a host the engine cannot run on was reported as an install problem:
  - "MLX requires Apple Silicon" and PocketTTS's Intel-Mac reason became "check installation";
  - "not supported on this platform" became "isn't installed yet", and an existing test asserted it.

  Each sent people after an install that could never work.
- **What changes:**
  - A platform category now says "This engine doesn't run on this computer's platform. Its guide lists the platforms it supports."
  - It matches after the license category and before the install and file checks.
  - "Apple Silicon only" is deliberately not a marker: mlx-audio says it on an M-series Mac when the package is merely missing, and there installing does help. A test pins that case.

## Tests (fail before, pass after)

- **License wording:** both engines' real reasons, with `one_click_install` unset, true and false, against the frontend's own regex.
- **Platform wording:** four real platform reasons, including the live `mlx_supported()` text on a non-Apple host. None may mention installing.
- **The mlx-audio missing-package case** still reads as an install gap.

This should land before the v0.5.2 tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
`public_backends()` now classifies license and platform blockers before installation failures and preserves manual-install guidance. This restores the license Accept button for Supertonic-3 and PocketTTS and directs unsupported-platform users to the platform guide. Tests verify frontend license detection and distinguish platform gaps from missing packages on supported Apple Silicon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->